### PR TITLE
fix: checks value instead of err when updating configmap

### DIFF
--- a/pkg/feature/feature.go
+++ b/pkg/feature/feature.go
@@ -160,13 +160,13 @@ func (f *Feature) CreateConfigMap(cfgMapName string, data map[string]string) err
 	}
 
 	configMaps := f.Clientset.CoreV1().ConfigMaps(configMap.Namespace)
-	_, err := configMaps.Get(context.TODO(), configMap.Name, metav1.GetOptions{})
+	found, err := configMaps.Get(context.TODO(), configMap.Name, metav1.GetOptions{})
 	if k8serrors.IsNotFound(err) { //nolint:gocritic
 		_, err = configMaps.Create(context.TODO(), configMap, metav1.CreateOptions{})
 		if err != nil {
 			return err
 		}
-	} else if k8serrors.IsAlreadyExists(err) {
+	} else if found != nil {
 		_, err = configMaps.Update(context.TODO(), configMap, metav1.UpdateOptions{})
 		if err != nil {
 			return err


### PR DESCRIPTION
## Description

`client.Get()` will never return an error of `IsAlreadyExists` if the resource exists, it would rather return the object.

`IsAlreadyExists` error is only relevant with `client.Create`

## How Has This Been Tested?

Attempt to update any of the source data for a ConfigMap that uses the feature framework. 

## Merge criteria:
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
