### PR TITLE
Deploy applications using server-side apply

### DIFF
--- a/pkg/utils/k8utils.go
+++ b/pkg/utils/k8utils.go
@@ -313,6 +313,12 @@ func (a *Apply) Apply(data []byte) error {
 	ioStreams := genericclioptions.IOStreams{In: os.Stdin, Out: os.Stdout, ErrOut: os.Stderr}
 	a.options = kubectlapply.NewApplyOptions(ioStreams)
 	a.options.DeleteFlags = a.deleteFlags("that contains the configuration to apply")
+	// This is a required field for server-side apply
+	a.options.FieldManager =  "application/apply-patch+yaml"
+	a.options.ServerSideApply = true
+	// This is required to apply aggregated cluster roles :
+	// https://kubernetes.io/docs/reference/access-authn-authz/rbac/#aggregated-clusterroles
+	a.options.ForceConflicts = true
 	initializeErr := a.init()
 	if initializeErr != nil {
 		return &kfapis.KfError{


### PR DESCRIPTION
## Description
This commit makes use of `ServerSideApply` option provided by
kubectl package to perform server-side apply while deploying manifests.
This will fix issues that result in failed reconciliation when oversized
CRDs are deployed.

## How Has This Been Tested?
1. Deploy custom operator image using instructions given here : https://github.com/opendatahub-io/opendatahub-operator/blob/master/operator.md#build-instructions (My custom image: quay.io/vhire/kfctl:v1.2)
2. Test if following KfDefs are applied successfully:
     - [ODH](https://github.com/opendatahub-io/odh-manifests/blob/master/kfdef/kfctl_openshift.yaml)
     - [Notebook Controller](https://github.com/opendatahub-io/odh-manifests/blob/master/kfdef/kfctl_odh_notebook_controller.yaml)
     - [Kubeflow Manifests](https://github.com/opendatahub-io/manifests/blob/v1.5-branch-openshift/openshift/kfdef/kfctl_openshift_v1.5.0_odh.yaml) 
3. Update Notebook Controller KfDef and confirm if the operator reconciles.


## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
