### PR TITLE
Support to watch/own object not known when the operator starts, but only after a component has been enabled.

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -59,6 +59,8 @@ linters-settings:
       # also allow generics
       - generic
       - EventHandler # for ToOwner
+      - predicate.Predicate
+      - client.Object
   revive:
     rules:
       - name: dot-imports

--- a/bundle/manifests/opendatahub-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/opendatahub-operator.clusterserviceversion.yaml
@@ -501,14 +501,6 @@ spec:
           - console.openshift.io
           resources:
           - consolelinks
-          verbs:
-          - create
-          - delete
-          - get
-          - patch
-        - apiGroups:
-          - console.openshift.io
-          resources:
           - odhquickstarts
           verbs:
           - create
@@ -624,15 +616,6 @@ spec:
           - dashboard.opendatahub.io
           resources:
           - acceleratorprofiles
-          verbs:
-          - create
-          - delete
-          - get
-          - list
-          - patch
-        - apiGroups:
-          - dashboard.opendatahub.io
-          resources:
           - odhapplications
           - odhdocuments
           verbs:
@@ -800,10 +783,22 @@ spec:
           resources:
           - servicemeshcontrolplanes
           - servicemeshmemberrolls
-          - servicemeshmembers
           - servicemeshmembers/finalizers
           verbs:
           - create
+          - get
+          - list
+          - patch
+          - update
+          - use
+          - watch
+        - apiGroups:
+          - maistra.io
+          resources:
+          - servicemeshmembers
+          verbs:
+          - create
+          - delete
           - get
           - list
           - patch

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -253,14 +253,6 @@ rules:
   - console.openshift.io
   resources:
   - consolelinks
-  verbs:
-  - create
-  - delete
-  - get
-  - patch
-- apiGroups:
-  - console.openshift.io
-  resources:
   - odhquickstarts
   verbs:
   - create
@@ -376,15 +368,6 @@ rules:
   - dashboard.opendatahub.io
   resources:
   - acceleratorprofiles
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-- apiGroups:
-  - dashboard.opendatahub.io
-  resources:
   - odhapplications
   - odhdocuments
   verbs:
@@ -552,10 +535,22 @@ rules:
   resources:
   - servicemeshcontrolplanes
   - servicemeshmemberrolls
-  - servicemeshmembers
   - servicemeshmembers/finalizers
   verbs:
   - create
+  - get
+  - list
+  - patch
+  - update
+  - use
+  - watch
+- apiGroups:
+  - maistra.io
+  resources:
+  - servicemeshmembers
+  verbs:
+  - create
+  - delete
   - get
   - list
   - patch

--- a/controllers/components/dashboard/dashboard.go
+++ b/controllers/components/dashboard/dashboard.go
@@ -39,7 +39,7 @@ func (s *componentHandler) Init(platform cluster.Platform) error {
 	return nil
 }
 
