### PR TITLE
Update logger and set to level4

### DIFF
--- a/bundle/manifests/opendatahub-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/opendatahub-operator.clusterserviceversion.yaml
@@ -1400,6 +1400,7 @@ spec:
                 - --health-probe-bind-address=:8081
                 - --metrics-bind-address=127.0.0.1:8080
                 - --leader-elect
+                - --logLevel=2
                 command:
                 - /manager
                 image: REPLACE_IMAGE:latest

--- a/components/component.go
+++ b/components/component.go
@@ -1,6 +1,7 @@
 package components
 
 import (
+	"github.com/go-logr/logr"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -13,8 +14,14 @@ type Component struct {
 }
 
 type ComponentInterface interface {
-	ReconcileComponent(owner metav1.Object, client client.Client, scheme *runtime.Scheme,
-		enabled bool, namespace string) error
+	ReconcileComponent(
+		owner metav1.Object,
+		client client.Client,
+		scheme *runtime.Scheme,
+		enabled bool,
+		namespace string,
+		logger logr.Logger,
+	) error
 	GetComponentName() string
 	SetImageParamsMap(imageMap map[string]string) map[string]string
 }

--- a/components/dashboard/dashboard.go
+++ b/components/dashboard/dashboard.go
@@ -4,6 +4,9 @@ import (
 	"fmt"
 
 	"context"
+	"strings"
+
+	"github.com/go-logr/logr"
 	"github.com/opendatahub-io/opendatahub-operator/v2/components"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/common"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/deploy"
@@ -11,7 +14,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"strings"
 )
 
 const (
@@ -49,78 +51,91 @@ func (d *Dashboard) GetComponentName() string {
 // Verifies that Dashboard implements ComponentInterface
 var _ components.ComponentInterface = (*Dashboard)(nil)
 
-func (d *Dashboard) ReconcileComponent(owner metav1.Object, cli client.Client, scheme *runtime.Scheme, enabled bool, namespace string) error {
+func (d *Dashboard) ReconcileComponent(
+	owner metav1.Object,
+	cli client.Client,
+	scheme *runtime.Scheme,
+	enabled bool,
+	namespace string,
+	logger logr.Logger,
+) error {
 
 	// TODO: Add any additional tasks if required when reconciling component
-	// Update Default rolebinding
+
 	platform, err := deploy.GetPlatform(cli)
 	if err != nil {
+		logger.Error(err, "Failed to determinate which platform running on")
 		return err
 	}
+
+	// Update Default rolebinding
+	var sa []string
 	if platform == deploy.OpenDataHub {
-		err := common.UpdatePodSecurityRolebinding(cli, []string{"odh-dashboard"}, namespace)
-		if err != nil {
-			return err
-		}
+		sa = []string{"odh-dashboard"}
+		err = common.UpdatePodSecurityRolebinding(cli, sa, namespace)
 	} else {
-		err := common.UpdatePodSecurityRolebinding(cli, []string{"rhods-dashboard"}, namespace)
-		if err != nil {
-			return err
-		}
+		sa = []string{"rhods-dashboard"}
+		err = common.UpdatePodSecurityRolebinding(cli, sa, namespace)
+	}
+	if err != nil {
+		logger.Error(err, "Failed to update rolebinding for serviceaccount "+fmt.Sprint(sa)+" in "+namespace)
+		return err
 	}
 
 	// Apply RHODS specific configs
 	if platform != deploy.OpenDataHub {
-		// Replace admin group
+		// Replace admin groups
 		if platform == deploy.SelfManagedRhods {
 			err = common.ReplaceStringsInFile(PathODHDashboardConfig+"/odhdashboardconfig.yaml", map[string]string{
 				"<admin_groups>": "rhods-admins",
 			})
-			if err != nil {
-				return err
-			}
 		} else {
 			err = common.ReplaceStringsInFile(PathODHDashboardConfig+"/odhdashboardconfig.yaml", map[string]string{
 				"<admin_groups>": "dedicated-admins",
 			})
-			if err != nil {
-				return err
-			}
 		}
+		if err != nil {
+			logger.Error(err, "Failed to replace admin_groups in manifests for "+string(platform))
+			return err
+		}
+
 		// Create ODHDashboardConfig if it doesn't exist already
 		err = deploy.DeployManifestsFromPath(owner, cli, ComponentNameSupported,
 			PathODHDashboardConfig,
 			namespace,
-			scheme, enabled)
+			scheme, enabled, logger)
 		if err != nil {
-			return fmt.Errorf("failed to set dashboard config from %s: %v", PathODHDashboardConfig, err)
+			logger.Error(err, "Failed to set dashboard config", "location", PathODHDashboardConfig)
+			return err
 		}
 
-		// Apply modelserving config
+		// Apply OVMS config
 		err = deploy.DeployManifestsFromPath(owner, cli, ComponentNameSupported,
 			PathOVMS,
 			namespace,
-			scheme, enabled)
+			scheme, enabled, logger)
 		if err != nil {
-			return fmt.Errorf("failed to set dashboard OVMS from %s: %v", PathOVMS, err)
+			logger.Error(err, "Failed to set dashboard OVMS", "location", PathOVMS)
+			return err
 		}
 
 		// Apply anaconda config
 		err = common.CreateSecret(cli, "anaconda-ce-access", namespace)
 		if err != nil {
-			return fmt.Errorf("failed to create access-secret for anaconda: %v", err)
+			return fmt.Errorf("Failed to create access-secret for anaconda: %v", err)
 		}
 		err = deploy.DeployManifestsFromPath(owner, cli, ComponentNameSupported,
 			PathAnaconda,
 			namespace,
-			scheme, enabled)
+			scheme, enabled, logger)
 		if err != nil {
-			return fmt.Errorf("failed to deploy anaconda resources from %s: %v", PathAnaconda, err)
+			return fmt.Errorf("Failed to deploy anaconda resources from %s: %v", PathAnaconda, err)
 		}
 	}
 
 	// Update image parameters
 	if err := deploy.ApplyImageParams(Path, imageParamMap); err != nil {
+		logger.Error(err, "Failed to replace image from params.env", "error", err.Error())
 		return err
 	}
 
@@ -129,8 +144,9 @@ func (d *Dashboard) ReconcileComponent(owner metav1.Object, cli client.Client, s
 		err = deploy.DeployManifestsFromPath(owner, cli, ComponentName,
 			Path,
 			namespace,
-			scheme, enabled)
+			scheme, enabled, logger)
 		if err != nil {
+			logger.Error(err, "Failed to set dashboard base config", "location", Path)
 			return err
 		}
 	} else {
@@ -138,8 +154,9 @@ func (d *Dashboard) ReconcileComponent(owner metav1.Object, cli client.Client, s
 		err = deploy.DeployManifestsFromPath(owner, cli, ComponentNameSupported,
 			PathSupported,
 			namespace,
-			scheme, enabled)
+			scheme, enabled, logger)
 		if err != nil {
+			logger.Error(err, "Failed to set dashboard overĺay authentication", "location", ComponentNameSupported)
 			return err
 		}
 	}
@@ -150,15 +167,17 @@ func (d *Dashboard) ReconcileComponent(owner metav1.Object, cli client.Client, s
 		err = deploy.DeployManifestsFromPath(owner, cli, ComponentNameSupported,
 			PathISVSM,
 			namespace,
-			scheme, enabled)
+			scheme, enabled, logger)
 		if err != nil {
-			return fmt.Errorf("failed to set dashboard ISV from %s: %v", PathISVSM, err)
+			logger.Error(err, "Failed to set dashboard ISV", "location", PathISVSM)
+			return err
 		}
 		// ConsoleLink handling
 		consoleRoute := &routev1.Route{}
 		err = cli.Get(context.TODO(), client.ObjectKey{Name: NameConsoleLink, Namespace: NamespaceConsoleLink}, consoleRoute)
 		if err != nil {
-			return fmt.Errorf("error getting console route URL : %v", err)
+			logger.Error(err, "Failed to get console route URL", "name", NameConsoleLink, "namespace", NamespaceConsoleLink)
+			return err
 		}
 		domainIndex := strings.Index(consoleRoute.Spec.Host, ".")
 		consolelinkDomain := consoleRoute.Spec.Host[domainIndex+1:]
@@ -166,23 +185,25 @@ func (d *Dashboard) ReconcileComponent(owner metav1.Object, cli client.Client, s
 			"<rhods-dashboard-url>": "https://rhods-dashboard-" + namespace + "." + consolelinkDomain,
 		})
 		if err != nil {
-			return fmt.Errorf("error replacing with correct dashboard url for ConsoleLink: %v", err)
+			logger.Error(err, "Failed to replace consolelink in manifests")
+			return err
 		}
 		err = deploy.DeployManifestsFromPath(owner, cli, ComponentNameSupported,
 			PathConsoleLink,
 			namespace,
-			scheme, enabled)
+			scheme, enabled, logger)
 		if err != nil {
-			return fmt.Errorf("failed to set dashboard consolelink from %s", PathConsoleLink)
+			logger.Error(err, "Failed to set dashboard consolelink", "location", PathConsoleLink)
+			return err
 		}
 		return err
 	case deploy.ManagedRhods:
 		err = deploy.DeployManifestsFromPath(owner, cli, ComponentNameSupported,
 			PathISVAddOn,
 			namespace,
-			scheme, enabled)
+			scheme, enabled, logger)
 		if err != nil {
-			return fmt.Errorf("failed to set dashboard ISV from %s: %v", PathISVAddOn, err)
+			return fmt.Errorf("Failed to set dashboard ISV from %s: %v", PathISVAddOn, err)
 		}
 		// ConsoleLink handling
 		consoleRoute := &routev1.Route{}
