### PR TITLE
feat(build): adds gci to go fmt target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,6 @@ cover.out
 # Ignore any local.mk files that would be consumed by the Makefile
 local.mk
 
+# Ignore temporary files created by the Makefile
+*.mktmp.*
+

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,7 +12,6 @@ linters-settings:
     sections:
       - standard
       - default
-      - blank
       - prefix(github.com/opendatahub-io/opendatahub-operator)
       - blank
       - dot

--- a/Makefile
+++ b/Makefile
@@ -243,7 +243,7 @@ $(CONTROLLER_GEN): $(LOCALBIN)
 	test -s $(CONTROLLER_GEN) || GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-tools/cmd/controller-gen@$(CONTROLLER_GEN_VERSION)
 
 .PHONY: yq
-yq: $(YQ) ## Download controller-gen locally if necessary.
+yq: $(YQ) ## Download yq locally if necessary.
 $(YQ): $(LOCALBIN)
 	test -s $(YQ) || GOBIN=$(LOCALBIN) go install github.com/mikefarah/yq/v4@$(YQ_VERSION)
 

--- a/Makefile
+++ b/Makefile
@@ -152,7 +152,7 @@ fmt: golangci-lint yq ## Formats code and imports.
 	go fmt ./...
 	$(YQ) e '.linters = {"disable-all": true, "enable": ["gci"]}' .golangci.yml  > $(GOLANGCI_TMP_FILE)
 	$(GOLANGCI_LINT) run --config=$(GOLANGCI_TMP_FILE) --fix
-CLEANFILES += ${GOLANGCI_TMP_FILE}
+CLEANFILES += $(GOLANGCI_TMP_FILE)
 
 .PHONY: vet
 vet: ## Run go vet against code.

--- a/Makefile
+++ b/Makefile
@@ -62,11 +62,13 @@ ENVTEST ?= $(LOCALBIN)/setup-envtest
 OPERATOR_SDK ?= $(LOCALBIN)/operator-sdk
 GOLANGCI_LINT ?= $(LOCALBIN)/golangci-lint
 CRD_REF_DOCS ?= $(LOCALBIN)/crd-ref-docs
+YQ ?= $(LOCALBIN)/yq
 ## Tool Versions
 KUSTOMIZE_VERSION ?= v3.8.7
 CONTROLLER_GEN_VERSION ?= v0.9.2
 OPERATOR_SDK_VERSION ?= v1.24.1
 GOLANGCI_LINT_VERSION ?= v1.54.0
+YQ_VERSION ?= v4.12.2
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.24.2
 CRD_REF_DOCS_VERSION = 0.0.11
@@ -144,9 +146,13 @@ manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and Cust
 generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.
 	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."
 
+GOLANGCI_TMP_FILE = .golangci.mktmp.yml
 .PHONY: fmt
-fmt: ## Run go fmt against code.
+fmt: golangci-lint yq ## Run go fmt against code.
 	go fmt ./...
+	$(YQ) e '.linters = {"disable-all": true, "enable": ["gci"]}' .golangci.yml  > $(GOLANGCI_TMP_FILE)
+	$(GOLANGCI_LINT) run --config=$(GOLANGCI_TMP_FILE) --fix
+CLEANFILES += ${GOLANGCI_TMP_FILE}
 
 .PHONY: vet
 vet: ## Run go vet against code.
@@ -235,6 +241,11 @@ $(KUSTOMIZE): $(LOCALBIN)
 controller-gen: $(CONTROLLER_GEN) ## Download controller-gen locally if necessary.
 $(CONTROLLER_GEN): $(LOCALBIN)
 	test -s $(CONTROLLER_GEN) || GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-tools/cmd/controller-gen@$(CONTROLLER_GEN_VERSION)
+
+.PHONY: yq
+yq: $(YQ) ## Download controller-gen locally if necessary.
+$(YQ): $(LOCALBIN)
+	test -s $(YQ) || GOBIN=$(LOCALBIN) go install github.com/mikefarah/yq/v4@$(YQ_VERSION)
 
 OPERATOR_SDK_DL_URL ?= https://github.com/operator-framework/operator-sdk/releases/download/$(OPERATOR_SDK_VERSION)
 .PHONY: operator-sdk

--- a/Makefile
+++ b/Makefile
@@ -148,7 +148,7 @@ generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and
 
 GOLANGCI_TMP_FILE = .golangci.mktmp.yml
 .PHONY: fmt
-fmt: golangci-lint yq ## Run go fmt against code.
+fmt: golangci-lint yq ## Formats code and imports.
 	go fmt ./...
 	$(YQ) e '.linters = {"disable-all": true, "enable": ["gci"]}' .golangci.yml  > $(GOLANGCI_TMP_FILE)
 	$(GOLANGCI_LINT) run --config=$(GOLANGCI_TMP_FILE) --fix


### PR DESCRIPTION
This update incorporates the `gci` tool into the `make fmt` command, aiming to improve the formatting of Go files and ensure that imports adhere to our established conventions.

Unfortunately, due to how `.golangci.yml` is defined, we are not able to just use `--disable-all --enable=gci` flags. This yields an error as we use `enable-all` and `disable` in the config file for linter.

To address this, the `golangci-lint` configuration is dynamically adjusted using the `yq` tool, which is now included in our toolchain.

This process creates a temporary configuration file specifically for `golangci-lint` execution, ensuring `gci`'s integration without altering the primary linting setup.

Furthermore, the generated temporary file is added to the `CLEANFILES` list, ensuring its removal when calling `make clean`, maintaining a clean build environment.

To prevent this temporary file from being tracked by Git, a `*.mktmp.*` pattern has been added to our `.gitignore`, safeguarding against accidental inclusion of temporary files in the repository.