### PR TITLE
Add support for manifestUri to overwrite params.env images

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,14 @@ Refer [Dev-Preview.md](./docs/Dev-Preview.md) for testing preview features.
   operator-sdk run bundle quay.io/<username>/opendatahub-operator-bundle:<VERSION> --namespace $OPERATOR_NAMESPACE
   ```
 
+### Test with customized manifests
+
+There are 2 ways to test your changes with modification:
+
+1. set `devFlags.ManifestsUri` field of DSCI instance during runtime: this will pull down manifests from remote git repo
+    by using this method, it overwrites manifests and component images if images are set in the params.env file
+2. [Under implementation] build operator image with local manifests   
+
 ### Example DataScienceCluster 
 
 When the operator is installed successfully in the cluster, a user can create a `DataScienceCluster` CR to enable ODH 

--- a/components/README.md
+++ b/components/README.md
@@ -31,7 +31,7 @@ can be found [here](https://github.com/opendatahub-io/opendatahub-operator/tree/
     ```go
     type ComponentInterface interface {
         ReconcileComponent(owner metav1.Object, client client.Client, scheme *runtime.Scheme,
-            enabled bool, namespace string) error
+            enabled bool, namespace string, manifestsUri string) error
         GetComponentName() string
         SetImageParamsMap(imageMap map[string]string) map[string]string
     }

