### PR TITLE
Update: segment-io CM namespace from monitoring to application's

### DIFF
--- a/controllers/dscinitialization/monitoring.go
+++ b/controllers/dscinitialization/monitoring.go
@@ -285,7 +285,7 @@ func (r *DSCInitializationReconciler) configureCommonMonitoring(dsciInit *dsci.D
 	// configure segment.io
 	err := deploy.DeployManifestsFromPath(dsciInit, r.Client, "segment-io",
 		deploy.DefaultManifestPath+"/monitoring/segment",
-		dsciInit.Spec.Monitoring.Namespace, r.Scheme, dsciInit.Spec.Monitoring.Enabled)
+		dsciInit.Spec.ApplicationsNamespace, r.Scheme, dsciInit.Spec.Monitoring.Enabled)
 	if err != nil {
 		r.Log.Error(err, "error to deploy manifests under /opt/manifests/monitoring/segment")
 		return err


### PR DESCRIPTION
## Description
From testing :
```
Changing this setting from the dashboard "cluster settings" page appears to work fine, but in the backend I see no changes to the odh-segment-key configmap.
configmap/secret from segment is now stored in the monitoring namespace instead of the applications namespace.
```


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
