### PR TITLE
fix: adds missing CRDs for k8s EnvTest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,11 +108,25 @@ help: ## Display this help.
 
 ##@ Development
 
+define go-mod-version
+$(shell go mod graph | grep $(1) | head -n 1 | cut -d'@' -f 2)
+endef
+
+# Using controller-gen to fetch external CRDs and put them in config/crd/external folder
+# They're used in tests, as they have to be created for controller to work
+define fetch-external-crds
+GOFLAGS="-mod=readonly" $(LOCALBIN)/controller-gen crd \
+paths=$(shell go env GOPATH)/pkg/mod/$(1)@$(call go-mod-version,$(1))/$(2)/... \
+output:crd:artifacts:config=config/crd/external
+endef
+
 .PHONY: manifests
 manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
 # TODO: enable below when we do webhook
 # $(CONTROLLER_GEN) rbac:roleName=controller-manager-role crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases
 	$(CONTROLLER_GEN) rbac:roleName=controller-manager-role crd paths="./..." output:crd:artifacts:config=config/crd/bases
+	$(call fetch-external-crds,github.com/openshift/api,route/v1)
+	$(call fetch-external-crds,github.com/openshift/api,user/v1)
 
 .PHONY: generate
 generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.

--- a/Makefile
+++ b/Makefile
@@ -115,7 +115,7 @@ endef
 # Using controller-gen to fetch external CRDs and put them in config/crd/external folder
 # They're used in tests, as they have to be created for controller to work
 define fetch-external-crds
-GOFLAGS="-mod=readonly" $(LOCALBIN)/controller-gen crd \
+GOFLAGS="-mod=readonly" $(CONTROLLER_GEN) crd \
 paths=$(shell go env GOPATH)/pkg/mod/$(1)@$(call go-mod-version,$(1))/$(2)/... \
 output:crd:artifacts:config=config/crd/external
 endef

