### PR TITLE
feat(codeflare): support unmanaged

### DIFF
--- a/bundle/manifests/datasciencecluster.opendatahub.io_datascienceclusters.yaml
+++ b/bundle/manifests/datasciencecluster.opendatahub.io_datascienceclusters.yaml
@@ -77,10 +77,12 @@ spec:
                           to keep it active. It will only upgrade the component if
                           it is safe to do so \n - \"Removed\" : the operator is actively
                           managing the component and will not install it, or if it
-                          is installed, the operator will try to remove it"
+                          is installed, the operator will try to remove it \n - \"Unmanaged\"
+                          : the operator will not take any action related to the component"
                         enum:
                         - Managed
                         - Removed
+                        - Unmanaged
                         pattern: ^(Managed|Unmanaged|Force|Removed)$
                         type: string
                     type: object
@@ -120,10 +122,12 @@ spec:
                           to keep it active. It will only upgrade the component if
                           it is safe to do so \n - \"Removed\" : the operator is actively
                           managing the component and will not install it, or if it
-                          is installed, the operator will try to remove it"
+                          is installed, the operator will try to remove it \n - \"Unmanaged\"
+                          : the operator will not take any action related to the component"
                         enum:
                         - Managed
                         - Removed
+                        - Unmanaged
                         pattern: ^(Managed|Unmanaged|Force|Removed)$
                         type: string
                     type: object
@@ -164,10 +168,12 @@ spec:
                           to keep it active. It will only upgrade the component if
                           it is safe to do so \n - \"Removed\" : the operator is actively
                           managing the component and will not install it, or if it
-                          is installed, the operator will try to remove it"
+                          is installed, the operator will try to remove it \n - \"Unmanaged\"
+                          : the operator will not take any action related to the component"
                         enum:
                         - Managed
                         - Removed
+                        - Unmanaged
                         pattern: ^(Managed|Unmanaged|Force|Removed)$
                         type: string
                     type: object
@@ -210,10 +216,12 @@ spec:
                           to keep it active. It will only upgrade the component if
                           it is safe to do so \n - \"Removed\" : the operator is actively
                           managing the component and will not install it, or if it
-                          is installed, the operator will try to remove it"
+                          is installed, the operator will try to remove it \n - \"Unmanaged\"
+                          : the operator will not take any action related to the component"
                         enum:
                         - Managed
                         - Removed
+                        - Unmanaged
                         pattern: ^(Managed|Unmanaged|Force|Removed)$
                         type: string
                     type: object
@@ -255,10 +263,12 @@ spec:
                           to keep it active. It will only upgrade the component if
                           it is safe to do so \n - \"Removed\" : the operator is actively
                           managing the component and will not install it, or if it
-                          is installed, the operator will try to remove it"
+                          is installed, the operator will try to remove it \n - \"Unmanaged\"
+                          : the operator will not take any action related to the component"
                         enum:
                         - Managed
                         - Removed
+                        - Unmanaged
                         pattern: ^(Managed|Unmanaged|Force|Removed)$
                         type: string
                     type: object
@@ -299,10 +309,12 @@ spec:
                           to keep it active. It will only upgrade the component if
                           it is safe to do so \n - \"Removed\" : the operator is actively
                           managing the component and will not install it, or if it
-                          is installed, the operator will try to remove it"
+                          is installed, the operator will try to remove it \n - \"Unmanaged\"
+                          : the operator will not take any action related to the component"
                         enum:
                         - Managed
                         - Removed
+                        - Unmanaged
                         pattern: ^(Managed|Unmanaged|Force|Removed)$
                         type: string
                     type: object
@@ -342,10 +354,12 @@ spec:
                           to keep it active. It will only upgrade the component if
                           it is safe to do so \n - \"Removed\" : the operator is actively
                           managing the component and will not install it, or if it
-                          is installed, the operator will try to remove it"
+                          is installed, the operator will try to remove it \n - \"Unmanaged\"
+                          : the operator will not take any action related to the component"
                         enum:
                         - Managed
                         - Removed
+                        - Unmanaged
                         pattern: ^(Managed|Unmanaged|Force|Removed)$
                         type: string
                     type: object
@@ -385,10 +399,12 @@ spec:
                           to keep it active. It will only upgrade the component if
                           it is safe to do so \n - \"Removed\" : the operator is actively
                           managing the component and will not install it, or if it
-                          is installed, the operator will try to remove it"
+                          is installed, the operator will try to remove it \n - \"Unmanaged\"
+                          : the operator will not take any action related to the component"
                         enum:
                         - Managed
                         - Removed
+                        - Unmanaged
                         pattern: ^(Managed|Unmanaged|Force|Removed)$
                         type: string
                     type: object

