### PR TITLE
[rhoai] cleanup gc action/engine leftover

### DIFF
--- a/pkg/controller/actions/gc/engine/gc_engine_test.go
+++ b/pkg/controller/actions/gc/engine/gc_engine_test.go
@@ -1,16 +1,33 @@
 package engine_test
 
 import (
+	"context"
 	"testing"
 
 	gTypes "github.com/onsi/gomega/types"
+	"github.com/rs/xid"
 	authorizationv1 "k8s.io/api/authorization/v1"
+	corev1 "k8s.io/api/core/v1"
+	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	labels2 "k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	ctrlCli "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/gc/engine"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/envt"
 
 	. "github.com/onsi/gomega"
 )
+
+//nolint:gochecknoinits
+func init() {
+	log.SetLogger(zap.New(zap.UseDevMode(true)))
+}
 
 func allVerb() []string {
 	return []string{"delete", "create", "get", "list", "patch"}
@@ -93,6 +110,160 @@ func TestMatchRules(t *testing.T) {
 					test.rule,
 				),
 			).To(test.matcher)
+		})
+	}
+}
+func TestEngine(t *testing.T) {
+	g := NewWithT(t)
+
+	envTest, err := envt.New()
+	g.Expect(err).NotTo(HaveOccurred())
+
+	t.Cleanup(func() {
+		_ = envTest.Stop()
+	})
+
+	ctx := context.Background()
+	cli := envTest.Client()
+	cmName := "gc-cm"
+	cmLabels := map[string]string{"foo": "bar"}
+
+	tests := []struct {
+		name         string
+		options      []engine.RunOptionsFn
+		matcher      gTypes.GomegaMatcher
+		countMatcher gTypes.GomegaMatcher
+	}{
+		{
+			name:         "should not collect leftovers without an object predicate",
+			matcher:      Not(HaveOccurred()),
+			countMatcher: BeNumerically("==", 0),
+		},
+		{
+			name:         "should collect leftovers matching the selector and object predicate",
+			matcher:      MatchError(k8serr.IsNotFound, "IsNotFound"),
+			countMatcher: BeNumerically("==", 1),
+			options: []engine.RunOptionsFn{
+				engine.WithSelector(labels2.SelectorFromSet(cmLabels)),
+				engine.WithObjectFilter(func(_ context.Context, obj unstructured.Unstructured) (bool, error) {
+					return obj.GetName() == cmName, nil
+				}),
+			},
+		},
+		{
+			name:         "should not collect leftovers not matching the selector and object predicate",
+			matcher:      Not(HaveOccurred()),
+			countMatcher: BeNumerically("==", 0),
+			options: []engine.RunOptionsFn{
+				engine.WithSelector(labels2.SelectorFromSet(map[string]string{
+					"foo": xid.New().String(),
+				})),
+				engine.WithObjectFilter(func(_ context.Context, obj unstructured.Unstructured) (bool, error) {
+					return obj.GetName() == cmName, nil
+				}),
+			},
+		},
+		{
+			name:         "should not collect leftovers not matching the object predicate",
+			matcher:      Not(HaveOccurred()),
+			countMatcher: BeNumerically("==", 0),
+			options: []engine.RunOptionsFn{
+				engine.WithSelector(labels2.SelectorFromSet(cmLabels)),
+				engine.WithObjectFilter(func(_ context.Context, obj unstructured.Unstructured) (bool, error) {
+					return obj.GetName() != cmName, nil
+				}),
+			},
+		},
+		{
+			name:         "should not collect leftovers not matching the type predicate",
+			matcher:      Not(HaveOccurred()),
+			countMatcher: BeNumerically("==", 0),
+			options: []engine.RunOptionsFn{
+				engine.WithTypeFilter(func(_ context.Context, kind schema.GroupVersionKind) (bool, error) {
+					return kind.Kind == "foo", nil
+				}),
+				engine.WithObjectFilter(func(_ context.Context, obj unstructured.Unstructured) (bool, error) {
+					return obj.GetName() == cmName, nil
+				}),
+			},
+		},
+		{
+			name:         "should collect leftovers matching the type and object predicate",
+			matcher:      MatchError(k8serr.IsNotFound, "IsNotFound"),
+			countMatcher: BeNumerically("==", 1),
+			options: []engine.RunOptionsFn{
+				engine.WithTypeFilter(func(_ context.Context, kind schema.GroupVersionKind) (bool, error) {
+					return kind == gvk.ConfigMap, nil
+				}),
+				engine.WithObjectFilter(func(_ context.Context, obj unstructured.Unstructured) (bool, error) {
+					return obj.GetName() == cmName, nil
+				}),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			id := xid.New().String()
+
+			gci := engine.New(
+				// This is required as there are no kubernetes controller running
+				// with the envtest, hence we can't use the foreground deletion
+				// policy (default)
+				engine.WithDeletePropagationPolicy(metav1.DeletePropagationBackground),
+			)
+
+			ns := corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: id,
+				},
+			}
+
+			g.Expect(cli.Create(ctx, &ns)).
+				NotTo(HaveOccurred())
+			g.Expect(gci.Refresh(ctx, cli, ns.Name)).
+				NotTo(HaveOccurred())
+
+			t.Cleanup(func() {
+				g.Eventually(func() error {
+					return cli.Delete(ctx, &ns)
+				}).Should(Or(
+					Not(HaveOccurred()),
+					MatchError(k8serr.IsNotFound, "IsNotFound"),
+				))
+			})
+
+			cm := corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      cmName,
+					Namespace: ns.Name,
+					Labels:    cmLabels,
+				},
+			}
+
+			t.Cleanup(func() {
+				g.Expect(cli.Delete(ctx, &cm)).Should(Or(
+					Not(HaveOccurred()),
+					MatchError(k8serr.IsNotFound, "IsNotFound"),
+				))
+			})
+
+			g.Expect(cli.Create(ctx, &cm)).
+				NotTo(HaveOccurred())
+
+			count, err := gci.Run(ctx, cli, tt.options...)
+			g.Expect(err).
+				NotTo(HaveOccurred())
+
+			if tt.matcher != nil {
+				err = cli.Get(ctx, ctrlCli.ObjectKeyFromObject(&cm), &corev1.ConfigMap{})
+				g.Expect(err).To(tt.matcher)
+			}
+
+			if tt.countMatcher != nil {
+				g.Expect(count).Should(tt.countMatcher)
+			}
 		})
 	}
 }

--- a/pkg/utils/test/scheme/scheme.go
+++ b/pkg/utils/test/scheme/scheme.go
@@ -7,6 +7,7 @@ import (
 	ofapi "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	ofapiv2 "github.com/operator-framework/api/pkg/operators/v2"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	coordinationv1 "k8s.io/api/coordination/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -31,6 +32,8 @@ var (
 		apiextensionsv1.AddToScheme,
 		oauthv1.AddToScheme,
 		ofapiv2.AddToScheme,
+		coordinationv1.AddToScheme,
+		apiextensionsv1.AddToScheme,
 	}
 )
 


### PR DESCRIPTION
With the GC engine now fully integrated into the GC action, some
previously split logic can be consolidated:

- The redundant "unremovable" setup, previously done in both the engine
  and the action, is now handled solely in the action.
- The selector is now passed to the GC engine via an option function,
  aligning with other optional parameters.
- The engine now collects only objects matching the object predicate,
  preventing unintended deletions by default.

(cherry picked from commit 0ebae575a9bc43308d01300b7dcc5b3c85db8155)

<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
