### PR TITLE
fix: when delete DSCI CR get stuck because the current instance updated and not preperly remove finalizer on it

### DIFF
--- a/controllers/dscinitialization/dscinitialization_controller.go
+++ b/controllers/dscinitialization/dscinitialization_controller.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/util/retry"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -113,11 +114,23 @@ func (r *DSCInitializationReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		if err := r.removeServiceMesh(ctx, instance); err != nil {
 			return reconcile.Result{}, err
 		}
-		if controllerutil.ContainsFinalizer(instance, finalizerName) {
-			controllerutil.RemoveFinalizer(instance, finalizerName)
-			if err := r.Update(ctx, instance); err != nil {
-				return ctrl.Result{}, err
+
+		err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			newInstance := &dsciv1.DSCInitialization{}
+			if err := r.Client.Get(ctx, client.ObjectKeyFromObject(instance), newInstance); err != nil {
+				return err
 			}
+			if controllerutil.ContainsFinalizer(newInstance, finalizerName) {
+				controllerutil.RemoveFinalizer(newInstance, finalizerName)
+				if err := r.Update(ctx, newInstance); err != nil {
+					return err
+				}
+			}
+			return nil
+		})
+		if err != nil {
+			r.Log.Error(err, "Failed to remove finalizer when deleting DSCInitialization instance")
+			return ctrl.Result{}, err
 		}
 
 		return ctrl.Result{}, nil


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->
For investigation in https://issues.redhat.com/browse/RHOAIENG-10300 we can identify the problem is from an updated DSCI before removing finalizer.
**To unblock this problem in regression, this is just a workaround.**
and we need a proper work as suggested in https://issues.redhat.com/browse/RHOAIENG-10300

Current change:
- after remove servicemesh and update condition, instance has been updated
- use retryonconflict to make sure it is removed when something else might also update DSCI at the same time



<!--- Link your JIRA and related links here for reference. -->
https://issues.redhat.com/browse/RHOAIENG-9606

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
local build: quay.io/wenzhou/opendatahub-operator-catalog:v2.15.1-9096
test step:
- remove ossm from cluster
- create dsci and dsc cr
- wait tiil "missing ossm" error in both
- delete dsc cr
- delete dsci cr
- done

also verified in QE cluster
## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
