### PR TITLE
feat: Operator disable create usergroup if detect user enabled external auth

### DIFF
--- a/bundle/manifests/opendatahub-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/opendatahub-operator.clusterserviceversion.yaml
@@ -357,6 +357,7 @@ spec:
         - apiGroups:
           - config.openshift.io
           resources:
+          - authentications
           - clusterversions
           verbs:
           - get

--- a/config/crd/external/config.openshift.io_authentications.yaml
+++ b/config/crd/external/config.openshift.io_authentications.yaml
@@ -1,0 +1,175 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.1
+  name: authentications.config.openshift.io
+spec:
+  group: config.openshift.io
+  names:
+    kind: Authentication
+    listKind: AuthenticationList
+    plural: authentications
+    singular: authentication
+  scope: Cluster
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          Authentication specifies cluster-wide settings for authentication (like OAuth and
+          webhook token authenticators). The canonical name of an instance is `cluster`.
+
+          Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec holds user settable values for configuration
+            properties:
+              oauthMetadata:
+                description: |-
+                  oauthMetadata contains the discovery endpoint data for OAuth 2.0
+                  Authorization Server Metadata for an external OAuth server.
+                  This discovery document can be viewed from its served location:
+                  oc get --raw '/.well-known/oauth-authorization-server'
+                  For further details, see the IETF Draft:
+                  https://tools.ietf.org/html/draft-ietf-oauth-discovery-04#section-2
+                  If oauthMetadata.name is non-empty, this value has precedence
+                  over any metadata reference stored in status.
+                  The key "oauthMetadata" is used to locate the data.
+                  If specified and the config map or expected key is not found, no metadata is served.
+                  If the specified metadata is not valid, no metadata is served.
+                  The namespace for this config map is openshift-config.
+                properties:
+                  name:
+                    description: name is the metadata.name of the referenced config
+                      map
+                    type: string
+                required:
+                - name
+                type: object
+              serviceAccountIssuer:
+                description: |-
+                  serviceAccountIssuer is the identifier of the bound service account token
+                  issuer.
+                  The default is https://kubernetes.default.svc
+                  WARNING: Updating this field will not result in immediate invalidation of all bound tokens with the
+                  previous issuer value. Instead, the tokens issued by previous service account issuer will continue to
+                  be trusted for a time period chosen by the platform (currently set to 24h).
+                  This time period is subject to change over time.
+                  This allows internal components to transition to use new service account issuer without service distruption.
+                type: string
+              type:
+                description: |-
+                  type identifies the cluster managed, user facing authentication mode in use.
+                  Specifically, it manages the component that responds to login attempts.
+                  The default is IntegratedOAuth.
+                type: string
+              webhookTokenAuthenticator:
+                description: |-
+                  webhookTokenAuthenticator configures a remote token reviewer.
+                  These remote authentication webhooks can be used to verify bearer tokens
+                  via the tokenreviews.authentication.k8s.io REST API. This is required to
+                  honor bearer tokens that are provisioned by an external authentication service.
+                properties:
+                  kubeConfig:
+                    description: |-
+                      kubeConfig references a secret that contains kube config file data which
+                      describes how to access the remote webhook service.
+                      The namespace for the referenced secret is openshift-config.
+
+                      For further details, see:
+
+                      https://kubernetes.io/docs/reference/access-authn-authz/authentication/#webhook-token-authentication
+
+                      The key "kubeConfig" is used to locate the data.
+                      If the secret or expected key is not found, the webhook is not honored.
+                      If the specified kube config data is not valid, the webhook is not honored.
+                    properties:
+                      name:
+                        description: name is the metadata.name of the referenced secret
+                        type: string
+                    required:
+                    - name
+                    type: object
+                required:
+                - kubeConfig
+                type: object
+              webhookTokenAuthenticators:
+                description: webhookTokenAuthenticators is DEPRECATED, setting it
+                  has no effect.
+                items:
+                  description: |-
+                    deprecatedWebhookTokenAuthenticator holds the necessary configuration options for a remote token authenticator.
+                    It's the same as WebhookTokenAuthenticator but it's missing the 'required' validation on KubeConfig field.
+                  properties:
+                    kubeConfig:
+                      description: |-
+                        kubeConfig contains kube config file data which describes how to access the remote webhook service.
+                        For further details, see:
+                        https://kubernetes.io/docs/reference/access-authn-authz/authentication/#webhook-token-authentication
+                        The key "kubeConfig" is used to locate the data.
+                        If the secret or expected key is not found, the webhook is not honored.
+                        If the specified kube config data is not valid, the webhook is not honored.
+                        The namespace for this secret is determined by the point of use.
+                      properties:
+                        name:
+                          description: name is the metadata.name of the referenced
+                            secret
+                          type: string
+                      required:
+                      - name
+                      type: object
+                  type: object
+                type: array
+            type: object
+          status:
+            description: status holds observed values from the cluster. They may not
+              be overridden.
+            properties:
+              integratedOAuthMetadata:
+                description: |-
+                  integratedOAuthMetadata contains the discovery endpoint data for OAuth 2.0
+                  Authorization Server Metadata for the in-cluster integrated OAuth server.
+                  This discovery document can be viewed from its served location:
+                  oc get --raw '/.well-known/oauth-authorization-server'
+                  For further details, see the IETF Draft:
+                  https://tools.ietf.org/html/draft-ietf-oauth-discovery-04#section-2
+                  This contains the observed value based on cluster state.
+                  An explicitly set value in spec.oauthMetadata has precedence over this field.
+                  This field has no meaning if authentication spec.type is not set to IntegratedOAuth.
+                  The key "oauthMetadata" is used to locate the data.
+                  If the config map or expected key is not found, no metadata is served.
+                  If the specified metadata is not valid, no metadata is served.
+                  The namespace for this config map is openshift-config-managed.
+                properties:
+                  name:
+                    description: name is the metadata.name of the referenced config
+                      map
+                    type: string
+                required:
+                - name
+                type: object
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -171,6 +171,7 @@ rules:
 - apiGroups:
   - config.openshift.io
   resources:
