### PR TITLE
refactor(webhook): change for mutating webhook to use Default to set ModelReg namespace

### DIFF
--- a/controllers/webhook/webhook.go
+++ b/controllers/webhook/webhook.go
@@ -130,18 +130,18 @@ func (w *OpenDataHubValidatingWebhook) Handle(ctx context.Context, req admission
 //+kubebuilder:webhook:path=/mutate-opendatahub-io-v1,mutating=true,failurePolicy=fail,sideEffects=None,groups=datasciencecluster.opendatahub.io,resources=datascienceclusters,verbs=create;update,versions=v1,name=mutate.operator.opendatahub.io,admissionReviewVersions=v1
 //nolint:lll
 
-// It currently only sets defaults for modelregiestry in datascienceclusters.
 type DSCDefaulter struct{}
 
 // just assert that DSCDefaulter implements webhook.CustomDefaulter.
 var _ webhook.CustomDefaulter = &DSCDefaulter{}
 
-func (m *DSCDefaulter) SetupMutateWebhookWithManager(mgr ctrl.Manager) {
+func (m *DSCDefaulter) SetupWithManager(mgr ctrl.Manager) {
 	mutateWebhook := admission.WithCustomDefaulter(mgr.GetScheme(), &dscv1.DataScienceCluster{}, m)
 	mgr.GetWebhookServer().Register("/mutate-opendatahub-io-v1", mutateWebhook)
 }
 
-// implement admission.CustomDefaulter interface.
+// Implement admission.CustomDefaulter interface.
+// It currently only sets defaults for modelregiestry in datascienceclusters.
 func (m *DSCDefaulter) Default(_ context.Context, obj runtime.Object) error {
 	dsc, isDSC := obj.(*dscv1.DataScienceCluster)
 	if !isDSC {

--- a/controllers/webhook/webhook.go
+++ b/controllers/webhook/webhook.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"net/http"
 
+	operatorv1 "github.com/openshift/api/operator/v1"
 	admissionv1 "k8s.io/api/admission/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -146,9 +147,12 @@ func (m *DSCDefaulter) Default(_ context.Context, obj runtime.Object) error {
 	if !isDSC {
 		return fmt.Errorf("expected DataScienceCluster but got a different type: %T", obj)
 	}
-	// set default registriesNamespace if empty
-	if len(dsc.Spec.Components.ModelRegistry.RegistriesNamespace) == 0 {
-		dsc.Spec.Components.ModelRegistry.RegistriesNamespace = modelregistry.DefaultModelRegistriesNamespace
+
+	// set default registriesNamespace if empty "" but ModelRegistry is enabled
+	if dsc.Spec.Components.ModelRegistry.ManagementState == operatorv1.Managed {
+		if dsc.Spec.Components.ModelRegistry.RegistriesNamespace == "" {
+			dsc.Spec.Components.ModelRegistry.RegistriesNamespace = modelregistry.DefaultModelRegistriesNamespace
+		}
 	}
 	return nil
 }

--- a/controllers/webhook/webhook_suite_test.go
+++ b/controllers/webhook/webhook_suite_test.go
@@ -136,12 +136,12 @@ var _ = BeforeSuite(func() {
 	(&webhook.OpenDataHubValidatingWebhook{
 		Client:  mgr.GetClient(),
 		Decoder: admission.NewDecoder(mgr.GetScheme()),
-	}).SetupWithManager(mgr)
+	}).SetupValidatingWebhookWithManager(mgr)
 
 	(&webhook.OpenDataHubMutatingWebhook{
 		Client:  mgr.GetClient(),
 		Decoder: admission.NewDecoder(mgr.GetScheme()),
-	}).SetupWithManager(mgr)
+	}).SetupMutateWebhookWithManager(mgr)
 
 	// +kubebuilder:scaffold:webhook
 

--- a/controllers/webhook/webhook_suite_test.go
+++ b/controllers/webhook/webhook_suite_test.go
@@ -139,7 +139,7 @@ var _ = BeforeSuite(func() {
 		Decoder: admission.NewDecoder(mgr.GetScheme()),
 	}).SetupWithManager(mgr)
 
-	(&webhook.DSCDefaulter{}).SetupMutateWebhookWithManager(mgr)
+	(&webhook.DSCDefaulter{}).SetupWithManager(mgr)
 
 	// +kubebuilder:scaffold:webhook
 

--- a/controllers/webhook/webhook_suite_test.go
+++ b/controllers/webhook/webhook_suite_test.go
@@ -136,7 +136,7 @@ var _ = BeforeSuite(func() {
 	(&webhook.OpenDataHubValidatingWebhook{
 		Client:  mgr.GetClient(),
 		Decoder: admission.NewDecoder(mgr.GetScheme()),
-	}).SetupValidatingWebhookWithManager(mgr)
+	}).SetupWithManager(mgr)
 
 	(&webhook.DSCDefaulter{}).SetupMutateWebhookWithManager(mgr)
 

--- a/controllers/webhook/webhook_suite_test.go
+++ b/controllers/webhook/webhook_suite_test.go
@@ -138,10 +138,7 @@ var _ = BeforeSuite(func() {
 		Decoder: admission.NewDecoder(mgr.GetScheme()),
 	}).SetupValidatingWebhookWithManager(mgr)
 
-	(&webhook.OpenDataHubMutatingWebhook{
-		Client:  mgr.GetClient(),
-		Decoder: admission.NewDecoder(mgr.GetScheme()),
-	}).SetupMutateWebhookWithManager(mgr)
+	(&webhook.DSCDefaulter{}).SetupMutateWebhookWithManager(mgr)
 
 	// +kubebuilder:scaffold:webhook
 

--- a/main.go
+++ b/main.go
@@ -213,7 +213,7 @@ func main() { //nolint:funlen,maintidx
 		Decoder: admission.NewDecoder(mgr.GetScheme()),
 	}).SetupWithManager(mgr)
 
-	(&webhook.DSCDefaulter{}).SetupMutateWebhookWithManager(mgr)
+	(&webhook.DSCDefaulter{}).SetupWithManager(mgr)
 
 	if err = (&dscictrl.DSCInitializationReconciler{
 		Client:                mgr.GetClient(),

--- a/main.go
+++ b/main.go
@@ -213,10 +213,7 @@ func main() { //nolint:funlen,maintidx
 		Decoder: admission.NewDecoder(mgr.GetScheme()),
 	}).SetupValidatingWebhookWithManager(mgr)
 
-	(&webhook.OpenDataHubMutatingWebhook{
-		Client:  mgr.GetClient(),
-		Decoder: admission.NewDecoder(mgr.GetScheme()),
-	}).SetupMutateWebhookWithManager(mgr)
+	(&webhook.DSCDefaulter{}).SetupMutateWebhookWithManager(mgr)
 
 	if err = (&dscictrl.DSCInitializationReconciler{
 		Client:                mgr.GetClient(),

--- a/main.go
+++ b/main.go
@@ -211,7 +211,7 @@ func main() { //nolint:funlen,maintidx
 	(&webhook.OpenDataHubValidatingWebhook{
 		Client:  mgr.GetClient(),
 		Decoder: admission.NewDecoder(mgr.GetScheme()),
-	}).SetupValidatingWebhookWithManager(mgr)
+	}).SetupWithManager(mgr)
 
 	(&webhook.DSCDefaulter{}).SetupMutateWebhookWithManager(mgr)
 

--- a/main.go
+++ b/main.go
@@ -211,12 +211,12 @@ func main() { //nolint:funlen,maintidx
 	(&webhook.OpenDataHubValidatingWebhook{
 		Client:  mgr.GetClient(),
 		Decoder: admission.NewDecoder(mgr.GetScheme()),
-	}).SetupWithManager(mgr)
+	}).SetupValidatingWebhookWithManager(mgr)
 
 	(&webhook.OpenDataHubMutatingWebhook{
 		Client:  mgr.GetClient(),
 		Decoder: admission.NewDecoder(mgr.GetScheme()),
-	}).SetupWithManager(mgr)
+	}).SetupMutateWebhookWithManager(mgr)
 
 	if err = (&dscictrl.DSCInitializationReconciler{
 		Client:                mgr.GetClient(),


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->
- use Default() instead of setDSCDefaults()

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
