### PR TITLE
Report reconciliation errors as part of the component' status

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,7 @@ SHELL = /usr/bin/env bash -o pipefail
 
 # E2E tests additional flags
 # See README.md, default go test timeout 10m
-E2E_TEST_FLAGS = -timeout 40m
+E2E_TEST_FLAGS = -timeout 50m
 
 # Default image-build is to not use local odh-manifests folder
 # set to "true" to use local instead

--- a/controllers/components/codeflare/codeflare_controller.go
+++ b/controllers/components/codeflare/codeflare_controller.go
@@ -30,16 +30,14 @@ import (
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/deploy"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/gc"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/render/kustomize"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/status/deployments"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/status/releases"
-	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/updatestatus"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/handlers"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/predicates/component"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/predicates/resources"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/reconciler"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/metadata/labels"
 )
-
-// CodeFlareReconciler reconciles a CodeFlare object.
 
 func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.Manager) error {
 	_, err := reconciler.ReconcilerFor(
@@ -65,7 +63,6 @@ func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.
 			reconciler.WithPredicates(
 				component.ForLabel(labels.ODH.Component(LegacyComponentName), labels.True)),
 		).
-		// Add CodeFlare-specific actions
 		WithAction(initialize).
 		WithAction(devFlags).
 		WithAction(releases.NewAction()).
@@ -77,9 +74,12 @@ func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.
 		WithAction(deploy.NewAction(
 			deploy.WithCache(),
 		)).
-		WithAction(updatestatus.NewAction()).
+		WithAction(deployments.NewAction()).
 		// must be final action
 		WithAction(gc.NewAction()).
+		// declares the list of additional, controller specific conditions that are
+		// contributing to the controller readiness status
+		WithConditions(conditionTypes...).
 		Build(ctx)
 
 	if err != nil {

--- a/controllers/components/codeflare/codeflare_support.go
+++ b/controllers/components/codeflare/codeflare_support.go
@@ -3,8 +3,6 @@ package codeflare
 import (
 	"path"
 
-	conditionsv1 "github.com/openshift/custom-resource-status/conditions/v1"
-
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/apis/components/v1alpha1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/controllers/status"
 	odhtypes "github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
@@ -14,7 +12,7 @@ import (
 const (
 	ComponentName = componentApi.CodeFlareComponentName
 
-	ReadyConditionType = conditionsv1.ConditionType(componentApi.CodeFlareKind + status.ReadySuffix)
+	ReadyConditionType = componentApi.CodeFlareKind + status.ReadySuffix
 
 	// LegacyComponentName is the name of the component that is assigned to deployments
 	// via Kustomize. Since a deployment selector is immutable, we can't upgrade existing
@@ -27,6 +25,10 @@ var (
 
 	imageParamMap = map[string]string{
 		"codeflare-operator-controller-image": "RELATED_IMAGE_ODH_CODEFLARE_OPERATOR_IMAGE",
+	}
+
+	conditionTypes = []string{
+		status.ConditionDeploymentsAvailable,
 	}
 )
 

--- a/controllers/components/dashboard/dashboard_controller.go
+++ b/controllers/components/dashboard/dashboard_controller.go
@@ -33,7 +33,7 @@ import (
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/deploy"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/gc"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/render/kustomize"
-	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/updatestatus"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/status/deployments"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/handlers"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/predicates/component"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/predicates/resources"
@@ -86,7 +86,6 @@ func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.
 			reconciler.Dynamic(),
 			reconciler.WithPredicates(resources.Deleted()),
 		).
-		// actions
 		WithAction(initialize).
 		WithAction(devFlags).
 		WithAction(setKustomizedParams).
@@ -108,12 +107,15 @@ func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.
 		WithAction(deploy.NewAction(
 			deploy.WithCache(),
 		)).
-		WithAction(updatestatus.NewAction()).
+		WithAction(deployments.NewAction()).
 		WithAction(updateStatus).
 		// must be the final action
 		WithAction(gc.NewAction(
 			gc.WithUnremovables(gvk.OdhDashboardConfig),
 		)).
+		// declares the list of additional, controller specific conditions that are
+		// contributing to the controller readiness status
+		WithConditions(conditionTypes...).
 		Build(ctx)
 
 	if err != nil {

--- a/controllers/components/dashboard/dashboard_support.go
+++ b/controllers/components/dashboard/dashboard_support.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	conditionsv1 "github.com/openshift/custom-resource-status/conditions/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/opendatahub-io/opendatahub-operator/v2/apis/common"
@@ -19,7 +18,7 @@ import (
 const (
 	ComponentName = componentApi.DashboardComponentName
 
-	ReadyConditionType = conditionsv1.ConditionType(componentApi.DashboardKind + status.ReadySuffix)
+	ReadyConditionType = componentApi.DashboardKind + status.ReadySuffix
 
 	// Legacy component names are the name of the component that is assigned to deployments
 	// via Kustomize. Since a deployment selector is immutable, we can't upgrade existing
@@ -60,6 +59,10 @@ var (
 
 	imagesMap = map[string]string{
 		"odh-dashboard-image": "RELATED_IMAGE_ODH_DASHBOARD_IMAGE",
+	}
+
+	conditionTypes = []string{
+		status.ConditionDeploymentsAvailable,
 	}
 )
 

--- a/controllers/components/datasciencepipelines/datasciencepipelines_controller.go
+++ b/controllers/components/datasciencepipelines/datasciencepipelines_controller.go
@@ -31,8 +31,8 @@ import (
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/deploy"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/gc"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/render/kustomize"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/status/deployments"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/status/releases"
-	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/updatestatus"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/handlers"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/predicates/component"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/predicates/resources"
@@ -61,7 +61,6 @@ func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.
 			reconciler.WithPredicates(
 				component.ForLabel(labels.ODH.Component(LegacyComponentName), labels.True)),
 		).
-		// Add datasciencepipelines-specific actions
 		WithAction(checkPreConditions).
 		WithAction(initialize).
 		WithAction(devFlags).
@@ -74,9 +73,12 @@ func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.
 		WithAction(deploy.NewAction(
 			deploy.WithCache(),
 		)).
-		WithAction(updatestatus.NewAction()).
+		WithAction(deployments.NewAction()).
 		// must be the final action
 		WithAction(gc.NewAction()).
+		// declares the list of additional, controller specific conditions that are
+		// contributing to the controller readiness status
+		WithConditions(conditionTypes...).
 		Build(ctx)
 
 	if err != nil {

--- a/controllers/components/datasciencepipelines/datasciencepipelines_support.go
+++ b/controllers/components/datasciencepipelines/datasciencepipelines_support.go
@@ -3,12 +3,11 @@ package datasciencepipelines
 import (
 	"path"
 
-	conditionsv1 "github.com/openshift/custom-resource-status/conditions/v1"
-
 	"github.com/opendatahub-io/opendatahub-operator/v2/apis/common"
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/apis/components/v1alpha1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/controllers/status"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
+	odherrors "github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/errors"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
 	odhdeploy "github.com/opendatahub-io/opendatahub-operator/v2/pkg/deploy"
 )
@@ -17,13 +16,17 @@ const (
 	ArgoWorkflowCRD = "workflows.argoproj.io"
 	ComponentName   = componentApi.DataSciencePipelinesComponentName
 
-	ReadyConditionType = conditionsv1.ConditionType(componentApi.DataSciencePipelinesKind + status.ReadySuffix)
+	ReadyConditionType = componentApi.DataSciencePipelinesKind + status.ReadySuffix
 
 	// LegacyComponentName is the name of the component that is assigned to deployments
 	// via Kustomize. Since a deployment selector is immutable, we can't upgrade existing
 	// deployment to the new component name, so keep it around till we figure out a solution.
 	LegacyComponentName      = "data-science-pipelines-operator"
 	platformVersionParamsKey = "PLATFORMVERSION"
+)
+
+var (
+	ErrArgoWorkflowAPINotOwned = odherrors.NewStopError(status.DataSciencePipelinesDoesntOwnArgoCRDMessage)
 )
 
 var (
@@ -46,6 +49,12 @@ var (
 		cluster.OpenDataHub:      "overlays/odh",
 		cluster.Unknown:          "overlays/odh",
 	}
+
+	conditionTypes = []string{
+		status.ConditionArgoWorkflowAvailable,
+		status.ConditionDeploymentsAvailable,
+	}
+
 	paramsPath = path.Join(odhdeploy.DefaultManifestPath, ComponentName, "base")
 )
 

--- a/controllers/components/feastoperator/feastoperator_controller.go
+++ b/controllers/components/feastoperator/feastoperator_controller.go
@@ -13,8 +13,8 @@ import (
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/deploy"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/gc"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/render/kustomize"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/status/deployments"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/status/releases"
-	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/updatestatus"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/handlers"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/predicates/component"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/predicates/resources"
@@ -52,7 +52,7 @@ func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.
 		WithAction(deploy.NewAction(
 			deploy.WithCache(),
 		)).
-		WithAction(updatestatus.NewAction()).
+		WithAction(deployments.NewAction()).
 		// must be the final action
 		WithAction(gc.NewAction()).
 		Build(ctx)

--- a/controllers/components/feastoperator/feastoperator_controller.go
+++ b/controllers/components/feastoperator/feastoperator_controller.go
@@ -55,6 +55,9 @@ func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.
 		WithAction(deployments.NewAction()).
 		// must be the final action
 		WithAction(gc.NewAction()).
+		// declares the list of additional, controller specific conditions that are
+		// contributing to the controller readiness status
+		WithConditions(conditionTypes...).
 		Build(ctx)
 
 	if err != nil {

--- a/controllers/components/feastoperator/feastoperator_support.go
+++ b/controllers/components/feastoperator/feastoperator_support.go
@@ -20,6 +20,10 @@ var (
 		"RELATED_IMAGE_FEAST_OPERATOR": "RELATED_IMAGE_ODH_FEAST_OPERATOR_IMAGE",
 		"RELATED_IMAGE_FEATURE_SERVER": "RELATED_IMAGE_ODH_FEAST_FEATURE_SERVER_IMAGE",
 	}
+
+	conditionTypes = []string{
+		status.ConditionDeploymentsAvailable,
+	}
 )
 
 func manifestPath() types.ManifestInfo {

--- a/controllers/components/feastoperator/feastoperator_support.go
+++ b/controllers/components/feastoperator/feastoperator_support.go
@@ -1,8 +1,6 @@
 package feastoperator
 
 import (
-	conditionsv1 "github.com/openshift/custom-resource-status/conditions/v1"
-
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/apis/components/v1alpha1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/controllers/status"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
@@ -12,7 +10,7 @@ import (
 const (
 	ComponentName = componentApi.FeastOperatorComponentName
 
-	ReadyConditionType = conditionsv1.ConditionType(componentApi.FeastOperatorKind + status.ReadySuffix)
+	ReadyConditionType = componentApi.FeastOperatorKind + status.ReadySuffix
 
 	ManifestsSourcePath = "overlays/odh"
 )

--- a/controllers/components/kserve/kserve.go
+++ b/controllers/components/kserve/kserve.go
@@ -15,6 +15,7 @@ import (
 	dscv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/datasciencecluster/v1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/controllers/status"
 	cr "github.com/opendatahub-io/opendatahub-operator/v2/pkg/componentsregistry"
+	odherrors "github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/errors"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/conditions"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/metadata/annotations"
 )
@@ -31,7 +32,22 @@ const (
 	// deployment to the new component name, so keep it around till we figure out a solution.
 	LegacyComponentName = "kserve"
 
-	ReadyConditionType = conditionsv1.ConditionType(componentApi.KserveKind + status.ReadySuffix)
+	ReadyConditionType = componentApi.KserveKind + status.ReadySuffix
+)
+
+var (
+	conditionTypes = []string{
+		status.ConditionServiceMeshAvailable,
+		status.ConditionServerlessAvailable,
+		status.ConditionDeploymentsAvailable,
+	}
+)
+
+var (
+	ErrServiceMeshNotConfigured        = odherrors.NewStopError(status.ServiceMeshNotConfiguredMessage)
+	ErrServiceMeshMemberAPINotFound    = odherrors.NewStopError(status.ServiceMeshOperatorNotInstalledMessage)
+	ErrServiceMeshOperatorNotInstalled = odherrors.NewStopError(status.ServiceMeshOperatorNotInstalledMessage)
+	ErrServerlessOperatorNotInstalled  = odherrors.NewStopError(status.ServerlessOperatorNotInstalledMessage)
 )
 
 type componentHandler struct{}

--- a/controllers/components/kserve/kserve.go
+++ b/controllers/components/kserve/kserve.go
@@ -37,8 +37,7 @@ const (
 
 var (
 	conditionTypes = []string{
-		status.ConditionServiceMeshAvailable,
-		status.ConditionServerlessAvailable,
+		status.ConditionServingAvailable,
 		status.ConditionDeploymentsAvailable,
 	}
 )

--- a/controllers/components/kserve/kserve_controller.go
+++ b/controllers/components/kserve/kserve_controller.go
@@ -38,8 +38,8 @@ import (
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/deploy"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/gc"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/render/kustomize"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/status/deployments"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/status/releases"
-	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/updatestatus"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/handlers"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/predicates"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/predicates/clusterrole"
@@ -173,10 +173,13 @@ func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.
 		WithAction(deploy.NewAction(
 			deploy.WithCache(),
 		)).
+		WithAction(deployments.NewAction()).
 		WithAction(setStatusFields).
-		WithAction(updatestatus.NewAction()).
 		// must be the final action
 		WithAction(gc.NewAction()).
+		// declares the list of additional, controller specific conditions that are
+		// contributing to the controller readiness status
+		WithConditions(conditionTypes...).
 		Build(ctx)
 
 	return err

--- a/controllers/components/kserve/kserve_controller_actions.go
+++ b/controllers/components/kserve/kserve_controller_actions.go
@@ -54,7 +54,7 @@ func checkPreConditions(ctx context.Context, rr *odhtypes.ReconciliationRequest)
 
 	if rr.DSCI.Spec.ServiceMesh == nil || rr.DSCI.Spec.ServiceMesh.ManagementState != operatorv1.Managed {
 		rr.Conditions.MarkFalse(
-			status.ConditionServerlessAvailable,
+			status.ConditionServiceMeshAvailable,
 			conditions.WithObservedGeneration(rr.Instance.GetGeneration()),
 			conditions.WithReason(status.ServiceMeshNotConfiguredReason),
 			conditions.WithMessage(status.ServiceMeshNotConfiguredMessage),

--- a/controllers/components/kserve/kserve_support.go
+++ b/controllers/components/kserve/kserve_support.go
@@ -8,6 +8,7 @@ import (
 	"path"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -153,7 +154,11 @@ func removeServerlessFeatures(ctx context.Context, cli client.Client, k *compone
 
 func getDefaultDeploymentMode(ctx context.Context, cli client.Client, dscispec *dsciv1.DSCInitializationSpec) (string, error) {
 	kserveConfigMap := corev1.ConfigMap{}
-	if err := cli.Get(ctx, client.ObjectKey{Name: kserveConfigMapName, Namespace: dscispec.ApplicationsNamespace}, &kserveConfigMap); err != nil {
+	err := cli.Get(ctx, client.ObjectKey{Name: kserveConfigMapName, Namespace: dscispec.ApplicationsNamespace}, &kserveConfigMap)
+	if errors.IsNotFound(err) {
+		return "", nil
+	}
+	if err != nil {
 		return "", err
 	}
 

--- a/controllers/components/kueue/kueue_controller_actions.go
+++ b/controllers/components/kueue/kueue_controller_actions.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	MultiKueueCRDMessage = "Kueue CRDs MultiKueueConfig v1alpha1 and/or MultiKueueCluster v1Alpha1 exist, please remove them to proceed"
+	MultiKueueCRDMessage = "Kueue CRDs MultiKueueConfig v1alpha1 and/or MultiKueueCluster v1alpha1 exist, please remove them to proceed"
 )
 
 func checkPreConditions(ctx context.Context, rr *odhtypes.ReconciliationRequest) error {

--- a/controllers/components/kueue/kueue_controller_actions.go
+++ b/controllers/components/kueue/kueue_controller_actions.go
@@ -4,44 +4,35 @@ import (
 	"context"
 	"fmt"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	"github.com/opendatahub-io/opendatahub-operator/v2/apis/common"
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/apis/components/v1alpha1"
-	"github.com/opendatahub-io/opendatahub-operator/v2/controllers/status"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
 	odherrors "github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/errors"
-	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/conditions"
 	odhtypes "github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
 	odhdeploy "github.com/opendatahub-io/opendatahub-operator/v2/pkg/deploy"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/metadata/annotations"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/resources"
 )
 
+const (
+	MultiKueueCRDMessage = "Kueue CRDs MultiKueueConfig v1alpha1 and/or MultiKueueCluster v1Alpha1 exist, please remove them to proceed"
+)
+
 func checkPreConditions(ctx context.Context, rr *odhtypes.ReconciliationRequest) error {
-	k, ok := rr.Instance.(*componentApi.Kueue)
-	if !ok {
-		return fmt.Errorf("resource instance %v is not a componentApi.Kueue)", rr.Instance)
+	rConfig, err := cluster.HasCRD(ctx, rr.Client, gvk.MultiKueueConfigV1Alpha1)
+	if err != nil {
+		return odherrors.NewStopError("failed to check %s CRDs version: %w", gvk.MultiKueueConfigV1Alpha1, err)
 	}
 
-	rConfig, eConfig := cluster.HasCRDWithVersion(ctx, rr.Client, gvk.MultiKueueConfigV1Alpha1.GroupKind(), gvk.MultiKueueConfigV1Alpha1.Version)
-	rCluster, eCluster := cluster.HasCRDWithVersion(ctx, rr.Client, gvk.MultikueueClusterV1Alpha1.GroupKind(), gvk.MultikueueClusterV1Alpha1.Version)
-	if eConfig != nil || eCluster != nil {
-		return odherrors.NewStopError("failed to check CRDs version: %v, %v", eConfig, eCluster)
+	rCluster, err := cluster.HasCRD(ctx, rr.Client, gvk.MultikueueClusterV1Alpha1)
+	if err != nil {
+		return odherrors.NewStopError("failed to check %s CRDs version: %w", gvk.MultikueueClusterV1Alpha1, err)
 	}
+
 	if rConfig || rCluster {
-		s := k.GetStatus()
-		s.Phase = status.PhaseNotReady
-		conditions.SetStatusCondition(k, common.Condition{
-			Type:               status.ConditionTypeReady,
-			Status:             metav1.ConditionFalse,
-			Reason:             status.MultiKueueCRDReason,
-			Message:            status.MultiKueueCRDMessage,
-			ObservedGeneration: s.ObservedGeneration,
-		})
-		return odherrors.NewStopError(status.MultiKueueCRDMessage)
+		return odherrors.NewStopError(MultiKueueCRDMessage)
 	}
+
 	return nil
 }
 

--- a/controllers/components/kueue/kueue_support.go
+++ b/controllers/components/kueue/kueue_support.go
@@ -1,8 +1,6 @@
 package kueue
 
 import (
-	conditionsv1 "github.com/openshift/custom-resource-status/conditions/v1"
-
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/apis/components/v1alpha1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/controllers/status"
 	odhtypes "github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
@@ -12,7 +10,7 @@ import (
 const (
 	ComponentName = componentApi.KueueComponentName
 
-	ReadyConditionType = conditionsv1.ConditionType(componentApi.KueueKind + status.ReadySuffix)
+	ReadyConditionType = componentApi.KueueKind + status.ReadySuffix
 
 	// LegacyComponentName is the name of the component that is assigned to deployments
 	// via Kustomize. Since a deployment selector is immutable, we can't upgrade existing
@@ -23,6 +21,10 @@ const (
 var (
 	imageParamMap = map[string]string{
 		"odh-kueue-controller-image": "RELATED_IMAGE_ODH_KUEUE_CONTROLLER_IMAGE",
+	}
+
+	conditionTypes = []string{
+		status.ConditionDeploymentsAvailable,
 	}
 )
 

--- a/controllers/components/modelcontroller/modelcontroller_support.go
+++ b/controllers/components/modelcontroller/modelcontroller_support.go
@@ -1,8 +1,6 @@
 package modelcontroller
 
 import (
-	conditionsv1 "github.com/openshift/custom-resource-status/conditions/v1"
-
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/apis/components/v1alpha1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/controllers/status"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
@@ -12,7 +10,7 @@ import (
 const (
 	ComponentName = componentApi.ModelControllerComponentName
 
-	ReadyConditionType = conditionsv1.ConditionType(componentApi.ModelControllerKind + status.ReadySuffix)
+	ReadyConditionType = componentApi.ModelControllerKind + status.ReadySuffix
 
 	// LegacyComponentName is the name of the component that is assigned to deployments
 	// via Kustomize. Since a deployment selector is immutable, we can't upgrade existing
@@ -23,6 +21,10 @@ const (
 var (
 	imageParamMap = map[string]string{
 		"odh-model-controller": "RELATED_IMAGE_ODH_MODEL_CONTROLLER_IMAGE",
+	}
+
+	conditionTypes = []string{
+		status.ConditionDeploymentsAvailable,
 	}
 )
 

--- a/controllers/components/modelmeshserving/modelmeshserving_controller.go
+++ b/controllers/components/modelmeshserving/modelmeshserving_controller.go
@@ -34,8 +34,8 @@ import (
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/deploy"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/gc"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/render/kustomize"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/status/deployments"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/status/releases"
-	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/updatestatus"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/handlers"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/predicates/clusterrole"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/predicates/component"
@@ -83,7 +83,6 @@ func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.
 				},
 			)),
 		).
-		// Add ModelMeshServing specific actions
 		WithAction(initialize).
 		WithAction(devFlags).
 		WithAction(releases.NewAction()).
@@ -95,8 +94,12 @@ func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.
 		WithAction(deploy.NewAction(
 			deploy.WithCache(),
 		)).
-		WithAction(updatestatus.NewAction()).
+		WithAction(deployments.NewAction()).
+		// must be the final action
 		WithAction(gc.NewAction()).
+		// declares the list of additional, controller specific conditions that are
+		// contributing to the controller readiness status
+		WithConditions(conditionTypes...).
 		Build(ctx) // include GenerationChangedPredicate no need set in each Owns() above
 
 	if err != nil {

--- a/controllers/components/modelmeshserving/modelmeshserving_support.go
+++ b/controllers/components/modelmeshserving/modelmeshserving_support.go
@@ -1,8 +1,6 @@
 package modelmeshserving
 
 import (
-	conditionsv1 "github.com/openshift/custom-resource-status/conditions/v1"
-
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/apis/components/v1alpha1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/controllers/status"
 	odhtypes "github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
@@ -12,7 +10,7 @@ import (
 const (
 	ComponentName = componentApi.ModelMeshServingComponentName
 
-	ReadyConditionType = conditionsv1.ConditionType(componentApi.ModelMeshServingKind + status.ReadySuffix)
+	ReadyConditionType = componentApi.ModelMeshServingKind + status.ReadySuffix
 
 	// LegacyComponentName is the name of the component that is assigned to deployments
 	// via Kustomize. Since a deployment selector is immutable, we can't upgrade existing
@@ -26,6 +24,10 @@ var (
 		"odh-modelmesh-runtime-adapter": "RELATED_IMAGE_ODH_MODELMESH_RUNTIME_ADAPTER_IMAGE",
 		"odh-modelmesh":                 "RELATED_IMAGE_ODH_MODELMESH_IMAGE",
 		"odh-modelmesh-controller":      "RELATED_IMAGE_ODH_MODELMESH_CONTROLLER_IMAGE",
+	}
+
+	conditionTypes = []string{
+		status.ConditionDeploymentsAvailable,
 	}
 )
 

--- a/controllers/components/modelregistry/modelregistry_controller.go
+++ b/controllers/components/modelregistry/modelregistry_controller.go
@@ -34,8 +34,8 @@ import (
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/gc"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/render/kustomize"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/render/template"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/status/deployments"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/status/releases"
-	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/updatestatus"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/handlers"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/predicates/component"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/predicates/generation"
@@ -76,7 +76,6 @@ func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.
 		// namespaces that may not be known when the controller is started, hence
 		// it should be watched dynamically
 		WatchesGVK(gvk.ServiceMeshMember, reconciler.Dynamic()).
-		// actions
 		WithAction(checkPreConditions).
 		WithAction(initialize).
 		WithAction(releases.NewAction()).
@@ -92,12 +91,15 @@ func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.
 		WithAction(deploy.NewAction(
 			deploy.WithCache(),
 		)).
-		WithAction(updatestatus.NewAction()).
+		WithAction(deployments.NewAction()).
 		WithAction(updateStatus).
 		// must be the final action
 		WithAction(gc.NewAction(
 			gc.WithUnremovables(gvk.ServiceMeshMember),
 		)).
+		// declares the list of additional, controller specific conditions that are
+		// contributing to the controller readiness status
+		WithConditions(conditionTypes...).
 		Build(ctx)
 
 	if err != nil {

--- a/controllers/components/modelregistry/modelregistry_controller_actions.go
+++ b/controllers/components/modelregistry/modelregistry_controller_actions.go
@@ -7,13 +7,12 @@ import (
 
 	operatorv1 "github.com/openshift/api/operator/v1"
 	corev1 "k8s.io/api/core/v1"
+	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/opendatahub-io/opendatahub-operator/v2/apis/common"
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/apis/components/v1alpha1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/controllers/status"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
-	odherrors "github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/errors"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/conditions"
 	odhtypes "github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
 	odhdeploy "github.com/opendatahub-io/opendatahub-operator/v2/pkg/deploy"
@@ -21,28 +20,36 @@ import (
 	_ "embed"
 )
 
-func checkPreConditions(_ context.Context, rr *odhtypes.ReconciliationRequest) error {
-	mr, ok := rr.Instance.(*componentApi.ModelRegistry)
-	if !ok {
-		return fmt.Errorf("resource instance %v is not a componentApi.ModelRegistry", rr.Instance)
+func checkPreConditions(ctx context.Context, rr *odhtypes.ReconciliationRequest) error {
+	rr.Conditions.MarkTrue(status.ConditionServerlessAvailable)
+
+	if rr.DSCI.Spec.ServiceMesh == nil || rr.DSCI.Spec.ServiceMesh.ManagementState != operatorv1.Managed {
+		rr.Conditions.MarkFalse(
+			status.ConditionServerlessAvailable,
+			conditions.WithObservedGeneration(rr.Instance.GetGeneration()),
+			conditions.WithReason(status.ServiceMeshNotConfiguredReason),
+			conditions.WithMessage(status.ServiceMeshNotConfiguredMessage),
+		)
+
+		return ErrServiceMeshNotConfigured
 	}
 
-	if rr.DSCI.Spec.ServiceMesh != nil && rr.DSCI.Spec.ServiceMesh.ManagementState == operatorv1.Managed {
-		return nil
+	_, err := cluster.GetCRD(ctx, rr.Client, ServiceMeshMemberCRD)
+	switch {
+	case k8serr.IsNotFound(err):
+		rr.Conditions.MarkFalse(
+			status.ConditionServerlessAvailable,
+			conditions.WithObservedGeneration(rr.Instance.GetGeneration()),
+			conditions.WithReason(status.ServiceMeshNotConfiguredReason),
+			conditions.WithMessage(ServiceMeshMemberAPINotFound),
+		)
+
+		return ErrServiceMeshMemberAPINotFound
+	case err != nil:
+		return err
 	}
 
-	s := mr.GetStatus()
-	s.Phase = "NotReady"
-
-	conditions.SetStatusCondition(mr, common.Condition{
-		Type:               status.ConditionTypeReady,
-		Status:             metav1.ConditionFalse,
-		Reason:             status.ServiceMeshNotConfiguredReason,
-		Message:            status.ServiceMeshNotConfiguredMessage,
-		ObservedGeneration: s.ObservedGeneration,
-	})
-
-	return odherrors.NewStopError(status.ServiceMeshNotConfiguredMessage)
+	return nil
 }
 
 func initialize(ctx context.Context, rr *odhtypes.ReconciliationRequest) error {
@@ -94,7 +101,6 @@ func configureDependencies(ctx context.Context, rr *odhtypes.ReconciliationReque
 	}
 
 	// Namespace
-
 	if err := rr.AddResources(
 		&corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
@@ -102,7 +108,7 @@ func configureDependencies(ctx context.Context, rr *odhtypes.ReconciliationReque
 			},
 		},
 	); err != nil {
-		return fmt.Errorf("failed to add namespace %s to manifests", mr.Spec.RegistriesNamespace)
+		return fmt.Errorf("failed to add namespace %s to manifests: %w", mr.Spec.RegistriesNamespace, err)
 	}
 
 	// Secret

--- a/controllers/components/modelregistry/modelregistry_controller_actions.go
+++ b/controllers/components/modelregistry/modelregistry_controller_actions.go
@@ -38,7 +38,7 @@ func checkPreConditions(ctx context.Context, rr *odhtypes.ReconciliationRequest)
 	switch {
 	case k8serr.IsNotFound(err):
 		rr.Conditions.MarkFalse(
-			status.ConditionServerlessAvailable,
+			status.ConditionServiceMeshAvailable,
 			conditions.WithObservedGeneration(rr.Instance.GetGeneration()),
 			conditions.WithReason(status.ServiceMeshNotConfiguredReason),
 			conditions.WithMessage(ServiceMeshMemberAPINotFound),

--- a/controllers/components/modelregistry/modelregistry_controller_actions.go
+++ b/controllers/components/modelregistry/modelregistry_controller_actions.go
@@ -21,7 +21,7 @@ import (
 )
 
 func checkPreConditions(ctx context.Context, rr *odhtypes.ReconciliationRequest) error {
-	rr.Conditions.MarkTrue(status.ConditionServerlessAvailable)
+	rr.Conditions.MarkTrue(status.ConditionServiceMeshAvailable)
 
 	if rr.DSCI.Spec.ServiceMesh == nil || rr.DSCI.Spec.ServiceMesh.ManagementState != operatorv1.Managed {
 		rr.Conditions.MarkFalse(

--- a/controllers/components/modelregistry/modelregistry_controller_actions.go
+++ b/controllers/components/modelregistry/modelregistry_controller_actions.go
@@ -25,7 +25,7 @@ func checkPreConditions(ctx context.Context, rr *odhtypes.ReconciliationRequest)
 
 	if rr.DSCI.Spec.ServiceMesh == nil || rr.DSCI.Spec.ServiceMesh.ManagementState != operatorv1.Managed {
 		rr.Conditions.MarkFalse(
-			status.ConditionServerlessAvailable,
+			status.ConditionServiceMeshAvailable,
 			conditions.WithObservedGeneration(rr.Instance.GetGeneration()),
 			conditions.WithReason(status.ServiceMeshNotConfiguredReason),
 			conditions.WithMessage(status.ServiceMeshNotConfiguredMessage),

--- a/controllers/components/modelregistry/modelregistry_support.go
+++ b/controllers/components/modelregistry/modelregistry_support.go
@@ -4,10 +4,9 @@ import (
 	"embed"
 	"path"
 
-	conditionsv1 "github.com/openshift/custom-resource-status/conditions/v1"
-
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/apis/components/v1alpha1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/controllers/status"
+	odherrors "github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/errors"
 	odhtypes "github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/deploy"
 )
@@ -15,17 +14,23 @@ import (
 const (
 	ComponentName = componentApi.ModelRegistryComponentName
 
-	ReadyConditionType = conditionsv1.ConditionType(componentApi.ModelRegistryKind + status.ReadySuffix)
+	ReadyConditionType = componentApi.ModelRegistryKind + status.ReadySuffix
 
 	DefaultModelRegistriesNamespace = "odh-model-registries"
 	DefaultModelRegistryCert        = "default-modelregistry-cert"
 	BaseManifestsSourcePath         = "overlays/odh"
 	ServiceMeshMemberTemplate       = "resources/servicemesh-member.tmpl.yaml"
-
+	ServiceMeshMemberCRD            = "servicemeshmembers.maistra.io"
+	ServiceMeshMemberAPINotFound    = "ServiceMeshMember API not found"
 	// LegacyComponentName is the name of the component that is assigned to deployments
 	// via Kustomize. Since a deployment selector is immutable, we can't upgrade existing
 	// deployment to the new component name, so keep it around till we figure out a solution.
 	LegacyComponentName = "model-registry-operator"
+)
+
+var (
+	ErrServiceMeshNotConfigured     = odherrors.NewStopError(status.ServiceMeshNotConfiguredMessage)
+	ErrServiceMeshMemberAPINotFound = odherrors.NewStopError(ServiceMeshMemberAPINotFound)
 )
 
 var (
@@ -37,6 +42,11 @@ var (
 
 	extraParamsMap = map[string]string{
 		"DEFAULT_CERT": DefaultModelRegistryCert,
+	}
+
+	conditionTypes = []string{
+		status.ConditionServerlessAvailable,
+		status.ConditionDeploymentsAvailable,
 	}
 )
 

--- a/controllers/components/modelregistry/modelregistry_support.go
+++ b/controllers/components/modelregistry/modelregistry_support.go
@@ -45,7 +45,7 @@ var (
 	}
 
 	conditionTypes = []string{
-		status.ConditionServerlessAvailable,
+		status.ConditionServiceMeshAvailable,
 		status.ConditionDeploymentsAvailable,
 	}
 )

--- a/controllers/components/ray/ray_controller.go
+++ b/controllers/components/ray/ray_controller.go
@@ -30,8 +30,8 @@ import (
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/deploy"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/gc"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/render/kustomize"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/status/deployments"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/status/releases"
-	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/updatestatus"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/handlers"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/predicates/component"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/predicates/resources"
@@ -58,7 +58,6 @@ func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.
 			reconciler.WithPredicates(
 				component.ForLabel(labels.ODH.Component(LegacyComponentName), labels.True)),
 		).
-		// Add Ray-specific actions
 		WithAction(initialize).
 		WithAction(devFlags).
 		WithAction(releases.NewAction()).
@@ -70,9 +69,12 @@ func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.
 		WithAction(deploy.NewAction(
 			deploy.WithCache(),
 		)).
-		WithAction(updatestatus.NewAction()).
+		WithAction(deployments.NewAction()).
 		// must be the final action
 		WithAction(gc.NewAction()).
+		// declares the list of additional, controller specific conditions that are
+		// contributing to the controller readiness status
+		WithConditions(conditionTypes...).
 		Build(ctx)
 
 	if err != nil {

--- a/controllers/components/ray/ray_support.go
+++ b/controllers/components/ray/ray_support.go
@@ -1,8 +1,6 @@
 package ray
 
 import (
-	conditionsv1 "github.com/openshift/custom-resource-status/conditions/v1"
-
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/apis/components/v1alpha1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/controllers/status"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
@@ -12,7 +10,7 @@ import (
 const (
 	ComponentName = componentApi.RayComponentName
 
-	ReadyConditionType = conditionsv1.ConditionType(componentApi.RayKind + status.ReadySuffix)
+	ReadyConditionType = componentApi.RayKind + status.ReadySuffix
 
 	// LegacyComponentName is the name of the component that is assigned to deployments
 	// via Kustomize. Since a deployment selector is immutable, we can't upgrade existing
@@ -23,6 +21,10 @@ const (
 var (
 	imageParamMap = map[string]string{
 		"odh-kuberay-operator-controller-image": "RELATED_IMAGE_ODH_KUBERAY_OPERATOR_CONTROLLER_IMAGE",
+	}
+
+	conditionTypes = []string{
+		status.ConditionDeploymentsAvailable,
 	}
 )
 

--- a/controllers/components/trainingoperator/trainingoperator_controller.go
+++ b/controllers/components/trainingoperator/trainingoperator_controller.go
@@ -30,8 +30,8 @@ import (
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/deploy"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/gc"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/render/kustomize"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/status/deployments"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/status/releases"
-	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/updatestatus"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/handlers"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/predicates/component"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/predicates/resources"
@@ -55,7 +55,6 @@ func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.
 			reconciler.WithPredicates(
 				component.ForLabel(labels.ODH.Component(LegacyComponentName), labels.True)),
 		).
-		// Add TrainingOperator-specific actions
 		WithAction(initialize).
 		WithAction(devFlags).
 		WithAction(releases.NewAction()).
@@ -67,9 +66,12 @@ func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.
 		WithAction(deploy.NewAction(
 			deploy.WithCache(),
 		)).
-		WithAction(updatestatus.NewAction()).
+		WithAction(deployments.NewAction()).
 		// must be the final action
 		WithAction(gc.NewAction()).
+		// declares the list of additional, controller specific conditions that are
+		// contributing to the controller readiness status
+		WithConditions(conditionTypes...).
 		Build(ctx)
 
 	if err != nil {

--- a/controllers/components/trainingoperator/trainingoperator_support.go
+++ b/controllers/components/trainingoperator/trainingoperator_support.go
@@ -1,8 +1,6 @@
 package trainingoperator
 
 import (
-	conditionsv1 "github.com/openshift/custom-resource-status/conditions/v1"
-
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/apis/components/v1alpha1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/controllers/status"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
@@ -12,7 +10,7 @@ import (
 const (
 	ComponentName = componentApi.TrainingOperatorComponentName
 
-	ReadyConditionType = conditionsv1.ConditionType(componentApi.TrainingOperatorKind + status.ReadySuffix)
+	ReadyConditionType = componentApi.TrainingOperatorKind + status.ReadySuffix
 
 	// LegacyComponentName is the name of the component that is assigned to deployments
 	// via Kustomize. Since a deployment selector is immutable, we can't upgrade existing
@@ -23,6 +21,10 @@ const (
 var (
 	imageParamMap = map[string]string{
 		"odh-training-operator-controller-image": "RELATED_IMAGE_ODH_TRAINING_OPERATOR_IMAGE",
+	}
+
+	conditionTypes = []string{
+		status.ConditionDeploymentsAvailable,
 	}
 )
 

--- a/controllers/components/trustyai/trustyai_controller.go
+++ b/controllers/components/trustyai/trustyai_controller.go
@@ -31,8 +31,8 @@ import (
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/deploy"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/gc"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/render/kustomize"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/status/deployments"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/status/releases"
-	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/updatestatus"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/handlers"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/predicates/component"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/predicates/resources"
@@ -65,8 +65,7 @@ func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.
 				},
 			)),
 		).
-		// Add TrustyAI-specific actions
-		WithAction(checkPreConditions). // check if CRD isvc is there
+		WithAction(checkPreConditions).
 		WithAction(initialize).
 		WithAction(devFlags).
 		WithAction(releases.NewAction()).
@@ -78,9 +77,12 @@ func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.
 		WithAction(deploy.NewAction(
 			deploy.WithCache(),
 		)).
-		WithAction(updatestatus.NewAction()).
+		WithAction(deployments.NewAction()).
 		// must be the final action
 		WithAction(gc.NewAction()).
+		// declares the list of additional, controller specific conditions that are
+		// contributing to the controller readiness status
+		WithConditions(conditionTypes...).
 		Build(ctx)
 
 	if err != nil {

--- a/controllers/components/trustyai/trustyai_controller_actions.go
+++ b/controllers/components/trustyai/trustyai_controller_actions.go
@@ -20,37 +20,25 @@ import (
 	"context"
 	"fmt"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	"github.com/opendatahub-io/opendatahub-operator/v2/apis/common"
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/apis/components/v1alpha1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/controllers/status"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
 	odherrors "github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/errors"
-	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/conditions"
 	odhtypes "github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
 	odhdeploy "github.com/opendatahub-io/opendatahub-operator/v2/pkg/deploy"
 )
 
 func checkPreConditions(ctx context.Context, rr *odhtypes.ReconciliationRequest) error {
-	t, ok := rr.Instance.(*componentApi.TrustyAI)
-	if !ok {
-		return fmt.Errorf("resource instance %v is not a componentApi.TrustyAI)", rr.Instance)
+	isvc, err := cluster.HasCRD(ctx, rr.Client, gvk.InferenceServices)
+	if err != nil {
+		return odherrors.NewStopError("failed to check %s CRDs version: %w", gvk.InferenceServices, err)
 	}
 
-	if err := cluster.CustomResourceDefinitionExists(ctx, rr.Client, gvk.InferenceServices.GroupKind()); err != nil {
-		s := t.GetStatus()
-		s.Phase = status.PhaseNotReady
-		conditions.SetStatusCondition(t, common.Condition{
-			Type:               status.ConditionTypeReady,
-			Status:             metav1.ConditionFalse,
-			Reason:             status.ISVCMissingCRDReason,
-			Message:            status.ISVCMissingCRDMessage,
-			ObservedGeneration: s.ObservedGeneration,
-		})
-		return odherrors.NewStopError("failed to find InferenceService CRD: %v", err)
+	if !isvc {
+		return odherrors.NewStopError(status.ISVCMissingCRDMessage)
 	}
+
 	return nil
 }
 

--- a/controllers/components/trustyai/trustyai_support.go
+++ b/controllers/components/trustyai/trustyai_support.go
@@ -1,8 +1,6 @@
 package trustyai
 
 import (
-	conditionsv1 "github.com/openshift/custom-resource-status/conditions/v1"
-
 	"github.com/opendatahub-io/opendatahub-operator/v2/apis/common"
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/apis/components/v1alpha1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/controllers/status"
@@ -14,7 +12,7 @@ import (
 const (
 	ComponentName = componentApi.TrustyAIComponentName
 
-	ReadyConditionType = conditionsv1.ConditionType(componentApi.TrustyAIKind + status.ReadySuffix)
+	ReadyConditionType = componentApi.TrustyAIKind + status.ReadySuffix
 
 	// LegacyComponentName is the name of the component that is assigned to deployments
 	// via Kustomize. Since a deployment selector is immutable, we can't upgrade existing
@@ -33,6 +31,10 @@ var (
 		cluster.ManagedRhoai:     "/overlays/rhoai",
 		cluster.OpenDataHub:      "/overlays/odh",
 		cluster.Unknown:          "/overlays/odh",
+	}
+
+	conditionTypes = []string{
+		status.ConditionDeploymentsAvailable,
 	}
 )
 

--- a/controllers/components/workbenches/workbenches_controller.go
+++ b/controllers/components/workbenches/workbenches_controller.go
@@ -31,8 +31,8 @@ import (
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/deploy"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/gc"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/render/kustomize"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/status/deployments"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/status/releases"
-	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/updatestatus"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/handlers"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/predicates/component"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/predicates/resources"
@@ -75,9 +75,12 @@ func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.
 		WithAction(deploy.NewAction(
 			deploy.WithCache(),
 		)).
-		WithAction(updatestatus.NewAction()).
+		WithAction(deployments.NewAction()).
 		// must be the final action
 		WithAction(gc.NewAction()).
+		// declares the list of additional, controller specific conditions that are
+		// contributing to the controller readiness status
+		WithConditions(conditionTypes...).
 		Build(ctx)
 
 	if err != nil {

--- a/controllers/components/workbenches/workbenches_support.go
+++ b/controllers/components/workbenches/workbenches_support.go
@@ -3,8 +3,6 @@ package workbenches
 import (
 	"path"
 
-	conditionsv1 "github.com/openshift/custom-resource-status/conditions/v1"
-
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/apis/components/v1alpha1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/controllers/status"
 	odhtypes "github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
@@ -14,7 +12,7 @@ import (
 const (
 	ComponentName = componentApi.WorkbenchesComponentName
 
-	ReadyConditionType = conditionsv1.ConditionType(componentApi.WorkbenchesKind + status.ReadySuffix)
+	ReadyConditionType = componentApi.WorkbenchesKind + status.ReadySuffix
 
 	notebooksPath                    = "notebooks"
 	notebookImagesManifestSourcePath = "overlays/additional"
@@ -35,6 +33,12 @@ var (
 	notebookControllerContextDir   = path.Join(ComponentName, notebookControllerPath)
 	kfNotebookControllerContextDir = path.Join(ComponentName, kfNotebookControllerPath)
 	notebookContextDir             = path.Join(ComponentName, notebooksPath)
+)
+
+var (
+	conditionTypes = []string{
+		status.ConditionDeploymentsAvailable,
+	}
 )
 
 // manifests for nbc in ODH and RHOAI + downstream use it for imageparams.

--- a/controllers/services/auth/auth_controller.go
+++ b/controllers/services/auth/auth_controller.go
@@ -46,7 +46,6 @@ func NewServiceReconciler(ctx context.Context, mgr ctrl.Manager) error {
 		WithAction(deploy.NewAction(
 			deploy.WithCache(),
 		)).
-		WithAction(setStatus).
 		Build(ctx)
 
 	if err != nil {

--- a/controllers/services/auth/auth_controller_actions.go
+++ b/controllers/services/auth/auth_controller_actions.go
@@ -143,14 +143,3 @@ func managePermissions(ctx context.Context, rr *odhtypes.ReconciliationRequest) 
 
 	return nil
 }
-
-func setStatus(ctx context.Context, rr *odhtypes.ReconciliationRequest) error {
-	ai, ok := rr.Instance.(*serviceApi.Auth)
-	if !ok {
-		return errors.New("instance is not of type *services.Auth")
-	}
-
-	ai.Status.Phase = "Ready"
-	ai.Status.ObservedGeneration = ai.GetObjectMeta().GetGeneration()
-	return nil
-}

--- a/controllers/services/monitoring/monitoring.go
+++ b/controllers/services/monitoring/monitoring.go
@@ -139,6 +139,6 @@ func isComponentReady(ctx context.Context, cli *odhcli.Client, obj common.Platfo
 	case err != nil:
 		return false, fmt.Errorf("failed to get component instance: %w", err)
 	default:
-		return conditions.IsStatusConditionTrue(obj, status.ConditionTypeReady), nil
+		return conditions.IsStatusConditionTrue(obj.GetStatus(), status.ConditionTypeReady), nil
 	}
 }

--- a/controllers/services/monitoring/monitoring_controller.go
+++ b/controllers/services/monitoring/monitoring_controller.go
@@ -58,7 +58,6 @@ func NewServiceReconciler(ctx context.Context, mgr ctrl.Manager) error {
 				return m.Spec.Namespace, nil
 			}),
 		)).
-		WithAction(deployments.NewAction()).
 		WithAction(initialize).
 		WithAction(updatePrometheusConfigMap).
 		WithAction(deploy.NewAction(

--- a/controllers/services/monitoring/monitoring_controller.go
+++ b/controllers/services/monitoring/monitoring_controller.go
@@ -18,6 +18,7 @@ package monitoring
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -25,9 +26,11 @@ import (
 	dscv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/datasciencecluster/v1"
 	serviceApi "github.com/opendatahub-io/opendatahub-operator/v2/apis/services/v1alpha1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/deploy"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/status/deployments"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/handlers"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/predicates/resources"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/reconciler"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
 )
 
 // NewServiceReconciler creates a ServiceReconciler for the Monitoring API.
@@ -45,12 +48,22 @@ func NewServiceReconciler(ctx context.Context, mgr ctrl.Manager) error {
 		Watches(&dscv1.DataScienceCluster{}, reconciler.WithEventHandler(handlers.ToNamed(serviceApi.MonitoringInstanceName)),
 			reconciler.WithPredicates(resources.DSCComponentUpdatePredicate)).
 		// actions
+		WithAction(deployments.NewAction(
+			deployments.InNamespaceFn(func(_ context.Context, rr *types.ReconciliationRequest) (string, error) {
+				m, ok := rr.Instance.(*serviceApi.Monitoring)
+				if !ok {
+					return "", errors.New("instance is not of type *services.Monitoring")
+				}
+
+				return m.Spec.Namespace, nil
+			}),
+		)).
+		WithAction(deployments.NewAction()).
 		WithAction(initialize).
 		WithAction(updatePrometheusConfigMap).
 		WithAction(deploy.NewAction(
 			deploy.WithCache(),
 		)).
-		WithAction(updateStatus).
 		Build(ctx)
 
 	if err != nil {

--- a/controllers/services/monitoring/monitoring_controller_actions.go
+++ b/controllers/services/monitoring/monitoring_controller_actions.go
@@ -2,21 +2,13 @@ package monitoring
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	operatorv1 "github.com/openshift/api/operator/v1"
-	appsv1 "k8s.io/api/apps/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/opendatahub-io/opendatahub-operator/v2/apis/common"
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/apis/components/v1alpha1"
-	serviceApi "github.com/opendatahub-io/opendatahub-operator/v2/apis/services/v1alpha1"
-	"github.com/opendatahub-io/opendatahub-operator/v2/controllers/status"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
 	cr "github.com/opendatahub-io/opendatahub-operator/v2/pkg/componentsregistry"
-	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/conditions"
 	odhtypes "github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
 	odhdeploy "github.com/opendatahub-io/opendatahub-operator/v2/pkg/deploy"
 )
@@ -79,54 +71,4 @@ func updatePrometheusConfigMap(ctx context.Context, rr *odhtypes.ReconciliationR
 			return fmt.Errorf("unsuported management state %s", ms)
 		}
 	})
-}
-
-func updateStatus(ctx context.Context, rr *odhtypes.ReconciliationRequest) error {
-	m, ok := rr.Instance.(*serviceApi.Monitoring)
-	if !ok {
-		return errors.New("instance is not of type *services.Monitoring")
-	}
-
-	// TODO: deprecate phase
-	// Cannot use status.PhaseNotReady as the value here is not the
-	// same as the constant ("Not Ready")
-	m.Status.Phase = "NotReady"
-
-	// condition
-	nc := common.Condition{
-		Type:    status.ConditionTypeReady,
-		Status:  metav1.ConditionFalse,
-		Reason:  "NotReady",
-		Message: "Prometheus deployment is not ready",
-	}
-
-	promDeployment := &appsv1.DeploymentList{}
-	err := rr.Client.List(
-		ctx,
-		promDeployment,
-		client.InNamespace(m.Spec.Namespace),
-	)
-	if err != nil {
-		return fmt.Errorf("error fetching promethus deployments: %w", err)
-	}
-
-	ready := 0
-	for _, deployment := range promDeployment.Items {
-		if deployment.Status.ReadyReplicas == deployment.Status.Replicas {
-			ready++
-		}
-	}
-
-	if len(promDeployment.Items) == ready {
-		// TODO: deprecate phase
-		m.Status.Phase = status.PhaseReady
-		// condition
-		nc.Status = metav1.ConditionTrue
-		nc.Reason = status.ReconcileCompleted
-		nc.Message = status.ReconcileCompletedMessage
-	}
-	conditions.SetStatusCondition(&m.Status, nc)
-	m.Status.ObservedGeneration = m.GetObjectMeta().GetGeneration()
-
-	return nil
 }

--- a/controllers/status/status.go
+++ b/controllers/status/status.go
@@ -74,6 +74,7 @@ const (
 	ConditionServiceMeshAvailable          = "ServiceMeshAvailable"
 	ConditionArgoWorkflowAvailable         = "ArgoWorkflowAvailable"
 	ConditionTypeComponentsReady           = "ComponentsReady"
+	ConditionServingAvailable              = "ServingAvailable"
 )
 
 const (

--- a/pkg/controller/actions/actions.go
+++ b/pkg/controller/actions/actions.go
@@ -18,6 +18,9 @@ const (
 
 type Fn func(ctx context.Context, rr *types.ReconciliationRequest) error
 
+// TODO replace with type alias in GO 1.24.
+type StringGetter func(context.Context, *types.ReconciliationRequest) (string, error)
+
 func (f Fn) String() string {
 	fn := runtime.FuncForPC(reflect.ValueOf(f).Pointer())
 	return fn.Name()

--- a/pkg/controller/actions/deploy/action_deploy.go
+++ b/pkg/controller/actions/deploy/action_deploy.go
@@ -118,6 +118,7 @@ func (a *Action) run(ctx context.Context, rr *odhTypes.ReconciliationRequest) er
 	}
 
 	controllerName := strings.ToLower(kind)
+	igvk := rr.Instance.GetObjectKind().GroupVersionKind()
 
 	for i := range rr.Resources {
 		res := rr.Resources[i]
@@ -132,9 +133,9 @@ func (a *Action) run(ctx context.Context, rr *odhTypes.ReconciliationRequest) er
 		case lookupErr != nil:
 			return fmt.Errorf("failed to lookup object %s/%s: %w", res.GetNamespace(), res.GetName(), lookupErr)
 		default:
-			// Remove the DSC and DSCI owner reference if set, This is required during the
+			// Remove the previous owner reference if set, This is required during the
 			// transition from the old to the new operator.
-			if err := resources.RemoveOwnerReferences(ctx, rr.Client, current, isLegacyOwnerRef); err != nil {
+			if err := resources.RemoveOwnerReferences(ctx, rr.Client, current, ownedTypeIsNot(&igvk)); err != nil {
 				return err
 			}
 

--- a/pkg/controller/actions/deploy/action_deploy_support.go
+++ b/pkg/controller/actions/deploy/action_deploy_support.go
@@ -2,6 +2,7 @@ package deploy
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
 )
@@ -14,5 +15,18 @@ func isLegacyOwnerRef(or metav1.OwnerReference) bool {
 		return true
 	default:
 		return false
+	}
+}
+
+func ownedTypeIsNot(ownerType *schema.GroupVersionKind) func(or metav1.OwnerReference) bool {
+	if ownerType == nil {
+		return func(or metav1.OwnerReference) bool {
+			return false
+		}
+	}
+
+	gv := ownerType.GroupVersion().String()
+	return func(or metav1.OwnerReference) bool {
+		return ownerType.Kind != or.Kind && gv != or.APIVersion
 	}
 }

--- a/pkg/controller/conditions/conditions.go
+++ b/pkg/controller/conditions/conditions.go
@@ -1,0 +1,345 @@
+// inspired by https://github.com/knative/pkg/blob/main/apis/condition_set.go
+
+package conditions
+
+import (
+	"cmp"
+	"fmt"
+	"slices"
+	"sort"
+	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/opendatahub-io/opendatahub-operator/v2/apis/common"
+)
+
+type Option func(*common.Condition)
+
+func WithReason(value string) Option {
+	return func(c *common.Condition) {
+		c.Reason = value
+	}
+}
+
+func WithMessage(msg string, opts ...any) Option {
+	value := msg
+	if len(opts) != 0 {
+		value = fmt.Sprintf(msg, opts...)
+	}
+
+	return func(c *common.Condition) {
+		c.Message = value
+	}
+}
+
+func WithObservedGeneration(value int64) Option {
+	return func(c *common.Condition) {
+		c.ObservedGeneration = value
+	}
+}
+
+func WithSeverity(value common.ConditionSeverity) Option {
+	return func(c *common.Condition) {
+		c.Severity = value
+	}
+}
+
+func WithError(err error) Option {
+	return func(c *common.Condition) {
+		c.Severity = common.ConditionSeverityError
+		c.Reason = common.ConditionReasonError
+		c.Message = err.Error()
+	}
+}
+
+type Manager struct {
+	happy      string
+	dependents []string
+	accessor   common.ConditionsAccessor
+}
+
+func NewManager(accessor common.ConditionsAccessor, happy string, dependents ...string) *Manager {
+	deps := make([]string, 0, len(dependents))
+	for _, d := range dependents {
+		if d == happy || slices.Contains(deps, d) {
+			continue
+		}
+		deps = append(deps, d)
+	}
+
+	m := Manager{
+		accessor:   accessor,
+		happy:      happy,
+		dependents: deps,
+	}
+
+	m.initializeConditions()
+
+	return &m
+}
+
+// initializeConditions ensures that the conditions for the manager and its dependents are properly
+// initialized. Specifically, it initializes the "happy" condition and sets the initial status for
+// each dependent condition.
+//
+// The method performs the following:
+//  1. Retrieves the "happy" condition using. If it does not exist, it creates a new one with
+//     `ConditionUnknown` status and sets it.
+//  2. Sets the status of each dependent condition based on the "happy" condition's status. If the
+//     "happy" condition's status is `True`, all dependent conditions are set to `True`, otherwise
+//     to `Unknown`.
+func (r *Manager) initializeConditions() {
+	happy := r.GetCondition(r.happy)
+	if happy == nil {
+		happy = &common.Condition{
+			Type:   r.happy,
+			Status: metav1.ConditionUnknown,
+		}
+		r.SetCondition(*happy)
+	}
+
+	status := metav1.ConditionUnknown
+	if happy.Status == metav1.ConditionTrue {
+		status = metav1.ConditionTrue
+	}
+
+	for _, t := range r.dependents {
+		if c := r.GetCondition(t); c != nil {
+			continue
+		}
+
+		r.SetCondition(common.Condition{
+			Type:   t,
+			Status: status,
+		})
+	}
+}
+
+func (r *Manager) IsHappy() bool {
+	if r.accessor == nil {
+		return false
+	}
+
+	return IsStatusConditionTrue(r.accessor, r.happy)
+}
+
+func (r *Manager) GetTopLevelCondition() *common.Condition {
+	return r.GetCondition(r.happy)
+}
+
+func (r *Manager) GetCondition(t string) *common.Condition {
+	return FindStatusCondition(r.accessor, t)
+}
+
+// SetCondition sets the given condition on the manager. It updates the list of conditions and
+// sorts them alphabetically. After updating, it recomputes the happiness state based on the
+// provided condition type.
+//
+// Parameters:
+//   - `cond`: The condition to set. The condition will be added or updated based on its type.
+func (r *Manager) SetCondition(cond common.Condition) {
+	if r.accessor == nil {
+		return
+	}
+
+	if !SetStatusCondition(r.accessor, cond) {
+		return
+	}
+
+	r.RecomputeHappiness(cond.Type)
+}
+
+// ClearCondition removes the specified condition type from the manager's list of conditions
+// and recomputes happiness.
+//
+// Parameters:
+//   - `t`: The type of the condition to remove.
+//
+// Returns:
+//   - `nil` if the condition was removed successfully or was not found.
+func (r *Manager) ClearCondition(t string) error {
+	if r.accessor == nil {
+		return nil
+	}
+
+	if !RemoveStatusCondition(r.accessor, t) {
+		return nil
+	}
+
+	r.RecomputeHappiness(t)
+
+	return nil
+}
+
+// Mark updates the status of a specified condition type and applies optional modifications.
+//
+// This method allows setting a condition to any of the possible statuses (`True`, `False`, or
+// `Unknown`) while also allowing additional options to modify the condition before it is stored.
+//
+// Parameters:
+//   - `t`: The type of the condition to update.
+//   - `status`: The new status of the condition (one of `metav1.ConditionTrue`,
+//     `metav1.ConditionFalse`, or `metav1.ConditionUnknown`).
+//   - `opts`: Variadic options that can modify attributes of the condition (e.g., reason,
+//     message, timestamp).
+//
+// Behavior:
+//  1. Creates a `common.Condition` with the specified type and status.
+//  2. Applies any provided options using `applyOpts(&c, opts...)`.
+//  3. Sets the condition using `r.SetCondition(c)`, which updates the condition list and
+//     recomputes happiness.
+func (r *Manager) Mark(t string, status metav1.ConditionStatus, opts ...Option) {
+	c := common.Condition{
+		Type:   t,
+		Status: status,
+	}
+
+	applyOpts(&c, opts...)
+
+	r.SetCondition(c)
+}
+
+func (r *Manager) MarkTrue(t string, opts ...Option) {
+	r.Mark(t, metav1.ConditionTrue, opts...)
+}
+
+func (r *Manager) MarkFalse(t string, opts ...Option) {
+	r.Mark(t, metav1.ConditionFalse, opts...)
+}
+
+func (r *Manager) MarkUnknown(t string, opts ...Option) {
+	r.Mark(t, metav1.ConditionUnknown, opts...)
+}
+
+func (r *Manager) MarkFrom(t string, in common.Condition) {
+	c := common.Condition{
+		Type:     t,
+		Status:   in.Status,
+		Reason:   in.Reason,
+		Message:  in.Message,
+		Severity: in.Severity,
+	}
+
+	r.SetCondition(c)
+}
+
+// RecomputeHappiness re-evaluates the happiness state of the manager based on the current set
+// of conditions.
+//
+// It checks if any dependent condition is unhappy (either `False` or `Unknown`). If found, the
+// "happy" condition is updated to reflect the first unhappy condition's status. If no unhappy
+// dependent conditions exist, it sets the "happy" condition to `True`.
+//
+// Parameters:
+//   - `t`: The type of the condition that may have triggered a recomputation of happiness.
+func (r *Manager) RecomputeHappiness(t string) {
+	if c := r.findUnhappyDependent(); c != nil {
+		r.SetCondition(common.Condition{
+			Type:    r.happy,
+			Status:  c.Status,
+			Reason:  c.Reason,
+			Message: c.Message,
+		})
+	} else if t != r.happy {
+		r.SetCondition(common.Condition{
+			Type:   r.happy,
+			Status: metav1.ConditionTrue,
+		})
+	}
+}
+
+// findUnhappyDependent identifies and returns the first dependent condition that is unhappy (i.e.,
+// False or Unknown).
+//
+// The method operates by filtering and sorting the current conditions, checking if they meet
+// the criteria for being unhappy:
+// - The condition must have a Severity level of "Error".
+// - The dependent condition is either `ConditionFalse` or `ConditionUnknown`.
+//
+// The function performs the following steps:
+//  1. It determines the number of dependents and retrieves the current conditions.
+//  2. It iterates through each condition, filtering out conditions that do not meet the criteria
+//     (e.g., those not related to the dependents or those without "Error" severity).
+//  3. It sorts the remaining conditions by the `LastTransitionTime` in descending order.
+//  4. It returns the first `ConditionFalse` or `ConditionUnknown` condition found, prioritizing
+//     the former.
+//
+// If no unhappy condition is found, the function returns nil.
+//
+// Returns:
+//   - A pointer to the first unhappy condition if found, otherwise nil.
+func (r *Manager) findUnhappyDependent() *common.Condition {
+	dn := len(r.dependents)
+
+	conditions := slices.Clone(r.accessor.GetConditions())
+	n := 0
+
+	for _, c := range conditions {
+		switch {
+		case dn == 0 && c.Type == r.happy:
+			break
+		case dn != 0 && !slices.Contains(r.dependents, c.Type):
+			break
+		case c.Severity != common.ConditionSeverityError:
+			break
+		default:
+			conditions[n] = c
+			n++
+		}
+	}
+
+	conditions = conditions[:n]
+
+	sort.Slice(conditions, func(i, j int) bool {
+		return conditions[i].LastTransitionTime.After(conditions[j].LastTransitionTime.Time)
+	})
+
+	for _, c := range conditions {
+		if c.Status == metav1.ConditionFalse {
+			ret := c
+			return &ret
+		}
+	}
+
+	for _, c := range conditions {
+		if c.Status == metav1.ConditionUnknown {
+			ret := c
+			return &ret
+		}
+	}
+
+	return nil
+}
+
+// Sort arranges the conditions retrieved from the accessor based on the following rules:
+// 1. `happy` condition is assigned the highest priority.
+// 2. `dependents` are prioritized in the order they are defined.
+// 3. Conditions with priority `0` (not explicitly listed) are sorted alphabetically.
+//
+// The sorting is stable, ensuring consistent ordering when conditions have the same
+// priority.
+func (r *Manager) Sort() {
+	conditions := r.accessor.GetConditions()
+	if len(conditions) <= 1 {
+		return
+	}
+
+	priorities := make(map[string]int)
+	dl := len(r.dependents)
+
+	for i, d := range r.dependents {
+		priorities[d] = dl - i
+	}
+
+	priorities[r.happy] = len(r.dependents) + 1
+
+	slices.SortStableFunc(conditions, func(a, b common.Condition) int {
+		ret := cmp.Compare(priorities[b.Type], priorities[a.Type])
+		if ret == 0 {
+			ret = strings.Compare(a.Type, b.Type)
+		}
+
+		return ret
+	})
+}

--- a/pkg/controller/conditions/conditions.go
+++ b/pkg/controller/conditions/conditions.go
@@ -84,7 +84,7 @@ func NewManager(accessor common.ConditionsAccessor, happy string, dependents ...
 // each dependent condition.
 //
 // The method performs the following:
-//  1. Retrieves the "happy" condition using. If it does not exist, it creates a new one with
+//  1. Retrieves the "happy" condition. If it does not exist, it creates a new one with
 //     `ConditionUnknown` status and sets it.
 //  2. Sets the status of each dependent condition based on the "happy" condition's status. If the
 //     "happy" condition's status is `True`, all dependent conditions are set to `True`, otherwise

--- a/pkg/controller/conditions/conditions_support.go
+++ b/pkg/controller/conditions/conditions_support.go
@@ -99,6 +99,12 @@ func IsStatusConditionPresentAndEqual(a common.ConditionsAccessor, conditionType
 	})
 }
 
+func applyOpts(c *common.Condition, opts ...Option) {
+	for _, o := range opts {
+		o(c)
+	}
+}
+
 func equals(c1 common.Condition, c2 common.Condition) bool {
 	return c1.Status == c2.Status &&
 		c1.Reason == c2.Reason &&

--- a/pkg/controller/conditions/conditions_support_test.go
+++ b/pkg/controller/conditions/conditions_support_test.go
@@ -11,18 +11,6 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-type fakeAccessor struct {
-	conditions []common.Condition
-}
-
-func (f *fakeAccessor) GetConditions() []common.Condition {
-	return f.conditions
-}
-
-func (f *fakeAccessor) SetConditions(values []common.Condition) {
-	f.conditions = values
-}
-
 func TestSetStatusCondition_LastTransitionTime(t *testing.T) {
 	a := fakeAccessor{}
 	a.conditions = make([]common.Condition, 0)

--- a/pkg/controller/conditions/conditions_test.go
+++ b/pkg/controller/conditions/conditions_test.go
@@ -1,0 +1,144 @@
+package conditions_test
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/opendatahub-io/opendatahub-operator/v2/apis/common"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/conditions"
+
+	. "github.com/onsi/gomega"
+)
+
+const (
+	readyCondition       = "Ready"
+	dependency1Condition = "Dependency1"
+	dependency2Condition = "Dependency2"
+)
+
+type fakeAccessor struct {
+	conditions []common.Condition
+}
+
+func (f *fakeAccessor) GetConditions() []common.Condition {
+	return f.conditions
+}
+
+func (f *fakeAccessor) SetConditions(values []common.Condition) {
+	f.conditions = values
+}
+
+func TestManager_InitializeConditions(t *testing.T) {
+	g := NewWithT(t)
+
+	accessor := &fakeAccessor{}
+	manager := conditions.NewManager(accessor, readyCondition, dependency1Condition, dependency2Condition)
+
+	g.Expect(accessor.GetConditions()).To(HaveLen(3))
+	g.Expect(manager.GetCondition(readyCondition)).NotTo(BeNil())
+	g.Expect(manager.GetCondition(readyCondition).Status).To(Equal(metav1.ConditionUnknown))
+	g.Expect(manager.GetCondition(dependency1Condition)).NotTo(BeNil())
+	g.Expect(manager.GetCondition(dependency2Condition)).NotTo(BeNil())
+}
+
+func TestManager_IsHappy(t *testing.T) {
+	g := NewWithT(t)
+
+	accessor := &fakeAccessor{}
+	manager := conditions.NewManager(accessor, readyCondition, dependency1Condition, dependency2Condition)
+
+	g.Expect(manager.IsHappy()).To(BeFalse())
+
+	manager.MarkFalse(dependency1Condition)
+	manager.MarkFalse(dependency2Condition)
+
+	g.Expect(manager.IsHappy()).To(BeFalse())
+
+	manager.MarkTrue(dependency1Condition)
+	g.Expect(manager.IsHappy()).To(BeFalse())
+
+	manager.MarkTrue(dependency2Condition)
+	g.Expect(manager.IsHappy()).To(BeTrue())
+}
+
+func TestManager_IsHappy_NoDependants(t *testing.T) {
+	g := NewWithT(t)
+
+	accessor := &fakeAccessor{}
+	accessor.SetConditions([]common.Condition{
+		{Type: dependency1Condition, Status: metav1.ConditionUnknown},
+		{Type: dependency2Condition, Status: metav1.ConditionUnknown},
+	})
+
+	manager := conditions.NewManager(accessor, readyCondition)
+	g.Expect(manager.IsHappy()).To(BeFalse())
+
+	manager.MarkFalse(dependency1Condition)
+	g.Expect(manager.IsHappy()).To(BeFalse())
+
+	manager.MarkTrue(dependency1Condition)
+	g.Expect(manager.IsHappy()).To(BeFalse())
+
+	manager.MarkFalse(dependency2Condition)
+	g.Expect(manager.IsHappy()).To(BeFalse())
+
+	manager.MarkTrue(dependency2Condition)
+	g.Expect(manager.IsHappy()).To(BeTrue())
+}
+
+func TestManager_SetAndClearCondition(t *testing.T) {
+	g := NewWithT(t)
+
+	accessor := &fakeAccessor{}
+	manager := conditions.NewManager(accessor, readyCondition, dependency1Condition)
+
+	manager.MarkTrue(dependency1Condition)
+	g.Expect(manager.GetCondition(dependency1Condition)).NotTo(BeNil())
+	g.Expect(manager.GetCondition(dependency1Condition).Status).To(Equal(metav1.ConditionTrue))
+
+	err := manager.ClearCondition(dependency1Condition)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(manager.GetCondition(dependency1Condition)).To(BeNil())
+}
+
+func TestManager_RecomputeHappiness(t *testing.T) {
+	g := NewWithT(t)
+
+	accessor := &fakeAccessor{}
+	manager := conditions.NewManager(accessor, readyCondition, dependency1Condition, dependency2Condition)
+
+	manager.MarkTrue(dependency1Condition)
+	manager.MarkFalse(dependency2Condition, conditions.WithSeverity(common.ConditionSeverityError))
+	g.Expect(manager.IsHappy()).To(BeFalse())
+	g.Expect(manager.GetTopLevelCondition().Status).To(Equal(metav1.ConditionFalse))
+
+	manager.MarkTrue(dependency2Condition)
+	g.Expect(manager.IsHappy()).To(BeTrue())
+}
+
+func TestManager_Sort(t *testing.T) {
+	g := NewWithT(t)
+
+	accessor := &fakeAccessor{conditions: make([]common.Condition, 0)}
+
+	manager := conditions.NewManager(accessor, "Z", "A", "C")
+	manager.MarkTrue("B")
+	manager.MarkTrue("D")
+	manager.MarkTrue("E")
+	manager.Sort()
+
+	result := make([]string, 0, len(accessor.conditions))
+	for _, c := range accessor.conditions {
+		result = append(result, c.Type)
+	}
+
+	g.Expect(result).To(HaveExactElements(
+		"Z",
+		"A",
+		"C",
+		"B",
+		"D",
+		"E",
+	))
+}

--- a/pkg/controller/predicates/dependent/dependent.go
+++ b/pkg/controller/predicates/dependent/dependent.go
@@ -77,6 +77,14 @@ func (p Predicate) Update(e event.UpdateEvent) bool {
 	if e.ObjectOld.GetResourceVersion() == e.ObjectNew.GetResourceVersion() {
 		return false
 	}
+	if !p.WatchStatus {
+		oldGen := e.ObjectOld.GetGeneration()
+		newGen := e.ObjectNew.GetGeneration()
+
+		if oldGen == newGen && newGen != 0 {
+			return false
+		}
+	}
 
 	oldObj, err := resources.ToUnstructured(e.ObjectOld)
 	if err != nil {

--- a/pkg/controller/reconciler/reconciler.go
+++ b/pkg/controller/reconciler/reconciler.go
@@ -323,7 +323,7 @@ func (r *Reconciler) apply(ctx context.Context, res common.PlatformObject) error
 			err.Error(),
 		)
 
-		return fmt.Errorf("reconile failed: %w", err)
+		return fmt.Errorf("reconcile failed: %w", err)
 	}
 
 	if provisionErr != nil {

--- a/pkg/controller/reconciler/reconciler.go
+++ b/pkg/controller/reconciler/reconciler.go
@@ -7,6 +7,8 @@ import (
 	"reflect"
 
 	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/tools/record"
@@ -18,13 +20,26 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	"github.com/opendatahub-io/opendatahub-operator/v2/apis/common"
+	"github.com/opendatahub-io/opendatahub-operator/v2/controllers/status"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions"
 	odherrors "github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/errors"
 	odhClient "github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/client"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/conditions"
 	odhManager "github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/manager"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/resources"
 )
+
+type ReconcilerOpt func(*Reconciler)
+
+func WithConditionsManagerFactory(happy string, dependants ...string) ReconcilerOpt {
+	return func(reconciler *Reconciler) {
+		reconciler.conditionsManagerFactory = func(accessor common.ConditionsAccessor) *conditions.Manager {
+			return conditions.NewManager(accessor, happy, dependants...)
+		}
+	}
+}
 
 const platformFinalizer = "platform.opendatahub.io/finalizer"
 
@@ -39,13 +54,14 @@ type Reconciler struct {
 	Recorder   record.EventRecorder
 	Release    common.Release
 
-	name            string
-	m               *odhManager.Manager
-	instanceFactory func() (common.PlatformObject, error)
+	name                     string
+	m                        *odhManager.Manager
+	instanceFactory          func() (common.PlatformObject, error)
+	conditionsManagerFactory func(common.ConditionsAccessor) *conditions.Manager
 }
 
 // NewReconciler creates a new reconciler for the given type.
-func NewReconciler[T common.PlatformObject](mgr manager.Manager, name string, object T) (*Reconciler, error) {
+func NewReconciler[T common.PlatformObject](mgr manager.Manager, name string, object T, opts ...ReconcilerOpt) (*Reconciler, error) {
 	oc, err := odhClient.NewFromManager(mgr)
 	if err != nil {
 		return nil, err
@@ -68,6 +84,13 @@ func NewReconciler[T common.PlatformObject](mgr manager.Manager, name string, ob
 
 			return res, nil
 		},
+		conditionsManagerFactory: func(accessor common.ConditionsAccessor) *conditions.Manager {
+			return conditions.NewManager(accessor, status.ConditionTypeReady)
+		},
+	}
+
+	for _, opt := range opts {
+		opt(&cc)
 	}
 
 	return &cc, nil
@@ -106,8 +129,12 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		return ctrl.Result{}, err
 	}
 
-	if err := r.Client.Get(ctx, client.ObjectKey{Name: req.Name}, res); err != nil {
+	if err := r.Client.Get(ctx, req.NamespacedName, res); err != nil {
 		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+
+	if err := resources.EnsureGroupVersionKind(r.Client.Scheme(), res); err != nil {
+		return ctrl.Result{}, fmt.Errorf("unable to set GVK to instance: %w", err)
 	}
 
 	if !res.GetDeletionTimestamp().IsZero() {
@@ -176,11 +203,12 @@ func (r *Reconciler) delete(ctx context.Context, res common.PlatformObject) erro
 	l.Info("delete")
 
 	rr := types.ReconciliationRequest{
-		Client:    r.Client,
-		Manager:   r.m,
-		Instance:  res,
-		Release:   r.Release,
-		Manifests: make([]types.ManifestInfo, 0),
+		Client:     r.Client,
+		Manager:    r.m,
+		Instance:   res,
+		Conditions: r.conditionsManagerFactory(res),
+		Release:    r.Release,
+		Manifests:  make([]types.ManifestInfo, 0),
 
 		// The DSCI should not be required when deleting a component, if the
 		// component requires some additional info, then such info should be
@@ -216,50 +244,97 @@ func (r *Reconciler) apply(ctx context.Context, res common.PlatformObject) error
 	l := log.FromContext(ctx)
 	l.Info("apply")
 
-	dsci, err := cluster.GetDSCI(ctx, r.Client)
-	if err != nil {
-		return errors.New("unable to find a DSCInitialization instance")
-	}
-
 	rr := types.ReconciliationRequest{
-		Client:    r.Client,
-		Manager:   r.m,
-		Instance:  res,
-		DSCI:      dsci,
-		Release:   r.Release,
-		Manifests: make([]types.ManifestInfo, 0),
+		Client:     r.Client,
+		Manager:    r.m,
+		Instance:   res,
+		Conditions: r.conditionsManagerFactory(res),
+		Release:    r.Release,
+		Manifests:  make([]types.ManifestInfo, 0),
 	}
 
-	// Execute actions
-	for _, action := range r.Actions {
-		l.Info("Executing action", "action", action)
+	var provisionErr error
 
-		actx := log.IntoContext(
-			ctx,
-			l.WithName(actions.ActionGroup).WithName(action.String()),
-		)
+	dsci, dscilErr := cluster.GetDSCI(ctx, r.Client)
+	switch {
+	case dscilErr != nil:
+		provisionErr = fmt.Errorf("failed to get DSCInitialization: %w", dscilErr)
+	default:
+		provisionErr = nil
+		rr.DSCI = dsci.DeepCopy()
 
-		if err := action(actx, &rr); err != nil {
-			se := odherrors.StopError{}
-			if !errors.As(err, &se) {
-				l.Error(err, "Failed to execute action", "action", action)
-				return err
+		// Execute actions
+		for _, action := range r.Actions {
+			l.Info("Executing action", "action", action)
+
+			actx := log.IntoContext(
+				ctx,
+				l.WithName(actions.ActionGroup).WithName(action.String()),
+			)
+
+			provisionErr = action(actx, &rr)
+			if provisionErr != nil {
+				break
 			}
-
-			l.V(3).Info("detected stop marker", "action", action)
-			break
 		}
 	}
 
-	err = r.Client.ApplyStatus(
+	if provisionErr != nil {
+		rr.Conditions.MarkFalse(
+			status.ConditionTypeProvisioningSucceeded,
+			conditions.WithError(provisionErr),
+			conditions.WithObservedGeneration(rr.Instance.GetGeneration()),
+		)
+	} else {
+		rr.Conditions.MarkTrue(
+			status.ConditionTypeProvisioningSucceeded,
+			conditions.WithObservedGeneration(rr.Instance.GetGeneration()),
+		)
+	}
+
+	is := rr.Instance.GetStatus()
+	is.Phase = status.PhaseNotReady
+
+	// Update happiness to cover the case where conditions were
+	// not set using the provided helper functions
+	rr.Conditions.RecomputeHappiness("")
+
+	// keep conditions sorted, keeping general conditions on the
+	// top, other conditions after
+	rr.Conditions.Sort()
+
+	if rr.Conditions.IsHappy() {
+		is.Phase = status.PhaseReady
+		is.ObservedGeneration = rr.Instance.GetGeneration()
+	}
+
+	err := r.Client.ApplyStatus(
 		ctx,
 		rr.Instance,
 		client.FieldOwner(r.name),
 		client.ForceOwnership,
 	)
 
-	if err != nil {
-		return client.IgnoreNotFound(err)
+	if err != nil && !k8serr.IsNotFound(err) {
+		r.Recorder.Event(
+			res,
+			corev1.EventTypeNormal,
+			"ReconcileError",
+			err.Error(),
+		)
+
+		return fmt.Errorf("reconile failed: %w", err)
+	}
+
+	if provisionErr != nil {
+		r.Recorder.Event(
+			res,
+			corev1.EventTypeWarning,
+			"ProvisioningError",
+			provisionErr.Error(),
+		)
+
+		return fmt.Errorf("provisioning failed: %w", provisionErr)
 	}
 
 	return nil

--- a/pkg/controller/reconciler/reconciler_test.go
+++ b/pkg/controller/reconciler/reconciler_test.go
@@ -1,0 +1,201 @@
+//nolint:testpackage
+package reconciler
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"testing"
+	"time"
+
+	gomegaTypes "github.com/onsi/gomega/types"
+	"github.com/rs/xid"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/tools/record"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+
+	"github.com/opendatahub-io/opendatahub-operator/v2/apis/common"
+	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/apis/components/v1alpha1"
+	dscv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/datasciencecluster/v1"
+	dsciv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/dscinitialization/v1"
+	"github.com/opendatahub-io/opendatahub-operator/v2/controllers/status"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
+	odherrors "github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/errors"
+	odhClient "github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/client"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/conditions"
+	odhtype "github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/resources"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/matchers/jq"
+	"github.com/opendatahub-io/opendatahub-operator/v2/tests/envtestutil"
+
+	. "github.com/onsi/gomega"
+)
+
+func createEnvTest(s *runtime.Scheme) (*envtest.Environment, error) {
+	utilruntime.Must(corev1.AddToScheme(s))
+	utilruntime.Must(appsv1.AddToScheme(s))
+	utilruntime.Must(apiextensionsv1.AddToScheme(s))
+	utilruntime.Must(componentApi.AddToScheme(s))
+	utilruntime.Must(dscv1.AddToScheme(s))
+	utilruntime.Must(dsciv1.AddToScheme(s))
+
+	projectDir, err := envtestutil.FindProjectRoot()
+	if err != nil {
+		return nil, err
+	}
+
+	envTest := envtest.Environment{
+		CRDInstallOptions: envtest.CRDInstallOptions{
+			Scheme: s,
+			Paths: []string{
+				filepath.Join(projectDir, "config", "crd", "bases"),
+			},
+			ErrorIfPathMissing: true,
+			CleanUpAfterUse:    false,
+		},
+	}
+
+	return &envTest, nil
+}
+
+func createReconciler(cli *odhClient.Client) *Reconciler {
+	return &Reconciler{
+		Client:   cli,
+		Scheme:   cli.Scheme(),
+		Log:      ctrl.Log.WithName("controllers").WithName("test"),
+		Release:  cluster.GetRelease(),
+		Recorder: record.NewFakeRecorder(100),
+		name:     "test",
+		instanceFactory: func() (common.PlatformObject, error) {
+			i := &componentApi.Dashboard{
+				TypeMeta: ctrl.TypeMeta{
+					APIVersion: gvk.Dashboard.GroupVersion().String(),
+					Kind:       gvk.Dashboard.Kind,
+				},
+			}
+
+			return i, nil
+		},
+		conditionsManagerFactory: func(accessor common.ConditionsAccessor) *conditions.Manager {
+			return conditions.NewManager(accessor, status.ConditionTypeReady)
+		},
+	}
+}
+
+func TestConditions(t *testing.T) {
+	ctx := context.Background()
+
+	g := NewWithT(t)
+	s := runtime.NewScheme()
+
+	envTest, err := createEnvTest(s)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	t.Cleanup(func() {
+		_ = envTest.Stop()
+	})
+
+	cfg, err := envTest.Start()
+	g.Expect(err).NotTo(HaveOccurred())
+
+	envTestClient, err := client.New(cfg, client.Options{Scheme: s})
+	g.Expect(err).NotTo(HaveOccurred())
+
+	cli, err := odhClient.NewFromConfig(cfg, envTestClient)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	dsci := resources.GvkToUnstructured(gvk.DSCInitialization)
+	dsci.SetName(xid.New().String())
+	dsci.SetGeneration(1)
+
+	err = cli.Create(ctx, dsci)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	tests := []struct {
+		name    string
+		err     error
+		matcher gomegaTypes.GomegaMatcher
+	}{
+		{
+			name: "ready",
+			err:  nil,
+			matcher: And(
+				jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, status.ConditionTypeReady, metav1.ConditionTrue),
+				jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, status.ConditionTypeProvisioningSucceeded, metav1.ConditionTrue),
+			),
+		},
+		{
+			name: "stop",
+			err:  odherrors.NewStopError("stop"),
+			matcher: And(
+				jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, status.ConditionTypeReady, metav1.ConditionFalse),
+				jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, status.ConditionTypeProvisioningSucceeded, metav1.ConditionFalse),
+			),
+		},
+		{
+			name: "failure",
+			err:  errors.New("failure"),
+			matcher: And(
+				jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, status.ConditionTypeReady, metav1.ConditionFalse),
+				jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, status.ConditionTypeProvisioningSucceeded, metav1.ConditionFalse),
+			),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dash := resources.GvkToUnstructured(gvk.Dashboard)
+			dash.SetName(componentApi.DashboardInstanceName)
+			dash.SetGeneration(1)
+
+			err = cli.Create(ctx, dash)
+			g.Expect(err).NotTo(HaveOccurred())
+
+			req := ctrl.Request{
+				NamespacedName: types.NamespacedName{
+					Name: componentApi.DashboardInstanceName,
+				},
+			}
+
+			cc := createReconciler(cli)
+			cc.AddAction(func(ctx context.Context, rr *odhtype.ReconciliationRequest) error {
+				return tt.err
+			})
+
+			result, err := cc.Reconcile(ctx, req)
+			if tt.err == nil {
+				g.Expect(err).ShouldNot(HaveOccurred())
+			} else {
+				g.Expect(err).Should(MatchError(tt.err))
+			}
+
+			g.Expect(result.Requeue).Should(BeFalse())
+
+			di := dash.DeepCopy()
+			err = cli.Get(ctx, client.ObjectKeyFromObject(di), di)
+			g.Expect(err).ShouldNot(HaveOccurred())
+			g.Expect(di).Should(tt.matcher)
+
+			err = cli.Delete(ctx, di, client.PropagationPolicy(metav1.DeletePropagationBackground))
+			g.Expect(err).ShouldNot(HaveOccurred())
+
+			g.Eventually(func() ([]componentApi.Dashboard, error) {
+				l := componentApi.DashboardList{}
+				if err := cli.List(ctx, &l, client.InNamespace("")); err != nil {
+					return nil, err
+				}
+
+				return l.Items, nil
+			}).WithTimeout(10 * time.Second).Should(BeEmpty())
+		})
+	}
+}

--- a/pkg/controller/types/types.go
+++ b/pkg/controller/types/types.go
@@ -14,6 +14,7 @@ import (
 	"github.com/opendatahub-io/opendatahub-operator/v2/apis/common"
 	dsciv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/dscinitialization/v1"
 	odhClient "github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/client"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/conditions"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/manager"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/resources"
 )
@@ -55,11 +56,12 @@ type TemplateInfo struct {
 type ReconciliationRequest struct {
 	*odhClient.Client
 
-	Manager   *manager.Manager
-	Instance  common.PlatformObject
-	DSCI      *dsciv1.DSCInitialization
-	Release   common.Release
-	Manifests []ManifestInfo
+	Manager    *manager.Manager
+	Conditions *conditions.Manager
+	Instance   common.PlatformObject
+	DSCI       *dsciv1.DSCInitialization
+	Release    common.Release
+	Manifests  []ManifestInfo
 
 	//
 	// TODO: unify templates and resources.

--- a/pkg/services/gc/gc.go
+++ b/pkg/services/gc/gc.go
@@ -126,7 +126,7 @@ func (gc *GC) listResources(
 ) ([]unstructured.Unstructured, error) {
 	items, err := gc.client.Dynamic().Resource(res.GroupVersionResource()).Namespace("").List(ctx, opts)
 	switch {
-	case k8serr.IsForbidden(err) || k8serr.IsMethodNotSupported(err):
+	case k8serr.IsForbidden(err) || k8serr.IsMethodNotSupported(err) || k8serr.IsNotFound(err):
 		gc.log(ctx).V(3).Info(
 			"cannot list resource",
 			"reason", err.Error(),

--- a/tests/e2e/components_test.go
+++ b/tests/e2e/components_test.go
@@ -106,6 +106,7 @@ func (c *ComponentTestCtx) ValidateComponentEnabled(t *testing.T) {
 		HaveEach(And(
 			jq.Match(`.metadata.ownerReferences[0].kind == "%s"`, gvk.DataScienceCluster.Kind),
 			jq.Match(`.status.conditions[] | select(.type == "Ready") | .status == "%s"`, metav1.ConditionTrue),
+			jq.Match(`.status.conditions[] | select(.type == "ProvisioningSucceeded") | .status == "%s"`, metav1.ConditionTrue),
 		)),
 	))
 }

--- a/tests/e2e/kserve_test.go
+++ b/tests/e2e/kserve_test.go
@@ -133,8 +133,7 @@ func (c *KserveTestCtx) validateConditions(t *testing.T) {
 	g.List(gvk.Kserve).Eventually().Should(And(
 		HaveLen(1),
 		HaveEach(And(
-			jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, status.ConditionServerlessAvailable, metav1.ConditionTrue),
-			jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, status.ConditionServiceMeshAvailable, metav1.ConditionTrue),
+			jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, status.ConditionServingAvailable, metav1.ConditionTrue),
 		)),
 	))
 }

--- a/tests/e2e/modelregistry_test.go
+++ b/tests/e2e/modelregistry_test.go
@@ -74,7 +74,7 @@ func (c *ModelRegistryTestCtx) validateConditions(t *testing.T) {
 	g.List(gvk.ModelRegistry).Eventually().Should(And(
 		HaveLen(1),
 		HaveEach(And(
-			jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, status.ConditionServerlessAvailable, metav1.ConditionTrue),
+			jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, status.ConditionServiceMeshAvailable, metav1.ConditionTrue),
 		)),
 	))
 }


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

This commit introduces some enhancement to what and how components are
reporting theirs status by:

- Includes a `Ready` top-level condition which summarizes more detailed
  conditions
- Includes a `ProvisioningSucceeded` condition that reports any
  provisioning error, i.e. a deployment fails to be provisioned because
  of any invalid fields, some pre-requisites are not met

```yaml
apiVersion: components.platform.opendatahub.io/v1alpha1
kind: ModelRegistry
metadata:
  name: default-modelregistry
spec:
  registriesNamespace: odh-model-registries
status:
  conditions:
  - lastTransitionTime: "2025-02-03T13:10:32Z"
    message: 0/1 deployments ready
    reason: DeploymentsNotReady
    status: "False"
    type: Ready
  - lastTransitionTime: "2025-02-03T12:55:45Z"
    status: "True"
    type: ProvisioningSucceeded
  - lastTransitionTime: "2025-02-03T13:10:32Z"
    message: 0/1 deployments ready
    reason: DeploymentsNotReady
    status: "False"
    type: DeploymentsAvailable
  - lastTransitionTime: "2025-02-03T12:55:32Z"
    status: "True"
    type: ServerlessAvailable
```
> [!NOTE]
> in the case we want a condition to be set to `False`, but that should not affect the top level condition, it is possible to set the `severity` field as `Info` (the default is `Error` and it is being represented by an empty value):
>
>```yaml
>   - lastTransitionTime: "2025-02-03T13:10:42Z"
>     reason: FooReasin
>     severity: Info
>     status: "True"
>     type: Foo
>```

If needed, additional conditions can be added by individual component or
services:

```go
_, err := reconciler.ReconcilerFor(mgr, &componentApi.ModelRegistry{}).
    // ...
    WithConditions(
	status.ConditionDeploymentsAvailable,
	status.ConditionServerlessAvailable).
    Build(ctx)
```

To help managing conditions, a `conditions.Manager` type has been
inrtoduced, largely inspired by Knative's conditions set code [1], but
improved to handle our specific use cases.

[1] https://github.com/knative/pkg/blob/main/apis/condition_set.go

<!--- Link your JIRA and related links here for reference. -->

https://issues.redhat.com/browse/RHOAIENG-18216

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
