### PR TITLE
feat(actions): support globs in template rendering; add labels and annotations

### DIFF
--- a/pkg/controller/actions/render/template/action_render_templates.go
+++ b/pkg/controller/actions/render/template/action_render_templates.go
@@ -4,10 +4,11 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/fs"
 	"maps"
 	gt "text/template"
 
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions"
@@ -30,6 +31,9 @@ type Action struct {
 
 	data   map[string]any
 	dataFn []func(context.Context, *types.ReconciliationRequest) (map[string]any, error)
+
+	labels      map[string]string
+	annotations map[string]string
 }
 
 type ActionOpts func(*Action)
@@ -54,8 +58,49 @@ func WithDataFn(fns ...func(context.Context, *types.ReconciliationRequest) (map[
 	}
 }
 
+func WithLabel(name string, value string) ActionOpts {
+	return func(a *Action) {
+		a.labels[name] = value
+	}
+}
+
+func WithLabels(values map[string]string) ActionOpts {
+	return func(a *Action) {
+		maps.Copy(a.labels, values)
+	}
+}
+
+func WithAnnotation(name string, value string) ActionOpts {
+	return func(a *Action) {
+		a.annotations[name] = value
+	}
+}
+
+func WithAnnotations(values map[string]string) ActionOpts {
+	return func(a *Action) {
+		maps.Copy(a.annotations, values)
+	}
+}
+
 func (a *Action) run(ctx context.Context, rr *types.ReconciliationRequest) error {
 	return a.ResourceCacher.Render(ctx, rr, a.render)
+}
+
+func (a *Action) decode(decoder runtime.Decoder, data []byte, info types.TemplateInfo) ([]unstructured.Unstructured, error) {
+	u, err := resources.Decode(decoder, data)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode template: %w", err)
+	}
+
+	for i := range u {
+		resources.SetLabels(&u[i], a.labels)
+		resources.SetAnnotations(&u[i], a.annotations)
+
+		resources.SetLabels(&u[i], info.Labels)
+		resources.SetAnnotations(&u[i], info.Annotations)
+	}
+
+	return u, err
 }
 
 func (a *Action) render(ctx context.Context, rr *types.ReconciliationRequest) (resources.UnstructuredList, error) {
@@ -80,31 +125,27 @@ func (a *Action) render(ctx context.Context, rr *types.ReconciliationRequest) (r
 	var buffer bytes.Buffer
 
 	for i := range rr.Templates {
-		content, err := fs.ReadFile(rr.Templates[i].FS, rr.Templates[i].Path)
+		tmpl, err := gt.ParseFS(rr.Templates[i].FS, rr.Templates[i].Path)
 		if err != nil {
-			return nil, fmt.Errorf("failed to read file: %w", err)
+			return nil, fmt.Errorf("failed to parse template from: %w", err)
 		}
 
-		tmpl, err := gt.New(rr.Templates[i].Path).
-			Option("missingkey=error").
-			Parse(string(content))
+		tmpl = tmpl.Option("missingkey=error")
 
-		if err != nil {
-			return nil, fmt.Errorf("failed to parse template: %w", err)
+		for _, t := range tmpl.Templates() {
+			buffer.Reset()
+			err = t.Execute(&buffer, data)
+			if err != nil {
+				return nil, fmt.Errorf("failed to execute template: %w", err)
+			}
+
+			u, err := a.decode(decoder, buffer.Bytes(), rr.Templates[i])
+			if err != nil {
+				return nil, fmt.Errorf("failed to decode template: %w", err)
+			}
+
+			result = append(result, u...)
 		}
-
-		buffer.Reset()
-		err = tmpl.Execute(&buffer, data)
-		if err != nil {
-			return nil, fmt.Errorf("failed to execute template: %w", err)
-		}
-
-		u, err := resources.Decode(decoder, buffer.Bytes())
-		if err != nil {
-			return nil, fmt.Errorf("failed to decode template: %w", err)
-		}
-
-		result = append(result, u...)
 	}
 
 	return result, nil
@@ -114,6 +155,8 @@ func NewAction(opts ...ActionOpts) actions.Fn {
 	action := Action{
 		data:           make(map[string]any),
 		ResourceCacher: resourcecacher.NewResourceCacher(rendererEngine),
+		labels:         make(map[string]string),
+		annotations:    make(map[string]string),
 	}
 
 	for _, opt := range opts {

--- a/pkg/controller/actions/render/template/resources/g/sm-01.yaml
+++ b/pkg/controller/actions/render/template/resources/g/sm-01.yaml
@@ -1,0 +1,11 @@
+apiVersion: maistra.io/v1
+kind: ServiceMeshMember
+metadata:
+  name: sm-01
+  namespace: {{ .DSCI.Spec.ApplicationsNamespace }}
+  annotations:
+    instance-name: {{ .Component.Name }}
+spec:
+  controlPlaneRef:
+    namespace: {{ .DSCI.Spec.ApplicationsNamespace }}
+    name: {{ .Component.Name }}

--- a/pkg/controller/actions/render/template/resources/g/sm-02.yaml
+++ b/pkg/controller/actions/render/template/resources/g/sm-02.yaml
@@ -1,0 +1,11 @@
+apiVersion: maistra.io/v1
+kind: ServiceMeshMember
+metadata:
+  name: sm-02
+  namespace: {{ .DSCI.Spec.ApplicationsNamespace }}
+  annotations:
+    instance-name: {{ .Component.Name }}
+spec:
+  controlPlaneRef:
+    namespace: {{ .DSCI.Spec.ApplicationsNamespace }}
+    name: {{ .Component.Name }}

--- a/pkg/controller/types/types.go
+++ b/pkg/controller/types/types.go
@@ -51,6 +51,9 @@ func (mi ManifestInfo) String() string {
 type TemplateInfo struct {
 	FS   fs.FS
 	Path string
+
+	Labels      map[string]string
+	Annotations map[string]string
 }
 
 type ReconciliationRequest struct {


### PR DESCRIPTION


<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

This commit enhances template rendering by introducing support
for glob patterns, allowing more flexible template selection.

Additionally, it adds the ability to set labels and annotations:
- Labels and Annotations can now be defined at the action level.
- Specific template sets can also have their own Labels and Annotations.

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
