### PR TITLE
(fix): ODH release automation: Release notes generation

### DIFF
--- a/.github/scripts/get-component-release-notes.js
+++ b/.github/scripts/get-component-release-notes.js
@@ -1,27 +1,51 @@
-function getModifiedComponentName(name){
+function getModifiedComponentName(name) {
     let modifiedWord = name.split("-").join(" ").replace(/[^a-zA-Z ]/g, "").trim()
     modifiedWord = modifiedWord[0].toUpperCase() + modifiedWord.slice(1).toLowerCase()
     return modifiedWord.replace("Odh", "ODH")
 }
-module.exports = ({ github, core }) => {
-    const { TRACKER_URL } = process.env
-    console.log(`The TRACKER_URL is ${TRACKER_URL}`)
-    const arr = TRACKER_URL.split("/")
+module.exports = async ({ github, core, context }) => {
+    const { TRACKER_URL: trackerUrl, VERSION: currentTag } = process.env
+    console.log(`The TRACKER_URL is ${trackerUrl}`)
+    const arr = trackerUrl.split("/")
     const owner = arr[3]
     const repo = arr[4]
     const issue_number = arr[6]
 
-    github.request('GET /repos/{owner}/{repo}/issues/{issue_number}/comments', {
-        owner,
-        repo,
-        issue_number,
-        headers: {
-            'X-GitHub-Api-Version': '2022-11-28',
-            'Accept': 'application/vnd.github.text+json'
-        }
-    }).then((result) => {
+    try {
+        const latestReleaseResult = await github.rest.repos.getLatestRelease({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            headers: {
+                'X-GitHub-Api-Version': '2022-11-28',
+                'Accept': 'application/vnd.github+json',
+            }
+        })
+        const previousTag = latestReleaseResult.data["tag_name"]
+        console.log(`The current tag is: ${previousTag}`)
+
+        const releaseNotesResult = await github.rest.repos.generateReleaseNotes({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            tag_name: currentTag,
+            previous_tag_name: previousTag,
+            headers: {
+                'X-GitHub-Api-Version': '2022-11-28',
+                'Accept': 'application/vnd.github+json'
+            }
+        })
+        const releaseNotesString = releaseNotesResult.data["body"]
+
+        const commentsResult = await github.rest.issues.listComments({
+            owner,
+            repo,
+            issue_number,
+            headers: {
+                'X-GitHub-Api-Version': '2022-11-28',
+                'Accept': 'application/vnd.github.text+json'
+            }
+        })
         let outputStr = "## Component Release Notes\n"
-        result.data.forEach((issue) => {
+        commentsResult.data.forEach((issue) => {
             let issueCommentBody = issue.body_text
             if (issueCommentBody.includes("#Release#")) {
                 let components = issueCommentBody.split("\n")
@@ -33,15 +57,16 @@ module.exports = ({ github, core }) => {
                         let [componentName, branchUrl, tagUrl] = component.split("|")
                         componentName = getModifiedComponentName(componentName.trim())
                         const releaseNotesUrl = (tagUrl || branchUrl).trim();
-                        if(!outputStr.includes(componentName)) outputStr += `- **${componentName}**: ${releaseNotesUrl}\n`
-        
+                        if (!outputStr.includes(componentName)) outputStr += `- **${componentName}**: ${releaseNotesUrl}\n`
+
                     }
                 })
             }
         })
+        outputStr += "\n" + releaseNotesString
         console.log("Created component release notes successfully...")
         core.setOutput('release-notes-body', outputStr);
-    }).catch(e => {
-        core.setFailed(`Action failed with error ${e}`);
-    })
+    } catch (error) {
+        core.setFailed(`Action failed with error ${error}`);
+    }
 }

--- a/.github/workflows/pre-release.yaml
+++ b/.github/workflows/pre-release.yaml
@@ -3,7 +3,6 @@ on:
   pull_request:
     types:
       - closed
-
 jobs:
   push-tags-and-create-release-prs:
     if: github.event_name == 'pull_request' && github.event.pull_request.merged == false && github.event.action == 'closed' && contains(github.event.pull_request.title, '[DO NOT MERGE] Test')
@@ -23,7 +22,7 @@ jobs:
           exit 1
         fi
       shell: bash
-    - name: Get release data
+    - name: Get release data from comment
       uses: peter-evans/find-comment@v3
       id: release-data
       with:
@@ -50,6 +49,8 @@ jobs:
         base-branch: incubation
     - name: Create release branch
       run: |
+        git fetch origin incubation:incubation
+        git checkout incubation
         git checkout -b odh-${{ env.VERSION }}
         git push -f origin odh-${{ env.VERSION }}
     - uses: ./.github/actions/update-manifest-branches

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -35,16 +35,14 @@ jobs:
         with:
           script: |
             const script = require('./.github/scripts/get-component-release-notes.js')
-            script({github, core})
+            await script({github, core, context})
       - name: Create GH release
         uses: softprops/action-gh-release@v2
         with:
           body: ${{ steps.release-notes.outputs.release-notes-body }}
           tag_name: v${{ env.VERSION }}
-          generate_release_notes: true
-          append_body: true
           make_latest: true
-  # To be enabled later.
+  # TODO: To be enabled later.
   # create-community-operators-pr:
   #   needs: [gh-release]
   #   name: Create community operators prod pr # https://github.com/redhat-openshift-ecosystem/community-operators-prod


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->
(fix): ODH release automation: Release notes generation 
- The GH action [softprops/action-gh-release@v2](https://github.com/softprops/action-gh-release) currently doesnot support choosing a tag range for the change-log. ie we cannot set a previous tag. ref: https://github.com/softprops/action-gh-release/issues/465 
This fix(PR) is aimed to work around it by using the GH api directly and creating the body of the release notes ourselves.
 - A minor fix which prevents gh action from doing a merge-commit.
 
ref: https://issues.redhat.com/browse/RHOAIENG-13458

## How Has This Been Tested?
 - Tested the action by running on my repo.


- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
