### PR TITLE
Manifests cleanup

### DIFF
--- a/apis/components/v1alpha1/codeflare_types.go
+++ b/apis/components/v1alpha1/codeflare_types.go
@@ -24,7 +24,7 @@ import (
 const (
 	CodeFlareComponentName = "codeflare"
 	// value should match whats set in the XValidation below
-	CodeFlareInstanceName = "default-codeflare"
+	CodeFlareInstanceName = "default-" + CodeFlareComponentName
 	CodeFlareKind         = "CodeFlare"
 )
 

--- a/apis/components/v1alpha1/dashboard_types.go
+++ b/apis/components/v1alpha1/dashboard_types.go
@@ -25,7 +25,7 @@ const (
 	DashboardComponentName = "dashboard"
 	// DashboardInstanceName the name of the Dashboard instance singleton.
 	// value should match whats set in the XValidation below
-	DashboardInstanceName = "default-dashboard"
+	DashboardInstanceName = "default-" + DashboardComponentName
 	DashboardKind         = "Dashboard"
 )
 

--- a/apis/components/v1alpha1/datasciencepipelines_types.go
+++ b/apis/components/v1alpha1/datasciencepipelines_types.go
@@ -32,6 +32,8 @@ const (
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:scope=Cluster
 // +kubebuilder:validation:XValidation:rule="self.metadata.name == 'default-datasciencepipelines'",message="DataSciencePipelines name must be default-datasciencepipelines"
+// +kubebuilder:printcolumn:name="Ready",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].status`,description="Ready"
+// +kubebuilder:printcolumn:name="Reason",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].reason`,description="Reason"
 
 // DataSciencePipelines is the Schema for the datasciencepipelines API
 type DataSciencePipelines struct {

--- a/apis/components/v1alpha1/datasciencepipelines_types.go
+++ b/apis/components/v1alpha1/datasciencepipelines_types.go
@@ -22,9 +22,9 @@ import (
 )
 
 const (
-	DataSciencePipelinesComponentName = "data-science-pipelines-operator"
+	DataSciencePipelinesComponentName = "datasciencepipelines"
 	// value should match whats set in the XValidation below
-	DataSciencePipelinesInstanceName = "default-datasciencepipelines"
+	DataSciencePipelinesInstanceName = "default-" + DataSciencePipelinesComponentName
 	DataSciencePipelinesKind         = "DataSciencePipelines"
 )
 

--- a/apis/components/v1alpha1/kserve_types.go
+++ b/apis/components/v1alpha1/kserve_types.go
@@ -25,10 +25,9 @@ import (
 )
 
 const (
-	KserveComponentName          = "kserve"
-	ModelControllerComponentName = "odh-model-controller" // shared by kserve and mm
+	KserveComponentName = "kserve"
 	// value should match what's set in the XValidation below
-	KserveInstanceName = "default-kserve"
+	KserveInstanceName = "default-" + KserveComponentName
 	KserveKind         = "Kserve"
 )
 

--- a/apis/components/v1alpha1/kueue_types.go
+++ b/apis/components/v1alpha1/kueue_types.go
@@ -24,7 +24,7 @@ import (
 const (
 	KueueComponentName = "kueue"
 	// value should match whats set in the XValidation below
-	KueueInstanceName = "default-kueue"
+	KueueInstanceName = "default-" + KueueComponentName
 	KueueKind         = "Kueue"
 )
 

--- a/apis/components/v1alpha1/modelcontroller_types.go
+++ b/apis/components/v1alpha1/modelcontroller_types.go
@@ -23,9 +23,10 @@ import (
 )
 
 const (
+	ModelControllerComponentName = "modelcontroller"
 	// shared by kserve and modelmeshserving
 	// value should match whats set in the XValidation below
-	ModelControllerInstanceName = "default-modelcontroller"
+	ModelControllerInstanceName = "default-" + ModelControllerComponentName
 	ModelControllerKind         = "ModelController"
 )
 

--- a/apis/components/v1alpha1/modelmeshserving_types.go
+++ b/apis/components/v1alpha1/modelmeshserving_types.go
@@ -22,9 +22,9 @@ import (
 )
 
 const (
-	ModelMeshServingComponentName = "model-mesh"
+	ModelMeshServingComponentName = "modelmeshserving"
 	// value should match whats set in the XValidation below
-	ModelMeshServingInstanceName = "default-modelmesh"
+	ModelMeshServingInstanceName = "default-" + ModelMeshServingComponentName
 	ModelMeshServingKind         = "ModelMeshServing"
 )
 
@@ -33,7 +33,7 @@ const (
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:scope=Cluster
-// +kubebuilder:validation:XValidation:rule="self.metadata.name == 'default-modelmesh'",message="ModelMeshServing name must be default-modelmesh"
+// +kubebuilder:validation:XValidation:rule="self.metadata.name == 'default-modelmeshserving'",message="ModelMeshServing name must be default-modelmeshserving"
 // +kubebuilder:printcolumn:name="Ready",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].status`,description="Ready"
 // +kubebuilder:printcolumn:name="Reason",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].reason`,description="Reason"
 

--- a/apis/components/v1alpha1/modelregistry_types.go
+++ b/apis/components/v1alpha1/modelregistry_types.go
@@ -22,10 +22,10 @@ import (
 )
 
 const (
-	ModelRegistryComponentName = "model-registry-operator"
+	ModelRegistryComponentName = "modelregistry"
 	// ModelRegistryInstanceName the name of the ModelRegistry instance singleton.
 	// value should match what's set in the XValidation below
-	ModelRegistryInstanceName = "default-model-registry"
+	ModelRegistryInstanceName = "default-" + ModelRegistryComponentName
 	ModelRegistryKind         = "ModelRegistry"
 )
 
@@ -62,7 +62,7 @@ type ModelRegistryStatus struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:scope=Cluster
-// +kubebuilder:validation:XValidation:rule="self.metadata.name == 'default-model-registry'",message="ModelRegistry name must be default-model-registry"
+// +kubebuilder:validation:XValidation:rule="self.metadata.name == 'default-modelregistry'",message="ModelRegistry name must be default-modelregistry"
 // +kubebuilder:printcolumn:name="Ready",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].status`,description="Ready"
 // +kubebuilder:printcolumn:name="Reason",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].reason`,description="Reason"
 

--- a/apis/components/v1alpha1/ray_types.go
+++ b/apis/components/v1alpha1/ray_types.go
@@ -24,7 +24,7 @@ import (
 const (
 	RayComponentName = "ray"
 	// value should match whats set in the XValidation below
-	RayInstanceName = "default-ray"
+	RayInstanceName = "default-" + RayComponentName
 	RayKind         = "Ray"
 )
 

--- a/apis/components/v1alpha1/trainingoperator_types.go
+++ b/apis/components/v1alpha1/trainingoperator_types.go
@@ -24,7 +24,7 @@ import (
 const (
 	TrainingOperatorComponentName = "trainingoperator"
 	// value should match whats set in the XValidation below
-	TrainingOperatorInstanceName = "default-trainingoperator"
+	TrainingOperatorInstanceName = "default-" + TrainingOperatorComponentName
 	TrainingOperatorKind         = "TrainingOperator"
 )
 

--- a/apis/components/v1alpha1/trustyai_types.go
+++ b/apis/components/v1alpha1/trustyai_types.go
@@ -24,7 +24,7 @@ import (
 const (
 	TrustyAIComponentName = "trustyai"
 	// value should match whats set in the XValidation below
-	TrustyAIInstanceName = "default-trustyai"
+	TrustyAIInstanceName = "default-" + TrustyAIComponentName
 	TrustyAIKind         = "TrustyAI"
 )
 

--- a/apis/components/v1alpha1/workbenches_types.go
+++ b/apis/components/v1alpha1/workbenches_types.go
@@ -25,7 +25,7 @@ const (
 	WorkbenchesComponentName = "workbenches"
 	// WorkbenchesInstanceName the name of the Workbenches instance singleton.
 	// value should match what is set in the XValidation below.
-	WorkbenchesInstanceName = "default-workbenches"
+	WorkbenchesInstanceName = "default-" + WorkbenchesComponentName
 	WorkbenchesKind         = "Workbenches"
 )
 

--- a/bundle/manifests/components.platform.opendatahub.io_datasciencepipelines.yaml
+++ b/bundle/manifests/components.platform.opendatahub.io_datasciencepipelines.yaml
@@ -14,7 +14,16 @@ spec:
     singular: datasciencepipelines
   scope: Cluster
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - description: Ready
+      jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - description: Reason
+      jsonPath: .status.conditions[?(@.type=="Ready")].reason
+      name: Reason
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: DataSciencePipelines is the Schema for the datasciencepipelines

--- a/bundle/manifests/components.platform.opendatahub.io_modelmeshservings.yaml
+++ b/bundle/manifests/components.platform.opendatahub.io_modelmeshservings.yaml
@@ -145,8 +145,8 @@ spec:
             type: object
         type: object
         x-kubernetes-validations:
-        - message: ModelMeshServing name must be default-modelmesh
-          rule: self.metadata.name == 'default-modelmesh'
+        - message: ModelMeshServing name must be default-modelmeshserving
+          rule: self.metadata.name == 'default-modelmeshserving'
     served: true
     storage: true
     subresources:

--- a/bundle/manifests/components.platform.opendatahub.io_modelregistries.yaml
+++ b/bundle/manifests/components.platform.opendatahub.io_modelregistries.yaml
@@ -154,8 +154,8 @@ spec:
             type: object
         type: object
         x-kubernetes-validations:
-        - message: ModelRegistry name must be default-model-registry
-          rule: self.metadata.name == 'default-model-registry'
+        - message: ModelRegistry name must be default-modelregistry
+          rule: self.metadata.name == 'default-modelregistry'
     served: true
     storage: true
     subresources:

--- a/config/crd/bases/components.platform.opendatahub.io_datasciencepipelines.yaml
+++ b/config/crd/bases/components.platform.opendatahub.io_datasciencepipelines.yaml
@@ -14,7 +14,16 @@ spec:
     singular: datasciencepipelines
   scope: Cluster
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - description: Ready
+      jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - description: Reason
+      jsonPath: .status.conditions[?(@.type=="Ready")].reason
+      name: Reason
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: DataSciencePipelines is the Schema for the datasciencepipelines

--- a/config/crd/bases/components.platform.opendatahub.io_modelmeshservings.yaml
+++ b/config/crd/bases/components.platform.opendatahub.io_modelmeshservings.yaml
@@ -145,8 +145,8 @@ spec:
             type: object
         type: object
         x-kubernetes-validations:
-        - message: ModelMeshServing name must be default-modelmesh
-          rule: self.metadata.name == 'default-modelmesh'
+        - message: ModelMeshServing name must be default-modelmeshserving
+          rule: self.metadata.name == 'default-modelmeshserving'
     served: true
     storage: true
     subresources:

--- a/config/crd/bases/components.platform.opendatahub.io_modelregistries.yaml
+++ b/config/crd/bases/components.platform.opendatahub.io_modelregistries.yaml
@@ -154,8 +154,8 @@ spec:
             type: object
         type: object
         x-kubernetes-validations:
-        - message: ModelRegistry name must be default-model-registry
-          rule: self.metadata.name == 'default-model-registry'
+        - message: ModelRegistry name must be default-modelregistry
+          rule: self.metadata.name == 'default-modelregistry'
     served: true
     storage: true
     subresources:

--- a/controllers/components/codeflare/codeflare.go
+++ b/controllers/components/codeflare/codeflare.go
@@ -70,7 +70,7 @@ func (s *componentHandler) UpdateDSCStatus(dsc *dscv1.DataScienceCluster, obj cl
 		return errors.New("failed to convert to CodeFlare")
 	}
 
-	dsc.Status.InstalledComponents[s.GetName()] = false
+	dsc.Status.InstalledComponents[LegacyComponentName] = false
 	dsc.Status.Components.CodeFlare.ManagementSpec.ManagementState = s.GetManagementState(dsc)
 	dsc.Status.Components.CodeFlare.CodeFlareCommonStatus = nil
 
@@ -83,7 +83,7 @@ func (s *componentHandler) UpdateDSCStatus(dsc *dscv1.DataScienceCluster, obj cl
 
 	switch s.GetManagementState(dsc) {
 	case operatorv1.Managed:
-		dsc.Status.InstalledComponents[s.GetName()] = true
+		dsc.Status.InstalledComponents[LegacyComponentName] = true
 		dsc.Status.Components.CodeFlare.CodeFlareCommonStatus = c.Status.CodeFlareCommonStatus.DeepCopy()
 
 		if rc := meta.FindStatusCondition(c.Status.Conditions, status.ConditionTypeReady); rc != nil {

--- a/controllers/components/codeflare/codeflare_controller.go
+++ b/controllers/components/codeflare/codeflare_controller.go
@@ -62,15 +62,15 @@ func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.
 			reconciler.WithEventHandler(
 				handlers.ToNamed(componentApi.CodeFlareInstanceName)),
 			reconciler.WithPredicates(
-				component.ForLabel(labels.ODH.Component(ComponentName), labels.True)),
+				component.ForLabel(labels.ODH.Component(LegacyComponentName), labels.True)),
 		).
 		// Add CodeFlare-specific actions
 		WithAction(initialize).
 		WithAction(devFlags).
 		WithAction(kustomize.NewAction(
 			kustomize.WithCache(),
-			kustomize.WithLabel(labels.ODH.Component(ComponentName), labels.True),
-			kustomize.WithLabel(labels.K8SCommon.PartOf, ComponentName),
+			kustomize.WithLabel(labels.ODH.Component(LegacyComponentName), labels.True),
+			kustomize.WithLabel(labels.K8SCommon.PartOf, LegacyComponentName),
 		)).
 		WithAction(deploy.NewAction(
 			deploy.WithCache(),

--- a/controllers/components/codeflare/codeflare_support.go
+++ b/controllers/components/codeflare/codeflare_support.go
@@ -10,6 +10,11 @@ import (
 
 const (
 	ComponentName = componentApi.CodeFlareComponentName
+
+	// LegacyComponentName is the name of the component that is assigned to deployments
+	// via Kustomize. Since a deployment selector is immutable, we can't upgrade existing
+	// deployment to the new component name, so keep it around till we figure out a solution.
+	LegacyComponentName = "codeflare"
 )
 
 var (

--- a/controllers/components/dashboard/dashboard.go
+++ b/controllers/components/dashboard/dashboard.go
@@ -42,7 +42,7 @@ func (s *componentHandler) Init(platform cluster.Platform) error {
 	mi := defaultManifestInfo(platform)
 
 	if err := odhdeploy.ApplyParams(mi.String(), imagesMap); err != nil {
-		return fmt.Errorf("failed to update images on path %s: %w", manifestPaths[platform], err)
+		return fmt.Errorf("failed to update images on path %s: %w", mi, err)
 	}
 
 	return nil
@@ -72,7 +72,7 @@ func (s *componentHandler) UpdateDSCStatus(dsc *dscv1.DataScienceCluster, obj cl
 		return errors.New("failed to convert to Dashboard")
 	}
 
-	dsc.Status.InstalledComponents[s.GetName()] = false
+	dsc.Status.InstalledComponents[LegacyComponentNameUpstream] = false
 	dsc.Status.Components.Dashboard.ManagementSpec.ManagementState = s.GetManagementState(dsc)
 	dsc.Status.Components.Dashboard.DashboardCommonStatus = nil
 
@@ -85,7 +85,7 @@ func (s *componentHandler) UpdateDSCStatus(dsc *dscv1.DataScienceCluster, obj cl
 
 	switch s.GetManagementState(dsc) {
 	case operatorv1.Managed:
-		dsc.Status.InstalledComponents[s.GetName()] = true
+		dsc.Status.InstalledComponents[LegacyComponentNameUpstream] = true
 		dsc.Status.Components.Dashboard.DashboardCommonStatus = c.Status.DashboardCommonStatus.DeepCopy()
 
 		if rc := meta.FindStatusCondition(c.Status.Conditions, status.ConditionTypeReady); rc != nil {

--- a/controllers/components/dashboard/dashboard_controller_actions.go
+++ b/controllers/components/dashboard/dashboard_controller_actions.go
@@ -49,12 +49,12 @@ func devFlags(ctx context.Context, rr *odhtypes.ReconciliationRequest) error {
 	// If dev flags are set, update default manifests path
 	if len(dashboard.Spec.DevFlags.Manifests) != 0 {
 		manifestConfig := dashboard.Spec.DevFlags.Manifests[0]
-		if err := odhdeploy.DownloadManifests(ctx, ComponentNameUpstream, manifestConfig); err != nil {
+		if err := odhdeploy.DownloadManifests(ctx, ComponentName, manifestConfig); err != nil {
 			return err
 		}
 		if manifestConfig.SourcePath != "" {
 			rr.Manifests[0].Path = odhdeploy.DefaultManifestPath
-			rr.Manifests[0].ContextDir = ComponentNameUpstream
+			rr.Manifests[0].ContextDir = ComponentName
 			rr.Manifests[0].SourcePath = manifestConfig.SourcePath
 		}
 	}

--- a/controllers/components/datasciencepipelines/datasciencepipelines.go
+++ b/controllers/components/datasciencepipelines/datasciencepipelines.go
@@ -70,7 +70,7 @@ func (s *componentHandler) UpdateDSCStatus(dsc *dscv1.DataScienceCluster, obj cl
 		return errors.New("failed to convert to DataSciencePipelines")
 	}
 
-	dsc.Status.InstalledComponents[s.GetName()] = false
+	dsc.Status.InstalledComponents[LegacyComponentName] = false
 	dsc.Status.Components.DataSciencePipelines.ManagementSpec.ManagementState = s.GetManagementState(dsc)
 	dsc.Status.Components.DataSciencePipelines.DataSciencePipelinesCommonStatus = nil
 
@@ -83,7 +83,7 @@ func (s *componentHandler) UpdateDSCStatus(dsc *dscv1.DataScienceCluster, obj cl
 
 	switch s.GetManagementState(dsc) {
 	case operatorv1.Managed:
-		dsc.Status.InstalledComponents[s.GetName()] = true
+		dsc.Status.InstalledComponents[LegacyComponentName] = true
 		dsc.Status.Components.DataSciencePipelines.DataSciencePipelinesCommonStatus = c.Status.DataSciencePipelinesCommonStatus.DeepCopy()
 
 		if rc := meta.FindStatusCondition(c.Status.Conditions, status.ConditionTypeReady); rc != nil {

--- a/controllers/components/datasciencepipelines/datasciencepipelines_controller.go
+++ b/controllers/components/datasciencepipelines/datasciencepipelines_controller.go
@@ -58,7 +58,7 @@ func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.
 			reconciler.WithEventHandler(
 				handlers.ToNamed(componentApi.DataSciencePipelinesInstanceName)),
 			reconciler.WithPredicates(
-				component.ForLabel(labels.ODH.Component(ComponentName), labels.True)),
+				component.ForLabel(labels.ODH.Component(LegacyComponentName), labels.True)),
 		).
 		// Add datasciencepipelines-specific actions
 		WithAction(checkPreConditions).
@@ -66,8 +66,8 @@ func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.
 		WithAction(devFlags).
 		WithAction(kustomize.NewAction(
 			kustomize.WithCache(),
-			kustomize.WithLabel(labels.ODH.Component(ComponentName), labels.True),
-			kustomize.WithLabel(labels.K8SCommon.PartOf, ComponentName),
+			kustomize.WithLabel(labels.ODH.Component(LegacyComponentName), labels.True),
+			kustomize.WithLabel(labels.K8SCommon.PartOf, LegacyComponentName),
 		)).
 		WithAction(deploy.NewAction(
 			deploy.WithCache(),

--- a/controllers/components/datasciencepipelines/datasciencepipelines_controller_actions.go
+++ b/controllers/components/datasciencepipelines/datasciencepipelines_controller_actions.go
@@ -50,7 +50,7 @@ func checkPreConditions(ctx context.Context, rr *odhtypes.ReconciliationRequest)
 
 	// Verify if existing workflow is deployed by ODH with label
 	// if not then set Argo capability status condition to false
-	odhLabelValue, odhLabelExists := workflowCRD.Labels[labels.ODH.Component(componentApi.DataSciencePipelinesComponentName)]
+	odhLabelValue, odhLabelExists := workflowCRD.Labels[labels.ODH.Component(LegacyComponentName)]
 	if !odhLabelExists || odhLabelValue != "true" {
 		s := dsp.GetStatus()
 		s.Phase = "NotReady"

--- a/controllers/components/datasciencepipelines/datasciencepipelines_support.go
+++ b/controllers/components/datasciencepipelines/datasciencepipelines_support.go
@@ -10,6 +10,11 @@ import (
 const (
 	ArgoWorkflowCRD = "workflows.argoproj.io"
 	ComponentName   = componentApi.DataSciencePipelinesComponentName
+
+	// LegacyComponentName is the name of the component that is assigned to deployments
+	// via Kustomize. Since a deployment selector is immutable, we can't upgrade existing
+	// deployment to the new component name, so keep it around till we figure out a solution.
+	LegacyComponentName = "data-science-pipelines-operator"
 )
 
 var (

--- a/controllers/components/kserve/kserve.go
+++ b/controllers/components/kserve/kserve.go
@@ -26,6 +26,11 @@ const (
 	serverlessOperator       = "serverless-operator"
 	kserveConfigMapName      = "inferenceservice-config"
 	kserveManifestSourcePath = "overlays/odh"
+
+	// LegacyComponentName is the name of the component that is assigned to deployments
+	// via Kustomize. Since a deployment selector is immutable, we can't upgrade existing
+	// deployment to the new component name, so keep it around till we figure out a solution.
+	LegacyComponentName = "kserve"
 )
 
 type componentHandler struct{}
@@ -75,7 +80,7 @@ func (s *componentHandler) UpdateDSCStatus(dsc *dscv1.DataScienceCluster, obj cl
 		return errors.New("failed to convert to Kserve")
 	}
 
-	dsc.Status.InstalledComponents[s.GetName()] = false
+	dsc.Status.InstalledComponents[LegacyComponentName] = false
 	dsc.Status.Components.Kserve.ManagementSpec.ManagementState = s.GetManagementState(dsc)
 	dsc.Status.Components.Kserve.KserveCommonStatus = nil
 
@@ -88,7 +93,7 @@ func (s *componentHandler) UpdateDSCStatus(dsc *dscv1.DataScienceCluster, obj cl
 
 	switch s.GetManagementState(dsc) {
 	case operatorv1.Managed:
-		dsc.Status.InstalledComponents[s.GetName()] = true
+		dsc.Status.InstalledComponents[LegacyComponentName] = true
 		dsc.Status.Components.Kserve.KserveCommonStatus = c.Status.KserveCommonStatus.DeepCopy()
 
 		if rc := meta.FindStatusCondition(c.Status.Conditions, status.ConditionTypeReady); rc != nil {

--- a/controllers/components/kueue/kueue.go
+++ b/controllers/components/kueue/kueue.go
@@ -70,7 +70,7 @@ func (s *componentHandler) UpdateDSCStatus(dsc *dscv1.DataScienceCluster, obj cl
 		return errors.New("failed to convert to Kueue")
 	}
 
-	dsc.Status.InstalledComponents[s.GetName()] = false
+	dsc.Status.InstalledComponents[LegacyComponentName] = false
 	dsc.Status.Components.Kueue.ManagementSpec.ManagementState = s.GetManagementState(dsc)
 	dsc.Status.Components.Kueue.KueueCommonStatus = nil
 
@@ -83,7 +83,7 @@ func (s *componentHandler) UpdateDSCStatus(dsc *dscv1.DataScienceCluster, obj cl
 
 	switch s.GetManagementState(dsc) {
 	case operatorv1.Managed:
-		dsc.Status.InstalledComponents[s.GetName()] = true
+		dsc.Status.InstalledComponents[LegacyComponentName] = true
 		dsc.Status.Components.Kueue.KueueCommonStatus = c.Status.KueueCommonStatus.DeepCopy()
 
 		if rc := meta.FindStatusCondition(c.Status.Conditions, status.ConditionTypeReady); rc != nil {

--- a/controllers/components/kueue/kueue_controller.go
+++ b/controllers/components/kueue/kueue_controller.go
@@ -62,15 +62,15 @@ func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.
 			reconciler.WithEventHandler(
 				handlers.ToNamed(componentApi.KueueComponentName)),
 			reconciler.WithPredicates(
-				component.ForLabel(labels.ODH.Component(ComponentName), labels.True)),
+				component.ForLabel(labels.ODH.Component(LegacyComponentName), labels.True)),
 		).
 		// Add Kueue-specific actions
 		WithAction(initialize).
 		WithAction(devFlags).
 		WithAction(kustomize.NewAction(
 			kustomize.WithCache(),
-			kustomize.WithLabel(labels.ODH.Component(ComponentName), labels.True),
-			kustomize.WithLabel(labels.K8SCommon.PartOf, ComponentName),
+			kustomize.WithLabel(labels.ODH.Component(LegacyComponentName), labels.True),
+			kustomize.WithLabel(labels.K8SCommon.PartOf, LegacyComponentName),
 		)).
 		WithAction(deploy.NewAction(
 			deploy.WithCache(),

--- a/controllers/components/kueue/kueue_support.go
+++ b/controllers/components/kueue/kueue_support.go
@@ -8,6 +8,11 @@ import (
 
 const (
 	ComponentName = componentApi.KueueComponentName
+
+	// LegacyComponentName is the name of the component that is assigned to deployments
+	// via Kustomize. Since a deployment selector is immutable, we can't upgrade existing
+	// deployment to the new component name, so keep it around till we figure out a solution.
+	LegacyComponentName = "kueue"
 )
 
 var (

--- a/controllers/components/modelcontroller/modelcontroller_support.go
+++ b/controllers/components/modelcontroller/modelcontroller_support.go
@@ -2,17 +2,30 @@ package modelcontroller
 
 import (
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/apis/components/v1alpha1"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
 	odhdeploy "github.com/opendatahub-io/opendatahub-operator/v2/pkg/deploy"
 )
 
 const (
 	ComponentName = componentApi.ModelControllerComponentName
+
+	// LegacyComponentName is the name of the component that is assigned to deployments
+	// via Kustomize. Since a deployment selector is immutable, we can't upgrade existing
+	// deployment to the new component name, so keep it around till we figure out a solution.
+	LegacyComponentName = "odh-model-controller"
 )
 
 var (
 	imageParamMap = map[string]string{
 		"odh-model-controller": "RELATED_IMAGE_ODH_MODEL_CONTROLLER_IMAGE",
+	}
+
+	serviceAccounts = map[cluster.Platform][]string{
+		cluster.SelfManagedRhoai: {LegacyComponentName},
+		cluster.ManagedRhoai:     {LegacyComponentName},
+		cluster.OpenDataHub:      {LegacyComponentName},
+		cluster.Unknown:          {LegacyComponentName},
 	}
 )
 

--- a/controllers/components/modelmeshserving/modelmeshserving.go
+++ b/controllers/components/modelmeshserving/modelmeshserving.go
@@ -72,7 +72,7 @@ func (s *componentHandler) UpdateDSCStatus(dsc *dscv1.DataScienceCluster, obj cl
 		return errors.New("failed to convert to ModelMeshServing")
 	}
 
-	dsc.Status.InstalledComponents[s.GetName()] = false
+	dsc.Status.InstalledComponents[LegacyComponentName] = false
 	dsc.Status.Components.ModelMeshServing.ManagementSpec.ManagementState = s.GetManagementState(dsc)
 	dsc.Status.Components.ModelMeshServing.ModelMeshServingCommonStatus = nil
 
@@ -85,7 +85,7 @@ func (s *componentHandler) UpdateDSCStatus(dsc *dscv1.DataScienceCluster, obj cl
 
 	switch s.GetManagementState(dsc) {
 	case operatorv1.Managed:
-		dsc.Status.InstalledComponents[s.GetName()] = true
+		dsc.Status.InstalledComponents[LegacyComponentName] = true
 		dsc.Status.Components.ModelMeshServing.ModelMeshServingCommonStatus = c.Status.ModelMeshServingCommonStatus.DeepCopy()
 
 		if rc := meta.FindStatusCondition(c.Status.Conditions, status.ConditionTypeReady); rc != nil {

--- a/controllers/components/modelmeshserving/modelmeshserving_support.go
+++ b/controllers/components/modelmeshserving/modelmeshserving_support.go
@@ -2,12 +2,18 @@ package modelmeshserving
 
 import (
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/apis/components/v1alpha1"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
 	odhtypes "github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
 	odhdeploy "github.com/opendatahub-io/opendatahub-operator/v2/pkg/deploy"
 )
 
 const (
 	ComponentName = componentApi.ModelMeshServingComponentName
+
+	// LegacyComponentName is the name of the component that is assigned to deployments
+	// via Kustomize. Since a deployment selector is immutable, we can't upgrade existing
+	// deployment to the new component name, so keep it around till we figure out a solution.
+	LegacyComponentName = "model-mesh"
 )
 
 var (
@@ -16,6 +22,13 @@ var (
 		"odh-modelmesh-runtime-adapter": "RELATED_IMAGE_ODH_MODELMESH_RUNTIME_ADAPTER_IMAGE",
 		"odh-modelmesh":                 "RELATED_IMAGE_ODH_MODELMESH_IMAGE",
 		"odh-modelmesh-controller":      "RELATED_IMAGE_ODH_MODELMESH_CONTROLLER_IMAGE",
+	}
+
+	serviceAccounts = map[cluster.Platform][]string{
+		cluster.SelfManagedRhoai: {"modelmesh", "modelmesh-controller"},
+		cluster.ManagedRhoai:     {"modelmesh", "modelmesh-controller"},
+		cluster.OpenDataHub:      {"modelmesh", "modelmesh-controller"},
+		cluster.Unknown:          {"modelmesh", "modelmesh-controller"},
 	}
 )
 

--- a/controllers/components/modelregistry/modelregistry.go
+++ b/controllers/components/modelregistry/modelregistry.go
@@ -80,7 +80,7 @@ func (s *componentHandler) UpdateDSCStatus(dsc *dscv1.DataScienceCluster, obj cl
 		return errors.New("failed to convert to ModelRegistry")
 	}
 
-	dsc.Status.InstalledComponents[s.GetName()] = false
+	dsc.Status.InstalledComponents[LegacyComponentName] = false
 	dsc.Status.Components.ModelRegistry.ManagementSpec.ManagementState = s.GetManagementState(dsc)
 	dsc.Status.Components.ModelRegistry.ModelRegistryCommonStatus = nil
 
@@ -93,7 +93,7 @@ func (s *componentHandler) UpdateDSCStatus(dsc *dscv1.DataScienceCluster, obj cl
 
 	switch s.GetManagementState(dsc) {
 	case operatorv1.Managed:
-		dsc.Status.InstalledComponents[s.GetName()] = true
+		dsc.Status.InstalledComponents[LegacyComponentName] = true
 		dsc.Status.Components.ModelRegistry.ModelRegistryCommonStatus = c.Status.ModelRegistryCommonStatus.DeepCopy()
 
 		if rc := meta.FindStatusCondition(c.Status.Conditions, status.ConditionTypeReady); rc != nil {

--- a/controllers/components/modelregistry/modelregistry_controller.go
+++ b/controllers/components/modelregistry/modelregistry_controller.go
@@ -69,7 +69,7 @@ func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.
 			reconciler.WithEventHandler(
 				handlers.ToNamed(componentApi.ModelRegistryInstanceName)),
 			reconciler.WithPredicates(
-				component.ForLabel(labels.ODH.Component(ComponentName), labels.True)),
+				component.ForLabel(labels.ODH.Component(LegacyComponentName), labels.True)),
 		).
 		// Some ClusterRoles are part of the component deployment, but not owned by
 		// the operator (overlays/odh/extras), so in order to properly keep them
@@ -88,8 +88,8 @@ func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.
 		)).
 		WithAction(kustomize.NewAction(
 			kustomize.WithCache(),
-			kustomize.WithLabel(labels.ODH.Component(ComponentName), labels.True),
-			kustomize.WithLabel(labels.K8SCommon.PartOf, ComponentName),
+			kustomize.WithLabel(labels.ODH.Component(LegacyComponentName), labels.True),
+			kustomize.WithLabel(labels.K8SCommon.PartOf, LegacyComponentName),
 		)).
 		WithAction(customizeResources).
 		WithAction(deploy.NewAction(

--- a/controllers/components/modelregistry/modelregistry_support.go
+++ b/controllers/components/modelregistry/modelregistry_support.go
@@ -15,6 +15,11 @@ const (
 	DefaultModelRegistryCert        = "default-modelregistry-cert"
 	BaseManifestsSourcePath         = "overlays/odh"
 	ServiceMeshMemberTemplate       = "resources/servicemesh-member.tmpl.yaml"
+
+	// LegacyComponentName is the name of the component that is assigned to deployments
+	// via Kustomize. Since a deployment selector is immutable, we can't upgrade existing
+	// deployment to the new component name, so keep it around till we figure out a solution.
+	LegacyComponentName = "model-registry-operator"
 )
 
 var (

--- a/controllers/components/ray/ray.go
+++ b/controllers/components/ray/ray.go
@@ -70,7 +70,7 @@ func (s *componentHandler) UpdateDSCStatus(dsc *dscv1.DataScienceCluster, obj cl
 		return errors.New("failed to convert to Ray")
 	}
 
-	dsc.Status.InstalledComponents[s.GetName()] = false
+	dsc.Status.InstalledComponents[LegacyComponentName] = false
 	dsc.Status.Components.Ray.ManagementSpec.ManagementState = s.GetManagementState(dsc)
 	dsc.Status.Components.Ray.RayCommonStatus = nil
 
@@ -83,7 +83,7 @@ func (s *componentHandler) UpdateDSCStatus(dsc *dscv1.DataScienceCluster, obj cl
 
 	switch s.GetManagementState(dsc) {
 	case operatorv1.Managed:
-		dsc.Status.InstalledComponents[s.GetName()] = true
+		dsc.Status.InstalledComponents[LegacyComponentName] = true
 		dsc.Status.Components.Ray.RayCommonStatus = c.Status.RayCommonStatus.DeepCopy()
 
 		if rc := meta.FindStatusCondition(c.Status.Conditions, status.ConditionTypeReady); rc != nil {

--- a/controllers/components/ray/ray_controller.go
+++ b/controllers/components/ray/ray_controller.go
@@ -55,15 +55,15 @@ func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.
 			reconciler.WithEventHandler(
 				handlers.ToNamed(componentApi.RayInstanceName)),
 			reconciler.WithPredicates(
-				component.ForLabel(labels.ODH.Component(ComponentName), labels.True)),
+				component.ForLabel(labels.ODH.Component(LegacyComponentName), labels.True)),
 		).
 		// Add Ray-specific actions
 		WithAction(initialize).
 		WithAction(devFlags).
 		WithAction(kustomize.NewAction(
 			kustomize.WithCache(),
-			kustomize.WithLabel(labels.ODH.Component(ComponentName), labels.True),
-			kustomize.WithLabel(labels.K8SCommon.PartOf, ComponentName),
+			kustomize.WithLabel(labels.ODH.Component(LegacyComponentName), labels.True),
+			kustomize.WithLabel(labels.K8SCommon.PartOf, LegacyComponentName),
 		)).
 		WithAction(deploy.NewAction(
 			deploy.WithCache(),

--- a/controllers/components/ray/ray_support.go
+++ b/controllers/components/ray/ray_support.go
@@ -8,6 +8,11 @@ import (
 
 const (
 	ComponentName = componentApi.RayComponentName
+
+	// LegacyComponentName is the name of the component that is assigned to deployments
+	// via Kustomize. Since a deployment selector is immutable, we can't upgrade existing
+	// deployment to the new component name, so keep it around till we figure out a solution.
+	LegacyComponentName = "ray"
 )
 
 var (

--- a/controllers/components/trainingoperator/trainingoperator.go
+++ b/controllers/components/trainingoperator/trainingoperator.go
@@ -69,7 +69,7 @@ func (s *componentHandler) UpdateDSCStatus(dsc *dscv1.DataScienceCluster, obj cl
 		return errors.New("failed to convert to TrainingOperator")
 	}
 
-	dsc.Status.InstalledComponents[s.GetName()] = false
+	dsc.Status.InstalledComponents[LegacyComponentName] = false
 	dsc.Status.Components.TrainingOperator.ManagementSpec.ManagementState = s.GetManagementState(dsc)
 	dsc.Status.Components.TrainingOperator.TrainingOperatorCommonStatus = nil
 
@@ -82,7 +82,7 @@ func (s *componentHandler) UpdateDSCStatus(dsc *dscv1.DataScienceCluster, obj cl
 
 	switch s.GetManagementState(dsc) {
 	case operatorv1.Managed:
-		dsc.Status.InstalledComponents[s.GetName()] = true
+		dsc.Status.InstalledComponents[LegacyComponentName] = true
 		dsc.Status.Components.TrainingOperator.TrainingOperatorCommonStatus = c.Status.TrainingOperatorCommonStatus.DeepCopy()
 
 		if rc := meta.FindStatusCondition(c.Status.Conditions, status.ConditionTypeReady); rc != nil {

--- a/controllers/components/trainingoperator/trainingoperator_controller.go
+++ b/controllers/components/trainingoperator/trainingoperator_controller.go
@@ -52,15 +52,15 @@ func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.
 			reconciler.WithEventHandler(
 				handlers.ToNamed(componentApi.TrainingOperatorInstanceName)),
 			reconciler.WithPredicates(
-				component.ForLabel(labels.ODH.Component(ComponentName), labels.True)),
+				component.ForLabel(labels.ODH.Component(LegacyComponentName), labels.True)),
 		).
 		// Add TrainingOperator-specific actions
 		WithAction(initialize).
 		WithAction(devFlags).
 		WithAction(kustomize.NewAction(
 			kustomize.WithCache(),
-			kustomize.WithLabel(labels.ODH.Component(ComponentName), labels.True),
-			kustomize.WithLabel(labels.K8SCommon.PartOf, ComponentName),
+			kustomize.WithLabel(labels.ODH.Component(LegacyComponentName), labels.True),
+			kustomize.WithLabel(labels.K8SCommon.PartOf, LegacyComponentName),
 		)).
 		WithAction(deploy.NewAction(
 			deploy.WithCache(),

--- a/controllers/components/trainingoperator/trainingoperator_support.go
+++ b/controllers/components/trainingoperator/trainingoperator_support.go
@@ -8,6 +8,11 @@ import (
 
 const (
 	ComponentName = componentApi.TrainingOperatorComponentName
+
+	// LegacyComponentName is the name of the component that is assigned to deployments
+	// via Kustomize. Since a deployment selector is immutable, we can't upgrade existing
+	// deployment to the new component name, so keep it around till we figure out a solution.
+	LegacyComponentName = "trainingoperator"
 )
 
 var (

--- a/controllers/components/trustyai/trustyai.go
+++ b/controllers/components/trustyai/trustyai.go
@@ -72,7 +72,7 @@ func (s *componentHandler) UpdateDSCStatus(dsc *dscv1.DataScienceCluster, obj cl
 		return errors.New("failed to convert to TrustyAI")
 	}
 
-	dsc.Status.InstalledComponents[s.GetName()] = false
+	dsc.Status.InstalledComponents[LegacyComponentName] = false
 	dsc.Status.Components.TrustyAI.ManagementSpec.ManagementState = s.GetManagementState(dsc)
 	dsc.Status.Components.TrustyAI.TrustyAICommonStatus = nil
 
@@ -85,7 +85,7 @@ func (s *componentHandler) UpdateDSCStatus(dsc *dscv1.DataScienceCluster, obj cl
 
 	switch s.GetManagementState(dsc) {
 	case operatorv1.Managed:
-		dsc.Status.InstalledComponents[s.GetName()] = true
+		dsc.Status.InstalledComponents[LegacyComponentName] = true
 		dsc.Status.Components.TrustyAI.TrustyAICommonStatus = c.Status.TrustyAICommonStatus.DeepCopy()
 
 		if rc := meta.FindStatusCondition(c.Status.Conditions, status.ConditionTypeReady); rc != nil {

--- a/controllers/components/trustyai/trustyai_controller.go
+++ b/controllers/components/trustyai/trustyai_controller.go
@@ -53,15 +53,15 @@ func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.
 			reconciler.WithEventHandler(
 				handlers.ToNamed(componentApi.TrustyAIInstanceName)),
 			reconciler.WithPredicates(
-				component.ForLabel(labels.ODH.Component(ComponentName), labels.True)),
+				component.ForLabel(labels.ODH.Component(LegacyComponentName), labels.True)),
 		).
 		// Add TrustyAI-specific actions
 		WithAction(initialize).
 		WithAction(devFlags).
 		WithAction(kustomize.NewAction(
 			kustomize.WithCache(),
-			kustomize.WithLabel(labels.ODH.Component(ComponentName), labels.True),
-			kustomize.WithLabel(labels.K8SCommon.PartOf, ComponentName),
+			kustomize.WithLabel(labels.ODH.Component(LegacyComponentName), labels.True),
+			kustomize.WithLabel(labels.K8SCommon.PartOf, LegacyComponentName),
 		)).
 		WithAction(deploy.NewAction(
 			deploy.WithCache(),

--- a/controllers/components/trustyai/trustyai_support.go
+++ b/controllers/components/trustyai/trustyai_support.go
@@ -8,8 +8,12 @@ import (
 )
 
 const (
-	ComponentName     = componentApi.TrustyAIComponentName
-	ComponentPathName = "trustyai-service-operator"
+	ComponentName = componentApi.TrustyAIComponentName
+
+	// LegacyComponentName is the name of the component that is assigned to deployments
+	// via Kustomize. Since a deployment selector is immutable, we can't upgrade existing
+	// deployment to the new component name, so keep it around till we figure out a solution.
+	LegacyComponentName = "trustyai"
 )
 
 var (
@@ -29,7 +33,7 @@ var (
 func manifestsPath(p cluster.Platform) types.ManifestInfo {
 	return types.ManifestInfo{
 		Path:       odhdeploy.DefaultManifestPath,
-		ContextDir: ComponentPathName,
+		ContextDir: ComponentName,
 		SourcePath: overlaysSourcePaths[p],
 	}
 }

--- a/controllers/components/workbenches/workbenches.go
+++ b/controllers/components/workbenches/workbenches.go
@@ -80,7 +80,7 @@ func (s *componentHandler) UpdateDSCStatus(dsc *dscv1.DataScienceCluster, obj cl
 		return errors.New("failed to convert to Workbenches")
 	}
 
-	dsc.Status.InstalledComponents[s.GetName()] = false
+	dsc.Status.InstalledComponents[LegacyComponentName] = false
 	dsc.Status.Components.Workbenches.ManagementSpec.ManagementState = s.GetManagementState(dsc)
 	dsc.Status.Components.Workbenches.WorkbenchesCommonStatus = nil
 
@@ -93,7 +93,7 @@ func (s *componentHandler) UpdateDSCStatus(dsc *dscv1.DataScienceCluster, obj cl
 
 	switch s.GetManagementState(dsc) {
 	case operatorv1.Managed:
-		dsc.Status.InstalledComponents[s.GetName()] = true
+		dsc.Status.InstalledComponents[LegacyComponentName] = true
 		dsc.Status.Components.Workbenches.WorkbenchesCommonStatus = c.Status.WorkbenchesCommonStatus.DeepCopy()
 
 		if rc := meta.FindStatusCondition(c.Status.Conditions, status.ConditionTypeReady); rc != nil {

--- a/controllers/components/workbenches/workbenches_controller.go
+++ b/controllers/components/workbenches/workbenches_controller.go
@@ -57,7 +57,7 @@ func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.
 			reconciler.WithEventHandler(
 				handlers.ToNamed(componentApi.WorkbenchesInstanceName)),
 			reconciler.WithPredicates(
-				component.ForLabel(labels.ODH.Component(ComponentName), labels.True)),
+				component.ForLabel(labels.ODH.Component(LegacyComponentName), labels.True)),
 		).
 		WithAction(initialize).
 		WithAction(devFlags).
@@ -65,8 +65,8 @@ func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.
 		WithAction(security.NewUpdatePodSecurityRoleBindingAction(serviceAccounts)).
 		WithAction(kustomize.NewAction(
 			kustomize.WithCache(),
-			kustomize.WithLabel(labels.ODH.Component(ComponentName), labels.True),
-			kustomize.WithLabel(labels.K8SCommon.PartOf, ComponentName),
+			kustomize.WithLabel(labels.ODH.Component(LegacyComponentName), labels.True),
+			kustomize.WithLabel(labels.K8SCommon.PartOf, LegacyComponentName),
 		)).
 		WithAction(deploy.NewAction(
 			deploy.WithCache(),

--- a/controllers/components/workbenches/workbenches_controller_actions.go
+++ b/controllers/components/workbenches/workbenches_controller_actions.go
@@ -45,7 +45,7 @@ func devFlags(ctx context.Context, rr *odhtypes.ReconciliationRequest) error {
 	for _, subcomponent := range workbenches.Spec.DevFlags.Manifests {
 		if strings.Contains(subcomponent.ContextDir, "components/odh-notebook-controller") {
 			// Download subcomponent
-			if err := odhdeploy.DownloadManifests(ctx, notebookControllerManifestContextDir, subcomponent); err != nil {
+			if err := odhdeploy.DownloadManifests(ctx, notebookControllerContextDir, subcomponent); err != nil {
 				return err
 			}
 			// If overlay is defined, update paths
@@ -56,7 +56,7 @@ func devFlags(ctx context.Context, rr *odhtypes.ReconciliationRequest) error {
 
 		if strings.Contains(subcomponent.ContextDir, "components/notebook-controller") {
 			// Download subcomponent
-			if err := odhdeploy.DownloadManifests(ctx, kfNotebookControllerManifestContextDir, subcomponent); err != nil {
+			if err := odhdeploy.DownloadManifests(ctx, kfNotebookControllerContextDir, subcomponent); err != nil {
 				return err
 			}
 			// If overlay is defined, update paths
@@ -65,9 +65,9 @@ func devFlags(ctx context.Context, rr *odhtypes.ReconciliationRequest) error {
 			}
 		}
 
-		if strings.Contains(subcomponent.URI, DependentComponentName) {
+		if strings.Contains(subcomponent.URI, notebooksPath) {
 			// Download subcomponent
-			if err := odhdeploy.DownloadManifests(ctx, DependentComponentName, subcomponent); err != nil {
+			if err := odhdeploy.DownloadManifests(ctx, notebookContextDir, subcomponent); err != nil {
 				return err
 			}
 			// If overlay is defined, update paths

--- a/controllers/components/workbenches/workbenches_support.go
+++ b/controllers/components/workbenches/workbenches_support.go
@@ -1,6 +1,8 @@
 package workbenches
 
 import (
+	"path"
+
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/apis/components/v1alpha1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
 	odhtypes "github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
@@ -8,32 +10,43 @@ import (
 )
 
 const (
-	ComponentName          = componentApi.WorkbenchesComponentName
-	DependentComponentName = "notebooks"
+	ComponentName = componentApi.WorkbenchesComponentName
 
-	notebookControllerManifestSourcePath = "base"
-	notebookControllerManifestContextDir = "odh-notebook-controller/odh-notebook-controller"
-
-	kfNotebookControllerManifestSourcePath = "overlays/openshift"
-	kfNotebookControllerManifestContextDir = "odh-notebook-controller/kf-notebook-controller"
-
+	notebooksPath                    = "notebooks"
 	notebookImagesManifestSourcePath = "overlays/additional"
 
+	notebookControllerPath               = "odh-notebook-controller"
+	notebookControllerManifestSourcePath = "base"
+
+	kfNotebookControllerPath               = "kf-notebook-controller"
+	kfNotebookControllerManifestSourcePath = "overlays/openshift"
+
 	nbcServiceAccountName = "notebook-controller-service-account"
+
+	// LegacyComponentName is the name of the component that is assigned to deployments
+	// via Kustomize. Since a deployment selector is immutable, we can't upgrade existing
+	// deployment to the new component name, so keep it around till we figure out a solution.
+	LegacyComponentName = "workbenches"
 )
 
-var serviceAccounts = map[cluster.Platform][]string{
-	cluster.SelfManagedRhoai: {nbcServiceAccountName},
-	cluster.ManagedRhoai:     {nbcServiceAccountName},
-	cluster.OpenDataHub:      {nbcServiceAccountName},
-	cluster.Unknown:          {nbcServiceAccountName},
-}
+var (
+	notebookControllerContextDir   = path.Join(ComponentName, notebookControllerPath)
+	kfNotebookControllerContextDir = path.Join(ComponentName, kfNotebookControllerPath)
+	notebookContextDir             = path.Join(ComponentName, notebooksPath)
+
+	serviceAccounts = map[cluster.Platform][]string{
+		cluster.SelfManagedRhoai: {nbcServiceAccountName},
+		cluster.ManagedRhoai:     {nbcServiceAccountName},
+		cluster.OpenDataHub:      {nbcServiceAccountName},
+		cluster.Unknown:          {nbcServiceAccountName},
+	}
+)
 
 // manifests for nbc in ODH and RHOAI + downstream use it for imageparams.
 func notebookControllerManifestInfo(sourcePath string) odhtypes.ManifestInfo {
 	return odhtypes.ManifestInfo{
 		Path:       odhdeploy.DefaultManifestPath,
-		ContextDir: notebookControllerManifestContextDir,
+		ContextDir: notebookControllerContextDir,
 		SourcePath: sourcePath,
 	}
 }
@@ -42,7 +55,7 @@ func notebookControllerManifestInfo(sourcePath string) odhtypes.ManifestInfo {
 func kfNotebookControllerManifestInfo(sourcePath string) odhtypes.ManifestInfo {
 	return odhtypes.ManifestInfo{
 		Path:       odhdeploy.DefaultManifestPath,
-		ContextDir: kfNotebookControllerManifestContextDir,
+		ContextDir: kfNotebookControllerContextDir,
 		SourcePath: sourcePath,
 	}
 }
@@ -51,7 +64,7 @@ func kfNotebookControllerManifestInfo(sourcePath string) odhtypes.ManifestInfo {
 func notebookImagesManifestInfo(sourcePath string) odhtypes.ManifestInfo {
 	return odhtypes.ManifestInfo{
 		Path:       odhdeploy.DefaultManifestPath,
-		ContextDir: DependentComponentName,
+		ContextDir: notebookContextDir,
 		SourcePath: sourcePath,
 	}
 }

--- a/controllers/datasciencecluster/datasciencecluster_controller.go
+++ b/controllers/datasciencecluster/datasciencecluster_controller.go
@@ -144,12 +144,15 @@ func (r *DataScienceClusterReconciler) Reconcile(ctx context.Context, req ctrl.R
 	})
 
 	err = r.Client.ApplyStatus(ctx, instance, client.FieldOwner(fieldOwner), client.ForceOwnership)
-	if err != nil {
+	switch {
+	case err == nil:
+		return ctrl.Result{}, nil
+	case k8serr.IsNotFound(err):
+		return ctrl.Result{}, nil
+	default:
 		r.reportError(ctx, err, instance, "failed to update DataScienceCluster status")
 		return ctrl.Result{}, err
 	}
-
-	return ctrl.Result{}, nil
 }
 
 func (r *DataScienceClusterReconciler) validate(ctx context.Context, _ *dscv1.DataScienceCluster) error {

--- a/get_all_manifests.sh
+++ b/get_all_manifests.sh
@@ -6,20 +6,32 @@ GITHUB_URL="https://github.com"
 # component: notebook, dsp, kserve, dashbaord, cf/ray/kueue/trainingoperator, trustyai, modelmesh, modelregistry.
 # in the format of "repo-org:repo-name:ref-name:source-folder:target-folder".
 declare -A COMPONENT_MANIFESTS=(
-    ["codeflare"]="opendatahub-io:codeflare-operator:main:config:codeflare"
-    ["ray"]="opendatahub-io:kuberay:dev:ray-operator/config:ray"
-    ["kueue"]="opendatahub-io:kueue:dev:config:kueue"
-    ["data-science-pipelines-operator"]="opendatahub-io:data-science-pipelines-operator:main:config:data-science-pipelines-operator"
+    # dashboard
     ["odh-dashboard"]="opendatahub-io:odh-dashboard:main:manifests:dashboard"
-    ["kf-notebook-controller"]="opendatahub-io:kubeflow:v1.7-branch:components/notebook-controller/config:odh-notebook-controller/kf-notebook-controller"
-    ["odh-notebook-controller"]="opendatahub-io:kubeflow:v1.7-branch:components/odh-notebook-controller/config:odh-notebook-controller/odh-notebook-controller"
-    ["notebooks"]="opendatahub-io:notebooks:main:manifests:notebooks"
-    ["trustyai"]="trustyai-explainability:trustyai-service-operator:main:config:trustyai-service-operator"
-    ["model-mesh"]="opendatahub-io:modelmesh-serving:release-0.12.0-rc0:config:model-mesh"
-    ["odh-model-controller"]="opendatahub-io:odh-model-controller:incubating:config:odh-model-controller"
+    # workbenches
+    ["kf-notebook-controller"]="opendatahub-io:kubeflow:v1.7-branch:components/notebook-controller/config:workbenches/kf-notebook-controller"
+    ["odh-notebook-controller"]="opendatahub-io:kubeflow:v1.7-branch:components/odh-notebook-controller/config:workbenches/odh-notebook-controller"
+    ["notebooks"]="opendatahub-io:notebooks:main:manifests:workbenches/notebooks"
+    # modelmeshserving
+    ["model-mesh"]="opendatahub-io:modelmesh-serving:release-0.12.0-rc0:config:modelmeshserving"
+    # kserve
     ["kserve"]="opendatahub-io:kserve:release-v0.14:config:kserve"
-    ["modelregistry"]="opendatahub-io:model-registry-operator:main:config:model-registry-operator"
+    # kueue
+    ["kueue"]="opendatahub-io:kueue:dev:config:kueue"
+    # codeflare
+    ["codeflare"]="opendatahub-io:codeflare-operator:main:config:codeflare"
+    # ray
+    ["ray"]="opendatahub-io:kuberay:dev:ray-operator/config:ray"
+    # trustyai
+    ["trustyai"]="trustyai-explainability:trustyai-service-operator:main:config:trustyai"
+    # modelregistry
+    ["modelregistry"]="opendatahub-io:model-registry-operator:main:config:modelregistry"
+    # trainingoperator
     ["trainingoperator"]="opendatahub-io:training-operator:dev:manifests:trainingoperator"
+    # datasciencepipelines
+    ["data-science-pipelines-operator"]="opendatahub-io:data-science-pipelines-operator:main:config:datasciencepipelines"
+    # modelcontroller
+    ["odh-model-controller"]="opendatahub-io:odh-model-controller:incubating:config:modelcontroller"
 )
 
 # Allow overwriting repo using flags component=repo

--- a/pkg/cluster/gvk/gvk.go
+++ b/pkg/cluster/gvk/gvk.go
@@ -140,6 +140,12 @@ var (
 		Kind:    "Kserve",
 	}
 
+	Kueue = schema.GroupVersionKind{
+		Group:   "components.platform.opendatahub.io",
+		Version: "v1alpha1",
+		Kind:    "Kueue",
+	}
+
 	CodeFlare = schema.GroupVersionKind{
 		Group:   "components.platform.opendatahub.io",
 		Version: "v1alpha1",

--- a/pkg/controller/reconciler/reconciler.go
+++ b/pkg/controller/reconciler/reconciler.go
@@ -213,7 +213,7 @@ func (r *Reconciler[T]) apply(ctx context.Context, res client.Object) error {
 	)
 
 	if err != nil {
-		return err
+		return client.IgnoreNotFound(err)
 	}
 
 	return nil

--- a/tests/e2e/codeflare_test.go
+++ b/tests/e2e/codeflare_test.go
@@ -22,6 +22,7 @@ import (
 
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/apis/components/v1alpha1"
 	dscv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/datasciencecluster/v1"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/metadata/labels"
 )
 
@@ -148,7 +149,7 @@ func (tc *CodeFlareTestCtx) testOwnerReferences() error {
 
 	// Test CodeFlare resources
 	appDeployments, err := tc.testCtx.kubeClient.AppsV1().Deployments(tc.testCtx.applicationsNamespace).List(tc.testCtx.ctx, metav1.ListOptions{
-		LabelSelector: labels.ODH.Component(componentApi.CodeFlareComponentName),
+		LabelSelector: labels.PlatformPartOf + "=" + strings.ToLower(gvk.CodeFlare.Kind),
 	})
 	if err != nil {
 		return fmt.Errorf("error listing component deployments %w", err)
@@ -262,7 +263,7 @@ func (tc *CodeFlareTestCtx) testUpdateCodeFlareComponentDisabled() error {
 
 	if tc.testCtx.testDsc.Spec.Components.CodeFlare.ManagementState == operatorv1.Managed {
 		appDeployments, err := tc.testCtx.kubeClient.AppsV1().Deployments(tc.testCtx.applicationsNamespace).List(tc.testCtx.ctx, metav1.ListOptions{
-			LabelSelector: labels.ODH.Component(componentApi.CodeFlareComponentName),
+			LabelSelector: labels.PlatformPartOf + "=" + strings.ToLower(gvk.CodeFlare.Kind),
 		})
 		if err != nil {
 			return fmt.Errorf("error getting enabled component %v", componentApi.CodeFlareComponentName)
@@ -310,17 +311,18 @@ func (tc *CodeFlareTestCtx) testUpdateCodeFlareComponentDisabled() error {
 		return fmt.Errorf("component CodeFlare is disabled, should not get the CodeFlare CR %v", tc.testCodeFlareInstance.Name)
 	}
 
-	// Sleep for 20 seconds to allow the operator to reconcile
-	time.Sleep(2 * generalRetryInterval)
-	_, err = tc.testCtx.kubeClient.AppsV1().Deployments(tc.testCtx.applicationsNamespace).Get(tc.testCtx.ctx, codeflareDeploymentName, metav1.GetOptions{})
+	appDeployments, err := tc.testCtx.kubeClient.AppsV1().Deployments(tc.testCtx.applicationsNamespace).List(tc.testCtx.ctx, metav1.ListOptions{
+		LabelSelector: labels.PlatformPartOf + "=" + strings.ToLower(gvk.CodeFlare.Kind),
+	})
+
 	if err != nil {
-		if k8serr.IsNotFound(err) {
-			return nil // correct result: should not find deployment after we disable it already
-		}
 		return fmt.Errorf("error getting component resource after reconcile: %w", err)
 	}
-	return fmt.Errorf("component %v is disabled, should not get its deployment %v from NS %v any more",
-		componentApi.CodeFlareKind,
-		codeflareDeploymentName,
-		tc.testCtx.applicationsNamespace)
+	if len(appDeployments.Items) != 0 {
+		return fmt.Errorf("component %v is disabled, should not have deployments in namespace %v any more",
+			componentApi.CodeFlareKind,
+			tc.testCtx.applicationsNamespace)
+	}
+
+	return nil
 }

--- a/tests/e2e/codeflare_test.go
+++ b/tests/e2e/codeflare_test.go
@@ -311,18 +311,17 @@ func (tc *CodeFlareTestCtx) testUpdateCodeFlareComponentDisabled() error {
 		return fmt.Errorf("component CodeFlare is disabled, should not get the CodeFlare CR %v", tc.testCodeFlareInstance.Name)
 	}
 
-	appDeployments, err := tc.testCtx.kubeClient.AppsV1().Deployments(tc.testCtx.applicationsNamespace).List(tc.testCtx.ctx, metav1.ListOptions{
-		LabelSelector: labels.PlatformPartOf + "=" + strings.ToLower(gvk.CodeFlare.Kind),
-	})
-
+	// Sleep for 20 seconds to allow the operator to reconcile
+	time.Sleep(2 * generalRetryInterval)
+	_, err = tc.testCtx.kubeClient.AppsV1().Deployments(tc.testCtx.applicationsNamespace).Get(tc.testCtx.ctx, codeflareDeploymentName, metav1.GetOptions{})
 	if err != nil {
+		if k8serr.IsNotFound(err) {
+			return nil // correct result: should not find deployment after we disable it already
+		}
 		return fmt.Errorf("error getting component resource after reconcile: %w", err)
 	}
-	if len(appDeployments.Items) != 0 {
-		return fmt.Errorf("component %v is disabled, should not have deployments in namespace %v any more",
-			componentApi.CodeFlareKind,
-			tc.testCtx.applicationsNamespace)
-	}
-
-	return nil
+	return fmt.Errorf("component %v is disabled, should not get its deployment %v from NS %v any more",
+		componentApi.CodeFlareKind,
+		codeflareDeploymentName,
+		tc.testCtx.applicationsNamespace)
 }

--- a/tests/e2e/controller_test.go
+++ b/tests/e2e/controller_test.go
@@ -40,18 +40,18 @@ var (
 
 	componentsTestSuites = map[string]TestFn{
 		// do not add modelcontroller here, due to dependency, test it separately below
-		"dashboard":             dashboardTestSuite,
-		"ray":                   rayTestSuite,
-		"modelregistry":         modelRegistryTestSuite,
-		"trustyai":              trustyAITestSuite,
-		"kueue":                 kueueTestSuite,
-		"trainingoperator":      trainingoperatorTestSuite,
-		"datasciencepipelienes": dataSciencePipelinesTestSuite,
-		"codeflare":             codeflareTestSuite,
-		"workbenches":           workbenchesTestSuite,
-		"kserve":                kserveTestSuite,
-		"modelmesh":             modelMeshServingTestSuite,
-		"modelcontroller":       modelControllerTestSuite,
+		componentApi.DashboardComponentName:            dashboardTestSuite,
+		componentApi.RayComponentName:                  rayTestSuite,
+		componentApi.ModelRegistryComponentName:        modelRegistryTestSuite,
+		componentApi.TrustyAIComponentName:             trustyAITestSuite,
+		componentApi.KueueComponentName:                kueueTestSuite,
+		componentApi.TrainingOperatorComponentName:     trainingoperatorTestSuite,
+		componentApi.DataSciencePipelinesComponentName: dataSciencePipelinesTestSuite,
+		componentApi.CodeFlareComponentName:            codeflareTestSuite,
+		componentApi.WorkbenchesComponentName:          workbenchesTestSuite,
+		componentApi.KserveComponentName:               kserveTestSuite,
+		componentApi.ModelMeshServingComponentName:     modelMeshServingTestSuite,
+		componentApi.ModelControllerComponentName:      modelControllerTestSuite,
 	}
 )
 

--- a/tests/e2e/dashboard_test.go
+++ b/tests/e2e/dashboard_test.go
@@ -18,6 +18,7 @@ import (
 
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/apis/components/v1alpha1"
 	dscv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/datasciencecluster/v1"
+	"github.com/opendatahub-io/opendatahub-operator/v2/controllers/components/dashboard"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/metadata/annotations"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/metadata/labels"
@@ -219,9 +220,11 @@ func (d *DashboardTestCtx) validateDashboardInstance(t *testing.T) {
 		d.List(gvk.DataScienceCluster),
 	).Should(And(
 		HaveLen(1),
-		HaveEach(
+		HaveEach(And(
 			jq.Match(`.status.conditions[] | select(.type == "%sReady") | .status == "%s"`, componentApi.DashboardComponentName, metav1.ConditionTrue),
-		),
+			jq.Match(`.status.installedComponents."%s" == true`, dashboard.LegacyComponentNameUpstream),
+			jq.Match(`.status.components.%s.managementState == "%s"`, componentApi.DashboardComponentName, operatorv1.Managed),
+		)),
 	))
 }
 

--- a/tests/e2e/datasciencepipelines_test.go
+++ b/tests/e2e/datasciencepipelines_test.go
@@ -353,18 +353,17 @@ func (tc *DataSciencePipelinesTestCtx) testUpdateDataSciencePipelinesComponentDi
 		return fmt.Errorf("component datasciencepipelines is disabled, should not get the DataSciencePipelines CR %v", tc.testDataSciencePipelinesInstance.Name)
 	}
 
-	appDeployments, err := tc.testCtx.kubeClient.AppsV1().Deployments(tc.testCtx.applicationsNamespace).List(tc.testCtx.ctx, metav1.ListOptions{
-		LabelSelector: labels.PlatformPartOf + "=" + strings.ToLower(gvk.DataSciencePipelines.Kind),
-	})
-
+	// Sleep for 20 seconds to allow the operator to reconcile
+	time.Sleep(2 * generalRetryInterval)
+	_, err = tc.testCtx.kubeClient.AppsV1().Deployments(tc.testCtx.applicationsNamespace).Get(tc.testCtx.ctx, dspDeploymentName, metav1.GetOptions{})
 	if err != nil {
+		if k8serr.IsNotFound(err) {
+			return nil // correct result: should not find deployment after we disable it already
+		}
 		return fmt.Errorf("error getting component resource after reconcile: %w", err)
 	}
-	if len(appDeployments.Items) != 0 {
-		return fmt.Errorf("component %v is disabled, should not have deployments in namespace %v any more",
-			componentApi.DataSciencePipelinesKind,
-			tc.testCtx.applicationsNamespace)
-	}
-
-	return nil
+	return fmt.Errorf("component %v is disabled, should not get its deployment %v from NS %v any more",
+		componentApi.DataSciencePipelinesKind,
+		dspDeploymentName,
+		tc.testCtx.applicationsNamespace)
 }

--- a/tests/e2e/kserve_test.go
+++ b/tests/e2e/kserve_test.go
@@ -17,6 +17,7 @@ import (
 
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/apis/components/v1alpha1"
 	dscv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/datasciencecluster/v1"
+	"github.com/opendatahub-io/opendatahub-operator/v2/controllers/components/kserve"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/metadata/labels"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/resources"
@@ -82,6 +83,8 @@ func (k *KserveTestCtx) validateKserveInstance(t *testing.T) {
 		HaveEach(And(
 			jq.Match(`.status.conditions[] | select(.type == "%sReady") | .status == "%s"`, componentApi.KserveComponentName, metav1.ConditionTrue),
 			jq.Match(`.status.conditions[] | select(.type == "%sReady") | .status == "%s"`, componentApi.ModelControllerComponentName, metav1.ConditionTrue),
+			jq.Match(`.status.installedComponents."%s" == true`, kserve.LegacyComponentName),
+			jq.Match(`.status.components.%s.managementState == "%s"`, componentApi.KserveComponentName, operatorv1.Managed),
 		)),
 	))
 

--- a/tests/e2e/kueue_test.go
+++ b/tests/e2e/kueue_test.go
@@ -311,18 +311,17 @@ func (tc *KueueTestCtx) testUpdateKueueComponentDisabled() error {
 		return fmt.Errorf("component kueue is disabled, should not get the Kueue CR %v", tc.testKueueInstance.Name)
 	}
 
-	appDeployments, err := tc.testCtx.kubeClient.AppsV1().Deployments(tc.testCtx.applicationsNamespace).List(tc.testCtx.ctx, metav1.ListOptions{
-		LabelSelector: labels.PlatformPartOf + "=" + strings.ToLower(gvk.Kueue.Kind),
-	})
-
+	// Sleep for 20 seconds to allow the operator to reconcile
+	time.Sleep(2 * generalRetryInterval)
+	_, err = tc.testCtx.kubeClient.AppsV1().Deployments(tc.testCtx.applicationsNamespace).Get(tc.testCtx.ctx, kueueDeploymentName, metav1.GetOptions{})
 	if err != nil {
+		if k8serr.IsNotFound(err) {
+			return nil // correct result: should not find deployment after we disable it already
+		}
 		return fmt.Errorf("error getting component resource after reconcile: %w", err)
 	}
-	if len(appDeployments.Items) != 0 {
-		return fmt.Errorf("component %v is disabled, should not have deployments in namespace %v any more",
-			componentApi.KueueKind,
-			tc.testCtx.applicationsNamespace)
-	}
-
-	return nil
+	return fmt.Errorf("component %v is disabled, should not get its deployment %v from NS %v any more",
+		componentApi.KueueKind,
+		kueueDeploymentName,
+		tc.testCtx.applicationsNamespace)
 }

--- a/tests/e2e/kueue_test.go
+++ b/tests/e2e/kueue_test.go
@@ -22,6 +22,7 @@ import (
 
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/apis/components/v1alpha1"
 	dscv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/datasciencecluster/v1"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/metadata/labels"
 )
 
@@ -148,7 +149,7 @@ func (tc *KueueTestCtx) testOwnerReferences() error {
 
 	// Test Kueue resources
 	appDeployments, err := tc.testCtx.kubeClient.AppsV1().Deployments(tc.testCtx.applicationsNamespace).List(tc.testCtx.ctx, metav1.ListOptions{
-		LabelSelector: labels.ODH.Component(componentApi.KueueComponentName),
+		LabelSelector: labels.PlatformPartOf + "=" + strings.ToLower(gvk.Kueue.Kind),
 	})
 	if err != nil {
 		return fmt.Errorf("error listing component deployments %w", err)
@@ -262,7 +263,7 @@ func (tc *KueueTestCtx) testUpdateKueueComponentDisabled() error {
 
 	if tc.testCtx.testDsc.Spec.Components.Kueue.ManagementState == operatorv1.Managed {
 		appDeployments, err := tc.testCtx.kubeClient.AppsV1().Deployments(tc.testCtx.applicationsNamespace).List(tc.testCtx.ctx, metav1.ListOptions{
-			LabelSelector: labels.ODH.Component(componentApi.KueueComponentName),
+			LabelSelector: labels.PlatformPartOf + "=" + strings.ToLower(gvk.Kueue.Kind),
 		})
 		if err != nil {
 			return fmt.Errorf("error getting enabled component %v", componentApi.KueueComponentName)
@@ -310,17 +311,18 @@ func (tc *KueueTestCtx) testUpdateKueueComponentDisabled() error {
 		return fmt.Errorf("component kueue is disabled, should not get the Kueue CR %v", tc.testKueueInstance.Name)
 	}
 
-	// Sleep for 20 seconds to allow the operator to reconcile
-	time.Sleep(2 * generalRetryInterval)
-	_, err = tc.testCtx.kubeClient.AppsV1().Deployments(tc.testCtx.applicationsNamespace).Get(tc.testCtx.ctx, kueueDeploymentName, metav1.GetOptions{})
+	appDeployments, err := tc.testCtx.kubeClient.AppsV1().Deployments(tc.testCtx.applicationsNamespace).List(tc.testCtx.ctx, metav1.ListOptions{
+		LabelSelector: labels.PlatformPartOf + "=" + strings.ToLower(gvk.Kueue.Kind),
+	})
+
 	if err != nil {
-		if k8serr.IsNotFound(err) {
-			return nil // correct result: should not find deployment after we disable it already
-		}
 		return fmt.Errorf("error getting component resource after reconcile: %w", err)
 	}
-	return fmt.Errorf("component %v is disabled, should not get its deployment %v from NS %v any more",
-		componentApi.KueueKind,
-		kueueDeploymentName,
-		tc.testCtx.applicationsNamespace)
+	if len(appDeployments.Items) != 0 {
+		return fmt.Errorf("component %v is disabled, should not have deployments in namespace %v any more",
+			componentApi.KueueKind,
+			tc.testCtx.applicationsNamespace)
+	}
+
+	return nil
 }

--- a/tests/e2e/modelregistry_test.go
+++ b/tests/e2e/modelregistry_test.go
@@ -225,9 +225,11 @@ func (mr *ModelRegistryTestCtx) validateModelRegistryInstance(t *testing.T) {
 		mr.List(gvk.DataScienceCluster),
 	).Should(And(
 		HaveLen(1),
-		HaveEach(
+		HaveEach(And(
 			jq.Match(`.status.conditions[] | select(.type == "%sReady") | .status == "%s"`, componentApi.ModelRegistryComponentName, metav1.ConditionTrue),
-		),
+			jq.Match(`.status.installedComponents."%s" == true`, modelregistry.LegacyComponentName),
+			jq.Match(`.status.components.%s.managementState == "%s"`, componentApi.ModelRegistryComponentName, operatorv1.Managed),
+		)),
 	))
 }
 

--- a/tests/e2e/ray_test.go
+++ b/tests/e2e/ray_test.go
@@ -22,6 +22,7 @@ import (
 
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/apis/components/v1alpha1"
 	dscv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/datasciencecluster/v1"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/metadata/labels"
 )
 
@@ -148,7 +149,7 @@ func (tc *RayTestCtx) testOwnerReferences() error {
 
 	// Test Ray resources
 	appDeployments, err := tc.testCtx.kubeClient.AppsV1().Deployments(tc.testCtx.applicationsNamespace).List(tc.testCtx.ctx, metav1.ListOptions{
-		LabelSelector: labels.ODH.Component(componentApi.RayComponentName),
+		LabelSelector: labels.PlatformPartOf + "=" + strings.ToLower(gvk.Ray.Kind),
 	})
 	if err != nil {
 		return fmt.Errorf("error listing component deployments %w", err)
@@ -262,7 +263,7 @@ func (tc *RayTestCtx) testUpdateRayComponentDisabled() error {
 
 	if tc.testCtx.testDsc.Spec.Components.Ray.ManagementState == operatorv1.Managed {
 		appDeployments, err := tc.testCtx.kubeClient.AppsV1().Deployments(tc.testCtx.applicationsNamespace).List(tc.testCtx.ctx, metav1.ListOptions{
-			LabelSelector: labels.ODH.Component(componentApi.RayComponentName),
+			LabelSelector: labels.PlatformPartOf + "=" + strings.ToLower(gvk.Ray.Kind),
 		})
 		if err != nil {
 			return fmt.Errorf("error getting enabled component %v", componentApi.RayComponentName)
@@ -310,17 +311,18 @@ func (tc *RayTestCtx) testUpdateRayComponentDisabled() error {
 		return fmt.Errorf("component ray is disabled, should not get the Ray CR %v", tc.testRayInstance.Name)
 	}
 
-	// Sleep for 20 seconds to allow the operator to reconcile
-	time.Sleep(2 * generalRetryInterval)
-	_, err = tc.testCtx.kubeClient.AppsV1().Deployments(tc.testCtx.applicationsNamespace).Get(tc.testCtx.ctx, rayDeploymentName, metav1.GetOptions{})
+	appDeployments, err := tc.testCtx.kubeClient.AppsV1().Deployments(tc.testCtx.applicationsNamespace).List(tc.testCtx.ctx, metav1.ListOptions{
+		LabelSelector: labels.PlatformPartOf + "=" + strings.ToLower(gvk.Ray.Kind),
+	})
+
 	if err != nil {
-		if k8serr.IsNotFound(err) {
-			return nil // correct result: should not find deployment after we disable it already
-		}
 		return fmt.Errorf("error getting component resource after reconcile: %w", err)
 	}
-	return fmt.Errorf("component %v is disabled, should not get its deployment %v from NS %v any more",
-		componentApi.RayKind,
-		rayDeploymentName,
-		tc.testCtx.applicationsNamespace)
+	if len(appDeployments.Items) != 0 {
+		return fmt.Errorf("component %v is disabled, should not have deployments in namespace %v any more",
+			componentApi.RayKind,
+			tc.testCtx.applicationsNamespace)
+	}
+
+	return nil
 }

--- a/tests/e2e/trustyai_test.go
+++ b/tests/e2e/trustyai_test.go
@@ -22,6 +22,7 @@ import (
 
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/apis/components/v1alpha1"
 	dscv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/datasciencecluster/v1"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/metadata/labels"
 )
 
@@ -148,7 +149,7 @@ func (tc *TrustyaiTestCtx) testOwnerReferences() error {
 
 	// Test Trustyai resources
 	appDeployments, err := tc.testCtx.kubeClient.AppsV1().Deployments(tc.testCtx.applicationsNamespace).List(tc.testCtx.ctx, metav1.ListOptions{
-		LabelSelector: labels.ODH.Component(componentApi.TrustyAIComponentName),
+		LabelSelector: labels.PlatformPartOf + "=" + strings.ToLower(gvk.TrustyAI.Kind),
 	})
 	if err != nil {
 		return fmt.Errorf("error listing component deployments %w", err)
@@ -262,7 +263,7 @@ func (tc *TrustyaiTestCtx) testUpdateTrustyaiComponentDisabled() error {
 
 	if tc.testCtx.testDsc.Spec.Components.TrustyAI.ManagementState == operatorv1.Managed {
 		appDeployments, err := tc.testCtx.kubeClient.AppsV1().Deployments(tc.testCtx.applicationsNamespace).List(tc.testCtx.ctx, metav1.ListOptions{
-			LabelSelector: labels.ODH.Component(componentApi.TrustyAIComponentName),
+			LabelSelector: labels.PlatformPartOf + "=" + strings.ToLower(gvk.TrustyAI.Kind),
 		})
 		if err != nil {
 			return fmt.Errorf("error getting enabled component %v", componentApi.TrustyAIComponentName)
@@ -310,17 +311,18 @@ func (tc *TrustyaiTestCtx) testUpdateTrustyaiComponentDisabled() error {
 		return fmt.Errorf("component trustyai is disabled, should not get the Trustyai CR %v", tc.testTrustyaiInstance.Name)
 	}
 
-	// Sleep for 20 seconds to allow the operator to reconcile
-	time.Sleep(2 * generalRetryInterval)
-	_, err = tc.testCtx.kubeClient.AppsV1().Deployments(tc.testCtx.applicationsNamespace).Get(tc.testCtx.ctx, trustyaiDeploymentName, metav1.GetOptions{})
+	appDeployments, err := tc.testCtx.kubeClient.AppsV1().Deployments(tc.testCtx.applicationsNamespace).List(tc.testCtx.ctx, metav1.ListOptions{
+		LabelSelector: labels.PlatformPartOf + "=" + strings.ToLower(gvk.TrustyAI.Kind),
+	})
+
 	if err != nil {
-		if k8serr.IsNotFound(err) {
-			return nil // correct result: should not find deployment after we disable it already
-		}
 		return fmt.Errorf("error getting component resource after reconcile: %w", err)
 	}
-	return fmt.Errorf("component %v is disabled, should not get its deployment %v from NS %v any more",
-		componentApi.TrustyAIKind,
-		trustyaiDeploymentName,
-		tc.testCtx.applicationsNamespace)
+	if len(appDeployments.Items) != 0 {
+		return fmt.Errorf("component %v is disabled, should not have deployments in namespace %v any more",
+			componentApi.TrustyAIKind,
+			tc.testCtx.applicationsNamespace)
+	}
+
+	return nil
 }

--- a/tests/e2e/workbenches_test.go
+++ b/tests/e2e/workbenches_test.go
@@ -314,18 +314,17 @@ func (tc *WorkbenchesTestCtx) testUpdateWorkbenchesComponentDisabled() error {
 		return fmt.Errorf("component %v is disabled, should not get the Workbenches CR %v", tc.testWorkbenchesInstance.Name, tc.testWorkbenchesInstance.Name)
 	}
 
-	appDeployments, err := tc.testCtx.kubeClient.AppsV1().Deployments(tc.testCtx.applicationsNamespace).List(tc.testCtx.ctx, metav1.ListOptions{
-		LabelSelector: labels.PlatformPartOf + "=" + strings.ToLower(gvk.Workbenches.Kind),
-	})
-
+	// Sleep for 20 seconds to allow the operator to reconcile
+	time.Sleep(2 * generalRetryInterval)
+	_, err = tc.testCtx.kubeClient.AppsV1().Deployments(tc.testCtx.applicationsNamespace).Get(tc.testCtx.ctx, workbenchesDeploymentName, metav1.GetOptions{})
 	if err != nil {
+		if k8serr.IsNotFound(err) {
+			return nil // correct result: should not find deployment after we disable it already
+		}
 		return fmt.Errorf("error getting component resource after reconcile: %w", err)
 	}
-	if len(appDeployments.Items) != 0 {
-		return fmt.Errorf("component %v is disabled, should not have deployments in namespace %v any more",
-			componentApi.WorkbenchesKind,
-			tc.testCtx.applicationsNamespace)
-	}
-
-	return nil
+	return fmt.Errorf("component %v is disabled, should not get its deployment %v from NS %v any more",
+		componentApi.WorkbenchesKind,
+		workbenchesDeploymentName,
+		tc.testCtx.applicationsNamespace)
 }

--- a/tests/e2e/workbenches_test.go
+++ b/tests/e2e/workbenches_test.go
@@ -22,6 +22,7 @@ import (
 
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/apis/components/v1alpha1"
 	dscv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/datasciencecluster/v1"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/metadata/labels"
 )
 
@@ -150,7 +151,7 @@ func (tc *WorkbenchesTestCtx) testOwnerReferences() error {
 	// Test Workbenches resources
 
 	appDeployments, err := tc.testCtx.kubeClient.AppsV1().Deployments(tc.testCtx.applicationsNamespace).List(tc.testCtx.ctx, metav1.ListOptions{
-		LabelSelector: labels.ODH.Component(componentApi.WorkbenchesComponentName),
+		LabelSelector: labels.PlatformPartOf + "=" + strings.ToLower(gvk.Workbenches.Kind),
 	})
 	if err != nil {
 		return fmt.Errorf("error listing component deployments %w", err)
@@ -263,7 +264,7 @@ func (tc *WorkbenchesTestCtx) testUpdateWorkbenchesComponentDisabled() error {
 
 	if tc.testCtx.testDsc.Spec.Components.Workbenches.ManagementState == operatorv1.Managed {
 		appDeployments, err := tc.testCtx.kubeClient.AppsV1().Deployments(tc.testCtx.applicationsNamespace).List(tc.testCtx.ctx, metav1.ListOptions{
-			LabelSelector: labels.ODH.Component(componentApi.WorkbenchesComponentName),
+			LabelSelector: labels.PlatformPartOf + "=" + strings.ToLower(gvk.Workbenches.Kind),
 		})
 		if err != nil {
 			return fmt.Errorf("error getting enabled component %v", componentApi.WorkbenchesComponentName)
@@ -313,17 +314,18 @@ func (tc *WorkbenchesTestCtx) testUpdateWorkbenchesComponentDisabled() error {
 		return fmt.Errorf("component %v is disabled, should not get the Workbenches CR %v", tc.testWorkbenchesInstance.Name, tc.testWorkbenchesInstance.Name)
 	}
 
-	// Sleep for 20 seconds to allow the operator to reconcile
-	time.Sleep(2 * generalRetryInterval)
-	_, err = tc.testCtx.kubeClient.AppsV1().Deployments(tc.testCtx.applicationsNamespace).Get(tc.testCtx.ctx, workbenchesDeploymentName, metav1.GetOptions{})
+	appDeployments, err := tc.testCtx.kubeClient.AppsV1().Deployments(tc.testCtx.applicationsNamespace).List(tc.testCtx.ctx, metav1.ListOptions{
+		LabelSelector: labels.PlatformPartOf + "=" + strings.ToLower(gvk.Workbenches.Kind),
+	})
+
 	if err != nil {
-		if k8serr.IsNotFound(err) {
-			return nil // correct result: should not find deployment after we disable it already
-		}
 		return fmt.Errorf("error getting component resource after reconcile: %w", err)
 	}
-	return fmt.Errorf("component %v is disabled, should not get its deployment %v from NS %v any more",
-		componentApi.WorkbenchesKind,
-		workbenchesDeploymentName,
-		tc.testCtx.applicationsNamespace)
+	if len(appDeployments.Items) != 0 {
+		return fmt.Errorf("component %v is disabled, should not have deployments in namespace %v any more",
+			componentApi.WorkbenchesKind,
+			tc.testCtx.applicationsNamespace)
+	}
+
+	return nil
 }


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

1. reorganize the manifests folder and the manifest fetcher script to
   use the compoennt name as a folder for manifests
2. introduce a LegacyComponentName variable to hold the legacy name of a
   component; this is required because existing deployment's selectors
   are immutable once created, hence to avoid disruption we can't change
   the selectgor to use the new name
3. add missing CRD watcher where missing
4. add additional tests
5. fix status handling to use legacy component names for legacy status
   fields


<!--- Link your JIRA and related links here for reference. -->

Requires:
- https://github.com/opendatahub-io/opendatahub-operator/pull/1449

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

This does not change the behavior, should be covered by existing tests

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [X] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [X] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] ~~Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).~~
- [ ] ~~The developer has manually tested the changes and verified that the changes work~~
