### PR TITLE
e2e: enable kserve before running TrustyAI tests

### DIFF
--- a/tests/e2e/trustyai_test.go
+++ b/tests/e2e/trustyai_test.go
@@ -66,9 +66,9 @@ func (c *TrustyAITestCtx) disableKserve(t *testing.T) {
 	g.Update(
 		gvk.DataScienceCluster,
 		c.DSCName,
-		testf.Transform(`.spec.components.%s.managementState = "%s"`, componentApi.KserveComponentName, operatorv1.Managed),
+		testf.Transform(`.spec.components.%s.managementState = "%s"`, componentApi.KserveComponentName, operatorv1.Removed),
 	).Eventually().Should(
-		jq.Match(`.spec.components.%s.managementState == "%s"`, componentApi.KserveComponentName, operatorv1.Managed),
+		jq.Match(`.spec.components.%s.managementState == "%s"`, componentApi.KserveComponentName, operatorv1.Removed),
 	)
 
 	g.List(gvk.Kserve).Eventually().Should(

--- a/tests/e2e/trustyai_test.go
+++ b/tests/e2e/trustyai_test.go
@@ -3,9 +3,16 @@ package e2e_test
 import (
 	"testing"
 
+	operatorv1 "github.com/openshift/api/operator/v1"
 	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/apis/components/v1alpha1"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/matchers/jq"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/testf"
+
+	. "github.com/onsi/gomega"
 )
 
 func trustyAITestSuite(t *testing.T) {
@@ -18,13 +25,53 @@ func trustyAITestSuite(t *testing.T) {
 		ComponentTestCtx: ct,
 	}
 
+	// TrustyAI requires some CRDs that are shipped by Kserve
+	t.Run("Enable Kserve", componentCtx.enableKserve)
+
 	t.Run("Validate component enabled", componentCtx.ValidateComponentEnabled)
 	t.Run("Validate operands have OwnerReferences", componentCtx.ValidateOperandsOwnerReferences)
 	t.Run("Validate update operand resources", componentCtx.ValidateUpdateDeploymentsResources)
 	t.Run("Validate component disabled", componentCtx.ValidateComponentDisabled)
 	t.Run("Validate component releases", componentCtx.ValidateComponentReleases)
+
+	t.Run("Disable Kserve", componentCtx.disableKserve)
 }
 
 type TrustyAITestCtx struct {
 	*ComponentTestCtx
+}
+
+func (c *TrustyAITestCtx) enableKserve(t *testing.T) {
+	g := c.NewWithT(t)
+
+	g.Update(
+		gvk.DataScienceCluster,
+		c.DSCName,
+		testf.Transform(`.spec.components.%s.managementState = "%s"`, componentApi.KserveComponentName, operatorv1.Managed),
+	).Eventually().Should(
+		jq.Match(`.spec.components.%s.managementState == "%s"`, componentApi.KserveComponentName, operatorv1.Managed),
+	)
+
+	g.List(gvk.Kserve).Eventually().Should(And(
+		HaveLen(1),
+		HaveEach(And(
+			jq.Match(`.status.conditions[] | select(.type == "Ready") | .status == "%s"`, metav1.ConditionTrue),
+		)),
+	))
+}
+
+func (c *TrustyAITestCtx) disableKserve(t *testing.T) {
+	g := c.NewWithT(t)
+
+	g.Update(
+		gvk.DataScienceCluster,
+		c.DSCName,
+		testf.Transform(`.spec.components.%s.managementState = "%s"`, componentApi.KserveComponentName, operatorv1.Managed),
+	).Eventually().Should(
+		jq.Match(`.spec.components.%s.managementState == "%s"`, componentApi.KserveComponentName, operatorv1.Managed),
+	)
+
+	g.List(gvk.Kserve).Eventually().Should(
+		BeEmpty(),
+	)
 }


### PR DESCRIPTION
The TrustyAI component requires some CRDs shipped as part of the kserve
component to be present in the cluster befoire starting the controller.

<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
