### PR TITLE
Draft: chore: use same version of golangci-lint as GHA

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -274,7 +274,7 @@ GOLANGCI_LINT_INSTALL_SCRIPT ?= 'https://raw.githubusercontent.com/golangci/gola
 .PHONY: golangci-lint
 golangci-lint: $(GOLANGCI_LINT) ## Download golangci-lint locally if necessary.
 $(GOLANGCI_LINT): $(LOCALBIN)
-	test -s $(GOLANGCI_LINT) || { curl -sSfL $(GOLANGCI_LINT_INSTALL_SCRIPT) | bash -s $(GOLANGCI_LINT_VERSION); }
+	{ curl -sSfL $(GOLANGCI_LINT_INSTALL_SCRIPT) | bash -s $(GOLANGCI_LINT_VERSION); }
 
 
 OS=$(shell uname -s)


### PR DESCRIPTION
**Ignore this until #1422 is merged: it made sense against incubation, but not yet against main**
-------

<!---
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

This is a follow up to #1327.

The GitHub action has updated past the version of golangci-lint that
we've specified in the Makefile. This brings them to the same version
to prevent inconsistency (moving to Go 1.22 will introduce such
inconsistency).

The task to install this tool currently doesn't ensure the version, if
it's already in place, so one can to run `make -B golangci-lint` once
to get the correct versions.

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

```
➜ ./bin/golangci-lint version
golangci-lint has version 1.60.2 built with go1.23.0 from f338f3ef on 2024-08-20T20:09:03Z

➜ make golangci-lint
make: Nothing to be done for 'golangci-lint'.

➜ make -B golangci-lint
mkdir -p /var/home/gryan/src/github.com/opendatahub-io/opendatahub-operator/bin
{ curl -sSfL 'https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh' | bash -s v1.61.0; }
golangci/golangci-lint info checking GitHub for tag 'v1.61.0'
golangci/golangci-lint info found version: 1.61.0 for v1.61.0/linux/arm64
golangci/golangci-lint info installed ./bin/golangci-lint

➜ ./bin/golangci-lint version
golangci-lint has version 1.61.0 built with go1.23.1 from a1d6c560 on 2024-09-09T17:44:42Z

➜ make golangci-lint
make: Nothing to be done for 'golangci-lint'.
```

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work