### PR TITLE
Fix: explictly check platform is selfmanaged or managed

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ following environment variables must be set when running locally:
 export KUBECONFIG=/path/to/kubeconfig
 ```
 
+Ensure when testing RHODS operator in dev mode, no ODH CSV exists
 Once the above variables are set, run the following:
 
 ```shell

--- a/components/workbenches/workbenches.go
+++ b/components/workbenches/workbenches.go
@@ -48,7 +48,7 @@ func (w *Workbenches) ReconcileComponent(owner metav1.Object, cli client.Client,
 	}
 
 	if enabled {
-		if platform != deploy.OpenDataHub {
+		if platform == deploy.SelfManagedRhods || platform == deploy.ManagedRhods{
 			err := common.CreateNamespace(cli, "rhods-notebooks")
 			if err != nil {
 				// no need to log error as it was already logged in createOdhNamespace


### PR DESCRIPTION
## Description
- when dev/test mode, done by olm (make deploy) without CSV, platform return ""
- explicitly set if self-managed or managed than not odh

ref: https://github.com/opendatahub-io/opendatahub-operator/issues/482

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
local image: push quay.io/wenzhou/opendatahub-operator:dev-2.8.999-1
manually update dashbord from enabled true to false and back to true in e2e-test DSC instance, pod created then removed and created again.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
