### PR TITLE
fix(ossm): disables service mesh routes generation

### DIFF
--- a/pkg/feature/templates/servicemesh/base/smcp.tmpl
+++ b/pkg/feature/templates/servicemesh/base/smcp.tmpl
@@ -24,6 +24,8 @@ spec:
       defaultConfig:
         terminationDrainDuration: 35s
   gateways:
+    openshiftRoute:
+      enabled: false
     ingress:
       service:
         metadata:


### PR DESCRIPTION
## Description
This disables automatic OpenShift routes creation.

## How Has This Been Tested?
Smoke testing: turning on Service Mesh and KServe with Serverless. Then, checking that no rejected routes are created in `istio-system` namespace.

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
