### PR TITLE
fix(feature): preserves original target namespace

### DIFF
--- a/pkg/feature/builder.go
+++ b/pkg/feature/builder.go
@@ -67,9 +67,11 @@ func (fb *featureBuilder) Source(source featurev1.Source) *featureBuilder {
 }
 
 // TargetNamespace sets the namespace in which the feature should be applied.
-// If not set, the feature will be applied in the application namespace.
+// Calling it multiple times in the builder chain will have no effect, as the first value is used.
 func (fb *featureBuilder) TargetNamespace(targetNs string) *featureBuilder {
-	fb.targetNs = targetNs
+	if fb.targetNs == "" {
+		fb.targetNs = targetNs
+	}
 
 	return fb
 }


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description

This change ensures that original target namespace is used when invoked directly in the builder.

Typically subsequent calls of `.TargetNamespace` in the feature builder indicate coding/copy-paste error and should be reduced to one.

However,in the FeatureHandler, where we group features together we do not have to specify target namespace for each feature, as it is defaulted to the one defined on the handler level. This is convenient, but limits application of features to a single namespace, as the value is always overwritten.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

By running `make` tests.

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
