### PR TITLE
Update go.mod to 1.23 and fix lint issues (#1858)

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   namespace: openshift
   name: release
-  tag: golang-1.22
+  tag: golang-1.23

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Additionally installing `Authorino operator` & `Service Mesh operator` enhances 
 
 #### Pre-requisites
 
-- Go version **go1.22**
+- Go version **go1.23**
 - operator-sdk version can be updated to **v1.37.0**
 
 #### Download manifests
@@ -206,7 +206,7 @@ e.g `make image-build USE_LOCAL=true"`
 **Deploying operator using OLM**
 
 - To create a new bundle in defined operator namespace, run following command:
-  
+
   ```commandline
   export OPERATOR_NAMESPACE=<namespace-to-install-operator>
   make bundle
@@ -215,13 +215,13 @@ e.g `make image-build USE_LOCAL=true"`
   **Note** : Skip the above step if you want to run the existing operator bundle.
 
 - Build Bundle Image:
-  
+
   ```commandline
   make bundle-build bundle-push BUNDLE_IMG=quay.io/<username>/opendatahub-operator-bundle:<VERSION>
   ```
 
 - Run the Bundle on a cluster:
-  
+
   ```commandline
   operator-sdk run bundle quay.io/<username>/opendatahub-operator-bundle:<VERSION> --namespace $OPERATOR_NAMESPACE --decompression-image quay.io/project-codeflare/busybox:1.36
   ```
@@ -237,7 +237,7 @@ There are 2 ways to test your changes with modification:
 
 Whenever a new api is added or a new field is added to the CRD, please make sure to run the command:
   ```commandline
-  make api-docs 
+  make api-docs
   ```
 This will ensure that the doc for the apis are updated accordingly.
 
@@ -305,7 +305,7 @@ Apply this example with modification for your usage.
 
 ### Example DataScienceCluster
 
-When the operator is installed successfully in the cluster, a user can create a `DataScienceCluster` CR to enable ODH 
+When the operator is installed successfully in the cluster, a user can create a `DataScienceCluster` CR to enable ODH
 components. At a given time, ODH supports only **one** instance of the CR, which can be updated to get custom list of components.
 
 1. Enable all components
@@ -349,7 +349,7 @@ spec:
     workbenches:
       managementState: Managed
     feastoperator:
-      managementState: Managed         
+      managementState: Managed
 ```
 
 2. Enable only Dashboard and Workbenches

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/opendatahub-io/opendatahub-operator/v2
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/blang/semver/v4 v4.0.0

--- a/pkg/rules/rules.go
+++ b/pkg/rules/rules.go
@@ -3,10 +3,10 @@ package rules
 import (
 	"context"
 	"fmt"
+	"maps"
 	"slices"
 	"strings"
 
-	"golang.org/x/exp/maps"
 	authorizationv1 "k8s.io/api/authorization/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -197,7 +197,7 @@ func ComputeDeletableResources(
 		}
 	}
 
-	result := maps.Keys(allowedResources)
+	result := slices.AppendSeq(make([]resources.Resource, 0, len(allowedResources)), maps.Keys(allowedResources))
 	slices.SortFunc(result, func(a, b resources.Resource) int {
 		return strings.Compare(a.String(), b.String())
 	})

--- a/tests/e2e/controller_test.go
+++ b/tests/e2e/controller_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"maps"
 	"os"
 	"slices"
 	"strings"
@@ -15,7 +16,6 @@ import (
 	ofapiv1 "github.com/operator-framework/api/pkg/operators/v1"
 	ofapi "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
-	"golang.org/x/exp/maps"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -223,7 +223,7 @@ func TestMain(m *testing.M) {
 	flag.BoolVar(&testOpts.operatorControllerTest, "test-operator-controller", true, "run operator controller tests")
 	flag.BoolVar(&testOpts.webhookTest, "test-webhook", true, "run webhook tests")
 
-	componentNames := strings.Join(maps.Keys(componentsTestSuites), ", ")
+	componentNames := strings.Join(slices.AppendSeq(make([]string, 0, len(componentsTestSuites)), maps.Keys(componentsTestSuites)), ", ")
 	flag.Var(&testOpts.components, "test-component", "run tests for the specified component. valid components names are: "+componentNames)
 
 	for _, n := range testOpts.components {
@@ -233,7 +233,7 @@ func TestMain(m *testing.M) {
 		}
 	}
 
-	serviceNames := strings.Join(maps.Keys(servicesTestSuites), ", ")
+	serviceNames := strings.Join(slices.AppendSeq(make([]string, 0, len(servicesTestSuites)), maps.Keys(servicesTestSuites)), ", ")
 	flag.Var(&testOpts.services, "test-service", "run tests for the specified service. valid service names are: "+serviceNames)
 
 	for _, n := range testOpts.components {


### PR DESCRIPTION
-------

<!---
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->
This is a manual cherry-pick of #1858.
<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work

## Summary by Sourcery

Update Go version to 1.23 and resolve associated linting and import issues

Bug Fixes:
- Replace deprecated golang.org/x/exp/maps import with standard library maps package

Enhancements:
- Update project to use Go 1.23, including updating go.mod and related configuration files

Tests:
- Update test-related code to be compatible with Go 1.23 standard library changes

Chores:
- Update README documentation to reflect new Go version
- Modify CI configuration to use Go 1.23 build root image