### PR TITLE
fix/chore: replace outdated cluster.Platform references

### DIFF
--- a/docs/COMPONENT_INTEGRATION.md
+++ b/docs/COMPONENT_INTEGRATION.md
@@ -226,7 +226,7 @@ func (s *componentHandler) GetManagementState(dsc *dscv1.DataScienceCluster) ope
 
 func (s *componentHandler) NewCRObject(dsc *dscv1.DataScienceCluster) common.PlatformObject
 
-func (s *componentHandler) Init(platform cluster.Platform) error 
+func (s *componentHandler) Init(platform common.Platform) error 
 
 func (s *componentHandler) UpdateDSCStatus(ctx context.Context, rr *types.ReconciliationRequest) (metav1.ConditionStatus, error)
 ```


### PR DESCRIPTION
## Description

This PR updates component-codegen template and component integration docs `Init()` headers to contain `common.Platform` instead of `cluster.Platform`, to reflect that this type definition was previously moved

First found and discussed in #1761 
