### PR TITLE
cluster: remove GetPlatform api

### DIFF
--- a/main.go
+++ b/main.go
@@ -144,11 +144,12 @@ func main() { //nolint:funlen,maintidx
 		os.Exit(1)
 	}
 	// Get operator platform
-	platform, err := cluster.GetPlatform(ctx, setupClient)
+	release, err := cluster.GetRelease(ctx, setupClient)
 	if err != nil {
-		setupLog.Error(err, "error getting platform")
+		setupLog.Error(err, "error getting release")
 		os.Exit(1)
 	}
+	platform := release.Name
 	setupLog.Info("running on", "platform", platform)
 
 	secretCache := createSecretCacheConfig(platform)

--- a/pkg/cluster/cluster_config.go
+++ b/pkg/cluster/cluster_config.go
@@ -114,7 +114,7 @@ func detectManagedRHODS(ctx context.Context, cli client.Client) (Platform, error
 	return ManagedRhods, nil
 }
 
-func GetPlatform(ctx context.Context, cli client.Client) (Platform, error) {
+func getPlatform(ctx context.Context, cli client.Client) (Platform, error) {
 	// First check if its addon installation to return 'ManagedRhods, nil'
 	if platform, err := detectManagedRHODS(ctx, cli); err != nil {
 		return Unknown, err
@@ -141,7 +141,7 @@ func GetRelease(ctx context.Context, cli client.Client) (Release, error) {
 		},
 	}
 	// Set platform
-	platform, err := GetPlatform(ctx, cli)
+	platform, err := getPlatform(ctx, cli)
 	if err != nil {
 		return initRelease, err
 	}

--- a/pkg/cluster/cluster_operations_suite_int_test.go
+++ b/pkg/cluster/cluster_operations_suite_int_test.go
@@ -1,11 +1,8 @@
 package cluster_test
 
 import (
-	"path/filepath"
 	"testing"
 
-	ofapiv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
-	ofapiv2 "github.com/operator-framework/api/pkg/operators/v2"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -37,19 +34,8 @@ var _ = BeforeSuite(func() {
 	By("Bootstrapping k8s test environment")
 
 	utilruntime.Must(corev1.AddToScheme(testScheme))
-	utilruntime.Must(ofapiv1alpha1.AddToScheme(testScheme))
-	utilruntime.Must(ofapiv2.AddToScheme(testScheme))
 
-	envTest = &envtest.Environment{
-		CRDInstallOptions: envtest.CRDInstallOptions{
-			Scheme: testScheme,
-			Paths: []string{
-				filepath.Join("..", "..", "config", "crd", "external"),
-			},
-			ErrorIfPathMissing: true,
-			CleanUpAfterUse:    false,
-		},
-	}
+	envTest = &envtest.Environment{}
 
 	config, err := envTest.Start()
 	Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
There is no need to maintain the api since GetRelease performs the call and returns the information.

The extra work GetRelease does (in addition to GetPlatform) is not important since only one call in startup left.

Since the api removed, tests do not make sense, so revert testing part of d73b3da69ccc ("refactor: get platform calls (#1251)")

<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
