### PR TITLE
Revert "chore: add cherrypick bot as owner"

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -19,4 +19,3 @@ aliases:
     - ugiordan
     - valdar
     - zdtsw
-    - openshift-cherrypick-robot


### PR DESCRIPTION
Reverts opendatahub-io/opendatahub-operator#1944

Konflux pipeline made a fix on this bug https://github.com/openshift-pipelines/pipelines-as-code/pull/2074
no need add bot in OWNER

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the platform alias list by removing an entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->