### PR TITLE
chore: move featuretracker out of feature.spec

### DIFF
--- a/pkg/feature/feature.go
+++ b/pkg/feature/feature.go
@@ -23,6 +23,7 @@ type Feature struct {
 	Name    string
 	Spec    *Spec
 	Enabled bool
+	Tracker *featurev1.FeatureTracker
 
 	Clientset     *kubernetes.Clientset
 	DynamicClient dynamic.Interface
@@ -212,14 +213,14 @@ func (f *Feature) apply(m manifest) error {
 }
 
 func (f *Feature) AsOwnerReference() metav1.OwnerReference {
-	return f.Spec.Tracker.ToOwnerReference()
+	return f.Tracker.ToOwnerReference()
 }
 
 // updateFeatureTrackerStatus updates conditions of a FeatureTracker.
 // It's deliberately logging errors instead of handing them as it is used in deferred error handling of Feature public API,
 // which is more predictable.
 func (f *Feature) updateFeatureTrackerStatus(condType conditionsv1.ConditionType, status corev1.ConditionStatus, reason featurev1.FeaturePhase, message string) {
-	tracker := f.Spec.Tracker
+	tracker := f.Tracker
 
 	// Update the status
 	if tracker.Status.Conditions == nil {
@@ -237,5 +238,5 @@ func (f *Feature) updateFeatureTrackerStatus(condType conditionsv1.ConditionType
 		f.Log.Error(err, "Error updating FeatureTracker status")
 	}
 
-	f.Spec.Tracker.Status = tracker.Status
+	f.Tracker.Status = tracker.Status
 }

--- a/pkg/feature/feature_tracker_handler.go
+++ b/pkg/feature/feature_tracker_handler.go
@@ -28,13 +28,13 @@ func (f *Feature) createFeatureTracker() error {
 		return err
 	}
 
-	f.Spec.Tracker = tracker
+	f.Tracker = tracker
 
 	return nil
 }
 
 func removeFeatureTracker(f *Feature) error {
-	if f.Spec.Tracker != nil {
+	if f.Tracker != nil {
 		return deleteTracker(f)
 	}
 
@@ -65,7 +65,7 @@ func (f *Feature) getFeatureTracker() (*featurev1.FeatureTracker, error) {
 func setFeatureTrackerIfAbsent(f *Feature) error {
 	tracker, err := f.getFeatureTracker()
 
-	f.Spec.Tracker = tracker
+	f.Tracker = tracker
 
 	return err
 }
@@ -86,7 +86,7 @@ func (f *Feature) ensureGVKSet(obj runtime.Object) error {
 }
 
 func deleteTracker(f *Feature) error {
-	err := f.Client.Delete(context.Background(), f.Spec.Tracker)
+	err := f.Client.Delete(context.Background(), f.Tracker)
 	if err != nil && !k8serrors.IsNotFound(err) {
 		return err
 	}

--- a/pkg/feature/types.go
+++ b/pkg/feature/types.go
@@ -15,7 +15,6 @@ type Spec struct {
 	Domain                   string
 	KnativeCertificateSecret string
 	KnativeIngressDomain     string
-	Tracker                  *featurev1.FeatureTracker
 	Source                   *featurev1.Source
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This PR moves the location of each Feature's FeatureTracker into the base of the Feature struct, rather than storing it inside of Feature.Spec. This makes more sense than storing it inside of the spec, and makes future changes to how feature.Spec is implemented easier. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Ensured that FeatureTracker related unit tests still work as expected and deployed the operator in CRC,

img: `quay.io/cgarriso/opendatahub-operator:dev-move-feature-tracker-location`
 deploying a DSCI with `serviceMesh.managementState: Managed` and checking that the expected FeatureTrackers were still created and also deleted upon DSCI deletion. 

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
