### PR TITLE
use appsdomain if set in ingress.config

### DIFF
--- a/pkg/cluster/cluster_config.go
+++ b/pkg/cluster/cluster_config.go
@@ -87,6 +87,11 @@ func GetDomain(ctx context.Context, c client.Client) (string, error) {
 		return "", fmt.Errorf("failed fetching cluster's ingress details: %w", err)
 	}
 
+	appsDomain, found, err := unstructured.NestedString(ingress.Object, "spec", "appsDomain")
+	if found && len(appsDomain) > 0 {
+		return appsDomain, err
+	}
+
 	domain, found, err := unstructured.NestedString(ingress.Object, "spec", "domain")
 	if !found {
 		return "", errors.New("spec.domain not found")


### PR DESCRIPTION
## Description

For installations of RHOSP onprem, users can configure ingress to custom domain - [appsdomain](https://docs.openshift.com/container-platform/4.15/networking/ingress-operator.html#nw-ingress-configuring-application-domain_configuring-ingress)

The consoleLinks etc assumes the default domain, while rhods-dashboard route's host is set correctly because of route's annotation has `openshift.io/host.generated: "true"`

## How Has This Been Tested?
No.

## Screenshot or short clip
![consolelink](https://github.com/user-attachments/assets/2c021916-f114-452f-979f-45b4b8d64c8b)
![rhods-dashboard-route-1](https://github.com/user-attachments/assets/78c89b1b-5905-4d9c-a584-fb989df6babf)

## Merge criteria

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [] The developer has manually tested the changes and verified that the changes work
