### PR TITLE
Improve e2e test configurability

### DIFF
--- a/tests/e2e/cfmap_deletion_test.go
+++ b/tests/e2e/cfmap_deletion_test.go
@@ -70,14 +70,14 @@ func (tc *testContext) testOwnedNamespacesAllExist(t *testing.T) {
 }
 
 func removeDeletionConfigMap(tc *testContext) {
-	_ = tc.kubeClient.CoreV1().ConfigMaps(tc.operatorNamespace).Delete(tc.ctx, deleteConfigMap, metav1.DeleteOptions{})
+	_ = tc.kubeClient.CoreV1().ConfigMaps(testOpts.operatorNamespace).Delete(tc.ctx, deleteConfigMap, metav1.DeleteOptions{})
 }
 
 func createDeletionConfigMap(tc *testContext, enableDeletion string) error {
 	configMap := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      deleteConfigMap,
-			Namespace: tc.operatorNamespace,
+			Namespace: testOpts.operatorNamespace,
 			Labels: map[string]string{
 				upgrade.DeleteConfigMapLabel: enableDeletion,
 			},

--- a/tests/e2e/controller_test.go
+++ b/tests/e2e/controller_test.go
@@ -257,7 +257,7 @@ func (tg *TestGroup) Validate() error {
 
 	for _, n := range tg.flags {
 		n = strings.TrimLeft(n, "!")
-		if _, ok := tg.scenarios[n]; !ok {
+		if !slices.Contains(tg.Names(), n) {
 			validValues := strings.Join(testOpts.components.Names(), ", ")
 			return fmt.Errorf("unsupported value %s, valid values are: %s", n, validValues)
 		}

--- a/tests/e2e/creation_test.go
+++ b/tests/e2e/creation_test.go
@@ -37,7 +37,7 @@ func creationTestSuite(t *testing.T) {
 			err = testCtx.testDSCICreation()
 			require.NoError(t, err, "error creating DSCI CR")
 		})
-		if testCtx.testOpts.webhookTest {
+		if testOpts.webhookTest {
 			t.Run("Creation of more than one of DSCInitialization instance", func(t *testing.T) {
 				testCtx.testDSCIDuplication(t)
 			})
@@ -55,7 +55,7 @@ func creationTestSuite(t *testing.T) {
 			err = testCtx.testDSCCreation(t)
 			require.NoError(t, err, "error creating DataScienceCluster instance")
 		})
-		if testCtx.testOpts.webhookTest {
+		if testOpts.webhookTest {
 			t.Run("Creation of more than one of DataScienceCluster instance", func(t *testing.T) {
 				testCtx.testDSCDuplication(t)
 			})
@@ -68,7 +68,7 @@ func creationTestSuite(t *testing.T) {
 		})
 
 		// ModelReg
-		if testCtx.testOpts.webhookTest {
+		if testOpts.webhookTest {
 			t.Run("Validate model registry config", func(t *testing.T) {
 				err = testCtx.validateModelRegistryConfig()
 				require.NoError(t, err, "error validating ModelRegistry config")

--- a/tests/e2e/helper_test.go
+++ b/tests/e2e/helper_test.go
@@ -54,7 +54,7 @@ const (
 
 func (tc *testContext) waitForOperatorDeployment(name string, replicas int32) error {
 	err := wait.PollUntilContextTimeout(tc.ctx, generalRetryInterval, operatorReadyTimeout, false, func(ctx context.Context) (bool, error) {
-		controllerDeployment, err := tc.kubeClient.AppsV1().Deployments(tc.operatorNamespace).Get(ctx, name, metav1.GetOptions{})
+		controllerDeployment, err := tc.kubeClient.AppsV1().Deployments(testOpts.operatorNamespace).Get(ctx, name, metav1.GetOptions{})
 		if err != nil {
 			if k8serr.IsNotFound(err) {
 				return false, nil


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->
 
This feature is to improve the configurability of the e2e test suite,
which is particularly useful when running the test suite locally.

There are two new flags to globally enabled/disable some test grouops
such as components and services:

* --test-components=true|false
* --test-services=true|false

It is also possible to disable a particular test by preceding its name
with an exlamation mark (!), i.e. to run only the test for the dashbaord
component and skip the tests for the auth service:

```shell
make e2e-test E2E_TEST_FLAGS='--test-component=dashboard --test-service=!auth'
```

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

When running the tests with:

```shell
make e2e-test E2E_TEST_FLAGS='-timeout 25m --test-operator-controller=false --test-webhook=false --test-component=dashboard --test-service=!auth'
```

The output is:

```
=== RUN   TestOdhOperator
=== RUN   TestOdhOperator/create_DSCI_and_DSC_CRs
    helper_test.go:458: Ensuring serverless-operator is installed
    helper_test.go:458: Ensuring servicemeshoperator is installed
=== RUN   TestOdhOperator/create_DSCI_and_DSC_CRs/e2e-test-dsc
=== RUN   TestOdhOperator/create_DSCI_and_DSC_CRs/e2e-test-dsc/Creation_of_DSCI_CR
=== RUN   TestOdhOperator/create_DSCI_and_DSC_CRs/e2e-test-dsc/Validate_DSCInitialization_instance
=== RUN   TestOdhOperator/create_DSCI_and_DSC_CRs/e2e-test-dsc/Check_owned_namespaces_exist
=== RUN   TestOdhOperator/create_DSCI_and_DSC_CRs/e2e-test-dsc/Creation_of_DataScienceCluster_instance
=== RUN   TestOdhOperator/create_DSCI_and_DSC_CRs/e2e-test-dsc/Validate_Knative_resource
=== RUN   TestOdhOperator/components
    controller_test.go:315: Skipping tests for components/trustyai
    controller_test.go:315: Skipping tests for components/kueue
    controller_test.go:315: Skipping tests for components/codeflare
    controller_test.go:315: Skipping tests for components/kserve
    controller_test.go:315: Skipping tests for components/modelmeshserving
    controller_test.go:315: Skipping tests for components/feastoperator
    controller_test.go:315: Skipping tests for components/ray
    controller_test.go:315: Skipping tests for components/modelregistry
    controller_test.go:315: Skipping tests for components/trainingoperator
    controller_test.go:315: Skipping tests for components/datasciencepipelines
    controller_test.go:315: Skipping tests for components/workbenches
    controller_test.go:315: Skipping tests for components/modelcontroller
=== RUN   TestOdhOperator/components/dashboard
=== RUN   TestOdhOperator/components/dashboard/Validate_component_enabled
=== RUN   TestOdhOperator/components/dashboard/Validate_operands_have_OwnerReferences
=== RUN   TestOdhOperator/components/dashboard/Validate_update_operand_resources
=== RUN   TestOdhOperator/components/dashboard/Validate_update_operand_resources/deployment_odh-dashboard
=== RUN   TestOdhOperator/components/dashboard/Validate_dynamically_watches_operands
=== RUN   TestOdhOperator/components/dashboard/Validate_CRDs_reinstated
=== RUN   TestOdhOperator/components/dashboard/Validate_CRDs_reinstated/acceleratorprofiles.dashboard.opendatahub.io
=== RUN   TestOdhOperator/components/dashboard/Validate_CRDs_reinstated/hardwareprofiles.dashboard.opendatahub.io
=== RUN   TestOdhOperator/components/dashboard/Validate_CRDs_reinstated/odhapplications.dashboard.opendatahub.io
=== RUN   TestOdhOperator/components/dashboard/Validate_CRDs_reinstated/odhdocuments.dashboard.opendatahub.io
=== RUN   TestOdhOperator/components/dashboard/Validate_component_disabled
=== RUN   TestOdhOperator/services
=== RUN   TestOdhOperator/services/monitoring
=== RUN   TestOdhOperator/services/monitoring/e2e-test-dsc
=== RUN   TestOdhOperator/services/monitoring/e2e-test-dsc/Auto_creation_of_Monitoring_CR
=== RUN   TestOdhOperator/services/monitoring/e2e-test-dsc/Test_Monitoring_CR_content
=== NAME  TestOdhOperator/services
    controller_test.go:315: Skipping tests for services/auth
=== RUN   TestOdhOperator/delete_components
=== RUN   TestOdhOperator/delete_components/e2e-test-dsc
=== RUN   TestOdhOperator/delete_components/e2e-test-dsc/Deletion_DSC_instance
=== RUN   TestOdhOperator/delete_components/e2e-test-dsc/Deletion_DSCI_instance
--- PASS: TestOdhOperator (204.77s)
    --- PASS: TestOdhOperator/create_DSCI_and_DSC_CRs (32.35s)
        --- PASS: TestOdhOperator/create_DSCI_and_DSC_CRs/e2e-test-dsc (21.02s)
            --- PASS: TestOdhOperator/create_DSCI_and_DSC_CRs/e2e-test-dsc/Creation_of_DSCI_CR (10.45s)
            --- PASS: TestOdhOperator/create_DSCI_and_DSC_CRs/e2e-test-dsc/Validate_DSCInitialization_instance (0.00s)
            --- PASS: TestOdhOperator/create_DSCI_and_DSC_CRs/e2e-test-dsc/Check_owned_namespaces_exist (0.11s)
            --- PASS: TestOdhOperator/create_DSCI_and_DSC_CRs/e2e-test-dsc/Creation_of_DataScienceCluster_instance (10.46s)
            --- PASS: TestOdhOperator/create_DSCI_and_DSC_CRs/e2e-test-dsc/Validate_Knative_resource (0.00s)
    --- PASS: TestOdhOperator/components (171.74s)
        --- PASS: TestOdhOperator/components/dashboard (171.74s)
            --- PASS: TestOdhOperator/components/dashboard/Validate_component_enabled (67.41s)
            --- PASS: TestOdhOperator/components/dashboard/Validate_operands_have_OwnerReferences (0.22s)
            --- PASS: TestOdhOperator/components/dashboard/Validate_update_operand_resources (30.57s)
                --- PASS: TestOdhOperator/components/dashboard/Validate_update_operand_resources/deployment_odh-dashboard (30.45s)
            --- PASS: TestOdhOperator/components/dashboard/Validate_dynamically_watches_operands (1.90s)
            --- PASS: TestOdhOperator/components/dashboard/Validate_CRDs_reinstated (69.39s)
                --- PASS: TestOdhOperator/components/dashboard/Validate_CRDs_reinstated/acceleratorprofiles.dashboard.opendatahub.io (4.70s)
                --- PASS: TestOdhOperator/components/dashboard/Validate_CRDs_reinstated/hardwareprofiles.dashboard.opendatahub.io (21.20s)
                --- PASS: TestOdhOperator/components/dashboard/Validate_CRDs_reinstated/odhapplications.dashboard.opendatahub.io (21.22s)
                --- PASS: TestOdhOperator/components/dashboard/Validate_CRDs_reinstated/odhdocuments.dashboard.opendatahub.io (22.27s)
            --- PASS: TestOdhOperator/components/dashboard/Validate_component_disabled (1.80s)
    --- PASS: TestOdhOperator/services (0.00s)
        --- PASS: TestOdhOperator/services/monitoring (0.00s)
            --- PASS: TestOdhOperator/services/monitoring/e2e-test-dsc (0.00s)
                --- PASS: TestOdhOperator/services/monitoring/e2e-test-dsc/Auto_creation_of_Monitoring_CR (0.00s)
                --- PASS: TestOdhOperator/services/monitoring/e2e-test-dsc/Test_Monitoring_CR_content (0.00s)
    --- PASS: TestOdhOperator/delete_components (0.68s)
        --- PASS: TestOdhOperator/delete_components/e2e-test-dsc (0.68s)
            --- PASS: TestOdhOperator/delete_components/e2e-test-dsc/Deletion_DSC_instance (0.34s)
            --- PASS: TestOdhOperator/delete_components/e2e-test-dsc/Deletion_DSCI_instance (0.34s)
```

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
