### PR TITLE
update: check on dependent operator done in one go

### DIFF
--- a/components/codeflare/codeflare.go
+++ b/components/codeflare/codeflare.go
@@ -3,7 +3,6 @@
 package codeflare
 
 import (
-	"fmt"
 	"path/filepath"
 
 	operatorv1 "github.com/openshift/api/operator/v1"
@@ -75,11 +74,8 @@ func (c *CodeFlare) ReconcileComponent(cli client.Client, owner metav1.Object, d
 			dependentOperator = RHCodeflareOperator
 		}
 
-		if found, err := deploy.OperatorExists(cli, dependentOperator); err != nil {
+		if _, err := deploy.OperatorExists(cli, ComponentName, false, dependentOperator); err != nil {
 			return err
-		} else if found {
-			return fmt.Errorf("operator %s  found. Please uninstall the operator before enabling %s component",
-				dependentOperator, ComponentName)
 		}
 
 		// Update image parameters only when we do not have customized manifests set

--- a/components/kserve/kserve.go
+++ b/components/kserve/kserve.go
@@ -2,7 +2,6 @@
 package kserve
 
 import (
-	"fmt"
 	"path/filepath"
 	"strings"
 
@@ -105,19 +104,8 @@ func (k *Kserve) ReconcileComponent(cli client.Client, owner metav1.Object, dsci
 		}
 
 		// check on dependent operators
-		if found, err := deploy.OperatorExists(cli, ServiceMeshOperator); err != nil {
+		if _, err := deploy.OperatorExists(cli, ComponentName, true, ServiceMeshOperator, ServerlessOperator); err != nil {
 			return err
-		} else if !found {
-			return fmt.Errorf("operator %s not found. Please install the operator before enabling %s component",
-				ServiceMeshOperator, ComponentName)
-		}
-
-		// check on dependent operators might be in multiple namespaces
-		if found, err := deploy.OperatorExists(cli, ServerlessOperator); err != nil {
-			return err
-		} else if !found {
-			return fmt.Errorf("operator %s not found. Please install the operator before enabling %s component",
-				ServerlessOperator, ComponentName)
 		}
 
 		if err := k.configureServerless(dscispec); err != nil {

--- a/components/kserve/kserve.go
+++ b/components/kserve/kserve.go
@@ -2,6 +2,7 @@
 package kserve
 
 import (
+	"fmt"
 	"path/filepath"
 	"strings"
 
@@ -160,7 +161,7 @@ func (k *Kserve) Cleanup(_ client.Client, instance *dsciv1.DSCInitializationSpec
 func (k *Kserve) configureServerless(instance *dsciv1.DSCInitializationSpec) error {
 	if k.Serving.ManagementState == operatorv1.Managed {
 		if instance.ServiceMesh.ManagementState != operatorv1.Managed {
-			return fmt.Errorf("service mesh is not configure in DataScienceInitialization cluster but required by KServe serving")
+			return fmt.Errorf("serviceMesh is not Managed in DSCI instance but required by KServe serving")
 		}
 
 		serverlessInitializer := feature.NewFeaturesInitializer(instance, k.configureServerlessFeatures)

--- a/tests/e2e/dsc_creation_test.go
+++ b/tests/e2e/dsc_creation_test.go
@@ -148,7 +148,7 @@ func (tc *testContext) testAllApplicationCreation(t *testing.T) error {
 		if tc.testDsc.Spec.Components.Kserve.ManagementState == operatorv1.Managed {
 			if err != nil {
 				// depedent operator error, as expected
-				if strings.Contains(err.Error(), "Please install the operator before enabling component") {
+				if strings.Contains(err.Error(), "please install all dependent operators") {
 					t.Logf("expected error: %v", err.Error())
 				} else {
 					require.NoError(t, err, "error validating application %v when enabled", tc.testDsc.Spec.Components.Kserve.GetComponentName())
@@ -197,7 +197,6 @@ func (tc *testContext) testAllApplicationCreation(t *testing.T) error {
 		err = tc.testApplicationCreation(&(tc.testDsc.Spec.Components.CodeFlare))
 		if tc.testDsc.Spec.Components.CodeFlare.ManagementState == operatorv1.Managed {
 			if err != nil {
-				// dependent operator error, as expected
 				{
 					require.NoError(t, err, "error validating application %v when enabled", tc.testDsc.Spec.Components.CodeFlare.GetComponentName())
 				}
@@ -270,7 +269,7 @@ func (tc *testContext) testApplicationCreation(component components.ComponentInt
 		} else { // when no deployment is found
 			// check Reconcile failed with missing dependent operator error
 			for _, Condition := range tc.testDsc.Status.Conditions {
-				if strings.Contains(Condition.Message, "Please install the operator before enabling "+component.GetComponentName()) {
+				if strings.Contains(Condition.Message, "all dependent operators ") {
 					return true, err
 				}
 			}


### PR DESCRIPTION
- use flag "installed" for two cases:
- set to "true" to positive check. e.g for kserve
   - if one of dependent operator(s) not found, throw error with all dependent operators name
- set to "false" to negative check. e.g for codeflare-operator
  - if any of the dependent operator(s) has been installed, throw error with all dependent operators name

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
local build: quay.io/wenzhou/opendatahub-operator-catalog:v2.11.6-999

test: when no other operator installed, 
- enable CFO, had no problem
- disable CFO, installed RHODS CFO operator, then enable CFO, had no problem, because not match for this operator
- enable Kserve, problem saying need to install 2 operators
![Screenshot from 2023-11-06 17-29-22](https://github.com/opendatahub-io/opendatahub-operator/assets/915053/df98d77f-2027-476a-a0c7-e5ee0d0a00ea)
- install servicemesh and serverless, kserve reconcile done from previous error


## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
