### PR TITLE
Fix and Cleanup: applyimageparams on kserve

### DIFF
--- a/components/codeflare/codeflare.go
+++ b/components/codeflare/codeflare.go
@@ -61,7 +61,7 @@ func (d *CodeFlare) ReconcileComponent(owner metav1.Object, client client.Client
 				return err
 			} else {
 				return fmt.Errorf("operator %s not found in namespace %s. Please install the operator before enabling %s component",
-				dependentOperator, dependentOperatorNamespace, ComponentName)
+					dependentOperator, dependentOperatorNamespace, ComponentName)
 			}
 		}
 

--- a/components/kserve/kserve.go
+++ b/components/kserve/kserve.go
@@ -20,13 +20,10 @@ const (
 	DependentPath          = deploy.DefaultManifestPath + "/" + DependentComponentName + "/base"
 )
 
-var imageParamMap = map[string]string{
-	"kserve-router":              "RELATED_IMAGE_ODH_KSERVE_ROUTE_IMAGE",
-	"kserve-agent":               "RELATED_IMAGE_ODH_KSERVE_AGENT_IMAGE",
-	"kserve-controller":          "RELATED_IMAGE_ODH_KSERVE_CONTROLLER_IMAGE",
-	"kserve-storage-initializer": "RELATED_IMAGE_ODH_KSERVE_STORAGE_INITIALIZER_IMAGE",
-}
+// Kserve to use
+var imageParamMap = map[string]string{}
 
+// odh-model-controller to use
 var dependentImageParamMap = map[string]string{
 	"odh-model-controller": "RELATED_IMAGE_ODH_MODEL_CONTROLLER_IMAGE",
 }
@@ -56,7 +53,6 @@ func (d *Kserve) ReconcileComponent(owner metav1.Object, cli client.Client, sche
 			return err
 		}
 	}
-
 	if err := deploy.DeployManifestsFromPath(owner, cli, ComponentName,
 		Path,
 		dscispec.ApplicationsNamespace,
@@ -64,6 +60,7 @@ func (d *Kserve) ReconcileComponent(owner metav1.Object, cli client.Client, sche
 		return err
 	}
 
+	// For odh-model-controller
 	if enabled {
 		err := common.UpdatePodSecurityRolebinding(cli, []string{"odh-model-controller"}, dscispec.ApplicationsNamespace)
 		if err != nil {
@@ -76,15 +73,14 @@ func (d *Kserve) ReconcileComponent(owner metav1.Object, cli client.Client, sche
 			}
 		}
 	}
-
 	if err := deploy.DeployManifestsFromPath(owner, cli, ComponentName,
 		DependentPath,
 		dscispec.ApplicationsNamespace,
 		scheme, enabled); err != nil {
 		return err
 	}
-	return nil
 
+	return nil
 }
 
 func (in *Kserve) DeepCopyInto(out *Kserve) {

--- a/controllers/datasciencecluster/datasciencecluster_controller.go
+++ b/controllers/datasciencecluster/datasciencecluster_controller.go
@@ -90,7 +90,7 @@ func (r *DataScienceClusterReconciler) Reconcile(ctx context.Context, req ctrl.R
 	}
 
 	if len(instances.Items) == 0 {
-    // DataScienceCluster instance not found
+		// DataScienceCluster instance not found
 		return ctrl.Result{}, nil
 	}
 


### PR DESCRIPTION
## Description
[cherry-pick] from https://github.com/red-hat-data-services/rhods-operator/pull/51
- kserve only use images from quay.io, remove variables, ref https://github.com/opendatahub-io/opendatahub-operator/issues/503
- add comments to be more clear
- fix wrong path of reconcile manifests after params.env is updated cherry-pick from https://github.com/red-hat-data-services/rhods-operator/pull/51


<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
