### PR TITLE
Add check for existing Argo Workflows

### DIFF
--- a/components/datasciencepipelines/datasciencepipelines.go
+++ b/components/datasciencepipelines/datasciencepipelines.go
@@ -10,12 +10,15 @@ import (
 
 	"github.com/go-logr/logr"
 	operatorv1 "github.com/openshift/api/operator/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	dsciv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/dscinitialization/v1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/components"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/deploy"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/metadata/labels"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/monitoring"
 )
 
@@ -104,6 +107,10 @@ func (d *DataSciencePipelines) ReconcileComponent(ctx context.Context,
 				return fmt.Errorf("failed to update image from %s : %w", Path, err)
 			}
 		}
+		// Check for existing Argo Workflows
+		if err := unmanagedArgoWorkFlowExists(ctx, cli); err != nil {
+			return err
+		}
 	}
 
 	// new overlay
@@ -140,4 +147,21 @@ func (d *DataSciencePipelines) ReconcileComponent(ctx context.Context,
 	}
 
 	return nil
+}
+
+func unmanagedArgoWorkFlowExists(ctx context.Context,
+	cli client.Client) error {
+	workflowCRD := &apiextensionsv1.CustomResourceDefinition{}
+	if err := cli.Get(ctx, client.ObjectKey{Name: "workflows.argoproj.io"}, workflowCRD); err != nil {
+		if apierrs.IsNotFound(err) {
+			return nil
+		}
+		return fmt.Errorf("failed to get Workflow CRD : %w", err)
+	}
+	// Verify if existing workflow is deployed by ODH
+	_, odhLabelExists := workflowCRD.Labels[labels.ODH.Component(ComponentName)]
+	if odhLabelExists {
+		return nil
+	}
+	return fmt.Errorf("failed to deploy DSP. Argo Workflow CRD already exists but not deployed by this operator . Remove CRD to upgrade")
 }

