### PR TITLE
RFC: reconcile components in parallel

### DIFF
--- a/main.go
+++ b/main.go
@@ -64,6 +64,7 @@ import (
 	"github.com/opendatahub-io/opendatahub-operator/v2/controllers/webhook"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/logger"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/safeclient"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/upgrade"
 )
 
@@ -98,6 +99,15 @@ func init() { //nolint:gochecknoinits
 	utilruntime.Must(apiregistrationv1.AddToScheme(scheme))
 	utilruntime.Must(monitoringv1.AddToScheme(scheme))
 	utilruntime.Must(operatorv1.Install(scheme))
+}
+
+func newClientFunc(config *rest.Config, options client.Options) (client.Client, error) { //nolint:ireturn
+	c, err := client.New(config, options)
+	if err != nil {
+		return c, err
+	}
+
+	return safeclient.New(c), nil
 }
 
 func main() { //nolint:funlen,maintidx
@@ -201,6 +211,7 @@ func main() { //nolint:funlen,maintidx
 		// if you are doing or is intended to do any operation such as perform cleanups
 		// after the manager stops then its usage might be unsafe.
 		// LeaderElectionReleaseOnCancel: true,
+		NewClient: newClientFunc,
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")

--- a/pkg/safeclient/safeclient.go
+++ b/pkg/safeclient/safeclient.go
@@ -1,0 +1,98 @@
+package safeclient
+
+import (
+	"context"
+	"sync"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type SafeClient struct {
+	cli  client.Client
+	lock sync.Mutex
+}
+
+func New(cli client.Client) *SafeClient {
+	return &SafeClient{
+		cli: cli,
+	}
+}
+
+// Reader.
+func (c *SafeClient) Get(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	return c.cli.Get(ctx, key, obj, opts...)
+}
+
+func (c *SafeClient) List(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	return c.cli.List(ctx, list, opts...)
+}
+
+// Writer.
+func (c *SafeClient) Create(ctx context.Context, obj client.Object, opts ...client.CreateOption) error {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	return c.cli.Create(ctx, obj, opts...)
+}
+func (c *SafeClient) Delete(ctx context.Context, obj client.Object, opts ...client.DeleteOption) error {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	return c.cli.Delete(ctx, obj, opts...)
+}
+func (c *SafeClient) Update(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	return c.cli.Update(ctx, obj, opts...)
+}
+func (c *SafeClient) Patch(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	return c.cli.Patch(ctx, obj, patch, opts...)
+}
+func (c *SafeClient) DeleteAllOf(ctx context.Context, obj client.Object, opts ...client.DeleteAllOfOption) error {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	return c.cli.DeleteAllOf(ctx, obj, opts...)
+}
+
+// StatusClient.
+func (c *SafeClient) Status() client.SubResourceWriter { //nolint:ireturn
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	return c.cli.Status()
+}
+
+// SubResourceClientConstructor.
+func (c *SafeClient) SubResource(subResource string) client.SubResourceClient { //nolint:ireturn
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	return c.cli.SubResource(subResource)
+}
+
+// Own methods.
+func (c *SafeClient) Scheme() *runtime.Scheme {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	return c.cli.Scheme()
+}
+func (c *SafeClient) RESTMapper() meta.RESTMapper { //nolint:ireturn
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	return c.cli.RESTMapper()
+}
+func (c *SafeClient) GroupVersionKindFor(obj runtime.Object) (schema.GroupVersionKind, error) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	return c.cli.GroupVersionKindFor(obj)
+}
+func (c *SafeClient) IsObjectNamespaced(obj runtime.Object) (bool, error) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	return c.cli.IsObjectNamespaced(obj)
+}


### PR DESCRIPTION
This is just an RFC.

There is a lot of independent work in component's reconciliation procedures which could run in parallel.
One of the reasons is that with the latest "wait for deployment ready" change initial setup takes much longer time.

The code is not thread-safe. I tried to address obvious issues:
1) unsafe Client (make a wrapper)
2) unsafe prometheus config update

With UpdateWithRetry updating DSC should be fine.

<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
