### PR TITLE
update: monitoring stack only apply if it is managed cluster

### DIFF
--- a/controllers/dscinitialization/dscinitialization_controller.go
+++ b/controllers/dscinitialization/dscinitialization_controller.go
@@ -234,22 +234,13 @@ func (r *DSCInitializationReconciler) Reconcile(ctx context.Context, req ctrl.Re
 			if !createUsergroup {
 				log.Info("DSCI disabled usergroup creation")
 			} else {
-				err := r.createUserGroup(ctx, instance, "rhods-admins")
-				if err != nil {
-					return reconcile.Result{}, err
-				}
-			}
-			if instance.Spec.Monitoring.ManagementState == operatorv1.Managed {
-				log.Info("Monitoring enabled, won't apply changes", "cluster", "Self-Managed RHODS Mode")
-				err = r.configureCommonMonitoring(ctx, instance)
-				if err != nil {
+				if err := r.createUserGroup(ctx, instance, "rhods-admins"); err != nil {
 					return reconcile.Result{}, err
 				}
 			}
 		case cluster.ManagedRhoai:
 			osdConfigsPath := filepath.Join(deploy.DefaultManifestPath, "osd-configs")
-			err = deploy.DeployManifestsFromPath(ctx, r.Client, instance, osdConfigsPath, r.ApplicationsNamespace, "osd", true)
-			if err != nil {
+			if err = deploy.DeployManifestsFromPath(ctx, r.Client, instance, osdConfigsPath, r.ApplicationsNamespace, "osd", true); err != nil {
 				log.Error(err, "Failed to apply osd specific configs from manifests", "Manifests path", osdConfigsPath)
 				r.Recorder.Eventf(instance, corev1.EventTypeWarning, "DSCInitializationReconcileError", "Failed to apply "+osdConfigsPath)
 
@@ -257,12 +248,10 @@ func (r *DSCInitializationReconciler) Reconcile(ctx context.Context, req ctrl.Re
 			}
 			if instance.Spec.Monitoring.ManagementState == operatorv1.Managed {
 				log.Info("Monitoring enabled in initialization stage", "cluster", "Managed Service Mode")
-				err := r.configureManagedMonitoring(ctx, instance, "init")
-				if err != nil {
+				if err := r.configureManagedMonitoring(ctx, instance, "init"); err != nil {
 					return reconcile.Result{}, err
 				}
-				err = r.configureCommonMonitoring(ctx, instance)
-				if err != nil {
+				if err = r.configureCommonMonitoring(ctx, instance); err != nil {
 					return reconcile.Result{}, err
 				}
 			}

--- a/pkg/upgrade/upgrade.go
+++ b/pkg/upgrade/upgrade.go
@@ -216,7 +216,7 @@ func CleanupExistingResource(ctx context.Context,
 	oldReleaseVersion cluster.Release,
 ) error {
 	var multiErr *multierror.Error
-	// Special Handling of cleanup of deprecated model monitoring stack
+	// Special Handling of cleanup of deprecated model monitoring stack on managed
 	if platform == cluster.ManagedRhoai {
 		deprecatedDeployments := []string{"rhods-prometheus-operator"}
 		multiErr = multierror.Append(multiErr, deleteDeprecatedResources(ctx, cli, dscMonitoringNamespace, deprecatedDeployments, &appsv1.DeploymentList{}))
@@ -245,9 +245,20 @@ func CleanupExistingResource(ctx context.Context,
 		deprecatedServicemonitors := []string{"modelmesh-federated-metrics"}
 		multiErr = multierror.Append(multiErr, deleteDeprecatedServiceMonitors(ctx, cli, dscMonitoringNamespace, deprecatedServicemonitors))
 	}
+	// Special Handling of cleanup of deprecated SRE monitoring stack on self-managed
+	if platform == cluster.SelfManagedRhoai {
+		deprecatedOperatorSM := []string{"rrhods-monitor-federation"}
+		multiErr = multierror.Append(multiErr, deleteDeprecatedServiceMonitors(ctx, cli, dscMonitoringNamespace, deprecatedOperatorSM))
+
+		deprecatedRolebindings := []string{"rhods-prometheus-cluster-monitoring-viewer-binding", "redhat-ods-monitoring"}
+		multiErr = multierror.Append(multiErr, deleteDeprecatedResources(ctx, cli, dscMonitoringNamespace, deprecatedRolebindings, &rbacv1.RoleBindingList{}))
+
+		deprecatedRroles := []string{"redhat-ods-monitoring"}
+		multiErr = multierror.Append(multiErr, deleteDeprecatedResources(ctx, cli, dscMonitoringNamespace, deprecatedRroles, &rbacv1.RoleList{}))
+	}
 	// common logic for both self-managed and managed
-	deprecatedOperatorSM := []string{"rhods-monitor-federation2"}
-	multiErr = multierror.Append(multiErr, deleteDeprecatedServiceMonitors(ctx, cli, dscMonitoringNamespace, deprecatedOperatorSM))
+	deprecatedOperatorSM2 := []string{"rhods-monitor-federation2"}
+	multiErr = multierror.Append(multiErr, deleteDeprecatedServiceMonitors(ctx, cli, dscMonitoringNamespace, deprecatedOperatorSM2))
 
 	// Remove deprecated opendatahub namespace(previously owned by kuberay and Kueue)
 	multiErr = multierror.Append(multiErr, deleteDeprecatedNamespace(ctx, cli, "opendatahub"))


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

- keep managed cluster logic as-is
- create redhat-ods-monitoring namespace in self-managed if dsic set monitoring to enabled
- remove role rolebinding and servicemonitor in upgrade for self-managed
- do not apply role rolebinding and servicemonitor in clean install for self-managed


<!--- Link your JIRA and related links here for reference. -->
ref: https://issues.redhat.com/browse/RHOAIENG-2761
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
