### PR TITLE
Make DSC's component conditions user friendly

### DIFF
--- a/controllers/components/codeflare/codeflare.go
+++ b/controllers/components/codeflare/codeflare.go
@@ -75,7 +75,7 @@ func (s *componentHandler) UpdateDSCStatus(dsc *dscv1.DataScienceCluster, obj cl
 	dsc.Status.Components.CodeFlare.CodeFlareCommonStatus = nil
 
 	nc := conditionsv1.Condition{
-		Type:    conditionsv1.ConditionType(s.GetName() + status.ReadySuffix),
+		Type:    ReadyConditionType,
 		Status:  corev1.ConditionFalse,
 		Reason:  "Unknown",
 		Message: "Not Available",

--- a/controllers/components/codeflare/codeflare_support.go
+++ b/controllers/components/codeflare/codeflare_support.go
@@ -3,13 +3,18 @@ package codeflare
 import (
 	"path"
 
+	conditionsv1 "github.com/openshift/custom-resource-status/conditions/v1"
+
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/apis/components/v1alpha1"
+	"github.com/opendatahub-io/opendatahub-operator/v2/controllers/status"
 	odhtypes "github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
 	odhdeploy "github.com/opendatahub-io/opendatahub-operator/v2/pkg/deploy"
 )
 
 const (
 	ComponentName = componentApi.CodeFlareComponentName
+
+	ReadyConditionType = conditionsv1.ConditionType(componentApi.CodeFlareKind + status.ReadySuffix)
 
 	// LegacyComponentName is the name of the component that is assigned to deployments
 	// via Kustomize. Since a deployment selector is immutable, we can't upgrade existing

--- a/controllers/components/dashboard/dashboard.go
+++ b/controllers/components/dashboard/dashboard.go
@@ -77,7 +77,7 @@ func (s *componentHandler) UpdateDSCStatus(dsc *dscv1.DataScienceCluster, obj cl
 	dsc.Status.Components.Dashboard.DashboardCommonStatus = nil
 
 	nc := conditionsv1.Condition{
-		Type:    conditionsv1.ConditionType(s.GetName() + status.ReadySuffix),
+		Type:    ReadyConditionType,
 		Status:  corev1.ConditionFalse,
 		Reason:  "Unknown",
 		Message: "Not Available",

--- a/controllers/components/dashboard/dashboard_support.go
+++ b/controllers/components/dashboard/dashboard_support.go
@@ -4,17 +4,21 @@ import (
 	"context"
 	"fmt"
 
+	conditionsv1 "github.com/openshift/custom-resource-status/conditions/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	componentsApi "github.com/opendatahub-io/opendatahub-operator/v2/apis/components/v1alpha1"
+	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/apis/components/v1alpha1"
 	dsciv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/dscinitialization/v1"
+	"github.com/opendatahub-io/opendatahub-operator/v2/controllers/status"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
 	odhtypes "github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
 	odhdeploy "github.com/opendatahub-io/opendatahub-operator/v2/pkg/deploy"
 )
 
 const (
-	ComponentName = componentsApi.DashboardComponentName
+	ComponentName = componentApi.DashboardComponentName
+
+	ReadyConditionType = conditionsv1.ConditionType(componentApi.DashboardKind + status.ReadySuffix)
 
 	// Legacy component names are the name of the component that is assigned to deployments
 	// via Kustomize. Since a deployment selector is immutable, we can't upgrade existing

--- a/controllers/components/datasciencepipelines/datasciencepipelines.go
+++ b/controllers/components/datasciencepipelines/datasciencepipelines.go
@@ -75,7 +75,7 @@ func (s *componentHandler) UpdateDSCStatus(dsc *dscv1.DataScienceCluster, obj cl
 	dsc.Status.Components.DataSciencePipelines.DataSciencePipelinesCommonStatus = nil
 
 	nc := conditionsv1.Condition{
-		Type:    conditionsv1.ConditionType(s.GetName() + status.ReadySuffix),
+		Type:    ReadyConditionType,
 		Status:  corev1.ConditionFalse,
 		Reason:  "Unknown",
 		Message: "Not Available",

--- a/controllers/components/datasciencepipelines/datasciencepipelines_support.go
+++ b/controllers/components/datasciencepipelines/datasciencepipelines_support.go
@@ -1,7 +1,10 @@
 package datasciencepipelines
 
 import (
+	conditionsv1 "github.com/openshift/custom-resource-status/conditions/v1"
+
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/apis/components/v1alpha1"
+	"github.com/opendatahub-io/opendatahub-operator/v2/controllers/status"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
 	odhdeploy "github.com/opendatahub-io/opendatahub-operator/v2/pkg/deploy"
@@ -10,6 +13,8 @@ import (
 const (
 	ArgoWorkflowCRD = "workflows.argoproj.io"
 	ComponentName   = componentApi.DataSciencePipelinesComponentName
+
+	ReadyConditionType = conditionsv1.ConditionType(componentApi.DataSciencePipelinesKind + status.ReadySuffix)
 
 	// LegacyComponentName is the name of the component that is assigned to deployments
 	// via Kustomize. Since a deployment selector is immutable, we can't upgrade existing

--- a/controllers/components/kserve/kserve.go
+++ b/controllers/components/kserve/kserve.go
@@ -31,6 +31,8 @@ const (
 	// via Kustomize. Since a deployment selector is immutable, we can't upgrade existing
 	// deployment to the new component name, so keep it around till we figure out a solution.
 	LegacyComponentName = "kserve"
+
+	ReadyConditionType = conditionsv1.ConditionType(componentApi.KserveKind + status.ReadySuffix)
 )
 
 type componentHandler struct{}
@@ -85,7 +87,7 @@ func (s *componentHandler) UpdateDSCStatus(dsc *dscv1.DataScienceCluster, obj cl
 	dsc.Status.Components.Kserve.KserveCommonStatus = nil
 
 	nc := conditionsv1.Condition{
-		Type:    conditionsv1.ConditionType(s.GetName() + status.ReadySuffix),
+		Type:    ReadyConditionType,
 		Status:  corev1.ConditionFalse,
 		Reason:  "Unknown",
 		Message: "Not Available",

--- a/controllers/components/kueue/kueue.go
+++ b/controllers/components/kueue/kueue.go
@@ -75,7 +75,7 @@ func (s *componentHandler) UpdateDSCStatus(dsc *dscv1.DataScienceCluster, obj cl
 	dsc.Status.Components.Kueue.KueueCommonStatus = nil
 
 	nc := conditionsv1.Condition{
-		Type:    conditionsv1.ConditionType(s.GetName() + status.ReadySuffix),
+		Type:    ReadyConditionType,
 		Status:  corev1.ConditionFalse,
 		Reason:  "Unknown",
 		Message: "Not Available",

--- a/controllers/components/kueue/kueue_support.go
+++ b/controllers/components/kueue/kueue_support.go
@@ -1,13 +1,18 @@
 package kueue
 
 import (
+	conditionsv1 "github.com/openshift/custom-resource-status/conditions/v1"
+
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/apis/components/v1alpha1"
+	"github.com/opendatahub-io/opendatahub-operator/v2/controllers/status"
 	odhtypes "github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
 	odhdeploy "github.com/opendatahub-io/opendatahub-operator/v2/pkg/deploy"
 )
 
 const (
 	ComponentName = componentApi.KueueComponentName
+
+	ReadyConditionType = conditionsv1.ConditionType(componentApi.KueueKind + status.ReadySuffix)
 
 	// LegacyComponentName is the name of the component that is assigned to deployments
 	// via Kustomize. Since a deployment selector is immutable, we can't upgrade existing

--- a/controllers/components/modelcontroller/modelcontroller.go
+++ b/controllers/components/modelcontroller/modelcontroller.go
@@ -92,7 +92,7 @@ func (s *componentHandler) UpdateDSCStatus(dsc *dscv1.DataScienceCluster, obj cl
 	}
 
 	nc := conditionsv1.Condition{
-		Type:    conditionsv1.ConditionType(s.GetName() + status.ReadySuffix),
+		Type:    ReadyConditionType,
 		Status:  corev1.ConditionFalse,
 		Reason:  "Unknown",
 		Message: "Not Available",

--- a/controllers/components/modelcontroller/modelcontroller_support.go
+++ b/controllers/components/modelcontroller/modelcontroller_support.go
@@ -1,7 +1,10 @@
 package modelcontroller
 
 import (
+	conditionsv1 "github.com/openshift/custom-resource-status/conditions/v1"
+
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/apis/components/v1alpha1"
+	"github.com/opendatahub-io/opendatahub-operator/v2/controllers/status"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
 	odhdeploy "github.com/opendatahub-io/opendatahub-operator/v2/pkg/deploy"
@@ -9,6 +12,8 @@ import (
 
 const (
 	ComponentName = componentApi.ModelControllerComponentName
+
+	ReadyConditionType = conditionsv1.ConditionType(componentApi.ModelControllerKind + status.ReadySuffix)
 
 	// LegacyComponentName is the name of the component that is assigned to deployments
 	// via Kustomize. Since a deployment selector is immutable, we can't upgrade existing

--- a/controllers/components/modelmeshserving/modelmeshserving.go
+++ b/controllers/components/modelmeshserving/modelmeshserving.go
@@ -77,7 +77,7 @@ func (s *componentHandler) UpdateDSCStatus(dsc *dscv1.DataScienceCluster, obj cl
 	dsc.Status.Components.ModelMeshServing.ModelMeshServingCommonStatus = nil
 
 	nc := conditionsv1.Condition{
-		Type:    conditionsv1.ConditionType(s.GetName() + status.ReadySuffix),
+		Type:    ReadyConditionType,
 		Status:  corev1.ConditionFalse,
 		Reason:  "Unknown",
 		Message: "Not Available",

--- a/controllers/components/modelmeshserving/modelmeshserving_support.go
+++ b/controllers/components/modelmeshserving/modelmeshserving_support.go
@@ -1,7 +1,10 @@
 package modelmeshserving
 
 import (
+	conditionsv1 "github.com/openshift/custom-resource-status/conditions/v1"
+
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/apis/components/v1alpha1"
+	"github.com/opendatahub-io/opendatahub-operator/v2/controllers/status"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
 	odhtypes "github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
 	odhdeploy "github.com/opendatahub-io/opendatahub-operator/v2/pkg/deploy"
@@ -9,6 +12,8 @@ import (
 
 const (
 	ComponentName = componentApi.ModelMeshServingComponentName
+
+	ReadyConditionType = conditionsv1.ConditionType(componentApi.ModelMeshServingKind + status.ReadySuffix)
 
 	// LegacyComponentName is the name of the component that is assigned to deployments
 	// via Kustomize. Since a deployment selector is immutable, we can't upgrade existing

--- a/controllers/components/modelregistry/modelregistry.go
+++ b/controllers/components/modelregistry/modelregistry.go
@@ -85,7 +85,7 @@ func (s *componentHandler) UpdateDSCStatus(dsc *dscv1.DataScienceCluster, obj cl
 	dsc.Status.Components.ModelRegistry.ModelRegistryCommonStatus = nil
 
 	nc := conditionsv1.Condition{
-		Type:    conditionsv1.ConditionType(s.GetName() + status.ReadySuffix),
+		Type:    ReadyConditionType,
 		Status:  corev1.ConditionFalse,
 		Reason:  "Unknown",
 		Message: "Not Available",

--- a/controllers/components/modelregistry/modelregistry_support.go
+++ b/controllers/components/modelregistry/modelregistry_support.go
@@ -4,13 +4,19 @@ import (
 	"embed"
 	"path"
 
+	conditionsv1 "github.com/openshift/custom-resource-status/conditions/v1"
+
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/apis/components/v1alpha1"
+	"github.com/opendatahub-io/opendatahub-operator/v2/controllers/status"
 	odhtypes "github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/deploy"
 )
 
 const (
-	ComponentName                   = componentApi.ModelRegistryComponentName
+	ComponentName = componentApi.ModelRegistryComponentName
+
+	ReadyConditionType = conditionsv1.ConditionType(componentApi.ModelRegistryKind + status.ReadySuffix)
+
 	DefaultModelRegistriesNamespace = "odh-model-registries"
 	DefaultModelRegistryCert        = "default-modelregistry-cert"
 	BaseManifestsSourcePath         = "overlays/odh"

--- a/controllers/components/ray/ray.go
+++ b/controllers/components/ray/ray.go
@@ -75,7 +75,7 @@ func (s *componentHandler) UpdateDSCStatus(dsc *dscv1.DataScienceCluster, obj cl
 	dsc.Status.Components.Ray.RayCommonStatus = nil
 
 	nc := conditionsv1.Condition{
-		Type:    conditionsv1.ConditionType(s.GetName() + status.ReadySuffix),
+		Type:    ReadyConditionType,
 		Status:  corev1.ConditionFalse,
 		Reason:  "Unknown",
 		Message: "Not Available",

--- a/controllers/components/ray/ray_support.go
+++ b/controllers/components/ray/ray_support.go
@@ -1,13 +1,18 @@
 package ray
 
 import (
+	conditionsv1 "github.com/openshift/custom-resource-status/conditions/v1"
+
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/apis/components/v1alpha1"
+	"github.com/opendatahub-io/opendatahub-operator/v2/controllers/status"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
 	odhdeploy "github.com/opendatahub-io/opendatahub-operator/v2/pkg/deploy"
 )
 
 const (
 	ComponentName = componentApi.RayComponentName
+
+	ReadyConditionType = conditionsv1.ConditionType(componentApi.RayKind + status.ReadySuffix)
 
 	// LegacyComponentName is the name of the component that is assigned to deployments
 	// via Kustomize. Since a deployment selector is immutable, we can't upgrade existing

--- a/controllers/components/trainingoperator/trainingoperator.go
+++ b/controllers/components/trainingoperator/trainingoperator.go
@@ -74,7 +74,7 @@ func (s *componentHandler) UpdateDSCStatus(dsc *dscv1.DataScienceCluster, obj cl
 	dsc.Status.Components.TrainingOperator.TrainingOperatorCommonStatus = nil
 
 	nc := conditionsv1.Condition{
-		Type:    conditionsv1.ConditionType(s.GetName() + status.ReadySuffix),
+		Type:    ReadyConditionType,
 		Status:  corev1.ConditionFalse,
 		Reason:  "Unknown",
 		Message: "Not Available",

--- a/controllers/components/trainingoperator/trainingoperator_support.go
+++ b/controllers/components/trainingoperator/trainingoperator_support.go
@@ -1,13 +1,18 @@
 package trainingoperator
 
 import (
+	conditionsv1 "github.com/openshift/custom-resource-status/conditions/v1"
+
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/apis/components/v1alpha1"
+	"github.com/opendatahub-io/opendatahub-operator/v2/controllers/status"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
 	odhdeploy "github.com/opendatahub-io/opendatahub-operator/v2/pkg/deploy"
 )
 
 const (
 	ComponentName = componentApi.TrainingOperatorComponentName
+
+	ReadyConditionType = conditionsv1.ConditionType(componentApi.TrainingOperatorKind + status.ReadySuffix)
 
 	// LegacyComponentName is the name of the component that is assigned to deployments
 	// via Kustomize. Since a deployment selector is immutable, we can't upgrade existing

--- a/controllers/components/trustyai/trustyai.go
+++ b/controllers/components/trustyai/trustyai.go
@@ -77,7 +77,7 @@ func (s *componentHandler) UpdateDSCStatus(dsc *dscv1.DataScienceCluster, obj cl
 	dsc.Status.Components.TrustyAI.TrustyAICommonStatus = nil
 
 	nc := conditionsv1.Condition{
-		Type:    conditionsv1.ConditionType(s.GetName() + status.ReadySuffix),
+		Type:    ReadyConditionType,
 		Status:  corev1.ConditionFalse,
 		Reason:  "Unknown",
 		Message: "Not Available",

--- a/controllers/components/trustyai/trustyai_support.go
+++ b/controllers/components/trustyai/trustyai_support.go
@@ -1,7 +1,10 @@
 package trustyai
 
 import (
+	conditionsv1 "github.com/openshift/custom-resource-status/conditions/v1"
+
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/apis/components/v1alpha1"
+	"github.com/opendatahub-io/opendatahub-operator/v2/controllers/status"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
 	odhdeploy "github.com/opendatahub-io/opendatahub-operator/v2/pkg/deploy"
@@ -9,6 +12,8 @@ import (
 
 const (
 	ComponentName = componentApi.TrustyAIComponentName
+
+	ReadyConditionType = conditionsv1.ConditionType(componentApi.TrustyAIKind + status.ReadySuffix)
 
 	// LegacyComponentName is the name of the component that is assigned to deployments
 	// via Kustomize. Since a deployment selector is immutable, we can't upgrade existing

--- a/controllers/components/workbenches/workbenches.go
+++ b/controllers/components/workbenches/workbenches.go
@@ -85,7 +85,7 @@ func (s *componentHandler) UpdateDSCStatus(dsc *dscv1.DataScienceCluster, obj cl
 	dsc.Status.Components.Workbenches.WorkbenchesCommonStatus = nil
 
 	nc := conditionsv1.Condition{
-		Type:    conditionsv1.ConditionType(s.GetName() + status.ReadySuffix),
+		Type:    ReadyConditionType,
 		Status:  corev1.ConditionFalse,
 		Reason:  "Unknown",
 		Message: "Not Available",

--- a/controllers/components/workbenches/workbenches_support.go
+++ b/controllers/components/workbenches/workbenches_support.go
@@ -3,7 +3,10 @@ package workbenches
 import (
 	"path"
 
+	conditionsv1 "github.com/openshift/custom-resource-status/conditions/v1"
+
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/apis/components/v1alpha1"
+	"github.com/opendatahub-io/opendatahub-operator/v2/controllers/status"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
 	odhtypes "github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
 	odhdeploy "github.com/opendatahub-io/opendatahub-operator/v2/pkg/deploy"
@@ -11,6 +14,8 @@ import (
 
 const (
 	ComponentName = componentApi.WorkbenchesComponentName
+
+	ReadyConditionType = conditionsv1.ConditionType(componentApi.WorkbenchesKind + status.ReadySuffix)
 
 	notebooksPath                    = "notebooks"
 	notebookImagesManifestSourcePath = "overlays/additional"

--- a/pkg/cluster/gvk/gvk.go
+++ b/pkg/cluster/gvk/gvk.go
@@ -6,6 +6,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/apis/components/v1alpha1"
 )
 
 var (
@@ -105,39 +107,39 @@ var (
 	}
 
 	Dashboard = schema.GroupVersionKind{
-		Group:   "components.platform.opendatahub.io",
-		Version: "v1alpha1",
-		Kind:    "Dashboard",
+		Group:   componentApi.GroupVersion.Group,
+		Version: componentApi.GroupVersion.Version,
+		Kind:    componentApi.DashboardKind,
 	}
 
 	Workbenches = schema.GroupVersionKind{
-		Group:   "components.platform.opendatahub.io",
-		Version: "v1alpha1",
-		Kind:    "Workbenches",
+		Group:   componentApi.GroupVersion.Group,
+		Version: componentApi.GroupVersion.Version,
+		Kind:    componentApi.WorkbenchesKind,
 	}
 
 	ModelController = schema.GroupVersionKind{
-		Group:   "components.platform.opendatahub.io",
-		Version: "v1alpha1",
-		Kind:    "ModelController",
+		Group:   componentApi.GroupVersion.Group,
+		Version: componentApi.GroupVersion.Version,
+		Kind:    componentApi.ModelControllerKind,
 	}
 
 	ModelMeshServing = schema.GroupVersionKind{
-		Group:   "components.platform.opendatahub.io",
-		Version: "v1alpha1",
-		Kind:    "ModelMeshServing",
+		Group:   componentApi.GroupVersion.Group,
+		Version: componentApi.GroupVersion.Version,
+		Kind:    componentApi.ModelMeshServingKind,
 	}
 
 	DataSciencePipelines = schema.GroupVersionKind{
-		Group:   "components.platform.opendatahub.io",
-		Version: "v1alpha1",
-		Kind:    "DataSciencePipelines",
+		Group:   componentApi.GroupVersion.Group,
+		Version: componentApi.GroupVersion.Version,
+		Kind:    componentApi.DataSciencePipelinesKind,
 	}
 
 	Kserve = schema.GroupVersionKind{
-		Group:   "components.platform.opendatahub.io",
-		Version: "v1alpha1",
-		Kind:    "Kserve",
+		Group:   componentApi.GroupVersion.Group,
+		Version: componentApi.GroupVersion.Version,
+		Kind:    componentApi.KserveKind,
 	}
 
 	Kueue = schema.GroupVersionKind{
@@ -147,33 +149,33 @@ var (
 	}
 
 	CodeFlare = schema.GroupVersionKind{
-		Group:   "components.platform.opendatahub.io",
-		Version: "v1alpha1",
-		Kind:    "CodeFlare",
+		Group:   componentApi.GroupVersion.Group,
+		Version: componentApi.GroupVersion.Version,
+		Kind:    componentApi.CodeFlareKind,
 	}
 
 	Ray = schema.GroupVersionKind{
-		Group:   "components.platform.opendatahub.io",
-		Version: "v1alpha1",
-		Kind:    "Ray",
+		Group:   componentApi.GroupVersion.Group,
+		Version: componentApi.GroupVersion.Version,
+		Kind:    componentApi.RayKind,
 	}
 
 	TrustyAI = schema.GroupVersionKind{
-		Group:   "components.platform.opendatahub.io",
-		Version: "v1alpha1",
-		Kind:    "TrustyAI",
+		Group:   componentApi.GroupVersion.Group,
+		Version: componentApi.GroupVersion.Version,
+		Kind:    componentApi.TrustyAIKind,
 	}
 
 	ModelRegistry = schema.GroupVersionKind{
-		Group:   "components.platform.opendatahub.io",
-		Version: "v1alpha1",
-		Kind:    "ModelRegistry",
+		Group:   componentApi.GroupVersion.Group,
+		Version: componentApi.GroupVersion.Version,
+		Kind:    componentApi.ModelRegistryKind,
 	}
 
 	TrainingOperator = schema.GroupVersionKind{
-		Group:   "components.platform.opendatahub.io",
-		Version: "v1alpha1",
-		Kind:    "TrainingOperator",
+		Group:   componentApi.GroupVersion.Group,
+		Version: componentApi.GroupVersion.Version,
+		Kind:    componentApi.TrainingOperatorKind,
 	}
 
 	CustomResourceDefinition = schema.GroupVersionKind{

--- a/pkg/cluster/gvk/gvk.go
+++ b/pkg/cluster/gvk/gvk.go
@@ -143,9 +143,9 @@ var (
 	}
 
 	Kueue = schema.GroupVersionKind{
-		Group:   "components.platform.opendatahub.io",
-		Version: "v1alpha1",
-		Kind:    "Kueue",
+		Group:   componentApi.GroupVersion.Group,
+		Version: componentApi.GroupVersion.Version,
+		Kind:    componentApi.KueueKind,
 	}
 
 	CodeFlare = schema.GroupVersionKind{

--- a/tests/e2e/codeflare_test.go
+++ b/tests/e2e/codeflare_test.go
@@ -22,6 +22,7 @@ import (
 
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/apis/components/v1alpha1"
 	dscv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/datasciencecluster/v1"
+	"github.com/opendatahub-io/opendatahub-operator/v2/controllers/components/codeflare"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/metadata/labels"
 )
@@ -192,7 +193,7 @@ func (tc *CodeFlareTestCtx) validateCodeFlareReady() error {
 		}
 
 		for _, c := range list.Items[0].Status.Conditions {
-			if c.Type == componentApi.CodeFlareComponentName+"Ready" {
+			if c.Type == codeflare.ReadyConditionType {
 				return c.Status == corev1.ConditionTrue, nil
 			}
 		}

--- a/tests/e2e/dashboard_test.go
+++ b/tests/e2e/dashboard_test.go
@@ -221,7 +221,7 @@ func (d *DashboardTestCtx) validateDashboardInstance(t *testing.T) {
 	).Should(And(
 		HaveLen(1),
 		HaveEach(And(
-			jq.Match(`.status.conditions[] | select(.type == "%sReady") | .status == "%s"`, componentApi.DashboardComponentName, metav1.ConditionTrue),
+			jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, dashboard.ReadyConditionType, metav1.ConditionTrue),
 			jq.Match(`.status.installedComponents."%s" == true`, dashboard.LegacyComponentNameUpstream),
 			jq.Match(`.status.components.%s.managementState == "%s"`, componentApi.DashboardComponentName, operatorv1.Managed),
 		)),

--- a/tests/e2e/datasciencepipelines_test.go
+++ b/tests/e2e/datasciencepipelines_test.go
@@ -22,6 +22,7 @@ import (
 
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/apis/components/v1alpha1"
 	dscv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/datasciencecluster/v1"
+	"github.com/opendatahub-io/opendatahub-operator/v2/controllers/components/datasciencepipelines"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/metadata/labels"
 )
@@ -230,7 +231,7 @@ func (tc *DataSciencePipelinesTestCtx) validateDataSciencePipelinesReady() error
 		}
 
 		for _, c := range list.Items[0].Status.Conditions {
-			if c.Type == componentApi.DataSciencePipelinesComponentName+"Ready" {
+			if c.Type == datasciencepipelines.ReadyConditionType {
 				return c.Status == corev1.ConditionTrue, nil
 			}
 		}

--- a/tests/e2e/kserve_test.go
+++ b/tests/e2e/kserve_test.go
@@ -18,6 +18,7 @@ import (
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/apis/components/v1alpha1"
 	dscv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/datasciencecluster/v1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/controllers/components/kserve"
+	"github.com/opendatahub-io/opendatahub-operator/v2/controllers/components/modelcontroller"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/metadata/labels"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/resources"
@@ -81,8 +82,8 @@ func (k *KserveTestCtx) validateKserveInstance(t *testing.T) {
 	).Should(And(
 		HaveLen(1),
 		HaveEach(And(
-			jq.Match(`.status.conditions[] | select(.type == "%sReady") | .status == "%s"`, componentApi.KserveComponentName, metav1.ConditionTrue),
-			jq.Match(`.status.conditions[] | select(.type == "%sReady") | .status == "%s"`, componentApi.ModelControllerComponentName, metav1.ConditionTrue),
+			jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, kserve.ReadyConditionType, metav1.ConditionTrue),
+			jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, modelcontroller.ReadyConditionType, metav1.ConditionTrue),
 			jq.Match(`.status.installedComponents."%s" == true`, kserve.LegacyComponentName),
 			jq.Match(`.status.components.%s.managementState == "%s"`, componentApi.KserveComponentName, operatorv1.Managed),
 		)),
@@ -133,7 +134,7 @@ func (k *KserveTestCtx) validateOperandsOwnerReferences(t *testing.T) {
 	).Should(And(
 		HaveLen(1),
 		HaveEach(
-			jq.Match(`.status.conditions[] | select(.type == "%sReady") | .status == "%s"`, componentApi.KserveComponentName, metav1.ConditionTrue),
+			jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, kserve.ReadyConditionType, metav1.ConditionTrue),
 		),
 	))
 }
@@ -252,7 +253,7 @@ func (k *KserveTestCtx) validateKserveDisabled(t *testing.T) {
 	).Should(And(
 		HaveLen(1),
 		HaveEach(
-			jq.Match(`.status.conditions[] | select(.type == "%sReady") | .status == "%s"`, componentApi.KserveComponentName, metav1.ConditionFalse),
+			jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, kserve.ReadyConditionType, metav1.ConditionFalse),
 		),
 	))
 }

--- a/tests/e2e/kueue_test.go
+++ b/tests/e2e/kueue_test.go
@@ -22,6 +22,7 @@ import (
 
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/apis/components/v1alpha1"
 	dscv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/datasciencecluster/v1"
+	"github.com/opendatahub-io/opendatahub-operator/v2/controllers/components/kueue"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/metadata/labels"
 )
@@ -192,7 +193,7 @@ func (tc *KueueTestCtx) validateKueueReady() error {
 		}
 
 		for _, c := range list.Items[0].Status.Conditions {
-			if c.Type == componentApi.KueueComponentName+"Ready" {
+			if c.Type == kueue.ReadyConditionType {
 				return c.Status == corev1.ConditionTrue, nil
 			}
 		}

--- a/tests/e2e/modelcontroller_test.go
+++ b/tests/e2e/modelcontroller_test.go
@@ -17,6 +17,7 @@ import (
 
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/apis/components/v1alpha1"
 	dscv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/datasciencecluster/v1"
+	"github.com/opendatahub-io/opendatahub-operator/v2/controllers/components/modelcontroller"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/metadata/labels"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/resources"
@@ -204,7 +205,7 @@ func (tc *ModelControllerTestCtx) validateModelControllerInstance(t *testing.T) 
 	).Should(And(
 		HaveLen(1),
 		HaveEach(And(
-			jq.Match(`.status.conditions[] | select(.type == "%sReady") | .status == "%s"`, componentApi.ModelControllerComponentName, metav1.ConditionTrue),
+			jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, modelcontroller.ReadyConditionType, metav1.ConditionTrue),
 		)),
 	))
 }
@@ -327,7 +328,7 @@ func (tc *ModelControllerTestCtx) validateModelControllerDisabled(t *testing.T) 
 	).Should(And(
 		HaveLen(1),
 		HaveEach(
-			jq.Match(`.status.conditions[] | select(.type == "%sReady") | .status == "%s"`, componentApi.ModelControllerComponentName, metav1.ConditionFalse),
+			jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, modelcontroller.ReadyConditionType, metav1.ConditionFalse),
 		),
 	))
 }

--- a/tests/e2e/modelmeshserving_test.go
+++ b/tests/e2e/modelmeshserving_test.go
@@ -17,6 +17,8 @@ import (
 
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/apis/components/v1alpha1"
 	dscv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/datasciencecluster/v1"
+	"github.com/opendatahub-io/opendatahub-operator/v2/controllers/components/modelcontroller"
+	"github.com/opendatahub-io/opendatahub-operator/v2/controllers/components/modelmeshserving"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/metadata/labels"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/resources"
@@ -204,8 +206,8 @@ func (tc *ModelMeshServingTestCtx) validateModelMeshServingInstance(t *testing.T
 	).Should(And(
 		HaveLen(1),
 		HaveEach(And(
-			jq.Match(`.status.conditions[] | select(.type == "%sReady") | .status == "%s"`, componentApi.ModelMeshServingComponentName, metav1.ConditionTrue),
-			jq.Match(`.status.conditions[] | select(.type == "%sReady") | .status == "%s"`, componentApi.ModelControllerComponentName, metav1.ConditionTrue),
+			jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, modelmeshserving.ReadyConditionType, metav1.ConditionTrue),
+			jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, modelcontroller.ReadyConditionType, metav1.ConditionTrue),
 		)),
 	))
 
@@ -337,7 +339,7 @@ func (tc *ModelMeshServingTestCtx) validateModelMeshServingDisabled(t *testing.T
 	).Should(And(
 		HaveLen(1),
 		HaveEach(
-			jq.Match(`.status.conditions[] | select(.type == "%sReady") | .status == "%s"`, componentApi.ModelMeshServingComponentName, metav1.ConditionFalse),
+			jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, modelmeshserving.ReadyConditionType, metav1.ConditionFalse),
 		),
 	))
 }

--- a/tests/e2e/modelregistry_test.go
+++ b/tests/e2e/modelregistry_test.go
@@ -226,7 +226,7 @@ func (mr *ModelRegistryTestCtx) validateModelRegistryInstance(t *testing.T) {
 	).Should(And(
 		HaveLen(1),
 		HaveEach(And(
-			jq.Match(`.status.conditions[] | select(.type == "%sReady") | .status == "%s"`, componentApi.ModelRegistryComponentName, metav1.ConditionTrue),
+			jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, modelregistry.ReadyConditionType, metav1.ConditionTrue),
 			jq.Match(`.status.installedComponents."%s" == true`, modelregistry.LegacyComponentName),
 			jq.Match(`.status.components.%s.managementState == "%s"`, componentApi.ModelRegistryComponentName, operatorv1.Managed),
 		)),

--- a/tests/e2e/ray_test.go
+++ b/tests/e2e/ray_test.go
@@ -22,6 +22,7 @@ import (
 
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/apis/components/v1alpha1"
 	dscv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/datasciencecluster/v1"
+	"github.com/opendatahub-io/opendatahub-operator/v2/controllers/components/ray"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/metadata/labels"
 )
@@ -192,7 +193,7 @@ func (tc *RayTestCtx) validateRayReady() error {
 		}
 
 		for _, c := range list.Items[0].Status.Conditions {
-			if c.Type == componentApi.RayComponentName+"Ready" {
+			if c.Type == ray.ReadyConditionType {
 				return c.Status == corev1.ConditionTrue, nil
 			}
 		}

--- a/tests/e2e/trustyai_test.go
+++ b/tests/e2e/trustyai_test.go
@@ -22,6 +22,7 @@ import (
 
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/apis/components/v1alpha1"
 	dscv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/datasciencecluster/v1"
+	"github.com/opendatahub-io/opendatahub-operator/v2/controllers/components/trustyai"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/metadata/labels"
 )
@@ -167,13 +168,13 @@ func (tc *TrustyaiTestCtx) testOwnerReferences() error {
 func (tc *TrustyaiTestCtx) validateTrustyaiReady() error {
 	err := wait.PollUntilContextTimeout(tc.testCtx.ctx, generalRetryInterval, componentReadyTimeout, true, func(ctx context.Context) (bool, error) {
 		key := types.NamespacedName{Name: tc.testTrustyaiInstance.Name}
-		trustyai := &componentApi.TrustyAI{}
+		tai := &componentApi.TrustyAI{}
 
-		err := tc.testCtx.customClient.Get(ctx, key, trustyai)
+		err := tc.testCtx.customClient.Get(ctx, key, tai)
 		if err != nil {
 			return false, err
 		}
-		return trustyai.Status.Phase == readyStatus, nil
+		return tai.Status.Phase == readyStatus, nil
 	})
 
 	if err != nil {
@@ -192,7 +193,7 @@ func (tc *TrustyaiTestCtx) validateTrustyaiReady() error {
 		}
 
 		for _, c := range list.Items[0].Status.Conditions {
-			if c.Type == componentApi.TrustyAIComponentName+"Ready" {
+			if c.Type == trustyai.ReadyConditionType {
 				return c.Status == corev1.ConditionTrue, nil
 			}
 		}
@@ -304,8 +305,8 @@ func (tc *TrustyaiTestCtx) testUpdateTrustyaiComponentDisabled() error {
 
 	if err = tc.testCtx.wait(func(ctx context.Context) (bool, error) {
 		// Verify trustyai CR is deleted
-		trustyai := &componentApi.TrustyAI{}
-		err = tc.testCtx.customClient.Get(ctx, client.ObjectKey{Name: tc.testTrustyaiInstance.Name}, trustyai)
+		tai := &componentApi.TrustyAI{}
+		err = tc.testCtx.customClient.Get(ctx, client.ObjectKey{Name: tc.testTrustyaiInstance.Name}, tai)
 		return k8serr.IsNotFound(err), nil
 	}); err != nil {
 		return fmt.Errorf("component trustyai is disabled, should not get the Trustyai CR %v", tc.testTrustyaiInstance.Name)


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

- **Make DSC's component conditions user friendly**

```yaml
  conditions:
  - lastHeartbeatTime: "2024-12-13T13:34:16Z"
    lastTransitionTime: "2024-12-13T13:33:58Z"
    message: Not Available
    reason: Unknown
    status: "False"
    type: CodeFlareReady
  - lastHeartbeatTime: "2024-12-13T13:34:16Z"
    lastTransitionTime: "2024-12-13T13:33:58Z"
    message: Component ManagementState is set to Removed
    reason: Removed
    status: "False"
    type: DashboardReady
  - lastHeartbeatTime: "2024-12-13T13:34:17Z"
    lastTransitionTime: "2024-12-13T13:33:59Z"
    message: Component ManagementState is set to Removed
    reason: Removed
    status: "False"
    type: KserveReady
  - lastHeartbeatTime: "2024-12-13T13:34:17Z"
    lastTransitionTime: "2024-12-13T13:33:59Z"
    message: Component ManagementState is set to Removed
    reason: Removed
    status: "False"
    type: KueueReady
  - lastHeartbeatTime: "2024-12-13T13:34:17Z"
    lastTransitionTime: "2024-12-13T13:33:59Z"
    message: Component ManagementState is set to Removed
    reason: Removed
    status: "False"
    type: ModelControllerReady
  - lastHeartbeatTime: "2024-12-13T13:34:17Z"
    lastTransitionTime: "2024-12-13T13:33:59Z"
    message: Component ManagementState is set to Removed
    reason: Removed
    status: "False"
    type: ModelMeshServingReady
  - lastHeartbeatTime: "2024-12-13T13:34:17Z"
    lastTransitionTime: "2024-12-13T13:33:59Z"
    message: Component ManagementState is set to Removed
    reason: Removed
    status: "False"
    type: ModelRegistryReady
  - lastHeartbeatTime: "2024-12-13T13:34:17Z"
    lastTransitionTime: "2024-12-13T13:33:59Z"
    message: Component ManagementState is set to Removed
    reason: Removed
    status: "False"
    type: RayReady
  - lastHeartbeatTime: "2024-12-13T13:34:17Z"
    lastTransitionTime: "2024-12-13T13:33:59Z"
    message: DataScienceCluster resource reconciled successfully
    reason: ReconcileCompleted
    status: "True"
    type: ReconcileComplete
  - lastHeartbeatTime: "2024-12-13T13:34:17Z"
    lastTransitionTime: "2024-12-13T13:33:59Z"
    message: Component ManagementState is set to Removed
    reason: Removed
    status: "False"
    type: TrainingOperatorReady
  - lastHeartbeatTime: "2024-12-13T13:34:17Z"
    lastTransitionTime: "2024-12-13T13:33:59Z"
    message: Component ManagementState is set to Removed
    reason: Removed
    status: "False"
    type: TrustyAIReady
  - lastHeartbeatTime: "2024-12-13T13:34:17Z"
    lastTransitionTime: "2024-12-13T13:33:59Z"
    message: Component ManagementState is set to Removed
    reason: Removed
    status: "False"
    type: WorkbenchesReady
```

Requires:
- https://github.com/opendatahub-io/opendatahub-operator/pull/1449
- https://github.com/opendatahub-io/opendatahub-operator/pull/1450

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

e2e tests have been amended

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [X] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [X] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] ~~Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).~~
- [X] The developer has manually tested the changes and verified that the changes work
