### PR TITLE
apis: DSCInitialization: annotate ApplicationsNamespace with omitempty

### DIFF
--- a/apis/dscinitialization/v1/dscinitialization_types.go
+++ b/apis/dscinitialization/v1/dscinitialization_types.go
@@ -37,7 +37,7 @@ type DSCInitializationSpec struct {
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,order=1
 	// +kubebuilder:validation:Pattern="^([a-z0-9]([-a-z0-9]*[a-z0-9])?)?$"
 	// +kubebuilder:validation:MaxLength=63
-	ApplicationsNamespace string `json:"applicationsNamespace"`
+	ApplicationsNamespace string `json:"applicationsNamespace,omitempty"`
 	// Enable monitoring on specified namespace
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,order=2
 	// +optional

--- a/config/crd/bases/dscinitialization.opendatahub.io_dscinitializations.yaml
+++ b/config/crd/bases/dscinitialization.opendatahub.io_dscinitializations.yaml
@@ -210,8 +210,6 @@ spec:
                 - customCABundle
                 - managementState
                 type: object
-            required:
-            - applicationsNamespace
             type: object
           status:
             description: DSCInitializationStatus defines the observed state of DSCInitialization.


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/RHOAIENG-18931

Api sets default value to opendatahub, but without "omitempty" in
case of operator automatically creates DSCI (upgrade.go:CreateDefaultDSCI), the resulting object contains applicationsNamespace: "" and it's not defaulted by the api server causing then problems like

```
Namespace "" is invalid: metadata.name: Required value: name or generateName is required
```

The problem was triggered by removing default value for command line switch in the cleanup.

Fixes: b0a0f87897e2 ("update: clean up old code before refactor (#1494)")

<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