@@ -196,14 +217,16 @@ func (d *Dashboard) ReconcileComponent(owner metav1.Object, cli client.Client, s
 			"<rhods-dashboard-url>": "https://rhods-dashboard-" + namespace + "." + consolelinkDomain,
 		})
 		if err != nil {
-			return fmt.Errorf("Error replacing with correct dashboard url for ConsoleLink: %v", err)
+			logger.Error(err, "Failed to replace consolelink in manifests")
+			return err
 		}
 		err = deploy.DeployManifestsFromPath(owner, cli, ComponentNameSupported,
 			PathConsoleLink,
 			namespace,
-			scheme, enabled)
+			scheme, enabled, logger)
 		if err != nil {
-			return fmt.Errorf("failed to set dashboard consolelink from %s", PathConsoleLink)
+			logger.Error(err, "Failed to set dashboardconsolelink", "location", PathConsoleLink)
+			return err
 		}
 		return err
 	default:

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -14,3 +14,4 @@ spec:
         - "--health-probe-bind-address=:8081"
         - "--metrics-bind-address=127.0.0.1:8080"
         - "--leader-elect"
+        - "--logLevel=2"

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -33,7 +33,7 @@ func UpdatePodSecurityRolebinding(cli client.Client, serviceAccountsList []strin
 	return cli.Update(context.TODO(), foundRoleBinding)
 }
 
