### PR TITLE
Update networkpolicy to allow all traffic access applicationNamespace

### DIFF
--- a/controllers/dscinitialization/utils.go
+++ b/controllers/dscinitialization/utils.go
@@ -152,18 +152,9 @@ func (r *DSCInitializationReconciler) reconcileDefaultNetworkPolicy(dscInit *dsc
 			Name:      name,
 			Namespace: name,
 		},
-		Spec: netv1.NetworkPolicySpec{
-			Ingress: []netv1.NetworkPolicyIngressRule{{
-				From: []netv1.NetworkPolicyPeer{
-					{
-						NamespaceSelector: &metav1.LabelSelector{
-							MatchLabels: map[string]string{
-								"opendatahub.io/generated-namespace": "true",
-							},
-						},
-					},
-				},
-			}},
+		Spec: netv1.NetworkPolicySpec{ 
+			// open ingress for all port for now, TODO: add explicit port per component
+			Ingress: []netv1.NetworkPolicyIngressRule{{}},
 			PolicyTypes: []netv1.PolicyType{
 				netv1.PolicyTypeIngress,
 			},


### PR DESCRIPTION
## Description
As a temp. workaround,  to get dashboard route working (and modelmesh monitoring route) , open all for now.
Ideally we should get all ports and define with is needed for which components. 
- ref https://github.com/opendatahub-io/odh-manifests/pull/882 

## How Has This Been Tested?
build test image, deploy to cluster, check networkpolicy content:

![Screenshot from 2023-07-17 17-31-08](https://github.com/opendatahub-io/opendatahub-operator/assets/915053/5ba8b876-3b3b-4f4d-a8df-ecf24c0d266d)


## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
