### PR TITLE
If TrustedCABundle ManagementState is set to Unmanaged. controller should not remove odh-trusted-ca-bundle ConfigMap

### DIFF
--- a/internal/controller/services/certconfigmapgenerator/certconfigmapgenerator_support.go
+++ b/internal/controller/services/certconfigmapgenerator/certconfigmapgenerator_support.go
@@ -4,6 +4,7 @@ package certconfigmapgenerator
 import (
 	"context"
 	"reflect"
+	"strconv"
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
@@ -16,6 +17,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	dsciv1 "github.com/opendatahub-io/opendatahub-operator/v2/api/dscinitialization/v1"
+	annotation "github.com/opendatahub-io/opendatahub-operator/v2/pkg/metadata/annotations"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/metadata/labels"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/resources"
 )
@@ -84,6 +86,20 @@ func DeleteOdhTrustedCABundleConfigMap(ctx context.Context, cli client.Client, n
 	}
 
 	return nil
+}
+
+func ShouldInjectTrustedCABundle(obj client.Object) bool {
+	value, found := obj.GetAnnotations()[annotation.InjectionOfCABundleAnnotatoion]
+	if !found {
+		return true
+	}
+
+	shouldInject, err := strconv.ParseBool(value)
+	if err != nil {
+		return true
+	}
+
+	return shouldInject
 }
 
 // dsciEventHandler creates an event handler for DSCInitialization events. When a DSCInitialization

--- a/internal/controller/services/certconfigmapgenerator/certconfigmapgenerator_test.go
+++ b/internal/controller/services/certconfigmapgenerator/certconfigmapgenerator_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/rs/xid"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -29,7 +30,16 @@ func init() {
 	log.SetLogger(zap.New(zap.UseDevMode(true)))
 }
 
