### PR TITLE
update: DSC status update and delete component CR if it is not set Managed

### DIFF
--- a/controllers/components/dashboard/dashboard.go
+++ b/controllers/components/dashboard/dashboard.go
@@ -25,16 +25,11 @@ func (s *componentHandler) GetName() string {
 	return componentsv1.DashboardComponentName
 }
 
-func (s *componentHandler) GetManagementState(dsc *dscv1.DataScienceCluster) string {
-	if s == nil || dsc.Spec.Components.Dashboard.ManagementState == operatorv1.Removed {
-		return string(operatorv1.Removed)
+func (s *componentHandler) GetManagementState(dsc *dscv1.DataScienceCluster) operatorv1.ManagementState {
+	if dsc.Spec.Components.Dashboard.ManagementState == operatorv1.Managed {
+		return operatorv1.Managed
 	}
-	switch dsc.Spec.Components.Dashboard.ManagementState {
-	case operatorv1.Managed:
-		return string(dsc.Spec.Components.Dashboard.ManagementState)
-	default: // Force and Unmanaged case for unknown values, we do not support these yet
-		return "Unknown"
-	}
+	return operatorv1.Removed
 }
 
 func (s *componentHandler) Init(platform cluster.Platform) error {
@@ -49,7 +44,7 @@ func (s *componentHandler) Init(platform cluster.Platform) error {
 
 func (s *componentHandler) NewCRObject(dsc *dscv1.DataScienceCluster) client.Object {
 	dashboardAnnotations := make(map[string]string)
-	dashboardAnnotations[annotations.ManagementStateAnnotation] = s.GetManagementState(dsc)
+	dashboardAnnotations[annotations.ManagementStateAnnotation] = string(s.GetManagementState(dsc))
 
 	return client.Object(&componentsv1.Dashboard{
 		TypeMeta: metav1.TypeMeta{

--- a/controllers/components/datasciencepipelines/datasciencepipelines.go
+++ b/controllers/components/datasciencepipelines/datasciencepipelines.go
@@ -29,16 +29,11 @@ func (s *componentHandler) GetName() string {
 	return componentsv1.DataSciencePipelinesComponentName
 }
 
-func (s *componentHandler) GetManagementState(dsc *dscv1.DataScienceCluster) string {
-	if s == nil || dsc.Spec.Components.DataSciencePipelines.ManagementState == operatorv1.Removed {
-		return string(operatorv1.Removed)
+func (s *componentHandler) GetManagementState(dsc *dscv1.DataScienceCluster) operatorv1.ManagementState {
+	if dsc.Spec.Components.DataSciencePipelines.ManagementState == operatorv1.Managed {
+		return operatorv1.Managed
 	}
-	switch dsc.Spec.Components.DataSciencePipelines.ManagementState {
-	case operatorv1.Managed:
-		return string(dsc.Spec.Components.DataSciencePipelines.ManagementState)
-	default: // Force and Unmanaged case for unknown values, we do not support these yet
-		return "Unknown"
-	}
+	return operatorv1.Removed
 }
 
 func (s *componentHandler) Init(platform cluster.Platform) error {
@@ -70,7 +65,7 @@ func (s *componentHandler) Init(platform cluster.Platform) error {
 
 func (s *componentHandler) NewCRObject(dsc *dscv1.DataScienceCluster) client.Object {
 	dataSciencePipelinesAnnotations := make(map[string]string)
-	dataSciencePipelinesAnnotations[annotations.ManagementStateAnnotation] = s.GetManagementState(dsc)
+	dataSciencePipelinesAnnotations[annotations.ManagementStateAnnotation] = string(s.GetManagementState(dsc))
 
 	return client.Object(&componentsv1.DataSciencePipelines{
 		TypeMeta: metav1.TypeMeta{

--- a/controllers/components/kueue/kueue.go
+++ b/controllers/components/kueue/kueue.go
@@ -33,21 +33,16 @@ func (s *componentHandler) GetName() string {
 	return componentsv1.KueueComponentName
 }
 
-func (s *componentHandler) GetManagementState(dsc *dscv1.DataScienceCluster) string {
-	if s == nil || dsc.Spec.Components.Kueue.ManagementState == operatorv1.Removed {
-		return string(operatorv1.Removed)
+func (s *componentHandler) GetManagementState(dsc *dscv1.DataScienceCluster) operatorv1.ManagementState {
+	if dsc.Spec.Components.Kueue.ManagementState == operatorv1.Managed {
+		return operatorv1.Managed
 	}
-	switch dsc.Spec.Components.Kueue.ManagementState {
-	case operatorv1.Managed:
-		return string(dsc.Spec.Components.Kueue.ManagementState)
-	default: // Force and Unmanaged case for unknown values, we do not support these yet
-		return "Unknown"
-	}
+	return operatorv1.Removed
 }
 
 func (s *componentHandler) NewCRObject(dsc *dscv1.DataScienceCluster) client.Object {
 	kueueAnnotations := make(map[string]string)
-	kueueAnnotations[annotations.ManagementStateAnnotation] = s.GetManagementState(dsc)
+	kueueAnnotations[annotations.ManagementStateAnnotation] = string(s.GetManagementState(dsc))
 	return client.Object(&componentsv1.Kueue{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       componentsv1.KueueKind,

--- a/controllers/components/modelregistry/modelregistry.go
+++ b/controllers/components/modelregistry/modelregistry.go
@@ -25,16 +25,11 @@ func (s *componentHandler) GetName() string {
 	return componentsv1.ModelRegistryComponentName
 }
 
-func (s *componentHandler) GetManagementState(dsc *dscv1.DataScienceCluster) string {
-	if s == nil || dsc.Spec.Components.ModelRegistry.ManagementState == operatorv1.Removed {
-		return string(operatorv1.Removed)
+func (s *componentHandler) GetManagementState(dsc *dscv1.DataScienceCluster) operatorv1.ManagementState {
+	if dsc.Spec.Components.ModelRegistry.ManagementState == operatorv1.Managed {
+		return operatorv1.Managed
 	}
-	switch dsc.Spec.Components.ModelRegistry.ManagementState {
-	case operatorv1.Managed:
-		return string(dsc.Spec.Components.ModelRegistry.ManagementState)
-	default: // Force and Unmanaged case for unknown values, we do not support these yet
-		return "Unknown"
-	}
+	return operatorv1.Removed
 }
 
 func (s *componentHandler) Init(_ cluster.Platform) error {
@@ -57,7 +52,7 @@ func (s *componentHandler) Init(_ cluster.Platform) error {
 
 func (s *componentHandler) NewCRObject(dsc *dscv1.DataScienceCluster) client.Object {
 	componentAnnotations := make(map[string]string)
-	componentAnnotations[annotations.ManagementStateAnnotation] = s.GetManagementState(dsc)
+	componentAnnotations[annotations.ManagementStateAnnotation] = string(s.GetManagementState(dsc))
 	return client.Object(&componentsv1.ModelRegistry{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       componentsv1.ModelRegistryKind,

--- a/controllers/components/ray/ray.go
+++ b/controllers/components/ray/ray.go
@@ -33,20 +33,15 @@ func (s *componentHandler) GetName() string {
 	return componentsv1.RayComponentName
 }
 
-func (s *componentHandler) GetManagementState(dsc *dscv1.DataScienceCluster) string {
-	if s == nil || dsc.Spec.Components.Ray.ManagementState == operatorv1.Removed {
-		return string(operatorv1.Removed)
+func (s *componentHandler) GetManagementState(dsc *dscv1.DataScienceCluster) operatorv1.ManagementState {
+	if dsc.Spec.Components.Ray.ManagementState == operatorv1.Managed {
+		return operatorv1.Managed
 	}
-	switch dsc.Spec.Components.Ray.ManagementState {
-	case operatorv1.Managed:
-		return string(dsc.Spec.Components.Ray.ManagementState)
-	default: // Force and Unmanaged case for unknown values, we do not support these yet
-		return "Unknown"
-	}
+	return operatorv1.Removed
 }
 func (s *componentHandler) NewCRObject(dsc *dscv1.DataScienceCluster) client.Object {
 	rayAnnotations := make(map[string]string)
-	rayAnnotations[annotations.ManagementStateAnnotation] = s.GetManagementState(dsc)
+	rayAnnotations[annotations.ManagementStateAnnotation] = string(s.GetManagementState(dsc))
 
 	return client.Object(&componentsv1.Ray{
 		TypeMeta: metav1.TypeMeta{

--- a/controllers/components/trainingoperator/trainingoperator.go
+++ b/controllers/components/trainingoperator/trainingoperator.go
@@ -33,20 +33,15 @@ func (s *componentHandler) GetName() string {
 	return componentsv1.TrainingOperatorComponentName
 }
 
-func (s *componentHandler) GetManagementState(dsc *dscv1.DataScienceCluster) string {
-	if s == nil || dsc.Spec.Components.TrainingOperator.ManagementState == operatorv1.Removed {
-		return string(operatorv1.Removed)
+func (s *componentHandler) GetManagementState(dsc *dscv1.DataScienceCluster) operatorv1.ManagementState {
+	if dsc.Spec.Components.TrainingOperator.ManagementState == operatorv1.Managed {
+		return operatorv1.Managed
 	}
-	switch dsc.Spec.Components.TrainingOperator.ManagementState {
-	case operatorv1.Managed:
-		return string(dsc.Spec.Components.TrainingOperator.ManagementState)
-	default: // Force and Unmanaged case for unknown values, we do not support these yet
-		return "Unknown"
-	}
+	return operatorv1.Removed
 }
 func (s *componentHandler) NewCRObject(dsc *dscv1.DataScienceCluster) k8sclient.Object {
 	trainingoperatorAnnotations := make(map[string]string)
-	trainingoperatorAnnotations[annotations.ManagementStateAnnotation] = s.GetManagementState(dsc)
+	trainingoperatorAnnotations[annotations.ManagementStateAnnotation] = string(s.GetManagementState(dsc))
 
 	return k8sclient.Object(&componentsv1.TrainingOperator{
 		TypeMeta: metav1.TypeMeta{

--- a/controllers/components/trustyai/trustyai.go
+++ b/controllers/components/trustyai/trustyai.go
@@ -39,21 +39,16 @@ func (s *componentHandler) GetName() string {
 	return componentsv1.TrustyAIComponentName
 }
 
-func (s *componentHandler) GetManagementState(dsc *dscv1.DataScienceCluster) string {
-	if s == nil || dsc.Spec.Components.TrustyAI.ManagementState == operatorv1.Removed {
-		return string(operatorv1.Removed)
+func (s *componentHandler) GetManagementState(dsc *dscv1.DataScienceCluster) operatorv1.ManagementState {
+	if dsc.Spec.Components.TrustyAI.ManagementState == operatorv1.Managed {
+		return operatorv1.Managed
 	}
-	switch dsc.Spec.Components.TrustyAI.ManagementState {
-	case operatorv1.Managed:
-		return string(dsc.Spec.Components.TrustyAI.ManagementState)
-	default: // Force and Unmanaged case for unknown values, we do not support these yet
-		return "Unknown"
-	}
+	return operatorv1.Removed
 }
 
 func (s *componentHandler) NewCRObject(dsc *dscv1.DataScienceCluster) client.Object {
 	trustyaiAnnotations := make(map[string]string)
-	trustyaiAnnotations[annotations.ManagementStateAnnotation] = s.GetManagementState(dsc)
+	trustyaiAnnotations[annotations.ManagementStateAnnotation] = string(s.GetManagementState(dsc))
 	return client.Object(&componentsv1.TrustyAI{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       componentsv1.TrustyAIKind,

--- a/controllers/datasciencecluster/datasciencecluster_controller.go
+++ b/controllers/datasciencecluster/datasciencecluster_controller.go
@@ -288,7 +288,7 @@ func (r *DataScienceClusterReconciler) ReconcileComponent(
 		return instance, err
 	}
 
-	enabled := component.GetManagementState(instance) == string(operatorv1.Managed)
+	enabled := component.GetManagementState(instance) == operatorv1.Managed
 
 	// TODO: check component status before update DSC status to successful .GetStatus().Phase == "Ready"
 	r.Log.Info("component reconciled successfully: " + componentName)
@@ -352,7 +352,7 @@ func (r *DataScienceClusterReconciler) apply(ctx context.Context, dsc *dscv1.Dat
 	}
 
 	managementStateAnn, exists := obj.GetAnnotations()[annotations.ManagementStateAnnotation]
-	if exists && (managementStateAnn == string(operatorv1.Removed) || managementStateAnn == "Unknown") {
+	if exists && managementStateAnn == string(operatorv1.Removed) {
 		err := r.Client.Delete(ctx, obj)
 		if k8serr.IsNotFound(err) {
 			return nil

--- a/pkg/componentsregistry/componentsregistry.go
+++ b/pkg/componentsregistry/componentsregistry.go
@@ -6,6 +6,7 @@ import (
 	"context"
 
 	"github.com/hashicorp/go-multierror"
+	operatorv1 "github.com/openshift/api/operator/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -20,7 +21,7 @@ type ComponentHandler interface {
 	// GetName and GetManagementState sound like pretty much the same across
 	// all components, but I could not find a way to avoid it
 	GetName() string
-	GetManagementState(dsc *dscv1.DataScienceCluster) string
+	GetManagementState(dsc *dscv1.DataScienceCluster) operatorv1.ManagementState
 	// NewCRObject constructs components specific Custom Resource
 	// e.g. Dashboard in datasciencecluster.opendatahub.io group
 	// It returns interface, but it simplifies DSC reconciler code a lot


### PR DESCRIPTION
- delete component CR when it is either set to Removed or not set in DSC
- remove old status updates"Component is disabled/enabled), only update when component CR create successful or failed (should have follow up to add check if CR status is ready or notready)
- fix a bug in datasciencpipeline :D  https://github.com/opendatahub-io/opendatahub-operator/pull/1340

<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->
split out changes not related to modelmesh from https://github.com/opendatahub-io/opendatahub-operator/pull/1338

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
