### PR TITLE
feat: adds EnabledWhen to the feature builder

### DIFF
--- a/pkg/feature/builder.go
+++ b/pkg/feature/builder.go
@@ -125,10 +125,10 @@ func (fb *featureBuilder) WithData(loader ...Action) *featureBuilder {
 	return fb
 }
 
-// EnabledWhen determines if a Feature should be loaded and applied based on specified criteria. 
+// EnabledWhen determines if a Feature should be loaded and applied based on specified criteria.
 // The criteria are supplied as a function.
 //
-// Note: The function passed should consistently return true while the feature is needed. 
+// Note: The function passed should consistently return true while the feature is needed.
 // If the function returns false at any point, the feature's contents might be removed during the reconciliation process.
 func (fb *featureBuilder) EnabledWhen(enabled func(f *Feature) bool) *featureBuilder {
 	fb.builders = append(fb.builders, func(f *Feature) error {
@@ -215,10 +215,10 @@ func (fb *featureBuilder) Load() error {
 	// If the feature is disabled, but the FeatureTracker exists in the cluster, ensure clean-up is triggered.
 	// This means that the feature was previously enabled, but now it is not anymore.
 	if !feature.Enabled {
-		if errGet := getFeatureTrackerIfAbsent(feature); client.IgnoreNotFound(err) != nil {
+		if errGet := getFeatureTrackerIfAbsent(feature); client.IgnoreNotFound(errGet) != nil {
 			return errGet
 		}
-		
+
 		return feature.Cleanup()
 	}
 

--- a/pkg/feature/builder.go
+++ b/pkg/feature/builder.go
@@ -125,8 +125,11 @@ func (fb *featureBuilder) WithData(loader ...Action) *featureBuilder {
 	return fb
 }
 
-// EnabledWhen allows to define if a Feature should be loaded and applied
-// note: enabled func passed in should consistently return true while needed, else feature contents will be removed
+// EnabledWhen determines if a Feature should be loaded and applied based on specified criteria. 
+// The criteria are supplied as a function.
+//
+// Note: The function passed should consistently return true while the feature is needed. 
+// If the function returns false at any point, the feature's contents might be removed during the reconciliation process.
 func (fb *featureBuilder) EnabledWhen(enabled func(f *Feature) bool) *featureBuilder {
 	fb.builders = append(fb.builders, func(f *Feature) error {
 		f.Enabled = enabled(f)

--- a/pkg/feature/builder.go
+++ b/pkg/feature/builder.go
@@ -192,7 +192,7 @@ func (fb *featureBuilder) OnDelete(cleanups ...Action) *featureBuilder {
 
 // Load creates a new Feature instance and add it to corresponding FeaturesHandler.
 // The actual feature creation in the cluster is not performed here.
-// nolint: contextcheck
+//nolint: contextcheck
 func (fb *featureBuilder) Load() error {
 	feature := newFeature(fb.name)
 

--- a/pkg/feature/builder.go
+++ b/pkg/feature/builder.go
@@ -212,13 +212,14 @@ func (fb *featureBuilder) Load() error {
 		}
 	}
 
-	// if feature is disabled, ensure we have cleaned it up
+	// If the feature is disabled, but the FeatureTracker exists in the cluster, ensure clean-up is triggered.
+	// This means that the feature was previously enabled, but now it is not anymore.
 	if !feature.Enabled {
-		err := getFeatureTrackerIfAbsent(feature)
-		if client.IgnoreNotFound(err) == nil {
-			return feature.Cleanup()
+		if errGet := getFeatureTrackerIfAbsent(feature); client.IgnoreNotFound(err) != nil {
+			return errGet
 		}
-		return err
+		
+		return feature.Cleanup()
 	}
 
 	feature.Spec.TargetNamespace = fb.targetNS

--- a/pkg/feature/feature.go
+++ b/pkg/feature/feature.go
@@ -21,7 +21,7 @@ import (
 type Feature struct {
 	Name    string
 	Spec    *Spec
-	Enabled bool
+	Enabled EnabledFunc
 	Managed bool
 	Tracker *featurev1.FeatureTracker
 
@@ -41,18 +41,33 @@ type Feature struct {
 
 func newFeature(name string) *Feature {
 	return &Feature{
-		Name:    name,
-		Enabled: true,
-		Log:     ctrlLog.Log.WithName("features").WithValues("feature", name),
+		Name: name,
+		Enabled: func(_ context.Context, feature *Feature) (bool, error) {
+			return true, nil
+		},
+		Log: ctrlLog.Log.WithName("features").WithValues("feature", name),
 	}
 }
 
 // Action is a func type which can be used for different purposes while having access to Feature struct.
 type Action func(ctx context.Context, feature *Feature) error
 
+// EnabledFunc is a func type used to determine if a feature should be enabled.
+type EnabledFunc func(ctx context.Context, feature *Feature) (bool, error)
+
 func (f *Feature) Apply(ctx context.Context) error {
-	if !f.Enabled {
-		return nil
+	// If the feature is disabled, but the FeatureTracker exists in the cluster, ensure clean-up is triggered.
+	// This means that the feature was previously enabled, but now it is not anymore.
+	if enabled, err := f.Enabled(ctx, f); !enabled || err != nil {
+		if err != nil {
+			return err
+		}
+		errGet := getFeatureTrackerIfAbsent(ctx, f)
+		if errGet == nil {
+			return f.Cleanup(ctx)
+		}
+
+		return client.IgnoreNotFound(errGet)
 	}
 
 	if trackerErr := f.createFeatureTracker(ctx); trackerErr != nil {

--- a/pkg/feature/feature.go
+++ b/pkg/feature/feature.go
@@ -125,10 +125,6 @@ func (f *Feature) applyFeature(ctx context.Context) error {
 }
 
 func (f *Feature) Cleanup(ctx context.Context) error {
-	if !f.Enabled {
-		return nil
-	}
-
 	// Ensure associated FeatureTracker instance has been removed as last one
 	// in the chain of cleanups.
 	f.addCleanup(removeFeatureTracker)

--- a/tests/integration/features/cleanup_int_test.go
+++ b/tests/integration/features/cleanup_int_test.go
@@ -110,7 +110,7 @@ var _ = Describe("feature cleanup", func() {
 					PreConditions(
 						feature.CreateNamespaceIfNotExists(namespace),
 					).
-					EnabledWhen(doesNsExist).
+					EnabledWhen(namespaceExists).
 					WithResources(fixtures.CreateSecret(secretName, namespace)).
 					Load()
 
@@ -142,7 +142,7 @@ var _ = Describe("feature cleanup", func() {
 					PreConditions(
 						feature.CreateNamespaceIfNotExists(namespace),
 					).
-					EnabledWhen(doesNsExist).
+					EnabledWhen(namespaceExists).
 					WithResources(fixtures.CreateSecret(secretName, namespace)).
 					Load()
 
@@ -164,7 +164,7 @@ var _ = Describe("feature cleanup", func() {
 
 func createdSecretHasOwnerReferenceToOwningFeature(namespace string) func(context.Context) error {
 	return func(ctx context.Context) error {
-		secretName := "test-secret" // Hardcoded value
+		secretName := "test-secret"
 		secret, err := envTestClientset.CoreV1().
 			Secrets(namespace).
 			Get(ctx, secretName, metav1.GetOptions{})
@@ -194,7 +194,7 @@ func createdSecretHasOwnerReferenceToOwningFeature(namespace string) func(contex
 	}
 }
 
-func doesNsExist(f *feature.Feature) bool {
+func namespaceExists(f *feature.Feature) bool {
 	namespace, err := fixtures.GetNamespace(context.TODO(), f.Client, "conditional-ns")
 	if err != nil {
 		if errors.IsNotFound(err) {

--- a/tests/integration/features/cleanup_int_test.go
+++ b/tests/integration/features/cleanup_int_test.go
@@ -2,7 +2,7 @@ package features_test
 
 import (
 	"context"
-
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -79,6 +79,86 @@ var _ = Describe("feature cleanup", func() {
 
 	})
 
+	Context("cleaning up conditionally enabled features", Ordered, func() {
+
+		const (
+			featureName = "enabled-conditionally"
+			secretName  = "test-secret"
+		)
+
+		var (
+			dsci            *dsciv1.DSCInitialization
+			namespace       string
+			featuresHandler *feature.FeaturesHandler
+		)
+
+		BeforeAll(func() {
+			namespace = envtestutil.AppendRandomNameTo("test-conditional-cleanup")
+			dsci = fixtures.NewDSCInitialization(namespace)
+		})
+
+		It("should create feature, apply resource and create feature tracker", func(ctx context.Context) {
+			// given
+			err := fixtures.CreateOrUpdateNamespace(ctx, envTestClient, fixtures.NewNamespace("conditional-ns"))
+			Expect(err).To(Not(HaveOccurred()))
+
+			featuresHandler = feature.ClusterFeaturesHandler(dsci, func(handler *feature.FeaturesHandler) error {
+				conditionalCreationErr := feature.CreateFeature(featureName).
+					For(handler).
+					UsingConfig(envTest.Config).
+					PreConditions(
+						feature.CreateNamespaceIfNotExists(namespace),
+					).
+					EnabledWhen(doesNsExist).
+					WithResources(fixtures.CreateSecret(secretName, namespace)).
+					Load()
+
+				Expect(conditionalCreationErr).ToNot(HaveOccurred())
+
+				return nil
+			})
+
+			// when
+			Expect(featuresHandler.Apply(ctx)).Should(Succeed())
+
+			// then
+			Eventually(createdSecretHasOwnerReferenceToOwningFeature(namespace, secretName)).
+				WithTimeout(fixtures.Timeout).
+				WithPolling(fixtures.Interval).
+				Should(Succeed())
+		})
+
+		It("should clean up resources when the condition is no longer met", func(ctx context.Context) {
+			// given
+			err := envTestClient.Delete(context.Background(), fixtures.NewNamespace("conditional-ns"))
+			Expect(err).To(Not(HaveOccurred()))
+
+			// Mimic reconcile by re-loading the feature handler
+			featuresHandler = feature.ClusterFeaturesHandler(dsci, func(handler *feature.FeaturesHandler) error {
+				conditionalCreationErr := feature.CreateFeature(featureName).
+					For(handler).
+					UsingConfig(envTest.Config).
+					PreConditions(
+						feature.CreateNamespaceIfNotExists(namespace),
+					).
+					EnabledWhen(doesNsExist).
+					WithResources(fixtures.CreateSecret(secretName, namespace)).
+					Load()
+
+				Expect(conditionalCreationErr).ToNot(HaveOccurred())
+
+				return nil
+			})
+
+			Expect(featuresHandler.Apply(ctx)).Should(Succeed())
+
+			// then
+			Eventually(createdSecretHasOwnerReferenceToOwningFeature(namespace, secretName)).
+				WithTimeout(fixtures.Timeout).
+				WithPolling(fixtures.Interval).
+				Should(WithTransform(errors.IsNotFound, BeTrue()))
+		})
+	})
 })
 
 func createdSecretHasOwnerReferenceToOwningFeature(namespace, secretName string) func(context.Context) error {
@@ -110,4 +190,18 @@ func createdSecretHasOwnerReferenceToOwningFeature(namespace, secretName string)
 			Name: trackerName,
 		}, tracker)
 	}
+}
+
+func doesNsExist(f *feature.Feature) bool {
+	namespace, err := fixtures.GetNamespace(context.TODO(), f.Client, "conditional-ns")
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return false
+		}
+	}
+	// ensuring it fails if namespace is still deleting
+	if namespace.Status.Phase == corev1.NamespaceTerminating {
+		return false
+	}
+	return namespace != nil
 }

--- a/tests/integration/features/cleanup_int_test.go
+++ b/tests/integration/features/cleanup_int_test.go
@@ -160,6 +160,18 @@ var _ = Describe("feature cleanup", func() {
 				WithTimeout(fixtures.Timeout).
 				WithPolling(fixtures.Interval).
 				Should(WithTransform(errors.IsNotFound, BeTrue()))
+
+			Consistently(func() error {
+				_, err := fixtures.GetFeatureTracker(ctx, envTestClient, namespace, featureName)
+				if errors.IsNotFound(err) {
+					return nil
+				}
+				return err
+			}).
+				WithContext(ctx).
+				WithTimeout(fixtures.Timeout).
+				WithPolling(fixtures.Interval).
+				Should(Succeed())
 		})
 	})
 })

--- a/tests/integration/features/cleanup_int_test.go
+++ b/tests/integration/features/cleanup_int_test.go
@@ -124,6 +124,7 @@ var _ = Describe("feature cleanup", func() {
 
 			// then
 			Eventually(createdSecretHasOwnerReferenceToOwningFeature(namespace)).
+				WithContext(ctx).
 				WithTimeout(fixtures.Timeout).
 				WithPolling(fixtures.Interval).
 				Should(Succeed())
@@ -155,6 +156,7 @@ var _ = Describe("feature cleanup", func() {
 
 			// then
 			Eventually(createdSecretHasOwnerReferenceToOwningFeature(namespace)).
+				WithContext(ctx).
 				WithTimeout(fixtures.Timeout).
 				WithPolling(fixtures.Interval).
 				Should(WithTransform(errors.IsNotFound, BeTrue()))

--- a/tests/integration/features/cleanup_int_test.go
+++ b/tests/integration/features/cleanup_int_test.go
@@ -219,11 +219,11 @@ func createdSecretHasOwnerReferenceToOwningFeature(namespace, featureName string
 func namespaceExists(ctx context.Context, f *feature.Feature) (bool, error) {
 	namespace, err := fixtures.GetNamespace(ctx, f.Client, "conditional-ns")
 	if errors.IsNotFound(err) {
-		return false, err
+		return false, nil
 	}
 	// ensuring it fails if namespace is still deleting
 	if namespace.Status.Phase == corev1.NamespaceTerminating {
-		return false, err
+		return false, nil
 	}
-	return namespace != nil, nil
+	return true, nil
 }

--- a/tests/integration/features/cleanup_int_test.go
+++ b/tests/integration/features/cleanup_int_test.go
@@ -196,10 +196,8 @@ func createdSecretHasOwnerReferenceToOwningFeature(namespace string) func(contex
 
 func namespaceExists(f *feature.Feature) bool {
 	namespace, err := fixtures.GetNamespace(context.TODO(), f.Client, "conditional-ns")
-	if err != nil {
-		if errors.IsNotFound(err) {
-			return false
-		}
+	if errors.IsNotFound(err) {
+		return false
 	}
 	// ensuring it fails if namespace is still deleting
 	if namespace.Status.Phase == corev1.NamespaceTerminating {

--- a/tests/integration/features/cleanup_int_test.go
+++ b/tests/integration/features/cleanup_int_test.go
@@ -2,6 +2,7 @@ package features_test
 
 import (
 	"context"
+
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -58,7 +59,7 @@ var _ = Describe("feature cleanup", func() {
 			Expect(featuresHandler.Apply(ctx)).Should(Succeed())
 
 			// then
-			Eventually(createdSecretHasOwnerReferenceToOwningFeature(namespace, secretName)).
+			Eventually(createdSecretHasOwnerReferenceToOwningFeature(namespace)).
 				WithContext(ctx).
 				WithTimeout(fixtures.Timeout).
 				WithPolling(fixtures.Interval).
@@ -70,7 +71,7 @@ var _ = Describe("feature cleanup", func() {
 			Expect(featuresHandler.Delete(ctx)).To(Succeed())
 
 			// then
-			Eventually(createdSecretHasOwnerReferenceToOwningFeature(namespace, secretName)).
+			Eventually(createdSecretHasOwnerReferenceToOwningFeature(namespace)).
 				WithContext(ctx).
 				WithTimeout(fixtures.Timeout).
 				WithPolling(fixtures.Interval).
@@ -122,7 +123,7 @@ var _ = Describe("feature cleanup", func() {
 			Expect(featuresHandler.Apply(ctx)).Should(Succeed())
 
 			// then
-			Eventually(createdSecretHasOwnerReferenceToOwningFeature(namespace, secretName)).
+			Eventually(createdSecretHasOwnerReferenceToOwningFeature(namespace)).
 				WithTimeout(fixtures.Timeout).
 				WithPolling(fixtures.Interval).
 				Should(Succeed())
@@ -153,7 +154,7 @@ var _ = Describe("feature cleanup", func() {
 			Expect(featuresHandler.Apply(ctx)).Should(Succeed())
 
 			// then
-			Eventually(createdSecretHasOwnerReferenceToOwningFeature(namespace, secretName)).
+			Eventually(createdSecretHasOwnerReferenceToOwningFeature(namespace)).
 				WithTimeout(fixtures.Timeout).
 				WithPolling(fixtures.Interval).
 				Should(WithTransform(errors.IsNotFound, BeTrue()))
@@ -161,8 +162,9 @@ var _ = Describe("feature cleanup", func() {
 	})
 })
 
-func createdSecretHasOwnerReferenceToOwningFeature(namespace, secretName string) func(context.Context) error {
+func createdSecretHasOwnerReferenceToOwningFeature(namespace string) func(context.Context) error {
 	return func(ctx context.Context) error {
+		secretName := "test-secret" // Hardcoded value
 		secret, err := envTestClientset.CoreV1().
 			Secrets(namespace).
 			Get(ctx, secretName, metav1.GetOptions{})


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

This PR introduces a featureBuilder function that enables conditional toggling of features named `EnabledWhen`. Features can now be activated or deactivated based on specific conditions such as the target platform, management mode, or the presence of particular resources in the cluster.

Building on the previous PR linked below which we didn't finish up, this update ensures that feature.Cleanup() is called if a feature's EnabledWhen() status changes from true to false across multiple reconciles. Additionally, this PR includes enhanced testing to validate these changes.

## JIRA issue:
<!--- Link your JIRA and related links here for reference. -->

https://issues.redhat.com/browse/RHOAIENG-8540

re-doing and finishing up work from PR #793 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Wrote additional cleanup integration tests - using an example function checking if a certain namespace exists to enable the feature. 

Ensured the feature applied when the namespace exists and that the feature was cleaned up on "reconcile" when the namespace no longer exists. 

## Screenshot or short clip:
<!--- Attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] Have a meaningful commit messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
