### PR TITLE
feat: add support to pass Oauth proxy image for downstream

### DIFF
--- a/internal/controller/components/kserve/kserve.go
+++ b/internal/controller/components/kserve/kserve.go
@@ -18,6 +18,7 @@ import (
 	odherrors "github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/errors"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/conditions"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
+	odhdeploy "github.com/opendatahub-io/opendatahub-operator/v2/pkg/deploy"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/metadata/annotations"
 )
 
@@ -58,8 +59,13 @@ func init() { //nolint:gochecknoinits
 	cr.Add(&componentHandler{})
 }
 
-// Init for set images.
+// Init to set oauth image.
 func (s *componentHandler) Init(platform common.Platform) error {
+	mp := kserveManifestInfo(kserveManifestSourcePath)
+
+	if err := odhdeploy.ApplyParams(mp.String(), imageParamMap); err != nil {
+		return fmt.Errorf("failed to update images on path %s: %w", mp, err)
+	}
 	return nil
 }
 

--- a/internal/controller/components/kserve/kserve_support.go
+++ b/internal/controller/components/kserve/kserve_support.go
@@ -26,12 +26,18 @@ import (
 	infrav1 "github.com/opendatahub-io/opendatahub-operator/v2/api/infrastructure/v1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
 	odhtypes "github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
-	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/deploy"
+	odhdeploy "github.com/opendatahub-io/opendatahub-operator/v2/pkg/deploy"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/metadata/labels"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/resources"
 )
 
 const DefaultCertificateSecretName = "knative-serving-cert"
+
+var (
+	imageParamMap = map[string]string{
+		"oauth-proxy": "RELATED_IMAGE_OSE_OAUTH_PROXY_IMAGE",
+	}
+)
 
 //go:embed resources
 var resourcesFS embed.FS
@@ -53,7 +59,7 @@ var isRequiredOperators = predicate.Funcs{
 
 func kserveManifestInfo(sourcePath string) odhtypes.ManifestInfo {
 	return odhtypes.ManifestInfo{
-		Path:       deploy.DefaultManifestPath,
+		Path:       odhdeploy.DefaultManifestPath,
 		ContextDir: componentName,
 		SourcePath: sourcePath,
 	}

--- a/internal/controller/components/trustyai/trustyai_support.go
+++ b/internal/controller/components/trustyai/trustyai_support.go
@@ -24,6 +24,7 @@ var (
 	imageParamMap = map[string]string{
 		"trustyaiServiceImage":  "RELATED_IMAGE_ODH_TRUSTYAI_SERVICE_IMAGE",
 		"trustyaiOperatorImage": "RELATED_IMAGE_ODH_TRUSTYAI_SERVICE_OPERATOR_IMAGE",
+		"oauthProxyImage":       "RELATED_IMAGE_OSE_OAUTH_PROXY_IMAGE",
 	}
 
 	overlaysSourcePaths = map[common.Platform]string{


### PR DESCRIPTION
- trustyai: add new variable to overwrite default image
- kserve: add replace in operator startup phase

<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->
after https://github.com/opendatahub-io/opendatahub-operator/pull/1967, seems we have more components are using oauth-proxy image.


<!--- Link your JIRA and related links here for reference. -->
ref https://issues.redhat.com/browse/RHOAIENG-25691

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
