### PR TITLE
fix(test): makes DSCI-dependent tests self-contained

### DIFF
--- a/tests/envtestutil/name_gen.go
+++ b/tests/envtestutil/name_gen.go
@@ -16,5 +16,5 @@ func AppendRandomNameTo(base string) string {
 	if len(base) > maxGeneratedNameLength {
 		base = base[:maxGeneratedNameLength]
 	}
-	return fmt.Sprintf("%s%s", base, utilrand.String(randomLength))
+	return fmt.Sprintf("%s-%s", base, utilrand.String(randomLength))
 }

--- a/tests/integration/features/fixtures/cluster_test_fixtures.go
+++ b/tests/integration/features/fixtures/cluster_test_fixtures.go
@@ -107,14 +107,14 @@ func GetFeatureTracker(ctx context.Context, cli client.Client, appNamespace, fea
 	return tracker, err
 }
 
-func NewDSCInitialization(ctx context.Context, cli client.Client, ns string) *dsciv1.DSCInitialization {
+func NewDSCInitialization(ctx context.Context, cli client.Client, dsciName, ns string) *dsciv1.DSCInitialization {
 	dsci := &dsciv1.DSCInitialization{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: gvk.DSCInitialization.Version,
 			Kind:       gvk.DSCInitialization.Kind,
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "default-dsci",
+			Name: dsciName,
 		},
 	}
 

--- a/tests/integration/features/manifests_int_test.go
+++ b/tests/integration/features/manifests_int_test.go
@@ -29,18 +29,19 @@ var _ = Describe("Applying resources", func() {
 
 	BeforeEach(func(ctx context.Context) {
 		objectCleaner = envtestutil.CreateCleaner(envTestClient, envTest.Config, fixtures.Timeout, fixtures.Interval)
-		nsName := envtestutil.AppendRandomNameTo("smcp-ns")
+		nsName := envtestutil.AppendRandomNameTo("ns-smcp")
+		dsciName := envtestutil.AppendRandomNameTo("dsci-smcp")
 
 		var err error
 		namespace, err = cluster.CreateNamespace(ctx, envTestClient, nsName)
 		Expect(err).ToNot(HaveOccurred())
 
-		dsci = fixtures.NewDSCInitialization(ctx, envTestClient, nsName)
+		dsci = fixtures.NewDSCInitialization(ctx, envTestClient, dsciName, nsName)
 		dsci.Spec.ServiceMesh.ControlPlane.Namespace = namespace.Name
 	})
 
 	AfterEach(func(ctx context.Context) {
-		objectCleaner.DeleteAll(ctx, namespace)
+		objectCleaner.DeleteAll(ctx, namespace, dsci)
 	})
 
 	It("should be able to process an embedded YAML file", func(ctx context.Context) {

--- a/tests/integration/features/preconditions_int_test.go
+++ b/tests/integration/features/preconditions_int_test.go
@@ -31,7 +31,12 @@ var _ = Describe("feature preconditions", func() {
 
 			testFeatureName := "test-ns-creation"
 			namespace = envtestutil.AppendRandomNameTo(testFeatureName)
-			dsci = fixtures.NewDSCInitialization(ctx, envTestClient, namespace)
+			dsciName := envtestutil.AppendRandomNameTo(testFeatureName)
+			dsci = fixtures.NewDSCInitialization(ctx, envTestClient, dsciName, namespace)
+		})
+
+		AfterEach(func(ctx context.Context) {
+			objectCleaner.DeleteAll(ctx, dsci)
 		})
 
 		It("should create namespace if it does not exist", func(ctx context.Context) {

--- a/tests/integration/features/resources_int_test.go
+++ b/tests/integration/features/resources_int_test.go
@@ -37,17 +37,18 @@ var _ = Describe("Applying and updating resources", func() {
 		objectCleaner = envtestutil.CreateCleaner(envTestClient, envTest.Config, fixtures.Timeout, fixtures.Interval)
 
 		testNamespace = envtestutil.AppendRandomNameTo("test-namespace")
+		dsciName := envtestutil.AppendRandomNameTo("test-dsci")
 
 		var err error
 		namespace, err = cluster.CreateNamespace(ctx, envTestClient, testNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
-		dsci = fixtures.NewDSCInitialization(ctx, envTestClient, testNamespace)
+		dsci = fixtures.NewDSCInitialization(ctx, envTestClient, dsciName, testNamespace)
 		dsci.Spec.ServiceMesh.ControlPlane.Namespace = namespace.Name
 	})
 
 	AfterEach(func(ctx context.Context) {
-		objectCleaner.DeleteAll(ctx, namespace)
+		objectCleaner.DeleteAll(ctx, namespace, dsci)
 	})
 
 	When("a feature is managed", func() {

--- a/tests/integration/features/serverless_feature_test.go
+++ b/tests/integration/features/serverless_feature_test.go
@@ -40,7 +40,9 @@ var _ = Describe("Serverless feature", func() {
 		Expect(err).ToNot(HaveOccurred())
 		objectCleaner = envtestutil.CreateCleaner(c, envTest.Config, fixtures.Timeout, fixtures.Interval)
 
-		dsci = fixtures.NewDSCInitialization(ctx, envTestClient, "default")
+		namespace := envtestutil.AppendRandomNameTo("ns-serverless")
+		dsciName := envtestutil.AppendRandomNameTo("dsci-serverless")
+		dsci = fixtures.NewDSCInitialization(ctx, envTestClient, dsciName, namespace)
 		kserveComponent = &kserve.Kserve{}
 	})
 

--- a/tests/integration/features/servicemesh_feature_test.go
+++ b/tests/integration/features/servicemesh_feature_test.go
@@ -38,8 +38,9 @@ var _ = Describe("Service Mesh setup", func() {
 		objectCleaner = envtestutil.CreateCleaner(c, envTest.Config, fixtures.Timeout, fixtures.Interval)
 
 		namespace := envtestutil.AppendRandomNameTo("service-mesh-settings")
+		dsciName := envtestutil.AppendRandomNameTo("service-mesh-settings")
 
-		dsci = fixtures.NewDSCInitialization(ctx, envTestClient, namespace)
+		dsci = fixtures.NewDSCInitialization(ctx, envTestClient, dsciName, namespace)
 
 		Expect(err).ToNot(HaveOccurred())
 	})
@@ -172,7 +173,7 @@ var _ = Describe("Service Mesh setup", func() {
 				BeforeEach(func(ctx context.Context) {
 					smcpCrdObj = installServiceMeshCRD(ctx)
 					objectCleaner = envtestutil.CreateCleaner(envTestClient, envTest.Config, fixtures.Timeout, fixtures.Interval)
-					dsci = fixtures.NewDSCInitialization(ctx, envTestClient, namespace)
+					dsci = fixtures.NewDSCInitialization(ctx, envTestClient, envtestutil.AppendRandomNameTo(namespace), namespace)
 
 					serviceMeshSpec = dsci.Spec.ServiceMesh
 

--- a/tests/integration/features/tracker_int_test.go
+++ b/tests/integration/features/tracker_int_test.go
@@ -11,6 +11,7 @@ import (
 	featurev1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/features/v1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/controllers/status"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/feature"
+	"github.com/opendatahub-io/opendatahub-operator/v2/tests/envtestutil"
 	"github.com/opendatahub-io/opendatahub-operator/v2/tests/integration/features/fixtures"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -20,14 +21,15 @@ import (
 
 var _ = Describe("Feature tracking capability", func() {
 
-	const appNamespace = "default"
-
 	var (
-		dsci *dsciv1.DSCInitialization
+		appNamespace string
+		dsci         *dsciv1.DSCInitialization
 	)
 
 	BeforeEach(func(ctx context.Context) {
-		dsci = fixtures.NewDSCInitialization(ctx, envTestClient, "default")
+		appNamespace = envtestutil.AppendRandomNameTo("app-namespace")
+		dsciName := envtestutil.AppendRandomNameTo("dsci-" + appNamespace)
+		dsci = fixtures.NewDSCInitialization(ctx, envTestClient, dsciName, appNamespace)
 	})
 
 	Context("Reporting progress when applying Feature", func() {
@@ -138,7 +140,7 @@ var _ = Describe("Feature tracking capability", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(featureTracker.Spec.Source).To(
 				MatchFields(IgnoreExtras, Fields{
-					"Name": Equal("default-dsci"),
+					"Name": Equal(dsci.Name),
 					"Type": Equal(featurev1.DSCIType),
 				}),
 			)
@@ -160,7 +162,7 @@ var _ = Describe("Feature tracking capability", func() {
 			// then
 			featureTracker, err := fixtures.GetFeatureTracker(ctx, envTestClient, appNamespace, "empty-feature")
 			Expect(err).ToNot(HaveOccurred())
-			Expect(featureTracker.Spec.AppNamespace).To(Equal("default"))
+			Expect(featureTracker.Spec.AppNamespace).To(Equal(dsci.Spec.ApplicationsNamespace))
 		})
 
 	})


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
Ensures each test uses a different DSCI instance as a test fixture. Without this change, tests are failing (as they do in the latest incubation commit). The reason is #1222 that introduced a validation check to ensure `AppNamespace` is immutable, but #1228 is trying to update DSCI violating the new constraint. The issue is that #1228 was merged first and only then #1222 came in, but without being first rebased on top of `incubation`.

With this change, each test uses a dedicated DSCI.

> [!IMPORTANT]
> This issue was not caught earlier for two reasons:
> * PRs are not enforced to be up-to-date with latest state of `incubation` before merged.
> * Pushes to `incubation` do not trigger test jobs.
>
> With this we ended up with #1228 merged first and #1222 being behind was merged afterwards without triggering the jobs. In conjunction, it results in failing `make test` against latest `incubation`.
> Ideally we should ensure both mentioned weaknesses are addressed.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
