### PR TITLE
Fix e2e services tests flags

### DIFF
--- a/tests/e2e/controller_test.go
+++ b/tests/e2e/controller_test.go
@@ -226,6 +226,11 @@ func TestMain(m *testing.M) {
 	componentNames := strings.Join(maps.Keys(componentsTestSuites), ", ")
 	flag.Var(&testOpts.components, "test-component", "run tests for the specified component. valid components names are: "+componentNames)
 
+	serviceNames := strings.Join(maps.Keys(servicesTestSuites), ", ")
+	flag.Var(&testOpts.services, "test-service", "run tests for the specified service. valid service names are: "+serviceNames)
+
+	flag.Parse()
+
 	for _, n := range testOpts.components {
 		if _, ok := componentsTestSuites[n]; !ok {
 			fmt.Printf("test-component: unknown component %s, valid values are: %s", n, componentNames)
@@ -233,16 +238,12 @@ func TestMain(m *testing.M) {
 		}
 	}
 
-	serviceNames := strings.Join(maps.Keys(servicesTestSuites), ", ")
-	flag.Var(&testOpts.services, "test-service", "run tests for the specified service. valid service names are: "+serviceNames)
-
-	for _, n := range testOpts.components {
-		if _, ok := componentsTestSuites[n]; !ok {
+	for _, n := range testOpts.services {
+		if _, ok := servicesTestSuites[n]; !ok {
 			fmt.Printf("test-service: unknown service %s, valid values are: %s", n, serviceNames)
 			os.Exit(1)
 		}
 	}
 
-	flag.Parse()
 	os.Exit(m.Run())
 }


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Run a combination of  `--test-service` flags, i.e. when enabling only `auth` service test. he output looks like:

```
=== RUN   TestOdhOperator/services
    controller_test.go:199: Skipping tests for services monitoring
=== RUN   TestOdhOperator/services/auth
=== RUN   TestOdhOperator/services/auth/e2e-test-dsc
=== RUN   TestOdhOperator/services/auth/e2e-test-dsc/Auto_creation_of_Auth_CR
=== RUN   TestOdhOperator/services/auth/e2e-test-dsc/Test_Auth_CR_content
=== RUN   TestOdhOperator/services/auth/e2e-test-dsc/Test_role_creation
=== RUN   TestOdhOperator/services/auth/e2e-test-dsc/Test_rolebinding_creation
=== RUN   TestOdhOperator/services/auth/e2e-test-dsc/Test_rolebinding_is_added_when_group_is_added
=== RUN   TestOdhOperator/services/auth/e2e-test-dsc/Test_clusterrole_is_added_when_group_is_added
=== RUN   TestOdhOperator/services/auth/e2e-test-dsc/Test_clusterrolebinding_is_added_when_group_is_added
```

When running without flags:

```
=== RUN   TestOdhOperator/services
=== RUN   TestOdhOperator/services/monitoring
=== RUN   TestOdhOperator/services/monitoring/e2e-test-dsc
=== RUN   TestOdhOperator/services/monitoring/e2e-test-dsc/Auto_creation_of_Monitoring_CR
=== RUN   TestOdhOperator/services/monitoring/e2e-test-dsc/Test_Monitoring_CR_content
=== RUN   TestOdhOperator/services/auth
=== RUN   TestOdhOperator/services/auth/e2e-test-dsc
=== RUN   TestOdhOperator/services/auth/e2e-test-dsc/Auto_creation_of_Auth_CR
=== RUN   TestOdhOperator/services/auth/e2e-test-dsc/Test_Auth_CR_content
=== RUN   TestOdhOperator/services/auth/e2e-test-dsc/Test_role_creation
=== RUN   TestOdhOperator/services/auth/e2e-test-dsc/Test_rolebinding_creation
=== RUN   TestOdhOperator/services/auth/e2e-test-dsc/Test_rolebinding_is_added_when_group_is_added
=== RUN   TestOdhOperator/services/auth/e2e-test-dsc/Test_clusterrole_is_added_when_group_is_added
=== RUN   TestOdhOperator/services/auth/e2e-test-dsc/Test_clusterrolebinding_is_added_when_group_is_added
```

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
