### PR TITLE
chore: cleanup Monitoring's initialize action

### DIFF
--- a/controllers/services/monitoring/monitoring_controller_actions.go
+++ b/controllers/services/monitoring/monitoring_controller_actions.go
@@ -10,13 +10,11 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/apis/components/v1alpha1"
 	dscv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/datasciencecluster/v1"
 	serviceApi "github.com/opendatahub-io/opendatahub-operator/v2/apis/services/v1alpha1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/controllers/status"
-	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
 	cr "github.com/opendatahub-io/opendatahub-operator/v2/pkg/componentsregistry"
 	odhtypes "github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
 	odhdeploy "github.com/opendatahub-io/opendatahub-operator/v2/pkg/deploy"
@@ -38,22 +36,13 @@ var componentRules = map[string]string{
 }
 
 // initialize handles all pre-deployment configurations.
-func initialize(ctx context.Context, rr *odhtypes.ReconciliationRequest) error {
-	log := logf.FromContext(ctx)
-	// Only handle manifests setup and initial configurations
-	platform := rr.Release.Name
-	switch platform {
-	case cluster.ManagedRhoai:
-		// Only set prometheus configmap path
-		rr.Manifests = []odhtypes.ManifestInfo{
-			{
-				Path:       odhdeploy.DefaultManifestPath,
-				ContextDir: "monitoring/prometheus/apps",
-			},
-		}
-
-	default:
-		log.V(3).Info("Monitoring enabled, won't apply changes in this mode", "cluster", platform)
+func initialize(_ context.Context, rr *odhtypes.ReconciliationRequest) error {
+	// Only set prometheus configmap path
+	rr.Manifests = []odhtypes.ManifestInfo{
+		{
+			Path:       odhdeploy.DefaultManifestPath,
+			ContextDir: "monitoring/prometheus/apps",
+		},
 	}
 
 	return nil


### PR DESCRIPTION
The Monitoring controller is initialized only when the platform is
managed, hence there's no need to conditionally add manifests

<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] ~~Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).~~
- [ ] ~~The developer has manually tested the changes and verified that the changes work~~
