### PR TITLE
chore: Small Makefile fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ IMAGE_TAG_BASE ?= quay.io/opendatahub/opendatahub-operator
 # keep the name based on IMG which already used from command line
 IMG_TAG ?= latest
 # Update IMG to a variable, to keep it consistent across versions for OpenShift CI
-IMG = $(IMAGE_TAG_BASE):$(IMG_TAG)
+IMG ?= $(IMAGE_TAG_BASE):$(IMG_TAG)
 # BUNDLE_IMG defines the image:tag used for the bundle.
 # You can use it as an arg. (E.g make bundle-build BUNDLE_IMG=<some-registry>/<project-name-bundle>:<tag>)
 BUNDLE_IMG ?= $(IMAGE_TAG_BASE)-bundle:v$(VERSION)
@@ -222,7 +222,7 @@ deploy: prepare ## Deploy controller to the K8s cluster specified in ~/.kube/con
 	$(KUSTOMIZE) build config/default | kubectl apply --namespace $(OPERATOR_NAMESPACE) -f -
 
 .PHONY: undeploy
-undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
+undeploy: prepare ## Undeploy controller from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
 	$(KUSTOMIZE) build config/default | kubectl delete --ignore-not-found=$(ignore-not-found) -f -
 
 ## Location to install dependencies to


### PR DESCRIPTION
## Description

* Go back to using `IMG ?=` rather than forcing the value with `IMG =`. This makes it easier to override the value of `IMG` for development, and also aligns it to how `BUNDLE_IMG` is assigned.
* Add `prepare` as dependency of the `undeploy` target. This is just for convenience, although when looking at the other targets, `prepare` may simply be a missing dependency in `undeploy`.

## How Has This Been Tested?
Using the Makefile :-)

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
