### PR TITLE
Add custom tag (latest) for new releases

### DIFF
--- a/.aicoe-ci.yaml
+++ b/.aicoe-ci.yaml
@@ -3,6 +3,7 @@ check:
 build:
   build-stratergy: "Dockerfile"
   dockerfile-path: "build/Dockerfile.multistage"
+  custom-tag: "latest"
   registry: "quay.io"
   registry-org: "opendatahub"
   registry-project: "opendatahub-operator"


### PR DESCRIPTION
When we create a new release (e.g. `v0.9.0`) this change will ensure `latest` points to this latest release