### PR TITLE
Use SSA for default NetworkPolicy creation

### DIFF
--- a/internal/controller/dscinitialization/dscinitialization_controller.go
+++ b/internal/controller/dscinitialization/dscinitialization_controller.go
@@ -57,6 +57,7 @@ import (
 
 const (
 	finalizerName = "dscinitialization.opendatahub.io/finalizer"
+	fieldManager  = "dscinitialization.opendatahub.io"
 )
 
 // DSCInitializationReconciler reconciles a DSCInitialization object.
@@ -419,7 +420,7 @@ func (r *DSCInitializationReconciler) newMonitoringCR(ctx context.Context, dsci 
 		ctx,
 		r.Client,
 		defaultMonitoring,
-		client.FieldOwner("dscinitialization.opendatahub.io"),
+		client.FieldOwner(fieldManager),
 		client.ForceOwnership,
 	)
 

--- a/pkg/cluster/gvk/gvk.go
+++ b/pkg/cluster/gvk/gvk.go
@@ -8,6 +8,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	coordinationv1 "k8s.io/api/coordination/v1"
 	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
@@ -341,5 +342,11 @@ var (
 		Group:   "operators.coreos.com",
 		Version: "v2",
 		Kind:    "OperatorCondition",
+	}
+
+	NetworkPolicy = schema.GroupVersionKind{
+		Group:   networkingv1.SchemeGroupVersion.Group,
+		Version: networkingv1.SchemeGroupVersion.Version,
+		Kind:    "NetworkPolicy",
 	}
 )

--- a/tests/e2e/creation_test.go
+++ b/tests/e2e/creation_test.go
@@ -57,6 +57,7 @@ func dscManagementTestSuite(t *testing.T) {
 		{"Validate ServiceMeshSpec in DSCInitialization instance", dscTestCtx.ValidateServiceMeshSpecInDSCI},
 		{"Validate Knative resource", dscTestCtx.ValidateKnativeSpecInDSC},
 		{"Validate owned namespaces exist", dscTestCtx.ValidateOwnedNamespacesAllExist},
+		{"Validate default NetworkPolicy exist", dscTestCtx.ValidateDefaultNetworkPolicyExists},
 	}
 
 	// Append webhook-specific tests.
@@ -210,6 +211,19 @@ func (tc *DSCTestCtx) ValidateOwnedNamespacesAllExist(t *testing.T) {
 			}),
 		WithCondition(BeNumerically(">=", ownedNamespaceNumber)),
 		WithCustomErrorMsg("Expected at least %d owned namespaces with label '%s'.", ownedNamespaceNumber, labels.ODH.OwnedNamespace),
+	)
+}
+
+// ValidateDefaultNetworkPolicyExists verifies that the default network policy exists.
+func (tc *DSCTestCtx) ValidateDefaultNetworkPolicyExists(t *testing.T) {
+	t.Helper()
+
+	dsci := tc.FetchDSCInitialization()
+
+	// Ensure namespaces with the owned namespace label exist.
+	tc.EnsureResourcesExist(
+		WithMinimalObject(gvk.NetworkPolicy, types.NamespacedName{Namespace: dsci.Spec.ApplicationsNamespace, Name: dsci.Spec.ApplicationsNamespace}),
+		WithCustomErrorMsg("Expected the default NetworkPolicy to be created."),
 	)
 }
 


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Simplified and unified network policy management for improved maintainability and reliability.
  - Centralized field manager identifier for consistent resource ownership.
- **New Features**
  - Introduced declarative application of network policies with improved ingress rule construction.
- **Tests**
  - Added a new test to verify that the default NetworkPolicy exists in the expected namespace.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->