### PR TITLE
[sync] fix: add extra check on servicemesh CRD and svc before proceeding create SMCP CR (#1359)

### DIFF
--- a/pkg/cluster/operator.go
+++ b/pkg/cluster/operator.go
@@ -4,9 +4,14 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/operator-framework/api/pkg/operators/v1alpha1"
 	ofapiv2 "github.com/operator-framework/api/pkg/operators/v2"
+	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -66,4 +71,32 @@ func OperatorExists(ctx context.Context, cli client.Client, operatorPrefix strin
 	}
 
 	return false, nil
+}
+
+// CustomResourceDefinitionExists checks if a CustomResourceDefinition with the given GVK exists.
+func CustomResourceDefinitionExists(ctx context.Context, cli client.Client, crdGK schema.GroupKind) error {
+	crd := &apiextv1.CustomResourceDefinition{}
+	resourceInterval, resourceTimeout := 2*time.Second, 5*time.Second
+	name := strings.ToLower(fmt.Sprintf("%ss.%s", crdGK.Kind, crdGK.Group)) // we need plural form of the kind
+
+	err := wait.PollUntilContextTimeout(ctx, resourceInterval, resourceTimeout, false, func(ctx context.Context) (bool, error) {
+		err := cli.Get(ctx, client.ObjectKey{Name: name}, crd)
+		if err != nil {
+			if errors.IsNotFound(err) {
+				return false, nil
+			}
+			return false, err
+		}
+
+		for _, condition := range crd.Status.Conditions {
+			if condition.Type == apiextv1.Established {
+				if condition.Status == apiextv1.ConditionTrue {
+					return true, nil
+				}
+			}
+		}
+		return false, nil
+	})
+
+	return err
 }

--- a/tests/integration/features/fixtures/cluster_test_fixtures.go
+++ b/tests/integration/features/fixtures/cluster_test_fixtures.go
@@ -79,6 +79,28 @@ func GetService(ctx context.Context, client client.Client, namespace, name strin
 	return svc, err
 }
 
+func CreateService(ctx context.Context, client client.Client, namespace, svcName string) (*corev1.Service, error) {
+	if err := client.Create(ctx, &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      svcName,
+			Namespace: namespace,
+		},
+		Spec: corev1.ServiceSpec{
+			Selector: map[string]string{
+				"name": "istio-operator",
+			},
+			Ports: []corev1.ServicePort{
+				{
+					Port: 443,
+				},
+			},
+		},
+	}); err != nil {
+		return nil, err
+	}
+	return GetService(ctx, client, namespace, svcName)
+}
+
 func CreateSecret(name, namespace string) feature.Action {
 	return func(ctx context.Context, cli client.Client, f *feature.Feature) error {
 		secret := &corev1.Secret{

--- a/tests/integration/features/servicemesh_feature_test.go
+++ b/tests/integration/features/servicemesh_feature_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"path"
 
+	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -49,9 +50,11 @@ var _ = Describe("Service Mesh setup", func() {
 
 		Context("operator setup", func() {
 
-			When("operator is not installed", func() {
+			Context("operator is not installed", Ordered, func() {
 
-				It("should fail using precondition check", func(ctx context.Context) {
+				var smcpCrdObj *apiextensionsv1.CustomResourceDefinition
+
+				It("should fail using precondition subscription check", func(ctx context.Context) {
 					// given
 					featuresHandler := feature.ClusterFeaturesHandler(dsci, func(registry feature.FeaturesRegistry) error {
 						errFeatureAdd := registry.Add(feature.Define("no-service-mesh-operator-check").
@@ -69,19 +72,72 @@ var _ = Describe("Service Mesh setup", func() {
 					// then
 					Expect(applyErr).To(MatchError(ContainSubstring("failed to find the pre-requisite operator subscription \"servicemeshoperator\"")))
 				})
+
+				It("should fail using precondition CRD check", func(ctx context.Context) {
+					// given
+					err := fixtures.CreateSubscription(ctx, envTestClient, "openshift-operators", fixtures.OssmSubscription)
+					Expect(err).ToNot(HaveOccurred())
+
+					featuresHandler := feature.ClusterFeaturesHandler(dsci, func(registry feature.FeaturesRegistry) error {
+						errFeatureAdd := registry.Add(feature.Define("no-service-mesh-crd-check").
+							PreConditions(servicemesh.EnsureServiceMeshOperatorInstalled),
+						)
+
+						Expect(errFeatureAdd).ToNot(HaveOccurred())
+
+						return nil
+					})
+
+					// when
+					applyErr := featuresHandler.Apply(ctx, envTestClient)
+
+					// then
+					Expect(applyErr).To(MatchError(ContainSubstring("failed to find the Service Mesh Control Plane CRD")))
+				})
+
+				It("should fail using precondition service check", func(ctx context.Context) {
+					// given
+					smcpCrdObj = installServiceMeshCRD(ctx)
+
+					featuresHandler := feature.ClusterFeaturesHandler(dsci, func(registry feature.FeaturesRegistry) error {
+						errFeatureAdd := registry.Add(feature.Define("no-service-mesh-service-check").
+							PreConditions(servicemesh.EnsureServiceMeshOperatorInstalled),
+						)
+
+						Expect(errFeatureAdd).ToNot(HaveOccurred())
+
+						return nil
+					})
+
+					// when
+					applyErr := featuresHandler.Apply(ctx, envTestClient)
+
+					// then
+					Expect(applyErr).To(MatchError(ContainSubstring("failed to find the Service Mesh VWC service")))
+				})
+
+				AfterAll(func(ctx context.Context) {
+					objectCleaner.DeleteAll(ctx, smcpCrdObj)
+				})
 			})
 
 			When("operator is installed", func() {
 				var smcpCrdObj *apiextensionsv1.CustomResourceDefinition
+				var svc *corev1.Service
 
 				BeforeEach(func(ctx context.Context) {
 					err := fixtures.CreateSubscription(ctx, envTestClient, "openshift-operators", fixtures.OssmSubscription)
 					Expect(err).ToNot(HaveOccurred())
+
 					smcpCrdObj = installServiceMeshCRD(ctx)
+
+					svc, err = fixtures.CreateService(ctx, envTestClient, "openshift-operators", "istio-operator-service")
+					Expect(err).ToNot(HaveOccurred())
+
 				})
 
 				AfterEach(func(ctx context.Context) {
-					objectCleaner.DeleteAll(ctx, smcpCrdObj)
+					objectCleaner.DeleteAll(ctx, smcpCrdObj, svc)
 				})
 
 				It("should succeed using precondition check", func(ctx context.Context) {


### PR DESCRIPTION
* fix: add extra check on servicemesh CRD and service before proceeding create SMCP CR
- when we install operator we might have a race condition:
    - ossm is not ready to server
    - dsci already created smcp CR
    - since we do not know the version of smcp to use
    - ossm webhook can run into conversion problem since no version specify in smcp CR
   -  test: add more negative test
       - when CRD does not exist
       - when service does not exist
---------

Signed-off-by: Wen Zhou <wenzhou@redhat.com>
(cherry picked from commit e25487a7deef512762a672cad1066c23baf125ba)

<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

<!--- Link your JIRA and related links here for reference. -->
https://issues.redhat.com/browse/RHOAIENG-15227

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
