### PR TITLE
fix: makes default knative secret local for serverless

### DIFF
--- a/pkg/feature/serverless/loaders.go
+++ b/pkg/feature/serverless/loaders.go
@@ -8,10 +8,12 @@ import (
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/feature"
 )
 
+const DefaultCertificateSecretName = "knative-serving-cert"
+
 func ServingDefaultValues(f *feature.Feature) error {
 	certificateSecretName := strings.TrimSpace(f.Spec.Serving.IngressGateway.Certificate.SecretName)
 	if len(certificateSecretName) == 0 {
-		certificateSecretName = cluster.DefaultCertificateSecretName
+		certificateSecretName = DefaultCertificateSecretName
 	}
 
 	f.Spec.KnativeCertificateSecret = certificateSecretName

--- a/pkg/feature/serverless/resources.go
+++ b/pkg/feature/serverless/resources.go
@@ -19,6 +19,6 @@ func ServingCertificateResource(f *feature.Feature) error {
 	case infrav1.Provided:
 		return nil
 	default:
-		return cluster.GetDefaultIngressCertificate(context.TODO(), f.Client, f.Spec.KnativeCertificateSecret, f.Spec.ControlPlane.Namespace)
+		return cluster.PropagateDefaultIngressCertificate(context.TODO(), f.Client, f.Spec.KnativeCertificateSecret, f.Spec.ControlPlane.Namespace)
 	}
 }

--- a/tests/e2e/dsc_creation_test.go
+++ b/tests/e2e/dsc_creation_test.go
@@ -26,6 +26,7 @@ import (
 	infrav1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/infrastructure/v1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/components"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/feature/serverless"
 )
 
 const (
@@ -400,7 +401,7 @@ func (tc *testContext) testDefaultCertsAvailable() error {
 	// Verify secret from Control Plane namespace matches the default cert secret
 	defaultSecretName := tc.testDsc.Spec.Components.Kserve.Serving.IngressGateway.Certificate.SecretName
 	if defaultSecretName == "" {
-		defaultSecretName = cluster.DefaultCertificateSecretName
+		defaultSecretName = serverless.DefaultCertificateSecretName
 	}
 	ctrlPlaneSecret, err := cluster.GetSecret(tc.ctx, tc.customClient, tc.testDSCI.Spec.ServiceMesh.ControlPlane.Namespace,
 		defaultSecretName)

--- a/tests/integration/features/serverless_feature_test.go
+++ b/tests/integration/features/serverless_feature_test.go
@@ -15,7 +15,6 @@ import (
 	dsciv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/dscinitialization/v1"
 	infrav1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/infrastructure/v1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/components/kserve"
-	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/feature"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/feature/serverless"
 	"github.com/opendatahub-io/opendatahub-operator/v2/tests/envtestutil"
@@ -184,7 +183,7 @@ var _ = Describe("Serverless feature", func() {
 			It("should set default value when value is empty in the DSCI", func() {
 				// Default value is blank -> testFeature.Spec.Serving.IngressGateway.Certificate.SecretName = ""
 				Expect(serverless.ServingDefaultValues(testFeature)).To(Succeed())
-				Expect(testFeature.Spec.KnativeCertificateSecret).To(Equal(cluster.DefaultCertificateSecretName))
+				Expect(testFeature.Spec.KnativeCertificateSecret).To(Equal(serverless.DefaultCertificateSecretName))
 			})
 
 			It("should use user value when set in the DSCI", func() {
@@ -262,7 +261,7 @@ var _ = Describe("Serverless feature", func() {
 
 			// then
 			Eventually(func() error {
-				secret, err := envTestClientset.CoreV1().Secrets(namespace.Name).Get(context.TODO(), cluster.DefaultCertificateSecretName, metav1.GetOptions{})
+				secret, err := envTestClientset.CoreV1().Secrets(namespace.Name).Get(context.TODO(), serverless.DefaultCertificateSecretName, metav1.GetOptions{})
 				if err != nil {
 					return err
 				}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

PR #1022 promoted knative default secret name as the default for the entire platform as part of the `cert.go` move. This can be confusing, therefore this change makes it local to kserve again.

## JIRA issue:

Follow-up to #1022

ref: https://issues.redhat.com/browse/RHOAIENG-4221

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip:
<!--- Attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] Have a meaningful commit messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
