### PR TITLE
chore(tests): isolates resource reconcile tests

### DIFF
--- a/tests/integration/features/fixtures/templates/managed-svc.tmpl.yaml
+++ b/tests/integration/features/fixtures/templates/managed-svc.tmpl.yaml
@@ -1,10 +1,10 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: unmanaged-svc
-  namespace: "test-namespace"
+  name: managed-svc
+  namespace: {{ .TargetNamespace }}
   annotations:
-    opendatahub.io/managed: "false"
+    opendatahub.io/managed: "true"
     test-annotation: "original-value"
 spec:
   ports:

--- a/tests/integration/features/fixtures/templates/unmanaged-svc.tmpl.yaml
+++ b/tests/integration/features/fixtures/templates/unmanaged-svc.tmpl.yaml
@@ -1,10 +1,10 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: managed-svc
-  namespace: "test-namespace"
+  name: unmanaged-svc
+  namespace: {{ .TargetNamespace }}
   annotations:
-    opendatahub.io/managed: "true"
+    opendatahub.io/managed: "false"
     test-annotation: "original-value"
 spec:
   ports:

--- a/tests/integration/features/resources_int_test.go
+++ b/tests/integration/features/resources_int_test.go
@@ -34,7 +34,7 @@ var _ = Describe("Applying and updating resources", func() {
 	BeforeEach(func(ctx context.Context) {
 		objectCleaner = envtestutil.CreateCleaner(envTestClient, envTest.Config, fixtures.Timeout, fixtures.Interval)
 
-		testNamespace = "test-namespace"
+		testNamespace = envtestutil.AppendRandomNameTo("test-namespace")
 
 		var err error
 		namespace, err = cluster.CreateNamespace(ctx, envTestClient, testNamespace)
@@ -92,7 +92,7 @@ var _ = Describe("Applying and updating resources", func() {
 					UsingConfig(envTest.Config).
 					Managed().
 					ManifestsLocation(fixtures.TestEmbeddedFiles).
-					Manifests(path.Join(fixtures.BaseDir, "unmanaged-svc.yaml")).
+					Manifests(path.Join(fixtures.BaseDir, "unmanaged-svc.tmpl.yaml")).
 					Load()
 
 			})
@@ -156,7 +156,7 @@ var _ = Describe("Applying and updating resources", func() {
 					For(handler).
 					UsingConfig(envTest.Config).
 					ManifestsLocation(fixtures.TestEmbeddedFiles).
-					Manifests(path.Join(fixtures.BaseDir, "managed-svc.yaml")).
+					Manifests(path.Join(fixtures.BaseDir, "managed-svc.tmpl.yaml")).
 					Load()
 			})
 			Expect(featuresHandler.Apply(ctx)).To(Succeed())


### PR DESCRIPTION
## Description

Ensures each test case deploys resources in its own namespace to avoid sharing state between tests (sometimes unintentionally).

Follow up to #1098

## How Has This Been Tested?
`make`

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
