### PR TITLE
feat(ray): pass down applicationNamespace to ray and codeflare in manifests

### DIFF
--- a/components/component.go
+++ b/components/component.go
@@ -65,3 +65,7 @@ type ComponentInterface interface {
 	SetImageParamsMap(imageMap map[string]string) map[string]string
 	OverrideManifests(platform string) error
 }
+
+func (c *Component) SetImageParamsMap(imageMap map[string]string) map[string]string {
+	return imageMap
+}

--- a/components/dashboard/dashboard.go
+++ b/components/dashboard/dashboard.go
@@ -36,10 +36,6 @@ var (
 	PathAnaconda           = deploy.DefaultManifestPath + "/partners/anaconda/base/"
 )
 
-var imageParamMap = map[string]string{
-	"odh-dashboard-image": "RELATED_IMAGE_ODH_DASHBOARD_IMAGE",
-}
-
 type Dashboard struct {
 	components.Component `json:""`
 }
@@ -69,11 +65,6 @@ func (d *Dashboard) OverrideManifests(platform string) error {
 	return nil
 }
 
-func (d *Dashboard) SetImageParamsMap(imageMap map[string]string) map[string]string {
-	imageParamMap = imageMap
-	return imageParamMap
-}
-
 func (d *Dashboard) GetComponentName() string {
 	return ComponentName
 }
