### PR TITLE
Move  dashboardConfig checking to Auth CR creation.

### DIFF
--- a/controllers/dscinitialization/auth.go
+++ b/controllers/dscinitialization/auth.go
@@ -2,35 +2,110 @@ package dscinitialization
 
 import (
 	"context"
+	"fmt"
 
+	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
+	dsciv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/dscinitialization/v1"
 	serviceApi "github.com/opendatahub-io/opendatahub-operator/v2/apis/services/v1alpha1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/controllers/components/dashboard"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/common"
 )
 
-func (r *DSCInitializationReconciler) createAuth(ctx context.Context) error {
-	// Create Auth CR singleton
-	defaultAuth := client.Object(&serviceApi.Auth{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       serviceApi.AuthKind,
-			APIVersion: serviceApi.GroupVersion.String(),
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name: serviceApi.AuthInstanceName,
-		},
-		Spec: serviceApi.AuthSpec{
-			AdminGroups:   []string{dashboard.GetAdminGroup()},
-			AllowedGroups: []string{"system:authenticated"},
-		},
-	},
-	)
-	err := r.Create(ctx, defaultAuth)
+func (r *DSCInitializationReconciler) createAuth(ctx context.Context, dscInit *dsciv1.DSCInitialization) error {
+	log := logf.FromContext(ctx)
+	// check for the dashboardConfig kind.
+	// Once the groupsConfig entry in the dashboardConfig is removed this logic can be removed.
+	crd := &apiextv1.CustomResourceDefinition{}
+	err := r.Client.Get(ctx, client.ObjectKey{Name: "odhdashboardconfigs.opendatahub.io"}, crd)
+
+	// can't find the dashboardConfig kind so create the default.
+	if err != nil && k8serr.IsNotFound(err) {
+		log.Info("couldn't find odhDashboardConfig CRD, creating auth with defaults.")
+		err = r.Create(ctx, buildDefaultAuth())
+		if err != nil && !k8serr.IsAlreadyExists(err) {
+			return err
+		}
+		return nil
+	} else if err != nil {
+		return fmt.Errorf("failed to get odhdashboardconfigs.opendatahub.io CRD: %w", err)
+	}
+
+	// check if a dashboardConfig instance exists.
+	odhObject := &unstructured.Unstructured{}
+	odhObject.SetGroupVersionKind(gvk.OdhDashboardConfig)
+	err = r.Client.Get(ctx, client.ObjectKey{
+		Name:      "odh-dashboard-config",
+		Namespace: dscInit.Spec.ApplicationsNamespace,
+	}, odhObject)
+	if err != nil && k8serr.IsNotFound(err) {
+		log.Info("couldn't find odhDashboardConfig instance, creating auth with defaults.")
+		err = r.Create(ctx, buildDefaultAuth())
+		if err != nil && !k8serr.IsAlreadyExists(err) {
+			return err
+		}
+		return nil
+	} else if err != nil {
+		return fmt.Errorf("failed to get odh-dashboard-config instance: %w", err)
+	}
+
+	// dashboardConfig CRD exists and we have an instance so copy the groups to the auth CR
+	foundGroups, ok, err := unstructured.NestedStringMap(odhObject.Object, "spec", "groupsConfig")
+	if err != nil {
+		return err
+	}
+	if ok {
+		adminGroup := []string{}
+		allowedGroup := []string{}
+		added := common.AddMissing(&adminGroup, foundGroups["adminGroups"])
+		added += common.AddMissing(&allowedGroup, foundGroups["allowedGroups"])
+
+		// only update if we found a new group in the list
+		if added == 0 {
+			return nil
+		}
+		err = r.Create(ctx, buildAuthWithGroups(adminGroup, allowedGroup))
+		if err != nil && !k8serr.IsAlreadyExists(err) {
+			return err
+		}
+		return nil
+	}
+
+	// found a dashboardConfig CRD and instance but no groupsConfig so instantiate an empty auth.
+	err = r.Create(ctx, buildEmptyAuth())
 	if err != nil && !k8serr.IsAlreadyExists(err) {
 		return err
 	}
 
 	return nil
+}
+
+func buildAuthWithGroups(adminGroup []string, allowedGroup []string) client.Object {
+	return &serviceApi.Auth{
+		TypeMeta:   metav1.TypeMeta{Kind: serviceApi.AuthKind, APIVersion: serviceApi.GroupVersion.String()},
+		ObjectMeta: metav1.ObjectMeta{Name: serviceApi.AuthInstanceName},
+		Spec:       serviceApi.AuthSpec{AdminGroups: adminGroup, AllowedGroups: allowedGroup},
+	}
+}
+
+func buildDefaultAuth() client.Object {
+	return &serviceApi.Auth{
+		TypeMeta:   metav1.TypeMeta{Kind: serviceApi.AuthKind, APIVersion: serviceApi.GroupVersion.String()},
+		ObjectMeta: metav1.ObjectMeta{Name: serviceApi.AuthInstanceName},
+		Spec:       serviceApi.AuthSpec{AdminGroups: []string{dashboard.GetAdminGroup()}, AllowedGroups: []string{"system:authenticated"}},
+	}
+}
+
+func buildEmptyAuth() client.Object {
+	return &serviceApi.Auth{
+		TypeMeta:   metav1.TypeMeta{Kind: serviceApi.AuthKind, APIVersion: serviceApi.GroupVersion.String()},
+		ObjectMeta: metav1.ObjectMeta{Name: serviceApi.AuthInstanceName},
+		Spec:       serviceApi.AuthSpec{AdminGroups: []string{}, AllowedGroups: []string{}},
+	}
 }

