### PR TITLE
chore: fix remove trailing slash from GITHUB_URL

### DIFF
--- a/get_all_manifests.sh
+++ b/get_all_manifests.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-GITHUB_URL="https://github.com/"
+GITHUB_URL="https://github.com"
 
 # component: notebook, dsp, kserve, dashbaord, cf/ray/kueue/trainingoperator, trustyai, modelmesh, modelregistry.
 # in the format of "repo-org:repo-name:branch-name:source-folder:target-folder".


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Many thanks for submitting your Pull Request ❤️!

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md)
- [x] Pull Request contains description of the issue
- [ ] ~~Pull Request contains link to the JIRA issue~~
- [ ] ~~Pull Request contains link to any dependent or related Pull Request~~

## Description

The GITHUB_URL was set to https://github.com/ (note the trailing slash)
which causes the script to fail in certain environment where git is
configured to rewrite the url i.e. to always use the ssh protocol:

```
  [url "git@github.com:"]
    insteadOf = https://github.com
```

## How Has This Been Tested?
- `get_all_manifests.sh` script executed with vanilla git config
- `get_all_manifests.sh` script executed with git url rewriting

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] Have a meaningful commit messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work
