### PR TITLE
e2e: add cleanup logic to kserve tests to ensure no KnativeServing is present in the cluster

### DIFF
--- a/tests/e2e/helper_test.go
+++ b/tests/e2e/helper_test.go
@@ -2,6 +2,7 @@ package e2e_test
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log"
 	"strings"
@@ -16,6 +17,7 @@ import (
 	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -28,10 +30,12 @@ import (
 	infrav1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/infrastructure/v1"
 	serviceApi "github.com/opendatahub-io/opendatahub-operator/v2/apis/services/v1alpha1"
 	modelregistryctrl "github.com/opendatahub-io/opendatahub-operator/v2/controllers/components/modelregistry"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/metadata/labels"
 )
 
 const (
+	knativeServingNamespace  = "knative-serving"
 	servicemeshNamespace     = "openshift-operators"
 	servicemeshOpName        = "servicemeshoperator"
 	serverlessOpName         = "serverless-operator"
@@ -456,6 +460,43 @@ func ensureServicemeshOperators(t *testing.T, tc *testContext) error { //nolint:
 	return errors.ErrorOrNil()
 }
 
+// nolint: thelper
+func (tc *testContext) setUpServerless(t *testing.T) error {
+	ksl := unstructured.UnstructuredList{}
+	ksl.SetGroupVersionKind(gvk.KnativeServing)
+
+	if err := tc.customClient.List(tc.ctx, &ksl, client.InNamespace(knativeServingNamespace)); err != nil {
+		return fmt.Errorf("error listing Knative Serving objects: %w", err)
+	}
+
+	if len(ksl.Items) != 0 {
+		t.Logf("Detected %d Knative Serving objects in namespace %s", len(ksl.Items), knativeServingNamespace)
+	}
+
+	for _, obj := range ksl.Items {
+		data, err := json.Marshal(obj)
+		if err != nil {
+			return fmt.Errorf("error marshalling Knative Serving object: %w", err)
+		}
+
+		t.Logf("Deleting Knative Serving %s in namespace %s: %s", obj.GetName(), obj.GetNamespace(), string(data))
+
+		if err := tc.customClient.Delete(tc.ctx, &obj); err != nil && !k8serr.IsNotFound(err) {
+			return fmt.Errorf("error deleting Knative Serving object: %w", err)
+		}
+	}
+
+	return nil
+}
+
 func (tc *testContext) setUp(t *testing.T) error { //nolint: thelper
-	return ensureServicemeshOperators(t, tc)
+	if err := ensureServicemeshOperators(t, tc); err != nil {
+		return err
+	}
+
+	if err := tc.setUpServerless(t); err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/tests/e2e/helper_test.go
+++ b/tests/e2e/helper_test.go
@@ -460,7 +460,7 @@ func ensureServicemeshOperators(t *testing.T, tc *testContext) error { //nolint:
 	return errors.ErrorOrNil()
 }
 
-// nolint: thelper
+//nolint:thelper
 func (tc *testContext) setUpServerless(t *testing.T) error {
 	ksl := unstructured.UnstructuredList{}
 	ksl.SetGroupVersionKind(gvk.KnativeServing)

--- a/tests/e2e/kserve_test.go
+++ b/tests/e2e/kserve_test.go
@@ -4,7 +4,9 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/apis/components/v1alpha1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/controllers/components/modelcontroller"
@@ -26,6 +28,7 @@ func kserveTestSuite(t *testing.T) {
 		ComponentTestCtx: ct,
 	}
 
+	t.Run("Validate environment", componentCtx.validateEnv)
 	t.Run("Validate component enabled", componentCtx.ValidateComponentEnabled)
 	t.Run("Validate component spec", componentCtx.validateSpec)
 	t.Run("Validate model controller", componentCtx.validateModelControllerInstance)
@@ -37,6 +40,30 @@ func kserveTestSuite(t *testing.T) {
 
 type KserveTestCtx struct {
 	*ComponentTestCtx
+}
+
+// validateEnv remove leftovers eventually present in the cluster. For some reason, the
+// KnativeServing may be left on the cluster, which causes the KServe tests to hang till
+// the test suite timeout (25m).
+func (c *KserveTestCtx) validateEnv(t *testing.T) {
+	g := c.NewWithT(t)
+	ns := "knative-serving"
+
+	kss, err := g.List(gvk.KnativeServing, client.InNamespace(ns)).Get()
+	g.Expect(err).NotTo(HaveOccurred())
+
+	if len(kss) != 0 {
+		t.Logf("Detected %d Knative Serving objects in namespace %s", len(kss), ns)
+	}
+
+	for _, ks := range kss {
+		t.Logf("Deleting Knative Serving %s in namespace %s", ks.GetName(), ks.GetNamespace())
+
+		g.Delete(gvk.KnativeServing, client.ObjectKeyFromObject(&ks)).Eventually().Should(Or(
+			MatchError(k8serr.IsNotFound, "IsNotFound"),
+			Not(HaveOccurred()),
+		))
+	}
 }
 
 func (c *KserveTestCtx) validateSpec(t *testing.T) {


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
