### PR TITLE
add manifests for odh-model-controller and model-mesh

### DIFF
--- a/components/kserve/kserve.go
+++ b/components/kserve/kserve.go
@@ -132,9 +132,13 @@ func (k *Kserve) ReconcileComponent(cli client.Client, owner metav1.Object, dsci
 				return err
 			}
 		}
-	}
-	if err := deploy.DeployManifestsFromPath(cli, owner, DependentPath, dscispec.ApplicationsNamespace, k.GetComponentName(), enabled); err != nil {
-		return err
+		if err := deploy.DeployManifestsFromPath(cli, owner, DependentPath, dscispec.ApplicationsNamespace, k.GetComponentName(), enabled); err != nil {
+			if strings.Contains(err.Error(), "spec.selector") && strings.Contains(err.Error(), "field is immutable") {
+				//ignore this error
+			} else {
+				return err
+			}
+		}
 	}
 
 	return nil

--- a/components/kserve/kserve.go
+++ b/components/kserve/kserve.go
@@ -132,12 +132,13 @@ func (k *Kserve) ReconcileComponent(cli client.Client, owner metav1.Object, dsci
 				return err
 			}
 		}
-		if err := deploy.DeployManifestsFromPath(cli, owner, DependentPath, dscispec.ApplicationsNamespace, k.GetComponentName(), enabled); err != nil {
-			if strings.Contains(err.Error(), "spec.selector") && strings.Contains(err.Error(), "field is immutable") {
-				//ignore this error
-			} else {
-				return err
-			}
+	}
+
+	if err := deploy.DeployManifestsFromPath(cli, owner, DependentPath, dscispec.ApplicationsNamespace, k.GetComponentName(), enabled); err != nil {
+		if strings.Contains(err.Error(), "spec.selector") && strings.Contains(err.Error(), "field is immutable") {
+			// ignore this error
+		} else {
+			return err
 		}
 	}
 

--- a/components/modelmeshserving/modelmeshserving.go
+++ b/components/modelmeshserving/modelmeshserving.go
@@ -114,12 +114,12 @@ func (m *ModelMeshServing) ReconcileComponent(cli client.Client, owner metav1.Ob
 				return err
 			}
 		}
-		if err := deploy.DeployManifestsFromPath(cli, owner, DependentPath, dscispec.ApplicationsNamespace, m.GetComponentName(), enabled); err != nil {
-			if strings.Contains(err.Error(), "spec.selector") && strings.Contains(err.Error(), "field is immutable") {
-				//ignore this error
-			} else {
-				return err
-			}
+	}
+	if err := deploy.DeployManifestsFromPath(cli, owner, DependentPath, dscispec.ApplicationsNamespace, m.GetComponentName(), enabled); err != nil {
+		if strings.Contains(err.Error(), "spec.selector") && strings.Contains(err.Error(), "field is immutable") {
+			// ignore this error
+		} else {
+			return err
 		}
 	}
 

--- a/components/modelmeshserving/modelmeshserving.go
+++ b/components/modelmeshserving/modelmeshserving.go
@@ -23,18 +23,6 @@ var (
 	DependentPath          = deploy.DefaultManifestPath + "/" + DependentComponentName + "/base"
 )
 
-var imageParamMap = map[string]string{
-	"odh-mm-rest-proxy":             "RELATED_IMAGE_ODH_MM_REST_PROXY_IMAGE",
-	"odh-modelmesh-runtime-adapter": "RELATED_IMAGE_ODH_MODELMESH_RUNTIME_ADAPTER_IMAGE",
-	"odh-modelmesh":                 "RELATED_IMAGE_ODH_MODELMESH_IMAGE",
-	"odh-modelmesh-controller":      "RELATED_IMAGE_ODH_MODELMESH_CONTROLLER_IMAGE",
-}
-
-// odh-model-controller to use
-var dependentImageParamMap = map[string]string{
-	"odh-model-controller": "RELATED_IMAGE_ODH_MODEL_CONTROLLER_IMAGE",
-}
-
 type ModelMeshServing struct {
 	components.Component `json:""`
 }
