### PR TITLE
chore: add auth namespace to auth cfgmap

### DIFF
--- a/pkg/feature/servicemesh/resources.go
+++ b/pkg/feature/servicemesh/resources.go
@@ -38,14 +38,19 @@ func MeshRefs(f *feature.Feature) error {
 // be easily accessed by other components which rely on this information.
 func AuthRefs(f *feature.Feature) error {
 	audiences := f.Spec.Auth.Audiences
-	namespace := f.Spec.AppNamespace
+	appNamespace := f.Spec.AppNamespace
+	authNamespace := f.Spec.Auth.Namespace
+	if len(authNamespace) == 0 {
+		authNamespace = appNamespace + "-auth-provider"
+	}
 	audiencesList := ""
 	if audiences != nil && len(*audiences) > 0 {
 		audiencesList = strings.Join(*audiences, ",")
 	}
 	data := map[string]string{
 		"AUTH_AUDIENCE":   audiencesList,
-		"AUTH_PROVIDER":   namespace + "-auth-provider",
+		"AUTH_PROVIDER":   appNamespace + "-auth-provider",
+		"AUTH_NAMESPACE":  authNamespace,
 		"AUTHORINO_LABEL": "security.opendatahub.io/authorization-group=default",
 	}
 
@@ -54,7 +59,7 @@ func AuthRefs(f *feature.Feature) error {
 		&corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "auth-refs",
-				Namespace: namespace,
+				Namespace: appNamespace,
 			},
 			Data: data,
 		},


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Small change, adding the namespace authorino is deployed to into our `auth-refs` configmap for reference. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested manually on CRC with image `quay.io/cgarriso/opendatahub-operator:dev-add-auth-ns-refs`

Ensured that when no auth namespace was specified in created DSCI with appNamespace: `opendatahub` that the name in the configmap was default (`opendatahub-auth-provider`) and that when the auth namespace was specified in created DSCI then the specified namespace was present in the configmap. 

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
