### PR TITLE
WIP:  Add support for creating an ODH trusted CA Bundle during DSCInitialization reconciliation loop

### DIFF
--- a/apis/dscinitialization/v1/dscinitialization_types.go
+++ b/apis/dscinitialization/v1/dscinitialization_types.go
@@ -45,9 +45,15 @@ type DSCInitializationSpec struct {
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,order=3
 	// +optional
 	ServiceMesh infrav1.ServiceMeshSpec `json:"serviceMesh,omitempty"`
+	// A custom CA bundle that will be available for  all  components in the
+	// Data Science Cluster(DSC). This bundle will be stored in odh-trusted-ca-bundle
+	// ConfigMap .data.odh-ca-bundle.crt within the DSCInitializtion.spec.ApplicationsNamespace.
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,order=4
+	// +optional
+	TrustedCABundle string `json:"trustedCABundle,omitempty"`
 	// Internal development useful field to test customizations.
 	// This is not recommended to be used in production environment.
-	// +operator-sdk:csv:customresourcedefinitions:type=spec,order=4
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,order=5
 	// +optional
 	DevFlags *DevFlags `json:"devFlags,omitempty"`
 }

--- a/controllers/dscinitialization/dscinitialization_test.go
+++ b/controllers/dscinitialization/dscinitialization_test.go
@@ -18,11 +18,13 @@ import (
 )
 
 const (
-	workingNamespace     = "test-operator-ns"
-	applicationNamespace = "test-application-ns"
-	configmapName        = "odh-common-config"
-	monitoringNamespace  = "test-monitoring-ns"
-	readyPhase           = "Ready"
+	workingNamespace      = "test-operator-ns"
+	applicationNamespace  = "test-application-ns"
+	configmapName         = "odh-common-config"
+	caBundleConfigmapName = "odh-trusted-ca-bundle"
+	caBundleDataField     = "odh-ca-bundle.crt"
+	monitoringNamespace   = "test-monitoring-ns"
+	readyPhase            = "Ready"
 )
 
 var _ = Describe("DataScienceCluster initialization", func() {
@@ -85,6 +87,16 @@ var _ = Describe("DataScienceCluster initialization", func() {
 			Expect(foundConfigMap.Name).To(Equal(configmapName))
 			Expect(foundConfigMap.Namespace).To(Equal(applicationNamespace))
 			expectedConfigmapData := map[string]string{"namespace": applicationNamespace}
+			Expect(foundConfigMap.Data).To(Equal(expectedConfigmapData))
+		})
+
+		It("Should create the trusted CA Bundle configmap", func() {
+			// then
+			foundConfigMap := &corev1.ConfigMap{}
+			Eventually(objectExists(caBundleConfigmapName, applicationNamespace, foundConfigMap), timeout, interval).Should(BeTrue())
+			Expect(foundConfigMap.Name).To(Equal(caBundleConfigmapName))
+			Expect(foundConfigMap.Namespace).To(Equal(applicationNamespace))
+			expectedConfigmapData := map[string]string{caBundleDataField: ""}
 			Expect(foundConfigMap.Data).To(Equal(expectedConfigmapData))
 		})
 	})
@@ -286,6 +298,7 @@ func createDSCI(appName string, enableMonitoring operatorv1.ManagementState, mon
 				Namespace:       monitoringNS,
 				ManagementState: enableMonitoring,
 			},
+			TrustedCABundle: "",
 		},
 	}
 }

--- a/controllers/dscinitialization/utils.go
+++ b/controllers/dscinitialization/utils.go
@@ -449,16 +449,16 @@ func (r *DSCInitializationReconciler) createOdhTrustedCABundleConfigMap(ctx cont
 			Namespace: name,
 			Labels: map[string]string{
 				"app.kubernetes.io/part-of": "opendatahub-operator",
-				// Label required for the Cluster Network Operator to inject the cluster trusted CA bundle
+				// Label required for the Cluster Network Operator(CNO) to inject the cluster trusted CA bundle
 				// into .data["ca-bundle.crt"]
 				"config.openshift.io/inject-trusted-cabundle": "true",
 			},
 		},
-		Data: map[string]string{caDataFieldName: ""},
+		// Add the DSCInitialzation specified TrustedCABundle to the odh-ca-bundle.crt data field
+		// Additionally, the CNO operator will automatically create and maintain ca-bundle.crt
+		//  based on the application of the label 'config.openshift.io/inject-trusted-cabundle'
+		Data: map[string]string{caDataFieldName: dscInit.Spec.TrustedCABundle},
 	}
-
-	// Add the DSCInitialzation specified TrustedCABundle to the odh-ca-bundle.crt data field
-	desiredConfigMap.Data[caDataFieldName] = dscInit.Spec.TrustedCABundle
 
 	// Create Configmap if doesn't exist
 	foundConfigMap := &corev1.ConfigMap{}

