### PR TITLE
chore: reworks authorino istio proxy injection patch

### DIFF
--- a/pkg/feature/feature.go
+++ b/pkg/feature/feature.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/hashicorp/go-multierror"
-	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -173,31 +172,6 @@ func (f *Feature) createApplier(m Manifest) applier {
 
 func (f *Feature) addCleanup(cleanupFuncs ...Action) {
 	f.cleanups = append(f.cleanups, cleanupFuncs...)
-}
-
-func (f *Feature) ApplyManifest(ctx context.Context, path string) error {
-	m, err := loadManifestsFrom(f.fsys, path)
-	if err != nil {
-		return err
-	}
-	for i := range m {
-		var objs []*unstructured.Unstructured
-		manifest := m[i]
-		apply := f.createApplier(manifest)
-
-		if objs, err = manifest.Process(f.Spec); err != nil {
-			return errors.WithStack(err)
-		}
-
-		if f.Managed {
-			manifest.MarkAsManaged(objs)
-		}
-
-		if err = apply(ctx, objs); err != nil {
-			return errors.WithStack(err)
-		}
-	}
-	return nil
 }
 
 func (f *Feature) AsOwnerReference() metav1.OwnerReference {


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description

Instead of performing patching of Authorino deployment as part of `PostConditions` hook, it is now a `Feature` on its own.

As a result, we no longer need the `ApplyManifest` mehtod for the `Feature` struct. This function was created solely to apply a single manifest as an `Action` and was used only for this specific use case. With the dedicated feature, a deployment patch can now be defined as a regular manifest source and included as a part of the Apply phase.

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I tested both the upgrade path and regular deployment on ROSA (hence `serviceMesh.auth.audiences` entry in the DSCI below)

Prerequisite: DSCI with Service Mesh enabled

```yaml
apiVersion: dscinitialization.opendatahub.io/v1
kind: DSCInitialization
metadata:
  name: default-dsci
spec:
  applicationsNamespace: opendatahub
  monitoring:
    managementState: Removed
    namespace: opendatahub-monitoring
  trustedCABundle:
      managementState: Managed
  serviceMesh:
    managementState: Managed
    auth:
      audiences:
      - https://rh-oidc.s3.us-east-1.amazonaws.com/27bd6cg0vs7nn08mue83fbof94dj4m9a
```

### Upgrade path

- deploy the latest operator (e.g. `incubation`)
- apply DSCI
- notice Authorino deployed with istio-proxy enabled
- the following feature trackers should be persisted in the cluster

```
❯ oc get featuretrackers -o name
featuretracker.features.opendatahub.io/opendatahub-enable-proxy-injection-in-authorino-deployment
featuretracker.features.opendatahub.io/opendatahub-mesh-control-plane-creation
featuretracker.features.opendatahub.io/opendatahub-mesh-control-plane-external-authz
featuretracker.features.opendatahub.io/opendatahub-mesh-metrics-collection
featuretracker.features.opendatahub.io/opendatahub-mesh-shared-configmap
```

- deploy operator from this PR (`quay.io/maistra-dev/opendatahub-operator:dev-patch-authorino-deployment-as-a-feature`)
- trigger reconcile (e.g. change monitoring ns to some other value assuming it's in `Removed` management state)
- observe no change in the cluster setup (all resources are up-to-date), but new Feature tracker is created:

```
❯ oc get featuretrackers -o name
featuretracker.features.opendatahub.io/opendatahub-enable-proxy-injection-in-authorino-deployment
featuretracker.features.opendatahub.io/opendatahub-mesh-control-plane-creation
featuretracker.features.opendatahub.io/opendatahub-mesh-control-plane-external-authz
featuretracker.features.opendatahub.io/opendatahub-mesh-metrics-collection
featuretracker.features.opendatahub.io/opendatahub-mesh-shared-configmap
```

> [!WARNING]
> Simple removal of DSCI might trigger reconcile error for Trusted CA bundle. Needs #1095 to be merged first.

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
