### PR TITLE
update(ray): new path to manifests

### DIFF
--- a/components/ray/ray.go
+++ b/components/ray/ray.go
@@ -15,7 +15,7 @@ import (
 
 var (
 	ComponentName = "ray"
-	RayPath       = deploy.DefaultManifestPath + "/" + "ray/operator/base"
+	RayPath       = deploy.DefaultManifestPath + "/ray/openshift"
 )
 
 type Ray struct {

--- a/get_all_manifests.sh
+++ b/get_all_manifests.sh
@@ -12,7 +12,7 @@ MANIFESTS_TARBALL_URL="${GITHUB_URL}/${MANIFEST_ORG}/odh-manifests/tarball/${MAN
 # TODO: workbench, modelmesh, monitoring, etc
 declare -A COMPONENT_MANIFESTS=(
     ["codeflare"]="opendatahub-io:distributed-workloads:main:codeflare-stack:codeflare"
-    ["ray"]="opendatahub-io:distributed-workloads:main:ray:ray"
+    ["ray"]="opendatahub-io:kuberay:master:ray-operator/config:ray"
     ["data-science-pipelines-operator"]="opendatahub-io:data-science-pipelines-operator:main:config:data-science-pipelines-operator"
     ["odh-dashboard"]="opendatahub-io:odh-dashboard:incubation:manifests:odh-dashboard"
     ["kf-notebook-controller"]="opendatahub-io:kubeflow:v1.7-branch:components/notebook-controller/config:odh-notebook-controller/kf-notebook-controller"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- changes with new location of DW manifests:
  - ray : https://github.com/opendatahub-io/kuberay/pull/3
 
part of : https://github.com/opendatahub-io/opendatahub-operator/issues/600

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
local build quay.io/wenzhou/opendatahub-operator-catalog:v2.10.600-99

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
