### PR TITLE
Add Github Workflows to Automate Build and Run e2e tests on kind cluster

### DIFF
--- a/.github/actions/kind/action.yaml
+++ b/.github/actions/kind/action.yaml
@@ -1,0 +1,58 @@
+name: "Set up KinD"
+description: "Step to start and configure KinD cluster"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Init directories
+      shell: bash
+      run: |
+        TEMP_DIR="$(pwd)/tmp"
+        mkdir -p "${TEMP_DIR}"
+        echo "TEMP_DIR=${TEMP_DIR}" >> $GITHUB_ENV
+
+        mkdir -p "$(pwd)/bin"
+        echo "$(pwd)/bin" >> $GITHUB_PATH
+
+    - name: Container image registry
+      shell: bash
+      run: |
+        podman run -d -p 5000:5000 --name registry registry:2.8.1
+
+        export REGISTRY_ADDRESS=$(hostname -i):5000
+        echo "REGISTRY_ADDRESS=${REGISTRY_ADDRESS}" >> $GITHUB_ENV
+        echo "Container image registry started at ${REGISTRY_ADDRESS}"
+
+        KIND_CONFIG_FILE=${{ env.TEMP_DIR }}/kind.yaml
+        echo "KIND_CONFIG_FILE=${KIND_CONFIG_FILE}" >> $GITHUB_ENV
+        envsubst < .github/resources/kind/kind.yaml > ${KIND_CONFIG_FILE}
+
+        sudo --preserve-env=REGISTRY_ADDRESS sh -c 'cat > /etc/containers/registries.conf.d/local.conf <<EOF
+        [[registry]]
+        prefix = "$REGISTRY_ADDRESS"
+        insecure = true
+        location = "$REGISTRY_ADDRESS"
+        EOF'
+
+    - name: Setup KinD cluster
+      uses: helm/kind-action@v1.8.0
+      with:
+        cluster_name: cluster
+        version: v0.17.0
+        config: ${{ env.KIND_CONFIG_FILE }}
+
+    - name: Print cluster info
+      shell: bash
+      run: |
+        echo "KinD cluster:"
+        kubectl cluster-info
+        kubectl describe nodes
+
+    - name: Install Ingress controller
+      shell: bash
+      run: |
+        VERSION=controller-v1.6.4
+        echo "Deploying Ingress controller into KinD cluster"
+        curl https://raw.githubusercontent.com/kubernetes/ingress-nginx/"${VERSION}"/deploy/static/provider/kind/deploy.yaml | sed "s/--publish-status-address=localhost/--report-node-internal-ip-address\\n        - --status-update-interval=10/g" | kubectl apply -f -
+        kubectl annotate ingressclass nginx "ingressclass.kubernetes.io/is-default-class=true"
+        kubectl -n ingress-nginx wait --timeout=300s --for=condition=Available deployments --all

--- a/.github/actions/kind/action.yaml
+++ b/.github/actions/kind/action.yaml
@@ -17,12 +17,12 @@ runs:
     - name: Container image registry
       shell: bash
       run: |
-        export REGISTRY_NAME='registry'
+        export REGISTRY_NAME='kind-registry'
         export REGISTRY_PORT=5001
         export REGISTRY_ADDRESS=$(hostname -i):$REGISTRY_PORT
 
         docker run \
-            -d --restart=always -p $(hostname -i):$REGISTRY_PORT:$REGISTRY_PORT --name $REGISTRY_NAME \
+            -d --restart=always -p $REGISTRY_ADDRESS:$REGISTRY_PORT --name $REGISTRY_NAME \
             registry:2.8.1
             
 

--- a/.github/actions/kind/action.yaml
+++ b/.github/actions/kind/action.yaml
@@ -17,9 +17,15 @@ runs:
     - name: Container image registry
       shell: bash
       run: |
-        podman run -d -p 5000:5000 --name registry registry:2.8.1
+        export REGISTRY_NAME='registry'
+        export REGISTRY_PORT=5001
+        export REGISTRY_ADDRESS=$(hostname -i):$REGISTRY_PORT
 
