### PR TITLE
(chore): Fix the token expiry and move release version update code to a composite action.

### DIFF
--- a/.github/actions/update-release-version/action.yaml
+++ b/.github/actions/update-release-version/action.yaml
@@ -1,0 +1,50 @@
+name: "Update release versions and create pr"
+description: "Update versions in the manifests/makefile and create a pr"
+inputs:
+  version:
+    description: 'The release version'
+    required: true
+  token:
+    description: "GH token with required rights to create pr"
+    required: true
+  commit-message:
+    description: "Commit message for the pr"
+    required: true
+  title:
+    description: "Title for the pr"
+    required: true
+  branch-name:
+    description: "Temporary branch to host the changes"
+    required: true
+outputs:
+  pull-request-number:
+    description: "Number of the pull request created"
+    value: ${{ steps.cpr.outputs.pull-request-number }}
+runs:
+  using: "composite"
+  steps:
+    - name: Update versions in relevant files
+      shell: bash
+      run: ./.github/scripts/update-versions.sh ${{ inputs.version }}
+    - name: Run make manifests & bundle
+      shell: bash
+      run: make manifests bundle
+    - name: Clean up
+      shell: bash
+      run: |
+        sed -i -e "s|image: quay.io/opendatahub/opendatahub-operator:latest.*|image: REPLACE_IMAGE:latest|g" bundle/manifests/opendatahub-operator.clusterserviceversion.yaml
+        rm ./config/manager/kustomization.yaml
+    - name: Create pr
+      id: cpr
+      uses: peter-evans/create-pull-request@v6
+      with:
+        token: ${{ inputs.token }}
+        commit-message: ${{ inputs.commit-message }}
+        branch: ${{ inputs.branch-name }}
+        delete-branch: true
+        title: ${{ inputs.title }}
+        reviewers: "VaishnaviHire,zdtsw"
+    - name: Set pr number in output
+      shell: bash
+      run: |
+        echo "pull-request-number=${{ steps.cpr.outputs.pull-request-number }}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/pre-release.yaml
+++ b/.github/workflows/pre-release.yaml
@@ -4,12 +4,16 @@ on:
     inputs:
       version:
         type: string
