### PR TITLE
tests: performance and time tuning for e2e

### DIFF
--- a/tests/e2e/controller_test.go
+++ b/tests/e2e/controller_test.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"os"
 	"testing"
-	"time"
 
 	operatorv1 "github.com/openshift/api/operator/v1"
 	routev1 "github.com/openshift/api/route/v1"
@@ -47,14 +46,10 @@ type testContext struct {
 	operatorNamespace string
 	// namespace of the deployed applications
 	applicationsNamespace string
-	// time required to create a resource
-	resourceCreationTimeout time.Duration
 	// test DataScienceCluster instance
 	testDsc *dscv1.DataScienceCluster
 	// test DSCI CR because we do not create it in ODH by default
 	testDSCI *dsciv1.DSCInitialization
-	// time interval to check for resource creation
-	resourceRetryInterval time.Duration
 	// context for accessing resources
 	//nolint:containedctx //reason: legacy v1 test setup
 	ctx context.Context
@@ -86,16 +81,14 @@ func NewTestContext() (*testContext, error) {
 	testDSC := setupDSCInstance("e2e-test-dsc")
 
 	return &testContext{
-		cfg:                     config,
-		kubeClient:              kc,
-		customClient:            custClient,
-		operatorNamespace:       opNamespace,
-		applicationsNamespace:   testDSCI.Spec.ApplicationsNamespace,
-		resourceCreationTimeout: time.Minute * 7, // since we introduce check for all deployment, we need prolong time here too and match what we set in the component
-		resourceRetryInterval:   time.Second * 10,
-		ctx:                     context.TODO(),
-		testDsc:                 testDSC,
-		testDSCI:                testDSCI,
+		cfg:                   config,
+		kubeClient:            kc,
+		customClient:          custClient,
+		operatorNamespace:     opNamespace,
+		applicationsNamespace: testDSCI.Spec.ApplicationsNamespace,
+		ctx:                   context.TODO(),
+		testDsc:               testDSC,
+		testDSCI:              testDSCI,
 	}, nil
 }
 

--- a/tests/e2e/creation_test.go
+++ b/tests/e2e/creation_test.go
@@ -69,20 +69,25 @@ func creationTestSuite(t *testing.T) {
 			err = testCtx.testOwnerrefrences()
 			require.NoError(t, err, "error getting all DataScienceCluster's Ownerrefrences")
 		})
-		t.Run("Validate default certs available", func(t *testing.T) {
-			err = testCtx.testDefaultCertsAvailable()
-			require.NoError(t, err, "error getting default cert secrets for Kserve")
-		})
 		t.Run("Validate all deployed components", func(t *testing.T) {
 			// this will take about 5-6 mins to complete
-			err = testCtx.testAllApplicationCreation(t)
+			err = testCtx.testAllComponentCreation(t)
 			require.NoError(t, err, "error testing deployments for DataScienceCluster: "+testCtx.testDsc.Name)
+		})
+		t.Run("Validate DSC Ready", func(t *testing.T) {
+			err = testCtx.validateDSCReady()
+			require.NoError(t, err, "DataScienceCluster instance is not Ready")
 		})
 
 		// Kserve
 		t.Run("Validate Knative resoruce", func(t *testing.T) {
 			err = testCtx.validateDSC()
 			require.NoError(t, err, "error getting Knatvie resrouce as part of DataScienceCluster validation")
+		})
+		t.Run("Validate default certs available", func(t *testing.T) {
+			// move it to be part of check with kserve since it is using serving's secret
+			err = testCtx.testDefaultCertsAvailable()
+			require.NoError(t, err, "error getting default cert secrets for Kserve")
 		})
 
 		// ModelReg
