### PR TITLE
Use image SHA in `make deploy` to avoid manual restarts

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ By default, building an image without any local changes(as a clean build)
 This is what the production build system is doing.
 
 In order to build an image with local `opt/manifests` folder set `USE_LOCAL` make variable to `true`
-e.g `make image-build USE_LOCAL=true"`
+e.g `make image-build USE_LOCAL=true`
 
 #### Build Image
 


### PR DESCRIPTION

## Description

Currently, when iterating on changes in order to re-deploy the
operator manager, a restart is required because `make deploy`
uses image tags, with this change, there is no need to rollout
restart the deployment and it will immediatelly be effective
while being no-op when the image SHA is equal.

<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

<!--- Describe your changes in detail -->

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?

`USE_LOCAL=true make image-build image-push deploy`

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced image handling to automatically resolve image references to digest-based references during customization.

- **Chores**
  - Added support for the `skopeo` tool to streamline image reference management.

- **Documentation**
  - Corrected a formatting issue in the README example command for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->