### PR TITLE
Fix: downstream workbranch to get imageparams

### DIFF
--- a/components/workbenches/workbenches.go
+++ b/components/workbenches/workbenches.go
@@ -82,8 +82,14 @@ func (w *Workbenches) ReconcileComponent(owner metav1.Object, cli client.Client,
 	// Update image parameters for notebook image
 	if enabled {
 		if dscispec.DevFlags.ManifestsUri == "" {
-			if err := deploy.ApplyImageParams(notebookImagesPath, imageParamMap); err != nil {
-				return err
+			if platform == deploy.OpenDataHub || platform == "" {
+				if err := deploy.ApplyImageParams(notebookImagesPath, imageParamMap); err != nil {
+					return err
+				}
+			} else {
+				if err := deploy.ApplyImageParams(notebookImagesPathSupported, imageParamMap); err != nil {
+					return err
+				}
 			}
 		}
 	}


### PR DESCRIPTION
## Description
when test downstream, got error: 

`2023-09-08T13:19:56Z	ERROR	controllers.DataScienceCluster	failed to reconcile workbenches on DataScienceCluster	{"instance.Name": "default", "error": "error during resmap resources: must build at directory: not a valid directory: evalsymlink failure on '/opt/manifests/notebook-images/overlays/additional/default' : lstat /opt/manifests/notebook-images: no such file or directory"}`

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
