### PR TITLE
chore: shifts FeatureTracker creation to Feature's Apply phase

### DIFF
--- a/pkg/feature/builder.go
+++ b/pkg/feature/builder.go
@@ -180,11 +180,5 @@ func (fb *featureBuilder) Load() (*Feature, error) {
 		}
 	}
 
-	if feature.Enabled {
-		if err := feature.createResourceTracker(); err != nil {
-			return feature, err
-		}
-	}
-
 	return feature, nil
 }

--- a/pkg/feature/feature.go
+++ b/pkg/feature/feature.go
@@ -49,6 +49,10 @@ func (f *Feature) Apply() error {
 		return nil
 	}
 
+	if err := f.createResourceTracker(); err != nil {
+		return err
+	}
+
 	// Verify all precondition and collect errors
 	var multiErr *multierror.Error
 	for _, precondition := range f.preconditions {
@@ -229,7 +233,9 @@ func (f *Feature) createResourceTracker() error {
 
 	// Register its own cleanup
 	f.addCleanup(func(feature *Feature) error {
-		if err := f.DynamicClient.Resource(gvr.ResourceTracker).Delete(context.TODO(), f.Spec.Tracker.Name, metav1.DeleteOptions{}); err != nil && !k8serrors.IsNotFound(err) {
+		err := f.DynamicClient.Resource(gvr.ResourceTracker).Delete(context.TODO(), f.Spec.Tracker.Name, metav1.DeleteOptions{})
+
+		if !k8serrors.IsNotFound(err) {
 			return err
 		}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This change removes tracker creation from the `Load()` phase in the builder, aligning with the principle that the builder's role is to set up features for execution. The creation of the associated tracker is more appropriately handled as the first step of the Feature's Apply phase.

It required small changes in the tests.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

K8s testenv tests + manual happy path.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
