### PR TITLE
allow setting default deployment mode for Kserve in DSC

### DIFF
--- a/bundle/manifests/datasciencecluster.opendatahub.io_datascienceclusters.yaml
+++ b/bundle/manifests/datasciencecluster.opendatahub.io_datascienceclusters.yaml
@@ -178,6 +178,12 @@ spec:
                       before enable component Does not support enabled ModelMeshServing
                       at the same time
                     properties:
+                      defaultDeploymentMode:
+                        default: Serverless
+                        enum:
+                        - Serverless
+                        - RawDeployment
+                        type: string
                       devFlags:
                         description: Add developer fields
                         properties:

--- a/bundle/manifests/datasciencecluster.opendatahub.io_datascienceclusters.yaml
+++ b/bundle/manifests/datasciencecluster.opendatahub.io_datascienceclusters.yaml
@@ -179,10 +179,15 @@ spec:
                       at the same time
                     properties:
                       defaultDeploymentMode:
-                        default: Serverless
+                        description: Configures the default deployment mode for Kserve.
+                          This can be set to 'Serverless' or 'RawDeployment'. The
+                          value specified in this field will be used to set the default
+                          deployment mode in the 'inferenceservice-config' configmap
+                          for Kserve
                         enum:
                         - Serverless
                         - RawDeployment
+                        pattern: ^(Serverless|RawDeployment)$
                         type: string
                       devFlags:
                         description: Add developer fields

--- a/bundle/manifests/opendatahub-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/opendatahub-operator.clusterserviceversion.yaml
@@ -1776,7 +1776,7 @@ spec:
                 env:
                 - name: DISABLE_DSC_CONFIG
                   value: "true"
-                image: REPLACE_IMAGE:latest
+                image: quay.io/whydant/opendatahub-operator:latest
                 imagePullPolicy: Always
                 livenessProbe:
                   httpGet:

--- a/bundle/manifests/opendatahub-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/opendatahub-operator.clusterserviceversion.yaml
@@ -1776,7 +1776,7 @@ spec:
                 env:
                 - name: DISABLE_DSC_CONFIG
                   value: "true"
-                image: quay.io/whydant/opendatahub-operator:latest
+                image: REPLACE_IMAGE:latest
                 imagePullPolicy: Always
                 livenessProbe:
                   httpGet:

--- a/components/kserve/kserve.go
+++ b/components/kserve/kserve.go
@@ -161,8 +161,10 @@ func (k *Kserve) ReconcileComponent(ctx context.Context, cli client.Client, resC
 		}
 	}
 
-	if err := k.setupKserveConfigAndDependencies(ctx, cli, dscispec); err != nil {
-		return err
+	if enabled {
+		if err := k.setupKserveConfigAndDependencies(ctx, cli, dscispec); err != nil {
+			return err
+		}
 	}
 
 	// CloudService Monitoring handling

--- a/components/kserve/kserve.go
+++ b/components/kserve/kserve.go
@@ -52,7 +52,6 @@ type Kserve struct {
 	// Configures the default deployment mode for Kserve. This can be set to 'Serverless' or 'RawDeployment'.
 	// The value specified in this field will be used to set the default deployment mode in the 'inferenceservice-config' configmap for Kserve
 	// +kubebuilder:validation:Enum=Serverless;RawDeployment
-	// +kubebuilder:default=Serverless
 	DefaultDeploymentMode DefaultDeploymentMode `json:"defaultDeploymentMode,omitempty"`
 }
 

--- a/components/kserve/kserve.go
+++ b/components/kserve/kserve.go
@@ -51,6 +51,7 @@ type Kserve struct {
 	Serving infrav1.ServingSpec `json:"serving,omitempty"`
 	// Configures the default deployment mode for Kserve. This can be set to 'Serverless' or 'RawDeployment'.
 	// The value specified in this field will be used to set the default deployment mode in the 'inferenceservice-config' configmap for Kserve
+	// If no default deployment mode is specified, Kserve will use Serverless mode
 	// +kubebuilder:validation:Enum=Serverless;RawDeployment
 	DefaultDeploymentMode DefaultDeploymentMode `json:"defaultDeploymentMode,omitempty"`
 }

--- a/components/kserve/kserve.go
+++ b/components/kserve/kserve.go
@@ -121,13 +121,6 @@ func (k *Kserve) ReconcileComponent(ctx context.Context, cli client.Client, resC
 				return err
 			}
 		}
