### PR TITLE
Fix typo in groupname

### DIFF
--- a/apis/dscinitialization/v1/groupversion_info.go
+++ b/apis/dscinitialization/v1/groupversion_info.go
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 // +kubebuilder:object:generate=true
-// +groupName=datasciencecluster.opendatahub.io
+// +groupName=dscinitialization.opendatahub.io
 
 // Package v1 contains API Schema definitions for the dscinitialization v1 API group
 package v1


### PR DESCRIPTION
## Description
introduced in https://github.com/opendatahub-io/opendatahub-operator/pull/488
it does not harm for current code base, since we do not have change in API, but it does generate one extra wrong `config/crd/bases/datasciencecluster.opendatahub.io_dscinitializations.yaml` locally when run `"make manifests"`

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
