### PR TITLE
Update TrustyAI operator version to 1.11.0

### DIFF
--- a/get_all_manifests.sh
+++ b/get_all_manifests.sh
@@ -18,7 +18,7 @@ declare -A COMPONENT_MANIFESTS=(
     ["kf-notebook-controller"]="opendatahub-io:kubeflow:v1.7-branch:components/notebook-controller/config:odh-notebook-controller/kf-notebook-controller"
     ["odh-notebook-controller"]="opendatahub-io:kubeflow:v1.7-branch:components/odh-notebook-controller/config:odh-notebook-controller/odh-notebook-controller"
     ["notebooks"]="opendatahub-io:notebooks:main:manifests:notebooks"
-    ["trustyai"]="trustyai-explainability:trustyai-service-operator:release/1.10.2:config:trustyai-service-operator"
+    ["trustyai"]="trustyai-explainability:trustyai-service-operator:release/1.11.0:config:trustyai-service-operator"
 )
 
 # Allow overwriting repo using flags component=repo


### PR DESCRIPTION
## Description

Update TrustyAI operator to latest upstream release [v1.11.0](https://github.com/trustyai-explainability/trustyai-service-operator/releases/tag/v1.11.0).

## How Has This Been Tested?

Locally with DSC and `trustyai` component.

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
