### PR TITLE
[DO NOT MERGE]: Release: ODH 2.4.0 II

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
 IMAGE_OWNER ?= opendatahub
-VERSION ?= 2.1.0
+VERSION ?= 2.4.0
 # IMAGE_TAG_BASE defines the opendatahub.io namespace and part of the image name for remote images.
 # This variable is used to construct full image tags for bundle and catalog images.
 #

--- a/bundle/manifests/opendatahub-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/opendatahub-operator.clusterserviceversion.yaml
@@ -71,8 +71,8 @@ metadata:
     capabilities: Full Lifecycle
     categories: AI/Machine Learning, Big Data
     certified: "False"
-    containerImage: quay.io/opendatahub/opendatahub-operator:v2.1.0
-    createdAt: "2023-8-23T00:00:00Z"
+    containerImage: quay.io/opendatahub/opendatahub-operator:v2.4.0
+    createdAt: "2023-11-02T00:00:00Z"
     olm.skipRange: '>=1.0.0 <2.0.0'
     operatorframework.io/initialization-resource: |-
       {
@@ -121,7 +121,7 @@ metadata:
     operators.operatorframework.io/internal-objects: '[dscinitialization.opendatahub.io]'
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/opendatahub-io/opendatahub-operator
-  name: opendatahub-operator.v2.1.0
+  name: opendatahub-operator.v2.4.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -1772,7 +1772,8 @@ spec:
   minKubeVersion: 1.22.0
   provider:
     name: ODH
+  replaces: opendatahub-operator.v2.3.0
   selector:
     matchLabels:
       component: opendatahub-operator
-  version: 2.1.0
+  version: 2.4.0

--- a/config/manifests/bases/opendatahub-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/opendatahub-operator.clusterserviceversion.yaml
@@ -6,8 +6,8 @@ metadata:
     capabilities: Full Lifecycle
     categories: AI/Machine Learning, Big Data
     certified: "False"
-    containerImage: quay.io/opendatahub/opendatahub-operator:v2.1.0
-    createdAt: "2023-8-23T00:00:00Z"
+    containerImage: quay.io/opendatahub/opendatahub-operator:v2.4.0
+    createdAt: "2023-11-02T00:00:00Z"
     olm.skipRange: '>=1.0.0 <2.0.0'
     operatorframework.io/initialization-resource: |-
       {
@@ -54,7 +54,7 @@ metadata:
       }
     operators.operatorframework.io/internal-objects: '[dscinitialization.opendatahub.io]'
     repository: https://github.com/opendatahub-io/opendatahub-operator
-  name: opendatahub-operator.v0.0.0
+  name: opendatahub-operator.v2.4.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -132,7 +132,8 @@ spec:
   minKubeVersion: 1.22.0
   provider:
     name: ODH
+  replaces: opendatahub-operator.v2.3.0
   selector:
     matchLabels:
       component: opendatahub-operator
-  version: 0.0.1
+  version: 2.4.0

--- a/controllers/dscinitialization/utils.go
+++ b/controllers/dscinitialization/utils.go
@@ -214,12 +214,23 @@ func (r *DSCInitializationReconciler) reconcileDefaultNetworkPolicy(ctx context.
 						},
 					},
 				},
