### PR TITLE
fix(serverless): checks if Service Mesh is defined

### DIFF
--- a/components/kserve/kserve_config_handler.go
+++ b/components/kserve/kserve_config_handler.go
@@ -129,9 +129,15 @@ func (k *Kserve) configureServerless(ctx context.Context, cli client.Client, ins
 		}
 
 	case operatorv1.Managed: // standard workflow to create CR
+		if instance.ServiceMesh == nil {
+			return errors.New("ServiceMesh needs to be configured and 'Managed' in DSCI CR, " +
+				"it is required by KServe serving")
+		}
+
 		switch instance.ServiceMesh.ManagementState {
 		case operatorv1.Unmanaged, operatorv1.Removed:
-			return errors.New("ServiceMesh is need to set to 'Managed' in DSCI CR, it is required by KServe serving field")
+			return fmt.Errorf("ServiceMesh is currently set to '%s'. It needs to be set to 'Managed' in DSCI CR, "+
+				"as it is required by the KServe serving field", instance.ServiceMesh.ManagementState)
 		}
 
 		// check on dependent operators if all installed in cluster


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description

This change ensures that ServiceMesh spec is set before proceeding with Serverless setup.

`DSCI.ServiceMesh` has been changed to a pointer to be truly `optional` in the DSCI CR. If it is not defined in the DSCI API, it is `nil` struct instead of being defaulted by the apiserver.

This resulted in panic when DSC has KServe with Serverless enabled, and it expects to have ServiceMesh configuration present to proceed with its settings.

## How Has This Been Tested?

Create the following DSCI and DSC:

```yaml
apiVersion: dscinitialization.opendatahub.io/v1
kind: DSCInitialization
metadata:
  name: default
spec:
  applicationsNamespace: opendatahub
  trustedCABundle:
    managementState: Removed
  monitoring:
    managementState: Managed
    namespace: opendatahub
---
apiVersion: datasciencecluster.opendatahub.io/v1
kind: DataScienceCluster
metadata:
  name: default
spec:
  components:
    kserve:
      managementState: Managed
      serving:
        ingressGateway:
          certificate:
            type: OpenshiftDefaultIngress
        managementState: Managed
        name: knative-serving
```


<details>
<summary>Observe `panic`</summary>

```bash
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
    panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0x2442c19]

goroutine 632 [running]:
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile.func1()
    /opt/app-root/src/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.14.6/pkg/internal/controller/controller.go:119 +0x1e5
panic({0x26910a0?, 0x3e1caa0?})
    /usr/lib/golang/src/runtime/panic.go:914 +0x21f
github.com/opendatahub-io/opendatahub-operator/v2/components/kserve.(*Kserve).configureServerless(0xc00664e868, {0x2c8fbd0, 0xc003634000}, {0x2c993c8, 0xc0000d2a20}, 0xc0001ba5f0)
    /workspace/components/kserve/kserve_config_handler.go:132 +0x159
github.com/opendatahub-io/opendatahub-operator/v2/components/kserve.(*Kserve).ReconcileComponent(0xc00664e868, {0x2c8fbd0, 0xc003634000}, {0x2c993c8, 0xc0000d2a20}, {{0x2c94d60?, 0xc0007...}})
    /workspace/components/kserve/kserve.go:115 +0x1f0
github.com/opendatahub-io/opendatahub-operator/v2/controllers/datasciencecluster.(*DataScienceClusterReconciler).reconcileSubComponent(0xc0001ba5a0, {0x2c8fbd0, 0xc003634000}, 0xc003b375...)
    /workspace/controllers/datasciencecluster/datasciencecluster_controller.go:317 +0x2c6
github.com/opendatahub-io/opendatahub-operator/v2/controllers/datasciencecluster.(*DataScienceClusterReconciler).Reconcile(0xc0001ba5a0, {0x2c8fbd0, 0xc003634000}, {{{0x0?, 0x0?}, {0xc00...}})
    /workspace/controllers/datasciencecluster/datasciencecluster_controller.go:243 +0xf77
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile(0x2c8fbd0?, {0x2c8fbd0?, 0xc003634000?}, {{{0x0?, 0x25892a0?}, {0xc008e391a6?, 0x2c7ea88?}}})
    /opt/app-root/src/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.14.6/pkg/internal/controller/controller.go:122 +0xb7
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler(0xc0005ffd60, {0x2c8fc08, 0xc00051cff0}, {0x2742e80?, 0xc0061bd440?})
    /opt/app-root/src/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.14.6/pkg/internal/controller/controller.go:323 +0x368
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem(0xc0005ffd60, {0x2c8fc08, 0xc00051cff0})
    /opt/app-root/src/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.14.6/pkg/internal/controller/controller.go:274 +0x1c9
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2()
    /opt/app-root/src/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.14.6/pkg/internal/controller/controller.go:235 +0x79
created by sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2 in goroutine 103
    /opt/app-root/src/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.14.6/pkg/internal/controller/controller.go:231 +0x565
```

</details>

Deploy controller image with this fix: `quay.io/bmajsak/opendatahub-operator:serverless-managed-check`

<details>
<summary>With this fix, there's an error instead</summary>

```json
{
  "level": "error",
  "ts": "2024-08-16T09:47:53Z",
  "logger": "opendatahub.controllers.DataScienceCluster",
  "msg": "failed to reconcile kserve on DataScienceCluster",
  "instance.Name": "default",
  "error": "ServiceMesh needs to be configured and 'Managed' in DSCI CR, it is required by KServe serving field",
  "stacktrace": "github.com/opendatahub-io/opendatahub-operator/v2/controllers/datasciencecluster.(*DataScienceClusterReconciler).reportError\n\t/workspace/controllers/datasciencecluster/datasciencecluster_controller.go:357\ngithub.com/opendatahub-io/opendatahub-operator/v2/controllers/datasciencecluster.(*DataScienceClusterReconciler).reconcileSubComponent\n\t/workspace/controllers/datasciencecluster/datasciencecluster_controller.go:321\ngithub.com/opendatahub-io/opendatahub-operator/v2/controllers/datasciencecluster.(*DataScienceClusterReconciler).Reconcile\n\t/workspace/controllers/datasciencecluster/datasciencecluster_controller.go:243\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile\n\t/opt/app-root/src/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.14.6/pkg/internal/controller/controller.go:122\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\t/opt/app-root/src/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.14.6/pkg/internal/controller/controller.go:323\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/opt/app-root/src/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.14.6/pkg/internal/controller/controller.go:274\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2\n\t/opt/app-root/src/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.14.6/pkg/internal/controller/controller.go:235"
}

```
</details>

## Screenshot or short clip

<details>
<summary>Short clip</summary>

![short-clip](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExNnhqMmg1cm9ianJpMmxlNjVzZWVhOWZhdGtsODJsYnZkbmQ5ZGlnNSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/Ju7l5y9osyymQ/giphy.gif)

</details>

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
