### PR TITLE
fix(nilpointer): when more than one DSCI CR in cluster

### DIFF
--- a/controllers/dscinitialization/dscinitialization_controller.go
+++ b/controllers/dscinitialization/dscinitialization_controller.go
@@ -94,7 +94,7 @@ func (r *DSCInitializationReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		earliestDSCI := &instances.Items[0]
 		for _, instance := range instances.Items {
 			currentDSCI := instance
-			if currentDSCI.CreationTimestamp.Before(&earliestDSCI.CreationTimestamp) || currentDSCI.CreationTimestamp.Equal(&earliestDSCI.CreationTimestamp) {
+			if currentDSCI.CreationTimestamp.Before(&earliestDSCI.CreationTimestamp) {
 				earliestDSCI = &currentDSCI
 			}
 		}

--- a/controllers/dscinitialization/dscinitialization_controller.go
+++ b/controllers/dscinitialization/dscinitialization_controller.go
@@ -91,23 +91,22 @@ func (r *DSCInitializationReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		instance = &instances.Items[0]
 	case len(instances.Items) > 1:
 		// find out the one by created timestamp and use it as the default one
-		markedWrongDSCI := []dsciv1.DSCInitialization{}
 		earliestDSCI := &instances.Items[0]
 		for _, instance := range instances.Items {
 			currentDSCI := instance
 			if currentDSCI.CreationTimestamp.Before(&earliestDSCI.CreationTimestamp) || currentDSCI.CreationTimestamp.Equal(&earliestDSCI.CreationTimestamp) {
 				earliestDSCI = &currentDSCI
-			} else {
-				markedWrongDSCI = append(markedWrongDSCI, currentDSCI)
 			}
 		}
 		message := fmt.Sprintf("only one instance of DSCInitialization object is allowed. Please delete other instances than %s", earliestDSCI.Name)
 		// update all instances Message and Status
-		for _, deletionInstance := range markedWrongDSCI {
-			_, _ = r.updateStatus(ctx, &deletionInstance, func(saved *dsciv1.DSCInitialization) {
-				status.SetErrorCondition(&saved.Status.Conditions, status.DuplicateDSCInitialization, message)
-				saved.Status.Phase = status.PhaseError
-			})
+		for _, deletionInstance := range instances.Items {
+			if deletionInstance.Name != earliestDSCI.Name {
+				_, _ = r.updateStatus(ctx, &deletionInstance, func(saved *dsciv1.DSCInitialization) {
+					status.SetErrorCondition(&saved.Status.Conditions, status.DuplicateDSCInitialization, message)
+					saved.Status.Phase = status.PhaseError
+				})
+			}
 		}
 
 		return ctrl.Result{}, errors.New(message)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
fix: https://github.com/opendatahub-io/opendatahub-operator/issues/755

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
** newest test**
live build :  quay.io/wenzhou/opendatahub-operator:dev-2.5.755-2
![Screenshot from 2023-12-14 17-57-24](https://github.com/opendatahub-io/opendatahub-operator/assets/915053/513de5de-14c9-4e24-9b79-84ae89af6c64)
![Screenshot from 2023-12-14 17-59-55](https://github.com/opendatahub-io/opendatahub-operator/assets/915053/115dfe32-55c1-45da-9409-11feab94f1dc)


**new test**
live build :  quay.io/wenzhou/opendatahub-operator:dev-2.5.666

- install operator
- get default DSCI CR "default-dsci" automatically
- manually create anothe DSCI CR "default-dsci2"
- check operator pod log

![Screenshot from 2023-11-27 13-25-04](https://github.com/opendatahub-io/opendatahub-operator/assets/915053/973403ed-ea7e-45f0-9d83-704eb2a49970)

- check both DSCI CRs Message:
- 
![Screenshot from 2023-11-27 13-26-08](https://github.com/opendatahub-io/opendatahub-operator/assets/915053/fae8b397-4837-4970-8832-650dba511e6f)
![Screenshot from 2023-11-27 13-25-56](https://github.com/opendatahub-io/opendatahub-operator/assets/915053/985ffa19-089d-4f72-9568-e6e2ddaab69b)







**old test**
test on PR change:
- auto create `default-dsci `DSCI CR
- manual create `default` DSCI CR
- check any of the CR 
![Screenshot from 2023-11-22 08-42-14](https://github.com/opendatahub-io/opendatahub-operator/assets/915053/24abc3eb-5a40-4384-a897-70843f546426)

from operator pod
![Screenshot from 2023-11-22 08-43-02](https://github.com/opendatahub-io/opendatahub-operator/assets/915053/e38814d5-e243-47c5-947f-fc433200d9dd)
 but no panic nor crashloop

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
