### PR TITLE
RHOAIENG-25258: Implement Validating Webhook for Kueue label Enforcement

### DIFF
--- a/bundle/manifests/opendatahub-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/opendatahub-operator.clusterserviceversion.yaml
@@ -110,7 +110,7 @@ metadata:
     categories: AI/Machine Learning, Big Data
     certified: "False"
     containerImage: quay.io/opendatahub/opendatahub-operator:v2.29.0
-    createdAt: "2025-06-05T18:03:15Z"
+    createdAt: "2025-06-16T08:22:18Z"
     operators.operatorframework.io/builder: operator-sdk-v1.39.2
     operators.operatorframework.io/internal-objects: '["featuretrackers.features.opendatahub.io",
       "codeflares.components.platform.opendatahub.io", "dashboards.components.platform.opendatahub.io",
@@ -1484,3 +1484,65 @@ spec:
     targetPort: 9443
     type: ValidatingAdmissionWebhook
     webhookPath: /validate-dscinitialization
+  - admissionReviewVersions:
+    - v1
+    containerPort: 443
+    deploymentName: opendatahub-operator-controller-manager
+    failurePolicy: Fail
+    generateName: kserve-kueuelabels-validator.opendatahub.io
+    rules:
+    - apiGroups:
+      - serving.kserve.io
+      apiVersions:
+      - v1beta1
+      operations:
+      - CREATE
+      - UPDATE
+      resources:
+      - inferenceservices
+    sideEffects: None
+    targetPort: 9443
+    type: ValidatingAdmissionWebhook
+    webhookPath: /validate-kueue
+  - admissionReviewVersions:
+    - v1
+    containerPort: 443
+    deploymentName: opendatahub-operator-controller-manager
+    failurePolicy: Fail
+    generateName: kubeflow-kueuelabels-validator.opendatahub.io
+    rules:
+    - apiGroups:
+      - kubeflow.org
+      apiVersions:
+      - v1
+      operations:
+      - CREATE
+      - UPDATE
+      resources:
+      - pytorchjobs
+      - notebooks
+    sideEffects: None
+    targetPort: 9443
+    type: ValidatingAdmissionWebhook
+    webhookPath: /validate-kueue
+  - admissionReviewVersions:
+    - v1
+    containerPort: 443
+    deploymentName: opendatahub-operator-controller-manager
+    failurePolicy: Fail
+    generateName: ray-kueuelabels-validator.opendatahub.io
+    rules:
+    - apiGroups:
+      - ray.io
+      apiVersions:
+      - v1alpha1
+      operations:
+      - CREATE
+      - UPDATE
+      resources:
+      - rayjobs
+      - rayclusters
+    sideEffects: None
+    targetPort: 9443
+    type: ValidatingAdmissionWebhook
+    webhookPath: /validate-kueue

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -69,3 +69,65 @@ webhooks:
     resources:
     - dscinitializations
   sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-kueue
+  failurePolicy: Fail
+  name: kserve-kueuelabels-validator.opendatahub.io
+  rules:
+  - apiGroups:
+    - serving.kserve.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - inferenceservices
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-kueue
+  failurePolicy: Fail
+  name: kubeflow-kueuelabels-validator.opendatahub.io
+  rules:
+  - apiGroups:
+    - kubeflow.org
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - pytorchjobs
+    - notebooks
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-kueue
+  failurePolicy: Fail
+  name: ray-kueuelabels-validator.opendatahub.io
+  rules:
+  - apiGroups:
+    - ray.io
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - rayjobs
+    - rayclusters
+  sideEffects: None

