### PR TITLE
Update: change default for DSCI monitoring to "true"

### DIFF
--- a/apis/dscinitialization/v1alpha1/dscinitialization_types.go
+++ b/apis/dscinitialization/v1alpha1/dscinitialization_types.go
@@ -40,8 +40,8 @@ type DSCInitializationSpec struct {
 }
 
 type Monitoring struct {
-	// +kubebuilder:default=false
-	// If enabled monitoring, default 'false'
+	// +kubebuilder:default=true
+	// If enabled monitoring, default 'true'
 	Enabled bool `json:"enabled,omitempty"`
 	// +kubebuilder:default=opendatahub
 	// Namespace for monitoring if it is enabled

--- a/bundle/manifests/dscinitialization.opendatahub.io_dscinitializations.yaml
+++ b/bundle/manifests/dscinitialization.opendatahub.io_dscinitializations.yaml
@@ -57,8 +57,8 @@ spec:
                 description: Enable monitoring on specified namespace
                 properties:
                   enabled:
-                    default: false
-                    description: If enabled monitoring, default 'false'
+                    default: true
+                    description: If enabled monitoring, default 'true'
                     type: boolean
                   namespace:
                     default: opendatahub

--- a/bundle/manifests/opendatahub-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/opendatahub-operator.clusterserviceversion.yaml
@@ -9,9 +9,6 @@ metadata:
           "kind": "OdhQuickStart",
           "metadata": {
             "annotations": {
-              "internal.config.kubernetes.io/previousKinds": "OdhQuickStart",
-              "internal.config.kubernetes.io/previousNames": "create-jupyter-notebook",
-              "internal.config.kubernetes.io/previousNamespaces": "default",
               "opendatahub.io/categories": "Getting started,Notebook environments"
             },
             "labels": {

--- a/config/crd/bases/dscinitialization.opendatahub.io_dscinitializations.yaml
+++ b/config/crd/bases/dscinitialization.opendatahub.io_dscinitializations.yaml
@@ -58,8 +58,8 @@ spec:
                 description: Enable monitoring on specified namespace
                 properties:
                   enabled:
-                    default: false
-                    description: If enabled monitoring, default 'false'
+                    default: true
+                    description: If enabled monitoring, default 'true'
                     type: boolean
                   namespace:
                     default: opendatahub

--- a/main.go
+++ b/main.go
@@ -172,7 +172,7 @@ func main() {
 			Spec: dsci.DSCInitializationSpec{
 				ApplicationsNamespace: dscApplicationsNamespace,
 				Monitoring: dsci.Monitoring{
-					Enabled: false,
+					Enabled: true,
 				},
 			},
 		}


### PR DESCRIPTION
## Description
ref: https://github.com/opendatahub-io/opendatahub-operator/issues/479
- once DSCI installed will create monitoring namespace
- when modelmesh component is Managed it will not cause issue

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
