### PR TITLE
update: add workbenchNamespace into DSC and Workbnech status

### DIFF
--- a/internal/controller/components/workbenches/workbenches_controller.go
+++ b/internal/controller/components/workbenches/workbenches_controller.go
@@ -79,6 +79,7 @@ func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.
 			deploy.WithCache(),
 		)).
 		WithAction(deployments.NewAction()).
+		WithAction(updateStatus).
 		// must be the final action
 		WithAction(gc.NewAction()).
 		// declares the list of additional, controller specific conditions that are

--- a/internal/controller/components/workbenches/workbenches_controller_actions.go
+++ b/internal/controller/components/workbenches/workbenches_controller_actions.go
@@ -113,3 +113,13 @@ func configureDependencies(ctx context.Context, rr *odhtypes.ReconciliationReque
 	}
 	return nil
 }
+
+func updateStatus(ctx context.Context, rr *odhtypes.ReconciliationRequest) error {
+	workbench, ok := rr.Instance.(*componentApi.Workbenches)
+	if !ok {
+		return fmt.Errorf("resource instance %v is not a componentApi.Workbenches", rr.Instance)
+	}
+	workbench.Status.WorkbenchNamespace = workbench.Spec.WorkbenchNamespace
+
+	return nil
+}


### PR DESCRIPTION
for dashboard to consume workbenchNamespace, it has been requested to add this into DSC's status, not spec
see https://redhat-internal.slack.com/archives/C08T1K4FQVC/p1749500889751089?thread_ts=1748945148.403179&cid=C08T1K4FQVC
- in DSC: .status.components.workbenches.workbenchNamespace
- in Workbench: .status.workbenchNamespace

<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

<!--- Link your JIRA and related links here for reference. -->
ref: https://issues.redhat.com/browse/RHOAIENG-22098

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
