### PR TITLE
add: get permission on resources

### DIFF
--- a/bundle/manifests/opendatahub-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/opendatahub-operator.clusterserviceversion.yaml
@@ -317,6 +317,7 @@ spec:
           - tokenreviews
           verbs:
           - create
+          - get
         - apiGroups:
           - authorino.kuadrant.io
           resources:
@@ -329,6 +330,7 @@ spec:
           - subjectaccessreviews
           verbs:
           - create
+          - get
         - apiGroups:
           - authorization.openshift.io
           resources:
@@ -360,6 +362,7 @@ spec:
           verbs:
           - create
           - delete
+          - get
           - list
           - patch
           - update
@@ -370,6 +373,7 @@ spec:
           - machineautoscalers
           verbs:
           - delete
+          - get
           - list
           - patch
         - apiGroups:
@@ -378,6 +382,7 @@ spec:
           - machinesets
           verbs:
           - delete
+          - get
           - list
           - patch
         - apiGroups:
@@ -417,6 +422,7 @@ spec:
           verbs:
           - create
           - delete
+          - get
           - list
           - patch
           - watch
@@ -438,6 +444,7 @@ spec:
           verbs:
           - create
           - delete
+          - get
           - list
           - patch
           - watch
@@ -454,6 +461,7 @@ spec:
           resources:
           - clusterversions
           verbs:
+          - get
           - list
           - watch
         - apiGroups:
@@ -507,6 +515,7 @@ spec:
           resources:
           - clusterversions
           verbs:
+          - get
           - list
           - watch
         - apiGroups:
@@ -577,6 +586,7 @@ spec:
           - namespaces/finalizers
           verbs:
           - delete
+          - get
           - list
           - patch
           - update
@@ -616,6 +626,7 @@ spec:
           resources:
           - rhmis
           verbs:
+          - get
           - list
           - watch
         - apiGroups:
@@ -674,6 +685,7 @@ spec:
           verbs:
           - create
           - delete
+          - get
           - list
           - patch
           - update
@@ -758,6 +770,7 @@ spec:
           resources:
           - datasciencepipelinesapplications/finalizers
           verbs:
+          - get
           - patch
           - update
         - apiGroups:
@@ -804,6 +817,7 @@ spec:
           - events
           verbs:
           - delete
+          - get
           - list
           - patch
           - watch
@@ -880,6 +894,7 @@ spec:
           - rhmis
           verbs:
           - delete
+          - get
           - list
           - patch
           - watch
@@ -907,6 +922,7 @@ spec:
           - machineautoscalers
           verbs:
           - delete
+          - get
           - list
           - patch
         - apiGroups:
@@ -915,6 +931,7 @@ spec:
           - machinesets
           verbs:
           - delete
+          - get
           - list
           - patch
         - apiGroups:
@@ -988,6 +1005,7 @@ spec:
           resources:
           - modelregistries/finalizers
           verbs:
+          - get
           - update
         - apiGroups:
           - modelregistry.opendatahub.io
@@ -1178,6 +1196,7 @@ spec:
           - virtualservices/status
           verbs:
           - delete
+          - get
           - patch
           - update
         - apiGroups:
@@ -1246,6 +1265,7 @@ spec:
           - consoles
           verbs:
           - delete
+          - get
           - list
           - patch
           - watch
@@ -1410,6 +1430,7 @@ spec:
           verbs:
           - create
           - delete
+          - get
           - list
           - patch
           - update
@@ -1421,6 +1442,7 @@ spec:
           verbs:
           - create
           - delete
+          - get
           - list
           - patch
           - update
@@ -1431,6 +1453,7 @@ spec:
           - services/status
           verbs:
           - delete
+          - get
           - patch
           - update
         - apiGroups:
@@ -1440,6 +1463,7 @@ spec:
           verbs:
           - create
           - delete
+          - get
           - list
           - patch
           - update
@@ -1451,6 +1475,7 @@ spec:
           verbs:
           - create
           - delete
+          - get
           - list
           - patch
           - update
@@ -1461,6 +1486,7 @@ spec:
           - clusterservingruntimes/status
           verbs:
           - delete
