### PR TITLE
cluster_config: make GetClusterServiceVersion return NotFound error

### DIFF
--- a/pkg/cluster/gvk/gvk.go
+++ b/pkg/cluster/gvk/gvk.go
@@ -3,6 +3,12 @@ package gvk
 import "k8s.io/apimachinery/pkg/runtime/schema"
 
 var (
+	ClusterServiceVersion = schema.GroupVersionKind{
+		Group:   "operators.coreos.com",
+		Version: "v1alpha1",
+		Kind:    "ClusterServiceVersion",
+	}
+
 	KnativeServing = schema.GroupVersionKind{
 		Group:   "operator.knative.dev",
 		Version: "v1beta1",

--- a/pkg/upgrade/uninstallation.go
+++ b/pkg/upgrade/uninstallation.go
@@ -141,23 +141,25 @@ func removeCSV(ctx context.Context, c client.Client) error {
 	}
 
 	operatorCsv, err := cluster.GetClusterServiceVersion(ctx, c, operatorNamespace)
+	if apierrs.IsNotFound(err) {
+		fmt.Printf("No clusterserviceversion for the operator found.\n")
+		return nil
+	}
+
 	if err != nil {
 		return err
 	}
 
-	if operatorCsv != nil {
-		fmt.Printf("Deleting CSV %s\n", operatorCsv.Name)
-		err = c.Delete(ctx, operatorCsv)
-		if err != nil {
-			if apierrs.IsNotFound(err) {
-				return nil
-			}
-
-			return fmt.Errorf("error deleting clusterserviceversion: %w", err)
+	fmt.Printf("Deleting CSV %s\n", operatorCsv.Name)
+	err = c.Delete(ctx, operatorCsv)
+	if err != nil {
+		if apierrs.IsNotFound(err) {
+			return nil
 		}
-		fmt.Printf("Clusterserviceversion %s deleted as a part of uninstall.\n", operatorCsv.Name)
-		return nil
+
+		return fmt.Errorf("error deleting clusterserviceversion: %w", err)
 	}
-	fmt.Printf("No clusterserviceversion for the operator found.\n")
+	fmt.Printf("Clusterserviceversion %s deleted as a part of uninstall.\n", operatorCsv.Name)
+
 	return nil
 }


### PR DESCRIPTION
GetClusterServiceVersion() may return nil error and nil pointer. On one hand it's ok to check object for nil in not found condition but it's a bit counter intuitive to have err nil when there is acutally "not found"

It caused a problem in GetVersion where this nil condition was not checked.

Refactor it to return the error and handle it properly.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
