### PR TITLE
Update dscinitiazation spec for monitoring

### DIFF
--- a/apis/dscinitialization/v1alpha1/dscinitialization_types.go
+++ b/apis/dscinitialization/v1alpha1/dscinitialization_types.go
@@ -40,8 +40,10 @@ type DSCInitializationSpec struct {
 }
 
 type Monitoring struct {
+	// +kubebuilder:default=false
 	Enabled   bool   `json:"enabled,omitempty"`
-	Namespace string `json:"namespace"`
+	// +kubebuilder:default=opendatahub
+	Namespace string `json:"namespace,omitempty"`
 }
 
 // DSCInitializationStatus defines the observed state of DSCInitialization

--- a/bundle/manifests/dscinitialization.opendatahub.io_dscinitializations.yaml
+++ b/bundle/manifests/dscinitialization.opendatahub.io_dscinitializations.yaml
@@ -54,11 +54,11 @@ spec:
               monitoring:
                 properties:
                   enabled:
+                    default: false
                     type: boolean
                   namespace:
+                    default: opendatahub
                     type: string
-                required:
-                - namespace
                 type: object
             required:
             - applicationsNamespace

--- a/bundle/manifests/opendatahub-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/opendatahub-operator.clusterserviceversion.yaml
@@ -5,6 +5,81 @@ metadata:
     alm-examples: |-
       [
         {
+          "apiVersion": "console.openshift.io/v1",
+          "kind": "OdhQuickStart",
+          "metadata": {
+            "annotations": {
+              "internal.config.kubernetes.io/previousKinds": "OdhQuickStart",
+              "internal.config.kubernetes.io/previousNames": "create-jupyter-notebook",
+              "internal.config.kubernetes.io/previousNamespaces": "default",
+              "opendatahub.io/categories": "Getting started,Notebook environments"
+            },
+            "labels": {
+              "app.kubernetes.io/created-by": "odh-dashboard",
+              "app.kubernetes.io/instance": "odh-dashboard-sample",
+              "app.kubernetes.io/managed-by": "kustomize",
+              "app.kubernetes.io/name": "odh-dashboard",
+              "app.kubernetes.io/part-of": "odh-dashboard"
+            },
+            "name": "create-jupyter-notebook-sample",
+            "namespace": "opendatahub"
+          },
+          "spec": {
+            "appName": "jupyterhub",
+            "displayName": "Creating a Jupyter notebook",
+            "durationMinutes": 5
+          }
+        },
+        {
+          "apiVersion": "dashboard.opendatahub.io/v1",
+          "kind": "OdhApplication",
+          "metadata": {
+            "labels": {
+              "app.kubernetes.io/created-by": "odh-dashboard",
+              "app.kubernetes.io/instance": "odh-dashboard-sample",
+              "app.kubernetes.io/managed-by": "kustomize",
+              "app.kubernetes.io/name": "odh-dashboard",
+              "app.kubernetes.io/part-of": "odh-dashboard"
+            },
+            "name": "jupyterhub-sample",
+            "namespace": "opendatahub"
+          },
+          "spec": {
+            "displayName": "JupyterHub",
+            "docsLink": "https://jupyter.org/hub",
+            "getStartedLink": "https://jupyterhub.readthedocs.io/en/stable/getting-started/index.html",
+            "getStartedMarkDown": "# MarkDown Description",
+            "kfdefApplications": [
+              "jupyterhub",
+              "notebook-images"
+            ],
+            "provider": "Jupyter",
+            "quickStart": "create-jupyter-notebook",
+            "route": "jupyterhub"
+          }
+        },
+        {
+          "apiVersion": "dashboard.opendatahub.io/v1",
+          "kind": "OdhDocument",
+          "metadata": {
+            "labels": {
+              "app.kubernetes.io/created-by": "odh-dashboard",
+              "app.kubernetes.io/instance": "odh-dashboard-sample",
+              "app.kubernetes.io/managed-by": "kustomize",
+              "app.kubernetes.io/name": "odh-dashboard",
+              "app.kubernetes.io/part-of": "odh-dashboard"
+            },
+            "name": "jupyterhub-view-installed-packages-sample",
+            "namespace": "opendatahub"
+          },
+          "spec": {
+            "appName": "jupyter",
+            "durationMinutes": 15,
+            "type": "how-to",
+            "url": "https://url.sample.com"
+          }
+        },
+        {
           "apiVersion": "datasciencecluster.opendatahub.io/v1alpha1",
           "kind": "DataScienceCluster",
           "metadata": {
@@ -17,7 +92,21 @@ metadata:
             },
             "name": "datasciencecluster-sample"
           },
-          "spec": null
+          "spec": {
+            "components": {
+              "dashboard": {},
+              "datasciencepipelines": {
+                "enabled": true
+              },
+              "modelmeshserving": {
+                "enabled": false
+              },
+              "workbenches": {
+                "enabled": true
+              }
+            },
+            "profile": "none"
+          }
         },
         {
           "apiVersion": "dscinitialization.opendatahub.io/v1alpha1",
@@ -32,14 +121,48 @@ metadata:
             },
             "name": "dscinitialization-sample"
           },
