### PR TITLE
chore(service-mesh): exports configmap names to const

### DIFF
--- a/pkg/feature/servicemesh/const.go
+++ b/pkg/feature/servicemesh/const.go
@@ -1,0 +1,6 @@
+package servicemesh
+
+const (
+	ConfigMapAuthRef = "auth-refs"
+	ConfigMapMeshRef = "service-mesh-refs"
+)

--- a/pkg/feature/servicemesh/resources.go
+++ b/pkg/feature/servicemesh/resources.go
@@ -31,7 +31,7 @@ func MeshRefs(ctx context.Context, f *feature.Feature) error {
 		f.Client,
 		&corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "service-mesh-refs",
+				Name:      ConfigMapMeshRef,
 				Namespace: namespace,
 			},
 			Data: data,
@@ -76,7 +76,7 @@ func AuthRefs(ctx context.Context, f *feature.Feature) error {
 		f.Client,
 		&corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "auth-refs",
+				Name:      ConfigMapAuthRef,
 				Namespace: targetNamespace,
 			},
 			Data: data,


### PR DESCRIPTION
## Description

While creating service mesh features, certain configs are written to the config maps. To allow extending of this shared configuration across the code base the names have been extracted and exported as const in `servicemesh` package.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
