### PR TITLE
Add Kserve ImageParams Map

### DIFF
--- a/components/kserve/kserve.go
+++ b/components/kserve/kserve.go
@@ -15,7 +15,12 @@ const (
 	Path          = deploy.DefaultManifestPath + "/" + ComponentName + "/base"
 )
 
-var imageParamMap = map[string]string{}
+var imageParamMap = map[string]string{
+	"kserve-router":              "RELATED_IMAGE_ODH_KSERVE_ROUTE_IMAGE",
+	"kserve-agent":               "RELATED_IMAGE_ODH_KSERVE_AGENT_IMAGE",
+	"kserve-controller":          "RELATED_IMAGE_ODH_KSERVE_CONTROLLER_IMAGE",
+	"kserve-storage-initializer": "RELATED_IMAGE_ODH_KSERVE_STORAGE_INITIALIZER_IMAGE",
+}
 
 type Kserve struct {
 	components.Component `json:""`


### PR DESCRIPTION
## Description
fix: https://github.com/opendatahub-io/opendatahub-operator/issues/383

so we will only have these 4 images
the other 2 of explainer are currently still needed but later similar function will be replaced by new images in trustyai.
therefore we no need these 2 images, and only refer them for the coming couple of releases.
already in https://github.com/red-hat-data-services/odh-manifests/pull/434/files params.env has  variables set

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
