### PR TITLE
RHOAIENG-965: Fix ODH Upgrade after label updates

### DIFF
--- a/pkg/upgrade/upgrade.go
+++ b/pkg/upgrade/upgrade.go
@@ -310,6 +310,14 @@ func UpdateFromLegacyVersion(cli client.Client, platform deploy.Platform, appNS 
 		return err
 	}
 
+	// TODO: Revert the following condition in 2.8 ODH Release
+	if platform == deploy.OpenDataHub {
+		fmt.Println("starting deletion of deployment in ODH cluster")
+		if err := deleteResource(cli, appNS, "deployment"); err != nil {
+			return fmt.Errorf("error deleting deployment: %w", err)
+		}
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Jira Issue: https://issues.redhat.com/browse/RHOAIENG-965 

## How Has This Been Tested?
1. Create custom catalog source with image `quay.io/opendatahub/opendatahub-operator-catalog:v2.4.0
2. Update catalogsource to quay.io/vhire/opendatahub-operator-catalog:v2.7.0 to trigger upgrade
3.  Deployments are deleted and recreated

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
