### PR TITLE
update(trusty): Change TrustyAI `apiGroup`

### DIFF
--- a/bundle/manifests/opendatahub-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/opendatahub-operator.clusterserviceversion.yaml
@@ -1615,7 +1615,7 @@ spec:
           verbs:
           - '*'
         - apiGroups:
-          - trustyai.opendatahub.io.trustyai.opendatahub.io
+          - trustyai.opendatahub.io
           resources:
           - trustyaiservices
           verbs:
@@ -1627,13 +1627,13 @@ spec:
           - update
           - watch
         - apiGroups:
-          - trustyai.opendatahub.io.trustyai.opendatahub.io
+          - trustyai.opendatahub.io
           resources:
           - trustyaiservices/finalizers
           verbs:
           - update
         - apiGroups:
-          - trustyai.opendatahub.io.trustyai.opendatahub.io
+          - trustyai.opendatahub.io
           resources:
           - trustyaiservices/status
           verbs:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -1409,7 +1409,7 @@ rules:
   verbs:
   - '*'
 - apiGroups:
-  - trustyai.opendatahub.io.trustyai.opendatahub.io
+  - trustyai.opendatahub.io
   resources:
   - trustyaiservices
   verbs:
@@ -1421,13 +1421,13 @@ rules:
   - update
   - watch
 - apiGroups:
-  - trustyai.opendatahub.io.trustyai.opendatahub.io
+  - trustyai.opendatahub.io
   resources:
   - trustyaiservices/finalizers
   verbs:
   - update
 - apiGroups:
-  - trustyai.opendatahub.io.trustyai.opendatahub.io
+  - trustyai.opendatahub.io
   resources:
   - trustyaiservices/status
   verbs:

--- a/controllers/datasciencecluster/kubebuilder_rbac.go
+++ b/controllers/datasciencecluster/kubebuilder_rbac.go
@@ -104,9 +104,9 @@ package datasciencecluster
 // +kubebuilder:rbac:groups="monitoring.coreos.com",resources=prometheusrules,verbs=get;create;patch;delete;deletecollection
 // +kubebuilder:rbac:groups="monitoring.coreos.com",resources=prometheuses,verbs=get;create;patch;delete;deletecollection
 
-//+kubebuilder:rbac:groups=trustyai.opendatahub.io.trustyai.opendatahub.io,resources=trustyaiservices,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=trustyai.opendatahub.io.trustyai.opendatahub.io,resources=trustyaiservices/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups=trustyai.opendatahub.io.trustyai.opendatahub.io,resources=trustyaiservices/finalizers,verbs=update
+//+kubebuilder:rbac:groups=trustyai.opendatahub.io,resources=trustyaiservices,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=trustyai.opendatahub.io,resources=trustyaiservices/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=trustyai.opendatahub.io,resources=trustyaiservices/finalizers,verbs=update
 
 // +kubebuilder:rbac:groups="monitoring.coreos.com",resources=prometheuses/finalizers,verbs=get;create;patch;delete;deletecollection
 // +kubebuilder:rbac:groups="monitoring.coreos.com",resources=prometheuses/status,verbs=get;create;patch;delete;deletecollection


### PR DESCRIPTION
This PR updates the TrustyAI API to make it consistent with the changes in: 
- https://github.com/trustyai-explainability/trustyai-service-operator/pull/169
- https://github.com/trustyai-explainability/trustyai-service-operator/issues/168

The TrustyAI `apiGroup` changed from `trustyai.opendatahub.io.trustyai.opendatahub.io/v1alpha1` to `trustyai.opendatahub.io/v1alpha1`.

This change is effective starting (and including) the releases:
- https://github.com/trustyai-explainability/trustyai-service-operator/releases/tag/v1.15.1
- https://github.com/trustyai-explainability/trustyai-explainability/releases/tag/v0.10.1

The image references in ODH should be also updated when merging this PR.