### PR TITLE
componentsregistry: use structure to store handlers

### DIFF
--- a/controllers/datasciencecluster/datasciencecluster_controller.go
+++ b/controllers/datasciencecluster/datasciencecluster_controller.go
@@ -101,7 +101,7 @@ func (r *DataScienceClusterReconciler) Reconcile(ctx context.Context, req ctrl.R
 	}
 
 	// deploy components
-	if err := r.reconcileComponents(ctx, instance); err != nil {
+	if err := r.reconcileComponents(ctx, instance, cr.DefaultRegistry()); err != nil {
 		log.Info(err.Error())
 		status.SetCondition(&instance.Status.Conditions, "Degraded", status.ReconcileFailed, err.Error(), corev1.ConditionTrue)
 	}
@@ -150,13 +150,16 @@ func (r *DataScienceClusterReconciler) validate(ctx context.Context, _ *dscv1.Da
 	return nil
 }
 
-func (r *DataScienceClusterReconciler) reconcileComponents(ctx context.Context, instance *dscv1.DataScienceCluster) error {
+func (r *DataScienceClusterReconciler) reconcileComponents(
+	ctx context.Context,
+	instance *dscv1.DataScienceCluster,
+	reg *cr.Registry) error {
 	log := logf.FromContext(ctx).WithName("DataScienceCluster")
 
 	notReadyComponents := make([]string, 0)
 
 	// all DSC defined components
-	componentErrors := cr.ForEach(func(component cr.ComponentHandler) error {
+	componentErrors := reg.ForEach(func(component cr.ComponentHandler) error {
 		ci, err := r.reconcileComponent(ctx, instance, component)
 		if err != nil {
 			return err

--- a/pkg/componentsregistry/componentsregistry.go
+++ b/pkg/componentsregistry/componentsregistry.go
@@ -32,23 +32,41 @@ type ComponentHandler interface {
 	UpdateDSCStatus(dsc *dscv1.DataScienceCluster, obj client.Object) error
 }
 
-var registry = []ComponentHandler{}
-
-// Add registers a new component handler
-// not thread safe, supposed to be called during init.
-// TODO: check if init() can be called in parallel.
-func Add(ch ComponentHandler) {
-	registry = append(registry, ch)
+// Registry is a struct that maintains a list of registered ComponentHandlers.
+type Registry struct {
+	handlers []ComponentHandler
 }
 
-// ForEach iterates over all registered component handlers
+var r = &Registry{}
+
+// Add registers a new ComponentHandler to the registry.
+// not thread safe, supposed to be called during init.
+func (r *Registry) Add(ch ComponentHandler) {
+	r.handlers = append(r.handlers, ch)
+}
+
+// ForEach iterates over all registered ComponentHandlers and applies the given function.
+// If any handler returns an error, that error is collected and returned at the end.
 // With go1.23 probably https://go.dev/blog/range-functions can be used.
-func ForEach(f func(ch ComponentHandler) error) error {
+func (r *Registry) ForEach(f func(ch ComponentHandler) error) error {
 	var errs *multierror.Error
-	for _, ch := range registry {
+	for _, ch := range r.handlers {
 		errs = multierror.Append(errs, f(ch))
 	}
+
 	return errs.ErrorOrNil()
+}
+
+func Add(ch ComponentHandler) {
+	r.Add(ch)
+}
+
+func ForEach(f func(ch ComponentHandler) error) error {
+	return r.ForEach(f)
+}
+
+func DefaultRegistry() *Registry {
+	return r
 }
 
 func IsManaged(ch ComponentHandler, dsc *dscv1.DataScienceCluster) bool {


### PR DESCRIPTION
To make it possible to mock registry in DSC reconcileComponents for testing, implement registry as a structure. Make package level wrappers on Add and ForEach methods which operate on the default statically created registry.

This allows keep working with the default registry in a real system without extra arguments like before. It's in init()s and in main(). But code under test can accept testing version when needed.

<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
