### PR TITLE
fix: upgrade for v1

### DIFF
--- a/controllers/dscinitialization/dscinitialization_controller.go
+++ b/controllers/dscinitialization/dscinitialization_controller.go
@@ -214,7 +214,7 @@ func (r *DSCInitializationReconciler) Reconcile(ctx context.Context, req ctrl.Re
 
 		// Apply update from legacy operator
 		// TODO: Update upgrade logic to get components through KfDef
-		if err = upgrade.UpdateFromLegacyVersion(r.Client, platform); err != nil {
+		if err = upgrade.UpdateFromLegacyVersion(r.Client, platform, r.ApplicationsNamespace); err != nil {
 			r.Log.Error(err, "unable to update from legacy operator version")
 
 			return reconcile.Result{}, err

--- a/main.go
+++ b/main.go
@@ -195,7 +195,7 @@ func main() { //nolint:funlen
 	}
 
 	// Apply update from legacy operator
-	if err = upgrade.UpdateFromLegacyVersion(setupClient, platform); err != nil {
+	if err = upgrade.UpdateFromLegacyVersion(setupClient, platform, dscApplicationsNamespace); err != nil {
 		setupLog.Error(err, "unable to update from legacy operator version")
 	}
 

--- a/pkg/plugins/addLabelsplugin.go
+++ b/pkg/plugins/addLabelsplugin.go
@@ -11,7 +11,7 @@ func ApplyAddLabelsPlugin(componentName string, resMap resmap.ResMap) error {
 	nsplug := builtins.LabelTransformerPlugin{
 		Labels: map[string]string{
 			"app.opendatahub.io/" + componentName: "true",
-			"app.kubernetes.io/part-of": componentName,
+			"app.kubernetes.io/part-of":           componentName,
 		},
 		FieldSpecs: []types.FieldSpec{
 			{

--- a/pkg/plugins/addLabelsplugin.go
+++ b/pkg/plugins/addLabelsplugin.go
@@ -11,8 +11,14 @@ func ApplyAddLabelsPlugin(componentName string, resMap resmap.ResMap) error {
 	nsplug := builtins.LabelTransformerPlugin{
 		Labels: map[string]string{
 			"app.opendatahub.io/" + componentName: "true",
+			"app.kubernetes.io/part-of": componentName,
 		},
 		FieldSpecs: []types.FieldSpec{
+			{
+				Gvk:                resid.Gvk{Kind: "Deployment"},
+				Path:               "spec/selector/matchLabels",
+				CreateIfNotPresent: true,
+			},
 			{
 				Gvk:                resid.Gvk{Kind: "Deployment"},
 				Path:               "spec/template/metadata/labels",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- cherrypick the revert label [change](https://github.com/red-hat-data-services/rhods-operator/pull/120) from downstream
- cherrypick Edson's [draft](https://github.com/red-hat-data-services/rhods-operator/pull/121) delete deployment from downstream
-  add the deployment selector filter to skip deletion if it is already v2 deployment
- the new labe is "app.opendatahub.io/<component>:true"
-  add pollUnit loop 

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

just to test it out in order to build a v1 
## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
