### PR TITLE
chore: renames base manifest type

### DIFF
--- a/pkg/feature/feature.go
+++ b/pkg/feature/feature.go
@@ -152,7 +152,7 @@ func (f *Feature) createApplier(m Manifest) applier {
 				return patchResources(f.Client, objects)
 			}
 		}
-	case *baseManifest:
+	case *rawManifest:
 		if manifest.patch {
 			return func(objects []*unstructured.Unstructured) error {
 				return patchResources(f.Client, objects)

--- a/pkg/feature/manifest.go
+++ b/pkg/feature/manifest.go
@@ -42,16 +42,16 @@ type Manifest interface {
 	Process(data any) ([]*unstructured.Unstructured, error)
 }
 
-type baseManifest struct {
+type rawManifest struct {
 	name,
 	path string
 	patch bool
 	fsys  fs.FS
 }
 
-var _ Manifest = (*baseManifest)(nil)
+var _ Manifest = (*rawManifest)(nil)
 
-func (b *baseManifest) Process(_ any) ([]*unstructured.Unstructured, error) {
+func (b *rawManifest) Process(_ any) ([]*unstructured.Unstructured, error) {
 	manifestFile, err := b.fsys.Open(b.path)
 	if err != nil {
 		return nil, err
@@ -169,7 +169,7 @@ func loadManifestsFrom(fsys fs.FS, path string) ([]Manifest, error) {
 		if isTemplateManifest(path) {
 			manifests = append(manifests, CreateTemplateManifestFrom(fsys, path))
 		} else {
-			manifests = append(manifests, CreateBaseManifestFrom(fsys, path))
+			manifests = append(manifests, CreateRawManifestFrom(fsys, path))
 		}
 
 		return nil
@@ -182,10 +182,10 @@ func loadManifestsFrom(fsys fs.FS, path string) ([]Manifest, error) {
 	return manifests, nil
 }
 
-func CreateBaseManifestFrom(fsys fs.FS, path string) *baseManifest { //nolint:golint,revive //No need to export baseManifest.
+func CreateRawManifestFrom(fsys fs.FS, path string) *rawManifest { //nolint:golint,revive //No need to export rawManifest.
 	basePath := filepath.Base(path)
 
-	return &baseManifest{
+	return &rawManifest{
 		name:  basePath,
 		path:  path,
 		patch: strings.Contains(basePath, ".patch"),

--- a/pkg/feature/manifest_test.go
+++ b/pkg/feature/manifest_test.go
@@ -39,7 +39,7 @@ var _ = Describe("Manifest Processing", func() {
 
 	})
 
-	Describe("baseManifest Process", func() {
+	Describe("Raw Manifest Processing", func() {
 		BeforeEach(func() {
 			resourceYaml := `
 apiVersion: v1
@@ -55,9 +55,9 @@ data:
 			Expect(err).ToNot(HaveOccurred())
 		})
 
-		It("should process the base manifest with no substitutions", func() {
+		It("should process the raw manifest with no substitutions", func() {
 			// given
-			manifest := feature.CreateBaseManifestFrom(inMemFS, path)
+			manifest := feature.CreateRawManifestFrom(inMemFS, path)
 
 			data := feature.Spec{
 				TargetNamespace: "not-used",
@@ -74,7 +74,7 @@ data:
 		})
 	})
 
-	Describe("TemplateManifest Process", func() {
+	Describe("Templated Manifest Processing", func() {
 		BeforeEach(func() {
 			resourceYaml := `
 apiVersion: v1
@@ -111,7 +111,7 @@ data:
 
 	})
 
-	Describe("KustomizeManifest Process", func() {
+	Describe("Kustomize Manifest Processing", func() {
 		BeforeEach(func() {
 			path = "/path/to/kustomization/" // base path here
 			kustFsys = filesys.MakeFsInMemory()


### PR DESCRIPTION
`RawManifest` describes better the purpose of the type, as it is a simple text file without any additional processing behavior.