### PR TITLE
update: remove duplicated createOdhNamespace call in DSCI

### DIFF
--- a/controllers/dscinitialization/dscinitialization_controller.go
+++ b/controllers/dscinitialization/dscinitialization_controller.go
@@ -155,14 +155,6 @@ func (r *DSCInitializationReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		}
 	}
 
-	// Check namespace
-	namespace := instance.Spec.ApplicationsNamespace
-	err = r.createOdhNamespace(ctx, instance, namespace)
-	if err != nil {
-		// no need to log error as it was already logged in createOdhNamespace
-		return reconcile.Result{}, err
-	}
-
 	// Get platform
 	platform, err := deploy.GetPlatform(r.Client)
 	if err != nil {


### PR DESCRIPTION
- we do not need to have this call for every reconcile
- the function does patching namespace on downstream logic everytime
- it is called in https://github.com/opendatahub-io/opendatahub-operator/pull/855/files#diff-c8a3eeefd24ebf5243ac88045140742b59124671a5ec221c43d2f9046dd3988dR199-R205 already

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
