### PR TITLE
Update alm-examples for 1.4.1 Release

### DIFF
--- a/deploy/olm-catalog/opendatahub/1.4.1/manifests/opendatahub-operator.v1.4.1.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/opendatahub/1.4.1/manifests/opendatahub-operator.v1.4.1.clusterserviceversion.yaml
@@ -24,9 +24,6 @@ metadata:
               },
               {
                 "kustomizeConfig": {
-                  "overlays": [
-                    "authentication"
-                  ],
                   "repoRef": {
                     "name": "manifests",
                     "path": "odh-dashboard"
@@ -38,10 +35,55 @@ metadata:
                 "kustomizeConfig": {
                   "repoRef": {
                     "name": "manifests",
+                    "path": "prometheus/cluster"
+                  }
+                },
+                "name": "prometheus-cluster"
+              },
+              {
+                "kustomizeConfig": {
+                  "repoRef": {
+                    "name": "manifests",
+                    "path": "prometheus/operator"
+                  }
+                },
+                "name": "prometheus-operator"
+              },
+              {
+                "kustomizeConfig": {
+                  "repoRef": {
+                    "name": "manifests",
+                    "path": "grafana/cluster"
+                  }
+                },
+                "name": "grafana-cluster"
+              },
+              {
+                "kustomizeConfig": {
+                  "repoRef": {
+                    "name": "manifests",
+                    "path": "grafana/grafana"
+                  }
+                },
+                "name": "grafana-instance"
+              },
+              {
+                "kustomizeConfig": {
+                  "repoRef": {
+                    "name": "manifests",
                     "path": "odh-notebook-controller"
                   }
                 },
                 "name": "odh-notebook-controller"
+              },
+              {
+                "kustomizeConfig": {
+                  "repoRef": {
+                    "name": "manifests",
+                    "path": "notebook-images"
+                  }
+                },
+                "name": "notebook-images"
               },
               {
                 "kustomizeConfig": {
@@ -68,58 +110,13 @@ metadata:
                     "path": "data-science-pipelines"
                   }
                 },
-                "name": "ds-pipelines"
-              },
-              {
-                "kustomizeConfig": {
-                  "repoRef": {
-                    "name": "manifests",
-                    "path": "grafana/cluster"
-                  }
-                },
-                "name": "grafana-cluster"
-              },
-              {
-                "kustomizeConfig": {
-                  "repoRef": {
-                    "name": "manifests",
-                    "path": "grafana/grafana"
-                  }
-                },
-                "name": "grafana-instance"
-              },
-              {
-                "kustomizeConfig": {
-                  "repoRef": {
-                    "name": "manifests",
-                    "path": "prometheus/cluster"
-                  }
-                },
-                "name": "prometheus-cluster"
-              },
-              {
-                "kustomizeConfig": {
-                  "repoRef": {
-                    "name": "manifests",
-                    "path": "prometheus/operator"
-                  }
-                },
-                "name": "prometheus-operator"
-              },
-              {
-                "kustomizeConfig": {
-                  "repoRef": {
-                    "name": "manifests",
-                    "path": "notebook-images"
-                  }
-                },
-                "name": "notebook-images"
+                "name": "data-science-pipelines"
               }
             ],
             "repos": [
               {
                 "name": "manifests",
-                "uri": "https://github.com/opendatahub-io/odh-manifests/tarball/v1.4"
+                "uri": "https://github.com/opendatahub-io/odh-manifests/tarball/v1.4.1"
               }
             ]
           }
@@ -181,16 +178,10 @@ spec:
     * Jupyter Notebooks - JupyterLab notebook that provide Python support for GPU workloads
     * Data Science Pipelines - Pipeline solution for end to end MLOps workflows that support the Kubeflow Pipelines SDK and Tekton
     * Model Mesh - ModelMesh Serving is the Controller for managing ModelMesh, a general-purpose model serving management/routing layer.
-    * Prometheus - Monitoring and alerting tool
-    * Grafana - Data visualization and monitoring
 
     To install one or multiple of these components use the default KfDef provided with the operator.
 
     NOTE: As of ODH 1.4, ODH has replaced JupyterHub multi-user server with ODH Notebook Controller for lifecycle management of Jupyter Notebook servers.  JupyterHub is still available for deployment but there will be no further updates and it will be officially deprecated with the release of ODH 1.5
-
-
-    ### Kubeflow Components
-    ODH 1.4 supports Kubeflow v1.6.0 and some components such as KF Serving and KFP on Tekton from master branch. Please visit [opendatahub-io/manifests](https://github.com/opendatahub-io/manifests/tree/v1.6-branch-openshift/openshift) for installation instructions on deploying Kubeflow v1.6.0 on OpenShift.
 
     ### Available Channels
 

--- a/deploy/olm-catalog/opendatahub/1.4.1/metadata/annotations.yaml
+++ b/deploy/olm-catalog/opendatahub/1.4.1/metadata/annotations.yaml
@@ -5,3 +5,4 @@ annotations:
   operators.operatorframework.io.bundle.package.v1: "opendatahub-operator"
   operators.operatorframework.io.bundle.channels.v1: "stable,rolling"
   operators.operatorframework.io.bundle.channel.default.v1: "stable"
+  com.redhat.openshift.versions: "v4.9"


### PR DESCRIPTION
## Description
Update the example kfdef in the v1.4.1 CSV to use the new `notebook-images` manifest

Signed-off-by: Landon LaSmith <LLaSmith@redhat.com>

## How Has This Been Tested?
Deployed using the new operator and the example kfdef in v1.4.1

## Merge criteria:
New operator bundle deploys the CRDs and deploys as expected.
