### PR TITLE
Update secret-controller to create OAuth client

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 	github.com/jlewi/cloud-endpoints-controller v0.0.0-20200604211613-aff0aaad5602
 	github.com/kubernetes-sigs/application v0.8.0
 	github.com/onrik/logrus v0.5.1
+	github.com/openshift/api v3.9.1-0.20190924102528-32369d4db2ad+incompatible
 	github.com/operator-framework/operator-lifecycle-manager v0.0.0-20191115003340-16619cd27fa5
 	github.com/operator-framework/operator-sdk v0.13.0
 	github.com/otiai10/copy v1.0.2
@@ -69,6 +70,7 @@ replace (
 	github.com/go-openapi/spec => github.com/go-openapi/spec v0.18.0
 	github.com/go-openapi/swag => github.com/go-openapi/swag v0.17.0
 	github.com/mitchellh/go-homedir => github.com/mitchellh/go-homedir v1.0.0
+	github.com/openshift/api => github.com/openshift/api v0.0.0-20171215170046-3922a2604003
 	github.com/otiai10/copy => github.com/otiai10/copy v1.0.2
 	github.com/otiai10/mint => github.com/otiai10/mint v1.3.0
 	github.com/russross/blackfriday => github.com/russross/blackfriday v1.5.2-0.20180428102519-11635eb403ff // indirect

--- a/go.sum
+++ b/go.sum
@@ -658,6 +658,8 @@ github.com/opencontainers/image-spec v1.0.1/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zM
 github.com/opencontainers/runc v0.0.0-20181113202123-f000fe11ece1/go.mod h1:qT5XzbpPznkRYVz/mWwUaVBUv2rmF59PVA73FjuZG0U=
 github.com/opencontainers/runtime-spec v1.0.0/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/selinux v0.0.0-20170621221121-4a2974bf1ee9/go.mod h1:+BLncwf63G4dgOzykXAxcmnFlUaOlkDdmw/CqsW6pjs=
+github.com/openshift/api v0.0.0-20171215170046-3922a2604003 h1:u7gCEu13BInetP0+8iqRtNqTVqUbAo7Gu/UJSnPfnbI=
+github.com/openshift/api v0.0.0-20171215170046-3922a2604003/go.mod h1:dh9o4Fs58gpFXGSYfnVxGR9PnV53I8TW84pQaJDdGiY=
 github.com/openshift/api v3.9.1-0.20190924102528-32369d4db2ad+incompatible/go.mod h1:dh9o4Fs58gpFXGSYfnVxGR9PnV53I8TW84pQaJDdGiY=
 github.com/openshift/client-go v0.0.0-20190923180330-3b6373338c9b/go.mod h1:6rzn+JTr7+WYS2E1TExP4gByoABxMznR6y2SnUIkmxk=
 github.com/openshift/origin v0.0.0-20160503220234-8f127d736703/go.mod h1:0Rox5r9C8aQn6j1oAOQ0c1uC86mYbUFObzjBRvUKHII=
@@ -668,6 +670,7 @@ github.com/openzipkin/zipkin-go v0.2.0/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnh
 github.com/operator-framework/operator-lifecycle-manager v0.0.0-20191115003340-16619cd27fa5 h1:rjaihxY50c5C+kbQIK4s36R8zxByATYrgRbua4eiG6o=
 github.com/operator-framework/operator-lifecycle-manager v0.0.0-20191115003340-16619cd27fa5/go.mod h1:zL34MNy92LPutBH5gQK+gGhtgTUlZZX03I2G12vWHF4=
 github.com/operator-framework/operator-registry v1.5.1/go.mod h1:agrQlkWOo1q8U1SAaLSS2WQ+Z9vswNT2M2HFib9iuLY=
+github.com/operator-framework/operator-sdk v0.8.2/go.mod h1:iVyukRkam5JZa8AnjYf+/G3rk7JI1+M6GsU0sq0B9NA=
 github.com/operator-framework/operator-sdk v0.13.0 h1:AWiKOl6ZeAyQgbGVoD8fNd+eCbFuRWgr4hciaaOEBmE=
 github.com/operator-framework/operator-sdk v0.13.0/go.mod h1:XRnicDD4uZCNbJbMXc0B7eyw7hjO4Xzol7FAkWHa1Nc=
 github.com/otiai10/copy v1.0.2 h1:DDNipYy6RkIkjMwy+AWzgKiNTyj2RUI9yEMeETEpVyc=

--- a/pkg/apis/apps/addtoscheme_kfdef_v1.go
+++ b/pkg/apis/apps/addtoscheme_kfdef_v1.go
@@ -2,9 +2,10 @@ package apps
 
 import (
 	v1 "github.com/kubeflow/kfctl/v3/pkg/apis/apps/kfdef/v1"
+	ocv1 "github.com/openshift/api/oauth/v1"
+	routev1 "github.com/openshift/api/route/v1"
 	operatorsv1alpha1 "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
 	apiserv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
-
 )
 
 func init() {
@@ -12,5 +13,7 @@ func init() {
 	AddToSchemes = append(AddToSchemes,
 		v1.SchemeBuilder.AddToScheme,
 		operatorsv1alpha1.AddToScheme,
-		apiserv1.AddToScheme)
+		apiserv1.AddToScheme,
+		ocv1.AddToScheme,
+		routev1.AddToScheme)
 }

--- a/pkg/controller/secretgenerator/secret.go
+++ b/pkg/controller/secretgenerator/secret.go
@@ -9,10 +9,11 @@ import (
 )
 
 const (
-	SECRET_NAME_ANNOTATION    = "secret-generator.opendatahub.io/name"
-	SECRET_TYPE_ANNOTATION    = "secret-generator.opendatahub.io/type"
-	SECRET_LENGTH_ANNOTATION  = "secret-generator.opendatahub.io/complexity"
-	SECRET_DEFAULT_COMPLEXITY = 16
+	SECRET_NAME_ANNOTATION         = "secret-generator.opendatahub.io/name"
+	SECRET_TYPE_ANNOTATION         = "secret-generator.opendatahub.io/type"
+	SECRET_LENGTH_ANNOTATION       = "secret-generator.opendatahub.io/complexity"
+	SECRET_OAUTH_CLIENT_ANNOTATION = "secret-generator.opendatahub.io/oauth-client-route"
+	SECRET_DEFAULT_COMPLEXITY      = 16
 
 	letterRunes = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
 
@@ -23,10 +24,11 @@ const (
 )
 
 type Secret struct {
-	Name       string
-	Type       string
-	Complexity int
-	Value      string
+	Name             string
+	Type             string
+	Complexity       int
+	Value            string
+	OAuthClientRoute string
 }
 
 func newSecret(annotations map[string]string) (*Secret, error) {
@@ -82,6 +84,9 @@ func newSecret(annotations map[string]string) (*Secret, error) {
 	default:
 		return nil, errors.New(errUnsupportedType)
 	}
-
+	// Get OAuthClient route name from annotation
+	if secretOAuthClientRoute, found := annotations[SECRET_OAUTH_CLIENT_ANNOTATION]; found {
+		secret.OAuthClientRoute = secretOAuthClientRoute
+	}
 	return &secret, nil
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fixes #175 

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
Operator Image: quay.io/vhire/opendatahub-operator:testoauth
1. Create an example secret with required annotations and plain text
```
apiVersion: v1
kind: Secret
metadata:
  name: example
  annotations:
    secret-generator.opendatahub.io/name: "password"
    secret-generator.opendatahub.io/type: "random"
    secret-generator.opendatahub.io/complexity: "16"
    secret-generator.opendatahub.io/oauth-client-route: "example-route"
type: Opaque

```
2. Create a Route for an example service to be accessed by Oauth client
```
kind: Route
apiVersion: route.openshift.io/v1
metadata:
  name: example-route
  namespace: test
spec:
  host: >-
    example-route-test.apps.ci-ln-2gzkqh2-76ef8.origin-ci-int-aws.dev.rhcloud.com
  to:
    kind: Service
    name: example
    weight: 100
  port:
    targetPort: 9376
```
The seceret Controller will generate a secret and an Oauth client
```
apiVersion: v1
kind: Secret
metadata:
  name: example-generated
data:
  password: jgKGv6grDaLEMo6r
type: Opaque
```

```
apiVersion: oauth.openshift.io/v1
grantMethod: auto
kind: OAuthClient
metadata:
  name: example-route
redirectURIs:
- example-route-test.apps.ci-ln-2gzkqh2-76ef8.origin-ci-int-aws.dev.rhcloud.com
secret: <secret-value>
```
## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
