### PR TITLE
Update v1 operator to use component repo for manifests not odh-manifests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,9 +5,7 @@
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
 VERSION ?= 0.0.1
 IMG ?= quay.io/opendatahub/opendatahub-operator:dev-$(VERSION)
-# Specify the url to download the tarball to use for the local repo manifest
-ODH_MANIFESTS_REF=master
-ODH_MANIFESTS_URL=https://github.com/opendatahub-io/odh-manifests/tarball/$(ODH_MANIFESTS_REF)
+
 IMAGE_BUILDER ?= podman
 OPERATOR_NAMESPACE ?= opendatahub-operator-system
 CHANNELS="rolling"
@@ -103,6 +101,10 @@ manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and Cust
 generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.
 	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."
 
+.PHONY: get-manifests
+get-manifests: ## Fetch components manifests from remote git repo
+	./get_all_manifests.sh
+
 .PHONY: fmt
 fmt: ## Run go fmt against code.
 	go fmt ./...
@@ -127,7 +129,7 @@ run: manifests generate fmt vet ## Run a controller from your host.
 
 .PHONY: docker-build
 docker-build: manifests generate fmt vet update-test-data ## Build docker image with the manager.
-	${IMAGE_BUILDER} build -t ${IMG} --build-arg ODH_MANIFESTS_REF=${ODH_MANIFESTS_REF} --build-arg ODH_MANIFESTS_URL=${ODH_MANIFESTS_URL} .
+	${IMAGE_BUILDER} build -t ${IMG} .
 
 .PHONY: docker-push
 docker-push: ## Push docker image with the manager.

--- a/README.md
+++ b/README.md
@@ -2,36 +2,38 @@
 
 ## Introduction
 
