### PR TITLE
fix(feature): uses server-side apply to reconile

### DIFF
--- a/pkg/feature/manifest.go
+++ b/pkg/feature/manifest.go
@@ -106,8 +106,11 @@ func markAsManaged(objs []*unstructured.Unstructured) {
 			objAnnotations = make(map[string]string)
 		}
 
-		objAnnotations[annotations.ManagedByODHOperator] = "true"
-		obj.SetAnnotations(objAnnotations)
+		// If resource already has an annotation, leave it as defined
+		if _, exists := objAnnotations[annotations.ManagedByODHOperator]; !exists {
+			objAnnotations[annotations.ManagedByODHOperator] = "true"
+			obj.SetAnnotations(objAnnotations)
+		}
 	}
 }
 
@@ -149,7 +152,7 @@ func CreateRawManifestFrom(fsys fs.FS, path string) *rawManifest {
 	return &rawManifest{
 		name:  basePath,
 		path:  path,
-		patch: strings.Contains(basePath, ".patch"),
+		patch: strings.Contains(basePath, ".patch."),
 		fsys:  fsys,
 	}
 }
@@ -170,7 +173,7 @@ func isTemplateManifest(path string) bool {
 }
 
 func convertToUnstructuredSlice(resources string) ([]*unstructured.Unstructured, error) {
-	splitter := regexp.MustCompile(YamlSeparator)
+	splitter := regexp.MustCompile(yamlResourceSeparator)
 	objectStrings := splitter.Split(resources, -1)
 	objs := make([]*unstructured.Unstructured, 0, len(objectStrings))
 	for _, str := range objectStrings {

--- a/tests/integration/features/fixtures/templates/local-gateway-svc.tmpl.yaml
+++ b/tests/integration/features/fixtures/templates/local-gateway-svc.tmpl.yaml
@@ -1,6 +1,8 @@
 apiVersion: v1
 kind: Service
 metadata:
+  annotations:
+    test-annotation: "original-value"
   labels:
     experimental.istio.io/disable-gateway-port-translation: "true"
   name: knative-local-gateway

--- a/tests/integration/features/fixtures/templates/unmanaged-svc.yaml
+++ b/tests/integration/features/fixtures/templates/unmanaged-svc.yaml
@@ -1,10 +1,10 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: managed-svc
+  name: unmanaged-svc
   namespace: "test-namespace"
   annotations:
-    opendatahub.io/managed: "true"
+    opendatahub.io/managed: "false"
     test-annotation: "original-value"
 spec:
   ports:


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
Aligns reconcile strategy for `Managed()` features to rely on Server-side apply rather than Update. The SSA approach is used by `deploy` package when reconciling kustomize resources, so keeping it the same makes sense. 

The previous one, based on `client.Update` call, tries to overwrite the entire resource rather than using a patch operation, which can lead to errors when trying to overwrite immutable fields such as:

```
failed to update object test-namespace/knative-local-gateway: Service "knative-local-gateway" is invalid: [metadata.resourceVersion: Invalid value: "": must be specified for an update, spec.clusterIP: Invalid value: "": field is immutable]
```

### Additional changes
- if "managed" annotation is present in one of the resources being part of the feature it will be respected
- reworked tests to be more self-descriptive. Extracted funcs were adding more hops while reading the code before understanding what was actually happening

## How Has This Been Tested?

In `make` we trust.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
