### PR TITLE
fix(kserve): check on multiple depends operators if all pre-installed

### DIFF
--- a/pkg/feature/feature.go
+++ b/pkg/feature/feature.go
@@ -116,8 +116,7 @@ func (f *Feature) Cleanup() error {
 func (f *Feature) applyManifests() error {
 	var applyErrors *multierror.Error
 	for _, m := range f.manifests {
-		err := f.apply(m)
-		applyErrors = multierror.Append(applyErrors, err)
+		applyErrors = multierror.Append(applyErrors, f.apply(m))
 	}
 
 	return applyErrors.ErrorOrNil()

--- a/pkg/feature/initializer.go
+++ b/pkg/feature/initializer.go
@@ -34,8 +34,7 @@ func (s *FeaturesInitializer) Apply() error {
 	var applyErrors *multierror.Error
 
 	for _, f := range s.Features {
-		err := f.Apply()
-		applyErrors = multierror.Append(applyErrors, err)
+		applyErrors = multierror.Append(applyErrors, f.Apply())
 	}
 
 	return applyErrors.ErrorOrNil()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
create new func `checkDepedentOps` in kserve
with mutlierr, we can be more clear with dependent operator(s) are not installed in one error message.


# How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

live build:
![Screenshot from 2023-11-15 18-27-39](https://github.com/opendatahub-io/opendatahub-operator/assets/915053/d885b325-3753-40ed-a758-68acb76599a3)
test when servicemesh operator is installed but serverless is not.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
