### PR TITLE
update(UI): add extra check on service before enable prometheus

### DIFF
--- a/components/README.md
+++ b/components/README.md
@@ -37,7 +37,6 @@ can be found [here](https://github.com/opendatahub-io/opendatahub-operator/tree/
       GetManagementState() operatorv1.ManagementState
       SetImageParamsMap(imageMap map[string]string) map[string]string
       UpdatePrometheusConfig(cli client.Client, enable bool, component string) error
-      WaitForDeploymentAvailable(ctx context.Context, r *rest.Config, c string, n string, i int, t int) error
     }
     ```
 ### Add reconcile and Events

--- a/components/codeflare/codeflare.go
+++ b/components/codeflare/codeflare.go
@@ -109,7 +109,7 @@ func (c *CodeFlare) ReconcileComponent(ctx context.Context, cli client.Client, r
 		if enabled {
 			// first check if the service is up, so prometheus wont fire alerts when it is just startup
 			if err := monitoring.WaitForDeploymentAvailable(ctx, resConf, ComponentName, dscispec.ApplicationsNamespace, 20, 2); err != nil {
-				return fmt.Errorf("deployment for %s is not ready to server: %w", ComponentName, err)
+				return fmt.Errorf("deployment for %s is not done: %w", ComponentName, err)
 			}
 			fmt.Printf("deployment for %s is done, updating monitoring rules\n", ComponentName)
 		}

--- a/components/dashboard/dashboard.go
+++ b/components/dashboard/dashboard.go
@@ -175,7 +175,11 @@ func (d *Dashboard) ReconcileComponent(ctx context.Context,
 			if enabled {
 				// first check if the service is up, so prometheus wont fire alerts when it is just startup
 				if err := monitoring.WaitForDeploymentAvailable(ctx, resConf, ComponentNameSupported, dscispec.ApplicationsNamespace, 20, 3); err != nil {
-					return fmt.Errorf("deployment for %s is not ready to server: %w", ComponentName, err)
+					return fmt.Errorf("deployment for %s is not done: %w", ComponentName, err)
+				}
+				// second check if service is up
+				if err := monitoring.WaitForServiceReady(ctx, resConf, ComponentNameSupported, dscispec.ApplicationsNamespace, 20, 3, "8443"); err != nil {
+					return fmt.Errorf("service for %s is not ready to server: %w", ComponentName, err)
 				}
 				fmt.Printf("deployment for %s is done, updating monitoring rules\n", ComponentNameSupported)
 			}

--- a/components/datasciencepipelines/datasciencepipelines.go
+++ b/components/datasciencepipelines/datasciencepipelines.go
@@ -102,7 +102,7 @@ func (d *DataSciencePipelines) ReconcileComponent(ctx context.Context,
 			// first check if the service is up, so prometheus wont fire alerts when it is just startup
 			// only 1 replica should be very quick
 			if err := monitoring.WaitForDeploymentAvailable(ctx, resConf, ComponentName, dscispec.ApplicationsNamespace, 10, 1); err != nil {
-				return fmt.Errorf("deployment for %s is not ready to server: %w", ComponentName, err)
+				return fmt.Errorf("deployment for %s is not done: %w", ComponentName, err)
 			}
 			fmt.Printf("deployment for %s is done, updating monitoring rules\n", ComponentName)
 		}

--- a/components/kserve/kserve.go
+++ b/components/kserve/kserve.go
@@ -154,9 +154,9 @@ func (k *Kserve) ReconcileComponent(ctx context.Context, cli client.Client, resC
 		if enabled {
 			// first check if the service is up, so prometheus wont fire alerts when it is just startup
 			if err := monitoring.WaitForDeploymentAvailable(ctx, resConf, ComponentName, dscispec.ApplicationsNamespace, 20, 2); err != nil {
-				return fmt.Errorf("deployment for %s is not ready to server: %w", ComponentName, err)
+				return fmt.Errorf("deployment for %s is not done: %w", ComponentName, err)
 			}
-			fmt.Printf("deployment for %s is done, updating monitoing rules", ComponentName)
+			fmt.Printf("deployment for %s is done, updating monitoring rules\n", ComponentName)
 		}
 		// kesrve rules
 		if err := k.UpdatePrometheusConfig(cli, enabled && monitoringEnabled, ComponentName); err != nil {

--- a/components/modelmeshserving/modelmeshserving.go
+++ b/components/modelmeshserving/modelmeshserving.go
@@ -152,7 +152,7 @@ func (m *ModelMeshServing) ReconcileComponent(ctx context.Context,
 		if enabled {
 			// first check if service is up, so prometheus wont fire alerts when it is just startup
 			if err := monitoring.WaitForDeploymentAvailable(ctx, resConf, ComponentName, dscispec.ApplicationsNamespace, 20, 2); err != nil {
-				return fmt.Errorf("deployment for %s is not ready to server: %w", ComponentName, err)
+				return fmt.Errorf("deployment for %s is not done: %w", ComponentName, err)
 			}
 			fmt.Printf("deployment for %s is done, updating monitoring rules\n", ComponentName)
 		}

--- a/components/ray/ray.go
+++ b/components/ray/ray.go
@@ -89,7 +89,7 @@ func (r *Ray) ReconcileComponent(ctx context.Context, cli client.Client, resConf
 		if enabled {
 			// first check if the service is up, so prometheus wont fire alerts when it is just startup
 			if err := monitoring.WaitForDeploymentAvailable(ctx, resConf, ComponentName, dscispec.ApplicationsNamespace, 20, 2); err != nil {
-				return fmt.Errorf("deployment for %s is not ready to server: %w", ComponentName, err)
+				return fmt.Errorf("deployment for %s is not done: %w", ComponentName, err)
 			}
 			fmt.Printf("deployment for %s is done, updating monitoring rules\n", ComponentName)
 		}

--- a/pkg/monitoring/monitoring.go
+++ b/pkg/monitoring/monitoring.go
@@ -2,7 +2,9 @@ package monitoring
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
+	"net/http"
 	"time"
 
 	errors "k8s.io/apimachinery/pkg/api/errors"
@@ -30,15 +32,64 @@ func WaitForDeploymentAvailable(_ context.Context, restConfig *rest.Config, comp
 			}
 		}
 		isReady := false
-		fmt.Printf("waiting for %d deployment to be ready for %s\n", len(componentDeploymentList.Items), componentName)
 		if len(componentDeploymentList.Items) != 0 {
 			for _, deployment := range componentDeploymentList.Items {
 				if deployment.Status.ReadyReplicas == deployment.Status.Replicas {
 					isReady = true
 				} else {
+					fmt.Printf("waiting for %d deployment to be ready for %s\n", len(componentDeploymentList.Items), componentName)
 					isReady = false
 				}
 			}
+		}
+		return isReady, nil
+	})
+}
+
+// use extras to set port and endpoint if needed
+func WaitForServiceReady(ctx context.Context, restConfig *rest.Config, serviceName string, namespace string, interval int, timeout int, extras ...string) error {
+	resourceInterval := time.Duration(interval) * time.Second
+	resourceTimeout := time.Duration(timeout) * time.Minute
+	var servicePort, serviceEndpoint string
+	for i, param := range extras {
+		switch i {
+		case 0:
+			servicePort = param
+		case 1:
+			serviceEndpoint = param
+		}
+	}
+	serviceURL := fmt.Sprintf("https://%s.%s.svc:%s%s", serviceName, namespace, servicePort, serviceEndpoint)
+	client := http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		},
+		Timeout: time.Second * 1,
+	}
+	return wait.PollUntilContextTimeout(context.TODO(), resourceInterval, resourceTimeout, true, func(ctx context.Context) (bool, error) {
+		clientset, err := kubernetes.NewForConfig(restConfig)
+		if err != nil {
+			return false, fmt.Errorf("error getting client: %v", err)
+		}
+		_, err = clientset.CoreV1().Services(namespace).Get(context.TODO(), serviceName, metav1.GetOptions{})
+		if err != nil {
+			if errors.IsNotFound(err) {
+				return false, nil
+			}
+		}
+		isReady := false
+		response, err := client.Get(serviceURL)
+		if err != nil {
+			return false, fmt.Errorf("error to query service: %v", err)
+		}
+		defer response.Body.Close()
+		// 200 or 403 as long as return
+		if response.StatusCode == http.StatusOK || response.StatusCode == http.StatusForbidden {
+			fmt.Printf("service %s is ready to server\n", serviceName)
+			isReady = true
+		} else {
+			fmt.Printf("waiting for service %s to be ready, got return code %d\n", serviceName, response.StatusCode)
+			isReady = false
 		}
 		return isReady, nil
 	})


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
ref: https://issues.redhat.com/browse/RHOAIENG-87

it is somewhat every strange design in v1 https://github.com/red-hat-data-services/odh-deployer/blob/f315a7aad26bf15bfa83855846efb8c6fab98a91/monitoring/prometheus/blackbox-exporter-common.yaml#L61
but if this can stop firing alerts for dashboard in a clean installed cluster then just do the same implmentation. 
mostly it get 403 with forbidden

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
