### PR TITLE
fix: bug not filling params.env with default cert value in model registry operator

### DIFF
--- a/controllers/components/modelregistry/modelregistry.go
+++ b/controllers/components/modelregistry/modelregistry.go
@@ -41,16 +41,8 @@ func (s *componentHandler) GetManagementState(dsc *dscv1.DataScienceCluster) ope
 func (s *componentHandler) Init(_ cluster.Platform) error {
 	mi := baseManifestInfo(BaseManifestsSourcePath)
 
-	params := make(map[string]string)
-	for k, v := range imagesMap {
-		params[k] = v
-	}
-	for k, v := range extraParamsMap {
-		params[k] = v
-	}
-
-	if err := odhdeploy.ApplyParams(mi.String(), params); err != nil {
-		return fmt.Errorf("failed to update images on path %s: %w", mi, err)
+	if err := odhdeploy.ApplyParams(mi.String(), imagesMap, extraParamsMap); err != nil {
+		return fmt.Errorf("failed to update params on path %s: %w", mi, err)
 	}
 
 	return nil


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->
Starting with version v2.22.0, the `DEFAULT_CERT` value in the `params.env` file for the model registry operator is not updated with the value from

```go
	extraParamsMap = map[string]string{
		"DEFAULT_CERT": DefaultModelRegistryCert,
	}
```
The problem seems to be that the extraParamsMap was merged with imageParams when it was passed to the `odhdeploy.ApplyParams` function, here the second argument went through
```go
	// 1. Update images with env variables
	// e.g "odh-kuberay-operator-controller-image": "RELATED_IMAGE_ODH_KUBERAY_OPERATOR_CONTROLLER_IMAGE",
	for i := range paramsEnvMap {
		relatedImageValue := os.Getenv(imageParamsMap[i])
		if relatedImageValue != "" {
			updated |= updateMap(&paramsEnvMap, i, relatedImageValue)
		}
	}
```
instead of 
```go
	// 2. Update other fileds with extraParamsMap which are not carried from component
	for _, extraParamsMap := range extraParamsMaps {
		for eKey, eValue := range extraParamsMap {
			updated |= updateMap(&paramsEnvMap, eKey, eValue)
		}
	}
```

so the empty value is explained

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

local testing

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->
envs from model registry operator

![image](https://github.com/user-attachments/assets/f9889717-6c19-4112-8818-940a54587f8a)

folder inside opendatahub-operator

![image](https://github.com/user-attachments/assets/40cce7dc-8413-4e7c-9428-817397161d87)


## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
