### PR TITLE
RHOAI-452 | feat: modified code to only use wait.ExponentialBackoffWithContext

### DIFF
--- a/internal/controller/dscinitialization/utils.go
+++ b/internal/controller/dscinitialization/utils.go
@@ -26,8 +26,7 @@ import (
 )
 
 var (
-	resourceInterval = 10 * time.Second
-	resourceTimeout  = 1 * time.Minute
+	resourceInterval = 2 * time.Second
 )
 
 // createOperatorResource include steps:
@@ -239,7 +238,13 @@ func ReconcileDefaultNetworkPolicy(
 
 func (r *DSCInitializationReconciler) waitForManagedSecret(ctx context.Context, name string, namespace string) (*corev1.Secret, error) {
 	managedSecret := &corev1.Secret{}
-	err := wait.PollUntilContextTimeout(ctx, resourceInterval, resourceTimeout, false, func(ctx context.Context) (bool, error) {
+	backoff := wait.Backoff{
+		Duration: resourceInterval,
+		Factor:   2.0,
+		Steps:    5,
+	}
+
+	err := wait.ExponentialBackoffWithContext(ctx, backoff, func(ctx context.Context) (bool, error) {
 		err := r.Client.Get(ctx, client.ObjectKey{
 			Namespace: namespace,
 			Name:      name,

--- a/pkg/upgrade/upgrade.go
+++ b/pkg/upgrade/upgrade.go
@@ -206,7 +206,7 @@ func CreateDefaultDSC(ctx context.Context, cli client.Client) error {
 			},
 		},
 	}
-	err := cluster.CreateWithRetry(ctx, cli, releaseDataScienceCluster, 1) // 1 min timeout
+	err := cluster.CreateWithRetry(ctx, cli, releaseDataScienceCluster) // 1 min timeout
 	if err != nil {
 		return fmt.Errorf("failed to create DataScienceCluster custom resource: %w", err)
 	}
@@ -264,7 +264,7 @@ func CreateDefaultDSCI(ctx context.Context, cli client.Client, _ common.Platform
 		return nil
 	case len(instances.Items) == 0:
 		log.Info("create default DSCI CR.")
-		err := cluster.CreateWithRetry(ctx, cli, defaultDsci, 1) // 1 min timeout
+		err := cluster.CreateWithRetry(ctx, cli, defaultDsci) // 1 min timeout
 		if err != nil {
 			return err
 		}

--- a/tests/integration/features/servicemesh_feature_test.go
+++ b/tests/integration/features/servicemesh_feature_test.go
@@ -188,7 +188,7 @@ var _ = Describe("Service Mesh setup", func() {
 					Expect(featuresHandler.Apply(ctx, envTestClient)).To(Succeed())
 				})
 
-				It("should fail to find Service Mesh Control Plane if not present", func(ctx context.Context) {
+				It("should fail to find Service Mesh Control Plane if not ready", func(ctx context.Context) {
 					// given
 					dsci.Spec.ServiceMesh.ControlPlane.Name = "test-name"
 					dsci.Spec.ServiceMesh.ControlPlane.Namespace = "test-namespace"
@@ -206,7 +206,8 @@ var _ = Describe("Service Mesh setup", func() {
 					})
 
 					// then
-					Expect(featuresHandler.Apply(ctx, envTestClient)).To(MatchError(ContainSubstring("failed to find Service Mesh Control Plane")))
+					expectedError := "service mesh control plane is not ready"
+					Expect(featuresHandler.Apply(ctx, envTestClient)).To(MatchError(ContainSubstring(expectedError)))
 				})
 
 			})


### PR DESCRIPTION


<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
Modified code to use wait.ExponentialBackoffWithContext instead of wait.PollUntilContextTimeout()

[Jira](https://issues.redhat.com/browse/RHOAIENG-452)

## How Has This Been Tested?
Deployed operator onto cluster -> worked fine
Ran tests

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved reliability of resource polling and retry mechanisms by switching from fixed-interval polling to exponential backoff strategies across various operations.
  - Adjusted polling intervals and timeouts for more efficient resource checks and retries.
  - Simplified function interfaces by removing unnecessary timeout parameters in some resource creation functions.

- **Style**
  - Updated internal logic to use consistent exponential backoff patterns for waiting and retry operations.

- **Bug Fixes**
  - Corrected error messaging related to Service Mesh Control Plane readiness.
  - Updated test cases to reflect changes in error messages for control plane readiness checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->