### PR TITLE
fix: change user of operator to 1001

### DIFF
--- a/bundle/manifests/opendatahub-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/opendatahub-operator.clusterserviceversion.yaml
@@ -1751,7 +1751,7 @@ spec:
                   name: cert
                   readOnly: true
               securityContext:
-                runAsNonRoot: true
+                runAsUser: 1001
               serviceAccountName: opendatahub-operator-controller-manager
               terminationGracePeriodSeconds: 10
               volumes:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -10,8 +10,6 @@ kind: Deployment
 metadata:
   name: controller-manager
   namespace: system
-  annotations:
-    openshift.io/required-scc: "anyuid"
   labels:
     control-plane: controller-manager
 spec:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -10,6 +10,8 @@ kind: Deployment
 metadata:
   name: controller-manager
   namespace: system
+  annotations:
+    openshift.io/required-scc: "anyuid"
   labels:
     control-plane: controller-manager
 spec:
@@ -26,7 +28,7 @@ spec:
         name: opendatahub-operator
     spec:
       securityContext:
-        runAsNonRoot: true
+        runAsUser: 1001
         # TODO(user): For common cases that do not require escalating privileges
         # it is recommended to ensure that all your Pods/Containers are restrictive.
         # More info: https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted


### PR DESCRIPTION
- this is the user we used for our image
- the previous only set to non-root user which can be conflict with customized SCC

<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

<!--- Link your JIRA and related links here for reference. -->
https://issues.redhat.com/browse/RHOAIENG-10272

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
local build: quay.io/wenzhou/opendatahub-operator-catalog:v2.13.10272-3
test:
- create a customized SCC as stated in the jira ticket ^ 
- install this operator build
-  operator pod should still work and no error on permission

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
