### PR TITLE
Add check on DSCI intance to explicity on "default" as name

### DIFF
--- a/controllers/datasciencecluster/datasciencecluster_controller.go
+++ b/controllers/datasciencecluster/datasciencecluster_controller.go
@@ -70,7 +70,7 @@ type DataScienceClusterConfig struct {
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
 func (r *DataScienceClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	r.Log.Info("Reconciling DataScienceCluster resources", "Request.Namespace", req.Namespace, "Request.Name", req.Name)
+	r.Log.Info("Reconciling DataScienceCluster resources", "Request.Name", req.Name)
 
 	instances := &dsc.DataScienceClusterList{}
 	if err := r.Client.List(ctx, instances); err != nil {


### PR DESCRIPTION
- also remove logger on namespace, which does not print anything in the log

## Description
looked back the change is introduced in https://github.com/opendatahub-io/opendatahub-operator/pull/446
but i think actually, we do not support /or cannot support in the current code base for a DSCI instance which is not named "`default`"
I did the test to update DSCI instance to "`something`" and got error when doing component reconcile:
```
2023-09-28T07:45:01Z	INFO	controllers.DSCInitialization	Reconciling DSCInitialization.	{"DSCInitialization": "", "Request.Name": "something"}
....
2023-09-28T07:59:49Z	ERROR	controllers.DataScienceCluster	failed to reconcile model-mesh on DataScienceCluster	{"instance.Name": "default", "error": "DSCInitialization.dscinitialization.opendatahub.io \"default\" not found"}
github.com/opendatahub-io/opendatahub-operator/v2/controllers/datasciencecluster.(*DataScienceClusterReconciler).reportError

```
because for DSC it is looking back the DSCI instance name hardcoded in the main.go, no matter what user config in DSCI, DSC reconcile wont respect that value.


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
