### PR TITLE
[sync]fix: added a filter to evicted pods when checking for ready status

### DIFF
--- a/pkg/feature/conditions.go
+++ b/pkg/feature/conditions.go
@@ -64,6 +64,7 @@ func WaitForPodsToBeReady(namespace string) Action {
 				return false, err
 			}
 
+			podList.Items = filterEvictedPods(podList.Items)
 			readyPods := 0
 			totalPods := len(podList.Items)
 
@@ -100,6 +101,18 @@ func WaitForPodsToBeReady(namespace string) Action {
 			return done, nil
 		})
 	}
+}
+
+func filterEvictedPods(pods []corev1.Pod) []corev1.Pod {
+	var filteredPods []corev1.Pod
+
+	for _, pod := range pods {
+		if pod.Status.Phase != corev1.PodFailed || pod.Status.Reason != "Evicted" {
+			filteredPods = append(filteredPods, pod)
+		}
+	}
+
+	return filteredPods
 }
 
 func WaitForResourceToBeCreated(namespace string, gvk schema.GroupVersionKind) Action {


### PR DESCRIPTION
* fix: added a filter to evicted pods

Signed-off-by: Alessio Pragliola <seth.pro@gmail.com>

---------

Signed-off-by: Alessio Pragliola <seth.pro@gmail.com>
(cherry picked from commit e589680f54bedd6c5170a110bceef8fd73879805)

<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

<!--- Link your JIRA and related links here for reference. -->
https://github.com/opendatahub-io/opendatahub-operator/pull/1334

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
