### PR TITLE
feat(tracker): allows to define ownerReferences for FeatureTrackers

### DIFF
--- a/components/component.go
+++ b/components/component.go
@@ -43,7 +43,7 @@ func (c *Component) GetManagementState() operatorv1.ManagementState {
 	return c.ManagementState
 }
 
-func (c *Component) Cleanup(_ context.Context, _ client.Client, _ *dsciv1.DSCInitializationSpec) error {
+func (c *Component) Cleanup(_ context.Context, _ client.Client, _ metav1.Object, _ *dsciv1.DSCInitializationSpec) error {
 	// noop
 	return nil
 }
@@ -80,7 +80,7 @@ type ManifestsConfig struct {
 type ComponentInterface interface {
 	ReconcileComponent(ctx context.Context, cli client.Client, logger logr.Logger,
 		owner metav1.Object, DSCISpec *dsciv1.DSCInitializationSpec, platform cluster.Platform, currentComponentStatus bool) error
-	Cleanup(ctx context.Context, cli client.Client, DSCISpec *dsciv1.DSCInitializationSpec) error
+	Cleanup(ctx context.Context, cli client.Client, owner metav1.Object, DSCISpec *dsciv1.DSCInitializationSpec) error
 	GetComponentName() string
 	GetManagementState() operatorv1.ManagementState
 	OverrideManifests(ctx context.Context, platform cluster.Platform) error

--- a/components/kserve/kserve.go
+++ b/components/kserve/kserve.go
@@ -107,12 +107,12 @@ func (k *Kserve) ReconcileComponent(ctx context.Context, cli client.Client,
 	monitoringEnabled := dscispec.Monitoring.ManagementState == operatorv1.Managed
 
 	if !enabled {
-		if err := k.removeServerlessFeatures(ctx, dscispec); err != nil {
+		if err := k.removeServerlessFeatures(ctx, cli, owner, dscispec); err != nil {
 			return err
 		}
 	} else {
 		// Configure dependencies
-		if err := k.configureServerless(ctx, cli, l, dscispec); err != nil {
+		if err := k.configureServerless(ctx, cli, l, owner, dscispec); err != nil {
 			return err
 		}
 		if k.DevFlags != nil {
@@ -123,7 +123,7 @@ func (k *Kserve) ReconcileComponent(ctx context.Context, cli client.Client,
 		}
 	}
 
-	if err := k.configureServiceMesh(ctx, cli, dscispec); err != nil {
+	if err := k.configureServiceMesh(ctx, cli, owner, dscispec); err != nil {
 		return fmt.Errorf("failed configuring service mesh while reconciling kserve component. cause: %w", err)
 	}
 
@@ -177,10 +177,10 @@ func (k *Kserve) ReconcileComponent(ctx context.Context, cli client.Client,
 	return nil
 }
 
-func (k *Kserve) Cleanup(ctx context.Context, cli client.Client, instance *dsciv1.DSCInitializationSpec) error {
-	if removeServerlessErr := k.removeServerlessFeatures(ctx, instance); removeServerlessErr != nil {
+func (k *Kserve) Cleanup(ctx context.Context, cli client.Client, owner metav1.Object, instance *dsciv1.DSCInitializationSpec) error {
+	if removeServerlessErr := k.removeServerlessFeatures(ctx, cli, owner, instance); removeServerlessErr != nil {
 		return removeServerlessErr
 	}
 
-	return k.removeServiceMeshConfigurations(ctx, cli, instance)
+	return k.removeServiceMeshConfigurations(ctx, cli, owner, instance)
 }

--- a/components/kserve/servicemesh_setup.go
+++ b/components/kserve/servicemesh_setup.go
@@ -6,6 +6,7 @@ import (
 	"path"
 
 	operatorv1 "github.com/openshift/api/operator/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -16,10 +17,10 @@ import (
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/feature/servicemesh"
 )
 
-func (k *Kserve) configureServiceMesh(ctx context.Context, cli client.Client, dscispec *dsciv1.DSCInitializationSpec) error {
+func (k *Kserve) configureServiceMesh(ctx context.Context, cli client.Client, owner metav1.Object, dscispec *dsciv1.DSCInitializationSpec) error {
 	if dscispec.ServiceMesh != nil {
 		if dscispec.ServiceMesh.ManagementState == operatorv1.Managed && k.GetManagementState() == operatorv1.Managed {
-			serviceMeshInitializer := feature.ComponentFeaturesHandler(k.GetComponentName(), dscispec.ApplicationsNamespace, k.defineServiceMeshFeatures(ctx, cli, dscispec))
+			serviceMeshInitializer := feature.ComponentFeaturesHandler(cli, owner, k.GetComponentName(), dscispec.ApplicationsNamespace, k.defineServiceMeshFeatures(ctx, cli, dscispec))
 			return serviceMeshInitializer.Apply(ctx)
 		}
 		if dscispec.ServiceMesh.ManagementState == operatorv1.Unmanaged && k.GetManagementState() == operatorv1.Managed {
@@ -27,11 +28,11 @@ func (k *Kserve) configureServiceMesh(ctx context.Context, cli client.Client, ds
 		}
 	}
 
-	return k.removeServiceMeshConfigurations(ctx, cli, dscispec)
+	return k.removeServiceMeshConfigurations(ctx, cli, owner, dscispec)
 }
 
-func (k *Kserve) removeServiceMeshConfigurations(ctx context.Context, cli client.Client, dscispec *dsciv1.DSCInitializationSpec) error {
-	serviceMeshInitializer := feature.ComponentFeaturesHandler(k.GetComponentName(), dscispec.ApplicationsNamespace, k.defineServiceMeshFeatures(ctx, cli, dscispec))
+func (k *Kserve) removeServiceMeshConfigurations(ctx context.Context, cli client.Client, owner metav1.Object, dscispec *dsciv1.DSCInitializationSpec) error {
+	serviceMeshInitializer := feature.ComponentFeaturesHandler(cli, owner, k.GetComponentName(), dscispec.ApplicationsNamespace, k.defineServiceMeshFeatures(ctx, cli, dscispec))
 	return serviceMeshInitializer.Delete(ctx)
 }
 

--- a/controllers/datasciencecluster/datasciencecluster_controller.go
+++ b/controllers/datasciencecluster/datasciencecluster_controller.go
@@ -137,7 +137,7 @@ func (r *DataScienceClusterReconciler) Reconcile(ctx context.Context, req ctrl.R
 			}
 		}
 		for _, component := range allComponents {
-			if err := component.Cleanup(ctx, r.Client, r.DataScienceCluster.DSCISpec); err != nil {
+			if err := component.Cleanup(ctx, r.Client, instance, r.DataScienceCluster.DSCISpec); err != nil {
 				return ctrl.Result{}, err
 			}
 		}
@@ -188,7 +188,7 @@ func (r *DataScienceClusterReconciler) Reconcile(ctx context.Context, req ctrl.R
 	} else {
 		r.Log.Info("Finalization DataScienceCluster start deleting instance", "name", instance.Name, "finalizer", finalizerName)
 		for _, component := range allComponents {
-			if err := component.Cleanup(ctx, r.Client, r.DataScienceCluster.DSCISpec); err != nil {
+			if err := component.Cleanup(ctx, r.Client, instance, r.DataScienceCluster.DSCISpec); err != nil {
 				return ctrl.Result{}, err
 			}
 		}

--- a/controllers/dscinitialization/servicemesh_setup.go
+++ b/controllers/dscinitialization/servicemesh_setup.go
@@ -91,7 +91,7 @@ func (r *DSCInitializationReconciler) removeServiceMesh(ctx context.Context, ins
 
 func (r *DSCInitializationReconciler) serviceMeshCapability(instance *dsciv1.DSCInitialization, initialCondition *conditionsv1.Condition) *feature.HandlerWithReporter[*dsciv1.DSCInitialization] { //nolint:lll // Reason: generics are long
 	return feature.NewHandlerWithReporter(
-		feature.ClusterFeaturesHandler(instance, r.serviceMeshCapabilityFeatures(instance)),
+		feature.ClusterFeaturesHandler(r.Client, instance, r.serviceMeshCapabilityFeatures(instance)),
 		createCapabilityReporter(r.Client, instance, initialCondition),
 	)
 }
@@ -119,7 +119,7 @@ func (r *DSCInitializationReconciler) authorizationCapability(ctx context.Contex
 	}
 
 	return feature.NewHandlerWithReporter(
-		feature.ClusterFeaturesHandler(instance, r.authorizationFeatures(instance)),
+		feature.ClusterFeaturesHandler(r.Client, instance, r.authorizationFeatures(instance)),
 		createCapabilityReporter(r.Client, instance, condition),
 	), nil
 }

--- a/pkg/cluster/gvk/gvk.go
+++ b/pkg/cluster/gvk/gvk.go
@@ -14,6 +14,11 @@ var (
 		Version: "v1",
 		Kind:    "DataScienceCluster",
 	}
+	DSCInitialization = schema.GroupVersionKind{
+		Group:   "dscinitialization.opendatahub.io",
+		Version: "v1",
+		Kind:    "DSCInitialization",
+	}
 
 	Deployment = schema.GroupVersionKind{
 		Group:   "apps",

--- a/pkg/cluster/meta.go
+++ b/pkg/cluster/meta.go
@@ -29,6 +29,8 @@ func WithOwnerReference(ownerReferences ...metav1.OwnerReference) MetaOptions {
 	}
 }
 
+// OwnedBy sets the owner reference for the object being created. It requires scheme to be passed
+// as TypeMeta might not be set for the owning object, see: https://github.com/kubernetes-sigs/controller-runtime/issues/1517
 func OwnedBy(owner metav1.Object, scheme *runtime.Scheme) MetaOptions {
 	return func(obj metav1.Object) error {
 		return controllerutil.SetOwnerReference(owner, obj, scheme)

--- a/pkg/feature/feature.go
+++ b/pkg/feature/feature.go
@@ -46,6 +46,7 @@ type Feature struct {
 
 	tracker *featurev1.FeatureTracker
 	source  *featurev1.Source
+	owner   metav1.Object
 
 	data map[string]any
 

--- a/pkg/feature/feature_tracker_handler.go
+++ b/pkg/feature/feature_tracker_handler.go
@@ -11,6 +11,7 @@ import (
 
 	featurev1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/features/v1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/controllers/status"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
 )
 
 // withConditionReasonError is a wrapper around an error which provides a reason for a feature condition.
@@ -41,13 +42,20 @@ func createFeatureTracker(ctx context.Context, f *Feature) error {
 			Source:       *f.source,
 			AppNamespace: f.TargetNamespace,
 		}
+		if f.owner != nil {
+			ownerRef := cluster.OwnedBy(f.owner, f.Client.Scheme())
+			if errMetaOpts := cluster.ApplyMetaOptions(tracker, ownerRef); errMetaOpts != nil {
+				return fmt.Errorf("failed adding owner to FeatureTracker %s: %w", tracker.Name, errMetaOpts)
+			}
+		}
+
 		if errCreate := f.Client.Create(ctx, tracker); errCreate != nil {
-			return errCreate
+			return fmt.Errorf("failed creating FeatureTracker %s: %w", tracker.Name, errCreate)
 		}
 	}
 
 	if errGVK := ensureGVKSet(tracker, f.Client.Scheme()); errGVK != nil {
-		return errGVK
+		return fmt.Errorf("failed ensuring GVK is set for %s: %w", tracker.Name, errGVK)
 	}
 
 	f.tracker = tracker

--- a/tests/integration/features/features_suite_int_test.go
+++ b/tests/integration/features/features_suite_int_test.go
@@ -15,6 +15,7 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
+	dsciv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/dscinitialization/v1"
 	featurev1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/features/v1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/tests/envtestutil"
 
@@ -51,6 +52,7 @@ var _ = BeforeSuite(func() {
 	utilruntime.Must(featurev1.AddToScheme(testScheme))
 	utilruntime.Must(apiextensionsv1.AddToScheme(testScheme))
 	utilruntime.Must(ofapiv1alpha1.AddToScheme(testScheme))
+	utilruntime.Must(dsciv1.AddToScheme(testScheme))
 
 	envTest = &envtest.Environment{
 		CRDInstallOptions: envtest.CRDInstallOptions{

--- a/tests/integration/features/fixtures/cluster_test_fixtures.go
+++ b/tests/integration/features/fixtures/cluster_test_fixtures.go
@@ -46,15 +46,13 @@ func createOrUpdateSubscription(ctx context.Context, client client.Client, subsc
 	return err
 }
 
-func CreateOrUpdateDSCI(ctx context.Context,
-	client client.Client,
-	dsci *dsciv1.DSCInitialization) (*dsciv1.DSCInitialization, error) {
+func CreateOrUpdateDSCI(ctx context.Context, client client.Client, dsci *dsciv1.DSCInitialization) error {
 	_, err := controllerutil.CreateOrUpdate(ctx, client, dsci, func() error {
 		return nil
 	})
 	dsci.APIVersion = dsciv1.GroupVersion.String()
 	dsci.Kind = gvk.DSCInitialization.Kind
-	return dsci, err
+	return err
 }
 
 func NewNamespace(name string) *corev1.Namespace {

--- a/tests/integration/features/fixtures/cluster_test_fixtures.go
+++ b/tests/integration/features/fixtures/cluster_test_fixtures.go
@@ -3,6 +3,7 @@ package fixtures
 import (
 	"context"
 
+	"github.com/onsi/gomega"
 	ofapiv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -14,6 +15,7 @@ import (
 	dsciv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/dscinitialization/v1"
 	featurev1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/features/v1"
 	infrav1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/infrastructure/v1"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/feature"
 )
 
@@ -44,21 +46,23 @@ func createOrUpdateSubscription(ctx context.Context, client client.Client, subsc
 	return err
 }
 
+func CreateOrUpdateDSCI(ctx context.Context,
+	client client.Client,
+	dsci *dsciv1.DSCInitialization) (*dsciv1.DSCInitialization, error) {
+	_, err := controllerutil.CreateOrUpdate(ctx, client, dsci, func() error {
+		return nil
+	})
+	dsci.APIVersion = dsciv1.GroupVersion.String()
+	dsci.Kind = gvk.DSCInitialization.Kind
+	return dsci, err
+}
+
 func NewNamespace(name string) *corev1.Namespace {
 	return &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
 		},
 	}
-}
-
-func GetConfigMap(client client.Client, namespace, name string) (*corev1.ConfigMap, error) {
-	cfgMap := &corev1.ConfigMap{}
-	err := client.Get(context.Background(), types.NamespacedName{
-		Name: name, Namespace: namespace,
-	}, cfgMap)
-
-	return cfgMap, err
 }
 
 func GetNamespace(ctx context.Context, client client.Client, namespace string) (*corev1.Namespace, error) {
@@ -105,12 +109,19 @@ func GetFeatureTracker(ctx context.Context, cli client.Client, appNamespace, fea
 	return tracker, err
 }
 
-func NewDSCInitialization(ns string) *dsciv1.DSCInitialization {
-	return &dsciv1.DSCInitialization{
+func NewDSCInitialization(ctx context.Context, cli client.Client, ns string) *dsciv1.DSCInitialization {
+	dsci := &dsciv1.DSCInitialization{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: gvk.DSCInitialization.Version,
+			Kind:       gvk.DSCInitialization.Kind,
+		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "default-dsci",
 		},
-		Spec: dsciv1.DSCInitializationSpec{
+	}
+
+	_, errCreate := controllerutil.CreateOrUpdate(ctx, cli, dsci, func() error {
+		dsci.Spec = dsciv1.DSCInitializationSpec{
 			ApplicationsNamespace: ns,
 			ServiceMesh: &infrav1.ServiceMeshSpec{
 				ManagementState: "Managed",
@@ -120,6 +131,12 @@ func NewDSCInitialization(ns string) *dsciv1.DSCInitialization {
 					MetricsCollection: "Istio",
 				},
 			},
-		},
-	}
+		}
+
+		return nil
+	})
+
+	gomega.Expect(errCreate).ToNot(gomega.HaveOccurred())
+
+	return dsci
 }

--- a/tests/integration/features/manifests_int_test.go
+++ b/tests/integration/features/manifests_int_test.go
@@ -35,7 +35,7 @@ var _ = Describe("Applying resources", func() {
 		namespace, err = cluster.CreateNamespace(ctx, envTestClient, nsName)
 		Expect(err).ToNot(HaveOccurred())
 
-		dsci = fixtures.NewDSCInitialization(nsName)
+		dsci = fixtures.NewDSCInitialization(ctx, envTestClient, nsName)
 		dsci.Spec.ServiceMesh.ControlPlane.Namespace = namespace.Name
 	})
 
@@ -45,9 +45,8 @@ var _ = Describe("Applying resources", func() {
 
 	It("should be able to process an embedded YAML file", func(ctx context.Context) {
 		// given
-		featuresHandler := feature.ClusterFeaturesHandler(dsci, func(registry feature.FeaturesRegistry) error {
+		featuresHandler := feature.ClusterFeaturesHandler(envTestClient, dsci, func(registry feature.FeaturesRegistry) error {
 			errNsCreate := registry.Add(feature.Define("create-namespaces").
-				UsingConfig(envTest.Config).
 				Manifests(
 					manifest.Location(fixtures.TestEmbeddedFiles).
 						Include(path.Join(fixtures.BaseDir, "namespaces.yaml")),
@@ -76,9 +75,8 @@ var _ = Describe("Applying resources", func() {
 
 	It("should be able to process an embedded template file", func(ctx context.Context) {
 		// given
-		featuresHandler := feature.ClusterFeaturesHandler(dsci, func(registry feature.FeaturesRegistry) error {
+		featuresHandler := feature.ClusterFeaturesHandler(envTestClient, dsci, func(registry feature.FeaturesRegistry) error {
 			errSvcCreate := registry.Add(feature.Define("create-local-gw-svc").
-				UsingConfig(envTest.Config).
 				Manifests(
 					manifest.Location(fixtures.TestEmbeddedFiles).
 						Include(path.Join(fixtures.BaseDir, "local-gateway-svc.tmpl.yaml")),
@@ -111,9 +109,8 @@ metadata:
 
 		Expect(fixtures.CreateFile(tempDir, "namespace.yaml", nsYAML)).To(Succeed())
 
-		featuresHandler := feature.ClusterFeaturesHandler(dsci, func(registry feature.FeaturesRegistry) error {
+		featuresHandler := feature.ClusterFeaturesHandler(envTestClient, dsci, func(registry feature.FeaturesRegistry) error {
 			errSvcCreate := registry.Add(feature.Define("create-namespace").
-				UsingConfig(envTest.Config).
 				Manifests(
 					manifest.Location(os.DirFS(tempDir)).
 						Include(path.Join("namespace.yaml")), // must be relative to root DirFS defined above

--- a/tests/integration/features/preconditions_int_test.go
+++ b/tests/integration/features/preconditions_int_test.go
@@ -26,12 +26,12 @@ var _ = Describe("feature preconditions", func() {
 			dsci          *dsciv1.DSCInitialization
 		)
 
-		BeforeEach(func() {
+		BeforeEach(func(ctx context.Context) {
 			objectCleaner = envtestutil.CreateCleaner(envTestClient, envTest.Config, fixtures.Timeout, fixtures.Interval)
 
 			testFeatureName := "test-ns-creation"
 			namespace = envtestutil.AppendRandomNameTo(testFeatureName)
-			dsci = fixtures.NewDSCInitialization(namespace)
+			dsci = fixtures.NewDSCInitialization(ctx, envTestClient, namespace)
 		})
 
 		It("should create namespace if it does not exist", func(ctx context.Context) {
@@ -41,9 +41,8 @@ var _ = Describe("feature preconditions", func() {
 			defer objectCleaner.DeleteAll(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}})
 
 			// when
-			featuresHandler := feature.ClusterFeaturesHandler(dsci, func(registry feature.FeaturesRegistry) error {
+			featuresHandler := feature.ClusterFeaturesHandler(envTestClient, dsci, func(registry feature.FeaturesRegistry) error {
 				errFeatureAdd := registry.Add(feature.Define("create-new-ns").
-					UsingConfig(envTest.Config).
 					PreConditions(feature.CreateNamespaceIfNotExists(namespace)),
 				)
 
@@ -77,9 +76,8 @@ var _ = Describe("feature preconditions", func() {
 			defer objectCleaner.DeleteAll(ctx, ns)
 
 			// when
-			featuresHandler := feature.ClusterFeaturesHandler(dsci, func(registry feature.FeaturesRegistry) error {
+			featuresHandler := feature.ClusterFeaturesHandler(envTestClient, dsci, func(registry feature.FeaturesRegistry) error {
 				errFeatureAdd := registry.Add(feature.Define("create-new-ns").
-					UsingConfig(envTest.Config).
 					PreConditions(feature.CreateNamespaceIfNotExists(namespace)),
 				)
 

--- a/tests/integration/features/resources_int_test.go
+++ b/tests/integration/features/resources_int_test.go
@@ -42,7 +42,7 @@ var _ = Describe("Applying and updating resources", func() {
 		namespace, err = cluster.CreateNamespace(ctx, envTestClient, testNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
-		dsci = fixtures.NewDSCInitialization(testNamespace)
+		dsci = fixtures.NewDSCInitialization(ctx, envTestClient, testNamespace)
 		dsci.Spec.ServiceMesh.ControlPlane.Namespace = namespace.Name
 	})
 
@@ -54,10 +54,9 @@ var _ = Describe("Applying and updating resources", func() {
 
 		It("should reconcile the resource to its managed state", func(ctx context.Context) {
 			// given managed feature
-			featuresHandler := feature.ClusterFeaturesHandler(dsci, func(registry feature.FeaturesRegistry) error {
+			featuresHandler := feature.ClusterFeaturesHandler(envTestClient, dsci, func(registry feature.FeaturesRegistry) error {
 				return registry.Add(
 					feature.Define("create-local-gw-svc").
-						UsingConfig(envTest.Config).
 						Managed().
 						Manifests(
 							manifest.Location(fixtures.TestEmbeddedFiles).
@@ -91,10 +90,9 @@ var _ = Describe("Applying and updating resources", func() {
 
 		It("should not reconcile explicitly opt-ed out resource", func(ctx context.Context) {
 			// given managed feature
-			featuresHandler := feature.ClusterFeaturesHandler(dsci, func(registry feature.FeaturesRegistry) error {
+			featuresHandler := feature.ClusterFeaturesHandler(envTestClient, dsci, func(registry feature.FeaturesRegistry) error {
 				return registry.Add(
 					feature.Define("create-unmanaged-svc").
-						UsingConfig(envTest.Config).
 						Managed().
 						Manifests(
 							manifest.Location(fixtures.TestEmbeddedFiles).
@@ -128,10 +126,9 @@ var _ = Describe("Applying and updating resources", func() {
 
 		It("should not reconcile the resource", func(ctx context.Context) {
 			// given unmanaged feature
-			featuresHandler := feature.ClusterFeaturesHandler(dsci, func(registry feature.FeaturesRegistry) error {
+			featuresHandler := feature.ClusterFeaturesHandler(envTestClient, dsci, func(registry feature.FeaturesRegistry) error {
 				return registry.Add(
 					feature.Define("create-local-gw-svc").
-						UsingConfig(envTest.Config).
 						Manifests(
 							manifest.Location(fixtures.TestEmbeddedFiles).
 								Include(path.Join(fixtures.BaseDir, "local-gateway-svc.tmpl.yaml")),
@@ -162,10 +159,9 @@ var _ = Describe("Applying and updating resources", func() {
 	When("a feature is unmanaged but the object is marked as managed", func() {
 		It("should reconcile this resource", func(ctx context.Context) {
 			// given unmanaged feature but object marked with managed annotation
-			featuresHandler := feature.ClusterFeaturesHandler(dsci, func(registry feature.FeaturesRegistry) error {
+			featuresHandler := feature.ClusterFeaturesHandler(envTestClient, dsci, func(registry feature.FeaturesRegistry) error {
 				return registry.Add(
 					feature.Define("create-managed-svc").
-						UsingConfig(envTest.Config).
 						Manifests(
 							manifest.Location(fixtures.TestEmbeddedFiles).
 								Include(path.Join(fixtures.BaseDir, "managed-svc.tmpl.yaml")),

--- a/tests/integration/features/tracker_int_test.go
+++ b/tests/integration/features/tracker_int_test.go
@@ -170,8 +170,7 @@ var _ = Describe("Feature tracking capability", func() {
 			// given
 
 			// DSCI created in cluster
-			dsci, dsciErr := fixtures.CreateOrUpdateDSCI(ctx, envTestClient, dsci)
-			Expect(dsciErr).ToNot(HaveOccurred())
+			Expect(fixtures.CreateOrUpdateDSCI(ctx, envTestClient, dsci)).ToNot(HaveOccurred())
 
 			feature, featErr := feature.Define("empty-feat-with-owner").
 				UsingClient(envTestClient).

--- a/tests/integration/features/tracker_int_test.go
+++ b/tests/integration/features/tracker_int_test.go
@@ -26,18 +26,15 @@ var _ = Describe("Feature tracking capability", func() {
 		dsci *dsciv1.DSCInitialization
 	)
 
-	BeforeEach(func() {
-		dsci = fixtures.NewDSCInitialization("default")
+	BeforeEach(func(ctx context.Context) {
+		dsci = fixtures.NewDSCInitialization(ctx, envTestClient, "default")
 	})
 
 	Context("Reporting progress when applying Feature", func() {
 
 		It("should indicate successful installation in FeatureTracker through Status conditions", func(ctx context.Context) {
-			featuresHandler := feature.ClusterFeaturesHandler(dsci, func(registry feature.FeaturesRegistry) error {
-				errFeatureAdd := registry.Add(
-					feature.Define("always-working-feature").
-						UsingConfig(envTest.Config),
-				)
+			featuresHandler := feature.ClusterFeaturesHandler(envTestClient, dsci, func(registry feature.FeaturesRegistry) error {
+				errFeatureAdd := registry.Add(feature.Define("always-working-feature"))
 
 				Expect(errFeatureAdd).ToNot(HaveOccurred())
 
@@ -62,9 +59,8 @@ var _ = Describe("Feature tracking capability", func() {
 
 		It("should indicate when failure occurs in preconditions through Status conditions", func(ctx context.Context) {
 			// given
-			featuresHandler := feature.ClusterFeaturesHandler(dsci, func(registry feature.FeaturesRegistry) error {
+			featuresHandler := feature.ClusterFeaturesHandler(envTestClient, dsci, func(registry feature.FeaturesRegistry) error {
 				errFeatureAdd := registry.Add(feature.Define("precondition-fail").
-					UsingConfig(envTest.Config).
 					PreConditions(func(_ context.Context, _ *feature.Feature) error {
 						return errors.New("during test always fail")
 					}),
@@ -93,9 +89,8 @@ var _ = Describe("Feature tracking capability", func() {
 
 		It("should indicate when failure occurs in post-conditions through Status conditions", func(ctx context.Context) {
 			// given
-			featuresHandler := feature.ClusterFeaturesHandler(dsci, func(registry feature.FeaturesRegistry) error {
+			featuresHandler := feature.ClusterFeaturesHandler(envTestClient, dsci, func(registry feature.FeaturesRegistry) error {
 				errFeatureAdd := registry.Add(feature.Define("post-condition-failure").
-					UsingConfig(envTest.Config).
 					PostConditions(func(_ context.Context, _ *feature.Feature) error {
 						return errors.New("during test always fail")
 					}),
@@ -127,10 +122,8 @@ var _ = Describe("Feature tracking capability", func() {
 
 		It("should correctly indicate source in the feature tracker", func(ctx context.Context) {
 			// given
-			featuresHandler := feature.ClusterFeaturesHandler(dsci, func(registry feature.FeaturesRegistry) error {
-				errFeatureAdd := registry.Add(feature.Define("always-working-feature").
-					UsingConfig(envTest.Config),
-				)
+			featuresHandler := feature.ClusterFeaturesHandler(envTestClient, dsci, func(registry feature.FeaturesRegistry) error {
+				errFeatureAdd := registry.Add(feature.Define("always-working-feature"))
 
 				Expect(errFeatureAdd).ToNot(HaveOccurred())
 
@@ -153,10 +146,8 @@ var _ = Describe("Feature tracking capability", func() {
 
 		It("should correctly indicate app namespace in the feature tracker", func(ctx context.Context) {
 			// given
-			featuresHandler := feature.ClusterFeaturesHandler(dsci, func(registry feature.FeaturesRegistry) error {
-				errFeatureAdd := registry.Add(feature.Define("empty-feature").
-					UsingConfig(envTest.Config),
-				)
+			featuresHandler := feature.ClusterFeaturesHandler(envTestClient, dsci, func(registry feature.FeaturesRegistry) error {
+				errFeatureAdd := registry.Add(feature.Define("empty-feature"))
 
 				Expect(errFeatureAdd).ToNot(HaveOccurred())
 
@@ -172,5 +163,55 @@ var _ = Describe("Feature tracking capability", func() {
 			Expect(featureTracker.Spec.AppNamespace).To(Equal("default"))
 		})
 
+	})
+
+	Context("adding ownerReferences to feature tracker", func() {
+		It("should indicate owner in the feature tracker when owner in feature", func(ctx context.Context) {
+			// given
+
+			// DSCI created in cluster
+			dsci, dsciErr := fixtures.CreateOrUpdateDSCI(ctx, envTestClient, dsci)
+			Expect(dsciErr).ToNot(HaveOccurred())
+
+			feature, featErr := feature.Define("empty-feat-with-owner").
+				UsingClient(envTestClient).
+				Source(featurev1.Source{
+					Type: featurev1.DSCIType,
+					Name: dsci.Name,
+				}).
+				TargetNamespace(appNamespace).
+				OwnedBy(dsci).
+				Create()
+
+			// when
+			Expect(featErr).ToNot(HaveOccurred())
+			Expect(feature.Apply(ctx)).To(Succeed())
+
+			// then
+			tracker, err := fixtures.GetFeatureTracker(ctx, envTestClient, appNamespace, "empty-feat-with-owner")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(tracker.OwnerReferences).ToNot(BeEmpty())
+		})
+
+		It("should not indicate owner in the feature tracker when owner not in feature", func(ctx context.Context) {
+			// given
+			feature, featErr := feature.Define("empty-feat-no-owner").
+				UsingClient(envTestClient).
+				Source(featurev1.Source{
+					Type: featurev1.DSCIType,
+					Name: dsci.Name,
+				}).
+				TargetNamespace(appNamespace).
+				Create()
+
+			// when
+			Expect(featErr).ToNot(HaveOccurred())
+			Expect(feature.Apply(ctx)).To(Succeed())
+
+			// then
+			tracker, err := fixtures.GetFeatureTracker(ctx, envTestClient, appNamespace, "empty-feat-no-owner")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(tracker.OwnerReferences).To(BeEmpty())
+		})
 	})
 })


### PR DESCRIPTION
## Description

Introduces the ability to define owner reference for FeatureTracker (internal custom resource). This enables garbage collection of resources belonging to the given Feature when its owner such as DSC or DSCI has been removed.

When Features are grouped through means of `FeatureHandler`s, the ownership is defined under the hood, linking it to DSCI or DSC, depending on the type used.

In addition, this PR simplifies how Feature relies on `client.Client` instance. Instead of creating its own instance, it expects to have one passed as part of the builder call chain. It creates a default one otherwise. With that we can rely on a client configured for controllers with the right schemas, caching rules, etc. As a consequence the change of retry logic for status needed to be adjusted. Besides a conflict, it needs to be triggered on the `NotFound` error, as a shared client's cache might not have yet an instance of FeatureTracker created just before the condition is reported. The reason why it was working before is the fact that Feature has its own simple client instance w/o caching.

> [!IMPORTANT]
>
> With DSCI and DSC becoming owners of particular FeatureTrackers, `func (c *Component) Cleanup` defined for `ComponentInterface` becomes somewhat speculative. It's been used in the finalizer block for respective controllers to ensure that FTs have been removed, but it also calls any other custom cleanup code attached to a Feature.
>
> The only use case where the custom function is invoked at this moment is unpatching/removing custom authorization provider added to SMCP. This was based on an early assumption that we might want to plug into customers' existing SMCP instance. It's unclear to me if this is still long-term thinking so we might want to revisit the need for this functionality.
>
> From the completeness point of view, if we allow to create/manipulate  resources programmatically as part of the Feature DSL, we should be able to register cleanup counter-part functions, especially if we cannot simply remove them (as this is handled through ownership of associated FeatureTracker).
>
> There is, however, a need to perform cleanup when the particular component is "Removed" (not managed anymore). Right now this is handled inside its `Reconcile` function.

Fixes [RHOAIENG-8629](https://issues.redhat.com/browse/RHOAIENG-8629)

Relates to https://github.com/opendatahub-io/opendatahub-operator/pull/1192#issuecomment-2314308317

## How Has This Been Tested?

`make test`

but also:

- create/remove DSCI to validate if FeatureTrackers are removed
- create/remove DSC with Kserve

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
