### PR TITLE
update: change ossm sidecar as labels on authornio deployment

### DIFF
--- a/controllers/dscinitialization/resources/authorino/deployment.injection.patch.tmpl.yaml
+++ b/controllers/dscinitialization/resources/authorino/deployment.injection.patch.tmpl.yaml
@@ -8,5 +8,3 @@ spec:
     metadata:
       labels:
         sidecar.istio.io/inject: "true"
-      annotations:
-        sidecar.istio.io/inject: "true"

--- a/controllers/dscinitialization/resources/authorino/deployment.injection.patch.tmpl.yaml
+++ b/controllers/dscinitialization/resources/authorino/deployment.injection.patch.tmpl.yaml
@@ -6,5 +6,7 @@ metadata:
 spec:
   template:
     metadata:
+      labels:
+        sidecar.istio.io/inject: "true"
       annotations:
         sidecar.istio.io/inject: "true"

--- a/controllers/dscinitialization/servicemesh_setup.go
+++ b/controllers/dscinitialization/servicemesh_setup.go
@@ -209,7 +209,7 @@ func (r *DSCInitializationReconciler) authorizationFeatures(instance *dsciv1.DSC
 
 			// We do not have the control over deployment resource creation.
 			// It is created by Authorino operator using Authorino CR and labels are not propagated from Authorino CR to spec.template
-			// See https://issues.redhat.com/browse/RHOAIENG-5494
+			// See https://issues.redhat.com/browse/RHOAIENG-5494 and https://github.com/Kuadrant/authorino-operator/pull/243
 			//
 			// To make it part of Service Mesh we have to patch it with injection
 			// enabled instead, otherwise it will not have proxy pod injected.


### PR DESCRIPTION
- change annotations to labels when we do patch on authornio deployment


<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->
rewrite of https://github.com/opendatahub-io/opendatahub-operator/pull/1513

<!--- Link your JIRA and related links here for reference. -->
https://issues.redhat.com/browse/RHOAIENG-18238

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
local build quay.io/wenzhou/opendatahub-operator:2.26.18238
- install operator
- install authornio servicemesh operator
- create DSCI with servicemesh Managed
- check authorino-XXX pod in opendatahub-auth-provider ns has 2 contains, one is istio-proxy

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
