### PR TITLE
deploy: ApplyParams: do not write params.env if there are no updates

### DIFF
--- a/pkg/deploy/envParams.go
+++ b/pkg/deploy/envParams.go
@@ -53,6 +53,17 @@ func writeParamsToTmp(params map[string]string, tmpDir string) (string, error) {
 	return tmp.Name(), nil
 }
 
+// updateMap returns the number of updates made (it operates on 1 field, so 0 or 1 only).
+func updateMap(m *map[string]string, key, val string) int {
+	old := (*m)[key]
+	if old == val {
+		return 0
+	}
+
+	(*m)[key] = val
+	return 1
+}
+
 /*
 overwrite values in components' manifests params.env file
 This is useful for air gapped cluster
@@ -75,20 +86,28 @@ func ApplyParams(componentPath string, imageParamsMap map[string]string, extraPa
 		return err
 	}
 
+	// will be used as a boolean (0 or non-0) and accumulate result of updates of every field
+	// Could use sum, but safe from hypothetically integer overflow
+	updated := 0
+
 	// 1. Update images with env variables
 	// e.g "odh-kuberay-operator-controller-image": "RELATED_IMAGE_ODH_KUBERAY_OPERATOR_CONTROLLER_IMAGE",
 	for i := range paramsEnvMap {
 		relatedImageValue := os.Getenv(imageParamsMap[i])
 		if relatedImageValue != "" {
-			paramsEnvMap[i] = relatedImageValue
+			updated |= updateMap(&paramsEnvMap, i, relatedImageValue)
 		}
 	}
 
 	// 2. Update other fileds with extraParamsMap which are not carried from component
 	for _, extraParamsMap := range extraParamsMaps {
 		for eKey, eValue := range extraParamsMap {
-			paramsEnvMap[eKey] = eValue
+			updated |= updateMap(&paramsEnvMap, eKey, eValue)
 		}
+	}
+
+	if updated == 0 {
+		return nil
 	}
 
 	tmp, err := writeParamsToTmp(paramsEnvMap, componentPath)


### PR DESCRIPTION
Optimize file operations, do not rewrite params.env on every reconcile if no updates for it. In practice updates happen only on the first run.

Jira:  https://issues.redhat.com/browse/RHOAIENG-11594

<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