--- a/internal/webhook/kueue/integration_test.go
+++ b/internal/webhook/kueue/integration_test.go
@@ -1,0 +1,242 @@
+package kueue_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	operatorv1 "github.com/openshift/api/operator/v1"
+	"github.com/rs/xid"
+	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apiextensionsclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+	k8serr "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/opendatahub-io/opendatahub-operator/v2/api/common"
+	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/api/components/v1alpha1"
+	dscv1 "github.com/opendatahub-io/opendatahub-operator/v2/api/datasciencecluster/v1"
+	dscwebhook "github.com/opendatahub-io/opendatahub-operator/v2/internal/webhook/datasciencecluster"
+	kueuewebhook "github.com/opendatahub-io/opendatahub-operator/v2/internal/webhook/kueue"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/envt"
+
+	. "github.com/onsi/gomega"
+)
+
+var (
+	notebookGVK = schema.GroupVersionKind{
+		Group:   "kubeflow.org",
+		Version: "v1",
+		Kind:    "Notebook",
+	}
+
+	kueueQueueNameLabelKey     = kueuewebhook.KueueQueueNameLabelKey
+	localQueueName             = "default"
+	kueueManagedLabelKey       = kueuewebhook.KueueManagedLabelKey
+	kueueLegacyManagedLabelKey = kueuewebhook.KueueLegacyManagedLabelKey
+	missingLabelError          = `Kueue label validation failed: missing required label "` + kueueQueueNameLabelKey + `"`
+)
+
+// mockNotebookCRD creates a fake Notebook CRD to allow webhook testing.
+func mockNotebookCRD() *apiextensionsv1.CustomResourceDefinition {
+	return &apiextensionsv1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{Name: "notebooks.kubeflow.org"},
+		Spec: apiextensionsv1.CustomResourceDefinitionSpec{
+			Group: "kubeflow.org",
+			Names: apiextensionsv1.CustomResourceDefinitionNames{
+				Plural:     "notebooks",
+				Singular:   "notebook",
+				Kind:       "Notebook",
+				ShortNames: []string{"nb"},
+			},
+			Scope: "Namespaced",
+			Versions: []apiextensionsv1.CustomResourceDefinitionVersion{{
+				Name:    "v1",
+				Served:  true,
+				Storage: true,
+				Schema: &apiextensionsv1.CustomResourceValidation{
+					OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{Type: "object"},
+				},
+			}},
+		},
+	}
+}
+
+// SetupEnvAndClientWithNotebook boots the envtest environment with webhook support.
+func SetupEnvAndClientWithNotebook(
+	t *testing.T,
+	registerWebhooks []envt.RegisterWebhooksFn,
+	timeout time.Duration,
+) (context.Context, *envt.EnvT, func(), client.Client) {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+
+	env, err := envt.New(envt.WithRegisterWebhooks(registerWebhooks...))
+	if err != nil {
+		t.Fatalf("failed to start envtest: %v", err)
+	}
+
+	env.Scheme().AddKnownTypeWithName(notebookGVK, &unstructured.Unstructured{})
+	env.Scheme().AddKnownTypeWithName(notebookGVK.GroupVersion().WithKind("NotebookList"), &unstructured.UnstructuredList{})
+
+	extClient, _ := apiextensionsclientset.NewForConfig(env.Config())
+	_, err = extClient.ApiextensionsV1().CustomResourceDefinitions().Create(ctx, mockNotebookCRD(), metav1.CreateOptions{})
+	if err != nil && !k8serr.IsAlreadyExists(err) {
+		t.Fatalf("failed to create mock Notebook CRD: %v", err)
+	}
+
+	mgrCtx, mgrCancel := context.WithCancel(ctx)
+	errChan := make(chan error, 1)
+
+	go func() {
+		t.Log("Starting manager...")
+		if err := env.Manager().Start(mgrCtx); err != nil {
+			select {
+			case errChan <- fmt.Errorf("manager exited with error: %w", err):
+			default:
+			}
+		}
+	}()
+
+	t.Log("Waiting for webhook server to be ready...")
+	if err := env.WaitForWebhookServer(timeout); err != nil {
+		t.Fatalf("webhook server not ready: %v", err)
+	}
+
+	teardown := func() {
+		mgrCancel()
+		cancel()
+		_ = env.Stop()
+		select {
+		case err := <-errChan:
+			t.Errorf("manager goroutine error: %v", err)
+		default:
+		}
+	}
+
+	return ctx, env, teardown, env.Client()
+}
+
+func createDSCWithStatus(ctx context.Context, g *WithT, c client.Client, state operatorv1.ManagementState) {
+	dsc := &dscv1.DataScienceCluster{ObjectMeta: metav1.ObjectMeta{Name: "default"}}
+	g.Expect(c.Create(ctx, dsc)).To(Succeed())
+
+	dsc.Status = dscv1.DataScienceClusterStatus{
+		Components: dscv1.ComponentsStatus{
+			Kueue: componentApi.DSCKueueStatus{
+				ManagementSpec: common.ManagementSpec{ManagementState: state},
+			},
+		},
+	}
+	g.Expect(c.Status().Update(ctx, dsc)).To(Succeed())
+}
+
+func newTestNamespace(name string, labels map[string]string) *corev1.Namespace {
+	return &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   name,
+			Labels: labels,
+		},
+	}
+}
+
+func newTestWorkload(name, namespace string, gvk schema.GroupVersionKind, labels map[string]string) *unstructured.Unstructured {
+	obj := &unstructured.Unstructured{}
+	obj.SetGroupVersionKind(gvk)
+	obj.SetNamespace(namespace)
+	obj.SetName(name)
+	obj.SetLabels(labels)
+	return obj
+}
+
+func TestKueueWebhook_Integration(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name              string
+		kueueState        operatorv1.ManagementState
+		nsLabels          map[string]string
+		workloadLabels    map[string]string
+		expectAllowed     bool
+		expectDeniedError string
+	}{
+		{
+			name:           "Kueue disabled in DSC - should allow",
+			kueueState:     operatorv1.Removed,
+			nsLabels:       map[string]string{kueueManagedLabelKey: "true"},
+			workloadLabels: map[string]string{},
+			expectAllowed:  true,
+		},
+		{
+			name:              "Kueue enabled, ns enabled, missing workload label - should deny",
+			kueueState:        operatorv1.Managed,
+			nsLabels:          map[string]string{kueueManagedLabelKey: "true"},
+			workloadLabels:    map[string]string{},
+			expectAllowed:     false,
+			expectDeniedError: missingLabelError,
+		},
+		{
+			name:           "Kueue enabled, ns enabled, valid workload label - should allow",
+			kueueState:     operatorv1.Managed,
+			nsLabels:       map[string]string{kueueManagedLabelKey: "true"},
+			workloadLabels: map[string]string{kueueQueueNameLabelKey: localQueueName},
+			expectAllowed:  true,
+		},
+		{
+			name:           "Kueue enabled, ns not labeled - should allow",
+			kueueState:     operatorv1.Managed,
+			nsLabels:       nil,
+			workloadLabels: map[string]string{},
+			expectAllowed:  true,
+		},
+		{
+			name:           "Kueue enabled, ns enabled with legacy label, valid workload label - should allow",
+			kueueState:     operatorv1.Managed,
+			nsLabels:       map[string]string{kueueLegacyManagedLabelKey: "true"},
+			workloadLabels: map[string]string{kueueQueueNameLabelKey: localQueueName},
+			expectAllowed:  true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewWithT(t)
+
+			ctx, _, teardown, k8sClient := SetupEnvAndClientWithNotebook(
+				t,
+				[]envt.RegisterWebhooksFn{
+					kueuewebhook.RegisterWebhooks,
+					dscwebhook.RegisterWebhooks,
+				},
+				20*time.Second,
+			)
+			t.Cleanup(teardown)
+
+			ns := xid.New().String()
+			createDSCWithStatus(ctx, g, k8sClient, tc.kueueState)
+			g.Expect(k8sClient.Create(ctx, newTestNamespace(ns, tc.nsLabels))).To(Succeed())
+
+			workload := newTestWorkload("test-notebook", ns, notebookGVK, tc.workloadLabels)
+			err := k8sClient.Create(ctx, workload)
+
+			if tc.expectAllowed {
+				g.Expect(err).To(Succeed(), fmt.Sprintf("Expected creation to be allowed but got: %v", err))
+			} else {
+				g.Expect(err).To(HaveOccurred(), "Expected creation to be denied but it was allowed.")
+				statusErr := &k8serr.StatusError{}
+				ok := errors.As(err, &statusErr)
+				g.Expect(ok).To(BeTrue(), "Expected error to be of type StatusError")
+				g.Expect(statusErr.Status().Code).To(Equal(int32(http.StatusForbidden)))
+				g.Expect(statusErr.Status().Message).To(ContainSubstring(tc.expectDeniedError))
+			}
+		})
+	}
+}

