### PR TITLE
secret-generator controller: avoid reporting 'Secret not found' error in reconcile

### DIFF
--- a/controllers/secretgenerator/secretgenerator_controller_test.go
+++ b/controllers/secretgenerator/secretgenerator_controller_test.go
@@ -5,8 +5,10 @@ import (
 	"testing"
 
 	"github.com/onsi/gomega/gstruct"
+	oauthv1 "github.com/openshift/api/oauth/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -26,6 +28,7 @@ func newFakeClient(objs ...client.Object) client.Client {
 	scheme := runtime.NewScheme()
 	utilruntime.Must(corev1.AddToScheme(scheme))
 	utilruntime.Must(appsv1.AddToScheme(scheme))
+	utilruntime.Must(oauthv1.AddToScheme(scheme))
 
 	return fake.NewClientBuilder().
 		WithScheme(scheme).
@@ -151,4 +154,93 @@ func TestExistingSecret(t *testing.T) {
 	g.Expect(generatedSecret.OwnerReferences).To(BeEmpty())
 	g.Expect(generatedSecret.Labels).To(BeEmpty())
 	g.Expect(generatedSecret.StringData).To(BeEmpty())
+}
+
+func TestSecretNotFound(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+
+	secretName := "fooo"
+	secretNs := "foooNs"
+
+	cli := newFakeClient()
+
+	r := secretgenerator.SecretGeneratorReconciler{
+		Client: cli,
+	}
+
+	_, err := r.Reconcile(ctx, reconcile.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      secretName,
+			Namespace: secretNs,
+		},
+	})
+	// secret not found, reconcile should end without error
+	g.Expect(err).ShouldNot(HaveOccurred())
+}
+
+func TestDeleteOAuthClientIfSecretNotFound(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+
+	secretName := "fooo"
+	secretNs := "foooNs"
+
+	// secret expected to be deleted
+	existingSecret := corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      secretName,
+			Namespace: secretNs,
+			Labels: map[string]string{
+				"fooo": "bar",
+			},
+			Annotations: map[string]string{
+				annotations.SecretNameAnnotation: "bar",
+				annotations.SecretTypeAnnotation: "random",
+			},
+		},
+	}
+
+	// future left-over oauth client to be cleaned up during reconcile
+	existingOauthClient := oauthv1.OAuthClient{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "OAuthClient",
+			APIVersion: "oauth.openshift.io/v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      secretName,
+			Namespace: secretNs,
+		},
+		Secret:       secretName,
+		RedirectURIs: []string{"https://foo.bar"},
+		GrantMethod:  oauthv1.GrantHandlerAuto,
+	}
+
+	cli := newFakeClient(&existingSecret, &existingOauthClient)
+
+	r := secretgenerator.SecretGeneratorReconciler{
+		Client: cli,
+	}
+
+	// delete secret
+	err := cli.Delete(ctx, &existingSecret)
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	// ensure the secret is deleted
+	err = cli.Get(ctx, client.ObjectKeyFromObject(&existingSecret), &existingSecret)
+	g.Expect(err).To(MatchError(k8serr.IsNotFound, "NotFound"))
+
+	_, err = r.Reconcile(ctx, reconcile.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      secretName,
+			Namespace: secretNs,
+		},
+	})
+	// secret not found, reconcile should clean-up left-over oauth client and end without error
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	// ensure the leftover OauthClient was deleted during reconcile
+	foundOauthClient := oauthv1.OAuthClient{}
+	err = cli.Get(ctx, client.ObjectKeyFromObject(&existingOauthClient), &foundOauthClient)
+	g.Expect(err).To(MatchError(k8serr.IsNotFound, "NotFound"))
 }


### PR DESCRIPTION
## Description
Previously, if the secret was not found, an error would be reported, despite the fact that the secret would be created later during reconcile.
The change in this PR intends to avoid reporting that 'Secret not found' error case

JIRA reference: [RHOAIENG-14189](https://issues.redhat.com/browse/RHOAIENG-14189)

## How Has This Been Tested?

## Screenshot or short clip

## Merge criteria

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
