### PR TITLE
chore: Improve automation logic for reading release branches

### DIFF
--- a/.github/scripts/get-component-release-notes.js
+++ b/.github/scripts/get-component-release-notes.js
@@ -20,10 +20,14 @@ module.exports = ({ github, core }) => {
             issueCommentBody = issue.body_text
             if (issueCommentBody.includes("#Release#")) {
                 let components = issueCommentBody.split("\n")
-                components = components.splice(2, components.length - 1)
+                const releaseIdx = components.indexOf("#Release#")
+                components = components.splice(releaseIdx + 1, components.length - 1)
+                const regex = /[A-Za-z-_0-9]+\|(https:\/\/github\.com\/.*tree.*){1}\|(https:\/\/github\.com\/.*releases.*){1}/gm;
                 components.forEach(component => {
-                    [componentName, branchUrl, tagUrl] = component.split("|")
-                        outputStr += `- **${componentName.charAt(0).toUpperCase() + componentName.slice(1)}**: ${tagUrl}\n`
+                    if (regex.test(component)) {
+                        [componentName, branchUrl, tagUrl] = component.split("|")
+                        outputStr += `- **${componentName.trim().charAt(0).toUpperCase() + componentName.trim().slice(1)}**: ${tagUrl.trim()}\n`
+                    }
                 })
             }
         })

--- a/.github/scripts/get-release-branches.js
+++ b/.github/scripts/get-release-branches.js
@@ -20,17 +20,23 @@ module.exports = ({ github, core }) => {
             issueCommentBody = issue.body_text
             if (issueCommentBody.includes("#Release#")) {
                 let components = issueCommentBody.split("\n")
-                components = components.splice(2, components.length - 1)
+                const releaseIdx = components.indexOf("#Release#")
+                components = components.splice(releaseIdx + 1, components.length - 1)
+                const regex = /[A-Za-z-_0-9]+\|(https:\/\/github\.com\/.*tree.*){1}\|(https:\/\/github\.com\/.*releases.*){1}/gm;
                 components.forEach(component => {
-                    [componentName, branchUrl] = component.split("|")
-                    const splitArr = branchUrl.split("/")
-                    const idx = splitArr.indexOf("tree")
-                    const branchName = splitArr.slice(idx + 1).join("/")
-                    if(componentName === "notebook-controller"){
-                        core.exportVariable("component_spec_odh-notebook-controller".toLowerCase(), branchName);
-                        core.exportVariable("component_spec_kf-notebook-controller".toLowerCase(), branchName);
-                    }else{
-                        core.exportVariable("component_spec_"+componentName.toLowerCase(), branchName);
+                    if (regex.test(component)) {
+                        [componentName, branchUrl] = component.split("|")
+                        componentName = componentName.trim()
+                        branchUrl = branchUrl.trim()
+                        const splitArr = branchUrl.split("/")
+                        const idx = splitArr.indexOf("tree")
+                        const branchName = splitArr.slice(idx + 1).join("/")
+                        if (componentName === "notebook-controller") {
+                            core.exportVariable("component_spec_odh-notebook-controller".toLowerCase(), branchName);
+                            core.exportVariable("component_spec_kf-notebook-controller".toLowerCase(), branchName);
+                        } else {
+                            core.exportVariable("component_spec_" + componentName.toLowerCase(), branchName);
+                        }
                     }
                 })
             }


### PR DESCRIPTION
Improve the release branch reading logic in release automation.

Many thanks for submitting your Pull Request ❤️!

## Description
The previous version had a hardcoded index of "2" to get the list of components and their release branches. Now the logic is improved to read the component data which is added(as bullet points) exactly after the `#Release#`.

## JIRA issue:
https://issues.redhat.com/browse/RHOAIENG-8829

## How Has This Been Tested?
Mock tracker: https://github.com/AjayJagan/notes-operator/issues/2
Changed logic and it was able to create the draft pr for e2e: https://github.com/AjayJagan/opendatahub-operator/pull/287

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] Have a meaningful commit messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
