### PR TITLE
[RHOAIENG-10647] - Configure Knative PVC support as default

### DIFF
--- a/components/kserve/resources/serving-install/knative-serving.tmpl.yaml
+++ b/components/kserve/resources/serving-install/knative-serving.tmpl.yaml
@@ -23,5 +23,7 @@ spec:
       kubernetes.podspec-affinity: enabled
       kubernetes.podspec-nodeselector: enabled
       kubernetes.podspec-tolerations: enabled
+      kubernetes.podspec-persistent-volume-write: enabled
+      kubernetes.podspec-persistent-volume-claim: enabled
     istio:
       local-gateway.knative-serving.knative-local-gateway: "knative-local-gateway.{{ .ControlPlane.Namespace }}.svc.cluster.local"


### PR DESCRIPTION
chore: Enable by default the serving features to allow pvc mounts.

<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