-        description: The version to update.
+        description: The version to update(https://semver.org/).
         required: true
       tracker-url:
         type: string
-        description: The URL to tracker issue.
+        description: The URL to tracker issue(https://github.com/opendatahub-io/opendatahub-community/issues).
         required: true
+permissions:
+  checks: read
+  pull-requests: write
+  contents: write
 env:
   VERSION: ${{ inputs.version }}
   TRACKER_URL: ${{ inputs.tracker-url }}
@@ -19,11 +23,6 @@ jobs:
     name: Create dry-run pr and update tags
     steps:
       - uses: actions/checkout@v4
-      - uses: tibdex/github-app-token@v1
-        id: generate-token
-        with:
-          app_id: ${{ secrets.ODH_RELEASE_APP_ID }}
-          private_key: ${{ secrets.ODH_RELEASE_APP_PRIVATE_KEY }}
       - name: Validate semver
         run: ./.github/scripts/validate-semver.sh v${{ env.VERSION }}
       - uses: ./.github/actions/update-manifest-branches
@@ -31,19 +30,19 @@ jobs:
         uses: peter-evans/create-pull-request@v6
         id: cpr-dry-run
         with:
-          token: ${{ steps.generate-token.outputs.token }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: "Test ${{ env.VERSION }} Release"
           branch: odh-release/e2e-dry-run
           delete-branch: true
           title: "[DO NOT MERGE] Test ${{ env.VERSION }} Release"
       - name: Wait for checks to pass
         env:
-          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: ./.github/scripts/wait-for-checks.sh ${{ steps.cpr-dry-run.outputs.pull-request-number }}
       - name: Close PR
         uses: peter-evans/close-pull@v3
         with:
-          token: ${{ steps.generate-token.outputs.token }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           pull-request-number: ${{ steps.cpr-dry-run.outputs.pull-request-number }}
           comment: Auto-closing pull request after success checks
           delete-branch: true
@@ -58,37 +57,31 @@ jobs:
     name: Create version update pr
     steps:
       - uses: actions/checkout@v4
-      - uses: tibdex/github-app-token@v1
-        id: generate-token
+      - name: Create version update pr in incubation
+        uses: ./.github/actions/update-release-version
         with:
-          app_id: ${{ secrets.ODH_RELEASE_APP_ID }}
-          private_key: ${{ secrets.ODH_RELEASE_APP_PRIVATE_KEY }}
+          version: ${{ inputs.version }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "Update version to ${{ env.VERSION }}"
+          title: "Update version to ${{ env.VERSION }}"
+          branch-name: "odh-release/version-update"
       - name: Create release branch
         run: |
           git checkout -b odh-${{ env.VERSION }}
           git push -f origin odh-${{ env.VERSION }}
       - uses: ./.github/actions/update-manifest-branches
-      - name: Update versions in relevant files
-        run: ./.github/scripts/update-versions.sh ${{ env.VERSION }}
-      - name: Run make manifests & bundle
-        run: make manifests bundle
-      - name: Clean up
-        run: |
-          sed -i -e "s|image: quay.io/opendatahub/opendatahub-operator:latest.*|image: REPLACE_IMAGE:latest|g" bundle/manifests/opendatahub-operator.clusterserviceversion.yaml
-          rm ./config/manager/kustomization.yaml
-      - name: Create release pr
-        uses: peter-evans/create-pull-request@v6
+      - name: Create release pr in release branch
+        uses: ./.github/actions/update-release-version
         id: cpr-release-pr
         with:
-          token: ${{ steps.generate-token.outputs.token }}
+          version: ${{ inputs.version }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: "ODH Release ${{ env.VERSION }}"
-          branch: odh-release/version-update
-          delete-branch: true
           title: "ODH Release ${{ env.VERSION }}: Version Update"
-          reviewers: "VaishnaviHire,zdtsw"
+          branch-name: "odh-release/release-branch-update"
       - name: Wait for checks to pass
         env:
-          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: ./.github/scripts/wait-for-checks.sh ${{ steps.cpr-release-pr.outputs.pull-request-number }}
       - name: Comment version and tracker url in the pr
         uses: thollander/actions-comment-pull-request@v2

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,17 +3,16 @@ on:
   pull_request:
     types:
       - closed
+permissions:
+  checks: read
+  pull-requests: write
+  contents: write
 jobs:
   gh-release:
     if: github.event.pull_request.merged && startsWith(github.event.pull_request.title, 'ODH Release') && endsWith(github.event.pull_request.title, 'Version Update')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: tibdex/github-app-token@v1
-        id: generate-token
-        with:
-          app_id: ${{ secrets.ODH_RELEASE_APP_ID }}
-          private_key: ${{ secrets.ODH_RELEASE_APP_PRIVATE_KEY }}
       - name: Get release data from pr
         uses: peter-evans/find-comment@v3
         id: fc


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
Token expiry fix:
The installation token generated through the GH app has a validity of 1 hour. ref: https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/generating-an-installation-access-token-for-a-github-app So the issue is, when waiting for e2e tests(github checks) which runs for more than 1 hr to finish, the token gets expired and then the gh action is no longer able to do other tasks(such as creating a pr)
In order to fix this, we can use the GITHUB_TOKEN that is generated for each workflow. ref: https://docs.github.com/en/actions/security-guides/automatic-token-authentication#about-the-github_token-secret The GITHUB_TOKEN expires when a job finishes or after a maximum of 24 hours.

Move version update to composite action:
There are 2 sets of steps in the job that does almost the same task. Instead of duplicating the steps, move it to a composite action and reuse the same.

<!--- Link your JIRA and related links here for reference. -->
JIRA: https://issues.redhat.com/browse/RHOAIENG-10059

## How Has This Been Tested?
Both release actions were able to run successfully in my local:
1. https://github.com/AjayJagan/opendatahub-operator/actions/runs/9993405670
2. https://github.com/AjayJagan/opendatahub-operator/actions/runs/9993447302


- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
