### PR TITLE
fix(serverless): Patch to enable Secret filtering in KNative Serving

### DIFF
--- a/pkg/feature/serverless/conditions.go
+++ b/pkg/feature/serverless/conditions.go
@@ -11,6 +11,10 @@ import (
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/gvr"
 )
 
+const (
+	KnativeServingNamespace = "knative-serving"
+)
+
 var log = ctrlLog.Log.WithName("features")
 
 func EnsureServerlessAbsent(f *feature.Feature) error {
@@ -50,3 +54,5 @@ func EnsureServerlessOperatorInstalled(f *feature.Feature) error {
 
 	return nil
 }
+
+var EnsureServerlessServingDeployed = feature.WaitForResourceToBeCreated(KnativeServingNamespace, gvr.KnativeServing)

--- a/pkg/feature/templates/serverless/serving-install/knative-serving.tmpl
+++ b/pkg/feature/templates/serverless/serving-install/knative-serving.tmpl
@@ -6,7 +6,7 @@ metadata:
   annotations:
     serverless.openshift.io/default-enable-http2: "true"
 spec:
-  deployments:
+  workloads:
     - annotations:
         sidecar.istio.io/inject: "true"
         sidecar.istio.io/rewriteAppHTTPProbers: "true"

--- a/pkg/feature/templates/serverless/serving-net-istio-secret-filtering.patch.tmpl
+++ b/pkg/feature/templates/serverless/serving-net-istio-secret-filtering.patch.tmpl
@@ -1,0 +1,21 @@
+apiVersion: operator.knative.dev/v1beta1
+kind: KnativeServing
+metadata:
+  name: {{ .Serving.Name }}
+  namespace: knative-serving
+spec:
+  workloads:
+    - name: activator
+      annotations:
+        sidecar.istio.io/inject: "true"
+        sidecar.istio.io/rewriteAppHTTPProbers: "true"
+    - name: autoscaler
+      annotations:
+        sidecar.istio.io/inject: "true"
+        sidecar.istio.io/rewriteAppHTTPProbers: "true"
+    - name: net-istio-controller
+      env:
+        - container: controller
+          envVars:
+            - name: ENABLE_SECRET_INFORMER_FILTERING_BY_CERT_UID
+              value: 'true'


### PR DESCRIPTION
## Description
This prevents KNative's net-istio pods from being OOMKilled in environments with a large number of Secrets.

This would patch a Managed installation. Custom installations would be left untouched.

Fixes: https://issues.redhat.com/browse/RHOAIENG-1467

## How Has This Been Tested?
* Do a build of the operator and deploy it:
```sh
make image-build IMG=$YOUR_CONTAINER_REPO
make deploy IMG=$YOUR_CONTAINER_REPO
```

* Create the default DSCI
```sh
oc apply -f config/samples/dscinitialization_v1_dscinitialization.yaml
```

* Create a KServe DSC
```yaml
apiVersion: datasciencecluster.opendatahub.io/v1
kind: DataScienceCluster
metadata:
  name: kserve-dsc
spec:
  components:
    dashboard:
      managementState: Removed
    datasciencepipelines:
      managementState: Removed
    codeflare:
      managementState: Removed
    ray:
      managementState: Removed
    kserve:
      managementState: Managed
      serving:
        managementState: Managed
    modelmeshserving:
      managementState: Removed
    workbenches:
      managementState: Removed
```

* Check the net-istio-controller depoyment of KNative has the `ENABLE_SECRET_INFORMER_FILTERING_BY_CERT_UID` environment variable set to "true".
```sh
oc get deploy -n knative-serving net-istio-controller -o jsonpath='{.spec.template.spec.containers[*].env[*]}'
```

## Merge criteria:
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
