### PR TITLE
fix(e2e): do not test deletion configmap is true

### DIFF
--- a/tests/e2e/controller_setup_test.go
+++ b/tests/e2e/controller_setup_test.go
@@ -116,7 +116,7 @@ func TestOdhOperator(t *testing.T) {
 	if !skipDeletion {
 		// This test case recreates entire DSC again and deletes afterward
 		// this is a negative test case, since by using the positive CM('true'), even CSV gets deleted which leaves no operator pod in prow
-		t.Run("components should not be removed if wrongly labeled configmap", cfgMapDeletionTestSuite)
+		t.Run("components should not be removed if labeled is set to 'false' on configmap", cfgMapDeletionTestSuite)
 
 		t.Run("delete components", deletionTestSuite)
 	}

--- a/tests/e2e/controller_setup_test.go
+++ b/tests/e2e/controller_setup_test.go
@@ -114,10 +114,11 @@ func TestOdhOperator(t *testing.T) {
 
 	// Run deletion if skipDeletion is not set
 	if !skipDeletion {
-		t.Run("delete components", deletionTestSuite)
-
 		// This test case recreates entire DSC again and deletes afterward
-		t.Run("remove components by using labeled configmap", cfgMapDeletionTestSuite)
+		// this is a negative test case, since by using the positive CM('true'), even CSV gets deleted which leaves no operator pod in prow
+		t.Run("components should not be removed if wrongly labeled configmap", cfgMapDeletionTestSuite)
+
+		t.Run("delete components", deletionTestSuite)
 	}
 }
 

--- a/tests/e2e/dsc_cfmap_deletion_test.go
+++ b/tests/e2e/dsc_cfmap_deletion_test.go
@@ -23,17 +23,13 @@ func cfgMapDeletionTestSuite(t *testing.T) {
 	defer removeDeletionConfigMap(testCtx)
 
 	t.Run(testCtx.testDsc.Name, func(t *testing.T) {
-		// t.Run("create data science cluster", func(t *testing.T) {
-		// 	err = testCtx.testDSCCreation()
-		// 	require.NoError(t, err, "Error to create DSC instance")
-		// })
 		t.Run("create configmap but set to disable deletion", func(t *testing.T) {
 			err = testCtx.testDSCDeletionUsingConfigMap("false")
 			require.NoError(t, err, "Configmap should not delete DSC instance")
 		})
 
 		t.Run("owned namespaces should be not deleted", func(t *testing.T) {
-			err = testCtx.testOwnedNamespacesAllExist(0)
+			err = testCtx.testOwnedNamespacesAllExist()
 			require.NoError(t, err, "Error while deleting owned namespaces")
 		})
 	})
@@ -58,7 +54,7 @@ func (tc *testContext) testDSCDeletionUsingConfigMap(enableDeletion string) erro
 
 	return nil
 }
-func (tc *testContext) testOwnedNamespacesAllExist(count int) error {
+func (tc *testContext) testOwnedNamespacesAllExist() error {
 	namespaces, err := tc.kubeClient.CoreV1().Namespaces().List(tc.ctx, metav1.ListOptions{
 		LabelSelector: labels.ODH.OwnedNamespace,
 	})
@@ -66,26 +62,12 @@ func (tc *testContext) testOwnedNamespacesAllExist(count int) error {
 	if err != nil {
 		return fmt.Errorf("failed getting owned namespaces %w", err)
 	}
-	if len(namespaces.Items) == count {
+	if len(namespaces.Items) == 0 {
 		return fmt.Errorf("all namespaces are gone")
 	}
 
 	return nil
 }
-
-// func (tc *testContext) testOwnedNamespacesDeletion() error {
-// 	if err := wait.PollUntilContextTimeout(tc.ctx, tc.resourceRetryInterval, tc.resourceCreationTimeout, false, func(ctx context.Context) (bool, error) {
-// 		namespaces, err := tc.kubeClient.CoreV1().Namespaces().List(ctx, metav1.ListOptions{
-// 			LabelSelector: labels.ODH.OwnedNamespace,
-// 		})
-
-// 		return len(namespaces.Items) == 0, err
-// 	}); err != nil {
-// 		return fmt.Errorf("failed waiting for all owned namespaces to be deleted: %w", err)
-// 	}
-
-// 	return nil
-// }
 
 func removeDeletionConfigMap(tc *testContext) {
 	_ = tc.kubeClient.CoreV1().ConfigMaps(tc.operatorNamespace).Delete(context.TODO(), "delete-self-managed", metav1.DeleteOptions{})

--- a/tests/e2e/dsc_cfmap_deletion_test.go
+++ b/tests/e2e/dsc_cfmap_deletion_test.go
@@ -10,11 +10,8 @@ import (
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/wait"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	dsc "github.com/opendatahub-io/opendatahub-operator/v2/apis/datasciencecluster/v1"
-	dsci "github.com/opendatahub-io/opendatahub-operator/v2/apis/dscinitialization/v1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/metadata/labels"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/upgrade"
 )
@@ -26,99 +23,81 @@ func cfgMapDeletionTestSuite(t *testing.T) {
 	defer removeDeletionConfigMap(testCtx)
 
 	t.Run(testCtx.testDsc.Name, func(t *testing.T) {
-		t.Run("create data science cluster", func(t *testing.T) {
-			err = testCtx.testDSCCreation()
-			require.NoError(t, err, "Error to create DSC instance")
+		// t.Run("create data science cluster", func(t *testing.T) {
+		// 	err = testCtx.testDSCCreation()
+		// 	require.NoError(t, err, "Error to create DSC instance")
+		// })
+		t.Run("create configmap but set to disable deletion", func(t *testing.T) {
+			err = testCtx.testDSCDeletionUsingConfigMap("false")
+			require.NoError(t, err, "Configmap should not delete DSC instance")
 		})
 
-		t.Run("ensure all components created", func(t *testing.T) {
-			err = testCtx.testAllApplicationCreation(t)
-			require.NoError(t, err, "Error to create DSC instance")
-		})
-
-		t.Run("trigger deletion using labeled config map", func(t *testing.T) {
-			err = testCtx.testDSCDeletionUsingConfigMap()
-			require.NoError(t, err, "Error to delete DSC instance")
-		})
-
-		t.Run("owned namespaces should be deleted", func(t *testing.T) {
-			err = testCtx.testOwnedNamespacesDeletion()
+		t.Run("owned namespaces should be not deleted", func(t *testing.T) {
+			err = testCtx.testOwnedNamespacesAllExist(0)
 			require.NoError(t, err, "Error while deleting owned namespaces")
-		})
-
-		t.Run("dsci should be deleted", func(t *testing.T) {
-			err = testCtx.testDSCIDeletion()
-			require.NoError(t, err, "failed deleting DSCI")
-		})
-
-		t.Run("applications resources should be deleted", func(t *testing.T) {
-			err = testCtx.testAllApplicationDeletion()
-			require.NoError(t, err, "Error to delete component")
 		})
 	})
 }
 
-func (tc *testContext) testDSCIDeletion() error {
-	dsciInstances := &dsci.DSCInitializationList{}
-	if err := tc.customClient.List(context.TODO(), dsciInstances); err != nil {
-		return fmt.Errorf("failed while listing DSCIs: %w", err)
-	}
-
-	if len(dsciInstances.Items) != 0 {
-		return fmt.Errorf("expected DSCI removal, but got %v", dsciInstances)
-	}
-
-	return nil
-}
-
-func (tc *testContext) testDSCDeletionUsingConfigMap() error {
+func (tc *testContext) testDSCDeletionUsingConfigMap(enableDeletion string) error {
 	dscLookupKey := types.NamespacedName{Name: tc.testDsc.Name}
 	expectedDSC := &dsc.DataScienceCluster{}
 
-	if err := createDeletionConfigMap(tc); err != nil {
+	if err := createDeletionConfigMap(tc, enableDeletion); err != nil {
 		return err
 	}
 
 	err := tc.customClient.Get(tc.ctx, dscLookupKey, expectedDSC)
-	if err == nil {
-		dscerr := tc.customClient.Delete(tc.ctx, expectedDSC, &client.DeleteOptions{})
-		if dscerr != nil {
-			return fmt.Errorf("error deleting DSC instance %s: %w", expectedDSC.Name, dscerr)
+	// should have DSC instance
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			return fmt.Errorf("should have DSC instance in cluster:%w", err)
 		}
-	} else if !k8serrors.IsNotFound(err) {
-		if err != nil {
-			return fmt.Errorf("error getting DSC instance :%w", err)
-		}
+		return fmt.Errorf("error getting DSC instance :%w", err)
+	}
+
+	return nil
+}
+func (tc *testContext) testOwnedNamespacesAllExist(count int) error {
+	namespaces, err := tc.kubeClient.CoreV1().Namespaces().List(tc.ctx, metav1.ListOptions{
+		LabelSelector: labels.ODH.OwnedNamespace,
+	})
+
+	if err != nil {
+		return fmt.Errorf("failed getting owned namespaces %w", err)
+	}
+	if len(namespaces.Items) == count {
+		return fmt.Errorf("all namespaces are gone")
 	}
 
 	return nil
 }
 
-func (tc *testContext) testOwnedNamespacesDeletion() error {
-	if err := wait.PollUntilContextTimeout(tc.ctx, tc.resourceRetryInterval, tc.resourceCreationTimeout, false, func(ctx context.Context) (bool, error) {
-		namespaces, err := tc.kubeClient.CoreV1().Namespaces().List(ctx, metav1.ListOptions{
-			LabelSelector: labels.ODH.OwnedNamespace,
-		})
+// func (tc *testContext) testOwnedNamespacesDeletion() error {
+// 	if err := wait.PollUntilContextTimeout(tc.ctx, tc.resourceRetryInterval, tc.resourceCreationTimeout, false, func(ctx context.Context) (bool, error) {
+// 		namespaces, err := tc.kubeClient.CoreV1().Namespaces().List(ctx, metav1.ListOptions{
+// 			LabelSelector: labels.ODH.OwnedNamespace,
+// 		})
 
-		return len(namespaces.Items) == 0, err
-	}); err != nil {
-		return fmt.Errorf("failed waiting for all owned namespaces to be deleted: %w", err)
-	}
+// 		return len(namespaces.Items) == 0, err
+// 	}); err != nil {
+// 		return fmt.Errorf("failed waiting for all owned namespaces to be deleted: %w", err)
+// 	}
 
-	return nil
-}
+// 	return nil
+// }
 
 func removeDeletionConfigMap(tc *testContext) {
 	_ = tc.kubeClient.CoreV1().ConfigMaps(tc.operatorNamespace).Delete(context.TODO(), "delete-self-managed", metav1.DeleteOptions{})
 }
 
-func createDeletionConfigMap(tc *testContext) error {
+func createDeletionConfigMap(tc *testContext, enableDeletion string) error {
 	configMap := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "delete-self-managed",
 			Namespace: tc.operatorNamespace,
 			Labels: map[string]string{
-				upgrade.DeleteConfigMapLabel: "true",
+				upgrade.DeleteConfigMapLabel: enableDeletion,
 			},
 		},
 	}

--- a/tests/e2e/dsc_deletion_test.go
+++ b/tests/e2e/dsc_deletion_test.go
@@ -29,7 +29,7 @@ func deletionTestSuite(t *testing.T) {
 
 	t.Run(testCtx.testDsc.Name, func(t *testing.T) {
 		t.Run("Deletion: DataScienceCluster instance", func(t *testing.T) {
-			err = testCtx.testDSCDeletion()
+			err = testCtx.testDeletionExistDSC()
 			require.NoError(t, err, "Error to delete DSC instance")
 		})
 		t.Run("Deletion: Application Resource", func(t *testing.T) {
@@ -37,13 +37,13 @@ func deletionTestSuite(t *testing.T) {
 			require.NoError(t, err, "Error to delete component")
 		})
 		t.Run("Deletion: DSCI instance", func(t *testing.T) {
-			err = testCtx.testDSCIDeletion()
+			err = testCtx.testDeletionExistDSCI()
 			require.NoError(t, err, "Error to delete DSCI instance")
 		})
 	})
 }
 
-func (tc *testContext) testDSCDeletion() error {
+func (tc *testContext) testDeletionExistDSC() error {
 	// Delete test DataScienceCluster resource if found
 
 	dscLookupKey := types.NamespacedName{Name: tc.testDsc.Name}
@@ -134,7 +134,9 @@ func (tc *testContext) testAllApplicationDeletion() error {
 	return err
 }
 
-func (tc *testContext) testDSCIDeletion() error {
+// To test if  DSCI CR is in the cluster and no problem to delete it
+// if fail on any of these two conditios, fail test.
+func (tc *testContext) testDeletionExistDSCI() error {
 	// Delete test DSCI resource if found
 
 	dsciLookupKey := types.NamespacedName{Name: tc.testDSCI.Name}


### PR DESCRIPTION
- only test negative case when set to false: resource should remain
- if we test postivie case, we wont get prow pod log after csv is deleted

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
e2e flow:
- creation   => no changes in PR
  - create DSCI
  - create more DSCI, should fail
  - create DSC
  - create more DSC should fail
  - ....
- test configmap case  => change in PR , previous as positive case to delete all, now negative should not delete
  - set to configmap but not enable deletion label
  - namespace still exists (MR namespace wont get label)
- test deletion case  => move from 2nd test suite to the 3rd one
  - check all components are enabled first
  - delete DSC CR
  - loop thro components: see their resources are all gone.
  - delete DSCI CR

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
