### PR TITLE
Update: refactory

### DIFF
--- a/bundle/manifests/opendatahub-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/opendatahub-operator.clusterserviceversion.yaml
@@ -9,9 +9,6 @@ metadata:
           "kind": "OdhQuickStart",
           "metadata": {
             "annotations": {
-              "internal.config.kubernetes.io/previousKinds": "OdhQuickStart",
-              "internal.config.kubernetes.io/previousNames": "create-jupyter-notebook",
-              "internal.config.kubernetes.io/previousNamespaces": "default",
               "opendatahub.io/categories": "Getting started,Notebook environments"
             },
             "labels": {
@@ -531,7 +528,6 @@ spec:
           resources:
           - builds
           verbs:
-          - catch
           - create
           - delete
           - list
@@ -621,6 +617,7 @@ spec:
           - create
           - delete
           - get
+          - list
           - patch
           - watch
         - apiGroups:
@@ -665,6 +662,7 @@ spec:
           - create
           - delete
           - get
+          - list
           - patch
           - update
           - watch
@@ -861,8 +859,9 @@ spec:
           resources:
           - dscinitializations/finalizers
           verbs:
+          - delete
           - get
-          - patchdelete
+          - patch
           - update
         - apiGroups:
           - dscinitialization.opendatahub.io

--- a/controllers/datasciencecluster/datasciencecluster_controller.go
+++ b/controllers/datasciencecluster/datasciencecluster_controller.go
@@ -284,7 +284,7 @@ func (r *DataScienceClusterReconciler) Reconcile(ctx context.Context, req ctrl.R
 	}
 
 	// Second check if instance exists, return
-	err := r.Client.Get(context.TODO(), types.NamespacedName{Name: req.Name}, instance)
+	err := r.Client.Get(ctx, req.NamespacedName, instance)
 	if err != nil {
 		if apierrs.IsNotFound(err) {
 			// DataScienceCluster instance not found
@@ -295,7 +295,7 @@ func (r *DataScienceClusterReconciler) Reconcile(ctx context.Context, req ctrl.R
 
 	// Last check if multiple instances of DataScienceCluster exist
 	instanceList := &dsc.DataScienceClusterList{}
-	err = r.Client.List(context.TODO(), instanceList)
+	err = r.Client.List(ctx, instanceList)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -310,7 +310,7 @@ func (r *DataScienceClusterReconciler) Reconcile(ctx context.Context, req ctrl.R
 	if instance.Status.Conditions == nil {
 		reason := status.ReconcileInit
 		message := "Initializing DataScienceCluster resource"
-		instance, err = r.updateStatus(instance, func(saved *dsc.DataScienceCluster) {
+		instance, err = r.updateStatus(ctx, instance, func(saved *dsc.DataScienceCluster) {
 			status.SetProgressingCondition(&saved.Status.Conditions, reason, message)
 			saved.Status.Phase = status.PhaseProgressing
 		})
@@ -333,7 +333,7 @@ func (r *DataScienceClusterReconciler) Reconcile(ctx context.Context, req ctrl.R
 	if len(dsciInstances.Items) == 0 {
 		reason := status.ReconcileFailed
 		message := "Failed to get a valid DSCInitialization instance"
-		instance, err = r.updateStatus(instance, func(saved *dsc.DataScienceCluster) {
+		instance, err = r.updateStatus(ctx, instance, func(saved *dsc.DataScienceCluster) {
 			status.SetProgressingCondition(&saved.Status.Conditions, reason, message)
 			saved.Status.Phase = status.PhaseError
 		})
@@ -351,7 +351,7 @@ func (r *DataScienceClusterReconciler) Reconcile(ctx context.Context, req ctrl.R
 	}
 
 	// Ensure all omitted components show up as explicitly disabled
-	instance, err = r.updateComponents(instance)
+	instance, err = r.updateComponents(ctx, instance)
 	if err != nil {
 		_ = r.reportError(err, instance, "error updating list of components in the CR")
 		return ctrl.Result{}, err
@@ -361,47 +361,47 @@ func (r *DataScienceClusterReconciler) Reconcile(ctx context.Context, req ctrl.R
 	componentErrorList := make(map[string]error)
 
 	// reconcile dashboard component
-	if instance, err = r.reconcileSubComponent(instance, dashboard.ComponentName, instance.Spec.Components.Dashboard.ManagementState,
+	if instance, err = r.reconcileSubComponent(ctx, instance, dashboard.ComponentName, instance.Spec.Components.Dashboard.ManagementState,
 		&(instance.Spec.Components.Dashboard)); err != nil {
 		// no need to log any errors as this is done in the reconcileSubComponent method
 		componentErrorList[dashboard.ComponentName] = err
 	}
 
 	// reconcile DataSciencePipelines component
-	if instance, err = r.reconcileSubComponent(instance, datasciencepipelines.ComponentName, instance.Spec.Components.DataSciencePipelines.ManagementState,
+	if instance, err = r.reconcileSubComponent(ctx, instance, datasciencepipelines.ComponentName, instance.Spec.Components.DataSciencePipelines.ManagementState,
 		&(instance.Spec.Components.DataSciencePipelines)); err != nil {
 		// no need to log any errors as this is done in the reconcileSubComponent method
 		componentErrorList[datasciencepipelines.ComponentName] = err
 	}
 
 	// reconcile Workbench component
-	if instance, err = r.reconcileSubComponent(instance, workbenches.ComponentName, instance.Spec.Components.Workbenches.ManagementState,
+	if instance, err = r.reconcileSubComponent(ctx, instance, workbenches.ComponentName, instance.Spec.Components.Workbenches.ManagementState,
 		&(instance.Spec.Components.Workbenches)); err != nil {
 		// no need to log any errors as this is done in the reconcileSubComponent method
 		componentErrorList[workbenches.ComponentName] = err
 	}
 
 	// reconcile Kserve component
-	if instance, err = r.reconcileSubComponent(instance, kserve.ComponentName, instance.Spec.Components.Kserve.ManagementState, &(instance.Spec.Components.Kserve)); err != nil {
+	if instance, err = r.reconcileSubComponent(ctx, instance, kserve.ComponentName, instance.Spec.Components.Kserve.ManagementState, &(instance.Spec.Components.Kserve)); err != nil {
 		// no need to log any errors as this is done in the reconcileSubComponent method
 		componentErrorList[kserve.ComponentName] = err
 	}
 
 	// reconcile ModelMesh component
-	if instance, err = r.reconcileSubComponent(instance, modelmeshserving.ComponentName, instance.Spec.Components.ModelMeshServing.ManagementState,
+	if instance, err = r.reconcileSubComponent(ctx, instance, modelmeshserving.ComponentName, instance.Spec.Components.ModelMeshServing.ManagementState,
 		&(instance.Spec.Components.ModelMeshServing)); err != nil {
 		// no need to log any errors as this is done in the reconcileSubComponent method
 		componentErrorList[modelmeshserving.ComponentName] = err
 	}
 
 	// reconcile CodeFlare component
-	if instance, err = r.reconcileSubComponent(instance, codeflare.ComponentName, instance.Spec.Components.CodeFlare.ManagementState, &(instance.Spec.Components.CodeFlare)); err != nil {
+	if instance, err = r.reconcileSubComponent(ctx, instance, codeflare.ComponentName, instance.Spec.Components.CodeFlare.ManagementState, &(instance.Spec.Components.CodeFlare)); err != nil {
 		// no need to log any errors as this is done in the reconcileSubComponent method
 		componentErrorList[codeflare.ComponentName] = err
 	}
 
 	// reconcile Ray component
-	if instance, err = r.reconcileSubComponent(instance, ray.ComponentName, instance.Spec.Components.Ray.ManagementState, &(instance.Spec.Components.Ray)); err != nil {
+	if instance, err = r.reconcileSubComponent(ctx, instance, ray.ComponentName, instance.Spec.Components.Ray.ManagementState, &(instance.Spec.Components.Ray)); err != nil {
 		// no need to log any errors as this is done in the reconcileSubComponent method
 		componentErrorList[ray.ComponentName] = err
 	}
@@ -409,7 +409,7 @@ func (r *DataScienceClusterReconciler) Reconcile(ctx context.Context, req ctrl.R
 	// Process errors for components
 	if componentErrorList != nil && len(componentErrorList) != 0 {
 		r.Log.Info("DataScienceCluster Deployment Incomplete.")
-		instance, err = r.updateStatus(instance, func(saved *dsc.DataScienceCluster) {
+		instance, err = r.updateStatus(ctx, instance, func(saved *dsc.DataScienceCluster) {
 			status.SetCompleteCondition(&saved.Status.Conditions, status.ReconcileCompletedWithComponentErrors,
 				fmt.Sprintf("DataScienceCluster resource reconciled with component errors: %v", fmt.Sprint(componentErrorList)))
 			saved.Status.Phase = status.PhaseReady
@@ -420,7 +420,7 @@ func (r *DataScienceClusterReconciler) Reconcile(ctx context.Context, req ctrl.R
 	}
 
 	// finalize reconciliation
-	instance, err = r.updateStatus(instance, func(saved *dsc.DataScienceCluster) {
+	instance, err = r.updateStatus(ctx, instance, func(saved *dsc.DataScienceCluster) {
 		status.SetCompleteCondition(&saved.Status.Conditions, status.ReconcileCompleted, "DataScienceCluster resource reconciled successfully")
 		saved.Status.Phase = status.PhaseReady
 	})
@@ -436,12 +436,12 @@ func (r *DataScienceClusterReconciler) Reconcile(ctx context.Context, req ctrl.R
 	return ctrl.Result{}, nil
 }
 
-func (r *DataScienceClusterReconciler) reconcileSubComponent(instance *dsc.DataScienceCluster, componentName string, mngmtState operatorv1.ManagementState,
+func (r *DataScienceClusterReconciler) reconcileSubComponent(ctx context.Context, instance *dsc.DataScienceCluster, componentName string, mngmtState operatorv1.ManagementState,
 	component components.ComponentInterface) (*dsc.DataScienceCluster, error) {
 	enabled := mngmtState == operatorv1.Managed
 
 	// First set contidions to reflect a component is about to be reconciled
-	instance, err := r.updateStatus(instance, func(saved *dsc.DataScienceCluster) {
+	instance, err := r.updateStatus(ctx, instance, func(saved *dsc.DataScienceCluster) {
 		if enabled {
 			status.SetComponentCondition(&saved.Status.Conditions, componentName, status.ReconcileInit, "Component is enabled", corev1.ConditionUnknown)
 		} else {
@@ -459,7 +459,7 @@ func (r *DataScienceClusterReconciler) reconcileSubComponent(instance *dsc.DataS
 	if err != nil {
 		// reconciliation failed: log errors, raise event and update status accordingly
 		instance = r.reportError(err, instance, "failed to reconcile "+componentName+" on DataScienceCluster")
-		instance, _ = r.updateStatus(instance, func(saved *dsc.DataScienceCluster) {
+		instance, _ = r.updateStatus(ctx, instance, func(saved *dsc.DataScienceCluster) {
 			if enabled {
 				status.SetComponentCondition(&saved.Status.Conditions, componentName, status.ReconcileFailed, fmt.Sprintf("Component reconciliation failed: %v", err), corev1.ConditionFalse)
 			} else {
@@ -469,7 +469,7 @@ func (r *DataScienceClusterReconciler) reconcileSubComponent(instance *dsc.DataS
 		return instance, err
 	} else {
 		// reconciliation succeeded: update status accordingly
-		instance, err = r.updateStatus(instance, func(saved *dsc.DataScienceCluster) {
+		instance, err = r.updateStatus(ctx, instance, func(saved *dsc.DataScienceCluster) {
 			if saved.Status.InstalledComponents == nil {
 				saved.Status.InstalledComponents = make(map[string]bool)
 			}
@@ -524,11 +524,11 @@ func (r *DataScienceClusterReconciler) SetupWithManager(mgr ctrl.Manager) error 
 		Complete(r)
 }
 
-func (r *DataScienceClusterReconciler) updateStatus(original *dsc.DataScienceCluster, update func(saved *dsc.DataScienceCluster)) (*dsc.DataScienceCluster, error) {
+func (r *DataScienceClusterReconciler) updateStatus(ctx context.Context, original *dsc.DataScienceCluster, update func(saved *dsc.DataScienceCluster)) (*dsc.DataScienceCluster, error) {
 	saved := &dsc.DataScienceCluster{}
 	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 
-		err := r.Client.Get(context.TODO(), client.ObjectKeyFromObject(original), saved)
+		err := r.Client.Get(ctx, client.ObjectKeyFromObject(original), saved)
 		if err != nil {
 			return err
 		}
@@ -537,6 +537,7 @@ func (r *DataScienceClusterReconciler) updateStatus(original *dsc.DataScienceClu
 
 		// Try to update
 		err = r.Client.Status().Update(context.TODO(), saved)
+
 		// Return err itself here (not wrapped inside another error)
 		// so that RetryOnConflict can identify it correctly.
 		return err
@@ -544,11 +545,10 @@ func (r *DataScienceClusterReconciler) updateStatus(original *dsc.DataScienceClu
 	return saved, err
 }
 
-func (r *DataScienceClusterReconciler) updateComponents(original *dsc.DataScienceCluster) (*dsc.DataScienceCluster, error) {
+func (r *DataScienceClusterReconciler) updateComponents(ctx context.Context, original *dsc.DataScienceCluster) (*dsc.DataScienceCluster, error) {
 	saved := &dsc.DataScienceCluster{}
 	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-
-		err := r.Client.Get(context.TODO(), client.ObjectKeyFromObject(original), saved)
+		err := r.Client.Get(ctx, client.ObjectKeyFromObject(original), saved)
 		if err != nil {
 			return err
 		}

--- a/controllers/secretgenerator/secretgenerator_controller.go
+++ b/controllers/secretgenerator/secretgenerator_controller.go
@@ -3,8 +3,9 @@ package secretgenerator
 import (
 	"context"
 	"fmt"
-	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"time"
+
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 
 	ocv1 "github.com/openshift/api/oauth/v1"
 	routev1 "github.com/openshift/api/route/v1"
@@ -84,11 +85,11 @@ func (r *SecretGeneratorReconciler) SetupWithManager(mgr ctrl.Manager) error {
 // conditions when a deployment mounts the secret before it is reconciled
 func (r *SecretGeneratorReconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.Result, error) {
 	foundSecret := &v1.Secret{}
-	err := r.Client.Get(context.TODO(), request.NamespacedName, foundSecret)
+	err := r.Client.Get(ctx, request.NamespacedName, foundSecret)
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
 			// If Secret is deleted, delete OAuthClient if exists
-			err = r.deleteOAuthClient(request.Name)
+			err = r.deleteOAuthClient(ctx, request.Name)
 		}
 		return ctrl.Result{}, err
 	}
@@ -108,7 +109,7 @@ func (r *SecretGeneratorReconciler) Reconcile(ctx context.Context, request ctrl.
 
 	generatedSecretKey := types.NamespacedName{
 		Name: generatedSecret.Name, Namespace: generatedSecret.Namespace}
-	err = r.Client.Get(context.TODO(), generatedSecretKey, generatedSecret)
+	err = r.Client.Get(ctx, generatedSecretKey, generatedSecret)
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
 			// Generate secret random value
@@ -125,20 +126,20 @@ func (r *SecretGeneratorReconciler) Reconcile(ctx context.Context, request ctrl.
 				secret.Name: secret.Value,
 			}
 
-			err = r.Client.Create(context.TODO(), generatedSecret)
+			err = r.Client.Create(ctx, generatedSecret)
 			if err != nil {
 				return ctrl.Result{}, err
 			}
 			if secret.OAuthClientRoute != "" {
 				// Get OauthClient Route
-				oauthClientRoute, err := r.getRoute(secret.OAuthClientRoute, request.Namespace)
+				oauthClientRoute, err := r.getRoute(ctx, secret.OAuthClientRoute, request.Namespace)
 				if err != nil {
 					secGenLog.Error(err, "Unable to retrieve route", "route-name", secret.OAuthClientRoute)
 					return ctrl.Result{}, err
 				}
 				// Generate OAuthClient for the generated secret
 				secGenLog.Info("Generating an oauth client resource for route", "route-name", oauthClientRoute.Name)
-				err = r.createOAuthClient(foundSecret.Name, secret.Value, oauthClientRoute.Spec.Host)
+				err = r.createOAuthClient(ctx, foundSecret.Name, secret.Value, oauthClientRoute.Spec.Host)
 				if err != nil {
 					secGenLog.Error(err, "error creating oauth client resource. Recreate the Secret", "secret-name",
 						foundSecret.Name)
@@ -155,12 +156,14 @@ func (r *SecretGeneratorReconciler) Reconcile(ctx context.Context, request ctrl.
 }
 
 // getRoute returns an OpenShift route object. It waits until the .spec.host value exists to avoid possible race conditions, fails otherwise.
-func (r *SecretGeneratorReconciler) getRoute(name string, namespace string) (*routev1.Route, error) {
+func (r *SecretGeneratorReconciler) getRoute(ctx context.Context, name string, namespace string) (*routev1.Route, error) {
 	route := &routev1.Route{}
 	// Get spec.host from route
 	err := wait.PollImmediate(resourceRetryInterval, resourceRetryTimeout, func() (done bool, err error) {
-		err = r.Client.Get(context.TODO(), types.NamespacedName{Name: name,
-			Namespace: namespace}, route)
+		err = r.Client.Get(ctx, client.ObjectKey{
+			Name:      name,
+			Namespace: namespace,
+		}, route)
 		if err != nil {
 			if k8serrors.IsNotFound(err) {
 				return false, nil
@@ -179,10 +182,13 @@ func (r *SecretGeneratorReconciler) getRoute(name string, namespace string) (*ro
 	return route, err
 }
 
-func (r *SecretGeneratorReconciler) createOAuthClient(name string, secretName string, uri string) error {
+func (r *SecretGeneratorReconciler) createOAuthClient(ctx context.Context, name string, secretName string, uri string) error {
 	// Create OAuthClient resource
 	oauthClient := &ocv1.OAuthClient{
-		TypeMeta: metav1.TypeMeta{},
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "OAuthClient",
+			APIVersion: "v1",
+		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
 		},
@@ -191,7 +197,7 @@ func (r *SecretGeneratorReconciler) createOAuthClient(name string, secretName st
 		GrantMethod:  ocv1.GrantHandlerAuto,
 	}
 
-	err := r.Client.Create(context.TODO(), oauthClient)
+	err := r.Client.Create(ctx, oauthClient)
 	if err != nil {
 		if k8serrors.IsAlreadyExists(err) {
 			secGenLog.Info("OAuth client resource already exists", "name", oauthClient.Name)
@@ -201,10 +207,12 @@ func (r *SecretGeneratorReconciler) createOAuthClient(name string, secretName st
 	return err
 }
 
-func (r *SecretGeneratorReconciler) deleteOAuthClient(secretName string) error {
+func (r *SecretGeneratorReconciler) deleteOAuthClient(ctx context.Context, secretName string) error {
 	oauthClient := &ocv1.OAuthClient{}
 
-	err := r.Client.Get(context.TODO(), types.NamespacedName{Name: secretName}, oauthClient)
+	err := r.Client.Get(ctx, client.ObjectKey{
+		Name: secretName,
+	}, oauthClient)
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
 			return nil
@@ -212,10 +220,10 @@ func (r *SecretGeneratorReconciler) deleteOAuthClient(secretName string) error {
 		return err
 	}
 
-	err = r.Client.Delete(context.TODO(), oauthClient)
+	err = r.Client.Delete(ctx, oauthClient)
 	if err != nil {
 		return fmt.Errorf("error deleting OAuthClient %v", oauthClient.Name)
 	}
 
-	return err
+	return nil
 }


### PR DESCRIPTION
## Description
- replace `context.TODO()` with `context.Context`
- replace` types.NamespacedName{Name: req.Name}` with `req.NamespacedName`
- explicit set rolebinding, configmap and networkpolicy type when create them
 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

local build: quay.io/wenzhou/opendatahub-operator-catalog:v2.8.21-0
rolebinding, configmap and networkpolicy are created
enable dashboard and workbench, can access 


## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
