### PR TITLE
get_all_manifests.sh: use key (component name) as the target folder

### DIFF
--- a/get_all_manifests.sh
+++ b/get_all_manifests.sh
@@ -3,39 +3,27 @@ set -e
 
 GITHUB_URL="https://github.com"
 
-# component: notebook, dsp, kserve, dashbaord, cf/ray/kueue/trainingoperator, trustyai, modelmesh, modelregistry.
-# in the format of "repo-org:repo-name:ref-name:source-folder:target-folder".
+# COMPONENT_MANIFESTS is a list of components repositories info to fetch the manifests
+# in the format of "repo-org:repo-name:ref-name:source-folder" and key is the target folder under manifests/
 declare -A COMPONENT_MANIFESTS=(
-    # dashboard
-    ["odh-dashboard"]="opendatahub-io:odh-dashboard:main:manifests:dashboard"
-    # workbenches
-    ["kf-notebook-controller"]="opendatahub-io:kubeflow:v1.7-branch:components/notebook-controller/config:workbenches/kf-notebook-controller"
-    ["odh-notebook-controller"]="opendatahub-io:kubeflow:v1.7-branch:components/odh-notebook-controller/config:workbenches/odh-notebook-controller"
-    ["notebooks"]="opendatahub-io:notebooks:main:manifests:workbenches/notebooks"
-    # modelmeshserving
-    ["model-mesh"]="opendatahub-io:modelmesh-serving:release-0.12.0-rc0:config:modelmeshserving"
-    # kserve
-    ["kserve"]="opendatahub-io:kserve:release-v0.14:config:kserve"
-    # kueue
-    ["kueue"]="opendatahub-io:kueue:dev:config:kueue"
-    # codeflare
-    ["codeflare"]="opendatahub-io:codeflare-operator:main:config:codeflare"
-    # ray
-    ["ray"]="opendatahub-io:kuberay:dev:ray-operator/config:ray"
-    # trustyai
-    ["trustyai"]="trustyai-explainability:trustyai-service-operator:main:config:trustyai"
-    # modelregistry
-    ["modelregistry"]="opendatahub-io:model-registry-operator:main:config:modelregistry"
-    # trainingoperator
-    ["trainingoperator"]="opendatahub-io:training-operator:dev:manifests:trainingoperator"
-    # datasciencepipelines
-    ["data-science-pipelines-operator"]="opendatahub-io:data-science-pipelines-operator:main:config:datasciencepipelines"
-    # modelcontroller
-    ["odh-model-controller"]="opendatahub-io:odh-model-controller:incubating:config:modelcontroller"
+    ["dashboard"]="opendatahub-io:odh-dashboard:main:manifests"
+    ["workbenches/kf-notebook-controller"]="opendatahub-io:kubeflow:v1.7-branch:components/notebook-controller/config"
+    ["workbenches/odh-notebook-controller"]="opendatahub-io:kubeflow:v1.7-branch:components/odh-notebook-controller/config"
+    ["workbenches/notebooks"]="opendatahub-io:notebooks:main:manifests"
+    ["modelmeshserving"]="opendatahub-io:modelmesh-serving:release-0.12.0-rc0:config"
+    ["kserve"]="opendatahub-io:kserve:release-v0.14:config"
+    ["kueue"]="opendatahub-io:kueue:dev:config"
+    ["codeflare"]="opendatahub-io:codeflare-operator:main:config"
+    ["ray"]="opendatahub-io:kuberay:dev:ray-operator/config"
+    ["trustyai"]="trustyai-explainability:trustyai-service-operator:main:config"
+    ["modelregistry"]="opendatahub-io:model-registry-operator:main:config"
+    ["trainingoperator"]="opendatahub-io:training-operator:dev:manifests"
+    ["datasciencepipelines"]="opendatahub-io:data-science-pipelines-operator:main:config"
+    ["modelcontroller"]="opendatahub-io:odh-model-controller:incubating:config"
 )
 
 # Allow overwriting repo using flags component=repo
-pattern="^[a-zA-Z0-9_.-]+:[a-zA-Z0-9_.-]+:[a-zA-Z0-9_.-]+:[a-zA-Z0-9_./-]+:[a-zA-Z0-9_./-]+$"
+pattern="^[a-zA-Z0-9_.-]+:[a-zA-Z0-9_.-]+:[a-zA-Z0-9_.-]+:[a-zA-Z0-9_./-]+$"
 if [ "$#" -ge 1 ]; then
     for arg in "$@"; do
         if [[ $arg == --* ]]; then
@@ -43,7 +31,7 @@ if [ "$#" -ge 1 ]; then
             IFS="=" read -r key value <<< "$arg"
             if [[ -n "${COMPONENT_MANIFESTS[$key]}" ]]; then
                 if [[ ! $value =~ $pattern ]]; then
-                    echo "ERROR: The value '$value' does not match the expected format 'repo-org:repo-name:branch-name:source-folder:target-folder'."
+                    echo "ERROR: The value '$value' does not match the expected format 'repo-org:repo-name:ref-name:source-folder'."
                     continue
                 fi
                 COMPONENT_MANIFESTS["$key"]=$value
@@ -89,7 +77,7 @@ for key in "${!COMPONENT_MANIFESTS[@]}"; do
     repo_name="${repo_info[1]}"
     repo_ref="${repo_info[2]}"
     source_path="${repo_info[3]}"
-    target_path="${repo_info[4]}"
+    target_path="${key}"
 
     repo_url="${GITHUB_URL}/${repo_org}/${repo_name}"
     repo_dir=${TMP_DIR}/${key}


### PR DESCRIPTION
There is no point to set target folder explicitly if it can be the same as the component name.

The patch is a step to unification of component names.

In the error message for overriding with an option also `branch-name` replaced to `ref-name`. Leftover.

For odh-notebook-controller subcomponents directory is a part of the key.

<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
