### PR TITLE
fix: add check to remove old kube-rbac-proxy container in modelregistry operator, fixes RHOAIENG-15328

### DIFF
--- a/components/modelregistry/modelregistry.go
+++ b/components/modelregistry/modelregistry.go
@@ -11,10 +11,8 @@ import (
 	"text/template"
 
 	operatorv1 "github.com/openshift/api/operator/v1"
-	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -24,7 +22,6 @@ import (
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/conversion"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/deploy"
-	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/metadata/labels"
 
 	_ "embed"
 )
@@ -162,10 +159,6 @@ func (m *ModelRegistry) ReconcileComponent(ctx context.Context, cli client.Clien
 	l.Info("apply extra manifests done")
 
 	if enabled {
-		// remove leftover kube-rbac-proxy container from older ODH installs
-		if err := removeUnusedKubeRbacProxy(ctx, cli, m.GetComponentName(), dscispec.ApplicationsNamespace); err != nil {
-			return fmt.Errorf("failed to remove kube-rbac-proxy from deployment for %s in namespace %s: %w", ComponentName, dscispec.ApplicationsNamespace, err)
-		}
 		if err := cluster.WaitForDeploymentAvailable(ctx, cli, m.GetComponentName(), dscispec.ApplicationsNamespace, 10, 1); err != nil {
 			return fmt.Errorf("deployment for %s is not ready to server: %w", ComponentName, err)
 		}
@@ -183,38 +176,6 @@ func (m *ModelRegistry) ReconcileComponent(ctx context.Context, cli client.Clien
 			return err
 		}
 		l.Info("updating SRE monitoring done")
-	}
-	return nil
-}
-
-// removeUnusedKubeRbacProxy removes older kube-rbac-proxy container in mr operator deployment.
-// This is required because patching a deployment using apply-patch doesn't remove older containers.
-// See: https://kubernetes.io/docs/tasks/manage-kubernetes-objects/update-api-object-kubectl-patch/#notes-on-the-strategic-merge-patch
-func removeUnusedKubeRbacProxy(ctx context.Context, cli client.Client, name string, namespace string) error {
-	// get MR operator deployment
-	componentDeploymentList := &appsv1.DeploymentList{}
-	err := cli.List(ctx, componentDeploymentList, client.InNamespace(namespace), client.HasLabels{labels.ODH.Component(name)})
-	if err != nil {
-		return fmt.Errorf("error fetching list of deployments: %w", err)
-	}
-	nItems := len(componentDeploymentList.Items)
-	if nItems != 1 {
-		return fmt.Errorf("error fetching model registry operator deployment, found %d deployments", nItems)
-	}
-
-	// check if deployment has a kube-rbac-proxy container
-	deployment := componentDeploymentList.Items[0]
-	containers := deployment.Spec.Template.Spec.Containers
-	// there should be a single container in latest deployment without kube-rbac-proxy
-	if len(containers) == 1 {
-		return nil
-	}
-	for i, container := range containers {
-		if container.Name == "kube-rbac-proxy" {
-			// remove if found
-			return cli.Patch(ctx, &deployment, client.RawPatch(types.JSONPatchType,
-				[]byte(fmt.Sprintf("[{\"op\": \"remove\", \"path\": \"/spec/template/spec/containers/%d\"}]", i))))
-		}
 	}
 	return nil
 }

--- a/pkg/upgrade/upgrade.go
+++ b/pkg/upgrade/upgrade.go
@@ -43,6 +43,7 @@ import (
 	"github.com/opendatahub-io/opendatahub-operator/v2/components/workbenches"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/metadata/labels"
 )
 
 type ResourceSpec struct {
@@ -275,6 +276,12 @@ func CleanupExistingResource(ctx context.Context,
 			return err
 		}
 	}
+	// remove modelreg proxy container from deployment in ODH
+	if platform == cluster.OpenDataHub {
+		if err := removeRBACProxyModelRegistry(ctx, cli, "model-registry-operator", "kube-rbac-proxy", dscApplicationsNamespace); err != nil {
+			return err
+		}
+	}
 
 	// to take a reference
 	toDelete := getDashboardWatsonResources(dscApplicationsNamespace)
@@ -484,6 +491,38 @@ func updateODCModelRegistry(ctx context.Context, cli client.Client, instanceName
 		return nil
 	}
 	log.Info("Upgrade does not force ModelRegistry to false due to from release >= 2.14.0")
+	return nil
+}
+
+// workaround for RHOAIENG-15328
+// TODO: this can be removed from ODH 2.22.
+func removeRBACProxyModelRegistry(ctx context.Context, cli client.Client, componentName string, containerName string, applicationNS string) error {
+	log := logf.FromContext(ctx)
+	deploymentList := &appsv1.DeploymentList{}
+	if err := cli.List(ctx, deploymentList, client.InNamespace(applicationNS), client.HasLabels{labels.ODH.Component(componentName)}); err != nil {
+		return fmt.Errorf("error fetching list of deployments: %w", err)
+	}
+
+	if len(deploymentList.Items) != 1 { // ModelRegistry operator is not deployed
+		return nil
+	}
+	mrDeployment := deploymentList.Items[0]
+	mrContainerList := mrDeployment.Spec.Template.Spec.Containers
+	// if only one container in deployment, we are already on newer deployment, no need more action
+	if len(mrContainerList) == 1 {
+		return nil
+	}
+
+	log.Info("Upgrade force ModelRegistry to remove container from deployment")
+	for i, container := range mrContainerList {
+		if container.Name == containerName {
+			removeUnusedKubeRbacProxy := []byte(fmt.Sprintf("[{\"op\": \"remove\", \"path\": \"/spec/template/spec/containers/%d\"}]", i))
+			if err := cli.Patch(ctx, &mrDeployment, client.RawPatch(types.JSONPatchType, removeUnusedKubeRbacProxy)); err != nil {
+				return fmt.Errorf("error removing ModelRegistry %s container from deployment: %w", containerName, err)
+			}
+			break
+		}
+	}
 	return nil
 }
 


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->
Add check to remove old kube-rbac-proxy container in modelregistry operator

