### PR TITLE
RHOAIENG-24104: Only deploy kserve SM resources with Authorino

### DIFF
--- a/internal/controller/components/kserve/kserve.go
+++ b/internal/controller/components/kserve/kserve.go
@@ -23,6 +23,7 @@ import (
 
 const (
 	componentName            = componentApi.KserveComponentName
+	authorinoOperator        = "authorino-operator"
 	serviceMeshOperator      = "servicemeshoperator"
 	serverlessOperator       = "serverless-operator"
 	kserveConfigMapName      = "inferenceservice-config"

--- a/internal/controller/components/kserve/kserve_controller_actions.go
+++ b/internal/controller/components/kserve/kserve_controller_actions.go
@@ -218,7 +218,7 @@ func addTemplateFiles(ctx context.Context, rr *odhtypes.ReconciliationRequest) e
 			Path: "resources/servicemesh/routing/local-gateway-svc.tmpl.yaml",
 		},
 
-		// TODO these are the servicemesh ones
+		// These are the servicemesh ones, only deployed when authorino also installed
 		{
 			FS:   resourcesFS,
 			Path: "resources/servicemesh/activator-envoyfilter.tmpl.yaml",
@@ -267,6 +267,11 @@ func cleanUpTemplatedResources(ctx context.Context, rr *odhtypes.ReconciliationR
 
 	logger := logf.FromContext(ctx)
 
+	authorinoInstalled, err := cluster.SubscriptionExists(ctx, rr.Client, "authorino-operator")
+	if err != nil {
+		return fmt.Errorf("failed to list subscriptions %w", err)
+	}
+
 	if rr.DSCI.Spec.ServiceMesh != nil {
 		// servicemesh is set to Removed
 		if rr.DSCI.Spec.ServiceMesh.ManagementState == operatorv1.Removed {
@@ -289,6 +294,30 @@ func cleanUpTemplatedResources(ctx context.Context, rr *odhtypes.ReconciliationR
 				}
 			}
 		}
+
+		// Need to explicitly remove resources from cluster if they exist,
+		// to delete resources accidentally created in 2.19.0.
+		if !authorinoInstalled {
+			for _, res := range rr.Resources {
+				if isForDependency("servicemesh")(&res) {
+					err := rr.Client.Delete(ctx, &res, client.PropagationPolicy(metav1.DeletePropagationForeground))
+					if err != nil {
+						if k8serr.IsNotFound(err) {
+							continue
+						}
+						if errors.Is(err, &meta.NoKindMatchError{}) { // when CRD is missing,
+							continue
+						}
+						return odherrors.NewStopErrorW(err)
+					}
+					logger.Info("Deleted", "kind", res.GetKind(), "name", res.GetName(), "namespace", res.GetNamespace())
+				}
+			}
+			if err := rr.RemoveResources(isForDependency("servicemesh")); err != nil {
+				return odherrors.NewStopErrorW(err)
+			}
+		}
+
 		// servicemesh is set to Removed or Unmanaged
 		if rr.DSCI.Spec.ServiceMesh.ManagementState != operatorv1.Managed {
 			if err := rr.RemoveResources(isForDependency("servicemesh")); err != nil {
@@ -296,7 +325,7 @@ func cleanUpTemplatedResources(ctx context.Context, rr *odhtypes.ReconciliationR
 			}
 		}
 	}
-	// serverless is Removed or Unamanged
+	// serverless is Removed or Unmananged
 	if k.Spec.Serving.ManagementState != operatorv1.Managed {
 		if err := rr.RemoveResources(isForDependency("serverless")); err != nil {
 			return odherrors.NewStopErrorW(err)


### PR DESCRIPTION
-------

<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->
Jira: https://issues.redhat.com/browse/RHOAIENG-24104

This fixes a bug where previously the AuthorizationPolicy and EnvoyFilter resources were only deployed when Authorino was installed, but it was refactored in 2.19 which caused those to be deployed even when Authorino not installed, which is incorrect.

Old code where it only deployed if authorino installed:
https://github.com/red-hat-data-services/rhods-operator/blob/rhoai-2.16/components/kserve/servicemesh_setup.go#L46

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Unit tests added with/without Authorino. e2e tests should pass too.

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work

## Summary by Sourcery

Fix deployment of KServe Service Mesh resources to only occur when Authorino is installed

Bug Fixes:
- Prevent AuthorizationPolicy and EnvoyFilter resources from being deployed when Authorino is not installed, addressing a regression from version 2.19

Tests:
- Added unit tests to verify resource deployment with and without Authorino installed