### PR TITLE
manifests: add grpconly label to apply global EnvoyFilter

### DIFF
--- a/components/kserve/servicemesh_setup.go
+++ b/components/kserve/servicemesh_setup.go
@@ -44,6 +44,18 @@ func (k *Kserve) defineServiceMeshFeatures() feature.FeaturesProvider {
 			return kserveExtAuthzErr
 		}
 
+		temporaryFixesErr := feature.CreateFeature("kserve-temporary-fixes").
+			For(handler).
+			Manifests(
+				path.Join(feature.KServeDir, "grpc-envoyfilter-temp-fix.tmpl"),
+			).
+			WithData(servicemesh.ClusterDetails).
+			Load()
+
+		if temporaryFixesErr != nil {
+			return temporaryFixesErr
+		}
+
 		return nil
 	}
 }

--- a/pkg/feature/templates/servicemesh/kserve/grpc-envoyfilter-temp-fix.tmpl
+++ b/pkg/feature/templates/servicemesh/kserve/grpc-envoyfilter-temp-fix.tmpl
@@ -1,0 +1,37 @@
+# Temporary workaround for https://issues.redhat.com/browse/RHOAIENG-165
+apiVersion: networking.istio.io/v1alpha3
+kind: EnvoyFilter
+metadata:
+  name: grpc-only
+  namespace: {{ .ControlPlane.Namespace }}
+  labels:
+    app.opendatahub.io/kserve: "true"
+    app.kubernetes.io/part-of: kserve
+    opendatahub.io/related-to: RHOAIENG-165
+spec:
+  priority: 20
+  workloadSelector:
+    labels:
+      protocol: "grpconly"
+  configPatches:
+    - applyTo: HTTP_FILTER
+      match:
+        context: SIDECAR_INBOUND
+        listener:
+          filterChain:
+            filter:
+              name: envoy.filters.network.http_connection_manager
+      patch:
+        operation: INSERT_BEFORE
+        value:
+          name: envoy.filters.http.lua
+          typed_config:
+            "@type": type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua
+            inlineCode: |
+              function envoy_on_request(request_handle)
+                local header_value = request_handle:headers():get("Content-Type")
+                local pattern = "^application/grpc"
+                if header_value:find(pattern) == nil then
+                  request_handle:respond({[":status"] = "400"}, "Invalid request, this endpoint only serves grpc.")
+                end
+              end


### PR DESCRIPTION
By adding this envoy filter, users can add a `protocol: grpconly` label to the manifests in order to prevent non-grpc traffic to reach grpc servers.

This workaround prevents certain grpc servers from stopping responding under certain conditions.

For more context, see https://issues.redhat.com/browse/RHOAIENG-165