+          - get
           - patch
           - update
         - apiGroups:
@@ -1470,6 +1496,7 @@ spec:
           verbs:
           - create
           - delete
+          - get
           - list
           - patch
           - update
@@ -1480,6 +1507,7 @@ spec:
           - inferencegraphs/status
           verbs:
           - delete
+          - get
           - patch
           - update
         - apiGroups:
@@ -1512,6 +1540,7 @@ spec:
           - inferenceservices/status
           verbs:
           - delete
+          - get
           - patch
           - update
         - apiGroups:
@@ -1521,6 +1550,7 @@ spec:
           verbs:
           - create
           - delete
+          - get
           - list
           - patch
           - update
@@ -1530,6 +1560,7 @@ spec:
           resources:
           - predictors/finalizers
           verbs:
+          - get
           - patch
           - update
         - apiGroups:
@@ -1538,6 +1569,7 @@ spec:
           - predictors/status
           verbs:
           - delete
+          - get
           - patch
           - update
         - apiGroups:
@@ -1563,6 +1595,7 @@ spec:
           resources:
           - servingruntimes/status
           verbs:
+          - get
           - patch
           - update
         - apiGroups:
@@ -1572,6 +1605,7 @@ spec:
           verbs:
           - create
           - delete
+          - get
           - list
           - patch
           - update
@@ -1582,6 +1616,7 @@ spec:
           - trainedmodels/status
           verbs:
           - delete
+          - get
           - patch
           - update
         - apiGroups:
@@ -1648,6 +1683,7 @@ spec:
           - users
           verbs:
           - delete
+          - get
           - list
           - patch
           - watch

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -132,6 +132,7 @@ rules:
   - tokenreviews
   verbs:
   - create
+  - get
 - apiGroups:
   - authorino.kuadrant.io
   resources:
@@ -144,6 +145,7 @@ rules:
   - subjectaccessreviews
   verbs:
   - create
+  - get
 - apiGroups:
   - authorization.openshift.io
   resources:
@@ -175,6 +177,7 @@ rules:
   verbs:
   - create
   - delete
+  - get
   - list
   - patch
   - update
@@ -185,6 +188,7 @@ rules:
   - machineautoscalers
   verbs:
   - delete
+  - get
   - list
   - patch
 - apiGroups:
@@ -193,6 +197,7 @@ rules:
   - machinesets
   verbs:
   - delete
+  - get
   - list
   - patch
 - apiGroups:
@@ -232,6 +237,7 @@ rules:
   verbs:
   - create
   - delete
+  - get
   - list
   - patch
   - watch
@@ -253,6 +259,7 @@ rules:
   verbs:
   - create
   - delete
+  - get
   - list
   - patch
   - watch
@@ -269,6 +276,7 @@ rules:
   resources:
   - clusterversions
   verbs:
+  - get
   - list
   - watch
 - apiGroups:
@@ -322,6 +330,7 @@ rules:
   resources:
   - clusterversions
   verbs:
+  - get
   - list
   - watch
 - apiGroups:
@@ -392,6 +401,7 @@ rules:
   - namespaces/finalizers
   verbs:
   - delete
+  - get
   - list
   - patch
   - update
@@ -431,6 +441,7 @@ rules:
   resources:
   - rhmis
   verbs:
+  - get
   - list
   - watch
 - apiGroups:
@@ -489,6 +500,7 @@ rules:
   verbs:
   - create
   - delete
+  - get
   - list
   - patch
   - update
@@ -573,6 +585,7 @@ rules:
   resources:
   - datasciencepipelinesapplications/finalizers
   verbs:
+  - get
   - patch
   - update
 - apiGroups:
@@ -619,6 +632,7 @@ rules:
   - events
   verbs:
   - delete
+  - get
   - list
   - patch
   - watch
@@ -695,6 +709,7 @@ rules:
   - rhmis
   verbs:
   - delete
+  - get
   - list
   - patch
   - watch
@@ -722,6 +737,7 @@ rules:
   - machineautoscalers
   verbs:
   - delete
+  - get
   - list
   - patch
 - apiGroups:
