### PR TITLE
DO NOT MERGE This deletes the kustomize folder to enable multiple kfdef installs

### DIFF
--- a/pkg/controller/kfdef/kfdef_controller.go
+++ b/pkg/controller/kfdef/kfdef_controller.go
@@ -1,7 +1,8 @@
 package kfdef
 
 import (
-	"context"
+	"os"
+        "context"
 	"io/ioutil"
 	"strings"
 
@@ -250,6 +251,17 @@ func kfLoadConfig(instance *kfdefv1.KfDef, reqLogger logr.Logger, action string)
 		reqLogger.Info("Failed to write config.yaml ", err)
 		return nil, err
 	}
+        
+        // This is temp. fix to allow users to install multiple kfdefs
+        if action == "apply" {
+            // Delete kustomize folder
+            reqLogger.Info("Deleting kustomize Folder")
+            err :=os.RemoveAll("/tmp/kustomize")
+            if err != nil {
+              reqLogger.Info("Error Deleting folder /tmp/kustomize", err)
+            }
+        }
+         
 	if action == "delete" {
 		// Enable force delete since inClusterConfig has no ./kube/config file to pass the delete safety check.
 		forceDeleteAnn := strings.Join([]string{kfutils.KfDefAnnotation, kfutils.ForceDelete}, "/")


### PR DESCRIPTION
This is a temporary fix to solve #9 
1. git clone this branch
2. Build the operator
```
   make -d build-operator
   cp build/_output/bin/opendatahub-operator build/_output/bin/kfctl
   make -d build-operator
   make push-operator
```
3. Follow the instructions to install the operator found here: https://github.com/nakfour/opendatahub-operator/blob/master/operator.md

4. Create different kfdefs in different namespaces