### PR TITLE
Update to /opt/manifests from /opt/odh-manifests

### DIFF
--- a/Dockerfiles/Dockerfile
+++ b/Dockerfiles/Dockerfile
@@ -28,6 +28,7 @@ ADD ${MANIFEST_TARBALL} ${MANIFEST_RELEASE}.tar.gz
 RUN mkdir /opt/odh-manifests/ && \
     tar --exclude={.*,*.md,LICENSE,Makefile,Dockerfile,version.py,OWNERS,tests,ai-library} --strip-components=1 -xf ${MANIFEST_RELEASE}.tar.gz -C /opt/odh-manifests/ && \
     rm -rf ${MANIFEST_RELEASE}.tar.gz
+# uncomment to test local changes
 # COPY odh-manifests/ /opt/odh-manifests/
 
 # Build
@@ -36,10 +37,10 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager main.go
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 WORKDIR /
 COPY --from=builder /workspace/manager .
-COPY --chown=1001:0 --from=builder /opt/odh-manifests /opt/odh-manifests
+COPY --chown=1001:0 --from=builder /opt/odh-manifests /opt/manifests
 # Recursive change all files
-RUN chown -R 1001:0 /opt/odh-manifests &&\
-    chmod -R a+r /opt/odh-manifests
+RUN chown -R 1001:0 /opt/manifests &&\
+    chmod -R a+r /opt/manifests
 USER 1001
 
 ENTRYPOINT ["/manager"]

--- a/Makefile
+++ b/Makefile
@@ -134,7 +134,7 @@ run: manifests generate fmt vet ## Run a controller from your host.
 	go run ./main.go
 
 .PHONY: image-build
-image-build: test odh-manifests/version.py ## Build image with the manager.
+image-build: test ## Build image with the manager.
 	$(IMAGE_BUILDER) build -f Dockerfiles/Dockerfile -t $(IMG) .
 
 .PHONY: image-push
@@ -144,10 +144,10 @@ image-push: ## Push image with the manager.
 .PHONY: image
 image: image-build image-push ## Build and push image with the manager.
 
-MANIFESTS_TARBALL_URL="https://github.com/$(IMAGE_BUILDER)/odh-manifests/tarball/$(MANIFEST_RELEASE)"
+MANIFESTS_TARBALL_URL="https://github.com/$(MANIFEST_REPO)/odh-manifests/tarball/$(MANIFEST_RELEASE)"
 
 .PHONY: get-manifests
-get-manifests: odh-manifests/version.py ## Get latest odh-manifests tarball
+get-manifests: odh-manifests/version.py ## Get latest odh-manifests tarball from github repo
 
 odh-manifests/version.py: ## Get latest odh-manifests tarball
 	rm -fr odh-manifests && mkdir odh-manifests

