### PR TITLE
controllers, monitoring: use local variable for logger

### DIFF
--- a/controllers/certconfigmapgenerator/certconfigmapgenerator_controller.go
+++ b/controllers/certconfigmapgenerator/certconfigmapgenerator_controller.go
@@ -33,7 +33,8 @@ type CertConfigmapGeneratorReconciler struct {
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *CertConfigmapGeneratorReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	r.Log.Info("Adding controller for Configmap Generation.")
+	log := r.Log
+	log.Info("Adding controller for Configmap Generation.")
 	return ctrl.NewControllerManagedBy(mgr).
 		Named("cert-configmap-generator-controller").
 		Watches(&corev1.ConfigMap{}, handler.EnqueueRequestsFromMapFunc(r.watchTrustedCABundleConfigMapResource), builder.WithPredicates(ConfigMapChangedPredicate)).
@@ -44,8 +45,9 @@ func (r *CertConfigmapGeneratorReconciler) SetupWithManager(mgr ctrl.Manager) er
 // Reconcile will generate new configmap, odh-trusted-ca-bundle, that includes cluster-wide trusted-ca bundle and custom
 // ca bundle in every new namespace created.
 func (r *CertConfigmapGeneratorReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	log := r.Log
 	// Request includes namespace that is newly created or where odh-trusted-ca-bundle configmap is updated.
-	r.Log.Info("Reconciling CertConfigMapGenerator.", " Request.Namespace", req.NamespacedName)
+	log.Info("Reconciling CertConfigMapGenerator.", " Request.Namespace", req.NamespacedName)
 	// Get namespace instance
 	userNamespace := &corev1.Namespace{}
 	if err := r.Client.Get(ctx, client.ObjectKey{Name: req.Namespace}, userNamespace); err != nil {
@@ -55,7 +57,7 @@ func (r *CertConfigmapGeneratorReconciler) Reconcile(ctx context.Context, req ct
 	// Get DSCI instance
 	dsciInstances := &dsciv1.DSCInitializationList{}
 	if err := r.Client.List(ctx, dsciInstances); err != nil {
-		r.Log.Error(err, "Failed to retrieve DSCInitialization resource for CertConfigMapGenerator ", "Request.Name", req.Name)
+		log.Error(err, "Failed to retrieve DSCInitialization resource for CertConfigMapGenerator ", "Request.Name", req.Name)
 		return ctrl.Result{}, err
 	}
 
@@ -73,10 +75,10 @@ func (r *CertConfigmapGeneratorReconciler) Reconcile(ctx context.Context, req ct
 
 	// Delete odh-trusted-ca-bundle Configmap if namespace has annotation set to opt-out CA bundle injection
 	if trustedcabundle.HasCABundleAnnotationDisabled(userNamespace) {
-		r.Log.Info("Namespace has opted-out of CA bundle injection using annotation", "namespace", userNamespace.Name,
+		log.Info("Namespace has opted-out of CA bundle injection using annotation", "namespace", userNamespace.Name,
 			"annotation", annotation.InjectionOfCABundleAnnotatoion)
 		if err := trustedcabundle.DeleteOdhTrustedCABundleConfigMap(ctx, r.Client, req.Namespace); client.IgnoreNotFound(err) != nil {
-			r.Log.Error(err, "error deleting existing configmap from namespace", "name", trustedcabundle.CAConfigMapName, "namespace", userNamespace.Name)
+			log.Error(err, "error deleting existing configmap from namespace", "name", trustedcabundle.CAConfigMapName, "namespace", userNamespace.Name)
 			return reconcile.Result{}, err
 		}
 
@@ -85,11 +87,11 @@ func (r *CertConfigmapGeneratorReconciler) Reconcile(ctx context.Context, req ct
 
 	// Add odh-trusted-ca-bundle Configmap
 	if trustedcabundle.ShouldInjectTrustedBundle(userNamespace) {
-		r.Log.Info("Adding trusted CA bundle configmap to the new or existing namespace ", "namespace", userNamespace.Name,
+		log.Info("Adding trusted CA bundle configmap to the new or existing namespace ", "namespace", userNamespace.Name,
 			"configmap", trustedcabundle.CAConfigMapName)
 		trustCAData := dsciInstance.Spec.TrustedCABundle.CustomCABundle
 		if err := trustedcabundle.CreateOdhTrustedCABundleConfigMap(ctx, r.Client, req.Namespace, trustCAData); err != nil {
-			r.Log.Error(err, "error adding configmap to namespace", "name", trustedcabundle.CAConfigMapName, "namespace", userNamespace.Name)
+			log.Error(err, "error adding configmap to namespace", "name", trustedcabundle.CAConfigMapName, "namespace", userNamespace.Name)
 			return reconcile.Result{}, err
 		}
 	}
@@ -108,8 +110,9 @@ func (r *CertConfigmapGeneratorReconciler) watchNamespaceResource(_ context.Cont
 }
 
 func (r *CertConfigmapGeneratorReconciler) watchTrustedCABundleConfigMapResource(_ context.Context, a client.Object) []reconcile.Request {
+	log := r.Log
 	if a.GetName() == trustedcabundle.CAConfigMapName {
-		r.Log.Info("Cert configmap has been updated, start reconcile")
+		log.Info("Cert configmap has been updated, start reconcile")
 		return []reconcile.Request{{NamespacedName: types.NamespacedName{Name: a.GetName(), Namespace: a.GetNamespace()}}}
 	}
 	return nil

--- a/controllers/dscinitialization/monitoring.go
+++ b/controllers/dscinitialization/monitoring.go
@@ -39,6 +39,7 @@ var (
 // only when reconcile on DSCI CR, initial set to true
 // if reconcile from monitoring, initial set to false, skip blackbox and rolebinding.
 func (r *DSCInitializationReconciler) configureManagedMonitoring(ctx context.Context, dscInit *dsciv1.DSCInitialization, initial string) error {
+	log := r.Log
 	if initial == "init" {
 		// configure Blackbox exporter
 		if err := configureBlackboxExporter(ctx, dscInit, r); err != nil {
@@ -61,7 +62,7 @@ func (r *DSCInitializationReconciler) configureManagedMonitoring(ctx context.Con
 				"(.*)-(.*)trustyai(.*).rules":                        "",
 			})
 		if err != nil {
-			r.Log.Error(err, "error to remove previous enabled component rules")
+			log.Error(err, "error to remove previous enabled component rules")
 			return err
 		}
 	}
@@ -83,34 +84,35 @@ func (r *DSCInitializationReconciler) configureManagedMonitoring(ctx context.Con
 		}
 	}
 
-	r.Log.Info("Success: finish config managed monitoring stack!")
+	log.Info("Success: finish config managed monitoring stack!")
 	return nil
 }
 
 func configureAlertManager(ctx context.Context, dsciInit *dsciv1.DSCInitialization, r *DSCInitializationReconciler) error {
+	log := r.Log
 	// Get Deadmansnitch secret
 	deadmansnitchSecret, err := r.waitForManagedSecret(ctx, "redhat-rhods-deadmanssnitch", dsciInit.Spec.Monitoring.Namespace)
 	if err != nil {
-		r.Log.Error(err, "error getting deadmansnitch secret from namespace "+dsciInit.Spec.Monitoring.Namespace)
+		log.Error(err, "error getting deadmansnitch secret from namespace "+dsciInit.Spec.Monitoring.Namespace)
 		return err
 	}
-	// r.Log.Info("Success: got deadmansnitch secret")
+	// log.Info("Success: got deadmansnitch secret")
 
 	// Get PagerDuty Secret
 	pagerDutySecret, err := r.waitForManagedSecret(ctx, "redhat-rhods-pagerduty", dsciInit.Spec.Monitoring.Namespace)
 	if err != nil {
-		r.Log.Error(err, "error getting pagerduty secret from namespace "+dsciInit.Spec.Monitoring.Namespace)
+		log.Error(err, "error getting pagerduty secret from namespace "+dsciInit.Spec.Monitoring.Namespace)
 		return err
 	}
-	// r.Log.Info("Success: got pagerduty secret")
+	// log.Info("Success: got pagerduty secret")
 
 	// Get Smtp Secret
 	smtpSecret, err := r.waitForManagedSecret(ctx, "redhat-rhods-smtp", dsciInit.Spec.Monitoring.Namespace)
 	if err != nil {
-		r.Log.Error(err, "error getting smtp secret from namespace "+dsciInit.Spec.Monitoring.Namespace)
+		log.Error(err, "error getting smtp secret from namespace "+dsciInit.Spec.Monitoring.Namespace)
 		return err
 	}
-	// r.Log.Info("Success: got smtp secret")
+	// log.Info("Success: got smtp secret")
 
 	// Replace variables in alertmanager configmap for the initial time
 	// TODO: Following variables can later be exposed by the API
@@ -124,10 +126,10 @@ func configureAlertManager(ctx context.Context, dsciInit *dsciv1.DSCInitializati
 			"<smtp_password>":   string(smtpSecret.Data["password"]),
 		})
 	if err != nil {
-		r.Log.Error(err, "error to inject data to alertmanager-configs.yaml")
+		log.Error(err, "error to inject data to alertmanager-configs.yaml")
 		return err
 	}
-	// r.Log.Info("Success: inject alertmanage-configs.yaml")
+	// log.Info("Success: inject alertmanage-configs.yaml")
 
 	// special handling for dev-mod
 	consolelinkDomain, err := cluster.GetDomain(ctx, r.Client)
@@ -135,33 +137,33 @@ func configureAlertManager(ctx context.Context, dsciInit *dsciv1.DSCInitializati
 		return fmt.Errorf("error getting console route URL : %w", err)
 	}
 	if strings.Contains(consolelinkDomain, "devshift.org") {
-		r.Log.Info("inject alertmanage-configs.yaml for dev mode1")
+		log.Info("inject alertmanage-configs.yaml for dev mode1")
 		err = common.ReplaceStringsInFile(filepath.Join(alertManagerPath, "alertmanager-configs.yaml"),
 			map[string]string{
 				"@devshift.net": "@rhmw.io",
 			})
 		if err != nil {
-			r.Log.Error(err, "error to replace data for dev mode1 to alertmanager-configs.yaml")
+			log.Error(err, "error to replace data for dev mode1 to alertmanager-configs.yaml")
 			return err
 		}
 	}
 	if strings.Contains(consolelinkDomain, "aisrhods") {
-		r.Log.Info("inject alertmanage-configs.yaml for dev mode2")
+		log.Info("inject alertmanage-configs.yaml for dev mode2")
 		err = common.ReplaceStringsInFile(filepath.Join(alertManagerPath, "alertmanager-configs.yaml"),
 			map[string]string{
 				"receiver: PagerDuty": "receiver: alerts-sink",
 			})
 		if err != nil {
-			r.Log.Error(err, "error to replace data for dev mode2 to alertmanager-configs.yaml")
+			log.Error(err, "error to replace data for dev mode2 to alertmanager-configs.yaml")
 			return err
 		}
 	}
 
-	// r.Log.Info("Success: inject alertmanage-configs.yaml for dev mode")
+	// log.Info("Success: inject alertmanage-configs.yaml for dev mode")
 
 	operatorNs, err := cluster.GetOperatorNamespace()
 	if err != nil {
-		r.Log.Error(err, "error getting operator namespace for smtp secret")
+		log.Error(err, "error getting operator namespace for smtp secret")
 		return err
 	}
 
@@ -170,41 +172,42 @@ func configureAlertManager(ctx context.Context, dsciInit *dsciv1.DSCInitializati
 	if err != nil {
 		return fmt.Errorf("error getting smtp receiver email secret: %w", err)
 	}
-	// r.Log.Info("Success: got smpt email secret")
+	// log.Info("Success: got smpt email secret")
 	// replace smtpEmailSecret in alertmanager-configs.yaml
 	if err = common.MatchLineInFile(filepath.Join(alertManagerPath, "alertmanager-configs.yaml"),
 		map[string]string{
 			"- to: ": "- to: " + string(smtpEmailSecret.Data["notification-email"]),
 		},
 	); err != nil {
-		r.Log.Error(err, "error to update with new notification-email")
+		log.Error(err, "error to update with new notification-email")
 		return err
 	}
-	// r.Log.Info("Success: update alertmanage-configs.yaml with email")
+	// log.Info("Success: update alertmanage-configs.yaml with email")
 	err = deploy.DeployManifestsFromPath(ctx, r.Client, dsciInit, alertManagerPath, dsciInit.Spec.Monitoring.Namespace, "alertmanager", true)
 	if err != nil {
-		r.Log.Error(err, "error to deploy manifests", "path", alertManagerPath)
+		log.Error(err, "error to deploy manifests", "path", alertManagerPath)
 		return err
 	}
-	// r.Log.Info("Success: update alertmanager with manifests")
+	// log.Info("Success: update alertmanager with manifests")
 
 	// Create alertmanager-proxy secret
 	if err := createMonitoringProxySecret(ctx, r.Client, "alertmanager-proxy", dsciInit); err != nil {
-		r.Log.Error(err, "error to create secret alertmanager-proxy")
+		log.Error(err, "error to create secret alertmanager-proxy")
 		return err
 	}
-	// r.Log.Info("Success: create alertmanager-proxy secret")
+	// log.Info("Success: create alertmanager-proxy secret")
 	return nil
 }
 
 func configurePrometheus(ctx context.Context, dsciInit *dsciv1.DSCInitialization, r *DSCInitializationReconciler) error {
+	log := r.Log
 	// Update rolebinding-viewer
 	err := common.ReplaceStringsInFile(filepath.Join(prometheusManifestsPath, "prometheus-rolebinding-viewer.yaml"),
 		map[string]string{
 			"<odh_monitoring_project>": dsciInit.Spec.Monitoring.Namespace,
 		})
 	if err != nil {
-		r.Log.Error(err, "error to inject data to prometheus-rolebinding-viewer.yaml")
+		log.Error(err, "error to inject data to prometheus-rolebinding-viewer.yaml")
 		return err
 	}
 	// Update prometheus-config for dashboard, dsp and workbench
@@ -219,7 +222,7 @@ func configurePrometheus(ctx context.Context, dsciInit *dsciv1.DSCInitialization
 			"<console_domain>":            consolelinkDomain,
 		})
 	if err != nil {
-		r.Log.Error(err, "error to inject data to prometheus-configs.yaml")
+		log.Error(err, "error to inject data to prometheus-configs.yaml")
 		return err
 	}
 
@@ -232,10 +235,10 @@ func configurePrometheus(ctx context.Context, dsciInit *dsciv1.DSCInitialization
 		dsciInit.Spec.Monitoring.Namespace,
 		"prometheus",
 		dsciInit.Spec.Monitoring.ManagementState == operatorv1.Managed); err != nil {
-		r.Log.Error(err, "error to deploy manifests for prometheus configs", "path", prometheusConfigPath)
+		log.Error(err, "error to deploy manifests for prometheus configs", "path", prometheusConfigPath)
 		return err
 	}
-	// r.Log.Info("Success: create prometheus configmap 'prometheus'")
+	// log.Info("Success: create prometheus configmap 'prometheus'")
 
 	// Get prometheus configmap
 	prometheusConfigMap := &corev1.ConfigMap{}
@@ -244,18 +247,18 @@ func configurePrometheus(ctx context.Context, dsciInit *dsciv1.DSCInitialization
 		Name:      "prometheus",
 	}, prometheusConfigMap)
 	if err != nil {
-		r.Log.Error(err, "error to get configmap 'prometheus'")
+		log.Error(err, "error to get configmap 'prometheus'")
 		return err
 	}
-	// r.Log.Info("Success: got prometheus configmap")
+	// log.Info("Success: got prometheus configmap")
 
 	// Get encoded prometheus data from configmap 'prometheus'
 	prometheusData, err := common.GetMonitoringData(fmt.Sprint(prometheusConfigMap.Data))
 	if err != nil {
-		r.Log.Error(err, "error to get prometheus data")
+		log.Error(err, "error to get prometheus data")
 		return err
 	}
-	// r.Log.Info("Success: read encoded prometheus data from prometheus.yml in configmap")
+	// log.Info("Success: read encoded prometheus data from prometheus.yml in configmap")
 
 	// Get alertmanager host
 	alertmanagerRoute := &routev1.Route{}
@@ -264,10 +267,10 @@ func configurePrometheus(ctx context.Context, dsciInit *dsciv1.DSCInitialization
 		Name:      "alertmanager",
 	}, alertmanagerRoute)
 	if err != nil {
-		r.Log.Error(err, "error to get alertmanager route")
+		log.Error(err, "error to get alertmanager route")
 		return err
 	}
-	// r.Log.Info("Success: got alertmanager route")
+	// log.Info("Success: got alertmanager route")
 
 	// Get alertmanager configmap
 	alertManagerConfigMap := &corev1.ConfigMap{}
@@ -276,17 +279,17 @@ func configurePrometheus(ctx context.Context, dsciInit *dsciv1.DSCInitialization
 		Name:      "alertmanager",
 	}, alertManagerConfigMap)
 	if err != nil {
-		r.Log.Error(err, "error to get configmap 'alertmanager'")
+		log.Error(err, "error to get configmap 'alertmanager'")
 		return err
 	}
-	// r.Log.Info("Success: got configmap 'alertmanager'")
+	// log.Info("Success: got configmap 'alertmanager'")
 
 	alertmanagerData, err := common.GetMonitoringData(alertManagerConfigMap.Data["alertmanager.yml"])
 	if err != nil {
-		r.Log.Error(err, "error to get encoded alertmanager data from alertmanager.yml")
+		log.Error(err, "error to get encoded alertmanager data from alertmanager.yml")
 		return err
 	}
-	// r.Log.Info("Success: read alertmanager data from alertmanage.yml")
+	// log.Info("Success: read alertmanager data from alertmanage.yml")
 
 	// Update prometheus deployment with alertmanager and prometheus data
 	err = common.ReplaceStringsInFile(filepath.Join(prometheusManifestsPath, "prometheus-deployment.yaml"),
@@ -294,20 +297,20 @@ func configurePrometheus(ctx context.Context, dsciInit *dsciv1.DSCInitialization
 			"<set_alertmanager_host>": alertmanagerRoute.Spec.Host,
 		})
 	if err != nil {
-		r.Log.Error(err, "error to inject set_alertmanager_host to prometheus-deployment.yaml")
+		log.Error(err, "error to inject set_alertmanager_host to prometheus-deployment.yaml")
 		return err
 	}
-	// r.Log.Info("Success: update set_alertmanager_host in prometheus-deployment.yaml")
+	// log.Info("Success: update set_alertmanager_host in prometheus-deployment.yaml")
 	err = common.MatchLineInFile(filepath.Join(prometheusManifestsPath, "prometheus-deployment.yaml"),
 		map[string]string{
 			"alertmanager: ": "alertmanager: " + alertmanagerData,
 			"prometheus: ":   "prometheus: " + prometheusData,
 		})
 	if err != nil {
-		r.Log.Error(err, "error to update annotations in prometheus-deployment.yaml")
+		log.Error(err, "error to update annotations in prometheus-deployment.yaml")
 		return err
 	}
-	// r.Log.Info("Success: update annotations in prometheus-deployment.yaml")
+	// log.Info("Success: update annotations in prometheus-deployment.yaml")
 
 	// final apply prometheus manifests including prometheus deployment
 	// Check if Prometheus deployment from legacy version exists(check for initContainer)
@@ -332,7 +335,7 @@ func configurePrometheus(ctx context.Context, dsciInit *dsciv1.DSCInitialization
 	err = deploy.DeployManifestsFromPath(ctx, r.Client, dsciInit, prometheusManifestsPath,
 		dsciInit.Spec.Monitoring.Namespace, "prometheus", true)
 	if err != nil {
-		r.Log.Error(err, "error to deploy manifests for prometheus", "path", prometheusManifestsPath)
+		log.Error(err, "error to deploy manifests for prometheus", "path", prometheusManifestsPath)
 		return err
 	}
 
@@ -340,11 +343,12 @@ func configurePrometheus(ctx context.Context, dsciInit *dsciv1.DSCInitialization
 	if err := createMonitoringProxySecret(ctx, r.Client, "prometheus-proxy", dsciInit); err != nil {
 		return err
 	}
-	// r.Log.Info("Success: create prometheus-proxy secret")
+	// log.Info("Success: create prometheus-proxy secret")
 	return nil
 }
 
 func configureBlackboxExporter(ctx context.Context, dsciInit *dsciv1.DSCInitialization, r *DSCInitializationReconciler) error {
+	log := r.Log
 	consoleRoute := &routev1.Route{}
 	err := r.Client.Get(ctx, client.ObjectKey{Name: "console", Namespace: "openshift-console"}, consoleRoute)
 	if err != nil {
@@ -380,7 +384,7 @@ func configureBlackboxExporter(ctx context.Context, dsciInit *dsciv1.DSCInitiali
 			dsciInit.Spec.Monitoring.Namespace,
 			"blackbox-exporter",
 			dsciInit.Spec.Monitoring.ManagementState == operatorv1.Managed); err != nil {
-			r.Log.Error(err, "error to deploy manifests: %w", "error", err)
+			log.Error(err, "error to deploy manifests: %w", "error", err)
 			return err
 		}
 	} else {
@@ -390,7 +394,7 @@ func configureBlackboxExporter(ctx context.Context, dsciInit *dsciv1.DSCInitiali
 			dsciInit.Spec.Monitoring.Namespace,
 			"blackbox-exporter",
 			dsciInit.Spec.Monitoring.ManagementState == operatorv1.Managed); err != nil {
-			r.Log.Error(err, "error to deploy manifests: %w", "error", err)
+			log.Error(err, "error to deploy manifests: %w", "error", err)
 			return err
 		}
 	}
@@ -434,6 +438,7 @@ func createMonitoringProxySecret(ctx context.Context, cli client.Client, name st
 }
 
 func (r *DSCInitializationReconciler) configureSegmentIO(ctx context.Context, dsciInit *dsciv1.DSCInitialization) error {
+	log := r.Log
 	// create segment.io only when configmap does not exist in the cluster
 	segmentioConfigMap := &corev1.ConfigMap{}
 	if err := r.Client.Get(ctx, client.ObjectKey{
@@ -441,7 +446,7 @@ func (r *DSCInitializationReconciler) configureSegmentIO(ctx context.Context, ds
 		Name:      "odh-segment-key-config",
 	}, segmentioConfigMap); err != nil {
 		if !k8serr.IsNotFound(err) {
-			r.Log.Error(err, "error to get configmap 'odh-segment-key-config'")
+			log.Error(err, "error to get configmap 'odh-segment-key-config'")
 			return err
 		} else {
 			segmentPath := filepath.Join(deploy.DefaultManifestPath, "monitoring", "segment")
@@ -453,7 +458,7 @@ func (r *DSCInitializationReconciler) configureSegmentIO(ctx context.Context, ds
 				dsciInit.Spec.ApplicationsNamespace,
 				"segment-io",
 				dsciInit.Spec.Monitoring.ManagementState == operatorv1.Managed); err != nil {
-				r.Log.Error(err, "error to deploy manifests under "+segmentPath)
+				log.Error(err, "error to deploy manifests under "+segmentPath)
 				return err
 			}
 		}
@@ -462,6 +467,7 @@ func (r *DSCInitializationReconciler) configureSegmentIO(ctx context.Context, ds
 }
 
 func (r *DSCInitializationReconciler) configureCommonMonitoring(ctx context.Context, dsciInit *dsciv1.DSCInitialization) error {
+	log := r.Log
 	if err := r.configureSegmentIO(ctx, dsciInit); err != nil {
 		return err
 	}
@@ -473,7 +479,7 @@ func (r *DSCInitializationReconciler) configureCommonMonitoring(ctx context.Cont
 			"<odh_monitoring_project>": dsciInit.Spec.Monitoring.Namespace,
 		})
 	if err != nil {
-		r.Log.Error(err, "error to inject namespace to common monitoring")
+		log.Error(err, "error to inject namespace to common monitoring")
 
 		return err
 	}
@@ -486,7 +492,7 @@ func (r *DSCInitializationReconciler) configureCommonMonitoring(ctx context.Cont
 		"",
 		"monitoring-base",
 		dsciInit.Spec.Monitoring.ManagementState == operatorv1.Managed); err != nil {
-		r.Log.Error(err, "error to deploy manifests under "+monitoringBasePath)
+		log.Error(err, "error to deploy manifests under "+monitoringBasePath)
 		return err
 	}
 	return nil

--- a/controllers/dscinitialization/servicemesh_setup.go
+++ b/controllers/dscinitialization/servicemesh_setup.go
@@ -19,11 +19,12 @@ import (
 )
 
 func (r *DSCInitializationReconciler) configureServiceMesh(ctx context.Context, instance *dsciv1.DSCInitialization) error {
+	log := r.Log
 	serviceMeshManagementState := operatorv1.Removed
 	if instance.Spec.ServiceMesh != nil {
 		serviceMeshManagementState = instance.Spec.ServiceMesh.ManagementState
 	} else {
-		r.Log.Info("ServiceMesh is not configured in DSCI, same as default to 'Removed'")
+		log.Info("ServiceMesh is not configured in DSCI, same as default to 'Removed'")
 	}
 
 	switch serviceMeshManagementState {
@@ -42,16 +43,16 @@ func (r *DSCInitializationReconciler) configureServiceMesh(ctx context.Context, 
 		for _, capability := range capabilities {
 			capabilityErr := capability.Apply(ctx, r.Client)
 			if capabilityErr != nil {
-				r.Log.Error(capabilityErr, "failed applying service mesh resources")
+				log.Error(capabilityErr, "failed applying service mesh resources")
 				r.Recorder.Eventf(instance, corev1.EventTypeWarning, "DSCInitializationReconcileError", "failed applying service mesh resources")
 				return capabilityErr
 			}
 		}
 
 	case operatorv1.Unmanaged:
-		r.Log.Info("ServiceMesh CR is not configured by the operator, we won't do anything")
+		log.Info("ServiceMesh CR is not configured by the operator, we won't do anything")
 	case operatorv1.Removed:
-		r.Log.Info("existing ServiceMesh CR (owned by operator) will be removed")
+		log.Info("existing ServiceMesh CR (owned by operator) will be removed")
 		if err := r.removeServiceMesh(ctx, instance); err != nil {
 			return err
 		}
@@ -61,6 +62,7 @@ func (r *DSCInitializationReconciler) configureServiceMesh(ctx context.Context, 
 }
 
 func (r *DSCInitializationReconciler) removeServiceMesh(ctx context.Context, instance *dsciv1.DSCInitialization) error {
+	log := r.Log
 	// on condition of Managed, do not handle Removed when set to Removed it trigger DSCI reconcile to clean up
 	if instance.Spec.ServiceMesh == nil {
 		return nil
@@ -80,7 +82,7 @@ func (r *DSCInitializationReconciler) removeServiceMesh(ctx context.Context, ins
 		for _, capability := range capabilities {
 			capabilityErr := capability.Delete(ctx, r.Client)
 			if capabilityErr != nil {
-				r.Log.Error(capabilityErr, "failed deleting service mesh resources")
+				log.Error(capabilityErr, "failed deleting service mesh resources")
 				r.Recorder.Eventf(instance, corev1.EventTypeWarning, "DSCInitializationReconcileError", "failed deleting service mesh resources")
 
 				return capabilityErr

--- a/controllers/dscinitialization/utils.go
+++ b/controllers/dscinitialization/utils.go
@@ -37,6 +37,7 @@ var (
 // - Network Policies 'opendatahub' that allow traffic between the ODH namespaces
 // - RoleBinding 'opendatahub'.
 func (r *DSCInitializationReconciler) createOdhNamespace(ctx context.Context, dscInit *dsciv1.DSCInitialization, name string, platform cluster.Platform) error {
+	log := r.Log
 	// Expected application namespace for the given name
 	desiredNamespace := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
@@ -53,25 +54,25 @@ func (r *DSCInitializationReconciler) createOdhNamespace(ctx context.Context, ds
 	err := r.Get(ctx, client.ObjectKey{Name: name}, foundNamespace)
 	if err != nil {
 		if k8serr.IsNotFound(err) {
-			r.Log.Info("Creating namespace", "name", name)
+			log.Info("Creating namespace", "name", name)
 			// Set Controller reference
 			// err = ctrl.SetControllerReference(dscInit, desiredNamespace, r.Scheme)
 			// if err != nil {
-			//	 r.Log.Error(err, "Unable to add OwnerReference to the Namespace")
+			//	 log.Error(err, "Unable to add OwnerReference to the Namespace")
 			//	 return err
 			// }
 			err = r.Create(ctx, desiredNamespace)
 			if err != nil && !k8serr.IsAlreadyExists(err) {
-				r.Log.Error(err, "Unable to create namespace", "name", name)
+				log.Error(err, "Unable to create namespace", "name", name)
 				return err
 			}
 		} else {
-			r.Log.Error(err, "Unable to fetch namespace", "name", name)
+			log.Error(err, "Unable to fetch namespace", "name", name)
 			return err
 		}
 		// Patch Application Namespace if it exists
 	} else if dscInit.Spec.Monitoring.ManagementState == operatorv1.Managed {
-		r.Log.Info("Patching application namespace for Managed cluster", "name", name)
+		log.Info("Patching application namespace for Managed cluster", "name", name)
 		labelPatch := `{"metadata":{"labels":{"openshift.io/cluster-monitoring":"true","pod-security.kubernetes.io/enforce":"baseline","opendatahub.io/generated-namespace": "true"}}}`
 		err = r.Patch(ctx, foundNamespace, client.RawPatch(types.MergePatchType,
 			[]byte(labelPatch)))
@@ -86,7 +87,7 @@ func (r *DSCInitializationReconciler) createOdhNamespace(ctx context.Context, ds
 		err := r.Get(ctx, client.ObjectKey{Name: monitoringName}, foundMonitoringNamespace)
 		if err != nil {
 			if k8serr.IsNotFound(err) {
-				r.Log.Info("Not found monitoring namespace", "name", monitoringName)
+				log.Info("Not found monitoring namespace", "name", monitoringName)
 				desiredMonitoringNamespace := &corev1.Namespace{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: monitoringName,
@@ -99,15 +100,15 @@ func (r *DSCInitializationReconciler) createOdhNamespace(ctx context.Context, ds
 				}
 				err = r.Create(ctx, desiredMonitoringNamespace)
 				if err != nil && !k8serr.IsAlreadyExists(err) {
-					r.Log.Error(err, "Unable to create namespace", "name", monitoringName)
+					log.Error(err, "Unable to create namespace", "name", monitoringName)
 					return err
 				}
 			} else {
-				r.Log.Error(err, "Unable to fetch monitoring namespace", "name", monitoringName)
+				log.Error(err, "Unable to fetch monitoring namespace", "name", monitoringName)
 				return err
 			}
 		} else { // force to patch monitoring namespace with label for cluster-monitoring
-			r.Log.Info("Patching monitoring namespace", "name", monitoringName)
+			log.Info("Patching monitoring namespace", "name", monitoringName)
 			labelPatch := `{"metadata":{"labels":{"openshift.io/cluster-monitoring":"true", "pod-security.kubernetes.io/enforce":"baseline","opendatahub.io/generated-namespace": "true"}}}`
 
 			err = r.Patch(ctx, foundMonitoringNamespace, client.RawPatch(types.MergePatchType, []byte(labelPatch)))
@@ -120,27 +121,28 @@ func (r *DSCInitializationReconciler) createOdhNamespace(ctx context.Context, ds
 	// Create default NetworkPolicy for the namespace
 	err = r.reconcileDefaultNetworkPolicy(ctx, name, dscInit, platform)
 	if err != nil {
-		r.Log.Error(err, "error reconciling network policy ", "name", name)
+		log.Error(err, "error reconciling network policy ", "name", name)
 		return err
 	}
 
 	// Create odh-common-config Configmap for the Namespace
 	err = r.createOdhCommonConfigMap(ctx, name, dscInit)
 	if err != nil {
-		r.Log.Error(err, "error creating configmap", "name", "odh-common-config")
+		log.Error(err, "error creating configmap", "name", "odh-common-config")
 		return err
 	}
 
 	// Create default Rolebinding for the namespace
 	err = r.createDefaultRoleBinding(ctx, name, dscInit)
 	if err != nil {
-		r.Log.Error(err, "error creating rolebinding", "name", name)
+		log.Error(err, "error creating rolebinding", "name", name)
 		return err
 	}
 	return nil
 }
 
 func (r *DSCInitializationReconciler) createDefaultRoleBinding(ctx context.Context, name string, dscInit *dsciv1.DSCInitialization) error {
+	log := r.Log
 	// Expected namespace for the given name
 	desiredRoleBinding := &rbacv1.RoleBinding{
 		TypeMeta: metav1.TypeMeta{
@@ -176,7 +178,7 @@ func (r *DSCInitializationReconciler) createDefaultRoleBinding(ctx context.Conte
 			// Set Controller reference
 			err = ctrl.SetControllerReference(dscInit, desiredRoleBinding, r.Scheme)
 			if err != nil {
-				r.Log.Error(err, "Unable to add OwnerReference to the rolebinding")
+				log.Error(err, "Unable to add OwnerReference to the rolebinding")
 				return err
 			}
 			err = r.Client.Create(ctx, desiredRoleBinding)
@@ -191,23 +193,24 @@ func (r *DSCInitializationReconciler) createDefaultRoleBinding(ctx context.Conte
 }
 
 func (r *DSCInitializationReconciler) reconcileDefaultNetworkPolicy(ctx context.Context, name string, dscInit *dsciv1.DSCInitialization, platform cluster.Platform) error {
+	log := r.Log
 	if platform == cluster.ManagedRhods || platform == cluster.SelfManagedRhods {
 		// Deploy networkpolicy for operator namespace
 		err := deploy.DeployManifestsFromPath(ctx, r.Client, dscInit, networkpolicyPath+"/operator", "redhat-ods-operator", "networkpolicy", true)
 		if err != nil {
-			r.Log.Error(err, "error to set networkpolicy in operator namespace", "path", networkpolicyPath)
+			log.Error(err, "error to set networkpolicy in operator namespace", "path", networkpolicyPath)
 			return err
 		}
 		// Deploy networkpolicy for monitoring namespace
 		err = deploy.DeployManifestsFromPath(ctx, r.Client, dscInit, networkpolicyPath+"/monitoring", dscInit.Spec.Monitoring.Namespace, "networkpolicy", true)
 		if err != nil {
-			r.Log.Error(err, "error to set networkpolicy in monitroing namespace", "path", networkpolicyPath)
+			log.Error(err, "error to set networkpolicy in monitroing namespace", "path", networkpolicyPath)
 			return err
 		}
 		// Deploy networkpolicy for applications namespace
 		err = deploy.DeployManifestsFromPath(ctx, r.Client, dscInit, networkpolicyPath+"/applications", dscInit.Spec.ApplicationsNamespace, "networkpolicy", true)
 		if err != nil {
-			r.Log.Error(err, "error to set networkpolicy in applications namespace", "path", networkpolicyPath)
+			log.Error(err, "error to set networkpolicy in applications namespace", "path", networkpolicyPath)
 			return err
 		}
 	} else { // Expected namespace for the given name in ODH
@@ -292,7 +295,7 @@ func (r *DSCInitializationReconciler) reconcileDefaultNetworkPolicy(ctx context.
 				// Set Controller reference
 				err = ctrl.SetControllerReference(dscInit, desiredNetworkPolicy, r.Scheme)
 				if err != nil {
-					r.Log.Error(err, "Unable to add OwnerReference to the Network policy")
+					log.Error(err, "Unable to add OwnerReference to the Network policy")
 					return err
 				}
 				err = r.Client.Create(ctx, desiredNetworkPolicy)
@@ -307,7 +310,7 @@ func (r *DSCInitializationReconciler) reconcileDefaultNetworkPolicy(ctx context.
 
 		// Reconcile the NetworkPolicy spec if it has been manually modified
 		if !justCreated && !CompareNotebookNetworkPolicies(*desiredNetworkPolicy, *foundNetworkPolicy) {
-			r.Log.Info("Reconciling Network policy", "name", foundNetworkPolicy.Name)
+			log.Info("Reconciling Network policy", "name", foundNetworkPolicy.Name)
 			// Retry the update operation when the ingress controller eventually
 			// updates the resource version field
 			err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
@@ -324,7 +327,7 @@ func (r *DSCInitializationReconciler) reconcileDefaultNetworkPolicy(ctx context.
 				return r.Update(ctx, foundNetworkPolicy)
 			})
 			if err != nil {
-				r.Log.Error(err, "Unable to reconcile the Network Policy")
+				log.Error(err, "Unable to reconcile the Network Policy")
 				return err
 			}
 		}
@@ -372,6 +375,7 @@ func GenerateRandomHex(length int) ([]byte, error) {
 }
 
 func (r *DSCInitializationReconciler) createOdhCommonConfigMap(ctx context.Context, name string, dscInit *dsciv1.DSCInitialization) error {
+	log := r.Log
 	// Expected configmap for the given namespace
 	desiredConfigMap := &corev1.ConfigMap{
 		TypeMeta: metav1.TypeMeta{
@@ -396,7 +400,7 @@ func (r *DSCInitializationReconciler) createOdhCommonConfigMap(ctx context.Conte
 			// Set Controller reference
 			err = ctrl.SetControllerReference(dscInit, foundConfigMap, r.Scheme)
 			if err != nil {
-				r.Log.Error(err, "Unable to add OwnerReference to the odh-common-config ConfigMap")
+				log.Error(err, "Unable to add OwnerReference to the odh-common-config ConfigMap")
 				return err
 			}
 			err = r.Client.Create(ctx, desiredConfigMap)


### PR DESCRIPTION
Prepare to switch to dynamic logger. It can be k8s contextual logging [1] or some internal one. Copy reconciler's logger into local variables.

Just to avoid polluting the other patch with the replacements.

[1] https://www.kubernetes.dev/blog/2022/05/25/contextual-logging/

<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
