### PR TITLE
chore: remove the need of passing rest config

### DIFF
--- a/components/README.md
+++ b/components/README.md
@@ -37,7 +37,6 @@ can be found [here](https://github.com/opendatahub-io/opendatahub-operator/tree/
       GetManagementState() operatorv1.ManagementState
       SetImageParamsMap(imageMap map[string]string) map[string]string
       UpdatePrometheusConfig(cli client.Client, enable bool, component string) error
-      WaitForDeploymentAvailable(ctx context.Context, r *rest.Config, c string, n string, i int, t int) error
     }
     ```
 ### Add reconcile and Events

--- a/components/codeflare/codeflare.go
+++ b/components/codeflare/codeflare.go
@@ -9,7 +9,6 @@ import (
 
 	operatorv1 "github.com/openshift/api/operator/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	dsciv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/dscinitialization/v1"
@@ -57,7 +56,7 @@ func (c *CodeFlare) GetComponentName() string {
 	return ComponentName
 }
 
-func (c *CodeFlare) ReconcileComponent(ctx context.Context, cli client.Client, resConf *rest.Config, owner metav1.Object, dscispec *dsciv1.DSCInitializationSpec, _ bool) error {
+func (c *CodeFlare) ReconcileComponent(ctx context.Context, cli client.Client, owner metav1.Object, dscispec *dsciv1.DSCInitializationSpec, _ bool) error {
 	var imageParamMap = map[string]string{
 		"codeflare-operator-controller-image": "RELATED_IMAGE_ODH_CODEFLARE_OPERATOR_IMAGE", // no need mcad, embedded in cfo
 		"namespace":                           dscispec.ApplicationsNamespace,
@@ -109,7 +108,7 @@ func (c *CodeFlare) ReconcileComponent(ctx context.Context, cli client.Client, r
 	if platform == deploy.ManagedRhods {
 		if enabled {
 			// first check if the service is up, so prometheus won't fire alerts when it is just startup
-			if err := monitoring.WaitForDeploymentAvailable(ctx, resConf, ComponentName, dscispec.ApplicationsNamespace, 20, 2); err != nil {
+			if err := monitoring.WaitForDeploymentAvailable(ctx, cli, ComponentName, dscispec.ApplicationsNamespace, 20, 2); err != nil {
 				return fmt.Errorf("deployment for %s is not ready to server: %w", ComponentName, err)
 			}
 			fmt.Printf("deployment for %s is done, updating monitoring rules\n", ComponentName)

--- a/components/component.go
+++ b/components/component.go
@@ -10,7 +10,6 @@ import (
 	operatorv1 "github.com/openshift/api/operator/v1"
 	"gopkg.in/yaml.v2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	dsciv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/dscinitialization/v1"
@@ -80,7 +79,7 @@ type ManifestsConfig struct {
 }
 
 type ComponentInterface interface {
-	ReconcileComponent(ctx context.Context, cli client.Client, resConf *rest.Config, owner metav1.Object, DSCISpec *dsciv1.DSCInitializationSpec, currentComponentStatus bool) error
+	ReconcileComponent(ctx context.Context, cli client.Client, owner metav1.Object, DSCISpec *dsciv1.DSCInitializationSpec, currentComponentStatus bool) error
 	Cleanup(cli client.Client, DSCISpec *dsciv1.DSCInitializationSpec) error
 	GetComponentName() string
 	GetManagementState() operatorv1.ManagementState

--- a/components/dashboard/dashboard.go
+++ b/components/dashboard/dashboard.go
@@ -13,7 +13,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	dsciv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/dscinitialization/v1"
@@ -83,7 +82,6 @@ func (d *Dashboard) GetComponentName() string {
 //nolint:gocyclo
 func (d *Dashboard) ReconcileComponent(ctx context.Context,
 	cli client.Client,
-	resConf *rest.Config,
 	owner metav1.Object,
 	dscispec *dsciv1.DSCInitializationSpec,
 	currentComponentExist bool,
@@ -169,7 +167,7 @@ func (d *Dashboard) ReconcileComponent(ctx context.Context,
 		if platform == deploy.ManagedRhods {
 			if enabled {
 				// first check if the service is up, so prometheus won't fire alerts when it is just startup
-				if err := monitoring.WaitForDeploymentAvailable(ctx, resConf, ComponentNameSupported, dscispec.ApplicationsNamespace, 20, 3); err != nil {
+				if err := monitoring.WaitForDeploymentAvailable(ctx, cli, ComponentNameSupported, dscispec.ApplicationsNamespace, 20, 3); err != nil {
 					return fmt.Errorf("deployment for %s is not ready to server: %w", ComponentName, err)
 				}
 				fmt.Printf("deployment for %s is done, updating monitoring rules\n", ComponentNameSupported)

--- a/components/datasciencepipelines/datasciencepipelines.go
+++ b/components/datasciencepipelines/datasciencepipelines.go
@@ -9,7 +9,6 @@ import (
 
 	operatorv1 "github.com/openshift/api/operator/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	dsciv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/dscinitialization/v1"
@@ -56,7 +55,6 @@ func (d *DataSciencePipelines) GetComponentName() string {
 
 func (d *DataSciencePipelines) ReconcileComponent(ctx context.Context,
 	cli client.Client,
-	resConf *rest.Config,
 	owner metav1.Object,
 	dscispec *dsciv1.DSCInitializationSpec,
 	_ bool,
@@ -101,7 +99,7 @@ func (d *DataSciencePipelines) ReconcileComponent(ctx context.Context,
 		if enabled {
 			// first check if the service is up, so prometheus won't fire alerts when it is just startup
 			// only 1 replica should be very quick
-			if err := monitoring.WaitForDeploymentAvailable(ctx, resConf, ComponentName, dscispec.ApplicationsNamespace, 10, 1); err != nil {
+			if err := monitoring.WaitForDeploymentAvailable(ctx, cli, ComponentName, dscispec.ApplicationsNamespace, 10, 1); err != nil {
 				return fmt.Errorf("deployment for %s is not ready to server: %w", ComponentName, err)
 			}
 			fmt.Printf("deployment for %s is done, updating monitoring rules\n", ComponentName)

--- a/components/kserve/kserve.go
+++ b/components/kserve/kserve.go
@@ -9,7 +9,6 @@ import (
 
 	operatorv1 "github.com/openshift/api/operator/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	dsciv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/dscinitialization/v1"
@@ -94,7 +93,7 @@ func (k *Kserve) GetComponentName() string {
 	return ComponentName
 }
 
-func (k *Kserve) ReconcileComponent(ctx context.Context, cli client.Client, resConf *rest.Config, owner metav1.Object, dscispec *dsciv1.DSCInitializationSpec, _ bool) error {
+func (k *Kserve) ReconcileComponent(ctx context.Context, cli client.Client, owner metav1.Object, dscispec *dsciv1.DSCInitializationSpec, _ bool) error {
 	// paramMap for Kserve to use.
 	var imageParamMap = map[string]string{}
 
@@ -168,7 +167,7 @@ func (k *Kserve) ReconcileComponent(ctx context.Context, cli client.Client, resC
 	if platform == deploy.ManagedRhods {
 		if enabled {
 			// first check if the service is up, so prometheus won't fire alerts when it is just startup
-			if err := monitoring.WaitForDeploymentAvailable(ctx, resConf, ComponentName, dscispec.ApplicationsNamespace, 20, 2); err != nil {
+			if err := monitoring.WaitForDeploymentAvailable(ctx, cli, ComponentName, dscispec.ApplicationsNamespace, 20, 2); err != nil {
 				return fmt.Errorf("deployment for %s is not ready to server: %w", ComponentName, err)
 			}
 			fmt.Printf("deployment for %s is done, updating monitoing rules", ComponentName)

--- a/components/kueue/kueue.go
+++ b/components/kueue/kueue.go
@@ -7,7 +7,6 @@ import (
 
 	operatorv1 "github.com/openshift/api/operator/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	dsciv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/dscinitialization/v1"
@@ -52,7 +51,7 @@ func (r *Kueue) GetComponentName() string {
 	return ComponentName
 }
 
-func (r *Kueue) ReconcileComponent(ctx context.Context, cli client.Client, resConf *rest.Config, owner metav1.Object, dscispec *dsciv1.DSCInitializationSpec, _ bool) error {
+func (r *Kueue) ReconcileComponent(ctx context.Context, cli client.Client, owner metav1.Object, dscispec *dsciv1.DSCInitializationSpec, _ bool) error {
 	var imageParamMap = map[string]string{
 		"odh-kueue-controller-image": "RELATED_IMAGE_ODH_KUEUE_CONTROLLER_IMAGE", // new kueue image
 	}
@@ -85,7 +84,7 @@ func (r *Kueue) ReconcileComponent(ctx context.Context, cli client.Client, resCo
 	if platform == deploy.ManagedRhods {
 		if enabled {
 			// first check if the service is up, so prometheus won't fire alerts when it is just startup
-			if err := monitoring.WaitForDeploymentAvailable(ctx, resConf, ComponentName, dscispec.ApplicationsNamespace, 20, 2); err != nil {
+			if err := monitoring.WaitForDeploymentAvailable(ctx, cli, ComponentName, dscispec.ApplicationsNamespace, 20, 2); err != nil {
 				return fmt.Errorf("deployment for %s is not ready to server: %w", ComponentName, err)
 			}
 			fmt.Printf("deployment for %s is done, updating monitoring rules\n", ComponentName)

--- a/components/modelmeshserving/modelmeshserving.go
+++ b/components/modelmeshserving/modelmeshserving.go
@@ -9,7 +9,6 @@ import (
 
 	operatorv1 "github.com/openshift/api/operator/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	dsciv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/dscinitialization/v1"
@@ -73,7 +72,6 @@ func (m *ModelMeshServing) GetComponentName() string {
 
 func (m *ModelMeshServing) ReconcileComponent(ctx context.Context,
 	cli client.Client,
-	resConf *rest.Config,
 	owner metav1.Object,
 	dscispec *dsciv1.DSCInitializationSpec,
 	_ bool,
@@ -151,7 +149,7 @@ func (m *ModelMeshServing) ReconcileComponent(ctx context.Context,
 	if platform == deploy.ManagedRhods {
 		if enabled {
 			// first check if service is up, so prometheus won't fire alerts when it is just startup
-			if err := monitoring.WaitForDeploymentAvailable(ctx, resConf, ComponentName, dscispec.ApplicationsNamespace, 20, 2); err != nil {
+			if err := monitoring.WaitForDeploymentAvailable(ctx, cli, ComponentName, dscispec.ApplicationsNamespace, 20, 2); err != nil {
 				return fmt.Errorf("deployment for %s is not ready to server: %w", ComponentName, err)
 			}
 			fmt.Printf("deployment for %s is done, updating monitoring rules\n", ComponentName)

--- a/components/modelregistry/modelregistry.go
+++ b/components/modelregistry/modelregistry.go
@@ -7,7 +7,6 @@ import (
 
 	operatorv1 "github.com/openshift/api/operator/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	dsciv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/dscinitialization/v1"
@@ -51,7 +50,7 @@ func (m *ModelRegistry) GetComponentName() string {
 	return ComponentName
 }
 
-func (m *ModelRegistry) ReconcileComponent(_ context.Context, cli client.Client, _ *rest.Config,
+func (m *ModelRegistry) ReconcileComponent(_ context.Context, cli client.Client,
 	owner metav1.Object, dscispec *dsciv1.DSCInitializationSpec, _ bool) error {
 	var imageParamMap = map[string]string{
 		"IMAGES_MODELREGISTRY_OPERATOR": "RELATED_IMAGE_ODH_MODEL_REGISTRY_OPERATOR_IMAGE",

--- a/components/ray/ray.go
+++ b/components/ray/ray.go
@@ -9,7 +9,6 @@ import (
 
 	operatorv1 "github.com/openshift/api/operator/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	dsciv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/dscinitialization/v1"
@@ -54,7 +53,7 @@ func (r *Ray) GetComponentName() string {
 	return ComponentName
 }
 
-func (r *Ray) ReconcileComponent(ctx context.Context, cli client.Client, resConf *rest.Config, owner metav1.Object, dscispec *dsciv1.DSCInitializationSpec, _ bool) error {
+func (r *Ray) ReconcileComponent(ctx context.Context, cli client.Client, owner metav1.Object, dscispec *dsciv1.DSCInitializationSpec, _ bool) error {
 	var imageParamMap = map[string]string{
 		"odh-kuberay-operator-controller-image": "RELATED_IMAGE_ODH_KUBERAY_OPERATOR_CONTROLLER_IMAGE",
 		"namespace":                             dscispec.ApplicationsNamespace,
@@ -88,7 +87,7 @@ func (r *Ray) ReconcileComponent(ctx context.Context, cli client.Client, resConf
 	if platform == deploy.ManagedRhods {
 		if enabled {
 			// first check if the service is up, so prometheus won't fire alerts when it is just startup
-			if err := monitoring.WaitForDeploymentAvailable(ctx, resConf, ComponentName, dscispec.ApplicationsNamespace, 20, 2); err != nil {
+			if err := monitoring.WaitForDeploymentAvailable(ctx, cli, ComponentName, dscispec.ApplicationsNamespace, 20, 2); err != nil {
 				return fmt.Errorf("deployment for %s is not ready to server: %w", ComponentName, err)
 			}
 			fmt.Printf("deployment for %s is done, updating monitoring rules\n", ComponentName)

--- a/components/trustyai/trustyai.go
+++ b/components/trustyai/trustyai.go
@@ -8,7 +8,6 @@ import (
 
 	operatorv1 "github.com/openshift/api/operator/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	dsciv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/dscinitialization/v1"
@@ -52,7 +51,7 @@ func (t *TrustyAI) GetComponentName() string {
 	return ComponentName
 }
 
-func (t *TrustyAI) ReconcileComponent(ctx context.Context, cli client.Client, resConf *rest.Config, owner metav1.Object, dscispec *dsciv1.DSCInitializationSpec, _ bool) error {
+func (t *TrustyAI) ReconcileComponent(ctx context.Context, cli client.Client, owner metav1.Object, dscispec *dsciv1.DSCInitializationSpec, _ bool) error {
 	var imageParamMap = map[string]string{
 		"trustyaiServiceImage":  "RELATED_IMAGE_ODH_TRUSTYAI_SERVICE_IMAGE",
 		"trustyaiOperatorImage": "RELATED_IMAGE_ODH_TRUSTYAI_SERVICE_OPERATOR_IMAGE",
@@ -86,7 +85,7 @@ func (t *TrustyAI) ReconcileComponent(ctx context.Context, cli client.Client, re
 	// CloudService Monitoring handling
 	if platform == deploy.ManagedRhods {
 		if enabled {
-			if err := monitoring.WaitForDeploymentAvailable(ctx, resConf, ComponentName, dscispec.ApplicationsNamespace, 10, 1); err != nil {
+			if err := monitoring.WaitForDeploymentAvailable(ctx, cli, ComponentName, dscispec.ApplicationsNamespace, 10, 1); err != nil {
 				return fmt.Errorf("deployment for %s is not ready to server: %w", ComponentName, err)
 			}
 			fmt.Printf("deployment for %s is done, updating monitoring rules\n", ComponentName)

--- a/components/workbenches/workbenches.go
+++ b/components/workbenches/workbenches.go
@@ -9,7 +9,6 @@ import (
 
 	operatorv1 "github.com/openshift/api/operator/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	dsci "github.com/opendatahub-io/opendatahub-operator/v2/apis/dscinitialization/v1"
@@ -95,7 +94,7 @@ func (w *Workbenches) GetComponentName() string {
 	return ComponentName
 }
 
-func (w *Workbenches) ReconcileComponent(ctx context.Context, cli client.Client, resConf *rest.Config, owner metav1.Object, dscispec *dsci.DSCInitializationSpec, _ bool) error {
+func (w *Workbenches) ReconcileComponent(ctx context.Context, cli client.Client, owner metav1.Object, dscispec *dsci.DSCInitializationSpec, _ bool) error {
 	var imageParamMap = map[string]string{
 		"odh-notebook-controller-image":    "RELATED_IMAGE_ODH_NOTEBOOK_CONTROLLER_IMAGE",
 		"odh-kf-notebook-controller-image": "RELATED_IMAGE_ODH_KF_NOTEBOOK_CONTROLLER_IMAGE",
@@ -177,7 +176,7 @@ func (w *Workbenches) ReconcileComponent(ctx context.Context, cli client.Client,
 		if enabled {
 			// first check if the service is up, so prometheus wont fire alerts when it is just startup
 			// only 1 replica set timeout to 1min
-			if err := monitoring.WaitForDeploymentAvailable(ctx, resConf, ComponentName, dscispec.ApplicationsNamespace, 10, 1); err != nil {
+			if err := monitoring.WaitForDeploymentAvailable(ctx, cli, ComponentName, dscispec.ApplicationsNamespace, 10, 1); err != nil {
 				return fmt.Errorf("deployments for %s are not ready to server: %w", ComponentName, err)
 			}
 			fmt.Printf("deployments for %s are done, updating monitoring rules\n", ComponentName)

--- a/controllers/datasciencecluster/datasciencecluster_controller.go
+++ b/controllers/datasciencecluster/datasciencecluster_controller.go
@@ -38,7 +38,6 @@ import (
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/retry"
 	apiregistrationv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
@@ -62,9 +61,8 @@ import (
 // DataScienceClusterReconciler reconciles a DataScienceCluster object.
 type DataScienceClusterReconciler struct { //nolint:golint,revive
 	client.Client
-	Scheme     *runtime.Scheme
-	Log        logr.Logger
-	RestConfig *rest.Config
+	Scheme *runtime.Scheme
+	Log    logr.Logger
 	// Recorder to generate events
 	Recorder           record.EventRecorder
 	DataScienceCluster *DataScienceClusterConfig
@@ -95,8 +93,8 @@ func (r *DataScienceClusterReconciler) Reconcile(ctx context.Context, req ctrl.R
 		// Owned objects are automatically garbage collected.
 		// For additional cleanup logic use operatorUninstall function.
 		// Return and don't requeue
-		if upgrade.HasDeleteConfigMap(r.Client) {
-			if uninstallErr := upgrade.OperatorUninstall(r.Client, r.RestConfig); uninstallErr != nil {
+		if upgrade.HasDeleteConfigMap(ctx, r.Client) {
+			if uninstallErr := upgrade.OperatorUninstall(ctx, r.Client); uninstallErr != nil {
 				return ctrl.Result{}, fmt.Errorf("error while operator uninstall: %w", uninstallErr)
 			}
 		}
@@ -114,7 +112,7 @@ func (r *DataScienceClusterReconciler) Reconcile(ctx context.Context, req ctrl.R
 	// If DSC CR exist and deletion CM exist
 	// delete DSC CR and let reconcile requeue
 	// sometimes with finalzier DSC CR wont get deleted, force to remove finalizer here
-	if upgrade.HasDeleteConfigMap(r.Client) {
+	if upgrade.HasDeleteConfigMap(ctx, r.Client) {
 		if controllerutil.ContainsFinalizer(instance, finalizerName) {
 			if controllerutil.RemoveFinalizer(instance, finalizerName) {
 				if err := r.Update(ctx, instance); err != nil {
@@ -189,7 +187,7 @@ func (r *DataScienceClusterReconciler) Reconcile(ctx context.Context, req ctrl.R
 				return ctrl.Result{}, err
 			}
 		}
-		if upgrade.HasDeleteConfigMap(r.Client) {
+		if upgrade.HasDeleteConfigMap(ctx, r.Client) {
 			// if delete configmap exists, requeue the request to handle operator uninstall
 			return reconcile.Result{Requeue: true}, nil
 		}
@@ -278,7 +276,7 @@ func (r *DataScienceClusterReconciler) reconcileSubComponent(ctx context.Context
 	}
 
 	// Reconcile component
-	err = component.ReconcileComponent(ctx, r.Client, r.RestConfig, instance, r.DataScienceCluster.DSCISpec, instance.Status.InstalledComponents[componentName])
+	err = component.ReconcileComponent(ctx, r.Client, instance, r.DataScienceCluster.DSCISpec, instance.Status.InstalledComponents[componentName])
 
 	if err != nil {
 		// reconciliation failed: log errors, raise event and update status accordingly

--- a/controllers/dscinitialization/dscinitialization_controller.go
+++ b/controllers/dscinitialization/dscinitialization_controller.go
@@ -387,7 +387,7 @@ func (r *DSCInitializationReconciler) watchDSCResource(_ client.Object) []reconc
 		// do not handle if cannot get list
 		return nil
 	}
-	if len(instanceList.Items) == 0 && !upgrade.HasDeleteConfigMap(r.Client) {
+	if len(instanceList.Items) == 0 && !upgrade.HasDeleteConfigMap(context.TODO(), r.Client) {
 		r.Log.Info("Found no DSC instance in cluster but not in uninstalltion process, reset monitoring stack config")
 
 		return []reconcile.Request{{NamespacedName: types.NamespacedName{Name: "backup"}}}

--- a/main.go
+++ b/main.go
@@ -154,10 +154,9 @@ func main() { //nolint:funlen
 	}
 
 	if err = (&datascienceclustercontrollers.DataScienceClusterReconciler{
-		Client:     mgr.GetClient(),
-		Scheme:     mgr.GetScheme(),
-		RestConfig: mgr.GetConfig(),
-		Log:        ctrl.Log.WithName("controllers").WithName("DataScienceCluster"),
+		Client: mgr.GetClient(),
+		Scheme: mgr.GetScheme(),
+		Log:    ctrl.Log.WithName("controllers").WithName("DataScienceCluster"),
 		DataScienceCluster: &datascienceclustercontrollers.DataScienceClusterConfig{
 			DSCISpec: &dsci.DSCInitializationSpec{
 				ApplicationsNamespace: dscApplicationsNamespace,

--- a/pkg/monitoring/monitoring.go
+++ b/pkg/monitoring/monitoring.go
@@ -5,41 +5,30 @@ import (
 	"fmt"
 	"time"
 
-	errors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// WaitForDeploymentAvailable to check if component deployment from 'namepsace' is ready within 'timeout' before apply prometheus rules for the component.
-func WaitForDeploymentAvailable(_ context.Context, restConfig *rest.Config, componentName string, namespace string, interval int, timeout int) error {
+// WaitForDeploymentAvailable to check if component deployment from 'namespace' is ready within 'timeout' before apply prometheus rules for the component.
+func WaitForDeploymentAvailable(ctx context.Context, c client.Client, componentName string, namespace string, interval int, timeout int) error {
 	resourceInterval := time.Duration(interval) * time.Second
 	resourceTimeout := time.Duration(timeout) * time.Minute
-	return wait.PollUntilContextTimeout(context.TODO(), resourceInterval, resourceTimeout, true, func(ctx context.Context) (bool, error) {
-		clientset, err := kubernetes.NewForConfig(restConfig)
+
+	return wait.PollUntilContextTimeout(ctx, resourceInterval, resourceTimeout, true, func(ctx context.Context) (bool, error) {
+		componentDeploymentList := &v1.DeploymentList{}
+		err := c.List(ctx, componentDeploymentList, client.InNamespace(namespace), client.HasLabels{"app.opendatahub.io/" + componentName})
 		if err != nil {
-			return false, fmt.Errorf("error getting client %w", err)
+			return false, fmt.Errorf("error fetching list of deployments: %w", err)
 		}
-		componentDeploymentList, err := clientset.AppsV1().Deployments(namespace).List(context.TODO(), metav1.ListOptions{
-			LabelSelector: "app.opendatahub.io/" + componentName,
-		})
-		if err != nil {
-			if errors.IsNotFound(err) {
+
+		fmt.Printf("waiting for %d deployment to be ready for %s\n", len(componentDeploymentList.Items), componentName)
+		for _, deployment := range componentDeploymentList.Items {
+			if deployment.Status.ReadyReplicas != deployment.Status.Replicas {
 				return false, nil
 			}
 		}
-		isReady := false
-		fmt.Printf("waiting for %d deployment to be ready for %s\n", len(componentDeploymentList.Items), componentName)
-		if len(componentDeploymentList.Items) != 0 {
-			for _, deployment := range componentDeploymentList.Items {
-				if deployment.Status.ReadyReplicas == deployment.Status.Replicas {
-					isReady = true
-				} else {
-					isReady = false
-				}
-			}
-		}
-		return isReady, nil
+
+		return true, nil
 	})
 }

--- a/pkg/upgrade/upgrade.go
+++ b/pkg/upgrade/upgrade.go
@@ -12,7 +12,6 @@ import (
 	operatorv1 "github.com/openshift/api/operator/v1"
 	routev1 "github.com/openshift/api/route/v1"
 	ofapi "github.com/operator-framework/api/pkg/operators/v1alpha1"
-	olmclientset "github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/clientset/versioned/typed/operators/v1alpha1"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -21,7 +20,6 @@ import (
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kfdefv1 "github.com/opendatahub-io/opendatahub-operator/apis/kfdef.apps.kubeflow.org/v1"
@@ -51,17 +49,17 @@ const (
 
 // OperatorUninstall deletes all the externally generated resources. This includes monitoring resources and applications
 // installed by KfDef.
-func OperatorUninstall(cli client.Client, cfg *rest.Config) error {
+func OperatorUninstall(ctx context.Context, cli client.Client) error {
 	platform, err := deploy.GetPlatform(cli)
 	if err != nil {
 		return err
 	}
 
-	if err := RemoveKfDefInstances(cli, platform); err != nil {
+	if err := RemoveKfDefInstances(ctx, cli); err != nil {
 		return err
 	}
 
-	if err := removeDSCInitialization(cli); err != nil {
+	if err := removeDSCInitialization(ctx, cli); err != nil {
 		return err
 	}
 
@@ -70,7 +68,7 @@ func OperatorUninstall(cli client.Client, cfg *rest.Config) error {
 	nsOptions := []client.ListOption{
 		client.MatchingLabels{cluster.ODHGeneratedNamespaceLabel: "true"},
 	}
-	if err := cli.List(context.TODO(), generatedNamespaces, nsOptions...); err != nil {
+	if err := cli.List(ctx, generatedNamespaces, nsOptions...); err != nil {
 		return fmt.Errorf("error getting generated namespaces : %w", err)
 	}
 
@@ -84,7 +82,7 @@ func OperatorUninstall(cli client.Client, cfg *rest.Config) error {
 	for _, namespace := range generatedNamespaces.Items {
 		namespace := namespace
 		if namespace.Status.Phase == corev1.NamespaceActive {
-			if err := cli.Delete(context.TODO(), &namespace, []client.DeleteOption{}...); err != nil {
+			if err := cli.Delete(ctx, &namespace); err != nil {
 				return fmt.Errorf("error deleting namespace %v: %w", namespace.Name, err)
 			}
 			fmt.Printf("Namespace %s deleted as a part of uninstallation.\n", namespace.Name)
@@ -113,23 +111,23 @@ func OperatorUninstall(cli client.Client, cfg *rest.Config) error {
 	}
 
 	fmt.Printf("Removing the operator CSV in turn remove operator deployment\n")
-	err = removeCSV(cli, cfg)
+	err = removeCSV(ctx, cli)
 
 	fmt.Printf("All resources deleted as part of uninstall.")
 	return err
 }
 
-func removeDSCInitialization(cli client.Client) error {
+func removeDSCInitialization(ctx context.Context, cli client.Client) error {
 	instanceList := &dsci.DSCInitializationList{}
 
-	if err := cli.List(context.TODO(), instanceList); err != nil {
+	if err := cli.List(ctx, instanceList); err != nil {
 		return err
 	}
 
 	var multiErr *multierror.Error
 	for _, dsciInstance := range instanceList.Items {
 		dsciInstance := dsciInstance
-		if err := cli.Delete(context.TODO(), &dsciInstance); !apierrs.IsNotFound(err) {
+		if err := cli.Delete(ctx, &dsciInstance); !apierrs.IsNotFound(err) {
 			multiErr = multierror.Append(multiErr, err)
 		}
 	}
@@ -139,7 +137,7 @@ func removeDSCInitialization(cli client.Client) error {
 
 // HasDeleteConfigMap returns true if delete configMap is added to the operator namespace by managed-tenants repo.
 // It returns false in all other cases.
-func HasDeleteConfigMap(c client.Client) bool {
+func HasDeleteConfigMap(ctx context.Context, c client.Client) bool {
 	// Get watchNamespace
 	operatorNamespace, err := GetOperatorNamespace()
 	if err != nil {
@@ -153,7 +151,7 @@ func HasDeleteConfigMap(c client.Client) bool {
 		client.MatchingLabels{DeleteConfigMapLabel: "true"},
 	}
 
-	if err := c.List(context.TODO(), deleteConfigMapList, cmOptions...); err != nil {
+	if err := c.List(ctx, deleteConfigMapList, cmOptions...); err != nil {
 		return false
 	}
 
@@ -162,7 +160,7 @@ func HasDeleteConfigMap(c client.Client) bool {
 
 // createDefaultDSC creates a default instance of DSC.
 // Note: When the platform is not Managed, and a DSC instance already exists, the function doesn't re-create/update the resource.
-func CreateDefaultDSC(cli client.Client, _ deploy.Platform) error {
+func CreateDefaultDSC(ctx context.Context, cli client.Client) error {
 	// Set the default DSC name depending on the platform
 	releaseDataScienceCluster := &dsc.DataScienceCluster{
 		TypeMeta: metav1.TypeMeta{
@@ -207,7 +205,7 @@ func CreateDefaultDSC(cli client.Client, _ deploy.Platform) error {
 			},
 		},
 	}
-	err := cli.Create(context.TODO(), releaseDataScienceCluster)
+	err := cli.Create(ctx, releaseDataScienceCluster)
 	switch {
 	case err == nil:
 		fmt.Printf("created DataScienceCluster resource\n")
@@ -294,10 +292,10 @@ func UpdateFromLegacyVersion(cli client.Client, platform deploy.Platform, appNS 
 			return err
 		}
 		fmt.Println("creating default DSC CR")
-		if err := CreateDefaultDSC(cli, platform); err != nil {
+		if err := CreateDefaultDSC(context.TODO(), cli); err != nil {
 			return err
 		}
-		return RemoveKfDefInstances(cli, platform)
+		return RemoveKfDefInstances(context.TODO(), cli)
 	}
 
 	if platform == deploy.SelfManagedRhods {
@@ -332,7 +330,7 @@ func UpdateFromLegacyVersion(cli client.Client, platform deploy.Platform, appNS 
 				return err
 			}
 			// create default DSC
-			if err = CreateDefaultDSC(cli, platform); err != nil {
+			if err = CreateDefaultDSC(context.TODO(), cli); err != nil {
 				return err
 			}
 		}
@@ -395,11 +393,11 @@ func GetOperatorNamespace() (string, error) {
 	return "", err
 }
 
-func RemoveKfDefInstances(cli client.Client, _ deploy.Platform) error {
+func RemoveKfDefInstances(ctx context.Context, cli client.Client) error {
 	// Check if kfdef are deployed
 	kfdefCrd := &apiextv1.CustomResourceDefinition{}
 
-	err := cli.Get(context.TODO(), client.ObjectKey{Name: "kfdefs.kfdef.apps.kubeflow.org"}, kfdefCrd)
+	err := cli.Get(ctx, client.ObjectKey{Name: "kfdefs.kfdef.apps.kubeflow.org"}, kfdefCrd)
 	if err != nil {
 		if apierrs.IsNotFound(err) {
 			// If no Crd found, return, since its a new Installation
@@ -408,7 +406,7 @@ func RemoveKfDefInstances(cli client.Client, _ deploy.Platform) error {
 		return fmt.Errorf("error retrieving kfdef CRD : %w", err)
 	}
 	expectedKfDefList := &kfdefv1.KfDefList{}
-	err = cli.List(context.TODO(), expectedKfDefList)
+	err = cli.List(ctx, expectedKfDefList)
 	if err != nil {
 		return fmt.Errorf("error getting list of kfdefs: %w", err)
 	}
@@ -418,11 +416,11 @@ func RemoveKfDefInstances(cli client.Client, _ deploy.Platform) error {
 		// Remove finalizer
 		updatedKfDef := &kfdef
 		updatedKfDef.Finalizers = []string{}
-		err = cli.Update(context.TODO(), updatedKfDef)
+		err = cli.Update(ctx, updatedKfDef)
 		if err != nil {
 			return fmt.Errorf("error removing finalizers from kfdef %v : %w", kfdef.Name, err)
 		}
-		err = cli.Delete(context.TODO(), updatedKfDef)
+		err = cli.Delete(ctx, updatedKfDef)
 		if err != nil {
 			return fmt.Errorf("error deleting kfdef %v : %w", kfdef.Name, err)
 		}
@@ -430,21 +428,21 @@ func RemoveKfDefInstances(cli client.Client, _ deploy.Platform) error {
 	return nil
 }
 
-func removeCSV(c client.Client, r *rest.Config) error {
+func removeCSV(ctx context.Context, c client.Client) error {
 	// Get watchNamespace
 	operatorNamespace, err := GetOperatorNamespace()
 	if err != nil {
 		return err
 	}
 
-	operatorCsv, err := getClusterServiceVersion(r, operatorNamespace)
+	operatorCsv, err := getClusterServiceVersion(ctx, c, operatorNamespace)
 	if err != nil {
 		return err
 	}
 
 	if operatorCsv != nil {
 		fmt.Printf("Deleting CSV %s\n", operatorCsv.Name)
-		err = c.Delete(context.TODO(), operatorCsv, []client.DeleteOption{}...)
+		err = c.Delete(ctx, operatorCsv)
 		if err != nil {
 			if apierrs.IsNotFound(err) {
 				return nil
@@ -460,23 +458,16 @@ func removeCSV(c client.Client, r *rest.Config) error {
 }
 
 // getClusterServiceVersion retries the clusterserviceversions available in the operator namespace.
-func getClusterServiceVersion(cfg *rest.Config, watchNameSpace string) (*ofapi.ClusterServiceVersion, error) {
-	operatorClient, err := olmclientset.NewForConfig(cfg)
-	if err != nil {
-		return nil, fmt.Errorf("error getting operator client %w", err)
-	}
-	csvs, err := operatorClient.ClusterServiceVersions(watchNameSpace).List(context.TODO(), metav1.ListOptions{})
-	if err != nil {
-		return nil, err
+func getClusterServiceVersion(ctx context.Context, c client.Client, watchNameSpace string) (*ofapi.ClusterServiceVersion, error) {
+	clusterServiceVersionList := &ofapi.ClusterServiceVersionList{}
+	if err := c.List(ctx, clusterServiceVersionList, client.InNamespace(watchNameSpace)); err != nil {
+		return nil, fmt.Errorf("failed listign cluster service versions: %w", err)
 	}
 
-	// get CSV with CRD DataScienceCluster
-	if len(csvs.Items) != 0 {
-		for _, csv := range csvs.Items {
-			for _, operatorCR := range csv.Spec.CustomResourceDefinitions.Owned {
-				if operatorCR.Kind == "DataScienceCluster" {
-					return &csv, nil
-				}
+	for _, csv := range clusterServiceVersionList.Items {
+		for _, operatorCR := range csv.Spec.CustomResourceDefinitions.Owned {
+			if operatorCR.Kind == "DataScienceCluster" {
+				return &csv, nil
 			}
 		}
 	}


### PR DESCRIPTION
As we are already using `client.Client` interface we do not have to instantiate other typed clients to e.g. list resources using their own
funcs. Generic `client.Client` is sufficient for these needs.

Additionally this change adds ctx propogation for these calls.
