### PR TITLE
Fix 1.4.1 CSV CRD displayname

### DIFF
--- a/deploy/olm-catalog/opendatahub/1.4.1/manifests/odhdashboardconfigs.opendatahub.io.crd.yaml
+++ b/deploy/olm-catalog/opendatahub/1.4.1/manifests/odhdashboardconfigs.opendatahub.io.crd.yaml
@@ -41,6 +41,10 @@ spec:
                       type: boolean
                     disableUserManagement:
                       type: boolean
+                    disableProjects:
+                      type: boolean
+                    disableModelServing:
+                      type: boolean
                 groupsConfig:
                   type: object
                   required:
@@ -78,6 +82,33 @@ spec:
                                 type: string
                               memory:
                                 type: string
+                modelServerSizes:
+                  type: array
+                  items:
+                    type: object
+                    required:
+                      - name
+                      - resources
+                    properties:
+                      name:
+                        type: string
+                      resources:
+                        type: object
+                        properties:
+                          requests:
+                            type: object
+                            properties:
+                              cpu:
+                                type: string
+                              memory:
+                                type: string
+                          limits:
+                            type: object
+                            properties:
+                              cpu:
+                                type: string
+                              memory:
+                                type: string
                 notebookController:
                   type: object
                   required:
@@ -88,6 +119,9 @@ spec:
                     notebookNamespace:
                       type: string
                     pvcSize:
+                      type: string
+                    gpuSetting:
+                      description: Configure how the GPU field works on the Jupyter tile. One of 'autodetect' (default, fetches for information), 'hidden' (remove the field) or a number-string (eg '5') to specify a hardcoded 0 to that number options
                       type: string
                     notebookTolerationSettings:
                       type: object

--- a/deploy/olm-catalog/opendatahub/1.4.1/manifests/opendatahub-operator.v1.4.1.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/opendatahub/1.4.1/manifests/opendatahub-operator.v1.4.1.clusterserviceversion.yaml
@@ -158,13 +158,13 @@ spec:
         kind: OdhDocument
         name: odhdocuments.dashboard.opendatahub.io
         version: v1
-        displayName: Open Data Hub Dashboard Configuration
+        displayName: Open Data Hub Dashboard Documentation
         group: dashboard.opendatahub.io
       - description: Extension for guiding user through various workflows in the Open Data Hub dashboard.
         kind: OdhQuickStart
         name: odhquickstarts.console.openshift.io
         version: v1
-        displayName: OdhQuickStart
+        displayName: Open Data Hub Dashboard QuickStart
         group: console.openshift.io
   description: |
     The Open Data Hub is a machine-learning-as-a-service platform built on Red Hat's Kubernetes-based OpenShift® Container Platform. Open Data Hub integrates multiple AI/ML open source components into one operator that can easily be downloaded and installed by OpenShift users.


### PR DESCRIPTION
Fixes a typo in the `displayName` for the `ODHDocument` CRD in the v1.4.1 CSV

Signed-off-by: Landon LaSmith <LLaSmith@redhat.com>
