### PR TITLE
chore: optimize kustomize sortOptions tests for readability

### DIFF
--- a/pkg/utils/test/matchers/jq/jq_matcher_test.go
+++ b/pkg/utils/test/matchers/jq/jq_matcher_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/onsi/gomega/types"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/matchers/jq"
@@ -11,83 +12,103 @@ import (
 	. "github.com/onsi/gomega"
 )
 
+// TestMatcher verifies the jq.Match function against various JSON strings.
+// It ensures correct behavior for simple key-value matches, array value checks,
+// handling of null values, and nested object conditions.
 func TestMatcher(t *testing.T) {
 	t.Parallel()
 
 	g := NewWithT(t)
 
-	g.Expect(`{"a":1}`).Should(
-		jq.Match(`.a == 1`),
-	)
+	// Define multiple test cases for jq matching
+	testCases := []struct {
+		input   string
+		matcher types.GomegaMatcher
+	}{
+		{
+			// Test matching a simple value
+			input:   `{"a":1}`,
+			matcher: jq.Match(`.a == 1`),
+		},
+		{
+			// Test when the value doesn't match
+			input:   `{"a":1}`,
+			matcher: Not(jq.Match(`.a == 2`)),
+		},
+		{
+			// Test array with values matching
+			input:   `{"Values":[ "foo" ]}`,
+			matcher: jq.Match(`.Values | if . then any(. == "foo") else false end`),
+		},
+		{
+			// Test array with non-matching value
+			input:   `{"Values":[ "foo" ]}`,
+			matcher: Not(jq.Match(`.Values | if . then any(. == "bar") else false end`)),
+		},
+		{
+			// Test when the value is null
+			input:   `{"Values": null}`,
+			matcher: Not(jq.Match(`.Values | if . then any(. == "foo") else false end`)),
+		},
+		{
+			// Test multiple matching conditions
+			input:   `{ "status": { "foo": { "bar": "fr", "baz": "fb" } } }`,
+			matcher: jq.Match(`(.status.foo.bar == "fr") and (.status.foo.baz == "fb")`),
+		},
+	}
 
-	g.Expect(`{"a":1}`).Should(
-		Not(
-			jq.Match(`.a == 2`),
-		),
-	)
-
-	g.Expect(`{"Values":[ "foo" ]}`).Should(
-		jq.Match(`.Values | if . then any(. == "foo") else false end`),
-	)
-
-	g.Expect(`{"Values":[ "foo" ]}`).Should(
-		Not(
-			jq.Match(`.Values | if . then any(. == "bar") else false end`),
-		),
-	)
-
-	g.Expect(`{"Values": null}`).Should(
-		Not(
-			jq.Match(`.Values | if . then any(. == "foo") else false end`),
-		),
-	)
-
-	g.Expect(`{ "status": { "foo": { "bar": "fr", "baz": "fb" } } }`).Should(
-		And(
-			jq.Match(`.status.foo.bar == "fr"`),
-			jq.Match(`.status.foo.baz == "fb"`),
-		),
-	)
+	// Run the test cases
+	for _, tc := range testCases {
+		g.Expect(tc.input).Should(tc.matcher)
+	}
 }
 
+// TestMatcherWithType validates jq.Match against different Go data types such as maps and structs.
+// It ensures that jq.Match works correctly after serializing Go types to JSON.
 func TestMatcherWithType(t *testing.T) {
 	t.Parallel()
 
 	g := NewWithT(t)
 
-	g.Expect(map[string]any{"a": 1}).
-		Should(
-			WithTransform(json.Marshal, jq.Match(`.a == 1`)),
-		)
-
-	g.Expect(
-		map[string]any{
-			"status": map[string]any{
-				"foo": map[string]any{
-					"bar": "fr",
-					"baz": "fb",
+	// Define multiple test cases for jq matching
+	testCases := []struct {
+		input   interface{}
+		matcher types.GomegaMatcher
+	}{
+		{
+			input:   map[string]any{"a": 1},
+			matcher: WithTransform(json.Marshal, jq.Match(`.a == 1`)),
+		},
+		{
+			input: map[string]any{
+				"status": map[string]any{
+					"foo": map[string]any{
+						"bar": "fr",
+						"baz": "fb",
+					},
 				},
 			},
-		}).
-		Should(
-			WithTransform(json.Marshal, And(
+			matcher: WithTransform(json.Marshal, And(
 				jq.Match(`.status.foo.bar == "fr"`),
 				jq.Match(`.status.foo.baz == "fb"`),
 			)),
-		)
+		},
+		{
+			input:   map[string]any{"a": 1},
+			matcher: jq.Match(`.a == 1`),
+		},
+		{
+			input: struct {
+				A int `json:"a"`
+			}{A: 1},
+			matcher: WithTransform(json.Marshal, jq.Match(`.a == 1`)),
+		},
+	}
 
-	g.Expect(map[string]any{"a": 1}).
-		Should(jq.Match(`.a == 1`))
-
-	g.Expect(
-		struct {
-			A int `json:"a"`
-		}{
-			A: 1,
-		}).
-		Should(
-			WithTransform(json.Marshal, jq.Match(`.a == 1`)),
-		)
+	// Run the test cases
+	for _, tc := range testCases {
+		g.Expect(tc.input).Should(tc.matcher)
+	}
 }
 
 func TestUnstructuredSliceMatcher(t *testing.T) {
@@ -101,9 +122,23 @@ func TestUnstructuredSliceMatcher(t *testing.T) {
 		}},
 	}
 
-	g.Expect(u).Should(
-		jq.Match(`.[0] | .a == 1`))
+	// Define multiple test cases for jq matching
+	testCases := []struct {
+		input   interface{}
+		matcher types.GomegaMatcher
+	}{
+		{
+			input:   u,
+			matcher: jq.Match(`.[0] | .a == 1`),
+		},
+		{
+			input:   unstructured.UnstructuredList{Items: u},
+			matcher: jq.Match(`.[0] | .a == 1`),
+		},
+	}
 
-	g.Expect(unstructured.UnstructuredList{Items: u}).Should(
-		jq.Match(`.[0] | .a == 1`))
+	// Run the test cases
+	for _, tc := range testCases {
+		g.Expect(tc.input).Should(tc.matcher)
+	}
 }


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->
This PR implements the optimizations suggested in https://github.com/opendatahub-io/opendatahub-operator/pull/1615#pullrequestreview-2596041004. It simplifies the test structure for kustomize's sortOptions configuration by improving the readability and clarity of the matcher usage. The changes make the tests more straightforward without altering their functionality.

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
The changes have been tested by running all the unit tests in `jq_matcher_test.go`.

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [X] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [X] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work
