### PR TITLE
(fix): Description patch during make bundle

### DIFF
--- a/config/manifests/kustomization.yaml
+++ b/config/manifests/kustomization.yaml
@@ -15,7 +15,6 @@ patches:
   target:
     group: operators.coreos.com
     kind: ClusterServiceVersion
-    name: opendatahub-operator.v0.0.0
 
 # [WEBHOOK] To enable webhooks, uncomment all the sections with [WEBHOOK] prefix.
 # Do NOT uncomment sections with prefix [CERTMANAGER], as OLM does not support cert-manager.


### PR DESCRIPTION
Fix description patch

## Description
While running `make bundle` command, it automatically updates the csv in `bundle/manifests`. Because of the `name` the patch did not apply and it got replaced to `This will be replaced by Kustomize`. This PR fixes that issue.
## How Has This Been Tested?
Run `make bundle` command and see that the description does not change.

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
