### PR TITLE
Add liveness and readiness probes

### DIFF
--- a/bundle/manifests/opendatahub-operator.v1.1.0.clusterserviceversion.yaml
+++ b/bundle/manifests/opendatahub-operator.v1.1.0.clusterserviceversion.yaml
@@ -307,10 +307,21 @@ spec:
                             fieldPath: metadata.name
                       - name: OPERATOR_NAME
                         value: opendatahub-operator
+                    ports:
+                      - containerPort: 8383
+                        protocol: TCP
                     image: quay.io/opendatahub/opendatahub-operator:v1.1.0
                     imagePullPolicy: Always
                     name: opendatahub-operator
                     resources: {}
+                    readinessProbe:
+                      tcpSocket:
+                        port: 8383
+                      initialDelaySeconds: 30
+                    livenessProbe:
+                      tcpSocket:
+                        port: 8383
+                      initialDelaySeconds: 30
                 serviceAccountName: opendatahub-operator
     strategy: deployment
   installModes:

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -17,8 +17,19 @@ spec:
         - name: kubeflow-operator
           # Replace this with the built image name
           image: aipipeline/kubeflow-operator:v1.1.0
+          readinessProbe:
+            tcpSocket:
+              port: 8383
+            initialDelaySeconds: 30
+          livenessProbe:
+            tcpSocket:
+              port: 8383
+            initialDelaySeconds: 30
           command:
           - kfctl
+          ports:
+            - containerPort: 8383
+              protocol: TCP
           imagePullPolicy: Always
           env:
             - name: WATCH_NAMESPACE


### PR DESCRIPTION
This commit adds health checks to the operator container. These probes
perform periodic diagnostics on the operator pod ensuring that the
pod is more reliable and robust

Jira Issue: https://issues.redhat.com/browse/ODH-501