### PR TITLE
chore: removes unused client parameter

### DIFF
--- a/components/kserve/kserve.go
+++ b/components/kserve/kserve.go
@@ -114,7 +114,7 @@ func (k *Kserve) ReconcileComponent(ctx context.Context, cli client.Client,
 		}
 	} else {
 		// Configure dependencies
-		if err := k.configureServerless(cli, dscispec); err != nil {
+		if err := k.configureServerless(dscispec); err != nil {
 			return err
 		}
 		if k.DevFlags != nil {

--- a/components/kserve/kserve_config_handler.go
+++ b/components/kserve/kserve_config_handler.go
@@ -114,7 +114,7 @@ func (k *Kserve) setDefaultDeploymentMode(ctx context.Context, cli client.Client
 	return nil
 }
 
-func (k *Kserve) configureServerless(_ client.Client, instance *dsciv1.DSCInitializationSpec) error {
+func (k *Kserve) configureServerless(instance *dsciv1.DSCInitializationSpec) error {
 	switch k.Serving.ManagementState {
 	case operatorv1.Unmanaged: // Bring your own CR
 		fmt.Println("Serverless CR is not configured by the operator, we won't do anything")

--- a/components/kserve/servicemesh_setup.go
+++ b/components/kserve/servicemesh_setup.go
@@ -13,10 +13,10 @@ import (
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/feature/servicemesh"
 )
 
-func (k *Kserve) configureServiceMesh(c client.Client, dscispec *dsciv1.DSCInitializationSpec) error {
+func (k *Kserve) configureServiceMesh(cli client.Client, dscispec *dsciv1.DSCInitializationSpec) error {
 	if dscispec.ServiceMesh != nil {
 		if dscispec.ServiceMesh.ManagementState == operatorv1.Managed && k.GetManagementState() == operatorv1.Managed {
-			serviceMeshInitializer := feature.ComponentFeaturesHandler(k.GetComponentName(), dscispec, k.defineServiceMeshFeatures(c))
+			serviceMeshInitializer := feature.ComponentFeaturesHandler(k.GetComponentName(), dscispec, k.defineServiceMeshFeatures(cli))
 			return serviceMeshInitializer.Apply()
 		}
 		if dscispec.ServiceMesh.ManagementState == operatorv1.Unmanaged && k.GetManagementState() == operatorv1.Managed {
@@ -24,7 +24,7 @@ func (k *Kserve) configureServiceMesh(c client.Client, dscispec *dsciv1.DSCIniti
 		}
 	}
 
-	return k.removeServiceMeshConfigurations(c, dscispec)
+	return k.removeServiceMeshConfigurations(cli, dscispec)
 }
 
 func (k *Kserve) removeServiceMeshConfigurations(cli client.Client, dscispec *dsciv1.DSCInitializationSpec) error {


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description

We were passing instance of `client.Client` to the functions that don't need it. Most likely copy-paste mistake. 

This PR cleans it up.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] ~Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.~
- [ ] ~Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).~
- [x] The developer has manually tested the changes and verified that the changes work
