### PR TITLE
add logic to ensure deprecated model monitoring stack is deleted

### DIFF
--- a/main.go
+++ b/main.go
@@ -29,6 +29,7 @@ import (
 	ocuserv1 "github.com/openshift/api/user/v1"
 	ofapiv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	ofapiv2 "github.com/operator-framework/api/pkg/operators/v2"
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	admv1 "k8s.io/api/admissionregistration/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -85,6 +86,7 @@ func init() { //nolint:gochecknoinits
 	utilruntime.Must(apiextv1.AddToScheme(scheme))
 	utilruntime.Must(admv1.AddToScheme(scheme))
 	utilruntime.Must(apiregistrationv1.AddToScheme(scheme))
+	utilruntime.Must(monitoringv1.AddToScheme(scheme))
 }
 
 func main() { //nolint:funlen
@@ -199,6 +201,10 @@ func main() { //nolint:funlen
 	// Apply update from legacy operator
 	if err = upgrade.UpdateFromLegacyVersion(setupClient, platform, dscApplicationsNamespace, dscMonitoringNamespace); err != nil {
 		setupLog.Error(err, "unable to update from legacy operator version")
+	}
+
+	if err = upgrade.CleanupExistingResource(setupClient, platform); err != nil {
+		setupLog.Error(err, "unable to perform cleanup")
 	}
 
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Solves: https://issues.redhat.com/browse/RHOAIENG-2479 
This PR introduces logic to ensure the deprecated monitoring stack is deleted during operator upgrades in the managed environment 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested by doing a kustomize build to apply the deprecated monitoring stack (This is because a fresh install no longer installs the stack) 
- `git clone git@github.com:red-hat-data-services/odh-manifests.git` 
- `cd odh-manifests/modelmesh-monitoring/base`
- ` kustomize build --load-restrictor LoadRestrictionsNone . > temp.yaml` 
- `oc new-project redhat-ods-monitoring`
- `oc apply -f temp.yaml -n redhat-ods-monitoring` 

Built operator using 
- `docker build -f Dockerfiles/Dockerfile -t quay.io/vedantm/opendatahub-operator:monitoring_cleanup .` 
- `make deploy -e IMG=quay.io/vedantm/opendatahub-operator:monitoring_cleanup -e OPERATOR_NAMESPACE=opendatahub-operator-system`

- Checked that the project `redhat-ods-monitoring` does not have the resources being deleted in this PR
- Verified no error logs in the operator 
```
2024-02-02T22:06:43Z INFO controller-runtime.metrics Metrics server is starting to listen {"addr": "0.0.0.0:8080"}
2024-02-02T22:06:43Z INFO secret-generator Adding controller for Secret Generation.
Attempting to delete rhods-prometheus-operator in namespace redhat-ods-monitoring
Successfully deleted rhods-prometheus-operator
Attempting to delete prometheus-rhods-model-monitoring in namespace redhat-ods-monitoring
Successfully deleted prometheus-rhods-model-monitoring
Attempting to delete rhods-model-monitoring in namespace redhat-ods-monitoring
Successfully deleted rhods-model-monitoring
Attempting to delete rhods-model-monitoring in namespace redhat-ods-monitoring
Successfully deleted rhods-model-monitoring
Attempting to delete rhods-monitoring-oauth-config in namespace redhat-ods-monitoring
Successfully deleted rhods-monitoring-oauth-config
Attempting to delete rhods-namespace-read in namespace redhat-ods-monitoring
Successfully deleted rhods-namespace-read
Attempting to delete rhods-prometheus-operator in namespace redhat-ods-monitoring
Successfully deleted rhods-prometheus-operator
Attempting to delete rhods-namespace-read in namespace redhat-ods-monitoring
Successfully deleted rhods-namespace-read
Attempting to delete rhods-prometheus-operator in namespace redhat-ods-monitoring
Successfully deleted rhods-prometheus-operator
Attempting to delete rhods-prometheus-operator in namespace redhat-ods-monitoring
Successfully deleted rhods-prometheus-operator
Attempting to delete modelmesh-federated-metrics in namespace redhat-ods-monitoring
Successfully deleted modelmesh-federated-metrics
```

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
