### PR TITLE
Fix syncing cache behind HTTP proxy (kubeflow/kfctl#326)

### DIFF
--- a/pkg/kfconfig/types.go
+++ b/pkg/kfconfig/types.go
@@ -527,7 +527,9 @@ func (c *KfConfig) SyncCache() error {
 				return errors.WithStack(err)
 			}
 		} else {
-			t := &http.Transport{}
+			t := &http.Transport{
+				Proxy: http.ProxyFromEnvironment,
+			}
 			t.RegisterProtocol("file", http.NewFileTransport(http.Dir("/")))
 			t.RegisterProtocol("", http.NewFileTransport(http.Dir("/")))
 			hclient := &http.Client{Transport: t}


### PR DESCRIPTION
Cherrypick fix from kubeflow/kfctl#326 to allow syncing when behind a proxy. 