### PR TITLE
feat: refactor manifest handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -319,7 +319,7 @@ toolbox: ## Create a toolbox instance with the proper Golang and Operator SDK ve
 	toolbox create opendatahub-toolbox --image localhost/opendatahub-toolbox:latest
 
 # Run tests.
-TEST_SRC=./controllers/... ./tests/integration/features/...
+TEST_SRC=./controllers/... ./tests/integration/features/... ./pkg/feature/...
 
 .PHONY: envtest
 envtest: $(ENVTEST) ## Download envtest-setup locally if necessary.

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-logr/logr v1.2.4
 	github.com/hashicorp/go-multierror v1.1.1
+	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/ginkgo/v2 v2.12.1
 	github.com/onsi/gomega v1.27.10
 	github.com/opendatahub-io/opendatahub-operator v1.7.0
@@ -16,6 +17,7 @@ require (
 	github.com/operator-framework/operator-lifecycle-manager v0.26.0
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.68.0
+	github.com/spf13/afero v1.2.2
 	github.com/stretchr/testify v1.8.3
 	golang.org/x/exp v0.0.0-20230905200255-921286631fa9
 	gopkg.in/yaml.v2 v2.4.0
@@ -63,6 +65,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
+	github.com/nxadm/tail v1.4.8 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_golang v1.16.0 // indirect
 	github.com/prometheus/client_model v0.4.0 // indirect
@@ -89,6 +92,7 @@ require (
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/protobuf v1.31.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
+	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/component-base v0.28.3 // indirect
 	k8s.io/klog/v2 v2.100.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-logr/logr v1.2.4
 	github.com/hashicorp/go-multierror v1.1.1
-	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/ginkgo/v2 v2.12.1
 	github.com/onsi/gomega v1.27.10
 	github.com/opendatahub-io/opendatahub-operator v1.7.0
@@ -65,7 +64,6 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
-	github.com/nxadm/tail v1.4.8 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_golang v1.16.0 // indirect
 	github.com/prometheus/client_model v0.4.0 // indirect
@@ -92,7 +90,6 @@ require (
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/protobuf v1.31.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
-	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/component-base v0.28.3 // indirect
 	k8s.io/klog/v2 v2.100.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -180,11 +180,14 @@ github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8m
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
+github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.12.1/go.mod h1:zj2OWP4+oCPe1qIXoGWkgMRwljMUYCdkwsT2108oapk=
 github.com/onsi/ginkgo v1.14.0/go.mod h1:iSB4RoI2tjJc9BBv4NKIKWKya62Rps+oPG/Lv9klQyY=
 github.com/onsi/ginkgo v1.16.4/go.mod h1:dX+/inL/fNMqNlz0e9LfyB9TswhZpCVdJM/Z6Vvnwo0=
+github.com/onsi/ginkgo v1.16.5 h1:8xi0RTUf59SOSfEtZMvwTvXYMzG4gV23XVHOZiXNtnE=
+github.com/onsi/ginkgo v1.16.5/go.mod h1:+E8gABHa3K6zRBolWtd+ROzc/U5bkGt0FwiG042wbpU=
 github.com/onsi/ginkgo/v2 v2.0.0/go.mod h1:vw5CSIxN1JObi/U8gcbwft7ZxR2dgaR70JSE3/PpL4c=
 github.com/onsi/ginkgo/v2 v2.1.3/go.mod h1:vw5CSIxN1JObi/U8gcbwft7ZxR2dgaR70JSE3/PpL4c=
 github.com/onsi/ginkgo/v2 v2.1.4/go.mod h1:um6tUpWM/cxCK3/FK8BXqEiUMUwRgSM4JXG47RKZmLU=
@@ -242,6 +245,7 @@ github.com/sergi/go-diff v1.2.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNX
 github.com/sirupsen/logrus v1.9.2 h1:oxx1eChJGI6Uks2ZC4W1zpLlVgqB8ner4EuQwV4Ik1Y=
 github.com/sirupsen/logrus v1.9.2/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
+github.com/spf13/afero v1.2.2 h1:5jhuqJyZCZf2JRofRvN/nIFgIWNzPa3/Vz8mYylgbWc=
 github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTdifk=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
@@ -469,6 +473,7 @@ gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EV
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
 gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
+gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkepLTh2hOroT7a+7czfdQ=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.3/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/go.sum
+++ b/go.sum
@@ -180,14 +180,11 @@ github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8m
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
-github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.12.1/go.mod h1:zj2OWP4+oCPe1qIXoGWkgMRwljMUYCdkwsT2108oapk=
 github.com/onsi/ginkgo v1.14.0/go.mod h1:iSB4RoI2tjJc9BBv4NKIKWKya62Rps+oPG/Lv9klQyY=
 github.com/onsi/ginkgo v1.16.4/go.mod h1:dX+/inL/fNMqNlz0e9LfyB9TswhZpCVdJM/Z6Vvnwo0=
-github.com/onsi/ginkgo v1.16.5 h1:8xi0RTUf59SOSfEtZMvwTvXYMzG4gV23XVHOZiXNtnE=
-github.com/onsi/ginkgo v1.16.5/go.mod h1:+E8gABHa3K6zRBolWtd+ROzc/U5bkGt0FwiG042wbpU=
 github.com/onsi/ginkgo/v2 v2.0.0/go.mod h1:vw5CSIxN1JObi/U8gcbwft7ZxR2dgaR70JSE3/PpL4c=
 github.com/onsi/ginkgo/v2 v2.1.3/go.mod h1:vw5CSIxN1JObi/U8gcbwft7ZxR2dgaR70JSE3/PpL4c=
 github.com/onsi/ginkgo/v2 v2.1.4/go.mod h1:um6tUpWM/cxCK3/FK8BXqEiUMUwRgSM4JXG47RKZmLU=
@@ -473,7 +470,6 @@ gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EV
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
 gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
-gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkepLTh2hOroT7a+7czfdQ=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.3/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/pkg/deploy/deploy.go
+++ b/pkg/deploy/deploy.go
@@ -175,7 +175,7 @@ func DeployManifestsFromPath(cli client.Client, owner metav1.Object, manifestPat
 		return err
 	}
 
-	objs, err := getResources(resMap)
+	objs, err := GetResources(resMap)
 	if err != nil {
 		return err
 	}
@@ -190,7 +190,7 @@ func DeployManifestsFromPath(cli client.Client, owner metav1.Object, manifestPat
 	return nil
 }
 
-func getResources(resMap resmap.ResMap) ([]*unstructured.Unstructured, error) {
+func GetResources(resMap resmap.ResMap) ([]*unstructured.Unstructured, error) {
 	resources := make([]*unstructured.Unstructured, 0, resMap.Size())
 	for _, res := range resMap.Resources() {
 		u := &unstructured.Unstructured{}

--- a/pkg/feature/manifest.go
+++ b/pkg/feature/manifest.go
@@ -7,13 +7,27 @@ import (
 	"html/template"
 	"io"
 	"io/fs"
+	"os"
 	"path"
 	"path/filepath"
+	"regexp"
 	"strings"
+
+	"github.com/ghodss/yaml"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/kustomize/api/krusty"
+	"sigs.k8s.io/kustomize/api/resmap"
+	"sigs.k8s.io/kustomize/kyaml/filesys"
+
+	featurev1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/features/v1"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/deploy"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/plugins"
 )
 
 //go:embed templates
 var embeddedFiles embed.FS
+
+const KustomizationFile = "kustomization.yaml"
 
 var (
 	BaseDir        = "templates"
@@ -21,17 +35,149 @@ var (
 	ServerlessDir  = path.Join(BaseDir, "serverless")
 )
 
-type manifest struct {
-	name,
-	path,
-	processedContent string
-	template,
-	patch bool
-	fsys fs.FS
+// Manifest defines the interface that all manifest types should implement.
+type Manifest interface {
+	Process(data interface{}) ([]*unstructured.Unstructured, error)
+	isPatch() bool
 }
 
-func loadManifestsFrom(fsys fs.FS, path string) ([]manifest, error) {
-	var manifests []manifest
+type baseManifest struct {
+	name,
+	path string
+	patch bool
+	fsys  fs.FS
+}
+
+func (b *baseManifest) isPatch() bool {
+	return b.patch
+}
+
+// Ensure baseManifest implements the Manifest interface.
+var _ Manifest = (*baseManifest)(nil)
+
+func (b *baseManifest) Process(_ interface{}) ([]*unstructured.Unstructured, error) {
+	manifestFile, err := b.fsys.Open(b.path)
+	if err != nil {
+		return nil, err
+	}
+	defer manifestFile.Close()
+
+	content, err := io.ReadAll(manifestFile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read file: %w", err)
+	}
+	resources := string(content)
+
+	var objs []*unstructured.Unstructured
+
+	objs, err = convertToUnstructureds(resources, objs)
+	if err != nil {
+		return nil, err
+	}
+	return objs, nil
+}
+
+type templateManifest struct {
+	name,
+	path string
+	patch bool
+	fsys  fs.FS
+}
+
+func (t *templateManifest) isPatch() bool {
+	return t.patch
+}
+
+func (t *templateManifest) Process(data interface{}) ([]*unstructured.Unstructured, error) {
+	manifestFile, err := t.fsys.Open(t.path)
+	if err != nil {
+		return nil, err
+	}
+	defer manifestFile.Close()
+
+	content, err := io.ReadAll(manifestFile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create file: %w", err)
+	}
+
+	tmpl, err := template.New(t.name).Funcs(template.FuncMap{"ReplaceChar": ReplaceChar}).Parse(string(content))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create file: %w", err)
+	}
+
+	var buffer bytes.Buffer
+	if err := tmpl.Execute(&buffer, data); err != nil {
+		return nil, err
+	}
+
+	resources := buffer.String()
+	var objs []*unstructured.Unstructured
+
+	objs, err = convertToUnstructureds(resources, objs)
+	if err != nil {
+		return nil, err
+	}
+	return objs, nil
+}
+
+// Ensure templateManifest implements the Manifest interface.
+var _ Manifest = (*templateManifest)(nil)
+
+// kustomizeManifest supports paths to kustomization files / directories containing a kustomization file
+// note that it only supports to paths within the mounted files ie: opt/manifests.
+type kustomizeManifest struct {
+	name,
+	path string // path is to the directory containing a kustomization.yaml file within it or path to kust file itself
+	fsys filesys.FileSystem
+}
+
+func (k *kustomizeManifest) isPatch() bool {
+	return false
+}
+
+func (k *kustomizeManifest) Process(data interface{}) ([]*unstructured.Unstructured, error) {
+	kustomizer := krusty.MakeKustomizer(krusty.MakeDefaultOptions())
+	var resMap resmap.ResMap
+	resMap, resErr := kustomizer.Run(k.fsys, k.path)
+
+	if resErr != nil {
+		return nil, fmt.Errorf("error during resmap resources: %w", resErr)
+	}
+
+	targetNs := getTargetNs(data)
+	if targetNs == "" {
+		return nil, fmt.Errorf("error grabbing targetNs from feature spec")
+	}
+
+	if err := plugins.ApplyNamespacePlugin(targetNs, resMap); err != nil {
+		return nil, err
+	}
+
+	// Todo: for now, this only supports applying labels to manifests source.Name when source.type==Component
+	componentName := getComponentName(data)
+	if componentName != "" {
+		if err := plugins.ApplyAddLabelsPlugin(componentName, resMap); err != nil {
+			return nil, err
+		}
+	}
+
+	objs, resErr := deploy.GetResources(resMap)
+	if resErr != nil {
+		return nil, resErr
+	}
+	return objs, nil
+}
+
+// Ensure kustomizeManifest implements the Manifest interface.
+var _ Manifest = (*kustomizeManifest)(nil)
+
+func loadManifestsFrom(fsys fs.FS, path string) ([]Manifest, error) {
+	var manifests []Manifest
+	if isKustomizeManifest(path) {
+		m := CreateKustomizeManifestFrom(path, nil)
+		manifests = append(manifests, m)
+		return manifests, nil
+	}
 
 	err := fs.WalkDir(fsys, path, func(path string, dirEntry fs.DirEntry, walkErr error) error {
 		if walkErr != nil {
@@ -46,8 +192,11 @@ func loadManifestsFrom(fsys fs.FS, path string) ([]manifest, error) {
 		if dirEntry.IsDir() {
 			return nil
 		}
-		m := createManifestFrom(fsys, path)
-		manifests = append(manifests, m)
+		if isTemplateManifest(path) {
+			manifests = append(manifests, CreateTemplateManifestFrom(fsys, path))
+		} else {
+			manifests = append(manifests, CreateBaseManifestFrom(fsys, path))
+		}
 
 		return nil
 	})
@@ -59,57 +208,99 @@ func loadManifestsFrom(fsys fs.FS, path string) ([]manifest, error) {
 	return manifests, nil
 }
 
-func createManifestFrom(fsys fs.FS, path string) manifest {
+func CreateBaseManifestFrom(fsys fs.FS, path string) *baseManifest { //nolint:golint,revive //No need to export baseManifest.
 	basePath := filepath.Base(path)
-	m := manifest{
-		name:     basePath,
-		path:     path,
-		patch:    strings.Contains(basePath, ".patch"),
-		template: filepath.Ext(path) == ".tmpl",
-		fsys:     fsys,
+	m := &baseManifest{
+		name:  basePath,
+		path:  path,
+		patch: strings.Contains(basePath, ".patch"),
+		fsys:  fsys,
 	}
 
 	return m
 }
 
-func (m *manifest) targetPath() string {
-	return fmt.Sprintf("%s%s", m.path[:len(m.path)-len(filepath.Ext(m.path))], ".yaml")
+func CreateTemplateManifestFrom(fsys fs.FS, path string) *templateManifest { //nolint:golint,revive //No need to export templateManifest.
+	basePath := filepath.Base(path)
+	m := &templateManifest{
+		name:  basePath,
+		path:  path,
+		patch: strings.Contains(basePath, ".patch"),
+		fsys:  fsys,
+	}
+
+	return m
 }
 
-func (m *manifest) process(data interface{}) error {
-	manifestFile, err := m.open()
-	if err != nil {
-		return err
+func CreateKustomizeManifestFrom(path string, fsys filesys.FileSystem) *kustomizeManifest { //nolint:golint,revive //No need to export kustomizeManifest.
+	basePath := filepath.Base(path)
+	if basePath == KustomizationFile {
+		path = filepath.Dir(path)
 	}
-	defer manifestFile.Close()
-
-	content, err := io.ReadAll(manifestFile)
-	if err != nil {
-		return fmt.Errorf("failed to create file: %w", err)
+	if fsys == nil {
+		fsys = filesys.MakeFsOnDisk()
 	}
-
-	if !m.template {
-		// If, by convention, the file is not suffixed with `.tmpl` we do not need to trigger template processing.
-		// It's safe to return at this point.
-		m.processedContent = string(content)
-		return nil
+	m := &kustomizeManifest{
+		name: basePath,
+		path: path,
+		fsys: fsys,
 	}
 
-	tmpl, err := template.New(m.name).Funcs(template.FuncMap{"ReplaceChar": ReplaceChar}).Parse(string(content))
-	if err != nil {
-		return fmt.Errorf("failed to create file: %w", err)
-	}
-
-	var buffer bytes.Buffer
-	if err := tmpl.Execute(&buffer, data); err != nil {
-		return err
-	}
-
-	m.processedContent = buffer.String()
-
-	return nil
+	return m
 }
 
-func (m *manifest) open() (fs.File, error) {
-	return m.fsys.Open(m.path)
+// parsing helpers
+// isKustomizeManifest checks default filesystem for presence of kustomization file at this path.
+func isKustomizeManifest(path string) bool {
+	if filepath.Base(path) == KustomizationFile {
+		return true
+	}
+	_, err := os.Stat(filepath.Join(path, KustomizationFile))
+	return err == nil
+}
+
+func isTemplateManifest(path string) bool {
+	return strings.Contains(path, ".tmpl")
+}
+
+func convertToUnstructureds(resources string, objs []*unstructured.Unstructured) ([]*unstructured.Unstructured, error) {
+	splitter := regexp.MustCompile(YamlSeparator)
+	objectStrings := splitter.Split(resources, -1)
+	for _, str := range objectStrings {
+		if strings.TrimSpace(str) == "" {
+			continue
+		}
+		u := &unstructured.Unstructured{}
+		if err := yaml.Unmarshal([]byte(str), u); err != nil {
+			return nil, err
+		}
+
+		if !isNamespaceSet(u) {
+			return nil, fmt.Errorf("no NS is set on %s", u.GetName())
+		}
+		objs = append(objs, u)
+	}
+	return objs, nil
+}
+
+// todo: rework these when spec is type map[string]any
+func getTargetNs(data interface{}) string {
+	if spec, ok := data.(*Spec); ok {
+		return spec.TargetNamespace
+	}
+	return ""
+}
+
+func getComponentName(data interface{}) string {
+	if featSpec, ok := data.(*Spec); ok {
+		source := featSpec.Source
+		if source == nil {
+			return ""
+		}
+		if source.Type == featurev1.ComponentType {
+			return source.Name
+		}
+		return ""
+	}
+	return ""
 }

--- a/pkg/feature/manifest_test.go
+++ b/pkg/feature/manifest_test.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/feature"
 
-	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
 

--- a/pkg/feature/manifest_test.go
+++ b/pkg/feature/manifest_test.go
@@ -1,0 +1,180 @@
+package feature_test
+
+import (
+	"io/fs"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/afero"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/kustomize/kyaml/filesys"
+
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/feature"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+// AferoFsAdapter adapts an afero.Fs to fs.FS.
+type AferoFsAdapter struct {
+	Afs afero.Fs
+}
+
+// Open adapts the Open method to comply with fs.FS interface.
+func (a AferoFsAdapter) Open(name string) (fs.File, error) {
+	return a.Afs.Open(name)
+}
+
+var _ = Describe("Manifest Processing", func() {
+	var (
+		mockFS AferoFsAdapter
+		path   string
+	)
+
+	BeforeEach(func() {
+		fSys := afero.NewMemMapFs()
+		mockFS = AferoFsAdapter{Afs: fSys}
+
+	})
+
+	Describe("baseManifest Process", func() {
+		BeforeEach(func() {
+			resourceYaml := `
+apiVersion: v1
+kind: ConfigMap
+metadata:
+ name: my-configmap
+ namespace: fake-ns
+data:
+ key: value
+`
+			path = "path/to/test.yaml"
+			err := afero.WriteFile(mockFS.Afs, path, []byte(resourceYaml), 0644)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should process the manifest correctly", func() {
+			// given
+			manifest := feature.CreateBaseManifestFrom(mockFS, path)
+
+			// when
+			// Simulate adding to and processing from a slice of Manifest interfaces
+			manifests := []feature.Manifest{manifest}
+			var err error
+			var objs []*unstructured.Unstructured
+			for i := range manifests {
+				objs, err = manifests[i].Process(nil)
+				if err != nil {
+					break
+				}
+			}
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(objs).To(HaveLen(1))
+			Expect(objs[0].GetKind()).To(Equal("ConfigMap"))
+			Expect(objs[0].GetName()).To(Equal("my-configmap"))
+		})
+	})
+
+	Describe("TemplateManifest Process", func() {
+		BeforeEach(func() {
+			resourceYaml := `
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: my-configmap
+  namespace: {{.Namespace}}
+data:
+  key: Data
+`
+			path = "path/to/template.yaml"
+			err := afero.WriteFile(mockFS.Afs, path, []byte(resourceYaml), 0644)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should process the template manifest correctly", func() {
+			// given
+			data := map[string]any{
+				"Namespace": "template-ns",
+			}
+			manifest := feature.CreateTemplateManifestFrom(mockFS, path)
+
+			// when
+			// Simulate adding to and processing from a slice of Manifest interfaces
+			manifests := []feature.Manifest{manifest}
+			var err error
+			var objs []*unstructured.Unstructured
+			for i := range manifests {
+				objs, err = manifests[i].Process(data)
+				if err != nil {
+					break
+				}
+			}
+			Expect(err).NotTo(HaveOccurred())
+
+			// then
+			Expect(objs).To(HaveLen(1))
+			Expect(objs[0].GetKind()).To(Equal("ConfigMap"))
+			Expect(objs[0].GetName()).To(Equal("my-configmap"))
+			Expect(objs[0].GetNamespace()).To(Equal("template-ns"))
+		})
+
+	})
+
+	Describe("KustomizeManifest Process", func() {
+		BeforeEach(func() {
+			path = "/path/to/kustomization/" // base path here
+		})
+
+		It("should process the kustomize manifest correctly", func() {
+			// given
+			fSys := filesys.MakeFsInMemory()
+			kustomizationYaml := `
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- resource.yaml
+`
+			resourceYaml := `
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: my-configmap
+data:
+  key: value
+`
+			// TODO: rework for map[string]any when supported
+			data := feature.Spec{
+				TargetNamespace: "kust-ns",
+			}
+
+			err := fSys.WriteFile(filepath.Join(path, "kustomization.yaml"), []byte(kustomizationYaml))
+			Expect(err).ToNot(HaveOccurred())
+			err = fSys.WriteFile(filepath.Join(path, "resource.yaml"), []byte(resourceYaml))
+			Expect(err).ToNot(HaveOccurred())
+			manifest := feature.CreateKustomizeManifestFrom("/path/to/kustomization/", fSys)
+
+			// when
+			manifests := []feature.Manifest{manifest}
+			var objs []*unstructured.Unstructured
+			for i := range manifests {
+				objs, err = manifests[i].Process(&data)
+				if err != nil {
+					break
+				}
+			}
+			Expect(err).NotTo(HaveOccurred())
+
+			// then
+			Expect(objs).To(HaveLen(1))
+			configMap := objs[0]
+			Expect(configMap.GetKind()).To(Equal("ConfigMap"))
+			Expect(configMap.GetName()).To(Equal("my-configmap"))
+		})
+	})
+})
+
+func TestFeature(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Feature Suite")
+}

--- a/pkg/feature/types.go
+++ b/pkg/feature/types.go
@@ -12,6 +12,7 @@ type Spec struct {
 	Serving                  *infrav1.ServingSpec
 	OAuth                    OAuth
 	AppNamespace             string
+	TargetNamespace          string
 	Domain                   string
 	KnativeCertificateSecret string
 	KnativeIngressDomain     string

--- a/tests/integration/features/features_int_test.go
+++ b/tests/integration/features/features_int_test.go
@@ -517,6 +517,30 @@ metadata:
 				Expect(err).ToNot(HaveOccurred())
 				Expect(realNs.Name).To(Equal("real-file-test-ns"))
 			})
+
+			It("should process kustomization manifests directly from the file system", func() {
+				// given
+				featuresHandler := feature.ClusterFeaturesHandler(dsci, func(handler *feature.FeaturesHandler) error {
+					createCfgMapErr := feature.CreateFeature("create-cfg-map").
+						For(handler).
+						UsingConfig(envTest.Config).
+						Manifests(path.Join(feature.BaseDir, "fake-kust-dir")).
+						Load()
+
+					Expect(createCfgMapErr).ToNot(HaveOccurred())
+
+					return nil
+				})
+
+				// when
+				Expect(featuresHandler.Apply()).To(Succeed())
+
+				// then
+				cfgMap, err := getConfigMap("my-configmap", featuresHandler.ApplicationsNamespace)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(cfgMap.Name).To(Equal("my-configmap"))
+				Expect(cfgMap.Data["key"]).To(Equal("value"))
+			})
 		})
 	})
 
@@ -618,6 +642,15 @@ func getService(name, namespace string) (*v1.Service, error) {
 	}, svc)
 
 	return svc, err
+}
+
+func getConfigMap(name, namespace string) (*v1.ConfigMap, error) {
+	cfgMap := &v1.ConfigMap{}
+	err := envTestClient.Get(context.Background(), types.NamespacedName{
+		Name: name, Namespace: namespace,
+	}, cfgMap)
+
+	return cfgMap, err
 }
 
 func createFile(dir, filename, data string) error {

--- a/tests/integration/features/templates/fake-kust-dir/kustomization.yaml
+++ b/tests/integration/features/templates/fake-kust-dir/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - resource.yaml

--- a/tests/integration/features/templates/fake-kust-dir/resource.yaml
+++ b/tests/integration/features/templates/fake-kust-dir/resource.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: my-configmap
+data:
+  key: "value"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The is PR reworks the way that the `Feature` framework creates and handles manifests. Rather than treat all manifests as one type with flags for how it should be treated, we now define Manifest as an interface, and add the `BaseManifest`, `TemplateManifest`, and  `KustomizeManifest` types - adding initial support for Kustomization files. Also, this PR adds the `TargetNamespace` field to Feature.spec, allowing users to specify a TargetNamespace for their kustomization manifests to be applied to. 

- `BaseManifest`s are created for processing raw yaml files - no templating needed, just apply yaml to create objects.
- `TemplateManifest`s are created for processing .tmpl files - templating is applied to these files (substituting values within file). 
Both of these support .patch files. 
- `KustomizeManifest`s are created for processing `kustomization.yaml` files (also supports passing in the directory that contains said file). 

This allows for better processing of each type of manifest - now the process() method returns a list of unstructured objects to be applied rather than storing strings within the manifest type. 

Note that KustomizeManifest's only support files stored within the filesystem - not the embedded filesystem. eg it supports files stored in `opt/manifests/...`.  

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Added new unit tests for each type's Process() method - added the path to this to `make unit-test`. Also added another feature integration test for a KustomizeManifest. 

For testing manually, built image `quay.io/cgarriso/opendatahub-operator:dev-split-manifest-types` and ensured features within DSCI's service mesh setup still worked as expected. Also, in this image I created some 'fake' features: 
```
createKustTwoErr := feature.CreateFeature("create-kustomization-two").
    For(handler).
    Manifests(path.Join("opt", "manifests", "fake-kust-dir")).
    TargetNamespace("istio-system").
    Load()
```
ensuring that KustomizeManifest's with a TargetNamespace worked as expected on CRC.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