+  - authentications
   - clusterversions
   verbs:
   - get

--- a/controllers/dscinitialization/dscinitialization_controller.go
+++ b/controllers/dscinitialization/dscinitialization_controller.go
@@ -215,10 +215,8 @@ func (r *DSCInitializationReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		return ctrl.Result{}, nil
 	default:
 		createUsergroup, err := cluster.IsDefaultAuthMethod(ctx, r.Client)
-		if err != nil {
-			if !k8serr.IsNotFound(err) { // only keep reconcile if real error but not missing CRD or missing CR
-				return ctrl.Result{}, err
-			}
+		if err != nil && !k8serr.IsNotFound(err) { // only keep reconcile if real error but not missing CRD or missing CR
+			return ctrl.Result{}, err
 		}
 
 		switch platform {

--- a/controllers/dscinitialization/dscinitialization_test.go
+++ b/controllers/dscinitialization/dscinitialization_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	operatorv1 "github.com/openshift/api/operator/v1"
+	userv1 "github.com/openshift/api/user/v1"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -21,6 +22,7 @@ const (
 	workingNamespace     = "test-operator-ns"
 	applicationName      = "default-dsci"
 	applicationNamespace = "test-application-ns"
+	usergroupName        = "odh-admins"
 	configmapName        = "odh-common-config"
 	monitoringNamespace  = "test-monitoring-ns"
 	readyPhase           = "Ready"
@@ -109,6 +111,14 @@ var _ = Describe("DataScienceCluster initialization", func() {
 			Expect(foundConfigMap.Data).To(Equal(expectedConfigmapData))
 		})
 
+		It("Should not create user group when we do not have authentications CR in the cluster", func(ctx context.Context) {
+			userGroup := &userv1.Group{}
+			Eventually(objectExists(usergroupName, "", userGroup)).
+				WithContext(ctx).
+				WithTimeout(timeout).
+				WithPolling(interval).
+				Should(BeFalse())
+		})
 	})
 
 	Context("Monitoring Resource", func() {
@@ -341,9 +351,9 @@ func namespaceExists(ns string, obj client.Object) func(ctx context.Context) boo
 	}
 }
 
-func objectExists(ns string, name string, obj client.Object) func(ctx context.Context) bool { //nolint:unparam
+func objectExists(name string, namespace string, obj client.Object) func(ctx context.Context) bool {
 	return func(ctx context.Context) bool {
-		err := k8sClient.Get(ctx, client.ObjectKey{Name: ns, Namespace: name}, obj)
+		err := k8sClient.Get(ctx, client.ObjectKey{Name: name, Namespace: namespace}, obj)
 
 		return err == nil
 	}

--- a/controllers/dscinitialization/suite_test.go
+++ b/controllers/dscinitialization/suite_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 	"time"
 
+	configv1 "github.com/openshift/api/config/v1"
 	routev1 "github.com/openshift/api/route/v1"
 	userv1 "github.com/openshift/api/user/v1"
 	ofapi "github.com/operator-framework/api/pkg/operators/v1alpha1"
@@ -116,6 +117,7 @@ var _ = BeforeSuite(func() {
 	utilruntime.Must(routev1.Install(testScheme))
 	utilruntime.Must(userv1.Install(testScheme))
 	utilruntime.Must(monitoringv1.AddToScheme(testScheme))
+	utilruntime.Must(configv1.Install(testScheme))
 	// +kubebuilder:scaffold:scheme
 
 	k8sClient, err = client.New(cfg, client.Options{Scheme: testScheme})

--- a/main.go
+++ b/main.go
@@ -204,7 +204,7 @@ func main() { //nolint:funlen,maintidx
 			},
 			// For authentication CR "cluster"
 			&configv1.Authentication{}: {
-				Field: fields.Set{"metadata.name": "cluster"}.AsSelector(),
+				Field: fields.Set{"metadata.name": cluster.ClusterAuthenticationObj}.AsSelector(),
 			},
 			// for prometheus and black-box deployment and ones we owns
 			&appsv1.Deployment{}: {Namespaces: deploymentCache},

--- a/main.go
+++ b/main.go
@@ -25,6 +25,7 @@ import (
 	addonv1alpha1 "github.com/openshift/addon-operator/apis/addons/v1alpha1"
 	ocappsv1 "github.com/openshift/api/apps/v1" //nolint:importas //reason: conflicts with appsv1 "k8s.io/api/apps/v1"
 	buildv1 "github.com/openshift/api/build/v1"
+	configv1 "github.com/openshift/api/config/v1"
 	imagev1 "github.com/openshift/api/image/v1"
 	oauthv1 "github.com/openshift/api/oauth/v1"
 	operatorv1 "github.com/openshift/api/operator/v1"
@@ -200,6 +201,10 @@ func main() { //nolint:funlen,maintidx
 			// For domain to get OpenshiftIngress and default cert
 			&operatorv1.IngressController{}: {
 				Field: fields.Set{"metadata.name": "default"}.AsSelector(),
+			},
+			// For authentication CR "cluster"
+			&configv1.Authentication{}: {
+				Field: fields.Set{"metadata.name": "cluster"}.AsSelector(),
 			},
 			// for prometheus and black-box deployment and ones we owns
 			&appsv1.Deployment{}: {Namespaces: deploymentCache},

--- a/pkg/cluster/cluster_config.go
+++ b/pkg/cluster/cluster_config.go
@@ -231,9 +231,9 @@ func getRelease(ctx context.Context, cli client.Client) (Release, error) {
 // This will give indication that Operator should create userGroups or not in the cluster.
 func IsDefaultAuthMethod(ctx context.Context, cli client.Client) (bool, error) {
 	authenticationobj := &configv1.Authentication{}
-	if err := cli.Get(ctx, client.ObjectKey{Name: "cluster", Namespace: ""}, authenticationobj); err != nil {
+	if err := cli.Get(ctx, client.ObjectKey{Name: ClusterAuthenticationObj, Namespace: ""}, authenticationobj); err != nil {
 		if errors.Is(err, &meta.NoKindMatchError{}) { // when CRD is missing, conver error type
-			return false, k8serr.NewNotFound(configv1.Resource("authentications"), "cluster")
+			return false, k8serr.NewNotFound(configv1.Resource("authentications"), ClusterAuthenticationObj)
 		}
 		return false, err
 	}

--- a/pkg/cluster/cluster_config.go
+++ b/pkg/cluster/cluster_config.go
@@ -241,5 +241,5 @@ func IsDefaultAuthMethod(ctx context.Context, cli client.Client) (bool, error) {
 	// for now, HPC support "" "None" "IntegratedOAuth"(default) "OIDC"
 	// other offering support "" "None" "IntegratedOAuth"(default)
 	// we only create userGroups for "IntegratedOAuth" or "" and leave other or new supported type value in the future
-	return (authenticationobj.Spec.Type == configv1.AuthenticationTypeIntegratedOAuth || authenticationobj.Spec.Type == ""), nil
+	return authenticationobj.Spec.Type == configv1.AuthenticationTypeIntegratedOAuth || authenticationobj.Spec.Type == "", nil
 }

--- a/pkg/cluster/const.go
+++ b/pkg/cluster/const.go
@@ -12,4 +12,7 @@ const (
 
 	// DefaultNotebooksNamespace defines default namespace for notebooks.
 	DefaultNotebooksNamespace = "rhods-notebooks"
+
+	// Default cluster-scope Authentication CR name.
+	ClusterAuthenticationObj = "cluster"
 )


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->
feat: Operator disable create usergroup if detect users enabled external auth
 - user internal Authentication CR Type indicate if Operator should create or not
 -  only grant "get, watch , list" as least permission
 - remove duplicated rbac for "ingress"
 - add object into cache 
(a different soltuion than https://github.com/opendatahub-io/opendatahub-operator/pull/1278)

<!--- Link your JIRA and related links here for reference. -->
https://issues.redhat.com/browse/RHOAIENG-14214

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
local build: quay.io/wenzhou/opendatahub-operator-catalog:v2.14214.8
1.

- on a clean cluster, without `odh-admins` group, create

```
apiVersion: operators.coreos.com/v1alpha1
kind: Subscription
metadata:
  name: opendatahub-operator
  namespace: openshift-operators
spec:
  channel: fast
  name: usergroup
  source: usergroup
  sourceNamespace: openshift-marketplace
  InstallPlanApproval: Manaual
---
apiVersion: operators.coreos.com/v1alpha1
kind: CatalogSource
metadata:
  name: usergroup
  namespace: openshift-marketplace
spec:
  displayName: usergroup
  image: 'quay.io/wenzhou/opendatahub-operator-catalog:v2.14214.8'
  publisher: wen
  sourceType: grpc
```

- check Auth CR cluster has type set to ""
- create DSCI CR
- check `odh-admins` group created

2.

- manually update Auth CR to set "IntegratedOAuth" as Type
- delete `odh-admins` group
- restart Operator pod
- `odh-admins` group created

3.
test on a cluster with external-auth setup
- check Auth CR cluster has type set to "OIDC"
- check no `odh-admins` group and cannot see Group form UI (user management)
- install Opreator
- create DSCI without servicemesh enabled
- no user group created


## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
