### PR TITLE
update: remove cache for deployment in model reg namespace

### DIFF
--- a/components/modelregistry/modelregistry.go
+++ b/components/modelregistry/modelregistry.go
@@ -32,10 +32,6 @@ var (
 	ComponentName                   = "model-registry-operator"
 	DefaultModelRegistriesNamespace = "odh-model-registries"
 	Path                            = deploy.DefaultManifestPath + "/" + ComponentName + "/overlays/odh"
-	// we should not apply this label to the namespace, as it triggered namspace deletion during operator uninstall
-	// modelRegistryLabels = cluster.WithLabels(
-	//      labels.ODH.OwnedNamespace, "true",
-	// ).
 )
 
 // Verifies that ModelRegistry implements ComponentInterface.
@@ -127,6 +123,10 @@ func (m *ModelRegistry) ReconcileComponent(ctx context.Context, cli client.Clien
 		}
 
 		// Create model registries namespace
+		// we should not apply this label to the namespace, as it triggered namspace deletion during operator uninstall
+		// modelRegistryLabels = cluster.WithLabels(
+		//      labels.ODH.OwnedNamespace, "true",
+		// ).
 		// We do not delete this namespace even when ModelRegistry is Removed or when operator is uninstalled.
 		ns, err := cluster.CreateNamespace(ctx, cli, m.RegistriesNamespace)
 		if err != nil {

--- a/main.go
+++ b/main.go
@@ -60,7 +60,6 @@ import (
 	dscv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/datasciencecluster/v1"
 	dsciv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/dscinitialization/v1"
 	featurev1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/features/v1"
-	"github.com/opendatahub-io/opendatahub-operator/v2/components/modelregistry"
 	"github.com/opendatahub-io/opendatahub-operator/v2/controllers/certconfigmapgenerator"
 	dscctrl "github.com/opendatahub-io/opendatahub-operator/v2/controllers/datasciencecluster"
 	dscictrl "github.com/opendatahub-io/opendatahub-operator/v2/controllers/dscinitialization"
@@ -384,7 +383,5 @@ func createDeploymentCacheConfig(platform cluster.Platform) map[string]cache.Con
 	default:
 		namespaceConfigs["opendatahub"] = cache.Config{}
 	}
-	// for modelregistry namespace
-	namespaceConfigs[modelregistry.DefaultModelRegistriesNamespace] = cache.Config{}
 	return namespaceConfigs
 }


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->
ODH operator no need to cache deployment in model reg namespace, as we only care about the applicationnamepsace and a bunch of other for monitorings.
it was a mistake in the past to add modelreg namespace into the cache for deployment resourcec.
this PR is to remove that piece of logic + move the comments about do not label model reg namespace in better place.


## Description
<!--- Describe your changes in detail -->

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
