### PR TITLE
update: pass modelreg namespace to dspo

### DIFF
--- a/apis/components/v1alpha1/datasciencepipelines_types.go
+++ b/apis/components/v1alpha1/datasciencepipelines_types.go
@@ -53,7 +53,8 @@ type DataSciencePipelinesSpec struct {
 }
 
 type DataSciencePipelinesCommonSpec struct {
-	common.DevFlagsSpec `json:",inline"`
+	common.DevFlagsSpec    `json:",inline"`
+	ModelRegistryNamespace string `json:"modelRegistryNamespace,omitempty"`
 }
 
 // DataSciencePipelinesCommonStatus defines the shared observed state of DataSciencePipelines

--- a/bundle/manifests/components.platform.opendatahub.io_datasciencepipelines.yaml
+++ b/bundle/manifests/components.platform.opendatahub.io_datasciencepipelines.yaml
@@ -75,6 +75,8 @@ spec:
                       type: object
                     type: array
                 type: object
+              modelRegistryNamespace:
+                type: string
             type: object
           status:
             description: DataSciencePipelinesStatus defines the observed state of

--- a/bundle/manifests/datasciencecluster.opendatahub.io_datascienceclusters.yaml
+++ b/bundle/manifests/datasciencecluster.opendatahub.io_datascienceclusters.yaml
@@ -186,6 +186,8 @@ spec:
                         - Removed
                         pattern: ^(Managed|Unmanaged|Force|Removed)$
                         type: string
+                      modelRegistryNamespace:
+                        type: string
                     type: object
                   feastoperator:
                     description: Feast Operator component configuration.

--- a/bundle/manifests/opendatahub-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/opendatahub-operator.clusterserviceversion.yaml
@@ -114,7 +114,7 @@ metadata:
     categories: AI/Machine Learning, Big Data
     certified: "False"
     containerImage: quay.io/opendatahub/opendatahub-operator:v2.24.0
-    createdAt: "2025-02-12T13:47:30Z"
+    createdAt: "2025-02-25T10:01:53Z"
     olm.skipRange: '>=1.0.0 <2.24.0'
     operators.operatorframework.io/builder: operator-sdk-v1.31.0
     operators.operatorframework.io/internal-objects: '["featuretrackers.features.opendatahub.io",

--- a/config/crd/bases/components.platform.opendatahub.io_datasciencepipelines.yaml
+++ b/config/crd/bases/components.platform.opendatahub.io_datasciencepipelines.yaml
@@ -75,6 +75,8 @@ spec:
                       type: object
                     type: array
                 type: object
+              modelRegistryNamespace:
+                type: string
             type: object
           status:
             description: DataSciencePipelinesStatus defines the observed state of

--- a/config/crd/bases/datasciencecluster.opendatahub.io_datascienceclusters.yaml
+++ b/config/crd/bases/datasciencecluster.opendatahub.io_datascienceclusters.yaml
@@ -186,6 +186,8 @@ spec:
                         - Removed
                         pattern: ^(Managed|Unmanaged|Force|Removed)$
                         type: string
+                      modelRegistryNamespace:
+                        type: string
                     type: object
                   feastoperator:
                     description: Feast Operator component configuration.

--- a/controllers/components/datasciencepipelines/datasciencepipelines.go
+++ b/controllers/components/datasciencepipelines/datasciencepipelines.go
@@ -63,7 +63,10 @@ func (s *componentHandler) NewCRObject(dsc *dscv1.DataScienceCluster) common.Pla
 			},
 		},
 		Spec: componentApi.DataSciencePipelinesSpec{
-			DataSciencePipelinesCommonSpec: dsc.Spec.Components.DataSciencePipelines.DataSciencePipelinesCommonSpec,
+			DataSciencePipelinesCommonSpec: componentApi.DataSciencePipelinesCommonSpec{
+				ModelRegistryNamespace: dsc.Spec.Components.ModelRegistry.RegistriesNamespace,
+				DevFlagsSpec:           dsc.Spec.Components.DataSciencePipelines.DevFlagsSpec,
+			},
 		},
 	}
 }

--- a/controllers/components/datasciencepipelines/datasciencepipelines_controller_actions.go
+++ b/controllers/components/datasciencepipelines/datasciencepipelines_controller_actions.go
@@ -71,8 +71,17 @@ func checkPreConditions(ctx context.Context, rr *odhtypes.ReconciliationRequest)
 }
 
 func initialize(_ context.Context, rr *odhtypes.ReconciliationRequest) error {
+	dsp, ok := rr.Instance.(*componentApi.DataSciencePipelines)
+	if !ok {
+		return fmt.Errorf("resource instance %v is not a componentApi.DataSciencePipelines)", rr.Instance)
+	}
+
 	rr.Manifests = append(rr.Manifests, manifestPath(rr.Release.Name))
 
+	// pass down ModelRegistry Namespace
+	if err := odhdeploy.ApplyParams(paramsPath, nil, map[string]string{modelregistryParamsKey: dsp.Spec.ModelRegistryNamespace}); err != nil {
+		return fmt.Errorf("failed to set ModelRegistry namespace %s : %w", paramsPath, err)
+	}
 	return nil
 }
 

