### PR TITLE
[wip]update: revmoe rollinupdate if it exist when recreate is used for deployment

### DIFF
--- a/pkg/controller/actions/deploy/action_deploy.go
+++ b/pkg/controller/actions/deploy/action_deploy.go
@@ -422,6 +422,11 @@ func (a *Action) apply(
 			break
 		}
 
+		// For deployments use Recreate but still have rollingupdate in manifests.
+		if err := ConvertRollingUpdate(old.Object, obj.Object); err != nil {
+			return nil, fmt.Errorf("failed to convert Deployment Strategy for %s/%s: %w", obj.GetNamespace(), obj.GetName(), err)
+		}
+
 		// To preserve backward compatibility with the current model, fields are being
 		// merged from an existing Deployment (if it exists) to the rendered manifest,
 		// hence the current value is preserved [1].

--- a/pkg/controller/actions/deploy/action_deploy.go
+++ b/pkg/controller/actions/deploy/action_deploy.go
@@ -423,7 +423,7 @@ func (a *Action) apply(
 		}
 
 		// For deployments use Recreate but still have rollingupdate in manifests.
-		if err := ConvertRollingUpdate(old.Object, obj.Object); err != nil {
+		if err := ConvertRollingUpdate(obj); err != nil {
 			return nil, fmt.Errorf("failed to convert Deployment Strategy for %s/%s: %w", obj.GetNamespace(), obj.GetName(), err)
 		}
 


### PR DESCRIPTION

- when deployment is changed from previous rollingupgrade to recreate manifests  cannot have rollingupgrade to nil

<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->
with this change https://github.com/opendatahub-io/kserve/pull/491 our code wont work for kserve

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
