### PR TITLE
[sync] RHOAIENG-21259 and RHOAIENG-22955

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -494,34 +494,26 @@ func getCommonCache(ctx context.Context, cli client.Client, platform common.Plat
 }
 
 func createSecretCacheConfig(ctx context.Context, cli client.Client, platform common.Platform) (map[string]cache.Config, error) {
-	namespaceConfigs := map[string]cache.Config{
-		"istio-system":      {}, // for both knative-serving-cert and default-modelregistry-cert, as an easy workarond, to watch both in this namespace
-		"openshift-ingress": {},
-	}
-
-	c, err := getCommonCache(ctx, cli, platform)
+	namespaceConfigs, err := getCommonCache(ctx, cli, platform)
 	if err != nil {
 		return nil, err
 	}
-	for n := range c {
-		namespaceConfigs[n] = cache.Config{}
-	}
+
+	namespaceConfigs["istio-system"] = cache.Config{} // for both knative-serving-cert and default-modelregistry-cert, as an easy workarond, to watch both in this namespace
+	namespaceConfigs["openshift-ingress"] = cache.Config{}
+
 	return namespaceConfigs, nil
 }
 
 func createODHGeneralCacheConfig(ctx context.Context, cli client.Client, platform common.Platform) (map[string]cache.Config, error) {
-	namespaceConfigs := map[string]cache.Config{
-		"istio-system":        {}, // for serivcemonitor: data-science-smcp-pilot-monitor
-		"openshift-operators": {}, // for dependent operators installed namespace
-	}
-
-	c, err := getCommonCache(ctx, cli, platform)
+	namespaceConfigs, err := getCommonCache(ctx, cli, platform)
 	if err != nil {
 		return nil, err
 	}
-	for n := range c {
-		namespaceConfigs[n] = cache.Config{}
-	}
+
+	namespaceConfigs["istio-system"] = cache.Config{}        // for serivcemonitor: data-science-smcp-pilot-monitor
+	namespaceConfigs["openshift-operators"] = cache.Config{} // for dependent operators installed namespace
+
 	return namespaceConfigs, nil
 }
 


### PR DESCRIPTION
This is a sync of https://github.com/opendatahub-io/opendatahub-operator/pull/1961

## Description
This address both: 
- https://issues.redhat.com/browse/RHOAIENG-21259
- https://issues.redhat.com/browse/RHOAIENG-22955

by removing the unneeded caches and refactoring cache init composition logic to better implement the intended behavior.

## How Has This Been Tested?
Both unit  and e2e tests.



## Merge criteria

- [X] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [X] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [X] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling for namespace selection, providing clearer error messages when multiple customized application namespaces are detected.
- **Refactor**
	- Simplified and clarified the logic for namespace handling in cache configuration, resulting in more predictable and maintainable behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->