### PR TITLE
pkg/upgrade: remove watson-studio dashboard application

### DIFF
--- a/pkg/gvk/gvk.go
+++ b/pkg/gvk/gvk.go
@@ -1,0 +1,9 @@
+package gvk
+
+import "k8s.io/apimachinery/pkg/runtime/schema"
+
+var (
+	OdhApplication = schema.GroupVersionKind{Group: "dashboard.opendatahub.io", Version: "v1", Kind: "OdhApplication"}
+	OdhDocument    = schema.GroupVersionKind{Group: "dashboard.opendatahub.io", Version: "v1", Kind: "OdhDocument"}
+	OdhQuickStart  = schema.GroupVersionKind{Group: "console.openshift.io", Version: "v1", Kind: "OdhQuickStart"}
+)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Remove deprecated dashboard resources, watson-studio

## Description

Jira: https://issues.redhat.com/browse/RHOAIENG-4764

 
<!--- Describe your changes in detail -->

## How Has This Been Tested?
- Install odh-2.9.0
- Deploy odh-manifests/dashboard/overlays/apps/base/watson
- Check odhapplications.dashboard.opendatahub.io, odhdocuments.dashboard.opendatahub.io and odhquickstarts.console.openshift.io in opendatahub namespace, watson objects exist
- Deploy PR version
- Restart operator pod
- Observe that watson objects do not exist anymore
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