--- a/config/crd/external/route.openshift.io_routes.yaml
+++ b/config/crd/external/route.openshift.io_routes.yaml
@@ -1,0 +1,605 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.9.2
+  creationTimestamp: null
+  name: routes.route.openshift.io
+spec:
+  group: route.openshift.io
+  names:
+    kind: Route
+    listKind: RouteList
+    plural: routes
+    singular: route
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: "A route allows developers to expose services through an HTTP(S)
+          aware load balancing and proxy layer via a public DNS entry. The route may
+          further specify TLS options and a certificate, or specify a public CNAME
+          that the router should also accept for HTTP and HTTPS traffic. An administrator
+          typically configures their router to be visible outside the cluster firewall,
+          and may also add additional security, caching, or traffic controls on the
+          service content. Routers usually talk directly to the service endpoints.
+          \n Once a route is created, the `host` field may not be changed. Generally,
+          routers use the oldest route with a given host when resolving conflicts.
+          \n Routers are subject to additional customization and may support additional
+          controls via the annotations field. \n Because administrators may configure
+          multiple routers, the route status field is used to return information to
+          clients about the names and states of the route under each router. If a
+          client chooses a duplicate name, for instance, the route status conditions
+          are used to indicate the route cannot be chosen. \n To enable HTTP/2 ALPN
+          on a route it requires a custom (non-wildcard) certificate. This prevents
+          connection coalescing by clients, notably web browsers. We do not support
+          HTTP/2 ALPN on routes that use the default certificate because of the risk
+          of connection re-use/coalescing. Routes that do not have their own custom
+          certificate will not be HTTP/2 ALPN-enabled on either the frontend or the
+          backend. \n Compatibility level 1: Stable within a major release for a minimum
+          of 12 months or 3 minor releases (whichever is longer)."
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec is the desired state of the route
+            properties:
+              alternateBackends:
+                description: alternateBackends allows up to 3 additional backends
+                  to be assigned to the route. Only the Service kind is allowed, and
+                  it will be defaulted to Service. Use the weight field in RouteTargetReference
+                  object to specify relative preference.
+                items:
+                  description: RouteTargetReference specifies the target that resolve
+                    into endpoints. Only the 'Service' kind is allowed. Use 'weight'
+                    field to emphasize one over others.
+                  properties:
+                    kind:
+                      default: Service
+                      description: The kind of target that the route is referring
+                        to. Currently, only 'Service' is allowed
+                      enum:
+                      - Service
+                      - ""
+                      type: string
+                    name:
+                      description: name of the service/target that is being referred
+                        to. e.g. name of the service
+                      minLength: 1
+                      type: string
+                    weight:
+                      default: 100
+                      description: weight as an integer between 0 and 256, default
+                        100, that specifies the target's relative weight against other
+                        target reference objects. 0 suppresses requests to this backend.
+                      format: int32
+                      maximum: 256
+                      minimum: 0
+                      type: integer
+                  required:
+                  - kind
+                  - name
+                  type: object
+                maxItems: 3
+                type: array
+              host:
+                description: host is an alias/DNS that points to the service. Optional.
+                  If not specified a route name will typically be automatically chosen.
+                  Must follow DNS952 subdomain conventions.
+                maxLength: 253
+                pattern: ^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])(\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9]))*$
+                type: string
+              httpHeaders:
+                description: httpHeaders defines policy for HTTP headers.
+                properties:
+                  actions:
+                    description: 'actions specifies options for modifying headers
+                      and their values. Note that this option only applies to cleartext
+                      HTTP connections and to secure HTTP connections for which the
+                      ingress controller terminates encryption (that is, edge-terminated
+                      or reencrypt connections).  Headers cannot be modified for TLS
+                      passthrough connections. Setting the HSTS (`Strict-Transport-Security`)
+                      header is not supported via actions. `Strict-Transport-Security`
+                      may only be configured using the "haproxy.router.openshift.io/hsts_header"
+                      route annotation, and only in accordance with the policy specified
+                      in Ingress.Spec.RequiredHSTSPolicies. In case of HTTP request
+                      headers, the actions specified in spec.httpHeaders.actions on
+                      the Route will be executed after the actions specified in the
+                      IngressController''s spec.httpHeaders.actions field. In case
+                      of HTTP response headers, the actions specified in spec.httpHeaders.actions
+                      on the IngressController will be executed after the actions
+                      specified in the Route''s spec.httpHeaders.actions field. The
+                      headers set via this API will not appear in access logs. Any
+                      actions defined here are applied after any actions related to
+                      the following other fields: cache-control, spec.clientTLS, spec.httpHeaders.forwardedHeaderPolicy,
+                      spec.httpHeaders.uniqueId, and spec.httpHeaders.headerNameCaseAdjustments.
+                      The following header names are reserved and may not be modified
+                      via this API: Strict-Transport-Security, Proxy, Cookie, Set-Cookie.
+                      Note that the total size of all net added headers *after* interpolating
+                      dynamic values must not exceed the value of spec.tuningOptions.headerBufferMaxRewriteBytes
+                      on the IngressController. Please refer to the documentation
+                      for that API field for more details.'
+                    properties:
+                      request:
+                        description: 'request is a list of HTTP request headers to
+                          modify. Currently, actions may define to either `Set` or
+                          `Delete` headers values. Actions defined here will modify
+                          the request headers of all requests made through a route.
+                          These actions are applied to a specific Route defined within
+                          a cluster i.e. connections made through a route. Currently,
+                          actions may define to either `Set` or `Delete` headers values.
+                          Route actions will be executed after IngressController actions
+                          for request headers. Actions are applied in sequence as
+                          defined in this list. A maximum of 20 request header actions
+                          may be configured. You can use this field to specify HTTP
+                          request headers that should be set or deleted when forwarding
+                          connections from the client to your application. Sample
+                          fetchers allowed are "req.hdr" and "ssl_c_der". Converters
+                          allowed are "lower" and "base64". Example header values:
+                          "%[req.hdr(X-target),lower]", "%{+Q}[ssl_c_der,base64]".
+                          Any request header configuration applied directly via a
+                          Route resource using this API will override header configuration
+                          for a header of the same name applied via spec.httpHeaders.actions
+                          on the IngressController or route annotation. Note: This
+                          field cannot be used if your route uses TLS passthrough.'
+                        items:
+                          description: RouteHTTPHeader specifies configuration for
+                            setting or deleting an HTTP header.
+                          properties:
+                            action:
+                              description: action specifies actions to perform on
+                                headers, such as setting or deleting headers.
+                              properties:
+                                set:
+                                  description: 'set defines the HTTP header that should
+                                    be set: added if it doesn''t exist or replaced
+                                    if it does. This field is required when type is
+                                    Set and forbidden otherwise.'
+                                  properties:
+                                    value:
+                                      description: value specifies a header value.
+                                        Dynamic values can be added. The value will
+                                        be interpreted as an HAProxy format string
+                                        as defined in http://cbonte.github.io/haproxy-dconv/2.6/configuration.html#8.2.6
+                                        and may use HAProxy's %[] syntax and otherwise
+                                        must be a valid HTTP header value as defined
+                                        in https://datatracker.ietf.org/doc/html/rfc7230#section-3.2.
+                                        The value of this field must be no more than
+                                        16384 characters in length. Note that the
+                                        total size of all net added headers *after*
+                                        interpolating dynamic values must not exceed
+                                        the value of spec.tuningOptions.headerBufferMaxRewriteBytes
+                                        on the IngressController.
+                                      maxLength: 16384
+                                      minLength: 1
+                                      type: string
+                                  required:
+                                  - value
+                                  type: object
+                                type:
+                                  description: type defines the type of the action
+                                    to be applied on the header. Possible values are
+                                    Set or Delete. Set allows you to set HTTP request
+                                    and response headers. Delete allows you to delete
+                                    HTTP request and response headers.
+                                  enum:
+                                  - Set
+                                  - Delete
+                                  type: string
+                              required:
+                              - type
+                              type: object
+                              x-kubernetes-validations:
+                              - message: set is required when type is Set, and forbidden
+                                  otherwise
+                                rule: 'has(self.type) && self.type == ''Set'' ?  has(self.set)
+                                  : !has(self.set)'
+                            name:
+                              description: 'name specifies the name of a header on
+                                which to perform an action. Its value must be a valid
+                                HTTP header name as defined in RFC 2616 section 4.2.
+                                The name must consist only of alphanumeric and the
+                                following special characters, "-!#$%&''*+.^_`". The
+                                following header names are reserved and may not be
+                                modified via this API: Strict-Transport-Security,
+                                Proxy, Cookie, Set-Cookie. It must be no more than
+                                255 characters in length. Header name must be unique.'
+                              maxLength: 255
+                              minLength: 1
+                              pattern: ^[-!#$%&'*+.0-9A-Z^_`a-z|~]+$
+                              type: string
+                              x-kubernetes-validations:
+                              - message: strict-transport-security header may not
+                                  be modified via header actions
+                                rule: self.lowerAscii() != 'strict-transport-security'
+                              - message: proxy header may not be modified via header
+                                  actions
+                                rule: self.lowerAscii() != 'proxy'
+                              - message: cookie header may not be modified via header
+                                  actions
+                                rule: self.lowerAscii() != 'cookie'
+                              - message: set-cookie header may not be modified via
+                                  header actions
+                                rule: self.lowerAscii() != 'set-cookie'
+                          required:
+                          - action
+                          - name
+                          type: object
+                        maxItems: 20
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                        x-kubernetes-validations:
+                        - message: Either the header value provided is not in correct
+                            format or the sample fetcher/converter specified is not
+                            allowed. The dynamic header value will be interpreted
+                            as an HAProxy format string as defined in http://cbonte.github.io/haproxy-dconv/2.6/configuration.html#8.2.6
+                            and may use HAProxy's %[] syntax and otherwise must be
+                            a valid HTTP header value as defined in https://datatracker.ietf.org/doc/html/rfc7230#section-3.2.
+                            Sample fetchers allowed are req.hdr, ssl_c_der. Converters
+                            allowed are lower, base64.
+                          rule: self.all(key, key.action.type == "Delete" || (has(key.action.set)
+                            && key.action.set.value.matches('^(?:%(?:%|(?:\\{[-+]?[QXE](?:,[-+]?[QXE])*\\})?\\[(?:req\\.hdr\\([0-9A-Za-z-]+\\)|ssl_c_der)(?:,(?:lower|base64))*\\])|[^%[:cntrl:]])+$')))
+                      response:
+                        description: 'response is a list of HTTP response headers
+                          to modify. Currently, actions may define to either `Set`
+                          or `Delete` headers values. Actions defined here will modify
+                          the response headers of all requests made through a route.
+                          These actions are applied to a specific Route defined within
+                          a cluster i.e. connections made through a route. Route actions
+                          will be executed before IngressController actions for response
+                          headers. Actions are applied in sequence as defined in this
+                          list. A maximum of 20 response header actions may be configured.
+                          You can use this field to specify HTTP response headers
+                          that should be set or deleted when forwarding responses
+                          from your application to the client. Sample fetchers allowed
+                          are "res.hdr" and "ssl_c_der". Converters allowed are "lower"
+                          and "base64". Example header values: "%[res.hdr(X-target),lower]",
+                          "%{+Q}[ssl_c_der,base64]". Note: This field cannot be used
+                          if your route uses TLS passthrough.'
+                        items:
+                          description: RouteHTTPHeader specifies configuration for
+                            setting or deleting an HTTP header.
+                          properties:
+                            action:
+                              description: action specifies actions to perform on
+                                headers, such as setting or deleting headers.
+                              properties:
+                                set:
+                                  description: 'set defines the HTTP header that should
+                                    be set: added if it doesn''t exist or replaced
+                                    if it does. This field is required when type is
+                                    Set and forbidden otherwise.'
+                                  properties:
+                                    value:
+                                      description: value specifies a header value.
+                                        Dynamic values can be added. The value will
+                                        be interpreted as an HAProxy format string
+                                        as defined in http://cbonte.github.io/haproxy-dconv/2.6/configuration.html#8.2.6
+                                        and may use HAProxy's %[] syntax and otherwise
+                                        must be a valid HTTP header value as defined
+                                        in https://datatracker.ietf.org/doc/html/rfc7230#section-3.2.
+                                        The value of this field must be no more than
+                                        16384 characters in length. Note that the
+                                        total size of all net added headers *after*
+                                        interpolating dynamic values must not exceed
+                                        the value of spec.tuningOptions.headerBufferMaxRewriteBytes
+                                        on the IngressController.
+                                      maxLength: 16384
+                                      minLength: 1
+                                      type: string
+                                  required:
+                                  - value
+                                  type: object
+                                type:
+                                  description: type defines the type of the action
+                                    to be applied on the header. Possible values are
+                                    Set or Delete. Set allows you to set HTTP request
+                                    and response headers. Delete allows you to delete
+                                    HTTP request and response headers.
+                                  enum:
+                                  - Set
+                                  - Delete
+                                  type: string
+                              required:
+                              - type
+                              type: object
+                              x-kubernetes-validations:
+                              - message: set is required when type is Set, and forbidden
+                                  otherwise
+                                rule: 'has(self.type) && self.type == ''Set'' ?  has(self.set)
+                                  : !has(self.set)'
+                            name:
+                              description: 'name specifies the name of a header on
+                                which to perform an action. Its value must be a valid
+                                HTTP header name as defined in RFC 2616 section 4.2.
+                                The name must consist only of alphanumeric and the
+                                following special characters, "-!#$%&''*+.^_`". The
+                                following header names are reserved and may not be
+                                modified via this API: Strict-Transport-Security,
+                                Proxy, Cookie, Set-Cookie. It must be no more than
+                                255 characters in length. Header name must be unique.'
+                              maxLength: 255
+                              minLength: 1
+                              pattern: ^[-!#$%&'*+.0-9A-Z^_`a-z|~]+$
+                              type: string
+                              x-kubernetes-validations:
+                              - message: strict-transport-security header may not
+                                  be modified via header actions
+                                rule: self.lowerAscii() != 'strict-transport-security'
+                              - message: proxy header may not be modified via header
+                                  actions
+                                rule: self.lowerAscii() != 'proxy'
+                              - message: cookie header may not be modified via header
+                                  actions
+                                rule: self.lowerAscii() != 'cookie'
+                              - message: set-cookie header may not be modified via
+                                  header actions
+                                rule: self.lowerAscii() != 'set-cookie'
+                          required:
+                          - action
+                          - name
+                          type: object
+                        maxItems: 20
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                        x-kubernetes-validations:
+                        - message: Either the header value provided is not in correct
+                            format or the sample fetcher/converter specified is not
+                            allowed. The dynamic header value will be interpreted
+                            as an HAProxy format string as defined in http://cbonte.github.io/haproxy-dconv/2.6/configuration.html#8.2.6
+                            and may use HAProxy's %[] syntax and otherwise must be
+                            a valid HTTP header value as defined in https://datatracker.ietf.org/doc/html/rfc7230#section-3.2.
+                            Sample fetchers allowed are res.hdr, ssl_c_der. Converters
+                            allowed are lower, base64.
+                          rule: self.all(key, key.action.type == "Delete" || (has(key.action.set)
+                            && key.action.set.value.matches('^(?:%(?:%|(?:\\{[-+]?[QXE](?:,[-+]?[QXE])*\\})?\\[(?:res\\.hdr\\([0-9A-Za-z-]+\\)|ssl_c_der)(?:,(?:lower|base64))*\\])|[^%[:cntrl:]])+$')))
+                    type: object
+                type: object
+              path:
+                description: path that the router watches for, to route traffic for
+                  to the service. Optional
+                pattern: ^/
+                type: string
+              port:
+                description: If specified, the port to be used by the router. Most
+                  routers will use all endpoints exposed by the service by default
+                  - set this value to instruct routers which port to use.
+                properties:
+                  targetPort:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: The target port on pods selected by the service this
+                      route points to. If this is a string, it will be looked up as
+                      a named port in the target endpoints port list. Required
+                    x-kubernetes-int-or-string: true
+                required:
+                - targetPort
+                type: object
+              subdomain:
+                description: "subdomain is a DNS subdomain that is requested within
+                  the ingress controller's domain (as a subdomain). If host is set
+                  this field is ignored. An ingress controller may choose to ignore
+                  this suggested name, in which case the controller will report the
+                  assigned name in the status.ingress array or refuse to admit the
+                  route. If this value is set and the server does not support this
+                  field host will be populated automatically. Otherwise host is left
+                  empty. The field may have multiple parts separated by a dot, but
+                  not all ingress controllers may honor the request. This field may
+                  not be changed after creation except by a user with the update routes/custom-host
+                  permission. \n Example: subdomain `frontend` automatically receives
+                  the router subdomain `apps.mycluster.com` to have a full hostname
+                  `frontend.apps.mycluster.com`."
+                maxLength: 253
+                pattern: ^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])(\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9]))*$
+                type: string
+              tls:
+                description: The tls field provides the ability to configure certificates
+                  and termination for the route.
+                properties:
+                  caCertificate:
+                    description: caCertificate provides the cert authority certificate
+                      contents
+                    type: string
+                  certificate:
+                    description: certificate provides certificate contents. This should
+                      be a single serving certificate, not a certificate chain. Do
+                      not include a CA certificate.
+                    type: string
+                  destinationCACertificate:
+                    description: destinationCACertificate provides the contents of
+                      the ca certificate of the final destination.  When using reencrypt
+                      termination this file should be provided in order to have routers
+                      use it for health checks on the secure connection. If this field
+                      is not specified, the router may provide its own destination
+                      CA and perform hostname validation using the short service name
+                      (service.namespace.svc), which allows infrastructure generated
+                      certificates to automatically verify.
+                    type: string
+                  externalCertificate:
+                    description: externalCertificate provides certificate contents
+                      as a secret reference. This should be a single serving certificate,
+                      not a certificate chain. Do not include a CA certificate. The
+                      secret referenced should be present in the same namespace as
+                      that of the Route. Forbidden when `certificate` is set.
+                    properties:
+                      name:
+                        description: 'name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                        type: string
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  insecureEdgeTerminationPolicy:
+                    description: "insecureEdgeTerminationPolicy indicates the desired
+                      behavior for insecure connections to a route. While each router
+                      may make its own decisions on which ports to expose, this is
+                      normally port 80. \n * Allow - traffic is sent to the server
+                      on the insecure port (edge/reencrypt terminations only) (default).
+                      * None - no traffic is allowed on the insecure port. * Redirect
+                      - clients are redirected to the secure port."
+                    enum:
+                    - Allow
+                    - None
+                    - Redirect
+                    - ""
+                    type: string
+                  key:
+                    description: key provides key file contents
+                    type: string
+                  termination:
+                    description: "termination indicates termination type. \n * edge
+                      - TLS termination is done by the router and http is used to
+                      communicate with the backend (default) * passthrough - Traffic
+                      is sent straight to the destination without the router providing
+                      TLS termination * reencrypt - TLS termination is done by the
+                      router and https is used to communicate with the backend \n
+                      Note: passthrough termination is incompatible with httpHeader
+                      actions"
+                    enum:
+                    - edge
+                    - reencrypt
+                    - passthrough
+                    type: string
+                required:
+                - termination
+                type: object
+                x-kubernetes-validations:
+                - message: 'cannot have both spec.tls.termination: passthrough and
+                    spec.tls.insecureEdgeTerminationPolicy: Allow'
+                  rule: 'has(self.termination) && has(self.insecureEdgeTerminationPolicy)
+                    ? !((self.termination==''passthrough'') && (self.insecureEdgeTerminationPolicy==''Allow''))
+                    : true'
+              to:
+                description: to is an object the route should use as the primary backend.
+                  Only the Service kind is allowed, and it will be defaulted to Service.
+                  If the weight field (0-256 default 100) is set to zero, no traffic
+                  will be sent to this backend.
+                properties:
+                  kind:
+                    default: Service
+                    description: The kind of target that the route is referring to.
+                      Currently, only 'Service' is allowed
+                    enum:
+                    - Service
+                    - ""
+                    type: string
+                  name:
+                    description: name of the service/target that is being referred
+                      to. e.g. name of the service
+                    minLength: 1
+                    type: string
+                  weight:
+                    default: 100
+                    description: weight as an integer between 0 and 256, default 100,
+                      that specifies the target's relative weight against other target
+                      reference objects. 0 suppresses requests to this backend.
+                    format: int32
+                    maximum: 256
+                    minimum: 0
+                    type: integer
+                required:
+                - kind
+                - name
+                type: object
+              wildcardPolicy:
+                default: None
+                description: Wildcard policy if any for the route. Currently only
+                  'Subdomain' or 'None' is allowed.
+                enum:
+                - None
+                - Subdomain
+                - ""
+                type: string
+            required:
+            - to
+            type: object
+            x-kubernetes-validations:
+            - message: header actions are not permitted when tls termination is passthrough.
+              rule: '!has(self.tls) || self.tls.termination != ''passthrough'' ||
+                !has(self.httpHeaders)'
+          status:
+            description: status is the current state of the route
+            properties:
+              ingress:
+                description: ingress describes the places where the route may be exposed.
+                  The list of ingress points may contain duplicate Host or RouterName
+                  values. Routes are considered live once they are `Ready`
+                items:
+                  description: RouteIngress holds information about the places where
+                    a route is exposed.
+                  properties:
+                    conditions:
+                      description: Conditions is the state of the route, may be empty.
+                      items:
+                        description: RouteIngressCondition contains details for the
+                          current condition of this route on a particular router.
+                        properties:
+                          lastTransitionTime:
+                            description: RFC 3339 date and time when this condition
+                              last transitioned
+                            format: date-time
+                            type: string
+                          message:
+                            description: Human readable message indicating details
+                              about last transition.
+                            type: string
+                          reason:
+                            description: (brief) reason for the condition's last transition,
+                              and is usually a machine and human readable constant
+                            type: string
+                          status:
+                            description: Status is the status of the condition. Can
+                              be True, False, Unknown.
+                            type: string
+                          type:
+                            description: Type is the type of the condition. Currently
+                              only Admitted.
+                            type: string
+                        required:
+                        - status
+                        - type
+                        type: object
+                      type: array
+                    host:
+                      description: Host is the host string under which the route is
+                        exposed; this value is required
+                      type: string
+                    routerCanonicalHostname:
+                      description: CanonicalHostname is the external host name for
+                        the router that can be used as a CNAME for the host requested
+                        for this route. This value is optional and may not be set
+                        in all cases.
+                      type: string
+                    routerName:
+                      description: Name is a name chosen by the router to identify
+                        itself; this value is required
+                      type: string
+                    wildcardPolicy:
+                      description: Wildcard policy is the wildcard policy that was
+                        allowed where this route is exposed.
+                      type: string
+                  type: object
+                type: array
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/config/crd/external/user.openshift.io_groups.yaml
+++ b/config/crd/external/user.openshift.io_groups.yaml
@@ -1,0 +1,46 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.9.2
+  creationTimestamp: null
+  name: groups.user.openshift.io
+spec:
+  group: user.openshift.io
+  names:
+    kind: Group
+    listKind: GroupList
+    plural: groups
+    singular: group
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: "Group represents a referenceable set of Users \n Compatibility
+          level 1: Stable within a major release for a minimum of 12 months or 3 minor
+          releases (whichever is longer)."
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          users:
+            description: Users is the list of users in this group.
+            items:
+              type: string
+            type: array
+        required:
+        - users
+        type: object
+    served: true
+    storage: true