-        export REGISTRY_ADDRESS=$(hostname -i):5000
+        docker run \
+            -d --restart=always -p $(hostname -i):$REGISTRY_PORT:$REGISTRY_PORT --name $REGISTRY_NAME \
+            registry:2.8.1
+            
+
         echo "REGISTRY_ADDRESS=${REGISTRY_ADDRESS}" >> $GITHUB_ENV
         echo "Container image registry started at ${REGISTRY_ADDRESS}"
 
@@ -37,7 +43,7 @@ runs:
     - name: Setup KinD cluster
       uses: helm/kind-action@v1.8.0
       with:
-        cluster_name: cluster
+        cluster_name: kind-cluster
         version: v0.17.0
         config: ${{ env.KIND_CONFIG_FILE }}
 

--- a/.github/resources/kind/kind.yaml
+++ b/.github/resources/kind/kind.yaml
@@ -1,0 +1,15 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+  - role: control-plane
+    image: kindest/node:v1.25.3@sha256:f52781bc0d7a19fb6c405c2af83abfeb311f130707a0e219175677e366cc45d1
+    kubeadmConfigPatches:
+      - |
+        kind: InitConfiguration
+        nodeRegistration:
+          kubeletExtraArgs:
+            node-labels: "ingress-ready=true"
+containerdConfigPatches:
+  - |-
+    [plugins."io.containerd.grpc.v1.cri".registry.mirrors."${REGISTRY_ADDRESS}"]
+      endpoint = ["http://${REGISTRY_ADDRESS}"]

--- a/.github/resources/kind/kind.yaml
+++ b/.github/resources/kind/kind.yaml
@@ -2,7 +2,7 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
   - role: control-plane
-    image: kindest/node:v1.25.3@sha256:f52781bc0d7a19fb6c405c2af83abfeb311f130707a0e219175677e366cc45d1
+    image: kindest/node:v1.28.0@sha256:9f3ff58f19dcf1a0611d11e8ac989fdb30a28f40f236f59f0bea31fb956ccf5c
     kubeadmConfigPatches:
       - |
         kind: InitConfiguration

--- a/.github/workflows/e2e_tests.yaml
+++ b/.github/workflows/e2e_tests.yaml
@@ -4,7 +4,7 @@ on:
   pull_request:
     branches:
       - main
-      - "incubation"
+      - 'incubation'
     paths-ignore:
       - 'docs/**'
       - '**.adoc'
@@ -13,7 +13,7 @@ on:
   push:
     branches:
       - main
-      - "incubation"
+      - 'incubation'
     paths-ignore:
       - 'docs/**'
       - '**.adoc'
@@ -32,7 +32,7 @@ env:
 
 jobs:
   kubernetes-e2e:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
@@ -43,6 +43,13 @@ jobs:
         uses: actions/setup-go@v3
         with:
           go-version: 1.19
+
+      - name: Log to Quay.io
+        uses: redhat-actions/podman-login@v1
+        with:
+          username: ${{ secrets.QUAY_ID }}
+          password: ${{ secrets.QUAY_TOKEN }}
+          registry: ${{ env.IMAGE_REGISTRY}}
 
       - name: Build Operator Bundle
         run: |
@@ -62,13 +69,6 @@ jobs:
           # Build operator bundle image
           make bundle-build -e BUNDLE_IMG=quay.io/${{ env.QUAY_ORG }}/${{ env.BUNDLE_IMAGE_NAME }}:${{ env.IMAGE_TAG }} \
           -e IMG=quay.io/${{ env.QUAY_ORG }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}
-
-      - name: Log to Quay.io
-        uses: redhat-actions/podman-login@v1
-        with:
-          username: ${{ secrets.QUAY_ID }}
-          password: ${{ secrets.QUAY_TOKEN }}
-          registry: ${{ env.IMAGE_REGISTRY}}
 
       - name: Push Operator Bundle Image
         run:  |
@@ -108,3 +108,4 @@ jobs:
       - name: Clean up KinD cluster
         run:  |
           kind delete cluster --name kind-cluster
+          

--- a/.github/workflows/e2e_tests.yaml
+++ b/.github/workflows/e2e_tests.yaml
@@ -32,7 +32,7 @@ env:
 
 jobs:
   kubernetes-e2e:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
@@ -40,12 +40,12 @@ jobs:
           submodules: recursive
 
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version: 1.19
 
       - name: Log to Quay.io
