### PR TITLE
Refactor DownloadManifests in deploy for clarity and modularity

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -66,6 +66,12 @@ linters-settings:
   perfsprint:
     sprintf1: false
     strconcat: false
+  # Enable gocritic for detecting bugs, performance, and style issues: https://golangci-lint.run/usage/linters/#gocritic
+  gocritic:
+    # https://go-critic.com/overview.html#checkers
+    enabled-checks:
+      - deferInLoop
+      - unnecessaryDefer
 
 linters:
   enable-all: true

--- a/pkg/deploy/deploy.go
+++ b/pkg/deploy/deploy.go
@@ -123,7 +123,7 @@ func unpackTarFromReader(reader io.Reader, basePath, componentName, contextDir s
 			return err
 		}
 
-		err = processTarHeader(header, tarReader, targetPath)
+		err = extractFileOrDirectory(header, tarReader, targetPath)
 		if err != nil {
 			return err
 		}
@@ -152,7 +152,7 @@ func resolveTargetPath(headerName, basePath, contextDir, componentName string) (
 }
 
 // processTarHeader processes a TAR header, creating files or directories as needed.
-func processTarHeader(header *tar.Header, tarReader *tar.Reader, targetPath string) error {
+func extractFileOrDirectory(header *tar.Header, tarReader *tar.Reader, targetPath string) error {
 	switch header.Typeflag {
 	case tar.TypeDir:
 		// Create a directory for the current header

--- a/pkg/deploy/deploy.go
+++ b/pkg/deploy/deploy.go
@@ -52,19 +52,21 @@ import (
 )
 
 var (
-	DefaultManifestPath = os.Getenv("DEFAULT_MANIFESTS_PATH")
+	DefaultManifestPath     = os.Getenv("DEFAULT_MANIFESTS_PATH")
+	errPathResolutionFailed = errors.New("path resolution failed")
+	errPathIrrelevant       = errors.New("path is irrelevant")
 )
 
 // DownloadManifests function performs following tasks:
 // 1. It takes component URI and only downloads folder specified by component.ContextDir field
 // 2. It saves the manifests in the odh-manifests/component-name/ folder.
 func DownloadManifests(ctx context.Context, componentName string, manifestConfig components.ManifestsConfig) error {
-	// Get the component repo from the given url
-	// e.g.  https://github.com/example/tarball/master
+	// Download and validate the manifest archive from the given url, e.g.  https://github.com/example/tarball/master
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, manifestConfig.URI, nil)
 	if err != nil {
 		return err
 	}
+
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return fmt.Errorf("error downloading manifests: %w", err)
@@ -75,76 +77,111 @@ func DownloadManifests(ctx context.Context, componentName string, manifestConfig
 		return fmt.Errorf("error downloading manifests: %v HTTP status", resp.StatusCode)
 	}
 
-	// Create a new gzip reader
+	// Initialize a gzip reader for the response body
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		return fmt.Errorf("error creating gzip reader: %w", err)
 	}
 	defer gzipReader.Close()
 
-	// Create a new TAR reader
-	tarReader := tar.NewReader(gzipReader)
-
-	// Create manifest directory
-	mode := os.ModePerm
-	err = os.MkdirAll(DefaultManifestPath, mode)
-	if err != nil {
-		return fmt.Errorf("error creating manifests directory : %w", err)
+	// Ensure manifest directory exists
+	if err := createDirectory(DefaultManifestPath); err != nil {
+		return err
 	}
 
-	// Extract the contents of the TAR archive to the current directory
+	// Extract TAR contents
+	return unpackTarFromReader(gzipReader, DefaultManifestPath, componentName, manifestConfig.ContextDir)
+}
+
+// createDirectory ensures the specified directory exists, creating it if necessary.
+func createDirectory(path string) error {
+	err := os.MkdirAll(path, os.ModePerm)
+	if err != nil {
+		return fmt.Errorf("error creating directory %s: %w", path, err)
+	}
+	return nil
+}
+
+// unpackTarFromReader extracts files from a TAR reader into the target base path.
+func unpackTarFromReader(reader io.Reader, basePath, componentName, contextDir string) error {
+	tarReader := tar.NewReader(reader)
+
 	for {
 		header, err := tarReader.Next()
 		if errors.Is(err, io.EOF) {
 			break
 		}
 		if err != nil {
+			return fmt.Errorf("error reading tar header: %w", err)
+		}
+
+		targetPath, err := resolveTargetPath(header.Name, basePath, componentName, contextDir)
+		if errors.Is(err, errPathIrrelevant) {
+			continue
+		}
+		if err != nil {
 			return err
 		}
 
-		componentFiles := strings.Split(header.Name, "/")
-		componentFileName := header.Name
-		componentManifestPath := componentFiles[0] + "/" + manifestConfig.ContextDir
-
-		if strings.Contains(componentFileName, componentManifestPath) {
-			// Get manifest path relative to repo
-			// e.g. of repo/a/b/manifests/base --> base/
-			componentFoldersList := strings.Split(componentFileName, "/")
-			componentFileRelativePathFound := strings.Join(componentFoldersList[len(strings.Split(componentManifestPath, "/")):], "/")
-
-			if header.Typeflag == tar.TypeDir {
-				err = os.MkdirAll(DefaultManifestPath+"/"+componentName+"/"+componentFileRelativePathFound, mode)
-				if err != nil {
-					return fmt.Errorf("error creating directory:%w", err)
-				}
-
-				continue
-			}
-
-			if header.Typeflag == tar.TypeReg {
-				file, err := os.Create(DefaultManifestPath + "/" + componentName + "/" + componentFileRelativePathFound)
-				if err != nil {
-					return fmt.Errorf("error creating file: %w", err)
-				}
-
-				defer file.Close()
-
-				for {
-					_, err := io.CopyN(file, tarReader, 1024)
-					if err != nil {
-						if errors.Is(err, io.EOF) {
-							break
-						}
-						return fmt.Errorf("error downloading file contents: %w", err)
-					}
-				}
-
-				continue
-			}
+		err = processTarHeader(header, tarReader, targetPath)
+		if err != nil {
+			return err
 		}
 	}
 
-	return err
+	return nil
+}
+
+// resolveTargetPath computes the target file path based on the tar header and context directory.
+func resolveTargetPath(headerName, basePath, contextDir, componentName string) (string, error) {
+	componentFiles := strings.Split(headerName, "/")
+	componentManifestPath := filepath.Join(componentFiles[0], contextDir)
+
+	if !strings.Contains(headerName, componentManifestPath) {
+		return "", errPathIrrelevant
+	}
+
+	componentFoldersList := strings.Split(headerName, "/")
+	if len(componentFoldersList) < len(strings.Split(componentManifestPath, "/")) {
+		return "", errPathResolutionFailed // Path resolution failed
+	}
+
+	relativePath := strings.Join(componentFoldersList[len(strings.Split(componentManifestPath, "/")):], "/")
+
+	return filepath.Join(basePath, componentName, relativePath), nil
+}
+
+// processTarHeader processes a TAR header, creating files or directories as needed.
+func processTarHeader(header *tar.Header, tarReader *tar.Reader, targetPath string) error {
+	switch header.Typeflag {
+	case tar.TypeDir:
+		// Create a directory for the current header
+		return createDirectory(targetPath)
+
+	case tar.TypeReg:
+		// Create a file and copy its contents from the TAR reader
+		return writeFileFromTar(targetPath, tarReader)
+
+	default:
+		// Handle unsupported header types if needed
+		return nil
+	}
+}
+
+// writeFileFromTar writes a file from the tar reader to the target path.
+func writeFileFromTar(targetPath string, tarReader *tar.Reader) error {
+	file, err := os.Create(targetPath)
+	if err != nil {
+		return fmt.Errorf("error creating file %s: %w", targetPath, err)
+	}
+	defer file.Close()
+
+	_, err = io.Copy(file, tarReader)
+	if err != nil {
+		return fmt.Errorf("error writing to file %s: %w", targetPath, err)
+	}
+
+	return nil
 }
 
 func DeployManifestsFromPath(


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

This PR refactors the DownloadManifests function in the deploy package to improve its structure, readability, and maintainability.

The PR introduces the following key changes:
- Refactored loop to skip failed or irrelevant paths using specific errors: `errPathResolutionFailed`, and `errPathIrrelevant`.
- Extracted TAR unpacking logic into `unpackTarFromReader`.
- Centralized path resolution into `resolveTargetPath`.
- Moved header processing into `processTarHeader` and `writeFileFromTar` for better organization.
- Unified directory creation with a reusable `createDirectory` function.
- Enabled [gocritic](https://golangci-lint.run/usage/linters/#gocritic) linter diagnostic `defer` [checkers](https://go-critic.com/overview.html#checkers).

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
