### PR TITLE
Improve regex to accept white spaces before delimiters(release-automation)

### DIFF
--- a/.github/scripts/get-component-release-notes.js
+++ b/.github/scripts/get-component-release-notes.js
@@ -22,9 +22,9 @@ module.exports = ({ github, core }) => {
                 let components = issueCommentBody.split("\n")
                 const releaseIdx = components.indexOf("#Release#")
                 components = components.splice(releaseIdx + 1, components.length)
-                const regex = /[A-Za-z-_0-9]+\|(https:\/\/github\.com\/.*tree.*){1}\|(https:\/\/github\.com\/.*releases.*){1}/;
+                const regex = /\s*[A-Za-z-_0-9]+\s*\|\s*(https:\/\/github\.com\/.*tree.*){1}\s*\|\s*(https:\/\/github\.com\/.*releases.*){1}\s*/;
                 components.forEach(component => {
-                    if (regex.test(component.trim())) {
+                    if (regex.test(component)) {
                         const [componentName, branchUrl, tagUrl] = component.split("|")
                         outputStr += `- **${componentName.trim().charAt(0).toUpperCase() + componentName.trim().slice(1)}**: ${tagUrl.trim()}\n`
                     }

--- a/.github/scripts/get-release-branches.js
+++ b/.github/scripts/get-release-branches.js
@@ -22,7 +22,7 @@ module.exports = ({ github, core }) => {
                 let components = issueCommentBody.split("\n")
                 const releaseIdx = components.indexOf("#Release#")
                 components = components.splice(releaseIdx + 1, components.length)
-                const regex = /[A-Za-z-_0-9]+\|(https:\/\/github\.com\/.*tree.*){1}\|(https:\/\/github\.com\/.*releases.*){1}/;
+                const regex = /\s*[A-Za-z-_0-9]+\s*\|\s*(https:\/\/github\.com\/.*tree.*){1}\s*\|\s*(https:\/\/github\.com\/.*releases.*){1}\s*/;
                 components.forEach(component => {
                     if (regex.test(component)) {
                         const [componentName, branchUrl] = component.split("|")
@@ -33,7 +33,7 @@ module.exports = ({ github, core }) => {
                             core.exportVariable("component_spec_odh-notebook-controller".toLowerCase(), branchName);
                             core.exportVariable("component_spec_kf-notebook-controller".toLowerCase(), branchName);
                         } else {
-                            core.exportVariable("component_spec_" + componentName.toLowerCase(), branchName);
+                            core.exportVariable("component_spec_" + componentName.trim().toLowerCase(), branchName);
                         }
                     }
                 })


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
Allows regex to accept whitespace before and after the delimiter '|' because when added without a whitespace github bleeds the url and makes it redirect to a malformed URL.

JIRA: https://issues.redhat.com/browse/RHOAIENG-9630

context: https://docs.google.com/document/d/1YX0zAxkl4N6-K5t4INsBqnUAxTN0GDPWV1jn9XjkgPg/edit?disco=AAABQq9SeXI

## How Has This Been Tested?
The text to test is
```
#Release#\n\ndata-science-pipelines-operator|https:
//github.com/opendatahub-io/data-science-pipelines-operator/tree/v2.0.1 |https://github.com/opendatahub-io/data-scienc
e-pipelines-operator/releases/tag/v2.0.1
```

and the code to test is https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/.github/scripts/get-release-branches.js#L22-L39 
with the modified regex from the pr.

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
