### PR TITLE
fix(lint): disables deprecated linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -34,20 +34,27 @@ linters:
   enable-all: true
   disable:
     - containedctx # detects struct contained context.Context field
+    - deadcode # deprecated
     - depguard # [replaced by gomodguard] checks if package imports are in a list of acceptable packages
     - exhaustivestruct # Prevents empty struct. We use a lot of these so I think it is safe to disable.
     - exhaustruct # Prevents empty struct. We use a lot of these so I think it is safe to disable.c
     - forbidigo
     - gochecknoglobals # Prevents use of global vars.
     - gofumpt
+    - golint # deprecated
     - gomnd # Doesnot allow hardcoded numbers
     - gomoddirectives # Doesnot allow replace in go mod file
+    - ifshort # deprecated
     - interfacer
+    - maligned # deprecated
     - nestif
     - nilnil
     - nosnakecase # snakecase is used in a lot of places. Need to check if that is required.
     - paralleltest # [too many false positives] detects missing usage of t.Parallel() method in your Go test
+    - scopelint # deprecated
+    - structcheck # deprecated
     - tagliatelle
+    - varcheck # deprecated
     - varnamelen # doesnot allow shorter names like c,k etc. But golang prefers short named vars.
     - wsl # [too strict and mostly code is not more readable] whitespace linter forces you to use empty lines
     - wrapcheck # check if this is required. Prevents direct return of err.

--- a/controllers/status/reporter.go
+++ b/controllers/status/reporter.go
@@ -1,4 +1,4 @@
-//nolint:structcheck,ireturn // Reason: false positive, complains about unused fields - see Update method. ireturn to statisfy client.Object interface
+//nolint:ireturn //reason: return T which is expected to be satisfying client.Object interface
 package status
 
 import (


### PR DESCRIPTION
## Description

Removes linters which are not maintained anymore and deprecated. Most has been replaced with `unused` linter which is enabled by default.

## JIRA issue:

Chore, N/A

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip:
<!--- Attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] Have a meaningful commit messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
