### PR TITLE
chore: simpliflies handling of k8s not-found errors

### DIFF
--- a/config/crd/bases/datasciencecluster.opendatahub.io_datascienceclusters.yaml
+++ b/config/crd/bases/datasciencecluster.opendatahub.io_datascienceclusters.yaml
@@ -184,7 +184,8 @@ spec:
                           This can be set to 'Serverless' or 'RawDeployment'. The
                           value specified in this field will be used to set the default
                           deployment mode in the 'inferenceservice-config' configmap
-                          for Kserve
+                          for Kserve If no default deployment mode is specified, Kserve
+                          will use Serverless mode
                         enum:
                         - Serverless
                         - RawDeployment

--- a/controllers/dscinitialization/utils.go
+++ b/controllers/dscinitialization/utils.go
@@ -376,10 +376,7 @@ func (r *DSCInitializationReconciler) waitForManagedSecret(ctx context.Context, 
 		}, managedSecret)
 
 		if err != nil {
-			if apierrs.IsNotFound(err) {
-				return false, nil
-			}
-			return false, err
+			return false, client.IgnoreNotFound(err)
 		}
 		return true, nil
 	})

--- a/controllers/secretgenerator/secretgenerator_controller.go
+++ b/controllers/secretgenerator/secretgenerator_controller.go
@@ -189,11 +189,7 @@ func (r *SecretGeneratorReconciler) getRoute(ctx context.Context, name string, n
 			Namespace: namespace,
 		}, route)
 		if err != nil {
-			if apierrs.IsNotFound(err) {
-				return false, nil
-			}
-
-			return false, err
+			return false, client.IgnoreNotFound(err)
 		}
 		if route.Spec.Host == "" {
 			return false, nil
@@ -248,11 +244,7 @@ func (r *SecretGeneratorReconciler) deleteOAuthClient(ctx context.Context, secre
 		Name: secretName,
 	}, oauthClient)
 	if err != nil {
-		if apierrs.IsNotFound(err) {
-			return nil
-		}
-
-		return err
+		return client.IgnoreNotFound(err)
 	}
 
 	if err = r.Client.Delete(ctx, oauthClient); err != nil {

--- a/pkg/deploy/setup.go
+++ b/pkg/deploy/setup.go
@@ -6,7 +6,6 @@ import (
 
 	ofapi "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -53,11 +52,7 @@ func isManagedRHODS(cli client.Client) (Platform, error) {
 
 	err := cli.Get(context.TODO(), client.ObjectKey{Name: "catalogsources.operators.coreos.com"}, catalogSourceCRD)
 	if err != nil {
-		if apierrs.IsNotFound(err) {
-			return "", nil
-		}
-
-		return "", err
+		return "", client.IgnoreNotFound(err)
 	}
 	expectedCatlogSource := &ofapi.CatalogSourceList{}
 	err = cli.List(context.TODO(), expectedCatlogSource)

--- a/pkg/trustedcabundle/trustedcabundle.go
+++ b/pkg/trustedcabundle/trustedcabundle.go
@@ -123,10 +123,7 @@ func DeleteOdhTrustedCABundleConfigMap(ctx context.Context, cli client.Client, n
 		Namespace: namespace,
 	}, foundConfigMap)
 	if err != nil {
-		if apierrs.IsNotFound(err) {
-			return nil
-		}
-		return err
+		return client.IgnoreNotFound(err)
 	}
 	return cli.Delete(ctx, foundConfigMap)
 }
@@ -153,10 +150,7 @@ func IsTrustedCABundleUpdated(ctx context.Context, cli client.Client, dscInit *d
 	}, foundConfigMap)
 
 	if err != nil {
-		if apierrs.IsNotFound(err) {
-			return false, nil
-		}
-		return false, err
+		return false, client.IgnoreNotFound(err)
 	}
 
 	return foundConfigMap.Data[CADataFieldName] != dscInit.Spec.TrustedCABundle.CustomCABundle, nil


### PR DESCRIPTION
Instead of 

```
if apierrs.IsNotFound(err) {
	return nil
}
return err
```

we can use

```
return client.IgnoreNotFound(err)
```