### PR TITLE
Allow to run the e2e test suite locally, against an out of the cluster operator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,8 @@ SHELL = /usr/bin/env bash -o pipefail
 .SHELLFLAGS = -ec
 
 # E2E tests additional flags
-E2E_TEST_FLAGS = "--skip-deletion=false" -timeout 25m # See README.md, default go test timeout 10m
+# See README.md, default go test timeout 10m
+E2E_TEST_FLAGS = -timeout 25m
 
 # Default image-build is to not use local odh-manifests folder
 # set to "true" to use local instead

--- a/README.md
+++ b/README.md
@@ -393,16 +393,29 @@ make e2e-test
 Additional flags that can be passed to e2e-tests by setting up `E2E_TEST_FLAGS`
 variable. Following table lists all the available flags to run the tests:
 
-| Flag            | Description                                                                                                                                                        | Default value |
-|-----------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------|
-| --skip-deletion | To skip running  of `dsc-deletion` test that includes deleting `DataScienceCluster` resources. Assign this variable to `true` to skip DataScienceCluster deletion. | false         |
+| Flag                       | Description                                                                                                                                                                   | Default value |
+|----------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------|
+| --skip-deletion            | To skip running  of `dsc-deletion` test that includes deleting `DataScienceCluster` resources. Assign this variable to `true` to skip DataScienceCluster deletion.            | false         |
+| --test-operator-controller | To configure the execution of tests related to the Operator POD, this is useful to run e2e tests for an operator running out of the cluster i.e. for debugging purposes       | true          |
+| --test-webhook             | To configure the execution of tests rellated to the Operator WebHooks, this is useful to run e2e tests for an operator running out of the cluster i.e. for debugging purposes | true          |
+| --test-component           | A repeatable flag that control what component should be tested, by default all component specific test are executed                                                           | true          |
 
-Example command to run full test suite skipping the test
-for DataScienceCluster deletion.
+Example command to run full test suite skipping the test for DataScienceCluster deletion.
 
 ```shell
 make e2e-test -e OPERATOR_NAMESPACE=<namespace> -e E2E_TEST_FLAGS="--skip-deletion=true"
 ```
+
+Example commands to run test suite for the dashboard `component` only, with the operator running out of the cluster.
+
+```shell
+make run-nowebhook
+```
+```shell
+make e2e-test -e OPERATOR_NAMESPACE=<namespace> -e E2E_TEST_FLAGS="--test-operator-controller=false --test-webhook=false --test-component=dashboard"
+```
+
+
 ### API Overview
 
 Please refer to [api documentation](docs/api-overview.md)

--- a/tests/e2e/creation_test.go
+++ b/tests/e2e/creation_test.go
@@ -43,14 +43,17 @@ func creationTestSuite(t *testing.T) {
 			err = testCtx.testDSCICreation()
 			require.NoError(t, err, "error creating DSCI CR")
 		})
-		t.Run("Creation of more than one of DSCInitialization instance", func(t *testing.T) {
-			testCtx.testDSCIDuplication(t)
-		})
+		if testCtx.testOpts.webhookTest {
+			t.Run("Creation of more than one of DSCInitialization instance", func(t *testing.T) {
+				testCtx.testDSCIDuplication(t)
+			})
+		}
 		// Validates Servicemesh fields
 		t.Run("Validate DSCInitialization instance", func(t *testing.T) {
 			err = testCtx.validateDSCI()
 			require.NoError(t, err, "error validating DSCInitialization instance")
 		})
+
 		t.Run("Check owned namespaces exist", func(t *testing.T) {
 			err = testCtx.testOwnedNamespacesAllExist()
 			require.NoError(t, err, "error owned namespace is missing")
@@ -61,9 +64,11 @@ func creationTestSuite(t *testing.T) {
 			err = testCtx.testDSCCreation(t)
 			require.NoError(t, err, "error creating DataScienceCluster instance")
 		})
-		t.Run("Creation of more than one of DataScienceCluster instance", func(t *testing.T) {
-			testCtx.testDSCDuplication(t)
-		})
+		if testCtx.testOpts.webhookTest {
+			t.Run("Creation of more than one of DataScienceCluster instance", func(t *testing.T) {
+				testCtx.testDSCDuplication(t)
+			})
+		}
 
 		// // Kserve
 		// t.Run("Validate Knative resoruce", func(t *testing.T) {
@@ -77,10 +82,13 @@ func creationTestSuite(t *testing.T) {
 		// })
 		//
 		// ModelReg
-		t.Run("Validate model registry config", func(t *testing.T) {
-			err = testCtx.validateModelRegistryConfig()
-			require.NoError(t, err, "error validating ModelRegistry config")
-		})
+
+		if testCtx.testOpts.webhookTest {
+			t.Run("Validate model registry config", func(t *testing.T) {
+				err = testCtx.validateModelRegistryConfig()
+				require.NoError(t, err, "error validating ModelRegistry config")
+			})
+		}
 	})
 }
 

