### PR TITLE
config, Makefile: add debug image build/deploy

### DIFF
--- a/Dockerfiles/debug.Dockerfile
+++ b/Dockerfiles/debug.Dockerfile
@@ -1,0 +1,61 @@
+# Build the manager binary
+ARG GOLANG_VERSION
+ARG USE_LOCAL=false
+ARG OVERWRITE_MANIFESTS=""
+
+################################################################################
+FROM registry.access.redhat.com/ubi8/go-toolset:$GOLANG_VERSION as builder_local_false
+ARG OVERWRITE_MANIFESTS
+# Get all manifests from remote git repo to builder_local_false by script
+USER root
+WORKDIR /opt
+COPY get_all_manifests.sh get_all_manifests.sh
+RUN ./get_all_manifests.sh ${OVERWRITE_MANIFESTS}
+
+################################################################################
+FROM registry.access.redhat.com/ubi8/go-toolset:$GOLANG_VERSION as builder_local_true
+# Get all manifests from local to builder_local_true
+USER root
+WORKDIR /opt
+# copy local manifests to build
+COPY odh-manifests/ /opt/odh-manifests/
+
+################################################################################
+FROM builder_local_${USE_LOCAL} as builder
+USER root
+WORKDIR /workspace
+# Copy the Go Modules manifests
+COPY go.mod go.mod
+COPY go.sum go.sum
+# cache deps before building and copying source so that we don't need to re-download as much
+# and so that source changes don't invalidate our downloaded layer
+RUN go mod download
+
+# Copy the go source
+COPY apis/ apis/
+COPY components/ components/
+COPY controllers/ controllers/
+COPY main.go main.go
+COPY pkg/ pkg/
+COPY infrastructure/ infrastructure/
+
+# Build
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -gcflags "-N -l" -a -o manager main.go
+RUN GOBIN=/usr/bin go install github.com/go-delve/delve/cmd/dlv@latest
+
+################################################################################
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+
+WORKDIR /
+COPY --from=builder /workspace/manager .
+COPY --chown=1001:0 --from=builder /opt/odh-manifests /opt/manifests
+# Recursive change all files
+RUN chown -R 1001:0 /opt/manifests &&\
+    chmod -R a+r /opt/manifests
+
+RUN mkdir -p /.config/dlv && chmod 777 /.config/dlv
+COPY --from=builder /usr/bin/dlv .
+
+USER 1001
+
+CMD ["/dlv", "--headless", "--api-version=2", "--log=true", "--continue=true", "--accept-multiclient", "--listen=:2345", "/manager"]

--- a/config/debug/dlv_container.yaml
+++ b/config/debug/dlv_container.yaml
@@ -1,0 +1,26 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: opendatahub-operator-controller-manager
+  namespace: opendatahub-operator-system
+spec:
+  replicas: 1
+  template:
+    spec:
+      containers:
+      - command:
+        - /dlv
+        args:
+        - exec
+        - --listen=:2345
+        - --headless
+        - --api-version=2
+        - --log=true
+        - --continue=true
+        - --accept-multiclient
+        - /manager
+        - --
+        - --health-probe-bind-address=:8081
+        - --metrics-bind-address=0.0.0.0:8080
+        - --leader-elect
+        name: manager

--- a/config/debug/kustomization.yaml
+++ b/config/debug/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../default
+patchesStrategicMerge:
+- dlv_container.yaml


### PR DESCRIPTION
Add some infrastructure to build and deploy an image which allows remote debugging of the operator on cluster.

The idea is taken from the pull request[1].

- add Dockerfile which builds binary with debug symbols and adds dlv (golang debugger) to the image;

- add config/debug/ kustomization which generates Deployment to run operator binary under debugger with remote debugging port exported (hardcoded 2345).

To access the port get the pod name and forward the port, ex.:

``` kubectl -n opendatahub-operator-system port-forward pod/opendatahub-operator-controller-manager-585dc47db6-ncr4q 2345 ```

It uses full name `opendatahub-operator-controller-manager` with the
prefix, otherwise the old kustomize complains that it cannot find
the object to patch. The new one works fine.

Also it uses patchesStrategicMerge so manager's command line
switches copied here (health-probe-bind-address...). Probably, would
be possible to use json patch.

- adds debug-image-build and debug-deploy targets to the Makefile.

  It moves common code to *-common targets and uses target specific
  variables. Use `make image-push` to push the debug image before
  deploy for debugging in the cluster.

  debug-image-build does not run unit-test. Leave some flexibility
  for debugging.

  With the change in theory for image-build building the image and
  running unit-tests can be run in parallel, but it should not make
  harm here.

[1] https://github.com/opendatahub-io/data-science-pipelines-operator/pull/21

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