--- a/config/crd/external/user.openshift.io_identities.yaml
+++ b/config/crd/external/user.openshift.io_identities.yaml
@@ -1,0 +1,97 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.9.2
+  creationTimestamp: null
+  name: identities.user.openshift.io
+spec:
+  group: user.openshift.io
+  names:
+    kind: Identity
+    listKind: IdentityList
+    plural: identities
+    singular: identity
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: "Identity records a successful authentication of a user with
+          an identity provider. The information about the source of authentication
+          is stored on the identity, and the identity is then associated with a single
+          user object. Multiple identities can reference a single user. Information
+          retrieved from the authentication provider is stored in the extra field
+          using a schema determined by the provider. \n Compatibility level 1: Stable
+          within a major release for a minimum of 12 months or 3 minor releases (whichever
+          is longer)."
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          extra:
+            additionalProperties:
+              type: string
+            description: Extra holds extra information about this identity
+            type: object
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          providerName:
+            description: ProviderName is the source of identity information
+            type: string
+          providerUserName:
+            description: ProviderUserName uniquely represents this identity in the
+              scope of the provider
+            type: string
+          user:
+            description: User is a reference to the user this identity is associated
+              with Both Name and UID must be set
+            properties:
+              apiVersion:
+                description: API version of the referent.
+                type: string
+              fieldPath:
+                description: 'If referring to a piece of an object instead of an entire
+                  object, this string should contain a valid JSON/Go field access
+                  statement, such as desiredState.manifest.containers[2]. For example,
+                  if the object reference is to a container within a pod, this would
+                  take on a value like: "spec.containers{name}" (where "name" refers
+                  to the name of the container that triggered the event) or if no
+                  container name is specified "spec.containers[2]" (container with
+                  index 2 in this pod). This syntax is chosen only to have some well-defined
+                  way of referencing a part of an object. TODO: this design is not
+                  final and this field is subject to change in the future.'
+                type: string
+              kind:
+                description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              name:
+                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                type: string
+              namespace:
+                description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                type: string
+              resourceVersion:
+                description: 'Specific resourceVersion to which this reference is
+                  made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                type: string
+              uid:
+                description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                type: string
+            type: object
+            x-kubernetes-map-type: atomic
+        required:
+        - providerName
+        - providerUserName
+        - user
+        type: object
+    served: true
+    storage: true

