### PR TITLE
chore: add CatalogSource to the list of non cached object

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -221,10 +221,6 @@ func main() { //nolint:funlen,maintidx,gocyclo
 			// TODO: we can limit scope of namespace if we find a way to only get list of DSProject
 			// also need for monitoring, trustcabundle
 			&corev1.Namespace{}: {},
-			// For catsrc (avoid frequently check cluster type)
-			&ofapiv1alpha1.CatalogSource{}: {
-				Field: fields.Set{"metadata.name": "addon-managed-odh-catalog"}.AsSelector(),
-			},
 			// For domain to get OpenshiftIngress and default cert
 			&operatorv1.IngressController{}: {
 				Field: fields.Set{"metadata.name": "default"}.AsSelector(),
@@ -301,6 +297,7 @@ func main() { //nolint:funlen,maintidx,gocyclo
 					&authorizationv1.SelfSubjectRulesReview{},
 					&corev1.Pod{},
 					&userv1.Group{},
+					&ofapiv1alpha1.CatalogSource{},
 				},
 				// Set it to true so the cache-backed client reads unstructured objects
 				// or lists from the cache instead of a live lookup.


### PR DESCRIPTION
The CatalogSource type is only used to determine the platform type at
startup, hence it is not required to keep this in the cache, nor to set
up aninformer/watcher

<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
