### PR TITLE
Migration uninstall configmap from DSC to setup controller

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ IMG ?= $(IMAGE_TAG_BASE):$(IMG_TAG)
 # You can use it as an arg. (E.g make bundle-build BUNDLE_IMG=<some-registry>/<project-name-bundle>:<tag>)
 BUNDLE_IMG ?= $(IMAGE_TAG_BASE)-bundle:v$(VERSION)
 
-IMAGE_BUILDER ?= docker
+IMAGE_BUILDER ?= podman
 OPERATOR_NAMESPACE ?= opendatahub-operator-system
 DEFAULT_MANIFESTS_PATH ?= opt/manifests
 CGO_ENABLED ?= 1

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ IMG ?= $(IMAGE_TAG_BASE):$(IMG_TAG)
 # You can use it as an arg. (E.g make bundle-build BUNDLE_IMG=<some-registry>/<project-name-bundle>:<tag>)
 BUNDLE_IMG ?= $(IMAGE_TAG_BASE)-bundle:v$(VERSION)
 
-IMAGE_BUILDER ?= podman
+IMAGE_BUILDER ?= docker
 OPERATOR_NAMESPACE ?= opendatahub-operator-system
 DEFAULT_MANIFESTS_PATH ?= opt/manifests
 CGO_ENABLED ?= 1

--- a/bundle/manifests/opendatahub-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/opendatahub-operator.clusterserviceversion.yaml
@@ -106,7 +106,7 @@ metadata:
     categories: AI/Machine Learning, Big Data
     certified: "False"
     containerImage: quay.io/opendatahub/opendatahub-operator:v2.21.0
-    createdAt: "2024-11-22T19:16:14Z"
+    createdAt: "2024-12-16T13:35:31Z"
     olm.skipRange: '>=1.0.0 <2.21.0'
     operators.operatorframework.io/builder: operator-sdk-v1.31.0
     operators.operatorframework.io/internal-objects: '["featuretrackers.features.opendatahub.io",
@@ -649,6 +649,7 @@ spec:
           verbs:
           - create
           - delete
+          - deletecollection
           - get
           - list
           - patch

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -389,6 +389,7 @@ rules:
   verbs:
   - create
   - delete
+  - deletecollection
   - get
   - list
   - patch

--- a/controllers/datasciencecluster/datasciencecluster_controller.go
+++ b/controllers/datasciencecluster/datasciencecluster_controller.go
@@ -28,7 +28,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
@@ -78,20 +77,18 @@ func (r *DataScienceClusterReconciler) Reconcile(ctx context.Context, req ctrl.R
 	log.Info("Reconciling DataScienceCluster resources", "Request.Name", req.Name)
 
 	instance := &dscv1.DataScienceCluster{}
-	err := r.Client.Get(ctx, req.NamespacedName, instance)
-	//Removed operator uninstall to the setup operator
+
+	// Removed operator uninstall to the setup operator
 	// We don't need finalizer anymore, remove it if present to handle the
 	// upgrade case
+
 	if controllerutil.RemoveFinalizer(instance, finalizerName) {
 		if err := r.Client.Update(ctx, instance); err != nil {
 			return ctrl.Result{}, err
 		}
 	}
 
-	// If DSC CR exist and deletion CM exist
-	// delete DSC CR and let reconcile requeue - Moved to setup controller
-	//No longer needed as setup is watches the HasDeleteConfigMap
-	/*if !instance.ObjectMeta.DeletionTimestamp.IsZero() {
+	if !instance.ObjectMeta.DeletionTimestamp.IsZero() {
 		log.Info("Finalization DataScienceCluster start deleting instance", "name", instance.Name)
 
 		if upgrade.HasDeleteConfigMap(ctx, r.Client) {
@@ -99,7 +96,7 @@ func (r *DataScienceClusterReconciler) Reconcile(ctx context.Context, req ctrl.R
 		}
 
 		return ctrl.Result{}, nil
-	}*/
+	}
 
 	// validate pre-requisites
 	if err := r.validate(ctx, instance); err != nil {
@@ -118,7 +115,7 @@ func (r *DataScienceClusterReconciler) Reconcile(ctx context.Context, req ctrl.R
 		return strings.Compare(string(a.Type), string(b.Type))
 	})
 
