### PR TITLE
chore(feature): adds context to manifest errors

### DIFF
--- a/pkg/feature/manifest.go
+++ b/pkg/feature/manifest.go
@@ -33,19 +33,24 @@ type rawManifest struct {
 var _ Manifest = (*rawManifest)(nil)
 
 func (b *rawManifest) Process(_ any) ([]*unstructured.Unstructured, error) {
-	manifestFile, err := b.fsys.Open(b.path)
-	if err != nil {
-		return nil, err
+	manifestFile, openErr := b.fsys.Open(b.path)
+	if openErr != nil {
+		return nil, fmt.Errorf("failed opening file %s: %w", b.path, openErr)
 	}
 	defer manifestFile.Close()
 
-	content, err := io.ReadAll(manifestFile)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read file: %w", err)
+	content, readErr := io.ReadAll(manifestFile)
+	if readErr != nil {
+		return nil, fmt.Errorf("failed to read file %s: %w", b.path, readErr)
 	}
 	resources := string(content)
 
-	return convertToUnstructuredSlice(resources)
+	unstructuredObjs, convertErr := convertToUnstructuredSlice(resources)
+	if convertErr != nil {
+		return nil, fmt.Errorf("failed to convert resources defined in %s to unstructured objects: %w", b.path, convertErr)
+	}
+
+	return unstructuredObjs, nil
 }
 
 func (b *rawManifest) MarkAsManaged(objects []*unstructured.Unstructured) {
@@ -64,33 +69,38 @@ type templateManifest struct {
 }
 
 func (t *templateManifest) Process(data any) ([]*unstructured.Unstructured, error) {
-	manifestFile, err := t.fsys.Open(t.path)
-	if err != nil {
-		return nil, err
+	manifestFile, openErr := t.fsys.Open(t.path)
+	if openErr != nil {
+		return nil, fmt.Errorf("failed opening file %s: %w", t.path, openErr)
 	}
 	defer manifestFile.Close()
 
-	content, err := io.ReadAll(manifestFile)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create file: %w", err)
+	content, readErr := io.ReadAll(manifestFile)
+	if readErr != nil {
+		return nil, fmt.Errorf("failed to read file %s: %w", t.path, readErr)
 	}
 
-	tmpl, err := template.New(t.name).
+	tmpl, parseErr := template.New(t.name).
 		Option("missingkey=error").
 		Funcs(template.FuncMap{"ReplaceChar": ReplaceChar}).
 		Parse(string(content))
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse template: %w", err)
+	if parseErr != nil {
+		return nil, fmt.Errorf("failed to parse template %s: %w", t.path, parseErr)
 	}
 
 	var buffer bytes.Buffer
-	if err := tmpl.Execute(&buffer, data); err != nil {
-		return nil, fmt.Errorf("failed to execute template: %w", err)
+	if executeTmplErr := tmpl.Execute(&buffer, data); executeTmplErr != nil {
+		return nil, fmt.Errorf("failed to execute template %s: %w", t.path, executeTmplErr)
 	}
 
 	resources := buffer.String()
 
-	return convertToUnstructuredSlice(resources)
+	unstructuredObjs, convertErr := convertToUnstructuredSlice(resources)
+	if convertErr != nil {
+		return nil, fmt.Errorf("failed to convert resources defined in %s to unstructured objects: %w", t.path, convertErr)
+	}
+
+	return unstructuredObjs, nil
 }
 
 func (t *templateManifest) MarkAsManaged(objects []*unstructured.Unstructured) {


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
During the processing of the manifest files, the names of the files were not reported as part of the errors such as missing keys referred in the templates. This commit adds this context to returned errors so the problems can be located faster.

## How Has This Been Tested?

`make` - this is not a functional change, this adds more details to error messages.

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] ~Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).~
- [x] The developer has manually tested the changes and verified that the changes work
