### PR TITLE
Makefile, config: add nowebhook installation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -227,6 +227,12 @@ deploy: prepare ## Deploy controller to the K8s cluster specified in ~/.kube/con
 undeploy: prepare ## Undeploy controller from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
 	$(KUSTOMIZE) build config/default | kubectl delete --ignore-not-found=$(ignore-not-found) -f -
 
+.PHONY: install-nowebhook uninstall-nowebhook
+install-nowebhook: prepare ## Install manifests without webhook configuration and operator deployment (for local run)
+	$(KUSTOMIZE) build config/nowebhook | kubectl apply --namespace $(OPERATOR_NAMESPACE) -f -
+uninstall-nowebhook: prepare ## Uninstall manifests deployed by install-nowebhook
+	$(KUSTOMIZE) build config/nowebhook | kubectl delete --ignore-not-found=$(ignore-not-found) -f -
+
 ## Location to install dependencies to
 LOCALBIN ?= $(shell pwd)/bin
 $(LOCALBIN):

--- a/config/nowebhook/kustomization.yaml
+++ b/config/nowebhook/kustomization.yaml
@@ -1,0 +1,26 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../default
+
+patches:
+  - patch: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: controller-manager
+        namespace: system
+      $patch: delete
+  - patch: |-
+      apiVersion: admissionregistration.k8s.io/v1
+      kind: MutatingWebhookConfiguration
+      metadata:
+        name: mutating-webhook-configuration
+      $patch: delete
+  - patch: |-
+      apiVersion: admissionregistration.k8s.io/v1
+      kind: ValidatingWebhookConfiguration
+      metadata:
+        name: validating-webhook-configuration
+      $patch: delete


### PR DESCRIPTION
Add nowebhoook kustomize configuration which creates manifests without webhook configurations and operator deployment to allow run the operator locally.

Add makefile targets install-nowebhook/uninstall-nowebhook to deploy that configuration in the cluster. Call it "install" since it does not deploy the operator, just manifests to make it runable.

It makes it possible to use `make run` locally if webhook configuration removed from main.go. More patches are coming to make it automatic.

<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
