### PR TITLE
It takes more than 10 minutes for kserve-controller to be created during 2.17 installation

### DIFF
--- a/controllers/components/kserve/kserve_controller.go
+++ b/controllers/components/kserve/kserve_controller.go
@@ -33,6 +33,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/apis/components/v1alpha1"
+	dsciv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/dscinitialization/v1"
 	featuresv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/features/v1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/deploy"
@@ -43,6 +44,7 @@ import (
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/predicates"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/predicates/clusterrole"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/predicates/component"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/predicates/generation"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/predicates/hash"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/predicates/resources"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/reconciler"
@@ -113,7 +115,12 @@ func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.
 				},
 			)),
 		).
-
+		// resource
+		Watches(
+			&dsciv1.DSCInitialization{},
+			reconciler.WithEventHandler(handlers.ToNamed(componentApi.KserveInstanceName)),
+			reconciler.WithPredicates(predicate.Or(generation.New(), resources.DSCIReadiness)),
+		).
 		// operands - dynamically watched
 		//
 		// A watch will be created dynamically for these kinds, if they exist on the cluster

--- a/pkg/controller/predicates/resources/resources.go
+++ b/pkg/controller/predicates/resources/resources.go
@@ -136,7 +136,7 @@ var DSCIReadiness = predicate.Funcs{
 		return false
 	},
 	DeleteFunc: func(e event.DeleteEvent) bool {
-		return true
+		return false
 	},
 	GenericFunc: func(e event.GenericEvent) bool {
 		return false

--- a/pkg/controller/predicates/resources/resources.go
+++ b/pkg/controller/predicates/resources/resources.go
@@ -9,6 +9,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	dscv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/datasciencecluster/v1"
+	dsciv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/dscinitialization/v1"
 )
 
 var _ predicate.Predicate = DeploymentPredicate{}
@@ -114,6 +115,30 @@ var DSCComponentUpdatePredicate = predicate.Funcs{
 				}
 			}
 		}
+		return false
+	},
+}
+
+var DSCIReadiness = predicate.Funcs{
+	UpdateFunc: func(e event.UpdateEvent) bool {
+		oldObj, ok := e.ObjectOld.(*dsciv1.DSCInitialization)
+		if !ok {
+			return false
+		}
+		newObj, ok := e.ObjectNew.(*dsciv1.DSCInitialization)
+		if !ok {
+			return false
+		}
+
+		return oldObj.Status.Phase != newObj.Status.Phase
+	},
+	CreateFunc: func(e event.CreateEvent) bool {
+		return false
+	},
+	DeleteFunc: func(e event.DeleteEvent) bool {
+		return true
+	},
+	GenericFunc: func(e event.GenericEvent) bool {
 		return false
 	},
 }

--- a/pkg/feature/servicemesh/conditions.go
+++ b/pkg/feature/servicemesh/conditions.go
@@ -90,6 +90,9 @@ func WaitForControlPlaneToBeReady(ctx context.Context, cli client.Client, f *fea
 
 	return wait.PollUntilContextTimeout(ctx, interval, duration, false, func(ctx context.Context) (bool, error) {
 		ready, err := CheckControlPlaneComponentReadiness(ctx, cli, smcp, smcpNs)
+		if k8serr.IsNotFound(err) {
+			return false, nil
+		}
 
 		if ready {
 			f.Log.Info("done waiting for control plane components to be ready", "control-plane", smcp, "namespace", smcpNs)
@@ -112,8 +115,11 @@ func CheckControlPlaneComponentReadiness(ctx context.Context, c client.Client, s
 	}
 
 	components, found, err := unstructured.NestedMap(smcpObj.Object, "status", "readiness", "components")
-	if err != nil || !found {
+	if err != nil {
 		return false, fmt.Errorf("status conditions not found or error in parsing of Service Mesh Control Plane: %w", err)
+	}
+	if !found {
+		return false, nil
 	}
 
 	readyComponents := len(components["ready"].([]interface{}))     //nolint:forcetypeassert,errcheck


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

The `Kserve` component requires certain resources to be available and ready, which may not always be the case, especially when the the operator starts on a fresh installation. To handle this, a wait condition was implemented; however, it did not properly check for errors. As a result, the wait loop was prematurely stopped, and no retry attempts were made until the next reconcile loop. Additionally, the Kserve component was not monitoring the `DSCI`, leading to further delays as any transition phases of the `DSCI` were ignored


<!--- Link your JIRA and related links here for reference. -->
https://issues.redhat.com/browse/RHOAIENG-18425

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

1. create DSCI and DSC as part of the same yaml file (with serverless enabled and kserve enabled as well)
2. apply the file
3. watch the Kserve component progressing

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

DSCI created at **2025-01-24T16:05:19Z**

```yaml
apiVersion: v1
items:
- apiVersion: dscinitialization.opendatahub.io/v1
  kind: DSCInitialization
  metadata:
    creationTimestamp: "2025-01-24T16:05:19Z"
```

Kserve created at **2025-01-24T16:05:20Z**
Kserve becomes ready at **2025-01-24T16:06:34Z**

```yaml
apiVersion: components.platform.opendatahub.io/v1alpha1
kind: Kserve
metadata:
  annotations:
    component.opendatahub.io/management-state: Managed
  creationTimestamp: "2025-01-24T16:05:20Z"
  name: default-kserve
status:
  conditions:
  - lastTransitionTime: "2025-01-24T16:06:34Z"
    message: 1/1 deployments ready
    observedGeneration: 1
    reason: Ready
    status: "True"
    type: Ready
  defaultDeploymentMode: Serverless
  observedGeneration: 1
  phase: Ready
```
## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
