### PR TITLE
Doc change: Add flag to operator sdk run bundle to use quay io registry for busyb…

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ e.g `make image-build -e IMAGE_BUILD_FLAGS="--build-arg USE_LOCAL=true"`
 - Run the Bundle on a cluster:
   
   ```commandline
-  operator-sdk run bundle quay.io/<username>/opendatahub-operator-bundle:<VERSION> --namespace $OPERATOR_NAMESPACE
+  operator-sdk run bundle quay.io/<username>/opendatahub-operator-bundle:<VERSION> --namespace $OPERATOR_NAMESPACE --decompression-image quay.io/project-codeflare/busybox:1.36
   ```
 ### Test with customized manifests
 


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
This is a change to pull busybox image from quay.io registry instead of docker hub as it was throwing pull rate limit error. 
<img width="1368" alt="image" src="https://github.com/opendatahub-io/opendatahub-operator/assets/100594859/e6975ce0-9254-4cd1-b0d5-1637c66c62e2">
Just by indicating the flag `--decompression-image quay.io/project-codeflare/busybox:1.36` from the operator-sdk official documentation: https://sdk.operatorframework.io/docs/cli/operator-sdk_run_bundle/#m-docsclioperator-sdk_run_bundle

This error was also hit on https://github.com/opendatahub-io/opendatahub-operator/pull/944 

## How Has This Been Tested?
By running the command, image gets pulled successfully:
```
$ operator-sdk run bundle quay.io/asanzgom/opendatahub-operator-bundle:2.10.0 --namespace openshift-operators --decompression-image quay.io/project-codeflare/busybox:1.36
[Deprecation Notice] This version is deprecated.The `go/v3` cannot scaffold projects using kustomize versions v4x+ and cannot fully support Kubernetes 1.25+.It is recommended to upgrade your project to the latest versions available (go/v4).Please, check the migration guide to learn how to upgrade your project

INFO[0016] Creating a File-Based Catalog of the bundle "quay.io/asanzgom/opendatahub-operator-bundle:2.10.0" 
INFO[0017] Generated a valid File-Based Catalog         
INFO[0024] Created registry pod: quay-io-asanzgom-opendatahub-operator-bundle-2-10-0 
INFO[0025] Created CatalogSource: opendatahub-operator-catalog 
INFO[0025] Created Subscription: opendatahub-operator-v2-10-0-sub 
INFO[0038] Approved InstallPlan install-6qklz for the Subscription: opendatahub-operator-v2-10-0-sub 
INFO[0038] Waiting for ClusterServiceVersion "openshift-operators/opendatahub-operator.v2.10.0" to reach 'Succeeded' phase 
INFO[0039]   Waiting for ClusterServiceVersion "openshift-operators/opendatahub-operator.v2.10.0" to appear 
INFO[0041]   Found ClusterServiceVersion "openshift-operators/opendatahub-operator.v2.10.0" phase: Pending 
INFO[0043]   Found ClusterServiceVersion "openshift-operators/opendatahub-operator.v2.10.0" phase: InstallReady 
INFO[0044]   Found ClusterServiceVersion "openshift-operators/opendatahub-operator.v2.10.0" phase: Installing 
INFO[0054]   Found ClusterServiceVersion "openshift-operators/opendatahub-operator.v2.10.0" phase: Succeeded 
INFO[0055] OLM has successfully installed "opendatahub-operator.v2.10.0" 
```

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
