### PR TITLE
(fix): Remove cleanup in release automation

### DIFF
--- a/.github/workflows/release-staging.yaml
+++ b/.github/workflows/release-staging.yaml
@@ -49,12 +49,7 @@ jobs:
       run: ./.github/scripts/update-versions.sh ${{ env.VERSION }}
 
     - name: Run make manifests & bundle
-      run: make manifests bundle
-
-    - name: Clean up bundle files
-      run: |
-        sed -i -e "s|image: quay.io/opendatahub/opendatahub-operator:latest.*|image: REPLACE_IMAGE:latest|g" bundle/manifests/opendatahub-operator.clusterserviceversion.yaml
-        rm -f ./config/manager/kustomization.yaml
+      run: make manifests bundle IMG_TAG=v${{ env.VERSION }}
 
     - name: Update branches in get_all_manifest.sh
       uses: actions/github-script@v7


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
While doing ODH release I figured out that we need to do two things
1. No clean up is needed after the make manifests bundle
2. add the IMG_TAG to point to correct image in the CSV while generating the manifests.

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the release workflow to automatically embed version tags during manifest and bundle generation, streamlining the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->