### PR TITLE
fix(gen): upgrades to crd-ref-doc generator to latest version

### DIFF
--- a/.github/workflows/check-file-updates.yaml
+++ b/.github/workflows/check-file-updates.yaml
@@ -21,6 +21,7 @@ jobs:
           if [[ -n $(git status -s) ]]
           then
             echo "Generated files have been missed in the PR"
+            git diff
             echo "missing_generated_files=true" >> $GITHUB_OUTPUT
           else
             echo "No new files to commit"

--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ OPERATOR_SDK_VERSION ?= v1.24.1
 GOLANGCI_LINT_VERSION ?= v1.54.0
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.24.2
-CRD_REF_DOCS_VERSION = 0.0.10
+CRD_REF_DOCS_VERSION = 0.0.11
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))

--- a/docs/api-overview.md
+++ b/docs/api-overview.md
@@ -18,12 +18,14 @@ which makes managing distributed compute infrastructure in the cloud easy and in
 
 CodeFlare struct holds the configuration for the CodeFlare component.
 
+
+
 _Appears in:_
 - [Components](#components)
 
-| Field | Description |
-| --- | --- |
-| `Component` _[Component](#component)_ |  |
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `Component` _[Component](#component)_ |  |  |  |
 
 
 
@@ -38,6 +40,8 @@ _Appears in:_
 
 Component struct defines the basis for each OpenDataHub component configuration.
 
+
+
 _Appears in:_
 - [CodeFlare](#codeflare)
 - [Dashboard](#dashboard)
@@ -50,10 +54,10 @@ _Appears in:_
 - [TrustyAI](#trustyai)
 - [Workbenches](#workbenches)
 
-| Field | Description |
-| --- | --- |
-| `managementState` _[ManagementState](#managementstate)_ | Set to one of the following values: <br /><br /> - "Managed" : the operator is actively managing the component and trying to keep it active. It will only upgrade the component if it is safe to do so <br /><br /> - "Removed" : the operator is actively managing the component and will not install it, or if it is installed, the operator will try to remove it |
-| `devFlags` _[DevFlags](#devflags)_ | Add developer fields |
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `managementState` _[ManagementState](#managementstate)_ | Set to one of the following values:<br /><br />- "Managed" : the operator is actively managing the component and trying to keep it active.<br />              It will only upgrade the component if it is safe to do so<br /><br />- "Removed" : the operator is actively managing the component and will not install it,<br />              or if it is installed, the operator will try to remove it |  | Enum: [Managed Removed] <br /> |
+| `devFlags` _[DevFlags](#devflags)_ | Add developer fields |  |  |
 
 
 
@@ -62,14 +66,17 @@ _Appears in:_
 
 
 
-DevFlags defines list of fields that can be used by developers to test customizations. This is not recommended to be used in production environment.
+DevFlags defines list of fields that can be used by developers to test customizations. This is not recommended
+to be used in production environment.
+
+
 
 _Appears in:_
 - [Component](#component)
 
-| Field | Description |
-| --- | --- |
-| `manifests` _[ManifestsConfig](#manifestsconfig) array_ | List of custom manifests for the given component |
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `manifests` _[ManifestsConfig](#manifestsconfig) array_ | List of custom manifests for the given component |  |  |
 
 
 #### ManifestsConfig
@@ -78,14 +85,16 @@ _Appears in:_
 
 
 
+
+
 _Appears in:_
 - [DevFlags](#devflags)
 
-| Field | Description |
-| --- | --- |
-| `uri` _string_ | uri is the URI point to a git repo with tag/branch. e.g.  https://github.com/org/repo/tarball/<tag/branch> |
-| `contextDir` _string_ | contextDir is the relative path to the folder containing manifests in a repository |
-| `sourcePath` _string_ | sourcePath is the subpath within contextDir where kustomize builds start. Examples include any sub-folder or path: `base`, `overlays/dev`, `default`, `odh` etc. |
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `uri` _string_ | uri is the URI point to a git repo with tag/branch. e.g.  https://github.com/org/repo/tarball/<tag/branch> |  |  |
+| `contextDir` _string_ | contextDir is the relative path to the folder containing manifests in a repository |  |  |
+| `sourcePath` _string_ | sourcePath is the subpath within contextDir where kustomize builds start. Examples include any sub-folder or path: `base`, `overlays/dev`, `default`, `odh` etc. |  |  |
 
 
 
@@ -102,12 +111,14 @@ installed Open Data Hub components with easy access to component UIs and documen
 
 Dashboard struct holds the configuration for the Dashboard component.
 
+
+
 _Appears in:_
 - [Components](#components)
 
-| Field | Description |
-| --- | --- |
-| `Component` _[Component](#component)_ |  |
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `Component` _[Component](#component)_ |  |  |  |
 
 
 
@@ -124,12 +135,14 @@ Pipeline solution for end to end MLOps workflows that support the Kubeflow Pipel
 
 DataSciencePipelines struct holds the configuration for the DataSciencePipelines component.
 
+
+
 _Appears in:_
 - [Components](#components)
 
-| Field | Description |
-| --- | --- |
-| `Component` _[Component](#component)_ |  |
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `Component` _[Component](#component)_ |  |  |  |
 
 
 
@@ -145,6 +158,9 @@ _Underlying type:_ _string_
 
 
 
+_Validation:_
+- Pattern: `^(Serverless|RawDeployment)$`
+
 _Appears in:_
 - [Kserve](#kserve)
 
@@ -156,14 +172,16 @@ _Appears in:_
 
 Kserve struct holds the configuration for the Kserve component.
 
+
+
 _Appears in:_
 - [Components](#components)
 
-| Field | Description |
-| --- | --- |
-| `Component` _[Component](#component)_ |  |
-| `serving` _[ServingSpec](#servingspec)_ | Serving configures the KNative-Serving stack used for model serving. A Service Mesh (Istio) is prerequisite, since it is used as networking layer. |
-| `defaultDeploymentMode` _[DefaultDeploymentMode](#defaultdeploymentmode)_ | Configures the default deployment mode for Kserve. This can be set to 'Serverless' or 'RawDeployment'. The value specified in this field will be used to set the default deployment mode in the 'inferenceservice-config' configmap for Kserve If no default deployment mode is specified, Kserve will use Serverless mode |
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `Component` _[Component](#component)_ |  |  |  |
+| `serving` _[ServingSpec](#servingspec)_ | Serving configures the KNative-Serving stack used for model serving. A Service<br />Mesh (Istio) is prerequisite, since it is used as networking layer. |  |  |
+| `defaultDeploymentMode` _[DefaultDeploymentMode](#defaultdeploymentmode)_ | Configures the default deployment mode for Kserve. This can be set to 'Serverless' or 'RawDeployment'.<br />The value specified in this field will be used to set the default deployment mode in the 'inferenceservice-config' configmap for Kserve<br />If no default deployment mode is specified, Kserve will use Serverless mode |  | Enum: [Serverless RawDeployment] <br />Pattern: `^(Serverless|RawDeployment)$` <br /> |
 
 
 
@@ -178,12 +196,14 @@ _Appears in:_
 
 Kueue struct holds the configuration for the Kueue component.
 
+
+
 _Appears in:_
 - [Components](#components)
 
-| Field | Description |
-| --- | --- |
-| `Component` _[Component](#component)_ |  |
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `Component` _[Component](#component)_ |  |  |  |
 
 
 
@@ -199,12 +219,14 @@ Package modelmeshserving provides utility functions to config MoModelMesh, a gen
 
 ModelMeshServing struct holds the configuration for the ModelMeshServing component.
 
+
+
 _Appears in:_
 - [Components](#components)
 
-| Field | Description |
-| --- | --- |
-| `Component` _[Component](#component)_ |  |
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `Component` _[Component](#component)_ |  |  |  |
 
 
 
@@ -220,12 +242,14 @@ Package modelregistry provides utility functions to config ModelRegistry, an ML 
 
 ModelRegistry struct holds the configuration for the ModelRegistry component.
 
+
+
 _Appears in:_
 - [Components](#components)
 
-| Field | Description |
-| --- | --- |
-| `Component` _[Component](#component)_ |  |
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `Component` _[Component](#component)_ |  |  |  |
 
 
 
@@ -242,12 +266,14 @@ which makes managing distributed compute infrastructure in the cloud easy and in
 
 Ray struct holds the configuration for the Ray component.
 
+
+
 _Appears in:_
 - [Components](#components)
 
-| Field | Description |
-| --- | --- |
-| `Component` _[Component](#component)_ |  |
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `Component` _[Component](#component)_ |  |  |  |
 
 
 
@@ -263,12 +289,14 @@ Package trustyai provides utility functions to config TrustyAI, a bias/fairness 
 
 TrustyAI struct holds the configuration for the TrustyAI component.
 
+
+
 _Appears in:_
 - [Components](#components)
 
-| Field | Description |
-| --- | --- |
-| `Component` _[Component](#component)_ |  |
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `Component` _[Component](#component)_ |  |  |  |
 
 
 
@@ -286,18 +314,22 @@ _Appears in:_
 
 
 
+
+
 _Appears in:_
 - [ServiceMeshSpec](#servicemeshspec)
 
-| Field | Description |
-| --- | --- |
-| `namespace` _string_ | Namespace where it is deployed. If not provided, the default is to use '-auth-provider' suffix on the ApplicationsNamespace of the DSCI. |
-| `audiences` _string_ | Audiences is a list of the identifiers that the resource server presented with the token identifies as. Audience-aware token authenticators will verify that the token was intended for at least one of the audiences in this list. If no audiences are provided, the audience will default to the audience of the Kubernetes apiserver (kubernetes.default.svc). |
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `namespace` _string_ | Namespace where it is deployed. If not provided, the default is to<br />use '-auth-provider' suffix on the ApplicationsNamespace of the DSCI. |  |  |
+| `audiences` _string_ | Audiences is a list of the identifiers that the resource server presented<br />with the token identifies as. Audience-aware token authenticators will verify<br />that the token was intended for at least one of the audiences in this list.<br />If no audiences are provided, the audience will default to the audience of the<br />Kubernetes apiserver (kubernetes.default.svc). | [https://kubernetes.default.svc] |  |
 
 
 #### CertType
 
 _Underlying type:_ _string_
+
+
 
 
 
@@ -310,15 +342,18 @@ _Appears in:_
 
 
 
-CertificateSpec represents the specification of the certificate securing communications of an Istio Gateway.
+CertificateSpec represents the specification of the certificate securing communications of
+an Istio Gateway.
+
+
 
 _Appears in:_
 - [IngressGatewaySpec](#ingressgatewayspec)
 
-| Field | Description |
-| --- | --- |
-| `secretName` _string_ | SecretName specifies the name of the Kubernetes Secret resource that contains a TLS certificate secure HTTP communications for the KNative network. |
-| `type` _[CertType](#certtype)_ | Type specifies if the TLS certificate should be generated automatically, or if the certificate is provided by the user. Allowed values are: * SelfSigned: A certificate is going to be generated using an own private key. * Provided: Pre-existence of the TLS Secret (see SecretName) with a valid certificate is assumed. |
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `secretName` _string_ | SecretName specifies the name of the Kubernetes Secret resource that contains a<br />TLS certificate secure HTTP communications for the KNative network. |  |  |
+| `type` _[CertType](#certtype)_ | Type specifies if the TLS certificate should be generated automatically, or if the certificate<br />is provided by the user. Allowed values are:<br />* SelfSigned: A certificate is going to be generated using an own private key.<br />* Provided: Pre-existence of the TLS Secret (see SecretName) with a valid certificate is assumed. | SelfSigned | Enum: [SelfSigned Provided] <br /> |
 
 
 #### Components
@@ -327,21 +362,23 @@ _Appears in:_
 
 
 
+
+
 _Appears in:_
 - [DataScienceClusterSpec](#datascienceclusterspec)
 
-| Field | Description |
-| --- | --- |
-| `dashboard` _[Dashboard](#dashboard)_ | Dashboard component configuration. |
-| `workbenches` _[Workbenches](#workbenches)_ | Workbenches component configuration. |
-| `modelmeshserving` _[ModelMeshServing](#modelmeshserving)_ | ModelMeshServing component configuration. Does not support enabled Kserve at the same time |
-| `datasciencepipelines` _[DataSciencePipelines](#datasciencepipelines)_ | DataServicePipeline component configuration. Require OpenShift Pipelines Operator to be installed before enable component |
-| `kserve` _[Kserve](#kserve)_ | Kserve component configuration. Require OpenShift Serverless and OpenShift Service Mesh Operators to be installed before enable component Does not support enabled ModelMeshServing at the same time |
-| `kueue` _[Kueue](#kueue)_ | Kueue component configuration. |
-| `codeflare` _[CodeFlare](#codeflare)_ | CodeFlare component configuration. If CodeFlare Operator has been installed in the cluster, it should be uninstalled first before enabled component. |
-| `ray` _[Ray](#ray)_ | Ray component configuration. |
-| `trustyai` _[TrustyAI](#trustyai)_ | TrustyAI component configuration. |
-| `modelregistry` _[ModelRegistry](#modelregistry)_ | ModelRegistry component configuration. |
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `dashboard` _[Dashboard](#dashboard)_ | Dashboard component configuration. |  |  |
+| `workbenches` _[Workbenches](#workbenches)_ | Workbenches component configuration. |  |  |
+| `modelmeshserving` _[ModelMeshServing](#modelmeshserving)_ | ModelMeshServing component configuration.<br />Does not support enabled Kserve at the same time |  |  |
+| `datasciencepipelines` _[DataSciencePipelines](#datasciencepipelines)_ | DataServicePipeline component configuration.<br />Require OpenShift Pipelines Operator to be installed before enable component |  |  |
+| `kserve` _[Kserve](#kserve)_ | Kserve component configuration.<br />Require OpenShift Serverless and OpenShift Service Mesh Operators to be installed before enable component<br />Does not support enabled ModelMeshServing at the same time |  |  |
+| `kueue` _[Kueue](#kueue)_ | Kueue component configuration. |  |  |
+| `codeflare` _[CodeFlare](#codeflare)_ | CodeFlare component configuration.<br />If CodeFlare Operator has been installed in the cluster, it should be uninstalled first before enabled component. |  |  |
+| `ray` _[Ray](#ray)_ | Ray component configuration. |  |  |
+| `trustyai` _[TrustyAI](#trustyai)_ | TrustyAI component configuration. |  |  |
+| `modelregistry` _[ModelRegistry](#modelregistry)_ | ModelRegistry component configuration. |  |  |
 
 
 #### ControlPlaneSpec
@@ -350,14 +387,16 @@ _Appears in:_
 
 
 
+
+
 _Appears in:_
 - [ServiceMeshSpec](#servicemeshspec)
 
-| Field | Description |
-| --- | --- |
-| `name` _string_ | Name is a name Service Mesh Control Plane. Defaults to "data-science-smcp". |
-| `namespace` _string_ | Namespace is a namespace where Service Mesh is deployed. Defaults to "istio-system". |
-| `metricsCollection` _string_ | MetricsCollection specifies if metrics from components on the Mesh namespace should be collected. Setting the value to "Istio" will collect metrics from the control plane and any proxies on the Mesh namespace (like gateway pods). Setting to "None" will disable metrics collection. |
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `name` _string_ | Name is a name Service Mesh Control Plane. Defaults to "data-science-smcp". | data-science-smcp |  |
+| `namespace` _string_ | Namespace is a namespace where Service Mesh is deployed. Defaults to "istio-system". | istio-system |  |
+| `metricsCollection` _string_ | MetricsCollection specifies if metrics from components on the Mesh namespace<br />should be collected. Setting the value to "Istio" will collect metrics from the<br />control plane and any proxies on the Mesh namespace (like gateway pods). Setting<br />to "None" will disable metrics collection. | Istio | Enum: [Istio None] <br /> |
 
 
 #### DataScienceCluster
@@ -368,15 +407,17 @@ DataScienceCluster is the Schema for the datascienceclusters API.
 
 
 
-| Field | Description |
-| --- | --- |
-| `apiVersion` _string_ | `datasciencecluster.opendatahub.io/v1`
-| `kind` _string_ | `DataScienceCluster`
-| `kind` _string_ | Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds |
-| `apiVersion` _string_ | APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources |
-| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |
-| `spec` _[DataScienceClusterSpec](#datascienceclusterspec)_ |  |
-| `status` _[DataScienceClusterStatus](#datascienceclusterstatus)_ |  |
+
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `apiVersion` _string_ | `datasciencecluster.opendatahub.io/v1` | | |
+| `kind` _string_ | `DataScienceCluster` | | |
+| `kind` _string_ | Kind is a string value representing the REST resource this object represents.<br />Servers may infer this from the endpoint the client submits requests to.<br />Cannot be updated.<br />In CamelCase.<br />More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds |  |  |
+| `apiVersion` _string_ | APIVersion defines the versioned schema of this representation of an object.<br />Servers should convert recognized schemas to the latest internal value, and<br />may reject unrecognized values.<br />More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources |  |  |
+| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |  |  |
+| `spec` _[DataScienceClusterSpec](#datascienceclusterspec)_ |  |  |  |
+| `status` _[DataScienceClusterStatus](#datascienceclusterstatus)_ |  |  |  |
 
 
 #### DataScienceClusterSpec
@@ -385,12 +426,14 @@ DataScienceCluster is the Schema for the datascienceclusters API.
 
 DataScienceClusterSpec defines the desired state of the cluster.
 
+
+
 _Appears in:_
 - [DataScienceCluster](#datasciencecluster)
 
-| Field | Description |
-| --- | --- |
-| `components` _[Components](#components)_ | Override and fine tune specific component configurations. |
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `components` _[Components](#components)_ | Override and fine tune specific component configurations. |  |  |
 
 
 #### DataScienceClusterStatus
@@ -399,16 +442,18 @@ _Appears in:_
 
 DataScienceClusterStatus defines the observed state of DataScienceCluster.
 
+
+
 _Appears in:_
 - [DataScienceCluster](#datasciencecluster)
 
-| Field | Description |
-| --- | --- |
-| `phase` _string_ | Phase describes the Phase of DataScienceCluster reconciliation state This is used by OLM UI to provide status information to the user |
-| `conditions` _Condition array_ | Conditions describes the state of the DataScienceCluster resource. |
-| `relatedObjects` _[ObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#objectreference-v1-core) array_ | RelatedObjects is a list of objects created and maintained by this operator. Object references will be added to this list after they have been created AND found in the cluster. |
-| `errorMessage` _string_ |  |
-| `installedComponents` _object (keys:string, values:boolean)_ | List of components with status if installed or not |
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `phase` _string_ | Phase describes the Phase of DataScienceCluster reconciliation state<br />This is used by OLM UI to provide status information to the user |  |  |
+| `conditions` _Condition array_ | Conditions describes the state of the DataScienceCluster resource. |  |  |
+| `relatedObjects` _[ObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#objectreference-v1-core) array_ | RelatedObjects is a list of objects created and maintained by this operator.<br />Object references will be added to this list after they have been created AND found in the cluster. |  |  |
+| `errorMessage` _string_ |  |  |  |
+| `installedComponents` _object (keys:string, values:boolean)_ | List of components with status if installed or not |  |  |
 
 
 #### IngressGatewaySpec
@@ -417,13 +462,15 @@ _Appears in:_
 
 IngressGatewaySpec represents the configuration of the Ingress Gateways.
 
+
+
 _Appears in:_
 - [ServingSpec](#servingspec)
 
-| Field | Description |
-| --- | --- |
-| `domain` _string_ | Domain specifies the DNS name for intercepting ingress requests coming from outside the cluster. Most likely, you will want to use a wildcard name, like *.example.com. If not set, the domain of the OpenShift Ingress is used. If you choose to generate a certificate, this is the domain used for the certificate request. |
-| `certificate` _[CertificateSpec](#certificatespec)_ | Certificate specifies configuration of the TLS certificate securing communications of the for Ingress Gateway. |
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `domain` _string_ | Domain specifies the DNS name for intercepting ingress requests coming from<br />outside the cluster. Most likely, you will want to use a wildcard name,<br />like *.example.com. If not set, the domain of the OpenShift Ingress is used.<br />If you choose to generate a certificate, this is the domain used for the certificate request. |  |  |
+| `certificate` _[CertificateSpec](#certificatespec)_ | Certificate specifies configuration of the TLS certificate securing communications of<br />the for Ingress Gateway. |  |  |
 
 
 #### ServiceMeshSpec
@@ -432,30 +479,35 @@ _Appears in:_
 
 ServiceMeshSpec configures Service Mesh.
 
+
+
 _Appears in:_
 - [DSCInitializationSpec](#dscinitializationspec)
 
-| Field | Description |
-| --- | --- |
-| `managementState` _[ManagementState](#managementstate)_ |  |
-| `controlPlane` _[ControlPlaneSpec](#controlplanespec)_ | ControlPlane holds configuration of Service Mesh used by Opendatahub. |
-| `auth` _[AuthSpec](#authspec)_ | Auth holds configuration of authentication and authorization services used by Service Mesh in Opendatahub. |
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `managementState` _[ManagementState](#managementstate)_ |  | Removed | Enum: [Managed Unmanaged Removed] <br /> |
+| `controlPlane` _[ControlPlaneSpec](#controlplanespec)_ | ControlPlane holds configuration of Service Mesh used by Opendatahub. |  |  |
+| `auth` _[AuthSpec](#authspec)_ | Auth holds configuration of authentication and authorization services<br />used by Service Mesh in Opendatahub. |  |  |
 
 
 #### ServingSpec
 
 
 
-ServingSpec specifies the configuration for the KNative Serving components and their bindings with the Service Mesh.
+ServingSpec specifies the configuration for the KNative Serving components and their
+bindings with the Service Mesh.
+
+
 
 _Appears in:_
 - [Kserve](#kserve)
 
-| Field | Description |
-| --- | --- |
-| `managementState` _[ManagementState](#managementstate)_ |  |
-| `name` _string_ | Name specifies the name of the KNativeServing resource that is going to be created to instruct the KNative Operator to deploy KNative serving components. This resource is created in the "knative-serving" namespace. |
-| `ingressGateway` _[IngressGatewaySpec](#ingressgatewayspec)_ | IngressGateway allows to customize some parameters for the Istio Ingress Gateway that is bound to KNative-Serving. |
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `managementState` _[ManagementState](#managementstate)_ |  | Managed | Enum: [Managed Unmanaged Removed] <br /> |
+| `name` _string_ | Name specifies the name of the KNativeServing resource that is going to be<br />created to instruct the KNative Operator to deploy KNative serving components.<br />This resource is created in the "knative-serving" namespace. | knative-serving |  |
+| `ingressGateway` _[IngressGatewaySpec](#ingressgatewayspec)_ | IngressGateway allows to customize some parameters for the Istio Ingress Gateway<br />that is bound to KNative-Serving. |  |  |
 
 
 
@@ -471,12 +523,14 @@ Package workbenches provides utility functions to config Workbenches to secure J
 
 Workbenches struct holds the configuration for the Workbenches component.
 
+
+
 _Appears in:_
 - [Components](#components)
 
-| Field | Description |
-| --- | --- |
-| `Component` _[Component](#component)_ |  |
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `Component` _[Component](#component)_ |  |  |  |
 
 
 
@@ -497,15 +551,17 @@ DSCInitialization is the Schema for the dscinitializations API.
 
 
 
-| Field | Description |
-| --- | --- |
-| `apiVersion` _string_ | `dscinitialization.opendatahub.io/v1`
-| `kind` _string_ | `DSCInitialization`
-| `kind` _string_ | Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds |
-| `apiVersion` _string_ | APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources |
-| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |
-| `spec` _[DSCInitializationSpec](#dscinitializationspec)_ |  |
-| `status` _[DSCInitializationStatus](#dscinitializationstatus)_ |  |
+
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `apiVersion` _string_ | `dscinitialization.opendatahub.io/v1` | | |
+| `kind` _string_ | `DSCInitialization` | | |
+| `kind` _string_ | Kind is a string value representing the REST resource this object represents.<br />Servers may infer this from the endpoint the client submits requests to.<br />Cannot be updated.<br />In CamelCase.<br />More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds |  |  |
+| `apiVersion` _string_ | APIVersion defines the versioned schema of this representation of an object.<br />Servers should convert recognized schemas to the latest internal value, and<br />may reject unrecognized values.<br />More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources |  |  |
+| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |  |  |
+| `spec` _[DSCInitializationSpec](#dscinitializationspec)_ |  |  |  |
+| `status` _[DSCInitializationStatus](#dscinitializationstatus)_ |  |  |  |
 
 
 #### DSCInitializationSpec
@@ -514,16 +570,18 @@ DSCInitialization is the Schema for the dscinitializations API.
 
 DSCInitializationSpec defines the desired state of DSCInitialization.
 
+
+
 _Appears in:_
 - [DSCInitialization](#dscinitialization)
 
-| Field | Description |
-| --- | --- |
-| `applicationsNamespace` _string_ | Namespace for applications to be installed, non-configurable, default to "opendatahub" |
-| `monitoring` _[Monitoring](#monitoring)_ | Enable monitoring on specified namespace |
-| `serviceMesh` _[ServiceMeshSpec](#servicemeshspec)_ | Configures Service Mesh as networking layer for Data Science Clusters components. The Service Mesh is a mandatory prerequisite for single model serving (KServe) and you should review this configuration if you are planning to use KServe. For other components, it enhances user experience; e.g. it provides unified authentication giving a Single Sign On experience. |
-| `trustedCABundle` _[TrustedCABundleSpec](#trustedcabundlespec)_ | When set to `Managed`, adds odh-trusted-ca-bundle Configmap to all namespaces that includes cluster-wide Trusted CA Bundle in .data["ca-bundle.crt"]. Additionally, this fields allows admins to add custom CA bundles to the configmap using the .CustomCABundle field. |
-| `devFlags` _[DevFlags](#devflags)_ | Internal development useful field to test customizations. This is not recommended to be used in production environment. |
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `applicationsNamespace` _string_ | Namespace for applications to be installed, non-configurable, default to "opendatahub" | opendatahub |  |
+| `monitoring` _[Monitoring](#monitoring)_ | Enable monitoring on specified namespace |  |  |
+| `serviceMesh` _[ServiceMeshSpec](#servicemeshspec)_ | Configures Service Mesh as networking layer for Data Science Clusters components.<br />The Service Mesh is a mandatory prerequisite for single model serving (KServe) and<br />you should review this configuration if you are planning to use KServe.<br />For other components, it enhances user experience; e.g. it provides unified<br />authentication giving a Single Sign On experience. |  |  |
+| `trustedCABundle` _[TrustedCABundleSpec](#trustedcabundlespec)_ | When set to `Managed`, adds odh-trusted-ca-bundle Configmap to all namespaces that includes<br />cluster-wide Trusted CA Bundle in .data["ca-bundle.crt"].<br />Additionally, this fields allows admins to add custom CA bundles to the configmap using the .CustomCABundle field. |  |  |
+| `devFlags` _[DevFlags](#devflags)_ | Internal development useful field to test customizations.<br />This is not recommended to be used in production environment. |  |  |
 
 
 #### DSCInitializationStatus
@@ -532,29 +590,34 @@ _Appears in:_
 
 DSCInitializationStatus defines the observed state of DSCInitialization.
 
+
+
 _Appears in:_
 - [DSCInitialization](#dscinitialization)
 
-| Field | Description |
-| --- | --- |
-| `phase` _string_ | Phase describes the Phase of DSCInitializationStatus This is used by OLM UI to provide status information to the user |
-| `conditions` _Condition array_ | Conditions describes the state of the DSCInitializationStatus resource |
-| `relatedObjects` _[ObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#objectreference-v1-core) array_ | RelatedObjects is a list of objects created and maintained by this operator. Object references will be added to this list after they have been created AND found in the cluster |
-| `errorMessage` _string_ |  |
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `phase` _string_ | Phase describes the Phase of DSCInitializationStatus<br />This is used by OLM UI to provide status information to the user |  |  |
+| `conditions` _Condition array_ | Conditions describes the state of the DSCInitializationStatus resource |  |  |
+| `relatedObjects` _[ObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#objectreference-v1-core) array_ | RelatedObjects is a list of objects created and maintained by this operator.<br />Object references will be added to this list after they have been created AND found in the cluster |  |  |
+| `errorMessage` _string_ |  |  |  |
 
 
 #### DevFlags
 
 
 
-DevFlags defines list of fields that can be used by developers to test customizations. This is not recommended to be used in production environment.
+DevFlags defines list of fields that can be used by developers to test customizations. This is not recommended
+to be used in production environment.
+
+
 
 _Appears in:_
 - [DSCInitializationSpec](#dscinitializationspec)
 
-| Field | Description |
-| --- | --- |
-| `manifestsUri` _string_ | Custom manifests uri for odh-manifests |
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `manifestsUri` _string_ | Custom manifests uri for odh-manifests |  |  |
 
 
 #### Monitoring
@@ -563,13 +626,15 @@ _Appears in:_
 
 
 
+
+
 _Appears in:_
 - [DSCInitializationSpec](#dscinitializationspec)
 
-| Field | Description |
-| --- | --- |
-| `managementState` _[ManagementState](#managementstate)_ | Set to one of the following values: - "Managed" : the operator is actively managing the component and trying to keep it active. It will only upgrade the component if it is safe to do so. - "Removed" : the operator is actively managing the component and will not install it, or if it is installed, the operator will try to remove it. |
-| `namespace` _string_ | Namespace for monitoring if it is enabled |
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `managementState` _[ManagementState](#managementstate)_ | Set to one of the following values:<br />- "Managed" : the operator is actively managing the component and trying to keep it active.<br />              It will only upgrade the component if it is safe to do so.<br />- "Removed" : the operator is actively managing the component and will not install it,<br />              or if it is installed, the operator will try to remove it. |  | Enum: [Managed Removed] <br /> |
+| `namespace` _string_ | Namespace for monitoring if it is enabled | opendatahub |  |
 
 
 #### TrustedCABundleSpec
@@ -578,12 +643,14 @@ _Appears in:_
 
 
 
+
+
 _Appears in:_
 - [DSCInitializationSpec](#dscinitializationspec)
 
-| Field | Description |
-| --- | --- |
-| `managementState` _[ManagementState](#managementstate)_ | managementState indicates whether and how the operator should manage customized CA bundle |
-| `customCABundle` _string_ | A custom CA bundle that will be available for  all  components in the Data Science Cluster(DSC). This bundle will be stored in odh-trusted-ca-bundle ConfigMap .data.odh-ca-bundle.crt . |
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `managementState` _[ManagementState](#managementstate)_ | managementState indicates whether and how the operator should manage customized CA bundle | Removed | Enum: [Managed Removed Unmanaged] <br /> |
+| `customCABundle` _string_ | A custom CA bundle that will be available for  all  components in the<br />Data Science Cluster(DSC). This bundle will be stored in odh-trusted-ca-bundle<br />ConfigMap .data.odh-ca-bundle.crt . |  |  |
 
 


### PR DESCRIPTION
- add "diff" in the failed GH action to help understand problem

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
in https://github.com/elastic/crd-ref-docs/releases/tag/v0.0.11 it has the bug fix for a wrong rending content.
this is causing the current runs failing, 
+ add debug to help know if it is a false error:

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

from current incubation:
![Screenshot from 2024-03-15 18-09-24](https://github.com/opendatahub-io/opendatahub-operator/assets/915053/a629e9fe-adc7-4ddb-bda2-cbb6b3fd7466)
from my PR code:
![Screenshot from 2024-03-15 18-09-32](https://github.com/opendatahub-io/opendatahub-operator/assets/915053/0f97a764-18a0-45f2-90b5-e2f488e59533)

failed GH action run with debug info:
want to revert "enum" part in the PR which indicates PR has change should be commited

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
