### PR TITLE
manager: adjust cpu request to 100m and memory to 512Mi

### DIFF
--- a/bundle/manifests/opendatahub-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/opendatahub-operator.clusterserviceversion.yaml
@@ -1699,8 +1699,8 @@ spec:
                     cpu: 500m
                     memory: 4Gi
                   requests:
-                    cpu: 500m
-                    memory: 256Mi
+                    cpu: 100m
+                    memory: 512Mi
                 securityContext:
                   allowPrivilegeEscalation: false
                   capabilities:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -69,7 +69,7 @@ spec:
             cpu: 500m
             memory: 4Gi
           requests:
-            cpu: 500m
-            memory: 256Mi
+            cpu: 100m
+            memory: 512Mi
       serviceAccountName: controller-manager
       terminationGracePeriodSeconds: 10


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
ref: https://github.com/opendatahub-io/opendatahub-operator/issues/578

## Description
<!--- Describe your changes in detail -->
Existing limits garantee the operator to run but are too agressive

So, decrease memory limit to the reasonable 2Gi and CPU request to 100m

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Run make e2e-test

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
