### PR TITLE
feat: add GH action for running integration tests - image building part

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -1,0 +1,67 @@
+name: Integration tests
+on:
+  pull_request:
+    paths-ignore:
+      - 'docs/**'
+      - '.github/**'
+      - '**.md'
+      - 'Makefile'
+      - 'OWNERS'
+      - 'OWNERS_ALIASES'
+      - 'PROJECT'
+
+env:
+  IMAGE_TAG_BASE: quay.io/${{ secrets.QUAY_ORG }}/opendatahub-operator
+  TAG: pr-${{ github.event.number }}
+jobs:
+  create-catalog-image:
+    name: Build and push catalog image
+    runs-on: ubuntu-latest
+    env:
+      IMAGE_BUILDER: podman
+    steps:
+      - name: Quay.io login
+        uses: redhat-actions/podman-login@v1
+        env:
+          QUAY_ID: ${{ secrets.QUAY_ID }}
+          QUAY_TOKEN: ${{ secrets.QUAY_TOKEN }}
+        with:
+          registry: quay.io
+          username: ${{ env.QUAY_ID }}
+          password: ${{ env.QUAY_TOKEN }}
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Create operator image
+        env:
+          IMG: ${{ env.IMAGE_TAG_BASE }}:${{ env.TAG }}
+        run:
+          make image
+      
+      - name: Get latest release version
+        env:
+          OPERATOR_REPOSITORY_NAME: opendatahub-io/opendatahub-operator
+        run: |
+          version_tag=$(curl -s https://api.github.com/repos/${OPERATOR_REPOSITORY_NAME}/releases/latest | jq -r .tag_name)-${{ env.TAG }}
+          echo "VERSION_TAG=$version_tag" >> $GITHUB_ENV
+
+      - name: Create bundle image
+        env:
+          BUNDLE_IMG: ${{ env.IMAGE_TAG_BASE }}-bundle:${VERSION_TAG}
+        run: |
+          make bundle-build
+          make bundle-push
+
+      - name: Create catalog image
+        env:
+          CATALOG_IMG: ${{ env.IMAGE_TAG_BASE }}-catalog:${VERSION_TAG}
+          BUNDLE_IMG: ${{ env.IMAGE_TAG_BASE }}-bundle:${VERSION_TAG}
+        run: |
+          make catalog-build 
+          make catalog-push


### PR DESCRIPTION
## Description
Based on the effort in #1818, I'm adding a GitHub action that will handle triggering integration tests for opendatahub-operator PRs. This PR only includes the image building part - so that we can see that this part works as intended, before we proceed to triggering the Jenkins pipeline itself

JIRA ref: [RHOAIENG-22511](https://issues.redhat.com/browse/RHOAIENG-22511)

## How Has This Been Tested?
As mentioned in #1818, the flow was successfully tested on my fork.

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Added a new GitHub Actions workflow to automate integration tests and container image builds for pull requests, excluding changes limited to documentation or configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->