### PR TITLE
Fix Kserve Unmanaged Installation

### DIFF
--- a/components/kserve/kserve.go
+++ b/components/kserve/kserve.go
@@ -108,13 +108,8 @@ func (k *Kserve) ReconcileComponent(ctx context.Context, cli client.Client, resC
 				return err
 			}
 		}
-		// check on dependent operators if all installed in cluster
-		dependOpsErrors := checkDependentOperators(cli).ErrorOrNil()
-		if dependOpsErrors != nil {
-			return dependOpsErrors
-		}
 
-		if err := k.configureServerless(dscispec); err != nil {
+		if err := k.configureServerless(cli, dscispec); err != nil {
 			return err
 		}
 
@@ -170,7 +165,7 @@ func (k *Kserve) Cleanup(_ client.Client, instance *dsciv1.DSCInitializationSpec
 	return k.removeServerlessFeatures(instance)
 }
 
-func (k *Kserve) configureServerless(instance *dsciv1.DSCInitializationSpec) error {
+func (k *Kserve) configureServerless(cli client.Client, instance *dsciv1.DSCInitializationSpec) error {
 	switch k.Serving.ManagementState {
 	case operatorv1.Unmanaged: // Bring your own CR
 		fmt.Println("Serverless CR is not configured by the operator, we won't do anything")
@@ -185,6 +180,12 @@ func (k *Kserve) configureServerless(instance *dsciv1.DSCInitializationSpec) err
 		switch instance.ServiceMesh.ManagementState {
 		case operatorv1.Unmanaged, operatorv1.Removed:
 			return fmt.Errorf("ServiceMesh is need to set to 'Managed' in DSCI CR, it is required by KServe serving field")
+		}
+
+		// check on dependent operators if all installed in cluster
+		dependOpsErrors := checkDependentOperators(cli).ErrorOrNil()
+		if dependOpsErrors != nil {
+			return dependOpsErrors
 		}
 
 		serverlessFeatures := feature.ComponentFeaturesHandler(k, instance, k.configureServerlessFeatures())

--- a/tests/e2e/dsc_creation_test.go
+++ b/tests/e2e/dsc_creation_test.go
@@ -241,14 +241,12 @@ func (tc *testContext) testAllApplicationCreation(t *testing.T) error { //nolint
 		// speed testing in parallel
 		t.Parallel()
 		err = tc.testApplicationCreation(&(tc.testDsc.Spec.Components.Kserve))
+		// test Unmanaged state, since servicemesh is not installed.
 		if tc.testDsc.Spec.Components.Kserve.ManagementState == operatorv1.Managed {
-			if err != nil {
-				// depedent operator error, as expected
-				if strings.Contains(err.Error(), "Please install the operator before enabling component") {
-					t.Logf("expected error: %v", err.Error())
-				} else {
-					require.NoError(t, err, "error validating application %v when enabled", tc.testDsc.Spec.Components.Kserve.GetComponentName())
-				}
+			if err != nil && tc.testDsc.Spec.Components.Kserve.Serving.ManagementState == operatorv1.Unmanaged {
+				require.NoError(t, err, "error validating application %v when enabled", tc.testDsc.Spec.Components.Workbenches.GetComponentName())
+			} else {
+				require.NoError(t, err, "error validating application %v when enabled", tc.testDsc.Spec.Components.Kserve.GetComponentName())
 			}
 		} else {
 			require.Error(t, err, "error validating application %v when disabled", tc.testDsc.Spec.Components.Kserve.GetComponentName())

--- a/tests/e2e/helper_test.go
+++ b/tests/e2e/helper_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/opendatahub-io/opendatahub-operator/v2/components/ray"
 	"github.com/opendatahub-io/opendatahub-operator/v2/components/trustyai"
 	"github.com/opendatahub-io/opendatahub-operator/v2/components/workbenches"
+	infrav1 "github.com/opendatahub-io/opendatahub-operator/v2/infrastructure/v1"
 )
 
 func (tc *testContext) waitForControllerDeployment(name string, replicas int32) error {
@@ -107,6 +108,9 @@ func setupDSCInstance(name string) *dsc.DataScienceCluster {
 				Kserve: kserve.Kserve{
 					Component: components.Component{
 						ManagementState: operatorv1.Managed,
+					},
+					Serving: infrav1.ServingSpec{
+						ManagementState: operatorv1.Unmanaged,
 					},
 				},
 				CodeFlare: codeflare.CodeFlare{


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
https://issues.redhat.com/browse/RHOAIENG-2951

## How Has This Been Tested?
1. Install operator using catalogsource quay.io/vhire/opendatahub-operator-catalog:v2.7.0
2. Create default DSCI
3. Create DSC with following spec
```

    kserve:
      managementState: Managed
      serving:
        ingressGateway:
          certificate:
            type: SelfSigned
        managementState: Unmanaged
        name: knative-serving
```
 

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