--- a/config/crd/external/user.openshift.io_useridentitymappings.yaml
+++ b/config/crd/external/user.openshift.io_useridentitymappings.yaml
@@ -1,0 +1,111 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.9.2
+  creationTimestamp: null
+  name: useridentitymappings.user.openshift.io
+spec:
+  group: user.openshift.io
+  names:
+    kind: UserIdentityMapping
+    listKind: UserIdentityMappingList
+    plural: useridentitymappings
+    singular: useridentitymapping
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: "UserIdentityMapping maps a user to an identity \n Compatibility
+          level 1: Stable within a major release for a minimum of 12 months or 3 minor
+          releases (whichever is longer)."
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          identity:
+            description: Identity is a reference to an identity
+            properties:
+              apiVersion:
+                description: API version of the referent.
+                type: string
+              fieldPath:
+                description: 'If referring to a piece of an object instead of an entire
+                  object, this string should contain a valid JSON/Go field access
+                  statement, such as desiredState.manifest.containers[2]. For example,
+                  if the object reference is to a container within a pod, this would
+                  take on a value like: "spec.containers{name}" (where "name" refers
+                  to the name of the container that triggered the event) or if no
+                  container name is specified "spec.containers[2]" (container with
+                  index 2 in this pod). This syntax is chosen only to have some well-defined
+                  way of referencing a part of an object. TODO: this design is not
+                  final and this field is subject to change in the future.'
+                type: string
+              kind:
+                description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              name:
+                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                type: string
+              namespace:
+                description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                type: string
+              resourceVersion:
+                description: 'Specific resourceVersion to which this reference is
+                  made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                type: string
+              uid:
+                description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                type: string
+            type: object
+            x-kubernetes-map-type: atomic
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          user:
+            description: User is a reference to a user
+            properties:
+              apiVersion:
+                description: API version of the referent.
+                type: string
+              fieldPath:
+                description: 'If referring to a piece of an object instead of an entire
+                  object, this string should contain a valid JSON/Go field access
+                  statement, such as desiredState.manifest.containers[2]. For example,
+                  if the object reference is to a container within a pod, this would
+                  take on a value like: "spec.containers{name}" (where "name" refers
+                  to the name of the container that triggered the event) or if no
+                  container name is specified "spec.containers[2]" (container with
+                  index 2 in this pod). This syntax is chosen only to have some well-defined
+                  way of referencing a part of an object. TODO: this design is not
+                  final and this field is subject to change in the future.'
+                type: string
+              kind:
+                description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              name:
+                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                type: string
+              namespace:
+                description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                type: string
+              resourceVersion:
+                description: 'Specific resourceVersion to which this reference is
+                  made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                type: string
+              uid:
+                description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                type: string
+            type: object
+            x-kubernetes-map-type: atomic
+        type: object
+    served: true
+    storage: true

