### PR TITLE
[rhoai] Improve controller-runtime cache configuration

### DIFF
--- a/controllers/dscinitialization/utils.go
+++ b/controllers/dscinitialization/utils.go
@@ -420,16 +420,10 @@ func (r *DSCInitializationReconciler) createUserGroup(ctx context.Context, dscIn
 		// Otherwise is errors with "error": "Group.user.openshift.io \"odh-admins\" is invalid: users: Invalid value: \"null\": users in body must be of type array: \"null\""}
 		Users: []string{},
 	}
-	err := r.Client.Get(ctx, client.ObjectKeyFromObject(userGroup), userGroup)
-	if err != nil {
-		if k8serr.IsNotFound(err) {
-			err = r.Client.Create(ctx, userGroup)
-			if err != nil && !k8serr.IsAlreadyExists(err) {
-				return err
-			}
-		} else {
-			return err
-		}
+
+	err := r.Client.Create(ctx, userGroup)
+	if err != nil && !k8serr.IsAlreadyExists(err) {
+		return err
 	}
 
 	return nil


### PR DESCRIPTION
* feat: tune controller-runtime cache

- remove managed fields, as they are not used directly by the operator
  code
- add Pods to the list of uncached objects as they may have an high
  cardinality
- add Group to the list of uncached objects, since such objects are only
  created once

* chore: replace Group GET+CREATE with just CREATE

(cherry picked from commit 6b2dcfcb13f6ffa1c254ec634db3e2c0dc600621)

<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