@@ -730,6 +746,7 @@ rules:
   - machinesets
   verbs:
   - delete
+  - get
   - list
   - patch
 - apiGroups:
@@ -803,6 +820,7 @@ rules:
   resources:
   - modelregistries/finalizers
   verbs:
+  - get
   - update
 - apiGroups:
   - modelregistry.opendatahub.io
@@ -993,6 +1011,7 @@ rules:
   - virtualservices/status
   verbs:
   - delete
+  - get
   - patch
   - update
 - apiGroups:
@@ -1061,6 +1080,7 @@ rules:
   - consoles
   verbs:
   - delete
+  - get
   - list
   - patch
   - watch
@@ -1225,6 +1245,7 @@ rules:
   verbs:
   - create
   - delete
+  - get
   - list
   - patch
   - update
@@ -1236,6 +1257,7 @@ rules:
   verbs:
   - create
   - delete
+  - get
   - list
   - patch
   - update
@@ -1246,6 +1268,7 @@ rules:
   - services/status
   verbs:
   - delete
+  - get
   - patch
   - update
 - apiGroups:
@@ -1255,6 +1278,7 @@ rules:
   verbs:
   - create
   - delete
+  - get
   - list
   - patch
   - update
@@ -1266,6 +1290,7 @@ rules:
   verbs:
   - create
   - delete
+  - get
   - list
   - patch
   - update
@@ -1276,6 +1301,7 @@ rules:
   - clusterservingruntimes/status
   verbs:
   - delete
+  - get
   - patch
   - update
 - apiGroups:
@@ -1285,6 +1311,7 @@ rules:
   verbs:
   - create
   - delete
+  - get
   - list
   - patch
   - update
@@ -1295,6 +1322,7 @@ rules:
   - inferencegraphs/status
   verbs:
   - delete
+  - get
   - patch
   - update
 - apiGroups:
@@ -1327,6 +1355,7 @@ rules:
   - inferenceservices/status
   verbs:
   - delete
+  - get
   - patch
   - update
 - apiGroups:
@@ -1336,6 +1365,7 @@ rules:
   verbs:
   - create
   - delete
+  - get
   - list
   - patch
   - update
@@ -1345,6 +1375,7 @@ rules:
   resources:
   - predictors/finalizers
   verbs:
+  - get
   - patch
   - update
 - apiGroups:
@@ -1353,6 +1384,7 @@ rules:
   - predictors/status
   verbs:
   - delete
+  - get
   - patch
   - update
 - apiGroups:
@@ -1378,6 +1410,7 @@ rules:
   resources:
   - servingruntimes/status
   verbs:
+  - get
   - patch
   - update
 - apiGroups:
@@ -1387,6 +1420,7 @@ rules:
   verbs:
   - create
   - delete
+  - get
   - list
   - patch
   - update
@@ -1397,6 +1431,7 @@ rules:
   - trainedmodels/status
   verbs:
   - delete
+  - get
   - patch
   - update
 - apiGroups:
@@ -1463,6 +1498,7 @@ rules:
   - users
   verbs:
   - delete
+  - get
   - list
   - patch
   - watch

--- a/controllers/datasciencecluster/kubebuilder_rbac.go
+++ b/controllers/datasciencecluster/kubebuilder_rbac.go
@@ -14,7 +14,7 @@ package datasciencecluster
 // +kubebuilder:rbac:groups="maistra.io",resources=servicemeshmemberrolls,verbs=create;get;list;patch;update;use;watch
 // +kubebuilder:rbac:groups="maistra.io",resources=servicemeshmembers,verbs=create;get;list;patch;update;use;watch
 // +kubebuilder:rbac:groups="maistra.io",resources=servicemeshmembers/finalizers,verbs=create;get;list;patch;update;use;watch
-// +kubebuilder:rbac:groups="networking.istio.io",resources=virtualservices/status,verbs=update;patch;delete
+// +kubebuilder:rbac:groups="networking.istio.io",resources=virtualservices/status,verbs=update;patch;delete;get
 // +kubebuilder:rbac:groups="networking.istio.io",resources=virtualservices/finalizers,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="networking.istio.io",resources=virtualservices,verbs=*
 // +kubebuilder:rbac:groups="networking.istio.io",resources=gateways,verbs=*
