### PR TITLE
Fix: in e2e or dev test should not apply addon manifests

### DIFF
--- a/components/workbenches/workbenches.go
+++ b/components/workbenches/workbenches.go
@@ -88,7 +88,7 @@ func (w *Workbenches) ReconcileComponent(owner metav1.Object, cli client.Client,
 		}
 	}
 
-	if platform == deploy.OpenDataHub {
+	if platform == deploy.OpenDataHub || platform == "" {
 		err = deploy.DeployManifestsFromPath(owner, cli, ComponentName,
 			notebookImagesPath,
 			dscispec.ApplicationsNamespace,


### PR DESCRIPTION
## Description
related to https://github.com/opendatahub-io/opendatahub-operator/pull/521
when run e2e locally got error 
`error during resmap resources: must build at directory: not a valid directory: evalsymlink failure on '/opt/manifests/jupyterhub/notebook-images/overlays/additional/default' : lstat /opt/manifests/jupyterhub: no such file or directory]"}
`
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
