### PR TITLE
Add fixes for operator and odh-manifests e2e tests 

### DIFF
--- a/controllers/kfdef.apps.kubeflow.org/kfdef_controller.go
+++ b/controllers/kfdef.apps.kubeflow.org/kfdef_controller.go
@@ -273,6 +273,7 @@ func (r *KfDefReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Watches(&source.Kind{Type: &rbacv1.RoleBinding{}}, watchedHandler, builder.WithPredicates(ownedResourcePredicates)).
 		Watches(&source.Kind{Type: &rbacv1.ClusterRole{}}, watchedHandler, builder.WithPredicates(ownedResourcePredicates)).
 		Watches(&source.Kind{Type: &rbacv1.ClusterRoleBinding{}}, watchedHandler, builder.WithPredicates(ownedResourcePredicates)).
+		Watches(&source.Kind{Type: &ofapi.Subscription{}}, watchedHandler, builder.WithPredicates(ownedResourcePredicates)).
 		Complete(r)
 
 	if err != nil {

--- a/pkg/kfapp/kustomize/kustomize.go
+++ b/pkg/kfapp/kustomize/kustomize.go
@@ -1559,8 +1559,11 @@ func GenerateYamlWithOwnerReference(resMap resmap.ResMap, instance *unstructured
 			},
 		}
 
-		if len(m.GetOwnerReferences()) == 0 {
+		// Do not add ownerreference to subscription, since it can be created in another namespace
+		// than the KfDef instance
+		if len(m.GetOwnerReferences()) == 0 && m.GetKind() != "Subscription" {
 			m.SetOwnerReferences(owner)
+			log.Infof("ownerReferences added for resource %v.%v", m.GetName(), m.GetNamespace())
 		}
 
 		out, err := yaml.Marshal(m)
@@ -1568,7 +1571,6 @@ func GenerateYamlWithOwnerReference(resMap resmap.ResMap, instance *unstructured
 			return nil, err
 		}
 
-		log.Infof("ownerReferences added for resource %v.%v", m.GetName(), m.GetNamespace())
 		if firstObj {
 			firstObj = false
 		} else {

--- a/tests/e2e/odh_controller_setup_test.go
+++ b/tests/e2e/odh_controller_setup_test.go
@@ -84,11 +84,12 @@ func NewTestContext() (*testContext, error) {
 	testKfDefContextList := []kfDefContext{setupCoreKfdef()}
 
 	return &testContext{
-		cfg:                     config,
-		kubeClient:              kc,
-		customClient:            custClient,
-		testNamespace:           kfdefTestNamespace,
-		resourceCreationTimeout: time.Minute * 2,
+		cfg:           config,
+		kubeClient:    kc,
+		customClient:  custClient,
+		testNamespace: kfdefTestNamespace,
+		// Set high timeout for CI environment
+		resourceCreationTimeout: time.Minute * 3,
 		resourceRetryInterval:   time.Second * 10,
 		ctx:                     context.TODO(),
 		testKfDefs:              testKfDefContextList,


### PR DESCRIPTION
This PR includes changes specific to e2e tests:
- Update resource creation timeout for CI environment
- Remove Kfdef Annotation tests as we moved to Ownerreferences
- Remove ownerreferences from Subscription resource (This is required for allowing operator installs for DSP tests)

Resolves:
- Test failures in openshift-ci

