### PR TITLE
Adding unit test for profile logic. Refactoring plan reconciliation to reduce coupling. Fixes #308

### DIFF
--- a/components/profiles/profiles.go
+++ b/components/profiles/profiles.go
@@ -74,26 +74,34 @@ type ReconciliationPlan struct {
 	Components map[string]bool
 }
 
-func PopulatePlan(profiledefaults ProfileConfig, plan *ReconciliationPlan, instance *dsc.DataScienceCluster) {
+func CreateReconciliationPlan(instance *dsc.DataScienceCluster) *ReconciliationPlan {
+	plan := &ReconciliationPlan{Components: make(map[string]bool)}
+	profile := instance.Spec.Profile
+	if profile == "" {
+		profile = ProfileCore
+	}
+	cfg := SetDefaultProfiles()[profile]
 
 	// serving is set to the default value, unless explicitly overriden
-	plan.Components[modelmeshserving.ComponentName] = profiledefaults.ComponentDefaults[modelmeshserving.ComponentName]
+	plan.Components[modelmeshserving.ComponentName] = cfg.ComponentDefaults[modelmeshserving.ComponentName]
 	if instance.Spec.Components.ModelMeshServing.Enabled != nil {
 		plan.Components[modelmeshserving.ComponentName] = *instance.Spec.Components.ModelMeshServing.Enabled
 	}
 	// training is set to the default value, unless explicitly overriden
-	plan.Components[datasciencepipelines.ComponentName] = profiledefaults.ComponentDefaults[datasciencepipelines.ComponentName]
+	plan.Components[datasciencepipelines.ComponentName] = cfg.ComponentDefaults[datasciencepipelines.ComponentName]
 	if instance.Spec.Components.DataSciencePipelines.Enabled != nil {
 		plan.Components[datasciencepipelines.ComponentName] = *instance.Spec.Components.DataSciencePipelines.Enabled
 	}
 	// workbenches is set to the default value, unless explicitly overriden
-	plan.Components[workbenches.ComponentName] = profiledefaults.ComponentDefaults[workbenches.ComponentName]
+	plan.Components[workbenches.ComponentName] = cfg.ComponentDefaults[workbenches.ComponentName]
 	if instance.Spec.Components.Workbenches.Enabled != nil {
 		plan.Components[workbenches.ComponentName] = *instance.Spec.Components.Workbenches.Enabled
 	}
 	// dashboard is set to the default value, unless explicitly overriden
-	plan.Components[dashboard.ComponentName] = profiledefaults.ComponentDefaults[dashboard.ComponentName]
+	plan.Components[dashboard.ComponentName] = cfg.ComponentDefaults[dashboard.ComponentName]
 	if instance.Spec.Components.Dashboard.Enabled != nil {
 		plan.Components[dashboard.ComponentName] = *instance.Spec.Components.Dashboard.Enabled
 	}
+
+	return plan
 }

--- a/components/profiles/profiles_suite_test.go
+++ b/components/profiles/profiles_suite_test.go
@@ -1,0 +1,13 @@
+package profiles_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestProfiles(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Profiles Suite")
+}

--- a/components/profiles/profiles_test.go
+++ b/components/profiles/profiles_test.go
@@ -1,0 +1,205 @@
+package profiles_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	dscapi "github.com/opendatahub-io/opendatahub-operator/apis/datasciencecluster/v1alpha1"
+	"github.com/opendatahub-io/opendatahub-operator/components"
+	"github.com/opendatahub-io/opendatahub-operator/components/dashboard"
+	"github.com/opendatahub-io/opendatahub-operator/components/datasciencepipelines"
+	"github.com/opendatahub-io/opendatahub-operator/components/modelmeshserving"
+	"github.com/opendatahub-io/opendatahub-operator/components/workbenches"
+
+	"github.com/opendatahub-io/opendatahub-operator/components/profiles"
+)
+
+var _ = Describe("Profiles", func() {
+	var baseServingProfile, baseTrainingProfile, baseWorkbenchesProfile, baseFullProfile, baseEmptyProfile *dscapi.DataScienceCluster
+	var servingPlusProfile, trainingPlusProfile, workbenchesPlusProfile, fullPlusProfile *dscapi.DataScienceCluster
+	var plan *profiles.ReconciliationPlan
+
+	Context("Default profiles without overrides", func() {
+		BeforeEach(func() {
+			baseServingProfile = &dscapi.DataScienceCluster{
+				Spec: dscapi.DataScienceClusterSpec{
+					Profile: profiles.ProfileServing,
+				},
+			}
+			baseTrainingProfile = &dscapi.DataScienceCluster{
+				Spec: dscapi.DataScienceClusterSpec{
+					Profile: profiles.ProfileTraining,
+				},
+			}
+			baseWorkbenchesProfile = &dscapi.DataScienceCluster{
+				Spec: dscapi.DataScienceClusterSpec{
+					Profile: profiles.ProfileWorkbench,
+				},
+			}
+			baseFullProfile = &dscapi.DataScienceCluster{
+				Spec: dscapi.DataScienceClusterSpec{
+					Profile: profiles.ProfileCore,
+				},
+			}
+			baseEmptyProfile = &dscapi.DataScienceCluster{}
+		})
+
+		It("Serving profile should enable only the serving components", func() {
+			plan = profiles.CreateReconciliationPlan(baseServingProfile)
+
+			Expect(plan.Components[modelmeshserving.ComponentName]).To(BeTrue())
+			Expect(plan.Components[datasciencepipelines.ComponentName]).To(BeFalse())
+			Expect(plan.Components[workbenches.ComponentName]).To(BeFalse())
+			Expect(plan.Components[dashboard.ComponentName]).To(BeTrue())
+		})
+		It("Training profile should enable only the training components", func() {
+			plan := profiles.CreateReconciliationPlan(baseTrainingProfile)
+
+			Expect(plan.Components[modelmeshserving.ComponentName]).To(BeFalse())
+			Expect(plan.Components[datasciencepipelines.ComponentName]).To(BeTrue())
+			Expect(plan.Components[workbenches.ComponentName]).To(BeFalse())
+			Expect(plan.Components[dashboard.ComponentName]).To(BeTrue())
+		})
+		It("Workbenches profile should enable only the workbench components", func() {
+			plan := profiles.CreateReconciliationPlan(baseWorkbenchesProfile)
+
+			Expect(plan.Components[modelmeshserving.ComponentName]).To(BeFalse())
+			Expect(plan.Components[datasciencepipelines.ComponentName]).To(BeFalse())
+			Expect(plan.Components[workbenches.ComponentName]).To(BeTrue())
+			Expect(plan.Components[dashboard.ComponentName]).To(BeTrue())
+		})
+		It("Full profile should enable all components", func() {
+			plan := profiles.CreateReconciliationPlan(baseFullProfile)
+
+			Expect(plan.Components[modelmeshserving.ComponentName]).To(BeTrue())
+			Expect(plan.Components[datasciencepipelines.ComponentName]).To(BeTrue())
+			Expect(plan.Components[workbenches.ComponentName]).To(BeTrue())
+			Expect(plan.Components[dashboard.ComponentName]).To(BeTrue())
+		})
+		It("Empty profile defaults to Full and should enable all components", func() {
+			plan := profiles.CreateReconciliationPlan(baseEmptyProfile)
+
+			Expect(plan.Components[modelmeshserving.ComponentName]).To(BeTrue())
+			Expect(plan.Components[datasciencepipelines.ComponentName]).To(BeTrue())
+			Expect(plan.Components[workbenches.ComponentName]).To(BeTrue())
+			Expect(plan.Components[dashboard.ComponentName]).To(BeTrue())
+		})
+	})
+
+	Context("Profiles with overrides", func() {
+		BeforeEach(func() {
+			t := true
+			f := false
+			servingPlusProfile = &dscapi.DataScienceCluster{
+				Spec: dscapi.DataScienceClusterSpec{
+					Profile: profiles.ProfileServing,
+					Components: dscapi.Components{
+						ModelMeshServing: modelmeshserving.ModelMeshServing{
+							Component: components.Component{Enabled: &f},
+						},
+						DataSciencePipelines: datasciencepipelines.DataSciencePipelines{
+							Component: components.Component{Enabled: &t},
+						},
+						Workbenches: workbenches.Workbenches{
+							Component: components.Component{Enabled: &t},
+						},
+						Dashboard: dashboard.Dashboard{
+							Component: components.Component{Enabled: &f},
+						},
+					},
+				},
+			}
+			trainingPlusProfile = &dscapi.DataScienceCluster{
+				Spec: dscapi.DataScienceClusterSpec{
+					Profile: profiles.ProfileTraining,
+					Components: dscapi.Components{
+						ModelMeshServing: modelmeshserving.ModelMeshServing{
+							Component: components.Component{Enabled: &t},
+						},
+						DataSciencePipelines: datasciencepipelines.DataSciencePipelines{
+							Component: components.Component{Enabled: &f},
+						},
+						Workbenches: workbenches.Workbenches{
+							Component: components.Component{Enabled: &t},
+						},
+						Dashboard: dashboard.Dashboard{
+							Component: components.Component{Enabled: &f},
+						},
+					},
+				},
+			}
+			workbenchesPlusProfile = &dscapi.DataScienceCluster{
+				Spec: dscapi.DataScienceClusterSpec{
+					Profile: profiles.ProfileWorkbench,
+					Components: dscapi.Components{
+						ModelMeshServing: modelmeshserving.ModelMeshServing{
+							Component: components.Component{Enabled: &t},
+						},
+						DataSciencePipelines: datasciencepipelines.DataSciencePipelines{
+							Component: components.Component{Enabled: &t},
+						},
+						Workbenches: workbenches.Workbenches{
+							Component: components.Component{Enabled: &f},
+						},
+						Dashboard: dashboard.Dashboard{
+							Component: components.Component{Enabled: &f},
+						},
+					},
+				},
+			}
+			fullPlusProfile = &dscapi.DataScienceCluster{
+				Spec: dscapi.DataScienceClusterSpec{
+					Profile: profiles.ProfileCore,
+					Components: dscapi.Components{
+						ModelMeshServing: modelmeshserving.ModelMeshServing{
+							Component: components.Component{Enabled: &f},
+						},
+						DataSciencePipelines: datasciencepipelines.DataSciencePipelines{
+							Component: components.Component{Enabled: &f},
+						},
+						Workbenches: workbenches.Workbenches{
+							Component: components.Component{Enabled: &f},
+						},
+						Dashboard: dashboard.Dashboard{
+							Component: components.Component{Enabled: &f},
+						},
+					},
+				},
+			}
+		})
+
+		It("Serving profile with opposite overrides", func() {
+			plan := profiles.CreateReconciliationPlan(servingPlusProfile)
+
+			Expect(plan.Components[modelmeshserving.ComponentName]).To(BeFalse())
+			Expect(plan.Components[datasciencepipelines.ComponentName]).To(BeTrue())
+			Expect(plan.Components[workbenches.ComponentName]).To(BeTrue())
+			Expect(plan.Components[dashboard.ComponentName]).To(BeFalse())
+		})
+		It("Training profile with opposite overrides", func() {
+			plan := profiles.CreateReconciliationPlan(trainingPlusProfile)
+
+			Expect(plan.Components[modelmeshserving.ComponentName]).To(BeTrue())
+			Expect(plan.Components[datasciencepipelines.ComponentName]).To(BeFalse())
+			Expect(plan.Components[workbenches.ComponentName]).To(BeTrue())
+			Expect(plan.Components[dashboard.ComponentName]).To(BeFalse())
+		})
+		It("Workbench profile with opposite overrides", func() {
+			plan := profiles.CreateReconciliationPlan(workbenchesPlusProfile)
+
+			Expect(plan.Components[modelmeshserving.ComponentName]).To(BeTrue())
+			Expect(plan.Components[datasciencepipelines.ComponentName]).To(BeTrue())
+			Expect(plan.Components[workbenches.ComponentName]).To(BeFalse())
+			Expect(plan.Components[dashboard.ComponentName]).To(BeFalse())
+		})
+		It("Full profile with opposite overrides", func() {
+			plan := profiles.CreateReconciliationPlan(fullPlusProfile)
+
+			Expect(plan.Components[modelmeshserving.ComponentName]).To(BeFalse())
+			Expect(plan.Components[datasciencepipelines.ComponentName]).To(BeFalse())
+			Expect(plan.Components[workbenches.ComponentName]).To(BeFalse())
+			Expect(plan.Components[dashboard.ComponentName]).To(BeFalse())
+		})
+	})
+
+})

--- a/controllers/datasciencecluster/datasciencecluster_controller.go
+++ b/controllers/datasciencecluster/datasciencecluster_controller.go
@@ -190,14 +190,9 @@ func (r *DataScienceClusterReconciler) SetupWithManager(mgr ctrl.Manager) error 
 }
 
 func (r *DataScienceClusterReconciler) CreateReconciliationPlan(instance *dsc.DataScienceCluster) *profiles.ReconciliationPlan {
-	plan := &profiles.ReconciliationPlan{Components: make(map[string]bool)}
-
-	profile := instance.Spec.Profile
-
-	// Set profile defaults
-	profiles.ProfileConfigs = profiles.SetDefaultProfiles()
 	// Create plan for component deployment
-	profiles.PopulatePlan(profiles.ProfileConfigs[profile], plan, instance)
+	profile := instance.Spec.Profile
+	plan := profiles.CreateReconciliationPlan(instance)
 
 	// warn of odd profile combinations
 	componentName := ""


### PR DESCRIPTION
Adding unit test for profile logic. Refactoring plan reconciliation to reduce coupling. Fixes #308

## How Has This Been Tested?
Included unit tests

## Merge criteria:
- [X] The commits are squashed in a cohesive manner and have meaningful messages.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work
