### PR TITLE
(fix): Avoid using pull_request_target event trigger.

### DIFF
--- a/.github/workflows/check-file-updates.yaml
+++ b/.github/workflows/check-file-updates.yaml
@@ -1,47 +1,36 @@
 name: Check config and readme updates
 on:
-  pull_request_target:
+  pull_request:
 jobs:
   file-updates:
-    permissions:
-      pull-requests: write
     name: Ensure generated files are included
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.2.2
         with:
           ref: ${{github.event.pull_request.head.ref}}
           repository: ${{github.event.pull_request.head.repo.full_name}}
-      - name: Generate files
-        id: generate-files
+      - name: Save the PR number for artifact upload
         run: |
-          CMD="make generate manifests api-docs"
-          $CMD
-          echo "CMD=$CMD" >> $GITHUB_OUTPUT
+          echo ${{ github.event.number }} > pr_number.txt
+      - name: Upload the PR number as artifact
+        id: artifact-upload
+        uses: actions/upload-artifact@v4
+        with:
+          name: pr_number
+          path: ./pr_number.txt
+          retention-days: 1 # This will delete the generated artifacts every day.
+      - name: Generate files
+        run: make generate manifests api-docs
       - name: Ensure generated files are up-to-date
         id: check_generated_files
         run : |
+          rm ./pr_number.txt # remove the pr_number.txt before checking "git status", to have correct assessment of the changed files.
           if [[ -n $(git status -s) ]]
           then
             echo "Generated files have been missed in the PR"
             git diff
-            echo "missing_generated_files=true" >> $GITHUB_OUTPUT
+           exit 1
           else
             echo "No new files to commit"
-            echo "missing_generated_files=false" >> $GITHUB_OUTPUT
           fi
-      - name: Report issue in PR
-        if: ${{ steps.check_generated_files.outputs.missing_generated_files == 'true' }}
-        uses: thollander/actions-comment-pull-request@v2
-        with:
-          message: |
-              ## This PR can't be merged just yet 😢
-
-                Please run `${{ steps.generate-files.outputs.CMD }}` and commit the changes.
-
-              For more info: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-      - name: Print git status and fail pr
-        if: ${{ steps.check_generated_files.outputs.missing_generated_files == 'true' }}
-        run: |
-          git status
-          exit 1

--- a/.github/workflows/comment-on-pr.yaml
+++ b/.github/workflows/comment-on-pr.yaml
@@ -1,0 +1,59 @@
+name: Comment on pr
+on:
+  workflow_run:
+    workflows: ["Check config and readme updates"]
+    types:
+      - completed
+jobs:  
+  download-artifact-data:
+    if: ${{ github.event.workflow_run.conclusion == 'failure' }}
+    runs-on: ubuntu-latest
+    outputs:
+      pr_number: ${{ steps.artifact-data.outputs.pr_number }}
+    steps:
+      - name: Download artifact
+        id: artifact-download
+        uses: actions/github-script@v7
+        with:
+          script: |
+            let allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: context.payload.workflow_run.id,
+            });
+            
+            let matchArtifact = allArtifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "pr_number"
+            })[0];
+
+            let download = await github.rest.actions.downloadArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: matchArtifact.id,
+               archive_format: 'zip',
+            });
+            let fs = require('fs');
+            fs.writeFileSync(`${process.env.GITHUB_WORKSPACE}/pr_number.zip`, Buffer.from(download.data));
+      - name: Unzip artifact
+        run: unzip pr_number.zip
+      - name: Extract data
+        id: artifact-data
+        run: |
+          echo "pr_number=$(head -n 1 pr_number.txt)" >> $GITHUB_OUTPUT
+  comment-on-pr:
+    needs:
+      - download-artifact-data
+    runs-on: ubuntu-latest
+    permissions: 
+      pull-requests: write 
+    steps:
+      - name: Report issue in PR
+        uses: thollander/actions-comment-pull-request@v3.0.1
+        with:
+          message: |
+              ## This PR can't be merged just yet 😢
+
+                Please run `make generate manifests api-docs` and commit the changes.
+
+                For more info: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.event.workflow_run.id }}
+          pr-number: ${{ needs.download-artifact-data.outputs.pr_number }}


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
Using pull_request_target event trigger results in security vulnerabilities explained here: https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/

According to the suggestion:
 Create 2 separate actions, one for executing the required `make`commands and one for commenting on the pr.
The comment-on-pr workflow will run only if changes are seen in the manifests or docs.
 Since data propagation does not happen between workflows, it is advised to use the artifacts of GHA.
 The artifacts created by the workflows for each pr will be cleared daily by GHA itself.

JIRA: https://issues.redhat.com/browse/RHOAIENG-15377

## How Has This Been Tested?
Tested in my fork
result: https://github.com/AjayJagan/opendatahub-operator/pull/593#issuecomment-2513748819

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
