### PR TITLE
fix: populate entire dscispec

### DIFF
--- a/controllers/datasciencecluster/datasciencecluster_controller.go
+++ b/controllers/datasciencecluster/datasciencecluster_controller.go
@@ -134,9 +134,8 @@ func (r *DataScienceClusterReconciler) Reconcile(ctx context.Context, req ctrl.R
 			return ctrl.Result{}, nil
 		}
 	case 1:
-		// Set Applications namespace defined in DSCInitialization
-		r.DataScienceCluster.DSCISpec.ApplicationsNamespace = dsciInstances.Items[0].Spec.ApplicationsNamespace
-		r.DataScienceCluster.DSCISpec.DevFlags.ManifestsUri = dsciInstances.Items[0].Spec.DevFlags.ManifestsUri
+		dscInitializationSpec := dsciInstances.Items[0].Spec
+		dscInitializationSpec.DeepCopyInto(r.DataScienceCluster.DSCISpec)
 	default:
 		return ctrl.Result{}, errors.New("only one instance of DSCInitialization object is allowed")
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This ensures DSCISpec kept as field in reconciler struct has all the fields propagated so components can use it.


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
