### PR TITLE
[RHOAIENG-26571] WorkbenchNamespace validation to support configuration during enablement

### DIFF
--- a/api/components/v1alpha1/workbenches_types.go
+++ b/api/components/v1alpha1/workbenches_types.go
@@ -37,9 +37,9 @@ type WorkbenchesCommonSpec struct {
 	common.DevFlagsSpec `json:",inline"`
 	// workbenches spec exposed only to internal api
 
-	// Namespace for workbenches to be installed, defaults to "rhods-notebooks" (not configurable)
+	// Namespace for workbenches to be installed, defaults to "rhods-notebooks" configurable once when component is enabled.
 	// +kubebuilder:default="rhods-notebooks"
-	// +kubebuilder:validation:XValidation:rule="self == '' || self == 'rhods-notebooks'",message="WorkbenchNamespace must be empty or 'rhods-notebooks'"
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="WorkbenchNamespace is immutable"
 	// +kubebuilder:validation:Pattern="^([a-z0-9]([-a-z0-9]*[a-z0-9])?)?$"
 	// +kubebuilder:validation:MaxLength=63
 	WorkbenchNamespace string `json:"workbenchNamespace,omitempty"`

--- a/config/crd/bases/components.platform.opendatahub.io_workbenches.yaml
+++ b/config/crd/bases/components.platform.opendatahub.io_workbenches.yaml
@@ -77,13 +77,13 @@ spec:
               workbenchNamespace:
                 default: rhods-notebooks
                 description: Namespace for workbenches to be installed, defaults to
-                  "rhods-notebooks" (not configurable)
+                  "rhods-notebooks" configurable once when component is enabled.
                 maxLength: 63
                 pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?)?$
                 type: string
                 x-kubernetes-validations:
-                - message: WorkbenchNamespace must be empty or 'rhods-notebooks'
-                  rule: self == '' || self == 'rhods-notebooks'
+                - message: WorkbenchNamespace is immutable
+                  rule: self == oldSelf
             type: object
           status:
             description: WorkbenchesStatus defines the observed state of Workbenches

--- a/config/crd/bases/datasciencecluster.opendatahub.io_datascienceclusters.yaml
+++ b/config/crd/bases/datasciencecluster.opendatahub.io_datascienceclusters.yaml
@@ -764,13 +764,14 @@ spec:
                       workbenchNamespace:
                         default: rhods-notebooks
                         description: Namespace for workbenches to be installed, defaults
-                          to "rhods-notebooks" (not configurable)
+                          to "rhods-notebooks" configurable once when component is
+                          enabled.
                         maxLength: 63
                         pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?)?$
                         type: string
                         x-kubernetes-validations:
-                        - message: WorkbenchNamespace must be empty or 'rhods-notebooks'
-                          rule: self == '' || self == 'rhods-notebooks'
+                        - message: WorkbenchNamespace is immutable
+                          rule: self == oldSelf
                     type: object
                 type: object
             type: object

