### PR TITLE
fix: wrong path when use devFlag + wrong default value + special name in TrustyAI

### DIFF
--- a/bundle/manifests/datasciencecluster.opendatahub.io_datascienceclusters.yaml
+++ b/bundle/manifests/datasciencecluster.opendatahub.io_datascienceclusters.yaml
@@ -53,7 +53,7 @@ spec:
                             items:
                               properties:
                                 contextDir:
-                                  default: ""
+                                  default: manifests
                                   description: contextDir is the relative path to
                                     the folder containing manifests in a repository
                                   type: string
@@ -96,7 +96,7 @@ spec:
                             items:
                               properties:
                                 contextDir:
-                                  default: ""
+                                  default: manifests
                                   description: contextDir is the relative path to
                                     the folder containing manifests in a repository
                                   type: string
@@ -140,7 +140,7 @@ spec:
                             items:
                               properties:
                                 contextDir:
-                                  default: ""
+                                  default: manifests
                                   description: contextDir is the relative path to
                                     the folder containing manifests in a repository
                                   type: string
@@ -198,7 +198,7 @@ spec:
                             items:
                               properties:
                                 contextDir:
-                                  default: ""
+                                  default: manifests
                                   description: contextDir is the relative path to
                                     the folder containing manifests in a repository
                                   type: string
@@ -301,7 +301,7 @@ spec:
                             items:
                               properties:
                                 contextDir:
-                                  default: ""
+                                  default: manifests
                                   description: contextDir is the relative path to
                                     the folder containing manifests in a repository
                                   type: string
@@ -345,7 +345,7 @@ spec:
                             items:
                               properties:
                                 contextDir:
-                                  default: ""
+                                  default: manifests
                                   description: contextDir is the relative path to
                                     the folder containing manifests in a repository
                                   type: string
@@ -388,7 +388,7 @@ spec:
                             items:
                               properties:
                                 contextDir:
-                                  default: ""
+                                  default: manifests
                                   description: contextDir is the relative path to
                                     the folder containing manifests in a repository
                                   type: string
@@ -431,7 +431,7 @@ spec:
                             items:
                               properties:
                                 contextDir:
-                                  default: ""
+                                  default: manifests
                                   description: contextDir is the relative path to
                                     the folder containing manifests in a repository
                                   type: string
@@ -474,7 +474,7 @@ spec:
                             items:
                               properties:
                                 contextDir:
-                                  default: ""
+                                  default: manifests
                                   description: contextDir is the relative path to
                                     the folder containing manifests in a repository
                                   type: string
@@ -517,7 +517,7 @@ spec:
                             items:
                               properties:
                                 contextDir:
-                                  default: ""
+                                  default: manifests
                                   description: contextDir is the relative path to
                                     the folder containing manifests in a repository
                                   type: string
@@ -560,7 +560,7 @@ spec:
                             items:
                               properties:
                                 contextDir:
-                                  default: ""
+                                  default: manifests
                                   description: contextDir is the relative path to
                                     the folder containing manifests in a repository
                                   type: string