-func (s *componentHandler) NewCRObject(dsc *dscv1.DataScienceCluster) client.Object { //nolint:ireturn
+func (s *componentHandler) NewCRObject(dsc *dscv1.DataScienceCluster) client.Object {
 	dashboardAnnotations := make(map[string]string)
 
 	switch dsc.Spec.Components.Dashboard.ManagementState {

--- a/controllers/components/datasciencepipelines/datasciencepipelines.go
+++ b/controllers/components/datasciencepipelines/datasciencepipelines.go
@@ -60,7 +60,7 @@ func (s *componentHandler) Init(platform cluster.Platform) error {
 	return nil
 }
 
-func (s *componentHandler) NewCRObject(dsc *dscv1.DataScienceCluster) client.Object { //nolint:ireturn
+func (s *componentHandler) NewCRObject(dsc *dscv1.DataScienceCluster) client.Object {
 	dataSciencePipelinesAnnotations := make(map[string]string)
 
 	switch dsc.Spec.Components.DataSciencePipelines.ManagementState {

--- a/controllers/components/datasciencepipelines/datasciencepipelines_controller.go
+++ b/controllers/components/datasciencepipelines/datasciencepipelines_controller.go
@@ -26,7 +26,6 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/builder"
 
 	componentsv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/components/v1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/deploy"
@@ -64,7 +63,7 @@ func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.
 		Owns(&corev1.ServiceAccount{}).
 		Owns(&corev1.Service{}).
 		Owns(&monitoringv1.ServiceMonitor{}).
-		Owns(&appsv1.Deployment{}, builder.WithPredicates(resources.NewDeploymentPredicate())).
+		Owns(&appsv1.Deployment{}, reconciler.WithPredicates(resources.NewDeploymentPredicate())).
 		Owns(&securityv1.SecurityContextConstraints{}).
 		Watches(&extv1.CustomResourceDefinition{}). // call ForLabel() + new predicates
 		// Add datasciencepipelines-specific actions

--- a/controllers/components/kueue/kueue.go
+++ b/controllers/components/kueue/kueue.go
@@ -37,7 +37,7 @@ func (s *componentHandler) GetManagementState(dsc *dscv1.DataScienceCluster) ope
 	return dsc.Spec.Components.Kueue.ManagementState
 }
 
-func (s *componentHandler) NewCRObject(dsc *dscv1.DataScienceCluster) client.Object { //nolint:ireturn
+func (s *componentHandler) NewCRObject(dsc *dscv1.DataScienceCluster) client.Object {
 	kueueAnnotations := make(map[string]string)
 	switch dsc.Spec.Components.Kueue.ManagementState {
 	case operatorv1.Managed, operatorv1.Removed:

--- a/controllers/components/kueue/kueue_controller.go
+++ b/controllers/components/kueue/kueue_controller.go
@@ -27,7 +27,6 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/builder"
 
 	componentsv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/components/v1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/deploy"
@@ -59,7 +58,7 @@ func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.
 		Owns(&promv1.PrometheusRule{}).
 		Owns(&admissionregistrationv1.MutatingWebhookConfiguration{}).
 		Owns(&admissionregistrationv1.ValidatingWebhookConfiguration{}).
-		Owns(&appsv1.Deployment{}, builder.WithPredicates(resources.NewDeploymentPredicate())).
+		Owns(&appsv1.Deployment{}, reconciler.WithPredicates(resources.NewDeploymentPredicate())).
 		Watches(&extv1.CustomResourceDefinition{}). // call ForLabel() + new predicates
 		// Add Kueue-specific actions
 		WithAction(initialize).

--- a/controllers/components/modelregistry/modelregistry.go
+++ b/controllers/components/modelregistry/modelregistry.go
@@ -47,7 +47,7 @@ func (s *componentHandler) Init(_ cluster.Platform) error {
 	return nil
 }
 
-func (s *componentHandler) NewCRObject(dsc *dscv1.DataScienceCluster) client.Object { //nolint:ireturn
+func (s *componentHandler) NewCRObject(dsc *dscv1.DataScienceCluster) client.Object {
 	componentAnnotations := make(map[string]string)
 
 	switch dsc.Spec.Components.ModelRegistry.ManagementState {

--- a/controllers/components/ray/ray.go
+++ b/controllers/components/ray/ray.go
@@ -37,7 +37,7 @@ func (s *componentHandler) GetManagementState(dsc *dscv1.DataScienceCluster) ope
 	return dsc.Spec.Components.Ray.ManagementState
 }
 
-func (s *componentHandler) NewCRObject(dsc *dscv1.DataScienceCluster) client.Object { //nolint:ireturn
+func (s *componentHandler) NewCRObject(dsc *dscv1.DataScienceCluster) client.Object {
 	rayAnnotations := make(map[string]string)
 	switch dsc.Spec.Components.Ray.ManagementState {
 	case operatorv1.Managed, operatorv1.Removed:

--- a/controllers/components/ray/ray_controller.go
+++ b/controllers/components/ray/ray_controller.go
@@ -25,7 +25,6 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/builder"
 
 	componentsv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/components/v1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/deploy"
@@ -51,7 +50,7 @@ func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.
 		Owns(&rbacv1.Role{}).
 		Owns(&rbacv1.RoleBinding{}).
 		Owns(&corev1.ServiceAccount{}).
-		Owns(&appsv1.Deployment{}, builder.WithPredicates(resources.NewDeploymentPredicate())).
+		Owns(&appsv1.Deployment{}, reconciler.WithPredicates(resources.NewDeploymentPredicate())).
 		Owns(&securityv1.SecurityContextConstraints{}).
 		Watches(&extv1.CustomResourceDefinition{}). // call ForLabel() + new predicates
 		// Add Ray-specific actions

--- a/controllers/components/trainingoperator/trainingoperator.go
+++ b/controllers/components/trainingoperator/trainingoperator.go
@@ -37,7 +37,7 @@ func (s *componentHandler) GetManagementState(dsc *dscv1.DataScienceCluster) ope
 	return dsc.Spec.Components.TrainingOperator.ManagementState
 }
 
-func (s *componentHandler) NewCRObject(dsc *dscv1.DataScienceCluster) k8sclient.Object { //nolint:ireturn
+func (s *componentHandler) NewCRObject(dsc *dscv1.DataScienceCluster) k8sclient.Object {
 	trainingoperatorAnnotations := make(map[string]string)
 	switch dsc.Spec.Components.TrainingOperator.ManagementState {
 	case operatorv1.Managed, operatorv1.Removed:

--- a/controllers/components/trainingoperator/trainingoperator_controller.go
+++ b/controllers/components/trainingoperator/trainingoperator_controller.go
@@ -25,7 +25,6 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/builder"
 
 	componentsv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/components/v1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/deploy"
@@ -49,7 +48,7 @@ func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.
 		Owns(&rbacv1.ClusterRoleBinding{}).
 		Owns(&rbacv1.ClusterRole{}).
 		Owns(&corev1.ServiceAccount{}).
-		Owns(&appsv1.Deployment{}, builder.WithPredicates(resources.NewDeploymentPredicate())).
+		Owns(&appsv1.Deployment{}, reconciler.WithPredicates(resources.NewDeploymentPredicate())).
 		Watches(&extv1.CustomResourceDefinition{}). // call ForLabel() + new predicates
 		// Add TrainingOperator-specific actions
 		WithAction(initialize).

--- a/controllers/components/trustyai/trustyai.go
+++ b/controllers/components/trustyai/trustyai.go
@@ -43,7 +43,7 @@ func (s *componentHandler) GetManagementState(dsc *dscv1.DataScienceCluster) ope
 	return dsc.Spec.Components.TrustyAI.ManagementState
 }
 
-func (s *componentHandler) NewCRObject(dsc *dscv1.DataScienceCluster) client.Object { //nolint:ireturn
+func (s *componentHandler) NewCRObject(dsc *dscv1.DataScienceCluster) client.Object {
 	trustyaiAnnotations := make(map[string]string)
 	switch dsc.Spec.Components.TrustyAI.ManagementState {
 	case operatorv1.Managed, operatorv1.Removed:

--- a/controllers/components/trustyai/trustyai_controller.go
+++ b/controllers/components/trustyai/trustyai_controller.go
@@ -24,7 +24,6 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/builder"
 
 	componentsv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/components/v1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/deploy"
@@ -50,7 +49,7 @@ func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.
 		Owns(&rbacv1.Role{}).
 		Owns(&rbacv1.RoleBinding{}).
 		Owns(&corev1.Service{}).
-		Owns(&appsv1.Deployment{}, builder.WithPredicates(resources.NewDeploymentPredicate())).
+		Owns(&appsv1.Deployment{}, reconciler.WithPredicates(resources.NewDeploymentPredicate())).
 		Watches(&extv1.CustomResourceDefinition{}). // call ForLabel() + new predicates
 		// Add TrustyAI-specific actions
 		WithAction(initialize).

--- a/controllers/datasciencecluster/kubebuilder_rbac.go
+++ b/controllers/datasciencecluster/kubebuilder_rbac.go
@@ -113,7 +113,8 @@ package datasciencecluster
 
 /* Only for RHODS */
 // +kubebuilder:rbac:groups="user.openshift.io",resources=users,verbs=list;watch;patch;delete;get
-// +kubebuilder:rbac:groups="console.openshift.io",resources=consolelinks,verbs=create;get;patch;delete
+// +kubebuilder:rbac:groups="user.openshift.io",resources=groups,verbs=get;create;list;watch;patch;delete
+// +kubebuilder:rbac:groups="console.openshift.io",resources=consolelinks,verbs=create;get;patch;list;delete;watch
 
 // Ray
 // +kubebuilder:rbac:groups=components.opendatahub.io,resources=rays,verbs=get;list;watch;create;update;patch;delete
@@ -138,9 +139,7 @@ package datasciencecluster
 // +kubebuilder:rbac:groups="console.openshift.io",resources=odhquickstarts,verbs=create;get;patch;list;delete;watch
 // +kubebuilder:rbac:groups="dashboard.opendatahub.io",resources=odhdocuments,verbs=create;get;patch;list;delete;watch
 // +kubebuilder:rbac:groups="dashboard.opendatahub.io",resources=odhapplications,verbs=create;get;patch;list;delete;watch
-// +kubebuilder:rbac:groups="dashboard.opendatahub.io",resources=acceleratorprofiles,verbs=create;get;patch;list;delete
-// +kubebuilder:rbac:groups="user.openshift.io",resources=groups,verbs=get;create;list;watch;patch;delete
-// +kubebuilder:rbac:groups="console.openshift.io",resources=consolelinks,verbs=create;get;patch;delete
+// +kubebuilder:rbac:groups="dashboard.opendatahub.io",resources=acceleratorprofiles,verbs=create;get;patch;list;delete;watch
 
 // ModelRegistry
 // +kubebuilder:rbac:groups=components.opendatahub.io,resources=modelregistries,verbs=get;list;watch;create;update;patch;delete
@@ -149,6 +148,7 @@ package datasciencecluster
 // +kubebuilder:rbac:groups=modelregistry.opendatahub.io,resources=modelregistries,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=modelregistry.opendatahub.io,resources=modelregistries/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=modelregistry.opendatahub.io,resources=modelregistries/finalizers,verbs=update;get
+// +kubebuilder:rbac:groups=maistra.io,resources=servicemeshmembers,verbs=get;list;watch;create;update;patch;delete
 
 // Kueue
 // +kubebuilder:rbac:groups=components.opendatahub.io,resources=kueues,verbs=get;list;watch;create;update;patch;delete

--- a/pkg/cluster/gvk/gvk.go
+++ b/pkg/cluster/gvk/gvk.go
@@ -85,6 +85,12 @@ var (
 		Kind:    "OdhDocument",
 	}
 
+	AcceleratorProfile = schema.GroupVersionKind{
+		Group:   "dashboard.opendatahub.io",
+		Version: "v1",
+		Kind:    "AcceleratorProfile",
+	}
+
 	OdhQuickStart = schema.GroupVersionKind{
 		Group:   "console.openshift.io",
 		Version: "v1",

--- a/pkg/controller/handlers/handlers.go
+++ b/pkg/controller/handlers/handlers.go
@@ -7,25 +7,23 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-
-	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/metadata/labels"
 )
 
-func ToOwner() handler.EventHandler {
+func LabelToName(label string) handler.EventHandler {
 	return handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, a client.Object) []reconcile.Request {
 		objLabels := a.GetLabels()
 		if len(objLabels) == 0 {
 			return []reconcile.Request{}
 		}
 
-		partOf := objLabels[labels.ComponentPartOf]
-		if partOf == "" {
+		name := objLabels[label]
+		if name == "" {
 			return []reconcile.Request{}
 		}
 
 		return []reconcile.Request{{
 			NamespacedName: types.NamespacedName{
-				Name: partOf,
+				Name: name,
 			},
 		}}
 	})

--- a/pkg/controller/predicates/resources/resources.go
+++ b/pkg/controller/predicates/resources/resources.go
@@ -36,3 +36,20 @@ func (DeploymentPredicate) Update(e event.UpdateEvent) bool {
 func NewDeploymentPredicate() *DeploymentPredicate {
 	return &DeploymentPredicate{}
 }
+
+func Deleted() predicate.Funcs {
+	return predicate.Funcs{
+		CreateFunc: func(e event.CreateEvent) bool {
+			return false
+		},
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			return false
+		},
+		DeleteFunc: func(e event.DeleteEvent) bool {
+			return true
+		},
+		GenericFunc: func(e event.GenericEvent) bool {
+			return false
+		},
+	}
+}

--- a/pkg/controller/reconciler/component_reconciler.go
+++ b/pkg/controller/reconciler/component_reconciler.go
@@ -162,7 +162,7 @@ func (r *ComponentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 
 	// Execute actions
 	for _, action := range r.Actions {
-		l.V(3).Info("Executing action", "action", action)
+		l.Info("Executing action", "action", action)
 
 		actx := log.IntoContext(
 			ctx,

--- a/pkg/controller/reconciler/component_reconciler_actions.go
+++ b/pkg/controller/reconciler/component_reconciler_actions.go
@@ -1,0 +1,70 @@
+package reconciler
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
+)
+
+type dynamicWatchAction struct {
+	mgr        ctrl.Manager
+	controller controller.Controller
+	watches    []watchInput
+	watched    map[schema.GroupVersionKind]struct{}
+}
+
+func (a *dynamicWatchAction) run(_ context.Context, rr *types.ReconciliationRequest) error {
+	controllerName := strings.ToLower(rr.Instance.GetObjectKind().GroupVersionKind().Kind)
+
+	for i := range a.watches {
+		w := a.watches[i]
+		gvk := w.object.GetObjectKind().GroupVersionKind()
+
+		if _, ok := a.watched[gvk]; ok {
+			// already registered
+			continue
+		}
+
+		err := a.controller.Watch(
+			source.Kind(a.mgr.GetCache(), w.object),
+			w.eventHandler,
+			w.predicates...,
+		)
+
+		if err != nil {
+			return fmt.Errorf("failed to create watcher for %s: %w", w.object.GetObjectKind().GroupVersionKind(), err)
+		}
+
+		DynamicWatchResourcesTotal.WithLabelValues(controllerName).Inc()
+		a.watched[gvk] = struct{}{}
+	}
+
+	return nil
+}
+
+func newDynamicWatchAction(mgr ctrl.Manager, controller controller.Controller, watches []watchInput) actions.Fn {
+	action := dynamicWatchAction{
+		mgr:        mgr,
+		controller: controller,
+		watched:    map[schema.GroupVersionKind]struct{}{},
+	}
+
+	for i := range watches {
+		if !watches[i].dynamic {
+			// not dynamic
+			continue
+		}
+
+		action.watches = append(action.watches, watches[i])
+	}
+
+	return action.run
+}

--- a/pkg/controller/reconciler/component_reconciler_metrics.go
+++ b/pkg/controller/reconciler/component_reconciler_metrics.go
@@ -1,0 +1,30 @@
+package reconciler
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+var (
+	// DynamicWatchResourcesTotal is a prometheus counter metrics which holds the total
+	// number of dynamically watched resource per controller.
+	// It has one labels.
+	// controller label refers to the controller name.
+	DynamicWatchResourcesTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "action_dynamic_watch_total",
+			Help: "Number of dynamically watched resources",
+		},
+		[]string{
+			"controller",
+		},
+	)
+)
+
+// init register metrics to the global registry from controller-runtime/pkg/metrics.
+// see https://book.kubebuilder.io/reference/metrics#publishing-additional-metrics
+//
+//nolint:gochecknoinits
+func init() {
+	metrics.Registry.MustRegister(DynamicWatchResourcesTotal)
+}

--- a/pkg/resources/resources.go
+++ b/pkg/resources/resources.go
@@ -113,15 +113,18 @@ func SetLabels(obj client.Object, values map[string]string) {
 	obj.SetLabels(target)
 }
 
-func SetLabel(obj client.Object, k string, v string) {
+func SetLabel(obj client.Object, k string, v string) string {
 	target := obj.GetLabels()
 	if target == nil {
 		target = make(map[string]string)
 	}
 
+	old := target[k]
 	target[k] = v
 
 	obj.SetLabels(target)
+
+	return old
 }
 
 func RemoveLabel(obj client.Object, k string) {
@@ -157,15 +160,18 @@ func SetAnnotations(obj client.Object, values map[string]string) {
 	obj.SetAnnotations(target)
 }
 
-func SetAnnotation(obj client.Object, k string, v string) {
+func SetAnnotation(obj client.Object, k string, v string) string {
 	target := obj.GetAnnotations()
 	if target == nil {
 		target = make(map[string]string)
 	}
 
+	old := target[k]
 	target[k] = v
 
 	obj.SetAnnotations(target)
+
+	return old
 }
 
 func RemoveAnnotation(obj client.Object, k string) {

--- a/tests/e2e/controller_test.go
+++ b/tests/e2e/controller_test.go
@@ -167,8 +167,10 @@ func TestOdhOperator(t *testing.T) {
 
 	// Run deletion if skipDeletion is not set
 	if !testOpts.skipDeletion {
-		// this is a negative test case, since by using the positive CM('true'), even CSV gets deleted which leaves no operator pod in prow
-		t.Run("components should not be removed if labeled is set to 'false' on configmap", cfgMapDeletionTestSuite)
+		if testOpts.operatorControllerTest {
+			// this is a negative test case, since by using the positive CM('true'), even CSV gets deleted which leaves no operator pod in prow
+			t.Run("components should not be removed if labeled is set to 'false' on configmap", cfgMapDeletionTestSuite)
+		}
 
 		t.Run("delete components", deletionTestSuite)
 	}


### PR DESCRIPTION
Signed-off-by: Luca Burgazzoli <lburgazzoli@gmail.com>

<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

<!--- Link your JIRA and related links here for reference. -->
https://issues.redhat.com/browse/RHOAIENG-15170

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [X] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [X] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work
