### PR TITLE
fix(reconcile): corrects KfDef status in case of any error

### DIFF
--- a/controllers/kfdef.apps.kubeflow.org/kfdef_controller.go
+++ b/controllers/kfdef.apps.kubeflow.org/kfdef_controller.go
@@ -247,13 +247,11 @@ func (r *KfDefReconciler) Reconcile(ctx context.Context, request ctrl.Request) (
 	}
 
 	// set status of the KfDef resource
-	if err := r.reconcileStatus(instance); err != nil {
-		return ctrl.Result{}, err
+	if reconcileError := r.reconcileStatus(instance); reconcileError != nil {
+		return ctrl.Result{}, reconcileError
 	}
 
-	// If deployment created successfully - don't requeue
-
-	return ctrl.Result{}, nil
+	return ctrl.Result{}, err
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/controllers/kfdef.apps.kubeflow.org/status.go
+++ b/controllers/kfdef.apps.kubeflow.org/status.go
@@ -40,7 +40,11 @@ func (r *KfDefReconciler) reconcileStatus(cr *kfdefv1.KfDef) error {
 func getReconcileStatus(cr *kfdefv1.KfDef, err error) error {
 	conditions := []kfdefv1.KfDefCondition{}
 
+	availabilityStatus := corev1.ConditionTrue
+
 	if err != nil {
+		availabilityStatus = corev1.ConditionFalse
+
 		conditions = append(conditions, kfdefv1.KfDefCondition{
 			LastUpdateTime: cr.CreationTimestamp,
 			Status:         corev1.ConditionTrue,
@@ -51,7 +55,7 @@ func getReconcileStatus(cr *kfdefv1.KfDef, err error) error {
 
 	conditions = append(conditions, kfdefv1.KfDefCondition{
 		LastUpdateTime: cr.CreationTimestamp,
-		Status:         corev1.ConditionTrue,
+		Status:         availabilityStatus,
 		Reason:         DeploymentCompleted,
 		Type:           kfdefv1.KfAvailable,
 	})


### PR DESCRIPTION
## Description

If the reconcile fails when trying to apply `KfDef` it can end-up in a "Schrodinger" state, meaning it's marked as successfully deployed but also degraded, where it can often means not all defined components are deployed despite the status claiming otherwise.

```yaml
status:
    conditions:
    - lastUpdateTime: "2023-08-31T08:54:48Z"
      reason: the server could not find the requested resource
      status: "True"
      type: Degraded
    - lastUpdateTime: "2023-08-31T08:54:48Z"
      reason: Kubeflow Deployment completed
      status: "True"
      type: Available
```

Whereas it should be

```yaml
status:
    conditions:
    - lastUpdateTime: "2023-08-31T08:54:48Z"
      reason: the server could not find the requested resource
      status: "True"
      type: Degraded
    - lastUpdateTime: "2023-08-31T08:54:48Z"
      reason: Kubeflow Deployment completed
      status: "False"
      type: Available
```

In addition, in case of failing on kf.Apply it actually returns an `err` leading to back-offed reconciliation. Previously it was always returning `nil`, leaving the deployment in an odd state and finished reconciliation.

## How Has This Been Tested?

Manually on CRC, as `make test` fails for me from the latest `master`

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
