### PR TITLE
fix(crd): adds validation pattern and max length for ns fields

### DIFF
--- a/apis/infrastructure/v1/servicemesh_types.go
+++ b/apis/infrastructure/v1/servicemesh_types.go
@@ -20,6 +20,8 @@ type ControlPlaneSpec struct {
 	Name string `json:"name,omitempty"`
 	// Namespace is a namespace where Service Mesh is deployed. Defaults to "istio-system".
 	// +kubebuilder:default=istio-system
+	// +kubebuilder:validation:Pattern="^([a-z0-9]([-a-z0-9]*[a-z0-9])?)?$"
+	// +kubebuilder:validation:MaxLength=63
 	Namespace string `json:"namespace,omitempty"`
 	// MetricsCollection specifies if metrics from components on the Mesh namespace
 	// should be collected. Setting the value to "Istio" will collect metrics from the
@@ -45,6 +47,8 @@ type GatewaySpec struct {
 type AuthSpec struct {
 	// Namespace where it is deployed. If not provided, the default is to
 	// use '-auth-provider' suffix on the ApplicationsNamespace of the DSCI.
+	// +kubebuilder:validation:Pattern="^([a-z0-9]([-a-z0-9]*[a-z0-9])?)?$"
+	// +kubebuilder:validation:MaxLength=63
 	Namespace string `json:"namespace,omitempty"`
 	// Audiences is a list of the identifiers that the resource server presented
 	// with the token identifies as. Audience-aware token authenticators will verify

--- a/bundle/manifests/dscinitialization.opendatahub.io_dscinitializations.yaml
+++ b/bundle/manifests/dscinitialization.opendatahub.io_dscinitializations.yaml
@@ -126,6 +126,8 @@ spec:
                         description: |-
                           Namespace where it is deployed. If not provided, the default is to
                           use '-auth-provider' suffix on the ApplicationsNamespace of the DSCI.
+                        maxLength: 63
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?)?$
                         type: string
                     type: object
                   controlPlane:
@@ -152,6 +154,8 @@ spec:
                         default: istio-system
                         description: Namespace is a namespace where Service Mesh is
                           deployed. Defaults to "istio-system".
+                        maxLength: 63
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?)?$
                         type: string
                     type: object
                   managementState:

--- a/config/crd/bases/dscinitialization.opendatahub.io_dscinitializations.yaml
+++ b/config/crd/bases/dscinitialization.opendatahub.io_dscinitializations.yaml
@@ -126,6 +126,8 @@ spec:
                         description: |-
                           Namespace where it is deployed. If not provided, the default is to
                           use '-auth-provider' suffix on the ApplicationsNamespace of the DSCI.
+                        maxLength: 63
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?)?$
                         type: string
                     type: object
                   controlPlane:
@@ -152,6 +154,8 @@ spec:
                         default: istio-system
                         description: Namespace is a namespace where Service Mesh is
                           deployed. Defaults to "istio-system".
+                        maxLength: 63
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?)?$
                         type: string
                     type: object
                   managementState:

--- a/docs/api-overview.md
+++ b/docs/api-overview.md
@@ -347,7 +347,7 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `namespace` _string_ | Namespace where it is deployed. If not provided, the default is to<br />use '-auth-provider' suffix on the ApplicationsNamespace of the DSCI. |  |  |
+| `namespace` _string_ | Namespace where it is deployed. If not provided, the default is to<br />use '-auth-provider' suffix on the ApplicationsNamespace of the DSCI. |  | MaxLength: 63 <br />Pattern: `^([a-z0-9]([-a-z0-9]*[a-z0-9])?)?$` <br /> |
 | `audiences` _string_ | Audiences is a list of the identifiers that the resource server presented<br />with the token identifies as. Audience-aware token authenticators will verify<br />that the token was intended for at least one of the audiences in this list.<br />If no audiences are provided, the audience will default to the audience of the<br />Kubernetes apiserver (kubernetes.default.svc). | [https://kubernetes.default.svc] |  |
 
 
@@ -443,7 +443,7 @@ _Appears in:_
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
 | `name` _string_ | Name is a name Service Mesh Control Plane. Defaults to "data-science-smcp". | data-science-smcp |  |
-| `namespace` _string_ | Namespace is a namespace where Service Mesh is deployed. Defaults to "istio-system". | istio-system |  |
+| `namespace` _string_ | Namespace is a namespace where Service Mesh is deployed. Defaults to "istio-system". | istio-system | MaxLength: 63 <br />Pattern: `^([a-z0-9]([-a-z0-9]*[a-z0-9])?)?$` <br /> |
 | `metricsCollection` _string_ | MetricsCollection specifies if metrics from components on the Mesh namespace<br />should be collected. Setting the value to "Istio" will collect metrics from the<br />control plane and any proxies on the Mesh namespace (like gateway pods). Setting<br />to "None" will disable metrics collection. | Istio | Enum: [Istio None] <br /> |
 
 


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
This commit introduces a validation pattern and maximum length constraint to the `Namespace` fields in our structs. We have missed it in the early days.

Validation rules ensure that namespace names does not exceed max length defined and are valid [RFC 1123 DNS labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/#namespaces-and-dns).

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
