### PR TITLE
Update: nbc manifests transit from odh-manifests to kubeflow repo

### DIFF
--- a/bundle/manifests/datasciencecluster.opendatahub.io_datascienceclusters.yaml
+++ b/bundle/manifests/datasciencecluster.opendatahub.io_datascienceclusters.yaml
@@ -33,7 +33,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: Defines the desired state of DataScienceCluster
+            description: DataScienceCluster defines the desired state of the cluster.
             properties:
               components:
                 description: Override and fine tune specific component configurations.

--- a/bundle/manifests/opendatahub-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/opendatahub-operator.clusterserviceversion.yaml
@@ -559,14 +559,24 @@ spec:
           - instascales
           verbs:
           - create
+          - delete
+          - get
+          - list
           - patch
+          - update
+          - watch
         - apiGroups:
           - codeflare.codeflare.dev
           resources:
           - mcads
           verbs:
           - create
+          - delete
+          - get
+          - list
           - patch
+          - update
+          - watch
         - apiGroups:
           - config.openshift.io
           resources:

--- a/components/codeflare/codeflare.go
+++ b/components/codeflare/codeflare.go
@@ -17,7 +17,7 @@ import (
 
 const (
 	ComponentName       = "codeflare"
-	CodeflarePath       = deploy.DefaultManifestPath + "/codeflare-stack/base"
+	CodeflarePath       = deploy.DefaultManifestPath + "/codeflare/base"
 	CodeflareOperator   = "codeflare-operator"
 	RHCodeflareOperator = "rhods-codeflare-operator"
 )

--- a/config/crd/bases/datasciencecluster.opendatahub.io_datascienceclusters.yaml
+++ b/config/crd/bases/datasciencecluster.opendatahub.io_datascienceclusters.yaml
@@ -34,7 +34,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: Defines the desired state of DataScienceCluster
+            description: DataScienceCluster defines the desired state of the cluster.
             properties:
               components:
                 description: Override and fine tune specific component configurations.

--- a/get_all_manifests.sh
+++ b/get_all_manifests.sh
@@ -4,12 +4,14 @@ set -e
 # component: dsp, kserve, dashbaord, cf/ray. in the format of "repo-name:branch-name:source-folder:target-folder"
 # TODO: workbench, modelmesh, monitoring, etc
 REPO_LIST=(
-    "distributed-workloads:main:codeflare-stack:codeflare-stack"
+    "distributed-workloads:main:codeflare-stack:codeflare"
     "distributed-workloads:main:ray:ray"
     "data-science-pipelines-operator:main:config:data-science-pipelines-operator"
     "kserve:release-v0.11:config:kserve"
     "odh-dashboard:main:manifests:odh-dashboard"
-    "notebooks:main:manifests:notebook-images"
+    "notebooks:main:manifests:notebook"
+    "kubeflow:v1.7-branch:components/notebook-controller/config:odh-notebook-controller/kf-notebook-controller"
+    "kubeflow:v1.7-branch:components/odh-notebook-controller/config:odh-notebook-controller/odh-notebook-controller"
 )
 
 # pre-cleanup local env
@@ -27,8 +29,6 @@ wget -q -c ${MANIFESTS_TARBALL_URL} -O - | tar -zxv -C ./.odh-manifests-tmp/ --s
 cp -r ./.odh-manifests-tmp/model-mesh/ ./odh-manifests
 cp -r ./.odh-manifests-tmp/odh-model-controller/ ./odh-manifests
 cp -r ./.odh-manifests-tmp/modelmesh-monitoring/ ./odh-manifests
-cp -r ./.odh-manifests-tmp/odh-notebook-controller/ ./odh-manifests
-ls -lat ./odh-manifests/
 rm -rf ${MANIFEST_RELEASE}.tar.gz ./.odh-manifests-tmp/
 
 for repo_info in ${REPO_LIST[@]}; do

--- a/pkg/deploy/deploy.go
+++ b/pkg/deploy/deploy.go
@@ -165,7 +165,6 @@ func DeployManifestsFromPath(cli client.Client, owner metav1.Object, manifestPat
 	if err != nil {
 		return err
 	}
-
 	// Create / apply / delete resources in the cluster
 	for _, obj := range objs {
 		err = manageResource(context.TODO(), cli, obj, owner, namespace, componentName, componentEnabled)


### PR DESCRIPTION
## Description
ref to change in NBC: https://github.com/opendatahub-io/kubeflow/pull/173
related to https://github.com/opendatahub-io/opendatahub-operator/issues/424
- since we cannot and should not get the whole kubeflow source repo into our final image, so the "component/base" is actually split to two parts and copied into image as  "odh-notebook-controller" and "notebook-controller"
- which means, in the old "odh-manifests" way, we can keep using "odh-notebook-controller" but the new way need extra path to be handled in operator workbench components
- this PR also cleaned up some calls to ApplyImageParams(). for workbench ApplyImageParams() is only used in downstream and only for 2 controller images

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
