### PR TITLE
Makefile: change always true conditions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ CHANNELS="fast"
 # To re-generate a bundle for other specific channels without changing the standard setup, you can:
 # - use the CHANNELS as arg of the bundle target (e.g make bundle CHANNELS=candidate,fast,stable)
 # - use environment variables to overwrite this value (e.g export CHANNELS="candidate,fast,stable")
-ifneq ($(origin CHANNELS), undefined)
+ifneq ($(CHANNELS),)
 BUNDLE_CHANNELS := --channels=$(CHANNELS)
 endif
 
@@ -37,7 +37,7 @@ DEFAULT_CHANNEL="fast"
 # To re-generate a bundle for any other default channel without changing the default setup, you can:
 # - use the DEFAULT_CHANNEL as arg of the bundle target (e.g make bundle DEFAULT_CHANNEL=stable)
 # - use environment variables to overwrite this value (e.g export DEFAULT_CHANNEL="stable")
-ifneq ($(origin DEFAULT_CHANNEL), undefined)
+ifneq ($(DEFAULT_CHANNEL),)
 BUNDLE_DEFAULT_CHANNEL := --default-channel=$(DEFAULT_CHANNEL)
 endif
 
@@ -271,7 +271,7 @@ BUNDLE_IMGS ?= $(BUNDLE_IMG)
 CATALOG_IMG ?= $(IMAGE_TAG_BASE)-catalog:v$(VERSION)
 
 # Set CATALOG_BASE_IMG to an existing catalog image tag to add $BUNDLE_IMGS to that image.
-ifneq ($(origin CATALOG_BASE_IMG), undefined)
+ifneq ($(CATALOG_BASE_IMG),)
 FROM_INDEX_OPT := --from-index $(CATALOG_BASE_IMG)
 endif
 


### PR DESCRIPTION
After commit
d0e6c9816f24 ("Update Dockerfile and Makefile")
which defines CHANNELS and DEFAULT_CHANNEL variables, conditions like `ifneq ($(origin CHANNELS), undefined)` are always true and misleading. Change it to check for blank since it still can be overwritten from command line.

Change also CATALOG_BASE_IMG. It was not affected by the old patch but looks like makes the same sense.

Fixes: d0e6c9816f24 ("Update Dockerfile and Makefile")

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