--- a/controllers/dscinitialization/dscinitialization_controller.go
+++ b/controllers/dscinitialization/dscinitialization_controller.go
@@ -289,7 +289,7 @@ func (r *DSCInitializationReconciler) Reconcile(ctx context.Context, req ctrl.Re
 			return reconcile.Result{}, errServiceMesh
 		}
 
-		err = r.createAuth(ctx)
+		err = r.createAuth(ctx, instance)
 		if err != nil {
 			log.Info("failed to create Auth")
 			return ctrl.Result{}, err

--- a/controllers/services/auth/auth_controller_actions.go
+++ b/controllers/services/auth/auth_controller_actions.go
@@ -53,7 +53,7 @@ func bindRole(ctx context.Context, rr *odhtypes.ReconciliationRequest, groups []
 		// we want to disallow adding system:authenticated to the adminGroups
 		if roleName == "admingroup-role" && e == "system:authenticated" || e == "" {
 			log := logf.FromContext(ctx)
-			log.Info("system:authenticated cannot be added to adminGroups")
+			log.Info("skipping adding invalid group to RoleBinding")
 			continue
 		}
 		rs := rbacv1.Subject{
@@ -90,7 +90,7 @@ func bindClusterRole(ctx context.Context, rr *odhtypes.ReconciliationRequest, gr
 		// we want to disallow adding system:authenticated to the adminGroups
 		if roleName == "admingroupcluster-role" && e == "system:authenticated" || e == "" {
 			log := logf.FromContext(ctx)
-			log.Info("system:authenticated cannot be added to adminGroups")
+			log.Info("skipping adding invalid group to ClusterRoleBinding")
 			continue
 		}
 		rs := rbacv1.Subject{

--- a/controllers/services/auth/auth_controller_actions.go
+++ b/controllers/services/auth/auth_controller_actions.go
@@ -21,15 +21,10 @@ import (
 	"errors"
 
 	rbacv1 "k8s.io/api/rbac/v1"
-	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	serviceApi "github.com/opendatahub-io/opendatahub-operator/v2/apis/services/v1alpha1"
-	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
-	common "github.com/opendatahub-io/opendatahub-operator/v2/pkg/common"
 	odhtypes "github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
 )
 
@@ -52,60 +47,11 @@ func initialize(ctx context.Context, rr *odhtypes.ReconciliationRequest) error {
 	return nil
 }
 
-// We only really expect this to copy once, the fields in the dashboardConfig will be immutable
-// but there may be edge cases where the dashboardConfig is created or edited later.
-// This function can be removed entirely when the dashboard team deprecates
-// the fields in question.
-func copyGroups(ctx context.Context, rr *odhtypes.ReconciliationRequest) error {
-	ai, ok := rr.Instance.(*serviceApi.Auth)
-	if !ok {
-		return errors.New("instance is not of type *services.Auth")
-	}
-
-	// check for the dashboardConfig kind
-	crd := &apiextv1.CustomResourceDefinition{}
-	if err := rr.Client.Get(ctx, client.ObjectKey{Name: "odhdashboardconfigs.opendatahub.io"}, crd); err != nil {
-		return client.IgnoreNotFound(err)
-	}
-
-	// Get groups from the dashboardConfig
-	odhObject := &unstructured.Unstructured{}
-	odhObject.SetGroupVersionKind(gvk.OdhDashboardConfig)
-
-	err := rr.Client.Get(ctx, client.ObjectKey{
-		Name:      "odh-dashboard-config",
-		Namespace: rr.DSCI.Spec.ApplicationsNamespace,
-	}, odhObject)
-	// if the kind exists but there is no odh-dashboard-config then return
-	if err != nil {
-		return client.IgnoreNotFound(err)
-	}
-	foundGroups, found, _ := unstructured.NestedStringMap(odhObject.Object, "spec", "groupsConfig")
-	if !found {
-		return errors.New("no groupsConfig found in dashboardConfig")
-	}
-
-	added := common.AddMissing(&ai.Spec.AdminGroups, foundGroups["adminGroups"])
-	added += common.AddMissing(&ai.Spec.AllowedGroups, foundGroups["allowedGroups"])
-
-	if added == 0 {
-		return nil
-	}
-
-	// only update if we found a new group in the list
-	err = rr.Client.Update(ctx, ai)
-	if err != nil {
-		return errors.New("error adding groups to Auth CR")
-	}
-
-	return nil
-}
-
 func bindRole(ctx context.Context, rr *odhtypes.ReconciliationRequest, groups []string, roleBindingName string, roleName string) error {
 	groupsToBind := []rbacv1.Subject{}
 	for _, e := range groups {
 		// we want to disallow adding system:authenticated to the adminGroups
-		if roleName == "admingroup-role" && e == "system:authenticated" {
+		if roleName == "admingroup-role" && e == "system:authenticated" || e == "" {
 			log := logf.FromContext(ctx)
 			log.Info("system:authenticated cannot be added to adminGroups")
 			continue
@@ -138,9 +84,15 @@ func bindRole(ctx context.Context, rr *odhtypes.ReconciliationRequest, groups []
 	return nil
 }
 
-func bindClusterRole(rr *odhtypes.ReconciliationRequest, groups []string, roleBindingName string, roleName string) error {
+func bindClusterRole(ctx context.Context, rr *odhtypes.ReconciliationRequest, groups []string, roleBindingName string, roleName string) error {
 	groupsToBind := []rbacv1.Subject{}
 	for _, e := range groups {
+		// we want to disallow adding system:authenticated to the adminGroups
+		if roleName == "admingroupcluster-role" && e == "system:authenticated" || e == "" {
+			log := logf.FromContext(ctx)
+			log.Info("system:authenticated cannot be added to adminGroups")
+			continue
+		}
 		rs := rbacv1.Subject{
 			Kind:     "Group",
 			APIGroup: "rbac.authorization.k8s.io",
@@ -179,7 +131,7 @@ func managePermissions(ctx context.Context, rr *odhtypes.ReconciliationRequest) 
 		return err
 	}
 
-	err = bindClusterRole(rr, ai.Spec.AdminGroups, "admingroupcluster-rolebinding", "admingroupcluster-role")
+	err = bindClusterRole(ctx, rr, ai.Spec.AdminGroups, "admingroupcluster-rolebinding", "admingroupcluster-role")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->
Add functionality to the Auth controller and fix bugs. [RHOAIENG-19716](https://issues.redhat.com/browse/RHOAIENG-19716)

- Move copying of groups from dashboardConfig to create action in DSCI.
- Remove watch of dashboardConfig.
- If there are no groups in either list remove the rolebindings.
- Add validation on clusterRole to omit system:authenticated.
- Add e2e test for removing groups and validating the rolebinding are removed.

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
_Auth CR created with Defaults_
- Install operator.
- Create DSCI.
- Validate the Auth CR is created with the defaults.

_Auth CR reads defaults from dashboardConfig_
- Install operator.
- Create odhDashboardConfig with non-default groups, ie not system:authenticated as allowedGroup.
- Create DSCI.
- Validate Auth CR contents reflects the non-default content and the defaults haven't been added.
- Validate you can remove the added group and the Auth controller does not readd the group.
## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