-	err = r.Client.ApplyStatus(ctx, instance, client.FieldOwner(fieldOwner), client.ForceOwnership)
+	err := r.Client.ApplyStatus(ctx, instance, client.FieldOwner(fieldOwner), client.ForceOwnership)
 	switch {
 	case err == nil:
 		return ctrl.Result{}, nil

--- a/controllers/datasciencecluster/datasciencecluster_controller.go
+++ b/controllers/datasciencecluster/datasciencecluster_controller.go
@@ -49,6 +49,7 @@ import (
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/handlers"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/predicates"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/predicates/dependent"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/upgrade"
 )
 
 // DataScienceClusterReconciler reconciles a DataScienceCluster object.
@@ -72,12 +73,12 @@ const (
 func (r *DataScienceClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := logf.FromContext(ctx).WithName("DataScienceCluster")
 	log.Info("Reconciling DataScienceCluster resources", "Request.Name", req.Name)
-
 	instance := &dscv1.DataScienceCluster{}
 
-	// Removed operator uninstall to the setup operator
-	// We don't need finalizer anymore, remove it if present to handle the
-	// upgrade case
+	if err := r.Client.Get(ctx, req.NamespacedName, instance); err != nil {
+		log := logf.Log.WithValues("namespace", req.NamespacedName.Namespace, "name", req.NamespacedName.Name)
+		log.Error(err, "Failed to get instance")
+	}
 
 	if controllerutil.RemoveFinalizer(instance, finalizerName) {
 		if err := r.Client.Update(ctx, instance); err != nil {

--- a/controllers/datasciencecluster/datasciencecluster_controller.go
+++ b/controllers/datasciencecluster/datasciencecluster_controller.go
@@ -49,7 +49,6 @@ import (
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/handlers"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/predicates"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/predicates/dependent"
-	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/upgrade"
 )
 
 // DataScienceClusterReconciler reconciles a DataScienceCluster object.
@@ -91,11 +90,6 @@ func (r *DataScienceClusterReconciler) Reconcile(ctx context.Context, req ctrl.R
 
 	if !instance.ObjectMeta.DeletionTimestamp.IsZero() {
 		log.Info("Finalization DataScienceCluster start deleting instance", "name", instance.Name)
-
-		if upgrade.HasDeleteConfigMap(ctx, r.Client) {
-			return ctrl.Result{Requeue: true}, nil
-		}
-
 		return ctrl.Result{}, nil
 	}
 

--- a/controllers/datasciencecluster/datasciencecluster_controller.go
+++ b/controllers/datasciencecluster/datasciencecluster_controller.go
@@ -75,11 +75,9 @@ func (r *DataScienceClusterReconciler) Reconcile(ctx context.Context, req ctrl.R
 	log.Info("Reconciling DataScienceCluster resources", "Request.Name", req.Name)
 	instance := &dscv1.DataScienceCluster{}
 
-	if err := r.Client.Get(ctx, req.NamespacedName, instance); err != nil {
-		log := logf.Log.WithValues("namespace", req.NamespacedName.Namespace, "name", req.NamespacedName.Name)
-		log.Error(err, "Failed to get instance")
+	if err := r.Client.Get(ctx, req.NamespacedName, instance); k8serr.IsNotFound(err) {
+		return ctrl.Result{}, err
 	}
-
 	if controllerutil.RemoveFinalizer(instance, finalizerName) {
 		if err := r.Client.Update(ctx, instance); err != nil {
 			return ctrl.Result{}, err

--- a/controllers/datasciencecluster/kubebuilder_rbac.go
+++ b/controllers/datasciencecluster/kubebuilder_rbac.go
@@ -2,7 +2,7 @@ package datasciencecluster
 
 // +kubebuilder:rbac:groups="datasciencecluster.opendatahub.io",resources=datascienceclusters/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups="datasciencecluster.opendatahub.io",resources=datascienceclusters/finalizers,verbs=update;patch
-// +kubebuilder:rbac:groups="datasciencecluster.opendatahub.io",resources=datascienceclusters,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups="datasciencecluster.opendatahub.io",resources=datascienceclusters,verbs=get;list;watch;create;update;patch;delete;deletecollection
 
 // +kubebuilder:rbac:groups="authentication.k8s.io",resources=tokenreviews,verbs=create;get
 // +kubebuilder:rbac:groups="authorization.k8s.io",resources=subjectaccessreviews,verbs=create;get

--- a/controllers/setupcontroller/setup_controller.go
+++ b/controllers/setupcontroller/setup_controller.go
@@ -8,8 +8,12 @@ import (
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	dscv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/datasciencecluster/v1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
@@ -21,9 +25,17 @@ type SetupControllerReconciler struct {
 	*odhClient.Client
 }
 
+const (
+	finalizerName = "datasciencecluster.opendatahub.io/finalizer"
+)
+
 func (r *SetupControllerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	log := logf.FromContext(ctx).WithName("DataScienceCluster")
-	log.Info("Reconciling setup controller", "Request.Name", req.Name)
+	log := logf.FromContext(ctx).WithName("SetupContoller")
+	log.Info("Reconciling setup controller", "Request.Name", req.Name) // log.V(1).Info(...)
+
+	if !upgrade.HasDeleteConfigMap(ctx, r.Client) {
+		return ctrl.Result{}, nil
+	}
 
 	instance := &dscv1.DataScienceCluster{}
 	err := r.Client.Get(ctx, req.NamespacedName, instance)
@@ -36,6 +48,7 @@ func (r *SetupControllerReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		// Return and don't requeue
 		if upgrade.HasDeleteConfigMap(ctx, r.Client) {
 			if uninstallErr := upgrade.OperatorUninstall(ctx, r.Client, cluster.GetRelease().Name); uninstallErr != nil {
+				log.Info("TRYING TO OperatorUninstall", "InstanceName", instance.Name)
 				return ctrl.Result{}, fmt.Errorf("error while operator uninstall: %w", uninstallErr)
 			}
 		}
@@ -45,10 +58,18 @@ func (r *SetupControllerReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		return ctrl.Result{}, err
 	}
 
+	if controllerutil.RemoveFinalizer(instance, finalizerName) {
+		if err := r.Client.Update(ctx, instance); err != nil {
+			return ctrl.Result{}, err
+		}
+	}
+
 	// If DSC CR exist and deletion CM exist
-	// delete DSC CR
+	// delete DSC CR first then Operator Uninstall
+
 	if upgrade.HasDeleteConfigMap(ctx, r.Client) {
 		deleteErr := r.Client.Delete(ctx, instance, client.PropagationPolicy(metav1.DeletePropagationForeground))
+		log.Info("TRYING TO DELETE", "InstanceName", instance.Name)
 		if deleteErr != nil {
 			return ctrl.Result{}, fmt.Errorf("error while deleting DSC CR: %w", deleteErr)
 		}
@@ -61,6 +82,46 @@ func (r *SetupControllerReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 
 func (r *SetupControllerReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&corev1.ConfigMap{}).
+		For(&corev1.ConfigMap{}, builder.WithPredicates(r.filterDeleteConfigMap())).
 		Complete(r)
+}
+
+func (r *SetupControllerReconciler) filterDeleteConfigMap() predicate.Funcs {
+	filter := func(obj client.Object) bool {
+		cm, ok := obj.(*corev1.ConfigMap)
+		if !ok {
+			return false
+		}
+
+		// Trigger reconcile function when uninstall configmap is created
+		operatorNs, err := cluster.GetOperatorNamespace()
+		if err != nil {
+			return false
+		}
+
+		if cm.Namespace != operatorNs {
+			return false
+		}
+
+		if cm.Labels[upgrade.DeleteConfigMapLabel] != "true" {
+			return false
+		}
+
+		return true
+	}
+
+	return predicate.Funcs{
+		CreateFunc: func(e event.CreateEvent) bool {
+			return filter(e.Object)
+		},
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			return filter(e.ObjectNew)
+		},
+		DeleteFunc: func(e event.DeleteEvent) bool {
+			return false
+		},
+		GenericFunc: func(e event.GenericEvent) bool {
+			return false
+		},
+	}
 }

--- a/controllers/setupcontroller/setup_controller.go
+++ b/controllers/setupcontroller/setup_controller.go
@@ -3,20 +3,18 @@ package setupcontroller
 import (
 	"context"
 	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	k8serr "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
 	dscv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/datasciencecluster/v1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
 	odhClient "github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/client"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/upgrade"
-	k8serr "k8s.io/apimachinery/pkg/api/errors"
-	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-)
-
-const (
-	finalizerName = "datasciencecluster.opendatahub.io/finalizer"
 )
 
 type SetupControllerReconciler struct {
@@ -26,52 +24,42 @@ type SetupControllerReconciler struct {
 func (r *SetupControllerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := logf.FromContext(ctx).WithName("DataScienceCluster")
 	log.Info("Reconciling setup controller", "Request.Name", req.Name)
-	currentOperatorRelease := cluster.GetRelease()
-	platform := currentOperatorRelease.Name
-	instances := &dscv1.DataScienceClusterList{}
 
-	// Check if the delete ConfigMap exists
-	if !upgrade.HasDeleteConfigMap(ctx, r.Client) {
-		log.Info("No delete ConfigMap found, skipping reconciliation")
-		return reconcile.Result{}, nil
-	}
+	instance := &dscv1.DataScienceCluster{}
+	err := r.Client.Get(ctx, req.NamespacedName, instance)
 
-	// Fetch the DataScienceCluster instance
-	if len(instances.Items) == 0 {
-		log.Info("No DataScienceCluster resources found")
+	switch {
+	case k8serr.IsNotFound(err):
+		// Request object not found, could have been deleted after reconcile request.
+		// Owned objects are automatically garbage collected.
+		// For additional cleanup logic use operatorUninstall function.
+		// Return and don't requeue
 		if upgrade.HasDeleteConfigMap(ctx, r.Client) {
-			if uninstallErr := upgrade.OperatorUninstall(ctx, r.Client, platform); uninstallErr != nil {
+			if uninstallErr := upgrade.OperatorUninstall(ctx, r.Client, cluster.GetRelease().Name); uninstallErr != nil {
 				return ctrl.Result{}, fmt.Errorf("error while operator uninstall: %w", uninstallErr)
 			}
 		}
-	}
-	instance := &instances.Items[0]
-	if upgrade.HasDeleteConfigMap(ctx, r.Client) {
-		if controllerutil.ContainsFinalizer(instance, finalizerName) {
-			if controllerutil.RemoveFinalizer(instance, finalizerName) {
-				if err := r.Update(ctx, instance); err != nil {
-					log.Info("Error to remove DSC finalizer", "error", err)
-					return ctrl.Result{}, err
-				}
-				log.Info("Removed finalizer for DataScienceCluster", "name", instance.Name, "finalizer", finalizerName)
 
-			}
-		}
-		// Delete the DataScienceCluster instance
-		if err := r.Client.Delete(ctx, instance, []client.DeleteOption{}...); err != nil {
-			if !k8serr.IsNotFound(err) {
-				log.Error(err, "Failed to delete DataScienceCluster instance", "name", instance.Name)
-				return reconcile.Result{}, err
-			}
-		}
-		log.Info("DataScienceCluster instance deleted successfully, should be requeuing [?]")
-		return reconcile.Result{Requeue: true}, nil
+		return ctrl.Result{}, nil
+	case err != nil:
+		return ctrl.Result{}, err
 	}
+
+	//upgrade
+	if upgrade.HasDeleteConfigMap(ctx, r.Client) {
+		err := r.Client.Delete(ctx, instance, client.PropagationPolicy(metav1.DeletePropagationForeground))
+		if err != nil {
+			return ctrl.Result{}, client.IgnoreNotFound(err)
+		}
+
+		return ctrl.Result{}, nil
+	}
+
 	return ctrl.Result{}, nil
 }
 
 func (r *SetupControllerReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&dscv1.DataScienceCluster{}).
+		For(&corev1.ConfigMap{}).
 		Complete(r)
 }

--- a/controllers/setupcontroller/setup_controller.go
+++ b/controllers/setupcontroller/setup_controller.go
@@ -22,19 +22,18 @@ type SetupControllerReconciler struct {
 }
 
 func (r *SetupControllerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	log := logf.FromContext(ctx).WithName("SetupContoller")
+	log := logf.FromContext(ctx).WithName("SetupController")
 	log.Info("Reconciling setup controller", "Request.Name", req.Name) // log.V(1).Info(...)
 
 	if !upgrade.HasDeleteConfigMap(ctx, r.Client) {
 		return ctrl.Result{}, nil
 	}
 
-	if err := upgrade.OperatorUninstall(ctx, r.Client, cluster.GetRelease().Name, req); err != nil {
+	if err := upgrade.OperatorUninstall(ctx, r.Client, cluster.GetRelease().Name); err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to uninstall setup controller: %w", err)
 	}
 
 	return ctrl.Result{}, nil
-
 }
 
 func (r *SetupControllerReconciler) SetupWithManager(mgr ctrl.Manager) error {

--- a/controllers/setupcontroller/setup_controller.go
+++ b/controllers/setupcontroller/setup_controller.go
@@ -1,0 +1,77 @@
+package setupcontroller
+
+import (
+	"context"
+	"fmt"
+	dscv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/datasciencecluster/v1"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
+	odhClient "github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/client"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/upgrade"
+	k8serr "k8s.io/apimachinery/pkg/api/errors"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+const (
+	finalizerName = "datasciencecluster.opendatahub.io/finalizer"
+)
+
+type SetupControllerReconciler struct {
+	*odhClient.Client
+}
+
+func (r *SetupControllerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	log := logf.FromContext(ctx).WithName("DataScienceCluster")
+	log.Info("Reconciling setup controller", "Request.Name", req.Name)
+	currentOperatorRelease := cluster.GetRelease()
+	platform := currentOperatorRelease.Name
+	instances := &dscv1.DataScienceClusterList{}
+
+	// Check if the delete ConfigMap exists
+	if !upgrade.HasDeleteConfigMap(ctx, r.Client) {
+		log.Info("No delete ConfigMap found, skipping reconciliation")
+		return reconcile.Result{}, nil
+	}
+
+	// Fetch the DataScienceCluster instance
+	if len(instances.Items) == 0 {
+		log.Info("No DataScienceCluster resources found")
+		if upgrade.HasDeleteConfigMap(ctx, r.Client) {
+			if uninstallErr := upgrade.OperatorUninstall(ctx, r.Client, platform); uninstallErr != nil {
+				return ctrl.Result{}, fmt.Errorf("error while operator uninstall: %w", uninstallErr)
+			}
+		}
+	}
+	instance := &instances.Items[0]
+	if upgrade.HasDeleteConfigMap(ctx, r.Client) {
+		if controllerutil.ContainsFinalizer(instance, finalizerName) {
+			if controllerutil.RemoveFinalizer(instance, finalizerName) {
+				if err := r.Update(ctx, instance); err != nil {
+					log.Info("Error to remove DSC finalizer", "error", err)
+					return ctrl.Result{}, err
+				}
+				log.Info("Removed finalizer for DataScienceCluster", "name", instance.Name, "finalizer", finalizerName)
+
+			}
+		}
+		// Delete the DataScienceCluster instance
+		if err := r.Client.Delete(ctx, instance, []client.DeleteOption{}...); err != nil {
+			if !k8serr.IsNotFound(err) {
+				log.Error(err, "Failed to delete DataScienceCluster instance", "name", instance.Name)
+				return reconcile.Result{}, err
+			}
+		}
+		log.Info("DataScienceCluster instance deleted successfully, should be requeuing [?]")
+		return reconcile.Result{Requeue: true}, nil
+	}
+	return ctrl.Result{}, nil
+}
+
+func (r *SetupControllerReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&dscv1.DataScienceCluster{}).
+		Complete(r)
+}

--- a/controllers/setupcontroller/setup_controller.go
+++ b/controllers/setupcontroller/setup_controller.go
@@ -45,11 +45,12 @@ func (r *SetupControllerReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		return ctrl.Result{}, err
 	}
 
-	//upgrade
+	// If DSC CR exist and deletion CM exist
+	// delete DSC CR
 	if upgrade.HasDeleteConfigMap(ctx, r.Client) {
-		err := r.Client.Delete(ctx, instance, client.PropagationPolicy(metav1.DeletePropagationForeground))
-		if err != nil {
-			return ctrl.Result{}, client.IgnoreNotFound(err)
+		deleteErr := r.Client.Delete(ctx, instance, client.PropagationPolicy(metav1.DeletePropagationForeground))
+		if deleteErr != nil {
+			return ctrl.Result{}, fmt.Errorf("error while deleting DSC CR: %w", deleteErr)
 		}
 
 		return ctrl.Result{}, nil

--- a/controllers/setupcontroller/setup_controller.go
+++ b/controllers/setupcontroller/setup_controller.go
@@ -5,17 +5,13 @@ import (
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
-	k8serr "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
-	dscv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/datasciencecluster/v1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
 	odhClient "github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/client"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/upgrade"
@@ -25,10 +21,6 @@ type SetupControllerReconciler struct {
 	*odhClient.Client
 }
 
-const (
-	finalizerName = "datasciencecluster.opendatahub.io/finalizer"
-)
-
 func (r *SetupControllerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := logf.FromContext(ctx).WithName("SetupContoller")
 	log.Info("Reconciling setup controller", "Request.Name", req.Name) // log.V(1).Info(...)
@@ -37,47 +29,12 @@ func (r *SetupControllerReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		return ctrl.Result{}, nil
 	}
 
-	instance := &dscv1.DataScienceCluster{}
-	err := r.Client.Get(ctx, req.NamespacedName, instance)
-
-	switch {
-	case k8serr.IsNotFound(err):
-		// Request object not found, could have been deleted after reconcile request.
-		// Owned objects are automatically garbage collected.
-		// For additional cleanup logic use operatorUninstall function.
-		// Return and don't requeue
-		if upgrade.HasDeleteConfigMap(ctx, r.Client) {
-			if uninstallErr := upgrade.OperatorUninstall(ctx, r.Client, cluster.GetRelease().Name); uninstallErr != nil {
-				log.Info("TRYING TO OperatorUninstall", "InstanceName", instance.Name)
-				return ctrl.Result{}, fmt.Errorf("error while operator uninstall: %w", uninstallErr)
-			}
-		}
-
-		return ctrl.Result{}, nil
-	case err != nil:
-		return ctrl.Result{}, err
-	}
-
-	if controllerutil.RemoveFinalizer(instance, finalizerName) {
-		if err := r.Client.Update(ctx, instance); err != nil {
-			return ctrl.Result{}, err
-		}
-	}
-
-	// If DSC CR exist and deletion CM exist
-	// delete DSC CR first then Operator Uninstall
-
-	if upgrade.HasDeleteConfigMap(ctx, r.Client) {
-		deleteErr := r.Client.Delete(ctx, instance, client.PropagationPolicy(metav1.DeletePropagationForeground))
-		log.Info("TRYING TO DELETE", "InstanceName", instance.Name)
-		if deleteErr != nil {
-			return ctrl.Result{}, fmt.Errorf("error while deleting DSC CR: %w", deleteErr)
-		}
-
-		return ctrl.Result{}, nil
+	if err := upgrade.OperatorUninstall(ctx, r.Client, cluster.GetRelease().Name, req); err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to uninstall setup controller: %w", err)
 	}
 
 	return ctrl.Result{}, nil
+
 }
 
 func (r *SetupControllerReconciler) SetupWithManager(mgr ctrl.Manager) error {

--- a/controllers/setupcontroller/setup_controller.go
+++ b/controllers/setupcontroller/setup_controller.go
@@ -30,7 +30,7 @@ func (r *SetupControllerReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	}
 
 	if err := upgrade.OperatorUninstall(ctx, r.Client, cluster.GetRelease().Name); err != nil {
-		return ctrl.Result{}, fmt.Errorf("failed to uninstall setup controller: %w", err)
+		return ctrl.Result{}, fmt.Errorf("operator uninstall failed : %w", err)
 	}
 
 	return ctrl.Result{}, nil

--- a/main.go
+++ b/main.go
@@ -69,6 +69,7 @@ import (
 	dscctrl "github.com/opendatahub-io/opendatahub-operator/v2/controllers/datasciencecluster"
 	dscictrl "github.com/opendatahub-io/opendatahub-operator/v2/controllers/dscinitialization"
 	"github.com/opendatahub-io/opendatahub-operator/v2/controllers/secretgenerator"
+	"github.com/opendatahub-io/opendatahub-operator/v2/controllers/setupcontroller"
 	"github.com/opendatahub-io/opendatahub-operator/v2/controllers/webhook"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
@@ -298,6 +299,13 @@ func main() { //nolint:funlen,maintidx
 		Recorder: mgr.GetEventRecorderFor("datasciencecluster-controller"),
 	}).SetupWithManager(ctx, mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "DataScienceCluster")
+		os.Exit(1)
+	}
+
+	if err = (&setupcontroller.SetupControllerReconciler{
+		Client: oc,
+	}).SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create controller", "controller", "SetupController")
 		os.Exit(1)
 	}
 

--- a/pkg/upgrade/uninstallation.go
+++ b/pkg/upgrade/uninstallation.go
@@ -30,10 +30,10 @@ const (
 func OperatorUninstall(ctx context.Context, cli client.Client, platform cluster.Platform) error {
 	log := logf.FromContext(ctx)
 
-	if deleteError := removeDSC(ctx, cli); deleteError != nil {
-		return deleteError
+	if err := removeDSC(ctx, cli); err != nil {
+		return err
 	}
-	// If DSC doesn't continue deleting DSCI and other resources
+
 	if err := removeDSCInitialization(ctx, cli); err != nil {
 		return err
 	}
@@ -101,7 +101,7 @@ func removeDSCInitialization(ctx context.Context, cli client.Client) error {
 
 	var multiErr *multierror.Error
 	for _, dsciInstance := range instanceList.Items {
-		if err := cli.Delete(ctx, &dsciInstance); !k8serr.IsNotFound(err) { // DeleteAll
+		if err := cli.Delete(ctx, &dsciInstance); !k8serr.IsNotFound(err) {
 			multiErr = multierror.Append(multiErr, err)
 		}
 	}
@@ -112,8 +112,8 @@ func removeDSCInitialization(ctx context.Context, cli client.Client) error {
 func removeDSC(ctx context.Context, cli client.Client) error {
 	instance := &dscv1.DataScienceCluster{}
 
-	if deleteErr := cli.DeleteAllOf(ctx, instance, client.PropagationPolicy(metav1.DeletePropagationForeground)); deleteErr != nil {
-		return fmt.Errorf("failure deleting DSC: %w", deleteErr)
+	if err := cli.DeleteAllOf(ctx, instance, client.PropagationPolicy(metav1.DeletePropagationForeground)); err != nil {
+		return fmt.Errorf("failure deleting DSC: %w", err)
 	}
 
 	return nil

--- a/pkg/upgrade/uninstallation.go
+++ b/pkg/upgrade/uninstallation.go
@@ -5,6 +5,10 @@ import (
 	"fmt"
 	"time"
 
+	dscv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/datasciencecluster/v1"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/hashicorp/go-multierror"
 	corev1 "k8s.io/api/core/v1"
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
@@ -25,8 +29,21 @@ const (
 
 // OperatorUninstall deletes all the externally generated resources.
 // This includes DSCI, namespace created by operator (but not workbench or MR's), subscription and CSV.
-func OperatorUninstall(ctx context.Context, cli client.Client, platform cluster.Platform) error {
+func OperatorUninstall(ctx context.Context, cli client.Client, platform cluster.Platform, req ctrl.Request) error {
 	log := logf.FromContext(ctx)
+	instance := &dscv1.DataScienceCluster{}
+	err := cli.Get(ctx, req.NamespacedName, instance)
+	if err != nil {
+		return fmt.Errorf("getting DataScienceCluster %s/%s failed: %w", req.Namespace, req.Name, err)
+	}
+	// if DSC exists then delete DSC
+	if !k8serr.IsNotFound(err) {
+		if deleteError := removeDSC(ctx, cli, req); deleteError != nil {
+			return fmt.Errorf("error deleting DSC : %w", deleteError)
+		}
+	}
+
+	// If DSC doesn't continue deleting DSCI and other resources
 	if err := removeDSCInitialization(ctx, cli); err != nil {
 		return err
 	}
@@ -97,6 +114,20 @@ func removeDSCInitialization(ctx context.Context, cli client.Client) error {
 		if err := cli.Delete(ctx, &dsciInstance); !k8serr.IsNotFound(err) {
 			multiErr = multierror.Append(multiErr, err)
 		}
+	}
+
+	return multiErr.ErrorOrNil()
+}
+
+func removeDSC(ctx context.Context, cli client.Client, req ctrl.Request) error {
+	instance := &dscv1.DataScienceCluster{}
+	if err := cli.Get(ctx, req.NamespacedName, instance); err != nil {
+		return err
+	}
+
+	var multiErr *multierror.Error
+	if deleteErr := cli.Delete(ctx, instance, client.PropagationPolicy(metav1.DeletePropagationForeground)); !k8serr.IsNotFound(deleteErr) {
+		multiErr = multierror.Append(multiErr, deleteErr)
 	}
 
 	return multiErr.ErrorOrNil()

--- a/pkg/upgrade/uninstallation.go
+++ b/pkg/upgrade/uninstallation.go
@@ -31,7 +31,7 @@ func OperatorUninstall(ctx context.Context, cli client.Client, platform cluster.
 	log := logf.FromContext(ctx)
 
 	if deleteError := removeDSC(ctx, cli); deleteError != nil {
-		return fmt.Errorf("error deleting DSC : %w", deleteError)
+		return deleteError
 	}
 	// If DSC doesn't continue deleting DSCI and other resources
 	if err := removeDSCInitialization(ctx, cli); err != nil {


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

JIRA: [RHOAIENG-16674](https://issues.redhat.com/browse/RHOAIENG-16674)

Created a new setup-controller and moved the below functionalities to uninstallation.go if `HasDeleteConfigMap` exists 
- Deletion of the DataScienceCluster instance
- Operator uninstall 
- Existing workflow 

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Testing process : 
- install cluster 
- create dsc and dsci
- create `delete-configmap` with 
```
labels:
    api.openshift.com/addon-managed-odh-delete: 'true'
```
- check dsc and dsci deletion and logs for deletion of other resources

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->
<img width="1617" alt="Screenshot 2024-12-16 at 1 00 29 PM" src="https://github.com/user-attachments/assets/a8685285-6683-4a86-960f-8e4738c126c5" />

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
