### PR TITLE
Improve Kserve's FeatureTraker handing

### DIFF
--- a/bundle/manifests/opendatahub-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/opendatahub-operator.clusterserviceversion.yaml
@@ -1005,6 +1005,14 @@ spec:
           verbs:
           - '*'
         - apiGroups:
+          - operator.knative.dev
+          resources:
+          - knativeservings/finalizers
+          verbs:
+          - get
+          - patch
+          - update
+        - apiGroups:
           - operator.openshift.io
           resources:
           - consoles

--- a/bundle/manifests/opendatahub-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/opendatahub-operator.clusterserviceversion.yaml
@@ -774,6 +774,14 @@ spec:
         - apiGroups:
           - features.opendatahub.io
           resources:
+          - featuretrackers/finalizers
+          verbs:
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - features.opendatahub.io
+          resources:
           - featuretrackers/status
           verbs:
           - delete

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -509,6 +509,14 @@ rules:
 - apiGroups:
   - features.opendatahub.io
   resources:
+  - featuretrackers/finalizers
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - features.opendatahub.io
+  resources:
   - featuretrackers/status
   verbs:
   - delete

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -740,6 +740,14 @@ rules:
   verbs:
   - '*'
 - apiGroups:
+  - operator.knative.dev
+  resources:
+  - knativeservings/finalizers
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
   - operator.openshift.io
   resources:
   - consoles

--- a/controllers/components/kserve/kserve_support.go
+++ b/controllers/components/kserve/kserve_support.go
@@ -269,12 +269,5 @@ func ownedViaFT(cli client.Client) handler.MapFunc {
 }
 
 func isLegacyOwnerRef(or metav1.OwnerReference) bool {
-	switch {
-	case or.APIVersion == gvk.DataScienceCluster.GroupVersion().String() && or.Kind == gvk.DataScienceCluster.Kind:
-		return true
-	case or.APIVersion == gvk.DSCInitialization.GroupVersion().String() && or.Kind == gvk.DSCInitialization.Kind:
-		return true
-	default:
-		return false
-	}
+	return or.APIVersion == gvk.DataScienceCluster.GroupVersion().String() && or.Kind == gvk.DataScienceCluster.Kind
 }

--- a/controllers/components/kserve/kserve_support.go
+++ b/controllers/components/kserve/kserve_support.go
@@ -22,6 +22,7 @@ import (
 	dsciv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/dscinitialization/v1"
 	featuresv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/features/v1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
 	odhtypes "github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/deploy"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/feature"
@@ -264,5 +265,16 @@ func ownedViaFT(cli client.Client) handler.MapFunc {
 		}
 
 		return []reconcile.Request{}
+	}
+}
+
+func isLegacyOwnerRef(or metav1.OwnerReference) bool {
+	switch {
+	case or.APIVersion == gvk.DataScienceCluster.GroupVersion().String() && or.Kind == gvk.DataScienceCluster.Kind:
+		return true
+	case or.APIVersion == gvk.DSCInitialization.GroupVersion().String() && or.Kind == gvk.DSCInitialization.Kind:
+		return true
+	default:
+		return false
 	}
 }

--- a/controllers/datasciencecluster/kubebuilder_rbac.go
+++ b/controllers/datasciencecluster/kubebuilder_rbac.go
@@ -191,6 +191,7 @@ package datasciencecluster
 /* Serverless prerequisite */
 // +kubebuilder:rbac:groups="networking.istio.io",resources=gateways,verbs=*
 // +kubebuilder:rbac:groups="operator.knative.dev",resources=knativeservings,verbs=*
+// +kubebuilder:rbac:groups="operator.knative.dev",resources=knativeservings/finalizers,verbs=update;patch;get
 // +kubebuilder:rbac:groups="config.openshift.io",resources=ingresses,verbs=get
 
 // WB

