### PR TITLE
Reduce log verbosity for the gc service

### DIFF
--- a/pkg/services/gc/gc.go
+++ b/pkg/services/gc/gc.go
@@ -117,7 +117,7 @@ func (gc *GC) Run(
 		items, err := dc.Resource(resources[r].GroupVersionResource()).Namespace("").List(ctx, lo)
 		if err != nil {
 			if k8serr.IsForbidden(err) {
-				l.Info(
+				l.V(3).Info(
 					"cannot list resource",
 					"reason", err.Error(),
 					"gvk", resources[r].GroupVersionKind(),


### PR DESCRIPTION
If the GC service is not authorixed to list some particular types, it
emits a message "cannot list resource" that may be misleading as it does
not impact the behavior of the GC service. This commit set the log
verbosity to 3 so it is not shown by default, but can be enabled
eventually for troubleshooting

<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] ~~Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).~~
- [x] The developer has manually tested the changes and verified that the changes work
