### PR TITLE
chore: removes SetImageParamsMap from ComponentInterface

### DIFF
--- a/components/README.md
+++ b/components/README.md
@@ -35,9 +35,8 @@ can be found [here](https://github.com/opendatahub-io/opendatahub-operator/tree/
       Cleanup(cli client.Client, DSCISpec *dsci.DSCInitializationSpec) error
       GetComponentName() string
       GetManagementState() operatorv1.ManagementState
-      SetImageParamsMap(imageMap map[string]string) map[string]string
+      OverrideManifests(platform string) error
       UpdatePrometheusConfig(cli client.Client, enable bool, component string) error
-      WaitForDeploymentAvailable(ctx context.Context, r *rest.Config, c string, n string, i int, t int) error
     }
     ```
 ### Add reconcile and Events

--- a/components/codeflare/codeflare.go
+++ b/components/codeflare/codeflare.go
@@ -91,7 +91,7 @@ func (c *CodeFlare) ReconcileComponent(ctx context.Context, cli client.Client, r
 
 		// Update image parameters only when we do not have customized manifests set
 		if (dscispec.DevFlags == nil || dscispec.DevFlags.ManifestsUri == "") && (c.DevFlags == nil || len(c.DevFlags.Manifests) == 0) {
-			if err := deploy.ApplyParams(ParamsPath, c.SetImageParamsMap(imageParamMap), true); err != nil {
+			if err := deploy.ApplyParams(ParamsPath, imageParamMap, true); err != nil {
 				return err
 			}
 		}

--- a/components/component.go
+++ b/components/component.go
@@ -46,10 +46,6 @@ func (c *Component) Cleanup(_ client.Client, _ *dsciv1.DSCInitializationSpec) er
 	return nil
 }
 
-func (c *Component) SetImageParamsMap(imageMap map[string]string) map[string]string {
-	return imageMap
-}
-
 // DevFlags defines list of fields that can be used by developers to test customizations. This is not recommended
 // to be used in production environment.
 // +kubebuilder:object:generate=true
@@ -84,7 +80,6 @@ type ComponentInterface interface {
 	Cleanup(cli client.Client, DSCISpec *dsciv1.DSCInitializationSpec) error
 	GetComponentName() string
 	GetManagementState() operatorv1.ManagementState
-	SetImageParamsMap(imageMap map[string]string) map[string]string
 	OverrideManifests(platform string) error
 	UpdatePrometheusConfig(cli client.Client, enable bool, component string) error
 }

--- a/components/dashboard/dashboard.go
+++ b/components/dashboard/dashboard.go
@@ -134,7 +134,7 @@ func (d *Dashboard) ReconcileComponent(ctx context.Context,
 
 		// 3. Update image parameters
 		if (dscispec.DevFlags == nil || dscispec.DevFlags.ManifestsUri == "") && (d.DevFlags == nil || len(d.DevFlags.Manifests) == 0) {
-			if err := deploy.ApplyParams(PathSupported, d.SetImageParamsMap(imageParamMap), false); err != nil {
+			if err := deploy.ApplyParams(PathSupported, imageParamMap, false); err != nil {
 				return err
 			}
 		}

--- a/components/datasciencepipelines/datasciencepipelines.go
+++ b/components/datasciencepipelines/datasciencepipelines.go
@@ -87,7 +87,7 @@ func (d *DataSciencePipelines) ReconcileComponent(ctx context.Context,
 		// skip check if the dependent operator has beeninstalled, this is done in dashboard
 		// Update image parameters only when we do not have customized manifests set
 		if (dscispec.DevFlags == nil || dscispec.DevFlags.ManifestsUri == "") && (d.DevFlags == nil || len(d.DevFlags.Manifests) == 0) {
-			if err := deploy.ApplyParams(Path, d.SetImageParamsMap(imageParamMap), false); err != nil {
+			if err := deploy.ApplyParams(Path, imageParamMap, false); err != nil {
 				return err
 			}
 		}

--- a/components/kserve/kserve.go
+++ b/components/kserve/kserve.go
@@ -128,7 +128,7 @@ func (k *Kserve) ReconcileComponent(ctx context.Context, cli client.Client, resC
 
 		// Update image parameters only when we do not have customized manifests set
 		if (dscispec.DevFlags == nil || dscispec.DevFlags.ManifestsUri == "") && (k.DevFlags == nil || len(k.DevFlags.Manifests) == 0) {
-			if err := deploy.ApplyParams(Path, k.SetImageParamsMap(imageParamMap), false); err != nil {
+			if err := deploy.ApplyParams(Path, imageParamMap, false); err != nil {
 				return err
 			}
 		}
@@ -151,7 +151,7 @@ func (k *Kserve) ReconcileComponent(ctx context.Context, cli client.Client, resC
 		}
 		// Update image parameters for odh-model-controller
 		if (dscispec.DevFlags == nil || dscispec.DevFlags.ManifestsUri == "") && (k.DevFlags == nil || len(k.DevFlags.Manifests) == 0) {
-			if err := deploy.ApplyParams(DependentPath, k.SetImageParamsMap(dependentParamMap), false); err != nil {
+			if err := deploy.ApplyParams(DependentPath, dependentParamMap, false); err != nil {
 				return err
 			}
 		}

--- a/components/kueue/kueue.go
+++ b/components/kueue/kueue.go
@@ -72,7 +72,7 @@ func (r *Kueue) ReconcileComponent(ctx context.Context, cli client.Client, resCo
 			}
 		}
 		if (dscispec.DevFlags == nil || dscispec.DevFlags.ManifestsUri == "") && (r.DevFlags == nil || len(r.DevFlags.Manifests) == 0) {
-			if err := deploy.ApplyParams(Path, r.SetImageParamsMap(imageParamMap), true); err != nil {
+			if err := deploy.ApplyParams(Path, imageParamMap, true); err != nil {
 				return err
 			}
 		}

--- a/components/modelmeshserving/modelmeshserving.go
+++ b/components/modelmeshserving/modelmeshserving.go
@@ -116,7 +116,7 @@ func (m *ModelMeshServing) ReconcileComponent(ctx context.Context,
 		}
 		// Update image parameters
 		if (dscispec.DevFlags == nil || dscispec.DevFlags.ManifestsUri == "") && (m.DevFlags == nil || len(m.DevFlags.Manifests) == 0) {
-			if err := deploy.ApplyParams(Path, m.SetImageParamsMap(imageParamMap), false); err != nil {
+			if err := deploy.ApplyParams(Path, imageParamMap, false); err != nil {
 				return err
 			}
 		}
@@ -135,7 +135,7 @@ func (m *ModelMeshServing) ReconcileComponent(ctx context.Context,
 		}
 		// Update image parameters for odh-model-controller
 		if dscispec.DevFlags == nil || dscispec.DevFlags.ManifestsUri == "" {
-			if err := deploy.ApplyParams(DependentPath, m.SetImageParamsMap(dependentImageParamMap), false); err != nil {
+			if err := deploy.ApplyParams(DependentPath, dependentImageParamMap, false); err != nil {
 				return err
 			}
 		}

--- a/components/modelregistry/modelregistry.go
+++ b/components/modelregistry/modelregistry.go
@@ -75,7 +75,7 @@ func (m *ModelRegistry) ReconcileComponent(_ context.Context, cli client.Client,
 
 		// Update image parameters only when we do not have customized manifests set
 		if (dscispec.DevFlags == nil || dscispec.DevFlags.ManifestsUri == "") && (m.DevFlags == nil || len(m.DevFlags.Manifests) == 0) {
-			if err := deploy.ApplyParams(Path, m.SetImageParamsMap(imageParamMap), false); err != nil {
+			if err := deploy.ApplyParams(Path, imageParamMap, false); err != nil {
 				return err
 			}
 		}

--- a/components/ray/ray.go
+++ b/components/ray/ray.go
@@ -75,7 +75,7 @@ func (r *Ray) ReconcileComponent(ctx context.Context, cli client.Client, resConf
 			}
 		}
 		if (dscispec.DevFlags == nil || dscispec.DevFlags.ManifestsUri == "") && (r.DevFlags == nil || len(r.DevFlags.Manifests) == 0) {
-			if err := deploy.ApplyParams(RayPath, r.SetImageParamsMap(imageParamMap), true); err != nil {
+			if err := deploy.ApplyParams(RayPath, imageParamMap, true); err != nil {
 				return err
 			}
 		}

--- a/components/trustyai/trustyai.go
+++ b/components/trustyai/trustyai.go
@@ -73,7 +73,7 @@ func (t *TrustyAI) ReconcileComponent(ctx context.Context, cli client.Client, re
 			}
 		}
 		if (dscispec.DevFlags == nil || dscispec.DevFlags.ManifestsUri == "") && (t.DevFlags == nil || len(t.DevFlags.Manifests) == 0) {
-			if err := deploy.ApplyParams(Path, t.SetImageParamsMap(imageParamMap), false); err != nil {
+			if err := deploy.ApplyParams(Path, imageParamMap, false); err != nil {
 				return err
 			}
 		}

--- a/components/workbenches/workbenches.go
+++ b/components/workbenches/workbenches.go
@@ -142,11 +142,11 @@ func (w *Workbenches) ReconcileComponent(ctx context.Context, cli client.Client,
 		if (dscispec.DevFlags == nil || dscispec.DevFlags.ManifestsUri == "") && (w.DevFlags == nil || len(w.DevFlags.Manifests) == 0) {
 			if platform == deploy.ManagedRhods || platform == deploy.SelfManagedRhods {
 				// for kf-notebook-controller image
-				if err := deploy.ApplyParams(notebookControllerPath, w.SetImageParamsMap(imageParamMap), false); err != nil {
+				if err := deploy.ApplyParams(notebookControllerPath, imageParamMap, false); err != nil {
 					return err
 				}
 				// for odh-notebook-controller image
-				if err := deploy.ApplyParams(kfnotebookControllerPath, w.SetImageParamsMap(imageParamMap), false); err != nil {
+				if err := deploy.ApplyParams(kfnotebookControllerPath, imageParamMap, false); err != nil {
 					return err
 				}
 			}


### PR DESCRIPTION
This is a simple pass-return method and does not seem to be used by any of the components with some customizations in place.

So I propose to remove it entirely from the codebase.
