### PR TITLE
feat: use label selector to pick namespace

### DIFF
--- a/controllers/dscinitialization/dscinitialization_controller.go
+++ b/controllers/dscinitialization/dscinitialization_controller.go
@@ -172,10 +172,9 @@ func (r *DSCInitializationReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		}
 	}
 
-	// Check namespace is not exist, then create
-	namespace := instance.Spec.ApplicationsNamespace
-	if err := r.createOperatorResource(ctx, instance, namespace, platform); err != nil {
-		// no need to log error as it was already logged in createOdhNamespace
+	// Deal with application namespace, configmap, networpolicy etc
+	if err := r.createOperatorResource(ctx, instance, platform); err != nil {
+		// no need to log error as it was already logged in createOperatorResource
 		return reconcile.Result{}, err
 	}
 

--- a/controllers/dscinitialization/dscinitialization_controller.go
+++ b/controllers/dscinitialization/dscinitialization_controller.go
@@ -174,8 +174,7 @@ func (r *DSCInitializationReconciler) Reconcile(ctx context.Context, req ctrl.Re
 
 	// Check namespace is not exist, then create
 	namespace := instance.Spec.ApplicationsNamespace
-	err := r.createOdhNamespace(ctx, instance, namespace, platform)
-	if err != nil {
+	if err := r.createOperatorResource(ctx, instance, namespace, platform); err != nil {
 		// no need to log error as it was already logged in createOdhNamespace
 		return reconcile.Result{}, err
 	}

--- a/controllers/dscinitialization/dscinitialization_test.go
+++ b/controllers/dscinitialization/dscinitialization_test.go
@@ -25,7 +25,7 @@ const (
 	workingNamespace     = "test-operator-ns"
 	applicationName      = "default-dsci"
 	customizedAppNs      = "my-opendatahub"
-	applicationNamespace = "opendatahub"
+	applicationNamespace = "test-application-ns"
 	usergroupName        = "odh-admins"
 	configmapName        = "odh-common-config"
 	monitoringNamespace  = "test-monitoring-ns"
@@ -58,7 +58,7 @@ var _ = Describe("DataScienceCluster initialization", func() {
 
 		AfterEach(cleanupResources)
 
-		It("Should have labels on application namespace", func(ctx context.Context) {
+		It("Should have security labels on application namespace", func(ctx context.Context) {
 			// then
 			appNS := &corev1.Namespace{}
 			Eventually(namespaceExists(customizedAppNs, appNS)).
@@ -70,9 +70,7 @@ var _ = Describe("DataScienceCluster initialization", func() {
 		})
 	})
 
-	Context("Creation of default related resources", func() {
-		// must be default as instance name, or it will break
-
+	Context("Creation of related resources", func() {
 		BeforeEach(func(ctx context.Context) {
 			// when
 			desiredDsci := createDSCI(operatorv1.Managed, operatorv1.Managed, monitoringNamespace)

--- a/controllers/dscinitialization/dscinitialization_test.go
+++ b/controllers/dscinitialization/dscinitialization_test.go
@@ -58,7 +58,7 @@ var _ = Describe("DataScienceCluster initialization", func() {
 
 		AfterEach(cleanupResources)
 
-		It("Should have security labels on application namespace", func(ctx context.Context) {
+		It("Should have security labels on existing DSCI specified application namespace", func(ctx context.Context) {
 			// then
 			appNS := &corev1.Namespace{}
 			Eventually(namespaceExists(customizedAppNs, appNS)).

--- a/pkg/metadata/labels/types.go
+++ b/pkg/metadata/labels/types.go
@@ -1,13 +1,14 @@
 package labels
 
 const (
-	ODHAppPrefix      = "app.opendatahub.io"
-	InjectTrustCA     = "config.openshift.io/inject-trusted-cabundle"
-	SecurityEnforce   = "pod-security.kubernetes.io/enforce"
-	ClusterMonitoring = "openshift.io/cluster-monitoring"
-	PlatformPartOf    = "platform.opendatahub.io/part-of"
-	Platform          = "platform"
-	True              = "true"
+	ODHAppPrefix           = "app.opendatahub.io"
+	InjectTrustCA          = "config.openshift.io/inject-trusted-cabundle"
+	SecurityEnforce        = "pod-security.kubernetes.io/enforce"
+	ClusterMonitoring      = "openshift.io/cluster-monitoring"
+	PlatformPartOf         = "platform.opendatahub.io/part-of"
+	Platform               = "platform"
+	True                   = "true"
+	CustomizedAppNamespace = "opendatahub.io/application-namespace"
 )
 
 // K8SCommon keeps common kubernetes labels [1]


### PR DESCRIPTION
cherry-pick https://github.com/opendatahub-io/opendatahub-operator/pull/1370 + more kinds

Add more information for this PR:
we keep managed cluster as is, we do not change logic for it
user can set to use their own application namespace, but this namespace must follow pre-req:
1. pre-created before ODH operator gets installed
2. this namespace must have "opendatahub.io/application-namespace: true" label
3. only one namespace in the cluster can have this "opendatahub.io/application-namespace: true" label, or operator crash during startup. till user remove labels from other namespace. then crashloop will stop.
4. if this namespace exist, operator use it for cache and ignore opendatahub/redhat-ods-applications in ODH or self-managed case.


operator does not care if application namespace already has  "opendatahub.io/generated-namespace:true" label or not
- if it does have, this namespace will be deleted during operator uninstallation, 
- if it does not, it will be kept even Operator is uninstalled.+

"pod-security.kubernetes.io/enforce:baseline" label will be added onto this namespace, regardless it is customized or default application namespace

- for clean installation:
  - if user keep using default namespace (opendatahuab/redhat-ods-application) : same as before this PR
  - if user want to use a different namespace as  application namepsace:  steps are
    1. they will need to create projects themselves, 
    2. only one new project can have label "opendatahub.io/application-namespace": "true" 
    3. then they install ODH operator
    4. then they create DSCI by fill applicationnamespace field with this namespace
    5. then create DSC
    
if user set a namespace in DSCI.applicationnamespace which 
- does not have label "opendatahub.io/application-namespace": "true"
- or has "opendatahub.io/application-namespace": "false"
in above 2 cases, this throws error in Operator, DSCI keep being "Error" status, 
if user ingore this and  preceed to create DSC, DSC keeps being "in pgrogress" and more error throw in operator pod log
the way to fix above case is to : delete DSC if already created, delete DSCI and recreate DSCI with the correct namespace value.

if step (2) is missed, that will require restart operator pod to get things fixed

this has no impact on the "upgrade" case: as if user already have ODH running in the cluster, after upgrade to new build with this PR included, it wont do anything, keep using the old default namespace.
unless user delete DSC, delete DSCI, create another namespace A with "opendatahub.io/appliation-namespace:true" label ,preform operator upgrade. In this case, the new namespace A will be used and old "opendatahub/redhat-ods-application" namespace remain in cluster (and some resources can be left there as well) but wont be used. therefore, it would be good, to uninstall old operator before using the new one (as do a proper cleanup not just delete DSC+DSCI to swith to new namespace A)


<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

<!--- Link your JIRA and related links here for reference. -->
ref: https://issues.redhat.com/browse/RHOAIENG-17688

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
local build: quay.io/wenzhou/opendatahub-operator:2.17.14115

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
