### PR TITLE
Update default applicationNamespace from opendatahub to opendatahub-system

### DIFF
--- a/apis/dscinitialization/v1alpha1/dscinitialization_types.go
+++ b/apis/dscinitialization/v1alpha1/dscinitialization_types.go
@@ -32,7 +32,7 @@ const (
 
 // DSCInitializationSpec defines the desired state of DSCInitialization
 type DSCInitializationSpec struct {
-	// +kubebuilder:default:=opendatahub
+	// +kubebuilder:default:=opendatahub-system
 	ApplicationsNamespace string     `json:"applicationsNamespace"`
 	Monitoring            Monitoring `json:"monitoring,omitempty"`
 	// Internal development useful field
@@ -42,7 +42,7 @@ type DSCInitializationSpec struct {
 type Monitoring struct {
 	// +kubebuilder:default=false
 	Enabled bool `json:"enabled,omitempty"`
-	// +kubebuilder:default=opendatahub
+	// +kubebuilder:default=opendatahub-system
 	Namespace string `json:"namespace,omitempty"`
 }
 

--- a/bundle/manifests/dscinitialization.opendatahub.io_dscinitializations.yaml
+++ b/bundle/manifests/dscinitialization.opendatahub.io_dscinitializations.yaml
@@ -46,7 +46,7 @@ spec:
             description: DSCInitializationSpec defines the desired state of DSCInitialization
             properties:
               applicationsNamespace:
-                default: opendatahub
+                default: opendatahub-system
                 type: string
               manifestsUri:
                 description: Internal development useful field

--- a/config/crd/bases/dscinitialization.opendatahub.io_dscinitializations.yaml
+++ b/config/crd/bases/dscinitialization.opendatahub.io_dscinitializations.yaml
@@ -47,7 +47,7 @@ spec:
             description: DSCInitializationSpec defines the desired state of DSCInitialization
             properties:
               applicationsNamespace:
-                default: opendatahub
+                default: opendatahub-system
                 type: string
               manifestsUri:
                 description: Internal development useful field
@@ -58,7 +58,7 @@ spec:
                     default: false
                     type: boolean
                   namespace:
-                    default: opendatahub
+                    default: opendatahub-system
                     type: string
                 type: object
             required:

--- a/main.go
+++ b/main.go
@@ -87,9 +87,9 @@ func main() {
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
-	flag.StringVar(&dscApplicationsNamespace, "dsc-applications-namespace", "opendatahub", "The namespace where data science cluster"+
+	flag.StringVar(&dscApplicationsNamespace, "dsc-applications-namespace", "opendatahub-system", "The namespace where data science cluster"+
 		"applications will be deployed")
-	flag.StringVar(&dscMonitoringNamespace, "dsc-monitoring-namespace", "opendatahub", "The namespace where data science cluster"+
+	flag.StringVar(&dscMonitoringNamespace, "dsc-monitoring-namespace", "opendatahub-system", "The namespace where data science cluster"+
 		"monitoring stack will be deployed")
 	opts := zap.Options{
 		Development: true,


### PR DESCRIPTION
## Description
discussion agreed to take "-system" as suffix, so we update to opendatahub-system.
This will reflect in the newer "quick install" doc.

## How Has This Been Tested?
catsrcimage:   quay.io/wenzhou/opendatahub-operator-catalog:v0.313.0

no "opendatahub" NS created
![Screenshot from 2023-07-14 10-55-57](https://github.com/opendatahub-io/opendatahub-operator/assets/915053/66318c9a-263d-43d9-bfdc-c62a8db287ad)
new CR created in "odh" when profile "workbenche" enabled
![Screenshot from 2023-07-14 10-55-47](https://github.com/opendatahub-io/opendatahub-operator/assets/915053/160e6a86-d7e8-46bd-a0d5-94e604e2de21)



## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
