### PR TITLE
enable thoth-bot kebechet to handle release changelogs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,24 @@
+---
+name: Bug report
+about: Create a report to help us improve
+labels: bug
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,17 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+labels: enhancement
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/major-release.md
+++ b/.github/ISSUE_TEMPLATE/major-release.md
@@ -1,0 +1,11 @@
+---
+name: Major release
+about: Create a new major release
+title: New major release
+assignees: 'sesheta'
+labels: bot
+---
+
+Hey, Kebechet!
+
+Create a new major release, please.

--- a/.github/ISSUE_TEMPLATE/minor-release.md
+++ b/.github/ISSUE_TEMPLATE/minor-release.md
@@ -1,0 +1,11 @@
+---
+name: Minor release
+about: Create a new minor release
+title: New minor release
+assignees: 'sesheta'
+labels: bot
+---
+
+Hey, Kebechet!
+
+Create a new minor release, please.

--- a/.github/ISSUE_TEMPLATE/patch-release.md
+++ b/.github/ISSUE_TEMPLATE/patch-release.md
@@ -1,0 +1,11 @@
+---
+name: Patch release
+about: Create a new patch release
+title: New patch release
+assignees: 'sesheta'
+labels: bot
+---
+
+Hey, Kebechet!
+
+Create a new patch release, please.

--- a/.github/ISSUE_TEMPLATE/redeliver_container_image.md
+++ b/.github/ISSUE_TEMPLATE/redeliver_container_image.md
@@ -1,0 +1,13 @@
+---
+name: Deliver Container Image
+about: build a git tag and push it as a container image to quay
+title: Deliver Container Image
+assignees: sesheta
+labels: bot
+---
+
+Hey, AICoE-CI!
+
+Please build and deliver the following git tag:
+
+Tag: x.y.z

--- a/.thoth.yaml
+++ b/.thoth.yaml
@@ -1,0 +1,10 @@
+managers:
+  - name: version
+    configuration:
+      maintainers:
+        - crobby
+        - vpavlin
+      assignees:
+        - sesheta
+      labels: [bot]
+      changelog_file: true

--- a/version.py
+++ b/version.py
@@ -1,0 +1,5 @@
+#!/usr/bin/env python3
+"""opendatahub operator."""
+
+
+__version__ = "0.8.0"


### PR DESCRIPTION
enable thoth-bot kebechet to handle release changelogs
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

the kebechet bot requires a version file where it would keep the version track of the component, based on that it would update the next update. following file names are accepted:
```
setup.py
__init__.py
__about__.py
version.py
app.py
wsgi.py
```
which one should we include in the application?

the file content would be : 
```
__version__ = "X.Y.Z"
```