--- a/controllers/components/datasciencepipelines/datasciencepipelines_support.go
+++ b/controllers/components/datasciencepipelines/datasciencepipelines_support.go
@@ -24,6 +24,7 @@ const (
 	// deployment to the new component name, so keep it around till we figure out a solution.
 	LegacyComponentName      = "data-science-pipelines-operator"
 	platformVersionParamsKey = "PLATFORMVERSION"
+	modelregistryParamsKey   = "MODELREGISTRY_NAMESPACE"
 )
 
 var (

--- a/docs/api-overview.md
+++ b/docs/api-overview.md
@@ -233,6 +233,7 @@ _Appears in:_
 | --- | --- | --- | --- |
 | `managementState` _[ManagementState](#managementstate)_ | Set to one of the following values:<br /><br />- "Managed" : the operator is actively managing the component and trying to keep it active.<br />              It will only upgrade the component if it is safe to do so<br /><br />- "Removed" : the operator is actively managing the component and will not install it,<br />              or if it is installed, the operator will try to remove it |  | Enum: [Managed Removed] <br /> |
 | `devFlags` _[DevFlags](#devflags)_ | Add developer fields |  |  |
+| `modelRegistryNamespace` _string_ |  |  |  |
 
 
 #### DSCDataSciencePipelinesStatus
@@ -700,6 +701,7 @@ _Appears in:_
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
 | `devFlags` _[DevFlags](#devflags)_ | Add developer fields |  |  |
+| `modelRegistryNamespace` _string_ |  |  |  |
 
 
 #### DataSciencePipelinesCommonStatus
@@ -753,6 +755,7 @@ _Appears in:_
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
 | `devFlags` _[DevFlags](#devflags)_ | Add developer fields |  |  |
+| `modelRegistryNamespace` _string_ |  |  |  |
 
 
 #### DataSciencePipelinesStatus

--- a/tests/e2e/datasciencepipelines_test.go
+++ b/tests/e2e/datasciencepipelines_test.go
@@ -6,6 +6,10 @@ import (
 	"github.com/stretchr/testify/require"
 
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/apis/components/v1alpha1"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/matchers/jq"
+
+	. "github.com/onsi/gomega"
 )
 
 func dataSciencePipelinesTestSuite(t *testing.T) {
@@ -19,6 +23,7 @@ func dataSciencePipelinesTestSuite(t *testing.T) {
 	}
 
 	t.Run("Validate component enabled", componentCtx.ValidateComponentEnabled)
+	t.Run("Validate component spec", componentCtx.validateSpec)
 	t.Run("Validate operands have OwnerReferences", componentCtx.ValidateOperandsOwnerReferences)
 	t.Run("Validate update operand resources", componentCtx.ValidateUpdateDeploymentsResources)
 	t.Run("Validate component disabled", componentCtx.ValidateComponentDisabled)
@@ -27,4 +32,18 @@ func dataSciencePipelinesTestSuite(t *testing.T) {
 
 type DataSciencePipelinesTestCtx struct {
 	*ComponentTestCtx
+}
+
+func (d *DataSciencePipelinesTestCtx) validateSpec(t *testing.T) {
+	g := d.NewWithT(t)
+
+	dsc, err := d.GetDSC()
+	g.Expect(err).NotTo(HaveOccurred())
+
+	g.List(gvk.DataSciencePipelines).Eventually().Should(And(
+		HaveLen(1),
+		HaveEach(And(
+			jq.Match(`.spec.modelRegistryNamespace == "%s"`, dsc.Spec.Components.ModelRegistry.RegistriesNamespace),
+		)),
+	))
 }


### PR DESCRIPTION
- in default-datasciencepipelines.spec.modelRegistryNamespace it has <MR NS value>
- in params.env it has MODELREGISTRY_NAMESPACE=<MR NS value>
- do not care if ModelReg is enabled or not, it always has NS value set in DSC by default
- if user modify DSC with new <MR NS value>, params.env gets updated to new value

<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

<!--- Link your JIRA and related links here for reference. -->
ref: https://issues.redhat.com/browse/RHOAIENG-20484

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
local build: quay.io/wenzhou/opendatahub-operator-catalog:v2.19.20484-3


## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
