### PR TITLE
chore: renames manifests source to location

### DIFF
--- a/components/kserve/feature_resources.go
+++ b/components/kserve/feature_resources.go
@@ -18,14 +18,14 @@ var Resources = struct {
 	InstallDir string
 	// GatewaysDir is the path to the Serving Istio gateways templates.
 	GatewaysDir string
-	// Source the templates to be used
-	Source fs.FS
+	// Location specifies the file system that contains the templates to be used.
+	Location fs.FS
 	// BaseDir is the path to the base of the embedded FS
 	BaseDir string
 }{
 	ServiceMeshDir: path.Join(baseDir, "servicemesh"),
 	InstallDir:     path.Join(baseDir, "serving-install"),
 	GatewaysDir:    path.Join(baseDir, "servicemesh", "routing"),
-	Source:         kserveEmbeddedFS,
+	Location:       kserveEmbeddedFS,
 	BaseDir:        baseDir,
 }

--- a/components/kserve/serverless_setup.go
+++ b/components/kserve/serverless_setup.go
@@ -12,7 +12,7 @@ func (k *Kserve) configureServerlessFeatures() feature.FeaturesProvider {
 	return func(handler *feature.FeaturesHandler) error {
 		servingDeploymentErr := feature.CreateFeature("serverless-serving-deployment").
 			For(handler).
-			ManifestSource(Resources.Source).
+			ManifestsLocation(Resources.Location).
 			Manifests(
 				path.Join(Resources.InstallDir),
 			).
@@ -33,7 +33,7 @@ func (k *Kserve) configureServerlessFeatures() feature.FeaturesProvider {
 
 		servingNetIstioSecretFilteringErr := feature.CreateFeature("serverless-net-istio-secret-filtering").
 			For(handler).
-			ManifestSource(Resources.Source).
+			ManifestsLocation(Resources.Location).
 			Manifests(
 				path.Join(Resources.BaseDir, "serving-net-istio-secret-filtering.patch.tmpl.yaml"),
 			).
@@ -56,7 +56,7 @@ func (k *Kserve) configureServerlessFeatures() feature.FeaturesProvider {
 				serverless.ServingIngressDomain,
 			).
 			WithResources(serverless.ServingCertificateResource).
-			ManifestSource(Resources.Source).
+			ManifestsLocation(Resources.Location).
 			Manifests(
 				path.Join(Resources.GatewaysDir),
 			).

--- a/components/kserve/servicemesh_setup.go
+++ b/components/kserve/servicemesh_setup.go
@@ -40,7 +40,7 @@ func (k *Kserve) defineServiceMeshFeatures(cli client.Client) feature.FeaturesPr
 		if authorinoInstalled {
 			kserveExtAuthzErr := feature.CreateFeature("kserve-external-authz").
 				For(handler).
-				ManifestSource(Resources.Source).
+				ManifestsLocation(Resources.Location).
 				Manifests(
 					path.Join(Resources.ServiceMeshDir, "activator-envoyfilter.tmpl.yaml"),
 					path.Join(Resources.ServiceMeshDir, "envoy-oauth-temp-fix.tmpl.yaml"),
@@ -59,7 +59,7 @@ func (k *Kserve) defineServiceMeshFeatures(cli client.Client) feature.FeaturesPr
 
 		temporaryFixesErr := feature.CreateFeature("kserve-temporary-fixes").
 			For(handler).
-			ManifestSource(Resources.Source).
+			ManifestsLocation(Resources.Location).
 			Manifests(
 				path.Join(Resources.ServiceMeshDir, "grpc-envoyfilter-temp-fix.tmpl.yaml"),
 			).

--- a/controllers/dscinitialization/feature_resources.go
+++ b/controllers/dscinitialization/feature_resources.go
@@ -18,14 +18,14 @@ var Templates = struct {
 	AuthorinoDir string
 	// MetricsDir is the path to the Metrics Collection templates.
 	MetricsDir string
-	// Source the templates to be used
-	Source fs.FS
+	// Location specifies the file system that contains the templates to be used.
+	Location fs.FS
 	// BaseDir is the path to the base of the embedded FS
 	BaseDir string
 }{
 	ServiceMeshDir: path.Join(baseDir, "servicemesh"),
 	AuthorinoDir:   path.Join(baseDir, "authorino"),
 	MetricsDir:     path.Join(baseDir, "metrics-collection"),
-	Source:         dsciEmbeddedFS,
+	Location:       dsciEmbeddedFS,
 	BaseDir:        baseDir,
 }

--- a/controllers/dscinitialization/servicemesh_setup.go
+++ b/controllers/dscinitialization/servicemesh_setup.go
@@ -118,7 +118,7 @@ func (r *DSCInitializationReconciler) serviceMeshCapabilityFeatures(instance *ds
 		serviceMeshSpec := instance.Spec.ServiceMesh
 		smcpCreationErr := feature.CreateFeature("mesh-control-plane-creation").
 			For(handler).
-			ManifestSource(Templates.Source).
+			ManifestsLocation(Templates.Location).
 			Manifests(
 				path.Join(Templates.ServiceMeshDir),
 			).
@@ -141,7 +141,7 @@ func (r *DSCInitializationReconciler) serviceMeshCapabilityFeatures(instance *ds
 				PreConditions(
 					servicemesh.EnsureServiceMeshInstalled,
 				).
-				ManifestSource(Templates.Source).
+				ManifestsLocation(Templates.Location).
 				Manifests(
 					path.Join(Templates.MetricsDir),
 				).
@@ -169,7 +169,7 @@ func (r *DSCInitializationReconciler) authorizationFeatures(instance *dsciv1.DSC
 
 		extAuthzErr := feature.CreateFeature("mesh-control-plane-external-authz").
 			For(handler).
-			ManifestSource(Templates.Source).
+			ManifestsLocation(Templates.Location).
 			Manifests(
 				path.Join(Templates.AuthorinoDir, "auth-smm.tmpl.yaml"),
 				path.Join(Templates.AuthorinoDir, "base"),

--- a/pkg/feature/builder.go
+++ b/pkg/feature/builder.go
@@ -65,13 +65,13 @@ func (u *usingFeaturesHandler) For(featuresHandler *FeaturesHandler) *featureBui
 	return fb
 }
 
-// Used to enforce that Manifests() is called after ManifestSource() in the chain.
+// Used to enforce that Manifests() is called after ManifestsLocation() in the chain.
 type featureBuilderWithManifestSource struct {
 	*featureBuilder
 }
 
-// ManifestSource sets the root file system (fsys) from which manifest paths are loaded.
-func (fb *featureBuilder) ManifestSource(fsys fs.FS) *featureBuilderWithManifestSource {
+// ManifestsLocation sets the root file system (fsys) from which manifest paths are loaded.
+func (fb *featureBuilder) ManifestsLocation(fsys fs.FS) *featureBuilderWithManifestSource {
 	fb.fsys = fsys
 	return &featureBuilderWithManifestSource{featureBuilder: fb}
 }

--- a/tests/integration/features/manifests_int_test.go
+++ b/tests/integration/features/manifests_int_test.go
@@ -47,7 +47,7 @@ var _ = Describe("Manifest sources", func() {
 			createNamespaceErr := feature.CreateFeature("create-namespace").
 				For(handler).
 				UsingConfig(envTest.Config).
-				ManifestSource(fixtures.TestEmbeddedFiles).
+				ManifestsLocation(fixtures.TestEmbeddedFiles).
 				Manifests(path.Join(fixtures.BaseDir, "namespace.yaml")).
 				Load()
 
@@ -72,7 +72,7 @@ var _ = Describe("Manifest sources", func() {
 			createServiceErr := feature.CreateFeature("create-local-gw-svc").
 				For(handler).
 				UsingConfig(envTest.Config).
-				ManifestSource(fixtures.TestEmbeddedFiles).
+				ManifestsLocation(fixtures.TestEmbeddedFiles).
 				Manifests(path.Join(fixtures.BaseDir, "local-gateway-svc.tmpl.yaml")).
 				Load()
 
@@ -105,7 +105,7 @@ metadata:
 			createServiceErr := feature.CreateFeature("create-namespace").
 				For(handler).
 				UsingConfig(envTest.Config).
-				ManifestSource(os.DirFS(tempDir)).
+				ManifestsLocation(os.DirFS(tempDir)).
 				Manifests(path.Join("namespace.yaml")). // must be relative to root DirFS defined above
 				Load()
 

--- a/tests/integration/features/resources_int_test.go
+++ b/tests/integration/features/resources_int_test.go
@@ -107,7 +107,7 @@ func createAndApplyFeature(dsci *dsciv1.DSCInitialization, managed bool, feature
 		creator := feature.CreateFeature(featureName).
 			For(handler).
 			UsingConfig(envTest.Config).
-			ManifestSource(fixtures.TestEmbeddedFiles).
+			ManifestsLocation(fixtures.TestEmbeddedFiles).
 			Manifests(path.Join(fixtures.BaseDir, yamlFile))
 		if managed {
 			creator.Managed()

--- a/tests/integration/features/servicemesh_feature_test.go
+++ b/tests/integration/features/servicemesh_feature_test.go
@@ -198,7 +198,7 @@ var _ = Describe("Service Mesh setup", func() {
 					handler := feature.ClusterFeaturesHandler(dsci, func(handler *feature.FeaturesHandler) error {
 						return feature.CreateFeature("control-plane-with-external-authz-provider").
 							For(handler).
-							ManifestSource(fixtures.TestEmbeddedFiles).
+							ManifestsLocation(fixtures.TestEmbeddedFiles).
 							Manifests(path.Join("templates", "mesh-authz-ext-provider.patch.tmpl.yaml")).
 							OnDelete(
 								servicemesh.RemoveExtensionProvider,


### PR DESCRIPTION
## Description

Minor refactoring

- Source is already used elsewhere in Feature DSL, so we might want to avoid confusion
- Location fits the purpose of this field better

## How Has This Been Tested?

by running `make`

## Merge criteria:

- [ ] Have a meaningful commit messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
