### PR TITLE
Fix: Return if DSC already exists

### DIFF
--- a/pkg/cluster/resources.go
+++ b/pkg/cluster/resources.go
@@ -184,7 +184,7 @@ func CreateWithRetry(ctx context.Context, cli client.Client, obj client.Object, 
 	return wait.PollUntilContextTimeout(ctx, interval, timeout, true, func(ctx context.Context) (bool, error) {
 		err := cli.Create(ctx, obj)
 		if err != nil {
-			return false, nil //nolint:nilerr
+			return false, err
 		}
 		return true, nil
 	})


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
Jira Issue: https://issues.redhat.com/browse/RHOAIENG-9753

**Root Cause:**
[Commit](https://github.com/opendatahub-io/opendatahub-operator/pull/1041/files#diff-1c2bd1d24587a4323e59931edaa538b2d6538fbd63dad45ea40ef8d1d9bbd939R105 ) introduced a change that failed to identify already existing DSC in Managed clusters.

This change fixes above issue and has been tested on Managed cluster


Operator Error
```
{"level":"error","ts":"2024-07-11T21:42:46Z","logger":"setup","msg":"unable to create default DSC CR by the operator","error":"failed to create DataScienceCluster custom resource: context deadline exceeded","stacktrace":"main.main.func2\n\t/workspace/main.go:245\nsigs.k8s.io/controller-runtime/pkg/manager.RunnableFunc.Start\n\t/opt/app-root/src/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.14.6/pkg/manager/manager.go:336\nsigs.k8s.io/controller-runtime/pkg/manager.(*runnableGroup).reconcile.func1\n\t/opt/app-root/src/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.14.6/pkg/manager/runnable_group.go:219"}
{"level":"info","ts":"2024-07-11T21:42:46Z","msg":"Stopping and waiting for non leader election runnables"}
{"level":"info","ts":"2024-07-11T21:42:46Z","msg":"Stopping and waiting for leader election runnables"}
```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