@@ -70,6 +58,11 @@ func (m *ModelMeshServing) ReconcileComponent(cli client.Client, owner metav1.Ob
 		"odh-modelmesh":                 "RELATED_IMAGE_ODH_MODELMESH_IMAGE",
 		"odh-modelmesh-controller":      "RELATED_IMAGE_ODH_MODELMESH_CONTROLLER_IMAGE",
 		"odh-model-controller":          "RELATED_IMAGE_ODH_MODEL_CONTROLLER_IMAGE",
+	}
+
+	// odh-model-controller to use
+	var dependentImageParamMap = map[string]string{
+		"odh-model-controller": "RELATED_IMAGE_ODH_MODEL_CONTROLLER_IMAGE",
 	}
 
 	enabled := m.GetManagementState() == operatorv1.Managed

--- a/get_all_manifests.sh
+++ b/get_all_manifests.sh
@@ -19,8 +19,8 @@ declare -A COMPONENT_MANIFESTS=(
     ["odh-notebook-controller"]="opendatahub-io:kubeflow:v1.7-branch:components/odh-notebook-controller/config:odh-notebook-controller/odh-notebook-controller"
     ["notebooks"]="opendatahub-io:notebooks:main:manifests:notebooks"
     ["trustyai"]="trustyai-explainability:trustyai-service-operator:release/1.10.2:config:trustyai-service-operator"
-    ["model-mesh"]="opendatahub-io:modelmesh-serving:release-0.11.1:config:model-mesh"
-    ["odh-model-controller"]="opendatahub-io:odh-model-controller:release-0.11.1:config:odh-model-controller"
+    ["model-mesh"]="opendatahub-io:modelmesh-serving:release-0.11.0:config:model-mesh"
+    ["odh-model-controller"]="opendatahub-io:odh-model-controller:release-0.11.0:config:odh-model-controller"
 )
 
 # Allow overwriting repo using flags component=repo

--- a/get_all_manifests.sh
+++ b/get_all_manifests.sh
@@ -19,8 +19,8 @@ declare -A COMPONENT_MANIFESTS=(
     ["odh-notebook-controller"]="opendatahub-io:kubeflow:v1.7-branch:components/odh-notebook-controller/config:odh-notebook-controller/odh-notebook-controller"
     ["notebooks"]="opendatahub-io:notebooks:main:manifests:notebooks"
     ["trustyai"]="trustyai-explainability:trustyai-service-operator:release/1.10.2:config:trustyai-service-operator"
-    ["model-mesh"]="opendatahub-io:modelmesh-serving:release-0.11:config:model-mesh"
-    ["odh-model-controller"]="opendatahub-io:odh-model-controller:release-0.11:config:odh-model-controller"
+    ["model-mesh"]="opendatahub-io:modelmesh-serving:release-0.11.1:config:model-mesh"
+    ["odh-model-controller"]="opendatahub-io:odh-model-controller:release-0.11.1:config:odh-model-controller"
 )
 
 # Allow overwriting repo using flags component=repo

--- a/get_all_manifests.sh
+++ b/get_all_manifests.sh
@@ -19,6 +19,8 @@ declare -A COMPONENT_MANIFESTS=(
     ["odh-notebook-controller"]="opendatahub-io:kubeflow:v1.7-branch:components/odh-notebook-controller/config:odh-notebook-controller/odh-notebook-controller"
     ["notebooks"]="opendatahub-io:notebooks:main:manifests:notebooks"
     ["trustyai"]="trustyai-explainability:trustyai-service-operator:release/1.10.2:config:trustyai-service-operator"
+    ["model-mesh"]="opendatahub-io:modelmesh-serving:release-0.11:config:model-mesh"
+    ["odh-model-controller"]="opendatahub-io:odh-model-controller:release-0.11:config:odh-model-controller"
 )
 
 # Allow overwriting repo using flags component=repo
