### PR TITLE
fix(make): ensures manifests are generated as part of default target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,7 @@ E2E_TEST_FLAGS = "--skip-deletion=false" -timeout 15m # See README.md, default g
 IMAGE_BUILD_FLAGS = --build-arg USE_LOCAL=false
 
 .PHONY: default
-default: lint unit-test build
+default: manifests lint unit-test build
 
 ##@ General
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This is based on the assumption that calling the `make` default target ensures the repo is always in the desired state.

This includes:

- all generated artifacts are up-to-date with the code they are derived from
- code passes defined linter checks
- a subset of tests (fast tests) is passing
- no compilation errors

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
