### PR TITLE
cluster_config: init cluster variables on startup

### DIFF
--- a/controllers/datasciencecluster/datasciencecluster_controller.go
+++ b/controllers/datasciencecluster/datasciencecluster_controller.go
@@ -88,11 +88,7 @@ func (r *DataScienceClusterReconciler) Reconcile(ctx context.Context, req ctrl.R
 	log.Info("Reconciling DataScienceCluster resources", "Request.Name", req.Name)
 
 	// Get information on version and platform
-	currentOperatorRelease, err := cluster.GetRelease(ctx, r.Client)
-	if err != nil {
-		log.Error(err, "failed to get operator release version")
-		return ctrl.Result{}, err
-	}
+	currentOperatorRelease := cluster.GetRelease()
 	// Set platform
 	platform := currentOperatorRelease.Name
 

--- a/controllers/dscinitialization/dscinitialization_controller.go
+++ b/controllers/dscinitialization/dscinitialization_controller.go
@@ -79,11 +79,7 @@ func (r *DSCInitializationReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	log := r.Log
 	log.Info("Reconciling DSCInitialization.", "DSCInitialization Request.Name", req.Name)
 
-	currentOperatorRelease, err := cluster.GetRelease(ctx, r.Client)
-	if err != nil {
-		log.Error(err, "failed to get operator release version")
-		return ctrl.Result{}, err
-	}
+	currentOperatorRelease := cluster.GetRelease()
 	// Set platform
 	platform := currentOperatorRelease.Name
 
@@ -142,7 +138,7 @@ func (r *DSCInitializationReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	if instance.Status.Conditions == nil {
 		reason := status.ReconcileInit
 		message := "Initializing DSCInitialization resource"
-		instance, err = status.UpdateWithRetry(ctx, r.Client, instance, func(saved *dsciv1.DSCInitialization) {
+		instance, err := status.UpdateWithRetry(ctx, r.Client, instance, func(saved *dsciv1.DSCInitialization) {
 			status.SetProgressingCondition(&saved.Status.Conditions, reason, message)
 			saved.Status.Phase = status.PhaseProgressing
 			saved.Status.Release = currentOperatorRelease
@@ -158,7 +154,7 @@ func (r *DSCInitializationReconciler) Reconcile(ctx context.Context, req ctrl.Re
 
 	// Check namespace is not exist, then create
 	namespace := instance.Spec.ApplicationsNamespace
-	err = r.createOdhNamespace(ctx, instance, namespace, platform)
+	err := r.createOdhNamespace(ctx, instance, namespace, platform)
 	if err != nil {
 		// no need to log error as it was already logged in createOdhNamespace
 		return reconcile.Result{}, err

--- a/main.go
+++ b/main.go
@@ -153,11 +153,7 @@ func main() { //nolint:funlen,maintidx
 	}
 
 	// Get operator platform
-	release, err := cluster.GetRelease(ctx, setupClient)
-	if err != nil {
-		setupLog.Error(err, "error getting release")
-		os.Exit(1)
-	}
+	release := cluster.GetRelease()
 	platform := release.Name
 
 	secretCache := createSecretCacheConfig(platform)

--- a/main.go
+++ b/main.go
@@ -49,6 +49,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	ctrlmetrics "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	ctrlwebhook "sigs.k8s.io/controller-runtime/pkg/webhook"
@@ -128,6 +129,7 @@ func main() { //nolint:funlen,maintidx
 
 	// root context
 	ctx := ctrl.SetupSignalHandler()
+	ctx = logf.IntoContext(ctx, setupLog)
 	// Create new uncached client to run initial setup
 	setupCfg, err := config.GetConfig()
 	if err != nil {
@@ -143,6 +145,13 @@ func main() { //nolint:funlen,maintidx
 		setupLog.Error(err, "error getting client for setup")
 		os.Exit(1)
 	}
+
+	err = cluster.Init(ctx, setupClient)
+	if err != nil {
+		setupLog.Error(err, "unable to initialize cluster config")
+		os.Exit(1)
+	}
+
 	// Get operator platform
 	release, err := cluster.GetRelease(ctx, setupClient)
 	if err != nil {
@@ -150,7 +159,6 @@ func main() { //nolint:funlen,maintidx
 		os.Exit(1)
 	}
 	platform := release.Name
-	setupLog.Info("running on", "platform", platform)
 
 	secretCache := createSecretCacheConfig(platform)
 	deploymentCache := createDeploymentCacheConfig(platform)

--- a/pkg/cluster/cluster_config.go
+++ b/pkg/cluster/cluster_config.go
@@ -21,6 +21,15 @@ import (
 
 // +kubebuilder:rbac:groups="config.openshift.io",resources=ingresses,verbs=get
 
+type Platform string
+
+// Release includes information on operator version and platform
+// +kubebuilder:object:generate=true
+type Release struct {
+	Name    Platform                `json:"name,omitempty"`
+	Version version.OperatorVersion `json:"version,omitempty"`
+}
+
 func GetDomain(ctx context.Context, c client.Client) (string, error) {
 	ingress := &unstructured.Unstructured{}
 	ingress.SetGroupVersionKind(gvk.OpenshiftIngress)
@@ -82,8 +91,6 @@ func GetClusterServiceVersion(ctx context.Context, c client.Client, namespace st
 		gvk.ClusterServiceVersion.Kind)
 }
 
-type Platform string
-
 // detectSelfManaged detects if it is Self Managed Rhods or OpenDataHub.
 func detectSelfManaged(ctx context.Context, cli client.Client) (Platform, error) {
 	variants := map[string]Platform{
@@ -124,13 +131,6 @@ func getPlatform(ctx context.Context, cli client.Client) (Platform, error) {
 
 	// check and return whether ODH or self-managed platform
 	return detectSelfManaged(ctx, cli)
-}
-
-// Release includes information on operator version and platform
-// +kubebuilder:object:generate=true
-type Release struct {
-	Name    Platform                `json:"name,omitempty"`
-	Version version.OperatorVersion `json:"version,omitempty"`
 }
 
 func GetRelease(ctx context.Context, cli client.Client) (Release, error) {

--- a/pkg/cluster/cluster_config.go
+++ b/pkg/cluster/cluster_config.go
@@ -72,8 +72,8 @@ func GetOperatorNamespace() (string, error) {
 	return clusterConfig.Namespace, nil
 }
 
-func GetRelease(_ context.Context, _ client.Client) (Release, error) {
-	return clusterConfig.Release, nil
+func GetRelease() Release {
+	return clusterConfig.Release
 }
 
 func GetDomain(ctx context.Context, c client.Client) (string, error) {


### PR DESCRIPTION
Cluster configuration is supposed to be the same during operator pod
lifetime. There is no point to detect it on every reconcile cycle
keeping in mind that it can causes many api requests.

Do the initialization on startup. Keep GetOperatorNamespace()
returning error since it defines some logic in the DSCInitialization
reconciler.

Automatically called init() won't work here due to need to check
error of the initialization.

Leave GetDomain() as is since it uses OpenshiftIngress configuration
which is created when DSCInitialization instantiated.

Log cluster configuration on success.


<!--- Provide a general summary of your changes in the Title above -->

Many thanks for submitting your Pull Request ❤️!

Please make sure that your PR meets the following requirements:

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md)
- [ ] Pull Request contains description of the issue
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains link to any dependent or related Pull Request

## Description
<!--- Describe your changes in detail -->

## JIRA issue:
<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip:
<!--- Attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] Have a meaningful commit messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
