### PR TITLE
Bump version to v1.0.5 for kebechet bot

### DIFF
--- a/version.py
+++ b/version.py
@@ -2,4 +2,4 @@
 """opendatahub operator."""
 
 
-__version__ = "1.0.4"
+__version__ = "1.0.5"


### PR DESCRIPTION
Updating the patch release version in `version.py` after manually tagging `v1.0.5`

Signed-off-by: Landon LaSmith <LLaSmith@redhat.com>