### PR TITLE
ci: ensures tests are run on push

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -5,7 +5,7 @@ on:
       - incubation
       - main
       - master
-  pull_request
+  pull_request:
 jobs:
   unit-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -1,5 +1,11 @@
 name: Unit Tests
-on: [push, pull_request]
+on: 
+  push:
+    branches:
+      - incubation
+      - main
+      - master
+  pull_request
 jobs:
   unit-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -1,6 +1,5 @@
 name: Unit Tests
-on:
-  pull_request:
+on: [push, pull_request]
 jobs:
   unit-test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description

Unit tests job is currently only executed on PRs, leaving pushes on e.g. incubation branch untested. This can lead to issues like the one described in #1235

This PR enables GH Action to be run also for push events.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

You can use [`act`](https://github.com/nektos/act) to test GH Actions locally instead of running them on your fork.

```sh
act "on: push" -j unit-test -P ubuntu-latest=ghcr.io/catthehacker/ubuntu:act-latest
```

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
