### PR TITLE
add ability to choose ingress creation for Kserve RawDeployment

### DIFF
--- a/bundle/manifests/datasciencecluster.opendatahub.io_datascienceclusters.yaml
+++ b/bundle/manifests/datasciencecluster.opendatahub.io_datascienceclusters.yaml
@@ -245,6 +245,17 @@ spec:
                         - Removed
                         pattern: ^(Managed|Unmanaged|Force|Removed)$
                         type: string
+                      rawRouteCreation:
+                        description: |-
+                          Configures the global setting for route creation for Kserve Raw InferenceServices.
+                          Managed: Route creation is enabled by default, InferenceServices will have to choose to opt out.
+                          Removed: Route creation is disabled globally. In this configuration it is not possible for an individual
+                          InferenceService to opt in to having a Route created automatically.
+                        enum:
+                        - Managed
+                        - Removed
+                        pattern: ^(Managed|Unmanaged|Force|Removed)$
+                        type: string
                       serving:
                         description: |-
                           Serving configures the KNative-Serving stack used for model serving. A Service

--- a/components/kserve/kserve.go
+++ b/components/kserve/kserve.go
@@ -54,6 +54,12 @@ type Kserve struct {
 	// This field is optional. If no default deployment mode is specified, Kserve will use Serverless mode.
 	// +kubebuilder:validation:Enum=Serverless;RawDeployment
 	DefaultDeploymentMode DefaultDeploymentMode `json:"defaultDeploymentMode,omitempty"`
+	// Configures the global setting for route creation for Kserve Raw InferenceServices.
+	// Managed: Route creation is enabled by default, InferenceServices will have to choose to opt out.
+	// Removed: Route creation is disabled globally. In this configuration it is not possible for an individual
+	// InferenceService to opt in to having a Route created automatically.
+	// +kubebuilder:validation:Enum=Managed;Removed
+	RawRouteCreation operatorv1.ManagementState `json:"rawRouteCreation,omitempty"`
 }
 
 func (k *Kserve) OverrideManifests(ctx context.Context, _ cluster.Platform) error {

--- a/components/kserve/kserve_config_handler.go
+++ b/components/kserve/kserve_config_handler.go
@@ -25,18 +25,13 @@ const (
 func (k *Kserve) setupKserveConfig(ctx context.Context, cli client.Client, logger logr.Logger, dscispec *dsciv1.DSCInitializationSpec) error {
 	// as long as Kserve.Serving is not 'Removed', we will setup the dependencies
 
-	var disableIngressCreation bool
 	defaultDeploymentMode := k.DefaultDeploymentMode
 	if defaultDeploymentMode == "" {
 		defaultDeploymentMode = Serverless
 	}
-	switch k.RawRouteCreation {
-	case operatorv1.Removed, "":
-		disableIngressCreation = true
-	case operatorv1.Managed:
+	disableIngressCreation := true
+	if k.RawRouteCreation == operatorv1.Managed {
 		disableIngressCreation = false
-	default:
-		disableIngressCreation = true
 	}
 	switch k.Serving.ManagementState {
 	case operatorv1.Managed, operatorv1.Unmanaged:

--- a/config/crd/bases/datasciencecluster.opendatahub.io_datascienceclusters.yaml
+++ b/config/crd/bases/datasciencecluster.opendatahub.io_datascienceclusters.yaml
@@ -245,6 +245,17 @@ spec:
                         - Removed
                         pattern: ^(Managed|Unmanaged|Force|Removed)$
                         type: string
+                      rawRouteCreation:
+                        description: |-
+                          Configures the global setting for route creation for Kserve Raw InferenceServices.
+                          Managed: Route creation is enabled by default, InferenceServices will have to choose to opt out.
+                          Removed: Route creation is disabled globally. In this configuration it is not possible for an individual
+                          InferenceService to opt in to having a Route created automatically.
+                        enum:
+                        - Managed
+                        - Removed
+                        pattern: ^(Managed|Unmanaged|Force|Removed)$
+                        type: string
                       serving:
                         description: |-
                           Serving configures the KNative-Serving stack used for model serving. A Service

--- a/docs/api-overview.md
+++ b/docs/api-overview.md
@@ -183,6 +183,7 @@ _Appears in:_
 | `Component` _[Component](#component)_ |  |  |  |
 | `serving` _[ServingSpec](#servingspec)_ | Serving configures the KNative-Serving stack used for model serving. A Service<br />Mesh (Istio) is prerequisite, since it is used as networking layer. |  |  |
 | `defaultDeploymentMode` _[DefaultDeploymentMode](#defaultdeploymentmode)_ | Configures the default deployment mode for Kserve. This can be set to 'Serverless' or 'RawDeployment'.<br />The value specified in this field will be used to set the default deployment mode in the 'inferenceservice-config' configmap for Kserve.<br />This field is optional. If no default deployment mode is specified, Kserve will use Serverless mode. |  | Enum: [Serverless RawDeployment] <br />Pattern: `^(Serverless\|RawDeployment)$` <br /> |
+| `rawRouteCreation` _[ManagementState](#managementstate)_ | Configures the global setting for route creation for Kserve Raw InferenceServices.<br />Managed: Route creation is enabled by default, InferenceServices will have to choose to opt out.<br />Removed: Route creation is disabled globally. In this configuration it is not possible for an individual<br />InferenceService to opt in to having a Route created automatically. |  | Enum: [Managed Removed] <br /> |
 
 
 


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->
Fixes : https://issues.redhat.com/browse/RHOAIENG-10291 
- Remove the logic to set the `disableIngressCreation` flag in `inferenceservice-config` 
  - This is now done in the Kserve Manifests itself, the flag will always be `true`
-  Added a field in the kserve spec for `disableIngressCreation`. Default is true, if user has set a value then that value will be used. 
- Set the `ingressDomain` in `inferenceservice-config` to the clusterDomain 

Merge after https://github.com/opendatahub-io/odh-model-controller/pull/274 and https://github.com/opendatahub-io/kserve/pull/419 

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- Deploy custom operator+kserve+odh-model-controller: 
- Using custom fork+branch to be able to apply the CRD changes along with the custom operator image
-- `git clone git@github.com:VedantMahabaleshwarkar/opendatahub-operator.git`
-- `cd opendatahub-operator` 
-- `git checkout origin/j-10291` 
-- `make deploy -e IMG=quay.io/vedantm/opendatahub-operator:latest -e OPERATOR_NAMESPACE=opendatahub-operator-system`

- To test Inference with auth: 
--  Create any kserve isvc+SR
-- isvc should have annotation : `"serving.kserve.io/deploymentMode" : RawDeployment`
-- isvc should have label: `"networking.kserve.io/odh-auth": "true"` 

- To test Inference without auth: 
-- remove isvc label `"networking.kserve.io/odh-auth": "true"`  

- To test disabling route for a particular ISVC 
--  Create any kserve isvc+SR
-- isvc should have annotation : `"serving.kserve.io/deploymentMode" : RawDeployment`
-- isvc should have label : `"networking.kserve.io/visibility": "cluster-local"`

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
