### PR TITLE
Don't restrict the nbc image update to downstream only

### DIFF
--- a/components/workbenches/workbenches.go
+++ b/components/workbenches/workbenches.go
@@ -136,18 +136,16 @@ func (w *Workbenches) ReconcileComponent(ctx context.Context, cli client.Client,
 	}
 	l.WithValues("Path", notebookControllerPath).Info("apply manifests done NBC")
 
-	// Update image parameters for nbc in downstream
+	// Update image parameters for nbc
 	if enabled {
 		if (dscispec.DevFlags == nil || dscispec.DevFlags.ManifestsUri == "") && (w.DevFlags == nil || len(w.DevFlags.Manifests) == 0) {
-			if platform == cluster.ManagedRhods || platform == cluster.SelfManagedRhods {
-				// for kf-notebook-controller image
-				if err := deploy.ApplyParams(notebookControllerPath, imageParamMap); err != nil {
-					return fmt.Errorf("failed to update image %s: %w", notebookControllerPath, err)
-				}
-				// for odh-notebook-controller image
-				if err := deploy.ApplyParams(kfnotebookControllerPath, imageParamMap); err != nil {
-					return fmt.Errorf("failed to update image %s: %w", kfnotebookControllerPath, err)
-				}
+			// for kf-notebook-controller image
+			if err := deploy.ApplyParams(notebookControllerPath, imageParamMap); err != nil {
+				return fmt.Errorf("failed to update image %s: %w", notebookControllerPath, err)
+			}
+			// for odh-notebook-controller image
+			if err := deploy.ApplyParams(kfnotebookControllerPath, imageParamMap); err != nil {
+				return fmt.Errorf("failed to update image %s: %w", kfnotebookControllerPath, err)
 			}
 		}
 	}


### PR DESCRIPTION
This should address the [1]. With current code it wasn't possible to override the images used for the notebook controllers via env property, now it should be possible.

[1] https://issues.redhat.com/browse/RHOAIENG-11134

## How Has This Been Tested?
I installed the latest OpenDataHub operator (v2.16) and amended the CSV by:
1. pointing the deployment containter to the image build for this PR
2. added the desired env variables `RELATED_IMAGE_ODH_KF_NOTEBOOK_CONTROLLER_IMAGE` and `RELATED_IMAGE_ODH_NOTEBOOK_CONTROLLER_IMAGE`
3. then create the DSCI and DSC instances and see what images were used for the both notebook controller pods

CSV
```
...
                containers:
                    env:
                      - name: DISABLE_DSC_CONFIG
                        value: 'true'
                      - name: OPERATOR_NAMESPACE
                        valueFrom:
                          fieldRef:
                            fieldPath: metadata.namespace
                      - name: DEFAULT_MANIFESTS_PATH
                        value: /opt/manifests
                      - name: RELATED_IMAGE_ODH_DASHBOARD_IMAGE
                        value: 'registry.redhat.io/rhoai/odh-dashboard-rhel8@sha256:f11a6e12fdba4547578f909cea56bc1de54e66d3cf4e3808494cb16dba4091a1'
                      - name: RELATED_IMAGE_ODH_KF_NOTEBOOK_CONTROLLER_IMAGE
                        value: 'registry.redhat.io/rhoai/odh-kf-notebook-controller-rhel8@sha256:f3a9f12560560739c8d0f44dd654a5fa834e5f4337f4aea13fc2e929f299e222'
                      - name: RELATED_IMAGE_ODH_NOTEBOOK_CONTROLLER_IMAGE
                        value: 'registry.redhat.io/rhoai/odh-notebook-controller-rhel8@sha256:1e1bddd06ed0d4234bcc9890bfafec29d06ad0e35a6c663c9d7174a8b2eaf3ab'
                    image: 'quay.io/opendatahub/opendatahub-operator@sha256:120687732c88e817cd176805d37866b475b837fee73e9fb8ed442cf2fae555f1'
...
```

Resulting in:

```
$ oc describe deployment -n opendatahub notebook-controller-deployment | grep Image
    Image:      registry.redhat.io/rhoai/odh-kf-notebook-controller-rhel8@sha256:f3a9f12560560739c8d0f44dd654a5fa834e5f4337f4aea13fc2e929f299e222

$ oc describe deployment -n opendatahub odh-notebook-controller-manager | grep Image
    Image:       registry.redhat.io/rhoai/odh-notebook-controller-rhel8@sha256:1e1bddd06ed0d4234bcc9890bfafec29d06ad0e35a6c663c9d7174a8b2eaf3ab
```

So now the changes are applied not only for the RHOAI build, but also for the ODH - which will be handy for the ODH-nightly builds, but also for the devel purpose and custom changes testing.

I also checked that using this new image without specifying the `RELATED_IMAGE_ODH_KF_NOTEBOOK_CONTROLLER_IMAGE` and `RELATED_IMAGE_ODH_NOTEBOOK_CONTROLLER_IMAGE` env variables doesn't cause any harm and the default images for these components are used, see:

```
$ oc describe deployment -n opendatahub notebook-controller-deployment | grep Image    
    Image:      quay.io/opendatahub/kubeflow-notebook-controller:1.7-8a9b65a

$ oc describe deployment -n opendatahub odh-notebook-controller-manager | grep Image
    Image:       quay.io/opendatahub/odh-notebook-controller:1.7-8a9b65a
```

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
