### PR TITLE
Update: Dockerfile and Makefile

### DIFF
--- a/bundle/manifests/opendatahub-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/opendatahub-operator.clusterserviceversion.yaml
@@ -161,7 +161,7 @@ spec:
                 - --leader-elect
                 command:
                 - /manager
-                image: quay.io/vhire/opendatahub-operator:dev-0.0.1
+                image: quay.io/opendatahub/opendatahub-operator:dev-0.0.1
                 imagePullPolicy: Always
                 livenessProbe:
                   httpGet:

--- a/controllers/dscinitialization/dscinitialization_controller.go
+++ b/controllers/dscinitialization/dscinitialization_controller.go
@@ -51,13 +51,13 @@ type DSCInitializationReconciler struct {
 }
 
 // Reconcile +kubebuilder:rbac:groups=*,resources=*,verbs=*
-//+kubebuilder:rbac:groups=dscinitialization.opendatahub.io,resources=dscinitializations,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=dscinitialization.opendatahub.io,resources=dscinitializations/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups=dscinitialization.opendatahub.io,resources=dscinitializations/finalizers,verbs=update
-//+kubebuilder:rbac:groups=networking.k8s.io,resources=networkpolicies,verbs=get;list;watch;create;update;patch
-//+kubebuilder:rbac:groups="",resources=services;namespaces;serviceaccounts;secrets;configmaps,verbs=get;list;watch;create;update;patch
-//+kubebuilder:rbac:groups=addons.managed.openshift.io,resources=addons,verbs=get;list
-//+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=rolebindings;roles;clusterrolebindings;clusterroles,verbs=get;list;watch;create;update;patch
+// +kubebuilder:rbac:groups=dscinitialization.opendatahub.io,resources=dscinitializations,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=dscinitialization.opendatahub.io,resources=dscinitializations/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=dscinitialization.opendatahub.io,resources=dscinitializations/finalizers,verbs=update
+// +kubebuilder:rbac:groups=networking.k8s.io,resources=networkpolicies,verbs=get;list;watch;create;update;patch
+// +kubebuilder:rbac:groups="",resources=services;namespaces;serviceaccounts;secrets;configmaps,verbs=get;list;watch;create;update;patch
+// +kubebuilder:rbac:groups=addons.managed.openshift.io,resources=addons,verbs=get;list
+// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=rolebindings;roles;clusterrolebindings;clusterroles,verbs=get;list;watch;create;update;patch
 func (r *DSCInitializationReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	r.Log.Info("Reconciling DSCInitialization.", "DSCInitialization", req.Namespace, "Request.Name", req.Name)
 


### PR DESCRIPTION
## Description
- Dockerfile add support to download odh-manifests tarball during build
- Makefile add target to download operator-sdk if not have it already
- rename target `docker-*` to `image-*` since default using `podman`
- go fmt for format
- update default image pullspec in CSV

## How Has This Been Tested?
build image locally
```
>docker run eceaa0bb36b94af36146c83513a4922309635b9f8b7e12abb41286aea82067a1 -- ls /opt/odh-manifests
LICENSE
Makefile
OWNERS
README.md
RELEASE.md
ceph
codeflare-stack
data-science-pipelines-operator
docs
grafana
....
```

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
