### PR TITLE
chore: add FeastOperator to PROJECT file

### DIFF
--- a/PROJECT
+++ b/PROJECT
@@ -127,6 +127,14 @@ resources:
     crdVersion: v1alpha1
   controller: true
   domain: platform.opendatahub.io
+  group: components
+  kind: FeastOperator
+  path: github.com/opendatahub-io/opendatahub-operator/v2/apis/components/v1alpha1
+  version: v1alpha1
+- api:
+    crdVersion: v1alpha1
+  controller: true
+  domain: platform.opendatahub.io
   group: services
   kind: Monitoring
   path: github.com/opendatahub-io/opendatahub-operator/v2/apis/services/v1alpha1


### PR DESCRIPTION
## Description
The `FeastOperator` CRD was recently added to the operator but an entry for the CRD was never added to the `PROJECT` file - this PR adds it. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