-<<<<<<< HEAD
-
-		if err := k.configureServerless(cli, dscispec); err != nil {
-			return err
-		}
-=======
->>>>>>> d5c8ebe (move kserve config logic to separate file + enhancements)
 
 		// Update image parameters only when we do not have customized manifests set
 		if (dscispec.DevFlags == nil || dscispec.DevFlags.ManifestsUri == "") && (k.DevFlags == nil || len(k.DevFlags.Manifests) == 0) {
@@ -192,65 +185,3 @@ func (k *Kserve) Cleanup(_ client.Client, instance *dsciv1.DSCInitializationSpec
 
 	return k.removeServiceMeshConfigurations(instance)
 }
-<<<<<<< HEAD
-
-func (k *Kserve) configureServerless(cli client.Client, instance *dsciv1.DSCInitializationSpec) error {
-	switch k.Serving.ManagementState {
-	case operatorv1.Unmanaged: // Bring your own CR
-		fmt.Println("Serverless CR is not configured by the operator, we won't do anything")
-
-	case operatorv1.Removed: // we remove serving CR
-		fmt.Println("existing Serverless CR (owned by operator) will be removed")
-		if err := k.removeServerlessFeatures(instance); err != nil {
-			return err
-		}
-
-	case operatorv1.Managed: // standard workflow to create CR
-		switch instance.ServiceMesh.ManagementState {
-		case operatorv1.Unmanaged, operatorv1.Removed:
-			return fmt.Errorf("ServiceMesh is need to set to 'Managed' in DSCI CR, it is required by KServe serving field")
-		}
-
-		// check on dependent operators if all installed in cluster
-		dependOpsErrors := checkDependentOperators(cli).ErrorOrNil()
-		if dependOpsErrors != nil {
-			return dependOpsErrors
-		}
-
-		serverlessFeatures := feature.ComponentFeaturesHandler(k, instance, k.configureServerlessFeatures())
-
-		if err := serverlessFeatures.Apply(); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func (k *Kserve) removeServerlessFeatures(instance *dsciv1.DSCInitializationSpec) error {
-	serverlessFeatures := feature.ComponentFeaturesHandler(k, instance, k.configureServerlessFeatures())
-
-	return serverlessFeatures.Delete()
-}
-
-func checkDependentOperators(cli client.Client) *multierror.Error {
-	var multiErr *multierror.Error
-
-	if found, err := deploy.OperatorExists(cli, ServiceMeshOperator); err != nil {
-		multiErr = multierror.Append(multiErr, err)
-	} else if !found {
-		err = fmt.Errorf("operator %s not found. Please install the operator before enabling %s component",
-			ServiceMeshOperator, ComponentName)
-		multiErr = multierror.Append(multiErr, err)
-	}
-
-	if found, err := deploy.OperatorExists(cli, ServerlessOperator); err != nil {
-		multiErr = multierror.Append(multiErr, err)
-	} else if !found {
-		err = fmt.Errorf("operator %s not found. Please install the operator before enabling %s component",
-			ServerlessOperator, ComponentName)
-		multiErr = multierror.Append(multiErr, err)
-	}
-	return multiErr
-}
-=======
->>>>>>> d5c8ebe (move kserve config logic to separate file + enhancements)

--- a/components/kserve/kserve_config_handler.go
+++ b/components/kserve/kserve_config_handler.go
@@ -19,21 +19,11 @@ const (
 	KserveConfigMapName string = "inferenceservice-config"
 )
 
-func (k *Kserve) setupKserveConfigAndDependencies(ctx context.Context, cli client.Client, dscispec *dsciv1.DSCInitializationSpec) error {
+func (k *Kserve) setupKserveConfig(ctx context.Context, cli client.Client, dscispec *dsciv1.DSCInitializationSpec) error {
 	// as long as Kserve.Serving is not 'Removed', we will setup the dependencies
 
 	switch k.Serving.ManagementState {
-	case operatorv1.Managed:
-		// check on dependent operators if all installed in cluster
-		dependOpsErrors := checkDependentOperators(cli).ErrorOrNil()
-		if dependOpsErrors != nil {
-			return dependOpsErrors
-		}
-
-		if err := k.configureServerless(dscispec); err != nil {
-			return err
-		}
-
+	case operatorv1.Managed, operatorv1.Unmanaged:
 		if k.DefaultDeploymentMode == "" {
 			// if the default mode is empty in the DSC, assume mode is "Serverless" since k.Serving is Managed
 			if err := k.setDefaultDeploymentMode(ctx, cli, dscispec, Serverless); err != nil {
@@ -44,12 +34,6 @@ func (k *Kserve) setupKserveConfigAndDependencies(ctx context.Context, cli clien
 			if err := k.setDefaultDeploymentMode(ctx, cli, dscispec, k.DefaultDeploymentMode); err != nil {
 				return err
 			}
-		}
-
-	case operatorv1.Unmanaged:
-		fmt.Println("Serverless is Unmanaged, Kserve will default to RawDeployment")
-		if err := k.setDefaultDeploymentMode(ctx, cli, dscispec, RawDeployment); err != nil {
-			return err
 		}
 	case operatorv1.Removed:
 		if k.DefaultDeploymentMode == Serverless {
@@ -80,36 +64,58 @@ func (k *Kserve) setDefaultDeploymentMode(ctx context.Context, cli client.Client
 	if err = json.Unmarshal([]byte(inferenceServiceConfigMap.Data["deploy"]), &deployData); err != nil {
 		return fmt.Errorf("error retrieving value for key 'deploy' from configmap %s. %w", KserveConfigMapName, err)
 	}
-	deployData["defaultDeploymentMode"] = defaultmode
-	deployDataBytes, err := json.MarshalIndent(deployData, "", " ")
-	if err != nil {
-		return fmt.Errorf("could not set values in configmap %s. %w", KserveConfigMapName, err)
-	}
-	inferenceServiceConfigMap.Data["deploy"] = string(deployDataBytes)
+	modeFound := deployData["defaultDeploymentMode"]
+	if modeFound != string(defaultmode) {
+		deployData["defaultDeploymentMode"] = defaultmode
+		deployDataBytes, err := json.MarshalIndent(deployData, "", " ")
+		if err != nil {
+			return fmt.Errorf("could not set values in configmap %s. %w", KserveConfigMapName, err)
+		}
+		inferenceServiceConfigMap.Data["deploy"] = string(deployDataBytes)
 
-	var ingressData map[string]interface{}
-	if err = json.Unmarshal([]byte(inferenceServiceConfigMap.Data["ingress"]), &ingressData); err != nil {
-		return fmt.Errorf("error retrieving value for key 'ingress' from configmap %s. %w", KserveConfigMapName, err)
-	}
-	if defaultmode == RawDeployment {
-		ingressData["disableIngressCreation"] = true
-	} else {
-		ingressData["disableIngressCreation"] = false
-	}
-	ingressDataBytes, err := json.MarshalIndent(ingressData, "", " ")
-	if err != nil {
-		return fmt.Errorf("could not set values in configmap %s. %w", KserveConfigMapName, err)
-	}
-	inferenceServiceConfigMap.Data["ingress"] = string(ingressDataBytes)
+		var ingressData map[string]interface{}
+		if err = json.Unmarshal([]byte(inferenceServiceConfigMap.Data["ingress"]), &ingressData); err != nil {
+			return fmt.Errorf("error retrieving value for key 'ingress' from configmap %s. %w", KserveConfigMapName, err)
+		}
+		if defaultmode == RawDeployment {
+			ingressData["disableIngressCreation"] = true
+		} else {
+			ingressData["disableIngressCreation"] = false
+		}
+		ingressDataBytes, err := json.MarshalIndent(ingressData, "", " ")
+		if err != nil {
+			return fmt.Errorf("could not set values in configmap %s. %w", KserveConfigMapName, err)
+		}
+		inferenceServiceConfigMap.Data["ingress"] = string(ingressDataBytes)
 
-	if err = cli.Update(ctx, inferenceServiceConfigMap); err != nil {
-		return fmt.Errorf("could not set default deployment mode for Kserve. %w", err)
+		if err = cli.Update(ctx, inferenceServiceConfigMap); err != nil {
+			return fmt.Errorf("could not set default deployment mode for Kserve. %w", err)
+		}
+
+		// Restart the pod if configmap is updated so that kserve boots with the correct value
+		podList := &corev1.PodList{}
+		listOpts := []client.ListOption{
+			client.InNamespace(dscispec.ApplicationsNamespace),
+			client.MatchingLabels{
+				"app.opendatahub.io/kserve": "true",
+				"control-plane":             "kserve-controller-manager",
+			},
+		}
+		if err := cli.List(ctx, podList, listOpts...); err != nil {
+			return fmt.Errorf("failed to list pods: %w", err)
+		}
+		for _, pod := range podList.Items {
+			pod := pod
+			if err := cli.Delete(ctx, &pod); err != nil {
+				return fmt.Errorf("failed to delete pod %s: %w", pod.Name, err)
+			}
+		}
 	}
 
 	return nil
 }
 
-func (k *Kserve) configureServerless(instance *dsciv1.DSCInitializationSpec) error {
+func (k *Kserve) configureServerless(cli client.Client, instance *dsciv1.DSCInitializationSpec) error {
 	switch k.Serving.ManagementState {
 	case operatorv1.Unmanaged: // Bring your own CR
 		fmt.Println("Serverless CR is not configured by the operator, we won't do anything")
@@ -124,6 +130,12 @@ func (k *Kserve) configureServerless(instance *dsciv1.DSCInitializationSpec) err
 		switch instance.ServiceMesh.ManagementState {
 		case operatorv1.Unmanaged, operatorv1.Removed:
 			return fmt.Errorf("ServiceMesh is need to set to 'Managed' in DSCI CR, it is required by KServe serving field")
+		}
+
+		// check on dependent operators if all installed in cluster
+		dependOpsErrors := checkDependentOperators(cli).ErrorOrNil()
+		if dependOpsErrors != nil {
+			return dependOpsErrors
 		}
 
 		serverlessFeatures := feature.ComponentFeaturesHandler(k, instance, k.configureServerlessFeatures())

--- a/components/kserve/kserve_config_handler.go
+++ b/components/kserve/kserve_config_handler.go
@@ -1,0 +1,148 @@
+package kserve
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/hashicorp/go-multierror"
+	operatorv1 "github.com/openshift/api/operator/v1"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	dsciv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/dscinitialization/v1"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/deploy"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/feature"
+)
+
+const (
+	KserveConfigMapName string = "inferenceservice-config"
+)
+
+func (k *Kserve) setupKserveConfigAndDependencies(ctx context.Context, cli client.Client, dscispec *dsciv1.DSCInitializationSpec) error {
+	// as long as Kserve.Serving is not 'Removed', we will setup the dependencies
+
+	if k.Serving.ManagementState != operatorv1.Removed {
+		if k.DefaultDeploymentMode == Serverless {
+			return fmt.Errorf("setting the defaultDeployment mode Serverless is not compatible with setting the management state for Serving as Removed")
+		}
+		// check on dependent operators if all installed in cluster
+		dependOpsErrors := checkDependentOperators(cli).ErrorOrNil()
+		if dependOpsErrors != nil {
+			return dependOpsErrors
+		}
+
+		if err := k.configureServerless(dscispec); err != nil {
+			return err
+		}
+
+		if err := k.setDefaultDeploymentMode(ctx, cli, dscispec, k.DefaultDeploymentMode); err != nil {
+			return err
+		}
+	}
+
+	// since serverless is specifically set to 'Removed'
+	// we do not need to check if dependent operators are installed and configure them
+	// in this case the default deployment mode is forced to be RawDeployment
+	fmt.Println("Serverless is specified as 'Removed', Kserve will default to RawDeployment")
+	return k.setDefaultDeploymentMode(ctx, cli, dscispec, RawDeployment)
+}
+
+func (k *Kserve) setDefaultDeploymentMode(ctx context.Context, cli client.Client, dscispec *dsciv1.DSCInitializationSpec, defaultmode DefaultDeploymentMode) error {
+	inferenceServiceConfigMap := &corev1.ConfigMap{}
+	err := cli.Get(ctx, client.ObjectKey{
+		Namespace: dscispec.ApplicationsNamespace,
+		Name:      KserveConfigMapName,
+	}, inferenceServiceConfigMap)
+	if err != nil {
+		return fmt.Errorf("error getting configmap 'inferenceservice-config'. %w", err)
+	}
+
+	// set data.deploy.defaultDeploymentMode to the model specified in the Kserve spec
+	var deployData map[string]interface{}
+	if err = json.Unmarshal([]byte(inferenceServiceConfigMap.Data["deploy"]), &deployData); err != nil {
+		return fmt.Errorf("error retrieving value for key 'deploy' from configmap %s. %w", KserveConfigMapName, err)
+	}
+	deployData["defaultDeploymentMode"] = defaultmode
+	deployDataBytes, err := json.MarshalIndent(deployData, "", " ")
+	if err != nil {
+		return fmt.Errorf("could not set values in configmap %s. %w", KserveConfigMapName, err)
+	}
+	inferenceServiceConfigMap.Data["deploy"] = string(deployDataBytes)
+
+	// disabling logic to enable or disable ingress creation till https://github.com/kserve/kserve/pull/3436/files is merged
+
+	// var ingressData map[string]interface{}
+	// if err = json.Unmarshal([]byte(inferenceServiceConfigMap.Data["ingress"]), &ingressData); err != nil {
+	// 	return fmt.Errorf("error retrieving value for key 'ingress' from configmap %s. %w", KserveConfigMapName, err)
+	// }
+	// if defaultmode == RawDeployment {
+	// 	ingressData["disableIngressCreation"] = true
+	// } else {
+	// 	ingressData["disableIngressCreation"] = false
+	// }
+	// ingressDataBytes, err := json.MarshalIndent(ingressData, "", " ")
+	// if err != nil {
+	// 	return fmt.Errorf("could not set values in configmap %s. %w", KserveConfigMapName, err)
+	// }
+	// inferenceServiceConfigMap.Data["ingress"] = string(ingressDataBytes)
+
+	if err = cli.Update(ctx, inferenceServiceConfigMap); err != nil {
+		return fmt.Errorf("could not set default deployment mode for Kserve. %w", err)
+	}
+
+	return nil
+}
+
+func (k *Kserve) configureServerless(instance *dsciv1.DSCInitializationSpec) error {
+	switch k.Serving.ManagementState {
+	case operatorv1.Unmanaged: // Bring your own CR
+		fmt.Println("Serverless CR is not configured by the operator, we won't do anything")
+
+	case operatorv1.Removed: // we remove serving CR
+		fmt.Println("existing Serverless CR (owned by operator) will be removed")
+		if err := k.removeServerlessFeatures(instance); err != nil {
+			return err
+		}
+
+	case operatorv1.Managed: // standard workflow to create CR
+		switch instance.ServiceMesh.ManagementState {
+		case operatorv1.Unmanaged, operatorv1.Removed:
+			return fmt.Errorf("ServiceMesh is need to set to 'Managed' in DSCI CR, it is required by KServe serving field")
+		}
+
+		serverlessFeatures := feature.ComponentFeaturesHandler(k, instance, k.configureServerlessFeatures())
+
+		if err := serverlessFeatures.Apply(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (k *Kserve) removeServerlessFeatures(instance *dsciv1.DSCInitializationSpec) error {
+	serverlessFeatures := feature.ComponentFeaturesHandler(k, instance, k.configureServerlessFeatures())
+
+	return serverlessFeatures.Delete()
+}
+
+func checkDependentOperators(cli client.Client) *multierror.Error {
+	var multiErr *multierror.Error
+
+	if found, err := deploy.OperatorExists(cli, ServiceMeshOperator); err != nil {
+		multiErr = multierror.Append(multiErr, err)
+	} else if !found {
+		err = fmt.Errorf("operator %s not found. Please install the operator before enabling %s component",
+			ServiceMeshOperator, ComponentName)
+		multiErr = multierror.Append(multiErr, err)
+	}
+
+	if found, err := deploy.OperatorExists(cli, ServerlessOperator); err != nil {
+		multiErr = multierror.Append(multiErr, err)
+	} else if !found {
+		err = fmt.Errorf("operator %s not found. Please install the operator before enabling %s component",
+			ServerlessOperator, ComponentName)
+		multiErr = multierror.Append(multiErr, err)
+	}
+	return multiErr
+}

--- a/components/kserve/kserve_config_handler.go
+++ b/components/kserve/kserve_config_handler.go
@@ -51,7 +51,6 @@ func (k *Kserve) setupKserveConfigAndDependencies(ctx context.Context, cli clien
 		}
 	}
 	return nil
-
 }
 
 func (k *Kserve) setDefaultDeploymentMode(ctx context.Context, cli client.Client, dscispec *dsciv1.DSCInitializationSpec, defaultmode DefaultDeploymentMode) error {

--- a/components/kserve/kserve_config_handler.go
+++ b/components/kserve/kserve_config_handler.go
@@ -23,9 +23,6 @@ func (k *Kserve) setupKserveConfigAndDependencies(ctx context.Context, cli clien
 	// as long as Kserve.Serving is not 'Removed', we will setup the dependencies
 
 	if k.Serving.ManagementState != operatorv1.Removed {
-		if k.DefaultDeploymentMode == Serverless {
-			return fmt.Errorf("setting the defaultDeployment mode Serverless is not compatible with setting the management state for Serving as Removed")
-		}
 		// check on dependent operators if all installed in cluster
 		dependOpsErrors := checkDependentOperators(cli).ErrorOrNil()
 		if dependOpsErrors != nil {
@@ -44,6 +41,9 @@ func (k *Kserve) setupKserveConfigAndDependencies(ctx context.Context, cli clien
 	// since serverless is specifically set to 'Removed'
 	// we do not need to check if dependent operators are installed and configure them
 	// in this case the default deployment mode is forced to be RawDeployment
+	if k.DefaultDeploymentMode == Serverless {
+		fmt.Println("setting the defaultDeployment mode Serverless is not compatible with setting the management state for Serving as Removed")
+	}
 	fmt.Println("Serverless is specified as 'Removed', Kserve will default to RawDeployment")
 	return k.setDefaultDeploymentMode(ctx, cli, dscispec, RawDeployment)
 }

--- a/components/kserve/kserve_config_handler.go
+++ b/components/kserve/kserve_config_handler.go
@@ -50,6 +50,7 @@ func (k *Kserve) setupKserveConfigAndDependencies(ctx context.Context, cli clien
 			return err
 		}
 	}
+	return nil
 
 }
 

--- a/config/crd/bases/datasciencecluster.opendatahub.io_datascienceclusters.yaml
+++ b/config/crd/bases/datasciencecluster.opendatahub.io_datascienceclusters.yaml
@@ -180,7 +180,6 @@ spec:
                       at the same time
                     properties:
                       defaultDeploymentMode:
-                        default: Serverless
                         description: Configures the default deployment mode for Kserve.
                           This can be set to 'Serverless' or 'RawDeployment'. The
                           value specified in this field will be used to set the default

--- a/config/crd/bases/datasciencecluster.opendatahub.io_datascienceclusters.yaml
+++ b/config/crd/bases/datasciencecluster.opendatahub.io_datascienceclusters.yaml
@@ -179,6 +179,12 @@ spec:
                       before enable component Does not support enabled ModelMeshServing
                       at the same time
                     properties:
+                      defaultDeploymentMode:
+                        default: Serverless
+                        enum:
+                        - Serverless
+                        - RawDeployment
+                        type: string
                       devFlags:
                         description: Add developer fields
                         properties:

--- a/config/crd/bases/datasciencecluster.opendatahub.io_datascienceclusters.yaml
+++ b/config/crd/bases/datasciencecluster.opendatahub.io_datascienceclusters.yaml
@@ -181,9 +181,15 @@ spec:
                     properties:
                       defaultDeploymentMode:
                         default: Serverless
+                        description: Configures the default deployment mode for Kserve.
+                          This can be set to 'Serverless' or 'RawDeployment'. The
+                          value specified in this field will be used to set the default
+                          deployment mode in the 'inferenceservice-config' configmap
+                          for Kserve
                         enum:
                         - Serverless
                         - RawDeployment
+                        pattern: ^(Serverless|RawDeployment)$
                         type: string
                       devFlags:
                         description: Add developer fields

--- a/controllers/datasciencecluster/kubebuilder_rbac.go
+++ b/controllers/datasciencecluster/kubebuilder_rbac.go
@@ -196,7 +196,7 @@ package datasciencecluster
 // +kubebuilder:rbac:groups="core",resources=endpoints,verbs=watch;list;get;create;update;delete
 
 // +kubebuilder:rbac:groups="core",resources=configmaps/status,verbs=get;update;patch;delete
-// +kubebuilder:rbac:groups="core",resources=configmaps,verbs=get;create;update;watch;patch;delete;list
+// +kubebuilder:rbac:groups="core",resources=configmaps,verbs=get;create;watch;patch;delete;list;update
 
 // +kubebuilder:rbac:groups="core",resources=clusterversions,verbs=watch;list
 // +kubebuilder:rbac:groups="config.openshift.io",resources=clusterversions,verbs=watch;list

--- a/docs/Dev-Preview.md
+++ b/docs/Dev-Preview.md
@@ -108,3 +108,28 @@ EOF
 
 - Currently on integration of ODH [core components](https://opendatahub.io/docs/tiered-components/) are available with the Operator.
 - Tier 1 and Tier 2 components can be deployed manually using [kustomize build](https://kubectl.docs.kubernetes.io/references/kustomize/cmd/build/)
+
+
+## Preview Features 
+
+### Kserve 
+
+#### Changing the Default Deployment Mode for Kserve 
+
+Kserve can now support `Serverless` and `RawDeployment` as the default deployment modes. The default deployment mode for Kserve can be set in the DSC as follows : 
+```
+kserve:
+  defaultDeploymentMode: RawDeployment
+  managementState: Managed
+  serving:
+    ingressGateway:
+      certificate:
+        type: SelfSigned
+    managementState: Removed
+    name: knative-serving
+```
+
+Notes : 
+- If a value for defaultDeploymentMode is not provided, it is assumed to be `Serverless` as long as kserve.serving.managementState is not `Removed`
+- If kserve.serving.managementState is `Removed`, the default deployment mode is assumed to be `RawDeployment` if no value is provided. 
+- Explicitly setting defaultDeploymentMode to `Serverless` with kserve.serving.managementState set to `Removed` will result in an expected error due to incompatible options. 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This change is to support Raw Deployments for Kserve. JIRA: https://issues.redhat.com/browse/RHOAIENG-3132 
This PR adds a field `DefaultDeploymentMode` to the Kserve spec in the DSC. The default value is `Serverless`, which introduces no changes in behavior. However, if the `DefaultDeploymentMode` is set to `RawDeployment`, the operator updates the configmap `inferenceservice-config` in the applications NS. The updates are as follows : 
- deploy["defaultDeploymentMode"] is set to match the value passed to the DSC since they both use the same enum
- ingress["disableIngressCreation "] is set to `true`  if the deployment mode is `RawDeployments`, otherwise it is `false` 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Changes tested against dev cluster by building and deploying `quay.io/vedantm/opendatahub-operator:rawdeployment` 
Testing instructions : 
- clone the operator repo and run `make deploy -e IMG=quay.io/vedantm/opendatahub-operator:latest -e OPERATOR_NAMESPACE=opendatahub-operator-system` 
- Create a DSCInitialization as follows
```
spec:
  applicationsNamespace: opendatahub
  monitoring:
    managementState: Managed
    namespace: opendatahub
  serviceMesh:
    controlPlane:
      metricsCollection: Istio
      name: data-science-smcp
      namespace: istio-system
    managementState: Unmanaged
``` 
- Create a DSC as follows 
```
    kserve:
      defaultDeploymentMode: RawDeployment
      managementState: Managed
      serving:
        ingressGateway:
          certificate:
            type: SelfSigned
        managementState: Removed
        name: knative-serving
``` 
- Once the DSC reconcile is successful, verify values in the `inferenceservice-config` ConfigMap in the applications NS 
![image](https://github.com/opendatahub-io/opendatahub-operator/assets/20891020/2ca18c13-cd36-49f5-814a-bfe61ca5781c)
![image](https://github.com/opendatahub-io/opendatahub-operator/assets/20891020/770cf72d-4db5-4174-9f6d-d25c490b7aad)
- Change the DSC spec such that default deployment is now `Serverless`, wait for DSC to reconcile and verify the corresponding changes in the `inferenceservice-config` object 



## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
