### PR TITLE
chore: remove kustomizationManifest + tests

### DIFF
--- a/pkg/feature/manifest_test.go
+++ b/pkg/feature/manifest_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/spf13/afero"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"sigs.k8s.io/kustomize/kyaml/filesys"
 
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/feature"
 
@@ -28,9 +27,8 @@ func (a AferoFsAdapter) Open(name string) (fs.File, error) {
 
 var _ = Describe("Manifest Processing", func() {
 	var (
-		inMemFS  AferoFsAdapter
-		path     string
-		kustFsys filesys.FileSystem
+		inMemFS AferoFsAdapter
+		path    string
 	)
 
 	BeforeEach(func() {
@@ -128,47 +126,6 @@ data:
 
 	})
 
-	Describe("Kustomize Manifest Processing", func() {
-		BeforeEach(func() {
-			path = "/path/to/kustomization/" // base path here
-			kustFsys = filesys.MakeFsInMemory()
-		})
-
-		It("should process the ConfigMap resource from the kustomize manifest", func() {
-			// given
-			kustomizationYaml := `
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
-resources:
-- resource.yaml
-`
-			resourceYaml := `
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: my-configmap
-data:
-  key: value
-`
-			data := feature.Spec{
-				TargetNamespace: "kust-ns",
-			}
-
-			Expect(kustFsys.WriteFile(filepath.Join(path, "kustomization.yaml"), []byte(kustomizationYaml))).To(Succeed())
-			Expect(kustFsys.WriteFile(filepath.Join(path, "resource.yaml"), []byte(resourceYaml))).To(Succeed())
-			manifest := feature.CreateKustomizeManifestFrom("/path/to/kustomization/", kustFsys)
-
-			// when
-			manifests := []feature.Manifest{manifest}
-			objs := processManifests(data, manifests)
-
-			// then
-			Expect(objs).To(HaveLen(1))
-			configMap := objs[0]
-			Expect(configMap.GetKind()).To(Equal("ConfigMap"))
-			Expect(configMap.GetName()).To(Equal("my-configmap"))
-		})
-	})
 })
 
 func processManifests(data feature.Spec, m []feature.Manifest) []*unstructured.Unstructured {

--- a/tests/integration/features/manifests_int_test.go
+++ b/tests/integration/features/manifests_int_test.go
@@ -149,28 +149,4 @@ metadata:
 		Expect(realNs.Name).To(Equal("real-file-test-ns"))
 	})
 
-	It("should process kustomization manifests directly from the file system", func() {
-		// given
-		featuresHandler := feature.ClusterFeaturesHandler(dsci, func(handler *feature.FeaturesHandler) error {
-			createCfgMapErr := feature.CreateFeature("create-cfg-map").
-				For(handler).
-				UsingConfig(envTest.Config).
-				Manifests(path.Join("fixtures", feature.BaseDir, "fake-kust-dir")).
-				Load()
-
-			Expect(createCfgMapErr).ToNot(HaveOccurred())
-
-			return nil
-		})
-
-		// when
-		Expect(featuresHandler.Apply()).To(Succeed())
-
-		// then
-		cfgMap, err := fixtures.GetConfigMap(envTestClient, featuresHandler.ApplicationsNamespace, "my-configmap")
-		Expect(err).ToNot(HaveOccurred())
-		Expect(cfgMap.Name).To(Equal("my-configmap"))
-		Expect(cfgMap.Data["key"]).To(Equal("value"))
-	})
-
 })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This PR removes (for now) `KustomizationManifest`. Reason being this comment from review of #932 

```
In a retrospect, I think making it available right now might be a bit premature. We do not have the whole thing in parity with deploy.go (especially in terms of feature create/update/remove path from the reconcile perspective). At the time we start looking at how to unify the approach we can bring this code back.
```

Note that removing this should be temporary, as Kustomize support with `Feature` should at some point be fully fleshed out. 

Note:  this is not yet used anywhere in the codebase, removing it is safe. 
