### PR TITLE
update: change previous workaround for subscription and add smcp in disable list

### DIFF
--- a/main.go
+++ b/main.go
@@ -269,7 +269,6 @@ func main() { //nolint:funlen,maintidx,gocyclo
 			&rbacv1.RoleBinding{}: {
 				Namespaces: oDHCache,
 			},
-			&ofapiv1alpha1.Subscription{}:            {}, // TODO: workaround to get all subs work, without specify it seems it does not cache from all namespaces
 			&rbacv1.ClusterRole{}:                    {},
 			&rbacv1.ClusterRoleBinding{}:             {},
 			&securityv1.SecurityContextConstraints{}: {},
@@ -302,6 +301,8 @@ func main() { //nolint:funlen,maintidx,gocyclo
 			Cache: &client.CacheOptions{
 				DisableFor: []client.Object{
 					resources.GvkToUnstructured(gvk.OpenshiftIngress),
+					&ofapiv1alpha1.Subscription{},
+					resources.GvkToUnstructured(gvk.ServiceMeshControlPlane),
 					&authorizationv1.SelfSubjectRulesReview{},
 				},
 				// Set it to true so the cache-backed client reads unstructured objects


### PR DESCRIPTION
- remove subs from client cache. as follow up from https://github.com/opendatahub-io/opendatahub-operator/pull/1555
- add smcp into disable cache, as we see in some cases SCMP is missing? 

<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

<!--- Link your JIRA and related links here for reference. -->
https://issues.redhat.com/browse/RHOAIENG-18425

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
