### PR TITLE
WIP: webhook: do not allow to delete DSCI if DSC exists

### DIFF
--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -23,6 +23,7 @@ webhooks:
     operations:
     - CREATE
     - UPDATE
+    - DELETE
     resources:
     - datascienceclusters
     - dscinitializations

--- a/controllers/webhook/webhook.go
+++ b/controllers/webhook/webhook.go
@@ -58,14 +58,33 @@ func (w *OpenDataHubWebhook) InjectClient(c client.Client) error {
 	return nil
 }
 
-func (w *OpenDataHubWebhook) checkDupCreation(ctx context.Context, req admission.Request) admission.Response {
-	if req.Operation != admissionv1.Create {
-		return admission.Allowed(fmt.Sprintf("duplication check: skipping %v request", req.Operation))
+func countObjects(ctx context.Context, cli client.Client, gvk schema.GroupVersionKind) (int, error) {
+	list := &unstructured.UnstructuredList{}
+	list.SetGroupVersionKind(gvk)
+
+	if err := cli.List(ctx, list); err != nil {
+		return 0, err
 	}
 
+	return len(list.Items), nil
+}
+
+func denyCountGtZero(ctx context.Context, cli client.Client, gvk schema.GroupVersionKind, msg string) admission.Response {
+	count, err := countObjects(ctx, cli, gvk)
+	if err != nil {
+		return admission.Errored(http.StatusBadRequest, err)
+	}
+
+	if count > 0 {
+		return admission.Denied(msg)
+	}
+
+	return admission.Allowed("")
+}
+
+func (w *OpenDataHubWebhook) checkDupCreation(ctx context.Context, req admission.Request) admission.Response {
 	switch req.Kind.Kind {
-	case "DataScienceCluster":
-	case "DSCInitialization":
+	case "DataScienceCluster", "DSCInitialization":
 	default:
 		log.Info("Got wrong kind", "kind", req.Kind.Kind)
 		return admission.Errored(http.StatusBadRequest, nil)
@@ -77,35 +96,26 @@ func (w *OpenDataHubWebhook) checkDupCreation(ctx context.Context, req admission
 		Kind:    req.Kind.Kind,
 	}
 
-	list := &unstructured.UnstructuredList{}
-	list.SetGroupVersionKind(gvk)
-
-	if err := w.client.List(ctx, list); err != nil {
-		return admission.Errored(http.StatusBadRequest, err)
-	}
-
-	// if len == 1 now creation of #2 is being handled
-	if len(list.Items) > 0 {
-		return admission.Denied(fmt.Sprintf("Only one instance of %s object is allowed", req.Kind.Kind))
-	}
-
-	return admission.Allowed(fmt.Sprintf("%s duplication check passed", req.Kind.Kind))
+	// if count == 1 now creation of #2 is being handled
+	return denyCountGtZero(ctx, w.client, gvk,
+		fmt.Sprintf("Only one instance of %s object is allowed", req.Kind.Kind))
 }
 
 func (w *OpenDataHubWebhook) Handle(ctx context.Context, req admission.Request) admission.Response {
 	var resp admission.Response
 
-	// Handle only Create and Update
-	if req.Operation == admissionv1.Delete || req.Operation == admissionv1.Connect {
-		msg := fmt.Sprintf("ODH skipping %v request", req.Operation)
+	switch req.Operation {
+	case admissionv1.Create:
+		resp = w.checkDupCreation(ctx, req)
+	default:
+		msg := fmt.Sprintf("Webhook skipping %v request", req.Operation)
 		log.Info(msg)
-		return admission.Allowed(msg)
+		resp = admission.Allowed("")
 	}
 
-	resp = w.checkDupCreation(ctx, req)
 	if !resp.Allowed {
 		return resp
 	}
 
-	return admission.Allowed(fmt.Sprintf("%s allowed", req.Kind.Kind))
+	return admission.Allowed(fmt.Sprintf("Operation %s on %s allowed", req.Operation, req.Kind.Kind))
 }

--- a/pkg/cluster/gvk/gvk.go
+++ b/pkg/cluster/gvk/gvk.go
@@ -9,6 +9,12 @@ var (
 		Kind:    "ClusterServiceVersion",
 	}
 
+	DataScienceCluster = schema.GroupVersionKind{
+		Group:   "datasciencecluster.opendatahub.io",
+		Version: "v1",
+		Kind:    "DataScienceCluster",
+	}
+
 	KnativeServing = schema.GroupVersionKind{
 		Group:   "operator.knative.dev",
 		Version: "v1beta1",


### PR DESCRIPTION
webhook: do not allow to delete DSCI if DSC exists

Implement deletion check. Count DataScienceCluster object and if
it's greater than zero block the request.

<!--- Provide a general summary of your changes in the Title above -->

Many thanks for submitting your Pull Request ❤️!

Please make sure that your PR meets the following requirements:

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md)
- [ ] Pull Request contains description of the issue
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains link to any dependent or related Pull Request

## Description
<!--- Describe your changes in detail -->

## JIRA issue:
<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip:
<!--- Attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] Have a meaningful commit messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
