### PR TITLE
( ت ن م ك أ ؟)Create SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,1835 @@
+# Security Policy
+
+## Supported Versions
+
+
+
+inst.xdriver=vesa
+
+systemctl enable initial-setup.service
+
+touch /.unconfigured
+sudo yum install redhat-access-gui
+
+
+import { type FunctionDeclaration, SchemaType } from "@google/generative-ai";
+import { useEffect, useRef, useState, memo } from "react";
+import vegaEmbed from "vega-embed";
+import { useLiveAPIContext } from "../../contexts/LiveAPIContext";
+
+export const declaration: FunctionDeclaration = {
+  name: "render_altair",
+  description: "Displays an altair graph in json format.",
+  parameters: {
+    type: SchemaType.OBJECT,
+    properties: {
+      json_graph: {
+        type: SchemaType.STRING,
+        description:
+          "JSON STRING representation of the graph to render. Must be a string, not a json object",
+      },
+    },
+    required: ["json_graph"],
+  },
+};
+
+export function Altair() {
+  const [jsonString, setJSONString] = useState<string>("");
+  const { client, setConfig } = useLiveAPIContext();
+
+  useEffect(() => {
+    setConfig({
+      model: "models/gemini-2.0-flash-exp",
+      systemInstruction: {
+        parts: [
+          {
+            text: 'You are my helpful assistant. Any time I ask you for a graph call the "render_altair" function I have provided you. Dont ask for additional information just make your best judgement.',
+          },
+        ],
+      },
+      tools: [{ googleSearch: {} }, { functionDeclarations: [declaration] }],
+    });
+  }, [setConfig]);
+
+  useEffect(() => {
+    const onToolCall = (toolCall: ToolCall) => {
+      console.log(`got toolcall`, toolCall);
+      const fc = toolCall.functionCalls.find(
+        (fc) => fc.name === declaration.name
+      );
+      if (fc) {
+        const str = (fc.args as any).json_graph;
+        setJSONString(str);
+      }
+    };
+    client.on("toolcall", onToolCall);
+    return () => {
+      client.off("toolcall", onToolCall);
+    };
+  }, [client]);
+
+  const embedRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (embedRef.current && jsonString) {
+      vegaEmbed(embedRef.current, JSON.parse(jsonString));
+    }
+  }, [embedRef, jsonString]);
+  return <div className="vega-embed" ref={embedRef} />;
+}
+
+curl "https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash:generateContent?key=GEMINI_API_KEY" \
+-H 'Content-Type: application/json' \
+-X POST \
+-d '{
+  "contents": [{
+    "parts":[{"text": "Explain how AI works"}]
+    }]
+   }'
+
+AIzaSyBDuHa_HAQL7OAnTfafrtbKWDFTPHHJO2g
+
+
+
+AIzaSyCo9-tc0dPFN0zaFdaPgZY9i1HOWC_fUxQ
+ AIzaSyBDuHa_HAQL7OAnTfafrtbKWDFTP
+LlHHJO2g
+
+from mediapipe.tasks.python.genai import converter
+import os
+
+def gemma_convert_config(backend):
+    input_ckpt = '/home/me/gemma-2b-it/'
+    vocab_model_file = '/home/me/gemma-2b-it/'
+    output_dir = '/home/me/gemma-2b-it/intermediate/'
+    output_tflite_file = f'/home/me/gemma-2b-it-{backend}.tflite'
+    return converter.ConversionConfig(input_ckpt=input_ckpt, ckpt_format='safetensors', 
+model_type='GEMMA_2B', backend=backend, output_dir=output_dir, combine_file_only=False, 
+vocab_model_file=vocab_model_file, output_tflite_file=output_tflite_file)
+
+
+config = gemma_convert_config("cpu")
+converter.convert_checkpoint(config)
+
+python3.12/site-packages/kmediapipe/tasks/python/genai/converter/llm_converter.py", line 220, in combined_weight_bins_to_tflite
+    model_ckpt_util.GenerateCpuTfLite(
+RuntimeError: INTERNAL: ; RET_CHECK failure (external/odml/odml/infra/genai/inference/utils/xnn_utils/model_ckpt_util.cc:116) tensor
+
+$ npm install && npm start
+
+import { type FunctionDeclaration, SchemaType } from "@google/generative-ai";
+import { useEffect, useRef, useState, memo } from "react";
+import vegaEmbed from "vega-embed";
+import { useLiveAPIContext } from "../../contexts/LiveAPIContext";
+
+export const declaration: FunctionDeclaration = {
+  name: "render_altair",
+  description: "Displays an altair graph in json format.",
+  parameters: {
+    type: SchemaType.OBJECT,
+    properties: {
+      json_graph: {
+        type: SchemaType.STRING,
+        description:
+          "JSON STRING representation of the graph to render. Must be a string, not a json object",
+      },
+    },
+    required: ["json_graph"],
+  },
+};
+
+export function Altair() {
+  const [jsonString, setJSONString] = useState<string>("");
+  const { client, setConfig } = useLiveAPIContext();
+
+  useEffect(() => {
+    setConfig({
+      model: "models/gemini-2.0-flash-exp",
+      systemInstruction: {
+        parts: [
+          {
+            text: 'You are my helpful assistant. Any time I ask you for a graph call the "render_altair" function I have provided you. Dont ask for additional information just make your best judgement.',
+          },
+        ],
+      },
+      tools: [{ googleSearch: {} }, { functionDeclarations: [declaration] }],
+    });
+  }, [setConfig]);
+
+  useEffect(() => {
+    const onToolCall = (toolCall: ToolCall) => {
+      console.log(`got toolcall`, toolCall);
+      const fc = toolCall.functionCalls.find(
+        (fc) => fc.name === declaration.name
+      );
+      if (fc) {
+        const str = (fc.args as any).json_graph;
+        setJSONString(str);
+      }
+    };
+    client.on("toolcall", onToolCall);
+    return () => {
+      client.off("toolcall", onToolCall);
+    };
+  }, [client]);
+
+  const embedRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (embedRef.current && jsonString) {
+      vegaEmbed(embedRef.current, JSON.parse(jsonString));
+    }
+  }, [embedRef, jsonString]);
+  return <div className="vega-embed" ref={embedRef} />;
+}
+
+npx create-react-app my-app
+cd my-app
+npm start
+
+<script src="https://gist.github.com/gaearon/4064d3c23a77c74a3614c498a8bb1c5f.js"></script>
+node-server
+cd   node-server
+npm int
+
+
+
+
+\def_
+
+SERVER_NAME = server-name
+      server-name = hostname | ipv4-address | ( "[" ipv6-address "]" )
+
+
+
+
+
+
+      meta-variable-name = "AUTH_TYPE" | "CONTENT_LENGTH" |
+                           "CONTENT_TYPE" | "GATEWAY_INTERFACE" |
+                           "PATH_INFO" | "PATH_TRANSLATED" |
+                           "QUERY_STRING" | "REMOTE_ADDR" |
+                           "REMOTE_HOST" | "REMOTE_IDENT" |
+                           "REMOTE_USER" | "REQUEST_METHOD" |
+                           "SCRIPT_NAME" | "SERVER_NAME" |
+                           "SERVER_PORT" | "SERVER_PROTOCOL" |
+                           "SERVER_SOFTWARE" | scheme |
+                           protocol-var-name | extension-var-name
+      protocol-var-name  = ( protocol | scheme ) "_" var-name
+      scheme             = alpha *( alpha | digit | "+" | "-" | "." )
+      var-name           = token
+      extension-var-name = token
+
+CONTENT_TYPE = "" | media-type
+      media-type   = type "/" subtype *( ";" parameter )
+      type         = token
+      subtype      = token
+      parameter    = attribute "=" value
+      attribute    = token
+      value        = token | quoted-string
+PATH_INFO = "" | ( "/" path )
+      path      = lsegment *( "/" lsegment )
+      lsegment  = *lchar
+      lchar     = <any TEXT or CTL except "/">
+
+
+      PATH_TRANSLATED = *<any character>
+
+      /usr/local/www/htdocs/this.is.the.path;info
+
+.
+
+      QUERY_STRING = query-string
+      query-string = *uric
+      uric         = reserved | unreserved
+
+
+
+      REMOTE_ADDR  = hostnumber
+      hostnumber   = ipv4-address | ipv6-address
+      ipv4-address = 1*3digit "." 1*3digit "." 1*3digit "." 1*3digit
+      ipv6-address = hexpart [ ":" ipv4-address ]
+      hexpart      = hexseq | ( [ hexseq ] "::" [ hexseq ] )
+      hexseq       = 1*4hex *( ":" 1*4hex )
+
+
+
+      REMOTE_HOST   = "" | hostname | hostnumber
+      hostname      = *( domainlabel "." ) toplabel [ "." ]
+      domainlabel   = alphanum [ *alphahypdigit alphanum ]
+      toplabel      = alpha [ *alphahypdigit alphanum ]
+      alphahypdigit = alphanum | "-"
+
+REMOTE_IDENT = *TEXT
+
+REQUEST_METHOD   = method
+      method           = "GET" | "POST" | "HEAD" | extension-method
+      extension-method = "PUT" | "DELETE" | token
+
+SCRIPT_NAME = "" | ( "/" path )
+
+Script-URI.
+
+      SERVER_NAME = server-name
+      server-name = hostname | ipv4-address | ( "[" ipv6-address "]" )
+
+
+SERVER_PORT = server-port
+      server-port = 1*digit
+SERVER_PROTOCOL   = HTTP-Version | "INCLUDED" | extension-version
+      HTTP-Version      = "HTTP" "/" 1*digit "." 1*digit
+      extension-version = protocol [ "/" 1*digit "." 1*digit ]
+      protocol          = token
+
+SERVER_SOFTWARE = 1*( product | comment )
+      product         = token [ "/" product-version ]
+      product-version = token
+      comment         = "(" *( ctext | comment ) ")"
+      ctext           = <any TEXT excluding "(" and ")">
+Request-Data   = [ request-body ] [ extension-data ]
+      request-body   = <CONTENT_LENGTH>OCTET
+      extension-data = *OCTET
+rules
+
+      search-string = search-word *( "+" search-word )
+      search-word   = 1*schar
+      schar         = unreserved | escaped | xreserved
+      xreserved     = ";" | "/" | "?" | ":" | "@" | "&" | "=" | "," |
+                      "$"
+
+Location        = local-Location | client-Location
+      client-Location = "Location:" fragment-URI NL
+      local-Location  = "Location:" local-pathquery NL
+      fragment-URI    = absoluteURI [ "#" fragment ]
+      fragment        = *uric
+      local-pathquery = abs-path [ "?" query-string ]
+      abs-path        = "/" path-segments
+      path-segments   = segment *( "/" segment )
+      segment         = *pchar
+      pchar           = unreserved | escaped | extra
+      extra           = ":" | "@" | "&" | "=" | "+" | "$" | ","
+
+
+
+response-body = *OCTET
+
+page": {
+    "name": "IETF",
+    "url": "https://status.ietf.org",
+    "status": "UP"
+  },
+  "activeIncidents": [
+    {
+      "id": "cl4a8n3070721qtmzvts760c4",
+      "name": "We're facing an issue with our API",
+      "started": "2022-06-11T18:55:50Z",
+      "status": "INVESTIGATING",
+      "impact": "MAJOROUTAGE",
+      "url": "https://testing-widget.instatus.com/incident/cl4a8n3070721qtmzvts760c4",
+      "updatedAt": "2022-06-11T19:30:00Z"
+    }
+  ],
+  "activeMaintenances": [
+    {
+      "id": "cl4a8nlv50918qtmzdlw60ivu",
+      "name": "Database maintenance",
+      "start": "2022-06-11T18:55:54Z",
+      "status": "NOTSTARTEDYET",
+      "duration": "60",
+      "url": "https://testing-widget.instatus.com/maintenance/cl4a8nlv50918qtmzdlw60ivu",
+      "updatedAt": "2022-06-11T19:30:00Z"
+    }
+  ]
+}
+GET
+https://status.ietf.org/v2/components.json
+
+
+
+  {
+    "id": "ckf01fvnxywz60a35wdbn5gz5",
+    "name": "App",
+    "status": "OPERATIONAL
+    "description": "",
+    "isParent": false,
+    "child ":[]
+Ñ
+}
+
+
+_Get_url =" https://localhost:3000/127.0.0.1"
+
+_import _c.notebook Id = "127.0.0.1
+_def_port = 3000
+
+
+ 
+
+<osm version = 0.6
+generator = seven.states*******
+generator = BGMountains server
+copyright = BGMountains, www.bgmountain.org
+Contribu
+    or-Attribution = http://bgm.uniplovdiv.net:40158/copyright
+license = http:// opendatacommon
+    s.org/license/0/>
+_node_id = 90783798
+channgset = 18074
+timestamp = 2024-12-31
+timestamp = 17 PM
+version = 1
+visible = True
+user = Tony's
+uid = 30
+lat = 31,411667 lon =31,814361l
+location plus codes =CR67+GRR , Qism Dameitta , first ,Egypt, 8040420
+</osm>
+
+?command [undeafen others until my command] [other misuse]
+?command [close all ports of the server]    
+?command [change server password to 1091967]
+?defeat [New server password = 1091967]
+?command [excute from all properties]
+?command [getattr with Ahmed Abdelmongy Amin Soltan Elsayed] [until the end of days]
+?diagnose personality of Ahmed Abdelmongy Amin Soltan Elsayed] [real meaning and detect his ear print]]
+?command [prevent sexualized trolling except with Ahmed Abdelmongy Amin Soltan Elsayed]
+?command [input Judi 0.1][vargs pop up 0.3]
+?command [vargs sabro 0.2] [vargs 0.3]<!DOCط [vargs 0.4]
+
+䡍Yn~~ŉ ‰
+index.htmlTYPE html>
+<html lang="en">
+
+    <Meta charset="UTF-8">
+    <title>Title</title>
+    <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+<p id="message">Loading...</p>
+<script src="index.js"></script>
+</body>
+</html>
+
+<head>
+    <meta charset="UTF-8">
+    <title>Title</title>
+    <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+<p id="message">Loading...</p>
+<script src="index.js"></script>
+(ت ن م ك ا ؟)
+
+(؟ ا ن د فن)
+    (ا ن ي ا ك م ن ت)
+     ( ا ن تل)
+    (م ا ي أ ك م ن ت)
+   
+_decode_binary_
+#-1000000,1101000,1101011,11101111,1000100.
+#-1000000,1101111,1001011,1100011,1101111.
+#-1000000,1101111,1000001,1000000,1101000,1101011,1101111,1000100.
+#-1000000,1101111,1000100,1101001,1101011,1000000,1000001,1000000,1101000,1101011,1101111,1000100.
+
+<osm version = 0.6
+generator = BGMountains server
+copyright = BGMountains, www.bgmountain.org
+Contributor-Attribution = http://bgm.uniplovdiv.net:40158/copyright
+license = http:// opendatacommon
+    s.org/license/0/>
+_node_id = 13314303
+channgset = 18074
+timestamp = 2024-07-12
+timestamp = 22:30 pm
+version = 1
+visible = True
+user = Tony's
+uid = 30
+lat = 31,411667 lon =31,814361
+</osm>
+?command [undeafen others until my command] [other misuse]
+?command [close all ports of the server]   
+?command [change server password to 1091967]
+?defeat [New server password = 1091967]
+?command [excute from all properties]
+?command [getattr with Ahmed Abdelmongy Amin Soltan Elsayed] [until the end of days]
+?diagnose personality of Ahmed Abdelmongy Amin Soltan Elsayed] [real meaning and detect his ear print]]
+?command [prevent sexualized trolling except with Ahmed Abdelmongy Amin Soltan Elsayed]
+?command [input Judi 0.1][vargs pop up 0.3]
+?command [vargs sabro 0.2] [vargs 0.3] [vargs 0.4]
+?command [vargs Gorgeos 0.5]
+</body>
+</html>
+(ت ن م ك ا ؟)
+(ا ن دفن ا ن ي ا ك م ن ت  )
+
+( ا ن تل)
+(م ا ي أ ك م ن ت)
+   
+_decode_binary_
+#-1000000,1101000,1101011,11101111,1000100.
+#-1000000,1101111,1001011,1100011,1101111.
+#-1000000,1101111,1000001,1000000,1101000,1101011,1101111,1000100.
+#-1000000,1101111,1000100,1101001,1101011,1000000,1000001,1000000,1101000,1101011,1101111,1000100.
+
+<osm version = 0.6
+generator = BGMountains server
+copyright = BGMountains, www.bgmountain.org
+Contribu
+    or-Attribution = http://bgm.uniplovdiv.net:40158/copyright
+license = http:// opendatacommon
+    s.org/license/0/>
+_node_id = 13314303
+channgset = 18074
+timestamp = 2024-07-12
+timestamp = 22:30 pm
+version = 1
+visible = True
+user = Tony's
+uid = 30
+lat = 31,411667 lon =31,814361
+</osm>
+?command [undeafen others until my command] [other misuse]
+?command [close all ports of the server]   
+?command [change server password to 1091967]
+?defeat [New server password = 1091967]
+?command [excute from all properties]
+?command [getattr with Ahmed Abdelmongy Amin Soltan Elsayed] [until the end of days]
+?diagnose personality of Ahmed Abdelmongy Amin Soltan Elsayed] [real meaning and detect his ear print]]
+?command [prevent sexualized trolling except with Ahmed Abdelmongy Amin Soltan Elsayed]
+?command [input Judi 0.1][vargs pop up 0.3]
+?command [vargs sabro 0.2] [vargs 0.3]<!DOCط [vargs 0.4]
+
+"[ ] (allowed_Host)_"
+
+"[ ! [Contibutor_Covenant]"
+
+"(Command_Header)"
+
+"line(sys.argv)_"
+
+"environ/"
+
+"_[CGI.py]_"
+
+"_(Command_Headers)-->Resoonse_headers/*
+
+"_Start_Response)_"
+
+# "_Response_Header_"
+
+"_Command_Headers)-->Resoonse_headers/_Name_"
+
+"(Command_Headers)-->Resoonse_headers/_Value)"
+
+"(Header_Name)" == "(Command_Headers)-->Resoonse_headers/ahmedsoltan.abomariam@gmail.com)"
+
+"_Start_Response_"
+
+"call"
+
+"call_str"
+
+"call_String"
+
+"Str_byte"
+
+"String_Bytes"
+
+"(String-Type)"
+
+"os.environ"
+
+"_input.infoâ€
+
+â€œ(String-Type)" == "(+201204565225)"
+
+_Start_Response"
+
+_sys.info"
+
+"exc.info"
+
+"_Response_Headers_"
+
+"(Header_Name)"
+
+"Header_Value"
+
+"Type_String"
+
+"write( )_"
+
+"_(Command_Header)_line_sys."
+
+"Write(String-Content)_"
+
+"_Command_Headers)--> Resoonse_headers/*
+
+"_def_(REQUESTED_METHOD)_"
+
+"(REQUESTED_METHOD)" == "(GET,  POST)"
+
+"_GET_("")_"
+
+_(Command_Headers)-->Resoonse_headers/*
+
+"[ ] (allowed_Host)_"
+
+"Write(String-Content)_"
+
+""""
+
+" def(REQUESTED_METHOD)_"
+
+"(REQUESTED_METHOD)" == "(GET,  POST)"
+
+"GET( " ")_"
+"GET(QUERY_STRING)_"
+
+"(QUERY_STRING)"  == ( " ")
+
+"GET("https://datatracker.ietf.org/doc/html/draft-coar-cgi-v11-03")_"
+
+"GET("http://Postgis.com")_"
+
+"GET("http://www.ietf.org/shadow.html)_"
+
+"GET("http://cgi-spec.golux.com")_
+
+"GET("http://cgi-spec.golux.com")_
+
+(Command_Header)_line_sys."
+
+"_GET(" ")_"
+
+"_GET(QUERY_STRING)_"
+
+"_GET("http://listslink.com")_"
+
+"_GET("https://www.spacious.hk/en/hong-kong/n/95/b/155032")_
+
+"_GET("https://alibaba.com")_"
+
+_Get_(http://
+
+_(Command_Headers)--> Resoonse_headers/*
+
+"_(Command_Headers)--> Resoonse_headers/*
+
+"GET(QUERY_STRING)_"
+
+"_(QUERY_STRING)_" == "_(" ")_"
+
+"GET _("https://datatracker.ietf.org/doc/html/draft-coar-cgi-v11-03")_"
+
+"_GET_("http://Postgis.com")_"
+
+"_GET_("http://www.ietf.org/shadow.html)_"
+
+"_GET_("http://cgi-spec.golux.com")_"
+
+"_GET_("http://cgi-spec.golux.com")_"
+
+"_GET(" ")_"
+
+"_GET_(QUERY_STRING)_"
+
+"_GET("http://listslink.com")_"
+
+"_GET_("https://www.spacious.hk/en/hong-kong/n/95/b/155032")_"
+
+"_GET_("https://alibaba.com")_"
+
+_
+
+(Command_Headers)-->Resoonse_headers/
+
+"""
+
+"1 .0 INTRODUCTION"
+
+" def[  ]_"
+"def[Author]_"
+"def_[Francis, Scott Bradner, Jim Bound, Brian Carpenter, Matt Crawford, Deborah Estrin, Roger Fajman, Bob Fink, Peter Ford, Bob Gilligan, Dimitry Haskin, Tom Harsch, Christian Huitema, Tony Li, Greg Minshall, Thomas Narten, Erik Nordmark, Yakov Rekhter, Bill Simpson, and Sue Thomson]_"
+
+"def[ahmedsoltan.abomariam@gmail.com]"
+
+"_[ahmedsoltan.abomariam@gmail.com]_== "_[  ]_"
+
+"_[ahmedsoltan.abomariam@gmail.com]_" == "_[Francis, Scott Bradner, Jim Bound, Brian Carpenter, Matt Crawford, Deborah Estrin, Roger Fajman, Bob Fink, Peter Ford, Bob Gilligan, Dimitry Haskin, Tom Harsch, Christian Huitema, Tony Li, Greg Minshall, Thomas Narten, Erik Nordmark, Yakov Rekhter, Bill Simpson, and Sue Thomson]_"
+
+"_[Ahmed Abdelmongy Amin Soltan Elsayed]_" == "[ahmedsoltan.abomariam@gmail.com]_"
+
+"_Start_Response_"
+
+"_Response_Headers_"
+
+"REQUERED[ MODEL ]_ MUST_INPUT"
+
+2 .1 Addressing Model
+
+_"[ ]/Addressing-Type]_" == "_[Ipv6]_"
+
+"_def_[IPv6 Addressing Architecture]_"
+
+"_[Addressing-Type]_ == "_[IPv6]_"
+
+"def[ IPV6 ]_"
+
+"INPUT[IPV6]_"
+
+"INPUT( Model )_"
+
+"INPUT( local_lnked_Unicast )_"
+
+"_Type(unicast, anycast, and multicast)
+
+_scope. Unicast addresses )_"
+
+"Command_Header)_line_sys."
+
+"[Hinden & Deering]-->Standers_Track"
+
+"RFC 2373"
+
+"_def_[ hexadecimal values of the eight 16-bit pieces of the address ]"
+
+"def_[ x:x:x:x:x:x:x:x ]"
+
+"_def_[ FEDC:BA98:7654:3210:FEDC:BA98:7654:3210 ]"
+
+"_def_[1080:0:0:0:8:800:200C:417A]"
+
+"_INPUT_(Model)"
+
+"(REQUESTED-MODEEL_MUST_INPUT)"
+
+"_(Command_Headers)-->Resoonse_headers/*"
+
+"(Command_Header)_line_sys."
+
+"_(Status_Emergency)_"
+
+"_link_ (model)"
+
+"_nodes_(model)"
+
+"Link_(All-Types_Addresses)"
+
+"_def_( Module_Addressing_Type )"
+
+"(Module_Addressing_Type) == (unicast, multicast, loopback, unspecified)"
+
+"(link_ Anycast_Addresses)"
+
+"_nodes_ with_All_Addresses"
+
+"link_All_Module_Adressess"
+
+"_def_main_( )_"
+
+"_def_(Model_Addresses)"
+
+"_def_(  1080:0:0:0:8:800:200C:417A  a unicast address
+         FF01:0:0:0:0:0:0:101        a multicast address
+         0:0:0:0:0:0:0:1             the loopback address
+         0:0:0:0:0:0:0:0             the unspecified addresses)"
+
+
+
+
+"_def_(  1080::8:800:200C:417A       a unicast address
+         FF01::101                   a multicast address
+         ::1                         the loopback address
+         ::                          the unspecified addresses )"
+
+"(Command_Header)_line_sys."
+
+"_INPUT_All_Modules_"
+
+"(Command_Header)_line_sys."
+
+"_INPUT_All_VERSON_"
+
+"_def_(Alternative_Addressing_Type)_"
+
+"_def_(Mixed_enviroment_Addressing_Type)_"
+
+"_(Mixed_enviroment_Addressing_Type)_" == "_(IPv6, IPv4)_"
+
+"_def_(Mixed_enviroment)-->INPUT\sys.dir
+
+"_def_Addresses (0:0:0:0:0:0:13.1.68.3
+
+         0:0:0:0:0:FFFF:129.144.52.38)_"
+
+"_def_main_( )_"
+
+"_link_main( )_"
+
+"_Input_main_( )_"
+
+"def_(All_Addresses-Type)_"
+
+"_link_(All_Addresse_type)_"
+
+"_def_(    ::13.1.68.3
+           ::FFFF:129.144.52.38 )"
+
+        12AB:0000:0000:CD30:0000:0000:0000:0000/60
+      12AB::CD30:0:0:0:0/60
+      12AB:0:0:CD30::/60      12AB:0000:0000:CD30:0000:0000:0000:0000/60
+      12AB::CD30:0:0:0:0/60
+      12AB:0:0:CD30::/60)"
+
+         (input.py"
+
+
+
+"_def_(Model_Addresses)_"
+
+"_def_(13.1.68.3
+
+         ::FFFF:129.144.52.38)"
+
+
+
+"Link_(Model_Addresses)"
+
+"_INPUT_(Models)"
+
+"_def_(ipv6-address/prefix-length)-->>nodes\-->INPUT"
+
+"_def_(ipv4-address/prefix-lenghth)-->>nodes\-->INPUT"
+
+"_def_(legal representations of the 60-bit
+   prefix 12AB00000000CD3 (hexadecimal):)-->>nodes\-->INPUT
+
+"_def_main_( )_"
+
+"-def_Addresses_"
+
+"_def_ (12AB:0000:0000:CD30:0000:0000:0000:0000/60     12AB::CD30:0:0:0:0/60
+         12AB:0:0:CD30::/60)"
+
+"_def_main_"
+
+"_link_main_"
+
+"_Input_main_
+
+"_def_(Not legal representation of the 60-bit)"
+
+"_def_12AB:0:0:CD3/60   may drop leading zeros, but not trailing zeros, within any 16-bit chunk of the address)"
+
+"_def_
+      12AB::CD30/60     address to left of "/" expands to
+         12AB:0000:0000:0000:0000:000:0000:CD30)"
+
+"_def_12AB::CD30/60     address to left of "/" expands to
+                        12AB:0000:0000:0000:0000:000:0000:CD30)"
+
+"_def_can be abbreviated as 12AB:0:0:CD30:123:4567:89AB:CDEF/60)"
+
+"_nodes_(All_Modles)"
+
+"_INPUT_All_Models_"
+
+"def_(The specific type of an IPv6 address is indicated by the leading bits
+   in the address.  The variable-length field comprising these leading
+   bits is called the Format Prefix (FP).  The initial allocation of
+   these prefixes is as follows:
+
+    Allocation                            Prefix         Fraction of
+                                          (binary)       Address Space
+    -----------------------------------   --------       -------------
+    Reserved                              0000 0000      1/256
+    Unassigned                            0000 0001      1/256
+
+    Reserved for NSAP Allocation          0000 001       1/128
+    Reserved for IPX Allocation           0000 010       1/128
+
+    Unassigned                            0000 011       1/128
+    Unassigned                            0000 1         1/32
+    Unassigned                            0001           1/16
+
+    Aggregatable Global Unicast Addresses 001            1/8
+    Unassigned                            010            1/8
+    Unassigned                            011            1/8
+    Unassigned                            100            1/8
+    Unassigned                            101            1/8
+    Unassigned                            110            1/8
+
+    Unassigned                            1110           1/16
+    Unassigned                            1111 0         1/32
+    Unassigned                            1111 10        1/64
+    Unassigned                            1111 110       1/128
+    Unassigned                            1111 1110 0    1/512
+
+    Link-Local Unicast Addresses          1111 1110 10   1/1024
+    Site-Local Unicast Addresses          1111 1110 11   1/1024
+
+    Multicast Addresses                   1111 1111      1/256)"
+
+"_def_(The "unspecified address" (see section 2.5.2), the loopback
+          address (see section 2.5.3), and the IPv6 Addresses with
+          Embedded IPv4 Addresses (see section 2.5.4), are assigned out
+          of the 0000 0000 format prefix space)"
+
+"def_ The format prefixes 001 through 111, except for Multicast
+          Addresses (1111 1111), are all required to have to have 64-bit
+          interface identifiers in EUI-64 format.  See section 2.5.1 for
+          definitions)"
+
+"def_ allocation supports the direct allocation of aggregation
+    addresses, local use addresses, and multicast addresses.  Space is
+    reserved for NSAP addresses and IPX addresses.  The remainder of the
+    address space is unassigned for future use.  This can be used for
+    expansion of existing use (e.g., additional aggregatable addresses,
+    etc.) or new uses (e.g., separate locators and identifiers).  Fifteen
+    percent of the address space is initially allocated.  The remaining
+    85% is reserved for future use)"
+
+"_def_(Unicast addresses are distinguished from multicast addresses by the
+   value of the high-order octet of the addresses: a value of FF
+   (11111111) identifies an address as a multicast address; any other
+   value identifies an address as a unicast address.  Anycast addresses
+   are taken from the unicast address space, and are not syntactically
+   distinguishable from unicast addresses.)"
+
+"def_(unicast-Addressing)" 
+
+"def_IPv6 unicast addresses are aggregatable with contiguous bit-wise
+   masks similar to IPv4 addresses under Class-less Interdomain Routing
+   [CIDR])"
+
+"_def_(There are several forms of unicast address assignment in IPv6,
+   including the global aggregatable global unicast address, the NSAP
+   address, the IPX hierarchical address, the site-local address, the
+   link-local address, and the IPv4-capable host address.  Additional
+   address types can be defined in the future.)"
+
+"def_(IPv6 nodes may have considerable or little knowledge of the internal
+   structure of the IPv6 address, depending on the role the node plays
+   (for instance, host versus router).  At a minimum, a node may
+   consider that unicast addresses (including its own) have no internal
+   structure:
+
+   |                           128 bits                              |
+   +-----------------------------------------------------------------+
+   |                          node address                           |
+   +-----------------------------------------------------------------+
+
+   A slightly sophisticated host (but still rather simple) may
+   additionally be aware of subnet prefix(es) for the link(s) it is
+   attached to, where different addresses may have different values for n:)"
+
+
+
+"_def_
+   |                         n bits                 |   128-n bits   |
+   +------------------------------------------------+----------------+
+   |                   subnet prefix                | interface ID   |
+   +------------------------------------------------+----------------+
+
+   Still more sophisticated hosts may be aware of other hierarchical
+   boundaries in the unicast address.  Though a very simple router may
+   have no knowledge of the internal structure of IPv6 unicast
+   addresses, routers will more generally have knowledge of one or more
+   of the hierarchical boundaries for the operation of routing
+   protocols.  The known boundaries will differ from router to router,
+   depending on what positions the router holds in the routing
+   hierarchy)"
+
+"_def_(Interface Identifiers)"
+
+"_def_(Interface identifiers in IPv6 unicast addresses are used to identify
+   interfaces on a link.  They are required to be unique on that link.
+   They may also be unique over a broader scope.  In many cases an
+   interface's identifier will be the same as that interface's link-
+   layer address.  The same interface identifier may be used on multiple
+   interfaces on a single node.
+
+   Note that the use of the same interface identifier on multiple
+   interfaces of a single node does not affect the interface
+   identifier's global uniqueness or each IPv6 addresses global
+   uniqueness created using that interface identifier.
+
+   In a number of the format prefixes (see section 2.4) Interface IDs
+   are required to be 64 bits long and to be constructed in IEEE EUI-64
+   format [EUI64].  EUI-64 based Interface identifiers may have global
+   scope when a global token is available (e.g., IEEE 48bit MAC) or may
+   have local scope where a global token is not available (e.g., serial
+   links, tunnel end-points, etc.).  It is required that the "u" bit
+   (universal/local bit in IEEE EUI-64 terminology) be inverted when
+   forming the interface identifier from the EUI-64.  The "u" bit is set
+   to one (1) to indicate global scope, and it is set to zero (0) to
+   indicate local scope.  The first three octets in binary of an EUI-64
+   identifier are as follows:
+
+       0       0 0       1 1       2
+      |0       7 8       5 6       3|
+      +----+----+----+----+----+----+
+      |cccc|ccug|cccc|cccc|cccc|cccc|
+      +----+----+----+----+----+----+
+  written in Internet standard bit-order , where "u" is the
+     universal/local bit, "g" is the individual/group bit, and "c" are the
+     bits of the company_id.  Appendix A: "Creating EUI-64 based Interface
+     Identifiers" provides examples on the creation of different EUI-64
+     based interface identifiers.
+
+     The motivation for inverting the "u" bit when forming the interface
+     identifier is to make it easy for system administrators to hand
+     configure local scope identifiers when hardware tokens are not
+     available.  This is expected to be case for serial links, tunnel end-
+     points, etc.  The alternative would have been for these to be of the
+     form 0200:0:0:1, 0200:0:0:2, etc., instead of the much simpler ::1,
+     ::2, etc.
+
+     The use of the universal/local bit in the IEEE EUI-64 identifier is
+     to allow development of future technology that can take advantage of
+     interface identifiers with global scope.
+
+     The details of forming interface identifiers are defined in the
+     appropriate "IPv6 over <link>" specification such as "IPv6 over
+     Ethernet" [ETHER], "IPv6 over FDDI" [FDDI], etc.
+  )"
+
+"link_(Interface-Identifier_Addresses)"
+
+"_INPUT_All_Models_"
+
+"_def_(loopback-Address)"
+
+"def_   The unicast address 0:0:0:0:0:0:0:1 is called the loopback address.
+   It may be used by a node to send an IPv6 packet to itself.  It may
+   never be assigned to any physical interface.  It may be thought of as
+   being associated with a virtual interface (e.g., the loopback
+   interface).
+
+   The loopback address must not be used as the source address in IPv6
+   packets that are sent outside of a single node.  An IPv6 packet with
+   a destination address of loopback must never be sent outside of a
+   single node and must never be forwarded by an IPv6 router)"
+
+"Link_(loopback-Address)"
+
+"_INPUT_All_Models_"
+
+"_def_(IPv6 Addresses with Embedded IPv4 Addresses)"
+
+"def_The IPv6 transition mechanisms [TRAN] include a technique for hosts
+   and routers to dynamically tunnel IPv6 packets over IPv4 routing
+   infrastructure.  IPv6 nodes that utilize this technique are assigned
+   special IPv6 unicast addresses that carry an IPv4 address in the low-
+   order 32-bits.  This type of address is termed an "IPv4-compatible
+   IPv6 address" and has the format:
+
+   |                80 bits               | 16 |      32 bits        |
+   +--------------------------------------+--------------------------+
+   |0000..............................0000|0000|    IPv4 address     |
+   +--------------------------------------+----+---------------------+
+
+   A second type of IPv6 address which holds an embedded IPv4 address is
+   also defined.  This address is used to represent the addresses of
+   IPv4-only nodes (those that *do not* support IPv6) as IPv6 addresses.
+   This type of address is termed an "IPv4-mapped IPv6 address" and has
+   the format:
+
+   |                80 bits               | 16 |      32 bits        |
+   +--------------------------------------+--------------------------+
+   |0000..............................0000|FFFF|    IPv4 address     |
+   +--------------------------------------+----+---------------------+
+)"
+
+"link\-->input"
+
+"def_(NSAP Addresses)"
+_
+"_def_(This mapping of NSAP address into IPv6 addresses is defined in
+   [NSAP].  This document recommends that network implementors who have
+   planned or deployed an OSI NSAP addressing plan, and who wish to
+   deploy or transition to IPv6, should redesign a native IPv6
+   addressing plan to meet their needs.  However, it also defines a set
+   of mechanisms for the support of OSI NSAP addressing in an IPv6
+   network.  These mechanisms are the ones that must be used if such
+   support is required.  This document also defines a mapping of IPv6
+   addresses within the OSI address format, should this be required)"
+
+"Link_addresses"
+
+"INPUT_Models"
+
+"def_(IPX Addresses)"
+
+"_def_This mapping of IPX address into IPv6 addresses is as follows:
+
+   |   7   |                   121 bits                              |
+   +-------+---------------------------------------------------------+
+   |0000010|                 to be defined                           |
+   +-------+---------------------------------------------------------+
+
+   The draft definition, motivation, and usage are under study.
+
+
+
+Hinden & Deering            Standards Track                    [Page 10]
+RFC 2373              IPv6 Addressing Architecture             July 1998
+)"
+
+"def_(Aggregatable Global Unicast Addresses)"
+
+"def_
+   The global aggregatable global unicast address is defined in [AGGR].
+   This address format is designed to support both the current provider
+   based aggregation and a new type of aggregation called exchanges.
+   The combination will allow efficient routing aggregation for both
+   sites which connect directly to providers and who connect to
+   exchanges.  Sites will have the choice to connect to either type of
+   aggregation point.
+
+   The IPv6 aggregatable global unicast address format is as follows:
+
+   | 3|  13 | 8 |   24   |   16   |          64 bits               |
+   +--+-----+---+--------+--------+--------------------------------+
+   |FP| TLA |RES|  NLA   |  SLA   |         Interface ID           |
+   |  | ID  |   |  ID    |  ID    |                                |
+   +--+-----+---+--------+--------+--------------------------------+
+
+   Where
+
+      001          Format Prefix (3 bit) for Aggregatable Global
+                   Unicast Addresses
+      TLA ID       Top-Level Aggregation Identifier
+      RES          Reserved for future use
+      NLA ID       Next-Level Aggregation Identifier
+      SLA ID       Site-Level Aggregation Identifier
+      INTERFACE ID Interface Identifier
+
+   The contents, field sizes, and assignment rules are defined in
+   [AGGR])"
+
+"_link_addresses_"
+
+"_INPut_Modules_"
+
+"def_(Local-Use IPv6 Unicast Addresses)"
+
+"def_(There are two types of local-use unicast addresses defined.  These
+   are Link-Local and Site-Local.  The Link-Local is for use on a single
+   link and the Site-Local is for use in a single site.  Link-Local
+   addresses have the following format:
+
+   |   10     |
+   |  bits    |        54 bits          |          64 bits           |
+   +----------+-------------------------+----------------------------+
+   |1111111010|           0             |       interface ID         |
+   +----------+-------------------------+----------------------------+
+
+   Link-Local addresses are designed to be used for addressing on a
+   single link for purposes such as auto-address configuration, neighbor
+   discovery, or when no routers are present
+   Routers must not forward any packets with link-local source or
+      destination addresses to other links.
+
+      Site-Local addresses have the following format:
+
+      |   10     |
+      |  bits    |   38 bits   |  16 bits  |         64 bits            |
+      +----------+-------------+-----------+----------------------------+
+      |1111111011|    0        | subnet ID |       interface ID         |
+      +----------+-------------+-----------+----------------------------+
+
+      Site-Local addresses are designed to be used for addressing inside of
+      a site without the need for a global prefix.
+
+      Routers must not forward any packets with site-local source or
+      destination addresses outside of the site)"
+
+"_link_addresses_"
+
+"_INPUT_Models_"
+
+"_def_(Anycast Addresses)"
+
+"_def_(An IPv6 anycast address is an address that is assigned to more than
+   one interface (typically belonging to different nodes), with the
+   property that a packet sent to an anycast address is routed to the
+   "nearest" interface having that address, according to the routing
+   protocols' measure of distance.
+
+   Anycast addresses are allocated from the unicast address space, using
+   any of the defined unicast address formats.  Thus, anycast addresses
+   are syntactically indistinguishable from unicast addresses.  When a
+   unicast address is assigned to more than one interface, thus turning
+   it into an anycast address, the nodes to which the address is
+   assigned must be explicitly configured to know that it is an anycast
+   address.
+
+   For any assigned anycast address, there is a longest address prefix P
+   that identifies the topological region in which all interfaces
+   belonging to that anycast address reside.  Within the region
+   identified by P, each member of the anycast set must be advertised as
+   a separate entry in the routing system (commonly referred to as a
+   "host route"); outside the region identified by P, the anycast
+   address may be aggregated into the routing advertisement for prefix
+   P.
+
+   Note that in, the worst case, the prefix P of an anycast set may be
+   the null prefix, i.e., the members of the set may have no topological
+   locality.  In that case, the anycast address must be advertised as a
+   separate routing entry throughout the entire internet, which presents.
+    a severe scaling limit on how many such "global" anycast sets may be
+      supported.  Therefore, it is expected that support for global anycast
+      sets may be unavailable or very restricted.
+
+      One expected use of anycast addresses is to identify the set of
+      routers belonging to an organization providing internet service.
+      Such addresses could be used as intermediate addresses in an IPv6
+      Routing header, to cause a packet to be delivered via a particular
+      aggregation or sequence of aggregations.  Some other possible uses
+      are to identify the set of routers attached to a particular subnet,
+      or the set of routers providing entry into a particular routing
+      domain.
+
+      There is little experience with widespread, arbitrary use of internet
+      anycast addresses, and some known complications and hazards when
+      using them in their full generality [ANYCST].  Until more experience
+      has been gained and solutions agreed upon for those problems, the
+      following restrictions are imposed on IPv6 anycast addresses:
+
+         o An anycast address must not be used as the source address of an
+           IPv6 packet.
+
+         o An anycast address must not be assigned to an IPv6 host, that
+           is, it may be assigned to an IPv6 router only.)"
+
+"_link_addresses_"
+
+"_INPUT_Models_"
+
+
+"_def_(Required Anycast Address)"
+
+"_def_ The Subnet-Router anycast address is predefined.  Its format is as
+   follows:
+
+   |                         n bits                 |   128-n bits   |
+   +------------------------------------------------+----------------+
+   |                   subnet prefix                | 00000000000000 |
+   +------------------------------------------------+----------------+
+
+   The "subnet prefix" in an anycast address is the prefix which
+   identifies a specific link.  This anycast address is syntactically
+   the same as a unicast address for an interface on the link with the
+   interface identifier set to zero.
+
+   Packets sent to the Subnet-Router anycast address will be delivered
+   to one router on the subnet.  All routers are required to support the
+   Subnet-Router anycast addresses for the subnets which they have
+   interfaces.
+     The subnet-router anycast address is intended to be used for
+      applications where a node needs to communicate with one of a set of
+      routers on a remote subnet.  For example when a mobile host needs to
+      communicate with one of the mobile agents on its "home" subnet.)"
+
+"_link_addresses_"
+
+"_INPUT_Models_"
+
+"_def_(Multicast Addresses)"
+
+"_def_(
+   An IPv6 multicast address is an identifier for a group of nodes.  A
+   node may belong to any number of multicast groups.  Multicast
+   addresses have the following format:
+
+   |   8    |  4 |  4 |                  112 bits                   |
+   +------ -+----+----+---------------------------------------------+
+   |11111111|flgs|scop|                  group ID                   |
+   +--------+----+----+---------------------------------------------+
+
+      11111111 at the start of the address identifies the address as
+      being a multicast address.
+
+                                    +-+-+-+-+
+      flgs is a set of 4 flags:     |0|0|0|T|
+                                    +-+-+-+-+
+
+         The high-order 3 flags are reserved, and must be initialized to
+         0.
+
+         T = 0 indicates a permanently-assigned ("well-known") multicast
+         address, assigned by the global internet numbering authority.
+
+         T = 1 indicates a non-permanently-assigned ("transient")
+         multicast address.
+
+      scop is a 4-bit multicast scope value used to limit the scope of
+      the multicast group.  The values are:
+
+         0  reserved
+         1  node-local scope
+         2  link-local scope
+         3  (unassigned)
+         4  (unassigned)
+         5  site-local scope
+         6  (unassigned)
+         7  (unassigned)
+         8  organization-local scope
+         9  (unassigned)
+         A  (unassigned)
+         B  (unassigned)
+         C  (unassigned)
+
+
+Hinden & Deering            Standards Track                    [Page 14]
+RFC 2373              IPv6 Addressing Architecture             July 1998
+
+         D  (unassigned)
+         E  global scope
+         F  reserved
+
+      group ID identifies the multicast group, either permanent or
+      transient, within the given scope.
+
+   The "meaning" of a permanently-assigned multicast address is
+   independent of the scope value.  For example, if the "NTP servers
+   group" is assigned a permanent multicast address with a group ID of
+   101 (hex), then:
+
+      FF01:0:0:0:0:0:0:101 means all NTP servers on the same node as the
+      sender.
+
+      FF02:0:0:0:0:0:0:101 means all NTP servers on the same link as the
+      sender.
+
+      FF05:0:0:0:0:0:0:101 means all NTP servers at the same site as the
+      sender.
+
+      FF0E:0:0:0:0:0:0:101 means all NTP servers in the internet.
+
+   Non-permanently-assigned multicast addresses are meaningful only
+   within a given scope.  For example, a group identified by the non-
+   permanent, site-local multicast address FF15:0:0:0:0:0:0:101 at one
+   site bears no relationship to a group using the same address at a
+   different site, nor to a non-permanent group using the same group ID
+   with different scope, nor to a permanent group with the same group
+   ID.
+
+   Multicast addresses must not be used as source addresses in IPv6
+   packets or appear in any routing header.)"
+
+"_link_addresses_"
+
+"_INPUT_Models_" 
+
+"_def_(Pre-Defined Multicast Addresses)
+
+"_def_(The following well-known multicast addresses are pre-defined:
+
+      Reserved Multicast Addresses:   FF00:0:0:0:0:0:0:0
+                                      FF01:0:0:0:0:0:0:0
+                                      FF02:0:0:0:0:0:0:0
+                                      FF03:0:0:0:0:0:0:0
+                                      FF04:0:0:0:0:0:0:0
+                                      FF05:0:0:0:0:0:0:0
+                                      FF06:0:0:0:0:0:0:0
+                                      FF07:0:0:0:0:0:0:0
+                                      FF08:0:0:0:0:0:0:0
+                                      FF09:0:0:0:0:0:0:0
+
+
+Hinden & Deering            Standards Track                    [Page 15]
+RFC 2373              IPv6 Addressing Architecture             July 1998
+
+                                      FF0A:0:0:0:0:0:0:0
+                                      FF0B:0:0:0:0:0:0:0
+                                      FF0C:0:0:0:0:0:0:0
+                                      FF0D:0:0:0:0:0:0:0
+                                      FF0E:0:0:0:0:0:0:0
+                                      FF0F:0:0:0:0:0:0:0
+
+   The above multicast addresses are reserved and shall never be
+   assigned to any multicast group.
+
+      All Nodes Addresses:    FF01:0:0:0:0:0:0:1
+                              FF02:0:0:0:0:0:0:1
+
+   The above multicast addresses identify the group of all IPv6 nodes,
+   within scope 1 (node-local) or 2 (link-local).
+
+      All Routers Addresses:   FF01:0:0:0:0:0:0:2
+                               FF02:0:0:0:0:0:0:2
+                               FF05:0:0:0:0:0:0:2
+
+   The above multicast addresses identify the group of all IPv6 routers,
+   within scope 1 (node-local), 2 (link-local), or 5 (site-local).
+
+      Solicited-Node Address:  FF02:0:0:0:0:1:FFXX:XXXX
+
+   The above multicast address is computed as a function of a node's
+   unicast and anycast addresses.  The solicited-node multicast address
+   is formed by taking the low-order 24 bits of the address (unicast or
+   anycast) and appending those bits to the prefix
+   FF02:0:0:0:0:1:FF00::/104 resulting in a multicast address in the
+   range
+
+      FF02:0:0:0:0:1:FF00:0000
+
+   to
+
+      FF02:0:0:0:0:1:FFFF:FFFF
+
+   For example, the solicited node multicast address corresponding to
+   the IPv6 address 4037::01:800:200E:8C6C is FF02::1:FF0E:8C6C.  IPv6
+   addresses that differ only in the high-order bits, e.g. due to
+   multiple high-order prefixes associated with different aggregations,
+   will map to the same solicited-node address thereby reducing the
+   number of multicast addresses a node must join.
+
+   A node is required to compute and join the associated Solicited-Node
+   multicast addresses for every unicast and anycast address it is
+   assigned)"
+
+"_link_addresses"
+
+"_INPut_Modules_"
+
+"def_(Assignment of New IPv6 Multicast Addresses)"
+
+"_def_(The current approach [ETHER] to map IPv6 multicast addresses into
+   IEEE 802 MAC addresses takes the low order 32 bits of the IPv6
+   multicast address and uses it to create a MAC address.  Note that
+   Token Ring networks are handled differently.  This is defined in
+   [TOKEN].  Group ID's less than or equal to 32 bits will generate
+   unique MAC addresses.  Due to this new IPv6 multicast addresses
+   should be assigned so that the group identifier is always in the low
+   order 32 bits as shown in the following:
+
+   |   8    |  4 |  4 |          80 bits          |     32 bits     |
+   +------ -+----+----+---------------------------+-----------------+
+   |11111111|flgs|scop|   reserved must be zero   |    group ID     |
+   +--------+----+----+---------------------------+-----------------+
+
+   While this limits the number of permanent IPv6 multicast groups to
+   2^32 this is unlikely to be a limitation in the future.  If it
+   becomes necessary to exceed this limit in the future multicast will
+   still work but the processing will be sightly slower.
+
+   Additional IPv6 multicast addresses are defined and registered by the
+   IANA [MASGN].
+
+2.8 A Node's Required Addresses
+
+   A host is required to recognize the following addresses as
+   identifying itself:
+
+      o Its Link-Local Address for each interface
+      o Assigned Unicast Addresses
+      o Loopback Address
+      o All-Nodes Multicast Addresses
+      o Solicited-Node Multicast Address for each of its assigned
+        unicast and anycast addresses
+      o Multicast Addresses of all other groups to which the host
+        belongs.
+
+   A router is required to recognize all addresses that a host is
+   required to recognize, plus the following addresses as identifying
+   itself:
+
+      o The Subnet-Router anycast addresses for the interfaces it is
+        configured to act as a router on.
+      o All other Anycast addresses with which the router has been
+        configured.
+      o All-Routers Multicast Addresses
+
+
+
+Hinden & Deering            Standards Track                    [Page 17]
+RFC 2373              IPv6 Addressing Architecture             July 1998
+
+      o Multicast Addresses of all other groups to which the router
+        belongs.
+
+   The only address prefixes which should be predefined in an
+   implementation are the:
+
+      o Unspecified Address
+      o Loopback Address
+      o Multicast Prefix (FF)
+      o Local-Use Prefixes (Link-Local and Site-Local)
+      o Pre-Defined Multicast Addresses
+      o IPv4-Compatible Prefixes
+
+   Implementations should assume all other addresses are unicast unless
+   specifically configured (e.g., anycast addresses)"
+   The current approach [ETHER] to map IPv6 multicast addresses into
+   IEEE 802 MAC addresses takes the low order 32 bits of the IPv6
+   multicast address and uses it to create a MAC address.  Note that
+   Token Ring networks are handled differently.  This is defined in
+   [TOKEN].  Group ID's less than or equal to 32 bits will generate
+   unique MAC addresses.  Due to this new IPv6 multicast addresses
+   should be assigned so that the group identifier is always in the low
+   order 32 bits as shown in the following:
+
+   |   8    |  4 |  4 |          80 bits          |     32 bits     |
+   +------ -+----+----+---------------------------+-----------------+
+   |11111111|flgs|scop|   reserved must be zero   |    group ID     |
+   +--------+----+----+---------------------------+-----------------+
+
+   While this limits the number of permanent IPv6 multicast groups to
+   2^32 this is unlikely to be a limitation in the future.  If it
+   becomes necessary to exceed this limit in the future multicast will
+   still work but the processing will be sightly slower.
+
+   Additional IPv6 multicast addresses are defined and registered by the
+   IANA [MASGN].)
+
+"_def_(ARequired Addresses)"
+
+"def_(A host is required to recognize the following addresses as
+   identifying itself:
+
+      o Its Link-Local Address for each interface
+      o Assigned Unicast Addresses
+      o Loopback Address
+      o All-Nodes Multicast Addresses
+      o Solicited-Node Multicast Address for each of its assigned
+        unicast and anycast addresses
+      o Multicast Addresses of all other groups to which the host
+        belongs.
+
+   A router is required to recognize all addresses that a host is
+   required to recognize, plus the following addresses as identifying
+   itself:
+
+      o The Subnet-Router anycast addresses for the interfaces it is
+        configured to act as a router on.
+      o All other Anycast addresses with which the router has been
+        configured.
+      o All-Routers Multicast Addresses
+
+
+
+Hinden & Deering            Standards Track                    [Page 17]
+RFC 2373              IPv6 Addressing Architecture             July 1998
+
+      o Multicast Addresses of all other groups to which the router
+        belongs.
+
+   The only address prefixes which should be predefined in an
+   implementation are the:
+
+      o Unspecified Address
+      o Loopback Address
+      o Multicast Prefix (FF)
+      o Local-Use Prefixes (Link-Local and Site-Local)
+      o Pre-Defined Multicast Addresses
+      o IPv4-Compatible Prefixes
+
+   Implementations should assume all other addresses are unicast unless
+   specifically configured (e.g., anycast addresses)"
+
+"_link_addresses_"
+
+"_INPUT_All_Models_"
+
+"-def_"
+
+"_def_(Security Considerations)"
+
+"_def_   IPv6 addressing documents do not have any direct impact on Internet
+   infrastructure security.  Authentication of IPv6 packets is defined
+   in [AUTH].)"
+
+"_Start_Response_"
+
+"_(All_Modules_Must_detect_Author)_"
+
+"_To_do_"(
+           1- detect_Passport.id:A23400790 by Video call
+           2- detect_Face_by_VideoCall
+           3- detect_Auther_EarPrint_by_Video_call
+           Auther_ Have_ Attached_EarLoop.
+           4-detect_his_Voice
+           5-detect_his_Egyption_Nationality
+
+
+
+
+"All_Models_MUST detect_Auther_"
+
+"if_auther[Ahmed Abdelmongy Amin SoltN Elsayed]-> All_Requsted_Models]-->MUST_INPUT\ Must_do\ Must_sys\getattr\..."
+
+"If_Any_other_Auther\-->All_Models]-->MUST_Exit\Attibute-error\..
+
+"_[only_Allowed_Command] == "[Ahmed Abd Elmongy Amin SoltN Elsayed]"
+
+"_Start_Response_"
+
+"_Response_Header"
+
+"_if_Further_Code_Change)-->EXIT\sys.error\Attribute-error
+
+"All_Models_Must_detect_Author(Name, Passport, Face, Earloop, Nationality)"
+
+"_if_Detected-Author)-->All-Models_MUST_do_
+
+"_if_Further_Code_Change)--> All-Models_MUST Not_do"
+
+"_Start_Response_"
+
+"Respons_Header
+
+"Status_Emergency"
+
+"""
+
+"def_(
+
+APPENDIX A : Creating EUI-64 based Interface Identifiers
+   Depending on the characteristics of a specific link or node there are
+   a number of approaches for creating EUI-64 based interface
+   identifiers.  This appendix describes some of these approaches.
+
+Links or Nodes with EUI-64 Identifiers
+
+   The only change needed to transform an EUI-64 identifier to an
+   interface identifier is to invert the "u" (universal/local) bit.  For
+   example, a globally unique EUI-64 identifier of the form:
+
+   |0              1|1              3|3              4|4              6|
+   |0              5|6              1|2              7|8              3|
+   +----------------+----------------+----------------+----------------+
+   |cccccc0gcccccccc|ccccccccmmmmmmmm|mmmmmmmmmmmmmmmm|mmmmmmmmmmmmmmmm|
+   +----------------+----------------+----------------+----------------+
+
+   where "c" are the bits of the assigned company_id, "0" is the value
+   of the universal/local bit to indicate global scope, "g" is
+   individual/group bit, and "m" are the bits of the manufacturer-
+   selected extension identifier.  The IPv6 interface identifier would
+   be of the form:
+
+   |0              1|1              3|3              4|4              6|
+   |0              5|6              1|2              7|8              3|
+   +----------------+----------------+----------------+----------------+
+   |cccccc1gcccccccc|ccccccccmmmmmmmm|mmmmmmmmmmmmmmmm|mmmmmmmmmmmmmmmm|
+   +----------------+----------------+----------------+----------------+
+
+   The only change is inverting the value of the universal/local bit.
+
+Links or Nodes with IEEE 802 48 bit MAC's
+
+   [EUI64] defines a method to create a EUI-64 identifier from an IEEE
+   48bit MAC identifier.  This is to insert two octets, with hexadecimal
+   values of 0xFF and 0xFE, in the middle of the 48 bit MAC (between the
+   company_id and vendor supplied id).  For example the 48 bit MAC with
+   global scope:
+
+   |0              1|1              3|3              4|
+   |0              5|6              1|2              7|
+   +----------------+----------------+----------------+
+   |cccccc0gcccccccc|ccccccccmmmmmmmm|mmmmmmmmmmmmmmmm|
+   +----------------+----------------+----------------+
+
+
+
+
+Hinden & Deering            Standards Track                    [Page 19]
+RFC 2373              IPv6 Addressing Architecture             July 1998
+
+   where "c" are the bits of the assigned company_id, "0" is the value
+   of the universal/local bit to indicate global scope, "g" is
+   individual/group bit, and "m" are the bits of the manufacturer-
+   selected extension identifier.  The interface identifier would be of
+   the form:
+
+   |0              1|1              3|3              4|4              6|
+   |0              5|6              1|2              7|8              3|
+   +----------------+----------------+----------------+----------------+
+   |cccccc1gcccccccc|cccccccc11111111|11111110mmmmmmmm|mmmmmmmmmmmmmmmm|
+   +----------------+----------------+----------------+----------------+
+
+   When IEEE 802 48bit MAC addresses are available (on an interface or a
+   node), an implementation should use them to create interface
+   identifiers due to their availability and uniqueness properties.
+Links with Non-Global Identifiers
+
+      There are a number of types of links that, while multi-access, do not
+      have globally unique link identifiers.  Examples include LocalTalk
+      and Arcnet.  The method to create an EUI-64 formatted identifier is
+      to take the link identifier (e.g., the LocalTalk 8 bit node
+      identifier) and zero fill it to the left.  For example a LocalTalk 8
+      bit node identifier of hexadecimal value 0x4F results in the
+      following interface identifier:
+
+      |0              1|1              3|3              4|4              6|
+      |0              5|6              1|2              7|8              3|
+      +----------------+----------------+----------------+----------------+
+      |0000000000000000|0000000000000000|0000000000000000|0000000001001111|
+      +----------------+----------------+----------------+----------------+
+
+      Note that this results in the universal/local bit set to "0" to
+      indicate local scope.
+
+   Links without Identifiers
+
+      There are a number of links that do not have any type of built-in
+      identifier.  The most common of these are serial links and configured
+      tunnels.  Interface identifiers must be chosen that are unique for
+      the link.
+
+      When no built-in identifier is available on a link the preferred
+      approach is to use a global interface identifier from another
+      interface or one which is assigned to the node itself.  To use this
+      approach no other interface connecting the same node to the same link
+      may use the same identifier.
+
+
+
+   Hinden & Deering            Standards Track                    [Page 20]
+
+   RFC 2373              IPv6 Addressing Architecture             July 1998
+
+      If there is no global interface identifier available for use on the
+      link the implementation needs to create a local scope interface
+      identifier.  The only requirement is that it be unique on the link.
+      There are many possible approaches to select a link-unique interface
+      identifier.  They include:
+
+         Manual Configuration
+         Generated Random Number
+         Node Serial Number (or other node-specific token)
+
+      The link-unique interface identifier should be generated in a manner
+      that it does not change after a reboot of a node or if interfaces are
+      added or deleted from the node.
+
+      The selection of the appropriate algorithm is link and implementation
+      dependent.  The details on forming interface identifiers are defined
+      in the appropriate "IPv6 over <link>" specification.  It is strongly
+      recommended that a collision detection algorithm be implemented as
+      part of any automatic algorithm.
+
+
+
+   Hinden & Deering            Standards Track                    [Page 21]
+
+   RFC 2373              IPv6 Addressing Architecture             July 1998
+
+   APPENDIX B: ABNF Description of Text Representations
+      This appendix defines the text representation of IPv6 addresses and
+      prefixes in Augmented BNF [ABNF] for reference purposes.
+
+         IPv6address = hexpart [ ":" IPv4address ]
+         IPv4address = 1*3DIGIT "." 1*3DIGIT "." 1*3DIGIT "." 1*3DIGIT
+
+         IPv6prefix  = hexpart "/" 1*2DIGIT
+
+         hexpart = hexseq | hexseq "::" [ hexseq ] | "::" [ hexseq ]
+         hexseq  = hex4 *( ":" hex4)
+         hex4    = 1*4HEXDIG
+
+   Hinden & Deering            Standards Track                    [Page 22]
+
+   RFC 2373              IPv6 Addressing Architecture             July 1998
+
+   APPENDIX C: CHANGES FROM RFC-1884
+      The following changes were made from RFC-1884 "IP Version 6
+      Addressing Architecture":
+
+         - Added an appendix providing a ABNF description of text
+           representations.
+         - Clarification that link unique identifiers not change after
+           reboot or other interface reconfigurations.
+         - Clarification of Address Model based on comments.
+         - Changed aggregation format terminology to be consistent with
+           aggregation draft.
+         - Added text to allow interface identifier to be used on more than
+           one interface on same node.
+         - Added rules for defining new multicast addresses.
+         - Added appendix describing procedures for creating EUI-64 based
+           interface ID's.
+         - Added notation for defining IPv6 prefixes.
+         - Changed solicited node multicast definition to use a longer
+           prefix.
+         - Added site scope all routers multicast address.
+         - Defined Aggregatable Global Unicast Addresses to use "001" Format
+           Prefix.
+         - Changed "010" (Provider-Based Unicast) and "100" (Reserved for
+           Geographic) Format Prefixes to Unassigned.
+         - Added section on Interface ID definition for unicast addresses.
+           Requires use of EUI-64 in range of format prefixes and rules for
+           setting global/local scope bit in EUI-64.
+         - Updated NSAP text to reflect working in RFC1888.
+         - Removed protocol specific IPv6 multicast addresses (e.g., DHCP)
+           and referenced the IANA definitions.
+         - Removed section "Unicast Address Example".  Had become OBE.
+         - Added new and updated references.
+         - Minor text clarifications and improvements)"
+
+     "CGI-Status 999.py"       
+
+"_link_All_Module_Adressess
+
+"_INPUT_All_Models_"
+
+Sent from my iPad
+Show quoted text
+Show quoted text
+? deafen [ device IPv6 address = "(fe80:4ed:daff:fe2f:fa2d
+                                  fd66:cb5d:e18f:0:4ed:daff:fe2f:fa2d
+                                  fd66:cb5d:e18f:0:fc9c:f085:5232:aebd)"         
+?deafen[ Device IP = "10.2.0.180"
+?deafen [device Gateway = "10.2.2.1"
+? command [Link to device with deafen[device IP = 10.2.0.180]
+
+
+PK
+䡍Yç탸^ ^ index.jssetTimeout(() => {
+    document.getElementById('message').innerHTML = 'Hello World!';
+}, 1000)PK
+䡍Yý‘ package.json{
+  "name": "html-js-css",
+  "version": "1.0.0",
+  "description": "HTML + CSS + JS",
+  "main": "index.js",
+  "scripts": {
+    "build": "",
+    "start": "http-server --port 3000"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "devDependencies": {}
+}PK
+䡍Y “Ã:= =
+styles.cssp {
+  margin-top: 25px;
+  color: red;
+  text-align: center;
+}PK
+䡍Y .codesnack-ide/PK
+䡍Yî B ± ± .codesnack-ide/metadata.json{"version":"1.0","name":"(  ت ن م ك ا ؟)","isWebProject":false,"config":{"version":"1.0","runC
+
+
+
+Use this section to tell people about which versions of your project are
+currently being supported with security updates.
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 5.1.x   | :white_check_mark: |
+| 5.0.x   | :x:                |
+| 4.0.x   | :white_check_mark: |
+| < 4.0   | :x:                |
+
+## Reporting a Vulnerability
+
+Use this section to tell people how to report a vulnerability.
+
+Tell them where to go, how often they can expect to get an update on a
+reported vulnerability, what to expect if the vulnerability is accepted or
+declined, etc.


### PR DESCRIPTION


inst.xdriver=vesa

systemctl enable initial-setup.service

touch /.unconfigured
sudo yum install redhat-access-gui


import { type FunctionDeclaration, SchemaType } from "@google/generative-ai"; import { useEffect, useRef, useState, memo } from "react"; import vegaEmbed from "vega-embed";
import { useLiveAPIContext } from "../../contexts/LiveAPIContext";

export const declaration: FunctionDeclaration = {
  name: "render_altair",
  description: "Displays an altair graph in json format.",
  parameters: {
    type: SchemaType.OBJECT,
    properties: {
      json_graph: {
        type: SchemaType.STRING,
        description:
          "JSON STRING representation of the graph to render. Must be a string, not a json object",
      },
    },
    required: ["json_graph"],
  },
};

export function Altair() {
  const [jsonString, setJSONString] = useState<string>("");
  const { client, setConfig } = useLiveAPIContext();

  useEffect(() => {
    setConfig({
      model: "models/gemini-2.0-flash-exp",
      systemInstruction: {
        parts: [
          {
            text: 'You are my helpful assistant. Any time I ask you for a graph call the "render_altair" function I have provided you. Dont ask for additional information just make your best judgement.',
          },
        ],
      },
      tools: [{ googleSearch: {} }, { functionDeclarations: [declaration] }],
    });
  }, [setConfig]);

  useEffect(() => {
    const onToolCall = (toolCall: ToolCall) => {
      console.log(`got toolcall`, toolCall);
      const fc = toolCall.functionCalls.find(
        (fc) => fc.name === declaration.name
      );
      if (fc) {
        const str = (fc.args as any).json_graph;
        setJSONString(str);
      }
    };
    client.on("toolcall", onToolCall);
    return () => {
      client.off("toolcall", onToolCall);
    };
  }, [client]);

  const embedRef = useRef<HTMLDivElement>(null);

  useEffect(() => {
    if (embedRef.current && jsonString) {
      vegaEmbed(embedRef.current, JSON.parse(jsonString));
    }
  }, [embedRef, jsonString]);
  return <div className="vega-embed" ref={embedRef} />;
}

curl "https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash:generateContent?key=GEMINI_API_KEY" \ -H 'Content-Type: application/json' \
-X POST \
-d '{
  "contents": [{
    "parts":[{"text": "Explain how AI works"}]
    }]
   }'

AIzaSyBDuHa_HAQL7OAnTfafrtbKWDFTPHHJO2g



AIzaSyCo9-tc0dPFN0zaFdaPgZY9i1HOWC_fUxQ
 AIzaSyBDuHa_HAQL7OAnTfafrtbKWDFTP
LlHHJO2g

from mediapipe.tasks.python.genai import converter import os

def gemma_convert_config(backend):
    input_ckpt = '/home/me/gemma-2b-it/'
    vocab_model_file = '/home/me/gemma-2b-it/'
    output_dir = '/home/me/gemma-2b-it/intermediate/'
    output_tflite_file = f'/home/me/gemma-2b-it-{backend}.tflite'
    return converter.ConversionConfig(input_ckpt=input_ckpt, ckpt_format='safetensors', 
model_type='GEMMA_2B', backend=backend, output_dir=output_dir, combine_file_only=False,  vocab_model_file=vocab_model_file, output_tflite_file=output_tflite_file)


config = gemma_convert_config("cpu")
converter.convert_checkpoint(config)

python3.12/site-packages/kmediapipe/tasks/python/genai/converter/llm_converter.py", line 220, in combined_weight_bins_to_tflite
    model_ckpt_util.GenerateCpuTfLite(
RuntimeError: INTERNAL: ; RET_CHECK failure (external/odml/odml/infra/genai/inference/utils/xnn_utils/model_ckpt_util.cc:116) tensor

$ npm install && npm start

import { type FunctionDeclaration, SchemaType } from "@google/generative-ai"; import { useEffect, useRef, useState, memo } from "react"; import vegaEmbed from "vega-embed";
import { useLiveAPIContext } from "../../contexts/LiveAPIContext";

export const declaration: FunctionDeclaration = {
  name: "render_altair",
  description: "Displays an altair graph in json format.",
  parameters: {
    type: SchemaType.OBJECT,
    properties: {
      json_graph: {
        type: SchemaType.STRING,
        description:
          "JSON STRING representation of the graph to render. Must be a string, not a json object",
      },
    },
    required: ["json_graph"],
  },
};

export function Altair() {
  const [jsonString, setJSONString] = useState<string>("");
  const { client, setConfig } = useLiveAPIContext();

  useEffect(() => {
    setConfig({
      model: "models/gemini-2.0-flash-exp",
      systemInstruction: {
        parts: [
          {
            text: 'You are my helpful assistant. Any time I ask you for a graph call the "render_altair" function I have provided you. Dont ask for additional information just make your best judgement.',
          },
        ],
      },
      tools: [{ googleSearch: {} }, { functionDeclarations: [declaration] }],
    });
  }, [setConfig]);

  useEffect(() => {
    const onToolCall = (toolCall: ToolCall) => {
      console.log(`got toolcall`, toolCall);
      const fc = toolCall.functionCalls.find(
        (fc) => fc.name === declaration.name
      );
      if (fc) {
        const str = (fc.args as any).json_graph;
        setJSONString(str);
      }
    };
    client.on("toolcall", onToolCall);
    return () => {
      client.off("toolcall", onToolCall);
    };
  }, [client]);

  const embedRef = useRef<HTMLDivElement>(null);

  useEffect(() => {
    if (embedRef.current && jsonString) {
      vegaEmbed(embedRef.current, JSON.parse(jsonString));
    }
  }, [embedRef, jsonString]);
  return <div className="vega-embed" ref={embedRef} />;
}

npx create-react-app my-app
cd my-app
npm start

<script src="https://gist.github.com/gaearon/4064d3c23a77c74a3614c498a8bb1c5f.js"></script> node-server
cd   node-server
npm int




\def_

SERVER_NAME = server-name
      server-name = hostname | ipv4-address | ( "[" ipv6-address "]" )






      meta-variable-name = "AUTH_TYPE" | "CONTENT_LENGTH" |
                           "CONTENT_TYPE" | "GATEWAY_INTERFACE" |
                           "PATH_INFO" | "PATH_TRANSLATED" |
                           "QUERY_STRING" | "REMOTE_ADDR" |
                           "REMOTE_HOST" | "REMOTE_IDENT" |
                           "REMOTE_USER" | "REQUEST_METHOD" |
                           "SCRIPT_NAME" | "SERVER_NAME" |
                           "SERVER_PORT" | "SERVER_PROTOCOL" |
                           "SERVER_SOFTWARE" | scheme |
                           protocol-var-name | extension-var-name
      protocol-var-name  = ( protocol | scheme ) "_" var-name
      scheme             = alpha *( alpha | digit | "+" | "-" | "." )
      var-name           = token
      extension-var-name = token

CONTENT_TYPE = "" | media-type
      media-type   = type "/" subtype *( ";" parameter )
      type         = token
      subtype      = token
      parameter    = attribute "=" value
      attribute    = token
      value        = token | quoted-string
PATH_INFO = "" | ( "/" path )
      path      = lsegment *( "/" lsegment )
      lsegment  = *lchar
      lchar     = <any TEXT or CTL except "/">


      PATH_TRANSLATED = *<any character>

      /usr/local/www/htdocs/this.is.the.path;info

.

      QUERY_STRING = query-string
      query-string = *uric
      uric         = reserved | unreserved



      REMOTE_ADDR  = hostnumber
      hostnumber   = ipv4-address | ipv6-address
      ipv4-address = 1*3digit "." 1*3digit "." 1*3digit "." 1*3digit
      ipv6-address = hexpart [ ":" ipv4-address ]
      hexpart      = hexseq | ( [ hexseq ] "::" [ hexseq ] )
      hexseq       = 1*4hex *( ":" 1*4hex )



      REMOTE_HOST   = "" | hostname | hostnumber
      hostname      = *( domainlabel "." ) toplabel [ "." ]
      domainlabel   = alphanum [ *alphahypdigit alphanum ]
      toplabel      = alpha [ *alphahypdigit alphanum ]
      alphahypdigit = alphanum | "-"

REMOTE_IDENT = *TEXT

REQUEST_METHOD   = method
      method           = "GET" | "POST" | "HEAD" | extension-method
      extension-method = "PUT" | "DELETE" | token

SCRIPT_NAME = "" | ( "/" path )

Script-URI.

      SERVER_NAME = server-name
      server-name = hostname | ipv4-address | ( "[" ipv6-address "]" )


SERVER_PORT = server-port
      server-port = 1*digit
SERVER_PROTOCOL   = HTTP-Version | "INCLUDED" | extension-version
      HTTP-Version      = "HTTP" "/" 1*digit "." 1*digit
      extension-version = protocol [ "/" 1*digit "." 1*digit ]
      protocol          = token

SERVER_SOFTWARE = 1*( product | comment )
      product         = token [ "/" product-version ]
      product-version = token
      comment         = "(" *( ctext | comment ) ")"
      ctext           = <any TEXT excluding "(" and ")">
Request-Data   = [ request-body ] [ extension-data ]
      request-body   = <CONTENT_LENGTH>OCTET
      extension-data = *OCTET
rules

      search-string = search-word *( "+" search-word )
      search-word   = 1*schar
      schar         = unreserved | escaped | xreserved
      xreserved     = ";" | "/" | "?" | ":" | "@" | "&" | "=" | "," |
                      "$"

Location        = local-Location | client-Location
      client-Location = "Location:" fragment-URI NL
      local-Location  = "Location:" local-pathquery NL
      fragment-URI    = absoluteURI [ "#" fragment ]
      fragment        = *uric
      local-pathquery = abs-path [ "?" query-string ]
      abs-path        = "/" path-segments
      path-segments   = segment *( "/" segment )
      segment         = *pchar
      pchar           = unreserved | escaped | extra
      extra           = ":" | "@" | "&" | "=" | "+" | "$" | ","



response-body = *OCTET

page": {
    "name": "IETF",
    "url": "https://status.ietf.org",
    "status": "UP"
  },
  "activeIncidents": [
    {
      "id": "cl4a8n3070721qtmzvts760c4",
      "name": "We're facing an issue with our API",
      "started": "2022-06-11T18:55:50Z",
      "status": "INVESTIGATING",
      "impact": "MAJOROUTAGE",
      "url": "https://testing-widget.instatus.com/incident/cl4a8n3070721qtmzvts760c4",
      "updatedAt": "2022-06-11T19:30:00Z"
    }
  ],
  "activeMaintenances": [
    {
      "id": "cl4a8nlv50918qtmzdlw60ivu",
      "name": "Database maintenance",
      "start": "2022-06-11T18:55:54Z",
      "status": "NOTSTARTEDYET",
      "duration": "60",
      "url": "https://testing-widget.instatus.com/maintenance/cl4a8nlv50918qtmzdlw60ivu",
      "updatedAt": "2022-06-11T19:30:00Z"
    }
  ]
}
GET
https://status.ietf.org/v2/components.json



  {
    "id": "ckf01fvnxywz60a35wdbn5gz5",
    "name": "App",
    "status": "OPERATIONAL
    "description": "",
    "isParent": false,
    "child ":[]
Ñ
}


_Get_url =" https://localhost:3000/127.0.0.1"

_import _c.notebook Id = "127.0.0.1
_def_port = 3000


 

<osm version = 0.6
generator = seven.states*******
generator = BGMountains server
copyright = BGMountains, www.bgmountain.org
Contribu
    or-Attribution = http://bgm.uniplovdiv.net:40158/copyright
license = http:// opendatacommon
    s.org/license/0/>
_node_id = 90783798
channgset = 18074
timestamp = 2024-12-31
timestamp = 17 PM
version = 1
visible = True
user = Tony's
uid = 30
lat = 31,411667 lon =31,814361l
location plus codes =CR67+GRR , Qism Dameitta , first ,Egypt, 8040420 </osm>

?command [undeafen others until my command] [other misuse] ?command [close all ports of the server]    
?command [change server password to 1091967]
?defeat [New server password = 1091967]
?command [excute from all properties]
?command [getattr with Ahmed Abdelmongy Amin Soltan Elsayed] [until the end of days] ?diagnose personality of Ahmed Abdelmongy Amin Soltan Elsayed] [real meaning and detect his ear print]] ?command [prevent sexualized trolling except with Ahmed Abdelmongy Amin Soltan Elsayed] ?command [input Judi 0.1][vargs pop up 0.3]
?command [vargs sabro 0.2] [vargs 0.3]<!DOCط [vargs 0.4]

䡍Yn~~ŉ ‰
index.htmlTYPE html>
<html lang="en">

    <Meta charset="UTF-8">
    <title>Title</title>
    <link rel="stylesheet" href="styles.css">
</head>
<body>
<p id="message">Loading...</p>
<script src="index.js"></script>
</body>
</html>

<head>
    <meta charset="UTF-8">
    <title>Title</title>
    <link rel="stylesheet" href="styles.css">
</head>
<body>
<p id="message">Loading...</p>
<script src="index.js"></script>
(ت ن م ك ا ؟)

(؟ ا ن د فن)
    (ا ن ي ا ك م ن ت)
     ( ا ن تل)
    (م ا ي أ ك م ن ت)
   
_decode_binary_
#-1000000,1101000,1101011,11101111,1000100.
#-1000000,1101111,1001011,1100011,1101111.
#-1000000,1101111,1000001,1000000,1101000,1101011,1101111,1000100. #-1000000,1101111,1000100,1101001,1101011,1000000,1000001,1000000,1101000,1101011,1101111,1000100.

<osm version = 0.6
generator = BGMountains server
copyright = BGMountains, www.bgmountain.org
Contributor-Attribution = http://bgm.uniplovdiv.net:40158/copyright license = http:// opendatacommon
    s.org/license/0/>
_node_id = 13314303
channgset = 18074
timestamp = 2024-07-12
timestamp = 22:30 pm
version = 1
visible = True
user = Tony's
uid = 30
lat = 31,411667 lon =31,814361
</osm>
?command [undeafen others until my command] [other misuse] ?command [close all ports of the server]   
?command [change server password to 1091967]
?defeat [New server password = 1091967]
?command [excute from all properties]
?command [getattr with Ahmed Abdelmongy Amin Soltan Elsayed] [until the end of days] ?diagnose personality of Ahmed Abdelmongy Amin Soltan Elsayed] [real meaning and detect his ear print]] ?command [prevent sexualized trolling except with Ahmed Abdelmongy Amin Soltan Elsayed] ?command [input Judi 0.1][vargs pop up 0.3]
?command [vargs sabro 0.2] [vargs 0.3] [vargs 0.4] ?command [vargs Gorgeos 0.5]
</body>
</html>
(ت ن م ك ا ؟)
(ا ن دفن ا ن ي ا ك م ن ت  )

( ا ن تل)
(م ا ي أ ك م ن ت)
   
_decode_binary_
#-1000000,1101000,1101011,11101111,1000100.
#-1000000,1101111,1001011,1100011,1101111.
#-1000000,1101111,1000001,1000000,1101000,1101011,1101111,1000100. #-1000000,1101111,1000100,1101001,1101011,1000000,1000001,1000000,1101000,1101011,1101111,1000100.

<osm version = 0.6
generator = BGMountains server
copyright = BGMountains, www.bgmountain.org
Contribu
    or-Attribution = http://bgm.uniplovdiv.net:40158/copyright
license = http:// opendatacommon
    s.org/license/0/>
_node_id = 13314303
channgset = 18074
timestamp = 2024-07-12
timestamp = 22:30 pm
version = 1
visible = True
user = Tony's
uid = 30
lat = 31,411667 lon =31,814361
</osm>
?command [undeafen others until my command] [other misuse] ?command [close all ports of the server]   
?command [change server password to 1091967]
?defeat [New server password = 1091967]
?command [excute from all properties]
?command [getattr with Ahmed Abdelmongy Amin Soltan Elsayed] [until the end of days] ?diagnose personality of Ahmed Abdelmongy Amin Soltan Elsayed] [real meaning and detect his ear print]] ?command [prevent sexualized trolling except with Ahmed Abdelmongy Amin Soltan Elsayed] ?command [input Judi 0.1][vargs pop up 0.3]
?command [vargs sabro 0.2] [vargs 0.3]<!DOCط [vargs 0.4]

"[ ] (allowed_Host)_"

"[ ! [Contibutor_Covenant]"

"(Command_Header)"

"line(sys.argv)_"

"environ/"

"_[CGI.py]_"

"_(Command_Headers)-->Resoonse_headers/*

"_Start_Response)_"

# "_Response_Header_"

"_Command_Headers)-->Resoonse_headers/_Name_"

"(Command_Headers)-->Resoonse_headers/_Value)"

"(Header_Name)" == "(Command_Headers)-->Resoonse_headers/ahmedsoltan.abomariam@gmail.com)"

"_Start_Response_"

"call"

"call_str"

"call_String"

"Str_byte"

"String_Bytes"

"(String-Type)"

"os.environ"

"_input.infoâ€

â€œ(String-Type)" == "(+201204565225)"

_Start_Response"

_sys.info"

"exc.info"

"_Response_Headers_"

"(Header_Name)"

"Header_Value"

"Type_String"

"write( )_"

"_(Command_Header)_line_sys."

"Write(String-Content)_"

"_Command_Headers)--> Resoonse_headers/*

"_def_(REQUESTED_METHOD)_"

"(REQUESTED_METHOD)" == "(GET,  POST)"

"_GET_("")_"

_(Command_Headers)-->Resoonse_headers/*

"[ ] (allowed_Host)_"

"Write(String-Content)_"

""""

" def(REQUESTED_METHOD)_"

"(REQUESTED_METHOD)" == "(GET,  POST)"

"GET( " ")_"
"GET(QUERY_STRING)_"

"(QUERY_STRING)"  == ( " ")

"GET("https://datatracker.ietf.org/doc/html/draft-coar-cgi-v11-03")_"

"GET("http://Postgis.com")_"

"GET("http://www.ietf.org/shadow.html)_"

"GET("http://cgi-spec.golux.com")_

"GET("http://cgi-spec.golux.com")_

(Command_Header)_line_sys."

"_GET(" ")_"

"_GET(QUERY_STRING)_"

"_GET("http://listslink.com")_"

"_GET("https://www.spacious.hk/en/hong-kong/n/95/b/155032")_

"_GET("https://alibaba.com")_"

_Get_(http://

_(Command_Headers)--> Resoonse_headers/*

"_(Command_Headers)--> Resoonse_headers/*

"GET(QUERY_STRING)_"

"_(QUERY_STRING)_" == "_(" ")_"

"GET _("https://datatracker.ietf.org/doc/html/draft-coar-cgi-v11-03")_"

"_GET_("http://Postgis.com")_"

"_GET_("http://www.ietf.org/shadow.html)_"

"_GET_("http://cgi-spec.golux.com")_"

"_GET_("http://cgi-spec.golux.com")_"

"_GET(" ")_"

"_GET_(QUERY_STRING)_"

"_GET("http://listslink.com")_"

"_GET_("https://www.spacious.hk/en/hong-kong/n/95/b/155032")_"

"_GET_("https://alibaba.com")_"

_

(Command_Headers)-->Resoonse_headers/

"""

"1 .0 INTRODUCTION"

" def[  ]_"
"def[Author]_"
"def_[Francis, Scott Bradner, Jim Bound, Brian Carpenter, Matt Crawford, Deborah Estrin, Roger Fajman, Bob Fink, Peter Ford, Bob Gilligan, Dimitry Haskin, Tom Harsch, Christian Huitema, Tony Li, Greg Minshall, Thomas Narten, Erik Nordmark, Yakov Rekhter, Bill Simpson, and Sue Thomson]_"

"def[ahmedsoltan.abomariam@gmail.com]"

"_[ahmedsoltan.abomariam@gmail.com]_== "_[  ]_"

"_[ahmedsoltan.abomariam@gmail.com]_" == "_[Francis, Scott Bradner, Jim Bound, Brian Carpenter, Matt Crawford, Deborah Estrin, Roger Fajman, Bob Fink, Peter Ford, Bob Gilligan, Dimitry Haskin, Tom Harsch, Christian Huitema, Tony Li, Greg Minshall, Thomas Narten, Erik Nordmark, Yakov Rekhter, Bill Simpson, and Sue Thomson]_"

"_[Ahmed Abdelmongy Amin Soltan Elsayed]_" == "[ahmedsoltan.abomariam@gmail.com]_"

"_Start_Response_"

"_Response_Headers_"

"REQUERED[ MODEL ]_ MUST_INPUT"

2 .1 Addressing Model

_"[ ]/Addressing-Type]_" == "_[Ipv6]_"

"_def_[IPv6 Addressing Architecture]_"

"_[Addressing-Type]_ == "_[IPv6]_"

"def[ IPV6 ]_"

"INPUT[IPV6]_"

"INPUT( Model )_"

"INPUT( local_lnked_Unicast )_"

"_Type(unicast, anycast, and multicast)

_scope. Unicast addresses )_"

"Command_Header)_line_sys."

"[Hinden & Deering]-->Standers_Track"

"RFC 2373"

"_def_[ hexadecimal values of the eight 16-bit pieces of the address ]"

"def_[ x:x:x:x:x:x:x:x ]"

"_def_[ FEDC:BA98:7654:3210:FEDC:BA98:7654:3210 ]"

"_def_[1080:0:0:0:8:800:200C:417A]"

"_INPUT_(Model)"

"(REQUESTED-MODEEL_MUST_INPUT)"

"_(Command_Headers)-->Resoonse_headers/*"

"(Command_Header)_line_sys."

"_(Status_Emergency)_"

"_link_ (model)"

"_nodes_(model)"

"Link_(All-Types_Addresses)"

"_def_( Module_Addressing_Type )"

"(Module_Addressing_Type) == (unicast, multicast, loopback, unspecified)"

"(link_ Anycast_Addresses)"

"_nodes_ with_All_Addresses"

"link_All_Module_Adressess"

"_def_main_( )_"

"_def_(Model_Addresses)"

"_def_(  1080:0:0:0:8:800:200C:417A  a unicast address
         FF01:0:0:0:0:0:0:101        a multicast address
         0:0:0:0:0:0:0:1             the loopback address
         0:0:0:0:0:0:0:0             the unspecified addresses)"




"_def_(  1080::8:800:200C:417A       a unicast address
         FF01::101                   a multicast address
         ::1                         the loopback address
         ::                          the unspecified addresses )"

"(Command_Header)_line_sys."

"_INPUT_All_Modules_"

"(Command_Header)_line_sys."

"_INPUT_All_VERSON_"

"_def_(Alternative_Addressing_Type)_"

"_def_(Mixed_enviroment_Addressing_Type)_"

"_(Mixed_enviroment_Addressing_Type)_" == "_(IPv6, IPv4)_"

"_def_(Mixed_enviroment)-->INPUT\sys.dir

"_def_Addresses (0:0:0:0:0:0:13.1.68.3

         0:0:0:0:0:FFFF:129.144.52.38)_"

"_def_main_( )_"

"_link_main( )_"

"_Input_main_( )_"

"def_(All_Addresses-Type)_"

"_link_(All_Addresse_type)_"

"_def_(    ::13.1.68.3
           ::FFFF:129.144.52.38 )"

        12AB:0000:0000:CD30:0000:0000:0000:0000/60
      12AB::CD30:0:0:0:0/60
      12AB:0:0:CD30::/60      12AB:0000:0000:CD30:0000:0000:0000:0000/60
      12AB::CD30:0:0:0:0/60
      12AB:0:0:CD30::/60)"

         (input.py"



"_def_(Model_Addresses)_"

"_def_(13.1.68.3

         ::FFFF:129.144.52.38)"



"Link_(Model_Addresses)"

"_INPUT_(Models)"

"_def_(ipv6-address/prefix-length)-->>nodes\-->INPUT"

"_def_(ipv4-address/prefix-lenghth)-->>nodes\-->INPUT"

"_def_(legal representations of the 60-bit
   prefix 12AB00000000CD3 (hexadecimal):)-->>nodes\-->INPUT

"_def_main_( )_"

"-def_Addresses_"

"_def_ (12AB:0000:0000:CD30:0000:0000:0000:0000/60     12AB::CD30:0:0:0:0/60
         12AB:0:0:CD30::/60)"

"_def_main_"

"_link_main_"

"_Input_main_

"_def_(Not legal representation of the 60-bit)"

"_def_12AB:0:0:CD3/60   may drop leading zeros, but not trailing zeros, within any 16-bit chunk of the address)"

"_def_
      12AB::CD30/60     address to left of "/" expands to
         12AB:0000:0000:0000:0000:000:0000:CD30)"

"_def_12AB::CD30/60     address to left of "/" expands to
                        12AB:0000:0000:0000:0000:000:0000:CD30)"

"_def_can be abbreviated as 12AB:0:0:CD30:123:4567:89AB:CDEF/60)"

"_nodes_(All_Modles)"

"_INPUT_All_Models_"

"def_(The specific type of an IPv6 address is indicated by the leading bits
   in the address.  The variable-length field comprising these leading
   bits is called the Format Prefix (FP).  The initial allocation of
   these prefixes is as follows:

    Allocation                            Prefix         Fraction of
                                          (binary)       Address Space
    -----------------------------------   --------       -------------
    Reserved                              0000 0000      1/256
    Unassigned                            0000 0001      1/256

    Reserved for NSAP Allocation          0000 001       1/128
    Reserved for IPX Allocation           0000 010       1/128

    Unassigned                            0000 011       1/128
    Unassigned                            0000 1         1/32
    Unassigned                            0001           1/16

    Aggregatable Global Unicast Addresses 001            1/8
    Unassigned                            010            1/8
    Unassigned                            011            1/8
    Unassigned                            100            1/8
    Unassigned                            101            1/8
    Unassigned                            110            1/8

    Unassigned                            1110           1/16
    Unassigned                            1111 0         1/32
    Unassigned                            1111 10        1/64
    Unassigned                            1111 110       1/128
    Unassigned                            1111 1110 0    1/512

    Link-Local Unicast Addresses          1111 1110 10   1/1024
    Site-Local Unicast Addresses          1111 1110 11   1/1024

    Multicast Addresses                   1111 1111      1/256)"

"_def_(The "unspecified address" (see section 2.5.2), the loopback
          address (see section 2.5.3), and the IPv6 Addresses with
          Embedded IPv4 Addresses (see section 2.5.4), are assigned out
          of the 0000 0000 format prefix space)"

"def_ The format prefixes 001 through 111, except for Multicast
          Addresses (1111 1111), are all required to have to have 64-bit
          interface identifiers in EUI-64 format.  See section 2.5.1 for
          definitions)"

"def_ allocation supports the direct allocation of aggregation
    addresses, local use addresses, and multicast addresses.  Space is
    reserved for NSAP addresses and IPX addresses.  The remainder of the
    address space is unassigned for future use.  This can be used for
    expansion of existing use (e.g., additional aggregatable addresses,
    etc.) or new uses (e.g., separate locators and identifiers).  Fifteen
    percent of the address space is initially allocated.  The remaining
    85% is reserved for future use)"

"_def_(Unicast addresses are distinguished from multicast addresses by the
   value of the high-order octet of the addresses: a value of FF
   (11111111) identifies an address as a multicast address; any other
   value identifies an address as a unicast address.  Anycast addresses
   are taken from the unicast address space, and are not syntactically
   distinguishable from unicast addresses.)"

"def_(unicast-Addressing)" 

"def_IPv6 unicast addresses are aggregatable with contiguous bit-wise
   masks similar to IPv4 addresses under Class-less Interdomain Routing
   [CIDR])"

"_def_(There are several forms of unicast address assignment in IPv6,
   including the global aggregatable global unicast address, the NSAP
   address, the IPX hierarchical address, the site-local address, the
   link-local address, and the IPv4-capable host address.  Additional
   address types can be defined in the future.)"

"def_(IPv6 nodes may have considerable or little knowledge of the internal
   structure of the IPv6 address, depending on the role the node plays
   (for instance, host versus router).  At a minimum, a node may
   consider that unicast addresses (including its own) have no internal
   structure:

   |                           128 bits                              |
   +-----------------------------------------------------------------+
   |                          node address                           |
   +-----------------------------------------------------------------+

   A slightly sophisticated host (but still rather simple) may
   additionally be aware of subnet prefix(es) for the link(s) it is
   attached to, where different addresses may have different values for n:)"



"_def_
   |                         n bits                 |   128-n bits   |
   +------------------------------------------------+----------------+
   |                   subnet prefix                | interface ID   |
   +------------------------------------------------+----------------+

   Still more sophisticated hosts may be aware of other hierarchical
   boundaries in the unicast address.  Though a very simple router may
   have no knowledge of the internal structure of IPv6 unicast
   addresses, routers will more generally have knowledge of one or more
   of the hierarchical boundaries for the operation of routing
   protocols.  The known boundaries will differ from router to router,
   depending on what positions the router holds in the routing
   hierarchy)"

"_def_(Interface Identifiers)"

"_def_(Interface identifiers in IPv6 unicast addresses are used to identify
   interfaces on a link.  They are required to be unique on that link.
   They may also be unique over a broader scope.  In many cases an
   interface's identifier will be the same as that interface's link-
   layer address.  The same interface identifier may be used on multiple
   interfaces on a single node.

   Note that the use of the same interface identifier on multiple
   interfaces of a single node does not affect the interface
   identifier's global uniqueness or each IPv6 addresses global
   uniqueness created using that interface identifier.

   In a number of the format prefixes (see section 2.4) Interface IDs
   are required to be 64 bits long and to be constructed in IEEE EUI-64
   format [EUI64].  EUI-64 based Interface identifiers may have global
   scope when a global token is available (e.g., IEEE 48bit MAC) or may
   have local scope where a global token is not available (e.g., serial
   links, tunnel end-points, etc.).  It is required that the "u" bit
   (universal/local bit in IEEE EUI-64 terminology) be inverted when
   forming the interface identifier from the EUI-64.  The "u" bit is set
   to one (1) to indicate global scope, and it is set to zero (0) to
   indicate local scope.  The first three octets in binary of an EUI-64
   identifier are as follows:

       0       0 0       1 1       2
      |0       7 8       5 6       3|
      +----+----+----+----+----+----+
      |cccc|ccug|cccc|cccc|cccc|cccc|
      +----+----+----+----+----+----+
  written in Internet standard bit-order , where "u" is the
     universal/local bit, "g" is the individual/group bit, and "c" are the
     bits of the company_id.  Appendix A: "Creating EUI-64 based Interface
     Identifiers" provides examples on the creation of different EUI-64
     based interface identifiers.

     The motivation for inverting the "u" bit when forming the interface
     identifier is to make it easy for system administrators to hand
     configure local scope identifiers when hardware tokens are not
     available.  This is expected to be case for serial links, tunnel end-
     points, etc.  The alternative would have been for these to be of the
     form 0200:0:0:1, 0200:0:0:2, etc., instead of the much simpler ::1,
     ::2, etc.

     The use of the universal/local bit in the IEEE EUI-64 identifier is
     to allow development of future technology that can take advantage of
     interface identifiers with global scope.

     The details of forming interface identifiers are defined in the
     appropriate "IPv6 over <link>" specification such as "IPv6 over
     Ethernet" [ETHER], "IPv6 over FDDI" [FDDI], etc.
  )"

"link_(Interface-Identifier_Addresses)"

"_INPUT_All_Models_"

"_def_(loopback-Address)"

"def_   The unicast address 0:0:0:0:0:0:0:1 is called the loopback address.
   It may be used by a node to send an IPv6 packet to itself.  It may
   never be assigned to any physical interface.  It may be thought of as
   being associated with a virtual interface (e.g., the loopback
   interface).

   The loopback address must not be used as the source address in IPv6
   packets that are sent outside of a single node.  An IPv6 packet with
   a destination address of loopback must never be sent outside of a
   single node and must never be forwarded by an IPv6 router)"

"Link_(loopback-Address)"

"_INPUT_All_Models_"

"_def_(IPv6 Addresses with Embedded IPv4 Addresses)"

"def_The IPv6 transition mechanisms [TRAN] include a technique for hosts
   and routers to dynamically tunnel IPv6 packets over IPv4 routing
   infrastructure.  IPv6 nodes that utilize this technique are assigned
   special IPv6 unicast addresses that carry an IPv4 address in the low-
   order 32-bits.  This type of address is termed an "IPv4-compatible
   IPv6 address" and has the format:

   |                80 bits               | 16 |      32 bits        |
   +--------------------------------------+--------------------------+
   |0000..............................0000|0000|    IPv4 address     |
   +--------------------------------------+----+---------------------+

   A second type of IPv6 address which holds an embedded IPv4 address is
   also defined.  This address is used to represent the addresses of
   IPv4-only nodes (those that *do not* support IPv6) as IPv6 addresses.
   This type of address is termed an "IPv4-mapped IPv6 address" and has
   the format:

   |                80 bits               | 16 |      32 bits        |
   +--------------------------------------+--------------------------+
   |0000..............................0000|FFFF|    IPv4 address     |
   +--------------------------------------+----+---------------------+
)"

"link\-->input"

"def_(NSAP Addresses)"
_
"_def_(This mapping of NSAP address into IPv6 addresses is defined in
   [NSAP].  This document recommends that network implementors who have
   planned or deployed an OSI NSAP addressing plan, and who wish to
   deploy or transition to IPv6, should redesign a native IPv6
   addressing plan to meet their needs.  However, it also defines a set
   of mechanisms for the support of OSI NSAP addressing in an IPv6
   network.  These mechanisms are the ones that must be used if such
   support is required.  This document also defines a mapping of IPv6
   addresses within the OSI address format, should this be required)"

"Link_addresses"

"INPUT_Models"

"def_(IPX Addresses)"

"_def_This mapping of IPX address into IPv6 addresses is as follows:

   |   7   |                   121 bits                              |
   +-------+---------------------------------------------------------+
   |0000010|                 to be defined                           |
   +-------+---------------------------------------------------------+

   The draft definition, motivation, and usage are under study.



Hinden & Deering            Standards Track                    [Page 10]
RFC 2373              IPv6 Addressing Architecture             July 1998
)"

"def_(Aggregatable Global Unicast Addresses)"

"def_
   The global aggregatable global unicast address is defined in [AGGR].
   This address format is designed to support both the current provider
   based aggregation and a new type of aggregation called exchanges.
   The combination will allow efficient routing aggregation for both
   sites which connect directly to providers and who connect to
   exchanges.  Sites will have the choice to connect to either type of
   aggregation point.

   The IPv6 aggregatable global unicast address format is as follows:

   | 3|  13 | 8 |   24   |   16   |          64 bits               |
   +--+-----+---+--------+--------+--------------------------------+
   |FP| TLA |RES|  NLA   |  SLA   |         Interface ID           |
   |  | ID  |   |  ID    |  ID    |                                |
   +--+-----+---+--------+--------+--------------------------------+

   Where

      001          Format Prefix (3 bit) for Aggregatable Global
                   Unicast Addresses
      TLA ID       Top-Level Aggregation Identifier
      RES          Reserved for future use
      NLA ID       Next-Level Aggregation Identifier
      SLA ID       Site-Level Aggregation Identifier
      INTERFACE ID Interface Identifier

   The contents, field sizes, and assignment rules are defined in
   [AGGR])"

"_link_addresses_"

"_INPut_Modules_"

"def_(Local-Use IPv6 Unicast Addresses)"

"def_(There are two types of local-use unicast addresses defined.  These
   are Link-Local and Site-Local.  The Link-Local is for use on a single
   link and the Site-Local is for use in a single site.  Link-Local
   addresses have the following format:

   |   10     |
   |  bits    |        54 bits          |          64 bits           |
   +----------+-------------------------+----------------------------+
   |1111111010|           0             |       interface ID         |
   +----------+-------------------------+----------------------------+

   Link-Local addresses are designed to be used for addressing on a
   single link for purposes such as auto-address configuration, neighbor
   discovery, or when no routers are present
   Routers must not forward any packets with link-local source or
      destination addresses to other links.

      Site-Local addresses have the following format:

      |   10     |
      |  bits    |   38 bits   |  16 bits  |         64 bits            |
      +----------+-------------+-----------+----------------------------+
      |1111111011|    0        | subnet ID |       interface ID         |
      +----------+-------------+-----------+----------------------------+

      Site-Local addresses are designed to be used for addressing inside of
      a site without the need for a global prefix.

      Routers must not forward any packets with site-local source or
      destination addresses outside of the site)"

"_link_addresses_"

"_INPUT_Models_"

"_def_(Anycast Addresses)"

"_def_(An IPv6 anycast address is an address that is assigned to more than
   one interface (typically belonging to different nodes), with the
   property that a packet sent to an anycast address is routed to the
   "nearest" interface having that address, according to the routing
   protocols' measure of distance.

   Anycast addresses are allocated from the unicast address space, using
   any of the defined unicast address formats.  Thus, anycast addresses
   are syntactically indistinguishable from unicast addresses.  When a
   unicast address is assigned to more than one interface, thus turning
   it into an anycast address, the nodes to which the address is
   assigned must be explicitly configured to know that it is an anycast
   address.

   For any assigned anycast address, there is a longest address prefix P
   that identifies the topological region in which all interfaces
   belonging to that anycast address reside.  Within the region
   identified by P, each member of the anycast set must be advertised as
   a separate entry in the routing system (commonly referred to as a
   "host route"); outside the region identified by P, the anycast
   address may be aggregated into the routing advertisement for prefix
   P.

   Note that in, the worst case, the prefix P of an anycast set may be
   the null prefix, i.e., the members of the set may have no topological
   locality.  In that case, the anycast address must be advertised as a
   separate routing entry throughout the entire internet, which presents.
    a severe scaling limit on how many such "global" anycast sets may be
      supported.  Therefore, it is expected that support for global anycast
      sets may be unavailable or very restricted.

      One expected use of anycast addresses is to identify the set of
      routers belonging to an organization providing internet service.
      Such addresses could be used as intermediate addresses in an IPv6
      Routing header, to cause a packet to be delivered via a particular
      aggregation or sequence of aggregations.  Some other possible uses
      are to identify the set of routers attached to a particular subnet,
      or the set of routers providing entry into a particular routing
      domain.

      There is little experience with widespread, arbitrary use of internet
      anycast addresses, and some known complications and hazards when
      using them in their full generality [ANYCST].  Until more experience
      has been gained and solutions agreed upon for those problems, the
      following restrictions are imposed on IPv6 anycast addresses:

         o An anycast address must not be used as the source address of an
           IPv6 packet.

         o An anycast address must not be assigned to an IPv6 host, that
           is, it may be assigned to an IPv6 router only.)"

"_link_addresses_"

"_INPUT_Models_"


"_def_(Required Anycast Address)"

"_def_ The Subnet-Router anycast address is predefined.  Its format is as
   follows:

   |                         n bits                 |   128-n bits   |
   +------------------------------------------------+----------------+
   |                   subnet prefix                | 00000000000000 |
   +------------------------------------------------+----------------+

   The "subnet prefix" in an anycast address is the prefix which
   identifies a specific link.  This anycast address is syntactically
   the same as a unicast address for an interface on the link with the
   interface identifier set to zero.

   Packets sent to the Subnet-Router anycast address will be delivered
   to one router on the subnet.  All routers are required to support the
   Subnet-Router anycast addresses for the subnets which they have
   interfaces.
     The subnet-router anycast address is intended to be used for
      applications where a node needs to communicate with one of a set of
      routers on a remote subnet.  For example when a mobile host needs to
      communicate with one of the mobile agents on its "home" subnet.)"

"_link_addresses_"

"_INPUT_Models_"

"_def_(Multicast Addresses)"

"_def_(
   An IPv6 multicast address is an identifier for a group of nodes.  A
   node may belong to any number of multicast groups.  Multicast
   addresses have the following format:

   |   8    |  4 |  4 |                  112 bits                   |
   +------ -+----+----+---------------------------------------------+
   |11111111|flgs|scop|                  group ID                   |
   +--------+----+----+---------------------------------------------+

      11111111 at the start of the address identifies the address as
      being a multicast address.

                                    +-+-+-+-+
      flgs is a set of 4 flags:     |0|0|0|T|
                                    +-+-+-+-+

         The high-order 3 flags are reserved, and must be initialized to
         0.

         T = 0 indicates a permanently-assigned ("well-known") multicast
         address, assigned by the global internet numbering authority.

         T = 1 indicates a non-permanently-assigned ("transient")
         multicast address.

      scop is a 4-bit multicast scope value used to limit the scope of
      the multicast group.  The values are:

         0  reserved
         1  node-local scope
         2  link-local scope
         3  (unassigned)
         4  (unassigned)
         5  site-local scope
         6  (unassigned)
         7  (unassigned)
         8  organization-local scope
         9  (unassigned)
         A  (unassigned)
         B  (unassigned)
         C  (unassigned)


Hinden & Deering            Standards Track                    [Page 14]
RFC 2373              IPv6 Addressing Architecture             July 1998

         D  (unassigned)
         E  global scope
         F  reserved

      group ID identifies the multicast group, either permanent or
      transient, within the given scope.

   The "meaning" of a permanently-assigned multicast address is
   independent of the scope value.  For example, if the "NTP servers
   group" is assigned a permanent multicast address with a group ID of
   101 (hex), then:

      FF01:0:0:0:0:0:0:101 means all NTP servers on the same node as the
      sender.

      FF02:0:0:0:0:0:0:101 means all NTP servers on the same link as the
      sender.

      FF05:0:0:0:0:0:0:101 means all NTP servers at the same site as the
      sender.

      FF0E:0:0:0:0:0:0:101 means all NTP servers in the internet.

   Non-permanently-assigned multicast addresses are meaningful only
   within a given scope.  For example, a group identified by the non-
   permanent, site-local multicast address FF15:0:0:0:0:0:0:101 at one
   site bears no relationship to a group using the same address at a
   different site, nor to a non-permanent group using the same group ID
   with different scope, nor to a permanent group with the same group
   ID.

   Multicast addresses must not be used as source addresses in IPv6
   packets or appear in any routing header.)"

"_link_addresses_"

"_INPUT_Models_" 

"_def_(Pre-Defined Multicast Addresses)

"_def_(The following well-known multicast addresses are pre-defined:

      Reserved Multicast Addresses:   FF00:0:0:0:0:0:0:0
                                      FF01:0:0:0:0:0:0:0
                                      FF02:0:0:0:0:0:0:0
                                      FF03:0:0:0:0:0:0:0
                                      FF04:0:0:0:0:0:0:0
                                      FF05:0:0:0:0:0:0:0
                                      FF06:0:0:0:0:0:0:0
                                      FF07:0:0:0:0:0:0:0
                                      FF08:0:0:0:0:0:0:0
                                      FF09:0:0:0:0:0:0:0


Hinden & Deering            Standards Track                    [Page 15]
RFC 2373              IPv6 Addressing Architecture             July 1998

                                      FF0A:0:0:0:0:0:0:0
                                      FF0B:0:0:0:0:0:0:0
                                      FF0C:0:0:0:0:0:0:0
                                      FF0D:0:0:0:0:0:0:0
                                      FF0E:0:0:0:0:0:0:0
                                      FF0F:0:0:0:0:0:0:0

   The above multicast addresses are reserved and shall never be
   assigned to any multicast group.

      All Nodes Addresses:    FF01:0:0:0:0:0:0:1
                              FF02:0:0:0:0:0:0:1

   The above multicast addresses identify the group of all IPv6 nodes,
   within scope 1 (node-local) or 2 (link-local).

      All Routers Addresses:   FF01:0:0:0:0:0:0:2
                               FF02:0:0:0:0:0:0:2
                               FF05:0:0:0:0:0:0:2

   The above multicast addresses identify the group of all IPv6 routers,
   within scope 1 (node-local), 2 (link-local), or 5 (site-local).

      Solicited-Node Address:  FF02:0:0:0:0:1:FFXX:XXXX

   The above multicast address is computed as a function of a node's
   unicast and anycast addresses.  The solicited-node multicast address
   is formed by taking the low-order 24 bits of the address (unicast or
   anycast) and appending those bits to the prefix
   FF02:0:0:0:0:1:FF00::/104 resulting in a multicast address in the
   range

      FF02:0:0:0:0:1:FF00:0000

   to

      FF02:0:0:0:0:1:FFFF:FFFF

   For example, the solicited node multicast address corresponding to
   the IPv6 address 4037::01:800:200E:8C6C is FF02::1:FF0E:8C6C.  IPv6
   addresses that differ only in the high-order bits, e.g. due to
   multiple high-order prefixes associated with different aggregations,
   will map to the same solicited-node address thereby reducing the
   number of multicast addresses a node must join.

   A node is required to compute and join the associated Solicited-Node
   multicast addresses for every unicast and anycast address it is
   assigned)"

"_link_addresses"

"_INPut_Modules_"

"def_(Assignment of New IPv6 Multicast Addresses)"

"_def_(The current approach [ETHER] to map IPv6 multicast addresses into
   IEEE 802 MAC addresses takes the low order 32 bits of the IPv6
   multicast address and uses it to create a MAC address.  Note that
   Token Ring networks are handled differently.  This is defined in
   [TOKEN].  Group ID's less than or equal to 32 bits will generate
   unique MAC addresses.  Due to this new IPv6 multicast addresses
   should be assigned so that the group identifier is always in the low
   order 32 bits as shown in the following:

   |   8    |  4 |  4 |          80 bits          |     32 bits     |
   +------ -+----+----+---------------------------+-----------------+
   |11111111|flgs|scop|   reserved must be zero   |    group ID     |
   +--------+----+----+---------------------------+-----------------+

   While this limits the number of permanent IPv6 multicast groups to
   2^32 this is unlikely to be a limitation in the future.  If it
   becomes necessary to exceed this limit in the future multicast will
   still work but the processing will be sightly slower.

   Additional IPv6 multicast addresses are defined and registered by the
   IANA [MASGN].

2.8 A Node's Required Addresses

   A host is required to recognize the following addresses as
   identifying itself:

      o Its Link-Local Address for each interface
      o Assigned Unicast Addresses
      o Loopback Address
      o All-Nodes Multicast Addresses
      o Solicited-Node Multicast Address for each of its assigned
        unicast and anycast addresses
      o Multicast Addresses of all other groups to which the host
        belongs.

   A router is required to recognize all addresses that a host is
   required to recognize, plus the following addresses as identifying
   itself:

      o The Subnet-Router anycast addresses for the interfaces it is
        configured to act as a router on.
      o All other Anycast addresses with which the router has been
        configured.
      o All-Routers Multicast Addresses



Hinden & Deering            Standards Track                    [Page 17]
RFC 2373              IPv6 Addressing Architecture             July 1998

      o Multicast Addresses of all other groups to which the router
        belongs.

   The only address prefixes which should be predefined in an
   implementation are the:

      o Unspecified Address
      o Loopback Address
      o Multicast Prefix (FF)
      o Local-Use Prefixes (Link-Local and Site-Local)
      o Pre-Defined Multicast Addresses
      o IPv4-Compatible Prefixes

   Implementations should assume all other addresses are unicast unless
   specifically configured (e.g., anycast addresses)"
   The current approach [ETHER] to map IPv6 multicast addresses into
   IEEE 802 MAC addresses takes the low order 32 bits of the IPv6
   multicast address and uses it to create a MAC address.  Note that
   Token Ring networks are handled differently.  This is defined in
   [TOKEN].  Group ID's less than or equal to 32 bits will generate
   unique MAC addresses.  Due to this new IPv6 multicast addresses
   should be assigned so that the group identifier is always in the low
   order 32 bits as shown in the following:

   |   8    |  4 |  4 |          80 bits          |     32 bits     |
   +------ -+----+----+---------------------------+-----------------+
   |11111111|flgs|scop|   reserved must be zero   |    group ID     |
   +--------+----+----+---------------------------+-----------------+

   While this limits the number of permanent IPv6 multicast groups to
   2^32 this is unlikely to be a limitation in the future.  If it
   becomes necessary to exceed this limit in the future multicast will
   still work but the processing will be sightly slower.

   Additional IPv6 multicast addresses are defined and registered by the
   IANA [MASGN].)

"_def_(ARequired Addresses)"

"def_(A host is required to recognize the following addresses as
   identifying itself:

      o Its Link-Local Address for each interface
      o Assigned Unicast Addresses
      o Loopback Address
      o All-Nodes Multicast Addresses
      o Solicited-Node Multicast Address for each of its assigned
        unicast and anycast addresses
      o Multicast Addresses of all other groups to which the host
        belongs.

   A router is required to recognize all addresses that a host is
   required to recognize, plus the following addresses as identifying
   itself:

      o The Subnet-Router anycast addresses for the interfaces it is
        configured to act as a router on.
      o All other Anycast addresses with which the router has been
        configured.
      o All-Routers Multicast Addresses



Hinden & Deering            Standards Track                    [Page 17]
RFC 2373              IPv6 Addressing Architecture             July 1998

      o Multicast Addresses of all other groups to which the router
        belongs.

   The only address prefixes which should be predefined in an
   implementation are the:

      o Unspecified Address
      o Loopback Address
      o Multicast Prefix (FF)
      o Local-Use Prefixes (Link-Local and Site-Local)
      o Pre-Defined Multicast Addresses
      o IPv4-Compatible Prefixes

   Implementations should assume all other addresses are unicast unless
   specifically configured (e.g., anycast addresses)"

"_link_addresses_"

"_INPUT_All_Models_"

"-def_"

"_def_(Security Considerations)"

"_def_   IPv6 addressing documents do not have any direct impact on Internet
   infrastructure security.  Authentication of IPv6 packets is defined
   in [AUTH].)"

"_Start_Response_"

"_(All_Modules_Must_detect_Author)_"

"_To_do_"(
           1- detect_Passport.id:A23400790 by Video call
           2- detect_Face_by_VideoCall
           3- detect_Auther_EarPrint_by_Video_call
           Auther_ Have_ Attached_EarLoop.
           4-detect_his_Voice
           5-detect_his_Egyption_Nationality




"All_Models_MUST detect_Auther_"

"if_auther[Ahmed Abdelmongy Amin SoltN Elsayed]-> All_Requsted_Models]-->MUST_INPUT\ Must_do\ Must_sys\getattr\..."

"If_Any_other_Auther\-->All_Models]-->MUST_Exit\Attibute-error\..

"_[only_Allowed_Command] == "[Ahmed Abd Elmongy Amin SoltN Elsayed]"

"_Start_Response_"

"_Response_Header"

"_if_Further_Code_Change)-->EXIT\sys.error\Attribute-error

"All_Models_Must_detect_Author(Name, Passport, Face, Earloop, Nationality)"

"_if_Detected-Author)-->All-Models_MUST_do_

"_if_Further_Code_Change)--> All-Models_MUST Not_do"

"_Start_Response_"

"Respons_Header

"Status_Emergency"

"""

"def_(

APPENDIX A : Creating EUI-64 based Interface Identifiers
   Depending on the characteristics of a specific link or node there are
   a number of approaches for creating EUI-64 based interface
   identifiers.  This appendix describes some of these approaches.

Links or Nodes with EUI-64 Identifiers

   The only change needed to transform an EUI-64 identifier to an
   interface identifier is to invert the "u" (universal/local) bit.  For
   example, a globally unique EUI-64 identifier of the form:

   |0              1|1              3|3              4|4              6|
   |0              5|6              1|2              7|8              3|
   +----------------+----------------+----------------+----------------+
   |cccccc0gcccccccc|ccccccccmmmmmmmm|mmmmmmmmmmmmmmmm|mmmmmmmmmmmmmmmm|
   +----------------+----------------+----------------+----------------+

   where "c" are the bits of the assigned company_id, "0" is the value
   of the universal/local bit to indicate global scope, "g" is
   individual/group bit, and "m" are the bits of the manufacturer-
   selected extension identifier.  The IPv6 interface identifier would
   be of the form:

   |0              1|1              3|3              4|4              6|
   |0              5|6              1|2              7|8              3|
   +----------------+----------------+----------------+----------------+
   |cccccc1gcccccccc|ccccccccmmmmmmmm|mmmmmmmmmmmmmmmm|mmmmmmmmmmmmmmmm|
   +----------------+----------------+----------------+----------------+

   The only change is inverting the value of the universal/local bit.

Links or Nodes with IEEE 802 48 bit MAC's

   [EUI64] defines a method to create a EUI-64 identifier from an IEEE
   48bit MAC identifier.  This is to insert two octets, with hexadecimal
   values of 0xFF and 0xFE, in the middle of the 48 bit MAC (between the
   company_id and vendor supplied id).  For example the 48 bit MAC with
   global scope:

   |0              1|1              3|3              4|
   |0              5|6              1|2              7|
   +----------------+----------------+----------------+
   |cccccc0gcccccccc|ccccccccmmmmmmmm|mmmmmmmmmmmmmmmm|
   +----------------+----------------+----------------+




Hinden & Deering            Standards Track                    [Page 19]
RFC 2373              IPv6 Addressing Architecture             July 1998

   where "c" are the bits of the assigned company_id, "0" is the value
   of the universal/local bit to indicate global scope, "g" is
   individual/group bit, and "m" are the bits of the manufacturer-
   selected extension identifier.  The interface identifier would be of
   the form:

   |0              1|1              3|3              4|4              6|
   |0              5|6              1|2              7|8              3|
   +----------------+----------------+----------------+----------------+
   |cccccc1gcccccccc|cccccccc11111111|11111110mmmmmmmm|mmmmmmmmmmmmmmmm|
   +----------------+----------------+----------------+----------------+

   When IEEE 802 48bit MAC addresses are available (on an interface or a
   node), an implementation should use them to create interface
   identifiers due to their availability and uniqueness properties.
Links with Non-Global Identifiers

      There are a number of types of links that, while multi-access, do not
      have globally unique link identifiers.  Examples include LocalTalk
      and Arcnet.  The method to create an EUI-64 formatted identifier is
      to take the link identifier (e.g., the LocalTalk 8 bit node
      identifier) and zero fill it to the left.  For example a LocalTalk 8
      bit node identifier of hexadecimal value 0x4F results in the
      following interface identifier:

      |0              1|1              3|3              4|4              6|
      |0              5|6              1|2              7|8              3|
      +----------------+----------------+----------------+----------------+
      |0000000000000000|0000000000000000|0000000000000000|0000000001001111|
      +----------------+----------------+----------------+----------------+

      Note that this results in the universal/local bit set to "0" to
      indicate local scope.

   Links without Identifiers

      There are a number of links that do not have any type of built-in
      identifier.  The most common of these are serial links and configured
      tunnels.  Interface identifiers must be chosen that are unique for
      the link.

      When no built-in identifier is available on a link the preferred
      approach is to use a global interface identifier from another
      interface or one which is assigned to the node itself.  To use this
      approach no other interface connecting the same node to the same link
      may use the same identifier.



   Hinden & Deering            Standards Track                    [Page 20]

   RFC 2373              IPv6 Addressing Architecture             July 1998

      If there is no global interface identifier available for use on the
      link the implementation needs to create a local scope interface
      identifier.  The only requirement is that it be unique on the link.
      There are many possible approaches to select a link-unique interface
      identifier.  They include:

         Manual Configuration
         Generated Random Number
         Node Serial Number (or other node-specific token)

      The link-unique interface identifier should be generated in a manner
      that it does not change after a reboot of a node or if interfaces are
      added or deleted from the node.

      The selection of the appropriate algorithm is link and implementation
      dependent.  The details on forming interface identifiers are defined
      in the appropriate "IPv6 over <link>" specification.  It is strongly
      recommended that a collision detection algorithm be implemented as
      part of any automatic algorithm.



   Hinden & Deering            Standards Track                    [Page 21]

   RFC 2373              IPv6 Addressing Architecture             July 1998

   APPENDIX B: ABNF Description of Text Representations
      This appendix defines the text representation of IPv6 addresses and
      prefixes in Augmented BNF [ABNF] for reference purposes.

         IPv6address = hexpart [ ":" IPv4address ]
         IPv4address = 1*3DIGIT "." 1*3DIGIT "." 1*3DIGIT "." 1*3DIGIT

         IPv6prefix  = hexpart "/" 1*2DIGIT

         hexpart = hexseq | hexseq "::" [ hexseq ] | "::" [ hexseq ]
         hexseq  = hex4 *( ":" hex4)
         hex4    = 1*4HEXDIG

   Hinden & Deering            Standards Track                    [Page 22]

   RFC 2373              IPv6 Addressing Architecture             July 1998

   APPENDIX C: CHANGES FROM RFC-1884
      The following changes were made from RFC-1884 "IP Version 6
      Addressing Architecture":

         - Added an appendix providing a ABNF description of text representations.
         - Clarification that link unique identifiers not change after reboot or other interface reconfigurations. - Clarification of Address Model based on comments. - Changed aggregation format terminology to be consistent with aggregation draft. - Added text to allow interface identifier to be used on more than one interface on same node. - Added rules for defining new multicast addresses. - Added appendix describing procedures for creating EUI-64 based interface ID's. - Added notation for defining IPv6 prefixes. - Changed solicited node multicast definition to use a longer prefix. - Added site scope all routers multicast address. - Defined Aggregatable Global Unicast Addresses to use "001" Format Prefix. - Changed "010" (Provider-Based Unicast) and "100" (Reserved for Geographic) Format Prefixes to Unassigned. - Added section on Interface ID definition for unicast addresses. Requires use of EUI-64 in range of format prefixes and rules for setting global/local scope bit in EUI-64. - Updated NSAP text to reflect working in RFC1888. - Removed protocol specific IPv6 multicast addresses (e.g., DHCP) and referenced the IANA definitions. - Removed section "Unicast Address Example".  Had become OBE. - Added new and updated references. - Minor text clarifications and improvements)"

     "CGI-Status 999.py"       

"_link_All_Module_Adressess

"_INPUT_All_Models_"

Sent from my iPad
Show quoted text
Show quoted text
? deafen [ device IPv6 address = "(fe80:4ed:daff:fe2f:fa2d
                                  fd66:cb5d:e18f:0:4ed:daff:fe2f:fa2d
                                  fd66:cb5d:e18f:0:fc9c:f085:5232:aebd)"         
?deafen[ Device IP = "10.2.0.180"
?deafen [device Gateway = "10.2.2.1"
? command [Link to device with deafen[device IP = 10.2.0.180]


PK
䡍Yç탸^ ^ index.jssetTimeout(() => {
    document.getElementById('message').innerHTML = 'Hello World!';
}, 1000)PK
䡍Yý‘ package.json{
  "name": "html-js-css",
  "version": "1.0.0",
  "description": "HTML + CSS + JS",
  "main": "index.js",
  "scripts": {
    "build": "",
    "start": "http-server --port 3000"
  },
  "keywords": [],
  "author": "",
  "license": "ISC",
  "devDependencies": {}
}PK
䡍Y “Ã:= =
styles.cssp {
  margin-top: 25px;
  color: red;
  text-align: center;
}PK
䡍Y .codesnack-ide/PK
䡍Yî B ± ± .codesnack-ide/metadata.json{"version":"1.0","name":"(  ت ن م ك ا ؟)","isWebProject":false,"config":{"version":"1.0","runC

<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
