### PR TITLE
chore: append ownerRef to resources owned by Features

### DIFF
--- a/pkg/cluster/cluster_operations_int_test.go
+++ b/pkg/cluster/cluster_operations_int_test.go
@@ -92,6 +92,13 @@ var _ = Describe("Creating cluster resources", func() {
 			Namespace: "default",
 		}
 
+		owner := &v1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "default",
+				UID:  "default",
+			},
+		}
+
 		It("should create configmap with labels and owner reference", func() {
 			// given
 			configMap := &v1.ConfigMap{
@@ -107,12 +114,7 @@ var _ = Describe("Creating cluster resources", func() {
 				envTestClient,
 				configMap,
 				cluster.WithLabels(labels.K8SCommon.PartOf, "opendatahub"),
-				cluster.WithOwnerReference(metav1.OwnerReference{
-					APIVersion: "v1",
-					Kind:       "Namespace",
-					Name:       "default",
-					UID:        "default",
-				}),
+				cluster.OwnedBy(owner, envTestClient.Scheme()),
 			)
 			Expect(err).ToNot(HaveOccurred())
 			defer objectCleaner.DeleteAll(configMap)

--- a/pkg/cluster/meta.go
+++ b/pkg/cluster/meta.go
@@ -22,13 +22,6 @@ func ApplyMetaOptions(obj metav1.Object, opts ...MetaOptions) error {
 	return nil
 }
 
-func WithOwnerReference(ownerReferences ...metav1.OwnerReference) MetaOptions {
-	return func(obj metav1.Object) error {
-		obj.SetOwnerReferences(ownerReferences)
-		return nil
-	}
-}
-
 func OwnedBy(owner metav1.Object, scheme *runtime.Scheme) MetaOptions {
 	return func(obj metav1.Object) error {
 		return controllerutil.SetOwnerReference(owner, obj, scheme)

--- a/pkg/feature/feature.go
+++ b/pkg/feature/feature.go
@@ -160,7 +160,7 @@ func (f *Feature) createApplier(m Manifest) applier {
 	}
 
 	return func(objects []*unstructured.Unstructured) error {
-		return applyResources(f.Client, objects, OwnedBy(f))
+		return applyResources(f.Client, objects, OwnedByFeatureTracker(f))
 	}
 }
 
@@ -197,6 +197,6 @@ func (f *Feature) AsOwnerReference() metav1.OwnerReference {
 	return f.Tracker.ToOwnerReference()
 }
 
-func OwnedBy(f *Feature) cluster.MetaOptions {
-	return cluster.WithOwnerReference(f.AsOwnerReference())
+func OwnedByFeatureTracker(f *Feature) cluster.MetaOptions {
+	return cluster.OwnedBy(f.Tracker, f.Client.Scheme())
 }

--- a/pkg/feature/servicemesh/conditions.go
+++ b/pkg/feature/servicemesh/conditions.go
@@ -28,7 +28,7 @@ func EnsureAuthNamespaceExists(f *feature.Feature) error {
 		return resolveNsErr
 	}
 
-	_, err := cluster.CreateNamespace(context.TODO(), f.Client, f.Spec.Auth.Namespace, feature.OwnedBy(f), cluster.WithLabels(labels.ODH.OwnedNamespace, "true"))
+	_, err := cluster.CreateNamespace(context.TODO(), f.Client, f.Spec.Auth.Namespace, feature.OwnedByFeatureTracker(f), cluster.WithLabels(labels.ODH.OwnedNamespace, "true"))
 	return err
 }
 

--- a/pkg/feature/servicemesh/resources.go
+++ b/pkg/feature/servicemesh/resources.go
@@ -32,7 +32,7 @@ func MeshRefs(f *feature.Feature) error {
 			},
 			Data: data,
 		},
-		feature.OwnedBy(f),
+		feature.OwnedByFeatureTracker(f),
 	)
 }
 
@@ -66,6 +66,6 @@ func AuthRefs(f *feature.Feature) error {
 			},
 			Data: data,
 		},
-		feature.OwnedBy(f),
+		feature.OwnedByFeatureTracker(f),
 	)
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This PR changes the way that `OwnerReference`s are added to resources created by Features. Previously, we were calling `unstructured.SetOwnerReferences` on objects to add the ownerReference to the relevant resources. This function was not appropriate for our usage, as it sets the ownerReferences on the object by replacing the object's OwnerReferences, potentially losing existing OwnerRefs that the object may have.

The PR changes it so we now call `controllerutil.SetOwnerReference(owner, obj, scheme)` which upsert's the owner into the object's OwnerReferences.

This sets up for a follow-up PR adding the relevant Owning DSC/DSCI to resources marked as Managed() in the FeatureBuilder.  

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Ensured preexisting unit test checking ownerReferences still functioned, deployed operator with changes `quay.io/cgarriso/opendatahub-operator:dev-append-ownerref` and ensured objects (eg. SMCP) still had the FeatureTracker in their OwnerReferences.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
