### PR TITLE
Replace components.opendatahub.io/managed-by with components.opendatahub.io/part-of

### DIFF
--- a/controllers/components/dashboard/dashboard_controller.go
+++ b/controllers/components/dashboard/dashboard_controller.go
@@ -62,9 +62,9 @@ func NewComponentReconciler(ctx context.Context, mgr ctrl.Manager) error {
 		//
 		// By default the Watches functions adds:
 		// - an event handler mapping to a cluster scope resource identified by the
-		//   components.opendatahub.io/managed-by annotation
+		//   components.opendatahub.io/part-of annotation
 		// - a predicate that check for generation change for Delete/Updates events
-		//   for to objects that have the label components.opendatahub.io/managed-by
+		//   for to objects that have the label components.opendatahub.io/part-of
 		//   set to the current owner
 		//
 		Watches(&extv1.CustomResourceDefinition{}).
@@ -88,10 +88,10 @@ func NewComponentReconciler(ctx context.Context, mgr ctrl.Manager) error {
 		WithAction(updatePodSecurityRolebinding).
 		WithAction(deploy.NewAction(
 			deploy.WithFieldOwner(componentsv1.DashboardInstanceName),
-			deploy.WithLabel(labels.ComponentManagedBy, componentsv1.DashboardInstanceName),
+			deploy.WithLabel(labels.ComponentPartOf, componentsv1.DashboardInstanceName),
 		)).
 		WithAction(updatestatus.NewAction(
-			updatestatus.WithSelectorLabel(labels.ComponentManagedBy, componentsv1.DashboardInstanceName),
+			updatestatus.WithSelectorLabel(labels.ComponentPartOf, componentsv1.DashboardInstanceName),
 		)).
 		WithAction(updateStatus).
 		Build(ctx)

--- a/controllers/components/dashboard/dashboard_controller_actions.go
+++ b/controllers/components/dashboard/dashboard_controller_actions.go
@@ -118,7 +118,7 @@ func updateStatus(ctx context.Context, rr *odhtypes.ReconciliationRequest) error
 		&rl,
 		client.InNamespace(rr.DSCI.Spec.ApplicationsNamespace),
 		client.MatchingLabels(map[string]string{
-			labels.ComponentManagedBy: componentsv1.DashboardInstanceName,
+			labels.ComponentPartOf: componentsv1.DashboardInstanceName,
 		}),
 	)
 

--- a/controllers/components/modelregistry/modelregistry_controller.go
+++ b/controllers/components/modelregistry/modelregistry_controller.go
@@ -82,10 +82,10 @@ func NewComponentReconciler(ctx context.Context, mgr ctrl.Manager) error {
 		WithAction(customizeResources).
 		WithAction(deploy.NewAction(
 			deploy.WithFieldOwner(componentsv1.ModelRegistryInstanceName),
-			deploy.WithLabel(labels.ComponentManagedBy, componentsv1.ModelRegistryInstanceName),
+			deploy.WithLabel(labels.ComponentPartOf, componentsv1.ModelRegistryInstanceName),
 		)).
 		WithAction(updatestatus.NewAction(
-			updatestatus.WithSelectorLabel(labels.ComponentManagedBy, componentsv1.ModelRegistryInstanceName),
+			updatestatus.WithSelectorLabel(labels.ComponentPartOf, componentsv1.ModelRegistryInstanceName),
 		)).
 		WithAction(updateStatus).
 		Build(ctx)

--- a/controllers/components/ray/ray_controller.go
+++ b/controllers/components/ray/ray_controller.go
@@ -63,10 +63,10 @@ func NewComponentReconciler(ctx context.Context, mgr ctrl.Manager) error {
 		)).
 		WithAction(deploy.NewAction(
 			deploy.WithFieldOwner(componentsv1.RayInstanceName),
-			deploy.WithLabel(labels.ComponentManagedBy, componentsv1.RayInstanceName),
+			deploy.WithLabel(labels.ComponentPartOf, componentsv1.RayInstanceName),
 		)).
 		WithAction(updatestatus.NewAction(
-			updatestatus.WithSelectorLabel(labels.ComponentManagedBy, componentsv1.RayInstanceName),
+			updatestatus.WithSelectorLabel(labels.ComponentPartOf, componentsv1.RayInstanceName),
 		)).
 		Build(ctx)
 

--- a/pkg/controller/actions/render/action_render_manifests_test.go
+++ b/pkg/controller/actions/render/action_render_manifests_test.go
@@ -193,7 +193,7 @@ func TestRenderResourcesWithCacheAction(t *testing.T) {
 
 	action := render.NewAction(
 		render.WithCache(true, render.DefaultCachingKeyFn),
-		render.WithLabel(labels.ComponentManagedBy, "foo"),
+		render.WithLabel(labels.ComponentPartOf, "foo"),
 		render.WithLabel("platform.opendatahub.io/namespace", ns),
 		render.WithAnnotation("platform.opendatahub.io/release", "1.2.3"),
 		render.WithAnnotation("platform.opendatahub.io/type", "managed"),
@@ -228,7 +228,7 @@ func TestRenderResourcesWithCacheAction(t *testing.T) {
 			HaveLen(1),
 			HaveEach(And(
 				jq.Match(`.metadata.namespace == "%s"`, ns),
-				jq.Match(`.metadata.labels."%s" == "%s"`, labels.ComponentManagedBy, "foo"),
+				jq.Match(`.metadata.labels."%s" == "%s"`, labels.ComponentPartOf, "foo"),
 				jq.Match(`.metadata.labels."platform.opendatahub.io/namespace" == "%s"`, ns),
 				jq.Match(`.metadata.annotations."platform.opendatahub.io/release" == "%s"`, "1.2.3"),
 				jq.Match(`.metadata.annotations."platform.opendatahub.io/type" == "%s"`, "managed"),

--- a/pkg/controller/handlers/handlers.go
+++ b/pkg/controller/handlers/handlers.go
@@ -18,14 +18,14 @@ func ToOwner() handler.EventHandler {
 			return []reconcile.Request{}
 		}
 
-		managedBy := objLabels[labels.ComponentManagedBy]
-		if managedBy == "" {
+		partOf := objLabels[labels.ComponentPartOf]
+		if partOf == "" {
 			return []reconcile.Request{}
 		}
 
 		return []reconcile.Request{{
 			NamespacedName: types.NamespacedName{
-				Name: managedBy,
+				Name: partOf,
 			},
 		}}
 	})

--- a/pkg/controller/reconciler/component_reconciler_support.go
+++ b/pkg/controller/reconciler/component_reconciler_support.go
@@ -174,7 +174,7 @@ func (b *ComponentReconcilerBuilder[T]) Build(ctx context.Context) (*ComponentRe
 		if len(watchOpts) == 0 {
 			watchOpts = append(watchOpts, builder.WithPredicates(predicate.And(
 				generation.New(),
-				component.ForLabel(labels.ComponentManagedBy, b.ownerName),
+				component.ForLabel(labels.ComponentPartOf, b.ownerName),
 			)))
 		}
 

--- a/pkg/metadata/labels/types.go
+++ b/pkg/metadata/labels/types.go
@@ -1,11 +1,11 @@
 package labels
 
 const (
-	ODHAppPrefix       = "app.opendatahub.io"
-	ComponentManagedBy = "components.opendatahub.io/managed-by"
-	InjectTrustCA      = "config.openshift.io/inject-trusted-cabundle"
-	SecurityEnforce    = "pod-security.kubernetes.io/enforce"
-	ClusterMonitoring  = "openshift.io/cluster-monitoring"
+	ODHAppPrefix      = "app.opendatahub.io"
+	ComponentPartOf   = "components.opendatahub.io/part-of"
+	InjectTrustCA     = "config.openshift.io/inject-trusted-cabundle"
+	SecurityEnforce   = "pod-security.kubernetes.io/enforce"
+	ClusterMonitoring = "openshift.io/cluster-monitoring"
 )
 
 // K8SCommon keeps common kubernetes labels [1]

--- a/tests/e2e/dashboard_test.go
+++ b/tests/e2e/dashboard_test.go
@@ -168,7 +168,7 @@ func (tc *DashboardTestCtx) testUpdateOnDashboardResources() error {
 	// Test Updating Dashboard Replicas
 
 	appDeployments, err := tc.testCtx.kubeClient.AppsV1().Deployments(tc.testCtx.applicationsNamespace).List(tc.testCtx.ctx, metav1.ListOptions{
-		LabelSelector: labels.ComponentManagedBy + "=" + tc.testDashboardInstance.Name,
+		LabelSelector: labels.ComponentPartOf + "=" + tc.testDashboardInstance.Name,
 	})
 	if err != nil {
 		return err

--- a/tests/e2e/modelregistry_test.go
+++ b/tests/e2e/modelregistry_test.go
@@ -152,7 +152,7 @@ func (mr *ModelRegistryTestCtx) validateOperandsOwnerReferences(t *testing.T) {
 		mr.List(
 			gvk.Deployment,
 			client.InNamespace(mr.applicationsNamespace),
-			client.MatchingLabels{labels.ComponentManagedBy: componentsv1.ModelRegistryInstanceName},
+			client.MatchingLabels{labels.ComponentPartOf: componentsv1.ModelRegistryInstanceName},
 		),
 	).Should(And(
 		HaveLen(1),
@@ -168,7 +168,7 @@ func (mr *ModelRegistryTestCtx) validateUpdateModelRegistryOperandsResources(t *
 	appDeployments, err := mr.kubeClient.AppsV1().Deployments(mr.applicationsNamespace).List(
 		mr.ctx,
 		metav1.ListOptions{
-			LabelSelector: labels.ComponentManagedBy + "=" + componentsv1.ModelRegistryInstanceName,
+			LabelSelector: labels.ComponentPartOf + "=" + componentsv1.ModelRegistryInstanceName,
 		},
 	)
 
@@ -203,7 +203,7 @@ func (mr *ModelRegistryTestCtx) validateUpdateModelRegistryOperandsResources(t *
 		mr.List(
 			gvk.Deployment,
 			client.InNamespace(mr.applicationsNamespace),
-			client.MatchingLabels{labels.ComponentManagedBy: componentsv1.ModelRegistryInstanceName},
+			client.MatchingLabels{labels.ComponentPartOf: componentsv1.ModelRegistryInstanceName},
 		),
 	).Should(And(
 		HaveLen(1),
@@ -216,7 +216,7 @@ func (mr *ModelRegistryTestCtx) validateUpdateModelRegistryOperandsResources(t *
 		mr.List(
 			gvk.Deployment,
 			client.InNamespace(mr.applicationsNamespace),
-			client.MatchingLabels{labels.ComponentManagedBy: componentsv1.ModelRegistryInstanceName},
+			client.MatchingLabels{labels.ComponentPartOf: componentsv1.ModelRegistryInstanceName},
 		),
 	).WithTimeout(30 * time.Second).WithPolling(1 * time.Second).Should(And(
 		HaveLen(1),
@@ -262,7 +262,7 @@ func (mr *ModelRegistryTestCtx) validateModelRegistryDisabled(t *testing.T) {
 		mr.List(
 			gvk.Deployment,
 			client.InNamespace(mr.applicationsNamespace),
-			client.MatchingLabels{labels.ComponentManagedBy: componentsv1.ModelRegistryInstanceName},
+			client.MatchingLabels{labels.ComponentPartOf: componentsv1.ModelRegistryInstanceName},
 		),
 	).Should(
 		HaveLen(1),
@@ -280,7 +280,7 @@ func (mr *ModelRegistryTestCtx) validateModelRegistryDisabled(t *testing.T) {
 		mr.List(
 			gvk.Deployment,
 			client.InNamespace(mr.applicationsNamespace),
-			client.MatchingLabels{labels.ComponentManagedBy: componentsv1.ModelRegistryInstanceName},
+			client.MatchingLabels{labels.ComponentPartOf: componentsv1.ModelRegistryInstanceName},
 		),
 	).Should(
 		BeEmpty(),

--- a/tests/e2e/ray_test.go
+++ b/tests/e2e/ray_test.go
@@ -162,7 +162,7 @@ func (tc *RayTestCtx) testUpdateOnRayResources() error {
 	// Test Updating Ray Replicas
 
 	appDeployments, err := tc.testCtx.kubeClient.AppsV1().Deployments(tc.testCtx.applicationsNamespace).List(tc.testCtx.ctx, metav1.ListOptions{
-		LabelSelector: labels.ComponentManagedBy + "=" + tc.testRayInstance.Name,
+		LabelSelector: labels.ComponentPartOf + "=" + tc.testRayInstance.Name,
 	})
 	if err != nil {
 		return err


### PR DESCRIPTION
This commit replaces then label components.opendatahub.io/managed-by
with components.opendatahub.io/part-of as managed-by was misleading
since the label is mainly used for watching and request mapping

<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] ~~Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).~~
- [ ] ~~The developer has manually tested the changes and verified that the changes work~~