--- a/bundle/manifests/opendatahub-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/opendatahub-operator.clusterserviceversion.yaml
@@ -91,7 +91,7 @@ metadata:
         "spec": {
           "components": {
             "codeflare": {
-              "managementState": "Removed"
+              "managementState": "Unmanaged"
             },
             "dashboard": {
               "managementState": "Managed"
@@ -106,7 +106,7 @@ metadata:
               "managementState": "Managed"
             },
             "ray": {
-              "managementState": "Removed"
+              "managementState": "Managed"
             },
             "workbenches": {
               "managementState": "Managed"

--- a/components/codeflare/codeflare.go
+++ b/components/codeflare/codeflare.go
@@ -4,7 +4,6 @@ package codeflare
 
 import (
 	"fmt"
-
 	"path/filepath"
 
 	dsci "github.com/opendatahub-io/opendatahub-operator/v2/apis/dscinitialization/v1"
@@ -17,7 +16,7 @@ import (
 
 var (
 	ComponentName       = "codeflare"
-	CodeflarePath       = deploy.DefaultManifestPath + "/" + ComponentName + "/base"
+	CodeflarePath       = deploy.DefaultManifestPath + "/" + ComponentName + "/manifests"
 	CodeflareOperator   = "codeflare-operator"
 	RHCodeflareOperator = "rhods-codeflare-operator"
 )
@@ -52,45 +51,42 @@ var _ components.ComponentInterface = (*CodeFlare)(nil)
 
 func (c *CodeFlare) ReconcileComponent(cli client.Client, owner metav1.Object, dscispec *dsci.DSCInitializationSpec) error {
 	var imageParamMap = map[string]string{
+		"odh-codeflare-operator-controller-image": "RELATED_IMAGE_ODH_CODEFLARE_OPERATOR_IMAGE", // no need mcad, embedded in cfo
 		"namespace": dscispec.ApplicationsNamespace,
 	}
-	enabled := c.GetManagementState() == operatorv1.Managed
 	platform, err := deploy.GetPlatform(cli)
 	if err != nil {
 		return err
 	}
 
-	if enabled {
-		// Download manifests and update paths
-		if err = c.OverrideManifests(string(platform)); err != nil {
+	dependentOperator := CodeflareOperator
+	// overwrite dependent operator if downstream not match upstream
+	if platform == deploy.SelfManagedRhods || platform == deploy.ManagedRhods {
+		dependentOperator = RHCodeflareOperator
+	}
+	// Download manifests and update paths
+	if err = c.OverrideManifests(string(platform)); err != nil {
+		return err
+	}
+	// Update image parameters only when we do not have customized manifests set
+	if dscispec.DevFlags.ManifestsUri == "" && len(c.DevFlags.Manifests) == 0 {
+		if err := deploy.ApplyParams(CodeflarePath+"/base", c.SetImageParamsMap(imageParamMap), true); err != nil {
 			return err
-		}
-		// check if the CodeFlare operator is installed
-		// codeflare operator not installed
-		dependentOperator := CodeflareOperator
-		// overwrite dependent operator if downstream not match upstream
-		if platform == deploy.SelfManagedRhods || platform == deploy.ManagedRhods {
-			dependentOperator = RHCodeflareOperator
-		}
-
-		if found, err := deploy.OperatorExists(cli, dependentOperator); err != nil {
-			return err
-		} else if !found {
-			return fmt.Errorf("operator %s not found. Please install the operator before enabling %s component",
-				dependentOperator, ComponentName)
-		}
-
-		// Update image parameters only when we do not have customized manifests set
-		if dscispec.DevFlags.ManifestsUri == "" && len(c.DevFlags.Manifests) == 0 {
-			if err := deploy.ApplyParams(CodeflarePath, c.SetImageParamsMap(imageParamMap), true); err != nil {
-				return err
-			}
 		}
 	}
-
-	// Deploy Codeflare
-	err = deploy.DeployManifestsFromPath(cli, owner, CodeflarePath, dscispec.ApplicationsNamespace, c.GetComponentName(), enabled)
-	return err
+	if c.GetManagementState() == operatorv1.Managed {
+		// check if the CodeFlare operator is installed
+		if found, err := deploy.OperatorExists(cli, dependentOperator); err != nil {
+			return err
+		} else if found {
+			return fmt.Errorf("operator %s already installed in cluster. Please uninstall the operator before enabling %s component",
+				dependentOperator, ComponentName)
+		}
+		// Deploy Codeflare
+		err = deploy.DeployManifestsFromPath(cli, owner, CodeflarePath, dscispec.ApplicationsNamespace, c.GetComponentName(), operatorv1.Managed)
+		return err
+	}
+	return nil
 }
 
 func (c *CodeFlare) DeepCopyInto(target *CodeFlare) {

--- a/components/component.go
+++ b/components/component.go
@@ -16,7 +16,9 @@ type Component struct {
 	// - "Removed" : the operator is actively managing the component and will not install it,
 	//               or if it is installed, the operator will try to remove it
 	//
-	// +kubebuilder:validation:Enum=Managed;Removed
+	// - "Unmanaged" : the operator will not take any action related to the component
+	//
+	// +kubebuilder:validation:Enum=Managed;Removed;Unmanaged
 	ManagementState operatorv1.ManagementState `json:"managementState,omitempty"`
 	// Add any other common fields across components below
 

--- a/components/dashboard/dashboard.go
+++ b/components/dashboard/dashboard.go
@@ -123,12 +123,12 @@ func (d *Dashboard) ReconcileComponent(cli client.Client, owner metav1.Object, d
 
 	// Deploy odh-dashboard manifests
 	if platform == deploy.OpenDataHub || platform == "" {
-		if err = deploy.DeployManifestsFromPath(cli, owner, Path, dscispec.ApplicationsNamespace, ComponentName, enabled); err != nil {
+		if err = deploy.DeployManifestsFromPath(cli, owner, Path, dscispec.ApplicationsNamespace, ComponentName, d.GetManagementState()); err != nil {
 			return err
 		}
 	} else if platform == deploy.SelfManagedRhods || platform == deploy.ManagedRhods {
 		// Apply authentication overlay
-		if err := deploy.DeployManifestsFromPath(cli, owner, PathSupported, dscispec.ApplicationsNamespace, ComponentNameSupported, enabled); err != nil {
+		if err := deploy.DeployManifestsFromPath(cli, owner, PathSupported, dscispec.ApplicationsNamespace, ComponentNameSupported, d.GetManagementState()); err != nil {
 			return err
 		}
 	}
@@ -163,8 +163,7 @@ func (d *Dashboard) deployCRDsForPlatform(cli client.Client, owner metav1.Object
 		componentName = ComponentNameSupported
 	}
 
-	enabled := d.ManagementState == operatorv1.Managed
-	return deploy.DeployManifestsFromPath(cli, owner, PathCRDs, namespace, componentName, enabled)
+	return deploy.DeployManifestsFromPath(cli, owner, PathCRDs, namespace, componentName, d.GetManagementState())
 }
 
 func (d *Dashboard) applyRhodsSpecificConfigs(cli client.Client, owner metav1.Object, namespace string, platform deploy.Platform) error {
@@ -178,12 +177,11 @@ func (d *Dashboard) applyRhodsSpecificConfigs(cli client.Client, owner metav1.Ob
 		return err
 	}
 
-	enabled := d.ManagementState == operatorv1.Managed
-	if err := deploy.DeployManifestsFromPath(cli, owner, PathODHDashboardConfig, namespace, ComponentNameSupported, enabled); err != nil {
+	if err := deploy.DeployManifestsFromPath(cli, owner, PathODHDashboardConfig, namespace, ComponentNameSupported, d.ManagementState); err != nil {
 		return fmt.Errorf("failed to set dashboard config from %s: %w", PathODHDashboardConfig, err)
 	}
 
-	if err := deploy.DeployManifestsFromPath(cli, owner, PathOVMS, namespace, ComponentNameSupported, enabled); err != nil {
+	if err := deploy.DeployManifestsFromPath(cli, owner, PathOVMS, namespace, ComponentNameSupported, d.ManagementState); err != nil {
 		return fmt.Errorf("failed to set dashboard OVMS from %s: %w", PathOVMS, err)
 	}
 
@@ -191,7 +189,7 @@ func (d *Dashboard) applyRhodsSpecificConfigs(cli client.Client, owner metav1.Ob
 		return fmt.Errorf("failed to create access-secret for anaconda: %w", err)
 	}
 
-	return deploy.DeployManifestsFromPath(cli, owner, PathAnaconda, namespace, ComponentNameSupported, enabled)
+	return deploy.DeployManifestsFromPath(cli, owner, PathAnaconda, namespace, ComponentNameSupported, d.ManagementState)
 }
 
 func (d *Dashboard) deployISVManifests(cli client.Client, owner metav1.Object, componentName, namespace string, platform deploy.Platform) error {
@@ -205,8 +203,7 @@ func (d *Dashboard) deployISVManifests(cli client.Client, owner metav1.Object, c
 		return nil
 	}
 
-	enabled := d.ManagementState == operatorv1.Managed
-	if err := deploy.DeployManifestsFromPath(cli, owner, path, namespace, componentName, enabled); err != nil {
+	if err := deploy.DeployManifestsFromPath(cli, owner, path, namespace, componentName, d.ManagementState); err != nil {
 		return fmt.Errorf("failed to set dashboard ISV from %s: %w", path, err)
 	}
 
@@ -230,9 +227,7 @@ func (d *Dashboard) deployConsoleLink(cli client.Client, owner metav1.Object, na
 	if err != nil {
 		return fmt.Errorf("error replacing with correct dashboard url for ConsoleLink: %w", err)
 	}
-
-	enabled := d.ManagementState == operatorv1.Managed
-	err = deploy.DeployManifestsFromPath(cli, owner, pathConsoleLink, namespace, componentName, enabled)
+	err = deploy.DeployManifestsFromPath(cli, owner, pathConsoleLink, namespace, componentName, d.ManagementState)
 	if err != nil {
 		return fmt.Errorf("failed to set dashboard consolelink from %s: %w", PathConsoleLink, err)
 	}

--- a/components/datasciencepipelines/datasciencepipelines.go
+++ b/components/datasciencepipelines/datasciencepipelines.go
@@ -77,7 +77,7 @@ func (d *DataSciencePipelines) ReconcileComponent(cli client.Client, owner metav
 		}
 	}
 
-	err = deploy.DeployManifestsFromPath(cli, owner, Path, dscispec.ApplicationsNamespace, d.GetComponentName(), enabled)
+	err = deploy.DeployManifestsFromPath(cli, owner, Path, dscispec.ApplicationsNamespace, d.GetComponentName(), d.GetManagementState())
 	return err
 }
 

--- a/components/kserve/kserve.go
+++ b/components/kserve/kserve.go
@@ -116,7 +116,7 @@ func (k *Kserve) ReconcileComponent(cli client.Client, owner metav1.Object, dsci
 		}
 	}
 
-	if err := deploy.DeployManifestsFromPath(cli, owner, Path, dscispec.ApplicationsNamespace, ComponentName, enabled); err != nil {
+	if err := deploy.DeployManifestsFromPath(cli, owner, Path, dscispec.ApplicationsNamespace, ComponentName, k.GetManagementState()); err != nil {
 		return err
 	}
 
@@ -133,7 +133,7 @@ func (k *Kserve) ReconcileComponent(cli client.Client, owner metav1.Object, dsci
 			}
 		}
 	}
-	if err := deploy.DeployManifestsFromPath(cli, owner, DependentPath, dscispec.ApplicationsNamespace, k.GetComponentName(), enabled); err != nil {
+	if err := deploy.DeployManifestsFromPath(cli, owner, DependentPath, dscispec.ApplicationsNamespace, k.GetComponentName(), k.GetManagementState()); err != nil {
 		return err
 	}
 

--- a/components/modelmeshserving/modelmeshserving.go
+++ b/components/modelmeshserving/modelmeshserving.go
@@ -83,7 +83,7 @@ func (m *ModelMeshServing) ReconcileComponent(cli client.Client, owner metav1.Ob
 		}
 	}
 
-	err = deploy.DeployManifestsFromPath(cli, owner, Path, dscispec.ApplicationsNamespace, ComponentName, enabled)
+	err = deploy.DeployManifestsFromPath(cli, owner, Path, dscispec.ApplicationsNamespace, ComponentName, m.GetManagementState())
 	if err != nil {
 		return err
 	}
@@ -104,7 +104,7 @@ func (m *ModelMeshServing) ReconcileComponent(cli client.Client, owner metav1.Ob
 	}
 
 	// If modelmesh is deployed successfully, deploy modelmesh-monitoring
-	err = deploy.DeployManifestsFromPath(cli, owner, monitoringPath, monitoringNamespace, ComponentName, enabled)
+	err = deploy.DeployManifestsFromPath(cli, owner, monitoringPath, monitoringNamespace, ComponentName, m.GetManagementState())
 
 	return err
 }

--- a/components/ray/ray.go
+++ b/components/ray/ray.go
@@ -72,7 +72,7 @@ func (r *Ray) ReconcileComponent(cli client.Client, owner metav1.Object, dscispe
 		}
 	}
 	// Deploy Ray Operator
-	err = deploy.DeployManifestsFromPath(cli, owner, RayPath, dscispec.ApplicationsNamespace, r.GetComponentName(), enabled)
+	err = deploy.DeployManifestsFromPath(cli, owner, RayPath, dscispec.ApplicationsNamespace, r.GetComponentName(), r.GetManagementState())
 	return err
 }
 

--- a/components/trustyai/trustyai.go
+++ b/components/trustyai/trustyai.go
@@ -70,7 +70,7 @@ func (t *TrustyAI) ReconcileComponent(cli client.Client, owner metav1.Object, ds
 		}
 	}
 	// Deploy TrustyAI Operator
-	err = deploy.DeployManifestsFromPath(cli, owner, Path, dscispec.ApplicationsNamespace, t.GetComponentName(), enabled)
+	err = deploy.DeployManifestsFromPath(cli, owner, Path, dscispec.ApplicationsNamespace, t.GetComponentName(), t.GetManagementState())
 	return err
 }
 

--- a/components/workbenches/workbenches.go
+++ b/components/workbenches/workbenches.go
@@ -124,7 +124,7 @@ func (w *Workbenches) ReconcileComponent(cli client.Client, owner metav1.Object,
 		}
 	}
 
-	err = deploy.DeployManifestsFromPath(cli, owner, notebookControllerPath, dscispec.ApplicationsNamespace, ComponentName, enabled)
+	err = deploy.DeployManifestsFromPath(cli, owner, notebookControllerPath, dscispec.ApplicationsNamespace, ComponentName, w.GetManagementState())
 	if err != nil {
 		return err
 	}
@@ -145,7 +145,7 @@ func (w *Workbenches) ReconcileComponent(cli client.Client, owner metav1.Object,
 		err = deploy.DeployManifestsFromPath(cli, owner,
 			kfnotebookControllerPath,
 			dscispec.ApplicationsNamespace,
-			ComponentName, enabled)
+			ComponentName, w.GetManagementState())
 		if err != nil {
 			return err
 		}
@@ -154,10 +154,10 @@ func (w *Workbenches) ReconcileComponent(cli client.Client, owner metav1.Object,
 			notebookImagesPath,
 			dscispec.ApplicationsNamespace,
 			ComponentName,
-			enabled)
+			w.GetManagementState())
 		return err
 	} else {
-		err = deploy.DeployManifestsFromPath(cli, owner, notebookImagesPathSupported, dscispec.ApplicationsNamespace, ComponentName, enabled)
+		err = deploy.DeployManifestsFromPath(cli, owner, notebookImagesPathSupported, dscispec.ApplicationsNamespace, ComponentName, w.GetManagementState())
 		return err
 	}
 }

--- a/config/crd/bases/datasciencecluster.opendatahub.io_datascienceclusters.yaml
+++ b/config/crd/bases/datasciencecluster.opendatahub.io_datascienceclusters.yaml
@@ -78,10 +78,12 @@ spec:
                           to keep it active. It will only upgrade the component if
                           it is safe to do so \n - \"Removed\" : the operator is actively
                           managing the component and will not install it, or if it
-                          is installed, the operator will try to remove it"
+                          is installed, the operator will try to remove it \n - \"Unmanaged\"
+                          : the operator will not take any action related to the component"
                         enum:
                         - Managed
                         - Removed
+                        - Unmanaged
                         pattern: ^(Managed|Unmanaged|Force|Removed)$
                         type: string
                     type: object
@@ -121,10 +123,12 @@ spec:
                           to keep it active. It will only upgrade the component if
                           it is safe to do so \n - \"Removed\" : the operator is actively
                           managing the component and will not install it, or if it
-                          is installed, the operator will try to remove it"
+                          is installed, the operator will try to remove it \n - \"Unmanaged\"
+                          : the operator will not take any action related to the component"
                         enum:
                         - Managed
                         - Removed
+                        - Unmanaged
                         pattern: ^(Managed|Unmanaged|Force|Removed)$
                         type: string
                     type: object
@@ -165,10 +169,12 @@ spec:
                           to keep it active. It will only upgrade the component if
                           it is safe to do so \n - \"Removed\" : the operator is actively
                           managing the component and will not install it, or if it
-                          is installed, the operator will try to remove it"
+                          is installed, the operator will try to remove it \n - \"Unmanaged\"
+                          : the operator will not take any action related to the component"
                         enum:
                         - Managed
                         - Removed
+                        - Unmanaged
                         pattern: ^(Managed|Unmanaged|Force|Removed)$
                         type: string
                     type: object
@@ -211,10 +217,12 @@ spec:
                           to keep it active. It will only upgrade the component if
                           it is safe to do so \n - \"Removed\" : the operator is actively
                           managing the component and will not install it, or if it
-                          is installed, the operator will try to remove it"
+                          is installed, the operator will try to remove it \n - \"Unmanaged\"
+                          : the operator will not take any action related to the component"
                         enum:
                         - Managed
                         - Removed
+                        - Unmanaged
                         pattern: ^(Managed|Unmanaged|Force|Removed)$
                         type: string
                     type: object
@@ -256,10 +264,12 @@ spec:
                           to keep it active. It will only upgrade the component if
                           it is safe to do so \n - \"Removed\" : the operator is actively
                           managing the component and will not install it, or if it
-                          is installed, the operator will try to remove it"
+                          is installed, the operator will try to remove it \n - \"Unmanaged\"
+                          : the operator will not take any action related to the component"
                         enum:
                         - Managed
                         - Removed
+                        - Unmanaged
                         pattern: ^(Managed|Unmanaged|Force|Removed)$
                         type: string
                     type: object
@@ -300,10 +310,12 @@ spec:
                           to keep it active. It will only upgrade the component if
                           it is safe to do so \n - \"Removed\" : the operator is actively
                           managing the component and will not install it, or if it
-                          is installed, the operator will try to remove it"
+                          is installed, the operator will try to remove it \n - \"Unmanaged\"
+                          : the operator will not take any action related to the component"
                         enum:
                         - Managed
                         - Removed
+                        - Unmanaged
                         pattern: ^(Managed|Unmanaged|Force|Removed)$
                         type: string
                     type: object
@@ -343,10 +355,12 @@ spec:
                           to keep it active. It will only upgrade the component if
                           it is safe to do so \n - \"Removed\" : the operator is actively
                           managing the component and will not install it, or if it
-                          is installed, the operator will try to remove it"
+                          is installed, the operator will try to remove it \n - \"Unmanaged\"
+                          : the operator will not take any action related to the component"
                         enum:
                         - Managed
                         - Removed
+                        - Unmanaged
                         pattern: ^(Managed|Unmanaged|Force|Removed)$
                         type: string
                     type: object
@@ -386,10 +400,12 @@ spec:
                           to keep it active. It will only upgrade the component if
                           it is safe to do so \n - \"Removed\" : the operator is actively
                           managing the component and will not install it, or if it
-                          is installed, the operator will try to remove it"
+                          is installed, the operator will try to remove it \n - \"Unmanaged\"
+                          : the operator will not take any action related to the component"
                         enum:
                         - Managed
                         - Removed
+                        - Unmanaged
                         pattern: ^(Managed|Unmanaged|Force|Removed)$
                         type: string
                     type: object

--- a/config/manifests/bases/opendatahub-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/opendatahub-operator.clusterserviceversion.yaml
@@ -26,7 +26,7 @@ metadata:
         "spec": {
           "components": {
             "codeflare": {
-              "managementState": "Removed"
+              "managementState": "Unmanaged"
             },
             "dashboard": {
               "managementState": "Managed"
@@ -41,7 +41,7 @@ metadata:
               "managementState": "Managed"
             },
             "ray": {
-              "managementState": "Removed"
+              "managementState": "Managed"
             },
             "workbenches": {
               "managementState": "Managed"

--- a/controllers/dscinitialization/dscinitialization_controller.go
+++ b/controllers/dscinitialization/dscinitialization_controller.go
@@ -23,13 +23,12 @@ import (
 	"fmt"
 	"path/filepath"
 
-	operatorv1 "github.com/openshift/api/operator/v1"
-
 	"github.com/go-logr/logr"
 	dsci "github.com/opendatahub-io/opendatahub-operator/v2/apis/dscinitialization/v1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/controllers/status"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/deploy"
 
+	v1 "github.com/openshift/api/operator/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	netv1 "k8s.io/api/networking/v1"
@@ -134,7 +133,7 @@ func (r *DSCInitializationReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		// Apply osd specific permissions
 		if platform == deploy.ManagedRhods {
 			osdConfigsPath := filepath.Join(deploy.DefaultManifestPath, "osd-configs")
-			err = deploy.DeployManifestsFromPath(r.Client, instance, osdConfigsPath, r.ApplicationsNamespace, "osd", true)
+			err = deploy.DeployManifestsFromPath(r.Client, instance, osdConfigsPath, r.ApplicationsNamespace, "osd", v1.Managed)
 			if err != nil {
 				r.Log.Error(err, "Failed to apply osd specific configs from manifests", "Manifests path", osdConfigsPath)
 				r.Recorder.Eventf(instance, corev1.EventTypeWarning, "DSCInitializationReconcileError", "Failed to apply "+osdConfigsPath)
@@ -158,7 +157,7 @@ func (r *DSCInitializationReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	}
 
 	// If monitoring enabled
-	if instance.Spec.Monitoring.ManagementState == operatorv1.Managed {
+	if instance.Spec.Monitoring.ManagementState == v1.Managed {
 		switch platform {
 		case deploy.SelfManagedRhods:
 			r.Log.Info("Monitoring enabled, won't apply changes", "cluster", "Self-Managed RHODS Mode")

--- a/controllers/dscinitialization/monitoring.go
+++ b/controllers/dscinitialization/monitoring.go
@@ -11,7 +11,7 @@ import (
 	dsci "github.com/opendatahub-io/opendatahub-operator/v2/apis/dscinitialization/v1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/common"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/deploy"
-	operatorv1 "github.com/openshift/api/operator/v1"
+	// operatorv1 "github.com/openshift/api/operator/v1"
 	routev1 "github.com/openshift/api/route/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
@@ -61,7 +61,7 @@ func configurePrometheus(ctx context.Context, dsciInit *dsci.DSCInitialization, 
 		basePath,
 		dsciInit.Spec.Monitoring.Namespace,
 		"prometheus",
-		dsciInit.Spec.Monitoring.ManagementState == operatorv1.Managed)
+		dsciInit.Spec.Monitoring.ManagementState)
 	if err != nil {
 		r.Log.Error(err, "error to deploy manifests", "path", basePath)
 		return err
@@ -116,7 +116,7 @@ func configurePrometheus(ctx context.Context, dsciInit *dsci.DSCInitialization, 
 		prometheusManifestsPath,
 		dsciInit.Spec.Monitoring.Namespace,
 		"prometheus",
-		dsciInit.Spec.Monitoring.ManagementState == operatorv1.Managed)
+		dsciInit.Spec.Monitoring.ManagementState)
 	if err != nil {
 		r.Log.Error(err, "error to deploy manifests", "path", prometheusManifestsPath)
 		return err
@@ -187,7 +187,7 @@ func configureAlertManager(ctx context.Context, dsciInit *dsci.DSCInitialization
 		alertManagerPath,
 		dsciInit.Spec.Monitoring.Namespace,
 		"alertmanager",
-		dsciInit.Spec.Monitoring.ManagementState == operatorv1.Managed)
+		dsciInit.Spec.Monitoring.ManagementState)
 	if err != nil {
 		r.Log.Error(err, "error to deploy manifests", "path", alertManagerPath)
 		return err
@@ -220,7 +220,7 @@ func configureBlackboxExporter(cli client.Client, dsciInit *dsci.DSCInitializati
 			filepath.Join(blackBoxPath, "internal"),
 			dsciInit.Spec.Monitoring.Namespace,
 			"blackbox-exporter",
-			dsciInit.Spec.Monitoring.ManagementState == operatorv1.Managed)
+			dsciInit.Spec.Monitoring.ManagementState)
 		if err != nil {
 			return fmt.Errorf("error to deploy manifests: %w", err)
 		}
@@ -230,7 +230,7 @@ func configureBlackboxExporter(cli client.Client, dsciInit *dsci.DSCInitializati
 			filepath.Join(blackBoxPath, "external"),
 			dsciInit.Spec.Monitoring.Namespace,
 			"blackbox-exporter",
-			dsciInit.Spec.Monitoring.ManagementState == operatorv1.Managed)
+			dsciInit.Spec.Monitoring.ManagementState)
 		if err != nil {
 			return fmt.Errorf("error to deploy manifests: %w", err)
 		}
@@ -320,7 +320,7 @@ func (r *DSCInitializationReconciler) configureCommonMonitoring(dsciInit *dsci.D
 		segmentPath,
 		dsciInit.Spec.Monitoring.Namespace,
 		"segment-io",
-		dsciInit.Spec.Monitoring.ManagementState == operatorv1.Managed)
+		dsciInit.Spec.Monitoring.ManagementState)
 	if err != nil {
 		r.Log.Error(err, "error to deploy manifests under /opt/manifests/monitoring/segment")
 		return err
@@ -333,7 +333,7 @@ func (r *DSCInitializationReconciler) configureCommonMonitoring(dsciInit *dsci.D
 		monitoringBasePath,
 		dsciInit.Spec.Monitoring.Namespace,
 		"monitoring-base",
-		dsciInit.Spec.Monitoring.ManagementState == operatorv1.Managed)
+		dsciInit.Spec.Monitoring.ManagementState)
 	if err != nil {
 		r.Log.Error(err, "error to deploy manifests under /opt/manifests/monitoring/base")
 		return err

--- a/get_all_manifests.sh
+++ b/get_all_manifests.sh
@@ -9,9 +9,9 @@ MANIFEST_RELEASE="master"
 MANIFESTS_TARBALL_URL="${GITHUB_URL}/${MANIFEST_ORG}/odh-manifests/tarball/${MANIFEST_RELEASE}"
 
 # component: dsp, kserve, dashbaord, cf/ray. in the format of "repo-org:repo-name:branch-name:source-folder:target-folder"
-# TODO: workbench, modelmesh, monitoring, etc
+# TODO: modelmesh, kserve, etc
 declare -A COMPONENT_MANIFESTS=(
-    ["codeflare"]="opendatahub-io:distributed-workloads:main:codeflare-stack:codeflare"
+    ["codeflare"]="opendatahub-io:codeflare-operator:main:config:codeflare"
     ["ray"]="opendatahub-io:kuberay:master:ray-operator/config:ray"
     ["data-science-pipelines-operator"]="opendatahub-io:data-science-pipelines-operator:main:config:data-science-pipelines-operator"
     ["odh-dashboard"]="opendatahub-io:odh-dashboard:incubation:manifests:dashboard"

--- a/tests/e2e/dsc_creation_test.go
+++ b/tests/e2e/dsc_creation_test.go
@@ -41,9 +41,9 @@ func creationTestSuite(t *testing.T) {
 			err = testCtx.testUpdateComponentReconcile()
 			require.NoError(t, err, "error testing updates for DSC managed resource")
 		})
-		t.Run("Validate Component Enabled field", func(t *testing.T) {
+		t.Run("Validate Component managementState field", func(t *testing.T) {
 			err = testCtx.testUpdateDSCComponentEnabled()
-			require.NoError(t, err, "error testing component enabled field")
+			require.NoError(t, err, "error testing component managementState field")
 		})
 	})
 }
@@ -87,7 +87,7 @@ func (tc *testContext) testDSCCreation() error {
 	return nil
 }
 
-func (tc *testContext) testAllApplicationCreation(t *testing.T) error {
+func (tc *testContext) testAllApplicationCreation(t *testing.T) error { //nolint
 	// Validate test instance is in Ready state
 
 	dscLookupKey := types.NamespacedName{Name: tc.testDsc.Name}
@@ -113,11 +113,11 @@ func (tc *testContext) testAllApplicationCreation(t *testing.T) error {
 		err = tc.testApplicationCreation(&(tc.testDsc.Spec.Components.Dashboard))
 		if tc.testDsc.Spec.Components.Dashboard.ManagementState == operatorv1.Managed {
 			if err != nil {
-				require.NoError(t, err, "error validating application %v when enabled", tc.testDsc.Spec.Components.Dashboard.GetComponentName())
+				require.NoError(t, err, "error validating application %v when Managed", tc.testDsc.Spec.Components.Dashboard.GetComponentName())
 			}
 		} else {
 			if err == nil {
-				require.NoError(t, err, "error validating application %v when disabled", tc.testDsc.Spec.Components.Dashboard.GetComponentName())
+				require.NoError(t, err, "error validating application %v when Removed", tc.testDsc.Spec.Components.Dashboard.GetComponentName())
 			}
 		}
 	})
@@ -128,11 +128,11 @@ func (tc *testContext) testAllApplicationCreation(t *testing.T) error {
 		err = tc.testApplicationCreation(&(tc.testDsc.Spec.Components.ModelMeshServing))
 		if tc.testDsc.Spec.Components.ModelMeshServing.ManagementState == operatorv1.Managed {
 			if err != nil {
-				require.NoError(t, err, "error validating application %v when enabled", tc.testDsc.Spec.Components.ModelMeshServing.GetComponentName())
+				require.NoError(t, err, "error validating application %v when Managed", tc.testDsc.Spec.Components.ModelMeshServing.GetComponentName())
 			}
 		} else {
 			if err == nil {
-				require.NoError(t, err, "error validating application %v when disabled", tc.testDsc.Spec.Components.ModelMeshServing.GetComponentName())
+				require.NoError(t, err, "error validating application %v when Removed", tc.testDsc.Spec.Components.ModelMeshServing.GetComponentName())
 			}
 		}
 	})
@@ -147,12 +147,12 @@ func (tc *testContext) testAllApplicationCreation(t *testing.T) error {
 				if strings.Contains(err.Error(), "Please install the operator before enabling component") {
 					t.Logf("expected error: %v", err.Error())
 				} else {
-					require.NoError(t, err, "error validating application %v when enabled", tc.testDsc.Spec.Components.Kserve.GetComponentName())
+					require.NoError(t, err, "error validating application %v when Managed", tc.testDsc.Spec.Components.Kserve.GetComponentName())
 				}
 			}
 		} else {
 			if err == nil {
-				require.NoError(t, err, "error validating application %v when disabled", tc.testDsc.Spec.Components.Kserve.GetComponentName())
+				require.NoError(t, err, "error validating application %v when Removed", tc.testDsc.Spec.Components.Kserve.GetComponentName())
 			}
 		}
 	})
@@ -163,11 +163,11 @@ func (tc *testContext) testAllApplicationCreation(t *testing.T) error {
 		err = tc.testApplicationCreation(&(tc.testDsc.Spec.Components.Workbenches))
 		if tc.testDsc.Spec.Components.Workbenches.ManagementState == operatorv1.Managed {
 			if err != nil {
-				require.NoError(t, err, "error validating application %v when enabled", tc.testDsc.Spec.Components.Workbenches.GetComponentName())
+				require.NoError(t, err, "error validating application %v when Managed", tc.testDsc.Spec.Components.Workbenches.GetComponentName())
 			}
 		} else {
 			if err == nil {
-				require.NoError(t, err, "error validating application %v when disabled", tc.testDsc.Spec.Components.Workbenches.GetComponentName())
+				require.NoError(t, err, "error validating application %v when Removed", tc.testDsc.Spec.Components.Workbenches.GetComponentName())
 			}
 		}
 	})
@@ -178,11 +178,11 @@ func (tc *testContext) testAllApplicationCreation(t *testing.T) error {
 		err = tc.testApplicationCreation(&(tc.testDsc.Spec.Components.DataSciencePipelines))
 		if tc.testDsc.Spec.Components.DataSciencePipelines.ManagementState == operatorv1.Managed {
 			if err != nil {
-				require.NoError(t, err, "error validating application %v when enabled", tc.testDsc.Spec.Components.DataSciencePipelines.GetComponentName())
+				require.NoError(t, err, "error validating application %v when Managed", tc.testDsc.Spec.Components.DataSciencePipelines.GetComponentName())
 			}
 		} else {
 			if err == nil {
-				require.NoError(t, err, "error validating application %v when disabled", tc.testDsc.Spec.Components.DataSciencePipelines.GetComponentName())
+				require.NoError(t, err, "error validating application %v when Removed", tc.testDsc.Spec.Components.DataSciencePipelines.GetComponentName())
 			}
 		}
 	})
@@ -191,18 +191,23 @@ func (tc *testContext) testAllApplicationCreation(t *testing.T) error {
 		// speed testing in parallel
 		t.Parallel()
 		err = tc.testApplicationCreation(&(tc.testDsc.Spec.Components.CodeFlare))
-		if tc.testDsc.Spec.Components.CodeFlare.ManagementState == operatorv1.Managed {
+		switch tc.testDsc.Spec.Components.CodeFlare.ManagementState {
+		case operatorv1.Managed:
 			if err != nil {
 				// dependent operator error, as expected
 				if strings.Contains(err.Error(), "Please install the operator before enabling component") {
 					t.Logf("expected error: %v", err.Error())
 				} else {
-					require.NoError(t, err, "error validating application %v when enabled", tc.testDsc.Spec.Components.CodeFlare.GetComponentName())
+					require.NoError(t, err, "error validating application %v when Managed", tc.testDsc.Spec.Components.CodeFlare.GetComponentName())
 				}
 			}
-		} else {
+		case operatorv1.Unmanaged:
+			if err != nil {
+				require.NoError(t, err, "error validating application %v when Unmanaged", tc.testDsc.Spec.Components.CodeFlare.GetComponentName())
+			}
+		case operatorv1.Removed:
 			if err == nil {
-				require.NoError(t, err, "error validating application %v when disabled", tc.testDsc.Spec.Components.CodeFlare.GetComponentName())
+				require.NoError(t, err, "error validating application %v when Removed", tc.testDsc.Spec.Components.CodeFlare.GetComponentName())
 			}
 		}
 	})
@@ -213,11 +218,11 @@ func (tc *testContext) testAllApplicationCreation(t *testing.T) error {
 		err = tc.testApplicationCreation(&(tc.testDsc.Spec.Components.Ray))
 		if tc.testDsc.Spec.Components.Ray.ManagementState == operatorv1.Managed {
 			if err != nil {
-				require.NoError(t, err, "error validating application %v when enabled", tc.testDsc.Spec.Components.Ray.GetComponentName())
+				require.NoError(t, err, "error validating application %v when Managed", tc.testDsc.Spec.Components.Ray.GetComponentName())
 			}
 		} else {
 			if err == nil {
-				require.NoError(t, err, "error validating application %v when disabled", tc.testDsc.Spec.Components.Ray.GetComponentName())
+				require.NoError(t, err, "error validating application %v when Removed", tc.testDsc.Spec.Components.Ray.GetComponentName())
 			}
 		}
 	})
@@ -228,11 +233,11 @@ func (tc *testContext) testAllApplicationCreation(t *testing.T) error {
 		err = tc.testApplicationCreation(&(tc.testDsc.Spec.Components.TrustyAI))
 		if tc.testDsc.Spec.Components.TrustyAI.ManagementState == operatorv1.Managed {
 			if err != nil {
-				require.NoError(t, err, "error validating application %v when enabled", tc.testDsc.Spec.Components.TrustyAI.GetComponentName())
+				require.NoError(t, err, "error validating application %v when Managed", tc.testDsc.Spec.Components.TrustyAI.GetComponentName())
 			}
 		} else {
 			if err == nil {
-				require.NoError(t, err, "error validating application %v when disabled", tc.testDsc.Spec.Components.TrustyAI.GetComponentName())
+				require.NoError(t, err, "error validating application %v when Removed", tc.testDsc.Spec.Components.TrustyAI.GetComponentName())
 			}
 		}
 	})
@@ -267,6 +272,12 @@ func (tc *testContext) testApplicationCreation(component components.ComponentInt
 			// check Reconcile failed with missing dependent operator error
 			for _, Condition := range tc.testDsc.Status.Conditions {
 				if strings.Contains(Condition.Message, "Please install the operator before enabling "+component.GetComponentName()) {
+					return true, err
+				}
+			}
+			// check component does not create deployment e.g CF
+			for _, Condition := range tc.testDsc.Status.Conditions {
+				if strings.Contains(Condition.Message, "Component "+component.GetComponentName()+" is unmanaged") {
 					return true, err
 				}
 			}
@@ -350,16 +361,16 @@ func (tc *testContext) testUpdateDSCComponentEnabled() error {
 			LabelSelector: "app.kubernetes.io/part-of=" + tc.testDsc.Spec.Components.Dashboard.GetComponentName(),
 		})
 		if err != nil {
-			return fmt.Errorf("error getting enabled component %v", tc.testDsc.Spec.Components.Dashboard.GetComponentName())
+			return fmt.Errorf("error getting Managed component %v", tc.testDsc.Spec.Components.Dashboard.GetComponentName())
 		}
 		if len(appDeployments.Items) > 0 {
 			dashboardDeploymentName = appDeployments.Items[0].Name
 			if appDeployments.Items[0].Status.ReadyReplicas == 0 {
-				return fmt.Errorf("error getting enabled component: %s its deployment 'ReadyReplicas'", dashboardDeploymentName)
+				return fmt.Errorf("error getting Managed component: %s its deployment 'ReadyReplicas'", dashboardDeploymentName)
 			}
 		}
 	} else {
-		return fmt.Errorf("dashboard spec should be in 'enabled: true' state in order to perform test")
+		return fmt.Errorf("dashboard spec should be in 'Managed' state in order to perform test")
 	}
 
 	// Disable component Dashboard
@@ -377,7 +388,7 @@ func (tc *testContext) testUpdateDSCComponentEnabled() error {
 		// Return err itself here (not wrapped inside another error)
 		// so that RetryOnConflict can identify it correctly.
 		if err != nil {
-			return fmt.Errorf("error updating component from 'enabled: true' to 'enabled: false': %w", err)
+			return fmt.Errorf("error updating component from 'Managed' to 'Removed: false': %w", err)
 		}
 		return nil
 	})

--- a/tests/e2e/helper_test.go
+++ b/tests/e2e/helper_test.go
@@ -82,9 +82,11 @@ func setupDSCInstance() *dsc.DataScienceCluster {
 						ManagementState: operatorv1.Managed,
 					},
 				},
+				// this should not return error from operator but it wont have anythng running
+				// because we do not pre-install CFO and we set it to be unmanaged
 				CodeFlare: codeflare.CodeFlare{
 					Component: components.Component{
-						ManagementState: operatorv1.Removed,
+						ManagementState: operatorv1.Unmanaged,
 					},
 				},
 				Ray: ray.Ray{


### PR DESCRIPTION
## Description
for the scope fo 1.35/2.4, since CFO will be on TP, we can keep the same logic of ODH operator 
and add more to handle "unmanaged" if it is needed in 2.5

- introduce new value of Unmanaged.
- old logic of handling "enable" is changed to match "managementState==Managed"
- set codeflare and ray by default as Unamaged when create default DSC instance

ref: https://github.com/opendatahub-io/opendatahub-operator/issues/600
depend on https://github.com/opendatahub-io/opendatahub-operator/pull/652

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## new test
wait for rebase after https://github.com/opendatahub-io/opendatahub-operator/pull/652 to update

## old test
when set "codeflare" to Unmanaged, when others are either Managed or Removed
it does not block codeflare(no reconcile on missing CFO):
![Screenshot from 2023-10-18 15-15-45](https://github.com/opendatahub-io/opendatahub-operator/assets/915053/b8098d72-f8d9-4133-b524-3a71b9571308)

![Screenshot from 2023-10-18 14-53-39](https://github.com/opendatahub-io/opendatahub-operator/assets/915053/9be11fdf-79d2-4505-bea0-0483a3bef884)
and it applied codeflare's manifests
![Screenshot from 2023-10-18 14-54-34](https://github.com/opendatahub-io/opendatahub-operator/assets/915053/bfd01fa7-a49d-4bfa-bb7c-195fbe1b5ef3)
and created imagestream 
![Screenshot from 2023-10-18 15-14-03](https://github.com/opendatahub-io/opendatahub-operator/assets/915053/af79d368-4c46-4218-a194-73f2ad5da719)


## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
