### PR TITLE
feat: enable rendering cache by default

### DIFF
--- a/internal/controller/components/codeflare/codeflare_controller.go
+++ b/internal/controller/components/codeflare/codeflare_controller.go
@@ -68,7 +68,6 @@ func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.
 		WithAction(devFlags).
 		WithAction(releases.NewAction()).
 		WithAction(kustomize.NewAction(
-			kustomize.WithCache(),
 			kustomize.WithLabel(labels.ODH.Component(LegacyComponentName), labels.True),
 			kustomize.WithLabel(labels.K8SCommon.PartOf, LegacyComponentName),
 		)).

--- a/internal/controller/components/dashboard/dashboard_controller.go
+++ b/internal/controller/components/dashboard/dashboard_controller.go
@@ -92,7 +92,6 @@ func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.
 		WithAction(setKustomizedParams).
 		WithAction(configureDependencies).
 		WithAction(kustomize.NewAction(
-			kustomize.WithCache(),
 			// Those are the default labels added by the legacy deploy method
 			// and should be preserved as the original plugin were affecting
 			// deployment selectors that are immutable once created, so it won't
@@ -106,9 +105,7 @@ func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.
 		)).
 		WithAction(observability.NewAction()).
 		WithAction(customizeResources).
-		WithAction(deploy.NewAction(
-			deploy.WithCache(),
-		)).
+		WithAction(deploy.NewAction()).
 		WithAction(deployments.NewAction()).
 		WithAction(updateStatus).
 		// must be the final action

--- a/internal/controller/components/datasciencepipelines/datasciencepipelines_controller.go
+++ b/internal/controller/components/datasciencepipelines/datasciencepipelines_controller.go
@@ -67,7 +67,6 @@ func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.
 		WithAction(devFlags).
 		WithAction(releases.NewAction()).
 		WithAction(kustomize.NewAction(
-			kustomize.WithCache(),
 			kustomize.WithLabel(labels.ODH.Component(LegacyComponentName), labels.True),
 			kustomize.WithLabel(labels.K8SCommon.PartOf, LegacyComponentName),
 		)).

--- a/internal/controller/components/feastoperator/feastoperator_controller.go
+++ b/internal/controller/components/feastoperator/feastoperator_controller.go
@@ -46,7 +46,6 @@ func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.
 		WithAction(devFlags).
 		WithAction(releases.NewAction()).
 		WithAction(kustomize.NewAction(
-			kustomize.WithCache(),
 			kustomize.WithLabel(labels.ODH.Component(ComponentName), labels.True),
 			kustomize.WithLabel(labels.K8SCommon.PartOf, ComponentName),
 		)).

--- a/internal/controller/components/kserve/kserve_controller.go
+++ b/internal/controller/components/kserve/kserve_controller.go
@@ -129,7 +129,6 @@ func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.
 		WithAction(releases.NewAction()).
 		WithAction(addTemplateFiles).
 		WithAction(template.NewAction(
-			template.WithCache(),
 			template.WithDataFn(getTemplateData),
 		)).
 
