### PR TITLE
update: operator-sdk to 1.32 + update golint + cleanup unnecessary files

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -38,6 +38,10 @@ linters-settings:
         alias: dscv1
       - pkg: github.com/opendatahub-io/opendatahub-operator/v2/apis/infrastructure/v1
         alias: infrav1
+      - pkg: github.com/opendatahub-io/opendatahub-operator/v2/apis/components/v1alpha1
+        alias: componentApi
+      - pkg: github.com/opendatahub-io/opendatahub-operator/v2/apis/services/v1alpha1
+        alias: serviceApi
       - pkg: k8s.io/apimachinery/pkg/api/errors
         alias: k8serr
       # Ensures that i.e. k8s.io/api/rbac/v1 is aliased as rbacv1
@@ -49,6 +53,10 @@ linters-settings:
         alias: dscctrl
       - pkg: github.com/opendatahub-io/opendatahub-operator/v2/controllers/dscinitialization
         alias: dscictrl
+      - pkg: github.com/opendatahub-io/opendatahub-operator/v2/controllers/components/(\w+)
+        alias: ${1}ctrl
+      - pkg: github.com/opendatahub-io/opendatahub-operator/v2/controllers/services/(\w+)
+        alias: ${1}ctrl
   ireturn:
     allow:
       # defaults https://golangci-lint.run/usage/linters/#ireturn

--- a/Dockerfiles/bundle.Dockerfile
+++ b/Dockerfiles/bundle.Dockerfile
@@ -7,7 +7,7 @@ LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=opendatahub-operator
 LABEL operators.operatorframework.io.bundle.channels.v1=fast
 LABEL operators.operatorframework.io.bundle.channel.default.v1=fast
-LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.31.0
+LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.32.0
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v3
 

--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ YQ ?= $(LOCALBIN)/yq
 ## Tool Versions
 KUSTOMIZE_VERSION ?= v5.0.2
 CONTROLLER_GEN_VERSION ?= v0.16.1
-OPERATOR_SDK_VERSION ?= v1.31.0
+OPERATOR_SDK_VERSION ?= v1.32.0
 GOLANGCI_LINT_VERSION ?= v1.61.0
 YQ_VERSION ?= v4.12.2
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
@@ -292,11 +292,12 @@ $(CRD_REF_DOCS): $(LOCALBIN)
 	)
 
 BUNDLE_DIR ?= "bundle"
+WARNINGMSG = "provided API should have an example annotation"
 .PHONY: bundle
 bundle: prepare operator-sdk ## Generate bundle manifests and metadata, then validate generated files.
 	$(OPERATOR_SDK) generate kustomize manifests -q
-	$(KUSTOMIZE) build config/manifests | $(OPERATOR_SDK) generate bundle $(BUNDLE_GEN_FLAGS)
-	$(OPERATOR_SDK) bundle validate ./$(BUNDLE_DIR)
+	$(KUSTOMIZE) build config/manifests | $(OPERATOR_SDK) generate bundle $(BUNDLE_GEN_FLAGS) 2>&1 | grep -v $(WARNINGMSG)
+	$(OPERATOR_SDK) bundle validate ./$(BUNDLE_DIR) 2>&1 | grep -v $(WARNINGMSG)
 	mv bundle.Dockerfile Dockerfiles/
 	rm -f bundle/manifests/opendatahub-operator-webhook-service_v1_service.yaml
 

--- a/bundle/manifests/opendatahub-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/opendatahub-operator.clusterserviceversion.yaml
@@ -108,7 +108,7 @@ metadata:
     containerImage: quay.io/opendatahub/opendatahub-operator:v2.21.0
     createdAt: "2024-11-22T19:16:14Z"
     olm.skipRange: '>=1.0.0 <2.21.0'
-    operators.operatorframework.io/builder: operator-sdk-v1.31.0
+    operators.operatorframework.io/builder: operator-sdk-v1.32.0
     operators.operatorframework.io/internal-objects: '["featuretrackers.features.opendatahub.io",
       "codeflares.components.platform.opendatahub.io", "dashboards.components.platform.opendatahub.io",
       "datasciencepipelines.components.platform.opendatahub.io", "kserves.components.platform.opendatahub.io",

--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -6,7 +6,7 @@ annotations:
   operators.operatorframework.io.bundle.package.v1: opendatahub-operator
   operators.operatorframework.io.bundle.channels.v1: fast
   operators.operatorframework.io.bundle.channel.default.v1: fast