-func subjectExistInRoleBinding(subjectList []authv1.Subject, serviceAccountName, namespace string) bool {
+func subjectExistInRoleBinding(subjectList []authv1.Subject, serviceAccountName string, namespace string) bool {
 	for _, subject := range subjectList {
 		if subject.Name == serviceAccountName && subject.Namespace == namespace {
 			return true

--- a/pkg/deploy/setup.go
+++ b/pkg/deploy/setup.go
@@ -22,7 +22,7 @@ const (
 
 type Platform string
 
-func isSelfManaged(cli client.Client) (Platform, error) {
+func checkSelfManaged(cli client.Client) (Platform, error) {
 	clusterCsvs := &ofapi.ClusterServiceVersionList{}
 	err := cli.List(context.TODO(), clusterCsvs)
 	if err != nil {
@@ -41,7 +41,8 @@ func isSelfManaged(cli client.Client) (Platform, error) {
 	}
 	return "", err
 }
-func isManagedRHODS(cli client.Client) (Platform, error) {
+
+func checkManagedRHODS(cli client.Client) (Platform, error) {
 	addonCRD := &apiextv1.CustomResourceDefinition{}
 
 	err := cli.Get(context.TODO(), client.ObjectKey{Name: "addons.managed.openshift.io"}, addonCRD)
@@ -66,11 +67,11 @@ func isManagedRHODS(cli client.Client) (Platform, error) {
 
 func GetPlatform(cli client.Client) (Platform, error) {
 	// First check if its addon installation
-	platform, err := isManagedRHODS(cli)
+	platform, err := checkManagedRHODS(cli)
 	if err == nil && platform == ManagedRhods {
 		return platform, nil
 	}
 
 	// return self-managed platform
-	return isSelfManaged(cli)
+	return checkSelfManaged(cli)
 }


### PR DESCRIPTION
## Description

- as part of ref: https://github.com/opendatahub-io/opendatahub-operator/issues/368
- but this wont suspend Warnings from kustomization.
- change wording for "Updating manifests..." to "Reconciling odh-dashboard from manifests:"
- update `secGenLog`
- change previous zap.Log from `deployment` true to false 
- rename function isSelfManaged to checkSelfManaged
- rename function isManagedRHODS to checkManagedRHODS

usages:
- can set log level in CSV as args to container
- change default level in main.go to build local `manager`

## new updated test result:
default (as loglevel 2)
```

{"level":"info","ts":"2023-08-04T16:14:01Z","msg":"Starting workers","controller":"datasciencecluster","controllerGroup":"datasciencecluster.opendatahub.io","controllerKind":"DataScienceCluster","worker count":1}
{"level":"info","ts":"2023-08-04T16:14:01Z","msg":"Starting workers","controller":"SecretGenerator","controllerGroup":"","controllerKind":"Secret","worker count":1}
# Warning: 'bases' is deprecated. Please use 'resources' instead. Run 'kustomize edit fix' to update your Kustomization automatically.
# Warning: 'bases' is deprecated. Please use 'resources' instead. Run 'kustomize edit fix' to update your Kustomization automatically.
# Warning: 'vars' is deprecated. Please use 'replacements' instead. [EXPERIMENTAL] Run 'kustomize edit fix' to update your Kustomization automatically.
```
set to loglevel 0
```
{"level":"info","ts":"2023-08-04T16:01:01Z","msg":"Starting workers","controller":"SecretGenerator","controllerGroup":"","controllerKind":"Secret","worker count":1}
{"level":"info","ts":"2023-08-04T16:01:01Z","msg":"Starting workers","controller":"datasciencecluster","controllerGroup":"datasciencecluster.opendatahub.io","controllerKind":"DataScienceCluster","worker count":1}
{"level":"info","ts":"2023-08-04T16:01:01Z","logger":"controllers.DataScienceCluster","msg":"Reconciling DataScienceCluster resources","Request.Namespace":"","Request.Name":"default"}
{"level":"info","ts":"2023-08-04T16:01:01Z","msg":"Starting workers","controller":"dscinitialization","controllerGroup":"dscinitialization.opendatahub.io","controllerKind":"DSCInitialization","worker count":1}
{"level":"info","ts":"2023-08-04T16:01:01Z","logger":"controllers.DSCInitialization","msg":"Reconciling DSCInitialization.","DSCInitialization":"","Request.Name":"default"}
{"level":"info","ts":"2023-08-04T16:01:01Z","logger":"controllers.DataScienceCluster","msg":"Reconcile odh-dashboard"}
{"level":"info","ts":"2023-08-04T16:01:04Z","logger":"controllers.DataScienceCluster","msg":"Reconciling odh-dashboard from manifests: /opt/manifests/odh-dashboard/base"}
# Warning: 'bases' is deprecated. Please use 'resources' instead. Run 'kustomize edit fix' to update your Kustomization automatically.
```

can prints more info , e.g 
`Reconciling odh-dashboard from manifests: /opt/manifests/odh-dashboard/base"}`
which are called by `r.Log.Info()`

as for error, they are the same_
`{"level":"error","ts":"2023-08-04T16:14:43Z","logger":"controllers.DataScienceCluster","msg":"failed to reconcile codeflare on DataScienceCluster","instance.Name":"default","error":"no matches for kind \"InstaScale\" in version \"codeflare.codeflare.dev/v1alpha1\"","stacktrace":"github.com/opendatahub-io/opendatahub-operator/v2/controllers/datasciencecluster.`

## Updated test result:
**When set to logLevel=2 with least printout**
![Screenshot from 2023-08-02 19-09-53](https://github.com/opendatahub-io/opendatahub-operator/assets/915053/dea4279a-a2ad-4bf1-a71a-acf71f72e05e)

**When set to logLevel=0 with Info printout**
![Screenshot from 2023-08-02 19-11-11](https://github.com/opendatahub-io/opendatahub-operator/assets/915053/83832848-a245-4269-ad8e-ddb5b7776d2f)

**When set to logLevel=1, previous r.Log.Info() change to debug level**
![Screenshot from 2023-08-02 19-12-11](https://github.com/opendatahub-io/opendatahub-operator/assets/915053/f0101053-f1d2-45b1-b7fa-8ad15b7604cd)


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
After 
![Screenshot from 2023-08-01 18-00-04](https://github.com/opendatahub-io/opendatahub-operator/assets/915053/ef57b445-c76b-4115-870b-2ee7238879fe)


^INFO of DSCI DSC are suspended.  Updating manifests as INFO

Before 
![Screenshot from 2023-07-25 17-00-31](https://github.com/opendatahub-io/opendatahub-operator/assets/915053/5d1372d4-c9ba-4cdb-af23-cdf00b962d15)

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
