### PR TITLE
Update metrics host IP

### DIFF
--- a/bundle/manifests/opendatahub-operator-manager-config_v1_configmap.yaml
+++ b/bundle/manifests/opendatahub-operator-manager-config_v1_configmap.yaml
@@ -6,7 +6,7 @@ data:
     health:
       healthProbeBindAddress: :8081
     metrics:
-      bindAddress: 127.0.0.1:8080
+      bindAddress: 0.0.0.0:8080
     webhook:
       port: 9443
     leaderElection:

--- a/bundle/manifests/opendatahub-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/opendatahub-operator.clusterserviceversion.yaml
@@ -406,7 +406,7 @@ spec:
               containers:
               - args:
                 - --health-probe-bind-address=:8081
-                - --metrics-bind-address=127.0.0.1:8080
+                - --metrics-bind-address=0.0.0.0:8080
                 - --leader-elect
                 command:
                 - /manager

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -12,5 +12,5 @@ spec:
       - name: manager
         args:
         - "--health-probe-bind-address=:8081"
-        - "--metrics-bind-address=127.0.0.1:8080"
+        - "--metrics-bind-address=0.0.0.0:8080"
         - "--leader-elect"

--- a/config/manager/controller_manager_config.yaml
+++ b/config/manager/controller_manager_config.yaml
@@ -3,7 +3,7 @@ kind: ControllerManagerConfig
 health:
   healthProbeBindAddress: :8081
 metrics:
-  bindAddress: 127.0.0.1:8080
+  bindAddress: 0.0.0.0:8080
 webhook:
   port: 9443
 leaderElection:


### PR DESCRIPTION
## Description

Update metrics host IP.
we do not specify it in old operator
from https://v0-19-x.sdk.operatorframework.io/docs/golang/legacy/monitoring/prometheus/ default is 0.0.0.0
this is part of the downstream PR https://github.com/red-hat-data-services/rhods-operator/pull/33
this will not automatically ships metrics, till: we apply promethusrules in manifests which are not available yet.


ref: https://github.com/opendatahub-io/opendatahub-operator/issues/444 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
