### PR TITLE
feat: add support for kueue to work with VAP on OCP 4.16+

### DIFF
--- a/bundle/manifests/opendatahub-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/opendatahub-operator.clusterserviceversion.yaml
@@ -293,6 +293,8 @@ spec:
           - admissionregistration.k8s.io
           resources:
           - mutatingwebhookconfigurations
+          - validatingadmissionpolicies
+          - validatingadmissionpolicybindings
           - validatingwebhookconfigurations
           verbs:
           - create

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -28,6 +28,8 @@ rules:
   - admissionregistration.k8s.io
   resources:
   - mutatingwebhookconfigurations
+  - validatingadmissionpolicies
+  - validatingadmissionpolicybindings
   - validatingwebhookconfigurations
   verbs:
   - create

--- a/controllers/components/kueue/kueue.go
+++ b/controllers/components/kueue/kueue.go
@@ -23,6 +23,8 @@ import (
 
 type componentHandler struct{}
 
+var enableVAP bool
+
 func init() { //nolint:gochecknoinits
 	cr.Add(&componentHandler{})
 }

--- a/controllers/components/kueue/kueue.go
+++ b/controllers/components/kueue/kueue.go
@@ -23,8 +23,6 @@ import (
 
 type componentHandler struct{}
 
-var enableVAP bool
-
 func init() { //nolint:gochecknoinits
 	cr.Add(&componentHandler{})
 }

--- a/controllers/components/kueue/kueue_controller_actions.go
+++ b/controllers/components/kueue/kueue_controller_actions.go
@@ -5,13 +5,19 @@ import (
 	"fmt"
 
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/apis/components/v1alpha1"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
 	odhtypes "github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
 	odhdeploy "github.com/opendatahub-io/opendatahub-operator/v2/pkg/deploy"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/metadata/annotations"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/resources"
 )
 
 func initialize(_ context.Context, rr *odhtypes.ReconciliationRequest) error {
 	rr.Manifests = append(rr.Manifests, manifestsPath())
-
+	// Add specific manifests if OCP is greater or equal 4.17.
+	if enableVAP {
+		rr.Manifests = append(rr.Manifests, extramanifestsPath())
+	}
 	return nil
 }
 
@@ -40,5 +46,16 @@ func devFlags(ctx context.Context, rr *odhtypes.ReconciliationRequest) error {
 		}
 	}
 
+	return nil
+}
+
+func customizeResources(_ context.Context, rr *odhtypes.ReconciliationRequest) error {
+	for i := range rr.Resources {
+		if rr.Resources[i].GroupVersionKind() == gvk.ValidatingAdmissionPolicyBinding {
+			// admin can update this resource
+			resources.SetAnnotation(&rr.Resources[i], annotations.ManagedByODHOperator, "false")
+			break // fast exist function
+		}
+	}
 	return nil
 }

