### PR TITLE
DSCI CRD: allow default as a value for logmode

### DIFF
--- a/apis/dscinitialization/v1/dscinitialization_types.go
+++ b/apis/dscinitialization/v1/dscinitialization_types.go
@@ -79,7 +79,7 @@ type DevFlags struct {
 	// Custom manifests uri for odh-manifests
 	// +optional
 	ManifestsUri string `json:"manifestsUri,omitempty"`
-	// +kubebuilder:validation:Enum=devel;development;prod;production
+	// +kubebuilder:validation:Enum=devel;development;prod;production;default
 	// +kubebuilder:default="production"
 	LogMode string `json:"logmode,omitempty"`
 }

--- a/bundle/manifests/dscinitialization.opendatahub.io_dscinitializations.yaml
+++ b/bundle/manifests/dscinitialization.opendatahub.io_dscinitializations.yaml
@@ -72,6 +72,7 @@ spec:
                     - development
                     - prod
                     - production
+                    - default
                     type: string
                   manifestsUri:
                     description: Custom manifests uri for odh-manifests

--- a/config/crd/bases/dscinitialization.opendatahub.io_dscinitializations.yaml
+++ b/config/crd/bases/dscinitialization.opendatahub.io_dscinitializations.yaml
@@ -72,6 +72,7 @@ spec:
                     - development
                     - prod
                     - production
+                    - default
                     type: string
                   manifestsUri:
                     description: Custom manifests uri for odh-manifests

--- a/docs/api-overview.md
+++ b/docs/api-overview.md
@@ -669,7 +669,7 @@ _Appears in:_
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
 | `manifestsUri` _string_ | Custom manifests uri for odh-manifests |  |  |
-| `logmode` _string_ |  | production | Enum: [devel development prod production] <br /> |
+| `logmode` _string_ |  | production | Enum: [devel development prod production default] <br /> |
 
 
 #### Monitoring


### PR DESCRIPTION
default is a separate mode in the sources, not just selection of one of the others, so allow it explicitly.

There is no difference if it is set to "" explicitly or not set since "" is a string default value.

In the current code as soon as devFlags are present, the mode is taken in use, so it is reset to default even if it is not set which does not look right (I would expect leave it untouched if is not set). If it is fixed, then it will be impossible to reset logging mode to default from devel or prod: if "" is considered as "not set explicitly", then there is no value for default, the object checker rejects values not in list.

<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
