### PR TITLE
Improve controller-runtime cache configuration

### DIFF
--- a/controllers/dscinitialization/utils.go
+++ b/controllers/dscinitialization/utils.go
@@ -418,16 +418,10 @@ func (r *DSCInitializationReconciler) createUserGroup(ctx context.Context, dscIn
 		// Otherwise is errors with "error": "Group.user.openshift.io \"odh-admins\" is invalid: users: Invalid value: \"null\": users in body must be of type array: \"null\""}
 		Users: []string{},
 	}
-	err := r.Client.Get(ctx, client.ObjectKeyFromObject(userGroup), userGroup)
-	if err != nil {
-		if k8serr.IsNotFound(err) {
-			err = r.Client.Create(ctx, userGroup)
-			if err != nil && !k8serr.IsAlreadyExists(err) {
-				return err
-			}
-		} else {
-			return err
-		}
+
+	err := r.Client.Create(ctx, userGroup)
+	if err != nil && !k8serr.IsAlreadyExists(err) {
+		return err
 	}
 
 	return nil

--- a/main.go
+++ b/main.go
@@ -43,6 +43,7 @@ import (
 	networkingv1 "k8s.io/api/networking/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -260,6 +261,14 @@ func main() { //nolint:funlen,maintidx,gocyclo
 			&rbacv1.ClusterRoleBinding{}:             {},
 			&securityv1.SecurityContextConstraints{}: {},
 		},
+		DefaultTransform: func(in any) (any, error) {
+			// Nilcheck managed fields to avoid hitting https://github.com/kubernetes/kubernetes/issues/124337
+			if obj, err := meta.Accessor(in); err == nil && obj.GetManagedFields() != nil {
+				obj.SetManagedFields(nil)
+			}
+
+			return in, nil
+		},
 	}
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{ // single pod does not need to have LeaderElection
@@ -291,6 +300,8 @@ func main() { //nolint:funlen,maintidx,gocyclo
 					&ofapiv1alpha1.Subscription{},
 					resources.GvkToUnstructured(gvk.ServiceMeshControlPlane),
 					&authorizationv1.SelfSubjectRulesReview{},
+					&corev1.Pod{},
+					&userv1.Group{},
 				},
 				// Set it to true so the cache-backed client reads unstructured objects
 				// or lists from the cache instead of a live lookup.


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

- remove managed fields, as they are not used directly by the operator code
- add `Pods` to the list of uncached objects because as today, we don't set any filter, hence we are caching all the Pods in a cluster
- add `Group` to the list of uncached objects, since such objects are only created once
- replace `Group` GET+CREATE with just CREATE since the objects are not more in the cache

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

This is not a very accurate analysis, but running a controller with the small optimization introduced by the PR (blue line), seems to report a constant reduction of the memory consumption of ~ 10 MB on pretty much empty cluster

![image](https://github.com/user-attachments/assets/c367dd6e-bcb3-4351-818c-5ef24ec455fd)

```shell

NAME                                                       CPU(cores)   MEMORY(bytes)   
opendatahub-operator-controller-manager-64c7594b46-9dccp   1m           173Mi     
     
NAME                                                       CPU(cores)   MEMORY(bytes)   
opendatahub-operator-controller-manager-6c655dd69d-m7scs   1m           183Mi            
```

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] ~~Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).~~
- [x] The developer has manually tested the changes and verified that the changes work
