### PR TITLE
Add ODH overlay to KF operator kustomize

### DIFF
--- a/kustomize/overlays/opendatahub/cluster_role_binding_patch.yaml
+++ b/kustomize/overlays/opendatahub/cluster_role_binding_patch.yaml
@@ -1,0 +1,6 @@
+- op: replace
+  path: /subjects/0/name
+  value: "opendatahub-operator"
+- op: replace
+  path: /roleRef/name
+  value: "opendatahub-operator"

--- a/kustomize/overlays/opendatahub/deployment_patch.yaml
+++ b/kustomize/overlays/opendatahub/deployment_patch.yaml
@@ -1,0 +1,13 @@
+- op: replace
+  path: /spec/selector/matchLabels/name
+  value: "opendatahub-operator"
+- op: replace
+  path: /spec/template/metadata/labels/name
+  value: "opendatahub-operator"
+- op: replace
+  path: /spec/template/spec/containers/0/command/0
+  value: "opendatahub-operator"
+
+- op: replace
+  path: /spec/template/spec/containers/0/name
+  value: "opendatahub-operator"

--- a/kustomize/overlays/opendatahub/kustomization.yaml
+++ b/kustomize/overlays/opendatahub/kustomization.yaml
@@ -1,0 +1,39 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../base
+
+namespace: openshift-operators
+
+patches:
+- path: name_patch.yaml
+  target:
+    kind: ServiceAccount
+    name: kubeflow-operator
+    version: v1
+- path: name_patch.yaml
+  target:
+    kind: ClusterRole
+    name: kubeflow-operator
+    version: v1
+- path: name_patch.yaml
+  target:
+    kind: ClusterRoleBinding
+    name: kubeflow-operator
+    version: v1
+- path: cluster_role_binding_patch.yaml
+  target:
+    kind: ClusterRoleBinding
+    name: kubeflow-operator
+    version: v1
+- path: deployment_patch.yaml
+  target:
+    kind: Deployment
+    name: kubeflow-operator
+    version: v1
+- path: name_patch.yaml
+  target:
+    kind: Deployment
+    name: kubeflow-operator
+    version: v1
+

--- a/kustomize/overlays/opendatahub/name_patch.yaml
+++ b/kustomize/overlays/opendatahub/name_patch.yaml
@@ -1,0 +1,3 @@
+- op: replace
+  path: /metadata/name
+  value: "opendatahub-operator"

--- a/kustomize/overlays/opendatahub/params.yaml
+++ b/kustomize/overlays/opendatahub/params.yaml
@@ -1,0 +1,4 @@
+varReference:
+- path: subjects/namespace
+  kind: ClusterRoleBinding
+  apiGroup: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
This PR:

* Adds `Dockerfile.ubi` for UBI based operator image
* Make `Makefile` and `build-operator` more flexible to configure
  * `DOCKERFILE` for Dockerfile name
  * `IMAGE_BUILDER` to allow using `podman` to build the image
* Add Kustomize for deployment manifests to simply run
  * `kustomize build deploy/` 
  * This allows simple extensibility and configurability for the deployment manifests (e.g. Open Data Hub will be able to rename some of the resources to `opendatahub-operator` without actually forking the manifests)

Depending on if you have Docker or podman installed (default is `docker`)
```
export IMAGE_BUILDER=podman
```

Set the image and the dockerfile name
```
export OPERATOR_IMG=quay.io/${USER}/opendatahub-operator:0.6.0
export DOCKERFILE=Dockerfile.ubi
```

Build and push the operator
```
make build-and-push-operator
```

Update the newly built image

```
pushd kustomize/overlays/opendatahub
kustomize edit set image aipipeline/kubeflow-operator:v1.0.0=${OPERATOR_IMG}
popd
```

Deploy

```
kustomize build kustomize/overlays/opendatahub | oc apply -f -
```

Closes #13 #12 