### PR TITLE
logger: set loglevel from ZAP_LOG_LEVEL environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,8 +222,10 @@ This will ensure that the doc for the apis are updated accordingly.
 
 ### Enabled logging
 
-Global logger configuration can be changed with a command line switch `--log-mode <mode>`
-for example from CSV. Valid values for `<mode>`: "" (as default) || prod || production || devel || development.
+Global logger configuration can be changed with an environemnt variable `ZAP_LOG_LEVEL`
+or a command line switch `--log-mode <mode>` for example from CSV.
+Command line switch has higher priority.
+Valid values for `<mode>`: "" (as default) || prod || production || devel || development.
 
 Verbosity level is INFO.
 To fine tune zap backend [standard operator sdk zap switches](https://sdk.operatorframework.io/docs/building-operators/golang/references/logging/)


### PR DESCRIPTION
Add possibility to set loglevel with the environment. The name is used used already.

Command line switch has priority over environment.

[1] https://github.com/opendatahub-io/data-science-pipelines-operator/blob/main/config/base/params.env#L13

<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
