### PR TITLE
Rename GetPlatform functions to not reflect implementation

### DIFF
--- a/controllers/datasciencecluster/datasciencecluster_controller.go
+++ b/controllers/datasciencecluster/datasciencecluster_controller.go
@@ -85,7 +85,7 @@ func (r *DataScienceClusterReconciler) Reconcile(ctx context.Context, req ctrl.R
 	r.Log.Info("Reconciling DataScienceCluster resources", "Request.Name", req.Name)
 
 	// Get information on version
-	currentOperatorReleaseVersion, err := cluster.GetReleaseFromCSV(ctx, r.Client)
+	currentOperatorReleaseVersion, err := cluster.GetRelease(ctx, r.Client)
 	if err != nil {
 		r.Log.Error(err, "failed to get operator release version")
 		return ctrl.Result{}, err

--- a/controllers/dscinitialization/dscinitialization_controller.go
+++ b/controllers/dscinitialization/dscinitialization_controller.go
@@ -78,7 +78,7 @@ type DSCInitializationReconciler struct {
 func (r *DSCInitializationReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) { //nolint:funlen,gocyclo,maintidx
 	r.Log.Info("Reconciling DSCInitialization.", "DSCInitialization Request.Name", req.Name)
 
-	currentOperatorReleaseVersion, err := cluster.GetReleaseFromCSV(ctx, r.Client)
+	currentOperatorReleaseVersion, err := cluster.GetRelease(ctx, r.Client)
 	if err != nil {
 		r.Log.Error(err, "failed to get operator release version")
 		return ctrl.Result{}, err

--- a/main.go
+++ b/main.go
@@ -257,7 +257,7 @@ func main() { //nolint:funlen,maintidx
 	}
 
 	// get old release version before we create default DSCI CR
-	oldReleaseVersion, _ := upgrade.GetReleaseFromCR(ctx, setupClient)
+	oldReleaseVersion, _ := upgrade.GetDeployedRelease(ctx, setupClient)
 
 	// Check if user opted for disabling DSC configuration
 	disableDSCConfig, existDSCConfig := os.LookupEnv("DISABLE_DSC_CONFIG")

--- a/pkg/cluster/cluster_config.go
+++ b/pkg/cluster/cluster_config.go
@@ -133,7 +133,7 @@ type Release struct {
 	Version version.OperatorVersion `json:"version,omitempty"`
 }
 
-func GetReleaseFromCSV(ctx context.Context, cli client.Client) (Release, error) {
+func GetRelease(ctx context.Context, cli client.Client) (Release, error) {
 	initRelease := Release{
 		// dummy version set to name "", version 0.0.0
 		Version: version.OperatorVersion{

--- a/pkg/upgrade/upgrade.go
+++ b/pkg/upgrade/upgrade.go
@@ -516,7 +516,7 @@ func deleteDeprecatedNamespace(ctx context.Context, cli client.Client, namespace
 	return nil
 }
 
-func GetReleaseFromCR(ctx context.Context, cli client.Client) (cluster.Release, error) {
+func GetDeployedRelease(ctx context.Context, cli client.Client) (cluster.Release, error) {
 	dsciInstance := &dsciv1.DSCInitializationList{}
 	if err := cli.List(ctx, dsciInstance); err != nil {
 		return cluster.Release{}, err


### PR DESCRIPTION
GetReleaseFromCSV name is more about implementation than the task it
performs. The function fetches actual running operator release and
CSV is only one possibility for that.

GetReleaseFromCR name is more about implementation than the task it
performs. The function fetches release from DSC/DSCI mean the latest
release the data science cluster was deployed by. Consider it as
"deployed release".


<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
