### PR TITLE
ci: disable temporary the custom catalog gh action

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -1,12 +1,12 @@
 name: Integration tests
-on:
-  pull_request_target:
-    paths:
-      - 'bundle/**'
-      - 'config/**'
-      - 'internal/**'
-      - 'pkg/**'
-      - 'cmd/main.go'
+on: {}
+#  pull_request_target:
+#    paths:
+#      - 'bundle/**'
+#      - 'config/**'
+#      - 'internal/**'
+#      - 'pkg/**'
+#      - 'cmd/main.go'
 
 permissions: {}
 
@@ -47,7 +47,7 @@ jobs:
         if: needs.get-merge-commit.outputs.mergedSha
         with:
           go-version-file: go.mod
-      
+
       - name: Get latest release version
         if: needs.get-merge-commit.outputs.mergedSha
         env:


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
Disable gh action temporarily to allow automated merge

## How Has This Been Tested?
Local

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Disabled automatic integration test workflow runs on pull requests.
	- Cleaned up minor whitespace in the workflow configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->