### PR TITLE
kserve: do not call ApplyParams for the empty list

### DIFF
--- a/components/kserve/kserve.go
+++ b/components/kserve/kserve.go
@@ -97,8 +97,6 @@ func (k *Kserve) GetComponentName() string {
 func (k *Kserve) ReconcileComponent(ctx context.Context, cli client.Client,
 	logger logr.Logger, owner metav1.Object, dscispec *dsciv1.DSCInitializationSpec, platform cluster.Platform, _ bool) error {
 	l := k.ConfigComponentLogger(logger, ComponentName, dscispec)
-	// paramMap for Kserve to use.
-	var imageParamMap = map[string]string{}
 
 	// dependentParamMap for odh-model-controller to use.
 	var dependentParamMap = map[string]string{
@@ -122,13 +120,6 @@ func (k *Kserve) ReconcileComponent(ctx context.Context, cli client.Client,
 			if err := k.OverrideManifests(ctx, platform); err != nil {
 				return err
 			}
-		}
-	}
-
-	// Update image parameters only when we do not have customized manifests set
-	if (dscispec.DevFlags == nil || dscispec.DevFlags.ManifestsUri == "") && (k.DevFlags == nil || len(k.DevFlags.Manifests) == 0) {
-		if err := deploy.ApplyParams(Path, imageParamMap, false); err != nil {
-			return fmt.Errorf("failed to update image from %s : %w", Path, err)
 		}
 	}
 


### PR DESCRIPTION
The call is not need since the code just declare empty parameters list:
        var imageParamMap = map[string]string{}

Fixes the issue of calling ApplyParams for non-enabled case.

Credits-to: Wen Zhou <wenzhou@redhat.com>
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
