### PR TITLE
model-registry: remove custom handdling of the modelregistry-editor-role and modelregistry-viewer-role cluster roles

### DIFF
--- a/controllers/components/modelregistry/modelregistry_controller.go
+++ b/controllers/components/modelregistry/modelregistry_controller.go
@@ -72,10 +72,6 @@ func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.
 			reconciler.WithPredicates(
 				component.ForLabel(labels.ODH.Component(LegacyComponentName), labels.True)),
 		).
-		// Some ClusterRoles are part of the component deployment, but not owned by
-		// the operator (overlays/odh/extras), so in order to properly keep them
-		// in sync with the manifests, we should also create an additional watcher
-		Watches(&rbacv1.ClusterRole{}).
 		// This component adds a ServiceMeshMember resource to the registries
 		// namespaces that may not be known when the controller is started, hence
 		// it should be watched dynamically
@@ -93,7 +89,6 @@ func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.
 			kustomize.WithLabel(labels.ODH.Component(LegacyComponentName), labels.True),
 			kustomize.WithLabel(labels.K8SCommon.PartOf, LegacyComponentName),
 		)).
-		WithAction(customizeResources).
 		WithAction(deploy.NewAction(
 			deploy.WithCache(),
 		)).

--- a/controllers/components/modelregistry/modelregistry_controller_actions.go
+++ b/controllers/components/modelregistry/modelregistry_controller_actions.go
@@ -13,13 +13,10 @@ import (
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/apis/components/v1alpha1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/controllers/status"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
-	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
 	odherrors "github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/errors"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/conditions"
 	odhtypes "github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
 	odhdeploy "github.com/opendatahub-io/opendatahub-operator/v2/pkg/deploy"
-	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/metadata/annotations"
-	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/resources"
 
 	_ "embed"
 )
@@ -127,26 +124,6 @@ func configureDependencies(ctx context.Context, rr *odhtypes.ReconciliationReque
 		},
 	); err != nil {
 		return fmt.Errorf("failed to add default ingress secret for model registry: %w", err)
-	}
-
-	return nil
-}
-
-func customizeResources(_ context.Context, rr *odhtypes.ReconciliationRequest) error {
-	// Some ClusterRoles are part of the component deployment, but not owned by the
-	// operator (overlays/odh/extras) and we expect them to be left on the cluster
-	// even if the component is removed, hence we should mark them a not managed by
-	// the operator. By doing so the deploy action won't set ownership and won't
-	// patch them, just recreate if missing
-	for i := range rr.Resources {
-		r := rr.Resources[i]
-
-		switch {
-		case r.GroupVersionKind() == gvk.ClusterRole && r.GetName() == "modelregistry-editor-role":
-			resources.SetAnnotation(&rr.Resources[i], annotations.ManagedByODHOperator, "false")
-		case r.GroupVersionKind() == gvk.ClusterRole && r.GetName() == "modelregistry-viewer-role":
-			resources.SetAnnotation(&rr.Resources[i], annotations.ManagedByODHOperator, "false")
-		}
 	}
 
 	return nil

--- a/pkg/cluster/gvk/gvk.go
+++ b/pkg/cluster/gvk/gvk.go
@@ -41,6 +41,12 @@ var (
 		Kind:    "Deployment",
 	}
 
+	OpenShiftClusterRole = schema.GroupVersionKind{
+		Group:   "authorization.openshift.io",
+		Version: "v1",
+		Kind:    "ClusterRole",
+	}
+
 	ClusterRole = schema.GroupVersionKind{
 		Group:   "rbac.authorization.k8s.io",
 		Version: "v1",


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

This PR is aimed a removing the custom handling of some specific MR's `ClusterRoles`:
- modelregistry-editor-role 
- modelregistry-viewer-role 

Which does not make much sense to keep them, since we are removing all the other `ClusterRoles`

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

1. Enable MR on DSC
2. Check for the presence of the mentioned `ClusterRoles`
3. Disable MR on DSC
4. the mentioned `ClusterRoles` should have gone

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
