### PR TITLE
RHOAIENG-2974: Restrict DSCI deletion before DSC

### DIFF
--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -23,6 +23,7 @@ webhooks:
     operations:
     - CREATE
     - UPDATE
+    - DELETE
     resources:
     - datascienceclusters
     - dscinitializations

--- a/controllers/webhook/webhook.go
+++ b/controllers/webhook/webhook.go
@@ -103,14 +103,14 @@ func (w *OpenDataHubWebhook) checkDupCreation(ctx context.Context, req admission
 		fmt.Sprintf("Only one instance of %s object is allowed", req.Kind.Kind))
 }
 
-func (w *OpenDataHubWebhook) checkDSCIDeletion(ctx context.Context, req admission.Request) admission.Response {
-	// Restrict deletion of DSCI if DSC exists
+func (w *OpenDataHubWebhook) checkDeletion(ctx context.Context, req admission.Request) admission.Response {
 	if req.Kind.Kind != "DSCInitialization" {
-		admission.Allowed("")
+		return admission.Allowed("")
 	}
 
+	// Restrict deletion of DSCI if DSC exists
 	return denyCountGtZero(ctx, w.client, gvk.DataScienceCluster,
-		fmt.Sprintf("Cannot delete %s object before %s", req.Kind.Kind, gvk.DataScienceCluster.Kind))
+		fmt.Sprintln("Cannot delete DSCI object when DSC object still exists"))
 }
 
 func (w *OpenDataHubWebhook) Handle(ctx context.Context, req admission.Request) admission.Response {
@@ -120,7 +120,7 @@ func (w *OpenDataHubWebhook) Handle(ctx context.Context, req admission.Request) 
 	case admissionv1.Create:
 		resp = w.checkDupCreation(ctx, req)
 	case admissionv1.Delete:
-		resp = w.checkDSCIDeletion(ctx, req)
+		resp = w.checkDeletion(ctx, req)
 	default:
 		msg := fmt.Sprintf("No logic check by webhook is applied on %v request", req.Operation)
 		log.Info(msg)

--- a/controllers/webhook/webhook.go
+++ b/controllers/webhook/webhook.go
@@ -104,7 +104,7 @@ func (w *OpenDataHubWebhook) checkDupCreation(ctx context.Context, req admission
 }
 
 func (w *OpenDataHubWebhook) checkDeletion(ctx context.Context, req admission.Request) admission.Response {
-	if req.Kind.Kind != "DSCInitialization" {
+	if req.Kind.Kind == "DataScienceCluster" {
 		return admission.Allowed("")
 	}
 

--- a/controllers/webhook/webhook.go
+++ b/controllers/webhook/webhook.go
@@ -28,11 +28,13 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
 )
 
 var log = ctrl.Log.WithName("odh-controller-webhook")
 
-//+kubebuilder:webhook:path=/validate-opendatahub-io-v1,mutating=false,failurePolicy=fail,sideEffects=None,groups=datasciencecluster.opendatahub.io;dscinitialization.opendatahub.io,resources=datascienceclusters;dscinitializations,verbs=create;update,versions=v1,name=operator.opendatahub.io,admissionReviewVersions=v1
+//+kubebuilder:webhook:path=/validate-opendatahub-io-v1,mutating=false,failurePolicy=fail,sideEffects=None,groups=datasciencecluster.opendatahub.io;dscinitialization.opendatahub.io,resources=datascienceclusters;dscinitializations,verbs=create;update;delete,versions=v1,name=operator.opendatahub.io,admissionReviewVersions=v1
 //nolint:lll
 
 type OpenDataHubWebhook struct {
@@ -101,12 +103,24 @@ func (w *OpenDataHubWebhook) checkDupCreation(ctx context.Context, req admission
 		fmt.Sprintf("Only one instance of %s object is allowed", req.Kind.Kind))
 }
 
+func (w *OpenDataHubWebhook) checkDSCIDeletion(ctx context.Context, req admission.Request) admission.Response {
+	// Restrict deletion of DSCI if DSC exists
+	if req.Kind.Kind != "DSCInitialization" {
+		admission.Allowed("")
+	}
+
+	return denyCountGtZero(ctx, w.client, gvk.DataScienceCluster,
+		fmt.Sprintf("Cannot delete %s object before %s", req.Kind.Kind, gvk.DataScienceCluster.Kind))
+}
+
 func (w *OpenDataHubWebhook) Handle(ctx context.Context, req admission.Request) admission.Response {
 	var resp admission.Response
 
 	switch req.Operation {
 	case admissionv1.Create:
 		resp = w.checkDupCreation(ctx, req)
+	case admissionv1.Delete:
+		resp = w.checkDSCIDeletion(ctx, req)
 	default:
 		msg := fmt.Sprintf("No logic check by webhook is applied on %v request", req.Operation)
 		log.Info(msg)

--- a/controllers/webhook/webhook_suite_test.go
+++ b/controllers/webhook/webhook_suite_test.go
@@ -159,15 +159,40 @@ var _ = Describe("DSC/DSCI webhook", func() {
 		Expect(k8sClient.Create(ctx, desiredDsci)).Should(Succeed())
 		desiredDsci2 := newDSCI(nameBase + "-dsci-2")
 		Expect(k8sClient.Create(ctx, desiredDsci2)).ShouldNot(Succeed())
+		Expect(clearInstance(ctx, desiredDsci)).Should(Succeed())
 	})
 
 	It("Should block creation of second DSC instance", func(ctx context.Context) {
-		dscSpec := newDSC(nameBase+"-dsc-1", namespace)
-		Expect(k8sClient.Create(ctx, dscSpec)).Should(Succeed())
-		dscSpec = newDSC(nameBase+"-dsc-2", namespace)
-		Expect(k8sClient.Create(ctx, dscSpec)).ShouldNot(Succeed())
+		dscSpec1 := newDSC(nameBase+"-dsc-1", namespace)
+		Expect(k8sClient.Create(ctx, dscSpec1)).Should(Succeed())
+		dscSpec2 := newDSC(nameBase+"-dsc-2", namespace)
+		Expect(k8sClient.Create(ctx, dscSpec2)).ShouldNot(Succeed())
+		Expect(clearInstance(ctx, dscSpec1)).Should(Succeed())
+	})
+
+	It("Should block deletion of DSCI instance when DSC instance exist", func(ctx context.Context) {
+		dscInstance := newDSC(nameBase+"-dsc-1", namespace)
+		Expect(k8sClient.Create(ctx, dscInstance)).Should(Succeed())
+		dsciInstance := newDSCI(nameBase + "-dsci-1")
+		Expect(k8sClient.Create(ctx, dsciInstance)).Should(Succeed())
+		Expect(k8sClient.Delete(ctx, dsciInstance)).ShouldNot(Succeed())
+		Expect(clearInstance(ctx, dscInstance)).Should(Succeed())
+		Expect(clearInstance(ctx, dsciInstance)).Should(Succeed())
+	})
+
+	It("Should allow deletion of DSCI instance when DSC instance does not exist", func(ctx context.Context) {
+		dscInstance := newDSC(nameBase+"-dsc-1", namespace)
+		Expect(k8sClient.Create(ctx, dscInstance)).Should(Succeed())
+		dsciInstance := newDSCI(nameBase + "-dsci-1")
+		Expect(k8sClient.Create(ctx, dsciInstance)).Should(Succeed())
+		Expect(k8sClient.Delete(ctx, dscInstance)).Should(Succeed())
+		Expect(k8sClient.Delete(ctx, dsciInstance)).Should(Succeed())
 	})
 })
+
+func clearInstance(ctx context.Context, instance client.Object) error {
+	return k8sClient.Delete(ctx, instance)
+}
 
 func newDSCI(appName string) *dsciv1.DSCInitialization {
 	monitoringNS := "monitoring-namespace"

--- a/controllers/webhook/webhook_suite_test.go
+++ b/controllers/webhook/webhook_suite_test.go
@@ -171,7 +171,7 @@ var _ = Describe("DSC/DSCI webhook", func() {
 	})
 
 	It("Should block deletion of DSCI instance when DSC instance exist", func(ctx context.Context) {
-		dscInstance := newDSC(nameBase+"-dsc-1", namespace)
+		dscInstance := newDSC(nameBase+"-dsc-1", "webhook-test-namespace")
 		Expect(k8sClient.Create(ctx, dscInstance)).Should(Succeed())
 		dsciInstance := newDSCI(nameBase + "-dsci-1")
 		Expect(k8sClient.Create(ctx, dsciInstance)).Should(Succeed())
@@ -181,7 +181,7 @@ var _ = Describe("DSC/DSCI webhook", func() {
 	})
 
 	It("Should allow deletion of DSCI instance when DSC instance does not exist", func(ctx context.Context) {
-		dscInstance := newDSC(nameBase+"-dsc-1", namespace)
+		dscInstance := newDSC(nameBase+"-dsc-1", "webhook-test-namespace")
 		Expect(k8sClient.Create(ctx, dscInstance)).Should(Succeed())
 		dsciInstance := newDSCI(nameBase + "-dsci-1")
 		Expect(k8sClient.Create(ctx, dsciInstance)).Should(Succeed())

--- a/pkg/cluster/gvk/gvk.go
+++ b/pkg/cluster/gvk/gvk.go
@@ -9,6 +9,12 @@ var (
 		Kind:    "ClusterServiceVersion",
 	}
 
+	DataScienceCluster = schema.GroupVersionKind{
+		Group:   "datasciencecluster.opendatahub.io",
+		Version: "v1",
+		Kind:    "DataScienceCluster",
+	}
+
 	KnativeServing = schema.GroupVersionKind{
 		Group:   "operator.knative.dev",
 		Version: "v1beta1",


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->
This PR fixes a race condition that happens while uninstalling the odh-operator. The issue occurs while uninstalling, at times DSCI instance gets removed first and DSC instance hangs over with error status expecting DSCI instance to be created. Manual deletion also does not remove the hanging DSC instance. This PR address the issue by blocking the deletion of DSCI before DSC through webhooks.

JIRA issue: https://issues.redhat.com/browse/RHOAIENG-2974

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Issue was reported as a race condition. To reproduce the race condition manually, followed the below steps

- Built and deployed the operator with this code changes.
- Created DSCI and DSC instances and checked pod logs if they are fine without errors.
- Deleted DSCI instance first and checked the status of DSC to be in error status
- Manually tried to delete the DSC instance and was able to remove the instance.

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->
<img width="1512" alt="Screenshot 2024-07-03 at 1 31 21 AM" src="https://github.com/opendatahub-io/opendatahub-operator/assets/40579476/f4c4fb60-e3bf-4324-a663-aa1de9d82f3e">

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
