### PR TITLE
add(api): shortname for CRD

### DIFF
--- a/apis/datasciencecluster/v1/datasciencecluster_types.go
+++ b/apis/datasciencecluster/v1/datasciencecluster_types.go
@@ -92,7 +92,7 @@ type DataScienceClusterStatus struct {
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
-//+kubebuilder:resource:scope=Cluster
+//+kubebuilder:resource:scope=Cluster,shortName=dsc
 //+kubebuilder:storageversion
 
 // DataScienceCluster is the Schema for the datascienceclusters API.

--- a/apis/dscinitialization/v1/dscinitialization_types.go
+++ b/apis/dscinitialization/v1/dscinitialization_types.go
@@ -82,7 +82,7 @@ type DSCInitializationStatus struct {
 }
 
 //+kubebuilder:object:root=true
-//+kubebuilder:resource:scope=Cluster
+//+kubebuilder:resource:scope=Cluster,shortName=dsci
 //+kubebuilder:subresource:status
 //+kubebuilder:printcolumn:name="Age",type=date,JSONPath=.metadata.creationTimestamp
 //+kubebuilder:printcolumn:name="Phase",type=string,JSONPath=.status.phase,description="Current Phase"

--- a/bundle/manifests/datasciencecluster.opendatahub.io_datascienceclusters.yaml
+++ b/bundle/manifests/datasciencecluster.opendatahub.io_datascienceclusters.yaml
@@ -11,6 +11,8 @@ spec:
     kind: DataScienceCluster
     listKind: DataScienceClusterList
     plural: datascienceclusters
+    shortNames:
+    - dsc
     singular: datasciencecluster
   scope: Cluster
   versions:

--- a/bundle/manifests/dscinitialization.opendatahub.io_dscinitializations.yaml
+++ b/bundle/manifests/dscinitialization.opendatahub.io_dscinitializations.yaml
@@ -11,6 +11,8 @@ spec:
     kind: DSCInitialization
     listKind: DSCInitializationList
     plural: dscinitializations
+    shortNames:
+    - dsci
     singular: dscinitialization
   scope: Cluster
   versions:

--- a/config/crd/bases/datasciencecluster.opendatahub.io_datascienceclusters.yaml
+++ b/config/crd/bases/datasciencecluster.opendatahub.io_datascienceclusters.yaml
@@ -12,6 +12,8 @@ spec:
     kind: DataScienceCluster
     listKind: DataScienceClusterList
     plural: datascienceclusters
+    shortNames:
+    - dsc
     singular: datasciencecluster
   scope: Cluster
   versions:

--- a/config/crd/bases/dscinitialization.opendatahub.io_dscinitializations.yaml
+++ b/config/crd/bases/dscinitialization.opendatahub.io_dscinitializations.yaml
@@ -12,6 +12,8 @@ spec:
     kind: DSCInitialization
     listKind: DSCInitializationList
     plural: dscinitializations
+    shortNames:
+    - dsci
     singular: dscinitialization
   scope: Cluster
   versions:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
dsc for DataScienceCluster
dsci for DataScienceClusterInitialization

## Description
<!--- Describe your changes in detail -->
fix:  https://github.com/opendatahub-io/opendatahub-operator/issues/642

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
local build: quay.io/wenzhou/opendatahub-operator-catalog:v2.10.642
after install operator, check:
```
oc api-resources | grep opendatahub
odhapplications                                                              dashboard.opendatahub.io/v1                   true         OdhApplication
odhdocuments                                                                 dashboard.opendatahub.io/v1                   true         OdhDocument
datascienceclusters                   dsc                                    datasciencecluster.opendatahub.io/v1          false        DataScienceCluster
dscinitializations                    dsci                                   dscinitialization.opendatahub.io/v1           false        DSCInitialization
servicemeshresourcetrackers                                                  dscinitialization.opendatahub.io/v1           false        ServiceMeshResourceTracker
odhdashboardconfigs                                                          opendatahub.io/v1alpha                        true         OdhDashboardConfig

oc get dsci 
NAME      AGE   PHASE   CREATED AT
default   76s   Ready   2023-10-19T07:29:15Z
```
## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
