### PR TITLE
feat: uses reflect to reconcile defined components

### DIFF
--- a/config/crd/bases/datasciencecluster.opendatahub.io_datascienceclusters.yaml
+++ b/config/crd/bases/datasciencecluster.opendatahub.io_datascienceclusters.yaml
@@ -19,7 +19,7 @@ spec:
     schema:
       openAPIV3Schema:
         description: DataScienceCluster is the Schema for the datascienceclusters
-          API
+          API.
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -351,7 +351,7 @@ spec:
                 type: object
             type: object
           status:
-            description: DataScienceClusterStatus defines the observed state of DataScienceCluster
+            description: DataScienceClusterStatus defines the observed state of DataScienceCluster.
             properties:
               conditions:
                 description: Conditions describes the state of the DataScienceCluster

--- a/config/crd/bases/dscinitialization.opendatahub.io_dscinitializations.yaml
+++ b/config/crd/bases/dscinitialization.opendatahub.io_dscinitializations.yaml
@@ -29,7 +29,7 @@ spec:
     name: v1
     schema:
       openAPIV3Schema:
-        description: DSCInitialization is the Schema for the dscinitializations API
+        description: DSCInitialization is the Schema for the dscinitializations API.
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -44,7 +44,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: DSCInitializationSpec defines the desired state of DSCInitialization
+            description: DSCInitializationSpec defines the desired state of DSCInitialization.
             properties:
               applicationsNamespace:
                 default: opendatahub
@@ -83,7 +83,7 @@ spec:
             - applicationsNamespace
             type: object
           status:
-            description: DSCInitializationStatus defines the observed state of DSCInitialization
+            description: DSCInitializationStatus defines the observed state of DSCInitialization.
             properties:
               conditions:
                 description: Conditions describes the state of the DSCInitializationStatus

