### PR TITLE
update: remove Unknown constant from platform detection logic

### DIFF
--- a/internal/controller/components/dashboard/dashboard_controller_actions.go
+++ b/internal/controller/components/dashboard/dashboard_controller_actions.go
@@ -78,7 +78,7 @@ func setKustomizedParams(ctx context.Context, rr *odhtypes.ReconciliationRequest
 }
 
 func configureDependencies(_ context.Context, rr *odhtypes.ReconciliationRequest) error {
-	if rr.Release.Name == cluster.Unknown || rr.Release.Name == cluster.OpenDataHub {
+	if rr.Release.Name == cluster.OpenDataHub {
 		return nil
 	}
 

--- a/internal/controller/components/dashboard/dashboard_support.go
+++ b/internal/controller/components/dashboard/dashboard_support.go
@@ -33,28 +33,24 @@ var (
 		cluster.SelfManagedRhoai: "rhods-admins",
 		cluster.ManagedRhoai:     "dedicated-admins",
 		cluster.OpenDataHub:      "odh-admins",
-		cluster.Unknown:          "odh-admins",
 	}
 
 	sectionTitle = map[common.Platform]string{
 		cluster.SelfManagedRhoai: "OpenShift Self Managed Services",
 		cluster.ManagedRhoai:     "OpenShift Managed Services",
 		cluster.OpenDataHub:      "OpenShift Open Data Hub",
-		cluster.Unknown:          "OpenShift Open Data Hub",
 	}
 
 	baseConsoleURL = map[common.Platform]string{
 		cluster.SelfManagedRhoai: "https://rhods-dashboard-",
 		cluster.ManagedRhoai:     "https://rhods-dashboard-",
 		cluster.OpenDataHub:      "https://odh-dashboard-",
-		cluster.Unknown:          "https://odh-dashboard-",
 	}
 
 	overlaysSourcePaths = map[common.Platform]string{
 		cluster.SelfManagedRhoai: "/rhoai/onprem",
 		cluster.ManagedRhoai:     "/rhoai/addon",
 		cluster.OpenDataHub:      "/odh",
-		cluster.Unknown:          "/odh",
 	}
 
 	imagesMap = map[string]string{

--- a/internal/controller/components/datasciencepipelines/datasciencepipelines_support.go
+++ b/internal/controller/components/datasciencepipelines/datasciencepipelines_support.go
@@ -47,7 +47,6 @@ var (
 		cluster.SelfManagedRhoai: "overlays/rhoai",
 		cluster.ManagedRhoai:     "overlays/rhoai",
 		cluster.OpenDataHub:      "overlays/odh",
-		cluster.Unknown:          "overlays/odh",
 	}
 
 	conditionTypes = []string{

--- a/internal/controller/components/trustyai/trustyai_support.go
+++ b/internal/controller/components/trustyai/trustyai_support.go
@@ -30,7 +30,6 @@ var (
 		cluster.SelfManagedRhoai: "/overlays/rhoai",
 		cluster.ManagedRhoai:     "/overlays/rhoai",
 		cluster.OpenDataHub:      "/overlays/odh",
-		cluster.Unknown:          "/overlays/odh",
 	}
 
 	conditionTypes = []string{

--- a/pkg/cluster/const.go
+++ b/pkg/cluster/const.go
@@ -9,8 +9,6 @@ const (
 	SelfManagedRhoai common.Platform = "OpenShift AI Self-Managed"
 	// OpenDataHub defines display name in csv.
 	OpenDataHub common.Platform = "Open Data Hub"
-	// Unknown indicates that operator is not deployed using OLM.
-	Unknown common.Platform = ""
 
 	// DefaultNotebooksNamespace defines default namespace for notebooks.
 	DefaultNotebooksNamespace = "rhods-notebooks"

--- a/tests/e2e/authcontroller_test.go
+++ b/tests/e2e/authcontroller_test.go
@@ -109,7 +109,7 @@ func (tc *AuthControllerTestCtx) validateAuthCRDefaultContent() error {
 		if tc.testAuthInstance.Spec.AdminGroups[0] != "dedicated-admins" {
 			return fmt.Errorf("expected dedicated-admins, found %v", tc.testAuthInstance.Spec.AdminGroups[0])
 		}
-	case cluster.OpenDataHub, cluster.Unknown:
+	case cluster.OpenDataHub:
 		if tc.testAuthInstance.Spec.AdminGroups[0] != "odh-admins" {
 			return fmt.Errorf("expected odh-admins, found %v", tc.testAuthInstance.Spec.AdminGroups[0])
 		}


### PR DESCRIPTION
## Description
This PR removes the Unknown platform constant (Unknown common.Platform = "") and modifies the dependent code. The use of this constant was either removed, or replaced by OpenDataHub constant as the default option

JIRA ref: [RHOAIENG-21371](https://issues.redhat.com/browse/RHOAIENG-21371)

## How Has This Been Tested?
As of this moment, standard e2e test suite was ran locally before the PR