--- a/internal/webhook/kueue/register.go
+++ b/internal/webhook/kueue/register.go
@@ -1,0 +1,19 @@
+//go:build !nowebhook
+
+package kueue
+
+import (
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+// RegisterWebhooks registers the webhooks for kueue.
+func RegisterWebhooks(mgr ctrl.Manager) error {
+	if err := (&Validator{
+		Client: mgr.GetAPIReader(),
+		Name:   "kueue-validating",
+	}).SetupWithManager(mgr); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/internal/webhook/kueue/validating.go
+++ b/internal/webhook/kueue/validating.go
@@ -1,0 +1,272 @@
+//go:build !nowebhook
+
+package kueue
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	operatorv1 "github.com/openshift/api/operator/v1"
+	admissionv1 "k8s.io/api/admission/v1"
+	k8serr "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/api/components/v1alpha1"
+	"github.com/opendatahub-io/opendatahub-operator/v2/internal/webhook/shared"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/resources"
+)
+
+// Webhooks for Kueue label validation:
+// - kubeflow.org/v1: pytorchjobs, notebooks
+// - ray.io/v1alpha1: rayjobs, rayclusters
+// - serving.kserve.io/v1beta1: inferenceservices
+
+//+kubebuilder:webhook:path=/validate-kueue,mutating=false,failurePolicy=fail,sideEffects=None,groups=kubeflow.org,resources=pytorchjobs;notebooks,verbs=create;update,versions=v1,name=kubeflow-kueuelabels-validator.opendatahub.io,admissionReviewVersions=v1
+//+kubebuilder:webhook:path=/validate-kueue,mutating=false,failurePolicy=fail,sideEffects=None,groups=ray.io,resources=rayjobs;rayclusters,verbs=create;update,versions=v1alpha1,name=ray-kueuelabels-validator.opendatahub.io,admissionReviewVersions=v1
+//+kubebuilder:webhook:path=/validate-kueue,mutating=false,failurePolicy=fail,sideEffects=None,groups=serving.kserve.io,resources=inferenceservices,verbs=create;update,versions=v1beta1,name=kserve-kueuelabels-validator.opendatahub.io,admissionReviewVersions=v1
+//nolint:lll
+
+const (
+	// Kueue component name used in DataScienceCluster status.
+	KueueComponentName = componentApi.KueueComponentName
+
+	// KueueManagedLabelKey indicates a namespace is managed by Kueue.
+	KueueManagedLabelKey = "kueue.openshift.io/managed"
+
+	// KueueLegacyManagedLabelKey is the legacy label key used to indicate a namespace is managed by Kueue.
+	KueueLegacyManagedLabelKey = "kueue-managed"
+
+	// KueueQueueNameLabelKey is the label key used to specify the Kueue queue name for workloads.
+	KueueQueueNameLabelKey = "kueue.x-k8s.io/queue-name"
+)
+
+var (
+	// Error messages for Kueue label validation.
+	ErrMissingRequiredLabel = fmt.Errorf("missing required label %q", KueueQueueNameLabelKey)
+	ErrEmptyRequiredLabel   = fmt.Errorf("label %q is set but empty", KueueQueueNameLabelKey)
+)
+
+// decodeObjectMeta decodes the object metadata from the admission request.
+//
+// Parameters:
+//   - req: The admission.Request containing the object details
+//
+// Returns:
+//   - *metav1.PartialObjectMetadata: The decoded object metadata
+//   - error: Any error encountered while decoding the object metadata
+func decodeObjectMeta(req *admission.Request) (*metav1.PartialObjectMetadata, error) {
+	var meta metav1.PartialObjectMetadata
+	if err := json.Unmarshal(req.Object.Raw, &meta); err != nil {
+		return nil, err
+	}
+
+	return &meta, nil
+}
+
+// isKueueEnabledInDSC checks if Kueue is enabled in the DataScienceCluster (DSC).
+//
+// Parameters:
+//   - ctx: Context for the API call
+//   - cli: The controller-runtime client to use for checking Kueue status in the DSC
+//
+// Returns:
+//   - bool: true if Kueue is enabled, false otherwise
+//   - error: Any error encountered while checking Kueue status in the DSC
+func isKueueEnabledInDSC(ctx context.Context, cli client.Reader) (bool, error) {
+	dsc, err := cluster.GetDSC(ctx, cli)
+	if err != nil {
+		return false, err
+	}
+
+	state := dsc.Status.Components.Kueue.ManagementState
+	// Kueue is considered enabled if it is either Managed or Unmanaged
+	return state == operatorv1.Managed || state == operatorv1.Unmanaged, nil
+}
+
+// validateNamespaceLabels checks if the given namespace is labeled for Kueue management.
+//
+// Parameters:
+//   - ns: The namespace metadata to check for Kueue labels
+//
+// Returns:
+//   - bool: true if the namespace is labeled for Kueue management, false otherwise
+func validateNamespaceLabels(ns client.Object) bool {
+	return resources.HasLabel(ns, KueueManagedLabelKey, "true") ||
+		resources.HasLabel(ns, KueueLegacyManagedLabelKey, "true")
+}
+
+// isNamespaceManagedByKueue checks if the given namespace is labeled for Kueue management.
+//
+// Parameters:
+//   - ctx: Context for the API call
+//   - cli: The controller-runtime client to use for checking the namespace labels
+//   - namespace: The name of the namespace to check
+//
+// Returns:
+//   - bool: true if the namespace is labeled for Kueue, false otherwise
+//   - error: Any error encountered while checking the namespace labels
+func isNamespaceManagedByKueue(ctx context.Context, cli client.Reader, namespace string) (bool, error) {
+	ns := &metav1.PartialObjectMetadata{}
+	ns.SetGroupVersionKind(gvk.Namespace)
+
+	if err := cli.Get(ctx, types.NamespacedName{Name: namespace}, ns); err != nil {
+		// Unable to get the namespace, return an error
+		return false, err
+	}
+
+	return validateNamespaceLabels(ns), nil
+}
+
+// validateKueueLabels checks if the required Kueue labels are present and valid.
+//
+// Parameters:
+//   - labels: The map of labels to validate
+//
+// Returns:
+//   - error: If the required label is missing or empty, returns an error
+func validateKueueLabels(labels map[string]string) error {
+	if labels == nil {
+		// Labels map is nil, which means no labels are set
+		return ErrMissingRequiredLabel
+	}
+
+	queueName, ok := labels[KueueQueueNameLabelKey]
+
+	if !ok {
+		// Required label is missing
+		return ErrMissingRequiredLabel
+	}
+
+	if queueName == "" {
+		// Required label is present but empty
+		return ErrEmptyRequiredLabel
+	}
+
+	// All required labels are present and valid
+	return nil
+}
+
+// performLabelValidation checks if the Kueue labels are present and valid for the given request.
+//
+// Parameters:
+//   - ctx: Context for the admission request
+//   - cli: The controller-runtime client to use for checking Kueue status and namespace labels
+//   - req: The admission.Request containing the operation and object details
+//
+// Returns:
+//   - admission.Response: The result of the label validation, indicating whether the operation is allowed or denied
+func performLabelValidation(ctx context.Context, cli client.Reader, req *admission.Request) admission.Response {
+	namespace := req.Namespace
+
+	// Decode the object metadata from the request
+	meta, err := decodeObjectMeta(req)
+	if err != nil {
+		// Unable to decode the object metadata, return an error response
+		return admission.Errored(http.StatusBadRequest, fmt.Errorf("failed to decode object metadata: %w", err))
+	}
+
+	// Check if the namespace is labeled for Kueue management
+	// TODO: to be removed: https://issues.redhat.com/browse/RHOAIENG-27558
+	kueueManagedNamespace, err := isNamespaceManagedByKueue(ctx, cli, namespace)
+	if err != nil {
+		// Unable to determine if the namespace is labeled for Kueue, return an error response
+		return admission.Errored(http.StatusInternalServerError, fmt.Errorf("failed to check if namespace %q is labeled for Kueue: %w", namespace, err))
+	}
+
+	if !kueueManagedNamespace {
+		// Namespace is not labeled for Kueue
+		return admission.Allowed(fmt.Sprintf("Namespace %q is not labeled for Kueue (%q), skipping Kueue label validation", namespace, KueueManagedLabelKey))
+	}
+
+	// Check if Kueue is enabled in the DataScienceCluster (DSC)
+	kueueEnabled, err := isKueueEnabledInDSC(ctx, cli)
+
+	switch {
+	case err != nil && k8serr.IsNotFound(err):
+		// DSC not found — skip validation
+		return admission.Allowed("No DataScienceCluster found, skipping Kueue label validation")
+	case err != nil:
+		// Unable to determine if Kueue is enabled, return an error response
+		return admission.Errored(http.StatusInternalServerError, fmt.Errorf("failed to check if Kueue is enabled: %w", err))
+	case !kueueEnabled:
+		// Kueue is not enabled in the DSC
+		return admission.Allowed("Kueue is not enabled in DSC, skipping Kueue label validation")
+	}
+
+	// Check if the workload has Kueue labels
+	if err := validateKueueLabels(meta.GetLabels()); err != nil {
+		// No Kueue labels found
+		return admission.Denied(fmt.Sprintf("Kueue label validation failed: %v", err))
+	}
+
+	// Kueue is enabled, namespace is labeled for Kueue, and workload has Kueue labels
+	return admission.Allowed(fmt.Sprintf("Kueue label validation passed for %q in namespace %q", req.Kind.Kind, namespace))
+}
+
+// Validator implements webhook.AdmissionHandler for Kueue validation webhooks.
+type Validator struct {
+	Client  client.Reader
+	Decoder admission.Decoder
+	Name    string
+}
+
+// Assert that Validator implements admission.Handler interface.
+var _ admission.Handler = &Validator{}
+
+// InjectDecoder implements admission.DecoderInjector so the manager can inject the decoder automatically.
+//
+// Parameters:
+//   - d: The admission.Decoder to inject.
+//
+// Returns:
+//   - error: Always nil.
+func (v *Validator) InjectDecoder(d admission.Decoder) error {
+	v.Decoder = d
+	return nil
+}
+
+// SetupWithManager registers the validating webhook with the provided controller-runtime manager.
+//
+// Parameters:
+//   - mgr: The controller-runtime manager to register the webhook with.
+//
+// Returns:
+//   - error: Always nil (for future extensibility).
+func (v *Validator) SetupWithManager(mgr ctrl.Manager) error {
+	hookServer := mgr.GetWebhookServer()
+	hookServer.Register("/validate-kueue", &webhook.Admission{
+		Handler:        v,
+		LogConstructor: shared.NewLogConstructor(v.Name),
+	})
+	return nil
+}
+
+// Handle processes admission requests for create and update operations on kueue workload-related resources.
+//
+// Parameters:
+//   - ctx: Context for the admission request (logger is extracted from here).
+//   - req: The admission.Request containing the operation and object details.
+//
+// Returns:
+//   - admission.Response: The result of the admission check, indicating whether the operation is allowed or denied.
+func (v *Validator) Handle(ctx context.Context, req admission.Request) admission.Response {
+	var resp admission.Response
+
+	switch req.Operation {
+	case admissionv1.Create, admissionv1.Update:
+		resp = performLabelValidation(ctx, v.Client, &req)
+	default:
+		resp.Allowed = true
+	}
+
+	return resp
+}

--- a/internal/webhook/kueue/validation_test.go
+++ b/internal/webhook/kueue/validation_test.go
@@ -1,0 +1,266 @@
+package kueue_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/onsi/gomega"
+	operatorv1 "github.com/openshift/api/operator/v1"
+	admissionv1 "k8s.io/api/admission/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	"github.com/opendatahub-io/opendatahub-operator/v2/api/common"
+	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/api/components/v1alpha1"
+	dscv1 "github.com/opendatahub-io/opendatahub-operator/v2/api/datasciencecluster/v1"
+	kueuewebhook "github.com/opendatahub-io/opendatahub-operator/v2/internal/webhook/kueue"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/scheme"
+)
+
+const (
+	testNamespace        = "test-ns"
+	nsLabelManaged       = kueuewebhook.KueueManagedLabelKey
+	legacyNsLabelManaged = kueuewebhook.KueueLegacyManagedLabelKey
+	objLabelQueueName    = kueuewebhook.KueueQueueNameLabelKey
+	validQueueName       = "queue"
+)
+
+func newFakeClientWithObjects(sch *runtime.Scheme, nsLabels map[string]string, kueueState operatorv1.ManagementState) *fake.ClientBuilder {
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   testNamespace,
+			Labels: nsLabels,
+		},
+	}
+
+	dsc := &dscv1.DataScienceCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "default",
+		},
+		Status: dscv1.DataScienceClusterStatus{
+			Components: dscv1.ComponentsStatus{
+				Kueue: componentApi.DSCKueueStatus{
+					ManagementSpec: common.ManagementSpec{
+						ManagementState: kueueState,
+					},
+				},
+			},
+		},
+	}
+
+	return fake.NewClientBuilder().WithScheme(sch).WithRuntimeObjects(ns, dsc)
+}
+
+func createWorkload(gvk schema.GroupVersionKind, ns string, labels map[string]string) *unstructured.Unstructured {
+	obj := &unstructured.Unstructured{}
+	obj.SetGroupVersionKind(gvk)
+	obj.SetNamespace(ns)
+	obj.SetName("workload")
+	obj.SetLabels(labels)
+	return obj
+}
+
+func createAdmissionRequest(t *testing.T, operation admissionv1.Operation, obj runtime.Object, ns string, gvk schema.GroupVersionKind) admission.Request {
+	t.Helper()
+	raw, err := runtime.Encode(unstructured.UnstructuredJSONScheme, obj)
+	if err != nil {
+		t.Fatalf("failed to marshal object: %v", err)
+	}
+
+	return admission.Request{
+		AdmissionRequest: admissionv1.AdmissionRequest{
+			Operation: operation,
+			Object:    runtime.RawExtension{Raw: raw},
+			Namespace: ns,
+			Kind: metav1.GroupVersionKind{
+				Group:   gvk.Group,
+				Version: gvk.Version,
+				Kind:    gvk.Kind,
+			},
+		},
+	}
+}
+
+func TestKueueWebhookHandler(t *testing.T) {
+	t.Parallel()
+	g := gomega.NewWithT(t)
+	ctx := context.Background()
+
+	sch, err := scheme.New()
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+
+	// Included NoteBook as representative GVK since the webhook logic is metadata-based
+	// and does not vary across resource types (GVKs). Other GVKs like RayJob, etc.,
+	// are not included here to avoid redundant tests. Add them only if GVK-specific logic
+	// is introduced in the future.
+	supportedGVKs := []schema.GroupVersionKind{
+		{Group: "kubeflow.org", Version: "v1", Kind: "NoteBook"},
+	}
+
+	testCases := []struct {
+		name          string
+		operation     admissionv1.Operation
+		nsLabels      map[string]string
+		kueueState    operatorv1.ManagementState
+		objLabels     map[string]string
+		expectAllow   bool
+		expectMessage string
+	}{
+		{
+			name: "Kueue not enabled, skip validation",
+			nsLabels: map[string]string{
+				nsLabelManaged: "true",
+			},
+			kueueState: operatorv1.Removed,
+			objLabels: map[string]string{
+				nsLabelManaged: "true",
+			},
+			expectAllow:   true,
+			expectMessage: "Kueue is not enabled in DSC, skipping Kueue label validation",
+			operation:     admissionv1.Create,
+		},
+		{
+			name:          "Namespace not labeled, skip validation",
+			nsLabels:      map[string]string{},
+			kueueState:    operatorv1.Managed,
+			objLabels:     map[string]string{nsLabelManaged: "true"},
+			expectAllow:   true,
+			expectMessage: "Namespace \"test-ns\" is not labeled for Kueue (\"kueue.openshift.io/managed\"), skipping Kueue label validation",
+			operation:     admissionv1.Create,
+		},
+		{
+			name: "Missing Kueue label",
+			nsLabels: map[string]string{
+				nsLabelManaged: "true",
+			},
+			kueueState:    operatorv1.Managed,
+			objLabels:     map[string]string{},
+			expectAllow:   false,
+			expectMessage: "Kueue label validation failed: missing required label \"kueue.x-k8s.io/queue-name\"",
+			operation:     admissionv1.Create,
+		},
+		{
+			name: "Empty Kueue label value",
+			nsLabels: map[string]string{
+				nsLabelManaged: "true",
+			},
+			kueueState: operatorv1.Managed,
+			objLabels: map[string]string{
+				objLabelQueueName: "",
+			},
+			expectAllow:   false,
+			expectMessage: "Kueue label validation failed: label \"kueue.x-k8s.io/queue-name\" is set but empty",
+			operation:     admissionv1.Create,
+		},
+		{
+			name: "Valid Kueue label",
+			nsLabels: map[string]string{
+				nsLabelManaged: "true",
+			},
+			kueueState: operatorv1.Managed,
+			objLabels: map[string]string{
+				objLabelQueueName: validQueueName,
+			},
+			expectAllow:   true,
+			expectMessage: "Kueue label validation passed for \"$Kind\" in namespace \"test-ns\"",
+			operation:     admissionv1.Create,
+		},
+		{
+			name: "Valid Kueue label with other extra labels",
+			nsLabels: map[string]string{
+				nsLabelManaged: "true",
+			},
+			kueueState: operatorv1.Managed,
+			objLabels: map[string]string{
+				objLabelQueueName:           validQueueName,
+				"random.label.io/something": "yes",
+			},
+			expectAllow:   true,
+			expectMessage: "Kueue label validation passed for \"$Kind\" in namespace \"test-ns\"",
+			operation:     admissionv1.Create,
+		},
+		{
+			name: "Incorrect Kueue label key",
+			nsLabels: map[string]string{
+				nsLabelManaged: "true",
+			},
+			kueueState: operatorv1.Managed,
+			objLabels: map[string]string{
+				"kueue.x-k8s.io/queue-naem": validQueueName,
+			},
+			expectAllow:   false,
+			expectMessage: "Kueue label validation failed: missing required label \"kueue.x-k8s.io/queue-name\"",
+			operation:     admissionv1.Create,
+		},
+		{
+			name:       "Queue label present but namespace not labeled",
+			nsLabels:   map[string]string{},
+			kueueState: operatorv1.Managed,
+			objLabels: map[string]string{
+				objLabelQueueName: validQueueName,
+			},
+			expectAllow:   true,
+			expectMessage: "Namespace \"test-ns\" is not labeled for Kueue (\"kueue.openshift.io/managed\"), skipping Kueue label validation",
+			operation:     admissionv1.Create,
+		},
+		{
+			name: "Namespace is Kueue-enabled with legacy label",
+			nsLabels: map[string]string{
+				legacyNsLabelManaged: "true",
+			},
+			kueueState: operatorv1.Managed,
+			objLabels: map[string]string{
+				objLabelQueueName: validQueueName,
+			},
+			expectAllow:   true,
+			expectMessage: "Kueue label validation passed for \"$Kind\" in namespace \"test-ns\"",
+			operation:     admissionv1.Create,
+		},
+		{
+			name: "Kueue unmanaged state treated as enabled - success",
+			nsLabels: map[string]string{
+				nsLabelManaged: "true",
+			},
+			kueueState: operatorv1.Unmanaged,
+			objLabels: map[string]string{
+				objLabelQueueName: validQueueName,
+			},
+			expectAllow:   true,
+			expectMessage: "Kueue label validation passed for \"$Kind\" in namespace \"test-ns\"",
+			operation:     admissionv1.Create,
+		},
+	}
+
+	for _, tc := range testCases {
+		for _, gvk := range supportedGVKs {
+			t.Run(tc.name+"_"+gvk.Kind, func(t *testing.T) {
+				t.Parallel()
+
+				cli := newFakeClientWithObjects(sch, tc.nsLabels, tc.kueueState).Build()
+				workload := createWorkload(gvk, testNamespace, tc.objLabels)
+				req := createAdmissionRequest(t, tc.operation, workload, testNamespace, gvk)
+
+				decoder := admission.NewDecoder(sch)
+				handler := &kueuewebhook.Validator{
+					Client:  cli,
+					Name:    "test",
+					Decoder: decoder,
+				}
+
+				resp := handler.Handle(ctx, req)
+
+				g.Expect(resp.Allowed).To(gomega.Equal(tc.expectAllow))
+				if tc.expectMessage != "" {
+					expectedMsg := strings.Replace(tc.expectMessage, "$Kind", gvk.Kind, 1)
+					g.Expect(resp.Result.Message).To(gomega.ContainSubstring(expectedMsg))
+				}
+			})
+		}
+	}
+}

