### PR TITLE
Debug and fix e2e tests in CI

### DIFF
--- a/controllers/datasciencecluster/datasciencecluster_controller.go
+++ b/controllers/datasciencecluster/datasciencecluster_controller.go
@@ -107,15 +107,6 @@ func (r *DataScienceClusterReconciler) Reconcile(ctx context.Context, req ctrl.R
 
 	instance := &instances.Items[0]
 
-	if instance.GetDeletionTimestamp() != nil {
-		r.Log.Info("DataScienceCluster instance is deleted.", "name", instance.Name)
-		if upgrade.HasDeleteConfigMap(r.Client) {
-			// if delete configmap exists, requeue the request to handle operator uninstall
-			return reconcile.Result{Requeue: true}, nil
-		}
-		return ctrl.Result{}, nil
-	}
-
 	var err error
 
 	// Verify a valid DSCInitialization instance is created
@@ -175,7 +166,10 @@ func (r *DataScienceClusterReconciler) Reconcile(ctx context.Context, req ctrl.R
 				return ctrl.Result{}, err
 			}
 		}
-
+		if upgrade.HasDeleteConfigMap(r.Client) {
+			// if delete configmap exists, requeue the request to handle operator uninstall
+			return reconcile.Result{Requeue: true}, nil
+		}
 		return ctrl.Result{}, nil
 	}
 

