### PR TITLE
Remove legacy ModelController deployment on upgrade

### DIFF
--- a/pkg/upgrade/upgrade.go
+++ b/pkg/upgrade/upgrade.go
@@ -573,8 +573,8 @@ func cleanupNimIntegration(ctx context.Context, cli client.Client, oldRelease cl
 // causes issues during upgrades, as existing deployments cannot be
 // modified accordingly.
 //
-// This function as to stay as long as there is any long term suport
-// release based on the old logic
+// This function as to stay as long as there is any long term support
+// release based on the old logic.
 func cleanupModelControllerLegacyDeployment(ctx context.Context, cli client.Client, applicationNS string) error {
 	l := logf.FromContext(ctx)
 

--- a/pkg/upgrade/upgrade.go
+++ b/pkg/upgrade/upgrade.go
@@ -560,6 +560,21 @@ func cleanupNimIntegration(ctx context.Context, cli client.Client, oldRelease cl
 	return errs.ErrorOrNil()
 }
 
+// When upgrading from version 2.16 to 2.17, the odh-model-controller
+// fails to be provisioned due to the immutability of the deployment's
+// label selectors. In RHOAI ≤ 2.16, the model controller was deployed
+// independently by both kserve and modelmesh, leading to variations
+// in label assignments depending on the deployment order. During a
+// redeployment or upgrade, this error was ignored, and the model
+// controller would eventually be reconciled by the appropriate component.
+//
+// However, in version 2.17, the model controller is now a defined
+// dependency with its own fixed labels and selectors. This change
+// causes issues during upgrades, as existing deployments cannot be
+// modified accordingly.
+//
+// This function as to stay as long as there is any long term suport
+// release based on the old logic
 func cleanupModelControllerLegacyDeployment(ctx context.Context, cli client.Client, applicationNS string) error {
 	l := logf.FromContext(ctx)
 


### PR DESCRIPTION


<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

When upgrading from version 2.16 to 2.17, the odh-model-controller
fails to be provisioned due to the immutability of the deployment's
label selectors. In RHOAI ≤ 2.16, the model controller was deployed
independently by both kserve and modelmesh, leading to variations
in label assignments depending on the deployment order. During a
redeployment or upgrade, this error was ignored, and the model
controller would eventually be reconciled by the appropriate component.

However, in version 2.17, the model controller is now a defined
dependency with its own fixed labels and selectors. This change
causes issues during upgrades, as existing deployments cannot be
modified accordingly.

<!--- Link your JIRA and related links here for reference. -->

https://issues.redhat.com/browse/RHOAIENG-18937

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- Install RHOAI 2.16
- Enable the ModelMesh or Kserve component
- Wait for the components to be come ready
- Upgrade to RHOAI 2.17
- The operator log should mnot report errors like `invalid: spec.selector`
- The odh-model-controller deployment is ready
- The odh-model-controller has a label `platform.opendatahub.io/part-of: modelcontroller`

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [X] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [X] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work
