### PR TITLE
Set controller deployment replicas to 3 for webhook HA

### DIFF
--- a/bundle/manifests/opendatahub-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/opendatahub-operator.clusterserviceversion.yaml
@@ -113,7 +113,7 @@ metadata:
     categories: AI/Machine Learning, Big Data
     certified: "False"
     containerImage: quay.io/opendatahub/opendatahub-operator:v2.30.0
-    createdAt: "2025-06-10T09:51:37Z"
+    createdAt: "2025-06-17T08:06:58Z"
     operators.operatorframework.io/builder: operator-sdk-v1.39.2
     operators.operatorframework.io/internal-objects: '["featuretrackers.features.opendatahub.io",
       "codeflares.components.platform.opendatahub.io", "dashboards.components.platform.opendatahub.io",
@@ -1284,7 +1284,7 @@ spec:
           name: opendatahub-operator
         name: opendatahub-operator-controller-manager
         spec:
-          replicas: 1
+          replicas: 3
           selector:
             matchLabels:
               control-plane: controller-manager

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -18,7 +18,7 @@ spec:
     matchLabels:
       name: opendatahub-operator
       control-plane: controller-manager
-  replicas: 1
+  replicas: 3
   template:
     metadata:
       annotations:

--- a/tests/e2e/odh_manager_test.go
+++ b/tests/e2e/odh_manager_test.go
@@ -39,7 +39,7 @@ func (tc *OperatorTestCtx) testODHDeployment(t *testing.T) {
 
 	// Verify if the operator deployment is created
 	controllerDeployment := "opendatahub-operator-controller-manager"
-	tc.EnsureDeploymentReady(types.NamespacedName{Namespace: tc.OperatorNamespace, Name: controllerDeployment}, 1)
+	tc.EnsureDeploymentReady(types.NamespacedName{Namespace: tc.OperatorNamespace, Name: controllerDeployment}, 3)
 }
 
 // ValidateOwnedCRDs validates if the owned CRDs are properly created and available.


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description

This PR sets the controller deployment replica count to 3 in the CSV manifest to ensure webhook high availability.

<!--- Describe your changes in detail -->
- Updates `replicas` to 3 for the controller deployment in the CSV.
- Ensures the webhook server is highly available.

<!--- Link your JIRA and related links here for reference. -->

