### PR TITLE
chore(feature): passes component name instead of whole struct

### DIFF
--- a/components/kserve/kserve_config_handler.go
+++ b/components/kserve/kserve_config_handler.go
@@ -138,7 +138,7 @@ func (k *Kserve) configureServerless(cli client.Client, instance *dsciv1.DSCInit
 			return dependOpsErrors
 		}
 
-		serverlessFeatures := feature.ComponentFeaturesHandler(k, instance, k.configureServerlessFeatures())
+		serverlessFeatures := feature.ComponentFeaturesHandler(k.GetComponentName(), instance, k.configureServerlessFeatures())
 
 		if err := serverlessFeatures.Apply(); err != nil {
 			return err
@@ -148,7 +148,7 @@ func (k *Kserve) configureServerless(cli client.Client, instance *dsciv1.DSCInit
 }
 
 func (k *Kserve) removeServerlessFeatures(instance *dsciv1.DSCInitializationSpec) error {
-	serverlessFeatures := feature.ComponentFeaturesHandler(k, instance, k.configureServerlessFeatures())
+	serverlessFeatures := feature.ComponentFeaturesHandler(k.GetComponentName(), instance, k.configureServerlessFeatures())
 
 	return serverlessFeatures.Delete()
 }

--- a/components/kserve/servicemesh_setup.go
+++ b/components/kserve/servicemesh_setup.go
@@ -12,7 +12,7 @@ import (
 
 func (k *Kserve) configureServiceMesh(dscispec *dsciv1.DSCInitializationSpec) error {
 	if dscispec.ServiceMesh.ManagementState == operatorv1.Managed && k.GetManagementState() == operatorv1.Managed {
-		serviceMeshInitializer := feature.ComponentFeaturesHandler(k, dscispec, k.defineServiceMeshFeatures())
+		serviceMeshInitializer := feature.ComponentFeaturesHandler(k.GetComponentName(), dscispec, k.defineServiceMeshFeatures())
 		return serviceMeshInitializer.Apply()
 	}
 	if dscispec.ServiceMesh.ManagementState == operatorv1.Unmanaged && k.GetManagementState() == operatorv1.Managed {
@@ -23,7 +23,7 @@ func (k *Kserve) configureServiceMesh(dscispec *dsciv1.DSCInitializationSpec) er
 }
 
 func (k *Kserve) removeServiceMeshConfigurations(dscispec *dsciv1.DSCInitializationSpec) error {
-	serviceMeshInitializer := feature.ComponentFeaturesHandler(k, dscispec, k.defineServiceMeshFeatures())
+	serviceMeshInitializer := feature.ComponentFeaturesHandler(k.GetComponentName(), dscispec, k.defineServiceMeshFeatures())
 	return serviceMeshInitializer.Delete()
 }
 

--- a/pkg/feature/handler.go
+++ b/pkg/feature/handler.go
@@ -7,7 +7,6 @@ import (
 
 	v1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/dscinitialization/v1"
 	featurev1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/features/v1"
-	"github.com/opendatahub-io/opendatahub-operator/v2/components"
 )
 
 // FeaturesHandler coordinates feature creations and removal from within controllers.
@@ -30,10 +29,10 @@ func ClusterFeaturesHandler(dsci *v1.DSCInitialization, def FeaturesProvider) *F
 	}
 }
 
-func ComponentFeaturesHandler(component components.ComponentInterface, spec *v1.DSCInitializationSpec, def FeaturesProvider) *FeaturesHandler {
+func ComponentFeaturesHandler(componentName string, spec *v1.DSCInitializationSpec, def FeaturesProvider) *FeaturesHandler {
 	return &FeaturesHandler{
 		DSCInitializationSpec: spec,
-		source:                featurev1.Source{Type: featurev1.ComponentType, Name: component.GetComponentName()},
+		source:                featurev1.Source{Type: featurev1.ComponentType, Name: componentName},
 		featuresProvider:      def,
 	}
 }

--- a/tests/integration/features/serverless_feature_test.go
+++ b/tests/integration/features/serverless_feature_test.go
@@ -90,7 +90,7 @@ var _ = Describe("Serverless feature", func() {
 
 			It("should fail on precondition check", func() {
 				// given
-				featuresHandler := feature.ComponentFeaturesHandler(kserveComponent, &dsci.Spec, func(handler *feature.FeaturesHandler) error {
+				featuresHandler := feature.ComponentFeaturesHandler(kserveComponent.GetComponentName(), &dsci.Spec, func(handler *feature.FeaturesHandler) error {
 					verificationFeatureErr := feature.CreateFeature("no-serverless-operator-check").
 						For(handler).
 						UsingConfig(envTest.Config).
@@ -134,7 +134,7 @@ var _ = Describe("Serverless feature", func() {
 
 			It("should succeed checking operator installation using precondition", func() {
 				// when
-				featuresHandler := feature.ComponentFeaturesHandler(kserveComponent, &dsci.Spec, func(handler *feature.FeaturesHandler) error {
+				featuresHandler := feature.ComponentFeaturesHandler(kserveComponent.GetComponentName(), &dsci.Spec, func(handler *feature.FeaturesHandler) error {
 					verificationFeatureErr := feature.CreateFeature("serverless-operator-check").
 						For(handler).
 						UsingConfig(envTest.Config).
@@ -152,7 +152,7 @@ var _ = Describe("Serverless feature", func() {
 
 			It("should succeed if serving is not installed for KNative serving precondition", func() {
 				// when
-				featuresHandler := feature.ComponentFeaturesHandler(kserveComponent, &dsci.Spec, func(handler *feature.FeaturesHandler) error {
+				featuresHandler := feature.ComponentFeaturesHandler(kserveComponent.GetComponentName(), &dsci.Spec, func(handler *feature.FeaturesHandler) error {
 					verificationFeatureErr := feature.CreateFeature("no-serving-installed-yet").
 						For(handler).
 						UsingConfig(envTest.Config).
@@ -181,7 +181,7 @@ var _ = Describe("Serverless feature", func() {
 				Expect(envTestClient.Create(context.TODO(), knativeServing)).To(Succeed())
 
 				// when
-				featuresHandler := feature.ComponentFeaturesHandler(kserveComponent, &dsci.Spec, func(handler *feature.FeaturesHandler) error {
+				featuresHandler := feature.ComponentFeaturesHandler(kserveComponent.GetComponentName(), &dsci.Spec, func(handler *feature.FeaturesHandler) error {
 					verificationFeatureErr := feature.CreateFeature("serving-already-installed").
 						For(handler).
 						UsingConfig(envTest.Config).
@@ -278,7 +278,7 @@ var _ = Describe("Serverless feature", func() {
 			kserveComponent.Serving.IngressGateway.Certificate.Type = infrav1.SelfSigned
 			kserveComponent.Serving.IngressGateway.Domain = testDomainFooCom
 
-			featuresHandler := feature.ComponentFeaturesHandler(kserveComponent, &dsci.Spec, func(handler *feature.FeaturesHandler) error {
+			featuresHandler := feature.ComponentFeaturesHandler(kserveComponent.GetComponentName(), &dsci.Spec, func(handler *feature.FeaturesHandler) error {
 				verificationFeatureErr := feature.CreateFeature("tls-secret-creation").
 					For(handler).
 					UsingConfig(envTest.Config).
@@ -317,7 +317,7 @@ var _ = Describe("Serverless feature", func() {
 			// given
 			kserveComponent.Serving.IngressGateway.Certificate.Type = infrav1.Provided
 			kserveComponent.Serving.IngressGateway.Domain = testDomainFooCom
-			featuresHandler := feature.ComponentFeaturesHandler(kserveComponent, &dsci.Spec, func(handler *feature.FeaturesHandler) error {
+			featuresHandler := feature.ComponentFeaturesHandler(kserveComponent.GetComponentName(), &dsci.Spec, func(handler *feature.FeaturesHandler) error {
 				verificationFeatureErr := feature.CreateFeature("tls-secret-creation").
 					For(handler).
 					UsingConfig(envTest.Config).


### PR DESCRIPTION
There is currently no need to pass the entire Component struct, so keeping API smaller makes sense.