### PR TITLE
RHODS-12939: Fixing operator upgrades

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ IMAGE_BUILDER ?= podman
 OPERATOR_NAMESPACE ?= opendatahub-operator-system
 
 
-CHANNELS="fast"
+CHANNELS ?= "fast"
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")
 # To re-generate a bundle for other specific channels without changing the standard setup, you can:

--- a/controllers/dscinitialization/dscinitialization_controller.go
+++ b/controllers/dscinitialization/dscinitialization_controller.go
@@ -214,7 +214,7 @@ func (r *DSCInitializationReconciler) Reconcile(ctx context.Context, req ctrl.Re
 
 		// Apply update from legacy operator
 		// TODO: Update upgrade logic to get components through KfDef
-		if err = upgrade.UpdateFromLegacyVersion(r.Client, platform); err != nil {
+		if err = upgrade.UpdateFromLegacyVersion(r.Client, platform, r.ApplicationsNamespace); err != nil {
 			r.Log.Error(err, "unable to update from legacy operator version")
 
 			return reconcile.Result{}, err

--- a/main.go
+++ b/main.go
@@ -195,7 +195,7 @@ func main() { //nolint:funlen
 	}
 
 	// Apply update from legacy operator
-	if err = upgrade.UpdateFromLegacyVersion(setupClient, platform); err != nil {
+	if err = upgrade.UpdateFromLegacyVersion(setupClient, platform, dscApplicationsNamespace); err != nil {
 		setupLog.Error(err, "unable to update from legacy operator version")
 	}
 

--- a/pkg/plugins/addLabelsplugin.go
+++ b/pkg/plugins/addLabelsplugin.go
@@ -11,7 +11,7 @@ func ApplyAddLabelsPlugin(componentName string, resMap resmap.ResMap) error {
 	nsplug := builtins.LabelTransformerPlugin{
 		Labels: map[string]string{
 			"app.opendatahub.io/" + componentName: "true",
-			"app.kubernetes.io/part-of": componentName,
+			"app.kubernetes.io/part-of":           componentName,
 		},
 		FieldSpecs: []types.FieldSpec{
 			{

--- a/pkg/plugins/addLabelsplugin.go
+++ b/pkg/plugins/addLabelsplugin.go
@@ -11,8 +11,14 @@ func ApplyAddLabelsPlugin(componentName string, resMap resmap.ResMap) error {
 	nsplug := builtins.LabelTransformerPlugin{
 		Labels: map[string]string{
 			"app.opendatahub.io/" + componentName: "true",
+			"app.kubernetes.io/part-of": componentName,
 		},
 		FieldSpecs: []types.FieldSpec{
+			{
+				Gvk:                resid.Gvk{Kind: "Deployment"},
+				Path:               "spec/selector/matchLabels",
+				CreateIfNotPresent: true,
+			},
 			{
 				Gvk:                resid.Gvk{Kind: "Deployment"},
 				Path:               "spec/template/metadata/labels",


### PR DESCRIPTION
Reverting changes to support v2->v2 upgrades
Adding logic to delete and recreate v1 Deployments during upgrade due to change in spec.selector.matchlabels

## How Has This Been Tested?
Manual upgrage tests

