### PR TITLE
feat: set DSCI application namespace to be immutable

### DIFF
--- a/apis/dscinitialization/v1/dscinitialization_types.go
+++ b/apis/dscinitialization/v1/dscinitialization_types.go
@@ -32,6 +32,7 @@ import (
 type DSCInitializationSpec struct {
 	// Namespace for applications to be installed, non-configurable, default to "opendatahub"
 	// +kubebuilder:default:=opendatahub
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="ApplicationsNamespace is immutable"
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,order=1
 	ApplicationsNamespace string `json:"applicationsNamespace"`
 	// Enable monitoring on specified namespace

--- a/bundle/manifests/dscinitialization.opendatahub.io_dscinitializations.yaml
+++ b/bundle/manifests/dscinitialization.opendatahub.io_dscinitializations.yaml
@@ -57,6 +57,9 @@ spec:
                 description: Namespace for applications to be installed, non-configurable,
                   default to "opendatahub"
                 type: string
+                x-kubernetes-validations:
+                - message: ApplicationsNamespace is immutable
+                  rule: self == oldSelf
               devFlags:
                 description: |-
                   Internal development useful field to test customizations.

--- a/config/crd/bases/dscinitialization.opendatahub.io_dscinitializations.yaml
+++ b/config/crd/bases/dscinitialization.opendatahub.io_dscinitializations.yaml
@@ -57,6 +57,9 @@ spec:
                 description: Namespace for applications to be installed, non-configurable,
                   default to "opendatahub"
                 type: string
+                x-kubernetes-validations:
+                - message: ApplicationsNamespace is immutable
+                  rule: self == oldSelf
               devFlags:
                 description: |-
                   Internal development useful field to test customizations.


### PR DESCRIPTION
**put on-hold label for now , just waiting for reviewers all agree on this change**

<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

- we do not support other values for now, this is to prevent user change to different value and cause old and new both running
- till we have a good solution to support this configable filed it is better to make it fixed value instead of dealing with post-fix when user change to another namespace after default one has been used.


<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
local build: quay.io/wenzhou/opendatahub-operator-catalog:v2.18.112

- instnall operator
- create default DSCI CR with opendatahub as applicationNamespace
- change applicatoinNamspace from `opendatahub` to `opendatahub2`, got error "Error "Invalid value: "string": ApplicationsNamespace is immutable" for field "spec.applicationsNamespace"."
- delete DSCI CR
- create another DSCI CR but with `opendatahub3` as applicationNamespace
- check opendatahub3 namespace created
- change applicationNamespace from `opendatahub3` to `opendatahub4` in DSCI, got error "Error "Invalid value: "string": ApplicationsNamespace is immutable" for field "spec.applicationsNamespace"." 



## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
