### PR TITLE
Add logging to show cluster type and if monitoring enabled by user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ARG GOLANG_VERSION=1.18.9
 FROM registry.access.redhat.com/ubi8/go-toolset:$GOLANG_VERSION as builder
 
 ARG MANIFEST_REPO="https://github.com/opendatahub-io/odh-manifests"
-ARG MANIFEST_RELEASE="master"
+ARG MANIFEST_RELEASE="feature-rearchitecture"
 ARG MANIFEST_TARBALL="${MANIFEST_REPO}/tarball/${MANIFEST_RELEASE}"
 
 WORKDIR /workspace
@@ -28,6 +28,7 @@ ADD $MANIFEST_TARBALL ${MANIFEST_RELEASE}.tar.gz
 RUN mkdir /opt/odh-manifests/ && \
     tar --strip-components=1 -xf ${MANIFEST_RELEASE}.tar.gz -C /opt/odh-manifests/ && \
     rm -rf ${MANIFEST_RELEASE}.tar.gz
+# COPY odh-manifests/ /opt/odh-manifests/
 
 # Build
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager main.go

--- a/controllers/dscinitialization/dscinitialization_controller.go
+++ b/controllers/dscinitialization/dscinitialization_controller.go
@@ -123,6 +123,7 @@ func (r *DSCInitializationReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	// If monitoring enabled
 	if instance.Spec.Monitoring.Enabled {
 		if platform == deploy.ManagedRhods {
+			r.Log.Info("Monitoring enabled", "cluster", "Managed Serivce Mode")
 			err := r.configureManagedMonitoring(instance)
 			if err != nil {
 				return reconcile.Result{}, err
@@ -130,6 +131,15 @@ func (r *DSCInitializationReconciler) Reconcile(ctx context.Context, req ctrl.Re
 
 		} else {
 			// TODO: ODH specific monitoring logic
+			r.Log.Info("Monitoring enabled, won't apply changes", "cluster", "Self-Managed  Mode")
+			// mocking to test
+			r.Log.Info("Monitoring enabled, apply changes for test purpose", "cluster", "Self-Managed  Mode")
+			err := r.configureManagedMonitoring(instance)
+			if err != nil {
+				return reconcile.Result{}, err
+			}
+			// mocking done
+
 		}
 	}
 

--- a/pkg/deploy/setup.go
+++ b/pkg/deploy/setup.go
@@ -50,6 +50,7 @@ func isManagedRHODS(cli client.Client) (Platform, error) {
 	err := cli.Get(context.TODO(), client.ObjectKey{Name: "addons.managed.openshift.io"}, addonCRD)
 	if err != nil {
 		if apierrs.IsNotFound(err) {
+			// self managed service
 			return "", nil
 		} else {
 			return "", err


### PR DESCRIPTION
## Description
add better logging to show cluster type and if monitoring enabled by user

related to https://github.com/opendatahub-io/opendatahub-operator/issues/252

## How Has This Been Tested?
tested on ROSA cluster 
```
2023-07-04T14:48:02Z	INFO	Starting workers	{"controller": "dscinitialization", "controllerGroup": "dscinitialization.opendatahub.io", "controllerKind": "DSCInitialization", "worker count": 1}
2023-07-04T14:48:02Z	INFO	controllers.DSCInitialization	Reconciling DSCInitialization.	{"DSCInitialization": "", "Request.Name": "default"}
2023-07-04T14:48:02Z	INFO	controllers.DSCInitialization	Monitoring enabled, won't apply changes	{"cluster": "Self-Managed  Mode"}
```

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
