### PR TITLE
Revert: do not set imageParamMap for CF

### DIFF
--- a/components/codeflare/codeflare.go
+++ b/components/codeflare/codeflare.go
@@ -13,10 +13,7 @@ const (
 	CodeflarePath = deploy.DefaultManifestPath + "/" + "codeflare-stack/base"
 )
 
-var imageParamMap = map[string]string{
-	"odh-codeflare-operator-image": "RELATED_IMAGE_ODH_CODEFLARE_OPERATOR_IMAGE",
-	"odh-mcad-controller-image":    "RELATED_IMAGE_ODH_MCAD_CONTROLLER_IMAGE",
-}
+var imageParamMap = map[string]string{}
 
 type CodeFlare struct {
 	components.Component `json:""`


### PR DESCRIPTION
## Description

- particially revert PR389
- CF does not need image to be used in manifests
ref: https://github.com/opendatahub-io/opendatahub-operator/issues/384

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
