### PR TITLE
[rhoai] Fix monitoring controller condition and owner reference setup

### DIFF
--- a/controllers/services/monitoring/monitoring_controller_actions.go
+++ b/controllers/services/monitoring/monitoring_controller_actions.go
@@ -103,7 +103,7 @@ func updateStatus(ctx context.Context, rr *odhtypes.ReconciliationRequest) error
 	nc := metav1.Condition{
 		Type:    status.ConditionTypeReady,
 		Status:  metav1.ConditionFalse,
-		Reason:  status.PhaseNotReady,
+		Reason:  "NotReady",
 		Message: "Prometheus deployment is not ready",
 	}
 


### PR DESCRIPTION
- fix a reason field in the ready condition to make it compliant to the
  expected validation (CamelCase, no spaces)
- use controllerutil.SetOwnerReference to set owner reference on the
  Monitoring CR as it enforces all the required fields to be set

(cherry picked from commit 0fc449e391a48bd488a64f19a5eb706eb2234666)

<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
