### PR TITLE
Cherry-pick: Auth validating webhook, PodAntiAffinity, and NodeAffinity support

### DIFF
--- a/bundle/manifests/opendatahub-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/opendatahub-operator.clusterserviceversion.yaml
@@ -1329,6 +1329,26 @@ spec:
                 control-plane: controller-manager
                 name: opendatahub-operator
             spec:
+              affinity:
+                nodeAffinity:
+                  requiredDuringSchedulingIgnoredDuringExecution:
+                    nodeSelectorTerms:
+                    - matchExpressions:
+                      - key: kubernetes.io/os
+                        operator: In
+                        values:
+                        - linux
+                podAntiAffinity:
+                  preferredDuringSchedulingIgnoredDuringExecution:
+                  - podAffinityTerm:
+                      labelSelector:
+                        matchExpressions:
+                        - key: name
+                          operator: In
+                          values:
+                          - opendatahub-operator
+                      topologyKey: kubernetes.io/hostname
+                    weight: 100
               containers:
               - args:
                 - --health-probe-bind-address=:8081

--- a/bundle/manifests/opendatahub-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/opendatahub-operator.clusterserviceversion.yaml
@@ -1462,6 +1462,26 @@ spec:
     containerPort: 443
     deploymentName: opendatahub-operator-controller-manager
     failurePolicy: Fail
+    generateName: auth-validator.opendatahub.io
+    rules:
+    - apiGroups:
+      - services.platform.opendatahub.io
+      apiVersions:
+      - v1alpha1
+      operations:
+      - CREATE
+      - UPDATE
+      resources:
+      - auths
+    sideEffects: None
+    targetPort: 9443
+    type: ValidatingAdmissionWebhook
+    webhookPath: /validate-auth
+  - admissionReviewVersions:
+    - v1
+    containerPort: 443
+    deploymentName: opendatahub-operator-controller-manager
+    failurePolicy: Fail
     generateName: datasciencecluster-defaulter.opendatahub.io
     rules:
     - apiGroups:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -27,6 +27,26 @@ spec:
         name: opendatahub-operator
         control-plane: controller-manager
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: name
+                  operator: In
+                  values:
+                  - opendatahub-operator
+              topologyKey: kubernetes.io/hostname
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: kubernetes.io/os
+                operator: In
+                values:
+                - linux
       securityContext:
         runAsNonRoot: true
         # TODO(user): For common cases that do not require escalating privileges

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -36,6 +36,26 @@ webhooks:
     service:
       name: webhook-service
       namespace: system
+      path: /validate-auth
+  failurePolicy: Fail
+  name: auth-validator.opendatahub.io
+  rules:
+  - apiGroups:
+    - services.platform.opendatahub.io
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - auths
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
       path: /validate-datasciencecluster
   failurePolicy: Fail
   name: datasciencecluster-validator.opendatahub.io

