### PR TITLE
Bump Serving components to v0.11.1

### DIFF
--- a/get_all_manifests.sh
+++ b/get_all_manifests.sh
@@ -15,9 +15,9 @@ declare -A COMPONENT_MANIFESTS=(
     ["odh-notebook-controller"]="opendatahub-io:kubeflow:v1.7-branch:components/odh-notebook-controller/config:odh-notebook-controller/odh-notebook-controller"
     ["notebooks"]="opendatahub-io:notebooks:main:manifests:notebooks"
     ["trustyai"]="trustyai-explainability:trustyai-service-operator:release/1.10.2:config:trustyai-service-operator"
-    ["model-mesh"]="opendatahub-io:modelmesh-serving:release-0.11.0:config:model-mesh"
-    ["odh-model-controller"]="opendatahub-io:odh-model-controller:release-0.11.0:config:odh-model-controller"
-    ["kserve"]="opendatahub-io:kserve:release-v0.11.0:config:kserve"
+    ["model-mesh"]="opendatahub-io:modelmesh-serving:release-0.11.1:config:model-mesh"
+    ["odh-model-controller"]="opendatahub-io:odh-model-controller:release-0.11.1:config:odh-model-controller"
+    ["kserve"]="opendatahub-io:kserve:release-v0.11.1:config:kserve"
     ["modelregistry"]="opendatahub-io:model-registry-operator:main:config:model-registry-operator"
 )
 


### PR DESCRIPTION
## Description
The `release-0.11.1` branch is the new fallback branch for serving components. This is updating the fallback branch.

This helps on generating developer builds using the latest revision of model serving components.

## How Has This Been Tested?
Running the `get_all_manifests.sh` script and observing the manifests can be fetched correctly.
Also, invoking `make image-build` to check that the container image is built without issues.

## Merge criteria:
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
