### PR TITLE
Add order in marker to reorder CSV + remove context which is not in use + remove logger for secretgen

### DIFF
--- a/apis/datasciencecluster/v1alpha1/datasciencecluster_types.go
+++ b/apis/datasciencecluster/v1alpha1/datasciencecluster_types.go
@@ -33,7 +33,7 @@ import (
 // Defines the desired state of DataScienceCluster
 type DataScienceClusterSpec struct {
 	// Override and fine tune specific component configurations.
-	// +operator-sdk:csv:customresourcedefinitions:type=spec
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,order=1
 	Components Components `json:"components,omitempty"`
 }
 

--- a/apis/dscinitialization/v1alpha1/dscinitialization_types.go
+++ b/apis/dscinitialization/v1alpha1/dscinitialization_types.go
@@ -23,17 +23,18 @@ import (
 )
 
 // DSCInitializationSpec defines the desired state of DSCInitialization
+// +operator-sdk:csv:customresourcedefinitions:order=1
 type DSCInitializationSpec struct {
 	// +kubebuilder:default:=opendatahub
 	// Namespace for applications to be installed, non-configurable, default to "opendatahub"
-	// +operator-sdk:csv:customresourcedefinitions:type=spec
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,order=1
 	ApplicationsNamespace string `json:"applicationsNamespace"`
 	// Enable monitoring on specified namespace
-	// +operator-sdk:csv:customresourcedefinitions:type=spec
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,order=2
 	// +optional
 	Monitoring Monitoring `json:"monitoring,omitempty"`
 	// Internal development useful field
-	// +operator-sdk:csv:customresourcedefinitions:type=spec
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,order=3
 	// +optional
 	ManifestsUri string `json:"manifestsUri,omitempty"`
 }

--- a/bundle/manifests/opendatahub-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/opendatahub-operator.clusterserviceversion.yaml
@@ -194,12 +194,12 @@ spec:
           default to "opendatahub"
         displayName: Applications Namespace
         path: applicationsNamespace
-      - description: Internal development useful field
-        displayName: Manifests Uri
-        path: manifestsUri
       - description: Enable monitoring on specified namespace
         displayName: Monitoring
         path: monitoring
+      - description: Internal development useful field
+        displayName: Manifests Uri
+        path: manifestsUri
       statusDescriptors:
       - description: Conditions describes the state of the DSCInitializationStatus
           resource.

--- a/config/manifests/bases/opendatahub-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/opendatahub-operator.clusterserviceversion.yaml
@@ -34,12 +34,12 @@ spec:
           default to "opendatahub"
         displayName: Applications Namespace
         path: applicationsNamespace
-      - description: Internal development useful field
-        displayName: Manifests Uri
-        path: manifestsUri
       - description: Enable monitoring on specified namespace
         displayName: Monitoring
         path: monitoring
+      - description: Internal development useful field
+        displayName: Manifests Uri
+        path: manifestsUri
       statusDescriptors:
       - description: Conditions describes the state of the DSCInitializationStatus
           resource.

--- a/controllers/datasciencecluster/datasciencecluster_controller.go
+++ b/controllers/datasciencecluster/datasciencecluster_controller.go
@@ -127,46 +127,46 @@ func (r *DataScienceClusterReconciler) Reconcile(ctx context.Context, req ctrl.R
 
 	// reconcile dashboard component
 	if instance, err = r.reconcileSubComponent(instance, dashboard.ComponentName, instance.Spec.Components.Dashboard.Enabled,
-		&(instance.Spec.Components.Dashboard), ctx); err != nil {
+		&(instance.Spec.Components.Dashboard)); err != nil {
 		// no need to log any errors as this is done in the reconcileSubComponent method
 		componentErrorList[dashboard.ComponentName] = err
 	}
 
 	// reconcile DataSciencePipelines component
 	if instance, err = r.reconcileSubComponent(instance, datasciencepipelines.ComponentName, instance.Spec.Components.DataSciencePipelines.Enabled,
-		&(instance.Spec.Components.DataSciencePipelines), ctx); err != nil {
+		&(instance.Spec.Components.DataSciencePipelines)); err != nil {
 		// no need to log any errors as this is done in the reconcileSubComponent method
 		componentErrorList[datasciencepipelines.ComponentName] = err
 	}
 
 	// reconcile Workbench component
 	if instance, err = r.reconcileSubComponent(instance, workbenches.ComponentName, instance.Spec.Components.Workbenches.Enabled,
-		&(instance.Spec.Components.Workbenches), ctx); err != nil {
+		&(instance.Spec.Components.Workbenches)); err != nil {
 		// no need to log any errors as this is done in the reconcileSubComponent method
 		componentErrorList[workbenches.ComponentName] = err
 	}
 
 	// reconcile Kserve component
-	if instance, err = r.reconcileSubComponent(instance, kserve.ComponentName, instance.Spec.Components.Kserve.Enabled, &(instance.Spec.Components.Kserve), ctx); err != nil {
+	if instance, err = r.reconcileSubComponent(instance, kserve.ComponentName, instance.Spec.Components.Kserve.Enabled, &(instance.Spec.Components.Kserve)); err != nil {
 		// no need to log any errors as this is done in the reconcileSubComponent method
 		componentErrorList[kserve.ComponentName] = err
 	}
 
 	// reconcile ModelMesh component
 	if instance, err = r.reconcileSubComponent(instance, modelmeshserving.ComponentName, instance.Spec.Components.ModelMeshServing.Enabled,
-		&(instance.Spec.Components.ModelMeshServing), ctx); err != nil {
+		&(instance.Spec.Components.ModelMeshServing)); err != nil {
 		// no need to log any errors as this is done in the reconcileSubComponent method
 		componentErrorList[modelmeshserving.ComponentName] = err
 	}
 
 	// reconcile CodeFlare component
-	if instance, err = r.reconcileSubComponent(instance, codeflare.ComponentName, instance.Spec.Components.CodeFlare.Enabled, &(instance.Spec.Components.CodeFlare), ctx); err != nil {
+	if instance, err = r.reconcileSubComponent(instance, codeflare.ComponentName, instance.Spec.Components.CodeFlare.Enabled, &(instance.Spec.Components.CodeFlare)); err != nil {
 		// no need to log any errors as this is done in the reconcileSubComponent method
 		componentErrorList[codeflare.ComponentName] = err
 	}
 
 	// reconcile Ray component
-	if instance, err = r.reconcileSubComponent(instance, ray.ComponentName, instance.Spec.Components.Ray.Enabled, &(instance.Spec.Components.Ray), ctx); err != nil {
+	if instance, err = r.reconcileSubComponent(instance, ray.ComponentName, instance.Spec.Components.Ray.Enabled, &(instance.Spec.Components.Ray)); err != nil {
 		// no need to log any errors as this is done in the reconcileSubComponent method
 		componentErrorList[ray.ComponentName] = err
 	}
@@ -202,7 +202,7 @@ func (r *DataScienceClusterReconciler) Reconcile(ctx context.Context, req ctrl.R
 }
 
 func (r *DataScienceClusterReconciler) reconcileSubComponent(instance *dsc.DataScienceCluster, componentName string, enabled bool,
-	component components.ComponentInterface, ctx context.Context) (*dsc.DataScienceCluster, error) {
+	component components.ComponentInterface) (*dsc.DataScienceCluster, error) {
 
 	// First set contidions to reflect a component is about to be reconciled
 	instance, err := r.updateStatus(instance, func(saved *dsc.DataScienceCluster) {

--- a/controllers/secretgenerator/secretgenerator_controller.go
+++ b/controllers/secretgenerator/secretgenerator_controller.go
@@ -78,7 +78,6 @@ func (r *SecretGeneratorReconciler) SetupWithManager(mgr ctrl.Manager) error {
 // based on the specified type and complexity. This will avoid possible race
 // conditions when a deployment mounts the secret before it is reconciled
 func (r *SecretGeneratorReconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.Result, error) {
-	_ = log.FromContext(ctx)
 	foundSecret := &v1.Secret{}
 	err := r.Client.Get(context.TODO(), request.NamespacedName, foundSecret)
 	if err != nil {


### PR DESCRIPTION
## Description
- logger for secretegenerator is not needed(cherry-pick this from downstream)
- context is not needed in dsc, not needed
- put order in api fileds, so internal one manifestsuri will be in lower order than monitoring, otherwise sort by alphabet 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
local build: quay.io/wenzhou/opendatahub-operator-catalog:v2.8.8


enabled several components
![Screenshot from 2023-08-08 09-40-39](https://github.com/opendatahub-io/opendatahub-operator/assets/915053/59291eca-6217-4aa6-989c-8d68f449aeb3)
Pod created and working, 
![Screenshot from 2023-08-08 09-40-51](https://github.com/opendatahub-io/opendatahub-operator/assets/915053/6f023c01-9d3f-49e0-a04e-a4d48b42e721)
For secretgenerator 
it prints logs ( since it is a cluster, it did reconcile at first then after dashboard-oauth-client-generated created all went well)
![Screenshot from 2023-08-08 09-42-11](https://github.com/opendatahub-io/opendatahub-operator/assets/915053/e8cc04d1-28b2-4a35-8cc5-c102b2527ca1)

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
