### PR TITLE
fix: update DSC/DSCI .status.release not depend on other's reconcile

### DIFF
--- a/controllers/datasciencecluster/datasciencecluster_controller.go
+++ b/controllers/datasciencecluster/datasciencecluster_controller.go
@@ -91,7 +91,6 @@ func (r *DataScienceClusterReconciler) Reconcile(ctx context.Context, req ctrl.R
 		r.Log.Error(err, "failed to get operator release version")
 		return ctrl.Result{}, err
 	}
-
 	instances := &dscv1.DataScienceClusterList{}
 
 	if err := r.Client.List(ctx, instances); err != nil {
@@ -229,6 +228,7 @@ func (r *DataScienceClusterReconciler) Reconcile(ctx context.Context, req ctrl.R
 		instance, err = status.UpdateWithRetry(ctx, r.Client, instance, func(saved *dscv1.DataScienceCluster) {
 			status.SetProgressingCondition(&saved.Status.Conditions, reason, message)
 			saved.Status.Phase = status.PhaseProgressing
+			saved.Status.Release = currentOperatorReleaseVersion
 		})
 		if err != nil {
 			_ = r.reportError(err, instance, fmt.Sprintf("failed to add conditions to status of DataScienceCluster resource name %s", req.Name))
@@ -269,7 +269,6 @@ func (r *DataScienceClusterReconciler) Reconcile(ctx context.Context, req ctrl.R
 	instance, err = status.UpdateWithRetry(ctx, r.Client, instance, func(saved *dscv1.DataScienceCluster) {
 		status.SetCompleteCondition(&saved.Status.Conditions, status.ReconcileCompleted, "DataScienceCluster resource reconciled successfully")
 		saved.Status.Phase = status.PhaseReady
-		saved.Status.Release = currentOperatorReleaseVersion
 	})
 
 	if err != nil {

--- a/controllers/dscinitialization/dscinitialization_controller.go
+++ b/controllers/dscinitialization/dscinitialization_controller.go
@@ -142,6 +142,7 @@ func (r *DSCInitializationReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		instance, err = status.UpdateWithRetry(ctx, r.Client, instance, func(saved *dsciv1.DSCInitialization) {
 			status.SetProgressingCondition(&saved.Status.Conditions, reason, message)
 			saved.Status.Phase = status.PhaseProgressing
+			saved.Status.Release = currentOperatorReleaseVersion
 		})
 		if err != nil {
 			r.Log.Error(err, "Failed to add conditions to status of DSCInitialization resource.", "DSCInitialization", req.Namespace, "Request.Name", req.Name)
@@ -258,7 +259,6 @@ func (r *DSCInitializationReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		_, err = status.UpdateWithRetry[*dsciv1.DSCInitialization](ctx, r.Client, instance, func(saved *dsciv1.DSCInitialization) {
 			status.SetCompleteCondition(&saved.Status.Conditions, status.ReconcileCompleted, status.ReconcileCompletedMessage)
 			saved.Status.Phase = status.PhaseReady
-			saved.Status.Release = currentOperatorReleaseVersion
 		})
 		if err != nil {
 			r.Log.Error(err, "failed to update DSCInitialization status after successfully completed reconciliation")


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->
- when we do not have e.g dependent operators installed, we should have .status.release info as well
- previous problem is, status update is in the end when reconcile on DSC/DSCI is finished, which can lead to a init value 0.0.0 and dashboard set to 0.0.0 to "About Modal"



<!--- Link your JIRA and related links here for reference. -->

https://issues.redhat.com/browse/RHOAIENG-12630

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
local build:
quay.io/wenzhou/opendatahub-operator-catalog:v2.18.12630
steps:
- uninstall ossm operator in the cluster
- create DSCI with default values
- wait for seconds to check DSCI has
```
- status:
  conditions:
    ....
      message: "2 errors occurred:\n\t* failed applying FeatureHandler features. cause: 1 error occurred:\n\t* 1 error occurred:\n\t* failed to find the pre-requisite Service Mesh Operator subscription, please ensure Service Mesh Operator is installed. failed to find the pre-requisite operator subscription \"servicemeshoperator\", please ensure operator is installed. missing operator \"servicemeshoperator\"\n\n\n\n\n\t* failed applying FeatureHandler features. cause: 1 error occurred:\n\t* 1 error occurred:\n\t* failed to find the pre-requisite Service Mesh Operator subscription, please ensure Service Mesh Operator is installed. failed to find the pre-requisite operator subscription \"servicemeshoperator\", please ensure operator is installed. missing operator \"servicemeshoperator\"\n\n\n\n\n\n"
      reason: MissingOperator
      status: 'False'
      type: CapabilityServiceMesh
  phase: Progressing
  release:
    name: Open Data Hub
    version: 2.18.12630
```
- create DSC CR with default values
- wait and check DSC
```
status:
  components: {}
  conditions:
   .....
  phase: Progressing
  release:
    name: Open Data Hub
    version: 2.18.12630
```

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
