### PR TITLE
Refactor the gc action/service

### DIFF
--- a/controllers/datasciencecluster/datasciencecluster_controller_actions.go
+++ b/controllers/datasciencecluster/datasciencecluster_controller_actions.go
@@ -17,7 +17,7 @@ import (
 )
 
 const (
-	//TODO: remove after https://issues.redhat.com/browse/RHOAIENG-15920
+	// TODO: remove after https://issues.redhat.com/browse/RHOAIENG-15920
 	finalizerName = "datasciencecluster.opendatahub.io/finalizer"
 )
 
@@ -31,7 +31,7 @@ func initialize(ctx context.Context, rr *odhtype.ReconciliationRequest) error {
 		instance.Status.InstalledComponents = make(map[string]bool)
 	}
 
-	//TODO: remove after https://issues.redhat.com/browse/RHOAIENG-15920
+	// TODO: remove after https://issues.redhat.com/browse/RHOAIENG-15920
 	if controllerutil.RemoveFinalizer(instance, finalizerName) {
 		if err := rr.Client.Update(ctx, instance); err != nil {
 			return err

--- a/main.go
+++ b/main.go
@@ -80,7 +80,6 @@ import (
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/logger"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/metadata/labels"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/resources"
-	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/services/gc"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/upgrade"
 
 	_ "github.com/opendatahub-io/opendatahub-operator/v2/controllers/components/codeflare"
@@ -322,18 +321,6 @@ func main() { //nolint:funlen,maintidx,gocyclo
 		os.Exit(1)
 	}
 
-	ons, err := cluster.GetOperatorNamespace()
-	if err != nil {
-		setupLog.Error(err, "unable to determine Operator Namespace")
-		os.Exit(1)
-	}
-
-	gc.Instance = gc.New(
-		oc,
-		ons,
-		gc.WithUnremovables(gvk.CustomResourceDefinition, gvk.Lease),
-	)
-
 	if err = (&dscictrl.DSCInitializationReconciler{
 		Client:   oc,
 		Scheme:   mgr.GetScheme(),
@@ -368,12 +355,6 @@ func main() { //nolint:funlen,maintidx,gocyclo
 		Scheme: mgr.GetScheme(),
 	}).SetupWithManager(ctx, mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "CertConfigmapGenerator")
-		os.Exit(1)
-	}
-
-	err = mgr.Add(gc.Instance)
-	if err != nil {
-		setupLog.Error(err, "unable to register GC service")
 		os.Exit(1)
 	}
 

--- a/pkg/controller/actions/actions_support.go
+++ b/pkg/controller/actions/actions_support.go
@@ -1,0 +1,21 @@
+package actions
+
+import (
+	"context"
+
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
+	odhTypes "github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
+)
+
+func ApplicationNamespace(_ context.Context, rr *odhTypes.ReconciliationRequest) (string, error) {
+	return rr.DSCI.Spec.ApplicationsNamespace, nil
+}
+
+func OperatorNamespace(_ context.Context, _ *odhTypes.ReconciliationRequest) (string, error) {
+	ns, err := cluster.GetOperatorNamespace()
+	if err != nil {
+		return "", err
+	}
+
+	return ns, nil
+}

--- a/pkg/controller/actions/gc/engine/gc_engine_support.go
+++ b/pkg/controller/actions/gc/engine/gc_engine_support.go
@@ -1,4 +1,4 @@
-package gc
+package engine
 
 import (
 	"slices"

--- a/pkg/controller/actions/gc/engine/gc_engine_test.go
+++ b/pkg/controller/actions/gc/engine/gc_engine_test.go
@@ -1,4 +1,4 @@
-package gc_test
+package engine_test
 
 import (
 	"testing"
@@ -7,7 +7,7 @@ import (
 	authorizationv1 "k8s.io/api/authorization/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/services/gc"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/gc/engine"
 
 	. "github.com/onsi/gomega"
 )
@@ -18,9 +18,9 @@ func allVerb() []string {
 
 func anyRule() authorizationv1.ResourceRule {
 	return authorizationv1.ResourceRule{
-		Verbs:     []string{gc.AnyVerb},
-		APIGroups: []string{gc.AnyVerb},
-		Resources: []string{gc.AnyVerb},
+		Verbs:     []string{engine.AnyVerb},
+		APIGroups: []string{engine.AnyVerb},
+		Resources: []string{engine.AnyVerb},
 	}
 }
 
@@ -52,7 +52,7 @@ func TestMatchRules(t *testing.T) {
 				Name: "baz",
 			},
 			rule: authorizationv1.ResourceRule{
-				APIGroups: []string{gc.AnyResource},
+				APIGroups: []string{engine.AnyResource},
 				Resources: []string{"baz"},
 			},
 			matcher: BeTrue(),
@@ -87,7 +87,7 @@ func TestMatchRules(t *testing.T) {
 			g := NewWithT(t)
 
 			g.Expect(
-				gc.MatchRule(
+				engine.MatchRule(
 					test.resourceGroup,
 					test.apiResource,
 					test.rule,

--- a/pkg/controller/actions/status/deployments/action_deployments_available.go
+++ b/pkg/controller/actions/status/deployments/action_deployments_available.go
@@ -117,10 +117,8 @@ func (a *Action) run(ctx context.Context, rr *types.ReconciliationRequest) error
 
 func NewAction(opts ...ActionOpts) actions.Fn {
 	action := Action{
-		labels: map[string]string{},
-		namespaceFn: func(ctx context.Context, rr *types.ReconciliationRequest) (string, error) {
-			return rr.DSCI.Spec.ApplicationsNamespace, nil
-		},
+		labels:      map[string]string{},
+		namespaceFn: actions.ApplicationNamespace,
 	}
 
 	for _, opt := range opts {


### PR DESCRIPTION
The original GC action/service was designed under the assumption that
all Kubernetes resource types the operator manages were known at
startup and remained unchanged over time. As a result, a single GC
service was shared across multiple GC actions.

However, with the removal of feature trackers and the need of dynamic
dependencies (e.g., Serverless, Service Mesh), this static resource
list assumption is no longer valid.

To address this, the shared GC service has been removed, and the GC
engine is now integrated directly within each GC action.

<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
