### PR TITLE
update: remove unnecessary param from ApplyParams()

### DIFF
--- a/components/codeflare/codeflare.go
+++ b/components/codeflare/codeflare.go
@@ -67,7 +67,6 @@ func (c *CodeFlare) ReconcileComponent(ctx context.Context,
 	l := c.ConfigComponentLogger(logger, ComponentName, dscispec)
 	var imageParamMap = map[string]string{
 		"codeflare-operator-controller-image": "RELATED_IMAGE_ODH_CODEFLARE_OPERATOR_IMAGE", // no need mcad, embedded in cfo
-		"namespace":                           dscispec.ApplicationsNamespace,
 	}
 
 	enabled := c.GetManagementState() == operatorv1.Managed
@@ -93,7 +92,7 @@ func (c *CodeFlare) ReconcileComponent(ctx context.Context,
 
 		// Update image parameters only when we do not have customized manifests set
 		if (dscispec.DevFlags == nil || dscispec.DevFlags.ManifestsUri == "") && (c.DevFlags == nil || len(c.DevFlags.Manifests) == 0) {
-			if err := deploy.ApplyParams(ParamsPath, imageParamMap, true); err != nil {
+			if err := deploy.ApplyParams(ParamsPath, imageParamMap, map[string]string{"namespace": dscispec.ApplicationsNamespace}); err != nil {
 				return fmt.Errorf("failed update image from %s : %w", CodeflarePath+"/bases", err)
 			}
 		}

--- a/components/dashboard/dashboard.go
+++ b/components/dashboard/dashboard.go
@@ -122,7 +122,7 @@ func (d *Dashboard) ReconcileComponent(ctx context.Context,
 		}
 
 		// 4. update params.env regardless devFlags is provided of not
-		if err := deploy.ApplyParams(entryPath, imageParamMap, false, extraParamsMap); err != nil {
+		if err := deploy.ApplyParams(entryPath, imageParamMap, extraParamsMap); err != nil {
 			return fmt.Errorf("failed to update params.env  from %s : %w", entryPath, err)
 		}
 	}

--- a/components/datasciencepipelines/datasciencepipelines.go
+++ b/components/datasciencepipelines/datasciencepipelines.go
@@ -104,7 +104,7 @@ func (d *DataSciencePipelines) ReconcileComponent(ctx context.Context,
 		// skip check if the dependent operator has beeninstalled, this is done in dashboard
 		// Update image parameters only when we do not have customized manifests set
 		if (dscispec.DevFlags == nil || dscispec.DevFlags.ManifestsUri == "") && (d.DevFlags == nil || len(d.DevFlags.Manifests) == 0) {
-			if err := deploy.ApplyParams(Path, imageParamMap, false); err != nil {
+			if err := deploy.ApplyParams(Path, imageParamMap); err != nil {
 				return fmt.Errorf("failed to update image from %s : %w", Path, err)
 			}
 		}

--- a/components/kserve/kserve.go
+++ b/components/kserve/kserve.go
@@ -127,7 +127,7 @@ func (k *Kserve) ReconcileComponent(ctx context.Context, cli client.Client,
 
 	// Update image parameters only when we do not have customized manifests set
 	if (dscispec.DevFlags == nil || dscispec.DevFlags.ManifestsUri == "") && (k.DevFlags == nil || len(k.DevFlags.Manifests) == 0) {
-		if err := deploy.ApplyParams(Path, imageParamMap, false); err != nil {
+		if err := deploy.ApplyParams(Path, imageParamMap); err != nil {
 			return fmt.Errorf("failed to update image from %s : %w", Path, err)
 		}
 	}
@@ -153,7 +153,7 @@ func (k *Kserve) ReconcileComponent(ctx context.Context, cli client.Client,
 		}
 		// Update image parameters for odh-model-controller
 		if (dscispec.DevFlags == nil || dscispec.DevFlags.ManifestsUri == "") && (k.DevFlags == nil || len(k.DevFlags.Manifests) == 0) {
-			if err := deploy.ApplyParams(DependentPath, dependentParamMap, false); err != nil {
+			if err := deploy.ApplyParams(DependentPath, dependentParamMap); err != nil {
 				return fmt.Errorf("failed to update image %s: %w", DependentPath, err)
 			}
 		}

--- a/components/kueue/kueue.go
+++ b/components/kueue/kueue.go
@@ -70,7 +70,7 @@ func (k *Kueue) ReconcileComponent(ctx context.Context, cli client.Client, logge
 			}
 		}
 		if (dscispec.DevFlags == nil || dscispec.DevFlags.ManifestsUri == "") && (k.DevFlags == nil || len(k.DevFlags.Manifests) == 0) {
-			if err := deploy.ApplyParams(Path, imageParamMap, true); err != nil {
+			if err := deploy.ApplyParams(Path, imageParamMap); err != nil {
 				return fmt.Errorf("failed to update image from %s : %w", Path, err)
 			}
 		}

--- a/components/modelmeshserving/modelmeshserving.go
+++ b/components/modelmeshserving/modelmeshserving.go
@@ -114,7 +114,7 @@ func (m *ModelMeshServing) ReconcileComponent(ctx context.Context,
 		}
 		// Update image parameters
 		if (dscispec.DevFlags == nil || dscispec.DevFlags.ManifestsUri == "") && (m.DevFlags == nil || len(m.DevFlags.Manifests) == 0) {
-			if err := deploy.ApplyParams(Path, imageParamMap, false); err != nil {
+			if err := deploy.ApplyParams(Path, imageParamMap); err != nil {
 				return fmt.Errorf("failed update image from %s : %w", Path, err)
 			}
 		}
@@ -132,7 +132,7 @@ func (m *ModelMeshServing) ReconcileComponent(ctx context.Context,
 		}
 		// Update image parameters for odh-model-controller
 		if dscispec.DevFlags == nil || dscispec.DevFlags.ManifestsUri == "" {
-			if err := deploy.ApplyParams(DependentPath, dependentImageParamMap, false); err != nil {
+			if err := deploy.ApplyParams(DependentPath, dependentImageParamMap); err != nil {
 				return err
 			}
 		}

--- a/components/modelregistry/modelregistry.go
+++ b/components/modelregistry/modelregistry.go
@@ -79,7 +79,7 @@ func (m *ModelRegistry) ReconcileComponent(ctx context.Context, cli client.Clien
 
 		// Update image parameters only when we do not have customized manifests set
 		if (dscispec.DevFlags == nil || dscispec.DevFlags.ManifestsUri == "") && (m.DevFlags == nil || len(m.DevFlags.Manifests) == 0) {
-			if err := deploy.ApplyParams(Path, imageParamMap, false); err != nil {
+			if err := deploy.ApplyParams(Path, imageParamMap); err != nil {
 				return fmt.Errorf("failed to update image from %s : %w", Path, err)
 			}
 		}

--- a/components/ray/ray.go
+++ b/components/ray/ray.go
@@ -61,7 +61,6 @@ func (r *Ray) ReconcileComponent(ctx context.Context, cli client.Client, logger 
 
 	var imageParamMap = map[string]string{
 		"odh-kuberay-operator-controller-image": "RELATED_IMAGE_ODH_KUBERAY_OPERATOR_CONTROLLER_IMAGE",
-		"namespace":                             dscispec.ApplicationsNamespace,
 	}
 
 	enabled := r.GetManagementState() == operatorv1.Managed
@@ -75,7 +74,7 @@ func (r *Ray) ReconcileComponent(ctx context.Context, cli client.Client, logger 
 			}
 		}
 		if (dscispec.DevFlags == nil || dscispec.DevFlags.ManifestsUri == "") && (r.DevFlags == nil || len(r.DevFlags.Manifests) == 0) {
-			if err := deploy.ApplyParams(RayPath, imageParamMap, true); err != nil {
+			if err := deploy.ApplyParams(RayPath, imageParamMap, map[string]string{"namespace": dscispec.ApplicationsNamespace}); err != nil {
 				return fmt.Errorf("failed to update image from %s : %w", RayPath, err)
 			}
 		}

--- a/components/trainingoperator/trainingoperator.go
+++ b/components/trainingoperator/trainingoperator.go
@@ -61,7 +61,6 @@ func (r *TrainingOperator) ReconcileComponent(ctx context.Context, cli client.Cl
 
 	var imageParamMap = map[string]string{
 		"odh-training-operator-controller-image": "RELATED_IMAGE_ODH_TRAINING_OPERATOR_IMAGE",
-		"namespace":                              dscispec.ApplicationsNamespace,
 	}
 
 	enabled := r.GetManagementState() == operatorv1.Managed
@@ -75,7 +74,7 @@ func (r *TrainingOperator) ReconcileComponent(ctx context.Context, cli client.Cl
 			}
 		}
 		if (dscispec.DevFlags == nil || dscispec.DevFlags.ManifestsUri == "") && (r.DevFlags == nil || len(r.DevFlags.Manifests) == 0) {
-			if err := deploy.ApplyParams(TrainingOperatorPath, imageParamMap, true); err != nil {
+			if err := deploy.ApplyParams(TrainingOperatorPath, imageParamMap); err != nil {
 				return err
 			}
 		}

--- a/components/trustyai/trustyai.go
+++ b/components/trustyai/trustyai.go
@@ -73,7 +73,7 @@ func (t *TrustyAI) ReconcileComponent(ctx context.Context, cli client.Client, lo
 			}
 		}
 		if (dscispec.DevFlags == nil || dscispec.DevFlags.ManifestsUri == "") && (t.DevFlags == nil || len(t.DevFlags.Manifests) == 0) {
-			if err := deploy.ApplyParams(Path, imageParamMap, false); err != nil {
+			if err := deploy.ApplyParams(Path, imageParamMap); err != nil {
 				return fmt.Errorf("failed to update image %s: %w", Path, err)
 			}
 		}

--- a/components/workbenches/workbenches.go
+++ b/components/workbenches/workbenches.go
@@ -141,11 +141,11 @@ func (w *Workbenches) ReconcileComponent(ctx context.Context, cli client.Client,
 		if (dscispec.DevFlags == nil || dscispec.DevFlags.ManifestsUri == "") && (w.DevFlags == nil || len(w.DevFlags.Manifests) == 0) {
 			if platform == cluster.ManagedRhods || platform == cluster.SelfManagedRhods {
 				// for kf-notebook-controller image
-				if err := deploy.ApplyParams(notebookControllerPath, imageParamMap, false); err != nil {
+				if err := deploy.ApplyParams(notebookControllerPath, imageParamMap); err != nil {
 					return fmt.Errorf("failed to update image %s: %w", notebookControllerPath, err)
 				}
 				// for odh-notebook-controller image
-				if err := deploy.ApplyParams(kfnotebookControllerPath, imageParamMap, false); err != nil {
+				if err := deploy.ApplyParams(kfnotebookControllerPath, imageParamMap); err != nil {
 					return fmt.Errorf("failed to update image %s: %w", kfnotebookControllerPath, err)
 				}
 			}

--- a/pkg/deploy/envParams.go
+++ b/pkg/deploy/envParams.go
@@ -15,10 +15,9 @@ priority of image values (from high to low):
 - image values set in manifests params.env if manifestsURI is set
 - RELATED_IMAGE_* values from CSV (if it is set)
 - image values set in manifests params.env if manifestsURI is not set.
-parameter isUpdateNamespace is used to set if should update namespace  with DSCI CR's applicationnamespace.
 extraParamsMaps is used to set extra parameters which are not carried from ENV variable. this can be passed per component.
 */
-func ApplyParams(componentPath string, imageParamsMap map[string]string, isUpdateNamespace bool, extraParamsMaps ...map[string]string) error {
+func ApplyParams(componentPath string, imageParamsMap map[string]string, extraParamsMaps ...map[string]string) error {
 	paramsFile := filepath.Join(componentPath, "params.env")
 	// Require params.env at the root folder
 	paramsEnv, err := os.Open(paramsFile)
@@ -54,12 +53,7 @@ func ApplyParams(componentPath string, imageParamsMap map[string]string, isUpdat
 		}
 	}
 
-	// 2. Update namespace variable with applicationNamepsace
-	if isUpdateNamespace {
-		paramsEnvMap["namespace"] = imageParamsMap["namespace"]
-	}
-
-	// 3. Update other fileds with extraParamsMap which are not carried from component
+	// 2. Update other fileds with extraParamsMap which are not carried from component
 	for _, extraParamsMap := range extraParamsMaps {
 		for eKey, eValue := range extraParamsMap {
 			paramsEnvMap[eKey] = eValue


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->
previously we use the boolean in ApplyParams() for some DW cases(CFO and Ray need, TO not really), because they would like to pass extra value (in that case namespace)
later for dashboard, extraParamsMaps has been introduced but the old boolean did not get cleaned up.
extraParamsMaps is generic to use, this PR is only to cleanup boolean and move the namespace variable from imageParamsMap away


<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
quay.io/wenzhou/opendatahub-operator-catalog:v2.16.96

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
