### PR TITLE
chore(meta): removes map size declaration

### DIFF
--- a/pkg/cluster/meta.go
+++ b/pkg/cluster/meta.go
@@ -68,15 +68,15 @@ func WithAnnotations(annotationKeyValue ...string) MetaOptions {
 	}
 }
 
-func extractKeyValues(kv []string) (map[string]string, error) {
-	lenKV := len(kv)
+func extractKeyValues(keyValues []string) (map[string]string, error) {
+	lenKV := len(keyValues)
 	if lenKV%2 != 0 {
 		return nil, fmt.Errorf("passed elements should be in key/value pairs, but got %d elements", lenKV)
 	}
 
-	kvMap := make(map[string]string, lenKV%2)
+	kvMap := make(map[string]string)
 	for i := 0; i < lenKV; i += 2 {
-		kvMap[kv[i]] = kv[i+1]
+		kvMap[keyValues[i]] = keyValues[i+1]
 	}
 
 	return kvMap, nil


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description

This change removes the declaration of map size. Relying on default allocation is sufficient for this use case, but more importantly, given the modulo check before, it has always been 0 (mistakenly using `%` operator). 

This is not only confusing for the reader but can result in immediate map resizing.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