--- a/controllers/dscinitialization/kubebuilder_rbac.go
+++ b/controllers/dscinitialization/kubebuilder_rbac.go
@@ -5,6 +5,7 @@ package dscinitialization
 // +kubebuilder:rbac:groups="dscinitialization.opendatahub.io",resources=dscinitializations,verbs=get;list;watch;create;update;patch;delete;deletecollection
 // +kubebuilder:rbac:groups="features.opendatahub.io",resources=featuretrackers,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="features.opendatahub.io",resources=featuretrackers/status,verbs=get;update;patch;delete
+// +kubebuilder:rbac:groups="features.opendatahub.io",resources=featuretrackers/finalizers,verbs=update;patch;get
 
 /* Auth */
 // +kubebuilder:rbac:groups="config.openshift.io",resources=authentications,verbs=get;watch;list

--- a/pkg/cluster/gvk/gvk.go
+++ b/pkg/cluster/gvk/gvk.go
@@ -8,6 +8,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/apis/components/v1alpha1"
+	featuresv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/features/v1"
 	serviceApi "github.com/opendatahub-io/opendatahub-operator/v2/apis/services/v1alpha1"
 )
 
@@ -27,6 +28,11 @@ var (
 		Group:   "dscinitialization.opendatahub.io",
 		Version: "v1",
 		Kind:    "DSCInitialization",
+	}
+	FeatureTracker = schema.GroupVersionKind{
+		Group:   featuresv1.GroupVersion.Group,
+		Version: featuresv1.GroupVersion.Version,
+		Kind:    "FeatureTracker",
 	}
 
 	Deployment = schema.GroupVersionKind{

--- a/pkg/cluster/meta.go
+++ b/pkg/cluster/meta.go
@@ -37,6 +37,12 @@ func OwnedBy(owner metav1.Object, scheme *runtime.Scheme) MetaOptions {
 	}
 }
 
