### PR TITLE
fix(DSCI): change serviceMesh and trustCAbundle to pointer type

### DIFF
--- a/apis/dscinitialization/v1/dscinitialization_types.go
+++ b/apis/dscinitialization/v1/dscinitialization_types.go
@@ -45,13 +45,13 @@ type DSCInitializationSpec struct {
 	// authentication giving a Single Sign On experience.
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,order=3
 	// +optional
-	ServiceMesh infrav1.ServiceMeshSpec `json:"serviceMesh,omitempty"`
+	ServiceMesh *infrav1.ServiceMeshSpec `json:"serviceMesh,omitempty"`
 	// When set to `Managed`, adds odh-trusted-ca-bundle Configmap to all namespaces that includes
 	// cluster-wide Trusted CA Bundle in .data["ca-bundle.crt"].
 	// Additionally, this fields allows admins to add custom CA bundles to the configmap using the .CustomCABundle field.
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,order=4
 	// +optional
-	TrustedCABundle TrustedCABundleSpec `json:"trustedCABundle,omitempty"`
+	TrustedCABundle *TrustedCABundleSpec `json:"trustedCABundle,omitempty"`
 	// Internal development useful field to test customizations.
 	// This is not recommended to be used in production environment.
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,order=5

--- a/apis/dscinitialization/v1/zz_generated.deepcopy.go
+++ b/apis/dscinitialization/v1/zz_generated.deepcopy.go
@@ -22,6 +22,7 @@ limitations under the License.
 package v1
 
 import (
+	infrastructurev1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/infrastructure/v1"
 	conditionsv1 "github.com/openshift/custom-resource-status/conditions/v1"
 	corev1 "k8s.io/api/core/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
@@ -90,8 +91,16 @@ func (in *DSCInitializationList) DeepCopyObject() runtime.Object {
 func (in *DSCInitializationSpec) DeepCopyInto(out *DSCInitializationSpec) {
 	*out = *in
 	out.Monitoring = in.Monitoring
-	in.ServiceMesh.DeepCopyInto(&out.ServiceMesh)
-	out.TrustedCABundle = in.TrustedCABundle
+	if in.ServiceMesh != nil {
+		in, out := &in.ServiceMesh, &out.ServiceMesh
+		*out = new(infrastructurev1.ServiceMeshSpec)
+		(*in).DeepCopyInto(*out)
+	}
+	if in.TrustedCABundle != nil {
+		in, out := &in.TrustedCABundle, &out.TrustedCABundle
+		*out = new(TrustedCABundleSpec)
+		**out = **in
+	}
 	if in.DevFlags != nil {
 		in, out := &in.DevFlags, &out.DevFlags
 		*out = new(DevFlags)

--- a/bundle/manifests/datasciencecluster.opendatahub.io_datascienceclusters.yaml
+++ b/bundle/manifests/datasciencecluster.opendatahub.io_datascienceclusters.yaml
@@ -186,8 +186,8 @@ spec:
                           This can be set to 'Serverless' or 'RawDeployment'. The
                           value specified in this field will be used to set the default
                           deployment mode in the 'inferenceservice-config' configmap
-                          for Kserve If no default deployment mode is specified, Kserve
-                          will use Serverless mode
+                          for Kserve. This field is optional. If no default deployment
+                          mode is specified, Kserve will use Serverless mode.
                         enum:
                         - Serverless
                         - RawDeployment

--- a/components/kserve/kserve.go
+++ b/components/kserve/kserve.go
@@ -50,8 +50,8 @@ type Kserve struct {
 	// Mesh (Istio) is prerequisite, since it is used as networking layer.
 	Serving infrav1.ServingSpec `json:"serving,omitempty"`
 	// Configures the default deployment mode for Kserve. This can be set to 'Serverless' or 'RawDeployment'.
-	// The value specified in this field will be used to set the default deployment mode in the 'inferenceservice-config' configmap for Kserve
-	// If no default deployment mode is specified, Kserve will use Serverless mode
+	// The value specified in this field will be used to set the default deployment mode in the 'inferenceservice-config' configmap for Kserve.
+	// This field is optional. If no default deployment mode is specified, Kserve will use Serverless mode.
 	// +kubebuilder:validation:Enum=Serverless;RawDeployment
 	DefaultDeploymentMode DefaultDeploymentMode `json:"defaultDeploymentMode,omitempty"`
 }
@@ -123,12 +123,12 @@ func (k *Kserve) ReconcileComponent(ctx context.Context, cli client.Client,
 				return err
 			}
 		}
+	}
 
-		// Update image parameters only when we do not have customized manifests set
-		if (dscispec.DevFlags == nil || dscispec.DevFlags.ManifestsUri == "") && (k.DevFlags == nil || len(k.DevFlags.Manifests) == 0) {
-			if err := deploy.ApplyParams(Path, imageParamMap, false); err != nil {
-				return fmt.Errorf("failed to update image from %s : %w", Path, err)
-			}
+	// Update image parameters only when we do not have customized manifests set
+	if (dscispec.DevFlags == nil || dscispec.DevFlags.ManifestsUri == "") && (k.DevFlags == nil || len(k.DevFlags.Manifests) == 0) {
+		if err := deploy.ApplyParams(Path, imageParamMap, false); err != nil {
+			return fmt.Errorf("failed to update image from %s : %w", Path, err)
 		}
 	}
 

--- a/components/kserve/servicemesh_setup.go
+++ b/components/kserve/servicemesh_setup.go
@@ -14,12 +14,14 @@ import (
 )
 
 func (k *Kserve) configureServiceMesh(c client.Client, dscispec *dsciv1.DSCInitializationSpec) error {
-	if dscispec.ServiceMesh.ManagementState == operatorv1.Managed && k.GetManagementState() == operatorv1.Managed {
-		serviceMeshInitializer := feature.ComponentFeaturesHandler(k.GetComponentName(), dscispec, k.defineServiceMeshFeatures(c))
-		return serviceMeshInitializer.Apply()
-	}
-	if dscispec.ServiceMesh.ManagementState == operatorv1.Unmanaged && k.GetManagementState() == operatorv1.Managed {
-		return nil
+	if dscispec.ServiceMesh != nil {
+		if dscispec.ServiceMesh.ManagementState == operatorv1.Managed && k.GetManagementState() == operatorv1.Managed {
+			serviceMeshInitializer := feature.ComponentFeaturesHandler(k.GetComponentName(), dscispec, k.defineServiceMeshFeatures(c))
+			return serviceMeshInitializer.Apply()
+		}
+		if dscispec.ServiceMesh.ManagementState == operatorv1.Unmanaged && k.GetManagementState() == operatorv1.Managed {
+			return nil
+		}
 	}
 
 	return k.removeServiceMeshConfigurations(c, dscispec)

--- a/config/crd/bases/datasciencecluster.opendatahub.io_datascienceclusters.yaml
+++ b/config/crd/bases/datasciencecluster.opendatahub.io_datascienceclusters.yaml
@@ -187,8 +187,8 @@ spec:
                           This can be set to 'Serverless' or 'RawDeployment'. The
                           value specified in this field will be used to set the default
                           deployment mode in the 'inferenceservice-config' configmap
-                          for Kserve If no default deployment mode is specified, Kserve
-                          will use Serverless mode
+                          for Kserve. This field is optional. If no default deployment
+                          mode is specified, Kserve will use Serverless mode.
                         enum:
                         - Serverless
                         - RawDeployment

--- a/controllers/certconfigmapgenerator/certconfigmapgenerator_controller.go
+++ b/controllers/certconfigmapgenerator/certconfigmapgenerator_controller.go
@@ -69,7 +69,7 @@ func (r *CertConfigmapGeneratorReconciler) Reconcile(ctx context.Context, req ct
 		dsciInstance = &dsciInstances.Items[0]
 	}
 
-	if dsciInstance.Spec.TrustedCABundle.ManagementState != operatorv1.Managed {
+	if skipApplyTrustCAConfig(dsciInstance.Spec.TrustedCABundle) {
 		return ctrl.Result{}, nil
 	}
 
@@ -146,4 +146,8 @@ var ConfigMapChangedPredicate = predicate.Funcs{
 	DeleteFunc: func(deleteEvent event.DeleteEvent) bool {
 		return true
 	},
+}
+
+func skipApplyTrustCAConfig(dsciConfigTrustCA *dsci.TrustedCABundleSpec) bool {
+	return dsciConfigTrustCA == nil || dsciConfigTrustCA.ManagementState != operatorv1.Managed
 }

--- a/controllers/dscinitialization/dscinitialization_test.go
+++ b/controllers/dscinitialization/dscinitialization_test.go
@@ -342,7 +342,7 @@ func createDSCI(enableMonitoring operatorv1.ManagementState, enableTrustedCABund
 				Namespace:       monitoringNS,
 				ManagementState: enableMonitoring,
 			},
-			TrustedCABundle: dsci.TrustedCABundleSpec{
+			TrustedCABundle: &dsci.TrustedCABundleSpec{
 				ManagementState: enableTrustedCABundle,
 			},
 		},

--- a/controllers/dscinitialization/servicemesh_setup.go
+++ b/controllers/dscinitialization/servicemesh_setup.go
@@ -20,7 +20,7 @@ func (r *DSCInitializationReconciler) configureServiceMesh(instance *dsciv1.DSCI
 	if instance.Spec.ServiceMesh != nil {
 		serviceMeshManagementState = instance.Spec.ServiceMesh.ManagementState
 	} else {
-		r.Log.Info("ServiceMesh is not configed in DSCI, same as default to 'Removed'")
+		r.Log.Info("ServiceMesh is not configured in DSCI, same as default to 'Removed'")
 	}
 
 	switch serviceMeshManagementState {

--- a/controllers/dscinitialization/servicemesh_setup.go
+++ b/controllers/dscinitialization/servicemesh_setup.go
@@ -16,7 +16,14 @@ import (
 )
 
 func (r *DSCInitializationReconciler) configureServiceMesh(instance *dsciv1.DSCInitialization) error {
-	switch instance.Spec.ServiceMesh.ManagementState {
+	serviceMeshManagementState := operatorv1.Removed
+	if instance.Spec.ServiceMesh != nil {
+		serviceMeshManagementState = instance.Spec.ServiceMesh.ManagementState
+	} else {
+		r.Log.Info("ServiceMesh is not configed in DSCI, same as default to 'Removed'")
+	}
+
+	switch serviceMeshManagementState {
 	case operatorv1.Managed:
 
 		capabilities := []*feature.HandlerWithReporter[*dsciv1.DSCInitialization]{
@@ -46,12 +53,14 @@ func (r *DSCInitializationReconciler) configureServiceMesh(instance *dsciv1.DSCI
 			return err
 		}
 	}
-
 	return nil
 }
 
 func (r *DSCInitializationReconciler) removeServiceMesh(instance *dsciv1.DSCInitialization) error {
 	// on condition of Managed, do not handle Removed when set to Removed it trigger DSCI reconcile to clean up
+	if instance.Spec.ServiceMesh == nil {
+		return nil
+	}
 	if instance.Spec.ServiceMesh.ManagementState == operatorv1.Managed {
 		capabilities := []*feature.HandlerWithReporter[*dsciv1.DSCInitialization]{
 			r.serviceMeshCapability(instance, serviceMeshCondition(status.RemovedReason, "Service Mesh removed")),
@@ -74,7 +83,6 @@ func (r *DSCInitializationReconciler) removeServiceMesh(instance *dsciv1.DSCInit
 			}
 		}
 	}
-
 	return nil
 }
 

--- a/controllers/webhook/webhook_suite_test.go
+++ b/controllers/webhook/webhook_suite_test.go
@@ -184,7 +184,7 @@ func newDSCI(appName string) *dsci.DSCInitialization {
 				Namespace:       monitoringNS,
 				ManagementState: operatorv1.Managed,
 			},
-			TrustedCABundle: dsci.TrustedCABundleSpec{
+			TrustedCABundle: &dsci.TrustedCABundleSpec{
 				ManagementState: operatorv1.Managed,
 			},
 		},

--- a/docs/api-overview.md
+++ b/docs/api-overview.md
@@ -182,7 +182,7 @@ _Appears in:_
 | --- | --- | --- | --- |
 | `Component` _[Component](#component)_ |  |  |  |
 | `serving` _[ServingSpec](#servingspec)_ | Serving configures the KNative-Serving stack used for model serving. A Service<br />Mesh (Istio) is prerequisite, since it is used as networking layer. |  |  |
-| `defaultDeploymentMode` _[DefaultDeploymentMode](#defaultdeploymentmode)_ | Configures the default deployment mode for Kserve. This can be set to 'Serverless' or 'RawDeployment'.<br />The value specified in this field will be used to set the default deployment mode in the 'inferenceservice-config' configmap for Kserve<br />If no default deployment mode is specified, Kserve will use Serverless mode |  | Enum: [Serverless RawDeployment] <br />Pattern: `^(Serverless|RawDeployment)$` <br /> |
+| `defaultDeploymentMode` _[DefaultDeploymentMode](#defaultdeploymentmode)_ | Configures the default deployment mode for Kserve. This can be set to 'Serverless' or 'RawDeployment'.<br />The value specified in this field will be used to set the default deployment mode in the 'inferenceservice-config' configmap for Kserve.<br />This field is optional. If no default deployment mode is specified, Kserve will use Serverless mode. |  | Enum: [Serverless RawDeployment] <br />Pattern: `^(Serverless|RawDeployment)$` <br /> |
 
 
 

--- a/pkg/feature/builder.go
+++ b/pkg/feature/builder.go
@@ -43,7 +43,7 @@ type usingFeaturesHandler struct {
 func (u *usingFeaturesHandler) For(featuresHandler *FeaturesHandler) *featureBuilder {
 	createSpec := func(f *Feature) error {
 		f.Spec = &Spec{
-			ServiceMeshSpec:  &featuresHandler.DSCInitializationSpec.ServiceMesh,
+			ServiceMeshSpec:  featuresHandler.DSCInitializationSpec.ServiceMesh,
 			Serving:          &infrav1.ServingSpec{},
 			Source:           &featuresHandler.source,
 			AppNamespace:     featuresHandler.DSCInitializationSpec.ApplicationsNamespace,

--- a/pkg/upgrade/upgrade.go
+++ b/pkg/upgrade/upgrade.go
@@ -127,7 +127,7 @@ func CreateDefaultDSCI(ctx context.Context, cli client.Client, _ cluster.Platfor
 			ManagementState: operatorv1.Managed,
 			Namespace:       monNamespace,
 		},
-		ServiceMesh: infrav1.ServiceMeshSpec{
+		ServiceMesh: &infrav1.ServiceMeshSpec{
 			ManagementState: "Managed",
 			ControlPlane: infrav1.ControlPlaneSpec{
 				Name:              "data-science-smcp",
@@ -135,7 +135,7 @@ func CreateDefaultDSCI(ctx context.Context, cli client.Client, _ cluster.Platfor
 				MetricsCollection: "Istio",
 			},
 		},
-		TrustedCABundle: dsci.TrustedCABundleSpec{
+		TrustedCABundle: &dsci.TrustedCABundleSpec{
 			ManagementState: "Managed",
 		},
 	}

--- a/tests/e2e/dsc_creation_test.go
+++ b/tests/e2e/dsc_creation_test.go
@@ -318,7 +318,7 @@ func (tc *testContext) testApplicationCreation(component components.ComponentInt
 
 func (tc *testContext) validateDSCI() error {
 	// expected
-	expServiceMeshSpec := infrav1.ServiceMeshSpec{
+	expServiceMeshSpec := &infrav1.ServiceMeshSpec{
 		ManagementState: operatorv1.Managed,
 		ControlPlane: infrav1.ControlPlaneSpec{
 			Name:              "data-science-smcp",

--- a/tests/e2e/helper_test.go
+++ b/tests/e2e/helper_test.go
@@ -82,11 +82,16 @@ func setupDSCICR(name string) *dsci.DSCInitialization {
 				ManagementState: "Managed",
 				Namespace:       "opendatahub",
 			},
-			TrustedCABundle: dsci.TrustedCABundleSpec{
+			TrustedCABundle: &dsci.TrustedCABundleSpec{
 				ManagementState: "Managed",
 				CustomCABundle:  "",
 			},
-			ServiceMesh: infrav1.ServiceMeshSpec{
+			ServiceMesh: &infrav1.ServiceMeshSpec{
+				ControlPlane: infrav1.ControlPlaneSpec{
+					MetricsCollection: "Istio",
+					Name:              "data-science-smcp",
+					Namespace:         "istio-system",
+				},
 				ManagementState: "Managed",
 			},
 		},

--- a/tests/integration/features/fixtures/cluster_test_fixtures.go
+++ b/tests/integration/features/fixtures/cluster_test_fixtures.go
@@ -13,6 +13,7 @@ import (
 
 	dsciv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/dscinitialization/v1"
 	featurev1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/features/v1"
+	infrav1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/infrastructure/v1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/feature"
 )
 
@@ -102,6 +103,14 @@ func NewDSCInitialization(ns string) *dsciv1.DSCInitialization {
 		},
 		Spec: dsciv1.DSCInitializationSpec{
 			ApplicationsNamespace: ns,
+			ServiceMesh: &infrav1.ServiceMeshSpec{
+				ManagementState: "Managed",
+				ControlPlane: infrav1.ControlPlaneSpec{
+					Name:              "data-science-smcp",
+					Namespace:         "istio-system",
+					MetricsCollection: "Istio",
+				},
+			},
 		},
 	}
 }

--- a/tests/integration/features/servicemesh_feature_test.go
+++ b/tests/integration/features/servicemesh_feature_test.go
@@ -175,7 +175,7 @@ var _ = Describe("Service Mesh setup", func() {
 					objectCleaner = envtestutil.CreateCleaner(envTestClient, envTest.Config, fixtures.Timeout, fixtures.Interval)
 					dsci = fixtures.NewDSCInitialization(namespace)
 
-					serviceMeshSpec = &dsci.Spec.ServiceMesh
+					serviceMeshSpec = dsci.Spec.ServiceMesh
 
 					serviceMeshSpec.ControlPlane.Name = name
 					serviceMeshSpec.ControlPlane.Namespace = namespace


### PR DESCRIPTION
- change trustCABundle to pointer, so if not set it is the same as set to Removed
- change serviceMesh to pointer too,  so if not set it is the same as set to Removed
- also include a fix in e2e test which set to use the wrong component name
ref : https://issues.redhat.com/browse/RHOAIENG-6295 

<!--- Provide a general summary of your changes in the Title above -->
When user install operator from OperatorHub UI it is not a problem, the default fields are added there by CSV
When user manually create DSCI via CLI, they might not know if any new fields have been added into release.
e.g  a mini config of DSCI will cause operator crash
```
apiVersion: dscinitialization.opendatahub.io/v1
kind: DSCInitialization
metadata:
  name: default-dsci
spec:
  applicationsNamespace: opendatahub
  monitoring:
    managementState: Managed
    namespace: opendatahub
```

## Description
<!--- Describe your changes in detail -->


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
NEW:
live-build quay.io/wenzhou/opendatahub-operator-catalog:v2.10.0-6
- install opreator
- manually create DSCI CR with out `trustedCABundle`:
```
spec:
  applicationsNamespace: opendatahub
  monitoring:
    managementState: Managed
    namespace: opendatahub
  serviceMesh:
    controlPlane:
      metricsCollection: Istio
      name: data-science-smcp
      namespace: istio-system
    managementState: Managed
```
- no odh-trusted-ca-bundle created into new namespace
- old namespace which had odh-trusted-ca-bundle (created by previous runs) got removed
- no error in operator pod


OLD:
live-build: 'quay.io/wenzhou/opendatahub-operator-catalog:v2.9.0-885'
## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