JIRA: [RHOAIENG-26410](https://issues.redhat.com/browse/RHOAIENG-26410)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested using the following script:
```
#!/bin/bash
set -euo pipefail

NAMESPACE=opendatahub-operator-system
LABEL_SELECTOR="name=opendatahub-operator"
RETRY_COUNT=5
SLEEP_AFTER_STEP=5

# Static template YAML base
BASE_YAML=$(cat <<'EOF'
apiVersion: datasciencecluster.opendatahub.io/v1
kind: DataScienceCluster
metadata:
  name: default-dsc
spec:
  components:
    dashboard:
      managementState: Managed
    modelmeshserving:
      managementState: Managed
    modelregistry:
      managementState: Removed
      registriesNamespace: odh-model-registries
    workbenches:
      managementState: Managed
      workbenchNamespace: opendatahub
EOF
)

function apply_management_state() {
  local state=$1
  echo "Applying managementState=$state"
  echo "$BASE_YAML" | yq e ".spec.components.modelregistry.managementState = \"$state\"" - | oc apply -f -
}

function delete_pods() {
  local count=$1
  echo "Deleting $count pod(s)..."
  
  # Get available pods
  PODS=($(oc get pods -n $NAMESPACE -l $LABEL_SELECTOR -o jsonpath='{.items[*].metadata.name}' 2>/dev/null || echo ""))
  
  if [[ ${#PODS[@]} -eq 0 ]]; then
    echo "No pods found with label $LABEL_SELECTOR"
    return 0
  fi
  
  # Don't try to delete more pods than exist
  local actual_count=${#PODS[@]}
  if [[ $count -gt $actual_count ]]; then
    echo "Requested to delete $count pods, but only $actual_count available. Deleting all available."
    count=$actual_count
  fi
  
  for ((j=0; j<count; j++)); do
    if [[ -n "${PODS[j]:-}" ]]; then
      echo "Deleting pod: ${PODS[j]}"
      oc delete pod "${PODS[j]}" -n $NAMESPACE --grace-period=0 --force 2>/dev/null || echo "Failed to delete ${PODS[j]}"
    fi
  done
}

function delete_leader_pod() {
  echo "Deleting leader pod..."
  
  # Find the lease that tracks leadership
  local leases=($(oc get lease -n $NAMESPACE -o jsonpath="{.items[*].metadata.name}" 2>/dev/null || echo ""))
  
  if [[ ${#leases[@]} -eq 0 ]]; then
    echo "No leases found in namespace $NAMESPACE"
    return 1
  fi
  
  # Use the first lease (you might need to adjust this logic based on your setup)
  local LEASE_NAME="${leases[0]}"
  echo "Using lease: $LEASE_NAME"
  
  local FULL_LEADER=$(oc get lease $LEASE_NAME -n $NAMESPACE -o jsonpath="{.spec.holderIdentity}" 2>/dev/null || echo "")
  
  if [[ -z "$FULL_LEADER" ]]; then
    echo "No holder identity found for lease $LEASE_NAME"
    return 1
  fi
  
  # Extract pod name (everything before first underscore)
  local LEADER_POD="${FULL_LEADER%%_*}"
  echo "Current leader pod (extracted): $LEADER_POD"
  
  if ! oc get pod $LEADER_POD -n $NAMESPACE &>/dev/null; then
    echo "Leader pod $LEADER_POD not found, skipping deletion"
    return 0
  fi
  
  echo "Deleting leader pod: $LEADER_POD"
  oc delete pod $LEADER_POD -n $NAMESPACE --grace-period=0 --force 2>/dev/null || echo "Failed to delete leader pod"
  
  # Just wait a reasonable time for leadership transition, don't loop indefinitely
  echo "Waiting for leadership transition..."
  sleep 15
  
  # Optional: Check if there's a new leader, but don't block on it
  local NEW_FULL_LEADER=$(oc get lease $LEASE_NAME -n $NAMESPACE -o jsonpath="{.spec.holderIdentity}" 2>/dev/null || echo "")
  if [[ -n "$NEW_FULL_LEADER" ]]; then
    local NEW_LEADER_POD="${NEW_FULL_LEADER%%_*}"
    echo "New leader appears to be: $NEW_LEADER_POD"
  else
    echo "No new leader detected yet, but continuing..."
  fi
  
  echo "Leadership transition wait completed, continuing..."
}

function wait_for_pods_ready() {
  echo "Waiting for pods to be ready..."
  local timeout=60
  local interval=5
  local elapsed=0
  
  while (( elapsed < timeout )); do
    local ready_pods=$(oc get pods -n $NAMESPACE -l $LABEL_SELECTOR -o jsonpath='{.items[?(@.status.conditions[?(@.type=="Ready" && @.status=="True")])].metadata.name}' 2>/dev/null | wc -w)
    echo "Ready pods: $ready_pods"
    
    if [[ $ready_pods -gt 0 ]]; then
      echo "At least one pod is ready"
      return 0
    fi
    
    sleep $interval
    elapsed=$((elapsed + interval))
  done
  
  echo "Warning: Timeout waiting for pods to be ready"
  return 0
}

function run_test_cycle() {
  local cycle=$1
  echo ">>> run_test_cycle() STARTING for cycle $cycle"
  
  echo "Step 1: Delete 1 pod, apply managementState=Removed"
  delete_pods 1
  apply_management_state "Removed"
  echo ""
  sleep $SLEEP_AFTER_STEP
  
  echo "Step 2: Delete 2 pods, apply managementState=Managed"
  delete_pods 2
  apply_management_state "Managed"
  echo ""
  sleep $SLEEP_AFTER_STEP
  
  echo "Step 3: Delete leader pod, apply managementState=Removed"
  delete_leader_pod
  apply_management_state "Removed"
  echo ""
  sleep $SLEEP_AFTER_STEP
  
  echo ">>> run_test_cycle() COMPLETED for cycle $cycle"
}

# Main execution loop
for ((i=1; i<=RETRY_COUNT; i++)); do
  echo "+++ DEBUG: entering iteration i=$i"
  echo "=== Starting test cycle #$i ==="
  
  if ! run_test_cycle "$i"; then
    echo ">>> ERROR: run_test_cycle failed for cycle $i"
    exit 1
  fi
  
  echo "=== Completed test cycle #$i ==="
  echo ""
done

echo "All test cycles completed."

```


Output sample:
```
/ha-testing.sh
+++ DEBUG: entering iteration i=1
=== Starting test cycle #1 ===
>>> run_test_cycle() STARTING for cycle 1
Step 1: Delete 1 pod, apply managementState=Removed
Deleting 1 pod(s)...
Deleting pod: opendatahub-operator-controller-manager-75684694b8-hsqww
pod "opendatahub-operator-controller-manager-75684694b8-hsqww" force deleted
Applying managementState=Removed
datasciencecluster.datasciencecluster.opendatahub.io/default-dsc unchanged

Step 2: Delete 2 pods, apply managementState=Managed
Deleting 2 pod(s)...
Deleting pod: opendatahub-operator-controller-manager-75684694b8-fwnxr
pod "opendatahub-operator-controller-manager-75684694b8-fwnxr" force deleted
Deleting pod: opendatahub-operator-controller-manager-75684694b8-pjb47
pod "opendatahub-operator-controller-manager-75684694b8-pjb47" force deleted
Applying managementState=Managed
datasciencecluster.datasciencecluster.opendatahub.io/default-dsc configured

Step 3: Delete leader pod, apply managementState=Removed
Deleting leader pod...
Using lease: 07ed84f7.opendatahub.io
Current leader pod (extracted): opendatahub-operator-controller-manager-75684694b8-pjb47
Leader pod opendatahub-operator-controller-manager-75684694b8-pjb47 not found, skipping deletion
Applying managementState=Removed
datasciencecluster.datasciencecluster.opendatahub.io/default-dsc configured

>>> run_test_cycle() COMPLETED for cycle 1
=== Completed test cycle #1 ===

+++ DEBUG: entering iteration i=2
=== Starting test cycle #2 ===
>>> run_test_cycle() STARTING for cycle 2
Step 1: Delete 1 pod, apply managementState=Removed
Deleting 1 pod(s)...
Deleting pod: opendatahub-operator-controller-manager-75684694b8-przlv
pod "opendatahub-operator-controller-manager-75684694b8-przlv" force deleted
Applying managementState=Removed
datasciencecluster.datasciencecluster.opendatahub.io/default-dsc unchanged

Step 2: Delete 2 pods, apply managementState=Managed
Deleting 2 pod(s)...
Deleting pod: opendatahub-operator-controller-manager-75684694b8-57tqq
pod "opendatahub-operator-controller-manager-75684694b8-57tqq" force deleted
Deleting pod: opendatahub-operator-controller-manager-75684694b8-rvb2t
pod "opendatahub-operator-controller-manager-75684694b8-rvb2t" force deleted
Applying managementState=Managed
Error from server (InternalError): error when applying patch:
{"metadata":{"annotations":{"kubectl.kubernetes.io/last-applied-configuration":"{\"apiVersion\":\"datasciencecluster.opendatahub.io/v1\",\"kind\":\"DataScienceCluster\",\"metadata\":{\"annotations\":{},\"name\":\"default-dsc\"},\"spec\":{\"components\":{\"dashboard\":{\"managementState\":\"Managed\"},\"modelmeshserving\":{\"managementState\":\"Managed\"},\"modelregistry\":{\"managementState\":\"Managed\",\"registriesNamespace\":\"odh-model-registries\"},\"workbenches\":{\"managementState\":\"Managed\",\"workbenchNamespace\":\"opendatahub\"}}}}\n"}},"spec":{"components":{"modelregistry":{"managementState":"Managed"}}}}
to:
Resource: "datasciencecluster.opendatahub.io/v1, Resource=datascienceclusters", GroupVersionKind: "datasciencecluster.opendatahub.io/v1, Kind=DataScienceCluster"
Name: "default-dsc", Namespace: ""
for: "STDIN": error when patching "STDIN": Internal error occurred: failed calling webhook "datasciencecluster-defaulter.opendatahub.io": failed to call webhook: Post "https://opendatahub-operator-controller-manager-service.opendatahub-operator-system.svc:443/mutate-datasciencecluster?timeout=10s": context deadline exceeded

Step 3: Delete leader pod, apply managementState=Removed
Deleting leader pod...
Using lease: 07ed84f7.opendatahub.io
Current leader pod (extracted): opendatahub-operator-controller-manager-75684694b8-xjcsw
Deleting leader pod: opendatahub-operator-controller-manager-75684694b8-xjcsw
pod "opendatahub-operator-controller-manager-75684694b8-xjcsw" force deleted
Waiting for leadership transition...
New leader appears to be: opendatahub-operator-controller-manager-75684694b8-xjcsw
Leadership transition wait completed, continuing...
Applying managementState=Removed
datasciencecluster.datasciencecluster.opendatahub.io/default-dsc unchanged

>>> run_test_cycle() COMPLETED for cycle 2
=== Completed test cycle #2 ===

+++ DEBUG: entering iteration i=3
=== Starting test cycle #3 ===
>>> run_test_cycle() STARTING for cycle 3
Step 1: Delete 1 pod, apply managementState=Removed
Deleting 1 pod(s)...
Deleting pod: opendatahub-operator-controller-manager-75684694b8-b4bz2
pod "opendatahub-operator-controller-manager-75684694b8-b4bz2" force deleted
Applying managementState=Removed
datasciencecluster.datasciencecluster.opendatahub.io/default-dsc unchanged

Step 2: Delete 2 pods, apply managementState=Managed
Deleting 2 pod(s)...
Deleting pod: opendatahub-operator-controller-manager-75684694b8-ghfct
pod "opendatahub-operator-controller-manager-75684694b8-ghfct" force deleted
Deleting pod: opendatahub-operator-controller-manager-75684694b8-qk2mb
pod "opendatahub-operator-controller-manager-75684694b8-qk2mb" force deleted
Applying managementState=Managed
datasciencecluster.datasciencecluster.opendatahub.io/default-dsc configured

Step 3: Delete leader pod, apply managementState=Removed
Deleting leader pod...
Using lease: 07ed84f7.opendatahub.io
Current leader pod (extracted): opendatahub-operator-controller-manager-75684694b8-tndqs
Deleting leader pod: opendatahub-operator-controller-manager-75684694b8-tndqs
pod "opendatahub-operator-controller-manager-75684694b8-tndqs" force deleted
Waiting for leadership transition...
New leader appears to be: opendatahub-operator-controller-manager-75684694b8-tndqs
Leadership transition wait completed, continuing...
Applying managementState=Removed
datasciencecluster.datasciencecluster.opendatahub.io/default-dsc configured

>>> run_test_cycle() COMPLETED for cycle 3
=== Completed test cycle #3 ===

+++ DEBUG: entering iteration i=4
=== Starting test cycle #4 ===
>>> run_test_cycle() STARTING for cycle 4
Step 1: Delete 1 pod, apply managementState=Removed
Deleting 1 pod(s)...
Deleting pod: opendatahub-operator-controller-manager-75684694b8-7pjrs
pod "opendatahub-operator-controller-manager-75684694b8-7pjrs" force deleted
Applying managementState=Removed
datasciencecluster.datasciencecluster.opendatahub.io/default-dsc unchanged

Step 2: Delete 2 pods, apply managementState=Managed
Deleting 2 pod(s)...
Deleting pod: opendatahub-operator-controller-manager-75684694b8-7xzqf
pod "opendatahub-operator-controller-manager-75684694b8-7xzqf" force deleted
Deleting pod: opendatahub-operator-controller-manager-75684694b8-q8wvz
pod "opendatahub-operator-controller-manager-75684694b8-q8wvz" force deleted
Applying managementState=Managed
datasciencecluster.datasciencecluster.opendatahub.io/default-dsc configured

Step 3: Delete leader pod, apply managementState=Removed
Deleting leader pod...
Using lease: 07ed84f7.opendatahub.io
Current leader pod (extracted): opendatahub-operator-controller-manager-75684694b8-7xzqf
Leader pod opendatahub-operator-controller-manager-75684694b8-7xzqf not found, skipping deletion
Applying managementState=Removed
datasciencecluster.datasciencecluster.opendatahub.io/default-dsc configured

>>> run_test_cycle() COMPLETED for cycle 4
=== Completed test cycle #4 ===

+++ DEBUG: entering iteration i=5
=== Starting test cycle #5 ===
>>> run_test_cycle() STARTING for cycle 5
Step 1: Delete 1 pod, apply managementState=Removed
Deleting 1 pod(s)...
Deleting pod: opendatahub-operator-controller-manager-75684694b8-2rgjt
pod "opendatahub-operator-controller-manager-75684694b8-2rgjt" force deleted
Applying managementState=Removed
datasciencecluster.datasciencecluster.opendatahub.io/default-dsc unchanged

Step 2: Delete 2 pods, apply managementState=Managed
Deleting 2 pod(s)...
Deleting pod: opendatahub-operator-controller-manager-75684694b8-bblzb
pod "opendatahub-operator-controller-manager-75684694b8-bblzb" force deleted
Deleting pod: opendatahub-operator-controller-manager-75684694b8-qjd4d
pod "opendatahub-operator-controller-manager-75684694b8-qjd4d" force deleted
Applying managementState=Managed
datasciencecluster.datasciencecluster.opendatahub.io/default-dsc configured

Step 3: Delete leader pod, apply managementState=Removed
Deleting leader pod...
Using lease: 07ed84f7.opendatahub.io
Current leader pod (extracted): opendatahub-operator-controller-manager-75684694b8-wv4ck
Deleting leader pod: opendatahub-operator-controller-manager-75684694b8-wv4ck
pod "opendatahub-operator-controller-manager-75684694b8-wv4ck" force deleted
Waiting for leadership transition...
New leader appears to be: opendatahub-operator-controller-manager-75684694b8-wv4ck
Leadership transition wait completed, continuing...
Applying managementState=Removed
datasciencecluster.datasciencecluster.opendatahub.io/default-dsc configured

>>> run_test_cycle() COMPLETED for cycle 5
=== Completed test cycle #5 ===

All test cycles completed.

```

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Increased the number of operator controller manager replicas from 1 to 3 for improved availability and scalability.
  - Updated release metadata to reflect a newer build date.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->