+func ControllerBy(owner metav1.Object, scheme *runtime.Scheme) MetaOptions {
+	return func(obj metav1.Object) error {
+		return controllerutil.SetControllerReference(owner, obj, scheme)
+	}
+}
+
 func WithLabels(labels ...string) MetaOptions {
 	return func(obj metav1.Object) error {
 		labelsMap, err := extractKeyValues(labels)

--- a/pkg/cluster/meta.go
+++ b/pkg/cluster/meta.go
@@ -37,7 +37,7 @@ func OwnedBy(owner metav1.Object, scheme *runtime.Scheme) MetaOptions {
 	}
 }
 
-func ControllerBy(owner metav1.Object, scheme *runtime.Scheme) MetaOptions {
+func ControlledBy(owner metav1.Object, scheme *runtime.Scheme) MetaOptions {
 	return func(obj metav1.Object) error {
 		return controllerutil.SetControllerReference(owner, obj, scheme)
 	}

--- a/pkg/controller/actions/deploy/action_deploy.go
+++ b/pkg/controller/actions/deploy/action_deploy.go
@@ -134,7 +134,7 @@ func (a *Action) run(ctx context.Context, rr *odhTypes.ReconciliationRequest) er
 		default:
 			// Remove the DSC and DSCI owner reference if set, This is required during the
 			// transition from the old to the new operator.
-			if err := removeOwnerReferences(ctx, rr.Client, current, isLegacyOwnerRef); err != nil {
+			if err := resources.RemoveOwnerReferences(ctx, rr.Client, current, isLegacyOwnerRef); err != nil {
 				return err
 			}
 

--- a/pkg/controller/actions/deploy/action_deploy_support.go
+++ b/pkg/controller/actions/deploy/action_deploy_support.go
@@ -1,11 +1,7 @@
 package deploy
 
 import (
-	"context"
-	"fmt"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
 )
@@ -19,55 +15,4 @@ func isLegacyOwnerRef(or metav1.OwnerReference) bool {
 	default:
 		return false
 	}
-}
-
-// removeOwnerReferences removes all owner references from a Kubernetes object that match the provided predicate.
-//
-// This function iterates through the OwnerReferences of the given object, filters out those that satisfy
-// the predicate, and updates the object in the cluster using the provided client.
-//
-// Parameters:
-//   - ctx: The context for the request, which can carry deadlines, cancellation signals, and other request-scoped values.
-//   - cli: A controller-runtime client used to update the Kubernetes object.
-//   - obj: The Kubernetes object whose OwnerReferences are to be filtered. It must implement client.Object.
-//   - predicate: A function that takes an OwnerReference and returns true if the reference should be removed.
-//
-// Returns:
-//   - An error if the update operation fails, otherwise nil.
-func removeOwnerReferences(
-	ctx context.Context,
-	cli client.Client,
-	obj client.Object,
-	predicate func(reference metav1.OwnerReference) bool,
-) error {
-	oldRefs := obj.GetOwnerReferences()
-	if len(oldRefs) == 0 {
-		return nil
-	}
-
-	newRefs := oldRefs[:0]
-	for _, ref := range oldRefs {
-		if !predicate(ref) {
-			newRefs = append(newRefs, ref)
-		}
-	}
-
-	if len(newRefs) == len(oldRefs) {
-		return nil
-	}
-
-	obj.SetOwnerReferences(newRefs)
-
-	// Update the object in the cluster
-	if err := cli.Update(ctx, obj); err != nil {
-		return fmt.Errorf(
-			"failed to remove owner references from object %s/%s with gvk %s: %w",
-			obj.GetNamespace(),
-			obj.GetName(),
-			obj.GetObjectKind().GroupVersionKind(),
-			err,
-		)
-	}
-
-	return nil
 }

--- a/pkg/controller/actions/deploy/action_deploy_support_test.go
+++ b/pkg/controller/actions/deploy/action_deploy_support_test.go
@@ -2,30 +2,12 @@
 package deploy
 
 import (
-	"context"
-	"path/filepath"
 	"testing"
 
-	"github.com/onsi/gomega/gstruct"
 	"github.com/onsi/gomega/types"
-	"github.com/rs/xid"
-	appsv1 "k8s.io/api/apps/v1"
-	corev1 "k8s.io/api/core/v1"
-	rbacv1 "k8s.io/api/rbac/v1"
-	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-	"sigs.k8s.io/controller-runtime/pkg/envtest"
 
-	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/apis/components/v1alpha1"
-	dscv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/datasciencecluster/v1"
-	dsciv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/dscinitialization/v1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
-	odhCli "github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/client"
-	"github.com/opendatahub-io/opendatahub-operator/v2/tests/envtestutil"
 
 	. "github.com/onsi/gomega"
 )
@@ -96,94 +78,4 @@ func TestIsLegacyOwnerRef(t *testing.T) {
 			g.Expect(result).To(tt.matcher)
 		})
 	}
-}
-
-func TestRemoveOwnerRef(t *testing.T) {
-	g := NewWithT(t)
-	s := runtime.NewScheme()
-
-	ctx := context.Background()
-	ns := xid.New().String()
-
-	utilruntime.Must(corev1.AddToScheme(s))
-	utilruntime.Must(appsv1.AddToScheme(s))
-	utilruntime.Must(apiextensionsv1.AddToScheme(s))
-	utilruntime.Must(componentApi.AddToScheme(s))
-	utilruntime.Must(dsciv1.AddToScheme(s))
-	utilruntime.Must(dscv1.AddToScheme(s))
-	utilruntime.Must(rbacv1.AddToScheme(s))
-
-	projectDir, err := envtestutil.FindProjectRoot()
-	g.Expect(err).NotTo(HaveOccurred())
-
-	envTest := &envtest.Environment{
-		CRDInstallOptions: envtest.CRDInstallOptions{
-			Scheme: s,
-			Paths: []string{
-				filepath.Join(projectDir, "config", "crd", "bases"),
-			},
-			ErrorIfPathMissing: true,
-			CleanUpAfterUse:    false,
-		},
-	}
-
-	t.Cleanup(func() {
-		_ = envTest.Stop()
-	})
-
-	cfg, err := envTest.Start()
-	g.Expect(err).NotTo(HaveOccurred())
-
-	envTestClient, err := client.New(cfg, client.Options{Scheme: s})
-	g.Expect(err).NotTo(HaveOccurred())
-
-	cli, err := odhCli.NewFromConfig(cfg, envTestClient)
-	g.Expect(err).NotTo(HaveOccurred())
-
-	err = cli.Create(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}})
-	g.Expect(err).ToNot(HaveOccurred())
-
-	cm1 := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "cm1", Namespace: ns}}
-	cm1.SetGroupVersionKind(gvk.ConfigMap)
-
-	err = cli.Create(ctx, cm1)
-	g.Expect(err).ToNot(HaveOccurred())
-
-	cm2 := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "cm2", Namespace: ns}}
-	cm2.SetGroupVersionKind(gvk.ConfigMap)
-
-	err = cli.Create(ctx, cm2)
-	g.Expect(err).ToNot(HaveOccurred())
-
-	// Create a ConfigMap with OwnerReferences
-	configMap := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "test-configmap", Namespace: ns}}
-
-	err = controllerutil.SetOwnerReference(cm1, configMap, s)
-	g.Expect(err).ToNot(HaveOccurred())
-	err = controllerutil.SetOwnerReference(cm2, configMap, s)
-	g.Expect(err).ToNot(HaveOccurred())
-
-	err = cli.Create(ctx, configMap)
-	g.Expect(err).ToNot(HaveOccurred())
-
-	predicate := func(ref metav1.OwnerReference) bool {
-		return ref.Name == cm1.Name
-	}
-
-	err = removeOwnerReferences(ctx, cli, configMap, predicate)
-	g.Expect(err).ToNot(HaveOccurred())
-
-	updatedConfigMap := &corev1.ConfigMap{}
-	err = cli.Get(ctx, client.ObjectKeyFromObject(configMap), updatedConfigMap)
-	g.Expect(err).ToNot(HaveOccurred())
-
-	g.Expect(updatedConfigMap.GetOwnerReferences()).Should(And(
-		HaveLen(1),
-		HaveEach(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
-			"Name":       Equal(cm2.Name),
-			"APIVersion": Equal(gvk.ConfigMap.GroupVersion().String()),
-			"Kind":       Equal(gvk.ConfigMap.Kind),
-			"UID":        Equal(cm2.UID),
-		})),
-	))
 }

