### PR TITLE
Fix: downstream codeflare has a different operator name than upstream

### DIFF
--- a/components/dashboard/dashboard.go
+++ b/components/dashboard/dashboard.go
@@ -175,7 +175,7 @@ func (d *Dashboard) ReconcileComponent(owner metav1.Object, cli client.Client, s
 		consolelinkDomain := consoleRoute.Spec.Host[domainIndex+1:]
 		err = common.ReplaceStringsInFile(PathConsoleLink, map[string]string{
 			"<rhods-dashboard-url>": "https://rhods-dashboard-" + namespace + "." + consolelinkDomain,
-			"<section-title>": "OpenShift Self Managed Services",
+			"<section-title>":       "OpenShift Self Managed Services",
 		})
 		if err != nil {
 			return fmt.Errorf("error replacing with correct dashboard url for ConsoleLink: %v", err)
@@ -206,7 +206,7 @@ func (d *Dashboard) ReconcileComponent(owner metav1.Object, cli client.Client, s
 		consolelinkDomain := consoleRoute.Spec.Host[domainIndex+1:]
 		err = common.ReplaceStringsInFile(PathConsoleLink, map[string]string{
 			"<rhods-dashboard-url>": "https://rhods-dashboard-" + namespace + "." + consolelinkDomain,
-			"<section-title>": "OpenShift Managed Services",
+			"<section-title>":       "OpenShift Managed Services",
 		})
 		if err != nil {
 			return fmt.Errorf("Error replacing with correct dashboard url for ConsoleLink: %v", err)

--- a/components/workbenches/workbenches.go
+++ b/components/workbenches/workbenches.go
@@ -49,7 +49,7 @@ func (w *Workbenches) ReconcileComponent(owner metav1.Object, cli client.Client,
 	}
 
 	if enabled {
-		if platform == deploy.SelfManagedRhods || platform == deploy.ManagedRhods{
+		if platform == deploy.SelfManagedRhods || platform == deploy.ManagedRhods {
 			err := common.CreateNamespace(cli, "rhods-notebooks")
 			if err != nil {
 				// no need to log error as it was already logged in createOdhNamespace


### PR DESCRIPTION
## Description
ref: https://issues.redhat.com/browse/RHODS-11706

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
**local ODH build image:** quay.io/wenzhou/opendatahub-operator-catalog:v2.9.5-11706

a bit difficult to test this, because i need a rhods subscription to test non-ODH case.
maybe easier to use this l**ocal rhods build image:**  quay.io/wenzhou/opendatahub-operator-catalog:v2.9.5-11706-2


## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
