### PR TITLE
[backport] fix: networkpolicy

### DIFF
--- a/main.go
+++ b/main.go
@@ -469,7 +469,7 @@ func getCommonCache(ctx context.Context, cli client.Client, platform cluster.Pla
 	// newtowkrpolicy need operator namespace
 	operatorNs, err := cluster.GetOperatorNamespace()
 	if err != nil {
-		operatorNs = "redhat-ods-operator" // fall back case
+		return namespaceConfigs, err
 	}
 	namespaceConfigs[operatorNs] = cache.Config{}
 

--- a/main.go
+++ b/main.go
@@ -212,6 +212,7 @@ func main() { //nolint:funlen,maintidx,gocyclo
 		setupLog.Error(err, "unable to get application namespace into cache")
 		os.Exit(1)
 	}
+
 	oDHCache, err := createODHGeneralCacheConfig(ctx, setupClient, platform)
 	if err != nil {
 		setupLog.Error(err, "unable to get application namespace into cache")
@@ -465,6 +466,13 @@ func main() { //nolint:funlen,maintidx,gocyclo
 
 func getCommonCache(ctx context.Context, cli client.Client, platform cluster.Platform) (map[string]cache.Config, error) {
 	namespaceConfigs := map[string]cache.Config{}
+	// newtowkrpolicy need operator namespace
+	operatorNs, err := cluster.GetOperatorNamespace()
+	if err != nil {
+		operatorNs = "redhat-ods-operator" // fall back case
+	}
+	namespaceConfigs[operatorNs] = cache.Config{}
+
 	if platform == cluster.ManagedRhoai {
 		namespaceConfigs["redhat-ods-monitoring"] = cache.Config{}
 		namespaceConfigs["redhat-ods-applications"] = cache.Config{}
@@ -498,14 +506,6 @@ func createSecretCacheConfig(ctx context.Context, cli client.Client, platform cl
 	namespaceConfigs := map[string]cache.Config{
 		"istio-system":      {}, // for both knative-serving-cert and default-modelregistry-cert, as an easy workarond, to watch both in this namespace
 		"openshift-ingress": {},
-	}
-
-	if platform == cluster.ManagedRhoai {
-		operatorNs, err := cluster.GetOperatorNamespace()
-		if err != nil {
-			operatorNs = "redhat-ods-operator" // fall back case
-		}
-		namespaceConfigs[operatorNs] = cache.Config{}
 	}
 
 	c, err := getCommonCache(ctx, cli, platform)


### PR DESCRIPTION
- rhoai both self and managed need networkpolicy on redhat-ods-operator namespace

(cherry picked from commit c2c38e244ed2470a041c8220f7f7e7a459de49c2)
Signed-off-by: Wen Zhou <wenzhou@redhat.com>

<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->
this  commit is done during testing rhoai build and found networkpolicy for monitoring is missing in the cache for operator namespace. on the same side to add it for all case even ODH

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
