### PR TITLE
Add Ability to configure resources in Kserve

### DIFF
--- a/pkg/deploy/deploy.go
+++ b/pkg/deploy/deploy.go
@@ -288,9 +288,17 @@ func manageResource(ctx context.Context, cli client.Client, obj *unstructured.Un
 		return nil
 	}
 
-	// do not reconcile kserve resource with annotation "opendatahub.io/managed: false"
-	if found.GetAnnotations()["opendatahub.io/managed"] == "false" && componentName == "kserve" {
-		return nil
+	// Kserve specific workflow:
+	// TODO: Remove this when we have generalize custom config requirements across all components
+	if componentName == "kserve" {
+		// do not reconcile kserve resource with annotation "opendatahub.io/managed: false"
+		if found.GetAnnotations()["opendatahub.io/managed"] == "false" {
+			return nil
+		}
+		// do not patch resources field in Kserve deployment i.e allows users to update resources field
+		if err := removeResourcesFromDeployment(obj); err != nil {
+			return err
+		}
 	}
 
 	// Preserve app.opendatahub.io/<component> labels of previous versions of existing objects
@@ -400,6 +408,44 @@ func ApplyParams(componentPath string, imageParamsMap map[string]string, isUpdat
 	err = os.Remove(backupPath)
 
 	return err
+}
+
+// removeResourcesFromDeployment checks if the provided resource is a Deployment,
+// and if so, removes the resources field from each container in the Deployment. This ensures we do not overwrite the
+// resources field when Patch is applied with the returned unstructured resource.
+func removeResourcesFromDeployment(u *unstructured.Unstructured) error {
+	// Check if the resource is a Deployment. This can be expanded to other resources as well.
+	if u.GetKind() != "Deployment" {
+		return nil
+	}
+	// Navigate to the containers array in the Deployment spec
+	containers, exists, err := unstructured.NestedSlice(u.Object, "spec", "template", "spec", "containers")
+	if err != nil {
+		return fmt.Errorf("error when trying to retrieve containers from Deployment: %w", err)
+	}
+	// Return if no containers exist
+	if !exists {
+		return nil
+	}
+
+	// Iterate over the containers to remove the resources field
+	for i := range containers {
+		container, ok := containers[i].(map[string]interface{})
+		// If containers field is not in expected type, return.
+		if !ok {
+			return nil
+		}
+		// Check and delete the resources field. This can be expanded to any whitelisted field.
+		delete(container, "resources")
+		containers[i] = container
+	}
+
+	// Update the containers in the original unstructured object
+	if err := unstructured.SetNestedSlice(u.Object, containers, "spec", "template", "spec", "containers"); err != nil {
+		return fmt.Errorf("failed to update containers in Deployment: %w", err)
+	}
+
+	return nil
 }
 
 // GetSubscription checks if a Subscription for the operator exists in the given namespace.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This is a very targeted change for Kserve component. The PR adds ability to configure `resources` field in Deployments objects of the component.

Eventually we will move to a generalize solution to whitelist fields for all components. See [[wip]ADR](https://github.com/opendatahub-io/architecture-decision-records/pull/32)

Jira Issue: https://issues.redhat.com/browse/RHOAIENG-280
## How Has This Been Tested?
1. Deploy custom operator image
2. Set Kserve component to Managed in DSC
3. Update `resources` field in `kserve-controller-manager` Deployment
4. Verify values are not overwritten
5.  Update `resources` field in  Deployment of any other component
6. Verify values are overwritten

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
