### PR TITLE
Add local bundle for odh manifests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,5 @@ scripts/gke/build/**
 
 # test data
 tests/data/test-data.tar.gz
+# Ignore downloaded odh manifests
+odh-manifests.tar.gz

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 # Build the manager binary
 ARG GOLANG_VERSION=1.18.4
+ARG LOCAL_BUNDLE=odh-manifests.tar.gz
 FROM registry.access.redhat.com/ubi8/go-toolset:$GOLANG_VERSION as builder
 ARG LOCAL_BUNDLE=odh-manifests.tar.gz
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,7 @@ FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 WORKDIR /
 COPY --from=builder /workspace/manager .
 COPY tests/data/test-data.tar.gz /opt/test-data/
-USER 65532:65532
+COPY odh-manifests.tar.gz /opt/manifests/
+USER 65532:65532  
 
 ENTRYPOINT ["/manager"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,11 +18,11 @@ COPY controllers/ controllers/
 COPY pkg/ pkg/
 
 # Build
-ARG LOCAL_BUNDLE=odh-manifests.tar.gz
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager main.go
 
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+ARG LOCAL_BUNDLE=odh-manifests.tar.gz
 WORKDIR /
 COPY --from=builder /workspace/manager .
 COPY tests/data/test-data.tar.gz /opt/test-data/

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 ARG GOLANG_VERSION=1.18.4
 ARG LOCAL_BUNDLE=odh-manifests.tar.gz
 FROM registry.access.redhat.com/ubi8/go-toolset:$GOLANG_VERSION as builder
-ARG LOCAL_BUNDLE=odh-manifests.tar.gz
+ARG LOCAL_BUNDLE
 
 WORKDIR /workspace
 USER root

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ COPY controllers/ controllers/
 COPY pkg/ pkg/
 
 # Build
+ARG LOCAL_BUNDLE=odh-manifests.tar.gz
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager main.go
 
 
@@ -25,7 +26,7 @@ FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 WORKDIR /
 COPY --from=builder /workspace/manager .
 COPY tests/data/test-data.tar.gz /opt/test-data/
-COPY odh-manifests.tar.gz /opt/manifests/
+COPY $LOCAL_BUNDLE /opt/manifests/
 USER 65532:65532  
 
 ENTRYPOINT ["/manager"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,7 @@ COPY pkg/ pkg/
 
 # Add the local bundle
 ADD https://github.com/opendatahub-io/odh-manifests/tarball/master $LOCAL_BUNDLE
+RUN chmod g+r $LOCAL_BUNDLE
 # Build
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager main.go
 

--- a/Makefile
+++ b/Makefile
@@ -123,7 +123,7 @@ run: manifests generate fmt vet ## Run a controller from your host.
 	go run ./main.go
 
 .PHONY: docker-build
-docker-build: manifests generate fmt vet get-tar update-test-data ## Build docker image with the manager.
+docker-build: manifests generate fmt vet update-test-data ## Build docker image with the manager.
 	${IMAGE_BUILDER} build -t ${IMG} .
 
 .PHONY: docker-push
@@ -256,8 +256,3 @@ e2e-test: ## Run e2e tests for the controller
 update-test-data:
 	tar -czvf ./tests/data/test-data.tar.gz ./tests/data/manifests
 	
-MANIFESTS_TARBALL_URL=https://github.com/opendatahub-io/odh-manifests/tarball/master
-
-.PHONY: get-tar
-get-tar: ## Get latest odh-manifests tarball
-	wget $(MANIFESTS_TARBALL_URL) -O odh-manifests.tar.gz

--- a/Makefile
+++ b/Makefile
@@ -123,7 +123,7 @@ run: manifests generate fmt vet ## Run a controller from your host.
 	go run ./main.go
 
 .PHONY: docker-build
-docker-build: manifests generate fmt vet update-test-data ## Build docker image with the manager.
+docker-build: manifests generate fmt vet get-tar update-test-data ## Build docker image with the manager.
 	${IMAGE_BUILDER} build -t ${IMG} .
 
 .PHONY: docker-push
@@ -255,3 +255,9 @@ e2e-test: ## Run e2e tests for the controller
 .PHONY: update-test-data ## Any update to manifests should be reflected in the tar.gz file
 update-test-data:
 	tar -czvf ./tests/data/test-data.tar.gz ./tests/data/manifests
+	
+MANIFESTS_TARBALL_URL=https://github.com/opendatahub-io/odh-manifests/tarball/master
+
+.PHONY: get-tar
+get-tar: ## Get latest odh-manifests tarball
+	wget $(MANIFESTS_TARBALL_URL) -O odh-manifests.tar.gz

--- a/bundle/manifests/opendatahub-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/opendatahub-operator.clusterserviceversion.yaml
@@ -140,7 +140,7 @@ metadata:
             "repos": [
               {
                 "name": "manifests",
-                "uri": "https://github.com/opendatahub-io/odh-manifests/tarball/v1.6"
+                "uri": "file:///opt/manifests/odh-manifests.tar.gz"
               }
             ]
           }

--- a/config/manifests/bases/opendatahub-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/opendatahub-operator.clusterserviceversion.yaml
@@ -140,7 +140,7 @@ metadata:
             "repos": [
               {
                 "name": "manifests",
-                "uri": "https://github.com/opendatahub-io/odh-manifests/tarball/v1.6"
+                "uri": "file:///opt/manifests/odh-manifests.tar.gz"
               }
             ]
           }

--- a/tests/e2e/helper.go
+++ b/tests/e2e/helper.go
@@ -2,9 +2,8 @@ package e2e
 
 import (
 	"context"
-	"log"
-
 	corev1 "k8s.io/api/core/v1"
+	"log"
 
 	kfdefappskubefloworgv1 "github.com/opendatahub-io/opendatahub-operator/apis/kfdef.apps.kubeflow.org/v1"
 	appsv1 "k8s.io/api/apps/v1"

--- a/tests/e2e/helper.go
+++ b/tests/e2e/helper.go
@@ -2,8 +2,9 @@ package e2e
 
 import (
 	"context"
-	corev1 "k8s.io/api/core/v1"
 	"log"
+
+	corev1 "k8s.io/api/core/v1"
 
 	kfdefappskubefloworgv1 "github.com/opendatahub-io/opendatahub-operator/apis/kfdef.apps.kubeflow.org/v1"
 	appsv1 "k8s.io/api/apps/v1"
@@ -72,7 +73,7 @@ func setupCoreKfdef() kfDefContext {
 			Repos: []kfdefappskubefloworgv1.Repo{
 				{
 					Name: "manifests",
-					URI:  "https://github.com/opendatahub-io/odh-manifests/tarball/master",
+					URI:  "file:///opt/manifests/odh-manifests.tar.gz",
 				}, {
 					//Any update to manifests should be reflected in the tar.gz file by doing
 					//`make update-test-data`


### PR DESCRIPTION
Resolves: #196 

## Description
This PR adds a function that adds a check whenever KFApply is called to check if there are any Repos specified, if not, it takes local manifests that are downloaded at build time.

## How Has This Been Tested?
1. Deployed operator specified in the PR on a cluster
2. Added the following KFDef:

    
      ```
      apiVersion: kfdef.apps.kubeflow.org/v1
            kind: KfDef
            metadata:
              name: odh-core-testing
            spec:
              applications:
              - kustomizeConfig:
                  repoRef:
                    name: manifests
                    path: odh-common
                name: odh-common
              - kustomizeConfig:
                  repoRef:
                    name: manifests
                    path: odh-dashboard
                name: odh-dashboard

3. Verified that the operator took its local file and deployed the resources despite not having a repo specified.
4. Verify that if the Repos section *is* specified, no functionality is broken.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