@@ -125,7 +130,7 @@ func (tc *testContext) testDSCICreation() error {
 	err = tc.customClient.Get(tc.ctx, dscLookupKey, createdDSCI)
 	if err != nil {
 		if k8serr.IsNotFound(err) {
-			nberr := wait.PollUntilContextTimeout(tc.ctx, tc.resourceRetryInterval, tc.resourceCreationTimeout, false, func(ctx context.Context) (bool, error) {
+			nberr := wait.PollUntilContextTimeout(tc.ctx, generalRetryInterval, dsciCreationTimeout, false, func(ctx context.Context) (bool, error) {
 				creationErr := tc.customClient.Create(ctx, tc.testDSCI)
 				if creationErr != nil {
 					log.Printf("error creating DSCI resource %v: %v, trying again",
@@ -140,26 +145,6 @@ func (tc *testContext) testDSCICreation() error {
 		} else {
 			return fmt.Errorf("error getting e2e-test-dsci DSCI CR %s: %w", tc.testDSCI.Name, err)
 		}
-	}
-
-	return nil
-}
-
-func waitDSCReady(tc *testContext) error {
-	err := tc.wait(func(ctx context.Context) (bool, error) {
-		key := types.NamespacedName{Name: tc.testDsc.Name}
-		dsc := &dscv1.DataScienceCluster{}
-
-		err := tc.customClient.Get(ctx, key, dsc)
-		if err != nil {
-			return false, err
-		}
-
-		return dsc.Status.Phase == "Ready", nil
-	})
-
-	if err != nil {
-		return fmt.Errorf("Error waiting Ready state for DSC %v: %w", tc.testDsc.Name, err)
 	}
 
 	return nil
@@ -181,11 +166,10 @@ func (tc *testContext) testDSCCreation() error {
 			return nil
 		}
 	}
-
 	err = tc.customClient.Get(tc.ctx, dscLookupKey, createdDSC)
 	if err != nil {
 		if k8serr.IsNotFound(err) {
-			nberr := wait.PollUntilContextTimeout(tc.ctx, tc.resourceRetryInterval, tc.resourceCreationTimeout, false, func(ctx context.Context) (bool, error) {
+			dsciErr := wait.PollUntilContextTimeout(tc.ctx, generalRetryInterval, dscCreationTimeout, false, func(ctx context.Context) (bool, error) {
 				creationErr := tc.customClient.Create(ctx, tc.testDsc)
 				if creationErr != nil {
 					log.Printf("error creating DSC resource %v: %v, trying again",
@@ -195,15 +179,40 @@ func (tc *testContext) testDSCCreation() error {
 				}
 				return true, nil
 			})
-			if nberr != nil {
-				return fmt.Errorf("error creating e2e-test-dsc DSC %s: %w", tc.testDsc.Name, nberr)
+			if dsciErr != nil {
+				return fmt.Errorf("error creating e2e-test-dsc DSC %s: %w", tc.testDsc.Name, dsciErr)
 			}
 		} else {
 			return fmt.Errorf("error getting e2e-test-dsc DSC %s: %w", tc.testDsc.Name, err)
 		}
 	}
+	return nil
+}
 
+func (tc *testContext) validateDSCReady() error {
 	return waitDSCReady(tc)
+}
+
+// Verify DSC instance is in Ready phase when all components are up and running
+
+func waitDSCReady(tc *testContext) error {
+	// wait for 2 mins which is on the safe side, normally it should get ready once all components are ready
+	err := tc.wait(func(ctx context.Context) (bool, error) {
+		key := types.NamespacedName{Name: tc.testDsc.Name}
+		dsc := &dscv1.DataScienceCluster{}
+
+		err := tc.customClient.Get(ctx, key, dsc)
+		if err != nil {
+			return false, err
+		}
+		return dsc.Status.Phase == "Ready", nil
+	})
+
+	if err != nil {
+		return fmt.Errorf("Error waiting Ready state for DSC %v: %w", tc.testDsc.Name, err)
+	}
+
+	return nil
 }
 
 func (tc *testContext) requireInstalled(t *testing.T, gvk schema.GroupVersionKind) {
@@ -256,13 +265,13 @@ func (tc *testContext) testDSCDuplication(t *testing.T) { //nolint:thelper
 	tc.testDuplication(t, gvk, dup)
 }
 
-func (tc *testContext) testAllApplicationCreation(t *testing.T) error { //nolint:funlen,thelper
-	// Validate test instance is in Ready state
+func (tc *testContext) testAllComponentCreation(t *testing.T) error { //nolint:funlen,thelper
+	// Validate all components are in Ready state
 
 	dscLookupKey := types.NamespacedName{Name: tc.testDsc.Name}
 	createdDSC := &dscv1.DataScienceCluster{}
 
-	// Wait for applications to get deployed
+	// Wait for components to get deployed
 	time.Sleep(1 * time.Minute)
 
 	err := tc.customClient.Get(tc.ctx, dscLookupKey, createdDSC)
@@ -281,28 +290,22 @@ func (tc *testContext) testAllApplicationCreation(t *testing.T) error { //nolint
 		name := c.GetComponentName()
 		t.Run("Validate "+name, func(t *testing.T) {
 			t.Parallel()
-
-			err = tc.testApplicationCreation(c)
-			require.NoError(t, err, "error validating application %v when "+c.GetManagementState())
+			err = tc.testComponentCreation(c)
+			require.NoError(t, err, "error validating component %v when "+c.GetManagementState())
 		})
 	}
-	// Verify DSC instance is in Ready phase in the end when all components are up and running
-	if tc.testDsc.Status.Phase != "Ready" {
-		return fmt.Errorf("DSC instance is not in Ready phase. Current phase: %v", tc.testDsc.Status.Phase)
-	}
-
 	return nil
 }
 
-func (tc *testContext) testApplicationCreation(component components.ComponentInterface) error {
-	err := wait.PollUntilContextTimeout(tc.ctx, tc.resourceRetryInterval, tc.resourceCreationTimeout, true, func(ctx context.Context) (bool, error) {
+func (tc *testContext) testComponentCreation(component components.ComponentInterface) error {
+	err := wait.PollUntilContextTimeout(tc.ctx, generalRetryInterval, componentReadyTimeout, true, func(ctx context.Context) (bool, error) {
 		// TODO: see if checking deployment is a good test, CF does not create deployment
 		appList, err := tc.kubeClient.AppsV1().Deployments(tc.applicationsNamespace).List(ctx, metav1.ListOptions{
 			LabelSelector: labels.ODH.Component(component.GetComponentName()),
 		})
 		if err != nil {
-			log.Printf("error listing application deployments :%v", err)
-			return false, fmt.Errorf("error listing application deployments :%w", err)
+			log.Printf("error listing component deployments :%v", err)
+			return false, fmt.Errorf("error listing component deployments :%w", err)
 		}
 		if len(appList.Items) != 0 {
 			if component.GetManagementState() == operatorv1.Removed {
@@ -312,7 +315,7 @@ func (tc *testContext) testApplicationCreation(component components.ComponentInt
 
 			for _, deployment := range appList.Items {
 				if deployment.Status.ReadyReplicas < 1 {
-					log.Printf("waiting for application deployments to be in Ready state.")
+					log.Printf("waiting for component deployments to be in Ready state: %s", deployment.Name)
 					return false, nil
 				}
 			}
@@ -386,7 +389,7 @@ func (tc *testContext) testOwnerrefrences() error {
 			LabelSelector: labels.ODH.Component(tc.testDsc.Spec.Components.Dashboard.GetComponentName()),
 		})
 		if err != nil {
-			return fmt.Errorf("error listing application deployments %w", err)
+			return fmt.Errorf("error listing component deployments %w", err)
 		}
 		// test any one deployment for ownerreference
 		if len(appDeployments.Items) != 0 && appDeployments.Items[0].OwnerReferences[0].Kind != "DataScienceCluster" {
@@ -532,7 +535,7 @@ func (tc *testContext) testUpdateComponentReconcile() error {
 
 	// Sleep for 40 seconds to allow the operator to reconcile
 	// we expect it should not revert back to original value because of AllowList
-	time.Sleep(4 * tc.resourceRetryInterval)
+	time.Sleep(4 * generalRetryInterval)
 	reconciledDep, err := tc.kubeClient.AppsV1().Deployments(tc.applicationsNamespace).Get(tc.ctx, testDeployment.Name, metav1.GetOptions{})
 	if err != nil {
 		return fmt.Errorf("error getting component resource after reconcile: %w", err)
@@ -590,7 +593,7 @@ func (tc *testContext) testUpdateDSCComponentEnabled() error {
 	}
 
 	// Sleep for 80 seconds to allow the operator to reconcile
-	time.Sleep(8 * tc.resourceRetryInterval)
+	time.Sleep(8 * generalRetryInterval)
 	_, err = tc.kubeClient.AppsV1().Deployments(tc.applicationsNamespace).Get(tc.ctx, dashboardDeploymentName, metav1.GetOptions{})
 	if err != nil {
 		if k8serr.IsNotFound(err) {

--- a/tests/e2e/deletion_test.go
+++ b/tests/e2e/deletion_test.go
@@ -24,21 +24,21 @@ func deletionTestSuite(t *testing.T) {
 	require.NoError(t, err)
 
 	// pre-check before deletion
-	t.Run("ensure all components created", func(t *testing.T) {
-		err = testCtx.testAllApplicationCreation(t)
+	t.Run("Ensure all components created", func(t *testing.T) {
+		err = testCtx.testAllComponentCreation(t)
 		require.NoError(t, err, "Not all components are created")
 	})
 
 	t.Run(testCtx.testDsc.Name, func(t *testing.T) {
-		t.Run("Deletion: DSC instance", func(t *testing.T) {
+		t.Run("Deletion DSC instance", func(t *testing.T) {
 			err = testCtx.testDeletionExistDSC()
 			require.NoError(t, err, "Error to delete DSC instance")
 		})
-		t.Run("Check: all component resource are deleted", func(t *testing.T) {
+		t.Run("Check all component resource are deleted", func(t *testing.T) {
 			err = testCtx.testAllApplicationDeletion(t)
 			require.NoError(t, err, "Should not found component exist")
 		})
-		t.Run("Deletion: DSCI instance", func(t *testing.T) {
+		t.Run("Deletion DSCI instance", func(t *testing.T) {
 			err = testCtx.testDeletionExistDSCI()
 			require.NoError(t, err, "Error to delete DSCI instance")
 		})
@@ -66,10 +66,9 @@ func (tc *testContext) testDeletionExistDSC() error {
 	return nil
 }
 
-func (tc *testContext) testApplicationDeletion(component components.ComponentInterface) error {
+func (tc *testContext) testComponentDeletion(component components.ComponentInterface) error {
 	// Deletion of Deployments
-
-	if err := wait.PollUntilContextTimeout(tc.ctx, tc.resourceRetryInterval, tc.resourceCreationTimeout, false, func(ctx context.Context) (bool, error) {
+	if err := wait.PollUntilContextTimeout(tc.ctx, generalRetryInterval, componentDeletionTimeout, true, func(ctx context.Context) (bool, error) {
 		appList, err := tc.kubeClient.AppsV1().Deployments(tc.applicationsNamespace).List(ctx, metav1.ListOptions{
 			LabelSelector: labels.ODH.Component(component.GetComponentName()),
 		})
@@ -99,7 +98,7 @@ func (tc *testContext) testAllApplicationDeletion(t *testing.T) error { //nolint
 		c := c
 		t.Run("Delete "+c.GetComponentName(), func(t *testing.T) {
 			t.Parallel()
-			err = tc.testApplicationDeletion(c)
+			err = tc.testComponentDeletion(c)
 			require.NoError(t, err)
 		})
 	}

--- a/tests/e2e/odh_manager_test.go
+++ b/tests/e2e/odh_manager_test.go
@@ -16,18 +16,25 @@ func testODHOperatorValidation(t *testing.T) {
 
 func (tc *testContext) testODHDeployment(t *testing.T) {
 	// Verify if the operator deployment is created
-	require.NoErrorf(t, tc.waitForControllerDeployment("opendatahub-operator-controller-manager", 1),
+	require.NoErrorf(t, tc.waitForOperatorDeployment("opendatahub-operator-controller-manager", 1),
 		"error in validating odh operator deployment")
 }
 
 func (tc *testContext) validateOwnedCRDs(t *testing.T) {
-	// Verify if 2 operators CRDs are installed
-	require.NoErrorf(t, tc.validateCRD("datascienceclusters.datasciencecluster.opendatahub.io"),
-		"error in validating CRD : datascienceclusters.datasciencecluster.opendatahub.io")
-
-	require.NoErrorf(t, tc.validateCRD("dscinitializations.dscinitialization.opendatahub.io"),
-		"error in validating CRD : dscinitializations.dscinitialization.opendatahub.io")
-
-	require.NoErrorf(t, tc.validateCRD("featuretrackers.features.opendatahub.io"),
-		"error in validating CRD : featuretrackers.features.opendatahub.io")
+	// Verify if 3 operators CRDs are installed in parallel
+	t.Run("Validate DSC CRD", func(t *testing.T) {
+		t.Parallel()
+		require.NoErrorf(t, tc.validateCRD("datascienceclusters.datasciencecluster.opendatahub.io"),
+			"error in validating CRD : datascienceclusters.datasciencecluster.opendatahub.io")
+	})
+	t.Run("Validate DSCI CRD", func(t *testing.T) {
+		t.Parallel()
+		require.NoErrorf(t, tc.validateCRD("dscinitializations.dscinitialization.opendatahub.io"),
+			"error in validating CRD : dscinitializations.dscinitialization.opendatahub.io")
+	})
+	t.Run("Validate FeatureTracker CRD", func(t *testing.T) {
+		t.Parallel()
+		require.NoErrorf(t, tc.validateCRD("featuretrackers.features.opendatahub.io"),
+			"error in validating CRD : featuretrackers.features.opendatahub.io")
+	})
 }


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->
- make check on CRD run in parallel
- add loop for check DSC status, so test on DSC status wont fail with timout
- move resourceCreationgTimeout and resourceRetryInterval out of tc
- rename resourceRetryInterval to generalRetryInterval
- create different timeout instead of using resourceCreationgTimeout for all cases
- move check on DSC ready out of testDSCCreation into validateDSCReady which calls waitDSCReady
- rename testAllApplicationCreation to testAllComponentCreation
- rename  testApplicationCreation to testComponentCreation
- do not immediate check func in testComponentCreation
- rename testApplicationDeletion to testComponentDeletion
- immediate check func in testComponentletion
- rename waitForControllerDeployment to waitForOperatorDeployment
- set new timeout, see const block



<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
