### PR TITLE
chore: use /usr/bin/env to locate the bash interpreter based on the user's PATH settings.

### DIFF
--- a/get_all_manifests.sh
+++ b/get_all_manifests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 GITHUB_URL="https://github.com"


### PR DESCRIPTION
On MacOSX, /bin/bash is quite outdate 3.2.57 and does not suport
`declare -A` which leads to the get_all_manifests.sh to fail.

Signed-off-by: Luca Burgazzoli <lburgazzoli@gmail.com>

<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] ~~Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.~~
- [ ] ~~Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).~~
- [ ] ~~The developer has manually tested the changes and verified that the changes work~~
