### PR TITLE
chore(gh): configures linter to reference go.mod for Go version

### DIFF
--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -10,15 +10,15 @@ jobs:
     name: golangci-lint
     runs-on: ubuntu-latest
     env:
-      REPOSITORY: ${{ github.repository }}
+      REPOSITORY: go/src/github.com/${{ github.repository }}
     steps:
+      - uses: actions/checkout@v4
+        with:
+          path: ${{ env.REPOSITORY }}
       - name: Set up Go env
         uses: actions/setup-go@v4
         with:
-          go-version: 1.18
-      - uses: actions/checkout@v4
-        with:
-          path: go/src/github.com/${{ env.REPOSITORY }}
+          go-version-file: ${{ env.REPOSITORY }}/go.mod
       - name: Set $GOPATH
         run: |
           echo "GOPATH=${{ github.workspace }}/go" >> $GITHUB_ENV
@@ -28,5 +28,5 @@ jobs:
         uses: golangci/golangci-lint-action@v3
         with:
           version: v1.54.0
-          working-directory: go/src/github.com/${{ env.REPOSITORY }}
+          working-directory: ${{ env.REPOSITORY }}
           args: --timeout 5m0s


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
`go.mod` ensures we use go1.19, so linter should have the same. 

We can simply read it from this file :)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
