### PR TITLE
fix: when app ns and monitoring ns are the same, createorupdate wont work

### DIFF
--- a/controllers/dscinitialization/utils.go
+++ b/controllers/dscinitialization/utils.go
@@ -56,7 +56,7 @@ func (r *DSCInitializationReconciler) createOperatorResource(ctx context.Context
 	// Patch monitoring namespace
 	err := r.patchMonitoringNS(ctx, dscInit)
 	if err != nil {
-		log.Error(err, "error patch monitoring namespace for managed cluster")
+		log.Error(err, "error patch monitoring namespace")
 		return err
 	}
 
@@ -151,11 +151,11 @@ func (r *DSCInitializationReconciler) createAppNamespace(ctx context.Context, ns
 
 func (r *DSCInitializationReconciler) patchMonitoringNS(ctx context.Context, dscInit *dsciv1.DSCInitialization) error {
 	log := logf.FromContext(ctx)
-	if dscInit.Spec.Monitoring.ManagementState != operatorv1.Managed {
+	monitoringName := dscInit.Spec.Monitoring.Namespace
+	if dscInit.Spec.Monitoring.ManagementState != operatorv1.Managed || dscInit.Spec.ApplicationsNamespace == monitoringName {
 		return nil
 	}
 	// Create Monitoring Namespace if it is enabled and not exists
-	monitoringName := dscInit.Spec.Monitoring.Namespace
 
 	desiredMonitoringNamespace := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
- monitoring should be only for rhoai and we only support fixed name for now
- but in upstream odh, we just set all namespace to the same one, 
- in old code, it was a "err = r.Patch(ctx, foundMonitoringNamespace, client.RawPatch(types.MergePatchType, []byte(labelPatch)))" call
but for some reason this is not 100% reproduciable
i have it passed in clean new cluster
i have it failed with error 
`{"level":"error","ts":"2025-01-21T15:42:30Z","msg":"error patch monitoring namespace for managed cluster","controller":"dscinitialization","controllerGroup":"dscinitialization.opendatahub.io","controllerKind":"DSCInitialization","DSCInitialization":{"name":"e2e-test-dsci"},"namespace":"","name":"e2e-test-dsci","reconcileID":"105251cf-09d0-4ae6-a552-4333d540a581","error":"namespaces \"opendatahub\" already exists","stacktrace":"github.com/opendatahub-io/opendatahub-operator/v2/controllers/dscinitialization.(*DSCInitializationReconciler).createOperatorResource\n\t/workspace/controllers/dscinitialization/utils.go:57\ngithub.com/opendatahub-io/opendatahub-operator/v2/controllers/dscinitialization.(*DSCInitializationReconciler).Reconcile\n\t/workspace/controllers/dscinitialization/dscinitialization_controller.go:177\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile\n\t/opt/app-root/src/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.17.5/pkg/internal/controller/controller.go:119\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\t/opt/app-root/src/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.17.5/pkg/internal/controller/controller.go:316\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/opt/app-root/src/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.17.5/pkg/internal/controller/controller.go:266\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2\n\t/opt/app-root/src/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.17.5/pkg/internal/controller/controller.go:227"}`

<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
