### PR TITLE
chore(lint): skips true|false for goconst

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -15,6 +15,8 @@ linters-settings:
       - dot
     skip-generated: false
     custom-order: true
+  goconst:
+    ignore-strings: "true|false"
   errcheck:
     check-type-assertions: true
   exhaustive:


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description

As we have labels and annotations with values either `true` or `false` we often compare them in the code. This leads to complains of `goconst` linter about extracting these "magic words" to constants. As this are obvious values to check against there's little benefit of doing so.

This change configures `goconst` for golangci-lint runner to skip such cases.

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] ~Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).~
- [x] The developer has manually tested the changes and verified that the changes work