--- a/controllers/datasciencecluster/datasciencecluster_controller.go
+++ b/controllers/datasciencecluster/datasciencecluster_controller.go
@@ -38,7 +38,6 @@ import (
 	dsci "github.com/opendatahub-io/opendatahub-operator/v2/apis/dscinitialization/v1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/components"
 	"github.com/opendatahub-io/opendatahub-operator/v2/controllers/status"
-	v1 "github.com/openshift/api/operator/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	netv1 "k8s.io/api/networking/v1"
@@ -154,20 +153,15 @@ func (r *DataScienceClusterReconciler) Reconcile(ctx context.Context, req ctrl.R
 	// Initialize error list, instead of returning errors after every component is deployed
 	var componentErrors *multierror.Error
 
-	componentsPtr := &instance.Spec.Components
-	definedComponents := reflect.ValueOf(componentsPtr).Elem()
-	for i := 0; i < definedComponents.NumField(); i++ {
-		c := definedComponents.Field(i)
-		if c.CanAddr() {
-			component, ok := c.Addr().Interface().(components.ComponentInterface)
-			if !ok {
-				return ctrl.Result{}, errors.New("this is not a pointer to ComponentInterface!")
-			}
+	allComponents, err := getAllComponents(&instance.Spec.Components)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
 
-			if instance, err = r.reconcileSubComponent(ctx, instance, component); err != nil {
-				// no need to log any errors as this is done in the reconcileSubComponent method
-				componentErrors = multierror.Append(componentErrors, err)
-			}
+	for _, component := range allComponents {
+		if instance, err = r.reconcileSubComponent(ctx, instance, component); err != nil {
+			// no need to log any errors as this is done in the reconcileSubComponent method
+			componentErrors = multierror.Append(componentErrors, err)
 		}
 	}
 
@@ -203,6 +197,25 @@ func (r *DataScienceClusterReconciler) Reconcile(ctx context.Context, req ctrl.R
 		"DataScienceCluster instance %s created and deployed successfully", instance.Name)
 
 	return ctrl.Result{}, nil
+}
+
+func getAllComponents(c *dsc.Components) ([]components.ComponentInterface, error) {
+	var allComponents []components.ComponentInterface
+
+	definedComponents := reflect.ValueOf(c).Elem()
+	for i := 0; i < definedComponents.NumField(); i++ {
+		c := definedComponents.Field(i)
+		if c.CanAddr() {
+			component, ok := c.Addr().Interface().(components.ComponentInterface)
+			if !ok {
+				return allComponents, errors.New("this is not a pointer to ComponentInterface")
+			}
+
+			allComponents = append(allComponents, component)
+		}
+	}
+
+	return allComponents, nil
 }
 
 func (r *DataScienceClusterReconciler) reconcileSubComponent(ctx context.Context, instance *dsc.DataScienceCluster,

--- a/controllers/datasciencecluster/datasciencecluster_controller.go
+++ b/controllers/datasciencecluster/datasciencecluster_controller.go
@@ -21,13 +21,16 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"reflect"
 	"time"
+
+	"github.com/go-logr/logr"
+	v1 "github.com/openshift/api/operator/v1"
 
 	"github.com/hashicorp/go-multierror"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
-	"github.com/go-logr/logr"
 	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -151,46 +154,21 @@ func (r *DataScienceClusterReconciler) Reconcile(ctx context.Context, req ctrl.R
 	// Initialize error list, instead of returning errors after every component is deployed
 	var componentErrors *multierror.Error
 
-	// reconcile dashboard component
-	if instance, err = r.reconcileSubComponent(ctx, instance, &(instance.Spec.Components.Dashboard)); err != nil {
-		// no need to log any errors as this is done in the reconcileSubComponent method
-		componentErrors = multierror.Append(componentErrors, err)
-	}
+	componentsPtr := &instance.Spec.Components
+	definedComponents := reflect.ValueOf(componentsPtr).Elem()
+	for i := 0; i < definedComponents.NumField(); i++ {
+		c := definedComponents.Field(i)
+		if c.CanAddr() {
+			component, ok := c.Addr().Interface().(components.ComponentInterface)
+			if !ok {
+				return ctrl.Result{}, errors.New("this is not a pointer to ComponentInterface!")
+			}
 
-	// reconcile DataSciencePipelines component
-	if instance, err = r.reconcileSubComponent(ctx, instance, &(instance.Spec.Components.DataSciencePipelines)); err != nil {
-		// no need to log any errors as this is done in the reconcileSubComponent method
-		componentErrors = multierror.Append(componentErrors, err)
-	}
-
-	// reconcile Workbench component
-	if instance, err = r.reconcileSubComponent(ctx, instance, &(instance.Spec.Components.Workbenches)); err != nil {
-		// no need to log any errors as this is done in the reconcileSubComponent method
-		componentErrors = multierror.Append(componentErrors, err)
-	}
-
-	// reconcile Kserve component
-	if instance, err = r.reconcileSubComponent(ctx, instance, &(instance.Spec.Components.Kserve)); err != nil {
-		// no need to log any errors as this is done in the reconcileSubComponent method
-		componentErrors = multierror.Append(componentErrors, err)
-	}
-
-	// reconcile ModelMesh component
-	if instance, err = r.reconcileSubComponent(ctx, instance, &(instance.Spec.Components.ModelMeshServing)); err != nil {
-		// no need to log any errors as this is done in the reconcileSubComponent method
-		componentErrors = multierror.Append(componentErrors, err)
-	}
-
-	// reconcile CodeFlare component
-	if instance, err = r.reconcileSubComponent(ctx, instance, &(instance.Spec.Components.CodeFlare)); err != nil {
-		// no need to log any errors as this is done in the reconcileSubComponent method
-		componentErrors = multierror.Append(componentErrors, err)
-	}
-
-	// reconcile Ray component
-	if instance, err = r.reconcileSubComponent(ctx, instance, &(instance.Spec.Components.Ray)); err != nil {
-		// no need to log any errors as this is done in the reconcileSubComponent method
-		componentErrors = multierror.Append(componentErrors, err)
+			if instance, err = r.reconcileSubComponent(ctx, instance, component); err != nil {
+				// no need to log any errors as this is done in the reconcileSubComponent method
+				componentErrors = multierror.Append(componentErrors, err)
+			}
+		}
 	}
 
 	// Process errors for components


### PR DESCRIPTION
## Description

In this PR, I would like to propose a streamlined approach to component reconciliation by leveraging Go's `reflect` package. This eliminates the necessity for manual reconciliation whenever a new component is introduced. As a result, we achieve consistent handling regardless of the number of components.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- smoke tested using [dashboard+workbenches DSC](https://gist.github.com/bartoszmajsak/89d71235e64c0c78bb65685ba95ae572). Custom controller image: `quay.io/maistra-dev/opendatahub-operator:dev-reflect`

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
