### PR TITLE
chore: update devFlags logic

### DIFF
--- a/controllers/components/codeflare/codeflare_controller.go
+++ b/controllers/components/codeflare/codeflare_controller.go
@@ -64,7 +64,6 @@ func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.
 				component.ForLabel(labels.ODH.Component(LegacyComponentName), labels.True)),
 		).
 		WithAction(initialize).
-		WithAction(devFlags).
 		WithAction(releases.NewAction()).
 		WithAction(kustomize.NewAction(
 			kustomize.WithCache(),

--- a/controllers/components/codeflare/codeflare_controller_actions.go
+++ b/controllers/components/codeflare/codeflare_controller_actions.go
@@ -9,38 +9,36 @@ import (
 	odhdeploy "github.com/opendatahub-io/opendatahub-operator/v2/pkg/deploy"
 )
 
-func initialize(_ context.Context, rr *odhtypes.ReconciliationRequest) error {
-	rr.Manifests = append(rr.Manifests, manifestsPath())
-
-	if err := odhdeploy.ApplyParams(paramsPath, nil, map[string]string{"namespace": rr.DSCI.Spec.ApplicationsNamespace}); err != nil {
-		return fmt.Errorf("failed to update params.env from %s : %w", paramsPath, err)
-	}
-
-	return nil
-}
-
-func devFlags(ctx context.Context, rr *odhtypes.ReconciliationRequest) error {
+func initialize(ctx context.Context, rr *odhtypes.ReconciliationRequest) error {
 	codeflare, ok := rr.Instance.(*componentApi.CodeFlare)
 	if !ok {
 		return fmt.Errorf("resource instance %v is not a componentApi.CodeFlare)", rr.Instance)
 	}
 
-	if codeflare.Spec.DevFlags == nil {
-		return nil
-	}
+	rr.Manifests = append(rr.Manifests, manifestsPath())
+
 	// Implement devflags support logic
 	// If dev flags are set, update default manifests path
-	if len(codeflare.Spec.DevFlags.Manifests) != 0 {
-		manifestConfig := codeflare.Spec.DevFlags.Manifests[0]
-		if err := odhdeploy.DownloadManifests(ctx, ComponentName, manifestConfig); err != nil {
-			return err
-		}
-		if manifestConfig.SourcePath != "" {
-			rr.Manifests[0].Path = odhdeploy.DefaultManifestPath
-			rr.Manifests[0].ContextDir = ComponentName
-			rr.Manifests[0].SourcePath = manifestConfig.SourcePath
+	if codeflare.GetDevFlags() != nil {
+		if len(codeflare.Spec.DevFlags.Manifests) != 0 {
+			manifestConfig := codeflare.Spec.DevFlags.Manifests[0]
+			if err := odhdeploy.DownloadManifests(ctx, ComponentName, manifestConfig); err != nil {
+				return err
+			}
+			if manifestConfig.SourcePath != "" {
+				rr.Manifests[0].Path = odhdeploy.DefaultManifestPath
+				rr.Manifests[0].ContextDir = ComponentName
+				rr.Manifests[0].SourcePath = manifestConfig.SourcePath
+			}
 		}
 	}
 
+	if err := odhdeploy.ApplyParams(
+		paramsPath,
+		nil,
+		map[string]string{"namespace": rr.DSCI.Spec.ApplicationsNamespace},
+	); err != nil {
+		return fmt.Errorf("failed to update params.env from %s : %w", paramsPath, err)
+	}
 	return nil
 }

--- a/controllers/components/dashboard/dashboard_controller_actions.go
+++ b/controllers/components/dashboard/dashboard_controller_actions.go
@@ -33,7 +33,7 @@ func devFlags(ctx context.Context, rr *odhtypes.ReconciliationRequest) error {
 		return fmt.Errorf("resource instance %v is not a componentApi.Dashboard)", rr.Instance)
 	}
 
-	if dashboard.Spec.DevFlags == nil {
+	if dashboard.GetDevFlags() == nil {
 		return nil
 	}
 	// Implement devflags support logic

--- a/controllers/components/datasciencepipelines/datasciencepipelines_controller_actions.go
+++ b/controllers/components/datasciencepipelines/datasciencepipelines_controller_actions.go
@@ -80,7 +80,7 @@ func devFlags(ctx context.Context, rr *odhtypes.ReconciliationRequest) error {
 		return fmt.Errorf("resource instance %v is not a componentApi.DataSciencePipelines)", rr.Instance)
 	}
 
-	if dsp.Spec.DevFlags == nil {
+	if dsp.GetDevFlags() == nil {
 		return nil
 	}
 

--- a/controllers/components/feastoperator/feastoperator_controller_actions.go
+++ b/controllers/components/feastoperator/feastoperator_controller_actions.go
@@ -20,7 +20,7 @@ func devFlags(ctx context.Context, rr *odhtypes.ReconciliationRequest) error {
 		return fmt.Errorf("resource instance %v is not a componentApi.FeastOperator)", rr.Instance)
 	}
 
-	if feastoperator.Spec.DevFlags == nil {
+	if feastoperator.GetDevFlags() == nil {
 		return nil
 	}
 	if len(feastoperator.Spec.DevFlags.Manifests) != 0 {

--- a/controllers/components/kueue/kueue_controller_actions.go
+++ b/controllers/components/kueue/kueue_controller_actions.go
@@ -53,7 +53,7 @@ func devFlags(ctx context.Context, rr *odhtypes.ReconciliationRequest) error {
 		return fmt.Errorf("resource instance %v is not a componentApi.Kueue)", rr.Instance)
 	}
 
-	if kueue.Spec.DevFlags == nil {
+	if kueue.GetDevFlags() == nil {
 		return nil
 	}
 

--- a/controllers/components/modelcontroller/modelcontroller_actions.go
+++ b/controllers/components/modelcontroller/modelcontroller_actions.go
@@ -32,33 +32,7 @@ import (
 )
 
 func initialize(_ context.Context, rr *odhtypes.ReconciliationRequest) error {
-	// early exist
-	mc, ok := rr.Instance.(*componentApi.ModelController)
-	if !ok {
-		return fmt.Errorf("resource instance %v is not a componentApi.ModelController)", rr.Instance)
-	}
 	rr.Manifests = append(rr.Manifests, manifestsPath())
-
-	nimState := operatorv1.Removed
-	if mc.Spec.Kserve.ManagementState == operatorv1.Managed {
-		nimState = mc.Spec.Kserve.NIM.ManagementState
-	}
-
-	mrState := operatorv1.Removed
-	if mc.Spec.ModelRegistry != nil && mc.Spec.ModelRegistry.ManagementState == operatorv1.Managed {
-		mrState = operatorv1.Managed
-	}
-
-	extraParamsMap := map[string]string{
-		"nim-state":              strings.ToLower(string(nimState)),
-		"kserve-state":           strings.ToLower(string(mc.Spec.Kserve.ManagementState)),
-		"modelmeshserving-state": strings.ToLower(string(mc.Spec.ModelMeshServing.ManagementState)),
-		"modelregistry-state":    strings.ToLower(string(mrState)),
-	}
-	if err := odhdeploy.ApplyParams(rr.Manifests[0].String(), nil, extraParamsMap); err != nil {
-		return fmt.Errorf("failed to update images on path %s: %w", rr.Manifests[0].String(), err)
-	}
-
 	return nil
 }
 
@@ -104,6 +78,35 @@ func devFlags(ctx context.Context, rr *odhtypes.ReconciliationRequest) error {
 		}
 
 		break
+	}
+
+	return nil
+}
+
+func setKustomizedParams(ctx context.Context, rr *odhtypes.ReconciliationRequest) error {
+	// early exist
+	mc, ok := rr.Instance.(*componentApi.ModelController)
+	if !ok {
+		return fmt.Errorf("resource instance %v is not a componentApi.ModelController)", rr.Instance)
+	}
+	nimState := operatorv1.Removed
+	if mc.Spec.Kserve.ManagementState == operatorv1.Managed {
+		nimState = mc.Spec.Kserve.NIM.ManagementState
+	}
+
+	mrState := operatorv1.Removed
+	if mc.Spec.ModelRegistry != nil && mc.Spec.ModelRegistry.ManagementState == operatorv1.Managed {
+		mrState = operatorv1.Managed
+	}
+
+	extraParamsMap := map[string]string{
+		"nim-state":              strings.ToLower(string(nimState)),
+		"kserve-state":           strings.ToLower(string(mc.Spec.Kserve.ManagementState)),
+		"modelmeshserving-state": strings.ToLower(string(mc.Spec.ModelMeshServing.ManagementState)),
+		"modelregistry-state":    strings.ToLower(string(mrState)),
+	}
+	if err := odhdeploy.ApplyParams(rr.Manifests[0].String(), nil, extraParamsMap); err != nil {
+		return fmt.Errorf("failed to update images on path %s: %w", rr.Manifests[0].String(), err)
 	}
 
 	return nil

--- a/controllers/components/modelcontroller/modelcontroller_controller.go
+++ b/controllers/components/modelcontroller/modelcontroller_controller.go
@@ -68,6 +68,7 @@ func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.
 		).
 		WithAction(initialize).
 		WithAction(devFlags).
+		WithAction(setKustomizedParams).
 		WithAction(kustomize.NewAction(
 			kustomize.WithCache(),
 			kustomize.WithLabel(labels.ODH.Component(LegacyComponentName), labels.True),

--- a/controllers/components/ray/ray_controller.go
+++ b/controllers/components/ray/ray_controller.go
@@ -59,7 +59,6 @@ func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.
 				component.ForLabel(labels.ODH.Component(LegacyComponentName), labels.True)),
 		).
 		WithAction(initialize).
-		WithAction(devFlags).
 		WithAction(releases.NewAction()).
 		WithAction(kustomize.NewAction(
 			kustomize.WithCache(),

--- a/controllers/components/trainingoperator/trainingoperator_controller_actions.go
+++ b/controllers/components/trainingoperator/trainingoperator_controller_actions.go
@@ -36,7 +36,7 @@ func devFlags(ctx context.Context, rr *odhtypes.ReconciliationRequest) error {
 		return fmt.Errorf("resource instance %v is not a componentApi.TrainingOperator)", rr.Instance)
 	}
 
-	if trainingoperator.Spec.DevFlags == nil {
+	if trainingoperator.GetDevFlags() == nil {
 		return nil
 	}
 	if len(trainingoperator.Spec.DevFlags.Manifests) != 0 {

--- a/controllers/components/trustyai/trustyai_controller_actions.go
+++ b/controllers/components/trustyai/trustyai_controller_actions.go
@@ -53,7 +53,7 @@ func devFlags(ctx context.Context, rr *odhtypes.ReconciliationRequest) error {
 		return fmt.Errorf("resource instance %v is not a componentApi.TrustyAI)", rr.Instance)
 	}
 
-	if trustyai.Spec.DevFlags == nil {
+	if trustyai.GetDevFlags() == nil {
 		return nil
 	}
 

--- a/controllers/components/workbenches/workbenches_controller_actions.go
+++ b/controllers/components/workbenches/workbenches_controller_actions.go
@@ -31,7 +31,7 @@ func devFlags(ctx context.Context, rr *odhtypes.ReconciliationRequest) error {
 		return fmt.Errorf("resource instance %v is not a componentApi.Workbenches)", rr.Instance)
 	}
 
-	if workbenches.Spec.DevFlags == nil || len(workbenches.Spec.DevFlags.Manifests) == 0 {
+	if workbenches.GetDevFlags() == nil || len(workbenches.Spec.DevFlags.Manifests) == 0 {
 		return nil
 	}
 


### PR DESCRIPTION
- we should consider when user enable devFlags some parameters set need to be kept e.g namespaces past to params.env
-  deprecated som devflags(), move  into initialize() and set customized value after devFlag logic is called
- use GetDevFlags() instead

<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

follow up convesation from https://github.com/opendatahub-io/opendatahub-operator/pull/1744#discussion_r1995797419

## Description
<!--- Describe your changes in detail -->

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
