### PR TITLE
Improving conditions management. Fixes #351

### DIFF
--- a/apis/dscinitialization/v1alpha1/dscinitialization_types.go
+++ b/apis/dscinitialization/v1alpha1/dscinitialization_types.go
@@ -22,23 +22,15 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// List of constants to show different  reconciliation messages and statuses.
-const (
-	ReconcileFailed           = "ReconcileFailed"
-	ReconcileInit             = "ReconcileInit"
-	ReconcileCompleted        = "ReconcileCompleted"
-	ReconcileCompletedMessage = "Reconcile completed successfully"
-)
-
 // DSCInitializationSpec defines the desired state of DSCInitialization
 type DSCInitializationSpec struct {
 	// +kubebuilder:default:=opendatahub
 	// Namespace for applications to be installed, non-configurable, default to "opendatahub"
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
-	ApplicationsNamespace string     `json:"applicationsNamespace"`
+	ApplicationsNamespace string `json:"applicationsNamespace"`
 	// Enable monitoring on specified namespace
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
-	Monitoring            Monitoring `json:"monitoring,omitempty"`
+	Monitoring Monitoring `json:"monitoring,omitempty"`
 	// Internal development useful field
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
 	ManifestsUri string `json:"manifestsUri,omitempty"`

--- a/controllers/datasciencecluster/datasciencecluster_controller.go
+++ b/controllers/datasciencecluster/datasciencecluster_controller.go
@@ -187,7 +187,9 @@ func (r *DataScienceClusterReconciler) reconcileSubComponent(instance *dsc.DataS
 	})
 	if err != nil {
 		instance = r.reportError(err, instance, "failed to update DataScienceCluster conditions before reconciling "+componentName)
-		// try to continue reconciliation
+		return instance, ctrl.Result{
+			// Retry after failure until success.
+			RequeueAfter: time.Second * 10}, err
 	}
 
 	// Reconcile component

--- a/controllers/status/status.go
+++ b/controllers/status/status.go
@@ -56,10 +56,8 @@ const (
 )
 
 const (
-	// TODO: update this list of constants with proper reasons for conditions
 	ReconcileInitiatedReason = "ReconcileInitiated"
-	AReason                  = "AReason"
-	AnotherReason            = "AnotherReason"
+	ReadySuffix              = "Ready"
 )
 
 // SetProgressingCondition sets the ProgressingCondition to True and other conditions to
@@ -107,6 +105,45 @@ func SetErrorCondition(conditions *[]conditionsv1.Condition, reason string, mess
 		Reason:  reason,
 		Message: message,
 	})
+	conditionsv1.SetStatusCondition(conditions, conditionsv1.Condition{
+		Type:    conditionsv1.ConditionAvailable,
+		Status:  corev1.ConditionFalse,
+		Reason:  reason,
+		Message: message,
+	})
+	conditionsv1.SetStatusCondition(conditions, conditionsv1.Condition{
+		Type:    conditionsv1.ConditionProgressing,
+		Status:  corev1.ConditionFalse,
+		Reason:  reason,
+		Message: message,
+	})
+	conditionsv1.SetStatusCondition(conditions, conditionsv1.Condition{
+		Type:    conditionsv1.ConditionDegraded,
+		Status:  corev1.ConditionTrue,
+		Reason:  reason,
+		Message: message,
+	})
+	conditionsv1.SetStatusCondition(conditions, conditionsv1.Condition{
+		Type:    conditionsv1.ConditionUpgradeable,
+		Status:  corev1.ConditionUnknown,
+		Reason:  reason,
+		Message: message,
+	})
+}
+
+func SetComponentCondition(conditions *[]conditionsv1.Condition, component string, reason string, message string, status corev1.ConditionStatus) {
+	condtype := component + ReadySuffix
+	conditionsv1.SetStatusCondition(conditions, conditionsv1.Condition{
+		Type:    conditionsv1.ConditionType(condtype),
+		Status:  status,
+		Reason:  reason,
+		Message: message,
+	})
+}
+
+func RemoveComponentCondition(conditions *[]conditionsv1.Condition, component string) {
+	condtype := component + ReadySuffix
+	conditionsv1.RemoveStatusCondition(conditions, conditionsv1.ConditionType(condtype))
 }
 
 // SetCompleteCondition sets the ConditionReconcileComplete to True and other Conditions

--- a/controllers/status/status.go
+++ b/controllers/status/status.go
@@ -56,8 +56,7 @@ const (
 )
 
 const (
-	ReconcileInitiatedReason = "ReconcileInitiated"
-	ReadySuffix              = "Ready"
+	ReadySuffix = "Ready"
 )
 
 // SetProgressingCondition sets the ProgressingCondition to True and other conditions to


### PR DESCRIPTION
Adding conditions for each installed component. 
Properly setting values for conditions during reconciliation.
Fixes #351 

## How Has This Been Tested?
Manually tested in the cluster

The following CR:
```yaml
apiVersion: datasciencecluster.opendatahub.io/v1alpha1
kind: DataScienceCluster
metadata:
  name: default
spec:
  components:
    dashboard:
      enabled: true
    datasciencepipelines:
      enabled: true
    distributedWorkloads:
      enabled: false
    kserve:
      enabled: true
    modelmeshserving:
      enabled: false
    workbenches:
      enabled: true
```

Results in the following conditions after reconciliation is complete:

<img width="1202" alt="Screenshot 2023-07-21 at 3 46 55 PM" src="https://github.com/opendatahub-io/opendatahub-operator/assets/457009/88d3f79d-2f29-476f-b568-fe008e1a1ad4">


## Merge criteria:
- [X] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work