--- a/controllers/datasciencecluster/datasciencecluster_controller.go
+++ b/controllers/datasciencecluster/datasciencecluster_controller.go
@@ -296,7 +296,7 @@ func (r *DataScienceClusterReconciler) reconcileSubComponent(ctx context.Context
 		instance = r.reportError(err, instance, "failed to reconcile "+componentName+" on DataScienceCluster")
 		instance, _ = status.UpdateWithRetry(ctx, r.Client, instance, func(saved *dsc.DataScienceCluster) {
 			if enabled {
-				if strings.Contains(err.Error(), datasciencepipelines.ArgoWorkflowCRD) {
+				if strings.Contains(err.Error(), datasciencepipelines.ArgoWorkflowCRD+" CRD already exists") {
 					status.SetExistingArgoCondition(&saved.Status.Conditions, status.ArgoWorkflowExist, fmt.Sprintf("Component update failed: %v", err))
 				} else {
 					status.SetComponentCondition(&saved.Status.Conditions, componentName, status.ReconcileFailed, fmt.Sprintf("Component reconciliation failed: %v", err), corev1.ConditionFalse)

--- a/controllers/datasciencecluster/datasciencecluster_controller.go
+++ b/controllers/datasciencecluster/datasciencecluster_controller.go
@@ -78,7 +78,7 @@ const (
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
-func (r *DataScienceClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) { //nolint:gocyclo
+func (r *DataScienceClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) { //nolint:maintidx,gocyclo
 	r.Log.Info("Reconciling DataScienceCluster resources", "Request.Name", req.Name)
 
 	instances := &dsc.DataScienceClusterList{}

--- a/controllers/datasciencecluster/datasciencecluster_controller.go
+++ b/controllers/datasciencecluster/datasciencecluster_controller.go
@@ -23,8 +23,6 @@ import (
 	"strings"
 	"time"
 
-	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-
 	"github.com/go-logr/logr"
 	"github.com/hashicorp/go-multierror"
 	ocbuildv1 "github.com/openshift/api/build/v1"
@@ -35,6 +33,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	netv1 "k8s.io/api/networking/v1"
 	authv1 "k8s.io/api/rbac/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"

--- a/controllers/datasciencecluster/datasciencecluster_controller.go
+++ b/controllers/datasciencecluster/datasciencecluster_controller.go
@@ -20,7 +20,6 @@ package datasciencecluster
 import (
 	"context"
 	"fmt"
-	"github.com/opendatahub-io/opendatahub-operator/v2/components/datasciencepipelines"
 	"strings"
 	"time"
 
@@ -52,6 +51,7 @@ import (
 	dsc "github.com/opendatahub-io/opendatahub-operator/v2/apis/datasciencecluster/v1"
 	dsci "github.com/opendatahub-io/opendatahub-operator/v2/apis/dscinitialization/v1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/components"
+	"github.com/opendatahub-io/opendatahub-operator/v2/components/datasciencepipelines"
 	"github.com/opendatahub-io/opendatahub-operator/v2/controllers/status"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/upgrade"
@@ -199,7 +199,7 @@ func (r *DataScienceClusterReconciler) Reconcile(ctx context.Context, req ctrl.R
 		if instance.Status.InstalledComponents[datasciencepipelines.ComponentName] {
 			if err := datasciencepipelines.UnmanagedArgoWorkFlowExists(ctx, r.Client); err != nil {
 				message := fmt.Sprintf("Failed upgrade: %v ", err.Error())
-				instance, err = status.UpdateWithRetry(ctx, r.Client, instance, func(saved *dsc.DataScienceCluster) {
+				_, err = status.UpdateWithRetry(ctx, r.Client, instance, func(saved *dsc.DataScienceCluster) {
 					status.SetExistingArgoCondition(&saved.Status.Conditions, status.ArgoWorkflowExist, message)
 					status.SetErrorCondition(&saved.Status.Conditions, status.ArgoWorkflowExist, message)
 				})

--- a/controllers/datasciencecluster/datasciencecluster_controller.go
+++ b/controllers/datasciencecluster/datasciencecluster_controller.go
@@ -296,7 +296,7 @@ func (r *DataScienceClusterReconciler) reconcileSubComponent(ctx context.Context
 		instance = r.reportError(err, instance, "failed to reconcile "+componentName+" on DataScienceCluster")
 		instance, _ = status.UpdateWithRetry(ctx, r.Client, instance, func(saved *dsc.DataScienceCluster) {
 			if enabled {
-				if componentName == datasciencepipelines.ComponentName && strings.Contains(err.Error(), datasciencepipelines.ArgoWorkflowCRD) {
+				if strings.Contains(err.Error(), datasciencepipelines.ArgoWorkflowCRD) {
 					status.SetExistingArgoCondition(&saved.Status.Conditions, status.ArgoWorkflowExist, fmt.Sprintf("Component update failed: %v", err))
 				} else {
 					status.SetComponentCondition(&saved.Status.Conditions, componentName, status.ReconcileFailed, fmt.Sprintf("Component reconciliation failed: %v", err), corev1.ConditionFalse)

--- a/controllers/status/status.go
+++ b/controllers/status/status.go
@@ -19,6 +19,7 @@ limitations under the License.
 package status
 
 import (
+	"github.com/opendatahub-io/opendatahub-operator/v2/components/datasciencepipelines"
 	conditionsv1 "github.com/openshift/custom-resource-status/conditions/v1"
 	corev1 "k8s.io/api/core/v1"
 )
@@ -68,6 +69,7 @@ const (
 const (
 	CapabilityServiceMesh              conditionsv1.ConditionType = "CapabilityServiceMesh"
 	CapabilityServiceMeshAuthorization conditionsv1.ConditionType = "CapabilityServiceMeshAuthorization"
+	CapabilityDSPv2Argo                conditionsv1.ConditionType = "CapabilityDSPv2Argo"
 )
 
 const (
@@ -75,6 +77,7 @@ const (
 	ConfiguredReason      string = "Configured"
 	RemovedReason         string = "Removed"
 	CapabilityFailed      string = "CapabilityFailed"
+	ArgoWorkflowExist     string = "ArgoWorkflowExist"
 )
 
 const (
@@ -145,7 +148,7 @@ func SetErrorCondition(conditions *[]conditionsv1.Condition, reason string, mess
 	})
 	conditionsv1.SetStatusCondition(conditions, conditionsv1.Condition{
 		Type:    conditionsv1.ConditionUpgradeable,
-		Status:  corev1.ConditionUnknown,
+		Status:  corev1.ConditionFalse,
 		Reason:  reason,
 		Message: message,
 	})
@@ -174,13 +177,13 @@ func SetCompleteCondition(conditions *[]conditionsv1.Condition, reason string, m
 	})
 	conditionsv1.SetStatusCondition(conditions, conditionsv1.Condition{
 		Type:    conditionsv1.ConditionDegraded,
-		Status:  corev1.ConditionFalse,
+		Status:  corev1.ConditionTrue,
 		Reason:  reason,
 		Message: message,
 	})
 	conditionsv1.SetStatusCondition(conditions, conditionsv1.Condition{
 		Type:    conditionsv1.ConditionUpgradeable,
-		Status:  corev1.ConditionTrue,
+		Status:  corev1.ConditionFalse,
 		Reason:  reason,
 		Message: message,
 	})
@@ -202,4 +205,16 @@ func SetComponentCondition(conditions *[]conditionsv1.Condition, component strin
 func RemoveComponentCondition(conditions *[]conditionsv1.Condition, component string) {
 	condType := component + ReadySuffix
 	conditionsv1.RemoveStatusCondition(conditions, conditionsv1.ConditionType(condType))
+}
+
+func SetExistingArgoCondition(conditions *[]conditionsv1.Condition, reason, message string) {
+	conditionsv1.SetStatusCondition(conditions, conditionsv1.Condition{
+		Type:    CapabilityDSPv2Argo,
+		Status:  corev1.ConditionFalse,
+		Reason:  reason,
+		Message: message,
+	})
+
+	SetComponentCondition(conditions, datasciencepipelines.ComponentName, ReconcileFailed, message, corev1.ConditionFalse)
+
 }

--- a/controllers/status/status.go
+++ b/controllers/status/status.go
@@ -19,9 +19,10 @@ limitations under the License.
 package status
 
 import (
-	"github.com/opendatahub-io/opendatahub-operator/v2/components/datasciencepipelines"
 	conditionsv1 "github.com/openshift/custom-resource-status/conditions/v1"
 	corev1 "k8s.io/api/core/v1"
+
+	"github.com/opendatahub-io/opendatahub-operator/v2/components/datasciencepipelines"
 )
 
 // These constants represent the overall Phase as used by .Status.Phase.
@@ -177,16 +178,17 @@ func SetCompleteCondition(conditions *[]conditionsv1.Condition, reason string, m
 	})
 	conditionsv1.SetStatusCondition(conditions, conditionsv1.Condition{
 		Type:    conditionsv1.ConditionDegraded,
-		Status:  corev1.ConditionTrue,
+		Status:  corev1.ConditionFalse,
 		Reason:  reason,
 		Message: message,
 	})
 	conditionsv1.SetStatusCondition(conditions, conditionsv1.Condition{
 		Type:    conditionsv1.ConditionUpgradeable,
-		Status:  corev1.ConditionFalse,
+		Status:  corev1.ConditionTrue,
 		Reason:  reason,
 		Message: message,
 	})
+	conditionsv1.RemoveStatusCondition(conditions, CapabilityDSPv2Argo)
 }
 
 // SetComponentCondition appends Condition Type with const ReadySuffix for given component
@@ -216,5 +218,4 @@ func SetExistingArgoCondition(conditions *[]conditionsv1.Condition, reason, mess
 	})
 
 	SetComponentCondition(conditions, datasciencepipelines.ComponentName, ReconcileFailed, message, corev1.ConditionFalse)
-
 }

--- a/main.go
+++ b/main.go
@@ -224,11 +224,6 @@ func main() { //nolint:funlen
 		}
 	}
 
-	// Apply update from legacy operator
-	if err = upgrade.UpdateFromLegacyVersion(setupClient, platform, dscApplicationsNamespace, dscMonitoringNamespace); err != nil {
-		setupLog.Error(err, "unable to update from legacy operator version")
-	}
-
 	var cleanExistingResourceFunc manager.RunnableFunc = func(ctx context.Context) error {
 		if err = upgrade.CleanupExistingResource(ctx, setupClient, platform, dscApplicationsNamespace, dscMonitoringNamespace); err != nil {
 			setupLog.Error(err, "unable to perform cleanup")
@@ -238,6 +233,11 @@ func main() { //nolint:funlen
 	err = mgr.Add(cleanExistingResourceFunc)
 	if err != nil {
 		setupLog.Error(err, "error remove deprecated resources from previous version")
+	}
+
+	// Apply update from legacy operator
+	if err = upgrade.UpdateFromLegacyVersion(setupClient, platform, dscApplicationsNamespace, dscMonitoringNamespace); err != nil {
+		setupLog.Error(err, "unable to update from legacy operator version")
 	}
 
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Jira Issue: https://issues.redhat.com/browse/RHOAIENG-4570
This PR introduces changes to handle existing Argo workflows for new install and upgrade. Following is the expected workflow 

```
For version n

1. New Install
    - Argo Workflow exists
        - All components in n deployed successfully except DSP
        - New Dashboard(n) shows warning banner

2. Upgrade from n-1 --> n
   - Argo workflow exists and DSP is enabled
      - Do not upgrade any component. All components in (n-1)
      - Dashboard will not show any warning
      - DSC(Operator) will trigger events stating remove Argo or disable DSP to upgrade to new version
      - Note, (n-1) manifests are no longer managed here

``` 
## How Has This Been Tested?

### New Install

1. Deploy [Workflow CRD ](https://github.com/opendatahub-io/data-science-pipelines-operator/blob/v2.0.1/config/argo/crd.workflows.yaml).
2. Deploy operator using catalogsource: quay.io/vhire/opendatahub-operator-catalog:v2.10.1
3. Create DSCI and DSC with DataSciecnePipelines enabled
4. Verify all components except DSP are updated
5. Verify conditiontype `CapabilityDSPv2Argo`  is triggered .
6. Verify DSP status is False

### Upgrade

1.  Install an ODH version with v1 dsp pipelines(e.g uay.io/vhire/opendatahub-operator-catalog:v2.7.0-711)
2.  Deploy [Workflow CRD ](https://github.com/opendatahub-io/data-science-pipelines-operator/blob/v2.0.1/config/argo/crd.workflows.yaml)
3. Create DSCi and DSC with DataSciecnePipelines enabled
4. Replace catalog source image with new version quay.io/vhire/opendatahub-operator-catalog:v2.10.1
5. Verify no components are upgraded to new version
6. Verify conditiontype `CapabilityDSPv2Argo`  is triggered .
8. Verify conditiontype `Upgradeable` is set to `False`

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
