### PR TITLE
update: add check before calling ApplyParams

### DIFF
--- a/components/codeflare/codeflare.go
+++ b/components/codeflare/codeflare.go
@@ -6,6 +6,7 @@ package codeflare
 import (
 	"context"
 	"fmt"
+	"os"
 	"path/filepath"
 
 	"github.com/go-logr/logr"
@@ -68,7 +69,6 @@ func (c *CodeFlare) ReconcileComponent(ctx context.Context,
 	var imageParamMap = map[string]string{
 		"codeflare-operator-controller-image": "RELATED_IMAGE_ODH_CODEFLARE_OPERATOR_IMAGE", // no need mcad, embedded in cfo
 	}
-
 	enabled := c.GetManagementState() == operatorv1.Managed
 	monitoringEnabled := dscispec.Monitoring.ManagementState == operatorv1.Managed
 
@@ -92,8 +92,14 @@ func (c *CodeFlare) ReconcileComponent(ctx context.Context,
 
 		// Update image parameters only when we do not have customized manifests set
 		if (dscispec.DevFlags == nil || dscispec.DevFlags.ManifestsUri == "") && (c.DevFlags == nil || len(c.DevFlags.Manifests) == 0) {
-			if err := deploy.ApplyParams(ParamsPath, imageParamMap, map[string]string{"namespace": dscispec.ApplicationsNamespace}); err != nil {
-				return fmt.Errorf("failed update image from %s : %w", CodeflarePath+"/bases", err)
+			// only update if passing image does not exist in params.env, to avoid unnecessary disk written
+			if err := deploy.CheckParams(ParamsPath, []string{
+				os.Getenv("RELATED_IMAGE_ODH_CODEFLARE_OPERATOR_IMAGE"),
+				dscispec.ApplicationsNamespace,
+			}); err != nil {
+				if err := deploy.ApplyParams(ParamsPath, imageParamMap, map[string]string{"namespace": dscispec.ApplicationsNamespace}); err != nil {
+					return fmt.Errorf("failed to update image from %s: %w", ParamsPath, err)
+				}
 			}
 		}
 	}

--- a/components/modelregistry/modelregistry.go
+++ b/components/modelregistry/modelregistry.go
@@ -5,6 +5,7 @@ package modelregistry
 import (
 	"context"
 	"fmt"
+	"os"
 	"path/filepath"
 
 	"github.com/go-logr/logr"
@@ -79,8 +80,15 @@ func (m *ModelRegistry) ReconcileComponent(ctx context.Context, cli client.Clien
 
 		// Update image parameters only when we do not have customized manifests set
 		if (dscispec.DevFlags == nil || dscispec.DevFlags.ManifestsUri == "") && (m.DevFlags == nil || len(m.DevFlags.Manifests) == 0) {
-			if err := deploy.ApplyParams(Path, imageParamMap); err != nil {
-				return fmt.Errorf("failed to update image from %s : %w", Path, err)
+			// only update if passing image does not exist in params.env, to avoid unnecessary disk written
+			var paramsMapValues []string
+			for _, image := range imageParamMap {
+				paramsMapValues = append(paramsMapValues, os.Getenv(image))
+			}
+			if err := deploy.CheckParams(Path, paramsMapValues); err != nil {
+				if err := deploy.ApplyParams(Path, imageParamMap); err != nil {
+					return fmt.Errorf("failed to update image from %s: %w", Path, err)
+				}
 			}
 		}
 

--- a/components/ray/ray.go
+++ b/components/ray/ray.go
@@ -6,6 +6,7 @@ package ray
 import (
 	"context"
 	"fmt"
+	"os"
 	"path/filepath"
 
 	"github.com/go-logr/logr"
@@ -74,8 +75,14 @@ func (r *Ray) ReconcileComponent(ctx context.Context, cli client.Client, logger 
 			}
 		}
 		if (dscispec.DevFlags == nil || dscispec.DevFlags.ManifestsUri == "") && (r.DevFlags == nil || len(r.DevFlags.Manifests) == 0) {
-			if err := deploy.ApplyParams(RayPath, imageParamMap, map[string]string{"namespace": dscispec.ApplicationsNamespace}); err != nil {
-				return fmt.Errorf("failed to update image from %s : %w", RayPath, err)
+			// only update if passing image does not exist in params.env, to avoid unnecessary disk written
+			if err := deploy.CheckParams(RayPath, []string{
+				os.Getenv("RELATED_IMAGE_ODH_KUBERAY_OPERATOR_CONTROLLER_IMAGE"),
+				dscispec.ApplicationsNamespace,
+			}); err != nil {
+				if err := deploy.ApplyParams(RayPath, imageParamMap, map[string]string{"namespace": dscispec.ApplicationsNamespace}); err != nil {
+					return fmt.Errorf("failed to update image from %s: %w", RayPath, err)
+				}
 			}
 		}
 	}

--- a/pkg/deploy/deploy_suite_test.go
+++ b/pkg/deploy/deploy_suite_test.go
@@ -1,0 +1,77 @@
+package deploy_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/deploy"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestStringSearch(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Check Params Suite")
+}
+
+var _ = Describe("Throw error if image still use old image registry", func() {
+
+	var (
+		tmpFile   *os.File
+		filePath  = "/tmp/manifests/components/one"
+		err       error
+		paramsenv string
+	)
+
+	// create a temp params.env file
+	BeforeEach(func() {
+		err = os.MkdirAll(filePath, 0755)
+		tmpFile, err = os.Create(filepath.Join(filePath, "params.env"))
+		Expect(err).NotTo(HaveOccurred())
+
+		// fake some lines
+		paramsenv = `url=https://www.odh.rbac.com
+myimagee=quay.io/opendatahub/repo:abc
+namespace=opendatahub`
+		_, err = tmpFile.WriteString(paramsenv)
+		Expect(err).NotTo(HaveOccurred())
+
+		err = tmpFile.Close()
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		err = os.Remove(tmpFile.Name())
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	Context("when searching in params.env", func() {
+		It("Should not throw error when string found", func() {
+			err := deploy.CheckParams(filePath, []string{"abc"})
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("Should not throw error when all string are matched", func() {
+			err := deploy.CheckParams(filePath, []string{"rbac", "abc"})
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("Should not throw error when emptry string provided(as env not found)", func() {
+			err := deploy.CheckParams(filePath, []string{""})
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("Should throw error when string not found", func() {
+			err := deploy.CheckParams(filePath, []string{"vw"})
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("Should throw error when multiple strings are not found", func() {
+			err := deploy.CheckParams(filePath, []string{"vw", "123"})
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
+})


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->
- this cherry-pick the function from PR https://github.com/opendatahub-io/opendatahub-operator/pull/1177 
- only when any of value(image, env) not present in params.env then call ApplyParams
- avoid frequently disk written to params.env by every reconcile on the components



<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
local build: quay.io/wenzhou/opendatahub-operator:2.16.97-1

- manually set RELATED_IMAGE_ODH_CODEFLARE_OPERATOR_IMAGE as env to a operator image
- create DSC and enable codeflare
- check codeflare podis running with new set image
- check codeflare's params.env time:
`-rw-r--r--. 1 1001 root  184 Aug 16 13:17 params.env`
- enable another component, to trigger reconcile
- wait till it is done and check codeflare's params.env time: should be the same since no need re-write
`-rw-r--r--. 1 1001 root  184 Aug 16 13:17 params.env`

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->
![hide-me](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExeGNjZnYxNHJidnJvcDhnZjJzZTB4ZWRzdTZ0c2llajEwOHhkd2hxaSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/WoWm8YzFQJg5i/giphy.gif)

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