--- a/tests/e2e/dashboard_test.go
+++ b/tests/e2e/dashboard_test.go
@@ -28,6 +28,8 @@ type DashboardTestCtx struct {
 }
 
 func dashboardTestSuite(t *testing.T) {
+	t.Helper()
+
 	dashboardCtx := DashboardTestCtx{}
 	var err error
 	dashboardCtx.testCtx, err = NewTestContext()

--- a/tests/e2e/modelregistry_test.go
+++ b/tests/e2e/modelregistry_test.go
@@ -112,6 +112,8 @@ func (mr *ModelRegistryTestCtx) updateComponent(fn func(dsc *dscv1.Components)) 
 }
 
 func modelRegistryTestSuite(t *testing.T) {
+	t.Helper()
+
 	tc, err := NewTestContext()
 	require.NoError(t, err)
 

--- a/tests/e2e/ray_test.go
+++ b/tests/e2e/ray_test.go
@@ -28,6 +28,8 @@ type RayTestCtx struct {
 }
 
 func rayTestSuite(t *testing.T) {
+	t.Helper()
+
 	rayCtx := RayTestCtx{}
 	var err error
 	rayCtx.testCtx, err = NewTestContext()


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->
It is not possible to control which e2e test should be executed by passing some flags to the e2e test suite using the `E2E_TEST_FLAGS` env var.

The new flags are:
- `--test-operator-controller` which control the execution of the test meant to validate the operator pod, default **true**
- `--test-webhook`  which control the execution of webhook related tests, default **true**
- `--test-component` a repeatable flag that control what component should be teste, by default all component specific test are executed

As an example, the following command:

```shell
➜  make e2e-test E2E_TEST_FLAGS="--test-operator-controller=false --test-webhook=false --test-component=dashboard"
```

Would result in the following test being executed:

```shell
controller=false --test-webhook=false --test-component=dashboard
=== RUN   TestOdhOperator
=== RUN   TestOdhOperator/create_DSCI_and_DSC_CRs
    helper_test.go:418: Ensuring serverless-operator is installed
    helper_test.go:418: Ensuring servicemeshoperator is installed
=== RUN   TestOdhOperator/create_DSCI_and_DSC_CRs/e2e-test-dsc
=== RUN   TestOdhOperator/create_DSCI_and_DSC_CRs/e2e-test-dsc/Creation_of_DSCI_CR
=== RUN   TestOdhOperator/create_DSCI_and_DSC_CRs/e2e-test-dsc/Validate_DSCInitialization_instance
=== RUN   TestOdhOperator/create_DSCI_and_DSC_CRs/e2e-test-dsc/Check_owned_namespaces_exist
=== RUN   TestOdhOperator/create_DSCI_and_DSC_CRs/e2e-test-dsc/Creation_of_DataScienceCluster_instance
=== RUN   TestOdhOperator/validate_installation_of_dashboard_component
=== RUN   TestOdhOperator/validate_installation_of_dashboard_component/e2e-test-dsc
=== RUN   TestOdhOperator/validate_installation_of_dashboard_component/e2e-test-dsc/Creation_of_Dashboard_CR
=== RUN   TestOdhOperator/validate_installation_of_dashboard_component/e2e-test-dsc/Validate_Dashboard_instance
=== RUN   TestOdhOperator/validate_installation_of_dashboard_component/e2e-test-dsc/Validate_Ownerrefrences_exist
=== RUN   TestOdhOperator/validate_installation_of_dashboard_component/e2e-test-dsc/Validate_Dashboard_Ready
=== RUN   TestOdhOperator/validate_installation_of_dashboard_component/e2e-test-dsc/Validate_Controller_reconcile
=== RUN   TestOdhOperator/validate_installation_of_dashboard_component/e2e-test-dsc/Validate_Disabling_Component
=== NAME  TestOdhOperator
    controller_test.go:157: Skipping tests for component ray
    controller_test.go:157: Skipping tests for component modelregistry
=== RUN   TestOdhOperator/components_should_not_be_removed_if_labeled_is_set_to_'false'_on_configmap
=== RUN   TestOdhOperator/components_should_not_be_removed_if_labeled_is_set_to_'false'_on_configmap/e2e-test-dsc
=== RUN   TestOdhOperator/components_should_not_be_removed_if_labeled_is_set_to_'false'_on_configmap/e2e-test-dsc/create_configmap_but_set_to_disable_deletion
=== RUN   TestOdhOperator/components_should_not_be_removed_if_labeled_is_set_to_'false'_on_configmap/e2e-test-dsc/owned_namespaces_should_be_not_deleted
=== RUN   TestOdhOperator/delete_components
=== RUN   TestOdhOperator/delete_components/e2e-test-dsc
=== RUN   TestOdhOperator/delete_components/e2e-test-dsc/Deletion_DSC_instance
=== RUN   TestOdhOperator/delete_components/e2e-test-dsc/Deletion_DSCI_instance
--- PASS: TestOdhOperator (185.37s)
    --- PASS: TestOdhOperator/create_DSCI_and_DSC_CRs (32.40s)
        --- PASS: TestOdhOperator/create_DSCI_and_DSC_CRs/e2e-test-dsc (21.08s)
            --- PASS: TestOdhOperator/create_DSCI_and_DSC_CRs/e2e-test-dsc/Creation_of_DSCI_CR (10.48s)
            --- PASS: TestOdhOperator/create_DSCI_and_DSC_CRs/e2e-test-dsc/Validate_DSCInitialization_instance (0.00s)
            --- PASS: TestOdhOperator/create_DSCI_and_DSC_CRs/e2e-test-dsc/Check_owned_namespaces_exist (0.12s)
            --- PASS: TestOdhOperator/create_DSCI_and_DSC_CRs/e2e-test-dsc/Creation_of_DataScienceCluster_instance (10.49s)
    --- PASS: TestOdhOperator/validate_installation_of_dashboard_component (151.51s)
        --- PASS: TestOdhOperator/validate_installation_of_dashboard_component/e2e-test-dsc (151.51s)
            --- PASS: TestOdhOperator/validate_installation_of_dashboard_component/e2e-test-dsc/Creation_of_Dashboard_CR (10.13s)
            --- PASS: TestOdhOperator/validate_installation_of_dashboard_component/e2e-test-dsc/Validate_Dashboard_instance (0.00s)
            --- PASS: TestOdhOperator/validate_installation_of_dashboard_component/e2e-test-dsc/Validate_Ownerrefrences_exist (0.12s)
            --- PASS: TestOdhOperator/validate_installation_of_dashboard_component/e2e-test-dsc/Validate_Dashboard_Ready (70.14s)
            --- PASS: TestOdhOperator/validate_installation_of_dashboard_component/e2e-test-dsc/Validate_Controller_reconcile (40.37s)
            --- PASS: TestOdhOperator/validate_installation_of_dashboard_component/e2e-test-dsc/Validate_Disabling_Component (30.75s)
    --- PASS: TestOdhOperator/components_should_not_be_removed_if_labeled_is_set_to_'false'_on_configmap (0.73s)
        --- PASS: TestOdhOperator/components_should_not_be_removed_if_labeled_is_set_to_'false'_on_configmap/e2e-test-dsc (0.60s)
            --- PASS: TestOdhOperator/components_should_not_be_removed_if_labeled_is_set_to_'false'_on_configmap/e2e-test-dsc/create_configmap_but_set_to_disable_deletion (0.48s)
            --- PASS: TestOdhOperator/components_should_not_be_removed_if_labeled_is_set_to_'false'_on_configmap/e2e-test-dsc/owned_namespaces_should_be_not_deleted (0.12s)
    --- PASS: TestOdhOperator/delete_components (0.73s)
        --- PASS: TestOdhOperator/delete_components/e2e-test-dsc (0.73s)
            --- PASS: TestOdhOperator/delete_components/e2e-test-dsc/Deletion_DSC_instance (0.36s)
            --- PASS: TestOdhOperator/delete_components/e2e-test-dsc/Deletion_DSCI_instance (0.37s)
PASS
ok      github.com/opendatahub-io/opendatahub-operator/v2/tests/e2e     185.387s
```

<!--- Link your JIRA and related links here for reference. -->

https://issues.redhat.com/browse/RHOAIENG-15143

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [X] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [X] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work
