### PR TITLE
Add Opendatahub-operator pod selector label

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -23,6 +23,7 @@ spec:
         kubectl.kubernetes.io/default-container: manager
       labels:
         control-plane: controller-manager
+        name: opendatahub-operator
     spec:
       securityContext:
         runAsNonRoot: true


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Add Opendatahub-operator pod selector label. Same is used in ODS_CI test suits to validate operator pod is running.
https://github.com/vaibhavjainwiz/ods-ci/blob/support_odh/ods_ci/tasks/Resources/RHODS_OLM/install/oc_install.robot#L77

Similliar label is already a part of rhods-operator.

I am doing this change as an effort to enable ODS_CI testsuit for ODH testing as well.

## Description
<!--- Describe your changes in detail -->

https://issues.redhat.com/browse/RHOAIENG-5321

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