--- a/internal/webhook/auth/integration_test.go
+++ b/internal/webhook/auth/integration_test.go
@@ -1,0 +1,170 @@
+package auth_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/rs/xid"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	serviceApi "github.com/opendatahub-io/opendatahub-operator/v2/api/services/v1alpha1"
+	"github.com/opendatahub-io/opendatahub-operator/v2/internal/webhook/auth"
+	"github.com/opendatahub-io/opendatahub-operator/v2/internal/webhook/envtestutil"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/envt"
+
+	. "github.com/onsi/gomega"
+)
+
+// TestAuthWebhook_Integration exercises the validating webhook logic for Auth resources.
+// It uses table-driven tests to verify group validation in a real envtest environment.
+func TestAuthWebhook_Integration(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name  string
+		setup func(ns string) []client.Object
+		test  func(g Gomega, ctx context.Context, k8sClient client.Client, ns string)
+	}{
+		{
+			name: "Valid groups: allows creation and update",
+			setup: func(ns string) []client.Object {
+				return nil
+			},
+			test: func(g Gomega, ctx context.Context, k8sClient client.Client, ns string) {
+				// Test creation with valid groups
+				validAuth := envtestutil.NewAuth("auth", ns, []string{"admin-group"}, []string{"allowed-group"})
+				g.Expect(k8sClient.Create(ctx, validAuth)).To(Succeed(), "should allow creation with valid groups")
+
+				// Test update with valid groups
+				validAuth.Spec.AdminGroups = []string{"updated-admin-group"}
+				validAuth.Spec.AllowedGroups = []string{"updated-allowed-group"}
+				g.Expect(k8sClient.Update(ctx, validAuth)).To(Succeed(), "should allow update with valid groups")
+			},
+		},
+		{
+			name: "Invalid AdminGroups: denies creation with system:authenticated",
+			setup: func(ns string) []client.Object {
+				return nil
+			},
+			test: func(g Gomega, ctx context.Context, k8sClient client.Client, ns string) {
+				invalidAuth := envtestutil.NewAuth("auth", ns, []string{"admin-group", "system:authenticated"}, []string{"allowed-group"})
+				err := k8sClient.Create(ctx, invalidAuth)
+				g.Expect(err).NotTo(Succeed(), "should deny creation with system:authenticated in AdminGroups")
+				g.Expect(err.Error()).To(ContainSubstring("Invalid groups found in AdminGroups"), "error should mention AdminGroups")
+				g.Expect(err.Error()).To(ContainSubstring("system:authenticated"), "error should mention system:authenticated")
+			},
+		},
+		{
+			name: "Invalid AdminGroups: denies creation with empty string",
+			setup: func(ns string) []client.Object {
+				return nil
+			},
+			test: func(g Gomega, ctx context.Context, k8sClient client.Client, ns string) {
+				invalidAuth := envtestutil.NewAuth("auth", ns, []string{"admin-group", ""}, []string{"allowed-group"})
+				err := k8sClient.Create(ctx, invalidAuth)
+				g.Expect(err).NotTo(Succeed(), "should deny creation with empty string in AdminGroups")
+				g.Expect(err.Error()).To(ContainSubstring("Invalid groups found in AdminGroups"), "error should mention AdminGroups")
+			},
+		},
+		{
+			name: "Valid AllowedGroups: allows creation with system:authenticated",
+			setup: func(ns string) []client.Object {
+				return nil
+			},
+			test: func(g Gomega, ctx context.Context, k8sClient client.Client, ns string) {
+				validAuth := envtestutil.NewAuth("auth", ns, []string{"admin-group"}, []string{"allowed-group", "system:authenticated"})
+				g.Expect(k8sClient.Create(ctx, validAuth)).To(Succeed(), "should allow creation with system:authenticated in AllowedGroups")
+			},
+		},
+		{
+			name: "Invalid AllowedGroups: denies creation with empty string",
+			setup: func(ns string) []client.Object {
+				return nil
+			},
+			test: func(g Gomega, ctx context.Context, k8sClient client.Client, ns string) {
+				invalidAuth := envtestutil.NewAuth("auth", ns, []string{"admin-group"}, []string{"allowed-group", ""})
+				err := k8sClient.Create(ctx, invalidAuth)
+				g.Expect(err).NotTo(Succeed(), "should deny creation with empty string in AllowedGroups")
+				g.Expect(err.Error()).To(ContainSubstring("Invalid groups found in AllowedGroups"), "error should mention AllowedGroups")
+			},
+		},
+		{
+			name: "Multiple invalid groups: denies creation with comprehensive error",
+			setup: func(ns string) []client.Object {
+				return nil
+			},
+			test: func(g Gomega, ctx context.Context, k8sClient client.Client, ns string) {
+				invalidAuth := envtestutil.NewAuth("auth", ns, []string{"admin-group", "system:authenticated", ""}, []string{"allowed-group"})
+				err := k8sClient.Create(ctx, invalidAuth)
+				g.Expect(err).NotTo(Succeed(), "should deny creation with multiple invalid groups")
+				g.Expect(err.Error()).To(ContainSubstring("Invalid groups found in AdminGroups"), "error should mention AdminGroups")
+				g.Expect(err.Error()).To(ContainSubstring("system:authenticated"), "error should mention system:authenticated")
+			},
+		},
+		{
+			name: "Update validation: denies update to invalid groups",
+			setup: func(ns string) []client.Object {
+				// Create a valid Auth resource first
+				return []client.Object{
+					envtestutil.NewAuth("auth", ns, []string{"admin-group"}, []string{"allowed-group"}),
+				}
+			},
+			test: func(g Gomega, ctx context.Context, k8sClient client.Client, ns string) {
+				// Get the existing Auth resource
+				auth := &serviceApi.Auth{}
+				key := types.NamespacedName{Name: "auth", Namespace: ns}
+				g.Expect(k8sClient.Get(ctx, key, auth)).To(Succeed(), "should get Auth for update test")
+
+				// Try to update with invalid groups (empty string)
+				auth.Spec.AllowedGroups = []string{"allowed-group", ""}
+				err := k8sClient.Update(ctx, auth)
+				g.Expect(err).NotTo(Succeed(), "should deny update with invalid groups")
+				g.Expect(err.Error()).To(ContainSubstring("Invalid groups found in AllowedGroups"), "error should mention AllowedGroups")
+			},
+		},
+		{
+			name: "Deletion: allows deletion regardless of group values",
+			setup: func(ns string) []client.Object {
+				// Create an Auth resource (even with technically invalid groups for deletion test)
+				return []client.Object{
+					envtestutil.NewAuth("auth", ns, []string{"admin-group"}, []string{"allowed-group"}),
+				}
+			},
+			test: func(g Gomega, ctx context.Context, k8sClient client.Client, ns string) {
+				auth := &serviceApi.Auth{}
+				key := types.NamespacedName{Name: "auth", Namespace: ns}
+				g.Expect(k8sClient.Get(ctx, key, auth)).To(Succeed(), "should get Auth for deletion test")
+				g.Expect(k8sClient.Delete(ctx, auth)).To(Succeed(), "should allow deletion regardless of group values")
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			t.Logf("Starting test case: %s", tc.name)
+			ctx, env, teardown := envtestutil.SetupEnvAndClient(
+				t,
+				[]envt.RegisterWebhooksFn{
+					auth.RegisterWebhooks,
+				},
+				envtestutil.DefaultWebhookTimeout,
+			)
+			t.Cleanup(teardown)
+
+			ns := xid.New().String()
+			t.Logf("Using namespace: %s", ns)
+			if tc.setup != nil {
+				for _, obj := range tc.setup(ns) {
+					t.Logf("Creating setup object: %+v", obj)
+					g := NewWithT(t)
+					g.Expect(env.Client().Create(ctx, obj)).To(Succeed(), "setup object creation should succeed")
+				}
+			}
+			g := NewWithT(t)
+			tc.test(g, ctx, env.Client(), ns)
+			t.Logf("Finished test case: %s", tc.name)
+		})
+	}
+}

