### PR TITLE
Fix wrong monitoring and add logger

### DIFF
--- a/bundle/manifests/opendatahub-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/opendatahub-operator.clusterserviceversion.yaml
@@ -9,9 +9,6 @@ metadata:
           "kind": "OdhQuickStart",
           "metadata": {
             "annotations": {
-              "internal.config.kubernetes.io/previousKinds": "OdhQuickStart",
-              "internal.config.kubernetes.io/previousNames": "create-jupyter-notebook",
-              "internal.config.kubernetes.io/previousNamespaces": "default",
               "opendatahub.io/categories": "Getting started,Notebook environments"
             },
             "labels": {
@@ -531,7 +528,6 @@ spec:
           resources:
           - builds
           verbs:
-          - catch
           - create
           - delete
           - list
@@ -621,6 +617,7 @@ spec:
           - create
           - delete
           - get
+          - list
           - patch
           - watch
         - apiGroups:
@@ -665,6 +662,7 @@ spec:
           - create
           - delete
           - get
+          - list
           - patch
           - update
           - watch
@@ -861,8 +859,9 @@ spec:
           resources:
           - dscinitializations/finalizers
           verbs:
+          - delete
           - get
-          - patchdelete
+          - patch
           - update
         - apiGroups:
           - dscinitialization.opendatahub.io

--- a/controllers/dscinitialization/monitoring.go
+++ b/controllers/dscinitialization/monitoring.go
@@ -32,6 +32,7 @@ func configurePrometheus(dsciInit *dsci.DSCInitialization, r *DSCInitializationR
 		r.Log.Error(err, "error to get alertmanager route")
 		return err
 	}
+	r.Log.Info("Success: got alertmanager route")
 
 	// Get alertmanager configmap
 	alertManagerConfigMap := &corev1.ConfigMap{}
@@ -43,13 +44,26 @@ func configurePrometheus(dsciInit *dsci.DSCInitialization, r *DSCInitializationR
 		r.Log.Error(err, "error to get alertmanager configmap")
 		return err
 	}
+	r.Log.Info("Success: got alertmanager CM")
+
 	alertmanagerData, err := getMonitoringData(alertManagerConfigMap.Data["alertmanager.yml"])
 	if err != nil {
 		r.Log.Error(err, "error to get alertmanager data from alertmanager.yaml")
 		return err
 	}
+	r.Log.Info("Success: read alertmanager data from alertmanage.yaml from CM")
 
-	// Get promethus configmap
+	// Deploy prometheus CM first
+	err = deploy.DeployManifestsFromPath(dsciInit, r.Client, "prometheus",
+		deploy.DefaultManifestPath+"/monitoring/prometheus/base",
+		dsciInit.Spec.Monitoring.Namespace, r.Scheme, dsciInit.Spec.Monitoring.ManagementState == operatorv1.Managed)
+	if err != nil {
+		r.Log.Error(err, "error to deploy manifests under /opt/manifests/monitoring/prometheus/base")
+		return err
+	}
+	r.Log.Info("Success: deploy prometheus CM")
+
+	// Get prometheus configmap
 	prometheusConfigMap := &corev1.ConfigMap{}
 	err = r.Client.Get(context.TODO(), client.ObjectKey{
 		Namespace: dsciInit.Spec.Monitoring.Namespace,
@@ -59,12 +73,15 @@ func configurePrometheus(dsciInit *dsci.DSCInitialization, r *DSCInitializationR
 		r.Log.Error(err, "error to get prometheus configmap")
 		return err
 	}
+	r.Log.Info("Success: got prometheus CM")
+
 	// Get prometheus data
 	prometheusData, err := getMonitoringData(fmt.Sprint(prometheusConfigMap.Data))
 	if err != nil {
 		r.Log.Error(err, "error to get prometheus data")
 		return err
 	}
+	r.Log.Info("Success: read prometheus data from prometheus.yaml from CM")
 
 	// Update prometheus manifests
 	err = common.ReplaceStringsInFile(deploy.DefaultManifestPath+"/monitoring/prometheus/prometheus.yaml", map[string]string{
@@ -108,6 +125,7 @@ func configureAlertManager(dsciInit *dsci.DSCInitialization, r *DSCInitializatio
 		r.Log.Error(err, "error getting deadmansnitch secret from namespace "+dsciInit.Spec.Monitoring.Namespace)
 		return err
 	}
+	r.Log.Info("Success: got deadmansnitch secret")
 
 	// Get PagerDuty Secret
 	pagerDutySecret, err := r.waitForManagedSecret("redhat-rhods-pagerduty", dsciInit.Spec.Monitoring.Namespace)
@@ -115,6 +133,7 @@ func configureAlertManager(dsciInit *dsci.DSCInitialization, r *DSCInitializatio
 		r.Log.Error(err, "error getting pagerduty secret from namespace "+dsciInit.Spec.Monitoring.Namespace)
 		return err
 	}
+	r.Log.Info("Success: got pagerduty secret")
 
 	// Get Smtp Secret
 	smtpSecret, err := r.waitForManagedSecret("redhat-rhods-smtp", dsciInit.Spec.Monitoring.Namespace)
@@ -122,16 +141,18 @@ func configureAlertManager(dsciInit *dsci.DSCInitialization, r *DSCInitializatio
 		r.Log.Error(err, "error getting smtp secret from namespace "+dsciInit.Spec.Monitoring.Namespace)
 		return err
 	}
+	r.Log.Info("Success: got smtp secret")
 
 	// Get SMTP receiver email secret (assume operator namespace for managed service is not configable)
 	smtpEmailSecret, err := r.waitForManagedSecret("addon-managed-odh-parameters", "redhat-ods-operator")
 	if err != nil {
 		return fmt.Errorf("error getting smtp receiver email secret: %v", err)
 	}
+	r.Log.Info("Success: got smpt email secret")
 
 	// Replace variables in alertmanager configmap
 	// TODO: Following variables can later be exposed by the API
-	err = common.ReplaceStringsInFile(deploy.DefaultManifestPath+"/monitoring/alertmanager/monitoring-configs.yaml",
+	err = common.ReplaceStringsInFile(deploy.DefaultManifestPath+"/monitoring/alertmanager/alertmanager-configs.yaml",
 		map[string]string{
 			"<snitch_url>":      b64.StdEncoding.EncodeToString(deadmansnitchSecret.Data["SNITCH_URL"]),
 			"<pagerduty_token>": b64.StdEncoding.EncodeToString(pagerDutySecret.Data["PAGERDUTY_KEY"]),
@@ -143,9 +164,10 @@ func configureAlertManager(dsciInit *dsci.DSCInitialization, r *DSCInitializatio
 			"@devshift.net":     "@rhmw.io",
 		})
 	if err != nil {
-		r.Log.Error(err, "error to inject data to monitoring-configs.yaml")
+		r.Log.Error(err, "error to inject data to alertmanager-configs.yaml")
 		return err
 	}
+	r.Log.Info("Success: generate alertmanage config")
 
 	err = deploy.DeployManifestsFromPath(dsciInit, r.Client, "alertmanager",
 		deploy.DefaultManifestPath+"/monitoring/alertmanager",
@@ -154,12 +176,14 @@ func configureAlertManager(dsciInit *dsci.DSCInitialization, r *DSCInitializatio
 		r.Log.Error(err, "error to deploy manifests under /opt/manifests/monitoring/alertmanager")
 		return err
 	}
+	r.Log.Info("Success: deploy alertmanager manifests")
 
 	// Create proxy secret
 	if err := createMonitoringProxySecret("alertmanager-proxy", dsciInit, r.Client, r.Scheme); err != nil {
 		r.Log.Error(err, "error to create secret alertmanager-proxy")
 		return err
 	}
+	r.Log.Info("Success: create alertmanage secret")
 	return nil
 }
 


### PR DESCRIPTION
## Description
reopen this PR, even monitoring not applicable for downstream also the path in odh-manifests might be different, still useful to have logic in
ref downstream: https://github.com/red-hat-data-services/rhods-operator/pull/16

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