--- a/pkg/controller/reconciler/reconciler.go
+++ b/pkg/controller/reconciler/reconciler.go
@@ -13,7 +13,6 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
@@ -25,10 +24,6 @@ import (
 	odhClient "github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/client"
 	odhManager "github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/manager"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
-)
-
-const (
-	finalizerName = "platform.opendatahub.io/finalizer"
 )
 
 // Reconciler provides generic reconciliation functionality for ODH objects.
@@ -117,50 +112,13 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		if err := r.delete(ctx, res); err != nil {
 			return ctrl.Result{}, err
 		}
-		if err := r.removeFinalizer(ctx, res); err != nil {
-			return ctrl.Result{}, err
-		}
 	} else {
-		if err := r.addFinalizer(ctx, res); err != nil {
-			return ctrl.Result{}, err
-		}
-
 		if err := r.apply(ctx, res); err != nil {
 			return ctrl.Result{}, err
 		}
 	}
 
 	return ctrl.Result{}, nil
-}
-
-func (r *Reconciler) addFinalizer(ctx context.Context, res common.PlatformObject) error {
-	if len(r.Finalizer) == 0 {
-		return nil
-	}
-
-	if !controllerutil.AddFinalizer(res, finalizerName) {
-		return nil
-	}
-
-	err := r.Client.Update(ctx, res)
-	if err != nil {
-		return fmt.Errorf("failure adding finalizer %s: %w", finalizerName, err)
-	}
-
-	return nil
-}
-
-func (r *Reconciler) removeFinalizer(ctx context.Context, res common.PlatformObject) error {
-	if !controllerutil.RemoveFinalizer(res, finalizerName) {
-		return nil
-	}
-
-	err := r.Client.Update(ctx, res)
-	if err != nil {
-		return fmt.Errorf("failure removing finalizer %s: %w", finalizerName, err)
-	}
-
-	return nil
 }
 
 func (r *Reconciler) delete(ctx context.Context, res common.PlatformObject) error {

--- a/pkg/feature/builder.go
+++ b/pkg/feature/builder.go
@@ -19,6 +19,7 @@ type featureBuilder struct {
 	managed     bool
 	source      featurev1.Source
 	owner       metav1.Object
+	controller  bool
 	targetNs    string
 
 	builders []partialBuilder
@@ -91,6 +92,12 @@ func (fb *featureBuilder) Manifests(creators ...resource.Creator) *featureBuilde
 // in the corresponding feature tracker.
 func (fb *featureBuilder) OwnedBy(object metav1.Object) *featureBuilder {
 	fb.owner = object
+
+	return fb
+}
+
+func (fb *featureBuilder) Controller(controller bool) *featureBuilder {
+	fb.controller = controller
 
 	return fb
 }
@@ -193,12 +200,13 @@ func (fb *featureBuilder) Create() (*Feature, error) {
 	}
 
 	f := &Feature{
-		Name:    fb.featureName,
-		Managed: fb.managed,
-		Enabled: alwaysEnabled,
-		Log:     log.Log.WithName("features").WithValues("feature", fb.featureName),
-		source:  &fb.source,
-		owner:   fb.owner,
+		Name:       fb.featureName,
+		Managed:    fb.managed,
+		Enabled:    alwaysEnabled,
+		Log:        log.Log.WithName("features").WithValues("feature", fb.featureName),
+		source:     &fb.source,
+		owner:      fb.owner,
+		controller: fb.controller,
 	}
 
 	for i := range fb.builders {

--- a/pkg/feature/feature_tracker_handler.go
+++ b/pkg/feature/feature_tracker_handler.go
@@ -48,7 +48,7 @@ func createFeatureTracker(ctx context.Context, cli client.Client, f *Feature) er
 	if f.owner != nil {
 		var ownerRef cluster.MetaOptions
 		if f.controller {
-			ownerRef = cluster.ControllerBy(f.owner, cli.Scheme())
+			ownerRef = cluster.ControlledBy(f.owner, cli.Scheme())
 		} else {
 			ownerRef = cluster.OwnedBy(f.owner, cli.Scheme())
 		}

--- a/pkg/feature/feature_tracker_handler.go
+++ b/pkg/feature/feature_tracker_handler.go
@@ -38,19 +38,33 @@ func createFeatureTracker(ctx context.Context, cli client.Client, f *Feature) er
 
 	if k8serr.IsNotFound(errGet) {
 		tracker = featurev1.NewFeatureTracker(f.Name, f.TargetNamespace)
-		tracker.Spec = featurev1.FeatureTrackerSpec{
-			Source:       *f.source,
-			AppNamespace: f.TargetNamespace,
-		}
-		if f.owner != nil {
-			ownerRef := cluster.OwnedBy(f.owner, cli.Scheme())
-			if errMetaOpts := cluster.ApplyMetaOptions(tracker, ownerRef); errMetaOpts != nil {
-				return fmt.Errorf("failed adding owner to FeatureTracker %s: %w", tracker.Name, errMetaOpts)
-			}
+	}
+
+	tracker.Spec = featurev1.FeatureTrackerSpec{
+		Source:       *f.source,
+		AppNamespace: f.TargetNamespace,
+	}
+
+	if f.owner != nil {
+		var ownerRef cluster.MetaOptions
+		if f.controller {
+			ownerRef = cluster.ControllerBy(f.owner, cli.Scheme())
+		} else {
+			ownerRef = cluster.OwnedBy(f.owner, cli.Scheme())
 		}
 
+		if errMetaOpts := cluster.ApplyMetaOptions(tracker, ownerRef); errMetaOpts != nil {
+			return fmt.Errorf("failed adding owner to FeatureTracker %s: %w", tracker.Name, errMetaOpts)
+		}
+	}
+
+	if k8serr.IsNotFound(errGet) {
 		if errCreate := cli.Create(ctx, tracker); errCreate != nil {
 			return fmt.Errorf("failed creating FeatureTracker %s: %w", tracker.Name, errCreate)
+		}
+	} else {
+		if errUpdate := cli.Update(ctx, tracker); errUpdate != nil {
+			return fmt.Errorf("failed updating FeatureTracker %s: %w", tracker.Name, errUpdate)
 		}
 	}
 

--- a/pkg/feature/handler.go
+++ b/pkg/feature/handler.go
@@ -30,6 +30,7 @@ var _ featuresHandler = (*FeaturesHandler)(nil)
 type FeaturesHandler struct {
 	source            featurev1.Source
 	owner             metav1.Object
+	controller        bool
 	targetNamespace   string
 	features          []*Feature
 	featuresProviders []FeaturesProvider
@@ -47,6 +48,7 @@ func (fh *FeaturesHandler) Add(builders ...*featureBuilder) error {
 		feature, err := fb.
 			TargetNamespace(fh.targetNamespace).
 			OwnedBy(fh.owner).
+			Controller(fh.controller).
 			Source(fh.source).
 			Create()
 		multiErr = multierror.Append(multiErr, err)
@@ -112,6 +114,7 @@ func ClusterFeaturesHandler(dsci *dsciv1.DSCInitialization, def ...FeaturesProvi
 func ComponentFeaturesHandler(owner metav1.Object, componentName, targetNamespace string, def ...FeaturesProvider) *FeaturesHandler {
 	return &FeaturesHandler{
 		owner:             owner,
+		controller:        true,
 		targetNamespace:   targetNamespace,
 		source:            featurev1.Source{Type: featurev1.ComponentType, Name: componentName},
 		featuresProviders: def,

--- a/pkg/resources/resources_test.go
+++ b/pkg/resources/resources_test.go
@@ -1,16 +1,32 @@
 package resources_test
 
 import (
+	"context"
 	"errors"
+	"path/filepath"
 	"testing"
 
+	"github.com/onsi/gomega/gstruct"
+	"github.com/rs/xid"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
 
+	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/apis/components/v1alpha1"
+	dscv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/datasciencecluster/v1"
+	dsciv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/dscinitialization/v1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
+	odhCli "github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/client"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/resources"
+	"github.com/opendatahub-io/opendatahub-operator/v2/tests/envtestutil"
 
 	. "github.com/onsi/gomega"
 )
@@ -135,4 +151,94 @@ func TestEnsureGroupVersionKind(t *testing.T) {
 		g.Expect(err).To(HaveOccurred())
 		g.Expect(err.Error()).To(ContainSubstring("failed to get GVK"))
 	})
+}
+
+func TestRemoveOwnerRef(t *testing.T) {
+	g := NewWithT(t)
+	s := runtime.NewScheme()
+
+	ctx := context.Background()
+	ns := xid.New().String()
+
+	utilruntime.Must(corev1.AddToScheme(s))
+	utilruntime.Must(appsv1.AddToScheme(s))
+	utilruntime.Must(apiextensionsv1.AddToScheme(s))
+	utilruntime.Must(componentApi.AddToScheme(s))
+	utilruntime.Must(dsciv1.AddToScheme(s))
+	utilruntime.Must(dscv1.AddToScheme(s))
+	utilruntime.Must(rbacv1.AddToScheme(s))
+
+	projectDir, err := envtestutil.FindProjectRoot()
+	g.Expect(err).NotTo(HaveOccurred())
+
+	envTest := &envtest.Environment{
+		CRDInstallOptions: envtest.CRDInstallOptions{
+			Scheme: s,
+			Paths: []string{
+				filepath.Join(projectDir, "config", "crd", "bases"),
+			},
+			ErrorIfPathMissing: true,
+			CleanUpAfterUse:    false,
+		},
+	}
+
+	t.Cleanup(func() {
+		_ = envTest.Stop()
+	})
+
+	cfg, err := envTest.Start()
+	g.Expect(err).NotTo(HaveOccurred())
+
+	envTestClient, err := client.New(cfg, client.Options{Scheme: s})
+	g.Expect(err).NotTo(HaveOccurred())
+
+	cli, err := odhCli.NewFromConfig(cfg, envTestClient)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	err = cli.Create(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}})
+	g.Expect(err).ToNot(HaveOccurred())
+
+	cm1 := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "cm1", Namespace: ns}}
+	cm1.SetGroupVersionKind(gvk.ConfigMap)
+
+	err = cli.Create(ctx, cm1)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	cm2 := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "cm2", Namespace: ns}}
+	cm2.SetGroupVersionKind(gvk.ConfigMap)
+
+	err = cli.Create(ctx, cm2)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	// Create a ConfigMap with OwnerReferences
+	configMap := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "test-configmap", Namespace: ns}}
+
+	err = controllerutil.SetOwnerReference(cm1, configMap, s)
+	g.Expect(err).ToNot(HaveOccurred())
+	err = controllerutil.SetOwnerReference(cm2, configMap, s)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	err = cli.Create(ctx, configMap)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	predicate := func(ref metav1.OwnerReference) bool {
+		return ref.Name == cm1.Name
+	}
+
+	err = resources.RemoveOwnerReferences(ctx, cli, configMap, predicate)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	updatedConfigMap := &corev1.ConfigMap{}
+	err = cli.Get(ctx, client.ObjectKeyFromObject(configMap), updatedConfigMap)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	g.Expect(updatedConfigMap.GetOwnerReferences()).Should(And(
+		HaveLen(1),
+		HaveEach(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+			"Name":       Equal(cm2.Name),
+			"APIVersion": Equal(gvk.ConfigMap.GroupVersion().String()),
+			"Kind":       Equal(gvk.ConfigMap.Kind),
+			"UID":        Equal(cm2.UID),
+		})),
+	))
 }

