### PR TITLE
e2e: add compoennt/services flags support for parsing comma-separated values

### DIFF
--- a/tests/e2e/controller_test.go
+++ b/tests/e2e/controller_test.go
@@ -84,7 +84,7 @@ func (i *arrayFlags) String() string {
 }
 
 func (i *arrayFlags) Set(value string) error {
-	*i = append(*i, value)
+	*i = append(*i, strings.Split(value, ",")...)
 	return nil
 }
 


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

It is now possible to set the list of components/services to test as a comma separated value:

```shell
make e2e-test E2E_TEST_FLAGS='--test-component=dashboard,modelregistry --test-component=ray'
```
<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] ~~Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.~~
- [ ] ~~Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).~~
- [x] The developer has manually tested the changes and verified that the changes work