--- a/components/codeflare/codeflare.go
+++ b/components/codeflare/codeflare.go
@@ -37,7 +37,7 @@ func (d *CodeFlare) GetComponentName() string {
 // Verifies that CodeFlare implements ComponentInterface
 var _ components.ComponentInterface = (*CodeFlare)(nil)
 
-func (d *CodeFlare) ReconcileComponent(owner metav1.Object, client client.Client, scheme *runtime.Scheme, managementState operatorv1.ManagementState, namespace string) error {
+func (d *CodeFlare) ReconcileComponent(owner metav1.Object, client client.Client, scheme *runtime.Scheme, managementState operatorv1.ManagementState, namespace string, manifestsUri string) error {
 	enabled := managementState == operatorv1.Managed
 
 	if enabled {
@@ -53,12 +53,14 @@ func (d *CodeFlare) ReconcileComponent(owner metav1.Object, client client.Client
 			}
 		}
 
-		// Update image parameters
-		if err := deploy.ApplyImageParams(CodeflarePath, imageParamMap); err != nil {
-			return err
+		// Update image parameters only when we do not have customized manifests set
+		if manifestsUri == "" {
+			if err := deploy.ApplyImageParams(CodeflarePath, imageParamMap); err != nil {
+				return err
+			}
 		}
-
 	}
+
 	// Deploy Codeflare
 	err := deploy.DeployManifestsFromPath(owner, client, ComponentName,
 		CodeflarePath,

--- a/components/component.go
+++ b/components/component.go
@@ -23,7 +23,7 @@ type Component struct {
 
 type ComponentInterface interface {
 	ReconcileComponent(owner metav1.Object, client client.Client, scheme *runtime.Scheme,
-		managementState operatorv1.ManagementState, namespace string) error
+		managementState operatorv1.ManagementState, namespace string, manifestsUri string) error
 	GetComponentName() string
 	SetImageParamsMap(imageMap map[string]string) map[string]string
 }

--- a/components/dashboard/dashboard.go
+++ b/components/dashboard/dashboard.go
@@ -52,7 +52,7 @@ func (d *Dashboard) GetComponentName() string {
 // Verifies that Dashboard implements ComponentInterface
 var _ components.ComponentInterface = (*Dashboard)(nil)
 
-func (d *Dashboard) ReconcileComponent(owner metav1.Object, cli client.Client, scheme *runtime.Scheme, managementState operatorv1.ManagementState, namespace string) error {
+func (d *Dashboard) ReconcileComponent(owner metav1.Object, cli client.Client, scheme *runtime.Scheme, managementState operatorv1.ManagementState, namespace string, manifestsUri string) error {
 	enabled := managementState == operatorv1.Managed
 
 	// TODO: Add any additional tasks if required when reconciling component
@@ -63,7 +63,6 @@ func (d *Dashboard) ReconcileComponent(owner metav1.Object, cli client.Client, s
 	}
 
 	if enabled {
-		// Update Default rolebinding
 		if platform == deploy.OpenDataHub || platform == "" {
 			err := common.UpdatePodSecurityRolebinding(cli, []string{"odh-dashboard"}, namespace)
 			if err != nil {
@@ -127,11 +126,13 @@ func (d *Dashboard) ReconcileComponent(owner metav1.Object, cli client.Client, s
 				return fmt.Errorf("failed to deploy anaconda resources from %s: %v", PathAnaconda, err)
 			}
 		}
-	}
 
-	// Update image parameters
-	if err := deploy.ApplyImageParams(Path, imageParamMap); err != nil {
-		return err
+		// Update image parameters
+		if manifestsUri == "" {
+			if err := deploy.ApplyImageParams(Path, imageParamMap); err != nil {
+				return err
+			}
+		}
 	}
 
 	// Deploy odh-dashboard manifests

--- a/components/datasciencepipelines/datasciencepipelines.go
+++ b/components/datasciencepipelines/datasciencepipelines.go
@@ -40,20 +40,22 @@ func (d *DataSciencePipelines) GetComponentName() string {
 // Verifies that Dashboard implements ComponentInterface
 var _ components.ComponentInterface = (*DataSciencePipelines)(nil)
 
-func (d *DataSciencePipelines) ReconcileComponent(owner metav1.Object, client client.Client, scheme *runtime.Scheme, managementState operatorv1.ManagementState, namespace string) error {
+func (d *DataSciencePipelines) ReconcileComponent(owner metav1.Object, client client.Client, scheme *runtime.Scheme, managementState operatorv1.ManagementState, namespace string, manifestsUri string) error {
 	enabled := managementState == operatorv1.Managed
 
-	// Update image parameters
-	if err := deploy.ApplyImageParams(Path, imageParamMap); err != nil {
-		return err
+	if enabled {
+		// Update image parameters
+		if manifestsUri == "" {
+			if err := deploy.ApplyImageParams(Path, imageParamMap); err != nil {
+				return err
+			}
+		}
 	}
-
 	err := deploy.DeployManifestsFromPath(owner, client, ComponentName,
 		Path,
 		namespace,
 		scheme, enabled)
 	return err
-
 }
 
 func (in *DataSciencePipelines) DeepCopyInto(out *DataSciencePipelines) {

--- a/components/kserve/kserve.go
+++ b/components/kserve/kserve.go
@@ -46,12 +46,14 @@ func (d *Kserve) GetComponentName() string {
 // Verifies that Kserve implements ComponentInterface
 var _ components.ComponentInterface = (*Kserve)(nil)
 
-func (d *Kserve) ReconcileComponent(owner metav1.Object, cli client.Client, scheme *runtime.Scheme, managementState operatorv1.ManagementState, namespace string) error {
+func (d *Kserve) ReconcileComponent(owner metav1.Object, cli client.Client, scheme *runtime.Scheme, managementState operatorv1.ManagementState, namespace string, manifestsUri string) error {
 	enabled := managementState == operatorv1.Managed
 
 	// Update image parameters
-	if err := deploy.ApplyImageParams(Path, imageParamMap); err != nil {
-		return err
+	if manifestsUri == "" {
+		if err := deploy.ApplyImageParams(Path, imageParamMap); err != nil {
+			return err
+		}
 	}
 
 	if err := deploy.DeployManifestsFromPath(owner, cli, ComponentName,
@@ -66,11 +68,12 @@ func (d *Kserve) ReconcileComponent(owner metav1.Object, cli client.Client, sche
 		if err != nil {
 			return err
 		}
-	}
-
-	// Update image parameters
-	if err := deploy.ApplyImageParams(Path, dependentImageParamMap); err != nil {
-		return err
+		// Update image parameters for keserve
+		if manifestsUri == "" {
+			if err := deploy.ApplyImageParams(Path, dependentImageParamMap); err != nil {
+				return err
+			}
+		}
 	}
 
 	if err := deploy.DeployManifestsFromPath(owner, cli, ComponentName,

--- a/components/modelmeshserving/modelmeshserving.go
+++ b/components/modelmeshserving/modelmeshserving.go
@@ -44,7 +44,7 @@ func (m *ModelMeshServing) SetImageParamsMap(imageMap map[string]string) map[str
 // Verifies that Dashboard implements ComponentInterface
 var _ components.ComponentInterface = (*ModelMeshServing)(nil)
 
-func (m *ModelMeshServing) ReconcileComponent(owner metav1.Object, cli client.Client, scheme *runtime.Scheme, managementState operatorv1.ManagementState, namespace string) error {
+func (m *ModelMeshServing) ReconcileComponent(owner metav1.Object, cli client.Client, scheme *runtime.Scheme, managementState operatorv1.ManagementState, namespace string, manifestsUri string) error {
 	enabled := managementState == operatorv1.Managed
 
 	// Update Default rolebinding
@@ -53,10 +53,12 @@ func (m *ModelMeshServing) ReconcileComponent(owner metav1.Object, cli client.Cl
 		if err != nil {
 			return err
 		}
-	}
-	// Update image parameters
-	if err := deploy.ApplyImageParams(Path, imageParamMap); err != nil {
-		return err
+		// Update image parameters
+		if manifestsUri == "" {
+			if err := deploy.ApplyImageParams(Path, imageParamMap); err != nil {
+				return err
+			}
+		}
 	}
 
 	err := deploy.DeployManifestsFromPath(owner, cli, ComponentName,

--- a/components/ray/ray.go
+++ b/components/ray/ray.go
@@ -35,13 +35,15 @@ func (d *Ray) GetComponentName() string {
 // Verifies that Ray implements ComponentInterface
 var _ components.ComponentInterface = (*Ray)(nil)
 
-func (d *Ray) ReconcileComponent(owner metav1.Object, client client.Client, scheme *runtime.Scheme, managementState operatorv1.ManagementState, namespace string) error {
+func (d *Ray) ReconcileComponent(owner metav1.Object, client client.Client, scheme *runtime.Scheme, managementState operatorv1.ManagementState, namespace string, manifestsUri string) error {
 	enabled := managementState == operatorv1.Managed
 
 	// Update image parameters
 	if enabled {
-		if err := deploy.ApplyImageParams(RayPath, imageParamMap); err != nil {
-			return err
+		if manifestsUri == "" {
+			if err := deploy.ApplyImageParams(RayPath, imageParamMap); err != nil {
+				return err
+			}
 		}
 	}
 	// Deploy Ray Operator

--- a/components/workbenches/workbenches.go
+++ b/components/workbenches/workbenches.go
@@ -38,7 +38,7 @@ func (w *Workbenches) SetImageParamsMap(imageMap map[string]string) map[string]s
 // Verifies that Dashboard implements ComponentInterface
 var _ components.ComponentInterface = (*Workbenches)(nil)
 
-func (w *Workbenches) ReconcileComponent(owner metav1.Object, cli client.Client, scheme *runtime.Scheme, managementState operatorv1.ManagementState, namespace string) error {
+func (w *Workbenches) ReconcileComponent(owner metav1.Object, cli client.Client, scheme *runtime.Scheme, managementState operatorv1.ManagementState, namespace string, manifestsUri string) error {
 	enabled := managementState == operatorv1.Managed
 
 	// Set default notebooks namespace
@@ -61,11 +61,12 @@ func (w *Workbenches) ReconcileComponent(owner metav1.Object, cli client.Client,
 		if err != nil {
 			return err
 		}
-
-	}
-	// Update image parameters
-	if err := deploy.ApplyImageParams(notebookControllerPath, imageParamMap); err != nil {
-		return err
+		// Update image parameters for notebook controller
+		if manifestsUri == "" {
+			if err := deploy.ApplyImageParams(notebookControllerPath, imageParamMap); err != nil {
+				return err
+			}
+		}
 	}
 
 	err = deploy.DeployManifestsFromPath(owner, cli, ComponentName,
@@ -76,9 +77,13 @@ func (w *Workbenches) ReconcileComponent(owner metav1.Object, cli client.Client,
 		return err
 	}
 
-	// Update image parameters
-	if err := deploy.ApplyImageParams(notebookImagesPath, imageParamMap); err != nil {
-		return err
+	// Update image parameters for notebook image
+	if enabled {
+		if manifestsUri == "" {
+			if err := deploy.ApplyImageParams(notebookImagesPath, imageParamMap); err != nil {
+				return err
+			}
+		}
 	}
 	err = deploy.DeployManifestsFromPath(owner, cli, ComponentName,
 		notebookImagesPath,

--- a/controllers/datasciencecluster/datasciencecluster_controller.go
+++ b/controllers/datasciencecluster/datasciencecluster_controller.go
@@ -64,6 +64,7 @@ type DataScienceClusterReconciler struct {
 	// Recorder to generate events
 	Recorder              record.EventRecorder
 	ApplicationsNamespace string
+	ManifestsUri          string
 }
 
 //+kubebuilder:rbac:groups="datasciencepipelinesapplications.opendatahub.io",resources=datasciencepipelinesapplications/status,verbs=update;patch
@@ -347,6 +348,8 @@ func (r *DataScienceClusterReconciler) Reconcile(ctx context.Context, req ctrl.R
 	} else if len(dsciInstances.Items) == 1 {
 		// Set Applications namespace defined in DSCInitialization
 		r.ApplicationsNamespace = dsciInstances.Items[0].Spec.ApplicationsNamespace
+		r.ManifestsUri = dsciInstances.Items[0].Spec.DevFlags.ManifestsUri
+
 	} else {
 		return ctrl.Result{}, fmt.Errorf(fmt.Sprintf("only one instance of DSCInitialization object is allowed."))
 	}
@@ -455,7 +458,7 @@ func (r *DataScienceClusterReconciler) reconcileSubComponent(instance *dsc.DataS
 	}
 
 	// Reconcile component
-	err = component.ReconcileComponent(instance, r.Client, r.Scheme, mngmtState, r.ApplicationsNamespace)
+	err = component.ReconcileComponent(instance, r.Client, r.Scheme, mngmtState, r.ApplicationsNamespace, r.ManifestsUri)
 
 	if err != nil {
 		// reconciliation failed: log errors, raise event and update status accordingly

--- a/pkg/deploy/deploy.go
+++ b/pkg/deploy/deploy.go
@@ -289,6 +289,14 @@ func manageResource(owner metav1.Object, ctx context.Context, cli client.Client,
 	return cli.Patch(ctx, found, client.RawPatch(types.ApplyPatchType, data), client.ForceOwnership, client.FieldOwner(owner.GetName()))
 }
 
+/*
+User env variable passed from CSV (if it is set) to overwrite values from manifests' params.env file
+This is useful for air gapped cluster
+priority of image values (from high to low):
+- image values set in manifests params.env if manifestsURI is set
+- RELATED_IMAGE_* values from CSV
+- image values set in manifests params.env if manifestsURI is not set
+*/
 func ApplyImageParams(componentPath string, imageParamsMap map[string]string) error {
 	envFilePath := componentPath + "/params.env"
 	// Require params.env at the root folder
@@ -318,6 +326,7 @@ func ApplyImageParams(componentPath string, imageParamsMap map[string]string) er
 	}
 
 	// Update images with env variables
+	// e.g "odh-kuberay-operator-controller-image": "RELATED_IMAGE_ODH_KUBERAY_OPERATOR_CONTROLLER_IMAGE",
 	for key, _ := range envMap {
 		relatedImageValue := os.Getenv(imageParamsMap[key])
 		if relatedImageValue != "" {
@@ -325,10 +334,8 @@ func ApplyImageParams(componentPath string, imageParamsMap map[string]string) er
 		}
 	}
 
-	// Move the existing file to a backup file
+	// Move the existing file to a backup file and create empty file
 	os.Rename(envFilePath, backupPath)
-
-	// Now, write the map back to the file
 	file, err = os.Create(envFilePath)
 	if err != nil {
 		// If create fails, restore the backup file
@@ -337,6 +344,7 @@ func ApplyImageParams(componentPath string, imageParamsMap map[string]string) er
 	}
 	defer file.Close()
 
+	// Now, write the map back to the file
 	writer := bufio.NewWriter(file)
 	for key, value := range envMap {
 		fmt.Fprintf(writer, "%s=%s\n", key, value)
@@ -352,6 +360,7 @@ func ApplyImageParams(componentPath string, imageParamsMap map[string]string) er
 		return err
 	}
 
+	// cleanup backup file
 	if err := os.Remove(backupPath); err != nil {
 		fmt.Printf("Failed to remove backup file: %v", err)
 		return err


### PR DESCRIPTION
## Description

- when manifestsUri is set in DSCSI spec, use image from it is setting
ref: https://github.com/opendatahub-io/opendatahub-operator/issues/460

- also some fix for the enabled in workbench to not applyimageparams


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
local build quay.io/wenzhou/opendatahub-operator-catalog:v2.8.23-460
test on ray component, steps
- current `odh-mainfests ray `from `master` branch is set to use `quay.io/opendatahub/kuberay-operator:v0.5.0`
- add in CSV with a different tag 0.3.0

```
env:
                    - name: RELATED_IMAGE_ODH_KUBERAY_OPERATOR_CONTROLLER_IMAGE
                      value: "quay.io/opendatahub/kuberay-operator:v0.3.0"
```
- install operator and see pod is up with env set to v0.3.0 (from env RELATED_IMAGE_ODH_KUBERAY_OPERATOR_CONTROLLER_IMAGE)
![Screenshot from 2023-08-23 11-57-22](https://github.com/opendatahub-io/opendatahub-operator/assets/915053/d619cd64-1ecf-4c7d-83f9-14dc5ea1ba16)
-  login to terminal can check params.env
![Screenshot from 2023-08-23 12-04-55](https://github.com/opendatahub-io/opendatahub-operator/assets/915053/8616b310-85ec-40dd-9166-2a464bc878eb)


- use test branch `https://github.comzdtsw-forking/odh-manifests/issue/460_test` with change in `odh-manifests/ray/operator/base/params.env` to `quay.io/opendatahub/kuberay-operator:latest`


- set ManiestsUri to my test branch
![Screenshot from 2023-08-23 12-06-00](https://github.com/opendatahub-io/opendatahub-operator/assets/915053/36a70b9f-7b0b-4cc3-ac0b-338209f2f5d5)

- reconcile starts and login to termnial, see params.env is set to latest
![Screenshot from 2023-08-23 12-08-05](https://github.com/opendatahub-io/opendatahub-operator/assets/915053/71d0aae0-5eaa-4fbc-8fa1-a052983a491f)


## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
