### PR TITLE
fix(features): makes rest config loader more flexible

### DIFF
--- a/pkg/feature/builder.go
+++ b/pkg/feature/builder.go
@@ -8,6 +8,7 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
 
 	v1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/dscinitialization/v1"
 	infrav1 "github.com/opendatahub-io/opendatahub-operator/v2/infrastructure/v1"
@@ -158,7 +159,7 @@ func (fb *featureBuilder) Load() (*Feature, error) {
 	// UsingConfig builder wasn't called while constructing this feature.
 	// Get default settings and create needed clients.
 	if feature.Client == nil {
-		config, err := rest.InClusterConfig()
+		restCfg, err := config.GetConfig()
 		if errors.Is(err, rest.ErrNotInCluster) {
 			// rollback to local kubeconfig - this can be helpful when running the process locally i.e. while debugging
 			kubeconfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
@@ -166,7 +167,7 @@ func (fb *featureBuilder) Load() (*Feature, error) {
 				&clientcmd.ConfigOverrides{},
 			)
 
-			config, err = kubeconfig.ClientConfig()
+			restCfg, err = kubeconfig.ClientConfig()
 			if err != nil {
 				return nil, err
 			}
@@ -174,7 +175,7 @@ func (fb *featureBuilder) Load() (*Feature, error) {
 			return nil, err
 		}
 
-		if err := createClients(config)(feature); err != nil {
+		if err := createClients(restCfg)(feature); err != nil {
 			return nil, err
 		}
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

By using client/config.GetConfig() we first check KUBECONFIG to only then fall back to a chain of alternatives including in-cluster config. This allows us to run ctrl binary locally and connect to cluster from outside - extra points for easier debugging :)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
