### PR TITLE
feat(dashboard): use new manifests structure from ODH

### DIFF
--- a/components/dashboard/dashboard.go
+++ b/components/dashboard/dashboard.go
@@ -40,7 +40,7 @@ var (
 
 	NameConsoleLink      = "console"
 	NamespaceConsoleLink = "openshift-console"
-	// PathAnaconda         = deploy.DefaultManifestPath + "/partners/anaconda/base/"
+	// PathAnaconda         = deploy.DefaultManifestPath + "/partners/anaconda/base/".
 )
 
 // Verifies that Dashboard implements ComponentInterface.

--- a/components/dashboard/dashboard.go
+++ b/components/dashboard/dashboard.go
@@ -25,19 +25,22 @@ import (
 )
 
 var (
-	ComponentName          = "dashboard"
-	ComponentNameSupported = "rhods-dashboard"
-	Path                   = deploy.DefaultManifestPath + "/" + ComponentName + "/base"
-	PathSupported          = deploy.DefaultManifestPath + "/" + ComponentName + "/overlays/rhods"
-	PathISVSM              = deploy.DefaultManifestPath + "/" + ComponentName + "/apps/apps-onprem"
-	PathISVAddOn           = deploy.DefaultManifestPath + "/" + ComponentName + "/apps/apps-addon"
-	PathOVMS               = deploy.DefaultManifestPath + "/" + ComponentName + "/modelserving"
-	PathODHDashboardConfig = deploy.DefaultManifestPath + "/" + ComponentName + "/odhdashboardconfig"
-	PathConsoleLink        = deploy.DefaultManifestPath + "/" + ComponentName + "/consolelink"
-	PathCRDs               = deploy.DefaultManifestPath + "/" + ComponentName + "/crd"
-	NameConsoleLink        = "console"
-	NamespaceConsoleLink   = "openshift-console"
-	PathAnaconda           = deploy.DefaultManifestPath + "/partners/anaconda/base/"
+	ComponentName    = "dashboard"
+	Path             = deploy.DefaultManifestPath + "/" + ComponentName + "/base"         // ODH
+	PathModelServing = deploy.DefaultManifestPath + "/" + ComponentName + "/modelserving" // ODH modelserving
+	PathCRDs         = deploy.DefaultManifestPath + "/" + ComponentName + "/crd"          // ODH + RHOAI
+
+	ComponentNameSupported    = "rhods-dashboard"
+	PathSupported             = deploy.DefaultManifestPath + "/" + ComponentName + "/overlays/rhoai"            // RHOAI
+	PathSupportedModelServing = deploy.DefaultManifestPath + "/" + ComponentName + "/overlays/modelserving"     // RHOAI modelserving
+	PathISVSM                 = deploy.DefaultManifestPath + "/" + ComponentName + "/overlays/apps/apps-onprem" // RHOAI APPS
+	PathISVAddOn              = deploy.DefaultManifestPath + "/" + ComponentName + "/overlays/apps/apps-addon"  // RHOAI APPS
+
+	PathConsoleLink = deploy.DefaultManifestPath + "/" + ComponentName + "/consolelink" // ODH(TODO) + RHOAI
+
+	NameConsoleLink      = "console"
+	NamespaceConsoleLink = "openshift-console"
+	PathAnaconda         = deploy.DefaultManifestPath + "/partners/anaconda/base/" // TODO: check if dashboard want to have this move to their ODH repo
 )
 
 // Verifies that Dashboard implements ComponentInterface.
