### PR TITLE
Switching default value for component's enabled property to false #324

### DIFF
--- a/components/component.go
+++ b/components/component.go
@@ -8,14 +8,11 @@ import (
 
 type Component struct {
 	// enables or disables the component. A disabled component will not be installed.
-	Enabled *bool `json:"enabled,omitempty"`
+	Enabled bool `json:"enabled"`
 	// Add any other common fields across components below
 }
 
 type ComponentInterface interface {
 	ReconcileComponent(owner metav1.Object, client client.Client, scheme *runtime.Scheme,
 		enabled bool, namespace string) error
-
-	IsEnabled() *bool
-	SetEnabled(enabled bool)
 }

--- a/components/dashboard/dashboard.go
+++ b/components/dashboard/dashboard.go
@@ -21,14 +21,6 @@ type Dashboard struct {
 // Verifies that Dashboard implements ComponentInterface
 var _ components.ComponentInterface = (*Dashboard)(nil)
 
-func (d *Dashboard) IsEnabled() *bool {
-	return d.Enabled
-}
-
-func (d *Dashboard) SetEnabled(enabled bool) {
-	d.Enabled = &enabled
-}
-
 func (d *Dashboard) ReconcileComponent(owner metav1.Object, cli client.Client, scheme *runtime.Scheme, enabled bool, namespace string) error {
 
 	// TODO: Add any additional tasks if required when reconciling component

--- a/components/datasciencepipelines/datasciencepipelines.go
+++ b/components/datasciencepipelines/datasciencepipelines.go
@@ -20,12 +20,12 @@ type DataSciencePipelines struct {
 // Verifies that Dashboard implements ComponentInterface
 var _ components.ComponentInterface = (*DataSciencePipelines)(nil)
 
-func (d *DataSciencePipelines) IsEnabled() *bool {
+func (d *DataSciencePipelines) IsEnabled() bool {
 	return d.Enabled
 }
 
 func (d *DataSciencePipelines) SetEnabled(enabled bool) {
-	d.Enabled = &enabled
+	d.Enabled = enabled
 }
 
 func (d *DataSciencePipelines) ReconcileComponent(owner metav1.Object, client client.Client, scheme *runtime.Scheme, enabled bool, namespace string) error {

--- a/components/distributedworkloads/distributedworkloads.go
+++ b/components/distributedworkloads/distributedworkloads.go
@@ -21,14 +21,6 @@ type DistributedWorkloads struct {
 // Verifies that Distributed Workloads implements ComponentInterface
 var _ components.ComponentInterface = (*DistributedWorkloads)(nil)
 
-func (d *DistributedWorkloads) IsEnabled() *bool {
-	return d.Enabled
-}
-
-func (d *DistributedWorkloads) SetEnabled(enabled bool) {
-	d.Enabled = &enabled
-}
-
 func (d *DistributedWorkloads) ReconcileComponent(owner metav1.Object, client client.Client, scheme *runtime.Scheme, enabled bool, namespace string) error {
 
 	// Deploy Codeflare

--- a/components/kserve/kserve.go
+++ b/components/kserve/kserve.go
@@ -22,12 +22,12 @@ type Kserve struct {
 // Verifies that Kserve implements ComponentInterface
 var _ components.ComponentInterface = (*Kserve)(nil)
 
-func (d *Kserve) IsEnabled() *bool {
+func (d *Kserve) IsEnabled() bool {
 	return d.Enabled
 }
 
 func (d *Kserve) SetEnabled(enabled bool) {
-	d.Enabled = &enabled
+	d.Enabled = enabled
 }
 
 func (m *Kserve) ReconcileComponent(owner metav1.Object, cli client.Client, scheme *runtime.Scheme, enabled bool, namespace string) error {

--- a/components/modelmeshserving/modelmeshserving.go
+++ b/components/modelmeshserving/modelmeshserving.go
@@ -22,12 +22,12 @@ type ModelMeshServing struct {
 // Verifies that Dashboard implements ComponentInterface
 var _ components.ComponentInterface = (*ModelMeshServing)(nil)
 
-func (d *ModelMeshServing) IsEnabled() *bool {
+func (d *ModelMeshServing) IsEnabled() bool {
 	return d.Enabled
 }
 
 func (d *ModelMeshServing) SetEnabled(enabled bool) {
-	d.Enabled = &enabled
+	d.Enabled = enabled
 }
 
 func (m *ModelMeshServing) ReconcileComponent(owner metav1.Object, cli client.Client, scheme *runtime.Scheme, enabled bool, namespace string) error {

--- a/components/workbenches/workbenches.go
+++ b/components/workbenches/workbenches.go
@@ -22,12 +22,12 @@ type Workbenches struct {
 // Verifies that Dashboard implements ComponentInterface
 var _ components.ComponentInterface = (*Workbenches)(nil)
 
-func (d *Workbenches) IsEnabled() *bool {
+func (d *Workbenches) IsEnabled() bool {
 	return d.Enabled
 }
 
 func (d *Workbenches) SetEnabled(enabled bool) {
-	d.Enabled = &enabled
+	d.Enabled = enabled
 }
 
 func (m *Workbenches) ReconcileComponent(owner metav1.Object, cli client.Client, scheme *runtime.Scheme, enabled bool, namespace string) error {

--- a/controllers/dscinitialization/utils.go
+++ b/controllers/dscinitialization/utils.go
@@ -354,7 +354,6 @@ func updatefromLegacyVersion(cli client.Client) error {
 		}
 
 		// Create DataScienceCluster with no components enabled to cleanup all previous controllers
-		f := false
 		defaultDataScienceCluster := &dsc.DataScienceCluster{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       "DataScienceCluster",
@@ -366,19 +365,19 @@ func updatefromLegacyVersion(cli client.Client) error {
 			Spec: dsc.DataScienceClusterSpec{
 				Components: dsc.Components{
 					ModelMeshServing: modelmeshserving.ModelMeshServing{
-						Component: components.Component{Enabled: &f},
+						Component: components.Component{Enabled: false},
 					},
 					DataSciencePipelines: datasciencepipelines.DataSciencePipelines{
-						Component: components.Component{Enabled: &f},
+						Component: components.Component{Enabled: false},
 					},
 					Workbenches: workbenches.Workbenches{
-						Component: components.Component{Enabled: &f},
+						Component: components.Component{Enabled: false},
 					},
 					Dashboard: dashboard.Dashboard{
-						Component: components.Component{Enabled: &f},
+						Component: components.Component{Enabled: false},
 					},
 					Kserve: kserve.Kserve{
-						Component: components.Component{Enabled: &f},
+						Component: components.Component{Enabled: false},
 					},
 				},
 			},


### PR DESCRIPTION
Switching default value for component's enabled property to false 
Changing enabled from *bool to bool and simplifying/cleaning code

fixes #324

## How Has This Been Tested?
Manually tested in the cluster. The following input CR:
```yaml
apiVersion: datasciencecluster.opendatahub.io/v1alpha1
kind: DataScienceCluster
metadata:
  name: default
spec:
  components:
    dashboard:
      enabled: false
    datasciencepipelines:
      enabled: true
    kserve:
      enabled: true
```

Generates the following yaml after creation:

```yaml
apiVersion: datasciencecluster.opendatahub.io/v1alpha1
kind: DataScienceCluster
...
spec:
  components:
    dashboard:
      enabled: false
    datasciencepipelines:
      enabled: true
    kserve:
      enabled: true
    modelmeshserving:
      enabled: false
    workbenches:
      enabled: false
...
```

## Merge criteria:
- [X] The commits are squashed in a cohesive manner and have meaningful messages.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work