-The Open Data Hub operator is responsible for managing the deployment and lifecycle of ODH Component manifests in [odh-manifests](https://github.com/opendatahub-io/odh-manifests) using the [KfDef](config/crd/bases/kfdef.apps.kubeflow.org_kfdefs.yaml) Custom Resource.  The focus is on supporting the [ODH Core](https://github.com/opendatahub-io/odh-manifests/blob/master/kfdef/odh-core.yaml) stack in the OpenShift clusters. 
+The Open Data Hub operator is responsible for managing the deployment and lifecycle of ODH Component manifests from either [odh-manifests](https://github.com/opendatahub-io/odh-manifests) or different component repos under `opendatahub-io` orgnization using the [KfDef](config/crd/bases/kfdef.apps.kubeflow.org_kfdefs.yaml) Custom Resource.  The focus is on supporting the [ODH Core](https://github.com/opendatahub-io/odh-manifests/blob/master/kfdef/odh-core.yaml) stack in the OpenShift clusters.
 
 NOTE: The Open Data Hub operator was originally a downstream project of the [kfctl](https://github.com/kubeflow/kfctl) operator but has diverged from the original functionality after the Kubeflow community deprecated the use of `kfctl` for deployment in favor of [kustomize](https://kustomize.io/).  `kfctl` cli is no longer a maintained or supported tool for parsing or processing the `kfdef` custom resource.
 
-##Usage
+## Usage
 
 ### Installation
 
-The latest version of operator can be installed from the community-operators catalog on OperatorHub. It can also be build 
+The latest version of operator can be installed from the community-operators catalog on OperatorHub. It can also be build
 and installed from source manually, see the Developer guide for further instructions.
 
 ### Developer Guide
 
 #### Pre-requisites
 
-- Go version **go1.18.4** 
+- Go version **go1.18.4**
 - operator-sdk version can be updated to **v1.24.1**
 
 #### Build Image
 
 - Custom operator image can be built using your local repository
-    ```
+
+    ``` shell
     make image -e IMG=quay.io/<username>/opendatahub-operator:<custom-tag>
     ```
-   The default image used is `quay.io/opendatahub/opendatahub-operator:dev-<VERSION>`
 
+   The default image used is `quay.io/opendatahub/opendatahub-operator:dev-<VERSION>`
 
 - Once the image is create, the operator can be deployed either directly, or through OLM. For each deployment method a
   kubeconfig should be exported
-  ```
+
+  ``` shell
   export KUBECONFIG=<path to kubeconfig>
   ```
 
@@ -40,43 +42,50 @@ and installed from source manually, see the Developer guide for further instruct
 **Deploying operator locally**
 
 - Define operator namespace
-  ```
+
+  ``` shell
   export OPERATOR_NAMESPACE=<namespace-to-install-operator>
   ```
+
 - Deploy the created image in your cluster using following command:
-  ```
+
+  ``` shell
   make deploy -e IMG=quay.io/<username>/opendatahub-operator:<custom-tag>
   ```
 
 - To remove resources created during installation use:
-  ```
+
+  ``` shell
   make undeploy
   ```
 
 **Deploying operator using OLM**
 
 - Define operator namespace
-  ```
+
+  ``` shell
   export OPERATOR_NAMESPACE=<namespace-to-install-operator>
   ```
   
 - To create a new bundle, run following command:
+
   ```commandline
   make bundle
   ```
+
   **Note** : Skip the above step if you want to run the existing operator bundle.
 
-
 - Build Bundle Image:
-  ```
+
+  ``` shell
   make bundle-build bundle-push BUNDLE_IMG=quay.io/<username>/opendatahub-operator-bundle:<VERSION>
   ```
   
 - Run the Bundle on a cluster:
+
   ```commandline
   operator-sdk run bundle quay.io/<username>/opendatahub-operator-bundle:<VERSION> --namespace $OPERATOR_NAMESPACE
   ```
-
 
 ### Example KfDefs
 
@@ -85,7 +94,7 @@ following KfDefs to install Open Data Hub components:
 
 - [KfDef](https://github.com/opendatahub-io/odh-manifests/blob/master/kfdef/odh-core.yaml) for Core Components
 
-
+Do condier most of the components in [odh-core.yaml](https://github.com/opendatahub-io/odh-manifests/blob/master/kfdef/odh-core.yaml) might point to a bunch of out-of-date manifests, ensure to modify to the correct source component repo and branch.
 
 ### Run e2e Tests
 
@@ -110,8 +119,6 @@ variable. Following table lists all the available flags to run the tests:
 | Flag            | Description                                                                                                                                         | Default value |
 |-----------------|-----------------------------------------------------------------------------------------------------------------------------------------------------|---------------|
 | --skip-deletion | To skip running  of `kfdef-deletion` test that includes deleting `KfDef` resources. Assign this variable to `true` to skip KfDef deletion. | false         |
-
-
 
 Example command to run full test suite in a custom namespace, skipping the test
 for KfDef deletion.

--- a/get_all_manifests.sh
+++ b/get_all_manifests.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+set -e
+
+# component: dsp, kserve, dashbaord, cf/ray. in the format of "repo-name:branch-name:source-folder:target-folder"
+# TODO: workbench, modelmesh, monitoring, etc
+REPO_LIST=(
+    "data-science-pipelines-operator:main:config:data-science-pipelines-operator"
+    "odh-dashboard:main:manifests:odh-dashboard"
+    "notebooks:main:manifests:notebook-images"
+    "kubeflow:v1.7-branch:components/notebook-controller/config:odh-notebook-controller/kf-notebook-controller"
+    "kubeflow:v1.7-branch:components/odh-notebook-controller/config:odh-notebook-controller/odh-notebook-controller"
+)
+
+# pre-cleanup local env
+rm -fr ./odh-manifests/* ./.odh-manifests-tmp/
+
+GITHUB_URL="https://github.com/"
+# update to use different git repo
+MANIFEST_ORG="opendatahub-io"
+
+MANIFEST_RELEASE="master"
+MANIFESTS_TARBALL_URL="${GITHUB_URL}/${MANIFEST_ORG}/odh-manifests/tarball/${MANIFEST_RELEASE}"
+mkdir -p ./.odh-manifests-tmp/ ./odh-manifests/
+wget -q -c ${MANIFESTS_TARBALL_URL} -O - | tar -zxv -C ./.odh-manifests-tmp/ --strip-components 1 > /dev/null
+cp -r ./.odh-manifests-tmp/model-mesh/ ./odh-manifests
+cp -r ./.odh-manifests-tmp/odh-model-controller/ ./odh-manifests
+cp -r ./.odh-manifests-tmp/modelmesh-monitoring/ ./odh-manifests
+cp -r ./.odh-manifests-tmp/prometheus ./odh-manifests
+cp -r ./.odh-manifests-tmp/odh-common ./odh-manifests
+rm -rf ${MANIFEST_RELEASE}.tar.gz ./.odh-manifests-tmp/
+
+for repo_info in ${REPO_LIST[@]}; do
+    echo "Git clone below repo ${repo_info}"
+    repo_name=$( echo $repo_info | cut -d ":" -f 1 )
+    repo_branch=$( echo $repo_info | cut -d ":" -f 2 )
+    source_path=$( echo $repo_info | cut -d ":" -f 3 )
+    target_path=$( echo $repo_info | cut -d ":" -f 4 )
+    repo_url="${GITHUB_URL}/${MANIFEST_ORG}/${repo_name}.git"
+    rm -rf ./.${repo_name}
+    git clone --depth 1 --branch ${repo_branch} ${repo_url} ./.${repo_name}
+    mkdir -p ./odh-manifests/${target_path}
+    cp -rf ./.${repo_name}/${source_path}/* ./odh-manifests/${target_path}
+    rm -rf ./.${repo_name}
+done


### PR DESCRIPTION
## Description
ref:  https://github.com/opendatahub-io/opendatahub-operator/issues/424
- wont create file `MANIFEST_VERSION` to store odh-manifests ref version
- wont have `tests/data/test-data.tar.gz` in final image
- simple dockerfile, to only support pull down from component git repo, not support local odh-manifests 
- only copy dashboard + dsp + workbench, the rest are from odh-manifests, including  promethus + odh-common + modelmesh

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
