### PR TITLE
refactor(feature): decouples Feature from the client

### DIFF
--- a/components/kserve/kserve_config_handler.go
+++ b/components/kserve/kserve_config_handler.go
@@ -148,9 +148,9 @@ func (k *Kserve) configureServerless(ctx context.Context, cli client.Client, log
 			return dependOpsErrors
 		}
 
-		serverlessFeatures := feature.ComponentFeaturesHandler(cli, owner, k.GetComponentName(), instance.ApplicationsNamespace, k.configureServerlessFeatures(instance))
+		serverlessFeatures := feature.ComponentFeaturesHandler(owner, k.GetComponentName(), instance.ApplicationsNamespace, k.configureServerlessFeatures(instance))
 
-		if err := serverlessFeatures.Apply(ctx); err != nil {
+		if err := serverlessFeatures.Apply(ctx, cli); err != nil {
 			return err
 		}
 	}
@@ -158,9 +158,9 @@ func (k *Kserve) configureServerless(ctx context.Context, cli client.Client, log
 }
 
 func (k *Kserve) removeServerlessFeatures(ctx context.Context, cli client.Client, owner metav1.Object, instance *dsciv1.DSCInitializationSpec) error {
-	serverlessFeatures := feature.ComponentFeaturesHandler(cli, owner, k.GetComponentName(), instance.ApplicationsNamespace, k.configureServerlessFeatures(instance))
+	serverlessFeatures := feature.ComponentFeaturesHandler(owner, k.GetComponentName(), instance.ApplicationsNamespace, k.configureServerlessFeatures(instance))
 
-	return serverlessFeatures.Delete(ctx)
+	return serverlessFeatures.Delete(ctx, cli)
 }
 
 func checkDependentOperators(ctx context.Context, cli client.Client) *multierror.Error {

--- a/components/kserve/servicemesh_setup.go
+++ b/components/kserve/servicemesh_setup.go
@@ -20,8 +20,8 @@ import (
 func (k *Kserve) configureServiceMesh(ctx context.Context, cli client.Client, owner metav1.Object, dscispec *dsciv1.DSCInitializationSpec) error {
 	if dscispec.ServiceMesh != nil {
 		if dscispec.ServiceMesh.ManagementState == operatorv1.Managed && k.GetManagementState() == operatorv1.Managed {
-			serviceMeshInitializer := feature.ComponentFeaturesHandler(cli, owner, k.GetComponentName(), dscispec.ApplicationsNamespace, k.defineServiceMeshFeatures(ctx, cli, dscispec))
-			return serviceMeshInitializer.Apply(ctx)
+			serviceMeshInitializer := feature.ComponentFeaturesHandler(owner, k.GetComponentName(), dscispec.ApplicationsNamespace, k.defineServiceMeshFeatures(ctx, cli, dscispec))
+			return serviceMeshInitializer.Apply(ctx, cli)
 		}
 		if dscispec.ServiceMesh.ManagementState == operatorv1.Unmanaged && k.GetManagementState() == operatorv1.Managed {
 			return nil
@@ -32,8 +32,8 @@ func (k *Kserve) configureServiceMesh(ctx context.Context, cli client.Client, ow
 }
 
 func (k *Kserve) removeServiceMeshConfigurations(ctx context.Context, cli client.Client, owner metav1.Object, dscispec *dsciv1.DSCInitializationSpec) error {
-	serviceMeshInitializer := feature.ComponentFeaturesHandler(cli, owner, k.GetComponentName(), dscispec.ApplicationsNamespace, k.defineServiceMeshFeatures(ctx, cli, dscispec))
-	return serviceMeshInitializer.Delete(ctx)
+	serviceMeshInitializer := feature.ComponentFeaturesHandler(owner, k.GetComponentName(), dscispec.ApplicationsNamespace, k.defineServiceMeshFeatures(ctx, cli, dscispec))
+	return serviceMeshInitializer.Delete(ctx, cli)
 }
 
 func (k *Kserve) defineServiceMeshFeatures(ctx context.Context, cli client.Client, dscispec *dsciv1.DSCInitializationSpec) feature.FeaturesProvider {

--- a/pkg/feature/feature.go
+++ b/pkg/feature/feature.go
@@ -41,8 +41,7 @@ type Feature struct {
 	Enabled         EnabledFunc
 	Managed         bool
 
-	Client client.Client
-	Log    logr.Logger
+	Log logr.Logger
 
 	tracker *featurev1.FeatureTracker
 	source  *featurev1.Source
@@ -61,7 +60,7 @@ type Feature struct {
 
 // Action is a func type which can be used for different purposes during Feature's lifecycle
 // while having access to Feature struct.
-type Action func(ctx context.Context, f *Feature) error
+type Action func(ctx context.Context, cli client.Client, f *Feature) error
 
 // CleanupFunc defines how to clean up resources associated with a feature.
 // By default, all resources created by the feature are deleted when the feature is,
@@ -70,70 +69,70 @@ type Action func(ctx context.Context, f *Feature) error
 type CleanupFunc func(ctx context.Context, cli client.Client) error
 
 // EnabledFunc is a func type used to determine if a feature should be enabled.
-type EnabledFunc func(ctx context.Context, feature *Feature) (bool, error)
+type EnabledFunc func(ctx context.Context, cli client.Client, feature *Feature) (bool, error)
 
 // Apply applies the feature to the cluster.
 // It creates a FeatureTracker resource to establish ownership and reports the result of the operation as a condition.
-func (f *Feature) Apply(ctx context.Context) error {
+func (f *Feature) Apply(ctx context.Context, cli client.Client) error {
 	// If the feature is disabled, but the FeatureTracker exists in the cluster, ensure clean-up is triggered.
 	// This means that the feature was previously enabled, but now it is not anymore.
-	if enabled, err := f.Enabled(ctx, f); !enabled || err != nil {
+	if enabled, err := f.Enabled(ctx, cli, f); !enabled || err != nil {
 		if err != nil {
 			return err
 		}
 
-		return f.Cleanup(ctx)
+		return f.Cleanup(ctx, cli)
 	}
 
-	if trackerErr := createFeatureTracker(ctx, f); trackerErr != nil {
+	if trackerErr := createFeatureTracker(ctx, cli, f); trackerErr != nil {
 		return trackerErr
 	}
 
-	if _, updateErr := status.UpdateWithRetry(ctx, f.Client, f.tracker, func(saved *featurev1.FeatureTracker) {
+	if _, updateErr := status.UpdateWithRetry(ctx, cli, f.tracker, func(saved *featurev1.FeatureTracker) {
 		status.SetProgressingCondition(&saved.Status.Conditions, string(featurev1.ConditionReason.FeatureCreated), fmt.Sprintf("Applying feature [%s]", f.Name))
 		saved.Status.Phase = status.PhaseProgressing
 	}); updateErr != nil {
 		return updateErr
 	}
 
-	applyErr := f.applyFeature(ctx)
-	_, reportErr := createFeatureTrackerStatusReporter(f).ReportCondition(ctx, applyErr)
+	applyErr := f.applyFeature(ctx, cli)
+	_, reportErr := createFeatureTrackerStatusReporter(cli, f).ReportCondition(ctx, applyErr)
 
 	return multierror.Append(applyErr, reportErr).ErrorOrNil()
 }
 
-func (f *Feature) applyFeature(ctx context.Context) error {
+func (f *Feature) applyFeature(ctx context.Context, cli client.Client) error {
 	var multiErr *multierror.Error
 
 	for _, dataProvider := range f.dataProviders {
-		multiErr = multierror.Append(multiErr, dataProvider(ctx, f))
+		multiErr = multierror.Append(multiErr, dataProvider(ctx, cli, f))
 	}
 	if errDataLoad := multiErr.ErrorOrNil(); errDataLoad != nil {
 		return &withConditionReasonError{reason: featurev1.ConditionReason.LoadTemplateData, err: errDataLoad}
 	}
 
 	for _, precondition := range f.preconditions {
-		multiErr = multierror.Append(multiErr, precondition(ctx, f))
+		multiErr = multierror.Append(multiErr, precondition(ctx, cli, f))
 	}
 	if preconditionsErr := multiErr.ErrorOrNil(); preconditionsErr != nil {
 		return &withConditionReasonError{reason: featurev1.ConditionReason.PreConditions, err: preconditionsErr}
 	}
 
 	for _, clusterOperation := range f.clusterOperations {
-		if errClusterOperation := clusterOperation(ctx, f); errClusterOperation != nil {
+		if errClusterOperation := clusterOperation(ctx, cli, f); errClusterOperation != nil {
 			return &withConditionReasonError{reason: featurev1.ConditionReason.ResourceCreation, err: errClusterOperation}
 		}
 	}
 
 	for i := range f.appliers {
 		r := f.appliers[i]
-		if processErr := r.Apply(ctx, f.Client, f.data, DefaultMetaOptions(f)...); processErr != nil {
+		if processErr := r.Apply(ctx, cli, f.data, DefaultMetaOptions(f)...); processErr != nil {
 			return &withConditionReasonError{reason: featurev1.ConditionReason.ApplyManifests, err: processErr}
 		}
 	}
 
 	for _, postcondition := range f.postconditions {
-		multiErr = multierror.Append(multiErr, postcondition(ctx, f))
+		multiErr = multierror.Append(multiErr, postcondition(ctx, cli, f))
 	}
 	if postConditionErr := multiErr.ErrorOrNil(); postConditionErr != nil {
 		return &withConditionReasonError{reason: featurev1.ConditionReason.PostConditions, err: postConditionErr}
@@ -142,14 +141,14 @@ func (f *Feature) applyFeature(ctx context.Context) error {
 	return nil
 }
 
-func (f *Feature) Cleanup(ctx context.Context) error {
+func (f *Feature) Cleanup(ctx context.Context, cli client.Client) error {
 	// Ensure associated FeatureTracker instance has been removed as last one
 	// in the chain of cleanups.
 	f.addCleanup(removeFeatureTracker(f))
 
 	var cleanupErrors *multierror.Error
 	for _, cleanupFunc := range f.cleanups {
-		cleanupErrors = multierror.Append(cleanupErrors, cleanupFunc(ctx, f.Client))
+		cleanupErrors = multierror.Append(cleanupErrors, cleanupFunc(ctx, cli))
 	}
 
 	return cleanupErrors.ErrorOrNil()

--- a/pkg/feature/feature_data.go
+++ b/pkg/feature/feature_data.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/feature/provider"
 )
 
@@ -13,8 +15,8 @@ import (
 //
 // If the value is static, consider using provider.ValueOf(variable).Get as passed provider function.
 func Entry[T any](key string, providerFunc provider.DataProviderFunc[T]) Action {
-	return func(ctx context.Context, f *Feature) error {
-		data, err := providerFunc(ctx, f.Client)
+	return func(ctx context.Context, cli client.Client, f *Feature) error {
+		data, err := providerFunc(ctx, cli)
 		if err != nil {
 			return err
 		}

--- a/pkg/feature/handler.go
+++ b/pkg/feature/handler.go
@@ -15,8 +15,8 @@ import (
 )
 
 type featuresHandler interface {
-	Apply(ctx context.Context) error
-	Delete(ctx context.Context) error
+	Apply(ctx context.Context, cli client.Client) error
+	Delete(ctx context.Context, cli client.Client) error
 }
 
 type FeaturesRegistry interface {
@@ -28,7 +28,6 @@ var _ featuresHandler = (*FeaturesHandler)(nil)
 // FeaturesHandler provides a structured way to manage and coordinate the creation, application,
 // and deletion of features needed in particular Data Science Cluster configuration.
 type FeaturesHandler struct {
-	cli               client.Client
 	source            featurev1.Source
 	owner             metav1.Object
 	targetNamespace   string
@@ -45,7 +44,7 @@ func (fh *FeaturesHandler) Add(builders ...*featureBuilder) error {
 
 	for i := range builders {
 		fb := builders[i]
-		feature, err := fb.UsingClient(fh.cli).
+		feature, err := fb.
 			TargetNamespace(fh.targetNamespace).
 			OwnedBy(fh.owner).
 			Source(fh.source).
@@ -57,7 +56,7 @@ func (fh *FeaturesHandler) Add(builders ...*featureBuilder) error {
 	return multiErr.ErrorOrNil()
 }
 
-func (fh *FeaturesHandler) Apply(ctx context.Context) error {
+func (fh *FeaturesHandler) Apply(ctx context.Context, cli client.Client) error {
 	fh.features = make([]*Feature, 0)
 
 	for _, featuresProvider := range fh.featuresProviders {
@@ -68,7 +67,7 @@ func (fh *FeaturesHandler) Apply(ctx context.Context) error {
 
 	var multiErr *multierror.Error
 	for _, f := range fh.features {
-		if applyErr := f.Apply(ctx); applyErr != nil {
+		if applyErr := f.Apply(ctx, cli); applyErr != nil {
 			multiErr = multierror.Append(multiErr, fmt.Errorf("failed applying FeatureHandler features. cause: %w", applyErr))
 		}
 	}
@@ -78,7 +77,7 @@ func (fh *FeaturesHandler) Apply(ctx context.Context) error {
 
 // Delete executes registered clean-up tasks for handled Features in the opposite order they were initiated.
 // This approach assumes that Features are either instantiated in the correct sequence or are self-contained.
-func (fh *FeaturesHandler) Delete(ctx context.Context) error {
+func (fh *FeaturesHandler) Delete(ctx context.Context, cli client.Client) error {
 	fh.features = make([]*Feature, 0)
 
 	for _, featuresProvider := range fh.featuresProviders {
@@ -89,7 +88,7 @@ func (fh *FeaturesHandler) Delete(ctx context.Context) error {
 
 	var multiErr *multierror.Error
 	for i := len(fh.features) - 1; i >= 0; i-- {
-		if cleanupErr := fh.features[i].Cleanup(ctx); cleanupErr != nil {
+		if cleanupErr := fh.features[i].Cleanup(ctx, cli); cleanupErr != nil {
 			multiErr = multierror.Append(multiErr, fmt.Errorf("failed executing cleanup in FeatureHandler. cause: %w", cleanupErr))
 		}
 	}
@@ -101,9 +100,8 @@ func (fh *FeaturesHandler) Delete(ctx context.Context) error {
 // and add them to the handler's registry.
 type FeaturesProvider func(registry FeaturesRegistry) error
 
-func ClusterFeaturesHandler(cli client.Client, dsci *dsciv1.DSCInitialization, def ...FeaturesProvider) *FeaturesHandler {
+func ClusterFeaturesHandler(dsci *dsciv1.DSCInitialization, def ...FeaturesProvider) *FeaturesHandler {
 	return &FeaturesHandler{
-		cli:               cli,
 		targetNamespace:   dsci.Spec.ApplicationsNamespace,
 		owner:             dsci,
 		source:            featurev1.Source{Type: featurev1.DSCIType, Name: dsci.Name},
@@ -111,9 +109,8 @@ func ClusterFeaturesHandler(cli client.Client, dsci *dsciv1.DSCInitialization, d
 	}
 }
 
-func ComponentFeaturesHandler(cli client.Client, owner metav1.Object, componentName, targetNamespace string, def ...FeaturesProvider) *FeaturesHandler {
+func ComponentFeaturesHandler(owner metav1.Object, componentName, targetNamespace string, def ...FeaturesProvider) *FeaturesHandler {
 	return &FeaturesHandler{
-		cli:               cli,
 		owner:             owner,
 		targetNamespace:   targetNamespace,
 		source:            featurev1.Source{Type: featurev1.ComponentType, Name: componentName},
@@ -143,16 +140,16 @@ func NewHandlerWithReporter[T client.Object](handler *FeaturesHandler, reporter 
 	}
 }
 
-func (h HandlerWithReporter[T]) Apply(ctx context.Context) error {
-	applyErr := h.handler.Apply(ctx)
+func (h HandlerWithReporter[T]) Apply(ctx context.Context, cli client.Client) error {
+	applyErr := h.handler.Apply(ctx, cli)
 	_, reportErr := h.reporter.ReportCondition(ctx, applyErr)
 	// We could have failed during Apply phase as well as during reporting.
 	// We should return both errors to the caller.
 	return multierror.Append(applyErr, reportErr).ErrorOrNil()
 }
 
-func (h HandlerWithReporter[T]) Delete(ctx context.Context) error {
-	deleteErr := h.handler.Delete(ctx)
+func (h HandlerWithReporter[T]) Delete(ctx context.Context, cli client.Client) error {
+	deleteErr := h.handler.Delete(ctx, cli)
 	_, reportErr := h.reporter.ReportCondition(ctx, deleteErr)
 	// We could have failed during Delete phase as well as during reporting.
 	// We should return both errors to the caller.

--- a/pkg/feature/resources.go
+++ b/pkg/feature/resources.go
@@ -3,14 +3,16 @@ package feature
 import (
 	"context"
 
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
 )
 
 // CreateNamespaceIfNotExists will create a namespace with the given name if it does not exist yet.
 // It does not set ownership nor apply extra metadata to the existing namespace.
 func CreateNamespaceIfNotExists(namespace string) Action {
-	return func(ctx context.Context, f *Feature) error {
-		_, err := cluster.CreateNamespace(ctx, f.Client, namespace)
+	return func(ctx context.Context, cli client.Client, _ *Feature) error {
+		_, err := cluster.CreateNamespace(ctx, cli, namespace)
 
 		return err
 	}

--- a/pkg/feature/serverless/conditions.go
+++ b/pkg/feature/serverless/conditions.go
@@ -16,11 +16,11 @@ const (
 	KnativeServingNamespace = "knative-serving"
 )
 
-func EnsureServerlessAbsent(ctx context.Context, f *feature.Feature) error {
+func EnsureServerlessAbsent(ctx context.Context, cli client.Client, f *feature.Feature) error {
 	list := &unstructured.UnstructuredList{}
 	list.SetGroupVersionKind(gvk.KnativeServing)
 
-	if err := f.Client.List(ctx, list, client.InNamespace("")); err != nil {
+	if err := cli.List(ctx, list, client.InNamespace("")); err != nil {
 		return fmt.Errorf("failed to list KnativeServings: %w", err)
 	}
 
@@ -46,8 +46,8 @@ func EnsureServerlessAbsent(ctx context.Context, f *feature.Feature) error {
 	return errors.New("existing KNativeServing resource was found; integrating to an existing installation is not supported")
 }
 
-func EnsureServerlessOperatorInstalled(ctx context.Context, f *feature.Feature) error {
-	if err := feature.EnsureOperatorIsInstalled("serverless-operator")(ctx, f); err != nil {
+func EnsureServerlessOperatorInstalled(ctx context.Context, cli client.Client, f *feature.Feature) error {
+	if err := feature.EnsureOperatorIsInstalled("serverless-operator")(ctx, cli, f); err != nil {
 		return fmt.Errorf("failed to find the pre-requisite KNative Serving Operator subscription, please ensure Serverless Operator is installed. %w", err)
 	}
 

--- a/pkg/feature/serverless/resources.go
+++ b/pkg/feature/serverless/resources.go
@@ -3,13 +3,15 @@ package serverless
 import (
 	"context"
 
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
 	infrav1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/infrastructure/v1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/feature"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/feature/servicemesh"
 )
 
-func ServingCertificateResource(ctx context.Context, f *feature.Feature) error {
+func ServingCertificateResource(ctx context.Context, cli client.Client, f *feature.Feature) error {
 	secretData, err := getSecretParams(f)
 	if err != nil {
 		return err
@@ -17,7 +19,7 @@ func ServingCertificateResource(ctx context.Context, f *feature.Feature) error {
 
 	switch secretData.Type {
 	case infrav1.SelfSigned:
-		return cluster.CreateSelfSignedCertificate(ctx, f.Client,
+		return cluster.CreateSelfSignedCertificate(ctx, cli,
 			secretData.Name,
 			secretData.Domain,
 			secretData.Namespace,
@@ -25,7 +27,7 @@ func ServingCertificateResource(ctx context.Context, f *feature.Feature) error {
 	case infrav1.Provided:
 		return nil
 	default:
-		return cluster.PropagateDefaultIngressCertificate(ctx, f.Client, secretData.Name, secretData.Namespace)
+		return cluster.PropagateDefaultIngressCertificate(ctx, cli, secretData.Name, secretData.Namespace)
 	}
 }
 

--- a/pkg/feature/servicemesh/conditions.go
+++ b/pkg/feature/servicemesh/conditions.go
@@ -23,30 +23,30 @@ const (
 )
 
 // EnsureAuthNamespaceExists creates a namespace for the Authorization provider and set ownership so it will be garbage collected when the operator is uninstalled.
-func EnsureAuthNamespaceExists(ctx context.Context, f *feature.Feature) error {
+func EnsureAuthNamespaceExists(ctx context.Context, cli client.Client, f *feature.Feature) error {
 	authNs, err := FeatureData.Authorization.Namespace.Extract(f)
 	if err != nil {
 		return fmt.Errorf("could not get auth from feature: %w", err)
 	}
 
-	_, err = cluster.CreateNamespace(ctx, f.Client, authNs, feature.OwnedBy(f), cluster.WithLabels(labels.ODH.OwnedNamespace, "true"))
+	_, err = cluster.CreateNamespace(ctx, cli, authNs, feature.OwnedBy(f), cluster.WithLabels(labels.ODH.OwnedNamespace, "true"))
 	return err
 }
 
-func EnsureServiceMeshOperatorInstalled(ctx context.Context, f *feature.Feature) error {
-	if err := feature.EnsureOperatorIsInstalled("servicemeshoperator")(ctx, f); err != nil {
+func EnsureServiceMeshOperatorInstalled(ctx context.Context, cli client.Client, f *feature.Feature) error {
+	if err := feature.EnsureOperatorIsInstalled("servicemeshoperator")(ctx, cli, f); err != nil {
 		return fmt.Errorf("failed to find the pre-requisite Service Mesh Operator subscription, please ensure Service Mesh Operator is installed. %w", err)
 	}
 
 	return nil
 }
 
-func EnsureServiceMeshInstalled(ctx context.Context, f *feature.Feature) error {
-	if err := EnsureServiceMeshOperatorInstalled(ctx, f); err != nil {
+func EnsureServiceMeshInstalled(ctx context.Context, cli client.Client, f *feature.Feature) error {
+	if err := EnsureServiceMeshOperatorInstalled(ctx, cli, f); err != nil {
 		return err
 	}
 
-	if err := WaitForControlPlaneToBeReady(ctx, f); err != nil {
+	if err := WaitForControlPlaneToBeReady(ctx, cli, f); err != nil {
 		controlPlane, errGet := FeatureData.ControlPlane.Extract(f)
 		if errGet != nil {
 			return fmt.Errorf("failed to get control plane struct: %w", err)
@@ -60,7 +60,7 @@ func EnsureServiceMeshInstalled(ctx context.Context, f *feature.Feature) error {
 	return nil
 }
 
-func WaitForControlPlaneToBeReady(ctx context.Context, f *feature.Feature) error {
+func WaitForControlPlaneToBeReady(ctx context.Context, cli client.Client, f *feature.Feature) error {
 	controlPlane, err := FeatureData.ControlPlane.Extract(f)
 	if err != nil {
 		return err
@@ -72,7 +72,7 @@ func WaitForControlPlaneToBeReady(ctx context.Context, f *feature.Feature) error
 	f.Log.Info("waiting for control plane components to be ready", "control-plane", smcp, "namespace", smcpNs, "duration (s)", duration.Seconds())
 
 	return wait.PollUntilContextTimeout(ctx, interval, duration, false, func(ctx context.Context) (bool, error) {
-		ready, err := CheckControlPlaneComponentReadiness(ctx, f.Client, smcp, smcpNs)
+		ready, err := CheckControlPlaneComponentReadiness(ctx, cli, smcp, smcpNs)
 
 		if ready {
 			f.Log.Info("done waiting for control plane components to be ready", "control-plane", smcp, "namespace", smcpNs)

--- a/pkg/feature/servicemesh/resources.go
+++ b/pkg/feature/servicemesh/resources.go
@@ -7,6 +7,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/feature"
@@ -14,7 +15,7 @@ import (
 
 // MeshRefs stores service mesh configuration in the config map, so it can
 // be easily accessed by other components which rely on this information.
-func MeshRefs(ctx context.Context, f *feature.Feature) error {
+func MeshRefs(ctx context.Context, cli client.Client, f *feature.Feature) error {
 	meshConfig, err := FeatureData.ControlPlane.Extract(f)
 	if err != nil {
 		return fmt.Errorf("failed to get control plane struct: %w", err)
@@ -28,7 +29,7 @@ func MeshRefs(ctx context.Context, f *feature.Feature) error {
 
 	return cluster.CreateOrUpdateConfigMap(
 		ctx,
-		f.Client,
+		cli,
 		&corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      ConfigMapMeshRef,
@@ -42,7 +43,7 @@ func MeshRefs(ctx context.Context, f *feature.Feature) error {
 
 // AuthRefs stores authorization configuration in the config map, so it can
 // be easily accessed by other components which rely on this information.
-func AuthRefs(ctx context.Context, f *feature.Feature) error {
+func AuthRefs(ctx context.Context, cli client.Client, f *feature.Feature) error {
 	targetNamespace := f.TargetNamespace
 	auth, err := FeatureData.Authorization.Spec.Extract(f)
 	if err != nil {
@@ -73,7 +74,7 @@ func AuthRefs(ctx context.Context, f *feature.Feature) error {
 
 	return cluster.CreateOrUpdateConfigMap(
 		ctx,
-		f.Client,
+		cli,
 		&corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      ConfigMapAuthRef,

--- a/tests/integration/features/cleanup_int_test.go
+++ b/tests/integration/features/cleanup_int_test.go
@@ -43,7 +43,6 @@ var _ = Describe("feature cleanup", func() {
 					Type: featurev1.DSCIType,
 					Name: dsci.Name,
 				}).
-				UsingClient(envTestClient).
 				PreConditions(
 					feature.CreateNamespaceIfNotExists(namespace),
 				).
@@ -56,7 +55,7 @@ var _ = Describe("feature cleanup", func() {
 
 		It("should successfully create resource and associated feature tracker", func(ctx context.Context) {
 			// when
-			Expect(testFeature.Apply(ctx)).Should(Succeed())
+			Expect(testFeature.Apply(ctx, envTestClient)).Should(Succeed())
 
 			// then
 			Eventually(createdSecretHasOwnerReferenceToOwningFeature(namespace, featureName)).
@@ -68,7 +67,7 @@ var _ = Describe("feature cleanup", func() {
 
 		It("should remove feature tracker on clean-up", func(ctx context.Context) {
 			// when
-			Expect(testFeature.Cleanup(ctx)).To(Succeed())
+			Expect(testFeature.Cleanup(ctx, envTestClient)).To(Succeed())
 
 			// then
 			Consistently(createdSecretHasOwnerReferenceToOwningFeature(namespace, featureName)).
@@ -103,7 +102,7 @@ var _ = Describe("feature cleanup", func() {
 			err := fixtures.CreateOrUpdateNamespace(ctx, envTestClient, fixtures.NewNamespace("conditional-ns"))
 			Expect(err).To(Not(HaveOccurred()))
 
-			featuresHandler = feature.ClusterFeaturesHandler(envTestClient, dsci, func(registry feature.FeaturesRegistry) error {
+			featuresHandler = feature.ClusterFeaturesHandler(dsci, func(registry feature.FeaturesRegistry) error {
 				return registry.Add(feature.Define(featureName).
 					EnabledWhen(namespaceExists).
 					PreConditions(
@@ -114,7 +113,7 @@ var _ = Describe("feature cleanup", func() {
 			})
 
 			// when
-			Expect(featuresHandler.Apply(ctx)).Should(Succeed())
+			Expect(featuresHandler.Apply(ctx, envTestClient)).Should(Succeed())
 
 			// then
 			Eventually(createdSecretHasOwnerReferenceToOwningFeature(namespace, featureName)).
@@ -130,7 +129,7 @@ var _ = Describe("feature cleanup", func() {
 			Expect(err).To(Not(HaveOccurred()))
 
 			// Mimic reconcile by re-loading the feature handler
-			featuresHandler = feature.ClusterFeaturesHandler(envTestClient, dsci, func(registry feature.FeaturesRegistry) error {
+			featuresHandler = feature.ClusterFeaturesHandler(dsci, func(registry feature.FeaturesRegistry) error {
 				return registry.Add(feature.Define(featureName).
 					EnabledWhen(namespaceExists).
 					PreConditions(
@@ -140,7 +139,7 @@ var _ = Describe("feature cleanup", func() {
 				)
 			})
 
-			Expect(featuresHandler.Apply(ctx)).Should(Succeed())
+			Expect(featuresHandler.Apply(ctx, envTestClient)).Should(Succeed())
 
 			// then
 			Consistently(createdSecretHasOwnerReferenceToOwningFeature(namespace, featureName)).
@@ -204,8 +203,8 @@ func createdSecretHasOwnerReferenceToOwningFeature(namespace, featureName string
 	}
 }
 
-func namespaceExists(ctx context.Context, f *feature.Feature) (bool, error) {
-	namespace, err := fixtures.GetNamespace(ctx, f.Client, "conditional-ns")
+func namespaceExists(ctx context.Context, cli client.Client, f *feature.Feature) (bool, error) {
+	namespace, err := fixtures.GetNamespace(ctx, cli, "conditional-ns")
 	if errors.IsNotFound(err) {
 		return false, nil
 	}

--- a/tests/integration/features/fixtures/cluster_test_fixtures.go
+++ b/tests/integration/features/fixtures/cluster_test_fixtures.go
@@ -79,8 +79,8 @@ func GetService(ctx context.Context, client client.Client, namespace, name strin
 	return svc, err
 }
 
-func CreateSecret(name, namespace string) func(ctx context.Context, f *feature.Feature) error {
-	return func(ctx context.Context, f *feature.Feature) error {
+func CreateSecret(name, namespace string) feature.Action {
+	return func(ctx context.Context, cli client.Client, f *feature.Feature) error {
 		secret := &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      name,
@@ -94,7 +94,7 @@ func CreateSecret(name, namespace string) func(ctx context.Context, f *feature.F
 			},
 		}
 
-		return f.Client.Create(ctx, secret)
+		return cli.Create(ctx, secret)
 	}
 }
 

--- a/tests/integration/features/manifests_int_test.go
+++ b/tests/integration/features/manifests_int_test.go
@@ -45,7 +45,7 @@ var _ = Describe("Applying resources", func() {
 
 	It("should be able to process an embedded YAML file", func(ctx context.Context) {
 		// given
-		featuresHandler := feature.ClusterFeaturesHandler(envTestClient, dsci, func(registry feature.FeaturesRegistry) error {
+		featuresHandler := feature.ClusterFeaturesHandler(dsci, func(registry feature.FeaturesRegistry) error {
 			errNsCreate := registry.Add(feature.Define("create-namespaces").
 				Manifests(
 					manifest.Location(fixtures.TestEmbeddedFiles).
@@ -59,7 +59,7 @@ var _ = Describe("Applying resources", func() {
 		})
 
 		// when
-		Expect(featuresHandler.Apply(ctx)).To(Succeed())
+		Expect(featuresHandler.Apply(ctx, envTestClient)).To(Succeed())
 
 		// then
 		embeddedNs1, errNS1 := fixtures.GetNamespace(ctx, envTestClient, "embedded-test-ns-1")
@@ -75,7 +75,7 @@ var _ = Describe("Applying resources", func() {
 
 	It("should be able to process an embedded template file", func(ctx context.Context) {
 		// given
-		featuresHandler := feature.ClusterFeaturesHandler(envTestClient, dsci, func(registry feature.FeaturesRegistry) error {
+		featuresHandler := feature.ClusterFeaturesHandler(dsci, func(registry feature.FeaturesRegistry) error {
 			errSvcCreate := registry.Add(feature.Define("create-local-gw-svc").
 				Manifests(
 					manifest.Location(fixtures.TestEmbeddedFiles).
@@ -90,7 +90,7 @@ var _ = Describe("Applying resources", func() {
 		})
 
 		// when
-		Expect(featuresHandler.Apply(ctx)).To(Succeed())
+		Expect(featuresHandler.Apply(ctx, envTestClient)).To(Succeed())
 
 		// then
 		service, err := fixtures.GetService(ctx, envTestClient, namespace.Name, "knative-local-gateway")
@@ -109,7 +109,7 @@ metadata:
 
 		Expect(fixtures.CreateFile(tempDir, "namespace.yaml", nsYAML)).To(Succeed())
 
-		featuresHandler := feature.ClusterFeaturesHandler(envTestClient, dsci, func(registry feature.FeaturesRegistry) error {
+		featuresHandler := feature.ClusterFeaturesHandler(dsci, func(registry feature.FeaturesRegistry) error {
 			errSvcCreate := registry.Add(feature.Define("create-namespace").
 				Manifests(
 					manifest.Location(os.DirFS(tempDir)).
@@ -123,7 +123,7 @@ metadata:
 		})
 
 		// when
-		Expect(featuresHandler.Apply(ctx)).To(Succeed())
+		Expect(featuresHandler.Apply(ctx, envTestClient)).To(Succeed())
 
 		// then
 		realNs, err := fixtures.GetNamespace(ctx, envTestClient, "real-file-test-ns")

--- a/tests/integration/features/preconditions_int_test.go
+++ b/tests/integration/features/preconditions_int_test.go
@@ -41,7 +41,7 @@ var _ = Describe("feature preconditions", func() {
 			defer objectCleaner.DeleteAll(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}})
 
 			// when
-			featuresHandler := feature.ClusterFeaturesHandler(envTestClient, dsci, func(registry feature.FeaturesRegistry) error {
+			featuresHandler := feature.ClusterFeaturesHandler(dsci, func(registry feature.FeaturesRegistry) error {
 				errFeatureAdd := registry.Add(feature.Define("create-new-ns").
 					PreConditions(feature.CreateNamespaceIfNotExists(namespace)),
 				)
@@ -52,7 +52,7 @@ var _ = Describe("feature preconditions", func() {
 			})
 
 			// then
-			Expect(featuresHandler.Apply(ctx)).To(Succeed())
+			Expect(featuresHandler.Apply(ctx, envTestClient)).To(Succeed())
 
 			// and
 			Eventually(func() error {
@@ -76,7 +76,7 @@ var _ = Describe("feature preconditions", func() {
 			defer objectCleaner.DeleteAll(ctx, ns)
 
 			// when
-			featuresHandler := feature.ClusterFeaturesHandler(envTestClient, dsci, func(registry feature.FeaturesRegistry) error {
+			featuresHandler := feature.ClusterFeaturesHandler(dsci, func(registry feature.FeaturesRegistry) error {
 				errFeatureAdd := registry.Add(feature.Define("create-new-ns").
 					PreConditions(feature.CreateNamespaceIfNotExists(namespace)),
 				)
@@ -87,7 +87,7 @@ var _ = Describe("feature preconditions", func() {
 			})
 
 			// then
-			Expect(featuresHandler.Apply(ctx)).To(Succeed())
+			Expect(featuresHandler.Apply(ctx, envTestClient)).To(Succeed())
 
 		})
 

--- a/tests/integration/features/resources_int_test.go
+++ b/tests/integration/features/resources_int_test.go
@@ -54,7 +54,7 @@ var _ = Describe("Applying and updating resources", func() {
 
 		It("should reconcile the resource to its managed state", func(ctx context.Context) {
 			// given managed feature
-			featuresHandler := feature.ClusterFeaturesHandler(envTestClient, dsci, func(registry feature.FeaturesRegistry) error {
+			featuresHandler := feature.ClusterFeaturesHandler(dsci, func(registry feature.FeaturesRegistry) error {
 				return registry.Add(
 					feature.Define("create-local-gw-svc").
 						Managed().
@@ -65,7 +65,7 @@ var _ = Describe("Applying and updating resources", func() {
 						WithData(feature.Entry("ControlPlane", provider.ValueOf(dsci.Spec.ServiceMesh.ControlPlane).Get)),
 				)
 			})
-			Expect(featuresHandler.Apply(ctx)).To(Succeed())
+			Expect(featuresHandler.Apply(ctx, envTestClient)).To(Succeed())
 
 			// expect created svc to have managed annotation
 			service, err := fixtures.GetService(ctx, envTestClient, testNamespace, "knative-local-gateway")
@@ -80,7 +80,7 @@ var _ = Describe("Applying and updating resources", func() {
 
 			// then
 			// expect that modification is reconciled away
-			Expect(featuresHandler.Apply(ctx)).To(Succeed())
+			Expect(featuresHandler.Apply(ctx, envTestClient)).To(Succeed())
 			updatedService, err := fixtures.GetService(ctx, envTestClient, testNamespace, "knative-local-gateway")
 			Expect(err).ToNot(HaveOccurred())
 			Expect(updatedService.Annotations).To(
@@ -90,7 +90,7 @@ var _ = Describe("Applying and updating resources", func() {
 
 		It("should not reconcile explicitly opt-ed out resource", func(ctx context.Context) {
 			// given managed feature
-			featuresHandler := feature.ClusterFeaturesHandler(envTestClient, dsci, func(registry feature.FeaturesRegistry) error {
+			featuresHandler := feature.ClusterFeaturesHandler(dsci, func(registry feature.FeaturesRegistry) error {
 				return registry.Add(
 					feature.Define("create-unmanaged-svc").
 						Managed().
@@ -101,7 +101,7 @@ var _ = Describe("Applying and updating resources", func() {
 						WithData(feature.Entry("ControlPlane", provider.ValueOf(dsci.Spec.ServiceMesh.ControlPlane).Get)),
 				)
 			})
-			Expect(featuresHandler.Apply(ctx)).To(Succeed())
+			Expect(featuresHandler.Apply(ctx, envTestClient)).To(Succeed())
 
 			// when
 			service, err := fixtures.GetService(ctx, envTestClient, testNamespace, "unmanaged-svc")
@@ -111,7 +111,7 @@ var _ = Describe("Applying and updating resources", func() {
 
 			// then
 			// expect that modification is reconciled away
-			Expect(featuresHandler.Apply(ctx)).To(Succeed())
+			Expect(featuresHandler.Apply(ctx, envTestClient)).To(Succeed())
 
 			updatedService, err := fixtures.GetService(ctx, envTestClient, testNamespace, "unmanaged-svc")
 			Expect(err).ToNot(HaveOccurred())
@@ -126,7 +126,7 @@ var _ = Describe("Applying and updating resources", func() {
 
 		It("should not reconcile the resource", func(ctx context.Context) {
 			// given unmanaged feature
-			featuresHandler := feature.ClusterFeaturesHandler(envTestClient, dsci, func(registry feature.FeaturesRegistry) error {
+			featuresHandler := feature.ClusterFeaturesHandler(dsci, func(registry feature.FeaturesRegistry) error {
 				return registry.Add(
 					feature.Define("create-local-gw-svc").
 						Manifests(
@@ -136,7 +136,7 @@ var _ = Describe("Applying and updating resources", func() {
 						WithData(feature.Entry("ControlPlane", provider.ValueOf(dsci.Spec.ServiceMesh.ControlPlane).Get)),
 				)
 			})
-			Expect(featuresHandler.Apply(ctx)).To(Succeed())
+			Expect(featuresHandler.Apply(ctx, envTestClient)).To(Succeed())
 
 			// when
 			service, err := fixtures.GetService(ctx, envTestClient, testNamespace, "knative-local-gateway")
@@ -146,7 +146,7 @@ var _ = Describe("Applying and updating resources", func() {
 
 			// then
 			// expect that modification is reconciled away
-			Expect(featuresHandler.Apply(ctx)).To(Succeed())
+			Expect(featuresHandler.Apply(ctx, envTestClient)).To(Succeed())
 			updatedService, err := fixtures.GetService(ctx, envTestClient, testNamespace, "knative-local-gateway")
 			Expect(err).ToNot(HaveOccurred())
 			Expect(updatedService.Annotations).To(
@@ -159,7 +159,7 @@ var _ = Describe("Applying and updating resources", func() {
 	When("a feature is unmanaged but the object is marked as managed", func() {
 		It("should reconcile this resource", func(ctx context.Context) {
 			// given unmanaged feature but object marked with managed annotation
-			featuresHandler := feature.ClusterFeaturesHandler(envTestClient, dsci, func(registry feature.FeaturesRegistry) error {
+			featuresHandler := feature.ClusterFeaturesHandler(dsci, func(registry feature.FeaturesRegistry) error {
 				return registry.Add(
 					feature.Define("create-managed-svc").
 						Manifests(
@@ -169,7 +169,7 @@ var _ = Describe("Applying and updating resources", func() {
 						WithData(feature.Entry("ControlPlane", provider.ValueOf(dsci.Spec.ServiceMesh.ControlPlane).Get)),
 				)
 			})
-			Expect(featuresHandler.Apply(ctx)).To(Succeed())
+			Expect(featuresHandler.Apply(ctx, envTestClient)).To(Succeed())
 
 			// when
 			service, err := fixtures.GetService(ctx, envTestClient, testNamespace, "managed-svc")
@@ -182,7 +182,7 @@ var _ = Describe("Applying and updating resources", func() {
 
 			// then
 			// expect that modification is reconciled away
-			Expect(featuresHandler.Apply(ctx)).To(Succeed())
+			Expect(featuresHandler.Apply(ctx, envTestClient)).To(Succeed())
 			updatedService, err := fixtures.GetService(ctx, envTestClient, testNamespace, "managed-svc")
 			Expect(err).ToNot(HaveOccurred())
 			Expect(updatedService.Annotations).To(

--- a/tests/integration/features/serverless_feature_test.go
+++ b/tests/integration/features/serverless_feature_test.go
@@ -61,10 +61,10 @@ var _ = Describe("Serverless feature", func() {
 					return nil
 				}
 
-				featuresHandler := feature.ComponentFeaturesHandler(envTestClient, dsci, kserveComponent.GetComponentName(), dsci.Spec.ApplicationsNamespace, featuresProvider)
+				featuresHandler := feature.ComponentFeaturesHandler(dsci, kserveComponent.GetComponentName(), dsci.Spec.ApplicationsNamespace, featuresProvider)
 
 				// when
-				applyErr := featuresHandler.Apply(ctx)
+				applyErr := featuresHandler.Apply(ctx, envTestClient)
 
 				// then
 				Expect(applyErr).To(MatchError(ContainSubstring("failed to find the pre-requisite operator subscription \"serverless-operator\"")))
@@ -109,10 +109,10 @@ var _ = Describe("Serverless feature", func() {
 					return nil
 				}
 
-				featuresHandler := feature.ComponentFeaturesHandler(envTestClient, dsci, kserveComponent.GetComponentName(), dsci.Spec.ApplicationsNamespace, featuresProvider)
+				featuresHandler := feature.ComponentFeaturesHandler(dsci, kserveComponent.GetComponentName(), dsci.Spec.ApplicationsNamespace, featuresProvider)
 
 				// then
-				Expect(featuresHandler.Apply(ctx)).To(Succeed())
+				Expect(featuresHandler.Apply(ctx, envTestClient)).To(Succeed())
 			})
 
 			It("should succeed if serving is not installed for KNative serving precondition", func(ctx context.Context) {
@@ -128,10 +128,10 @@ var _ = Describe("Serverless feature", func() {
 					return nil
 				}
 
-				featuresHandler := feature.ComponentFeaturesHandler(envTestClient, dsci, kserveComponent.GetComponentName(), dsci.Spec.ApplicationsNamespace, featuresProvider)
+				featuresHandler := feature.ComponentFeaturesHandler(dsci, kserveComponent.GetComponentName(), dsci.Spec.ApplicationsNamespace, featuresProvider)
 
 				// then
-				Expect(featuresHandler.Apply(ctx)).To(Succeed())
+				Expect(featuresHandler.Apply(ctx, envTestClient)).To(Succeed())
 			})
 
 			It("should fail if serving is already installed for KNative serving precondition", func(ctx context.Context) {
@@ -158,27 +158,16 @@ var _ = Describe("Serverless feature", func() {
 					return nil
 				}
 
-				featuresHandler := feature.ComponentFeaturesHandler(envTestClient, dsci, kserveComponent.GetComponentName(), dsci.Spec.ApplicationsNamespace, featuresProvider)
+				featuresHandler := feature.ComponentFeaturesHandler(dsci, kserveComponent.GetComponentName(), dsci.Spec.ApplicationsNamespace, featuresProvider)
 
 				// then
-				Expect(featuresHandler.Apply(ctx)).ToNot(Succeed())
+				Expect(featuresHandler.Apply(ctx, envTestClient)).ToNot(Succeed())
 			})
 		})
 
 	})
 
 	Context("default values", func() {
-
-		var testFeature *feature.Feature
-
-		BeforeEach(func() {
-			// Stubbing feature as we want to test particular functions in isolation
-			testFeature = &feature.Feature{
-				Name: "test-feature",
-			}
-
-			testFeature.Client = envTestClient
-		})
 
 		Context("ingress gateway TLS secret name", func() {
 
@@ -300,10 +289,10 @@ var _ = Describe("Serverless feature", func() {
 				return nil
 			}
 
-			featuresHandler := feature.ComponentFeaturesHandler(envTestClient, dsci, kserveComponent.GetComponentName(), dsci.Spec.ApplicationsNamespace, featuresProvider)
+			featuresHandler := feature.ComponentFeaturesHandler(dsci, kserveComponent.GetComponentName(), dsci.Spec.ApplicationsNamespace, featuresProvider)
 
 			// when
-			Expect(featuresHandler.Apply(ctx)).To(Succeed())
+			Expect(featuresHandler.Apply(ctx, envTestClient)).To(Succeed())
 
 			// then
 			Eventually(func() error {
@@ -342,10 +331,10 @@ var _ = Describe("Serverless feature", func() {
 				return nil
 			}
 
-			featuresHandler := feature.ComponentFeaturesHandler(envTestClient, dsci, kserveComponent.GetComponentName(), dsci.Spec.ApplicationsNamespace, featuresProvider)
+			featuresHandler := feature.ComponentFeaturesHandler(dsci, kserveComponent.GetComponentName(), dsci.Spec.ApplicationsNamespace, featuresProvider)
 
 			// when
-			Expect(featuresHandler.Apply(ctx)).To(Succeed())
+			Expect(featuresHandler.Apply(ctx, envTestClient)).To(Succeed())
 
 			// then
 			Consistently(func() error {

--- a/tests/integration/features/servicemesh_feature_test.go
+++ b/tests/integration/features/servicemesh_feature_test.go
@@ -52,7 +52,7 @@ var _ = Describe("Service Mesh setup", func() {
 
 				It("should fail using precondition check", func(ctx context.Context) {
 					// given
-					featuresHandler := feature.ClusterFeaturesHandler(envTestClient, dsci, func(registry feature.FeaturesRegistry) error {
+					featuresHandler := feature.ClusterFeaturesHandler(dsci, func(registry feature.FeaturesRegistry) error {
 						errFeatureAdd := registry.Add(feature.Define("no-service-mesh-operator-check").
 							PreConditions(servicemesh.EnsureServiceMeshOperatorInstalled),
 						)
@@ -63,7 +63,7 @@ var _ = Describe("Service Mesh setup", func() {
 					})
 
 					// when
-					applyErr := featuresHandler.Apply(ctx)
+					applyErr := featuresHandler.Apply(ctx, envTestClient)
 
 					// then
 					Expect(applyErr).To(MatchError(ContainSubstring("failed to find the pre-requisite operator subscription \"servicemeshoperator\"")))
@@ -85,7 +85,7 @@ var _ = Describe("Service Mesh setup", func() {
 
 				It("should succeed using precondition check", func(ctx context.Context) {
 					// when
-					featuresHandler := feature.ClusterFeaturesHandler(envTestClient, dsci, func(registry feature.FeaturesRegistry) error {
+					featuresHandler := feature.ClusterFeaturesHandler(dsci, func(registry feature.FeaturesRegistry) error {
 						errFeatureAdd := registry.Add(
 							feature.Define("service-mesh-operator-check").
 								WithData(feature.Entry("ControlPlane", provider.ValueOf(dsci.Spec.ServiceMesh.ControlPlane).Get)).
@@ -98,7 +98,7 @@ var _ = Describe("Service Mesh setup", func() {
 					})
 
 					// when
-					Expect(featuresHandler.Apply(ctx)).To(Succeed())
+					Expect(featuresHandler.Apply(ctx, envTestClient)).To(Succeed())
 
 				})
 
@@ -117,7 +117,7 @@ var _ = Describe("Service Mesh setup", func() {
 					dsci.Spec.ServiceMesh.ControlPlane.Name = "test-name"
 
 					// when
-					featuresHandler := feature.ClusterFeaturesHandler(envTestClient, dsci, func(registry feature.FeaturesRegistry) error {
+					featuresHandler := feature.ClusterFeaturesHandler(dsci, func(registry feature.FeaturesRegistry) error {
 						errFeatureAdd := registry.Add(feature.Define("service-mesh-control-plane-check").
 							WithData(feature.Entry("ControlPlane", provider.ValueOf(dsci.Spec.ServiceMesh.ControlPlane).Get)).
 							PreConditions(servicemesh.EnsureServiceMeshInstalled),
@@ -129,7 +129,7 @@ var _ = Describe("Service Mesh setup", func() {
 					})
 
 					// then
-					Expect(featuresHandler.Apply(ctx)).To(Succeed())
+					Expect(featuresHandler.Apply(ctx, envTestClient)).To(Succeed())
 				})
 
 				It("should fail to find Service Mesh Control Plane if not present", func(ctx context.Context) {
@@ -138,7 +138,7 @@ var _ = Describe("Service Mesh setup", func() {
 					dsci.Spec.ServiceMesh.ControlPlane.Namespace = "test-namespace"
 
 					// when
-					featuresHandler := feature.ClusterFeaturesHandler(envTestClient, dsci, func(registry feature.FeaturesRegistry) error {
+					featuresHandler := feature.ClusterFeaturesHandler(dsci, func(registry feature.FeaturesRegistry) error {
 						errFeatureAdd := registry.Add(feature.Define("no-service-mesh-control-plane-check").
 							WithData(feature.Entry("ControlPlane", provider.ValueOf(dsci.Spec.ServiceMesh.ControlPlane).Get)).
 							PreConditions(servicemesh.EnsureServiceMeshInstalled),
@@ -150,7 +150,7 @@ var _ = Describe("Service Mesh setup", func() {
 					})
 
 					// then
-					Expect(featuresHandler.Apply(ctx)).To(MatchError(ContainSubstring("failed to find Service Mesh Control Plane")))
+					Expect(featuresHandler.Apply(ctx, envTestClient)).To(MatchError(ContainSubstring("failed to find Service Mesh Control Plane")))
 				})
 
 			})
@@ -194,7 +194,7 @@ var _ = Describe("Service Mesh setup", func() {
 
 					createServiceMeshControlPlane(ctx, name, namespace)
 
-					handler := feature.ClusterFeaturesHandler(envTestClient, dsci, func(registry feature.FeaturesRegistry) error {
+					handler := feature.ClusterFeaturesHandler(dsci, func(registry feature.FeaturesRegistry) error {
 						return registry.Add(feature.Define("control-plane-with-external-authz-provider").
 							Manifests(
 								manifest.Location(fixtures.TestEmbeddedFiles).
@@ -216,7 +216,7 @@ var _ = Describe("Service Mesh setup", func() {
 
 					// when
 					By("verifying extension provider has been added after applying feature", func() {
-						Expect(handler.Apply(ctx)).To(Succeed())
+						Expect(handler.Apply(ctx, envTestClient)).To(Succeed())
 						serviceMeshControlPlane, err := getServiceMeshControlPlane(ctx, namespace, name)
 						Expect(err).ToNot(HaveOccurred())
 
@@ -239,7 +239,7 @@ var _ = Describe("Service Mesh setup", func() {
 
 					// then
 					By("verifying that extension provider has been removed and namespace is gone too", func() {
-						Expect(handler.Delete(ctx)).To(Succeed())
+						Expect(handler.Delete(ctx, envTestClient)).To(Succeed())
 						Eventually(func(ctx context.Context) []any {
 
 							serviceMeshControlPlane, err := getServiceMeshControlPlane(ctx, namespace, name)

--- a/tests/integration/features/tracker_int_test.go
+++ b/tests/integration/features/tracker_int_test.go
@@ -6,6 +6,7 @@ import (
 
 	conditionsv1 "github.com/openshift/custom-resource-status/conditions/v1"
 	corev1 "k8s.io/api/core/v1"
+	ctrlruntime "sigs.k8s.io/controller-runtime/pkg/client"
 
 	dsciv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/dscinitialization/v1"
 	featurev1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/features/v1"
@@ -33,7 +34,7 @@ var _ = Describe("Feature tracking capability", func() {
 	Context("Reporting progress when applying Feature", func() {
 
 		It("should indicate successful installation in FeatureTracker through Status conditions", func(ctx context.Context) {
-			featuresHandler := feature.ClusterFeaturesHandler(envTestClient, dsci, func(registry feature.FeaturesRegistry) error {
+			featuresHandler := feature.ClusterFeaturesHandler(dsci, func(registry feature.FeaturesRegistry) error {
 				errFeatureAdd := registry.Add(feature.Define("always-working-feature"))
 
 				Expect(errFeatureAdd).ToNot(HaveOccurred())
@@ -42,7 +43,7 @@ var _ = Describe("Feature tracking capability", func() {
 			})
 
 			// when
-			Expect(featuresHandler.Apply(ctx)).To(Succeed())
+			Expect(featuresHandler.Apply(ctx, envTestClient)).To(Succeed())
 
 			// then
 			featureTracker, err := fixtures.GetFeatureTracker(ctx, envTestClient, appNamespace, "always-working-feature")
@@ -59,9 +60,9 @@ var _ = Describe("Feature tracking capability", func() {
 
 		It("should indicate when failure occurs in preconditions through Status conditions", func(ctx context.Context) {
 			// given
-			featuresHandler := feature.ClusterFeaturesHandler(envTestClient, dsci, func(registry feature.FeaturesRegistry) error {
+			featuresHandler := feature.ClusterFeaturesHandler(dsci, func(registry feature.FeaturesRegistry) error {
 				errFeatureAdd := registry.Add(feature.Define("precondition-fail").
-					PreConditions(func(_ context.Context, _ *feature.Feature) error {
+					PreConditions(func(_ context.Context, _ ctrlruntime.Client, _ *feature.Feature) error {
 						return errors.New("during test always fail")
 					}),
 				)
@@ -72,7 +73,7 @@ var _ = Describe("Feature tracking capability", func() {
 			})
 
 			// when
-			Expect(featuresHandler.Apply(ctx)).ToNot(Succeed())
+			Expect(featuresHandler.Apply(ctx, envTestClient)).ToNot(Succeed())
 
 			// then
 			featureTracker, err := fixtures.GetFeatureTracker(ctx, envTestClient, appNamespace, "precondition-fail")
@@ -89,9 +90,9 @@ var _ = Describe("Feature tracking capability", func() {
 
 		It("should indicate when failure occurs in post-conditions through Status conditions", func(ctx context.Context) {
 			// given
-			featuresHandler := feature.ClusterFeaturesHandler(envTestClient, dsci, func(registry feature.FeaturesRegistry) error {
+			featuresHandler := feature.ClusterFeaturesHandler(dsci, func(registry feature.FeaturesRegistry) error {
 				errFeatureAdd := registry.Add(feature.Define("post-condition-failure").
-					PostConditions(func(_ context.Context, _ *feature.Feature) error {
+					PostConditions(func(_ context.Context, _ ctrlruntime.Client, _ *feature.Feature) error {
 						return errors.New("during test always fail")
 					}),
 				)
@@ -102,7 +103,7 @@ var _ = Describe("Feature tracking capability", func() {
 			})
 
 			// when
-			Expect(featuresHandler.Apply(ctx)).ToNot(Succeed())
+			Expect(featuresHandler.Apply(ctx, envTestClient)).ToNot(Succeed())
 
 			// then
 			featureTracker, err := fixtures.GetFeatureTracker(ctx, envTestClient, appNamespace, "post-condition-failure")
@@ -122,7 +123,7 @@ var _ = Describe("Feature tracking capability", func() {
 
 		It("should correctly indicate source in the feature tracker", func(ctx context.Context) {
 			// given
-			featuresHandler := feature.ClusterFeaturesHandler(envTestClient, dsci, func(registry feature.FeaturesRegistry) error {
+			featuresHandler := feature.ClusterFeaturesHandler(dsci, func(registry feature.FeaturesRegistry) error {
 				errFeatureAdd := registry.Add(feature.Define("always-working-feature"))
 
 				Expect(errFeatureAdd).ToNot(HaveOccurred())
@@ -131,7 +132,7 @@ var _ = Describe("Feature tracking capability", func() {
 			})
 
 			// when
-			Expect(featuresHandler.Apply(ctx)).To(Succeed())
+			Expect(featuresHandler.Apply(ctx, envTestClient)).To(Succeed())
 
 			// then
 			featureTracker, err := fixtures.GetFeatureTracker(ctx, envTestClient, appNamespace, "always-working-feature")
@@ -146,7 +147,7 @@ var _ = Describe("Feature tracking capability", func() {
 
 		It("should correctly indicate app namespace in the feature tracker", func(ctx context.Context) {
 			// given
-			featuresHandler := feature.ClusterFeaturesHandler(envTestClient, dsci, func(registry feature.FeaturesRegistry) error {
+			featuresHandler := feature.ClusterFeaturesHandler(dsci, func(registry feature.FeaturesRegistry) error {
 				errFeatureAdd := registry.Add(feature.Define("empty-feature"))
 
 				Expect(errFeatureAdd).ToNot(HaveOccurred())
@@ -155,7 +156,7 @@ var _ = Describe("Feature tracking capability", func() {
 			})
 
 			// when
-			Expect(featuresHandler.Apply(ctx)).To(Succeed())
+			Expect(featuresHandler.Apply(ctx, envTestClient)).To(Succeed())
 
 			// then
 			featureTracker, err := fixtures.GetFeatureTracker(ctx, envTestClient, appNamespace, "empty-feature")
@@ -173,7 +174,6 @@ var _ = Describe("Feature tracking capability", func() {
 			Expect(fixtures.CreateOrUpdateDSCI(ctx, envTestClient, dsci)).ToNot(HaveOccurred())
 
 			feature, featErr := feature.Define("empty-feat-with-owner").
-				UsingClient(envTestClient).
 				Source(featurev1.Source{
 					Type: featurev1.DSCIType,
 					Name: dsci.Name,
@@ -184,7 +184,7 @@ var _ = Describe("Feature tracking capability", func() {
 
 			// when
 			Expect(featErr).ToNot(HaveOccurred())
-			Expect(feature.Apply(ctx)).To(Succeed())
+			Expect(feature.Apply(ctx, envTestClient)).To(Succeed())
 
 			// then
 			tracker, err := fixtures.GetFeatureTracker(ctx, envTestClient, appNamespace, "empty-feat-with-owner")
@@ -195,7 +195,6 @@ var _ = Describe("Feature tracking capability", func() {
 		It("should not indicate owner in the feature tracker when owner not in feature", func(ctx context.Context) {
 			// given
 			feature, featErr := feature.Define("empty-feat-no-owner").
-				UsingClient(envTestClient).
 				Source(featurev1.Source{
 					Type: featurev1.DSCIType,
 					Name: dsci.Name,
@@ -205,7 +204,7 @@ var _ = Describe("Feature tracking capability", func() {
 
 			// when
 			Expect(featErr).ToNot(HaveOccurred())
-			Expect(feature.Apply(ctx)).To(Succeed())
+			Expect(feature.Apply(ctx, envTestClient)).To(Succeed())
 
 			// then
 			tracker, err := fixtures.GetFeatureTracker(ctx, envTestClient, appNamespace, "empty-feat-no-owner")


### PR DESCRIPTION
## Description

Including the client in the function signature and decoupling it from `Feature` struct makes its usage explicit and more idiomatic. This approach clarifies that the client is intended for use within the function. 

It's a follow-up to PR [#1228](https://github.com/opendatahub-io/opendatahub-operator/pull/1228#issuecomment-2343046440).

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