--- a/internal/webhook/auth/register.go
+++ b/internal/webhook/auth/register.go
@@ -1,0 +1,22 @@
+//go:build !nowebhook
+
+package auth
+
+import (
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+// RegisterWebhooks registers all Auth-related webhooks with the given manager.
+// Returns the first error encountered during registration, or nil if all succeed.
+func RegisterWebhooks(mgr ctrl.Manager) error {
+	if err := (&Validator{
+		Client:  mgr.GetClient(),
+		Decoder: admission.NewDecoder(mgr.GetScheme()),
+		Name:    "auth-validator",
+	}).SetupWithManager(mgr); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/internal/webhook/auth/validating.go
+++ b/internal/webhook/auth/validating.go
@@ -1,0 +1,172 @@
+//go:build !nowebhook
+
+package auth
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+
+	admissionv1 "k8s.io/api/admission/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	serviceApi "github.com/opendatahub-io/opendatahub-operator/v2/api/services/v1alpha1"
+	"github.com/opendatahub-io/opendatahub-operator/v2/internal/webhook/shared"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
+)
+
+//+kubebuilder:webhook:path=/validate-auth,mutating=false,failurePolicy=fail,sideEffects=None,groups=services.platform.opendatahub.io,resources=auths,verbs=create;update,versions=v1alpha1,name=auth-validator.opendatahub.io,admissionReviewVersions=v1
+//nolint:lll
+
+// Constants for invalid group values that should be rejected.
+const (
+	SystemAuthenticatedGroup = "system:authenticated"
+	EmptyGroup               = ""
+)
+
+// Validator implements webhook.AdmissionHandler for Auth validation webhooks.
+// It validates that AdminGroups and AllowedGroups don't contain invalid values.
+type Validator struct {
+	Client  client.Reader
+	Decoder admission.Decoder
+	Name    string
+}
+
+// Assert that Validator implements admission.Handler interface.
+var _ admission.Handler = &Validator{}
+
+// InjectDecoder implements admission.DecoderInjector so the manager can inject the decoder automatically.
+//
+// Parameters:
+//   - d: The admission.Decoder to inject.
+//
+// Returns:
+//   - error: Always nil.
+func (v *Validator) InjectDecoder(d admission.Decoder) error {
+	v.Decoder = d
+	return nil
+}
+
+// SetupWithManager registers the validating webhook with the provided controller-runtime manager.
+//
+// Parameters:
+//   - mgr: The controller-runtime manager to register the webhook with.
+//
+// Returns:
+//   - error: Always nil (for future extensibility).
+func (v *Validator) SetupWithManager(mgr ctrl.Manager) error {
+	hookServer := mgr.GetWebhookServer()
+	hookServer.Register("/validate-auth", &webhook.Admission{
+		Handler:        v,
+		LogConstructor: shared.NewLogConstructor(v.Name),
+	})
+	return nil
+}
+
+// Handle processes admission requests for create and update operations on Auth resources.
+// It validates that AdminGroups and AllowedGroups don't contain invalid values.
+//
+// Parameters:
+//   - ctx: Context for the admission request (logger is extracted from here).
+//   - req: The admission.Request containing the operation and object details.
+//
+// Returns:
+//   - admission.Response: The result of the admission check, indicating whether the operation is allowed or denied.
+func (v *Validator) Handle(ctx context.Context, req admission.Request) admission.Response {
+	log := logf.FromContext(ctx)
+
+	// Check if decoder is properly injected
+	if v.Decoder == nil {
+		log.Error(nil, "Decoder is nil - webhook not properly initialized")
+		return admission.Errored(http.StatusInternalServerError, errors.New("webhook decoder not initialized"))
+	}
+
+	// Validate that we're processing the correct Kind
+	if req.Kind.Kind != gvk.Auth.Kind {
+		err := fmt.Errorf("unexpected kind: %s", req.Kind.Kind)
+		log.Error(err, "got wrong kind")
+		return admission.Errored(http.StatusBadRequest, err)
+	}
+
+	var resp admission.Response
+
+	switch req.Operation {
+	case admissionv1.Create, admissionv1.Update:
+		resp = v.validateAuthGroups(ctx, req)
+	default:
+		resp.Allowed = true
+	}
+
+	if !resp.Allowed {
+		return resp
+	}
+
+	return admission.Allowed(fmt.Sprintf("Operation %s on %s allowed", req.Operation, req.Kind.Kind))
+}
+
+// validateAuthGroups validates that AdminGroups and AllowedGroups don't contain invalid values.
+func (v *Validator) validateAuthGroups(ctx context.Context, req admission.Request) admission.Response {
+	log := logf.FromContext(ctx)
+
+	// Decode the Auth object
+	auth := &serviceApi.Auth{}
+	if err := v.Decoder.Decode(req, auth); err != nil {
+		log.Error(err, "failed to decode Auth object")
+		return admission.Errored(http.StatusBadRequest, err)
+	}
+
+	// Validate both AdminGroups and AllowedGroups
+	if invalidAdminGroups := validateAdminGroups(auth.Spec.AdminGroups); len(invalidAdminGroups) > 0 {
+		msg := fmt.Sprintf("Invalid groups found in AdminGroups: %s. Groups cannot be '%s' or empty string",
+			strings.Join(invalidAdminGroups, ", "), SystemAuthenticatedGroup)
+		log.Info("Rejecting Auth resource due to invalid AdminGroups", "invalidGroups", invalidAdminGroups)
+		return admission.Denied(msg)
+	}
+
+	if invalidAllowedGroups := validateAllowedGroups(auth.Spec.AllowedGroups); len(invalidAllowedGroups) > 0 {
+		msg := fmt.Sprintf("Invalid groups found in AllowedGroups: %s. Groups cannot be empty string",
+			strings.Join(invalidAllowedGroups, ", "))
+		log.Info("Rejecting Auth resource due to invalid AllowedGroups", "invalidGroups", invalidAllowedGroups)
+		return admission.Denied(msg)
+	}
+
+	return admission.Allowed("")
+}
+
+// validateAdminGroups checks AdminGroups for invalid values.
+// AdminGroups cannot contain 'system:authenticated' (security risk) or empty strings.
+func validateAdminGroups(groups []string) []string {
+	if len(groups) == 0 {
+		return nil
+	}
+
+	var invalidGroups []string
+	for _, group := range groups {
+		if group == SystemAuthenticatedGroup || group == EmptyGroup {
+			invalidGroups = append(invalidGroups, fmt.Sprintf("'%s'", group))
+		}
+	}
+	return invalidGroups
+}
+
+// validateAllowedGroups checks AllowedGroups for invalid values.
+// AllowedGroups cannot contain empty strings, but 'system:authenticated' is allowed for general access.
+func validateAllowedGroups(groups []string) []string {
+	if len(groups) == 0 {
+		return nil
+	}
+
+	var invalidGroups []string
+	for _, group := range groups {
+		if group == EmptyGroup {
+			invalidGroups = append(invalidGroups, fmt.Sprintf("'%s'", group))
+		}
+	}
+	return invalidGroups
+}

--- a/internal/webhook/auth/validating_test.go
+++ b/internal/webhook/auth/validating_test.go
@@ -1,0 +1,211 @@
+package auth_test
+
+import (
+	"context"
+	"testing"
+
+	admissionv1 "k8s.io/api/admission/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	"github.com/opendatahub-io/opendatahub-operator/v2/internal/webhook/auth"
+	"github.com/opendatahub-io/opendatahub-operator/v2/internal/webhook/envtestutil"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/scheme"
+
+	. "github.com/onsi/gomega"
+)
+
+// TestAuth_ValidatingWebhook exercises the validating webhook logic for Auth resources.
+// It verifies that invalid groups in AdminGroups and AllowedGroups are properly rejected
+// using table-driven tests and a fake client.
+func TestAuth_ValidatingWebhook(t *testing.T) {
+	t.Parallel()
+	g := NewWithT(t)
+	ctx := context.Background()
+	sch, err := scheme.New()
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	ns := "test-ns"
+
+	cases := []struct {
+		name         string
+		existingObjs []client.Object
+		req          admission.Request
+		allowed      bool
+		errorMessage string
+	}{
+		{
+			name:         "Allows creation with valid groups",
+			existingObjs: nil,
+			req: envtestutil.NewAdmissionRequest(
+				t,
+				admissionv1.Create,
+				envtestutil.NewAuth("test-valid", ns, []string{"valid-admin-group"}, []string{"valid-allowed-group"}),
+				gvk.Auth,
+				metav1.GroupVersionResource{
+					Group:    gvk.Auth.Group,
+					Version:  gvk.Auth.Version,
+					Resource: "auths",
+				},
+			),
+			allowed: true,
+		},
+		{
+			name:         "Allows update with valid groups",
+			existingObjs: nil,
+			req: envtestutil.NewAdmissionRequest(
+				t,
+				admissionv1.Update,
+				envtestutil.NewAuth("test-valid", ns, []string{"updated-admin-group"}, []string{"updated-allowed-group"}),
+				gvk.Auth,
+				metav1.GroupVersionResource{
+					Group:    gvk.Auth.Group,
+					Version:  gvk.Auth.Version,
+					Resource: "auths",
+				},
+			),
+			allowed: true,
+		},
+		{
+			name:         "Allows delete operation (no validation)",
+			existingObjs: nil,
+			req: envtestutil.NewAdmissionRequest(
+				t,
+				admissionv1.Delete,
+				envtestutil.NewAuth("test-delete", ns, []string{"any-admin-group"}, []string{"any-allowed-group"}),
+				gvk.Auth,
+				metav1.GroupVersionResource{
+					Group:    gvk.Auth.Group,
+					Version:  gvk.Auth.Version,
+					Resource: "auths",
+				},
+			),
+			allowed: true,
+		},
+		{
+			name:         "Denies creation with system:authenticated in AdminGroups",
+			existingObjs: nil,
+			req: envtestutil.NewAdmissionRequest(
+				t,
+				admissionv1.Create,
+				envtestutil.NewAuth("test-invalid-admin", ns, []string{"valid-admin-group", "system:authenticated"}, []string{"valid-allowed-group"}),
+				gvk.Auth,
+				metav1.GroupVersionResource{
+					Group:    gvk.Auth.Group,
+					Version:  gvk.Auth.Version,
+					Resource: "auths",
+				},
+			),
+			allowed:      false,
+			errorMessage: "Invalid groups found in AdminGroups: 'system:authenticated'. Groups cannot be 'system:authenticated' or empty string",
+		},
+		{
+			name:         "Denies creation with empty string in AdminGroups",
+			existingObjs: nil,
+			req: envtestutil.NewAdmissionRequest(
+				t,
+				admissionv1.Create,
+				envtestutil.NewAuth("test-invalid-admin-empty", ns, []string{"valid-admin-group", ""}, []string{"valid-allowed-group"}),
+				gvk.Auth,
+				metav1.GroupVersionResource{
+					Group:    gvk.Auth.Group,
+					Version:  gvk.Auth.Version,
+					Resource: "auths",
+				},
+			),
+			allowed:      false,
+			errorMessage: "Invalid groups found in AdminGroups: ''. Groups cannot be 'system:authenticated' or empty string",
+		},
+		{
+			name:         "Allows creation with system:authenticated in AllowedGroups",
+			existingObjs: nil,
+			req: envtestutil.NewAdmissionRequest(
+				t,
+				admissionv1.Create,
+				envtestutil.NewAuth("test-valid-allowed", ns, []string{"valid-admin-group"}, []string{"valid-allowed-group", "system:authenticated"}),
+				gvk.Auth,
+				metav1.GroupVersionResource{
+					Group:    gvk.Auth.Group,
+					Version:  gvk.Auth.Version,
+					Resource: "auths",
+				},
+			),
+			allowed: true,
+		},
+		{
+			name:         "Denies creation with empty string in AllowedGroups",
+			existingObjs: nil,
+			req: envtestutil.NewAdmissionRequest(
+				t,
+				admissionv1.Create,
+				envtestutil.NewAuth("test-invalid-allowed-empty", ns, []string{"valid-admin-group"}, []string{"valid-allowed-group", ""}),
+				gvk.Auth,
+				metav1.GroupVersionResource{
+					Group:    gvk.Auth.Group,
+					Version:  gvk.Auth.Version,
+					Resource: "auths",
+				},
+			),
+			allowed:      false,
+			errorMessage: "Invalid groups found in AllowedGroups: ''. Groups cannot be empty string",
+		},
+		{
+			name:         "Denies creation with multiple invalid groups in AdminGroups",
+			existingObjs: nil,
+			req: envtestutil.NewAdmissionRequest(
+				t,
+				admissionv1.Create,
+				envtestutil.NewAuth("test-multiple-invalid-admin", ns, []string{"valid-admin-group", "system:authenticated", ""}, []string{"valid-allowed-group"}),
+				gvk.Auth,
+				metav1.GroupVersionResource{
+					Group:    gvk.Auth.Group,
+					Version:  gvk.Auth.Version,
+					Resource: "auths",
+				},
+			),
+			allowed:      false,
+			errorMessage: "Invalid groups found in AdminGroups: 'system:authenticated', ''. Groups cannot be 'system:authenticated' or empty string",
+		},
+		{
+			name:         "Denies update with invalid groups",
+			existingObjs: nil,
+			req: envtestutil.NewAdmissionRequest(
+				t,
+				admissionv1.Update,
+				envtestutil.NewAuth("test-invalid-update", ns, []string{"valid-admin-group"}, []string{"valid-allowed-group", ""}),
+				gvk.Auth,
+				metav1.GroupVersionResource{
+					Group:    gvk.Auth.Group,
+					Version:  gvk.Auth.Version,
+					Resource: "auths",
+				},
+			),
+			allowed:      false,
+			errorMessage: "Invalid groups found in AllowedGroups: ''. Groups cannot be empty string",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			cli := fake.NewClientBuilder().WithScheme(sch).WithObjects(tc.existingObjs...).Build()
+			decoder := admission.NewDecoder(sch)
+			validator := &auth.Validator{
+				Client:  cli,
+				Name:    "test",
+				Decoder: decoder,
+			}
+			resp := validator.Handle(ctx, tc.req)
+			g.Expect(resp.Allowed).To(Equal(tc.allowed))
+			if !tc.allowed {
+				g.Expect(resp.Result.Message).ToNot(BeEmpty(), "Expected error message when request is denied")
+				if tc.errorMessage != "" {
+					g.Expect(resp.Result.Message).To(ContainSubstring(tc.errorMessage), "Expected specific error message")
+				}
+			}
+		})
+	}
+}

