### PR TITLE
chore: trustcabundle

### DIFF
--- a/controllers/certconfigmapgenerator/certconfigmapgenerator_controller.go
+++ b/controllers/certconfigmapgenerator/certconfigmapgenerator_controller.go
@@ -49,19 +49,17 @@ func (r *CertConfigmapGeneratorReconciler) SetupWithManager(mgr ctrl.Manager) er
 // ca bundle in every new namespace created.
 func (r *CertConfigmapGeneratorReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	// Request includes namespace that is newly created or where odh-trusted-ca-bundle configmap is updated.
-	r.Log.Info("Reconciling certConfigMapGenerator.", "CertConfigMapGenerator Request.Namespace", req.NamespacedName)
+	r.Log.Info("Reconciling CertConfigMapGenerator.", " Request.Namespace", req.NamespacedName)
 	// Get namespace instance
 	userNamespace := &corev1.Namespace{}
-	err := r.Client.Get(ctx, client.ObjectKey{Name: req.Namespace}, userNamespace)
-	if err != nil {
-		return ctrl.Result{}, errors.WithMessage(err, "error getting user namespace to inject trustedCA bundle ")
+	if err := r.Client.Get(ctx, client.ObjectKey{Name: req.Namespace}, userNamespace); err != nil {
+		return ctrl.Result{}, errors.WithMessage(err, "error getting namespace to inject trustedCA bundle ")
 	}
 
 	// Get DSCI instance
 	dsciInstances := &dsci.DSCInitializationList{}
-	err = r.Client.List(ctx, dsciInstances)
-	if err != nil {
-		r.Log.Error(err, "Failed to retrieve DSCInitialization resource for certconfigmapgenerator ", "CertConfigmapGenerator Request.Name", req.Name)
+	if err := r.Client.List(ctx, dsciInstances); err != nil {
+		r.Log.Error(err, "Failed to retrieve DSCInitialization resource for CertConfigMapGenerator ", "Request.Name", req.Name)
 		return ctrl.Result{}, err
 	}
 
@@ -77,32 +75,30 @@ func (r *CertConfigmapGeneratorReconciler) Reconcile(ctx context.Context, req ct
 		return ctrl.Result{}, nil
 	}
 
-	// Verify if namespace did not opt out of trustedCABundle injection
+	// Delete odh-trusted-ca-bundle Configmap if namespace has annoation set to opt-out CA bundle injection
 	if trustedcabundle.HasCABundleAnnotationDisabled(userNamespace) {
 		r.Log.Info("Namespace has opted-out of CA bundle injection using annotation ", "namespace", userNamespace.Name,
 			"annotation", trustedcabundle.InjectionOfCABundleAnnotatoion)
-		err := trustedcabundle.DeleteOdhTrustedCABundleConfigMap(ctx, r.Client, req.Namespace)
-		if err != nil {
+		if err := trustedcabundle.DeleteOdhTrustedCABundleConfigMap(ctx, r.Client, req.Namespace); err != nil {
 			if !apierrors.IsNotFound(err) {
-				r.Log.Error(err, "error deleting existing configmap from namespace", "name", trustedcabundle.CAConfigMapName, "namespace", req.Namespace)
+				r.Log.Error(err, "error deleting existing configmap from namespace", "name", trustedcabundle.CAConfigMapName, "namespace", userNamespace.Name)
 				return reconcile.Result{}, err
 			}
 		}
 		return reconcile.Result{}, nil
 	}
 
-	// Verify odh-trusted-ca-bundle Configmap is created for the given namespace
+	// Add odh-trusted-ca-bundle Configmap
 	if trustedcabundle.ShouldInjectTrustedBundle(userNamespace) {
 		r.Log.Info("Adding trusted CA bundle configmap to the new or existing namespace ", "namespace", userNamespace.Name,
 			"configmap", trustedcabundle.CAConfigMapName)
 		trustCAData := dsciInstance.Spec.TrustedCABundle.CustomCABundle
-		err = trustedcabundle.CreateOdhTrustedCABundleConfigMap(ctx, r.Client, req.Namespace, trustCAData)
-		if err != nil {
-			r.Log.Error(err, "error adding configmap to namespace", "name", trustedcabundle.CAConfigMapName, "namespace", req.Namespace)
+		if err := trustedcabundle.CreateOdhTrustedCABundleConfigMap(ctx, r.Client, req.Namespace, trustCAData); err != nil {
+			r.Log.Error(err, "error adding configmap to namespace", "name", trustedcabundle.CAConfigMapName, "namespace", userNamespace.Name)
 			return reconcile.Result{}, err
 		}
 	}
-	return ctrl.Result{}, err
+	return ctrl.Result{}, nil
 }
 
 func (r *CertConfigmapGeneratorReconciler) watchNamespaceResource(a client.Object) []reconcile.Request {

--- a/controllers/dscinitialization/dscinitialization_controller.go
+++ b/controllers/dscinitialization/dscinitialization_controller.go
@@ -55,7 +55,7 @@ const (
 	finalizerName = "dscinitialization.opendatahub.io/finalizer"
 )
 
-// This ar is required by the .spec.TrustedCABundle field. When a user goes from Unmanaged to Managed, update all
+// This ar is required by the .spec.TrustedCABundle field on Reconcile Update Event. When a user goes from Unmanaged to Managed, update all
 // namespaces irrespective of any changes in the configmap.
 var managementStateChangeTrustedCA = false
 
@@ -144,9 +144,8 @@ func (r *DSCInitializationReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		return reconcile.Result{}, err
 	}
 
-	// Verify odh-trusted-ca-bundle Configmap is configured for the namespaces
-	err = trustedcabundle.ConfigureTrustedCABundle(ctx, r.Client, r.Log, instance, managementStateChangeTrustedCA)
-	if err != nil {
+	// Check ManagementState to verify if odh-trusted-ca-bundle Configmap should be configured for namespaces
+	if err := trustedcabundle.ConfigureTrustedCABundle(ctx, r.Client, r.Log, instance, managementStateChangeTrustedCA); err != nil {
 		return reconcile.Result{}, err
 	}
 	managementStateChangeTrustedCA = false

--- a/pkg/trustedcabundle/trustedcabundle.go
+++ b/pkg/trustedcabundle/trustedcabundle.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+	"github.com/hashicorp/go-multierror"
 	operatorv1 "github.com/openshift/api/operator/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
@@ -32,45 +33,19 @@ func ShouldInjectTrustedBundle(ns client.Object) bool {
 	return false
 }
 
+// return true if namespace has annotation "security.opendatahub.io/inject-trusted-ca-bundle: false"
+// return false if annotation is "true" or not set.
 func HasCABundleAnnotationDisabled(ns client.Object) bool {
 	if value, found := ns.GetAnnotations()[InjectionOfCABundleAnnotatoion]; found {
-		enabled, err := strconv.ParseBool(value)
-		return err == nil && !enabled
+		shouldInject, err := strconv.ParseBool(value)
+		return err == nil && !shouldInject
 	}
 	return false
 }
 
-func AddCABundleConfigMapInAllNamespaces(ctx context.Context, cli client.Client, dscInit *dsci.DSCInitialization) error {
-	namespaceList := &corev1.NamespaceList{}
-	err := cli.List(ctx, namespaceList)
-	if err != nil {
-		return err
-	}
-
-	for i := range namespaceList.Items {
-		ns := &namespaceList.Items[i]
-		// check namespace status if not Active, then skip
-		if ns.Status.Phase != corev1.NamespaceActive {
-			continue
-		}
-		if ShouldInjectTrustedBundle(ns) {
-			if err := wait.PollUntilContextTimeout(ctx, time.Second*1, time.Second*10, false, func(ctx context.Context) (bool, error) {
-				if cmErr := CreateOdhTrustedCABundleConfigMap(ctx, cli, ns.Name, dscInit.Spec.TrustedCABundle.CustomCABundle); cmErr != nil {
-					// Logging the error for debugging
-					fmt.Printf("error creating cert configmap in namespace %v: %v", ns.Name, cmErr)
-					return false, nil
-				}
-				return true, nil
-			}); err != nil {
-				return err
-			}
-		}
-	}
-	return nil
-}
-
-// createOdhTrustedCABundleConfigMap creates a configMap  'odh-trusted-ca-bundle' -- Certificates for the cluster
-// trusted CA Cert Bundle.
+// createOdhTrustedCABundleConfigMap creates a configMap 'odh-trusted-ca-bundle' in given namespace with labels and data
+// or update existing odh-trusted-ca-bundle configmap if already exists with new content of .data.odh-ca-bundle.crt
+// this is certificates for the cluster trusted CA Cert Bundle.
 func CreateOdhTrustedCABundleConfigMap(ctx context.Context, cli client.Client, namespace string, customCAData string) error {
 	// Expected configmap for the given namespace
 	desiredConfigMap := &corev1.ConfigMap{
@@ -96,11 +71,10 @@ func CreateOdhTrustedCABundleConfigMap(ctx context.Context, cli client.Client, n
 
 	// Create Configmap if doesn't exist
 	foundConfigMap := &corev1.ConfigMap{}
-	err := cli.Get(ctx, client.ObjectKey{
+	if err := cli.Get(ctx, client.ObjectKey{
 		Name:      CAConfigMapName,
 		Namespace: namespace,
-	}, foundConfigMap)
-	if err != nil {
+	}, foundConfigMap); err != nil {
 		if apierrs.IsNotFound(err) {
 			err = cli.Create(ctx, desiredConfigMap)
 			if err != nil && !apierrs.IsAlreadyExists(err) {
@@ -122,17 +96,18 @@ func CreateOdhTrustedCABundleConfigMap(ctx context.Context, cli client.Client, n
 func DeleteOdhTrustedCABundleConfigMap(ctx context.Context, cli client.Client, namespace string) error {
 	// Delete Configmap if exists
 	foundConfigMap := &corev1.ConfigMap{}
-	err := cli.Get(ctx, client.ObjectKey{
+	if err := cli.Get(ctx, client.ObjectKey{
 		Name:      CAConfigMapName,
 		Namespace: namespace,
-	}, foundConfigMap)
-	if err != nil {
+	}, foundConfigMap); err != nil {
 		return client.IgnoreNotFound(err)
 	}
 	return cli.Delete(ctx, foundConfigMap)
 }
 
-// IsTrustedCABundleUpdated verifies for a given namespace if the odh-ca-bundle.crt field in cert configmap is updated.
+// IsTrustedCABundleUpdated check if data in CM "odh-trusted-ca-bundle" from applciation namespace matches DSCI's TrustedCABundle.CustomCABundle
+// return false when these two are matching => skip update
+// return true when not match => need upate.
 func IsTrustedCABundleUpdated(ctx context.Context, cli client.Client, dscInit *dsci.DSCInitialization) (bool, error) {
 	usernamespace := &corev1.Namespace{}
 	if err := cli.Get(ctx, client.ObjectKey{Name: dscInit.Spec.ApplicationsNamespace}, usernamespace); err != nil {
@@ -143,17 +118,15 @@ func IsTrustedCABundleUpdated(ctx context.Context, cli client.Client, dscInit *d
 		return false, err
 	}
 
-	if HasCABundleAnnotationDisabled(usernamespace) {
+	if ShouldInjectTrustedBundle(usernamespace) {
 		return false, nil
 	}
 
 	foundConfigMap := &corev1.ConfigMap{}
-	err := cli.Get(ctx, client.ObjectKey{
+	if err := cli.Get(ctx, client.ObjectKey{
 		Name:      CAConfigMapName,
 		Namespace: dscInit.Spec.ApplicationsNamespace,
-	}, foundConfigMap)
-
-	if err != nil {
+	}, foundConfigMap); err != nil {
 		return false, client.IgnoreNotFound(err)
 	}
 
@@ -163,38 +136,36 @@ func IsTrustedCABundleUpdated(ctx context.Context, cli client.Client, dscInit *d
 func ConfigureTrustedCABundle(ctx context.Context, cli client.Client, log logr.Logger, dscInit *dsci.DSCInitialization, managementStateChanged bool) error {
 	switch dscInit.Spec.TrustedCABundle.ManagementState {
 	case operatorv1.Managed:
-		log.Info("Trusted CA Bundle injection is set to `Managed` state. Reconciling to add/update cert configmaps")
+		log.Info("Trusted CA Bundle injection is set to `Managed` state. Reconciling to add/update " + CAConfigMapName)
 		istrustedCABundleUpdated, err := IsTrustedCABundleUpdated(ctx, cli, dscInit)
 		if err != nil {
 			return err
 		}
 
 		if istrustedCABundleUpdated || managementStateChanged {
-			err = AddCABundleConfigMapInAllNamespaces(ctx, cli, dscInit)
-			if err != nil {
+			if err := AddCABundleConfigMapInAllNamespaces(ctx, cli, dscInit); err != nil {
 				log.Error(err, "error adding configmap to all namespaces", "name", CAConfigMapName)
 				return err
 			}
 		}
 	case operatorv1.Removed:
-		log.Info("Trusted CA Bundle injection is set to `Removed` state. Reconciling to delete all cert configmaps")
-		err := RemoveCABundleConfigMapInAllNamespaces(ctx, cli)
-		if err != nil {
+		log.Info("Trusted CA Bundle injection is set to `Removed` state. Reconciling to delete all " + CAConfigMapName)
+		if err := RemoveCABundleConfigMapInAllNamespaces(ctx, cli).ErrorOrNil(); err != nil {
 			log.Error(err, "error deleting configmap from all namespaces", "name", CAConfigMapName)
 			return err
 		}
 
 	case operatorv1.Unmanaged:
-		log.Info("Trusted CA Bundle injection is set to `Unmanaged` state. Cert configmaps are no longer managed by DSCI")
+		log.Info("Trusted CA Bundle injection is set to `Unmanaged` state. " + CAConfigMapName + " configmaps are no longer managed by operator")
 	}
 
 	return nil
 }
 
-func RemoveCABundleConfigMapInAllNamespaces(ctx context.Context, cli client.Client) error {
+// when DSCI TrustedCABundle.ManagementState is set to `Managed`.
+func AddCABundleConfigMapInAllNamespaces(ctx context.Context, cli client.Client, dscInit *dsci.DSCInitialization) error {
 	namespaceList := &corev1.NamespaceList{}
-	err := cli.List(ctx, namespaceList)
-	if err != nil {
+	if err := cli.List(ctx, namespaceList); err != nil {
 		return err
 	}
 
@@ -204,9 +175,41 @@ func RemoveCABundleConfigMapInAllNamespaces(ctx context.Context, cli client.Clie
 		if ns.Status.Phase != corev1.NamespaceActive {
 			continue
 		}
-		if err := DeleteOdhTrustedCABundleConfigMap(ctx, cli, ns.Name); err != nil {
-			return err
+
+		if ShouldInjectTrustedBundle(ns) {
+			if err := wait.PollUntilContextTimeout(ctx, time.Second*1, time.Second*10, false, func(ctx context.Context) (bool, error) {
+				if cmErr := CreateOdhTrustedCABundleConfigMap(ctx, cli, ns.Name, dscInit.Spec.TrustedCABundle.CustomCABundle); cmErr != nil {
+					// Logging the error for debugging
+					fmt.Printf("error creating cert configmap in namespace %v: %v", ns.Name, cmErr)
+					return false, nil
+				}
+				return true, nil
+			}); err != nil {
+				return err
+			}
 		}
 	}
 	return nil
+}
+
+// when DSCI TrustedCABundle.ManagementState is set to `Removed`.
+func RemoveCABundleConfigMapInAllNamespaces(ctx context.Context, cli client.Client) *multierror.Error {
+	var multiErr *multierror.Error
+
+	namespaceList := &corev1.NamespaceList{}
+	if err := cli.List(ctx, namespaceList); err != nil {
+		return multierror.Append(multiErr, err)
+	}
+
+	for i := range namespaceList.Items {
+		ns := &namespaceList.Items[i]
+		// check namespace status if not Active, then skip
+		if ns.Status.Phase != corev1.NamespaceActive {
+			continue
+		}
+		if err := DeleteOdhTrustedCABundleConfigMap(ctx, cli, ns.Name); err != nil {
+			multiErr = multierror.Append(multiErr, err)
+		}
+	}
+	return multiErr
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
update comments

- use ShouldInjectTrustedBundle than HasCABundleAnnotationDisabled in the call => even it is limited to application namespace, user might set to any reserved one in their DSCI CR
- change error in RemoveCABundleConfigMapInAllNamespaces

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