-        uses: redhat-actions/podman-login@v1
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.QUAY_ID }}
           password: ${{ secrets.QUAY_TOKEN }}
@@ -108,4 +108,3 @@ jobs:
       - name: Clean up KinD cluster
         run:  |
           kind delete cluster --name kind-cluster
-          

--- a/.github/workflows/e2e_tests.yaml
+++ b/.github/workflows/e2e_tests.yaml
@@ -1,0 +1,74 @@
+name: e2e Tests
+
+on:
+  pull_request:
+    branches:
+      - main
+      - "incubation"
+    paths-ignore:
+      - 'docs/**'
+      - '**.adoc'
+      - '**.md'
+      - 'LICENSE'
+  push:
+    branches:
+      - main
+      - "incubation"
+    paths-ignore:
+      - 'docs/**'
+      - '**.adoc'
+      - '**.md'
+      - 'LICENSE'
+concurrency:
+  group: ${{ github.head_ref }}-${{ github.workflow }}
+  cancel-in-progress: true
+
+env:
+  QUAY_ORG: opendatahub
+  QUAY_ID: ${{ secrets.QUAY_ID }}
+  QUAY_TOKEN: ${{ secrets.QUAY_TOKEN }}
+  BUNDLE_IMAGE_NAME: opendatahub-operator-bundle
+  IMAGE_NAME: opendatahub-operator
+  IMAGE_TAG: pr-${{ github.event.pull_request.number }}
+
+jobs:
+  kubernetes-e2e:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Set Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.19
+
+      - name: Build Operator Bundle
+        run: |
+          # Pull the Docker image from registry
+          podman pull quay.io/${env.QUAY_ORG}/${env.IMAGE_NAME}:${env.IMAGE_TAG}
+
+          # Create an Operator Bundle using the image
+          operator-sdk bundle create quay.io/${env.QUAY_ORG}/${env.BUNDLE_IMAGE_NAME}:${env.IMAGE_TAG} --image quay.io/${env.QUAY_ORG}/${env.IMAGE_NAME}:${env.IMAGE_TAG} --overwrite
+    
+      - name: Setup and start KinD cluster
+        uses: ./.github/actions/kind
+
+      - name: Load Image in KinD cluster
+        run: |
+          kind load docker-image ${env.BUNDLE_IMAGE_NAME}:${env.IMAGE_TAG}
+      
+      - name: Deploy Operatorhub operator bundle
+        id: deploy
+        run: |
+          echo Deploying Operatorhub operator
+          IMG="${REGISTRY_ADDRESS}"/${env.BUNDLE_IMAGE_NAME}:${env.IMAGE_TAG}
+          make deploy -e IMG="${IMG}"
+          kubectl wait --timeout=120s --for=condition=Available=true deployment -n openshift-operators opendatahub-operator-manager
+
+      - name: Run e2e tests
+        run: |
+          make e2e-test

--- a/.github/workflows/e2e_tests.yaml
+++ b/.github/workflows/e2e_tests.yaml
@@ -24,7 +24,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  QUAY_ORG: opendatahub
+  QUAY_ORG: ${{ secrets.QUAY_ORG}}
   IMAGE_REGISTRY: quay.io
   BUNDLE_IMAGE_NAME: opendatahub-operator-bundle
   IMAGE_NAME: opendatahub-operator

--- a/.github/workflows/e2e_tests.yaml
+++ b/.github/workflows/e2e_tests.yaml
@@ -27,6 +27,7 @@ env:
   QUAY_ORG: opendatahub
   QUAY_ID: ${{ secrets.QUAY_ID }}
   QUAY_TOKEN: ${{ secrets.QUAY_TOKEN }}
+  IMAGE_REGISTRY: quay.io
   BUNDLE_IMAGE_NAME: opendatahub-operator-bundle
   IMAGE_NAME: opendatahub-operator
   IMAGE_TAG: pr-${{ github.event.pull_request.number }}
@@ -34,41 +35,72 @@ env:
 jobs:
   kubernetes-e2e:
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
         with:
           submodules: recursive
 
-      - name: Set Go
+      - name: Set up Go
         uses: actions/setup-go@v3
         with:
           go-version: 1.19
 
