### PR TITLE
Ensure GOMAXPROCS & GOMEMLIMIT align with K8s limits

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -48,6 +48,14 @@ spec:
             value: /opt/manifests
           - name: ODH_PLATFORM_TYPE
             value: OpenDataHub
+          - name: GOMEMLIMIT
+            valueFrom:
+              resourceFieldRef:
+                resource: limits.memory
+          - name: GOMAXPROCS
+            valueFrom:
+              resourceFieldRef:
+                resource: limits.cpu
         args:
         - --leader-elect
         - --operator-name=opendatahub

--- a/pkg/cluster/cluster_config.go
+++ b/pkg/cluster/cluster_config.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	goruntime "runtime"
+	"runtime/debug"
 	"strings"
 
 	"github.com/blang/semver/v4"
@@ -67,6 +69,11 @@ func printClusterConfig(log logr.Logger) {
 		"Operator Namespace", clusterConfig.Namespace,
 		"Release", clusterConfig.Release,
 		"Cluster", clusterConfig.ClusterInfo)
+
+	log.Info("Env",
+		"GOMAXPROCS", goruntime.GOMAXPROCS(0),
+		"GOMEMLIMIT", debug.SetMemoryLimit(-1),
+	)
 }
 
 func GetOperatorNamespace() (string, error) {


### PR DESCRIPTION


<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

Set GOMAXPROCS and GOMEMLIMIT based on the CPU/memory limits
defined in the deployment manifests. This ensures optimal
resource utilization and prevents performance degradation
caused by CPU throttling or OOM issues in containerized Go apps.

References:
- https://www.ardanlabs.com/blog/2024/02/kubernetes-cpu-limits-go.html
- https://www.ardanlabs.com/blog/2024/02/kubernetes-memory-limits-go.html

> [!NOTE]
> As of today, we do configure the operator Deployment with some
> resources requests and limits, however, we do not configure the go
> runtime according. At this stage this is just an hypothesis, but since 
> that on a large cluster, the GOMAXPROCS would be automatically
> set to the number of cores, resulting in a sub-optimal setup as the
> go runtime would assume it can use all the cores, However, we set
> 500m as resource limit for CPU so we won't be able to use more than
> a single thread.

>
<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
