### PR TITLE
[sync]fix: allow dashboard to use devFlags but still get the correct values…

### DIFF
--- a/controllers/components/dashboard/dashboard_controller.go
+++ b/controllers/components/dashboard/dashboard_controller.go
@@ -89,6 +89,7 @@ func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.
 		// actions
 		WithAction(initialize).
 		WithAction(devFlags).
+		WithAction(setKustomizedParams).
 		WithAction(configureDependencies).
 		WithAction(kustomize.NewAction(
 			kustomize.WithCache(),

--- a/controllers/components/dashboard/dashboard_controller_actions.go
+++ b/controllers/components/dashboard/dashboard_controller_actions.go
@@ -24,15 +24,6 @@ import (
 func initialize(ctx context.Context, rr *odhtypes.ReconciliationRequest) error {
 	rr.Manifests = []odhtypes.ManifestInfo{defaultManifestInfo(rr.Release.Name)}
 
-	extraParamsMap, err := computeKustomizeVariable(ctx, rr.Client, rr.Release.Name, &rr.DSCI.Spec)
-	if err != nil {
-		return errors.New("failed to set variable for extraParamsMap")
-	}
-
-	if err := odhdeploy.ApplyParams(rr.Manifests[0].String(), nil, extraParamsMap); err != nil {
-		return fmt.Errorf("failed to update params.env  from %s : %w", rr.Manifests[0].String(), err)
-	}
-
 	return nil
 }
 
@@ -71,6 +62,18 @@ func customizeResources(_ context.Context, rr *odhtypes.ReconciliationRequest) e
 		}
 	}
 
+	return nil
+}
+
+func setKustomizedParams(ctx context.Context, rr *odhtypes.ReconciliationRequest) error {
+	extraParamsMap, err := computeKustomizeVariable(ctx, rr.Client, rr.Release.Name, &rr.DSCI.Spec)
+	if err != nil {
+		return errors.New("failed to set variable for url, section-title etc")
+	}
+
+	if err := odhdeploy.ApplyParams(rr.Manifests[0].String(), nil, extraParamsMap); err != nil {
+		return fmt.Errorf("failed to update params.env from %s : %w", rr.Manifests[0].String(), err)
+	}
 	return nil
 }
 


### PR DESCRIPTION
… (#1648)

Signed-off-by: Wen Zhou <wenzhou@redhat.com>
(cherry picked from commit 834a976a3ebc36da29f3a72ecf2c343a5ee6d948)

<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->
sync https://github.com/opendatahub-io/opendatahub-operator/pull/1648

<!--- Link your JIRA and related links here for reference. -->
ref: https://issues.redhat.com/browse/RHOAIENG-19713 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
