### PR TITLE
Add helper functions to retrieve object singletons

### DIFF
--- a/controllers/datasciencecluster/datasciencecluster_controller.go
+++ b/controllers/datasciencecluster/datasciencecluster_controller.go
@@ -128,23 +128,12 @@ func (r *DataScienceClusterReconciler) validate(ctx context.Context, _ *dscv1.Da
 	// of more than one instance of the DataScienceCluster, however one can create a
 	// DataScienceCluster instance while the operator is stopped, hence this extra check
 
-	dscInstances := &dscv1.DataScienceClusterList{}
-	if err := r.Client.List(ctx, dscInstances); err != nil {
-		return fmt.Errorf("failed to retrieve DataScienceCluster resource: %w", err)
+	if _, err := cluster.GetDSCI(ctx, r.Client); err != nil {
+		return fmt.Errorf("failed to get a valid DataScienceCluster instance, %w", err)
 	}
 
-	if len(dscInstances.Items) != 1 {
-		return fmt.Errorf("failed to get a valid DataScienceCluster instance, expected to find 1 instance, found %d", len(dscInstances.Items))
-	}
-
-	dsciInstances := &dsciv1.DSCInitializationList{}
-	err := r.Client.List(ctx, dsciInstances)
-	if err != nil {
-		return fmt.Errorf("failed to retrieve DSCInitialization resource: %w", err)
-	}
-
-	if len(dsciInstances.Items) != 1 {
-		return fmt.Errorf("failed to get a valid DSCInitialization instance, expected to find 1 instance, found %d", len(dscInstances.Items))
+	if _, err := cluster.GetDSC(ctx, r.Client); err != nil {
+		return fmt.Errorf("failed to get a valid DSCInitialization instance, %w", err)
 	}
 
 	return nil

--- a/pkg/cluster/resources.go
+++ b/pkg/cluster/resources.go
@@ -48,11 +48,10 @@ func GetSingleton[T client.Object](ctx context.Context, cli client.Client, obj T
 		return errors.New("obj must be a pointer")
 	}
 
-	if err := resources.EnsureGroupVersionKind(cli.Scheme(), obj); err != nil {
+	objGVK, err := resources.GetGroupVersionKindForObject(cli.Scheme(), obj)
+	if err != nil {
 		return err
 	}
-
-	objGVK := obj.GetObjectKind().GroupVersionKind()
 
 	instances := unstructured.UnstructuredList{}
 	instances.SetAPIVersion(objGVK.GroupVersion().String())

--- a/pkg/cluster/resources.go
+++ b/pkg/cluster/resources.go
@@ -4,16 +4,107 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"reflect"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
+	dscv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/datasciencecluster/v1"
+	dsciv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/dscinitialization/v1"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/resources"
 )
+
+// GetSingleton retrieves a singleton instance of a Kubernetes resource of type T.
+//
+// It ensures that only one instance exists and updates the provided object pointer
+// with the retrieved data and:
+//   - If no instances are found, it returns a "NotFound" error.
+//   - If multiple instances are found, it returns an error indicating an unexpected
+//     number of instances.
+//   - A generic error in case of other failures
+//
+// Generic Parameters:
+//   - T: A Kubernetes API resource that implements client.Object.
+//     T **must be a pointer to a struct**, allowing the function to update its contents.
+//
+// Parameters:
+//   - ctx: The context for the API request, allowing for cancellation and timeouts.
+//   - cli: The Kubernetes client used to interact with the cluster.
+//   - obj: A **pointer to a struct** that implements client.Object, which will be populated with the retrieved resource.
+//
+// Returns:
+//   - nil if exactly one instance of the resource is found and successfully assigned to obj.
+//   - An error if no instances or multiple instances are found, or if any failure occurs.
+func GetSingleton[T client.Object](ctx context.Context, cli client.Client, obj T) error {
+	if reflect.ValueOf(obj).IsNil() {
+		return errors.New("obj must be a pointer")
+	}
+
+	if err := resources.EnsureGroupVersionKind(cli.Scheme(), obj); err != nil {
+		return err
+	}
+
+	objGVK := obj.GetObjectKind().GroupVersionKind()
+
+	instances := unstructured.UnstructuredList{}
+	instances.SetAPIVersion(objGVK.GroupVersion().String())
+	instances.SetKind(objGVK.Kind)
+
+	if err := cli.List(ctx, &instances); err != nil {
+		return fmt.Errorf("failed to list resources of type %s: %w", objGVK, err)
+	}
+
+	switch len(instances.Items) {
+	case 1:
+		if err := cli.Scheme().Convert(&instances.Items[0], obj, ctx); err != nil {
+			return fmt.Errorf("failed to convert resource to %T: %w", obj, err)
+		}
+		return nil
+	case 0:
+		mapping, err := cli.RESTMapper().RESTMapping(objGVK.GroupKind(), objGVK.Version)
+		if err != nil {
+			return fmt.Errorf("failed to get REST mapping for %s: %w", objGVK, err)
+		}
+
+		return k8serr.NewNotFound(
+			schema.GroupResource{
+				Group:    objGVK.Group,
+				Resource: mapping.Resource.Resource,
+			},
+			"",
+		)
+	default:
+		return fmt.Errorf("failed to get a valid %s instance, expected to find 1 instance, found %d", objGVK, len(instances.Items))
+	}
+}
+
+// GetDSC retrieves the DataScienceCluster (DSC) instance from the Kubernetes cluster.
+func GetDSC(ctx context.Context, cli client.Client) (*dscv1.DataScienceCluster, error) {
+	obj := dscv1.DataScienceCluster{}
+	if err := GetSingleton(ctx, cli, &obj); err != nil {
+		return nil, err
+	}
+
+	return &obj, nil
+}
+
+// GetDSCI retrieves the DSCInitialization (DSCI) instance from the Kubernetes cluster.
+func GetDSCI(ctx context.Context, cli client.Client) (*dsciv1.DSCInitialization, error) {
+	obj := dsciv1.DSCInitialization{}
+	if err := GetSingleton(ctx, cli, &obj); err != nil {
+		return nil, err
+	}
+
+	return &obj, nil
+}
 
 // UpdatePodSecurityRolebinding update default rolebinding which is created in applications namespace by manifests
 // being used by different components and SRE monitoring.

--- a/pkg/cluster/resources_test.go
+++ b/pkg/cluster/resources_test.go
@@ -1,0 +1,162 @@
+package cluster_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	k8serr "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	dscv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/datasciencecluster/v1"
+	dsciv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/dscinitialization/v1"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/fakeclient"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestGetSingletonWithConfigMap(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("should return not found error when no ConfigMap exists", func(t *testing.T) {
+		g := NewWithT(t)
+		cli, err := fakeclient.New()
+		g.Expect(err).ShouldNot(HaveOccurred())
+
+		obj := &corev1.ConfigMap{}
+		err = cluster.GetSingleton(ctx, cli, obj)
+
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(k8serr.IsNotFound(err)).To(BeTrue(), "Expected NotFound error")
+	})
+
+	t.Run("should retrieve the singleton ConfigMap successfully", func(t *testing.T) {
+		g := NewWithT(t)
+
+		cli, err := fakeclient.New(
+			&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "singleton-configmap"}})
+
+		g.Expect(err).ShouldNot(HaveOccurred())
+
+		result := &corev1.ConfigMap{}
+		err = cluster.GetSingleton(ctx, cli, result)
+
+		g.Expect(err).NotTo(HaveOccurred())
+	})
+
+	t.Run("should return an error if multiple ConfigMaps exist", func(t *testing.T) {
+		g := NewWithT(t)
+
+		cli, err := fakeclient.New(
+			&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "configmap1"}},
+			&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "configmap2"}},
+		)
+
+		g.Expect(err).ShouldNot(HaveOccurred())
+
+		result := &corev1.ConfigMap{}
+		err = cluster.GetSingleton(ctx, cli, result)
+
+		g.Expect(err).To(HaveOccurred())
+	})
+
+	t.Run("should return an error when obj is nil", func(t *testing.T) {
+		g := NewWithT(t)
+
+		cli, err := fakeclient.New()
+		g.Expect(err).ShouldNot(HaveOccurred())
+
+		err = cluster.GetSingleton[*corev1.ConfigMap](ctx, cli, (*corev1.ConfigMap)(nil))
+
+		g.Expect(err).To(HaveOccurred())
+	})
+}
+
+func TestGetClusterSingletons(t *testing.T) {
+	g := NewWithT(t)
+
+	dsciFn := func(ctx context.Context, c client.Client) (client.Object, error) {
+		return cluster.GetDSCI(ctx, c)
+	}
+	dscFn := func(ctx context.Context, c client.Client) (client.Object, error) {
+		return cluster.GetDSC(ctx, c)
+	}
+
+	// Define test cases
+	tests := []struct {
+		name string
+		objs []client.Object
+		err  error
+		fn   func(context.Context, client.Client) (client.Object, error)
+	}{
+
+		{
+			name: "Single DSCInitialization instance found",
+			objs: []client.Object{&dsciv1.DSCInitialization{ObjectMeta: metav1.ObjectMeta{Name: "test-dsci"}}},
+			err:  nil,
+			fn:   dsciFn,
+		},
+		{
+			name: "No DSCInitialization instances found",
+			objs: []client.Object{},
+			err:  k8serr.NewNotFound(schema.GroupResource{Group: gvk.DSCInitialization.Group, Resource: "dscinitializations"}, ""),
+			fn:   dsciFn,
+		},
+		{
+			name: "Multiple DSCInitialization instances found",
+			objs: []client.Object{
+				&dsciv1.DSCInitialization{ObjectMeta: metav1.ObjectMeta{Name: "dsci-1"}},
+				&dsciv1.DSCInitialization{ObjectMeta: metav1.ObjectMeta{Name: "dsci-2"}},
+			},
+			err: errors.New("failed to get a valid dscinitialization.opendatahub.io/v1, Kind=DSCInitialization instance, expected to find 1 instance, found 2"),
+			fn:  dsciFn,
+		},
+
+		{
+			name: "Single DataScienceCluster instance found",
+			objs: []client.Object{&dscv1.DataScienceCluster{ObjectMeta: metav1.ObjectMeta{Name: "test-dsc"}}},
+			err:  nil,
+			fn:   dscFn,
+		},
+		{
+			name: "No DataScienceCluster instances found",
+			objs: []client.Object{},
+			err:  k8serr.NewNotFound(schema.GroupResource{Group: gvk.DataScienceCluster.Group, Resource: "datascienceclusters"}, ""),
+			fn:   dscFn,
+		},
+		{
+			name: "Multiple DataScienceCluster instances found",
+			objs: []client.Object{
+				&dscv1.DataScienceCluster{ObjectMeta: metav1.ObjectMeta{Name: "dsc-1"}},
+				&dscv1.DataScienceCluster{ObjectMeta: metav1.ObjectMeta{Name: "dsc-2"}},
+			},
+			err: errors.New("failed to get a valid datasciencecluster.opendatahub.io/v1, Kind=DataScienceCluster instance, expected to find 1 instance, found 2"),
+			fn:  dscFn,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cli, err := fakeclient.New(tt.objs...)
+			g.Expect(err).ShouldNot(HaveOccurred())
+
+			ctx := context.Background()
+
+			result, err := tt.fn(ctx, cli)
+
+			// Validate results
+			if tt.err == nil {
+				g.Expect(err).ShouldNot(HaveOccurred())
+				g.Expect(result).ShouldNot(BeNil())
+			} else {
+				g.Expect(err).Should(MatchError(tt.err))
+				g.Expect(result).Should(BeNil())
+			}
+		})
+	}
+}

