### PR TITLE
Improve gc action to only collect owned resources by default

### DIFF
--- a/pkg/controller/actions/gc/action_gc.go
+++ b/pkg/controller/actions/gc/action_gc.go
@@ -28,6 +28,7 @@ type Action struct {
 	gc                *gc.GC
 	objectPredicateFn ObjectPredicateFn
 	typePredicateFn   TypePredicateFn
+	onlyOwned         bool
 }
 
 func WithLabel(name string, value string) ActionOpts {
@@ -69,6 +70,7 @@ func WithObjectPredicate(value ObjectPredicateFn) ActionOpts {
 		action.objectPredicateFn = value
 	}
 }
+
 func WithTypePredicate(value TypePredicateFn) ActionOpts {
 	return func(action *Action) {
 		if value == nil {
@@ -76,6 +78,12 @@ func WithTypePredicate(value TypePredicateFn) ActionOpts {
 		}
 
 		action.typePredicateFn = value
+	}
+}
+
+func WithCollectOwned(value bool) ActionOpts {
+	return func(action *Action) {
+		action.onlyOwned = value
 	}
 }
 
@@ -96,19 +104,19 @@ func (a *Action) run(ctx context.Context, rr *odhTypes.ReconciliationRequest) er
 		return nil
 	}
 
-	kind, err := resources.KindForObject(rr.Client.Scheme(), rr.Instance)
+	igvk, err := resources.GetGroupVersionKindForObject(rr.Client.Scheme(), rr.Instance)
 	if err != nil {
 		return err
 	}
 
-	controllerName := strings.ToLower(kind)
+	controllerName := strings.ToLower(igvk.Kind)
 
 	CyclesTotal.WithLabelValues(controllerName).Inc()
 
 	selector := a.selector
 	if selector == nil {
 		selector = labels.SelectorFromSet(map[string]string{
-			odhLabels.PlatformPartOf: strings.ToLower(kind),
+			odhLabels.PlatformPartOf: controllerName,
 		})
 	}
 
@@ -130,6 +138,16 @@ func (a *Action) run(ctx context.Context, rr *odhTypes.ReconciliationRequest) er
 				return false, nil
 			}
 
+			if a.onlyOwned {
+				o, err := resources.IsOwnedByType(&obj, igvk)
+				if err != nil {
+					return false, err
+				}
+				if !o {
+					return false, nil
+				}
+			}
+
 			return a.objectPredicateFn(rr, obj)
 		}),
 	)
@@ -149,6 +167,7 @@ func NewAction(opts ...ActionOpts) actions.Fn {
 	action := Action{}
 	action.objectPredicateFn = DefaultObjectPredicate
 	action.typePredicateFn = DefaultTypePredicate
+	action.onlyOwned = true
 	action.unremovables = make(map[schema.GroupVersionKind]struct{})
 
 	for _, opt := range opts {

--- a/pkg/controller/actions/gc/action_gc_support.go
+++ b/pkg/controller/actions/gc/action_gc_support.go
@@ -23,7 +23,7 @@ func DefaultObjectPredicate(rr *odhTypes.ReconciliationRequest, obj unstructured
 	iu := resources.GetAnnotation(&obj, odhAnnotations.InstanceUID)
 
 	if pv == "" || pt == "" || ig == "" || iu == "" {
-		return false, nil
+		return true, nil
 	}
 
 	if pv != rr.Release.Version.String() {

--- a/pkg/resources/resources.go
+++ b/pkg/resources/resources.go
@@ -390,3 +390,28 @@ func RemoveOwnerReferences(
 
 	return nil
 }
+
+// IsOwnedByType checks if the given object (obj) is owned by an entity of the specified GroupVersionKind.
+// It iterates through the object's owner references to determine ownership.
+//
+// Parameters:
+// - obj: The Kubernetes object to check ownership for.
+// - ownerGVK: The GroupVersionKind (GVK) of the expected owner.
+//
+// Returns:
+// - A boolean indicating whether the object is owned by an entity of the specified GVK.
+// - An error if any issue occurs while parsing the owner's API version.
+func IsOwnedByType(obj client.Object, ownerGVK schema.GroupVersionKind) (bool, error) {
+	for _, ref := range obj.GetOwnerReferences() {
+		av, err := schema.ParseGroupVersion(ref.APIVersion)
+		if err != nil {
+			return false, err
+		}
+
+		if av.Group == ownerGVK.Group && av.Version == ownerGVK.Version && ref.Kind == ownerGVK.Kind {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}


### PR DESCRIPTION
This update modifies the garbage collection (GC) action to, by default,
collect only resources owned by the controller that is using the action.

This commit enhances

<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
