### PR TITLE
feat(authz): conditionally enables authorization capability

### DIFF
--- a/components/kserve/kserve.go
+++ b/components/kserve/kserve.go
@@ -183,13 +183,13 @@ func (k *Kserve) ReconcileComponent(ctx context.Context, cli client.Client,
 		l.Info("updating SRE monitoring done")
 	}
 
-	return k.configureServiceMesh(dscispec)
+	return k.configureServiceMesh(cli, dscispec)
 }
 
-func (k *Kserve) Cleanup(_ client.Client, instance *dsciv1.DSCInitializationSpec) error {
+func (k *Kserve) Cleanup(cli client.Client, instance *dsciv1.DSCInitializationSpec) error {
 	if removeServerlessErr := k.removeServerlessFeatures(instance); removeServerlessErr != nil {
 		return removeServerlessErr
 	}
 
-	return k.removeServiceMeshConfigurations(instance)
+	return k.removeServiceMeshConfigurations(cli, instance)
 }

--- a/components/kserve/servicemesh_setup.go
+++ b/components/kserve/servicemesh_setup.go
@@ -1,47 +1,59 @@
 package kserve
 
 import (
+	"fmt"
 	"path"
 
 	operatorv1 "github.com/openshift/api/operator/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	dsciv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/dscinitialization/v1"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/deploy"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/feature"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/feature/servicemesh"
 )
 
-func (k *Kserve) configureServiceMesh(dscispec *dsciv1.DSCInitializationSpec) error {
+func (k *Kserve) configureServiceMesh(c client.Client, dscispec *dsciv1.DSCInitializationSpec) error {
 	if dscispec.ServiceMesh.ManagementState == operatorv1.Managed && k.GetManagementState() == operatorv1.Managed {
-		serviceMeshInitializer := feature.ComponentFeaturesHandler(k.GetComponentName(), dscispec, k.defineServiceMeshFeatures())
+		serviceMeshInitializer := feature.ComponentFeaturesHandler(k.GetComponentName(), dscispec, k.defineServiceMeshFeatures(c))
 		return serviceMeshInitializer.Apply()
 	}
 	if dscispec.ServiceMesh.ManagementState == operatorv1.Unmanaged && k.GetManagementState() == operatorv1.Managed {
 		return nil
 	}
 
-	return k.removeServiceMeshConfigurations(dscispec)
+	return k.removeServiceMeshConfigurations(c, dscispec)
 }
 
-func (k *Kserve) removeServiceMeshConfigurations(dscispec *dsciv1.DSCInitializationSpec) error {
-	serviceMeshInitializer := feature.ComponentFeaturesHandler(k.GetComponentName(), dscispec, k.defineServiceMeshFeatures())
+func (k *Kserve) removeServiceMeshConfigurations(cli client.Client, dscispec *dsciv1.DSCInitializationSpec) error {
+	serviceMeshInitializer := feature.ComponentFeaturesHandler(k.GetComponentName(), dscispec, k.defineServiceMeshFeatures(cli))
 	return serviceMeshInitializer.Delete()
 }
 
-func (k *Kserve) defineServiceMeshFeatures() feature.FeaturesProvider {
+func (k *Kserve) defineServiceMeshFeatures(cli client.Client) feature.FeaturesProvider {
 	return func(handler *feature.FeaturesHandler) error {
-		kserveExtAuthzErr := feature.CreateFeature("kserve-external-authz").
-			For(handler).
-			Manifests(
-				path.Join(feature.KServeDir, "activator-envoyfilter.tmpl"),
-				path.Join(feature.KServeDir, "envoy-oauth-temp-fix.tmpl"),
-				path.Join(feature.KServeDir, "kserve-predictor-authorizationpolicy.tmpl"),
-				path.Join(feature.KServeDir, "z-migrations"),
-			).
-			WithData(servicemesh.ClusterDetails).
-			Load()
+		authorinoInstalled, err := deploy.ClusterSubscriptionExists(cli, "authorino-operator")
+		if err != nil {
+			return fmt.Errorf("failed to list subscriptions %w", err)
+		}
 
-		if kserveExtAuthzErr != nil {
-			return kserveExtAuthzErr
+		if authorinoInstalled {
+			kserveExtAuthzErr := feature.CreateFeature("kserve-external-authz").
+				For(handler).
+				Manifests(
+					path.Join(feature.KServeDir, "activator-envoyfilter.tmpl"),
+					path.Join(feature.KServeDir, "envoy-oauth-temp-fix.tmpl"),
+					path.Join(feature.KServeDir, "kserve-predictor-authorizationpolicy.tmpl"),
+					path.Join(feature.KServeDir, "z-migrations"),
+				).
+				WithData(servicemesh.ClusterDetails).
+				Load()
+
+			if kserveExtAuthzErr != nil {
+				return kserveExtAuthzErr
+			}
+		} else {
+			fmt.Printf("WARN: Authorino operator is not installed on the cluster, skipping authorization capability\n")
 		}
 
 		temporaryFixesErr := feature.CreateFeature("kserve-temporary-fixes").

--- a/components/kserve/servicemesh_setup.go
+++ b/components/kserve/servicemesh_setup.go
@@ -53,7 +53,7 @@ func (k *Kserve) defineServiceMeshFeatures(cli client.Client) feature.FeaturesPr
 				return kserveExtAuthzErr
 			}
 		} else {
-			fmt.Printf("WARN: Authorino operator is not installed on the cluster, skipping authorization capability\n")
+			fmt.Println("WARN: Authorino operator is not installed on the cluster, skipping authorization capability")
 		}
 
 		temporaryFixesErr := feature.CreateFeature("kserve-temporary-fixes").

--- a/controllers/datasciencecluster/datasciencecluster_controller.go
+++ b/controllers/datasciencecluster/datasciencecluster_controller.go
@@ -37,7 +37,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
-	"k8s.io/client-go/util/retry"
 	apiregistrationv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -150,7 +149,7 @@ func (r *DataScienceClusterReconciler) Reconcile(ctx context.Context, req ctrl.R
 		reason := status.ReconcileFailed
 		message := "Failed to get a valid DSCInitialization instance, please create a DSCI instance"
 		r.Log.Info(message)
-		instance, err = r.updateStatus(ctx, instance, func(saved *dsc.DataScienceCluster) {
+		instance, err = status.UpdateWithRetry(ctx, r.Client, instance, func(saved *dsc.DataScienceCluster) {
 			status.SetProgressingCondition(&saved.Status.Conditions, reason, message)
 			saved.Status.Phase = status.PhaseError
 		})
@@ -198,7 +197,7 @@ func (r *DataScienceClusterReconciler) Reconcile(ctx context.Context, req ctrl.R
 	if instance.Status.Conditions == nil {
 		reason := status.ReconcileInit
 		message := "Initializing DataScienceCluster resource"
-		instance, err = r.updateStatus(ctx, instance, func(saved *dsc.DataScienceCluster) {
+		instance, err = status.UpdateWithRetry(ctx, r.Client, instance, func(saved *dsc.DataScienceCluster) {
 			status.SetProgressingCondition(&saved.Status.Conditions, reason, message)
 			saved.Status.Phase = status.PhaseProgressing
 		})
@@ -221,7 +220,7 @@ func (r *DataScienceClusterReconciler) Reconcile(ctx context.Context, req ctrl.R
 	// Process errors for components
 	if componentErrors != nil {
 		r.Log.Info("DataScienceCluster Deployment Incomplete.")
-		instance, err = r.updateStatus(ctx, instance, func(saved *dsc.DataScienceCluster) {
+		instance, err = status.UpdateWithRetry(ctx, r.Client, instance, func(saved *dsc.DataScienceCluster) {
 			status.SetCompleteCondition(&saved.Status.Conditions, status.ReconcileCompletedWithComponentErrors,
 				fmt.Sprintf("DataScienceCluster resource reconciled with component errors: %v", componentErrors))
 			saved.Status.Phase = status.PhaseReady
@@ -238,7 +237,7 @@ func (r *DataScienceClusterReconciler) Reconcile(ctx context.Context, req ctrl.R
 	}
 
 	// finalize reconciliation
-	instance, err = r.updateStatus(ctx, instance, func(saved *dsc.DataScienceCluster) {
+	instance, err = status.UpdateWithRetry(ctx, r.Client, instance, func(saved *dsc.DataScienceCluster) {
 		status.SetCompleteCondition(&saved.Status.Conditions, status.ReconcileCompleted, "DataScienceCluster resource reconciled successfully")
 		saved.Status.Phase = status.PhaseReady
 	})
@@ -262,7 +261,7 @@ func (r *DataScienceClusterReconciler) reconcileSubComponent(ctx context.Context
 
 	enabled := component.GetManagementState() == v1.Managed
 	// First set conditions to reflect a component is about to be reconciled
-	instance, err := r.updateStatus(ctx, instance, func(saved *dsc.DataScienceCluster) {
+	instance, err := status.UpdateWithRetry(ctx, r.Client, instance, func(saved *dsc.DataScienceCluster) {
 		message := "Component is disabled"
 		if enabled {
 			message = "Component is enabled"
@@ -280,7 +279,7 @@ func (r *DataScienceClusterReconciler) reconcileSubComponent(ctx context.Context
 	if err != nil {
 		// reconciliation failed: log errors, raise event and update status accordingly
 		instance = r.reportError(err, instance, "failed to reconcile "+componentName+" on DataScienceCluster")
-		instance, _ = r.updateStatus(ctx, instance, func(saved *dsc.DataScienceCluster) {
+		instance, _ = status.UpdateWithRetry(ctx, r.Client, instance, func(saved *dsc.DataScienceCluster) {
 			if enabled {
 				status.SetComponentCondition(&saved.Status.Conditions, componentName, status.ReconcileFailed, fmt.Sprintf("Component reconciliation failed: %v", err), corev1.ConditionFalse)
 			} else {
@@ -291,7 +290,7 @@ func (r *DataScienceClusterReconciler) reconcileSubComponent(ctx context.Context
 		return instance, err
 	}
 	// reconciliation succeeded: update status accordingly
-	instance, err = r.updateStatus(ctx, instance, func(saved *dsc.DataScienceCluster) {
+	instance, err = status.UpdateWithRetry(ctx, r.Client, instance, func(saved *dsc.DataScienceCluster) {
 		if saved.Status.InstalledComponents == nil {
 			saved.Status.InstalledComponents = make(map[string]bool)
 		}
@@ -411,28 +410,6 @@ func (r *DataScienceClusterReconciler) SetupWithManager(mgr ctrl.Manager) error 
 		// this predicates prevents meaningless reconciliations from being triggered
 		WithEventFilter(predicate.Or(predicate.GenerationChangedPredicate{}, predicate.LabelChangedPredicate{})).
 		Complete(r)
-}
-
-func (r *DataScienceClusterReconciler) updateStatus(ctx context.Context, original *dsc.DataScienceCluster, update func(saved *dsc.DataScienceCluster),
-) (*dsc.DataScienceCluster, error) {
-	saved := &dsc.DataScienceCluster{}
-	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		err := r.Client.Get(ctx, client.ObjectKeyFromObject(original), saved)
-		if err != nil {
-			return err
-		}
-		// update status here
-		update(saved)
-
-		// Try to update
-		err = r.Client.Status().Update(context.TODO(), saved)
-
-		// Return err itself here (not wrapped inside another error)
-		// so that RetryOnConflict can identify it correctly.
-		return err
-	})
-
-	return saved, err
 }
 
 func (r *DataScienceClusterReconciler) watchDataScienceClusterResources(a client.Object) []reconcile.Request {

--- a/controllers/dscinitialization/capabilities.go
+++ b/controllers/dscinitialization/capabilities.go
@@ -1,0 +1,49 @@
+package dscinitialization
+
+import (
+	"errors"
+
+	conditionsv1 "github.com/openshift/custom-resource-status/conditions/v1"
+	corev1 "k8s.io/api/core/v1"
+
+	dsciv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/dscinitialization/v1"
+	"github.com/opendatahub-io/opendatahub-operator/v2/controllers/status"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/feature"
+)
+
+func serviceMeshCondition(reason, message string) *conditionsv1.Condition {
+	return &conditionsv1.Condition{
+		Type:    status.CapabilityServiceMesh,
+		Status:  corev1.ConditionTrue,
+		Reason:  reason,
+		Message: message,
+	}
+}
+
+func authorizationCondition(reason, message string) *conditionsv1.Condition {
+	return &conditionsv1.Condition{
+		Type:    status.CapabilityServiceMeshAuthorization,
+		Status:  corev1.ConditionTrue,
+		Reason:  reason,
+		Message: message,
+	}
+}
+
+func createCapabilityReporter(condition *conditionsv1.Condition) *status.Reporter[*dsciv1.DSCInitialization] {
+	return status.NewStatusReporter[*dsciv1.DSCInitialization](
+		func(err error) status.SaveStatusFunc[*dsciv1.DSCInitialization] {
+			return func(saved *dsciv1.DSCInitialization) {
+				if err != nil {
+					condition.Status = corev1.ConditionFalse
+					condition.Message = err.Error()
+					condition.Reason = status.CapabilityFailed
+					var missingOperatorErr *feature.MissingOperatorError
+					if errors.As(err, &missingOperatorErr) {
+						condition.Reason = status.MissingOperatorReason
+					}
+				}
+				conditionsv1.SetStatusCondition(&saved.Status.Conditions, *condition)
+			}
+		},
+	)
+}

--- a/controllers/dscinitialization/capabilities.go
+++ b/controllers/dscinitialization/capabilities.go
@@ -5,6 +5,7 @@ import (
 
 	conditionsv1 "github.com/openshift/custom-resource-status/conditions/v1"
 	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	dsciv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/dscinitialization/v1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/controllers/status"
@@ -29,8 +30,10 @@ func authorizationCondition(reason, message string) *conditionsv1.Condition {
 	}
 }
 
-func createCapabilityReporter(condition *conditionsv1.Condition) *status.Reporter[*dsciv1.DSCInitialization] {
+func createCapabilityReporter(cli client.Client, object *dsciv1.DSCInitialization, condition *conditionsv1.Condition) *status.Reporter[*dsciv1.DSCInitialization] {
 	return status.NewStatusReporter[*dsciv1.DSCInitialization](
+		cli,
+		object,
 		func(err error) status.SaveStatusFunc[*dsciv1.DSCInitialization] {
 			return func(saved *dsciv1.DSCInitialization) {
 				if err != nil {

--- a/controllers/dscinitialization/dscinitialization_controller.go
+++ b/controllers/dscinitialization/dscinitialization_controller.go
@@ -32,7 +32,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
-	"k8s.io/client-go/util/retry"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -124,7 +123,7 @@ func (r *DSCInitializationReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	if instance.Status.Conditions == nil {
 		reason := status.ReconcileInit
 		message := "Initializing DSCInitialization resource"
-		instance, err = r.updateStatus(ctx, instance, func(saved *dsciv1.DSCInitialization) {
+		instance, err = status.UpdateWithRetry(ctx, r.Client, instance, func(saved *dsciv1.DSCInitialization) {
 			status.SetProgressingCondition(&saved.Status.Conditions, reason, message)
 			saved.Status.Phase = status.PhaseProgressing
 		})
@@ -204,7 +203,7 @@ func (r *DSCInitializationReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		if instance.Status.Conditions == nil {
 			reason := status.ReconcileInit
 			message := "Initializing DSCInitialization resource"
-			instance, err = r.updateStatus(ctx, instance, func(saved *dsciv1.DSCInitialization) {
+			instance, err = status.UpdateWithRetry(ctx, r.Client, instance, func(saved *dsciv1.DSCInitialization) {
 				status.SetProgressingCondition(&saved.Status.Conditions, reason, message)
 				saved.Status.Phase = status.PhaseProgressing
 			})
@@ -266,7 +265,7 @@ func (r *DSCInitializationReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		}
 
 		// Finish reconciling
-		_, err = r.updateStatus(ctx, instance, func(saved *dsciv1.DSCInitialization) {
+		_, err = status.UpdateWithRetry[*dsciv1.DSCInitialization](ctx, r.Client, instance, func(saved *dsciv1.DSCInitialization) {
 			status.SetCompleteCondition(&saved.Status.Conditions, status.ReconcileCompleted, status.ReconcileCompletedMessage)
 			saved.Status.Phase = status.PhaseReady
 		})
@@ -302,24 +301,6 @@ func (r *DSCInitializationReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Watches(&source.Kind{Type: &corev1.Secret{}}, handler.EnqueueRequestsFromMapFunc(r.watchMonitoringSecretResource), builder.WithPredicates(SecretContentChangedPredicate)).
 		Watches(&source.Kind{Type: &corev1.ConfigMap{}}, handler.EnqueueRequestsFromMapFunc(r.watchMonitoringConfigMapResource), builder.WithPredicates(CMContentChangedPredicate)).
 		Complete(r)
-}
-
-func (r *DSCInitializationReconciler) updateStatus(ctx context.Context, original *dsciv1.DSCInitialization, update func(saved *dsciv1.DSCInitialization),
-) (*dsciv1.DSCInitialization, error) {
-	saved := &dsciv1.DSCInitialization{}
-	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		if err := r.Client.Get(ctx, client.ObjectKeyFromObject(original), saved); err != nil {
-			return err
-		}
-
-		update(saved)
-
-		// Return err itself here (not wrapped inside another error)
-		// so that RetryOnConflict can identify it correctly.
-		return r.Client.Status().Update(ctx, saved)
-	})
-
-	return saved, err
 }
 
 var SecretContentChangedPredicate = predicate.Funcs{

--- a/controllers/dscinitialization/servicemesh_setup.go
+++ b/controllers/dscinitialization/servicemesh_setup.go
@@ -100,7 +100,8 @@ func (r *DSCInitializationReconciler) authorizationCapability(instance *dsciv1.D
 		}
 
 		return feature.NewHandlerWithReporter(
-			// Noop feature handler results in invoking reporter to set MissingOperator condition for authorino
+			// EmptyFeaturesHandler acts as all the authorization features are disabled (calling Apply/Delete has no actual effect on the cluster)
+			// but it's going to be reported as CapabilityServiceMeshAuthorization/MissingOperator condition/reason
 			feature.EmptyFeaturesHandler,
 			createCapabilityReporter(r.Client, instance, authzMissingOperatorCondition),
 		), nil

--- a/controllers/status/reporter.go
+++ b/controllers/status/reporter.go
@@ -1,0 +1,57 @@
+//nolint:structcheck,ireturn // Reason: false positive, complains about unused fields - see Update method. ireturn to statisfy client.Object interface
+package status
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/client-go/util/retry"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// Reporter defines how the condition should be updated.
+// Its centerpiece is an calculateCondition closure which contains the logic of how the given condition should be calculated.
+type Reporter[T client.Object] struct {
+	calculateCondition CalculateCondition[T]
+}
+
+// CalculateCondition is a closure function that allow to define how condition should be set.
+// It can use Reporter.Err if available to set faulty condition.
+// It should return a SaveStatusFunc which will be used to update the status of the object.
+type CalculateCondition[T client.Object] func(err error) SaveStatusFunc[T]
+
+// NewStatusReporter creates r new Reporter with all required fields.
+func NewStatusReporter[T client.Object](update CalculateCondition[T]) *Reporter[T] {
+	return &Reporter[T]{
+		calculateCondition: update,
+	}
+}
+
+// ReportCondition updates the status of the object using the calculateCondition function.
+func (r *Reporter[T]) ReportCondition(c client.Client, instance T, optionalErr error) (T, error) {
+	return UpdateWithRetry[T](context.Background(), c, instance, r.calculateCondition(optionalErr))
+}
+
+// SaveStatusFunc is a closure function that allow to define custom logic of updating status of a concrete resource object.
+type SaveStatusFunc[T client.Object] func(saved T)
+
+// UpdateWithRetry updates the status of object using passed function and retries on conflict.
+func UpdateWithRetry[T client.Object](ctx context.Context, cli client.Client, original T, update SaveStatusFunc[T]) (T, error) {
+	saved, ok := original.DeepCopyObject().(T)
+	if !ok {
+		return *new(T), fmt.Errorf("failed to deep copy object")
+	}
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		if err := cli.Get(ctx, client.ObjectKeyFromObject(original), saved); err != nil {
+			return err
+		}
+
+		update(saved)
+
+		// Return rr itself here (not wrapped inside another error)
+		// so that RetryOnConflict can identify it correctly.
+		return cli.Status().Update(ctx, saved)
+	})
+
+	return saved, err
+}

--- a/controllers/status/status.go
+++ b/controllers/status/status.go
@@ -66,6 +66,18 @@ const (
 )
 
 const (
+	CapabilityServiceMesh              conditionsv1.ConditionType = "CapabilityServiceMesh"
+	CapabilityServiceMeshAuthorization conditionsv1.ConditionType = "CapabilityServiceMeshAuthorization"
+)
+
+const (
+	MissingOperatorReason string = "MissingOperator"
+	ConfiguredReason      string = "Configured"
+	RemovedReason         string = "Removed"
+	CapabilityFailed      string = "CapabilityFailed"
+)
+
+const (
 	ReadySuffix = "Ready"
 )
 

--- a/pkg/feature/conditions.go
+++ b/pkg/feature/conditions.go
@@ -21,6 +21,11 @@ const (
 
 type MissingOperatorError struct {
 	OperatorName string
+	Err          error
+}
+
+func (e *MissingOperatorError) Unwrap() error {
+	return e.Err
 }
 
 func (e *MissingOperatorError) Error() string {
@@ -31,10 +36,9 @@ func EnsureOperatorIsInstalled(operatorName string) Action {
 	return func(f *Feature) error {
 		if found, err := deploy.ClusterSubscriptionExists(f.Client, operatorName); !found || err != nil {
 			return fmt.Errorf(
-				"failed to find the pre-requisite operator subscription %q, please ensure operator is installed. %w %w",
+				"failed to find the pre-requisite operator subscription %q, please ensure operator is installed. %w",
 				operatorName,
-				&MissingOperatorError{OperatorName: operatorName},
-				err,
+				&MissingOperatorError{OperatorName: operatorName, Err: err},
 			)
 		}
 		return nil

--- a/pkg/feature/conditions.go
+++ b/pkg/feature/conditions.go
@@ -20,16 +20,23 @@ const (
 )
 
 type MissingOperatorError struct {
-	OperatorName string
-	Err          error
+	operatorName string
+	err          error
+}
+
+func NewMissingOperatorError(operatorName string, err error) *MissingOperatorError {
+	return &MissingOperatorError{
+		operatorName: operatorName,
+		err:          err,
+	}
 }
 
 func (e *MissingOperatorError) Unwrap() error {
-	return e.Err
+	return e.err
 }
 
 func (e *MissingOperatorError) Error() string {
-	return fmt.Sprintf("missing operator %q", e.OperatorName)
+	return fmt.Sprintf("missing operator %q", e.operatorName)
 }
 
 func EnsureOperatorIsInstalled(operatorName string) Action {
@@ -38,7 +45,7 @@ func EnsureOperatorIsInstalled(operatorName string) Action {
 			return fmt.Errorf(
 				"failed to find the pre-requisite operator subscription %q, please ensure operator is installed. %w",
 				operatorName,
-				&MissingOperatorError{OperatorName: operatorName, Err: err},
+				NewMissingOperatorError(operatorName, err),
 			)
 		}
 		return nil

--- a/pkg/feature/conditions.go
+++ b/pkg/feature/conditions.go
@@ -19,10 +19,23 @@ const (
 	duration = 5 * time.Minute
 )
 
-func EnsureOperatorIsInstalled(name string) Action {
+type MissingOperatorError struct {
+	OperatorName string
+}
+
+func (e *MissingOperatorError) Error() string {
+	return fmt.Sprintf("missing operator %q", e.OperatorName)
+}
+
+func EnsureOperatorIsInstalled(operatorName string) Action {
 	return func(f *Feature) error {
-		if found, err := deploy.ClusterSubscriptionExists(f.Client, name); !found || err != nil {
-			return fmt.Errorf("failed to find the pre-requisite operator subscription %q, please ensure operator is installed. %w", name, err)
+		if found, err := deploy.ClusterSubscriptionExists(f.Client, operatorName); !found || err != nil {
+			return fmt.Errorf(
+				"failed to find the pre-requisite operator subscription %q, please ensure operator is installed. %w %w",
+				operatorName,
+				&MissingOperatorError{OperatorName: operatorName},
+				err,
+			)
 		}
 		return nil
 	}

--- a/pkg/feature/handler.go
+++ b/pkg/feature/handler.go
@@ -52,12 +52,16 @@ func NewHandlerWithReporter[T client.Object](handler *FeaturesHandler, reporter 
 func (h HandlerWithReporter[T]) Apply() error {
 	applyErr := h.handler.Apply()
 	_, reportErr := h.reporter.ReportCondition(applyErr)
+	// We could have failed during Apply phase as well as during reporting.
+	// We should return both errors to the caller.
 	return multierror.Append(applyErr, reportErr).ErrorOrNil()
 }
 
 func (h HandlerWithReporter[T]) Delete() error {
 	deleteErr := h.handler.Delete()
 	_, reportErr := h.reporter.ReportCondition(deleteErr)
+	// We could have failed during Delete phase as well as during reporting.
+	// We should return both errors to the caller.
 	return multierror.Append(deleteErr, reportErr).ErrorOrNil()
 }
 

--- a/pkg/feature/handler.go
+++ b/pkg/feature/handler.go
@@ -4,46 +4,67 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/go-multierror"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	v1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/dscinitialization/v1"
 	featurev1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/features/v1"
+	"github.com/opendatahub-io/opendatahub-operator/v2/controllers/status"
 )
 
 // FeaturesHandler coordinates feature creations and removal from within controllers.
 type FeaturesHandler struct {
 	*v1.DSCInitializationSpec
-	source           featurev1.Source
-	features         []*Feature
-	featuresProvider FeaturesProvider
+	source            featurev1.Source
+	features          []*Feature
+	featuresProviders []FeaturesProvider
+}
+
+// EmptyFeaturesHandler is noop handler so that we can avoid nil checks in the code and safely call Apply/Delete methods.
+var EmptyFeaturesHandler = &FeaturesHandler{
+	features:          []*Feature{},
+	featuresProviders: []FeaturesProvider{},
+}
+
+// HandlerWithReporter is a wrapper around FeaturesHandler and status.Reporter
+// It is intended apply features related to a given resource capabilities and report its status using custom reporter.
+type HandlerWithReporter[T client.Object] struct {
+	*FeaturesHandler
+	*status.Reporter[T]
+}
+
+func (h HandlerWithReporter[T]) ReportCondition(c client.Client, instance T, err error) (T, error) { //nolint:ireturn // Reason: to statisfy client.Object interface
+	return h.Reporter.ReportCondition(c, instance, err)
 }
 
 // FeaturesProvider is a function which allow to define list of features
 // and couple them with the given initializer.
 type FeaturesProvider func(handler *FeaturesHandler) error
 
-func ClusterFeaturesHandler(dsci *v1.DSCInitialization, def FeaturesProvider) *FeaturesHandler {
+func ClusterFeaturesHandler(dsci *v1.DSCInitialization, def ...FeaturesProvider) *FeaturesHandler {
 	return &FeaturesHandler{
 		DSCInitializationSpec: &dsci.Spec,
 		source:                featurev1.Source{Type: featurev1.DSCIType, Name: dsci.Name},
-		featuresProvider:      def,
+		featuresProviders:     def,
 	}
 }
 
-func ComponentFeaturesHandler(componentName string, spec *v1.DSCInitializationSpec, def FeaturesProvider) *FeaturesHandler {
+func ComponentFeaturesHandler(componentName string, spec *v1.DSCInitializationSpec, def ...FeaturesProvider) *FeaturesHandler {
 	return &FeaturesHandler{
 		DSCInitializationSpec: spec,
 		source:                featurev1.Source{Type: featurev1.ComponentType, Name: componentName},
-		featuresProvider:      def,
+		featuresProviders:     def,
 	}
 }
 
-func (f *FeaturesHandler) Apply() error {
-	if err := f.featuresProvider(f); err != nil {
-		return fmt.Errorf("apply phase failed when wiring Feature instances: %w", err)
+func (fh *FeaturesHandler) Apply() error {
+	for _, featuresProvider := range fh.featuresProviders {
+		if err := featuresProvider(fh); err != nil {
+			return fmt.Errorf("apply phase failed when applying features: %w", err)
+		}
 	}
 
 	var applyErrors *multierror.Error
-	for _, f := range f.features {
+	for _, f := range fh.features {
 		applyErrors = multierror.Append(applyErrors, f.Apply())
 	}
 
@@ -54,14 +75,16 @@ func (f *FeaturesHandler) Apply() error {
 // For instance, this allows for the undoing patches before its deletion.
 // This approach assumes that Features are either instantiated in the correct sequence
 // or are self-contained.
-func (f *FeaturesHandler) Delete() error {
-	if err := f.featuresProvider(f); err != nil {
-		return fmt.Errorf("delete phase failed when wiring Feature instances: %w", err)
+func (fh *FeaturesHandler) Delete() error {
+	for _, featuresProvider := range fh.featuresProviders {
+		if err := featuresProvider(fh); err != nil {
+			return fmt.Errorf("delete phase failed when wiring Feature instances: %w", err)
+		}
 	}
 
 	var cleanupErrors *multierror.Error
-	for i := len(f.features) - 1; i >= 0; i-- {
-		cleanupErrors = multierror.Append(cleanupErrors, f.features[i].Cleanup())
+	for i := len(fh.features) - 1; i >= 0; i-- {
+		cleanupErrors = multierror.Append(cleanupErrors, fh.features[i].Cleanup())
 	}
 
 	return cleanupErrors.ErrorOrNil()


### PR DESCRIPTION
> [!IMPORTANT]
> There are automated tests missing and they will be added to this PR shortly, opened it for code review to first gather feedback about the solution as such.

> [!WARNING]
> Requires https://github.com/opendatahub-io/odh-model-controller/pull/183 merged to work end-to-end. See `How Has This Been Tested?` part to know which images to use before this PR lands in the main branch.

## Description

When Authorino Operator is missing the reconcile will continue without throwing an error about missing pre-requisite and asking user to install it. This fact is instead reported as DSCI.status condition:

```yaml
- lastHeartbeatTime: "2024-04-04T16:32:22Z"
  lastTransitionTime: "2024-04-04T16:24:38Z"
  message: Authorino operator is not installed on the cluster, skipping authorization capability
  reason: MissingOperator
  status: "False"
  type: CapabilityServiceMeshAuthorization
```

This allows existing KServe installations that do not have authorization capability to migrate smoothly and continue working without authz layer.
This is a soft opt-in for Authz layer (leveraging Authorino), as there is no consensus on the automated installation of this dependent operator on behalf of the user.

#### Restructuring service mesh setup code

This PR introduces a notion of capability, though not fully fleshed out as a concept - only condition type for now. 

It is necessary to split the set of service mesh features to core and authz so that they not only can be reported separately but can be handled on their own. 

This is needed for so-called "soft opt-in" mentioned above.

#### Generic Reporter struct

Generic struct Reporter has been introduced to handle status/condition updates uniformly for any resource (of type `client.Object`).

It evolved from `updateStatus` functions available in DSCI and DSC controllers (and these are also moved to a single generic func now).

The new reporter struct has a single responsibility - it reports a condition for a given type. The developer defines how Condition should be constructed in `CalculateCondition` closure where the optional error will be passed for inspection.

This closure is similar to its previous incarnation `update func(saved)` which appends the target object's conditions. The only difference is access to optional error to make changes in the condition to be reported based on occured error.

The main goal behind this new concept is to avoid catch-error-on-defer, where we rely on named return parameters and mutate conditions directly in the function which performs actions based on the resource desired state.

#### Example

```golang
func createReporter(cli client.Client, object *dsciv1.DSCInitialization, condition *conditionsv1.Condition) *status.Reporter[*dsciv1.DSCInitialization] {
	return status.NewStatusReporter[*dsciv1.DSCInitialization](
		cli,
		object,
		func(err error) status.SaveStatusFunc[*dsciv1.DSCInitialization] {
			return func(saved *dsciv1.DSCInitialization) {
				if err != nil {
					condition.Status = corev1.ConditionFalse
					condition.Message = err.Error()
					condition.Reason = status.CapabilityFailed
					var missingOperatorErr *feature.MissingOperatorError
					if errors.As(err, &missingOperatorErr) {
						condition.Reason = status.MissingOperatorReason
					}
				}
				conditionsv1.SetStatusCondition(&saved.Status.Conditions, *condition)
			}
		},
	)
}
```

Then to call it:

```golang
func (r *DSCInitializationReconciler) doServiceMeshStuff(instance *dsciv1.DSCInitialization) error {
	reporter := createReporter(r.Client, instance, &conditionsv1.Condition{
		Type:    status.CapabilityServiceMesh,
		Status:  corev1.ConditionTrue,
		Reason:  status.ConfiguredReason,
		Message: "Service Mesh configured",
	})

	serviceMeshErr := createServiceMesh(instance)
	_, reportError := reporter.ReportCondition(serviceMeshErr)

	return reportError

}
```

## How Has This Been Tested?

> [!NOTE] 
> As missing authorino operator does not yield an error you need to trigger reconciliation manually. One way is to e.g. change another piece of `DSCI` from one mgmt state to another.

#### Authorization verification

<details>
<summary>Steps</summary>

- use custom images for odh-operator (and odh-model-controller)
  - quay.io/bmajsak/opendatahub-operator:dev-authz-soft-opt-in
  - quay.io/bmajsak/odh-model-controller:latest (reference updated in the odh operator image)
  - note: odh-operator image manifests point to `main` branch of odh-model-controller

- install all prerequisites BUT Authorino Operator
   - notice there's no `auth-provider` ns nor authorino-related configuration for service mesh
- enable KServe in DSC
- test sample isvc (e.g. by using [this script](https://gist.githubusercontent.com/israel-hdez/af374562ef9e5b9d80890aa6f0bce20d/raw/5651e4d7c35be51751049c3c2a236771e9005ace/kserve-sample-model-test.sh))
- observe 200
- install Authorino operator
- trigger reconcile of DSCI and DSC so changes are applied both to cluster setup and component
- restart `odh-model-controller` pod
- trigger sample script again
- observe 200
- check Authorino logs and see anonymous access was granted  
- enable authorization on isvc
  - i.e. `oc annotate isvc sklearn-v2-iris security.opendatahub.io/enable-auth=true`
- call isvc again
- observe 401
- add token to isvc call's Header
- observe 200
</details>

#### Conditions check

##### No operators installed

Expected DSCI status:

```yaml
- lastHeartbeatTime: "2024-04-04T16:21:36Z"
  lastTransitionTime: "2024-04-04T16:21:13Z"
  message: "2 errors occurred:\n\t* failed to find the pre-requisite Service Mesh
    Operator subscription, please ensure Service Mesh Operator is installed. failed
    to find the pre-requisite operator subscription \"servicemeshoperator\", please
    ensure operator is installed. missing operator \"servicemeshoperator\" %!w(<nil>)\n\t*
    failed to find the pre-requisite Service Mesh Operator subscription, please
    ensure Service Mesh Operator is installed. failed to find the pre-requisite
    operator subscription \"servicemeshoperator\", please ensure operator is installed.
    missing operator \"servicemeshoperator\" %!w(<nil>)\n\n"
  reason: MissingOperator
  status: "False"
  type: CapabilityServiceMesh
```

> [!IMPORTANT]
> No authorino capability should be present in the status at this point, Service Mesh is pre-requisite.

##### Only service mesh installed

Expected DSCI status:

```yaml
- lastHeartbeatTime: "2024-04-04T16:32:22Z"
  lastTransitionTime: "2024-04-04T16:32:22Z"
  message: Service Mesh configured
  reason: Configured
  status: "True"
  type: CapabilityServiceMesh
- lastHeartbeatTime: "2024-04-04T16:32:22Z"
  lastTransitionTime: "2024-04-04T16:24:38Z"
  message: Authorino operator is not installed on the cluster, skipping authorization capability
  reason: MissingOperator
  status: "False"
  type: CapabilityServiceMeshAuthorization
```

##### Both operators installed

Expected DSCI status:

```yaml
- lastHeartbeatTime: "2024-04-04T16:34:55Z"
  lastTransitionTime: "2024-04-04T16:32:22Z"
  message: Service Mesh configured
  reason: Configured
  status: "True"
  type: CapabilityServiceMesh
- lastHeartbeatTime: "2024-04-04T16:35:06Z"
  lastTransitionTime: "2024-04-04T16:35:06Z"
  message: Service Mesh Authorization configured
  reason: Configured
  status: "True"
  type: CapabilityServiceMeshAuthorization
```
    
## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
