### PR TITLE
feat: add gate in TrustyAI if ISVC CRD is not in the cluster

### DIFF
--- a/controllers/components/trustyai/trustyai_controller.go
+++ b/controllers/components/trustyai/trustyai_controller.go
@@ -55,12 +55,13 @@ func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.
 			&extv1.CustomResourceDefinition{},
 			reconciler.WithEventHandler(
 				handlers.ToNamed(componentApi.TrustyAIInstanceName)),
-			reconciler.WithPredicates(predicate.Or(
-				component.ForLabel(labels.ODH.Component(componentApi.KserveComponentName), labels.True),
-				component.ForLabel(labels.ODH.Component("model-mesh"), labels.True)),
+			reconciler.WithPredicates(
+				component.ForLabel(labels.ODH.Component(LegacyComponentName), labels.True)),
+			reconciler.WithPredicates(
 				predicate.Funcs{
 					CreateFunc: func(e event.CreateEvent) bool {
-						return e.Object.GetName() == "inferenceservices.serving.kserve.io"
+						return e.Object.GetName() == "inferenceservices.serving.kserve.io" &&
+							(e.Object.GetLabels()[labels.ODH.Component(componentApi.KserveComponentName)] == labels.True) || (e.Object.GetLabels()[labels.ODH.Component("model-mesh")] == labels.True)
 					},
 				},
 			),

--- a/controllers/components/trustyai/trustyai_controller.go
+++ b/controllers/components/trustyai/trustyai_controller.go
@@ -55,28 +55,15 @@ func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.
 			&extv1.CustomResourceDefinition{},
 			reconciler.WithEventHandler(
 				handlers.ToNamed(componentApi.TrustyAIInstanceName)),
-			reconciler.WithPredicates(
-				component.ForLabel(labels.ODH.Component(LegacyComponentName), labels.True)),
-		).
-		Watches(
-			&extv1.CustomResourceDefinition{},
-			reconciler.WithEventHandler(
-				handlers.ToNamed(componentApi.TrustyAIInstanceName)),
 			reconciler.WithPredicates(predicate.Or(
-				component.ForLabel(labels.ODH.Component(LegacyComponentName), labels.True),
+				component.ForLabel(labels.ODH.Component(componentApi.KserveComponentName), labels.True),
+				component.ForLabel(labels.ODH.Component("model-mesh"), labels.True)),
 				predicate.Funcs{
 					CreateFunc: func(e event.CreateEvent) bool {
-						return e.Object.GetName() == "inferenceservices.serving.kserve.io" &&
-							(e.Object.GetLabels()[labels.ODH.Component(componentApi.KserveComponentName)] == labels.True)
+						return e.Object.GetName() == "inferenceservices.serving.kserve.io"
 					},
 				},
-				predicate.Funcs{
-					CreateFunc: func(e event.CreateEvent) bool {
-						return e.Object.GetName() == "inferenceservices.serving.kserve.io" &&
-							(e.Object.GetLabels()[labels.ODH.Component(componentApi.ModelMeshServingComponentName)] == labels.True)
-					},
-				},
-			)),
+			),
 		).
 		// Add TrustyAI-specific actions
 		WithAction(checkPreConditions). // check if CRD isvc is there

--- a/controllers/components/trustyai/trustyai_controller.go
+++ b/controllers/components/trustyai/trustyai_controller.go
@@ -55,16 +55,16 @@ func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.
 			&extv1.CustomResourceDefinition{},
 			reconciler.WithEventHandler(
 				handlers.ToNamed(componentApi.TrustyAIInstanceName)),
-			reconciler.WithPredicates(predicate.Or( // if TrustyAI CR is changed
-				component.ForLabel(labels.ODH.Component(LegacyComponentName), labels.True),
-				predicate.Funcs{ // OR if ISVC from kserve or model-mesh is craeted
+			reconciler.WithPredicates(predicate.Or(
+				component.ForLabel(labels.ODH.Component(LegacyComponentName), labels.True), // if TrustyAI CR is changed
+				predicate.Funcs{ // OR if ISVC from kserve or model-mesh is created
 					CreateFunc: func(e event.CreateEvent) bool {
 						return e.Object.GetName() == "inferenceservices.serving.kserve.io" &&
 							(e.Object.GetLabels()[labels.ODH.Component(componentApi.KserveComponentName)] == labels.True) || (e.Object.GetLabels()[labels.ODH.Component("model-mesh")] == labels.True)
 					},
 				},
-			),
-			)).
+			)),
+		).
 		// Add TrustyAI-specific actions
 		WithAction(checkPreConditions). // check if CRD isvc is there
 		WithAction(initialize).