@@ -25,11 +25,11 @@ package datasciencecluster
 
 /* This is for DSP */
 //+kubebuilder:rbac:groups="datasciencepipelinesapplications.opendatahub.io",resources=datasciencepipelinesapplications/status,verbs=update;patch;get
-//+kubebuilder:rbac:groups="datasciencepipelinesapplications.opendatahub.io",resources=datasciencepipelinesapplications/finalizers,verbs=update;patch
+//+kubebuilder:rbac:groups="datasciencepipelinesapplications.opendatahub.io",resources=datasciencepipelinesapplications/finalizers,verbs=update;patch;get
 //+kubebuilder:rbac:groups="datasciencepipelinesapplications.opendatahub.io",resources=datasciencepipelinesapplications,verbs=create;delete;list;update;watch;patch;get
 //+kubebuilder:rbac:groups="image.openshift.io",resources=imagestreamtags,verbs=get
-//+kubebuilder:rbac:groups="authentication.k8s.io",resources=tokenreviews,verbs=create
-//+kubebuilder:rbac:groups="authorization.k8s.io",resources=subjectaccessreviews,verbs=create
+//+kubebuilder:rbac:groups="authentication.k8s.io",resources=tokenreviews,verbs=create;get
+//+kubebuilder:rbac:groups="authorization.k8s.io",resources=subjectaccessreviews,verbs=create;get
 
 /* This is for dashboard */
 // +kubebuilder:rbac:groups="opendatahub.io",resources=odhdashboardconfigs,verbs=create;get;patch;watch;update;delete;list
@@ -48,7 +48,7 @@ package datasciencecluster
 
 // +kubebuilder:rbac:groups="apiextensions.k8s.io",resources=customresourcedefinitions,verbs=get;list;watch
 
-// +kubebuilder:rbac:groups="user.openshift.io",resources=users,verbs=list;watch;patch;delete
+// +kubebuilder:rbac:groups="user.openshift.io",resources=users,verbs=list;watch;patch;delete;get
 
 // +kubebuilder:rbac:groups="template.openshift.io",resources=templates,verbs=*
 
@@ -56,26 +56,26 @@ package datasciencecluster
 
 // +kubebuilder:rbac:groups="snapshot.storage.k8s.io",resources=volumesnapshots,verbs=create;delete;patch;get
 
-// +kubebuilder:rbac:groups="serving.kserve.io",resources=trainedmodels/status,verbs=update;patch;delete
-// +kubebuilder:rbac:groups="serving.kserve.io",resources=trainedmodels,verbs=create;delete;list;update;watch;patch
-// +kubebuilder:rbac:groups="serving.kserve.io",resources=servingruntimes/status,verbs=update;patch
+// +kubebuilder:rbac:groups="serving.kserve.io",resources=trainedmodels/status,verbs=update;patch;delete;get
+// +kubebuilder:rbac:groups="serving.kserve.io",resources=trainedmodels,verbs=create;delete;list;update;watch;patch;get
+// +kubebuilder:rbac:groups="serving.kserve.io",resources=servingruntimes/status,verbs=update;patch;get
 // +kubebuilder:rbac:groups="serving.kserve.io",resources=servingruntimes/finalizers,verbs=create;delete;list;update;watch;patch;get
 // +kubebuilder:rbac:groups="serving.kserve.io",resources=servingruntimes,verbs=*
