### PR TITLE
feat(cluster): add roles and role bindings management

### DIFF
--- a/pkg/cluster/roles.go
+++ b/pkg/cluster/roles.go
@@ -1,0 +1,89 @@
+package cluster
+
+import (
+	"context"
+
+	rbacv1 "k8s.io/api/rbac/v1"
+	k8serr "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// CreateOrUpdateClusterRole creates cluster role based on define PolicyRules and optional metadata fields and updates the rules if it already exists.
+func CreateOrUpdateClusterRole(ctx context.Context, cli client.Client, name string, rules []rbacv1.PolicyRule, metaOptions ...MetaOptions) (*rbacv1.ClusterRole, error) {
+	desiredClusterRole := &rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Rules: rules,
+	}
+
+	if err := ApplyMetaOptions(desiredClusterRole, metaOptions...); err != nil {
+		return nil, err
+	}
+
+	foundClusterRole := &rbacv1.ClusterRole{}
+	err := cli.Get(ctx, client.ObjectKey{Name: desiredClusterRole.GetName()}, foundClusterRole)
+	if k8serr.IsNotFound(err) {
+		return desiredClusterRole, cli.Create(ctx, desiredClusterRole)
+	}
+
+	if err := ApplyMetaOptions(foundClusterRole, metaOptions...); err != nil {
+		return nil, err
+	}
+	foundClusterRole.Rules = rules
+
+	return foundClusterRole, cli.Update(ctx, foundClusterRole)
+}
+
+// DeleteClusterRole simply calls delete on a ClusterRole with the given name. Any error is returned. Check for IsNotFound.
+func DeleteClusterRole(ctx context.Context, cli client.Client, name string) error {
+	desiredClusterRole := &rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+	}
+	return cli.Delete(ctx, desiredClusterRole)
+}
+
+// CreateOrUpdateClusterRoleBinding creates cluster role bindings based on define PolicyRules and optional metadata fields and updates the bindings if it already exists.
+func CreateOrUpdateClusterRoleBinding(ctx context.Context, cli client.Client, name string,
+	subjects []rbacv1.Subject, roleRef rbacv1.RoleRef,
+	metaOptions ...MetaOptions) (*rbacv1.ClusterRoleBinding, error) {
+	desiredClusterRoleBinding := &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Subjects: subjects,
+		RoleRef:  roleRef,
+	}
+
+	if err := ApplyMetaOptions(desiredClusterRoleBinding, metaOptions...); err != nil {
+		return nil, err
+	}
+
+	foundClusterRoleBinding := &rbacv1.ClusterRoleBinding{}
+	err := cli.Get(ctx, client.ObjectKey{Name: desiredClusterRoleBinding.GetName()}, foundClusterRoleBinding)
+	if k8serr.IsNotFound(err) {
+		return desiredClusterRoleBinding, cli.Create(ctx, desiredClusterRoleBinding)
+	}
+
+	if err := ApplyMetaOptions(foundClusterRoleBinding, metaOptions...); err != nil {
+		return nil, err
+	}
+	foundClusterRoleBinding.Subjects = subjects
+	foundClusterRoleBinding.RoleRef = roleRef
+
+	return foundClusterRoleBinding, cli.Update(ctx, foundClusterRoleBinding)
+}
+
+// DeleteClusterRoleBinding simply calls delete on a ClusterRoleBinding with the given name. Any error is returned. Check for IsNotFound.
+func DeleteClusterRoleBinding(ctx context.Context, cli client.Client, name string) error {
+	desiredClusterRoleBinding := &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+	}
+
+	return cli.Delete(ctx, desiredClusterRoleBinding)
+}


### PR DESCRIPTION
## Description

Introduces functions to create, update, and delete ClusterRoles and ClusterRoleBindings.

This is part of Authorization capability work provided as stacked PR. We simply want to avoid humongous PR like 605 and have focused review instead.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] ~Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).~
- [x] The developer has manually tested the changes and verified that the changes work
