### PR TITLE
Fix: missing odh-admins group

### DIFF
--- a/controllers/dscinitialization/dscinitialization_controller.go
+++ b/controllers/dscinitialization/dscinitialization_controller.go
@@ -21,13 +21,11 @@ import (
 	"context"
 	"fmt"
 	operatorv1 "github.com/openshift/api/operator/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	logr "github.com/go-logr/logr"
 
 	"k8s.io/client-go/util/retry"
 
-	ocuserv1 "github.com/openshift/api/user/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	netv1 "k8s.io/api/networking/v1"
@@ -153,27 +151,18 @@ func (r *DSCInitializationReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		} else {
 			// Apply self-managed rhods config
 			// Create rhods-admins Group if it doesn't exist
-			rhodsuserGroup := &ocuserv1.Group{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "rhods-admins",
-				},
-			}
-			err := r.Client.Get(ctx, client.ObjectKey{
-				Name: rhodsuserGroup.Name,
-			}, rhodsuserGroup)
+			err := r.createUserGroup(instance, "rhods-admins", ctx)
 			if err != nil {
-				if apierrs.IsNotFound(err) {
-					err = r.Client.Create(ctx, rhodsuserGroup)
-					if err != nil && !apierrs.IsAlreadyExists(err) {
-						return reconcile.Result{}, err
-					}
-				} else {
-					return reconcile.Result{}, err
-				}
+				return reconcile.Result{}, err
 			}
 		}
-
 		// Apply common rhods-specific config
+	} else { // ODH case
+		// Create odh-admins Group if it doesn't exist
+		err := r.createUserGroup(instance, "odh-admins", ctx)
+		if err != nil {
+			return reconcile.Result{}, err
+		}
 	}
 
 	// If monitoring enabled


### PR DESCRIPTION
## Description
we do not have odh-admins group created automatically, and this has an error in dashboard

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
local test:quay.io/wenzhou/opendatahub-operator-catalog:v2.1.666

**before:**
![Screenshot from 2023-09-14 14-12-42](https://github.com/opendatahub-io/opendatahub-operator/assets/915053/4c39a118-5469-4163-881a-a233b51194b9)

**AFter**
**![Screenshot from 2023-09-14 14-21-33](https://github.com/opendatahub-io/opendatahub-operator/assets/915053/4a011452-70a1-4784-aef3-d83436478cd5)**
![Screenshot from 2023-09-14 14-24-10](https://github.com/opendatahub-io/opendatahub-operator/assets/915053/3d483d3f-aeed-4200-8ef4-d067b4cdfcd0)


## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
