### PR TITLE
feat(cleanup): remove jupyterhub OdhDocument CR from previous release

### DIFF
--- a/pkg/cluster/gvk/gvk.go
+++ b/pkg/cluster/gvk/gvk.go
@@ -34,4 +34,10 @@ var (
 		Group:   "console.openshift.io",
 		Version: "v1", Kind: "OdhQuickStart",
 	}
+
+	OdhDashboardConfig = schema.GroupVersionKind{
+		Group:   "opendatahub.io",
+		Version: "v1alpha",
+		Kind:    "OdhDashboardConfig",
+	}
 )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
fix: https://issues.redhat.com/browse/RHOAIENG-443
during testing, found we have more Jupyterhub related CR need to clean


## Description
<!--- Describe your changes in detail -->
here are CRs from https://github.com/red-hat-data-services/odh-dashboard/blob/rhoai-2.8/manifests/apps/jupyter/jupyter-docs.yaml


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
live-build quay.io/wenzhou/opendatahub-operator-catalog:v2.10.443-1
- manually create these CR in the cluster
- install local build
- no need to create DSCI or DSC CR
- check if these 4 CR still in the cluster

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
