### PR TITLE
[rhoai] Cluster-monitoring label missing from redhat-ods-monitoring namespace

### DIFF
--- a/internal/controller/dscinitialization/utils_test.go
+++ b/internal/controller/dscinitialization/utils_test.go
@@ -1,0 +1,106 @@
+package dscinitialization_test
+
+import (
+	"context"
+	"testing"
+
+	operatorv1 "github.com/openshift/api/operator/v1"
+	"github.com/rs/xid"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/opendatahub-io/opendatahub-operator/v2/api/common"
+	dsciv1 "github.com/opendatahub-io/opendatahub-operator/v2/api/dscinitialization/v1"
+	serviceApi "github.com/opendatahub-io/opendatahub-operator/v2/api/services/v1alpha1"
+	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/dscinitialization"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/metadata/labels"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/fakeclient"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestPatchMonitoringNS(t *testing.T) {
+	g := NewWithT(t)
+
+	ctx := context.Background()
+	monitoringNS := xid.New().String()
+	appsNS := xid.New().String()
+
+	cli, err := fakeclient.New()
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	dscInit := &dsciv1.DSCInitialization{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-dsc",
+		},
+		Spec: dsciv1.DSCInitializationSpec{
+			Monitoring: serviceApi.DSCIMonitoring{
+				ManagementSpec: common.ManagementSpec{
+					ManagementState: operatorv1.Managed,
+				},
+				MonitoringCommonSpec: serviceApi.MonitoringCommonSpec{
+					Namespace: monitoringNS,
+				},
+			},
+			ApplicationsNamespace: appsNS,
+		},
+	}
+
+	err = dscinitialization.PatchMonitoringNS(ctx, cli, dscInit)
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	// Assert that the namespace was created and has correct labels
+	ns := &corev1.Namespace{}
+	err = cli.Get(ctx, client.ObjectKey{Name: monitoringNS}, ns)
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	g.Expect(ns.Labels).To(HaveKeyWithValue(labels.ODH.OwnedNamespace, labels.True))
+	g.Expect(ns.Labels).To(HaveKeyWithValue(labels.SecurityEnforce, "baseline"))
+	g.Expect(ns.Labels).To(HaveKeyWithValue(labels.ClusterMonitoring, labels.True))
+}
+
+func TestPatchExistingMonitoringNS(t *testing.T) {
+	g := NewWithT(t)
+
+	ctx := context.Background()
+	monitoringNS := xid.New().String()
+	appsNS := xid.New().String()
+
+	cli, err := fakeclient.New(&corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: monitoringNS,
+		},
+	})
+
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	dscInit := &dsciv1.DSCInitialization{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-dsc",
+		},
+		Spec: dsciv1.DSCInitializationSpec{
+			Monitoring: serviceApi.DSCIMonitoring{
+				ManagementSpec: common.ManagementSpec{
+					ManagementState: operatorv1.Managed,
+				},
+				MonitoringCommonSpec: serviceApi.MonitoringCommonSpec{
+					Namespace: monitoringNS,
+				},
+			},
+			ApplicationsNamespace: appsNS,
+		},
+	}
+
+	err = dscinitialization.PatchMonitoringNS(ctx, cli, dscInit)
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	// Assert that the namespace was created and has correct labels
+	ns := &corev1.Namespace{}
+	err = cli.Get(ctx, client.ObjectKey{Name: monitoringNS}, ns)
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	g.Expect(ns.Labels).To(HaveKeyWithValue(labels.ODH.OwnedNamespace, labels.True))
+	g.Expect(ns.Labels).To(HaveKeyWithValue(labels.SecurityEnforce, "baseline"))
+	g.Expect(ns.Labels).To(HaveKeyWithValue(labels.ClusterMonitoring, labels.True))
+}


### PR DESCRIPTION
(cherry picked from commit 782709a4d0dd04b112f0989ae93e54d75996c0fc)

<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
