### PR TITLE
Implement template rendering action

### DIFF
--- a/controllers/components/dashboard/dashboard_controller.go
+++ b/controllers/components/dashboard/dashboard_controller.go
@@ -31,6 +31,7 @@ import (
 
 	componentsv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/components/v1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/deploy"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/render"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/render/kustomize"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/security"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/updatestatus"
@@ -76,7 +77,7 @@ func NewComponentReconciler(ctx context.Context, mgr ctrl.Manager) error {
 		WithAction(configureDependencies).
 		WithAction(security.NewUpdatePodSecurityRoleBindingAction(serviceAccounts)).
 		WithAction(kustomize.NewAction(
-			kustomize.WithCache(kustomize.DefaultCachingKeyFn),
+			kustomize.WithCache(render.DefaultCachingKeyFn),
 			// Those are the default labels added by the legacy deploy method
 			// and should be preserved as the original plugin were affecting
 			// deployment selectors that are immutable once created, so it won't

--- a/controllers/components/kueue/kueue_controller.go
+++ b/controllers/components/kueue/kueue_controller.go
@@ -19,6 +19,7 @@ package kueue
 import (
 	"context"
 
+
 	promv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	appsv1 "k8s.io/api/apps/v1"
@@ -31,6 +32,7 @@ import (
 
 	componentsv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/components/v1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/deploy"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/render"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/render/kustomize"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/updatestatus"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/predicates/resources"
@@ -64,7 +66,7 @@ func NewComponentReconciler(ctx context.Context, mgr ctrl.Manager) error {
 		WithAction(initialize).
 		WithAction(devFlags).
 		WithAction(kustomize.NewAction(
-			kustomize.WithCache(kustomize.DefaultCachingKeyFn),
+			kustomize.WithCache(render.DefaultCachingKeyFn),
 			kustomize.WithLabel(labels.ODH.Component(ComponentName), "true"),
 			kustomize.WithLabel(labels.K8SCommon.PartOf, ComponentName),
 		)).

--- a/controllers/components/kueue/kueue_controller.go
+++ b/controllers/components/kueue/kueue_controller.go
@@ -19,7 +19,6 @@ package kueue
 import (
 	"context"
 
-
 	promv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	appsv1 "k8s.io/api/apps/v1"

--- a/controllers/components/modelregistry/modelregistry_controller_actions.go
+++ b/controllers/components/modelregistry/modelregistry_controller_actions.go
@@ -57,6 +57,10 @@ func initialize(ctx context.Context, rr *odhtypes.ReconciliationRequest) error {
 		baseManifestInfo(BaseManifestsSourcePath),
 		extraManifestInfo(BaseManifestsSourcePath),
 	}
+	rr.Templates = []odhtypes.TemplateInfo{{
+		FS:   resourcesFS,
+		Path: ServiceMeshMemberTemplate,
+	}}
 
 	df := mr.GetDevFlags()
 
@@ -121,17 +125,6 @@ func configureDependencies(ctx context.Context, rr *odhtypes.ReconciliationReque
 		},
 	); err != nil {
 		return fmt.Errorf("failed to add default ingress secret for model registry: %w", err)
-	}
-
-	// Service Mesh
-
-	smm, err := createServiceMeshMember(rr.DSCI, mr.Spec.RegistriesNamespace)
-	if err != nil {
-		return fmt.Errorf("failed to create ServiceMesh Member: %w", err)
-	}
-
-	if err := rr.AddResource(smm); err != nil {
-		return fmt.Errorf("failed to add ServiceMesh Member: %w", err)
 	}
 
 	return nil

--- a/controllers/components/modelregistry/modelregistry_support.go
+++ b/controllers/components/modelregistry/modelregistry_support.go
@@ -1,26 +1,12 @@
 package modelregistry
 
 import (
-	"context"
-	"fmt"
+	"embed"
 	"path"
-	"strings"
-	"text/template"
-
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/event"
-	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	componentsv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/components/v1"
-	dsciv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/dscinitialization/v1"
-	infrav1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/infrastructure/v1"
-	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
 	odhtypes "github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
-	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/conversion"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/deploy"
-
-	_ "embed"
 )
 
 const (
@@ -28,6 +14,7 @@ const (
 	DefaultModelRegistriesNamespace = "odh-model-registries"
 	DefaultModelRegistryCert        = "default-modelregistry-cert"
 	BaseManifestsSourcePath         = "overlays/odh"
+	ServiceMeshMemberTemplate       = "resources/servicemesh-member.tmpl.yaml"
 )
 
 var (
@@ -42,8 +29,8 @@ var (
 	}
 )
 
-//go:embed resources/servicemesh-member.tmpl.yaml
-var smmTemplate string
+//go:embed resources
+var resourcesFS embed.FS
 
 func baseManifestInfo(sourcePath string) odhtypes.ManifestInfo {
 	return odhtypes.ManifestInfo{
@@ -58,62 +45,5 @@ func extraManifestInfo(sourcePath string) odhtypes.ManifestInfo {
 		Path:       deploy.DefaultManifestPath,
 		ContextDir: ComponentName,
 		SourcePath: path.Join(sourcePath, "extras"),
-	}
-}
-
-func createServiceMeshMember(dsci *dsciv1.DSCInitialization, namespace string) (*unstructured.Unstructured, error) {
-	tmpl, err := template.New("servicemeshmember").Parse(smmTemplate)
-	if err != nil {
-		return nil, fmt.Errorf("error parsing servicemeshmember template: %w", err)
-	}
-
-	controlPlaneData := struct {
-		Namespace    string
-		ControlPlane *infrav1.ControlPlaneSpec
-	}{
-		Namespace:    namespace,
-		ControlPlane: &dsci.Spec.ServiceMesh.ControlPlane,
-	}
-
-	builder := strings.Builder{}
-	if err = tmpl.Execute(&builder, controlPlaneData); err != nil {
-		return nil, fmt.Errorf("error executing servicemeshmember template: %w", err)
-	}
-
-	obj, err := conversion.StrToUnstructured(builder.String())
-	if err != nil || len(obj) != 1 {
-		return nil, fmt.Errorf("error converting servicemeshmember template: %w", err)
-	}
-
-	return obj[0], nil
-}
-
-func ingressSecret(ctx context.Context, cli client.Client) predicate.Funcs {
-	f := func(obj client.Object) bool {
-		ic, err := cluster.FindAvailableIngressController(ctx, cli)
-		if err != nil {
-			return false
-		}
-		if ic.Spec.DefaultCertificate == nil {
-			return false
-		}
-
-		return obj.GetName() == ic.Spec.DefaultCertificate.Name &&
-			obj.GetNamespace() == cluster.IngressNamespace
-	}
-
-	return predicate.Funcs{
-		CreateFunc: func(e event.CreateEvent) bool {
-			return false
-		},
-		GenericFunc: func(e event.GenericEvent) bool {
-			return false
-		},
-		DeleteFunc: func(e event.DeleteEvent) bool {
-			return f(e.Object)
-		},
-		UpdateFunc: func(e event.UpdateEvent) bool {
-			return f(e.ObjectNew)
-		},
 	}
 }

--- a/controllers/components/modelregistry/resources/servicemesh-member.tmpl.yaml
+++ b/controllers/components/modelregistry/resources/servicemesh-member.tmpl.yaml
@@ -2,7 +2,7 @@ apiVersion: maistra.io/v1
 kind: ServiceMeshMember
 metadata:
   name: default
-  namespace: {{.Instance.Spec.RegistriesNamespace}}
+  namespace: {{.Component.Spec.RegistriesNamespace}}
 spec:
   controlPlaneRef:
     namespace: {{ .DSCI.Spec.ServiceMesh.ControlPlane.Namespace }}

--- a/controllers/components/modelregistry/resources/servicemesh-member.tmpl.yaml
+++ b/controllers/components/modelregistry/resources/servicemesh-member.tmpl.yaml
@@ -2,8 +2,8 @@ apiVersion: maistra.io/v1
 kind: ServiceMeshMember
 metadata:
   name: default
-  namespace: {{.Namespace}}
+  namespace: {{.Instance.Spec.RegistriesNamespace}}
 spec:
   controlPlaneRef:
-    namespace: {{ .ControlPlane.Namespace }}
-    name: {{ .ControlPlane.Name }}
+    namespace: {{ .DSCI.Spec.ServiceMesh.ControlPlane.Namespace }}
+    name: {{ .DSCI.Spec.ServiceMesh.ControlPlane.Name }}

--- a/controllers/components/ray/ray_controller.go
+++ b/controllers/components/ray/ray_controller.go
@@ -29,6 +29,7 @@ import (
 
 	componentsv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/components/v1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/deploy"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/render"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/render/kustomize"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/updatestatus"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/predicates/resources"
@@ -57,7 +58,7 @@ func NewComponentReconciler(ctx context.Context, mgr ctrl.Manager) error {
 		WithAction(initialize).
 		WithAction(devFlags).
 		WithAction(kustomize.NewAction(
-			kustomize.WithCache(kustomize.DefaultCachingKeyFn),
+			kustomize.WithCache(render.DefaultCachingKeyFn),
 			kustomize.WithLabel(labels.ODH.Component(ComponentName), "true"),
 			kustomize.WithLabel(labels.K8SCommon.PartOf, ComponentName),
 		)).

--- a/controllers/components/trainingoperator/trainingoperator_controller.go
+++ b/controllers/components/trainingoperator/trainingoperator_controller.go
@@ -19,6 +19,7 @@ package trainingoperator
 import (
 	"context"
 
+
 	promv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -29,6 +30,7 @@ import (
 
 	componentsv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/components/v1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/deploy"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/render"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/render/kustomize"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/updatestatus"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/predicates/resources"
@@ -54,7 +56,7 @@ func NewComponentReconciler(ctx context.Context, mgr ctrl.Manager) error {
 		WithAction(initialize).
 		WithAction(devFlags).
 		WithAction(kustomize.NewAction(
-			kustomize.WithCache(kustomize.DefaultCachingKeyFn),
+			kustomize.WithCache(render.DefaultCachingKeyFn),
 			kustomize.WithLabel(labels.ODH.Component(ComponentName), "true"),
 			kustomize.WithLabel(labels.K8SCommon.PartOf, ComponentName),
 		)).

--- a/controllers/components/trainingoperator/trainingoperator_controller.go
+++ b/controllers/components/trainingoperator/trainingoperator_controller.go
@@ -19,7 +19,6 @@ package trainingoperator
 import (
 	"context"
 
-
 	promv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"

--- a/controllers/components/trustyai/trustyai_controller.go
+++ b/controllers/components/trustyai/trustyai_controller.go
@@ -28,6 +28,7 @@ import (
 
 	componentsv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/components/v1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/deploy"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/render"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/render/kustomize"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/updatestatus"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/predicates/resources"
@@ -55,7 +56,7 @@ func NewComponentReconciler(ctx context.Context, mgr ctrl.Manager) error {
 		WithAction(initialize).
 		WithAction(devFlags).
 		WithAction(kustomize.NewAction(
-			kustomize.WithCache(kustomize.DefaultCachingKeyFn),
+			kustomize.WithCache(render.DefaultCachingKeyFn),
 			kustomize.WithLabel(labels.ODH.Component(ComponentName), "true"),
 			kustomize.WithLabel(labels.K8SCommon.PartOf, ComponentName),
 		)).

--- a/pkg/controller/actions/render/kustomize/action_render_manifests_test.go
+++ b/pkg/controller/actions/render/kustomize/action_render_manifests_test.go
@@ -193,7 +193,7 @@ func TestRenderResourcesWithCacheAction(t *testing.T) {
 	g.Expect(err).ShouldNot(HaveOccurred())
 
 	action := kustomize.NewAction(
-		kustomize.WithCache(kustomize.DefaultCachingKeyFn),
+		kustomize.WithCache(render.DefaultCachingKeyFn),
 		kustomize.WithLabel(labels.ComponentPartOf, "foo"),
 		kustomize.WithLabel("platform.opendatahub.io/namespace", ns),
 		kustomize.WithAnnotation("platform.opendatahub.io/release", "1.2.3"),

--- a/pkg/controller/actions/render/template/action_render_templates.go
+++ b/pkg/controller/actions/render/template/action_render_templates.go
@@ -20,7 +20,7 @@ import (
 
 const (
 	RendererEngine = "template"
-	InstanceKey    = "Instance"
+	ComponentKey   = "Component"
 	DSCIKey        = "DSCI"
 )
 
@@ -97,7 +97,7 @@ func (a *Action) render(rr *types.ReconciliationRequest) ([]unstructured.Unstruc
 	decoder := serializer.NewCodecFactory(rr.Client.Scheme()).UniversalDeserializer()
 
 	data := maps.Clone(a.data)
-	data[InstanceKey] = rr.Instance
+	data[ComponentKey] = rr.Instance
 	data[DSCIKey] = rr.DSCI
 
 	result := make([]unstructured.Unstructured, 0)

--- a/pkg/controller/actions/render/template/action_render_templates_test.go
+++ b/pkg/controller/actions/render/template/action_render_templates_test.go
@@ -1,0 +1,148 @@
+package template_test
+
+import (
+	"context"
+	"embed"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/rs/xid"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	componentsv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/components/v1"
+	dscv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/datasciencecluster/v1"
+	dsciv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/dscinitialization/v1"
+	infrav1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/infrastructure/v1"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/render"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/render/template"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/fakeclient"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/matchers/jq"
+
+	. "github.com/onsi/gomega"
+)
+
+//go:embed resources
+var testFS embed.FS
+
+func TestRenderTemplateAction(t *testing.T) {
+	g := NewWithT(t)
+
+	ctx := context.Background()
+	ns := xid.New().String()
+
+	cl, err := fakeclient.New(ctx)
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	action := template.NewAction()
+
+	rr := types.ReconciliationRequest{
+		Client: cl,
+		Instance: &componentsv1.Dashboard{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: ns,
+			},
+		},
+		DSCI: &dsciv1.DSCInitialization{
+			Spec: dsciv1.DSCInitializationSpec{
+				ApplicationsNamespace: ns,
+				ServiceMesh: &infrav1.ServiceMeshSpec{
+					ControlPlane: infrav1.ControlPlaneSpec{
+						Name:      xid.New().String(),
+						Namespace: xid.New().String(),
+					},
+				},
+			},
+		},
+		DSC:       &dscv1.DataScienceCluster{},
+		Release:   cluster.Release{Name: cluster.OpenDataHub},
+		Templates: []types.TemplateInfo{{FS: testFS, Path: "resources/smm.tmpl.yaml"}},
+	}
+
+	err = action(ctx, &rr)
+
+	g.Expect(err).ShouldNot(HaveOccurred())
+	g.Expect(rr.Resources).Should(And(
+		HaveLen(1),
+		HaveEach(And(
+			jq.Match(`.metadata.namespace == "%s"`, ns),
+			jq.Match(`.spec.controlPlaneRef.namespace == "%s"`, rr.DSCI.Spec.ServiceMesh.ControlPlane.Namespace),
+			jq.Match(`.spec.controlPlaneRef.name == "%s"`, rr.DSCI.Spec.ServiceMesh.ControlPlane.Name),
+			jq.Match(`.metadata.annotations."instance-name" == "%s"`, rr.Instance.GetName()),
+		)),
+	))
+}
+
+func TestRenderTemplateWithCacheAction(t *testing.T) {
+	g := NewWithT(t)
+
+	ctx := context.Background()
+	ns := xid.New().String()
+
+	cl, err := fakeclient.New(ctx)
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	action := template.NewAction(
+		template.WithCache(render.DefaultCachingKeyFn),
+	)
+
+	render.RenderedResourcesTotal.Reset()
+
+	dsci := dsciv1.DSCInitialization{
+		Spec: dsciv1.DSCInitializationSpec{
+			ApplicationsNamespace: ns,
+			ServiceMesh: &infrav1.ServiceMeshSpec{
+				ControlPlane: infrav1.ControlPlaneSpec{
+					Name:      xid.New().String(),
+					Namespace: xid.New().String(),
+				},
+			},
+		},
+	}
+
+	for i := int64(0); i < 3; i++ {
+		d := componentsv1.Dashboard{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: ns,
+			},
+		}
+
+		if i >= 1 {
+			d.Generation = 1
+		}
+
+		rr := types.ReconciliationRequest{
+			Client:    cl,
+			Instance:  &d,
+			DSCI:      &dsci,
+			DSC:       &dscv1.DataScienceCluster{},
+			Release:   cluster.Release{Name: cluster.OpenDataHub},
+			Templates: []types.TemplateInfo{{FS: testFS, Path: "resources/smm.tmpl.yaml"}},
+		}
+
+		err = action(ctx, &rr)
+
+		g.Expect(err).ShouldNot(HaveOccurred())
+		g.Expect(rr.Resources).Should(And(
+			HaveLen(1),
+			HaveEach(And(
+				jq.Match(`.metadata.namespace == "%s"`, ns),
+				jq.Match(`.spec.controlPlaneRef.namespace == "%s"`, rr.DSCI.Spec.ServiceMesh.ControlPlane.Namespace),
+				jq.Match(`.spec.controlPlaneRef.name == "%s"`, rr.DSCI.Spec.ServiceMesh.ControlPlane.Name),
+				jq.Match(`.metadata.annotations."instance-name" == "%s"`, rr.Instance.GetName()),
+			)),
+		))
+
+		rc := testutil.ToFloat64(render.RenderedResourcesTotal)
+
+		switch i {
+		case 0:
+			g.Expect(rc).Should(BeNumerically("==", 1))
+		case 1:
+			g.Expect(rc).Should(BeNumerically("==", 2))
+		case 2:
+			g.Expect(rc).Should(BeNumerically("==", 2))
+		}
+	}
+}

--- a/pkg/controller/actions/render/template/resources/smm-data.tmpl.yaml
+++ b/pkg/controller/actions/render/template/resources/smm-data.tmpl.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{.SMM.Name}}
   namespace: {{.DSCI.Spec.ApplicationsNamespace}}
   annotations:
-    instance-name: {{.Instance.Name}}
+    instance-name: {{.Component.Name}}
     instance-id: {{.ID}}
 spec:
   controlPlaneRef:

--- a/pkg/controller/actions/render/template/resources/smm-data.tmpl.yaml
+++ b/pkg/controller/actions/render/template/resources/smm-data.tmpl.yaml
@@ -1,0 +1,12 @@
+apiVersion: maistra.io/v1
+kind: ServiceMeshMember
+metadata:
+  name: {{.SMM.Name}}
+  namespace: {{.DSCI.Spec.ApplicationsNamespace}}
+  annotations:
+    instance-name: {{.Instance.Name}}
+    instance-id: {{.ID}}
+spec:
+  controlPlaneRef:
+    namespace: {{ .DSCI.Spec.ServiceMesh.ControlPlane.Namespace }}
+    name: {{ .DSCI.Spec.ServiceMesh.ControlPlane.Name }}

--- a/pkg/controller/actions/render/template/resources/smm.tmpl.yaml
+++ b/pkg/controller/actions/render/template/resources/smm.tmpl.yaml
@@ -1,0 +1,11 @@
+apiVersion: maistra.io/v1
+kind: ServiceMeshMember
+metadata:
+  name: default
+  namespace: {{.DSCI.Spec.ApplicationsNamespace}}
+  annotations:
+    instance-name: {{.Instance.Name}}
+spec:
+  controlPlaneRef:
+    namespace: {{ .DSCI.Spec.ServiceMesh.ControlPlane.Namespace }}
+    name: {{ .DSCI.Spec.ServiceMesh.ControlPlane.Name }}

--- a/pkg/controller/actions/render/template/resources/smm.tmpl.yaml
+++ b/pkg/controller/actions/render/template/resources/smm.tmpl.yaml
@@ -4,7 +4,7 @@ metadata:
   name: default
   namespace: {{.DSCI.Spec.ApplicationsNamespace}}
   annotations:
-    instance-name: {{.Instance.Name}}
+    instance-name: {{.Component.Name}}
 spec:
   controlPlaneRef:
     namespace: {{ .DSCI.Spec.ServiceMesh.ControlPlane.Namespace }}

--- a/pkg/controller/predicates/resources/resources.go
+++ b/pkg/controller/predicates/resources/resources.go
@@ -6,26 +6,33 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
 
-func NewDeploymentPredicate() predicate.Funcs {
-	return predicate.Funcs{
-		UpdateFunc: func(e event.UpdateEvent) bool {
-			if e.ObjectOld == nil || e.ObjectNew == nil {
-				return true
-			}
+var _ predicate.Predicate = DeploymentPredicate{}
 
-			oldDeployment, ok := e.ObjectOld.(*appsv1.Deployment)
-			if !ok {
-				return false
-			}
+type DeploymentPredicate struct {
+	predicate.Funcs
+}
 
-			newDeployment, ok := e.ObjectNew.(*appsv1.Deployment)
-			if !ok {
-				return false
-			}
-
-			return oldDeployment.Generation != newDeployment.Generation ||
-				oldDeployment.Status.Replicas != newDeployment.Status.Replicas ||
-				oldDeployment.Status.ReadyReplicas != newDeployment.Status.ReadyReplicas
-		},
+// Update implements default UpdateEvent filter for validating generation change.
+func (DeploymentPredicate) Update(e event.UpdateEvent) bool {
+	if e.ObjectOld == nil || e.ObjectNew == nil {
+		return false
 	}
+
+	oldDeployment, ok := e.ObjectOld.(*appsv1.Deployment)
+	if !ok {
+		return false
+	}
+
+	newDeployment, ok := e.ObjectNew.(*appsv1.Deployment)
+	if !ok {
+		return false
+	}
+
+	return oldDeployment.Generation != newDeployment.Generation ||
+		oldDeployment.Status.Replicas != newDeployment.Status.Replicas ||
+		oldDeployment.Status.ReadyReplicas != newDeployment.Status.ReadyReplicas
+}
+
+func NewDeploymentPredicate() *DeploymentPredicate {
+	return &DeploymentPredicate{}
 }

--- a/pkg/controller/predicates/resources/resources.go
+++ b/pkg/controller/predicates/resources/resources.go
@@ -8,16 +8,6 @@ import (
 
 func NewDeploymentPredicate() predicate.Funcs {
 	return predicate.Funcs{
-		CreateFunc: func(e event.CreateEvent) bool {
-			return true
-		},
-		DeleteFunc: func(e event.DeleteEvent) bool {
-			return true
-		},
-		GenericFunc: func(e event.GenericEvent) bool {
-			return true
-		},
-
 		UpdateFunc: func(e event.UpdateEvent) bool {
 			if e.ObjectOld == nil || e.ObjectNew == nil {
 				return true

--- a/pkg/controller/reconciler/component_reconciler.go
+++ b/pkg/controller/reconciler/component_reconciler.go
@@ -138,7 +138,7 @@ func (r *ComponentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	if !res.GetDeletionTimestamp().IsZero() {
 		// Execute finalizers
 		for _, action := range r.Finalizer {
-			l.Info("Executing finalizer", "action", action)
+			l.V(3).Info("Executing finalizer", "action", action)
 
 			actx := log.IntoContext(
 				ctx,
@@ -152,7 +152,7 @@ func (r *ComponentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 					return ctrl.Result{}, err
 				}
 
-				l.Info("detected stop marker", "action", action)
+				l.V(3).Info("detected stop marker", "action", action)
 				break
 			}
 		}
@@ -162,7 +162,7 @@ func (r *ComponentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 
 	// Execute actions
 	for _, action := range r.Actions {
-		l.Info("Executing action", "action", action)
+		l.V(3).Info("Executing action", "action", action)
 
 		actx := log.IntoContext(
 			ctx,
@@ -176,7 +176,7 @@ func (r *ComponentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 				return ctrl.Result{}, err
 			}
 
-			l.Info("detected stop marker", "action", action)
+			l.V(3).Info("detected stop marker", "action", action)
 			break
 		}
 	}

--- a/pkg/controller/reconciler/component_reconciler_support.go
+++ b/pkg/controller/reconciler/component_reconciler_support.go
@@ -97,30 +97,7 @@ func (b *ComponentReconcilerBuilder) WatchesH(object client.Object, eventHandler
 	return b
 }
 
-func (b *ComponentReconcilerBuilder) WatchesM(object client.Object, fn handler.MapFunc, opts ...builder.WatchesOption) *ComponentReconcilerBuilder {
-	b.watches = append(b.watches, watchInput{
-		object:       object,
-		eventHandler: handler.EnqueueRequestsFromMapFunc(fn),
-		options:      slices.Clone(opts),
-	})
-
-	return b
-}
-
-func (b *ComponentReconcilerBuilder) WatchesGVK(gvk schema.GroupVersionKind, opts ...builder.WatchesOption) *ComponentReconcilerBuilder {
-	u := unstructured.Unstructured{}
-	u.SetGroupVersionKind(gvk)
-
-	b.watches = append(b.watches, watchInput{
-		object:       &u,
-		eventHandler: handlers.ToOwner(),
-		options:      slices.Clone(opts),
-	})
-
-	return b
-}
-
-func (b *ComponentReconcilerBuilder) WatchesGVKH(gvk schema.GroupVersionKind, eventHandler handler.EventHandler, opts ...builder.WatchesOption) *ComponentReconcilerBuilder {
+func (b *ComponentReconcilerBuilder) WatchesGVK(gvk schema.GroupVersionKind, eventHandler handler.EventHandler, opts ...builder.WatchesOption) *ComponentReconcilerBuilder {
 	u := unstructured.Unstructured{}
 	u.SetGroupVersionKind(gvk)
 
@@ -133,12 +110,9 @@ func (b *ComponentReconcilerBuilder) WatchesGVKH(gvk schema.GroupVersionKind, ev
 	return b
 }
 
-func (b *ComponentReconcilerBuilder) WatchesGVKM(gvk schema.GroupVersionKind, fn handler.MapFunc, opts ...builder.WatchesOption) *ComponentReconcilerBuilder {
-	u := unstructured.Unstructured{}
-	u.SetGroupVersionKind(gvk)
-
+func (b *ComponentReconcilerBuilder) WatchesM(object client.Object, fn handler.MapFunc, opts ...builder.WatchesOption) *ComponentReconcilerBuilder {
 	b.watches = append(b.watches, watchInput{
-		object:       &u,
+		object:       object,
 		eventHandler: handler.EnqueueRequestsFromMapFunc(fn),
 		options:      slices.Clone(opts),
 	})

--- a/pkg/controller/reconciler/component_reconciler_support.go
+++ b/pkg/controller/reconciler/component_reconciler_support.go
@@ -97,7 +97,30 @@ func (b *ComponentReconcilerBuilder) WatchesH(object client.Object, eventHandler
 	return b
 }
 
-func (b *ComponentReconcilerBuilder) WatchesGVK(gvk schema.GroupVersionKind, eventHandler handler.EventHandler, opts ...builder.WatchesOption) *ComponentReconcilerBuilder {
+func (b *ComponentReconcilerBuilder) WatchesM(object client.Object, fn handler.MapFunc, opts ...builder.WatchesOption) *ComponentReconcilerBuilder {
+	b.watches = append(b.watches, watchInput{
+		object:       object,
+		eventHandler: handler.EnqueueRequestsFromMapFunc(fn),
+		options:      slices.Clone(opts),
+	})
+
+	return b
+}
+
+func (b *ComponentReconcilerBuilder) WatchesGVK(gvk schema.GroupVersionKind, opts ...builder.WatchesOption) *ComponentReconcilerBuilder {
+	u := unstructured.Unstructured{}
+	u.SetGroupVersionKind(gvk)
+
+	b.watches = append(b.watches, watchInput{
+		object:       &u,
+		eventHandler: handlers.ToOwner(),
+		options:      slices.Clone(opts),
+	})
+
+	return b
+}
+
+func (b *ComponentReconcilerBuilder) WatchesGVKH(gvk schema.GroupVersionKind, eventHandler handler.EventHandler, opts ...builder.WatchesOption) *ComponentReconcilerBuilder {
 	u := unstructured.Unstructured{}
 	u.SetGroupVersionKind(gvk)
 
@@ -110,9 +133,12 @@ func (b *ComponentReconcilerBuilder) WatchesGVK(gvk schema.GroupVersionKind, eve
 	return b
 }
 
-func (b *ComponentReconcilerBuilder) WatchesM(object client.Object, fn handler.MapFunc, opts ...builder.WatchesOption) *ComponentReconcilerBuilder {
+func (b *ComponentReconcilerBuilder) WatchesGVKM(gvk schema.GroupVersionKind, fn handler.MapFunc, opts ...builder.WatchesOption) *ComponentReconcilerBuilder {
+	u := unstructured.Unstructured{}
+	u.SetGroupVersionKind(gvk)
+
 	b.watches = append(b.watches, watchInput{
-		object:       object,
+		object:       &u,
 		eventHandler: handler.EnqueueRequestsFromMapFunc(fn),
 		options:      slices.Clone(opts),
 	})

--- a/pkg/controller/types/types.go
+++ b/pkg/controller/types/types.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"fmt"
+	"io/fs"
 	"path"
 
 	"github.com/go-logr/logr"
@@ -46,6 +47,11 @@ func (mi *ManifestInfo) String() string {
 	return result
 }
 
+type TemplateInfo struct {
+	FS   fs.FS
+	Path string
+}
+
 type ReconciliationRequest struct {
 	*odhClient.Client
 
@@ -55,6 +61,28 @@ type ReconciliationRequest struct {
 	DSCI      *dsciv1.DSCInitialization
 	Release   cluster.Release
 	Manifests []ManifestInfo
+
+	//
+	// TODO: unify templates and resources.
+	//
+	// Unfortunately, the kustomize APIs do not yet support a FileSystem that is
+	// backed by golang's fs.Fs so it is not simple to have a single abstraction
+	// for both the manifests types.
+	//
+	// it would be nice to have a structure like:
+	//
+	// struct {
+	//   FS  fs.FS
+	//   URI net.URL
+	// }
+	//
+	// where the URI could be something like:
+	// - kustomize:///path/to/overlay
+	// - template:///path/to/resource.tmpl.yaml
+	//
+	// and use the scheme as discriminator for the rendering engine
+	//
+	Templates []TemplateInfo
 	Resources []unstructured.Unstructured
 }
 

--- a/pkg/resources/resources.go
+++ b/pkg/resources/resources.go
@@ -2,11 +2,12 @@ package resources
 
 import (
 	"bytes"
+	"crypto/sha256"
 	"errors"
 	"fmt"
 	"io"
-	"crypto/sha256"
 
+	"github.com/davecgh/go-spew/spew"
 	routev1 "github.com/openshift/api/route/v1"
 	"gopkg.in/yaml.v3"
 	corev1 "k8s.io/api/core/v1"
@@ -14,7 +15,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"github.com/davecgh/go-spew/spew"
 )
 
 func ToUnstructured(obj any) (*unstructured.Unstructured, error) {


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->
This PR introduces a new rendering engine that is based on the go text/template package.

The template is rendered to the actual objects taking a subset of the `ReconciliationRequest` struct: `Instance` and `DSCI` so as an example, the `ServiceMeshMember` template that is part of the model registry component would looks like:

```yaml
apiVersion: maistra.io/v1
kind: ServiceMeshMember
metadata:
  name: default
  namespace: {{.Instance.Spec.RegistriesNamespace}}
spec:
  controlPlaneRef:
    namespace: {{ .DSCI.Spec.ServiceMesh.ControlPlane.Namespace }}
    name: {{ .DSCI.Spec.ServiceMesh.ControlPlane.Name }}

```

<!--- Link your JIRA and related links here for reference. -->
https://issues.redhat.com/browse/RHOAIENG-15534

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

1. Enable the model registry component in DSC
2. Check for the presence of a  `ServiceMeshMember` instance in the model registries namespace named `default` and that it contains the expected values
3. Check metrics related to the render action, it should include something like:
```
# HELP action_renderer_manifests_total Number of rendered resources
# TYPE action_renderer_manifests_total counter
action_renderer_manifests_total{controller="modelregistry",engine="kustomize"} 17
action_renderer_manifests_total{controller="modelregistry",engine="template"} 1
```


## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [X] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [X] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work
