### PR TITLE
(chore): Default to pre-release for gh releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -41,7 +41,7 @@ jobs:
         with:
           body: ${{ steps.release-notes.outputs.release-notes-body }}
           tag_name: v${{ env.VERSION }}
-          make_latest: true
+          prerelease: true
   # TODO: To be enabled later.
   # create-community-operators-pr:
   #   needs: [gh-release]


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
This adds a pre-release label to the ODH release in Github. After a successful OperatorHub release, we can manually change the release to `latest`(for now). This is to avoid confusion amongst teams, where they see a release in ODH github repo but the released version is missing in the OperatorHub(like ODH 2.23.1 or 2.24.0)

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
