### PR TITLE
logger, controllers: use common logging level, INFO by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,17 +224,12 @@ This will ensure that the doc for the apis are updated accordingly.
 
 #### Controller level
 
-Logger on all controllers can only be changed from CSV with parameters: --log-mode devel
-valid value: "" (as default) || prod || production || devel || development
+Global logger configuration can be changed with a command line switch `--log-mode <mode>`
+for example from CSV. Valid values for `<mode>`: "" (as default) || prod || production || devel || development.
 
-This mainly impacts logging for operator pod startup, generating common resource, monitoring deployment.
-
-| --log-mode value | mapping Log level   | Comments       |
-| ---------------- | ------------------- | -------------- |
-| devel            | debug  / 0          | lowest level   |
-| ""               | info / 1            | default option |
-| default          | info / 1            | default option |
-| prod             | error / 2           | highest level  |
+Verbosity level is INFO.
+To fine tune zap backend [standard operator sdk zap switches](https://sdk.operatorframework.io/docs/building-operators/golang/references/logging/)
+can be used.
 
 #### Component level
 

--- a/main.go
+++ b/main.go
@@ -239,7 +239,7 @@ func main() { //nolint:funlen,maintidx
 	if err = (&dscictrl.DSCInitializationReconciler{
 		Client:                mgr.GetClient(),
 		Scheme:                mgr.GetScheme(),
-		Log:                   logger.LogWithLevel(ctrl.Log.WithName(operatorName).WithName("controllers").WithName("DSCInitialization"), logmode),
+		Log:                   ctrl.Log.WithName(operatorName).WithName("controllers").WithName("DSCInitialization"),
 		Recorder:              mgr.GetEventRecorderFor("dscinitialization-controller"),
 		ApplicationsNamespace: dscApplicationsNamespace,
 	}).SetupWithManager(ctx, mgr); err != nil {
@@ -250,7 +250,7 @@ func main() { //nolint:funlen,maintidx
 	if err = (&dscctrl.DataScienceClusterReconciler{
 		Client: mgr.GetClient(),
 		Scheme: mgr.GetScheme(),
-		Log:    logger.LogWithLevel(ctrl.Log.WithName(operatorName).WithName("controllers").WithName("DataScienceCluster"), logmode),
+		Log:    ctrl.Log.WithName(operatorName).WithName("controllers").WithName("DataScienceCluster"),
 		DataScienceCluster: &dscctrl.DataScienceClusterConfig{
 			DSCISpec: &dsciv1.DSCInitializationSpec{
 				ApplicationsNamespace: dscApplicationsNamespace,
@@ -265,7 +265,7 @@ func main() { //nolint:funlen,maintidx
 	if err = (&secretgenerator.SecretGeneratorReconciler{
 		Client: mgr.GetClient(),
 		Scheme: mgr.GetScheme(),
-		Log:    logger.LogWithLevel(ctrl.Log.WithName(operatorName).WithName("controllers").WithName("SecretGenerator"), logmode),
+		Log:    ctrl.Log.WithName(operatorName).WithName("controllers").WithName("SecretGenerator"),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "SecretGenerator")
 		os.Exit(1)
@@ -274,7 +274,7 @@ func main() { //nolint:funlen,maintidx
 	if err = (&certconfigmapgenerator.CertConfigmapGeneratorReconciler{
 		Client: mgr.GetClient(),
 		Scheme: mgr.GetScheme(),
-		Log:    logger.LogWithLevel(ctrl.Log.WithName(operatorName).WithName("controllers").WithName("CertConfigmapGenerator"), logmode),
+		Log:    ctrl.Log.WithName(operatorName).WithName("controllers").WithName("CertConfigmapGenerator"),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "CertConfigmapGenerator")
 		os.Exit(1)

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -3,18 +3,11 @@ package logger
 import (
 	"flag"
 	"os"
-	"strings"
 
 	"github.com/go-logr/logr"
 	"go.uber.org/zap/zapcore"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
-
-var logLevelMapping = map[string]int{
-	"devel":   0,
-	"default": 1, // default one when not set log-mode
-	"prod":    2,
-}
 
 // NewNamedLogger creates a new logger for a component.
 // If the mode is set (so can be different from the default one),
@@ -24,16 +17,6 @@ func NewNamedLogger(log logr.Logger, name string, mode string) logr.Logger {
 		log = NewLogger(mode)
 	}
 	return log.WithName(name)
-}
-
-// in each controller, to use different log level.
-func LogWithLevel(logger logr.Logger, level string) logr.Logger {
-	level = strings.TrimSpace(level)
-	verbosityLevel, ok := logLevelMapping[level]
-	if !ok {
-		verbosityLevel = 1 // fallback to info level
-	}
-	return logger.V(verbosityLevel)
 }
 
 func NewLoggerWithOptions(mode string, override *zap.Options) logr.Logger {


### PR DESCRIPTION
Remove increasing logging level for controllers (it was also passed to components if not overridden from DSCI) since:

- it made logging inconsistent. The base contoller runtime logger is set up with INFO level for all log modes, so when controllers are configured for Error level, user sees INFO messages from both controller-runtime and other parts of operator which use controller-runtime's logger directly;

- since the base logger is configured for INFO, there is no difference in levels between "default" and "devel". Having levels 1 and 2 there is misleading.

Update documentation.

This patch changes default logging, former filtered Info messages are displayed now.

There is no _big_ difference in practice since currently the log is anyway full of info messages from parts which do not use reconciler's logger, like:

{"level":"info","ts":"2024-10-09T13:23:11Z","msg":"waiting for 1 deployment to be ready for dashboard"}

<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