--- a/controllers/components/kueue/kueue_controller_actions.go
+++ b/controllers/components/kueue/kueue_controller_actions.go
@@ -14,10 +14,12 @@ import (
 
 func initialize(_ context.Context, rr *odhtypes.ReconciliationRequest) error {
 	rr.Manifests = append(rr.Manifests, manifestsPath())
+	return nil
+}
+
+func extraInitialize(_ context.Context, rr *odhtypes.ReconciliationRequest) error {
 	// Add specific manifests if OCP is greater or equal 4.17.
-	if enableVAP {
-		rr.Manifests = append(rr.Manifests, extramanifestsPath())
-	}
+	rr.Manifests = append(rr.Manifests, extramanifestsPath())
 	return nil
 }
 

--- a/controllers/components/kueue/kueue_support.go
+++ b/controllers/components/kueue/kueue_support.go
@@ -1,6 +1,8 @@
 package kueue
 
 import (
+	"context"
+
 	conditionsv1 "github.com/openshift/custom-resource-status/conditions/v1"
 
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/apis/components/v1alpha1"
@@ -32,4 +34,17 @@ func manifestsPath() odhtypes.ManifestInfo {
 		ContextDir: ComponentName,
 		SourcePath: "rhoai",
 	}
+}
+
+func extramanifestsPath() odhtypes.ManifestInfo {
+	return odhtypes.ManifestInfo{
+		Path:       odhdeploy.DefaultManifestPath,
+		ContextDir: ComponentName,
+		SourcePath: "rhoai/ocp-4.17-addons",
+	}
+}
+
+// return true if OCP is greater or equal 4.17.
+func vapPredicate(context.Context, *odhtypes.ReconciliationRequest) bool {
+	return enableVAP
 }

--- a/controllers/components/kueue/kueue_support.go
+++ b/controllers/components/kueue/kueue_support.go
@@ -1,8 +1,6 @@
 package kueue
 
 import (
-	"context"
-
 	conditionsv1 "github.com/openshift/custom-resource-status/conditions/v1"
 
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/apis/components/v1alpha1"
@@ -42,9 +40,4 @@ func extramanifestsPath() odhtypes.ManifestInfo {
 		ContextDir: ComponentName,
 		SourcePath: "rhoai/ocp-4.17-addons",
 	}
-}
-
-// return true if OCP is greater or equal 4.17.
-func vapPredicate(context.Context, *odhtypes.ReconciliationRequest) bool {
-	return enableVAP
 }

--- a/controllers/datasciencecluster/kubebuilder_rbac.go
+++ b/controllers/datasciencecluster/kubebuilder_rbac.go
@@ -156,6 +156,8 @@ package datasciencecluster
 // +kubebuilder:rbac:groups=components.platform.opendatahub.io,resources=kueues/finalizers,verbs=update
 // +kubebuilder:rbac:groups="monitoring.coreos.com",resources=prometheusrules,verbs=get;create;patch;delete;deletecollection;list;watch
 // +kubebuilder:rbac:groups="monitoring.coreos.com",resources=podmonitors,verbs=get;create;delete;update;watch;list;patch
+// +kubebuilder:rbac:groups="admissionregistration.k8s.io",resources=validatingadmissionpolicybindings,verbs=get;create;delete;update;watch;list;patch
+// +kubebuilder:rbac:groups="admissionregistration.k8s.io",resources=validatingadmissionpolicies,verbs=get;create;delete;update;watch;list;patch
 
 // CFO
 //+kubebuilder:rbac:groups=components.platform.opendatahub.io,resources=codeflares,verbs=get;list;watch;create;update;patch;delete
@@ -191,7 +193,7 @@ package datasciencecluster
 // +kubebuilder:rbac:groups="operator.knative.dev",resources=knativeservings,verbs=*
 // +kubebuilder:rbac:groups="config.openshift.io",resources=ingresses,verbs=get
 
-// TODO: WB
+// WB
 // +kubebuilder:rbac:groups=components.platform.opendatahub.io,resources=workbenches,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=components.platform.opendatahub.io,resources=workbenches/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=components.platform.opendatahub.io,resources=workbenches/finalizers,verbs=update

--- a/pkg/cluster/const.go
+++ b/pkg/cluster/const.go
@@ -15,4 +15,7 @@ const (
 
 	// Default cluster-scope Authentication CR name.
 	ClusterAuthenticationObj = "cluster"
+
+	// Default OpenShift version CR name.
+	OpenShiftVersionObj = "version"
 )

--- a/pkg/cluster/gvk/gvk.go
+++ b/pkg/cluster/gvk/gvk.go
@@ -219,4 +219,16 @@ var (
 		Version: "v1alpha1",
 		Kind:    "Auth",
 	}
+
+	ValidatingAdmissionPolicy = schema.GroupVersionKind{
+		Group:   "admissionregistration.k8s.io",
+		Version: "v1",
+		Kind:    "ValidatingAdmissionPolicy",
+	}
+
+	ValidatingAdmissionPolicyBinding = schema.GroupVersionKind{
+		Group:   "admissionregistration.k8s.io",
+		Version: "v1",
+		Kind:    "ValidatingAdmissionPolicyBinding",
+	}
 )

--- a/tests/e2e/components_test.go
+++ b/tests/e2e/components_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/blang/semver/v4"
+	configv1 "github.com/openshift/api/config/v1"
 	operatorv1 "github.com/openshift/api/operator/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -15,6 +17,7 @@ import (
 	"github.com/opendatahub-io/opendatahub-operator/v2/apis/common"
 	dscv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/datasciencecluster/v1"
 	dsciv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/dscinitialization/v1"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/metadata/labels"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/resources"
@@ -277,4 +280,14 @@ func (c *ComponentTestCtx) GetDSCI() (*dsciv1.DSCInitialization, error) {
 	}
 
 	return &obj, nil
