### PR TITLE
Update Dockerfile to pull manifests from different component repo

### DIFF
--- a/Dockerfiles/Dockerfile
+++ b/Dockerfiles/Dockerfile
@@ -1,15 +1,27 @@
 # Build the manager binary
 ARG GOLANG_VERSION=1.18.9
+ARG USE_LOCAL=false
 
-FROM registry.access.redhat.com/ubi8/go-toolset:$GOLANG_VERSION as builder
-
-ARG MANIFEST_REPO="https://github.com/opendatahub-io/odh-manifests"
-ARG MANIFEST_RELEASE="v1.9"
-
-ARG MANIFEST_TARBALL="${MANIFEST_REPO}/tarball/${MANIFEST_RELEASE}"
-
-WORKDIR /workspace
+################################################################################
+FROM registry.access.redhat.com/ubi8/go-toolset:$GOLANG_VERSION as builder_local_false
+# Get all manifests from remote git repo to builder_local_false by script
 USER root
+WORKDIR /opt
+COPY get_all_manifests.sh get_all_manifests.sh
+RUN ./get_all_manifests.sh
+
+################################################################################
+FROM registry.access.redhat.com/ubi8/go-toolset:$GOLANG_VERSION as builder_local_true
+# Get all manifests from local to builder_local_true
+USER root
+WORKDIR /opt
+# copy local manifests to build
+COPY odh-manifests/ /opt/odh-manifests/
+
+################################################################################
+FROM builder_local_${USE_LOCAL} as builder
+USER root
+WORKDIR /workspace
 # Copy the Go Modules manifests
 COPY go.mod go.mod
 COPY go.sum go.sum
@@ -18,23 +30,16 @@ COPY go.sum go.sum
 RUN go mod download
 
 # Copy the go source
-COPY main.go main.go
 COPY apis/ apis/
-COPY controllers/ controllers/
-COPY pkg/ pkg/
 COPY components/ components/
-
-# Download odh-manifests tarball
-ADD ${MANIFEST_TARBALL} ${MANIFEST_RELEASE}.tar.gz
-RUN mkdir /opt/odh-manifests/ && \
-    tar --exclude={.*,*.md,LICENSE,Makefile,Dockerfile,version.py,OWNERS,tests,ai-library} --strip-components=1 -xf ${MANIFEST_RELEASE}.tar.gz -C /opt/odh-manifests/ && \
-    rm -rf ${MANIFEST_RELEASE}.tar.gz
-# uncomment to test local changes
-# COPY odh-manifests/ /opt/odh-manifests/
+COPY controllers/ controllers/
+COPY main.go main.go
+COPY pkg/ pkg/
 
 # Build
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager main.go
 
+################################################################################
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 WORKDIR /
 COPY --from=builder /workspace/manager .

--- a/README.md
+++ b/README.md
@@ -41,6 +41,42 @@ Refer [Dev-Preview.md](./docs/Dev-Preview.md) for testing preview features.
 - Go version **go1.18.9**
 - operator-sdk version can be updated to **v1.24.1**
 
+#### Download manifests
+
+`get_all_manifests.sh` is used to fetch manifests from remote git repos.
+
+It uses a local empty folder `odh-manifests` to host all manifests operator needs, either from `odh-manifests` git repo or from component's source repo.
+
+The way to config this is to update `get_all_manifests.sh` REPO_LIST variable.
+By adding new entity in variable `REPO_LIST` in the format of `<repo-name>:<branch-name>:<source-folder>:<target-folder>` this will:
+
+- git clone remote repo `opendatahub-io/<repo-name>` from its `<branch-name>` branch
+- copy content from its relative path `<source-folder>` into local `odh-manifests/<target-folder>` folder
+
+For those components cannot directly use manifests from `opendatahub-io/<repo-name>`, it falls back to use `opendatahub-io/odh-manifests` git repo. To control which version of `opendatahub-io/odh-manifests` to download, this is set in the `get_all_manifests.sh` variable `MANIFEST_RELEASE`.
+
+##### for local development
+
+```
+
+make get-manifests
+```
+
+This first cleanup your local `odh-manifests` folder.
+Ensure back up before run this command if you have local changes of manifests want to re-user later.
+
+##### for build operator image
+
+```
+
+make image-build
+```
+
+By default, building an image without any local changes(as a clean build)
+This is what the production build system does. Same for the "make image-build" does.
+
+In order to build an image with local `odh-manifests` folder, to set `--build-arg USE_LOCAL=true` in Makefile.
+
 #### Build Image
 
 - Custom operator image can be built using your local repository

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ make get-manifests
 ```
 
 This first cleanup your local `odh-manifests` folder.
-Ensure back up before run this command if you have local changes of manifests want to re-user later.
+Ensure back up before run this command if you have local changes of manifests want to reuse later.
 
 ##### for build operator image
 
@@ -73,9 +73,10 @@ make image-build
 ```
 
 By default, building an image without any local changes(as a clean build)