--- a/config/crd/external/user.openshift.io_users.yaml
+++ b/config/crd/external/user.openshift.io_users.yaml
@@ -1,0 +1,61 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.9.2
+  creationTimestamp: null
+  name: users.user.openshift.io
+spec:
+  group: user.openshift.io
+  names:
+    kind: User
+    listKind: UserList
+    plural: users
+    singular: user
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: "Upon log in, every user of the system receives a User and Identity
+          resource. Administrators may directly manipulate the attributes of the users
+          for their own tracking, or set groups via the API. The user name is unique
+          and is chosen based on the value provided by the identity provider - if
+          a user already exists with the incoming name, the user name may have a number
+          appended to it depending on the configuration of the system. \n Compatibility
+          level 1: Stable within a major release for a minimum of 12 months or 3 minor
+          releases (whichever is longer)."
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          fullName:
+            description: FullName is the full name of user
+            type: string
+          groups:
+            description: Groups specifies group names this user is a member of. This
+              field is deprecated and will be removed in a future release. Instead,
+              create a Group object containing the name of this User.
+            items:
+              type: string
+            type: array
+          identities:
+            description: Identities are the identities associated with this user
+            items:
+              type: string
+            type: array
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+        required:
+        - groups
+        type: object
+    served: true
+    storage: true