--- a/controllers/dscinitialization/dscinitialization_controller.go
+++ b/controllers/dscinitialization/dscinitialization_controller.go
@@ -29,8 +29,6 @@ import (
 	dsci "github.com/opendatahub-io/opendatahub-operator/v2/apis/dscinitialization/v1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/controllers/status"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/deploy"
-	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/upgrade"
-
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	netv1 "k8s.io/api/networking/v1"
@@ -136,13 +134,6 @@ func (r *DSCInitializationReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	platform, err := deploy.GetPlatform(r.Client)
 	if err != nil {
 		r.Log.Error(err, "Failed to determine platform (managed vs self-managed)")
-		return reconcile.Result{}, err
-	}
-
-	// Apply update from legacy operator
-	// TODO: Update upgrade logic to get components through KfDef
-	if err = upgrade.UpdateFromLegacyVersion(r.Client, platform); err != nil {
-		r.Log.Error(err, "unable to update from legacy operator version")
 		return reconcile.Result{}, err
 	}
 

--- a/pkg/deploy/deploy.go
+++ b/pkg/deploy/deploy.go
@@ -233,15 +233,8 @@ func manageResource(ctx context.Context, cli client.Client, obj *unstructured.Un
 			}
 		}
 
-		existingOwnerReferences := found.GetOwnerReferences()
-		if existingOwnerReferences == nil {
+		if obj.GetOwnerReferences() == nil {
 			return cli.Delete(ctx, found)
-		} else if len(existingOwnerReferences) > 0 {
-			for _, owner := range existingOwnerReferences {
-				if owner.Kind != "DataScienceCluster" && owner.Kind != "DataScienceInitialization" {
-					return nil
-				}
-			}
 		}
 
 		found.SetOwnerReferences([]metav1.OwnerReference{})
@@ -250,8 +243,6 @@ func manageResource(ctx context.Context, cli client.Client, obj *unstructured.Un
 			return err
 		}
 
-		// Patch the resources when ownerreferences are set to nil.
-		// This Patch request is needed to ensure, DSC ownerreference is removed from a resource before deleting it.
 		err = cli.Patch(ctx, found, client.RawPatch(types.ApplyPatchType, data), client.ForceOwnership, client.FieldOwner(owner.GetName()))
 		if err != nil {
 			return err

--- a/pkg/deploy/deploy.go
+++ b/pkg/deploy/deploy.go
@@ -233,8 +233,15 @@ func manageResource(ctx context.Context, cli client.Client, obj *unstructured.Un
 			}
 		}
 
-		if obj.GetOwnerReferences() == nil {
+		existingOwnerReferences := found.GetOwnerReferences()
+		if existingOwnerReferences == nil {
 			return cli.Delete(ctx, found)
+		} else if len(existingOwnerReferences) > 0 {
+			for _, owner := range existingOwnerReferences {
+				if owner.Kind != "DataScienceCluster" && owner.Kind != "DataScienceInitialization" {
+					return nil
+				}
+			}
 		}
 
 		found.SetOwnerReferences([]metav1.OwnerReference{})
@@ -243,6 +250,8 @@ func manageResource(ctx context.Context, cli client.Client, obj *unstructured.Un
 			return err
 		}
 
+		// Patch the resources when ownerreferences are set to nil.
+		// This Patch request is needed to ensure, DSC ownerreference is removed from a resource before deleting it.
 		err = cli.Patch(ctx, found, client.RawPatch(types.ApplyPatchType, data), client.ForceOwnership, client.FieldOwner(owner.GetName()))
 		if err != nil {
 			return err

--- a/pkg/upgrade/upgrade.go
+++ b/pkg/upgrade/upgrade.go
@@ -139,7 +139,7 @@ func HasDeleteConfigMap(c client.Client) bool {
 
 // createDefaultDSC creates a default instance of DSC.
 // Note: When the platform is not Managed, and a DSC instance already exists, the function doesn't re-create/update the resource.
-func createDefaultDSC(cli client.Client, platform deploy.Platform) error {
+func CreateDefaultDSC(cli client.Client, platform deploy.Platform) error {
 	releaseDataScienceCluster := &dsc.DataScienceCluster{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "DataScienceCluster",
@@ -204,7 +204,7 @@ func createDefaultDSC(cli client.Client, platform deploy.Platform) error {
 func UpdateFromLegacyVersion(cli client.Client, platform deploy.Platform) error {
 	// If platform is Managed, remove Kfdefs and create default dsc
 	if platform == deploy.ManagedRhods {
-		err := createDefaultDSC(cli, platform)
+		err := CreateDefaultDSC(cli, platform)
 		if err != nil {
 			return err
 		}
@@ -216,37 +216,21 @@ func UpdateFromLegacyVersion(cli client.Client, platform deploy.Platform) error 
 		return nil
 	}
 
-	// If KfDef CRD is not found, we see it as a cluster not pre-installed v1 operator	// Check if kfdef are deployed
-	kfdefCrd := &apiextv1.CustomResourceDefinition{}
-	err := cli.Get(context.TODO(), client.ObjectKey{Name: "kfdefs.kfdef.apps.kubeflow.org"}, kfdefCrd)
-	if err != nil {
-		if apierrs.IsNotFound(err) {
-			// If no Crd found, return, since its a new Installation
-			return nil
-		} else {
-			return fmt.Errorf("error retrieving kfdef CRD : %v", err)
-		}
-	}
-
-	// If KfDef Instances found, and no DSC instances are found in Self-managed, that means this is an upgrade path from
-	// legacy version. Create a default DSC instance
-	kfDefList := &kfdefv1.KfDefList{}
-	err = cli.List(context.TODO(), kfDefList)
-	if err != nil {
-		if apierrs.IsNotFound(err) {
-			// If no KfDefs, do nothing and return
-			return nil
-		} else {
-			return fmt.Errorf("error getting list of kfdefs: %v", err)
-		}
-	}
-	if len(kfDefList.Items) > 0 {
-		err := createDefaultDSC(cli, platform)
+	if platform == deploy.SelfManagedRhods {
+		kfDefList, err := getKfDefInstances(cli)
 		if err != nil {
-			return err
+			return fmt.Errorf("error getting kfdef instances: %v", err)
 		}
+
+		if len(kfDefList.Items) > 0 {
+			err := CreateDefaultDSC(cli, platform)
+			if err != nil {
+				return err
+			}
+		}
+		return err
 	}
-	return err
+	return nil
 }
 
 func GetOperatorNamespace() (string, error) {
@@ -261,28 +245,12 @@ func GetOperatorNamespace() (string, error) {
 
 func RemoveKfDefInstances(cli client.Client, platform deploy.Platform) error {
 	// Check if kfdef are deployed
-	kfdefCrd := &apiextv1.CustomResourceDefinition{}
-
-	err := cli.Get(context.TODO(), client.ObjectKey{Name: "kfdefs.kfdef.apps.kubeflow.org"}, kfdefCrd)
+	expectedKfDefList, err := getKfDefInstances(cli)
 	if err != nil {
-		if apierrs.IsNotFound(err) {
-			// If no Crd found, return, since its a new Installation
-			return nil
-		} else {
-			return fmt.Errorf("error retrieving kfdef CRD : %v", err)
-		}
-	} else {
-		expectedKfDefList := &kfdefv1.KfDefList{}
-		err := cli.List(context.TODO(), expectedKfDefList)
-		if err != nil {
-			if apierrs.IsNotFound(err) {
-				// If no KfDefs, do nothing and return
-				return nil
-			} else {
-				return fmt.Errorf("error getting list of kfdefs: %v", err)
-			}
-		}
-		// Delete kfdefs
+		return err
+	}
+	// Delete kfdefs
+	if len(expectedKfDefList.Items) > 0 {
 		for _, kfdef := range expectedKfDefList.Items {
 			// Remove finalizer
 			updatedKfDef := &kfdef
@@ -297,6 +265,7 @@ func RemoveKfDefInstances(cli client.Client, platform deploy.Platform) error {
 			}
 		}
 	}
+
 	return nil
 }
 
@@ -349,4 +318,32 @@ func getClusterServiceVersion(cfg *rest.Config, watchNameSpace string) (*ofapi.C
 		}
 	}
 	return nil, nil
+}
+
+func getKfDefInstances(c client.Client) (*kfdefv1.KfDefList, error) {
+	// If KfDef CRD is not found, we see it as a cluster not pre-installed v1 operator	// Check if kfdef are deployed
+	kfdefCrd := &apiextv1.CustomResourceDefinition{}
+	err := c.Get(context.TODO(), client.ObjectKey{Name: "kfdefs.kfdef.apps.kubeflow.org"}, kfdefCrd)
+	if err != nil {
+		if apierrs.IsNotFound(err) {
+			// If no Crd found, return, since its a new Installation
+			return nil, nil
+		} else {
+			return nil, fmt.Errorf("error retrieving kfdef CRD : %v", err)
+		}
+	}
+
+	// If KfDef Instances found, and no DSC instances are found in Self-managed, that means this is an upgrade path from
+	// legacy version. Create a default DSC instance
+	kfDefList := &kfdefv1.KfDefList{}
+	err = c.List(context.TODO(), kfDefList)
+	if err != nil {
+		if apierrs.IsNotFound(err) {
+			// If no KfDefs, do nothing and return
+			return nil, nil
+		} else {
+			return nil, fmt.Errorf("error getting list of kfdefs: %v", err)
+		}
+	}
+	return kfDefList, nil
 }

--- a/tests/e2e/dsc_creation_test.go
+++ b/tests/e2e/dsc_creation_test.go
@@ -194,9 +194,7 @@ func (tc *testContext) testAllApplicationCreation(t *testing.T) error {
 		if tc.testDsc.Spec.Components.CodeFlare.ManagementState == operatorv1.Managed {
 			if err != nil {
 				// dependent operator error, as expected
-				if strings.Contains(err.Error(), "Please install the operator before enabling component") {
-					t.Logf("expected error: %v", err.Error())
-				} else {
+				{
 					require.NoError(t, err, "error validating application %v when enabled", tc.testDsc.Spec.Components.CodeFlare.GetComponentName())
 				}
 			}

--- a/tests/e2e/dsc_deletion_test.go
+++ b/tests/e2e/dsc_deletion_test.go
@@ -57,7 +57,7 @@ func (tc *testContext) testApplicationDeletion(component components.ComponentInt
 
 	if err := wait.PollUntilContextTimeout(tc.ctx, tc.resourceRetryInterval, tc.resourceCreationTimeout, false, func(ctx context.Context) (done bool, err error) {
 		appList, err := tc.kubeClient.AppsV1().Deployments(tc.applicationsNamespace).List(ctx, metav1.ListOptions{
-			LabelSelector: "app.kubernetes.io/part-of=" + component.GetComponentName(),
+			LabelSelector: "app.opendatahub.io/" + component.GetComponentName(),
 		})
 		if err != nil {
 			log.Printf("error listing component deployments :%v. Trying again...", err)


### PR DESCRIPTION
This PR introduces following changes: 
- Updated tests to use `app.opendatahub.io` label instead of `app.kubernetes.io/part-of` label to get component deployments.  The reason we moved to our custom labels instead of `app.kubernetes.io/part-of`, is most manifests use this label as part of deployments and cannot be used to differentiate between odh and non-odh resources.
- Codeflare manifests have changed their default path, which was not updated in the codeflare component in operator. This resulted codeflare deployment failures
- Move creation of default DSC out of reconcile. As part of upgrade logic, we introduced creation of default DSC in reconcile function. This caused recreation of DSC instance after it was removed. Moved the default dsc creation out of reconcile. Also for ODH deployment, no default DSC would be created.
- Updated deployment logic to only remove resources that are owned by operator or those that do not have any ownerref.
## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
- Test output is posted below
## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
