### PR TITLE
Add: cleanup resource from old namespace but keep namespace itself

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,6 @@ BUNDLE_IMG ?= $(IMAGE_TAG_BASE)-bundle:v$(VERSION)
 IMAGE_BUILDER ?= podman
 OPERATOR_NAMESPACE ?= opendatahub-operator-system
 
-
 CHANNELS="fast"
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")

--- a/bundle/manifests/opendatahub-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/opendatahub-operator.clusterserviceversion.yaml
@@ -530,6 +530,7 @@ spec:
           verbs:
           - create
           - delete
+          - deletecollection
           - get
           - list
           - patch
@@ -1038,6 +1039,7 @@ spec:
           verbs:
           - create
           - delete
+          - deletecollection
           - get
           - list
           - patch

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -354,6 +354,7 @@ rules:
   verbs:
   - create
   - delete
+  - deletecollection
   - get
   - list
   - patch
@@ -862,6 +863,7 @@ rules:
   verbs:
   - create
   - delete
+  - deletecollection
   - get
   - list
   - patch

--- a/controllers/datasciencecluster/kubebuilder_rbac.go
+++ b/controllers/datasciencecluster/kubebuilder_rbac.go
@@ -77,7 +77,7 @@ package datasciencecluster
 
 // +kubebuilder:rbac:groups="oauth.openshift.io",resources=oauthclients,verbs=*
 
-// +kubebuilder:rbac:groups="networking.k8s.io",resources=networkpolicies,verbs=get;create;list;watch;delete;update;patch
+// +kubebuilder:rbac:groups="networking.k8s.io",resources=networkpolicies,verbs=get;create;list;watch;delete;update;patch;deletecollection
 // +kubebuilder:rbac:groups="networking.k8s.io",resources=ingresses,verbs=create;delete;list;update;watch;patch;get
 
 // +kubebuilder:rbac:groups="networking.istio.io",resources=virtualservices/status,verbs=update;patch;delete
@@ -143,7 +143,7 @@ package datasciencecluster
 // +kubebuilder:rbac:groups="core",resources=endpoints,verbs=watch;list
 
 // +kubebuilder:rbac:groups="core",resources=configmaps/status,verbs=get;update;patch;delete
-// +kubebuilder:rbac:groups="core",resources=configmaps,verbs=get;create;watch;patch;delete;list
+// +kubebuilder:rbac:groups="core",resources=configmaps,verbs=get;create;watch;patch;delete;list;deletecollection
 
 // +kubebuilder:rbac:groups="core",resources=clusterversions,verbs=watch;list
 // +kubebuilder:rbac:groups="config.openshift.io",resources=clusterversions,verbs=watch;list

--- a/pkg/plugins/addLabelsplugin.go
+++ b/pkg/plugins/addLabelsplugin.go
@@ -12,6 +12,7 @@ func ApplyAddLabelsPlugin(componentName string, resMap resmap.ResMap) error {
 		Labels: map[string]string{
 			"app.kubernetes.io/part-of":           componentName,
 			"app.opendatahub.io/" + componentName: "true",
+			"opendatahub.io/component":            "true",
 		},
 		FieldSpecs: []types.FieldSpec{
 			{
@@ -20,13 +21,11 @@ func ApplyAddLabelsPlugin(componentName string, resMap resmap.ResMap) error {
 				CreateIfNotPresent: true,
 			},
 			{
-				Gvk: resid.Gvk{
-					Kind: "Deployment",
-				},
+				Gvk:                resid.Gvk{Kind: "Deployment"},
 				Path:               "spec/selector/matchLabels",
 				CreateIfNotPresent: true,
 			},
-			{
+			{ // for all kinds
 				Gvk:                resid.Gvk{},
 				Path:               "metadata/labels",
 				CreateIfNotPresent: true,


### PR DESCRIPTION
## Description
- create new label  ` "opendatahub.io/component": "true",` to know if these resource are originally created by operator
- no need to include pod or rc, since deployment till handle these
- apply lable plugin to more than just deployment
ref: https://github.com/opendatahub-io/opendatahub-operator/issues/455


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
test image: quay.io/wenzhou/opendatahub-operator-catalog:v2.9.455-2
since it depends on the new label, some resources created already might not be cleanedup.
- create DSCI (default to use `opendatahub` ns)
- create DSC with `dashboard` enabled
- check in `opendatahub` ns  has `dashboard`created  there
- update DSCI to use `redhat-ods-applications` as new ns
- check `dashboard` deployment in `opendatahub` ns is gone along with pod
![Screenshot from 2023-09-22 17-11-25](https://github.com/opendatahub-io/opendatahub-operator/assets/915053/2c58447f-684c-4556-929c-db01e561ef75)

- check dashboard deployment and pods are created in r`edhat-ods-applications`
- update DSC to enable `workbench` and `dspa`
- check `notebookcontroller` and `dspa` also created in `redhat-ods-appliation` ns
- update DSCI to set to `new-opendatabhub-ns` as newer ns
![Screenshot from 2023-09-22 17-11-42](https://github.com/opendatahub-io/opendatahub-operator/assets/915053/e886ae7d-7fd7-4c7a-b0bb-af942adc7c9c)

- check r`edhat-ods-applications` dont have deployment or pod but namespace still exist
![Screenshot from 2023-09-22 17-14-50](https://github.com/opendatahub-io/opendatahub-operator/assets/915053/e6d4469e-dfdb-4019-a15a-8e48afecbaea)

- check `new-opendatahub-ns `has new deployment and pod
![Screenshot from 2023-09-22 17-14-29](https://github.com/opendatahub-io/opendatahub-operator/assets/915053/38be2b50-2329-4ac8-a51a-341d4567d61e)

- check route of dashbaord still working
-  

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
