### PR TITLE
fix: ensure input CAbundle always end with a newline

### DIFF
--- a/pkg/trustedcabundle/trustedcabundle.go
+++ b/pkg/trustedcabundle/trustedcabundle.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -47,6 +48,10 @@ func HasCABundleAnnotationDisabled(ns client.Object) bool {
 // or update existing odh-trusted-ca-bundle configmap if already exists with new content of .data.odh-ca-bundle.crt
 // this is certificates for the cluster trusted CA Cert Bundle.
 func CreateOdhTrustedCABundleConfigMap(ctx context.Context, cli client.Client, namespace string, customCAData string) error {
+	// Adding newline breaker if user input does not have it
+	if !strings.HasSuffix(customCAData, "\n") {
+		customCAData += "\n"
+	}
 	// Expected configmap for the given namespace
 	desiredConfigMap := &corev1.ConfigMap{
 		TypeMeta: metav1.TypeMeta{

--- a/pkg/trustedcabundle/trustedcabundle.go
+++ b/pkg/trustedcabundle/trustedcabundle.go
@@ -49,9 +49,8 @@ func HasCABundleAnnotationDisabled(ns client.Object) bool {
 // this is certificates for the cluster trusted CA Cert Bundle.
 func CreateOdhTrustedCABundleConfigMap(ctx context.Context, cli client.Client, namespace string, customCAData string) error {
 	// Adding newline breaker if user input does not have it
-	if !strings.HasSuffix(customCAData, "\n") {
-		customCAData += "\n"
-	}
+	customCAData = strings.TrimSpace(customCAData) + "\n"
+
 	// Expected configmap for the given namespace
 	desiredConfigMap := &corev1.ConfigMap{
 		TypeMeta: metav1.TypeMeta{


### PR DESCRIPTION
- missing newline will cause problem when inject data into configmap
- this happens when user use kustomize with their own CA as overlayer for DSCI, it set to use |- not |
related to https://github.com/kubernetes-sigs/kustomize/issues/4602

i am not fond of the solution provided in https://issues.redhat.com/browse/RHOAIENG-11895 on a component base.
this could protentially cause other components to fail.


<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
quay.io/wenzhou/opendatahub-operator:2.20.114
1. input
```
  trustedCABundle:
    customCABundle: -----BEGIN CERTIFICATE-----
      MIIFVjCCAz6gAwIBAgIUQ+NxE9izWRRdt86M/TX9b7wFjUUwDQYJKoZIhvcNAQEL
     ...
      IrrVQJLuM7IjWcmOvFjai57QGfIvWcaMY1q6n6MLsLOaXLoRuBLpDLvPbmyAhykU
      ------END ------
```
output in CM:
```
odh-ca-bundle.crt: |
    -----BEGIN CERTIFICATE----- MIIFVjCCAz6gAwIBAgIUQ+NxE9izWRRdt86M/TX9b7wFjUUwDQYJKoZIhvcNAQEL ...IrrVQJLuM7IjWcmOvFjai57QGfIvWcaMY1q6n6MLsLOaXLoRuBLpDLvPbmyAhykU 
   ------END ------
```


2. input
 ```
  trustedCABundle:
    customCABundle: |
      -----BEGIN CERTIFICATE----- 
      MIIFVjCCAz6gAwIBAgIUQ+NxE9izWRRdt86M/TX9b7wFjUUwDQYJKoZIhvcNAQEL 
      ...
      IrrVQJLuM7IjWcmOvFjai57QGfIvWcaMY1q6n6MLsLOaXLoRuBLpDLvPbmyAhykU 
      ------END ------
    managementState: Managed
```
output in CM:
```
  odh-ca-bundle.crt: |
    -----BEGIN CERTIFICATE----- 
    MIIFVjCCAz6gAwIBAgIUQ+NxE9izWRRdt86M/TX9b7wFjUUwDQYJKoZIhvcNAQEL 
    ...
    IrrVQJLuM7IjWcmOvFjai57QGfIvWcaMY1q6n6MLsLOaXLoRuBLpDLvPbmyAhykU 
    ------END ------
```

3. input
 ```
trustedCABundle:
    customCABundle: |-
      -----BEGIN CERTIFICATE-----
      MIIFVjCCAz6gAwIBAgIUQ+NxE9izWRRdt86M/TX9b7wFjUUwDQYJKoZIhvcNAQEL
      ...
      IrrVQJLuM7IjWcmOvFjai57QGfIvWcaMY1q6n6MLsLOaXLoRuBLpDLvPbmyAhykU
      ------END ------
```

output in CM:
```
  odh-ca-bundle.crt: |
    -----BEGIN CERTIFICATE-----
    MIIFVjCCAz6gAwIBAgIUQ+NxE9izWRRdt86M/TX9b7wFjUUwDQYJKoZIhvcNAQEL
    ...
    IrrVQJLuM7IjWcmOvFjai57QGfIvWcaMY1q6n6MLsLOaXLoRuBLpDLvPbmyAhykU
    ------END ------
```

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
