### PR TITLE
fix: to make the unset env variable in CSV work with fallback

### DIFF
--- a/pkg/cluster/cluster_config.go
+++ b/pkg/cluster/cluster_config.go
@@ -173,13 +173,14 @@ func detectManagedRHODS(ctx context.Context, cli client.Client) (Platform, error
 
 func getPlatform(ctx context.Context, cli client.Client) (Platform, error) {
 	switch os.Getenv("ODH_PLATFORM_TYPE") {
-	case "OpenDataHub", "":
+	case "OpenDataHub":
 		return OpenDataHub, nil
 	case "ManagedRHOAI":
 		return ManagedRhods, nil
 	case "SelfManagedRHOAI":
 		return SelfManagedRhods, nil
-	default: // fall back to detect platform if ODH_PLATFORM_TYPE env is not provided
+	default:
+		// fall back to detect platform if ODH_PLATFORM_TYPE env is not provided in CSV or set to ""
 		if platform, err := detectManagedRHODS(ctx, cli); err != nil {
 			return Unknown, err
 		} else if platform == ManagedRhods {


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->
- previous code, will run into "opendathaub" case if env is not set
- change make in both "not set" and "set to empty string" fall back to old logic with auto detection

related to change from  https://github.com/opendatahub-io/opendatahub-operator/pull/1252
<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
