### PR TITLE
[rhoai] Avoid modelmesh and Kserve loop on updating shared CRDs

### DIFF
--- a/controllers/components/modelmeshserving/modelmeshserving_controller.go
+++ b/controllers/components/modelmeshserving/modelmeshserving_controller.go
@@ -27,6 +27,8 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/apis/components/v1alpha1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/deploy"
@@ -63,8 +65,23 @@ func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.
 			&extv1.CustomResourceDefinition{},
 			reconciler.WithEventHandler(
 				handlers.ToNamed(componentApi.ModelMeshServingInstanceName)),
-			reconciler.WithPredicates(
-				component.ForLabel(labels.ODH.Component(LegacyComponentName), labels.True)),
+			reconciler.WithPredicates(predicate.And(
+				component.ForLabel(labels.ODH.Component(LegacyComponentName), labels.True),
+				predicate.Funcs{
+					UpdateFunc: func(event event.UpdateEvent) bool {
+						// The KServe and ModelMesh are shipping the same CRDs as part of their manifests
+						// but with different versions, this cause the respective component reconcilers to
+						// keep trying to install their respective version, ending in an infinite loop.
+						switch event.ObjectNew.GetName() {
+						case "inferenceservices.serving.kserve.io":
+							return false
+						case "servingruntimes.serving.kserve.io":
+							return false
+						}
+						return true
+					},
+				},
+			)),
 		).
 		// Add ModelMeshServing specific actions
 		WithAction(initialize).


### PR DESCRIPTION
The KServe and ModelMesh are shipping the same CRDs as part of
their manifests but with different versions, this cause the
respective component reconcilers to keep trying to install
their respective version, ending in a infinite loop.

This commit does not solve the underlying problem of having two
components shipping the same CRDs with different versions, but
avoids the infinite reconcile loop. The CRDs that is actually
installed on the cluster is undefined, the latest one that is
applied wins

(cherry picked from commit 36b829caf9258be3dfdef0eb9d16d0cbc032666c)

<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

<!--- Link your JIRA and related links here for reference. -->
https://issues.redhat.com/browse/RHOAIENG-18518


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
