### PR TITLE
Dockerfile: merges manifests builder stages to one

### DIFF
--- a/Dockerfiles/Dockerfile
+++ b/Dockerfiles/Dockerfile
@@ -1,27 +1,21 @@
 # Build the manager binary
 ARG GOLANG_VERSION=1.21
+
+################################################################################
+FROM registry.access.redhat.com/ubi8/toolbox as manifests
 ARG USE_LOCAL=false
 ARG OVERWRITE_MANIFESTS=""
-
-################################################################################
-FROM registry.access.redhat.com/ubi8/go-toolset:$GOLANG_VERSION as builder_local_false
-ARG OVERWRITE_MANIFESTS
-# Get all manifests from remote git repo to builder_local_false by script
 USER root
 WORKDIR /
-COPY get_all_manifests.sh get_all_manifests.sh
-RUN ./get_all_manifests.sh ${OVERWRITE_MANIFESTS}
-
-################################################################################
-FROM registry.access.redhat.com/ubi8/go-toolset:$GOLANG_VERSION as builder_local_true
-# Get all manifests from local to builder_local_true
-USER root
-WORKDIR /opt
-# copy local manifests to build
 COPY opt/manifests/ /opt/manifests/
+COPY get_all_manifests.sh get_all_manifests.sh
+RUN if [ "${USE_LOCAL}" != "true" ]; then \
+        rm -rf /opt/manifests/*; \
+        ./get_all_manifests.sh ${OVERWRITE_MANIFESTS}; \
+    fi
 
 ################################################################################
-FROM builder_local_${USE_LOCAL} as builder
+FROM registry.access.redhat.com/ubi8/go-toolset:$GOLANG_VERSION as builder
 ARG CGO_ENABLED=1
 USER root
 WORKDIR /workspace
@@ -46,7 +40,7 @@ RUN CGO_ENABLED=${CGO_ENABLED} GOOS=linux GOARCH=amd64 go build -a -o manager ma
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 WORKDIR /
 COPY --from=builder /workspace/manager .
-COPY --chown=1001:0 --from=builder /opt/manifests /opt/manifests
+COPY --chown=1001:0 --from=manifests /opt/manifests /opt/manifests
 # Recursive change all files
 RUN chown -R 1001:0 /opt/manifests &&\
     chmod -R g=u /opt/manifests


### PR DESCRIPTION
We can combine two build stages into one, as there is no need to always build both images (not done by podman) to only then decide from which one we want to copy manifests to the target image. Instead manifests stage will either copy local manifests or fetches using the script based on USE_LOCAL argument.

Move USE_LOCAL and OVERWIRTE_MANIFESTS args under FROM since args have scope of the FROM they are declared in.

It requires opt/manifests directory to exist, but since it's a part of git repo, it's fine.

Original patch from: Bartosz Majsak <bartosz.majsak@gmail.com> [1]

[1] https://github.com/opendatahub-io/opendatahub-operator/pull/773

<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
