### PR TITLE
Makefile: generate default image name based on current user

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,16 +3,23 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-IMAGE_OWNER ?= opendatahub
+ifneq ($(USER),)
+IMAGE_OWNER = $(USER)
+else
+IMAGE_OWNER = opendatahub
+endif
 VERSION ?= 2.4.0
 # IMAGE_TAG_BASE defines the opendatahub.io namespace and part of the image name for remote images.
 # This variable is used to construct full image tags for bundle and catalog images.
 #
 # For example, running 'make bundle-build bundle-push catalog-build catalog-push' will build and push both
 # opendatahub.io/opendatahub-operator-bundle:$VERSION and opendatahub.io/opendatahub-operator-catalog:$VERSION.
-IMAGE_TAG_BASE ?= quay.io/$(IMAGE_OWNER)/opendatahub-operator
+IMAGE_TAG_BASE = quay.io/$(IMAGE_OWNER)/opendatahub-operator
+
+# keep the name based on IMG which already used from command line
+IMG_TAG = latest
 # Update IMG to a variable, to keep it consistent across versions for OpenShift CI
-IMG ?= REPLACE_IMAGE
+IMG = $(IMAGE_TAG_BASE):$(IMG_TAG)
 # BUNDLE_IMG defines the image:tag used for the bundle.
 # You can use it as an arg. (E.g make bundle-build BUNDLE_IMG=<some-registry>/<project-name-bundle>:<tag>)
 BUNDLE_IMG ?= $(IMAGE_TAG_BASE)-bundle:v$(VERSION)


### PR DESCRIPTION
It's a bit tedeous to supply IMG for barely every make call so make it contstructed by Makefile itself based on the current user.

The default image name will be quay.io/$(USER)/opendatahub-operator:latest if USER environment variable is not empty.

It's still possible to amend the generation with variables:

```
IMAGE_OWNER - as before, uses value as quay.io space.
IMG_TAG - use the tag instead of `latest`. The variable name is
  chosen because of IMG variable.
IMG - as before, use the complete image name
```
In the assignments '?=' replaced/used by '=' to not mess up with the environment by accident since the names are pretty generic (it's always possible to use `make -e` for those who wants).

It should not make problems with CI since it uses the names directly [1] using our csv [2]. To push the image it uses workflow [3] (code [4]).

[1] https://github.com/openshift/release/blob/master/ci-operator/config/opendatahub-io/opendatahub-operator/opendatahub-io-opendatahub-operator-incubation.yaml#L24
[2] https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/bundle/manifests/opendatahub-operator.clusterserviceversion.yaml#L1678
[3] https://github.com/openshift/release/blob/master/ci-operator/config/opendatahub-io/opendatahub-operator/opendatahub-io-opendatahub-operator-incubation.yaml#L47
[4] https://github.com/openshift/release/blob/master/ci-operator/step-registry/opendatahub-io/ci/image-mirror/opendatahub-io-ci-image-mirror-commands.sh

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