@@ -82,6 +73,9 @@ func (d *Dashboard) GetComponentName() string {
 var _ components.ComponentInterface = (*Dashboard)(nil)
 
 func (d *Dashboard) ReconcileComponent(cli client.Client, owner metav1.Object, dscispec *dsci.DSCInitializationSpec) error {
+	var imageParamMap = map[string]string{
+		"odh-dashboard-image": "RELATED_IMAGE_ODH_DASHBOARD_IMAGE",
+	}
 	platform, err := deploy.GetPlatform(cli)
 	if err != nil {
 		return err
@@ -121,7 +115,7 @@ func (d *Dashboard) ReconcileComponent(cli client.Client, owner metav1.Object, d
 
 		// Update image parameters (ODH does not use this solution, only downstream)
 		if dscispec.DevFlags.ManifestsUri == "" && len(d.DevFlags.Manifests) == 0 {
-			if err := deploy.ApplyImageParams(PathSupported, imageParamMap); err != nil {
+			if err := deploy.ApplyParams(PathSupported, d.SetImageParamsMap(imageParamMap), false); err != nil {
 				return err
 			}
 		}

--- a/components/kserve/kserve.go
+++ b/components/kserve/kserve.go
@@ -4,15 +4,16 @@ package kserve
 import (
 	"fmt"
 
+	"path/filepath"
+	"strings"
+
 	dsci "github.com/opendatahub-io/opendatahub-operator/v2/apis/dscinitialization/v1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/components"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/common"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/deploy"
 	operatorv1 "github.com/openshift/api/operator/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"path/filepath"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"strings"
 )
 
 var (
@@ -23,14 +24,6 @@ var (
 	ServiceMeshOperator    = "servicemeshoperator"
 	ServerlessOperator     = "serverless-operator"
 )
-
-// Kserve to use.
-var imageParamMap = map[string]string{}
-
-// odh-model-controller to use.
-var dependentImageParamMap = map[string]string{
-	"odh-model-controller": "RELATED_IMAGE_ODH_MODEL_CONTROLLER_IMAGE",
-}
 
 type Kserve struct {
 	components.Component `json:""`
@@ -71,11 +64,6 @@ func (k *Kserve) OverrideManifests(_ string) error {
 	return nil
 }
 
-func (k *Kserve) SetImageParamsMap(imageMap map[string]string) map[string]string {
-	imageParamMap = imageMap
-	return imageParamMap
-}
-
 func (k *Kserve) GetComponentName() string {
 	return ComponentName
 }
@@ -84,6 +72,14 @@ func (k *Kserve) GetComponentName() string {
 var _ components.ComponentInterface = (*Kserve)(nil)
 
 func (k *Kserve) ReconcileComponent(cli client.Client, owner metav1.Object, dscispec *dsci.DSCInitializationSpec) error {
+	// paramMap for Kserve to use.
+	var imageParamMap = map[string]string{}
+
+	// dependentParamMap for odh-model-controller to use.
+	var dependentParamMap = map[string]string{
+		"odh-model-controller": "RELATED_IMAGE_ODH_MODEL_CONTROLLER_IMAGE",
+	}
+
 	enabled := k.GetManagementState() == operatorv1.Managed
 	platform, err := deploy.GetPlatform(cli)
 	if err != nil {
@@ -114,7 +110,7 @@ func (k *Kserve) ReconcileComponent(cli client.Client, owner metav1.Object, dsci
 
 		// Update image parameters only when we do not have customized manifests set
 		if dscispec.DevFlags.ManifestsUri == "" && len(k.DevFlags.Manifests) == 0 {
-			if err := deploy.ApplyImageParams(Path, imageParamMap); err != nil {
+			if err := deploy.ApplyParams(Path, k.SetImageParamsMap(imageParamMap), false); err != nil {
 				return err
 			}
 		}
@@ -132,7 +128,7 @@ func (k *Kserve) ReconcileComponent(cli client.Client, owner metav1.Object, dsci
 		}
 		// Update image parameters for odh-maodel-controller
 		if dscispec.DevFlags.ManifestsUri == "" && len(k.DevFlags.Manifests) == 0 {
-			if err := deploy.ApplyImageParams(DependentPath, dependentImageParamMap); err != nil {
+			if err := deploy.ApplyParams(DependentPath, k.SetImageParamsMap(dependentParamMap), false); err != nil {
 				return err
 			}
 		}

--- a/components/modelmeshserving/modelmeshserving.go
+++ b/components/modelmeshserving/modelmeshserving.go
@@ -3,13 +3,14 @@ package modelmeshserving
 
 import (
 	"context"
+	"path/filepath"
+
 	dsci "github.com/opendatahub-io/opendatahub-operator/v2/apis/dscinitialization/v1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/components"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/common"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/deploy"
 	operatorv1 "github.com/openshift/api/operator/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"path/filepath"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -18,14 +19,6 @@ var (
 	Path           = deploy.DefaultManifestPath + "/" + ComponentName + "/base"
 	monitoringPath = deploy.DefaultManifestPath + "/" + "modelmesh-monitoring/base"
 )
-
-var imageParamMap = map[string]string{
-	"odh-mm-rest-proxy":             "RELATED_IMAGE_ODH_MM_REST_PROXY_IMAGE",
-	"odh-modelmesh-runtime-adapter": "RELATED_IMAGE_ODH_MODELMESH_RUNTIME_ADAPTER_IMAGE",
-	"odh-modelmesh":                 "RELATED_IMAGE_ODH_MODELMESH_IMAGE",
-	"odh-modelmesh-controller":      "RELATED_IMAGE_ODH_MODELMESH_CONTROLLER_IMAGE",
-	"odh-model-controller":          "RELATED_IMAGE_ODH_MODEL_CONTROLLER_IMAGE",
-}
 
 type ModelMeshServing struct {
 	components.Component `json:""`
@@ -52,15 +45,18 @@ func (m *ModelMeshServing) GetComponentName() string {
 	return ComponentName
 }
 
-func (m *ModelMeshServing) SetImageParamsMap(imageMap map[string]string) map[string]string {
-	imageParamMap = imageMap
-	return imageParamMap
-}
-
 // Verifies that Dashboard implements ComponentInterface.
 var _ components.ComponentInterface = (*ModelMeshServing)(nil)
 
 func (m *ModelMeshServing) ReconcileComponent(cli client.Client, owner metav1.Object, dscispec *dsci.DSCInitializationSpec) error {
+	var imageParamMap = map[string]string{
+		"odh-mm-rest-proxy":             "RELATED_IMAGE_ODH_MM_REST_PROXY_IMAGE",
+		"odh-modelmesh-runtime-adapter": "RELATED_IMAGE_ODH_MODELMESH_RUNTIME_ADAPTER_IMAGE",
+		"odh-modelmesh":                 "RELATED_IMAGE_ODH_MODELMESH_IMAGE",
+		"odh-modelmesh-controller":      "RELATED_IMAGE_ODH_MODELMESH_CONTROLLER_IMAGE",
+		"odh-model-controller":          "RELATED_IMAGE_ODH_MODEL_CONTROLLER_IMAGE",
+	}
+
 	enabled := m.GetManagementState() == operatorv1.Managed
 	platform, err := deploy.GetPlatform(cli)
 	if err != nil {
@@ -81,7 +77,7 @@ func (m *ModelMeshServing) ReconcileComponent(cli client.Client, owner metav1.Ob
 		}
 		// Update image parameters
 		if dscispec.DevFlags.ManifestsUri == "" && len(m.DevFlags.Manifests) == 0 {
-			if err := deploy.ApplyImageParams(Path, imageParamMap); err != nil {
+			if err := deploy.ApplyParams(Path, m.SetImageParamsMap(imageParamMap), false); err != nil {
 				return err
 			}
 		}

--- a/components/ray/ray.go
+++ b/components/ray/ray.go
@@ -3,12 +3,13 @@
 package ray
 
 import (
+	"path/filepath"
+
 	dsci "github.com/opendatahub-io/opendatahub-operator/v2/apis/dscinitialization/v1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/components"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/deploy"
 	operatorv1 "github.com/openshift/api/operator/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"path/filepath"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -16,10 +17,6 @@ var (
 	ComponentName = "ray"
 	RayPath       = deploy.DefaultManifestPath + "/" + "ray/operator/base"
 )
-
-var imageParamMap = map[string]string{
-	"odh-kuberay-operator-controller-image": "RELATED_IMAGE_ODH_KUBERAY_OPERATOR_CONTROLLER_IMAGE",
-}
 
 type Ray struct {
 	components.Component `json:""`
@@ -42,11 +39,6 @@ func (r *Ray) OverrideManifests(_ string) error {
 	return nil
 }
 
-func (r *Ray) SetImageParamsMap(imageMap map[string]string) map[string]string {
-	imageParamMap = imageMap
-	return imageParamMap
-}
-
 func (r *Ray) GetComponentName() string {
 	return ComponentName
 }
@@ -55,6 +47,11 @@ func (r *Ray) GetComponentName() string {
 var _ components.ComponentInterface = (*Ray)(nil)
 
 func (r *Ray) ReconcileComponent(cli client.Client, owner metav1.Object, dscispec *dsci.DSCInitializationSpec) error {
+	var imageParamMap = map[string]string{
+		"odh-kuberay-operator-controller-image": "RELATED_IMAGE_ODH_KUBERAY_OPERATOR_CONTROLLER_IMAGE",
+		"namespace":                             dscispec.ApplicationsNamespace,
+	}
+
 	enabled := r.GetManagementState() == operatorv1.Managed
 
 	platform, err := deploy.GetPlatform(cli)
@@ -69,7 +66,7 @@ func (r *Ray) ReconcileComponent(cli client.Client, owner metav1.Object, dscispe
 		}
 
 		if dscispec.DevFlags.ManifestsUri == "" || len(r.DevFlags.Manifests) == 0 {
-			if err := deploy.ApplyImageParams(RayPath, imageParamMap); err != nil {
+			if err := deploy.ApplyParams(RayPath, r.SetImageParamsMap(imageParamMap), true); err != nil {
 				return err
 			}
 		}

--- a/components/workbenches/workbenches.go
+++ b/components/workbenches/workbenches.go
@@ -2,15 +2,16 @@
 package workbenches
 
 import (
+	"path/filepath"
+	"strings"
+
 	dsci "github.com/opendatahub-io/opendatahub-operator/v2/apis/dscinitialization/v1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/components"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/common"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/deploy"
 	operatorv1 "github.com/openshift/api/operator/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"path/filepath"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"strings"
 )
 
 var (
@@ -23,11 +24,6 @@ var (
 	notebookImagesPath          = deploy.DefaultManifestPath + "/notebooks/overlays/additional"
 	notebookImagesPathSupported = deploy.DefaultManifestPath + "/jupyterhub/notebook-images/overlays/additional"
 )
-
-var imageParamMap = map[string]string{
-	"odh-notebook-controller-image":    "RELATED_IMAGE_ODH_NOTEBOOK_CONTROLLER_IMAGE",
-	"odh-kf-notebook-controller-image": "RELATED_IMAGE_ODH_KF_NOTEBOOK_CONTROLLER_IMAGE",
-}
 
 type Workbenches struct {
 	components.Component `json:""`
@@ -91,15 +87,15 @@ func (w *Workbenches) GetComponentName() string {
 	return ComponentName
 }
 
-func (w *Workbenches) SetImageParamsMap(imageMap map[string]string) map[string]string {
-	imageParamMap = imageMap
-	return imageParamMap
-}
-
 // Verifies that Dashboard implements ComponentInterface.
 var _ components.ComponentInterface = (*Workbenches)(nil)
 
 func (w *Workbenches) ReconcileComponent(cli client.Client, owner metav1.Object, dscispec *dsci.DSCInitializationSpec) error {
+	var imageParamMap = map[string]string{
+		"odh-notebook-controller-image":    "RELATED_IMAGE_ODH_NOTEBOOK_CONTROLLER_IMAGE",
+		"odh-kf-notebook-controller-image": "RELATED_IMAGE_ODH_KF_NOTEBOOK_CONTROLLER_IMAGE",
+	}
+
 	// Set default notebooks namespace
 	// Create rhods-notebooks namespace in managed platforms
 	platform, err := deploy.GetPlatform(cli)
@@ -137,7 +133,7 @@ func (w *Workbenches) ReconcileComponent(cli client.Client, owner metav1.Object,
 	if enabled {
 		if dscispec.DevFlags.ManifestsUri == "" && len(w.DevFlags.Manifests) == 0 {
 			if platform == deploy.ManagedRhods || platform == deploy.SelfManagedRhods {
-				if err := deploy.ApplyImageParams(notebookControllerPath, imageParamMap); err != nil {
+				if err := deploy.ApplyParams(notebookControllerPath, w.SetImageParamsMap(imageParamMap), false); err != nil {
 					return err
 				}
 			}

--- a/pkg/deploy/deploy.go
+++ b/pkg/deploy/deploy.go
@@ -294,8 +294,9 @@ priority of image values (from high to low):
 - image values set in manifests params.env if manifestsURI is set
 - RELATED_IMAGE_* values from CSV
 - image values set in manifests params.env if manifestsURI is not set.
+parameter isUpdateNamespace is used to set if should update namespace  with dsci applicationnamespace.
 */
-func ApplyImageParams(componentPath string, imageParamsMap map[string]string) error {
+func ApplyParams(componentPath string, imageParamsMap map[string]string, isUpdateNamespace bool) error {
 	envFilePath := filepath.Join(componentPath, "params.env")
 	// Require params.env at the root folder
 	file, err := os.Open(envFilePath)
@@ -330,6 +331,11 @@ func ApplyImageParams(componentPath string, imageParamsMap map[string]string) er
 		if relatedImageValue != "" {
 			envMap[i] = relatedImageValue
 		}
+	}
+
+	// Update namespace variable with applicationNamepsace
+	if isUpdateNamespace {
+		envMap["namespace"] = imageParamsMap["namespace"]
 	}
 
 	// Move the existing file to a backup file and create empty file


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
ref: https://github.com/opendatahub-io/kuberay/pull/3/files#diff-acaa2de02231c3fc528b55d6d109904b65a42e2387eef38fa18bc12ba2dc279e

- only enable ray and codeflare. these are the two components use "namespace" in params.env for now.
- move `applyImageParam` into ReconcileComponent() to pass down` dsci.ApplicationNamespace`
-  rename  `ApplyImageParams()` to `ApplyParams()`
-  move SetImageParamsMap to component


## Description
<!--- Describe your changes in detail -->
related: https://github.com/opendatahub-io/opendatahub-operator/issues/600 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

local build: quay.io/wenzhou/opendatahub-operator:dev-2.10.600-0


## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
