### PR TITLE
fix: properly updates config map

### DIFF
--- a/pkg/cluster/cluster_operations_int_test.go
+++ b/pkg/cluster/cluster_operations_int_test.go
@@ -137,7 +137,7 @@ var _ = Describe("Creating cluster resources", func() {
 				"default",
 				map[string]string{
 					"test-key": "new-value",
-					"new-key": "sth-new",
+					"new-key":  "sth-new",
 				},
 			)
 			Expect(err).ToNot(HaveOccurred())
@@ -146,7 +146,7 @@ var _ = Describe("Creating cluster resources", func() {
 			// then
 			Expect(updatedConfigMap.Data).To(HaveKeyWithValue("test-key", "new-value"))
 			Expect(updatedConfigMap.Data).To(HaveKeyWithValue("new-key", "sth-new"))
-			
+
 		})
 	})
 

--- a/pkg/cluster/cluster_operations_int_test.go
+++ b/pkg/cluster/cluster_operations_int_test.go
@@ -93,7 +93,7 @@ var _ = Describe("Creating cluster resources", func() {
 			}
 
 			// when
-			configMap, err := cluster.CreateConfigMap(
+			configMap, err := cluster.CreateOrUpdateConfigMap(
 				envTestClient,
 				"config-regs",
 				"default",
@@ -115,6 +115,38 @@ var _ = Describe("Creating cluster resources", func() {
 				return reference.Name
 			}
 			Expect(configMap.OwnerReferences[0]).To(WithTransform(getOwnerRefName, Equal("default")))
+		})
+
+		It("should be able to update existing config map", func() {
+			// given
+			data := map[string]string{
+				"test-key": "test-value",
+			}
+
+			// when
+			configMap, err := cluster.CreateOrUpdateConfigMap(
+				envTestClient,
+				"config-regs",
+				"default",
+				data,
+			)
+			Expect(err).ToNot(HaveOccurred())
+			updatedConfigMap, err := cluster.CreateOrUpdateConfigMap(
+				envTestClient,
+				"config-regs",
+				"default",
+				map[string]string{
+					"test-key": "new-value",
+					"new-key": "sth-new",
+				},
+			)
+			Expect(err).ToNot(HaveOccurred())
+			defer objectCleaner.DeleteAll(configMap)
+
+			// then
+			Expect(updatedConfigMap.Data).To(HaveKeyWithValue("test-key", "new-value"))
+			Expect(updatedConfigMap.Data).To(HaveKeyWithValue("new-key", "sth-new"))
+			
 		})
 	})
 

--- a/pkg/cluster/resources.go
+++ b/pkg/cluster/resources.go
@@ -92,12 +92,11 @@ func CreateOrUpdateConfigMap(c client.Client, name string, namespace string, dat
 		return nil, err
 	}
 
-
 	getErr := c.Get(context.TODO(), client.ObjectKey{
 		Name:      name,
 		Namespace: namespace,
 	}, configMap)
-	
+
 	if getErr != nil {
 		if apierrs.IsNotFound(getErr) {
 			if err := c.Create(context.TODO(), configMap); err != nil {

--- a/pkg/feature/servicemesh/resources.go
+++ b/pkg/feature/servicemesh/resources.go
@@ -43,7 +43,7 @@ func AuthRefs(f *feature.Feature) error {
 		"AUTH_PROVIDER":   namespace + "-auth-provider",
 		"AUTHORINO_LABEL": "security.opendatahub.io/authorization-group=default",
 	}
-	
+
 	_, err := cluster.CreateOrUpdateConfigMap(
 		f.Client,
 		"auth-refs",

--- a/pkg/feature/servicemesh/resources.go
+++ b/pkg/feature/servicemesh/resources.go
@@ -18,7 +18,7 @@ func MeshRefs(f *feature.Feature) error {
 		"MESH_NAMESPACE":     meshConfig.Namespace,
 	}
 
-	_, err := cluster.CreateConfigMap(
+	_, err := cluster.CreateOrUpdateConfigMap(
 		f.Client,
 		"service-mesh-refs",
 		namespace,
@@ -34,7 +34,6 @@ func MeshRefs(f *feature.Feature) error {
 func AuthRefs(f *feature.Feature) error {
 	audiences := f.Spec.Auth.Audiences
 	namespace := f.Spec.AppNamespace
-
 	audiencesList := ""
 	if audiences != nil && len(*audiences) > 0 {
 		audiencesList = strings.Join(*audiences, ",")
@@ -44,8 +43,8 @@ func AuthRefs(f *feature.Feature) error {
 		"AUTH_PROVIDER":   namespace + "-auth-provider",
 		"AUTHORINO_LABEL": "security.opendatahub.io/authorization-group=default",
 	}
-
-	_, err := cluster.CreateConfigMap(
+	
+	_, err := cluster.CreateOrUpdateConfigMap(
 		f.Client,
 		"auth-refs",
 		namespace,


### PR DESCRIPTION
## Description

Previously the desired configmap state was overwritten by existing version fetched using `client.Get`.

This bug resulted in configuration not being propagated to configs maps which are created to share configuration with other controllers residing in the application namespace.

## How Has This Been Tested?

Includes test which fails without the patched function.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
