### PR TITLE
chore: remove generics from Reconcier and use PlatformObject as base object type

### DIFF
--- a/pkg/controller/reconciler/reconciler_support.go
+++ b/pkg/controller/reconciler/reconciler_support.go
@@ -192,7 +192,7 @@ func (b *ReconcilerBuilder[T]) OwnsGVK(gvk schema.GroupVersionKind, opts ...Watc
 	return b.Owns(resources.GvkToUnstructured(gvk), opts...)
 }
 
-func (b *ReconcilerBuilder[T]) Build(_ context.Context) (*Reconciler[T], error) {
+func (b *ReconcilerBuilder[T]) Build(_ context.Context) (*Reconciler, error) {
 	if b.errors != nil {
 		return nil, b.errors
 	}

--- a/pkg/controller/types/types.go
+++ b/pkg/controller/types/types.go
@@ -57,7 +57,7 @@ type ReconciliationRequest struct {
 	*odhClient.Client
 
 	Manager   *manager.Manager
-	Instance  client.Object
+	Instance  common.PlatformObject
 	DSCI      *dsciv1.DSCInitialization
 	Release   cluster.Release
 	Manifests []ManifestInfo


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->
- remove generics from Reconciler struct as it is not needed
- set PlatformObject as the base obnject that the Reconciler handles to
  ensure the reconciler can access to common objects fields

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] ~~Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.~~
- [ ] ~~Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).~~
- [ ] ~~The developer has manually tested the changes and verified that the changes work~~
