### PR TITLE
Add github action to import GH issue to Jira

### DIFF
--- a/.github/workflows/gh-to-jira.yaml
+++ b/.github/workflows/gh-to-jira.yaml
@@ -1,0 +1,80 @@
+name: Create Jira Issue from GH Release
+run-name: GH Release to Jira.
+on:
+  workflow_dispatch:
+    inputs:
+      component:
+        default: 'Data Science Pipelines'
+        description: 'ODH Component'
+        required: true
+      target_release:
+        description: 'Target Downstream Release'
+        required: true
+      gh_org:
+        default: 'opendatahub-io'
+        description: 'Upstream GH Org'
+        required: true
+      repos:
+        default: |
+          [
+            {"repo_name":"opendatahub-operator","target_release":"UPDATE","previous_release":"UPDATE"},
+            {"repo_name":"odh-manifests","target_release":"UPDATE","previous_release":"UPDATE"}
+          ]
+        description: 'Upstream Source Repos & Tags'
+        required: true
+      labels:
+        default: 'qe/verify'
+        required: true
+        description: ""
+      jira_server:
+        default: 'https://issues.redhat.com'
+        required: true
+        description: "Jira Server"
+      jira_project:
+        default: "RHODS"
+        required: true
+        description: "Jira Project"
+      jira_labels:
+        default: "Platform"
+        required: true
+        description: "Jira Labels to Add"
+      jira_issue_type:
+        default: "Story"
+        required: true
+        description: "Jira Issue Type"
+      jira_priority:
+        default: 'Normal'
+        required: true
+        description: "Jira Priority to Set"
+
+jobs:
+  gh-to-jira:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@v3
+        with:
+          repository: HumairAK/gh-to-jira
+          fetch-depth: '0'
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v1
+        with:
+          python-version: '3.10'
+      - name: Install dependencies
+        run: |
+          pip install -r requirements.txt
+      - name: Submit Jira
+        env:
+          GITHUB_TOKEN: ${{ secrets.GTJ_GH_TOKEN }}
+          JIRA_TOKEN: ${{ secrets.GTJ_JIRA_TOKEN }}
+          REPOS: ${{ inputs.repos }}
+        run: |
+          python src --component="${{ inputs.component }}" \
+            --target_release="${{ inputs.target_release }}" \
+            --org="${{ inputs.gh_org }}" \
+            --labels="${{ inputs.labels }}" \
+            --jira_server="${{ inputs.jira_server }}" \
+            --jira_project="${{ inputs.jira_project }}" \
+            --jira_labels="${{ inputs.jira_labels }}" \
+            --jira_issue_type="${{ inputs.jira_issue_type }}" \
+            --jira_priority="${{ inputs.jira_priority }}"


### PR DESCRIPTION
## Description
Ref: https://github.com/opendatahub-io/opendatahub-operator/issues/371
set to use:
- jira_label: Platform
- jira_issue_type: Story
- labels: qe/verify
- jira_priority: Normal

To Be Done:
need two tokens:
- github token with view permission
- jira token with create permission

Workflow:
- per each RHODS release, devel manually trigger github action
- github action collects all github issues matching labels "qe/verify" from specified github repo list
- then generate a jira issue with all above github issue as description

Question: 
- owner of odh-manifests not clear => jira_label to be set on this repo
- we probably dont use "qe/verify" label then we define which label on these issue to filter out

In order to show this jira issue in Errata:
devel need to add this jira issue in their commit message


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
