### PR TITLE
Update: rbac group, kubebuilder, Owns order and add  recorder

### DIFF
--- a/apis/dscinitialization/v1alpha1/dscinitialization_types.go
+++ b/apis/dscinitialization/v1alpha1/dscinitialization_types.go
@@ -35,12 +35,14 @@ type DSCInitializationSpec struct {
 	// +kubebuilder:default:=opendatahub
 	// Namespace for applications to be installed, non-configurable, default to "opendatahub"
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
-	ApplicationsNamespace string     `json:"applicationsNamespace"`
+	ApplicationsNamespace string `json:"applicationsNamespace"`
 	// Enable monitoring on specified namespace
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
-	Monitoring            Monitoring `json:"monitoring,omitempty"`
+	// +optional
+	Monitoring Monitoring `json:"monitoring,omitempty"`
 	// Internal development useful field
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
+	// +optional
 	ManifestsUri string `json:"manifestsUri,omitempty"`
 }
 

--- a/bundle/manifests/opendatahub-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/opendatahub-operator.clusterserviceversion.yaml
@@ -9,9 +9,6 @@ metadata:
           "kind": "OdhQuickStart",
           "metadata": {
             "annotations": {
-              "internal.config.kubernetes.io/previousKinds": "OdhQuickStart",
-              "internal.config.kubernetes.io/previousNames": "create-jupyter-notebook",
-              "internal.config.kubernetes.io/previousNamespaces": "default",
               "opendatahub.io/categories": "Getting started,Notebook environments"
             },
             "labels": {
@@ -253,6 +250,28 @@ spec:
       clusterPermissions:
       - rules:
         - apiGroups:
+          - '*'
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        - apiGroups:
+          - addons.managed.openshift.io
+          resources:
+          - addons
+          verbs:
+          - get
+          - list
+        - apiGroups:
+          - apps
+          resources:
+          - daemonsets
+          - deployments
+          - replicasets
+          - statefulsets
+          verbs:
+          - '*'
+        - apiGroups:
           - ""
           resources:
           - configmaps
@@ -280,28 +299,6 @@ spec:
           - patch
           - update
           - watch
-        - apiGroups:
-          - '*'
-          resources:
-          - '*'
-          verbs:
-          - '*'
-        - apiGroups:
-          - addons.managed.openshift.io
-          resources:
-          - addons
-          verbs:
-          - get
-          - list
-        - apiGroups:
-          - apps
-          resources:
-          - daemonsets
-          - deployments
-          - replicasets
-          - statefulsets
-          verbs:
-          - '*'
         - apiGroups:
           - datasciencecluster.opendatahub.io
           resources:

--- a/components/kserve/kserve.go
+++ b/components/kserve/kserve.go
@@ -34,7 +34,7 @@ func (d *Kserve) SetEnabled(enabled bool) {
 	d.Enabled = enabled
 }
 
-func (m *Kserve) ReconcileComponent(owner metav1.Object, cli client.Client, scheme *runtime.Scheme, enabled bool, namespace string) error {
+func (d *Kserve) ReconcileComponent(owner metav1.Object, cli client.Client, scheme *runtime.Scheme, enabled bool, namespace string) error {
 
 	// Update Default rolebinding
 	err := common.UpdatePodSecurityRolebinding(cli, []string{"kserve-controller-manager"}, namespace)

--- a/components/modelmeshserving/modelmeshserving.go
+++ b/components/modelmeshserving/modelmeshserving.go
@@ -19,19 +19,19 @@ type ModelMeshServing struct {
 	components.Component `json:""`
 }
 
-func (d *ModelMeshServing) GetComponentName() string {
+func (m *ModelMeshServing) GetComponentName() string {
 	return ComponentName
 }
 
 // Verifies that Dashboard implements ComponentInterface
 var _ components.ComponentInterface = (*ModelMeshServing)(nil)
 
-func (d *ModelMeshServing) IsEnabled() bool {
-	return d.Enabled
+func (m *ModelMeshServing) IsEnabled() bool {
+	return m.Enabled
 }
 
-func (d *ModelMeshServing) SetEnabled(enabled bool) {
-	d.Enabled = enabled
+func (m *ModelMeshServing) SetEnabled(enabled bool) {
+	m.Enabled = enabled
 }
 
 func (m *ModelMeshServing) ReconcileComponent(owner metav1.Object, cli client.Client, scheme *runtime.Scheme, enabled bool, namespace string) error {

--- a/components/workbenches/workbenches.go
+++ b/components/workbenches/workbenches.go
@@ -19,22 +19,22 @@ type Workbenches struct {
 	components.Component `json:""`
 }
 
-func (d *Workbenches) GetComponentName() string {
+func (w *Workbenches) GetComponentName() string {
 	return ComponentName
 }
 
 // Verifies that Dashboard implements ComponentInterface
 var _ components.ComponentInterface = (*Workbenches)(nil)
 
-func (d *Workbenches) IsEnabled() bool {
-	return d.Enabled
+func (w *Workbenches) IsEnabled() bool {
+	return w.Enabled
 }
 
-func (d *Workbenches) SetEnabled(enabled bool) {
-	d.Enabled = enabled
+func (w *Workbenches) SetEnabled(enabled bool) {
+	w.Enabled = enabled
 }
 
-func (m *Workbenches) ReconcileComponent(owner metav1.Object, cli client.Client, scheme *runtime.Scheme, enabled bool, namespace string) error {
+func (w *Workbenches) ReconcileComponent(owner metav1.Object, cli client.Client, scheme *runtime.Scheme, enabled bool, namespace string) error {
 	// Update Default rolebinding
 	err := common.UpdatePodSecurityRolebinding(cli, []string{"notebook-controller-service-account"}, namespace)
 	if err != nil {

--- a/config/crd/bases/kfdef.apps.kubeflow.org_kfdefs.yaml
+++ b/config/crd/bases/kfdef.apps.kubeflow.org_kfdefs.yaml
@@ -1,0 +1,189 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.9.2
+    operatorframework.io/required-by: "opendatahub-operator.v0.0.7"
+    operatorframework.io/owning-operator: ""
+  creationTimestamp: null
+  name: kfdefs.kfdef.apps.kubeflow.org
+spec:
+  group: kfdef.apps.kubeflow.org
+  names:
+    kind: KfDef
+    listKind: KfDefList
+    plural: kfdefs
+    singular: kfdef
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: KfDef is the Schema for the kfdefs API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KfDefSpec defines the desired state of KfDef
+            properties:
+              applications:
+                items:
+                  description: Application defines an application to install
+                  properties:
+                    kustomizeConfig:
+                      properties:
+                        overlays:
+                          items:
+                            type: string
+                          type: array
+                        parameters:
+                          items:
+                            properties:
+                              name:
+                                type: string
+                              value:
+                                type: string
+                            type: object
+                          type: array
+                        repoRef:
+                          properties:
+                            name:
+                              type: string
+                            path:
+                              type: string
+                          type: object
+                      type: object
+                    name:
+                      type: string
+                  type: object
+                type: array
+              plugins:
+                items:
+                  description: Plugin can be used to customize the generation and
+                    deployment of Kubeflow
+                  properties:
+                    apiVersion:
+                      description: 'APIVersion defines the versioned schema of this
+                        representation of an object. Servers should convert recognized
+                        schemas to the latest internal value, and may reject unrecognized
+                        values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                      type: string
+                    kind:
+                      description: 'Kind is a string value representing the REST resource
+                        this object represents. Servers may infer this from the endpoint
+                        the client submits requests to. Cannot be updated. In CamelCase.
+                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                      type: string
+                    metadata:
+                      type: object
+                    spec:
+                      type: object
+                  type: object
+                type: array
+              repos:
+                items:
+                  description: Repo provides information about a repository providing
+                    config (e.g. kustomize packages, Deployment manager configs, etc...)
+                  properties:
+                    name:
+                      description: Name is a name to identify the repository.
+                      type: string
+                    uri:
+                      description: 'URI where repository can be obtained. Can use
+                        any URI understood by go-getter: https://github.com/hashicorp/go-getter/blob/master/README.md#installation-and-usage'
+                      type: string
+                  type: object
+                type: array
+              secrets:
+                items:
+                  description: Secret provides information about secrets needed to
+                    configure Kubeflow. Secrets can be provided via references.
+                  properties:
+                    name:
+                      type: string
+                    secretSource:
+                      properties:
+                        envSource:
+                          properties:
+                            name:
+                              type: string
+                          type: object
+                        literalSource:
+                          properties:
+                            value:
+                              type: string
+                          type: object
+                      type: object
+                  type: object
+                type: array
+              version:
+                type: string
+            type: object
+          status:
+            description: KfDefStatus defines the observed state of KfDef
+            properties:
+              conditions:
+                items:
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      format: date-time
+                      type: string
+                    lastUpdateTime:
+                      description: The last time this condition was updated.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of deployment condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              reposCache:
+                description: ReposCache is used to cache information about local caching
+                  of the URIs.
+                items:
+                  properties:
+                    localPath:
+                      type: string
+                    name:
+                      type: string
+                  required:
+                  - localPath
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -6,6 +6,28 @@ metadata:
   name: controller-manager-role
 rules:
 - apiGroups:
+  - '*'
+  resources:
+  - '*'
+  verbs:
+  - '*'
+- apiGroups:
+  - addons.managed.openshift.io
+  resources:
+  - addons
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - apps
+  resources:
+  - daemonsets
+  - deployments
+  - replicasets
+  - statefulsets
+  verbs:
+  - '*'
+- apiGroups:
   - ""
   resources:
   - configmaps
@@ -33,28 +55,6 @@ rules:
   - patch
   - update
   - watch
-- apiGroups:
-  - '*'
-  resources:
-  - '*'
-  verbs:
-  - '*'
-- apiGroups:
-  - addons.managed.openshift.io
-  resources:
-  - addons
-  verbs:
-  - get
-  - list
-- apiGroups:
-  - apps
-  resources:
-  - daemonsets
-  - deployments
-  - replicasets
-  - statefulsets
-  verbs:
-  - '*'
 - apiGroups:
   - datasciencecluster.opendatahub.io
   resources:

--- a/controllers/dscinitialization/dscinitialization_controller.go
+++ b/controllers/dscinitialization/dscinitialization_controller.go
@@ -42,6 +42,7 @@ import (
 	dsci "github.com/opendatahub-io/opendatahub-operator/v2/apis/dscinitialization/v1alpha1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/controllers/status"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/deploy"
+	"k8s.io/client-go/tools/record"
 )
 
 // DSCInitializationReconciler reconciles a DSCInitialization object
@@ -49,6 +50,7 @@ type DSCInitializationReconciler struct {
 	client.Client
 	Scheme                *runtime.Scheme
 	Log                   logr.Logger
+	Recorder              record.EventRecorder
 	ApplicationsNamespace string
 }
 
@@ -59,7 +61,7 @@ type DSCInitializationReconciler struct {
 // +kubebuilder:rbac:groups=dscinitialization.opendatahub.io,resources=dscinitializations/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=dscinitialization.opendatahub.io,resources=dscinitializations/finalizers,verbs=update
 // +kubebuilder:rbac:groups=networking.k8s.io,resources=networkpolicies,verbs=get;list;watch;create;update;patch
-// +kubebuilder:rbac:groups="",resources=services;namespaces;serviceaccounts;secrets;configmaps,verbs=get;list;watch;create;update;patch
+// +kubebuilder:rbac:groups="core",resources=services;namespaces;serviceaccounts;secrets;configmaps,verbs=get;list;watch;create;update;patch
 // +kubebuilder:rbac:groups=addons.managed.openshift.io,resources=addons,verbs=get;list
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=rolebindings;roles;clusterrolebindings;clusterroles,verbs=get;list;watch;create;update;patch
 
@@ -69,10 +71,13 @@ func (r *DSCInitializationReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	instance := &dsci.DSCInitialization{}
 	// Only apply reconcile logic to 'default' instance of DataScienceInitialization
 	err := r.Client.Get(ctx, types.NamespacedName{Name: "default"}, instance)
-	if err != nil && apierrs.IsNotFound(err) {
-		return ctrl.Result{}, nil
-	} else if err != nil {
+	if err != nil {
+		if apierrs.IsNotFound(err) {
+			// DataScienceInitialization instance not found.
+			return ctrl.Result{}, nil
+		}
 		r.Log.Error(err, "Failed to retrieve DSCInitialization resource.", "DSCInitialization", req.Namespace, "Request.Name", req.Name)
+		r.Recorder.Eventf(instance, corev1.EventTypeWarning, "DSCInitializationReconcileError", "Failed to retrieve DSCInitialization instance")
 		return ctrl.Result{}, err
 	}
 
@@ -86,6 +91,8 @@ func (r *DSCInitializationReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		err = r.Client.Status().Update(ctx, instance)
 		if err != nil {
 			r.Log.Error(err, "Failed to add conditions to status of DSCInitialization resource.", "DSCInitialization", req.Namespace, "Request.Name", req.Name)
+			r.Recorder.Eventf(instance, corev1.EventTypeWarning, "DSCInitializationReconcileError",
+				"%s for instance %s", message, instance.Name)
 			return reconcile.Result{}, err
 		}
 	}
@@ -102,6 +109,7 @@ func (r *DSCInitializationReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	err = deploy.DownloadManifests(instance.Spec.ManifestsUri)
 	if err != nil {
 		r.Log.Error(err, "Failed to download and unpack manifests.", "ManifestsURI", instance.Spec.ManifestsUri)
+		r.Recorder.Eventf(instance, corev1.EventTypeWarning, "DSCInitializationReconcileError", "Failed to download and unpack manifests")
 		return reconcile.Result{}, err
 	}
 
@@ -127,6 +135,7 @@ func (r *DSCInitializationReconciler) Reconcile(ctx context.Context, req ctrl.Re
 			r.ApplicationsNamespace, r.Scheme, true)
 		if err != nil {
 			r.Log.Error(err, "Failed to apply osd specific configs from manifests", "Manifests path", deploy.DefaultManifestPath+"/osd-configs")
+			r.Recorder.Eventf(instance, corev1.EventTypeWarning, "DSCInitializationReconcileError", "Failed to apply "+deploy.DefaultManifestPath+"/osd-configs")
 			return reconcile.Result{}, err
 		}
 	}
@@ -140,7 +149,6 @@ func (r *DSCInitializationReconciler) Reconcile(ctx context.Context, req ctrl.Re
 				// no need to log error as it was already logged in configureManagedMonitoring
 				return reconcile.Result{}, err
 			}
-
 		} else {
 			// TODO: ODH specific monitoring logic
 			r.Log.Info("Monitoring enabled, won't apply changes", "cluster", "Self-Managed  Mode")
@@ -169,6 +177,7 @@ func (r *DSCInitializationReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	})
 	if err != nil {
 		r.Log.Error(err, "failed to update DSCInitialization status after successfuly completed reconciliation")
+		r.Recorder.Eventf(instance, corev1.EventTypeWarning, "DSCInitializationReconcileError", "Failed to update DSCInitialization status")
 	}
 	return ctrl.Result{}, nil
 }
@@ -177,6 +186,7 @@ func (r *DSCInitializationReconciler) Reconcile(ctx context.Context, req ctrl.Re
 func (r *DSCInitializationReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&dsci.DSCInitialization{}, builder.WithPredicates(singletonPredicate)).
+		Owns(&corev1.Namespace{}).
 		Owns(&corev1.Secret{}).
 		Owns(&corev1.ConfigMap{}).
 		Owns(&netv1.NetworkPolicy{}).
@@ -184,10 +194,11 @@ func (r *DSCInitializationReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&authv1.RoleBinding{}).
 		Owns(&authv1.ClusterRole{}).
 		Owns(&authv1.ClusterRoleBinding{}).
-		Owns(&corev1.Namespace{}).
-		Owns(&corev1.Pod{}).
 		Owns(&appsv1.Deployment{}).
 		Owns(&appsv1.ReplicaSet{}).
+		Owns(&corev1.Pod{}).
+		Owns(&corev1.ServiceAccount{}).
+		Owns(&corev1.Service{}).
 		// this predicates prevents meaningless reconciliations from being triggered
 		WithEventFilter(predicate.Or(predicate.GenerationChangedPredicate{}, predicate.LabelChangedPredicate{})).
 		Complete(r)

--- a/main.go
+++ b/main.go
@@ -127,6 +127,7 @@ func main() {
 		Client:                mgr.GetClient(),
 		Scheme:                mgr.GetScheme(),
 		Log:                   ctrl.Log.WithName("controllers").WithName("DSCInitialization"),
+		Recorder:              mgr.GetEventRecorderFor("dscinitialization-controller"),
 		ApplicationsNamespace: dscApplicationsNamespace,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "DSCInitiatlization")


### PR DESCRIPTION
## Description
- set rbac for "core" group not empty, more explict
- set Option for fileds are not required
- reorder Owns() to have depended resource high prio and add ServiceAccount and Service
- add recorder for dscinitialization to get events





## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
build quay.io/wenzhou/opendatahub-operator-catalog:v2.0.1

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
