### PR TITLE
Fix: missing metrics change

### DIFF
--- a/controllers/dscinitialization/monitoring.go
+++ b/controllers/dscinitialization/monitoring.go
@@ -314,5 +314,14 @@ func (r *DSCInitializationReconciler) configureCommonMonitoring(dsciInit *dsci.D
 		r.Log.Error(err, "error to deploy manifests under /opt/manifests/monitoring/segment")
 		return err
 	}
+
+	// configure monitoring base
+	err = deploy.DeployManifestsFromPath(dsciInit, r.Client, "monitoring-base",
+		deploy.DefaultManifestPath+"/monitoring/base",
+		dsciInit.Spec.Monitoring.Namespace, r.Scheme, dsciInit.Spec.Monitoring.ManagementState == operatorv1.Managed)
+	if err != nil {
+		r.Log.Error(err, "error to deploy manifests under /opt/manifests/monitoring/base")
+		return err
+	}
 	return nil
 }


### PR DESCRIPTION
## Description
https://github.com/red-hat-data-services/rhods-operator/pull/33 was intended only for downstream, so it was not originally port-back to ODH, with sync from ODH back to downstream, this piece is missing on main and cause the 1.33 is not working with metrics again.


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
