### PR TITLE
Fix "replaces" property in 0.6.1 CSV

### DIFF
--- a/deploy/olm-catalog/opendatahub/0.6.1/opendatahub-operator.v0.6.1.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/opendatahub/0.6.1/opendatahub-operator.v0.6.1.clusterserviceversion.yaml
@@ -358,7 +358,7 @@ spec:
     - Open Data Hub
     - opendatahub
   version: 0.6.1
-  replaces: 0.6.0
+  replaces: opendatahub-operator.v0.6.0
   selector:
     matchLabels:
       component: opendatahub-operator


### PR DESCRIPTION
The 0.6.1 CSV had a typo in the `replaces` property that did not point to a valid ODH CSV object. This issue was fixed in the official CSV release in  [community operators](https://github.com/operator-framework/community-operators/blob/master/community-operators/opendatahub-operator/0.6.1/opendatahub-operator.v0.6.1.clusterserviceversion.yaml#L361) but we need to add it back to our repo