### PR TITLE
fix: authz patch injection feature precondition uses correct namespace value

### DIFF
--- a/controllers/dscinitialization/servicemesh_setup.go
+++ b/controllers/dscinitialization/servicemesh_setup.go
@@ -219,7 +219,12 @@ func (r *DSCInitializationReconciler) authorizationFeatures(instance *dsciv1.DSC
 				).
 				PreConditions(
 					func(ctx context.Context, f *feature.Feature) error {
-						return feature.WaitForPodsToBeReady(serviceMeshSpec.Auth.Namespace)(ctx, f)
+						namespace, err := servicemesh.FeatureData.Authorization.Namespace.Extract(f)
+						if err != nil {
+							return err
+						}
+
+						return feature.WaitForPodsToBeReady(namespace)(ctx, f)
 					},
 				).
 				WithData(servicemesh.FeatureData.ControlPlane.Define(&instance.Spec).AsAction()).

--- a/controllers/dscinitialization/servicemesh_setup.go
+++ b/controllers/dscinitialization/servicemesh_setup.go
@@ -221,7 +221,7 @@ func (r *DSCInitializationReconciler) authorizationFeatures(instance *dsciv1.DSC
 					func(ctx context.Context, f *feature.Feature) error {
 						namespace, err := servicemesh.FeatureData.Authorization.Namespace.Extract(f)
 						if err != nil {
-							return err
+							return fmt.Errorf("failed trying to resolve authorization provider namespace for feature '%s': %w", f.Name, err)
 						}
 
 						return feature.WaitForPodsToBeReady(namespace)(ctx, f)


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description

If the authorization provider namespace is not specified in the DSCI the default is constructed to be `application-namespace-auth-provider`, e.g. `opendatahub-auth-provider`.

With the #1052 refactoring, the regression has been introduced where the value is directly read from the spec instead of being dynamically constructed based on the rule described above.

This is manifested with the following error, as the feature mistakenly waits for pods across all namespaces (because of list option for namespace being `corev1.NamespaceAll == ""`). This obviously rarely is true, especially for large clusters.

```json
Failed applying [enable-proxy-injection-in-authorino-deployment]: 1 error occurred:
* client rate limiter Wait returned an error: context deadline exceeded
```

leading to failure of reconciling this feature.

The fix is to read the namespace from `FeatureData` instead, where the defaulting logic is defined.

Fixes https://issues.redhat.com/browse/RHOAIENG-10268


<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?

- create DSCI with service mesh enabled
- see all features applied correctly instead of erroring

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