-  operators.operatorframework.io.metrics.builder: operator-sdk-v1.31.0
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.32.0
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
   operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v3
 

--- a/config/samples/kustomization.yaml
+++ b/config/samples/kustomization.yaml
@@ -2,20 +2,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
+# Do not add component, service and featuretracker, coz we do not want them to show in CSV
 resources:
 - datasciencecluster_v1_datasciencecluster.yaml
 - dscinitialization_v1_dscinitialization.yaml
-#- components_v1_dashboard.yaml
-#- components_v1_workbenches.yaml
-#- components_v1_modelmeshserving.yaml
-#- components_v1_datasciencepipelines.yaml
-#- components_v1_kserve.yaml
-#- components_v1_kueue.yaml
-#- components_v1_codeflare.yaml
-#- components_v1_ray.yaml
-#- components_v1_trustyai.yaml
-#- components_v1_modelregistry.yaml
-#- components_v1_trainingoperator.yaml
-#- services_v1_dscmonitoring.yaml
-- services_v1_monitoring.yaml
 #+kubebuilder:scaffold:manifestskustomizesamples

--- a/controllers/webhook/webhook.go
+++ b/controllers/webhook/webhook.go
@@ -36,7 +36,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	dscv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/datasciencecluster/v1"
-	"github.com/opendatahub-io/opendatahub-operator/v2/controllers/components/modelregistry"
+	modelregistryctrl "github.com/opendatahub-io/opendatahub-operator/v2/controllers/components/modelregistry"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
 )
 
