### PR TITLE
Add acceleratorprofiles from dashboard as new CRD

### DIFF
--- a/bundle/manifests/opendatahub-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/opendatahub-operator.clusterserviceversion.yaml
@@ -687,6 +687,16 @@ spec:
         - apiGroups:
           - dashboard.opendatahub.io
           resources:
+          - acceleratorprofiles
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+        - apiGroups:
+          - dashboard.opendatahub.io
+          resources:
           - odhapplications
           verbs:
           - create

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -511,6 +511,16 @@ rules:
 - apiGroups:
   - dashboard.opendatahub.io
   resources:
+  - acceleratorprofiles
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+- apiGroups:
+  - dashboard.opendatahub.io
+  resources:
   - odhapplications
   verbs:
   - create

--- a/controllers/datasciencecluster/kubebuilder_rbac.go
+++ b/controllers/datasciencecluster/kubebuilder_rbac.go
@@ -17,6 +17,7 @@ package datasciencecluster
 // +kubebuilder:rbac:groups="console.openshift.io",resources=odhquickstarts,verbs=create;get;patch;list;delete
 // +kubebuilder:rbac:groups="dashboard.opendatahub.io",resources=odhdocuments,verbs=create;get;patch;list;delete
 // +kubebuilder:rbac:groups="dashboard.opendatahub.io",resources=odhapplications,verbs=create;get;patch;list;delete
+// +kubebuilder:rbac:groups="dashboard.opendatahub.io",resources=acceleratorprofiles,verbs=create;get;patch;list;delete
 
 // +kubebuilder:rbac:groups="operators.coreos.com",resources=clusterserviceversions,verbs=get;list;watch
 // +kubebuilder:rbac:groups="operators.coreos.com",resources=customresourcedefinitions,verbs=create;get;patch;delete


### PR DESCRIPTION
## Description
see conversation: https://redhat-internal.slack.com/archives/C05NXTEHLGY/p1695810959718189?thread_ts=1695113073.646639&cid=C05NXTEHLGY

this will not directly solve the problem seen on odh-nightly, but we will need it once the docker build is fixed to use CRD from odh-dashboard incubation branch

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
