### PR TITLE
fix(service-mesh): reverts disabling network policy management

### DIFF
--- a/controllers/dscinitialization/servicemesh_setup.go
+++ b/controllers/dscinitialization/servicemesh_setup.go
@@ -90,21 +90,6 @@ func configureServiceMeshFeatures(s *feature.FeaturesInitializer) error {
 	}
 	s.Features = append(s.Features, smcpCreation)
 
-	noDefaultNetworkPolicies, errNp := feature.CreateFeature("mesh-control-plane-no-default-network-policies").
-		For(s.DSCInitializationSpec).
-		PreConditions(
-			servicemesh.EnsureServiceMeshInstalled,
-		).
-		Manifests(
-			path.Join(rootDir, templatesDir, "base", "control-plane-disable-networkpolicies.patch.tmpl"),
-		).
-		Load()
-
-	if errNp != nil {
-		return errNp
-	}
-	s.Features = append(s.Features, noDefaultNetworkPolicies)
-
 	if serviceMeshSpec.ControlPlane.MetricsCollection == "Istio" {
 		metricsCollection, errMetrics := feature.CreateFeature("mesh-metrics-collection").
 			For(s.DSCInitializationSpec).

--- a/pkg/feature/templates/servicemesh/base/control-plane-disable-networkpolicies.patch.tmpl
+++ b/pkg/feature/templates/servicemesh/base/control-plane-disable-networkpolicies.patch.tmpl
@@ -1,8 +1,0 @@
-apiVersion: maistra.io/v2
-kind: ServiceMeshControlPlane
-metadata:
-  name: {{ .ControlPlane.Name }}
-  namespace: {{ .ControlPlane.Namespace }}
-spec:
-  security:
-    manageNetworkPolicy: false

--- a/tests/integration/features/servicemesh_feature_test.go
+++ b/tests/integration/features/servicemesh_feature_test.go
@@ -2,10 +2,6 @@ package features_test
 
 import (
 	"context"
-	"io"
-	"os"
-	"path"
-	"path/filepath"
 
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -218,57 +214,4 @@ func createSMCPInCluster(cfg *rest.Config, smcpObj *unstructured.Unstructured, n
 	}
 
 	return nil
-}
-
-func getServiceMeshControlPlane(cfg *rest.Config, namespace, name string) (*unstructured.Unstructured, error) {
-	dynamicClient, err := dynamic.NewForConfig(cfg)
-	if err != nil {
-		return nil, err
-	}
-
-	smcp, err := dynamicClient.Resource(gvr.SMCP).Namespace(namespace).Get(context.TODO(), name, metav1.GetOptions{})
-	if err != nil {
-		return nil, err
-	}
-
-	return smcp, nil
-}
-
-func fromTestTmpDir(fileName string) string {
-	root, err := envtestutil.FindProjectRoot()
-	Expect(err).ToNot(HaveOccurred())
-
-	tmpDir := filepath.Join(os.TempDir(), envtestutil.RandomUUIDName(16))
-	if err := os.Mkdir(tmpDir, os.ModePerm); err != nil {
-		Fail(err.Error())
-	}
-
-	src := path.Join(root, "pkg", "feature", fileName)
-	dest := path.Join(tmpDir, fileName)
-	if err := copyFile(src, dest); err != nil {
-		Fail(err.Error())
-	}
-
-	return dest
-}
-
-func copyFile(src, dst string) error {
-	source, err := os.Open(src)
-	if err != nil {
-		return err
-	}
-	defer source.Close()
-
-	if err := os.MkdirAll(filepath.Dir(dst), os.ModePerm); err != nil {
-		return err
-	}
-
-	destination, err := os.Create(dst)
-	if err != nil {
-		return err
-	}
-	defer destination.Close()
-
-	_, err = io.Copy(destination, source)
-	return err
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Until we fix Serverless Operator we can't just disable those. Reverting #798 

Related issue: https://issues.redhat.com/browse/SRVKS-1189

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
