### PR TITLE
codecov config to show code coverage numbers on every PR as informational and not blocking

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,5 +1,3 @@
-codecov:
-  branch: main # set new Default branch
 coverage:
   status:
     project:

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,2 +1,10 @@
 codecov:
   branch: main # set new Default branch
+coverage:
+  status:
+    project:
+      default:
+        informational: false
+    patch:
+      default:
+        informational: false

--- a/codecov.yml
+++ b/codecov.yml
@@ -4,7 +4,7 @@ coverage:
   status:
     project:
       default:
-        informational: false
+        informational: true
     patch:
       default:
         informational: true

--- a/codecov.yml
+++ b/codecov.yml
@@ -7,4 +7,4 @@ coverage:
         informational: false
     patch:
       default:
-        informational: false
+        informational: true


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->
This configuration will make codecov informational and will not block to merge on Pull Requests as first step defined on:
https://about.codecov.io/blog/the-5-levels-of-code-coverage-how-to-build-a-testing-culture-in-your-organization/

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
