### PR TITLE
feat: skip create usergroups if group CRD does not exsit in cluster

### DIFF
--- a/controllers/dscinitialization/dscinitialization_controller.go
+++ b/controllers/dscinitialization/dscinitialization_controller.go
@@ -200,7 +200,7 @@ func (r *DSCInitializationReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	default:
 		switch platform {
 		case cluster.SelfManagedRhods:
-			err := r.createUserGroup(ctx, instance, "rhods-admins")
+			err := r.createUserGroup(ctx, instance, log, "rhods-admins")
 			if err != nil {
 				return reconcile.Result{}, err
 			}
@@ -232,7 +232,7 @@ func (r *DSCInitializationReconciler) Reconcile(ctx context.Context, req ctrl.Re
 				}
 			}
 		default:
-			err := r.createUserGroup(ctx, instance, "odh-admins")
+			err := r.createUserGroup(ctx, instance, log, "odh-admins")
 			if err != nil {
 				return reconcile.Result{}, err
 			}

--- a/pkg/cluster/roles.go
+++ b/pkg/cluster/roles.go
@@ -3,6 +3,7 @@ package cluster
 import (
 	"context"
 
+	userv1 "github.com/openshift/api/user/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -86,4 +87,17 @@ func DeleteClusterRoleBinding(ctx context.Context, cli client.Client, name strin
 	}
 
 	return cli.Delete(ctx, desiredClusterRoleBinding)
+}
+
+// Check if userGroup exists in the cluster.
+func CheckUserGroup(ctx context.Context, cli client.Client, userGroupName string, applicationsNamespace string) error {
+	userGroup := &userv1.Group{}
+	err := cli.Get(ctx, client.ObjectKey{
+		Name:      userGroupName,
+		Namespace: applicationsNamespace,
+	}, userGroup)
+	if err != nil {
+		return err
+	}
+	return nil
 }


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

- this will make operator work but dashboard etc which rely on it wont work if components are not disabled
Signed-off-by: Wen Zhou <wenzhou@redhat.com>


<!--- Link your JIRA and related links here for reference. -->
local build quay.io/wenzhou/opendatahub-operator-catalog:v2.14.1004

postivie case:
- test on the normal HCP and groups get created
negative case:
- when remove config/crd/external/user.openshift.io_groups.yaml and do "make unit-test" also work
- but will need to test it on HCP with external-auth-provider as well to see how it work  ====> TODO


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
