### PR TITLE
fix(make): cleans linter cache on clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -249,7 +249,7 @@ GOLANGCI_LINT_INSTALL_SCRIPT ?= 'https://raw.githubusercontent.com/golangci/gola
 .PHONY: golangci-lint
 golangci-lint: $(GOLANGCI_LINT) ## Download golangci-lint locally if necessary.
 $(GOLANGCI_LINT): $(LOCALBIN)
-	test -s $(LOCALBIN)/golangci-lint || { curl -sSfL $(GOLANGCI_LINT_INSTALL_SCRIPT) | bash -s $(GOLANGCI_LINT_VERSION); }
+	test -s $(GOLANGCI_LINT) || { curl -sSfL $(GOLANGCI_LINT_INSTALL_SCRIPT) | bash -s $(GOLANGCI_LINT_VERSION); }
 
 CRD_REF_DOCS_DL_URL ?= 'https://github.com/elastic/crd-ref-docs/releases/download/v$(CRD_REF_DOCS_VERSION)/crd-ref-docs'
 .PHONY: crd-ref-docs
@@ -353,6 +353,7 @@ CLEANFILES += cover.out
 e2e-test: ## Run e2e tests for the controller
 	go test ./tests/e2e/ -run ^TestOdhOperator -v --operator-namespace=${OPERATOR_NAMESPACE} ${E2E_TEST_FLAGS}
 
-clean:
+clean: $(GOLANGCI_LINT)
+	$(GOLANGCI_LINT) cache clean
 	chmod u+w -R $(LOCALBIN) # envtest makes its dir RO
 	rm -rf $(CLEANFILES)


### PR DESCRIPTION
When juggling between branches golangci linter cache can have leftovers from the code that does not exist in the other branch.

This can lead to errors while running `make lint` as linter tries to check cached sources first.

This change cleans linter cache as part of clean target to ensure consistency.

Here's an example of invalid cache state leading to error:

```
WARN [runner] Can't process result by autogenerated_exclude processor: can't filter issue result.Issue{FromLinter:"ireturn", Text:"Entry returns interface (github.com/opendatahub-io/opendatahub-operator/v2/pkg/feature.DataProvider)", Severity:"", SourceLines:[]string(nil), Replacement:(*result.Replacement)(nil), Pkg:(*packages.Package)(0xc001343e00), LineRange:(*result.Range)(nil), Pos:token.Position{Filename:"/home/bartek/code/rhods/opendatahub-operator/incubation/pkg/feature/data_provider.go", Offset:1382, Line:45, Column:1}, HunkPos:0, ExpectNoLint:false, ExpectedNoLintLinter:""}: failed to get doc of file
```