### PR TITLE
Add support for custom subscription config

### DIFF
--- a/main.go
+++ b/main.go
@@ -156,45 +156,48 @@ func main() {
 	}
 
 	//+kubebuilder:scaffold:builder
-
-	// Create OCSInitialization CR if it's not present
-	client := mgr.GetClient()
-	releaseDscInitialization := &dsci.DSCInitialization{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "DSCInitialization",
-			APIVersion: "dscinitialization.opendatahub.io/v1alpha1",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "default",
-		},
-		Spec: dsci.DSCInitializationSpec{
-			ApplicationsNamespace: dscApplicationsNamespace,
-			Monitoring: dsci.Monitoring{
-				Enabled: false,
+	// Check if user opted for disabling DSC configuration
+	_, disableDSCConfig := os.LookupEnv("DISABLE_DSC_CONFIG")
+	if !disableDSCConfig {
+		// Create DSCInitialization CR if it's not present
+		client := mgr.GetClient()
+		releaseDscInitialization := &dsci.DSCInitialization{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "DSCInitialization",
+				APIVersion: "dscinitialization.opendatahub.io/v1alpha1",
 			},
-		},
-	}
-	err = client.Create(context.TODO(), releaseDscInitialization)
-	switch {
-	case err == nil:
-		setupLog.Info("created DscInitialization resource")
-	case errors.IsAlreadyExists(err):
-		// Update if already exists
-		setupLog.Info("DscInitialization resource already exists. Updating it.")
-		data, err := json.Marshal(releaseDscInitialization)
-		if err != nil {
-			setupLog.Error(err, "failed to get DscInitialization custom resource data")
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "default",
+			},
+			Spec: dsci.DSCInitializationSpec{
+				ApplicationsNamespace: dscApplicationsNamespace,
+				Monitoring: dsci.Monitoring{
+					Enabled: false,
+				},
+			},
 		}
-		err = client.Patch(context.TODO(), releaseDscInitialization, client2.RawPatch(types.ApplyPatchType, data),
-			client2.ForceOwnership, client2.FieldOwner("opendatahub-operator"))
-		if err != nil {
-			setupLog.Error(err, "failed to update DscInitialization custom resource")
+		err = client.Create(context.TODO(), releaseDscInitialization)
+		switch {
+		case err == nil:
+			setupLog.Info("created DscInitialization resource")
+		case errors.IsAlreadyExists(err):
+			// Update if already exists
+			setupLog.Info("DscInitialization resource already exists. Updating it.")
+			data, err := json.Marshal(releaseDscInitialization)
+			if err != nil {
+				setupLog.Error(err, "failed to get DscInitialization custom resource data")
+			}
+			err = client.Patch(context.TODO(), releaseDscInitialization, client2.RawPatch(types.ApplyPatchType, data),
+				client2.ForceOwnership, client2.FieldOwner("opendatahub-operator"))
+			if err != nil {
+				setupLog.Error(err, "failed to update DscInitialization custom resource")
+			}
+		default:
+			setupLog.Error(err, "failed to create DscInitialization custom resource")
+			os.Exit(1)
 		}
-	default:
-		setupLog.Error(err, "failed to create DscInitialization custom resource")
-		os.Exit(1)
-	}
 
+	}
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
 		setupLog.Error(err, "unable to set up health check")
 		os.Exit(1)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fixes #436 
## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
1. Deploy following dev catalogsource
```
quay.io/vhire/opendatahub-operator-catalog:v2.0.32 
```
2. Subscribe to operator using following subscription
```
apiVersion: operators.coreos.com/v1alpha1
kind: Subscription
metadata:
  name: opendatahub-operator
  namespace: openshift-operators
spec:
  channel: fast
  name: opendatahub-operator
  source: opendatahub-dev-catalog
  sourceNamespace: openshift-marketplace
  config:
     env:
        - name: "DISABLE_DSC_CONFIG"
```
3. Verify no namespaces are created
4. Verify when `DataScienceCluster` CR is created, it goes into Error phase

----
**To Enable Components**
5. Create `DSCInitialization` CR
```
apiVersion: dscinitialization.opendatahub.io/v1alpha1
kind: DSCInitialization
metadata:
  name: default
spec:
  monitoring:
    enabled: false
    namespace: 'opendatahub'
  applicationsNamespace: 'opendatahub'
```
6. Then create `DataScienceCluster` CR
```
apiVersion: datasciencecluster.opendatahub.io/v1alpha1
kind: DataScienceCluster
metadata:
  name: default
spec:
  components:
    dashboard:
      enabled: true
```
## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
