### PR TITLE
Use {IMAGE_BUILDER} in Makefile for opm index cmd

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -240,7 +240,7 @@ endif
 # https://github.com/operator-framework/community-operators/blob/7f1438c/docs/packaging-operator.md#updating-your-existing-operator
 .PHONY: catalog-build
 catalog-build: opm ## Build a catalog image.
-	$(OPM) index add --container-tool docker --mode semver --tag $(CATALOG_IMG) --bundles $(BUNDLE_IMGS) $(FROM_INDEX_OPT)
+	$(OPM) index add --container-tool $(IMAGE_BUILDER) --mode semver --tag $(CATALOG_IMG) --bundles $(BUNDLE_IMGS) $(FROM_INDEX_OPT)
 
 # Push the catalog image.
 .PHONY: catalog-push


### PR DESCRIPTION
## Description
Add the `${IMAGE_BUILDER}` variable to the `make catalog-build` target to resolve errors when `docker` is not installed on the system

## How Has This Been Tested?
run `make catalog-build` to generate a catalog image successfully

## Merge criteria:
You can successfully run `make catalog-build` when only `podman` is installed

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