-// +kubebuilder:rbac:groups="serving.kserve.io",resources=predictors/status,verbs=update;patch;delete
-// +kubebuilder:rbac:groups="serving.kserve.io",resources=predictors/finalizers,verbs=update;patch
-// +kubebuilder:rbac:groups="serving.kserve.io",resources=predictors,verbs=create;delete;list;update;watch;patch
-// +kubebuilder:rbac:groups="serving.kserve.io",resources=inferenceservices/status,verbs=update;patch;delete
+// +kubebuilder:rbac:groups="serving.kserve.io",resources=predictors/status,verbs=update;patch;delete;get
+// +kubebuilder:rbac:groups="serving.kserve.io",resources=predictors/finalizers,verbs=update;patch;get
+// +kubebuilder:rbac:groups="serving.kserve.io",resources=predictors,verbs=create;delete;list;update;watch;patch;get
+// +kubebuilder:rbac:groups="serving.kserve.io",resources=inferenceservices/status,verbs=update;patch;delete;get
 // +kubebuilder:rbac:groups="serving.kserve.io",resources=inferenceservices/finalizers,verbs=create;delete;list;update;watch;patch;get
 // +kubebuilder:rbac:groups="serving.kserve.io",resources=inferenceservices,verbs=create;delete;list;update;watch;patch;get
-// +kubebuilder:rbac:groups="serving.kserve.io",resources=inferencegraphs/status,verbs=update;patch;delete
-// +kubebuilder:rbac:groups="serving.kserve.io",resources=inferencegraphs,verbs=create;delete;list;update;watch;patch
-// +kubebuilder:rbac:groups="serving.kserve.io",resources=clusterservingruntimes/status,verbs=update;patch;delete
-// +kubebuilder:rbac:groups="serving.kserve.io",resources=clusterservingruntimes/finalizers,verbs=create;delete;list;update;watch;patch
-// +kubebuilder:rbac:groups="serving.kserve.io",resources=clusterservingruntimes,verbs=create;delete;list;update;watch;patch
+// +kubebuilder:rbac:groups="serving.kserve.io",resources=inferencegraphs/status,verbs=update;patch;delete;get
+// +kubebuilder:rbac:groups="serving.kserve.io",resources=inferencegraphs,verbs=create;delete;list;update;watch;patch;get
+// +kubebuilder:rbac:groups="serving.kserve.io",resources=clusterservingruntimes/status,verbs=update;patch;delete;get
+// +kubebuilder:rbac:groups="serving.kserve.io",resources=clusterservingruntimes/finalizers,verbs=create;delete;list;update;watch;patch;get
+// +kubebuilder:rbac:groups="serving.kserve.io",resources=clusterservingruntimes,verbs=create;delete;list;update;watch;patch;get
 
-// +kubebuilder:rbac:groups="serving.knative.dev",resources=services/status,verbs=update;patch;delete
-// +kubebuilder:rbac:groups="serving.knative.dev",resources=services/finalizers,verbs=create;delete;list;watch;update;patch
-// +kubebuilder:rbac:groups="serving.knative.dev",resources=services,verbs=create;delete;list;watch;update;patch
+// +kubebuilder:rbac:groups="serving.knative.dev",resources=services/status,verbs=update;patch;delete;get
+// +kubebuilder:rbac:groups="serving.knative.dev",resources=services/finalizers,verbs=create;delete;list;watch;update;patch;get
+// +kubebuilder:rbac:groups="serving.knative.dev",resources=services,verbs=create;delete;list;watch;update;patch;get
 
 // +kubebuilder:rbac:groups="security.openshift.io",resources=securitycontextconstraints,verbs=*,resourceNames=restricted
 // +kubebuilder:rbac:groups="security.openshift.io",resources=securitycontextconstraints,verbs=*,resourceNames=anyuid
@@ -97,7 +97,7 @@ package datasciencecluster
 
 // +kubebuilder:rbac:groups="apiregistration.k8s.io",resources=apiservices,verbs=create;delete;list;watch;update;patch;get
 
-// +kubebuilder:rbac:groups="operator.openshift.io",resources=consoles,verbs=list;watch;patch;delete
+// +kubebuilder:rbac:groups="operator.openshift.io",resources=consoles,verbs=list;watch;patch;delete;get
 
 // +kubebuilder:rbac:groups="oauth.openshift.io",resources=oauthclients,verbs=create;delete;list;watch;update;patch;get
 
@@ -127,7 +127,7 @@ package datasciencecluster
 
 //+kubebuilder:rbac:groups=modelregistry.opendatahub.io,resources=modelregistries,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=modelregistry.opendatahub.io,resources=modelregistries/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups=modelregistry.opendatahub.io,resources=modelregistries/finalizers,verbs=update
