### PR TITLE
tests: e2e: testApplicationCreation cleanup

### DIFF
--- a/tests/e2e/creation_test.go
+++ b/tests/e2e/creation_test.go
@@ -311,17 +311,13 @@ func (tc *testContext) testApplicationCreation(component components.ComponentInt
 			return false, fmt.Errorf("error listing application deployments :%w", err)
 		}
 		if len(appList.Items) != 0 {
-			allAppDeploymentsReady := true
 			for _, deployment := range appList.Items {
 				if deployment.Status.ReadyReplicas < 1 {
-					allAppDeploymentsReady = false
+					log.Printf("waiting for application deployments to be in Ready state.")
+					return false, nil
 				}
 			}
-			if allAppDeploymentsReady {
-				return true, nil
-			}
-			log.Printf("waiting for application deployments to be in Ready state.")
-			return false, nil
+			return true, nil
 		}
 		// when no deployment is found
 		return false, nil

--- a/tests/e2e/creation_test.go
+++ b/tests/e2e/creation_test.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"log"
 	"reflect"
-	"strings"
 	"testing"
 	"time"
 
@@ -325,12 +324,6 @@ func (tc *testContext) testApplicationCreation(component components.ComponentInt
 			return false, nil
 		}
 		// when no deployment is found
-		// check Reconcile failed with missing dependent operator error
-		for _, Condition := range tc.testDsc.Status.Conditions {
-			if strings.Contains(Condition.Message, "Please install the operator before enabling "+component.GetComponentName()) {
-				return true, err
-			}
-		}
 		return false, nil
 	})
 

--- a/tests/e2e/creation_test.go
+++ b/tests/e2e/creation_test.go
@@ -302,7 +302,7 @@ func (tc *testContext) testAllApplicationCreation(t *testing.T) error { //nolint
 }
 
 func (tc *testContext) testApplicationCreation(component components.ComponentInterface) error {
-	err := wait.PollUntilContextTimeout(tc.ctx, tc.resourceRetryInterval, tc.resourceCreationTimeout, false, func(ctx context.Context) (bool, error) {
+	err := wait.PollUntilContextTimeout(tc.ctx, tc.resourceRetryInterval, tc.resourceCreationTimeout, true, func(ctx context.Context) (bool, error) {
 		// TODO: see if checking deployment is a good test, CF does not create deployment
 		appList, err := tc.kubeClient.AppsV1().Deployments(tc.applicationsNamespace).List(ctx, metav1.ListOptions{
 			LabelSelector: labels.ODH.Component(component.GetComponentName()),

--- a/tests/e2e/creation_test.go
+++ b/tests/e2e/creation_test.go
@@ -308,9 +308,8 @@ func (tc *testContext) testApplicationCreation(component components.ComponentInt
 			LabelSelector: labels.ODH.Component(component.GetComponentName()),
 		})
 		if err != nil {
-			log.Printf("error listing application deployments :%v. Trying again...", err)
-
-			return false, fmt.Errorf("error listing application deployments :%w. Trying again", err)
+			log.Printf("error listing application deployments :%v", err)
+			return false, fmt.Errorf("error listing application deployments :%w", err)
 		}
 		if len(appList.Items) != 0 {
 			allAppDeploymentsReady := true


### PR DESCRIPTION
- do not print Trying again if cannot list deployments
- enable immediate for PollUntilContextTimeout
- remove check for dependent operator
- early return from the loop

<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
