### PR TITLE
RHOAIENG-9751: Update release.name from DSC and DSCI in ODH

### DIFF
--- a/pkg/cluster/const.go
+++ b/pkg/cluster/const.go
@@ -6,7 +6,7 @@ const (
 	// SelfManagedRhods defines display name in csv.
 	SelfManagedRhods Platform = "OpenShift AI Self-Managed"
 	// OpenDataHub defines display name in csv.
-	OpenDataHub Platform = "Open Data Hub Operator"
+	OpenDataHub Platform = "Open Data Hub"
 	// Unknown indicates that operator is not deployed using OLM.
 	Unknown Platform = ""
 )


### PR DESCRIPTION
## Description
This PR amends the release.name for ODH csv.
Related JIRA: https://issues.redhat.com/browse/RHOAIENG-9751

## How Has This Been Tested?
Installing manually the ODH operator in a cluster and check that Open Data Hub is shown in the release.name field


- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
