### PR TITLE
feat(kserve): update domain template to include a namespace level (opendatahub-io/kserve#96)

### DIFF
--- a/pkg/feature/templates/serverless/serving-install/knative-serving.tmpl
+++ b/pkg/feature/templates/serverless/serving-install/knative-serving.tmpl
@@ -21,3 +21,5 @@ spec:
   config:
     istio:
       local-gateway.knative-serving.knative-local-gateway: "knative-local-gateway.{{ .ControlPlane.Namespace }}.svc.cluster.local"
+    network:
+      domainTemplate: "{{.Name}}.{{.Namespace}}.{{.Domain}}"


### PR DESCRIPTION
## Description
Adds a Namespace level to the KServe generated model routes.

## How Has This Been Tested?
Manual.

* Verified config change updates the correct CM, config-network in knative-serving
* Verified that the ISCV use the new domain template when generating Status.URL

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
