### PR TITLE
Add samples back and remove kfdef from "owned" in CSV

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ OPERATOR_SDK ?= $(LOCALBIN)/operator-sdk
 
 ## Tool Versions
 KUSTOMIZE_VERSION ?= v3.8.7
-CONTROLLER_GEN_VERSION ?= v0.12.0
+CONTROLLER_GEN_VERSION ?= v0.9.2
 OPERATOR_SDK_VERSION ?= v1.24.1
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.24.2

--- a/bundle/manifests/opendatahub-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/opendatahub-operator.clusterserviceversion.yaml
@@ -2,7 +2,164 @@ apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion
 metadata:
   annotations:
-    alm-examples: '[]'
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "console.openshift.io/v1",
+          "kind": "OdhQuickStart",
+          "metadata": {
+            "annotations": {
+              "internal.config.kubernetes.io/previousKinds": "OdhQuickStart",
+              "internal.config.kubernetes.io/previousNames": "create-jupyter-notebook",
+              "internal.config.kubernetes.io/previousNamespaces": "default",
+              "opendatahub.io/categories": "Getting started,Notebook environments"
+            },
+            "labels": {
+              "app.kubernetes.io/created-by": "odh-dashboard",
+              "app.kubernetes.io/instance": "odh-dashboard-sample",
+              "app.kubernetes.io/managed-by": "kustomize",
+              "app.kubernetes.io/name": "odh-dashboard",
+              "app.kubernetes.io/part-of": "odh-dashboard"
+            },
+            "name": "create-jupyter-notebook-sample",
+            "namespace": "opendatahub"
+          },
+          "spec": {
+            "appName": "jupyterhub",
+            "displayName": "Creating a Jupyter notebook",
+            "durationMinutes": 5
+          }
+        },
+        {
+          "apiVersion": "dashboard.opendatahub.io/v1",
+          "kind": "OdhApplication",
+          "metadata": {
+            "labels": {
+              "app.kubernetes.io/created-by": "odh-dashboard",
+              "app.kubernetes.io/instance": "odh-dashboard-sample",
+              "app.kubernetes.io/managed-by": "kustomize",
+              "app.kubernetes.io/name": "odh-dashboard",
+              "app.kubernetes.io/part-of": "odh-dashboard"
+            },
+            "name": "jupyterhub-sample",
+            "namespace": "opendatahub"
+          },
+          "spec": {
+            "displayName": "JupyterHub",
+            "docsLink": "https://jupyter.org/hub",
+            "getStartedLink": "https://jupyterhub.readthedocs.io/en/stable/getting-started/index.html",
+            "getStartedMarkDown": "# MarkDown Description",
+            "provider": "Jupyter",
+            "quickStart": "create-jupyter-notebook",
+            "route": "jupyterhub"
+          }
+        },
+        {
+          "apiVersion": "dashboard.opendatahub.io/v1",
+          "kind": "OdhDocument",
+          "metadata": {
+            "labels": {
+              "app.kubernetes.io/created-by": "odh-dashboard",
+              "app.kubernetes.io/instance": "odh-dashboard-sample",
+              "app.kubernetes.io/managed-by": "kustomize",
+              "app.kubernetes.io/name": "odh-dashboard",
+              "app.kubernetes.io/part-of": "odh-dashboard"
+            },
+            "name": "jupyterhub-view-installed-packages-sample",
+            "namespace": "opendatahub"
+          },
+          "spec": {
+            "appName": "jupyter",
+            "durationMinutes": 15,
+            "type": "how-to",
+            "url": "https://url.sample.com"
+          }
+        },
+        {
+          "apiVersion": "datasciencecluster.opendatahub.io/v1alpha1",
+          "kind": "DataScienceCluster",
+          "metadata": {
+            "labels": {
+              "app.kubernetes.io/created-by": "opendatahub-operator",
+              "app.kubernetes.io/instance": "default",
+              "app.kubernetes.io/managed-by": "kustomize",
+              "app.kubernetes.io/name": "datasciencecluster",
+              "app.kubernetes.io/part-of": "opendatahub-operator"
+            },
+            "name": "default"
+          },
+          "spec": {
+            "components": {
+              "dashboard": {
+                "enabled": false
+              },
+              "datasciencepipelines": {
+                "enabled": false
+              },
+              "distributedworkloads": {
+                "enabled": false
+              },
+              "kserve": {
+                "enabled": false
+              },
+              "modelmeshserving": {
+                "enabled": false
+              },
+              "workbenches": {
+                "enabled": false
+              }
+            }
+          }
+        },
+        {
+          "apiVersion": "dscinitialization.opendatahub.io/v1alpha1",
+          "kind": "DSCInitialization",
+          "metadata": {
+            "labels": {
+              "app.kubernetes.io/created-by": "opendatahub-operator",
+              "app.kubernetes.io/instance": "default",
+              "app.kubernetes.io/managed-by": "kustomize",
+              "app.kubernetes.io/name": "dscinitialization",
+              "app.kubernetes.io/part-of": "opendatahub-operator"
+            },
+            "name": "default"
+          },
+          "spec": {
+            "applicationsNamespace": "opendatahub-system",
+            "monitoring": {
+              "enabled": false,
+              "namespace": "opendatahub-system"
+            }
+          }
+        },
+        {
+          "apiVersion": "opendatahub.io/v1alpha",
+          "kind": "OdhDashboardConfig",
+          "metadata": {
+            "labels": {
+              "app.kubernetes.io/created-by": "odh-dashboard",
+              "app.kubernetes.io/instance": "odh-dashboard-sample",
+              "app.kubernetes.io/managed-by": "kustomize",
+              "app.kubernetes.io/name": "odh-dashboard",
+              "app.kubernetes.io/part-of": "odh-dashboard",
+              "opendatahub.io/dashboard": "true"
+            },
+            "name": "odh-dashboard-config-sample",
+            "namespace": "opendatahub"
+          },
+          "spec": {
+            "dashboardConfig": null,
+            "groupsConfig": {
+              "adminGroups": "odh-admins",
+              "allowedGroups": "system:authenticated"
+            },
+            "notebookController": {
+              "enabled": true
+            },
+            "templateOrder": []
+          }
+        }
+      ]
     capabilities: Seamless Upgrades
     olm.skipRange: '>=1.0.0 <2.0.0'
     operatorframework.io/initialization-resource: "{ \n  \"apiVersion\": \"datasciencecluster.opendatahub.io/v1alpha1\",\n
