### PR TITLE
Remove useless e2e sleep time

### DIFF
--- a/tests/e2e/helper_test.go
+++ b/tests/e2e/helper_test.go
@@ -28,6 +28,7 @@ import (
 	infrav1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/infrastructure/v1"
 	serviceApi "github.com/opendatahub-io/opendatahub-operator/v2/apis/services/v1alpha1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/controllers/components/modelregistry"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/metadata/labels"
 )
 
 const (
@@ -73,6 +74,26 @@ func (tc *testContext) waitForOperatorDeployment(name string, replicas int32) er
 	})
 
 	return err
+}
+
+func (tc *testContext) getComponentDeployments(componentGVK schema.GroupVersionKind) ([]appsv1.Deployment, error) {
+	deployments := appsv1.DeploymentList{}
+	err := tc.customClient.List(
+		tc.ctx,
+		&deployments,
+		client.InNamespace(
+			tc.applicationsNamespace,
+		),
+		client.MatchingLabels{
+			labels.PlatformPartOf: strings.ToLower(componentGVK.Kind),
+		},
+	)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return deployments.Items, nil
 }
 
 func setupDSCICR(name string) *dsciv1.DSCInitialization {

--- a/tests/e2e/kueue_test.go
+++ b/tests/e2e/kueue_test.go
@@ -259,28 +259,23 @@ func (tc *KueueTestCtx) testUpdateOnKueueResources() error {
 }
 
 func (tc *KueueTestCtx) testUpdateKueueComponentDisabled() error {
-	// Test Updating Kueue to be disabled
-	var kueueDeploymentName string
+	if tc.testCtx.testDsc.Spec.Components.Kueue.ManagementState != operatorv1.Managed {
+		return errors.New("the Kueue spec should be in 'enabled: true' state in order to perform test")
+	}
 
-	if tc.testCtx.testDsc.Spec.Components.Kueue.ManagementState == operatorv1.Managed {
-		appDeployments, err := tc.testCtx.kubeClient.AppsV1().Deployments(tc.testCtx.applicationsNamespace).List(tc.testCtx.ctx, metav1.ListOptions{
-			LabelSelector: labels.PlatformPartOf + "=" + strings.ToLower(gvk.Kueue.Kind),
-		})
-		if err != nil {
-			return fmt.Errorf("error getting enabled component %v", componentApi.KueueComponentName)
+	deployments, err := tc.testCtx.getComponentDeployments(gvk.Kueue)
+	if err != nil {
+		return fmt.Errorf("error getting enabled component %s", componentApi.KueueComponentName)
+	}
+
+	for _, d := range deployments {
+		if d.Status.ReadyReplicas == 0 {
+			return fmt.Errorf("component %s deployment %sis not ready", d.Name, componentApi.KueueComponentName)
 		}
-		if len(appDeployments.Items) > 0 {
-			kueueDeploymentName = appDeployments.Items[0].Name
-			if appDeployments.Items[0].Status.ReadyReplicas == 0 {
-				return fmt.Errorf("error getting enabled component: %s its deployment 'ReadyReplicas'", kueueDeploymentName)
-			}
-		}
-	} else {
-		return errors.New("kueue spec should be in 'enabled: true' state in order to perform test")
 	}
 
 	// Disable component Kueue
-	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+	err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		// refresh DSC instance in case it was updated during the reconcile
 		err := tc.testCtx.customClient.Get(tc.testCtx.ctx, types.NamespacedName{Name: tc.testCtx.testDsc.Name}, tc.testCtx.testDsc)
 		if err != nil {
@@ -312,17 +307,16 @@ func (tc *KueueTestCtx) testUpdateKueueComponentDisabled() error {
 		return fmt.Errorf("component kueue is disabled, should not get the Kueue CR %v", tc.testKueueInstance.Name)
 	}
 
-	// Sleep for 20 seconds to allow the operator to reconcile
-	time.Sleep(2 * generalRetryInterval)
-	_, err = tc.testCtx.kubeClient.AppsV1().Deployments(tc.testCtx.applicationsNamespace).Get(tc.testCtx.ctx, kueueDeploymentName, metav1.GetOptions{})
+	deployments, err = tc.testCtx.getComponentDeployments(gvk.Kueue)
 	if err != nil {
-		if k8serr.IsNotFound(err) {
-			return nil // correct result: should not find deployment after we disable it already
-		}
-		return fmt.Errorf("error getting component resource after reconcile: %w", err)
+		return fmt.Errorf("error listing deployments: %w", err)
 	}
-	return fmt.Errorf("component %v is disabled, should not get its deployment %v from NS %v any more",
-		componentApi.KueueKind,
-		kueueDeploymentName,
-		tc.testCtx.applicationsNamespace)
+
+	if len(deployments) != 0 {
+		return fmt.Errorf("component %v is disabled, should not have deployments in NS %v any more",
+			gvk.Kueue.Kind,
+			tc.testCtx.applicationsNamespace)
+	}
+
+	return nil
 }

--- a/tests/e2e/ray_test.go
+++ b/tests/e2e/ray_test.go
@@ -259,28 +259,23 @@ func (tc *RayTestCtx) testUpdateOnRayResources() error {
 }
 
 func (tc *RayTestCtx) testUpdateRayComponentDisabled() error {
-	// Test Updating Ray to be disabled
-	var rayDeploymentName string
+	if tc.testCtx.testDsc.Spec.Components.Ray.ManagementState != operatorv1.Managed {
+		return errors.New("the Ray spec should be in 'enabled: true' state in order to perform test")
+	}
 
-	if tc.testCtx.testDsc.Spec.Components.Ray.ManagementState == operatorv1.Managed {
-		appDeployments, err := tc.testCtx.kubeClient.AppsV1().Deployments(tc.testCtx.applicationsNamespace).List(tc.testCtx.ctx, metav1.ListOptions{
-			LabelSelector: labels.PlatformPartOf + "=" + strings.ToLower(gvk.Ray.Kind),
-		})
-		if err != nil {
-			return fmt.Errorf("error getting enabled component %v", componentApi.RayComponentName)
+	deployments, err := tc.testCtx.getComponentDeployments(gvk.Ray)
+	if err != nil {
+		return fmt.Errorf("error getting enabled component %s", componentApi.RayComponentName)
+	}
+
+	for _, d := range deployments {
+		if d.Status.ReadyReplicas == 0 {
+			return fmt.Errorf("component %s deployment %sis not ready", d.Name, componentApi.RayComponentName)
 		}
-		if len(appDeployments.Items) > 0 {
-			rayDeploymentName = appDeployments.Items[0].Name
-			if appDeployments.Items[0].Status.ReadyReplicas == 0 {
-				return fmt.Errorf("error getting enabled component: %s its deployment 'ReadyReplicas'", rayDeploymentName)
-			}
-		}
-	} else {
-		return errors.New("ray spec should be in 'enabled: true' state in order to perform test")
 	}
 
 	// Disable component Ray
-	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+	err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		// refresh DSC instance in case it was updated during the reconcile
 		err := tc.testCtx.customClient.Get(tc.testCtx.ctx, types.NamespacedName{Name: tc.testCtx.testDsc.Name}, tc.testCtx.testDsc)
 		if err != nil {
@@ -312,17 +307,16 @@ func (tc *RayTestCtx) testUpdateRayComponentDisabled() error {
 		return fmt.Errorf("component ray is disabled, should not get the Ray CR %v", tc.testRayInstance.Name)
 	}
 
-	// Sleep for 20 seconds to allow the operator to reconcile
-	time.Sleep(2 * generalRetryInterval)
-	_, err = tc.testCtx.kubeClient.AppsV1().Deployments(tc.testCtx.applicationsNamespace).Get(tc.testCtx.ctx, rayDeploymentName, metav1.GetOptions{})
+	deployments, err = tc.testCtx.getComponentDeployments(gvk.Ray)
 	if err != nil {
-		if k8serr.IsNotFound(err) {
-			return nil // correct result: should not find deployment after we disable it already
-		}
-		return fmt.Errorf("error getting component resource after reconcile: %w", err)
+		return fmt.Errorf("error listing deployments: %w", err)
 	}
-	return fmt.Errorf("component %v is disabled, should not get its deployment %v from NS %v any more",
-		componentApi.RayKind,
-		rayDeploymentName,
-		tc.testCtx.applicationsNamespace)
+
+	if len(deployments) != 0 {
+		return fmt.Errorf("component %v is disabled, should not have deployments in NS %v any more",
+			gvk.Ray.Kind,
+			tc.testCtx.applicationsNamespace)
+	}
+
+	return nil
 }

--- a/tests/e2e/trustyai_test.go
+++ b/tests/e2e/trustyai_test.go
@@ -259,28 +259,23 @@ func (tc *TrustyaiTestCtx) testUpdateOnTrustyaiResources() error {
 }
 
 func (tc *TrustyaiTestCtx) testUpdateTrustyaiComponentDisabled() error {
-	// Test Updating Trustyai to be disabled
-	var trustyaiDeploymentName string
+	if tc.testCtx.testDsc.Spec.Components.TrustyAI.ManagementState != operatorv1.Managed {
+		return errors.New("the TrustyAI spec should be in 'enabled: true' state in order to perform test")
+	}
 
-	if tc.testCtx.testDsc.Spec.Components.TrustyAI.ManagementState == operatorv1.Managed {
-		appDeployments, err := tc.testCtx.kubeClient.AppsV1().Deployments(tc.testCtx.applicationsNamespace).List(tc.testCtx.ctx, metav1.ListOptions{
-			LabelSelector: labels.PlatformPartOf + "=" + strings.ToLower(gvk.TrustyAI.Kind),
-		})
-		if err != nil {
-			return fmt.Errorf("error getting enabled component %v", componentApi.TrustyAIComponentName)
+	deployments, err := tc.testCtx.getComponentDeployments(gvk.TrustyAI)
+	if err != nil {
+		return fmt.Errorf("error getting enabled component %s", componentApi.TrustyAIComponentName)
+	}
+
+	for _, d := range deployments {
+		if d.Status.ReadyReplicas == 0 {
+			return fmt.Errorf("component %s deployment %sis not ready", d.Name, componentApi.TrustyAIComponentName)
 		}
-		if len(appDeployments.Items) > 0 {
-			trustyaiDeploymentName = appDeployments.Items[0].Name
-			if appDeployments.Items[0].Status.ReadyReplicas == 0 {
-				return fmt.Errorf("error getting enabled component: %s its deployment 'ReadyReplicas'", trustyaiDeploymentName)
-			}
-		}
-	} else {
-		return errors.New("trustyai spec should be in 'enabled: true' state in order to perform test")
 	}
 
 	// Disable component Trustyai
-	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+	err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		// refresh DSC instance in case it was updated during the reconcile
 		err := tc.testCtx.customClient.Get(tc.testCtx.ctx, types.NamespacedName{Name: tc.testCtx.testDsc.Name}, tc.testCtx.testDsc)
 		if err != nil {
@@ -312,17 +307,16 @@ func (tc *TrustyaiTestCtx) testUpdateTrustyaiComponentDisabled() error {
 		return fmt.Errorf("component trustyai is disabled, should not get the Trustyai CR %v", tc.testTrustyaiInstance.Name)
 	}
 
-	// Sleep for 20 seconds to allow the operator to reconcile
-	time.Sleep(2 * generalRetryInterval)
-	_, err = tc.testCtx.kubeClient.AppsV1().Deployments(tc.testCtx.applicationsNamespace).Get(tc.testCtx.ctx, trustyaiDeploymentName, metav1.GetOptions{})
+	deployments, err = tc.testCtx.getComponentDeployments(gvk.TrustyAI)
 	if err != nil {
-		if k8serr.IsNotFound(err) {
-			return nil // correct result: should not find deployment after we disable it already
-		}
-		return fmt.Errorf("error getting component resource after reconcile: %w", err)
+		return fmt.Errorf("error listing deployments: %w", err)
 	}
-	return fmt.Errorf("component %v is disabled, should not get its deployment %v from NS %v any more",
-		componentApi.TrustyAIKind,
-		trustyaiDeploymentName,
-		tc.testCtx.applicationsNamespace)
+
+	if len(deployments) != 0 {
+		return fmt.Errorf("component %v is disabled, should not have deployments in NS %v any more",
+			gvk.TrustyAI.Kind,
+			tc.testCtx.applicationsNamespace)
+	}
+
+	return nil
 }


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

The tests to validate the correctness of the operator when components
are disabled have been refactored to:

1. take into account all the component's deployments, not only the first
   one to avoid swallowing misbehavior
2. remove useless waiting time before checking the presence of
   component's deployments because within the introduction of the
   internal APIs, the object hierarchy now allow for a proper cleanup as
   all the object have a proper owner reference. The operator deletes
   the component API using foreground deletion policy hence once the top
   level component CR is removed, the all the owned objects should have
   been deleted too.

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] ~~Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).~~
- [x] The developer has manually tested the changes and verified that the changes work
