### PR TITLE
chore: cleanup static-named nim resources for switching to naming convention

### DIFF
--- a/pkg/upgrade/upgrade.go
+++ b/pkg/upgrade/upgrade.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/go-multierror"
 	operatorv1 "github.com/openshift/api/operator/v1"
 	routev1 "github.com/openshift/api/route/v1"
+	openshiftv1 "github.com/openshift/api/template/v1"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
@@ -288,8 +289,8 @@ func CleanupExistingResource(ctx context.Context,
 	toDelete := getDashboardWatsonResources(dscApplicationsNamespace)
 	multiErr = multierror.Append(multiErr, deleteResources(ctx, cli, &toDelete))
 
-	// cleanup nvidia nim integration remove tech preview
-	multiErr = multierror.Append(multiErr, cleanupNimIntegrationTechPreview(ctx, cli, oldReleaseVersion, dscApplicationsNamespace))
+	// cleanup nvidia nim integration
+	multiErr = multierror.Append(multiErr, cleanupNimIntegration(ctx, cli, oldReleaseVersion, dscApplicationsNamespace))
 
 	return multiErr.ErrorOrNil()
 }
@@ -608,35 +609,56 @@ func GetDeployedRelease(ctx context.Context, cli client.Client) (cluster.Release
 	return cluster.Release{}, nil
 }
 
-func cleanupNimIntegrationTechPreview(ctx context.Context, cli client.Client, oldRelease cluster.Release, applicationNS string) error {
+func cleanupNimIntegration(ctx context.Context, cli client.Client, oldRelease cluster.Release, applicationNS string) error {
 	var errs *multierror.Error
 
-	if oldRelease.Version.Minor >= 14 && oldRelease.Version.Minor <= 15 {
+	if oldRelease.Version.Minor >= 14 && oldRelease.Version.Minor <= 16 {
 		log := logf.FromContext(ctx)
-		nimCronjob := "nvidia-nim-periodic-validator"
-		nimConfigMap := "nvidia-nim-validation-result"
-		nimAPISec := "nvidia-nim-access"
-
-		deleteObjs := []struct {
+		type objForDel struct {
 			obj        client.Object
 			name, desc string
-		}{
-			{
-				obj:  &batchv1.CronJob{},
-				name: nimCronjob,
-				desc: "validator CronJob",
-			},
+		}
+
+		// the following objects created by TP (14-15) and by the first GA (16)
+		deleteObjs := []objForDel{
 			{
 				obj:  &corev1.ConfigMap{},
-				name: nimConfigMap,
-				desc: "validation result ConfigMap",
+				name: "nvidia-nim-images-data",
+				desc: "data ConfigMap",
+			},
+			{
+				obj:  &openshiftv1.Template{},
+				name: "nvidia-nim-serving-template",
+				desc: "runtime Template",
 			},
 			{
 				obj:  &corev1.Secret{},
-				name: nimAPISec,
-				desc: "API key Secret",
+				name: "nvidia-nim-image-pull",
+				desc: "pull Secret",
 			},
 		}
+
+		// the following objects created by TP (14-15)
+		if oldRelease.Version.Minor < 16 {
+			deleteObjs = append(deleteObjs,
+				objForDel{
+					obj:  &batchv1.CronJob{},
+					name: "nvidia-nim-periodic-validator",
+					desc: "validator CronJob",
+				},
+				objForDel{
+					obj:  &corev1.ConfigMap{},
+					name: "nvidia-nim-validation-result",
+					desc: "validation result ConfigMap",
+				},
+				// the api key is also used by GA (16), but cleanup is only required for TP->GA switch
+				objForDel{
+					obj:  &corev1.Secret{},
+					name: "nvidia-nim-access",
+					desc: "API key Secret",
+				})
+		}
+
 		for _, delObj := range deleteObjs {
 			if gErr := cli.Get(ctx, types.NamespacedName{Name: delObj.name, Namespace: applicationNS}, delObj.obj); gErr != nil {
 				if !k8serr.IsNotFound(gErr) {


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

Following the merge of https://github.com/opendatahub-io/odh-dashboard/pull/3535, we can use a naming convention to create the resources owned by NIM runtimes instead of static names. This means that if upgrading from 2.14-2.16, we need to look for and delete the static-named resources. Deleting them will trigger a reconciliation that will create them with the correct names.

For the resources created with the new naming conventions; see (replace-this).

<!--- Link your JIRA and related links here for reference. -->

Jira: [NVPE-29](https://issues.redhat.com/browse/NVPE-29)
Slack: [thread](https://redhat-internal.slack.com/archives/C07CZDA6DE1/p1734382422391069)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

```shell
make unit-test
make build
```

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