--- a/internal/webhook/envtestutil/envtestutil.go
+++ b/internal/webhook/envtestutil/envtestutil.go
@@ -17,6 +17,7 @@ import (
 	dscv1 "github.com/opendatahub-io/opendatahub-operator/v2/api/datasciencecluster/v1"
 	dsciv1 "github.com/opendatahub-io/opendatahub-operator/v2/api/dscinitialization/v1"
 	hwpv1alpha1 "github.com/opendatahub-io/opendatahub-operator/v2/api/infrastructure/v1alpha1"
+	serviceApi "github.com/opendatahub-io/opendatahub-operator/v2/api/services/v1alpha1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/envt"
 )
@@ -133,6 +134,38 @@ func NewDSC(name, namespace string, opts ...func(*dscv1.DataScienceCluster)) *ds
 		opt(dsc)
 	}
 	return dsc
+}
+
+// NewAuth creates an Auth object with the given name, namespace, and groups for use in tests.
+//
+// Parameters:
+//   - name: The name of the Auth object.
+//   - namespace: The namespace for the object.
+//   - adminGroups: The admin groups for the Auth resource.
+//   - allowedGroups: The allowed groups for the Auth resource.
+//   - opts: Optional functional options to mutate the object.
+//
+// Returns:
+//   - *serviceApi.Auth: The constructed Auth object.
+func NewAuth(name, namespace string, adminGroups, allowedGroups []string, opts ...func(*serviceApi.Auth)) *serviceApi.Auth {
+	auth := &serviceApi.Auth{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       gvk.Auth.Kind,
+			APIVersion: serviceApi.GroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: serviceApi.AuthSpec{
+			AdminGroups:   adminGroups,
+			AllowedGroups: allowedGroups,
+		},
+	}
+	for _, opt := range opts {
+		opt(auth)
+	}
+	return auth
 }
 
 // NewHWP creates a HardwareProfile object with the given name and namespace for use in tests.

