### PR TITLE
[sync]fix: add missing port in the podmointor (#1743)

### DIFF
--- a/controllers/dscinitialization/resources/metrics-collection/envoy-metrics-collection.tmpl.yaml
+++ b/controllers/dscinitialization/resources/metrics-collection/envoy-metrics-collection.tmpl.yaml
@@ -10,4 +10,6 @@ spec:
       operator: DoesNotExist
   podMetricsEndpoints:
   - path: /stats/prometheus
+    port: http-envoy-prom # 15090 for both ingress and egress
+    scheme: http
     interval: 30s


### PR DESCRIPTION
- both ingress and egress is using this name
- explicility set to http as default one

Signed-off-by: Wen Zhou <wenzhou@redhat.com>
(cherry picked from commit 015c546da3569dd75d1dcf366e88684546170b82)

<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->
sync https://github.com/opendatahub-io/opendatahub-operator/pull/1743

<!--- Link your JIRA and related links here for reference. -->
ref https://issues.redhat.com/browse/RHOAIENG-20131

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
