### PR TITLE
[RHOAIENG-25135] Updated default workbench namespace, namespace creation logic

### DIFF
--- a/api/components/v1alpha1/workbenches_types.go
+++ b/api/components/v1alpha1/workbenches_types.go
@@ -37,8 +37,8 @@ type WorkbenchesCommonSpec struct {
 	common.DevFlagsSpec `json:",inline"`
 	// workbenches spec exposed only to internal api
 
-	// Namespace for workbenches to be installed, configurable only once when workbenches are enabled, defaults to "rhods-notebooks"
-	// +kubebuilder:default="rhods-notebooks"
+	// Namespace for workbenches to be installed, configurable only once when workbenches are enabled, defaults to "opendatahub"
+	// +kubebuilder:default="opendatahub"
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="WorkbenchNamespace is immutable"
 	// +kubebuilder:validation:Pattern="^([a-z0-9]([-a-z0-9]*[a-z0-9])?)?$"
 	// +kubebuilder:validation:MaxLength=63

--- a/config/crd/bases/components.platform.opendatahub.io_workbenches.yaml
+++ b/config/crd/bases/components.platform.opendatahub.io_workbenches.yaml
@@ -75,9 +75,9 @@ spec:
                     type: array
                 type: object
               workbenchNamespace:
-                default: rhods-notebooks
+                default: opendatahub
                 description: Namespace for workbenches to be installed, configurable
-                  only once when workbenches are enabled, defaults to "rhods-notebooks"
+                  only once when workbenches are enabled, defaults to "opendatahub"
                 maxLength: 63
                 pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?)?$
                 type: string

--- a/config/crd/bases/datasciencecluster.opendatahub.io_datascienceclusters.yaml
+++ b/config/crd/bases/datasciencecluster.opendatahub.io_datascienceclusters.yaml
@@ -716,9 +716,9 @@ spec:
                         pattern: ^(Managed|Unmanaged|Force|Removed)$
                         type: string
                       workbenchNamespace:
-                        default: rhods-notebooks
+                        default: opendatahub
                         description: Namespace for workbenches to be installed, configurable
-                          only once when workbenches are enabled, defaults to "rhods-notebooks"
+                          only once when workbenches are enabled, defaults to "opendatahub"
                         maxLength: 63
                         pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?)?$
                         type: string

