### PR TITLE
feat: add default managementstate to only ModelReg if it was not set in DSC CR

### DIFF
--- a/bundle/manifests/datasciencecluster.opendatahub.io_datascienceclusters.yaml
+++ b/bundle/manifests/datasciencecluster.opendatahub.io_datascienceclusters.yaml
@@ -399,6 +399,8 @@ spec:
                         type: string
                     type: object
                   modelregistry:
+                    default:
+                      ManagementState: Removed
                     description: ModelRegistry component configuration.
                     properties:
                       devFlags:

--- a/bundle/manifests/datasciencecluster.opendatahub.io_datascienceclusters.yaml
+++ b/bundle/manifests/datasciencecluster.opendatahub.io_datascienceclusters.yaml
@@ -399,8 +399,6 @@ spec:
                         type: string
                     type: object
                   modelregistry:
-                    default:
-                      ManagementState: Removed
                     description: ModelRegistry component configuration.
                     properties:
                       devFlags:
@@ -432,6 +430,7 @@ spec:
                             type: array
                         type: object
                       managementState:
+                        default: Removed
                         description: |-
                           Set to one of the following values:
 

--- a/components/modelregistry/modelregistry.go
+++ b/components/modelregistry/modelregistry.go
@@ -44,15 +44,16 @@ var _ components.ComponentInterface = (*ModelRegistry)(nil)
 
 // ModelRegistry struct holds the configuration for the ModelRegistry component.
 // The property `registriesNamespace` is immutable when `managementState` is `Managed`
-// if managementstate is omitted to show in existing DSC CR(upgrade case) even treated as removed, this will default to "Removed" in .spec.components
 
 // +kubebuilder:object:generate=true
 // +kubebuilder:validation:XValidation:rule="(self.managementState != 'Managed') || (oldSelf.registriesNamespace == '') || (oldSelf.managementState != 'Managed')|| (self.registriesNamespace == oldSelf.registriesNamespace)",message="RegistriesNamespace is immutable when model registry is Managed"
 //nolint:lll
 
 type ModelRegistry struct {
-	// +kubebuilder:default={"ManagementState": "Removed"}
 	components.Component `json:""`
+	// if managementstate is omitted to show in existing DSC CR(upgrade case) even treated as removed, this will default to "Removed" in .spec.components
+	// +kubebuilder:default="Removed"
+	ManagementState operatorv1.ManagementState `json:"managementState,omitempty"`
 
 	// Namespace for model registries to be installed, configurable only once when model registry is enabled, defaults to "odh-model-registries"
 	// +kubebuilder:default="odh-model-registries"

--- a/components/modelregistry/modelregistry.go
+++ b/components/modelregistry/modelregistry.go
@@ -44,12 +44,14 @@ var _ components.ComponentInterface = (*ModelRegistry)(nil)
 
 // ModelRegistry struct holds the configuration for the ModelRegistry component.
 // The property `registriesNamespace` is immutable when `managementState` is `Managed`
+// if managementstate is omitted to show in existing DSC CR(upgrade case) even treated as removed, this will default to "Removed" in .spec.components
 
 // +kubebuilder:object:generate=true
 // +kubebuilder:validation:XValidation:rule="(self.managementState != 'Managed') || (oldSelf.registriesNamespace == '') || (oldSelf.managementState != 'Managed')|| (self.registriesNamespace == oldSelf.registriesNamespace)",message="RegistriesNamespace is immutable when model registry is Managed"
 //nolint:lll
 
 type ModelRegistry struct {
+	// +kubebuilder:default={"ManagementState": "Removed"}
 	components.Component `json:""`
 
 	// Namespace for model registries to be installed, configurable only once when model registry is enabled, defaults to "odh-model-registries"

--- a/config/crd/bases/datasciencecluster.opendatahub.io_datascienceclusters.yaml
+++ b/config/crd/bases/datasciencecluster.opendatahub.io_datascienceclusters.yaml
@@ -399,6 +399,8 @@ spec:
                         type: string
                     type: object
                   modelregistry:
+                    default:
+                      ManagementState: Removed
                     description: ModelRegistry component configuration.
                     properties:
                       devFlags:

--- a/config/crd/bases/datasciencecluster.opendatahub.io_datascienceclusters.yaml
+++ b/config/crd/bases/datasciencecluster.opendatahub.io_datascienceclusters.yaml
@@ -399,8 +399,6 @@ spec:
                         type: string
                     type: object
                   modelregistry:
-                    default:
-                      ManagementState: Removed
                     description: ModelRegistry component configuration.
                     properties:
                       devFlags:
@@ -432,6 +430,7 @@ spec:
                             type: array
                         type: object
                       managementState:
+                        default: Removed
                         description: |-
                           Set to one of the following values:
 

--- a/docs/api-overview.md
+++ b/docs/api-overview.md
@@ -250,7 +250,7 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `Component` _[Component](#component)_ |  |  |  |
+| `Component` _[Component](#component)_ |  | \{ ManagementState:Removed \} |  |
 | `registriesNamespace` _string_ | Namespace for model registries to be installed, configurable only once when model registry is enabled, defaults to "odh-model-registries" | odh-model-registries | MaxLength: 63 <br />Pattern: `^([a-z0-9]([-a-z0-9]*[a-z0-9])?)?$` <br /> |
 
 

--- a/docs/api-overview.md
+++ b/docs/api-overview.md
@@ -250,7 +250,8 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `Component` _[Component](#component)_ |  | \{ ManagementState:Removed \} |  |
+| `Component` _[Component](#component)_ |  |  |  |
+| `managementState` _[ManagementState](#managementstate)_ | if managementstate is omitted to show in existing DSC CR(upgrade case) even treated as removed, this will default to "Removed" in .spec.components | Removed |  |
 | `registriesNamespace` _string_ | Namespace for model registries to be installed, configurable only once when model registry is enabled, defaults to "odh-model-registries" | odh-model-registries | MaxLength: 63 <br />Pattern: `^([a-z0-9]([-a-z0-9]*[a-z0-9])?)?$` <br /> |
 
 


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->
- for upgrade case if DSC CR does not have MR component, with this change it will show as Removed
- keep other components as-is (do not set Removed if upgrade from very old release to new one which has components)


<!--- Link your JIRA and related links here for reference. -->
https://issues.redhat.com/browse/RHOAIENG-14194 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