--- a/controllers/components/trustyai/trustyai_controller.go
+++ b/controllers/components/trustyai/trustyai_controller.go
@@ -24,6 +24,8 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/apis/components/v1alpha1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/deploy"
@@ -56,7 +58,22 @@ func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.
 			reconciler.WithPredicates(
 				component.ForLabel(labels.ODH.Component(LegacyComponentName), labels.True)),
 		).
+		Watches(
+			&extv1.CustomResourceDefinition{},
+			reconciler.WithEventHandler(
+				handlers.ToNamed(componentApi.TrustyAIInstanceName)),
+			reconciler.WithPredicates(predicate.Or(
+				component.ForLabel(labels.ODH.Component("kserve"), labels.True),
+				component.ForLabel(labels.ODH.Component("model-mesh"), labels.True)),
+				predicate.Funcs{
+					CreateFunc: func(e event.CreateEvent) bool {
+						return e.Object.GetName() == "inferenceservices.serving.kserve.io"
+					},
+				},
+			),
+		).
 		// Add TrustyAI-specific actions
+		WithAction(checkPreConditions). // check if CRD isvc is there
 		WithAction(initialize).
 		WithAction(devFlags).
 		WithAction(releases.NewAction()).

--- a/controllers/components/trustyai/trustyai_controller.go
+++ b/controllers/components/trustyai/trustyai_controller.go
@@ -63,14 +63,20 @@ func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.
 			reconciler.WithEventHandler(
 				handlers.ToNamed(componentApi.TrustyAIInstanceName)),
 			reconciler.WithPredicates(predicate.Or(
-				component.ForLabel(labels.ODH.Component("kserve"), labels.True),
-				component.ForLabel(labels.ODH.Component("model-mesh"), labels.True)),
+				component.ForLabel(labels.ODH.Component(LegacyComponentName), labels.True),
 				predicate.Funcs{
 					CreateFunc: func(e event.CreateEvent) bool {
-						return e.Object.GetName() == "inferenceservices.serving.kserve.io"
+						return e.Object.GetName() == "inferenceservices.serving.kserve.io" &&
+							(e.Object.GetLabels()[labels.ODH.Component(componentApi.KserveComponentName)] == labels.True)
 					},
 				},
-			),
+				predicate.Funcs{
+					CreateFunc: func(e event.CreateEvent) bool {
+						return e.Object.GetName() == "inferenceservices.serving.kserve.io" &&
+							(e.Object.GetLabels()[labels.ODH.Component(componentApi.ModelMeshServingComponentName)] == labels.True)
+					},
+				},
+			)),
 		).
 		// Add TrustyAI-specific actions
 		WithAction(checkPreConditions). // check if CRD isvc is there

--- a/controllers/components/trustyai/trustyai_controller_actions.go
+++ b/controllers/components/trustyai/trustyai_controller_actions.go
@@ -20,10 +20,38 @@ import (
 	"context"
 	"fmt"
 
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/apis/components/v1alpha1"
+	"github.com/opendatahub-io/opendatahub-operator/v2/controllers/status"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
+	odherrors "github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/errors"
 	odhtypes "github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
 	odhdeploy "github.com/opendatahub-io/opendatahub-operator/v2/pkg/deploy"
 )