--- a/docs/api-overview.md
+++ b/docs/api-overview.md
@@ -535,7 +535,7 @@ _Appears in:_
 | --- | --- | --- | --- |
 | `managementState` _[ManagementState](#managementstate)_ | Set to one of the following values:<br /><br />- "Managed" : the operator is actively managing the component and trying to keep it active.<br />              It will only upgrade the component if it is safe to do so<br /><br />- "Removed" : the operator is actively managing the component and will not install it,<br />              or if it is installed, the operator will try to remove it |  | Enum: [Managed Removed] <br /> |
 | `devFlags` _[DevFlags](#devflags)_ | Add developer fields |  |  |
-| `workbenchNamespace` _string_ | Namespace for workbenches to be installed, configurable only once when workbenches are enabled, defaults to "rhods-notebooks" | rhods-notebooks | MaxLength: 63 <br />Pattern: `^([a-z0-9]([-a-z0-9]*[a-z0-9])?)?$` <br /> |
+| `workbenchNamespace` _string_ | Namespace for workbenches to be installed, configurable only once when workbenches are enabled, defaults to "opendatahub" | opendatahub | MaxLength: 63 <br />Pattern: `^([a-z0-9]([-a-z0-9]*[a-z0-9])?)?$` <br /> |
 
 
 #### DSCWorkbenchesStatus
@@ -1905,7 +1905,7 @@ _Appears in:_
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
 | `devFlags` _[DevFlags](#devflags)_ | Add developer fields |  |  |
-| `workbenchNamespace` _string_ | Namespace for workbenches to be installed, configurable only once when workbenches are enabled, defaults to "rhods-notebooks" | rhods-notebooks | MaxLength: 63 <br />Pattern: `^([a-z0-9]([-a-z0-9]*[a-z0-9])?)?$` <br /> |
+| `workbenchNamespace` _string_ | Namespace for workbenches to be installed, configurable only once when workbenches are enabled, defaults to "opendatahub" | opendatahub | MaxLength: 63 <br />Pattern: `^([a-z0-9]([-a-z0-9]*[a-z0-9])?)?$` <br /> |
 
 
 #### WorkbenchesCommonStatus
@@ -1960,7 +1960,7 @@ _Appears in:_
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
 | `devFlags` _[DevFlags](#devflags)_ | Add developer fields |  |  |
-| `workbenchNamespace` _string_ | Namespace for workbenches to be installed, configurable only once when workbenches are enabled, defaults to "rhods-notebooks" | rhods-notebooks | MaxLength: 63 <br />Pattern: `^([a-z0-9]([-a-z0-9]*[a-z0-9])?)?$` <br /> |
+| `workbenchNamespace` _string_ | Namespace for workbenches to be installed, configurable only once when workbenches are enabled, defaults to "opendatahub" | opendatahub | MaxLength: 63 <br />Pattern: `^([a-z0-9]([-a-z0-9]*[a-z0-9])?)?$` <br /> |
 
 
 #### WorkbenchesStatus

--- a/internal/controller/components/workbenches/workbenches_controller_actions.go
+++ b/internal/controller/components/workbenches/workbenches_controller_actions.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/api/components/v1alpha1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
@@ -92,26 +92,31 @@ func configureDependencies(ctx context.Context, rr *odhtypes.ReconciliationReque
 		return fmt.Errorf("resource instance %v is not a componentApi.Workbenches", rr.Instance)
 	}
 
-	wbNS := &corev1.Namespace{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: cluster.DefaultNotebooksNamespace,
-			Labels: map[string]string{
-				labels.ODH.OwnedNamespace: "true",
-			},
-		}}
+	wbNS := &corev1.Namespace{}
+
+	switch rr.Release.Name {
+	case cluster.SelfManagedRhoai, cluster.ManagedRhoai:
+		wbNS.Name = cluster.DefaultNotebooksNamespaceRHOAI
+
+	case cluster.OpenDataHub:
+		wbNS.Name = cluster.DefaultNotebooksNamespaceODH
+		wbNS.Labels = map[string]string{
+			labels.ODH.OwnedNamespace: "true",
+		}
+	}
 
 	if workbench.Spec.WorkbenchNamespace != "" || len(workbench.Spec.WorkbenchNamespace) > 0 {
 		wbNS.Name = workbench.Spec.WorkbenchNamespace
 	}
 
-	platform := rr.Release.Name
-	if platform == cluster.SelfManagedRhoai || platform == cluster.ManagedRhoai {
-		// Intentionally leaving the ownership unset for this namespace.
-		// Specifying this label triggers its deletion when the operator is uninstalled.
-		if err := rr.AddResources(wbNS); err != nil {
-			return fmt.Errorf("failed to add namespace %s to manifests", wbNS.Name)
-		}
+	err := rr.Client.Create(ctx, wbNS)
+	if err != nil && !errors.IsAlreadyExists(err) {
+		return fmt.Errorf("failed to create namespace %s: %w", wbNS.Name, err)
 	}
 
+	err = rr.AddResources(wbNS)
+	if err != nil {
+		return fmt.Errorf("failed to add resource to workbenches: %w", err)
+	}
 	return nil
 }

--- a/pkg/cluster/const.go
+++ b/pkg/cluster/const.go
@@ -10,8 +10,10 @@ const (
 	// OpenDataHub defines display name in csv.
 	OpenDataHub common.Platform = "Open Data Hub"
 
-	// DefaultNotebooksNamespace defines default namespace for notebooks.
-	DefaultNotebooksNamespace = "rhods-notebooks"
+	// DefaultNotebooksNamespaceODH defines default namespace for notebooks.
+	DefaultNotebooksNamespaceODH = "opendatahub"
+	// DefaultNotebooksNamespaceRHOAI defines default namespace for notebooks.
+	DefaultNotebooksNamespaceRHOAI = "rhods-notebooks"
 
 	// Default cluster-scope Authentication CR name.
 	ClusterAuthenticationObj = "cluster"


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->
Updated default workbench namespace back to opendatahub.
Updated logic to always attempt to create the workbench namespace.

Fixes RHOAIENG-25135
<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

On a 4.18.11 cluster, I was successfully able to 

- create the default `opendatahub` namespace when it did not exist.
- create the default `rhods-notebooks` namespace when it did not exist.
- create a new `custom-notebook-ns` namespace when it did not exist.

I've ensured there is also logic that will ignore the error if the namespace already exists.

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Updated the default namespace for workbenches from "rhods-notebooks" to "opendatahub" across the platform.
- **Documentation**
  - Revised documentation and API schema descriptions to reflect the new default namespace.
- **Refactor**
  - Introduced distinct constants for default namespaces to support multiple deployment contexts.
  - Enhanced namespace creation process with explicit creation and improved error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->