### PR TITLE
[WIP] To use internal service endpoint, added http port for knative local gw

### DIFF
--- a/components/kserve/resources/servicemesh/routing/istio-local-gateway.yaml
+++ b/components/kserve/resources/servicemesh/routing/istio-local-gateway.yaml
@@ -15,3 +15,9 @@ spec:
         protocol: HTTPS
       tls:
         mode: ISTIO_MUTUAL
+    - hosts:
+      - '*.svc.cluster.local'
+      port:
+        name: http
+        number: 8082
+        protocol: HTTP

--- a/components/kserve/resources/servicemesh/routing/local-gateway-svc.tmpl.yaml
+++ b/components/kserve/resources/servicemesh/routing/local-gateway-svc.tmpl.yaml
@@ -11,6 +11,10 @@ spec:
       port: 80
       protocol: TCP
       targetPort: 8081
+    - name: http
+      port: 8082
+      protocol: TCP
+      targetPort: 8082      
   selector:
     knative: ingressgateway
   type: ClusterIP


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
knative-local-gateway use `ISTIO_MUTUAL` mode for TLS so it is not possible to access the endpoint using Service Hostname. To allow users to access the endpoint internally, there are several ways:
- SIMPLE tls +  a new certificate
- HTTP

This is for the second option. If it needs to be encrypted, we will revisit it later.

example service hostname: 
```caikit-tgis-example-isvc-grpc.kserve-demo.svc.cluster.local```
[RHOAIENG-5157](https://issues.redhat.com/browse/RHOAIENG-5157)


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
THis will be updated.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