-//nolint:dupl
+func G(t *testing.T) *WithT {
+	t.Helper()
+
+	g := NewWithT(t)
+	g.DurationBundle.EventuallyTimeout = 30 * time.Second
+	g.DurationBundle.ConsistentlyDuration = 15 * time.Second
+
+	return g
+}
+
 func TestCertConfigmapGeneratorReconciler(t *testing.T) {
 	g := NewWithT(t)
 	gctx, cancel := context.WithCancel(context.Background())
@@ -73,50 +83,14 @@ func TestCertConfigmapGeneratorReconciler(t *testing.T) {
 	ns2.Name = xid.New().String()
 	ns2.Annotations = map[string]string{}
 
+	ns3 := corev1.Namespace{}
+	ns3.Name = "openshift-" + xid.New().String()
+	ns3.Annotations = map[string]string{}
+
 	err = env.Client().Create(gctx, &ns2)
 	g.Expect(err).ShouldNot(HaveOccurred())
 
-	t.Run("TrustedCABundle missing (nil)", func(t *testing.T) {
-		ctx := context.Background()
-		g := G(t)
-
-		// Remove TrustedCABundle from the spec (set to nil)
-		_, err = ctrl.CreateOrUpdate(ctx, env.Client(), &dsci, func() error {
-			dsci.Spec.TrustedCABundle = nil
-			return nil
-		})
-
-		g.Expect(err).ShouldNot(HaveOccurred())
-
-		g.Consistently(func() ([]corev1.ConfigMap, error) {
-			return listCABundleConfigMaps(ctx, env.Client())
-		}).Should(
-			BeEmpty(),
-		)
-	})
-
-	t.Run("TrustedCABundle set to Removed", func(t *testing.T) {
-		ctx := context.Background()
-		g := G(t)
-
-		_, err = ctrl.CreateOrUpdate(ctx, env.Client(), &dsci, func() error {
-			dsci.Spec.TrustedCABundle = &dsciv1.TrustedCABundleSpec{
-				ManagementState: operatorv1.Removed,
-			}
-
-			return nil
-		})
-
-		g.Expect(err).ShouldNot(HaveOccurred())
-
-		g.Consistently(func() ([]corev1.ConfigMap, error) {
-			return listCABundleConfigMaps(ctx, env.Client())
-		}).Should(
-			BeEmpty(),
-		)
-	})
-
-	t.Run("TrustedCABundle set to Managed", func(t *testing.T) {
+	t.Run("TrustedCABundle ManagementState set to Managed", func(t *testing.T) {
 		ctx := context.Background()
 		g := G(t)
 
@@ -124,39 +98,26 @@ func TestCertConfigmapGeneratorReconciler(t *testing.T) {
 			ns1.Annotations = map[string]string{
 				annotation.InjectionOfCABundleAnnotatoion: "false",
 			}
-
 			return nil
 		})
 
-		g.Expect(err).ShouldNot(HaveOccurred())
-
-		err = env.Client().Update(ctx, &ns1)
 		g.Expect(err).ShouldNot(HaveOccurred())
 
 		_, err = ctrl.CreateOrUpdate(ctx, env.Client(), &dsci, func() error {
 			dsci.Spec.TrustedCABundle = &dsciv1.TrustedCABundleSpec{
 				ManagementState: operatorv1.Managed,
 			}
-
 			return nil
 		})
 
 		g.Expect(err).ShouldNot(HaveOccurred())
 
-		g.Consistently(func() (*corev1.ConfigMap, error) {
-			return getCABundlesConfigMap(ctx, env.Client(), ns1.Name)
-		}).Should(
-			BeNil(),
-		)
-
-		g.Expect(func() (*corev1.ConfigMap, error) {
-			return getCABundlesConfigMap(ctx, env.Client(), ns2.Name)
-		}).ShouldNot(
-			BeNil(),
-		)
+		g.Consistently(getCABundlesConfigMap(ctx, env.Client(), ns1.Name)).Should(BeNil())
+		g.Eventually(getCABundlesConfigMap(ctx, env.Client(), ns2.Name)).ShouldNot(BeNil())
+		g.Consistently(getCABundlesConfigMap(ctx, env.Client(), ns3.Name)).Should(BeNil())
 	})
 
-	t.Run("Namespace opt-in", func(t *testing.T) {
+	t.Run("TrustedCABundle ManagementState set to Managed, Namespace opt-in", func(t *testing.T) {
 		ctx := context.Background()
 		g := G(t)
 
@@ -164,39 +125,53 @@ func TestCertConfigmapGeneratorReconciler(t *testing.T) {
 			ns1.Annotations = map[string]string{
 				annotation.InjectionOfCABundleAnnotatoion: "true",
 			}
-
 			return nil
 		})
-
 		g.Expect(err).ShouldNot(HaveOccurred())
 
-		err = env.Client().Update(ctx, &ns1)
+		g.Eventually(getCABundlesConfigMap(ctx, env.Client(), ns1.Name)).ShouldNot(BeNil())
+		g.Eventually(getCABundlesConfigMap(ctx, env.Client(), ns2.Name)).ShouldNot(BeNil())
+		g.Consistently(getCABundlesConfigMap(ctx, env.Client(), ns3.Name)).Should(BeNil())
+	})
+
+	t.Run("TrustedCABundle ManagementState set to Managed, Namespace opt-out", func(t *testing.T) {
+		ctx := context.Background()
+		g := G(t)
+
+		_, err = ctrl.CreateOrUpdate(ctx, env.Client(), &ns1, func() error {
+			ns1.Annotations = map[string]string{
+				annotation.InjectionOfCABundleAnnotatoion: "False",
+			}
+			return nil
+		})
 		g.Expect(err).ShouldNot(HaveOccurred())
+
+		g.Eventually(getCABundlesConfigMap(ctx, env.Client(), ns1.Name)).Should(BeNil())
+		g.Consistently(getCABundlesConfigMap(ctx, env.Client(), ns1.Name)).Should(BeNil())
+
+		g.Eventually(getCABundlesConfigMap(ctx, env.Client(), ns2.Name)).ShouldNot(BeNil())
+		g.Consistently(getCABundlesConfigMap(ctx, env.Client(), ns3.Name)).Should(BeNil())
+	})
+
+	t.Run("TrustedCABundle ManagementState set to Unmanaged", func(t *testing.T) {
+		ctx := context.Background()
+		g := G(t)
 
 		_, err = ctrl.CreateOrUpdate(ctx, env.Client(), &dsci, func() error {
 			dsci.Spec.TrustedCABundle = &dsciv1.TrustedCABundleSpec{
-				ManagementState: operatorv1.Managed,
+				ManagementState: operatorv1.Unmanaged,
 			}
-
 			return nil
 		})
 
 		g.Expect(err).ShouldNot(HaveOccurred())
 
-		g.Expect(func() (*corev1.ConfigMap, error) {
-			return getCABundlesConfigMap(ctx, env.Client(), ns1.Name)
-		}).ShouldNot(
-			BeNil(),
-		)
-
-		g.Expect(func() (*corev1.ConfigMap, error) {
-			return getCABundlesConfigMap(ctx, env.Client(), ns2.Name)
-		}).ShouldNot(
-			BeNil(),
-		)
+		g.Consistently(getCABundlesConfigMap(ctx, env.Client(), ns1.Name)).Should(BeNil())
+		g.Consistently(getCABundlesConfigMap(ctx, env.Client(), ns2.Name)).ShouldNot(BeNil())
+		g.Consistently(getCABundlesConfigMap(ctx, env.Client(), ns3.Name)).Should(BeNil())
 	})
 
-	t.Run("TrustedCABundle reset to Removed", func(t *testing.T) {
+	t.Run("TrustedCABundle ManagementState set to Removed", func(t *testing.T) {
 		ctx := context.Background()
 		g := G(t)
 
@@ -204,66 +179,160 @@ func TestCertConfigmapGeneratorReconciler(t *testing.T) {
 			dsci.Spec.TrustedCABundle = &dsciv1.TrustedCABundleSpec{
 				ManagementState: operatorv1.Removed,
 			}
-
 			return nil
 		})
 
 		g.Expect(err).ShouldNot(HaveOccurred())
 
-		g.Eventually(func() ([]corev1.ConfigMap, error) {
-			return listCABundleConfigMaps(ctx, env.Client())
-		}).Should(
-			BeEmpty(),
-		)
+		g.Eventually(listCABundleConfigMaps(ctx, env.Client())).Should(BeEmpty())
+		g.Consistently(listCABundleConfigMaps(ctx, env.Client())).Should(BeEmpty())
+	})
+
+	t.Run("TrustedCABundle set to nil", func(t *testing.T) {
+		ctx := context.Background()
+		g := G(t)
+
+		_, err = ctrl.CreateOrUpdate(ctx, env.Client(), &dsci, func() error {
+			dsci.Spec.TrustedCABundle = &dsciv1.TrustedCABundleSpec{
+				ManagementState: operatorv1.Managed,
+			}
+			return nil
+		})
+
+		g.Expect(err).ShouldNot(HaveOccurred())
+
+		g.Consistently(getCABundlesConfigMap(ctx, env.Client(), ns1.Name)).Should(BeNil())
+		g.Eventually(getCABundlesConfigMap(ctx, env.Client(), ns2.Name)).ShouldNot(BeNil())
+		g.Consistently(getCABundlesConfigMap(ctx, env.Client(), ns3.Name)).Should(BeNil())
+
+		_, err = ctrl.CreateOrUpdate(ctx, env.Client(), &dsci, func() error {
+			dsci.Spec.TrustedCABundle = nil
+			return nil
+		})
+
+		g.Expect(err).ShouldNot(HaveOccurred())
+
+		g.Eventually(listCABundleConfigMaps(ctx, env.Client())).Should(BeEmpty())
+		g.Consistently(listCABundleConfigMaps(ctx, env.Client())).Should(BeEmpty())
 	})
 }
 
-func G(t *testing.T) *WithT {
-	t.Helper()
+func listCABundleConfigMaps(ctx context.Context, cli client.Client) func() ([]corev1.ConfigMap, error) {
+	return func() ([]corev1.ConfigMap, error) {
+		items := corev1.ConfigMapList{}
 
-	g := NewWithT(t)
-	g.DurationBundle.EventuallyTimeout = 30 * time.Second
-	g.DurationBundle.ConsistentlyDuration = 30 * time.Second
+		err := cli.List(
+			ctx,
+			&items,
+			client.MatchingFields{
+				"metadata.name": certconfigmapgenerator.CAConfigMapName,
+			},
+			client.MatchingLabels{
+				labels.K8SCommon.PartOf: certconfigmapgenerator.PartOf,
+			},
+		)
 
-	return g
+		if err != nil {
+			return nil, err
+		}
+
+		return items.Items, nil
+	}
 }
 
-func listCABundleConfigMaps(ctx context.Context, cli client.Client) ([]corev1.ConfigMap, error) {
-	items := corev1.ConfigMapList{}
+func getCABundlesConfigMap(ctx context.Context, cli client.Client, ns string) func() (*corev1.ConfigMap, error) {
+	return func() (*corev1.ConfigMap, error) {
+		nn := types.NamespacedName{
+			Name:      certconfigmapgenerator.CAConfigMapName,
+			Namespace: ns,
+		}
 
-	err := cli.List(
-		ctx,
-		&items,
-		client.MatchingFields{
-			"metadata.name": certconfigmapgenerator.CAConfigMapName,
-		},
-		client.MatchingLabels{
-			labels.K8SCommon.PartOf: certconfigmapgenerator.PartOf,
-		},
-	)
+		item := corev1.ConfigMap{}
 
-	if err != nil {
-		return nil, err
+		err := cli.Get(ctx, nn, &item)
+		switch {
+		case errors.IsNotFound(err):
+			return nil, nil
+		case err != nil:
+			return nil, err
+		default:
+			return &item, nil
+		}
 	}
-
-	return items.Items, nil
 }
 
-func getCABundlesConfigMap(ctx context.Context, cli client.Client, ns string) (*corev1.ConfigMap, error) {
-	nn := types.NamespacedName{
-		Name:      certconfigmapgenerator.CAConfigMapName,
-		Namespace: ns,
+func TestInjectTrustedCABundle(t *testing.T) {
+	tests := []struct {
+		name        string
+		annotations map[string]string
+		want        bool
+	}{
+		{
+			name:        "no annotations",
+			annotations: nil,
+			want:        true,
+		},
+		{
+			name:        "empty annotations",
+			annotations: map[string]string{},
+			want:        true,
+		},
+		{
+			name: "annotation not found",
+			annotations: map[string]string{
+				"other-annotation": "value",
+			},
+			want: true,
+		},
+		{
+			name: "annotation set to true",
+			annotations: map[string]string{
+				annotation.InjectionOfCABundleAnnotatoion: "true",
+			},
+			want: true,
+		},
+		{
+			name: "annotation set to false",
+			annotations: map[string]string{
+				annotation.InjectionOfCABundleAnnotatoion: "false",
+			},
+			want: false,
+		},
+		{
+			name: "annotation set to false (mixed case)",
+			annotations: map[string]string{
+				annotation.InjectionOfCABundleAnnotatoion: "False",
+			},
+			want: false,
+		},
+		{
+			name: "annotation with invalid value",
+			annotations: map[string]string{
+				annotation.InjectionOfCABundleAnnotatoion: "invalid",
+			},
+			want: true,
+		},
+		{
+			name: "annotation with mixed case",
+			annotations: map[string]string{
+				annotation.InjectionOfCABundleAnnotatoion: "TRUE",
+			},
+			want: true,
+		},
 	}
 
-	item := corev1.ConfigMap{}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			ns := &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "test-namespace",
+					Annotations: tt.annotations,
+				},
+			}
 
-	err := cli.Get(ctx, nn, &item)
-	switch {
-	case errors.IsNotFound(err):
-		return nil, nil
-	case err != nil:
-		return nil, err
-	default:
-		return &item, nil
+			got := certconfigmapgenerator.ShouldInjectTrustedCABundle(ns)
+			g.Expect(got).To(Equal(tt.want), "ShouldInjectTrustedCABundle() = %v, want %v", got, tt.want)
+		})
 	}
 }


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

<!--- Link your JIRA and related links here for reference. -->
https://issues.redhat.com/browse/RHOAIENG-26115
https://issues.redhat.com/browse/RHOAIENG-26122

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Added support for controlling trusted CA bundle injection into namespaces via a specific annotation.
- **Bug Fixes**
	- Improved handling of different management states for trusted CA bundles, providing more precise control and clearer logging.
- **Tests**
	- Expanded and refined test coverage for trusted CA bundle management states and namespace annotation scenarios, ensuring more robust validation of expected behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->