### PR TITLE
Add support for dynamic template data computation in template rendering action

### DIFF
--- a/pkg/controller/actions/render/template/resources/smm-data.tmpl.yaml
+++ b/pkg/controller/actions/render/template/resources/smm-data.tmpl.yaml
@@ -6,6 +6,8 @@ metadata:
   annotations:
     instance-name: {{.Component.Name}}
     instance-id: {{.ID}}
+    instance-uid: {{.UID}}
+    instance-foo: {{.Foo}}
 spec:
   controlPlaneRef:
     namespace: {{ .DSCI.Spec.ServiceMesh.ControlPlane.Namespace }}


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

When creating a template rendering action, is is now possible to compute dynamic data based on the current `ReconciliationRequest`:

```go
action := template.NewAction(
  template.WithData(map[string]any{
	  "ID": id,
	  "SMM": map[string]any{
		  "Name": name,
	  },
	  "Foo": "bar",
  }),
  template.WithDataFn(func(_ context.Context, rr *types.ReconciliationRequest) (map[string]any, error) {
	  return map[string]any{
		  "Foo": "bar",
		  "UID": rr.Instance.GetUID(),
	  }, nil
  }),
)
```
<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
