### PR TITLE
fix: when servicemesh is not managed in DSCI should not have MissingOperator True

### DIFF
--- a/internal/controller/services/servicemesh/servicemesh_support.go
+++ b/internal/controller/services/servicemesh/servicemesh_support.go
@@ -54,9 +54,33 @@ func (r *ServiceMeshReconciler) configureServiceMesh(ctx context.Context, instan
 
 	case operatorv1.Unmanaged:
 		log.Info("ServiceMesh CR is not configured by the operator, we won't do anything")
+		// Update status ServiceMesh is unmanaged
+		conditions := instance.Status.Conditions
+		status.SetCondition(&conditions, status.CapabilityServiceMesh, status.MissingOperatorReason,
+			"ServiceMesh is Unmanaged in DSCI", metav1.ConditionFalse)
+		instance.Status.SetConditions(conditions)
+		if err := r.Client.Status().Update(ctx, instance); err != nil {
+			log.Error(err, "failed to update DSCI status condition for ServiceMesh")
+			return err
+		}
+
 	case operatorv1.Removed:
 		log.Info("existing ServiceMesh CR (owned by operator) will be removed")
 		if err := r.removeServiceMesh(ctx, instance); err != nil {
+			return err
+		}
+
+		// Remove condition if it was set when DSCI has Removed
+		conditions := instance.Status.Conditions
+		newConditions := []common.Condition{}
+		for _, cond := range conditions {
+			if cond.Type != status.CapabilityServiceMesh {
+				newConditions = append(newConditions, cond)
+			}
+		}
+		instance.Status.SetConditions(newConditions)
+		if err := r.Client.Status().Update(ctx, instance); err != nil {
+			log.Error(err, "failed to remove status condition for Removed ServiceMesh case")
 			return err
 		}
 	}

--- a/internal/controller/services/servicemesh/servicemesh_support.go
+++ b/internal/controller/services/servicemesh/servicemesh_support.go
@@ -73,10 +73,16 @@ func (r *ServiceMeshReconciler) configureServiceMesh(ctx context.Context, instan
 		// Remove condition if it was set when DSCI has Removed
 		conditions := instance.Status.Conditions
 		newConditions := []common.Condition{}
+		conditionExists := false
 		for _, cond := range conditions {
 			if cond.Type != status.CapabilityServiceMesh {
 				newConditions = append(newConditions, cond)
+			} else {
+				conditionExists = true
 			}
+		}
+		if !conditionExists {
+			return nil // fast exit
 		}
 		instance.Status.SetConditions(newConditions)
 		if err := r.Client.Status().Update(ctx, instance); err != nil {

--- a/internal/controller/status/status.go
+++ b/internal/controller/status/status.go
@@ -112,6 +112,7 @@ const (
 	MissingOperatorReason     string = "MissingOperator"
 	ConfiguredReason          string = "Configured"
 	RemovedReason             string = "Removed"
+	UnmanagedReason           string = "Unmanaged"
 	CapabilityFailed          string = "CapabilityFailed"
 	ArgoWorkflowExist         string = "ArgoWorkflowExist"
 	NoManagedComponentsReason        = "NoManagedComponents"


### PR DESCRIPTION
- if Removed: do not show this condition at all
- if Unmanaged: have missingoperator to False on CapabilityServiceMesh type

<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->
follow changes from https://github.com/opendatahub-io/opendatahub-operator/pull/1894

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved status reporting for ServiceMesh capability, including clear indicators when ServiceMesh is unmanaged or removed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->