### PR TITLE
deploy: refactor whitelisting with custom kustomize RemoverPlugin

### DIFF
--- a/pkg/cluster/gvk/gvk.go
+++ b/pkg/cluster/gvk/gvk.go
@@ -9,6 +9,12 @@ var (
 		Kind:    "ClusterServiceVersion",
 	}
 
+	Deployment = schema.GroupVersionKind{
+		Group:   "apps",
+		Version: "v1",
+		Kind:    "Deployment",
+	}
+
 	KnativeServing = schema.GroupVersionKind{
 		Group:   "operator.knative.dev",
 		Version: "v1beta1",

--- a/pkg/plugins/remover_plugin_test.go
+++ b/pkg/plugins/remover_plugin_test.go
@@ -1,0 +1,266 @@
+package plugins_test
+
+import (
+	"sigs.k8s.io/kustomize/api/provider"
+	"sigs.k8s.io/kustomize/api/resource"
+
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/plugins"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var factory = provider.NewDefaultDepProvider().GetResourceFactory()
+
+var _ = Describe("Remover plugin", func() {
+	var res *resource.Resource
+
+	BeforeEach(func() {
+		var err error
+		res, err = factory.FromBytes([]byte(`
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: testdeployment
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      control-plane: odh-component
+  template:
+    metadata:
+      labels:
+        app: odh-component
+        app.opendatahub.io/odh-component: "true"
+        control-plane: odh-component
+    spec:
+      containers:
+      - name: conatiner0
+        env:
+        - name: NAMESPACE
+          value: namespace
+        image: quay.io/opendatahub/odh-component:latest
+        ports:
+        - containerPort: 80
+      - name: conatiner1
+        env:
+        - name: NAMESPACE
+          value: namespace
+        image: quay.io/opendatahub/odh-component:latest
+        ports:
+        - containerPort: 8080
+        resources:
+          limits:
+            cpu: 500m
+            memory: 2Gi
+          requests:
+            cpu: 10m
+            memory: 64Mi
+
+`))
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("Should remove replicas", func() {
+		rmPlug := plugins.RemoverPlugin{
+			Gvk:  gvk.Deployment,
+			Path: []string{"spec", "replicas"},
+		}
+
+		expected := `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: testdeployment
+spec:
+  selector:
+    matchLabels:
+      control-plane: odh-component
+  template:
+    metadata:
+      labels:
+        app: odh-component
+        app.opendatahub.io/odh-component: "true"
+        control-plane: odh-component
+    spec:
+      containers:
+      - name: conatiner0
+        env:
+        - name: NAMESPACE
+          value: namespace
+        image: quay.io/opendatahub/odh-component:latest
+        ports:
+        - containerPort: 80
+      - name: conatiner1
+        env:
+        - name: NAMESPACE
+          value: namespace
+        image: quay.io/opendatahub/odh-component:latest
+        ports:
+        - containerPort: 8080
+        resources:
+          limits:
+            cpu: 500m
+            memory: 2Gi
+          requests:
+            cpu: 10m
+            memory: 64Mi
+
+`
+		err := rmPlug.TransformResource(res)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(res.MustYaml()).To(MatchYAML(expected))
+	})
+
+	It("Should remove resources", func() {
+		rmPlug := plugins.RemoverPlugin{
+			Gvk:  gvk.Deployment,
+			Path: []string{"spec", "template", "spec", "containers", "*", "resources"},
+		}
+
+		expected := `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: testdeployment
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      control-plane: odh-component
+  template:
+    metadata:
+      labels:
+        app: odh-component
+        app.opendatahub.io/odh-component: "true"
+        control-plane: odh-component
+    spec:
+      containers:
+      - name: conatiner0
+        env:
+        - name: NAMESPACE
+          value: namespace
+        image: quay.io/opendatahub/odh-component:latest
+        ports:
+        - containerPort: 80
+      - name: conatiner1
+        env:
+        - name: NAMESPACE
+          value: namespace
+        image: quay.io/opendatahub/odh-component:latest
+        ports:
+        - containerPort: 8080
+`
+		err := rmPlug.TransformResource(res)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(res.MustYaml()).To(MatchYAML(expected))
+	})
+
+	It("Should remove replicas and resources", func() {
+		rmPlugRep := plugins.RemoverPlugin{
+			Gvk:  gvk.Deployment,
+			Path: []string{"spec", "replicas"},
+		}
+		rmPlugRes := plugins.RemoverPlugin{
+			Gvk:  gvk.Deployment,
+			Path: []string{"spec", "template", "spec", "containers", "*", "resources"},
+		}
+
+		expected := `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: testdeployment
+spec:
+  selector:
+    matchLabels:
+      control-plane: odh-component
+  template:
+    metadata:
+      labels:
+        app: odh-component
+        app.opendatahub.io/odh-component: "true"
+        control-plane: odh-component
+    spec:
+      containers:
+      - name: conatiner0
+        env:
+        - name: NAMESPACE
+          value: namespace
+        image: quay.io/opendatahub/odh-component:latest
+        ports:
+        - containerPort: 80
+      - name: conatiner1
+        env:
+        - name: NAMESPACE
+          value: namespace
+        image: quay.io/opendatahub/odh-component:latest
+        ports:
+        - containerPort: 8080
+`
+		err := rmPlugRep.TransformResource(res)
+		Expect(err).NotTo(HaveOccurred())
+
+		err = rmPlugRes.TransformResource(res)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(res.MustYaml()).To(MatchYAML(expected))
+	})
+
+	It("Should not change if field does not exist", func() {
+		rmPlug := plugins.RemoverPlugin{
+			Gvk:  gvk.Deployment,
+			Path: []string{"spec", "unexisted"},
+		}
+
+		expected := `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: testdeployment
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      control-plane: odh-component
+  template:
+    metadata:
+      labels:
+        app: odh-component
+        app.opendatahub.io/odh-component: "true"
+        control-plane: odh-component
+    spec:
+      containers:
+      - name: conatiner0
+        env:
+        - name: NAMESPACE
+          value: namespace
+        image: quay.io/opendatahub/odh-component:latest
+        ports:
+        - containerPort: 80
+      - name: conatiner1
+        env:
+        - name: NAMESPACE
+          value: namespace
+        image: quay.io/opendatahub/odh-component:latest
+        ports:
+        - containerPort: 8080
+        resources:
+          limits:
+            cpu: 500m
+            memory: 2Gi
+          requests:
+            cpu: 10m
+            memory: 64Mi
+
+`
+		err := rmPlug.TransformResource(res)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(res.MustYaml()).To(MatchYAML(expected))
+	})
+
+})

--- a/pkg/plugins/removerplugin.go
+++ b/pkg/plugins/removerplugin.go
@@ -1,0 +1,85 @@
+package plugins
+
+import (
+	"errors"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/kustomize/api/resmap"
+	"sigs.k8s.io/kustomize/api/resource"
+	"sigs.k8s.io/kustomize/kyaml/kio"
+	kyaml "sigs.k8s.io/kustomize/kyaml/yaml"
+)
+
+// Removes the field from the resources of ResMap if they match GVK.
+type RemoverPlugin struct {
+	Gvk  schema.GroupVersionKind
+	Path []string
+}
+
+var _ resmap.Transformer = &RemoverPlugin{}
+
+type RemoverFilter struct {
+	Gvk  schema.GroupVersionKind
+	Path []string
+}
+
+var _ kio.Filter = RemoverFilter{}
+
+func (f RemoverFilter) Filter(nodes []*kyaml.RNode) ([]*kyaml.RNode, error) {
+	return kio.FilterAll(kyaml.FilterFunc(f.run)).Filter(nodes)
+}
+
+func (f RemoverFilter) run(node *kyaml.RNode) (*kyaml.RNode, error) {
+	pathLen := len(f.Path)
+	if pathLen == 0 {
+		return node, errors.New("no field set to remove, path to the field cannot be empty")
+	}
+
+	typeMeta := kyaml.TypeMeta{
+		APIVersion: f.Gvk.GroupVersion().String(),
+		Kind:       f.Gvk.Kind,
+	}
+
+	meta, err := node.GetMeta()
+	if err != nil {
+		return node, err
+	}
+
+	if meta.TypeMeta != typeMeta {
+		return node, nil
+	}
+
+	path := f.Path[:pathLen-1]
+	name := f.Path[pathLen-1]
+
+	matcher := &kyaml.PathMatcher{Path: path}
+	result, err := node.Pipe(matcher)
+	if err != nil {
+		return node, err
+	}
+
+	return node, result.VisitElements(
+		func(node *kyaml.RNode) error {
+			return node.PipeE(kyaml.FieldClearer{Name: name})
+		})
+}
+
+func (p *RemoverPlugin) Transform(m resmap.ResMap) error {
+	filter := RemoverFilter{
+		Gvk:  p.Gvk,
+		Path: p.Path,
+	}
+	return m.ApplyFilter(filter)
+}
+
+// TransformResource is an additional method to work not on the whole ResMap but one resource.
+func (p *RemoverPlugin) TransformResource(r *resource.Resource) error {
+	filter := RemoverFilter{
+		Gvk:  p.Gvk,
+		Path: p.Path,
+	}
+
+	nodes := []*kyaml.RNode{&r.RNode}
+	_, err := filter.Filter(nodes)
+	return err
+}

--- a/pkg/plugins/suite_test.go
+++ b/pkg/plugins/suite_test.go
@@ -1,0 +1,14 @@
+package plugins_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestPlugins(t *testing.T) {
+	RegisterFailHandler(Fail)
+
+	RunSpecs(t, "Plugins test suite")
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

This patchset implements custom kustomize plugin RemoverPlugin to make it easier field removing specific fields from specific GroupVersionKind resources. The path to the component accept the same fields addresses as `replacement` feature. And takes it in use for existing Deployment whitelisting

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?

- deploy original ODH
- amend some component deployment resources
- observe the changes reverted after short time (several seconds)
- deploy patched ODH
- delete (restart) ODH controller pod
- amend some component deployment resources
- observe the changes preserved

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
