### PR TITLE
[sync] Improve e2e test configurability (#1650)

### DIFF
--- a/bundle/manifests/rhods-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/rhods-operator.clusterserviceversion.yaml
@@ -1379,6 +1379,8 @@ spec:
                       fieldPath: metadata.namespace
                 - name: DEFAULT_MANIFESTS_PATH
                   value: /opt/manifests
+                # - name: ODH_PLATFORM_TYPE
+                #   value: SelfManagedRHOAI
                 image: REPLACE_IMAGE:latest
                 imagePullPolicy: Always
                 livenessProbe:

--- a/config/manifests/bases/rhods-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/rhods-operator.clusterserviceversion.yaml
@@ -165,6 +165,11 @@ spec:
         displayName: Conditions
         path: conditions
       version: v1
+    - description: FeastOperator is the Schema for the FeastOperator API
+      displayName: Feast Operator
+      kind: FeastOperator
+      name: feastoperators.components.platform.opendatahub.io
+      version: v1alpha1
     - description: Kserve is the Schema for the kserves API
       displayName: Kserve
       kind: Kserve

--- a/tests/e2e/authcontroller_test.go
+++ b/tests/e2e/authcontroller_test.go
@@ -102,20 +102,17 @@ func (tc *AuthControllerTestCtx) validateAuthCRDefaultContent() error {
 
 	switch tc.platform {
 	case cluster.SelfManagedRhoai:
-		if tc.testAuthInstance.Spec.AdminGroups[0] == "rhods-admins" {
-			return nil
+		if tc.testAuthInstance.Spec.AdminGroups[0] != "rhods-admins" {
+			return fmt.Errorf("expected rhods-admins, found %v", tc.testAuthInstance.Spec.AdminGroups[0])
 		}
-		return fmt.Errorf("expected rhods-admins, found %v", tc.testAuthInstance.Spec.AdminGroups[0])
 	case cluster.ManagedRhoai:
-		if tc.testAuthInstance.Spec.AdminGroups[0] == "dedicated-admins" {
-			return nil
+		if tc.testAuthInstance.Spec.AdminGroups[0] != "dedicated-admins" {
+			return fmt.Errorf("expected dedicated-admins, found %v", tc.testAuthInstance.Spec.AdminGroups[0])
 		}
-		return fmt.Errorf("expected dedicated-admins, found %v", tc.testAuthInstance.Spec.AdminGroups[0])
 	case cluster.OpenDataHub, cluster.Unknown:
-		if tc.testAuthInstance.Spec.AdminGroups[0] == "odh-admins" {
-			return nil
+		if tc.testAuthInstance.Spec.AdminGroups[0] != "odh-admins" {
+			return fmt.Errorf("expected odh-admins, found %v", tc.testAuthInstance.Spec.AdminGroups[0])
 		}
-		return fmt.Errorf("expected odh-admins, found %v", tc.testAuthInstance.Spec.AdminGroups[0])
 	}
 
 	if tc.testAuthInstance.Spec.AllowedGroups[0] != "system:authenticated" {

--- a/tests/e2e/authcontroller_test.go
+++ b/tests/e2e/authcontroller_test.go
@@ -129,12 +129,11 @@ func (tc *AuthControllerTestCtx) validateAuthCRRoleCreation() error {
 	adminRole := &rbacv1.Role{}
 	allowedRole := &rbacv1.Role{}
 
-	fmt.Print("this is the ns " + tc.testContext.applicationsNamespace)
-	if err := tc.testContext.customClient.Get(tc.ctx, types.NamespacedName{Namespace: tc.testContext.applicationsNamespace, Name: "admingroup-role"}, adminRole); err != nil {
+	if err := tc.testContext.customClient.Get(tc.ctx, types.NamespacedName{Namespace: tc.applicationsNamespace, Name: "admingroup-role"}, adminRole); err != nil {
 		return err
 	}
 
-	if err := tc.testContext.customClient.Get(tc.ctx, types.NamespacedName{Namespace: tc.testContext.applicationsNamespace, Name: "allowedgroup-role"}, allowedRole); err != nil {
+	if err := tc.testContext.customClient.Get(tc.ctx, types.NamespacedName{Namespace: tc.applicationsNamespace, Name: "allowedgroup-role"}, allowedRole); err != nil {
 		return err
 	}
 
@@ -144,7 +143,7 @@ func (tc *AuthControllerTestCtx) validateAuthCRRoleCreation() error {
 func (tc *AuthControllerTestCtx) validateAuthCRClusterRoleCreation() error {
 	adminClusterRole := &rbacv1.ClusterRole{}
 
-	if err := tc.testContext.customClient.Get(tc.ctx, types.NamespacedName{Name: "admingroupcluster-role"}, adminClusterRole); err != nil {
+	if err := tc.testContext.customClient.Get(tc.ctx, types.NamespacedName{Namespace: tc.applicationsNamespace, Name: "admingroupcluster-role"}, adminClusterRole); err != nil {
 		return err
 	}
 
@@ -155,8 +154,7 @@ func (tc *AuthControllerTestCtx) validateAuthCRRoleBindingCreation() error {
 	adminRolebinding := &rbacv1.RoleBinding{}
 	allowedRolebinding := &rbacv1.RoleBinding{}
 
-	if err := tc.testContext.customClient.Get(tc.ctx, types.NamespacedName{Namespace: tc.testContext.applicationsNamespace,
-		Name: "admingroup-rolebinding"}, adminRolebinding); err != nil {
+	if err := tc.testContext.customClient.Get(tc.ctx, types.NamespacedName{Namespace: tc.applicationsNamespace, Name: "admingroup-rolebinding"}, adminRolebinding); err != nil {
 		return err
 	}
 

--- a/tests/e2e/cfmap_deletion_test.go
+++ b/tests/e2e/cfmap_deletion_test.go
@@ -70,14 +70,14 @@ func (tc *testContext) testOwnedNamespacesAllExist(t *testing.T) {
 }
 
 func removeDeletionConfigMap(tc *testContext) {
-	_ = tc.kubeClient.CoreV1().ConfigMaps(tc.operatorNamespace).Delete(tc.ctx, deleteConfigMap, metav1.DeleteOptions{})
+	_ = tc.kubeClient.CoreV1().ConfigMaps(testOpts.operatorNamespace).Delete(tc.ctx, deleteConfigMap, metav1.DeleteOptions{})
 }
 
 func createDeletionConfigMap(tc *testContext, enableDeletion string) error {
 	configMap := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      deleteConfigMap,
-			Namespace: tc.operatorNamespace,
+			Namespace: testOpts.operatorNamespace,
 			Labels: map[string]string{
 				upgrade.DeleteConfigMapLabel: enableDeletion,
 			},

--- a/tests/e2e/controller_test.go
+++ b/tests/e2e/controller_test.go
@@ -35,7 +35,6 @@ import (
 	dsciv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/dscinitialization/v1"
 	featurev1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/features/v1"
 	serviceApi "github.com/opendatahub-io/opendatahub-operator/v2/apis/services/v1alpha1"
-	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
 )
 
 type TestFn func(t *testing.T)
@@ -135,7 +134,6 @@ func NewTestContext() (*testContext, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize custom client: %w", err)
 	}
-	release := cluster.GetRelease()
 	// setup DSCI CR since we do not create automatically by operator
 	testDSCI := setupDSCICR("e2e-test-dsci")
 	// Setup DataScienceCluster CR
@@ -149,7 +147,7 @@ func NewTestContext() (*testContext, error) {
 		ctx:                   context.TODO(),
 		testDsc:               testDSC,
 		testDSCI:              testDSCI,
-		platform:              release.Name,
+		platform:              testDSCI.Status.Release.Name,
 	}, nil
 }
 

--- a/tests/e2e/controller_test.go
+++ b/tests/e2e/controller_test.go
@@ -2,6 +2,7 @@ package e2e_test
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"os"
@@ -40,28 +41,36 @@ import (
 type TestFn func(t *testing.T)
 
 var (
-	testOpts testContextConfig
-	Scheme   = runtime.NewScheme()
+	Scheme = runtime.NewScheme()
 
-	componentsTestSuites = map[string]TestFn{
-		// do not add modelcontroller here, due to dependency, test it separately below
-		componentApi.DashboardComponentName:            dashboardTestSuite,
-		componentApi.RayComponentName:                  rayTestSuite,
-		componentApi.ModelRegistryComponentName:        modelRegistryTestSuite,
-		componentApi.TrustyAIComponentName:             trustyAITestSuite,
-		componentApi.KueueComponentName:                kueueTestSuite,
-		componentApi.TrainingOperatorComponentName:     trainingOperatorTestSuite,
-		componentApi.DataSciencePipelinesComponentName: dataSciencePipelinesTestSuite,
-		componentApi.CodeFlareComponentName:            codeflareTestSuite,
-		componentApi.WorkbenchesComponentName:          workbenchesTestSuite,
-		componentApi.KserveComponentName:               kserveTestSuite,
-		componentApi.ModelMeshServingComponentName:     modelMeshServingTestSuite,
-		componentApi.ModelControllerComponentName:      modelControllerTestSuite,
-	}
-
-	servicesTestSuites = map[string]TestFn{
-		serviceApi.MonitoringServiceName: monitoringTestSuite,
-		serviceApi.AuthServiceName:       authControllerTestSuite,
+	testOpts = testContextConfig{
+		components: TestGroup{
+			name:    "components",
+			enabled: true,
+			scenarios: map[string]TestFn{
+				// do not add modelcontroller here, due to dependency, test it separately below
+				componentApi.DashboardComponentName:            dashboardTestSuite,
+				componentApi.RayComponentName:                  rayTestSuite,
+				componentApi.ModelRegistryComponentName:        modelRegistryTestSuite,
+				componentApi.TrustyAIComponentName:             trustyAITestSuite,
+				componentApi.KueueComponentName:                kueueTestSuite,
+				componentApi.TrainingOperatorComponentName:     trainingOperatorTestSuite,
+				componentApi.DataSciencePipelinesComponentName: dataSciencePipelinesTestSuite,
+				componentApi.CodeFlareComponentName:            codeflareTestSuite,
+				componentApi.WorkbenchesComponentName:          workbenchesTestSuite,
+				componentApi.KserveComponentName:               kserveTestSuite,
+				componentApi.ModelMeshServingComponentName:     modelMeshServingTestSuite,
+				componentApi.ModelControllerComponentName:      modelControllerTestSuite,
+			},
+		},
+		services: TestGroup{
+			name:    "services",
+			enabled: true,
+			scenarios: map[string]TestFn{
+				serviceApi.MonitoringServiceName: monitoringTestSuite,
+				serviceApi.AuthServiceName:       authControllerTestSuite,
+			},
+		},
 	}
 )
 
@@ -82,8 +91,8 @@ type testContextConfig struct {
 
 	operatorControllerTest bool
 	webhookTest            bool
-	components             arrayFlags
-	services               arrayFlags
+	components             TestGroup
+	services               TestGroup
 }
 
 // Holds information specific to individual tests.
@@ -94,8 +103,6 @@ type testContext struct {
 	kubeClient *k8sclient.Clientset
 	// custom client for managing custom resources
 	customClient client.Client
-	// namespace of the operator
-	operatorNamespace string
 	// namespace of the deployed applications
 	applicationsNamespace string
 	// test DataScienceCluster instance
@@ -107,8 +114,6 @@ type testContext struct {
 	// context for accessing resources
 	//nolint:containedctx //reason: legacy v1 test setup
 	ctx context.Context
-	// test configuration
-	testOpts testContextConfig
 }
 
 func NewTestContext() (*testContext, error) {
@@ -130,7 +135,7 @@ func NewTestContext() (*testContext, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize custom client: %w", err)
 	}
-
+	release := cluster.GetRelease()
 	// setup DSCI CR since we do not create automatically by operator
 	testDSCI := setupDSCICR("e2e-test-dsci")
 	// Setup DataScienceCluster CR
@@ -140,13 +145,11 @@ func NewTestContext() (*testContext, error) {
 		cfg:                   config,
 		kubeClient:            kc,
 		customClient:          custClient,
-		operatorNamespace:     testOpts.operatorNamespace,
 		applicationsNamespace: testDSCI.Spec.ApplicationsNamespace,
 		ctx:                   context.TODO(),
 		testDsc:               testDSC,
 		testDSCI:              testDSCI,
-		platform:              cluster.SelfManagedRhoai,
-		testOpts:              testOpts,
+		platform:              release.Name,
 	}, nil
 }
 
@@ -181,27 +184,8 @@ func TestOdhOperator(t *testing.T) {
 	// Run create and delete tests for all the components
 	t.Run("create DSCI and DSC CRs", creationTestSuite)
 
-	t.Run("components", func(t *testing.T) {
-		for k, v := range componentsTestSuites {
-			if len(testOpts.components) != 0 && !slices.Contains(testOpts.components, k) {
-				t.Logf("Skipping tests for component %s", k)
-				continue
-			}
-
-			t.Run(k, v)
-		}
-	})
-
-	t.Run("services", func(t *testing.T) {
-		for k, v := range servicesTestSuites {
-			if len(testOpts.services) != 0 && !slices.Contains(testOpts.services, k) {
-				t.Logf("Skipping tests for services %s", k)
-				continue
-			}
-
-			t.Run(k, v)
-		}
-	})
+	t.Run(testOpts.components.String(), testOpts.components.Run)
+	t.Run(testOpts.services.String(), testOpts.services.Run)
 
 	// Run deletion if skipDeletion is not set
 	if !testOpts.skipDeletion {
@@ -222,26 +206,92 @@ func TestMain(m *testing.M) {
 	flag.BoolVar(&testOpts.operatorControllerTest, "test-operator-controller", true, "run operator controller tests")
 	flag.BoolVar(&testOpts.webhookTest, "test-webhook", true, "run webhook tests")
 
-	componentNames := strings.Join(maps.Keys(componentsTestSuites), ", ")
-	flag.Var(&testOpts.components, "test-component", "run tests for the specified component. valid components names are: "+componentNames)
+	componentNames := strings.Join(testOpts.components.Names(), ", ")
+	flag.BoolVar(&testOpts.components.enabled, "test-components", testOpts.components.enabled, "enable tests for components")
+	flag.Var(&testOpts.components.flags, "test-component", "run tests for the specified component. valid components names are: "+componentNames)
 
-	for _, n := range testOpts.components {
-		if _, ok := componentsTestSuites[n]; !ok {
-			fmt.Printf("test-component: unknown component %s, valid values are: %s", n, componentNames)
-			os.Exit(1)
-		}
+	serviceNames := strings.Join(testOpts.services.Names(), ", ")
+	flag.BoolVar(&testOpts.services.enabled, "test-services", testOpts.services.enabled, "enable tests for services")
+	flag.Var(&testOpts.services.flags, "test-service", "run tests for the specified service. valid service names are: "+serviceNames)
+
+	flag.Parse()
+
+	if err := testOpts.components.Validate(); err != nil {
+		fmt.Printf("test-component: %s", err.Error())
+		os.Exit(1)
 	}
 
-	serviceNames := strings.Join(maps.Keys(servicesTestSuites), ", ")
-	flag.Var(&testOpts.services, "test-service", "run tests for the specified service. valid service names are: "+serviceNames)
-
-	for _, n := range testOpts.components {
-		if _, ok := componentsTestSuites[n]; !ok {
-			fmt.Printf("test-service: unknown service %s, valid values are: %s", n, serviceNames)
-			os.Exit(1)
-		}
+	if err := testOpts.services.Validate(); err != nil {
+		fmt.Printf("test-service: %s", err.Error())
+		os.Exit(1)
 	}
 
 	flag.Parse()
 	os.Exit(m.Run())
+}
+
+type TestGroup struct {
+	name      string
+	enabled   bool
+	scenarios map[string]TestFn
+	flags     arrayFlags
+}
+
+func (tg *TestGroup) String() string {
+	return tg.name
+}
+
+func (tg *TestGroup) Names() []string {
+	return maps.Keys(tg.scenarios)
+}
+
+func (tg *TestGroup) Validate() error {
+	if tg.enabled == false && len(tg.flags) != 0 {
+		return errors.New("enabling individual scenarios is not supported when the entire group is disabled")
+	}
+
+	for _, n := range tg.flags {
+		n = strings.TrimLeft(n, "!")
+		if !slices.Contains(tg.Names(), n) {
+			validValues := strings.Join(testOpts.components.Names(), ", ")
+			return fmt.Errorf("unsupported value %s, valid values are: %s", n, validValues)
+		}
+	}
+
+	return nil
+}
+
+func (tg *TestGroup) Run(t *testing.T) {
+	if !tg.enabled {
+		t.Skipf("Test group %s is disabled", tg.name)
+		return
+	}
+
+	disabled := make([]string, 0)
+	enabled := make([]string, 0)
+
+	for _, n := range tg.flags {
+		if strings.HasPrefix(n, "!") {
+			disabled = append(disabled, strings.TrimLeft(n, "!"))
+		} else {
+			enabled = append(enabled, n)
+		}
+	}
+
+	if len(enabled) == 0 {
+		enabled = maps.Keys(tg.scenarios)
+	}
+
+	enabled = slices.DeleteFunc(enabled, func(n string) bool {
+		return slices.Contains(disabled, n)
+	})
+
+	for k, v := range tg.scenarios {
+		if !slices.Contains(enabled, k) {
+			t.Logf("Skipping tests for %s/%s", tg.name, k)
+			continue
+		}
+
+		t.Run(k, v)
+	}
 }

--- a/tests/e2e/creation_test.go
+++ b/tests/e2e/creation_test.go
@@ -37,7 +37,7 @@ func creationTestSuite(t *testing.T) {
 			err = testCtx.testDSCICreation()
 			require.NoError(t, err, "error creating DSCI CR")
 		})
-		if testCtx.testOpts.webhookTest {
+		if testOpts.webhookTest {
 			t.Run("Creation of more than one of DSCInitialization instance", func(t *testing.T) {
 				testCtx.testDSCIDuplication(t)
 			})
@@ -55,7 +55,7 @@ func creationTestSuite(t *testing.T) {
 			err = testCtx.testDSCCreation(t)
 			require.NoError(t, err, "error creating DataScienceCluster instance")
 		})
-		if testCtx.testOpts.webhookTest {
+		if testOpts.webhookTest {
 			t.Run("Creation of more than one of DataScienceCluster instance", func(t *testing.T) {
 				testCtx.testDSCDuplication(t)
 			})
@@ -68,7 +68,7 @@ func creationTestSuite(t *testing.T) {
 		})
 
 		// ModelReg
-		if testCtx.testOpts.webhookTest {
+		if testOpts.webhookTest {
 			t.Run("Validate model registry config", func(t *testing.T) {
 				err = testCtx.validateModelRegistryConfig()
 				require.NoError(t, err, "error validating ModelRegistry config")

--- a/tests/e2e/helper_test.go
+++ b/tests/e2e/helper_test.go
@@ -53,7 +53,7 @@ const (
 
 func (tc *testContext) waitForOperatorDeployment(name string, replicas int32) error {
 	err := wait.PollUntilContextTimeout(tc.ctx, generalRetryInterval, operatorReadyTimeout, false, func(ctx context.Context) (bool, error) {
-		controllerDeployment, err := tc.kubeClient.AppsV1().Deployments(tc.operatorNamespace).Get(ctx, name, metav1.GetOptions{})
+		controllerDeployment, err := tc.kubeClient.AppsV1().Deployments(testOpts.operatorNamespace).Get(ctx, name, metav1.GetOptions{})
 		if err != nil {
 			if k8serr.IsNotFound(err) {
 				return false, nil


### PR DESCRIPTION
* Improve e2e test configurability

This feature is to improve the configurability of the e2e test suite, which is particularly useful when running the test suite locally.

There are two new flags to globally enabled/disable some test grouops such as components and services:

* --test-components=true|false
* --test-services=true|false

It is also possible to disable a particular test by preceding its name with an exlamation mark (!), i.e. to run only the test for the dashbaord component and skip the tests for the auth service:

  make e2e-test E2E_TEST_FLAGS='--test-component=dashboard --test-service=!auth'

* Fix validation logic

(cherry picked from commit 39da6211f97e8eb98552fb8c2f9da7137620ad12)

<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->
sync https://github.com/opendatahub-io/opendatahub-operator/pull/1650

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
