### PR TITLE
components: move params.env image updating to Init stage

### DIFF
--- a/components/codeflare/codeflare.go
+++ b/components/codeflare/codeflare.go
@@ -12,6 +12,7 @@ import (
 	operatorv1 "github.com/openshift/api/operator/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	dsciv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/dscinitialization/v1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/components"
@@ -33,6 +34,20 @@ var _ components.ComponentInterface = (*CodeFlare)(nil)
 // +kubebuilder:object:generate=true
 type CodeFlare struct {
 	components.Component `json:""`
+}
+
+func (c *CodeFlare) Init(ctx context.Context, _ cluster.Platform) error {
+	log := logf.FromContext(ctx).WithName(ComponentName)
+
+	var imageParamMap = map[string]string{
+		"codeflare-operator-controller-image": "RELATED_IMAGE_ODH_CODEFLARE_OPERATOR_IMAGE", // no need mcad, embedded in cfo
+	}
+
+	if err := deploy.ApplyParams(ParamsPath, imageParamMap); err != nil {
+		log.Error(err, "failed to update image", "path", CodeflarePath+"/bases")
+	}
+
+	return nil
 }
 
 func (c *CodeFlare) OverrideManifests(ctx context.Context, _ cluster.Platform) error {
@@ -64,10 +79,6 @@ func (c *CodeFlare) ReconcileComponent(ctx context.Context,
 	dscispec *dsciv1.DSCInitializationSpec,
 	platform cluster.Platform,
 	_ bool) error {
-	var imageParamMap = map[string]string{
-		"codeflare-operator-controller-image": "RELATED_IMAGE_ODH_CODEFLARE_OPERATOR_IMAGE", // no need mcad, embedded in cfo
-	}
-
 	enabled := c.GetManagementState() == operatorv1.Managed
 	monitoringEnabled := dscispec.Monitoring.ManagementState == operatorv1.Managed
 
@@ -89,11 +100,9 @@ func (c *CodeFlare) ReconcileComponent(ctx context.Context,
 				dependentOperator, ComponentName)
 		}
 
-		// Update image parameters only when we do not have customized manifests set
-		if (dscispec.DevFlags == nil || dscispec.DevFlags.ManifestsUri == "") && (c.DevFlags == nil || len(c.DevFlags.Manifests) == 0) {
-			if err := deploy.ApplyParams(ParamsPath, imageParamMap, map[string]string{"namespace": dscispec.ApplicationsNamespace}); err != nil {
-				return fmt.Errorf("failed update image from %s : %w", CodeflarePath+"/bases", err)
-			}
+		// It updates stock manifests, overridden manifests should contain proper namespace
+		if err := deploy.ApplyParams(ParamsPath, nil, map[string]string{"namespace": dscispec.ApplicationsNamespace}); err != nil {
+			return fmt.Errorf("failed update image from %s : %w", CodeflarePath+"/bases", err)
 		}
 	}
 

--- a/components/component.go
+++ b/components/component.go
@@ -38,6 +38,10 @@ type Component struct {
 	DevFlags *DevFlags `json:"devFlags,omitempty"`
 }
 
+func (c *Component) Init(_ context.Context, _ cluster.Platform) error {
+	return nil
+}
+
 func (c *Component) GetManagementState() operatorv1.ManagementState {
 	return c.ManagementState
 }
@@ -77,6 +81,7 @@ type ManifestsConfig struct {
 }
 
 type ComponentInterface interface {
+	Init(ctx context.Context, platform cluster.Platform) error
 	ReconcileComponent(ctx context.Context, cli client.Client, logger logr.Logger,
 		owner metav1.Object, DSCISpec *dsciv1.DSCInitializationSpec, platform cluster.Platform, currentComponentStatus bool) error
 	Cleanup(ctx context.Context, cli client.Client, owner metav1.Object, DSCISpec *dsciv1.DSCInitializationSpec) error

--- a/components/trainingoperator/trainingoperator.go
+++ b/components/trainingoperator/trainingoperator.go
@@ -12,6 +12,7 @@ import (
 	operatorv1 "github.com/openshift/api/operator/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	dsciv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/dscinitialization/v1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/components"
@@ -31,6 +32,20 @@ var _ components.ComponentInterface = (*TrainingOperator)(nil)
 // +kubebuilder:object:generate=true
 type TrainingOperator struct {
 	components.Component `json:""`
+}
+
+func (r *TrainingOperator) Init(ctx context.Context, _ cluster.Platform) error {
+	log := logf.FromContext(ctx).WithName(ComponentName)
+
+	var imageParamMap = map[string]string{
+		"odh-training-operator-controller-image": "RELATED_IMAGE_ODH_TRAINING_OPERATOR_IMAGE",
+	}
+
+	if err := deploy.ApplyParams(TrainingOperatorPath, imageParamMap); err != nil {
+		log.Error(err, "failed to update image", "path", TrainingOperatorPath)
+	}
+
+	return nil
 }
 
 func (r *TrainingOperator) OverrideManifests(ctx context.Context, _ cluster.Platform) error {
@@ -57,10 +72,6 @@ func (r *TrainingOperator) GetComponentName() string {
 
 func (r *TrainingOperator) ReconcileComponent(ctx context.Context, cli client.Client, l logr.Logger,
 	owner metav1.Object, dscispec *dsciv1.DSCInitializationSpec, platform cluster.Platform, _ bool) error {
-	var imageParamMap = map[string]string{
-		"odh-training-operator-controller-image": "RELATED_IMAGE_ODH_TRAINING_OPERATOR_IMAGE",
-	}
-
 	enabled := r.GetManagementState() == operatorv1.Managed
 	monitoringEnabled := dscispec.Monitoring.ManagementState == operatorv1.Managed
 
@@ -68,11 +79,6 @@ func (r *TrainingOperator) ReconcileComponent(ctx context.Context, cli client.Cl
 		if r.DevFlags != nil {
 			// Download manifests and update paths
 			if err := r.OverrideManifests(ctx, platform); err != nil {
-				return err
-			}
-		}
-		if (dscispec.DevFlags == nil || dscispec.DevFlags.ManifestsUri == "") && (r.DevFlags == nil || len(r.DevFlags.Manifests) == 0) {
-			if err := deploy.ApplyParams(TrainingOperatorPath, imageParamMap); err != nil {
 				return err
 			}
 		}

--- a/components/trustyai/trustyai.go
+++ b/components/trustyai/trustyai.go
@@ -11,6 +11,7 @@ import (
 	operatorv1 "github.com/openshift/api/operator/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	dsciv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/dscinitialization/v1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/components"
@@ -24,6 +25,7 @@ var (
 	PathUpstream      = deploy.DefaultManifestPath + "/" + ComponentPathName + "/overlays/odh"
 	PathDownstream    = deploy.DefaultManifestPath + "/" + ComponentPathName + "/overlays/rhoai"
 	OverridePath      = ""
+	DefaultPath       = ""
 )
 
 // Verifies that TrustyAI implements ComponentInterface.
@@ -33,6 +35,27 @@ var _ components.ComponentInterface = (*TrustyAI)(nil)
 // +kubebuilder:object:generate=true
 type TrustyAI struct {
 	components.Component `json:""`
+}
+
+func (t *TrustyAI) Init(ctx context.Context, platform cluster.Platform) error {
+	log := logf.FromContext(ctx).WithName(ComponentName)
+
+	DefaultPath = map[cluster.Platform]string{
+		cluster.SelfManagedRhods: PathDownstream,
+		cluster.ManagedRhods:     PathDownstream,
+		cluster.OpenDataHub:      PathUpstream,
+		cluster.Unknown:          PathUpstream,
+	}[platform]
+	var imageParamMap = map[string]string{
+		"trustyaiServiceImage":  "RELATED_IMAGE_ODH_TRUSTYAI_SERVICE_IMAGE",
+		"trustyaiOperatorImage": "RELATED_IMAGE_ODH_TRUSTYAI_SERVICE_OPERATOR_IMAGE",
+	}
+
+	if err := deploy.ApplyParams(DefaultPath, imageParamMap); err != nil {
+		log.Error(err, "failed to update image", "path", DefaultPath)
+	}
+
+	return nil
 }
 
 func (t *TrustyAI) OverrideManifests(ctx context.Context, _ cluster.Platform) error {
@@ -58,19 +81,9 @@ func (t *TrustyAI) GetComponentName() string {
 
 func (t *TrustyAI) ReconcileComponent(ctx context.Context, cli client.Client, l logr.Logger,
 	owner metav1.Object, dscispec *dsciv1.DSCInitializationSpec, platform cluster.Platform, _ bool) error {
-	var imageParamMap = map[string]string{
-		"trustyaiServiceImage":  "RELATED_IMAGE_ODH_TRUSTYAI_SERVICE_IMAGE",
-		"trustyaiOperatorImage": "RELATED_IMAGE_ODH_TRUSTYAI_SERVICE_OPERATOR_IMAGE",
-	}
-	entryPath := map[cluster.Platform]string{
-		cluster.SelfManagedRhods: PathDownstream,
-		cluster.ManagedRhods:     PathDownstream,
-		cluster.OpenDataHub:      PathUpstream,
-		cluster.Unknown:          PathUpstream,
-	}[platform]
-
 	enabled := t.GetManagementState() == operatorv1.Managed
 	monitoringEnabled := dscispec.Monitoring.ManagementState == operatorv1.Managed
+	entryPath := DefaultPath
 
 	if enabled {
 		if t.DevFlags != nil {
@@ -80,11 +93,6 @@ func (t *TrustyAI) ReconcileComponent(ctx context.Context, cli client.Client, l 
 			}
 			if OverridePath != "" {
 				entryPath = OverridePath
-			}
-		}
-		if (dscispec.DevFlags == nil || dscispec.DevFlags.ManifestsUri == "") && (t.DevFlags == nil || len(t.DevFlags.Manifests) == 0) {
-			if err := deploy.ApplyParams(entryPath, imageParamMap); err != nil {
-				return fmt.Errorf("failed to update image %s: %w", entryPath, err)
 			}
 		}
 	}

--- a/components/workbenches/workbenches.go
+++ b/components/workbenches/workbenches.go
@@ -12,6 +12,7 @@ import (
 	operatorv1 "github.com/openshift/api/operator/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	dsciv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/dscinitialization/v1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/components"
@@ -38,6 +39,26 @@ var _ components.ComponentInterface = (*Workbenches)(nil)
 // +kubebuilder:object:generate=true
 type Workbenches struct {
 	components.Component `json:""`
+}
+
+func (w *Workbenches) Init(ctx context.Context, _ cluster.Platform) error {
+	log := logf.FromContext(ctx).WithName(ComponentName)
+
+	var imageParamMap = map[string]string{
+		"odh-notebook-controller-image":    "RELATED_IMAGE_ODH_NOTEBOOK_CONTROLLER_IMAGE",
+		"odh-kf-notebook-controller-image": "RELATED_IMAGE_ODH_KF_NOTEBOOK_CONTROLLER_IMAGE",
+	}
+
+	// for kf-notebook-controller image
+	if err := deploy.ApplyParams(notebookControllerPath, imageParamMap); err != nil {
+		log.Error(err, "failed to update image", "path", notebookControllerPath)
+	}
+	// for odh-notebook-controller image
+	if err := deploy.ApplyParams(kfnotebookControllerPath, imageParamMap); err != nil {
+		log.Error(err, "failed to update image", "path", kfnotebookControllerPath)
+	}
+
+	return nil
 }
 
 func (w *Workbenches) OverrideManifests(ctx context.Context, platform cluster.Platform) error {
@@ -92,11 +113,6 @@ func (w *Workbenches) GetComponentName() string {
 
 func (w *Workbenches) ReconcileComponent(ctx context.Context, cli client.Client, l logr.Logger,
 	owner metav1.Object, dscispec *dsciv1.DSCInitializationSpec, platform cluster.Platform, _ bool) error {
-	var imageParamMap = map[string]string{
-		"odh-notebook-controller-image":    "RELATED_IMAGE_ODH_NOTEBOOK_CONTROLLER_IMAGE",
-		"odh-kf-notebook-controller-image": "RELATED_IMAGE_ODH_KF_NOTEBOOK_CONTROLLER_IMAGE",
-	}
-
 	// Set default notebooks namespace
 	// Create rhods-notebooks namespace in managed platforms
 	enabled := w.GetManagementState() == operatorv1.Managed
@@ -123,19 +139,6 @@ func (w *Workbenches) ReconcileComponent(ctx context.Context, cli client.Client,
 		}
 	}
 
-	// Update image parameters for nbc
-	if enabled {
-		if (dscispec.DevFlags == nil || dscispec.DevFlags.ManifestsUri == "") && (w.DevFlags == nil || len(w.DevFlags.Manifests) == 0) {
-			// for kf-notebook-controller image
-			if err := deploy.ApplyParams(notebookControllerPath, imageParamMap); err != nil {
-				return fmt.Errorf("failed to update image %s: %w", notebookControllerPath, err)
-			}
-			// for odh-notebook-controller image
-			if err := deploy.ApplyParams(kfnotebookControllerPath, imageParamMap); err != nil {
-				return fmt.Errorf("failed to update image %s: %w", kfnotebookControllerPath, err)
-			}
-		}
-	}
 	if err := deploy.DeployManifestsFromPath(ctx, cli, owner,
 		notebookControllerPath,
 		dscispec.ApplicationsNamespace,


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/RHOAIENG-11592

Image names in environment are not supposed to be changed during
runtime of the operator, so it makes sense to update them only on
startup.

If manifests are overriden by DevFlags, the DevFlags' version will
be used.

The change is straight forward for most of the components where only
images are updated and params.env is located in the kustomize root
directory, but some components (dashboard, ray, codeflare,
modelregistry) also update some extra parameters. For them image
part only is moved to Init since other updates require runtime DSCI
information.

The patch also changes logic for ray, codeflare, and modelregistry
in this regard to update non-image parameters regardless of DevFlags
like it was changed in dashboard recently.

The DevFlags functionality brings some concerns:

- For most components the code is written such a way that as soon as
DevFlags supplied the global path variables are changed and never
reverted back to the defaults. For some (dashboard, trustyai) there
is (still global) OverridePath/entryPath pair and manifests reverted
to the default, BUT there is no logic of transition.

- codeflare: when manifests are overridden namespace param is
updated in the hardcoded (stock) path;

This logic is preserved.

<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
