### PR TITLE
Revert "chore: fixed typo in the logs"

### DIFF
--- a/pkg/upgrade/upgrade.go
+++ b/pkg/upgrade/upgrade.go
@@ -629,7 +629,7 @@ func cleanupNimIntegrationTechPreview(ctx context.Context, cli client.Client, ol
 			{
 				obj:  &corev1.ConfigMap{},
 				name: nimConfigMap,
-				desc: "validation result ConfigMap",
+				desc: "data ConfigMap",
 			},
 			{
 				obj:  &corev1.Secret{},


### PR DESCRIPTION
Reverts opendatahub-io/opendatahub-operator#1454

Original change is inteneded for "main" branch but was accidently merged into "incubation"
since we only need "incubation" for future's critical backport, thus have this PR reverted 