### PR TITLE
Update e2e test: timeout + ray + logging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -125,7 +125,7 @@ test: manifests generate fmt vet envtest ## Run tests.
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test ./controllers/... -coverprofile cover.out
 
 # E2E tests additional flags
-E2E_TEST_FLAGS = "--skip-deletion=true" # See README.md
+E2E_TEST_FLAGS = "--skip-deletion=false" -timeout 15m # See README.md, default go test timeout 10m
 
 ##@ Build
 

--- a/tests/e2e/controller_setup_test.go
+++ b/tests/e2e/controller_setup_test.go
@@ -81,7 +81,7 @@ func NewTestContext() (*testContext, error) {
 	dscInit := &dsci.DSCInitialization{}
 	err = custClient.Get(context.TODO(), types.NamespacedName{Name: "default"}, dscInit)
 	if err != nil {
-		return nil, errors.Wrap(err, "error getting DSCInitialization instance")
+		return nil, errors.Wrap(err, "error getting DSCInitialization instance 'default'")
 	}
 
 	return &testContext{
@@ -108,13 +108,15 @@ func TestOdhOperator(t *testing.T) {
 	utilruntime.Must(dsc.AddToScheme(scheme))
 
 	// individual test suites after the operator is running
-	if !t.Run("validate operator pod", testODHOperatorValidation) {
+	if !t.Run("validate operator pod is running", testODHOperatorValidation) {
 		return
 	}
-	// Run create and delete tests for all the test KfDefs
-	t.Run("create", creationTestSuite)
+	// Run create and delete tests for all the components
+	t.Run("create Opendatahub components", creationTestSuite)
+
+	// Run deleteion if skipDeletion is not set
 	if !skipDeletion {
-		t.Run("delete", deletionTestSuite)
+		t.Run("delete components", deletionTestSuite)
 	}
 }
 

--- a/tests/e2e/dsc_deletion_test.go
+++ b/tests/e2e/dsc_deletion_test.go
@@ -23,13 +23,13 @@ func deletionTestSuite(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run(testCtx.testDsc.Name, func(t *testing.T) {
-		t.Run("DataScienceCluster instance Deletion", func(t *testing.T) {
+		t.Run("Deletion: DataScienceCluster instance", func(t *testing.T) {
 			err = testCtx.testDSCDeletion()
-			require.NoError(t, err, "error deleting DSC object ")
+			require.NoError(t, err, "Error to delete DSC instance")
 		})
-		t.Run("Application Resource Deletion", func(t *testing.T) {
+		t.Run("Deletion: Application Resource", func(t *testing.T) {
 			err = testCtx.testAllApplicationDeletion()
-			require.NoError(t, err, "error testing deletion of DSC defined applications")
+			require.NoError(t, err, "Error to delete component")
 		})
 	})
 
@@ -37,6 +37,7 @@ func deletionTestSuite(t *testing.T) {
 
 func (tc *testContext) testDSCDeletion() error {
 	// Delete test DataScienceCluster resource if found
+
 	dscLookupKey := types.NamespacedName{Name: tc.testDsc.Name}
 	expectedDSC := &dsc.DataScienceCluster{}
 
@@ -44,25 +45,25 @@ func (tc *testContext) testDSCDeletion() error {
 	if err == nil {
 		dscerr := tc.customClient.Delete(tc.ctx, expectedDSC, &client.DeleteOptions{})
 		if dscerr != nil {
-			return fmt.Errorf("error deleting test DSC %s: %v", expectedDSC.Name, dscerr)
+			return fmt.Errorf("error deleting DSC instance %s: %v", expectedDSC.Name, dscerr)
 		}
 	} else if !errors.IsNotFound(err) {
 		if err != nil {
-			return fmt.Errorf("error getting test DSC instance :%v", err)
+			return fmt.Errorf("error getting DSC instance :%v", err)
 		}
 	}
 	return nil
 }
 
 func (tc *testContext) testApplicationDeletion(component components.ComponentInterface) error {
-
 	// Deletion of Deployments
+
 	if err := wait.PollUntilContextTimeout(tc.ctx, tc.resourceRetryInterval, tc.resourceCreationTimeout, false, func(ctx context.Context) (done bool, err error) {
 		appList, err := tc.kubeClient.AppsV1().Deployments(tc.applicationsNamespace).List(ctx, metav1.ListOptions{
 			LabelSelector: "app.kubernetes.io/part-of=" + component.GetComponentName(),
 		})
 		if err != nil {
-			log.Printf("error listing application deployments :%v. Trying again...", err)
+			log.Printf("error listing component deployments :%v. Trying again...", err)
 			return false, err
 		}
 		if len(appList.Items) != 0 {
@@ -71,42 +72,41 @@ func (tc *testContext) testApplicationDeletion(component components.ComponentInt
 			return true, nil
 		}
 	}); err != nil {
-		return err
+		return fmt.Errorf("error deleting component: %v", component.GetComponentName())
 	}
 
 	return nil
 }
 
 func (tc *testContext) testAllApplicationDeletion() error {
+	// Deletion all listed components' deployments
 
-	err := tc.testApplicationDeletion(&(tc.testDsc.Spec.Components.Dashboard))
-	if err != nil {
-		return fmt.Errorf("error deleting application %v", tc.testDsc.Spec.Components.Dashboard)
+	if err := tc.testApplicationDeletion(&(tc.testDsc.Spec.Components.Dashboard)); err != nil {
+		return err
 	}
 
-	err = tc.testApplicationDeletion(&(tc.testDsc.Spec.Components.ModelMeshServing))
-	if err != nil {
-		return fmt.Errorf("error deleting application %v", tc.testDsc.Spec.Components.ModelMeshServing)
+	if err := tc.testApplicationDeletion(&(tc.testDsc.Spec.Components.ModelMeshServing)); err != nil {
+		return err
 	}
 
-	err = tc.testApplicationDeletion(&(tc.testDsc.Spec.Components.Kserve))
-	if err != nil {
-		return fmt.Errorf("error deleting application %v", tc.testDsc.Spec.Components.Kserve)
+	if err := tc.testApplicationDeletion(&(tc.testDsc.Spec.Components.Kserve)); err != nil {
+		return err
 	}
 
-	err = tc.testApplicationDeletion(&(tc.testDsc.Spec.Components.Workbenches))
-	if err != nil {
-		return fmt.Errorf("error deleting application %v", tc.testDsc.Spec.Components.Workbenches)
+	if err := tc.testApplicationDeletion(&(tc.testDsc.Spec.Components.Workbenches)); err != nil {
+		return err
 	}
 
-	err = tc.testApplicationDeletion(&(tc.testDsc.Spec.Components.DataSciencePipelines))
-	if err != nil {
-		return fmt.Errorf("error deleting application %v", tc.testDsc.Spec.Components.DataSciencePipelines)
+	if err := tc.testApplicationDeletion(&(tc.testDsc.Spec.Components.DataSciencePipelines)); err != nil {
+		return err
 	}
 
-	err = tc.testApplicationDeletion(&(tc.testDsc.Spec.Components.CodeFlare))
-	if err != nil {
-		return fmt.Errorf("error deleting application %v", tc.testDsc.Spec.Components.CodeFlare)
+	if err := tc.testApplicationDeletion(&(tc.testDsc.Spec.Components.CodeFlare)); err != nil {
+		return err
+	}
+
+	if err := tc.testApplicationDeletion(&(tc.testDsc.Spec.Components.Ray)); err != nil {
+		return err
 	}
 	return nil
 }

--- a/tests/e2e/helper_test.go
+++ b/tests/e2e/helper_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/opendatahub-io/opendatahub-operator/v2/components/datasciencepipelines"
 	"github.com/opendatahub-io/opendatahub-operator/v2/components/kserve"
 	"github.com/opendatahub-io/opendatahub-operator/v2/components/modelmeshserving"
+	"github.com/opendatahub-io/opendatahub-operator/v2/components/ray"
 	"github.com/opendatahub-io/opendatahub-operator/v2/components/workbenches"
 	corev1 "k8s.io/api/core/v1"
 
@@ -57,6 +58,7 @@ func setupDSCInstance() *dsc.DataScienceCluster {
 		},
 		Spec: dsc.DataScienceClusterSpec{
 			Components: dsc.Components{
+				// keep dashboard as enabled, because other test is rely on this
 				Dashboard: dashboard.Dashboard{
 					Component: components.Component{
 						Enabled: true,
@@ -87,6 +89,11 @@ func setupDSCInstance() *dsc.DataScienceCluster {
 						Enabled: false,
 					},
 				},
+				Ray: ray.Ray{
+					Component: components.Component{
+						Enabled: true,
+					},
+				},
 			},
 		},
 	}
@@ -104,7 +111,7 @@ func (tc *testContext) validateCRD(crdName string) error {
 			if errors.IsNotFound(err) {
 				return false, nil
 			}
-			log.Printf("Failed to get %s crd", crdName)
+			log.Printf("Failed to get CRD %s", crdName)
 			return false, err
 		}
 
@@ -115,7 +122,7 @@ func (tc *testContext) validateCRD(crdName string) error {
 				}
 			}
 		}
-		log.Printf("Error in getting %s crd ", crdName)
+		log.Printf("Error to get CRD %s condition's matching", crdName)
 		return false, nil
 
 	})

--- a/tests/e2e/odh_manager_test.go
+++ b/tests/e2e/odh_manager_test.go
@@ -9,24 +9,26 @@ import (
 func testODHOperatorValidation(t *testing.T) {
 	testCtx, err := NewTestContext()
 	require.NoError(t, err)
-	t.Run("Validate ODH Operator pod", testCtx.testODHDeployment)
-	t.Run("Validate CRDs owned by the operator", testCtx.validateOwnedCRDs)
+
+	t.Run("validate ODH Operator pod", testCtx.testODHDeployment)
+	t.Run("validate CRDs owned by the operator", testCtx.validateOwnedCRDs)
 }
 
 func (tc *testContext) testODHDeployment(t *testing.T) {
-	// Verify if the operator pod is running
+	// Verify if the operator deployment is created
 	require.NoErrorf(t, tc.waitForControllerDeployment("opendatahub-operator-controller-manager", 1),
 		"error in validating odh operator deployment")
 }
 
 func (tc *testContext) validateOwnedCRDs(t *testing.T) {
-	// Verify if all the required CRDs are installed
+	// Verify if 2 operators CRDs are installed
 	require.NoErrorf(t, tc.validateCRD("datascienceclusters.datasciencecluster.opendatahub.io"),
 		"error in validating CRD : datascienceclusters.datasciencecluster.opendatahub.io")
 
 	require.NoErrorf(t, tc.validateCRD("dscinitializations.dscinitialization.opendatahub.io"),
 		"error in validating CRD : dscinitializations.dscinitialization.opendatahub.io")
 
+	// Verify if 4 dashabord required CRDs are installed
 	require.NoErrorf(t, tc.validateCRD("odhquickstarts.console.openshift.io"),
 		"error in validating CRD : odhquickstarts.console.openshift.io")
 


### PR DESCRIPTION
## Description
- run check component test in parallel, other test case still in sequence
- add longer timeout due to new components(keep it here even updated testing in parallel)
- add Ray in the testing
- logs for error message
- enable test on "deletion"

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

took 761s (>10m)
![Screenshot from 2023-08-11 17-24-24](https://github.com/opendatahub-io/opendatahub-operator/assets/915053/8778b151-6472-4dbc-84d4-71342eaa09ad)

after change to run in parallel took 300s
![Screenshot from 2023-08-13 17-16-55](https://github.com/opendatahub-io/opendatahub-operator/assets/915053/9008de46-bf03-4515-9196-8a3d0c51ec1f)


## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