+
+func checkPreConditions(ctx context.Context, rr *odhtypes.ReconciliationRequest) error {
+	t, ok := rr.Instance.(*componentApi.TrustyAI)
+	if !ok {
+		return fmt.Errorf("resource instance %v is not a componentApi.TrustyAI)", rr.Instance)
+	}
+
+	if err := cluster.CustomResourceDefinitionExists(ctx, rr.Client, gvk.InferenceServices.GroupKind()); err != nil {
+		s := t.GetStatus()
+		s.Phase = status.PhaseNotReady
+		meta.SetStatusCondition(&s.Conditions, metav1.Condition{
+			Type:               status.ConditionTypeReady,
+			Status:             metav1.ConditionFalse,
+			Reason:             status.ISVCMissingCRDReason,
+			Message:            status.ISVCMissingCRDMessage,
+			ObservedGeneration: s.ObservedGeneration,
+		})
+		return odherrors.NewStopError("failed to find InferenceService CRD: %v", err)
+	}
+	return nil
+}
 
 func initialize(_ context.Context, rr *odhtypes.ReconciliationRequest) error {
 	rr.Manifests = append(rr.Manifests, manifestsPath(rr.Release.Name))

--- a/controllers/status/status.go
+++ b/controllers/status/status.go
@@ -108,6 +108,12 @@ const (
 	MultiKueueCRDMessage = "MultiKueue CRDs MultiKueueConfig v1alpha1 and MultiKueueCluster v1Alpha1 exist, please remove them to proceed"
 )
 
+// For TrustyAI require ISVC CRD.
+const (
+	ISVCMissingCRDReason  = "InferenceServiceCRDMissing"
+	ISVCMissingCRDMessage = "InferenceServices CRD does not exist, please enable serving component first"
+)
+
 // SetProgressingCondition sets the ProgressingCondition to True and other conditions to false or
 // Unknown. Used when we are just starting to reconcile, and there are no existing conditions.
 func SetProgressingCondition(conditions *[]conditionsv1.Condition, reason string, message string) {

--- a/pkg/cluster/gvk/gvk.go
+++ b/pkg/cluster/gvk/gvk.go
@@ -262,4 +262,10 @@ var (
 		Version: "v1alpha1",
 		Kind:    "MultiKueueCluster",
 	}
+
+	InferenceServices = schema.GroupVersionKind{
+		Group:   "serving.kserve.io",
+		Version: "v1beta1",
+		Kind:    "InferenceService",
+	}
 )

--- a/tests/e2e/trustyai_test.go
+++ b/tests/e2e/trustyai_test.go
@@ -31,6 +31,7 @@ func trustyAITestSuite(t *testing.T) {
 	t.Run("Validate component enabled", componentCtx.ValidateComponentEnabled)
 	t.Run("Validate operands have OwnerReferences", componentCtx.ValidateOperandsOwnerReferences)
 	t.Run("Validate update operand resources", componentCtx.ValidateUpdateDeploymentsResources)
+	t.Run("Validate CRDs reinstated", componentCtx.validateCRDReinstated)
 	t.Run("Validate component disabled", componentCtx.ValidateComponentDisabled)
 	t.Run("Validate component releases", componentCtx.ValidateComponentReleases)
 
@@ -74,4 +75,18 @@ func (c *TrustyAITestCtx) disableKserve(t *testing.T) {
 	g.List(gvk.Kserve).Eventually().Should(
 		BeEmpty(),
 	)
+}
+
+func (c *TrustyAITestCtx) validateCRDReinstated(t *testing.T) {
+	// validate multikuueclusters, multikueueconfigs has v1beta1 version
+
+	crds := []string{
+		"inferenceservices.serving.kserve.io", // SR is not needed any more in 2.18.0
+	}
+
+	for _, crd := range crds {
+		t.Run(crd, func(t *testing.T) {
+			c.ValidateCRDReinstated(t, crd)
+		})
+	}
 }

--- a/tests/e2e/trustyai_test.go
+++ b/tests/e2e/trustyai_test.go
@@ -86,7 +86,7 @@ func (c *TrustyAITestCtx) disableKserve(t *testing.T) {
 
 func (c *TrustyAITestCtx) validateCRDReinstated(t *testing.T) {
 	crds := []string{
-		"inferenceservices.serving.kserve.io", // SR is not needed any more in 2.18.0
+		"inferenceservices.serving.kserve.io", // SR is not needed any more in 2.18.0 by TrustyAI
 	}
 
 	for _, crd := range crds {

--- a/tests/e2e/trustyai_test.go
+++ b/tests/e2e/trustyai_test.go
@@ -101,7 +101,7 @@ func (c *TrustyAITestCtx) validateCRDReinstated(t *testing.T) {
 func (c *TrustyAITestCtx) validateTrustyAIPreCheck(t *testing.T) {
 	// validate precheck on CRD version:
 	// pre-req: skip trusty to removed (done by ValidateComponentDisabled)
-	// step: delete isvc left from enableKserve wait till it is gone
+	// step: delete isvc left from enabled Kserve, wait till it is gone
 	// set trustyai to managed, result to error, enable mm, result to success
 
 	g := c.NewWithT(t)

--- a/tests/e2e/trustyai_test.go
+++ b/tests/e2e/trustyai_test.go
@@ -85,8 +85,6 @@ func (c *TrustyAITestCtx) disableKserve(t *testing.T) {
 }
 
 func (c *TrustyAITestCtx) validateCRDReinstated(t *testing.T) {
-	// validate multikuueclusters, multikueueconfigs has v1beta1 version
-
 	crds := []string{
 		"inferenceservices.serving.kserve.io", // SR is not needed any more in 2.18.0
 	}


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

if Trustyai is enabled but cluster does not have ISVC (new cluster, cluster never had serving enabled)
DSC.status.components.trustyai
- InferenceServiceCRDMissing"
- InferenceServices CRD does not exist, please enable serving component first


## Description
<!--- Describe your changes in detail -->
Due of the ongoing changes in TrustyAI, SR wont be a problem any more, the only dependency is ISVC
this requires https://github.com/trustyai-explainability/trustyai-service-operator/pull/400 and its sync to ODH done first

<!--- Link your JIRA and related links here for reference. -->
https://issues.redhat.com/browse/RHOAIENG-19261

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
