### PR TITLE
fix: should create CRB not RB + add ControlledBy() for MetaOptions

### DIFF
--- a/components/dashboard/dashboard.go
+++ b/components/dashboard/dashboard.go
@@ -103,11 +103,11 @@ func (d *Dashboard) ReconcileComponent(ctx context.Context,
 
 		// 2. platform specific RBAC
 		if platform == cluster.OpenDataHub || platform == "" {
-			if err := cluster.UpdatePodSecurityRolebinding(ctx, cli, dscispec.ApplicationsNamespace, "odh-dashboard"); err != nil {
+			if err := cluster.UpdatePodSecurityClusterRolebinding(ctx, cli, dscispec.ApplicationsNamespace, "odh-dashboard"); err != nil {
 				return err
 			}
 		} else {
-			if err := cluster.UpdatePodSecurityRolebinding(ctx, cli, dscispec.ApplicationsNamespace, "rhods-dashboard"); err != nil {
+			if err := cluster.UpdatePodSecurityClusterRolebinding(ctx, cli, dscispec.ApplicationsNamespace, "rhods-dashboard"); err != nil {
 				return err
 			}
 		}

--- a/components/kserve/kserve.go
+++ b/components/kserve/kserve.go
@@ -148,7 +148,7 @@ func (k *Kserve) ReconcileComponent(ctx context.Context, cli client.Client,
 		}
 
 		// For odh-model-controller
-		if err := cluster.UpdatePodSecurityRolebinding(ctx, cli, dscispec.ApplicationsNamespace, "odh-model-controller"); err != nil {
+		if err := cluster.UpdatePodSecurityClusterRolebinding(ctx, cli, dscispec.ApplicationsNamespace, "odh-model-controller"); err != nil {
 			return err
 		}
 		// Update image parameters for odh-model-controller

--- a/components/modelmeshserving/modelmeshserving.go
+++ b/components/modelmeshserving/modelmeshserving.go
@@ -105,7 +105,7 @@ func (m *ModelMeshServing) ReconcileComponent(ctx context.Context,
 			}
 		}
 
-		if err := cluster.UpdatePodSecurityRolebinding(ctx, cli, dscispec.ApplicationsNamespace,
+		if err := cluster.UpdatePodSecurityClusterRolebinding(ctx, cli, dscispec.ApplicationsNamespace,
 			"modelmesh",
 			"modelmesh-controller",
 			"odh-prometheus-operator",
@@ -126,7 +126,7 @@ func (m *ModelMeshServing) ReconcileComponent(ctx context.Context,
 	l.WithValues("Path", Path).Info("apply manifests done for modelmesh")
 	// For odh-model-controller
 	if enabled {
-		if err := cluster.UpdatePodSecurityRolebinding(ctx, cli, dscispec.ApplicationsNamespace,
+		if err := cluster.UpdatePodSecurityClusterRolebinding(ctx, cli, dscispec.ApplicationsNamespace,
 			"odh-model-controller"); err != nil {
 			return err
 		}

--- a/components/workbenches/workbenches.go
+++ b/components/workbenches/workbenches.go
@@ -126,7 +126,7 @@ func (w *Workbenches) ReconcileComponent(ctx context.Context, cli client.Client,
 			}
 		}
 		// Update Default rolebinding
-		err := cluster.UpdatePodSecurityRolebinding(ctx, cli, dscispec.ApplicationsNamespace, "notebook-controller-service-account")
+		err := cluster.UpdatePodSecurityClusterRolebinding(ctx, cli, dscispec.ApplicationsNamespace, "notebook-controller-service-account")
 		if err != nil {
 			return err
 		}

--- a/controllers/dscinitialization/dscinitialization_test.go
+++ b/controllers/dscinitialization/dscinitialization_test.go
@@ -69,10 +69,10 @@ var _ = Describe("DataScienceCluster initialization", func() {
 			Expect(foundNetworkPolicy.Spec.PolicyTypes[0]).To(Equal(networkingv1.PolicyTypeIngress))
 		})
 
-		It("Should create default rolebinding", func(ctx context.Context) {
+		It("Should create default clusterrolebinding", func(ctx context.Context) {
 			// then
-			foundRoleBinding := &rbacv1.RoleBinding{}
-			Eventually(objectExists(applicationNamespace, applicationNamespace, foundRoleBinding)).
+			foundClusterRoleBinding := &rbacv1.ClusterRoleBinding{}
+			Eventually(objectExists(applicationNamespace, applicationNamespace, foundClusterRoleBinding)).
 				WithContext(ctx).
 				WithTimeout(timeout).
 				WithPolling(interval).
@@ -89,10 +89,9 @@ var _ = Describe("DataScienceCluster initialization", func() {
 				Kind:     "ClusterRole",
 				Name:     "system:openshift:scc:anyuid",
 			}
-			Expect(foundRoleBinding.Name).To(Equal(applicationNamespace))
-			Expect(foundRoleBinding.Namespace).To(Equal(applicationNamespace))
-			Expect(foundRoleBinding.Subjects).To(Equal(expectedSubjects))
-			Expect(foundRoleBinding.RoleRef).To(Equal(expectedRoleRef))
+			Expect(foundClusterRoleBinding.Name).To(Equal(applicationNamespace))
+			Expect(foundClusterRoleBinding.Subjects).To(Equal(expectedSubjects))
+			Expect(foundClusterRoleBinding.RoleRef).To(Equal(expectedRoleRef))
 		})
 
 		It("Should create default configmap", func(ctx context.Context) {

--- a/controllers/dscinitialization/monitoring.go
+++ b/controllers/dscinitialization/monitoring.go
@@ -77,7 +77,7 @@ func (r *DSCInitializationReconciler) configureManagedMonitoring(ctx context.Con
 	}
 
 	if initial == "init" {
-		err := cluster.UpdatePodSecurityRolebinding(ctx, r.Client, dscInit.Spec.Monitoring.Namespace, "redhat-ods-monitoring")
+		err := cluster.UpdatePodSecurityClusterRolebinding(ctx, r.Client, dscInit.Spec.Monitoring.Namespace, "redhat-ods-monitoring")
 		if err != nil {
 			return fmt.Errorf("error to update monitoring security rolebinding: %w", err)
 		}

--- a/controllers/dscinitialization/monitoring.go
+++ b/controllers/dscinitialization/monitoring.go
@@ -13,8 +13,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	controllerutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	dsciv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/dscinitialization/v1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
@@ -418,7 +418,7 @@ func createMonitoringProxySecret(ctx context.Context, cli client.Client, name st
 	if err != nil {
 		if k8serr.IsNotFound(err) {
 			// Set Controller reference
-			err = ctrl.SetControllerReference(dsciInit, desiredProxySecret, cli.Scheme())
+			err = controllerutil.SetControllerReference(dsciInit, desiredProxySecret, cli.Scheme())
 			if err != nil {
 				return err
 			}

--- a/controllers/dscinitialization/utils.go
+++ b/controllers/dscinitialization/utils.go
@@ -131,7 +131,7 @@ func (r *DSCInitializationReconciler) createOdhNamespace(ctx context.Context, ds
 		return err
 	}
 
-	// Create/update Rolebinding connects "default" SA and anyuid ClusterRole in namespace
+	// Create/update ClusterRolebinding connects "default" SA and anyuid ClusterRole in namespace
 	// ensure it has dsci CR as controller reference
 	if _, err = cluster.CreateOrUpdateClusterRoleBinding(
 		ctx, r.Client, name,

--- a/pkg/cluster/meta.go
+++ b/pkg/cluster/meta.go
@@ -29,6 +29,12 @@ func WithOwnerReference(ownerReferences ...metav1.OwnerReference) MetaOptions {
 	}
 }
 
+func ControlledBy(owner metav1.Object, scheme *runtime.Scheme) MetaOptions {
+	return func(obj metav1.Object) error {
+		return controllerutil.SetControllerReference(owner, obj, scheme)
+	}
+}
+
 func OwnedBy(owner metav1.Object, scheme *runtime.Scheme) MetaOptions {
 	return func(obj metav1.Object) error {
 		return controllerutil.SetOwnerReference(owner, obj, scheme)

--- a/pkg/cluster/resources.go
+++ b/pkg/cluster/resources.go
@@ -17,18 +17,18 @@ import (
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/metadata/labels"
 )
 
-// UpdatePodSecurityRolebinding update default rolebinding which is created in applications namespace by manifests
+// UpdatePodSecurityClusterRolebinding update default clusterrolebinding which is created in applications namespace by manifests
 // being used by different components and SRE monitoring.
-func UpdatePodSecurityRolebinding(ctx context.Context, cli client.Client, namespace string, serviceAccountsList ...string) error {
-	foundRoleBinding := &rbacv1.RoleBinding{}
-	if err := cli.Get(ctx, client.ObjectKey{Name: namespace, Namespace: namespace}, foundRoleBinding); err != nil {
-		return fmt.Errorf("error to get rolebinding %s from namespace %s: %w", namespace, namespace, err)
+func UpdatePodSecurityClusterRolebinding(ctx context.Context, cli client.Client, namespace string, serviceAccountsList ...string) error {
+	foundClusterRoleBinding := &rbacv1.ClusterRoleBinding{}
+	if err := cli.Get(ctx, client.ObjectKey{Name: namespace, Namespace: namespace}, foundClusterRoleBinding); err != nil {
+		return fmt.Errorf("error to get clusterrolebinding %s from namespace %s: %w", namespace, namespace, err)
 	}
 
 	for _, sa := range serviceAccountsList {
 		// Append serviceAccount if not added already
-		if !subjectExistInRoleBinding(foundRoleBinding.Subjects, sa, namespace) {
-			foundRoleBinding.Subjects = append(foundRoleBinding.Subjects, rbacv1.Subject{
+		if !subjectExistInRoleBinding(foundClusterRoleBinding.Subjects, sa, namespace) {
+			foundClusterRoleBinding.Subjects = append(foundClusterRoleBinding.Subjects, rbacv1.Subject{
 				Kind:      rbacv1.ServiceAccountKind,
 				Name:      sa,
 				Namespace: namespace,
@@ -36,7 +36,7 @@ func UpdatePodSecurityRolebinding(ctx context.Context, cli client.Client, namesp
 		}
 	}
 
-	if err := cli.Update(ctx, foundRoleBinding); err != nil {
+	if err := cli.Update(ctx, foundClusterRoleBinding); err != nil {
 		return fmt.Errorf("error update rolebinding %s with serviceaccount: %w", namespace, err)
 	}
 

--- a/pkg/deploy/deploy.go
+++ b/pkg/deploy/deploy.go
@@ -37,8 +37,8 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	controllerutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/kustomize/api/krusty"
 	"sigs.k8s.io/kustomize/api/resmap"
 	"sigs.k8s.io/kustomize/api/resource"
@@ -279,7 +279,7 @@ func createResource(ctx context.Context, cli client.Client, res *resource.Resour
 		return err
 	}
 	if obj.GetKind() != "CustomResourceDefinition" && obj.GetKind() != "OdhDashboardConfig" {
-		if err := ctrl.SetControllerReference(owner, metav1.Object(obj), cli.Scheme()); err != nil {
+		if err := controllerutil.SetControllerReference(owner, metav1.Object(obj), cli.Scheme()); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
- fix resource type: it should be a clusterrolebinding than a rolebiding, if roleref is set to clusterrole not role. 
- replace createDefaultRoleBinding() with CreateOrUpdateClusterRoleBinding()
- ref package from ctrl to controllerutil
- update testcase

<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
local build: quay.io/wenzhou/opendatahub-operator-catalog:v2.14.77-715

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
