### PR TITLE
RHOAIENG-26152-knative-enable-podspec-schedulername by default

### DIFF
--- a/internal/controller/components/kserve/resources/serving-install/knative-serving.tmpl.yaml
+++ b/internal/controller/components/kserve/resources/serving-install/knative-serving.tmpl.yaml
@@ -35,5 +35,6 @@ spec:
       kubernetes.podspec-tolerations: enabled
       kubernetes.podspec-persistent-volume-write: enabled
       kubernetes.podspec-persistent-volume-claim: enabled
+      kubernetes.podspec-schedulername: enabled
     istio:
       local-gateway.knative-serving.knative-local-gateway: "knative-local-gateway.{{ .ControlPlane.Namespace }}.svc.cluster.local"


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->
Enabling knative feature flag for podspec-schdeulername.
<!--- Link your JIRA and related links here for reference. -->
https://issues.redhat.com/browse/RHOAIENG-26152
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tests are in opendatahub/kserve and opendatahub/opendatahub-tests repos.
## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enabled support for specifying custom scheduler names in pod specifications for Knative Serving resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->