### PR TITLE
test: add regression test for nil TrustedCABundle in DSCInitialization

### DIFF
--- a/internal/controller/services/certconfigmapgenerator/certconfigmapgenerator_test.go
+++ b/internal/controller/services/certconfigmapgenerator/certconfigmapgenerator_test.go
@@ -76,6 +76,25 @@ func TestCertConfigmapGeneratorReconciler(t *testing.T) {
 	err = env.Client().Create(gctx, &ns2)
 	g.Expect(err).ShouldNot(HaveOccurred())
 
+	t.Run("TrustedCABundle missing (nil)", func(t *testing.T) {
+		ctx := context.Background()
+		g := G(t)
+
+		// Remove TrustedCABundle from the spec (set to nil)
+		_, err = ctrl.CreateOrUpdate(ctx, env.Client(), &dsci, func() error {
+			dsci.Spec.TrustedCABundle = nil
+			return nil
+		})
+
+		g.Expect(err).ShouldNot(HaveOccurred())
+
+		g.Consistently(func() ([]corev1.ConfigMap, error) {
+			return listCABundleConfigMaps(ctx, env.Client())
+		}).Should(
+			BeEmpty(),
+		)
+	})
+
 	t.Run("TrustedCABundle set to Removed", func(t *testing.T) {
 		ctx := context.Background()
 		g := G(t)


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->
This PR adds a regression test to the `certconfigmapgenerator` controller to ensure that DSCInitialization resources with a missing (`nil`) `TrustedCABundle` field are handled safely.  
The test verifies that the controller does not panic and does not inject a CA bundle ConfigMap when `TrustedCABundle` is omitted, covering the scenario described in RHOAIENG-25073.

<!--- Link your JIRA and related links here for reference. -->
- Jira: [RHOAIENG-25073](https://issues.redhat.com/browse/RHOAIENG-25073)
- Related fix/refactor: [PR #1861](https://github.com/opendatahub-io/opendatahub-operator/pull/1861)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
- Added a new unit test in `certconfigmapgenerator_test.go` that sets `TrustedCABundle` to nil in the DSCInitialization spec.
- Ran the test suite locally using `go test ./internal/controller/services/certconfigmapgenerator -v` with the appropriate envtest binaries.
- Also ran all unit tests with `make unit-test` to ensure the change does not break any other tests.
- Verified that the test passes and that no CA bundle ConfigMap is created when `TrustedCABundle` is nil.

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->
N/A (test-only change)

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work