### PR TITLE
Update: GitHub Action for sync CRD from odh-dashboard

### DIFF
--- a/.github/workflows/sync_dashboard_crds.yaml
+++ b/.github/workflows/sync_dashboard_crds.yaml
@@ -3,27 +3,35 @@ name: Sync Dashboard CRDs
 
 # Await dispatch from dashboard repo that crds have been modified
 on:
-  workflow_dispatch
+  workflow_dispatch:
+    inputs:
+      dashboard_label:
+        description: "Label from odh-dashboard to sync CRD from"
+      source_branch:
+        default: "master"
+        description: "branch of opendatahub-operator to checkout from"
 
 jobs:
   dashboard-sync:
     runs-on: ubuntu-latest
     steps:
-      - name: Git checkout
+      - name: Checkout operator source code on master branch
         uses: actions/checkout@v3
         with:
-          fetch-depth: '0'
+          fetch-depth: '1'
+          ref: ${{ github.event.inputs.source_branch }}
       - name: Gather files
         shell: bash
         run: |
           cd ${{ github.workspace }}/config/crd/dashboard-crds
-          svn export --force https://github.com/opendatahub-io/odh-dashboard/branches/main/manifests/crd .
+          svn export --force "https://github.com/opendatahub-io/odh-dashboard/tags/${{ github.event.inputs.dashboard_label }}/manifests/crd" .
           rm kustomization.yaml
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v4.2.3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          branch: dashboard-sync
-          commit-message: Automated Change
-          title: Sync operator crds with dashboard crds
+          commit-message: Automated Change by GitHub Action
+          delete-branch: true
+          title: Sync operator CRDs from odh-dashboard manifests CRDs
           body: This is an automated pull request to sync the operator crds with dashboard crds.
+          signoff: true


### PR DESCRIPTION
Update: GitHub Action for sync CRD from odh-dashboard

## Description
            - only check out source code branch not all ref object
            - make dashboard only export by label not "master" branch
            - delete branch after PR is merged, so next run wont be problem
            - update wording
            - add signoff

## How Has This Been Tested?
Tested from my forked repo, 
set source repo to "zdtsw/github_1" (since my master is downstream from rhods repo) 
set label of dashboard to v2.11.0
![Screenshot from 2023-06-11 17-48-53](https://github.com/opendatahub-io/opendatahub-operator/assets/915053/5dedb9fb-1194-4f0e-be40-fe6deeeb2caf)
Action run https://github.com/zdtsw/opendatahub-operator/actions/runs/5236279870
Created PR https://github.com/zdtsw/opendatahub-operator/pull/2


## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
