### PR TITLE
fix(dashboard): add app for ODH base to deploy

### DIFF
--- a/components/dashboard/dashboard.go
+++ b/components/dashboard/dashboard.go
@@ -27,6 +27,7 @@ import (
 var (
 	ComponentName    = "dashboard"
 	Path             = deploy.DefaultManifestPath + "/" + ComponentName + "/base"         // ODH
+	PathISV          = deploy.DefaultManifestPath + "/" + ComponentName + "/apps"         // ODH APPS
 	PathModelServing = deploy.DefaultManifestPath + "/" + ComponentName + "/modelserving" // ODH modelserving
 	PathCRDs         = deploy.DefaultManifestPath + "/" + ComponentName + "/crd"          // ODH + RHOAI
 	PathConsoleLink  = deploy.DefaultManifestPath + "/" + ComponentName + "/consolelink"  // ODH consolelink
@@ -190,6 +191,10 @@ func (d *Dashboard) ReconcileComponent(ctx context.Context,
 	default:
 		// base
 		if err = deploy.DeployManifestsFromPath(cli, owner, Path, dscispec.ApplicationsNamespace, ComponentName, enabled); err != nil {
+			return err
+		}
+		// ISV
+		if err = deploy.DeployManifestsFromPath(cli, owner, PathISV, dscispec.ApplicationsNamespace, ComponentName, enabled); err != nil {
 			return err
 		}
 		// modelserving


### PR DESCRIPTION
- jupyter-install-python-packages jupyter-update-server-settings jupyter-use-s3-bucket-data jupyter-view-installed-packages  OdhDocument
- jupyter OdhApplication
- deploy-python-model and create-jupyter-notebook OdhQuickStart

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
to fix odh-nightly build with missing default resource
https://redhat-internal.slack.com/archives/C05NXTEHLGY/p1711380633005149 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
