### PR TITLE
chore(make): handles kustomize substitutions without polluting history

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -188,13 +188,9 @@ endif
 .PHONY: prepare
 prepare: manifests kustomize
 
-# - makes necessary substitutions in kustomize manifests
-# - calls actual kustomize command
-# - restores manifests to original state
 define kustomize-with-undo
-trap 'git restore config/manager/kustomization.yaml' EXIT
-$(shell cd config/manager && $(KUSTOMIZE) edit set image controller=$(IMG))
-$(KUSTOMIZE) $(1)
+cd config/manager && $(KUSTOMIZE) edit set image controller=$(IMG)
+trap 'git restore config/manager/kustomization.yaml' EXIT && $(KUSTOMIZE) $(1)
 endef
 
 .PHONY: install

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -1,3 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 resources:
 - manager.yaml
 
@@ -8,8 +10,8 @@ configMapGenerator:
 - files:
   - controller_manager_config.yaml
   name: manager-config
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
+
 images:
 - name: controller
-  newName: REPLACE_IMAGE
+  newName: quay.io/opendatahub/opendatahub-operator
+  newTag: latest


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- introduces a wrapper to call `kustomize` with customizations and undo after
- simplifies make targets
- removes the need for `.yaml.in` convention and enables kustomize manifests as a whole can be validated and supported by IDEs
- sets a reference to existing manager image instead of a placeholder; this makes kustomize work without Makefile involvement

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
