### PR TITLE
fix: RHOAIENG-16229 - Renaming Alerts

### DIFF
--- a/config/monitoring/prometheus/apps/prometheus-configs.yaml
+++ b/config/monitoring/prometheus/apps/prometheus-configs.yaml
@@ -1652,11 +1652,11 @@ data:
     groups:
       - name: SLOs-probe_success_model_controller
         rules:
-        - alert: Model Registry Operator Probe Success Burn Rate
+        - alert: Model Registry Operator Probe Success 5m and 1h Burn Rate high
           annotations:
             message: 'High error budget burn for {{ $labels.instance }} (current value: {{ $value }}).'
             triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Model-Serving/rhoai-model-registry-operator-probe-success-burn-rate.md"
-            summary: Model Registry Operator Probe Success Burn Rate
+            summary: Model Registry Operator Probe Success 5m and 1h Burn Rate high
           expr: |
             sum(probe_success:burnrate5m{instance=~"model-registry-operator"}) by (instance) > (14.40 * (1-0.98000))
             and
@@ -1665,11 +1665,11 @@ data:
           labels:
             severity: critical
             namespace: redhat-ods-applications
-        - alert: Model Registry Operator Probe Success Burn Rate
+        - alert: Model Registry Operator Probe Success 30m and 6h Burn Rate high
           annotations:
             message: 'High error budget burn for {{ $labels.instance }} (current value: {{ $value }}).'
             triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Model-Serving/rhoai-model-registry-operator-probe-success-burn-rate.md"
-            summary: Model Registry Operator Probe Success Burn Rate
+            summary: Model Registry Operator Probe Success 30m and 6h Burn Rate high
           expr: |
             sum(probe_success:burnrate30m{instance=~"model-registry-operator"}) by (instance) > (6.00 * (1-0.98000))
             and
@@ -1678,11 +1678,11 @@ data:
           labels:
             severity: critical
             namespace: redhat-ods-applications
-        - alert: Model Registry Operator Probe Success Burn Rate
+        - alert: Model Registry Operator Probe Success 2h and 1d Burn Rate high
           annotations:
             message: 'High error budget burn for {{ $labels.instance }} (current value: {{ $value }}).'
             triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Model-Serving/rhoai-model-registry-operator-probe-success-burn-rate.md"
-            summary: Model Registry Operator Probe Success Burn Rate
+            summary: Model Registry Operator Probe Success 2h and 1d Burn Rate high
           expr: |
             sum(probe_success:burnrate2h{instance=~"model-registry-operator"}) by (instance) > (3.00 * (1-0.98000))
             and


### PR DESCRIPTION
## Description
**JIRA:** [RHOAIENG-16229](https://issues.redhat.com/browse/RHOAIENG-16229)

This is a fix for #1397 
That PR missed alert renaming for Model Registry Operator.

/cc @StevenTobin @grdryn @jackdelahunt 
## How Has This Been Tested?
Using PR checks, no testing needed as model registry doesn't have alert tests yet.

## Screenshot or short clip
Not applicable.

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work

@cc