### PR TITLE
Fixes #324 . Showing all components in YAML CR, even if disabled.

### DIFF
--- a/controllers/datasciencecluster/datasciencecluster_controller.go
+++ b/controllers/datasciencecluster/datasciencecluster_controller.go
@@ -114,12 +114,12 @@ func (r *DataScienceClusterReconciler) Reconcile(ctx context.Context, req ctrl.R
 		}
 	}
 
-	// // Ensure all omitted components show up as explicitly disabled
-	// instance, err = r.updateComponents(instance)
-	// if err != nil {
-	// 	_ = r.reportError(err, instance, "error updating list of components in the CR")
-	// 	return ctrl.Result{}, err
-	// }
+	// Ensure all omitted components show up as explicitly disabled
+	instance, err = r.updateComponents(instance)
+	if err != nil {
+		_ = r.reportError(err, instance, "error updating list of components in the CR")
+		return ctrl.Result{}, err
+	}
 
 	// Initialize error list, instead of returning errors after every component is deployed
 	componentErrorList := make(map[string]error)
@@ -306,20 +306,20 @@ func (r *DataScienceClusterReconciler) updateStatus(original *dsc.DataScienceClu
 	return saved, err
 }
 
-// func (r *DataScienceClusterReconciler) updateComponents(original *dsc.DataScienceCluster) (*dsc.DataScienceCluster, error) {
-// 	saved := &dsc.DataScienceCluster{}
-// 	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+func (r *DataScienceClusterReconciler) updateComponents(original *dsc.DataScienceCluster) (*dsc.DataScienceCluster, error) {
+	saved := &dsc.DataScienceCluster{}
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 
-// 		err := r.Client.Get(context.TODO(), client.ObjectKeyFromObject(original), saved)
-// 		if err != nil {
-// 			return err
-// 		}
+		err := r.Client.Get(context.TODO(), client.ObjectKeyFromObject(original), saved)
+		if err != nil {
+			return err
+		}
 
-// 		// Try to update
-// 		err = r.Client.Update(context.TODO(), saved)
-// 		// Return err itself here (not wrapped inside another error)
-// 		// so that RetryOnConflict can identify it correctly.
-// 		return err
-// 	})
-// 	return saved, err
-// }
+		// Try to update
+		err = r.Client.Update(context.TODO(), saved)
+		// Return err itself here (not wrapped inside another error)
+		// so that RetryOnConflict can identify it correctly.
+		return err
+	})
+	return saved, err
+}


### PR DESCRIPTION
Fixes #324 . Showing all components in YAML CR, even if disabled.

## How Has This Been Tested?
Manually tested in the cluster

## Merge criteria:
- [X] The commits are squashed in a cohesive manner and have meaningful messages.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work
