### PR TITLE
Add sefroberg GH alias to owners list

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -14,6 +14,7 @@ aliases:
     - mlassak
     - resoluteCoder
     - robotmaxtron
+    - sefroberg
     - StevenTobin
     - ugiordan
     - valdar


### PR DESCRIPTION
Please add GitHub User sefroberg to the owners list. 
Jira ticket: https://issues.redhat.com/browse/RHOAIENG-21225

## Summary by Sourcery

Chores:
- Update OWNERS_ALIASES file to include sefroberg as a new team member