### PR TITLE
chore: Remove/replace deprecated linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -106,7 +106,8 @@ linters:
     - varnamelen # doesnot allow shorter names like c,k etc. But golang prefers short named vars.
     - wsl # [too strict and mostly code is not more readable] whitespace linter forces you to use empty lines
     - wrapcheck # check if this is required. Prevents direct return of err.
-    - exportloopref # Since Go1.22 (loopvar) this linter is no longer relevant. Replaced by copyloopvar.
+    - tenv # Duplicate feature in another linter. Replaced by usetesting.
+
 
     # Need to check
     - nlreturn # [too strict and mostly code is not more readable] checks for a new line before return and branch statements to increase code clarity

--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ YQ ?= $(LOCALBIN)/yq
 KUSTOMIZE_VERSION ?= v5.0.2
 CONTROLLER_GEN_VERSION ?= v0.16.1
 OPERATOR_SDK_VERSION ?= v1.31.0
-GOLANGCI_LINT_VERSION ?= v1.63.4
+GOLANGCI_LINT_VERSION ?= v1.64.7
 YQ_VERSION ?= v4.12.2
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.31.0

--- a/pkg/utils/test/testf/testf.go
+++ b/pkg/utils/test/testf/testf.go
@@ -50,7 +50,6 @@ func WithScheme(value *runtime.Scheme) TestContextOpt {
 	}
 }
 
-//nolint:fatcontext
 func WitContext(value context.Context) TestContextOpt {
 	return func(tc *testContextOpts) {
 		tc.ctx = value

--- a/pkg/utils/test/testf/testf_assertions.go
+++ b/pkg/utils/test/testf/testf_assertions.go
@@ -84,6 +84,7 @@ func (a *Assertion[T]) WithContext(ctx context.Context) *Assertion[T] {
 	return a
 }
 
+//nolint:ireturn
 func (a *Assertion[T]) build(f interface{}) gomega.AsyncAssertion {
 	var aa gomega.AsyncAssertion
 


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->
Fixes two warnings in the `lint` job:

```
WARN [lintersdb] The linter "exportloopref" is deprecated (step 2) and deactivated. It should be removed from the list of disabled linters. https://golangci-lint.run/product/roadmap/#linter-deprecation-cycle 
WARN The linter 'tenv' is deprecated (since v1.64.0) due to: Duplicate feature in another linter. Replaced by usetesting. 
ChatGPT ha detto:
```

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
By running `lint` check:
```
golangci-lint run
```

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [X] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [X] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work