--- a/internal/webhook/webhook.go
+++ b/internal/webhook/webhook.go
@@ -5,6 +5,7 @@ package webhook
 import (
 	ctrl "sigs.k8s.io/controller-runtime"
 
+	authwebhook "github.com/opendatahub-io/opendatahub-operator/v2/internal/webhook/auth"
 	dscwebhook "github.com/opendatahub-io/opendatahub-operator/v2/internal/webhook/datasciencecluster"
 	dsciwebhook "github.com/opendatahub-io/opendatahub-operator/v2/internal/webhook/dscinitialization"
 	kueuewebhook "github.com/opendatahub-io/opendatahub-operator/v2/internal/webhook/kueue"
@@ -16,6 +17,7 @@ func RegisterAllWebhooks(mgr ctrl.Manager) error {
 	webhookRegistrations := []func(ctrl.Manager) error{
 		dscwebhook.RegisterWebhooks,
 		dsciwebhook.RegisterWebhooks,
+		authwebhook.RegisterWebhooks,
 		kueuewebhook.RegisterWebhooks,
 	}
 	for _, reg := range webhookRegistrations {

--- a/pkg/utils/test/scheme/scheme.go
+++ b/pkg/utils/test/scheme/scheme.go
@@ -35,7 +35,6 @@ var (
 		oauthv1.AddToScheme,
 		ofapiv2.AddToScheme,
 		coordinationv1.AddToScheme,
-		apiextensionsv1.AddToScheme,
 		serviceApi.AddToScheme,
 		admissionv1.AddToScheme,
 	}

--- a/tests/e2e/authcontroller_test.go
+++ b/tests/e2e/authcontroller_test.go
@@ -8,6 +8,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	serviceApi "github.com/opendatahub-io/opendatahub-operator/v2/api/services/v1alpha1"
+	"github.com/opendatahub-io/opendatahub-operator/v2/internal/webhook/envtestutil"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/resources"
@@ -52,7 +53,7 @@ func authControllerTestSuite(t *testing.T) {
 		TestContext: tc,
 		AuthNamespacedName: types.NamespacedName{
 			Name:      serviceApi.AuthInstanceName,
-			Namespace: tc.AppsNamespace,
+			Namespace: "", // Auth is cluster-scoped, no namespace needed
 		},
 	}
 
@@ -66,6 +67,23 @@ func authControllerTestSuite(t *testing.T) {
 		{"Validate addition of ClusterRole when group is added", authCtx.ValidateAuthCRClusterRoleCreation},
 		{"Validate addition of ClusterRoleBinding when group is added", authCtx.ValidateAuthCRClusterRoleBindingCreation},
 		{"Validate removal of bindings when a group is removed", authCtx.ValidateRemovingGroups},
+	}
+
+	// Append webhook-specific tests if webhook testing is enabled.
+	if testOpts.webhookTest {
+		webhookTests := []TestCase{
+			{"Validate webhook blocks Auth creation with invalid groups", authCtx.ValidateWebhookBlocksInvalidGroupsOnCreation},
+			{"Validate webhook blocks Auth update with invalid groups", authCtx.ValidateWebhookBlocksInvalidGroupsOnUpdate},
+			{"Validate webhook allows Auth with valid groups", authCtx.ValidateWebhookAllowsValidGroups},
+		}
+
+		testCases = append(testCases, TestCase{
+			name: "Webhook Validation",
+			testFn: func(t *testing.T) {
+				t.Helper()
+				RunTestCases(t, webhookTests)
+			},
+		})
 	}
 
 	// Run the test suite.
@@ -91,7 +109,6 @@ func (tc *AuthControllerTestCtx) ValidateAuthCRCreation(t *testing.T) {
 func (tc *AuthControllerTestCtx) ValidateAuthCRDefaultContent(t *testing.T) {
 	t.Helper()
 
-	// Get the expected values.
 	var expectedAdminGroup string
 	expectedAllowedGroup := "system:authenticated"
 
@@ -238,4 +255,150 @@ func (tc *AuthControllerTestCtx) ValidateRemovingGroups(t *testing.T) {
 		"Expected RoleBinding '%s' to have exactly one subject with name '%s'", adminGroupRoleBindingName, expectedGroup)
 	validateBinding(gvk.ClusterRoleBinding, adminGroupClusterRoleBindingName,
 		"Expected ClusterRoleBinding '%s' to have exactly one subject with name '%s'", adminGroupClusterRoleBindingName, expectedGroup)
+}
+
+// ValidateWebhookBlocksInvalidGroupsOnCreation tests that the webhook blocks creation of Auth resources
+// with invalid groups. Since Auth resources are singletons (must be named "auth"), we need to delete
+// the existing Auth CR first, test webhook validation on creation, then recreate a valid Auth CR.
+func (tc *AuthControllerTestCtx) ValidateWebhookBlocksInvalidGroupsOnCreation(t *testing.T) {
+	t.Helper()
+
+	// Delete the existing Auth CR to enable creation testing
+	tc.DeleteResource(
+		WithMinimalObject(gvk.Auth, tc.AuthNamespacedName),
+		WithCustomErrorMsg("Failed to delete existing Auth CR before creation webhook testing"),
+	)
+
+	// Test cases for different invalid creation scenarios
+	testCases := []struct {
+		name          string
+		invalidValue  string
+		fieldName     string
+		adminGroups   []string
+		allowedGroups []string
+	}{
+		{
+			name:          "system:authenticated in AdminGroups",
+			invalidValue:  "system:authenticated",
+			fieldName:     "AdminGroups",
+			adminGroups:   []string{"valid-admin-group", "system:authenticated"},
+			allowedGroups: []string{"valid-allowed-group"},
+		},
+		{
+			name:          "empty string in AdminGroups",
+			invalidValue:  "empty string",
+			fieldName:     "AdminGroups",
+			adminGroups:   []string{"valid-admin-group", ""},
+			allowedGroups: []string{"valid-allowed-group"},
+		},
+		{
+			name:          "empty string in AllowedGroups",
+			invalidValue:  "empty string",
+			fieldName:     "AllowedGroups",
+			adminGroups:   []string{"valid-admin-group"},
+			allowedGroups: []string{"valid-allowed-group", ""},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			// Create a test Auth resource with invalid values (must use name "auth" due to singleton constraint)
+			invalidAuth := envtestutil.NewAuth("auth", "", testCase.adminGroups, testCase.allowedGroups)
+
+			// Test webhook validation by attempting to create the invalid resource
+			tc.EnsureWebhookBlocksResourceCreation(
+				WithObjectToCreate(invalidAuth),
+				WithInvalidValue(testCase.invalidValue),
+				WithFieldName(testCase.fieldName),
+				WithCustomErrorMsg("Expected Auth resource creation with %s in %s to be blocked by webhook", testCase.invalidValue, testCase.fieldName),
+			)
+		})
+	}
+
+	// Recreate a valid Auth resource for subsequent tests
+	validAuth := envtestutil.NewAuth("auth", "", []string{"valid-admin-group"}, []string{"system:authenticated"})
+	tc.EventuallyResourceCreatedOrUpdated(
+		WithObjectToCreate(validAuth),
+		WithCustomErrorMsg("Failed to recreate valid Auth resource after webhook creation tests"),
+	)
+}
+
+// ValidateWebhookBlocksInvalidGroupsOnUpdate tests that the webhook blocks Auth resources
+// with invalid groups in both AdminGroups and AllowedGroups fields.
+// Since Auth resources must be named "auth", we test by attempting to update the existing resource.
+func (tc *AuthControllerTestCtx) ValidateWebhookBlocksInvalidGroupsOnUpdate(t *testing.T) {
+	t.Helper()
+
+	testCases := []struct {
+		name         string
+		invalidValue string
+		fieldName    string
+		transform    string
+	}{
+		{
+			name:         "system:authenticated in AdminGroups",
+			invalidValue: "system:authenticated",
+			fieldName:    "AdminGroups",
+			transform:    `.spec.adminGroups |= . + ["system:authenticated"]`,
+		},
+		{
+			name:         "empty string in AdminGroups",
+			invalidValue: "empty string",
+			fieldName:    "AdminGroups",
+			transform:    `.spec.adminGroups |= . + [""]`,
+		},
+		{
+			name:         "empty string in AllowedGroups",
+			invalidValue: "empty string",
+			fieldName:    "AllowedGroups",
+			transform:    `.spec.allowedGroups |= . + [""]`,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			// Test webhook validation by attempting to update the existing "auth" resource
+			tc.EnsureWebhookBlocksResourceUpdate(
+				WithMinimalObject(gvk.Auth, tc.AuthNamespacedName),
+				WithMutateFunc(testf.Transform(testCase.transform)),
+				WithInvalidValue(testCase.invalidValue),
+				WithFieldName(testCase.fieldName),
+				WithCustomErrorMsg("Expected Auth resource update with %s in %s to be blocked by webhook", testCase.invalidValue, testCase.fieldName),
+			)
+		})
+	}
+}
+
+// ValidateWebhookAllowsValidGroups tests that the webhook allows Auth resources with valid groups.
+// Since Auth resources must be named "auth", we test by updating the existing resource.
+func (tc *AuthControllerTestCtx) ValidateWebhookAllowsValidGroups(t *testing.T) {
+	t.Helper()
+
+	testCases := []struct {
+		name        string
+		transform   string
+		description string
+	}{
+		{
+			name:        "valid groups only",
+			transform:   `.spec.adminGroups = ["valid-admin-group-1", "valid-admin-group-2"] | .spec.allowedGroups = ["valid-allowed-group-1", "valid-allowed-group-2"]`,
+			description: "Expected Auth resource update with valid groups to be allowed",
+		},
+		{
+			name:        "system:authenticated in AllowedGroups",
+			transform:   `.spec.adminGroups = ["valid-admin-group"] | .spec.allowedGroups = ["valid-allowed-group", "system:authenticated"]`,
+			description: "Expected Auth resource update with system:authenticated in AllowedGroups to be allowed",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			// Test that the webhook allows this valid update
+			tc.EventuallyResourceCreatedOrUpdated(
+				WithMinimalObject(gvk.Auth, tc.AuthNamespacedName),
+				WithMutateFunc(testf.Transform(testCase.transform)),
+				WithCustomErrorMsg(testCase.description),
+			)
+		})
+	}
 }

--- a/tests/e2e/resource_options_test.go
+++ b/tests/e2e/resource_options_test.go
@@ -83,6 +83,12 @@ type ResourceOptions struct {
 	// WaitForDeletion determines whether to wait for the resource to be fully deleted from the cluster.
 	// If true, the DeleteResource function will block until the resource is confirmed to be gone.
 	WaitForDeletion bool
+
+	// Webhook validation fields for testing
+	// InvalidValue holds the description of the invalid value being tested in webhook validation
+	InvalidValue string
+	// FieldName holds the name of the field being validated by the webhook
+	FieldName string
 }
 
 // ResourceOpts is a function type used to configure options for the ResourceOptions object.
@@ -238,9 +244,25 @@ func WithConsistentlyDuration(value time.Duration) ResourceOpts {
 	}
 }
 
-// WithConsistentlyPollingInterval sets the default polling interval for Consistently assertions.
+// WithConsistentlyPollingInterval creates a ResourceOpts function that sets the polling interval for Consistently assertions.
 func WithConsistentlyPollingInterval(value time.Duration) ResourceOpts {
 	return func(ro *ResourceOptions) {
 		ro.tc.g.SetDefaultConsistentlyPollingInterval(value)
+	}
+}
+
+// WithInvalidValue creates a ResourceOpts function that sets the invalid value description for webhook validation tests.
+// This is used for better error messages in webhook validation tests.
+func WithInvalidValue(description string) ResourceOpts {
+	return func(ro *ResourceOptions) {
+		ro.InvalidValue = description
+	}
+}
+
+// WithFieldName creates a ResourceOpts function that sets the field name being validated by the webhook.
+// This is used for better error messages and validation in webhook tests.
+func WithFieldName(fieldName string) ResourceOpts {
+	return func(ro *ResourceOptions) {
+		ro.FieldName = fieldName
 	}
 }


### PR DESCRIPTION
This is a manual cherry-pick of https://github.com/opendatahub-io/opendatahub-operator/pull/2085 and https://github.com/opendatahub-io/opendatahub-operator/pull/2079.

<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
