### PR TITLE
Show KServe defaultDeploymentMode in DSC status

### DIFF
--- a/apis/components/v1alpha1/kserve_types.go
+++ b/apis/components/v1alpha1/kserve_types.go
@@ -74,6 +74,9 @@ type KserveSpec struct {
 
 // KserveCommonStatus defines the shared observed state of Kserve
 type KserveCommonStatus struct {
+	// DefaultDeploymentMode is the value of the defaultDeploymentMode field
+	// as read from the "deploy" JSON in the inferenceservice-config ConfigMap
+	DefaultDeploymentMode string `json:"defaultDeploymentMode,omitempty"`
 }
 
 // KserveStatus defines the observed state of Kserve

--- a/bundle/manifests/components.platform.opendatahub.io_kserves.yaml
+++ b/bundle/manifests/components.platform.opendatahub.io_kserves.yaml
@@ -216,6 +216,11 @@ spec:
                 x-kubernetes-list-map-keys:
                 - type
                 x-kubernetes-list-type: map
+              defaultDeploymentMode:
+                description: |-
+                  DefaultDeploymentMode is the value of the defaultDeploymentMode field
+                  as read from the "deploy" JSON in the inferenceservice-config ConfigMap
+                type: string
               observedGeneration:
                 format: int64
                 type: integer

--- a/bundle/manifests/datasciencecluster.opendatahub.io_datascienceclusters.yaml
+++ b/bundle/manifests/datasciencecluster.opendatahub.io_datascienceclusters.yaml
@@ -718,6 +718,11 @@ spec:
                   kserve:
                     description: Kserve component status.
                     properties:
+                      defaultDeploymentMode:
+                        description: |-
+                          DefaultDeploymentMode is the value of the defaultDeploymentMode field
+                          as read from the "deploy" JSON in the inferenceservice-config ConfigMap
+                        type: string
                       managementState:
                         description: |-
                           Set to one of the following values:

--- a/bundle/manifests/opendatahub-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/opendatahub-operator.clusterserviceversion.yaml
@@ -106,7 +106,7 @@ metadata:
     categories: AI/Machine Learning, Big Data
     certified: "False"
     containerImage: quay.io/opendatahub/opendatahub-operator:v2.21.0
-    createdAt: "2024-12-16T13:35:31Z"
+    createdAt: "2025-01-02T20:06:57Z"
     olm.skipRange: '>=1.0.0 <2.21.0'
     operators.operatorframework.io/builder: operator-sdk-v1.31.0
     operators.operatorframework.io/internal-objects: '["featuretrackers.features.opendatahub.io",

--- a/config/crd/bases/components.platform.opendatahub.io_kserves.yaml
+++ b/config/crd/bases/components.platform.opendatahub.io_kserves.yaml
@@ -216,6 +216,11 @@ spec:
                 x-kubernetes-list-map-keys:
                 - type
                 x-kubernetes-list-type: map
+              defaultDeploymentMode:
+                description: |-
+                  DefaultDeploymentMode is the value of the defaultDeploymentMode field
+                  as read from the "deploy" JSON in the inferenceservice-config ConfigMap
+                type: string
               observedGeneration:
                 format: int64
                 type: integer

--- a/config/crd/bases/datasciencecluster.opendatahub.io_datascienceclusters.yaml
+++ b/config/crd/bases/datasciencecluster.opendatahub.io_datascienceclusters.yaml
@@ -718,6 +718,11 @@ spec:
                   kserve:
                     description: Kserve component status.
                     properties:
+                      defaultDeploymentMode:
+                        description: |-
+                          DefaultDeploymentMode is the value of the defaultDeploymentMode field
+                          as read from the "deploy" JSON in the inferenceservice-config ConfigMap
+                        type: string
                       managementState:
                         description: |-
                           Set to one of the following values:

--- a/controllers/components/kserve/config.go
+++ b/controllers/components/kserve/config.go
@@ -1,0 +1,26 @@
+package kserve
+
+import (
+	"encoding/json"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+// ConfigMap Keys.
+const (
+	DeployConfigName     = "deploy"
+	IngressConfigKeyName = "ingress"
+)
+
+type DeployConfig struct {
+	DefaultDeploymentMode string `json:"defaultDeploymentMode,omitempty"`
+}
+
+func getDeployConfig(cm *corev1.ConfigMap) (*DeployConfig, error) {
+	deployConfig := DeployConfig{}
+	if err := json.Unmarshal([]byte(cm.Data[DeployConfigName]), &deployConfig); err != nil {
+		return nil, fmt.Errorf("error retrieving value for key '%s' from ConfigMap %s. %w", DeployConfigName, cm.Name, err)
+	}
+	return &deployConfig, nil
+}

--- a/controllers/components/kserve/kserve_controller.go
+++ b/controllers/components/kserve/kserve_controller.go
@@ -157,6 +157,7 @@ func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.
 		WithAction(deploy.NewAction(
 			deploy.WithCache(),
 		)).
+		WithAction(setStatusFields).
 		WithAction(updatestatus.NewAction()).
 		// must be the final action
 		WithAction(gc.NewAction()).

--- a/controllers/components/kserve/kserve_controller_actions.go
+++ b/controllers/components/kserve/kserve_controller_actions.go
@@ -262,3 +262,18 @@ func customizeKserveConfigMap(ctx context.Context, rr *odhtypes.ReconciliationRe
 
 	return nil
 }
+
+func setStatusFields(ctx context.Context, rr *odhtypes.ReconciliationRequest) error {
+	k, ok := rr.Instance.(*componentApi.Kserve)
+	if !ok {
+		return fmt.Errorf("resource instance %v is not a componentApi.Kserve)", rr.Instance)
+	}
+
+	ddm, err := getDefaultDeploymentMode(ctx, rr.Client, &rr.DSCI.Spec)
+	if err != nil {
+		return err
+	}
+
+	k.Status.DefaultDeploymentMode = ddm
+	return nil
+}

--- a/docs/api-overview.md
+++ b/docs/api-overview.md
@@ -805,6 +805,9 @@ _Appears in:_
 - [DSCKserveStatus](#dsckservestatus)
 - [KserveStatus](#kservestatus)
 
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `defaultDeploymentMode` _string_ | DefaultDeploymentMode is the value of the defaultDeploymentMode field<br />as read from the "deploy" JSON in the inferenceservice-config ConfigMap |  |  |
 
 
 #### KserveList
@@ -862,6 +865,7 @@ _Appears in:_
 | `phase` _string_ |  |  |  |
 | `observedGeneration` _integer_ |  |  |  |
 | `conditions` _[Condition](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#condition-v1-meta) array_ |  |  |  |
+| `defaultDeploymentMode` _string_ | DefaultDeploymentMode is the value of the defaultDeploymentMode field<br />as read from the "deploy" JSON in the inferenceservice-config ConfigMap |  |  |
 
 
 #### Kueue

--- a/tests/e2e/helper_test.go
+++ b/tests/e2e/helper_test.go
@@ -161,6 +161,7 @@ func setupDSCInstance(name string) *dscv1.DataScienceCluster {
 						ManagementState: operatorv1.Removed,
 					},
 					KserveCommonSpec: componentApi.KserveCommonSpec{
+						DefaultDeploymentMode: componentApi.Serverless,
 						Serving: infrav1.ServingSpec{
 							ManagementState: operatorv1.Managed,
 							Name:            "knative-serving",

--- a/tests/e2e/kserve_test.go
+++ b/tests/e2e/kserve_test.go
@@ -74,6 +74,7 @@ func (k *KserveTestCtx) validateKserveInstance(t *testing.T) {
 				k.testDsc.Spec.Components.Kserve.Serving.IngressGateway.Certificate.Type),
 
 			jq.Match(`.status.phase == "%s"`, readyStatus),
+			jq.Match(`.status.defaultDeploymentMode == "%s"`, k.testDsc.Spec.Components.Kserve.DefaultDeploymentMode),
 		)),
 	))
 
@@ -86,6 +87,7 @@ func (k *KserveTestCtx) validateKserveInstance(t *testing.T) {
 			jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, modelcontroller.ReadyConditionType, metav1.ConditionTrue),
 			jq.Match(`.status.installedComponents."%s" == true`, kserve.LegacyComponentName),
 			jq.Match(`.status.components.%s.managementState == "%s"`, componentApi.KserveComponentName, operatorv1.Managed),
+			jq.Match(`.status.components.%s.defaultDeploymentMode == "%s"`, componentApi.KserveComponentName, k.testDsc.Spec.Components.Kserve.DefaultDeploymentMode),
 		)),
 	))
 


### PR DESCRIPTION
<!---
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

JIRA: https://issues.redhat.com/browse/RHOAIENG-16240

The dashboard would like to be able to read this value, and should
only read it from the status.

The value for the status is always read from the KServe ConfigMap,
rather than ever assuming that what is set in the DSC, or what the
operator defaults to, is correct: this is because that ConfigMap can
be annotated to be unmanaged by the operator, in which case a user may
have changed the value to something else, and the status should
reflect this reality.

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Manually during development
  - including setting the ConfigMap to not be managed, and changing the value from what the operator would have set, and seeing that reflected in the Kserve and DSC CRs
- e2e test has been updated to check for the field

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work