### PR TITLE
Specify full x.y.z version of Go in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/opendatahub-io/opendatahub-operator/v2
 
-go 1.22
+go 1.22.0
 
 require (
 	github.com/blang/semver/v4 v4.0.0


### PR DESCRIPTION
-------

<!---
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->
JIRA: https://issues.redhat.com/browse/RHOAIENG-16819

## Description
<!--- Describe your changes in detail -->

It seems like on some platforms, when the local installation
installation of Go decides that it needs to download a different
toolchain, that it may fail unless we either specify a full x.y.z
version in the `go` directive, or explicitly specify the `toolchain`
directive.

I believe for our uses, using a fully specified x.y.z `go` directive
value is preferable, to prevent any issues with explicitly defining a
toolchain where we might have a newer version in a container image
build that has a default of `GOTOOLCHAIN='local'` (I'm not 100% sure
if that would cause any issues, but I'm 100% sure that the way
proposed in this commit shouldn't).

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- builds fine
- runs fine

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work