### PR TITLE
feat: add REGISTRIES_NAMESPACE param for model registry, fixes RHOAIENG-21660

### DIFF
--- a/controllers/components/modelregistry/modelregistry_controller.go
+++ b/controllers/components/modelregistry/modelregistry_controller.go
@@ -78,6 +78,7 @@ func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.
 		WatchesGVK(gvk.ServiceMeshMember, reconciler.Dynamic()).
 		WithAction(checkPreConditions).
 		WithAction(initialize).
+		WithAction(customizeManifests).
 		WithAction(releases.NewAction()).
 		WithAction(configureDependencies).
 		WithAction(template.NewAction(

--- a/controllers/components/modelregistry/modelregistry_controller_actions.go
+++ b/controllers/components/modelregistry/modelregistry_controller_actions.go
@@ -58,6 +58,14 @@ func initialize(ctx context.Context, rr *odhtypes.ReconciliationRequest) error {
 		return fmt.Errorf("resource instance %v is not a componentApi.ModelRegistry)", rr.Instance)
 	}
 
+	// update registries namespace in manifests
+	mi := baseManifestInfo(BaseManifestsSourcePath)
+	if err := odhdeploy.ApplyParams(mi.String(), nil, map[string]string{
+		"REGISTRIES_NAMESPACE": mr.Spec.RegistriesNamespace,
+	}); err != nil {
+		return fmt.Errorf("failed to update params on path %s: %w", mi, err)
+	}
+
 	rr.Manifests = []odhtypes.ManifestInfo{
 		baseManifestInfo(BaseManifestsSourcePath),
 		extraManifestInfo(BaseManifestsSourcePath),

--- a/controllers/components/modelregistry/modelregistry_controller_actions.go
+++ b/controllers/components/modelregistry/modelregistry_controller_actions.go
@@ -58,14 +58,6 @@ func initialize(ctx context.Context, rr *odhtypes.ReconciliationRequest) error {
 		return fmt.Errorf("resource instance %v is not a componentApi.ModelRegistry)", rr.Instance)
 	}
 
-	// update registries namespace in manifests
-	mi := baseManifestInfo(BaseManifestsSourcePath)
-	if err := odhdeploy.ApplyParams(mi.String(), nil, map[string]string{
-		"REGISTRIES_NAMESPACE": mr.Spec.RegistriesNamespace,
-	}); err != nil {
-		return fmt.Errorf("failed to update params on path %s: %w", mi, err)
-	}
-
 	rr.Manifests = []odhtypes.ManifestInfo{
 		baseManifestInfo(BaseManifestsSourcePath),
 		extraManifestInfo(BaseManifestsSourcePath),
@@ -99,6 +91,21 @@ func initialize(ctx context.Context, rr *odhtypes.ReconciliationRequest) error {
 		}
 	}
 
+	return nil
+}
+
+func customizeManifests(ctx context.Context, rr *odhtypes.ReconciliationRequest) error {
+	mr, ok := rr.Instance.(*componentApi.ModelRegistry)
+	if !ok {
+		return fmt.Errorf("resource instance %v is not a componentApi.ModelRegistry)", rr.Instance)
+	}
+
+	// update registries namespace in manifests
+	if err := odhdeploy.ApplyParams(rr.Manifests[0].String(), nil, map[string]string{
+		"REGISTRIES_NAMESPACE": mr.Spec.RegistriesNamespace,
+	}); err != nil {
+		return fmt.Errorf("failed to update params on path %s: %w", rr.Manifests[0].String(), err)
+	}
 	return nil
 }
 


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->
Add REGISTRIES_NAMESPACE param for model registry in modelregistry_controller_actions.go initialize() function
This param is used by model registry operator in a validation webhook to ensure model registry instances cannot be created outside the configured namespace per RHOAIENG-20962
Fixes RHOAIENG-21660

<!--- Link your JIRA and related links here for reference. -->
https://issues.redhat.com/browse/RHOAIENG-21660

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
All existing tests should pass

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [X] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [X] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work