### PR TITLE
RHOAIENG-25351 | feat: added missing operator monitoring checks

### DIFF
--- a/api/services/v1alpha1/monitoring_types.go
+++ b/api/services/v1alpha1/monitoring_types.go
@@ -82,6 +82,7 @@ type MonitoringStatus struct {
 	URL string `json:"url,omitempty"`
 }
 
+// Traces enables and defines the configuration for traces collection
 type Traces struct {
 	Storage TracesStorage `json:"storage"`
 }

--- a/config/crd/bases/dscinitialization.opendatahub.io_dscinitializations.yaml
+++ b/config/crd/bases/dscinitialization.opendatahub.io_dscinitializations.yaml
@@ -190,6 +190,8 @@ spec:
                     - message: MonitoringNamespace is immutable
                       rule: self == oldSelf
                   traces:
+                    description: Traces enables and defines the configuration for
+                      traces collection
                     properties:
                       storage:
                         description: TracesStorage defines the storage configuration

--- a/config/crd/bases/services.platform.opendatahub.io_monitorings.yaml
+++ b/config/crd/bases/services.platform.opendatahub.io_monitorings.yaml
@@ -138,6 +138,8 @@ spec:
                 - message: MonitoringNamespace is immutable
                   rule: self == oldSelf
               traces:
+                description: Traces enables and defines the configuration for traces
+                  collection
                 properties:
                   storage:
                     description: TracesStorage defines the storage configuration for

--- a/docs/api-overview.md
+++ b/docs/api-overview.md
@@ -2792,7 +2792,7 @@ _Appears in:_
 
 
 
-
+Traces enables and defines the configuration for traces collection
 
 
 

--- a/internal/controller/dscinitialization/utils.go
+++ b/internal/controller/dscinitialization/utils.go
@@ -167,7 +167,7 @@ func ReconcileDefaultNetworkPolicy(
 		// Get operator namepsace
 		operatorNs, err := cluster.GetOperatorNamespace()
 		if err != nil {
-			log.Error(err, "error getting operator namespace for networkplicy creation")
+			log.Error(err, "error getting operator namespace for networkpolicy creation")
 			return err
 		}
 		// Deploy networkpolicy for operator namespace

--- a/internal/controller/services/monitoring/monitoring_controller.go
+++ b/internal/controller/services/monitoring/monitoring_controller.go
@@ -112,6 +112,7 @@ func (h *serviceHandler) NewReconciler(ctx context.Context, mgr ctrl.Manager) er
 			reconciler.WithEventHandler(
 				handlers.ToNamed(serviceApi.MonitoringInstanceName)),
 		).
+		WithAction(addMonitoringCapability).
 		WithAction(initialize).
 		WithAction(updatePrometheusConfigMap).
 		WithAction(createMonitoringStack).

--- a/tests/e2e/creation_test.go
+++ b/tests/e2e/creation_test.go
@@ -97,6 +97,7 @@ func (tc *DSCTestCtx) ValidateOperatorsInstallation(t *testing.T) {
 		{nn: types.NamespacedName{Name: serverlessOpName, Namespace: serverlessOperatorNamespace}, skipOperatorGroup: false},
 		{nn: types.NamespacedName{Name: authorinoOpName, Namespace: openshiftOperatorsNamespace}, skipOperatorGroup: true},
 		{nn: types.NamespacedName{Name: observabilityOpName, Namespace: observabilityOpNamespace}, skipOperatorGroup: false},
+		{nn: types.NamespacedName{Name: telemetryOpName, Namespace: telemetryOpNamespace}, skipOperatorGroup: false},
 		{nn: types.NamespacedName{Name: tempoOpName, Namespace: tempoOpNamespace}, skipOperatorGroup: false},
 	}
 


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
Adding missing operator checks for the monitoring controller when metris and traces are enabled

https://issues.redhat.com/browse/RHOAIENG-25351

## How Has This Been Tested?
mocking a managed cluster: https://docs.google.com/document/d/17oZQB5wru71X_uOR1C4e9ghfWSdZwnkZZC0jp4CIrXE/edit?usp=sharing

Created dsci cr while operators were missing & when operators were present

## Screenshot or short clip
- Create a default dsci cr
- Create  a monitoring cr
- Verify errors thrown when traces or metrics are not nil


## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Monitoring now validates the presence of required operator subscriptions and updates readiness conditions accordingly.
  * Telemetry operator is now included in end-to-end installation validation tests.

* **Documentation**
  * Added descriptions for the traces configuration in API documentation and CRD schemas.

* **Bug Fixes**
  * Corrected a typographical error in a network policy-related log message.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->