### PR TITLE
[sync] update: add servicemesh check in Kserve before create knative resources

### DIFF
--- a/internal/controller/components/kserve/kserve.go
+++ b/internal/controller/components/kserve/kserve.go
@@ -47,6 +47,7 @@ var (
 
 var (
 	ErrServiceMeshNotConfigured        = odherrors.NewStopError(status.ServiceMeshNeedConfiguredMessage)
+	ErrServiceMeshNotReady             = odherrors.NewStopError(status.ServiceMeshNotReadyMessage)
 	ErrServiceMeshMemberAPINotFound    = odherrors.NewStopError(status.ServiceMeshOperatorNotInstalledMessage)
 	ErrServiceMeshOperatorNotInstalled = odherrors.NewStopError(status.ServiceMeshOperatorNotInstalledMessage)
 	ErrServerlessOperatorNotInstalled  = odherrors.NewStopError(status.ServerlessOperatorNotInstalledMessage)

--- a/internal/controller/components/kserve/kserve_controller.go
+++ b/internal/controller/components/kserve/kserve_controller.go
@@ -113,7 +113,7 @@ func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.
 		Watches(
 			&dsciv1.DSCInitialization{},
 			reconciler.WithEventHandler(handlers.ToNamed(componentApi.KserveInstanceName)),
-			reconciler.WithPredicates(predicate.Or(generation.New(), resources.DSCIReadiness)),
+			reconciler.WithPredicates(predicate.Or(generation.New(), resources.DSCIReadiness, resources.DSCIServiceMeshCondition)),
 		).
 		WatchesGVK(
 			gvk.OperatorCondition,

--- a/internal/controller/components/kserve/kserve_controller_actions.go
+++ b/internal/controller/components/kserve/kserve_controller_actions.go
@@ -86,6 +86,17 @@ func checkPreConditions(ctx context.Context, rr *odhtypes.ReconciliationRequest)
 		return odherrors.NewStopErrorW(operatorsErr)
 	}
 
+	// Check if the CapabilityServiceMesh condition is not true, Serverless require ServiceMesh to be ready before creating SMM
+	if !conditions.IsStatusConditionTrue(&rr.DSCI.Status, status.CapabilityServiceMesh) {
+		rr.Conditions.MarkFalse(
+			status.ConditionServingAvailable,
+			conditions.WithObservedGeneration(rr.Instance.GetGeneration()),
+			conditions.WithReason(status.ServiceMeshNotReadyReason),
+			conditions.WithMessage(status.ServiceMeshNotReadyMessage),
+		)
+		return ErrServiceMeshNotReady
+	}
+
 	rr.Conditions.MarkTrue(status.ConditionServingAvailable)
 
 	return nil

--- a/internal/controller/components/kserve/kserve_controller_actions_test.go
+++ b/internal/controller/components/kserve/kserve_controller_actions_test.go
@@ -11,6 +11,7 @@ import (
 	ofapiv2 "github.com/operator-framework/api/pkg/operators/v2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/opendatahub-io/opendatahub-operator/v2/api/common"
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/api/components/v1alpha1"
 	dsciv1 "github.com/opendatahub-io/opendatahub-operator/v2/api/dscinitialization/v1"
 	infrav1 "github.com/opendatahub-io/opendatahub-operator/v2/api/infrastructure/v1"
@@ -222,9 +223,17 @@ func TestCheckPreConditions_ServiceMeshManaged_AllOperator(t *testing.T) {
 	ks := componentApi.Kserve{}
 	ks.Spec.Serving.ManagementState = operatorv1.Managed
 
+	// Set ServiceMesh condition to True since we're testing operator checks
 	dsci := dsciv1.DSCInitialization{}
 	dsci.Spec.ServiceMesh = &infrav1.ServiceMeshSpec{
 		ManagementState: operatorv1.Managed,
+	}
+	dsci.Status.Conditions = []common.Condition{
+		{
+			Type:   status.CapabilityServiceMesh,
+			Status: metav1.ConditionTrue,
+			Reason: "ServiceMeshReady",
+		},
 	}
 
 	rr := types.ReconciliationRequest{
@@ -239,6 +248,59 @@ func TestCheckPreConditions_ServiceMeshManaged_AllOperator(t *testing.T) {
 	g.Expect(&ks).Should(
 		WithTransform(resources.ToUnstructured, And(
 			jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, status.ConditionServingAvailable, metav1.ConditionTrue),
+		)),
+	)
+}
+
+func TestCheckPreConditions_ServiceMeshConditionNotTrue(t *testing.T) {
+	ctx := context.Background()
+	g := NewWithT(t)
+
+	cli, err := fakeclient.New(
+		fakeclient.WithObjects(
+			&ofapiv2.OperatorCondition{ObjectMeta: metav1.ObjectMeta{
+				Name: serviceMeshOperator,
+			}},
+			&ofapiv2.OperatorCondition{ObjectMeta: metav1.ObjectMeta{
+				Name: serverlessOperator,
+			}},
+		),
+	)
+
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	ks := componentApi.Kserve{}
+	ks.Spec.Serving.ManagementState = operatorv1.Managed
+
+	dsci := dsciv1.DSCInitialization{}
+	// Set ServiceMesh to Managed
+	dsci.Spec.ServiceMesh = &infrav1.ServiceMeshSpec{
+		ManagementState: operatorv1.Managed,
+	}
+	// Set ServiceMesh condition to Unknown (not ready)
+	dsci.Status.Conditions = []common.Condition{
+		{
+			Type:   status.CapabilityServiceMesh,
+			Status: metav1.ConditionUnknown,
+			Reason: "ServiceMeshNotReady",
+		},
+	}
+
+	rr := types.ReconciliationRequest{
+		Client:     cli,
+		Instance:   &ks,
+		DSCI:       &dsci,
+		Conditions: conditions.NewManager(&ks, status.ConditionTypeReady),
+	}
+
+	err = checkPreConditions(ctx, &rr)
+	g.Expect(err).Should(
+		MatchError(ContainSubstring(status.ServiceMeshNotReadyMessage)),
+	)
+	g.Expect(&ks).Should(
+		WithTransform(resources.ToUnstructured, And(
+			jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, status.ConditionServingAvailable, metav1.ConditionFalse),
+			jq.Match(`.status.conditions[] | select(.type == "%s") | .message == "%s"`, status.ConditionServingAvailable, status.ServiceMeshNotReadyMessage),
 		)),
 	)
 }

--- a/internal/controller/status/status.go
+++ b/internal/controller/status/status.go
@@ -130,8 +130,10 @@ const (
 
 const (
 	ServiceMeshNotConfiguredReason   = "ServiceMeshNotConfigured"
+	ServiceMeshNotReadyReason        = "ServiceMeshNotReady"
 	ServiceMeshNeedConfiguredMessage = "ServiceMesh needs to be set to 'Managed' in DSCI CR"
 	ServiceMeshNotConfiguredMessage  = "ServiceMesh is not configured in DSCI CR"
+	ServiceMeshNotReadyMessage       = "ServiceMesh is not ready"
 
 	ServiceMeshOperatorNotInstalledReason  = "ServiceMeshOperatorNotInstalled"
 	ServiceMeshOperatorNotInstalledMessage = "ServiceMesh operator must be installed for this component's configuration"

--- a/pkg/controller/predicates/resources/resources.go
+++ b/pkg/controller/predicates/resources/resources.go
@@ -10,6 +10,8 @@ import (
 
 	dscv1 "github.com/opendatahub-io/opendatahub-operator/v2/api/datasciencecluster/v1"
 	dsciv1 "github.com/opendatahub-io/opendatahub-operator/v2/api/dscinitialization/v1"
+	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/status"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/conditions"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/resources"
 )
 
@@ -156,4 +158,35 @@ func AnnotationChanged(name string) predicate.Funcs {
 			return resources.GetAnnotation(e.ObjectNew, name) != resources.GetAnnotation(e.ObjectOld, name)
 		},
 	}
+}
+
+var DSCIServiceMeshCondition = predicate.Funcs{
+	UpdateFunc: func(e event.UpdateEvent) bool {
+		oldObj, ok := e.ObjectOld.(*dsciv1.DSCInitialization)
+		if !ok {
+			return false
+		}
+		newObj, ok := e.ObjectNew.(*dsciv1.DSCInitialization)
+		if !ok {
+			return false
+		}
+
+		oldMeshCondition := conditions.FindStatusCondition(&oldObj.Status, status.CapabilityServiceMesh)
+		newMeshCondition := conditions.FindStatusCondition(&newObj.Status, status.CapabilityServiceMesh)
+
+		if oldMeshCondition == nil || newMeshCondition == nil {
+			return oldMeshCondition != newMeshCondition
+		}
+
+		return oldMeshCondition.Status != newMeshCondition.Status
+	},
+	CreateFunc: func(e event.CreateEvent) bool {
+		return false
+	},
+	DeleteFunc: func(e event.DeleteEvent) bool {
+		return false
+	},
+	GenericFunc: func(e event.GenericEvent) bool {
+		return false
+	},
 }

--- a/pkg/controller/predicates/resources/resources_test.go
+++ b/pkg/controller/predicates/resources/resources_test.go
@@ -7,6 +7,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 
+	"github.com/opendatahub-io/opendatahub-operator/v2/api/common"
+	dsciv1 "github.com/opendatahub-io/opendatahub-operator/v2/api/dscinitialization/v1"
+	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/status"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/predicates/resources"
 
 	. "github.com/onsi/gomega"
@@ -86,4 +89,157 @@ func TestAnnotationChanged(t *testing.T) {
 			g.Expect(got).To(Equal(tt.want))
 		})
 	}
+}
+
+func TestDSCIServiceMeshCondition(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		oldObj   *dsciv1.DSCInitialization
+		newObj   *dsciv1.DSCInitialization
+		expected bool
+	}{
+		{
+			name: "when new condition is added (length changed)",
+			oldObj: &dsciv1.DSCInitialization{
+				Status: dsciv1.DSCInitializationStatus{
+					Conditions: []common.Condition{},
+				},
+			},
+			newObj: &dsciv1.DSCInitialization{
+				Status: dsciv1.DSCInitializationStatus{
+					Conditions: []common.Condition{
+						{
+							Type:   status.CapabilityServiceMesh,
+							Status: metav1.ConditionTrue,
+						},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "when old condition is removed(length changed)",
+			oldObj: &dsciv1.DSCInitialization{
+				Status: dsciv1.DSCInitializationStatus{
+					Conditions: []common.Condition{
+						{
+							Type:   status.CapabilityServiceMesh,
+							Status: metav1.ConditionTrue,
+						},
+					},
+				},
+			},
+			newObj: &dsciv1.DSCInitialization{
+				Status: dsciv1.DSCInitializationStatus{
+					Conditions: []common.Condition{},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "when condition status changes(SMCP to ready)",
+			oldObj: &dsciv1.DSCInitialization{
+				Status: dsciv1.DSCInitializationStatus{
+					Conditions: []common.Condition{
+						{
+							Type:   status.CapabilityServiceMesh,
+							Status: metav1.ConditionFalse,
+						},
+					},
+				},
+			},
+			newObj: &dsciv1.DSCInitialization{
+				Status: dsciv1.DSCInitializationStatus{
+					Conditions: []common.Condition{
+						{
+							Type:   status.CapabilityServiceMesh,
+							Status: metav1.ConditionTrue,
+						},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "when condition status remains the same",
+			oldObj: &dsciv1.DSCInitialization{
+				Status: dsciv1.DSCInitializationStatus{
+					Conditions: []common.Condition{
+						{
+							Type:   status.CapabilityServiceMesh,
+							Status: metav1.ConditionTrue,
+						},
+					},
+				},
+			},
+			newObj: &dsciv1.DSCInitialization{
+				Status: dsciv1.DSCInitializationStatus{
+					Conditions: []common.Condition{
+						{
+							Type:   status.CapabilityServiceMesh,
+							Status: metav1.ConditionTrue,
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "when other condition changes",
+			oldObj: &dsciv1.DSCInitialization{
+				Status: dsciv1.DSCInitializationStatus{
+					Conditions: []common.Condition{
+						{
+							Type:   status.CapabilityServiceMeshAuthorization,
+							Status: metav1.ConditionFalse,
+						},
+					},
+				},
+			},
+			newObj: &dsciv1.DSCInitialization{
+				Status: dsciv1.DSCInitializationStatus{
+					Conditions: []common.Condition{
+						{
+							Type:   status.CapabilityServiceMeshAuthorization,
+							Status: metav1.ConditionTrue,
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewWithT(t)
+			e := event.UpdateEvent{
+				ObjectOld: tt.oldObj,
+				ObjectNew: tt.newObj,
+			}
+			g.Expect(resources.DSCIServiceMeshCondition.UpdateFunc(e)).To(Equal(tt.expected))
+		})
+	}
+
+	// Test Create, Delete, and Generic events
+	t.Run("Create event returns false", func(t *testing.T) {
+		g := NewWithT(t)
+		e := event.CreateEvent{}
+		g.Expect(resources.DSCIServiceMeshCondition.CreateFunc(e)).To(BeFalse())
+	})
+
+	t.Run("Delete event returns false", func(t *testing.T) {
+		g := NewWithT(t)
+		e := event.DeleteEvent{}
+		g.Expect(resources.DSCIServiceMeshCondition.DeleteFunc(e)).To(BeFalse())
+	})
+
+	t.Run("Generic event returns false", func(t *testing.T) {
+		g := NewWithT(t)
+		e := event.GenericEvent{}
+		g.Expect(resources.DSCIServiceMeshCondition.GenericFunc(e)).To(BeFalse())
+	})
 }

--- a/pkg/utils/test/envt/envt.go
+++ b/pkg/utils/test/envt/envt.go
@@ -262,7 +262,9 @@ func (et *EnvT) ReadFile(elem ...string) ([]byte, error) {
 }
 
 // Manager returns the controller-runtime manager for the test environment, if one was created.
-func (et *EnvT) Manager() manager.Manager { //nolint:ireturn
+//
+//nolint:ireturn
+func (et *EnvT) Manager() manager.Manager {
 	return et.mgr
 }
 


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

<!--- Link your JIRA and related links here for reference. -->
ref https://issues.redhat.com/browse/RHOAIENG-27521

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
