### PR TITLE
fix: removed unneeded fields from HardwareProfile

### DIFF
--- a/api/infrastructure/v1alpha1/hardwareprofile_types.go
+++ b/api/infrastructure/v1alpha1/hardwareprofile_types.go
@@ -35,16 +35,6 @@ const (
 
 // HardwareProfileSpec defines the desired state of HardwareProfile.
 type HardwareProfileSpec struct {
-	// The display name of the hardware profile.
-	DisplayName string `json:"displayName"`
-
-	// Indicates whether the hardware profile is available for new resources.
-	Enabled bool `json:"enabled"`
-
-	// A short description of the hardware profile.
-	// +optional
-	Description string `json:"description,omitempty"`
-
 	// The array of identifiers
 	// +optional
 	Identifiers []HardwareIdentifier `json:"identifiers,omitempty"`

--- a/bundle/manifests/infrastructure.opendatahub.io_hardwareprofiles.yaml
+++ b/bundle/manifests/infrastructure.opendatahub.io_hardwareprofiles.yaml
@@ -39,16 +39,6 @@ spec:
           spec:
             description: HardwareProfileSpec defines the desired state of HardwareProfile.
             properties:
-              description:
-                description: A short description of the hardware profile.
-                type: string
-              displayName:
-                description: The display name of the hardware profile.
-                type: string
-              enabled:
-                description: Indicates whether the hardware profile is available for
-                  new resources.
-                type: boolean
               identifiers:
                 description: The array of identifiers
                 items:
@@ -193,9 +183,6 @@ spec:
                     set, and the 'kueue' field must not be set
                   rule: 'self.type == ''Node'' ? (has(self.node) && !has(self.kueue))
                     : true'
-            required:
-            - displayName
-            - enabled
             type: object
           status:
             description: HardwareProfileStatus defines the observed state of HardwareProfile.

--- a/config/crd/bases/infrastructure.opendatahub.io_hardwareprofiles.yaml
+++ b/config/crd/bases/infrastructure.opendatahub.io_hardwareprofiles.yaml
@@ -39,16 +39,6 @@ spec:
           spec:
             description: HardwareProfileSpec defines the desired state of HardwareProfile.
             properties:
-              description:
-                description: A short description of the hardware profile.
-                type: string
-              displayName:
-                description: The display name of the hardware profile.
-                type: string
-              enabled:
-                description: Indicates whether the hardware profile is available for
-                  new resources.
-                type: boolean
               identifiers:
                 description: The array of identifiers
                 items:
@@ -193,9 +183,6 @@ spec:
                     set, and the 'kueue' field must not be set
                   rule: 'self.type == ''Node'' ? (has(self.node) && !has(self.kueue))
                     : true'
-            required:
-            - displayName
-            - enabled
             type: object
           status:
             description: HardwareProfileStatus defines the observed state of HardwareProfile.

--- a/docs/api-overview.md
+++ b/docs/api-overview.md
@@ -2444,9 +2444,6 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `displayName` _string_ | The display name of the hardware profile. |  |  |
-| `enabled` _boolean_ | Indicates whether the hardware profile is available for new resources. |  |  |
-| `description` _string_ | A short description of the hardware profile. |  |  |
 | `identifiers` _[HardwareIdentifier](#hardwareidentifier) array_ | The array of identifiers |  |  |
 | `scheduling` _[SchedulingSpec](#schedulingspec)_ | SchedulingSpec specifies how workloads using this hardware profile should be scheduled. |  |  |
 


### PR DESCRIPTION
## Description

JIRA: [RHOAIENG-26717](https://issues.redhat.com/browse/RHOAIENG-26717)

This PR removes the `DisplayName`, `Description`, and `Enabled` fields from the `HardwareProfile` CRD. These fields are mainly for UI purposes and aren't as useful in an API-centric context.

Rather than setting these fields in the CR `.spec`, they will now be exposed as annotations. The user can set the following annotations which the odh-dashboard will look for when displaying the HardwareProfiles in the UI:
```yaml
  'opendatahub.io/description': string
  'opendatahub.io/display-name': string
  'opendatahub.io/disabled': bool
```

## How Has This Been Tested?
These changes were tested by building operator, bundle, and catalog images, then verifying that the DSC and DSCI CRs successfully reconcile. It was also verified that the new `DisplayName`, `Description`, and `Enabled` fields were removed from the `HardwareProfile` CRD as expected.

The following images were used for testing and can be used for verification:
```
quay.io/ckyrillo/opendatahub-operator:v2.29.0
quay.io/ckyrillo/opendatahub-operator-bundle:v2.29.0
quay.io/ckyrillo/opendatahub-operator-catalog:v2.29.0
```

## Screenshot or short clip

## Merge criteria
- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work