### PR TITLE
chore: simplifies deployment funcs

### DIFF
--- a/components/codeflare/codeflare.go
+++ b/components/codeflare/codeflare.go
@@ -2,14 +2,13 @@
 package codeflare
 
 import (
-	"fmt"
-	operatorv1 "github.com/openshift/api/operator/v1"
-
 	"context"
+	"fmt"
 	dsci "github.com/opendatahub-io/opendatahub-operator/v2/apis/dscinitialization/v1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/components"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/deploy"
 	imagev1 "github.com/openshift/api/image/v1"
+	operatorv1 "github.com/openshift/api/operator/v1"
 	codeflarev1alpha1 "github.com/project-codeflare/codeflare-operator/api/codeflare/v1alpha1"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -18,7 +17,7 @@ import (
 
 const (
 	ComponentName       = "codeflare"
-	CodeflarePath       = deploy.DefaultManifestPath + "/" + "codeflare-stack" + "/base"
+	CodeflarePath       = deploy.DefaultManifestPath + "/codeflare-stack/base"
 	CodeflareOperator   = "codeflare-operator"
 	RHCodeflareOperator = "rhods-codeflare-operator"
 )
@@ -112,10 +111,7 @@ func (c *CodeFlare) ReconcileComponent(cli client.Client, owner metav1.Object, d
 	}
 
 	// Deploy Codeflare
-	err := deploy.DeployManifestsFromPath(owner, cli, c.GetComponentName(),
-		CodeflarePath,
-		dscispec.ApplicationsNamespace,
-		cli.Scheme(), enabled)
+	err := deploy.DeployManifestsFromPath(cli, owner, CodeflarePath, dscispec.ApplicationsNamespace, c.GetComponentName(), enabled)
 
 	return err
 

--- a/components/datasciencepipelines/datasciencepipelines.go
+++ b/components/datasciencepipelines/datasciencepipelines.go
@@ -54,10 +54,7 @@ func (d *DataSciencePipelines) ReconcileComponent(cli client.Client, owner metav
 		}
 	}
 
-	err := deploy.DeployManifestsFromPath(owner, cli, d.GetComponentName(),
-		Path,
-		dscispec.ApplicationsNamespace,
-		cli.Scheme(), enabled)
+	err := deploy.DeployManifestsFromPath(cli, owner, Path, dscispec.ApplicationsNamespace, d.GetComponentName(), enabled)
 	return err
 }
 

--- a/components/kserve/kserve.go
+++ b/components/kserve/kserve.go
@@ -74,10 +74,7 @@ func (k *Kserve) ReconcileComponent(cli client.Client, owner metav1.Object, dsci
 		}
 	}
 
-	if err := deploy.DeployManifestsFromPath(owner, cli, ComponentName,
-		Path,
-		dscispec.ApplicationsNamespace,
-		cli.Scheme(), enabled); err != nil {
+	if err := deploy.DeployManifestsFromPath(cli, owner, Path, dscispec.ApplicationsNamespace, ComponentName, enabled); err != nil {
 		return err
 	}
 
@@ -94,10 +91,7 @@ func (k *Kserve) ReconcileComponent(cli client.Client, owner metav1.Object, dsci
 			}
 		}
 	}
-	if err := deploy.DeployManifestsFromPath(owner, cli, k.GetComponentName(),
-		DependentPath,
-		dscispec.ApplicationsNamespace,
-		cli.Scheme(), enabled); err != nil {
+	if err := deploy.DeployManifestsFromPath(cli, owner, DependentPath, dscispec.ApplicationsNamespace, k.GetComponentName(), enabled); err != nil {
 		return err
 	}
 

--- a/components/modelmeshserving/modelmeshserving.go
+++ b/components/modelmeshserving/modelmeshserving.go
@@ -60,10 +60,7 @@ func (m *ModelMeshServing) ReconcileComponent(cli client.Client, owner metav1.Ob
 		}
 	}
 
