### PR TITLE
fix(test): pin version not latest which just introduced to use go 1.22

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,6 +71,7 @@ GOLANGCI_LINT_VERSION ?= v1.54.0
 YQ_VERSION ?= v4.12.2
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.24.2
+ENVTEST_PACKAGE_VERSION = v0.0.0-20240320141353-395cfc7486e6
 CRD_REF_DOCS_VERSION = 0.0.11
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
@@ -350,7 +351,7 @@ TEST_SRC=./controllers/... ./tests/integration/... ./pkg/...
 .PHONY: envtest
 envtest: $(ENVTEST) ## Download envtest-setup locally if necessary.
 $(ENVTEST): $(LOCALBIN)
-	test -s $(LOCALBIN)/setup-envtest || GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@v0.0.0-20240320141353-395cfc7486e6
+	test -s $(LOCALBIN)/setup-envtest || GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@$(ENVTEST_PACKAGE_VERSION)
 
 .PHONY: test
 test: unit-test e2e-test

--- a/Makefile
+++ b/Makefile
@@ -351,7 +351,7 @@ TEST_SRC=./controllers/... ./tests/integration/... ./pkg/...
 .PHONY: envtest
 envtest: $(ENVTEST) ## Download envtest-setup locally if necessary.
 $(ENVTEST): $(LOCALBIN)
-	test -s $(LOCALBIN)/setup-envtest || GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@$(ENVTEST_PACKAGE_VERSION)
+	test -s $(ENVTEST) || GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@$(ENVTEST_PACKAGE_VERSION)
 
 .PHONY: test
 test: unit-test e2e-test

--- a/Makefile
+++ b/Makefile
@@ -350,7 +350,7 @@ TEST_SRC=./controllers/... ./tests/integration/... ./pkg/...
 .PHONY: envtest
 envtest: $(ENVTEST) ## Download envtest-setup locally if necessary.
 $(ENVTEST): $(LOCALBIN)
-	test -s $(LOCALBIN)/setup-envtest || GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
+	test -s $(LOCALBIN)/setup-envtest || GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@v0.0.0-20240320141353-395cfc7486e6
 
 .PHONY: test
 test: unit-test e2e-test


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

GH unit-test failing with error:
```
mkdir -p /home/runner/work/opendatahub-operator/opendatahub-operator/bin
test -s /home/runner/work/opendatahub-operator/opendatahub-operator/bin/setup-envtest || GOBIN=/home/runner/work/opendatahub-operator/opendatahub-operator/bin go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
go: downloading sigs.k8s.io/controller-runtime/tools/setup-envtest v0.0.0-2024032210[5](https://github.com/opendatahub-io/opendatahub-operator/actions/runs/8390354373/job/22978408816?pr=933#step:4:6)421-affb9[6](https://github.com/opendatahub-io/opendatahub-operator/actions/runs/8390354373/job/22978408816?pr=933#step:4:7)[7](https://github.com/opendatahub-io/opendatahub-operator/actions/runs/8390354373/job/22978408816?pr=933#step:4:8)08000
go: downloading sigs.k8s.io/controller-runtime v0.17.2
go: sigs.k[8](https://github.com/opendatahub-io/opendatahub-operator/actions/runs/8390354373/job/22978408816?pr=933#step:4:9)s.io/controller-runtime/tools/setup-envtest@latest (in sigs.k8s.io/controller-runtime/tools/setup-envtest@v0.0.0-20240322105421-affb[9](https://github.com/opendatahub-io/opendatahub-operator/actions/runs/8390354373/job/22978408816?pr=933#step:4:10)6708000): go.mod:3: invalid go version '1.22.0': must match format 1.23
make: *** [Makefile:353: /home/runner/work/opendatahub-operator/opendatahub-operator/bin/setup-envtest] Error 1
```

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
