### PR TITLE
Removing DSC version v1alpha1 from the CSV

### DIFF
--- a/config/manifests/bases/opendatahub-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/opendatahub-operator.clusterserviceversion.yaml
@@ -65,15 +65,6 @@ spec:
       - description: Override and fine tune specific component configurations.
         displayName: Components
         path: components
-      version: v1alpha1
-    - description: DataScienceCluster is the Schema for the datascienceclusters API
-      displayName: Data Science Cluster
-      kind: DataScienceCluster
-      name: datascienceclusters.datasciencecluster.opendatahub.io
-      specDescriptors:
-      - description: Override and fine tune specific component configurations.
-        displayName: Components
-        path: components
       version: v1
     - description: DSCInitialization is the Schema for the dscinitializations API
       displayName: DSC Initialization


### PR DESCRIPTION
Removing DSC version v1alpha1 from the CSV as it is being replaced by v1 without backward support.

## Merge criteria:
- [X] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
