### PR TITLE
fix(authz): Fix broken external auth configuration

### DIFF
--- a/pkg/feature/templates/servicemesh/authorino/mesh-authz-ext-provider.patch.tmpl
+++ b/pkg/feature/templates/servicemesh/authorino/mesh-authz-ext-provider.patch.tmpl
@@ -9,5 +9,5 @@ spec:
       extensionProviders:
       - name: {{ .AppNamespace }}-auth-provider
         envoyExtAuthzGrpc:
-          service: {{ .AuthProviderName }}-authorization.{{ .Auth.Namespace }}.svc.cluster.local
+          service: {{ .AuthProviderName }}-authorino-authorization.{{ .Auth.Namespace }}.svc.cluster.local
           port: 50051

--- a/pkg/feature/templates/servicemesh/kserve/z-fix-jira-4192/kserve-predictor-authorizationpolicy.patch.tmpl
+++ b/pkg/feature/templates/servicemesh/kserve/z-fix-jira-4192/kserve-predictor-authorizationpolicy.patch.tmpl
@@ -1,0 +1,8 @@
+apiVersion: security.istio.io/v1beta1
+kind: AuthorizationPolicy
+metadata:
+  name: kserve-predictor
+  namespace: {{ .ControlPlane.Namespace }}
+spec:
+  provider:
+    name: {{ .AppNamespace }}-auth-provider


### PR DESCRIPTION
## Description
There are two misconfigurations being fixed:
* In the SMCP, the service hostname of Authorino was coded with `-authorization` suffix, but the right suffix is `-authorino-authorization`.
* In the `kserve-predictor` AuthorizationPolicy, the hardcoded `opendatahub-odh-auth-provider` provider name was used, but it should have been the template `{{ .AppNamespace }}-auth-provider`.

In `pkg/feature/feature.go` the patch manifests (i.e. the ones containing `.patch` in the filename) are always applied. Thus, the first bullet is solved by fixing the patch file that adds the `extensionProvider` to the SMCP.

For the second bullet, the faulty AuthorizationPolicy is created with a regular manifest template which is only applied if the resource does not exist. Thus, a patch manifest is added to properly fix the faulty policy (including operator upgrades).

Fixes https://issues.redhat.com/browse/RHOAIENG-4192

## How Has This Been Tested?
Both doing a clean install, and simulating an upgrade.

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
