### PR TITLE
Revert "chore: remove duplicated logic by function call (#1080)"

### DIFF
--- a/components/kserve/kserve.go
+++ b/components/kserve/kserve.go
@@ -114,7 +114,7 @@ func (k *Kserve) ReconcileComponent(ctx context.Context, cli client.Client,
 		}
 	} else {
 		// Configure dependencies
-		if err := k.configureServerless(ctx, dscispec); err != nil {
+		if err := k.configureServerless(ctx, cli, dscispec); err != nil {
 			return err
 		}
 		if k.DevFlags != nil {


### PR DESCRIPTION
This reverts commit f3e6a135cb0526b4672cdd6fb23a764d32495129.

previous cleanup removed the error from component when ossm and or authorino is not installed
which is causing DSC does not show error but keep reconcile on kserve
this is to revert the change to keep both in DSC and DSCI do the dependent check

<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

<!--- Link your JIRA and related links here for reference. -->
https://issues.redhat.com/browse/RHOAIENG-9664
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
