### PR TITLE
[backport]fix: need apply application NWP for self-managed cluster

### DIFF
--- a/internal/controller/dscinitialization/utils.go
+++ b/internal/controller/dscinitialization/utils.go
@@ -162,7 +162,7 @@ func ReconcileDefaultNetworkPolicy(
 	dscInit *dsciv1.DSCInitialization,
 	platform common.Platform,
 ) error {
-	if platform == cluster.ManagedRhoai {
+	if platform == cluster.ManagedRhoai || platform == cluster.SelfManagedRhoai {
 		log := logf.FromContext(ctx)
 
 		// Get operator namepsace
@@ -177,11 +177,13 @@ func ReconcileDefaultNetworkPolicy(
 			log.Error(err, "error to set networkpolicy in operator namespace", "path", networkpolicyPath)
 			return err
 		}
-		// Deploy networkpolicy for monitoring namespace
-		err = deploy.DeployManifestsFromPath(ctx, cli, dscInit, networkpolicyPath+"/monitoring", dscInit.Spec.Monitoring.Namespace, "networkpolicy", true)
-		if err != nil {
-			log.Error(err, "error to set networkpolicy in monitroing namespace", "path", networkpolicyPath)
-			return err
+		// Deploy networkpolicy for monitoring namespace only when it is managed cluster.
+		if platform == cluster.ManagedRhoai {
+			err = deploy.DeployManifestsFromPath(ctx, cli, dscInit, networkpolicyPath+"/monitoring", dscInit.Spec.Monitoring.Namespace, "networkpolicy", true)
+			if err != nil {
+				log.Error(err, "error to set networkpolicy in monitroing namespace", "path", networkpolicyPath)
+				return err
+			}
 		}
 		// Deploy networkpolicy for applications namespace
 		err = deploy.DeployManifestsFromPath(ctx, cli, dscInit, networkpolicyPath+"/applications", dscInit.Spec.ApplicationsNamespace, "networkpolicy", true)

--- a/internal/controller/dscinitialization/utils.go
+++ b/internal/controller/dscinitialization/utils.go
@@ -181,7 +181,7 @@ func ReconcileDefaultNetworkPolicy(
 		if platform == cluster.ManagedRhoai {
 			err = deploy.DeployManifestsFromPath(ctx, cli, dscInit, networkpolicyPath+"/monitoring", dscInit.Spec.Monitoring.Namespace, "networkpolicy", true)
 			if err != nil {
-				log.Error(err, "error to set networkpolicy in monitroing namespace", "path", networkpolicyPath)
+				log.Error(err, "error to set networkpolicy in monitoring namespace", "path", networkpolicyPath)
 				return err
 			}
 		}


### PR DESCRIPTION
- monitoring NWP can be only for managed cluster
- components might require certain ports e.g 9443 to be open

<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->
backport https://github.com/red-hat-data-services/rhods-operator/pull/7972

<!--- Link your JIRA and related links here for reference. -->
ref: https://issues.redhat.com/browse/RHOAIENG-26005

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of network policy deployment to better support both managed and self-managed platforms, ensuring the monitoring namespace network policy is only applied where appropriate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->