### PR TITLE
Fix: wrong image for odh-model-controller when enable kserve

### DIFF
--- a/components/kserve/kserve.go
+++ b/components/kserve/kserve.go
@@ -84,9 +84,9 @@ func (k *Kserve) ReconcileComponent(cli client.Client, owner metav1.Object, dsci
 		if err != nil {
 			return err
 		}
-		// Update image parameters for kserve
+		// Update image parameters for odh-maodel-controller
 		if dscispec.DevFlags.ManifestsUri == "" {
-			if err := deploy.ApplyImageParams(Path, dependentImageParamMap); err != nil {
+			if err := deploy.ApplyImageParams(DependentPath, dependentImageParamMap); err != nil {
 				return err
 			}
 		}


### PR DESCRIPTION
# Description
<!--- Describe your changes in detail -->
ref:  https://issues.redhat.com/browse/RHODS-12074

the original fix made in ODH https://github.com/opendatahub-io/opendatahub-operator/pull/504 was removed after code rebase , so it did not end into OHD main, and not sync down to RHODS main


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