--- a/tests/e2e/kserve_test.go
+++ b/tests/e2e/kserve_test.go
@@ -2,16 +2,21 @@ package e2e_test
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"testing"
 
+	"github.com/rs/xid"
 	"github.com/stretchr/testify/require"
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/apis/components/v1alpha1"
+	featuresv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/features/v1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/controllers/components/modelcontroller"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
@@ -31,13 +36,12 @@ func kserveTestSuite(t *testing.T) {
 		ComponentTestCtx: ct,
 	}
 
-	// TODO: removed once we know what's left on the cluster that's causing the tests
-	//       to fail because of "existing KNativeServing resource was found"
 	err = componentCtx.setUpServerless(t)
 	require.NoError(t, err)
 
 	t.Run("Validate component enabled", componentCtx.ValidateComponentEnabled)
 	t.Run("Validate component spec", componentCtx.validateSpec)
+	t.Run("Validate FeatureTrackers", componentCtx.validateFeatureTrackers)
 	t.Run("Validate model controller", componentCtx.validateModelControllerInstance)
 	t.Run("Validate operands have OwnerReferences", componentCtx.ValidateOperandsOwnerReferences)
 	t.Run("Validate default certs", componentCtx.validateDefaultCertsAvailable)
@@ -51,6 +55,8 @@ type KserveTestCtx struct {
 
 //nolint:thelper
 func (c *KserveTestCtx) setUpServerless(t *testing.T) error {
+	// TODO: removed once we know what's left on the cluster that's causing the tests
+	//       to fail because of "existing KNativeServing resource was found"
 	ksl := unstructured.UnstructuredList{}
 	ksl.SetGroupVersionKind(gvk.KnativeServing)
 
@@ -75,6 +81,24 @@ func (c *KserveTestCtx) setUpServerless(t *testing.T) error {
 		}
 	}
 
+	ft := &featuresv1.FeatureTracker{}
+	ft.SetName(c.ApplicationNamespace + "-serverless-serving-deployment")
+
+	if _, err := controllerutil.CreateOrUpdate(c.Context(), c.Client(), ft, func() error {
+		dsc, err := c.GetDSC()
+		if err != nil {
+			return err
+		}
+		if err := controllerutil.SetOwnerReference(dsc, ft, c.Client().Scheme()); err != nil {
+			return err
+		}
+		ft.Spec.Source.Name = xid.New().String()
+
+		return nil
+	}); err != nil {
+		return errors.New("error creating pre-existing FeatureTracker")
+	}
+
 	return nil
 }
 
