### PR TITLE
chore: use targetNamespace for authorino feature

### DIFF
--- a/controllers/dscinitialization/servicemesh_setup.go
+++ b/controllers/dscinitialization/servicemesh_setup.go
@@ -94,8 +94,12 @@ func configureServiceMeshFeatures() feature.FeaturesProvider {
 			return cfgMapErr
 		}
 
+		authNs := servicemesh.CreateAuthNamespace(serviceMeshSpec.Auth.Namespace,
+			handler.DSCInitializationSpec.ApplicationsNamespace)
+
 		extAuthzErr := feature.CreateFeature("mesh-control-plane-external-authz").
 			For(handler).
+			TargetNamespace(authNs).
 			Manifests(
 				path.Join(feature.AuthDir, "auth-smm.tmpl"),
 				path.Join(feature.AuthDir, "base"),
@@ -105,7 +109,7 @@ func configureServiceMeshFeatures() feature.FeaturesProvider {
 			PreConditions(
 				feature.EnsureOperatorIsInstalled("authorino-operator"),
 				servicemesh.EnsureServiceMeshInstalled,
-				servicemesh.EnsureAuthNamespaceExists,
+				feature.CreateNamespaceIfNotExists(authNs),
 			).
 			PostConditions(
 				feature.WaitForPodsToBeReady(serviceMeshSpec.ControlPlane.Namespace),

--- a/pkg/feature/servicemesh/conditions.go
+++ b/pkg/feature/servicemesh/conditions.go
@@ -20,15 +20,6 @@ const (
 	duration = 5 * time.Minute
 )
 
-func EnsureAuthNamespaceExists(f *feature.Feature) error {
-	if resolveNsErr := ResolveAuthNamespace(f); resolveNsErr != nil {
-		return resolveNsErr
-	}
-
-	_, err := cluster.CreateNamespace(f.Client, f.Spec.Auth.Namespace)
-	return err
-}
-
 func EnsureServiceMeshOperatorInstalled(f *feature.Feature) error {
 	if err := feature.EnsureOperatorIsInstalled("servicemeshoperator")(f); err != nil {
 		return fmt.Errorf("failed to find the pre-requisite Service Mesh Operator subscription, please ensure Service Mesh Operator is installed. %w", err)

--- a/pkg/feature/servicemesh/loaders.go
+++ b/pkg/feature/servicemesh/loaders.go
@@ -21,12 +21,12 @@ func ClusterDetails(f *feature.Feature) error {
 	return nil
 }
 
-func ResolveAuthNamespace(f *feature.Feature) error {
-	dsciAuthNamespace := strings.TrimSpace(f.Spec.Auth.Namespace)
+func CreateAuthNamespace(authNs, appNs string) string {
+	dsciAuthNamespace := strings.TrimSpace(authNs)
 
 	if len(dsciAuthNamespace) == 0 {
-		f.Spec.Auth.Namespace = f.Spec.AppNamespace + "-auth-provider"
+		return appNs + "-auth-provider"
 	}
 
-	return nil
+	return dsciAuthNamespace
 }

--- a/pkg/feature/templates/servicemesh/authorino/auth-smm.tmpl
+++ b/pkg/feature/templates/servicemesh/authorino/auth-smm.tmpl
@@ -2,7 +2,7 @@ apiVersion: maistra.io/v1
 kind: ServiceMeshMember
 metadata:
   name: default
-  namespace: {{ .Auth.Namespace }}
+  namespace: {{ .TargetNamespace }}
 spec:
   controlPlaneRef:
     namespace: {{ .ControlPlane.Namespace }}

--- a/pkg/feature/templates/servicemesh/authorino/base/operator-cluster-wide-no-tls.tmpl
+++ b/pkg/feature/templates/servicemesh/authorino/base/operator-cluster-wide-no-tls.tmpl
@@ -2,7 +2,7 @@ apiVersion: operator.authorino.kuadrant.io/v1beta1
 kind: Authorino
 metadata:
   name: {{ .AuthProviderName }}
-  namespace: {{ .Auth.Namespace }}
+  namespace: {{ .TargetNamespace }}
 spec:
   authConfigLabelSelectors: security.opendatahub.io/authorization-group=default
   clusterWide: true

--- a/pkg/feature/templates/servicemesh/authorino/deployment.injection.patch.tmpl
+++ b/pkg/feature/templates/servicemesh/authorino/deployment.injection.patch.tmpl
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .AuthProviderName }}
-  namespace: {{ .Auth.Namespace }}
+  namespace: {{ .TargetNamespace }}
 spec:
   template:
     metadata:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This PR uses TargetNamespace for the authorino feature, removing the need for the helper ResolveAuthNamespace() function. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested on CRC with image `quay.io/cgarriso/opendatahub-operator:dev-use-target-ns`, created DSCI with default auth namespace and saw that authorino pod was created in targetNS `opendatahub-auth-provider` as expected and then specified in DSCI with namespace `auth-provider` to ensure specifying still works. 

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
