### PR TITLE
chore: disable deprecated linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -97,11 +97,13 @@ linters:
     - varnamelen # doesnot allow shorter names like c,k etc. But golang prefers short named vars.
     - wsl # [too strict and mostly code is not more readable] whitespace linter forces you to use empty lines
     - wrapcheck # check if this is required. Prevents direct return of err.
+    - exportloopref # Since Go1.22 (loopvar) this linter is no longer relevant. Replaced by copyloopvar.
+    - execinquery # Deprecated upstream. Not applicable since we don't make DB queries.
 
     # Need to check
     - nlreturn # [too strict and mostly code is not more readable] checks for a new line before return and branch statements to increase code clarity
     - err113 # [too strict] checks the errors handling expressions
-    
+
     # To be fixed
     - gocognit # https://github.com/opendatahub-io/opendatahub-operator/issues/709
     - cyclop   # https://github.com/opendatahub-io/opendatahub-operator/issues/709


### PR DESCRIPTION
-------

<!---
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

<!--- Link your JIRA and related links here for reference. -->


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Before (see warnings):
```
➜ make lint
test -s /var/home/gryan/src/github.com/opendatahub-io/opendatahub-operator/bin/golangci-lint || { curl -sSfL 'https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh' | bash -s v1.61.0; }
/var/home/gryan/src/github.com/opendatahub-io/opendatahub-operator/bin/golangci-lint run --timeout=5m0s --sort-results
WARN The linter 'exportloopref' is deprecated (since v1.60.2) due to: Since Go1.22 (loopvar) this linter is no longer relevant. Replaced by copyloopvar. 
WARN The linter 'execinquery' is deprecated (since v1.58.0) due to: The repository of the linter has been archived by the owner.  
```

After (no warnings):
```
➜ make lint
test -s /var/home/gryan/src/github.com/opendatahub-io/opendatahub-operator/bin/golangci-lint || { curl -sSfL 'https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh' | bash -s v1.61.0; }
/var/home/gryan/src/github.com/opendatahub-io/opendatahub-operator/bin/golangci-lint run --timeout=5m0s --sort-results

```

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work