--- a/docs/api-overview.md
+++ b/docs/api-overview.md
@@ -570,7 +570,7 @@ _Appears in:_
 | --- | --- | --- | --- |
 | `managementState` _[ManagementState](#managementstate)_ | Set to one of the following values:<br /><br />- "Managed" : the operator is actively managing the component and trying to keep it active.<br />              It will only upgrade the component if it is safe to do so<br /><br />- "Removed" : the operator is actively managing the component and will not install it,<br />              or if it is installed, the operator will try to remove it |  | Enum: [Managed Removed] <br /> |
 | `devFlags` _[DevFlags](#devflags)_ | Add developer fields |  |  |
-| `workbenchNamespace` _string_ | Namespace for workbenches to be installed, defaults to "rhods-notebooks" (not configurable) | rhods-notebooks | MaxLength: 63 <br />Pattern: `^([a-z0-9]([-a-z0-9]*[a-z0-9])?)?$` <br /> |
+| `workbenchNamespace` _string_ | Namespace for workbenches to be installed, defaults to "rhods-notebooks" configurable once when component is enabled. | rhods-notebooks | MaxLength: 63 <br />Pattern: `^([a-z0-9]([-a-z0-9]*[a-z0-9])?)?$` <br /> |
 
 
 #### DSCWorkbenchesStatus
@@ -2051,7 +2051,7 @@ _Appears in:_
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
 | `devFlags` _[DevFlags](#devflags)_ | Add developer fields |  |  |
-| `workbenchNamespace` _string_ | Namespace for workbenches to be installed, defaults to "rhods-notebooks" (not configurable) | rhods-notebooks | MaxLength: 63 <br />Pattern: `^([a-z0-9]([-a-z0-9]*[a-z0-9])?)?$` <br /> |
+| `workbenchNamespace` _string_ | Namespace for workbenches to be installed, defaults to "rhods-notebooks" configurable once when component is enabled. | rhods-notebooks | MaxLength: 63 <br />Pattern: `^([a-z0-9]([-a-z0-9]*[a-z0-9])?)?$` <br /> |
 
 
 #### WorkbenchesCommonStatus
@@ -2106,7 +2106,7 @@ _Appears in:_
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
 | `devFlags` _[DevFlags](#devflags)_ | Add developer fields |  |  |
-| `workbenchNamespace` _string_ | Namespace for workbenches to be installed, defaults to "rhods-notebooks" (not configurable) | rhods-notebooks | MaxLength: 63 <br />Pattern: `^([a-z0-9]([-a-z0-9]*[a-z0-9])?)?$` <br /> |
+| `workbenchNamespace` _string_ | Namespace for workbenches to be installed, defaults to "rhods-notebooks" configurable once when component is enabled. | rhods-notebooks | MaxLength: 63 <br />Pattern: `^([a-z0-9]([-a-z0-9]*[a-z0-9])?)?$` <br /> |
 
 
 #### WorkbenchesStatus

--- a/internal/controller/components/workbenches/workbenches.go
+++ b/internal/controller/components/workbenches/workbenches.go
@@ -95,18 +95,6 @@ func (s *componentHandler) UpdateDSCStatus(ctx context.Context, rr *types.Reconc
 
 	rr.Conditions.MarkFalse(ReadyConditionType)
 
-	// TODO: remove this once we have proper solution for config workbenchNamespace
-	workbenchNamespace := dsc.Spec.Components.Workbenches.WorkbenchNamespace
-	if workbenchNamespace != "" && workbenchNamespace != "rhods-notebooks" {
-		rr.Conditions.MarkFalse(
-			ReadyConditionType,
-			conditions.WithReason(status.ErrorReason),
-			conditions.WithMessage(status.WorkbenchNamespaceErrorMessage),
-			conditions.WithSeverity(common.ConditionSeverityError),
-		)
-		return metav1.ConditionFalse, nil
-	}
-
 	switch s.GetManagementState(dsc) {
 	case operatorv1.Managed:
 		dsc.Status.InstalledComponents[LegacyComponentName] = true

--- a/internal/controller/status/status.go
+++ b/internal/controller/status/status.go
@@ -142,7 +142,6 @@ const (
 	ServerlessOperatorNotInstalledMessage = "Serverless operator must be installed for this component's configuration"
 
 	ServerlessUnsupportedCertMessage = "Serverless certificate type is not supported"
-	WorkbenchNamespaceErrorMessage   = "DSC must have workbenchNamespace set to empty '' or 'rhods-notebooks'"
 )
 
 const (


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->
Updated WorkbenchesCommonSpec to include validations that allow WorkbenchNamespace to be user configurable when the component is enabled.

<!--- Link your JIRA and related links here for reference. -->
RHOAIENG-26571

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
On a 4.18.14 cluster, I successfully created DSCI and DSC objects where the application namespace has been set to `odh`, and the WorkbenchNamespace field of the DSC has been set to `custom-notebook-ns`. Two components were enabled, Dashboard and Workbenches.
The DSC correctly reported the workbench namespace via status as `custom-notebook-ns` and is reporting the component status True for type `WorkbenchesReady`. The Dashboard and Workbenches components both show up with a true status in the `Installed Components` section.

The Dashboard was launched, and was able to use the Jupyter Tile to launch a Python 3.11 Workbench and verified it was working as expected by printing "Hello, World" within the notebook. Verified the jupyter pod shows up in the namespace `custom-notebook-ns`.

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

```
oc get dsci
NAME           AGE   PHASE   CREATED AT
default-dsci   15m   Ready   2025-06-26T20:12:07Z

oc get dsc
NAME          READY   REASON
default-dsc   True

oc get pods -n odh
NAME                                              READY   STATUS    RESTARTS   AGE
notebook-controller-deployment-6c6fb44998-sfd9g   1/1     Running   0          4m24s
odh-dashboard-65d544d644-m7wwb                    2/2     Running   0          4m24s
odh-dashboard-65d544d644-mfln6                    2/2     Running   0          4m24s
odh-notebook-controller-manager-5bf547c4c-rnczn   1/1     Running   0          4m24s
rhods-operator-5cf776fb8b-65n8r                   1/1     Running   0          17m
rhods-operator-5cf776fb8b-nqcxw                   1/1     Running   0          17m
rhods-operator-5cf776fb8b-vsrd5                   1/1     Running   0          17m

oc get pods -n custom-notebook-ns
NAME                        READY   STATUS    RESTARTS   AGE
jupyter-nb-kube-3aadmin-0   2/2     Running   0          107s
```

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
