### PR TITLE
fix(service-mesh): ensures SMCP is available before patching network policy

### DIFF
--- a/controllers/dscinitialization/servicemesh_setup.go
+++ b/controllers/dscinitialization/servicemesh_setup.go
@@ -92,6 +92,9 @@ func configureServiceMeshFeatures(s *feature.FeaturesInitializer) error {
 
 	noDefaultNetworkPolicies, errNp := feature.CreateFeature("mesh-control-plane-no-default-network-policies").
 		For(s.DSCInitializationSpec).
+		PreConditions(
+			servicemesh.EnsureServiceMeshInstalled,
+		).
 		Manifests(
 			path.Join(rootDir, templatesDir, "base", "control-plane-disable-networkpolicies.patch.tmpl"),
 		).
@@ -105,11 +108,11 @@ func configureServiceMeshFeatures(s *feature.FeaturesInitializer) error {
 	if serviceMeshSpec.ControlPlane.MetricsCollection == "Istio" {
 		metricsCollection, errMetrics := feature.CreateFeature("mesh-metrics-collection").
 			For(s.DSCInitializationSpec).
-			Manifests(
-				path.Join(rootDir, templatesDir, "metrics-collection"),
-			).
 			PreConditions(
 				servicemesh.EnsureServiceMeshInstalled,
+			).
+			Manifests(
+				path.Join(rootDir, templatesDir, "metrics-collection"),
 			).
 			Load()
 		if errMetrics != nil {

--- a/pkg/feature/builder.go
+++ b/pkg/feature/builder.go
@@ -145,10 +145,7 @@ func (fb *featureBuilder) WithResources(resources ...Action) *featureBuilder {
 }
 
 func (fb *featureBuilder) Load() (*Feature, error) {
-	feature := &Feature{
-		Name:    fb.name,
-		Enabled: true,
-	}
+	feature := newFeature(fb.name)
 
 	// UsingConfig builder wasn't called while constructing this feature.
 	// Get default settings and create needed clients.

--- a/pkg/feature/conditions.go
+++ b/pkg/feature/conditions.go
@@ -24,11 +24,11 @@ func EnsureCRDIsInstalled(name string) Action {
 }
 
 func WaitForPodsToBeReady(namespace string) Action {
-	return func(feature *Feature) error {
-		log.Info("waiting for pods to become ready", "feature", feature.Name, "namespace", namespace, "duration (s)", duration.Seconds())
+	return func(f *Feature) error {
+		f.Log.Info("waiting for pods to become ready", "namespace", namespace, "duration (s)", duration.Seconds())
 
 		return wait.PollUntilContextTimeout(context.TODO(), interval, duration, false, func(ctx context.Context) (bool, error) {
-			podList, err := feature.Clientset.CoreV1().Pods(namespace).List(context.TODO(), metav1.ListOptions{})
+			podList, err := f.Clientset.CoreV1().Pods(namespace).List(context.TODO(), metav1.ListOptions{})
 			if err != nil {
 				return false, err
 			}
@@ -63,7 +63,7 @@ func WaitForPodsToBeReady(namespace string) Action {
 			done := readyPods == totalPods
 
 			if done {
-				log.Info("done waiting for pods to become ready", "feature", feature.Name, "namespace", namespace)
+				f.Log.Info("done waiting for pods to become ready", "namespace", namespace)
 			}
 
 			return done, nil
@@ -72,19 +72,19 @@ func WaitForPodsToBeReady(namespace string) Action {
 }
 
 func WaitForResourceToBeCreated(namespace string, gvr schema.GroupVersionResource) Action {
-	return func(feature *Feature) error {
-		log.Info("waiting for resource to be created", "namespace", namespace, "resource", gvr)
+	return func(f *Feature) error {
+		f.Log.Info("waiting for resource to be created", "namespace", namespace, "resource", gvr)
 
 		return wait.PollUntilContextTimeout(context.TODO(), interval, duration, false, func(ctx context.Context) (bool, error) {
-			resources, err := feature.DynamicClient.Resource(gvr).Namespace(namespace).List(context.TODO(), metav1.ListOptions{Limit: 1})
+			resources, err := f.DynamicClient.Resource(gvr).Namespace(namespace).List(context.TODO(), metav1.ListOptions{Limit: 1})
 			if err != nil {
-				log.Error(err, "failed waiting for resource", "namespace", namespace, "resource", gvr)
+				f.Log.Error(err, "failed waiting for resource", "namespace", namespace, "resource", gvr)
 
 				return false, err
 			}
 
 			if len(resources.Items) > 0 {
-				log.Info("resource created", "namespace", namespace, "resource", gvr)
+				f.Log.Info("resource created", "namespace", namespace, "resource", gvr)
 
 				return true, nil
 			}

--- a/pkg/feature/feature.go
+++ b/pkg/feature/feature.go
@@ -59,7 +59,6 @@ func (f *Feature) Apply() error {
 	}
 
 	if err := f.createResourceTracker(); err != nil {
-		f.Log.Error(err, "failed creating resource tracker")
 		return err
 	}
 
@@ -70,7 +69,6 @@ func (f *Feature) Apply() error {
 	}
 
 	if preconditionsErr := multiErr.ErrorOrNil(); preconditionsErr != nil {
-		f.Log.Error(preconditionsErr, "failed ensuring preconditions are met")
 		return preconditionsErr
 	}
 
@@ -80,14 +78,12 @@ func (f *Feature) Apply() error {
 	}
 
 	if dataLoadErr := multiErr.ErrorOrNil(); dataLoadErr != nil {
-		f.Log.Error(dataLoadErr, "failed loading template data")
 		return dataLoadErr
 	}
 
 	// create or update resources
 	for _, resource := range f.resources {
 		if err := resource(f); err != nil {
-			f.Log.Error(err, "failed creating a resource")
 			return errors.WithStack(err)
 		}
 	}
@@ -95,13 +91,11 @@ func (f *Feature) Apply() error {
 	// Process and apply manifests
 	for _, m := range f.manifests {
 		if err := m.processTemplate(f.Spec); err != nil {
-			f.Log.Error(err, "failed processing a template")
 			return errors.WithStack(err)
 		}
 	}
 
 	if err := f.applyManifests(); err != nil {
-		f.Log.Error(err, "failed applying manifests")
 		return errors.WithStack(err)
 	}
 
@@ -109,12 +103,7 @@ func (f *Feature) Apply() error {
 		multiErr = multierror.Append(multiErr, postcondition(f))
 	}
 
-	if postconditionsErr := multiErr.ErrorOrNil(); postconditionsErr != nil {
-		f.Log.Error(postconditionsErr, "failed ensuring postconditions are met")
-		return postconditionsErr
-	}
-
-	return nil
+	return multiErr.ErrorOrNil()
 }
 
 func (f *Feature) Cleanup() error {

--- a/pkg/feature/feature.go
+++ b/pkg/feature/feature.go
@@ -3,7 +3,6 @@ package feature
 import (
 	"context"
 
-
 	"github.com/go-logr/logr"
 	"github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
@@ -70,8 +69,7 @@ func (f *Feature) Apply() error {
 		multiErr = multierror.Append(multiErr, precondition(f))
 	}
 
-	preconditionsErr := multiErr.ErrorOrNil()
-	if preconditionsErr != nil {
+	if preconditionsErr := multiErr.ErrorOrNil(); preconditionsErr != nil {
 		f.Log.Error(preconditionsErr, "failed ensuring preconditions are met")
 		return preconditionsErr
 	}
@@ -81,8 +79,7 @@ func (f *Feature) Apply() error {
 		multiErr = multierror.Append(multiErr, loader(f))
 	}
 
-	dataLoadErr := multiErr.ErrorOrNil()
-	if dataLoadErr != nil {
+	if dataLoadErr := multiErr.ErrorOrNil(); dataLoadErr != nil {
 		f.Log.Error(dataLoadErr, "failed loading template data")
 		return dataLoadErr
 	}
@@ -112,8 +109,7 @@ func (f *Feature) Apply() error {
 		multiErr = multierror.Append(multiErr, postcondition(f))
 	}
 
-	postconditionsErr := multiErr.ErrorOrNil()
-	if postconditionsErr != nil {
+	if postconditionsErr := multiErr.ErrorOrNil(); postconditionsErr != nil {
 		f.Log.Error(postconditionsErr, "failed ensuring postconditions are met")
 		return postconditionsErr
 	}

--- a/pkg/feature/feature.go
+++ b/pkg/feature/feature.go
@@ -112,10 +112,10 @@ func (f *Feature) Apply() error {
 		multiErr = multierror.Append(multiErr, postcondition(f))
 	}
 
-	postconditionErr := multiErr.ErrorOrNil()
-	if postconditionErr != nil {
-		f.Log.Error(preconditionsErr, "failed ensuring postconditions are met")
-		return postconditionErr
+	postconditionsErr := multiErr.ErrorOrNil()
+	if postconditionsErr != nil {
+		f.Log.Error(postconditionsErr, "failed ensuring postconditions are met")
+		return postconditionsErr
 	}
 
 	return nil

--- a/pkg/feature/initializer.go
+++ b/pkg/feature/initializer.go
@@ -25,8 +25,6 @@ func NewFeaturesInitializer(spec *v1.DSCInitializationSpec, def DefinedFeatures)
 // such as Features and their templates, are processed and initialized
 // before proceeding with the actual cluster set-up.
 func (s *FeaturesInitializer) Prepare() error {
-	log.Info("Initializing features")
-
 	return s.definedFeatures(s)
 }
 
@@ -47,7 +45,6 @@ func (s *FeaturesInitializer) Apply() error {
 func (s *FeaturesInitializer) Delete() error {
 	var cleanupErrors *multierror.Error
 	for i := len(s.Features) - 1; i >= 0; i-- {
-		log.Info("cleanup", "name", s.Features[i].Name)
 		cleanupErrors = multierror.Append(cleanupErrors, s.Features[i].Cleanup())
 	}
 

--- a/pkg/feature/manifest.go
+++ b/pkg/feature/manifest.go
@@ -57,7 +57,7 @@ func (m *manifest) processTemplate(data interface{}) error {
 
 	f, err := os.Create(path)
 	if err != nil {
-		return errors.Wrap(err, "failed to create file")
+		return fmt.Errorf("failed to create file: %w", err)
 	}
 
 	tmpl := template.New(m.name).Funcs(template.FuncMap{"ReplaceChar": ReplaceChar})

--- a/pkg/feature/manifest.go
+++ b/pkg/feature/manifest.go
@@ -57,9 +57,7 @@ func (m *manifest) processTemplate(data interface{}) error {
 
 	f, err := os.Create(path)
 	if err != nil {
-		log.Error(err, "Failed to create file")
-
-		return err
+		return errors.Wrap(err, "failed to create file")
 	}
 
 	tmpl := template.New(m.name).Funcs(template.FuncMap{"ReplaceChar": ReplaceChar})

--- a/pkg/feature/raw_resources.go
+++ b/pkg/feature/raw_resources.go
@@ -58,11 +58,11 @@ func (f *Feature) createResourceFromFile(filename string) error {
 			f.AsOwnerReference(),
 		})
 
-		log.Info("Creating resource", "name", name)
+		f.Log.Info("Creating resource", "name", name)
 
 		err := f.Client.Get(context.TODO(), k8stypes.NamespacedName{Name: name, Namespace: namespace}, u.DeepCopy())
 		if err == nil {
-			log.Info("Object already exists...")
+			f.Log.Info("Object already exists...")
 
 			continue
 		}
@@ -92,7 +92,7 @@ func (f *Feature) patchResourceFromFile(filename string) error {
 		}
 		u := &unstructured.Unstructured{}
 		if err := yaml.Unmarshal([]byte(str), u); err != nil {
-			log.Error(err, "error unmarshalling yaml")
+			f.Log.Error(err, "error unmarshalling yaml")
 
 			return errors.WithStack(err)
 		}
@@ -108,7 +108,7 @@ func (f *Feature) patchResourceFromFile(filename string) error {
 		// Convert the patch from YAML to JSON
 		patchAsJSON, err := yaml.YAMLToJSON(data)
 		if err != nil {
-			log.Error(err, "error converting yaml to json")
+			f.Log.Error(err, "error converting yaml to json")
 
 			return errors.WithStack(err)
 		}
@@ -117,7 +117,7 @@ func (f *Feature) patchResourceFromFile(filename string) error {
 			Namespace(u.GetNamespace()).
 			Patch(context.TODO(), u.GetName(), k8stypes.MergePatchType, patchAsJSON, metav1.PatchOptions{})
 		if err != nil {
-			log.Error(err, "error patching resource",
+			f.Log.Error(err, "error patching resource",
 				"gvr", fmt.Sprintf("%+v\n", gvr),
 				"patch", fmt.Sprintf("%+v\n", u),
 				"json", fmt.Sprintf("%+v\n", patchAsJSON))

--- a/pkg/feature/servicemesh/conditions.go
+++ b/pkg/feature/servicemesh/conditions.go
@@ -2,6 +2,7 @@ package servicemesh
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/hashicorp/go-multierror"
@@ -67,12 +68,12 @@ func WaitForControlPlaneToBeReady(f *feature.Feature) error {
 func CheckControlPlaneComponentReadiness(dynamicClient dynamic.Interface, smcp, smcpNs string) (bool, error) {
 	unstructObj, err := dynamicClient.Resource(gvr.SMCP).Namespace(smcpNs).Get(context.TODO(), smcp, metav1.GetOptions{})
 	if err != nil {
-		return false, errors.Wrap(err, "failed to find Service Mesh Control Plane")
+		return false, fmt.Errorf("failed to find Service Mesh Control Plane: %w", err)
 	}
 
 	components, found, err := unstructured.NestedMap(unstructObj.Object, "status", "readiness", "components")
 	if err != nil || !found {
-		return false, errors.Wrap(err, "status conditions not found or error in parsing of Service Mesh Control Plane")
+		return false, fmt.Errorf("status conditions not found or error in parsing of Service Mesh Control Plane: %w", err)
 	}
 
 	readyComponents := len(components["ready"].([]interface{}))     //nolint:forcetypeassert

--- a/pkg/feature/servicemesh/conditions.go
+++ b/pkg/feature/servicemesh/conditions.go
@@ -22,7 +22,7 @@ const (
 
 func EnsureServiceMeshOperatorInstalled(f *feature.Feature) error {
 	if err := feature.EnsureCRDIsInstalled("servicemeshcontrolplanes.maistra.io")(f); err != nil {
-		f.Log.Info("Failed to find the pre-requisite Service Mesh Control Plane CRD, please ensure Service Mesh Operator is installed.", "feature", f.Name)
+		f.Log.Info("Failed to find the pre-requisite Service Mesh Control Plane CRD, please ensure Service Mesh Operator is installed.")
 
 		return err
 	}

--- a/tests/integration/features/servicemesh_feature_test.go
+++ b/tests/integration/features/servicemesh_feature_test.go
@@ -58,7 +58,7 @@ var _ = Describe("Service Mesh feature", func() {
 
 		When("operator is installed", func() {
 
-			It("should faile checking operator presence prerequisite when CRD not installed", func() {
+			It("should fail checking operator presence prerequisite when CRD not installed", func() {
 				Expect(servicemesh.EnsureServiceMeshOperatorInstalled(testFeature)).ToNot(Succeed())
 			})
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

If a Service Mesh Control Plane is not created, applying a network policy patch does not make sense. We could have fail earlier and report the actual problem instead of 

```
ERROR features error patching resource {"gvr": "http://maistra.io/v2, Resource=servicemeshcontrolplanes\n", 
"patch": "&{Object:map[apiVersion:maistra.io/v2 kind:ServiceMeshControlPlane metadata:map[name:basic namespace:istio-system] spec:map[security:map[manageNetworkPolicy:false]]]}\n", 
"json": "[...]\n", "error": "the server could not find the requested resource", "feature": "mesh-control-plane-no-default-network-policies"}
```

With this improvement, the error message is a bit more helpful:

```
ERROR features Failed to find the pre-requisite Service Mesh Control Plane CRD, please ensure Service Mesh Operator is installed. {"feature": "mesh-control-plane-no-default-network-policiesn"}
```

This PR also unifies logger usage per feature.

## How Has This Been Tested?

Manually on the cluster.

Steps:

- Do not install OSSM operator
- Create DSCI
- See error above

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
