### PR TITLE
refactor: moves conversion to unstr to dedicated package

### DIFF
--- a/pkg/conversion/conversion.go
+++ b/pkg/conversion/conversion.go
@@ -1,0 +1,52 @@
+package conversion
+
+import (
+	"regexp"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/kustomize/api/resmap"
+	"sigs.k8s.io/yaml"
+)
+
+const (
+	resourceSeparator = "(?m)^---[ \t]*$"
+)
+
+// StrToUnstructured converts a string containing multiple resources in YAML format to a slice of Unstructured objects.
+// The input string is split by "---" separator and each part is unmarshalled into an Unstructured object.
+func StrToUnstructured(resources string) ([]*unstructured.Unstructured, error) {
+	splitter := regexp.MustCompile(resourceSeparator)
+	objectStrings := splitter.Split(resources, -1)
+	objs := make([]*unstructured.Unstructured, 0, len(objectStrings))
+	for _, str := range objectStrings {
+		if strings.TrimSpace(str) == "" {
+			continue
+		}
+		u := &unstructured.Unstructured{}
+		if err := yaml.Unmarshal([]byte(str), u); err != nil {
+			return nil, err
+		}
+
+		objs = append(objs, u)
+	}
+	return objs, nil
+}
+
+// ResMapToUnstructured converts a ResMap to a slice of Unstructured objects.
+func ResMapToUnstructured(resMap resmap.ResMap) ([]*unstructured.Unstructured, error) {
+	resources := make([]*unstructured.Unstructured, 0, resMap.Size())
+	for _, res := range resMap.Resources() {
+		u := &unstructured.Unstructured{}
+		asYAML, errToYAML := res.AsYAML()
+		if errToYAML != nil {
+			return nil, errToYAML
+		}
+		if errUnmarshal := yaml.Unmarshal(asYAML, u); errUnmarshal != nil {
+			return nil, errUnmarshal
+		}
+		resources = append(resources, u)
+	}
+
+	return resources, nil
+}

--- a/pkg/feature/raw_resources.go
+++ b/pkg/feature/raw_resources.go
@@ -26,10 +26,6 @@ import (
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/metadata/annotations"
 )
 
-const (
-	yamlResourceSeparator = "(?m)^---[ \t]*$"
-)
-
 func applyResources(ctx context.Context, cli client.Client, objects []*unstructured.Unstructured, metaOptions ...cluster.MetaOptions) error {
 	for _, source := range objects {
 		target := source.DeepCopy()


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
We rely on conversion to Unstructured resources in quite a few places in the code base. With the introduction of a dedicated pkg, we can keep those functions together and reuse them across the code base.

> [!IMPORTANT]
> While converting Kustomize `ResMap` we do not use `MustYaml` func anymore, as this one panics. We attempt to convert to YAML and handle the error instead.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
