### PR TITLE
fix(rbac): missing get verbs on MWC and Secret

### DIFF
--- a/bundle/manifests/opendatahub-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/opendatahub-operator.clusterserviceversion.yaml
@@ -279,6 +279,7 @@ spec:
           verbs:
           - create
           - delete
+          - get
           - list
           - patch
           - update
@@ -675,6 +676,7 @@ spec:
           verbs:
           - create
           - delete
+          - get
           - list
           - patch
           - update

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -56,6 +56,7 @@ rules:
   verbs:
   - create
   - delete
+  - get
   - list
   - patch
   - update
@@ -452,6 +453,7 @@ rules:
   verbs:
   - create
   - delete
+  - get
   - list
   - patch
   - update

--- a/controllers/datasciencecluster/kubebuilder_rbac.go
+++ b/controllers/datasciencecluster/kubebuilder_rbac.go
@@ -164,7 +164,7 @@ package datasciencecluster
 
 // +kubebuilder:rbac:groups="core",resources=serviceaccounts,verbs=get;list;watch;create;update;patch;delete
 
-// +kubebuilder:rbac:groups="core",resources=secrets,verbs=create;delete;list;update;watch;patch
+// +kubebuilder:rbac:groups="core",resources=secrets,verbs=create;delete;list;update;watch;patch;get
 // +kubebuilder:rbac:groups="core",resources=secrets/finalizers,verbs=get;create;watch;update;patch;list;delete
 
 // +kubebuilder:rbac:groups="core",resources=rhmis,verbs=watch;list
@@ -233,7 +233,7 @@ package datasciencecluster
 // +kubebuilder:rbac:groups="apiextensions.k8s.io",resources=customresourcedefinitions,verbs=get;list;watch;create;patch;delete
 
 // +kubebuilder:rbac:groups="admissionregistration.k8s.io",resources=validatingwebhookconfigurations,verbs=get;list;watch;create;update;delete;patch
-// +kubebuilder:rbac:groups="admissionregistration.k8s.io",resources=mutatingwebhookconfigurations,verbs=create;delete;list;update;watch;patch
+// +kubebuilder:rbac:groups="admissionregistration.k8s.io",resources=mutatingwebhookconfigurations,verbs=create;delete;list;update;watch;patch;get
 
 /* This is needed to derterminiate cluster type */
 // +kubebuilder:rbac:groups="addons.managed.openshift.io",resources=addons,verbs=get


### PR DESCRIPTION
- this is causing MWC CR from kserve did not get cleanedup when kserve is Removed
- during debug the issue saw the error is also on Secret, therefore add "get" on it as well

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

ref https://issues.redhat.com/browse/RHOAIENG-908

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
live build: quay.io/wenzhou/opendatahub-operator-catalog:v2.5.788-1

after enable kserve and workbenches see Ownerreference is added
![Screenshot from 2023-12-14 12-25-00](https://github.com/opendatahub-io/opendatahub-operator/assets/915053/13056ce1-a015-4be5-b887-923e034b72f2)


## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
