### PR TITLE
Update: add check in Kserve before create resources

### DIFF
--- a/internal/controller/components/kserve/kserve.go
+++ b/internal/controller/components/kserve/kserve.go
@@ -47,6 +47,7 @@ var (
 
 var (
 	ErrServiceMeshNotConfigured        = odherrors.NewStopError(status.ServiceMeshNeedConfiguredMessage)
+	ErrServiceMeshNotReady             = odherrors.NewStopError(status.ServiceMeshNotReadyMessage)
 	ErrServiceMeshMemberAPINotFound    = odherrors.NewStopError(status.ServiceMeshOperatorNotInstalledMessage)
 	ErrServiceMeshOperatorNotInstalled = odherrors.NewStopError(status.ServiceMeshOperatorNotInstalledMessage)
 	ErrServerlessOperatorNotInstalled  = odherrors.NewStopError(status.ServerlessOperatorNotInstalledMessage)

--- a/internal/controller/components/kserve/kserve_controller_actions.go
+++ b/internal/controller/components/kserve/kserve_controller_actions.go
@@ -58,6 +58,18 @@ func checkPreConditions(ctx context.Context, rr *odhtypes.ReconciliationRequest)
 		return ErrServiceMeshNotConfigured
 	}
 
+	// Check if the CapabilityServiceMesh condition is not true, Serverless require ServiceMesh to be ready before creating SMM
+	for _, condition := range rr.DSCI.Status.Conditions {
+		if condition.Type == status.CapabilityServiceMesh && condition.Status != metav1.ConditionTrue {
+			rr.Conditions.MarkFalse(
+				status.ConditionServingAvailable,
+				conditions.WithReason(status.ServiceMeshNotReadyReason),
+				conditions.WithMessage(status.ServiceMeshNotReadyMessage),
+			)
+			return ErrServiceMeshNotReady
+		}
+	}
+
 	var operatorsErr error
 
 	if found, err := cluster.OperatorExists(ctx, rr.Client, serviceMeshOperator); err != nil || !found {

--- a/internal/controller/status/status.go
+++ b/internal/controller/status/status.go
@@ -131,8 +131,10 @@ const (
 
 const (
 	ServiceMeshNotConfiguredReason   = "ServiceMeshNotConfigured"
+	ServiceMeshNotReadyReason        = "ServiceMeshNotReady"
 	ServiceMeshNeedConfiguredMessage = "ServiceMesh needs to be set to 'Managed' in DSCI CR"
 	ServiceMeshNotConfiguredMessage  = "ServiceMesh is not configured in DSCI CR"
+	ServiceMeshNotReadyMessage       = "ServiceMesh is not ready"
 
 	ServiceMeshOperatorNotInstalledReason  = "ServiceMeshOperatorNotInstalled"
 	ServiceMeshOperatorNotInstalledMessage = "ServiceMesh operator must be installed for this component's configuration"

--- a/pkg/utils/test/envt/envt.go
+++ b/pkg/utils/test/envt/envt.go
@@ -262,7 +262,9 @@ func (et *EnvT) ReadFile(elem ...string) ([]byte, error) {
 }
 
 // Manager returns the controller-runtime manager for the test environment, if one was created.
-func (et *EnvT) Manager() manager.Manager { //nolint:ireturn
+//
+//nolint:ireturn
+func (et *EnvT) Manager() manager.Manager {
 	return et.mgr
 }
 


### PR DESCRIPTION
- extra check in checkPreConditions: if DSIC does not have servicmesh condition ready do not create resources. 
knative-serving need istio-proxy to be injected that requires smcp ready first

<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
