### PR TITLE
chore: change local "manifests" folder to match in-image path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,7 +51,7 @@ components/gcp-click-to-deploy/src/user_config/**
 **/reg_tmp
 scripts/gke/build/**
 
-odh-manifests/
+opt/manifests/
 
 cover.out
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,5 +55,6 @@ IMG_TAG=my-dev-tag
 OPERATOR_NAMESPACE=my-dev-odh-operator-system
 IMAGE_BUILD_FLAGS=--build-arg USE_LOCAL=true
 E2E_TEST_FLAGS="--skip-deletion=true" -timeout 15m
+DEFAULT_MANIFESTS_PATH=./opt/manifests
 ```
 

--- a/Dockerfiles/Dockerfile
+++ b/Dockerfiles/Dockerfile
@@ -8,7 +8,7 @@ FROM registry.access.redhat.com/ubi8/go-toolset:$GOLANG_VERSION as builder_local
 ARG OVERWRITE_MANIFESTS
 # Get all manifests from remote git repo to builder_local_false by script
 USER root
-WORKDIR /opt
+WORKDIR /
 COPY get_all_manifests.sh get_all_manifests.sh
 RUN ./get_all_manifests.sh ${OVERWRITE_MANIFESTS}
 
@@ -18,7 +18,7 @@ FROM registry.access.redhat.com/ubi8/go-toolset:$GOLANG_VERSION as builder_local
 USER root
 WORKDIR /opt
 # copy local manifests to build
-COPY odh-manifests/ /opt/odh-manifests/
+COPY opt/manifests/ /opt/manifests/
 
 ################################################################################
 FROM builder_local_${USE_LOCAL} as builder
@@ -45,7 +45,7 @@ RUN CGO_ENABLED=1 GOOS=linux GOARCH=amd64 go build -a -o manager main.go
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 WORKDIR /
 COPY --from=builder /workspace/manager .
-COPY --chown=1001:0 --from=builder /opt/odh-manifests /opt/manifests
+COPY --chown=1001:0 --from=builder /opt/manifests /opt/manifests
 # Recursive change all files
 RUN chown -R 1001:0 /opt/manifests &&\
     chmod -R a+r /opt/manifests

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ BUNDLE_IMG ?= $(IMAGE_TAG_BASE)-bundle:v$(VERSION)
 
 IMAGE_BUILDER ?= podman
 OPERATOR_NAMESPACE ?= opendatahub-operator-system
+DEFAULT_MANIFESTS_PATH ?= opt/manifests
 
 
 CHANNELS="fast"
@@ -166,7 +167,7 @@ lint: golangci-lint ## Run golangci-lint against code.
 .PHONY: get-manifests
 get-manifests: ## Fetch components manifests from remote git repo
 	./get_all_manifests.sh
-CLEANFILES += odh-manifests/*
+CLEANFILES += opt/manifests/*
 
 .PHONY: api-docs
 api-docs: crd-ref-docs ## Creates API docs using https://github.com/elastic/crd-ref-docs
@@ -181,7 +182,7 @@ build: generate fmt vet ## Build manager binary.
 
 .PHONY: run
 run: manifests generate fmt vet ## Run a controller from your host.
-	go run ./main.go
+	OPERATOR_NAMESPACE=$(OPERATOR_NAMESPACE) DEFAULT_MANIFESTS_PATH=${DEFAULT_MANIFESTS_PATH} go run ./main.go
 
 .PHONY: image-build
 image-build: # unit-test ## Build image with the manager.

--- a/bundle/manifests/opendatahub-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/opendatahub-operator.clusterserviceversion.yaml
@@ -1710,6 +1710,8 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.namespace
+                - name: DEFAULT_MANIFESTS_PATH
+                  value: /opt/manifests
                 image: REPLACE_IMAGE:latest
                 imagePullPolicy: Always
                 livenessProbe:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -44,6 +44,8 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
+          - name: DEFAULT_MANIFESTS_PATH
+            value: /opt/manifests
         args:
         - --operator-name=opendatahub
         image: controller:latest

--- a/get_all_manifests.sh
+++ b/get_all_manifests.sh
@@ -65,7 +65,7 @@ for key in "${!COMPONENT_MANIFESTS[@]}"; do
     mkdir -p ${repo_dir}
     git clone -q --depth 1 --branch ${repo_branch} ${repo_url} ${repo_dir}
 
-    mkdir -p ./odh-manifests/${target_path}
-    cp -rf ${repo_dir}/${source_path}/* ./odh-manifests/${target_path}
+    mkdir -p ./opt/manifests/${target_path}
+    cp -rf ${repo_dir}/${source_path}/* ./opt/manifests/${target_path}
 
 done

--- a/pkg/deploy/deploy.go
+++ b/pkg/deploy/deploy.go
@@ -51,8 +51,8 @@ import (
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/plugins"
 )
 
-const (
-	DefaultManifestPath = "/opt/manifests"
+var (
+	DefaultManifestPath = os.Getenv("DEFAULT_MANIFESTS_PATH")
 )
 
 // DownloadManifests function performs following tasks:


### PR DESCRIPTION
- from odh-manifests to opt/manifests which is where image is using
- set default manifests path in CSV for release
- user can point to local manifests for debug

<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
`>make clean`
removed opt/manifests folder
`>make get-manifests`
downloaded components manifests into $(pwd)/opt/manifests

local build: quay.io/wenzhou/opendatahub-operator-catalog:v2.15.7-29
create DSCI and DSC CR
check pods in application NS
`>oc get pod -n opendatahub`
NAME                                                              READY   STATUS    RESTARTS   AGE
codeflare-operator-manager-5bb9f6745c-7mhv9                       1/1     Running   0          2m1s
data-science-pipelines-operator-controller-manager-79468c977tct   1/1     Running   0          2m43s
etcd-5cd44cd8dd-hbrrn                                             1/1     Running   0          2m45s
kserve-controller-manager-5766998974-qmh69                        1/1     Running   0          2m6s
kuberay-operator-99c646567-4w2zv                                  1/1     Running   0          114s
kueue-controller-manager-54556ffb7f-l2rlq                         1/1     Running   0          2m2s
modelmesh-controller-b7897bb45-q8vgw                              1/1     Running   0          2m45s
modelmesh-controller-b7897bb45-s7p6d                              1/1     Running   0          2m45s
modelmesh-controller-b7897bb45-sv2f6                              1/1     Running   0          2m45s
notebook-controller-deployment-8554657d6d-5gd75                   1/1     Running   0          2m49s
odh-dashboard-76c49655cf-5hx99                                    2/2     Running   0          2m51s
odh-dashboard-76c49655cf-hg9mk                                    2/2     Running   0          2m51s
odh-model-controller-57b9ffbdfc-99q7m                             1/1     Running   0          2m44s
odh-model-controller-57b9ffbdfc-xlk7p                             1/1     Running   0          2m44s
odh-model-controller-57b9ffbdfc-z5ndw                             1/1     Running   0          2m44s
odh-notebook-controller-manager-7cf9954577-6jh7h                  1/1     Running   0          2m51s
trustyai-service-operator-controller-manager-6f7bff965f-l6szm     1/1     Running   0          113s

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
