### PR TITLE
backport of rhoai RHOAIENG-21259: added openshift-operators namespace cache to createODHGeneralCacheConfig

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -512,7 +512,8 @@ func createODHGeneralCacheConfig(ctx context.Context, cli client.Client, platfor
 		return nil, err
 	}
 
-	namespaceConfigs["istio-system"] = cache.Config{} // for serivcemonitor: data-science-smcp-pilot-monitor
+	namespaceConfigs["istio-system"] = cache.Config{}        // for serivcemonitor: data-science-smcp-pilot-monitor
+	namespaceConfigs["openshift-operators"] = cache.Config{} // for dependent operators installed namespace
 
 	return namespaceConfigs, nil
 }


### PR DESCRIPTION
## Description
Syncing https://github.com/opendatahub-io/opendatahub-operator/pull/1961  to rhoai branch https://github.com/opendatahub-io/opendatahub-operator/pull/1980

we figure out that a nemaspace cache was missing in main so backporting it.

## How Has This Been Tested?
unit and e2e  tests

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [X] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [X] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Expanded support to monitor resources in the "openshift-operators" namespace in addition to the existing "istio-system" namespace.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->