### PR TITLE
Make it possible to define predicates along with a dynamic watcher

### DIFF
--- a/pkg/controller/reconciler/component_reconciler_actions.go
+++ b/pkg/controller/reconciler/component_reconciler_actions.go
@@ -34,15 +34,12 @@ func (a *dynamicWatchAction) run(ctx context.Context, rr *types.ReconciliationRe
 			continue
 		}
 
-		ok, err := a.shouldWatch(ctx, w, rr)
-		if err != nil {
-			return err
-		}
+		ok := a.shouldWatch(ctx, w, rr)
 		if !ok {
 			continue
 		}
 
-		err = a.fn(w.object, w.eventHandler, w.predicates...)
+		err := a.fn(w.object, w.eventHandler, w.predicates...)
 		if err != nil {
 			return fmt.Errorf("failed to create watcher for %s: %w", w.object.GetObjectKind().GroupVersionKind(), err)
 		}
@@ -54,16 +51,17 @@ func (a *dynamicWatchAction) run(ctx context.Context, rr *types.ReconciliationRe
 	return nil
 }
 
-func (a *dynamicWatchAction) shouldWatch(ctx context.Context, in watchInput, rr *types.ReconciliationRequest) (bool, error) {
+func (a *dynamicWatchAction) shouldWatch(ctx context.Context, in watchInput, rr *types.ReconciliationRequest) bool {
 	for pi := range in.dynamicPred {
 		ok := in.dynamicPred[pi](ctx, rr)
 		if !ok {
-			return false, nil
+			return false
 		}
 	}
 
-	return true, nil
+	return true
 }
+
 func newDynamicWatch(fn dynamicWatchFn, watches []watchInput) *dynamicWatchAction {
 	action := dynamicWatchAction{
 		fn:      fn,

--- a/pkg/controller/reconciler/component_reconciler_actions.go
+++ b/pkg/controller/reconciler/component_reconciler_actions.go
@@ -1,4 +1,3 @@
-//nilint:testpackage
 package reconciler
 
 import (
@@ -57,10 +56,7 @@ func (a *dynamicWatchAction) run(ctx context.Context, rr *types.ReconciliationRe
 
 func (a *dynamicWatchAction) shouldWatch(ctx context.Context, in watchInput, rr *types.ReconciliationRequest) (bool, error) {
 	for pi := range in.dynamicPred {
-		ok, err := in.dynamicPred[pi](ctx, rr)
-		if err != nil {
-			return false, err
-		}
+		ok := in.dynamicPred[pi](ctx, rr)
 		if !ok {
 			return false, nil
 		}

--- a/pkg/controller/reconciler/component_reconciler_actions_test.go
+++ b/pkg/controller/reconciler/component_reconciler_actions_test.go
@@ -3,7 +3,6 @@ package reconciler
 
 import (
 	"context"
-	"errors"
 	"testing"
 
 	gomegaTypes "github.com/onsi/gomega/types"
@@ -42,11 +41,11 @@ func TestDynamicWatchAction_Run(t *testing.T) {
 		},
 
 		{
-			name:   "should register a watcher the predicate evaluate to true",
+			name:   "should register a watcher when the predicate evaluate to true",
 			object: &componentsv1.Dashboard{TypeMeta: metav1.TypeMeta{Kind: gvk.Dashboard.Kind}},
 			preds: []DynamicPredicate{
-				func(_ context.Context, rr *types.ReconciliationRequest) (bool, error) {
-					return true, nil
+				func(_ context.Context, rr *types.ReconciliationRequest) bool {
+					return true
 				},
 			},
 			errMatcher: Not(HaveOccurred()),
@@ -66,11 +65,11 @@ func TestDynamicWatchAction_Run(t *testing.T) {
 				},
 			},
 			preds: []DynamicPredicate{
-				func(_ context.Context, rr *types.ReconciliationRequest) (bool, error) {
-					return rr.Instance.GetGeneration() > 0, nil
+				func(_ context.Context, rr *types.ReconciliationRequest) bool {
+					return rr.Instance.GetGeneration() > 0
 				},
-				func(_ context.Context, rr *types.ReconciliationRequest) (bool, error) {
-					return rr.Instance.GetResourceVersion() != "", nil
+				func(_ context.Context, rr *types.ReconciliationRequest) bool {
+					return rr.Instance.GetResourceVersion() != ""
 				},
 			},
 			errMatcher: Not(HaveOccurred()),
@@ -82,8 +81,8 @@ func TestDynamicWatchAction_Run(t *testing.T) {
 			name:   "should not register a watcher the predicate returns false",
 			object: &componentsv1.Dashboard{TypeMeta: metav1.TypeMeta{Kind: gvk.Dashboard.Kind}},
 			preds: []DynamicPredicate{
-				func(_ context.Context, rr *types.ReconciliationRequest) (bool, error) {
-					return false, nil
+				func(_ context.Context, rr *types.ReconciliationRequest) bool {
+					return false
 				},
 			},
 			errMatcher: Not(HaveOccurred()),
@@ -103,38 +102,14 @@ func TestDynamicWatchAction_Run(t *testing.T) {
 				},
 			},
 			preds: []DynamicPredicate{
-				func(_ context.Context, rr *types.ReconciliationRequest) (bool, error) {
-					return rr.Instance.GetGeneration() > 0, nil
+				func(_ context.Context, rr *types.ReconciliationRequest) bool {
+					return rr.Instance.GetGeneration() > 0
 				},
-				func(_ context.Context, rr *types.ReconciliationRequest) (bool, error) {
-					return rr.Instance.GetResourceVersion() != "", nil
+				func(_ context.Context, rr *types.ReconciliationRequest) bool {
+					return rr.Instance.GetResourceVersion() != ""
 				},
 			},
 			errMatcher: Not(HaveOccurred()),
-			cntMatcher: BeNumerically("==", 0),
-			keyMatcher: BeEmpty(),
-		},
-
-		{
-			name: "should return an error when a predicate returns an error",
-			object: &componentsv1.Dashboard{
-				TypeMeta: metav1.TypeMeta{
-					Kind: gvk.Dashboard.Kind,
-				},
-				ObjectMeta: metav1.ObjectMeta{
-					Generation:      1,
-					ResourceVersion: "",
-				},
-			},
-			preds: []DynamicPredicate{
-				func(_ context.Context, rr *types.ReconciliationRequest) (bool, error) {
-					return rr.Instance.GetGeneration() > 0, nil
-				},
-				func(_ context.Context, rr *types.ReconciliationRequest) (bool, error) {
-					return false, errors.New("error")
-				},
-			},
-			errMatcher: HaveOccurred(),
 			cntMatcher: BeNumerically("==", 0),
 			keyMatcher: BeEmpty(),
 		},
@@ -189,15 +164,15 @@ func TestDynamicWatchAction_Inputs(t *testing.T) {
 		{
 			object:  resources.GvkToUnstructured(gvk.Secret),
 			dynamic: true,
-			dynamicPred: []DynamicPredicate{func(_ context.Context, rr *types.ReconciliationRequest) (bool, error) {
-				return rr.Instance.GetGeneration() == 0, nil
+			dynamicPred: []DynamicPredicate{func(_ context.Context, rr *types.ReconciliationRequest) bool {
+				return rr.Instance.GetGeneration() == 0
 			}},
 		},
 		{
 			object:  resources.GvkToUnstructured(gvk.ConfigMap),
 			dynamic: true,
-			dynamicPred: []DynamicPredicate{func(_ context.Context, rr *types.ReconciliationRequest) (bool, error) {
-				return rr.Instance.GetGeneration() > 0, nil
+			dynamicPred: []DynamicPredicate{func(_ context.Context, rr *types.ReconciliationRequest) bool {
+				return rr.Instance.GetGeneration() > 0
 			}},
 		},
 	}
@@ -238,8 +213,8 @@ func TestDynamicWatchAction_NotTwice(t *testing.T) {
 		{
 			object:  resources.GvkToUnstructured(gvk.ConfigMap),
 			dynamic: true,
-			dynamicPred: []DynamicPredicate{func(_ context.Context, rr *types.ReconciliationRequest) (bool, error) {
-				return rr.Instance.GetGeneration() > 0, nil
+			dynamicPred: []DynamicPredicate{func(_ context.Context, rr *types.ReconciliationRequest) bool {
+				return rr.Instance.GetGeneration() > 0
 			}},
 		},
 	}

--- a/pkg/controller/reconciler/component_reconciler_actions_test.go
+++ b/pkg/controller/reconciler/component_reconciler_actions_test.go
@@ -1,0 +1,280 @@
+//nolint:testpackage
+package reconciler
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	gomegaTypes "github.com/onsi/gomega/types"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/rs/xid"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+
+	"github.com/opendatahub-io/opendatahub-operator/v2/apis/components"
+	componentsv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/components/v1"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/resources"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestDynamicWatchAction_Run(t *testing.T) {
+	tests := []struct {
+		name       string
+		object     components.ComponentObject
+		preds      []DynamicPredicate
+		errMatcher gomegaTypes.GomegaMatcher
+		cntMatcher gomegaTypes.GomegaMatcher
+		keyMatcher gomegaTypes.GomegaMatcher
+	}{
+		{
+			name:       "should register a watcher if no predicates",
+			object:     &componentsv1.Dashboard{TypeMeta: metav1.TypeMeta{Kind: gvk.Dashboard.Kind}},
+			preds:      []DynamicPredicate{},
+			errMatcher: Not(HaveOccurred()),
+			cntMatcher: BeNumerically("==", 1),
+			keyMatcher: HaveKey(gvk.ConfigMap),
+		},
+
+		{
+			name:   "should register a watcher the predicate evaluate to true",
+			object: &componentsv1.Dashboard{TypeMeta: metav1.TypeMeta{Kind: gvk.Dashboard.Kind}},
+			preds: []DynamicPredicate{
+				func(_ context.Context, rr *types.ReconciliationRequest) (bool, error) {
+					return true, nil
+				},
+			},
+			errMatcher: Not(HaveOccurred()),
+			cntMatcher: BeNumerically("==", 1),
+			keyMatcher: HaveKey(gvk.ConfigMap),
+		},
+
+		{
+			name: "should register a watcher when all predicates evaluate to true",
+			object: &componentsv1.Dashboard{
+				TypeMeta: metav1.TypeMeta{
+					Kind: gvk.Dashboard.Kind,
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Generation:      1,
+					ResourceVersion: xid.New().String(),
+				},
+			},
+			preds: []DynamicPredicate{
+				func(_ context.Context, rr *types.ReconciliationRequest) (bool, error) {
+					return rr.Instance.GetGeneration() > 0, nil
+				},
+				func(_ context.Context, rr *types.ReconciliationRequest) (bool, error) {
+					return rr.Instance.GetResourceVersion() != "", nil
+				},
+			},
+			errMatcher: Not(HaveOccurred()),
+			cntMatcher: BeNumerically("==", 1),
+			keyMatcher: HaveKey(gvk.ConfigMap),
+		},
+
+		{
+			name:   "should not register a watcher the predicate returns false",
+			object: &componentsv1.Dashboard{TypeMeta: metav1.TypeMeta{Kind: gvk.Dashboard.Kind}},
+			preds: []DynamicPredicate{
+				func(_ context.Context, rr *types.ReconciliationRequest) (bool, error) {
+					return false, nil
+				},
+			},
+			errMatcher: Not(HaveOccurred()),
+			cntMatcher: BeNumerically("==", 0),
+			keyMatcher: BeEmpty(),
+		},
+
+		{
+			name: "should not register a watcher when a predicate returns false",
+			object: &componentsv1.Dashboard{
+				TypeMeta: metav1.TypeMeta{
+					Kind: gvk.Dashboard.Kind,
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Generation:      1,
+					ResourceVersion: "",
+				},
+			},
+			preds: []DynamicPredicate{
+				func(_ context.Context, rr *types.ReconciliationRequest) (bool, error) {
+					return rr.Instance.GetGeneration() > 0, nil
+				},
+				func(_ context.Context, rr *types.ReconciliationRequest) (bool, error) {
+					return rr.Instance.GetResourceVersion() != "", nil
+				},
+			},
+			errMatcher: Not(HaveOccurred()),
+			cntMatcher: BeNumerically("==", 0),
+			keyMatcher: BeEmpty(),
+		},
+
+		{
+			name: "should return an error when a predicate returns an error",
+			object: &componentsv1.Dashboard{
+				TypeMeta: metav1.TypeMeta{
+					Kind: gvk.Dashboard.Kind,
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Generation:      1,
+					ResourceVersion: "",
+				},
+			},
+			preds: []DynamicPredicate{
+				func(_ context.Context, rr *types.ReconciliationRequest) (bool, error) {
+					return rr.Instance.GetGeneration() > 0, nil
+				},
+				func(_ context.Context, rr *types.ReconciliationRequest) (bool, error) {
+					return false, errors.New("error")
+				},
+			},
+			errMatcher: HaveOccurred(),
+			cntMatcher: BeNumerically("==", 0),
+			keyMatcher: BeEmpty(),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			g := NewWithT(t)
+			ctx := context.Background()
+
+			watches := []watchInput{{
+				object:      resources.GvkToUnstructured(gvk.ConfigMap),
+				dynamic:     true,
+				dynamicPred: test.preds,
+			}}
+
+			mockFn := func(_ client.Object, _ handler.EventHandler, _ ...predicate.Predicate) error {
+				return nil
+			}
+
+			DynamicWatchResourcesTotal.Reset()
+			DynamicWatchResourcesTotal.WithLabelValues("dashboard").Add(0)
+
+			action := newDynamicWatch(mockFn, watches)
+			err := action.run(ctx, &types.ReconciliationRequest{Instance: test.object})
+
+			if test.cntMatcher != nil {
+				g.Expect(err).To(test.errMatcher)
+			}
+			if test.cntMatcher != nil {
+				g.Expect(testutil.ToFloat64(DynamicWatchResourcesTotal)).To(test.cntMatcher)
+			}
+			if test.keyMatcher != nil {
+				g.Expect(action.watched).Should(test.keyMatcher)
+			}
+		})
+	}
+}
+
+func TestDynamicWatchAction_Inputs(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+
+	mockFn := func(_ client.Object, _ handler.EventHandler, _ ...predicate.Predicate) error {
+		return nil
+	}
+
+	DynamicWatchResourcesTotal.Reset()
+	DynamicWatchResourcesTotal.WithLabelValues("dashboard").Add(0)
+
+	watches := []watchInput{
+		{
+			object:  resources.GvkToUnstructured(gvk.Secret),
+			dynamic: true,
+			dynamicPred: []DynamicPredicate{func(_ context.Context, rr *types.ReconciliationRequest) (bool, error) {
+				return rr.Instance.GetGeneration() == 0, nil
+			}},
+		},
+		{
+			object:  resources.GvkToUnstructured(gvk.ConfigMap),
+			dynamic: true,
+			dynamicPred: []DynamicPredicate{func(_ context.Context, rr *types.ReconciliationRequest) (bool, error) {
+				return rr.Instance.GetGeneration() > 0, nil
+			}},
+		},
+	}
+
+	action := newDynamicWatch(mockFn, watches)
+	err := action.run(ctx, &types.ReconciliationRequest{Instance: &componentsv1.Dashboard{
+		TypeMeta: metav1.TypeMeta{
+			Kind: gvk.Dashboard.Kind,
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Generation: 1,
+		},
+	}})
+
+	g.Expect(err).
+		ShouldNot(HaveOccurred())
+	g.Expect(testutil.ToFloat64(DynamicWatchResourcesTotal)).
+		Should(BeNumerically("==", 1))
+	g.Expect(action.watched).
+		Should(And(
+			HaveLen(1),
+			HaveKey(gvk.ConfigMap)),
+		)
+}
+
+func TestDynamicWatchAction_NotTwice(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+
+	mockFn := func(_ client.Object, _ handler.EventHandler, _ ...predicate.Predicate) error {
+		return nil
+	}
+
+	DynamicWatchResourcesTotal.Reset()
+	DynamicWatchResourcesTotal.WithLabelValues("dashboard").Add(0)
+
+	watches := []watchInput{
+		{
+			object:  resources.GvkToUnstructured(gvk.ConfigMap),
+			dynamic: true,
+			dynamicPred: []DynamicPredicate{func(_ context.Context, rr *types.ReconciliationRequest) (bool, error) {
+				return rr.Instance.GetGeneration() > 0, nil
+			}},
+		},
+	}
+
+	action := newDynamicWatch(mockFn, watches)
+
+	err1 := action.run(ctx, &types.ReconciliationRequest{Instance: &componentsv1.Dashboard{
+		TypeMeta: metav1.TypeMeta{
+			Kind: gvk.Dashboard.Kind,
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Generation: 1,
+		},
+	}})
+
+	g.Expect(err1).
+		ShouldNot(HaveOccurred())
+
+	err2 := action.run(ctx, &types.ReconciliationRequest{Instance: &componentsv1.Dashboard{
+		TypeMeta: metav1.TypeMeta{
+			Kind: gvk.Dashboard.Kind,
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Generation: 1,
+		},
+	}})
+
+	g.Expect(err2).
+		ShouldNot(HaveOccurred())
+
+	g.Expect(testutil.ToFloat64(DynamicWatchResourcesTotal)).
+		Should(BeNumerically("==", 1))
+	g.Expect(action.watched).
+		Should(And(
+			HaveLen(1),
+			HaveKey(gvk.ConfigMap)),
+		)
+}

--- a/pkg/controller/reconciler/component_reconciler_actions_test.go
+++ b/pkg/controller/reconciler/component_reconciler_actions_test.go
@@ -136,7 +136,7 @@ func TestDynamicWatchAction_Run(t *testing.T) {
 			action := newDynamicWatch(mockFn, watches)
 			err := action.run(ctx, &types.ReconciliationRequest{Instance: test.object})
 
-			if test.cntMatcher != nil {
+			if test.errMatcher != nil {
 				g.Expect(err).To(test.errMatcher)
 			}
 			if test.cntMatcher != nil {

--- a/pkg/controller/reconciler/component_reconciler_support.go
+++ b/pkg/controller/reconciler/component_reconciler_support.go
@@ -46,7 +46,7 @@ type forInput struct {
 	gvk     schema.GroupVersionKind
 }
 
-type DynamicPredicate func(context.Context, *types.ReconciliationRequest) (bool, error)
+type DynamicPredicate func(context.Context, *types.ReconciliationRequest) bool
 
 type watchInput struct {
 	object       client.Object


### PR DESCRIPTION
In some case, a dynamic watcher should be conditionally registered, as
an example, when a component depends on a specific operator to be
installed, then it should be possible to register a dynamic watcher with
a predicate, so the actual watch is registered only if the predicate
succeed.

<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] ~~Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).~~
- [X] The developer has manually tested the changes and verified that the changes work
