### PR TITLE
Add special handling for Aggregatin ClusterRole

### DIFF
--- a/pkg/controller/actions/deploy/action_deploy_test.go
+++ b/pkg/controller/actions/deploy/action_deploy_test.go
@@ -2,29 +2,40 @@ package deploy_test
 
 import (
 	"context"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"testing"
 
 	"github.com/blang/semver/v4"
+	"github.com/onsi/gomega/gstruct"
 	"github.com/operator-framework/api/pkg/lib/version"
 	"github.com/rs/xid"
 	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	apimachinery "k8s.io/apimachinery/pkg/types"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
 
 	componentsv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/components/v1"
 	dscv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/datasciencecluster/v1"
 	dsciv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/dscinitialization/v1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/deploy"
+	odhCli "github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/client"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/metadata/annotations"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/metadata/labels"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/resources"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/fakeclient"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/matchers/jq"
+	"github.com/opendatahub-io/opendatahub-operator/v2/tests/envtestutil"
 
 	. "github.com/onsi/gomega"
 )
@@ -238,4 +249,128 @@ func TestDeployNotOwnedCreate(t *testing.T) {
 		jq.Match(`.metadata.annotations | has("%s") | not`, annotations.ManagedByODHOperator),
 		jq.Match(`.spec.strategy.type == "%s"`, appsv1.RollingUpdateDeploymentStrategyType),
 	))
+}
+
+func TestDeployClusterRole(t *testing.T) {
+	g := NewWithT(t)
+	s := runtime.NewScheme()
+
+	utilruntime.Must(corev1.AddToScheme(s))
+	utilruntime.Must(appsv1.AddToScheme(s))
+	utilruntime.Must(apiextensionsv1.AddToScheme(s))
+	utilruntime.Must(componentsv1.AddToScheme(s))
+	utilruntime.Must(rbacv1.AddToScheme(s))
+
+	projectDir, err := envtestutil.FindProjectRoot()
+	g.Expect(err).NotTo(HaveOccurred())
+
+	envTest := &envtest.Environment{
+		CRDInstallOptions: envtest.CRDInstallOptions{
+			Scheme: s,
+			Paths: []string{
+				filepath.Join(projectDir, "config", "crd", "bases"),
+			},
+			ErrorIfPathMissing: true,
+			CleanUpAfterUse:    false,
+		},
+	}
+
+	t.Cleanup(func() {
+		_ = envTest.Stop()
+	})
+
+	cfg, err := envTest.Start()
+	g.Expect(err).NotTo(HaveOccurred())
+
+	envTestClient, err := client.New(cfg, client.Options{Scheme: s})
+	g.Expect(err).NotTo(HaveOccurred())
+
+	cli, err := odhCli.NewFromConfig(cfg, envTestClient)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	t.Run("aggregation", func(t *testing.T) {
+		ctx := context.Background()
+		name := xid.New().String()
+
+		deployClusterRoles(t, ctx, cli, rbacv1.ClusterRole{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: name,
+			},
+			Rules: []rbacv1.PolicyRule{{
+				Verbs:     []string{"*"},
+				Resources: []string{"*"},
+				APIGroups: []string{"*"},
+			}},
+			AggregationRule: &rbacv1.AggregationRule{
+				ClusterRoleSelectors: []metav1.LabelSelector{{
+					MatchLabels: map[string]string{"foo": "bar"},
+				}},
+			},
+		})
+
+		out := rbacv1.ClusterRole{}
+		err = cli.Get(ctx, client.ObjectKey{Name: name}, &out)
+		g.Expect(err).NotTo(HaveOccurred())
+
+		g.Expect(out).To(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+			"Rules": BeEmpty(),
+		}))
+	})
+
+	t.Run("no aggregation", func(t *testing.T) {
+		ctx := context.Background()
+		name := xid.New().String()
+
+		deployClusterRoles(t, ctx, cli, rbacv1.ClusterRole{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: name,
+			},
+			Rules: []rbacv1.PolicyRule{{
+				Verbs:     []string{"*"},
+				Resources: []string{"*"},
+				APIGroups: []string{"*"},
+			}},
+		})
+
+		out := rbacv1.ClusterRole{}
+		err = cli.Get(ctx, client.ObjectKey{Name: name}, &out)
+		g.Expect(err).NotTo(HaveOccurred())
+
+		g.Expect(out).To(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+			"Rules": HaveLen(1),
+		}))
+	})
+}
+
+func deployClusterRoles(t *testing.T, ctx context.Context, cli *odhCli.Client, roles ...rbacv1.ClusterRole) {
+	t.Helper()
+
+	g := NewWithT(t)
+
+	rr := types.ReconciliationRequest{
+		Client: cli,
+		DSCI: &dsciv1.DSCInitialization{Spec: dsciv1.DSCInitializationSpec{
+			ApplicationsNamespace: xid.New().String(),
+		}},
+		DSC: &dscv1.DataScienceCluster{},
+		Instance: &componentsv1.Dashboard{
+			ObjectMeta: metav1.ObjectMeta{
+				Generation: 1,
+				UID:        apimachinery.UID(xid.New().String()),
+			},
+		},
+		Release: cluster.Release{
+			Name: cluster.OpenDataHub,
+			Version: version.OperatorVersion{Version: semver.Version{
+				Major: 1, Minor: 2, Patch: 3,
+			}}},
+	}
+
+	for i := range roles {
+		err := rr.AddResources(roles[i].DeepCopy())
+		g.Expect(err).ShouldNot(HaveOccurred())
+	}
+
+	err := deploy.NewAction()(ctx, &rr)
+	g.Expect(err).ShouldNot(HaveOccurred())
 }


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->



## Description
<!--- Describe your changes in detail -->
For `ClusterRole`, if `AggregationRule` is set, then the Rules are controller managed and direct changes to Rules will be stomped by the controller. This also happen if the rules are set to an empty slice or nil. This commit add a special handling for the `ClusterRole` resource so that the `rules` filed is removed in case aggregation is configured.

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

1. Enable `KServe`
2. Watch for a `ClusterRole` named `kserve-admin`
3. if a reconcile kicks in i.e. because `KServe` pods are deleted, then the `ClusterRole` named `kserve-admin` should not receive updates

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
