### PR TITLE
refactor: dashboard with new manifests structure

### DIFF
--- a/components/README.md
+++ b/components/README.md
@@ -35,7 +35,7 @@ can be found [here](https://github.com/opendatahub-io/opendatahub-operator/tree/
       Cleanup(cli client.Client, DSCISpec *dsciv1.DSCInitializationSpec) error
       GetComponentName() string
       GetManagementState() operatorv1.ManagementState
-      OverrideManifests(platform string) error
+      OverrideManifests(platform cluster.Platform) error
       UpdatePrometheusConfig(cli client.Client, enable bool, component string) error
       ConfigComponentLogger(logger logr.Logger, component string, dscispec *dsciv1.DSCInitializationSpec) logr.Logger
     }

--- a/components/codeflare/codeflare.go
+++ b/components/codeflare/codeflare.go
@@ -35,7 +35,7 @@ type CodeFlare struct {
 	components.Component `json:""`
 }
 
-func (c *CodeFlare) OverrideManifests(ctx context.Context, _ string) error {
+func (c *CodeFlare) OverrideManifests(ctx context.Context, _ cluster.Platform) error {
 	// If devflags are set, update default manifests path
 	if len(c.DevFlags.Manifests) != 0 {
 		manifestConfig := c.DevFlags.Manifests[0]
@@ -76,7 +76,7 @@ func (c *CodeFlare) ReconcileComponent(ctx context.Context,
 	if enabled {
 		if c.DevFlags != nil {
 			// Download manifests and update paths
-			if err := c.OverrideManifests(ctx, string(platform)); err != nil {
+			if err := c.OverrideManifests(ctx, platform); err != nil {
 				return err
 			}
 		}

--- a/components/component.go
+++ b/components/component.go
@@ -84,7 +84,7 @@ type ComponentInterface interface {
 	Cleanup(ctx context.Context, cli client.Client, DSCISpec *dsciv1.DSCInitializationSpec) error
 	GetComponentName() string
 	GetManagementState() operatorv1.ManagementState
-	OverrideManifests(ctx context.Context, platform string) error
+	OverrideManifests(ctx context.Context, platform cluster.Platform) error
 	UpdatePrometheusConfig(cli client.Client, enable bool, component string) error
 	ConfigComponentLogger(logger logr.Logger, component string, dscispec *dsciv1.DSCInitializationSpec) logr.Logger
 }

--- a/components/dashboard/dashboard.go
+++ b/components/dashboard/dashboard.go
@@ -5,13 +5,12 @@ package dashboard
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"path/filepath"
-	"strings"
 
 	"github.com/go-logr/logr"
 	operatorv1 "github.com/openshift/api/operator/v1"
-	routev1 "github.com/openshift/api/route/v1"
 	corev1 "k8s.io/api/core/v1"
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -20,26 +19,17 @@ import (
 	dsciv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/dscinitialization/v1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/components"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
-	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/common"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/deploy"
 )
 
 var (
-	ComponentName   = "dashboard"
-	Path            = deploy.DefaultManifestPath + "/" + ComponentName + "/base"        // ODH
-	PathISV         = deploy.DefaultManifestPath + "/" + ComponentName + "/apps"        // ODH APPS
-	PathCRDs        = deploy.DefaultManifestPath + "/" + ComponentName + "/crd"         // ODH + RHOAI
-	PathConsoleLink = deploy.DefaultManifestPath + "/" + ComponentName + "/consolelink" // ODH consolelink
+	ComponentNameUpstream = "dashboard"
+	PathUpstream          = deploy.DefaultManifestPath + "/" + ComponentNameUpstream + "/odh"
 
-	ComponentNameSupported   = "rhods-dashboard"
-	PathSupported            = deploy.DefaultManifestPath + "/" + ComponentName + "/overlays/rhoai"              // RHOAI
-	PathISVSM                = deploy.DefaultManifestPath + "/" + ComponentName + "/overlays/apps/apps-onprem"   // RHOAI APPS
-	PathISVAddOn             = deploy.DefaultManifestPath + "/" + ComponentName + "/overlays/apps/apps-addon"    // RHOAI APPS
-	PathConsoleLinkSupported = deploy.DefaultManifestPath + "/" + ComponentName + "/overlays/consolelink"        // RHOAI
-	PathODHDashboardConfig   = deploy.DefaultManifestPath + "/" + ComponentName + "/overlays/odhdashboardconfig" // RHOAI odhdashboardconfig
-
-	NameConsoleLink      = "console"
-	NamespaceConsoleLink = "openshift-console"
+	ComponentNameDownstream = "rhods-dashboard"
+	PathDownstream          = deploy.DefaultManifestPath + "/" + ComponentNameUpstream + "/rhoai"
+	PathSelfDownstream      = PathDownstream + "/onprem"
+	PathManagedDownstream   = PathDownstream + "/addon"
 )
 
 // Verifies that Dashboard implements ComponentInterface.
@@ -51,26 +41,33 @@ type Dashboard struct {
 	components.Component `json:""`
 }
 
-func (d *Dashboard) OverrideManifests(ctx context.Context, platform string) error {
+func (d *Dashboard) OverrideManifests(ctx context.Context, platform cluster.Platform) error {
 	// If devflags are set, update default manifests path
 	if len(d.DevFlags.Manifests) != 0 {
+		ComponentName := ComponentNameUpstream
 		manifestConfig := d.DevFlags.Manifests[0]
 		if err := deploy.DownloadManifests(ctx, ComponentName, manifestConfig); err != nil {
 			return err
 		}
-		// If overlay is defined, update paths
-		if platform == string(cluster.ManagedRhods) || platform == string(cluster.SelfManagedRhods) {
-			defaultKustomizePath := "overlays/rhoai"
+		switch platform {
+		case cluster.SelfManagedRhods:
+			defaultKustomizePath := "rhoai/onprem"
 			if manifestConfig.SourcePath != "" {
 				defaultKustomizePath = manifestConfig.SourcePath
 			}
-			PathSupported = filepath.Join(deploy.DefaultManifestPath, ComponentName, defaultKustomizePath)
-		} else {
-			defaultKustomizePath := "base"
+			PathSelfDownstream = filepath.Join(deploy.DefaultManifestPath, ComponentName, defaultKustomizePath)
+		case cluster.ManagedRhods:
+			defaultKustomizePath := "rhoai/addon"
 			if manifestConfig.SourcePath != "" {
 				defaultKustomizePath = manifestConfig.SourcePath
 			}
-			Path = filepath.Join(deploy.DefaultManifestPath, ComponentName, defaultKustomizePath)
+			PathManagedDownstream = filepath.Join(deploy.DefaultManifestPath, ComponentName, defaultKustomizePath)
+		default:
+			defaultKustomizePath := "odh"
+			if manifestConfig.SourcePath != "" {
+				defaultKustomizePath = manifestConfig.SourcePath
+			}
+			PathUpstream = filepath.Join(deploy.DefaultManifestPath, ComponentName, defaultKustomizePath)
 		}
 	}
 
@@ -78,10 +75,9 @@ func (d *Dashboard) OverrideManifests(ctx context.Context, platform string) erro
 }
 
 func (d *Dashboard) GetComponentName() string {
-	return ComponentName
+	return ComponentNameUpstream
 }
 
-//nolint:gocyclo
 func (d *Dashboard) ReconcileComponent(ctx context.Context,
 	cli client.Client,
 	logger logr.Logger,
@@ -93,54 +89,60 @@ func (d *Dashboard) ReconcileComponent(ctx context.Context,
 	var l logr.Logger
 
 	if platform == cluster.SelfManagedRhods || platform == cluster.ManagedRhods {
-		l = d.ConfigComponentLogger(logger, ComponentNameSupported, dscispec)
+		l = d.ConfigComponentLogger(logger, ComponentNameDownstream, dscispec)
 	} else {
-		l = d.ConfigComponentLogger(logger, ComponentName, dscispec)
+		l = d.ConfigComponentLogger(logger, ComponentNameUpstream, dscispec)
 	}
 
-	var imageParamMap = map[string]string{
-		"odh-dashboard-image": "RELATED_IMAGE_ODH_DASHBOARD_IMAGE",
-	}
+	entryPath := map[cluster.Platform]string{
+		cluster.SelfManagedRhods: PathDownstream + "/onprem",
+		cluster.ManagedRhods:     PathDownstream + "/addon",
+		cluster.OpenDataHub:      PathUpstream,
+	}[platform]
+
 	enabled := d.GetManagementState() == operatorv1.Managed
 	monitoringEnabled := dscispec.Monitoring.ManagementState == operatorv1.Managed
 
-	// Update Default rolebinding
 	if enabled {
-		// Update Default rolebinding
-		// cleanup OAuth client related secret and CR if dashboard is in 'installed false' status
+		// 1. cleanup OAuth client related secret and CR if dashboard is in 'installed false' status
 		if err := d.cleanOauthClient(ctx, cli, dscispec, currentComponentExist, l); err != nil {
 			return err
 		}
 		if d.DevFlags != nil {
 			// Download manifests and update paths
-			if err := d.OverrideManifests(ctx, string(platform)); err != nil {
+			if err := d.OverrideManifests(ctx, platform); err != nil {
 				return err
 			}
-		}
-		// 1. Deploy CRDs
-		if err := d.deployCRDsForPlatform(ctx, cli, owner, dscispec.ApplicationsNamespace, platform); err != nil {
-			return fmt.Errorf("failed to deploy Dashboard CRD: %w", err)
 		}
 
 		// 2. platform specific RBAC
 		if platform == cluster.OpenDataHub || platform == "" {
-			err := cluster.UpdatePodSecurityRolebinding(ctx, cli, dscispec.ApplicationsNamespace, "odh-dashboard")
-			if err != nil {
+			if err := cluster.UpdatePodSecurityRolebinding(ctx, cli, dscispec.ApplicationsNamespace, "odh-dashboard"); err != nil {
 				return err
 			}
 		}
 
 		if platform == cluster.SelfManagedRhods || platform == cluster.ManagedRhods {
-			err := cluster.UpdatePodSecurityRolebinding(ctx, cli, dscispec.ApplicationsNamespace, "rhods-dashboard")
-			if err != nil {
+			if err := cluster.UpdatePodSecurityRolebinding(ctx, cli, dscispec.ApplicationsNamespace, "rhods-dashboard"); err != nil {
 				return err
 			}
 		}
 
 		// 3. Update image parameters
+		var imageParamMap = map[string]string{
+			"odh-dashboard-image": "RELATED_IMAGE_ODH_DASHBOARD_IMAGE",
+		}
+
+		// 4. Append or Update variable for component to consume
+		extraParamsMap, err := updateKustomizeVariable(ctx, cli, platform, dscispec)
+		if err != nil {
+			return errors.New("failed to set variable for extraParamsMap")
+		}
+
+		// 5. update params.env
 		if (dscispec.DevFlags == nil || dscispec.DevFlags.ManifestsUri == "") && (d.DevFlags == nil || len(d.DevFlags.Manifests) == 0) {
-			if err := deploy.ApplyParams(PathSupported, imageParamMap, false); err != nil {
-				return fmt.Errorf("failed to update image from %s : %w", PathSupported, err)
+			if err := deploy.ApplyParams(entryPath, imageParamMap, false, extraParamsMap); err != nil {
+				return fmt.Errorf("failed to update params.env  from %s : %w", entryPath, err)
 			}
 		}
 	}
@@ -153,18 +155,9 @@ func (d *Dashboard) ReconcileComponent(ctx context.Context,
 		if err := cluster.CreateSecret(ctx, cli, "anaconda-ce-access", dscispec.ApplicationsNamespace); err != nil {
 			return fmt.Errorf("failed to create access-secret for anaconda: %w", err)
 		}
-		// overlay which including ../../base + anaconda-ce-validator
-		if err := deploy.DeployManifestsFromPath(ctx, cli, owner, PathSupported, dscispec.ApplicationsNamespace, ComponentNameSupported, enabled); err != nil {
-			return fmt.Errorf("failed to apply manifests from %s: %w", PathSupported, err)
-		}
-
-		// Apply RHOAI specific configs, e.g anaconda screct and cronjob and ISV
-		if err := d.applyRHOAISpecificConfigs(ctx, cli, owner, dscispec.ApplicationsNamespace, platform); err != nil {
-			return err
-		}
-		// consolelink
-		if err := d.deployConsoleLink(ctx, cli, owner, platform, dscispec.ApplicationsNamespace, ComponentNameSupported); err != nil {
-			return err
+		// Deploy RHOAI manifests
+		if err := deploy.DeployManifestsFromPath(ctx, cli, owner, entryPath, dscispec.ApplicationsNamespace, ComponentNameDownstream, enabled); err != nil {
+			return fmt.Errorf("failed to apply manifests from %s: %w", PathDownstream, err)
 		}
 		l.Info("apply manifests done")
 
@@ -172,13 +165,13 @@ func (d *Dashboard) ReconcileComponent(ctx context.Context,
 		if platform == cluster.ManagedRhods {
 			if enabled {
 				// first check if the service is up, so prometheus won't fire alerts when it is just startup
-				if err := cluster.WaitForDeploymentAvailable(ctx, cli, ComponentNameSupported, dscispec.ApplicationsNamespace, 20, 3); err != nil {
-					return fmt.Errorf("deployment for %s is not ready to server: %w", ComponentName, err)
+				if err := cluster.WaitForDeploymentAvailable(ctx, cli, ComponentNameDownstream, dscispec.ApplicationsNamespace, 20, 3); err != nil {
+					return fmt.Errorf("deployment for %s is not ready to server: %w", ComponentNameDownstream, err)
 				}
 				l.Info("deployment is done, updating monitoring rules")
 			}
 
-			if err := d.UpdatePrometheusConfig(cli, enabled && monitoringEnabled, ComponentNameSupported); err != nil {
+			if err := d.UpdatePrometheusConfig(cli, enabled && monitoringEnabled, ComponentNameDownstream); err != nil {
 				return err
 			}
 			if err := deploy.DeployManifestsFromPath(ctx, cli, owner,
@@ -190,17 +183,10 @@ func (d *Dashboard) ReconcileComponent(ctx context.Context,
 			l.Info("updating SRE monitoring done")
 		}
 		return nil
+
 	default:
-		// base
-		if err := deploy.DeployManifestsFromPath(ctx, cli, owner, Path, dscispec.ApplicationsNamespace, ComponentName, enabled); err != nil {
-			return err
-		}
-		// ISV
-		if err := deploy.DeployManifestsFromPath(ctx, cli, owner, PathISV, dscispec.ApplicationsNamespace, ComponentName, enabled); err != nil {
-			return err
-		}
-		// consolelink
-		if err := d.deployConsoleLink(ctx, cli, owner, platform, dscispec.ApplicationsNamespace, ComponentName); err != nil {
+		// Deploy ODH manifests
+		if err := deploy.DeployManifestsFromPath(ctx, cli, owner, entryPath, dscispec.ApplicationsNamespace, ComponentNameUpstream, enabled); err != nil {
 			return err
 		}
 		l.Info("apply manifests done")
@@ -208,81 +194,34 @@ func (d *Dashboard) ReconcileComponent(ctx context.Context,
 	}
 }
 
-func (d *Dashboard) deployCRDsForPlatform(ctx context.Context, cli client.Client, owner metav1.Object, namespace string, platform cluster.Platform) error {
-	componentName := ComponentName
-	if platform == cluster.SelfManagedRhods || platform == cluster.ManagedRhods {
-		componentName = ComponentNameSupported
-	}
-	// we only deploy CRD, we do not remove CRD
-	return deploy.DeployManifestsFromPath(ctx, cli, owner, PathCRDs, namespace, componentName, true)
-}
-
-func (d *Dashboard) applyRHOAISpecificConfigs(ctx context.Context, cli client.Client, owner metav1.Object, namespace string, platform cluster.Platform) error {
-	enabled := d.ManagementState == operatorv1.Managed
-
-	// set proper group name
-	dashboardConfig := filepath.Join(PathODHDashboardConfig, "odhdashboardconfig.yaml")
+func updateKustomizeVariable(ctx context.Context, cli client.Client, platform cluster.Platform, dscispec *dsciv1.DSCInitializationSpec) (map[string]string, error) {
 	adminGroups := map[cluster.Platform]string{
 		cluster.SelfManagedRhods: "rhods-admins",
 		cluster.ManagedRhods:     "dedicated-admins",
+		cluster.OpenDataHub:      "odh-admins",
 	}[platform]
 
-	if err := common.ReplaceStringsInFile(dashboardConfig, map[string]string{"<admin_groups>": adminGroups}); err != nil {
-		return err
-	}
-	if err := deploy.DeployManifestsFromPath(ctx, cli, owner, PathODHDashboardConfig, namespace, ComponentNameSupported, enabled); err != nil {
-		return fmt.Errorf("failed to create OdhDashboardConfig from %s: %w", PathODHDashboardConfig, err)
-	}
-	// ISV
-	path := PathISVSM
-	if platform == cluster.ManagedRhods {
-		path = PathISVAddOn
-	}
-	if err := deploy.DeployManifestsFromPath(ctx, cli, owner, path, namespace, ComponentNameSupported, enabled); err != nil {
-		return fmt.Errorf("failed to set dashboard ISV from %s : %w", Path, err)
-	}
-	return nil
-}
+	sectionTitle := map[cluster.Platform]string{
+		cluster.SelfManagedRhods: "OpenShift Self Managed Services",
+		cluster.ManagedRhods:     "OpenShift Managed Services",
+		cluster.OpenDataHub:      "OpenShift Open Data Hub",
+	}[platform]
 
-func (d *Dashboard) deployConsoleLink(ctx context.Context, cli client.Client, owner metav1.Object, platform cluster.Platform, namespace, componentName string) error {
-	var manifestsPath, sectionTitle, routeName string
-	switch platform {
-	case cluster.SelfManagedRhods:
-		sectionTitle = "OpenShift Self Managed Services"
-		manifestsPath = PathConsoleLinkSupported
-		routeName = componentName
-	case cluster.ManagedRhods:
-		sectionTitle = "OpenShift Managed Services"
-		manifestsPath = PathConsoleLinkSupported
-		routeName = componentName
-	default:
-		sectionTitle = "OpenShift Open Data Hub"
-		manifestsPath = PathConsoleLink
-		routeName = "odh-dashboard"
+	consoleLinkDomain, err := cluster.GetDomain(ctx, cli)
+	if err != nil {
+		return nil, fmt.Errorf("error getting console route URL %s : %w", consoleLinkDomain, err)
 	}
+	consoleURL := map[cluster.Platform]string{
+		cluster.SelfManagedRhods: "https://rhods-dashboard-" + dscispec.ApplicationsNamespace + "." + consoleLinkDomain,
+		cluster.ManagedRhods:     "https://rhods-dashboard-" + dscispec.ApplicationsNamespace + "." + consoleLinkDomain,
+		cluster.OpenDataHub:      "https://odh-dashboard-" + dscispec.ApplicationsNamespace + "." + consoleLinkDomain,
+	}[platform]
 
-	pathConsoleLink := filepath.Join(manifestsPath, "consolelink.yaml")
-
-	consoleRoute := &routev1.Route{}
-	if err := cli.Get(ctx, client.ObjectKey{Name: NameConsoleLink, Namespace: NamespaceConsoleLink}, consoleRoute); err != nil {
-		return fmt.Errorf("error getting console route URL %s : %w", NameConsoleLink, err)
-	}
-
-	domainIndex := strings.Index(consoleRoute.Spec.Host, ".")
-	consoleLinkDomain := consoleRoute.Spec.Host[domainIndex+1:]
-	if err := common.ReplaceStringsInFile(pathConsoleLink, map[string]string{
-		"<dashboard-url>": "https://" + routeName + "-" + namespace + "." + consoleLinkDomain,
-		"<section-title>": sectionTitle,
-	}); err != nil {
-		return fmt.Errorf("error replacing with correct dashboard URL for consolelink : %w", err)
-	}
-
-	enabled := d.ManagementState == operatorv1.Managed
-	if err := deploy.DeployManifestsFromPath(ctx, cli, owner, PathConsoleLink, namespace, componentName, enabled); err != nil {
-		return fmt.Errorf("failed to set dashboard consolelink %s : %w", pathConsoleLink, err)
-	}
-
-	return nil
+	return map[string]string{
+		"admin_groups":  adminGroups,
+		"dashboard-url": consoleURL,
+		"section-title": sectionTitle,
+	}, nil
 }
 
 func (d *Dashboard) cleanOauthClient(ctx context.Context, cli client.Client, dscispec *dsciv1.DSCInitializationSpec, currentComponentExist bool, l logr.Logger) error {

--- a/components/dashboard/dashboard.go
+++ b/components/dashboard/dashboard.go
@@ -80,6 +80,7 @@ func (d *Dashboard) ReconcileComponent(ctx context.Context,
 		cluster.SelfManagedRhods: PathDownstream + "/onprem",
 		cluster.ManagedRhods:     PathDownstream + "/addon",
 		cluster.OpenDataHub:      PathUpstream,
+		cluster.Unknown:          PathUpstream,
 	}[platform]
 
 	enabled := d.GetManagementState() == operatorv1.Managed
@@ -105,9 +106,7 @@ func (d *Dashboard) ReconcileComponent(ctx context.Context,
 			if err := cluster.UpdatePodSecurityRolebinding(ctx, cli, dscispec.ApplicationsNamespace, "odh-dashboard"); err != nil {
 				return err
 			}
-		}
-
-		if platform == cluster.SelfManagedRhods || platform == cluster.ManagedRhods {
+		} else {
 			if err := cluster.UpdatePodSecurityRolebinding(ctx, cli, dscispec.ApplicationsNamespace, "rhods-dashboard"); err != nil {
 				return err
 			}
@@ -184,12 +183,14 @@ func updateKustomizeVariable(ctx context.Context, cli client.Client, platform cl
 		cluster.SelfManagedRhods: "rhods-admins",
 		cluster.ManagedRhods:     "dedicated-admins",
 		cluster.OpenDataHub:      "odh-admins",
+		cluster.Unknown:          "odh-admins",
 	}[platform]
 
 	sectionTitle := map[cluster.Platform]string{
 		cluster.SelfManagedRhods: "OpenShift Self Managed Services",
 		cluster.ManagedRhods:     "OpenShift Managed Services",
 		cluster.OpenDataHub:      "OpenShift Open Data Hub",
+		cluster.Unknown:          "OpenShift Open Data Hub",
 	}[platform]
 
 	consoleLinkDomain, err := cluster.GetDomain(ctx, cli)
@@ -200,6 +201,7 @@ func updateKustomizeVariable(ctx context.Context, cli client.Client, platform cl
 		cluster.SelfManagedRhods: "https://rhods-dashboard-" + dscispec.ApplicationsNamespace + "." + consoleLinkDomain,
 		cluster.ManagedRhods:     "https://rhods-dashboard-" + dscispec.ApplicationsNamespace + "." + consoleLinkDomain,
 		cluster.OpenDataHub:      "https://odh-dashboard-" + dscispec.ApplicationsNamespace + "." + consoleLinkDomain,
+		cluster.Unknown:          "https://odh-dashboard-" + dscispec.ApplicationsNamespace + "." + consoleLinkDomain,
 	}[platform]
 
 	return map[string]string{

--- a/components/datasciencepipelines/datasciencepipelines.go
+++ b/components/datasciencepipelines/datasciencepipelines.go
@@ -41,7 +41,7 @@ type DataSciencePipelines struct {
 	components.Component `json:""`
 }
 
-func (d *DataSciencePipelines) OverrideManifests(ctx context.Context, _ string) error {
+func (d *DataSciencePipelines) OverrideManifests(ctx context.Context, _ cluster.Platform) error {
 	// If devflags are set, update default manifests path
 	if len(d.DevFlags.Manifests) != 0 {
 		manifestConfig := d.DevFlags.Manifests[0]
@@ -97,7 +97,7 @@ func (d *DataSciencePipelines) ReconcileComponent(ctx context.Context,
 	if enabled {
 		if d.DevFlags != nil {
 			// Download manifests and update paths
-			if err := d.OverrideManifests(ctx, string(platform)); err != nil {
+			if err := d.OverrideManifests(ctx, platform); err != nil {
 				return err
 			}
 		}

--- a/components/kserve/kserve.go
+++ b/components/kserve/kserve.go
@@ -56,7 +56,7 @@ type Kserve struct {
 	DefaultDeploymentMode DefaultDeploymentMode `json:"defaultDeploymentMode,omitempty"`
 }
 
-func (k *Kserve) OverrideManifests(ctx context.Context, _ string) error {
+func (k *Kserve) OverrideManifests(ctx context.Context, _ cluster.Platform) error {
 	// Download manifests if defined by devflags
 	// Go through each manifest and set the overlays if defined
 	for _, subcomponent := range k.DevFlags.Manifests {
@@ -119,7 +119,7 @@ func (k *Kserve) ReconcileComponent(ctx context.Context, cli client.Client,
 		}
 		if k.DevFlags != nil {
 			// Download manifests and update paths
-			if err := k.OverrideManifests(ctx, string(platform)); err != nil {
+			if err := k.OverrideManifests(ctx, platform); err != nil {
 				return err
 			}
 		}

--- a/components/kueue/kueue.go
+++ b/components/kueue/kueue.go
@@ -31,7 +31,7 @@ type Kueue struct {
 	components.Component `json:""`
 }
 
-func (k *Kueue) OverrideManifests(ctx context.Context, _ string) error {
+func (k *Kueue) OverrideManifests(ctx context.Context, _ cluster.Platform) error {
 	// If devflags are set, update default manifests path
 	if len(k.DevFlags.Manifests) != 0 {
 		manifestConfig := k.DevFlags.Manifests[0]
@@ -65,7 +65,7 @@ func (k *Kueue) ReconcileComponent(ctx context.Context, cli client.Client, logge
 	if enabled {
 		if k.DevFlags != nil {
 			// Download manifests and update paths
-			if err := k.OverrideManifests(ctx, string(platform)); err != nil {
+			if err := k.OverrideManifests(ctx, platform); err != nil {
 				return err
 			}
 		}

--- a/components/modelmeshserving/modelmeshserving.go
+++ b/components/modelmeshserving/modelmeshserving.go
@@ -35,7 +35,7 @@ type ModelMeshServing struct {
 	components.Component `json:""`
 }
 
-func (m *ModelMeshServing) OverrideManifests(ctx context.Context, _ string) error {
+func (m *ModelMeshServing) OverrideManifests(ctx context.Context, _ cluster.Platform) error {
 	// Go through each manifest and set the overlays if defined
 	for _, subcomponent := range m.DevFlags.Manifests {
 		if strings.Contains(subcomponent.URI, DependentComponentName) {
@@ -100,7 +100,7 @@ func (m *ModelMeshServing) ReconcileComponent(ctx context.Context,
 	if enabled {
 		if m.DevFlags != nil {
 			// Download manifests and update paths
-			if err := m.OverrideManifests(ctx, string(platform)); err != nil {
+			if err := m.OverrideManifests(ctx, platform); err != nil {
 				return err
 			}
 		}

--- a/components/modelregistry/modelregistry.go
+++ b/components/modelregistry/modelregistry.go
@@ -36,7 +36,7 @@ type ModelRegistry struct {
 	components.Component `json:""`
 }
 
-func (m *ModelRegistry) OverrideManifests(ctx context.Context, _ string) error {
+func (m *ModelRegistry) OverrideManifests(ctx context.Context, _ cluster.Platform) error {
 	// If devflags are set, update default manifests path
 	if len(m.DevFlags.Manifests) != 0 {
 		manifestConfig := m.DevFlags.Manifests[0]
@@ -71,7 +71,7 @@ func (m *ModelRegistry) ReconcileComponent(ctx context.Context, cli client.Clien
 	if enabled {
 		if m.DevFlags != nil {
 			// Download manifests and update paths
-			if err := m.OverrideManifests(ctx, string(platform)); err != nil {
+			if err := m.OverrideManifests(ctx, platform); err != nil {
 				return err
 			}
 		}

--- a/components/ray/ray.go
+++ b/components/ray/ray.go
@@ -33,7 +33,7 @@ type Ray struct {
 	components.Component `json:""`
 }
 
-func (r *Ray) OverrideManifests(ctx context.Context, _ string) error {
+func (r *Ray) OverrideManifests(ctx context.Context, _ cluster.Platform) error {
 	// If devflags are set, update default manifests path
 	if len(r.DevFlags.Manifests) != 0 {
 		manifestConfig := r.DevFlags.Manifests[0]
@@ -70,7 +70,7 @@ func (r *Ray) ReconcileComponent(ctx context.Context, cli client.Client, logger 
 	if enabled {
 		if r.DevFlags != nil {
 			// Download manifests and update paths
-			if err := r.OverrideManifests(ctx, string(platform)); err != nil {
+			if err := r.OverrideManifests(ctx, platform); err != nil {
 				return err
 			}
 		}

--- a/components/trainingoperator/trainingoperator.go
+++ b/components/trainingoperator/trainingoperator.go
@@ -33,7 +33,7 @@ type TrainingOperator struct {
 	components.Component `json:""`
 }
 
-func (r *TrainingOperator) OverrideManifests(ctx context.Context, _ string) error {
+func (r *TrainingOperator) OverrideManifests(ctx context.Context, _ cluster.Platform) error {
 	// If devflags are set, update default manifests path
 	if len(r.DevFlags.Manifests) != 0 {
 		manifestConfig := r.DevFlags.Manifests[0]
@@ -70,7 +70,7 @@ func (r *TrainingOperator) ReconcileComponent(ctx context.Context, cli client.Cl
 	if enabled {
 		if r.DevFlags != nil {
 			// Download manifests and update paths
-			if err := r.OverrideManifests(ctx, string(platform)); err != nil {
+			if err := r.OverrideManifests(ctx, platform); err != nil {
 				return err
 			}
 		}

--- a/components/trustyai/trustyai.go
+++ b/components/trustyai/trustyai.go
@@ -33,7 +33,7 @@ type TrustyAI struct {
 	components.Component `json:""`
 }
 
-func (t *TrustyAI) OverrideManifests(ctx context.Context, _ string) error {
+func (t *TrustyAI) OverrideManifests(ctx context.Context, _ cluster.Platform) error {
 	// If devflags are set, update default manifests path
 	if len(t.DevFlags.Manifests) != 0 {
 		manifestConfig := t.DevFlags.Manifests[0]
@@ -68,7 +68,7 @@ func (t *TrustyAI) ReconcileComponent(ctx context.Context, cli client.Client, lo
 	if enabled {
 		if t.DevFlags != nil {
 			// Download manifests and update paths
-			if err := t.OverrideManifests(ctx, string(platform)); err != nil {
+			if err := t.OverrideManifests(ctx, platform); err != nil {
 				return err
 			}
 		}

--- a/components/workbenches/workbenches.go
+++ b/components/workbenches/workbenches.go
@@ -40,7 +40,7 @@ type Workbenches struct {
 	components.Component `json:""`
 }
 
-func (w *Workbenches) OverrideManifests(ctx context.Context, platform string) error {
+func (w *Workbenches) OverrideManifests(ctx context.Context, platform cluster.Platform) error {
 	// Download manifests if defined by devflags
 	// Go through each manifest and set the overlays if defined
 	for _, subcomponent := range w.DevFlags.Manifests {
@@ -56,7 +56,7 @@ func (w *Workbenches) OverrideManifests(ctx context.Context, platform string) er
 				defaultKustomizePath = subcomponent.SourcePath
 				defaultKustomizePathSupported = subcomponent.SourcePath
 			}
-			if platform == string(cluster.ManagedRhods) || platform == string(cluster.SelfManagedRhods) {
+			if platform == cluster.ManagedRhods || platform == cluster.SelfManagedRhods {
 				notebookImagesPathSupported = filepath.Join(deploy.DefaultManifestPath, "jupyterhub", defaultKustomizePathSupported)
 			} else {
 				notebookImagesPath = filepath.Join(deploy.DefaultManifestPath, DependentComponentName, defaultKustomizePath)
@@ -113,7 +113,7 @@ func (w *Workbenches) ReconcileComponent(ctx context.Context, cli client.Client,
 	if enabled {
 		if w.DevFlags != nil {
 			// Download manifests and update paths
-			if err := w.OverrideManifests(ctx, string(platform)); err != nil {
+			if err := w.OverrideManifests(ctx, platform); err != nil {
 				return err
 			}
 		}

--- a/pkg/plugins/addLabelsplugin.go
+++ b/pkg/plugins/addLabelsplugin.go
@@ -1,7 +1,7 @@
 package plugins
 
 import (
-	"sigs.k8s.io/kustomize/api/builtins" //nolint:staticcheck //Remove after package update
+	"sigs.k8s.io/kustomize/api/builtins"
 	"sigs.k8s.io/kustomize/api/types"
 	"sigs.k8s.io/kustomize/kyaml/resid"
 

--- a/pkg/plugins/addLabelsplugin.go
+++ b/pkg/plugins/addLabelsplugin.go
@@ -1,7 +1,7 @@
 package plugins
 
 import (
-	"sigs.k8s.io/kustomize/api/builtins"
+	"sigs.k8s.io/kustomize/api/builtins" //nolint:staticcheck // Remove after package update
 	"sigs.k8s.io/kustomize/api/types"
 	"sigs.k8s.io/kustomize/kyaml/resid"
 

--- a/pkg/plugins/namespacePlugin.go
+++ b/pkg/plugins/namespacePlugin.go
@@ -1,7 +1,7 @@
 package plugins
 
 import (
-	"sigs.k8s.io/kustomize/api/builtins" //nolint:staticcheck // Remove after package update
+	"sigs.k8s.io/kustomize/api/builtins"
 	"sigs.k8s.io/kustomize/api/filters/namespace"
 	"sigs.k8s.io/kustomize/api/types"
 	"sigs.k8s.io/kustomize/kyaml/resid"

--- a/pkg/plugins/namespacePlugin.go
+++ b/pkg/plugins/namespacePlugin.go
@@ -1,7 +1,7 @@
 package plugins
 
 import (
-	"sigs.k8s.io/kustomize/api/builtins"
+	"sigs.k8s.io/kustomize/api/builtins" //nolint:staticcheck // Remove after package update
 	"sigs.k8s.io/kustomize/api/filters/namespace"
 	"sigs.k8s.io/kustomize/api/types"
 	"sigs.k8s.io/kustomize/kyaml/resid"


### PR DESCRIPTION
## Description
- also update the method parameters
- and some cleanup functions


currently the build is based on changes from https://github.com/opendatahub-io/odh-dashboard/pull/2906
which just got merged
ref: https://issues.redhat.com/browse/RHOAIENG-8510


Please make sure that your PR meets the following requirements:

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md)
- [ ] Pull Request contains description of the issue
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains link to any dependent or related Pull Request





## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- local  ODH build: quay.io/wenzhou/opendatahub-operator-catalog:v2.12.8510-1 
- local RHOAI build:  ~~quay.io/wenzhou/rhods-operator-catalog:v2.12.851-2~~  quay.io/wenzhou/rhods-operator-catalog:v2.12.8510-2


## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] Have a meaningful commit messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