@@ -185,7 +185,7 @@ func (m *DSCDefaulter) Default(_ context.Context, obj runtime.Object) error {
 	// set default registriesNamespace if empty "" but ModelRegistry is enabled
 	if dsc.Spec.Components.ModelRegistry.ManagementState == operatorv1.Managed {
 		if dsc.Spec.Components.ModelRegistry.RegistriesNamespace == "" {
-			dsc.Spec.Components.ModelRegistry.RegistriesNamespace = modelregistry.DefaultModelRegistriesNamespace
+			dsc.Spec.Components.ModelRegistry.RegistriesNamespace = modelregistryctrl.DefaultModelRegistriesNamespace
 		}
 	}
 	return nil

--- a/controllers/webhook/webhook_suite_test.go
+++ b/controllers/webhook/webhook_suite_test.go
@@ -45,7 +45,7 @@ import (
 	dscv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/datasciencecluster/v1"
 	dsciv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/dscinitialization/v1"
 	serviceApi "github.com/opendatahub-io/opendatahub-operator/v2/apis/services/v1alpha1"
-	modelregistry2 "github.com/opendatahub-io/opendatahub-operator/v2/controllers/components/modelregistry"
+	modelregistryctrl "github.com/opendatahub-io/opendatahub-operator/v2/controllers/components/modelregistry"
 	"github.com/opendatahub-io/opendatahub-operator/v2/controllers/webhook"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -211,7 +211,7 @@ var _ = Describe("DSC mutating webhook", func() {
 		dscInstance := newMRDSC1(nameBase+"-dsc-mr1", "", operatorv1.Managed)
 		Expect(k8sClient.Create(ctx, dscInstance)).Should(Succeed())
 		Expect(dscInstance.Spec.Components.ModelRegistry.RegistriesNamespace).
-			Should(Equal(modelregistry2.DefaultModelRegistriesNamespace))
+			Should(Equal(modelregistryctrl.DefaultModelRegistriesNamespace))
 		Expect(clearInstance(ctx, dscInstance)).Should(Succeed())
 	})
 

--- a/pkg/cluster/gvk/gvk.go
+++ b/pkg/cluster/gvk/gvk.go
@@ -122,6 +122,12 @@ var (
 		Kind:    "ModelMeshServing",
 	}
 
+	ModelController = schema.GroupVersionKind{
+		Group:   "components.opendatahub.io",
+		Version: "v1",
+		Kind:    "ModelController",
+	}
+
 	DataSciencePipelines = schema.GroupVersionKind{
 		Group:   "components.platform.opendatahub.io",
 		Version: "v1alpha1",

--- a/tests/e2e/creation_test.go
+++ b/tests/e2e/creation_test.go
@@ -21,7 +21,7 @@ import (
 	dscv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/datasciencecluster/v1"
 	dsciv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/dscinitialization/v1"
 	infrav1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/infrastructure/v1"
-	"github.com/opendatahub-io/opendatahub-operator/v2/controllers/components/modelregistry"
+	modelregistryctrl "github.com/opendatahub-io/opendatahub-operator/v2/controllers/components/modelregistry"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/feature/serverless"
 )
@@ -403,14 +403,14 @@ func (tc *testContext) validateModelRegistryConfig() error {
 			return err
 		}
 		// allowed to set registriesNamespace back to default value
-		err = patchRegistriesNamespace(tc, modelregistry.DefaultModelRegistriesNamespace,
-			modelregistry.DefaultModelRegistriesNamespace, false)
+		err = patchRegistriesNamespace(tc, modelregistryctrl.DefaultModelRegistriesNamespace,
+			modelregistryctrl.DefaultModelRegistriesNamespace, false)
 		if err != nil {
 			return err
 		}
 	} else {
 		// not allowed to change registriesNamespace
-		err := patchRegistriesNamespace(tc, testNs, modelregistry.DefaultModelRegistriesNamespace, true)
+		err := patchRegistriesNamespace(tc, testNs, modelregistryctrl.DefaultModelRegistriesNamespace, true)
 		if err != nil {
 			return err
 		}

--- a/tests/e2e/helper_test.go
+++ b/tests/e2e/helper_test.go
@@ -27,7 +27,7 @@ import (
 	dsciv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/dscinitialization/v1"
 	infrav1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/infrastructure/v1"
 	serviceApi "github.com/opendatahub-io/opendatahub-operator/v2/apis/services/v1alpha1"
-	"github.com/opendatahub-io/opendatahub-operator/v2/controllers/components/modelregistry"
+	modelregistryctrl "github.com/opendatahub-io/opendatahub-operator/v2/controllers/components/modelregistry"
 )
 
 const (
@@ -174,7 +174,7 @@ func setupDSCInstance(name string) *dscv1.DataScienceCluster {
 						ManagementState: operatorv1.Managed,
 					},
 					ModelRegistryCommonSpec: componentApi.ModelRegistryCommonSpec{
-						RegistriesNamespace: modelregistry.DefaultModelRegistriesNamespace,
+						RegistriesNamespace: modelregistryctrl.DefaultModelRegistriesNamespace,
 					},
 				},
 				TrainingOperator: componentApi.DSCTrainingOperator{

--- a/tests/e2e/modelregistry_test.go
+++ b/tests/e2e/modelregistry_test.go
@@ -18,7 +18,7 @@ import (
 
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/apis/components/v1alpha1"
 	dscv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/datasciencecluster/v1"
-	"github.com/opendatahub-io/opendatahub-operator/v2/controllers/components/modelregistry"
+	modelregistryctrl "github.com/opendatahub-io/opendatahub-operator/v2/controllers/components/modelregistry"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/metadata/annotations"
@@ -357,7 +357,7 @@ func (mr *ModelRegistryTestCtx) validateModelRegistryCert(t *testing.T) {
 		mr.Get(
 			gvk.Secret,
 			mr.testDSCI.Spec.ServiceMesh.ControlPlane.Namespace,
-			modelregistry.DefaultModelRegistryCert,
+			modelregistryctrl.DefaultModelRegistryCert,
 		),
 	).Should(And(
 		jq.Match(`.type == "%s"`, is.Type),
@@ -370,7 +370,7 @@ func (mr *ModelRegistryTestCtx) validateModelRegistryServiceMeshMember(t *testin
 	g := mr.WithT(t)
 
 	g.Eventually(
-		mr.Get(gvk.ServiceMeshMember, modelregistry.DefaultModelRegistriesNamespace, "default"),
+		mr.Get(gvk.ServiceMeshMember, modelregistryctrl.DefaultModelRegistriesNamespace, "default"),
 	).Should(
 		jq.Match(`.spec | has("controlPlaneRef")`),
 	)


### PR DESCRIPTION
**CAN WAIT TILL API VERSION CHANGE GET MERGED FIRST**
- change operator-sdk from 1.31(202307) to 1.32(202310)
- add modelcontroller into gvk (not in use for now)
- remove component and service sample yamls
- remove service example from CSV
- disable warning message from make target due to above
- update golint to force alias on component and service to be "<name>ctrl" on api to be componentsv1 and servicesv1

<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