--- a/components/component.go
+++ b/components/component.go
@@ -64,9 +64,9 @@ type ManifestsConfig struct {
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,order=1
 	URI string `json:"uri,omitempty"`
 
-	// contextDir is the relative path to the folder containing manifests in a repository
+	// contextDir is the relative path to the folder containing manifests in a repository, default value "manifests"
 	// +optional
-	// +kubebuilder:default:=""
+	// +kubebuilder:default:="manifests"
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,order=2
 	ContextDir string `json:"contextDir,omitempty"`
 

--- a/components/kueue/kueue.go
+++ b/components/kueue/kueue.go
@@ -39,7 +39,7 @@ func (k *Kueue) OverrideManifests(_ string) error {
 			return err
 		}
 		// If overlay is defined, update paths
-		defaultKustomizePath := "openshift"
+		defaultKustomizePath := "rhoai"
 		if manifestConfig.SourcePath != "" {
 			defaultKustomizePath = manifestConfig.SourcePath
 		}

--- a/components/trainingoperator/trainingoperator.go
+++ b/components/trainingoperator/trainingoperator.go
@@ -41,7 +41,7 @@ func (r *TrainingOperator) OverrideManifests(_ string) error {
 			return err
 		}
 		// If overlay is defined, update paths
-		defaultKustomizePath := "openshift"
+		defaultKustomizePath := "rhoai"
 		if manifestConfig.SourcePath != "" {
 			defaultKustomizePath = manifestConfig.SourcePath
 		}

--- a/components/trustyai/trustyai.go
+++ b/components/trustyai/trustyai.go
@@ -19,8 +19,9 @@ import (
 )
 
 var (
-	ComponentName = "trustyai"
-	Path          = deploy.DefaultManifestPath + "/" + "trustyai-service-operator/base"
+	ComponentName     = "trustyai"
+	ComponentPathName = "trustyai-service-operator"
+	Path              = deploy.DefaultManifestPath + "/" + ComponentPathName + "/base"
 )
 
 // Verifies that TrustyAI implements ComponentInterface.
@@ -36,7 +37,7 @@ func (t *TrustyAI) OverrideManifests(_ string) error {
 	// If devflags are set, update default manifests path
 	if len(t.DevFlags.Manifests) != 0 {
 		manifestConfig := t.DevFlags.Manifests[0]
-		if err := deploy.DownloadManifests(ComponentName, manifestConfig); err != nil {
+		if err := deploy.DownloadManifests(ComponentPathName, manifestConfig); err != nil {
 			return err
 		}
 		// If overlay is defined, update paths
@@ -44,7 +45,7 @@ func (t *TrustyAI) OverrideManifests(_ string) error {
 		if manifestConfig.SourcePath != "" {
 			defaultKustomizePath = manifestConfig.SourcePath
 		}
-		Path = filepath.Join(deploy.DefaultManifestPath, ComponentName, defaultKustomizePath)
+		Path = filepath.Join(deploy.DefaultManifestPath, ComponentPathName, defaultKustomizePath)
 	}
 	return nil
 }

--- a/config/crd/bases/datasciencecluster.opendatahub.io_datascienceclusters.yaml
+++ b/config/crd/bases/datasciencecluster.opendatahub.io_datascienceclusters.yaml
@@ -54,9 +54,10 @@ spec:
                             items:
                               properties:
                                 contextDir:
-                                  default: ""
+                                  default: manifests
                                   description: contextDir is the relative path to
-                                    the folder containing manifests in a repository
+                                    the folder containing manifests in a repository,
+                                    default value "manifests"
                                   type: string
                                 sourcePath:
                                   default: ""
@@ -97,9 +98,10 @@ spec:
                             items:
                               properties:
                                 contextDir:
-                                  default: ""
+                                  default: manifests
                                   description: contextDir is the relative path to
-                                    the folder containing manifests in a repository
+                                    the folder containing manifests in a repository,
+                                    default value "manifests"
                                   type: string
                                 sourcePath:
                                   default: ""
@@ -141,9 +143,10 @@ spec:
                             items:
                               properties:
                                 contextDir:
-                                  default: ""
+                                  default: manifests
                                   description: contextDir is the relative path to
-                                    the folder containing manifests in a repository
+                                    the folder containing manifests in a repository,
+                                    default value "manifests"
                                   type: string
                                 sourcePath:
                                   default: ""
@@ -199,9 +202,10 @@ spec:
                             items:
                               properties:
                                 contextDir:
-                                  default: ""
+                                  default: manifests
                                   description: contextDir is the relative path to
-                                    the folder containing manifests in a repository
+                                    the folder containing manifests in a repository,
+                                    default value "manifests"
                                   type: string
                                 sourcePath:
                                   default: ""
@@ -302,9 +306,10 @@ spec:
                             items:
                               properties:
                                 contextDir:
-                                  default: ""
+                                  default: manifests
                                   description: contextDir is the relative path to
-                                    the folder containing manifests in a repository
+                                    the folder containing manifests in a repository,
+                                    default value "manifests"
                                   type: string
                                 sourcePath:
                                   default: ""
@@ -346,9 +351,10 @@ spec:
                             items:
                               properties:
                                 contextDir:
-                                  default: ""
+                                  default: manifests
                                   description: contextDir is the relative path to
-                                    the folder containing manifests in a repository
+                                    the folder containing manifests in a repository,
+                                    default value "manifests"
                                   type: string
                                 sourcePath:
                                   default: ""
@@ -389,9 +395,10 @@ spec:
                             items:
                               properties:
                                 contextDir:
-                                  default: ""
+                                  default: manifests
                                   description: contextDir is the relative path to
-                                    the folder containing manifests in a repository
+                                    the folder containing manifests in a repository,
+                                    default value "manifests"
                                   type: string
                                 sourcePath:
                                   default: ""
@@ -432,9 +439,10 @@ spec:
                             items:
                               properties:
                                 contextDir:
-                                  default: ""
+                                  default: manifests
                                   description: contextDir is the relative path to
-                                    the folder containing manifests in a repository
+                                    the folder containing manifests in a repository,
+                                    default value "manifests"
                                   type: string
                                 sourcePath:
                                   default: ""
@@ -475,9 +483,10 @@ spec:
                             items:
                               properties:
                                 contextDir:
-                                  default: ""
+                                  default: manifests
                                   description: contextDir is the relative path to
-                                    the folder containing manifests in a repository
+                                    the folder containing manifests in a repository,
+                                    default value "manifests"
                                   type: string
                                 sourcePath:
                                   default: ""
@@ -518,9 +527,10 @@ spec:
                             items:
                               properties:
                                 contextDir:
-                                  default: ""
+                                  default: manifests
                                   description: contextDir is the relative path to
-                                    the folder containing manifests in a repository
+                                    the folder containing manifests in a repository,
+                                    default value "manifests"
                                   type: string
                                 sourcePath:
                                   default: ""
@@ -561,9 +571,10 @@ spec:
                             items:
                               properties:
                                 contextDir:
-                                  default: ""
+                                  default: manifests
                                   description: contextDir is the relative path to
-                                    the folder containing manifests in a repository
+                                    the folder containing manifests in a repository,
+                                    default value "manifests"
                                   type: string
                                 sourcePath:
                                   default: ""

--- a/docs/api-overview.md
+++ b/docs/api-overview.md
@@ -94,7 +94,7 @@ _Appears in:_
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
 | `uri` _string_ | uri is the URI point to a git repo with tag/branch. e.g.  https://github.com/org/repo/tarball/<tag/branch> |  |  |
-| `contextDir` _string_ | contextDir is the relative path to the folder containing manifests in a repository |  |  |
+| `contextDir` _string_ | contextDir is the relative path to the folder containing manifests in a repository, default value "manifests" | manifests |  |
 | `sourcePath` _string_ | sourcePath is the subpath within contextDir where kustomize builds start. Examples include any sub-folder or path: `base`, `overlays/dev`, `default`, `odh` etc. |  |  |
 
 


### PR DESCRIPTION
- we have a bit lag for maintain the devFlags since new componets added and path changed
- contextDir is not necessary if it has default value

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
ref: https://issues.redhat.com/browse/RHOAIENG-6882

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
