### PR TITLE
chore: Rework release automation - ||

### DIFF
--- a/.github/scripts/get-component-release-notes.js
+++ b/.github/scripts/get-component-release-notes.js
@@ -1,37 +1,8 @@
-
-function getComponentName(name){
-    switch(name){
-        case "codeflare":
-            return "Codeflare"
-        case "ray":
-            return "Ray"
-        case "kueue":
-            return "Kueue"
-        case "data-science-pipelines-operator":
-            return "Datascience Pipelines"
-        case "odh-dashboard":
-            return "Dashboard"
-        case "notebook-controller":
-            return "Notebook controller"
-        case "notebooks":
-            return "Notebooks"
-        case "trustyai":
-            return "TrustyAI"
-        case "model-mesh":
-            return "Model mesh"
-        case "odh-model-controller":
-            return "ODH Model Controller"
-        case "kserve":
-            return "Kserve"
-        case "modelregistry":
-            return "Model Registry"
-        case "trainingoperator":
-            return "Training operator"
-        default:
-            return null
-    }   
+function getModifiedComponentName(name){
+    let modifiedWord = name.split("-").join(" ")
+    modifiedWord = modifiedWord[0].toUpperCase() + modifiedWord.slice(1).toLowerCase()
+    return modifiedWord.replace("Odh", "ODH")
 }
-
 module.exports = ({ github, core }) => {
     const { TRACKER_URL } = process.env
     console.log(`The TRACKER_URL is ${TRACKER_URL}`)
@@ -50,9 +21,6 @@ module.exports = ({ github, core }) => {
         }
     }).then((result) => {
         let outputStr = "## Component Release Notes\n"
-        let servingComponents = '- **Serving**\n\t'
-        let distributedWorkloadComponents = '- **Distributed Workloads**\n\t'
-        let workbenchComponents= '- **Workbench**\n\t'
         result.data.forEach((issue) => {
             let issueCommentBody = issue.body_text
             if (issueCommentBody.includes("#Release#")) {
@@ -64,26 +32,13 @@ module.exports = ({ github, core }) => {
                     if (regex.test(component)) {
                         let [componentName, branchUrl, tagUrl] = component.split("|")
                         componentName = componentName.trim()
-                        let releaseNotesUrl = tagUrl
-                        if(!releaseNotesUrl){
-                            releaseNotesUrl = branchUrl
-                        }
-                        releaseNotesUrl = releaseNotesUrl.trim()
-                        if(["model-mesh", "kserve","odh-model-controller"].includes(componentName)){
-                           servingComponents+=` - ${getComponentName(componentName)}: ${releaseNotesUrl}\n\t`
-                        }else if(["codeflare", "ray", "kueue", "trainingoperator"].includes(componentName)){
-                            distributedWorkloadComponents+=` - ${getComponentName(componentName)}: ${releaseNotesUrl}\n\t`
-                        }else if(["notebooks", "notebook-controller"].includes(componentName)){
-                            workbenchComponents+=` - ${getComponentName(componentName)}: ${releaseNotesUrl}\n\t`
-                        }else{
-                            outputStr+= getComponentName(componentName)?`- **${getComponentName(componentName)}**: ${releaseNotesUrl}\n`:""
-                        }
+                        const releaseNotesUrl = (tagUrl || branchUrl).trim();
+                        outputStr += `- **${getModifiedComponentName(componentName)}**: ${releaseNotesUrl}\n`
         
                     }
                 })
             }
         })
-        outputStr+=servingComponents.slice(0,-1)+distributedWorkloadComponents.slice(0,-1)+workbenchComponents.slice(0,-1)
         console.log("Created component release notes successfully...")
         core.setOutput('release-notes-body', outputStr);
     }).catch(e => {

--- a/.github/scripts/get-component-release-notes.js
+++ b/.github/scripts/get-component-release-notes.js
@@ -1,3 +1,37 @@
+
+function getComponentName(name){
+    switch(name){
+        case "codeflare":
+            return "Codeflare"
+        case "ray":
+            return "Ray"
+        case "kueue":
+            return "Kueue"
+        case "data-science-pipelines-operator":
+            return "Datascience Pipelines"
+        case "odh-dashboard":
+            return "Dashboard"
+        case "notebook-controller":
+            return "Notebook controller"
+        case "notebooks":
+            return "Notebooks"
+        case "trustyai":
+            return "TrustyAI"
+        case "model-mesh":
+            return "Model mesh"
+        case "odh-model-controller":
+            return "ODH Model Controller"
+        case "kserve":
+            return "Kserve"
+        case "modelregistry":
+            return "Model Registry"
+        case "trainingoperator":
+            return "Training operator"
+        default:
+            return null
+    }   
+}
+
 module.exports = ({ github, core }) => {
     const { TRACKER_URL } = process.env
     console.log(`The TRACKER_URL is ${TRACKER_URL}`)
@@ -16,21 +50,40 @@ module.exports = ({ github, core }) => {
         }
     }).then((result) => {
         let outputStr = "## Component Release Notes\n"
+        let servingComponents = '- **Serving**\n\t'
+        let distributedWorkloadComponents = '- **Distributed Workloads**\n\t'
+        let workbenchComponents= '- **Workbench**\n\t'
         result.data.forEach((issue) => {
-            issueCommentBody = issue.body_text
+            let issueCommentBody = issue.body_text
             if (issueCommentBody.includes("#Release#")) {
                 let components = issueCommentBody.split("\n")
                 const releaseIdx = components.indexOf("#Release#")
                 components = components.splice(releaseIdx + 1, components.length)
-                const regex = /\s*[A-Za-z-_0-9]+\s*\|\s*(https:\/\/github\.com\/.*tree.*){1}\s*\|\s*(https:\/\/github\.com\/.*releases.*){1}\s*/;
+                const regex = /\s*[A-Za-z-_0-9]+\s*\|\s*(https:\/\/github\.com\/.*(tree|releases).*){1}\s*\|?\s*(https:\/\/github\.com\/.*releases.*)?\s*/;
                 components.forEach(component => {
                     if (regex.test(component)) {
-                        const [componentName, branchUrl, tagUrl] = component.split("|")
-                        outputStr += `- **${componentName.trim().charAt(0).toUpperCase() + componentName.trim().slice(1)}**: ${tagUrl.trim()}\n`
+                        let [componentName, branchUrl, tagUrl] = component.split("|")
+                        componentName = componentName.trim()
+                        let releaseNotesUrl = tagUrl
+                        if(!releaseNotesUrl){
+                            releaseNotesUrl = branchUrl
+                        }
+                        releaseNotesUrl = releaseNotesUrl.trim()
+                        if(["model-mesh", "kserve","odh-model-controller"].includes(componentName)){
+                           servingComponents+=` - ${getComponentName(componentName)}: ${releaseNotesUrl}\n\t`
+                        }else if(["codeflare", "ray", "kueue", "trainingoperator"].includes(componentName)){
+                            distributedWorkloadComponents+=` - ${getComponentName(componentName)}: ${releaseNotesUrl}\n\t`
+                        }else if(["notebooks", "notebook-controller"].includes(componentName)){
+                            workbenchComponents+=` - ${getComponentName(componentName)}: ${releaseNotesUrl}\n\t`
+                        }else{
+                            outputStr+= getComponentName(componentName)?`- **${getComponentName(componentName)}**: ${releaseNotesUrl}\n`:""
+                        }
+        
                     }
                 })
             }
         })
+        outputStr+=servingComponents.slice(0,-1)+distributedWorkloadComponents.slice(0,-1)+workbenchComponents.slice(0,-1)
         console.log("Created component release notes successfully...")
         core.setOutput('release-notes-body', outputStr);
     }).catch(e => {

--- a/.github/scripts/get-release-branches.js
+++ b/.github/scripts/get-release-branches.js
@@ -17,17 +17,22 @@ module.exports = ({ github, core }) => {
         }
     }).then((result) => {
         result.data.forEach((issue) => {
-            issueCommentBody = issue.body_text
+            let issueCommentBody = issue.body_text
             if (issueCommentBody.includes("#Release#")) {
                 let components = issueCommentBody.split("\n")
                 const releaseIdx = components.indexOf("#Release#")
                 components = components.splice(releaseIdx + 1, components.length)
-                const regex = /\s*[A-Za-z-_0-9]+\s*\|\s*(https:\/\/github\.com\/.*tree.*){1}\s*\|\s*(https:\/\/github\.com\/.*releases.*){1}\s*/;
+                const regex = /\s*[A-Za-z-_0-9]+\s*\|\s*(https:\/\/github\.com\/.*(tree|releases).*){1}\s*\|?\s*(https:\/\/github\.com\/.*releases.*)?\s*/;
                 components.forEach(component => {
                     if (regex.test(component)) {
-                        const [componentName, branchUrl] = component.split("|")
-                        const splitArr = branchUrl.trim().split("/")
-                        const idx = splitArr.indexOf("tree")
+                        const [componentName, branchOrTagUrl] = component.split("|")
+                        const splitArr = branchOrTagUrl.trim().split("/")
+                        let idx = null
+                        if (splitArr.includes("tag")) {
+                            idx = splitArr.indexOf("tag")
+                        } else if (splitArr.includes("tree")) {
+                            idx = splitArr.indexOf("tree")
+                        }
                         const branchName = splitArr.slice(idx + 1).join("/")
                         if (componentName.trim() === "notebook-controller") {
                             core.exportVariable("component_spec_odh-notebook-controller".toLowerCase(), branchName);

--- a/.github/workflows/pre-release.yaml
+++ b/.github/workflows/pre-release.yaml
@@ -46,12 +46,11 @@ jobs:
           pull-request-number: ${{ steps.cpr-dry-run.outputs.pull-request-number }}
           comment: Auto-closing pull request after success checks
           delete-branch: true
-      # Will enable this section once we have conformation from devops if we can use a bot to push tags.
-      # - name: Push version tag to quay.io
-      #   run: |
-      #     skopeo login -u ${{ secrets.QUAY_ID }} -p ${{ secrets.QUAY_TOKEN }} quay.io/{{ secrets.QUAY_ORG }}
-      #     skopeo copy docker://quay.io/{{ secrets.QUAY_ORG }}/opendatahub-operator:pr-${{ steps.cpr-dry-run.outputs.pull-request-number }} docker://quay.io/{{ secrets.QUAY_ORG }}/opendatahub-operator:${{ env.VERSION }}
-      #     echo "Successfully updated tag to quay.io with version: ${{ env.VERSION }}"
+      - name: Push version tag to quay.io
+        run: |
+          skopeo login -u ${{ secrets.QUAY_ID }} -p ${{ secrets.QUAY_TOKEN }} quay.io
+          skopeo copy docker://quay.io/${{ secrets.QUAY_ORG }}/opendatahub-operator:pr-${{ steps.cpr-dry-run.outputs.pull-request-number }} docker://quay.io/${{ secrets.QUAY_ORG }}/opendatahub-operator:${{ env.VERSION }}
+          echo "Successfully updated tag to quay.io with version: ${{ env.VERSION }}"
   release-branch-pr:
     needs: dry-run-pr
     runs-on: ubuntu-latest
@@ -80,10 +79,6 @@ jobs:
           commit-message: "ODH Release ${{ env.VERSION }}"
           title: "ODH Release ${{ env.VERSION }}: Version Update"
           branch-name: "odh-release/release-branch-update"
-      - name: Wait for checks to pass
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: ./.github/scripts/wait-for-checks.sh ${{ steps.cpr-release-pr.outputs.pull-request-number }}
       - name: Comment version and tracker url in the pr
         uses: thollander/actions-comment-pull-request@v2
         with:


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
The following changes are added
- Allow the tracker URL to support adding tags ie. 
  - If a component has both tag and branch as the same value then the tracker can be updated as `component_name|branch-or-tag-url`
  - If a component has different tag and branch values, the the tracker can be updated as 
  `component_name|branch-or-tag-url|release-notes-url`
- Remove wait for checks for the version update pr as we can manually verify the checks and merge(This merge will trigger the next set of gh actions)
- Improve grouping in the release notes. eg: Under "Serving" heading we should have the notes of Modelmesh, odh-model-controller etc
- Fix skopeo login issue


## How Has This Been Tested?
Tested in my repo:
https://github.com/AjayJagan/opendatahub-operator/actions/runs/10501974699
https://github.com/AjayJagan/opendatahub-operator/actions/runs/10502024580


## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
