### PR TITLE
Update README for deprecation of kfctl

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 ## Introduction
 
-Open Data Hub operator is a downstream project of [kfctl](https://github.com/kubeflow/kfctl) operator that manages the 
-[KfDef](config/crd/bases/kfdef.apps.kubeflow.org_kfdefs.yaml) Custom Resource . This CR is used to deploy [Open Data Hub components](https://github.com/opendatahub-io/odh-manifests/blob/master/kfdef/odh-core.yaml) in the
-OpenShift cluster. 
+The Open Data Hub operator is responsible for managing the deployment and lifecycle of ODH Component manifests in [odh-manifests](https://github.com/opendatahub-io/odh-manifests) using the [KfDef](config/crd/bases/kfdef.apps.kubeflow.org_kfdefs.yaml) Custom Resource.  The focus is on supporting the [ODH Core](https://github.com/opendatahub-io/odh-manifests/blob/master/kfdef/odh-core.yaml) stack in the OpenShift clusters. 
 
-## Usage
+NOTE: The Open Data Hub operator was originally a downstream project of the [kfctl](https://github.com/kubeflow/kfctl) operator but has diverged from the original functionality after the Kubeflow community deprecated the use of `kfctl` for deployment in favor of [kustomize](https://kustomize.io/).  `kfctl` cli is no longer a maintained or supported tool for parsing or processing the `kfdef` custom resource.
+
+##Usage
 
 ### Installation
 


### PR DESCRIPTION
## Description
Update README to reflect that `kfctl` is no longer supported and the odh-operator is no longer a downstream project of `kubeflow-operator`

## How Has This Been Tested?
N/A

## Merge criteria:
CI Passes successfully 

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
