### PR TITLE
backport(workbench): support images in two path for downstream

### DIFF
--- a/components/workbenches/workbenches.go
+++ b/components/workbenches/workbenches.go
@@ -20,7 +20,7 @@ var (
 	DependentComponentName = "notebooks"
 	// manifests for nbc in ODH and downstream + downstream use it for imageparams
 	notebookControllerPath = deploy.DefaultManifestPath + "/odh-notebook-controller/odh-notebook-controller/base"
-	// manifests for ODH nbc
+	// manifests for ODH nbc + downstream use it for imageparams
 	kfnotebookControllerPath    = deploy.DefaultManifestPath + "/odh-notebook-controller/kf-notebook-controller/overlays/openshift"
 	notebookImagesPath          = deploy.DefaultManifestPath + "/notebooks/overlays/additional"
 	notebookImagesPathSupported = deploy.DefaultManifestPath + "/jupyterhub/notebook-images/overlays/additional"
@@ -134,7 +134,12 @@ func (w *Workbenches) ReconcileComponent(cli client.Client, owner metav1.Object,
 	if enabled {
 		if dscispec.DevFlags.ManifestsUri == "" && len(w.DevFlags.Manifests) == 0 {
 			if platform == deploy.ManagedRhods || platform == deploy.SelfManagedRhods {
+				// for kf-notebook-controller image
 				if err := deploy.ApplyParams(notebookControllerPath, w.SetImageParamsMap(imageParamMap), false); err != nil {
+					return err
+				}
+				// for odh-notebook-controller image
+				if err := deploy.ApplyParams(kfnotebookControllerPath, w.SetImageParamsMap(imageParamMap), false); err != nil {
 					return err
 				}
 			}
@@ -142,7 +147,6 @@ func (w *Workbenches) ReconcileComponent(cli client.Client, owner metav1.Object,
 	}
 
 	if platform == deploy.OpenDataHub || platform == "" {
-		// only for ODH after transit to kubeflow repo
 		err = deploy.DeployManifestsFromPath(cli, owner,
 			kfnotebookControllerPath,
 			dscispec.ApplicationsNamespace,
@@ -158,7 +162,11 @@ func (w *Workbenches) ReconcileComponent(cli client.Client, owner metav1.Object,
 			enabled)
 		return err
 	} else {
-		err = deploy.DeployManifestsFromPath(cli, owner, notebookImagesPathSupported, dscispec.ApplicationsNamespace, ComponentName, enabled)
+		err = deploy.DeployManifestsFromPath(cli, owner,
+			notebookImagesPathSupported,
+			dscispec.ApplicationsNamespace,
+			ComponentName,
+			enabled)
 		return err
 	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
relate to https://github.com/red-hat-data-services/kubeflow/pull/29
ref: https://github.com/opendatahub-io/opendatahub-operator/issues/579

**this is backport from downstream logic and only add for downstream logic  which is already in place**

## Description
<!--- Describe your changes in detail -->


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

cherrypick kubeflow pr 29
local build:  quay.io/wenzhou/opendatahub-operator:dev-2.10.579-29
check params.env

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
