### PR TITLE
fix:RHOAIENG-21276 delete unused odh-common-config in DSCInitialization controller

### DIFF
--- a/internal/controller/dscinitialization/utils.go
+++ b/internal/controller/dscinitialization/utils.go
@@ -41,8 +41,7 @@ var (
 //   - Pod security labels for baseline permissions
 //
 // - 2. Patch monitoring namespace
-// - 3. Network Policies 'opendatahub' that allow traffic between the ODH namespaces
-// - 4. ConfigMap 'odh-common-config'.
+// - 3. Network Policies 'opendatahub' that allow traffic between the ODH namespaces.
 func (r *DSCInitializationReconciler) createOperatorResource(ctx context.Context, dscInit *dsciv1.DSCInitialization, platform common.Platform) error {
 	log := logf.FromContext(ctx)
 
@@ -63,12 +62,6 @@ func (r *DSCInitializationReconciler) createOperatorResource(ctx context.Context
 	if err := r.reconcileDefaultNetworkPolicy(ctx, dscInit, platform); err != nil {
 		log.Error(err, "error reconciling network policy ", "name", dscInit.Spec.ApplicationsNamespace)
 		return fmt.Errorf("error: %w", err)
-	}
-
-	// Create odh-common-config Configmap for the Namespace
-	if err := r.createOdhCommonConfigMap(ctx, dscInit); err != nil {
-		log.Error(err, "error creating configmap", "name", "odh-common-config")
-		return err
 	}
 
 	return nil
@@ -367,42 +360,4 @@ func GenerateRandomHex(length int) ([]byte, error) {
 	}
 
 	return randomBytes, nil
-}
-
-func (r *DSCInitializationReconciler) createOdhCommonConfigMap(ctx context.Context, dscInit *dsciv1.DSCInitialization) error {
-	log := logf.FromContext(ctx)
-	name := dscInit.Spec.ApplicationsNamespace
-	// Expected configmap for the given namespace
-	desiredConfigMap := &corev1.ConfigMap{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "ConfigMap",
-			APIVersion: "v1",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "odh-common-config",
-			Namespace: name,
-		},
-		Data: map[string]string{"namespace": name},
-	}
-
-	// Create Configmap if it doesn't exist
-	foundConfigMap := &corev1.ConfigMap{}
-	err := r.Client.Get(ctx, client.ObjectKeyFromObject(desiredConfigMap), foundConfigMap)
-	if err != nil {
-		if k8serr.IsNotFound(err) {
-			// Set Controller reference
-			err = ctrl.SetControllerReference(dscInit, foundConfigMap, r.Scheme)
-			if err != nil {
-				log.Error(err, "Unable to add OwnerReference to the odh-common-config ConfigMap")
-				return err
-			}
-			err = r.Client.Create(ctx, desiredConfigMap)
-			if err != nil && !k8serr.IsAlreadyExists(err) {
-				return err
-			}
-		} else {
-			return err
-		}
-	}
-	return nil
 }


### PR DESCRIPTION
## Description
Remove unused odh-common-config and the relevant tests

* https://issues.redhat.com/browse/RHOAIENG-21276

## How Has This Been Tested?
Tested using Jenkins Smoke and Operator tests

* https://quay.io/repository/rh-ee-froman/opendatahub-operator
* https://quay.io/repository/rh-ee-froman/opendatahub-operator-bundle
* https://quay.io/repository/rh-ee-froman/opendatahub-operator-catalog

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
