### PR TITLE
Revert: change to delete CF resource is not required

### DIFF
--- a/components/codeflare/codeflare.go
+++ b/components/codeflare/codeflare.go
@@ -2,15 +2,11 @@
 package codeflare
 
 import (
-	"context"
 	"fmt"
 	dsci "github.com/opendatahub-io/opendatahub-operator/v2/apis/dscinitialization/v1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/components"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/deploy"
-	imagev1 "github.com/openshift/api/image/v1"
 	operatorv1 "github.com/openshift/api/operator/v1"
-	codeflarev1alpha1 "github.com/project-codeflare/codeflare-operator/api/codeflare/v1alpha1"
-	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -69,45 +65,6 @@ func (c *CodeFlare) ReconcileComponent(cli client.Client, owner metav1.Object, d
 				return err
 			}
 		}
-	}
-
-	// Special handling to delete MCAD InstaScale ImageStream resources
-	if c.GetManagementState() == operatorv1.Removed {
-		// Fetch the MCAD resource based on the request
-		mcad := &codeflarev1alpha1.MCAD{}
-		err := cli.Get(context.TODO(), client.ObjectKey{
-			Name: "mcad",
-		}, mcad)
-		if err != nil {
-			if apierrs.IsNotFound(err) {
-				return fmt.Errorf("failed to get MCAD instance mcad: %w", err)
-			}
-		}
-		err = cli.Delete(context.TODO(), mcad)
-
-		// Fetch InstaScale based on the request
-		instascale := &codeflarev1alpha1.InstaScale{}
-		err = cli.Get(context.TODO(), client.ObjectKey{
-			Name: "instascale",
-		}, instascale)
-		if err != nil {
-			if apierrs.IsNotFound(err) {
-				return fmt.Errorf("failed to get InstaScale instance instascale: %w", err)
-			}
-		}
-		err = cli.Delete(context.TODO(), instascale)
-
-		// Fetch Imagestream based on the request
-		imagestream := &imagev1.ImageStream{}
-		err = cli.Get(context.TODO(), client.ObjectKey{
-			Name: "codeflare-notebook",
-		}, imagestream)
-		if err != nil {
-			if apierrs.IsNotFound(err) {
-				return fmt.Errorf("failed to get Imagestream instance codeflare-notebook: %w", err)
-			}
-		}
-		err = cli.Delete(context.TODO(), imagestream)
 	}
 
 	// Deploy Codeflare


### PR DESCRIPTION
## Description
revert changes for https://github.com/opendatahub-io/opendatahub-operator/issues/510
tl;dr:  handling done in CF operator, wont require action from ODH operator
detail https://github.com/opendatahub-io/opendatahub-operator/pull/511/files 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
