### PR TITLE
update: add cleanup for rhods-monitor-federation2

### DIFF
--- a/pkg/upgrade/upgrade.go
+++ b/pkg/upgrade/upgrade.go
@@ -20,7 +20,6 @@ import (
 	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -49,11 +48,6 @@ const (
 	// TODO: Label should be updated if addon name changes.
 	DeleteConfigMapLabel = "api.openshift.com/addon-managed-odh-delete"
 )
-
-type Resource interface {
-	metav1.Object
-	runtime.Object
-}
 
 // OperatorUninstall deletes all the externally generated resources. This includes monitoring resources and applications
 // installed by KfDef.
@@ -367,11 +361,11 @@ func UpdateFromLegacyVersion(cli client.Client, platform deploy.Platform, appNS 
 
 func CleanupExistingResource(cli client.Client, platform deploy.Platform) error {
 	var multiErr *multierror.Error
+	montNamespace := "redhat-ods-monitoring"
+	ctx := context.TODO()
 
 	// Special Handling of cleanup of deprecated model monitoring stack
 	if platform == deploy.ManagedRhods {
-		montNamespace := "redhat-ods-monitoring"
-		ctx := context.TODO()
 		deprecatedDeployments := []string{"rhods-prometheus-operator"}
 		multiErr = multierror.Append(multiErr, deleteDeprecatedResources(ctx, cli, montNamespace, deprecatedDeployments, &appsv1.DeploymentList{}))
 
@@ -399,6 +393,9 @@ func CleanupExistingResource(cli client.Client, platform deploy.Platform) error 
 		deprecatedServicemonitors := []string{"modelmesh-federated-metrics"}
 		multiErr = multierror.Append(multiErr, deleteDeprecatedServiceMonitors(ctx, cli, montNamespace, deprecatedServicemonitors))
 	}
+	// common logic for both self-managed and managed
+	deprecatedOperatorSM := []string{"rhods-monitor-federation2"}
+	multiErr = multierror.Append(multiErr, deleteDeprecatedServiceMonitors(ctx, cli, montNamespace, deprecatedOperatorSM))
 
 	return multiErr.ErrorOrNil()
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
follow up changes in https://github.com/red-hat-data-services/rhods-operator/pull/188

**do not merge till we know PR 188 does not break regression**

Get confirm in Self-Managed, without this servicemonitor, everything is working and no more error in "ingest" https://issues.redhat.com/browse/RHOAIENG-859 

**still wait for confirm on managed cluster**
confirmed in https://issues.redhat.com/browse/RHOAIENG-859, by not having this Servicemonitor, nothing is breaking, we can proceed with this PR



## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
