### PR TITLE
Cleanup of deprecated RoleBinding

### DIFF
--- a/controllers/dscinitialization/dscinitialization_test.go
+++ b/controllers/dscinitialization/dscinitialization_test.go
@@ -7,7 +7,6 @@ import (
 	userv1 "github.com/openshift/api/user/v1"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
-	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -76,32 +75,6 @@ var _ = Describe("DataScienceCluster initialization", func() {
 			Expect(foundNetworkPolicy.Name).To(Equal(applicationNamespace))
 			Expect(foundNetworkPolicy.Namespace).To(Equal(applicationNamespace))
 			Expect(foundNetworkPolicy.Spec.PolicyTypes[0]).To(Equal(networkingv1.PolicyTypeIngress))
-		})
-
-		It("Should create default rolebinding", func(ctx context.Context) {
-			// then
-			foundRoleBinding := &rbacv1.RoleBinding{}
-			Eventually(objectExists(applicationNamespace, applicationNamespace, foundRoleBinding)).
-				WithContext(ctx).
-				WithTimeout(timeout).
-				WithPolling(interval).
-				Should(BeTrue())
-			expectedSubjects := []rbacv1.Subject{
-				{
-					Kind:      "ServiceAccount",
-					Namespace: applicationNamespace,
-					Name:      "default",
-				},
-			}
-			expectedRoleRef := rbacv1.RoleRef{
-				APIGroup: "rbac.authorization.k8s.io",
-				Kind:     "ClusterRole",
-				Name:     "system:openshift:scc:anyuid",
-			}
-			Expect(foundRoleBinding.Name).To(Equal(applicationNamespace))
-			Expect(foundRoleBinding.Namespace).To(Equal(applicationNamespace))
-			Expect(foundRoleBinding.Subjects).To(Equal(expectedSubjects))
-			Expect(foundRoleBinding.RoleRef).To(Equal(expectedRoleRef))
 		})
 
 		It("Should create default configmap", func(ctx context.Context) {
@@ -174,54 +147,6 @@ var _ = Describe("DataScienceCluster initialization", func() {
 	Context("Handling existing resources", func() {
 		AfterEach(cleanupResources)
 		const applicationName = "default-dsci"
-
-		It("Should not update rolebinding if it exists", func(ctx context.Context) {
-
-			// given
-			desiredRoleBinding := &rbacv1.RoleBinding{
-				TypeMeta: metav1.TypeMeta{
-					Kind:       "RoleBinding",
-					APIVersion: "v1",
-				},
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      applicationNamespace,
-					Namespace: applicationNamespace,
-				},
-
-				RoleRef: rbacv1.RoleRef{
-					APIGroup: "rbac.authorization.k8s.io",
-					Kind:     "ClusterRole",
-					Name:     "system:openshift:scc:anyuid",
-				},
-			}
-			Expect(k8sClient.Create(ctx, desiredRoleBinding)).Should(Succeed())
-			createdRoleBinding := &rbacv1.RoleBinding{}
-			Eventually(objectExists(applicationNamespace, applicationNamespace, createdRoleBinding)).
-				WithContext(ctx).
-				WithTimeout(timeout).
-				WithPolling(interval).
-				Should(BeTrue())
-
-			// when
-			desiredDsci := createDSCI(operatorv1.Managed, operatorv1.Managed, monitoringNamespace)
-			Expect(k8sClient.Create(ctx, desiredDsci)).Should(Succeed())
-			foundDsci := &dsciv1.DSCInitialization{}
-			Eventually(dscInitializationIsReady(applicationName, workingNamespace, foundDsci)).
-				WithContext(ctx).
-				WithTimeout(timeout).
-				WithPolling(interval).
-				Should(BeTrue())
-
-			// then
-			foundRoleBinding := &rbacv1.RoleBinding{}
-			Eventually(objectExists(applicationNamespace, applicationNamespace, foundRoleBinding)).
-				WithContext(ctx).
-				WithTimeout(timeout).
-				WithPolling(interval).
-				Should(BeTrue())
-			Expect(foundRoleBinding.UID).To(Equal(createdRoleBinding.UID))
-			Expect(foundRoleBinding.Subjects).To(BeNil())
-		})
 
 		It("Should not update configmap if it exists", func(ctx context.Context) {
 
@@ -379,20 +304,8 @@ func cleanupResources(ctx context.Context) {
 
 	Expect(k8sClient.DeleteAllOf(ctx, &networkingv1.NetworkPolicy{}, appNamespace)).To(Succeed())
 	Expect(k8sClient.DeleteAllOf(ctx, &corev1.ConfigMap{}, appNamespace)).To(Succeed())
-	Expect(k8sClient.DeleteAllOf(ctx, &rbacv1.RoleBinding{}, appNamespace)).To(Succeed())
-	Expect(k8sClient.DeleteAllOf(ctx, &rbacv1.ClusterRoleBinding{}, appNamespace)).To(Succeed())
 
 	Eventually(noInstanceExistsIn(workingNamespace, &dsciv1.DSCInitializationList{})).
-		WithContext(ctx).
-		WithTimeout(timeout).
-		WithPolling(interval).
-		Should(BeTrue())
-	Eventually(noInstanceExistsIn(applicationNamespace, &rbacv1.ClusterRoleBindingList{})).
-		WithContext(ctx).
-		WithTimeout(timeout).
-		WithPolling(interval).
-		Should(BeTrue())
-	Eventually(noInstanceExistsIn(applicationNamespace, &rbacv1.RoleBindingList{})).
 		WithContext(ctx).
 		WithTimeout(timeout).
 		WithPolling(interval).

--- a/controllers/dscinitialization/utils.go
+++ b/controllers/dscinitialization/utils.go
@@ -42,8 +42,7 @@ var (
 //
 // - 2. Patch monitoring namespace
 // - 3. Network Policies 'opendatahub' that allow traffic between the ODH namespaces
-// - 4. ConfigMap 'odh-common-config'
-// - 5. RoleBinding 'opendatahub'.
+// - 4. ConfigMap 'odh-common-config'.
 func (r *DSCInitializationReconciler) createOperatorResource(ctx context.Context, dscInit *dsciv1.DSCInitialization, platform cluster.Platform) error {
 	log := logf.FromContext(ctx)
 

--- a/controllers/dscinitialization/utils.go
+++ b/controllers/dscinitialization/utils.go
@@ -12,7 +12,6 @@ import (
 	userv1 "github.com/openshift/api/user/v1"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
-	rbacv1 "k8s.io/api/rbac/v1"
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -74,12 +73,6 @@ func (r *DSCInitializationReconciler) createOperatorResource(ctx context.Context
 		return err
 	}
 
-	// Create default Rolebinding for the namespace
-	err = r.createDefaultRoleBinding(ctx, dscInit)
-	if err != nil {
-		log.Error(err, "error creating rolebinding", "name", dscInit.Spec.ApplicationsNamespace)
-		return err
-	}
 	return nil
 }
 
@@ -175,55 +168,6 @@ func (r *DSCInitializationReconciler) patchMonitoringNS(ctx context.Context, dsc
 		log.Error(err, "Unable to create or patcth monitoirng namespace")
 	}
 	return err
-}
-
-func (r *DSCInitializationReconciler) createDefaultRoleBinding(ctx context.Context, dscInit *dsciv1.DSCInitialization) error {
-	log := logf.FromContext(ctx)
-	name := dscInit.Spec.ApplicationsNamespace
-	// Expected namespace for the given name
-	desiredRoleBinding := &rbacv1.RoleBinding{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "RoleBinding",
-			APIVersion: "v1",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: name,
-		},
-		Subjects: []rbacv1.Subject{
-			{
-				Kind:      "ServiceAccount",
-				Namespace: name,
-				Name:      "default",
-			},
-		},
-		RoleRef: rbacv1.RoleRef{
-			APIGroup: "rbac.authorization.k8s.io",
-			Kind:     "ClusterRole",
-			Name:     "system:openshift:scc:anyuid",
-		},
-	}
-
-	// Create RoleBinding if doesn't exists
-	foundRoleBinding := &rbacv1.RoleBinding{}
-	err := r.Client.Get(ctx, client.ObjectKeyFromObject(desiredRoleBinding), foundRoleBinding)
-	if err != nil {
-		if k8serr.IsNotFound(err) {
-			// Set Controller reference
-			err = ctrl.SetControllerReference(dscInit, desiredRoleBinding, r.Scheme)
-			if err != nil {
-				log.Error(err, "Unable to add OwnerReference to the rolebinding")
-				return err
-			}
-			err = r.Client.Create(ctx, desiredRoleBinding)
-			if err != nil && !k8serr.IsAlreadyExists(err) {
-				return err
-			}
-		} else {
-			return err
-		}
-	}
-	return nil
 }
 
 func (r *DSCInitializationReconciler) reconcileDefaultNetworkPolicy(

--- a/pkg/upgrade/upgrade.go
+++ b/pkg/upgrade/upgrade.go
@@ -255,6 +255,10 @@ func CleanupExistingResource(ctx context.Context,
 	deprecatedFeatureTrackers := []string{dscApplicationsNamespace + "-kserve-temporary-fixes"}
 	multiErr = multierror.Append(multiErr, deleteDeprecatedResources(ctx, cli, dscApplicationsNamespace, deprecatedFeatureTrackers, &featuresv1.FeatureTrackerList{}))
 
+	// Cleanup of deprecated default RoleBinding resources
+	deprecatedDefaultRoleBinding := []string{dscApplicationsNamespace}
+	multiErr = multierror.Append(multiErr, deleteDeprecatedResources(ctx, cli, dscApplicationsNamespace, deprecatedDefaultRoleBinding, &rbacv1.RoleBindingList{}))
+
 	// Handling for dashboard OdhDocument Jupyterhub CR, see jira #443 comments
 	odhDocJPH := getJPHOdhDocumentResources(
 		dscApplicationsNamespace,


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->
This PR ensures proper cleanup of the default RoleBinding that assigned the default ServiceAccount to the anyuid SCC.

It follows the previous [PR](https://github.com/opendatahub-io/opendatahub-operator/pull/1460) that removed ServiceAccounts like Notebook, ModelMesh, ModelController, and Dashboard from similar RoleBindings.

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