-	err := deploy.DeployManifestsFromPath(owner, cli, ComponentName,
-		Path,
-		dscispec.ApplicationsNamespace,
-		cli.Scheme(), enabled)
+	err := deploy.DeployManifestsFromPath(cli, owner, Path, dscispec.ApplicationsNamespace, ComponentName, enabled)
 
 	if err != nil {
 		return err
@@ -85,10 +82,7 @@ func (m *ModelMeshServing) ReconcileComponent(cli client.Client, owner metav1.Ob
 	}
 
 	// If modelmesh is deployed successfully, deploy modelmesh-monitoring
-	err = deploy.DeployManifestsFromPath(owner, cli, ComponentName,
-		monitoringPath,
-		monitoringNamespace,
-		cli.Scheme(), enabled)
+	err = deploy.DeployManifestsFromPath(cli, owner, monitoringPath, monitoringNamespace, ComponentName, enabled)
 
 	return err
 }

--- a/components/ray/ray.go
+++ b/components/ray/ray.go
@@ -46,10 +46,7 @@ func (r *Ray) ReconcileComponent(cli client.Client, owner metav1.Object, dscispe
 		}
 	}
 	// Deploy Ray Operator
-	err := deploy.DeployManifestsFromPath(owner, cli, r.GetComponentName(),
-		RayPath,
-		dscispec.ApplicationsNamespace,
-		cli.Scheme(), enabled)
+	err := deploy.DeployManifestsFromPath(cli, owner, RayPath, dscispec.ApplicationsNamespace, r.GetComponentName(), enabled)
 	return err
 
 }

--- a/components/workbenches/workbenches.go
+++ b/components/workbenches/workbenches.go
@@ -70,10 +70,7 @@ func (w *Workbenches) ReconcileComponent(cli client.Client, owner metav1.Object,
 		}
 	}
 
-	err = deploy.DeployManifestsFromPath(owner, cli, ComponentName,
-		notebookControllerPath,
-		dscispec.ApplicationsNamespace,
-		cli.Scheme(), enabled)
+	err = deploy.DeployManifestsFromPath(cli, owner, notebookControllerPath, dscispec.ApplicationsNamespace, ComponentName, enabled)
 	if err != nil {
 		return err
 	}
@@ -94,16 +91,10 @@ func (w *Workbenches) ReconcileComponent(cli client.Client, owner metav1.Object,
 	}
 
 	if platform == deploy.OpenDataHub || platform == "" {
-		err = deploy.DeployManifestsFromPath(owner, cli, ComponentName,
-			notebookImagesPath,
-			dscispec.ApplicationsNamespace,
-			cli.Scheme(), enabled)
+		err = deploy.DeployManifestsFromPath(cli, owner, notebookImagesPath, dscispec.ApplicationsNamespace, ComponentName, enabled)
 		return err
 	} else {
-		err = deploy.DeployManifestsFromPath(owner, cli, ComponentName,
-			notebookImagesPathSupported,
-			dscispec.ApplicationsNamespace,
-			cli.Scheme(), enabled)
+		err = deploy.DeployManifestsFromPath(cli, owner, notebookImagesPathSupported, dscispec.ApplicationsNamespace, ComponentName, enabled)
 		return err
 	}
 

--- a/controllers/dscinitialization/dscinitialization_controller.go
+++ b/controllers/dscinitialization/dscinitialization_controller.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	operatorv1 "github.com/openshift/api/operator/v1"
+	"path/filepath"
 
 	"github.com/go-logr/logr"
 
