### PR TITLE
chore: remove UPDATE from webhook operation list

### DIFF
--- a/bundle/manifests/opendatahub-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/opendatahub-operator.clusterserviceversion.yaml
@@ -1811,7 +1811,6 @@ spec:
       - v1
       operations:
       - CREATE
-      - UPDATE
       - DELETE
       resources:
       - datascienceclusters

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -22,7 +22,6 @@ webhooks:
     - v1
     operations:
     - CREATE
-    - UPDATE
     - DELETE
     resources:
     - datascienceclusters

--- a/controllers/webhook/webhook.go
+++ b/controllers/webhook/webhook.go
@@ -121,10 +121,12 @@ func (w *OpenDataHubWebhook) Handle(ctx context.Context, req admission.Request) 
 		resp = w.checkDupCreation(ctx, req)
 	case admissionv1.Delete:
 		resp = w.checkDeletion(ctx, req)
+	case admissionv1.Update:
+		return admission.Allowed("")
 	default:
-		msg := fmt.Sprintf("No logic check by webhook is applied on %v request", req.Operation)
+		msg := fmt.Sprintf("No logic check by webhook is applied on %v request: allowed", req.Operation)
 		log.Info(msg)
-		resp = admission.Allowed("")
+		return admission.Allowed("")
 	}
 
 	if !resp.Allowed {

--- a/controllers/webhook/webhook.go
+++ b/controllers/webhook/webhook.go
@@ -34,7 +34,7 @@ import (
 
 var log = ctrl.Log.WithName("odh-controller-webhook")
 
-//+kubebuilder:webhook:path=/validate-opendatahub-io-v1,mutating=false,failurePolicy=fail,sideEffects=None,groups=datasciencecluster.opendatahub.io;dscinitialization.opendatahub.io,resources=datascienceclusters;dscinitializations,verbs=create;update;delete,versions=v1,name=operator.opendatahub.io,admissionReviewVersions=v1
+//+kubebuilder:webhook:path=/validate-opendatahub-io-v1,mutating=false,failurePolicy=fail,sideEffects=None,groups=datasciencecluster.opendatahub.io;dscinitialization.opendatahub.io,resources=datascienceclusters;dscinitializations,verbs=create;delete,versions=v1,name=operator.opendatahub.io,admissionReviewVersions=v1
 //nolint:lll
 
 type OpenDataHubWebhook struct {
@@ -115,20 +115,16 @@ func (w *OpenDataHubWebhook) checkDeletion(ctx context.Context, req admission.Re
 
 func (w *OpenDataHubWebhook) Handle(ctx context.Context, req admission.Request) admission.Response {
 	var resp admission.Response
+	resp.Allowed = true // initialize Allowed to be true in case Operation falls into "default" case
 
 	switch req.Operation {
 	case admissionv1.Create:
 		resp = w.checkDupCreation(ctx, req)
 	case admissionv1.Delete:
 		resp = w.checkDeletion(ctx, req)
-	case admissionv1.Update:
-		return admission.Allowed("")
-	default:
-		msg := fmt.Sprintf("No logic check by webhook is applied on %v request: allowed", req.Operation)
-		log.Info(msg)
-		return admission.Allowed("")
+	default: // for other operations by default it is admission.Allowed("")
+		// no-op
 	}
-
 	if !resp.Allowed {
 		return resp
 	}


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->
alot in logs from Operator Pod on operator of UPDATE:
`{"level":"info","ts":"2024-07-23T14:01:16Z","logger":"odh-controller-webhook","msg":"No logic check by webhook is applied on UPDATE request"}` this is confusing users.
- the changes is to remove this message from pod by not filter on Update operation.

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
`make unit-test`

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
