### PR TITLE
Add check on dependent operators on KServe 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ VERSION ?= 2.1.0
 # opendatahub.io/opendatahub-operator-bundle:$VERSION and opendatahub.io/opendatahub-operator-catalog:$VERSION.
 IMAGE_TAG_BASE ?= quay.io/$(IMAGE_OWNER)/opendatahub-operator
 # Update IMG to a variable, to keep it consistent across versions for OpenShift CI
-IMG ?= REPLACE_IMAGE
+IMG ?= REPLACE_IMAGE 
 # BUNDLE_IMG defines the image:tag used for the bundle.
 # You can use it as an arg. (E.g make bundle-build BUNDLE_IMG=<some-registry>/<project-name-bundle>:<tag>)
 BUNDLE_IMG ?= $(IMAGE_TAG_BASE)-bundle:v$(VERSION)

--- a/bundle/manifests/opendatahub-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/opendatahub-operator.clusterserviceversion.yaml
@@ -9,6 +9,9 @@ metadata:
           "kind": "OdhQuickStart",
           "metadata": {
             "annotations": {
+              "internal.config.kubernetes.io/previousKinds": "OdhQuickStart",
+              "internal.config.kubernetes.io/previousNames": "create-jupyter-notebook",
+              "internal.config.kubernetes.io/previousNamespaces": "default",
               "opendatahub.io/categories": "Getting started,Notebook environments"
             },
             "labels": {
@@ -1148,6 +1151,14 @@ spec:
           - delete
           - get
           - patch
+        - apiGroups:
+          - operators.coreos.com
+          resources:
+          - operatorconditions
+          verbs:
+          - get
+          - list
+          - watch
         - apiGroups:
           - operators.coreos.com
           resources:

--- a/components/datasciencepipelines/datasciencepipelines.go
+++ b/components/datasciencepipelines/datasciencepipelines.go
@@ -41,18 +41,20 @@ func (d *DataSciencePipelines) GetComponentName() string {
 // Verifies that Dashboard implements ComponentInterface
 var _ components.ComponentInterface = (*DataSciencePipelines)(nil)
 
-func (d *DataSciencePipelines) ReconcileComponent(owner metav1.Object, client client.Client, scheme *runtime.Scheme, managementState operatorv1.ManagementState, dscispec *dsci.DSCInitializationSpec) error {
+func (d *DataSciencePipelines) ReconcileComponent(owner metav1.Object, cli client.Client, scheme *runtime.Scheme, managementState operatorv1.ManagementState, dscispec *dsci.DSCInitializationSpec) error {
 	enabled := managementState == operatorv1.Managed
 
 	if enabled {
-		// Update image parameters
+		// check if the dependent operator installed is done in dashboard
+
+		// Update image parameters only when we do not have customized manifests set
 		if dscispec.DevFlags.ManifestsUri == "" {
 			if err := deploy.ApplyImageParams(Path, imageParamMap); err != nil {
 				return err
 			}
 		}
 	}
-	err := deploy.DeployManifestsFromPath(owner, client, ComponentName,
+	err := deploy.DeployManifestsFromPath(owner, cli, ComponentName,
 		Path,
 		dscispec.ApplicationsNamespace,
 		scheme, enabled)

--- a/components/ray/ray.go
+++ b/components/ray/ray.go
@@ -36,10 +36,9 @@ func (d *Ray) GetComponentName() string {
 // Verifies that Ray implements ComponentInterface
 var _ components.ComponentInterface = (*Ray)(nil)
 
-func (d *Ray) ReconcileComponent(owner metav1.Object, client client.Client, scheme *runtime.Scheme, managementState operatorv1.ManagementState, dscispec *dsci.DSCInitializationSpec) error {
+func (d *Ray) ReconcileComponent(owner metav1.Object, cli client.Client, scheme *runtime.Scheme, managementState operatorv1.ManagementState, dscispec *dsci.DSCInitializationSpec) error {
 	enabled := managementState == operatorv1.Managed
 
-	// Update image parameters
 	if enabled {
 		if dscispec.DevFlags.ManifestsUri == "" {
 			if err := deploy.ApplyImageParams(RayPath, imageParamMap); err != nil {
@@ -48,7 +47,7 @@ func (d *Ray) ReconcileComponent(owner metav1.Object, client client.Client, sche
 		}
 	}
 	// Deploy Ray Operator
-	err := deploy.DeployManifestsFromPath(owner, client, ComponentName,
+	err := deploy.DeployManifestsFromPath(owner, cli, ComponentName,
 		RayPath,
 		dscispec.ApplicationsNamespace,
 		scheme, enabled)

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -867,6 +867,14 @@ rules:
 - apiGroups:
   - operators.coreos.com
   resources:
+  - operatorconditions
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - operators.coreos.com
+  resources:
   - subscriptions
   verbs:
   - get

--- a/controllers/datasciencecluster/kubebuilder_rbac.go
+++ b/controllers/datasciencecluster/kubebuilder_rbac.go
@@ -17,6 +17,8 @@ package datasciencecluster
 
 // +kubebuilder:rbac:groups="operators.coreos.com",resources=clusterserviceversions,verbs=get;list;watch
 // +kubebuilder:rbac:groups="operators.coreos.com",resources=customresourcedefinitions,verbs=create;get;patch;delete
+// +kubebuilder:rbac:groups="operators.coreos.com",resources=subscriptions,verbs=get;list;watch
+// +kubebuilder:rbac:groups="operators.coreos.com",resources=operatorconditions,verbs=get;list;watch
 
 // +kubebuilder:rbac:groups="apiextensions.k8s.io",resources=customresourcedefinitions,verbs=get;list;watch
 
@@ -66,8 +68,6 @@ package datasciencecluster
 // +kubebuilder:rbac:groups="ray.io",resources=rayservices,verbs=create;delete;list;watch;update;patch
 // +kubebuilder:rbac:groups="ray.io",resources=rayjobs,verbs=create;delete;list;update;watch;patch
 // +kubebuilder:rbac:groups="ray.io",resources=rayclusters,verbs=create;delete;list;patch
-
-// +kubebuilder:rbac:groups="operators.coreos.com",resources=subscriptions,verbs=get;list;watch
 
 // +kubebuilder:rbac:groups="operator.openshift.io",resources=consoles,verbs=list;watch;patch;delete
 

--- a/main.go
+++ b/main.go
@@ -31,7 +31,8 @@ import (
 	ocv1 "github.com/openshift/api/oauth/v1"
 	routev1 "github.com/openshift/api/route/v1"
 	ocuserv1 "github.com/openshift/api/user/v1"
-	ofapi "github.com/operator-framework/api/pkg/operators/v1alpha1"
+	ofapiv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
+	ofapiv2 "github.com/operator-framework/api/pkg/operators/v2"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	netv1 "k8s.io/api/networking/v1"
@@ -73,8 +74,9 @@ func init() {
 	utilruntime.Must(routev1.AddToScheme(scheme))
 	utilruntime.Must(appsv1.AddToScheme(scheme))
 	utilruntime.Must(ocv1.AddToScheme(scheme))
-	utilruntime.Must(ofapi.AddToScheme(scheme))
+	utilruntime.Must(ofapiv1alpha1.AddToScheme(scheme))
 	utilruntime.Must(ocuserv1.AddToScheme(scheme))
+	utilruntime.Must(ofapiv2.AddToScheme(scheme))
 	//+kubebuilder:scaffold:scheme
 }
 

--- a/tests/e2e/helper_test.go
+++ b/tests/e2e/helper_test.go
@@ -82,7 +82,7 @@ func setupDSCInstance() *dsc.DataScienceCluster {
 				},
 				Kserve: kserve.Kserve{
 					Component: components.Component{
-						ManagementState: operatorv1.Removed,
+						ManagementState: operatorv1.Managed,
 					},
 				},
 				CodeFlare: codeflare.CodeFlare{


### PR DESCRIPTION
## Description
- similar to what we are doing for codeflare, add check on Kserve
- for code consistency, set to use "cli" instead of "client" in components, since some are calling `client.ObjectKey{}`
- create new function to check operatorCondition which is auto created once operator is installed and removed when operator is uninstalled.
- enabled e2e kserve component
ref: https://github.com/opendatahub-io/opendatahub-operator/issues/434

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
**update with new commit:**
new test image: quay.io/wenzhou/opendatahub-operator-catalog:v2.9.5-497-4
install ODH operator, but no pipeline operator
![Screenshot from 2023-09-05 13-35-20](https://github.com/opendatahub-io/opendatahub-operator/assets/915053/00d5263f-62f3-4ad4-947c-9ce8f07d512e)

operator reconcile with error
![Screenshot from 2023-09-05 13-35-55](https://github.com/opendatahub-io/opendatahub-operator/assets/915053/94daf91d-0a70-4432-b96c-2e49b7f28dab)

then install pipeline operator 
![Screenshot from 2023-09-05 13-37-11](https://github.com/opendatahub-io/opendatahub-operator/assets/915053/3d3b2729-c084-4f59-b3e4-04116541e583)

all done
![Screenshot from 2023-09-05 13-36-59](https://github.com/opendatahub-io/opendatahub-operator/assets/915053/9de67423-9128-4a5b-8eff-76bb4fceea97)

**old test on first commit, can ignore below:**
test with: quay.io/wenzhou/opendatahub-operator:dev-2.8.31-1

![Screenshot from 2023-08-31 10-45-55](https://github.com/opendatahub-io/opendatahub-operator/assets/915053/440227f1-b85a-4eec-bfc7-3fe47d86a0be)
![Screenshot from 2023-08-31 10-47-22](https://github.com/opendatahub-io/opendatahub-operator/assets/915053/ea4d8cac-ada3-46a0-8472-4fad4506637a)
![Screenshot from 2023-08-31 10-53-43](https://github.com/opendatahub-io/opendatahub-operator/assets/915053/722a910a-bcf2-45a8-8254-f4697d806d4c)

test with no operators installed but kserve and dsp enabled
then install 3 operators and opendatahub-operator pod stopped reconciliation. 

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
