### PR TITLE
Remove GOARCH from the go build

### DIFF
--- a/Dockerfiles/Dockerfile
+++ b/Dockerfiles/Dockerfile
@@ -39,7 +39,7 @@ COPY main.go main.go
 COPY pkg/ pkg/
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager main.go
+RUN CGO_ENABLED=0 go build -a -o manager main.go
 
 ################################################################################
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
GOARCH will be set by default to the target architecture, explicit mention of GOARCH is not necessary. This change will give flexibility to build this image on non-amd64 platform.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Podman build:
```
% podman build -t opendatahub-operator:latest -f ./Dockerfiles/Dockerfile .
[1/4] STEP 1/6: FROM registry.access.redhat.com/ubi8/go-toolset:1.19 AS builder_local_false
[1/4] STEP 2/6: ARG OVERWRITE_MANIFESTS
--> 66127cb9c850
[1/4] STEP 3/6: USER root
--> afb17858b3be
[1/4] STEP 4/6: WORKDIR /opt
--> 16f00e5a32af
[1/4] STEP 5/6: COPY get_all_manifests.sh get_all_manifests.sh
--> 2e53fa9c87e6
[1/4] STEP 6/6: RUN ./get_all_manifests.sh ${OVERWRITE_MANIFESTS}
Cloning repo kserve: opendatahub-io:kserve:release-v0.11.1:config:kserve
Cloning repo odh-dashboard: opendatahub-io:odh-dashboard:incubation:manifests:dashboard
Cloning repo odh-notebook-controller: opendatahub-io:kubeflow:v1.7-branch:components/odh-notebook-controller/config:odh-notebook-controller/odh-notebook-controller
Cloning repo notebooks: opendatahub-io:notebooks:main:manifests:notebooks
Cloning repo odh-model-controller: opendatahub-io:odh-model-controller:release-0.11.1:config:odh-model-controller
Cloning repo kueue: opendatahub-io:kueue:dev:config:kueue
Cloning repo ray: opendatahub-io:kuberay:master:ray-operator/config:ray
Cloning repo modelregistry: opendatahub-io:model-registry-operator:main:config:model-registry-operator
Cloning repo kf-notebook-controller: opendatahub-io:kubeflow:v1.7-branch:components/notebook-controller/config:odh-notebook-controller/kf-notebook-controller
Cloning repo data-science-pipelines-operator: opendatahub-io:data-science-pipelines-operator:main:config:data-science-pipelines-operator
Cloning repo trustyai: trustyai-explainability:trustyai-service-operator:release/1.10.2:config:trustyai-service-operator
Cloning repo model-mesh: opendatahub-io:modelmesh-serving:release-0.11.1:config:model-mesh
Cloning repo codeflare: opendatahub-io:codeflare-operator:main:config:codeflare
--> 0588b4f5b6d8
[3/4] STEP 1/12: FROM 0588b4f5b6d86d0c4ca7475a1dc567de4abff7076b08c3e758220bdf89456617 AS builder
[3/4] STEP 2/12: USER root
--> a5381ce9b4cd
[3/4] STEP 3/12: WORKDIR /workspace
--> a8234c793cf0
[3/4] STEP 4/12: COPY go.mod go.mod
--> 4ed411ad026a
[3/4] STEP 5/12: COPY go.sum go.sum
--> b0f041d5b250
[3/4] STEP 6/12: RUN go mod download
--> 99de042d53e6
[3/4] STEP 7/12: COPY apis/ apis/
--> dfe8e62cf195
[3/4] STEP 8/12: COPY components/ components/
--> 66d72c821923
[3/4] STEP 9/12: COPY controllers/ controllers/
--> 9818217ab117
[3/4] STEP 10/12: COPY main.go main.go
--> 726adb96a87f
[3/4] STEP 11/12: COPY pkg/ pkg/
--> d1ad9f14f92a
[3/4] STEP 12/12: RUN CGO_ENABLED=0 GOOS=linux go build -a -o manager main.go
--> 7c5fe820cf88
[4/4] STEP 1/7: FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
Trying to pull registry.access.redhat.com/ubi8/ubi-minimal:latest...
Getting image source signatures
Checking if image destination supports signatures
Copying blob sha256:e3649b5f99e0fcf52b3d19c3b201484e78f19873fb98a5b5a4b3a4d64c75ae78
Copying config sha256:f0dc20fdb65a920a81ec9cd7bcbb294d875a4115c11a15e1daf442c80a54dc70
Writing manifest to image destination
Storing signatures
[4/4] STEP 2/7: WORKDIR /
--> 09cd862077c9
[4/4] STEP 3/7: COPY --from=builder /workspace/manager .
--> 92fc24859491
[4/4] STEP 4/7: COPY --chown=1001:0 --from=builder /opt/odh-manifests /opt/manifests
--> 2c6c111be5b2
[4/4] STEP 5/7: RUN chown -R 1001:0 /opt/manifests &&    chmod -R a+r /opt/manifests
--> 29d7e7732edc
[4/4] STEP 6/7: USER 1001
--> 9e2153c59efc
[4/4] STEP 7/7: ENTRYPOINT ["/manager"]
[4/4] COMMIT opendatahub-operator:latest
--> f96c3d30c2ad
Successfully tagged localhost/opendatahub-operator:latest
f96c3d30c2aded7fa171a29e7e19d3bf4a5f4bf904b17ffee153cc7d38769e64
```

Podman run:
```
% podman run -ti opendatahub-operator:latest --help
Usage of /manager:
  -dsc-applications-namespace string
    	The namespace where data science clusterapplications will be deployed (default "opendatahub")
  -dsc-monitoring-namespace string
    	The namespace where data science clustermonitoring stack will be deployed (default "opendatahub")
  -health-probe-bind-address string
    	The address the probe endpoint binds to. (default ":8081")
  -kubeconfig string
    	Paths to a kubeconfig. Only required if out-of-cluster.
  -leader-elect
    	Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager.
  -metrics-bind-address string
    	The address the metric endpoint binds to. (default ":8080")
  -zap-devel
    	Development Mode defaults(encoder=consoleEncoder,logLevel=Debug,stackTraceLevel=Warn). Production Mode defaults(encoder=jsonEncoder,logLevel=Info,stackTraceLevel=Error) (default true)
  -zap-encoder value
    	Zap log encoding (one of 'json' or 'console')
  -zap-log-level value
    	Zap Level to configure the verbosity of logging. Can be one of 'debug', 'info', 'error', or any integer value > 0 which corresponds to custom debug levels of increasing verbosity
  -zap-stacktrace-level value
    	Zap Level at and above which stacktraces are captured (one of 'info', 'error', 'panic').
  -zap-time-encoding value
    	Zap time encoding (one of 'epoch', 'millis', 'nano', 'iso8601', 'rfc3339' or 'rfc3339nano'). Defaults to 'epoch'.
```

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
