### PR TITLE
disable: modelmesh-monitoring

### DIFF
--- a/components/modelmeshserving/modelmeshserving.go
+++ b/components/modelmeshserving/modelmeshserving.go
@@ -16,9 +16,9 @@ import (
 )
 
 var (
-	ComponentName          = "model-mesh"
-	Path                   = deploy.DefaultManifestPath + "/" + ComponentName + "/overlays/odh"
-	monitoringPath         = deploy.DefaultManifestPath + "/" + "modelmesh-monitoring/base"
+	ComponentName = "model-mesh"
+	Path          = deploy.DefaultManifestPath + "/" + ComponentName + "/overlays/odh"
+	// monitoringPath         = deploy.DefaultManifestPath + "/" + "modelmesh-monitoring/base"
 	DependentComponentName = "odh-model-controller"
 	DependentPath          = deploy.DefaultManifestPath + "/" + DependentComponentName + "/base"
 )
@@ -139,15 +139,15 @@ func (m *ModelMeshServing) ReconcileComponent(cli client.Client, owner metav1.Ob
 	if err != nil {
 		return err
 	}
-	var monitoringNamespace string
-	if dscInit.Spec.Monitoring.Namespace != "" {
-		monitoringNamespace = dscInit.Spec.Monitoring.Namespace
-	} else {
-		monitoringNamespace = dscispec.ApplicationsNamespace
-	}
+	// var monitoringNamespace string
+	// if dscInit.Spec.Monitoring.Namespace != "" {
+	// 	monitoringNamespace = dscInit.Spec.Monitoring.Namespace
+	// } else {
+	// 	monitoringNamespace = dscispec.ApplicationsNamespace
+	// }
 
-	// If modelmesh is deployed successfully, deploy modelmesh-monitoring
-	err = deploy.DeployManifestsFromPath(cli, owner, monitoringPath, monitoringNamespace, ComponentName, enabled)
+	//// If modelmesh is deployed successfully, deploy modelmesh-monitoring
+	// err = deploy.DeployManifestsFromPath(cli, owner, monitoringPath, monitoringNamespace, ComponentName, enabled)
 
 	return err
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
https://redhat-internal.slack.com/archives/C05NXTEHLGY/p1698757907709679?thread_ts=1698263859.245689&cid=C05NXTEHLGY
 no need in ODH any more

think to just comment out first
and will removed the logic totally when downstream is in 2.5
so we do not get confused why sync code


## Description
<!--- Describe your changes in detail -->
unless we figure out where to get the modelmesh monitoring manifests from ODH, we cannot have the logic in modelmesh it will cause operator reconcile

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