+//+kubebuilder:rbac:groups=modelregistry.opendatahub.io,resources=modelregistries/finalizers,verbs=update;get
 
 // +kubebuilder:rbac:groups="monitoring.coreos.com",resources=prometheuses/finalizers,verbs=get;create;patch;delete;deletecollection
 // +kubebuilder:rbac:groups="monitoring.coreos.com",resources=prometheuses/status,verbs=get;create;patch;delete;deletecollection
@@ -143,16 +143,16 @@ package datasciencecluster
 
 // +kubebuilder:rbac:groups="machinelearning.seldon.io",resources=seldondeployments,verbs=*
 
-// +kubebuilder:rbac:groups="machine.openshift.io",resources=machinesets,verbs=list;patch;delete
-// +kubebuilder:rbac:groups="machine.openshift.io",resources=machineautoscalers,verbs=list;patch;delete
+// +kubebuilder:rbac:groups="machine.openshift.io",resources=machinesets,verbs=list;patch;delete;get
+// +kubebuilder:rbac:groups="machine.openshift.io",resources=machineautoscalers,verbs=list;patch;delete;get
 
 /* TODO: cleanup once kfdef is not needed*/
 // +kubebuilder:rbac:groups="kubeflow.org",resources=*,verbs=*
 // +kubebuilder:rbac:groups="kfdef.apps.kubeflow.org",resources=kfdefs,verbs=get;list;watch;patch;delete;update
 
-// +kubebuilder:rbac:groups="integreatly.org",resources=rhmis,verbs=list;watch;patch;delete
+// +kubebuilder:rbac:groups="integreatly.org",resources=rhmis,verbs=list;watch;patch;delete;get
 
-// +kubebuilder:rbac:groups="image.openshift.io",resources=imagestreams,verbs=patch;create;update;delete
+// +kubebuilder:rbac:groups="image.openshift.io",resources=imagestreams,verbs=patch;create;update;delete;get
 // +kubebuilder:rbac:groups="image.openshift.io",resources=imagestreams,verbs=create;list;watch;patch;delete;get
 
 // +kubebuilder:rbac:groups="extensions",resources=replicasets,verbs=*
@@ -160,7 +160,7 @@ package datasciencecluster
 
 // +kubebuilder:rbac:groups="custom.tekton.dev",resources=pipelineloops,verbs=*
 
-// +kubebuilder:rbac:groups="core",resources=services/finalizers,verbs=create;delete;list;update;watch;patch
+// +kubebuilder:rbac:groups="core",resources=services/finalizers,verbs=create;delete;list;update;watch;patch;get
 // +kubebuilder:rbac:groups="core",resources=services,verbs=get;create;watch;update;patch;list;delete
 // +kubebuilder:rbac:groups="core",resources=services,verbs=*
 // +kubebuilder:rbac:groups="*",resources=services,verbs=*
@@ -170,7 +170,7 @@ package datasciencecluster
 // +kubebuilder:rbac:groups="core",resources=secrets,verbs=create;delete;list;update;watch;patch;get
 // +kubebuilder:rbac:groups="core",resources=secrets/finalizers,verbs=get;create;watch;update;patch;list;delete
 
-// +kubebuilder:rbac:groups="core",resources=rhmis,verbs=watch;list
+// +kubebuilder:rbac:groups="core",resources=rhmis,verbs=watch;list;get
 
 // +kubebuilder:rbac:groups="core",resources=pods/log,verbs=*
 // +kubebuilder:rbac:groups="core",resources=pods/exec,verbs=*
@@ -179,19 +179,19 @@ package datasciencecluster
 // +kubebuilder:rbac:groups="core",resources=persistentvolumes,verbs=*
 // +kubebuilder:rbac:groups="core",resources=persistentvolumeclaims,verbs=*
 
-// +kubebuilder:rbac:groups="core",resources=namespaces/finalizers,verbs=update;list;watch;patch;delete
+// +kubebuilder:rbac:groups="core",resources=namespaces/finalizers,verbs=update;list;watch;patch;delete;get
 // +kubebuilder:rbac:groups="core",resources=namespaces,verbs=get;create;patch;delete;watch;update;list
 
 // +kubebuilder:rbac:groups="core",resources=events,verbs=get;create;watch;update;list;patch;delete
