### PR TITLE
Create an non-cached client to access resources bypassing the cache

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -74,6 +74,7 @@ linters-settings:
       - common.PlatformObject
       - types.AsyncAssertion
       - kubernetes.Interface
+      - client.Client
   revive:
     rules:
       - name: dot-imports

--- a/pkg/controller/reconciler/reconciler_finalizer_test.go
+++ b/pkg/controller/reconciler/reconciler_finalizer_test.go
@@ -1,4 +1,4 @@
-//nolint:testpackage
+//nolint:testpackage,ireturn
 package reconciler
 
 import (
@@ -47,21 +47,16 @@ type MockManager struct {
 	mapper meta.RESTMapper
 }
 
-//nolint:ireturn
 func (f *MockManager) GetClient() client.Client   { return f.client }
 func (f *MockManager) GetScheme() *runtime.Scheme { return f.scheme }
 
-//nolint:ireturn
 func (f *MockManager) GetRESTMapper() meta.RESTMapper { return f.mapper }
 func (f *MockManager) GetConfig() *rest.Config        { return &rest.Config{} }
 
-//nolint:ireturn
 func (f *MockManager) GetFieldIndexer() client.FieldIndexer { return nil }
 
-//nolint:ireturn
 func (f *MockManager) GetEventRecorderFor(name string) record.EventRecorder { return nil }
 
-//nolint:ireturn
 func (f *MockManager) GetCache() cache.Cache                                    { return nil }
 func (f *MockManager) GetLogger() logr.Logger                                   { return ctrl.Log }
 func (f *MockManager) Add(runnable manager.Runnable) error                      { return nil }
@@ -73,15 +68,12 @@ func (f *MockManager) AddMetricsServerExtraHandler(name string, handler http.Han
 }
 func (f *MockManager) AddReadyzCheck(name string, check healthz.Checker) error { return nil }
 
-//nolint:ireturn
 func (f *MockManager) GetAPIReader() client.Reader             { return nil }
 func (f *MockManager) GetControllerOptions() config.Controller { return config.Controller{} }
 func (f *MockManager) GetHTTPClient() *http.Client             { return &http.Client{} }
 
-//nolint:ireturn
 func (f *MockManager) GetWebhookServer() webhook.Server { return nil }
 
-//nolint:ireturn
 func setupTest(mockDashboard *componentApi.Dashboard) (context.Context, *MockManager, client.WithWatch) {
 	ctx := context.Background()
 

--- a/pkg/utils/test/fakeclient/fakeclient.go
+++ b/pkg/utils/test/fakeclient/fakeclient.go
@@ -50,12 +50,15 @@ func New(objs ...ctrlClient.Object) (*client.Client, error) {
 		ro[i] = u
 	}
 
+	cf := clientFake.NewClientBuilder().
+		WithScheme(s).
+		WithRESTMapper(fakeMapper).
+		WithObjects(objs...).
+		Build()
+
 	c := client.New(
-		clientFake.NewClientBuilder().
-			WithScheme(s).
-			WithRESTMapper(fakeMapper).
-			WithObjects(objs...).
-			Build(),
+		cf,
+		cf,
 		k8sFake.NewSimpleClientset(ro...),
 		dynamicFake.NewSimpleDynamicClient(s, ro...),
 	)


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

This commit introduces a non cached client, so reconcilers can retrieve 
objects rarely accessed without passing through the cache. Th client is
not used at this stage, but it will be in future PRs about the introduction
of `PartialObjectMetaData` , which allows clients to retrieve only the
metadata of a resource without fetching the entire object, reducing 
memory and  resource utilization.

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