--- a/internal/webhook/webhook.go
+++ b/internal/webhook/webhook.go
@@ -7,6 +7,7 @@ import (
 
 	dscwebhook "github.com/opendatahub-io/opendatahub-operator/v2/internal/webhook/datasciencecluster"
 	dsciwebhook "github.com/opendatahub-io/opendatahub-operator/v2/internal/webhook/dscinitialization"
+	kueuewebhook "github.com/opendatahub-io/opendatahub-operator/v2/internal/webhook/kueue"
 )
 
 // RegisterAllWebhooks registers all webhook setup functions with the given manager.
@@ -15,6 +16,7 @@ func RegisterAllWebhooks(mgr ctrl.Manager) error {
 	webhookRegistrations := []func(ctrl.Manager) error{
 		dscwebhook.RegisterWebhooks,
 		dsciwebhook.RegisterWebhooks,
+		kueuewebhook.RegisterWebhooks,
 	}
 	for _, reg := range webhookRegistrations {
 		if err := reg(mgr); err != nil {

--- a/pkg/cluster/resources.go
+++ b/pkg/cluster/resources.go
@@ -91,7 +91,7 @@ func GetSingleton[T client.Object](ctx context.Context, cli client.Client, obj T
 }
 
 // GetDSC retrieves the DataScienceCluster (DSC) instance from the Kubernetes cluster.
-func GetDSC(ctx context.Context, cli client.Client) (*dscv1.DataScienceCluster, error) {
+func GetDSC(ctx context.Context, cli client.Reader) (*dscv1.DataScienceCluster, error) {
 	instances := dscv1.DataScienceClusterList{}
 	if err := cli.List(ctx, &instances); err != nil {
 		return nil, fmt.Errorf("failed to list resources of type %s: %w", gvk.DataScienceCluster, err)


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
This PR introduces a new validating admission webhook to enforce the presence of the required label on workloads when Kueue is installed.

Supported frameworks have been updated as per the discussion 
1. kubeflow.org/v1: pytorchjobs, notebooks
2. ray.io/v1alpha1: rayjobs, rayclusters
3. serving.kserve.io/v1beta1: inferenceservices

**The webhook inspects workloads on both create and update operations, and performs the following checks:**
1. Ensures the Kueue component is installed.
2. Verifies the namespace has the label `kueue.openshift.io/managed=true`.
3. Validates that the workload has the `kueue.x-k8s.io/queue-name` label set.

**Added two new edge cases to ensure label validation**
1. When the workload has a valid queue label but the namespace isn't labeled, validation fails
2. When the namespace and workload object(Job, etc) are labeled but Kueue isn't installed, validation fails.

**Uncached client change using "mgr.GetAPIReader()"**

Also included:
Unit test

<!--- Link your JIRA and related links here for reference. -->
https://issues.redhat.com/browse/RHOAIENG-25258

## How Has This Been Tested?
1. Unit tests were added to cover:
- Presence and correctness of workload labels.
- Namespace label validation.
- Kueue controller presence detection.
2. Tested webhook behaviour by creating and deploying a custom image on the cluster.
3. Tested webhook behaviour via OLM by deploying a custom bundle on the cluster.

**Working on the manual testing**

## Screenshot or short clip
I added an OCP console screenshot about the kueue webhook handler validation failure.

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
