### PR TITLE
fix: ensures Wait function waits for pods to appear in a given namespace

### DIFF
--- a/pkg/feature/conditions.go
+++ b/pkg/feature/conditions.go
@@ -36,6 +36,10 @@ func WaitForPodsToBeReady(namespace string) Action {
 			readyPods := 0
 			totalPods := len(podList.Items)
 
+			if totalPods == 0 { // We want to wait for "something", so make sure we have "something" before we claim success.
+				return false, nil
+			}
+
 			for _, pod := range podList.Items {
 				podReady := true
 				// Consider a "PodSucceeded" as ready, since these will never will


### PR DESCRIPTION
## Description

When the Wait function is called to wait for e.g. the expected outcome of another operator, the operator might take longer then the initial interval time of 2s to create a pod. In this scenario the Wait function would get 0 Pods returned from the API Server to check the state of and assume all is done.

Ensure we at least get a pod count higher then 0 before we return successful. This gives the other operator our 5min deadline to create and start the pod(s).

## How Has This Been Tested?

Manually.

Verify that the Wait for ServiceMesh/Serverless pods take more then 2s (assuming it takes the Operator more then 2s to create the pod)

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
