### PR TITLE
chore: removes GetComponentDevFlags as it is exported field of the struct

### DIFF
--- a/components/codeflare/codeflare.go
+++ b/components/codeflare/codeflare.go
@@ -44,10 +44,6 @@ func (c *CodeFlare) OverrideManifests(_ string) error {
 	return nil
 }
 
-func (c *CodeFlare) GetComponentDevFlags() components.DevFlags {
-	return c.DevFlags
-}
-
 func (c *CodeFlare) SetImageParamsMap(imageMap map[string]string) map[string]string {
 	imageParamMap = imageMap
 	return imageParamMap

--- a/components/component.go
+++ b/components/component.go
@@ -62,7 +62,6 @@ type ComponentInterface interface {
 	ReconcileComponent(cli client.Client, owner metav1.Object, DSCISpec *dsci.DSCInitializationSpec) error
 	GetComponentName() string
 	GetManagementState() operatorv1.ManagementState
-	GetComponentDevFlags() DevFlags
 	SetImageParamsMap(imageMap map[string]string) map[string]string
 	OverrideManifests(platform string) error
 }

--- a/components/dashboard/dashboard.go
+++ b/components/dashboard/dashboard.go
@@ -69,10 +69,6 @@ func (d *Dashboard) OverrideManifests(platform string) error {
 	return nil
 }
 
-func (d *Dashboard) GetComponentDevFlags() components.DevFlags {
-	return d.DevFlags
-}
-
 func (d *Dashboard) SetImageParamsMap(imageMap map[string]string) map[string]string {
 	imageParamMap = imageMap
 	return imageParamMap

--- a/components/datasciencepipelines/datasciencepipelines.go
+++ b/components/datasciencepipelines/datasciencepipelines.go
@@ -47,10 +47,6 @@ func (d *DataSciencePipelines) OverrideManifests(_ string) error {
 	return nil
 }
 
-func (d *DataSciencePipelines) GetComponentDevFlags() components.DevFlags {
-	return d.DevFlags
-}
-
 func (d *DataSciencePipelines) SetImageParamsMap(imageMap map[string]string) map[string]string {
 	imageParamMap = imageMap
 	return imageParamMap

--- a/components/kserve/kserve.go
+++ b/components/kserve/kserve.go
@@ -71,10 +71,6 @@ func (k *Kserve) OverrideManifests(_ string) error {
 	return nil
 }
 
-func (k *Kserve) GetComponentDevFlags() components.DevFlags {
-	return k.DevFlags
-}
-
 func (k *Kserve) SetImageParamsMap(imageMap map[string]string) map[string]string {
 	imageParamMap = imageMap
 	return imageParamMap

--- a/components/modelmeshserving/modelmeshserving.go
+++ b/components/modelmeshserving/modelmeshserving.go
@@ -48,10 +48,6 @@ func (m *ModelMeshServing) OverrideManifests(_ string) error {
 	return nil
 }
 
-func (m *ModelMeshServing) GetComponentDevFlags() components.DevFlags {
-	return m.DevFlags
-}
-
 func (m *ModelMeshServing) GetComponentName() string {
 	return ComponentName
 }

--- a/components/ray/ray.go
+++ b/components/ray/ray.go
@@ -42,10 +42,6 @@ func (r *Ray) OverrideManifests(_ string) error {
 	return nil
 }
 
-func (r *Ray) GetComponentDevFlags() components.DevFlags {
-	return r.DevFlags
-}
-
 func (r *Ray) SetImageParamsMap(imageMap map[string]string) map[string]string {
 	imageParamMap = imageMap
 	return imageParamMap

--- a/components/workbenches/workbenches.go
+++ b/components/workbenches/workbenches.go
@@ -87,10 +87,6 @@ func (w *Workbenches) OverrideManifests(platform string) error {
 	return nil
 }
 
-func (w *Workbenches) GetComponentDevFlags() components.DevFlags {
-	return w.DevFlags
-}
-
 func (w *Workbenches) GetComponentName() string {
 	return ComponentName
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

It is already accessed through `d.DevFlags`, no need for an extra contract for each component.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
