### PR TITLE
Typo fixes "manifests"

### DIFF
--- a/components/kueue/kueue.go
+++ b/components/kueue/kueue.go
@@ -82,7 +82,7 @@ func (k *Kueue) ReconcileComponent(ctx context.Context, cli client.Client,
 	}
 	// Deploy Kueue Operator
 	if err := deploy.DeployManifestsFromPath(ctx, cli, owner, Path, dscispec.ApplicationsNamespace, ComponentName, enabled); err != nil {
-		return fmt.Errorf("failed to apply manifetss %s: %w", Path, err)
+		return fmt.Errorf("failed to apply manifests %s: %w", Path, err)
 	}
 	l.Info("apply manifests done")
 

--- a/components/ray/ray.go
+++ b/components/ray/ray.go
@@ -87,7 +87,7 @@ func (r *Ray) ReconcileComponent(ctx context.Context, cli client.Client,
 	}
 	// Deploy Ray Operator
 	if err := deploy.DeployManifestsFromPath(ctx, cli, owner, RayPath, dscispec.ApplicationsNamespace, ComponentName, enabled); err != nil {
-		return fmt.Errorf("failed to apply manifets from %s : %w", RayPath, err)
+		return fmt.Errorf("failed to apply manifest from %s : %w", RayPath, err)
 	}
 	l.Info("apply manifests done")
 

--- a/components/workbenches/workbenches.go
+++ b/components/workbenches/workbenches.go
@@ -143,7 +143,7 @@ func (w *Workbenches) ReconcileComponent(ctx context.Context, cli client.Client,
 		notebookControllerPath,
 		dscispec.ApplicationsNamespace,
 		ComponentName, enabled); err != nil {
-		return fmt.Errorf("failed to apply manifetss %s: %w", notebookControllerPath, err)
+		return fmt.Errorf("failed to apply manifests %s: %w", notebookControllerPath, err)
 	}
 	l.WithValues("Path", notebookControllerPath).Info("apply manifests done notebook controller done")
 
@@ -151,7 +151,7 @@ func (w *Workbenches) ReconcileComponent(ctx context.Context, cli client.Client,
 		kfnotebookControllerPath,
 		dscispec.ApplicationsNamespace,
 		ComponentName, enabled); err != nil {
-		return fmt.Errorf("failed to apply manifetss %s: %w", kfnotebookControllerPath, err)
+		return fmt.Errorf("failed to apply manifests %s: %w", kfnotebookControllerPath, err)
 	}
 	l.WithValues("Path", kfnotebookControllerPath).Info("apply manifests done kf-notebook controller done")
 


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->
I noticed a typo from messages shown in the DSC, i.e.,:
```
    - lastHeartbeatTime: '2024-11-29T16:22:36Z'
      lastTransitionTime: '2024-11-29T16:22:36Z'
      message: 'Component reconciliation failed: failed to apply manifetss /opt/manifests/kueue/rhoai: no matches for kind "ValidatingAdmissionPolicy" in version "admissionregistration.k8s.io/v1alpha1"'
      reason: ReconcileFailed
      status: 'False'
```


<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
