### PR TITLE
feat: option to disable create default userGroup on ODH and self-managed

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Additionally installing `Authorino operator` & `Service Mesh operator` enhances 
         sourceNamespace: openshift-marketplace
       EOF
       ```
-      If user would prefer skipping group "odh-admin" to be created by DSCI CR automatically, explicitly set env variable ODH_DISABLE_USERGROUP to "true". example:
+      If user would prefer skipping group "odh-admin" to be created by DSCI CR automatically, explicitly set env variable ODH_USE_EXTERNAL_AUTH to "true". example:
 
     ```console
       cat <<EOF | oc create -f -
@@ -82,7 +82,7 @@ Additionally installing `Authorino operator` & `Service Mesh operator` enhances 
         sourceNamespace: openshift-marketplace
         config:
           env:
-            - name: "ODH_DISABLE_USERGROUP"
+            - name: "ODH_USE_EXTERNAL_AUTH"
               value: "true"
       EOF
 

--- a/README.md
+++ b/README.md
@@ -66,6 +66,25 @@ Additionally installing `Authorino operator` & `Service Mesh operator` enhances 
         sourceNamespace: openshift-marketplace
       EOF
       ```
+      If user would prefer skipping group "odh-admin" to be created by DSCI CR automatically, explicitly set env variable ODH_DISABLE_USERGROUP to "true". example:
+
+    ```console
+      cat <<EOF | oc create -f -
+      apiVersion: operators.coreos.com/v1alpha1
+      kind: Subscription
+      metadata:
+        name: opendatahub-operator
+        namespace: openshift-operators
+      spec:
+        channel: fast
+        name: opendatahub-operator
+        source: community-operators
+        sourceNamespace: openshift-marketplace
+        config:
+          env:
+            - name: "ODH_DISABLE_USERGROUP"
+              value: "true"
+      EOF
 
   2. Create [DSCInitialization](#example-dscinitialization) CR manually.
     You can also use operator to create default DSCI CR by removing env variable DISABLE_DSC_CONFIG from CSV or changing the value to "false", followed by restarting the operator pod.

--- a/controllers/dscinitialization/dscinitialization_controller.go
+++ b/controllers/dscinitialization/dscinitialization_controller.go
@@ -202,8 +202,7 @@ func (r *DSCInitializationReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		switch platform {
 		case cluster.SelfManagedRhods:
 			// Check if user opted for disabling creating user groups
-			disableUserGroup, exist := os.LookupEnv("DISABLE_USERGROUP")
-			if exist && disableUserGroup != "false" {
+			if os.Getenv("ODH_DISABLE_USERGROUP") == "true" {
 				log.Info("DSCI disabled usergroup creation")
 			} else {
 				err := r.createUserGroup(ctx, instance, "rhods-admins")
@@ -240,8 +239,7 @@ func (r *DSCInitializationReconciler) Reconcile(ctx context.Context, req ctrl.Re
 			}
 		default:
 			// Check if user opted for disabling creating user groups
-			disableUserGroup, exist := os.LookupEnv("DISABLE_USERGROUP")
-			if exist && disableUserGroup != "false" {
+			if os.Getenv("ODH_DISABLE_USERGROUP") == "true" {
 				log.Info("DSCI disabled usergroup creation")
 			} else {
 				err := r.createUserGroup(ctx, instance, "odh-admins")

--- a/controllers/dscinitialization/dscinitialization_controller.go
+++ b/controllers/dscinitialization/dscinitialization_controller.go
@@ -202,7 +202,7 @@ func (r *DSCInitializationReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		switch platform {
 		case cluster.SelfManagedRhods:
 			// Check if user opted for disabling creating user groups
-			if os.Getenv("ODH_DISABLE_USERGROUP") == "true" {
+			if os.Getenv("ODH_USE_EXTERNAL_AUTH") == "true" {
 				log.Info("DSCI disabled usergroup creation")
 			} else {
 				err := r.createUserGroup(ctx, instance, "rhods-admins")
@@ -239,7 +239,7 @@ func (r *DSCInitializationReconciler) Reconcile(ctx context.Context, req ctrl.Re
 			}
 		default:
 			// Check if user opted for disabling creating user groups
-			if os.Getenv("ODH_DISABLE_USERGROUP") == "true" {
+			if os.Getenv("ODH_USE_EXTERNAL_AUTH") == "true" {
 				log.Info("DSCI disabled usergroup creation")
 			} else {
 				err := r.createUserGroup(ctx, instance, "odh-admins")

--- a/controllers/dscinitialization/dscinitialization_controller.go
+++ b/controllers/dscinitialization/dscinitialization_controller.go
@@ -19,6 +19,7 @@ package dscinitialization
 
 import (
 	"context"
+	"os"
 	"path/filepath"
 	"reflect"
 
@@ -200,9 +201,15 @@ func (r *DSCInitializationReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	default:
 		switch platform {
 		case cluster.SelfManagedRhods:
-			err := r.createUserGroup(ctx, instance, "rhods-admins")
-			if err != nil {
-				return reconcile.Result{}, err
+			// Check if user opted for disabling creating user groups
+			disableUserGroup, exist := os.LookupEnv("DISABLE_USERGROUP")
+			if exist && disableUserGroup != "false" {
+				log.Info("DSCI disabled usergroup creation")
+			} else {
+				err := r.createUserGroup(ctx, instance, "rhods-admins")
+				if err != nil {
+					return reconcile.Result{}, err
+				}
 			}
 			if instance.Spec.Monitoring.ManagementState == operatorv1.Managed {
 				log.Info("Monitoring enabled, won't apply changes", "cluster", "Self-Managed RHODS Mode")
@@ -232,9 +239,15 @@ func (r *DSCInitializationReconciler) Reconcile(ctx context.Context, req ctrl.Re
 				}
 			}
 		default:
-			err := r.createUserGroup(ctx, instance, "odh-admins")
-			if err != nil {
-				return reconcile.Result{}, err
+			// Check if user opted for disabling creating user groups
+			disableUserGroup, exist := os.LookupEnv("DISABLE_USERGROUP")
+			if exist && disableUserGroup != "false" {
+				log.Info("DSCI disabled usergroup creation")
+			} else {
+				err := r.createUserGroup(ctx, instance, "odh-admins")
+				if err != nil {
+					return reconcile.Result{}, err
+				}
 			}
 			if instance.Spec.Monitoring.ManagementState == operatorv1.Managed {
 				log.Info("Monitoring enabled, won't apply changes", "cluster", "ODH Mode")


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->
user env variable `ODH_USE_EXTERNAL_AUTH` to disable user group creation.
this works by manually create subscritpon and set value to "true"
by install operator from Operatorhub will still ,by default, to create group

(a different soltuion than https://github.com/opendatahub-io/opendatahub-operator/pull/1276)

<!--- Link your JIRA and related links here for reference. -->
https://issues.redhat.com/browse/RHOAIENG-14214

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- delete odh-admin group from cluster
- create 
```
apiVersion: operators.coreos.com/v1alpha1
kind: CatalogSource
metadata:
  name: rhoai-catalog-dev
  namespace: openshift-marketplace
spec:
  displayName: usergroup
  image: 'quay.io/wenzhou/opendatahub-operator-catalog:v2.14.1007'
  publisher: wen
  sourceType: grpc
```
and
```
apiVersion: operators.coreos.com/v1alpha1
kind: Subscription 
metadata:
  name: opendatahub-operator
  namespace: openshift-operators
spec:
  name: opendatahub-operator
  channel: fast
  source: rhoai-catalog-dev
  sourceNamespace: openshift-marketplace
  config:
     env:
      - name: "ODH_DISABLE_USERGROUP"
        value: "true"
```

- see operator installed
- manually create DSCI 
- check no group created afterwards 

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