@@ -141,12 +142,11 @@ func (r *DSCInitializationReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	if platform == deploy.ManagedRhods || platform == deploy.SelfManagedRhods {
 		//Apply osd specific permissions
 		if platform == deploy.ManagedRhods {
-			err = deploy.DeployManifestsFromPath(instance, r.Client, "osd",
-				deploy.DefaultManifestPath+"/osd-configs",
-				r.ApplicationsNamespace, r.Scheme, true)
+			osdConfigsPath := filepath.Join(deploy.DefaultManifestPath, "osd-configs")
+			err = deploy.DeployManifestsFromPath(r.Client, instance, osdConfigsPath, r.ApplicationsNamespace, "osd", true)
 			if err != nil {
-				r.Log.Error(err, "Failed to apply osd specific configs from manifests", "Manifests path", deploy.DefaultManifestPath+"/osd-configs")
-				r.Recorder.Eventf(instance, corev1.EventTypeWarning, "DSCInitializationReconcileError", "Failed to apply "+deploy.DefaultManifestPath+"/osd-configs")
+				r.Log.Error(err, "Failed to apply osd specific configs from manifests", "Manifests path", osdConfigsPath)
+				r.Recorder.Eventf(instance, corev1.EventTypeWarning, "DSCInitializationReconcileError", "Failed to apply "+osdConfigsPath)
 				return reconcile.Result{}, err
 			}
 		} else {

--- a/controllers/dscinitialization/monitoring.go
+++ b/controllers/dscinitialization/monitoring.go
@@ -112,7 +112,7 @@ func configurePrometheus(ctx context.Context, dsciInit *dsci.DSCInitialization, 
 	}
 
 	// Create proxy secret
-	if err := createMonitoringProxySecret("prometheus-proxy", dsciInit, r.Client); err != nil {
+	if err := createMonitoringProxySecret(r.Client, "prometheus-proxy", dsciInit); err != nil {
 		return err
 	}
 	return nil
@@ -178,7 +178,7 @@ func configureAlertManager(ctx context.Context, dsciInit *dsci.DSCInitialization
 	r.Log.Info("Success: deploy alertmanager manifests")
 
 	// Create proxy secret
-	if err := createMonitoringProxySecret("alertmanager-proxy", dsciInit, r.Client); err != nil {
+	if err := createMonitoringProxySecret(r.Client, "alertmanager-proxy", dsciInit); err != nil {
 		r.Log.Error(err, "error to create secret alertmanager-proxy")
 		return err
 	}
@@ -186,7 +186,7 @@ func configureAlertManager(ctx context.Context, dsciInit *dsci.DSCInitialization
 	return nil
 }
 
-func configureBlackboxExporter(dsciInit *dsci.DSCInitialization, cli client.Client) error {
+func configureBlackboxExporter(cli client.Client, dsciInit *dsci.DSCInitialization) error {
 	consoleRoute := &routev1.Route{}
 	err := cli.Get(context.TODO(), client.ObjectKey{Name: "console", Namespace: "openshift-console"}, consoleRoute)
 	if err != nil {
@@ -223,13 +223,13 @@ func (r *DSCInitializationReconciler) configureManagedMonitoring(ctx context.Con
 	}
 
 	// configure Blackbox exporter
-	if err := configureBlackboxExporter(dscInit, r.Client); err != nil {
+	if err := configureBlackboxExporter(r.Client, dscInit); err != nil {
 		return fmt.Errorf("error in configureBlackboxExporter: %w", err)
 	}
 	return nil
 }
 
-func createMonitoringProxySecret(name string, dsciInit *dsci.DSCInitialization, cli client.Client) error {
+func createMonitoringProxySecret(cli client.Client, name string, dsciInit *dsci.DSCInitialization) error {
 
 	sessionSecret, err := GenerateRandomHex(32)
 	if err != nil {

--- a/controllers/dscinitialization/monitoring.go
+++ b/controllers/dscinitialization/monitoring.go
@@ -11,7 +11,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
+	"path/filepath"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"strings"
@@ -52,12 +52,13 @@ func configurePrometheus(ctx context.Context, dsciInit *dsci.DSCInitialization, 
 	}
 	r.Log.Info("Success: read alertmanager data from alertmanage.yaml from CM")
 
+	prometheusManifestsPath := filepath.Join(deploy.DefaultManifestPath, "monitoring", "prometheus")
+
 	// Deploy prometheus CM first
-	err = deploy.DeployManifestsFromPath(dsciInit, r.Client, "prometheus",
-		deploy.DefaultManifestPath+"/monitoring/prometheus/base",
-		dsciInit.Spec.Monitoring.Namespace, r.Scheme, dsciInit.Spec.Monitoring.ManagementState == operatorv1.Managed)
+	basePath := filepath.Join(prometheusManifestsPath, "base")
+	err = deploy.DeployManifestsFromPath(r.Client, dsciInit, basePath, dsciInit.Spec.Monitoring.Namespace, "prometheus", dsciInit.Spec.Monitoring.ManagementState == operatorv1.Managed)
 	if err != nil {
-		r.Log.Error(err, "error to deploy manifests under /opt/manifests/monitoring/prometheus/base")
+		r.Log.Error(err, "error to deploy manifests", "path", basePath)
 		return err
 	}
 	r.Log.Info("Success: deploy prometheus CM")
@@ -83,35 +84,35 @@ func configurePrometheus(ctx context.Context, dsciInit *dsci.DSCInitialization, 
 	r.Log.Info("Success: read prometheus data from prometheus.yaml from CM")
 
 	// Update prometheus manifests
-	err = common.ReplaceStringsInFile(deploy.DefaultManifestPath+"/monitoring/prometheus/prometheus.yaml", map[string]string{
-		"<set_alertmanager_host>":    alertmanagerRoute.Spec.Host,
-		"<alertmanager_config_hash>": alertmanagerData,
-		"<prometheus_config_hash>":   prometheusData,
-	})
+	err = common.ReplaceStringsInFile(filepath.Join(prometheusManifestsPath, "prometheus.yaml"),
+		map[string]string{
+			"<set_alertmanager_host>":    alertmanagerRoute.Spec.Host,
+			"<alertmanager_config_hash>": alertmanagerData,
+			"<prometheus_config_hash>":   prometheusData,
+		})
 	if err != nil {
 		r.Log.Error(err, "error to inject data to prometheus.yaml manifests")
 		return err
 	}
 
-	err = common.ReplaceStringsInFile(deploy.DefaultManifestPath+"/monitoring/prometheus/prometheus-viewer-rolebinding.yaml", map[string]string{
-		"<odh_monitoring_project>": dsciInit.Spec.Monitoring.Namespace,
-	})
+	err = common.ReplaceStringsInFile(filepath.Join(prometheusManifestsPath, "prometheus-viewer-rolebinding.yaml"),
+		map[string]string{
+			"<odh_monitoring_project>": dsciInit.Spec.Monitoring.Namespace,
+		})
 	if err != nil {
 		r.Log.Error(err, "error to inject data to prometheus-viewer-rolebinding.yaml")
 		return err
 	}
 
 	// Deploy manifests
-	err = deploy.DeployManifestsFromPath(dsciInit, r.Client, "prometheus",
-		deploy.DefaultManifestPath+"/monitoring/prometheus",
-		dsciInit.Spec.Monitoring.Namespace, r.Scheme, dsciInit.Spec.Monitoring.ManagementState == operatorv1.Managed)
+	err = deploy.DeployManifestsFromPath(r.Client, dsciInit, prometheusManifestsPath, dsciInit.Spec.Monitoring.Namespace, "prometheus", dsciInit.Spec.Monitoring.ManagementState == operatorv1.Managed)
 	if err != nil {
-		r.Log.Error(err, "error to deploy manifests under /opt/manifests/monitoring/prometheus")
+		r.Log.Error(err, "error to deploy manifests", "path", prometheusManifestsPath)
 		return err
 	}
 
 	// Create proxy secret
-	if err := createMonitoringProxySecret("prometheus-proxy", dsciInit, r.Client, r.Scheme); err != nil {
+	if err := createMonitoringProxySecret("prometheus-proxy", dsciInit, r.Client); err != nil {
 		return err
 	}
 	return nil
@@ -151,7 +152,7 @@ func configureAlertManager(ctx context.Context, dsciInit *dsci.DSCInitialization
 
 	// Replace variables in alertmanager configmap
 	// TODO: Following variables can later be exposed by the API
-	err = common.ReplaceStringsInFile(deploy.DefaultManifestPath+"/monitoring/alertmanager/alertmanager-configs.yaml",
+	err = common.ReplaceStringsInFile(filepath.Join(deploy.DefaultManifestPath, "monitoring", "alertmanager", "alertmanager-configs.yaml"),
 		map[string]string{
 			"<snitch_url>":      b64.StdEncoding.EncodeToString(deadmansnitchSecret.Data["SNITCH_URL"]),
 			"<pagerduty_token>": b64.StdEncoding.EncodeToString(pagerDutySecret.Data["PAGERDUTY_KEY"]),
@@ -168,17 +169,16 @@ func configureAlertManager(ctx context.Context, dsciInit *dsci.DSCInitialization
 	}
 	r.Log.Info("Success: generate alertmanage config")
 
-	err = deploy.DeployManifestsFromPath(dsciInit, r.Client, "alertmanager",
-		deploy.DefaultManifestPath+"/monitoring/alertmanager",
-		dsciInit.Spec.Monitoring.Namespace, r.Scheme, dsciInit.Spec.Monitoring.ManagementState == operatorv1.Managed)
+	alertManagerPath := filepath.Join(deploy.DefaultManifestPath, "monitoring", "alertmanager")
+	err = deploy.DeployManifestsFromPath(r.Client, dsciInit, alertManagerPath, dsciInit.Spec.Monitoring.Namespace, "alertmanager", dsciInit.Spec.Monitoring.ManagementState == operatorv1.Managed)
 	if err != nil {
-		r.Log.Error(err, "error to deploy manifests under /opt/manifests/monitoring/alertmanager")
+		r.Log.Error(err, "error to deploy manifests", "path", alertManagerPath)
 		return err
 	}
 	r.Log.Info("Success: deploy alertmanager manifests")
 
 	// Create proxy secret
-	if err := createMonitoringProxySecret("alertmanager-proxy", dsciInit, r.Client, r.Scheme); err != nil {
+	if err := createMonitoringProxySecret("alertmanager-proxy", dsciInit, r.Client); err != nil {
 		r.Log.Error(err, "error to create secret alertmanager-proxy")
 		return err
 	}
@@ -186,7 +186,7 @@ func configureAlertManager(ctx context.Context, dsciInit *dsci.DSCInitialization
 	return nil
 }
 
-func configureBlackboxExporter(dsciInit *dsci.DSCInitialization, cli client.Client, s *runtime.Scheme) error {
+func configureBlackboxExporter(dsciInit *dsci.DSCInitialization, cli client.Client) error {
 	consoleRoute := &routev1.Route{}
 	err := cli.Get(context.TODO(), client.ObjectKey{Name: "console", Namespace: "openshift-console"}, consoleRoute)
 	if err != nil {
@@ -195,18 +195,15 @@ func configureBlackboxExporter(dsciInit *dsci.DSCInitialization, cli client.Clie
 		}
 	}
 
+	blackBoxPath := filepath.Join(deploy.DefaultManifestPath, "monitoring", "blackbox-exporter")
 	if apierrs.IsNotFound(err) || strings.Contains(consoleRoute.Spec.Host, "redhat.com") {
-		err := deploy.DeployManifestsFromPath(dsciInit, cli, "blackbox-exporter",
-			deploy.DefaultManifestPath+"/monitoring/blackbox-exporter/internal",
-			dsciInit.Spec.Monitoring.Namespace, s, dsciInit.Spec.Monitoring.ManagementState == operatorv1.Managed)
+		err := deploy.DeployManifestsFromPath(cli, dsciInit, filepath.Join(blackBoxPath, "internal"), dsciInit.Spec.Monitoring.Namespace, "blackbox-exporter", dsciInit.Spec.Monitoring.ManagementState == operatorv1.Managed)
 		if err != nil {
 			return fmt.Errorf("error to deploy manifests: %w", err)
 		}
 
 	} else {
-		err := deploy.DeployManifestsFromPath(dsciInit, cli, "blackbox-exporter",
-			deploy.DefaultManifestPath+"/monitoring/blackbox-exporter/external",
-			dsciInit.Spec.Monitoring.Namespace, s, dsciInit.Spec.Monitoring.ManagementState == operatorv1.Managed)
+		err := deploy.DeployManifestsFromPath(cli, dsciInit, filepath.Join(blackBoxPath, "external"), dsciInit.Spec.Monitoring.Namespace, "blackbox-exporter", dsciInit.Spec.Monitoring.ManagementState == operatorv1.Managed)
 		if err != nil {
 			return fmt.Errorf("error to deploy manifests: %w", err)
 		}
@@ -226,13 +223,13 @@ func (r *DSCInitializationReconciler) configureManagedMonitoring(ctx context.Con
 	}
 
 	// configure Blackbox exporter
-	if err := configureBlackboxExporter(dscInit, r.Client, r.Scheme); err != nil {
+	if err := configureBlackboxExporter(dscInit, r.Client); err != nil {
 		return fmt.Errorf("error in configureBlackboxExporter: %w", err)
 	}
 	return nil
 }
 
-func createMonitoringProxySecret(name string, dsciInit *dsci.DSCInitialization, cli client.Client, s *runtime.Scheme) error {
+func createMonitoringProxySecret(name string, dsciInit *dsci.DSCInitialization, cli client.Client) error {
 
 	sessionSecret, err := GenerateRandomHex(32)
 	if err != nil {
@@ -254,7 +251,7 @@ func createMonitoringProxySecret(name string, dsciInit *dsci.DSCInitialization, 
 	if err != nil {
 		if apierrs.IsNotFound(err) {
 			// Set Controller reference
-			err = ctrl.SetControllerReference(dsciInit, desiredProxySecret, s)
+			err = ctrl.SetControllerReference(dsciInit, desiredProxySecret, cli.Scheme())
 			if err != nil {
 				return err
 			}
@@ -307,11 +304,10 @@ func getMonitoringData(data string) (string, error) {
 
 func (r *DSCInitializationReconciler) configureCommonMonitoring(dsciInit *dsci.DSCInitialization) error {
 	// configure segment.io
-	err := deploy.DeployManifestsFromPath(dsciInit, r.Client, "segment-io",
-		deploy.DefaultManifestPath+"/monitoring/segment",
-		dsciInit.Spec.Monitoring.Namespace, r.Scheme, dsciInit.Spec.Monitoring.ManagementState == operatorv1.Managed)
+	segmentPath := filepath.Join(deploy.DefaultManifestPath, "monitoring", "segment")
+	err := deploy.DeployManifestsFromPath(r.Client, dsciInit, segmentPath, dsciInit.Spec.Monitoring.Namespace, "segment-io", dsciInit.Spec.Monitoring.ManagementState == operatorv1.Managed)
 	if err != nil {
-		r.Log.Error(err, "error to deploy manifests under /opt/manifests/monitoring/segment")
+		r.Log.Error(err, "error to deploy manifests", "path", segmentPath)
 		return err
 	}
 	return nil

--- a/pkg/deploy/deploy.go
+++ b/pkg/deploy/deploy.go
@@ -129,7 +129,7 @@ func DownloadManifests(uri string) error {
 	return nil
 }
 
-func DeployManifestsFromPath(cli client.Client, owner metav1.Object, manifestPath, namespace, componentName string, componentEnabled bool) error {
+func DeployManifestsFromPath(cli client.Client, owner metav1.Object, manifestPath string, namespace string, componentName string, componentEnabled bool) error {
 
 	// Render the Kustomize manifests
 	k := krusty.MakeKustomizer(krusty.MakeDefaultOptions())

--- a/pkg/deploy/deploy.go
+++ b/pkg/deploy/deploy.go
@@ -38,7 +38,6 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/yaml"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/kustomize/api/filesys"
@@ -100,7 +99,7 @@ func DownloadManifests(uri string) error {
 			if err != nil {
 				return err
 			}
-			manifestsPath := strings.Split(header.Name, "/")
+			manifestsPath := strings.Split(header.Name, string(os.PathSeparator))
 
 			// Determine the file or directory path to extract to
 			target := filepath.Join(DefaultManifestPath, strings.Join(manifestsPath[1:], "/"))
@@ -130,7 +129,7 @@ func DownloadManifests(uri string) error {
 	return nil
 }
 
-func DeployManifestsFromPath(owner metav1.Object, cli client.Client, componentName, manifestPath, namespace string, s *runtime.Scheme, componentEnabled bool) error {
+func DeployManifestsFromPath(cli client.Client, owner metav1.Object, manifestPath, namespace, componentName string, componentEnabled bool) error {
 
 	// Render the Kustomize manifests
 	k := krusty.MakeKustomizer(krusty.MakeDefaultOptions())
@@ -139,10 +138,10 @@ func DeployManifestsFromPath(owner metav1.Object, cli client.Client, componentNa
 	// Create resmap
 	// Use kustomization file under manifestPath or use `default` overlay
 	var resMap resmap.ResMap
-	_, err := os.Stat(manifestPath + "/kustomization.yaml")
+	_, err := os.Stat(filepath.Join(manifestPath, "kustomization.yaml"))
 	if err != nil {
 		if os.IsNotExist(err) {
-			resMap, err = k.Run(fs, manifestPath+"/default")
+			resMap, err = k.Run(fs, filepath.Join(manifestPath, "default"))
 		}
 	} else {
 		resMap, err = k.Run(fs, manifestPath)
@@ -169,7 +168,7 @@ func DeployManifestsFromPath(owner metav1.Object, cli client.Client, componentNa
 
 	// Create / apply / delete resources in the cluster
 	for _, obj := range objs {
-		err = manageResource(owner, context.TODO(), cli, obj, s, componentEnabled, namespace, componentName)
+		err = manageResource(context.TODO(), cli, obj, owner, namespace, componentName, componentEnabled)
 		if err != nil {
 			return err
 		}
@@ -193,7 +192,7 @@ func getResources(resMap resmap.ResMap) ([]*unstructured.Unstructured, error) {
 	return resources, nil
 }
 
-func manageResource(owner metav1.Object, ctx context.Context, cli client.Client, obj *unstructured.Unstructured, s *runtime.Scheme, enabled bool, applicationNamespace, componentName string) error {
+func manageResource(ctx context.Context, cli client.Client, obj *unstructured.Unstructured, owner metav1.Object, applicationNamespace, componentName string, enabled bool) error {
 	resourceName := obj.GetName()
 	namespace := obj.GetNamespace()
 
@@ -258,7 +257,7 @@ func manageResource(owner metav1.Object, ctx context.Context, cli client.Client,
 	// Create the resource if it doesn't exist and component is enabled
 	if errors.IsNotFound(err) {
 		// Set the owner reference for garbage collection
-		if err = ctrl.SetControllerReference(owner, metav1.Object(obj), s); err != nil {
+		if err = ctrl.SetControllerReference(owner, metav1.Object(obj), cli.Scheme()); err != nil {
 			return err
 		}
 		return cli.Create(ctx, obj)
@@ -300,7 +299,7 @@ priority of image values (from high to low):
 - image values set in manifests params.env if manifestsURI is not set
 */
 func ApplyImageParams(componentPath string, imageParamsMap map[string]string) error {
-	envFilePath := componentPath + "/params.env"
+	envFilePath := filepath.Join(componentPath, "params.env")
 	// Require params.env at the root folder
 	file, err := os.Open(envFilePath)
 	if err != nil {
@@ -372,40 +371,41 @@ func ApplyImageParams(componentPath string, imageParamsMap map[string]string) er
 		fmt.Printf("Failed to remove backup file: %v", err)
 		return err
 	}
+
 	return nil
 }
 
-// SubscriptionExists checks if a Subscription for the an operator exists in the given namespace.
+// SubscriptionExists checks if a Subscription for the operator exists in the given namespace.
 func SubscriptionExists(cli client.Client, namespace string, name string) (bool, error) {
 	sub := &ofapiv1alpha1.Subscription{}
-	err := cli.Get(context.TODO(), client.ObjectKey{Namespace: namespace, Name: name}, sub)
-	if err != nil {
+	if err := cli.Get(context.TODO(), client.ObjectKey{Namespace: namespace, Name: name}, sub); err != nil {
 		if apierrs.IsNotFound(err) {
 			return false, nil
 		} else {
 			return false, err
 		}
 	}
+
 	return true, nil
 }
 
-// OperatorExists checks if an Operator with 'operatorprefix' is installed.
+// OperatorExists checks if an Operator with 'operatorPrefix' is installed.
 // Return true if found it, false if not.
 // TODO: if we need to check exact version of the operator installed, can append vX.Y.Z later
-func OperatorExists(cli client.Client, operatorprefix string) (bool, error) {
+func OperatorExists(cli client.Client, operatorPrefix string) (bool, error) {
 	opConditionList := &ofapiv2.OperatorConditionList{}
-	err := cli.List(context.TODO(), opConditionList)
-	if err != nil {
+	if err := cli.List(context.TODO(), opConditionList); err != nil {
 		if !apierrs.IsNotFound(err) { // real error to run List()
 			return false, err
 		}
 	} else {
 		for _, opCondition := range opConditionList.Items {
-			if strings.HasPrefix(opCondition.Name, operatorprefix) {
+			if strings.HasPrefix(opCondition.Name, operatorPrefix) {
 				return true, nil
 			}
 		}
 	}
+
 	return false, nil
 }
 

--- a/pkg/deploy/deploy.go
+++ b/pkg/deploy/deploy.go
@@ -102,7 +102,7 @@ func DownloadManifests(uri string) error {
 			manifestsPath := strings.Split(header.Name, string(os.PathSeparator))
 
 			// Determine the file or directory path to extract to
-			target := filepath.Join(DefaultManifestPath, strings.Join(manifestsPath[1:], "/"))
+			target := filepath.Join(DefaultManifestPath, strings.Join(manifestsPath[1:], string(os.PathSeparator)))
 
 			if header.Typeflag == tar.TypeDir {
 				// Create directories

--- a/pkg/plugins/addLabelsplugin.go
+++ b/pkg/plugins/addLabelsplugin.go
@@ -33,10 +33,6 @@ func ApplyAddLabelsPlugin(componentName string, resMap resmap.ResMap) error {
 			},
 		},
 	}
-	// Add labels plugin
-	err := nsplug.Transform(resMap)
-	if err != nil {
-		return err
-	}
-	return nil
+
+	return nsplug.Transform(resMap)
 }

--- a/pkg/plugins/namespacePlugin.go
+++ b/pkg/plugins/namespacePlugin.go
@@ -64,10 +64,6 @@ func ApplyNamespacePlugin(manifestNamespace string, resMap resmap.ResMap) error 
 		UnsetOnly:              false,
 		SetRoleBindingSubjects: namespace.AllServiceAccountSubjects,
 	}
-	// Add namespace plugin
-	err := nsplug.Transform(resMap)
-	if err != nil {
-		return err
-	}
-	return nil
+
+	return nsplug.Transform(resMap)
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Hopefully last round before Service Mesh component :)

- cleans up deployment `func`s - reducing parameters
- unifies `func`s having the client passed to always be the first parameter
- uses `filepath.Join` instead of string concatenation when constructing manifests paths

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

`make test` and manual testing of `quay.io/maistra-dev/opendatahub-operator:dev-service-mesh` image

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