+}
+
+func (c *ComponentTestCtx) GetClusterVersion() (semver.Version, error) {
+	clusterVersion := &configv1.ClusterVersion{}
+	if err := c.Client().Get(c.Context(), client.ObjectKey{
+		Name: cluster.OpenShiftVersionObj,
+	}, clusterVersion); err != nil {
+		return semver.Version{}, err
+	}
+	return semver.ParseTolerant(clusterVersion.Status.History[0].Version)
 }

--- a/tests/e2e/kueue_test.go
+++ b/tests/e2e/kueue_test.go
@@ -3,9 +3,19 @@ package e2e_test
 import (
 	"testing"
 
+	"github.com/blang/semver/v4"
 	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/apis/components/v1alpha1"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/resources"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/matchers/jq"
+
+	. "github.com/onsi/gomega"
 )
 
 func kueueTestSuite(t *testing.T) {
@@ -20,10 +30,36 @@ func kueueTestSuite(t *testing.T) {
 
 	t.Run("Validate component enabled", componentCtx.ValidateComponentEnabled)
 	t.Run("Validate operands have OwnerReferences", componentCtx.ValidateOperandsOwnerReferences)
+	t.Run("Validate Kueue Dynamically create VAP", componentCtx.validateKueueVAPReady)
 	t.Run("Validate update operand resources", componentCtx.ValidateUpdateDeploymentsResources)
 	t.Run("Validate component disabled", componentCtx.ValidateComponentDisabled)
 }
 
 type KueueTestCtx struct {
 	*ComponentTestCtx
+}
+
+func (tc *KueueTestCtx) validateKueueVAPReady(t *testing.T) {
+	g := tc.NewWithT(t)
+	if cluster.GetClusterInfo().Version.GTE(semver.MustParse("4.17.0")) {
+		g.Get(gvk.ValidatingAdmissionPolicy, types.NamespacedName{Name: "kueue-validating-admission-policy"}).Eventually().Should(
+			jq.Match(`.metadata.ownerReferences == "%s"`, componentApi.KueueInstanceName),
+		)
+		vapb, err := g.Get(gvk.ValidatingAdmissionPolicyBinding, types.NamespacedName{Name: "kueue-validating-admission-policy-binding"}).Get()
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(vapb.GetOwnerReferences()).Should(BeEmpty())
+		return
+	}
+	scheme := runtime.NewScheme()
+	vap := &unstructured.Unstructured{}
+	vap.SetKind(gvk.ValidatingAdmissionPolicy.Kind)
+	err := resources.EnsureGroupVersionKind(scheme, vap)
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("failed to get GVK"))
+
+	vapb := &unstructured.Unstructured{}
+	vapb.SetKind(gvk.ValidatingAdmissionPolicyBinding.Kind)
+	err = resources.EnsureGroupVersionKind(scheme, vapb)
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("failed to get GVK"))
 }

--- a/tests/e2e/kueue_test.go
+++ b/tests/e2e/kueue_test.go
@@ -28,8 +28,8 @@ func kueueTestSuite(t *testing.T) {
 
 	t.Run("Validate component enabled", componentCtx.ValidateComponentEnabled)
 	t.Run("Validate operands have OwnerReferences", componentCtx.ValidateOperandsOwnerReferences)
-	t.Run("Validate Kueue Dynamically create VAP", componentCtx.validateKueueVAPReady)
 	t.Run("Validate update operand resources", componentCtx.ValidateUpdateDeploymentsResources)
+	t.Run("Validate Kueue Dynamically create VAP and VAPB", componentCtx.validateKueueVAPReady)
 	t.Run("Validate component disabled", componentCtx.ValidateComponentDisabled)
 }
 


### PR DESCRIPTION
- only add VAP specific manifests into list if latest OCP version in history is over 16 in min version
- add check OCP function to get OCP version during main startup, and value can be access by components also show in the dsc status

<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

<!--- Link your JIRA and related links here for reference. -->
https://issues.redhat.com/browse/RHOAIENG-16133

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
manual test on quay.io/wenzhou/opendatahub-operator-catalog:v2.17.1613315
spin up two clusters
- 4.17.9:  
   create DSCI, DSC only enable kueue
   kueue CR ready, 2 new resource VAP and VAPB created
   change VAPB action from Deny to Warn, it keeps new value
   disable kueue
   kueue CR removed, VAP removed, VAPB remains
- 4.15.6 then upgrade to 4.16.27: cretae DSCI, DSC only enable kueue
   kueue CR ready, no API registered in cluster for VAP/VAPB CRD, operator pod not throw error

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