@@ -93,6 +117,49 @@ func (c *KserveTestCtx) validateSpec(t *testing.T) {
 			jq.Match(`.spec.serving.name == "%s"`, dsc.Spec.Components.Kserve.Serving.Name),
 			jq.Match(`.spec.serving.ingressGateway.certificate.type == "%s"`, dsc.Spec.Components.Kserve.Serving.IngressGateway.Certificate.Type),
 		)),
+	))
+}
+
+func (c *KserveTestCtx) validateFeatureTrackers(t *testing.T) {
+	g := c.NewWithT(t)
+	ftName := types.NamespacedName{Name: c.ApplicationNamespace + "-serverless-serving-deployment"}
+
+	g.Get(gvk.FeatureTracker, ftName).Eventually().Should(And(
+		jq.Match(`(.metadata.ownerReferences | length) == 1`),
+		jq.Match(`.metadata.ownerReferences[0].apiVersion == "%s"`, gvk.Kserve.GroupVersion().String()),
+		jq.Match(`.metadata.ownerReferences[0].kind == "%s"`, gvk.Kserve.Kind),
+		jq.Match(`.metadata.ownerReferences[0].blockOwnerDeletion == true`),
+		jq.Match(`.metadata.ownerReferences[0].controller == true`),
+	))
+
+	dsc, err := c.GetDSC()
+	g.Expect(err).NotTo(HaveOccurred())
+
+	g.Update(
+		gvk.FeatureTracker,
+		ftName,
+		func(obj *unstructured.Unstructured) error {
+			if err := controllerutil.SetOwnerReference(dsc, obj, c.Client().Scheme()); err != nil {
+				return err
+			}
+
+			// trigger reconciliation as spec changes
+			if err = unstructured.SetNestedField(obj.Object, xid.New().String(), "spec", "source", "name"); err != nil {
+				return err
+			}
+
+			return nil
+		},
+	).Eventually().Should(And(
+		jq.Match(`(.metadata.ownerReferences | length) == 2`),
+	))
+
+	g.Get(gvk.FeatureTracker, ftName).Eventually().Should(And(
+		jq.Match(`(.metadata.ownerReferences | length) == 1`),
+		jq.Match(`.metadata.ownerReferences[0].apiVersion == "%s"`, gvk.Kserve.GroupVersion().String()),
+		jq.Match(`.metadata.ownerReferences[0].kind == "%s"`, gvk.Kserve.Kind),
+		jq.Match(`.metadata.ownerReferences[0].blockOwnerDeletion == true`),
+		jq.Match(`.metadata.ownerReferences[0].controller == true`),
 	))
 }
 


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

- Make it possible to set FT's OwnerReference as Controller reference so
  the kubernetes garbage collector can block owner deletion till the FT
  has been deleted
- Make it possible to set FT's generated resources OwnerReference as 
  Controller reference so the kubernetes garbage collector can block
  FT deletion till the resources have been deleted
- Add an Kserver reconciler action to remove legacy ownership on
  DSCI/DSC is any and related e2e tests

<!--- Link your JIRA and related links here for reference. -->

Relates to https://issues.redhat.com/browse/RHOAIENG-18590

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
