### PR TITLE
feat(dashboard): add consolelink for ODH

### DIFF
--- a/components/dashboard/dashboard.go
+++ b/components/dashboard/dashboard.go
@@ -29,13 +29,14 @@ var (
 	Path             = deploy.DefaultManifestPath + "/" + ComponentName + "/base"         // ODH
 	PathModelServing = deploy.DefaultManifestPath + "/" + ComponentName + "/modelserving" // ODH modelserving
 	PathCRDs         = deploy.DefaultManifestPath + "/" + ComponentName + "/crd"          // ODH + RHOAI
+	PathConsoleLink  = deploy.DefaultManifestPath + "/" + ComponentName + "/consolelink"  // ODH consolelink
 
 	ComponentNameSupported    = "rhods-dashboard"
 	PathSupported             = deploy.DefaultManifestPath + "/" + ComponentName + "/overlays/rhoai"              // RHOAI
 	PathSupportedModelServing = deploy.DefaultManifestPath + "/" + ComponentName + "/overlays/modelserving"       // RHOAI modelserving
 	PathISVSM                 = deploy.DefaultManifestPath + "/" + ComponentName + "/overlays/apps/apps-onprem"   // RHOAI APPS
 	PathISVAddOn              = deploy.DefaultManifestPath + "/" + ComponentName + "/overlays/apps/apps-addon"    // RHOAI APPS
-	PathConsoleLink           = deploy.DefaultManifestPath + "/" + ComponentName + "/overlays/consolelink"        // RHOAI
+	PathConsoleLinkSupported  = deploy.DefaultManifestPath + "/" + ComponentName + "/overlays/consolelink"        // RHOAI
 	PathODHDashboardConfig    = deploy.DefaultManifestPath + "/" + ComponentName + "/overlays/odhdashboardconfig" // RHOAI odhdashboardconfig
 
 	NameConsoleLink      = "console"
@@ -196,10 +197,10 @@ func (d *Dashboard) ReconcileComponent(ctx context.Context,
 		if err := deploy.DeployManifestsFromPath(cli, owner, PathModelServing, dscispec.ApplicationsNamespace, ComponentName, enabled); err != nil {
 			return fmt.Errorf("failed to set dashboard modelserving from %s: %w", PathModelServing, err)
 		}
-		// consolelink, TODO: uncomment once we want to add consoleline for ODH + need update logic
-		// if err := d.deployConsoleLink(cli, owner, dscispec.ApplicationsNamespace, ComponentNameSupported); err != nil {
-		// 	return err
-		// }
+		// consolelink
+		if err := d.deployConsoleLink(cli, owner, platform, dscispec.ApplicationsNamespace, ComponentName); err != nil {
+			return err
+		}
 		return nil
 	}
 }
@@ -241,11 +242,23 @@ func (d *Dashboard) applyRHOAISpecificConfigs(cli client.Client, owner metav1.Ob
 }
 
 func (d *Dashboard) deployConsoleLink(cli client.Client, owner metav1.Object, platform deploy.Platform, namespace, componentName string) error {
-	sectionTitle := "OpenShift Managed Services"
-	if platform == deploy.SelfManagedRhods {
+	var manifestsPath, sectionTitle, routeName string
+	switch platform {
+	case deploy.SelfManagedRhods:
 		sectionTitle = "OpenShift Self Managed Services"
+		manifestsPath = PathConsoleLinkSupported
+		routeName = componentName
+	case deploy.ManagedRhods:
+		sectionTitle = "OpenShift Managed Services"
+		manifestsPath = PathConsoleLinkSupported
+		routeName = componentName
+	default:
+		sectionTitle = "OpenShift Open Data Hub"
+		manifestsPath = PathConsoleLink
+		routeName = "odh-dashboard"
 	}
-	pathConsoleLink := filepath.Join(PathConsoleLink, "consolelink.yaml")
+
+	pathConsoleLink := filepath.Join(manifestsPath, "consolelink.yaml")
 
 	consoleRoute := &routev1.Route{}
 	if err := cli.Get(context.TODO(), client.ObjectKey{Name: NameConsoleLink, Namespace: NamespaceConsoleLink}, consoleRoute); err != nil {
@@ -255,7 +268,7 @@ func (d *Dashboard) deployConsoleLink(cli client.Client, owner metav1.Object, pl
 	domainIndex := strings.Index(consoleRoute.Spec.Host, ".")
 	consoleLinkDomain := consoleRoute.Spec.Host[domainIndex+1:]
 	err := common.ReplaceStringsInFile(pathConsoleLink, map[string]string{
-		"<dashboard-url>": "https://rhods-dashboard-" + namespace + "." + consoleLinkDomain,
+		"<dashboard-url>": "https://" + routeName + "-" + namespace + "." + consoleLinkDomain,
 		"<section-title>": sectionTitle,
 	})
 	if err != nil {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
ref: https://issues.redhat.com/browse/RHOAIENG-3760 

## How Has This Been Tested?
**NEW**  
new live build after rebase quay.io/wenzhou/opendatahub-operator-catalog:v2.9.884-2
`this build is using main branch from ODH odh-dashboard, since the old incubation is not updated so the consolelink.yaml not even exist there`
on ODH
![Screenshot from 2024-03-08 10-00-34](https://github.com/opendatahub-io/opendatahub-operator/assets/915053/c22e081d-7acc-44e9-bd77-ad017469b59b)

**OLD**
live-build:  quay.io/wenzhou/opendatahub-operator-catalog:v2.9.884-1

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
