### PR TITLE
fix: Enable annotations using golangci-lint(gh action)

### DIFF
--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -13,24 +13,14 @@ jobs:
   golangci:
     name: golangci-lint
     runs-on: ubuntu-latest
-    env:
-      REPOSITORY: go/src/github.com/${{ github.repository }}
     steps:
       - uses: actions/checkout@v4
-        with:
-          path: ${{ env.REPOSITORY }}
       - name: Set up Go env
         uses: actions/setup-go@v4
         with:
-          go-version-file: ${{ env.REPOSITORY }}/go.mod
-      - name: Set $GOPATH
-        run: |
-          echo "GOPATH=${{ github.workspace }}/go" >> $GITHUB_ENV
-          echo "${{ github.workspace }}/go/bin" >> $GITHUB_PATH
-        shell: bash
+          go-version-file: go.mod
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
           version: v1.54.0
-          working-directory: ${{ env.REPOSITORY }}
           args: --timeout 5m0s


### PR DESCRIPTION
Fixes the gh action for linters to create annotations in the PR.

## Description
The golangci-lint action was not creating annotations in the prs created. This is a fix for the issue.

JIRA issue: https://issues.redhat.com/browse/RHOAIENG-4526

## How Has This Been Tested?
working ref: https://github.com/AjayJagan/opendatahub-operator/pull/10/files

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
