### PR TITLE
fix(manifests): return walkErr immediately

### DIFF
--- a/pkg/feature/manifest.go
+++ b/pkg/feature/manifest.go
@@ -34,6 +34,10 @@ func loadManifestsFrom(fsys fs.FS, path string) ([]manifest, error) {
 	var manifests []manifest
 
 	err := fs.WalkDir(fsys, path, func(path string, dirEntry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+
 		_, err := dirEntry.Info()
 		if err != nil {
 			return err


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

`walkErr` is propagated as part of a recursive call when traversing a directory tree.

This adds a guard check and does not proceed if the error happens in the call chain.

Without this, the controller will `panic` in case of the wrong path defined for a manifest.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
