### PR TITLE
fix auth tests for RHOAI

### DIFF
--- a/tests/e2e/authcontroller_test.go
+++ b/tests/e2e/authcontroller_test.go
@@ -100,17 +100,21 @@ func (tc *AuthControllerTestCtx) validateAuthCRDefaultContent() error {
 		return errors.New("AdminGroups is empty ")
 	}
 
-	if tc.platform == cluster.SelfManagedRhoai {
+	switch tc.platform {
+	case cluster.SelfManagedRhoai:
 		if tc.testAuthInstance.Spec.AdminGroups[0] == "rhods-admins" {
 			return nil
 		}
 		return fmt.Errorf("expected rhods-admins, found %v", tc.testAuthInstance.Spec.AdminGroups[0])
-	} else if tc.platform == cluster.ManagedRhoai {
+	case cluster.ManagedRhoai:
 		if tc.testAuthInstance.Spec.AdminGroups[0] == "dedicated-admins" {
 			return nil
 		}
 		return fmt.Errorf("expected dedicated-admins, found %v", tc.testAuthInstance.Spec.AdminGroups[0])
-	} else if tc.testAuthInstance.Spec.AdminGroups[0] != "odh-admins" {
+	case cluster.OpenDataHub, cluster.Unknown:
+		if tc.testAuthInstance.Spec.AdminGroups[0] == "odh-admins" {
+			return nil
+		}
 		return fmt.Errorf("expected odh-admins, found %v", tc.testAuthInstance.Spec.AdminGroups[0])
 	}
 

--- a/tests/e2e/authcontroller_test.go
+++ b/tests/e2e/authcontroller_test.go
@@ -12,7 +12,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	serviceApi "github.com/opendatahub-io/opendatahub-operator/v2/apis/services/v1alpha1"
-	"github.com/opendatahub-io/opendatahub-operator/v2/controllers/components/dashboard"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
 
 	. "github.com/onsi/gomega"
 )
@@ -100,8 +100,18 @@ func (tc *AuthControllerTestCtx) validateAuthCRDefaultContent() error {
 		return errors.New("AdminGroups is empty ")
 	}
 
-	if tc.testAuthInstance.Spec.AdminGroups[0] != dashboard.GetAdminGroup() {
-		return fmt.Errorf("expected %s, found %v", dashboard.GetAdminGroup(), tc.testAuthInstance.Spec.AdminGroups[0])
+	if tc.platform == cluster.SelfManagedRhoai {
+		if tc.testAuthInstance.Spec.AdminGroups[0] == "rhods-admins" {
+			return nil
+		}
+		return fmt.Errorf("expected rhods-admins, found %v", tc.testAuthInstance.Spec.AdminGroups[0])
+	} else if tc.platform == cluster.ManagedRhoai {
+		if tc.testAuthInstance.Spec.AdminGroups[0] == "dedicated-admins" {
+			return nil
+		}
+		return fmt.Errorf("expected dedicated-admins, found %v", tc.testAuthInstance.Spec.AdminGroups[0])
+	} else if tc.testAuthInstance.Spec.AdminGroups[0] != "odh-admins" {
+		return fmt.Errorf("expected odh-admins, found %v", tc.testAuthInstance.Spec.AdminGroups[0])
 	}
 
 	if tc.testAuthInstance.Spec.AllowedGroups[0] != "system:authenticated" {
@@ -197,7 +207,10 @@ func (tc *AuthControllerTestCtx) validateAddingGroups() error {
 }
 
 func (tc *AuthControllerTestCtx) validateRemovingGroups() error {
-	expectedGroup := dashboard.GetAdminGroup()
+	expectedGroup := "odh-admins"
+	if tc.platform == cluster.ManagedRhoai || tc.platform == cluster.SelfManagedRhoai {
+		expectedGroup = "rhods-admins"
+	}
 	if _, err := controllerutil.CreateOrUpdate(tc.ctx, tc.customClient, &tc.testAuthInstance, func() error {
 		tc.testAuthInstance.Spec.AdminGroups = []string{expectedGroup}
 		return nil
@@ -213,7 +226,7 @@ func (tc *AuthControllerTestCtx) validateRemovingGroups() error {
 			return fmt.Errorf("Expected 1 subject in adminRoleBinding found %v", len(adminRolebinding.Subjects))
 		}
 		if adminRolebinding.Subjects[0].Name != expectedGroup {
-			return fmt.Errorf("Expected adminRolebinding to only contain %s found %s", expectedGroup, adminRolebinding.Subjects[1].Name)
+			return fmt.Errorf("Expected adminRolebinding to only contain %s found %s", expectedGroup, adminRolebinding.Subjects[0].Name)
 		}
 	}
 
@@ -223,7 +236,7 @@ func (tc *AuthControllerTestCtx) validateRemovingGroups() error {
 			return fmt.Errorf("Expected 1 subject in adminClusterRoleBinding found %v", len(adminClusterRolebinding.Subjects))
 		}
 		if adminClusterRolebinding.Subjects[0].Name != expectedGroup {
-			return fmt.Errorf("Expected adminClusterRolebinding to only contain %s found %s", expectedGroup, adminClusterRolebinding.Subjects[1].Name)
+			return fmt.Errorf("Expected adminClusterRolebinding to only contain %s found %s", expectedGroup, adminClusterRolebinding.Subjects[0].Name)
 		}
 	}
 


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->
e2e failures in https://github.com/opendatahub-io/opendatahub-operator/pull/1674 seem to be caused by the function for returning the adminGroup getting an empty platform and returning the wrong group. Fix this by setting the group in the test.
<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
