### PR TITLE
Revert "fix: add missing new pipeline flag into default sample"

### DIFF
--- a/bundle/manifests/opendatahub-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/opendatahub-operator.clusterserviceversion.yaml
@@ -26,11 +26,6 @@ metadata:
                 "managementState": "Managed"
               },
               "datasciencepipelines": {
-                "managedPipelines": {
-                  "instructLab": {
-                    "state": "Removed"
-                  }
-                },
                 "managementState": "Managed"
               },
               "feastoperator": {

--- a/config/samples/datasciencecluster_v1_datasciencecluster.yaml
+++ b/config/samples/datasciencecluster_v1_datasciencecluster.yaml
@@ -16,9 +16,6 @@ spec:
       managementState: "Managed"
     datasciencepipelines:
       managementState: "Managed"
-      managedPipelines:
-        instructLab:
-          state: Removed
     kserve: {
       managementState: "Managed",
       nim: {


### PR DESCRIPTION
Reverts opendatahub-io/opendatahub-operator#1609

this part should had been reverted in https://github.com/opendatahub-io/opendatahub-operator/pull/1652