### PR TITLE
update(kserve): manifests path from in-repo

### DIFF
--- a/components/kserve/kserve.go
+++ b/components/kserve/kserve.go
@@ -18,7 +18,7 @@ import (
 
 var (
 	ComponentName          = "kserve"
-	Path                   = deploy.DefaultManifestPath + "/" + ComponentName + "/base"
+	Path                   = deploy.DefaultManifestPath + "/" + ComponentName + "/overlays/odh"
 	DependentComponentName = "odh-model-controller"
 	DependentPath          = deploy.DefaultManifestPath + "/" + DependentComponentName + "/base"
 	ServiceMeshOperator    = "servicemeshoperator"
@@ -53,7 +53,7 @@ func (k *Kserve) OverrideManifests(_ string) error {
 					return err
 				}
 				// If overlay is defined, update paths
-				defaultKustomizePath := "base"
+				defaultKustomizePath := "overlays/odh"
 				if subcomponent.SourcePath != "" {
 					defaultKustomizePath = subcomponent.SourcePath
 				}

--- a/get_all_manifests.sh
+++ b/get_all_manifests.sh
@@ -48,14 +48,7 @@ if [ "$#" -ge 1 ]; then
     done
 fi
 
-# pre-cleanup local env
-rm -fr ./odh-manifests/* ./.odh-manifests-tmp/
-
-mkdir -p ./.odh-manifests-tmp/ ./odh-manifests/
-wget -q -c ${MANIFESTS_TARBALL_URL} -O - | tar -zxv -C ./.odh-manifests-tmp/ --strip-components 1 > /dev/null
-cp -r ./.odh-manifests-tmp/modelmesh-monitoring/ ./odh-manifests
-cp -r ./.odh-manifests-tmp/kserve/ ./odh-manifests
-rm -rf ${MANIFEST_RELEASE}.tar.gz ./.odh-manifests-tmp/
+# R.I.P, odh-manifests
 
 for key in "${!COMPONENT_MANIFESTS[@]}"; do
     echo "Cloning repo ${key}: ${COMPONENT_MANIFESTS[$key]}"

--- a/get_all_manifests.sh
+++ b/get_all_manifests.sh
@@ -9,7 +9,7 @@ MANIFEST_RELEASE="master"
 MANIFESTS_TARBALL_URL="${GITHUB_URL}/${MANIFEST_ORG}/odh-manifests/tarball/${MANIFEST_RELEASE}"
 
 # component: dsp, kserve, dashbaord, cf/ray. in the format of "repo-org:repo-name:branch-name:source-folder:target-folder"
-# TODO: workbench, modelmesh, monitoring, etc
+# TODO: odh-mm-monitoring, etc
 declare -A COMPONENT_MANIFESTS=(
     ["codeflare"]="opendatahub-io:codeflare-operator:main:config:codeflare"
     ["ray"]="opendatahub-io:kuberay:master:ray-operator/config:ray"
@@ -21,6 +21,7 @@ declare -A COMPONENT_MANIFESTS=(
     ["trustyai"]="trustyai-explainability:trustyai-service-operator:release/1.10.2:config:trustyai-service-operator"
     ["model-mesh"]="opendatahub-io:modelmesh-serving:release-0.11.0:config:model-mesh"
     ["odh-model-controller"]="opendatahub-io:odh-model-controller:release-0.11.0:config:odh-model-controller"
+    ["kserve"]="opendatahub-io:kserve:release-v0.11.0:config:kserve"
 )
 
 # Allow overwriting repo using flags component=repo


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- kserve has moved from odh-manifests to kserve repo in OHD
ref: https://github.com/opendatahub-io/opendatahub-operator/issues/579#issuecomment-1773319113
- cleanup download manifests parts

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
