### PR TITLE
feat(lint): configures importas for consistent import aliases

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -28,6 +28,21 @@ linters-settings:
   nolintlint:
     allow-no-explanation: [ funlen, lll ]
     require-specific: true
+  importas:
+    alias:
+      - pkg: github.com/opendatahub-io/opendatahub-operator/v2/apis/dscinitialization/v1
+        alias: dsciv1
+      - pkg: github.com/opendatahub-io/opendatahub-operator/v2/apis/datasciencecluster/v1
+        alias: dscv1
+      - pkg: github.com/opendatahub-io/opendatahub-operator/v2/apis/infrastructure/v1
+        alias: infrav1
+      - pkg: k8s.io/apimachinery/pkg/api/errors
+        alias: k8serr
+      # Ensures that i.e. k8s.io/api/rbac/v1 is aliased as rbacv1
+      - pkg: k8s.io/api/(\w+)/(v[\w\d]+)
+        alias: $1$2
+      - pkg: github.com/openshift/api/(\w+)/(v[\w\d]+)
+        alias: $1$2
   revive:
     rules:
       - name: dot-imports

--- a/components/dashboard/dashboard.go
+++ b/components/dashboard/dashboard.go
@@ -12,8 +12,8 @@ import (
 	"github.com/go-logr/logr"
 	operatorv1 "github.com/openshift/api/operator/v1"
 	routev1 "github.com/openshift/api/route/v1"
-	v1 "k8s.io/api/core/v1"
-	apierrs "k8s.io/apimachinery/pkg/api/errors"
+	corev1 "k8s.io/api/core/v1"
+	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -293,13 +293,13 @@ func (d *Dashboard) cleanOauthClient(ctx context.Context, cli client.Client, dsc
 	if !currentComponentExist {
 		fmt.Println("Cleanup any left secret")
 		// Delete client secrets from previous installation
-		oauthClientSecret := &v1.Secret{}
+		oauthClientSecret := &corev1.Secret{}
 		err := cli.Get(ctx, client.ObjectKey{
 			Namespace: dscispec.ApplicationsNamespace,
 			Name:      name,
 		}, oauthClientSecret)
 		if err != nil {
-			if !apierrs.IsNotFound(err) {
+			if !k8serr.IsNotFound(err) {
 				return fmt.Errorf("error getting secret %s: %w", name, err)
 			}
 		} else {

--- a/components/datasciencepipelines/datasciencepipelines.go
+++ b/components/datasciencepipelines/datasciencepipelines.go
@@ -13,7 +13,7 @@ import (
 	conditionsv1 "github.com/openshift/custom-resource-status/conditions/v1"
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	apierrs "k8s.io/apimachinery/pkg/api/errors"
+	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -154,7 +154,7 @@ func UnmanagedArgoWorkFlowExists(ctx context.Context,
 	cli client.Client) error {
 	workflowCRD := &apiextensionsv1.CustomResourceDefinition{}
 	if err := cli.Get(ctx, client.ObjectKey{Name: ArgoWorkflowCRD}, workflowCRD); err != nil {
-		if apierrs.IsNotFound(err) {
+		if k8serr.IsNotFound(err) {
 			return nil
 		}
 		return fmt.Errorf("failed to get existing Workflow CRD : %w", err)

--- a/components/workbenches/workbenches.go
+++ b/components/workbenches/workbenches.go
@@ -13,7 +13,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	dsci "github.com/opendatahub-io/opendatahub-operator/v2/apis/dscinitialization/v1"
+	dsciv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/dscinitialization/v1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/components"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/deploy"
@@ -97,7 +97,7 @@ func (w *Workbenches) GetComponentName() string {
 }
 
 func (w *Workbenches) ReconcileComponent(ctx context.Context, cli client.Client, logger logr.Logger,
-	owner metav1.Object, dscispec *dsci.DSCInitializationSpec, platform cluster.Platform, _ bool) error {
+	owner metav1.Object, dscispec *dsciv1.DSCInitializationSpec, platform cluster.Platform, _ bool) error {
 	l := w.ConfigComponentLogger(logger, ComponentName, dscispec)
 	var imageParamMap = map[string]string{
 		"odh-notebook-controller-image":    "RELATED_IMAGE_ODH_NOTEBOOK_CONTROLLER_IMAGE",

--- a/controllers/certconfigmapgenerator/certconfigmapgenerator_controller.go
+++ b/controllers/certconfigmapgenerator/certconfigmapgenerator_controller.go
@@ -9,7 +9,7 @@ import (
 	operatorv1 "github.com/openshift/api/operator/v1"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -21,7 +21,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
-	dsci "github.com/opendatahub-io/opendatahub-operator/v2/apis/dscinitialization/v1"
+	dsciv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/dscinitialization/v1"
 	annotation "github.com/opendatahub-io/opendatahub-operator/v2/pkg/metadata/annotations"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/trustedcabundle"
 )
@@ -55,13 +55,13 @@ func (r *CertConfigmapGeneratorReconciler) Reconcile(ctx context.Context, req ct
 	}
 
 	// Get DSCI instance
-	dsciInstances := &dsci.DSCInitializationList{}
+	dsciInstances := &dsciv1.DSCInitializationList{}
 	if err := r.Client.List(ctx, dsciInstances); err != nil {
 		r.Log.Error(err, "Failed to retrieve DSCInitialization resource for CertConfigMapGenerator ", "Request.Name", req.Name)
 		return ctrl.Result{}, err
 	}
 
-	var dsciInstance *dsci.DSCInitialization
+	var dsciInstance *dsciv1.DSCInitialization
 	switch len(dsciInstances.Items) {
 	case 0:
 		return ctrl.Result{}, nil
@@ -78,7 +78,7 @@ func (r *CertConfigmapGeneratorReconciler) Reconcile(ctx context.Context, req ct
 		r.Log.Info("Namespace has opted-out of CA bundle injection using annotation", "namespace", userNamespace.Name,
 			"annotation", annotation.InjectionOfCABundleAnnotatoion)
 		if err := trustedcabundle.DeleteOdhTrustedCABundleConfigMap(ctx, r.Client, req.Namespace); err != nil {
-			if !apierrors.IsNotFound(err) {
+			if !k8serr.IsNotFound(err) {
 				r.Log.Error(err, "error deleting existing configmap from namespace", "name", trustedcabundle.CAConfigMapName, "namespace", userNamespace.Name)
 				return reconcile.Result{}, err
 			}
@@ -148,6 +148,6 @@ var ConfigMapChangedPredicate = predicate.Funcs{
 	},
 }
 
-func skipApplyTrustCAConfig(dsciConfigTrustCA *dsci.TrustedCABundleSpec) bool {
+func skipApplyTrustCAConfig(dsciConfigTrustCA *dsciv1.TrustedCABundleSpec) bool {
 	return dsciConfigTrustCA == nil || dsciConfigTrustCA.ManagementState != operatorv1.Managed
 }

--- a/controllers/datasciencecluster/datasciencecluster_controller.go
+++ b/controllers/datasciencecluster/datasciencecluster_controller.go
@@ -26,16 +26,16 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/hashicorp/go-multierror"
-	ocbuildv1 "github.com/openshift/api/build/v1"
-	ocimgv1 "github.com/openshift/api/image/v1"
-	v1 "github.com/openshift/api/operator/v1"
-	admv1 "k8s.io/api/admissionregistration/v1"
+	buildv1 "github.com/openshift/api/build/v1"
+	imagev1 "github.com/openshift/api/image/v1"
+	operatorv1 "github.com/openshift/api/operator/v1"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	netv1 "k8s.io/api/networking/v1"
-	authv1 "k8s.io/api/rbac/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	apierrs "k8s.io/apimachinery/pkg/api/errors"
+	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
@@ -50,8 +50,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
-	dsc "github.com/opendatahub-io/opendatahub-operator/v2/apis/datasciencecluster/v1"
-	dsci "github.com/opendatahub-io/opendatahub-operator/v2/apis/dscinitialization/v1"
+	dscv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/datasciencecluster/v1"
+	dsciv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/dscinitialization/v1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/components"
 	"github.com/opendatahub-io/opendatahub-operator/v2/components/datasciencepipelines"
 	"github.com/opendatahub-io/opendatahub-operator/v2/controllers/status"
@@ -72,7 +72,7 @@ type DataScienceClusterReconciler struct {
 
 // DataScienceClusterConfig passing Spec of DSCI for reconcile DataScienceCluster.
 type DataScienceClusterConfig struct {
-	DSCISpec *dsci.DSCInitializationSpec
+	DSCISpec *dsciv1.DSCInitializationSpec
 }
 
 const (
@@ -91,7 +91,7 @@ func (r *DataScienceClusterReconciler) Reconcile(ctx context.Context, req ctrl.R
 		return ctrl.Result{}, err
 	}
 
-	instances := &dsc.DataScienceClusterList{}
+	instances := &dscv1.DataScienceClusterList{}
 
 	if err := r.Client.List(ctx, instances); err != nil {
 		return ctrl.Result{}, err
@@ -132,7 +132,7 @@ func (r *DataScienceClusterReconciler) Reconcile(ctx context.Context, req ctrl.R
 			}
 		}
 		if err := r.Client.Delete(ctx, instance, []client.DeleteOption{}...); err != nil {
-			if !apierrs.IsNotFound(err) {
+			if !k8serr.IsNotFound(err) {
 				return reconcile.Result{}, err
 			}
 		}
@@ -145,7 +145,7 @@ func (r *DataScienceClusterReconciler) Reconcile(ctx context.Context, req ctrl.R
 	}
 
 	// Verify a valid DSCInitialization instance is created
-	dsciInstances := &dsci.DSCInitializationList{}
+	dsciInstances := &dsciv1.DSCInitializationList{}
 	err = r.Client.List(ctx, dsciInstances)
 	if err != nil {
 		r.Log.Error(err, "Failed to retrieve DSCInitialization resource.", "DSCInitialization Request.Name", req.Name)
@@ -160,7 +160,7 @@ func (r *DataScienceClusterReconciler) Reconcile(ctx context.Context, req ctrl.R
 		reason := status.ReconcileFailed
 		message := "Failed to get a valid DSCInitialization instance, please create a DSCI instance"
 		r.Log.Info(message)
-		instance, err = status.UpdateWithRetry(ctx, r.Client, instance, func(saved *dsc.DataScienceCluster) {
+		instance, err = status.UpdateWithRetry(ctx, r.Client, instance, func(saved *dscv1.DataScienceCluster) {
 			status.SetProgressingCondition(&saved.Status.Conditions, reason, message)
 			// Patch Degraded with True status
 			status.SetCondition(&saved.Status.Conditions, "Degraded", reason, message, corev1.ConditionTrue)
@@ -211,7 +211,7 @@ func (r *DataScienceClusterReconciler) Reconcile(ctx context.Context, req ctrl.R
 		if instance.Status.InstalledComponents[datasciencepipelines.ComponentName] {
 			if err := datasciencepipelines.UnmanagedArgoWorkFlowExists(ctx, r.Client); err != nil {
 				message := fmt.Sprintf("Failed upgrade: %v ", err.Error())
-				_, err = status.UpdateWithRetry(ctx, r.Client, instance, func(saved *dsc.DataScienceCluster) {
+				_, err = status.UpdateWithRetry(ctx, r.Client, instance, func(saved *dscv1.DataScienceCluster) {
 					datasciencepipelines.SetExistingArgoCondition(&saved.Status.Conditions, status.ArgoWorkflowExist, message)
 					status.SetErrorCondition(&saved.Status.Conditions, status.ArgoWorkflowExist, message)
 					saved.Status.Phase = status.PhaseError
@@ -225,7 +225,7 @@ func (r *DataScienceClusterReconciler) Reconcile(ctx context.Context, req ctrl.R
 	if instance.Status.Conditions == nil {
 		reason := status.ReconcileInit
 		message := "Initializing DataScienceCluster resource"
-		instance, err = status.UpdateWithRetry(ctx, r.Client, instance, func(saved *dsc.DataScienceCluster) {
+		instance, err = status.UpdateWithRetry(ctx, r.Client, instance, func(saved *dscv1.DataScienceCluster) {
 			status.SetProgressingCondition(&saved.Status.Conditions, reason, message)
 			saved.Status.Phase = status.PhaseProgressing
 		})
@@ -248,7 +248,7 @@ func (r *DataScienceClusterReconciler) Reconcile(ctx context.Context, req ctrl.R
 	// Process errors for components
 	if componentErrors != nil {
 		r.Log.Info("DataScienceCluster Deployment Incomplete.")
-		instance, err = status.UpdateWithRetry(ctx, r.Client, instance, func(saved *dsc.DataScienceCluster) {
+		instance, err = status.UpdateWithRetry(ctx, r.Client, instance, func(saved *dscv1.DataScienceCluster) {
 			status.SetCompleteCondition(&saved.Status.Conditions, status.ReconcileCompletedWithComponentErrors,
 				fmt.Sprintf("DataScienceCluster resource reconciled with component errors: %v", componentErrors))
 			saved.Status.Phase = status.PhaseReady
@@ -265,7 +265,7 @@ func (r *DataScienceClusterReconciler) Reconcile(ctx context.Context, req ctrl.R
 	}
 
 	// finalize reconciliation
-	instance, err = status.UpdateWithRetry(ctx, r.Client, instance, func(saved *dsc.DataScienceCluster) {
+	instance, err = status.UpdateWithRetry(ctx, r.Client, instance, func(saved *dscv1.DataScienceCluster) {
 		status.SetCompleteCondition(&saved.Status.Conditions, status.ReconcileCompleted, "DataScienceCluster resource reconciled successfully")
 		saved.Status.Phase = status.PhaseReady
 		saved.Status.Release = currentOperatorReleaseVersion
@@ -284,12 +284,12 @@ func (r *DataScienceClusterReconciler) Reconcile(ctx context.Context, req ctrl.R
 	return ctrl.Result{}, nil
 }
 
-func (r *DataScienceClusterReconciler) reconcileSubComponent(ctx context.Context, instance *dsc.DataScienceCluster,
+func (r *DataScienceClusterReconciler) reconcileSubComponent(ctx context.Context, instance *dscv1.DataScienceCluster,
 	component components.ComponentInterface,
-) (*dsc.DataScienceCluster, error) {
+) (*dscv1.DataScienceCluster, error) {
 	componentName := component.GetComponentName()
 
-	enabled := component.GetManagementState() == v1.Managed
+	enabled := component.GetManagementState() == operatorv1.Managed
 	installedComponentValue, isExistStatus := instance.Status.InstalledComponents[componentName]
 
 	// First set conditions to reflect a component is about to be reconciled
@@ -299,7 +299,7 @@ func (r *DataScienceClusterReconciler) reconcileSubComponent(ctx context.Context
 		if enabled {
 			message = "Component is enabled"
 		}
-		instance, err := status.UpdateWithRetry(ctx, r.Client, instance, func(saved *dsc.DataScienceCluster) {
+		instance, err := status.UpdateWithRetry(ctx, r.Client, instance, func(saved *dscv1.DataScienceCluster) {
 			status.SetComponentCondition(&saved.Status.Conditions, componentName, status.ReconcileInit, message, corev1.ConditionUnknown)
 		})
 		if err != nil {
@@ -319,7 +319,7 @@ func (r *DataScienceClusterReconciler) reconcileSubComponent(ctx context.Context
 	if err != nil {
 		// reconciliation failed: log errors, raise event and update status accordingly
 		instance = r.reportError(err, instance, "failed to reconcile "+componentName+" on DataScienceCluster")
-		instance, _ = status.UpdateWithRetry(ctx, r.Client, instance, func(saved *dsc.DataScienceCluster) {
+		instance, _ = status.UpdateWithRetry(ctx, r.Client, instance, func(saved *dscv1.DataScienceCluster) {
 			if enabled {
 				if strings.Contains(err.Error(), datasciencepipelines.ArgoWorkflowCRD+" CRD already exists") {
 					datasciencepipelines.SetExistingArgoCondition(&saved.Status.Conditions, status.ArgoWorkflowExist, fmt.Sprintf("Component update failed: %v", err))
@@ -333,7 +333,7 @@ func (r *DataScienceClusterReconciler) reconcileSubComponent(ctx context.Context
 		return instance, err
 	}
 	// reconciliation succeeded: update status accordingly
-	instance, err = status.UpdateWithRetry(ctx, r.Client, instance, func(saved *dsc.DataScienceCluster) {
+	instance, err = status.UpdateWithRetry(ctx, r.Client, instance, func(saved *dscv1.DataScienceCluster) {
 		if saved.Status.InstalledComponents == nil {
 			saved.Status.InstalledComponents = make(map[string]bool)
 		}
@@ -353,7 +353,7 @@ func (r *DataScienceClusterReconciler) reconcileSubComponent(ctx context.Context
 	return instance, nil
 }
 
-func (r *DataScienceClusterReconciler) reportError(err error, instance *dsc.DataScienceCluster, message string) *dsc.DataScienceCluster {
+func (r *DataScienceClusterReconciler) reportError(err error, instance *dscv1.DataScienceCluster, message string) *dscv1.DataScienceCluster {
 	r.Log.Error(err, message, "instance.Name", instance.Name)
 	r.Recorder.Eventf(instance, corev1.EventTypeWarning, "DataScienceClusterReconcileError",
 		"%s for instance %s", message, instance.Name)
@@ -428,27 +428,27 @@ var modelMeshGeneralPredicates = predicate.Funcs{
 // SetupWithManager sets up the controller with the Manager.
 func (r *DataScienceClusterReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&dsc.DataScienceCluster{}).
+		For(&dscv1.DataScienceCluster{}).
 		Owns(&corev1.Namespace{}).
 		Owns(&corev1.Secret{}).
 		Owns(&corev1.ConfigMap{}, builder.WithPredicates(configMapPredicates)).
-		Owns(&netv1.NetworkPolicy{}).
-		Owns(&authv1.Role{}, builder.WithPredicates(predicate.Or(predicate.GenerationChangedPredicate{}, modelMeshRolePredicates))).
-		Owns(&authv1.RoleBinding{}, builder.WithPredicates(predicate.Or(predicate.GenerationChangedPredicate{}, modelMeshRBPredicates))).
-		Owns(&authv1.ClusterRole{}, builder.WithPredicates(predicate.Or(predicate.GenerationChangedPredicate{}, modelMeshRolePredicates))).
-		Owns(&authv1.ClusterRoleBinding{}, builder.WithPredicates(predicate.Or(predicate.GenerationChangedPredicate{}, modelMeshRBPredicates))).
+		Owns(&networkingv1.NetworkPolicy{}).
+		Owns(&rbacv1.Role{}, builder.WithPredicates(predicate.Or(predicate.GenerationChangedPredicate{}, modelMeshRolePredicates))).
+		Owns(&rbacv1.RoleBinding{}, builder.WithPredicates(predicate.Or(predicate.GenerationChangedPredicate{}, modelMeshRBPredicates))).
+		Owns(&rbacv1.ClusterRole{}, builder.WithPredicates(predicate.Or(predicate.GenerationChangedPredicate{}, modelMeshRolePredicates))).
+		Owns(&rbacv1.ClusterRoleBinding{}, builder.WithPredicates(predicate.Or(predicate.GenerationChangedPredicate{}, modelMeshRBPredicates))).
 		Owns(&appsv1.Deployment{}).
 		Owns(&corev1.PersistentVolumeClaim{}).
 		Owns(&corev1.Service{}, builder.WithPredicates(predicate.Or(predicate.GenerationChangedPredicate{}, modelMeshGeneralPredicates))).
 		Owns(&appsv1.StatefulSet{}).
-		Owns(&ocimgv1.ImageStream{}).
-		Owns(&ocbuildv1.BuildConfig{}).
+		Owns(&imagev1.ImageStream{}).
+		Owns(&buildv1.BuildConfig{}).
 		Owns(&apiregistrationv1.APIService{}).
-		Owns(&netv1.Ingress{}).
-		Owns(&admv1.MutatingWebhookConfiguration{}).
-		Owns(&admv1.ValidatingWebhookConfiguration{}, builder.WithPredicates(modelMeshwebhookPredicates)).
+		Owns(&networkingv1.Ingress{}).
+		Owns(&admissionregistrationv1.MutatingWebhookConfiguration{}).
+		Owns(&admissionregistrationv1.ValidatingWebhookConfiguration{}, builder.WithPredicates(modelMeshwebhookPredicates)).
 		Owns(&corev1.ServiceAccount{}, builder.WithPredicates(saPredicates)).
-		Watches(&source.Kind{Type: &dsci.DSCInitialization{}}, handler.EnqueueRequestsFromMapFunc(r.watchDataScienceClusterForDSCI)).
+		Watches(&source.Kind{Type: &dsciv1.DSCInitialization{}}, handler.EnqueueRequestsFromMapFunc(r.watchDataScienceClusterForDSCI)).
 		Watches(&source.Kind{Type: &corev1.ConfigMap{}}, handler.EnqueueRequestsFromMapFunc(r.watchDataScienceClusterResources), builder.WithPredicates(configMapPredicates)).
 		Watches(&source.Kind{Type: &apiextensionsv1.CustomResourceDefinition{}}, handler.EnqueueRequestsFromMapFunc(r.watchDataScienceClusterResources),
 			builder.WithPredicates(argoWorkflowCRDPredicates)).
@@ -500,7 +500,7 @@ func (r *DataScienceClusterReconciler) watchDataScienceClusterResources(a client
 }
 
 func (r *DataScienceClusterReconciler) getRequestName() (string, error) {
-	instanceList := &dsc.DataScienceClusterList{}
+	instanceList := &dscv1.DataScienceClusterList{}
 	err := r.Client.List(context.TODO(), instanceList)
 	if err != nil {
 		return "", err

--- a/controllers/datasciencecluster/suite_test.go
+++ b/controllers/datasciencecluster/suite_test.go
@@ -27,7 +27,7 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
-	datascienceclusterv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/datasciencecluster/v1"
+	dscv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/datasciencecluster/v1"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -63,7 +63,7 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 	Expect(cfg).NotTo(BeNil())
 
-	err = datascienceclusterv1.AddToScheme(scheme.Scheme)
+	err = dscv1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
 	//+kubebuilder:scaffold:scheme

--- a/controllers/dscinitialization/dscinitialization_controller.go
+++ b/controllers/dscinitialization/dscinitialization_controller.go
@@ -27,8 +27,8 @@ import (
 	routev1 "github.com/openshift/api/route/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	netv1 "k8s.io/api/networking/v1"
-	authv1 "k8s.io/api/rbac/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
@@ -294,11 +294,11 @@ func (r *DSCInitializationReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&corev1.Namespace{}, builder.WithPredicates(predicate.Or(predicate.GenerationChangedPredicate{}, predicate.LabelChangedPredicate{}))).
 		Owns(&corev1.Secret{}, builder.WithPredicates(predicate.Or(predicate.GenerationChangedPredicate{}, predicate.LabelChangedPredicate{}))).
 		Owns(&corev1.ConfigMap{}, builder.WithPredicates(predicate.Or(predicate.GenerationChangedPredicate{}, predicate.LabelChangedPredicate{}))).
-		Owns(&netv1.NetworkPolicy{}, builder.WithPredicates(predicate.Or(predicate.GenerationChangedPredicate{}, predicate.LabelChangedPredicate{}))).
-		Owns(&authv1.Role{}, builder.WithPredicates(predicate.Or(predicate.GenerationChangedPredicate{}, predicate.LabelChangedPredicate{}))).
-		Owns(&authv1.RoleBinding{}, builder.WithPredicates(predicate.Or(predicate.GenerationChangedPredicate{}, predicate.LabelChangedPredicate{}))).
-		Owns(&authv1.ClusterRole{}, builder.WithPredicates(predicate.Or(predicate.GenerationChangedPredicate{}, predicate.LabelChangedPredicate{}))).
-		Owns(&authv1.ClusterRoleBinding{}, builder.WithPredicates(predicate.Or(predicate.GenerationChangedPredicate{}, predicate.LabelChangedPredicate{}))).
+		Owns(&networkingv1.NetworkPolicy{}, builder.WithPredicates(predicate.Or(predicate.GenerationChangedPredicate{}, predicate.LabelChangedPredicate{}))).
+		Owns(&rbacv1.Role{}, builder.WithPredicates(predicate.Or(predicate.GenerationChangedPredicate{}, predicate.LabelChangedPredicate{}))).
+		Owns(&rbacv1.RoleBinding{}, builder.WithPredicates(predicate.Or(predicate.GenerationChangedPredicate{}, predicate.LabelChangedPredicate{}))).
+		Owns(&rbacv1.ClusterRole{}, builder.WithPredicates(predicate.Or(predicate.GenerationChangedPredicate{}, predicate.LabelChangedPredicate{}))).
+		Owns(&rbacv1.ClusterRoleBinding{}, builder.WithPredicates(predicate.Or(predicate.GenerationChangedPredicate{}, predicate.LabelChangedPredicate{}))).
 		Owns(&appsv1.Deployment{}, builder.WithPredicates(predicate.Or(predicate.GenerationChangedPredicate{}, predicate.LabelChangedPredicate{}))).
 		Owns(&corev1.ServiceAccount{}, builder.WithPredicates(predicate.Or(predicate.GenerationChangedPredicate{}, predicate.LabelChangedPredicate{}))).
 		Owns(&corev1.Service{}, builder.WithPredicates(predicate.Or(predicate.GenerationChangedPredicate{}, predicate.LabelChangedPredicate{}))).

--- a/controllers/dscinitialization/dscinitialization_test.go
+++ b/controllers/dscinitialization/dscinitialization_test.go
@@ -5,13 +5,13 @@ import (
 
 	operatorv1 "github.com/openshift/api/operator/v1"
 	corev1 "k8s.io/api/core/v1"
-	netv1 "k8s.io/api/networking/v1"
-	authv1 "k8s.io/api/rbac/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	dsci "github.com/opendatahub-io/opendatahub-operator/v2/apis/dscinitialization/v1"
+	dsciv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/dscinitialization/v1"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -34,7 +34,7 @@ var _ = Describe("DataScienceCluster initialization", func() {
 			// when
 			desiredDsci := createDSCI(operatorv1.Managed, operatorv1.Managed, monitoringNamespace)
 			Expect(k8sClient.Create(context.Background(), desiredDsci)).Should(Succeed())
-			foundDsci := &dsci.DSCInitialization{}
+			foundDsci := &dsciv1.DSCInitialization{}
 			Eventually(dscInitializationIsReady(applicationName, workingNamespace, foundDsci)).
 				WithTimeout(timeout).
 				WithPolling(interval).
@@ -56,31 +56,31 @@ var _ = Describe("DataScienceCluster initialization", func() {
 		// Currently commented out in the DSCI reconcile - setting test to Pending
 		It("Should create default network policy", func() {
 			// then
-			foundNetworkPolicy := &netv1.NetworkPolicy{}
+			foundNetworkPolicy := &networkingv1.NetworkPolicy{}
 			Eventually(objectExists(applicationNamespace, applicationNamespace, foundNetworkPolicy)).
 				WithTimeout(timeout).
 				WithPolling(interval).
 				Should(BeTrue())
 			Expect(foundNetworkPolicy.Name).To(Equal(applicationNamespace))
 			Expect(foundNetworkPolicy.Namespace).To(Equal(applicationNamespace))
-			Expect(foundNetworkPolicy.Spec.PolicyTypes[0]).To(Equal(netv1.PolicyTypeIngress))
+			Expect(foundNetworkPolicy.Spec.PolicyTypes[0]).To(Equal(networkingv1.PolicyTypeIngress))
 		})
 
 		It("Should create default rolebinding", func() {
 			// then
-			foundRoleBinding := &authv1.RoleBinding{}
+			foundRoleBinding := &rbacv1.RoleBinding{}
 			Eventually(objectExists(applicationNamespace, applicationNamespace, foundRoleBinding)).
 				WithTimeout(timeout).
 				WithPolling(interval).
 				Should(BeTrue())
-			expectedSubjects := []authv1.Subject{
+			expectedSubjects := []rbacv1.Subject{
 				{
 					Kind:      "ServiceAccount",
 					Namespace: applicationNamespace,
 					Name:      "default",
 				},
 			}
-			expectedRoleRef := authv1.RoleRef{
+			expectedRoleRef := rbacv1.RoleRef{
 				APIGroup: "rbac.authorization.k8s.io",
 				Kind:     "ClusterRole",
 				Name:     "system:openshift:scc:anyuid",
@@ -114,7 +114,7 @@ var _ = Describe("DataScienceCluster initialization", func() {
 			// when
 			desiredDsci := createDSCI(operatorv1.Removed, operatorv1.Managed, monitoringNamespace2)
 			Expect(k8sClient.Create(context.Background(), desiredDsci)).Should(Succeed())
-			foundDsci := &dsci.DSCInitialization{}
+			foundDsci := &dsciv1.DSCInitialization{}
 			Eventually(dscInitializationIsReady(applicationName, workingNamespace, foundDsci)).
 				WithTimeout(timeout).
 				WithPolling(interval).
@@ -130,7 +130,7 @@ var _ = Describe("DataScienceCluster initialization", func() {
 			// when
 			desiredDsci := createDSCI(operatorv1.Managed, operatorv1.Managed, monitoringNamespace2)
 			Expect(k8sClient.Create(context.Background(), desiredDsci)).Should(Succeed())
-			foundDsci := &dsci.DSCInitialization{}
+			foundDsci := &dsciv1.DSCInitialization{}
 			Eventually(dscInitializationIsReady(applicationName, workingNamespace, foundDsci)).
 				WithTimeout(timeout).
 				WithPolling(interval).
@@ -152,7 +152,7 @@ var _ = Describe("DataScienceCluster initialization", func() {
 		It("Should not update rolebinding if it exists", func() {
 
 			// given
-			desiredRoleBinding := &authv1.RoleBinding{
+			desiredRoleBinding := &rbacv1.RoleBinding{
 				TypeMeta: metav1.TypeMeta{
 					Kind:       "RoleBinding",
 					APIVersion: "v1",
@@ -162,14 +162,14 @@ var _ = Describe("DataScienceCluster initialization", func() {
 					Namespace: applicationNamespace,
 				},
 
-				RoleRef: authv1.RoleRef{
+				RoleRef: rbacv1.RoleRef{
 					APIGroup: "rbac.authorization.k8s.io",
 					Kind:     "ClusterRole",
 					Name:     "system:openshift:scc:anyuid",
 				},
 			}
 			Expect(k8sClient.Create(context.Background(), desiredRoleBinding)).Should(Succeed())
-			createdRoleBinding := &authv1.RoleBinding{}
+			createdRoleBinding := &rbacv1.RoleBinding{}
 			Eventually(objectExists(applicationNamespace, applicationNamespace, createdRoleBinding)).
 				WithTimeout(timeout).
 				WithPolling(interval).
@@ -178,14 +178,14 @@ var _ = Describe("DataScienceCluster initialization", func() {
 			// when
 			desiredDsci := createDSCI(operatorv1.Managed, operatorv1.Managed, monitoringNamespace)
 			Expect(k8sClient.Create(context.Background(), desiredDsci)).Should(Succeed())
-			foundDsci := &dsci.DSCInitialization{}
+			foundDsci := &dsciv1.DSCInitialization{}
 			Eventually(dscInitializationIsReady(applicationName, workingNamespace, foundDsci)).
 				WithTimeout(timeout).
 				WithPolling(interval).
 				Should(BeTrue())
 
 			// then
-			foundRoleBinding := &authv1.RoleBinding{}
+			foundRoleBinding := &rbacv1.RoleBinding{}
 			Eventually(objectExists(applicationNamespace, applicationNamespace, foundRoleBinding)).
 				WithTimeout(timeout).
 				WithPolling(interval).
@@ -218,7 +218,7 @@ var _ = Describe("DataScienceCluster initialization", func() {
 			// when
 			desiredDsci := createDSCI(operatorv1.Managed, operatorv1.Managed, monitoringNamespace)
 			Expect(k8sClient.Create(context.Background(), desiredDsci)).Should(Succeed())
-			foundDsci := &dsci.DSCInitialization{}
+			foundDsci := &dsciv1.DSCInitialization{}
 			Eventually(dscInitializationIsReady(applicationName, workingNamespace, foundDsci)).
 				WithTimeout(timeout).
 				WithPolling(interval).
@@ -254,7 +254,7 @@ var _ = Describe("DataScienceCluster initialization", func() {
 			// when
 			desiredDsci := createDSCI(operatorv1.Managed, operatorv1.Managed, monitoringNamespace)
 			Expect(k8sClient.Create(context.Background(), desiredDsci)).Should(Succeed())
-			foundDsci := &dsci.DSCInitialization{}
+			foundDsci := &dsciv1.DSCInitialization{}
 			Eventually(dscInitializationIsReady(applicationName, workingNamespace, foundDsci)).
 				WithTimeout(timeout).
 				WithPolling(interval).
@@ -275,22 +275,22 @@ var _ = Describe("DataScienceCluster initialization", func() {
 func cleanupResources() {
 	defaultNamespace := client.InNamespace(workingNamespace)
 	appNamespace := client.InNamespace(applicationNamespace)
-	Expect(k8sClient.DeleteAllOf(context.TODO(), &dsci.DSCInitialization{}, defaultNamespace)).To(Succeed())
+	Expect(k8sClient.DeleteAllOf(context.TODO(), &dsciv1.DSCInitialization{}, defaultNamespace)).To(Succeed())
 
-	Expect(k8sClient.DeleteAllOf(context.TODO(), &netv1.NetworkPolicy{}, appNamespace)).To(Succeed())
+	Expect(k8sClient.DeleteAllOf(context.TODO(), &networkingv1.NetworkPolicy{}, appNamespace)).To(Succeed())
 	Expect(k8sClient.DeleteAllOf(context.TODO(), &corev1.ConfigMap{}, appNamespace)).To(Succeed())
-	Expect(k8sClient.DeleteAllOf(context.TODO(), &authv1.RoleBinding{}, appNamespace)).To(Succeed())
-	Expect(k8sClient.DeleteAllOf(context.TODO(), &authv1.ClusterRoleBinding{}, appNamespace)).To(Succeed())
+	Expect(k8sClient.DeleteAllOf(context.TODO(), &rbacv1.RoleBinding{}, appNamespace)).To(Succeed())
+	Expect(k8sClient.DeleteAllOf(context.TODO(), &rbacv1.ClusterRoleBinding{}, appNamespace)).To(Succeed())
 
-	Eventually(noInstanceExistsIn(workingNamespace, &dsci.DSCInitializationList{})).
+	Eventually(noInstanceExistsIn(workingNamespace, &dsciv1.DSCInitializationList{})).
 		WithTimeout(timeout).
 		WithPolling(interval).
 		Should(BeTrue())
-	Eventually(noInstanceExistsIn(applicationNamespace, &authv1.ClusterRoleBindingList{})).
+	Eventually(noInstanceExistsIn(applicationNamespace, &rbacv1.ClusterRoleBindingList{})).
 		WithTimeout(timeout).
 		WithPolling(interval).
 		Should(BeTrue())
-	Eventually(noInstanceExistsIn(applicationNamespace, &authv1.RoleBindingList{})).
+	Eventually(noInstanceExistsIn(applicationNamespace, &rbacv1.RoleBindingList{})).
 		WithTimeout(timeout).
 		WithPolling(interval).
 		Should(BeTrue())
@@ -326,8 +326,8 @@ func objectExists(ns string, name string, obj client.Object) func() bool { //nol
 	}
 }
 
-func createDSCI(enableMonitoring operatorv1.ManagementState, enableTrustedCABundle operatorv1.ManagementState, monitoringNS string) *dsci.DSCInitialization {
-	return &dsci.DSCInitialization{
+func createDSCI(enableMonitoring operatorv1.ManagementState, enableTrustedCABundle operatorv1.ManagementState, monitoringNS string) *dsciv1.DSCInitialization {
+	return &dsciv1.DSCInitialization{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "DSCInitialization",
 			APIVersion: "v1",
@@ -336,20 +336,20 @@ func createDSCI(enableMonitoring operatorv1.ManagementState, enableTrustedCABund
 			Name:      applicationName,
 			Namespace: workingNamespace,
 		},
-		Spec: dsci.DSCInitializationSpec{
+		Spec: dsciv1.DSCInitializationSpec{
 			ApplicationsNamespace: applicationNamespace,
-			Monitoring: dsci.Monitoring{
+			Monitoring: dsciv1.Monitoring{
 				Namespace:       monitoringNS,
 				ManagementState: enableMonitoring,
 			},
-			TrustedCABundle: &dsci.TrustedCABundleSpec{
+			TrustedCABundle: &dsciv1.TrustedCABundleSpec{
 				ManagementState: enableTrustedCABundle,
 			},
 		},
 	}
 }
 
-func dscInitializationIsReady(ns string, name string, dsciObj *dsci.DSCInitialization) func() bool { //nolint:unparam
+func dscInitializationIsReady(ns string, name string, dsciObj *dsciv1.DSCInitialization) func() bool { //nolint:unparam
 	return func() bool {
 		_ = k8sClient.Get(context.Background(), client.ObjectKey{Name: ns, Namespace: name}, dsciObj)
 

--- a/controllers/dscinitialization/suite_test.go
+++ b/controllers/dscinitialization/suite_test.go
@@ -29,9 +29,9 @@ import (
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	netv1 "k8s.io/api/networking/v1"
-	authv1 "k8s.io/api/rbac/v1"
-	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -43,8 +43,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	kfdefv1 "github.com/opendatahub-io/opendatahub-operator/apis/kfdef.apps.kubeflow.org/v1"
-	datascienceclusterv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/datasciencecluster/v1"
-	dscinitializationv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/dscinitialization/v1"
+	dscv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/datasciencecluster/v1"
+	dsciv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/dscinitialization/v1"
 	dsci "github.com/opendatahub-io/opendatahub-operator/v2/controllers/dscinitialization"
 	"github.com/opendatahub-io/opendatahub-operator/v2/tests/envtestutil"
 
@@ -101,12 +101,12 @@ var _ = BeforeSuite(func() {
 	Expect(cfg).NotTo(BeNil())
 
 	utilruntime.Must(clientgoscheme.AddToScheme(testScheme))
-	utilruntime.Must(dscinitializationv1.AddToScheme(testScheme))
-	utilruntime.Must(datascienceclusterv1.AddToScheme(testScheme))
-	utilruntime.Must(netv1.AddToScheme(testScheme))
-	utilruntime.Must(authv1.AddToScheme(testScheme))
+	utilruntime.Must(dsciv1.AddToScheme(testScheme))
+	utilruntime.Must(dscv1.AddToScheme(testScheme))
+	utilruntime.Must(networkingv1.AddToScheme(testScheme))
+	utilruntime.Must(rbacv1.AddToScheme(testScheme))
 	utilruntime.Must(corev1.AddToScheme(testScheme))
-	utilruntime.Must(apiextv1.AddToScheme(testScheme))
+	utilruntime.Must(apiextensionsv1.AddToScheme(testScheme))
 	utilruntime.Must(appsv1.AddToScheme(testScheme))
 	utilruntime.Must(ofapi.AddToScheme(testScheme))
 	utilruntime.Must(ofapiv2.AddToScheme(testScheme))

--- a/controllers/webhook/webhook_suite_test.go
+++ b/controllers/webhook/webhook_suite_test.go
@@ -36,8 +36,8 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
-	dsc "github.com/opendatahub-io/opendatahub-operator/v2/apis/datasciencecluster/v1"
-	dsci "github.com/opendatahub-io/opendatahub-operator/v2/apis/dscinitialization/v1"
+	dscv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/datasciencecluster/v1"
+	dsciv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/dscinitialization/v1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/components"
 	"github.com/opendatahub-io/opendatahub-operator/v2/components/codeflare"
 	"github.com/opendatahub-io/opendatahub-operator/v2/components/dashboard"
@@ -95,10 +95,10 @@ var _ = BeforeSuite(func() {
 
 	scheme := runtime.NewScheme()
 	// DSCI
-	err = dsci.AddToScheme(scheme)
+	err = dsciv1.AddToScheme(scheme)
 	Expect(err).NotTo(HaveOccurred())
 	// DSC
-	err = dsc.AddToScheme(scheme)
+	err = dscv1.AddToScheme(scheme)
 	Expect(err).NotTo(HaveOccurred())
 	// Webhook
 	err = admissionv1beta1.AddToScheme(scheme)
@@ -167,9 +167,9 @@ var _ = Describe("DSC/DSCI webhook", func() {
 	})
 })
 
-func newDSCI(appName string) *dsci.DSCInitialization {
+func newDSCI(appName string) *dsciv1.DSCInitialization {
 	monitoringNS := "monitoring-namespace"
-	return &dsci.DSCInitialization{
+	return &dsciv1.DSCInitialization{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "DSCInitialization",
 			APIVersion: "v1",
@@ -178,26 +178,26 @@ func newDSCI(appName string) *dsci.DSCInitialization {
 			Name:      appName,
 			Namespace: namespace,
 		},
-		Spec: dsci.DSCInitializationSpec{
+		Spec: dsciv1.DSCInitializationSpec{
 			ApplicationsNamespace: namespace,
-			Monitoring: dsci.Monitoring{
+			Monitoring: dsciv1.Monitoring{
 				Namespace:       monitoringNS,
 				ManagementState: operatorv1.Managed,
 			},
-			TrustedCABundle: &dsci.TrustedCABundleSpec{
+			TrustedCABundle: &dsciv1.TrustedCABundleSpec{
 				ManagementState: operatorv1.Managed,
 			},
 		},
 	}
 }
-func newDSC(name string, namespace string) *dsc.DataScienceCluster {
-	return &dsc.DataScienceCluster{
+func newDSC(name string, namespace string) *dscv1.DataScienceCluster {
+	return &dscv1.DataScienceCluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
 		},
-		Spec: dsc.DataScienceClusterSpec{
-			Components: dsc.Components{
+		Spec: dscv1.DataScienceClusterSpec{
+			Components: dscv1.Components{
 				Dashboard: dashboard.Dashboard{
 					Component: components.Component{
 						ManagementState: operatorv1.Removed,

--- a/main.go
+++ b/main.go
@@ -22,22 +22,22 @@ import (
 	"os"
 
 	addonv1alpha1 "github.com/openshift/addon-operator/apis/addons/v1alpha1"
-	ocappsv1 "github.com/openshift/api/apps/v1"
-	ocbuildv1 "github.com/openshift/api/build/v1"
-	ocimgv1 "github.com/openshift/api/image/v1"
-	ocv1 "github.com/openshift/api/oauth/v1"
+	ocappsv1 "github.com/openshift/api/apps/v1" //nolint:importas //reason: conflicts with appsv1 "k8s.io/api/apps/v1"
+	buildv1 "github.com/openshift/api/build/v1"
+	imagev1 "github.com/openshift/api/image/v1"
+	oauthv1 "github.com/openshift/api/oauth/v1"
 	operatorv1 "github.com/openshift/api/operator/v1"
 	routev1 "github.com/openshift/api/route/v1"
-	ocuserv1 "github.com/openshift/api/user/v1"
+	userv1 "github.com/openshift/api/user/v1"
 	ofapiv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	ofapiv2 "github.com/operator-framework/api/pkg/operators/v2"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
-	admv1 "k8s.io/api/admissionregistration/v1"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	netv1 "k8s.io/api/networking/v1"
-	authv1 "k8s.io/api/rbac/v1"
-	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -50,8 +50,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	kfdefv1 "github.com/opendatahub-io/opendatahub-operator/apis/kfdef.apps.kubeflow.org/v1"
-	dsc "github.com/opendatahub-io/opendatahub-operator/v2/apis/datasciencecluster/v1"
-	dsci "github.com/opendatahub-io/opendatahub-operator/v2/apis/dscinitialization/v1"
+	dscv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/datasciencecluster/v1"
+	dsciv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/dscinitialization/v1"
 	featurev1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/features/v1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/controllers/certconfigmapgenerator"
 	datascienceclustercontrollers "github.com/opendatahub-io/opendatahub-operator/v2/controllers/datasciencecluster"
@@ -73,26 +73,26 @@ var (
 func init() { //nolint:gochecknoinits
 	//+kubebuilder:scaffold:scheme
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
-	utilruntime.Must(dsci.AddToScheme(scheme))
-	utilruntime.Must(dsc.AddToScheme(scheme))
+	utilruntime.Must(dsciv1.AddToScheme(scheme))
+	utilruntime.Must(dscv1.AddToScheme(scheme))
 	utilruntime.Must(featurev1.AddToScheme(scheme))
-	utilruntime.Must(netv1.AddToScheme(scheme))
+	utilruntime.Must(networkingv1.AddToScheme(scheme))
 	utilruntime.Must(addonv1alpha1.AddToScheme(scheme))
-	utilruntime.Must(authv1.AddToScheme(scheme))
+	utilruntime.Must(rbacv1.AddToScheme(scheme))
 	utilruntime.Must(corev1.AddToScheme(scheme))
-	utilruntime.Must(apiextv1.AddToScheme(scheme))
+	utilruntime.Must(apiextensionsv1.AddToScheme(scheme))
 	utilruntime.Must(routev1.Install(scheme))
 	utilruntime.Must(appsv1.AddToScheme(scheme))
-	utilruntime.Must(ocv1.Install(scheme))
+	utilruntime.Must(oauthv1.Install(scheme))
 	utilruntime.Must(ofapiv1alpha1.AddToScheme(scheme))
-	utilruntime.Must(ocuserv1.Install(scheme))
+	utilruntime.Must(userv1.Install(scheme))
 	utilruntime.Must(ofapiv2.AddToScheme(scheme))
 	utilruntime.Must(kfdefv1.AddToScheme(scheme))
 	utilruntime.Must(ocappsv1.Install(scheme))
-	utilruntime.Must(ocbuildv1.Install(scheme))
-	utilruntime.Must(ocimgv1.Install(scheme))
-	utilruntime.Must(apiextv1.AddToScheme(scheme))
-	utilruntime.Must(admv1.AddToScheme(scheme))
+	utilruntime.Must(buildv1.Install(scheme))
+	utilruntime.Must(imagev1.Install(scheme))
+	utilruntime.Must(apiextensionsv1.AddToScheme(scheme))
+	utilruntime.Must(admissionregistrationv1.AddToScheme(scheme))
 	utilruntime.Must(apiregistrationv1.AddToScheme(scheme))
 	utilruntime.Must(monitoringv1.AddToScheme(scheme))
 	utilruntime.Must(operatorv1.Install(scheme))
@@ -148,7 +148,7 @@ func main() { //nolint:funlen
 		Scheme: mgr.GetScheme(),
 		Log:    logger.LogWithLevel(ctrl.Log.WithName(operatorName).WithName("controllers").WithName("DataScienceCluster"), logmode),
 		DataScienceCluster: &datascienceclustercontrollers.DataScienceClusterConfig{
-			DSCISpec: &dsci.DSCInitializationSpec{
+			DSCISpec: &dsciv1.DSCInitializationSpec{
 				ApplicationsNamespace: dscApplicationsNamespace,
 			},
 		},

--- a/pkg/cluster/cluster_config.go
+++ b/pkg/cluster/cluster_config.go
@@ -10,7 +10,7 @@ import (
 	"github.com/operator-framework/api/pkg/lib/version"
 	ofapi "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	apierrs "k8s.io/apimachinery/pkg/api/errors"
+	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -59,7 +59,7 @@ func GetClusterServiceVersion(ctx context.Context, c client.Client, watchNameSpa
 		}
 	}
 
-	return nil, apierrs.NewNotFound(
+	return nil, k8serr.NewNotFound(
 		schema.GroupResource{Group: gvk.ClusterServiceVersion.Group},
 		gvk.ClusterServiceVersion.Kind)
 }
@@ -156,7 +156,7 @@ func GetRelease(cli client.Client) (Release, error) {
 		return initRelease, nil
 	}
 	csv, err := GetClusterServiceVersion(context.TODO(), cli, operatorNamespace)
-	if apierrs.IsNotFound(err) {
+	if k8serr.IsNotFound(err) {
 		// hide not found, return default
 		return initRelease, nil
 	}

--- a/pkg/cluster/cluster_operations_int_test.go
+++ b/pkg/cluster/cluster_operations_int_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"time"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrlruntime "sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -34,21 +34,21 @@ var _ = Describe("Creating cluster resources", func() {
 		It("should create namespace if it does not exist", func(ctx context.Context) {
 			// given
 			namespace := envtestutil.AppendRandomNameTo("new-ns")
-			defer objectCleaner.DeleteAll(&v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}})
+			defer objectCleaner.DeleteAll(&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}})
 
 			// when
 			ns, err := cluster.CreateNamespace(ctx, envTestClient, namespace)
 
 			// then
 			Expect(err).ToNot(HaveOccurred())
-			Expect(ns.Status.Phase).To(Equal(v1.NamespaceActive))
+			Expect(ns.Status.Phase).To(Equal(corev1.NamespaceActive))
 			Expect(ns.ObjectMeta.Generation).To(BeZero())
 		})
 
 		It("should not try to create namespace if it does already exist", func(ctx context.Context) {
 			// given
 			namespace := envtestutil.AppendRandomNameTo("existing-ns")
-			newNamespace := &v1.Namespace{
+			newNamespace := &corev1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: namespace,
 				},
@@ -67,7 +67,7 @@ var _ = Describe("Creating cluster resources", func() {
 		It("should set labels", func(ctx context.Context) {
 			// given
 			namespace := envtestutil.AppendRandomNameTo("new-ns-with-labels")
-			defer objectCleaner.DeleteAll(&v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}})
+			defer objectCleaner.DeleteAll(&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}})
 
 			// when
 			nsWithLabels, err := cluster.CreateNamespace(ctx, envTestClient, namespace, cluster.WithLabels("opendatahub.io/test-label", "true"))
@@ -80,7 +80,7 @@ var _ = Describe("Creating cluster resources", func() {
 		It("should set annotations", func(ctx context.Context) {
 			// given
 			namespace := envtestutil.AppendRandomNameTo("new-ns-with-labels")
-			defer objectCleaner.DeleteAll(&v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}})
+			defer objectCleaner.DeleteAll(&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}})
 
 			// when
 			nsWithLabels, err := cluster.CreateNamespace(ctx, envTestClient, namespace, cluster.WithAnnotations("opendatahub.io/test-annotation", "true"))
@@ -113,7 +113,7 @@ var _ = Describe("Creating cluster resources", func() {
 
 		It("should create configmap with ns set through metaoptions", func(ctx context.Context) {
 			// given
-			configMap := &v1.ConfigMap{
+			configMap := &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{Name: "config-regs"},
 				Data: map[string]string{
 					"test-key": "test-value",
@@ -131,14 +131,14 @@ var _ = Describe("Creating cluster resources", func() {
 			defer objectCleaner.DeleteAll(configMap)
 
 			// then
-			actualConfigMap := &v1.ConfigMap{}
+			actualConfigMap := &corev1.ConfigMap{}
 			Expect(envTestClient.Get(ctx, ctrlruntime.ObjectKeyFromObject(configMap), actualConfigMap)).To(Succeed())
 			Expect(actualConfigMap.Namespace).To(Equal(namespace))
 		})
 
 		It("should create configmap with labels and owner reference", func(ctx context.Context) {
 			// given
-			configMap := &v1.ConfigMap{
+			configMap := &corev1.ConfigMap{
 				ObjectMeta: configMapMeta,
 				Data: map[string]string{
 					"test-key": "test-value",
@@ -162,7 +162,7 @@ var _ = Describe("Creating cluster resources", func() {
 			defer objectCleaner.DeleteAll(configMap)
 
 			// then
-			actualConfigMap := &v1.ConfigMap{}
+			actualConfigMap := &corev1.ConfigMap{}
 			Expect(envTestClient.Get(ctx, ctrlruntime.ObjectKeyFromObject(configMap), actualConfigMap)).To(Succeed())
 			Expect(actualConfigMap.Labels).To(HaveKeyWithValue(labels.K8SCommon.PartOf, "opendatahub"))
 			getOwnerRefName := func(reference metav1.OwnerReference) string {
@@ -176,7 +176,7 @@ var _ = Describe("Creating cluster resources", func() {
 			createErr := cluster.CreateOrUpdateConfigMap(
 				ctx,
 				envTestClient,
-				&v1.ConfigMap{
+				&corev1.ConfigMap{
 					ObjectMeta: configMapMeta,
 					Data: map[string]string{
 						"test-key": "test-value",
@@ -187,7 +187,7 @@ var _ = Describe("Creating cluster resources", func() {
 			Expect(createErr).ToNot(HaveOccurred())
 
 			// when
-			updatedConfigMap := &v1.ConfigMap{
+			updatedConfigMap := &corev1.ConfigMap{
 				ObjectMeta: configMapMeta,
 				Data: map[string]string{
 					"test-key": "new-value",
@@ -205,7 +205,7 @@ var _ = Describe("Creating cluster resources", func() {
 			defer objectCleaner.DeleteAll(updatedConfigMap)
 
 			// then
-			actualConfigMap := &v1.ConfigMap{}
+			actualConfigMap := &corev1.ConfigMap{}
 			Expect(envTestClient.Get(ctx, ctrlruntime.ObjectKeyFromObject(updatedConfigMap), actualConfigMap)).To(Succeed())
 			Expect(actualConfigMap.Data).To(HaveKeyWithValue("test-key", "new-value"))
 			Expect(actualConfigMap.Data).To(HaveKeyWithValue("new-key", "sth-new"))

--- a/pkg/cluster/cluster_operations_suite_int_test.go
+++ b/pkg/cluster/cluster_operations_suite_int_test.go
@@ -3,7 +3,7 @@ package cluster_test
 import (
 	"testing"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -33,7 +33,7 @@ var _ = BeforeSuite(func() {
 
 	By("Bootstrapping k8s test environment")
 
-	utilruntime.Must(v1.AddToScheme(testScheme))
+	utilruntime.Must(corev1.AddToScheme(testScheme))
 
 	envTest = &envtest.Environment{}
 

--- a/pkg/cluster/resources.go
+++ b/pkg/cluster/resources.go
@@ -6,10 +6,10 @@ import (
 	"fmt"
 	"time"
 
-	v1 "k8s.io/api/apps/v1"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	authv1 "k8s.io/api/rbac/v1"
-	apierrs "k8s.io/apimachinery/pkg/api/errors"
+	rbacv1 "k8s.io/api/rbac/v1"
+	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -20,7 +20,7 @@ import (
 // UpdatePodSecurityRolebinding update default rolebinding which is created in applications namespace by manifests
 // being used by different components and SRE monitoring.
 func UpdatePodSecurityRolebinding(ctx context.Context, cli client.Client, namespace string, serviceAccountsList ...string) error {
-	foundRoleBinding := &authv1.RoleBinding{}
+	foundRoleBinding := &rbacv1.RoleBinding{}
 	if err := cli.Get(ctx, client.ObjectKey{Name: namespace, Namespace: namespace}, foundRoleBinding); err != nil {
 		return fmt.Errorf("error to get rolebinding %s from namespace %s: %w", namespace, namespace, err)
 	}
@@ -28,8 +28,8 @@ func UpdatePodSecurityRolebinding(ctx context.Context, cli client.Client, namesp
 	for _, sa := range serviceAccountsList {
 		// Append serviceAccount if not added already
 		if !subjectExistInRoleBinding(foundRoleBinding.Subjects, sa, namespace) {
-			foundRoleBinding.Subjects = append(foundRoleBinding.Subjects, authv1.Subject{
-				Kind:      authv1.ServiceAccountKind,
+			foundRoleBinding.Subjects = append(foundRoleBinding.Subjects, rbacv1.Subject{
+				Kind:      rbacv1.ServiceAccountKind,
 				Name:      sa,
 				Namespace: namespace,
 			})
@@ -45,7 +45,7 @@ func UpdatePodSecurityRolebinding(ctx context.Context, cli client.Client, namesp
 
 // Internal function used by UpdatePodSecurityRolebinding()
 // Return whether Rolebinding matching service account and namespace exists or not.
-func subjectExistInRoleBinding(subjectList []authv1.Subject, serviceAccountName, namespace string) bool {
+func subjectExistInRoleBinding(subjectList []rbacv1.Subject, serviceAccountName, namespace string) bool {
 	for _, subject := range subjectList {
 		if subject.Name == serviceAccountName && subject.Namespace == namespace {
 			return true
@@ -72,9 +72,9 @@ func CreateSecret(ctx context.Context, cli client.Client, name, namespace string
 	foundSecret := &corev1.Secret{}
 	err := cli.Get(ctx, client.ObjectKey{Name: name, Namespace: namespace}, foundSecret)
 	if err != nil {
-		if apierrs.IsNotFound(err) {
+		if k8serr.IsNotFound(err) {
 			err = cli.Create(ctx, desiredSecret)
-			if err != nil && !apierrs.IsAlreadyExists(err) {
+			if err != nil && !k8serr.IsAlreadyExists(err) {
 				return err
 			}
 		} else {
@@ -103,7 +103,7 @@ func CreateOrUpdateConfigMap(ctx context.Context, c client.Client, desiredCfgMap
 		Namespace: desiredCfgMap.Namespace,
 	}, existingCfgMap)
 
-	if apierrs.IsNotFound(err) {
+	if k8serr.IsNotFound(err) {
 		return c.Create(ctx, desiredCfgMap)
 	} else if err != nil {
 		return err
@@ -147,7 +147,7 @@ func CreateNamespace(ctx context.Context, cli client.Client, namespace string, m
 	}
 
 	createErr := cli.Create(ctx, desiredNamespace)
-	if apierrs.IsAlreadyExists(createErr) {
+	if k8serr.IsAlreadyExists(createErr) {
 		return foundNamespace, nil
 	}
 
@@ -160,7 +160,7 @@ func WaitForDeploymentAvailable(ctx context.Context, c client.Client, componentN
 	resourceTimeout := time.Duration(timeout) * time.Minute
 
 	return wait.PollUntilContextTimeout(ctx, resourceInterval, resourceTimeout, true, func(ctx context.Context) (bool, error) {
-		componentDeploymentList := &v1.DeploymentList{}
+		componentDeploymentList := &appsv1.DeploymentList{}
 		err := c.List(ctx, componentDeploymentList, client.InNamespace(namespace), client.HasLabels{labels.ODH.Component(componentName)})
 		if err != nil {
 			return false, fmt.Errorf("error fetching list of deployments: %w", err)

--- a/pkg/deploy/deploy.go
+++ b/pkg/deploy/deploy.go
@@ -32,7 +32,7 @@ import (
 	"strings"
 
 	"golang.org/x/exp/maps"
-	apierrs "k8s.io/apimachinery/pkg/api/errors"
+	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -220,7 +220,7 @@ func manageResource(ctx context.Context, cli client.Client, obj *unstructured.Un
 		return handleDisabledComponent(ctx, cli, found, componentName)
 	}
 
-	if apierrs.IsNotFound(err) {
+	if k8serr.IsNotFound(err) {
 		// Create resource if it doesn't exist and enabled
 		if enabled {
 			return createResource(ctx, cli, obj, owner)
@@ -365,7 +365,7 @@ func getResource(ctx context.Context, cli client.Client, obj *unstructured.Unstr
 	err := cli.Get(ctx, types.NamespacedName{Name: obj.GetName(), Namespace: obj.GetNamespace()}, found)
 	if errors.Is(err, &meta.NoKindMatchError{}) {
 		// convert the error to NotFound to handle both the same way in the caller
-		return nil, apierrs.NewNotFound(schema.GroupResource{Group: obj.GroupVersionKind().Group}, obj.GetName())
+		return nil, k8serr.NewNotFound(schema.GroupResource{Group: obj.GroupVersionKind().Group}, obj.GetName())
 	}
 	if err != nil {
 		return nil, err

--- a/pkg/feature/feature_tracker_handler.go
+++ b/pkg/feature/feature_tracker_handler.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"fmt"
 
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -32,7 +32,7 @@ func (e *withConditionReasonError) Error() string {
 // All resources which particular feature is composed of will have this object attached as an OwnerReference.
 func (f *Feature) createFeatureTracker() error {
 	tracker, err := f.getFeatureTracker()
-	if k8serrors.IsNotFound(err) {
+	if k8serr.IsNotFound(err) {
 		if err := f.Client.Create(context.TODO(), tracker); err != nil {
 			return err
 		}

--- a/pkg/feature/handler.go
+++ b/pkg/feature/handler.go
@@ -7,7 +7,7 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	v1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/dscinitialization/v1"
+	dsciv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/dscinitialization/v1"
 	featurev1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/features/v1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/controllers/status"
 )
@@ -21,7 +21,7 @@ var _ featureHandler = (*FeaturesHandler)(nil)
 
 // FeaturesHandler coordinates feature creations and removal from within controllers.
 type FeaturesHandler struct {
-	*v1.DSCInitializationSpec
+	*dsciv1.DSCInitializationSpec
 	source            featurev1.Source
 	features          []*Feature
 	featuresProviders []FeaturesProvider
@@ -69,7 +69,7 @@ func (h HandlerWithReporter[T]) Delete() error {
 // and couple them with the given initializer.
 type FeaturesProvider func(handler *FeaturesHandler) error
 
-func ClusterFeaturesHandler(dsci *v1.DSCInitialization, def ...FeaturesProvider) *FeaturesHandler {
+func ClusterFeaturesHandler(dsci *dsciv1.DSCInitialization, def ...FeaturesProvider) *FeaturesHandler {
 	return &FeaturesHandler{
 		DSCInitializationSpec: &dsci.Spec,
 		source:                featurev1.Source{Type: featurev1.DSCIType, Name: dsci.Name},
@@ -77,7 +77,7 @@ func ClusterFeaturesHandler(dsci *v1.DSCInitialization, def ...FeaturesProvider)
 	}
 }
 
-func ComponentFeaturesHandler(componentName string, spec *v1.DSCInitializationSpec, def ...FeaturesProvider) *FeaturesHandler {
+func ComponentFeaturesHandler(componentName string, spec *dsciv1.DSCInitializationSpec, def ...FeaturesProvider) *FeaturesHandler {
 	return &FeaturesHandler{
 		DSCInitializationSpec: spec,
 		source:                featurev1.Source{Type: featurev1.ComponentType, Name: componentName},

--- a/pkg/upgrade/uninstallation.go
+++ b/pkg/upgrade/uninstallation.go
@@ -7,10 +7,10 @@ import (
 
 	"github.com/hashicorp/go-multierror"
 	corev1 "k8s.io/api/core/v1"
-	apierrs "k8s.io/apimachinery/pkg/api/errors"
+	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	dsci "github.com/opendatahub-io/opendatahub-operator/v2/apis/dscinitialization/v1"
+	dsciv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/dscinitialization/v1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/metadata/labels"
 )
@@ -93,7 +93,7 @@ func OperatorUninstall(ctx context.Context, cli client.Client) error {
 }
 
 func removeDSCInitialization(ctx context.Context, cli client.Client) error {
-	instanceList := &dsci.DSCInitializationList{}
+	instanceList := &dsciv1.DSCInitializationList{}
 
 	if err := cli.List(ctx, instanceList); err != nil {
 		return err
@@ -102,7 +102,7 @@ func removeDSCInitialization(ctx context.Context, cli client.Client) error {
 	var multiErr *multierror.Error
 	for _, dsciInstance := range instanceList.Items {
 		dsciInstance := dsciInstance
-		if err := cli.Delete(ctx, &dsciInstance); !apierrs.IsNotFound(err) {
+		if err := cli.Delete(ctx, &dsciInstance); !k8serr.IsNotFound(err) {
 			multiErr = multierror.Append(multiErr, err)
 		}
 	}
@@ -141,7 +141,7 @@ func removeCSV(ctx context.Context, c client.Client) error {
 	}
 
 	operatorCsv, err := cluster.GetClusterServiceVersion(ctx, c, operatorNamespace)
-	if apierrs.IsNotFound(err) {
+	if k8serr.IsNotFound(err) {
 		fmt.Printf("No clusterserviceversion for the operator found.\n")
 		return nil
 	}
@@ -153,7 +153,7 @@ func removeCSV(ctx context.Context, c client.Client) error {
 	fmt.Printf("Deleting CSV %s\n", operatorCsv.Name)
 	err = c.Delete(ctx, operatorCsv)
 	if err != nil {
-		if apierrs.IsNotFound(err) {
+		if k8serr.IsNotFound(err) {
 			return nil
 		}
 

--- a/tests/e2e/controller_setup_test.go
+++ b/tests/e2e/controller_setup_test.go
@@ -22,8 +22,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	ctrlruntime "sigs.k8s.io/controller-runtime/pkg/client/config"
 
-	dsc "github.com/opendatahub-io/opendatahub-operator/v2/apis/datasciencecluster/v1"
-	dsci "github.com/opendatahub-io/opendatahub-operator/v2/apis/dscinitialization/v1"
+	dscv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/datasciencecluster/v1"
+	dsciv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/dscinitialization/v1"
 	featurev1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/features/v1"
 )
 
@@ -48,9 +48,9 @@ type testContext struct {
 	// time required to create a resource
 	resourceCreationTimeout time.Duration
 	// test DataScienceCluster instance
-	testDsc *dsc.DataScienceCluster
+	testDsc *dscv1.DataScienceCluster
 	// test DSCI CR because we do not create it in ODH by default
-	testDSCI *dsci.DSCInitialization
+	testDSCI *dsciv1.DSCInitialization
 	// time interval to check for resource creation
 	resourceRetryInterval time.Duration
 	// context for accessing resources
@@ -102,8 +102,8 @@ func TestOdhOperator(t *testing.T) {
 	utilruntime.Must(routev1.AddToScheme(scheme))
 	utilruntime.Must(apiextv1.AddToScheme(scheme))
 	utilruntime.Must(autoscalingv1.AddToScheme(scheme))
-	utilruntime.Must(dsci.AddToScheme(scheme))
-	utilruntime.Must(dsc.AddToScheme(scheme))
+	utilruntime.Must(dsciv1.AddToScheme(scheme))
+	utilruntime.Must(dscv1.AddToScheme(scheme))
 	utilruntime.Must(featurev1.AddToScheme(scheme))
 	utilruntime.Must(monitoringv1.AddToScheme(scheme))
 	utilruntime.Must(ofapi.AddToScheme(scheme))

--- a/tests/e2e/dsc_cfmap_deletion_test.go
+++ b/tests/e2e/dsc_cfmap_deletion_test.go
@@ -8,11 +8,11 @@ import (
 
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
-	dsc "github.com/opendatahub-io/opendatahub-operator/v2/apis/datasciencecluster/v1"
+	dscv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/datasciencecluster/v1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/metadata/labels"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/upgrade"
 )
@@ -38,7 +38,7 @@ func cfgMapDeletionTestSuite(t *testing.T) {
 
 func (tc *testContext) testDSCDeletionUsingConfigMap(enableDeletion string) error {
 	dscLookupKey := types.NamespacedName{Name: tc.testDsc.Name}
-	expectedDSC := &dsc.DataScienceCluster{}
+	expectedDSC := &dscv1.DataScienceCluster{}
 
 	if err := createDeletionConfigMap(tc, enableDeletion); err != nil {
 		return err
@@ -47,7 +47,7 @@ func (tc *testContext) testDSCDeletionUsingConfigMap(enableDeletion string) erro
 	err := tc.customClient.Get(tc.ctx, dscLookupKey, expectedDSC)
 	// should have DSC instance
 	if err != nil {
-		if k8serrors.IsNotFound(err) {
+		if k8serr.IsNotFound(err) {
 			return fmt.Errorf("should have DSC instance in cluster:%w", err)
 		}
 		return fmt.Errorf("error getting DSC instance :%w", err)
@@ -88,11 +88,11 @@ func createDeletionConfigMap(tc *testContext, enableDeletion string) error {
 	configMaps := tc.kubeClient.CoreV1().ConfigMaps(configMap.Namespace)
 	if _, err := configMaps.Get(context.TODO(), configMap.Name, metav1.GetOptions{}); err != nil {
 		switch {
-		case k8serrors.IsNotFound(err):
+		case k8serr.IsNotFound(err):
 			if _, err = configMaps.Create(context.TODO(), configMap, metav1.CreateOptions{}); err != nil {
 				return err
 			}
-		case k8serrors.IsAlreadyExists(err):
+		case k8serr.IsAlreadyExists(err):
 			if _, err = configMaps.Update(context.TODO(), configMap, metav1.UpdateOptions{}); err != nil {
 				return err
 			}

--- a/tests/e2e/dsc_creation_test.go
+++ b/tests/e2e/dsc_creation_test.go
@@ -13,7 +13,7 @@ import (
 	operatorv1 "github.com/openshift/api/operator/v1"
 	"github.com/stretchr/testify/require"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -22,8 +22,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/util/retry"
 
-	dsc "github.com/opendatahub-io/opendatahub-operator/v2/apis/datasciencecluster/v1"
-	dsci "github.com/opendatahub-io/opendatahub-operator/v2/apis/dscinitialization/v1"
+	dscv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/datasciencecluster/v1"
+	dsciv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/dscinitialization/v1"
 	infrav1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/infrastructure/v1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/components"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
@@ -90,8 +90,8 @@ func creationTestSuite(t *testing.T) {
 
 func (tc *testContext) testDSCICreation() error {
 	dscLookupKey := types.NamespacedName{Name: tc.testDsc.Name}
-	createdDSCI := &dsci.DSCInitialization{}
-	existingDSCIList := &dsci.DSCInitializationList{}
+	createdDSCI := &dsciv1.DSCInitialization{}
+	existingDSCIList := &dsciv1.DSCInitializationList{}
 
 	err := tc.customClient.List(tc.ctx, existingDSCIList)
 	if err == nil {
@@ -104,7 +104,7 @@ func (tc *testContext) testDSCICreation() error {
 	// create one for you
 	err = tc.customClient.Get(tc.ctx, dscLookupKey, createdDSCI)
 	if err != nil {
-		if k8serrors.IsNotFound(err) {
+		if k8serr.IsNotFound(err) {
 			nberr := wait.PollUntilContextTimeout(tc.ctx, tc.resourceRetryInterval, tc.resourceCreationTimeout, false, func(ctx context.Context) (bool, error) {
 				creationErr := tc.customClient.Create(tc.ctx, tc.testDSCI)
 				if creationErr != nil {
@@ -128,7 +128,7 @@ func (tc *testContext) testDSCICreation() error {
 func waitDSCReady(tc *testContext) error {
 	err := tc.wait(func(ctx context.Context) (bool, error) {
 		key := types.NamespacedName{Name: tc.testDsc.Name}
-		dsc := &dsc.DataScienceCluster{}
+		dsc := &dscv1.DataScienceCluster{}
 
 		err := tc.customClient.Get(tc.ctx, key, dsc)
 		if err != nil {
@@ -149,8 +149,8 @@ func (tc *testContext) testDSCCreation() error {
 	// Create DataScienceCluster resource if not already created
 
 	dscLookupKey := types.NamespacedName{Name: tc.testDsc.Name}
-	createdDSC := &dsc.DataScienceCluster{}
-	existingDSCList := &dsc.DataScienceClusterList{}
+	createdDSC := &dscv1.DataScienceCluster{}
+	existingDSCList := &dscv1.DataScienceClusterList{}
 
 	err := tc.customClient.List(tc.ctx, existingDSCList)
 	if err == nil {
@@ -164,7 +164,7 @@ func (tc *testContext) testDSCCreation() error {
 
 	err = tc.customClient.Get(tc.ctx, dscLookupKey, createdDSC)
 	if err != nil {
-		if k8serrors.IsNotFound(err) {
+		if k8serr.IsNotFound(err) {
 			nberr := wait.PollUntilContextTimeout(tc.ctx, tc.resourceRetryInterval, tc.resourceCreationTimeout, false, func(ctx context.Context) (bool, error) {
 				creationErr := tc.customClient.Create(tc.ctx, tc.testDsc)
 				if creationErr != nil {
@@ -240,7 +240,7 @@ func (tc *testContext) testAllApplicationCreation(t *testing.T) error { //nolint
 	// Validate test instance is in Ready state
 
 	dscLookupKey := types.NamespacedName{Name: tc.testDsc.Name}
-	createdDSC := &dsc.DataScienceCluster{}
+	createdDSC := &dscv1.DataScienceCluster{}
 
 	// Wait for applications to get deployed
 	time.Sleep(1 * time.Minute)
@@ -512,7 +512,7 @@ func (tc *testContext) testUpdateDSCComponentEnabled() error {
 	time.Sleep(4 * tc.resourceRetryInterval)
 	_, err = tc.kubeClient.AppsV1().Deployments(tc.applicationsNamespace).Get(context.TODO(), dashboardDeploymentName, metav1.GetOptions{})
 	if err != nil {
-		if k8serrors.IsNotFound(err) {
+		if k8serr.IsNotFound(err) {
 			return nil // correct result: should not find deployment after we disable it already
 		}
 

--- a/tests/e2e/dsc_deletion_test.go
+++ b/tests/e2e/dsc_deletion_test.go
@@ -13,8 +13,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	dsc "github.com/opendatahub-io/opendatahub-operator/v2/apis/datasciencecluster/v1"
-	dsci "github.com/opendatahub-io/opendatahub-operator/v2/apis/dscinitialization/v1"
+	dscv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/datasciencecluster/v1"
+	dsciv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/dscinitialization/v1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/components"
 )
 
@@ -47,7 +47,7 @@ func (tc *testContext) testDeletionExistDSC() error {
 	// Delete test DataScienceCluster resource if found
 
 	dscLookupKey := types.NamespacedName{Name: tc.testDsc.Name}
-	expectedDSC := &dsc.DataScienceCluster{}
+	expectedDSC := &dscv1.DataScienceCluster{}
 
 	err := tc.customClient.Get(tc.ctx, dscLookupKey, expectedDSC)
 	if err == nil {
@@ -111,7 +111,7 @@ func (tc *testContext) testDeletionExistDSCI() error {
 	// Delete test DSCI resource if found
 
 	dsciLookupKey := types.NamespacedName{Name: tc.testDSCI.Name}
-	expectedDSCI := &dsci.DSCInitialization{}
+	expectedDSCI := &dsciv1.DSCInitialization{}
 
 	err := tc.customClient.Get(tc.ctx, dsciLookupKey, expectedDSCI)
 	if err == nil {

--- a/tests/e2e/helper_test.go
+++ b/tests/e2e/helper_test.go
@@ -20,8 +20,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	dsc "github.com/opendatahub-io/opendatahub-operator/v2/apis/datasciencecluster/v1"
-	dsci "github.com/opendatahub-io/opendatahub-operator/v2/apis/dscinitialization/v1"
+	dscv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/datasciencecluster/v1"
+	dsciv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/dscinitialization/v1"
 	infrav1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/infrastructure/v1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/components"
 	"github.com/opendatahub-io/opendatahub-operator/v2/components/codeflare"
@@ -71,18 +71,18 @@ func (tc *testContext) waitForControllerDeployment(name string, replicas int32) 
 	return err
 }
 
-func setupDSCICR(name string) *dsci.DSCInitialization {
-	dsciTest := &dsci.DSCInitialization{
+func setupDSCICR(name string) *dsciv1.DSCInitialization {
+	dsciTest := &dsciv1.DSCInitialization{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
 		},
-		Spec: dsci.DSCInitializationSpec{
+		Spec: dsciv1.DSCInitializationSpec{
 			ApplicationsNamespace: "opendatahub",
-			Monitoring: dsci.Monitoring{
+			Monitoring: dsciv1.Monitoring{
 				ManagementState: "Managed",
 				Namespace:       "opendatahub",
 			},
-			TrustedCABundle: &dsci.TrustedCABundleSpec{
+			TrustedCABundle: &dsciv1.TrustedCABundleSpec{
 				ManagementState: "Managed",
 				CustomCABundle:  "",
 			},
@@ -99,13 +99,13 @@ func setupDSCICR(name string) *dsci.DSCInitialization {
 	return dsciTest
 }
 
-func setupDSCInstance(name string) *dsc.DataScienceCluster {
-	dscTest := &dsc.DataScienceCluster{
+func setupDSCInstance(name string) *dscv1.DataScienceCluster {
+	dscTest := &dscv1.DataScienceCluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
 		},
-		Spec: dsc.DataScienceClusterSpec{
-			Components: dsc.Components{
+		Spec: dscv1.DataScienceClusterSpec{
+			Components: dscv1.Components{
 				// keep dashboard as enabled, because other test is rely on this
 				Dashboard: dashboard.Dashboard{
 					Component: components.Component{

--- a/tests/envtestutil/cleaner.go
+++ b/tests/envtestutil/cleaner.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -122,7 +122,7 @@ func (c *Cleaner) DeleteAll(objects ...client.Object) {
 		Eventually(func() metav1.StatusReason {
 			key := client.ObjectKeyFromObject(obj)
 			if err := c.client.Get(context.Background(), key, obj); err != nil {
-				return apierrors.ReasonForError(err)
+				return k8serr.ReasonForError(err)
 			}
 
 			return ""
@@ -131,7 +131,7 @@ func (c *Cleaner) DeleteAll(objects ...client.Object) {
 }
 
 func ignoreMethodNotAllowed(err error) error {
-	if apierrors.ReasonForError(err) == metav1.StatusReasonMethodNotAllowed {
+	if k8serr.ReasonForError(err) == metav1.StatusReasonMethodNotAllowed {
 		return nil
 	}
 

--- a/tests/integration/features/features_suite_int_test.go
+++ b/tests/integration/features/features_suite_int_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	ofapiv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -54,7 +54,7 @@ var _ = BeforeSuite(func() {
 		return
 	}
 
-	utilruntime.Must(v1.AddToScheme(testScheme))
+	utilruntime.Must(corev1.AddToScheme(testScheme))
 	utilruntime.Must(featurev1.AddToScheme(testScheme))
 	utilruntime.Must(apiextensionsv1.AddToScheme(testScheme))
 	utilruntime.Must(ofapiv1alpha1.AddToScheme(testScheme))

--- a/tests/integration/features/fixtures/cluster_test_fixtures.go
+++ b/tests/integration/features/fixtures/cluster_test_fixtures.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	ofapiv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/yaml"
@@ -30,7 +30,7 @@ func CreateSubscription(client client.Client, namespace, subscriptionYaml string
 	return createOrUpdateSubscription(client, subscription)
 }
 
-func CreateOrUpdateNamespace(client client.Client, ns *v1.Namespace) error {
+func CreateOrUpdateNamespace(client client.Client, ns *corev1.Namespace) error {
 	_, err := controllerutil.CreateOrUpdate(context.Background(), client, ns, func() error {
 		return nil
 	})
@@ -44,23 +44,23 @@ func createOrUpdateSubscription(client client.Client, subscription *ofapiv1alpha
 	return err
 }
 
-func NewNamespace(name string) *v1.Namespace {
-	return &v1.Namespace{
+func NewNamespace(name string) *corev1.Namespace {
+	return &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
 		},
 	}
 }
 
-func GetNamespace(client client.Client, namespace string) (*v1.Namespace, error) {
+func GetNamespace(client client.Client, namespace string) (*corev1.Namespace, error) {
 	ns := NewNamespace(namespace)
 	err := client.Get(context.Background(), types.NamespacedName{Name: namespace}, ns)
 
 	return ns, err
 }
 
-func GetService(client client.Client, namespace, name string) (*v1.Service, error) {
-	svc := &v1.Service{}
+func GetService(client client.Client, namespace, name string) (*corev1.Service, error) {
+	svc := &corev1.Service{}
 	err := client.Get(context.Background(), types.NamespacedName{
 		Name: name, Namespace: namespace,
 	}, svc)
@@ -70,7 +70,7 @@ func GetService(client client.Client, namespace, name string) (*v1.Service, erro
 
 func CreateSecret(name, namespace string) func(f *feature.Feature) error {
 	return func(f *feature.Feature) error {
-		secret := &v1.Secret{
+		secret := &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      name,
 				Namespace: namespace,

--- a/tests/integration/features/preconditions_int_test.go
+++ b/tests/integration/features/preconditions_int_test.go
@@ -3,8 +3,8 @@ package features_test
 import (
 	"context"
 
-	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	corev1 "k8s.io/api/core/v1"
+	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	dsciv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/dscinitialization/v1"
@@ -37,8 +37,8 @@ var _ = Describe("feature preconditions", func() {
 		It("should create namespace if it does not exist", func() {
 			// given
 			_, err := fixtures.GetNamespace(envTestClient, namespace)
-			Expect(errors.IsNotFound(err)).To(BeTrue())
-			defer objectCleaner.DeleteAll(&v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}})
+			Expect(k8serr.IsNotFound(err)).To(BeTrue())
+			defer objectCleaner.DeleteAll(&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}})
 
 			// when
 			featuresHandler := feature.ClusterFeaturesHandler(dsci, func(handler *feature.FeaturesHandler) error {

--- a/tests/integration/features/resources_int_test.go
+++ b/tests/integration/features/resources_int_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"path"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	dsciv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/dscinitialization/v1"
@@ -21,7 +21,7 @@ import (
 var _ = Describe("Applying and updating resources", func() {
 	var (
 		testNamespace   string
-		namespace       *v1.Namespace
+		namespace       *corev1.Namespace
 		objectCleaner   *envtestutil.Cleaner
 		dsci            *dsciv1.DSCInitialization
 		dummyAnnotation string
@@ -118,7 +118,7 @@ func createAndApplyFeature(dsci *dsciv1.DSCInitialization, managed bool, feature
 	return featuresHandler
 }
 
-func getServiceAndExpectAnnotations(testClient client.Client, namespace, serviceName string, annotations map[string]string) *v1.Service {
+func getServiceAndExpectAnnotations(testClient client.Client, namespace, serviceName string, annotations map[string]string) *corev1.Service {
 	service, err := fixtures.GetService(testClient, namespace, serviceName)
 	Expect(err).ToNot(HaveOccurred())
 	for key, val := range annotations {
@@ -127,7 +127,7 @@ func getServiceAndExpectAnnotations(testClient client.Client, namespace, service
 	return service
 }
 
-func modifyAndExpectUpdate(client client.Client, service *v1.Service, annotationKey, newValue string) {
+func modifyAndExpectUpdate(client client.Client, service *corev1.Service, annotationKey, newValue string) {
 	if service.Annotations == nil {
 		service.Annotations = make(map[string]string)
 	}


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description

This linter ensures that we use consistent aliases for imports, which are especially handy for versioned API packages. 

We can ensure that e.g. "k8s.io/api/core/v1" is consistently aliased as `corev1` with simple rules. 

In the case of "k8s.io/apimachinery/pkg/api/errors" it will expect `k8serr` alias instead of `apierrs`, as the former is more descriptive.


## How Has This Been Tested?

`make lint`

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
