### PR TITLE
update(dsci): do not create default DSCI CR if it is running in  ODH

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,10 @@ and installed from source manually, see the Developer guide for further instruct
     EOF
     ```
 
-2. Create [DataScienceCluster](#example-datasciencecluster) CR to enable components
+2. Create [DSCInitializationc](#example-dscinitialization) CR manually.
+  You can also use operator to create default DSCI CR by removing env variable DISABLE_DSC_CONFIG from CSV following restart operator pod.
+
+3. Create [DataScienceCluster](#example-datasciencecluster) CR to enable components
 
 ## Dev Preview
 
@@ -195,7 +198,31 @@ There are 2 ways to test your changes with modification:
 
 1. set `devFlags.ManifestsUri` field of DSCI instance during runtime: this will pull down manifests from remote git repo
     by using this method, it overwrites manifests and component images if images are set in the params.env file
-2. [Under implementation] build operator image with local manifests   
+2. [Under implementation] build operator image with local manifests.
+
+### Example DSCInitialization
+
+Below is the default DSCI CR config
+
+```console
+apiVersion: dscinitialization.opendatahub.io/v1
+kind: DSCInitialization
+metadata:
+  name: default-dsci
+spec:
+  applicationsNamespace: opendatahub
+  monitoring:
+    managementState: Managed
+    namespace: opendatahub
+  serviceMesh:
+    controlPlane:
+      metricsCollection: Istio
+      name: data-science-smcp
+      namespace: istio-system
+    managementState: Managed
+```
+
+Apply this example with modification for your usage.
 
 ### Example DataScienceCluster
 
@@ -208,7 +235,7 @@ components. At a given time, ODH supports only **one** instance of the CR, which
 apiVersion: datasciencecluster.opendatahub.io/v1
 kind: DataScienceCluster
 metadata:
-  name: example
+  name: default-dsc
 spec:
   components:
     codeflare:

--- a/bundle/manifests/opendatahub-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/opendatahub-operator.clusterserviceversion.yaml
@@ -1747,6 +1747,9 @@ spec:
                 - --leader-elect
                 command:
                 - /manager
+                env:
+                - name: DISABLE_DSC_CONFIG
+                  value: "true"
                 image: REPLACE_IMAGE:latest
                 imagePullPolicy: Always
                 livenessProbe:

--- a/bundle/manifests/opendatahub-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/opendatahub-operator.clusterserviceversion.yaml
@@ -105,49 +105,6 @@ metadata:
     containerImage: quay.io/opendatahub/opendatahub-operator:v2.1.0
     createdAt: "2023-8-23T00:00:00Z"
     olm.skipRange: '>=1.0.0 <2.0.0'
-    operatorframework.io/initialization-resource: |-
-      {
-        "apiVersion": "datasciencecluster.opendatahub.io/v1",
-        "kind": "DataScienceCluster",
-        "metadata": {
-          "name": "default",
-          "labels": {
-            "app.kubernetes.io/name": "datasciencecluster",
-            "app.kubernetes.io/instance": "default",
-            "app.kubernetes.io/part-of": "opendatahub-operator",
-            "app.kubernetes.io/managed-by": "kustomize",
-            "app.kubernetes.io/created-by": "opendatahub-operator"
-          }
-        },
-        "spec": {
-          "components": {
-            "codeflare": {
-              "managementState": "Removed"
-            },
-            "dashboard": {
-              "managementState": "Managed"
-            },
-            "datasciencepipelines": {
-              "managementState": "Managed"
-            },
-            "kserve": {
-              "managementState": "Removed"
-            },
-            "modelmeshserving": {
-              "managementState": "Managed"
-            },
-            "ray": {
-              "managementState": "Removed"
-            },
-            "workbenches": {
-              "managementState": "Managed"
-            },
-            "trustyai": {
-              "managementState": "Removed"
-            }
-          }
-        }
-      }
     operators.operatorframework.io/builder: operator-sdk-v1.24.1
     operators.operatorframework.io/internal-objects: '[dscinitialization.opendatahub.io]'
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -36,6 +36,9 @@ spec:
       containers:
       - command:
         - /manager
+        env:
+          - name: DISABLE_DSC_CONFIG
+            value: 'true'
         args:
         - --leader-elect
         image: controller:latest

--- a/config/manifests/bases/opendatahub-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/opendatahub-operator.clusterserviceversion.yaml
@@ -9,49 +9,6 @@ metadata:
     containerImage: quay.io/opendatahub/opendatahub-operator:v2.1.0
     createdAt: "2023-8-23T00:00:00Z"
     olm.skipRange: '>=1.0.0 <2.0.0'
-    operatorframework.io/initialization-resource: |-
-      {
-        "apiVersion": "datasciencecluster.opendatahub.io/v1",
-        "kind": "DataScienceCluster",
-        "metadata": {
-          "name": "default",
-          "labels": {
-            "app.kubernetes.io/name": "datasciencecluster",
-            "app.kubernetes.io/instance": "default",
-            "app.kubernetes.io/part-of": "opendatahub-operator",
-            "app.kubernetes.io/managed-by": "kustomize",
-            "app.kubernetes.io/created-by": "opendatahub-operator"
-          }
-        },
-        "spec": {
-          "components": {
-            "codeflare": {
-              "managementState": "Removed"
-            },
-            "dashboard": {
-              "managementState": "Managed"
-            },
-            "datasciencepipelines": {
-              "managementState": "Managed"
-            },
-            "kserve": {
-              "managementState": "Removed"
-            },
-            "modelmeshserving": {
-              "managementState": "Managed"
-            },
-            "ray": {
-              "managementState": "Removed"
-            },
-            "workbenches": {
-              "managementState": "Managed"
-            },
-            "trustyai": {
-              "managementState": "Removed"
-            }
-          }
-        }
-      }
     operators.operatorframework.io/internal-objects: '[dscinitialization.opendatahub.io]'
     repository: https://github.com/opendatahub-io/opendatahub-operator
   name: opendatahub-operator.v0.0.0

--- a/controllers/datasciencecluster/datasciencecluster_controller.go
+++ b/controllers/datasciencecluster/datasciencecluster_controller.go
@@ -133,7 +133,8 @@ func (r *DataScienceClusterReconciler) Reconcile(ctx context.Context, req ctrl.R
 	switch len(dsciInstances.Items) {
 	case 0:
 		reason := status.ReconcileFailed
-		message := "Failed to get a valid DSCInitialization instance"
+		message := "Failed to get a valid DSCInitialization instance, please create a DSCI instance"
+		r.Log.Info(message)
 		instance, err = r.updateStatus(ctx, instance, func(saved *dsc.DataScienceCluster) {
 			status.SetProgressingCondition(&saved.Status.Conditions, reason, message)
 			saved.Status.Phase = status.PhaseError

--- a/tests/e2e/controller_setup_test.go
+++ b/tests/e2e/controller_setup_test.go
@@ -48,6 +48,8 @@ type testContext struct {
 	resourceCreationTimeout time.Duration
 	// test DataScienceCluster instance
 	testDsc *dsc.DataScienceCluster
+	// test DSCI CR because we do not create it in ODH by default
+	testDSCI *dsci.DSCInitialization
 	// time interval to check for resource creation
 	resourceRetryInterval time.Duration
 	// context for accessing resources
@@ -89,6 +91,7 @@ func NewTestContext() (*testContext, error) { //nolint:golint,revive // Only use
 		resourceRetryInterval:   time.Second * 10,
 		ctx:                     context.TODO(),
 		testDsc:                 testDSC,
+		testDSCI:                testDSCI,
 	}, nil
 }
 

--- a/tests/e2e/controller_setup_test.go
+++ b/tests/e2e/controller_setup_test.go
@@ -14,7 +14,6 @@ import (
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	k8sclient "k8s.io/client-go/kubernetes"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -75,22 +74,17 @@ func NewTestContext() (*testContext, error) { //nolint:golint,revive // Only use
 		return nil, errors.Wrap(err, "failed to initialize custom client")
 	}
 
+	// setup DSCI CR since we do not create automatically by operator
+	testDSCI := setupDSCICR()
 	// Setup DataScienceCluster CR
 	testDSC := setupDSCInstance()
-
-	// Get Applications namespace from DSCInitialization instance
-	dscInit := &dsci.DSCInitialization{}
-	err = custClient.Get(context.TODO(), types.NamespacedName{Name: "default-dsci"}, dscInit)
-	if err != nil {
-		return nil, errors.Wrap(err, "error getting DSCInitialization instance")
-	}
 
 	return &testContext{
 		cfg:                     config,
 		kubeClient:              kc,
 		customClient:            custClient,
 		operatorNamespace:       opNamespace,
-		applicationsNamespace:   dscInit.Spec.ApplicationsNamespace,
+		applicationsNamespace:   testDSCI.Spec.ApplicationsNamespace,
 		resourceCreationTimeout: time.Minute * 2,
 		resourceRetryInterval:   time.Second * 10,
 		ctx:                     context.TODO(),

--- a/tests/e2e/helper_test.go
+++ b/tests/e2e/helper_test.go
@@ -14,6 +14,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	dsc "github.com/opendatahub-io/opendatahub-operator/v2/apis/datasciencecluster/v1"
+	dsci "github.com/opendatahub-io/opendatahub-operator/v2/apis/dscinitialization/v1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/components"
 	"github.com/opendatahub-io/opendatahub-operator/v2/components/codeflare"
 	"github.com/opendatahub-io/opendatahub-operator/v2/components/dashboard"
@@ -53,10 +54,26 @@ func (tc *testContext) waitForControllerDeployment(name string, replicas int32) 
 	return err
 }
 
+func setupDSCICR() *dsci.DSCInitialization {
+	dsciTest := &dsci.DSCInitialization{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "e2e-test-dsci",
+		},
+		Spec: dsci.DSCInitializationSpec{
+			ApplicationsNamespace: "opendatahub",
+			Monitoring: dsci.Monitoring{
+				ManagementState: "Managed",
+				Namespace:       "opendatahub",
+			},
+		},
+	}
+	return dsciTest
+}
+
 func setupDSCInstance() *dsc.DataScienceCluster {
 	dscTest := &dsc.DataScienceCluster{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "e2e-test",
+			Name: "e2e-test-dsc",
 		},
 		Spec: dsc.DataScienceClusterSpec{
 			Components: dsc.Components{


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
ref: https://github.com/opendatahub-io/opendatahub-operator/issues/765

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
keep the same logic in the operator, only add env variable into CSV and set to true by default.
**new**
live build:  quay.io/wenzhou/opendatahub-operator-catalog:v2.6.766-3
![Screenshot from 2023-12-04 09-39-47](https://github.com/opendatahub-io/opendatahub-operator/assets/915053/38a5f69f-69bf-4f39-9687-9592167898ae)


**old**
live build:  quay.io/wenzhou/opendatahub-operator-catalog:v2.6.765

- after install operator, no DSC nor DSCI CR created
![Screenshot from 2023-11-28 10-59-08](https://github.com/opendatahub-io/opendatahub-operator/assets/915053/6cdbeea4-34cd-4972-b1c5-a102963758ed)

- then manually create DSC CR

- check DSC CR event, pod log
![Screenshot from 2023-11-28 11-52-28](https://github.com/opendatahub-io/opendatahub-operator/assets/915053/afcb7345-2e5a-477f-8428-efebde47f3ff)


![Screenshot from 2023-11-28 11-10-14](https://github.com/opendatahub-io/opendatahub-operator/assets/915053/ac78625d-4fe4-474b-ae21-bdd35d0f6c66)

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
