### PR TITLE
feat: migrate resource deploy logic to SSA

### DIFF
--- a/pkg/cluster/cert.go
+++ b/pkg/cluster/cert.go
@@ -20,9 +20,15 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/resources"
 )
 
-const IngressNamespace = "openshift-ingress"
+const (
+	CertFieldOwner   = resources.PlatformFieldOwner + "/cert"
+	IngressNamespace = "openshift-ingress"
+)
 
 var IngressControllerName = types.NamespacedName{
 	Namespace: "openshift-ingress-operator",
@@ -39,8 +45,13 @@ func CreateSelfSignedCertificate(ctx context.Context, c client.Client, secretNam
 		return errApply
 	}
 
-	if errGen := generateCertSecret(ctx, c, certSecret); errGen != nil {
-		return fmt.Errorf("failed update self-signed certificate secret: %w", errGen)
+	opts := []client.PatchOption{
+		client.ForceOwnership,
+		client.FieldOwner(CertFieldOwner),
+	}
+	err = resources.Apply(ctx, c, certSecret, opts...)
+	if err != nil && !k8serr.IsAlreadyExists(err) {
+		return err
 	}
 
 	return nil
@@ -53,6 +64,10 @@ func GenerateSelfSignedCertificateAsSecret(name, addr, namespace string) (*corev
 	}
 
 	return &corev1.Secret{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       gvk.Secret.Kind,
+			APIVersion: gvk.Secret.Version,
+		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
@@ -184,6 +199,10 @@ func GetSecret(ctx context.Context, c client.Client, namespace, name string) (*c
 
 func copySecretToNamespace(ctx context.Context, c client.Client, secret *corev1.Secret, newSecretName, namespace string) error {
 	newSecret := &corev1.Secret{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       gvk.Secret.Kind,
+			APIVersion: gvk.Secret.Version,
+		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      newSecretName,
 			Namespace: namespace,
@@ -192,67 +211,14 @@ func copySecretToNamespace(ctx context.Context, c client.Client, secret *corev1.
 		Type: secret.Type,
 	}
 
-	if err := generateCertSecret(ctx, c, newSecret); err != nil {
-		return fmt.Errorf("failed to deploy default cert secret to namespace %s: %w", namespace, err)
+	opts := []client.PatchOption{
+		client.ForceOwnership,
+		client.FieldOwner(CertFieldOwner),
+	}
+	err := resources.Apply(ctx, c, newSecret, opts...)
+	if err != nil && !k8serr.IsAlreadyExists(err) {
+		return err
 	}
 
 	return nil
-}
-
-// recreateSecret deletes the existing secret and creates a new one.
-func recreateSecret(ctx context.Context, c client.Client, existingSecret, newSecret *corev1.Secret) error {
-	if err := c.Delete(ctx, existingSecret); err != nil {
-		return fmt.Errorf("failed to delete existing secret before recreating new one: %w", err)
-	}
-	if err := c.Create(ctx, newSecret); err != nil {
-		return fmt.Errorf("failed to create new secret after existing one has been deleted: %w", err)
-	}
-	return nil
-}
-
-// generateCertSecret creates a secret if it does not exist; recreate this secret if type not match; update data if outdated.
-func generateCertSecret(ctx context.Context, c client.Client, certSecret *corev1.Secret) error {
-	existingSecret := &corev1.Secret{}
-	errGet := c.Get(ctx, client.ObjectKeyFromObject(certSecret), existingSecret)
-	switch {
-	case errGet == nil:
-		// Secret exists but with a different type, delete and create it again
-		if existingSecret.Type != certSecret.Type {
-			return recreateSecret(ctx, c, existingSecret, certSecret)
-		}
-		// update data if found with same type but outdated content
-		if isSecretOutdated(existingSecret.Data, certSecret.Data) {
-			if errUpdate := c.Update(ctx, certSecret); errUpdate != nil {
-				return fmt.Errorf("failed to update existing secret: %w", errUpdate)
-			}
-		}
-	case k8serr.IsNotFound(errGet):
-		// Secret does not exist, create it
-		if errCreate := c.Create(ctx, certSecret); errCreate != nil {
-			return fmt.Errorf("failed creating new certificate secret: %w", errCreate)
-		}
-	default:
-		return fmt.Errorf("failed getting certificate secret: %w", errGet)
-	}
-
-	return nil
-}
-
-// isSecretOutdated compares two secret data of type map[string][]byte and returns true if they are not equal.
-func isSecretOutdated(existingSecretData, newSecretData map[string][]byte) bool {
-	if len(existingSecretData) != len(newSecretData) {
-		return true
-	}
-
-	for key, value1 := range existingSecretData {
-		value2, ok := newSecretData[key]
-		if !ok {
-			return true
-		}
-		if !bytes.Equal(value1, value2) {
-			return true
-		}
-	}
-
-	return false
 }

--- a/pkg/cluster/cluster_operations_int_test.go
+++ b/pkg/cluster/cluster_operations_int_test.go
@@ -61,7 +61,7 @@ var _ = Describe("Creating cluster resources", func() {
 
 			// then
 			Expect(err).ToNot(HaveOccurred())
-			Expect(existingNamespace).To(Equal(newNamespace))
+			Expect(existingNamespace.UID).To(Equal(newNamespace.UID))
 		})
 
 		It("should set labels", func(ctx context.Context) {

--- a/pkg/controller/actions/deploy/action_deploy.go
+++ b/pkg/controller/actions/deploy/action_deploy.go
@@ -27,8 +27,6 @@ type Mode string
 const (
 	ModePatch Mode = "patch"
 	ModeSSA   Mode = "ssa"
-
-	PlatformFieldOwner = "platform.opendatahub.io"
 )
 
 // Action deploys the resources that are included in the ReconciliationRequest using
@@ -198,7 +196,7 @@ func (a *Action) deployCRD(
 		client.ForceOwnership,
 		// Since CRDs are not bound to a component, set the field
 		// owner to the platform itself
-		client.FieldOwner(PlatformFieldOwner),
+		client.FieldOwner(resources.PlatformFieldOwner),
 	}
 
 	switch a.deployMode {

--- a/pkg/resources/resources.go
+++ b/pkg/resources/resources.go
@@ -27,6 +27,8 @@ import (
 	"github.com/opendatahub-io/opendatahub-operator/v2/api/common"
 )
 
+const PlatformFieldOwner = "platform.opendatahub.io"
+
 func ToUnstructured(obj any) (*unstructured.Unstructured, error) {
 	data, err := runtime.DefaultUnstructuredConverter.ToUnstructured(obj)
 	if err != nil {


### PR DESCRIPTION
## Description

JIRA: [RHOAIENG-21398](https://issues.redhat.com/browse/RHOAIENG-21398)

This PR migrates as many instances of Client-Side Apply (CSA) to Server-Side Apply (SSA) as possible. There are some instances where CSA is kept due to constraints listed in the JIRA description or because the code in question is about to be refactored in an unrelated ticket.

## How Has This Been Tested?
These changes were tested by building operator, bundle, and catalog images, then verifying that the DSC and DSCI CRs successfully reconcile.

The following images were used for testing and can be used for verification:
```
quay.io/ckyrillo/opendatahub-operator:rhoaieng-21398-2
quay.io/ckyrillo/opendatahub-operator-bundle:rhoaieng-21398-2
quay.io/ckyrillo/opendatahub-operator-catalog:rhoaieng-21398-2
```

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work

## Summary by Sourcery

Migrate resource deployment logic from Client-Side Apply (CSA) to Server-Side Apply (SSA) across multiple components of the OpenDataHub operator

New Features:
- Introduce a centralized Apply method that supports Server-Side Apply with field ownership

Enhancements:
- Refactor resource management to use Server-Side Apply (SSA) for more consistent and predictable resource handling
- Standardize resource creation and update methods across different components of the operator

Chores:
- Remove multiple custom resource management methods in favor of a unified SSA approach
- Consolidate resource creation logic to reduce code complexity