### PR TITLE
Fix parameter order in resolveTargetPath to ensure manifest overwrite

### DIFF
--- a/pkg/deploy/deploy.go
+++ b/pkg/deploy/deploy.go
@@ -133,7 +133,7 @@ func unpackTarFromReader(reader io.Reader, basePath, componentName, contextDir s
 }
 
 // resolveTargetPath computes the target file path based on the tar header and context directory.
-func resolveTargetPath(headerName, basePath, contextDir, componentName string) (string, error) {
+func resolveTargetPath(headerName, basePath, componentName, contextDir string) (string, error) {
 	componentFiles := strings.Split(headerName, "/")
 	componentManifestPath := filepath.Join(componentFiles[0], contextDir)
 


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
This PR fixes an issue in the `DownloadManifests` function where the parameters `componentName` and `contextDir` were passed in the wrong order to the `resolveTargetPath` function.

The incorrect order caused downloaded component manifests to be ignored, preventing them from overwriting existing local manifest files as intended.

<!--- Describe your changes in detail -->
Fixing https://issues.redhat.com/browse/RHOAIENG-17146

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
