### PR TITLE
fix(cfgmap): simplifies create/update (again!)

### DIFF
--- a/pkg/cluster/meta.go
+++ b/pkg/cluster/meta.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
 // MetaOptions allows to add additional settings for the object being created through a chain
@@ -24,6 +26,12 @@ func WithOwnerReference(ownerReferences ...metav1.OwnerReference) MetaOptions {
 	return func(obj metav1.Object) error {
 		obj.SetOwnerReferences(ownerReferences)
 		return nil
+	}
+}
+
+func OwnedBy(owner metav1.Object, scheme *runtime.Scheme) MetaOptions {
+	return func(obj metav1.Object) error {
+		return controllerutil.SetOwnerReference(owner, obj, scheme)
 	}
 }
 

--- a/pkg/feature/servicemesh/resources.go
+++ b/pkg/feature/servicemesh/resources.go
@@ -3,6 +3,9 @@ package servicemesh
 import (
 	"strings"
 
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/feature"
 )
@@ -18,15 +21,17 @@ func MeshRefs(f *feature.Feature) error {
 		"MESH_NAMESPACE":     meshConfig.Namespace,
 	}
 
-	_, err := cluster.CreateOrUpdateConfigMap(
+	return cluster.CreateOrUpdateConfigMap(
 		f.Client,
-		"service-mesh-refs",
-		namespace,
-		data,
+		&corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "service-mesh-refs",
+				Namespace: namespace,
+			},
+			Data: data,
+		},
 		feature.OwnedBy(f),
 	)
-
-	return err
 }
 
 // AuthRefs stores authorization configuration in the config map, so it can
@@ -44,13 +49,15 @@ func AuthRefs(f *feature.Feature) error {
 		"AUTHORINO_LABEL": "security.opendatahub.io/authorization-group=default",
 	}
 
-	_, err := cluster.CreateOrUpdateConfigMap(
+	return cluster.CreateOrUpdateConfigMap(
 		f.Client,
-		"auth-refs",
-		namespace,
-		data,
+		&corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "auth-refs",
+				Namespace: namespace,
+			},
+			Data: data,
+		},
 		feature.OwnedBy(f),
 	)
-
-	return err
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This is a follow-up PR to #948.

One thing which I missed was updating labels if the config map already existed. This is now ensured for both `Create` and `Update` paths and captured in tests.

In addition, `CreateOrUpdateConfigMap` takes a pointer to a ConfigMap "prototype" instance, where you can define `ObjectMeta` and `Data`. This simplifies function signature and allows you to pass an anonymous struct when you do not want to use the return value later. Previously this had to be ignored by using `_` as a variable name.

### Additional changes

- `ConfigMap.ObjectMeta.[Name|Namespace]` is required as it will be used for the initial `Get` call. It returns an error otherwise. Previously both `name` and `namespace` string params were not validated before invoking k8s client.
- `.Data` keys will be merged if configmap already exists. This is similar to the previous behavior, except it handles `nil` maps too.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
