### PR TITLE
RHOAIENG-26313-enable-multi-container-probing

### DIFF
--- a/internal/controller/components/kserve/resources/serving-install/knative-serving.tmpl.yaml
+++ b/internal/controller/components/kserve/resources/serving-install/knative-serving.tmpl.yaml
@@ -36,5 +36,6 @@ spec:
       kubernetes.podspec-persistent-volume-write: enabled
       kubernetes.podspec-persistent-volume-claim: enabled
       kubernetes.podspec-schedulername: enabled
+      multi-container-probing: enabled
     istio:
       local-gateway.knative-serving.knative-local-gateway: "knative-local-gateway.{{ .ControlPlane.Namespace }}.svc.cluster.local"


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Kserve FVT tests were added in the kserve repository.

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enabled support for probing in multi-container pods, enhancing observability and health checks for deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->