### PR TITLE
Changed ODH/Kuberay to point to dev branch

### DIFF
--- a/get_all_manifests.sh
+++ b/get_all_manifests.sh
@@ -7,7 +7,7 @@ GITHUB_URL="https://github.com/"
 # in the format of "repo-org:repo-name:branch-name:source-folder:target-folder".
 declare -A COMPONENT_MANIFESTS=(
     ["codeflare"]="opendatahub-io:codeflare-operator:main:config:codeflare"
-    ["ray"]="opendatahub-io:kuberay:master:ray-operator/config:ray"
+    ["ray"]="opendatahub-io:kuberay:dev:ray-operator/config:ray"
     ["kueue"]="opendatahub-io:kueue:dev:config:kueue"
     ["data-science-pipelines-operator"]="opendatahub-io:data-science-pipelines-operator:main:config:data-science-pipelines-operator"
     ["odh-dashboard"]="opendatahub-io:odh-dashboard:incubation:manifests:dashboard"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
With the addition of the `dev` [branch](https://github.com/opendatahub-io/kuberay/tree/dev) introduced in ODH/Kuberay we need the ODH Operator to point to it.
## Description
<!--- Describe your changes in detail -->
Changed `master` to `dev` for Ray in `get_all_manifests.sh`
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Run the `get_all_manifests.sh` script and the KubeRay manifsts should be cloned in the odh-manifests folder. 
## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
