### PR TITLE
Apply independent component name for odh-model-controller

### DIFF
--- a/components/kserve/kserve.go
+++ b/components/kserve/kserve.go
@@ -143,7 +143,7 @@ func (k *Kserve) ReconcileComponent(ctx context.Context, cli client.Client, resC
 		}
 	}
 
-	if err := deploy.DeployManifestsFromPath(cli, owner, DependentPath, dscispec.ApplicationsNamespace, ComponentName, enabled); err != nil {
+	if err := deploy.DeployManifestsFromPath(cli, owner, DependentPath, dscispec.ApplicationsNamespace, DependentComponentName, enabled); err != nil {
 		if !strings.Contains(err.Error(), "spec.selector") || !strings.Contains(err.Error(), "field is immutable") {
 			// explicitly ignore error if error contains keywords "spec.selector" and "field is immutable" and return all other error.
 			return err

--- a/components/modelmeshserving/modelmeshserving.go
+++ b/components/modelmeshserving/modelmeshserving.go
@@ -140,7 +140,7 @@ func (m *ModelMeshServing) ReconcileComponent(ctx context.Context,
 			}
 		}
 	}
-	if err := deploy.DeployManifestsFromPath(cli, owner, DependentPath, dscispec.ApplicationsNamespace, m.GetComponentName(), enabled); err != nil {
+	if err := deploy.DeployManifestsFromPath(cli, owner, DependentPath, dscispec.ApplicationsNamespace, DependentComponentName, enabled); err != nil {
 		// explicitly ignore error if error contains keywords "spec.selector" and "field is immutable" and return all other error.
 		if !strings.Contains(err.Error(), "spec.selector") || !strings.Contains(err.Error(), "field is immutable") {
 			return err

--- a/controllers/datasciencecluster/datasciencecluster_controller.go
+++ b/controllers/datasciencecluster/datasciencecluster_controller.go
@@ -22,7 +22,6 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
-	"strings"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -334,57 +333,6 @@ var configMapPredicates = predicate.Funcs{
 	},
 }
 
-// a workaround for 2.5 due to odh-model-controller serivceaccount keeps updates with label.
-var saPredicates = predicate.Funcs{
-	UpdateFunc: func(e event.UpdateEvent) bool {
-		if e.ObjectNew.GetName() == "odh-model-controller" && (e.ObjectNew.GetNamespace() == "redhat-ods-applications" || e.ObjectNew.GetNamespace() == "opendatahub") {
-			return false
-		}
-		return true
-	},
-}
-
-// a workaround for 2.5 due to modelmesh-servingruntime.serving.kserve.io keeps updates.
-var modelMeshwebhookPredicates = predicate.Funcs{
-	UpdateFunc: func(e event.UpdateEvent) bool {
-		return e.ObjectNew.GetName() != "modelmesh-servingruntime.serving.kserve.io"
-	},
-}
-
-var modelMeshRolePredicates = predicate.Funcs{
-	UpdateFunc: func(e event.UpdateEvent) bool {
-		notAllowedNames := []string{"leader-election-role", "proxy-role", "metrics-reader", "kserve-prometheus-k8s", "odh-model-controller-role"}
-		for _, notallowedName := range notAllowedNames {
-			if e.ObjectNew.GetName() == notallowedName {
-				return false
-			}
-		}
-		return true
-	},
-}
-
-var modelMeshRBPredicates = predicate.Funcs{
-	UpdateFunc: func(e event.UpdateEvent) bool {
-		notAllowedNames := []string{"leader-election-rolebinding", "proxy-rolebinding", "odh-model-controller-rolebinding-opendatahub"}
-		for _, notallowedName := range notAllowedNames {
-			if e.ObjectNew.GetName() == notallowedName {
-				return false
-			}
-		}
-		return true
-	},
-}
-
-// ignore label updates if it is from application namespace.
-var modelMeshGeneralPredicates = predicate.Funcs{
-	UpdateFunc: func(e event.UpdateEvent) bool {
-		if strings.Contains(e.ObjectNew.GetName(), "odh-model-controller") || strings.Contains(e.ObjectNew.GetName(), "kserve") {
-			return false
-		}
-		return true
-	},
-}
-
 // SetupWithManager sets up the controller with the Manager.
 func (r *DataScienceClusterReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
@@ -393,21 +341,21 @@ func (r *DataScienceClusterReconciler) SetupWithManager(mgr ctrl.Manager) error 
 		Owns(&corev1.Secret{}).
 		Owns(&corev1.ConfigMap{}, builder.WithPredicates(configMapPredicates)).
 		Owns(&netv1.NetworkPolicy{}).
-		Owns(&authv1.Role{}, builder.WithPredicates(predicate.Or(predicate.GenerationChangedPredicate{}, modelMeshRolePredicates))).
-		Owns(&authv1.RoleBinding{}, builder.WithPredicates(predicate.Or(predicate.GenerationChangedPredicate{}, modelMeshRBPredicates))).
-		Owns(&authv1.ClusterRole{}, builder.WithPredicates(predicate.Or(predicate.GenerationChangedPredicate{}, modelMeshRolePredicates))).
-		Owns(&authv1.ClusterRoleBinding{}, builder.WithPredicates(predicate.Or(predicate.GenerationChangedPredicate{}, modelMeshRBPredicates))).
+		Owns(&authv1.Role{}).
+		Owns(&authv1.RoleBinding{}).
+		Owns(&authv1.ClusterRole{}).
+		Owns(&authv1.ClusterRoleBinding{}).
 		Owns(&appsv1.Deployment{}).
 		Owns(&corev1.PersistentVolumeClaim{}).
-		Owns(&corev1.Service{}, builder.WithPredicates(predicate.Or(predicate.GenerationChangedPredicate{}, modelMeshGeneralPredicates))).
+		Owns(&corev1.Service{}).
 		Owns(&appsv1.StatefulSet{}).
 		Owns(&ocimgv1.ImageStream{}).
 		Owns(&ocbuildv1.BuildConfig{}).
 		Owns(&apiregistrationv1.APIService{}).
 		Owns(&netv1.Ingress{}).
 		Owns(&admv1.MutatingWebhookConfiguration{}).
-		Owns(&admv1.ValidatingWebhookConfiguration{}, builder.WithPredicates(modelMeshwebhookPredicates)).
-		Owns(&corev1.ServiceAccount{}, builder.WithPredicates(saPredicates)).
+		Owns(&admv1.ValidatingWebhookConfiguration{}).
+		Owns(&corev1.ServiceAccount{}).
 		Watches(&source.Kind{Type: &dsci.DSCInitialization{}}, handler.EnqueueRequestsFromMapFunc(r.watchDataScienceClusterResources)).
 		Watches(&source.Kind{Type: &corev1.ConfigMap{}}, handler.EnqueueRequestsFromMapFunc(r.watchDataScienceClusterResources), builder.WithPredicates(configMapPredicates)).
 		// this predicates prevents meaningless reconciliations from being triggered


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This change is to fix https://issues.redhat.com/browse/RHOAIENG-1894

**Analysis**
odh-model-controller is common component which is called from both KServe and ModelMesh. When both KServe and ModelMesh are enabled the they applies odh-model-controller manifest twice, once for each of them. When ModelMesh apply odh-model-controller manifest it pass component name as model-mesh which subesequently set as label in resources generated by odh-model-controller such as ServiceAccount(odh-model-controller-metrics-monitor) whereas when KServe apply odh-model-controller manifest it pass component name as Kserve.
Same label modification by both KServe and ModelMesh causes DataScienceCluster reconcilation to run in infinite loop.

**Solution**
Provide independent component name for odh-model-controller so that it would be same when applied by ModelMesh or KServe.

<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