--- a/controllers/dscinitialization/dscinitialization_controller.go
+++ b/controllers/dscinitialization/dscinitialization_controller.go
@@ -110,7 +110,7 @@ func (r *DSCInitializationReconciler) Reconcile(ctx context.Context, req ctrl.Re
 
 	// Check namespace
 	namespace := instance.Spec.ApplicationsNamespace
-	err = r.createOdhNamespace(instance, namespace, ctx)
+	err = r.createOdhNamespace(ctx, instance, namespace)
 	if err != nil {
 		// no need to log error as it was already logged in createOdhNamespace
 		return reconcile.Result{}, err
@@ -144,7 +144,7 @@ func (r *DSCInitializationReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		} else {
 			// Apply self-managed rhods config
 			// Create rhods-admins Group if it doesn't exist
-			err := r.createUserGroup(instance, "rhods-admins", ctx)
+			err := r.createUserGroup(ctx, instance, "rhods-admins")
 			if err != nil {
 				return reconcile.Result{}, err
 			}
@@ -152,7 +152,7 @@ func (r *DSCInitializationReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		// Apply common rhods-specific config
 	} else { // ODH case
 		// Create odh-admins Group if it doesn't exist
-		err := r.createUserGroup(instance, "odh-admins", ctx)
+		err := r.createUserGroup(ctx, instance, "odh-admins")
 		if err != nil {
 			return reconcile.Result{}, err
 		}

--- a/controllers/dscinitialization/dscinitialization_test.go
+++ b/controllers/dscinitialization/dscinitialization_test.go
@@ -48,7 +48,8 @@ var _ = Describe("DataScienceCluster initialization", func() {
 			Expect(foundMonitoringNamespace.Name).Should(Equal(monitoringNamespace))
 		})
 
-		It("Should create default network policy", func() {
+		// Currently commented out in the DSCI reconcile - setting test to Pending
+		PIt("Should create default network policy", func() {
 			// then
 			foundNetworkPolicy := &netv1.NetworkPolicy{}
 			Eventually(objectExists(applicationNamespace, applicationNamespace, foundNetworkPolicy), timeout, interval).Should(BeTrue())

--- a/controllers/dscinitialization/suite_test.go
+++ b/controllers/dscinitialization/suite_test.go
@@ -18,6 +18,7 @@ package dscinitialization_test
 
 import (
 	"context"
+	"k8s.io/apimachinery/pkg/runtime"
 	"path/filepath"
 	"testing"
 	"time"
@@ -30,6 +31,7 @@ import (
 	dscinitializationv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/dscinitialization/v1"
 	dsci "github.com/opendatahub-io/opendatahub-operator/v2/controllers/dscinitialization"
 	routev1 "github.com/openshift/api/route/v1"
+	userv1 "github.com/openshift/api/user/v1"
 	ofapi "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -37,7 +39,6 @@ import (
 	authv1 "k8s.io/api/rbac/v1"
 	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	"k8s.io/client-go/kubernetes/scheme"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -64,11 +65,13 @@ const (
 	interval = 250 * time.Millisecond
 )
 
-func TestAPIs(t *testing.T) {
+func TestDataScienceClusterInitialization(t *testing.T) {
 	RegisterFailHandler(Fail)
 
-	RunSpecs(t, "Controller Suite")
+	RunSpecs(t, "Data Science Cluster Initialization Controller Suite")
 }
+
+var testScheme = runtime.NewScheme()
 
 var _ = BeforeSuite(func() {
 	ctx, cancel = context.WithCancel(context.TODO())
@@ -76,12 +79,17 @@ var _ = BeforeSuite(func() {
 	By("bootstrapping test environment")
 	rootPath, pathErr := util.FindProjectRoot()
 	Expect(pathErr).ToNot(HaveOccurred(), pathErr)
+
 	testEnv = &envtest.Environment{
-		CRDDirectoryPaths: []string{
-			filepath.Join(rootPath, "config", "crd", "bases"),
-			filepath.Join(rootPath, "config", "crd", "external"),
+		CRDInstallOptions: envtest.CRDInstallOptions{
+			Scheme: testScheme,
+			Paths: []string{
+				filepath.Join(rootPath, "config", "crd", "bases"),
+				filepath.Join(rootPath, "config", "crd", "external"),
+			},
+			ErrorIfPathMissing: true,
+			CleanUpAfterUse:    false,
 		},
-		ErrorIfCRDPathMissing: true,
 	}
 
 	var err error
@@ -89,23 +97,24 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 	Expect(cfg).NotTo(BeNil())
 
-	utilruntime.Must(clientgoscheme.AddToScheme(scheme.Scheme))
-	utilruntime.Must(dscinitializationv1.AddToScheme(scheme.Scheme))
-	utilruntime.Must(netv1.AddToScheme(scheme.Scheme))
-	utilruntime.Must(authv1.AddToScheme(scheme.Scheme))
-	utilruntime.Must(corev1.AddToScheme(scheme.Scheme))
-	utilruntime.Must(apiextv1.AddToScheme(scheme.Scheme))
-	utilruntime.Must(routev1.AddToScheme(scheme.Scheme))
-	utilruntime.Must(appsv1.AddToScheme(scheme.Scheme))
-	utilruntime.Must(ofapi.AddToScheme(scheme.Scheme))
+	utilruntime.Must(clientgoscheme.AddToScheme(testScheme))
+	utilruntime.Must(dscinitializationv1.AddToScheme(testScheme))
+	utilruntime.Must(netv1.AddToScheme(testScheme))
+	utilruntime.Must(authv1.AddToScheme(testScheme))
+	utilruntime.Must(corev1.AddToScheme(testScheme))
+	utilruntime.Must(apiextv1.AddToScheme(testScheme))
+	utilruntime.Must(appsv1.AddToScheme(testScheme))
+	utilruntime.Must(ofapi.AddToScheme(testScheme))
+	utilruntime.Must(routev1.Install(testScheme))
+	utilruntime.Must(userv1.Install(testScheme))
 	//+kubebuilder:scaffold:scheme
 
-	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
+	k8sClient, err = client.New(cfg, client.Options{Scheme: testScheme})
 	Expect(err).NotTo(HaveOccurred())
 	Expect(k8sClient).NotTo(BeNil())
 
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
-		Scheme:             scheme.Scheme,
+		Scheme:             testScheme,
 		LeaderElection:     false,
 		MetricsBindAddress: "0",
 	})
@@ -114,7 +123,7 @@ var _ = BeforeSuite(func() {
 
 	err = (&dsci.DSCInitializationReconciler{
 		Client:   k8sClient,
-		Scheme:   scheme.Scheme,
+		Scheme:   testScheme,
 		Log:      ctrl.Log.WithName("controllers").WithName("DSCInitialization"),
 		Recorder: mgr.GetEventRecorderFor("dscinitialization-controller"),
 	}).SetupWithManager(mgr)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

After latest merges EvnTest tests stopped working. This PR addresses the problems by:

- adds download of needed CRDs to `config/crd/external` when running `make manifests` target
- adds missing scheme installation in the test setup
- passes ns when creating UserGroup resource
- marks one test as Pending due to NetworkPolicies being disabled right now

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
`make test`

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
