### PR TITLE
Move to Trusty Operator in CSV example kfdef

### DIFF
--- a/config/manifests/bases/opendatahub-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/opendatahub-operator.clusterserviceversion.yaml
@@ -110,10 +110,10 @@ metadata:
                 "kustomizeConfig": {
                   "repoRef": {
                     "name": "manifests",
-                    "path": "trustyai-service"
+                    "path": "trustyai-service-operator"
                   }
                 },
-                "name": "trustyai"
+                "name": "trustyai-service-operator"
               }
             ],
             "repos": [


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
The example/default kfdef in the operator clusterserviceversion was recommending a trustyai-service installation, which will 
a) no longer work with the latest odh-manifests
and 
b) break any attempted use of the trustyai-service-operator later

This PR swaps the trustyai-service KustomizeConfig for a **trustyai-service-operator** config.

Addresses https://github.com/opendatahub-io/opendatahub-operator/issues/343

## Description
<!--- Describe your changes in detail -->
See above

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
The new kfdef aligns with the (passing) odh-manifests CI deployment

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
