### PR TITLE
configure aicoe-ci to support image build release.

### DIFF
--- a/.aicoe-ci.yaml
+++ b/.aicoe-ci.yaml
@@ -1,0 +1,9 @@
+check:
+  - thoth-build
+build:
+  build-stratergy: "Dockerfile"
+  dockerfile-path: "build/Dockerfile.multistage"
+  registry: "quay.io"
+  registry-org: "opendatahub"
+  registry-project: "opendatahub-operator"
+  registry-secret: "opendatahub-thoth-pusher-secret"


### PR DESCRIPTION
# Pull request 

Allow aicoe-ci to assist with:
-  image build on tag release. 
-  build-check on each pull request.

Tested it on fork: 
Following configuration was used:
https://github.com/harshad16/opendatahub-operator/blob/master/.aicoe-ci.yaml
Built image based on the demo tag:
[quay.io/harshad16/opendatahub-operator:demo] (https://quay.io/harshad16/opendatahub-operator:demo)

# Description 
configure aicoe-ci to support image build release.
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>