### PR TITLE
docs(api): set manifestUri as deprecated

### DIFF
--- a/apis/dscinitialization/v1/dscinitialization_types.go
+++ b/apis/dscinitialization/v1/dscinitialization_types.go
@@ -66,6 +66,7 @@ type DSCInitializationSpec struct {
 // DevFlags defines list of fields that can be used by developers to test customizations. This is not recommended
 // to be used in production environment.
 type DevFlags struct {
+	// ## DEPRECATED ## : ManifestsUri set on DSCI is not maintained.
 	// Custom manifests uri for odh-manifests
 	// +optional
 	ManifestsUri string `json:"manifestsUri,omitempty"`

--- a/bundle/manifests/dscinitialization.opendatahub.io_dscinitializations.yaml
+++ b/bundle/manifests/dscinitialization.opendatahub.io_dscinitializations.yaml
@@ -82,7 +82,9 @@ spec:
                     - default
                     type: string
                   manifestsUri:
-                    description: Custom manifests uri for odh-manifests
+                    description: |-
+                      ## DEPRECATED ## : ManifestsUri set on DSCI is not maintained.
+                      Custom manifests uri for odh-manifests
                     type: string
                 type: object
               monitoring:

--- a/config/crd/bases/dscinitialization.opendatahub.io_dscinitializations.yaml
+++ b/config/crd/bases/dscinitialization.opendatahub.io_dscinitializations.yaml
@@ -82,7 +82,9 @@ spec:
                     - default
                     type: string
                   manifestsUri:
-                    description: Custom manifests uri for odh-manifests
+                    description: |-
+                      ## DEPRECATED ## : ManifestsUri set on DSCI is not maintained.
+                      Custom manifests uri for odh-manifests
                     type: string
                 type: object
               monitoring:

--- a/docs/api-overview.md
+++ b/docs/api-overview.md
@@ -2103,7 +2103,7 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `manifestsUri` _string_ | Custom manifests uri for odh-manifests |  |  |
+| `manifestsUri` _string_ | ## DEPRECATED ## : ManifestsUri set on DSCI is not maintained.<br />Custom manifests uri for odh-manifests |  |  |
 | `logmode` _string_ | ## DEPRECATED ##: Ignored, use LogLevel instead | production | Enum: [devel development prod production default] <br /> |
 | `logLevel` _string_ | Override Zap log level. Can be "debug", "info", "error" or a number (more verbose). |  |  |
 


### PR DESCRIPTION
- we do not use this for devFlag in DSCI any more
- it was used when we still have odh-manifests repo
- if use would set devFlags, it should be done in DSC on component base
- keep logic still in code but only set warning on API

<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
