### PR TITLE
Update path for downstream dashboard image to use

### DIFF
--- a/components/dashboard/dashboard.go
+++ b/components/dashboard/dashboard.go
@@ -128,9 +128,9 @@ func (d *Dashboard) ReconcileComponent(owner metav1.Object, cli client.Client, s
 			}
 		}
 
-		// Update image parameters
+		// Update image parameters (ODH does not use this solution, only downstream)
 		if dscispec.DevFlags.ManifestsUri == "" {
-			if err := deploy.ApplyImageParams(Path, imageParamMap); err != nil {
+			if err := deploy.ApplyImageParams(PathSupported, imageParamMap); err != nil {
 				return err
 			}
 		}


### PR DESCRIPTION
## Description
when in https://github.com/red-hat-data-services/odh-manifests/pull/446 the structure is changed, thus for ODH it does not matter for a missing params.env file but downstream need it to be swapped with midstream built image.
before this the file was located in the `Path` 
ref: https://issues.redhat.com/browse/RHODS-11814
https://github.com/red-hat-data-services/odh-manifests/blob/master/odh-dashboard/overlays/rhods/params.env

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
