### PR TITLE
DO NOT MERGE: Build a compatible v1.7.0 operator image with the v1.7.0 odh-manifest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ ARG GOLANG_VERSION=1.18.4
 ARG LOCAL_BUNDLE=odh-manifests.tar.gz
 
 FROM registry.access.redhat.com/ubi8/go-toolset:$GOLANG_VERSION as builder
-ARG ODH_MANIFESTS_REF=master
+ARG ODH_MANIFESTS_REF=v1.7.0
 ARG ODH_MANIFESTS_URL=https://github.com/opendatahub-io/odh-manifests/tarball/$ODH_MANIFESTS_REF
 ARG LOCAL_BUNDLE
 


### PR DESCRIPTION
# DO NOT MERGE: Hack to generate release image for v1.7.0 with odh-manifests v1.7.0
