### PR TITLE
RHOAI-21888 - DSCi errors with 'unable to get: opendatahub/redhat-ods…

### DIFF
--- a/main.go
+++ b/main.go
@@ -154,7 +154,7 @@ func main() { //nolint:funlen,maintidx,gocyclo
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
-	flag.StringVar(&monitoringNamespace, "dsc-monitoring-namespace", "opendatahub", "The namespace where data science cluster "+
+	flag.StringVar(&monitoringNamespace, "dsc-monitoring-namespace", "redhat-ods-monitoring", "The namespace where data science cluster "+
 		"monitoring stack will be deployed")
 	flag.StringVar(&logmode, "log-mode", "", "Log mode ('', prod, devel), default to ''")
 


### PR DESCRIPTION
…-monitoring because of unknown namespace for the cache'


## Description
**JIRA:** [RHOAIENG-21888](https://issues.redhat.com/browse/RHOAIENG-21888)
DSCi cannot be created because the namespace does not exist, we should change it to `redhat-ods-monitoring`.

## How Has This Been Tested?
Locally on a managed cluster.

## Screenshot or short clip
N/A

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