-// +kubebuilder:rbac:groups="events.k8s.io",resources=events,verbs=list;watch;patch;delete
+// +kubebuilder:rbac:groups="events.k8s.io",resources=events,verbs=list;watch;patch;delete;get
 
 // +kubebuilder:rbac:groups="core",resources=endpoints,verbs=watch;list;get;create;update;delete
 
 // +kubebuilder:rbac:groups="core",resources=configmaps/status,verbs=get;update;patch;delete
 // +kubebuilder:rbac:groups="core",resources=configmaps,verbs=get;create;watch;patch;delete;list;update
 
-// +kubebuilder:rbac:groups="core",resources=clusterversions,verbs=watch;list
-// +kubebuilder:rbac:groups="config.openshift.io",resources=clusterversions,verbs=watch;list
+// +kubebuilder:rbac:groups="core",resources=clusterversions,verbs=watch;list;get
+// +kubebuilder:rbac:groups="config.openshift.io",resources=clusterversions,verbs=watch;list;get
 
 // +kubebuilder:rbac:groups="coordination.k8s.io",resources=leases,verbs=get;list;watch;create;update;patch;delete
 
@@ -200,18 +200,18 @@ package datasciencecluster
 // +kubebuilder:rbac:groups="cert-manager.io",resources=certificates;issuers,verbs=create;patch
 
 // OpenVino still need buildconfig
-// +kubebuilder:rbac:groups="build.openshift.io",resources=builds,verbs=create;patch;delete;list;watch
+// +kubebuilder:rbac:groups="build.openshift.io",resources=builds,verbs=create;patch;delete;list;watch;get
 // +kubebuilder:rbac:groups="build.openshift.io",resources=buildconfigs/instantiate,verbs=create;patch;delete;get;list;watch
-// +kubebuilder:rbac:groups="build.openshift.io",resources=buildconfigs,verbs=list;watch;create;patch;delete
+// +kubebuilder:rbac:groups="build.openshift.io",resources=buildconfigs,verbs=list;watch;create;patch;delete;get
 
 // +kubebuilder:rbac:groups="batch",resources=jobs/status,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="batch",resources=jobs,verbs=*
 // +kubebuilder:rbac:groups="batch",resources=cronjobs,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="batch",resources=cronjobs,verbs=create;get;patch
 
-// +kubebuilder:rbac:groups="autoscaling",resources=horizontalpodautoscalers,verbs=watch;create;update;delete;list;patch
-// +kubebuilder:rbac:groups="autoscaling.openshift.io",resources=machinesets,verbs=list;patch;delete
-// +kubebuilder:rbac:groups="autoscaling.openshift.io",resources=machineautoscalers,verbs=list;patch;delete
+// +kubebuilder:rbac:groups="autoscaling",resources=horizontalpodautoscalers,verbs=watch;create;update;delete;list;patch;get
+// +kubebuilder:rbac:groups="autoscaling.openshift.io",resources=machinesets,verbs=list;patch;delete;get
+// +kubebuilder:rbac:groups="autoscaling.openshift.io",resources=machineautoscalers,verbs=list;patch;delete;get
 
 // +kubebuilder:rbac:groups="authorization.openshift.io",resources=roles,verbs=*
 // +kubebuilder:rbac:groups="authorization.openshift.io",resources=rolebindings,verbs=*


### PR DESCRIPTION
- since we already have these resource for create, list, delete etc, no harm to add get on them

<!--- Provide a general summary of your changes in the Title above -->


## Description
<!--- Describe your changes in detail -->
related to some offline discussion for the error seen recently:
`"buildconfigs.build.openshift.io "rstudio-server-rhel9" is forbidden: User "system:serviceaccount:redhat-ods-operator:redhat-ods-operator-controller-manager" cannot get resource "buildconfigs" in API group "build.openshift.io" in the namespace "redhat-ods-applications"`
root cause has not been identify, but should be no harm to have all our  resource with get permission.



## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
