### PR TITLE
Report error in status if more than one DataScienceCluster installed

### DIFF
--- a/controllers/datasciencecluster/datasciencecluster_controller.go
+++ b/controllers/datasciencecluster/datasciencecluster_controller.go
@@ -102,7 +102,12 @@ func (r *DataScienceClusterReconciler) Reconcile(ctx context.Context, req ctrl.R
 	if len(instances.Items) > 1 {
 		message := fmt.Sprintf("only one instance of DataScienceCluster object is allowed. Update existing instance %s", req.Name)
 		err := errors.New(message)
-		_ = r.reportError(err, &instances.Items[0], message)
+		_ = r.reportError(err, instance, message)
+
+		_, _ = r.updateStatus(ctx, instance, func(saved *dsc.DataScienceCluster) {
+			status.SetErrorCondition(&saved.Status.Conditions, status.DuplicateDataScienceCluster, message)
+			saved.Status.Phase = status.PhaseError
+		})
 
 		return ctrl.Result{}, err
 	}

--- a/controllers/datasciencecluster/datasciencecluster_controller.go
+++ b/controllers/datasciencecluster/datasciencecluster_controller.go
@@ -86,14 +86,6 @@ func (r *DataScienceClusterReconciler) Reconcile(ctx context.Context, req ctrl.R
 		return ctrl.Result{}, err
 	}
 
-	if len(instances.Items) > 1 {
-		message := fmt.Sprintf("only one instance of DataScienceCluster object is allowed. Update existing instance %s", req.Name)
-		err := errors.New(message)
-		_ = r.reportError(err, &instances.Items[0], message)
-
-		return ctrl.Result{}, err
-	}
-
 	if len(instances.Items) == 0 {
 		// Request object not found, could have been deleted after reconcile request.
 		// Owned objects are automatically garbage collected. For additional cleanup logic use operatorUninstall function.
@@ -106,6 +98,14 @@ func (r *DataScienceClusterReconciler) Reconcile(ctx context.Context, req ctrl.R
 	}
 
 	instance := &instances.Items[0]
+
+	if len(instances.Items) > 1 {
+		message := fmt.Sprintf("only one instance of DataScienceCluster object is allowed. Update existing instance %s", req.Name)
+		err := errors.New(message)
+		_ = r.reportError(err, &instances.Items[0], message)
+
+		return ctrl.Result{}, err
+	}
 
 	var err error
 

--- a/controllers/datasciencecluster/datasciencecluster_controller.go
+++ b/controllers/datasciencecluster/datasciencecluster_controller.go
@@ -142,7 +142,12 @@ func (r *DataScienceClusterReconciler) Reconcile(ctx context.Context, req ctrl.R
 		dscInitializationSpec := dsciInstances.Items[0].Spec
 		dscInitializationSpec.DeepCopyInto(r.DataScienceCluster.DSCISpec)
 	default:
-		return ctrl.Result{}, errors.New("only one instance of DSCInitialization object is allowed")
+		message := "only one instance of DSCInitialization object is allowed"
+		_, _ = r.updateStatus(ctx, instance, func(saved *dsc.DataScienceCluster) {
+			status.SetErrorCondition(&saved.Status.Conditions, status.DuplicateDSCInitialization, message)
+			saved.Status.Phase = status.PhaseError
+		})
+		return ctrl.Result{}, errors.New(message)
 	}
 
 	allComponents, err := getAllComponents(&instance.Spec.Components)

--- a/controllers/dscinitialization/dscinitialization_controller.go
+++ b/controllers/dscinitialization/dscinitialization_controller.go
@@ -82,6 +82,11 @@ func (r *DSCInitializationReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	if len(instances.Items) > 1 {
 		message := fmt.Sprintf("only one instance of DSCInitialization object is allowed. Update existing instance name %s", req.Name)
 
+		_, _ = r.updateStatus(ctx, instance, func(saved *dsci.DSCInitialization) {
+			status.SetErrorCondition(&saved.Status.Conditions, status.DuplicateDSCInitialization, message)
+			saved.Status.Phase = status.PhaseError
+		})
+
 		return ctrl.Result{}, errors.New(message)
 	}
 

--- a/controllers/dscinitialization/dscinitialization_controller.go
+++ b/controllers/dscinitialization/dscinitialization_controller.go
@@ -73,17 +73,17 @@ func (r *DSCInitializationReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		return ctrl.Result{}, err
 	}
 
-	if len(instances.Items) > 1 {
-		message := fmt.Sprintf("only one instance of DSCInitialization object is allowed. Update existing instance name %s", req.Name)
-
-		return ctrl.Result{}, errors.New(message)
-	}
-
 	if len(instances.Items) == 0 {
 		return ctrl.Result{}, nil
 	}
 
 	instance := &instances.Items[0]
+
+	if len(instances.Items) > 1 {
+		message := fmt.Sprintf("only one instance of DSCInitialization object is allowed. Update existing instance name %s", req.Name)
+
+		return ctrl.Result{}, errors.New(message)
+	}
 
 	if instance.ObjectMeta.DeletionTimestamp.IsZero() {
 		if !controllerutil.ContainsFinalizer(instance, finalizerName) {

--- a/controllers/status/status.go
+++ b/controllers/status/status.go
@@ -60,6 +60,7 @@ const (
 	ReconcileCompleted                    = "ReconcileCompleted"
 	ReconcileCompletedWithComponentErrors = "ReconcileCompletedWithComponentErrors"
 	ReconcileCompletedMessage             = "Reconcile completed successfully"
+	DuplicateDataScienceCluster           = "DuplicateDataScienceCluster"
 
 	// ConditionReconcileComplete represents extra Condition Type, used by .Condition.Type.
 	ConditionReconcileComplete conditionsv1.ConditionType = "ReconcileComplete"

--- a/controllers/status/status.go
+++ b/controllers/status/status.go
@@ -61,6 +61,7 @@ const (
 	ReconcileCompletedWithComponentErrors = "ReconcileCompletedWithComponentErrors"
 	ReconcileCompletedMessage             = "Reconcile completed successfully"
 	DuplicateDataScienceCluster           = "DuplicateDataScienceCluster"
+	DuplicateDSCInitialization            = "DuplicateDSCInitialization"
 
 	// ConditionReconcileComplete represents extra Condition Type, used by .Condition.Type.
 	ConditionReconcileComplete conditionsv1.ConditionType = "ReconcileComplete"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Report error in status if more than one DataScienceCluster installed

V2
- update `phase` to `phaseError` as well
- add reporting for DSCInitialization

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?

- Installed 2 DSCs in the same namespace with different name
- Checked `oc describe datasciencecluster.datasciencecluster.opendatahub.io/<NAME>` for both clusters

Both clusters report like 

```
Status:
  Conditions:
    Last Heartbeat Time:   2023-11-01T08:33:42Z
    Last Transition Time:  2023-11-01T08:32:20Z
    Message:               only one instance of DataScienceCluster object is allowed. Update existing instance on namespace  and name ykaliuta.dsc2
    Reason:                DuplicateDataScienceCluster
    Status:                False
    Type:                  ReconcileComplete
    Last Heartbeat Time:   2023-11-01T08:33:42Z
    Last Transition Time:  2023-11-01T08:32:20Z
    Message:               only one instance of DataScienceCluster object is allowed. Update existing instance on namespace  and name ykaliuta.dsc2
    Reason:                DuplicateDataScienceCluster
    Status:                False
    Type:                  Available
    Last Heartbeat Time:   2023-11-01T08:33:42Z
    Last Transition Time:  2023-11-01T08:31:39Z
    Message:               only one instance of DataScienceCluster object is allowed. Update existing instance on namespace  and name ykaliuta.dsc2
    Reason:                DuplicateDataScienceCluster
    Status:                False
    Type:                  Progressing
    Last Heartbeat Time:   2023-11-01T08:33:42Z
    Last Transition Time:  2023-11-01T08:32:20Z
    Message:               only one instance of DataScienceCluster object is allowed. Update existing instance on namespace  and name ykaliuta.dsc2
    Reason:                DuplicateDataScienceCluster
    Status:                True
    Type:                  Degraded
    Last Heartbeat Time:   2023-11-01T08:33:42Z
    Last Transition Time:  2023-11-01T08:32:20Z
    Message:               only one instance of DataScienceCluster object is allowed. Update existing instance on namespace  and name ykaliuta.dsc2
    Reason:                DuplicateDataScienceCluster
    Status:                Unknown
    Type:                  Upgradeable
    Last Heartbeat Time:   2023-11-01T08:32:12Z
    Last Transition Time:  2023-11-01T08:32:12Z
    Message:               Component reconciled successfully
    Reason:                ReconcileCompleted
    Status:                True
    Type:                  workbenchesReady
```

For DSCInitialization checked both DataScinceCluster:

```

  status:
    conditions:
    - lastHeartbeatTime: "2023-11-01T20:26:35Z"
      lastTransitionTime: "2023-11-01T20:26:14Z"
      message: only one instance of DSCInitialization object is allowed
      reason: DuplicateDSCInitialization
      status: "False"
      type: ReconcileComplete
    - lastHeartbeatTime: "2023-11-01T20:26:35Z"
      lastTransitionTime: "2023-11-01T20:26:14Z"
      message: only one instance of DSCInitialization object is allowed
      reason: DuplicateDSCInitialization
      status: "False"
      type: Available
    - lastHeartbeatTime: "2023-11-01T20:26:35Z"
      lastTransitionTime: "2023-11-01T20:26:14Z"
      message: only one instance of DSCInitialization object is allowed
      reason: DuplicateDSCInitialization
      status: "False"
      type: Progressing
    - lastHeartbeatTime: "2023-11-01T20:26:35Z"
      lastTransitionTime: "2023-11-01T20:26:14Z"
      message: only one instance of DSCInitialization object is allowed
      reason: DuplicateDSCInitialization
      status: "True"
      type: Degraded
    - lastHeartbeatTime: "2023-11-01T20:26:35Z"
      lastTransitionTime: "2023-11-01T20:26:14Z"
      message: only one instance of DSCInitialization object is allowed
      reason: DuplicateDSCInitialization
      status: Unknown
      type: Upgradeable
    phase: Error
```

and DSCIinitialization:

```status:
  conditions:
  - lastHeartbeatTime: "2023-11-01T20:25:08Z"
    lastTransitionTime: "2023-11-01T20:23:46Z"
    message: only one instance of DSCInitialization object is allowed. Update existing
      instance name new
    reason: DuplicateDSCInitialization
    status: "False"
    type: ReconcileComplete
  - lastHeartbeatTime: "2023-11-01T20:25:08Z"
    lastTransitionTime: "2023-11-01T20:23:46Z"
    message: only one instance of DSCInitialization object is allowed. Update existing
      instance name new
    reason: DuplicateDSCInitialization
    status: "False"
    type: Available
  - lastHeartbeatTime: "2023-11-01T20:25:08Z"
    lastTransitionTime: "2023-11-01T20:19:40Z"
    message: only one instance of DSCInitialization object is allowed. Update existing
      instance name new
    reason: DuplicateDSCInitialization
    status: "False"
    type: Progressing
  - lastHeartbeatTime: "2023-11-01T20:25:08Z"
    lastTransitionTime: "2023-11-01T20:23:46Z"
    message: only one instance of DSCInitialization object is allowed. Update existing
      instance name new
    reason: DuplicateDSCInitialization
    status: "True"
    type: Degraded
  - lastHeartbeatTime: "2023-11-01T20:25:08Z"
    lastTransitionTime: "2023-11-01T20:23:46Z"
    message: only one instance of DSCInitialization object is allowed. Update existing
      instance name new
    reason: DuplicateDSCInitialization
    status: Unknown
    type: Upgradeable
  phase: Error
```


<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