-          "spec": null
+          "spec": {
+            "applicationsNamespace": [
+              "opendatahub"
+            ],
+            "monitoring": {
+              "enabled": false,
+              "namespace": "opendatahub"
+            }
+          }
+        },
+        {
+          "apiVersion": "opendatahub.io/v1alpha",
+          "kind": "OdhDashboardConfig",
+          "metadata": {
+            "labels": {
+              "app.kubernetes.io/created-by": "odh-dashboard",
+              "app.kubernetes.io/instance": "odh-dashboard-sample",
+              "app.kubernetes.io/managed-by": "kustomize",
+              "app.kubernetes.io/name": "odh-dashboard",
+              "app.kubernetes.io/part-of": "odh-dashboard",
+              "opendatahub.io/dashboard": "true"
+            },
+            "name": "odh-dashboard-config-sample",
+            "namespace": "opendatahub"
+          },
+          "spec": {
+            "dashboardConfig": null,
+            "groupsConfig": {
+              "adminGroups": "odh-admins",
+              "allowedGroups": "system:authenticated"
+            },
+            "notebookController": {
+              "enabled": true
+            },
+            "templateOrder": []
+          }
         }
       ]
     capabilities: Basic Install
-    operatorframework.io/initialization-resource: |-
-      { "apiVersion": "datasciencecluster.opendatahub.io/v1alpha1",
-      "kind": "DataScienceCluster", "metadata":{ "name": "default" }, "spec" : {}
-      }
+    operatorframework.io/initialization-resource: "{ \n  \"apiVersion\": \"datasciencecluster.opendatahub.io/v1alpha1\",\n
+      \ \"kind\": \"DataScienceCluster\", \n  \"metadata\":{ \n    \"name\": \"default\"\n
+      \ },\n  \"spec\": {}\n}"
     operators.operatorframework.io/builder: operator-sdk-v1.24.1
     operators.operatorframework.io/internal-objects: '[dscinitialization.opendatahub.io]'
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3

--- a/config/crd/bases/dscinitialization.opendatahub.io_dscinitializations.yaml
+++ b/config/crd/bases/dscinitialization.opendatahub.io_dscinitializations.yaml
@@ -54,11 +54,11 @@ spec:
               monitoring:
                 properties:
                   enabled:
+                    default: false
                     type: boolean
                   namespace:
+                    default: opendatahub
                     type: string
-                required:
-                - namespace
                 type: object
             required:
             - applicationsNamespace

--- a/config/manifests/bases/opendatahub-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/opendatahub-operator.clusterserviceversion.yaml
@@ -4,10 +4,9 @@ metadata:
   annotations:
     alm-examples: '[]'
     capabilities: Basic Install
-    operatorframework.io/initialization-resource: |-
-      { "apiVersion": "datasciencecluster.opendatahub.io/v1alpha1",
-      "kind": "DataScienceCluster", "metadata":{ "name": "default" }, "spec" : {}
-      }
+    operatorframework.io/initialization-resource: "{ \n  \"apiVersion\": \"datasciencecluster.opendatahub.io/v1alpha1\",\n
+      \ \"kind\": \"DataScienceCluster\", \n  \"metadata\":{ \n    \"name\": \"default\"\n
+      \ },\n  \"spec\": {}\n}"
     operators.operatorframework.io/internal-objects: '[dscinitialization.opendatahub.io]'
     repository: https://github.com/opendatahub-io/opendatahub-operator
   name: opendatahub-operator.v0.0.0

--- a/config/samples/console_v1_odhquickstarts.yaml
+++ b/config/samples/console_v1_odhquickstarts.yaml
@@ -1,0 +1,20 @@
+apiVersion: console.openshift.io/v1
+kind: OdhQuickStart
+metadata:
+  annotations:
+    internal.config.kubernetes.io/previousKinds: OdhQuickStart
+    internal.config.kubernetes.io/previousNames: create-jupyter-notebook
+    internal.config.kubernetes.io/previousNamespaces: default
+    opendatahub.io/categories: 'Getting started,Notebook environments'
+  name: create-jupyter-notebook-sample
+  namespace: opendatahub
+  labels:
+    app.kubernetes.io/part-of: odh-dashboard
+    app.kubernetes.io/name: odh-dashboard
+    app.kubernetes.io/instance: odh-dashboard-sample
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/created-by: odh-dashboard
+spec:
+  durationMinutes: 5
+  appName: jupyterhub
+  displayName: Creating a Jupyter notebook