+      - name: Log in to image registry Quay.io
+        uses: redhat-actions/podman-login@v1
+        with:
+          username: ${{ env.QUAY_ID }}
+          password: ${{ env.QUAY_TOKEN }}
+          registry: ${{ env.IMAGE_REGISTRY}}
+
       - name: Build Operator Bundle
         run: |
-          # Pull the Docker image from registry
-          podman pull quay.io/${env.QUAY_ORG}/${env.IMAGE_NAME}:${env.IMAGE_TAG}
+          # Pull the image from registry
+          while true
+          do
+            echo "Pulling image from Quay.io";
+            sleep 10
 
-          # Create an Operator Bundle using the image
-          operator-sdk bundle create quay.io/${env.QUAY_ORG}/${env.BUNDLE_IMAGE_NAME}:${env.IMAGE_TAG} --image quay.io/${env.QUAY_ORG}/${env.IMAGE_NAME}:${env.IMAGE_TAG} --overwrite
-    
+            if podman pull quay.io/${{ env.QUAY_ORG }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}
+            then
+              break
+            fi
+
+          done
+
+          # Build operator bundle image
+          make bundle-build -e BUNDLE_IMG=quay.io/${{ env.QUAY_ORG }}/${{ env.BUNDLE_IMAGE_NAME }}:${{ env.IMAGE_TAG }} \
+          -e IMG=quay.io/${{ env.QUAY_ORG }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}
+
+      - name: Push Operator Bundle Image
+        run:  |
+          podman push quay.io/${{ env.QUAY_ORG }}/${{ env.BUNDLE_IMAGE_NAME }}:${{ env.IMAGE_TAG }}
+     
       - name: Setup and start KinD cluster
         uses: ./.github/actions/kind
 
+      - name: Verify KinD
+        run:  |
+          kubectl get nodes -o wide
+
       - name: Load Image in KinD cluster
         run: |
-          kind load docker-image ${env.BUNDLE_IMAGE_NAME}:${env.IMAGE_TAG}
+          podman save docker.io/kindest/node:v1.28.0 -o quay.io/${{ env.QUAY_ORG }}/${{ env.BUNDLE_IMAGE_NAME }}:${{ env.IMAGE_TAG }}
+          kind load image-archive quay.io/${{ env.QUAY_ORG }}/${{ env.BUNDLE_IMAGE_NAME }}:${{ env.IMAGE_TAG }} --name kind-cluster
       
-      - name: Deploy Operatorhub operator bundle
+      - name: Deploy Operatorhub operator
         id: deploy
         run: |
           echo Deploying Operatorhub operator
-          IMG="${REGISTRY_ADDRESS}"/${env.BUNDLE_IMAGE_NAME}:${env.IMAGE_TAG}
+          IMG=quay.io/${{ env.QUAY_ORG }}/${{ env.BUNDLE_IMAGE_NAME }}:${{ env.IMAGE_TAG }}
+
           make deploy -e IMG="${IMG}"
-          kubectl wait --timeout=120s --for=condition=Available=true deployment -n openshift-operators opendatahub-operator-manager
+          kubectl wait --timeout=120s --for=condition=Available=true deployment -n opendatahub-operator-system
 
       - name: Run e2e tests
         run: |
           make e2e-test
+
+      - name: Clean up KinD cluster
+        run:  |
+          kind delete cluster --name kind-cluster

--- a/.github/workflows/e2e_tests.yaml
+++ b/.github/workflows/e2e_tests.yaml
@@ -44,12 +44,12 @@ jobs:
         with:
           go-version: 1.19
 
-      - name: Log to Quay.io
-        uses: docker/login-action@v2
+      - name: Login to Quay.io
+        uses: redhat-actions/podman-login@v1
         with:
+          registry: ${{ env.IMAGE_REGISTRY}}
           username: ${{ secrets.QUAY_ID }}
           password: ${{ secrets.QUAY_TOKEN }}
-          registry: ${{ env.IMAGE_REGISTRY}}
 
       - name: Build Operator Bundle
         run: |

--- a/.github/workflows/e2e_tests.yaml
+++ b/.github/workflows/e2e_tests.yaml
@@ -25,8 +25,6 @@ concurrency:
 
 env:
   QUAY_ORG: opendatahub
