### PR TITLE
update(dsc): change condition to check if component is ready to serve

### DIFF
--- a/components/component.go
+++ b/components/component.go
@@ -1,10 +1,18 @@
 package components
 
 import (
+	"context"
+	"fmt"
+
 	dsci "github.com/opendatahub-io/opendatahub-operator/v2/apis/dscinitialization/v1"
 	operatorv1 "github.com/openshift/api/operator/v1"
+	errors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"time"
 )
 
 type Component struct {
@@ -70,8 +78,39 @@ type ComponentInterface interface {
 	GetManagementState() operatorv1.ManagementState
 	SetImageParamsMap(imageMap map[string]string) map[string]string
 	OverrideManifests(platform string) error
+	WaitForDeploymentAvailable(ctx context.Context, r *rest.Config, c string, n string, i int, t int) error
 }
 
 func (c *Component) SetImageParamsMap(imageMap map[string]string) map[string]string {
 	return imageMap
+}
+
+func (c *Component) WaitForDeploymentAvailable(ctx context.Context, restConfig *rest.Config, componentName string, namespace string, interval int, timeout int) error {
+	resourceInterval := time.Duration(interval) * time.Second
+	resourceTimeout := time.Duration(timeout) * time.Minute
+	return wait.PollUntilContextTimeout(context.TODO(), resourceInterval, resourceTimeout, true, func(ctx context.Context) (bool, error) {
+		clientset, err := kubernetes.NewForConfig(restConfig)
+		if err != nil {
+			return false, fmt.Errorf("error getting client %v", err)
+		}
+		componentDeploymentList, err := clientset.AppsV1().Deployments(namespace).List(context.TODO(), metav1.ListOptions{
+			LabelSelector: "app.opendatahub.io/" + componentName,
+		})
+		if err != nil {
+			if errors.IsNotFound(err) {
+				return false, nil
+			}
+		}
+		isReady := false
+		if len(componentDeploymentList.Items) != 0 {
+			for _, deployment := range componentDeploymentList.Items {
+				if deployment.Status.ReadyReplicas == deployment.Status.Replicas {
+					isReady = true
+				} else {
+					isReady = false
+				}
+			}
+		}
+		return isReady, nil
+	})
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
ref: https://issues.redhat.com/browse/RHOAIENG-408
update(dsc): change condition to check if component is ready to serve 
   - this will make the "DSC" status as "Progressing" till all components are done to set to "Ready"
    - for any enabled component, it checks if the deployment is done
      to set:
            -  Message to "component ready to serve"
            -  Status to "True"
      from:
            - Meesage "Component reconciled successfully"
            - Status "Unknown"  
   - remove return type for reportError()
   - set disabled component init Status from unknown to false
    


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
local build:  quay.io/wenzhou/opendatahub-operator-catalog:v2.10.645-2
enable dashboard only
![Screenshot from 2023-10-31 09-30-08](https://github.com/opendatahub-io/opendatahub-operator/assets/915053/8b7eddb3-b301-4a90-8456-25583555ac2f)
wait for a while
![Screenshot from 2023-10-31 09-30-56](https://github.com/opendatahub-io/opendatahub-operator/assets/915053/c8019305-6f0a-4555-aa35-e253489b06e2)

enabled workbench
![Screenshot from 2023-10-31 11-02-15](https://github.com/opendatahub-io/opendatahub-operator/assets/915053/95f5979a-6fc0-4ac4-92ae-0e63a3334214)

wait for a while
![Screenshot from 2023-10-31 11-02-47](https://github.com/opendatahub-io/opendatahub-operator/assets/915053/2dd31976-efc2-4666-a94c-912ef318d2f2)


## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
