### PR TITLE
fix: add missing owner on knative-serving-cert

### DIFF
--- a/pkg/feature/serverless/resources.go
+++ b/pkg/feature/serverless/resources.go
@@ -27,7 +27,7 @@ func ServingCertificateResource(ctx context.Context, cli client.Client, f *featu
 	case infrav1.Provided:
 		return nil
 	default:
-		return cluster.PropagateDefaultIngressCertificate(ctx, cli, secretData.Name, secretData.Namespace)
+		return cluster.PropagateDefaultIngressCertificate(ctx, cli, secretData.Name, secretData.Namespace, feature.DefaultMetaOptions(f)...)
 	}
 }
 


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->
(out of this comment i had in another PR https://github.com/opendatahub-io/opendatahub-operator/pull/1165#discussion_r1719757151)
- why using default ingress cert, owner is not set to FTer: serverless-serving-gateway
- this makes the cleanup did not get this secret removed


<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
local build: quay.io/wenzhou/opendatahub-operator:2.16.98 

- enable kserve
- check knative-serving-cert
- has FTer set there
- delete DSCI, knative-serving-cert is removed

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->
![short-clip](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExNHcyMTVxYjBqazl6YjhoZWt1MmdoZHh2ejFhZjg2bXBpNWJtMzNheiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9dg/E1gszwEsNMHGoven31/giphy.gif)

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
