### PR TITLE
fix(crd): do not set ownerreference on CRD

### DIFF
--- a/pkg/deploy/deploy.go
+++ b/pkg/deploy/deploy.go
@@ -257,8 +257,11 @@ func manageResource(ctx context.Context, cli client.Client, obj *unstructured.Un
 	// Create the resource if it doesn't exist and component is enabled
 	if apierrs.IsNotFound(err) {
 		// Set the owner reference for garbage collection
-		if err = ctrl.SetControllerReference(owner, metav1.Object(obj), cli.Scheme()); err != nil {
-			return err
+		// Skip set on CRD, e.g we should not delete notebook CRD if we delete DSC instance
+		if found.GetKind() != "CustomResourceDefinition" {
+			if err = ctrl.SetControllerReference(owner, metav1.Object(obj), cli.Scheme()); err != nil {
+				return err
+			}
 		}
 
 		return cli.Create(ctx, obj)


### PR DESCRIPTION
-  we covered the case when set component from Managed to Remvoe to not remove CRD (e.g notebook)
-  this is to cover the case when delete DSC CR , so if we do not set it when created at first then it wont get deleted when DSC CR is gone

<!--- Provide a general summary of your changes in the Title above -->
fix https://github.com/opendatahub-io/opendatahub-operator/issues/723

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
live build: quay.io/wenzhou/opendatahub-operator-catalog:v2.11.723
first enable workbench and dashboard  then create workbench from dashboard
![Screenshot from 2023-11-10 17-56-51](https://github.com/opendatahub-io/opendatahub-operator/assets/915053/c6ca0468-e436-49cf-9b1a-fadbd09ca4a8)

then delete DSC CR
![Screenshot from 2023-11-10 17-57-11](https://github.com/opendatahub-io/opendatahub-operator/assets/915053/ddd64013-462b-4010-adb2-863c5ddecefe)

eventually DSC CR gone, only workbench pods in cluster
![Screenshot from 2023-11-10 17-58-59](https://github.com/opendatahub-io/opendatahub-operator/assets/915053/12adad9b-0c91-4f1b-91be-f00b0c8c1ddd)



## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
