### PR TITLE
fix(deploy): wrong logic in if when apply ownership

### DIFF
--- a/pkg/deploy/deploy.go
+++ b/pkg/deploy/deploy.go
@@ -272,7 +272,7 @@ func manageResource(ctx context.Context, cli client.Client, obj *unstructured.Un
 		// Set the owner reference for garbage collection
 		// Skip set on CRD, e.g. we should not delete notebook CRD if we delete DSC instance
 		// Skip on OdhDashboardConfig CR, because we want user to be able to update it
-		if found.GetKind() != "CustomResourceDefinition" || found.GetKind() != "OdhDashboardConfig" {
+		if found.GetKind() != "CustomResourceDefinition" && found.GetKind() != "OdhDashboardConfig" {
 			if err = ctrl.SetControllerReference(owner, metav1.Object(obj), cli.Scheme()); err != nil {
 				return err
 			}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
previous commit has a if logic error
we should not add ownership when it is CRD or odhdashboardconfig
the error is causing:
- odhdashboardconfig CR still has ownership set to it
- CRD also gets ownership set on them


## Description
<!--- Describe your changes in detail -->
ref: https://issues.redhat.com/browse/RHOAIENG-3963

## How Has This Been Tested?
live build quay.io/wenzhou/rhods-operator-catalog:v2.9.3963-419
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
