### PR TITLE
feat: add priorityClass field to HardwareProfile CRD

### DIFF
--- a/api/infrastructure/v1alpha1/hardwareprofile_types.go
+++ b/api/infrastructure/v1alpha1/hardwareprofile_types.go
@@ -111,6 +111,10 @@ type KueueSchedulingSpec struct {
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:MinLength=1
 	LocalQueueName string `json:"localQueueName"`
+
+	// PriorityClass specifies the name of the WorkloadPriorityClass associated with the HardwareProfile.
+	// +optional
+	PriorityClass string `json:"priorityClass,omitempty"`
 }
 
 // NodeSchedulingSpec defines direct node scheduling configuration.

--- a/bundle/manifests/infrastructure.opendatahub.io_hardwareprofiles.yaml
+++ b/bundle/manifests/infrastructure.opendatahub.io_hardwareprofiles.yaml
@@ -109,6 +109,10 @@ spec:
                           placement and tolerations.
                         minLength: 1
                         type: string
+                      priorityClass:
+                        description: PriorityClass specifies the name of the WorkloadPriorityClass
+                          associated with the HardwareProfile.
+                        type: string
                     required:
                     - localQueueName
                     type: object

--- a/config/crd/bases/infrastructure.opendatahub.io_hardwareprofiles.yaml
+++ b/config/crd/bases/infrastructure.opendatahub.io_hardwareprofiles.yaml
@@ -109,6 +109,10 @@ spec:
                           placement and tolerations.
                         minLength: 1
                         type: string
+                      priorityClass:
+                        description: PriorityClass specifies the name of the WorkloadPriorityClass
+                          associated with the HardwareProfile.
+                        type: string
                     required:
                     - localQueueName
                     type: object

--- a/docs/api-overview.md
+++ b/docs/api-overview.md
@@ -2478,6 +2478,7 @@ _Appears in:_
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
 | `localQueueName` _string_ | LocalQueueName specifies the name of the local queue to use for workload scheduling.<br />When specified, workloads using this hardware profile will be submitted to the<br />specified queue and the queue's configuration will determine the actual node<br />placement and tolerations. |  | MinLength: 1 <br />Required: \{\} <br /> |
+| `priorityClass` _string_ | PriorityClass specifies the name of the WorkloadPriorityClass associated with the HardwareProfile. |  |  |
 
 
 #### NodeSchedulingSpec


### PR DESCRIPTION
## Description

JIRA: [RHOAIENG-26729](https://issues.redhat.com/browse/RHOAIENG-26729)

This PR add an optional `PriorityClass` string field to the `KueueSchedulingSpec` block in the `HardwareProfile` CRD. This field is added so a user can reference a Kueue [WorkloadPriorityClass](https://kueue.sigs.k8s.io/docs/concepts/workload_priority_class/).

## How Has This Been Tested?
These changes were tested by building operator, bundle, and catalog images, then verifying that the DSC and DSCI CRs successfully reconcile. It was also verified that the new `PriorityClass` field is present in the `HardwareProfile` CRD as expected.

The following images were used for testing and can be used for verification:
```
quay.io/ckyrillo/opendatahub-operator:v2.29.0
quay.io/ckyrillo/opendatahub-operator-bundle:v2.29.0
quay.io/ckyrillo/opendatahub-operator-catalog:v2.29.0
```

## Screenshot or short clip

## Merge criteria
- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work