### PR TITLE
Revert change for networkpolicy

### DIFF
--- a/controllers/dscinitialization/utils.go
+++ b/controllers/dscinitialization/utils.go
@@ -188,31 +188,34 @@ func (r *DSCInitializationReconciler) reconcileDefaultNetworkPolicy(dscInit *dsc
 			Namespace: name,
 		},
 		Spec: netv1.NetworkPolicySpec{
+			// open ingress for all port for now, TODO: add explicit port per component
+			Ingress: []netv1.NetworkPolicyIngressRule{{}},
 			// open ingress for only ODH created namespaces
-			Ingress: []netv1.NetworkPolicyIngressRule{
-				{
-					From: []netv1.NetworkPolicyPeer{
-						{
-							NamespaceSelector: &metav1.LabelSelector{ // AND logic
-								MatchLabels: map[string]string{
-									"opendatahub.io/generated-namespace": "true",
-								},
-							},
-						},
-					},
-				},
-				{ // OR logic
-					From: []netv1.NetworkPolicyPeer{
-						{ // need this for access dashboard
-							NamespaceSelector: &metav1.LabelSelector{
-								MatchLabels: map[string]string{
-									"kubernetes.io/metadata.name": "openshift-ingress",
-								},
-							},
-						},
-					},
-				},
-			},
+			// this is tested on ROSA but not enough for PSI
+			// Ingress: []netv1.NetworkPolicyIngressRule{
+			// 	{
+			// 		From: []netv1.NetworkPolicyPeer{
+			// 			{
+			// 				NamespaceSelector: &metav1.LabelSelector{ // AND logic
+			// 					MatchLabels: map[string]string{
+			// 						"opendatahub.io/generated-namespace": "true",
+			// 					},
+			// 				},
+			// 			},
+			// 		},
+			// 	},
+			// 	{ // OR logic
+			// 		From: []netv1.NetworkPolicyPeer{
+			// 			{ // need this for access dashboard
+			// 				NamespaceSelector: &metav1.LabelSelector{
+			// 					MatchLabels: map[string]string{
+			// 						"kubernetes.io/metadata.name": "openshift-ingress",
+			// 					},
+			// 				},
+			// 			},
+			// 		},
+			// 	},
+			// },
 			PolicyTypes: []netv1.PolicyType{
 				netv1.PolicyTypeIngress,
 			},


### PR DESCRIPTION
## Description
- revert it , need more namespace for PSI cluster
revert https://github.com/opendatahub-io/opendatahub-operator/pull/527
ref: https://github.com/opendatahub-io/opendatahub-operator/issues/423

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
