### PR TITLE
Makefile: run linter and unit tests from default target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,8 +88,8 @@ E2E_TEST_FLAGS = "--skip-deletion=false" -timeout 15m # See README.md, default g
 # see target "image-build"
 IMAGE_BUILD_FLAGS = --build-arg USE_LOCAL=false
 
-.PHONY: all
-all: build
+.PHONY: default
+default: lint unit-test build
 
 ##@ General
 


### PR DESCRIPTION
- rename default target `all` to `default`. Sounds more appropriate since there are a lot of other jobs left.
- depend `default` from `lint` and `unit-test`

It looks like more appropriate default for developers.

Related: #696

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