--- a/config/samples/dashboard_v1_odhapplications.yaml
+++ b/config/samples/dashboard_v1_odhapplications.yaml
@@ -1,0 +1,23 @@
+apiVersion: dashboard.opendatahub.io/v1
+kind: OdhApplication
+metadata:
+  name: jupyterhub-sample
+  namespace: opendatahub
+  labels:
+    app.kubernetes.io/part-of: odh-dashboard
+    app.kubernetes.io/name: odh-dashboard
+    app.kubernetes.io/instance: odh-dashboard-sample
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/created-by: odh-dashboard
+spec:
+  getStartedLink: 'https://jupyterhub.readthedocs.io/en/stable/getting-started/index.html'
+  route: jupyterhub
+  displayName: JupyterHub
+  kfdefApplications:
+    - jupyterhub
+    - notebook-images
+  provider: Jupyter
+  docsLink: 'https://jupyter.org/hub'
+  quickStart: create-jupyter-notebook
+  getStartedMarkDown: >-
+    # MarkDown Description

--- a/config/samples/dashboard_v1_odhdocuments.yaml
+++ b/config/samples/dashboard_v1_odhdocuments.yaml
@@ -1,0 +1,16 @@
+apiVersion: dashboard.opendatahub.io/v1
+kind: OdhDocument
+metadata:
+  name: jupyterhub-view-installed-packages-sample
+  namespace: opendatahub
+  labels:
+    app.kubernetes.io/part-of: odh-dashboard
+    app.kubernetes.io/name: odh-dashboard
+    app.kubernetes.io/instance: odh-dashboard-sample
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/created-by: odh-dashboard
+spec:
+  appName: jupyter
+  durationMinutes: 15
+  type: how-to
+  url: "https://url.sample.com"

--- a/config/samples/datasciencecluster_v1alpha1_datasciencecluster.yaml
+++ b/config/samples/datasciencecluster_v1alpha1_datasciencecluster.yaml
@@ -9,4 +9,15 @@ metadata:
     app.kubernetes.io/created-by: opendatahub-operator
   name: datasciencecluster-sample
 spec:
-  # TODO(user): Add fields here
+  profile: "none"
+  components:
+    dashboard: {}
+    workbenches: {
+      enabled: true
+    }
+    datasciencepipelines: {
+      enabled: true
+    }
+    modelmeshserving: {
+      enabled: false
+    }

--- a/config/samples/dscinitialization_v1alpha1_dscinitialization.yaml
+++ b/config/samples/dscinitialization_v1alpha1_dscinitialization.yaml
@@ -9,4 +9,8 @@ metadata:
     app.kubernetes.io/created-by: opendatahub-operator
   name: dscinitialization-sample
 spec:
-  # TODO(user): Add fields here
+  monitoring:
+    enabled: false
+    namespace: 'opendatahub'
+  applicationsNamespace:
+    - opendatahub

--- a/config/samples/kustomization.yaml
+++ b/config/samples/kustomization.yaml
@@ -2,4 +2,8 @@
 resources:
 - dscinitialization_v1alpha1_dscinitialization.yaml
 - datasciencecluster_v1alpha1_datasciencecluster.yaml
+- opendatahub_v1alpha1_odhdashboardconfigs.yaml
+- dashboard_v1_odhdocuments.yaml
+- dashboard_v1_odhapplications.yaml
+- console_v1_odhquickstarts.yaml
 #+kubebuilder:scaffold:manifestskustomizesamples

--- a/config/samples/opendatahub_v1alpha1_odhdashboardconfigs.yaml
+++ b/config/samples/opendatahub_v1alpha1_odhdashboardconfigs.yaml
@@ -1,0 +1,20 @@
+apiVersion: opendatahub.io/v1alpha
+kind: OdhDashboardConfig
+metadata:
+  labels:
+    opendatahub.io/dashboard: 'true'
+    app.kubernetes.io/part-of: odh-dashboard
+    app.kubernetes.io/name: odh-dashboard
+    app.kubernetes.io/instance: odh-dashboard-sample
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/created-by: odh-dashboard
+  name: odh-dashboard-config-sample
+  namespace: opendatahub
+spec:
+  dashboardConfig:
+  groupsConfig:
+    adminGroups: odh-admins
+    allowedGroups: 'system:authenticated'
+  notebookController:
+    enabled: true
+  templateOrder: []


### PR DESCRIPTION
## Description
- set `.spec.monitoring.namespace` as omitempty/not required , because zero value of bool, meaning enabled by default false. unless user  update it to "true" is not needed any namespace to be monitored
- add spec for sample yamls for disabling warning when run "make bundle"
- add default value `false` for .`spec.monitoring.enabeld `
-  set .`spec.monitoring.namespace` with `opendatahub`

## How Has This Been Tested?
```
make deploy -e IMG=quay.io/wenzhou/opendatahub-operator:dev-0.0.4
make bundle-build bundle-push catalog-build catalog-push  -e BUNDLE_IMAGE=quay.io/wenzhou/opendatahub-operator:v0.0.4
operator-sdk run bundle quay.io/wenzhou/opendatahub-operator-bundle:v0.0.4
```
![Screenshot from 2023-07-04 13-10-27](https://github.com/opendatahub-io/opendatahub-operator/assets/915053/3d755824-181a-430c-aed6-3531e139b8bd)

![Screenshot from 2023-07-04 13-41-02](https://github.com/opendatahub-io/opendatahub-operator/assets/915053/d662ba4c-5a88-4cb3-a121-b0d376ad7f1d)

## Merge criteria:
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
