### PR TITLE
chore: Allow cross-compilation in Dockerfile

### DIFF
--- a/Dockerfiles/Dockerfile
+++ b/Dockerfiles/Dockerfile
@@ -1,8 +1,11 @@
 # Build the manager binary
 ARG GOLANG_VERSION=1.22
 
+ARG BUILDPLATFORM
+ARG TARGETPLATFORM
+
 ################################################################################
-FROM registry.access.redhat.com/ubi8/toolbox as manifests
+FROM --platform=$BUILDPLATFORM registry.access.redhat.com/ubi8/toolbox as manifests
 ARG USE_LOCAL=false
 ARG OVERWRITE_MANIFESTS=""
 USER root
@@ -20,7 +23,7 @@ COPY config/monitoring/ /opt/manifests/monitoring
 COPY config/osd-configs/ /opt/manifests/osd-configs
 
 ################################################################################
-FROM registry.access.redhat.com/ubi8/go-toolset:$GOLANG_VERSION as builder
+FROM --platform=$BUILDPLATFORM registry.access.redhat.com/ubi8/go-toolset:$GOLANG_VERSION as builder
 ARG CGO_ENABLED=1
 ARG TARGETARCH
 USER root
@@ -42,7 +45,7 @@ COPY pkg/ pkg/
 RUN CGO_ENABLED=${CGO_ENABLED} GOOS=linux GOARCH=${TARGETARCH} go build -a -tags strictfipsruntime -o manager main.go
 
 ################################################################################
-FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+FROM --platform=$TARGETPLATFORM registry.access.redhat.com/ubi8/ubi-minimal:latest
 WORKDIR /
 COPY --from=builder /workspace/manager .
 COPY --chown=1001:0 --from=manifests /opt/manifests /opt/manifests


### PR DESCRIPTION
<!---
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->
My machine runs on linux/arm64, but I want to be able to run container
images that I build during development on x86_64 clusters.

The main problem is that the default is to use the TARGETPLATFORM for
all stages in an image build, which means that, for example, the `go`
commands that are run in the `builder` stage will be using an x86_64
`go` binary, which essentially doesn't work on aarch64.

When this instead specifies to use BUILDPLATFORM for those stages
before the last one, it defaults to using the local platform (os/arch)
for those containers, so I get aarch64 builder stage container images,
containing aarch64 `go` binaries.

Since I specify `--platform=linux/amd64` when doing the `podman
build`, it will still build an aarch64 binary of the operator, and put
that into an aarch64 final image.

The full command that I use to build the image is as follows.

```commandline
podman build --platform linux/amd64 -f Dockerfiles/Dockerfile \
  --build-arg CGO_ENABLED=0 \
  -t odh-operator:latest .
```

Notice that I also have to specify CGO_ENABLED=0, otherwise it'll
complain with the following error at the `go build` command:

> gcc: error: unrecognized command line option '-m64'

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Built an image successfully

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work