### PR TITLE
Add aggregate clusterroles from workbench,dspa,modelmesh

### DIFF
--- a/bundle/manifests/opendatahub-operator-aggregate-dspa-admin-edit_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/bundle/manifests/opendatahub-operator-aggregate-dspa-admin-edit_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,21 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+  name: opendatahub-operator-aggregate-dspa-admin-edit
+rules:
+- apiGroups:
+  - datasciencepipelinesapplications.opendatahub.io
+  resources:
+  - datasciencepipelinesapplications
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete

--- a/bundle/manifests/opendatahub-operator-model-serving-admin_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/bundle/manifests/opendatahub-operator-model-serving-admin_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,12 @@
+aggregationRule:
+  clusterRoleSelectors:
+  - matchLabels:
+      rbac.authorization.k8s.io/aggregate-to-model-serving-admin: "true"
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+  name: opendatahub-operator-model-serving-admin
+rules: []

--- a/bundle/manifests/opendatahub-operator-model-serving-edit_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/bundle/manifests/opendatahub-operator-model-serving-edit_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,22 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    rbac.authorization.k8s.io/aggregate-to-model-serving-admin: "true"
+  name: opendatahub-operator-model-serving-edit
+rules:
+- apiGroups:
+  - serving.kserve.io
+  resources:
+  - inferenceservices
+  - servingruntimes
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch

--- a/bundle/manifests/opendatahub-operator-model-serving-view_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/bundle/manifests/opendatahub-operator-model-serving-view_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,21 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+  name: opendatahub-operator-model-serving-view
+rules:
+- apiGroups:
+  - kubeflow.org
+  resources:
+  - servingruntimes
+  - servingruntimes/status
+  - servingruntimes/finalizers
+  - inferenceservices
+  - inferenceservices/status
+  - inferenceservices/finalizers
+  verbs:
+  - get
+  - list
+  - watch

--- a/bundle/manifests/opendatahub-operator-notebooks-admin_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/bundle/manifests/opendatahub-operator-notebooks-admin_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,12 @@
+aggregationRule:
+  clusterRoleSelectors:
+  - matchLabels:
+      rbac.authorization.k8s.io/aggregate-to-notebooks-admin: "true"
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+  name: opendatahub-operator-notebooks-admin
+rules: []

--- a/bundle/manifests/opendatahub-operator-notebooks-edit_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/bundle/manifests/opendatahub-operator-notebooks-edit_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,23 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    rbac.authorization.k8s.io/aggregate-to-notebooks-admin: "true"
+  name: opendatahub-operator-notebooks-edit
+rules:
+- apiGroups:
+  - kubeflow.org
+  resources:
+  - notebooks
+  - notebooks/status
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+  - deletecollection
+  - patch
+  - update

--- a/bundle/manifests/opendatahub-operator-notebooks-view_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/bundle/manifests/opendatahub-operator-notebooks-view_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+  name: opendatahub-operator-notebooks-view
+rules:
+- apiGroups:
+  - kubeflow.org
+  resources:
+  - notebooks
+  - notebooks/status
+  verbs:
+  - get
+  - list
+  - watch

--- a/bundle/manifests/opendatahub-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/opendatahub-operator.clusterserviceversion.yaml
@@ -559,14 +559,24 @@ spec:
           - instascales
           verbs:
           - create
+          - delete
+          - get
+          - list
           - patch
+          - update
+          - watch
         - apiGroups:
           - codeflare.codeflare.dev
           resources:
           - mcads
           verbs:
           - create
+          - delete
+          - get
+          - list
           - patch
+          - update
+          - watch
         - apiGroups:
           - config.openshift.io
           resources:

--- a/config/rbac/aggregate-dspa-admin-edit.yaml
+++ b/config/rbac/aggregate-dspa-admin-edit.yaml
@@ -1,0 +1,20 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+  name: aggregate-dspa-admin-edit
+rules:
+  - apiGroups:
+      - datasciencepipelinesapplications.opendatahub.io
+    resources:
+      - datasciencepipelinesapplications
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete

--- a/config/rbac/aggregate-modelmesh-admin.yaml
+++ b/config/rbac/aggregate-modelmesh-admin.yaml
@@ -1,0 +1,56 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: model-serving-admin
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+aggregationRule:
+  clusterRoleSelectors:
+    - matchLabels:
+        rbac.authorization.k8s.io/aggregate-to-model-serving-admin: "true"
+rules: []
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: model-serving-edit
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    rbac.authorization.k8s.io/aggregate-to-model-serving-admin: "true"
+rules:
+  - apiGroups:
+      - serving.kserve.io
+    resources:
+      - inferenceservices
+      - servingruntimes
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: model-serving-view
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+rules:
+  - apiGroups:
+      - kubeflow.org
+    resources:
+      - servingruntimes
+      - servingruntimes/status
+      - servingruntimes/finalizers
+      - inferenceservices
+      - inferenceservices/status
+      - inferenceservices/finalizers
+    verbs:
+      - get
+      - list
+      - watch

--- a/config/rbac/aggregate-nbc-admin.yaml
+++ b/config/rbac/aggregate-nbc-admin.yaml
@@ -1,0 +1,54 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: notebooks-admin
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+aggregationRule:
+  clusterRoleSelectors:
+    - matchLabels:
+        rbac.authorization.k8s.io/aggregate-to-notebooks-admin: "true"
+rules: []
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: notebooks-edit
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    rbac.authorization.k8s.io/aggregate-to-notebooks-admin: "true"
+rules:
+  - apiGroups:
+      - kubeflow.org
+    resources:
+      - notebooks
+      - notebooks/status
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - delete
+      - deletecollection
+      - patch
+      - update
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: notebooks-view
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+rules:
+  - apiGroups:
+      - kubeflow.org
+    resources:
+      - notebooks
+      - notebooks/status
+    verbs:
+      - get
+      - list
+      - watch

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -11,6 +11,10 @@ resources:
 - role_binding.yaml
 - leader_election_role.yaml
 - leader_election_role_binding.yaml
+# Add aggreated clusterroles from workbench modelmesh and dspa
+- aggregate-nbc-admin.yaml
+- aggregate-modelmesh-admin.yaml
+- aggregate-dspa-admin-edit.yaml
 # Comment the following 4 lines if you want to disable
 # the auth proxy (https://github.com/brancz/kube-rbac-proxy)
 # which protects your /metrics endpoint.


### PR DESCRIPTION
## Description
more fix for https://github.com/opendatahub-io/opendatahub-operator/issues/519

several components use annotation aggregated to get admin or edit or view permission for users.
get the original manifests from odh-manifests

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
