### PR TITLE
Add ODH ClusterServiceVersion for 0.8.0 release

### DIFF
--- a/deploy/olm-catalog/opendatahub/0.8.0/kfdef.apps.kubeflow.org.crd.yaml
+++ b/deploy/olm-catalog/opendatahub/0.8.0/kfdef.apps.kubeflow.org.crd.yaml
@@ -1,0 +1,44 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: kfdefs.kfdef.apps.kubeflow.org
+  labels:
+    component: opendatahub-operator
+spec:
+  group: kfdef.apps.kubeflow.org
+  names:
+    kind: KfDef
+    listKind: KfDefList
+    plural: kfdefs
+    singular: kfdef
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: KfDef is the Schema for the kfdefs API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: KfDefSpec defines the desired state of KfDef
+          type: object
+        status:
+          description: KfDefStatus defines the observed state of KfDef
+          type: object
+      type: object
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true

--- a/deploy/olm-catalog/opendatahub/0.8.0/opendatahub-operator.v0.8.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/opendatahub/0.8.0/opendatahub-operator.v0.8.0.clusterserviceversion.yaml
@@ -1,0 +1,368 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "kfdef.apps.kubeflow.org/v1",
+          "kind": "KfDef",
+          "metadata": {
+            "annotations": {
+              "kfctl.kubeflow.io/force-delete": "false"
+            },
+            "name": "opendatahub",
+            "namespace": "opendatahub"
+          },
+          "spec": {
+            "applications": [
+              {
+                "kustomizeConfig": {
+                  "repoRef": {
+                    "name": "manifests",
+                    "path": "odh-common"
+                  }
+                },
+                "name": "odh-common"
+              },
+              {
+                "kustomizeConfig": {
+                  "repoRef": {
+                    "name": "manifests",
+                    "path": "odhseldon/cluster"
+                  }
+                },
+                "name": "odhseldon"
+              },
+              {
+                "kustomizeConfig": {
+                  "repoRef": {
+                    "name": "manifests",
+                    "path": "ai-library/cluster"
+                  }
+                },
+                "name": "ai-library-cluster"
+              },
+              {
+                "kustomizeConfig": {
+                  "repoRef": {
+                    "name": "manifests",
+                    "path": "ai-library/operator"
+                  }
+                },
+                "name": "ai-library-operator"
+              },
+              {
+                "kustomizeConfig": {
+                  "parameters": [
+                    {
+                      "name": "SUPERSET_ADMIN_PASSWORD",
+                      "value": "admin"
+                    }
+                  ],
+                  "repoRef": {
+                    "name": "manifests",
+                    "path": "superset"
+                  }
+                },
+                "name": "superset"
+              },
+              {
+                "kustomizeConfig": {
+                  "parameters": [
+                    {
+                      "name": "namespace",
+                      "value": "openshift-operators"
+                    }
+                  ],
+                  "repoRef": {
+                    "name": "manifests",
+                    "path": "kafka/cluster"
+                  }
+                },
+                "name": "strimzi-operator"
+              },
+              {
+                "kustomizeConfig": {
+                  "repoRef": {
+                    "name": "manifests",
+                    "path": "kafka/kafka"
+                  }
+                },
+                "name": "kafka-cluster"
+              },
+              {
+                "kustomizeConfig": {
+                  "repoRef": {
+                    "name": "manifests",
+                    "path": "grafana/cluster"
+                  }
+                },
+                "name": "grafana-cluster"
+              },
+              {
+                "kustomizeConfig": {
+                  "repoRef": {
+                    "name": "manifests",
+                    "path": "grafana/grafana"
+                  }
+                },
+                "name": "grafana-instance"
+              },
+              {
+                "kustomizeConfig": {
+                  "repoRef": {
+                    "name": "manifests",
+                    "path": "radanalyticsio/spark/cluster"
+                  }
+                },
+                "name": "radanalyticsio-cluster"
+              },
+              {
+                "kustomizeConfig": {
+                  "repoRef": {
+                    "name": "manifests",
+                    "path": "radanalyticsio/spark/operator"
+                  }
+                },
+                "name": "radanalyticsio-spark-operator"
+              },
+              {
+                "kustomizeConfig": {
+                  "repoRef": {
+                    "name": "manifests",
+                    "path": "prometheus/cluster"
+                  }
+                },
+                "name": "prometheus-cluster"
+              },
+              {
+                "kustomizeConfig": {
+                  "repoRef": {
+                    "name": "manifests",
+                    "path": "prometheus/operator"
+                  }
+                },
+                "name": "prometheus-operator"
+              },
+              {
+                "kustomizeConfig": {
+                  "parameters": [
+                    {
+                      "name": "s3_endpoint_url",
+                      "value": "s3.odh.com"
+                    }
+                  ],
+                  "repoRef": {
+                    "name": "manifests",
+                    "path": "jupyterhub/jupyterhub"
+                  }
+                },
+                "name": "jupyterhub"
+              },
+              {
+                "kustomizeConfig": {
+                  "overlays": [
+                    "additional"
+                  ],
+                  "repoRef": {
+                    "name": "manifests",
+                    "path": "jupyterhub/notebook-images"
+                  }
+                },
+                "name": "notebook-images"
+              },
+              {
+                "kustomizeConfig": {
+                  "repoRef": {
+                    "name": "manifests",
+                    "path": "airflow/operator"
+                  }
+                },
+                "name": "airflow-operator"
+              },
+              {
+                "kustomizeConfig": {
+                  "repoRef": {
+                    "name": "manifests",
+                    "path": "airflow/cluster"
+                  }
+                },
+                "name": "airflow-cluster"
+              },
+              {
+                "kustomizeConfig": {
+                  "repoRef": {
+                    "name": "manifests",
+                    "path": "odhargo/cluster"
+                  }
+                },
+                "name": "odhargo-cluster"
+              },
+              {
+                "kustomizeConfig": {
+                  "repoRef": {
+                    "name": "manifests",
+                    "path": "odhargo/odhargo"
+                  }
+                },
+                "name": "odhargo"
+              }
+            ],
+            "repos": [
+              {
+                "name": "kf-manifests",
+                "uri": "https://github.com/opendatahub-io/manifests/tarball/v1.0-branch-openshift"
+              },
+              {
+                "name": "manifests",
+                "uri": "https://github.com/opendatahub-io/odh-manifests/tarball/v0.8.0"
+              }
+            ],
+            "version": "v0.8.0"
+          },
+          "status": {}
+        }
+      ]
+    capabilities: Basic Install
+    categories: AI/Machine Learning, Big Data
+    description: "Open Data Hub Operator for deployment and management of Open Data Hub and Kubeflow on OpenShift"
+    support: Open Data Hub
+    repository: https://github.com/opendatahub-io/opendatahub-operator
+    createdAt: '2020-08-31T00:00:00Z'
+    containerImage: quay.io/opendatahub/opendatahub-operator:v0.8.0
+    certified: 'False'
+  name: opendatahub-operator.v0.8.0
+  namespace: placeholder
+spec:
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+    - description: KfDef is the Schema for the applications API
+      kind: KfDef
+      name: kfdefs.kfdef.apps.kubeflow.org
+      version: v1
+      displayName: Open Data Hub
+      group: kfdef.apps.kubeflow.org
+  description: |
+    The Open Data Hub is a machine-learning-as-a-service platform built on Red Hat's Kubernetes-based OpenShift® Container Platform, Ceph Object Storage, and integrating a collection of open source projects.
+
+    Open Data Hub operator allows users to install and manage Open Data Hub and Kubeflow components. Users can mix and match tools from each project to fulfill the needs of their use case. Each of the
+    projects share some components, but can be mostly seen as an extension of each other to provide as complete a solution as possible for both hobby and enterprise users.
+
+    ### Components
+    * JupyterHub v3.0.7 - Open source multi-user notebook platform w/ GPU support. ***NEW*** Notebook with support Elyra and JupyterLab
+    * Apache Spark v2.4.5 - Unified analytics engine for large-scale data processing
+    * Prometheus v2.7.1 - Monitoring and alerting tool
+    * Grafana v6.2.4 - Data visualization and monitoring
+    * Airflow v1.10.2 - Workflow management
+    * AI-Library v0.6.0 - An open source collection of machine learning algorithms
+    * Seldon v1.2.0 - Open source platform for deploying machine learning models
+    * Argo v2.7.0 - Container-native Workflow Engine
+    * Apache Superset v0.34.0 - Open source application for data exploration and visualization
+    * Apache Kafka v2.4.0 - The open source stream processing platform
+
+    #### Mixing ODH and Kubeflow
+    As part of our work to extend the capabilities of Kubeflow on OpenShift, we have KfDef manifests that combine components of Open Data Hub and Kubeflow into a single deployment. You can find more information about how we combine these components on [opendatahub.io](http://opendatahub.io/docs/kubeflow/mixing.html)
+
+    ### Available Channels
+
+    #### Beta
+
+    Channel `beta` offers the latest version of Open Data Hub operator. It is based on Kubeflow Operator and Kustomize for deployment configuration. This version is compatible with [Open Data Hub manifests](https://github.com/opendatahub-io/odh-manifests/) as well as [Kubeflow manifests](https://github.com/opendatahub-io/manifests). This channel will offer new components and features.
+
+    To deploy Kubeflow, use [this example](https://github.com/opendatahub-io/manifests/blob/v1.0-branch-openshift/kfdef/kfctl_openshift.yaml).
+
+    #### Legacy
+
+    Channel `legacy` offers Ansible Operator based version of Open Data Hub operator. It installs Open Data Hub [v0.5.2](https://gitlab.com/opendatahub/opendatahub-operator) which will only be updated with bug fixes, and will not receive new features and components.
+
+    To deploy `legacy` version, use [this example](https://gitlab.com/opendatahub/opendatahub-operator/-/blob/master/deploy/crds/opendatahub_v1alpha1_opendatahub_cr.yaml).
+
+  displayName: Open Data Hub Operator
+  icon:
+  - base64data: iVBORw0KGgoAAAANSUhEUgAAAUIAAAEiCAYAAACMWdvGAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAAOxAAADsQBlSsOGwAAABl0RVh0U29mdHdhcmUAd3d3Lmlua3NjYXBlLm9yZ5vuPBoAACAASURBVHic7N15eFTV+Qfw73vuTBKyQdhVkIC4orjUBREtO6KE1ewBqVqsW0Xb+lOxNq11a+tWbVW0ikAWiIAQQSEo1gWtuyAKsiS4IMoSkplsM3PP+/sjC5NJcu8kmSQQ3s/z5HmYc8895wyTvHPvPRsghBBCCCGEEEIIIYQQQgghhBBCCCGEEEIIIYQQQgghhBBCCCGEEEIIIYQQQgghhBBCCCGEEEIIIYQQQgghhBBCCCGEEEIIIYQQQgghhBBCCCGEEEIIIYQQQgghhBBCCCGEEEIIIYQQQgghhBBCCCGEEEIIIYQQQgghhBBCCCGEEEIIIYQQQgghhBBCCCGEEEIIIYQQQgghhBBCCCGEEEIIIYQQQgghhBBCCCGEEEIIIYQQnQR1dAPEsWnWluJzoTECzB4itf6ls7rtDMyz5p8cftDtmgXCZcTKy8Rrd1RF52Vmku6INovOSwKhaFeJWzisCxe/CEaaX7LJzA8uGtrjj7UJSzNLunvD1BsAzvE/n8Gvd4+OmXrFb6mqvdosOj/V0Q0Qx5YufOjBgCAIAAYR3TNzU/Hs2gRPOD2BgCAIAAS6vNjlvquNmymOMRIIRbuZXVgYAebfNHWciG8DgBczOYKYEpssiGhWGzRPHMMkEHZi5eU7+u/lvVEd3Y5avvLu/QBEWmQ5DQAiHBW9AIQ3nY1PDGnDxDFPAmEnwsyq1Lvr0hLPrn+Vegr3+hzGt5HeipJSb+HKgxU7Ozx4kPY6bbKEAYAG2f1eyu+tCClHRzdAtF6xp+hcAzq91FuURKD+AT1gBhiTHYY6u5S//0Us9TvQMa0U4sglgfAoxczKVVU4CYp+B/BlANkNARjAHs9tAO5plwYKcRSRQHiUYf6ui9vrm+XyFt0ORac051wi9cu2apcQRzMJhEcJZlYub9Esl893P4DjW1iKL6SNEqKTkEB4FHB5i0aVeoseIeBccCsKIqwLWaOE6EQkEB7BDlbsPNHhUE8w89TWTwGiLysdZU+GoFlCdDoyDOEIVeLZNcthqE1gTG1dSeRm4BntpMt60xB3aFonROciV4RHGBdv78U+xzNgTG9FMZVgWs+k86qc5cslAAphTQLhEeSQd9d49tJCAH1acj4DnxPwhNfpW96DTi4NcfOE6LQkEB4hXJ7COcz8L7ToM+H3oPFwbPjAV4moNd0pQhyTJBB2MObt4S6v42kGftXsVdEYaxT0ndHhJ21uaf17OD+yqkzFal0VC8OIVT42lIN9Xu2scpoo9+nyAyd1TyppaflCHA0kEHYgF+/o7fKq5QAuaeapmzXx77qFDSoI9oQ9nB9Z5eYLwPpiKJwKplMADK5y696AhiID0AAUQWuCARPaAJQRjkLXylIA3zGhiIBNpPkjr8P86OTIGd83s91CHJEkEHYQNxf21V68AeCMZpxWSsAd0c7454nItMu8u2zFLzSrGQBGV7n1eQCcIEILxiLGAhhCjCEArmQiOEwHCl0rfyDQa8x4NTyGCo6nhPJmlyzEEUACYQdw864+2ov1aF4Q3MjavDo2YvAOq0xFruWnazauJYXpWmNg61pq6wQGXwfCdVVurihyrVwNmPfGx0z/uo3rFSKkJBC2sxZcCVaCkBnjiP9HU1eBG3iDY6C7dLIG38ig0USgVs1AaZkuDFxFMC4vKsv/ZXxUwqft3gIhWkgCYTty8Y7e2kvvADw4qBOIvtdMU7s5B3zS2GHmTLW77NxUuEszGRhsu/5MO2AgGlo/ieY/9xSiw8jMknbCXBjBXmNF0EEQ+MBw4MJuYY0HwV2lryQUuc/9nBmLGQi2zPZy8e5Dr8Z1dCOECJZcEbYDZqZSb9ECAoYHdwYtinHyHKL4ysAj35Xnn+Az9b8ATAlxM0OJtIMsltoX4sgigbAdlHoK7yOi5CCzPxvjHHBD4MBoZqbd7vwbfKZ+ENW9uG2hFIAJAAzEUMt/P3YOjL5yb+iaJUTbkkDYxlxVuxKZaF4weQl4PNoZf3tgECwsXtGtyL1qAUJxFUgoIo13taIvSGO7Ir0dpuPHAd0mFQdm3cJLw2JKnP1NA/2J1SBNOI+ILgDz2Wh6cyVm8J2tbqcQ7UgCYRsqL9/R30f0bHC5+ZGYsEG/D0wtdK84B6xeBnBSC5tRxYT1pHmZYdDaE6Om7An2xCGU5AGws+bnLQAvAEAhb4igctco1jyZgEkM9AMAAr5n4A+DYqa+3MK2CtEhJBC2kZoVpRcACKbTYEFsY0GwdNUUMOcA6NLc+gn8JYP+rb1V2aGeIjeQRlUCeK3m54bt5cv6KQpTgyI++Z4oU4eyLiHagwTCNuLyFf0fgNFBZH0nxulrsOl5UemqazXxMy14TvcmoO+Lj5n2VjPPazGZaieOdhII24Dbs+tszfhzEFm3sdMxlWhglX9iYemq/2PiB6k5qzAQfahAdw+ITnijue0V4lgngTDEmJlc3qInAdhsZk5uaHNyV+p/0D+1yLXqRgY/1IwqS0G4Nz6q8imiJNv5x7UymdW3m0viTdKnAziRwX1AFEGMrly9/MKh6h/+ltjYobly66Kz+5Y1o11HvKVL2ajaWTpQEQ1hpuMI3JW06sqAArEXxG4CDjBUkUnGN7Pu7PJtR7dZtA0JhCFW6tmdRoRLg8h6a2zESd/4JxS5V6Yzc3P2FVnrMNS1/SMTfggm86wtxeey5isU6Je7viy+GITow0erF2NoODOPwKRBFOaZtelAToSHbp1/fvejclmuZ59lZ3Sx+2JoTABorHeHe6iCigDXXnoT2L/DnmtnKjIM9iHrAZcbwHsg3qBM442UeZGfyPqPnYMEwhDax1tjyMcP287zJayIdca/4J+0y50/nlm/iOBm+2gAf4mP/uw+u86Ja7buO97nVXMASofmwQSAWzYROQxEV1eG45TEpXxpXpL96jdHisUPuc8izXNwwJ0BoFt1aov+D6IBTADTBK00sh9078h+wLWIyLcw9a64opA1WLQ7CYQhFO4JvweEEywzEX6Aw/lr/6RdFasHkM+XDdvbaYAANxQlxUdNfs0q38zN+08nUvf4vEgMptxmuLjL6QevArAkhGW2iez73eOY+E/Q3Fbzngcz8Gdmx72LH3AthaIHM+6MbvEiuaLjSCAMERfv6A0vbra9GNQ8N4b6Hah9vZ3XhJPLmwdCD/ta6CCYJsVHJbzfVI6Mr/Ydp0zjYQDp4LaZS05Ml+IIDoQ5D5RcpKEeZPCodqrSICAVmlOyHnAt9Wnjd1ffExnU4wpxZJBAGCLsMW4DIdIm25sx4YPqDTY23N5HQLggiCp+ZOZRA2Mnb2u8AUyzNhffBBP3o+2m4NVW5m3b8lvm2UyOjAlz36+B36JjFhQhAMkOZV6R/YA70zE46omko+gRwrFMVp8JgYO8sysIDcYC1sc+xXquf0qha9UvCbgxiCpKQPqKQbFTGg2Cs7f83HfWl8WvgfAk2jwIAiBY3pZ3hKy/llwYHe7+nIG56Pjf6xgGP+Ld4S5Y+jd33w5uiwhCR//CdApOn3Ez6h7CN45A//LfZKmQN0QA/CzsxwpWaFaTBkZP+7yxg7O/3H+BNh2fAJjQ3Ha30NKXzuqxrp3qCkr2/e4MKPVfME7u6LYEGOX18edZD7ku6+iGCGtya9xKzFvCXF6+1SZbJTlRb2wguUvnMXBqEBXcdFJswruNHcrYVDxVM2eDmj8Fz48H4E3MtF8pcmlwsWIyGNwHQD8CHcfgngCKALzw7f64v7WirpBiZsp5oOx+Jr6rNeUQ8AMD3wD4EQw3FJdBUxQIcSD0B+MUAN1bWHwfaKzLftCVnnZXzLLWtFO0HQmEreT2dJkMQi+rPAz+TzQNqluWalfF6gHs8/3BrmwCPR8fO+XFxo7N/PJgCjEvQvM/Q2bgv8RYBkN/WIEen+cNIU8zyzgiZD/kegREtzX7RMZ+EPIArPeB/3v13bEH7E7JebA4ntkYpUGXEzAZQEQzagxnxpLFD5TekHF37HPNbq9ocxIIW4mhrrYZk+bVJv3DP4FM371oehmrWls4OuaWxg5kbCqeSsyLARjNaOpegJ5RPry04Nyjf8xb9gPuh5m5uUHwPQL/w9UzZvX111OzOnxqxgm+CODFpQ8d7OrVzjQAvwcwKMgiDAI9k32/qyRtXszS5jVbtLWO3+TiKFa9ERN/B5DFFwotjg2Ln1n7amfp8lOIjC02iyloYr40PnbqxsADs784MEwrehPBr0hTzsyPVhrmw3lDeruDPKdNzNy8/3SC+soqz8KzulPWXysGQPmKQlj1JjDmps+L2RDCMrEhkx17nK4MED0EoE+Qp3mY6YqMedEyJ/wIIleEraB9nGEdBAEi/Vz918a9Qawo82xjQTB18099NGg5gg+Ca2DqOYvO6Wk7pm0DZzrCD5T0gabeBqEswlQ/nN33H0f73GIPQPOO90Q9PiqTfKEuvKbMBS9mFr8S5nT8HYTrgjgtjIiXLnyo4lyZu3zkkCvCVij1FH0E8PkWWXbFOOMH185HLXSv7gv27QYQZnFOMXx60MC4aYf8EzOZ1a4tB9eBaUwQTTPB9OdBZ3W7P5Oo0Sl4H/78h74+8k0m1lMYOA+g3mg4isAFYDsDrzHRK5f0fOwTasVGoe17RUiFSlNS6j1RH7eunOBl3e9KAeE5wH8Od5Ped/eI/mVzb9FF25ArwhYq5W094eXzrPIQ4SX/SfnMvl+TdRAEGH8PDIIAsOvLQzcBQQXBMiaeseis7msbO/jBz7eO0KD7fPBeBoZi6+/CGADnEXAeMc97f9/c79/fR48WH/L9+4qTn6yyOrGDfUaMian3RP3UnpWmz4vJzXqwbDtYrwHQ2yb7xdH73X8EcG87NE3YkHGELcSesHGw/v9jnw8L617wUoOYr7Updl9VFZ4KTLxm677jAb4viGZ5wEhcdGaPBkHwgwO3nPHeT3NXatA7AEbatL0p/Zj50W5dja3v75ubzjZRtGPwR07lHZU2L7pdg2Ct9LuiPjHAlwKwr59wR+4Dpae0fauEHQmELURkO4B5c1yXgUW1LwrLuowB0QDrU/ip03pNcQWmer3G3wB0tanPhOL0hUO7N5j18f7Pt12tTeNTIky2KSNY8cxY/P6+uS9/sff3USEqs/UI25ygK5Pu7NhlwlLujv1Gs7oC1bsCWgk3QQ2++ET7k0DYAsxMIIyzzkT1rsqIebpldsBnKHo+MH3W5oNDCUgNolF3LBzS4+X6SaD3fpqbyeAFsB+u0xLTy5Rv4/s/zo1vg7KbicoMhWlJd8fs6+iWAMDMeVGfkuYM2K/3NS7rfld7LQ4hmiCBsAVcVbtOBuN4qzxKmXXT0JgzFcAJlvmBFY3uMMf0R9h8Tgy8Neis7o8Hpr+/b+4CIvzJ6twQGMoGNr578NYT27gea4wbU/4v5usObUOAtHti8xkNH3U0QLinHZojLEggbAEiOsfyOFAe5dDv1L4uKj3vQsA6cDJTVmDarC0HTwTxVJvmlJoGzQ7sHd748213Aphlc26oHKd8tLIDb5PXpc+LXmifrf1pZ9ldAL6zyTY654GSi9qjPaJxEghbgIGzbY5/RHRyXa8qke1uduXhMVTQIFXjetj17DMeyD4jbrd/0vv7bp0M8P02dTbFheoVsJvrnHJlvtQBHSheA9zoDJwjwaw/9C1j4Ha7fJrVNe3RHtE4CYQtYntF+IX/aya2+7Z//XhKKK+XwkywfzZ40BFm/ts/YcPPN0Yz03wE/9luZvCd0DQ0zFceNbz347Hf9/ohDIr6gSgdwMsAglpTj8EzPth3W2KQ9YYGUVbK3bHf2GfsOOl3RS8D8JllJkLy0ke5NYtniFaQcYQtoXC21SNwBn0RkHShVXEEfjMwbeZXBy4E1ECr85jpiRdO61WvlzmCwn7HHNR0r5+Y+ffDe8dlB+57kkR5JoAfAGQDyP7gwC1nmKbxOMGmgwgAg+//mOesOJ/mt8dAYTYUHzGr4TSFiDj7QfffmTnbIltXX6VrAoBX2qtd4jC5Imymfbw1Bmy9L4mGuan23zsr8k8EYLk4p6nof4FpZBrjbZriDTNUvQfxH/x0ax9m/N7mPAD8mcNQF1zS54nFdps/AcCwHk9+NbxXt8sR3Dajgz37IucEka/VCHj3SOsgaYqjKmoZAMtVbhg0tp2aIwJIIGymsCqn7YrD5c4uddPIyNR2aw5WVkZWbWqQSmw9i4T47f8M6VpvT2Qmug4207sY+MYM84y5sMejdg/w61dHmXp47yfuItDDQWSfa5+l9ZiwuD3qCYWkTPJw9WMGK8HMHBJtQAJhM5FBdoHw0PF0fN3zPmKyvL0FsHUIJdVbDzBxKRuA9T4mxGpVYBoDU2zqqiJlTLm029PFNvmaNKxX17vBaHArH2Dwe3t/e2ZL6wiWMo0jbssAK0rzapsspy38u8tuap5oAxIIm4m07fO3vfVeEewC4a7AhPBT9w8GrDeCMphe9X+9cf9tJwCwWgACxPzU8J6PbLVpjyWiTA2mubDrWVZkN+yntXak3hPZrKvajuZw+N6GTceTYeK0dmqO8COBsJk0WT/vQ8AcU2bub5WZGUWBaUo5zrCpw/XC0G71AigxT4T1akImAX+3KTcow/s+thmgNVZ5CHRFKOqy0G6ryoRKzdS/xnchrMUSCDuCBMJmUkTW+w8T/VzvZfUKLlYF/thIaj/LKoDtgWnMtislbxzW54kQLkSg7Xo3z2zTMYVsE1COXJZDfRg0uL0aIg6TQNhMWpP18vjM9cYDMthytgUxN7L4KVtedTKwo0E5NucA/J718eYxtGn3nDDmnb239Axlnf6YqLCtym5TxJbtJs1x7dUUcZgEwjZGIMtAyNQwEDLYpueX9zZMI8spfARqOI+5FXb3+elb2Cwo4DAcdivmtBxpu5VdjkyarNtNNncQok1IIGxjxNaD1hXQcAl5Issd0gjU4JaTAcuAq0Eh3a+kZtC15fL32qy/4o1WDdvdUgTVYLmyowGRXSDk2HZqivAjgbCNMaHc6rjWDXuHia17Fokbfm4KZPn8z/7WuXk+OHBLLACnZaZwXS9YGabtmopI3MLWK3jXUCY1WMX7aMA2ny3Y5tGLaBMSCEOMwPWvABmWGyARNTpMxvLqTauGAUiDLW99CXyy1fFmM9VQmxxalan6awPadTQBiPD9ZB1ca4ty6qN9YylxBJFA2EykYH0lwlRvs3ci60AIUGMPxy3rIEZ8gzSgsd7nw80CXVm9LmJoaFJ2q11/O7z/YxX12sBk23nSLbJPyHebE8KOBMJmYm29FwVT/QHXDFivmNzI8v0MshsofHqDFK0/tDmn9wf7DtltLxCUNdtvCQc4ySoPMxrrpbZbvNV8cjA8NnmECDkJhM1kKNN6LF7Ayi/MsB7mwQ1nnrDmIptm9Ltm6756vYthfSrfBshy6hwDD4XiqjCum+NGMKz3X6HGVlHhi61PwRfw2/WvLbiqdp/h9u4ce6iiyG7GjziGSCBsLpsrQhB6MfPh/1ebcWNo5NmdQ9NmWA9NIY9XDfNPOJ/me5nZcrYHgKHv7y9u1bLwHxy45QxmzrTJVsUUVm/PlsSlbBDBMhACaLO5w4cqdw8q9RS+x6S3aFYFyuBdpd7CVaW8rc3GOoqjhwTCZuIwtpudYZRU7q67WjKUXSDECd+Wraw3BnDBuXGH0MgcZH8KNK2RxBybugCmzPf3zU23zdeIjftvO0GbxkoAlkM8CPTqiF5/q9dj3GXIoaGw2YmPNL9qdbyl9vLeKKV0AYDh9Q4wEuB1vlLvi0sck+QXoJmicdJ+2IzJU4rrelR1ZLctgPVzL9NUDRZuJeJ3Gstbdxw0PTPgD/iSXo+vBvC+1XkAiBmL3vtpbuZSTgx6qMbGn347HJo/AmA3Bcw0zYYbRpGGXfA9VLat+0fBtqc5orwVM4GmpiDSJSW+QlkH8BgngbCZiEgDvNkyjzq8p8lAGlUJkE1+PTwwTYMabNLuj8F9dn5VMjIwXYHvsDqvtkoi/Knf/hO+2PjT3KkbOLPJQd//23f7KRv3zV0IUu8AOC6Isl8acdxjW/wTbtnO4Qy+2vo0fjMviYLaEqC52GbrVQX6RVvUK44eslR/y2wCmn7exeCh9V/r/5HFHxszTQJQL4CFkbHOy6YHQJMDjMk05wH11wYc1vuJdzf+PPdlAFdZvoPqhg0BYUX4vpLi93++da0GthCpnwGOZMYgYhpjsrZbCcdfiTLMBleDpRXFV4Fg/SyOaZ3l8dbQuNhq+QdmPipnqYjQkSvCFgjcnKkBpnP9XyqijdYl8uk7S/LrdZr8Z0jXgyCbzgOi0VdvKr4sMFlT2DUAvrSus179cQxKIdB9YH4WjMcIuAXEzQmCGsQZw3o8+b1/4sgN7GDC/9mcW+E0jLxm1BW0QxVFA0F2V7LUJrfk4ughgbAFmFTDpfXrG3SocnfdMymHNl9nm3m5iswZgWla0wK7tmjiP9fseFdnRK+/uQztm8zAfrvzQ4WJ7hje64kGnR39ex26GcBZ1mdTTuC2A6FCSl9ik6Uy1lluvcOc6PQkELZAlaNiE8CWgc1Qum7zpX6x0w8QGh1gfBjRdYFj/Kq2dstHI0tu1TsNGDlrc/FNgekX9X2qUDGmwmbDoJAg+vslvR57JDB55heu3sTc4FY5EIOebpuGASBq8Pw1IMPHRENkEPcxTgJhC/Si01yA+sAqDxPq7UJHhHybYk/6tuwXo/wT8pLIZMLjtg0i/H3mFwcb7BFycZ/H3zOZLgRhS2OnhUAVAb8a3uuxBh00iUvZIMO7AEA3mzLeW3RWtzZZbZqrr5Qn2WQK6TqN4ugkgbCFiPC6ZQbGGOaP6xYQ8CleCpv9KjT41sC0buFxzwM2s1OACFLIDpxtAgCX9nlsl1LmcALnwmb9wGbaDtajL+79+ILGDnY5vfghMCbalMFKcxDbj7ZMqbfoIgIst0qA/XAjcQyQQNhCmk27Xs7YUrNn3VXh4Mip37Ft8OSEnWWr6u1e9+TJVEWEeUE06Syf11gz84u9DdYlHNbjydKLez+RyoovAvBWEGU13URgP4PvPFRinjW8zz8b7QS6elPxrwD7/ZUZyF5wdg/LK+vWIKYGz10DVJSHdVnfVvWLo4cEwhaKdQ76BDYLKhDrX9VL0PysXbkG872BaS8NicslUEEQzRpBKix/zsd7Gt0B75KeT3w0vPfjoxTzeAaeB2ymC9ZieACsI8aNHngGXtL7iYevOPnJqsayzvzy4E1M/HwQpZY7wHcFVX9LEU+3Po61famvLOclZBxhSxGRLvUUvQ7wzCYzMSWU8raesXTqfgAYGONZU+QK293YijN1pzAm7XbnjxkQnfCGX2VMnxXPYQc2wW4zKGBUZXjE+l9tPpD84lk9Gl3FZlifJwoAFDBnqg9+PnQxAxcz4VQi9AIQBYYXzMVEahdDbwpzRqw7v/vDJZa1MtPMzQf/Qozg5jIT3/rimY23LxRc3sKRdhtaMfPytqpfHF0kELaCJr1IMTUdCIEw9jpTATwJAERJZqFr5UMALHtJNeunC3nD0OpZKdUWnBtXdPWXB69nRnYQTbvYBH02a/PB2QvP6t7k/F2iTI3q3uxWdRjM+nz/Cfiy+BkQWXdM1GAga9GZPYK5amwxBn5rk8XLTqNN5jaLo4/cGrdCV8fANwj41ioPgX7jP6m/PLrqBTDvtin6ZLhdDW4bXzqzew4ITwXZvB4AVs3adHD+NVv3WW7s1GLMNHPzgWthqC9h1zt72NZK5fuNVQbTEUSnjslNdjwdrNh5IpgTLM9nrO9GAyyXLRPHDgmErUBEWjMttMl2httTWPesaggleRh0v13ZDL57V+krlwamf7sv7jaC7VCcuiaC8Guf19g+68uDD167paR7kOdZmvMxO2dtOpg2a3PxJwR6HvZDZKox9mhlJOQN6W25aEVFZcR+AF6LLF7lqWxyawKHUjcCZHe3M9/muDiGSCBsJWa1ADbDUjTRPPab/bE7JvZFAJ9bnUOAQxFlbyvNrzdH961R5AuvqkwhguXqNAEiwbjTq80fZm0qzsvYVDz1lu0cbn+aH2aavaX4nFmbD95dGV68A4QsEM61P7EagX5S0GMWD+lqOUAcAK7PpHIASy1KW5yU2XgwLeHvuoNwvU0Vu2PC4oP9MhHHAHlG2ErdIk7cWeIpeoPATS7lRMA5rqrCSai5khtFo3xFpfk3Mul3YfFlxEC/cNI5W3jplUMoqW72w/zzjy+f+cXeiUqFr2Cw5coqASJAfJUCriqpLC6dtfngJ8z0uVL4XGvsViC3Jl+5kx1VptLHaaA/MfoDGEpfHhqnwX1sa2jcPq157KKze24N9gQf+FYH6HQA5/mnE/CO9lTNbeo88ph3gWyuUAn/JmqblW7E0Slk+8wey1zeotHM/IZVHgY+j3XGn+//B1joWvUMwHZXLwCQGx/9WXpN50adW7ZzeEll8fMAMlrW8naxycFq2gtDu1kuNNuYpZkc5nG6MhThMobyMXHBjqrovMxM0o3lLy/f0d/nML4BYLUvdAWczv6x1K/tpx42Iut+960gtpottC797piQ7C0jgidXhCEQ44x/s9RTuBGBKyD7IeCcUm/hDcDhzg5lqru0YU6E/aZGKYWuc/cA+J1/4pMnUxWAmbM2HfgMRA/jyPs8l7D2XPvC2S0bq5eUSR4AL9T82PI5jExYB0EAWNRRQVAcueQZYYiwsu8AIdD9ZVxUtyTUgG6TilnrRNisYA0ARLi90LXy6cY2X1o4tMejivRwAEHferaxUoB+u/DMuNRFLQyCzVXiKRwGwGbxV1T6TG37ObUp4jbdnEq0jATCEOnqiF8DkN3iAbGml+v9IQ7qOu1DJgpmCh0A/Ga369yXPuZnG2yCvuDMnh9VuMrOI+K/AKho5Nz2wchxOM3TF54V92RjO9J9x0u7FJXmX1xYsmrYdl7TvA6bxWnmTgAAIABJREFUpqrk7eEE/AeA9dYDTE9273KS5XCnNsf42fI48d52aonwI4EwhDTpu4PINrvEV3SFf8LAqIRHAAQ1y4EJGT3dfd8sKlvWYLHRvOH9K146s8eflI/OAPhFWA9BCSkivMNKjVk4tHvaC6f1ajC0hZmp0LXyBp87/AcmvRGK33e6vd/vcq9s9fNNl8eRCcBuEdlDHGY81Nq6WstHXACgyRWxCcp+Ay4RctJZEmKl3qI8MNstk7/PcNLZURT/Y23Cd7y0i+kOX8fAiCCr+pGZkwfFTm1yGE3aV8UDHCbfjOpbxl5BltscHgBLidXjLw3t9klTmbaV5vcMU/xCE4OcmRlTB8VOWdWSBpR4dl5AoI224wYJd8c6Bz7YkjpCbfH97jQiXojAK1jG/PR5McF0nokQk0AYYjU9l18DaLAKjD8GrY91DphQvRlUte9Klnb3qfB3YH91U8sE0z/DY+ie4ymhvKlMiVs4rIt5aCIpPbVmf5TW7OVbRaC3mfgVRb7lC4b0tryVK3SvvByM5wGcYJHt84ExU4Iek1irlLf1hDfsY8Bms3nQjhinMZSof8c9Mgiw+K8lw0ip2wGcBuAnBi1OvytqIbXxBveicRII20Cpt/BOMOyvPojmxTrjH/BP2lH+Sn/DpDcANNj43cIuUnRzfNRk+w3SmSn9q4OnK42LAQwl0KmoDiQ9an5qH5e4Ub26zh6AtjHxNjbxviO25KMFAwdWNl74YTsr8k9UPv0YAOsVYGpadSB6b/j5dH3Qt/LMbJR6d79uNX6zhibiUTHOQW8HW7Y49kggbAPMW8Jc3shPAQyxyaqJOSUmfFC9jYsK3av7gn1rAQxt4rym/JdY3RUfm9Bhi43ucC3vbZDxOwA3ga2viv2Ux0dPjm7O1VBpVeHDINhuXUqgp2LC4m8JtlxxbJJA2EbcVTvP0qQ+hP24tkoQjYl1xtdb5HT3oVfjtGGuATCsuXUz+A1i46n4mIp8oqR2mUGxs3T5KYqMGwH8GkCj6yE2jbIHxky22wC+Tqmn6BqAn4f9729hpbN8aG8aYjm3WQgJhG3I5Sm6kcH/ss9J+1n7Lu4aMbjePNw9nB9Z6dbzCQg6SNQvFkXMlKUUL4uPmhLyndq+L13ew6uMSWBci+pOnpb8Pn3rMNTw/pEJPwST2VW1K4mJsmE3VAYwiTA2xjnwrRa0SRxjJBC2sVJv4QpU7yZnjfEjQY2NCR/wVeChXa6VNxPwCCw2ew/CLoAKmPhd8up3B8ZNK2puAd+XLu/hUc5fEJvDAJoI4ALYByQra5lw9aDoKUGtlH3Iu2ucYsoHYD/+kPiOWOegv7eibeIYIoGwjZXwd93J6/sUtj2bsAyGRaWvDGeihQBOClXTANoB8HZm/EDEpSAqAVMFCJHQCCfiaGacCEI/EAaBER+iuj1MNG9gVMIjwT4XLPEWXk6M5QC62GYmejnGMSBJemBFsCQQtgNX1e4hTPo9AF2DyL5PgcdFhw36IvDAHs6PrHTp+4hwK1p3JdaB6BOlzOsHRE1rctxhoFJP4dUAngPQYEZNI76qclYNq95yVYjgSCBsJ27v7jGa9WsI7o+5FEqnxzpOanQp+cKSVy6Con8jYImqI1wxgHnx0VXzm9OBU+otuhvMf0VQv6u0H9q8JDbipG9a3kxxLJJA2I5KPYWzUb2SSjD/7xqEe2Ic8Q81dovHzFTozk8k8H0ATglxU0OpAqDnfHD89eSYKyx3/fPH/F0Xl9f3FIBrgjylVEOP6RZ2UptsFi86NwmE7czlLZrH1Vc4QWFgSZWz/LqmhoBs4A2OgS7X1SA9l0Fnhq6lrUOAG4SnNfBIsJ0htVxVRaczYSnAQb0fAsqZ+PJY56DmrNotRB0JhB0g6JknhxUS4Rq7oSBFrlWjGXwzgMnouGeInxL4BfZx1sC4aYeae3LNVfNTsJmi6MfDhCldnQNfb25dQtSSQNhBSjyFt9UMiQn2M9AEPOlyht99PB3f5LxioHqRAyfMqQSaAcJotG7YjS0Cfwmi10DIael4xeKKwnhD8VMgujL4elHOSic39SxViGBJIOxALk/hDQz8C836HGgHGHfEhsevCCb3zoNLu8IRcalSuISYRzBwPuxnu1gxCfw1M30Coo3aQa+f1CWhxWv8MX/sdPl63EaMP3GzZqTQfgYndA0b+EFL6xailgTCDuaq2nUVEy1A8LeCtd7W0L9rbucA81Lj25LIAdrhO5kYg5nQH0xxALoB3I1Aihk+IrgYMAHsJcJ3zPwDtNrdpSJ8c9++E1q96jQzk8uzeyqI74P9nOxAhdA8MTZi0LbWtkMIQALhEcFdtWuoJnoFwMBmnsoMLNGgv8WFxYd8Cl1bYGZyVRUmsKJMQvDbgfr5yHDSFP+1HIVoLQmER4iatfWWAhjVwiLeZEWPxhoD1hyJMyr28t6oSG9lCoNvamEAZAL+Ge0sv4NoiO0eL0I0hwTCIwjzBofLM+DP1ctL2ay43LRviJDFps49EgYWuz2F55jgXxMoA0BsC4spBuNXseEDV4aybULUkkB4BCrxFF5EwAJUr17cYgR8ysS5SvPrUWGDvmyPK0Xmj51uX89LmXkSQAkAD25difSuaeqMuC6DdoemhUI0JIHwCFUzs+J+ALciJJts0X4Qv83MbzH4fa/Tuy0U83FL+fse7PNeoIALWdMFIB4BoFvr24uDAN8Z4xz4/JF4qy86FwmER7iaq8NHYbF5fEsx8B1A2wC9TRF+0oxDYBTDUMUGm1UAYEIZSnP1LS2pXszcD0T9AR6A6o3p7VfVaTZaTE7f72JosPXWl0KEiATCowAzk9tTOIOJHkLoluE6En1ARHfHOOM3dHRDxLFFAuFRhHlLWKk38iZi3AFC345uTwh9yIoyuzri7TefEqINSCA8CjFvD3d5HWkA3R7swgRHJn6PlXqwqyN+dUe3RBzbJBAexZiZSn1F40ljLgjjcHQs1nqIQIvBvmdjwgd/2dGNEQKQQNhpuHlXH9OLJAKlALgYR9Zn62HQ2wTOdjvDl9gtGiFEezuS/lhEiBRX7BpgONRV0DwahEsBxHRAMw4A9BqxzveG8drudFJJB7RBiKBIIOzkmDc4Sr3xvyDCSGhcBsIQVA97CeFnzz6AvgL4IwJ9ZII+6uoc8AURtcueykK0lgTCY9Ae3hPZxes51cF8KhROZcZxDMQpII5BcQDHgREJQgUAMFCiAM1AFQPfE/h7Bu0mxrea9PeVzqiv+1LfVq9II4QQQgghhBBCCCGEEEIIIYQQQgghhBBCCCGEEEIIIYQQQgghhBBCCCGEEEIIIYQQQgghhBBCCCGEEO3jmFiqf8OGDRE+n+98Zu6vlIph5v1KqaJ33nnn88zMTG117tq1a/sbhnGqVR4iOlheXr41ISGh0d3ZXn311bjw8PDhzW23w+H436hRo/YDwJo1a3qFhYWdXXvM6/XumDhxYlFT52ZmZqoRI0aMrn2ttT40fvz4j+3qnJCY2D1C03lWeUxN+xzcZfcrryw4FNQbCZAwI3WIgnlcXdtg/Ji/LGdLYL4piYlnsGkMbEkdBod9sGLFwgOB6ZOmpl1oGL7YuroV78zPyytsSR2JiYlGlWlcXvvaJO1bvWzpWqtzJk9PudL/9arluXV7Ok+ZktIfDl33u6ZhfJ+/LGdrU2VNnJ7eL4y8p9W+9mn6YfWKJV/Xvp40LfViQ5lRVu1hRkWVwV+vzcs7aJWvs3N0dAPa0htvvHGe1vpun883EUAkEYGZAQBaa1xyySX7CwoKchwOx99GjRr1fWNlKKWmMPOTVvUwMyIiInwFBQVvaq0fnjBhwpv+xyMiIs5k5leb236v1zsBwDoAcDgcFzPzytpjDofj2/Xr1583duzYBn/sADB+/PjwsrKygtrXRPQugEvt6nSyca5mFFjlIQJMqjQTpqd8CtCiCMP3fF5eXkUw72nOnDnOvftLX9dQ/Q6n8g9z5swZOH/+fK9/Xq2N6wH8NphyA3kNz1gAb/inTZs2s7ePvG9rVuF1iT68BWBUS+oA0IWBus9VsSoH0GTgyczMVJ9s2hr4e1B3McIOnsKs6n7XiPhfAG5uqjyDzUka6um6+omfBfAbv/Of06yG2L2JMBNImJ7yKRE9tmpZThYAtjuns1Ed3YC28PHHHzvXr1//uNb6YwAzAEQ2kbUngFt8Pt8369evv7aV1ToAjFdKrS8oKPhTK8sKxonM/BIzd9RVvQHgAoD/WWka26ZclRLUFe+P+0sTGegXkHzCnv2lU0LfxPp88N0EILxeImHk5BmpQ9u67qPAecy8KGF68vyObkhH6HSBcMOGDY7i4uJXmPlWBH/r34WZn1+3bt29IWgCAchcv3791BCUZefK9evX/64d6rHTX2u8NWlG2hVB5G30Co9At4S4TfVMnDgxHMRzGjumwU1edR176LogP8dOpdMFQq/X+zCAwA/yBwB/IKKzmfkEZr6Ame8DUG/TcSLKLCgomGFTxZPjxo2jcePG0dixYxUzn0BECQA+98/EzPOaKoCZN3q93gi7n3HjxlneotZ4sKCgYEQQ+VrqPV2lutf+sGH2Y4VRRHgGgMcvn5OYc6+ckTaoqYISpicPA3CRX5LfLRhfNmla8tn++SOUeS8bZj//H4Iejfq2B+Zhw+xnlpW865/JiIhNBtC3sbqJkT4hMbG7zf/DUU8Z5pD85blU++OrKIkgpokgFPvnI9aTOqqNHaVTPSMsKCg4HQ2vONYDuGrcuHH+QW8PgI/feOON/2itXwdQ+8CZADy6cePGNcOHD7d95kVEXFPWnrVr136olPoKQI+aw7949dVX4yZNmlTc2HlXXHFFVfPeXZMczJyzYcOGc2s7VkKK4V29Otv/PRSj+ovlrSlXpSzSGmsAdK3JHEOM+wGkNl6UupUOxx8G0wOgw18YRHQLgOtqX+fl5ZUg4MsqYUZqN3C9R1i+V/PyfrB7GzVl1yoB4SVw3e9KpFOrawH83a6czuS1116rAvB6woyU+QD+7/ARdnZUmzpKp7oiJKKbUD+47+rSpcv0gCBYZ8yYMbtN00wAUOmXfGJZWdm05tY9YcKEnwG8598cp9N5QnPLaQki6uf1ehdmZma26+e58uXcjSC6oV5bwIkJCak9A/NOnpxyPIEPX20zCiIcvvsB+PdWpk2bNqtH4LmtNXl60mUAzj+cwguhzEcAmHXtZropMTHRCHXdRwMGAq6Gle3ogs6mU10RMnOC/2siemDEiBEuq3Muv/zyHQUFBQvg19sGYDKA7ObWT0TEflcrhmF4msgaXlBQcKJVWZWVlfubGo5TYzWAMQAiauqeOHz48DsBPNC8VrdO/rKc3ITpKX8BMLgmyYCTxyPg/087cDMBdVcaTHgmLy+vImF68kKA5tYkd/HBcx2Ah0PZRiZ1q/9NuGbMX52X923CjJR1YEysSR5QqR0JAF4JZd1HEs2q35Uz0uq+9BWb3QC6HIxf1WVi2ubqGv5ShzSwA3WaQLhx48YuZWVl9YKLYRirm8rvj5lfIyK/YQd0mlX+xqxfv74HM/v3nHpN02zqlu18ALutyouIiEgGsLSp40T0BYBVzPysX9p969at+9/48ePfaOq8NsAA3sThQAgQD/bPkJiY2KXSxK/9kn48vmds9TASUs/Cv2OLcOPIkSMfeeutt3yhaNwV09MGgPXkwyn09uoVuV8CADQ/C6KJdYeYb0HrAmGXhOkpjQ7DAoBPNjU5JLB9aFqr4D9stl5fohfAcgccv31rwYJKHGM6za2xy+UKvB3TI0eO/CnI0/f4v2DmXsHWu3bt2qiCgoKRzLwah58PAsC7EyZMKAu2nJYYO3bsfAAL/ZIUEWW9/vrrxzV1Tptg2lv/Nep9FpWmIx04nEbA/NoxgzUDht/2y35idPe+9a7sW8MgfTP8v/CrO3kAABEO/SqAb/2yj54yJf2sVlRHAE6w+TlSVRGoyqd8nb7TqDGdJhBGRUUFznJQa9eujQvmXKVUvT9cZm7QweFnzvr16w+uX7/+YEFBwSGllBvABgT0hjLz/UE1vJW01jcC+MovqY9hGFlVVVXt9ryL6zpLahNUwP8f+3dU+Lwwnq93mOjZei9DNJQmISEhEoxr/JL2+8oPLa99kZeXZxLwYr2WOswbQ1H3EYlRCkJx3U/1VWCtaAbPAvMHNb37x5ROc2s8YsQIV0FBwT4AdVdzSqkxAPKCOH2k/wsi2mmRN5yZwy2OM4C7rW5PiegLrfV1TR0HAI/HY9WGOhMmTCh78803k0zT/BCHB46PMk3znmDODwUirveHw9BFtf9OmJY6GmD/AcufKM19rpya1qc2QZHerRnlqGs/j5oyJf2slSuzNreqXWGRVzP7dQQw3lThcWdeOTXtcBKbn4HI7zVmTp06+64WTh/0MjU9bEqxIgY3+fxTa5T5NQXM1NREgNoCI+E/np7I6pkylMO8eGVeXt2XZmZmpvroi69PNYjuZ6C2g7ArQP8G8AscQzNMOk0gBAAiWs3Ms/1e37lhw4YVo0aNavJ50/r163sACBxo2+zpcDXeI6I/jx071nL8HzO7g5n3G6zRo0dvWbdu3U1EVHd1w8x3hKp8K1NmpFykuf7VsDLp8Hxb0nMDnkVdpJSu9951I7O9tWHeDOD6VjSNmAOuLAlJinRSQLbA86K0qroWwCMtqNP76rIlTQ7BqZli12QgJMbe+s1hyznfpOlc//wM/jH4pgI18+y/TkxMTKk0jQMAomsOnXvljLSBq5dl72pOeUezTnNrDABE9Bzqf4udZ5rm00uXLm30NnHt2rVRzLyEmf1voQ9WVVW9bFHNf4noer+fDGaeoLXuM27cuBF2QbCtjB8/fgERLfBLavOpd5Mnp/bRmgJ6GPm1Vaty9wBAQmLiQIBaOkthZmuG0kyeljoBwOktOZfBt3TEUBrtNT4A4P+lffbk6SmTG8s7dWrySSBc5Z9mEL3XWN4gmPAbSgQADviaHBjfGXWqK8IxY8ZsXLdu3RIiSqlNY+br4uLiTlu7du2fSkpK/puUlGSuWbMmPCwsbGLNc7wzAor5U2ODoP1sqemkOOIYhnGDaZrnMvPZ9rlbLjExsWuFT01n4vtQvwOgSvPhgbnsc9xKxC0NKF188PwKwD9acjIT39rCegFgQIV2XAEgvxVlNNvq1dnFCdOTXwWobnomA9mTZyT/oTIybOG6RYvKEhMTjUqvGm8q+jdqhk7V2B5G5v+aW2diYmLXKm08hIDnvD4d0AHWyXWqQAgAkZGRcyorK08PCAYjlFJvxMXFVaxbt+4AEfVq4jnforFjx/6rHZp5fkFBge1tBzM/P378+KDHBY4aNapy/fr1SQA+BhDTmgbWIYxImJFyeNAzQ1Wa6EoNrzeZiK5bvbx6aMrkyZNjmA4/pgBQ5TPM/q/l5e1rqqqEGalJYF7iV/fNiYmJj+Xl5ZlNndOYSTPSTgbr8X5J30UY5kCrciZPT/kjA3+pq7p6KE27BkIAUIaep01jHA6vYhPFTP8OL/M+kTA95cdKEz2hGiwiwiC6w+7/SZvG0skzUuqGxjCja6WJ/ghciILpq9Urchssi9aZdapbY6C60wTVA40bWxeuCxH1Q+AHX21+XFzctTXT5tpaOICBQfw0+9Zw7Nix3xBRo4sLtJADjLi6n8AeYgBglBJz8qplOYvrkozIX/nnJdDLVkEQAI7rEbMCgP9zrgGVPtXsea/E5lz4/W4T8JxdkPAZ5nOo34s67sppyWc2t+7WWpmX9xUTpQIInOLpBHAiGq6kxADuyV+WE8z4xyHM+EXtD6rHfgb+LZSA9GwcQx0lQCcMhAAwduzYA8XFxVcS0WwAO2yyvwNg1Lhx464///zzvTZ5jwpjx47NBfBcO1T1MwgPO+A8edWKJf698wRQvWEopuJnYWP+/PleBhbUT23eUJqpU2d3A2iWX5JPG+YLduetycvbC6p/BagINzSVvy29uiwnXzNfCK5ei9LCl0xqUv7y3FDMJvIB/IrJfGH+8iUfhaC8o0qnuzWulZSUZAJ4iZkXrl27dqjD4fil1noAEUUT0X6tdaFhGAVjxoyxnOGhlNpomuadfkmfNbctRLSLmf/Q3PMA1P1Caq2/Ukrd6ff6fasTHQ7Hb30+3zfM1c/olFJNznjwp7XaYbC+s6njpLiMoX4mYOuqZTmb0ciVw7RpM3v54H2x7ghR1eqXc94Jpn4Y5r/gM+rmhhMRT5w4MbxmgQA4tHOvD57D/5eEegtNmEZVX2j8tfY1g38MZlEGAFA+I1Mr88PD55LbKn9cXFzVj/tK69pCii2/SDMzM3XCtJSgfg9Wr1jyJYAJkxMTB2ufMYoUTgEjFuBygvqeod/OX77kY1hfuT0WOLjdHxExiA+Z0LvDdMTHja3oLYQQQgghhBBCCCGEEEIIIYQQQgghhBBCCCGEEKKTa/OlmjpCWlrayVojOTc3+6/+6YmJs040DHNEbm5Wg42ZUlLSrwKoeqczhUqG3q693pV5eXluAEhJzdhhKD4vKyurtLntSUnLyARzEoDyvT/+MCxU+3F0ZikpKf1BanluTvYFDY6lpi8B09O5uYvfak0diYmJ0Q5H2FRmPgXAftOh1uQtXmw3JTPkRo4c6ejb94SpRDgLwH6fwht5WVlf2Z4oQqZTzjXWTHeC6DdJaWmj/NMNQw9gvyW66iFMZGIHK/0JtN6pGOcZjrBPMzIymrX/R2pqxtLk5JlnHn6d2gfMU3NzsoZIEDxypKRkDDccYV9pYAQUdkOprobJa5NT0+9t77b0Oa7fciZOAWiPBuIMjWXJyckntXc7jmWdbq7xzJkze3t8+gJoXKOIbkf1fiJBUaD3c7KzltW8XJScmvGDz6dvAFDvj2POnDnOErf7CsV0qibaq71VuXl5eZ7k5JmnM+t4MvTwpLS0vuz1vsdEU8CoSkpLG6O03gGgKDk5/QIoupRIlxDzypycnP1A9R+nUrrKJHIC6Gkwv6c1TXQ61XqvVycC3AXQL+fm5hYlp6cPI+ZfQmNPbGx0bu1mSP5SUtKnGQY+8jKfZjBdwIzte/f+8Ip/ME5KSxurNM5hhR/LXdEr8vPnl6empl/t83ny8/LyDgJAWlraOczqlJycxXW76qWkpV1bHhGx9LwTTyz7+ptvEqr/L3jb6aeckp+Zmalnz54dUVXly3A61QqPx0wpKTn4/GuvvVaVmpo6gpmGEdFen8/zSu0Vd2Zmptq6dfsUJpwB4q9Nr+Njw2H9nZGaOnM0oC/SxDt+2rNnxSmnnEIuV9lvcnKynqzNk5aWNoBZnZuTs/iVw+el9mTwMjDNWJK7eGNt+uRrrnk8sqJqQ3Ja2s4l2dlZ1e+bowHs1zASiPkQkV5R+3kBQHp6+lk+ptGkuZxIr8rJyfmpuo6MGcy+95VS5zDT2QB9k5OzeDkC5gYnJMyJJJRdHhsTHeX3Gd7nny8lZeb5gHkpFEpNr3dVXs0qPqmpGVOV4o+zsrK+B+quLK/Lzc16BgCS0zJu1t6q/yhHeAqxb21ubu4e//YC5uu5ubnf1fyf9GFWk1lRpIP4zays1m2TcLTpdFeEPp/+LTGeXbIkax0T+iUnz2zRKsUAQIwdUNRgR7sSV9mDYDqdiL9UrM8zHGG5AMCG2QuELtDop4BBYWFhTmI6AUCkAgYBiEtJSbuHFD9ErPcRUzeGeic1NXVIdcl6tGb8jTR+pzRVAejJhDu9Pv0SERQT9QIZ/0tOy7hZab6BWB0CYWapu2xBE28hw9R4xmAaw4ytAI3ue9wJBSNHjnQAQEpK+osGqzlE6gfFdEpUdNn/EhMTezFwqnI6k2sL0Ux3MPix2bNnRwBARkbGccx0a7jLVb512/bVBDqfmbYopmFbt23PAYCysrJIBt/j9Zq5UBzdv39/nZKS8RBDXQ+orwH0NIywgoSEOZEAaOu27atAmK5AW8F0unL4HrX6bJjwBw09gRlbCfTLvsed8OY333zDDFyRnJ5et4cKM90EcMDSYSoDTCty/YIgAKx64QWXJr6dNN0KAFrTMIbxV4a6l5gLiRDHUBsTZ84cCADJqRm/Mhn/UIzdUOxl0Ku1xxg8C2TM11BjmVHK0HempqY3WKY/P39+OQNbSkvdj6anp/erbXbt8eTU9DtB+u+s1AFm1dVwhL2dnl69056GztBax9fm7dWrlxN0eGFcYr7H4Qh/SYHjnU6nLyUl/RpT43nS7AIQBnJkT77mmpjk5IyzGfQqETyk+VtT8+OpqRl1i8MeCzrVFWFCwpxI5rJk0/ScCwDEeJKVvhX1N28PysyZM6O8Pj2HmBYGHluSk/V7v5drUlLTf0hMTDSWZme/nZKW/h1rtWxJ9uIvACAtLW2FZnX+kuys+YmJs05wOMwMn88zNC8vzwMAycnpX7EyHkT1pvIAyJObk5VYc+7JBAwk6NF1V41p6f3AemROTvZVNe95UVR02feZmZmqZg+K+pi/yMnNrt1QaEVKWnpWn+OPvyo1NfV7AANychaPrs2anJaxz3CG38WmekYp8zkATyckzIlklJ0OYHGFx3MFgOVejSQFLCYj7CoGti/JzvpjTRGrU1LTs5OTM87Wuuo7AP219o1ZsmTJzuTk5JNIOS7NzckagZo/9JSUNIqKKktPTk7fzYBjSU7WzMNtSbshYAe6wDf25ZKcrNo/+hWpqWkvHXfcCSmA/jdpmgPgg5EjRzoYmFTmjsqsdyZhMJgbXUWoMiLisy4VVSf75e6Sm5OVXtvm1NT0nwyfvmfkyJHXE/gu0+s5Oy8vr6Lms9xjmHwLgNtRfcKHS7IX/6X6vaasYDI2Amiwl0yYQ03wmnynqfnDlLT0r9jE35YsyVqXmDi7L7H32ogI51kLavYaTkpL2wSmhwEEtQUCkV6QnZ29Zs6cOU6vWfaniDDn2QsW1G1M9S8ASElLf5BNdX3uksUo1QP9AAAILklEQVSfAkBiYuKbhiNsDTrxZveBOlUgjIxxXw3QdlLOYUlpaWDCz6SRlJiY+Mc8m0VBAYDBf0tJTb+LAcPr07FgfjEnN6vBJuvJaRk3E+tpBNLV5yHO7XY7ELDvQyCHQ5/BwEe1QRAAtPa8Zaiwpw+3gQL3PNnifytGjEImVfde8vPnl6ekppd88smeCAANdjEjUgHLX/F/FdOZmhBHoLfrHTLpLRh66pIlC79JSU13pqSkxANlF4FouUm8zND0ZwDLSXOiMpBiMq4nxujU1PS6NjPQVynzRK3xHUCFS5Ys2VndDucQgPunpqav88sbC+Y1MFSkYv5v/bYYb0GZTQdChXrvi5n+C9CZp5126t3btm1/KC0tLU5rdSmIC/Lz5wf8v9AeDtiEvlZkeflgkHF42a7qfUDqrtB8DvW24dM39OnTZwCAHg5H2KrU1PSa90NOMNftka2g36z9d25u7p6U1HT/pfXrLFq06GcAt48cOfKO4447biKUWpCUlpYCeAyAPlngt+F6t+jo/5a6yl5srJyqmBhHZEVVvTSv17seANxudzxYFfoFQX9DlOKHa98HADCjd2N1dFadJhBmZmaqbdu238zAe4pVYt0BwibDGf4bVD93sUTAn4h4tTsiwrfqhRdcjeVJTJx1Imkz5bTTTrms5gqMUlLT620Qbxi60d54rdVuIvNU/7T/b+9uY+yoyjiA/59z5rI3FpVUsTVUg1HZ1sIHYmIIfFjEBlGJLZJL5850634w25akvCSkgKJt2n4QStiSmKoYy9runbnr0PBSaEp4TUQgYiIJ1IpbXivvJBS3l+7OnXMeP9x93+0WAwGy+f++3XvPzDw5dzI55zmT8xjTtgTAS2MxqJ+SGJOhiZ9UoOJ18t0+C9+qybJ/7HiVMwVywEIPe2jHpMbWLYE3rVgUu1SCiqieY+Cvq9eSgbAafyWO47Ocx2CtVvtPGMavwODOdHxEOKZSqcwHxvfnM8a/4iEH06T2/altV0bRTwAsnxbLLDvtGY9vYWK1QSNnwuvzmzZt8mEU7VIvkYpfBmenxeaspLbQJ6Io2pEkycT9KAWwmyfVOladlFox3i8FcNh7/5o18m5RDF90vN2vvTEnXBhbvXr1F44EQX7Pzp2DI7nbvWEULxOVc63on52ivRVXqzcajcZiKF5uBSvHVM1YudLy0NDZU18EybKsCQCDgye/Ou/kxund3d2laflkj8NFIOs+iRXzT4s58yB87rlDPwbkQD3tm7RNfWdn55eazj/V1dW1bWho9vtSFY00TWYr3IRSqRj0KvMHBgaWViqr3wuC4koFTlmwYEHrDvR4U0V+EIarTiuXg4fyfGzwh5GR1qEwWnWLOvM7tcVCUWwXjOd1PmoCvaxajd8qrDwVOP2eQn5ojN6Q582GDU76RRhG16i6O0VKi0V1C8StAIByuVQfGi4eFsGRJEkGRjroDufNn6B6MwA4l6dWTnoiDOODQSCP5N4vtSoXpmlt2vQvSZKnw2rcDKNVv3RNs7NUKhZ6b7rL5eDKRqNxrwRtG6vVeH1R2LuNcYsFWDPbnqMKXBqG0esuMH+zhX4XqsvL5dK3AUBU/6gijwjwVr1/97NTj812735xZRRd5VX+Eobxjcbokw5YJGquhugbRTPfPt5/+FoYRptFNFG1X4fTHkB+mmXZsZXVeE8QlP4QRdFW52ybiLvcWrlxdPHig2g2/fmfaQ7fXK3GtwL+H6ryVSgugZcVSX/thTCKnwmjeLszsiNw7lTnsV1EWjWrRR8FsLla7TwKFPP8LKmEvXtvez+MVmWDg+/fXq1WbxKRsldZD3XXqsWvrdNdURStbzaDt60tLhXRQ2mafuw1Wz4pc2axRNV/Q1Vumvp9a9qhO44da56lKu8A+viMx4v+3Rg9/k7GovvzPG8mSfIuVNY4jw225K5XlX0Q3NZoNDwAGKNbVLAERi8EUPbeHzHQx0ZP44q8E14PGuN/ZSCXQaU7TfseAAA1+KeqDIy2NcYcheDRSXFCD0wtQK/AvqI4POOoRGB+7iFftk63KrBI4M6r1Wr/zbLMuSJf1rpOaauIv8D74kdpmv4LAHp7e49AcIcX/c342XwC0X83GvPuAoAsy466Iu8QQXvhtcdAOqyVnpHGuU4YiQLA5z477xJ4/54N3DYPExvjf9vb2zuUZVlebgs6AHzRWtcjoh0Guk4gD874X6g+aUTXAFhgnW4F5HRXlM4bnfalafoOFM8LZMYpJAD0J0ndWbkAgtOc4nooLoZiWz2phRNHeCpSV4OnAbsRRi9WRTS6yNKf1q7zgodUsVFE13uDu0cfggL81apO2vFZodMeLGnat0e9rPDAIlVzBYDvQN3y/pF83eIzvtklKs9Ypzd4mKp6rEvTvv2t3864XUV/D+haQM4X9VcosO9416snfRtU/f2A3eBVLhdIrV6vv9Zfq90LlWs85GdBUGwRMYPt7e33Ha/v5qI5+UI1tYRhvEfE96Rp+tiJW88NXV1dp+R5Pt+r3FduK509Mb/2/wrDeC2MLKwnfZs+ugjp02jOTI1pBgYNLyfOU80VlUrl80PDzcehUlbF2g/zEAQAFRmG6oc6BxERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERfbz+BxL4U4Izn2y+AAAAAElFTkSuQmCC
+    mediatype: image/png
+  install:
+    spec:
+      clusterPermissions:
+      - rules:
+        - apiGroups:
+          - '*'
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        - nonResourceURLs:
+          - '*'
+          verbs:
+          - '*'
+        serviceAccountName: opendatahub-operator
+      deployments:
+      - name: opendatahub-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              name: opendatahub-operator
+          strategy: {}
+          template:
+            metadata:
+              labels:
+                name: opendatahub-operator
+            spec:
+              containers:
+              - command:
+                - opendatahub-operator
+                env:
+                - name: WATCH_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.annotations['olm.targetNamespaces']
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: OPERATOR_NAME
+                  value: opendatahub-operator
+                image: quay.io/opendatahub/opendatahub-operator:v0.8.0
+                imagePullPolicy: Always
+                name: opendatahub-operator
+                resources: {}
+              serviceAccountName: opendatahub-operator
+    strategy: deployment
+  installModes:
+  - supported: false
+    type: OwnNamespace
+  - supported: false
+    type: SingleNamespace
+  - supported: false
+    type: MultiNamespace
+  - supported: true
+    type: AllNamespaces
+  maturity: beta
+  links:
+  - name: Open Data Hub
+    url: https://opendatahub.io
+  - name: Open Data Hub Community
+    url: https://github.com/opendatahub-io
+  - name: Kubeflow
+    url: https://www.kubeflow.org/
+  - name: Kubeflow on OpenShift
+    url: https://www.kubeflow.org/docs/openshift/
+  provider:
+    name: Open Data Hub
+  maintainers:
+    - name: Open Data Hub Contributors
+      email: contributors@lists.opendatahub.io
+  keywords:
+    - Kubeflow
+    - Operator
+    - OpenShift
+    - Open Data Hub
+    - opendatahub
+  version: 0.8.0
+  replaces: opendatahub-operator.v0.7.0
+  selector:
+    matchLabels:
+      component: opendatahub-operator

--- a/deploy/olm-catalog/opendatahub/opendatahub-operator.package.yaml
+++ b/deploy/olm-catalog/opendatahub/opendatahub-operator.package.yaml
@@ -1,5 +1,5 @@
 channels:
-- currentCSV: opendatahub-operator.v0.6.1
+- currentCSV: opendatahub-operator.v0.8.0
   name: beta
 defaultChannel: beta
 packageName: opendatahub


### PR DESCRIPTION
ODH release for 0.8 release. 
The only major update that I added to the description was the support for JupyterLab notebooks in JupyterHub

Closes #54 