### PR TITLE
fix(envoy-filter): properly removes headers

### DIFF
--- a/components/kserve/resources/servicemesh/envoy-oauth-temp-fix.tmpl.yaml
+++ b/components/kserve/resources/servicemesh/envoy-oauth-temp-fix.tmpl.yaml
@@ -75,6 +75,6 @@ spec:
               local xauth = headers:get("x-authorization")
               if xauth then
                 headers:replace("authorization", xauth)
-                headers.remove("x-authorization")
+                headers:remove("x-authorization")
               end
             end

--- a/components/kserve/servicemesh_setup.go
+++ b/components/kserve/servicemesh_setup.go
@@ -43,6 +43,7 @@ func (k *Kserve) defineServiceMeshFeatures(ctx context.Context, cli client.Clien
 		if authorinoInstalled {
 			kserveExtAuthzErr := feature.CreateFeature("kserve-external-authz").
 				For(handler).
+				Managed().
 				ManifestsLocation(Resources.Location).
 				Manifests(
 					path.Join(Resources.ServiceMeshDir, "activator-envoyfilter.tmpl.yaml"),
@@ -62,6 +63,7 @@ func (k *Kserve) defineServiceMeshFeatures(ctx context.Context, cli client.Clien
 
 		temporaryFixesErr := feature.CreateFeature("kserve-temporary-fixes").
 			For(handler).
+			Managed().
 			ManifestsLocation(Resources.Location).
 			Manifests(
 				path.Join(Resources.ServiceMeshDir, "grpc-envoyfilter-temp-fix.tmpl.yaml"),

--- a/pkg/feature/builder.go
+++ b/pkg/feature/builder.go
@@ -105,8 +105,15 @@ func (fb *featureBuilder) TargetNamespace(targetNs string) *featureBuilder {
 	return fb
 }
 
-// Managed marks the feature as managed by the operator.  This effectively marks all resources which are part of this feature
-// as those that should be updated on operator reconcile.
+// Managed marks the feature as managed by the operator.
+//
+// This effectively makes all resources which are part of this feature as reconciled to the desired state
+// defined by provided manifests.
+//
+// NOTE: Although the actual instance of the resource in the cluster might have this configuration altered,
+// we intentionally do not read the management configuration from there due to the lack of clear requirements.
+// This means that management state is defined by the Feature resources provided by the operator
+// and not by the actual state of the resource.
 func (fb *featureBuilder) Managed() *featureBuilder {
 	fb.managed = true
 

--- a/tests/integration/features/fixtures/templates/local-gateway-svc.tmpl.yaml
+++ b/tests/integration/features/fixtures/templates/local-gateway-svc.tmpl.yaml
@@ -3,7 +3,6 @@ kind: Service
 metadata:
   annotations:
     test: "original-value"
-  labels:
     experimental.istio.io/disable-gateway-port-translation: "true"
   name: knative-local-gateway
   namespace: {{ .ControlPlane.Namespace }}


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description

The current implementation incorrectly calls removal of a header which is manifested in ingress gateway proxy logs when trying to access inference service:

```
envoy lua external/envoy/source/extensions/filters/http/lua/lua_filter.cc:930  script log: [string "function envoy_on_request(request_handle)..."]:10: bad argument #1 to 'remove' (N5Envoy10Extensions11HttpFilters3Lua16HeaderMapWrapperE expected, got string`
```

This fixes the Lua syntax and marks Service Mesh Features related to KServe setup as `Managed()`. This ensures that updating the existing filters will happen on operator upgrade or next reconcile.

## How Has This Been Tested?

- deploy latest `incubation` operator
- create DSCI with Service Mesh enabled
- create DSC with KServe enabled
- check the content of the filter `oc get envoyfilter/envoy-oauth-temp-fix-after  -n istio-system -o yaml`. Notice wrong syntax `.remove` in Lua snippet
- try accessing ISVC and notice error in the ingress gateway logs
- deploy operator image based on this PR
- confirm logs are not showing up on the ingress gateway proxy
- check the content of the filter `oc get envoyfilter/envoy-oauth-temp-fix-after  -n istio-system -o yaml`. Notice correct/patched syntax `:remove` in Lua snippet

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
