### PR TITLE
fix: added a filter to evicted pods when checking for ready status

### DIFF
--- a/pkg/feature/conditions.go
+++ b/pkg/feature/conditions.go
@@ -64,14 +64,16 @@ func WaitForPodsToBeReady(namespace string) Action {
 				return false, err
 			}
 
+			pods := podList.DeepCopy()
+			pods.Items = filterEvictedPods(podList.Items)
 			readyPods := 0
-			totalPods := len(podList.Items)
+			totalPods := len(pods.Items)
 
 			if totalPods == 0 { // We want to wait for "something", so make sure we have "something" before we claim success.
 				return false, nil
 			}
 
-			for _, pod := range podList.Items {
+			for _, pod := range pods.Items {
 				podReady := true
 				// Consider a "PodSucceeded" as ready, since these will never will
 				// be in Ready condition (i.e. Jobs that already completed).
@@ -100,6 +102,18 @@ func WaitForPodsToBeReady(namespace string) Action {
 			return done, nil
 		})
 	}
+}
+
+func filterEvictedPods(pods []corev1.Pod) []corev1.Pod {
+	var filteredPods []corev1.Pod
+
+	for _, pod := range pods {
+		if pod.Status.Phase != corev1.PodFailed || pod.Status.Reason != "Evicted" {
+			filteredPods = append(filteredPods, pod)
+		}
+	}
+
+	return filteredPods
 }
 
 func WaitForResourceToBeCreated(namespace string, gvk schema.GroupVersionKind) Action {

--- a/pkg/feature/conditions.go
+++ b/pkg/feature/conditions.go
@@ -64,16 +64,15 @@ func WaitForPodsToBeReady(namespace string) Action {
 				return false, err
 			}
 
-			pods := podList.DeepCopy()
-			pods.Items = filterEvictedPods(podList.Items)
+			podList.Items = filterEvictedPods(podList.Items)
 			readyPods := 0
-			totalPods := len(pods.Items)
+			totalPods := len(podList.Items)
 
 			if totalPods == 0 { // We want to wait for "something", so make sure we have "something" before we claim success.
 				return false, nil
 			}
 
-			for _, pod := range pods.Items {
+			for _, pod := range podList.Items {
 				podReady := true
 				// Consider a "PodSucceeded" as ready, since these will never will
 				// be in Ready condition (i.e. Jobs that already completed).


### PR DESCRIPTION
Tracking issue: RHOAIENG-15614

## Description
<!--- Describe your changes in detail -->

I experienced a problem in a cluster, in namespace `opendatahub-auth-provider` there was a pod in `Evicted` state and another one Ready and working correctly.
When DSCi tried to reconcile on `CapabilityServiceMeshAuthorization` it failed with the following error:

```
{"level":"info","ts":"2024-10-31T15:23:27Z","logger":"features","msg":"waiting for pods to become ready","feature":"mesh-control-plane-external-authz","namespace":"istio-system","duration (s)":300}
{"level":"info","ts":"2024-10-31T15:23:29Z","logger":"features","msg":"done waiting for pods to become ready","feature":"mesh-control-plane-external-authz","namespace":"istio-system"}
{"level":"info","ts":"2024-10-31T15:23:29Z","logger":"features","msg":"waiting for pods to become ready","feature":"enable-proxy-injection-in-authorino-deployment","namespace":"opendatahub-auth-provider","duration (s)":300}
{"level":"error","ts":"2024-10-31T15:28:29Z","msg":"failed applying service mesh resources","controller":"dscinitialization","controllerGroup":"dscinitialization.opendatahub.io","controllerKind":"DSCInitialization","DSCInitialization":{"name":"default-dsci"},"namespace":"","name":"default-dsci","reconcileID":"a003af8b-de11-4fe0-bd6a-b036070ac1be","error":"1 error occurred:\n\t* failed applying FeatureHandler features. cause: 1 error occurred:\n\t* 1 error occurred:\n\t* context deadline exceeded\n\n\n\n\n\n","stacktrace":"github.com/opendatahub-io/opendatahub-operator/v2/controllers/dscinitialization.(*DSCInitializationReconciler).configureServiceMesh\n\t/workspace/controllers/dscinitialization/servicemesh_setup.go:47\ngithub.com/opendatahub-io/opendatahub-operator/v2/controllers/dscinitialization.(*DSCInitializationReconciler).Reconcile\n\t/workspace/controllers/dscinitialization/dscinitialization_controller.go:285\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile\n\t/opt/app-root/src/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.17.5/pkg/internal/controller/controller.go:119\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\t/opt/app-root/src/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.17.5/pkg/internal/controller/controller.go:316\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/opt/app-root/src/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.17.5/pkg/internal/controller/controller.go:266\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2\n\t/opt/app-root/src/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.17.5/pkg/internal/controller/controller.go:227"}
```

Reason being that in the function `WaitForPodsToBeReady` we expect every pod to be ready after we apply patches to Authorino deployment, now with the pod in Evicted state if no one manually deletes it or the garbage collector procs, the status of the Capability will never get to be True even if Authorino is actually working.

Let me know what you think about it 🙏🏼 

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
`make test`

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
