### PR TITLE
tests: e2e: disable FeastOperator

### DIFF
--- a/tests/e2e/controller_test.go
+++ b/tests/e2e/controller_test.go
@@ -61,7 +61,9 @@ var (
 				componentApi.KserveComponentName:               kserveTestSuite,
 				componentApi.ModelMeshServingComponentName:     modelMeshServingTestSuite,
 				componentApi.ModelControllerComponentName:      modelControllerTestSuite,
-				componentApi.FeastOperatorComponentName:        feastOperatorTestSuite,
+				// Temporary disable Feast until images are moved from docker.io
+				// TODO: enable when ready
+				// componentApi.FeastOperatorComponentName:        feastOperatorTestSuite,
 			},
 		},
 		services: TestGroup{

--- a/tests/e2e/feastoperator_test.go
+++ b/tests/e2e/feastoperator_test.go
@@ -8,7 +8,8 @@ import (
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/apis/components/v1alpha1"
 )
 
-func feastOperatorTestSuite(t *testing.T) {
+// TODO: remove unused when test enabled back.
+func feastOperatorTestSuite(t *testing.T) { //nolint:unused
 	t.Helper()
 
 	ct, err := NewComponentTestCtx(&componentApi.FeastOperator{})


### PR DESCRIPTION
Feast stored image on docker.io which tends to report RateLimit error.

It was agreed that images will be moved, but until then disable it.

<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
