### PR TITLE
Fix cleanup of ODHApplications

### DIFF
--- a/pkg/upgrade/upgrade.go
+++ b/pkg/upgrade/upgrade.go
@@ -383,7 +383,7 @@ func CleanupExistingResource(ctx context.Context, cli client.Client, platform de
 	JupyterhubApp := schema.GroupVersionKind{
 		Group:   "dashboard.opendatahub.io",
 		Version: "v1",
-		Kind:    "odhapplications",
+		Kind:    "OdhApplication",
 	}
 	multiErr = multierror.Append(multiErr, removOdhApplicationsCR(ctx, cli, JupyterhubApp, "jupyterhub", dscApplicationsNamespace))
 	return multiErr.ErrorOrNil()
@@ -541,7 +541,7 @@ func deleteDeprecatedServiceMonitors(ctx context.Context, cli client.Client, nam
 func removOdhApplicationsCR(ctx context.Context, cli client.Client, gvk schema.GroupVersionKind, instanceName string, applicationNS string) error {
 	// first check if CRD in cluster
 	crd := &apiextv1.CustomResourceDefinition{}
-	if err := cli.Get(ctx, client.ObjectKey{Name: fmt.Sprintf("%s.%s", gvk.Kind, gvk.Group)}, crd); err != nil {
+	if err := cli.Get(ctx, client.ObjectKey{Name: "odhapplications.dashboard.opendatahub.io"}, crd); err != nil {
 		return client.IgnoreNotFound(err)
 	}
 


### PR DESCRIPTION

On upgrade, odhApplications do not get cleaned up and the operator pod throws following error
```
failed to find CR: %!w(*meta.NoKindMatchError=&{{dashboard.opendatahub.io odhapplications} [v1]})

```
Will include this in odh-2.9 release branch
## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
