### PR TITLE
Fix odh-manifests file name and add more logger

### DIFF
--- a/components/dashboard/dashboard.go
+++ b/components/dashboard/dashboard.go
@@ -2,7 +2,6 @@ package dashboard
 
 import (
 	"fmt"
-
 	"github.com/opendatahub-io/opendatahub-operator/v2/components"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/common"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/deploy"
@@ -45,17 +44,17 @@ func (d *Dashboard) ReconcileComponent(owner metav1.Object, cli client.Client, s
 	// Update Default rolebinding
 	platform, err := deploy.GetPlatform(cli)
 	if err != nil {
-		return err
+		return fmt.Errorf(err.Error())
 	}
 	if platform == deploy.OpenDataHub {
 		err := common.UpdatePodSecurityRolebinding(cli, []string{"odh-dashboard"}, namespace)
 		if err != nil {
-			return err
+			return fmt.Errorf(err.Error())
 		}
 	} else {
 		err := common.UpdatePodSecurityRolebinding(cli, []string{"rhods-dashboard"}, namespace)
 		if err != nil {
-			return err
+			return fmt.Errorf(err.Error())
 		}
 	}
 

--- a/components/datasciencepipelines/datasciencepipelines.go
+++ b/components/datasciencepipelines/datasciencepipelines.go
@@ -1,6 +1,7 @@
 package datasciencepipelines
 
 import (
+	"fmt"
 	"github.com/opendatahub-io/opendatahub-operator/v2/components"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/deploy"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -57,8 +58,7 @@ func (d *DataSciencePipelines) ReconcileComponent(owner metav1.Object, client cl
 		Path,
 		namespace,
 		scheme, enabled)
-	return err
-
+	return fmt.Errorf(err.Error())
 }
 
 func (in *DataSciencePipelines) DeepCopyInto(out *DataSciencePipelines) {

--- a/components/kserve/kserve.go
+++ b/components/kserve/kserve.go
@@ -5,6 +5,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"fmt"
 	"github.com/opendatahub-io/opendatahub-operator/v2/components"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/common"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/deploy"
@@ -46,7 +47,7 @@ func (d *Kserve) ReconcileComponent(owner metav1.Object, cli client.Client, sche
 	// Update Default rolebinding
 	err := common.UpdatePodSecurityRolebinding(cli, []string{"kserve-controller-manager"}, namespace)
 	if err != nil {
-		return err
+		return fmt.Errorf(err.Error())
 	}
 
 	// Update image parameters
@@ -58,7 +59,7 @@ func (d *Kserve) ReconcileComponent(owner metav1.Object, cli client.Client, sche
 		Path,
 		namespace,
 		scheme, enabled)
-	return err
+	return fmt.Errorf(err.Error())
 }
 
 func (in *Kserve) DeepCopyInto(out *Kserve) {

--- a/components/modelmeshserving/modelmeshserving.go
+++ b/components/modelmeshserving/modelmeshserving.go
@@ -1,6 +1,7 @@
 package modelmeshserving
 
 import (
+	"fmt"
 	"github.com/opendatahub-io/opendatahub-operator/v2/components"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/common"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/deploy"
@@ -52,7 +53,7 @@ func (m *ModelMeshServing) ReconcileComponent(owner metav1.Object, cli client.Cl
 	// Update Default rolebinding
 	err := common.UpdatePodSecurityRolebinding(cli, []string{"modelmesh", "modelmesh-controller", "odh-model-controller", "odh-prometheus-operator", "prometheus-custom"}, namespace)
 	if err != nil {
-		return err
+		return fmt.Errorf(err.Error())
 	}
 
 	// Update image parameters
@@ -66,7 +67,7 @@ func (m *ModelMeshServing) ReconcileComponent(owner metav1.Object, cli client.Cl
 		scheme, enabled)
 
 	if err != nil {
-		return err
+		return fmt.Errorf(err.Error())
 	}
 
 	// If modelmesh is deployed successfully, deploy modelmesh-monitoring
@@ -75,7 +76,7 @@ func (m *ModelMeshServing) ReconcileComponent(owner metav1.Object, cli client.Cl
 		namespace,
 		scheme, enabled)
 
-	return err
+	return fmt.Errorf(err.Error())
 }
 
 func (in *ModelMeshServing) DeepCopyInto(out *ModelMeshServing) {

--- a/components/workbenches/workbenches.go
+++ b/components/workbenches/workbenches.go
@@ -1,6 +1,7 @@
 package workbenches
 
 import (
+	"fmt"
 	"github.com/opendatahub-io/opendatahub-operator/v2/components"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/common"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/deploy"
@@ -48,7 +49,7 @@ func (w *Workbenches) ReconcileComponent(owner metav1.Object, cli client.Client,
 	// Update Default rolebinding
 	err := common.UpdatePodSecurityRolebinding(cli, []string{"notebook-controller-service-account"}, namespace)
 	if err != nil {
-		return err
+		return fmt.Errorf(err.Error())
 	}
 
 	// Update image parameters
@@ -61,7 +62,7 @@ func (w *Workbenches) ReconcileComponent(owner metav1.Object, cli client.Client,
 		namespace,
 		scheme, enabled)
 	if err != nil {
-		return err
+		return fmt.Errorf(err.Error())
 	}
 
 	// Update image parameters
@@ -72,7 +73,7 @@ func (w *Workbenches) ReconcileComponent(owner metav1.Object, cli client.Client,
 		notebookImagesPath,
 		namespace,
 		scheme, enabled)
-	return err
+	return fmt.Errorf(err.Error())
 
 }
 


### PR DESCRIPTION
## Description
- Wrong yaml files name
- add deploy promethues CM first
this should go with https://github.com/red-hat-data-services/odh-manifests/pull/409

ref: https://github.com/opendatahub-io/opendatahub-operator/issues/341

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
test with quay.io/wenzhou/opendatahub-operator:dev-0.0.62
![Screenshot from 2023-07-19 11-01-44](https://github.com/opendatahub-io/opendatahub-operator/assets/915053/56889f82-5c89-49f5-87db-4b618a2298c2)


## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
