### PR TITLE
Update: makefile to support local build bundle image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -252,7 +252,7 @@ endif
 
 # A comma-separated list of bundle images (e.g. make catalog-build BUNDLE_IMGS=example.com/operator-bundle:v0.1.0,example.com/operator-bundle:v0.2.0).
 # These images MUST exist in a registry and be pull-able.
-BUNDLE_IMGS=quay.io/$(IMAGE_OWNER)/opendatahub-operator-bundle:v0.0.2,quay.io/$(IMAGE_OWNER)/opendatahub-operator-bundle:v0.0.3
+BUNDLE_IMGS ?= $(IMAGE_TAG_BASE)-bundle:v0.0.2,$(IMAGE_TAG_BASE)-bundle:v0.0.3,$(BUNDLE_IMG)
 
 # The image tag given to the resulting catalog image (e.g. make catalog-build CATALOG_IMG=example.com/operator-catalog:v0.2.0).
 CATALOG_IMG ?= $(IMAGE_TAG_BASE)-catalog:v$(VERSION)


### PR DESCRIPTION
## Description
When build local image to test, it sets the v0.0.3 as operator version.
since it is hardcoded in the image-bundle
to have this change, will always append the last built image in the bundle

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
