### PR TITLE
(backport): wrong CR name in the message.

### DIFF
--- a/components/kserve/kserve.go
+++ b/components/kserve/kserve.go
@@ -176,7 +176,7 @@ func (k *Kserve) configureServerless(instance *dsciv1.DSCInitializationSpec) err
 		fmt.Println("Serverless CR is not configured by the operator, we won't do anything")
 
 	case operatorv1.Removed: // we remove serving CR
-		fmt.Println("existing ServiceMesh CR (owned by operator) will be removed")
+		fmt.Println("existing Serverless CR (owned by operator) will be removed")
 		if err := k.removeServerlessFeatures(instance); err != nil {
 			return err
 		}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
from downstream 2.6 https://github.com/red-hat-data-services/rhods-operator/pull/170

ref jira https://issues.redhat.com/browse/RHOAIENG-440
## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
