### PR TITLE
Fix: missing permission is needed when DSP is disabled, to keep same behavior as for v1

### DIFF
--- a/bundle/manifests/opendatahub-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/opendatahub-operator.clusterserviceversion.yaml
@@ -9,9 +9,6 @@ metadata:
           "kind": "OdhQuickStart",
           "metadata": {
             "annotations": {
-              "internal.config.kubernetes.io/previousKinds": "OdhQuickStart",
-              "internal.config.kubernetes.io/previousNames": "create-jupyter-notebook",
-              "internal.config.kubernetes.io/previousNamespaces": "default",
               "opendatahub.io/categories": "Getting started,Notebook environments"
             },
             "labels": {
@@ -425,6 +422,18 @@ spec:
           verbs:
           - '*'
         - apiGroups:
+          - authentication.k8s.io
+          resources:
+          - tokenreviews
+          verbs:
+          - create
+        - apiGroups:
+          - authorization.k8s.io
+          resources:
+          - subjectaccessreviews
+          verbs:
+          - create
+        - apiGroups:
           - authorization.openshift.io
           resources:
           - clusterrolebindings
@@ -565,6 +574,15 @@ spec:
           verbs:
           - list
           - watch
+        - apiGroups:
+          - console.openshift.io
+          resources:
+          - consolelinks
+          verbs:
+          - create
+          - delete
+          - get
+          - patch
         - apiGroups:
           - console.openshift.io
           resources:
@@ -818,6 +836,7 @@ spec:
           verbs:
           - create
           - delete
+          - get
           - list
           - patch
           - update
@@ -834,6 +853,7 @@ spec:
           resources:
           - datasciencepipelinesapplications/status
           verbs:
+          - get
           - patch
           - update
         - apiGroups:
@@ -908,6 +928,12 @@ spec:
           - patch
           - update
           - watch
+        - apiGroups:
+          - image.openshift.io
+          resources:
+          - imagestreamtags
+          verbs:
+          - get
         - apiGroups:
           - integreatly.org
           resources:
@@ -1010,6 +1036,7 @@ spec:
           verbs:
           - create
           - delete
+          - get
           - list
           - patch
         - apiGroups:
@@ -1174,6 +1201,7 @@ spec:
           verbs:
           - create
           - delete
+          - get
           - list
           - patch
         - apiGroups:
@@ -1183,6 +1211,7 @@ spec:
           verbs:
           - create
           - delete
+          - get
           - list
           - patch
           - update
@@ -1194,6 +1223,7 @@ spec:
           verbs:
           - create
           - delete
+          - get
           - list
           - patch
           - update
@@ -1444,6 +1474,7 @@ spec:
           verbs:
           - create
           - delete
+          - get
           - patch
         - apiGroups:
           - tekton.dev
@@ -1457,6 +1488,17 @@ spec:
           - templates
           verbs:
           - '*'
+        - apiGroups:
+          - user.openshift.io
+          resources:
+          - groups
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - watch
         - apiGroups:
           - user.openshift.io
           resources:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -138,6 +138,18 @@ rules:
   verbs:
   - '*'
 - apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+- apiGroups:
   - authorization.openshift.io
   resources:
   - clusterrolebindings
@@ -550,6 +562,7 @@ rules:
   verbs:
   - create
   - delete
+  - get
   - list
   - patch
   - update
@@ -566,6 +579,7 @@ rules:
   resources:
   - datasciencepipelinesapplications/status
   verbs:
+  - get
   - patch
   - update
 - apiGroups:
@@ -640,6 +654,12 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - image.openshift.io
+  resources:
+  - imagestreamtags
+  verbs:
+  - get
 - apiGroups:
   - integreatly.org
   resources:
@@ -742,6 +762,7 @@ rules:
   verbs:
   - create
   - delete
+  - get
   - list
   - patch
 - apiGroups:
@@ -906,6 +927,7 @@ rules:
   verbs:
   - create
   - delete
+  - get
   - list
   - patch
 - apiGroups:
@@ -915,6 +937,7 @@ rules:
   verbs:
   - create
   - delete
+  - get
   - list
   - patch
   - update
@@ -926,6 +949,7 @@ rules:
   verbs:
   - create
   - delete
+  - get
   - list
   - patch
   - update
@@ -1176,6 +1200,7 @@ rules:
   verbs:
   - create
   - delete
+  - get
   - patch
 - apiGroups:
   - tekton.dev

--- a/controllers/datasciencecluster/kubebuilder_rbac.go
+++ b/controllers/datasciencecluster/kubebuilder_rbac.go
@@ -5,9 +5,12 @@ package datasciencecluster
 //+kubebuilder:rbac:groups="datasciencecluster.opendatahub.io",resources=datascienceclusters,verbs=get;list;watch;create;update;patch;delete
 
 /* This is for DSP */
-//+kubebuilder:rbac:groups="datasciencepipelinesapplications.opendatahub.io",resources=datasciencepipelinesapplications/status,verbs=update;patch
+//+kubebuilder:rbac:groups="datasciencepipelinesapplications.opendatahub.io",resources=datasciencepipelinesapplications/status,verbs=update;patch;get
 //+kubebuilder:rbac:groups="datasciencepipelinesapplications.opendatahub.io",resources=datasciencepipelinesapplications/finalizers,verbs=update;patch
-//+kubebuilder:rbac:groups="datasciencepipelinesapplications.opendatahub.io",resources=datasciencepipelinesapplications,verbs=create;delete;list;update;watch;patch
+//+kubebuilder:rbac:groups="datasciencepipelinesapplications.opendatahub.io",resources=datasciencepipelinesapplications,verbs=create;delete;list;update;watch;patch;get
+//+kubebuilder:rbac:groups="image.openshift.io",resources=imagestreamtags,verbs=get
+//+kubebuilder:rbac:groups="authentication.k8s.io",resources=tokenreviews,verbs=create
+//+kubebuilder:rbac:groups="authorization.k8s.io",resources=subjectaccessreviews,verbs=create
 
 /* This is for dashboard */
 // +kubebuilder:rbac:groups="opendatahub.io",resources=odhdashboardconfigs,verbs=create;get;patch;watch;update;delete;list
@@ -28,7 +31,7 @@ package datasciencecluster
 
 // +kubebuilder:rbac:groups="tekton.dev",resources=*,verbs=*
 
-// +kubebuilder:rbac:groups="snapshot.storage.k8s.io",resources=volumesnapshots,verbs=create;delete;patch
+// +kubebuilder:rbac:groups="snapshot.storage.k8s.io",resources=volumesnapshots,verbs=create;delete;patch;get
 
 // +kubebuilder:rbac:groups="serving.kserve.io",resources=trainedmodels/status,verbs=update;patch;delete
 // +kubebuilder:rbac:groups="serving.kserve.io",resources=trainedmodels,verbs=create;delete;list;update;watch;patch
@@ -65,9 +68,9 @@ package datasciencecluster
 
 // +kubebuilder:rbac:groups="rbac.authorization.k8s.io",resources=clusterrolebindings,verbs=*
 
-// +kubebuilder:rbac:groups="ray.io",resources=rayservices,verbs=create;delete;list;watch;update;patch
-// +kubebuilder:rbac:groups="ray.io",resources=rayjobs,verbs=create;delete;list;update;watch;patch
-// +kubebuilder:rbac:groups="ray.io",resources=rayclusters,verbs=create;delete;list;patch
+// +kubebuilder:rbac:groups="ray.io",resources=rayservices,verbs=create;delete;list;watch;update;patch;get
+// +kubebuilder:rbac:groups="ray.io",resources=rayjobs,verbs=create;delete;list;update;watch;patch;get
+// +kubebuilder:rbac:groups="ray.io",resources=rayclusters,verbs=create;delete;list;patch;get
 
 // +kubebuilder:rbac:groups="operator.openshift.io",resources=consoles,verbs=list;watch;patch;delete
 
@@ -85,7 +88,7 @@ package datasciencecluster
 // +kubebuilder:rbac:groups="monitoring.coreos.com",resources=prometheusrules,verbs=get;create;patch;delete
 // +kubebuilder:rbac:groups="monitoring.coreos.com",resources=prometheuses,verbs=get;create;patch;delete
 
-// +kubebuilder:rbac:groups="mcad.ibm.com",resources=appwrappers,verbs=create;delete;list;patch
+// +kubebuilder:rbac:groups="mcad.ibm.com",resources=appwrappers,verbs=create;delete;list;patch;get
 
 // +kubebuilder:rbac:groups="machinelearning.seldon.io",resources=seldondeployments,verbs=*
 
@@ -128,7 +131,6 @@ package datasciencecluster
 // +kubebuilder:rbac:groups="core",resources=namespaces,verbs=get;create;patch;delete;watch;update;list
 
 // +kubebuilder:rbac:groups="core",resources=events,verbs=get;create;watch;update;list;patch;delete
-// +kubebuilder:rbac:groups="core",resources=events,verbs=delete
 // +kubebuilder:rbac:groups="events.k8s.io",resources=events,verbs=list;watch;patch;delete
 
 // +kubebuilder:rbac:groups="core",resources=endpoints,verbs=watch;list


### PR DESCRIPTION
## Description
ref: https://github.com/opendatahub-io/opendatahub-operator/issues/519
some of the permissions from https://github.com/red-hat-data-services/odh-manifests/blob/master/data-science-pipelines-operator/rbac/role.yaml is not there.
in v2, only when enable DSP they will be added, but if we want v2 works as v1, we need eg. get be there.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
local build **quay.io/wenzhou/opendatahub-operator-catalog:v2.9.519**

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
