### PR TITLE
update(UI): cleanup jupyterhub CR from dashboard

### DIFF
--- a/main.go
+++ b/main.go
@@ -199,6 +199,10 @@ func main() { //nolint:funlen
 		setupLog.Error(err, "unable to update from legacy operator version")
 	}
 
+	if err = upgrade.CleanupExistingResource(mgr.GetConfig(), dscApplicationsNamespace); err != nil {
+		setupLog.Error(err, "unable to perform cleanup")
+	}
+
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
 		setupLog.Error(err, "unable to set up health check")
 		os.Exit(1)

--- a/pkg/gvr/gvr.go
+++ b/pkg/gvr/gvr.go
@@ -32,4 +32,10 @@ var (
 		Version:  "v1",
 		Resource: "networkpolicies",
 	}
+
+	JupyterhubApp = schema.GroupVersionResource{
+		Group:    "dashboard.opendatahub.io",
+		Version:  "v1",
+		Resource: "odhapplications",
+	}
 )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
this is just a workaround to get dashboard moving forward
we will work on a proper solution in general for the "prune" case
ref: https://issues.redhat.com/browse/RHOAIENG-443


## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
live build quay.io/wenzhou/opendatahub-operator-catalog:v2.6.443-1

tested:
1.  when a cluster already have such CR (manually created one called jupyterhub in opendatahub ns)
2. when clean install cluster (should not have such CR): no error but log saying jupyterhub not exist in opendatahub, nothing to prune
3. when a cluster already have such CR( created by operator) : 
-install operator, 
- turn dashboard on: see both jupyterhub and jupyter CR created with same timestamp
- restart operator pod: check above 2 CR again, jupyterhub will be first deleted then recreated (if UI manifests still include this definition), both have different timestamp after reconcile done.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