-This is what the production build system does. Same for the "make image-build" does.
+This is what the production build system is doing.
 
-In order to build an image with local `odh-manifests` folder, to set `--build-arg USE_LOCAL=true` in Makefile.
+In order to build an image with local `odh-manifests` folder, to set `IMAGE_BUILD_FLAGS ="--build-arg USE_LOCAL=true"` in make.
+e.g `make image-build -e IMAGE_BUILD_FLAGS="--build-arg USE_LOCAL=true"`
 
 #### Build Image
 

--- a/components/kserve/kserve.go
+++ b/components/kserve/kserve.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	ComponentName          = "kserve"
-	Path                   = deploy.DefaultManifestPath + "/" + ComponentName + "/config/overlays/odh"
+	Path                   = deploy.DefaultManifestPath + "/" + ComponentName + "/overlays/odh"
 	DependentComponentName = "odh-model-controller"
 	DependentPath          = deploy.DefaultManifestPath + "/" + DependentComponentName + "/base"
 	ServiceMeshOperator    = "servicemeshoperator"

--- a/components/kserve/kserve.go
+++ b/components/kserve/kserve.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	ComponentName          = "kserve"
-	Path                   = deploy.DefaultManifestPath + "/" + ComponentName + "/base"
+	Path                   = deploy.DefaultManifestPath + "/" + ComponentName
 	DependentComponentName = "odh-model-controller"
 	DependentPath          = deploy.DefaultManifestPath + "/" + DependentComponentName + "/base"
 	ServiceMeshOperator    = "servicemeshoperator"

--- a/components/kserve/kserve.go
+++ b/components/kserve/kserve.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	ComponentName          = "kserve"
-	Path                   = deploy.DefaultManifestPath + "/" + ComponentName
+	Path                   = deploy.DefaultManifestPath + "/" + ComponentName + "/config/overlays/odh"
 	DependentComponentName = "odh-model-controller"
 	DependentPath          = deploy.DefaultManifestPath + "/" + DependentComponentName + "/base"
 	ServiceMeshOperator    = "servicemeshoperator"

