### PR TITLE
feat: add additional auth_refs for global config

### DIFF
--- a/pkg/feature/servicemesh/resources.go
+++ b/pkg/feature/servicemesh/resources.go
@@ -25,7 +25,9 @@ func ConfigMaps(feature *feature.Feature) error {
 	}
 	if err := feature.CreateConfigMap("auth-refs",
 		map[string]string{
-			"AUTH_AUDIENCE": audiencesList,
+			"AUTH_AUDIENCE":   audiencesList,
+			"AUTH_PROVIDER":   feature.Spec.AppNamespace + "-auth-provider",
+			"AUTHORINO_LABEL": "security.opendatahub.io/authorization-group=default",
 		}); err != nil {
 		return errors.WithStack(err)
 	}


### PR DESCRIPTION
## Description

Add more global lookup configurations to the auth_refs CM.

`AUTH_PROVIDER` refers to the Provider name used in SMCP to configure ExtAuth. Used in e.g. AuthorizationPolicy objects. 

`AUTHORINO_LABEL` refers to the labelselector used by the Authorino service. Used in AuthConfig objects.


## How Has This Been Tested?

Manually

## Merge criteria:
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
