### PR TITLE
chore: swaps errors.Wrap to fmt.Errorf

### DIFF
--- a/pkg/cluster/operations.go
+++ b/pkg/cluster/operations.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	authv1 "k8s.io/api/rbac/v1"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
@@ -120,7 +119,7 @@ func WithLabels(labels ...string) MetaOptions {
 	return func(obj metav1.Object) error {
 		labelsMap, err := extractKeyValues(labels)
 		if err != nil {
-			return errors.Wrap(err, "unable to set labels")
+			return fmt.Errorf("failed unable to set labels: %w", err)
 		}
 
 		obj.SetLabels(labelsMap)

--- a/tests/e2e/controller_setup_test.go
+++ b/tests/e2e/controller_setup_test.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	routev1 "github.com/openshift/api/route/v1"
-	"github.com/pkg/errors"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -67,13 +66,13 @@ func NewTestContext() (*testContext, error) { //nolint:golint,revive // Only use
 
 	kc, err := k8sclient.NewForConfig(config)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to initialize Kubernetes client")
+		return nil, fmt.Errorf("failed to initialize Kubernetes client: %w", err)
 	}
 
 	// custom client to manages resources like Route etc
 	custClient, err := client.New(config, client.Options{Scheme: scheme})
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to initialize custom client")
+		return nil, fmt.Errorf("failed to initialize custom client: %w", err)
 	}
 
 	// setup DSCI CR since we do not create automatically by operator

--- a/tests/e2e/dsc_cfmap_deletion_test.go
+++ b/tests/e2e/dsc_cfmap_deletion_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -62,7 +61,7 @@ func cfgMapDeletionTestSuite(t *testing.T) {
 func (tc *testContext) testDSCIDeletion() error {
 	dsciInstances := &dsci.DSCInitializationList{}
 	if err := tc.customClient.List(context.TODO(), dsciInstances); err != nil {
-		return errors.Wrap(err, "failed while listing DSCIs")
+		return fmt.Errorf("failed while listing DSCIs: %w", err)
 	}
 
 	if len(dsciInstances.Items) != 0 {
@@ -103,7 +102,7 @@ func (tc *testContext) testOwnedNamespacesDeletion() error {
 
 		return len(namespaces.Items) == 0, err
 	}); err != nil {
-		return errors.Wrap(err, "failed waiting for all owned namespaces to be deleted")
+		return fmt.Errorf("failed waiting for all owned namespaces to be deleted: %w", err)
 	}
 
 	return nil


### PR DESCRIPTION
Based on https://github.com/opendatahub-io/opendatahub-operator/pull/805#discussion_r1454202693 

@VaishnaviHire @zdtsw Not sure what we want to do with `errors.WithStack`. Do we need it? Is it useful?