--- a/get_all_manifests.sh
+++ b/get_all_manifests.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+set -e
+
+# component: dsp, kserve, dashbaord, cf/ray. in the format of "repo-name:branch-name:source-folder:target-folder"
+# TODO: workbench, modelmesh, monitoring, etc
+REPO_LIST=(
+    "distributed-workloads:main:codeflare-stack:codeflare-stack"
+    "distributed-workloads:main:ray:ray"
+    "data-science-pipelines-operator:main:config:data-science-pipelines-operator"
+    "kserve:master:config:kserve"
+    "odh-dashboard:main:manifests:odh-dashboard"
+)
+
+# pre-cleanup local env
+rm -fr ./odh-manifests/* ./.odh-manifests-tmp/
+
+GITHUB_URL="https://github.com/"
+# update to use different git repo
+MANIFEST_ORG="opendatahub-io"
+
+# comment out below logic once we have all component manifests ready to get from source git repo
+MANIFEST_RELEASE="master"
+MANIFESTS_TARBALL_URL="${GITHUB_URL}/${MANIFEST_ORG}/odh-manifests/tarball/${MANIFEST_RELEASE}"
+mkdir ./.odh-manifests-tmp/ ./odh-manifests/
+wget -q -c ${MANIFESTS_TARBALL_URL} -O - | tar -zxv -C ./.odh-manifests-tmp/ --strip-components 1 > /dev/null
+cp -r ./.odh-manifests-tmp/model-mesh/ ./odh-manifests
+cp -r ./.odh-manifests-tmp/odh-model-controller/ ./odh-manifests
+cp -r ./.odh-manifests-tmp/modelmesh-monitoring/ ./odh-manifests
+cp -r ./.odh-manifests-tmp/notebook-images/ ./odh-manifests
+cp -r ./.odh-manifests-tmp/odh-notebook-controller/ ./odh-manifests
+ls -lat ./odh-manifests/
+rm -rf ${MANIFEST_RELEASE}.tar.gz ./.odh-manifests-tmp/
+
+for repo_info in ${REPO_LIST[@]}; do
+    echo "Git clone below repo ${repo_info}"
+    repo_name=$( echo $repo_info | cut -d ":" -f 1 )
+    repo_branch=$( echo $repo_info | cut -d ":" -f 2 )
+    source_path=$( echo $repo_info | cut -d ":" -f 3 )
+    target_path=$( echo $repo_info | cut -d ":" -f 4 )
+    repo_url="${GITHUB_URL}/${MANIFEST_ORG}/${repo_name}.git"
+    rm -rf ./.${repo_name}
+    git clone --depth 1 --branch ${repo_branch} ${repo_url} ./.${repo_name}
+    mkdir -p ./odh-manifests/${target_path}
+    cp -rf ./.${repo_name}/${source_path}/* ./odh-manifests/${target_path}
+    rm -rf ./.${repo_name}
+done

--- a/get_all_manifests.sh
+++ b/get_all_manifests.sh
@@ -7,7 +7,7 @@ REPO_LIST=(
     "distributed-workloads:main:codeflare-stack:codeflare-stack"
     "distributed-workloads:main:ray:ray"
     "data-science-pipelines-operator:main:config:data-science-pipelines-operator"
-    "kserve:master:config:kserve"
+    "kserve:release-v0.11:config:kserve"
     "odh-dashboard:main:manifests:odh-dashboard"
 )
 

--- a/get_all_manifests.sh
+++ b/get_all_manifests.sh
@@ -9,6 +9,7 @@ REPO_LIST=(
     "data-science-pipelines-operator:main:config:data-science-pipelines-operator"
     "kserve:release-v0.11:config:kserve"
     "odh-dashboard:main:manifests:odh-dashboard"
+    "notebooks:main:manifests:notebook-images"
 )
 
 # pre-cleanup local env
@@ -21,12 +22,11 @@ MANIFEST_ORG="opendatahub-io"
 # comment out below logic once we have all component manifests ready to get from source git repo
 MANIFEST_RELEASE="master"
 MANIFESTS_TARBALL_URL="${GITHUB_URL}/${MANIFEST_ORG}/odh-manifests/tarball/${MANIFEST_RELEASE}"
-mkdir ./.odh-manifests-tmp/ ./odh-manifests/
+mkdir -p ./.odh-manifests-tmp/ ./odh-manifests/
 wget -q -c ${MANIFESTS_TARBALL_URL} -O - | tar -zxv -C ./.odh-manifests-tmp/ --strip-components 1 > /dev/null
 cp -r ./.odh-manifests-tmp/model-mesh/ ./odh-manifests
 cp -r ./.odh-manifests-tmp/odh-model-controller/ ./odh-manifests
 cp -r ./.odh-manifests-tmp/modelmesh-monitoring/ ./odh-manifests
-cp -r ./.odh-manifests-tmp/notebook-images/ ./odh-manifests
 cp -r ./.odh-manifests-tmp/odh-notebook-controller/ ./odh-manifests
 ls -lat ./odh-manifests/
 rm -rf ${MANIFEST_RELEASE}.tar.gz ./.odh-manifests-tmp/


### PR DESCRIPTION
## Description
- leave notebook, modelmesh, monitoring as-is from odh-manifests
- the old implmenetation is to get all from odh-manifests, the new one is to only get above listed from odh-manifests, the rest are defined as a list in makefile.
- another difference is the kserve.  the old implementation gets its manifests from odh-manifests which is the "outcome" of kustomize build, the new implementation is to copy over from kserve git repo (which are the source of the odh-manifests part) so no need "base" in the path
- move fetch logic into `get_all_aminfests.sh`
- instruction  of how to fetch manifests has been added into README

ref: https://github.com/opendatahub-io/opendatahub-operator/issues/424 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
**UPDATES:**
new local build image: from 14th Sep  quay.io/wenzhou/opendatahub-operator-catalog:v2.9.424



**OLD:**
![Screenshot from 2023-08-10 10-02-30](https://github.com/opendatahub-io/opendatahub-operator/assets/915053/365fa5d4-6b9a-49ad-ba85-6689a7c20bb2)
![Screenshot from 2023-08-10 10-38-07](https://github.com/opendatahub-io/opendatahub-operator/assets/915053/ec21e3c3-e3ae-4f10-82ac-5672798176bd)

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
