### PR TITLE
feat: KServe InferenceGraph auth configurations [main]

### DIFF
--- a/controllers/components/kserve/kserve_support.go
+++ b/controllers/components/kserve/kserve_support.go
@@ -115,6 +115,8 @@ func defineServiceMeshFeatures(ctx context.Context, cli client.Client, dscispec 
 							path.Join(Resources.ServiceMeshDir, "activator-envoyfilter.tmpl.yaml"),
 							path.Join(Resources.ServiceMeshDir, "envoy-oauth-temp-fix.tmpl.yaml"),
 							path.Join(Resources.ServiceMeshDir, "kserve-predictor-authorizationpolicy.tmpl.yaml"),
+							path.Join(Resources.ServiceMeshDir, "kserve-inferencegraph-envoyfilter.tmpl.yaml"),
+							path.Join(Resources.ServiceMeshDir, "kserve-inferencegraph-authorizationpolicy.tmpl.yaml"),
 						),
 				).
 				Managed().

--- a/controllers/components/kserve/resources/servicemesh/kserve-inferencegraph-authorizationpolicy.tmpl.yaml
+++ b/controllers/components/kserve/resources/servicemesh/kserve-inferencegraph-authorizationpolicy.tmpl.yaml
@@ -1,0 +1,23 @@
+apiVersion: security.istio.io/v1beta1
+kind: AuthorizationPolicy
+metadata:
+  name: kserve-inferencegraph
+  namespace: {{ .ControlPlane.Namespace }}
+  labels:
+    app.opendatahub.io/kserve: "true"
+    app.kubernetes.io/part-of: kserve
+spec:
+  action: CUSTOM
+  provider:
+    name: {{ .AuthExtensionName }}
+  rules:
+  - to:
+    - operation:
+        notPaths:
+        - /healthz
+        - /debug/pprof/
+        - /metrics
+        - /wait-for-drain
+  selector:
+    matchLabels:
+      serving.kserve.io/kind: InferenceGraph

--- a/controllers/components/kserve/resources/servicemesh/kserve-inferencegraph-envoyfilter.tmpl.yaml
+++ b/controllers/components/kserve/resources/servicemesh/kserve-inferencegraph-envoyfilter.tmpl.yaml
@@ -1,0 +1,43 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: EnvoyFilter
+metadata:
+  name: kserve-inferencegraph-host-header
+  namespace: {{ .ControlPlane.Namespace }}
+  labels:
+    app.opendatahub.io/kserve: "true"
+    app.kubernetes.io/part-of: kserve
+spec:
+  priority: 20
+  workloadSelector:
+    labels:
+      serving.kserve.io/kind: InferenceGraph
+  configPatches:
+  - applyTo: HTTP_FILTER
+    match:
+      listener:
+        filterChain:
+          filter:
+            name: envoy.filters.network.http_connection_manager
+    patch:
+      operation: INSERT_BEFORE
+      value:
+        name: envoy.filters.http.lua
+        typed_config:
+          '@type': type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua
+          inlineCode: |
+           function envoy_on_request(request_handle)
+              local headers = request_handle:headers()
+              if not headers then
+                return
+              end
+           
+              local original_host = headers:get("k-original-host")
+              if original_host then
+           
+                port_seperator = string.find(original_host, ":", 7)
+                if port_seperator then
+                  original_host = string.sub(original_host, 0, port_seperator-1)
+                end
+                headers:replace('host', original_host)
+              end
+            end


### PR DESCRIPTION
## Description
This adds resources required to support auth for KServe InferenceGraphs.

https://issues.redhat.com/browse/RHOAIENG-13449

Other related PRs:
* opendatahub-io/kserve#463
* opendatahub-io/odh-model-controller#345

## How Has This Been Tested?
1. Deploy operator
2. Install KServe
3. Check that the new resources are present

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
