### PR TITLE
Update github action to sync dashboard CRD to v2 operator

### DIFF
--- a/.github/workflows/sync_dashboard_crds.yaml
+++ b/.github/workflows/sync_dashboard_crds.yaml
@@ -1,29 +1,41 @@
-# Opens a PR in the opendatahub-operator repo when crds are updated in the dashboard repo
-name: Sync Dashboard CRDs
+# Opens a PR in the opendatahub-operator repo to sync crds from the dashboard repo
+name: Sync Dashboard CRDs for Operator v2.x
 
 # Await dispatch from dashboard repo that crds have been modified
 on:
-  workflow_dispatch
+  # Triggers the workflow every Sat at 22pm UTC am 0 22 * * 6
+  schedule:
+    - cron: "0 22 * * 6"
+  workflow_dispatch:
+    inputs:
+      dashboard_label:
+        default: "main"
+        description: "Label from odh-dashboard to sync CRD from, default to use main branch"
+      source_branch:
+        default: "main"
+        description: "branch of opendatahub-operator to checkout from"
 
 jobs:
   dashboard-sync:
     runs-on: ubuntu-latest
     steps:
-      - name: Git checkout
+      - name: Checkout operator source code on master branch
         uses: actions/checkout@v3
         with:
-          fetch-depth: '0'
+          fetch-depth: '1'
+          ref: ${{ github.event.inputs.source_branch }}
       - name: Gather files
         shell: bash
         run: |
-          cd ${{ github.workspace }}/config/crd/dashboard-crds
-          svn export --force https://github.com/opendatahub-io/odh-dashboard/branches/main/manifests/crd .
+          cd ${{ github.workspace }}/bundle/manifests
+          svn export --force "https://github.com/opendatahub-io/odh-dashboard/tags/${{ github.event.inputs.dashboard_label }}/manifests/crd" .
           rm kustomization.yaml
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v4.2.3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          branch: dashboard-sync
-          commit-message: Automated Change
-          title: Sync operator crds with dashboard crds
-          body: This is an automated pull request to sync the operator crds with dashboard crds.
+          commit-message: Automated Change by GitHub Action 'Sync Dashboard CRDs for Operator v2.x'
+          delete-branch: true
+          title: Sync operator v2.X dashboard CRDs from 'odh-dashboard' manifests CRDs
+          body: This is an automated PR to sync the operator CRDs with dashboard CRDs.
+          signoff: true


### PR DESCRIPTION
## Description
- either manually trigger with input dashboard release tag
- or run on a weekly(sat night) basis
-  similar to the GH action setup for v1 but with some modification: default branch, add crontab and some wording

ref: https://github.com/opendatahub-io/opendatahub-operator/issues/464

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
