### PR TITLE
chore(mesh): Use third party service account tokens

### DIFF
--- a/pkg/feature/templates/servicemesh/base/smcp.tmpl
+++ b/pkg/feature/templates/servicemesh/base/smcp.tmpl
@@ -19,6 +19,8 @@ spec:
   security:
     dataPlane:
       mtls: true # otherwise inference-graph will not work. We use PeerAuthentication resources to force mTLS
+    identity:
+      type: ThirdParty
   techPreview:
     meshConfig:
       defaultConfig:


### PR DESCRIPTION
## Description
This should allow Service Mesh to run on any OpenShift flavor.

Fixes opendatahub-io/kserve#138

## How Has This Been Tested?
Manually, depoying Service Mesh with the operator.

## Merge criteria:
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
