### PR TITLE
Remove redundant TrustyAI reconciliation

### DIFF
--- a/controllers/datasciencecluster/datasciencecluster_controller.go
+++ b/controllers/datasciencecluster/datasciencecluster_controller.go
@@ -164,12 +164,6 @@ func (r *DataScienceClusterReconciler) Reconcile(ctx context.Context, req ctrl.R
 		}
 	}
 
-	// reconcile TrustyAI component
-	if instance, err = r.reconcileSubComponent(ctx, instance, &(instance.Spec.Components.TrustyAI)); err != nil {
-		// no need to log any errors as this is done in the reconcileSubComponent method
-		componentErrors = multierror.Append(componentErrors, err)
-	}
-
 	// Process errors for components
 	if componentErrors != nil {
 		r.Log.Info("DataScienceCluster Deployment Incomplete.")


### PR DESCRIPTION
In the DSC reconciliation, the TrustyAI component is being reconciled after all sub-components are already reconciled.

## Description

Remove redundant TrustyAI reconciliation.

## How Has This Been Tested?

Tested locally with DSC creation with `trustyai` component.

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
