### PR TITLE
Makefile: make USE_LOCAL overridable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,7 @@ IMAGE_BUILDER ?= podman
 OPERATOR_NAMESPACE ?= opendatahub-operator-system
 DEFAULT_MANIFESTS_PATH ?= opt/manifests
 CGO_ENABLED ?= 1
+USE_LOCAL = false
 
 CHANNELS="fast"
 # CHANNELS define the bundle channels used in the bundle.
@@ -93,7 +94,7 @@ E2E_TEST_FLAGS = "--skip-deletion=false" -timeout 25m # See README.md, default g
 # Default image-build is to not use local odh-manifests folder
 # set to "true" to use local instead
 # see target "image-build"
-IMAGE_BUILD_FLAGS ?= --build-arg USE_LOCAL=false
+IMAGE_BUILD_FLAGS ?= --build-arg USE_LOCAL=$(USE_LOCAL)
 IMAGE_BUILD_FLAGS += --build-arg CGO_ENABLED=$(CGO_ENABLED)
 
 # Read any custom variables overrides from a local.mk file.  This will only be read if it exists in the

--- a/README.md
+++ b/README.md
@@ -134,8 +134,8 @@ make image-build
 By default, building an image without any local changes(as a clean build)
 This is what the production build system is doing.
 
-In order to build an image with local `opt/manifests` folder, to set `IMAGE_BUILD_FLAGS ="--build-arg USE_LOCAL=true"` in make.
-e.g `make image-build -e IMAGE_BUILD_FLAGS="--build-arg USE_LOCAL=true"`
+In order to build an image with local `opt/manifests` folder set `USE_LOCAL` make variable to `true`
+e.g `make image-build USE_LOCAL=true"`
 
 #### Build Image
 


### PR DESCRIPTION
Get USE_LOCAL image build flag from makefile variable to make it overridable with `make USE_LOCAL=true image`

Do not allow to get its value for environment be default due to pretty generic name.

This is shorter than the old recommendation of overriding  IMAGE_BUILD_FLAGS. And since now CGO_ENABLED is also a flag, does not mess up with it.

* USE_LOCAL=true uses existing manifests from opt/manifests for the produced image without downloading them with get_all_manifests.sh making it possible to both save time and make local amendments.

<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
