### PR TITLE
(chore): replace trustyai-explainability to opendatahub-io for releases

### DIFF
--- a/.github/scripts/update-manifests-tags.sh
+++ b/.github/scripts/update-manifests-tags.sh
@@ -15,3 +15,7 @@ env | while IFS="=" read varname value; do
     component=${component//_/-}
     update_tags $(basename $component) $value
 done
+
+# This ensures the release uses the midstream repository which has the incubation branch(used for release)
+echo "Updating trustyai repository reference..."
+sed -i 's|trustyai-explainability:|opendatahub-io:|g' get_all_manifests.sh


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
For odh release, we need to use the midstream(opendatahub-io) instead of the upstream(trustyai-explainability). So while running the release automation, update this in the release branch everytime.

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
