### PR TITLE
fix(feature): cleanup funcs should not rely on feature's data

### DIFF
--- a/controllers/dscinitialization/servicemesh_setup.go
+++ b/controllers/dscinitialization/servicemesh_setup.go
@@ -203,7 +203,10 @@ func (r *DSCInitializationReconciler) authorizationFeatures(instance *dsciv1.DSC
 					feature.WaitForPodsToBeReady(serviceMeshSpec.ControlPlane.Namespace),
 				).
 				OnDelete(
-					servicemesh.RemoveExtensionProvider,
+					servicemesh.RemoveExtensionProvider(
+						instance.Spec.ServiceMesh.ControlPlane,
+						instance.Spec.ApplicationsNamespace+"-auth-provider",
+					),
 				),
 
 			// We do not have the control over deployment resource creation.

--- a/pkg/feature/builder.go
+++ b/pkg/feature/builder.go
@@ -174,11 +174,7 @@ func (fb *featureBuilder) PostConditions(postconditions ...Action) *featureBuild
 }
 
 // OnDelete allow to add cleanup hooks that are executed when the feature is going to be deleted.
-// By default, all resources created by the feature are deleted when the feature is deleted, so there is no need to
-// explicitly add cleanup hooks for them.
-//
-// This is useful when you need to perform some additional cleanup actions such as removing effects of a patch operation.
-func (fb *featureBuilder) OnDelete(cleanups ...Action) *featureBuilder {
+func (fb *featureBuilder) OnDelete(cleanups ...CleanupFunc) *featureBuilder {
 	fb.builders = append(fb.builders, func(f *Feature) error {
 		f.addCleanup(cleanups...)
 

--- a/pkg/feature/servicemesh/cleanup.go
+++ b/pkg/feature/servicemesh/cleanup.go
@@ -2,65 +2,62 @@ package servicemesh
 
 import (
 	"context"
-	"fmt"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	infrav1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/infrastructure/v1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/feature"
 )
 
-func RemoveExtensionProvider(ctx context.Context, f *feature.Feature) error {
-	extensionName, errExtName := FeatureData.Authorization.ExtensionProviderName.Extract(f)
-	if errExtName != nil {
-		return fmt.Errorf("failed to get extension name struct: %w", errExtName)
-	}
+func RemoveExtensionProvider(controlPlane infrav1.ControlPlaneSpec, extensionName string) feature.CleanupFunc {
+	return func(ctx context.Context, cli client.Client) error {
+		smcp := &unstructured.Unstructured{}
+		smcp.SetGroupVersionKind(gvk.ServiceMeshControlPlane)
 
-	controlPlane, err := FeatureData.ControlPlane.Extract(f)
-	if err != nil {
-		return fmt.Errorf("failed to get control plane struct: %w", err)
-	}
+		if err := cli.Get(ctx, client.ObjectKey{
+			Namespace: controlPlane.Namespace,
+			Name:      controlPlane.Name,
+		}, smcp); err != nil {
+			return client.IgnoreNotFound(err)
+		}
 
-	smcp := &unstructured.Unstructured{}
-	smcp.SetGroupVersionKind(gvk.ServiceMeshControlPlane)
+		extensionProviders, found, err := unstructured.NestedSlice(smcp.Object, "spec", "techPreview", "meshConfig", "extensionProviders")
+		if err != nil {
+			return err
+		}
+		if !found {
+			return nil
+		}
 
-	if err := f.Client.Get(ctx, client.ObjectKey{
-		Namespace: controlPlane.Namespace,
-		Name:      controlPlane.Name,
-	}, smcp); err != nil {
-		return client.IgnoreNotFound(err)
-	}
+		removed := false
 
-	extensionProviders, found, err := unstructured.NestedSlice(smcp.Object, "spec", "techPreview", "meshConfig", "extensionProviders")
-	if err != nil {
-		return err
-	}
-	if !found {
-		f.Log.Info("no extension providers found", "feature", f.Name, "control-plane", controlPlane.Name, "namespace", controlPlane.Namespace)
+		for i, v := range extensionProviders {
+			extensionProvider, ok := v.(map[string]interface{})
+			if !ok {
+				continue
+			}
+
+			currentExtensionName, isString := extensionProvider["name"].(string)
+			if !isString {
+				continue
+			}
+			if currentExtensionName == extensionName {
+				extensionProviders = append(extensionProviders[:i], extensionProviders[i+1:]...)
+				err = unstructured.SetNestedSlice(smcp.Object, extensionProviders, "spec", "techPreview", "meshConfig", "extensionProviders")
+				if err != nil {
+					return err
+				}
+				removed = true
+				break
+			}
+		}
+
+		if removed {
+			return cli.Update(ctx, smcp)
+		}
+
 		return nil
 	}
-
-	for i, v := range extensionProviders {
-		extensionProvider, ok := v.(map[string]interface{})
-		if !ok {
-			f.Log.Info("WARN: Unexpected type for extensionProvider, it will not be removed")
-			continue
-		}
-		currentExtensionName, isString := extensionProvider["name"].(string)
-		if !isString {
-			f.Log.Info("WARN: Unexpected type for currentExtensionName, it will not be removed")
-			continue
-		}
-		if currentExtensionName == extensionName {
-			extensionProviders = append(extensionProviders[:i], extensionProviders[i+1:]...)
-			err = unstructured.SetNestedSlice(smcp.Object, extensionProviders, "spec", "techPreview", "meshConfig", "extensionProviders")
-			if err != nil {
-				return err
-			}
-			break
-		}
-	}
-
-	return f.Client.Update(ctx, smcp)
 }

--- a/tests/integration/features/servicemesh_feature_test.go
+++ b/tests/integration/features/servicemesh_feature_test.go
@@ -212,7 +212,10 @@ var _ = Describe("Service Mesh setup", func() {
 								servicemesh.FeatureData.ControlPlane.Define(&dsci.Spec).AsAction(),
 							).
 							OnDelete(
-								servicemesh.RemoveExtensionProvider,
+								servicemesh.RemoveExtensionProvider(
+									dsci.Spec.ServiceMesh.ControlPlane,
+									dsci.Spec.ApplicationsNamespace+"-auth-provider",
+								),
 							))
 					})
 


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
Initially, `Cleanup` functions did not rely on loading Feature's data for invocation, as certain data was held as fields of the Feature struct, making it implicitly available. With the refactoring of Feature to become a "glorified map" container, this behavior has changed, leading to errors under certain circumstances.

With `DSCI.ServiceMesh` now being a pointer to a struct, there is a corner case where the (now needed) ServiceMesh spec is `nil`, leading to a panic.

When the reconciliation of DSC is triggered, it is invoked for each component, even if it is never defined or changed. In a simple case where DSCI does not have a specified ServiceMesh (`nil` instead of the default), and DSC has a single `Managed` component that is not KServe/Serverless, the reconciliation will trigger the removal of KServe resources regardless. This, in turn, will call for the removal of Serverless features, which rely on SMCP config when they are applied. With data now being loaded in the cleanup step, this leads to an error, as there is no SMCP config to read from.

By default, the cleanup logic removes the owner FeatureTracker for each Feature, and this does not require loading Feature's data, as FeatureTracker is used as `OwnerReference` for each resource created for a given Feature.

In addition, the API allows defining custom functions that can be invoked during the clean up phase. There is one custom cleanup function requiring the Service Mesh control plane spec to remove part of the config introduced by its patch. The code in question only worked because it had default values to work on and was not failing if the patched object was not found.

The refactoring wrongly enforced the loading of Feature data during cleanup for this single case, and this cascaded to other Feature sets where it was unnecessary, exposing this faulty behavior.

With this change, no reference to Feature is enforced at the API level by introducing the `CleanupFunc(ctx, client)` type for defining custom cleanup logic. The custom patch function has been reworked to comply with this.

## How Has This Been Tested?

Create following DSCI and DSC:

```yaml
apiVersion: dscinitialization.opendatahub.io/v1
kind: DSCInitialization
metadata:
  name: default
spec:
  applicationsNamespace: opendatahub
  trustedCABundle:
    managementState: Removed
  monitoring:
    managementState: Managed
    namespace: opendatahub
---
apiVersion: datasciencecluster.opendatahub.io/v1
kind: DataScienceCluster
metadata:
  name: default
spec:
  components:
    modelregistry:
      managementState: "Managed"
```

<details>
<summary>Observe PANIC</summary>

```bash
panic: runtime error: invalid memory address or nil pointer dereference [recovered]                                                                                                           
    panic: runtime error: invalid memory address or nil pointer dereference                                                                                                                   
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x243ac21]                                                                                                                       
                                                                                                                                                                                              
goroutine 597 [running]:                                                                                                                                                                      
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile.func1()                                                                                                        
    /opt/app-root/src/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.14.6/pkg/internal/controller/controller.go:119 +0x1e5                                                                      
panic({0x26904e0?, 0x3e1baa0?})                                                                                                                                                               
    /usr/lib/golang/src/runtime/panic.go:914 +0x21f                                                                                                                                           
github.com/opendatahub-io/opendatahub-operator/v2/pkg/feature/servicemesh.glob..func1.1({0xc003f6d810?, 0x7?}, {0xc003f6d820?, 0xf?})                                                         
    /workspace/pkg/feature/servicemesh/data.go:35 +0x21                                                                                                                                       
github.com/opendatahub-io/opendatahub-operator/v2/pkg/feature.DataEntry[...].func1(0xc00355e500?)                                                                                             
    /workspace/pkg/feature/feature_data.go:17 +0x65                                                                                                                                           
github.com/opendatahub-io/opendatahub-operator/v2/pkg/feature.(*Feature).Cleanup(0xc00355e500, {0x2c8ef30, 0xc0033e1b00})                                                                     
    /workspace/pkg/feature/feature.go:146 +0x154                                                                                                                                              
github.com/opendatahub-io/opendatahub-operator/v2/pkg/feature.(*FeaturesHandler).Delete(0xc000ecbf20, {0x2c8ef30, 0xc0033e1b00})                                                              
    /workspace/pkg/feature/handler.go:87 +0x165                                                                                                                                               
github.com/opendatahub-io/opendatahub-operator/v2/components/kserve.(*Kserve).removeServerlessFeatures(0xc0004a59e8, {0x2c8ef30, 0xc0033e1b00}, 0xc0000194a0)                                 
    /workspace/components/kserve/kserve_config_handler.go:155 +0x185                                                                                                                          
github.com/opendatahub-io/opendatahub-operator/v2/components/kserve.(*Kserve).ReconcileComponent(0xc0004a59e8, {0x2c8ef30, 0xc0033e1b00}, {0x2c98728, 0xc000016480}, {{0x2c940c0?, 0xc000711bf
0?}, 0x3ff0000000000000?}, {0x2ca3f70, 0xc0006a0a80}, ...)                                                                                                                                    
    /workspace/components/kserve/kserve.go:110 +0x25f                                                                                                                                         
github.com/opendatahub-io/opendatahub-operator/v2/controllers/datasciencecluster.(*DataScienceClusterReconciler).reconcileSubComponent(0xc000019450, {0x2c8ef30, 0xc0033e1b00}, 0xc0006a0a80, 
{0x7f52b80c8d30, 0xc0004a59e8})                                                                                                                                                               
    /workspace/controllers/datasciencecluster/datasciencecluster_controller.go:317 +0x2c6                                                                                                     
github.com/opendatahub-io/opendatahub-operator/v2/controllers/datasciencecluster.(*DataScienceClusterReconciler).Reconcile(0xc000019450, {0x2c8ef30, 0xc0033e1b00}, {{{0x0?, 0x0?}, {0xc003fb7
a76?, 0xe64a85?}}})                                                                                                                                                                           
    /workspace/controllers/datasciencecluster/datasciencecluster_controller.go:243 +0xf77                                                                                                     
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile(0x2c8ef30?, {0x2c8ef30?, 0xc0033e1b00?}, {{{0x0?, 0x25886e0?}, {0xc003fb7a76?, 0x2c7dde8?}}})                  
    /opt/app-root/src/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.14.6/pkg/internal/controller/controller.go:122 +0xb7                                                                       
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler(0xc000484780, {0x2c8ef68, 0xc000018730}, {0x27422c0?, 0xc003520120?})                                   
    /opt/app-root/src/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.14.6/pkg/internal/controller/controller.go:323 +0x368                                                                      
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem(0xc000484780, {0x2c8ef68, 0xc000018730})                                                             
    /opt/app-root/src/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.14.6/pkg/internal/controller/controller.go:274 +0x1c9                                                                      
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2()                                                                                                          
    /opt/app-root/src/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.14.6/pkg/internal/controller/controller.go:235 +0x79                                                                       
created by sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2 in goroutine 132                                                                                  
    /opt/app-root/src/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.14.6/pkg/internal/controller/controller.go:231 +0x565
```

</details>

Deploy image `quay.io/bmajsak/opendatahub-operator:cleanup-fix` with this fix

.... no error \o/


## Screenshot or short clip

<details>
<summary>PANIC</summary>

![panic](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExMTgxd3hvYW90dDlod3pnNTg3YWM0YWFhajd6c2NhdXQxZW0zN3czYSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/jIw2JjXd7On9UpGu0V/giphy.gif)

</details>

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
