### PR TITLE
feat: add servicemeshmember for model registry namespace, fixes RHOAIENG-11831

### DIFF
--- a/components/modelregistry/modelregistry.go
+++ b/components/modelregistry/modelregistry.go
@@ -200,9 +200,9 @@ func createServicemeshMember(ctx context.Context, cli client.Client, dscispec *d
 		return fmt.Errorf("error executing servicemeshmember template: %w", err)
 	}
 
-	unstructured, err := conversion.StrToUnstructured(builder.String())
-	if err != nil || len(unstructured) != 1 {
-		return fmt.Errorf("error converting servicemeshmember template to unstructured: %w", err)
+	unstrObj, err := conversion.StrToUnstructured(builder.String())
+	if err != nil || len(unstrObj) != 1 {
+		return fmt.Errorf("error converting servicemeshmember template: %w", err)
 	}
 
 	return client.IgnoreAlreadyExists(cli.Create(ctx, unstructured[0]))

--- a/components/modelregistry/modelregistry.go
+++ b/components/modelregistry/modelregistry.go
@@ -204,5 +204,5 @@ func createServicemeshMember(ctx context.Context, cli client.Client, dscispec *d
 		return fmt.Errorf("error converting servicemeshmember template to unstructured: %w", err)
 	}
 
-	return cli.Create(ctx, unstructured[0])
+	return client.IgnoreAlreadyExists(cli.Create(ctx, unstructured[0]))
 }

--- a/components/modelregistry/modelregistry.go
+++ b/components/modelregistry/modelregistry.go
@@ -191,11 +191,12 @@ func createServicemeshMember(ctx context.Context, cli client.Client, dscispec *d
 		return fmt.Errorf("error parsing servicemeshmember template: %w", err)
 	}
 	builder := strings.Builder{}
-	err = tmpl.Execute(&builder, struct {
+	controlPlaneData := struct {
 		Namespace    string
 		ControlPlane *infrav1.ControlPlaneSpec
-	}{Namespace: namespace.Name, ControlPlane: &dscispec.ServiceMesh.ControlPlane})
-	if err != nil {
+	}{Namespace: namespace.Name, ControlPlane: &dscispec.ServiceMesh.ControlPlane}
+	
+	if err = tmpl.Execute(&builder, controlPlaneData); err != nil {
 		return fmt.Errorf("error executing servicemeshmember template: %w", err)
 	}
 

--- a/components/modelregistry/modelregistry.go
+++ b/components/modelregistry/modelregistry.go
@@ -7,6 +7,8 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
+	"strings"
+	"text/template"
 
 	"github.com/go-logr/logr"
 	operatorv1 "github.com/openshift/api/operator/v1"
@@ -15,9 +17,13 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	dsciv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/dscinitialization/v1"
+	infrav1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/infrastructure/v1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/components"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/conversion"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/deploy"
+
+	_ "embed"
 )
 
 const DefaultModelRegistryCert = "default-modelregistry-cert"
@@ -27,8 +33,9 @@ var (
 	Path          = deploy.DefaultManifestPath + "/" + ComponentName + "/overlays/odh"
 	// we should not apply this label to the namespace, as it triggered namspace deletion during operator uninstall
 	// modelRegistryLabels = cluster.WithLabels(
-	// 	labels.ODH.OwnedNamespace, "true",
+	//      labels.ODH.OwnedNamespace, "true",
 	// ).
+	ModelRegistriesNamespace = "odh-model-registries"
 )
 
 // Verifies that ModelRegistry implements ComponentInterface.
@@ -100,9 +107,14 @@ func (m *ModelRegistry) ReconcileComponent(ctx context.Context, cli client.Clien
 			}
 		}
 
-		// Create odh-model-registries namespace
+		// Create model registries namespace
 		// We do not delete this namespace even when ModelRegistry is Removed or when operator is uninstalled.
-		_, err := cluster.CreateNamespace(ctx, cli, "odh-model-registries")
+		ns, err := cluster.CreateNamespace(ctx, cli, ModelRegistriesNamespace)
+		if err != nil {
+			return err
+		}
+		// create servicemeshmember here, for now until post MVP solution
+		err = createServicemeshMember(ctx, cli, dscispec, ns)
 		if err != nil {
 			return err
 		}
@@ -168,4 +180,29 @@ func (m *ModelRegistry) removeDependencies(ctx context.Context, cli client.Clien
 		return err
 	}
 	return nil
+}
+
+//go:embed resources/servicemesh-member.tmpl.yaml
+var smmTemplate string
+
+func createServicemeshMember(ctx context.Context, cli client.Client, dscispec *dsciv1.DSCInitializationSpec, namespace *corev1.Namespace) error {
+	tmpl, err := template.New("servicemeshmember").Parse(smmTemplate)
+	if err != nil {
+		return fmt.Errorf("error parsing servicemeshmember template: %w", err)
+	}
+	builder := strings.Builder{}
+	err = tmpl.Execute(&builder, struct {
+		Namespace    string
+		ControlPlane *infrav1.ControlPlaneSpec
+	}{Namespace: namespace.Name, ControlPlane: &dscispec.ServiceMesh.ControlPlane})
+	if err != nil {
+		return fmt.Errorf("error executing servicemeshmember template: %w", err)
+	}
+
+	unstructured, err := conversion.StrToUnstructured(builder.String())
+	if err != nil || len(unstructured) != 1 {
+		return fmt.Errorf("error converting servicemeshmember template to unstructured: %w", err)
+	}
+
+	return cli.Create(ctx, unstructured[0])
 }

--- a/components/modelregistry/resources/servicemesh-member.tmpl.yaml
+++ b/components/modelregistry/resources/servicemesh-member.tmpl.yaml
@@ -1,0 +1,9 @@
+apiVersion: maistra.io/v1
+kind: ServiceMeshMember
+metadata:
+  name: default
+  namespace: {{.Namespace}}
+spec:
+  controlPlaneRef:
+    namespace: {{ .ControlPlane.Namespace }}
+    name: {{ .ControlPlane.Name }}


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->
Add servicemeshmember for model registry namespace
Fixes RHOAIENG-11831

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added test to confirm that the smm gets created in the MR namespace

To verify that model registry component is worked, make sure it's set to Managed in the dsc, and perform the following steps:
1. Clone the model registry operator repo for sample configuration
2. Run the following commands to checkout the sample, create sample MR:
```shell
git clone git@github.com:opendatahub-io/model-registry-operator.git
cd model-registry-operator
oc project odh-model-registries
make certificates
oc apply -k config/samples/secure-db/mysql-tls/
oc wait --for=condition=Available=true modelregistries/modelregistry-sample --timeout=5m
```
3. Run the following commands to run a curl command against the sample MR API to verify it works:
```shell
export TOKEN=`oc whoami -t`
export DOMAIN=`oc get ingresses.config/cluster -o jsonpath='{.spec.domain}'`
curl -s -H "Authorization: Bearer $TOKEN" https://modelregistry-sample-rest.$DOMAIN/api/model_registry/v1alpha3/registered_models
```
4. The expected output should be similar to:
```json
{
  "items": [],
  "nextPageToken": "",
  "pageSize": 0,
  "size": 0
}
```

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [X] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [X] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work