### PR TITLE
fix(lint): explicitly configures ireturn exceptions

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -43,6 +43,15 @@ linters-settings:
         alias: $1$2
       - pkg: github.com/openshift/api/(\w+)/(v[\w\d]+)
         alias: $1$2
+  ireturn:
+    allow:
+      # defaults https://golangci-lint.run/usage/linters/#ireturn
+      - anon
+      - error
+      - empty
+      - stdlib
+      # also allow generics
+      - generic
   revive:
     rules:
       - name: dot-imports

--- a/controllers/status/reporter.go
+++ b/controllers/status/reporter.go
@@ -1,4 +1,3 @@
-//nolint:ireturn //reason: return T which is expected to be satisfying client.Object interface
 package status
 
 import (

--- a/pkg/plugins/addLabelsplugin.go
+++ b/pkg/plugins/addLabelsplugin.go
@@ -15,8 +15,8 @@ import (
 //   - It adds labels to the "metadata/labels" path for all resource kinds.
 //   - It adds labels to the "spec/template/metadata/labels" and "spec/selector/matchLabels" paths
 //     for resources of kind "Deployment".
-func CreateAddLabelsPlugin(componentName string) builtins.LabelTransformerPlugin {
-	return builtins.LabelTransformerPlugin{
+func CreateAddLabelsPlugin(componentName string) *builtins.LabelTransformerPlugin {
+	return &builtins.LabelTransformerPlugin{
 		Labels: map[string]string{
 			labels.ODH.Component(componentName): "true",
 			labels.K8SCommon.PartOf:             componentName,

--- a/pkg/plugins/namespacePlugin.go
+++ b/pkg/plugins/namespacePlugin.go
@@ -8,8 +8,8 @@ import (
 )
 
 // CreateNamespaceApplierPlugin creates a plugin to ensure resources have the specified target namespace.
-func CreateNamespaceApplierPlugin(targetNamespace string) builtins.NamespaceTransformerPlugin {
-	return builtins.NamespaceTransformerPlugin{
+func CreateNamespaceApplierPlugin(targetNamespace string) *builtins.NamespaceTransformerPlugin {
+	return &builtins.NamespaceTransformerPlugin{
 		ObjectMeta: types.ObjectMeta{
 			Name:      "odh-namespace-plugin",
 			Namespace: targetNamespace,


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description

Instead of using `//nolint:ireturn` the linter allows the use of `generic` return types through the global config (on top of the listed defaults which now have been explicitly set).

This approach also eliminates a recurring issue where `nolintlint` reports the directive above as not used by the defined linter.

Related issue: https://github.com/golangci/golangci-lint/issues/3228

On top of that, we have `--fix` flag enabled for `golangci-lint` runner. This results in the removal of these comments as `nolintlint` tries to auto fix.

As a consequence the subsequent run of `make lint` yields errors for previously disabled linters and the cycle continues :)

> [!IMPORTANT]
> This behaviour has also been observed for other linters.

As part of this work, the declarations of kustomize plugin constructor funcs has been reworked to return struct pointers instead. The reason for this is that in our feature branch, we rely on kustomize plugins and want to iterate over a slice of `resmap.Transfomers` but these functions cannot be used in the current form because structs returned have pointer receivers. From the current functionality standpoint (on the incubation branch) this change is harmless.

## How Has This Been Tested?

`make`

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] ~Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).~
- [x] The developer has manually tested the changes and verified that the changes work
