### PR TITLE
(fix): Rework shell script for odh release to work with new get_all_manifests.sh changes

### DIFF
--- a/.github/scripts/get-release-branches.js
+++ b/.github/scripts/get-release-branches.js
@@ -34,7 +34,7 @@ module.exports = ({ github, core }) => {
                             idx = splitArr.indexOf("tree")
                         }
                         const branchName = splitArr.slice(idx + 1).join("/")
-                        if (componentName.trim() === "notebook-controller") {
+                        if (componentName.trim() === "workbenches/notebook-controller") {
                             core.exportVariable("component_spec_odh-notebook-controller".toLowerCase(), branchName);
                             core.exportVariable("component_spec_kf-notebook-controller".toLowerCase(), branchName);
                         } else {

--- a/.github/scripts/update-manifests-tags.sh
+++ b/.github/scripts/update-manifests-tags.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 update_tags(){
-    sed  -i -r "/\"$1\"/s|([^:]*):([^:]*):[^:]*:(.*)|\1:\2:$2:\3|" get_all_manifests.sh
+    sed -i -r "/\"(.*\/)*$1\"/s|([^:]*):([^:]*):[^:]*:(.*)|\1:\2:$2:\3|" get_all_manifests.sh
 }
 
 prefix=component_spec_
@@ -12,6 +12,6 @@ echo
 env | while IFS="=" read varname value; do
     [[ $varname =~ "${prefix}" ]] || continue
     component=${varname#${prefix}}
-    component=${component/_/-}
-    update_tags $component $value
+    component=${component//_/-}
+    update_tags $(basename $component) $value
 done


### PR DESCRIPTION
…

<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
With a few changes in the names of the components in the get_all_manifests.sh script, the shell script that is used to update the tags was broken. This fix resolves the issue

JIRA: https://issues.redhat.com/browse/RHOAIENG-18361

## How Has This Been Tested?
Tested the action is my repo: 
action:https://github.com/AjayJagan/opendatahub-operator/actions/runs/12882587722
result: https://github.com/AjayJagan/opendatahub-operator/pull/2


- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
