### PR TITLE
RHOAIENG-18095: Deprecation of kube-rbac-proxy

### DIFF
--- a/config/monitoring/prometheus/apps/prometheus-configs.yaml
+++ b/config/monitoring/prometheus/apps/prometheus-configs.yaml
@@ -334,7 +334,11 @@ data:
     - job_name: 'Kueue Operator'
       honor_labels: true
       metrics_path: /metrics
-      scheme: http
+      scheme: https
+      tls_config:
+        insecure_skip_verify: true
+      authorization:
+        credentials_file: /run/secrets/kubernetes.io/serviceaccount/token
       kubernetes_sd_configs:
         - role: endpoints
           namespaces:
@@ -348,7 +352,7 @@ data:
         - source_labels: [__address__]
           regex: (.+):(\d+)
           target_label: __address__
-          replacement: ${1}:8080
+          replacement: ${1}:8443
 
     - job_name: 'TrustyAI Controller Manager'
       honor_labels: true


### PR DESCRIPTION
## Description
With the deprecation of kube-rbac-proxy  , we have changed the /metrics  port to 8443 . And so the prometheus.yml file contained redhat-ods-monitoring/prometheus must be updated also to reflect that change.


## How Has This Been Tested?



## Screenshot or short clip
<img width="1509" alt="image" src="https://github.com/user-attachments/assets/d4394255-0cbc-497a-a23e-f6ef9f7b9be6" />



## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