@@ -28,9 +185,6 @@ spec:
       kind: DSCInitialization
       name: dscinitializations.dscinitialization.opendatahub.io
       version: v1alpha1
-    - kind: KfDef
-      name: kfdefs.kfdef.apps.kubeflow.org
-      version: v1
     - kind: OdhApplication
       name: odhapplications.dashboard.opendatahub.io
       version: v1

--- a/config/manifests/kustomization.yaml
+++ b/config/manifests/kustomization.yaml
@@ -6,6 +6,7 @@ kind: Kustomization
 resources:
 - bases/opendatahub-operator.clusterserviceversion.yaml
 - ../default
+- ../samples
 - ../scorecard
 
 patches:

--- a/config/samples/datasciencecluster_v1alpha1_datasciencecluster.yaml
+++ b/config/samples/datasciencecluster_v1alpha1_datasciencecluster.yaml
@@ -11,13 +11,14 @@ metadata:
 spec:
   components:
     dashboard:
-      component: true
-    workbenches:
-      component: true
+      enabled: false
     datasciencepipelines:
-      component: true
-    modelmeshserving:
-      component: true
+      enabled: false
+    distributedworkloads:
+      enabled: false
     kserve:
-      component: true
-
+      enabled: false
+    modelmeshserving:
+      enabled: false
+    workbenches:
+      enabled: false

--- a/docs/Dev-Preview.md
+++ b/docs/Dev-Preview.md
@@ -84,6 +84,8 @@ $ cat <<EOF | oc apply -f -
         enabled: true
       datasciencepipelines:
         enabled: true
+      distributedworkloads:
+        enabled: true
       kserve:
         enabled: true
       modelmeshserving:


### PR DESCRIPTION
## Description
Not sure if it was mistakenly added but "kfdef" is in "owned" and "required" both section in CSV yaml

also samples are gone when create CR
![Screenshot from 2023-07-18 11-42-28](https://github.com/opendatahub-io/opendatahub-operator/assets/915053/9ebf1c5a-2533-4740-8e90-f14fa5ada0d1)



## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
