### PR TITLE
feat: added integration tests to cover evicted pods in post conditions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -403,7 +403,7 @@ test: unit-test e2e-test
 
 .PHONY: unit-test
 unit-test: envtest
-	OPERATOR_NAMESPACE=$(OPERATOR_NAMESPACE) KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test $(TEST_SRC) -v  -coverprofile cover.out
+	OPERATOR_NAMESPACE=$(OPERATOR_NAMESPACE) KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test $(TEST_SRC) -v -timeout 15m -coverprofile cover.out
 CLEANFILES += cover.out
 
 $(PROMETHEUS_TEST_DIR)/%.rules.yaml: $(PROMETHEUS_TEST_DIR)/%.unit-tests.yaml $(PROMETHEUS_CONFIG_YAML) $(YQ)

--- a/tests/integration/features/fixtures/cluster_test_fixtures.go
+++ b/tests/integration/features/fixtures/cluster_test_fixtures.go
@@ -79,6 +79,15 @@ func GetService(ctx context.Context, client client.Client, namespace, name strin
 	return svc, err
 }
 
+func GetPod(ctx context.Context, client client.Client, namespace, name string) (*corev1.Pod, error) {
+	pod := &corev1.Pod{}
+	err := client.Get(ctx, types.NamespacedName{
+		Name: name, Namespace: namespace,
+	}, pod)
+
+	return pod, err
+}
+
 func CreateService(ctx context.Context, client client.Client, namespace, svcName string) (*corev1.Service, error) {
 	if err := client.Create(ctx, &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
@@ -99,6 +108,27 @@ func CreateService(ctx context.Context, client client.Client, namespace, svcName
 		return nil, err
 	}
 	return GetService(ctx, client, namespace, svcName)
+}
+
+func CreatePod(ctx context.Context, client client.Client, namespace, name string) (*corev1.Pod, error) {
+	if err := client.Create(ctx, &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:  "test",
+					Image: "test",
+				},
+			},
+		},
+	}); err != nil {
+		return nil, err
+	}
+
+	return GetPod(ctx, client, namespace, name)
 }
 
 func CreateSecret(name, namespace string) feature.Action {

--- a/tests/integration/features/postconditions_int_test.go
+++ b/tests/integration/features/postconditions_int_test.go
@@ -104,6 +104,8 @@ var _ = Describe("feature postconditions", func() {
 		})
 
 		It("should fail when there are no pods ready in the namespace", func(ctx context.Context) {
+			Skip("Skipping this test until the timeout for the postconditions is configurable")
+
 			// given
 			ns := fixtures.NewNamespace(namespace)
 			Expect(envTestClient.Create(ctx, ns)).To(Succeed())

--- a/tests/integration/features/postconditions_int_test.go
+++ b/tests/integration/features/postconditions_int_test.go
@@ -5,7 +5,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 
-	dsciv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/dscinitialization/v1"
+	dsciv1 "github.com/opendatahub-io/opendatahub-operator/v2/api/dscinitialization/v1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/feature"
 	"github.com/opendatahub-io/opendatahub-operator/v2/tests/envtestutil"
 	"github.com/opendatahub-io/opendatahub-operator/v2/tests/integration/features/fixtures"

--- a/tests/integration/features/postconditions_int_test.go
+++ b/tests/integration/features/postconditions_int_test.go
@@ -1,0 +1,104 @@
+package features_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	dsciv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/dscinitialization/v1"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/feature"
+	"github.com/opendatahub-io/opendatahub-operator/v2/tests/envtestutil"
+	"github.com/opendatahub-io/opendatahub-operator/v2/tests/integration/features/fixtures"
+	corev1 "k8s.io/api/core/v1"
+)
+
+var _ = Describe("feature postconditions", func() {
+	Context("wait for pods to be ready", func() {
+		var (
+			objectCleaner *envtestutil.Cleaner
+			namespace     string
+			dsci          *dsciv1.DSCInitialization
+		)
+
+		BeforeEach(func(ctx context.Context) {
+			objectCleaner = envtestutil.CreateCleaner(envTestClient, envTest.Config, fixtures.Timeout, fixtures.Interval)
+
+			testFeatureName := "test-pods-ready"
+			namespace = envtestutil.AppendRandomNameTo(testFeatureName)
+			dsciName := envtestutil.AppendRandomNameTo(testFeatureName)
+			dsci = fixtures.NewDSCInitialization(ctx, envTestClient, dsciName, namespace)
+		})
+
+		AfterEach(func(ctx context.Context) {
+			objectCleaner.DeleteAll(ctx, dsci)
+		})
+
+		It("should succeed when all pods in the namespace are ready", func(ctx context.Context) {
+			// given
+			ns := fixtures.NewNamespace(namespace)
+			Expect(envTestClient.Create(ctx, ns)).To(Succeed())
+
+			podReady, err := fixtures.CreatePod(ctx, envTestClient, namespace, "test-pod")
+			Expect(err).ToNot(HaveOccurred())
+
+			podReady.Status.Phase = corev1.PodSucceeded
+
+			Expect(envTestClient.Status().Update(ctx, podReady)).To(Succeed())
+
+			// when
+			featuresHandler := feature.ClusterFeaturesHandler(dsci, func(registry feature.FeaturesRegistry) error {
+				errFeatureAdd := registry.Add(feature.Define("check-pods-ready").
+					PostConditions(feature.WaitForPodsToBeReady(namespace)),
+				)
+
+				Expect(errFeatureAdd).ToNot(HaveOccurred())
+
+				return nil
+			})
+
+			// then
+			Expect(featuresHandler.Apply(ctx, envTestClient)).To(Succeed())
+		})
+
+		It("should succeed when there are evicted pods in the namespace", func(ctx context.Context) {
+			// given
+			ns := fixtures.NewNamespace(namespace)
+			Expect(envTestClient.Create(ctx, ns)).To(Succeed())
+
+			podReady, err := fixtures.CreatePod(ctx, envTestClient, namespace, "test-pod")
+			Expect(err).ToNot(HaveOccurred())
+
+			podReady.Status.Phase = corev1.PodSucceeded
+
+			Expect(envTestClient.Status().Update(ctx, podReady)).To(Succeed())
+
+			podEvicted, err := fixtures.CreatePod(ctx, envTestClient, namespace, "test-pod-evicted")
+			Expect(err).ToNot(HaveOccurred())
+
+			podEvicted.Status.Phase = corev1.PodFailed
+			podEvicted.Status.Reason = "Evicted"
+			podEvicted.Status.Conditions = []corev1.PodCondition{
+				{
+					Type:   corev1.PodReady,
+					Status: corev1.ConditionFalse,
+				},
+			}
+
+			Expect(envTestClient.Status().Update(ctx, podEvicted)).To(Succeed())
+
+			// when
+			featuresHandler := feature.ClusterFeaturesHandler(dsci, func(registry feature.FeaturesRegistry) error {
+				errFeatureAdd := registry.Add(feature.Define("check-pods-ready").
+					PostConditions(feature.WaitForPodsToBeReady(namespace)),
+				)
+
+				Expect(errFeatureAdd).ToNot(HaveOccurred())
+
+				return nil
+			})
+
+			// then
+			Expect(featuresHandler.Apply(ctx, envTestClient)).To(Succeed())
+		})
+	})
+})

--- a/tests/integration/features/postconditions_int_test.go
+++ b/tests/integration/features/postconditions_int_test.go
@@ -3,13 +3,15 @@ package features_test
 import (
 	"context"
 
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+
 	dsciv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/dscinitialization/v1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/feature"
 	"github.com/opendatahub-io/opendatahub-operator/v2/tests/envtestutil"
 	"github.com/opendatahub-io/opendatahub-operator/v2/tests/integration/features/fixtures"
-	corev1 "k8s.io/api/core/v1"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("feature postconditions", func() {


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

Tracking issue: RHOAIENG-15614

## Description
Seeing that testing in a real cluster can be quite problematic, I added integration tests to cover scenarios with evicted pods, I didn't add a negative test because it takes 5 minutes to fail and the timeout duration is not configurable.

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
`make test`

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Added new integration tests to verify feature postconditions, specifically the handling of pod readiness within Kubernetes namespaces.
  - Enhanced test utilities to support creation and retrieval of Pods for more comprehensive integration testing.
- **Chores**
  - Added a 15-minute timeout to unit test execution to improve test run management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->