### PR TITLE
feat(status): change Degraded status from False to True if no DSCI CR

### DIFF
--- a/controllers/datasciencecluster/datasciencecluster_controller.go
+++ b/controllers/datasciencecluster/datasciencecluster_controller.go
@@ -154,6 +154,8 @@ func (r *DataScienceClusterReconciler) Reconcile(ctx context.Context, req ctrl.R
 		r.Log.Info(message)
 		instance, err = status.UpdateWithRetry(ctx, r.Client, instance, func(saved *dsc.DataScienceCluster) {
 			status.SetProgressingCondition(&saved.Status.Conditions, reason, message)
+			// Patch Degraded with True status
+			status.SetGeneralCondition(&saved.Status.Conditions, "Degraded", reason, message, corev1.ConditionTrue)
 			saved.Status.Phase = status.PhaseError
 		})
 		if err != nil {

--- a/controllers/status/status.go
+++ b/controllers/status/status.go
@@ -219,3 +219,13 @@ func SetExistingArgoCondition(conditions *[]conditionsv1.Condition, reason, mess
 
 	SetComponentCondition(conditions, datasciencepipelines.ComponentName, ReconcileFailed, message, corev1.ConditionFalse)
 }
+
+// General function to patch any type of condition.
+func SetGeneralCondition(conditions *[]conditionsv1.Condition, conditionType string, reason string, message string, status corev1.ConditionStatus) {
+	conditionsv1.SetStatusCondition(conditions, conditionsv1.Condition{
+		Type:    conditionsv1.ConditionType(conditionType),
+		Status:  status,
+		Reason:  reason,
+		Message: message,
+	})
+}


### PR DESCRIPTION
- in most of the case, DSC CR should have Degraded as False if that was caused by subcomponent reconcile failure (component or dependencies)
- in the case of a missing/invalid DSCI, DSC CR is totally malfunction,

related to https://issues.redhat.com/browse/RHOAIENG-3913 but not to fix the Degraded in the case of "failed to get dependency of component"

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
local build: quay.io/wenzhou/opendatahub-operator-catalog:v2.10.3913
- install operator
- do not create DSCI CR, only create DSC CR with default content
- check DSC CR status
![Screenshot from 2024-04-30 11-20-53](https://github.com/opendatahub-io/opendatahub-operator/assets/915053/ce9d7387-b501-4889-82bf-e20b7c9c83d3)
here Degraded is True
- go create DSCI CR
- wait till all Managed components finished reoncile
- check DSC CR status again
![Screenshot from 2024-04-30 11-22-08](https://github.com/opendatahub-io/opendatahub-operator/assets/915053/5c787fa4-b7de-47bd-a6e5-e5a5f9b1825c)
here Degraded is False

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