@@ -58,7 +61,7 @@ func (d *Dashboard) OverrideManifests(platform string) error {
 		}
 		// If overlay is defined, update paths
 		if platform == string(deploy.ManagedRhods) || platform == string(deploy.SelfManagedRhods) {
-			defaultKustomizePath := "overlays/rhods"
+			defaultKustomizePath := "overlays/rhoai"
 			if manifestConfig.SourcePath != "" {
 				defaultKustomizePath = manifestConfig.SourcePath
 			}
@@ -98,9 +101,10 @@ func (d *Dashboard) ReconcileComponent(ctx context.Context,
 		return err
 	}
 
-	// Update Default rolebinding
+	// For only "add" if dashboard is Managed, we do not remove if set to Removed
 	if enabled {
-		// cleanup OAuth client related secret and CR if dashboard is in 'installed falas' status
+		// Update Default rolebinding
+		// cleanup OAuth client related secret and CR if dashboard is in 'installed false' status
 		if err := d.cleanOauthClient(cli, dscispec, currentComponentExist); err != nil {
 			return err
 		}
@@ -110,14 +114,16 @@ func (d *Dashboard) ReconcileComponent(ctx context.Context,
 				return err
 			}
 		}
+		// 1. Deploy CRDs
+		if err := d.deployCRDsForPlatform(cli, owner, dscispec.ApplicationsNamespace, platform); err != nil {
+			return fmt.Errorf("failed to deploy %s crds %s: %w", ComponentName, PathCRDs, err)
+		}
+
+		// 2. platform specific RBAC
 		if platform == deploy.OpenDataHub || platform == "" {
 			err := cluster.UpdatePodSecurityRolebinding(cli, dscispec.ApplicationsNamespace, "odh-dashboard")
 			if err != nil {
 				return err
-			}
-			// Deploy CRDs
-			if err := d.deployCRDsForPlatform(cli, owner, dscispec.ApplicationsNamespace, platform); err != nil {
-				return fmt.Errorf("failed to deploy %s crds %s: %w", ComponentName, PathCRDs, err)
 			}
 		}
 
@@ -126,17 +132,9 @@ func (d *Dashboard) ReconcileComponent(ctx context.Context,
 			if err != nil {
 				return err
 			}
-			// Deploy CRDs
-			if err := d.deployCRDsForPlatform(cli, owner, dscispec.ApplicationsNamespace, platform); err != nil {
-				return fmt.Errorf("failed to deploy %s crds %s: %w", ComponentNameSupported, PathCRDs, err)
-			}
-			// Apply RHODS specific configs
-			if err := d.applyRhodsSpecificConfigs(cli, owner, dscispec.ApplicationsNamespace, platform); err != nil {
-				return err
-			}
 		}
 
-		// Update image parameters (ODH does not use this solution, only downstream)
+		// 3. Update image parameters
 		if (dscispec.DevFlags == nil || dscispec.DevFlags.ManifestsUri == "") && (d.DevFlags == nil || len(d.DevFlags.Manifests) == 0) {
 			if err := deploy.ApplyParams(PathSupported, d.SetImageParamsMap(imageParamMap), false); err != nil {
 				return err
@@ -144,30 +142,25 @@ func (d *Dashboard) ReconcileComponent(ctx context.Context,
 		}
 	}
 
-	// Deploy odh-dashboard manifests
-	if platform == deploy.OpenDataHub || platform == "" {
-		if err = deploy.DeployManifestsFromPath(cli, owner, Path, dscispec.ApplicationsNamespace, ComponentName, enabled); err != nil {
-			return err
-		}
-	} else if platform == deploy.SelfManagedRhods || platform == deploy.ManagedRhods {
-		// Apply authentication overlay
+	// common: Deploy odh-dashboard manifests
+	// TODO: check if we can have the same component name odh-dashboard for both, or still keep rhods-dashboard for RHOAI
+	switch platform {
+	case deploy.SelfManagedRhods, deploy.ManagedRhods:
+		// overlay which including ../../base
 		if err := deploy.DeployManifestsFromPath(cli, owner, PathSupported, dscispec.ApplicationsNamespace, ComponentNameSupported, enabled); err != nil {
 			return err
 		}
-	}
-
-	switch platform {
-	case deploy.SelfManagedRhods, deploy.ManagedRhods:
-		sectionTitle := "OpenShift Managed Services"
-		if platform == deploy.SelfManagedRhods {
-			sectionTitle = "OpenShift Self Managed Services"
+		// modelserving
+		if err := deploy.DeployManifestsFromPath(cli, owner, PathSupportedModelServing, dscispec.ApplicationsNamespace, ComponentNameSupported, enabled); err != nil {
+			return fmt.Errorf("failed to set dashboard modelserving from %s: %w", PathSupportedModelServing, err)
 		}
 
-		if err := d.deployISVManifests(cli, owner, ComponentNameSupported, dscispec.ApplicationsNamespace, platform); err != nil {
+		// Apply RHOAI specific configs, e.g anaconda screct and cronjob and ISV
+		if err := d.applyRHOAISpecificConfigs(cli, owner, dscispec.ApplicationsNamespace, platform); err != nil {
 			return err
 		}
-
-		if err := d.deployConsoleLink(cli, owner, dscispec.ApplicationsNamespace, ComponentNameSupported, sectionTitle); err != nil {
+		// consolelink
+		if err := d.deployConsoleLink(cli, owner, platform, dscispec.ApplicationsNamespace, ComponentNameSupported); err != nil {
 			return err
 		}
 		// CloudService Monitoring handling
@@ -192,6 +185,18 @@ func (d *Dashboard) ReconcileComponent(ctx context.Context,
 		}
 		return nil
 	default:
+		// base
+		if err = deploy.DeployManifestsFromPath(cli, owner, Path, dscispec.ApplicationsNamespace, ComponentName, enabled); err != nil {
+			return err
+		}
+		// modelserving
+		if err := deploy.DeployManifestsFromPath(cli, owner, PathModelServing, dscispec.ApplicationsNamespace, ComponentName, enabled); err != nil {
+			return fmt.Errorf("failed to set dashboard modelserving from %s: %w", PathModelServing, err)
+		}
+		// consolelink, TODO: uncomment once we want to add consoleline for ODH
+		// if err := d.deployConsoleLink(cli, owner, dscispec.ApplicationsNamespace, ComponentNameSupported); err != nil {
+		// 	return err
+		// }
 		return nil
 	}
 }
@@ -201,59 +206,37 @@ func (d *Dashboard) deployCRDsForPlatform(cli client.Client, owner metav1.Object
 	if platform == deploy.SelfManagedRhods || platform == deploy.ManagedRhods {
 		componentName = ComponentNameSupported
 	}
-
-	enabled := d.ManagementState == operatorv1.Managed
-
-	return deploy.DeployManifestsFromPath(cli, owner, PathCRDs, namespace, componentName, enabled)
+	// we only deploy CRD, we do not remove CRD
+	return deploy.DeployManifestsFromPath(cli, owner, PathCRDs, namespace, componentName, true)
 }
 
-func (d *Dashboard) applyRhodsSpecificConfigs(cli client.Client, owner metav1.Object, namespace string, platform deploy.Platform) error {
-	dashboardConfig := filepath.Join(PathODHDashboardConfig, "odhdashboardconfig.yaml")
-	adminGroups := map[deploy.Platform]string{
-		deploy.SelfManagedRhods: "rhods-admins",
-		deploy.ManagedRhods:     "dedicated-admins",
-	}[platform]
-
-	if err := common.ReplaceStringsInFile(dashboardConfig, map[string]string{"<admin_groups>": adminGroups}); err != nil {
-		return err
-	}
-
+func (d *Dashboard) applyRHOAISpecificConfigs(cli client.Client, owner metav1.Object, namespace string, platform deploy.Platform) error {
 	enabled := d.ManagementState == operatorv1.Managed
-	if err := deploy.DeployManifestsFromPath(cli, owner, PathODHDashboardConfig, namespace, ComponentNameSupported, enabled); err != nil {
-		return fmt.Errorf("failed to set dashboard config from %s: %w", PathODHDashboardConfig, err)
-	}
 
-	if err := deploy.DeployManifestsFromPath(cli, owner, PathOVMS, namespace, ComponentNameSupported, enabled); err != nil {
-		return fmt.Errorf("failed to set dashboard OVMS from %s: %w", PathOVMS, err)
-	}
-
+	// anaconda
 	if err := cluster.CreateSecret(cli, "anaconda-ce-access", namespace); err != nil {
 		return fmt.Errorf("failed to create access-secret for anaconda: %w", err)
 	}
-
-	return deploy.DeployManifestsFromPath(cli, owner, PathAnaconda, namespace, ComponentNameSupported, enabled)
-}
-
-func (d *Dashboard) deployISVManifests(cli client.Client, owner metav1.Object, componentName, namespace string, platform deploy.Platform) error {
-	var path string
-	switch platform {
-	case deploy.SelfManagedRhods:
-		path = PathISVSM
-	case deploy.ManagedRhods:
-		path = PathISVAddOn
-	default:
-		return nil
+	if err := deploy.DeployManifestsFromPath(cli, owner, PathAnaconda, namespace, ComponentNameSupported, enabled); err != nil {
+		return fmt.Errorf("failed to set anaconda from %s: %w", PathAnaconda, err)
 	}
 
-	enabled := d.ManagementState == operatorv1.Managed
-	if err := deploy.DeployManifestsFromPath(cli, owner, path, namespace, componentName, enabled); err != nil {
+	// ISV
+	path := PathISVSM
+	if platform == deploy.ManagedRhods {
+		path = PathISVAddOn
+	}
+	if err := deploy.DeployManifestsFromPath(cli, owner, path, namespace, ComponentNameSupported, enabled); err != nil {
 		return fmt.Errorf("failed to set dashboard ISV from %s: %w", path, err)
 	}
-
 	return nil
 }
 
-func (d *Dashboard) deployConsoleLink(cli client.Client, owner metav1.Object, namespace, componentName, sectionTitle string) error {
+func (d *Dashboard) deployConsoleLink(cli client.Client, owner metav1.Object, platform deploy.Platform, namespace, componentName string) error {
+	sectionTitle := "OpenShift Managed Services"
+	if platform == deploy.SelfManagedRhods {
+		sectionTitle = "OpenShift Self Managed Services"
+	}
 	pathConsoleLink := filepath.Join(PathConsoleLink, "consolelink.yaml")
 
 	consoleRoute := &routev1.Route{}
@@ -264,8 +247,8 @@ func (d *Dashboard) deployConsoleLink(cli client.Client, owner metav1.Object, na
 	domainIndex := strings.Index(consoleRoute.Spec.Host, ".")
 	consoleLinkDomain := consoleRoute.Spec.Host[domainIndex+1:]
 	err := common.ReplaceStringsInFile(pathConsoleLink, map[string]string{
-		"<rhods-dashboard-url>": "https://rhods-dashboard-" + namespace + "." + consoleLinkDomain,
-		"<section-title>":       sectionTitle,
+		"<dashboard-url>": "https://rhods-dashboard-" + namespace + "." + consoleLinkDomain,
+		"<section-title>": sectionTitle,
 	})
 	if err != nil {
 		return fmt.Errorf("error replacing with correct dashboard url for ConsoleLink: %w", err)

--- a/components/dashboard/dashboard.go
+++ b/components/dashboard/dashboard.go
@@ -35,12 +35,10 @@ var (
 	PathSupportedModelServing = deploy.DefaultManifestPath + "/" + ComponentName + "/overlays/modelserving"     // RHOAI modelserving
 	PathISVSM                 = deploy.DefaultManifestPath + "/" + ComponentName + "/overlays/apps/apps-onprem" // RHOAI APPS
 	PathISVAddOn              = deploy.DefaultManifestPath + "/" + ComponentName + "/overlays/apps/apps-addon"  // RHOAI APPS
-
-	PathConsoleLink = deploy.DefaultManifestPath + "/" + ComponentName + "/consolelink" // ODH(TODO) + RHOAI
+	PathConsoleLink           = deploy.DefaultManifestPath + "/" + ComponentName + "/overlays/consolelink"      // RHOAI
 
 	NameConsoleLink      = "console"
 	NamespaceConsoleLink = "openshift-console"
-	// PathAnaconda         = deploy.DefaultManifestPath + "/partners/anaconda/base/".
 )
 
 // Verifies that Dashboard implements ComponentInterface.


### PR DESCRIPTION
- logic change to consolidate with downstream

<!--- Provide a general summary of your changes in the Title above -->

ref: https://issues.redhat.com/browse/RHOAIENG-2993
need to go with ~~https://github.com/opendatahub-io/odh-dashboard/pull/2507~~  https://github.com/opendatahub-io/odh-dashboard/pull/2519

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
build with changes from "dgutride:odh-dashboard:dgutride/migrate-manifests" branch
**update**
latest live-build quay.io/wenzhou/opendatahub-operator-catalog:v2.8.2993-10
build with     ["odh-dashboard"]="lucferbux:odh-dashboard:rhoaieng-943:manifests:dashboard"
for downstream
![Screenshot from 2024-02-26 17-34-54](https://github.com/opendatahub-io/opendatahub-operator/assets/915053/2d3e82b3-df8f-427d-969e-9d7391a81820)


odh live build quay.io/wenzhou/opendatahub-operator-catalog:v2.8.2993-0
rhoai live build:  quay.io/wenzhou/rhoai-operator-catalog:v2.8.2993-0


<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
