### PR TITLE
Update crd for OpenShift 4.9

### DIFF
--- a/bundle/manifests/kfdef.apps.kubeflow.org.crd.yaml
+++ b/bundle/manifests/kfdef.apps.kubeflow.org.crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: kfdefs.kfdef.apps.kubeflow.org
@@ -42,3 +42,47 @@ spec:
   - name: v1
     served: true
     storage: true
+    schema:
+      openAPIV3Schema:
+        description: KfDef is the Schema for the kfdefs API
+        type: object
+        properties:
+          apiVersion:
+            description: >-
+              APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the
+              latest internal value, and may reject unrecognized values. More
+              info:
+              https://git.k8s.io/community/contributors/devel/api-conventions.md#resources
+            type: string
+          kind:
+            description: >-
+              Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the
+              client submits requests to. Cannot be updated. In CamelCase.
+              More info:
+              https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KfDefSpec defines the desired state of KfDef
+            type: object
+            properties:
+              applications:
+                type: array
+                items:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+              repos:
+                type: array
+                items:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+              version:
+                type: string
+          status:
+            description: KfDefStatus defines the observed state of KfDef
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+

--- a/deploy/crds/kfdef.apps.kubeflow.org_kfdefs_crd.yaml
+++ b/deploy/crds/kfdef.apps.kubeflow.org_kfdefs_crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: kfdefs.kfdef.apps.kubeflow.org
@@ -40,3 +40,46 @@ spec:
   - name: v1
     served: true
     storage: true
+    schema:
+      openAPIV3Schema:
+        description: KfDef is the Schema for the kfdefs API
+        type: object
+        properties:
+          apiVersion:
+            description: >-
+              APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the
+              latest internal value, and may reject unrecognized values. More
+              info:
+              https://git.k8s.io/community/contributors/devel/api-conventions.md#resources
+            type: string
+          kind:
+            description: >-
+              Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the
+              client submits requests to. Cannot be updated. In CamelCase.
+              More info:
+              https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KfDefSpec defines the desired state of KfDef
+            type: object
+            properties:
+              applications:
+                type: array
+                items:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+              repos:
+                type: array
+                items:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+              version:
+                type: string
+          status:
+            description: KfDefStatus defines the observed state of KfDef
+            type: object
+            x-kubernetes-preserve-unknown-fields: true


### PR DESCRIPTION
This commit updates apiextextensions.k8s.io api from v1beta1 to v1 as
the former is no longer supported on OpenShift versions 4.9+

Jira Issue: https://issues.redhat.com/browse/ODH-452