### PR TITLE
feat: Introduce dedicated ServiceMesh controller

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -95,6 +95,7 @@ import (
 	_ "github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/services/certconfigmapgenerator"
 	_ "github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/services/monitoring"
 	_ "github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/services/secretgenerator"
+	_ "github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/services/servicemesh"
 	_ "github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/services/setup"
 )
 

--- a/internal/controller/services/servicemesh/capabilities.go
+++ b/internal/controller/services/servicemesh/capabilities.go
@@ -1,4 +1,4 @@
-package dscinitialization
+package servicemesh
 
 import (
 	"errors"
@@ -31,7 +31,7 @@ func authorizationCondition(reason, message string) *conditionsv1.Condition {
 }
 
 func createCapabilityReporter(cli client.Client, object *dsciv1.DSCInitialization, successfulCondition *conditionsv1.Condition) *status.Reporter[*dsciv1.DSCInitialization] {
-	return status.NewStatusReporter[*dsciv1.DSCInitialization](
+	return status.NewStatusReporter(
 		cli,
 		object,
 		func(err error) status.SaveStatusFunc[*dsciv1.DSCInitialization] {

--- a/internal/controller/services/servicemesh/servicemesh.go
+++ b/internal/controller/services/servicemesh/servicemesh.go
@@ -1,0 +1,48 @@
+package servicemesh
+
+import (
+	"context"
+	"fmt"
+
+	operatorv1 "github.com/openshift/api/operator/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	"github.com/opendatahub-io/opendatahub-operator/v2/api/common"
+	sr "github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/services/registry"
+)
+
+const (
+	ServiceName = "servicemesh"
+)
+
+//nolint:gochecknoinits
+func init() {
+	sr.Add(&serviceHandler{})
+}
+
+type serviceHandler struct {
+}
+
+func (h *serviceHandler) Init(_ common.Platform) error {
+	return nil
+}
+
+func (h *serviceHandler) GetName() string {
+	return ServiceName
+}
+
+func (h *serviceHandler) GetManagementState(_ common.Platform) operatorv1.ManagementState {
+	return operatorv1.Managed
+}
+
+func (h *serviceHandler) NewReconciler(ctx context.Context, mgr ctrl.Manager) error {
+	rec := &ServiceMeshReconciler{
+		Client: mgr.GetClient(),
+	}
+
+	if err := rec.SetupWithManager(ctx, mgr); err != nil {
+		return fmt.Errorf("could not create the %s controller: %w", ServiceName, err)
+	}
+
+	return nil
+}

--- a/internal/controller/services/servicemesh/servicemesh_controller.go
+++ b/internal/controller/services/servicemesh/servicemesh_controller.go
@@ -1,0 +1,82 @@
+package servicemesh
+
+import (
+	"context"
+	"reflect"
+
+	"k8s.io/client-go/tools/record"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+
+	dsciv1 "github.com/opendatahub-io/opendatahub-operator/v2/api/dscinitialization/v1"
+)
+
+type ServiceMeshReconciler struct {
+	Client   client.Client
+	Recorder record.EventRecorder
+}
+
+func (r *ServiceMeshReconciler) dsciServiceMeshPredicate() predicate.Funcs {
+	return predicate.Funcs{
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			oldDsci, ok := e.ObjectOld.(*dsciv1.DSCInitialization)
+			if !ok {
+				return false
+			}
+			newDsci, ok := e.ObjectNew.(*dsciv1.DSCInitialization)
+			if !ok {
+				return false
+			}
+
+			return !reflect.DeepEqual(oldDsci.Spec.ServiceMesh, newDsci.Spec.ServiceMesh)
+		},
+
+		CreateFunc: func(e event.CreateEvent) bool {
+			return true
+		},
+
+		DeleteFunc: func(e event.DeleteEvent) bool {
+			return true
+		},
+	}
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *ServiceMeshReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager) error {
+	logf.FromContext(ctx).Info("Adding controller for ServiceMesh.")
+
+	return ctrl.NewControllerManagedBy(mgr).
+		Named("servicemesh-controller").
+		For(&dsciv1.DSCInitialization{}, builder.WithPredicates(r.dsciServiceMeshPredicate())).
+		Complete(r)
+}
+
+func (r *ServiceMeshReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	log := logf.FromContext(ctx)
+	log.Info("Reconciling ServiceMesh controller")
+
+	dsciInstance := &dsciv1.DSCInitialization{}
+	if err := r.Client.Get(ctx, req.NamespacedName, dsciInstance); err != nil {
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+
+	if !dsciInstance.DeletionTimestamp.IsZero() {
+		// DSCI is being deleted, remove ServiceMesh
+		if err := r.removeServiceMesh(ctx, dsciInstance); err != nil {
+			return ctrl.Result{}, err
+		}
+
+		return ctrl.Result{}, nil
+	}
+
+	// Apply Service Mesh configurations
+	if err := r.configureServiceMesh(ctx, dsciInstance); err != nil {
+		return ctrl.Result{}, err
+	}
+
+	return ctrl.Result{}, nil
+}

--- a/internal/controller/services/servicemesh/servicemesh_support.go
+++ b/internal/controller/services/servicemesh/servicemesh_support.go
@@ -1,4 +1,4 @@
-package dscinitialization
+package servicemesh
 
 import (
 	"context"
@@ -12,6 +12,7 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	dsciv1 "github.com/opendatahub-io/opendatahub-operator/v2/api/dscinitialization/v1"
+	dscictrl "github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/dscinitialization"
 	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/status"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/feature"
@@ -19,7 +20,7 @@ import (
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/feature/servicemesh"
 )
 
-func (r *DSCInitializationReconciler) configureServiceMesh(ctx context.Context, instance *dsciv1.DSCInitialization) error {
+func (r *ServiceMeshReconciler) configureServiceMesh(ctx context.Context, instance *dsciv1.DSCInitialization) error {
 	log := logf.FromContext(ctx)
 	serviceMeshManagementState := operatorv1.Removed
 	if instance.Spec.ServiceMesh != nil {
@@ -45,7 +46,7 @@ func (r *DSCInitializationReconciler) configureServiceMesh(ctx context.Context, 
 			capabilityErr := capability.Apply(ctx, r.Client)
 			if capabilityErr != nil {
 				log.Error(capabilityErr, "failed applying service mesh resources")
-				r.Recorder.Eventf(instance, corev1.EventTypeWarning, "DSCInitializationReconcileError", "failed applying service mesh resources")
+				r.Recorder.Eventf(instance, corev1.EventTypeWarning, "ServiceMeshReconcileError", "failed applying service mesh resources")
 				return capabilityErr
 			}
 		}
@@ -62,7 +63,7 @@ func (r *DSCInitializationReconciler) configureServiceMesh(ctx context.Context, 
 	return nil
 }
 
-func (r *DSCInitializationReconciler) removeServiceMesh(ctx context.Context, instance *dsciv1.DSCInitialization) error {
+func (r *ServiceMeshReconciler) removeServiceMesh(ctx context.Context, instance *dsciv1.DSCInitialization) error {
 	log := logf.FromContext(ctx)
 	// on condition of Managed, do not handle Removed when set to Removed it trigger DSCI reconcile to clean up
 	if instance.Spec.ServiceMesh == nil {
@@ -84,7 +85,7 @@ func (r *DSCInitializationReconciler) removeServiceMesh(ctx context.Context, ins
 			capabilityErr := capability.Delete(ctx, r.Client)
 			if capabilityErr != nil {
 				log.Error(capabilityErr, "failed deleting service mesh resources")
-				r.Recorder.Eventf(instance, corev1.EventTypeWarning, "DSCInitializationReconcileError", "failed deleting service mesh resources")
+				r.Recorder.Eventf(instance, corev1.EventTypeWarning, "ServiceMeshReconcileError", "failed deleting service mesh resources")
 
 				return capabilityErr
 			}
@@ -93,14 +94,14 @@ func (r *DSCInitializationReconciler) removeServiceMesh(ctx context.Context, ins
 	return nil
 }
 
-func (r *DSCInitializationReconciler) serviceMeshCapability(instance *dsciv1.DSCInitialization, initialCondition *conditionsv1.Condition) *feature.HandlerWithReporter[*dsciv1.DSCInitialization] { //nolint:lll // Reason: generics are long
+func (r *ServiceMeshReconciler) serviceMeshCapability(instance *dsciv1.DSCInitialization, initialCondition *conditionsv1.Condition) *feature.HandlerWithReporter[*dsciv1.DSCInitialization] { //nolint:lll // Reason: generics are long
 	return feature.NewHandlerWithReporter(
 		feature.ClusterFeaturesHandler(instance, r.serviceMeshCapabilityFeatures(instance)),
 		createCapabilityReporter(r.Client, instance, initialCondition),
 	)
 }
 
-func (r *DSCInitializationReconciler) authorizationCapability(ctx context.Context, instance *dsciv1.DSCInitialization, condition *conditionsv1.Condition) (*feature.HandlerWithReporter[*dsciv1.DSCInitialization], error) { //nolint:lll // Reason: generics are long
+func (r *ServiceMeshReconciler) authorizationCapability(ctx context.Context, instance *dsciv1.DSCInitialization, condition *conditionsv1.Condition) (*feature.HandlerWithReporter[*dsciv1.DSCInitialization], error) { //nolint:lll // Reason: generics are long
 	authorinoInstalled, err := cluster.SubscriptionExists(ctx, r.Client, "authorino-operator")
 	if err != nil {
 		return nil, fmt.Errorf("failed to list subscriptions %w", err)
@@ -128,7 +129,7 @@ func (r *DSCInitializationReconciler) authorizationCapability(ctx context.Contex
 	), nil
 }
 
-func (r *DSCInitializationReconciler) serviceMeshCapabilityFeatures(instance *dsciv1.DSCInitialization) feature.FeaturesProvider {
+func (r *ServiceMeshReconciler) serviceMeshCapabilityFeatures(instance *dsciv1.DSCInitialization) feature.FeaturesProvider {
 	return func(registry feature.FeaturesRegistry) error {
 		controlPlaneSpec := instance.Spec.ServiceMesh.ControlPlane
 
@@ -139,10 +140,9 @@ func (r *DSCInitializationReconciler) serviceMeshCapabilityFeatures(instance *ds
 		return registry.Add(
 			feature.Define("mesh-control-plane-creation").
 				Manifests(
-					manifest.Location(Templates.Location).
-						Include(
-							path.Join(Templates.ServiceMeshDir),
-						),
+					manifest.Location(dscictrl.Templates.Location).Include(
+						path.Join(dscictrl.Templates.ServiceMeshDir),
+					),
 				).
 				WithData(servicemesh.FeatureData.ControlPlane.Define(&instance.Spec).AsAction()).
 				PreConditions(
@@ -155,9 +155,9 @@ func (r *DSCInitializationReconciler) serviceMeshCapabilityFeatures(instance *ds
 			feature.Define("mesh-metrics-collection").
 				EnabledWhen(meshMetricsCollection).
 				Manifests(
-					manifest.Location(Templates.Location).
+					manifest.Location(dscictrl.Templates.Location).
 						Include(
-							path.Join(Templates.MetricsDir),
+							path.Join(dscictrl.Templates.MetricsDir),
 						),
 				).
 				WithData(
@@ -178,18 +178,18 @@ func (r *DSCInitializationReconciler) serviceMeshCapabilityFeatures(instance *ds
 	}
 }
 
-func (r *DSCInitializationReconciler) authorizationFeatures(instance *dsciv1.DSCInitialization) feature.FeaturesProvider {
+func (r *ServiceMeshReconciler) authorizationFeatures(instance *dsciv1.DSCInitialization) feature.FeaturesProvider {
 	return func(registry feature.FeaturesRegistry) error {
 		serviceMeshSpec := instance.Spec.ServiceMesh
 
 		return registry.Add(
 			feature.Define("mesh-control-plane-external-authz").
 				Manifests(
-					manifest.Location(Templates.Location).
+					manifest.Location(dscictrl.Templates.Location).
 						Include(
-							path.Join(Templates.AuthorinoDir, "auth-smm.tmpl.yaml"),
-							path.Join(Templates.AuthorinoDir, "base"),
-							path.Join(Templates.AuthorinoDir, "mesh-authz-ext-provider.patch.tmpl.yaml"),
+							path.Join(dscictrl.Templates.AuthorinoDir, "auth-smm.tmpl.yaml"),
+							path.Join(dscictrl.Templates.AuthorinoDir, "base"),
+							path.Join(dscictrl.Templates.AuthorinoDir, "mesh-authz-ext-provider.patch.tmpl.yaml"),
 						),
 				).
 				WithData(
@@ -215,8 +215,8 @@ func (r *DSCInitializationReconciler) authorizationFeatures(instance *dsciv1.DSC
 			// enabled instead, otherwise it will not have proxy pod injected.
 			feature.Define("enable-proxy-injection-in-authorino-deployment").
 				Manifests(
-					manifest.Location(Templates.Location).
-						Include(path.Join(Templates.AuthorinoDir, "deployment.injection.patch.tmpl.yaml")),
+					manifest.Location(dscictrl.Templates.Location).
+						Include(path.Join(dscictrl.Templates.AuthorinoDir, "deployment.injection.patch.tmpl.yaml")),
 				).
 				PreConditions(
 					func(ctx context.Context, cli client.Client, f *feature.Feature) error {


### PR DESCRIPTION
## Description
This PR introduces a new controller responsible for ServiceMesh setup/removal. This logic was extracted from the DSCI controller.

JIRA ref: [RHOAIENG-23147](https://issues.redhat.com/browse/RHOAIENG-23147)

## How Has This Been Tested?
- e2e test run against my local cluster
- installed operator -> created/modified DSCI with ServiceMesh config -> checked operator pod logs
- installed operator -> setup ODH with Dashboard, DSP, Workbenches, KServe and TrustyAI -> checked that the setup was successful

Utilized images:
`quay.io/repository/mlassak/opendatahub-operator:23147`
`quay.io/repository/mlassak/opendatahub-operator-bundle:v2.27.0-23147`
`quay.io/repository/mlassak/opendatahub-operator-catalog:v2.27.0-23147`

## Merge criteria

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced Service Mesh integration, including a new controller to manage Service Mesh configurations within DSCInitialization resources.
  - Service Mesh is now registered and initialized as part of the operator's service registry.
- **Refactor**
  - Updated and reorganized Service Mesh-related code for improved modularity and maintainability.
  - Adjusted event recording and manifest path references to align with new Service Mesh structure.
- **Bug Fixes**
  - Simplified DSCInitialization finalization and reconciliation by removing outdated Service Mesh configuration steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->