-				{ // OR logic
+				{ // OR logic for ROSA
 					From: []netv1.NetworkPolicyPeer{
 						{ // need this for access dashboard
 							NamespaceSelector: &metav1.LabelSelector{
 								MatchLabels: map[string]string{
 									"kubernetes.io/metadata.name": "openshift-ingress",
+								},
+							},
+						},
+					},
+				},
+				{ // OR logic for PSI
+					From: []netv1.NetworkPolicyPeer{
+						{ // need this for access dashboard
+							NamespaceSelector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{
+									"kubernetes.io/metadata.name": "openshift-host-network",
 								},
 							},
 						},

--- a/get_all_manifests.sh
+++ b/get_all_manifests.sh
@@ -4,19 +4,18 @@ set -e
 GITHUB_URL="https://github.com/"
 
 # component: dsp, kserve, dashbaord, cf/ray. in the format of "repo-org:repo-name:branch-name:source-folder:target-folder"
-# TODO: odh-mm-monitoring, etc
 declare -A COMPONENT_MANIFESTS=(
     ["codeflare"]="opendatahub-io:codeflare-operator:main:config:codeflare"
     ["ray"]="opendatahub-io:kuberay:master:ray-operator/config:ray"
-    ["data-science-pipelines-operator"]="opendatahub-io:data-science-pipelines-operator:main:config:data-science-pipelines-operator"
-    ["odh-dashboard"]="opendatahub-io:odh-dashboard:incubation:manifests:dashboard"
-    ["kf-notebook-controller"]="opendatahub-io:kubeflow:v1.7-branch:components/notebook-controller/config:odh-notebook-controller/kf-notebook-controller"
-    ["odh-notebook-controller"]="opendatahub-io:kubeflow:v1.7-branch:components/odh-notebook-controller/config:odh-notebook-controller/odh-notebook-controller"
-    ["notebooks"]="opendatahub-io:notebooks:main:manifests:notebooks"
-    ["trustyai"]="trustyai-explainability:trustyai-service-operator:release/1.10.2:config:trustyai-service-operator"
-    ["model-mesh"]="opendatahub-io:modelmesh-serving:release-0.11.0:config:model-mesh"
-    ["odh-model-controller"]="opendatahub-io:odh-model-controller:release-0.11.0:config:odh-model-controller"
-    ["kserve"]="opendatahub-io:kserve:release-v0.11.0:config:kserve"
+    ["data-science-pipelines-operator"]="opendatahub-io:data-science-pipelines-operator:v1.6.0:config:data-science-pipelines-operator"
+    ["odh-dashboard"]="opendatahub-io:odh-dashboard:v2.17.0-incubation:manifests:dashboard"
+    ["kf-notebook-controller"]="opendatahub-io:kubeflow:v1.7.0-5:components/notebook-controller/config:odh-notebook-controller/kf-notebook-controller"
+    ["odh-notebook-controller"]="opendatahub-io:kubeflow:v1.7.0-5:components/odh-notebook-controller/config:odh-notebook-controller/odh-notebook-controller"
+    ["notebooks"]="opendatahub-io:notebooks:v1.12.0:manifests:notebooks"
+    ["trustyai"]="trustyai-explainability:trustyai-service-operator:v1.11.1:config:trustyai-service-operator"
+    ["model-mesh"]="opendatahub-io:modelmesh-serving:v0.11.1.0:config:model-mesh"
+    ["odh-model-controller"]="opendatahub-io:odh-model-controller:v0.11.1.0:config:odh-model-controller"
+    ["kserve"]="opendatahub-io:kserve:v0.11.1.0:config:kserve"
 )
 
 # Allow overwriting repo using flags component=repo


### PR DESCRIPTION
- keep same release tags from components
- DW still use branch since no tags ready
- fix(namespace): for access dashboard (#701)

<!--- Provide a general summary of your changes in the Title above -->

**THIS IS TO BUILD A NEW IMAGE WITH NETWORKPOLICY FIX FROM 2.3.0 AND WE CAN TAG PR-IMAGE AS OFFICIAL RELEASE IMAGE**
background: the previous release 2.3.0 has an issue with access to dashboard, 
PR700 is to fix it and merged into incubation branch. 
PR701 is the same cherrypick onto "odh-2.4.0" branch. 
but in order to trigger a new 2.4.0 image build (PR701 wont do due to lack of automation on release branch), it need to have both code from odh-2.4.0 (release commit) , so this PR702  is combined with both odh-2.4.0(branch from) and the PR700/701, once pr-image is created, we will close this PR and no need to merge it to any branch

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
