### PR TITLE
Refactor and Optimize E2E Tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,17 +409,19 @@ make e2e-test
 Additional flags that can be passed to e2e-tests by setting up `E2E_TEST_FLAGS`
 variable. Following table lists all the available flags to run the tests:
 
-| Flag                       | Description                                                                                                                                                                   | Default value |
-|----------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------|
-| --skip-deletion            | To skip running  of `dsc-deletion` test that includes deleting `DataScienceCluster` resources. Assign this variable to `true` to skip DataScienceCluster deletion.            | false         |
-| --test-operator-controller | To configure the execution of tests related to the Operator POD, this is useful to run e2e tests for an operator running out of the cluster i.e. for debugging purposes       | true          |
-| --test-webhook             | To configure the execution of tests rellated to the Operator WebHooks, this is useful to run e2e tests for an operator running out of the cluster i.e. for debugging purposes | true          |
-| --test-component           | A repeatable flag that control what component should be tested, by default all component specific test are executed                                                           | true          |
+| Flag                       | Description                                                                                                                                                                   | Default value                 |
+|----------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------|
+| --operator-namespace       | Namespace where the ODH operator is deployed.                                                                                                                                 | `opendatahub-operator-system` |
+| --applications-namespace   | Namespace where the ODH applications are deployed.                                                                                                                            | `opendatahub`                 |
+| --test-operator-controller | To configure the execution of tests related to the Operator POD, this is useful to run e2e tests for an operator running out of the cluster i.e. for debugging purposes       | `true`                        |
+| --test-webhook             | To configure the execution of tests rellated to the Operator WebHooks, this is useful to run e2e tests for an operator running out of the cluster i.e. for debugging purposes | `true`                        |
+| --test-component           | A repeatable flag that control what component should be tested, by default all component specific test are executed                                                           | `true`                        |
+| --deletion-policy          | Specify when to delete `DataScienceCluster`, `DSCInitialization`, and controllers. Valid options are: `always`, `on-failure`, and `never`. The default is never.              | `always`                      |
 
 Example command to run full test suite skipping the test for DataScienceCluster deletion.
 
 ```shell
-make e2e-test OPERATOR_NAMESPACE=<namespace> E2E_TEST_FLAGS="--skip-deletion=true"
+make e2e-test OPERATOR_NAMESPACE=<namespace> E2E_TEST_FLAGS="--deletion-policy=never"
 ```
 
 Example commands to run test suite for the dashboard `component` only, with the operator running out of the cluster.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -73,7 +73,7 @@ IMAGE_TAG_BASE=quay.io/my-dev-env/opendatahub-operator
 IMG_TAG=my-dev-tag
 OPERATOR_NAMESPACE=my-dev-odh-operator-system
 IMAGE_BUILD_FLAGS=--build-arg USE_LOCAL=true
-E2E_TEST_FLAGS="--skip-deletion=true" -timeout 15m
+E2E_TEST_FLAGS="--deletion-policy=never" -timeout 15m
 DEFAULT_MANIFESTS_PATH=./opt/manifests
 PLATFORM=linux/amd64,linux/ppc64le,linux/s390x
 ```

--- a/pkg/cluster/gvk/gvk.go
+++ b/pkg/cluster/gvk/gvk.go
@@ -1,6 +1,10 @@
 package gvk
 
 import (
+	configv1 "github.com/openshift/api/config/v1"
+	operatorsv1 "github.com/operator-framework/api/pkg/operators/v1"
+	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	coordinationv1 "k8s.io/api/coordination/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -8,27 +12,61 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/api/components/v1alpha1"
+	dscv1 "github.com/opendatahub-io/opendatahub-operator/v2/api/datasciencecluster/v1"
+	dsciv1 "github.com/opendatahub-io/opendatahub-operator/v2/api/dscinitialization/v1"
 	featuresv1 "github.com/opendatahub-io/opendatahub-operator/v2/api/features/v1"
 	serviceApi "github.com/opendatahub-io/opendatahub-operator/v2/api/services/v1alpha1"
 )
 
 var (
+	Namespace = schema.GroupVersionKind{
+		Group:   "",
+		Version: "v1",
+		Kind:    "Namespace",
+	}
+
+	OperatorGroup = schema.GroupVersionKind{
+		Group:   operatorsv1.SchemeGroupVersion.Group,
+		Version: operatorsv1.SchemeGroupVersion.Version,
+		Kind:    "OperatorGroup",
+	}
+
+	Subscription = schema.GroupVersionKind{
+		Group:   operatorsv1alpha1.SchemeGroupVersion.Group,
+		Version: operatorsv1alpha1.SchemeGroupVersion.Version,
+		Kind:    operatorsv1alpha1.SubscriptionKind,
+	}
+
+	InstallPlan = schema.GroupVersionKind{
+		Group:   operatorsv1alpha1.SchemeGroupVersion.Group,
+		Version: operatorsv1alpha1.SchemeGroupVersion.Version,
+		Kind:    operatorsv1alpha1.InstallPlanKind,
+	}
+
 	ClusterServiceVersion = schema.GroupVersionKind{
-		Group:   "operators.coreos.com",
-		Version: "v1alpha1",
-		Kind:    "ClusterServiceVersion",
+		Group:   operatorsv1alpha1.SchemeGroupVersion.Group,
+		Version: operatorsv1alpha1.SchemeGroupVersion.Version,
+		Kind:    operatorsv1alpha1.ClusterServiceVersionKind,
+	}
+
+	ClusterVersion = schema.GroupVersionKind{
+		Group:   configv1.SchemeGroupVersion.Group,
+		Version: configv1.SchemeGroupVersion.Version,
+		Kind:    "ClusterVersion",
 	}
 
 	DataScienceCluster = schema.GroupVersionKind{
-		Group:   "datasciencecluster.opendatahub.io",
-		Version: "v1",
+		Group:   dscv1.GroupVersion.Group,
+		Version: dscv1.GroupVersion.Version,
 		Kind:    "DataScienceCluster",
 	}
+
 	DSCInitialization = schema.GroupVersionKind{
-		Group:   "dscinitialization.opendatahub.io",
-		Version: "v1",
+		Group:   dsciv1.GroupVersion.Group,
+		Version: dsciv1.GroupVersion.Version,
 		Kind:    "DSCInitialization",
 	}
+
 	FeatureTracker = schema.GroupVersionKind{
 		Group:   featuresv1.GroupVersion.Group,
 		Version: featuresv1.GroupVersion.Version,
@@ -48,9 +86,21 @@ var (
 	}
 
 	ClusterRole = schema.GroupVersionKind{
-		Group:   "rbac.authorization.k8s.io",
-		Version: "v1",
+		Group:   rbacv1.SchemeGroupVersion.Group,
+		Version: rbacv1.SchemeGroupVersion.Version,
 		Kind:    "ClusterRole",
+	}
+
+	ClusterRoleBinding = schema.GroupVersionKind{
+		Group:   rbacv1.SchemeGroupVersion.Group,
+		Version: rbacv1.SchemeGroupVersion.Version,
+		Kind:    "ClusterRoleBinding",
+	}
+
+	Role = schema.GroupVersionKind{
+		Group:   rbacv1.SchemeGroupVersion.Group,
+		Version: rbacv1.SchemeGroupVersion.Version,
+		Kind:    "Role",
 	}
 
 	RoleBinding = schema.GroupVersionKind{
@@ -246,20 +296,20 @@ var (
 	}
 
 	Auth = schema.GroupVersionKind{
-		Group:   "services.platform.opendatahub.io",
-		Version: "v1alpha1",
-		Kind:    "Auth",
+		Group:   serviceApi.GroupVersion.Group,
+		Version: serviceApi.GroupVersion.Version,
+		Kind:    serviceApi.AuthKind,
 	}
 
 	ValidatingAdmissionPolicy = schema.GroupVersionKind{
-		Group:   "admissionregistration.k8s.io",
-		Version: "v1",
+		Group:   admissionregistrationv1.SchemeGroupVersion.Group,
+		Version: admissionregistrationv1.SchemeGroupVersion.Version,
 		Kind:    "ValidatingAdmissionPolicy",
 	}
 
 	ValidatingAdmissionPolicyBinding = schema.GroupVersionKind{
-		Group:   "admissionregistration.k8s.io",
-		Version: "v1",
+		Group:   admissionregistrationv1.SchemeGroupVersion.Group,
+		Version: admissionregistrationv1.SchemeGroupVersion.Version,
 		Kind:    "ValidatingAdmissionPolicyBinding",
 	}
 

--- a/pkg/controller/reconciler/reconciler_actions_test.go
+++ b/pkg/controller/reconciler/reconciler_actions_test.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"testing"
 
-	gomegaTypes "github.com/onsi/gomega/types"
+	gTypes "github.com/onsi/gomega/types"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/rs/xid"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -27,9 +27,9 @@ func TestDynamicWatchAction_Run(t *testing.T) {
 		name       string
 		object     common.PlatformObject
 		preds      []DynamicPredicate
-		errMatcher gomegaTypes.GomegaMatcher
-		cntMatcher gomegaTypes.GomegaMatcher
-		keyMatcher gomegaTypes.GomegaMatcher
+		errMatcher gTypes.GomegaMatcher
+		cntMatcher gTypes.GomegaMatcher
+		keyMatcher gTypes.GomegaMatcher
 	}{
 		{
 			name:       "should register a watcher if no predicates",

--- a/pkg/resources/resources.go
+++ b/pkg/resources/resources.go
@@ -38,6 +38,55 @@ func ToUnstructured(obj any) (*unstructured.Unstructured, error) {
 	return &u, nil
 }
 
+func FromUnstructured(obj *unstructured.Unstructured, intoObj any) error {
+	if obj == nil {
+		return errors.New("nil object")
+	}
+
+	err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.Object, intoObj)
+	if err != nil {
+		return fmt.Errorf("unable to convert unstructured object to %T: %w", intoObj, err)
+	}
+	return nil
+}
+
+func ObjectToUnstructured(s *runtime.Scheme, obj client.Object) (*unstructured.Unstructured, error) {
+	// Ensure that the object has a GroupVersionKind set
+	if err := EnsureGroupVersionKind(s, obj); err != nil {
+		return nil, fmt.Errorf("failed to ensure GroupVersionKind: %w", err)
+	}
+
+	// Now, convert the object to unstructured
+	u, err := ToUnstructured(obj)
+	if err != nil {
+		return nil, err
+	}
+
+	return u, nil
+}
+
+func ObjectFromUnstructured(s *runtime.Scheme, obj *unstructured.Unstructured, intoObj client.Object) error {
+	// Convert the unstructured object to the typed object
+	err := FromUnstructured(obj, intoObj)
+	if err != nil {
+		return fmt.Errorf("unable to convert unstructured object to %T: %w", intoObj, err)
+	}
+
+	// Ensure that the GroupVersionKind is correctly set on the target object
+	err = EnsureGroupVersionKind(s, intoObj)
+	if err != nil {
+		return fmt.Errorf("unable to ensure GroupVersionKind: %w", err)
+	}
+
+	// Validate that the GroupVersionKind is known in the scheme
+	gvk := intoObj.GetObjectKind().GroupVersionKind()
+	if _, err := s.New(gvk); err != nil {
+		return fmt.Errorf("unable to create object for GVK %s: %w", gvk, err)
+	}
+
+	return nil
+}
+
 func Decode(decoder runtime.Decoder, content []byte) ([]unstructured.Unstructured, error) {
 	results := make([]unstructured.Unstructured, 0)
 
@@ -338,6 +387,20 @@ func NamespacedNameFromObject(obj client.Object) types.NamespacedName {
 		Namespace: obj.GetNamespace(),
 		Name:      obj.GetName(),
 	}
+}
+
+func FormatNamespacedName(nn types.NamespacedName) string {
+	if nn.Namespace == "" {
+		return nn.Name
+	}
+	return nn.String()
+}
+
+func FormatUnstructuredName(obj *unstructured.Unstructured) string {
+	if obj.GetNamespace() == "" {
+		return obj.GetName()
+	}
+	return obj.GetNamespace() + string(types.Separator) + obj.GetName()
 }
 
 // RemoveOwnerReferences removes all owner references from a Kubernetes object that match the provided predicate.

--- a/pkg/utils/test/testf/testf_support.go
+++ b/pkg/utils/test/testf/testf_support.go
@@ -6,6 +6,7 @@ import (
 	"github.com/itchyny/gojq"
 	"github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 )
 
 // StopErr stops the retry process with a specified message and wraps the provided error.
@@ -99,6 +100,35 @@ func Transform(format string, args ...any) TransformFn {
 		}
 
 		in.SetUnstructuredContent(uc)
+
+		return nil
+	}
+}
+
+// TransformSpecToUnstructured creates a transformation function that converts a Go struct
+// representing a Kubernetes resource spec into an unstructured format and applies it to
+// the spec field of an unstructured Kubernetes object (`unstructured.Unstructured`).
+//
+// This function generates a transformation function that, when applied to an `*unstructured.Unstructured`
+// object, will set its `spec` field to the unstructured representation of the provided struct.
+//
+// Parameters:
+//   - spec: A Go struct representing the spec of a Kubernetes resource (e.g., SubscriptionSpec, PodSpec).
+//     This struct will be converted into an unstructured format and applied to the `spec` field.
+//
+// Returns:
+//   - func(*unstructured.Unstructured) error: A function that applies the unstructured spec data
+//     to the provided `*unstructured.Unstructured` object. If the conversion or update fails, an error is returned.
+func TransformSpecToUnstructured(spec interface{}) TransformFn {
+	return func(in *unstructured.Unstructured) error {
+		// Convert the spec to unstructured format
+		specData, err := runtime.DefaultUnstructuredConverter.ToUnstructured(spec)
+		if err != nil {
+			return fmt.Errorf("failed to convert spec to unstructured: %w", err)
+		}
+
+		// Set the spec in the unstructured object
+		in.Object["spec"] = specData
 
 		return nil
 	}

--- a/pkg/utils/test/testf/testf_witht.go
+++ b/pkg/utils/test/testf/testf_witht.go
@@ -11,11 +11,23 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	odhClient "github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/client"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/resources"
 )
 
+// WithT encapsulates the test context and the Kubernetes client, along with gomega's assertion methods.
+// It provides utility methods to interact with resources in a Kubernetes cluster and perform assertions on them.
+type WithT struct {
+	ctx    context.Context
+	client *odhClient.Client
+
+	*gomega.WithT
+}
+
+// WithTOpts is a function type used to configure options for the WithT object.
+// These options modify the behavior of the tests, such as timeouts and polling intervals.
 type WithTOpts func(*WithT)
 
 func WithFailHandler(value gomegaTypes.GomegaFailHandler) WithTOpts {
@@ -24,45 +36,84 @@ func WithFailHandler(value gomegaTypes.GomegaFailHandler) WithTOpts {
 	}
 }
 
+// WithEventuallyTimeout sets the default timeout for Eventually assertions.
+//
+// Parameters:
+//   - value (time.Duration): The timeout duration for Eventually assertions.
+//
+// Returns:
+//   - WithTOpts: A function that applies the timeout configuration to a WithT instance.
 func WithEventuallyTimeout(value time.Duration) WithTOpts {
 	return func(g *WithT) {
 		g.SetDefaultEventuallyTimeout(value)
 	}
 }
 
+// WithEventuallyPollingInterval sets the default polling interval for Eventually assertions.
+//
+// Parameters:
+//   - value (time.Duration): The polling interval for Eventually assertions.
+//
+// Returns:
+//   - WithTOpts: A function that applies the polling interval configuration to a WithT instance.
 func WithEventuallyPollingInterval(value time.Duration) WithTOpts {
 	return func(g *WithT) {
 		g.SetDefaultEventuallyPollingInterval(value)
 	}
 }
 
+// WithConsistentlyDuration sets the default duration for Consistently assertions.
+//
+// Parameters:
+//   - value (time.Duration): The duration for Consistently assertions.
+//
+// Returns:
+//   - WithTOpts: A function that applies the duration configuration to a WithT instance.
 func WithConsistentlyDuration(value time.Duration) WithTOpts {
 	return func(g *WithT) {
 		g.SetDefaultConsistentlyDuration(value)
 	}
 }
 
+// WithConsistentlyPollingInterval sets the default polling interval for Consistently assertions.
+//
+// Parameters:
+//   - value (time.Duration): The polling interval for Consistently assertions.
+//
+// Returns:
+//   - WithTOpts: A function that applies the polling interval configuration to a WithT instance.
 func WithConsistentlyPollingInterval(value time.Duration) WithTOpts {
 	return func(g *WithT) {
 		g.SetDefaultConsistentlyPollingInterval(value)
 	}
 }
 
-type WithT struct {
-	ctx    context.Context
-	client *odhClient.Client
-
-	*gomega.WithT
-}
-
+// Context returns the current context associated with the test, used for resource operations.
+//
+// Returns:
+//   - context.Context: The current context for the test, which can be used for Kubernetes operations.
 func (t *WithT) Context() context.Context {
 	return t.ctx
 }
 
+// Client returns the `odhClient.Client` used to interact with the cluster for resource operations.
+//
+// Returns:
+//   - *odhClient.Client: The Kubernetes client used for performing operations on the cluster.
 func (t *WithT) Client() *odhClient.Client {
 	return t.client
 }
 
+// List performs a `kubectl get` operation to list resources of the specified GroupVersionKind.
+// It returns the list of resources wrapped in an EventuallyValue to be used with Gomega assertions.
+//
+// Parameters:
+//   - gvk (schema.GroupVersionKind): The GroupVersionKind of the resources to list.
+//   - option (...client.ListOption): Optional options to modify the list operation.
+//
+// Returns:
+//   - *EventuallyValue[[]unstructured.Unstructured]: The eventually available list of resources wrapped in an EventuallyValue,
+//     which can be used with Gomega assertions to test the list result.
 func (t *WithT) List(
 	gvk schema.GroupVersionKind,
 	option ...client.ListOption,
@@ -84,6 +135,17 @@ func (t *WithT) List(
 	}
 }
 
+// Get performs a `kubectl get` operation for the specified resource and returns the resource wrapped in an EventuallyValue.
+// The result can be used in Gomega assertions to test the resource's existence and state.
+//
+// Parameters:
+//   - gvk (schema.GroupVersionKind): The GroupVersionKind of the resource to get.
+//   - nn (types.NamespacedName): The namespace and name of the resource to get.
+//   - option (...client.GetOption): Optional options for the get operation.
+//
+// Returns:
+//   - *EventuallyValue[*unstructured.Unstructured]: The eventually available resource wrapped in an EventuallyValue,
+//     which can be used with Gomega assertions to test the resource's state.
 func (t *WithT) Get(
 	gvk schema.GroupVersionKind,
 	nn types.NamespacedName,
@@ -109,6 +171,200 @@ func (t *WithT) Get(
 	}
 }
 
+// Create performs a `kubectl create` operation to create the specified Kubernetes resource.
+// It returns an EventuallyValue that wraps the created resource, which can be used with Gomega assertions.
+//
+// Parameters:
+//   - obj (*unstructured.Unstructured): The resource to create. It must have the appropriate GroupVersionKind,
+//     name, and namespace set in its metadata.
+//   - nn (types.NamespacedName): The namespace and name of the resource. This should match the metadata in `obj`.
+//   - option (...client.CreateOption): Optional client options for the create operation.
+//
+// Returns:
+//   - *EventuallyValue[*unstructured.Unstructured]: The eventually available created resource, wrapped in an EventuallyValue,
+//     which can be used with Gomega assertions to test the created resource.
+func (t *WithT) Create(
+	obj *unstructured.Unstructured,
+	nn types.NamespacedName,
+	option ...client.CreateOption,
+) *EventuallyValue[*unstructured.Unstructured] {
+	return &EventuallyValue[*unstructured.Unstructured]{
+		ctx: t.Context(),
+		g:   t.WithT,
+		f: func(ctx context.Context) (*unstructured.Unstructured, error) {
+			err := t.Client().Create(ctx, obj, option...)
+			if err != nil {
+				return nil, StopErr(err, "failed to create resource: %s, nn: %s", obj.GetObjectKind().GroupVersionKind(), nn.String())
+			}
+
+			return obj, nil
+		},
+	}
+}
+
+// CreateOrUpdate ensures the specified resource exists by either creating it if it does not exist,
+// or updating it if it already exists. This method applies the provided mutation function to modify
+// the resource before creating or updating it. The function wraps `controllerutil.CreateOrUpdate`,
+// ensuring that the resource is created or updated atomically.
+//
+// Parameters:
+//   - gvk (schema.GroupVersionKind): The GroupVersionKind of the resource.
+//   - nn (types.NamespacedName): The namespace and name of the resource to be operated on.
+//   - fn (func): An optional function that applies a mutation to the resource before creation or update.
+//     If omitted, the resource is created or updated without modification.
+//
+// Returns:
+//   - *EventuallyValue[*unstructured.Unstructured]: The eventually available resource after being created or updated,
+//     wrapped for use with Gomega assertions.
+func (t *WithT) CreateOrUpdate(
+	obj *unstructured.Unstructured,
+	fn ...func(obj *unstructured.Unstructured) error,
+) *EventuallyValue[*unstructured.Unstructured] {
+	return &EventuallyValue[*unstructured.Unstructured]{
+		ctx: t.Context(),
+		g:   t.WithT,
+		f: func(ctx context.Context) (*unstructured.Unstructured, error) {
+			// Use the provided fn or a default no-op if fn is not provided
+			mutationFn := func() error {
+				if len(fn) > 0 && fn[0] != nil {
+					return fn[0](obj) // Use the provided mutation function
+				}
+				return nil // Default no-op function if fn is omitted
+			}
+
+			_, err := controllerutil.CreateOrUpdate(ctx, t.Client(), obj, mutationFn)
+
+			switch {
+			case errors.IsForbidden(err):
+				return nil, StopErr(
+					err,
+					"failed to create or update resource: %s, nn: %s",
+					obj.GetObjectKind().GroupVersionKind(),
+					obj.GetNamespace(),
+				)
+			case err != nil:
+				return nil, err
+			default:
+				return obj, nil
+			}
+		},
+	}
+}
+
+// CreateOrPatch ensures the specified resource exists by either creating it if it does not exist,
+// or applying a patch if the resource already exists. This function uses the
+// `controllerutil.CreateOrPatch` method to handle the creation and patching operations atomically.
+//
+// Parameters:
+//   - gvk (schema.GroupVersionKind): The GroupVersionKind of the resource to be operated on.
+//   - nn (types.NamespacedName): The namespace and name of the resource to be created or patched.
+//   - fn (func): A function that modifies the resource before creating or patching it.
+//
+// Returns:
+//   - *EventuallyValue[*unstructured.Unstructured]: The eventually available resource after being created or patched.
+func (t *WithT) CreateOrPatch(
+	obj *unstructured.Unstructured,
+	fn ...func(obj *unstructured.Unstructured) error,
+) *EventuallyValue[*unstructured.Unstructured] {
+	return &EventuallyValue[*unstructured.Unstructured]{
+		ctx: t.Context(),
+		g:   t.WithT,
+		f: func(ctx context.Context) (*unstructured.Unstructured, error) {
+			// Use the provided fn or a default no-op if fn is not provided
+			mutationFn := func() error {
+				// Remove status fields that should not be modified directly
+				unstructured.RemoveNestedField(obj.Object, "status")
+
+				if len(fn) > 0 && fn[0] != nil {
+					return fn[0](obj) // Use the provided mutation function
+				}
+
+				return nil // Default no-op function if fn is omitted
+			}
+
+			_, err := controllerutil.CreateOrPatch(ctx, t.Client(), obj, mutationFn)
+
+			// Check for errors
+			switch {
+			case err != nil:
+				return nil, StopErr(
+					err,
+					"failed to create or patch resource: %s, nn: %s",
+					obj.GetObjectKind().GroupVersionKind(),
+					obj.GetNamespace(),
+				)
+			default:
+				return obj, nil // Successfully created or patched
+			}
+		},
+	}
+}
+
+// Update performs a `kubectl update` operation on the specified resource, applying a function to mutate the resource
+// before updating. The result is wrapped in an EventuallyValue, which can be used in Gomega assertions.
+//
+// Parameters:
+//   - gvk (schema.GroupVersionKind): The GroupVersionKind of the resource to update.
+//   - nn (types.NamespacedName): The namespace and name of the resource to update.
+//   - fn (func): A function that modifies the resource before updating.
+//   - option (...client.UpdateOption): Optional options for the update operation.
+//
+// Returns:
+//   - *EventuallyValue[*unstructured.Unstructured]: The eventually available resource wrapped in an EventuallyValue,
+//     which can be used with Gomega assertions to test the updated resource.
+func (t *WithT) Update(
+	gvk schema.GroupVersionKind,
+	nn types.NamespacedName,
+	fn func(obj *unstructured.Unstructured) error,
+	option ...client.UpdateOption,
+) *EventuallyValue[*unstructured.Unstructured] {
+	return &EventuallyValue[*unstructured.Unstructured]{
+		ctx: t.Context(),
+		g:   t.WithT,
+		f: func(ctx context.Context) (*unstructured.Unstructured, error) {
+			u := resources.GvkToUnstructured(gvk)
+
+			err := t.Client().Get(ctx, nn, u)
+			switch {
+			case errors.IsNotFound(err):
+				return nil, nil
+			case err != nil:
+				return nil, StopErr(err, "failed to get resource: %s, nn: %s", gvk, nn.String())
+			}
+
+			in, err := resources.ToUnstructured(u)
+			if err != nil {
+				return nil, StopErr(err, "failed to convert to unstructured")
+			}
+
+			if err := fn(in); err != nil {
+				return nil, StopErr(err, "failed to apply function")
+			}
+
+			err = t.Client().Update(ctx, in, option...)
+			switch {
+			case errors.IsForbidden(err):
+				return nil, StopErr(err, "failed to update resource: %s, nn: %s", gvk, nn.String())
+			case err != nil:
+				return nil, err
+			default:
+				return in, nil
+			}
+		},
+	}
+}
+
+// Delete performs a `kubectl delete` operation on the specified resource.
+// It returns an EventuallyErr, which can be used in Gomega assertions to check for the deletion's success or failure.
+//
+// Parameters:
+//   - gvk (schema.GroupVersionKind): The GroupVersionKind of the resource to delete.
+//   - nn (types.NamespacedName): The namespace and name of the resource to delete.
+//   - option (...client.DeleteOption): Optional options for the delete operation.
+//
+// Returns:
+//   - *EventuallyErr: The eventually available result of the delete operation, wrapped in an EventuallyErr,
+//     which can be used with Gomega assertions to test the deletion result.
 func (t *WithT) Delete(
 	gvk schema.GroupVersionKind,
 	nn types.NamespacedName,
@@ -130,48 +386,6 @@ func (t *WithT) Delete(
 				return StopErr(err, "failed to delete resource: %s, nn: %s", gvk, nn.String())
 			default:
 				return nil
-			}
-		},
-	}
-}
-
-func (t *WithT) Update(
-	gvk schema.GroupVersionKind,
-	nn types.NamespacedName,
-	fn func(obj *unstructured.Unstructured) error,
-	option ...client.UpdateOption,
-) *EventuallyValue[*unstructured.Unstructured] {
-	return &EventuallyValue[*unstructured.Unstructured]{
-		ctx: t.Context(),
-		g:   t.WithT,
-		f: func(ctx context.Context) (*unstructured.Unstructured, error) {
-			obj := resources.GvkToUnstructured(gvk)
-
-			err := t.Client().Get(ctx, nn, obj)
-			switch {
-			case errors.IsNotFound(err):
-				return nil, nil
-			case err != nil:
-				return nil, StopErr(err, "failed to get resource: %s, nn: %s", gvk, nn.String())
-			}
-
-			in, err := resources.ToUnstructured(obj)
-			if err != nil {
-				return nil, StopErr(err, "failed to convert to unstructured")
-			}
-
-			if err := fn(in); err != nil {
-				return nil, StopErr(err, "failed to apply function")
-			}
-
-			err = t.Client().Update(ctx, in, option...)
-			switch {
-			case errors.IsForbidden(err):
-				return nil, StopErr(err, "failed to update resource: %s, nn: %s", gvk, nn.String())
-			case err != nil:
-				return nil, err
-			default:
-				return in, nil
 			}
 		},
 	}

--- a/tests/e2e/authcontroller_test.go
+++ b/tests/e2e/authcontroller_test.go
@@ -1,245 +1,229 @@
 package e2e_test
 
 import (
-	"errors"
-	"fmt"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
-	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	serviceApi "github.com/opendatahub-io/opendatahub-operator/v2/api/services/v1alpha1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/matchers/jq"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/testf"
 
 	. "github.com/onsi/gomega"
 )
 
+const (
+	// Default admin group names for different platforms.
+	rhodsAdminsName = "rhods-admins"
+	odhAdminsName   = "odh-admins"
+
+	// Role names used for RBAC configuration.
+	adminGroupRoleName   = "admingroup-role"
+	allowedGroupRoleName = "allowedgroup-role"
+
+	// RoleBinding names to bind roles to specific groups.
+	adminGroupRoleBindingName   = "admingroup-rolebinding"
+	allowedGroupRoleBindingName = "allowedgroup-rolebinding"
+
+	// ClusterRole and ClusterRoleBinding names for admin group access at cluster level.
+	adminGroupClusterRoleName        = "admingroupcluster-role"
+	adminGroupClusterRoleBindingName = "admingroupcluster-rolebinding"
+)
+
 type AuthControllerTestCtx struct {
-	*testContext
-	testAuthInstance serviceApi.Auth
+	*TestContext
+	AuthNamespacedName types.NamespacedName
 }
 
 func authControllerTestSuite(t *testing.T) {
 	t.Helper()
 
-	tc, err := NewTestContext()
-	require.NoError(t, err)
+	// Initialize the test context.
+	tc, err := NewTestContext(t)
+	require.NoError(t, err, "Failed to initialize test context")
 
-	authServiceCtx := AuthControllerTestCtx{
-		testContext: tc,
+	// Create an instance of test context.
+	authCtx := AuthControllerTestCtx{
+		TestContext: tc,
+		AuthNamespacedName: types.NamespacedName{
+			Name:      serviceApi.AuthInstanceName,
+			Namespace: tc.AppsNamespace,
+		},
 	}
 
-	t.Run(tc.testDsc.Name, func(t *testing.T) {
-		t.Run("Auto creation of Auth CR", func(t *testing.T) {
-			err = authServiceCtx.validateAuthCRCreation()
-			require.NoError(t, err, "error getting Auth CR")
-		})
-		t.Run("Test Auth CR content", func(t *testing.T) {
-			err = authServiceCtx.validateAuthCRDefaultContent()
-			require.NoError(t, err, "unexpected content in Auth CR")
-		})
-		t.Run("Test role creation", func(t *testing.T) {
-			err = authServiceCtx.validateAuthCRRoleCreation()
-			require.NoError(t, err, "error getting created roles")
-		})
-		t.Run("Test rolebinding creation", func(t *testing.T) {
-			err = authServiceCtx.validateAuthCRRoleBindingCreation()
-			require.NoError(t, err, "error getting created rolebindings")
-		})
-		t.Run("Test rolebinding is added when group is added", func(t *testing.T) {
-			err = authServiceCtx.validateAddingGroups()
-			require.NoError(t, err, "error getting created rolebindings")
-		})
-		t.Run("Test clusterrole is added when group is added", func(t *testing.T) {
-			err = authServiceCtx.validateAuthCRClusterRoleCreation()
-			require.NoError(t, err, "error getting created rolebindings")
-		})
-		t.Run("Test clusterrolebinding is added when group is added", func(t *testing.T) {
-			err = authServiceCtx.validateAuthCRClusterRoleBindingCreation()
-			require.NoError(t, err, "error getting created rolebindings")
-		})
-		t.Run("Test bindings are removed when a group is removed", func(t *testing.T) {
-			err = authServiceCtx.validateRemovingGroups()
-			require.NoError(t, err, "error validating group removal")
-		})
-	})
+	// Define test cases.
+	testCases := []TestCase{
+		{"Validate Auth CR creation", authCtx.ValidateAuthCRCreation},
+		{"Validate Auth CR default content", authCtx.ValidateAuthCRDefaultContent},
+		{"Validate Auth Role creation", authCtx.ValidateAuthCRRoleCreation},
+		{"Validate Auth RoleBinding creation", authCtx.ValidateAuthCRRoleBindingCreation},
+		{"Validate addition of RoleBinding when group is added", authCtx.ValidateAddingGroups},
+		{"Validate addition of ClusterRole when group is added", authCtx.ValidateAuthCRClusterRoleCreation},
+		{"Validate addition of ClusterRoleBinding when group is added", authCtx.ValidateAuthCRClusterRoleBindingCreation},
+		{"Validate removal of bindings when a group is removed", authCtx.ValidateRemovingGroups},
+	}
+
+	// Run the test suite.
+	authCtx.RunTestCases(t, testCases)
 }
 
-func (tc *AuthControllerTestCtx) WithT(t *testing.T) *WithT {
+// ValidateAuthCRCreation ensures that the Auth CR is created.
+func (tc *AuthControllerTestCtx) ValidateAuthCRCreation(t *testing.T) {
 	t.Helper()
 
-	g := NewWithT(t)
-	g.SetDefaultEventuallyTimeout(generalWaitTimeout)
-	g.SetDefaultEventuallyPollingInterval(1 * time.Second)
-
-	return g
+	// Ensure that exactly one Auth CR exists.
+	tc.EnsureExactlyOneResourceExists(gvk.Auth, tc.AuthNamespacedName)
 }
 
-func (tc *AuthControllerTestCtx) validateAuthCRCreation() error {
-	authList := &serviceApi.AuthList{}
-	if err := tc.testContext.customClient.List(tc.ctx, authList); err != nil {
-		return fmt.Errorf("unable to find Auth CR instance: %w", err)
-	}
+// ValidateAuthCRDefaultContent validates the default content of the Auth CR.
+func (tc *AuthControllerTestCtx) ValidateAuthCRDefaultContent(t *testing.T) {
+	t.Helper()
 
-	switch {
-	case len(authList.Items) == 1:
-		tc.testAuthInstance = authList.Items[0]
-		return nil
-	case len(authList.Items) > 1:
-		return fmt.Errorf("only one Auth CR expected, found %v", len(authList.Items))
-	default:
-		return nil
-	}
-}
+	// Get the expected values.
+	var expectedAdminGroup string
+	expectedAllowedGroup := "system:authenticated"
 
-func (tc *AuthControllerTestCtx) validateAuthCRDefaultContent() error {
-	if len(tc.testAuthInstance.Spec.AdminGroups) == 0 {
-		return errors.New("AdminGroups is empty ")
-	}
-
-	switch tc.platform {
+	// Determine expected admin group based on platform.
+	switch tc.Platform {
 	case cluster.SelfManagedRhoai:
-		if tc.testAuthInstance.Spec.AdminGroups[0] != "rhods-admins" {
-			return fmt.Errorf("expected rhods-admins, found %v", tc.testAuthInstance.Spec.AdminGroups[0])
-		}
+		expectedAdminGroup = rhodsAdminsName
 	case cluster.ManagedRhoai:
-		if tc.testAuthInstance.Spec.AdminGroups[0] != "dedicated-admins" {
-			return fmt.Errorf("expected dedicated-admins, found %v", tc.testAuthInstance.Spec.AdminGroups[0])
-		}
+		expectedAdminGroup = "dedicated-admins"
 	case cluster.OpenDataHub:
-		if tc.testAuthInstance.Spec.AdminGroups[0] != "odh-admins" {
-			return fmt.Errorf("expected odh-admins, found %v", tc.testAuthInstance.Spec.AdminGroups[0])
-		}
+		expectedAdminGroup = odhAdminsName
 	}
 
-	if tc.testAuthInstance.Spec.AllowedGroups[0] != "system:authenticated" {
-		return fmt.Errorf("expected system:authenticated, found %v", tc.testAuthInstance.Spec.AllowedGroups[0])
-	}
+	// Enhanced error messages with dynamic values.
+	expectedMessage := "Expected resource '%s' to have at least one entry in 'adminGroups' (first value: '%s') and 'allowedGroups' (first value: '%s')"
 
-	return nil
+	tc.EnsureResourceExistsAndMatchesCondition(
+		gvk.Auth,
+		tc.AuthNamespacedName,
+		And(
+			jq.Match(`.spec.adminGroups | length > 0 and .[0] == "%s"`, expectedAdminGroup),
+			jq.Match(`.spec.allowedGroups | length > 0 and .[0] == "%s"`, expectedAllowedGroup),
+		),
+		expectedMessage, expectedAdminGroup, expectedAllowedGroup,
+	)
 }
 
-func (tc *AuthControllerTestCtx) validateAuthCRRoleCreation() error {
-	adminRole := &rbacv1.Role{}
-	allowedRole := &rbacv1.Role{}
+// ValidateAuthCRRoleCreation validates the creation of the roles for the Auth CR.
+func (tc *AuthControllerTestCtx) ValidateAuthCRRoleCreation(t *testing.T) {
+	t.Helper()
 
-	if err := tc.testContext.customClient.Get(tc.ctx, types.NamespacedName{Namespace: tc.applicationsNamespace, Name: "admingroup-role"}, adminRole); err != nil {
-		return err
+	// Validate the role for admin and allowed groups.
+	roles := []string{adminGroupRoleName, allowedGroupRoleName}
+	for _, roleName := range roles {
+		tc.EnsureResourceExists(
+			gvk.Role,
+			types.NamespacedName{Namespace: tc.AppsNamespace, Name: roleName},
+			"Expected admin Role %s to be created", roleName,
+		)
 	}
-
-	if err := tc.testContext.customClient.Get(tc.ctx, types.NamespacedName{Namespace: tc.applicationsNamespace, Name: "allowedgroup-role"}, allowedRole); err != nil {
-		return err
-	}
-
-	return nil
 }
 
-func (tc *AuthControllerTestCtx) validateAuthCRClusterRoleCreation() error {
-	adminClusterRole := &rbacv1.ClusterRole{}
+// ValidateAuthCRClusterRoleCreation validates the creation of the cluster role.
+func (tc *AuthControllerTestCtx) ValidateAuthCRClusterRoleCreation(t *testing.T) {
+	t.Helper()
 
-	if err := tc.testContext.customClient.Get(tc.ctx, types.NamespacedName{Namespace: tc.applicationsNamespace, Name: "admingroupcluster-role"}, adminClusterRole); err != nil {
-		return err
-	}
-
-	return nil
+	tc.EnsureResourceExists(
+		gvk.ClusterRole,
+		types.NamespacedName{Namespace: tc.AppsNamespace, Name: adminGroupClusterRoleName},
+		"Expected admin ClusterRole %s to be created", adminGroupClusterRoleName,
+	)
 }
 
-func (tc *AuthControllerTestCtx) validateAuthCRRoleBindingCreation() error {
-	adminRolebinding := &rbacv1.RoleBinding{}
-	allowedRolebinding := &rbacv1.RoleBinding{}
+// ValidateAuthCRRoleBindingCreation validates the creation of the role bindings.
+func (tc *AuthControllerTestCtx) ValidateAuthCRRoleBindingCreation(t *testing.T) {
+	t.Helper()
 
-	if err := tc.testContext.customClient.Get(tc.ctx, types.NamespacedName{Namespace: tc.applicationsNamespace, Name: "admingroup-rolebinding"}, adminRolebinding); err != nil {
-		return err
+	roleBindings := []string{adminGroupRoleBindingName, allowedGroupRoleBindingName}
+	for _, roleBinding := range roleBindings {
+		tc.EnsureResourceExists(
+			gvk.RoleBinding,
+			types.NamespacedName{Namespace: tc.AppsNamespace, Name: roleBinding},
+			"Expected admin RoleBinding %s to be created", roleBinding,
+		)
 	}
-
-	if err := tc.testContext.customClient.Get(tc.ctx, types.NamespacedName{Namespace: tc.applicationsNamespace, Name: "allowedgroup-rolebinding"}, allowedRolebinding); err != nil {
-		return err
-	}
-
-	return nil
 }
 
-func (tc *AuthControllerTestCtx) validateAuthCRClusterRoleBindingCreation() error {
-	adminClusterRolebinding := &rbacv1.ClusterRoleBinding{}
+// ValidateAuthCRClusterRoleBindingCreation validates the creation of the cluster role bindings.
+func (tc *AuthControllerTestCtx) ValidateAuthCRClusterRoleBindingCreation(t *testing.T) {
+	t.Helper()
 
-	if err := tc.testContext.customClient.Get(tc.ctx, types.NamespacedName{Namespace: tc.applicationsNamespace,
-		Name: "admingroupcluster-rolebinding"}, adminClusterRolebinding); err != nil {
-		return err
-	}
-
-	return nil
+	tc.EnsureResourceExists(
+		gvk.ClusterRoleBinding,
+		types.NamespacedName{Namespace: tc.AppsNamespace, Name: adminGroupClusterRoleBindingName},
+		"Expected admin ClusterRoleBinding %s to be created", adminGroupClusterRoleBindingName,
+	)
 }
 
-func (tc *AuthControllerTestCtx) validateAddingGroups() error {
-	tc.testAuthInstance.Spec.AdminGroups = append(tc.testAuthInstance.Spec.AdminGroups, "aTestAdminGroup")
-	tc.testAuthInstance.Spec.AllowedGroups = append(tc.testAuthInstance.Spec.AllowedGroups, "aTestAllowedGroup")
-	err := tc.customClient.Update(tc.ctx, &tc.testAuthInstance)
-	if err != nil {
-		fmt.Println("Error updating groups in Auth CR: ", err)
+// ValidateAddingGroups adds groups and validates.
+func (tc *AuthControllerTestCtx) ValidateAddingGroups(t *testing.T) {
+	t.Helper()
+
+	testAdminGroup := "aTestAdminGroup"
+	testAllowedGroup := "aTestAllowedGroup"
+
+	// Update the Auth CR with new admin and allowed groups.
+	tc.EnsureResourceCreatedOrUpdated(
+		WithMinimalObject(gvk.Auth, tc.AuthNamespacedName),
+		testf.Transform(
+			`.spec.adminGroups |= . + ["%s"] | .spec.allowedGroups |= . + ["%s"]`, testAdminGroup, testAllowedGroup,
+		),
+	)
+
+	// Helper function to validate the role and cluster role bindings.
+	validateBinding := func(gvk schema.GroupVersionKind, bindingName, groupName string) {
+		tc.EnsureResourceExistsAndMatchesCondition(
+			gvk,
+			types.NamespacedName{Namespace: tc.AppsNamespace, Name: bindingName},
+			jq.Match(`.subjects[1].name == "%s"`, groupName),
+		)
 	}
 
-	adminRolebinding := &rbacv1.RoleBinding{}
-	adminClusterRolebinding := &rbacv1.ClusterRoleBinding{}
-	allowedRolebinding := &rbacv1.RoleBinding{}
-
-	if err := tc.testContext.customClient.Get(tc.ctx, types.NamespacedName{Namespace: tc.applicationsNamespace, Name: "admingroup-rolebinding"}, adminRolebinding); err != nil {
-		if adminRolebinding.Subjects[1].Name != "aTestAdminGroup" {
-			return fmt.Errorf("Expected aTestAdminGroup found %s ", adminRolebinding.Subjects[1].Name)
-		}
-	}
-
-	if err := tc.testContext.customClient.Get(tc.ctx, types.NamespacedName{Namespace: tc.applicationsNamespace,
-		Name: "admingroupcluster-rolebinding"}, adminClusterRolebinding); err != nil {
-		if adminRolebinding.Subjects[1].Name != "aTestAdminGroup" {
-			return fmt.Errorf("Expected aTestAdminGroup found %s ", adminRolebinding.Subjects[1].Name)
-		}
-	}
-
-	if err := tc.testContext.customClient.Get(tc.ctx, types.NamespacedName{Namespace: tc.applicationsNamespace, Name: "allowedgroup-rolebinding"}, allowedRolebinding); err != nil {
-		if allowedRolebinding.Subjects[1].Name != "aTestAllowedGroup" {
-			return fmt.Errorf("Expected aTestAllowedGroup found %s ", allowedRolebinding.Subjects[1].Name)
-		}
-	}
-
-	return nil
+	// Validate the RoleBinding and ClusterRoleBinding for admin and allowed groups.
+	validateBinding(gvk.RoleBinding, adminGroupRoleBindingName, testAdminGroup)
+	validateBinding(gvk.ClusterRoleBinding, adminGroupClusterRoleBindingName, testAdminGroup)
+	validateBinding(gvk.RoleBinding, allowedGroupRoleBindingName, testAllowedGroup)
 }
 
-func (tc *AuthControllerTestCtx) validateRemovingGroups() error {
-	expectedGroup := "odh-admins"
-	if tc.platform == cluster.ManagedRhoai || tc.platform == cluster.SelfManagedRhoai {
-		expectedGroup = "rhods-admins"
-	}
-	if _, err := controllerutil.CreateOrUpdate(tc.ctx, tc.customClient, &tc.testAuthInstance, func() error {
-		tc.testAuthInstance.Spec.AdminGroups = []string{expectedGroup}
-		return nil
-	}); err != nil {
-		return errors.New("error removing groups from auth CR")
+// ValidateRemovingGroups removes groups from Auth CR and validates the changes.
+func (tc *AuthControllerTestCtx) ValidateRemovingGroups(t *testing.T) {
+	t.Helper()
+
+	expectedGroup := odhAdminsName
+	if tc.Platform == cluster.ManagedRhoai || tc.Platform == cluster.SelfManagedRhoai {
+		expectedGroup = rhodsAdminsName
 	}
 
-	adminRolebinding := &rbacv1.RoleBinding{}
-	adminClusterRolebinding := &rbacv1.ClusterRoleBinding{}
+	// Update the Auth CR to set only the expected admin group.
+	tc.EnsureResourceCreatedOrUpdated(
+		WithMinimalObject(gvk.Auth, tc.AuthNamespacedName),
+		testf.Transform(`.spec.adminGroups = ["%s"]`, expectedGroup),
+		"Failed to create or update Auth resource '%s' with admin group '%s'", serviceApi.AuthInstanceName, expectedGroup,
+	)
 
-	if err := tc.testContext.customClient.Get(tc.ctx, types.NamespacedName{Namespace: tc.applicationsNamespace, Name: "admingroup-rolebinding"}, adminRolebinding); err != nil {
-		if len(adminRolebinding.Subjects) > 1 {
-			return fmt.Errorf("Expected 1 subject in adminRoleBinding found %v", len(adminRolebinding.Subjects))
-		}
-		if adminRolebinding.Subjects[0].Name != expectedGroup {
-			return fmt.Errorf("Expected adminRolebinding to only contain %s found %s", expectedGroup, adminRolebinding.Subjects[0].Name)
-		}
+	// Helper function to validate binding conditions after removal.
+	validateBinding := func(bindingType schema.GroupVersionKind, bindingName string, args ...any) {
+		tc.EnsureResourceExistsAndMatchesCondition(
+			bindingType,
+			types.NamespacedName{Namespace: tc.AppsNamespace, Name: bindingName},
+			And(
+				jq.Match(`.subjects | length == 1`),
+				jq.Match(`.subjects[0].name == "%s"`, expectedGroup),
+			),
+			args...,
+		)
 	}
 
-	if err := tc.testContext.customClient.Get(tc.ctx, types.NamespacedName{Namespace: tc.applicationsNamespace,
-		Name: "admingroupcluster-rolebinding"}, adminClusterRolebinding); err != nil {
-		if len(adminClusterRolebinding.Subjects) > 1 {
-			return fmt.Errorf("Expected 1 subject in adminClusterRoleBinding found %v", len(adminClusterRolebinding.Subjects))
-		}
-		if adminClusterRolebinding.Subjects[0].Name != expectedGroup {
-			return fmt.Errorf("Expected adminClusterRolebinding to only contain %s found %s", expectedGroup, adminClusterRolebinding.Subjects[0].Name)
-		}
-	}
-
-	return nil
+	// Validate RoleBinding and ClusterRoleBinding for admin group after removal.
+	validateBinding(gvk.RoleBinding, adminGroupRoleBindingName,
+		"Expected RoleBinding '%s' to have exactly one subject with name '%s'", adminGroupRoleBindingName, expectedGroup)
+	validateBinding(gvk.ClusterRoleBinding, adminGroupClusterRoleBindingName,
+		"Expected ClusterRoleBinding '%s' to have exactly one subject with name '%s'", adminGroupClusterRoleBindingName, expectedGroup)
 }

--- a/tests/e2e/cfmap_deletion_test.go
+++ b/tests/e2e/cfmap_deletion_test.go
@@ -1,104 +1,108 @@
 package e2e_test
 
 import (
-	"fmt"
 	"testing"
 
-	"github.com/onsi/gomega"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
-	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	dscv1 "github.com/opendatahub-io/opendatahub-operator/v2/api/datasciencecluster/v1"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/metadata/labels"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/upgrade"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/testf"
 )
 
+// CfgMapDeletionTestCtx holds the context for the config map deletion tests.
+type CfgMapDeletionTestCtx struct {
+	*TestContext
+	ConfigMapNamespacedName types.NamespacedName
+}
+
+// cfgMapDeletionTestSuite runs the testing flow for DataScienceCluster deletion logic via ConfigMap.
 func cfgMapDeletionTestSuite(t *testing.T) {
-	testCtx, err := NewTestContext()
-	require.NoError(t, err)
+	t.Helper()
 
-	defer removeDeletionConfigMap(testCtx)
+	// Initialize the test context.
+	tc, err := NewTestContext(t)
+	require.NoError(t, err, "Failed to initialize test context")
 
-	t.Run(testCtx.testDsc.Name, func(t *testing.T) {
-		t.Run("create configmap but set to disable deletion", func(t *testing.T) {
-			err = testCtx.testDSCDeletionUsingConfigMap("false")
-			require.NoError(t, err, "Configmap should not delete DSC instance")
-		})
-
-		t.Run("owned namespaces should be not deleted", testCtx.testOwnedNamespacesAllExist)
-	})
-}
-
-func (tc *testContext) testDSCDeletionUsingConfigMap(enableDeletion string) error {
-	dscLookupKey := types.NamespacedName{Name: tc.testDsc.Name}
-	expectedDSC := &dscv1.DataScienceCluster{}
-
-	if err := createDeletionConfigMap(tc, enableDeletion); err != nil {
-		return err
+	// Create an instance of test context.
+	cfgMapDeletionTestCtx := &CfgMapDeletionTestCtx{
+		TestContext: tc,
+		ConfigMapNamespacedName: types.NamespacedName{
+			Name:      "delete-configmap-name",
+			Namespace: tc.OperatorNamespace,
+		},
 	}
 
-	err := tc.customClient.Get(tc.ctx, dscLookupKey, expectedDSC)
-	// should have DSC instance
-	if err != nil {
-		if k8serr.IsNotFound(err) {
-			return fmt.Errorf("should have DSC instance in cluster:%w", err)
-		}
-		return fmt.Errorf("error getting DSC instance :%w", err)
+	// Ensure ConfigMap cleanup after tests
+	defer cfgMapDeletionTestCtx.RemoveDeletionConfigMap(t)
+
+	// Define test cases
+	testCases := []TestCase{
+		{name: "Validate creation of configmap with deletion disabled", testFn: cfgMapDeletionTestCtx.ValidateDSCDeletionUsingConfigMap},
+		{name: "Validate that owned namespaces are not deleted", testFn: cfgMapDeletionTestCtx.ValidateOwnedNamespacesAllExist},
 	}
 
-	return nil
-}
-func (tc *testContext) testOwnedNamespacesAllExist(t *testing.T) {
-	g := gomega.NewWithT(t)
-
-	g.Eventually(func() ([]corev1.Namespace, error) {
-		namespaces, err := tc.kubeClient.CoreV1().Namespaces().List(tc.ctx, metav1.ListOptions{
-			LabelSelector: labels.ODH.OwnedNamespace,
-		})
-
-		if err != nil {
-			return nil, fmt.Errorf("failed getting owned namespaces %w", err)
-		}
-
-		return namespaces.Items, nil
-	}).Should(gomega.Satisfy(func(in []corev1.Namespace) bool {
-		return len(in) >= ownedNamespaceNumber
-	}))
+	// Run the test suite
+	cfgMapDeletionTestCtx.RunTestCases(t, testCases)
 }
 
-func removeDeletionConfigMap(tc *testContext) {
-	_ = tc.kubeClient.CoreV1().ConfigMaps(testOpts.operatorNamespace).Delete(tc.ctx, deleteConfigMap, metav1.DeleteOptions{})
-}
+// ValidateDSCDeletionUsingConfigMap tests the deletion of DataScienceCluster based on the config map setting.
+func (tc *CfgMapDeletionTestCtx) ValidateDSCDeletionUsingConfigMap(t *testing.T) {
+	t.Helper()
 
-func createDeletionConfigMap(tc *testContext, enableDeletion string) error {
+	// Create or update the deletion config map
+	enableDeletion := "false"
 	configMap := &corev1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ConfigMap",
+			APIVersion: corev1.SchemeGroupVersion.Version,
+		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      deleteConfigMap,
-			Namespace: testOpts.operatorNamespace,
+			Name:      tc.ConfigMapNamespacedName.Name,
+			Namespace: tc.ConfigMapNamespacedName.Namespace,
 			Labels: map[string]string{
 				upgrade.DeleteConfigMapLabel: enableDeletion,
 			},
 		},
 	}
 
-	configMaps := tc.kubeClient.CoreV1().ConfigMaps(configMap.Namespace)
-	if _, err := configMaps.Get(tc.ctx, configMap.Name, metav1.GetOptions{}); err != nil {
-		switch {
-		case k8serr.IsNotFound(err):
-			if _, err = configMaps.Create(tc.ctx, configMap, metav1.CreateOptions{}); err != nil {
-				return err
-			}
-		case k8serr.IsAlreadyExists(err):
-			if _, err = configMaps.Update(tc.ctx, configMap, metav1.UpdateOptions{}); err != nil {
-				return err
-			}
-		default:
-			return err
-		}
-	}
+	tc.EnsureResourceCreatedOrUpdated(
+		WithObjectToCreate(configMap),
+		NoOpMutationFn,
+		testf.Transform(`.metadata.labels[%s] = %s`, upgrade.DeleteConfigMapLabel, enableDeletion),
+		"Failed to create or update deletion config map",
+	)
 
-	return nil
+	// Verify the existence of the DataScienceCluster instance.
+	tc.EnsureResourceExists(gvk.DataScienceCluster, tc.DataScienceClusterNamespacedName)
+}
+
+// ValidateOwnedNamespacesAllExist verifies that the owned namespaces exist.
+func (tc *CfgMapDeletionTestCtx) ValidateOwnedNamespacesAllExist(t *testing.T) {
+	t.Helper()
+
+	// Ensure namespaces with the owned namespace label exist
+	tc.EnsureResourcesWithLabelsExist(
+		gvk.Namespace,
+		client.MatchingLabels{labels.ODH.OwnedNamespace: "true"},
+		ownedNamespaceNumber,
+		"Expected %d owned namespaces with label '%s'. Owned namespaces should not be deleted: %v", ownedNamespaceNumber, labels.ODH.OwnedNamespace,
+	)
+}
+
+// RemoveDeletionConfigMap ensures the deletion of the ConfigMap.
+func (tc *CfgMapDeletionTestCtx) RemoveDeletionConfigMap(t *testing.T) {
+	t.Helper()
+
+	// Delete the config map
+	tc.DeleteResource(
+		gvk.ConfigMap,
+		tc.ConfigMapNamespacedName,
+		client.PropagationPolicy(metav1.DeletePropagationForeground),
+	)
 }

--- a/tests/e2e/cleanup_test.go
+++ b/tests/e2e/cleanup_test.go
@@ -1,0 +1,26 @@
+package e2e_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
+)
+
+// CleanupAllResources handles the cleanup of all resources (DSC, DSCI, etc.)
+func CleanupAllResources(t *testing.T) {
+	t.Helper()
+
+	// Initialize the test context.
+	tc, err := NewTestContext(t)
+	require.NoError(t, err, "Failed to initialize test context")
+
+	// Cleanup DataScienceCluster
+	t.Log("Cleaning up DataScienceCluster")
+	tc.DeleteResourceIfExists(gvk.DataScienceCluster, tc.DataScienceClusterNamespacedName)
+
+	// Cleanup DSCInitialization
+	t.Log("Cleaning up DSCInitialization")
+	tc.DeleteResourceIfExists(gvk.DSCInitialization, tc.DSCInitializationNamespacedName)
+}

--- a/tests/e2e/cleanup_test.go
+++ b/tests/e2e/cleanup_test.go
@@ -18,9 +18,9 @@ func CleanupAllResources(t *testing.T) {
 
 	// Cleanup DataScienceCluster
 	t.Log("Cleaning up DataScienceCluster")
-	tc.DeleteResourceIfExists(gvk.DataScienceCluster, tc.DataScienceClusterNamespacedName)
+	tc.DeleteResourceIfExists(WithMinimalObject(gvk.DataScienceCluster, tc.DataScienceClusterNamespacedName))
 
 	// Cleanup DSCInitialization
 	t.Log("Cleaning up DSCInitialization")
-	tc.DeleteResourceIfExists(gvk.DSCInitialization, tc.DSCInitializationNamespacedName)
+	tc.DeleteResourceIfExists(WithMinimalObject(gvk.DSCInitialization, tc.DSCInitializationNamespacedName))
 }

--- a/tests/e2e/codeflare_test.go
+++ b/tests/e2e/codeflare_test.go
@@ -8,23 +8,29 @@ import (
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/api/components/v1alpha1"
 )
 
+type CodeFlareTestCtx struct {
+	*ComponentTestCtx
+}
+
 func codeflareTestSuite(t *testing.T) {
 	t.Helper()
 
-	ct, err := NewComponentTestCtx(&componentApi.CodeFlare{})
+	ct, err := NewComponentTestCtx(t, &componentApi.CodeFlare{})
 	require.NoError(t, err)
 
 	componentCtx := CodeFlareTestCtx{
 		ComponentTestCtx: ct,
 	}
 
-	t.Run("Validate component enabled", componentCtx.ValidateComponentEnabled)
-	t.Run("Validate operands have OwnerReferences", componentCtx.ValidateOperandsOwnerReferences)
-	t.Run("Validate update operand resources", componentCtx.ValidateUpdateDeploymentsResources)
-	t.Run("Validate component releases", componentCtx.ValidateComponentReleases)
-	t.Run("Validate component disabled", componentCtx.ValidateComponentDisabled)
-}
+	// Define test cases.
+	testCases := []TestCase{
+		{"Validate component enabled", componentCtx.ValidateComponentEnabled},
+		{"Validate operands have OwnerReferences", componentCtx.ValidateOperandsOwnerReferences},
+		{"Validate update operand resources", componentCtx.ValidateUpdateDeploymentsResources},
+		{"Validate component releases", componentCtx.ValidateComponentReleases},
+		{"Validate component disabled", componentCtx.ValidateComponentDisabled},
+	}
 
-type CodeFlareTestCtx struct {
-	*ComponentTestCtx
+	// Run the test suite.
+	componentCtx.RunTestCases(t, testCases)
 }

--- a/tests/e2e/components_test.go
+++ b/tests/e2e/components_test.go
@@ -1,24 +1,22 @@
 package e2e_test
 
 import (
-	"fmt"
 	"strings"
 	"testing"
 	"time"
 
-	"github.com/blang/semver/v4"
-	configv1 "github.com/openshift/api/config/v1"
+	gTypes "github.com/onsi/gomega/types"
 	operatorv1 "github.com/openshift/api/operator/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8slabels "k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/opendatahub-io/opendatahub-operator/v2/api/common"
-	dscv1 "github.com/opendatahub-io/opendatahub-operator/v2/api/datasciencecluster/v1"
-	dsciv1 "github.com/opendatahub-io/opendatahub-operator/v2/api/dscinitialization/v1"
+	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/api/components/v1alpha1"
+	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/components/modelcontroller"
 	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/status"
-	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/metadata/labels"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/resources"
@@ -28,318 +26,322 @@ import (
 	. "github.com/onsi/gomega"
 )
 
+// ComponentTestCtx holds the context for component tests.
 type ComponentTestCtx struct {
-	*testf.TestContext
-
-	GVK                  schema.GroupVersionKind
-	DSCName              types.NamespacedName
-	DSCIName             types.NamespacedName
-	ApplicationNamespace string
+	*TestContext
+	// Any additional fields specific to component tests
+	GVK            schema.GroupVersionKind
+	NamespacedName types.NamespacedName
 }
 
-func NewComponentTestCtx(object common.PlatformObject) (*ComponentTestCtx, error) {
-	tcf, err := testf.NewTestContext(
-		testf.WithTOptions(
-			testf.WithEventuallyTimeout(generalWaitTimeout),
-			testf.WithEventuallyPollingInterval(generalPollInterval),
-		),
-	)
+// CRD represents a custom resource definition with a name and version.
+type CRD struct {
+	Name    string
+	Version string
+}
 
+// NewComponentTestCtx initializes a new component test context.
+func NewComponentTestCtx(t *testing.T, object common.PlatformObject) (*ComponentTestCtx, error) { //nolint:thelper
+	baseCtx, err := NewTestContext(t)
 	if err != nil {
 		return nil, err
 	}
 
-	ogvk, err := resources.GetGroupVersionKindForObject(tcf.Scheme(), object)
+	ogvk, err := resources.GetGroupVersionKindForObject(baseCtx.Scheme(), object)
 	if err != nil {
 		return nil, err
-	}
-
-	dsciList := dsciv1.DSCInitializationList{}
-	if err := tcf.Client().List(tcf.Context(), &dsciList); err != nil {
-		return nil, err
-	}
-
-	if len(dsciList.Items) != 1 {
-		return nil, fmt.Errorf("failure looking up DSCInitialization, expected=1, found=%d", len(dsciList.Items))
-	}
-
-	dscList := dscv1.DataScienceClusterList{}
-	if err := tcf.Client().List(tcf.Context(), &dscList); err != nil {
-		return nil, err
-	}
-
-	if len(dscList.Items) != 1 {
-		return nil, fmt.Errorf("failure looking up DataScienceCluster, expected=1, found=%d", len(dscList.Items))
 	}
 
 	componentCtx := ComponentTestCtx{
-		TestContext:          tcf,
-		GVK:                  ogvk,
-		DSCName:              client.ObjectKeyFromObject(&dscList.Items[0]),
-		DSCIName:             client.ObjectKeyFromObject(&dsciList.Items[0]),
-		ApplicationNamespace: dsciList.Items[0].Spec.ApplicationsNamespace,
+		TestContext:    baseCtx,
+		GVK:            ogvk,
+		NamespacedName: resources.NamespacedNameFromObject(object),
 	}
 
 	return &componentCtx, nil
 }
 
-func (c *ComponentTestCtx) ValidateComponentEnabled(t *testing.T) {
-	g := c.NewWithT(t)
+// ValidateComponentEnabled ensures that the component is enabled and its status is "Ready".
+func (tc *ComponentTestCtx) ValidateComponentEnabled(t *testing.T) {
+	t.Helper()
 
-	g.Update(
-		gvk.DataScienceCluster,
-		c.DSCName,
-		testf.Transform(`.spec.components.%s.managementState = "%s"`, strings.ToLower(c.GVK.Kind), operatorv1.Managed),
-	).Eventually().Should(
-		Succeed(),
+	// Ensure that DataScienceCluster exists and its component state is "Removed", with the "Ready" condition true.
+	tc.UpdateComponentStateInDataScienceCluster(operatorv1.Managed)
+
+	// Ensure that any Deployment resources for the component are present
+	tc.EnsureResourcesExist(
+		gvk.Deployment,
+		types.NamespacedName{Namespace: tc.AppsNamespace},
+		&client.ListOptions{
+			LabelSelector: k8slabels.Set{
+				labels.PlatformPartOf: strings.ToLower(tc.GVK.Kind),
+			}.AsSelector(),
+		},
 	)
 
-	g.List(gvk.DataScienceCluster).Eventually().Should(And(
-		HaveLen(1),
-		HaveEach(And(
-			jq.Match(`.spec.components.%s.managementState == "%s"`, strings.ToLower(c.GVK.Kind), operatorv1.Managed),
-			jq.Match(`.status.conditions[] | select(.type == "%sReady") | .status == "%s"`, c.GVK.Kind, metav1.ConditionTrue),
-			jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, status.ConditionTypeProvisioningSucceeded, metav1.ConditionTrue),
-			jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, status.ConditionTypeComponentsReady, metav1.ConditionTrue),
-		)),
-	))
-
-	g.List(c.GVK).Eventually().Should(And(
-		HaveLen(1),
-		HaveEach(And(
-			jq.Match(`.metadata.ownerReferences[0].kind == "%s"`, gvk.DataScienceCluster.Kind),
-			jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, status.ConditionTypeReady, metav1.ConditionTrue),
-			jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, status.ConditionTypeProvisioningSucceeded, metav1.ConditionTrue),
-		)),
-	))
-}
-
-func (c *ComponentTestCtx) ValidateOperandsOwnerReferences(t *testing.T) {
-	g := c.NewWithT(t)
-
-	g.List(
-		gvk.Deployment,
-		client.InNamespace(c.ApplicationNamespace),
-		client.MatchingLabels{labels.PlatformPartOf: strings.ToLower(c.GVK.Kind)},
-	).Eventually().Should(And(
-		Not(BeEmpty()),
-		HaveEach(
-			jq.Match(`.metadata.ownerReferences[0].kind == "%s"`, c.GVK.Kind),
+	// Ensure the component resource exists and is marked "Ready".
+	tc.EnsureResourcesExistAndMatchCondition(
+		tc.GVK,
+		tc.NamespacedName,
+		nil,
+		And(
+			HaveLen(1),
+			HaveEach(And(
+				jq.Match(`.metadata.ownerReferences[0].kind == "%s"`, gvk.DataScienceCluster.Kind),
+				jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, status.ConditionTypeReady, metav1.ConditionTrue),
+				jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, status.ConditionTypeProvisioningSucceeded, metav1.ConditionTrue),
+			)),
 		),
-	))
+	)
 }
 
-func (c *ComponentTestCtx) ValidateUpdateDeploymentsResources(t *testing.T) {
-	g := c.NewWithT(t)
+// ValidateComponentDisabled ensures that the component is disabled and its resources are deleted.
+func (tc *ComponentTestCtx) ValidateComponentDisabled(t *testing.T) {
+	t.Helper()
 
-	deployments := g.List(
+	// Ensure that the resources associated with the component exist
+	tc.EnsureResourcesExist(tc.GVK, tc.NamespacedName, nil)
+
+	// Ensure that DataScienceCluster exists and its component state is "Removed", with the "Ready" condition false.
+	tc.UpdateComponentStateInDataScienceCluster(operatorv1.Removed)
+
+	// Ensure that any Deployment resources for the component are not present
+	tc.EnsureResourcesGone(
 		gvk.Deployment,
-		client.InNamespace(c.ApplicationNamespace),
-		client.MatchingLabels{
-			labels.PlatformPartOf: strings.ToLower(c.GVK.Kind),
+		types.NamespacedName{Namespace: tc.AppsNamespace},
+		&client.ListOptions{
+			LabelSelector: k8slabels.Set{
+				labels.PlatformPartOf: strings.ToLower(tc.GVK.Kind),
+			}.AsSelector(),
 		},
-	).Eventually().ShouldNot(
-		BeEmpty(),
+	)
+
+	// Ensure that the resources associated with the component do not exist
+	tc.EnsureResourcesGone(tc.GVK, tc.NamespacedName, nil)
+}
+
+// ValidateOperandsOwnerReferences ensures that all deployment resources have the correct owner references.
+func (tc *ComponentTestCtx) ValidateOperandsOwnerReferences(t *testing.T) {
+	t.Helper()
+
+	// Ensure that the Deployment resources exist with the proper owner references
+	tc.EnsureResourcesExistAndMatchCondition(
+		gvk.Deployment,
+		types.NamespacedName{Namespace: tc.AppsNamespace},
+		&client.ListOptions{
+			Namespace: tc.AppsNamespace,
+			LabelSelector: k8slabels.Set{
+				labels.PlatformPartOf: strings.ToLower(tc.GVK.Kind),
+			}.AsSelector(),
+		},
+		HaveEach(
+			jq.Match(`.metadata.ownerReferences[0].kind == "%s"`, tc.GVK.Kind),
+		),
+		"Deployment resources with correct owner references should exist",
+	)
+}
+
+// ValidateUpdateDeploymentsResources verifies the update of deployment replicas for the component.
+func (tc *ComponentTestCtx) ValidateUpdateDeploymentsResources(t *testing.T) {
+	t.Helper()
+
+	// Ensure that deployments exist for the component
+	deployments := tc.EnsureResourcesExist(
+		gvk.Deployment,
+		types.NamespacedName{Namespace: tc.AppsNamespace},
+		&client.ListOptions{
+			Namespace: tc.AppsNamespace,
+			LabelSelector: k8slabels.Set{
+				labels.PlatformPartOf: strings.ToLower(tc.GVK.Kind),
+			}.AsSelector(),
+		},
 	)
 
 	for _, d := range deployments {
 		t.Run("deployment_"+d.GetName(), func(t *testing.T) {
-			replicas, err := jq.ExtractValue[int](d, `.spec.replicas`)
-			g.Expect(err).ShouldNot(HaveOccurred())
+			t.Helper()
+
+			// Extract the current replica count
+			replicas := ExtractAndExpectValue[int](tc.g, d, `.spec.replicas`, Not(BeNil()))
 
 			expectedReplica := replicas + 1
 			if replicas > 1 {
 				expectedReplica = 1
 			}
 
-			g.Update(
-				gvk.Deployment,
-				client.ObjectKeyFromObject(&d),
+			// Update the deployment's replica count
+			tc.EnsureResourceCreatedOrUpdatedWithCondition(
+				WithMinimalObject(gvk.Deployment, resources.NamespacedNameFromObject(&d)),
 				testf.Transform(`.spec.replicas = %d`, expectedReplica),
-			).Eventually().WithTimeout(30 * time.Second).WithPolling(1 * time.Second).Should(
 				jq.Match(`.spec.replicas == %d`, expectedReplica),
 			)
 
-			g.Get(
+			tc.EnsureResourceExistsAndMatchesConditionConsistently(
 				gvk.Deployment,
-				client.ObjectKeyFromObject(&d),
-			).Eventually().Should(
+				resources.NamespacedNameFromObject(&d),
 				jq.Match(`.spec.replicas == %d`, expectedReplica),
-			)
-
-			g.Get(
-				gvk.Deployment,
-				client.ObjectKeyFromObject(&d),
-			).Consistently().WithTimeout(30 * time.Second).WithPolling(1 * time.Second).Should(
-				jq.Match(`.spec.replicas == %d`, expectedReplica),
+				30*time.Second,
+				1*time.Second,
 			)
 		})
 	}
 }
 
-func (c *ComponentTestCtx) ValidateComponentDisabled(t *testing.T) {
-	g := c.NewWithT(t)
-
-	g.List(c.GVK).Eventually().ShouldNot(
-		BeEmpty(),
-	)
-
-	g.Update(
-		gvk.DataScienceCluster,
-		c.DSCName,
-		testf.Transform(`.spec.components.%s.managementState = "%s"`, strings.ToLower(c.GVK.Kind), operatorv1.Removed),
-	).Eventually().Should(
-		Succeed(),
-	)
-
-	g.List(c.GVK).Eventually().Should(
-		BeEmpty(),
-	)
-
-	g.List(
-		gvk.Deployment,
-		client.InNamespace(c.ApplicationNamespace),
-		client.MatchingLabels{
-			labels.PlatformPartOf: strings.ToLower(c.GVK.Kind),
-		},
-	).Eventually().Should(
-		BeEmpty(),
-	)
-
-	g.List(gvk.DataScienceCluster).Eventually().Should(And(
-		HaveLen(1),
-		HaveEach(And(
-			jq.Match(`.spec.components.%s.managementState == "%s"`, strings.ToLower(c.GVK.Kind), operatorv1.Removed),
-			jq.Match(`.status.conditions[] | select(.type == "%sReady") | .status == "%s"`, c.GVK.Kind, metav1.ConditionFalse),
-		)),
-	))
-}
-
-func (c *ComponentTestCtx) ValidateCRDReinstated(t *testing.T, name string, version ...string) {
+// ValidateCRDsReinstated ensures that the CRDs are properly removed and reinstated when a component is disabled and re-enabled.
+func (tc *ComponentTestCtx) ValidateCRDsReinstated(t *testing.T, crds []CRD) {
 	t.Helper()
 
-	g := c.NewWithT(t)
-	crdSel := client.MatchingFields{"metadata.name": name}
+	// Disable the component first and validate that all CRDs are removed
+	tc.ValidateComponentDisabled(t)
 
-	g.Update(
+	// Check that all CRDs are removed
+	for _, crd := range crds {
+		t.Run(crd.Name, func(t *testing.T) {
+			tc.ValidateCRDRemoval(crd.Name)
+		})
+	}
+
+	// Enable the component now and validate that all CRDs are reinstated
+	tc.ValidateComponentEnabled(t)
+
+	// Check that all CRDs are reinstated
+	for _, crd := range crds {
+		t.Run(crd.Name, func(t *testing.T) {
+			tc.ValidateCRDReinstatement(crd.Name, crd.Version)
+		})
+	}
+}
+
+// ValidateComponentReleases ensures that the component releases exist and have valid fields.
+func (tc *ComponentTestCtx) ValidateComponentReleases(t *testing.T) {
+	t.Helper()
+
+	componentName := strings.ToLower(tc.GVK.Kind)
+
+	// Ensure the DataScienceCluster exists and the component's conditions are met
+	tc.EnsureResourceExistsAndMatchesCondition(
 		gvk.DataScienceCluster,
-		c.DSCName,
-		testf.Transform(`.spec.components.%s.managementState = "%s"`, strings.ToLower(c.GVK.Kind), operatorv1.Removed),
-	).Eventually().Should(
-		Succeed(),
-	)
+		tc.DataScienceClusterNamespacedName,
+		And(
+			// Ensure the component's management state is "Managed"
+			jq.Match(`.spec.components.%s.managementState == "%s"`, componentName, operatorv1.Managed),
 
-	g.List(c.GVK).Eventually().Should(
-		BeEmpty(),
-	)
-	g.List(gvk.CustomResourceDefinition, crdSel).Eventually().Should(
-		HaveLen(1),
-	)
+			// Validate that the releases field contains at least one release for the component
+			jq.Match(`.status.components.%s.releases | length > 0`, componentName),
 
-	g.Delete(
+			// Validate the fields (name, version, repoUrl) for each release
+			// No need to check for length here, the previous check validates if any release exists
+			And(
+				jq.Match(`.status.components.%s.releases[].name != ""`, componentName),
+				jq.Match(`.status.components.%s.releases[].version != ""`, componentName),
+				jq.Match(`.status.components.%s.releases[].repoUrl != ""`, componentName),
+			),
+		),
+	)
+}
+
+// ValidateComponentCondition ensures that the specified component instance has the expected condition set to "True".
+func (tc *ComponentTestCtx) ValidateComponentCondition(gvk schema.GroupVersionKind, componentName, statusType string) {
+	tc.EnsureResourceExistsAndMatchesCondition(
+		gvk,
+		types.NamespacedName{Name: componentName},
+		jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, statusType, metav1.ConditionTrue),
+	)
+}
+
+// UpdateComponentStateInDataScienceCluster updates the management state of a specified component in the DataScienceCluster.
+func (tc *ComponentTestCtx) UpdateComponentStateInDataScienceCluster(state operatorv1.ManagementState, kind ...string) {
+	componentKind := tc.GVK.Kind
+	if len(kind) > 0 {
+		componentKind = kind[0]
+	}
+
+	componentName := strings.ToLower(componentKind)
+	readyCondition := metav1.ConditionFalse
+	if state == operatorv1.Managed {
+		readyCondition = metav1.ConditionTrue
+	}
+
+	// Define common conditions to match.
+	conditions := []gTypes.GomegaMatcher{
+		// Validate that the component's management state is updated correctly
+		jq.Match(`.spec.components.%s.managementState == "%s"`, componentName, state),
+
+		// Validate the "Ready" condition for the component
+		jq.Match(`.status.conditions[] | select(.type == "%sReady") | .status == "%s"`, componentKind, readyCondition),
+	}
+
+	// If the state is "Managed", add additional checks for provisioning and components readiness.
+	if state == operatorv1.Managed {
+		conditions = append(conditions,
+			// Validate the "ProvisioningSucceeded" condition
+			jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, status.ConditionTypeProvisioningSucceeded, readyCondition),
+
+			// Validate the "ComponentsReady" condition
+			jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, status.ConditionTypeComponentsReady, readyCondition),
+		)
+	}
+
+	// Update the management state of the component in the DataScienceCluster.
+	tc.EnsureResourceCreatedOrUpdatedWithCondition(
+		WithMinimalObject(gvk.DataScienceCluster, tc.DataScienceClusterNamespacedName),
+		testf.Transform(`.spec.components.%s.managementState = "%s"`, componentName, state),
+		And(conditions...),
+	)
+}
+
+// ValidateCRDRemoval ensures that the CRD is properly removed when the component is disabled.
+func (tc *ComponentTestCtx) ValidateCRDRemoval(name string) {
+	nn := types.NamespacedName{Name: name}
+
+	// Ensure the CustomResourceDefinition (CRD) exists before deletion
+	tc.EnsureResourceExists(gvk.CustomResourceDefinition, nn)
+
+	// Delete the CRD
+	tc.DeleteResource(
 		gvk.CustomResourceDefinition,
 		types.NamespacedName{Name: name},
-		client.PropagationPolicy(metav1.DeletePropagationForeground),
-	).Eventually().Should(
-		Succeed(),
-	)
+		client.PropagationPolicy(metav1.DeletePropagationForeground))
 
-	g.List(gvk.CustomResourceDefinition, crdSel).Eventually().Should(
-		BeEmpty(),
-	)
+	// Ensure the CRD is removed
+	tc.EnsureResourceGone(gvk.CustomResourceDefinition, nn)
+}
 
-	g.Update(
-		gvk.DataScienceCluster,
-		c.DSCName,
-		testf.Transform(`.spec.components.%s.managementState = "%s"`, strings.ToLower(c.GVK.Kind), operatorv1.Managed),
-	).Eventually().Should(
-		Succeed(),
-	)
+// ValidateCRDReinstatement ensures that the CRD is properly reinstated when the component is enabled.
+func (tc *ComponentTestCtx) ValidateCRDReinstatement(name string, version string) {
+	nn := types.NamespacedName{Name: name}
 
-	g.List(c.GVK).Eventually().Should(
-		HaveLen(1),
-	)
-	g.List(gvk.CustomResourceDefinition, crdSel).Eventually().Should(
-		HaveLen(1),
-	)
+	// Ensure the CRD is recreated
+	tc.EnsureResourceExists(gvk.CustomResourceDefinition, nn)
+
+	// Ensure the CRD has the specified version
 	if len(version) != 0 {
-		g.Get(
+		tc.EnsureResourceExistsAndMatchesCondition(
 			gvk.CustomResourceDefinition,
 			types.NamespacedName{Name: name},
-		).Eventually(5*time.Second, 500*time.Millisecond).Should(
-			jq.Match(`.status.storedVersions[0] == "%s"`, version[0]),
+			jq.Match(`.status.storedVersions[0] == "%s"`, version),
 		)
 	}
 }
 
-// Validate releases for any component in the DataScienceCluster.
-func (c *ComponentTestCtx) ValidateComponentReleases(t *testing.T) {
+// ValidateModelControllerInstance validates the existence and correct status of the ModelController and DataScienceCluster.
+func (tc *ComponentTestCtx) ValidateModelControllerInstance(t *testing.T) {
 	t.Helper()
 
-	g := c.NewWithT(t)
-
-	componentName := strings.ToLower(c.GVK.Kind)
-
-	// Transform the DataScienceCluster to set the management state of the component
-	g.Update(
-		gvk.DataScienceCluster,
-		c.DSCName,
-		testf.Transform(
-			`.spec.components.%s.managementState = "%s"`, componentName, operatorv1.Managed,
+	// Ensure ModelController resource exists with the expected owner references and status phase.
+	tc.EnsureResourceExistsAndMatchesCondition(
+		gvk.ModelController,
+		types.NamespacedName{Name: componentApi.ModelControllerInstanceName},
+		And(
+			jq.Match(`.metadata.ownerReferences[0].kind == "%s"`, gvk.DataScienceCluster.Kind),
+			jq.Match(`.status.phase == "%s"`, status.ConditionTypeReady),
 		),
-	).Eventually().Should(
-		Succeed(),
 	)
 
-	// Check if the releases field contains multiple releases for the component
-	g.List(gvk.DataScienceCluster).Eventually().Should(And(
-		HaveLen(1),
-		HaveEach(
-			// Check releases for the component itself
-			jq.Match(`.status.components.%s.releases | length > 0`, componentName),
-		),
-	))
-
-	// Validate each release's fields (name, version, repoUrl) using HaveEach
-	g.List(gvk.DataScienceCluster).Eventually().Should(And(
-		HaveLen(1),
-		HaveEach(And(
-			// Check that each release has the required fields (name, version, repoUrl)
-			jq.Match(`.status.components.%s.releases[].name != ""`, componentName),
-			jq.Match(`.status.components.%s.releases[].version != ""`, componentName),
-			jq.Match(`.status.components.%s.releases[].repoUrl != ""`, componentName)),
-		),
-	))
-}
-
-func (c *ComponentTestCtx) GetDSC() (*dscv1.DataScienceCluster, error) {
-	obj := dscv1.DataScienceCluster{}
-
-	err := c.Client().Get(c.Context(), c.DSCName, &obj)
-	if err != nil {
-		return nil, err
-	}
-
-	return &obj, nil
-}
-
-func (c *ComponentTestCtx) GetDSCI() (*dsciv1.DSCInitialization, error) {
-	obj := dsciv1.DSCInitialization{}
-
-	err := c.Client().Get(c.Context(), c.DSCIName, &obj)
-	if err != nil {
-		return nil, err
-	}
-
-	return &obj, nil
-}
-
-func (c *ComponentTestCtx) GetClusterVersion() (semver.Version, error) {
-	clusterVersion := &configv1.ClusterVersion{}
-	if err := c.Client().Get(c.Context(), client.ObjectKey{
-		Name: cluster.OpenShiftVersionObj,
-	}, clusterVersion); err != nil {
-		return semver.Version{}, err
-	}
-	return semver.ParseTolerant(clusterVersion.Status.History[0].Version)
+	// Ensure ModelController condition matches the expected status in the DataScienceCluster.
+	tc.ValidateComponentCondition(
+		gvk.DataScienceCluster,
+		tc.DataScienceClusterNamespacedName.Name,
+		modelcontroller.ReadyConditionType,
+	)
 }

--- a/tests/e2e/controller_test.go
+++ b/tests/e2e/controller_test.go
@@ -1,7 +1,6 @@
 package e2e_test
 
 import (
-	"context"
 	"errors"
 	"flag"
 	"fmt"
@@ -10,7 +9,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/onsi/gomega"
 	"github.com/onsi/gomega/format"
 	operatorv1 "github.com/openshift/api/operator/v1"
 	routev1 "github.com/openshift/api/route/v1"
@@ -21,12 +19,9 @@ import (
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	k8sclient "k8s.io/client-go/kubernetes"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/client-go/rest"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	ctrlruntime "sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
@@ -36,209 +31,107 @@ import (
 	dsciv1 "github.com/opendatahub-io/opendatahub-operator/v2/api/dscinitialization/v1"
 	featurev1 "github.com/opendatahub-io/opendatahub-operator/v2/api/features/v1"
 	serviceApi "github.com/opendatahub-io/opendatahub-operator/v2/api/services/v1alpha1"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/testf"
 )
 
+// Test function signature.
 type TestFn func(t *testing.T)
 
-var (
-	Scheme = runtime.NewScheme()
-
-	testOpts = testContextConfig{
-		components: TestGroup{
-			name:    "components",
-			enabled: true,
-			scenarios: map[string]TestFn{
-				// do not add modelcontroller here, due to dependency, test it separately below
-				componentApi.DashboardComponentName:            dashboardTestSuite,
-				componentApi.RayComponentName:                  rayTestSuite,
-				componentApi.ModelRegistryComponentName:        modelRegistryTestSuite,
-				componentApi.TrustyAIComponentName:             trustyAITestSuite,
-				componentApi.KueueComponentName:                kueueTestSuite,
-				componentApi.TrainingOperatorComponentName:     trainingOperatorTestSuite,
-				componentApi.DataSciencePipelinesComponentName: dataSciencePipelinesTestSuite,
-				componentApi.CodeFlareComponentName:            codeflareTestSuite,
-				componentApi.WorkbenchesComponentName:          workbenchesTestSuite,
-				componentApi.KserveComponentName:               kserveTestSuite,
-				componentApi.ModelMeshServingComponentName:     modelMeshServingTestSuite,
-				componentApi.ModelControllerComponentName:      modelControllerTestSuite,
-				componentApi.FeastOperatorComponentName:        feastOperatorTestSuite,
-			},
-		},
-		services: TestGroup{
-			name:    "services",
-			enabled: true,
-			scenarios: map[string]TestFn{
-				serviceApi.MonitoringServiceName: monitoringTestSuite,
-				serviceApi.AuthServiceName:       authControllerTestSuite,
-			},
-		},
-	}
-)
-
-type arrayFlags []string
-
-func (i *arrayFlags) String() string {
-	return fmt.Sprintf("%v", *i)
-}
-
-func (i *arrayFlags) Set(value string) error {
-	*i = append(*i, strings.Split(value, ",")...)
-	return nil
-}
-
-type testContextConfig struct {
+// Struct to store test configurations.
+type TestContextConfig struct {
 	operatorNamespace string
+	appsNamespace     string
 	skipDeletion      bool
+	deleteOnFailure   bool
 
 	operatorControllerTest bool
 	webhookTest            bool
-	components             TestGroup
-	services               TestGroup
 }
 
-// Holds information specific to individual tests.
-type testContext struct {
-	// Rest config
-	cfg *rest.Config
-	// client for k8s resources
-	kubeClient *k8sclient.Clientset
-	// custom client for managing custom resources
-	customClient client.Client
-	// namespace of the deployed applications
-	applicationsNamespace string
-	// test DataScienceCluster instance
-	testDsc *dscv1.DataScienceCluster
-	// test DSCI CR because we do not create it in ODH by default
-	testDSCI *dsciv1.DSCInitialization
-	// test platform
-	platform common.Platform
-	// context for accessing resources
-	//nolint:containedctx //reason: legacy v1 test setup
-	ctx context.Context
-}
-
-func NewTestContext() (*testContext, error) {
-	// GetConfig(): If KUBECONFIG env variable is set, it is used to create
-	// the client, else the inClusterConfig() is used.
-	// Lastly if none of them are set, it uses  $HOME/.kube/config to create the client.
-	config, err := ctrlruntime.GetConfig()
-	if err != nil {
-		return nil, fmt.Errorf("error creating the config object %w", err)
-	}
-
-	kc, err := k8sclient.NewForConfig(config)
-	if err != nil {
-		return nil, fmt.Errorf("failed to initialize Kubernetes client: %w", err)
-	}
-
-	// custom client to manages resources like Route etc
-	custClient, err := client.New(config, client.Options{Scheme: Scheme})
-	if err != nil {
-		return nil, fmt.Errorf("failed to initialize custom client: %w", err)
-	}
-
-	// setup DSCI CR since we do not create automatically by operator
-	testDSCI := setupDSCICR("e2e-test-dsci")
-	// Setup DataScienceCluster CR
-	testDSC := setupDSCInstance("e2e-test-dsc")
-
-	return &testContext{
-		cfg:                   config,
-		kubeClient:            kc,
-		customClient:          custClient,
-		applicationsNamespace: testDSCI.Spec.ApplicationsNamespace,
-		ctx:                   context.TODO(),
-		testDsc:               testDSC,
-		testDSCI:              testDSCI,
-		platform:              testDSCI.Status.Release.Name,
-	}, nil
-}
-
-// TestOdhOperator sets up the testing suite for ODH Operator.
-func TestOdhOperator(t *testing.T) {
-	utilruntime.Must(clientgoscheme.AddToScheme(Scheme))
-	utilruntime.Must(routev1.AddToScheme(Scheme))
-	utilruntime.Must(apiextv1.AddToScheme(Scheme))
-	utilruntime.Must(autoscalingv1.AddToScheme(Scheme))
-	utilruntime.Must(dsciv1.AddToScheme(Scheme))
-	utilruntime.Must(dscv1.AddToScheme(Scheme))
-	utilruntime.Must(featurev1.AddToScheme(Scheme))
-	utilruntime.Must(monitoringv1.AddToScheme(Scheme))
-	utilruntime.Must(ofapi.AddToScheme(Scheme))
-	utilruntime.Must(operatorv1.AddToScheme(Scheme))
-	utilruntime.Must(componentApi.AddToScheme(Scheme))
-	utilruntime.Must(serviceApi.AddToScheme(Scheme))
-	utilruntime.Must(ofapiv1.AddToScheme(Scheme))
-
-	log.SetLogger(zap.New(zap.UseDevMode(true)))
-
-	// config gomega output
-	format.MaxLength = 0         // diabled max length
-	format.TruncatedDiff = false // do not truncate
-
-	gomega.SetDefaultEventuallyTimeout(generalWaitTimeout)
-	gomega.SetDefaultEventuallyPollingInterval(generalPollInterval)
-
-	if testOpts.operatorControllerTest {
-		// individual test suites after the operator is running
-		if !t.Run("validate operator pod is running", testODHOperatorValidation) {
-			return
-		}
-	}
-
-	// Run create and delete tests for all the components
-	t.Run("create DSCI and DSC CRs", creationTestSuite)
-
-	t.Run(testOpts.components.String(), testOpts.components.Run)
-	t.Run(testOpts.services.String(), testOpts.services.Run)
-
-	// Run deletion if skipDeletion is not set
-	if !testOpts.skipDeletion {
-		if testOpts.operatorControllerTest {
-			// this is a negative test case, since by using the positive CM('true'), even CSV gets deleted which leaves no operator pod in prow
-			t.Run("components should not be removed if labeled is set to 'false' on configmap", cfgMapDeletionTestSuite)
-		}
-
-		t.Run("delete components", deletionTestSuite)
-	}
-}
-
-func TestMain(m *testing.M) {
-	// call flag.Parse() here if TestMain uses flags
-	flag.StringVar(&testOpts.operatorNamespace, "operator-namespace", "opendatahub-operator-system", "Namespace where the odh operator is deployed")
-	flag.BoolVar(&testOpts.skipDeletion, "skip-deletion", false, "skip deletion of the controllers")
-
-	flag.BoolVar(&testOpts.operatorControllerTest, "test-operator-controller", true, "run operator controller tests")
-	flag.BoolVar(&testOpts.webhookTest, "test-webhook", true, "run webhook tests")
-
-	componentNames := strings.Join(testOpts.components.Names(), ", ")
-	flag.BoolVar(&testOpts.components.enabled, "test-components", testOpts.components.enabled, "enable tests for components")
-	flag.Var(&testOpts.components.flags, "test-component", "run tests for the specified component. valid components names are: "+componentNames)
-
-	serviceNames := strings.Join(testOpts.services.Names(), ", ")
-	flag.BoolVar(&testOpts.services.enabled, "test-services", testOpts.services.enabled, "enable tests for services")
-	flag.Var(&testOpts.services.flags, "test-service", "run tests for the specified service. valid service names are: "+serviceNames)
-
-	flag.Parse()
-
-	if err := testOpts.components.Validate(); err != nil {
-		fmt.Printf("test-component: %s", err.Error())
-		os.Exit(1)
-	}
-
-	if err := testOpts.services.Validate(); err != nil {
-		fmt.Printf("test-service: %s", err.Error())
-		os.Exit(1)
-	}
-
-	os.Exit(m.Run())
-}
-
+// TestGroup defines the test groups.
 type TestGroup struct {
 	name      string
 	enabled   bool
 	scenarios map[string]TestFn
 	flags     arrayFlags
+}
+
+type TestCase struct {
+	name   string
+	testFn func(t *testing.T)
+}
+
+// TestContext holds test execution context.
+type TestContext struct {
+	// Embeds the common test context.
+	*testf.TestContext
+
+	// Shared Gomega test wrapper.
+	g *testf.WithT
+
+	// Namespace of the deployed applications.
+	OperatorNamespace string
+
+	// Namespace of the deployed applications.
+	AppsNamespace string
+
+	// Namespaced name of the test DSCInitialization CR instance.
+	DSCInitializationNamespacedName types.NamespacedName
+
+	// Namespaced name of the test DataScienceCluster instance.
+	DataScienceClusterNamespacedName types.NamespacedName
+
+	// Test platform.
+	Platform common.Platform
+}
+
+var (
+	Scheme   = runtime.NewScheme()
+	testOpts = TestContextConfig{}
+
+	Components = TestGroup{
+		name:    "components",
+		enabled: true,
+		scenarios: map[string]TestFn{
+			componentApi.DashboardComponentName:            dashboardTestSuite,
+			componentApi.RayComponentName:                  rayTestSuite,
+			componentApi.ModelRegistryComponentName:        modelRegistryTestSuite,
+			componentApi.TrustyAIComponentName:             trustyAITestSuite,
+			componentApi.KueueComponentName:                kueueTestSuite,
+			componentApi.TrainingOperatorComponentName:     trainingOperatorTestSuite,
+			componentApi.DataSciencePipelinesComponentName: dataSciencePipelinesTestSuite,
+			componentApi.CodeFlareComponentName:            codeflareTestSuite,
+			componentApi.WorkbenchesComponentName:          workbenchesTestSuite,
+			componentApi.KserveComponentName:               kserveTestSuite,
+			componentApi.ModelMeshServingComponentName:     modelMeshServingTestSuite,
+			componentApi.ModelControllerComponentName:      modelControllerTestSuite,
+			componentApi.FeastOperatorComponentName:        feastOperatorTestSuite,
+		},
+	}
+
+	Services = TestGroup{
+		name:    "services",
+		enabled: true,
+		scenarios: map[string]TestFn{
+			serviceApi.MonitoringServiceName: monitoringTestSuite,
+			serviceApi.AuthServiceName:       authControllerTestSuite,
+		},
+	}
+)
+
+// Custom flag handling.
+type arrayFlags []string
+
+// String returns the string representation of the arrayFlags.
+func (i *arrayFlags) String() string {
+	return fmt.Sprintf("%v", *i)
+}
+
+// Set appends a new value to the arrayFlags.
+func (i *arrayFlags) Set(value string) error {
+	*i = append(*i, value)
+	return nil
 }
 
 func (tg *TestGroup) String() string {
@@ -254,11 +147,11 @@ func (tg *TestGroup) Validate() error {
 		return errors.New("enabling individual scenarios is not supported when the entire group is disabled")
 	}
 
-	for _, n := range tg.flags {
-		n = strings.TrimLeft(n, "!")
-		if !slices.Contains(tg.Names(), n) {
+	for _, name := range tg.flags {
+		name = strings.TrimLeft(name, "!")
+		if _, ok := tg.scenarios[name]; !ok {
 			validValues := strings.Join(tg.Names(), ", ")
-			return fmt.Errorf("unsupported value %s, valid values are: %s", n, validValues)
+			return fmt.Errorf("unsupported value %s, valid values are: %s", name, validValues)
 		}
 	}
 
@@ -266,36 +159,183 @@ func (tg *TestGroup) Validate() error {
 }
 
 func (tg *TestGroup) Run(t *testing.T) {
+	t.Helper()
+
 	if !tg.enabled {
 		t.Skipf("Test group %s is disabled", tg.name)
 		return
 	}
 
-	disabled := make([]string, 0)
-	enabled := make([]string, 0)
+	disabledTests := make([]string, 0)
+	enabledTests := make([]string, 0)
 
-	for _, n := range tg.flags {
-		if strings.HasPrefix(n, "!") {
-			disabled = append(disabled, strings.TrimLeft(n, "!"))
+	for _, name := range tg.flags {
+		if strings.HasPrefix(name, "!") {
+			disabledTests = append(disabledTests, strings.TrimLeft(name, "!"))
 		} else {
-			enabled = append(enabled, n)
+			enabledTests = append(enabledTests, name)
 		}
 	}
 
-	if len(enabled) == 0 {
-		enabled = maps.Keys(tg.scenarios)
+	// Run all tests if none are explicitly enabled
+	if len(enabledTests) == 0 {
+		enabledTests = maps.Keys(tg.scenarios)
 	}
 
-	enabled = slices.DeleteFunc(enabled, func(n string) bool {
-		return slices.Contains(disabled, n)
+	// Remove disabled tests
+	enabledTests = slices.DeleteFunc(enabledTests, func(n string) bool {
+		return slices.Contains(disabledTests, n)
 	})
 
-	for k, v := range tg.scenarios {
-		if !slices.Contains(enabled, k) {
-			t.Logf("Skipping tests for %s/%s", tg.name, k)
+	// Run each test case
+	for testName, testFunc := range tg.scenarios {
+		if !slices.Contains(enabledTests, testName) {
+			t.Logf("Skipping tests for %s/%s", tg.name, testName)
 			continue
 		}
 
-		t.Run(k, v)
+		mustRun(t, testName, testFunc)
+	}
+}
+
+// NewTestContext initializes a new test context.
+func NewTestContext(t *testing.T) (*TestContext, error) { //nolint:thelper
+	tcf, err := testf.NewTestContext(
+		testf.WithTOptions(
+			testf.WithEventuallyTimeout(defaultEventuallyTimeout),
+			testf.WithEventuallyPollingInterval(defaultEventuallyPollInterval),
+			testf.WithConsistentlyDuration(defaultConsistentlyDuration),
+			testf.WithConsistentlyPollingInterval(defaultConsistentlyPollInterval),
+		),
+	)
+
+	if err != nil {
+		return nil, err
+	}
+
+	release := cluster.GetRelease()
+
+	return &TestContext{
+		TestContext:                      tcf,
+		g:                                tcf.NewWithT(t),
+		DSCInitializationNamespacedName:  types.NamespacedName{Name: dsciInstanceName},
+		DataScienceClusterNamespacedName: types.NamespacedName{Name: dscInstanceName},
+		Platform:                         release.Name,
+		OperatorNamespace:                testOpts.operatorNamespace,
+		AppsNamespace:                    testOpts.appsNamespace,
+	}, nil
+}
+
+// TestOdhOperator sets up the testing suite for ODH Operator.
+func TestOdhOperator(t *testing.T) {
+	registerSchemes()
+
+	log.SetLogger(zap.New(zap.UseDevMode(true)))
+
+	if testOpts.operatorControllerTest {
+		// individual test suites after the operator is running
+		mustRun(t, "ODH Manager E2E Tests", odhOperatorTestSuite)
+	}
+
+	// Run DSCI/DSC test suites
+	mustRun(t, "DSCInitialization and DataScienceCluster management E2E Tests", dscManagementTestSuite)
+
+	// Run components and services test suites
+	mustRun(t, Components.String(), Components.Run)
+	mustRun(t, Services.String(), Services.Run)
+
+	// Run deletion if skipDeletion is not set
+	if !testOpts.skipDeletion {
+		if testOpts.operatorControllerTest {
+			// this is a negative test case, since by using the positive CM('true'), even CSV gets deleted which leaves no operator pod in prow
+			mustRun(t, "Deletion ConfigMap E2E Tests", cfgMapDeletionTestSuite)
+		}
+
+		mustRun(t, "DataScienceCluster/DSCInitialization Deletion E2E Tests", deletionTestSuite)
+	}
+
+	// Cleanup logic after the test finishes, if the test failed
+	t.Cleanup(func() {
+		if t.Failed() && testOpts.deleteOnFailure {
+			fmt.Println("Test failed, running cleanup...")
+			// Cleanup all resources (DSC, DSCI, etc.)
+			CleanupAllResources(t)
+		}
+	})
+}
+
+func TestMain(m *testing.M) {
+	// call flag.Parse() here if TestMain uses flags
+	flag.StringVar(&testOpts.operatorNamespace, "operator-namespace", "opendatahub-operator-system", "Namespace where the odh operator is deployed")
+	flag.StringVar(&testOpts.appsNamespace, "applications-namespace", "opendatahub", "Namespace where the odh applications are deployed")
+	flag.BoolVar(&testOpts.skipDeletion, "skip-deletion", false, "skip deletion of the controllers")
+	flag.BoolVar(&testOpts.deleteOnFailure, "delete-on-failure", false, "Delete DSCInitialization/DataScienceCluster on test failure")
+
+	flag.BoolVar(&testOpts.operatorControllerTest, "test-operator-controller", true, "run operator controller tests")
+	flag.BoolVar(&testOpts.webhookTest, "test-webhook", true, "run webhook tests")
+
+	// Component flags
+	componentNames := strings.Join(Components.Names(), ", ")
+	flag.BoolVar(&Components.enabled, "test-components", Components.enabled, "Enable tests for components")
+	flag.Var(&Components.flags, "test-component", "Run tests for the specified component. Valid names: "+componentNames)
+
+	// Service flags
+	serviceNames := strings.Join(Services.Names(), ", ")
+	flag.BoolVar(&Services.enabled, "test-services", Services.enabled, "Enable tests for services")
+	flag.Var(&Services.flags, "test-service", "Run tests for the specified service. Valid names: "+serviceNames)
+
+	flag.Parse()
+
+	if err := Components.Validate(); err != nil {
+		fmt.Printf("test-component: %s", err.Error())
+		os.Exit(1)
+	}
+
+	if err := Services.Validate(); err != nil {
+		fmt.Printf("test-service: %s", err.Error())
+		os.Exit(1)
+	}
+
+	// Gomega output config:
+	format.MaxLength = 0 // 0 disables truncation entirely
+
+	os.Exit(m.Run())
+}
+
+// registerSchemes registers all necessary schemes for testing.
+func registerSchemes() {
+	schemes := []func(*runtime.Scheme) error{
+		clientgoscheme.AddToScheme,
+		routev1.AddToScheme,
+		apiextv1.AddToScheme,
+		autoscalingv1.AddToScheme,
+		dsciv1.AddToScheme,
+		dscv1.AddToScheme,
+		featurev1.AddToScheme,
+		monitoringv1.AddToScheme,
+		ofapi.AddToScheme,
+		operatorv1.AddToScheme,
+		componentApi.AddToScheme,
+		serviceApi.AddToScheme,
+		ofapiv1.AddToScheme,
+	}
+
+	for _, schemeFn := range schemes {
+		utilruntime.Must(schemeFn(Scheme))
+	}
+}
+
+// mustRun executes a test and stops execution if it fails.
+func mustRun(t *testing.T, name string, testFunc func(t *testing.T)) {
+	t.Helper()
+
+	// If the test already failed, skip running the next test
+	if t.Failed() {
+		return
+	}
+
+	if !t.Run(name, testFunc) {
+		t.Logf("Stopping: %s test failed.", name)
+		t.Fail()
 	}
 }

--- a/tests/e2e/controller_test.go
+++ b/tests/e2e/controller_test.go
@@ -25,13 +25,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
-	"github.com/opendatahub-io/opendatahub-operator/v2/api/common"
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/api/components/v1alpha1"
 	dscv1 "github.com/opendatahub-io/opendatahub-operator/v2/api/datasciencecluster/v1"
 	dsciv1 "github.com/opendatahub-io/opendatahub-operator/v2/api/dscinitialization/v1"
 	featurev1 "github.com/opendatahub-io/opendatahub-operator/v2/api/features/v1"
 	serviceApi "github.com/opendatahub-io/opendatahub-operator/v2/api/services/v1alpha1"
-	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/testf"
 )
 
@@ -81,9 +79,6 @@ type TestContext struct {
 
 	// Namespaced name of the test DataScienceCluster instance.
 	DataScienceClusterNamespacedName types.NamespacedName
-
-	// Test platform.
-	Platform common.Platform
 }
 
 var (
@@ -204,7 +199,7 @@ func NewTestContext(t *testing.T) (*TestContext, error) { //nolint:thelper
 		testf.WithTOptions(
 			testf.WithEventuallyTimeout(defaultEventuallyTimeout),
 			testf.WithEventuallyPollingInterval(defaultEventuallyPollInterval),
-			testf.WithConsistentlyDuration(defaultConsistentlyDuration),
+			testf.WithConsistentlyDuration(defaultConsistentlyTimeout),
 			testf.WithConsistentlyPollingInterval(defaultConsistentlyPollInterval),
 		),
 	)
@@ -213,14 +208,11 @@ func NewTestContext(t *testing.T) (*TestContext, error) { //nolint:thelper
 		return nil, err
 	}
 
-	release := cluster.GetRelease()
-
 	return &TestContext{
 		TestContext:                      tcf,
 		g:                                tcf.NewWithT(t),
 		DSCInitializationNamespacedName:  types.NamespacedName{Name: dsciInstanceName},
 		DataScienceClusterNamespacedName: types.NamespacedName{Name: dscInstanceName},
-		Platform:                         release.Name,
 		OperatorNamespace:                testOpts.operatorNamespace,
 		AppsNamespace:                    testOpts.appsNamespace,
 	}, nil

--- a/tests/e2e/creation_test.go
+++ b/tests/e2e/creation_test.go
@@ -1,335 +1,183 @@
-//nolint:unused
 package e2e_test
 
 import (
-	"context"
+	"encoding/json"
 	"fmt"
-	"log"
-	"reflect"
 	"testing"
 
+	gTypes "github.com/onsi/gomega/types"
 	operatorv1 "github.com/openshift/api/operator/v1"
 	"github.com/stretchr/testify/require"
-	k8serr "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	dscv1 "github.com/opendatahub-io/opendatahub-operator/v2/api/datasciencecluster/v1"
-	dsciv1 "github.com/opendatahub-io/opendatahub-operator/v2/api/dscinitialization/v1"
 	infrav1 "github.com/opendatahub-io/opendatahub-operator/v2/api/infrastructure/v1"
 	modelregistryctrl "github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/components/modelregistry"
+	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/status"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/metadata/labels"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/matchers/jq"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/testf"
+
+	. "github.com/onsi/gomega"
 )
 
-func creationTestSuite(t *testing.T) {
-	testCtx, err := NewTestContext()
-	require.NoError(t, err)
+const (
+	testNamespace               = "test-model-registries"   // Namespace used for model registry testing
+	dsciInstanceNameDuplicate   = "e2e-test-dsci-duplicate" // Instance name for the duplicate DSCInitialization resource
+	dscInstanceNameDuplicate    = "e2e-test-dsc-duplicate"  // Instance name for the duplicate DataScienceCluster resource
+	openshiftOperatorsNamespace = "openshift-operators"     // Namespace for OpenShift Operators
+	serverlessOperatorNamespace = "openshift-serverless"    // Namespace for the Serverless Operator
+)
 
-	err = testCtx.setUp(t)
-	require.NoError(t, err, "error setting up environment")
-
-	t.Run(testCtx.testDsc.Name, func(t *testing.T) {
-		// DSCI
-		t.Run("Creation of DSCI CR", func(t *testing.T) {
-			err = testCtx.testDSCICreation()
-			require.NoError(t, err, "error creating DSCI CR")
-		})
-		if testOpts.webhookTest {
-			t.Run("Creation of more than one of DSCInitialization instance", func(t *testing.T) {
-				testCtx.testDSCIDuplication(t)
-			})
-		}
-		// Validates Servicemesh fields
-		t.Run("Validate DSCInitialization instance", func(t *testing.T) {
-			err = testCtx.validateDSCI()
-			require.NoError(t, err, "error validating DSCInitialization instance")
-		})
-
-		t.Run("Check owned namespaces exist", testCtx.testOwnedNamespacesAllExist)
-
-		// DSC
-		t.Run("Creation of DataScienceCluster instance", func(t *testing.T) {
-			err = testCtx.testDSCCreation(t)
-			require.NoError(t, err, "error creating DataScienceCluster instance")
-		})
-		if testOpts.webhookTest {
-			t.Run("Creation of more than one of DataScienceCluster instance", func(t *testing.T) {
-				testCtx.testDSCDuplication(t)
-			})
-		}
-
-		// Kserve
-		t.Run("Validate Knative resource", func(t *testing.T) {
-			err = testCtx.validateDSC()
-			require.NoError(t, err, "error getting Knative resource as part of DataScienceCluster validation")
-		})
-
-		// ModelReg
-		if testOpts.webhookTest {
-			t.Run("Validate model registry config", func(t *testing.T) {
-				err = testCtx.validateModelRegistryConfig()
-				require.NoError(t, err, "error validating ModelRegistry config")
-			})
-		}
-	})
+// DSCTestCtx holds the context for the DSCInitialization and DataScienceCluster management tests.
+type DSCTestCtx struct {
+	*TestContext
 }
 
-func (tc *testContext) testDSCICreation() error {
-	dscLookupKey := types.NamespacedName{Name: tc.testDsc.Name}
-	createdDSCI := &dsciv1.DSCInitialization{}
-	existingDSCIList := &dsciv1.DSCInitializationList{}
-
-	err := tc.customClient.List(tc.ctx, existingDSCIList)
-	if err == nil {
-		// use what you have
-		if len(existingDSCIList.Items) == 1 {
-			tc.testDSCI = &existingDSCIList.Items[0]
-			return nil
-		}
-	}
-	// create one for you
-	err = tc.customClient.Get(tc.ctx, dscLookupKey, createdDSCI)
-	if err != nil {
-		if k8serr.IsNotFound(err) {
-			nberr := wait.PollUntilContextTimeout(tc.ctx, generalRetryInterval, dsciCreationTimeout, false, func(ctx context.Context) (bool, error) {
-				creationErr := tc.customClient.Create(ctx, tc.testDSCI)
-				if creationErr != nil {
-					log.Printf("error creating DSCI resource %v: %v, trying again",
-						tc.testDSCI.Name, creationErr)
-					return false, nil
-				}
-				return true, nil
-			})
-			if nberr != nil {
-				return fmt.Errorf("error creating e2e-test-dsci DSCI CR %s: %w", tc.testDSCI.Name, nberr)
-			}
-		} else {
-			return fmt.Errorf("error getting e2e-test-dsci DSCI CR %s: %w", tc.testDSCI.Name, err)
-		}
-	}
-
-	return nil
-}
-
-func (tc *testContext) testDSCCreation(t *testing.T) error {
+// dscManagementTestSuite runs the DataScienceCluster and DSCInitialization management test suite.
+func dscManagementTestSuite(t *testing.T) {
 	t.Helper()
-	// Create DataScienceCluster resource if not already created
 
-	existingDSCList := &dscv1.DataScienceClusterList{}
-	err := tc.customClient.List(tc.ctx, existingDSCList)
-	if err == nil {
-		if len(existingDSCList.Items) > 0 {
-			// Use DSC instance if it already exists
-			tc.testDsc = &existingDSCList.Items[0]
-			return nil
-		}
+	// Initialize the test context.
+	tc, err := NewTestContext(t)
+	require.NoError(t, err, "Failed to initialize test context")
+
+	// Create an instance of test context.
+	dscTestCtx := DSCTestCtx{
+		TestContext: tc,
 	}
 
-	dscLookupKey := types.NamespacedName{Name: tc.testDsc.Name}
-	createdDSC := &dscv1.DataScienceCluster{}
-	err = tc.customClient.Get(tc.ctx, dscLookupKey, createdDSC)
-	if err != nil {
-		if k8serr.IsNotFound(err) {
-			dsciErr := wait.PollUntilContextTimeout(tc.ctx, generalRetryInterval, dscCreationTimeout, false, func(ctx context.Context) (bool, error) {
-				creationErr := tc.customClient.Create(ctx, tc.testDsc)
-				if creationErr != nil {
-					log.Printf("error creating DSC resource %v: %v, trying again",
-						tc.testDsc.Name, creationErr)
-
-					return false, nil
-				}
-				return true, nil
-			})
-			if dsciErr != nil {
-				return fmt.Errorf("error creating e2e-test-dsc DSC %s: %w", tc.testDsc.Name, dsciErr)
-			}
-		} else {
-			return fmt.Errorf("error getting e2e-test-dsc DSC %s: %w", tc.testDsc.Name, err)
-		}
-	}
-	return nil
-}
-
-func (tc *testContext) validateDSCReady() error {
-	return waitDSCReady(tc)
-}
-
-// Verify DSC instance is in Ready phase when all components are up and running
-
-func waitDSCReady(tc *testContext) error {
-	// wait for 2 mins which is on the safe side, normally it should get ready once all components are ready
-	err := tc.wait(func(ctx context.Context) (bool, error) {
-		key := types.NamespacedName{Name: tc.testDsc.Name}
-		dsc := &dscv1.DataScienceCluster{}
-
-		err := tc.customClient.Get(ctx, key, dsc)
-		if err != nil {
-			return false, err
-		}
-		return dsc.Status.Phase == readyStatus, nil
-	})
-
-	if err != nil {
-		return fmt.Errorf("Error waiting Ready state for DSC %v: %w", tc.testDsc.Name, err)
+	// Define test cases.
+	testCases := []TestCase{
+		{"Ensure Service Mesh and Serverless operators are installed", dscTestCtx.ValidateOperatorsInstallation},
+		{"Validate creation of DSCInitialization instance", dscTestCtx.ValidateDSCICreation},
+		{"Validate creation of DataScienceCluster instance", dscTestCtx.ValidateDSCCreation},
+		{"Validate ServiceMeshSpec in DSCInitialization instance", dscTestCtx.ValidateServiceMeshSpecInDSCI},
+		{"Validate Knative resource", dscTestCtx.ValidateKnativeSpecInDSC},
+		{"Validate owned namespaces exist", dscTestCtx.ValidateOwnedNamespacesAllExist},
 	}
 
-	return nil
+	// Append webhook-specific tests.
+	if testOpts.webhookTest {
+		webhookTests := []TestCase{
+			{"Validate creation of more than one DSCInitialization instance", dscTestCtx.ValidateDSCIDuplication},
+			{"Validate creation of more than one DataScienceCluster instance", dscTestCtx.ValidateDSCDuplication},
+			{"Validate Model Registry Configuration Changes", dscTestCtx.ValidateModelRegistryConfig},
+		}
+
+		testCases = append(testCases, TestCase{
+			name: "Webhook",
+			testFn: func(t *testing.T) {
+				t.Helper()
+				dscTestCtx.RunTestCases(t, webhookTests)
+			},
+		})
+	}
+
+	// Run the test suite.
+	dscTestCtx.RunTestCases(t, testCases)
 }
 
-func (tc *testContext) requireInstalled(t *testing.T, gvk schema.GroupVersionKind) {
+// ValidateOperatorsInstallation ensures the Service Mesh and Serverless operators are installed.
+func (tc *DSCTestCtx) ValidateOperatorsInstallation(t *testing.T) {
 	t.Helper()
-	list := &unstructured.UnstructuredList{}
-	list.SetGroupVersionKind(gvk)
 
-	err := tc.customClient.List(tc.ctx, list)
-	require.NoErrorf(t, err, "Could not get %s list", gvk.Kind)
+	// Define operators to be installed.
+	operators := []struct {
+		nn                types.NamespacedName
+		skipOperatorGroup bool
+	}{
+		{nn: types.NamespacedName{Name: serviceMeshOpName, Namespace: openshiftOperatorsNamespace}, skipOperatorGroup: true},
+		{nn: types.NamespacedName{Name: serverlessOpName, Namespace: serverlessOperatorNamespace}, skipOperatorGroup: false},
+		{nn: types.NamespacedName{Name: authorinoOpName, Namespace: openshiftOperatorsNamespace}, skipOperatorGroup: true},
+	}
 
-	require.NotEmptyf(t, list.Items, "%s has not been installed", gvk.Kind)
+	// Create and run test cases in parallel.
+	testCases := make([]TestCase, len(operators))
+	for i, op := range operators {
+		testCases[i] = TestCase{
+			name: fmt.Sprintf("Ensure %s is installed", op.nn.Name),
+			testFn: func(t *testing.T) {
+				t.Helper()
+				tc.EnsureOperatorInstalled(op.nn, op.skipOperatorGroup)
+			},
+		}
+	}
+
+	tc.RunTestCases(t, testCases, WithParallel())
 }
 
-func (tc *testContext) testDuplication(t *testing.T, gvk schema.GroupVersionKind, o any) {
+// ValidateDSCICreation validates the creation of a DSCInitialization.
+func (tc *DSCTestCtx) ValidateDSCICreation(t *testing.T) {
 	t.Helper()
-	tc.requireInstalled(t, gvk)
 
-	u, err := runtime.DefaultUnstructuredConverter.ToUnstructured(o)
-	require.NoErrorf(t, err, "Could not unstructure %s", gvk.Kind)
+	// Increase time required to get DSCI created
+	reset := tc.OverrideEventuallyTimeout(eventuallyTimeoutLong, defaultEventuallyPollInterval)
+	defer reset() // Ensure reset happens after test completes
 
-	obj := &unstructured.Unstructured{
-		Object: u,
-	}
-	obj.SetGroupVersionKind(gvk)
-
-	err = tc.customClient.Create(tc.ctx, obj)
-
-	require.Errorf(t, err, "Could create second %s", gvk.Kind)
+	tc.EnsureResourceCreatedOrUpdatedWithCondition(
+		WithObjectToCreate(CreateDSCI(tc.DSCInitializationNamespacedName.Name, tc.AppsNamespace)),
+		NoOpMutationFn,
+		jq.Match(`.status.phase == "%s"`, status.ConditionTypeReady),
+		"Failed to create DSCInitialization resource %s", tc.DSCInitializationNamespacedName.Name,
+	)
 }
 
-func (tc *testContext) testDSCIDuplication(t *testing.T) { //nolint:thelper
-	gvk := schema.GroupVersionKind{
-		Group:   "dscinitialization.opendatahub.io",
-		Version: "v1",
-		Kind:    "DSCInitialization",
-	}
-	dup := setupDSCICR("e2e-test-dsci-dup")
+// ValidateDSCCreation validates the creation of a DataScienceCluster.
+func (tc *DSCTestCtx) ValidateDSCCreation(t *testing.T) {
+	t.Helper()
 
-	tc.testDuplication(t, gvk, dup)
+	// Increase time required to get DSC created
+	reset := tc.OverrideEventuallyTimeout(eventuallyTimeoutMedium, defaultEventuallyPollInterval)
+	defer reset() // Ensure reset happens after test completes
+
+	tc.EnsureResourceCreatedOrUpdatedWithCondition(
+		WithObjectToCreate(CreateDSC(tc.DataScienceClusterNamespacedName.Name)),
+		NoOpMutationFn,
+		jq.Match(`.status.phase == "%s"`, status.ConditionTypeReady),
+		"Failed to create DataScienceCluster resource %s", tc.DataScienceClusterNamespacedName.Name,
+	)
 }
 
-func (tc *testContext) testDSCDuplication(t *testing.T) { //nolint:thelper
-	gvk := schema.GroupVersionKind{
-		Group:   "datasciencecluster.opendatahub.io",
-		Version: "v1",
-		Kind:    "DataScienceCluster",
-	}
-	dup := setupDSCInstance("e2e-test-dsc-dup")
+// ValidateServiceMeshSpecInDSCI validates the ServiceMeshSpec within a DSCInitialization instance.
+func (tc *DSCTestCtx) ValidateServiceMeshSpecInDSCI(t *testing.T) {
+	t.Helper()
 
-	tc.testDuplication(t, gvk, dup)
-}
-
-// TODO: cleanup
-// func (tc *testContext) testAllComponentCreation(t *testing.T) error { //nolint:funlen,thelper
-// 	// Validate all components are in Ready state
-
-// 	dscLookupKey := types.NamespacedName{Name: tc.testDsc.Name}
-// 	createdDSC := &dscv1.DataScienceCluster{}
-
-// 	// Wait for components to get deployed
-// 	time.Sleep(1 * time.Minute)
-
-// 	err := tc.customClient.Get(tc.ctx, dscLookupKey, createdDSC)
-// 	if err != nil {
-// 		return fmt.Errorf("error getting DataScienceCluster instance :%v", tc.testDsc.Name)
-// 	}
-// 	tc.testDsc = createdDSC
-
-// 	components, err := tc.testDsc.GetComponents()
-// 	if err != nil {
-// 		return err
-// 	}
-
-// 	for _, c := range components {
-// 		c := c
-// 		name := c.GetComponentName()
-// 		t.Run("Validate "+name, func(t *testing.T) {
-// 			t.Parallel()
-// 			err = tc.testComponentCreation(c)
-// 			require.NoError(t, err, "error validating component %s when %v", name, c.GetManagementState())
-// 		})
-// 	}
-// 	return nil
-// }
-
-// TODO: cleanup
-// func (tc *testContext) testComponentCreation(component components.ComponentInterface) error {
-// 	err := wait.PollUntilContextTimeout(tc.ctx, generalRetryInterval, componentReadyTimeout, true, func(ctx context.Context) (bool, error) {
-// 		// TODO: see if checking deployment is a good test, CF does not create deployment
-// 		appList, err := tc.kubeClient.AppsV1().Deployments(tc.applicationsNamespace).List(ctx, metav1.ListOptions{
-// 			LabelSelector: labels.ODH.Component(component.GetComponentName()),
-// 		})
-// 		if err != nil {
-// 			log.Printf("error listing component deployments :%v", err)
-// 			return false, fmt.Errorf("error listing component deployments :%w", err)
-// 		}
-// 		if len(appList.Items) != 0 {
-// 			if component.GetManagementState() == operatorv1.Removed {
-// 				// deployment exists for removed component, retrying
-// 				return false, nil
-// 			}
-
-// 			for _, deployment := range appList.Items {
-// 				if deployment.Status.ReadyReplicas < 1 {
-// 					log.Printf("waiting for component deployments to be in Ready state: %s", deployment.Name)
-// 					return false, nil
-// 				}
-// 			}
-// 			return true, nil
-// 		}
-// 		// when no deployment is found
-// 		// It's ok not to have deployements for unmanaged component
-// 		if component.GetManagementState() != operatorv1.Managed {
-// 			return true, nil
-// 		}
-
-// 		return false, nil
-// 	})
-
-// 	return err
-// }
-
-func (tc *testContext) validateDSCI() error {
-	// expected
+	// expected ServiceMeshSpec.
 	expServiceMeshSpec := &infrav1.ServiceMeshSpec{
 		ManagementState: operatorv1.Managed,
 		ControlPlane: infrav1.ControlPlaneSpec{
-			Name:              "data-science-smcp",
-			Namespace:         "istio-system",
-			MetricsCollection: "Istio",
+			Name:              serviceMeshControlPlane,
+			Namespace:         serviceMeshNamespace,
+			MetricsCollection: serviceMeshMetricsCollection,
 		},
 		Auth: infrav1.AuthSpec{
 			Audiences: &[]string{"https://kubernetes.default.svc"},
 		},
 	}
 
-	// actual
-	act := tc.testDSCI
+	// Marshal the expected ServiceMeshSpec to JSON.
+	expServiceMeshSpecJSON, err := json.Marshal(expServiceMeshSpec)
+	tc.g.Expect(err).ShouldNot(HaveOccurred(), "Error marshaling expected ServiceMeshSpec")
 
-	if !reflect.DeepEqual(act.Spec.ServiceMesh, expServiceMeshSpec) {
-		err := fmt.Errorf("Expected service mesh spec %v, got %v",
-			expServiceMeshSpec, act.Spec.ServiceMesh)
-		return err
-	}
-
-	return nil
+	// Assert that the actual ServiceMeshSpec matches the expected one.
+	tc.EnsureResourceExistsAndMatchesCondition(
+		gvk.DSCInitialization,
+		tc.DSCInitializationNamespacedName,
+		jq.Match(`.spec.serviceMesh == %s`, expServiceMeshSpecJSON),
+		"Error validating DSCInitialization instance: Service Mesh spec mismatch",
+	)
 }
 
-// test if knative resource has been created.
-func (tc *testContext) validateDSC() error {
-	expServingSpec := infrav1.ServingSpec{
+// ValidateKnativeSpecInDSC validates that the Kserve serving spec in the DataScienceCluster matches the expected spec.
+func (tc *DSCTestCtx) ValidateKnativeSpecInDSC(t *testing.T) {
+	t.Helper()
+
+	// expected ServingSpec
+	expServingSpec := &infrav1.ServingSpec{
 		ManagementState: operatorv1.Managed,
-		Name:            "knative-serving",
+		Name:            knativeServingNamespace,
 		IngressGateway: infrav1.GatewaySpec{
 			Certificate: infrav1.CertificateSpec{
 				Type: infrav1.OpenshiftDefaultIngress,
@@ -337,61 +185,89 @@ func (tc *testContext) validateDSC() error {
 		},
 	}
 
-	act := tc.testDsc
+	// Marshal the expected ServingSpec to JSON
+	expServingSpecJSON, err := json.Marshal(expServingSpec)
+	tc.g.Expect(err).ShouldNot(HaveOccurred(), "Error marshaling expected ServingSpec")
 
-	if act.Spec.Components.Kserve.Serving != expServingSpec {
-		err := fmt.Errorf("Expected serving spec %v, got %v",
-			expServingSpec, act.Spec.Components.Kserve.Serving)
-		return err
-	}
-
-	return nil
+	// Assert that the actual ServingSpec matches the expected one.
+	tc.EnsureResourceExistsAndMatchesCondition(
+		gvk.DataScienceCluster,
+		tc.DataScienceClusterNamespacedName,
+		jq.Match(`.spec.components.kserve.serving == %s`, expServingSpecJSON),
+		"Error validating DSCInitialization instance: Knative Serving spec mismatch",
+	)
 }
 
-const testNs = "test-model-registries"
+// ValidateOwnedNamespacesAllExist verifies that the owned namespaces exist.
+func (tc *DSCTestCtx) ValidateOwnedNamespacesAllExist(t *testing.T) {
+	t.Helper()
 
-func (tc *testContext) validateModelRegistryConfig() error {
-	// check immutable property registriesNamespace
-	if tc.testDsc.Spec.Components.ModelRegistry.ManagementState != operatorv1.Managed {
-		// allowed to set registriesNamespace to non-default
-		err := patchRegistriesNamespace(tc, testNs, testNs, false)
-		if err != nil {
-			return err
-		}
-		// allowed to set registriesNamespace back to default value
-		err = patchRegistriesNamespace(tc, modelregistryctrl.DefaultModelRegistriesNamespace,
-			modelregistryctrl.DefaultModelRegistriesNamespace, false)
-		if err != nil {
-			return err
-		}
-	} else {
-		// not allowed to change registriesNamespace
-		err := patchRegistriesNamespace(tc, testNs, modelregistryctrl.DefaultModelRegistriesNamespace, true)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
+	// Ensure namespaces with the owned namespace label exist.
+	tc.EnsureResourcesWithLabelsExist(
+		gvk.Namespace,
+		client.MatchingLabels{labels.ODH.OwnedNamespace: "true"},
+		ownedNamespaceNumber,
+		"Expected %d owned namespaces with label '%s'.", labels.ODH.OwnedNamespace,
+	)
 }
 
-func patchRegistriesNamespace(tc *testContext, namespace string, expected string, expectErr bool) error {
-	patchStr := fmt.Sprintf("{\"spec\":{\"components\":{\"modelregistry\":{\"registriesNamespace\":\"%s\"}}}}", namespace)
-	err := tc.customClient.Patch(tc.ctx, tc.testDsc, client.RawPatch(types.MergePatchType, []byte(patchStr)))
-	if err != nil {
-		if !expectErr {
-			return fmt.Errorf("unexpected error when setting registriesNamespace in DSC %s to %s: %w",
-				tc.testDsc.Name, namespace, err)
-		}
+// ValidateDSCIDuplication ensures that no duplicate DSCInitialization resource can be created.
+func (tc *DSCTestCtx) ValidateDSCIDuplication(t *testing.T) {
+	t.Helper()
+
+	dup := CreateDSCI(dsciInstanceNameDuplicate, tc.AppsNamespace)
+	tc.EnsureResourceIsUnique(dup)
+}
+
+// ValidateDSCDuplication ensures that no duplicate DataScienceCluster resource can be created.
+func (tc *DSCTestCtx) ValidateDSCDuplication(t *testing.T) {
+	t.Helper()
+
+	dup := CreateDSC(dscInstanceNameDuplicate)
+	tc.EnsureResourceIsUnique(dup, "Error validating DataScienceCluster duplication")
+}
+
+// ValidateModelRegistryConfig validates the ModelRegistry configuration changes based on ManagementState.
+func (tc *DSCTestCtx) ValidateModelRegistryConfig(t *testing.T) {
+	t.Helper()
+
+	// Retrieve the DataScienceCluster object.
+	dsc := tc.RetrieveDataScienceCluster(tc.DataScienceClusterNamespacedName)
+
+	// Check if the ModelRegistry is managed.
+	if dsc.Spec.Components.ModelRegistry.ManagementState == operatorv1.Managed {
+		// Ensure changing registriesNamespace is not allowed and expect failure.
+		tc.UpdateRegistriesNamespace(testNamespace, modelregistryctrl.DefaultModelRegistriesNamespace, true)
+
+		// No further checks if it's managed
+		return
+	}
+
+	// Ensure setting registriesNamespace to a non-default value is allowed.
+	// No error is expected, and we check the value of the patch after it's successful.
+	tc.UpdateRegistriesNamespace(testNamespace, testNamespace, false)
+
+	// Ensure resetting registriesNamespace to the default value is allowed.
+	tc.UpdateRegistriesNamespace(modelregistryctrl.DefaultModelRegistriesNamespace, modelregistryctrl.DefaultModelRegistriesNamespace, false)
+}
+
+// UpdateRegistriesNamespace updates the ModelRegistry component's `RegistriesNamespace` field.
+func (tc *DSCTestCtx) UpdateRegistriesNamespace(targetNamespace, expectedValue string, shouldFail bool) {
+	// Build the condition:
+	// If shouldFail, we expect a failure (Not(Succeed())).
+	// If should not fail, we expect the registriesNamespace to match the expected value.
+	var expectedCondition gTypes.GomegaMatcher
+	if shouldFail {
+		expectedCondition = Not(Succeed()) // If shouldFail is true, expect failure.
 	} else {
-		if expectErr {
-			return fmt.Errorf("unexpected success when setting registriesNamespace in DSC %s to %s",
-				tc.testDsc.Name, namespace)
-		}
+		expectedCondition = And(Succeed(), jq.Match(`.spec.components.modelregistry.registriesNamespace == "%s"`, expectedValue))
 	}
-	// compare expected against returned registriesNamespace
-	if tc.testDsc.Spec.Components.ModelRegistry.RegistriesNamespace != expected {
-		return fmt.Errorf("expected registriesNamespace %s, got %s",
-			expected, tc.testDsc.Spec.Components.ModelRegistry.RegistriesNamespace)
-	}
-	return nil
+
+	// Update the registriesNamespace field.
+	tc.EnsureResourceCreatedOrPatchedWithCondition(
+		WithMinimalObject(gvk.DataScienceCluster, tc.DataScienceClusterNamespacedName),
+		testf.Transform(`.spec.components.modelregistry.registriesNamespace = "%s"`, targetNamespace),
+		expectedCondition,
+		"Failed to update RegistriesNamespace to %s, expected %s", targetNamespace, expectedValue,
+	)
 }

--- a/tests/e2e/datasciencepipelines_test.go
+++ b/tests/e2e/datasciencepipelines_test.go
@@ -4,45 +4,48 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/api/components/v1alpha1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/status"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
-	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/matchers/jq"
-
-	. "github.com/onsi/gomega"
 )
+
+type DataSciencePipelinesTestCtx struct {
+	*ComponentTestCtx
+}
 
 func dataSciencePipelinesTestSuite(t *testing.T) {
 	t.Helper()
 
-	ct, err := NewComponentTestCtx(&componentApi.DataSciencePipelines{})
+	ct, err := NewComponentTestCtx(t, &componentApi.DataSciencePipelines{})
 	require.NoError(t, err)
 
 	componentCtx := DataSciencePipelinesTestCtx{
 		ComponentTestCtx: ct,
 	}
 
-	t.Run("Validate component enabled", componentCtx.ValidateComponentEnabled)
-	t.Run("Validate component conditions", componentCtx.validateConditions)
-	t.Run("Validate operands have OwnerReferences", componentCtx.ValidateOperandsOwnerReferences)
-	t.Run("Validate update operand resources", componentCtx.ValidateUpdateDeploymentsResources)
-	t.Run("Validate component releases", componentCtx.ValidateComponentReleases)
-	t.Run("Validate component disabled", componentCtx.ValidateComponentDisabled)
+	// Define test cases.
+	testCases := []TestCase{
+		{"Validate component enabled", componentCtx.ValidateComponentEnabled},
+		{"Validate component conditions", componentCtx.ValidateConditions},
+		{"Validate operands have OwnerReferences", componentCtx.ValidateOperandsOwnerReferences},
+		{"Validate update operand resources", componentCtx.ValidateUpdateDeploymentsResources},
+		{"Validate component releases", componentCtx.ValidateComponentReleases},
+		{"Validate component disabled", componentCtx.ValidateComponentDisabled},
+	}
+
+	// Run the test suite.
+	componentCtx.RunTestCases(t, testCases)
 }
 
-type DataSciencePipelinesTestCtx struct {
-	*ComponentTestCtx
-}
+// ValidateConditions validates that the DataSciencePipelines instance's status conditions are correct.
+func (tc *DataSciencePipelinesTestCtx) ValidateConditions(t *testing.T) {
+	t.Helper()
 
-func (c *DataSciencePipelinesTestCtx) validateConditions(t *testing.T) {
-	g := c.NewWithT(t)
-
-	g.List(gvk.DataSciencePipelines).Eventually().Should(And(
-		HaveLen(1),
-		HaveEach(And(
-			jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, status.ConditionArgoWorkflowAvailable, metav1.ConditionTrue),
-		)),
-	))
+	// Ensure the DataSciencePipelines resource has the "ArgoWorkflowAvailable" condition set to "True".
+	tc.ValidateComponentCondition(
+		gvk.DataSciencePipelines,
+		componentApi.DataSciencePipelinesInstanceName,
+		status.ConditionArgoWorkflowAvailable,
+	)
 }

--- a/tests/e2e/deletion_test.go
+++ b/tests/e2e/deletion_test.go
@@ -1,75 +1,52 @@
 package e2e_test
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	k8serr "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	dscv1 "github.com/opendatahub-io/opendatahub-operator/v2/api/datasciencecluster/v1"
-	dsciv1 "github.com/opendatahub-io/opendatahub-operator/v2/api/dscinitialization/v1"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
 )
 
+type DeletionTestCtx struct {
+	*TestContext
+}
+
+// deletionTestSuite runs the deletion test suite.
 func deletionTestSuite(t *testing.T) {
-	testCtx, err := NewTestContext()
-	require.NoError(t, err)
+	t.Helper()
 
-	t.Run(testCtx.testDsc.Name, func(t *testing.T) {
-		t.Run("Deletion DSC instance", func(t *testing.T) {
-			err = testCtx.testDeletionExistDSC()
-			require.NoError(t, err, "Error to delete DSC instance")
-		})
+	// Initialize the test context.
+	tc, err := NewTestContext(t)
+	require.NoError(t, err, "Failed to initialize test context")
 
-		t.Run("Deletion DSCI instance", func(t *testing.T) {
-			err = testCtx.testDeletionExistDSCI()
-			require.NoError(t, err, "Error to delete DSCI instance")
-		})
-	})
-}
-
-func (tc *testContext) testDeletionExistDSC() error {
-	// Delete test DataScienceCluster resource if found
-
-	dscLookupKey := types.NamespacedName{Name: tc.testDsc.Name}
-	expectedDSC := &dscv1.DataScienceCluster{}
-
-	err := tc.customClient.Get(tc.ctx, dscLookupKey, expectedDSC)
-	if err == nil {
-		dscerr := tc.customClient.Delete(tc.ctx, expectedDSC, &client.DeleteOptions{})
-		if dscerr != nil {
-			return fmt.Errorf("error deleting DSC instance %s: %w", expectedDSC.Name, dscerr)
-		}
-	} else if !k8serr.IsNotFound(err) {
-		if err != nil {
-			return fmt.Errorf("could not find DSC instance to delete: %w", err)
-		}
+	// Create an instance of test context.
+	deletionTestCtx := DeletionTestCtx{
+		TestContext: tc,
 	}
 
-	return nil
-}
-
-// To test if  DSCI CR is in the cluster and no problem to delete it
-// if fail on any of these two conditios, fail test.
-func (tc *testContext) testDeletionExistDSCI() error {
-	// Delete test DSCI resource if found
-
-	dsciLookupKey := types.NamespacedName{Name: tc.testDSCI.Name}
-	expectedDSCI := &dsciv1.DSCInitialization{}
-
-	err := tc.customClient.Get(tc.ctx, dsciLookupKey, expectedDSCI)
-	if err == nil {
-		dscierr := tc.customClient.Delete(tc.ctx, expectedDSCI, &client.DeleteOptions{})
-		if dscierr != nil {
-			return fmt.Errorf("error deleting DSCI instance %s: %w", expectedDSCI.Name, dscierr)
-		}
-	} else if !k8serr.IsNotFound(err) {
-		if err != nil {
-			return fmt.Errorf("could not find DSCI instance to delete :%w", err)
-		}
+	// Define the test cases
+	testCases := []TestCase{
+		{"Deletion DataScienceCluster instance", deletionTestCtx.DeletionDSC},
+		{"Deletion DSCInitialization instance", deletionTestCtx.DeletionDSCI},
 	}
 
-	return nil
+	// Run the test suite.
+	deletionTestCtx.RunTestCases(t, testCases)
+}
+
+// DeletionDSC deletes the DataScienceCluster instance if it exists.
+func (tc *DeletionTestCtx) DeletionDSC(t *testing.T) {
+	t.Helper()
+
+	// Delete the DataScienceCluster instance
+	tc.DeleteResource(gvk.DataScienceCluster, tc.DataScienceClusterNamespacedName)
+}
+
+// DeletionDSCI deletes the DSCInitialization instance if it exists.
+func (tc *DeletionTestCtx) DeletionDSCI(t *testing.T) {
+	t.Helper()
+
+	// Delete the DSCInitialization instance
+	tc.DeleteResource(gvk.DSCInitialization, tc.DSCInitializationNamespacedName)
 }

--- a/tests/e2e/deletion_test.go
+++ b/tests/e2e/deletion_test.go
@@ -40,7 +40,7 @@ func (tc *DeletionTestCtx) DeletionDSC(t *testing.T) {
 	t.Helper()
 
 	// Delete the DataScienceCluster instance
-	tc.DeleteResource(gvk.DataScienceCluster, tc.DataScienceClusterNamespacedName)
+	tc.DeleteResource(WithMinimalObject(gvk.DataScienceCluster, tc.DataScienceClusterNamespacedName))
 }
 
 // DeletionDSCI deletes the DSCInitialization instance if it exists.
@@ -48,5 +48,5 @@ func (tc *DeletionTestCtx) DeletionDSCI(t *testing.T) {
 	t.Helper()
 
 	// Delete the DSCInitialization instance
-	tc.DeleteResource(gvk.DSCInitialization, tc.DSCInitializationNamespacedName)
+	tc.DeleteResource(WithMinimalObject(gvk.DSCInitialization, tc.DSCInitializationNamespacedName))
 }

--- a/tests/e2e/feastoperator_test.go
+++ b/tests/e2e/feastoperator_test.go
@@ -8,25 +8,29 @@ import (
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/api/components/v1alpha1"
 )
 
-// TODO: remove unused when test enabled back.
+type FeastOperatorTestCtx struct {
+	*ComponentTestCtx
+}
+
 func feastOperatorTestSuite(t *testing.T) {
 	t.Helper()
 
-	ct, err := NewComponentTestCtx(&componentApi.FeastOperator{})
+	ct, err := NewComponentTestCtx(t, &componentApi.FeastOperator{})
 	require.NoError(t, err)
 
 	componentCtx := FeastOperatorTestCtx{
 		ComponentTestCtx: ct,
 	}
 
-	t.Run("Validate component enabled", componentCtx.ValidateComponentEnabled)
-	t.Run("Validate operands have OwnerReferences", componentCtx.ValidateOperandsOwnerReferences)
-	t.Run("Validate update operand resources", componentCtx.ValidateUpdateDeploymentsResources)
-	t.Run("Validate component disabled", componentCtx.ValidateComponentDisabled)
-	// TODO: Uncomment the following tests after yaml is in ODH repo
-	// t.Run("Validate component releases", componentCtx.ValidateComponentReleases)
-}
+	// Define test cases.
+	testCases := []TestCase{
+		{"Validate component enabled", componentCtx.ValidateComponentEnabled},
+		{"Validate operands have OwnerReferences", componentCtx.ValidateOperandsOwnerReferences},
+		{"Validate update operand resources", componentCtx.ValidateUpdateDeploymentsResources},
+		{"Validate component releases", componentCtx.ValidateComponentReleases},
+		{"Validate component disabled", componentCtx.ValidateComponentDisabled},
+	}
 
-type FeastOperatorTestCtx struct {
-	*ComponentTestCtx
+	// Run the test suite.
+	componentCtx.RunTestCases(t, testCases)
 }

--- a/tests/e2e/helper_test.go
+++ b/tests/e2e/helper_test.go
@@ -1,25 +1,26 @@
 package e2e_test
 
 import (
-	"context"
 	"fmt"
-	"log"
-	"strings"
+	"reflect"
 	"testing"
 	"time"
 
-	"github.com/hashicorp/go-multierror"
+	"github.com/onsi/gomega/gstruct"
+	"github.com/onsi/gomega/matchers"
+	gTypes "github.com/onsi/gomega/types"
+	configv1 "github.com/openshift/api/config/v1"
 	operatorv1 "github.com/openshift/api/operator/v1"
-	ofapiv1 "github.com/operator-framework/api/pkg/operators/v1"
 	ofapi "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	k8serr "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	k8slabels "k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/opendatahub-io/opendatahub-operator/v2/api/common"
@@ -29,87 +30,1301 @@ import (
 	infrav1 "github.com/opendatahub-io/opendatahub-operator/v2/api/infrastructure/v1"
 	serviceApi "github.com/opendatahub-io/opendatahub-operator/v2/api/services/v1alpha1"
 	modelregistryctrl "github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/components/modelregistry"
-	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/metadata/labels"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/resources"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/matchers/jq"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/testf"
+
+	. "github.com/onsi/gomega"
 )
 
-const (
-	knativeServingNamespace  = "knative-serving"
-	serverlessOpName         = "serverless-operator"
-	ownedNamespaceNumber     = 1 // set to 4 for RHOAI
-	deleteConfigMap          = "delete-configmap-name"
-	operatorReadyTimeout     = 2 * time.Minute
-	componentReadyTimeout    = 7 * time.Minute // in component code is to set 2-3 mins, keep it 7 mins just the same value we used after introduce "Ready" check
-	componentDeletionTimeout = 1 * time.Minute
-	crdReadyTimeout          = 1 * time.Minute
-	csvWaitTimeout           = 1 * time.Minute
-	dsciCreationTimeout      = 20 * time.Second // time required to get a DSCI is created.
-	dscCreationTimeout       = 20 * time.Second // time required to wait till DSC is created.
-	generalRetryInterval     = 10 * time.Second
-	generalWaitTimeout       = 2 * time.Minute
-	generalPollInterval      = 1 * time.Second
-	readyStatus              = "Ready"
-	dscKind                  = "DataScienceCluster"
-)
-
-func (tc *testContext) waitForOperatorDeployment(name string, replicas int32) error {
-	err := wait.PollUntilContextTimeout(tc.ctx, generalRetryInterval, operatorReadyTimeout, false, func(ctx context.Context) (bool, error) {
-		controllerDeployment, err := tc.kubeClient.AppsV1().Deployments(testOpts.operatorNamespace).Get(ctx, name, metav1.GetOptions{})
-		if err != nil {
-			if k8serr.IsNotFound(err) {
-				return false, nil
-			}
-			log.Printf("Failed to get %s controller deployment", name)
-
-			return false, err
-		}
-
-		for _, condition := range controllerDeployment.Status.Conditions {
-			if condition.Type == appsv1.DeploymentAvailable {
-				if condition.Status == corev1.ConditionTrue && controllerDeployment.Status.ReadyReplicas == replicas {
-					return true, nil
-				}
-			}
-		}
-		log.Printf("Error in %s deployment", name)
-		return false, nil
-	})
-
-	return err
+var NoOpMutationFn = func(obj *unstructured.Unstructured) error {
+	return nil // No operation, just return nil
 }
 
-func (tc *testContext) getComponentDeployments(componentGVK schema.GroupVersionKind) ([]appsv1.Deployment, error) {
-	deployments := appsv1.DeploymentList{}
-	err := tc.customClient.List(
-		tc.ctx,
-		&deployments,
-		client.InNamespace(
-			tc.applicationsNamespace,
-		),
-		client.MatchingLabels{
-			labels.PlatformPartOf: strings.ToLower(componentGVK.Kind),
-		},
-	)
+// Namespace and Operator Constants.
+const (
+	// Namespaces for various components.
+	knativeServingNamespace = "knative-serving" // Namespace for Knative Serving components
 
-	if err != nil {
-		return nil, err
+	// Operators constants.
+	serviceMeshOpName            = "servicemeshoperator" // Name of the Service Mesh Operator
+	serverlessOpName             = "serverless-operator" // Name of the Serverless Operator
+	authorinoOpName              = "authorino-operator"  // Name of the Serverless Operator
+	serviceMeshControlPlane      = "data-science-smcp"   // Service Mesh control plane name
+	serviceMeshNamespace         = "istio-system"        // Namespace for Istio Service Mesh control plane
+	serviceMeshMetricsCollection = "Istio"               // Metrics collection for Service Mesh (e.g., Istio)
+	serviceMeshMemberName        = "default"
+)
+
+// Timeout & Interval Constants.
+const (
+	generalRetryInterval = 10 * time.Second // Retry interval for general operations
+
+	defaultEventuallyTimeout        = 5 * time.Minute  // Set default timeout for Eventually (default is 1 second).
+	defaultEventuallyPollInterval   = 2 * time.Second  // Set default timeout for Eventually (default is 1 second).
+	defaultConsistentlyDuration     = 10 * time.Second // Set default duration for Consistently (default is 2 seconds).
+	defaultConsistentlyPollInterval = 2 * time.Second  // Set default polling interval for Consistently (default is 50ms).
+
+	eventuallyTimeoutMedium = 7 * time.Minute  // Medium timeout for readiness checks (e.g., CSV, DSC)
+	eventuallyTimeoutLong   = 10 * time.Minute // Longer timeout for more complex readiness (e.g., DSCInitialization, KServe)
+)
+
+// Configuration and Miscellaneous Constants.
+const (
+	ownedNamespaceNumber = 1 // Number of namespaces owned, adjust to 4 for RHOAI deployment
+
+	dsciInstanceName = "e2e-test-dsci" // Instance name for the DSCInitialization
+	dscInstanceName  = "e2e-test-dsc"  // Instance name for the DataScienceCluster
+
+	// Standard error messages format.
+	resourceNotNilErrorMsg     = "Expected a non-nil resource object but got nil."
+	resourceNotFoundErrorMsg   = "Expected resource '%s' of kind '%s' to exist, but it was not found or could not be retrieved."
+	resourceFoundErrorMsg      = "Expected resource '%s' of kind '%s' to not exist, but it was found."
+	resourceEmptyErrorMsg      = "Expected resource list '%s' of kind '%s' to contain resources, but it was empty."
+	resourceNotEmptyErrorMsg   = "Expected resource list '%s' of kind '%s' to be empty, but it contains resources."
+	resourceFetchErrorMsg      = "Error occurred while fetching the resource '%s' of kind '%s': %v"
+	unexpectedErrorMismatchMsg = "Expected error '%v' to match the actual error '%v' for resource of kind '%s'."
+)
+
+// RunTestCases runs a series of test cases, optionally in parallel based on the provided options.
+//
+// Parameters:
+//   - t (*testing.T): The test context passed into the test function.
+//   - testCases ([]TestCase): A slice of test cases to execute.
+//   - opts (...TestCaseOption): Optional configuration options, like enabling parallel execution.
+func (tc *TestContext) RunTestCases(t *testing.T, testCases []TestCase, opts ...TestCaseOption) {
+	t.Helper()
+
+	// Apply all provided options (e.g., parallel execution) to each test case.
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			// Apply each option to the current test
+			for _, opt := range opts {
+				opt(t)
+			}
+
+			// Run the test function for the current test case
+			testCase.testFn(t)
+		})
+	}
+}
+
+// TestCaseOption defines a function type that can be used to modify how individual test cases are executed.
+type TestCaseOption func(t *testing.T)
+
+// WithParallel is an option that marks test cases to run in parallel.
+func WithParallel() TestCaseOption {
+	return func(t *testing.T) {
+		t.Helper()
+
+		t.Parallel() // Marks the test case to run in parallel with other tests
+	}
+}
+
+// ResourceOption defines a function type for constructing or retrieving an unstructured Kubernetes resource.
+type ResourceOption func(tc *TestContext) *unstructured.Unstructured
+
+// WithObjectToCreate creates a ResourceOption that converts any object to an unstructured object.
+// This is used when the object doesn't exist yet and needs to be created (or updated).
+func WithObjectToCreate(obj client.Object) ResourceOption {
+	return func(tc *TestContext) *unstructured.Unstructured {
+		// Convert the input object to unstructured
+		u, err := resources.ObjectToUnstructured(tc.Scheme(), obj)
+		tc.g.Expect(err).NotTo(HaveOccurred())
+
+		return u
+	}
+}
+
+// WithFetchedObject returns a ResourceOption that fetches the resource by GroupVersionKind and NamespacedName.
+// It calls `EnsureResourceExists` internally to retrieve the resource for updating or patching.
+func WithFetchedObject(gvk schema.GroupVersionKind, nn types.NamespacedName) ResourceOption {
+	return func(tc *TestContext) *unstructured.Unstructured {
+		return tc.EnsureResourceExists(gvk, nn)
+	}
+}
+
+// WithMinimalObject creates a ResourceOption that creates an unstructured object with only the specified
+// GroupVersionKind, Namespace, and Name. This is useful for cases where only minimal resource details are needed,
+// like namespaces or certain simple resource types.
+func WithMinimalObject(gvk schema.GroupVersionKind, nn types.NamespacedName) ResourceOption {
+	return func(tc *TestContext) *unstructured.Unstructured {
+		// Create a new unstructured object and set the necessary fields
+		u := resources.GvkToUnstructured(gvk) // Set the GroupVersionKind
+		u.SetNamespace(nn.Namespace)          // Set the Namespace
+		u.SetName(nn.Name)                    // Set the Name
+
+		// Return the object with only the essential fields set
+		return u
+	}
+}
+
+// WithMinimalObjectFrom creates a ResourceOption that creates an unstructured object with the minimal required fields
+// (GroupVersionKind, Namespace, Name) extracted from the provided object.
+func WithMinimalObjectFrom(obj client.Object) ResourceOption {
+	return func(tc *TestContext) *unstructured.Unstructured {
+		// Extract the GroupVersionKind (GVK) from the object
+		groupVersionKind := obj.GetObjectKind().GroupVersionKind()
+
+		// Create a new unstructured object with the extracted GVK
+		u := resources.GvkToUnstructured(groupVersionKind)
+
+		// Set the Namespace and Name from the provided object
+		u.SetNamespace(obj.GetNamespace())
+		u.SetName(obj.GetName())
+
+		// Return the object with only the essential fields set (GVK, Namespace, Name)
+		return u
+	}
+}
+
+// OverrideEventuallyTimeout temporarily changes the Eventually timeout and polling period.
+func (tc *TestContext) OverrideEventuallyTimeout(timeout, pollInterval time.Duration) func() {
+	// Save current timeout values (you'll need to store these manually)
+	previousTimeout := tc.g.DurationBundle.EventuallyTimeout
+	previousPollInterval := tc.g.DurationBundle.EventuallyPollingInterval
+
+	// Override with new values
+	tc.g.SetDefaultEventuallyTimeout(timeout)
+	tc.g.SetDefaultConsistentlyPollingInterval(pollInterval)
+
+	// Return a function to reset them back
+	return func() {
+		// Override with new values
+		tc.g.SetDefaultEventuallyTimeout(previousTimeout)
+		tc.g.SetDefaultConsistentlyPollingInterval(previousPollInterval)
+	}
+}
+
+// EnsureResourceExistsOrNil attempts to retrieve a specific Kubernetes resource from the cluster.
+// It retries fetching the resource until the retry window expires. If the resource exists, it returns it.
+// If the resource does not exist, it returns nil and does not fail the test, which is useful when subsequent actions
+// (such as creating the resource) are intended.
+//
+// Parameters:
+//   - gvk (schema.GroupVersionKind): The GroupVersionKind of the resource being checked.
+//   - nn (types.NamespacedName): The namespace and name of the resource.
+//   - args (...interface{}): Optional Gomega assertion message arguments. If none are provided, a default message
+//     is used for failure when the resource is expected to exist but cannot be found.
+//
+// Returns:
+//   - *unstructured.Unstructured: The resource object if it exists, or nil if not found.
+func (tc *TestContext) EnsureResourceExistsOrNil(
+	gvk schema.GroupVersionKind,
+	nn types.NamespacedName,
+	args ...any,
+) (*unstructured.Unstructured, error) {
+	// Construct a resource identifier.
+	resourceID := resources.FormatNamespacedName(nn)
+
+	// Attempt to get the resource with retries
+	var u *unstructured.Unstructured
+	var err error
+	tc.g.Eventually(func(g Gomega) {
+		// Fetch the resource
+		u, err = tc.g.Get(gvk, nn).Get()
+
+		// Explicitly set to nil if the resource is not found
+		if errors.IsNotFound(err) {
+			u = nil
+			return
+		}
+
+		// Ensure no unexpected errors occurred while fetching the resource
+		g.Expect(err).ToNot(HaveOccurred(),
+			appendDefaultIfNeeded(resourceFetchErrorMsg, []any{resourceID, gvk.Kind, err}, args)...,
+		)
+	}).Should(Succeed())
+
+	// Return the resource or nil if it wasn't found
+	return u, err
+}
+
+// EnsureResourceExists verifies whether a specific Kubernetes resource exists by checking its presence in the cluster.
+// If the resource doesn't exist, it will fail the test with an error message.
+//
+// Parameters:
+//   - gvk (schema.GroupVersionKind): The GroupVersionKind of the resource being checked.
+//   - nn (types.NamespacedName): The namespace and name of the resource.
+//   - args (...interface{}): Optional Gomega assertion message arguments. If none are provided, a default message is used.
+//
+// Returns:
+//   - *unstructured.Unstructured: The resource object if it exists.
+func (tc *TestContext) EnsureResourceExists(
+	gvk schema.GroupVersionKind,
+	nn types.NamespacedName,
+	args ...any,
+) *unstructured.Unstructured {
+	// Construct a resource identifier.
+	resourceID := resources.FormatNamespacedName(nn)
+
+	// Use EnsureResourceExistsOrNil to attempt to fetch the resource with retries
+	u, _ := tc.EnsureResourceExistsOrNil(gvk, nn)
+
+	// Ensure that the resource object is not nil
+	tc.g.Expect(u).NotTo(BeNil(),
+		appendDefaultIfNeeded(resourceNotFoundErrorMsg, []any{resourceID, gvk.Kind}, args)...)
+
+	return u
+}
+
+// EnsureResourceExistsAndMatchesCondition ensures that the resource exists and matches the given condition.
+// Callers should explicitly use `Not(matcher)` if they need to assert a negative condition.
+//
+// Parameters:
+//   - gvk (schema.GroupVersionKind): The GroupVersionKind of the resource being checked.
+//   - nn (types.NamespacedName): The namespace and name of the resource (used for filtering).
+//   - condition: A Gomega matcher specifying the expected condition (e.g., BeEmpty(), Not(BeEmpty()), jq.Match()).
+//   - args (optional): Gomega assertion message arguments. If not provided, a default message is used.
+//
+// Returns:
+//   - *unstructured.Unstructured: The resource that was found and matched.
+func (tc *TestContext) EnsureResourceExistsAndMatchesCondition(
+	gvk schema.GroupVersionKind,
+	nn types.NamespacedName,
+	condition gTypes.GomegaMatcher,
+	args ...any,
+) *unstructured.Unstructured {
+	var u *unstructured.Unstructured
+
+	tc.g.Eventually(func(g Gomega) {
+		// Ensure the resource exists by using EnsureResourceExists
+		u = tc.EnsureResourceExists(gvk, nn)
+
+		// Get GroupVersionKind from the resource.
+		groupVersionKind := u.GetObjectKind().GroupVersionKind()
+
+		// Construct a resource identifier.
+		resourceID := resources.FormatUnstructuredName(u)
+
+		// Apply the provided condition matcher to the resource.
+		applyMatchers(g, resourceID, groupVersionKind, u, nil, condition, args)
+	}).Should(Succeed())
+
+	return u
+}
+
+// EnsureResourceExistsAndMatchesConditionConsistently verifies that a Kubernetes resource exists and
+// consistently matches a specified condition over a period of time.
+//
+// It repeatedly checks the resource using the provided condition for the specified `timeout` and `polling`
+// intervals, and ensures that the condition holds true consistently within the given time frame.
+//
+// Parameters:
+//   - gvk (schema.GroupVersionKind): The GroupVersionKind of the resource to be checked.
+//   - nn (types.NamespacedName): The namespaced name (namespace + name) of the resource.
+//   - condition: A Gomega matcher specifying the expected condition (e.g., BeEmpty(), Not(BeEmpty()), jq.Match()).
+//   - timeout (time.Duration): The maximum time to wait for the condition to be true consistently.
+//   - polling (time.Duration): The interval to poll for checking the condition.
+//
+// Optional Arguments:
+//   - If `timeout` and `polling` are not provided, default values will be used.
+//     Default timeout: 10 seconds
+//     Default polling interval: 2 second
+//
+// Returns:
+//   - *unstructured.Unstructured: The resource that was found and matched.
+func (tc *TestContext) EnsureResourceExistsAndMatchesConditionConsistently(
+	gvk schema.GroupVersionKind,
+	nn types.NamespacedName,
+	condition gTypes.GomegaMatcher,
+	timeout time.Duration,
+	polling time.Duration,
+	args ...any,
+) {
+	// Set default values for timeout and polling if not provided
+	if timeout == 0 {
+		timeout = defaultConsistentlyDuration // default timeout if not provided
+	}
+	if polling == 0 {
+		polling = defaultConsistentlyPollInterval // default polling interval if not provided
 	}
 
-	return deployments.Items, nil
+	// Ensure the resource exists and matches the condition consistently over the specified period.
+	tc.g.Consistently(func(g Gomega) {
+		// Retrieve the resource
+		u := tc.EnsureResourceExists(gvk, nn)
+
+		// Get GroupVersionKind from the resource.
+		groupVersionKind := u.GetObjectKind().GroupVersionKind()
+
+		// Construct a resource identifier.
+		resourceID := resources.FormatUnstructuredName(u)
+
+		// Apply the condition to the resource and assert that it matches
+		applyMatchers(g, resourceID, groupVersionKind, u, nil, condition, args)
+	}, timeout, polling)
 }
 
-func setupDSCICR(name string) *dsciv1.DSCInitialization {
-	dsciTest := &dsciv1.DSCInitialization{
+// EnsureResourceDoesNotExist verifies whether a specific Kubernetes resource does not exist by checking its presence in the cluster.
+// If the resource exists, it will fail the test with an error message.
+//
+// Parameters:
+//   - gvk (schema.GroupVersionKind): The GroupVersionKind of the resource being checked.
+//   - nn (types.NamespacedName): The namespace and name of the resource.
+//   - args (...interface{}): Optional Gomega assertion message arguments. If none are provided, a default message is used.
+func (tc *TestContext) EnsureResourceDoesNotExist(
+	gvk schema.GroupVersionKind,
+	nn types.NamespacedName,
+	args ...any,
+) {
+	_ = tc.ensureResourceDoesNotExist(tc.g, gvk, nn, args)
+}
+
+// EnsureResourceDoesNotExistAndErrorMatches ensures that the given resource does not exist
+// and that the error encountered while retrieving it matches the expected error.
+//
+// Parameters:
+//   - gvk (schema.GroupVersionKind): The GroupVersionKind of the resource to check.
+//   - nn (types.NamespacedName): The namespaced name of the resource.
+//   - expectedErr (error): The expected error (e.g., &meta.NoKindMatchError{}).
+func (tc *TestContext) EnsureResourceDoesNotExistAndErrorMatches(
+	gvk schema.GroupVersionKind,
+	nn types.NamespacedName,
+	expectedErr error,
+	args ...any,
+) {
+	err := tc.ensureResourceDoesNotExist(tc.g, gvk, nn, args)
+
+	// Ensure the error matches the expected condition.
+	tc.g.Expect(err).To(MatchError(expectedErr), unexpectedErrorMismatchMsg, expectedErr, err, gvk.Kind)
+}
+
+// EnsureResourceGone waits for the specified resource to disappear or until a timeout occurs.
+// It retries checking the resource at regular intervals and fails if the resource is still found after the timeout.
+//
+// Parameters:
+//   - gvk (schema.GroupVersionKind): The GroupVersionKind of the resource to check.
+//   - nn (types.NamespacedName): The namespace and name of the resource.
+//   - args (...interface{}): Optional Gomega assertion message arguments.
+func (tc *TestContext) EnsureResourceGone(
+	gvk schema.GroupVersionKind,
+	nn types.NamespacedName,
+	args ...any,
+) {
+	// Use Eventually to retry checking the resource until it disappears or timeout occurs
+	tc.g.Eventually(func(g Gomega) {
+		_ = tc.ensureResourceDoesNotExist(g, gvk, nn, args)
+	}).Should(Succeed())
+}
+
+// EnsureResourceIsGoneAndErrorMatches ensures that the given resource is eventually removed from the cluster
+// and that the error encountered while retrieving it matches the expected error.
+//
+// Parameters:
+//   - gvk (schema.GroupVersionKind): The GroupVersionKind of the resource to check.
+//   - nn (types.NamespacedName): The namespaced name of the resource.
+//   - expectedErr (error): The expected error (e.g., &meta.NoKindMatchError{}).
+func (tc *TestContext) EnsureResourceIsGoneAndErrorMatches(
+	gvk schema.GroupVersionKind,
+	nn types.NamespacedName,
+	expectedErr error,
+	args ...any,
+) {
+	// Use Eventually to retry checking the resource until it disappears or timeout occurs
+	tc.g.Eventually(func(g Gomega) {
+		err := tc.ensureResourceDoesNotExist(g, gvk, nn, args)
+
+		// Ensure the error matches the expected condition.
+		g.Expect(err).To(MatchError(expectedErr), unexpectedErrorMismatchMsg, expectedErr, err, gvk.Kind)
+	}).Should(Succeed())
+}
+
+// EnsureResourcesExist verifies whether a list of specific Kubernetes resources exists in the cluster.
+// It waits for the resources to appear and fails the test with a message if any resource is not found within the timeout.
+//
+// Parameters:
+//   - gvk (schema.GroupVersionKind): The GroupVersionKind of the resource being checked.
+//   - nn (types.NamespacedName): The namespace and name of the resource.
+//   - listOptions (*client.ListOptions): Optional list options like label selectors or other filters.
+//   - args (...interface{}): Optional Gomega assertion message arguments. If none are provided, a default message is used.
+//
+// Returns:
+//   - []unstructured.Unstructured: The list of resources if they exist.
+func (tc *TestContext) EnsureResourcesExist(
+	gvk schema.GroupVersionKind,
+	nn types.NamespacedName,
+	listOptions *client.ListOptions,
+	args ...any,
+) []unstructured.Unstructured {
+	// Construct a resource identifier
+	resourceID := resources.FormatNamespacedName(nn)
+
+	resourcesList := tc.RetrieveResources(gvk, nn, listOptions, args...)
+
+	// Ensure that the resources list is not empty
+	tc.g.Expect(resourcesList).NotTo(BeEmpty(), resourceEmptyErrorMsg, resourceID, gvk.Kind)
+
+	return resourcesList
+}
+
+// EnsureResourcesExistAndMatchCondition verifies whether a list of resources of a specific kind exists
+// in the cluster, and ensures that the list matches the specified condition (e.g., length, owner references, etc.).
+//
+// Parameters:
+//   - gvk (schema.GroupVersionKind): The GroupVersionKind of the resource being checked.
+//   - nn (types.NamespacedName): The namespace and name of the resource.
+//   - listOptions (*client.ListOptions): Optional list options like label selectors or other filters.
+//   - condition gTypes.GomegaMatcher: The condition to check the list of resources against (e.g., owner references, length).
+//   - args (...interface{}): Optional Gomega assertion message arguments.
+//
+// Returns:
+//   - []unstructured.Unstructured: The list of resources that match the condition.
+func (tc *TestContext) EnsureResourcesExistAndMatchCondition(
+	gvk schema.GroupVersionKind,
+	nn types.NamespacedName,
+	listOptions *client.ListOptions,
+	condition gTypes.GomegaMatcher,
+	args ...any,
+) []unstructured.Unstructured {
+	var resourcesList []unstructured.Unstructured
+
+	tc.g.Eventually(func(g Gomega) {
+		// Construct a resource identifier
+		resourceID := resources.FormatNamespacedName(nn)
+
+		// First, ensure that the resources exist using EnsureResourcesExist
+		resourcesList = tc.EnsureResourcesExist(gvk, nn, listOptions, args...)
+
+		// Apply the provided condition matcher to the resource.
+		applyMatchers(g, resourceID, gvk, resourcesList, nil, condition, args)
+	}).Should(Succeed())
+
+	return resourcesList
+}
+
+// EnsureResourcesDoNotExist ensures that the resources for a given GVK and namespace do not exist in the cluster.
+//
+// This function uses `Eventually` to ensure that no resources are found matching the given criteria,
+// verifying that the resources do not exist or have been removed successfully.
+//
+// Parameters:
+//   - gvk (schema.GroupVersionKind): The GroupVersionKind of the resources to ensure do not exist.
+//   - nn (types.NamespacedName): The namespace and name of the resource(s) to check.
+//   - listOptions (*client.ListOptions, optional): Optional list options (e.g., label selectors) for filtering the resources.
+//   - args (...any, optional): Optional arguments for error messages or logging.
+func (tc *TestContext) EnsureResourcesDoNotExist(
+	gvk schema.GroupVersionKind,
+	nn types.NamespacedName,
+	listOptions *client.ListOptions,
+	args ...any,
+) {
+	tc.ensureResourcesDoNotExist(tc.g, gvk, nn, listOptions, args)
+}
+
+// EnsureResourcesGone waits for the list of resources to disappear or until a timeout occurs.
+// It retries checking the resources at regular intervals and fails if any resource is still found after the timeout.
+//
+// Parameters:
+//   - gvk (schema.GroupVersionKind): The GroupVersionKind of the resources to check.
+//   - nn (types.NamespacedName): The namespace and name of the resource(s).
+//   - listOptions (*client.ListOptions, optional): Optional list options for filtering the resources (e.g., label selectors).
+//   - args (...interface{}): Optional Gomega assertion message arguments.
+func (tc *TestContext) EnsureResourcesGone(
+	gvk schema.GroupVersionKind,
+	nn types.NamespacedName,
+	listOptions *client.ListOptions,
+	args ...any,
+) {
+	// Use Eventually to retry checking the resource until it disappears or timeout occurs
+	tc.g.Eventually(func(g Gomega) {
+		tc.ensureResourcesDoNotExist(g, gvk, nn, listOptions, args)
+	}).Should(Succeed())
+}
+
+// EnsureExactlyOneResourceExists verifies that exactly one instance of a specific Kubernetes resource
+// exists in the cluster. If there are none or more than one, it fails the test.
+//
+// Parameters:
+//   - gvk (schema.GroupVersionKind): The GroupVersionKind of the resource being checked.
+//   - nn (types.NamespacedName): The namespace and name of the resource (used for filtering).
+//   - args (...interface{}): Optional Gomega assertion message arguments. Defaults to a standard error message.
+//
+// Returns:
+//   - *unstructured.Unstructured: The resource object if exactly one instance exists.
+func (tc *TestContext) EnsureExactlyOneResourceExists(
+	gvk schema.GroupVersionKind,
+	nn types.NamespacedName,
+	args ...any,
+) *unstructured.Unstructured {
+	// Construct a resource identifier.
+	resourceID := resources.FormatNamespacedName(nn)
+
+	// Use Eventually to retry getting the resources until they appears
+	var objList []unstructured.Unstructured
+	tc.g.Eventually(func(g Gomega) {
+		// Fetch the resources
+		var err error
+		objList, err = tc.g.List(gvk).Get()
+
+		// Ensure no error occurred when fetching resources
+		g.Expect(err).NotTo(HaveOccurred(), appendDefaultIfNeeded(
+			resourceFetchErrorMsg,
+			[]any{resourceID, gvk.Kind, err},
+			args,
+		)...)
+
+		// Ensure the resource list is not empty
+		g.Expect(objList).NotTo(BeEmpty(), resourceEmptyErrorMsg, resourceID, gvk.Kind)
+
+		// Ensure exactly one resource exists
+		g.Expect(objList).To(HaveLen(1), appendDefaultIfNeeded(
+			"Expected exactly one resource '%s' of kind '%s', but found %d.",
+			[]any{resourceID, gvk.Kind, len(objList)},
+			args,
+		)...)
+	}).Should(Succeed())
+
+	return &objList[0]
+}
+
+// EnsureResourcesWithLabelsExist ensures that at least `minCount` resources of a given kind
+// exist in the cluster, filtered by the specified labels.
+//
+// Parameters:
+//   - gvk (schema.GroupVersionKind): The GroupVersionKind of the resources being checked.
+//   - matchingLabels (client.MatchingLabels): The label selector used to filter the resources.
+//   - minCount (int): The minimum number of matching resources expected.
+//   - args (...any): Optional additional arguments for assertion messages.
+func (tc *TestContext) EnsureResourcesWithLabelsExist(
+	gvk schema.GroupVersionKind,
+	matchingLabels client.MatchingLabels,
+	minCount int,
+	args ...any,
+) {
+	tc.g.Eventually(func(g Gomega) {
+		// Fetch resources based on labels
+		var err error
+		objList, err := tc.g.List(gvk, matchingLabels).Get()
+
+		// Check if an error occurred while listing resources
+		g.Expect(err).NotTo(
+			HaveOccurred(),
+			"Failed to list resources of kind '%s' with labels '%s': %v",
+			gvk.Kind, k8slabels.FormatLabels(matchingLabels), err,
+		)
+
+		// Ensure at least `minCount` resources exist
+		g.Expect(len(objList)).To(
+			BeNumerically(">=", minCount),
+			appendDefaultIfNeeded(
+				"Expected at least %d resources of kind '%s' with labels '%s', but found %d.",
+				[]any{minCount, gvk.Kind, k8slabels.FormatLabels(matchingLabels), len(objList)},
+				args,
+			)...,
+		)
+	}).Should(Succeed())
+}
+
+// EnsureResourceCreatedOrUpdated ensures that a given Kubernetes resource exists.
+// If the resource is missing, it will be created; if it already exists, it will be updated
+// using the provided mutation function.
+//
+// Parameters:
+//   - option (ResourceOption): A function that provides the resource object (either existing or new).
+//   - fn (func(*unstructured.Unstructured) error): A function to modify the resource before applying it.
+//   - args (...interface{}): Optional Gomega assertion message arguments. If none are provided, a default message is used.
+//
+// Returns:
+//   - *unstructured.Unstructured: The existing or newly created (updated) resource object.
+func (tc *TestContext) EnsureResourceCreatedOrUpdated(
+	option ResourceOption,
+	fn func(obj *unstructured.Unstructured) error,
+	args ...any,
+) *unstructured.Unstructured {
+	return tc.EnsureResourceCreatedOrUpdatedWithCondition(option, fn, Succeed(), args...)
+}
+
+// EnsureResourceCreatedOrUpdatedWithCondition ensures that a Kubernetes resource is either created or updated
+// and that it meets a specified condition. It allows resources to be provided either by directly passing an object
+// or by fetching one from the cluster.
+//
+// Parameters:
+//   - option: A function that provides the resource (either an existing object or fetched from the cluster).
+//   - fn (func(*unstructured.Unstructured) error): A function to modify the resource before applying it.
+//   - condition (gTypes.GomegaMatcher): The Gomega matcher condition to assert on the resource after it is created or updated.
+//   - args (...interface{}): Optional Gomega assertion message arguments. Defaults to a standard error message.
+//
+// Returns:
+//   - *unstructured.Unstructured: The existing or newly created (updated) resource object.
+func (tc *TestContext) EnsureResourceCreatedOrUpdatedWithCondition(
+	option ResourceOption,
+	fn func(obj *unstructured.Unstructured) error,
+	condition gTypes.GomegaMatcher,
+	args ...any,
+) *unstructured.Unstructured {
+	return tc.ensureResourceAppliedWithCondition(option, fn, condition, tc.g.CreateOrUpdate, args...)
+}
+
+// EnsureResourceCreatedOrPatched ensures that a given Kubernetes resource exists.
+// If the resource is missing, it will be created; if it already exists, it will be patched
+// using the provided mutation function.
+//
+// Parameters:
+//   - option (ResourceOption): A function that provides the resource object (either existing or new).
+//   - fn (func(*unstructured.Unstructured) error): A function to modify the resource before applying it.
+//   - args (...interface{}): Optional Gomega assertion message arguments. Defaults to a standard error message.
+//
+// Returns:
+//   - *unstructured.Unstructured: The existing or newly created (patched) resource object.
+func (tc *TestContext) EnsureResourceCreatedOrPatched(
+	option ResourceOption,
+	fn func(obj *unstructured.Unstructured) error,
+	args ...any,
+) *unstructured.Unstructured {
+	return tc.EnsureResourceCreatedOrPatchedWithCondition(option, fn, Succeed(), args...)
+}
+
+// EnsureResourceCreatedOrPatchedWithCondition ensures that a given Kubernetes resource exists
+// and that it matches the specified condition. If the resource is missing, it will be created;
+// if it already exists, it will be patched using the provided mutation function.
+//
+// Parameters:
+//   - option (ResourceOption): A function that provides the resource (either an existing object or fetched from the cluster).
+//   - fn (func(*unstructured.Unstructured) error): A function to modify the resource before applying it.
+//   - condition (gTypes.GomegaMatcher): The Gomega matcher condition to assert on the resource after it is created or patched.
+//   - args (...interface{}): Optional Gomega assertion message arguments. Defaults to a standard error message.
+//
+// Returns:
+//   - *unstructured.Unstructured: The existing or newly created (patched) resource object.
+func (tc *TestContext) EnsureResourceCreatedOrPatchedWithCondition(
+	option ResourceOption,
+	fn func(obj *unstructured.Unstructured) error,
+	condition gTypes.GomegaMatcher,
+	args ...any,
+) *unstructured.Unstructured {
+	return tc.ensureResourceAppliedWithCondition(option, fn, condition, tc.g.CreateOrPatch, args...)
+}
+
+// EnsureSubscriptionExistsOrCreate ensures that the specified Subscription exists.
+// If the Subscription is missing, it will be created; if it already exists, no action is taken.
+// This function reuses the `EnsureResourceCreatedOrUpdated` logic to guarantee that the Subscription
+// exists or is created.
+//
+// Parameters:
+//   - nn (types.NamespacedName): The namespace and name of the Subscription.
+//
+// Returns:
+//   - *unstructured.Unstructured: The existing or newly created Subscription object.
+func (tc *TestContext) EnsureSubscriptionExistsOrCreate(
+	nn types.NamespacedName,
+) *unstructured.Unstructured {
+	// Construct a resource identifier.
+	resourceID := resources.FormatNamespacedName(nn)
+
+	// Create the subscription object using the necessary values (adapt as needed)
+	sub := createSubscription(nn)
+
+	// Ensure the Subscription exists or create it if missing
+	return tc.EnsureResourceCreatedOrUpdatedWithCondition(
+		WithObjectToCreate(sub),
+		testf.TransformSpecToUnstructured(sub.Spec),
+		jq.Match(`.status | has("installPlanRef")`),
+		"Failed to ensure Subscription '%s' exists", resourceID,
+	)
+}
+
+// EnsureResourcesAreEqual asserts that two resource objects are identical.
+// Uses Gomega's `BeEquivalentTo` for a flexible deep comparison.
+//
+// Parameters:
+//   - actualResource (interface{}): The resource to be compared.
+//   - expectedResource (interface{}): The expected resource.
+//   - args (...interface{}): Optional Gomega assertion message arguments.
+func (tc *TestContext) EnsureResourcesAreEqual(
+	actualResource, expectedResource interface{},
+	args ...any,
+) {
+	// Use Gomega's BeEquivalentTo for flexible deep comparison
+	tc.g.Expect(actualResource).To(
+		BeEquivalentTo(expectedResource),
+		appendDefaultIfNeeded(
+			"Expected resource to be equal to the actual resource, but they differ.\nActual: %v\nExpected: %v", []any{actualResource, expectedResource},
+			args,
+		)...,
+	)
+}
+
+// EnsureResourceNotNil verifies that the given resource is not nil and fails the test if it is.
+//
+// Parameters:
+//   - obj (*unstructured.Unstructured): The resource object to check.
+//   - resourceID (string): The identifier of the resource (e.g., "namespace/name").
+//   - kind (string): The kind of the resource (e.g., "Deployment").
+//   - args (...interface{}): Optional Gomega assertion message arguments.
+func (tc *TestContext) EnsureResourceNotNil(
+	obj any,
+	args ...any,
+) {
+	tc.EnsureResourceConditionMet(obj, Not(BeNil()), args...)
+}
+
+// EnsureResourceConditionMet verifies that a given resource satisfies a specified condition.
+// Callers should explicitly use `Not(matcher)` if they need to assert a negative condition.
+//
+// Parameters:
+//   - obj (any): The resource object to check.
+//   - matcher: A Gomega matcher specifying the expected condition (e.g., BeEmpty(), Not(BeEmpty())).
+//   - args (...interface{}): Optional Gomega assertion message arguments. If not provided, a default message is used.
+func (tc *TestContext) EnsureResourceConditionMet(
+	obj any,
+	condition gTypes.GomegaMatcher,
+	args ...any,
+) {
+	// Ensure obj is not nil before proceeding
+	tc.g.Expect(obj).NotTo(BeNil(), resourceNotNilErrorMsg)
+
+	// Convert the input object to unstructured
+	u, err := resources.ToUnstructured(obj)
+	tc.g.Expect(err).NotTo(HaveOccurred())
+
+	// Construct a meaningful resource identifier
+	resourceID := resources.FormatUnstructuredName(u)
+
+	// Perform the assertion using the custom condition
+	tc.g.Expect(obj).To(
+		condition,
+		appendDefaultIfNeeded(
+			"Expected resource '%s' of kind '%s' to satisfy condition '%v' but did not.",
+			[]any{resourceID, u.GetKind()},
+			args,
+		)...,
+	)
+}
+
+// EnsureDeploymentReady ensures that the specified Deployment is ready by checking its status and conditions.
+//
+// This function performs the following steps:
+// 1. Ensures that the deployment resource exists using `EnsureResourceExists`.
+// 2. Converts the `Unstructured` resource into a `Deployment` object using Kubernetes' runtime conversion.
+// 3. Asserts that the `Deployment` condition `DeploymentAvailable` is `True`.
+// 4. Verifies that the number of ready replicas in the deployment matches the expected count.
+//
+// Parameters:
+//   - nn (types.NamespacedName): The namespace and name of the deployment to check.
+//   - replicas (int32): The expected number of ready replicas for the deployment.
+func (tc *TestContext) EnsureDeploymentReady(
+	nn types.NamespacedName,
+	replicas int32,
+) {
+	// Construct a resource identifier.
+	resourceID := resources.FormatNamespacedName(nn)
+
+	// Ensure the deployment exists and retrieve the object.
+	deployment := &appsv1.Deployment{}
+	tc.RetrieveResource(
+		gvk.Deployment,
+		nn,
+		deployment,
+		"Deployment %s was expected to exist but was not found", resourceID,
+	)
+
+	// Assert that the deployment contains the necessary condition (DeploymentAvailable) with status "True"
+	tc.g.Expect(deployment.Status.Conditions).To(
+		ContainElement(
+			gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+				"Type":   Equal(appsv1.DeploymentAvailable),
+				"Status": Equal(corev1.ConditionTrue),
+			}),
+		), "Expected DeploymentAvailable condition to be True for deployment %s", resourceID)
+
+	// Assert the number of ready replicas matches the expected count
+	tc.g.Expect(deployment.Status.ReadyReplicas).To(
+		Equal(replicas),
+		"Expected %d ready replicas for deployment, but got %d", replicas, resourceID, deployment.Status.ReadyReplicas)
+}
+
+// EnsureCRDEstablished ensures that the specified CustomResourceDefinition is fully established.
+//
+// This function performs the following steps:
+// 1. Ensures that the CRD resource exists using `EnsureResourceExists`.
+// 2. Converts the `Unstructured` resource into a `CustomResourceDefinition` object using Kubernetes' runtime conversion.
+// 3. Asserts that the CRD condition `Established` is `True`.
+//
+// Parameters:
+//   - name (string): The name of the CRD to check.
+func (tc *TestContext) EnsureCRDEstablished(
+	name string,
+) {
+	// Ensure the CustomResourceDefinition exists and retrieve the object
+	crd := &apiextv1.CustomResourceDefinition{}
+	tc.RetrieveResource(
+		gvk.CustomResourceDefinition,
+		types.NamespacedName{Name: name},
+		crd,
+		"CRD %s was expected to exist but was not found", name,
+	)
+
+	// Assert that the CustomResourceDefinition contains the necessary condition (Established) with status "True"
+	tc.g.Expect(crd.Status.Conditions).To(
+		ContainElement(
+			gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+				"Type":   Equal(apiextv1.Established),
+				"Status": Equal(apiextv1.ConditionTrue),
+			}),
+		), "Expected CRD condition 'Established' to be True for CRD %s", name)
+}
+
+// EnsureResourceIsUnique ensures that creating a second instance of a given resource fails.
+//
+// This function performs the following steps:
+// 1. Converts the provided resource object into an `Unstructured` format using `ObjectToUnstructured`.
+// 2. Extracts the `GroupVersionKind` (GVK) from the object.
+// 3. Ensures that at least one resource of the same kind already exists in the cluster using `EnsureResourceExists`.
+// 4. Attempts to create a duplicate resource using `CreateUnstructured`.
+// 5. Asserts that the creation attempt fails, ensuring uniqueness constraints are enforced.
+//
+// Parameters:
+//   - tc (*TestContext): The test context that provides access to Gomega and the Kubernetes client.
+//   - obj (any): The resource object to create, which must be convertible to an unstructured format.
+//
+// Returns:
+//   - error: Returns nil if the duplicate creation fails as expected, otherwise returns an error.
+func (tc *TestContext) EnsureResourceIsUnique(
+	obj client.Object,
+	args ...any,
+) {
+	// Ensure obj is not nil before proceeding
+	tc.g.Expect(obj).NotTo(BeNil(), resourceNotNilErrorMsg)
+
+	// Convert the input object to unstructured
+	u, err := resources.ObjectToUnstructured(tc.Scheme(), obj)
+	tc.g.Expect(err).NotTo(HaveOccurred(), err)
+
+	// Extract GroupVersionKind from the unstructured object
+	groupVersionKind := u.GetObjectKind().GroupVersionKind()
+
+	// Ensure that at least one resource of this kind already exists
+	tc.EnsureResourcesExist(
+		groupVersionKind,
+		types.NamespacedName{Namespace: u.GetNamespace()},
+		&client.ListOptions{Namespace: u.GetNamespace()},
+		"Failed to verify existence of %s", groupVersionKind.Kind,
+	)
+
+	// Attempt to create the duplicate resource, expecting failure
+	tc.g.Eventually(func(g Gomega) {
+		// Try to create the resource
+		_, err := tc.g.Create(u, types.NamespacedName{Namespace: u.GetNamespace(), Name: u.GetName()}).Get()
+
+		// If there's no error, that means the duplicate creation succeeded, which is a failure
+		g.Expect(err).To(HaveOccurred(), appendDefaultIfNeeded(
+			"Expected creation of duplicate %s to fail due to uniqueness constraint, but it succeeded.",
+			[]any{groupVersionKind.Kind},
+			args,
+		)...)
+
+		// Check if the error is a Kubernetes StatusError and was denied by an admission webhook
+		// Ensure the failure is due to uniqueness constraints (Forbidden error)
+		g.Expect(errors.IsForbidden(err)).To(BeTrue(),
+			appendDefaultIfNeeded(
+				"Expected failure due to uniqueness constraint (Forbidden), but got: %v",
+				[]any{err},
+				args,
+			)...,
+		)
+	}).Should(Succeed())
+}
+
+// EnsureOperatorInstalled ensures that the specified operator is installed and the associated
+// ClusterServiceVersion (CSV) reaches the 'Succeeded' phase.
+//
+// This function performs the following tasks:
+// 1. Creates or updates the namespace for the operator, if necessary.
+// 2. Optionally creates or updates the operator group, depending on the 'skipOperatorGroupCreation' flag.
+// 3. Retrieves the InstallPlan for the operator and approves it if not already approved.
+// 4. Verifies that the operator's ClusterServiceVersion (CSV) reaches the 'Succeeded' phase.
+//
+// Parameters:
+//   - nn (types.NamespacedName): The namespace and name of the operator being installed.
+//   - skipOperatorGroupCreation (bool): If true, skips the creation or update of the operator group.
+func (tc *TestContext) EnsureOperatorInstalled(nn types.NamespacedName, skipOperatorGroupCreation bool) {
+	// Construct a resource identifier.
+	resourceID := resources.FormatNamespacedName(nn)
+
+	// Ensure the operator's namespace is created.
+	tc.EnsureResourceCreatedOrUpdated(
+		WithMinimalObject(gvk.Namespace, types.NamespacedName{Name: nn.Namespace}),
+		NoOpMutationFn,
+		"Failed to create or update namespace '%s'", nn.Namespace,
+	)
+
+	// Ensure the operator group is created or updated only if necessary.
+	if !skipOperatorGroupCreation {
+		tc.EnsureResourceCreatedOrUpdated(
+			WithMinimalObject(gvk.OperatorGroup, nn),
+			NoOpMutationFn,
+			"Failed to create or update operator group '%s'", resourceID,
+		)
+	}
+
+	// Retrieve the InstallPlan
+	plan := tc.RetrieveInstallPlan(nn)
+
+	// in CI InstallPlan is in Manual mode
+	if !plan.Spec.Approved {
+		tc.ApproveInstallPlan(plan)
+	}
+
+	// Retrieve the CSV name from the InstallPlan and ensure it reaches 'Succeeded' phase.
+	tc.g.Expect(plan.Spec.ClusterServiceVersionNames).NotTo(BeEmpty(), "No CSV found in InstallPlan for operator '%s'", resourceID)
+	csvName := plan.Spec.ClusterServiceVersionNames[0] // Assuming first in the list
+
+	tc.g.Eventually(func(g Gomega) {
+		csv := tc.RetrieveClusterServiceVersion(types.NamespacedName{Namespace: nn.Namespace, Name: csvName})
+		g.Expect(csv.Status.Phase).To(
+			Equal(ofapi.CSVPhaseSucceeded),
+			"CSV %s did not reach 'Succeeded' phase", resourceID,
+		)
+	}).WithTimeout(eventuallyTimeoutMedium).WithPolling(generalRetryInterval)
+}
+
+// DeleteResource verifies whether a specific Kubernetes resource exists and deletes it if found.
+// If the resource exists, it is deleted using the provided client options. The test will fail if the resource
+// does not exist or if the deletion fails.
+//
+// Parameters:
+//   - gvk (schema.GroupVersionKind): The GroupVersionKind of the resource to be deleted.
+//   - nn (types.NamespacedName): The namespace and name of the resource to be deleted.
+//   - clientOption (...client.DeleteOption): Optional delete options such as cascading or propagation policy.
+func (tc *TestContext) DeleteResource(
+	gvk schema.GroupVersionKind,
+	nn types.NamespacedName,
+	clientOption ...client.DeleteOption,
+) {
+	// Construct a resource identifier.
+	resourceID := resources.FormatNamespacedName(nn)
+
+	// Ensure the resource exists before attempting deletion
+	tc.EnsureResourceExists(
+		gvk,
+		nn,
+		"Expected %s instance %s to exist before attempting deletion", gvk.Kind, resourceID,
+	)
+
+	// Delete the resource if it exists
+	tc.g.Delete(
+		gvk,
+		nn,
+		clientOption...,
+	).Eventually().Should(Succeed(), "Failed to delete %s instance %s", gvk.Kind, resourceID)
+}
+
+// DeleteResourceIfExists verifies whether a specific Kubernetes resource exists and deletes it if found.
+// If the resource exists, it is deleted using the provided client options. The test will succeed even if the resource
+// does not exist (i.e., the deletion is considered successful if the resource is not found).
+//
+// Parameters:
+//   - gvk (schema.GroupVersionKind): The GroupVersionKind of the resource to be deleted.
+//   - nn (types.NamespacedName): The namespace and name of the resource to be deleted.
+//   - clientOption (...client.DeleteOption): Optional delete options such as cascading or propagation policy.
+func (tc *TestContext) DeleteResourceIfExists(
+	gvk schema.GroupVersionKind,
+	nn types.NamespacedName,
+	clientOption ...client.DeleteOption,
+) {
+	// Construct a resource identifier.
+	resourceID := resources.FormatNamespacedName(nn)
+
+	// Use EnsureResourceExistsOrNil to attempt to fetch the resource with retries
+	_, err := tc.EnsureResourceExistsOrNil(gvk, nn)
+
+	// If error is not nil and not IsNotFound, we fail the test.
+	if err != nil && !errors.IsNotFound(err) {
+		tc.g.Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("Unexpected error while checking existence of %s instance %s", gvk.Kind, resourceID))
+		return
+	}
+
+	// Delete the resource
+	tc.g.Delete(
+		gvk,
+		nn,
+		clientOption...,
+	).Eventually().Should(Succeed(), "Failed to delete %s instance %s", gvk.Kind, resourceID)
+}
+
+// RetrieveInstallPlanName retrieves the name of the InstallPlan associated with a subscription.
+// It ensures that the subscription exists (or is created) and then retrieves the InstallPlan name.
+// This function does not return an error, it will panic if anything goes wrong (such as a missing InstallPlanRef).
+//
+// Parameters:
+//   - name (string): The name of the Subscription to check.
+//   - ns (string): The namespace of the Subscription.
+//
+// Returns:
+//   - string: The name of the InstallPlan associated with the Subscription.
+func (tc *TestContext) RetrieveInstallPlanName(nn types.NamespacedName) string {
+	// Ensure the subscription exists or is created
+	u := tc.EnsureSubscriptionExistsOrCreate(nn)
+
+	// Convert the Unstructured object to Subscription and assert no error
+	sub := &ofapi.Subscription{}
+	tc.ConvertUnstructuredToResource(u, sub)
+
+	// Return the name of the InstallPlan
+	return sub.Status.InstallPlanRef.Name
+}
+
+// RetrieveInstallPlan retrieves the InstallPlan associated with a Subscription by its name and namespace.
+// It ensures the Subscription exists (or is created) and fetches the InstallPlan object by its name and namespace.
+//
+// Parameters:
+//   - name (string): The name of the Subscription to check.
+//   - ns (string): The namespace of the Subscription.
+//
+// Returns:
+//   - *ofapi.InstallPlan: The InstallPlan associated with the Subscription.
+func (tc *TestContext) RetrieveInstallPlan(nn types.NamespacedName) *ofapi.InstallPlan {
+	// Retrieve the InstallPlan name using getInstallPlanName (ensuring Subscription exists if necessary)
+	planName := tc.RetrieveInstallPlanName(nn)
+
+	// Ensure the InstallPlan exists and retrieve the object.
+	installPlan := &ofapi.InstallPlan{}
+	tc.RetrieveResource(
+		gvk.InstallPlan,
+		types.NamespacedName{Namespace: nn.Namespace, Name: planName},
+		installPlan,
+		"InstallPlan %s was expected to exist but was not found", planName,
+	)
+
+	// Return the InstallPlan object
+	return installPlan
+}
+
+// RetrieveClusterServiceVersion retrieves a ClusterServiceVersion (CSV) for an operator by name and namespace.
+// If the CSV does not exist, the function will fail the test using Gomega assertions.
+//
+// Parameters:
+//   - name (string): The name of the ClusterServiceVersion to retrieve.
+//   - ns (string): The namespace where the ClusterServiceVersion is expected to be found.
+//
+// Returns:
+//   - *ofapi.ClusterServiceVersion: A pointer to the retrieved ClusterServiceVersion object.
+func (tc *TestContext) RetrieveClusterServiceVersion(nn types.NamespacedName) *ofapi.ClusterServiceVersion {
+	// Construct a resource identifier.
+	resourceID := resources.FormatNamespacedName(nn)
+
+	// Retrieve the CSV
+	csv := &ofapi.ClusterServiceVersion{}
+	tc.RetrieveResource(gvk.ClusterServiceVersion, nn, csv)
+
+	// Assert that we found the CSV
+	tc.g.Expect(csv).NotTo(BeNil(), "CSV %s not found", resourceID)
+
+	return csv
+}
+
+// RetrieveClusterVersion retrieves the ClusterVersion for the cluster.
+// If the ClusterVersion does not exist, the function will fail the test using Gomega assertions.
+//
+// Returns:
+//   - *configv1.ClusterVersion: A pointer to the retrieved ClusterVersion object.
+func (tc *TestContext) RetrieveClusterVersion() *configv1.ClusterVersion {
+	// Retrieve the ClusterVersion
+	cv := &configv1.ClusterVersion{}
+	tc.RetrieveResource(gvk.ClusterVersion, types.NamespacedName{Name: cluster.OpenShiftVersionObj}, cv)
+
+	// Assert that we found the ClusterVersion
+	tc.g.Expect(cv).NotTo(BeNil(), "ClusterVersion not found")
+
+	return cv
+}
+
+// RetrieveDSCInitialization retrieves the DSCInitialization resource.
+//
+// This function ensures that the DSCInitialization resource exists and then retrieves it
+// as a strongly typed object.
+//
+// Parameters:
+//   - nn (types.NamespacedName): The namespaced name (namespace + name) of the DSCInitialization.
+//
+// Returns:
+//   - *dsciv1.DSCInitialization: The retrieved DSCInitialization object.
+func (tc *TestContext) RetrieveDSCInitialization(nn types.NamespacedName) *dsciv1.DSCInitialization {
+	// Ensure the DSCInitialization exists and retrieve the object
+	dsci := &dsciv1.DSCInitialization{}
+	tc.RetrieveResource(gvk.DSCInitialization, nn, dsci)
+
+	return dsci
+}
+
+// RetrieveDataScienceCluster retrieves the DataScienceCluster resource.
+//
+// This function ensures that the DataScienceCluster resource exists and then retrieves it
+// as a strongly typed object.
+//
+// Parameters:
+//   - nn (types.NamespacedName): The namespaced name (namespace + name) of the DataScienceCluster.
+//
+// Returns:
+//   - *dsciv1.DataScienceCluster: The retrieved DataScienceCluster object.
+func (tc *TestContext) RetrieveDataScienceCluster(nn types.NamespacedName) *dscv1.DataScienceCluster {
+	// Ensure the DataScienceCluster exists and retrieve the object
+	dsc := &dscv1.DataScienceCluster{}
+	tc.RetrieveResource(gvk.DataScienceCluster, nn, dsc)
+
+	return dsc
+}
+
+// RetrieveResource ensures a Kubernetes resource exists and retrieves it into a typed object.
+//
+// This function first verifies that the resource exists using `EnsureResourceExists` and then
+// converts the retrieved Unstructured object into the provided typed object.
+//
+// Parameters:
+//   - gvk (schema.GroupVersionKind): The GroupVersionKind of the resource to retrieve.
+//   - nn (types.NamespacedName): The namespaced name (namespace + name) of the resource.
+//   - obj (any): A pointer to the typed object where the resource data will be stored.
+//   - args (any, optional): Additional arguments for error messages or logging.
+//
+// Panics:
+//   - If the resource does not exist.
+//   - If conversion from Unstructured to the typed object fails.
+func (tc *TestContext) RetrieveResource(
+	gvk schema.GroupVersionKind,
+	nn types.NamespacedName,
+	obj client.Object,
+	args ...any,
+) {
+	// Ensure the resource exists and retrieve the object
+	u := tc.EnsureResourceExists(gvk, nn, args...)
+
+	// Convert the Unstructured object to a typed object
+	tc.ConvertUnstructuredToResource(u, obj)
+}
+
+// RetrieveResources fetches a list of resources from the cluster and waits for their successful retrieval.
+//
+// This function uses the `Eventually` mechanism to repeatedly attempt to retrieve the resources from
+// the cluster until they are available. It ensures no errors occur during the retrieval process and that
+// the list of resources is successfully fetched.
+//
+// Parameters:
+//   - gvk (schema.GroupVersionKind): The GroupVersionKind (GVK) of the resources being retrieved.
+//   - nn (types.NamespacedName): The namespace and name of the resource(s) to be fetched.
+//   - listOptions (*client.ListOptions, optional): Additional options for listing the resources (e.g., label selectors).
+//   - args (...any, optional): Optional arguments for custom error messages or logging.
+//
+// Returns:
+//   - []unstructured.Unstructured: A list of resources fetched from the cluster.
+func (tc *TestContext) RetrieveResources(
+	gvk schema.GroupVersionKind,
+	nn types.NamespacedName,
+	listOptions *client.ListOptions,
+	args ...any,
+) []unstructured.Unstructured {
+	// Construct a resource identifier
+	resourceID := resources.FormatNamespacedName(nn)
+
+	// If no ListOptions are provided, initialize an empty one
+	if listOptions == nil {
+		listOptions = &client.ListOptions{}
+	}
+
+	// Use Eventually to retry getting the resource list until they appear
+	var resourcesList []unstructured.Unstructured
+	tc.g.Eventually(func(g Gomega) {
+		// Fetch the list of resources
+		var err error
+		resourcesList, _ = tc.g.List(gvk, listOptions).Get()
+
+		// Ensure no unexpected errors occurred while fetching the resources
+		g.Expect(err).ToNot(HaveOccurred(),
+			appendDefaultIfNeeded(resourceFetchErrorMsg, []any{resourceID, gvk.Kind, err}, args)...,
+		)
+	}).Should(Succeed())
+
+	return resourcesList
+}
+
+// ApproveInstallPlan approves the provided InstallPlan by applying a patch to update its approval status.
+//
+// This function performs the following steps:
+// 1. Prepares the InstallPlan object with the necessary changes to approve it.
+// 2. Sets up patch options, including force applying the patch with the specified field manager.
+// 3. Applies the patch to update the InstallPlan, marking it as approved automatically.
+// 4. Asserts that no error occurs during the patch application process.
+//
+// Parameters:
+//   - plan (*ofapi.InstallPlan): The InstallPlan object that needs to be approved.
+func (tc *TestContext) ApproveInstallPlan(plan *ofapi.InstallPlan) {
+	// Prepare the InstallPlan object to be approved
+	obj := createInstallPlan(plan.ObjectMeta.Name, plan.ObjectMeta.Namespace, plan.Spec.ClusterServiceVersionNames)
+
+	// Set up patch options
+	force := true
+	opt := &client.PatchOptions{
+		FieldManager: dscInstanceName,
+		Force:        &force,
+	}
+
+	// Apply the patch to approve the InstallPlan
+	err := tc.Client().Patch(tc.Context(), obj, client.Apply, opt)
+	tc.g.Expect(err).
+		NotTo(
+			HaveOccurred(),
+			"Failed to approve InstallPlan %s in namespace %s: %v", obj.ObjectMeta.Name, obj.ObjectMeta.Namespace, err,
+		)
+}
+
+// ConvertUnstructuredToResource converts the provided Unstructured object to the specified resource type.
+// This function performs the conversion and asserts that no error occurs during the conversion process.
+//
+// The function utilizes Gomega's Expect method to assert that the conversion is successful.
+// If the conversion fails, the test will fail.
+//
+// Parameters:
+//   - u (*unstructured.Unstructured): The Unstructured object to be converted.
+//   - obj (T): A pointer to the target resource object to which the Unstructured object will be converted. The object must be a pointer to a struct.
+func (tc *TestContext) ConvertUnstructuredToResource(u *unstructured.Unstructured, obj client.Object) {
+	// Convert Unstructured object to the given resource object
+	err := resources.ObjectFromUnstructured(tc.Scheme(), u, obj)
+	tc.g.Expect(err).NotTo(HaveOccurred(), "Failed converting %T from Unstructured.Object: %v", obj, u.Object)
+}
+
+// ExtractAndExpectValue extracts a value from an input using a jq expression and asserts conditions on it.
+//
+// This function extracts a value of type T from the given input using the specified jq expression.
+// It ensures that extraction succeeds and applies one or more assertions to validate the extracted value.
+//
+// Parameters:
+//   - g (Gomega): The Gomega testing instance used for assertions.
+//   - in (any): The input data (e.g., a Kubernetes resource).
+//   - expression (string): The jq expression used to extract a value from the input.
+//   - matchers (GomegaMatcher): One or more Gomega matchers to validate the extracted value.
+func ExtractAndExpectValue[T any](g Gomega, in any, expression string, matchers ...gTypes.GomegaMatcher) T {
+	// Extract the value using the jq expression
+	value, err := jq.ExtractValue[T](in, expression)
+
+	// Expect no errors during extraction
+	g.Expect(err).NotTo(HaveOccurred(), "Failed to extract value using expression: %s", expression)
+
+	// Apply matchers to validate the extracted value
+	g.Expect(value).To(And(matchers...), "Extracted value from %s does not match expected conditions", expression)
+
+	return value
+}
+
+// CreateDSCI creates a DSCInitialization CR.
+func CreateDSCI(name, appNamespace string) *dsciv1.DSCInitialization {
+	return &dsciv1.DSCInitialization{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "DSCInitialization",
+			APIVersion: dsciv1.GroupVersion.String(),
+		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
 		},
 		Spec: dsciv1.DSCInitializationSpec{
-			ApplicationsNamespace: "opendatahub",
+			ApplicationsNamespace: appNamespace,
 			Monitoring: serviceApi.DSCIMonitoring{
 				ManagementSpec: common.ManagementSpec{
 					ManagementState: operatorv1.Removed, // keep rhoai branch to Managed so we can test it
 				},
 				MonitoringCommonSpec: serviceApi.MonitoringCommonSpec{
-					Namespace: "opendatahub",
+					Namespace: appNamespace,
 				},
 			},
 			TrustedCABundle: &dsciv1.TrustedCABundleSpec{
@@ -117,20 +1332,24 @@ func setupDSCICR(name string) *dsciv1.DSCInitialization {
 				CustomCABundle:  "",
 			},
 			ServiceMesh: &infrav1.ServiceMeshSpec{
-				ControlPlane: infrav1.ControlPlaneSpec{
-					MetricsCollection: "Istio",
-					Name:              "data-science-smcp",
-					Namespace:         "istio-system",
-				},
 				ManagementState: operatorv1.Managed,
+				ControlPlane: infrav1.ControlPlaneSpec{
+					Name:              serviceMeshControlPlane,
+					Namespace:         serviceMeshNamespace,
+					MetricsCollection: serviceMeshMetricsCollection,
+				},
 			},
 		},
 	}
-	return dsciTest
 }
 
-func setupDSCInstance(name string) *dscv1.DataScienceCluster {
-	dscTest := &dscv1.DataScienceCluster{
+// CreateDSC creates a DataScienceCluster CR.
+func CreateDSC(name string) *dscv1.DataScienceCluster {
+	return &dscv1.DataScienceCluster{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "DataScienceCluster",
+			APIVersion: dscv1.GroupVersion.String(),
+		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
 		},
@@ -163,12 +1382,9 @@ func setupDSCInstance(name string) *dscv1.DataScienceCluster {
 					},
 					KserveCommonSpec: componentApi.KserveCommonSpec{
 						DefaultDeploymentMode: componentApi.Serverless,
-						NIM: componentApi.NimSpec{
-							ManagementState: operatorv1.Managed,
-						},
 						Serving: infrav1.ServingSpec{
 							ManagementState: operatorv1.Managed,
-							Name:            "knative-serving",
+							Name:            knativeServingNamespace,
 							IngressGateway: infrav1.GatewaySpec{
 								Certificate: infrav1.CertificateSpec{
 									Type: infrav1.OpenshiftDefaultIngress,
@@ -218,318 +1434,324 @@ func setupDSCInstance(name string) *dscv1.DataScienceCluster {
 			},
 		},
 	}
-
-	return dscTest
 }
 
-func setupSubscription(name string, ns string) *ofapi.Subscription {
+// ensureResourceAppliedWithCondition is a common function for handling create/patch and create/update operations.
+// It applies a given resource and ensures it meets the expected condition.
+//
+// Parameters:
+//   - gvk: The GroupVersionKind of the resource.
+//   - nn: The NamespacedName identifying the resource.
+//   - fn: A mutation function to modify the resource before applying.
+//   - condition: A Gomega matcher that the resource must satisfy.
+//   - applyResourceFn: The function responsible for applying the resource.
+//   - args: Additional arguments for error message formatting.
+//
+// Returns:
+//   - *unstructured.Unstructured: The applied resource if it meets the expected condition.
+func (tc *TestContext) ensureResourceAppliedWithCondition(
+	option ResourceOption,
+	fn func(obj *unstructured.Unstructured) error,
+	condition gTypes.GomegaMatcher,
+	applyResourceFn func(obj *unstructured.Unstructured, fn ...func(obj *unstructured.Unstructured) error) *testf.EventuallyValue[*unstructured.Unstructured],
+	args ...any,
+) *unstructured.Unstructured {
+	// Retrieve the object using the provided option
+	obj := option(tc)
+
+	// Get GroupVersionKind from the resource.
+	groupVersionKind := obj.GetObjectKind().GroupVersionKind()
+
+	// Construct a resource identifier.
+	resourceID := resources.FormatUnstructuredName(obj)
+
+	// Wrap condition if it's not already wrapped correctly
+	wrapConditionIfNeeded(&condition)
+
+	// Use Eventually to retry getting the resource until it appears
+	var u *unstructured.Unstructured
+	tc.g.Eventually(func(g Gomega) {
+		// Fetch the resource
+		var err error
+		u, err = applyResourceFn(obj, fn).Get()
+
+		// Evaluate the condition to check if failure is expected
+		expectingFailure := tc.isFailureExpected(condition)
+
+		// Error handling based on failure expectation
+		if !expectingFailure {
+			// Expect no error if success is expected
+			g.Expect(err).NotTo(
+				HaveOccurred(),
+				"Error occurred while applying the resource '%s' of kind '%s': %v", resourceID, groupVersionKind.Kind, err,
+			)
+
+			// Ensure that the resource object is not nil
+			g.Expect(u).NotTo(BeNil(), resourceNotFoundErrorMsg, resourceID, groupVersionKind.Kind)
+		} else {
+			// Expect error if failure is expected
+			g.Expect(err).To(HaveOccurred(), "Expected applyResourceFn to fail but it succeeded")
+		}
+
+		// Apply the matchers based on the condition
+		applyMatchers(g, resourceID, groupVersionKind, u, err, condition, args)
+	}).Should(Succeed())
+
+	return u
+}
+
+// ensureResourceDoesNotExist is a helper function that attempts to retrieve a Kubernetes resource
+// and checks if it does not exist. It returns an error if the resource is found in the cluster.
+//
+// Parameters:
+//   - g (Gomega): The Gomega assertion wrapper.
+//   - gvk (schema.GroupVersionKind): The GroupVersionKind of the resource being checked.
+//   - nn (types.NamespacedName): The namespaced name of the resource (e.g., "namespace/resource-name").
+//   - args ([]any): Optional arguments that can be used for retries or custom messages during resource retrieval.
+//
+// Returns:
+//   - error: An error if the resource is found in the cluster, or nil if the resource does not exist.
+func (tc *TestContext) ensureResourceDoesNotExist(
+	g Gomega,
+	gvk schema.GroupVersionKind,
+	nn types.NamespacedName,
+	args []any,
+) error {
+	// Construct a resource identifier.
+	resourceID := resources.FormatNamespacedName(nn)
+
+	// Use EnsureResourceExistsOrNil to attempt to fetch the resource with retries
+	u, err := tc.EnsureResourceExistsOrNil(gvk, nn, args...)
+
+	// Ensure that the resource object is not nil
+	g.Expect(u).To(BeNil(), resourceFoundErrorMsg, resourceID, gvk.Kind)
+
+	return err
+}
+
+// ensureResourcesDoNotExist is a helper function that retrieves a list of Kubernetes resources
+// and checks if the resources do not exist (i.e., the list is empty). It performs an assertion
+// to ensure that the list of resources is empty. If any resources are found, it fails the test.
+//
+// Parameters:
+//   - g (Gomega): The Gomega assertion wrapper.
+//   - gvk (schema.GroupVersionKind): The GroupVersionKind of the resources to check.
+//   - nn (types.NamespacedName): The namespace and name of the resource(s).
+//   - listOptions (*client.ListOptions, optional): Optional list options for filtering the resources (e.g., label selectors).
+//   - args (...interface{}): Optional Gomega assertion message arguments.
+//
+// Returns:
+//   - error: An error if the resource is found in the cluster, or nil if the resource does not exist.
+func (tc *TestContext) ensureResourcesDoNotExist(
+	g Gomega,
+	gvk schema.GroupVersionKind,
+	nn types.NamespacedName,
+	listOptions *client.ListOptions,
+	args []any,
+) {
+	// Construct a resource identifier for logging
+	resourceID := resources.FormatNamespacedName(nn)
+
+	// Retrieve the resources list using the common function
+	resourcesList := tc.RetrieveResources(gvk, nn, listOptions, args...)
+
+	// Ensure that the resources list is empty (resources should not exist)
+	g.Expect(resourcesList).To(BeEmpty(), resourceNotEmptyErrorMsg, resourceID, gvk.Kind)
+}
+
+// applyMatchers applies Gomega matchers to a single resource or a list of resources.
+//
+// Parameters:
+//   - g (Gomega): The Gomega assertion wrapper.
+//   - resourceID (string): A string identifier for logging purposes.
+//   - gvk (schema.GroupVersionKind): The GroupVersionKind of the resource(s).
+//   - resource any: Can be a single unstructured.Unstructured or a list ([]unstructured.Unstructured).
+//   - err error: The error returned when fetching the resource(s).
+//   - condition gTypes.GomegaMatcher: The Gomega matcher to apply.
+//   - args []any: Optional additional arguments for assertion messages.
+func applyMatchers(
+	g Gomega,
+	resourceID string,
+	gvk schema.GroupVersionKind,
+	resource any,
+	err error,
+	condition gTypes.GomegaMatcher,
+	args []any,
+) {
+	// Check if the condition is an And, Or, or Not and recursively inspect the inner matchers
+	switch v := condition.(type) {
+	case *matchers.AndMatcher:
+		// If the condition is an And, apply each matcher recursively
+		for _, inner := range v.Matchers {
+			applyMatchers(g, resourceID, gvk, resource, err, inner, args)
+		}
+	case *matchers.OrMatcher:
+		// If the condition is an Or, apply each matcher recursively
+		for _, inner := range v.Matchers {
+			applyMatchers(g, resourceID, gvk, resource, err, inner, args)
+		}
+	case *matchers.NotMatcher:
+		// If the condition is a Not, apply the negated matcher recursively
+		applyMatchers(g, resourceID, gvk, resource, err, v.Matcher, args)
+	case gTypes.GomegaMatcher: // Base matcher (for non-Error matchers)
+		// If matcher is an error matcher, apply it to the error
+		if isErrorMatcher(v) {
+			g.Expect(err).To(v, appendDefaultIfNeeded(
+				"Expected error when applying resource '%s' of kind '%s'.",
+				[]any{resourceID, gvk.Kind}, args,
+			)...)
+			return
+		}
+
+		// If working on a list of resources
+		if resourcesList, ok := resource.([]unstructured.Unstructured); ok {
+			// Apply the matcher to the list
+			g.Expect(resourcesList).To(v, appendDefaultIfNeeded(
+				"Expected list of '%s' resources to match condition %v.",
+				[]any{gvk.Kind, dereferenceCondition(condition)}, args,
+			)...)
+			return
+		}
+
+		// If working on a single resource
+		if u, ok := resource.(*unstructured.Unstructured); ok {
+			g.Expect(u.Object).To(v, appendDefaultIfNeeded(
+				"Expected resource '%s' of kind '%s' to match condition %v.",
+				[]any{resourceID, gvk.Kind, dereferenceCondition(condition)}, args,
+			)...)
+		}
+	}
+}
+
+// Helper function to evaluate if failure is expected based on the matcher.
+func (tc *TestContext) isFailureExpected(condition gTypes.GomegaMatcher) bool {
+	// Check if the condition is an And, Or, or Not and recursively inspect the inner matchers
+	switch v := condition.(type) {
+	case *matchers.AndMatcher:
+		// If the condition is And(), we recursively check the inner matchers
+		for _, inner := range v.Matchers {
+			if tc.isFailureExpected(inner) {
+				return true
+			}
+		}
+	case *matchers.OrMatcher:
+		// If the condition is Or(), we recursively check the inner matchers
+		for _, inner := range v.Matchers {
+			if tc.isFailureExpected(inner) {
+				return true
+			}
+		}
+	case *matchers.NotMatcher:
+		// If the condition is Not(Succeed()), we expect failure
+		if _, ok := v.Matcher.(*matchers.SucceedMatcher); ok {
+			return true
+		}
+	case gTypes.GomegaMatcher:
+		// For basic matchers (not wrapped in And/Or/Not), check if it is Not(Succeed()) or any other condition
+		expectingFailure, _ := condition.Match(Not(Succeed()))
+		return expectingFailure
+	}
+
+	// Default case if none of the conditions matched, return false (no failure expected)
+	return false
+}
+
+// Check if the matcher is an error matcher like Succeed(), HaveOccurred(), etc.
+func isErrorMatcher(matcher gTypes.GomegaMatcher) bool {
+	switch matcher.(type) {
+	case *matchers.SucceedMatcher, *matchers.HaveOccurredMatcher, *matchers.MatchErrorMatcher:
+		return true
+	default:
+		return false
+	}
+}
+
+// wrapConditionIfNeeded ensures that the condition is wrapped in And(Succeed(), condition)
+// if it's not already wrapped in such a way.
+func wrapConditionIfNeeded(condition *gTypes.GomegaMatcher) {
+	// Check if the condition is already an 'And' that contains Succeed()
+	if _, ok := (*condition).(*matchers.SucceedMatcher); ok || isAndContainingSucceed(*condition) {
+		return
+	}
+
+	// Wrap condition inside And(Succeed(), condition) if it's not already wrapped correctly
+	*condition = And(Succeed(), *condition)
+}
+
+// isAndContainingSucceed checks if the matcher is an AndMatcher containing Succeed().
+func isAndContainingSucceed(matcher gTypes.GomegaMatcher) bool {
+	// Check if the condition is already an 'And' that contains Succeed()
+	andMatcher, ok := matcher.(*matchers.AndMatcher)
+	if !ok {
+		return false
+	}
+
+	// Check if Succeed is one of the matchers in the And condition
+	for _, m := range andMatcher.Matchers {
+		if _, ok := m.(*matchers.SucceedMatcher); ok {
+			return true
+		}
+	}
+
+	return false
+}
+
+// appendDefaultIfNeeded appends a default message to args if args is empty.
+// It formats the default message using the provided format and formatArgs.
+func appendDefaultIfNeeded(format string, formatArgs []any, args []any) []any {
+	// If no custom args are provided, append the default message
+	if len(args) == 0 {
+		args = append(args, fmt.Sprintf(format, formatArgs...))
+	}
+	return args
+}
+
+// createSubscription creates a Subscription object.
+func createSubscription(nn types.NamespacedName) *ofapi.Subscription {
 	return &ofapi.Subscription{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       ofapi.SubscriptionKind,
+			APIVersion: ofapi.SubscriptionCRDAPIVersion,
+		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: ns,
+			Name:      nn.Name,
+			Namespace: nn.Namespace,
 		},
 		Spec: &ofapi.SubscriptionSpec{
 			CatalogSource:          "redhat-operators",
 			CatalogSourceNamespace: "openshift-marketplace",
 			Channel:                "stable",
-			Package:                name,
+			Package:                nn.Name,
 			InstallPlanApproval:    ofapi.ApprovalAutomatic,
 		},
 	}
 }
 
-func (tc *testContext) validateCRD(crdName string) error {
-	crd := &apiextv1.CustomResourceDefinition{}
-	obj := client.ObjectKey{
-		Name: crdName,
-	}
-
-	err := wait.PollUntilContextTimeout(tc.ctx, generalRetryInterval, crdReadyTimeout, false, func(ctx context.Context) (bool, error) {
-		err := tc.customClient.Get(ctx, obj, crd)
-		if err != nil {
-			if k8serr.IsNotFound(err) {
-				return false, nil
-			}
-			log.Printf("Failed to get CRD %s", crdName)
-
-			return false, err
-		}
-
-		for _, condition := range crd.Status.Conditions {
-			if condition.Type == apiextv1.Established {
-				if condition.Status == apiextv1.ConditionTrue {
-					return true, nil
-				}
-			}
-		}
-		log.Printf("Error to get CRD %s condition's matching", crdName)
-
-		return false, nil
-	})
-
-	return err
-}
-
-func (tc *testContext) wait(isReady func(ctx context.Context) (bool, error)) error {
-	return wait.PollUntilContextTimeout(tc.ctx, generalRetryInterval, generalWaitTimeout, true, isReady)
-}
-
-func getCSV(ctx context.Context, cli client.Client, name string, namespace string) (*ofapi.ClusterServiceVersion, error) {
-	isMatched := func(csv *ofapi.ClusterServiceVersion, name string) bool {
-		return strings.Contains(csv.ObjectMeta.Name, name)
-	}
-
-	opt := &client.ListOptions{
-		Namespace: namespace,
-	}
-	csvList := &ofapi.ClusterServiceVersionList{}
-	err := cli.List(ctx, csvList, opt)
-	if err != nil {
-		return nil, err
-	}
-
-	// do not use range Items to avoid pointer to the loop variable
-	for i := range len(csvList.Items) {
-		csv := &csvList.Items[i]
-		if isMatched(csv, name) {
-			return csv, nil
-		}
-	}
-
-	return nil, k8serr.NewNotFound(schema.GroupResource{}, name)
-}
-
-// Use existing or create a new one.
-func getSubscription(tc *testContext, name string, ns string) (*ofapi.Subscription, error) {
-	createSubscription := func(name string, ns string) (*ofapi.Subscription, error) {
-		// this just creates a manifest
-		sub := setupSubscription(name, ns)
-
-		if err := tc.customClient.Create(tc.ctx, sub); err != nil {
-			return nil, fmt.Errorf("error creating subscription: %w", err)
-		}
-
-		return sub, nil
-	}
-
-	sub := &ofapi.Subscription{}
-	key := types.NamespacedName{
-		Namespace: ns,
-		Name:      name,
-	}
-
-	err := tc.customClient.Get(tc.ctx, key, sub)
-	if k8serr.IsNotFound(err) {
-		return createSubscription(name, ns)
-	}
-	if err != nil {
-		return nil, fmt.Errorf("error getting subscription: %w", err)
-	}
-
-	return sub, nil
-}
-
-func waitCSV(tc *testContext, name string, ns string) error {
-	interval := generalRetryInterval
-	isReady := func(ctx context.Context) (bool, error) {
-		csv, err := getCSV(ctx, tc.customClient, name, ns)
-		if k8serr.IsNotFound(err) {
-			return false, nil
-		}
-		if err != nil {
-			return false, err
-		}
-
-		return csv.Status.Phase == "Succeeded", nil
-	}
-
-	err := wait.PollUntilContextTimeout(tc.ctx, interval, csvWaitTimeout, false, isReady)
-	if err != nil {
-		return fmt.Errorf("Error installing %s CSV: %w", name, err)
-	}
-
-	return nil
-}
-
-func getInstallPlanName(tc *testContext, name string, ns string) (string, error) {
-	sub := &ofapi.Subscription{}
-
-	// waits for InstallPlanRef and copies value out of the closure
-	err := tc.wait(func(ctx context.Context) (bool, error) {
-		_sub, err := getSubscription(tc, name, ns)
-		if err != nil {
-			return false, err
-		}
-		*sub = *_sub
-		return sub.Status.InstallPlanRef != nil, nil
-	})
-
-	if err != nil {
-		return "", fmt.Errorf("Error creating subscription %s: %w", name, err)
-	}
-
-	return sub.Status.InstallPlanRef.Name, nil
-}
-
-func getInstallPlan(tc *testContext, name string, ns string) (*ofapi.InstallPlan, error) {
-	// it creates subscription under the hood if needed and waits for InstallPlan reference
-	planName, err := getInstallPlanName(tc, name, ns)
-	if err != nil {
-		return nil, err
-	}
-
-	obj := &ofapi.InstallPlan{}
-	key := types.NamespacedName{
-		Namespace: ns,
-		Name:      planName,
-	}
-
-	err = tc.customClient.Get(tc.ctx, key, obj)
-	if err != nil {
-		return nil, err
-	}
-	return obj, nil
-}
-
-func approveInstallPlan(tc *testContext, plan *ofapi.InstallPlan) error {
-	obj := &ofapi.InstallPlan{
+// createInstallPlan creates an InstallPlan object.
+func createInstallPlan(name string, ns string, csvNames []string) *ofapi.InstallPlan {
+	return &ofapi.InstallPlan{
 		TypeMeta: metav1.TypeMeta{
-			Kind:       "InstallPlan",
-			APIVersion: "operators.coreos.com/v1alpha1",
+			Kind:       ofapi.InstallPlanKind,
+			APIVersion: ofapi.InstallPlanAPIVersion,
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      plan.ObjectMeta.Name,
-			Namespace: plan.ObjectMeta.Namespace,
+			Name:      name,
+			Namespace: ns,
 		},
 		Spec: ofapi.InstallPlanSpec{
 			Approved:                   true,
 			Approval:                   ofapi.ApprovalAutomatic,
-			ClusterServiceVersionNames: plan.Spec.ClusterServiceVersionNames,
+			ClusterServiceVersionNames: csvNames,
 		},
 	}
-	force := true
-	opt := &client.PatchOptions{
-		FieldManager: "e2e-test-dsc",
-		Force:        &force,
-	}
-
-	err := tc.customClient.Patch(tc.ctx, obj, client.Apply, opt)
-	if err != nil {
-		return fmt.Errorf("Error patching InstallPlan %s: %w", obj.ObjectMeta.Name, err)
-	}
-
-	return nil
 }
 
-func ensureOperatorNamespace(tc *testContext, name, ns string) error {
-	operatorNS := &corev1.Namespace{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: ns,
-		},
+// Helper function to safely dereference the condition pointer.
+func dereferenceCondition(condition gTypes.GomegaMatcher) any {
+	// If condition is a pointer, dereference it
+	if reflect.TypeOf(condition).Kind() == reflect.Ptr {
+		return reflect.ValueOf(condition).Elem().Interface()
 	}
-	foundNamespace := &corev1.Namespace{}
-	err := tc.customClient.Get(tc.ctx, client.ObjectKeyFromObject(operatorNS), foundNamespace)
-	if k8serr.IsNotFound(err) {
-		if err := tc.customClient.Create(tc.ctx, operatorNS); err != nil {
-			return fmt.Errorf("error create dependent operator namespace: %w", err)
-		}
-		// Just create it since namespace was not even there, and do not set spec with targetnamespaces!
-		operatorGroup := &ofapiv1.OperatorGroup{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      name,
-				Namespace: ns,
-			},
-		}
-		if err := tc.customClient.Create(tc.ctx, operatorGroup); err != nil {
-			return fmt.Errorf("error create operatorgroup %s: %w", name, err)
-		}
-		return nil
-	}
-	return err
-}
-
-// 1. Ensure namespace exists.
-// 2. Ensure Subscription exists.
-// 3. Ensure InstallPlan exists.
-// 4. InstallPlan to Automatic.
-// 5. Wait for CSV.
-func ensureOperator(tc *testContext, name string, ns string) error {
-	// check namespace first if not exsit then create it along with OG
-	if err := ensureOperatorNamespace(tc, name, ns); err != nil {
-		return err
-	}
-	// it creates subscription under the hood if needed
-	plan, err := getInstallPlan(tc, name, ns)
-	if err != nil {
-		return err
-	}
-
-	// in CI InstallPlan is in Manual mode
-	if !plan.Spec.Approved {
-		err = approveInstallPlan(tc, plan)
-		if err != nil {
-			return err
-		}
-	}
-
-	return waitCSV(tc, name, ns)
-}
-
-func ensureServicemeshOperators(t *testing.T, tc *testContext) error { //nolint: thelper
-	depOperators := map[string]string{
-		"serverless-operator": "openshift-serverless",
-		"servicemeshoperator": "openshift-operators",
-		"authorino-operator":  "openshift-operators",
-	}
-
-	var errors *multierror.Error
-	c := make(chan error)
-
-	for name, ns := range depOperators {
-		t.Logf("Ensuring %s is installed", name)
-		go func(name, ns string) {
-			err := ensureOperator(tc, name, ns)
-			c <- err
-		}(name, ns)
-	}
-	for range depOperators {
-		err := <-c
-		errors = multierror.Append(errors, err)
-	}
-	return errors.ErrorOrNil()
-}
-
-func (tc *testContext) setUp(t *testing.T) error { //nolint: thelper
-	return ensureServicemeshOperators(t, tc)
-}
-
-func mockCRDcreation(group, version, kind, componentName string) *apiextv1.CustomResourceDefinition {
-	return &apiextv1.CustomResourceDefinition{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: strings.ToLower(fmt.Sprintf("%ss.%s", kind, group)),
-			Labels: map[string]string{
-				labels.ODH.Component(componentName): labels.True,
-			},
-		},
-		Spec: apiextv1.CustomResourceDefinitionSpec{
-			Group: group,
-			Names: apiextv1.CustomResourceDefinitionNames{
-				Kind:   kind,
-				Plural: strings.ToLower(kind) + "s",
-			},
-			Scope: apiextv1.ClusterScoped,
-			Versions: []apiextv1.CustomResourceDefinitionVersion{
-				{
-					Name:    version,
-					Served:  true,
-					Storage: true,
-					Schema: &apiextv1.CustomResourceValidation{
-						OpenAPIV3Schema: &apiextv1.JSONSchemaProps{
-							Type: "object",
-						},
-					},
-				},
-			},
-		},
-	}
+	// If it's not a pointer, return the condition as is
+	return condition
 }

--- a/tests/e2e/helper_test.go
+++ b/tests/e2e/helper_test.go
@@ -2,12 +2,10 @@ package e2e_test
 
 import (
 	"fmt"
-	"reflect"
 	"testing"
 	"time"
 
 	"github.com/onsi/gomega/gstruct"
-	"github.com/onsi/gomega/matchers"
 	gTypes "github.com/onsi/gomega/types"
 	configv1 "github.com/openshift/api/config/v1"
 	operatorv1 "github.com/openshift/api/operator/v1"
@@ -18,8 +16,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	k8slabels "k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -38,10 +34,6 @@ import (
 
 	. "github.com/onsi/gomega"
 )
-
-var NoOpMutationFn = func(obj *unstructured.Unstructured) error {
-	return nil // No operation, just return nil
-}
 
 // Namespace and Operator Constants.
 const (
@@ -64,7 +56,7 @@ const (
 
 	defaultEventuallyTimeout        = 5 * time.Minute  // Set default timeout for Eventually (default is 1 second).
 	defaultEventuallyPollInterval   = 2 * time.Second  // Set default timeout for Eventually (default is 1 second).
-	defaultConsistentlyDuration     = 10 * time.Second // Set default duration for Consistently (default is 2 seconds).
+	defaultConsistentlyTimeout      = 10 * time.Second // Set default duration for Consistently (default is 2 seconds).
 	defaultConsistentlyPollInterval = 2 * time.Second  // Set default polling interval for Consistently (default is 50ms).
 
 	eventuallyTimeoutMedium = 7 * time.Minute  // Medium timeout for readiness checks (e.g., CSV, DSC)
@@ -79,13 +71,13 @@ const (
 	dscInstanceName  = "e2e-test-dsc"  // Instance name for the DataScienceCluster
 
 	// Standard error messages format.
-	resourceNotNilErrorMsg     = "Expected a non-nil resource object but got nil."
-	resourceNotFoundErrorMsg   = "Expected resource '%s' of kind '%s' to exist, but it was not found or could not be retrieved."
-	resourceFoundErrorMsg      = "Expected resource '%s' of kind '%s' to not exist, but it was found."
-	resourceEmptyErrorMsg      = "Expected resource list '%s' of kind '%s' to contain resources, but it was empty."
-	resourceNotEmptyErrorMsg   = "Expected resource list '%s' of kind '%s' to be empty, but it contains resources."
-	resourceFetchErrorMsg      = "Error occurred while fetching the resource '%s' of kind '%s': %v"
-	unexpectedErrorMismatchMsg = "Expected error '%v' to match the actual error '%v' for resource of kind '%s'."
+	resourceNotNilErrorMsg       = "Expected a non-nil resource object but got nil."
+	resourceNotFoundErrorMsg     = "Expected resource '%s' of kind '%s' to exist, but it was not found or could not be retrieved."
+	resourceFoundErrorMsg        = "Expected resource '%s' of kind '%s' to not exist, but it was found."
+	resourceEmptyErrorMsg        = "Expected resource list '%s' of kind '%s' to contain resources, but it was empty."
+	resourceListNotEmptyErrorMsg = "Expected resource list '%s' of kind '%s' to be empty, but it contains resources."
+	resourceFetchErrorMsg        = "Error occurred while fetching the resource '%s' of kind '%s': %v"
+	unexpectedErrorMismatchMsg   = "Expected error '%v' to match the actual error '%v' for resource of kind '%s'."
 )
 
 // RunTestCases runs a series of test cases, optionally in parallel based on the provided options.
@@ -93,8 +85,8 @@ const (
 // Parameters:
 //   - t (*testing.T): The test context passed into the test function.
 //   - testCases ([]TestCase): A slice of test cases to execute.
-//   - opts (...TestCaseOption): Optional configuration options, like enabling parallel execution.
-func (tc *TestContext) RunTestCases(t *testing.T, testCases []TestCase, opts ...TestCaseOption) {
+//   - opts (...TestCaseOpts): Optional configuration options, like enabling parallel execution.
+func (tc *TestContext) RunTestCases(t *testing.T, testCases []TestCase, opts ...TestCaseOpts) {
 	t.Helper()
 
 	// Apply all provided options (e.g., parallel execution) to each test case.
@@ -111,72 +103,15 @@ func (tc *TestContext) RunTestCases(t *testing.T, testCases []TestCase, opts ...
 	}
 }
 
-// TestCaseOption defines a function type that can be used to modify how individual test cases are executed.
-type TestCaseOption func(t *testing.T)
+// TestCaseOpts defines a function type that can be used to modify how individual test cases are executed.
+type TestCaseOpts func(t *testing.T)
 
 // WithParallel is an option that marks test cases to run in parallel.
-func WithParallel() TestCaseOption {
+func WithParallel() TestCaseOpts {
 	return func(t *testing.T) {
 		t.Helper()
 
 		t.Parallel() // Marks the test case to run in parallel with other tests
-	}
-}
-
-// ResourceOption defines a function type for constructing or retrieving an unstructured Kubernetes resource.
-type ResourceOption func(tc *TestContext) *unstructured.Unstructured
-
-// WithObjectToCreate creates a ResourceOption that converts any object to an unstructured object.
-// This is used when the object doesn't exist yet and needs to be created (or updated).
-func WithObjectToCreate(obj client.Object) ResourceOption {
-	return func(tc *TestContext) *unstructured.Unstructured {
-		// Convert the input object to unstructured
-		u, err := resources.ObjectToUnstructured(tc.Scheme(), obj)
-		tc.g.Expect(err).NotTo(HaveOccurred())
-
-		return u
-	}
-}
-
-// WithFetchedObject returns a ResourceOption that fetches the resource by GroupVersionKind and NamespacedName.
-// It calls `EnsureResourceExists` internally to retrieve the resource for updating or patching.
-func WithFetchedObject(gvk schema.GroupVersionKind, nn types.NamespacedName) ResourceOption {
-	return func(tc *TestContext) *unstructured.Unstructured {
-		return tc.EnsureResourceExists(gvk, nn)
-	}
-}
-
-// WithMinimalObject creates a ResourceOption that creates an unstructured object with only the specified
-// GroupVersionKind, Namespace, and Name. This is useful for cases where only minimal resource details are needed,
-// like namespaces or certain simple resource types.
-func WithMinimalObject(gvk schema.GroupVersionKind, nn types.NamespacedName) ResourceOption {
-	return func(tc *TestContext) *unstructured.Unstructured {
-		// Create a new unstructured object and set the necessary fields
-		u := resources.GvkToUnstructured(gvk) // Set the GroupVersionKind
-		u.SetNamespace(nn.Namespace)          // Set the Namespace
-		u.SetName(nn.Name)                    // Set the Name
-
-		// Return the object with only the essential fields set
-		return u
-	}
-}
-
-// WithMinimalObjectFrom creates a ResourceOption that creates an unstructured object with the minimal required fields
-// (GroupVersionKind, Namespace, Name) extracted from the provided object.
-func WithMinimalObjectFrom(obj client.Object) ResourceOption {
-	return func(tc *TestContext) *unstructured.Unstructured {
-		// Extract the GroupVersionKind (GVK) from the object
-		groupVersionKind := obj.GetObjectKind().GroupVersionKind()
-
-		// Create a new unstructured object with the extracted GVK
-		u := resources.GvkToUnstructured(groupVersionKind)
-
-		// Set the Namespace and Name from the provided object
-		u.SetNamespace(obj.GetNamespace())
-		u.SetName(obj.GetName())
-
-		// Return the object with only the essential fields set (GVK, Namespace, Name)
-		return u
 	}
 }
 
@@ -198,424 +133,80 @@ func (tc *TestContext) OverrideEventuallyTimeout(timeout, pollInterval time.Dura
 	}
 }
 
-// EnsureResourceExistsOrNil attempts to retrieve a specific Kubernetes resource from the cluster.
-// It retries fetching the resource until the retry window expires. If the resource exists, it returns it.
-// If the resource does not exist, it returns nil and does not fail the test, which is useful when subsequent actions
-// (such as creating the resource) are intended.
+// ==============================
+//     RESOURCE OPERATIONS
+// ==============================
+
+// EnsureResourceExists verifies whether a specific Kubernetes resource exists in the cluster and optionally matches a given condition.
+// If the resource exists and matches the condition (if provided), it will return the object.
 //
 // Parameters:
-//   - gvk (schema.GroupVersionKind): The GroupVersionKind of the resource being checked.
-//   - nn (types.NamespacedName): The namespace and name of the resource.
-//   - args (...interface{}): Optional Gomega assertion message arguments. If none are provided, a default message
-//     is used for failure when the resource is expected to exist but cannot be found.
+//   - opts (...ResourceOpts): Optional functional arguments that customize the behavior of the operation.
 //
 // Returns:
-//   - *unstructured.Unstructured: The resource object if it exists, or nil if not found.
-func (tc *TestContext) EnsureResourceExistsOrNil(
-	gvk schema.GroupVersionKind,
-	nn types.NamespacedName,
-	args ...any,
-) (*unstructured.Unstructured, error) {
-	// Construct a resource identifier.
-	resourceID := resources.FormatNamespacedName(nn)
+//   - *unstructured.Unstructured: The resource object if it exists and meets the condition (if provided).
+func (tc *TestContext) EnsureResourceExists(opts ...ResourceOpts) *unstructured.Unstructured {
+	// Create a ResourceOptions object based on the provided opts.
+	ro := tc.NewResourceOptions(opts...)
 
-	// Attempt to get the resource with retries
 	var u *unstructured.Unstructured
-	var err error
+
 	tc.g.Eventually(func(g Gomega) {
-		// Fetch the resource
-		u, err = tc.g.Get(gvk, nn).Get()
+		// Use ensureResourceExistsOrNil to attempt to fetch the resource with retries
+		u, _ = tc.ensureResourceExistsOrNil(ro)
 
-		// Explicitly set to nil if the resource is not found
-		if errors.IsNotFound(err) {
-			u = nil
-			return
-		}
-
-		// Ensure no unexpected errors occurred while fetching the resource
-		g.Expect(err).ToNot(HaveOccurred(),
-			appendDefaultIfNeeded(resourceFetchErrorMsg, []any{resourceID, gvk.Kind, err}, args)...,
+		// Ensure that the resource object is not nil
+		g.Expect(u).NotTo(
+			BeNil(),
+			defaultErrorMessageIfNone(resourceNotFoundErrorMsg, []any{ro.ResourceID, ro.GVK.Kind}, ro.CustomErrorArgs)...,
 		)
-	}).Should(Succeed())
 
-	// Return the resource or nil if it wasn't found
-	return u, err
-}
-
-// EnsureResourceExists verifies whether a specific Kubernetes resource exists by checking its presence in the cluster.
-// If the resource doesn't exist, it will fail the test with an error message.
-//
-// Parameters:
-//   - gvk (schema.GroupVersionKind): The GroupVersionKind of the resource being checked.
-//   - nn (types.NamespacedName): The namespace and name of the resource.
-//   - args (...interface{}): Optional Gomega assertion message arguments. If none are provided, a default message is used.
-//
-// Returns:
-//   - *unstructured.Unstructured: The resource object if it exists.
-func (tc *TestContext) EnsureResourceExists(
-	gvk schema.GroupVersionKind,
-	nn types.NamespacedName,
-	args ...any,
-) *unstructured.Unstructured {
-	// Construct a resource identifier.
-	resourceID := resources.FormatNamespacedName(nn)
-
-	// Use EnsureResourceExistsOrNil to attempt to fetch the resource with retries
-	u, _ := tc.EnsureResourceExistsOrNil(gvk, nn)
-
-	// Ensure that the resource object is not nil
-	tc.g.Expect(u).NotTo(BeNil(),
-		appendDefaultIfNeeded(resourceNotFoundErrorMsg, []any{resourceID, gvk.Kind}, args)...)
-
-	return u
-}
-
-// EnsureResourceExistsAndMatchesCondition ensures that the resource exists and matches the given condition.
-// Callers should explicitly use `Not(matcher)` if they need to assert a negative condition.
-//
-// Parameters:
-//   - gvk (schema.GroupVersionKind): The GroupVersionKind of the resource being checked.
-//   - nn (types.NamespacedName): The namespace and name of the resource (used for filtering).
-//   - condition: A Gomega matcher specifying the expected condition (e.g., BeEmpty(), Not(BeEmpty()), jq.Match()).
-//   - args (optional): Gomega assertion message arguments. If not provided, a default message is used.
-//
-// Returns:
-//   - *unstructured.Unstructured: The resource that was found and matched.
-func (tc *TestContext) EnsureResourceExistsAndMatchesCondition(
-	gvk schema.GroupVersionKind,
-	nn types.NamespacedName,
-	condition gTypes.GomegaMatcher,
-	args ...any,
-) *unstructured.Unstructured {
-	var u *unstructured.Unstructured
-
-	tc.g.Eventually(func(g Gomega) {
-		// Ensure the resource exists by using EnsureResourceExists
-		u = tc.EnsureResourceExists(gvk, nn)
-
-		// Get GroupVersionKind from the resource.
-		groupVersionKind := u.GetObjectKind().GroupVersionKind()
-
-		// Construct a resource identifier.
-		resourceID := resources.FormatUnstructuredName(u)
-
-		// Apply the provided condition matcher to the resource.
-		applyMatchers(g, resourceID, groupVersionKind, u, nil, condition, args)
+		// If a condition is provided via WithCondition, apply it inside the Eventually block
+		if ro.Condition != nil {
+			// Apply the provided condition matcher to the resource.
+			applyMatchers(g, ro.ResourceID, ro.GVK, u, nil, ro.Condition, ro.CustomErrorArgs)
+		}
 	}).Should(Succeed())
 
 	return u
 }
 
-// EnsureResourceExistsAndMatchesConditionConsistently verifies that a Kubernetes resource exists and
+// EnsureResourceExistsConsistently verifies that a Kubernetes resource exists and
 // consistently matches a specified condition over a period of time.
 //
 // It repeatedly checks the resource using the provided condition for the specified `timeout` and `polling`
-// intervals, and ensures that the condition holds true consistently within the given time frame.
+// intervals, ensuring the condition holds true consistently within the given time frame.
 //
 // Parameters:
-//   - gvk (schema.GroupVersionKind): The GroupVersionKind of the resource to be checked.
-//   - nn (types.NamespacedName): The namespaced name (namespace + name) of the resource.
-//   - condition: A Gomega matcher specifying the expected condition (e.g., BeEmpty(), Not(BeEmpty()), jq.Match()).
-//   - timeout (time.Duration): The maximum time to wait for the condition to be true consistently.
-//   - polling (time.Duration): The interval to poll for checking the condition.
-//
-// Optional Arguments:
-//   - If `timeout` and `polling` are not provided, default values will be used.
-//     Default timeout: 10 seconds
-//     Default polling interval: 2 second
+//   - opts (...ResourceOpts): Optional functional arguments that customize the behavior of the operation.
 //
 // Returns:
 //   - *unstructured.Unstructured: The resource that was found and matched.
-func (tc *TestContext) EnsureResourceExistsAndMatchesConditionConsistently(
-	gvk schema.GroupVersionKind,
-	nn types.NamespacedName,
-	condition gTypes.GomegaMatcher,
-	timeout time.Duration,
-	polling time.Duration,
-	args ...any,
-) {
-	// Set default values for timeout and polling if not provided
-	if timeout == 0 {
-		timeout = defaultConsistentlyDuration // default timeout if not provided
-	}
-	if polling == 0 {
-		polling = defaultConsistentlyPollInterval // default polling interval if not provided
-	}
+func (tc *TestContext) EnsureResourceExistsConsistently(opts ...ResourceOpts) *unstructured.Unstructured {
+	// Create a ResourceOptions object based on the provided opts.
+	ro := tc.NewResourceOptions(opts...)
+
+	var u *unstructured.Unstructured
 
 	// Ensure the resource exists and matches the condition consistently over the specified period.
 	tc.g.Consistently(func(g Gomega) {
-		// Retrieve the resource
-		u := tc.EnsureResourceExists(gvk, nn)
+		// Use ensureResourceExistsOrNil to attempt to fetch the resource with retries
+		u, _ = tc.ensureResourceExistsOrNil(ro)
 
-		// Get GroupVersionKind from the resource.
-		groupVersionKind := u.GetObjectKind().GroupVersionKind()
-
-		// Construct a resource identifier.
-		resourceID := resources.FormatUnstructuredName(u)
-
-		// Apply the condition to the resource and assert that it matches
-		applyMatchers(g, resourceID, groupVersionKind, u, nil, condition, args)
-	}, timeout, polling)
-}
-
-// EnsureResourceDoesNotExist verifies whether a specific Kubernetes resource does not exist by checking its presence in the cluster.
-// If the resource exists, it will fail the test with an error message.
-//
-// Parameters:
-//   - gvk (schema.GroupVersionKind): The GroupVersionKind of the resource being checked.
-//   - nn (types.NamespacedName): The namespace and name of the resource.
-//   - args (...interface{}): Optional Gomega assertion message arguments. If none are provided, a default message is used.
-func (tc *TestContext) EnsureResourceDoesNotExist(
-	gvk schema.GroupVersionKind,
-	nn types.NamespacedName,
-	args ...any,
-) {
-	_ = tc.ensureResourceDoesNotExist(tc.g, gvk, nn, args)
-}
-
-// EnsureResourceDoesNotExistAndErrorMatches ensures that the given resource does not exist
-// and that the error encountered while retrieving it matches the expected error.
-//
-// Parameters:
-//   - gvk (schema.GroupVersionKind): The GroupVersionKind of the resource to check.
-//   - nn (types.NamespacedName): The namespaced name of the resource.
-//   - expectedErr (error): The expected error (e.g., &meta.NoKindMatchError{}).
-func (tc *TestContext) EnsureResourceDoesNotExistAndErrorMatches(
-	gvk schema.GroupVersionKind,
-	nn types.NamespacedName,
-	expectedErr error,
-	args ...any,
-) {
-	err := tc.ensureResourceDoesNotExist(tc.g, gvk, nn, args)
-
-	// Ensure the error matches the expected condition.
-	tc.g.Expect(err).To(MatchError(expectedErr), unexpectedErrorMismatchMsg, expectedErr, err, gvk.Kind)
-}
-
-// EnsureResourceGone waits for the specified resource to disappear or until a timeout occurs.
-// It retries checking the resource at regular intervals and fails if the resource is still found after the timeout.
-//
-// Parameters:
-//   - gvk (schema.GroupVersionKind): The GroupVersionKind of the resource to check.
-//   - nn (types.NamespacedName): The namespace and name of the resource.
-//   - args (...interface{}): Optional Gomega assertion message arguments.
-func (tc *TestContext) EnsureResourceGone(
-	gvk schema.GroupVersionKind,
-	nn types.NamespacedName,
-	args ...any,
-) {
-	// Use Eventually to retry checking the resource until it disappears or timeout occurs
-	tc.g.Eventually(func(g Gomega) {
-		_ = tc.ensureResourceDoesNotExist(g, gvk, nn, args)
-	}).Should(Succeed())
-}
-
-// EnsureResourceIsGoneAndErrorMatches ensures that the given resource is eventually removed from the cluster
-// and that the error encountered while retrieving it matches the expected error.
-//
-// Parameters:
-//   - gvk (schema.GroupVersionKind): The GroupVersionKind of the resource to check.
-//   - nn (types.NamespacedName): The namespaced name of the resource.
-//   - expectedErr (error): The expected error (e.g., &meta.NoKindMatchError{}).
-func (tc *TestContext) EnsureResourceIsGoneAndErrorMatches(
-	gvk schema.GroupVersionKind,
-	nn types.NamespacedName,
-	expectedErr error,
-	args ...any,
-) {
-	// Use Eventually to retry checking the resource until it disappears or timeout occurs
-	tc.g.Eventually(func(g Gomega) {
-		err := tc.ensureResourceDoesNotExist(g, gvk, nn, args)
-
-		// Ensure the error matches the expected condition.
-		g.Expect(err).To(MatchError(expectedErr), unexpectedErrorMismatchMsg, expectedErr, err, gvk.Kind)
-	}).Should(Succeed())
-}
-
-// EnsureResourcesExist verifies whether a list of specific Kubernetes resources exists in the cluster.
-// It waits for the resources to appear and fails the test with a message if any resource is not found within the timeout.
-//
-// Parameters:
-//   - gvk (schema.GroupVersionKind): The GroupVersionKind of the resource being checked.
-//   - nn (types.NamespacedName): The namespace and name of the resource.
-//   - listOptions (*client.ListOptions): Optional list options like label selectors or other filters.
-//   - args (...interface{}): Optional Gomega assertion message arguments. If none are provided, a default message is used.
-//
-// Returns:
-//   - []unstructured.Unstructured: The list of resources if they exist.
-func (tc *TestContext) EnsureResourcesExist(
-	gvk schema.GroupVersionKind,
-	nn types.NamespacedName,
-	listOptions *client.ListOptions,
-	args ...any,
-) []unstructured.Unstructured {
-	// Construct a resource identifier
-	resourceID := resources.FormatNamespacedName(nn)
-
-	resourcesList := tc.RetrieveResources(gvk, nn, listOptions, args...)
-
-	// Ensure that the resources list is not empty
-	tc.g.Expect(resourcesList).NotTo(BeEmpty(), resourceEmptyErrorMsg, resourceID, gvk.Kind)
-
-	return resourcesList
-}
-
-// EnsureResourcesExistAndMatchCondition verifies whether a list of resources of a specific kind exists
-// in the cluster, and ensures that the list matches the specified condition (e.g., length, owner references, etc.).
-//
-// Parameters:
-//   - gvk (schema.GroupVersionKind): The GroupVersionKind of the resource being checked.
-//   - nn (types.NamespacedName): The namespace and name of the resource.
-//   - listOptions (*client.ListOptions): Optional list options like label selectors or other filters.
-//   - condition gTypes.GomegaMatcher: The condition to check the list of resources against (e.g., owner references, length).
-//   - args (...interface{}): Optional Gomega assertion message arguments.
-//
-// Returns:
-//   - []unstructured.Unstructured: The list of resources that match the condition.
-func (tc *TestContext) EnsureResourcesExistAndMatchCondition(
-	gvk schema.GroupVersionKind,
-	nn types.NamespacedName,
-	listOptions *client.ListOptions,
-	condition gTypes.GomegaMatcher,
-	args ...any,
-) []unstructured.Unstructured {
-	var resourcesList []unstructured.Unstructured
-
-	tc.g.Eventually(func(g Gomega) {
-		// Construct a resource identifier
-		resourceID := resources.FormatNamespacedName(nn)
-
-		// First, ensure that the resources exist using EnsureResourcesExist
-		resourcesList = tc.EnsureResourcesExist(gvk, nn, listOptions, args...)
-
-		// Apply the provided condition matcher to the resource.
-		applyMatchers(g, resourceID, gvk, resourcesList, nil, condition, args)
-	}).Should(Succeed())
-
-	return resourcesList
-}
-
-// EnsureResourcesDoNotExist ensures that the resources for a given GVK and namespace do not exist in the cluster.
-//
-// This function uses `Eventually` to ensure that no resources are found matching the given criteria,
-// verifying that the resources do not exist or have been removed successfully.
-//
-// Parameters:
-//   - gvk (schema.GroupVersionKind): The GroupVersionKind of the resources to ensure do not exist.
-//   - nn (types.NamespacedName): The namespace and name of the resource(s) to check.
-//   - listOptions (*client.ListOptions, optional): Optional list options (e.g., label selectors) for filtering the resources.
-//   - args (...any, optional): Optional arguments for error messages or logging.
-func (tc *TestContext) EnsureResourcesDoNotExist(
-	gvk schema.GroupVersionKind,
-	nn types.NamespacedName,
-	listOptions *client.ListOptions,
-	args ...any,
-) {
-	tc.ensureResourcesDoNotExist(tc.g, gvk, nn, listOptions, args)
-}
-
-// EnsureResourcesGone waits for the list of resources to disappear or until a timeout occurs.
-// It retries checking the resources at regular intervals and fails if any resource is still found after the timeout.
-//
-// Parameters:
-//   - gvk (schema.GroupVersionKind): The GroupVersionKind of the resources to check.
-//   - nn (types.NamespacedName): The namespace and name of the resource(s).
-//   - listOptions (*client.ListOptions, optional): Optional list options for filtering the resources (e.g., label selectors).
-//   - args (...interface{}): Optional Gomega assertion message arguments.
-func (tc *TestContext) EnsureResourcesGone(
-	gvk schema.GroupVersionKind,
-	nn types.NamespacedName,
-	listOptions *client.ListOptions,
-	args ...any,
-) {
-	// Use Eventually to retry checking the resource until it disappears or timeout occurs
-	tc.g.Eventually(func(g Gomega) {
-		tc.ensureResourcesDoNotExist(g, gvk, nn, listOptions, args)
-	}).Should(Succeed())
-}
-
-// EnsureExactlyOneResourceExists verifies that exactly one instance of a specific Kubernetes resource
-// exists in the cluster. If there are none or more than one, it fails the test.
-//
-// Parameters:
-//   - gvk (schema.GroupVersionKind): The GroupVersionKind of the resource being checked.
-//   - nn (types.NamespacedName): The namespace and name of the resource (used for filtering).
-//   - args (...interface{}): Optional Gomega assertion message arguments. Defaults to a standard error message.
-//
-// Returns:
-//   - *unstructured.Unstructured: The resource object if exactly one instance exists.
-func (tc *TestContext) EnsureExactlyOneResourceExists(
-	gvk schema.GroupVersionKind,
-	nn types.NamespacedName,
-	args ...any,
-) *unstructured.Unstructured {
-	// Construct a resource identifier.
-	resourceID := resources.FormatNamespacedName(nn)
-
-	// Use Eventually to retry getting the resources until they appears
-	var objList []unstructured.Unstructured
-	tc.g.Eventually(func(g Gomega) {
-		// Fetch the resources
-		var err error
-		objList, err = tc.g.List(gvk).Get()
-
-		// Ensure no error occurred when fetching resources
-		g.Expect(err).NotTo(HaveOccurred(), appendDefaultIfNeeded(
-			resourceFetchErrorMsg,
-			[]any{resourceID, gvk.Kind, err},
-			args,
-		)...)
-
-		// Ensure the resource list is not empty
-		g.Expect(objList).NotTo(BeEmpty(), resourceEmptyErrorMsg, resourceID, gvk.Kind)
-
-		// Ensure exactly one resource exists
-		g.Expect(objList).To(HaveLen(1), appendDefaultIfNeeded(
-			"Expected exactly one resource '%s' of kind '%s', but found %d.",
-			[]any{resourceID, gvk.Kind, len(objList)},
-			args,
-		)...)
-	}).Should(Succeed())
-
-	return &objList[0]
-}
-
-// EnsureResourcesWithLabelsExist ensures that at least `minCount` resources of a given kind
-// exist in the cluster, filtered by the specified labels.
-//
-// Parameters:
-//   - gvk (schema.GroupVersionKind): The GroupVersionKind of the resources being checked.
-//   - matchingLabels (client.MatchingLabels): The label selector used to filter the resources.
-//   - minCount (int): The minimum number of matching resources expected.
-//   - args (...any): Optional additional arguments for assertion messages.
-func (tc *TestContext) EnsureResourcesWithLabelsExist(
-	gvk schema.GroupVersionKind,
-	matchingLabels client.MatchingLabels,
-	minCount int,
-	args ...any,
-) {
-	tc.g.Eventually(func(g Gomega) {
-		// Fetch resources based on labels
-		var err error
-		objList, err := tc.g.List(gvk, matchingLabels).Get()
-
-		// Check if an error occurred while listing resources
-		g.Expect(err).NotTo(
-			HaveOccurred(),
-			"Failed to list resources of kind '%s' with labels '%s': %v",
-			gvk.Kind, k8slabels.FormatLabels(matchingLabels), err,
+		// Ensure that the resource object is not nil
+		g.Expect(u).NotTo(
+			BeNil(),
+			defaultErrorMessageIfNone(resourceNotFoundErrorMsg, []any{ro.ResourceID, ro.GVK.Kind}, ro.CustomErrorArgs)...,
 		)
 
-		// Ensure at least `minCount` resources exist
-		g.Expect(len(objList)).To(
-			BeNumerically(">=", minCount),
-			appendDefaultIfNeeded(
-				"Expected at least %d resources of kind '%s' with labels '%s', but found %d.",
-				[]any{minCount, gvk.Kind, k8slabels.FormatLabels(matchingLabels), len(objList)},
-				args,
-			)...,
-		)
-	}).Should(Succeed())
+		// If a condition is provided via WithCondition, apply it inside the Eventually block
+		if ro.Condition != nil {
+			// Apply the provided condition matcher to the resource.
+			applyMatchers(g, ro.ResourceID, ro.GVK, u, nil, ro.Condition, ro.CustomErrorArgs)
+		}
+	})
+
+	return u
 }
 
 // EnsureResourceCreatedOrUpdated ensures that a given Kubernetes resource exists.
@@ -623,79 +214,146 @@ func (tc *TestContext) EnsureResourcesWithLabelsExist(
 // using the provided mutation function.
 //
 // Parameters:
-//   - option (ResourceOption): A function that provides the resource object (either existing or new).
-//   - fn (func(*unstructured.Unstructured) error): A function to modify the resource before applying it.
-//   - args (...interface{}): Optional Gomega assertion message arguments. If none are provided, a default message is used.
+//   - opts (...ResourceOpts): Optional functional arguments that customize the behavior of the operation.
 //
 // Returns:
 //   - *unstructured.Unstructured: The existing or newly created (updated) resource object.
-func (tc *TestContext) EnsureResourceCreatedOrUpdated(
-	option ResourceOption,
-	fn func(obj *unstructured.Unstructured) error,
-	args ...any,
-) *unstructured.Unstructured {
-	return tc.EnsureResourceCreatedOrUpdatedWithCondition(option, fn, Succeed(), args...)
-}
+func (tc *TestContext) EnsureResourceCreatedOrUpdated(opts ...ResourceOpts) *unstructured.Unstructured {
+	// Create a ResourceOptions object based on the provided opts.
+	ro := tc.NewResourceOptions(opts...)
 
-// EnsureResourceCreatedOrUpdatedWithCondition ensures that a Kubernetes resource is either created or updated
-// and that it meets a specified condition. It allows resources to be provided either by directly passing an object
-// or by fetching one from the cluster.
-//
-// Parameters:
-//   - option: A function that provides the resource (either an existing object or fetched from the cluster).
-//   - fn (func(*unstructured.Unstructured) error): A function to modify the resource before applying it.
-//   - condition (gTypes.GomegaMatcher): The Gomega matcher condition to assert on the resource after it is created or updated.
-//   - args (...interface{}): Optional Gomega assertion message arguments. Defaults to a standard error message.
-//
-// Returns:
-//   - *unstructured.Unstructured: The existing or newly created (updated) resource object.
-func (tc *TestContext) EnsureResourceCreatedOrUpdatedWithCondition(
-	option ResourceOption,
-	fn func(obj *unstructured.Unstructured) error,
-	condition gTypes.GomegaMatcher,
-	args ...any,
-) *unstructured.Unstructured {
-	return tc.ensureResourceAppliedWithCondition(option, fn, condition, tc.g.CreateOrUpdate, args...)
+	// Default the condition to Succeed() if it's not provided.
+	if ro.Condition == nil {
+		ro.Condition = Succeed()
+	}
+
+	// Apply the resource using ensureResourceApplied.
+	return tc.ensureResourceApplied(ro, tc.g.CreateOrUpdate)
 }
 
 // EnsureResourceCreatedOrPatched ensures that a given Kubernetes resource exists.
-// If the resource is missing, it will be created; if it already exists, it will be patched
-// using the provided mutation function.
+// If the resource is missing, it will be created; if it already exists, it will be patched.
+// If a condition is provided, it will be evaluated; otherwise, Succeed() is used.
 //
 // Parameters:
-//   - option (ResourceOption): A function that provides the resource object (either existing or new).
-//   - fn (func(*unstructured.Unstructured) error): A function to modify the resource before applying it.
-//   - args (...interface{}): Optional Gomega assertion message arguments. Defaults to a standard error message.
+//   - opts (...ResourceOpts): Optional functional arguments that customize the behavior of the operation.
 //
 // Returns:
 //   - *unstructured.Unstructured: The existing or newly created (patched) resource object.
-func (tc *TestContext) EnsureResourceCreatedOrPatched(
-	option ResourceOption,
-	fn func(obj *unstructured.Unstructured) error,
-	args ...any,
-) *unstructured.Unstructured {
-	return tc.EnsureResourceCreatedOrPatchedWithCondition(option, fn, Succeed(), args...)
+func (tc *TestContext) EnsureResourceCreatedOrPatched(opts ...ResourceOpts) *unstructured.Unstructured {
+	// Create a ResourceOptions object based on the provided opts.
+	ro := tc.NewResourceOptions(opts...)
+
+	// Default the condition to Succeed() if it's not provided
+	if ro.Condition == nil {
+		ro.Condition = Succeed()
+	}
+
+	// Apply the resource using ensureResourceApplied
+	return tc.ensureResourceApplied(ro, tc.g.CreateOrPatch)
 }
 
-// EnsureResourceCreatedOrPatchedWithCondition ensures that a given Kubernetes resource exists
-// and that it matches the specified condition. If the resource is missing, it will be created;
-// if it already exists, it will be patched using the provided mutation function.
+// EnsureResourceDoesNotExist verifies that a Kubernetes resource does not exist.
+// If the resource is found, the test fails. If an expected error is provided via WithExpectedErr, it validates the error.
 //
 // Parameters:
-//   - option (ResourceOption): A function that provides the resource (either an existing object or fetched from the cluster).
-//   - fn (func(*unstructured.Unstructured) error): A function to modify the resource before applying it.
-//   - condition (gTypes.GomegaMatcher): The Gomega matcher condition to assert on the resource after it is created or patched.
-//   - args (...interface{}): Optional Gomega assertion message arguments. Defaults to a standard error message.
+//   - opts (...ResourceOpts): Optional functional arguments that customize the behavior of the operation.
+func (tc *TestContext) EnsureResourceDoesNotExist(opts ...ResourceOpts) {
+	// Create a ResourceOptions object based on the provided opts.
+	ro := tc.NewResourceOptions(opts...)
+
+	err := tc.ensureResourceDoesNotExist(tc.g, ro)
+
+	// Validate the error if an expected error is set
+	if ro.ExpectedErr != nil {
+		tc.g.Expect(err).To(MatchError(ro.ExpectedErr), unexpectedErrorMismatchMsg, ro.ExpectedErr, err, ro.GVK.Kind)
+	}
+}
+
+// EnsureResourceGone retries checking a resource until it is deleted or times out.
+// If the resource still exists after the timeout, the test will fail.
+//
+// Parameters:
+//   - opts (...ResourceOpts): Optional functional arguments that customize the behavior of the operation.
 //
 // Returns:
-//   - *unstructured.Unstructured: The existing or newly created (patched) resource object.
-func (tc *TestContext) EnsureResourceCreatedOrPatchedWithCondition(
-	option ResourceOption,
-	fn func(obj *unstructured.Unstructured) error,
-	condition gTypes.GomegaMatcher,
-	args ...any,
-) *unstructured.Unstructured {
-	return tc.ensureResourceAppliedWithCondition(option, fn, condition, tc.g.CreateOrPatch, args...)
+//   - error: If the resource still exists after the timeout.
+func (tc *TestContext) EnsureResourceGone(opts ...ResourceOpts) {
+	// Create a ResourceOptions object based on the provided opts.
+	ro := tc.NewResourceOptions(opts...)
+
+	// Use Eventually to retry checking the resource until it disappears or timeout occurs
+	tc.g.Eventually(func(g Gomega) {
+		err := tc.ensureResourceDoesNotExist(g, ro)
+
+		// Validate the error if an expected error is set
+		if ro.ExpectedErr != nil {
+			g.Expect(err).To(MatchError(ro.ExpectedErr), unexpectedErrorMismatchMsg, ro.ExpectedErr, err, ro.GVK.Kind)
+		}
+	}).Should(Succeed())
+}
+
+// EnsureResourcesExist ensures that a specific list of Kubernetes resources exists in the cluster.
+// It will retry fetching the resources until they are found or the timeout occurs.
+// If a condition is provided, it will retry the condition check on the resources until the condition is satisfied.
+//
+// Parameters:
+//   - opts (...ResourceOpts): Optional functional arguments that customize the behavior of the operation.
+//
+// Returns:
+//   - []unstructured.Unstructured: The list of resources if they exist and meet the condition (if provided).
+func (tc *TestContext) EnsureResourcesExist(opts ...ResourceOpts) []unstructured.Unstructured {
+	// Create a ResourceOptions object based on the provided opts.
+	ro := tc.NewResourceOptions(opts...)
+
+	var resourcesList []unstructured.Unstructured
+
+	tc.g.Eventually(func(g Gomega) {
+		resourcesList, _ := tc.fetchResources(ro)
+
+		// If no condition is provided, simply ensure the list is not empty
+		g.Expect(resourcesList).NotTo(BeEmpty(), resourceEmptyErrorMsg, ro.ResourceID, ro.GVK.Kind)
+
+		// If a condition is provided via WithCondition, apply it inside the Eventually block
+		if ro.Condition != nil {
+			// Apply the condition matcher (e.g., length check, label check, etc.)
+			applyMatchers(g, ro.ResourceID, ro.GVK, resourcesList, nil, ro.Condition, ro.CustomErrorArgs)
+		}
+	}).Should(Succeed())
+
+	return resourcesList
+}
+
+// EnsureResourcesDoNotExist performs a one-time check to verify that a list of resources does not exist in the cluster.
+//
+// This function fetches the resources once and fails the test immediately if any exist.
+//
+// Parameters:
+//   - opts (...ResourceOpts): Optional functional arguments that customize the behavior of the operation.
+//
+// This function does not retry; use EnsureResourcesGone if you need to wait for deletion.
+func (tc *TestContext) EnsureResourcesDoNotExist(opts ...ResourceOpts) {
+	// Create a ResourceOptions object based on the provided opts
+	ro := tc.NewResourceOptions(opts...)
+
+	_ = tc.ensureResourcesDoNotExist(tc.g, ro)
+}
+
+// EnsureResourcesGone waits for a list of resources to be deleted, retrying the check until they no longer exist.
+//
+// This function repeatedly checks if the resources are gone, failing the test only if they still exist after the timeout.
+//
+// Parameters:
+//   - opts (...ResourceOpts): Optional functional arguments that customize the behavior of the operation.
+func (tc *TestContext) EnsureResourcesGone(opts ...ResourceOpts) {
+	// Create a ResourceOptions object based on the provided opts.
+	ro := tc.NewResourceOptions(opts...)
+
+	// Use Eventually to retry checking the resource until it disappears or timeout occurs
+	tc.g.Eventually(func(g Gomega) {
+		err := tc.ensureResourcesDoNotExist(g, ro)
+		g.Expect(err).NotTo(HaveOccurred())
+	}).Should(Succeed())
 }
 
 // EnsureSubscriptionExistsOrCreate ensures that the specified Subscription exists.
@@ -708,9 +366,7 @@ func (tc *TestContext) EnsureResourceCreatedOrPatchedWithCondition(
 //
 // Returns:
 //   - *unstructured.Unstructured: The existing or newly created Subscription object.
-func (tc *TestContext) EnsureSubscriptionExistsOrCreate(
-	nn types.NamespacedName,
-) *unstructured.Unstructured {
+func (tc *TestContext) EnsureSubscriptionExistsOrCreate(nn types.NamespacedName) *unstructured.Unstructured {
 	// Construct a resource identifier.
 	resourceID := resources.FormatNamespacedName(nn)
 
@@ -718,11 +374,11 @@ func (tc *TestContext) EnsureSubscriptionExistsOrCreate(
 	sub := createSubscription(nn)
 
 	// Ensure the Subscription exists or create it if missing
-	return tc.EnsureResourceCreatedOrUpdatedWithCondition(
+	return tc.EnsureResourceCreatedOrUpdated(
 		WithObjectToCreate(sub),
-		testf.TransformSpecToUnstructured(sub.Spec),
-		jq.Match(`.status | has("installPlanRef")`),
-		"Failed to ensure Subscription '%s' exists", resourceID,
+		WithMutateFunc(testf.TransformSpecToUnstructured(sub.Spec)),
+		WithCondition(jq.Match(`.status | has("installPlanRef")`)),
+		WithCustomErrorMsg("Failed to ensure Subscription '%s' exists", resourceID),
 	)
 }
 
@@ -733,14 +389,11 @@ func (tc *TestContext) EnsureSubscriptionExistsOrCreate(
 //   - actualResource (interface{}): The resource to be compared.
 //   - expectedResource (interface{}): The expected resource.
 //   - args (...interface{}): Optional Gomega assertion message arguments.
-func (tc *TestContext) EnsureResourcesAreEqual(
-	actualResource, expectedResource interface{},
-	args ...any,
-) {
+func (tc *TestContext) EnsureResourcesAreEqual(actualResource, expectedResource interface{}, args ...any) {
 	// Use Gomega's BeEquivalentTo for flexible deep comparison
 	tc.g.Expect(actualResource).To(
 		BeEquivalentTo(expectedResource),
-		appendDefaultIfNeeded(
+		defaultErrorMessageIfNone(
 			"Expected resource to be equal to the actual resource, but they differ.\nActual: %v\nExpected: %v", []any{actualResource, expectedResource},
 			args,
 		)...,
@@ -751,13 +404,10 @@ func (tc *TestContext) EnsureResourcesAreEqual(
 //
 // Parameters:
 //   - obj (*unstructured.Unstructured): The resource object to check.
-//   - resourceID (string): The identifier of the resource (e.g., "namespace/name").
+//   - ResourceID (string): The identifier of the resource (e.g., "namespace/name").
 //   - kind (string): The kind of the resource (e.g., "Deployment").
 //   - args (...interface{}): Optional Gomega assertion message arguments.
-func (tc *TestContext) EnsureResourceNotNil(
-	obj any,
-	args ...any,
-) {
+func (tc *TestContext) EnsureResourceNotNil(obj any, args ...any) {
 	tc.EnsureResourceConditionMet(obj, Not(BeNil()), args...)
 }
 
@@ -768,11 +418,7 @@ func (tc *TestContext) EnsureResourceNotNil(
 //   - obj (any): The resource object to check.
 //   - matcher: A Gomega matcher specifying the expected condition (e.g., BeEmpty(), Not(BeEmpty())).
 //   - args (...interface{}): Optional Gomega assertion message arguments. If not provided, a default message is used.
-func (tc *TestContext) EnsureResourceConditionMet(
-	obj any,
-	condition gTypes.GomegaMatcher,
-	args ...any,
-) {
+func (tc *TestContext) EnsureResourceConditionMet(obj any, condition gTypes.GomegaMatcher, args ...any) {
 	// Ensure obj is not nil before proceeding
 	tc.g.Expect(obj).NotTo(BeNil(), resourceNotNilErrorMsg)
 
@@ -786,7 +432,7 @@ func (tc *TestContext) EnsureResourceConditionMet(
 	// Perform the assertion using the custom condition
 	tc.g.Expect(obj).To(
 		condition,
-		appendDefaultIfNeeded(
+		defaultErrorMessageIfNone(
 			"Expected resource '%s' of kind '%s' to satisfy condition '%v' but did not.",
 			[]any{resourceID, u.GetKind()},
 			args,
@@ -805,20 +451,16 @@ func (tc *TestContext) EnsureResourceConditionMet(
 // Parameters:
 //   - nn (types.NamespacedName): The namespace and name of the deployment to check.
 //   - replicas (int32): The expected number of ready replicas for the deployment.
-func (tc *TestContext) EnsureDeploymentReady(
-	nn types.NamespacedName,
-	replicas int32,
-) {
+func (tc *TestContext) EnsureDeploymentReady(nn types.NamespacedName, replicas int32) {
 	// Construct a resource identifier.
 	resourceID := resources.FormatNamespacedName(nn)
 
 	// Ensure the deployment exists and retrieve the object.
 	deployment := &appsv1.Deployment{}
-	tc.RetrieveResource(
-		gvk.Deployment,
-		nn,
+	tc.FetchTypedResource(
 		deployment,
-		"Deployment %s was expected to exist but was not found", resourceID,
+		WithMinimalObject(gvk.Deployment, nn),
+		WithCustomErrorMsg("Deployment %s was expected to exist but was not found", resourceID),
 	)
 
 	// Assert that the deployment contains the necessary condition (DeploymentAvailable) with status "True"
@@ -845,16 +487,13 @@ func (tc *TestContext) EnsureDeploymentReady(
 //
 // Parameters:
 //   - name (string): The name of the CRD to check.
-func (tc *TestContext) EnsureCRDEstablished(
-	name string,
-) {
+func (tc *TestContext) EnsureCRDEstablished(name string) {
 	// Ensure the CustomResourceDefinition exists and retrieve the object
 	crd := &apiextv1.CustomResourceDefinition{}
-	tc.RetrieveResource(
-		gvk.CustomResourceDefinition,
-		types.NamespacedName{Name: name},
+	tc.FetchTypedResource(
 		crd,
-		"CRD %s was expected to exist but was not found", name,
+		WithMinimalObject(gvk.CustomResourceDefinition, types.NamespacedName{Name: name}),
+		WithCustomErrorMsg("CRD %s was expected to exist but was not found", name),
 	)
 
 	// Assert that the CustomResourceDefinition contains the necessary condition (Established) with status "True"
@@ -882,10 +521,7 @@ func (tc *TestContext) EnsureCRDEstablished(
 //
 // Returns:
 //   - error: Returns nil if the duplicate creation fails as expected, otherwise returns an error.
-func (tc *TestContext) EnsureResourceIsUnique(
-	obj client.Object,
-	args ...any,
-) {
+func (tc *TestContext) EnsureResourceIsUnique(obj client.Object, args ...any) {
 	// Ensure obj is not nil before proceeding
 	tc.g.Expect(obj).NotTo(BeNil(), resourceNotNilErrorMsg)
 
@@ -898,10 +534,9 @@ func (tc *TestContext) EnsureResourceIsUnique(
 
 	// Ensure that at least one resource of this kind already exists
 	tc.EnsureResourcesExist(
-		groupVersionKind,
-		types.NamespacedName{Namespace: u.GetNamespace()},
-		&client.ListOptions{Namespace: u.GetNamespace()},
-		"Failed to verify existence of %s", groupVersionKind.Kind,
+		WithMinimalObject(groupVersionKind, types.NamespacedName{Namespace: u.GetNamespace()}),
+		WithListOptions(&client.ListOptions{Namespace: u.GetNamespace()}),
+		WithCustomErrorMsg("Failed to verify existence of %s", groupVersionKind.Kind),
 	)
 
 	// Attempt to create the duplicate resource, expecting failure
@@ -910,7 +545,7 @@ func (tc *TestContext) EnsureResourceIsUnique(
 		_, err := tc.g.Create(u, types.NamespacedName{Namespace: u.GetNamespace(), Name: u.GetName()}).Get()
 
 		// If there's no error, that means the duplicate creation succeeded, which is a failure
-		g.Expect(err).To(HaveOccurred(), appendDefaultIfNeeded(
+		g.Expect(err).To(HaveOccurred(), defaultErrorMessageIfNone(
 			"Expected creation of duplicate %s to fail due to uniqueness constraint, but it succeeded.",
 			[]any{groupVersionKind.Kind},
 			args,
@@ -919,7 +554,7 @@ func (tc *TestContext) EnsureResourceIsUnique(
 		// Check if the error is a Kubernetes StatusError and was denied by an admission webhook
 		// Ensure the failure is due to uniqueness constraints (Forbidden error)
 		g.Expect(errors.IsForbidden(err)).To(BeTrue(),
-			appendDefaultIfNeeded(
+			defaultErrorMessageIfNone(
 				"Expected failure due to uniqueness constraint (Forbidden), but got: %v",
 				[]any{err},
 				args,
@@ -947,21 +582,19 @@ func (tc *TestContext) EnsureOperatorInstalled(nn types.NamespacedName, skipOper
 	// Ensure the operator's namespace is created.
 	tc.EnsureResourceCreatedOrUpdated(
 		WithMinimalObject(gvk.Namespace, types.NamespacedName{Name: nn.Namespace}),
-		NoOpMutationFn,
-		"Failed to create or update namespace '%s'", nn.Namespace,
+		WithCustomErrorMsg("Failed to create or update namespace '%s'", nn.Namespace),
 	)
 
 	// Ensure the operator group is created or updated only if necessary.
 	if !skipOperatorGroupCreation {
 		tc.EnsureResourceCreatedOrUpdated(
 			WithMinimalObject(gvk.OperatorGroup, nn),
-			NoOpMutationFn,
-			"Failed to create or update operator group '%s'", resourceID,
+			WithCustomErrorMsg("Failed to create or update operator group '%s'", resourceID),
 		)
 	}
 
 	// Retrieve the InstallPlan
-	plan := tc.RetrieveInstallPlan(nn)
+	plan := tc.FetchInstallPlan(nn)
 
 	// in CI InstallPlan is in Manual mode
 	if !plan.Spec.Approved {
@@ -973,7 +606,7 @@ func (tc *TestContext) EnsureOperatorInstalled(nn types.NamespacedName, skipOper
 	csvName := plan.Spec.ClusterServiceVersionNames[0] // Assuming first in the list
 
 	tc.g.Eventually(func(g Gomega) {
-		csv := tc.RetrieveClusterServiceVersion(types.NamespacedName{Namespace: nn.Namespace, Name: csvName})
+		csv := tc.FetchClusterServiceVersion(types.NamespacedName{Namespace: nn.Namespace, Name: csvName})
 		g.Expect(csv.Status.Phase).To(
 			Equal(ofapi.CSVPhaseSucceeded),
 			"CSV %s did not reach 'Succeeded' phase", resourceID,
@@ -986,30 +619,23 @@ func (tc *TestContext) EnsureOperatorInstalled(nn types.NamespacedName, skipOper
 // does not exist or if the deletion fails.
 //
 // Parameters:
-//   - gvk (schema.GroupVersionKind): The GroupVersionKind of the resource to be deleted.
-//   - nn (types.NamespacedName): The namespace and name of the resource to be deleted.
-//   - clientOption (...client.DeleteOption): Optional delete options such as cascading or propagation policy.
-func (tc *TestContext) DeleteResource(
-	gvk schema.GroupVersionKind,
-	nn types.NamespacedName,
-	clientOption ...client.DeleteOption,
-) {
-	// Construct a resource identifier.
-	resourceID := resources.FormatNamespacedName(nn)
+//   - options(...ResourceOpts): Optional options for configuring the resource and deletion behavior.
+func (tc *TestContext) DeleteResource(opts ...ResourceOpts) {
+	// Create a ResourceOptions object based on the provided opts.
+	ro := tc.NewResourceOptions(opts...)
 
 	// Ensure the resource exists before attempting deletion
 	tc.EnsureResourceExists(
-		gvk,
-		nn,
-		"Expected %s instance %s to exist before attempting deletion", gvk.Kind, resourceID,
+		WithMinimalObject(ro.GVK, ro.NN),
+		WithCustomErrorMsg("Expected %s instance %s to exist before attempting deletion", ro.GVK.Kind, ro.ResourceID),
 	)
 
 	// Delete the resource if it exists
 	tc.g.Delete(
-		gvk,
-		nn,
-		clientOption...,
-	).Eventually().Should(Succeed(), "Failed to delete %s instance %s", gvk.Kind, resourceID)
+		ro.GVK,
+		ro.NN,
+		ro.ClientDeleteOptions,
+	).Eventually().Should(Succeed(), "Failed to delete %s instance %s", ro.GVK.Kind, ro.ResourceID)
 }
 
 // DeleteResourceIfExists verifies whether a specific Kubernetes resource exists and deletes it if found.
@@ -1017,35 +643,32 @@ func (tc *TestContext) DeleteResource(
 // does not exist (i.e., the deletion is considered successful if the resource is not found).
 //
 // Parameters:
-//   - gvk (schema.GroupVersionKind): The GroupVersionKind of the resource to be deleted.
-//   - nn (types.NamespacedName): The namespace and name of the resource to be deleted.
-//   - clientOption (...client.DeleteOption): Optional delete options such as cascading or propagation policy.
-func (tc *TestContext) DeleteResourceIfExists(
-	gvk schema.GroupVersionKind,
-	nn types.NamespacedName,
-	clientOption ...client.DeleteOption,
-) {
-	// Construct a resource identifier.
-	resourceID := resources.FormatNamespacedName(nn)
+//   - opts(...ResourceOpts): Optional options for configuring the resource and deletion behavior.
+func (tc *TestContext) DeleteResourceIfExists(opts ...ResourceOpts) {
+	// Create a ResourceOptions object based on the provided opts.
+	ro := tc.NewResourceOptions(opts...)
 
-	// Use EnsureResourceExistsOrNil to attempt to fetch the resource with retries
-	_, err := tc.EnsureResourceExistsOrNil(gvk, nn)
+	// Use ensureResourceExistsOrNil to attempt to fetch the resource with retries
+	_, err := tc.ensureResourceExistsOrNil(ro)
 
 	// If error is not nil and not IsNotFound, we fail the test.
 	if err != nil && !errors.IsNotFound(err) {
-		tc.g.Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("Unexpected error while checking existence of %s instance %s", gvk.Kind, resourceID))
+		tc.g.Expect(err).NotTo(
+			HaveOccurred(),
+			"Unexpected error while checking existence of %s instance %s", ro.GVK.Kind, ro.ResourceID,
+		)
 		return
 	}
 
 	// Delete the resource
 	tc.g.Delete(
-		gvk,
-		nn,
-		clientOption...,
-	).Eventually().Should(Succeed(), "Failed to delete %s instance %s", gvk.Kind, resourceID)
+		ro.GVK,
+		ro.NN,
+		ro.ClientDeleteOptions,
+	).Eventually().Should(Succeed(), "Failed to delete %s instance %s", ro.GVK.Kind, ro.ResourceID)
 }
 
-// RetrieveInstallPlanName retrieves the name of the InstallPlan associated with a subscription.
+// FetchInstallPlanName retrieves the name of the InstallPlan associated with a subscription.
 // It ensures that the subscription exists (or is created) and then retrieves the InstallPlan name.
 // This function does not return an error, it will panic if anything goes wrong (such as a missing InstallPlanRef).
 //
@@ -1055,19 +678,19 @@ func (tc *TestContext) DeleteResourceIfExists(
 //
 // Returns:
 //   - string: The name of the InstallPlan associated with the Subscription.
-func (tc *TestContext) RetrieveInstallPlanName(nn types.NamespacedName) string {
+func (tc *TestContext) FetchInstallPlanName(nn types.NamespacedName) string {
 	// Ensure the subscription exists or is created
 	u := tc.EnsureSubscriptionExistsOrCreate(nn)
 
 	// Convert the Unstructured object to Subscription and assert no error
 	sub := &ofapi.Subscription{}
-	tc.ConvertUnstructuredToResource(u, sub)
+	tc.convertToResource(u, sub)
 
 	// Return the name of the InstallPlan
 	return sub.Status.InstallPlanRef.Name
 }
 
-// RetrieveInstallPlan retrieves the InstallPlan associated with a Subscription by its name and namespace.
+// FetchInstallPlan retrieves the InstallPlan associated with a Subscription by its name and namespace.
 // It ensures the Subscription exists (or is created) and fetches the InstallPlan object by its name and namespace.
 //
 // Parameters:
@@ -1076,24 +699,23 @@ func (tc *TestContext) RetrieveInstallPlanName(nn types.NamespacedName) string {
 //
 // Returns:
 //   - *ofapi.InstallPlan: The InstallPlan associated with the Subscription.
-func (tc *TestContext) RetrieveInstallPlan(nn types.NamespacedName) *ofapi.InstallPlan {
+func (tc *TestContext) FetchInstallPlan(nn types.NamespacedName) *ofapi.InstallPlan {
 	// Retrieve the InstallPlan name using getInstallPlanName (ensuring Subscription exists if necessary)
-	planName := tc.RetrieveInstallPlanName(nn)
+	planName := tc.FetchInstallPlanName(nn)
 
 	// Ensure the InstallPlan exists and retrieve the object.
 	installPlan := &ofapi.InstallPlan{}
-	tc.RetrieveResource(
-		gvk.InstallPlan,
-		types.NamespacedName{Namespace: nn.Namespace, Name: planName},
+	tc.FetchTypedResource(
 		installPlan,
-		"InstallPlan %s was expected to exist but was not found", planName,
+		WithMinimalObject(gvk.InstallPlan, types.NamespacedName{Namespace: nn.Namespace, Name: planName}),
+		WithCustomErrorMsg("InstallPlan %s was expected to exist but was not found", planName),
 	)
 
 	// Return the InstallPlan object
 	return installPlan
 }
 
-// RetrieveClusterServiceVersion retrieves a ClusterServiceVersion (CSV) for an operator by name and namespace.
+// FetchClusterServiceVersion retrieves a ClusterServiceVersion (CSV) for an operator by name and namespace.
 // If the CSV does not exist, the function will fail the test using Gomega assertions.
 //
 // Parameters:
@@ -1102,13 +724,13 @@ func (tc *TestContext) RetrieveInstallPlan(nn types.NamespacedName) *ofapi.Insta
 //
 // Returns:
 //   - *ofapi.ClusterServiceVersion: A pointer to the retrieved ClusterServiceVersion object.
-func (tc *TestContext) RetrieveClusterServiceVersion(nn types.NamespacedName) *ofapi.ClusterServiceVersion {
+func (tc *TestContext) FetchClusterServiceVersion(nn types.NamespacedName) *ofapi.ClusterServiceVersion {
 	// Construct a resource identifier.
 	resourceID := resources.FormatNamespacedName(nn)
 
 	// Retrieve the CSV
 	csv := &ofapi.ClusterServiceVersion{}
-	tc.RetrieveResource(gvk.ClusterServiceVersion, nn, csv)
+	tc.FetchTypedResource(csv, WithMinimalObject(gvk.ClusterServiceVersion, nn))
 
 	// Assert that we found the CSV
 	tc.g.Expect(csv).NotTo(BeNil(), "CSV %s not found", resourceID)
@@ -1116,15 +738,15 @@ func (tc *TestContext) RetrieveClusterServiceVersion(nn types.NamespacedName) *o
 	return csv
 }
 
-// RetrieveClusterVersion retrieves the ClusterVersion for the cluster.
+// FetchClusterVersion retrieves the ClusterVersion for the cluster.
 // If the ClusterVersion does not exist, the function will fail the test using Gomega assertions.
 //
 // Returns:
 //   - *configv1.ClusterVersion: A pointer to the retrieved ClusterVersion object.
-func (tc *TestContext) RetrieveClusterVersion() *configv1.ClusterVersion {
+func (tc *TestContext) FetchClusterVersion() *configv1.ClusterVersion {
 	// Retrieve the ClusterVersion
 	cv := &configv1.ClusterVersion{}
-	tc.RetrieveResource(gvk.ClusterVersion, types.NamespacedName{Name: cluster.OpenShiftVersionObj}, cv)
+	tc.FetchTypedResource(cv, WithMinimalObject(gvk.ClusterVersion, types.NamespacedName{Name: cluster.OpenShiftVersionObj}))
 
 	// Assert that we found the ClusterVersion
 	tc.g.Expect(cv).NotTo(BeNil(), "ClusterVersion not found")
@@ -1132,109 +754,104 @@ func (tc *TestContext) RetrieveClusterVersion() *configv1.ClusterVersion {
 	return cv
 }
 
-// RetrieveDSCInitialization retrieves the DSCInitialization resource.
+// FetchPlatformRelease retrieves the platform release name from the DSCInitialization resource.
+//
+// This function ensures that the DSCInitialization resource and its status exist before accessing
+// the release name. If any required field is missing, the function will fail the test using Gomega assertions.
+//
+// Returns:
+//   - common.Platform: The platform release name retrieved from the DSCInitialization resource.
+func (tc *TestContext) FetchPlatformRelease() common.Platform {
+	// Ensure the DSCInitialization exists and retrieve the object
+	dsci := &dsciv1.DSCInitialization{}
+	tc.FetchTypedResource(dsci,
+		WithMinimalObject(gvk.DSCInitialization, tc.DSCInitializationNamespacedName),
+		WithCondition(jq.Match(`.status.release.name | length > 0`)), // Ensure that the release name is non-empty
+	)
+
+	return dsci.Status.Release.Name
+}
+
+// FetchDSCInitialization retrieves the DSCInitialization resource.
 //
 // This function ensures that the DSCInitialization resource exists and then retrieves it
 // as a strongly typed object.
 //
-// Parameters:
-//   - nn (types.NamespacedName): The namespaced name (namespace + name) of the DSCInitialization.
-//
 // Returns:
 //   - *dsciv1.DSCInitialization: The retrieved DSCInitialization object.
-func (tc *TestContext) RetrieveDSCInitialization(nn types.NamespacedName) *dsciv1.DSCInitialization {
+func (tc *TestContext) FetchDSCInitialization() *dsciv1.DSCInitialization {
 	// Ensure the DSCInitialization exists and retrieve the object
 	dsci := &dsciv1.DSCInitialization{}
-	tc.RetrieveResource(gvk.DSCInitialization, nn, dsci)
+	tc.FetchTypedResource(dsci, WithMinimalObject(gvk.DSCInitialization, tc.DSCInitializationNamespacedName))
 
 	return dsci
 }
 
-// RetrieveDataScienceCluster retrieves the DataScienceCluster resource.
+// FetchDataScienceCluster retrieves the DataScienceCluster resource.
 //
 // This function ensures that the DataScienceCluster resource exists and then retrieves it
 // as a strongly typed object.
 //
-// Parameters:
-//   - nn (types.NamespacedName): The namespaced name (namespace + name) of the DataScienceCluster.
-//
 // Returns:
 //   - *dsciv1.DataScienceCluster: The retrieved DataScienceCluster object.
-func (tc *TestContext) RetrieveDataScienceCluster(nn types.NamespacedName) *dscv1.DataScienceCluster {
+func (tc *TestContext) FetchDataScienceCluster() *dscv1.DataScienceCluster {
 	// Ensure the DataScienceCluster exists and retrieve the object
 	dsc := &dscv1.DataScienceCluster{}
-	tc.RetrieveResource(gvk.DataScienceCluster, nn, dsc)
+	tc.FetchTypedResource(dsc, WithMinimalObject(gvk.DataScienceCluster, tc.DataScienceClusterNamespacedName))
 
 	return dsc
 }
 
-// RetrieveResource ensures a Kubernetes resource exists and retrieves it into a typed object.
-//
-// This function first verifies that the resource exists using `EnsureResourceExists` and then
-// converts the retrieved Unstructured object into the provided typed object.
+// FetchResource ensures a Kubernetes resource exists and retrieves it as an Unstructured object.
 //
 // Parameters:
-//   - gvk (schema.GroupVersionKind): The GroupVersionKind of the resource to retrieve.
-//   - nn (types.NamespacedName): The namespaced name (namespace + name) of the resource.
-//   - obj (any): A pointer to the typed object where the resource data will be stored.
-//   - args (any, optional): Additional arguments for error messages or logging.
+//   - options(...ResourceOpts): Functional options to configure the resource retrieval.
+//
+// Returns:
+//   - *unstructured.Unstructured: The retrieved resource in unstructured format.
+func (tc *TestContext) FetchResource(opts ...ResourceOpts) *unstructured.Unstructured {
+	// Create a ResourceOptions object based on the provided opts.
+	ro := tc.NewResourceOptions(opts...)
+
+	// Use fetchResource to attempt to fetch the resources with retries
+	resourcesList, _ := tc.fetchResource(ro)
+
+	return resourcesList
+}
+
+// FetchTypedResource ensures a Kubernetes resource exists and retrieves it as a typed object.
+//
+// This function first ensures the resource exists using `EnsureResourceExists`, then converts
+// the Unstructured object into the provided typed object.
+//
+// Parameters:
+//   - obj (client.Object): The target object where the retrieved resource should be stored.
+//   - options(...ResourceOpts): Functional options to configure the resource retrieval.
 //
 // Panics:
 //   - If the resource does not exist.
 //   - If conversion from Unstructured to the typed object fails.
-func (tc *TestContext) RetrieveResource(
-	gvk schema.GroupVersionKind,
-	nn types.NamespacedName,
-	obj client.Object,
-	args ...any,
-) {
+func (tc *TestContext) FetchTypedResource(obj client.Object, opts ...ResourceOpts) {
 	// Ensure the resource exists and retrieve the object
-	u := tc.EnsureResourceExists(gvk, nn, args...)
+	u := tc.EnsureResourceExists(opts...)
 
-	// Convert the Unstructured object to a typed object
-	tc.ConvertUnstructuredToResource(u, obj)
+	// Convert and store it in the provided object
+	tc.convertToResource(u, obj)
 }
 
-// RetrieveResources fetches a list of resources from the cluster and waits for their successful retrieval.
-//
-// This function uses the `Eventually` mechanism to repeatedly attempt to retrieve the resources from
-// the cluster until they are available. It ensures no errors occur during the retrieval process and that
-// the list of resources is successfully fetched.
+// FetchResources fetches a list of Kubernetes resources from the cluster and fails the test if retrieval fails.
 //
 // Parameters:
-//   - gvk (schema.GroupVersionKind): The GroupVersionKind (GVK) of the resources being retrieved.
-//   - nn (types.NamespacedName): The namespace and name of the resource(s) to be fetched.
-//   - listOptions (*client.ListOptions, optional): Additional options for listing the resources (e.g., label selectors).
-//   - args (...any, optional): Optional arguments for custom error messages or logging.
+//   - options(...ResourceOpts): Optional functional arguments that customize the behavior of the operation.
 //
 // Returns:
 //   - []unstructured.Unstructured: A list of resources fetched from the cluster.
-func (tc *TestContext) RetrieveResources(
-	gvk schema.GroupVersionKind,
-	nn types.NamespacedName,
-	listOptions *client.ListOptions,
-	args ...any,
-) []unstructured.Unstructured {
-	// Construct a resource identifier
-	resourceID := resources.FormatNamespacedName(nn)
+func (tc *TestContext) FetchResources(opts ...ResourceOpts) []unstructured.Unstructured {
+	// Create a ResourceOptions object based on the provided opts.
+	ro := tc.NewResourceOptions(opts...)
 
-	// If no ListOptions are provided, initialize an empty one
-	if listOptions == nil {
-		listOptions = &client.ListOptions{}
-	}
-
-	// Use Eventually to retry getting the resource list until they appear
-	var resourcesList []unstructured.Unstructured
-	tc.g.Eventually(func(g Gomega) {
-		// Fetch the list of resources
-		var err error
-		resourcesList, _ = tc.g.List(gvk, listOptions).Get()
-
-		// Ensure no unexpected errors occurred while fetching the resources
-		g.Expect(err).ToNot(HaveOccurred(),
-			appendDefaultIfNeeded(resourceFetchErrorMsg, []any{resourceID, gvk.Kind, err}, args)...,
-		)
-	}).Should(Succeed())
+	// Use fetchResources to attempt to fetch the resources with retries
+	resourcesList, _ := tc.fetchResources(ro)
 
 	return resourcesList
 }
@@ -1267,21 +884,6 @@ func (tc *TestContext) ApproveInstallPlan(plan *ofapi.InstallPlan) {
 			HaveOccurred(),
 			"Failed to approve InstallPlan %s in namespace %s: %v", obj.ObjectMeta.Name, obj.ObjectMeta.Namespace, err,
 		)
-}
-
-// ConvertUnstructuredToResource converts the provided Unstructured object to the specified resource type.
-// This function performs the conversion and asserts that no error occurs during the conversion process.
-//
-// The function utilizes Gomega's Expect method to assert that the conversion is successful.
-// If the conversion fails, the test will fail.
-//
-// Parameters:
-//   - u (*unstructured.Unstructured): The Unstructured object to be converted.
-//   - obj (T): A pointer to the target resource object to which the Unstructured object will be converted. The object must be a pointer to a struct.
-func (tc *TestContext) ConvertUnstructuredToResource(u *unstructured.Unstructured, obj client.Object) {
-	// Convert Unstructured object to the given resource object
-	err := resources.ObjectFromUnstructured(tc.Scheme(), u, obj)
-	tc.g.Expect(err).NotTo(HaveOccurred(), "Failed converting %T from Unstructured.Object: %v", obj, u.Object)
 }
 
 // ExtractAndExpectValue extracts a value from an input using a jq expression and asserts conditions on it.
@@ -1436,269 +1038,21 @@ func CreateDSC(name string) *dscv1.DataScienceCluster {
 	}
 }
 
-// ensureResourceAppliedWithCondition is a common function for handling create/patch and create/update operations.
-// It applies a given resource and ensures it meets the expected condition.
+// convertToResource converts an Unstructured object to the specified resource type.
+// It asserts that no error occurs during the conversion.
 //
 // Parameters:
-//   - gvk: The GroupVersionKind of the resource.
-//   - nn: The NamespacedName identifying the resource.
-//   - fn: A mutation function to modify the resource before applying.
-//   - condition: A Gomega matcher that the resource must satisfy.
-//   - applyResourceFn: The function responsible for applying the resource.
-//   - args: Additional arguments for error message formatting.
-//
-// Returns:
-//   - *unstructured.Unstructured: The applied resource if it meets the expected condition.
-func (tc *TestContext) ensureResourceAppliedWithCondition(
-	option ResourceOption,
-	fn func(obj *unstructured.Unstructured) error,
-	condition gTypes.GomegaMatcher,
-	applyResourceFn func(obj *unstructured.Unstructured, fn ...func(obj *unstructured.Unstructured) error) *testf.EventuallyValue[*unstructured.Unstructured],
-	args ...any,
-) *unstructured.Unstructured {
-	// Retrieve the object using the provided option
-	obj := option(tc)
-
-	// Get GroupVersionKind from the resource.
-	groupVersionKind := obj.GetObjectKind().GroupVersionKind()
-
-	// Construct a resource identifier.
-	resourceID := resources.FormatUnstructuredName(obj)
-
-	// Wrap condition if it's not already wrapped correctly
-	wrapConditionIfNeeded(&condition)
-
-	// Use Eventually to retry getting the resource until it appears
-	var u *unstructured.Unstructured
-	tc.g.Eventually(func(g Gomega) {
-		// Fetch the resource
-		var err error
-		u, err = applyResourceFn(obj, fn).Get()
-
-		// Evaluate the condition to check if failure is expected
-		expectingFailure := tc.isFailureExpected(condition)
-
-		// Error handling based on failure expectation
-		if !expectingFailure {
-			// Expect no error if success is expected
-			g.Expect(err).NotTo(
-				HaveOccurred(),
-				"Error occurred while applying the resource '%s' of kind '%s': %v", resourceID, groupVersionKind.Kind, err,
-			)
-
-			// Ensure that the resource object is not nil
-			g.Expect(u).NotTo(BeNil(), resourceNotFoundErrorMsg, resourceID, groupVersionKind.Kind)
-		} else {
-			// Expect error if failure is expected
-			g.Expect(err).To(HaveOccurred(), "Expected applyResourceFn to fail but it succeeded")
-		}
-
-		// Apply the matchers based on the condition
-		applyMatchers(g, resourceID, groupVersionKind, u, err, condition, args)
-	}).Should(Succeed())
-
-	return u
+//   - u (*unstructured.Unstructured): The Unstructured object to convert.
+//   - obj (T): A pointer to the target resource object to which the Unstructured object will be converted.
+func (tc *TestContext) convertToResource(u *unstructured.Unstructured, obj client.Object) {
+	// Convert Unstructured object to the given resource object
+	err := resources.ObjectFromUnstructured(tc.Scheme(), u, obj)
+	tc.g.Expect(err).NotTo(HaveOccurred(), "Failed converting %T from Unstructured.Object: %v", obj, u.Object)
 }
 
-// ensureResourceDoesNotExist is a helper function that attempts to retrieve a Kubernetes resource
-// and checks if it does not exist. It returns an error if the resource is found in the cluster.
-//
-// Parameters:
-//   - g (Gomega): The Gomega assertion wrapper.
-//   - gvk (schema.GroupVersionKind): The GroupVersionKind of the resource being checked.
-//   - nn (types.NamespacedName): The namespaced name of the resource (e.g., "namespace/resource-name").
-//   - args ([]any): Optional arguments that can be used for retries or custom messages during resource retrieval.
-//
-// Returns:
-//   - error: An error if the resource is found in the cluster, or nil if the resource does not exist.
-func (tc *TestContext) ensureResourceDoesNotExist(
-	g Gomega,
-	gvk schema.GroupVersionKind,
-	nn types.NamespacedName,
-	args []any,
-) error {
-	// Construct a resource identifier.
-	resourceID := resources.FormatNamespacedName(nn)
-
-	// Use EnsureResourceExistsOrNil to attempt to fetch the resource with retries
-	u, err := tc.EnsureResourceExistsOrNil(gvk, nn, args...)
-
-	// Ensure that the resource object is not nil
-	g.Expect(u).To(BeNil(), resourceFoundErrorMsg, resourceID, gvk.Kind)
-
-	return err
-}
-
-// ensureResourcesDoNotExist is a helper function that retrieves a list of Kubernetes resources
-// and checks if the resources do not exist (i.e., the list is empty). It performs an assertion
-// to ensure that the list of resources is empty. If any resources are found, it fails the test.
-//
-// Parameters:
-//   - g (Gomega): The Gomega assertion wrapper.
-//   - gvk (schema.GroupVersionKind): The GroupVersionKind of the resources to check.
-//   - nn (types.NamespacedName): The namespace and name of the resource(s).
-//   - listOptions (*client.ListOptions, optional): Optional list options for filtering the resources (e.g., label selectors).
-//   - args (...interface{}): Optional Gomega assertion message arguments.
-//
-// Returns:
-//   - error: An error if the resource is found in the cluster, or nil if the resource does not exist.
-func (tc *TestContext) ensureResourcesDoNotExist(
-	g Gomega,
-	gvk schema.GroupVersionKind,
-	nn types.NamespacedName,
-	listOptions *client.ListOptions,
-	args []any,
-) {
-	// Construct a resource identifier for logging
-	resourceID := resources.FormatNamespacedName(nn)
-
-	// Retrieve the resources list using the common function
-	resourcesList := tc.RetrieveResources(gvk, nn, listOptions, args...)
-
-	// Ensure that the resources list is empty (resources should not exist)
-	g.Expect(resourcesList).To(BeEmpty(), resourceNotEmptyErrorMsg, resourceID, gvk.Kind)
-}
-
-// applyMatchers applies Gomega matchers to a single resource or a list of resources.
-//
-// Parameters:
-//   - g (Gomega): The Gomega assertion wrapper.
-//   - resourceID (string): A string identifier for logging purposes.
-//   - gvk (schema.GroupVersionKind): The GroupVersionKind of the resource(s).
-//   - resource any: Can be a single unstructured.Unstructured or a list ([]unstructured.Unstructured).
-//   - err error: The error returned when fetching the resource(s).
-//   - condition gTypes.GomegaMatcher: The Gomega matcher to apply.
-//   - args []any: Optional additional arguments for assertion messages.
-func applyMatchers(
-	g Gomega,
-	resourceID string,
-	gvk schema.GroupVersionKind,
-	resource any,
-	err error,
-	condition gTypes.GomegaMatcher,
-	args []any,
-) {
-	// Check if the condition is an And, Or, or Not and recursively inspect the inner matchers
-	switch v := condition.(type) {
-	case *matchers.AndMatcher:
-		// If the condition is an And, apply each matcher recursively
-		for _, inner := range v.Matchers {
-			applyMatchers(g, resourceID, gvk, resource, err, inner, args)
-		}
-	case *matchers.OrMatcher:
-		// If the condition is an Or, apply each matcher recursively
-		for _, inner := range v.Matchers {
-			applyMatchers(g, resourceID, gvk, resource, err, inner, args)
-		}
-	case *matchers.NotMatcher:
-		// If the condition is a Not, apply the negated matcher recursively
-		applyMatchers(g, resourceID, gvk, resource, err, v.Matcher, args)
-	case gTypes.GomegaMatcher: // Base matcher (for non-Error matchers)
-		// If matcher is an error matcher, apply it to the error
-		if isErrorMatcher(v) {
-			g.Expect(err).To(v, appendDefaultIfNeeded(
-				"Expected error when applying resource '%s' of kind '%s'.",
-				[]any{resourceID, gvk.Kind}, args,
-			)...)
-			return
-		}
-
-		// If working on a list of resources
-		if resourcesList, ok := resource.([]unstructured.Unstructured); ok {
-			// Apply the matcher to the list
-			g.Expect(resourcesList).To(v, appendDefaultIfNeeded(
-				"Expected list of '%s' resources to match condition %v.",
-				[]any{gvk.Kind, dereferenceCondition(condition)}, args,
-			)...)
-			return
-		}
-
-		// If working on a single resource
-		if u, ok := resource.(*unstructured.Unstructured); ok {
-			g.Expect(u.Object).To(v, appendDefaultIfNeeded(
-				"Expected resource '%s' of kind '%s' to match condition %v.",
-				[]any{resourceID, gvk.Kind, dereferenceCondition(condition)}, args,
-			)...)
-		}
-	}
-}
-
-// Helper function to evaluate if failure is expected based on the matcher.
-func (tc *TestContext) isFailureExpected(condition gTypes.GomegaMatcher) bool {
-	// Check if the condition is an And, Or, or Not and recursively inspect the inner matchers
-	switch v := condition.(type) {
-	case *matchers.AndMatcher:
-		// If the condition is And(), we recursively check the inner matchers
-		for _, inner := range v.Matchers {
-			if tc.isFailureExpected(inner) {
-				return true
-			}
-		}
-	case *matchers.OrMatcher:
-		// If the condition is Or(), we recursively check the inner matchers
-		for _, inner := range v.Matchers {
-			if tc.isFailureExpected(inner) {
-				return true
-			}
-		}
-	case *matchers.NotMatcher:
-		// If the condition is Not(Succeed()), we expect failure
-		if _, ok := v.Matcher.(*matchers.SucceedMatcher); ok {
-			return true
-		}
-	case gTypes.GomegaMatcher:
-		// For basic matchers (not wrapped in And/Or/Not), check if it is Not(Succeed()) or any other condition
-		expectingFailure, _ := condition.Match(Not(Succeed()))
-		return expectingFailure
-	}
-
-	// Default case if none of the conditions matched, return false (no failure expected)
-	return false
-}
-
-// Check if the matcher is an error matcher like Succeed(), HaveOccurred(), etc.
-func isErrorMatcher(matcher gTypes.GomegaMatcher) bool {
-	switch matcher.(type) {
-	case *matchers.SucceedMatcher, *matchers.HaveOccurredMatcher, *matchers.MatchErrorMatcher:
-		return true
-	default:
-		return false
-	}
-}
-
-// wrapConditionIfNeeded ensures that the condition is wrapped in And(Succeed(), condition)
-// if it's not already wrapped in such a way.
-func wrapConditionIfNeeded(condition *gTypes.GomegaMatcher) {
-	// Check if the condition is already an 'And' that contains Succeed()
-	if _, ok := (*condition).(*matchers.SucceedMatcher); ok || isAndContainingSucceed(*condition) {
-		return
-	}
-
-	// Wrap condition inside And(Succeed(), condition) if it's not already wrapped correctly
-	*condition = And(Succeed(), *condition)
-}
-
-// isAndContainingSucceed checks if the matcher is an AndMatcher containing Succeed().
-func isAndContainingSucceed(matcher gTypes.GomegaMatcher) bool {
-	// Check if the condition is already an 'And' that contains Succeed()
-	andMatcher, ok := matcher.(*matchers.AndMatcher)
-	if !ok {
-		return false
-	}
-
-	// Check if Succeed is one of the matchers in the And condition
-	for _, m := range andMatcher.Matchers {
-		if _, ok := m.(*matchers.SucceedMatcher); ok {
-			return true
-		}
-	}
-
-	return false
-}
-
-// appendDefaultIfNeeded appends a default message to args if args is empty.
+// defaultErrorMessageIfNone appends a default message to args if args is empty.
 // It formats the default message using the provided format and formatArgs.
-func appendDefaultIfNeeded(format string, formatArgs []any, args []any) []any {
+func defaultErrorMessageIfNone(format string, formatArgs []any, args []any) []any {
 	// If no custom args are provided, append the default message
 	if len(args) == 0 {
 		args = append(args, fmt.Sprintf(format, formatArgs...))
@@ -1744,14 +1098,4 @@ func createInstallPlan(name string, ns string, csvNames []string) *ofapi.Install
 			ClusterServiceVersionNames: csvNames,
 		},
 	}
-}
-
-// Helper function to safely dereference the condition pointer.
-func dereferenceCondition(condition gTypes.GomegaMatcher) any {
-	// If condition is a pointer, dereference it
-	if reflect.TypeOf(condition).Kind() == reflect.Ptr {
-		return reflect.ValueOf(condition).Elem().Interface()
-	}
-	// If it's not a pointer, return the condition as is
-	return condition
 }

--- a/tests/e2e/helper_test.go
+++ b/tests/e2e/helper_test.go
@@ -54,13 +54,16 @@ const (
 const (
 	generalRetryInterval = 10 * time.Second // Retry interval for general operations
 
-	defaultEventuallyTimeout        = 5 * time.Minute  // Set default timeout for Eventually (default is 1 second).
-	defaultEventuallyPollInterval   = 2 * time.Second  // Set default timeout for Eventually (default is 1 second).
-	defaultConsistentlyTimeout      = 10 * time.Second // Set default duration for Consistently (default is 2 seconds).
-	defaultConsistentlyPollInterval = 2 * time.Second  // Set default polling interval for Consistently (default is 50ms).
+	// Gomega default values for Eventually/Consistently can be found here:
+	// https://onsi.github.io/gomega/#making-asynchronous-assertions
 
-	eventuallyTimeoutMedium = 7 * time.Minute  // Medium timeout for readiness checks (e.g., CSV, DSC)
-	eventuallyTimeoutLong   = 10 * time.Minute // Longer timeout for more complex readiness (e.g., DSCInitialization, KServe)
+	defaultEventuallyTimeout        = 5 * time.Minute  // Timeout used for Eventually; overrides Gomega's default of 1 second.
+	defaultEventuallyPollInterval   = 2 * time.Second  // Polling interval for Eventually; overrides Gomega's default of 10 milliseconds.
+	defaultConsistentlyTimeout      = 10 * time.Second // Duration used for Consistently; overrides Gomega's default of 2 seconds.
+	defaultConsistentlyPollInterval = 2 * time.Second  // Polling interval for Consistently; overrides Gomega's default of 50 milliseconds.
+
+	eventuallyTimeoutMedium = 7 * time.Minute  // Medium timeout for readiness checks (e.g., ClusterServiceVersion, DataScienceCluster).
+	eventuallyTimeoutLong   = 10 * time.Minute // Long timeout for more complex readiness (e.g., DSCInitialization, KServe).
 )
 
 // Configuration and Miscellaneous Constants.
@@ -253,11 +256,15 @@ func (tc *TestContext) EnsureResourceCreatedOrPatched(opts ...ResourceOpts) *uns
 	return tc.ensureResourceApplied(ro, tc.g.CreateOrPatch)
 }
 
-// EnsureResourceDoesNotExist verifies that a Kubernetes resource does not exist.
-// If the resource is found, the test fails. If an expected error is provided via WithExpectedErr, it validates the error.
+// EnsureResourceDoesNotExist performs a one-time check to verify that a resource does not exist in the cluster.
+//
+// This function fetches the resource once and fails the test immediately if it exists.
+// If an expected error is provided via WithExpectedErr, it validates the error.
 //
 // Parameters:
 //   - opts (...ResourceOpts): Optional functional arguments that customize the behavior of the operation.
+//
+// This function does not retry; use EnsureResourceGone if you need to wait for deletion.
 func (tc *TestContext) EnsureResourceDoesNotExist(opts ...ResourceOpts) {
 	// Create a ResourceOptions object based on the provided opts.
 	ro := tc.NewResourceOptions(opts...)
@@ -275,9 +282,6 @@ func (tc *TestContext) EnsureResourceDoesNotExist(opts ...ResourceOpts) {
 //
 // Parameters:
 //   - opts (...ResourceOpts): Optional functional arguments that customize the behavior of the operation.
-//
-// Returns:
-//   - error: If the resource still exists after the timeout.
 func (tc *TestContext) EnsureResourceGone(opts ...ResourceOpts) {
 	// Create a ResourceOptions object based on the provided opts.
 	ro := tc.NewResourceOptions(opts...)

--- a/tests/e2e/kserve_test.go
+++ b/tests/e2e/kserve_test.go
@@ -2,16 +2,13 @@ package e2e_test
 
 import (
 	"encoding/json"
-	"errors"
-	"fmt"
 	"strings"
 	"testing"
 
+	gomegaTypes "github.com/onsi/gomega/types"
 	operatorv1 "github.com/openshift/api/operator/v1"
 	"github.com/rs/xid"
 	"github.com/stretchr/testify/require"
-	k8serr "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
@@ -20,45 +17,15 @@ import (
 
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/api/components/v1alpha1"
 	featuresv1 "github.com/opendatahub-io/opendatahub-operator/v2/api/features/v1"
-	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/components/modelcontroller"
 	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/status"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/metadata/labels"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/matchers/jq"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/testf"
 
 	. "github.com/onsi/gomega"
 )
-
-func kserveTestSuite(t *testing.T) {
-	t.Helper()
-
-	ct, err := NewComponentTestCtx(&componentApi.Kserve{})
-	require.NoError(t, err)
-
-	componentCtx := KserveTestCtx{
-		ComponentTestCtx: ct,
-	}
-
-	err = componentCtx.setUpServerless(t)
-	require.NoError(t, err)
-
-	err = componentCtx.createDummyFeatureTrackers(t)
-	require.NoError(t, err)
-
-	t.Run("Validate component enabled", componentCtx.ValidateComponentEnabled)
-	t.Run("Validate component spec", componentCtx.validateSpec)
-	t.Run("Validate component conditions", componentCtx.validateConditions)
-	t.Run("Validate model controller", componentCtx.validateModelControllerInstance)
-	t.Run("Validate operands have OwnerReferences", componentCtx.ValidateOperandsOwnerReferences)
-	t.Run("Validate no FeatureTracker OwnerReferences", componentCtx.ValidateNoFeatureTrackerOwnerReferences)
-	t.Run("Validate no Kserve FeatureTrackers", componentCtx.ValidateNoKserveFeatureTrackers)
-	t.Run("Validate default certs", componentCtx.validateDefaultCertsAvailable)
-	t.Run("Validate update operand resources", componentCtx.ValidateUpdateDeploymentsResources)
-	t.Run("Validate serving transition to Unmanaged", componentCtx.ValidateServingTransitionToUnmanaged)
-	t.Run("Validate serving transition to Removed", componentCtx.ValidateServingTransitionToRemoved)
-	t.Run("Validate component disabled", componentCtx.ValidateComponentDisabled)
-}
 
 type KserveTestCtx struct {
 	*ComponentTestCtx
@@ -81,279 +48,320 @@ var templatedResources = []struct {
 	{gvk.Gateway, types.NamespacedName{Namespace: "knative-serving", Name: "knative-local-gateway"}},
 }
 
-//nolint:thelper
-func (c *KserveTestCtx) setUpServerless(t *testing.T) error {
+func kserveTestSuite(t *testing.T) {
+	t.Helper()
+
+	ct, err := NewComponentTestCtx(t, &componentApi.Kserve{})
+	require.NoError(t, err)
+
+	componentCtx := KserveTestCtx{
+		ComponentTestCtx: ct,
+	}
+
+	// Increase the global eventually timeout
+	reset := componentCtx.OverrideEventuallyTimeout(eventuallyTimeoutLong, defaultEventuallyPollInterval)
+	defer reset() // Make sure it's reset after all tests run
+
 	// TODO: removed once we know what's left on the cluster that's causing the tests
 	//       to fail because of "existing KNativeServing resource was found"
-	ksl := unstructured.UnstructuredList{}
-	ksl.SetGroupVersionKind(gvk.KnativeServing)
+	t.Run("Setup Serverless", componentCtx.SetUpServerless)
 
-	if err := c.Client().List(c.Context(), &ksl, client.InNamespace(knativeServingNamespace)); err != nil {
-		return fmt.Errorf("error listing Knative Serving objects: %w", err)
+	// Define test cases.
+	testCases := []TestCase{
+		{"Validate component enabled", componentCtx.ValidateComponentEnabled},
+		{"Validate serving enabled", componentCtx.ValidateServingEnabled},
+		{"Validate component spec", componentCtx.ValidateSpec},
+		{"Validate component conditions", componentCtx.ValidateConditions},
+		{"Validate model controller", componentCtx.ValidateModelControllerInstance},
+		{"Validate operands have OwnerReferences", componentCtx.ValidateOperandsOwnerReferences},
+		{"Validate no FeatureTracker OwnerReferences", componentCtx.ValidateNoFeatureTrackerOwnerReferences},
+		{"Validate no Kserve FeatureTrackers", componentCtx.ValidateNoKserveFeatureTrackers},
+		{"Validate default certs", componentCtx.ValidateDefaultCertsAvailable},
+		{"Validate update operand resources", componentCtx.ValidateUpdateDeploymentsResources},
+		{"Validate serving transition to Unmanaged", componentCtx.ValidateServingTransitionToUnmanaged},
+		{"Validate serving transition to Removed", componentCtx.ValidateServingTransitionToRemoved},
+		{"Validate component releases", componentCtx.ValidateComponentReleases},
+		{"Validate component disabled", componentCtx.ValidateComponentDisabled},
 	}
 
-	if len(ksl.Items) != 0 {
-		t.Logf("Detected %d Knative Serving objects in namespace %s", len(ksl.Items), knativeServingNamespace)
-	}
-
-	for _, obj := range ksl.Items {
-		data, err := json.Marshal(obj)
-		if err != nil {
-			return fmt.Errorf("error marshalling Knative Serving object: %w", err)
-		}
-
-		t.Logf("Deleting Knative Serving %s in namespace %s: %s", obj.GetName(), obj.GetNamespace(), string(data))
-
-		if err := c.Client().Delete(c.Context(), &obj); err != nil && !k8serr.IsNotFound(err) {
-			return fmt.Errorf("error deleting Knative Serving object: %w", err)
-		}
-	}
-
-	return nil
+	// Run the test suite.
+	componentCtx.RunTestCases(t, testCases)
 }
 
-func (c *KserveTestCtx) createDummyFeatureTrackers(_ *testing.T) error {
-	ftNames := []string{
-		c.ApplicationNamespace + "-serverless-serving-deployment",
-		c.ApplicationNamespace + "-serverless-net-istio-secret-filtering",
-		c.ApplicationNamespace + "-serverless-serving-gateways",
-		c.ApplicationNamespace + "-kserve-external-authz",
-	}
+// SetUpServerless sets up the serverless feature in the test environment.
+func (tc *KserveTestCtx) SetUpServerless(t *testing.T) {
+	t.Helper()
 
-	for _, name := range ftNames {
-		ft := &featuresv1.FeatureTracker{}
-		ft.SetName(name)
+	// TODO: removed once we know what's left on the cluster that's causing the tests
+	//       to fail because of "existing KNativeServing resource was found"
+	tc.cleanExistingKnativeServing(t)
 
-		if _, err := controllerutil.CreateOrUpdate(c.Context(), c.Client(), ft, func() error {
-			dsc, err := c.GetDSC()
-			if err != nil {
-				return err
-			}
-			if err := controllerutil.SetOwnerReference(dsc, ft, c.Client().Scheme()); err != nil {
-				return err
-			}
-			ft.Spec.Source.Name = xid.New().String()
-
-			return nil
-		}); err != nil {
-			return errors.New("error creating pre-existing FeatureTracker")
-		}
-	}
-
-	return nil
+	// Ensure the feature tracker resource is created or updated with the expected conditions.
+	tc.createDummyFeatureTrackers()
 }
 
-func (c *KserveTestCtx) validateSpec(t *testing.T) {
-	g := c.NewWithT(t)
+// ValidateSpec ensures that the Kserve instance configuration matches the expected specification.
+func (tc *KserveTestCtx) ValidateServingEnabled(t *testing.T) {
+	t.Helper()
 
-	dsc, err := c.GetDSC()
-	g.Expect(err).NotTo(HaveOccurred())
+	// Ensure the DataScienceCluster exists and the component's conditions are met
+	tc.EnsureResourceCreatedOrUpdatedWithCondition(
+		WithMinimalObject(gvk.DataScienceCluster, tc.DataScienceClusterNamespacedName),
+		testf.TransformPipeline(
+			testf.Transform(`.spec.components.%s.serving.managementState = "%s"`, strings.ToLower(tc.GVK.Kind), operatorv1.Managed),
+		),
+		jq.Match(`.spec.components.%s.serving.managementState == "%s"`, strings.ToLower(tc.GVK.Kind), operatorv1.Managed),
+	)
+}
 
-	g.List(gvk.Kserve).Eventually().Should(And(
-		HaveLen(1),
-		HaveEach(And(
+// ValidateSpec ensures that the Kserve instance configuration matches the expected specification.
+func (tc *KserveTestCtx) ValidateSpec(t *testing.T) {
+	t.Helper()
+
+	// Retrieve the DataScienceCluster instance.
+	dsc := tc.RetrieveDataScienceCluster(tc.DataScienceClusterNamespacedName)
+
+	tc.EnsureResourceExistsAndMatchesCondition(
+		gvk.Kserve,
+		types.NamespacedName{Name: componentApi.KserveInstanceName},
+		And(
+			// Validate Kserve default deployment mode.
 			jq.Match(`.spec.defaultDeploymentMode == "%s"`, dsc.Spec.Components.Kserve.DefaultDeploymentMode),
+			// Validate management states of NIM and serving components.
 			jq.Match(`.spec.nim.managementState == "%s"`, dsc.Spec.Components.Kserve.NIM.ManagementState),
 			jq.Match(`.spec.serving.managementState == "%s"`, dsc.Spec.Components.Kserve.Serving.ManagementState),
+			// Validate serving name and ingress certificate type.
 			jq.Match(`.spec.serving.name == "%s"`, dsc.Spec.Components.Kserve.Serving.Name),
 			jq.Match(`.spec.serving.ingressGateway.certificate.type == "%s"`, dsc.Spec.Components.Kserve.Serving.IngressGateway.Certificate.Type),
-		)),
-	))
+		),
+	)
 }
 
-func (c *KserveTestCtx) validateConditions(t *testing.T) {
-	g := c.NewWithT(t)
+// ValidateConditions validates that the Kserve instance's status conditions are correct.
+func (tc *KserveTestCtx) ValidateConditions(t *testing.T) {
+	t.Helper()
 
-	g.List(gvk.Kserve).Eventually().Should(And(
-		HaveLen(1),
-		HaveEach(And(
-			jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, status.ConditionServingAvailable, metav1.ConditionTrue),
-		)),
-	))
-}
-func (c *KserveTestCtx) validateModelControllerInstance(t *testing.T) {
-	g := c.NewWithT(t)
-
-	g.List(gvk.ModelController).Eventually().Should(And(
-		HaveLen(1),
-		HaveEach(And(
-			jq.Match(`.metadata.ownerReferences[0].kind == "%s"`, gvk.DataScienceCluster.Kind),
-			jq.Match(`.status.phase == "%s"`, readyStatus),
-		)),
-	))
-
-	g.List(gvk.DataScienceCluster).Eventually().Should(And(
-		HaveLen(1),
-		HaveEach(And(
-			jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, modelcontroller.ReadyConditionType, metav1.ConditionTrue),
-		)),
-	))
+	// Ensure the Kserve resource has the "ServingAvailable" condition set to "True".
+	tc.ValidateComponentCondition(
+		gvk.Kserve,
+		componentApi.KserveInstanceName,
+		status.ConditionServingAvailable,
+	)
 }
 
-func (c *KserveTestCtx) validateDefaultCertsAvailable(t *testing.T) {
-	g := c.NewWithT(t)
+// ValidateNoFeatureTrackerOwnerReferences ensures no FeatureTrackers are owned by Kserve.
+func (tc *KserveTestCtx) ValidateNoFeatureTrackerOwnerReferences(t *testing.T) {
+	t.Helper()
 
-	defaultIngressSecret, err := cluster.FindDefaultIngressSecret(g.Context(), g.Client())
-	g.Expect(err).ToNot(HaveOccurred())
+	for _, child := range templatedResources {
+		tc.EnsureResourceExistsAndMatchesCondition(
+			child.gvk,
+			child.nn,
+			And(
+				jq.Match(`.metadata.ownerReferences | any(.kind == "%s")`, gvk.Kserve.Kind),
+				jq.Match(`.metadata.ownerReferences | all(.kind != "%s")`, gvk.FeatureTracker.Kind),
+			),
+			`Checking if %s/%s in %s has expected owner refs`, child.gvk, child.nn.Name, child.nn.Namespace,
+		)
+	}
+}
 
-	dsc, err := c.GetDSC()
-	g.Expect(err).ToNot(HaveOccurred())
+// ValidateNoKserveFeatureTrackers ensures there are no FeatureTrackers for Kserve.
+func (tc *KserveTestCtx) ValidateNoKserveFeatureTrackers(t *testing.T) {
+	t.Helper()
 
-	dsci, err := c.GetDSCI()
-	g.Expect(err).ToNot(HaveOccurred())
+	tc.EnsureResourcesExistAndMatchCondition(
+		gvk.FeatureTracker,
+		tc.NamespacedName,
+		nil,
+		HaveEach(And(
+			jq.Match(`.metadata.name != "%s"`, tc.AppsNamespace+"-kserve-external-authz"),
+			jq.Match(`.metadata.name != "%s"`, tc.AppsNamespace+"-serverless-serving-gateways"),
+			jq.Match(`.metadata.name != "%s"`, tc.AppsNamespace+"-serverless-serving-deployment"),
+			jq.Match(`.metadata.name != "%s"`, tc.AppsNamespace+"-serverless-net-istio-secret-filtering"),
 
+			// there should be no FeatureTrackers owned by a Kserve
+			jq.Match(`.metadata.ownerReferences | all(.kind != "%s")`, gvk.Kserve.Kind),
+		)),
+		`Ensuring there are no Kserve FeatureTrackers`,
+	)
+}
+
+// ValidateDefaultCertsAvailable ensures that the default ingress certificate matches the control plane secret in terms of Type and Data fields.
+func (tc *KserveTestCtx) ValidateDefaultCertsAvailable(t *testing.T) {
+	t.Helper()
+
+	// Retrieve the default ingress secret used for ingress TLS termination.
+	defaultIngressSecret, err := cluster.FindDefaultIngressSecret(tc.g.Context(), tc.g.Client())
+	tc.g.Expect(err).ToNot(HaveOccurred())
+
+	// Retrieve the DSCInitialization and DataScienceCluster instances.
+	dsci := tc.RetrieveDSCInitialization(tc.DSCInitializationNamespacedName)
+	dsc := tc.RetrieveDataScienceCluster(tc.DataScienceClusterNamespacedName)
+
+	// Determine the control plane's ingress certificate secret name.
 	defaultSecretName := dsc.Spec.Components.Kserve.Serving.IngressGateway.Certificate.SecretName
 	if defaultSecretName == "" {
 		defaultSecretName = "knative-serving-cert"
 	}
 
-	ctrlPlaneSecret, err := cluster.GetSecret(g.Context(), g.Client(), dsci.Spec.ServiceMesh.ControlPlane.Namespace, defaultSecretName)
-	g.Expect(err).ToNot(HaveOccurred())
+	// Fetch the control plane secret from the ServiceMesh namespace.
+	ctrlPlaneSecret, err := cluster.GetSecret(tc.g.Context(), tc.g.Client(), dsci.Spec.ServiceMesh.ControlPlane.Namespace, defaultSecretName)
+	tc.g.Expect(err).ToNot(HaveOccurred())
 
-	g.Expect(ctrlPlaneSecret.Type).Should(Equal(defaultIngressSecret.Type))
-	g.Expect(defaultIngressSecret.Data).Should(Equal(ctrlPlaneSecret.Data))
+	// Validate that the secret types match.
+	tc.EnsureResourcesAreEqual(
+		ctrlPlaneSecret.Type, defaultIngressSecret.Type,
+		"Secret type mismatch: Expected %v, but got %v", defaultIngressSecret.Type, ctrlPlaneSecret.Type,
+	)
+
+	// Validate that the secret data (certificate content) is identical.
+	tc.EnsureResourcesAreEqual(
+		ctrlPlaneSecret.Data, defaultIngressSecret.Data,
+		"Secret data mismatch: Expected %v, but got %v", defaultIngressSecret.Data, ctrlPlaneSecret.Data,
+	)
 }
 
-func (c *KserveTestCtx) ValidateNoFeatureTrackerOwnerReferences(t *testing.T) {
-	g := c.NewWithT(t)
+// ValidateServingTransitionToUnmanaged checks if serving transitions to unmanaged state.
+func (tc *KserveTestCtx) ValidateServingTransitionToUnmanaged(t *testing.T) {
+	t.Helper()
 
+	tc.validateOwnerRefsAndLabels(true)
+
+	tc.updateKserveServingState(operatorv1.Unmanaged)
+	tc.validateOwnerRefsAndLabels(false)
+
+	tc.updateKserveServingState(operatorv1.Managed)
+	tc.validateOwnerRefsAndLabels(true)
+}
+
+// ValidateServingTransitionToRemoved checks if serving transitions to removed state.
+func (tc *KserveTestCtx) ValidateServingTransitionToRemoved(t *testing.T) {
+	t.Helper()
+
+	// Validate that the resources have the expected owner references and labels when they are "Managed".
+	tc.validateOwnerRefsAndLabels(true)
+
+	// Update Kserve to transition to the "Removed" state.
+	tc.updateKserveDeploymentAndServingState(componentApi.RawDeployment, operatorv1.Removed)
+
+	// Ensure that the associated resources are removed from the cluster.
 	for _, child := range templatedResources {
-		g.Get(child.gvk, child.nn).Eventually(300).Should(And(
-			jq.Match(`.metadata.ownerReferences | any(.kind == "%s")`, gvk.Kserve.Kind),
-			jq.Match(`.metadata.ownerReferences | all(.kind != "%s")`, gvk.FeatureTracker.Kind),
-		),
-			`Checking if %s/%s in %s has expected owner refs`, child.gvk, child.nn.Name, child.nn.Namespace)
+		tc.EnsureResourceGone(child.gvk, child.nn, `Ensuring %s/%s in %s no longer exists`, child.gvk, child.nn.Name, child.nn.Namespace)
+	}
+
+	// Restore the Kserve deployment mode and serving state to "Serverless" and "Managed".
+	tc.updateKserveDeploymentAndServingState(componentApi.Serverless, operatorv1.Managed)
+
+	// Validate that the resources have the expected owner references and labels after the restoration.
+	tc.validateOwnerRefsAndLabels(true)
+}
+
+// createDummyFeatureTrackers creates dummy FeatureTrackers for the Kserve component.
+func (tc *KserveTestCtx) createDummyFeatureTrackers() {
+	ftNames := []string{
+		tc.AppsNamespace + "-serverless-serving-deployment",
+		tc.AppsNamespace + "-serverless-net-istio-secret-filtering",
+		tc.AppsNamespace + "-serverless-serving-gateways",
+		tc.AppsNamespace + "-kserve-external-authz",
+	}
+
+	// Retrieve the DataScienceCluster instance.
+	dsc := tc.RetrieveDataScienceCluster(tc.DataScienceClusterNamespacedName)
+
+	for _, name := range ftNames {
+		ft := &featuresv1.FeatureTracker{}
+		ft.SetName(name)
+
+		tc.EnsureResourceCreatedOrUpdated(
+			WithMinimalObject(gvk.FeatureTracker, types.NamespacedName{Name: name}),
+			func(obj *unstructured.Unstructured) error {
+				if err := controllerutil.SetOwnerReference(dsc, obj, tc.Client().Scheme()); err != nil {
+					return err
+				}
+
+				// Trigger reconciliation as spec changes.
+				if err := unstructured.SetNestedField(obj.Object, xid.New().String(), "spec", "source", "name"); err != nil {
+					return err
+				}
+
+				return nil
+			},
+			"error creating or updating pre-existing FeatureTracker",
+		)
 	}
 }
 
-func (c *KserveTestCtx) ValidateNoKserveFeatureTrackers(t *testing.T) {
-	g := c.NewWithT(t)
+// cleanExistingKnativeServing cleans up any existing KnativeServing resources.
+func (tc *KserveTestCtx) cleanExistingKnativeServing(t *testing.T) {
+	t.Helper()
 
-	g.List(
-		gvk.FeatureTracker,
-	).Eventually(300).Should(
-		HaveEach(And(
-			jq.Match(`.metadata.name != "%s"`, c.ApplicationNamespace+"-kserve-external-authz"),
-			jq.Match(`.metadata.name != "%s"`, c.ApplicationNamespace+"-serverless-serving-gateways"),
-			jq.Match(`.metadata.name != "%s"`, c.ApplicationNamespace+"-serverless-serving-deployment"),
-			jq.Match(`.metadata.name != "%s"`, c.ApplicationNamespace+"-serverless-net-istio-secret-filtering"),
+	ksl := tc.RetrieveResources(gvk.KnativeServing, types.NamespacedName{Namespace: knativeServingNamespace}, &client.ListOptions{Namespace: knativeServingNamespace})
 
-			// there should be no FeatureTrackers owned by a Kserve
-			jq.Match(`.metadata.ownerReferences | all(.kind != "%s")`, gvk.Kserve.Kind),
-		)),
-		`Ensuring there are no Kserve FeatureTrackers`)
-}
-
-func (c *KserveTestCtx) ValidateServingTransitionToUnmanaged(t *testing.T) {
-	g := c.NewWithT(t)
-
-	for _, child := range templatedResources {
-		g.Get(child.gvk, child.nn).Eventually(120).Should(And(
-			jq.Match(`.metadata.labels | has("platform.opendatahub.io/part-of") == %v`, "true"),
-			jq.Match(`.metadata.ownerReferences | length == %d`, 1),
-			jq.Match(`.metadata.ownerReferences[0].kind == "%s"`, c.GVK.Kind),
-		),
-			`Ensuring %s/%s in %s has expected owner ref and part-of label`, child.gvk, child.nn.Name, child.nn.Namespace)
+	if len(ksl) != 0 {
+		t.Logf("Detected %d Knative Serving objects in namespace %s", len(ksl), knativeServingNamespace)
 	}
 
-	g.Update(
-		gvk.DataScienceCluster,
-		c.DSCName,
-		testf.Transform(`.spec.components.%s.serving.managementState = "%s"`, strings.ToLower(c.GVK.Kind), operatorv1.Unmanaged),
-	).Eventually(120).Should(
-		Succeed(),
-		"Marking serving state as unmanaged",
-	)
+	for _, obj := range ksl {
+		data, err := json.Marshal(obj)
+		tc.g.Expect(err).NotTo(HaveOccurred(), "error marshalling Knative Serving object: %w", err)
 
-	for _, child := range templatedResources {
-		g.Get(child.gvk, child.nn).Eventually(120).Should(And(
-			Not(BeNil()),
-			jq.Match(`.metadata.labels | has("platform.opendatahub.io/part-of") == %v`, false),
-			jq.Match(`.metadata.ownerReferences | length == %d`, 0),
-		),
-			`Ensuring %s/%s in %s still exists but is de-owned`, child.gvk, child.nn.Name, child.nn.Namespace)
-	}
+		t.Logf("Deleting Knative Serving %s in namespace %s: %s", obj.GetName(), obj.GetNamespace(), string(data))
+		tc.DeleteResourceIfExists(gvk.KnativeServing, types.NamespacedName{Namespace: knativeServingNamespace, Name: obj.GetName()})
 
-	g.Update(
-		gvk.DataScienceCluster,
-		c.DSCName,
-		testf.Transform(`.spec.components.%s.serving.managementState = "%s"`, strings.ToLower(c.GVK.Kind), operatorv1.Managed),
-	).Eventually(120).Should(
-		Succeed(),
-		"Resetting serving state to managed for subsequent tests",
-	)
-
-	for _, child := range templatedResources {
-		g.Get(child.gvk, child.nn).Eventually(120).Should(And(
-			jq.Match(`.metadata.labels | has("platform.opendatahub.io/part-of") == %v`, "true"),
-			jq.Match(`.metadata.ownerReferences | length == %d`, 1),
-			jq.Match(`.metadata.ownerReferences[0].kind == "%s"`, c.GVK.Kind),
-		),
-			`Ensuring %s/%s in %s is re-owned`, child.gvk, child.nn.Name, child.nn.Namespace)
+		// We also need to restart the Operator Pod.
+		operatorDeployment := "opendatahub-operator-controller-manager"
+		tc.DeleteResource(gvk.Deployment, types.NamespacedName{Namespace: tc.OperatorNamespace, Name: operatorDeployment})
 	}
 }
 
-func (c *KserveTestCtx) ValidateServingTransitionToRemoved(t *testing.T) {
-	g := c.NewWithT(t)
-
-	for _, child := range templatedResources {
-		g.Get(child.gvk, child.nn).Eventually(120).Should(And(
-			jq.Match(`.metadata.labels | has("platform.opendatahub.io/part-of") == %v`, "true"),
-			jq.Match(`.metadata.ownerReferences | length == %d`, 1),
-			jq.Match(`.metadata.ownerReferences[0].kind == "%s"`, c.GVK.Kind),
+// updateKserveDeploymentAndServingState updates the Kserve deployment mode and serving state.
+func (tc *KserveTestCtx) updateKserveDeploymentAndServingState(mode componentApi.DefaultDeploymentMode, state operatorv1.ManagementState) {
+	tc.EnsureResourceCreatedOrUpdated(
+		WithMinimalObject(gvk.DataScienceCluster, tc.DataScienceClusterNamespacedName),
+		testf.TransformPipeline(
+			// Update defaultDeploymentMode
+			testf.Transform(`.spec.components.%s.defaultDeploymentMode = "%s"`, strings.ToLower(tc.GVK.Kind), mode),
+			// Update serving managementState
+			testf.Transform(`.spec.components.%s.serving.managementState = "%s"`, strings.ToLower(tc.GVK.Kind), state),
 		),
-			`Ensuring %s/%s in %s has expected owner ref and part-of label`, child.gvk, child.nn.Name, child.nn.Namespace)
-	}
-
-	g.Update(
-		gvk.DataScienceCluster,
-		c.DSCName,
-		testf.Transform(`.spec.components.%s.defaultDeploymentMode = "%s"`, strings.ToLower(c.GVK.Kind), componentApi.RawDeployment),
-	).Eventually(120).Should(
-		Succeed(),
-		"Setting defaultDeploymentMode to RawDeployment so that serving can be removed",
+		"Updating defaultDeploymentMode and serving managementState",
 	)
+}
 
-	g.Update(
-		gvk.DataScienceCluster,
-		c.DSCName,
-		testf.Transform(`.spec.components.%s.serving.managementState = "%s"`, strings.ToLower(c.GVK.Kind), operatorv1.Removed),
-	).Eventually(120).Should(
-		Succeed(),
-		"Marking serving state as removed",
+// updateKserveServingState updates the state of the serving component in Kserve.
+func (tc *KserveTestCtx) updateKserveServingState(state operatorv1.ManagementState) {
+	tc.EnsureResourceCreatedOrUpdated(
+		WithMinimalObject(gvk.DataScienceCluster, tc.DataScienceClusterNamespacedName),
+		testf.Transform(`.spec.components.%s.serving.managementState = "%s"`, strings.ToLower(tc.GVK.Kind), state),
+		"Updating serving managementState",
 	)
+}
 
+// validateOwnerRefsAndLabels validates the owner references and labels of Kserve components.
+func (tc *KserveTestCtx) validateOwnerRefsAndLabels(expectOwned bool) {
 	for _, child := range templatedResources {
-		g.Get(child.gvk, child.nn).Eventually(300).Should(And(
-			BeNil(),
-		),
-			`Ensuring %s/%s in %s no longer exists`, child.gvk, child.nn.Name, child.nn.Namespace)
-	}
+		conds := []gomegaTypes.GomegaMatcher{}
+		var msg string
 
-	g.Update(
-		gvk.DataScienceCluster,
-		c.DSCName,
-		testf.Transform(`.spec.components.%s.serving.managementState = "%s"`, strings.ToLower(c.GVK.Kind), operatorv1.Managed),
-	).Eventually(120).Should(
-		Succeed(),
-		"Marking serving state as managed for subsequent tests",
-	)
-
-	g.Update(
-		gvk.DataScienceCluster,
-		c.DSCName,
-		testf.Transform(`.spec.components.%s.defaultDeploymentMode = "%s"`, strings.ToLower(c.GVK.Kind), componentApi.Serverless),
-	).Eventually(120).Should(
-		Succeed(),
-		"Setting defaultDeploymentMode to Serverless for subsequent tests",
-	)
-
-	for _, child := range templatedResources {
-		g.Get(child.gvk, child.nn).Eventually(120).Should(And(
-			jq.Match(`.metadata.labels | has("platform.opendatahub.io/part-of") == %v`, "true"),
-			jq.Match(`.metadata.ownerReferences | length == %d`, 1),
-			jq.Match(`.metadata.ownerReferences[0].kind == "%s"`, c.GVK.Kind),
-		),
-			`Ensuring %s/%s in %s is re-created`, child.gvk, child.nn.Name, child.nn.Namespace)
+		if expectOwned {
+			conds = append(conds,
+				jq.Match(`.metadata.labels | has("%s") == %v`, labels.PlatformPartOf, true),
+				jq.Match(`.metadata.ownerReferences | length == 1`),
+				jq.Match(`.metadata.ownerReferences[0].kind == "%s"`, tc.GVK.Kind),
+			)
+			msg = `Ensuring %s/%s in %s has expected owner ref and part-of label`
+		} else {
+			conds = append(conds,
+				jq.Match(`.metadata.labels | has("%s") == %v`, labels.PlatformPartOf, false),
+				jq.Match(`.metadata.ownerReferences | length == 0`),
+			)
+			msg = `Ensuring %s/%s in %s still exists but is de-owned`
+		}
+		tc.EnsureResourceExistsAndMatchesCondition(
+			child.gvk,
+			child.nn,
+			And(conds...),
+			msg, child.gvk, child.nn.Name, child.nn.Namespace)
 	}
 }

--- a/tests/e2e/kueue_test.go
+++ b/tests/e2e/kueue_test.go
@@ -1,176 +1,220 @@
 package e2e_test
 
 import (
-	"context"
+	"fmt"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/blang/semver/v4"
 	operatorv1 "github.com/openshift/api/operator/v1"
 	"github.com/stretchr/testify/require"
-	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	k8serr "k8s.io/apimachinery/pkg/api/errors"
+	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/api/components/v1alpha1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/metadata/labels"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/matchers/jq"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/testf"
 
 	. "github.com/onsi/gomega"
 )
 
+type KueueTestCtx struct {
+	*ComponentTestCtx
+}
+
 func kueueTestSuite(t *testing.T) {
 	t.Helper()
 
-	ct, err := NewComponentTestCtx(&componentApi.Kueue{})
+	ct, err := NewComponentTestCtx(t, &componentApi.Kueue{})
 	require.NoError(t, err)
 
 	componentCtx := KueueTestCtx{
 		ComponentTestCtx: ct,
 	}
 
-	t.Run("Validate component enabled", componentCtx.ValidateComponentEnabled)
-	t.Run("Validate operands have OwnerReferences", componentCtx.ValidateOperandsOwnerReferences)
-	t.Run("Validate update operand resources", componentCtx.ValidateUpdateDeploymentsResources)
-	t.Run("Validate Kueue Dynamically create VAP and VAPB", componentCtx.validateKueueVAPReady)
-	t.Run("Validate CRDs reinstated", componentCtx.validateCRDReinstated)
-	t.Run("Validate pre check", componentCtx.validateKueuePreCheck)
-	t.Run("Validate component releases", componentCtx.ValidateComponentReleases)
-	t.Run("Validate component disabled", componentCtx.ValidateComponentDisabled)
+	// Define test cases.
+	testCases := []TestCase{
+		{"Validate component enabled", componentCtx.ValidateComponentEnabled},
+		{"Validate operands have OwnerReferences", componentCtx.ValidateOperandsOwnerReferences},
+		{"Validate update operand resources", componentCtx.ValidateUpdateDeploymentsResources},
+		{"Validate Kueue Dynamically create VAP and VAPB", componentCtx.ValidateKueueVAPReady},
+		{"Validate CRDs reinstated", componentCtx.ValidateCRDReinstated},
+		{"Validate pre check", componentCtx.ValidateKueuePreCheck},
+		{"Validate component releases", componentCtx.ValidateComponentReleases},
+		{"Validate component disabled", componentCtx.ValidateComponentDisabled},
+	}
+
+	// Run the test suite.
+	componentCtx.RunTestCases(t, testCases)
 }
 
-type KueueTestCtx struct {
-	*ComponentTestCtx
-}
+// ValidateKueueVAPReady ensures that Validating Admission Policies (VAP) and Bindings (VAPB) are properly configured.
+func (tc *KueueTestCtx) ValidateKueueVAPReady(t *testing.T) {
+	t.Helper()
 
-func (tc *KueueTestCtx) validateKueueVAPReady(t *testing.T) {
-	g := tc.NewWithT(t)
-	v, err := tc.GetClusterVersion()
-	g.Expect(err).ToNot(HaveOccurred())
+	v := tc.getClusterVersion()
+
 	if v.GTE(semver.MustParse("4.17.0")) {
-		g.Get(gvk.ValidatingAdmissionPolicy, types.NamespacedName{Name: "kueue-validating-admission-policy"}).Eventually().WithTimeout(1 * time.Second).
-			Should(
-				jq.Match(`.metadata.ownerReferences[0].name == "%s"`, componentApi.KueueInstanceName),
-			)
-		g.Get(gvk.ValidatingAdmissionPolicyBinding, types.NamespacedName{Name: "kueue-validating-admission-policy-binding"}).Eventually().WithTimeout(1 * time.Second).Should(
+		// Validate that VAP exists and has correct owner references.
+		tc.EnsureResourceExistsAndMatchesCondition(
+			gvk.ValidatingAdmissionPolicy,
+			types.NamespacedName{Name: "kueue-validating-admission-policy"},
+			jq.Match(`.metadata.ownerReferences[0].name == "%s"`, componentApi.KueueInstanceName),
+		)
+
+		// Validate that VAPB exists and has no owner references.
+		tc.EnsureResourceExistsAndMatchesCondition(
+			gvk.ValidatingAdmissionPolicyBinding,
+			types.NamespacedName{Name: "kueue-validating-admission-policy-binding"},
 			jq.Match(`.metadata.ownerReferences | length == 0`),
 		)
-		return
-	}
-	_, err = g.Get(gvk.ValidatingAdmissionPolicy, types.NamespacedName{Name: "kueue-validating-admission-policy"}).Get()
-	g.Expect(err).Should(MatchError(&meta.NoKindMatchError{}))
-	_, err = g.Get(gvk.ValidatingAdmissionPolicyBinding, types.NamespacedName{Name: "kueue-validating-admission-policy-binding"}).Get()
-	g.Expect(err).Should(MatchError(&meta.NoKindMatchError{}))
-}
+	} else {
+		// Ensure that VAP and VAPB do not exist.
+		tc.EnsureResourceDoesNotExistAndErrorMatches(
+			gvk.ValidatingAdmissionPolicy,
+			types.NamespacedName{Name: "kueue-validating-admission-policy"},
+			&meta.NoKindMatchError{})
 
-func (tc *KueueTestCtx) validateCRDReinstated(t *testing.T) {
-	// validate multikuueclusters, multikueueconfigs has v1beta1 version
-
-	crds := map[string]string{
-		"workloads.kueue.x-k8s.io":          "v1beta1",
-		"multikueueclusters.kueue.x-k8s.io": "v1beta1",
-		"multikueueconfigs.kueue.x-k8s.io":  "v1beta1",
-	}
-
-	for crd, version := range crds {
-		t.Run(crd, func(t *testing.T) {
-			tc.ValidateCRDReinstated(t, crd, version)
-		})
+		tc.EnsureResourceDoesNotExistAndErrorMatches(
+			gvk.ValidatingAdmissionPolicyBinding,
+			types.NamespacedName{Name: "kueue-validating-admission-policy-binding"},
+			&meta.NoKindMatchError{})
 	}
 }
 
-func (tc *KueueTestCtx) validateKueuePreCheck(t *testing.T) {
-	// validate precheck on CRD version
-	// step:
-	// delete crd, check it is gone, then install old crd,
-	// set kueue to managed, result to error, delete crd, result to success.
+// ValidateCRDReinstated ensures that required CRDs are reinstated if deleted.
+func (tc *KueueTestCtx) ValidateCRDReinstated(t *testing.T) {
+	t.Helper()
 
-	g := tc.NewWithT(t)
+	crds := []CRD{
+		{Name: "workloads.kueue.x-k8s.io", Version: "v1beta1"},
+		{Name: "multikueueclusters.kueue.x-k8s.io", Version: "v1beta1"},
+		{Name: "multikueueconfigs.kueue.x-k8s.io", Version: "v1beta1"},
+	}
 
-	g.Update(
-		gvk.DataScienceCluster,
-		tc.DSCName,
-		testf.Transform(`.spec.components.%s.managementState = "%s"`, strings.ToLower(tc.GVK.Kind), operatorv1.Removed),
-	).Eventually().Should(
-		Succeed(),
-	)
+	tc.ValidateCRDsReinstated(t, crds)
+}
 
-	g.List(tc.GVK).Eventually().Should(
-		BeEmpty())
+// ValidateKueuePreCheck performs a pre-check by manipulating CRDs and validating expected behavior.
+func (tc *KueueTestCtx) ValidateKueuePreCheck(t *testing.T) {
+	t.Helper()
 
 	var mkConfig = "multikueueconfigs.kueue.x-k8s.io"
 	var mkCluster = "multikueueclusters.kueue.x-k8s.io"
 
-	g.Delete(gvk.CustomResourceDefinition,
-		types.NamespacedName{Name: mkCluster},
-		client.PropagationPolicy(metav1.DeletePropagationForeground),
-	).Eventually().Should(
-		Succeed(),
-	)
-	g.Eventually(func() bool {
-		var crd extv1.CustomResourceDefinition
-		err := tc.Client().Get(context.Background(), types.NamespacedName{Name: mkCluster}, &crd)
-		return k8serr.IsNotFound(err)
-	}).Should(BeTrue())
+	// Ensure DataScienceCluster component is initially removed.
+	tc.UpdateComponentStateInDataScienceCluster(operatorv1.Removed)
 
-	g.Delete(gvk.CustomResourceDefinition,
-		types.NamespacedName{Name: mkConfig},
-		client.PropagationPolicy(metav1.DeletePropagationForeground),
-	).Eventually().Should(
-		Succeed(),
-	)
-	g.Eventually(func() bool {
-		var crd extv1.CustomResourceDefinition
-		err := tc.Client().Get(context.Background(), types.NamespacedName{Name: mkConfig}, &crd)
-		return k8serr.IsNotFound(err)
-	}).Should(BeTrue())
+	// Verify there are no instances of the component
+	tc.EnsureResourceGone(tc.GVK, types.NamespacedName{Name: componentApi.KueueInstanceName})
 
-	c1 := mockCRDcreation("kueue.x-k8s.io", "v1alpha1", "multikueuecluster", "kueue")
-	e1 := tc.Client().Create(context.Background(), c1)
-	g.Expect(e1).ToNot(HaveOccurred())
+	// Delete and validate CRDs
+	tc.deleteAndValidateCRD(mkCluster)
+	tc.deleteAndValidateCRD(mkConfig)
 
-	c2 := mockCRDcreation("kueue.x-k8s.io", "v1alpha1", "multikueueconfig", "kueue")
-	e2 := tc.Client().Create(context.Background(), c2)
-	g.Expect(e2).ToNot(HaveOccurred())
+	// Create new CRDs
+	tc.createMockCRD(gvk.MultikueueClusterV1Alpha1, "kueue")
+	tc.createMockCRD(gvk.MultiKueueConfigV1Alpha1, "kueue")
 
-	g.Update(
-		gvk.DataScienceCluster,
-		tc.DSCName,
+	// Update DataScienceCluster to Managed state and check readiness condition
+	tc.EnsureResourceCreatedOrUpdatedWithCondition(
+		WithMinimalObject(gvk.DataScienceCluster, tc.DataScienceClusterNamespacedName),
 		testf.Transform(`.spec.components.%s.managementState = "%s"`, strings.ToLower(tc.GVK.Kind), operatorv1.Managed),
-	).Eventually().Should(
-		Succeed(),
-	)
-
-	g.List(gvk.DataScienceCluster).Eventually().Should(And(
-		HaveLen(1),
-		HaveEach(And(
+		And(
 			jq.Match(`.spec.components.%s.managementState == "%s"`, strings.ToLower(tc.GVK.Kind), operatorv1.Managed),
 			jq.Match(`.status.conditions[] | select(.type == "%sReady") | .status == "%s"`, tc.GVK.Kind, metav1.ConditionFalse),
-		)),
-	))
+		),
+	)
 
-	g.Delete(gvk.CustomResourceDefinition,
+	// Delete the CRDs.
+	tc.DeleteResource(
+		gvk.CustomResourceDefinition,
 		types.NamespacedName{Name: mkCluster},
 		client.PropagationPolicy(metav1.DeletePropagationForeground),
-	).Eventually().Should(
-		Succeed(),
 	)
-	g.Delete(gvk.CustomResourceDefinition,
+	tc.DeleteResource(
+		gvk.CustomResourceDefinition,
 		types.NamespacedName{Name: mkConfig},
 		client.PropagationPolicy(metav1.DeletePropagationForeground),
-	).Eventually().Should(
-		Succeed(),
 	)
 
-	g.List(gvk.DataScienceCluster).Eventually().Should(And(
-		HaveLen(1),
-		HaveEach(
-			jq.Match(`.status.conditions[] | select(.type == "%sReady") | .status == "%s"`, tc.GVK.Kind, metav1.ConditionTrue),
-		),
-	))
+	// Verify the DataScienceCluster become "Ready"
+	tc.EnsureResourceExistsAndMatchesCondition(
+		gvk.DataScienceCluster,
+		tc.DataScienceClusterNamespacedName,
+		jq.Match(`.status.conditions[] | select(.type == "%sReady") | .status == "%s"`, tc.GVK.Kind, metav1.ConditionTrue),
+	)
+}
+
+// deleteAndValidateCRD deletes a given CRD and ensures it no longer exists.
+func (tc *KueueTestCtx) deleteAndValidateCRD(crdName string) {
+	// Delete the CRD
+	tc.DeleteResource(
+		gvk.CustomResourceDefinition,
+		types.NamespacedName{Name: crdName},
+		client.PropagationPolicy(metav1.DeletePropagationForeground),
+	)
+
+	// Verify the CRD is deleted
+	tc.EnsureResourceGone(
+		gvk.CustomResourceDefinition,
+		types.NamespacedName{Name: crdName},
+	)
+}
+
+// createMockCRD creates a mock CRD for a given group, version, kind, and namespace.
+func (tc *KueueTestCtx) createMockCRD(gvk schema.GroupVersionKind, namespace string) {
+	crd := mockCRDCreation(gvk.Group, gvk.Version, strings.ToLower(gvk.Kind), namespace)
+
+	tc.EnsureResourceCreatedOrUpdated(
+		WithObjectToCreate(crd),
+		NoOpMutationFn,
+	)
+}
+
+// mockCRDCreation generates a mock CRD with the specified parameters.
+func mockCRDCreation(group, version, kind, componentName string) *apiextv1.CustomResourceDefinition {
+	return &apiextv1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: strings.ToLower(fmt.Sprintf("%ss.%s", kind, group)),
+			Labels: map[string]string{
+				labels.ODH.Component(componentName): labels.True,
+			},
+		},
+		Spec: apiextv1.CustomResourceDefinitionSpec{
+			Group: group,
+			Names: apiextv1.CustomResourceDefinitionNames{
+				Kind:   kind,
+				Plural: strings.ToLower(kind) + "s",
+			},
+			Scope: apiextv1.ClusterScoped,
+			Versions: []apiextv1.CustomResourceDefinitionVersion{
+				{
+					Name:    version,
+					Served:  true,
+					Storage: true,
+					Schema: &apiextv1.CustomResourceValidation{
+						OpenAPIV3Schema: &apiextv1.JSONSchemaProps{
+							Type: "object",
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// getClusterVersion retrieves and parses the cluster version.
+func (tc *ComponentTestCtx) getClusterVersion() semver.Version {
+	cv := tc.RetrieveClusterVersion()
+	v, err := semver.ParseTolerant(cv.Status.History[0].Version)
+	tc.g.Expect(err).ToNot(HaveOccurred(), "Failed to get cluster version")
+
+	return v
 }

--- a/tests/e2e/modelcontroller_test.go
+++ b/tests/e2e/modelcontroller_test.go
@@ -3,15 +3,17 @@ package e2e_test
 import (
 	"strings"
 	"testing"
-	"time"
 
 	operatorv1 "github.com/openshift/api/operator/v1"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8slabels "k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/api/components/v1alpha1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/components/modelcontroller"
+	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/status"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/metadata/labels"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/matchers/jq"
@@ -20,114 +22,139 @@ import (
 	. "github.com/onsi/gomega"
 )
 
+type ModelControllerTestCtx struct {
+	*ComponentTestCtx
+}
+
 func modelControllerTestSuite(t *testing.T) {
 	t.Helper()
 
-	ct, err := NewComponentTestCtx(&componentApi.ModelController{})
+	ct, err := NewComponentTestCtx(t, &componentApi.ModelController{})
 	require.NoError(t, err)
 
 	componentCtx := ModelControllerTestCtx{
 		ComponentTestCtx: ct,
 	}
 
-	t.Run("Validate component enabled", componentCtx.validateComponentEnabled)
-	t.Run("Validate operands have OwnerReferences", componentCtx.ValidateOperandsOwnerReferences)
-	t.Run("Validate update operand resources", componentCtx.ValidateUpdateDeploymentsResources)
-	t.Run("Validate component disabled", componentCtx.validateComponentDisabled)
+	// Define test cases.
+	testCases := []TestCase{
+		{"Validate component enabled", componentCtx.ValidateComponentEnabled},
+		{"Validate operands have OwnerReferences", componentCtx.ValidateOperandsOwnerReferences},
+		{"Validate update operand resources", componentCtx.ValidateUpdateDeploymentsResources},
+		{"Validate component disabled", componentCtx.ValidateComponentDisabled},
+	}
+
+	// Run the test suite.
+	componentCtx.RunTestCases(t, testCases)
 }
 
-type ModelControllerTestCtx struct {
-	*ComponentTestCtx
+// ValidateComponentEnabled validates that the components are enabled with the correct states.
+func (tc *ModelControllerTestCtx) ValidateComponentEnabled(t *testing.T) {
+	t.Helper()
+
+	// Define the test cases for checking component states
+	testCases := []TestCase{
+		{"ModelMeshServing enabled", func(t *testing.T) {
+			t.Helper()
+			tc.ValidateComponentDeployed(operatorv1.Managed, operatorv1.Removed, operatorv1.Removed, metav1.ConditionTrue)
+		}},
+		{"Kserve enabled", func(t *testing.T) {
+			t.Helper()
+			tc.ValidateComponentDeployed(operatorv1.Removed, operatorv1.Managed, operatorv1.Removed, metav1.ConditionTrue)
+		}},
+		{"Kserve and ModelMeshServing enabled", func(t *testing.T) {
+			t.Helper()
+			tc.ValidateComponentDeployed(operatorv1.Managed, operatorv1.Managed, operatorv1.Removed, metav1.ConditionTrue)
+		}},
+		{"ModelRegistry enabled", func(t *testing.T) {
+			t.Helper()
+			tc.ValidateComponentDeployed(operatorv1.Managed, operatorv1.Managed, operatorv1.Managed, metav1.ConditionTrue)
+		}},
+	}
+
+	// Run the test suite.
+	tc.RunTestCases(t, testCases)
 }
 
-func (c *ModelControllerTestCtx) validateComponentEnabled(t *testing.T) {
-	t.Run("ModelMeshServing enabled", func(t *testing.T) {
-		c.validateComponentDeployed(t, operatorv1.Managed, operatorv1.Removed, operatorv1.Removed, metav1.ConditionTrue)
-	})
-	t.Run("Kserve enabled", func(t *testing.T) {
-		c.validateComponentDeployed(t, operatorv1.Removed, operatorv1.Managed, operatorv1.Removed, metav1.ConditionTrue)
-	})
-	t.Run("Kserve and ModelMeshServing enabled", func(t *testing.T) {
-		c.validateComponentDeployed(t, operatorv1.Managed, operatorv1.Managed, operatorv1.Removed, metav1.ConditionTrue)
-	})
-	t.Run("ModelRegistry enabled", func(t *testing.T) {
-		c.validateComponentDeployed(t, operatorv1.Managed, operatorv1.Managed, operatorv1.Managed, metav1.ConditionTrue)
+// ValidateComponentDisabled validates that the components are disabled.
+func (tc *ModelControllerTestCtx) ValidateComponentDisabled(t *testing.T) {
+	t.Helper()
+
+	t.Run("Kserve ModelMeshServing and ModelRegistry disabled", func(t *testing.T) {
+		t.Helper()
+		tc.ValidateComponentDeployed(operatorv1.Removed, operatorv1.Removed, operatorv1.Removed, metav1.ConditionFalse)
 	})
 }
 
-func (c *ModelControllerTestCtx) validateComponentDisabled(t *testing.T) {
-	t.Run("Kserve and ModelMeshServing disabled", func(t *testing.T) {
-		c.validateComponentDeployed(t, operatorv1.Removed, operatorv1.Removed, operatorv1.Removed, metav1.ConditionFalse)
-	})
-}
-
-func (c *ModelControllerTestCtx) validateComponentDeployed(
-	t *testing.T,
+// ValidateComponentDeployed validates that the components are deployed with the correct management state.
+func (tc *ModelControllerTestCtx) ValidateComponentDeployed(
 	modelMeshState operatorv1.ManagementState,
 	kserveState operatorv1.ManagementState,
 	modelRegistryState operatorv1.ManagementState,
 	status metav1.ConditionStatus,
 ) {
-	t.Helper()
-
-	g := c.NewWithT(t)
-
-	g.Update(
-		gvk.DataScienceCluster,
-		c.DSCName,
+	// Ensure the components are updated with the correct states in DataScienceCluster.
+	tc.EnsureResourceCreatedOrUpdated(
+		WithMinimalObject(gvk.DataScienceCluster, tc.DataScienceClusterNamespacedName),
 		testf.TransformPipeline(
 			testf.Transform(`.spec.components.%s.managementState = "%s"`, componentApi.ModelMeshServingComponentName, modelMeshState),
 			testf.Transform(`.spec.components.%s.managementState = "%s"`, componentApi.KserveComponentName, kserveState),
 			testf.Transform(`.spec.components.%s.managementState = "%s"`, componentApi.ModelRegistryComponentName, modelRegistryState),
 		),
-	).Eventually().WithTimeout(30 * time.Second).WithPolling(1 * time.Second).Should(
-		Succeed(),
 	)
 
+	// Verify resources based on the desired status.
 	if status == metav1.ConditionTrue {
-		g.List(gvk.ModelController).Eventually().Should(And(
-			HaveLen(1),
-			HaveEach(And(
-				jq.Match(`.metadata.ownerReferences[0].kind == "%s"`, gvk.DataScienceCluster.Kind),
-				jq.Match(`.status.phase == "%s"`, readyStatus),
-			)),
-		))
-
-		g.List(
-			gvk.Deployment,
-			client.InNamespace(c.ApplicationNamespace),
-			client.MatchingLabels{
-				labels.PlatformPartOf: strings.ToLower(c.GVK.Kind),
-			},
-		).Eventually().ShouldNot(
-			BeEmpty(),
-		)
+		tc.verifyResourcesDeployed()
 	} else {
-		g.List(gvk.Kserve).Eventually().Should(
-			BeEmpty(),
-		)
-		g.List(gvk.ModelMeshServing).Eventually().Should(
-			BeEmpty(),
-		)
-		g.List(gvk.ModelController).Eventually().Should(
-			BeEmpty(),
-		)
-
-		g.List(
-			gvk.Deployment,
-			client.InNamespace(c.ApplicationNamespace),
-			client.MatchingLabels{
-				labels.PlatformPartOf: strings.ToLower(gvk.ModelController.Kind),
-			},
-		).Eventually().Should(
-			BeEmpty(),
-		)
+		tc.verifyResourcesNotDeployed()
 	}
 
-	g.List(gvk.DataScienceCluster).Eventually().Should(And(
-		HaveLen(1),
-		HaveEach(And(
-			jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, modelcontroller.ReadyConditionType, status),
-		)),
-	))
+	// Ensure ModelController condition matches the expected status in the DataScienceCluster.
+	tc.EnsureResourceExistsAndMatchesCondition(
+		gvk.DataScienceCluster,
+		tc.DataScienceClusterNamespacedName,
+		jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, modelcontroller.ReadyConditionType, status),
+	)
+}
+
+// verifyResourcesDeployed ensures that the required resources are deployed.
+func (tc *ModelControllerTestCtx) verifyResourcesDeployed() {
+	// Ensure ModelController and related Deployments are deployed.
+	tc.EnsureResourceExistsAndMatchesCondition(
+		gvk.ModelController,
+		types.NamespacedName{Name: componentApi.ModelControllerInstanceName},
+		And(
+			jq.Match(`.metadata.ownerReferences[0].kind == "%s"`, gvk.DataScienceCluster.Kind),
+			jq.Match(`.status.phase == "%s"`, status.ConditionTypeReady),
+		),
+	)
+
+	// Ensure the ModelController deployment exists.
+	tc.EnsureResourcesExist(
+		gvk.Deployment,
+		types.NamespacedName{Namespace: tc.AppsNamespace},
+		&client.ListOptions{
+			LabelSelector: k8slabels.Set{
+				labels.PlatformPartOf: strings.ToLower(tc.GVK.Kind),
+			}.AsSelector(),
+		},
+	)
+}
+
+// verifyResourcesNotDeployed ensures that the required resources are not deployed.
+func (tc *ModelControllerTestCtx) verifyResourcesNotDeployed() {
+	// Ensure that the components are not deployed
+	tc.EnsureResourceGone(gvk.Kserve, types.NamespacedName{Name: componentApi.KserveInstanceName})
+	tc.EnsureResourceGone(gvk.ModelMeshServing, types.NamespacedName{Name: componentApi.ModelMeshServingInstanceName})
+	tc.EnsureResourceGone(gvk.ModelController, types.NamespacedName{Name: componentApi.ModelControllerInstanceName})
+	tc.EnsureResourcesGone(
+		gvk.Deployment,
+		types.NamespacedName{Namespace: tc.AppsNamespace},
+		&client.ListOptions{
+			LabelSelector: k8slabels.Set{
+				labels.PlatformPartOf: strings.ToLower(tc.GVK.Kind),
+			}.AsSelector(),
+		},
+	)
 }

--- a/tests/e2e/modelcontroller_test.go
+++ b/tests/e2e/modelcontroller_test.go
@@ -44,6 +44,10 @@ func modelControllerTestSuite(t *testing.T) {
 		{"Validate component disabled", componentCtx.ValidateComponentDisabled},
 	}
 
+	// Increase the global eventually timeout
+	reset := componentCtx.OverrideEventuallyTimeout(eventuallyTimeoutMedium, defaultEventuallyPollInterval)
+	defer reset() // Make sure it's reset after all tests run
+
 	// Run the test suite.
 	componentCtx.RunTestCases(t, testCases)
 }

--- a/tests/e2e/modelmeshserving_test.go
+++ b/tests/e2e/modelmeshserving_test.go
@@ -4,53 +4,34 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/api/components/v1alpha1"
-	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/components/modelcontroller"
-	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
-	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/matchers/jq"
-
-	. "github.com/onsi/gomega"
 )
+
+type ModelMeshServingTestCtx struct {
+	*ComponentTestCtx
+}
 
 func modelMeshServingTestSuite(t *testing.T) {
 	t.Helper()
 
-	ct, err := NewComponentTestCtx(&componentApi.ModelMeshServing{})
+	ct, err := NewComponentTestCtx(t, &componentApi.ModelMeshServing{})
 	require.NoError(t, err)
 
 	componentCtx := ModelMeshServingTestCtx{
 		ComponentTestCtx: ct,
 	}
 
-	t.Run("Validate component enabled", componentCtx.ValidateComponentEnabled)
-	t.Run("Validate model controller", componentCtx.validateModelControllerInstance)
-	t.Run("Validate operands have OwnerReferences", componentCtx.ValidateOperandsOwnerReferences)
-	t.Run("Validate update operand resources", componentCtx.ValidateUpdateDeploymentsResources)
-	t.Run("Validate component disabled", componentCtx.ValidateComponentDisabled)
-	// t.Run("Validate component releases", componentCtx.ValidateComponentReleases)
-}
+	// Define test cases.
+	testCases := []TestCase{
+		{"Validate component enabled", componentCtx.ValidateComponentEnabled},
+		{"Validate model controller", componentCtx.ValidateModelControllerInstance},
+		{"Validate operands have OwnerReferences", componentCtx.ValidateOperandsOwnerReferences},
+		{"Validate update operand resources", componentCtx.ValidateUpdateDeploymentsResources},
+		{"Validate component releases", componentCtx.ValidateComponentReleases},
+		{"Validate component disabled", componentCtx.ValidateComponentDisabled},
+	}
 
-type ModelMeshServingTestCtx struct {
-	*ComponentTestCtx
-}
-
-func (tc *ModelMeshServingTestCtx) validateModelControllerInstance(t *testing.T) {
-	g := tc.NewWithT(t)
-
-	g.List(gvk.ModelController).Eventually().Should(And(
-		HaveLen(1),
-		HaveEach(And(
-			jq.Match(`.metadata.ownerReferences[0].kind == "%s"`, gvk.DataScienceCluster.Kind),
-			jq.Match(`.status.phase == "%s"`, readyStatus),
-		)),
-	))
-
-	g.List(gvk.DataScienceCluster).Eventually().Should(And(
-		HaveLen(1),
-		HaveEach(And(
-			jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, modelcontroller.ReadyConditionType, metav1.ConditionTrue),
-		)),
-	))
+	// Run the test suite.
+	componentCtx.RunTestCases(t, testCases)
 }

--- a/tests/e2e/modelregistry_test.go
+++ b/tests/e2e/modelregistry_test.go
@@ -1,15 +1,12 @@
 package e2e_test
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/rs/xid"
 	"github.com/stretchr/testify/require"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/api/components/v1alpha1"
 	modelregistryctrl "github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/components/modelregistry"
@@ -17,7 +14,6 @@ import (
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/metadata/annotations"
-	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/metadata/labels"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/resources"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/matchers/jq"
 
@@ -31,140 +27,171 @@ type ModelRegistryTestCtx struct {
 func modelRegistryTestSuite(t *testing.T) {
 	t.Helper()
 
-	ct, err := NewComponentTestCtx(&componentApi.ModelRegistry{})
+	ct, err := NewComponentTestCtx(t, &componentApi.ModelRegistry{})
 	require.NoError(t, err)
 
 	componentCtx := ModelRegistryTestCtx{
 		ComponentTestCtx: ct,
 	}
 
-	t.Run("Validate component enabled", componentCtx.ValidateComponentEnabled)
-	t.Run("Validate component spec", componentCtx.validateSpec)
-	t.Run("Validate component conditions", componentCtx.validateConditions)
-	t.Run("Validate operands have OwnerReferences", componentCtx.ValidateOperandsOwnerReferences)
-	t.Run("Validate update operand resources", componentCtx.ValidateUpdateDeploymentsResources)
+	// Define test cases.
+	testCases := []TestCase{
+		{"Validate component enabled", componentCtx.ValidateComponentEnabled},
+		{"Validate component spec", componentCtx.ValidateSpec},
+		{"Validate component conditions", componentCtx.ValidateConditions},
+		{"Validate operands have OwnerReferences", componentCtx.ValidateOperandsOwnerReferences},
+		{"Validate update operand resources", componentCtx.ValidateUpdateDeploymentsResources},
+		{"Validate watched resources", componentCtx.ValidateOperandsWatchedResources},
+		{"Validate dynamically watches operands", componentCtx.ValidateOperandsDynamicallyWatchedResources},
+		{"Validate CRDs reinstated", componentCtx.ValidateCRDReinstated},
+		{"Validate cert", componentCtx.ValidateModelRegistryCert},
+		{"Validate ServiceMeshMember", componentCtx.ValidateModelRegistryServiceMeshMember},
+		{"Validate component releases", componentCtx.ValidateComponentReleases},
+		{"Validate component disabled", componentCtx.ValidateComponentDisabled},
+	}
 
-	t.Run("Validate watched resources", componentCtx.validateOperandsWatchedResources)
-	t.Run("Validate dynamically watches operands", componentCtx.validateOperandsDynamicallyWatchedResources)
-	t.Run("Validate CRDs reinstated", componentCtx.validateCRDReinstated)
-	t.Run("Validate cert", componentCtx.validateModelRegistryCert)
-	t.Run("Validate ServiceMeshMember", componentCtx.validateModelRegistryServiceMeshMember)
-
-	t.Run("Validate component releases", componentCtx.ValidateComponentReleases)
-	t.Run("Validate component disabled", componentCtx.ValidateComponentDisabled)
+	// Run the test suite.
+	componentCtx.RunTestCases(t, testCases)
 }
 
-func (c *ModelRegistryTestCtx) validateSpec(t *testing.T) {
-	g := c.NewWithT(t)
+// ValidateSpec checks the ModelRegistry spec against the DataScienceCluster instance.
+func (tc *ModelRegistryTestCtx) ValidateSpec(t *testing.T) {
+	t.Helper()
 
-	dsc, err := c.GetDSC()
-	g.Expect(err).NotTo(HaveOccurred())
+	// Retrieve the DataScienceCluster instance.
+	dsc := tc.RetrieveDataScienceCluster(tc.DataScienceClusterNamespacedName)
 
-	g.List(gvk.ModelRegistry).Eventually().Should(And(
-		HaveLen(1),
-		HaveEach(And(
-			jq.Match(`.spec.registriesNamespace == "%s"`, dsc.Spec.Components.ModelRegistry.RegistriesNamespace),
-		)),
-	))
+	// Validate that the registriesNamespace in ModelRegistry matches the corresponding value in DataScienceCluster spec.
+	tc.EnsureResourceExistsAndMatchesCondition(
+		gvk.ModelRegistry,
+		types.NamespacedName{Name: componentApi.ModelRegistryInstanceName},
+		jq.Match(`.spec.registriesNamespace == "%s"`, dsc.Spec.Components.ModelRegistry.RegistriesNamespace),
+	)
 }
 
-func (c *ModelRegistryTestCtx) validateConditions(t *testing.T) {
-	g := c.NewWithT(t)
+// ValidateConditions validates that the ModelRegistry instance's status conditions are correct.
+func (tc *ModelRegistryTestCtx) ValidateConditions(t *testing.T) {
+	t.Helper()
 
-	g.List(gvk.ModelRegistry).Eventually().Should(And(
-		HaveLen(1),
-		HaveEach(And(
-			jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, status.ConditionServiceMeshAvailable, metav1.ConditionTrue),
-		)),
-	))
+	// Ensure the ModelRegistry resource has the "ServiceMeshAvailable" condition set to "True".
+	tc.ValidateComponentCondition(
+		gvk.ModelRegistry,
+		componentApi.ModelRegistryInstanceName,
+		status.ConditionServiceMeshAvailable,
+	)
 }
 
-func (c *ModelRegistryTestCtx) validateOperandsWatchedResources(t *testing.T) {
-	g := c.NewWithT(t)
+// ValidateOperandsWatchedResources validates the resources being watched by the operands.
+func (tc *ModelRegistryTestCtx) ValidateOperandsWatchedResources(t *testing.T) {
+	t.Helper()
 
-	g.List(
+	// Retrieve the ModelRegistry instance.
+	mri := tc.retrieveModelRegistry()
+
+	// Ensure the correct labels are set on the ServiceMeshMember and that ownerReferences are not present.
+	tc.EnsureResourceExistsAndMatchesCondition(
 		gvk.ServiceMeshMember,
-		client.MatchingLabels{labels.PlatformPartOf: strings.ToLower(componentApi.ModelRegistryKind)},
-	).Eventually().Should(And(
-		HaveLen(1),
-		HaveEach(And(
-			jq.Match(`.metadata | has("ownerReferences") | not`),
-		)),
-	))
+		types.NamespacedName{Namespace: mri.Spec.RegistriesNamespace, Name: serviceMeshMemberName},
+		jq.Match(`.metadata | has("ownerReferences") | not`),
+	)
 }
 
-func (c *ModelRegistryTestCtx) validateOperandsDynamicallyWatchedResources(t *testing.T) {
-	g := c.NewWithT(t)
+// ValidateOperandsDynamicallyWatchedResources validates the dynamic watching of operands.
+func (tc *ModelRegistryTestCtx) ValidateOperandsDynamicallyWatchedResources(t *testing.T) {
+	t.Helper()
 
-	mri, err := g.Get(gvk.ModelRegistry, types.NamespacedName{Name: componentApi.ModelRegistryInstanceName}).Get()
-	g.Expect(err).ShouldNot(HaveOccurred())
+	// Retrieve the ModelRegistry instance.
+	mri := tc.retrieveModelRegistry()
 
-	rn, err := jq.ExtractValue[string](mri, ".spec.registriesNamespace")
-	g.Expect(err).ShouldNot(HaveOccurred())
-	g.Expect(rn).ShouldNot(BeEmpty())
-
+	// Generate unique platform type values
 	newPt := xid.New().String()
 	oldPt := ""
 
-	g.Update(gvk.ServiceMeshMember, types.NamespacedName{Name: "default", Namespace: rn}, func(obj *unstructured.Unstructured) error {
-		oldPt = resources.SetAnnotation(obj, annotations.PlatformType, newPt)
-		return nil
-	}).Eventually().Should(
-		Succeed(),
+	// Apply new platform type annotation and verify
+	tc.EnsureResourceCreatedOrUpdated(
+		WithMinimalObject(gvk.ServiceMeshMember,
+			types.NamespacedName{Namespace: mri.Spec.RegistriesNamespace, Name: serviceMeshMemberName},
+		),
+		func(obj *unstructured.Unstructured) error {
+			oldPt = resources.SetAnnotation(obj, annotations.PlatformType, newPt)
+			return nil
+		},
 	)
 
-	g.List(
+	// Ensure previously created resource retains their old platform type annotation
+	tc.EnsureResourceExistsAndMatchesCondition(
 		gvk.ServiceMeshMember,
-		client.MatchingLabels{labels.PlatformPartOf: strings.ToLower(componentApi.ModelRegistryKind)},
-	).Eventually().Should(And(
-		HaveLen(1),
-		HaveEach(And(
-			jq.Match(`.metadata.annotations."%s" == "%s"`, annotations.PlatformType, oldPt),
-		)),
-	))
+		types.NamespacedName{Namespace: mri.Spec.RegistriesNamespace, Name: serviceMeshMemberName},
+		jq.Match(`.metadata.annotations."%s" == "%s"`, annotations.PlatformType, oldPt),
+	)
 }
 
-func (c *ModelRegistryTestCtx) validateModelRegistryCert(t *testing.T) {
-	g := c.NewWithT(t)
+// ValidateModelRegistryCert validates the ModelRegistry certificate for the associated ServiceMesh.
+func (tc *ModelRegistryTestCtx) ValidateModelRegistryCert(t *testing.T) {
+	t.Helper()
 
-	dsci, err := g.Get(gvk.DSCInitialization, c.DSCIName).Get()
-	g.Expect(err).ShouldNot(HaveOccurred())
+	// Retrieve DSCInitialization resource
+	dsci := tc.RetrieveDSCInitialization(tc.DSCInitializationNamespacedName)
 
-	smns, err := jq.ExtractValue[string](dsci, ".spec.serviceMesh.controlPlane.namespace")
-	g.Expect(err).ShouldNot(HaveOccurred())
-	g.Expect(smns).ShouldNot(BeEmpty())
+	// Ensure that the Service Mesh control plane namespace is not empty.
+	tc.g.Expect(dsci.Spec.ServiceMesh.ControlPlane.Namespace).ToNot(BeEmpty())
 
-	is, err := cluster.FindDefaultIngressSecret(g.Context(), g.Client())
-	g.Expect(err).ShouldNot(HaveOccurred())
+	is, err := cluster.FindDefaultIngressSecret(tc.g.Context(), tc.g.Client())
+	tc.g.Expect(err).NotTo(HaveOccurred())
 
-	g.Get(gvk.Secret, types.NamespacedName{Namespace: smns, Name: modelregistryctrl.DefaultModelRegistryCert}).Eventually().Should(And(
-		jq.Match(`.type == "%s"`, is.Type),
-		jq.Match(`(.data."tls.crt" | @base64d) == "%s"`, is.Data["tls.crt"]),
-		jq.Match(`(.data."tls.key" | @base64d) == "%s"`, is.Data["tls.key"]),
-	))
+	tc.EnsureResourceExistsAndMatchesCondition(
+		gvk.Secret,
+		types.NamespacedName{
+			Namespace: dsci.Spec.ServiceMesh.ControlPlane.Namespace,
+			Name:      modelregistryctrl.DefaultModelRegistryCert,
+		},
+		And(
+			jq.Match(`.type == "%s"`, is.Type),
+			jq.Match(`(.data."tls.crt" | @base64d) == "%s"`, is.Data["tls.crt"]),
+			jq.Match(`(.data."tls.key" | @base64d) == "%s"`, is.Data["tls.key"]),
+		),
+	)
 }
 
-func (c *ModelRegistryTestCtx) validateModelRegistryServiceMeshMember(t *testing.T) {
-	g := c.NewWithT(t)
+// ValidateModelRegistryServiceMeshMember validates the ModelRegistry ServiceMeshMember.
+func (tc *ModelRegistryTestCtx) ValidateModelRegistryServiceMeshMember(t *testing.T) {
+	t.Helper()
 
-	mri, err := g.Get(gvk.ModelRegistry, types.NamespacedName{Name: componentApi.ModelRegistryInstanceName}).Get()
-	g.Expect(err).ShouldNot(HaveOccurred())
+	// Retrieve the ModelRegistry instance.
+	mri := tc.retrieveModelRegistry()
 
-	rn, err := jq.ExtractValue[string](mri, ".spec.registriesNamespace")
-	g.Expect(err).ShouldNot(HaveOccurred())
-	g.Expect(rn).ShouldNot(BeEmpty())
+	// Ensure that the registries namespace is not empty.
+	tc.g.Expect(mri.Spec.RegistriesNamespace).ToNot(BeEmpty())
 
-	g.Get(gvk.ServiceMeshMember, types.NamespacedName{Namespace: rn, Name: "default"}).Eventually().Should(
+	// Ensure that the ServiceMeshMember exists and matches the expected condition.
+	tc.EnsureResourceExistsAndMatchesCondition(
+		gvk.ServiceMeshMember,
+		types.NamespacedName{Namespace: mri.Spec.RegistriesNamespace, Name: serviceMeshMemberName},
 		jq.Match(`.spec | has("controlPlaneRef")`),
 	)
 }
 
-func (c *ModelRegistryTestCtx) validateCRDReinstated(t *testing.T) {
-	crds := []string{"modelregistries.modelregistry.opendatahub.io"}
+// ValidateCRDReinstated ensures that required CRDs are reinstated if deleted.
+func (tc *ModelRegistryTestCtx) ValidateCRDReinstated(t *testing.T) {
+	t.Helper()
 
-	for _, crd := range crds {
-		t.Run(crd, func(t *testing.T) {
-			c.ValidateCRDReinstated(t, crd)
-		})
+	crds := []CRD{
+		{Name: "modelregistries.modelregistry.opendatahub.io", Version: ""},
 	}
+
+	tc.ValidateCRDsReinstated(t, crds)
+}
+
+func (tc *ModelRegistryTestCtx) retrieveModelRegistry() *componentApi.ModelRegistry {
+	mri := &componentApi.ModelRegistry{}
+	tc.RetrieveResource(
+		gvk.ModelRegistry,
+		types.NamespacedName{Name: componentApi.ModelRegistryInstanceName},
+		mri,
+	)
+
+	// Ensure that the registries namespace is not empty.
+	tc.g.Expect(mri.Spec.RegistriesNamespace).ToNot(BeEmpty())
+
+	return mri
 }

--- a/tests/e2e/monitoring_test.go
+++ b/tests/e2e/monitoring_test.go
@@ -1,70 +1,85 @@
 package e2e_test
 
 import (
-	"fmt"
 	"testing"
 
 	operatorv1 "github.com/openshift/api/operator/v1"
 	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/types"
 
 	serviceApi "github.com/opendatahub-io/opendatahub-operator/v2/api/services/v1alpha1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
+
+	. "github.com/onsi/gomega"
 )
 
 type MonitoringTestCtx struct {
-	*testContext
-	testMonitoringInstance serviceApi.Monitoring
+	*TestContext
 }
 
 func monitoringTestSuite(t *testing.T) {
 	t.Helper()
 
-	tc, err := NewTestContext()
+	// Initialize the test context.
+	tc, err := NewTestContext(t)
 	require.NoError(t, err)
 
+	// Create an instance of test context.
 	monitoringServiceCtx := MonitoringTestCtx{
-		testContext: tc,
+		TestContext: tc,
 	}
 
-	t.Run(tc.testDsc.Name, func(t *testing.T) {
-		t.Run("Auto creation of Monitoring CR", func(t *testing.T) {
-			err = monitoringServiceCtx.validateMonitoringCRCreation()
-			require.NoError(t, err, "error getting Auth CR")
-		})
-		t.Run("Test Monitoring CR content", func(t *testing.T) {
-			err = monitoringServiceCtx.validateMonitoringCRDefaultContent()
-			require.NoError(t, err, "unexpected content in Auth CR")
-		})
-		// TODO: Add Managed monitoring test suite
-	})
+	// Skip tests if the ManagementState is 'Removed'.
+	skipIfMonitoringRemoved(t, tc)
+
+	// Define test cases.
+	testCases := []TestCase{
+		{"Auto creation of Monitoring CR", monitoringServiceCtx.ValidateMonitoringCRCreation},
+		{"Test Monitoring CR content", monitoringServiceCtx.ValidateMonitoringCRDefaultContent},
+	}
+
+	// Run the test suite.
+	monitoringServiceCtx.RunTestCases(t, testCases)
 }
 
-func (tc *MonitoringTestCtx) validateMonitoringCRCreation() error {
-	if tc.testDSCI.Spec.Monitoring.ManagementState == operatorv1.Removed {
-		return nil
-	}
-	monitoringList := &serviceApi.MonitoringList{}
-	if err := tc.testContext.customClient.List(tc.ctx, monitoringList); err != nil {
-		return fmt.Errorf("unable to find Monitoring CR instance: %w", err)
-	}
+// skipIfMonitoringRemoved checks if the ManagementState is 'Removed' and skips tests accordingly.
+func skipIfMonitoringRemoved(t *testing.T, tc *TestContext) {
+	t.Helper()
 
-	switch {
-	case len(monitoringList.Items) == 1:
-		tc.testMonitoringInstance = monitoringList.Items[0]
-		return nil
-	case len(monitoringList.Items) > 1:
-		return fmt.Errorf("only one Monitoring CR expected, found %v", len(monitoringList.Items))
-	default:
-		return nil
+	// Retrieve DSCInitialization resource.
+	dsci := tc.RetrieveDSCInitialization(tc.DSCInitializationNamespacedName)
+
+	// Skip tests if ManagementState is 'Removed'.
+	if dsci.Spec.Monitoring.ManagementState == operatorv1.Removed {
+		t.Skip("Monitoring ManagementState is 'Removed', skipping all monitoring-related tests.")
 	}
 }
 
-func (tc *MonitoringTestCtx) validateMonitoringCRDefaultContent() error {
-	if tc.platform == cluster.ManagedRhoai {
-		if tc.testMonitoringInstance.Spec.MonitoringCommonSpec.Namespace != tc.testDSCI.Spec.Monitoring.Namespace {
-			return fmt.Errorf("unexpected monitoring namespace reference. Expected %v, got %v", tc.testDSCI.Spec.Monitoring.Namespace,
-				tc.testMonitoringInstance.Spec.MonitoringCommonSpec.Namespace)
-		}
+// ValidateMonitoringCRCreation ensures that exactly one Monitoring CR exists.
+func (tc *MonitoringTestCtx) ValidateMonitoringCRCreation(t *testing.T) {
+	t.Helper()
+
+	// Ensure exactly one Monitoring CR exists.
+	tc.EnsureExactlyOneResourceExists(gvk.Monitoring, types.NamespacedName{})
+}
+
+// ValidateMonitoringCRDefaultContent validates the default content of the Monitoring CR.
+func (tc *MonitoringTestCtx) ValidateMonitoringCRDefaultContent(t *testing.T) {
+	t.Helper()
+
+	if tc.Platform == cluster.ManagedRhoai {
+		// Retrieve the DSCInitialization object.
+		dsci := tc.RetrieveDSCInitialization(tc.DSCInitializationNamespacedName)
+
+		// Ensure that the Monitoring resource exists.
+		monitoring := &serviceApi.Monitoring{}
+		tc.RetrieveResource(gvk.Monitoring, types.NamespacedName{}, monitoring)
+
+		// Validate that the Monitoring CR's namespace matches the DSCInitialization spec.
+		tc.g.Expect(monitoring.Spec.MonitoringCommonSpec.Namespace).
+			To(Equal(dsci.Spec.Monitoring.Namespace),
+				"Monitoring CR's namespace mismatch: Expected namespace '%v' as per DSCInitialization, but found '%v' in Monitoring CR.",
+				dsci.Spec.Monitoring.Namespace, monitoring.Spec.MonitoringCommonSpec.Namespace)
 	}
-	return nil
 }

--- a/tests/e2e/odh_manager_test.go
+++ b/tests/e2e/odh_manager_test.go
@@ -4,116 +4,74 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/types"
 )
 
-func testODHOperatorValidation(t *testing.T) {
-	testCtx, err := NewTestContext()
-	require.NoError(t, err)
-
-	t.Run("validate ODH Operator pod", testCtx.testODHDeployment)
-	t.Run("validate CRDs owned by the operator", testCtx.validateOwnedCRDs)
+type OperatorTestCtx struct {
+	*TestContext
 }
 
-func (tc *testContext) testODHDeployment(t *testing.T) {
+func odhOperatorTestSuite(t *testing.T) {
+	t.Helper()
+
+	// Initialize the test context.
+	tc, err := NewTestContext(t)
+	require.NoError(t, err, "Failed to initialize test context")
+
+	// Create an instance of test context.
+	operatorTestCtx := OperatorTestCtx{
+		TestContext: tc,
+	}
+
+	// Define test cases.
+	testCases := []TestCase{
+		{name: "Validate ODH Operator pod", testFn: operatorTestCtx.testODHDeployment},
+		{name: "Validate CRDs owned by the operator", testFn: operatorTestCtx.ValidateOwnedCRDs},
+	}
+
+	// Run the test suite.
+	operatorTestCtx.RunTestCases(t, testCases)
+}
+
+// testODHDeployment checks if the ODH deployment exists and is correctly configured.
+func (tc *OperatorTestCtx) testODHDeployment(t *testing.T) {
+	t.Helper()
+
 	// Verify if the operator deployment is created
-	require.NoErrorf(t, tc.waitForOperatorDeployment("opendatahub-operator-controller-manager", 1),
-		"error in validating odh operator deployment")
+	controllerDeployment := "opendatahub-operator-controller-manager"
+	tc.EnsureDeploymentReady(types.NamespacedName{Namespace: tc.OperatorNamespace, Name: controllerDeployment}, 1)
 }
 
-func (tc *testContext) validateOwnedCRDs(t *testing.T) {
-	// Verify if 3 operators CRDs are installed in parallel
-	t.Run("Validate DSC CRD", func(t *testing.T) {
-		t.Parallel()
-		require.NoErrorf(t, tc.validateCRD("datascienceclusters.datasciencecluster.opendatahub.io"),
-			"error in validating CRD : datascienceclusters.datasciencecluster.opendatahub.io")
-	})
-	t.Run("Validate DSCI CRD", func(t *testing.T) {
-		t.Parallel()
-		require.NoErrorf(t, tc.validateCRD("dscinitializations.dscinitialization.opendatahub.io"),
-			"error in validating CRD : dscinitializations.dscinitialization.opendatahub.io")
-	})
-	t.Run("Validate FeatureTracker CRD", func(t *testing.T) {
-		t.Parallel()
-		require.NoErrorf(t, tc.validateCRD("featuretrackers.features.opendatahub.io"),
-			"error in validating CRD : featuretrackers.features.opendatahub.io")
-	})
+// ValidateOwnedCRDs validates if the owned CRDs are properly created and available.
+func (tc *OperatorTestCtx) ValidateOwnedCRDs(t *testing.T) {
+	t.Helper()
 
-	// Validate component CRDs
-	t.Run("Validate Dashboard CRD", func(t *testing.T) {
-		t.Parallel()
-		require.NoErrorf(t, tc.validateCRD("dashboards.components.platform.opendatahub.io"),
-			"error in validating CRD : dashboards.components.platform.opendatahub.io")
-	})
+	crdsTestCases := []struct {
+		name string
+		crd  string
+	}{
+		{"Datascience Cluster CRD", "datascienceclusters.datasciencecluster.opendatahub.io"},
+		{"DataScienceCluster Initialization CRD", "dscinitializations.dscinitialization.opendatahub.io"},
+		{"FeatureTracker CRD", "featuretrackers.features.opendatahub.io"},
+		{"Dashboard CRD", "dashboards.components.platform.opendatahub.io"},
+		{"Ray CRD", "rays.components.platform.opendatahub.io"},
+		{"ModelRegistry CRD", "modelregistries.components.platform.opendatahub.io"},
+		{"TrustyAI CRD", "trustyais.components.platform.opendatahub.io"},
+		{"Kueue CRD", "kueues.components.platform.opendatahub.io"},
+		{"TrainingOperator CRD", "trainingoperators.components.platform.opendatahub.io"},
+		{"FeastOperator CRD", "feastoperators.components.platform.opendatahub.io"},
+		{"DataSciencePipelines CRD", "datasciencepipelines.components.platform.opendatahub.io"},
+		{"Workbenches CRD", "workbenches.components.platform.opendatahub.io"},
+		{"Kserve CRD", "kserves.components.platform.opendatahub.io"},
+		{"ModelMeshServing CRD", "modelmeshservings.components.platform.opendatahub.io"},
+		{"ModelController CRD", "modelcontrollers.components.platform.opendatahub.io"},
+		{"Monitoring CRD", "monitorings.services.platform.opendatahub.io"},
+	}
 
-	t.Run("Validate Ray CRD", func(t *testing.T) {
-		t.Parallel()
-		require.NoErrorf(t, tc.validateCRD("rays.components.platform.opendatahub.io"),
-			"error in validating CRD : rays.components.platform.opendatahub.io")
-	})
-
-	t.Run("Validate ModelRegistry CRD", func(t *testing.T) {
-		t.Parallel()
-		require.NoErrorf(t, tc.validateCRD("modelregistries.components.platform.opendatahub.io"),
-			"error in validating CRD : modelregistries.components.platform.opendatahub.io")
-	})
-
-	t.Run("Validate TrustyAI CRD", func(t *testing.T) {
-		t.Parallel()
-		require.NoErrorf(t, tc.validateCRD("trustyais.components.platform.opendatahub.io"),
-			"error in validating CRD : trustyais.components.platform.opendatahub.io")
-	})
-
-	t.Run("Validate Kueue CRD", func(t *testing.T) {
-		t.Parallel()
-		require.NoErrorf(t, tc.validateCRD("kueues.components.platform.opendatahub.io"),
-			"error in validating CRD : kueues.components.platform.opendatahub.io")
-	})
-
-	t.Run("Validate TrainingOperator CRD", func(t *testing.T) {
-		t.Parallel()
-		require.NoErrorf(t, tc.validateCRD("trainingoperators.components.platform.opendatahub.io"),
-			"error in validating CRD : trainingoperators.components.platform.opendatahub.io")
-	})
-
-	t.Run("Validate FeastOperator CRD", func(t *testing.T) {
-		t.Parallel()
-		require.NoErrorf(t, tc.validateCRD("feastoperators.components.platform.opendatahub.io"),
-			"error in validating CRD : feastoperators.components.platform.opendatahub.io")
-	})
-
-	t.Run("Validate DataSciencePipelines CRD", func(t *testing.T) {
-		t.Parallel()
-		require.NoErrorf(t, tc.validateCRD("datasciencepipelines.components.platform.opendatahub.io"),
-			"error in validating CRD : datasciencepipelines.components.platform.opendatahub.io")
-	})
-
-	t.Run("Validate Workbenches CRD", func(t *testing.T) {
-		t.Parallel()
-		require.NoErrorf(t, tc.validateCRD("workbenches.components.platform.opendatahub.io"),
-			"error in validating CRD : workbenches.components.platform.opendatahub.io")
-	})
-
-	t.Run("Validate Kserve CRD", func(t *testing.T) {
-		t.Parallel()
-		require.NoErrorf(t, tc.validateCRD("kserves.components.platform.opendatahub.io"),
-			"error in validating CRD : kserves.components.platform.opendatahub.io")
-	})
-
-	t.Run("Validate ModelMeshServing CRD", func(t *testing.T) {
-		t.Parallel()
-		require.NoErrorf(t, tc.validateCRD("modelmeshservings.components.platform.opendatahub.io"),
-			"error in validating CRD : modelmeshservings.components.platform.opendatahub.io")
-	})
-
-	t.Run("Validate ModelController CRD", func(t *testing.T) {
-		t.Parallel()
-		require.NoErrorf(t, tc.validateCRD("modelcontrollers.components.platform.opendatahub.io"),
-			"error in validating CRD : modelcontrollers.components.platform.opendatahub.io")
-	})
-
-	t.Run("Validate Monitoring CRD", func(t *testing.T) {
-		t.Parallel()
-		require.NoErrorf(t, tc.validateCRD("monitorings.services.platform.opendatahub.io"),
-			"error in validating CRD : monitorings.services.platform.opendatahub.io")
-	})
+	for _, testCase := range crdsTestCases {
+		t.Run("Validate "+testCase.name, func(t *testing.T) {
+			t.Parallel()
+			tc.EnsureCRDEstablished(testCase.crd)
+		})
+	}
 }

--- a/tests/e2e/ray_test.go
+++ b/tests/e2e/ray_test.go
@@ -8,23 +8,29 @@ import (
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/api/components/v1alpha1"
 )
 
+type RayTestCtx struct {
+	*ComponentTestCtx
+}
+
 func rayTestSuite(t *testing.T) {
 	t.Helper()
 
-	ct, err := NewComponentTestCtx(&componentApi.Ray{})
+	ct, err := NewComponentTestCtx(t, &componentApi.Ray{})
 	require.NoError(t, err)
 
 	componentCtx := RayTestCtx{
 		ComponentTestCtx: ct,
 	}
 
-	t.Run("Validate component enabled", componentCtx.ValidateComponentEnabled)
-	t.Run("Validate operands have OwnerReferences", componentCtx.ValidateOperandsOwnerReferences)
-	t.Run("Validate update operand resources", componentCtx.ValidateUpdateDeploymentsResources)
-	t.Run("Validate component releases", componentCtx.ValidateComponentReleases)
-	t.Run("Validate component disabled", componentCtx.ValidateComponentDisabled)
-}
+	// Define test cases.
+	testCases := []TestCase{
+		{"Validate component enabled", componentCtx.ValidateComponentEnabled},
+		{"Validate operands have OwnerReferences", componentCtx.ValidateOperandsOwnerReferences},
+		{"Validate update operand resources", componentCtx.ValidateUpdateDeploymentsResources},
+		{"Validate component releases", componentCtx.ValidateComponentReleases},
+		{"Validate component disabled", componentCtx.ValidateComponentDisabled},
+	}
 
-type RayTestCtx struct {
-	*ComponentTestCtx
+	// Run the test suite.
+	componentCtx.RunTestCases(t, testCases)
 }

--- a/tests/e2e/resource_applier_test.go
+++ b/tests/e2e/resource_applier_test.go
@@ -1,0 +1,232 @@
+package e2e_test
+
+import (
+	"reflect"
+
+	"github.com/onsi/gomega/matchers"
+	gTypes "github.com/onsi/gomega/types"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/testf"
+
+	. "github.com/onsi/gomega"
+)
+
+// Check if the matcher is an error matcher like Succeed(), HaveOccurred(), etc.
+func isErrorMatcher(matcher gTypes.GomegaMatcher) bool {
+	switch matcher.(type) {
+	case *matchers.SucceedMatcher, *matchers.HaveOccurredMatcher, *matchers.MatchErrorMatcher:
+		return true
+	default:
+		return false
+	}
+}
+
+// isNumericMatcher checks if the given matcher is used for numeric comparisons, such as BeNumerically.
+func isNumericMatcher(matcher gTypes.GomegaMatcher) bool {
+	switch matcher.(type) {
+	case *matchers.BeNumericallyMatcher, // for numerical comparison
+		*matchers.EqualMatcher,          // for equality check
+		*matchers.BeEquivalentToMatcher: // for equivalence check
+		return true
+	default:
+		return false
+	}
+}
+
+// Helper function to safely dereference the condition pointer.
+func dereferenceCondition(condition gTypes.GomegaMatcher) any {
+	// If condition is a pointer, dereference it
+	if reflect.TypeOf(condition).Kind() == reflect.Ptr {
+		return reflect.ValueOf(condition).Elem().Interface()
+	}
+	// If it's not a pointer, return the condition as is
+	return condition
+}
+
+// applyMatchers applies Gomega matchers to a single resource or a list of resources.
+//
+// Parameters:
+//   - g (Gomega): The Gomega assertion wrapper.
+//   - ResourceID (string): A string identifier for logging purposes.
+//   - gvk (schema.GroupVersionKind): The GroupVersionKind of the resource(s).
+//   - resource any: Can be a single unstructured.Unstructured or a list ([]unstructured.Unstructured).
+//   - err error: The error returned when fetching the resource(s).
+//   - condition gTypes.GomegaMatcher: The Gomega matcher to apply.
+//   - args []any: Optional additional arguments for assertion messages.
+func applyMatchers(
+	g Gomega,
+	resourceID string,
+	gvk schema.GroupVersionKind,
+	resource any,
+	err error,
+	condition gTypes.GomegaMatcher,
+	args []any,
+) {
+	// Check if the condition is an And, Or, or Not and recursively inspect the inner matchers
+	switch v := condition.(type) {
+	case *matchers.AndMatcher:
+		// If the condition is an And, apply each matcher recursively
+		for _, inner := range v.Matchers {
+			applyMatchers(g, resourceID, gvk, resource, err, inner, args)
+		}
+	case *matchers.OrMatcher:
+		// If the condition is an Or, apply each matcher recursively
+		for _, inner := range v.Matchers {
+			applyMatchers(g, resourceID, gvk, resource, err, inner, args)
+		}
+	case *matchers.NotMatcher:
+		// If the condition is a Not, apply the negated matcher recursively
+		applyMatchers(g, resourceID, gvk, resource, err, v.Matcher, args)
+	case gTypes.GomegaMatcher: // Base matcher (for non-Error matchers)
+		// If matcher is an error matcher, apply it to the error
+		if isErrorMatcher(v) {
+			g.Expect(err).To(v, defaultErrorMessageIfNone(
+				"Expected error when applying resource '%s' of kind '%s'.",
+				[]any{resourceID, gvk.Kind}, args,
+			)...)
+			return
+		}
+
+		// If working on a list of resources
+		if resourcesList, ok := resource.([]unstructured.Unstructured); ok {
+			// If the matcher applies to numeric values, apply it to len(resourcesList)
+			if isNumericMatcher(v) {
+				g.Expect(len(resourcesList)).To(v, defaultErrorMessageIfNone(
+					"Expected number of '%s' resources to match condition %v, but found %d.",
+					[]any{gvk.Kind, dereferenceCondition(condition), len(resourcesList)}, args,
+				)...)
+			} else {
+				// Apply the matcher to the list
+				g.Expect(resourcesList).To(v, defaultErrorMessageIfNone(
+					"Expected list of '%s' resources to match condition %v.",
+					[]any{gvk.Kind, dereferenceCondition(condition)}, args,
+				)...)
+			}
+			return
+		}
+
+		// If working on a single resource
+		if u, ok := resource.(*unstructured.Unstructured); ok {
+			g.Expect(u.Object).To(v, defaultErrorMessageIfNone(
+				"Expected resource '%s' of kind '%s' to match condition %v.",
+				[]any{resourceID, gvk.Kind, dereferenceCondition(condition)}, args,
+			)...)
+		}
+	}
+}
+
+// wrapConditionIfNeeded ensures that the condition is wrapped in And(Succeed(), condition)
+// if it's not already wrapped in such a way.
+func wrapConditionIfNeeded(condition *gTypes.GomegaMatcher) {
+	// Check if the condition is already an 'And' that contains Succeed()
+	if _, ok := (*condition).(*matchers.SucceedMatcher); ok || isAndContainingSucceed(*condition) {
+		return
+	}
+
+	// Wrap condition inside And(Succeed(), condition) if it's not already wrapped correctly
+	*condition = And(Succeed(), *condition)
+}
+
+// isAndContainingSucceed checks if the matcher is an AndMatcher containing Succeed().
+func isAndContainingSucceed(matcher gTypes.GomegaMatcher) bool {
+	// Check if the condition is already an 'And' that contains Succeed()
+	andMatcher, ok := matcher.(*matchers.AndMatcher)
+	if !ok {
+		return false
+	}
+
+	// Check if Succeed is one of the matchers in the And condition
+	for _, m := range andMatcher.Matchers {
+		if _, ok := m.(*matchers.SucceedMatcher); ok {
+			return true
+		}
+	}
+
+	return false
+}
+
+// Helper function to evaluate if failure is expected based on the matcher.
+func isFailureExpected(condition gTypes.GomegaMatcher) bool {
+	// Check if the condition is an And, Or, or Not and recursively inspect the inner matchers
+	switch v := condition.(type) {
+	case *matchers.AndMatcher:
+		// If the condition is And(), we recursively check the inner matchers
+		for _, inner := range v.Matchers {
+			if isFailureExpected(inner) {
+				return true
+			}
+		}
+	case *matchers.OrMatcher:
+		// If the condition is Or(), we recursively check the inner matchers
+		for _, inner := range v.Matchers {
+			if isFailureExpected(inner) {
+				return true
+			}
+		}
+	case *matchers.NotMatcher:
+		// If the condition is Not(Succeed()), we expect failure
+		if _, ok := v.Matcher.(*matchers.SucceedMatcher); ok {
+			return true
+		}
+	case gTypes.GomegaMatcher:
+		// For basic matchers (not wrapped in And/Or/Not), check if it is Not(Succeed()) or any other condition
+		expectingFailure, _ := condition.Match(Not(Succeed()))
+		return expectingFailure
+	}
+
+	// Default case if none of the conditions matched, return false (no failure expected)
+	return false
+}
+
+// ensureResourceApplied is a common function for handling create/patch and create/update operations.
+// It applies a given resource and ensures it meets the expected condition.
+//
+// Parameters:
+//   - ro: The ResourceOptions object that contains all the configuration for the resource, condition, and mutation function.
+//   - applyResourceFn: The function responsible for applying the resource (create, patch, etc.).
+//
+// Returns:
+//   - *unstructured.Unstructured: The applied resource if it meets the expected condition.
+func (tc *TestContext) ensureResourceApplied(
+	ro *ResourceOptions,
+	applyResourceFn func(obj *unstructured.Unstructured, fn ...func(obj *unstructured.Unstructured) error) *testf.EventuallyValue[*unstructured.Unstructured],
+) *unstructured.Unstructured {
+	// Wrap condition if it's not already wrapped correctly
+	wrapConditionIfNeeded(&ro.Condition)
+
+	// Use Eventually to retry getting the resource until it appears
+	var u *unstructured.Unstructured
+	tc.g.Eventually(func(g Gomega) {
+		// Fetch the resource
+		var err error
+		u, err = applyResourceFn(ro.Obj, ro.MutateFunc).Get()
+
+		// Evaluate the condition to check if failure is expected
+		expectingFailure := isFailureExpected(ro.Condition)
+
+		// Error handling based on failure expectation
+		if !expectingFailure {
+			// Expect no error if success is expected
+			g.Expect(err).NotTo(
+				HaveOccurred(),
+				"Error occurred while applying the resource '%s' of kind '%s': %v",
+				ro.ResourceID,
+				ro.GVK.Kind,
+				err,
+			)
+
+			// Ensure that the resource object is not nil
+			g.Expect(u).NotTo(BeNil(), resourceNotFoundErrorMsg, ro.ResourceID, ro.GVK.Kind)
+		} else {
+			// Expect error if failure is expected
+			g.Expect(err).To(HaveOccurred(), "Expected applyResourceFn to fail but it succeeded")
+		}
+
+		// Apply the matchers based on the condition
+		applyMatchers(g, ro.ResourceID, ro.GVK, u, err, ro.Condition, ro.CustomErrorArgs)
+	}).Should(Succeed())
+
+	return u
+}

--- a/tests/e2e/resource_fetcher_test.go
+++ b/tests/e2e/resource_fetcher_test.go
@@ -1,0 +1,140 @@
+package e2e_test
+
+import (
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	. "github.com/onsi/gomega"
+)
+
+// fetchResource attempts to retrieve a single Kubernetes resource, retrying automatically until success or timeout.
+//
+// It ensures that transient failures or delays in resource creation do not cause test flakiness
+// by using Gomega's Eventually mechanism.
+//
+// Parameters:
+//   - ro (*ResourceOptions): Contains details about the resource, including GVK, NamespacedName (NN),
+//     expected error conditions, and custom assertion messages.
+//
+// Returns:
+//   - *unstructured.Unstructured: The retrieved resource if found; otherwise, nil.
+//   - error: The error encountered during retrieval, if any.
+func (tc *TestContext) fetchResource(ro *ResourceOptions) (*unstructured.Unstructured, error) {
+	// Retry logic to fetch the resource with appropriate error handling.
+	var u *unstructured.Unstructured
+	var fetchErr error
+
+	tc.g.Eventually(func(g Gomega) {
+		// Fetch the resource
+		u, fetchErr = tc.g.Get(ro.GVK, ro.NN).Get()
+
+		// Check if ExpectedErr is provided and match it if encountered
+		if ro.ExpectedErr != nil && fetchErr != nil {
+			g.Expect(fetchErr).To(MatchError(ro.ExpectedErr), unexpectedErrorMismatchMsg, ro.ExpectedErr, fetchErr, ro.GVK.Kind)
+		}
+
+		// If the resource is not found, we set the object to nil
+		if errors.IsNotFound(fetchErr) {
+			u = nil
+		}
+	}).Should(Succeed())
+
+	return u, fetchErr
+}
+
+// fetchResources retrieves a list of Kubernetes resources, retrying automatically until success or timeout.
+//
+// It ensures transient issues do not cause test failures by using Gomega's Eventually mechanism.
+//
+// Parameters:
+//   - ro (*ResourceOptions): Contains details about the resources, including GVK, NamespacedName (NN),
+//     list filtering options, and custom assertion messages.
+//
+// Returns:
+//   - []unstructured.Unstructured: A list of retrieved resources, which may be empty if none exist.
+//   - error: The error encountered during retrieval, if any.
+func (tc *TestContext) fetchResources(ro *ResourceOptions) ([]unstructured.Unstructured, error) {
+	var resourcesList []unstructured.Unstructured
+	var fetchErr error
+
+	tc.g.Eventually(func(g Gomega) {
+		// Attempt to retrieve the list of resources
+		resourcesList, fetchErr = tc.g.List(ro.GVK, ro.ListOptions).Get()
+
+		// Check if ExpectedErr is provided and match it if encountered
+		if ro.ExpectedErr != nil && fetchErr != nil {
+			g.Expect(fetchErr).To(MatchError(ro.ExpectedErr), unexpectedErrorMismatchMsg, ro.ExpectedErr, fetchErr, ro.GVK.Kind)
+		}
+
+		// Ensure no unexpected errors occurred during retrieval
+		g.Expect(fetchErr).NotTo(
+			HaveOccurred(),
+			defaultErrorMessageIfNone(resourceFetchErrorMsg, []any{ro.ResourceID, ro.GVK.Kind, fetchErr}, ro.CustomErrorArgs)...,
+		)
+	}).Should(Succeed())
+
+	return resourcesList, fetchErr
+}
+
+// ensureResourceExistsOrNil retrieves a Kubernetes resource, retrying until it is found or the timeout expires.
+// If the resource exists, it returns the object. If not found, it returns nil without failing the test.
+// Unexpected errors will fail the test.
+//
+// Parameters:
+//   - ro (*ResourceOptions): Metadata and retrieval logic for the resource.
+//
+// Returns:
+//   - *unstructured.Unstructured: The resource if found, otherwise nil.
+//   - error: Any error encountered during retrieval.
+func (tc *TestContext) ensureResourceExistsOrNil(ro *ResourceOptions) (*unstructured.Unstructured, error) {
+	// Fetch the resource using fetchResource.
+	u, err := tc.fetchResource(ro)
+
+	// Ensure no unexpected errors occurred while fetching the resource
+	tc.g.Expect(err).NotTo(
+		HaveOccurred(),
+		defaultErrorMessageIfNone(resourceFetchErrorMsg, []any{ro.ResourceID, ro.GVK.Kind, err}, ro.CustomErrorArgs)...,
+	)
+
+	// Return the resource or nil if it wasn't found
+	return u, err
+}
+
+// ensureResourceDoesNotExist attempts to retrieve a Kubernetes resource and checks if it does not exist.
+// It uses Gomega assertions to ensure the resource is not found and fails the test if it is found.
+//
+// Parameters:
+//   - g (Gomega): The Gomega assertion wrapper.
+//   - ro (*ResourceOptions): Metadata and retrieval logic for the resource.
+//
+// Returns:
+//   - error: An error if the resource is found, or nil if the resource does not exist.
+func (tc *TestContext) ensureResourceDoesNotExist(g Gomega, ro *ResourceOptions) error {
+	// Fetch the resource using fetchResource.
+	u, err := tc.fetchResource(ro)
+
+	// Assert that the resource is not found.
+	g.Expect(u).To(BeNil(), resourceFoundErrorMsg, ro.ResourceID, ro.GVK.Kind)
+
+	// Return the error encountered during resource retrieval, if any.
+	return err
+}
+
+// ensureResourcesDoNotExist is a helper function that retrieves a list of Kubernetes resources
+// and checks if the resources do not exist (i.e., the list is empty). It performs an assertion
+// to ensure that the list of resources is empty. If any resources are found, it fails the test.
+//
+// Parameters:
+//   - g (Gomega): The Gomega assertion wrapper.
+//   - ro (*ResourceOptions): Metadata and retrieval logic for the resource.
+//
+// Returns:
+//   - error: An error if the resource is found in the cluster, or nil if the resource does not exist.
+func (tc *TestContext) ensureResourcesDoNotExist(g Gomega, ro *ResourceOptions) error {
+	resourcesList, err := tc.fetchResources(ro)
+
+	// Ensure that the resources list is empty (resources should not exist)
+	g.Expect(resourcesList).To(BeEmpty(), resourceListNotEmptyErrorMsg, ro.ResourceID, ro.GVK.Kind)
+
+	return err
+}

--- a/tests/e2e/resource_options_test.go
+++ b/tests/e2e/resource_options_test.go
@@ -1,0 +1,250 @@
+package e2e_test
+
+import (
+	"time"
+
+	gTypes "github.com/onsi/gomega/types"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/resources"
+
+	. "github.com/onsi/gomega"
+)
+
+// ==============================
+//        RESOURCE OPTIONS
+// ==============================
+
+// ResourceOptions encapsulates the various configuration options for resource handling operations,
+// such as fetching, creating, updating, patching, and deleting resources. It allows customization of
+// the behavior of resource handling functions by setting custom error messages, conditions, and resource
+// fetch or manipulation logic. These options are used across a range of functions to perform operations
+// on Kubernetes resources with flexible configuration.
+type ResourceOptions struct {
+	// tc is the test context that provides access to the Gomega configuration,
+	// including default timeouts and polling intervals for Eventually and Consistently assertions.
+	tc *TestContext
+
+	// ObjFn is responsible for retrieving or creating the resource.
+	ObjFn func(*TestContext) *unstructured.Unstructured
+
+	// Cached object after ObjFn is called.
+	// Holds the result of the ObjFn call and is used throughout subsequent operations.
+	Obj *unstructured.Unstructured
+
+	// ListOptions for resource listing, such as label selectors.
+	// This field defines the filtering criteria when listing resources, such as label selectors,
+	// field selectors, or other Kubernetes-specific options to narrow down the resource list.
+	ListOptions *client.ListOptions
+
+	// ClientDeleteOptions defines the behavior of resource deletion.
+	// This field holds the options that control how a resource should be deleted (e.g., cascading deletion
+	// policy, grace period for deletion). It is used when calling Kubernetes client methods for resource
+	// deletion. Deletion behavior such as the propagation policy (Foreground, Background, or Orphan) can
+	// be set via these options. It allows fine-grained control over how the resource is removed from the cluster.
+	ClientDeleteOptions *client.DeleteOptions
+
+	// MutateFunc is responsible for modifying the resource before it is applied (e.g., setting fields or configurations).
+	// This function can be used to mutate the resource object before applying any changes to it.
+	MutateFunc func(obj *unstructured.Unstructured) error
+
+	// Condition is the Gomega matcher that checks the final condition of the resource.
+	// This matcher allows the user to specify conditions on the resource that should be met in order for the
+	// operation to be considered successful. For example, checking if the resource has the correct status or labels.
+	Condition gTypes.GomegaMatcher
+
+	// Custom error message and arguments for error handling.
+	// A customizable error message template with placeholders for dynamic values. This can be used to provide
+	// detailed error messages when operations fail.
+	CustomErrorArgs []any
+
+	// ExpectedErr is the error expected during resource retrieval or manipulation (e.g., when resource is not found).
+	// This allows users to specify what error they expect during certain operations (e.g., expecting a "not found" error).
+	ExpectedErr error
+
+	// GroupVersionKind and NamespacedName of the resource.
+	// These fields define the type (GVK) and identifier (NN) for the resource. GVK is used to specify the
+	// kind of resource (e.g., Pod, Deployment), and NamespacedName specifies the resource's namespace and name.
+	GVK schema.GroupVersionKind
+	NN  types.NamespacedName
+
+	// Unique identifier for logging and error messages.
+	// The ResourceID is used to provide a unique identifier for the resource, which is especially useful
+	// when working with multiple resources of the same type.
+	ResourceID string
+}
+
+// ResourceOpts is a function type used to configure options for the ResourceOptions object.
+// These options modify the behavior of resource handling operations, such as custom error messages, conditions, etc.
+// The functions that modify ResourceOptions can be chained together to build a customized resource operation.
+type ResourceOpts func(*ResourceOptions)
+
+// NewResourceOptions applies multiple `ResourceOpts` functions to configure a `ResourceOptions` object.
+func (tc *TestContext) NewResourceOptions(opts ...ResourceOpts) *ResourceOptions {
+	ro := &ResourceOptions{tc: tc}
+	for _, opt := range opts {
+		opt(ro)
+	}
+
+	// Ensure ObjFn is set and fetch the object.
+	if ro.Obj == nil && ro.ObjFn != nil {
+		// If Obj is not provided, call ObjFn to get the object.
+		ro.Obj = ro.ObjFn(tc)
+	}
+
+	// Ensure that Obj is not nil before returning the options.
+	if ro.Obj == nil {
+		panic("Obj must be set in ResourceOptions") // Panics if Obj is nil to enforce validation.
+	}
+
+	// Ensure ListOptions is not nil before using it
+	if ro.ListOptions == nil {
+		ro.ListOptions = &client.ListOptions{}
+	}
+
+	// Ensure ClientDeleteOptions is not nil before using it
+	if ro.ClientDeleteOptions == nil {
+		ro.ClientDeleteOptions = &client.DeleteOptions{}
+	}
+
+	return ro
+}
+
+// ==============================
+//        RESOURCE HELPERS
+// ==============================
+
+// WithObjectToCreate creates a ResourceOpts function that sets the ObjFn field of the ResourceOptions to
+// convert the provided object into an unstructured resource. This is used when the resource doesn't exist
+// yet and needs to be created or updated.
+func WithObjectToCreate(obj client.Object) ResourceOpts {
+	return func(ro *ResourceOptions) {
+		ro.ObjFn = func(tc *TestContext) *unstructured.Unstructured {
+			// Convert the input object to unstructured
+			u, err := resources.ObjectToUnstructured(tc.Scheme(), obj)
+			tc.g.Expect(err).NotTo(HaveOccurred())
+			return u
+		}
+		ro.GVK = obj.GetObjectKind().GroupVersionKind()
+		ro.NN = types.NamespacedName{Name: obj.GetName(), Namespace: obj.GetNamespace()}
+		ro.ResourceID = resources.FormatNamespacedName(ro.NN)
+	}
+}
+
+// WithFetchedObject creates a ResourceOpts function that sets the ObjFn field of the ResourceOptions to
+// fetch an existing resource by its GroupVersionKind (GVK) and NamespacedName (NN). This is useful when
+// the resource already exists and needs to be updated or patched.
+func WithFetchedObject(gvk schema.GroupVersionKind, nn types.NamespacedName) ResourceOpts {
+	return func(ro *ResourceOptions) {
+		ro.ObjFn = func(tc *TestContext) *unstructured.Unstructured {
+			u, err := tc.g.Get(gvk, nn).Get()
+			tc.g.Expect(err).NotTo(HaveOccurred(), "Failed to fetch resource %s", nn.Name)
+			return u
+		}
+		ro.NN = nn
+		ro.GVK = gvk
+		ro.ResourceID = resources.FormatNamespacedName(nn)
+	}
+}
+
+// WithMinimalObject creates a ResourceOpts function that sets the ObjFn field of the ResourceOptions to
+// create a minimal unstructured resource with the provided GroupVersionKind (GVK) and NamespacedName (NN).
+// This is useful for scenarios where only a few essential fields of the resource need to be specified, such
+// as when creating simple resources like namespaces.
+func WithMinimalObject(gvk schema.GroupVersionKind, nn types.NamespacedName) ResourceOpts {
+	return func(ro *ResourceOptions) {
+		ro.ObjFn = func(tc *TestContext) *unstructured.Unstructured {
+			// Create a new unstructured object and set the necessary fields
+			u := resources.GvkToUnstructured(gvk) // Set the GroupVersionKind
+			u.SetNamespace(nn.Namespace)          // Set the Namespace
+			u.SetName(nn.Name)                    // Set the Name
+
+			// Return the object with only the essential fields set
+			return u
+		}
+		ro.NN = nn
+		ro.GVK = gvk
+		ro.ResourceID = resources.FormatNamespacedName(nn)
+	}
+}
+
+// WithListOptions creates a ResourceOpts function that sets the ListOptions field of the ResourceOptions.
+// ListOptions are used to specify filters like label selectors or other query parameters when listing resources.
+func WithListOptions(listOptions *client.ListOptions) ResourceOpts {
+	return func(ro *ResourceOptions) {
+		ro.ListOptions = listOptions
+	}
+}
+
+// WithClientDeleteOptions creates a ResourceOpts function that sets the ClientDeleteOptions field
+// of the ResourceOptions. This will be used to configure the deletion behavior (e.g., propagation policy, grace period).
+func WithClientDeleteOptions(deleteOptions *client.DeleteOptions) ResourceOpts {
+	return func(ro *ResourceOptions) {
+		ro.ClientDeleteOptions = deleteOptions
+	}
+}
+
+// WithMutateFunc creates a ResourceOpts function that sets a function that modifies the resource before it is applied.
+// This function can be used to mutate or update the resource in any desired way.
+func WithMutateFunc(fn func(obj *unstructured.Unstructured) error) ResourceOpts {
+	return func(ro *ResourceOptions) {
+		ro.MutateFunc = fn
+	}
+}
+
+// WithCondition creates a ResourceOpts function that sets a custom Gomega matcher condition (e.g., Expect(Succeed())).
+// This condition is used for verifying whether the resource operation has succeeded or failed, and can be used to
+// customize the expected behavior of the resource handling function.
+func WithCondition(condition gTypes.GomegaMatcher) ResourceOpts {
+	return func(ro *ResourceOptions) {
+		ro.Condition = condition
+	}
+}
+
+// WithExpectedErr creates a ResourceOpts function that sets the ExpectedErr field in ResourceOptions.
+// This allows specifying an error that should be encountered during resource retrieval or manipulation.
+func WithExpectedErr(expectedErr error) func(*ResourceOptions) {
+	return func(ro *ResourceOptions) {
+		ro.ExpectedErr = expectedErr
+	}
+}
+
+// WithCustomErrorMsg creates a ResourceOpts function that sets a custom error message with the specified
+// formatting pattern and arguments. This allows users to customize the error message displayed when an error
+// occurs during resource operations, such as when applying, updating, or patching a resource.
+func WithCustomErrorMsg(args ...interface{}) ResourceOpts {
+	return func(ro *ResourceOptions) {
+		ro.CustomErrorArgs = args
+	}
+}
+
+// WithEventuallyTimeout sets the default timeout for Eventually assertions.
+func WithEventuallyTimeout(value time.Duration) ResourceOpts {
+	return func(ro *ResourceOptions) {
+		ro.tc.g.SetDefaultEventuallyTimeout(value)
+	}
+}
+
+// WithEventuallyPollingInterval sets the default polling interval for Eventually assertions.
+func WithEventuallyPollingInterval(value time.Duration) ResourceOpts {
+	return func(ro *ResourceOptions) {
+		ro.tc.g.SetDefaultEventuallyPollingInterval(value)
+	}
+}
+
+// WithConsistentlyDuration sets the default duration for Consistently assertions.
+func WithConsistentlyDuration(value time.Duration) ResourceOpts {
+	return func(ro *ResourceOptions) {
+		ro.tc.g.SetDefaultConsistentlyDuration(value)
+	}
+}
+
+// WithConsistentlyPollingInterval sets the default polling interval for Consistently assertions.
+func WithConsistentlyPollingInterval(value time.Duration) ResourceOpts {
+	return func(ro *ResourceOptions) {
+		ro.tc.g.SetDefaultConsistentlyPollingInterval(value)
+	}
+}

--- a/tests/e2e/trainingoperator_test.go
+++ b/tests/e2e/trainingoperator_test.go
@@ -8,23 +8,29 @@ import (
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/api/components/v1alpha1"
 )
 
+type TrainingOperatorTestCtx struct {
+	*ComponentTestCtx
+}
+
 func trainingOperatorTestSuite(t *testing.T) {
 	t.Helper()
 
-	ct, err := NewComponentTestCtx(&componentApi.TrainingOperator{})
+	ct, err := NewComponentTestCtx(t, &componentApi.TrainingOperator{})
 	require.NoError(t, err)
 
 	componentCtx := TrainingOperatorTestCtx{
 		ComponentTestCtx: ct,
 	}
 
-	t.Run("Validate component enabled", componentCtx.ValidateComponentEnabled)
-	t.Run("Validate operands have OwnerReferences", componentCtx.ValidateOperandsOwnerReferences)
-	t.Run("Validate update operand resources", componentCtx.ValidateUpdateDeploymentsResources)
-	t.Run("Validate component releases", componentCtx.ValidateComponentReleases)
-	t.Run("Validate component disabled", componentCtx.ValidateComponentDisabled)
-}
+	// Define test cases.
+	testCases := []TestCase{
+		{"Validate component enabled", componentCtx.ValidateComponentEnabled},
+		{"Validate operands have OwnerReferences", componentCtx.ValidateOperandsOwnerReferences},
+		{"Validate update operand resources", componentCtx.ValidateUpdateDeploymentsResources},
+		{"Validate component releases", componentCtx.ValidateComponentReleases},
+		{"Validate component disabled", componentCtx.ValidateComponentDisabled},
+	}
 
-type TrainingOperatorTestCtx struct {
-	*ComponentTestCtx
+	// Run the test suite.
+	componentCtx.RunTestCases(t, testCases)
 }

--- a/tests/e2e/workbenches_test.go
+++ b/tests/e2e/workbenches_test.go
@@ -1,324 +1,38 @@
 package e2e_test
 
 import (
-	"context"
-	"errors"
-	"fmt"
-	"reflect"
-	"strings"
 	"testing"
-	"time"
 
-	operatorv1 "github.com/openshift/api/operator/v1"
 	"github.com/stretchr/testify/require"
-	autoscalingv1 "k8s.io/api/autoscaling/v1"
-	k8serr "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/client-go/util/retry"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/api/components/v1alpha1"
-	dscv1 "github.com/opendatahub-io/opendatahub-operator/v2/api/datasciencecluster/v1"
-	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/components/workbenches"
-	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
-	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/metadata/labels"
 )
 
 type WorkbenchesTestCtx struct {
-	testCtx                 *testContext
-	testWorkbenchesInstance componentApi.Workbenches
+	*ComponentTestCtx
 }
 
 func workbenchesTestSuite(t *testing.T) {
 	t.Helper()
 
-	workbenchesCtx := WorkbenchesTestCtx{}
-	var err error
-	workbenchesCtx.testCtx, err = NewTestContext()
+	ct, err := NewComponentTestCtx(t, &componentApi.Workbenches{})
 	require.NoError(t, err)
 
-	testCtx := workbenchesCtx.testCtx
-
-	t.Run(testCtx.testDsc.Name, func(t *testing.T) {
-		t.Run("Creation of Workbenches CR", func(t *testing.T) {
-			err = workbenchesCtx.testWorkbenchesCreation()
-			require.NoError(t, err, "error creating Workbenches CR")
-		})
-
-		t.Run("Validate Workbenches instance", func(t *testing.T) {
-			err = workbenchesCtx.validateWorkbenches()
-			require.NoError(t, err, "error validating Workbenches instance")
-		})
-
-		t.Run("Validate Ownerreferences exist", func(t *testing.T) {
-			err = workbenchesCtx.testOwnerReferences()
-			require.NoError(t, err, "error getting all Workbenches's Ownerreferences")
-		})
-
-		t.Run("Validate Workbenches Ready", func(t *testing.T) {
-			err = workbenchesCtx.validateWorkbenchesReady()
-			require.NoError(t, err, "Workbenches instance is not Ready")
-		})
-
-		// reconcile
-		t.Run("Validate Controller reconcile", func(t *testing.T) {
-			err = workbenchesCtx.testUpdateOnWorkbenchesResources()
-			require.NoError(t, err, "error testing updates for Workbenches' managed resources")
-		})
-
-		t.Run("Validate Disabling Component", func(t *testing.T) {
-			err = workbenchesCtx.testUpdateWorkbenchesComponentDisabled()
-			require.NoError(t, err, "error testing component enabled field")
-		})
-	})
-}
-
-func (tc *WorkbenchesTestCtx) testWorkbenchesCreation() error {
-	err := tc.testCtx.wait(func(ctx context.Context) (bool, error) {
-		key := client.ObjectKeyFromObject(tc.testCtx.testDsc)
-
-		err := tc.testCtx.customClient.Get(ctx, key, tc.testCtx.testDsc)
-		if err != nil {
-			return false, fmt.Errorf("error getting resource %w", err)
-		}
-
-		tc.testCtx.testDsc.Spec.Components.Workbenches.ManagementState = operatorv1.Managed
-
-		switch err = tc.testCtx.customClient.Update(ctx, tc.testCtx.testDsc); {
-		case err == nil:
-			return true, nil
-		case k8serr.IsConflict(err):
-			return false, nil
-		default:
-			return false, fmt.Errorf("error updating resource %w", err)
-		}
-	})
-	if err != nil {
-		return fmt.Errorf("error after retry %w", err)
+	componentCtx := WorkbenchesTestCtx{
+		ComponentTestCtx: ct,
 	}
 
-	err = tc.testCtx.wait(func(ctx context.Context) (bool, error) {
-		existingWorkbenchesList := &componentApi.WorkbenchesList{}
+	require.NoError(t, err)
 
-		err := tc.testCtx.customClient.List(ctx, existingWorkbenchesList)
-		if err != nil {
-			return false, err
-		}
-
-		switch {
-		case len(existingWorkbenchesList.Items) == 1:
-			tc.testWorkbenchesInstance = existingWorkbenchesList.Items[0]
-			return true, nil
-
-		case len(existingWorkbenchesList.Items) > 1:
-			return false, fmt.Errorf(
-				"unexpected Workbenches CR instances. Expected 1 , Found %v instance", len(existingWorkbenchesList.Items))
-		default:
-			return false, nil
-		}
-	})
-
-	if err != nil {
-		return fmt.Errorf("unable to find Workbenches CR instance: %w", err)
+	// Define test cases.
+	testCases := []TestCase{
+		{"Validate component enabled", componentCtx.ValidateComponentEnabled},
+		{"Validate operands have OwnerReferences", componentCtx.ValidateOperandsOwnerReferences},
+		{"Validate update operand resources", componentCtx.ValidateUpdateDeploymentsResources},
+		{"Validate component releases", componentCtx.ValidateComponentReleases},
+		{"Validate component disabled", componentCtx.ValidateComponentDisabled},
 	}
 
-	return nil
-}
-
-func (tc *WorkbenchesTestCtx) validateWorkbenches() error {
-	// Workbenches spec should match the spec of Workbenches component in DSC
-	if !reflect.DeepEqual(tc.testCtx.testDsc.Spec.Components.Workbenches.WorkbenchesCommonSpec, tc.testWorkbenchesInstance.Spec.WorkbenchesCommonSpec) {
-		err := fmt.Errorf("expected spec for Workbenches %v, got %v",
-			tc.testCtx.testDsc.Spec.Components.Workbenches.WorkbenchesCommonSpec, tc.testWorkbenchesInstance.Spec.WorkbenchesCommonSpec)
-		return err
-	}
-	return nil
-}
-
-func (tc *WorkbenchesTestCtx) testOwnerReferences() error {
-	if len(tc.testWorkbenchesInstance.OwnerReferences) != 1 {
-		return errors.New("expect CR has ownerreferences set")
-	}
-
-	// Test Workbenches CR ownerref
-	if tc.testWorkbenchesInstance.OwnerReferences[0].Kind != dscKind {
-		return fmt.Errorf("expected ownerreference DataScienceCluster not found. Got ownerreferrence: %v",
-			tc.testWorkbenchesInstance.OwnerReferences[0].Kind)
-	}
-
-	// Test Workbenches resources
-
-	appDeployments, err := tc.testCtx.kubeClient.AppsV1().Deployments(tc.testCtx.applicationsNamespace).List(tc.testCtx.ctx, metav1.ListOptions{
-		LabelSelector: labels.PlatformPartOf + "=" + strings.ToLower(gvk.Workbenches.Kind),
-	})
-	if err != nil {
-		return fmt.Errorf("error listing component deployments %w", err)
-	}
-	// test any one deployment for ownerreference
-	if len(appDeployments.Items) != 0 && appDeployments.Items[0].OwnerReferences[0].Kind != componentApi.WorkbenchesKind {
-		return fmt.Errorf("expected ownerreference not found. Got ownerreferrence: %v",
-			appDeployments.Items[0].OwnerReferences)
-	}
-
-	return nil
-}
-
-// Verify Workbenches instance is in Ready phase when Workbenches deployments are up and running.
-func (tc *WorkbenchesTestCtx) validateWorkbenchesReady() error {
-	err := wait.PollUntilContextTimeout(tc.testCtx.ctx, generalRetryInterval, componentReadyTimeout, true, func(ctx context.Context) (bool, error) {
-		key := types.NamespacedName{Name: tc.testWorkbenchesInstance.Name}
-		wb := &componentApi.Workbenches{}
-
-		err := tc.testCtx.customClient.Get(ctx, key, wb)
-		if err != nil {
-			return false, err
-		}
-		return wb.Status.Phase == readyStatus, nil
-	})
-
-	if err != nil {
-		return fmt.Errorf("error waiting on Ready state for Workbenches %v: %w", tc.testWorkbenchesInstance.Name, err)
-	}
-
-	err = wait.PollUntilContextTimeout(tc.testCtx.ctx, generalRetryInterval, componentReadyTimeout, true, func(ctx context.Context) (bool, error) {
-		list := dscv1.DataScienceClusterList{}
-		err := tc.testCtx.customClient.List(ctx, &list)
-		if err != nil {
-			return false, err
-		}
-
-		if len(list.Items) != 1 {
-			return false, fmt.Errorf("expected 1 DataScience Cluster CR but found %v", len(list.Items))
-		}
-
-		for _, c := range list.Items[0].Status.Conditions {
-			if c.Type == workbenches.ReadyConditionType {
-				return c.Status == metav1.ConditionTrue, nil
-			}
-		}
-
-		return false, nil
-	})
-
-	if err != nil {
-		return fmt.Errorf("error waiting on Ready state for Workbenches component in DSC: %w", err)
-	}
-
-	return nil
-}
-
-func (tc *WorkbenchesTestCtx) testUpdateOnWorkbenchesResources() error {
-	appDeployments, err := tc.testCtx.kubeClient.AppsV1().Deployments(tc.testCtx.applicationsNamespace).List(tc.testCtx.ctx, metav1.ListOptions{
-		LabelSelector: labels.PlatformPartOf + "=" + strings.ToLower(tc.testWorkbenchesInstance.Kind),
-	})
-	if err != nil {
-		return err
-	}
-
-	// expects odh-notebook-controller-manager and notebook-controller-deployment deployments
-	if len(appDeployments.Items) != 2 {
-		return fmt.Errorf("error getting deployment for component %s", tc.testWorkbenchesInstance.Name)
-	}
-
-	const expectedReplica int32 = 2
-
-	testDeployment := appDeployments.Items[0]
-	patchedReplica := &autoscalingv1.Scale{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      testDeployment.Name,
-			Namespace: testDeployment.Namespace,
-		},
-		Spec: autoscalingv1.ScaleSpec{
-			Replicas: expectedReplica,
-		},
-		Status: autoscalingv1.ScaleStatus{},
-	}
-	updatedDep, err := tc.testCtx.kubeClient.AppsV1().Deployments(tc.testCtx.applicationsNamespace).UpdateScale(tc.testCtx.ctx,
-		testDeployment.Name, patchedReplica, metav1.UpdateOptions{})
-	if err != nil {
-		return fmt.Errorf("error patching component resources : %w", err)
-	}
-	if updatedDep.Spec.Replicas != patchedReplica.Spec.Replicas {
-		return fmt.Errorf("failed to patch replicas : expect to be %v but got %v", patchedReplica.Spec.Replicas, updatedDep.Spec.Replicas)
-	}
-
-	// Sleep for 40 seconds to allow the operator to reconcile
-	// we expect it should not revert back to original value because of AllowList
-	time.Sleep(4 * generalRetryInterval)
-	reconciledDep, err := tc.testCtx.kubeClient.AppsV1().Deployments(tc.testCtx.applicationsNamespace).Get(tc.testCtx.ctx, testDeployment.Name, metav1.GetOptions{})
-	if err != nil {
-		return fmt.Errorf("error getting component resource after reconcile: %w", err)
-	}
-	if *reconciledDep.Spec.Replicas != expectedReplica {
-		return fmt.Errorf("failed to revert back replicas : expect to be %v but got %v", expectedReplica, *reconciledDep.Spec.Replicas)
-	}
-
-	return nil
-}
-
-func (tc *WorkbenchesTestCtx) testUpdateWorkbenchesComponentDisabled() error {
-	if tc.testCtx.testDsc.Spec.Components.Workbenches.ManagementState != operatorv1.Managed {
-		return errors.New("the Workbenches spec should be in 'enabled: true' state in order to perform test")
-	}
-
-	deployments, err := tc.testCtx.getComponentDeployments(gvk.Workbenches)
-	if err != nil {
-		return fmt.Errorf("error getting enabled component %s", componentApi.WorkbenchesComponentName)
-	}
-
-	for _, d := range deployments {
-		if d.Status.ReadyReplicas == 0 {
-			return fmt.Errorf("component %s deployment %sis not ready", d.Name, componentApi.WorkbenchesComponentName)
-		}
-	}
-
-	// Disable component Workbenches
-	err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		// refresh the instance in case it was updated during the reconcile
-		err := tc.testCtx.customClient.Get(tc.testCtx.ctx, types.NamespacedName{Name: tc.testCtx.testDsc.Name}, tc.testCtx.testDsc)
-		if err != nil {
-			return fmt.Errorf("error getting resource %w", err)
-		}
-		// Disable the Component
-		tc.testCtx.testDsc.Spec.Components.Workbenches.ManagementState = operatorv1.Removed
-
-		// Try to update
-		err = tc.testCtx.customClient.Update(tc.testCtx.ctx, tc.testCtx.testDsc)
-		// Return err itself here (not wrapped inside another error)
-		// so that RetryOnConflict can identify it correctly.
-		if err != nil {
-			return fmt.Errorf("error updating component from 'enabled: true' to 'enabled: false': %w", err)
-		}
-
-		return nil
-	})
-	if err != nil {
-		return fmt.Errorf("error after retry %w", err)
-	}
-
-	err = tc.testCtx.wait(func(ctx context.Context) (bool, error) {
-		// Verify Workbenches CR is deleted
-		wb := &componentApi.Workbenches{}
-		err = tc.testCtx.customClient.Get(ctx, client.ObjectKey{Name: tc.testWorkbenchesInstance.Name}, wb)
-		return k8serr.IsNotFound(err), nil
-	})
-
-	if err != nil {
-		return fmt.Errorf("component %v is disabled, should not get the Workbenches CR %v", tc.testWorkbenchesInstance.Name, tc.testWorkbenchesInstance.Name)
-	}
-
-	deployments, err = tc.testCtx.getComponentDeployments(gvk.Workbenches)
-	if err != nil {
-		return fmt.Errorf("error listing deployments: %w", err)
-	}
-
-	if len(deployments) != 0 {
-		return fmt.Errorf("component %v is disabled, should not have deployments in NS %v any more",
-			gvk.Workbenches.Kind,
-			tc.testCtx.applicationsNamespace)
-	}
-
-	return nil
+	// Run the test suite.
+	componentCtx.RunTestCases(t, testCases)
 }


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->
[RHOAIENG-20490](https://issues.redhat.com/browse/RHOAIENG-20490)

## Description
<!--- Describe your changes in detail -->
The current E2E tests can be optimized to reduce redundancy, improve consistency, and enhance debugging. This task involves:

- Using Gomega’s matchers properly for better readability.
- Extracting common logic into reusable helper functions.
- Ensuring stable and efficient resource handling with Eventually.
- Standardizing constants for namespaces and operators.
- Implementing the `Options` pattern through `ResourceOptions` to configure test resources in a flexible and extensible way, improving test maintainability and readability.

This PR introduces new and improved configuration flags for the E2E test suite:

#### 🔧 New Flags

- `--deletion-policy=always|on-failure|never`  
  Controls when `DataScienceCluster`, `DSCInitialization`, and related controller resources are deleted:
  - `always`: Run deletion logic after tests, regardless of success/failure.
  - `on-failure`: Only run cleanup if tests fail.
  - `never`: Skip all deletion steps.

- `--applications-namespace=<namespace>`  
  Allows specifying the namespace where ODH applications are deployed (default is `opendatahub`).

#### ✅ Replaced

- Deprecated `--skip-deletion` and `--delete-on-failure` (introduced before by this PR) in favor of the unified and clearer `--deletion-policy` flag.

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
When running the tests with the following command:
```
make e2e-test E2E_TEST_FLAGS='-timeout 25m --applications-namespace=opendatahub --test-operator-controller=false --test-webhook=false --test-component=trustyai --test-service=!auth --delete-on-failure=true'
```

if an issue occurs during the test, the output is as follows:
```
go test ./tests/e2e/ -run ^TestOdhOperator -v --operator-namespace=opendatahub-operator-system -timeout 25m --applications-namespace=opendatahub --test-operator-controller=false --test-webhook=false --test-component=trustyai --test-service=!auth --delete-on-failure=true
=== RUN   TestOdhOperator
=== RUN   TestOdhOperator/DSCInitialization_and_DataScienceCluster_management_E2E_Tests
=== RUN   TestOdhOperator/DSCInitialization_and_DataScienceCluster_management_E2E_Tests/Ensure_Service_Mesh_and_Serverless_operators_are_installed
=== RUN   TestOdhOperator/DSCInitialization_and_DataScienceCluster_management_E2E_Tests/Ensure_Service_Mesh_and_Serverless_operators_are_installed/Ensure_openshift-operators/servicemeshoperator_Operator_is_installed
=== PAUSE TestOdhOperator/DSCInitialization_and_DataScienceCluster_management_E2E_Tests/Ensure_Service_Mesh_and_Serverless_operators_are_installed/Ensure_openshift-operators/servicemeshoperator_Operator_is_installed
=== RUN   TestOdhOperator/DSCInitialization_and_DataScienceCluster_management_E2E_Tests/Ensure_Service_Mesh_and_Serverless_operators_are_installed/Ensure_openshift-serverless/serverless-operator_Operator_is_installed
=== PAUSE TestOdhOperator/DSCInitialization_and_DataScienceCluster_management_E2E_Tests/Ensure_Service_Mesh_and_Serverless_operators_are_installed/Ensure_openshift-serverless/serverless-operator_Operator_is_installed
=== CONT  TestOdhOperator/DSCInitialization_and_DataScienceCluster_management_E2E_Tests/Ensure_Service_Mesh_and_Serverless_operators_are_installed/Ensure_openshift-operators/servicemeshoperator_Operator_is_installed
=== CONT  TestOdhOperator/DSCInitialization_and_DataScienceCluster_management_E2E_Tests/Ensure_Service_Mesh_and_Serverless_operators_are_installed/Ensure_openshift-serverless/serverless-operator_Operator_is_installed
=== RUN   TestOdhOperator/DSCInitialization_and_DataScienceCluster_management_E2E_Tests/Validate_creation_of_DSCInitialization_instance
=== RUN   TestOdhOperator/DSCInitialization_and_DataScienceCluster_management_E2E_Tests/Validate_creation_of_DataScienceCluster_instance
=== RUN   TestOdhOperator/DSCInitialization_and_DataScienceCluster_management_E2E_Tests/Validate_ServiceMeshSpec_in_DSCInitialization_instance
=== RUN   TestOdhOperator/DSCInitialization_and_DataScienceCluster_management_E2E_Tests/Validate_Knative_resource
=== RUN   TestOdhOperator/DSCInitialization_and_DataScienceCluster_management_E2E_Tests/Validate_owned_namespaces_exist
=== RUN   TestOdhOperator/components
    controller_test.go:313: Skipping tests for components/codeflare
    controller_test.go:313: Skipping tests for components/kserve
    controller_test.go:313: Skipping tests for components/modelmeshserving
    controller_test.go:313: Skipping tests for components/dashboard
    controller_test.go:313: Skipping tests for components/datasciencepipelines
=== RUN   TestOdhOperator/components/trustyai
=== RUN   TestOdhOperator/components/trustyai/Enable_Kserve
=== NAME  TestOdhOperator/components/trustyai
    helper_test.go:288:
        Timed out after 120.001s.
        The function passed to Eventually failed at /Users/ugogiordano/workdir/rhoai/opendatahub-io/opendatahub-operator/tests/e2e/helper_test.go:1560 with:
        Expected resource 'default-kserve' of kind 'Kserve' to match condition {.status.conditions[] | select(.type == "Ready") | .status == "True" []}.
        cannot iterate over: null
=== NAME  TestOdhOperator/components/trustyai/Enable_Kserve
    testing.go:1577: test executed panic(nil) or runtime.Goexit: subtest may have called FailNow on a parent test
=== NAME  TestOdhOperator/components
    controller_test.go:313: Skipping tests for components/kueue
    controller_test.go:313: Skipping tests for components/trainingoperator
    controller_test.go:313: Skipping tests for components/workbenches
    controller_test.go:313: Skipping tests for components/modelcontroller
    controller_test.go:313: Skipping tests for components/feastoperator
    controller_test.go:313: Skipping tests for components/ray
    controller_test.go:313: Skipping tests for components/modelregistry
=== RUN   TestOdhOperator/services
=== RUN   TestOdhOperator/services/monitoring
    controller_test.go:317: Monitoring ManagementState is 'Removed', skipping all monitoring-related tests.
=== NAME  TestOdhOperator/services
    controller_test.go:313: Skipping tests for services/auth
=== RUN   TestOdhOperator/trustyAITestSuite
=== RUN   TestOdhOperator/trustyAITestSuite/Enable_Kserve
=== NAME  TestOdhOperator/trustyAITestSuite
    helper_test.go:288:
        Timed out after 120.001s.
        The function passed to Eventually failed at /Users/ugogiordano/workdir/rhoai/opendatahub-io/opendatahub-operator/tests/e2e/helper_test.go:1560 with:
        Expected resource 'default-kserve' of kind 'Kserve' to match condition {.status.conditions[] | select(.type == "Ready") | .status == "True" []}.
        cannot iterate over: null
=== NAME  TestOdhOperator/trustyAITestSuite/Enable_Kserve
    testing.go:1577: test executed panic(nil) or runtime.Goexit: subtest may have called FailNow on a parent test
=== NAME  TestOdhOperator
    controller_test.go:223: Cleaning up DataScienceCluster
    controller_test.go:223: Cleaning up DSCInitialization
--- FAIL: TestOdhOperator (280.53s)
    --- PASS: TestOdhOperator/DSCInitialization_and_DataScienceCluster_management_E2E_Tests (37.20s)
        --- PASS: TestOdhOperator/DSCInitialization_and_DataScienceCluster_management_E2E_Tests/Ensure_Service_Mesh_and_Serverless_operators_are_installed (0.00s)
            --- PASS: TestOdhOperator/DSCInitialization_and_DataScienceCluster_management_E2E_Tests/Ensure_Service_Mesh_and_Serverless_operators_are_installed/Ensure_openshift-operators/servicemeshoperator_Operator_is_installed (2.80s)
            --- PASS: TestOdhOperator/DSCInitialization_and_DataScienceCluster_management_E2E_Tests/Ensure_Service_Mesh_and_Serverless_operators_are_installed/Ensure_openshift-serverless/serverless-operator_Operator_is_installed (2.80s)
        --- PASS: TestOdhOperator/DSCInitialization_and_DataScienceCluster_management_E2E_Tests/Validate_creation_of_DSCInitialization_instance (31.15s)
        --- PASS: TestOdhOperator/DSCInitialization_and_DataScienceCluster_management_E2E_Tests/Validate_creation_of_DataScienceCluster_instance (2.75s)
        --- PASS: TestOdhOperator/DSCInitialization_and_DataScienceCluster_management_E2E_Tests/Validate_ServiceMeshSpec_in_DSCInitialization_instance (0.16s)
        --- PASS: TestOdhOperator/DSCInitialization_and_DataScienceCluster_management_E2E_Tests/Validate_Knative_resource (0.17s)
        --- PASS: TestOdhOperator/DSCInitialization_and_DataScienceCluster_management_E2E_Tests/Validate_owned_namespaces_exist (0.16s)
    --- FAIL: TestOdhOperator/components (120.59s)
        --- FAIL: TestOdhOperator/components/trustyai (120.59s)
            --- FAIL: TestOdhOperator/components/trustyai/Enable_Kserve (120.57s)
    --- PASS: TestOdhOperator/services (0.35s)
        --- SKIP: TestOdhOperator/services/monitoring (0.35s)
    --- FAIL: TestOdhOperator/trustyAITestSuite (121.25s)
        --- FAIL: TestOdhOperator/trustyAITestSuite/Enable_Kserve (121.21s)
FAIL
FAIL	github.com/opendatahub-io/opendatahub-operator/v2/tests/e2e	281.621s
FAIL
make: *** [e2e-test] Error 1
```


## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