--- a/controllers/dscinitialization/utils.go
+++ b/controllers/dscinitialization/utils.go
@@ -34,6 +34,7 @@ var (
 // - Odh specific labels
 // - Pod security labels for baseline permissions
 // - ConfigMap  'odh-common-config'
+// - ConfigMap  'odh-trusted-ca-bundle' -- Certificates for the cluster trusted CA Cert Bundle
 // - Network Policies 'opendatahub' that allow traffic between the ODH namespaces
 // - RoleBinding 'opendatahub'.
 func (r *DSCInitializationReconciler) createOdhNamespace(ctx context.Context, dscInit *dsci.DSCInitialization, name string) error {
@@ -152,6 +153,13 @@ func (r *DSCInitializationReconciler) createOdhNamespace(ctx context.Context, ds
 	err = r.createOdhCommonConfigMap(ctx, name, dscInit)
 	if err != nil {
 		r.Log.Error(err, "error creating configmap", "name", "odh-common-config")
+		return err
+	}
+
+	// Create odh-trusted-ca-bundle Configmap for the Namespace
+	err = r.createOdhTrustedCABundleConfigMap(ctx, name, dscInit)
+	if err != nil {
+		r.Log.Error(err, "error creating configmap", "name", "odh-trusted-ca-bundle")
 		return err
 	}
 
@@ -423,6 +431,64 @@ func (r *DSCInitializationReconciler) createOdhCommonConfigMap(ctx context.Conte
 			return err
 		}
 	}
+	return nil
+}
+
+func (r *DSCInitializationReconciler) createOdhTrustedCABundleConfigMap(ctx context.Context, name string, dscInit *dsci.DSCInitialization) error {
+	caConfigMapName := "odh-trusted-ca-bundle"
+	caDataFieldName := "odh-ca-bundle.crt"
+
+	// Expected configmap for the given namespace
+	desiredConfigMap := &corev1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ConfigMap",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      caConfigMapName,
+			Namespace: name,
+			Labels: map[string]string{
+				"app.kubernetes.io/part-of": "opendatahub-operator",
+				// Label required for the Cluster Network Operator to inject the cluster trusted CA bundle
+				// into .data["ca-bundle.crt"]
+				"config.openshift.io/inject-trusted-cabundle": "true",
+			},
+		},
+		Data: map[string]string{caDataFieldName: ""},
+	}
+
+	// Add the DSCInitialzation specified TrustedCABundle to the odh-ca-bundle.crt data field
+	desiredConfigMap.Data[caDataFieldName] = dscInit.Spec.TrustedCABundle
+
+	// Create Configmap if doesn't exist
+	foundConfigMap := &corev1.ConfigMap{}
+	err := r.Client.Get(ctx, client.ObjectKey{
+		Name:      caConfigMapName,
+		Namespace: name,
+	}, foundConfigMap)
+	if err != nil {
+		if apierrs.IsNotFound(err) {
+			// Set Controller reference
+			err = ctrl.SetControllerReference(dscInit, foundConfigMap, r.Scheme)
+			if err != nil {
+				r.Log.Error(err, "Unable to add OwnerReference to the", caConfigMapName, "ConfigMap")
+				return err
+			}
+			err = r.Client.Create(ctx, desiredConfigMap)
+			if err != nil && !apierrs.IsAlreadyExists(err) {
+				return err
+			}
+		} else {
+			return err
+		}
+	}
+
+	if foundConfigMap.Data[caDataFieldName] != dscInit.Spec.TrustedCABundle {
+		r.Log.Info("Updating CA Bundle data field", "name", caDataFieldName)
+		foundConfigMap.Data[caDataFieldName] = dscInit.Spec.TrustedCABundle
+		return r.Client.Update(ctx, foundConfigMap)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Initial implementationfor creating an `odh-trusted-ca-bundle` ConfigMap in the DataScienceCluster namespace.  This will [inject](https://docs.openshift.com/container-platform/4.14/networking/configuring-a-custom-pki.html#certificate-injection-using-operators_configuring-a-custom-pki) the cluster-wide Trusted CA Bundle into the `.data["ca-bundle.crt"]` field of the ConfigMap via the Cluster Network Operator. 

Jira: [RHOAIENG-2465](https://issues.redhat.com/browse/RHOAIENG-2465)

Additionally, this adds a new `trustedCABundle` property in `DSCInitialization` for an admin to include a separate CA Certificate Bundle in the `.data["odh-ca-bundle.crt]` field of the `odh-trusted-ca-bundle` ConfigMap
This that can be used for centralizing the trusted CA Bundle for all ODH components to reference as part of the DSC deployment.


## How Has This Been Tested?
Local deployment in my development cluster 

Generated my own self signed certificate using `openssl` that is linked to other services that use TLS ([minio](https://min.io/docs/minio/linux/operations/network-encryption.html)

```
## Create a Self Signed Certificate using openssl
$ SELF_SIGNED_CERT_NAME=my-self-signed-cert
$ openssl req -newkey rsa:2048 -nodes -keyout ${SELF_SIGNED_CERT_NAME}.key -x509 -days 365 -out ${SELF_SIGNED_CERT_NAME}.crt
```

The CA bundle is a collection of encrypted certificates in text format.


## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