--- a/pkg/utils/test/fakeclient/fakeclient.go
+++ b/pkg/utils/test/fakeclient/fakeclient.go
@@ -13,6 +13,8 @@ import (
 	clientFake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/apis/components/v1alpha1"
+	dscv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/datasciencecluster/v1"
+	dsciv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/dscinitialization/v1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/client"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/resources"
 )
@@ -23,6 +25,14 @@ func New(objs ...ctrlClient.Object) (*client.Client, error) {
 	utilruntime.Must(appsv1.AddToScheme(scheme))
 	utilruntime.Must(rbacv1.AddToScheme(scheme))
 	utilruntime.Must(componentApi.AddToScheme(scheme))
+	utilruntime.Must(dsciv1.AddToScheme(scheme))
+	utilruntime.Must(dscv1.AddToScheme(scheme))
+
+	for _, o := range objs {
+		if err := resources.EnsureGroupVersionKind(scheme, o); err != nil {
+			return nil, err
+		}
+	}
 
 	fakeMapper := meta.NewDefaultRESTMapper(scheme.PreferredVersionAllGroups())
 	for gvk := range scheme.AllKnownTypes() {


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

There are a number of places where we have to lookup singleton objects,
such as the DSC or DSCI and, with the introduction of per component and
service APIs, potentially for each component/service ad we relies on the
list retrieval and validation. This commit introduces some helper
function to avoid repating the same logic over and over again, in
particular for commonly accessed singletons:

- cluster.GetSingleton
- cluster.GetDSCI
- cluster.GetDSC

Example code to retrieve an instance of the dashbaord component:

```go
obj := &componentv1.Dashboard{}
err := cluster.GetSingleton(ctx, cli, obj)
switch {
case k8serr.IsNotFound(err):
    // do something
case err != nil:
    return err
}
```

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] ~~Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).~~
- [ ] ~~The developer has manually tested the changes and verified that the changes work~~
