### PR TITLE
e2e: improve testOwnedNamespacesAllExist by leveragin gomega's async assertions

### DIFF
--- a/tests/e2e/controller_test.go
+++ b/tests/e2e/controller_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/onsi/gomega"
 	operatorv1 "github.com/openshift/api/operator/v1"
 	routev1 "github.com/openshift/api/route/v1"
 	ofapi "github.com/operator-framework/api/pkg/operators/v1alpha1"
@@ -160,6 +161,9 @@ func TestOdhOperator(t *testing.T) {
 	utilruntime.Must(serviceApi.AddToScheme(Scheme))
 
 	log.SetLogger(zap.New(zap.UseDevMode(true)))
+
+	gomega.SetDefaultEventuallyTimeout(generalWaitTimeout)
+	gomega.SetDefaultEventuallyPollingInterval(generalPollInterval)
 
 	if testOpts.operatorControllerTest {
 		// individual test suites after the operator is running

--- a/tests/e2e/creation_test.go
+++ b/tests/e2e/creation_test.go
@@ -48,10 +48,7 @@ func creationTestSuite(t *testing.T) {
 			require.NoError(t, err, "error validating DSCInitialization instance")
 		})
 
-		t.Run("Check owned namespaces exist", func(t *testing.T) {
-			err = testCtx.testOwnedNamespacesAllExist()
-			require.NoError(t, err, "error owned namespace is missing")
-		})
+		t.Run("Check owned namespaces exist", testCtx.testOwnedNamespacesAllExist)
 
 		// DSC
 		t.Run("Creation of DataScienceCluster instance", func(t *testing.T) {


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

When the e2e test suite starts, it may take a while for some of the
owned namespace to become available and in such case the related test
would fail, since it does not retry. This commit replace the current
synchronous test with an asynchronous one.

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