<!--- Link your JIRA and related links here for reference. -->
Fixes[ RHOAIENG-15328](https://issues.redhat.com/browse/RHOAIENG-15328)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally by creating a DSC with MR, and manually adding a kube-rbac-proxy container with the following commands:

```shell
# create a patch file with kube-rbac-proxy container
cat - >> rbac-container.yaml << EOF
spec:
  template:
    spec:
      containers:
      - args:
        - --secure-listen-address=0.0.0.0:8443
        - --upstream=http://127.0.0.1:8080/
        - --logtostderr=true
        - --v=0
        - --tls-cert-file=/etc/server-cert/tls.crt
        - --tls-private-key-file=/etc/server-cert/tls.key
        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.14.1
        name: kube-rbac-proxy
        ports:
        - containerPort: 8443
          name: https
          protocol: TCP
        resources:
          limits:
            cpu: 500m
            memory: 128Mi
          requests:
            cpu: 5m
            memory: 64Mi
        securityContext:
          allowPrivilegeEscalation: false
          capabilities:
            drop:
            - ALL
        volumeMounts:
        - mountPath: /etc/server-cert
          name: server-cert
          readOnly: true
EOF
# patch the modelregistry operator deployment
oc patch deployment -n opendatahub model-registry-operator-controller-manager --patch-file rbac-container.yaml
# restart the odh operator, it doesn't detect that a resource it created was modified!!!
oc delete pod -n opendatahub-operator-system -l name=opendatahub-operator
watch oc get pods -n opendatahub
```

Watch the number of pods in the model-registry-operator-controller-manager deployment, which should change to 1 after the kube-rbac-proxy container is removed by this patch.

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [X] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [X] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work