### PR TITLE
Adding refresh and retry logic in the DSCInitialization reconciliation loop

### DIFF
--- a/components/component.go
+++ b/components/component.go
@@ -8,14 +8,11 @@ import (
 
 type Component struct {
 	// enables or disables the component. A disabled component will not be installed.
-	Enabled *bool `json:"enabled,omitempty"`
+	Enabled bool `json:"enabled,omitempty"`
 	// Add any other common fields across components below
 }
 
 type ComponentInterface interface {
 	ReconcileComponent(owner metav1.Object, client client.Client, scheme *runtime.Scheme,
 		enabled bool, namespace string) error
-
-	IsEnabled() *bool
-	SetEnabled(enabled bool)
 }

--- a/components/dashboard/dashboard.go
+++ b/components/dashboard/dashboard.go
@@ -21,12 +21,12 @@ type Dashboard struct {
 // Verifies that Dashboard implements ComponentInterface
 var _ components.ComponentInterface = (*Dashboard)(nil)
 
-func (d *Dashboard) IsEnabled() *bool {
+func (d *Dashboard) IsEnabled() bool {
 	return d.Enabled
 }
 
 func (d *Dashboard) SetEnabled(enabled bool) {
-	d.Enabled = &enabled
+	d.Enabled = enabled
 }
 
 func (d *Dashboard) ReconcileComponent(owner metav1.Object, cli client.Client, scheme *runtime.Scheme, enabled bool, namespace string) error {

--- a/components/dashboard/dashboard.go
+++ b/components/dashboard/dashboard.go
@@ -21,14 +21,6 @@ type Dashboard struct {
 // Verifies that Dashboard implements ComponentInterface
 var _ components.ComponentInterface = (*Dashboard)(nil)
 
-func (d *Dashboard) IsEnabled() bool {
-	return d.Enabled
-}
-
-func (d *Dashboard) SetEnabled(enabled bool) {
-	d.Enabled = enabled
-}
-
 func (d *Dashboard) ReconcileComponent(owner metav1.Object, cli client.Client, scheme *runtime.Scheme, enabled bool, namespace string) error {
 
 	// TODO: Add any additional tasks if required when reconciling component

--- a/components/datasciencepipelines/datasciencepipelines.go
+++ b/components/datasciencepipelines/datasciencepipelines.go
@@ -20,12 +20,12 @@ type DataSciencePipelines struct {
 // Verifies that Dashboard implements ComponentInterface
 var _ components.ComponentInterface = (*DataSciencePipelines)(nil)
 
-func (d *DataSciencePipelines) IsEnabled() *bool {
+func (d *DataSciencePipelines) IsEnabled() bool {
 	return d.Enabled
 }
 
 func (d *DataSciencePipelines) SetEnabled(enabled bool) {
-	d.Enabled = &enabled
+	d.Enabled = enabled
 }
 
 func (d *DataSciencePipelines) ReconcileComponent(owner metav1.Object, client client.Client, scheme *runtime.Scheme, enabled bool, namespace string) error {

--- a/components/kserve/kserve.go
+++ b/components/kserve/kserve.go
@@ -22,12 +22,12 @@ type Kserve struct {
 // Verifies that Kserve implements ComponentInterface
 var _ components.ComponentInterface = (*Kserve)(nil)
 
-func (d *Kserve) IsEnabled() *bool {
+func (d *Kserve) IsEnabled() bool {
 	return d.Enabled
 }
 
 func (d *Kserve) SetEnabled(enabled bool) {
-	d.Enabled = &enabled
+	d.Enabled = enabled
 }
 
 func (m *Kserve) ReconcileComponent(owner metav1.Object, cli client.Client, scheme *runtime.Scheme, enabled bool, namespace string) error {

--- a/components/modelmeshserving/modelmeshserving.go
+++ b/components/modelmeshserving/modelmeshserving.go
@@ -22,12 +22,12 @@ type ModelMeshServing struct {
 // Verifies that Dashboard implements ComponentInterface
 var _ components.ComponentInterface = (*ModelMeshServing)(nil)
 
-func (d *ModelMeshServing) IsEnabled() *bool {
+func (d *ModelMeshServing) IsEnabled() bool {
 	return d.Enabled
 }
 
 func (d *ModelMeshServing) SetEnabled(enabled bool) {
-	d.Enabled = &enabled
+	d.Enabled = enabled
 }
 
 func (m *ModelMeshServing) ReconcileComponent(owner metav1.Object, cli client.Client, scheme *runtime.Scheme, enabled bool, namespace string) error {

--- a/components/workbenches/workbenches.go
+++ b/components/workbenches/workbenches.go
@@ -22,12 +22,12 @@ type Workbenches struct {
 // Verifies that Dashboard implements ComponentInterface
 var _ components.ComponentInterface = (*Workbenches)(nil)
 
-func (d *Workbenches) IsEnabled() *bool {
+func (d *Workbenches) IsEnabled() bool {
 	return d.Enabled
 }
 
 func (d *Workbenches) SetEnabled(enabled bool) {
-	d.Enabled = &enabled
+	d.Enabled = enabled
 }
 
 func (m *Workbenches) ReconcileComponent(owner metav1.Object, cli client.Client, scheme *runtime.Scheme, enabled bool, namespace string) error {

--- a/controllers/datasciencecluster/datasciencecluster_controller.go
+++ b/controllers/datasciencecluster/datasciencecluster_controller.go
@@ -75,7 +75,6 @@ func (r *DataScienceClusterReconciler) Reconcile(ctx context.Context, req ctrl.R
 		return ctrl.Result{}, err
 	}
 
-<<<<<<< HEAD
 	// If instance is being deleted, return
 	if instance.GetDeletionTimestamp() != nil {
 		return ctrl.Result{}, nil
@@ -88,26 +87,10 @@ func (r *DataScienceClusterReconciler) Reconcile(ctx context.Context, req ctrl.R
 		return ctrl.Result{}, err
 	}
 
-=======
-	var instance *dsc.DataScienceCluster
->>>>>>> 16be06a (Adding retry on failure capability)
 	if len(instanceList.Items) > 1 {
 		message := fmt.Sprintf("only one instance of DataScienceCluster object is allowed. Update existing instance on namespace %s and name %s", req.Namespace, req.Name)
 		_ = r.reportError(err, &instanceList.Items[0], message)
 		return ctrl.Result{}, fmt.Errorf(message)
-<<<<<<< HEAD
-=======
-	} else if len(instanceList.Items) != 0 {
-		instance = &instanceList.Items[0]
-	} else {
-		// this should never happen
-		return ctrl.Result{}, nil
-	}
-
-	// If instance is being deleted, return
-	if instance.GetDeletionTimestamp() != nil {
-		return ctrl.Result{}, err
->>>>>>> 16be06a (Adding retry on failure capability)
 	}
 
 	// Start reconciling
@@ -228,21 +211,22 @@ func (r *DataScienceClusterReconciler) updateStatus(original *dsc.DataScienceClu
 	var saved *dsc.DataScienceCluster
 	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 
+		r.Log.Info("--DEBUG--1. Retrieving DataScienceCluster", "instance.Name", client.ObjectKeyFromObject(original))
 		err := r.Client.Get(context.TODO(), client.ObjectKeyFromObject(original), saved)
 		if err != nil {
+			r.Log.Info("--DEBUG--2. Retrieving DataScienceCluster ERROR", "err", err)
 			return err
 		}
 		// update status here
 		saved.Status = original.Status
 
 		// Try to update
+		r.Log.Info("--DEBUG--3. Updating DataScienceCluster status", "instance", saved)
 		err = r.Client.Status().Update(context.TODO(), saved)
+		r.Log.Info("--DEBUG--4. Result", "error", err)
 		// Return err itself here (not wrapped inside another error)
 		// so that RetryOnConflict can identify it correctly.
 		return err
 	})
-	if saved == nil {
-		saved = original
-	}
 	return saved, err
 }

--- a/controllers/datasciencecluster/datasciencecluster_controller.go
+++ b/controllers/datasciencecluster/datasciencecluster_controller.go
@@ -241,5 +241,8 @@ func (r *DataScienceClusterReconciler) updateStatus(original *dsc.DataScienceClu
 		// so that RetryOnConflict can identify it correctly.
 		return err
 	})
+	if saved == nil {
+		saved = original
+	}
 	return saved, err
 }

--- a/controllers/datasciencecluster/datasciencecluster_controller.go
+++ b/controllers/datasciencecluster/datasciencecluster_controller.go
@@ -109,75 +109,39 @@ func (r *DataScienceClusterReconciler) Reconcile(ctx context.Context, req ctrl.R
 	}
 
 	// reconcile dashboard component
-	enabled := r.isComponentEnabled(&(instance.Spec.Components.Dashboard))
-	if val, err := r.reconcileSubComponent(instance, dashboard.ComponentName, enabled, &(instance.Spec.Components.Dashboard), ctx); err != nil {
-		// Update immediately only when error occurs, else skip to end
-		err := r.Client.Update(ctx, instance)
-		if err != nil {
-			r.Log.Info(fmt.Sprintf("failed to set DataScienceCluster component %s to enabled: false", dashboard.ComponentName), "error", err)
-			// no need to return error as this is not critical and will be reconciled in the next update or reconcile loop
-		}
+	if val, err := r.reconcileSubComponent(instance, dashboard.ComponentName, instance.Spec.Components.Dashboard.Enabled,
+		&(instance.Spec.Components.Dashboard), ctx); err != nil {
 		// no need to log any errors as this is done in the reconcileSubComponent method
 		return val, err
 	}
 
 	// reconcile DataSciencePipelines component
-	enabled = r.isComponentEnabled(&(instance.Spec.Components.DataSciencePipelines))
-	if val, err := r.reconcileSubComponent(instance, datasciencepipelines.ComponentName, enabled, &(instance.Spec.Components.DataSciencePipelines), ctx); err != nil {
-		// Update immediately only when error occurs, else skip to end
-		err := r.Client.Update(ctx, instance)
-		if err != nil {
-			r.Log.Info(fmt.Sprintf("failed to set DataScienceCluster component %s to enabled: false", datasciencepipelines.ComponentName), "error", err)
-			// no need to return error as this is not critical and will be reconciled in the next update or reconcile loop
-		}
+	if val, err := r.reconcileSubComponent(instance, datasciencepipelines.ComponentName, instance.Spec.Components.DataSciencePipelines.Enabled,
+		&(instance.Spec.Components.DataSciencePipelines), ctx); err != nil {
 		// no need to log any errors as this is done in the reconcileSubComponent method
 		return val, err
 	}
 
 	// reconcile ModelMesh component
-	enabled = r.isComponentEnabled(&(instance.Spec.Components.ModelMeshServing))
-	if val, err := r.reconcileSubComponent(instance, modelmeshserving.ComponentName, enabled, &(instance.Spec.Components.ModelMeshServing), ctx); err != nil {
-		// Update immediately only when error occurs, else skip to end
-		err := r.Client.Update(ctx, instance)
-		if err != nil {
-			r.Log.Info(fmt.Sprintf("failed to set DataScienceCluster component %s to enabled: false", modelmeshserving.ComponentName), "error", err)
-			// no need to return error as this is not critical and will be reconciled in the next update or reconcile loop
-		}
+	if val, err := r.reconcileSubComponent(instance, modelmeshserving.ComponentName, instance.Spec.Components.ModelMeshServing.Enabled,
+		&(instance.Spec.Components.ModelMeshServing), ctx); err != nil {
 		// no need to log any errors as this is done in the reconcileSubComponent method
 		return val, err
 	}
 
 	// reconcile Workbench component
-	enabled = r.isComponentEnabled(&(instance.Spec.Components.Workbenches))
-	if val, err := r.reconcileSubComponent(instance, workbenches.ComponentName, enabled, &(instance.Spec.Components.Workbenches), ctx); err != nil {
-		// Update immediately only when error occurs, else skip to end
-		err := r.Client.Update(ctx, instance)
-		if err != nil {
-			r.Log.Info(fmt.Sprintf("failed to set DataScienceCluster component %s to enabled: false", workbenches.ComponentName), "error", err)
-			// no need to return error as this is not critical and will be reconciled in the next update or reconcile loop
-		}
+	if val, err := r.reconcileSubComponent(instance, workbenches.ComponentName, instance.Spec.Components.Workbenches.Enabled,
+		&(instance.Spec.Components.Workbenches), ctx); err != nil {
 		// no need to log any errors as this is done in the reconcileSubComponent method
 		return val, err
 	}
 
 	// reconcile Kserve component
-	enabled = r.isComponentEnabled(&(instance.Spec.Components.Kserve))
-	if val, err := r.reconcileSubComponent(instance, kserve.ComponentName, enabled, &(instance.Spec.Components.Kserve), ctx); err != nil {
-		err := r.Client.Update(ctx, instance)
-		if err != nil {
-			r.Log.Info(fmt.Sprintf("failed to set DataScienceCluster component %s to enabled: false", kserve.ComponentName), "error", err)
-			// no need to return error as this is not critical and will be reconciled in the next update or reconcile loop
-		}
+	if val, err := r.reconcileSubComponent(instance, kserve.ComponentName, instance.Spec.Components.Kserve.Enabled, &(instance.Spec.Components.Kserve), ctx); err != nil {
 		// no need to log any errors as this is done in the reconcileSubComponent method
 		return val, err
 	}
 
-	// Update final state of spec
-	err = r.Client.Update(ctx, instance)
-	if err != nil {
-		r.Log.Info(fmt.Sprintf("failed to set DataScienceCluster CR :%v", instance.Name), "error", err)
-		// no need to return error as this is not critical and will be reconciled in the next update or reconcile loop
-	}
 	// finalize reconciliation
 	status.SetCompleteCondition(&instance.Status.Conditions, status.ReconcileCompleted, "DataScienceCluster resource reconciled successfully.")
 	err = r.Client.Status().Update(ctx, instance)
@@ -196,13 +160,6 @@ func (r *DataScienceClusterReconciler) Reconcile(ctx context.Context, req ctrl.R
 	}
 
 	return ctrl.Result{}, nil
-}
-
-func (r *DataScienceClusterReconciler) isComponentEnabled(component components.ComponentInterface) bool {
-	if component.IsEnabled() == nil {
-		component.SetEnabled(false)
-	}
-	return *component.IsEnabled()
 }
 
 func (r *DataScienceClusterReconciler) reconcileSubComponent(instance *dsc.DataScienceCluster, componentName string, enabled bool,

--- a/controllers/dscinitialization/dscinitialization_controller.go
+++ b/controllers/dscinitialization/dscinitialization_controller.go
@@ -147,6 +147,13 @@ func (r *DSCInitializationReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	}
 
 	// Finish reconciling
+
+	// refresh the instance in case it was updated during the reconcile
+	err = r.Client.Get(ctx, types.NamespacedName{Name: "default"}, instance)
+	if err != nil {
+		r.Log.Error(err, "failed to retrieve DSCInitialization instance for status update after successfuly completed reconciliation")
+		return ctrl.Result{}, err
+	}
 	reason := status.ReconcileCompleted
 	message := status.ReconcileCompletedMessage
 	status.SetCompleteCondition(&instance.Status.Conditions, reason, message)

--- a/controllers/dscinitialization/utils.go
+++ b/controllers/dscinitialization/utils.go
@@ -354,7 +354,6 @@ func updatefromLegacyVersion(cli client.Client) error {
 		}
 
 		// Create DataScienceCluster with no components enabled to cleanup all previous controllers
-		f := false
 		defaultDataScienceCluster := &dsc.DataScienceCluster{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       "DataScienceCluster",
@@ -366,19 +365,19 @@ func updatefromLegacyVersion(cli client.Client) error {
 			Spec: dsc.DataScienceClusterSpec{
 				Components: dsc.Components{
 					ModelMeshServing: modelmeshserving.ModelMeshServing{
-						Component: components.Component{Enabled: &f},
+						Component: components.Component{Enabled: false},
 					},
 					DataSciencePipelines: datasciencepipelines.DataSciencePipelines{
-						Component: components.Component{Enabled: &f},
+						Component: components.Component{Enabled: false},
 					},
 					Workbenches: workbenches.Workbenches{
-						Component: components.Component{Enabled: &f},
+						Component: components.Component{Enabled: false},
 					},
 					Dashboard: dashboard.Dashboard{
-						Component: components.Component{Enabled: &f},
+						Component: components.Component{Enabled: false},
 					},
 					Kserve: kserve.Kserve{
-						Component: components.Component{Enabled: &f},
+						Component: components.Component{Enabled: false},
 					},
 				},
 			},


### PR DESCRIPTION
Adding refresh and retry logic in the DSCInitialization reconciliation loop to resolve errors and crashloop. #331
Manually tested on the cluster.

## Merge criteria:
- [X] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work
