### PR TITLE
Add missing predicates for Kserve dynamic watches

### DIFF
--- a/controllers/components/kserve/kserve_controller.go
+++ b/controllers/components/kserve/kserve_controller.go
@@ -124,27 +124,27 @@ func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.
 		// implicit predicate, so the simpler "DefaultPredicate" is also added.
 		WatchesGVK(
 			gvk.KnativeServing,
-			reconciler.Dynamic(),
+			reconciler.Dynamic(ifGVKInstalled(gvk.KnativeServing)),
 			reconciler.WithEventMapper(ownedViaFTMapFunc),
 			reconciler.WithPredicates(predicates.DefaultPredicate)).
 		WatchesGVK(
 			gvk.ServiceMeshMember,
-			reconciler.Dynamic(),
+			reconciler.Dynamic(ifGVKInstalled(gvk.ServiceMeshMember)),
 			reconciler.WithEventMapper(ownedViaFTMapFunc),
 			reconciler.WithPredicates(predicates.DefaultPredicate)).
 		WatchesGVK(
 			gvk.EnvoyFilter,
-			reconciler.Dynamic(),
+			reconciler.Dynamic(ifGVKInstalled(gvk.EnvoyFilter)),
 			reconciler.WithEventMapper(ownedViaFTMapFunc),
 			reconciler.WithPredicates(predicates.DefaultPredicate)).
 		WatchesGVK(
 			gvk.AuthorizationPolicy,
-			reconciler.Dynamic(),
+			reconciler.Dynamic(ifGVKInstalled(gvk.AuthorizationPolicy)),
 			reconciler.WithEventMapper(ownedViaFTMapFunc),
 			reconciler.WithPredicates(predicates.DefaultPredicate)).
 		WatchesGVK(
 			gvk.Gateway,
-			reconciler.Dynamic(),
+			reconciler.Dynamic(ifGVKInstalled(gvk.Gateway)),
 			reconciler.WithEventMapper(ownedViaFTMapFunc),
 			reconciler.WithPredicates(predicates.DefaultPredicate)).
 

--- a/controllers/components/kserve/kserve_support.go
+++ b/controllers/components/kserve/kserve_support.go
@@ -271,3 +271,14 @@ func ownedViaFT(cli client.Client) handler.MapFunc {
 func isLegacyOwnerRef(or metav1.OwnerReference) bool {
 	return or.APIVersion == gvk.DataScienceCluster.GroupVersion().String() && or.Kind == gvk.DataScienceCluster.Kind
 }
+
+func ifGVKInstalled(kvg schema.GroupVersionKind) func(context.Context, *odhtypes.ReconciliationRequest) bool {
+	return func(ctx context.Context, rr *odhtypes.ReconciliationRequest) bool {
+		hasCRD, err := cluster.HasCRD(ctx, rr.Client, kvg)
+		if err != nil {
+			ctrl.Log.Error(err, "error checking if CRD installed", "GVK", kvg)
+			return false
+		}
+		return hasCRD
+	}
+}


### PR DESCRIPTION
<!---
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

Before this change, these watches don't work properly, and modifying a
matching resource doesn't lead to a new reconciliation request being
enqueued.

To demonstrate this, once can annotate a matching resource and notice
that before this change Kserve reconciliation doesn't happen. With
this change, reconciliation occurs as expected.

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Before this change, the following doesn't lead to reconciliation:

```
oc annotate knativeserving -n knative-serving knative-serving a=a
```

After this change, the following DOES lead to reconciliation:

```
oc annotate knativeserving -n knative-serving knative-serving b=b
```

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work