### PR TITLE
dead code

### DIFF
--- a/controllers/status/status.go
+++ b/controllers/status/status.go
@@ -60,8 +60,6 @@ const (
 	ReconcileCompleted                    = "ReconcileCompleted"
 	ReconcileCompletedWithComponentErrors = "ReconcileCompletedWithComponentErrors"
 	ReconcileCompletedMessage             = "Reconcile completed successfully"
-	DuplicateDataScienceCluster           = "DuplicateDataScienceCluster"
-	DuplicateDSCInitialization            = "DuplicateDSCInitialization"
 
 	// ConditionReconcileComplete represents extra Condition Type, used by .Condition.Type.
 	ConditionReconcileComplete conditionsv1.ConditionType = "ReconcileComplete"


### PR DESCRIPTION
- **Fix cleanup of ODHApplications (#914)**
  

- **chore: moves config map creation logic from Feature pkg (#909)**
  #### Refactors cluster resource creation funcs
  
  Cleans up the structure of the resource creation logic by:
    
    - adding CreateConfigMap func to be used in service-mesh refs logic
    - moving MetaOption and related object "decorators" to a single place (`meta.go`)
    - introducing `WithOwnerReference` decorator
    - opening up secret creation function for optional meta decorators
  
  #### Splits service mesh-related config map creation
  
  In addition, it reuses the generic purpose `CreateConfigMap` func introduced as part of this PR.
  
  #### Adds config map creation test
  
  and moves the suite to the package.
    

- **feat(tmpl): fails when key does not exist (#916)**
  The templates used in Feature SDK are not intended (at least right now) to provide conditional rendering like in Helm. Thus we should fail fast if the Feature's underlying map does not provide the key referred to in a template. 
  
  This is achieved by passing the parsing option (missingkey=error) to built-in Golang templating.
  
  > [!NOTE]
  > This works out of the box with `struct`s but we should also fail when dealing with `map`s.

- **chore(deps): bump google.golang.org/protobuf from 1.31.0 to 1.33.0 (#918)**
  Bumps google.golang.org/protobuf from 1.31.0 to 1.33.0.
  
  ---
  updated-dependencies:
  - dependency-name: google.golang.org/protobuf
    dependency-type: indirect
  ...
  
  Signed-off-by: dependabot[bot] <support@github.com>
  Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>

- **feat(gh-action): ensures generated files are up-to-date in PR (#917)**
  * RHOAIENG-4433 Update readme/config files
  
  * rework gh action based on comments
  
  * feat(gh-action): ensures generated files are up-to-date in PR
  
  * fix review comments
  
  * reuse cmd

- **fix(gen): upgrades to crd-ref-doc generator to latest version (#920)**
  fix(gen): upgrades to crd-ref-doc to latest version
  
  - add "diff" in the failed GH action to help understand problem
  - update: api doc
  
  ---------
  
  Signed-off-by: Wen Zhou <wenzhou@redhat.com>
  

- **fix: Enable annotations using golangci-lint(gh action) (#919)**
  * fix: Enable annotations using golangci-lint(gh action)
  
  * update versions

- **chore: move testing fixtures to fixtures directory (#906)**
  This change aims to enhance the readability of our test suite. 
  
  It brings `/crds` and `/templates` into `/fixtures` and moves more helper functions out into dedicated files.
  

- **fix(make): cleans linter cache on clean (#922)**
  When juggling between branches golangci linter cache can have leftovers from the code that does not exist in the other branch.
  
  This can lead to errors while running `make lint` as the linter tries to check cached sources first.
  
  This change cleans the linter cache as part of the clean target to ensure consistency.
  
  Here's an example of an invalid cache state leading to error:
  
  ```
  WARN [runner] Can't process result by autogenerated_exclude processor: can't filter issue result.Issue{FromLinter:"ireturn", Text:"Entry returns interface (github.com/opendatahub-io/opendatahub-operator/v2/pkg/feature.DataProvider)", Severity:"", SourceLines:[]string(nil), Replacement:(*result.Replacement)(nil), Pkg:(*packages.Package)(0xc001343e00), LineRange:(*result.Range)(nil), Pos:token.Position{Filename:"/home/bartek/code/rhods/opendatahub-operator/incubation/pkg/feature/data_provider.go", Offset:1382, Line:45, Column:1}, HunkPos:0, ExpectNoLint:false, ExpectedNoLintLinter:""}: failed to get doc of file
  ```

- **feat(build): adds gci to go fmt target (#925)**
  This update incorporates the `gci` tool into the `make fmt` command, aiming to improve the formatting of Go files and ensure that imports adhere to our established conventions.
  
  Unfortunately, due to how `.golangci.yml` is defined, we are not able to just use `--disable-all --enable=gci` flags. This yields an error as we use `enable-all` and `disable` in the config file for linter.
  
  To address this, the `golangci-lint` configuration is dynamically adjusted using the `yq` tool, which is now included in our toolchain.
  
  This process creates a temporary configuration file specifically for `golangci-lint` execution, ensuring `gci`'s integration without altering the primary linting setup.
  
  Furthermore, the generated temporary file is added to the `CLEANFILES` list, ensuring its removal when calling `make clean`, maintaining a clean build environment.
  
  To prevent this temporary file from being tracked by Git, a `*.mktmp.*` pattern has been added to our `.gitignore`, safeguarding against accidental inclusion of temporary files in the repository.: 
  
  ### Tidies
  
  - removes duplicate `blank` import section in `gci` config, otherwise it can add `_` imports twice

- **chore(Github): update issue template re-direct user for jira (#838)**
  * chore(Github): update issue template re-direct user for jira
  
  Signed-off-by: Wen Zhou <wenzhou@redhat.com>
  
  * Update .github/ISSUE_TEMPLATE/feature_request.md
  
  Co-authored-by: Ajay Jaganathan <36824134+AjayJagan@users.noreply.github.com>
  
  * Update .github/ISSUE_TEMPLATE/bug_report.md
  
  Co-authored-by: Ajay Jaganathan <36824134+AjayJagan@users.noreply.github.com>
  
  ---------
  
  Signed-off-by: Wen Zhou <wenzhou@redhat.com>
  Co-authored-by: Ajay Jaganathan <36824134+AjayJagan@users.noreply.github.com>

- **chore: splits feature tests to separate files (#924)**
  As the number of test cases (grouped as `Describe`) started to grow, we can split a single file into several groups per functionality.
  
  Follow-up for #906.

- **fix(dashboard): do not set owner on CR (#923)**
  Signed-off-by: Wen Zhou <wenzhou@redhat.com>

- **(fix): Description patch during make bundle (#926)**
  

- **chore: Small Makefile fixes (#928)**
  * Go back to using `IMG ?=` rather than forcing the value with `IMG =`. This makes it easier to override the value of `IMG` for development, and it also aligns it to how `BUNDLE_IMG` is assigned.
  * Add `prepare` as dependency of the `undeploy` target. This is just for convenience, although when looking at the other targets, `prepare` may simply be a missing dependency in `undeploy`.
  
  Signed-off-by: Edgar Hernández <23639005+israel-hdez@users.noreply.github.com>

- **feat(DW): prepare CF,ray,kueue for GA (#929)**
  Signed-off-by: Wen Zhou <wenzhou@redhat.com>

- **fix(test): pin version not latest which just introduced to use go 1.22 (#934)**
  * fix(test): pin version not latest which just introduced to use go 1.22
  
  Signed-off-by: Wen Zhou <wenzhou@redhat.com>
  
  * update: code review
  
  Signed-off-by: Wen Zhou <wenzhou@redhat.com>
  
  ---------
  
  Signed-off-by: Wen Zhou <wenzhou@redhat.com>

- **fix(dashboard): wrong path for consolelink in downstream (#933)**
  Signed-off-by: Wen Zhou <wenzhou@redhat.com>

- **chore: removes unused statuses**
  after introducing validating webhook these are not needed anymore.
  