--- a/components/dashboard/dashboard.go
+++ b/components/dashboard/dashboard.go
@@ -11,7 +11,7 @@ import (
 
 const (
 	ComponentName = "odh-dashboard"
-	Path          = "/opt/odh-manifests/odh-dashboard/base"
+	Path          = deploy.DefaultManifestPath + "/" + ComponentName + "/base"
 )
 
 type Dashboard struct {

--- a/components/datasciencepipelines/datasciencepipelines.go
+++ b/components/datasciencepipelines/datasciencepipelines.go
@@ -10,7 +10,7 @@ import (
 
 const (
 	ComponentName = "data-science-pipelines-operator"
-	Path          = "/opt/odh-manifests/data-science-pipelines-operator/base"
+	Path          = deploy.DefaultManifestPath + "/" + ComponentName + "/base"
 )
 
 type DataSciencePipelines struct {

--- a/components/modelmeshserving/modelmeshserving.go
+++ b/components/modelmeshserving/modelmeshserving.go
@@ -11,7 +11,7 @@ import (
 
 const (
 	ComponentName = "model-mesh"
-	Path          = "/opt/odh-manifests/model-mesh/base"
+	Path          = deploy.DefaultManifestPath + "/" + ComponentName + "/base"
 )
 
 type ModelMeshServing struct {

--- a/components/workbenches/workbenches.go
+++ b/components/workbenches/workbenches.go
@@ -10,9 +10,9 @@ import (
 )
 
 const (
-	ComponentName      = "workbenches"
-	Path               = "/opt/odh-manifests/odh-notebook-controller/base"
-	notebookImagesPath = "/opt/odh-manifests/notebook-images/overlays/additional"
+	ComponentName          = "workbenches"
+	notebookControllerPath = deploy.DefaultManifestPath + "/odh-notebook-controller/base"
+	notebookImagesPath     = deploy.DefaultManifestPath + "/notebook-images/overlays/additional"
 )
 
 type Workbenches struct {
@@ -30,7 +30,7 @@ func (m *Workbenches) ReconcileComponent(owner metav1.Object, cli client.Client,
 	}
 
 	err = deploy.DeployManifestsFromPath(owner, cli,
-		Path,
+		notebookControllerPath,
 		namespace,
 		scheme, enabled)
 	if err != nil {

--- a/config/crd/bases/datasciencecluster.opendatahub.io_datascienceclusters.yaml
+++ b/config/crd/bases/datasciencecluster.opendatahub.io_datascienceclusters.yaml
@@ -3,8 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.2
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.12.0
   name: datascienceclusters.datasciencecluster.opendatahub.io
 spec:
   group: datasciencecluster.opendatahub.io

--- a/config/crd/bases/dscinitialization.opendatahub.io_dscinitializations.yaml
+++ b/config/crd/bases/dscinitialization.opendatahub.io_dscinitializations.yaml
@@ -3,8 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.2
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.12.0
   name: dscinitializations.dscinitialization.opendatahub.io
 spec:
   group: dscinitialization.opendatahub.io

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -2,7 +2,6 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  creationTimestamp: null
   name: controller-manager-role
 rules:
 - apiGroups:

--- a/controllers/dscinitialization/monitoring.go
+++ b/controllers/dscinitialization/monitoring.go
@@ -88,7 +88,7 @@ func configurePrometheus(dsciInit *dsci.DSCInitialization, r *DSCInitializationR
 		deploy.DefaultManifestPath+"/monitoring/prometheus",
 		dsciInit.Spec.Monitoring.Namespace, r.Scheme, dsciInit.Spec.Monitoring.Enabled)
 	if err != nil {
-		r.Log.Error(err, "error to deploy manifests under /odh-manifests/monitoring/prometheus")
+		r.Log.Error(err, "error to deploy manifests under /opt/manifests/monitoring/prometheus")
 		return err
 	}
 
@@ -149,7 +149,7 @@ func configureAlertManager(dsciInit *dsci.DSCInitialization, r *DSCInitializatio
 		deploy.DefaultManifestPath+"/monitoring/alertmanager",
 		dsciInit.Spec.Monitoring.Namespace, r.Scheme, dsciInit.Spec.Monitoring.Enabled)
 	if err != nil {
-		r.Log.Error(err, "error to deploy manifests under /odh-manifests/monitoring/alertmanager")
+		r.Log.Error(err, "error to deploy manifests under /opt/manifests/monitoring/alertmanager")
 		return err
 	}
 

--- a/pkg/deploy/deploy.go
+++ b/pkg/deploy/deploy.go
@@ -28,12 +28,12 @@ import (
 )
 
 const (
-	DefaultManifestPath = "/opt/odh-manifests"
+	DefaultManifestPath = "/opt/manifests"
 )
 
 // DownloadManifests function performs following tasks:
 // 1. Given remote URI, download manifests, else extract local bundle
-// 2. It saves the manifests in the odh-manifests/component-name/ folder
+// 2. It saves the manifests in the /opt/manifests/component-name/ folder
 func DownloadManifests(uri string) error {
 	// Get the component repo from the given url
 	// e.g  https://github.com/example/tarball/master\


### PR DESCRIPTION
## Description
- reuse the same path as operator v1 set
- this will help when we build downstream RHODS to use the same image of odh-manifests
- change each component to use deploy.go `DefaultManifestPath` 

## How Has This Been Tested?
build local image
> docker run -it --entrypoint bash quay.io/wenzhou/opendatahub-operator:test-0.0.1
```
...
bash-4.4$ ls
ceph                             docs     model-mesh            notebook-images  odh-notebook-controller  ray
codeflare-stack                  grafana  modelmesh-monitoring  odh-common       openshift-pipelines      trustyai-service
data-science-pipelines-operator  kfdef    must-gather           odh-dashboard    prometheus
bash-4.4$ pwd
/opt/manifests
```

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
