### PR TITLE
Updates for the ODH v1.7 release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,9 +22,9 @@ COPY apis/ apis/
 COPY controllers/ controllers/
 COPY pkg/ pkg/
 
-# Add the local bundle
+# Add the local bundle and add a marker file so we know the ref this image was built from
 ADD $ODH_MANIFESTS_URL $LOCAL_BUNDLE
-RUN chmod g+r $LOCAL_BUNDLE
+RUN echo "$ODH_MANIFESTS_REF" > MANIFEST_VERSION && chmod g+r $LOCAL_BUNDLE
 # Build
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager main.go
 
@@ -34,7 +34,7 @@ ARG LOCAL_BUNDLE
 WORKDIR /
 COPY --from=builder /workspace/manager .
 COPY tests/data/test-data.tar.gz /opt/test-data/
-COPY --from=builder /workspace/$LOCAL_BUNDLE /opt/manifests/
+COPY --from=builder /workspace/MANIFEST_VERSION /workspace/$LOCAL_BUNDLE /opt/manifests/
 USER 65532:65532  
 
 ENTRYPOINT ["/manager"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,10 @@
 # Build the manager binary
 ARG GOLANG_VERSION=1.18.4
 ARG LOCAL_BUNDLE=odh-manifests.tar.gz
+
 FROM registry.access.redhat.com/ubi8/go-toolset:$GOLANG_VERSION as builder
+ARG ODH_MANIFESTS_REF=master
+ARG ODH_MANIFESTS_URL=https://github.com/opendatahub-io/odh-manifests/tarball/$ODH_MANIFESTS_REF
 ARG LOCAL_BUNDLE
 
 WORKDIR /workspace
@@ -20,7 +23,7 @@ COPY controllers/ controllers/
 COPY pkg/ pkg/
 
 # Add the local bundle
-ADD https://github.com/opendatahub-io/odh-manifests/tarball/master $LOCAL_BUNDLE
+ADD $ODH_MANIFESTS_URL $LOCAL_BUNDLE
 RUN chmod g+r $LOCAL_BUNDLE
 # Build
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager main.go

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ VERSION ?= 0.0.1
 IMG ?= quay.io/opendatahub/opendatahub-operator:dev-$(VERSION)
 IMAGE_BUILDER ?= podman
 OPERATOR_NAMESPACE ?= opendatahub-operator-system
-CHANNELS="stable,rolling"
+CHANNELS="rolling"
 DEFAULT_CHANNEL="rolling"
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,9 @@
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
 VERSION ?= 0.0.1
 IMG ?= quay.io/opendatahub/opendatahub-operator:dev-$(VERSION)
+# Specify the url to download the tarball to use for the local repo manifest
+ODH_MANIFESTS_REF=master
+ODH_MANIFESTS_URL=https://github.com/opendatahub-io/odh-manifests/tarball/$(ODH_MANIFESTS_REF)
 IMAGE_BUILDER ?= podman
 OPERATOR_NAMESPACE ?= opendatahub-operator-system
 CHANNELS="rolling"
@@ -124,7 +127,7 @@ run: manifests generate fmt vet ## Run a controller from your host.
 
 .PHONY: docker-build
 docker-build: manifests generate fmt vet update-test-data ## Build docker image with the manager.
-	${IMAGE_BUILDER} build -t ${IMG} .
+	${IMAGE_BUILDER} build -t ${IMG} --build-arg ODH_MANIFESTS_REF=${ODH_MANIFESTS_REF} --build-arg ODH_MANIFESTS_URL=${ODH_MANIFESTS_URL} .
 
 .PHONY: docker-push
 docker-push: ## Push docker image with the manager.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Updates the Makefile and Dockerfile to support build time configuration of the url for the odh-manifests to download and include in the odh-operator container image

## How Has This Been Tested?
Local deployment using
```
make docker-build -e IMG=<TEST IMAGE>
make deploy
make e2e-test -e IMG=<TEST IMAGE>
```

## Merge criteria:
Operator image build successfully
odh-manifests test runs successfully. NOTE: Known issue that the pipelines test will fail due to error in ocp-pipelines operator subscription

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
