### PR TITLE
Read env variables from KfDef Parameters

### DIFF
--- a/pkg/kfapp/kustomize/kustomize_test.go
+++ b/pkg/kfapp/kustomize/kustomize_test.go
@@ -213,3 +213,54 @@ func TestCreateStackAppKustomization(t *testing.T) {
 		}
 	}
 }
+
+
+func TestGetParameterValue(t *testing.T) {
+	type testCase struct {
+		Name     string
+		Input    string
+		Expected string
+	}
+	// Set EXAMPLE_VAR env variable
+	err := os.Setenv("EXAMPLE_VAR", "example")
+	if err !=nil {
+		t.Fatalf("Error setting env variable: %v", err)
+	}
+
+	testCases := []testCase{
+		{
+			Name:     "Input env variable of type $VAR",
+			Input:    "$EXAMPLE_VAR",
+			Expected: "example",
+		},
+		{
+			Name:     "Input env variable of type ${VAR}",
+			Input:    "${EXAMPLE_VAR}",
+			Expected: "example",
+		},
+		{
+			Name:     "Input string without env variable",
+			Input:    "example",
+			Expected: "example",
+		},
+	}
+
+	for _, c := range testCases {
+
+		t.Log(c.Name)
+		result := getParameterValue(c.Input)
+
+		if diff := cmp.Diff(c.Expected, result); diff != "" {
+			t.Fatalf("Result string is different from expected. (-want, +got):\n%s", diff)
+		}
+
+	}
+
+	// Unset the env variable
+	err = os.Unsetenv("EXAMPLE_VAR")
+	if err !=nil {
+		t.Fatalf("Error unsetting env variable: %v", err)
+	}
+
+
+}


### PR DESCRIPTION
Fixes #179 

## How Has This Been Tested?
1. Install Open Data Hub operator
2. Update CSV with following two changes:
     - spec.image : quay.io/vhire/opendatahub-operator:env 
     - Add following env variable under spec.env
       ```
       name: MINIMAL_IMAGE
       value: quay.io/thoth-station/s2i-minimal-py38-notebook:v0.3.0
      ``` 
3. Deploy following KfDef
```

apiVersion: kfdef.apps.kubeflow.org/v1
kind: KfDef
metadata:
  name: opendatahub
  namespace: opendatahub
spec:
  applications:
  - kustomizeConfig:
      repoRef:
        name: manifests
        path: odh-common
    name: odh-common
  - kustomizeConfig:
      overlays:
      - additional
      parameters:
       - name: minimal-image
         value: $MINIMAL_IMAGE
      repoRef:
        name: manifests
        path: jupyterhub/notebook-images
    name: notebook-images
  repos:
  - name: manifests
    uri: https://github.com/VaishnaviHire/odh-manifests/tarball/test_image_vars
```
 



## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