-  QUAY_ID: ${{ secrets.QUAY_ID }}
-  QUAY_TOKEN: ${{ secrets.QUAY_TOKEN }}
   IMAGE_REGISTRY: quay.io
   BUNDLE_IMAGE_NAME: opendatahub-operator-bundle
   IMAGE_NAME: opendatahub-operator
@@ -45,13 +43,6 @@ jobs:
         uses: actions/setup-go@v3
         with:
           go-version: 1.19
-
-      - name: Log in to image registry Quay.io
-        uses: redhat-actions/podman-login@v1
-        with:
-          username: ${{ env.QUAY_ID }}
-          password: ${{ env.QUAY_TOKEN }}
-          registry: ${{ env.IMAGE_REGISTRY}}
 
       - name: Build Operator Bundle
         run: |
@@ -72,6 +63,13 @@ jobs:
           make bundle-build -e BUNDLE_IMG=quay.io/${{ env.QUAY_ORG }}/${{ env.BUNDLE_IMAGE_NAME }}:${{ env.IMAGE_TAG }} \
           -e IMG=quay.io/${{ env.QUAY_ORG }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}
 
+      - name: Log to Quay.io
+        uses: redhat-actions/podman-login@v1
+        with:
+          username: ${{ secrets.QUAY_ID }}
+          password: ${{ secrets.QUAY_TOKEN }}
+          registry: ${{ env.IMAGE_REGISTRY}}
+
       - name: Push Operator Bundle Image
         run:  |
           podman push quay.io/${{ env.QUAY_ORG }}/${{ env.BUNDLE_IMAGE_NAME }}:${{ env.IMAGE_TAG }}
@@ -81,6 +79,8 @@ jobs:
 
       - name: Verify KinD
         run:  |
+          export KUBECONFIG="$(kind get kubeconfig-path --name="kind-cluster")"
+          kind get clusters
           kubectl get nodes -o wide
 
       - name: Load Image in KinD cluster
@@ -96,6 +96,10 @@ jobs:
 
           make deploy -e IMG="${IMG}"
           kubectl wait --timeout=120s --for=condition=Available=true deployment -n opendatahub-operator-system
+
+          kubectl get nodes -o wide
+          kubectl get pods --all-namesapces
+          kubectl get services --all-namesapces -o wide
 
       - name: Run e2e tests
         run: |

--- a/Makefile
+++ b/Makefile
@@ -203,7 +203,7 @@ KUSTOMIZE_INSTALL_SCRIPT ?= "https://raw.githubusercontent.com/kubernetes-sigs/k
 .PHONY: kustomize
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.
 $(KUSTOMIZE): $(LOCALBIN)
-	test -s $(LOCALBIN)/kustomize || { curl -s $(KUSTOMIZE_INSTALL_SCRIPT) | sh -s -- $(subst v,,$(KUSTOMIZE_VERSION)) $(LOCALBIN); }
+	test -s $(LOCALBIN)/kustomize || { curl -Ss $(KUSTOMIZE_INSTALL_SCRIPT) | bash -s -- $(subst v,,$(KUSTOMIZE_VERSION)) $(LOCALBIN); }
 
 .PHONY: controller-gen
 controller-gen: $(CONTROLLER_GEN) ## Download controller-gen locally if necessary.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Resolve: https://github.com/opendatahub-io/opendatahub-operator/issues/520

## Description
<!--- Describe your changes in detail -->
Add Github Workflows to Automate Build and Run e2e tests on kind cluster
- [ ] Create workflow that builds operator bundle from the image created in OpenShift CI by [job](https://prow.ci.openshift.org/job-history/gs/origin-ci-test/pr-logs/directory/pull-ci-opendatahub-io-opendatahub-operator-main-opendatahub-operator-pr-image-mirror) 
- [ ] Create workflow to set `Kind` cluster and install operator bundle
- [ ] Create workflow to run e2e tests in the above created cluster.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- Set QUAY_ID, QUAY_ORG and QUAY_TOKEN of your personal Quay.io account in your fork repo 
- Open a PR on fork repo with this branch
- Make sure you should have image into Quay.io `operatorhub-operator:pr-{pr number}` ,  as image build and pushed by openshift ci tool on remote branches. On fork repo openshift ci build will not run. So push image manually or add hard code IMAGE_TAG in workflow for testing.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] The commits are squashed in a cohesive manner and have meaningful messages.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work
