### PR TITLE
[sync] feat: migrate resource deploy logic to SSA

### DIFF
--- a/pkg/cluster/cluster_operations_int_test.go
+++ b/pkg/cluster/cluster_operations_int_test.go
@@ -61,7 +61,7 @@ var _ = Describe("Creating cluster resources", func() {
 
 			// then
 			Expect(err).ToNot(HaveOccurred())
-			Expect(existingNamespace).To(Equal(newNamespace))
+			Expect(existingNamespace.UID).To(Equal(newNamespace.UID))
 		})
 
 		It("should set labels", func(ctx context.Context) {

--- a/pkg/cluster/gvk/gvk.go
+++ b/pkg/cluster/gvk/gvk.go
@@ -13,6 +13,12 @@ import (
 )
 
 var (
+	Namespace = schema.GroupVersionKind{
+		Group:   "",
+		Version: "v1",
+		Kind:    "Namespace",
+	}
+
 	ClusterServiceVersion = schema.GroupVersionKind{
 		Group:   "operators.coreos.com",
 		Version: "v1alpha1",

--- a/pkg/controller/actions/deploy/action_deploy.go
+++ b/pkg/controller/actions/deploy/action_deploy.go
@@ -27,8 +27,6 @@ type Mode string
 const (
 	ModePatch Mode = "patch"
 	ModeSSA   Mode = "ssa"
-
-	PlatformFieldOwner = "platform.opendatahub.io"
 )
 
 // Action deploys the resources that are included in the ReconciliationRequest using
@@ -198,7 +196,7 @@ func (a *Action) deployCRD(
 		client.ForceOwnership,
 		// Since CRDs are not bound to a component, set the field
 		// owner to the platform itself
-		client.FieldOwner(PlatformFieldOwner),
+		client.FieldOwner(resources.PlatformFieldOwner),
 	}
 
 	switch a.deployMode {

--- a/pkg/resources/resources.go
+++ b/pkg/resources/resources.go
@@ -27,6 +27,8 @@ import (
 	"github.com/opendatahub-io/opendatahub-operator/v2/api/common"
 )
 
+const PlatformFieldOwner = "platform.opendatahub.io"
+
 func ToUnstructured(obj any) (*unstructured.Unstructured, error) {
 	data, err := runtime.DefaultUnstructuredConverter.ToUnstructured(obj)
 	if err != nil {


### PR DESCRIPTION
## Description
sync #1873

This PR also adds the GVK for the Namespace resource which was missing on `rhoai` for some reason.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work

## Summary by Sourcery

Migrate resource deployment logic to Server-Side Apply (SSA) across multiple components of the OpenDataHub operator

New Features:
- Add Group-Version-Kind (GVK) definition for Namespace resource
- Introduce centralized field owner management for resources

Enhancements:
- Refactor resource management to use Server-Side Apply (SSA) for more robust and consistent resource deployment
- Standardize resource creation and update processes using a centralized Apply method

Chores:
- Remove manual resource creation and update logic in favor of a more generic Apply method
- Consolidate resource management approaches across different components