@@ -140,7 +139,6 @@ func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.
 		WithAction(removeOwnershipFromUnmanagedResources).
 		WithAction(cleanUpTemplatedResources).
 		WithAction(kustomize.NewAction(
-			kustomize.WithCache(),
 			// These are the default labels added by the legacy deploy method
 			// and should be preserved as the original plugin were affecting
 			// deployment selectors that are immutable once created, so it won't

--- a/internal/controller/components/kserve/kserve_controller_actions_test.go
+++ b/internal/controller/components/kserve/kserve_controller_actions_test.go
@@ -396,7 +396,6 @@ func TestCleanUpTemplatedResources_withAuthorino(t *testing.T) {
 	g.Expect(err).ShouldNot(HaveOccurred())
 
 	err = template.NewAction(
-		template.WithCache(),
 		template.WithDataFn(getTemplateData),
 	)(ctx, &rrHeaded)
 	g.Expect(err).ShouldNot(HaveOccurred())
@@ -458,7 +457,6 @@ func TestCleanUpTemplatedResources_withoutAuthorino(t *testing.T) {
 	g.Expect(err).ShouldNot(HaveOccurred())
 
 	err = template.NewAction(
-		template.WithCache(),
 		template.WithDataFn(getTemplateData),
 	)(ctx, &rrHeaded)
 	g.Expect(err).ShouldNot(HaveOccurred())

--- a/internal/controller/components/kueue/kueue_controller.go
+++ b/internal/controller/components/kueue/kueue_controller.go
@@ -87,7 +87,6 @@ func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.
 		WithAction(devFlags).
 		WithAction(releases.NewAction()).
 		WithAction(kustomize.NewAction(
-			kustomize.WithCache(),
 			kustomize.WithLabel(labels.ODH.Component(LegacyComponentName), labels.True),
 			kustomize.WithLabel(labels.K8SCommon.PartOf, LegacyComponentName),
 		)).

--- a/internal/controller/components/llamastackoperator/llamastackoperator_controller.go
+++ b/internal/controller/components/llamastackoperator/llamastackoperator_controller.go
@@ -45,7 +45,6 @@ func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.
 		WithAction(devFlags).
 		WithAction(releases.NewAction()).
 		WithAction(kustomize.NewAction(
-			kustomize.WithCache(),
 			kustomize.WithLabel(labels.ODH.Component(ComponentName), labels.True),
 			kustomize.WithLabel(labels.K8SCommon.PartOf, ComponentName),
 		)).

--- a/internal/controller/components/modelcontroller/modelcontroller_controller.go
+++ b/internal/controller/components/modelcontroller/modelcontroller_controller.go
@@ -70,7 +70,6 @@ func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.
 		WithAction(initialize).
 		WithAction(devFlags).
 		WithAction(kustomize.NewAction(
-			kustomize.WithCache(),
 			kustomize.WithLabel(labels.ODH.Component(LegacyComponentName), labels.True),
 			kustomize.WithLabel(labels.K8SCommon.PartOf, LegacyComponentName),
 		)).

--- a/internal/controller/components/modelmeshserving/modelmeshserving_controller.go
+++ b/internal/controller/components/modelmeshserving/modelmeshserving_controller.go
@@ -87,7 +87,6 @@ func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.
 		WithAction(devFlags).
 		WithAction(releases.NewAction()).
 		WithAction(kustomize.NewAction(
-			kustomize.WithCache(),
 			kustomize.WithLabel(labels.ODH.Component(LegacyComponentName), labels.True),
 			kustomize.WithLabel(labels.K8SCommon.PartOf, LegacyComponentName),
 		)).

--- a/internal/controller/components/modelregistry/modelregistry_controller.go
+++ b/internal/controller/components/modelregistry/modelregistry_controller.go
@@ -83,11 +83,8 @@ func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.
 		WithAction(customizeManifests).
 		WithAction(releases.NewAction()).
 		WithAction(configureDependencies).
-		WithAction(template.NewAction(
-			template.WithCache(),
-		)).
+		WithAction(template.NewAction()).
 		WithAction(kustomize.NewAction(
-			kustomize.WithCache(),
 			kustomize.WithLabel(labels.ODH.Component(LegacyComponentName), labels.True),
 			kustomize.WithLabel(labels.K8SCommon.PartOf, LegacyComponentName),
 		)).

--- a/internal/controller/components/ray/ray_controller.go
+++ b/internal/controller/components/ray/ray_controller.go
@@ -63,7 +63,6 @@ func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.
 		WithAction(devFlags).
 		WithAction(releases.NewAction()).
 		WithAction(kustomize.NewAction(
-			kustomize.WithCache(),
 			kustomize.WithLabel(labels.ODH.Component(LegacyComponentName), labels.True),
 			kustomize.WithLabel(labels.K8SCommon.PartOf, LegacyComponentName),
 		)).

--- a/internal/controller/components/trainingoperator/trainingoperator_controller.go
+++ b/internal/controller/components/trainingoperator/trainingoperator_controller.go
@@ -60,7 +60,6 @@ func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.
 		WithAction(devFlags).
 		WithAction(releases.NewAction()).
 		WithAction(kustomize.NewAction(
-			kustomize.WithCache(),
 			kustomize.WithLabel(labels.ODH.Component(LegacyComponentName), labels.True),
 			kustomize.WithLabel(labels.K8SCommon.PartOf, LegacyComponentName),
 		)).

--- a/internal/controller/components/trustyai/trustyai_controller.go
+++ b/internal/controller/components/trustyai/trustyai_controller.go
@@ -71,7 +71,6 @@ func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.
 		WithAction(devFlags).
 		WithAction(releases.NewAction()).
 		WithAction(kustomize.NewAction(
-			kustomize.WithCache(),
 			kustomize.WithLabel(labels.ODH.Component(LegacyComponentName), labels.True),
 			kustomize.WithLabel(labels.K8SCommon.PartOf, LegacyComponentName),
 		)).

--- a/internal/controller/components/workbenches/workbenches_controller.go
+++ b/internal/controller/components/workbenches/workbenches_controller.go
@@ -70,7 +70,6 @@ func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.
 				path.Join(odhdeploy.DefaultManifestPath, ComponentName, kfNotebookControllerPath, releases.ComponentMetadataFilename)))).
 		WithAction(configureDependencies).
 		WithAction(kustomize.NewAction(
-			kustomize.WithCache(),
 			kustomize.WithLabel(labels.ODH.Component(LegacyComponentName), labels.True),
 			kustomize.WithLabel(labels.K8SCommon.PartOf, LegacyComponentName),
 		)).

--- a/internal/controller/services/auth/auth_controller.go
+++ b/internal/controller/services/auth/auth_controller.go
@@ -61,9 +61,7 @@ func (h *serviceHandler) NewReconciler(ctx context.Context, mgr ctrl.Manager) er
 		Owns(&rbacv1.RoleBinding{}).
 		// actions
 		WithAction(initialize).
-		WithAction(template.NewAction(
-			template.WithCache(),
-		)).
+		WithAction(template.NewAction()).
 		WithAction(createDefaultGroup).
 		WithAction(managePermissions).
 		WithAction(deploy.NewAction(


### PR DESCRIPTION


<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

The rendering cache has been running for a while now without any issue,
in order make the code simpler, the rendering cache is now enabled by
default.

Caching can be turned off by using:
- kustomize.WithCache(false)
- template.WithCache(false)

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Disabled caching for rendering actions across multiple components to improve consistency.
  - Enhanced control over caching behavior in rendering actions with explicit enable/disable options.
- **Tests**
  - Updated tests to align with new caching behavior, explicitly toggling cache as needed.

No changes to user-facing features or functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->