@@ -50,8 +52,6 @@ rm -fr ./odh-manifests/* ./.odh-manifests-tmp/
 
 mkdir -p ./.odh-manifests-tmp/ ./odh-manifests/
 wget -q -c ${MANIFESTS_TARBALL_URL} -O - | tar -zxv -C ./.odh-manifests-tmp/ --strip-components 1 > /dev/null
-cp -r ./.odh-manifests-tmp/model-mesh/ ./odh-manifests
-cp -r ./.odh-manifests-tmp/odh-model-controller/ ./odh-manifests
 cp -r ./.odh-manifests-tmp/modelmesh-monitoring/ ./odh-manifests
 cp -r ./.odh-manifests-tmp/kserve/ ./odh-manifests
 rm -rf ${MANIFEST_RELEASE}.tar.gz ./.odh-manifests-tmp/


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Added model-mesh and odh-model-controller manifests to `get_all_manifests.sh` 
- added logic to allow kserve and model-mesh to share a singular odh-model-controller deployment 

## Testing 
The testing for this PR is to be done along with the testing for [this](https://github.com/opendatahub-io/odh-model-controller/pull/92) and [this](https://github.com/opendatahub-io/modelmesh-serving/pull/221) PR since they target the same set of overall changes. 
The ODH operator image has been built with the following changes : 
- odh-model-controller manifests are pre built from https://github.com/opendatahub-io/odh-model-controller/tree/remove_kserve_flag which has equivalent changes to this repo, except that it deploys the image `quay.io/vedantm/odh-model-controller:remove-kserve-flag` which contains the changes for this PR. 
- model-mesh manifests are pre built from https://github.com/opendatahub-io/modelmesh-serving/tree/manifests_transition_v2 and the manfest location is opendatahub/manifests. These manifests are now no longer bundled with odh-model-controller manifests 
- opendatahub-operator reconciliation for kserve and modelmesh allow a common deployment of odh-model-controller

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
#### ModelMesh testing
- cluster login
- `git clone git@github.com:VedantMahabaleshwarkar/opendatahub-operator.git`
- `cd opendatahub-operator` 
- switch to branch `transition`
- `make deploy -e IMG=quay.io/vedantm/opendatahub-operator:version_builtin` 
- This will install the ODH operator in NS `opendatahub-operator-system` with the image `quay.io/vedantm/opendatahub-operator:version_builtin`
- create the following DSC in NS `opendatahub` 
```
apiVersion: datasciencecluster.opendatahub.io/v1
kind: DataScienceCluster
metadata:
  name: example
spec:
  components:
    modelmeshserving:
      managementState: Managed
```
- deploy and test a model with modelmesh 

#### Kserve testing
```
Note: Cleanup kserve CRDs before testing modelmesh
```
- cluster login
- install ODH Kserve + dependencies stack by following [instructions](https://github.com/opendatahub-io/caikit-tgis-serving/blob/main/demo/kserve/install-manual.md)
```
Note: Only install the dependencies, the ODH operator will be a custom install according to next steps
```
- `git clone git@github.com:VedantMahabaleshwarkar/opendatahub-operator.git`
- `cd opendatahub-operator` 
- switch to branch `transition`
- `make deploy -e IMG=quay.io/vedantm/opendatahub-operator:version_builtin` 
- This will install the ODH operator in NS `opendatahub-operator-system` with the image `quay.io/vedantm/opendatahub-operator:version_builtin`
- create the following DSC in NS `opendatahub` 
```
apiVersion: datasciencecluster.opendatahub.io/v1
kind: DataScienceCluster
metadata:
  name: default
spec:
  components:
    kserve:
      managementState: Managed
```
- deploy and test a kserve model using [instructions](https://github.com/opendatahub-io/caikit-tgis-serving/blob/main/demo/kserve/deploy-remove-scripts.md)


## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
