### PR TITLE
chore: moves operator/subscriptions funcs to pkg/cluster

### DIFF
--- a/components/codeflare/codeflare.go
+++ b/components/codeflare/codeflare.go
@@ -81,7 +81,7 @@ func (c *CodeFlare) ReconcileComponent(ctx context.Context, cli client.Client, l
 		// Both ODH and RHOAI should have the same operator name
 		dependentOperator := CodeflareOperator
 
-		if found, err := deploy.OperatorExists(cli, dependentOperator); err != nil {
+		if found, err := cluster.OperatorExists(cli, dependentOperator); err != nil {
 			return fmt.Errorf("operator exists throws error %w", err)
 		} else if found {
 			return fmt.Errorf("operator %s is found. Please uninstall the operator before enabling %s component",

--- a/components/kserve/servicemesh_setup.go
+++ b/components/kserve/servicemesh_setup.go
@@ -8,7 +8,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	dsciv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/dscinitialization/v1"
-	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/deploy"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/feature"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/feature/servicemesh"
 )
@@ -32,7 +32,7 @@ func (k *Kserve) removeServiceMeshConfigurations(cli client.Client, dscispec *ds
 
 func (k *Kserve) defineServiceMeshFeatures(cli client.Client) feature.FeaturesProvider {
 	return func(handler *feature.FeaturesHandler) error {
-		authorinoInstalled, err := deploy.ClusterSubscriptionExists(cli, "authorino-operator")
+		authorinoInstalled, err := cluster.SubscriptionExists(cli, "authorino-operator")
 		if err != nil {
 			return fmt.Errorf("failed to list subscriptions %w", err)
 		}

--- a/controllers/dscinitialization/servicemesh_setup.go
+++ b/controllers/dscinitialization/servicemesh_setup.go
@@ -10,7 +10,7 @@ import (
 
 	dsciv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/dscinitialization/v1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/controllers/status"
-	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/deploy"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/feature"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/feature/servicemesh"
 )
@@ -86,7 +86,7 @@ func (r *DSCInitializationReconciler) serviceMeshCapability(instance *dsciv1.DSC
 }
 
 func (r *DSCInitializationReconciler) authorizationCapability(instance *dsciv1.DSCInitialization, condition *conditionsv1.Condition) (*feature.HandlerWithReporter[*dsciv1.DSCInitialization], error) { //nolint:lll // Reason: generics are long
-	authorinoInstalled, err := deploy.ClusterSubscriptionExists(r.Client, "authorino-operator")
+	authorinoInstalled, err := cluster.SubscriptionExists(r.Client, "authorino-operator")
 	if err != nil {
 		return nil, fmt.Errorf("failed to list subscriptions %w", err)
 	}

--- a/pkg/cluster/operator.go
+++ b/pkg/cluster/operator.go
@@ -1,0 +1,69 @@
+package cluster
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/operator-framework/api/pkg/operators/v1alpha1"
+	v2 "github.com/operator-framework/api/pkg/operators/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// GetSubscription checks if a Subscription for the operator exists in the given namespace.
+// if exists, return object; otherwise, return error.
+func GetSubscription(cli client.Client, namespace string, name string) (*v1alpha1.Subscription, error) {
+	sub := &v1alpha1.Subscription{}
+	if err := cli.Get(context.TODO(), client.ObjectKey{Namespace: namespace, Name: name}, sub); err != nil {
+		// real error or 'not found' both return here
+		return nil, err
+	}
+	return sub, nil
+}
+
+func SubscriptionExists(cli client.Client, name string) (bool, error) {
+	subscriptionList := &v1alpha1.SubscriptionList{}
+	if err := cli.List(context.TODO(), subscriptionList); err != nil {
+		return false, err
+	}
+
+	for _, sub := range subscriptionList.Items {
+		if sub.Name == name {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// DeleteExistingSubscription deletes given Subscription if it exists
+// Do not error if the Subscription does not exist.
+func DeleteExistingSubscription(cli client.Client, operatorNs string, subsName string) error {
+	sub, err := GetSubscription(cli, operatorNs, subsName)
+	if err != nil {
+		return client.IgnoreNotFound(err)
+	}
+
+	if err := cli.Delete(context.TODO(), sub); client.IgnoreNotFound(err) != nil {
+		return fmt.Errorf("error deleting subscription %s: %w", sub.Name, err)
+	}
+
+	return nil
+}
+
+// OperatorExists checks if an Operator with 'operatorPrefix' is installed.
+// Return true if found it, false if not.
+// if we need to check exact version of the operator installed, can append vX.Y.Z later.
+func OperatorExists(cli client.Client, operatorPrefix string) (bool, error) {
+	opConditionList := &v2.OperatorConditionList{}
+	err := cli.List(context.TODO(), opConditionList)
+	if err != nil {
+		return false, err
+	}
+	for _, opCondition := range opConditionList.Items {
+		if strings.HasPrefix(opCondition.Name, operatorPrefix) {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}

--- a/pkg/deploy/deploy.go
+++ b/pkg/deploy/deploy.go
@@ -31,8 +31,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	ofapiv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
-	ofapiv2 "github.com/operator-framework/api/pkg/operators/v2"
 	"golang.org/x/exp/maps"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -353,38 +351,6 @@ func removeResourcesFromDeployment(u *unstructured.Unstructured) error {
 	}
 
 	return nil
-}
-
-func ClusterSubscriptionExists(cli client.Client, name string) (bool, error) {
-	subscriptionList := &ofapiv1alpha1.SubscriptionList{}
-	if err := cli.List(context.TODO(), subscriptionList); err != nil {
-		return false, err
-	}
-
-	for _, sub := range subscriptionList.Items {
-		if sub.Name == name {
-			return true, nil
-		}
-	}
-	return false, nil
-}
-
-// OperatorExists checks if an Operator with 'operatorPrefix' is installed.
-// Return true if found it, false if not.
-// if we need to check exact version of the operator installed, can append vX.Y.Z later.
-func OperatorExists(cli client.Client, operatorPrefix string) (bool, error) {
-	opConditionList := &ofapiv2.OperatorConditionList{}
-	err := cli.List(context.TODO(), opConditionList)
-	if err != nil {
-		return false, err
-	}
-	for _, opCondition := range opConditionList.Items {
-		if strings.HasPrefix(opCondition.Name, operatorPrefix) {
-			return true, nil
-		}
-	}
-
-	return false, nil
 }
 
 func getResource(ctx context.Context, cli client.Client, obj *unstructured.Unstructured) (*unstructured.Unstructured, error) {

--- a/pkg/feature/conditions.go
+++ b/pkg/feature/conditions.go
@@ -11,7 +11,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/deploy"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
 )
 
 const (
@@ -41,7 +41,7 @@ func (e *MissingOperatorError) Error() string {
 
 func EnsureOperatorIsInstalled(operatorName string) Action {
 	return func(f *Feature) error {
-		if found, err := deploy.ClusterSubscriptionExists(f.Client, operatorName); !found || err != nil {
+		if found, err := cluster.SubscriptionExists(f.Client, operatorName); !found || err != nil {
 			return fmt.Errorf(
 				"failed to find the pre-requisite operator subscription %q, please ensure operator is installed. %w",
 				operatorName,

--- a/pkg/upgrade/uninstallation.go
+++ b/pkg/upgrade/uninstallation.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-multierror"
-	ofapiv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -81,7 +80,7 @@ func OperatorUninstall(ctx context.Context, cli client.Client) error {
 		subsName = "rhods-operator"
 	}
 	if platform != cluster.ManagedRhods {
-		if err := DeleteExistingSubscription(cli, operatorNs, subsName); err != nil {
+		if err := cluster.DeleteExistingSubscription(cli, operatorNs, subsName); err != nil {
 			return err
 		}
 	}
@@ -161,30 +160,4 @@ func removeCSV(ctx context.Context, c client.Client) error {
 	}
 	fmt.Printf("No clusterserviceversion for the operator found.\n")
 	return nil
-}
-
-// DeleteExistingSubscription deletes given Subscription if it exists
-// Do not error if the Subscription does not exist.
-func DeleteExistingSubscription(cli client.Client, operatorNs string, subsName string) error {
-	sub, err := getSubscription(cli, operatorNs, subsName)
-	if err != nil {
-		return client.IgnoreNotFound(err)
-	}
-
-	if err := cli.Delete(context.TODO(), sub); client.IgnoreNotFound(err) != nil {
-		return fmt.Errorf("error deleting subscription %s: %w", sub.Name, err)
-	}
-
-	return nil
-}
-
-// GetSubscription checks if a Subscription for the operator exists in the given namespace.
-// if exist, return object; otherwise, return error.
-func getSubscription(cli client.Client, namespace string, name string) (*ofapiv1alpha1.Subscription, error) {
-	sub := &ofapiv1alpha1.Subscription{}
-	if err := cli.Get(context.TODO(), client.ObjectKey{Namespace: namespace, Name: name}, sub); err != nil {
-		// real error or 'not found' both return here
-		return nil, err
-	}
-	return sub, nil
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

They do not belong to `pkg/deploy` as they are about reading/writing cluster resources rather than deploying resources.

I also think `pkg/deploy/deploy.go` should be reviewed and responsibilities split even further, as now it's still doing both kustomize manifests deployments and cluster resources manipulation which were added lately.

This change is stacked PR which unblocks us from cyclic import on our end :)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
