### PR TITLE
feat: adds finalizers to DSC and DSCI

### DIFF
--- a/components/README.md
+++ b/components/README.md
@@ -32,6 +32,7 @@ can be found [here](https://github.com/opendatahub-io/opendatahub-operator/tree/
     ```go
     type ComponentInterface interface {
       ReconcileComponent(cli client.Client, owner metav1.Object, DSCISpec *dsci.DSCInitializationSpec) error
+      Cleanup(cli client.Client, DSCISpec *dsci.DSCInitializationSpec) error
       GetComponentName() string
       GetManagementState() operatorv1.ManagementState
       SetImageParamsMap(imageMap map[string]string) map[string]string

--- a/components/component.go
+++ b/components/component.go
@@ -30,6 +30,11 @@ func (c *Component) GetManagementState() operatorv1.ManagementState {
 	return c.ManagementState
 }
 
+func (c *Component) Cleanup(_ client.Client, _ *dsci.DSCInitializationSpec) error {
+	// noop
+	return nil
+}
+
 // DevFlags defines list of fields that can be used by developers to test customizations. This is not recommended
 // to be used in production environment.
 type DevFlags struct {
@@ -60,6 +65,7 @@ type ManifestsConfig struct {
 
 type ComponentInterface interface {
 	ReconcileComponent(cli client.Client, owner metav1.Object, DSCISpec *dsci.DSCInitializationSpec) error
+	Cleanup(cli client.Client, DSCISpec *dsci.DSCInitializationSpec) error
 	GetComponentName() string
 	GetManagementState() operatorv1.ManagementState
 	SetImageParamsMap(imageMap map[string]string) map[string]string

--- a/controllers/dscinitialization/dscinitialization_controller.go
+++ b/controllers/dscinitialization/dscinitialization_controller.go
@@ -21,28 +21,32 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/upgrade"
 	"path/filepath"
 
+	"github.com/go-logr/logr"
 	operatorv1 "github.com/openshift/api/operator/v1"
 
-	"github.com/go-logr/logr"
 	dsci "github.com/opendatahub-io/opendatahub-operator/v2/apis/dscinitialization/v1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/controllers/status"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/deploy"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/upgrade"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	netv1 "k8s.io/api/networking/v1"
 	authv1 "k8s.io/api/rbac/v1"
-	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/retry"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+const (
+	finalizerName = "dscinitialization.opendatahub.io/finalizer"
 )
 
 // DSCInitializationReconciler reconciles a DSCInitialization object.
@@ -63,36 +67,47 @@ type DSCInitializationReconciler struct {
 func (r *DSCInitializationReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	r.Log.Info("Reconciling DSCInitialization.", "DSCInitialization", req.Namespace, "Request.Name", req.Name)
 
-	instance := &dsci.DSCInitialization{}
-	// First check if instance is being deleted, return
-	if instance.GetDeletionTimestamp() != nil {
-		return ctrl.Result{}, nil
-	}
-
-	// Second check if instance exists, return
-	err := r.Client.Get(ctx, req.NamespacedName, instance)
-	if err != nil {
-		if apierrs.IsNotFound(err) {
-			// DSCInitialization instance not found
-			return ctrl.Result{}, nil
-		}
+	instances := &dsci.DSCInitializationList{}
+	if err := r.Client.List(ctx, instances); err != nil {
 		r.Log.Error(err, "Failed to retrieve DSCInitialization resource.", "DSCInitialization", req.Namespace, "Request.Name", req.Name)
-		r.Recorder.Eventf(instance, corev1.EventTypeWarning, "DSCInitializationReconcileError", "Failed to retrieve DSCInitialization instance")
+		r.Recorder.Eventf(instances, corev1.EventTypeWarning, "DSCInitializationReconcileError", "Failed to retrieve DSCInitialization instance")
 		return ctrl.Result{}, err
 	}
 
-	// Last check if multiple instances of DSCInitialization exist
-	instanceList := &dsci.DSCInitializationList{}
-	err = r.Client.List(ctx, instanceList)
-	if err != nil {
-		return ctrl.Result{}, err
-	}
-
-	if len(instanceList.Items) > 1 {
+	if len(instances.Items) > 1 {
 		message := fmt.Sprintf("only one instance of DSCInitialization object is allowed. Update existing instance on namespace %s and name %s", req.Namespace, req.Name)
+
 		return ctrl.Result{}, errors.New(message)
 	}
 
+	if len(instances.Items) == 0 {
+		return ctrl.Result{}, nil
+	}
+
+	instance := &instances.Items[0]
+
+	if instance.ObjectMeta.DeletionTimestamp.IsZero() {
+		if !controllerutil.ContainsFinalizer(instance, finalizerName) {
+			r.Log.Info("Adding finalizer for DSCInitialization", "name", instance.Name, "namespace", instance.Namespace, "finalizer", finalizerName)
+			controllerutil.AddFinalizer(instance, finalizerName)
+			if err := r.Update(ctx, instance); err != nil {
+				return ctrl.Result{}, err
+			}
+		}
+	} else {
+		r.Log.Info("Finalization DSCInitialization start deleting instance", "name", instance.Name, "namespace", instance.Namespace, "finalizer", finalizerName)
+		// Add cleanup logic here
+		if controllerutil.ContainsFinalizer(instance, finalizerName) {
+			controllerutil.RemoveFinalizer(instance, finalizerName)
+			if err := r.Update(ctx, instance); err != nil {
+				return ctrl.Result{}, err
+			}
+		}
+
+		return ctrl.Result{}, nil
+	}
+
+	var err error
 	// Start reconciling
 	if instance.Status.Conditions == nil {
 		reason := status.ReconcileInit


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

### **Finalizer Implementation for DSC and DSCI**
- **Based on:** PRs #301 and #605.
- Provides a default no-op `Cleanup` method for each component.
- Utilizes `controllerutil` methods for finalizer management.

### **Additional Changes:**
- Optimizes the DSCI controller: Now uses the `List` operation directly, mirroring the DSC controller's behavior and eliminating the previous `Get` then `List` approach.

## How Has This Been Tested?

In prow we trust.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
