### PR TITLE
feat: add replicas configable in DSCI.spec.monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,6 +330,7 @@ spec:
     managementState: Managed
     namespace: opendatahub
     metrics:
+      replicas: 2
       resources:
         cpulimit: 500m
         cpurequest: 100m

--- a/api/services/v1alpha1/monitoring_types.go
+++ b/api/services/v1alpha1/monitoring_types.go
@@ -41,10 +41,11 @@ type MonitoringSpec struct {
 }
 
 // Metrics defines the desired state of metrics for the monitoring service
+// +kubebuilder:validation:XValidation:rule="!(self.storage == null && self.resources == null) || !has(self.replicas) || self.replicas == 0",message="Replicas can only be set to non-zero value when either Storage or Resources is configured"
 type Metrics struct {
 	Storage   *MetricsStorage   `json:"storage,omitempty"`
 	Resources *MetricsResources `json:"resources,omitempty"`
-	// Replicas specifies the number of replicas in monitoringstack , default is 2
+	// Replicas specifies the number of replicas in monitoringstack, default is 2 if not set
 	Replicas int32 `json:"replicas,omitempty"`
 }
 

--- a/api/services/v1alpha1/monitoring_types.go
+++ b/api/services/v1alpha1/monitoring_types.go
@@ -44,6 +44,8 @@ type MonitoringSpec struct {
 type Metrics struct {
 	Storage   *MetricsStorage   `json:"storage,omitempty"`
 	Resources *MetricsResources `json:"resources,omitempty"`
+	// Replicas specifies the number of replicas in monitoringstack , default is 2
+	Replicas int32 `json:"replicas,omitempty"`
 }
 
 // MetricsStorage defines the storage configuration for the monitoring service

--- a/bundle/manifests/dscinitialization.opendatahub.io_dscinitializations.yaml
+++ b/bundle/manifests/dscinitialization.opendatahub.io_dscinitializations.yaml
@@ -107,6 +107,11 @@ spec:
                   metrics:
                     description: metrics collection
                     properties:
+                      replicas:
+                        description: Replicas specifies the number of replicas in
+                          monitoringstack , default is 2
+                        format: int32
+                        type: integer
                       resources:
                         description: MetricsResources defines the resource requests
                           and limits for the monitoring service

--- a/bundle/manifests/dscinitialization.opendatahub.io_dscinitializations.yaml
+++ b/bundle/manifests/dscinitialization.opendatahub.io_dscinitializations.yaml
@@ -109,7 +109,7 @@ spec:
                     properties:
                       replicas:
                         description: Replicas specifies the number of replicas in
-                          monitoringstack , default is 2
+                          monitoringstack, default is 2 if not set
                         format: int32
                         type: integer
                       resources:
@@ -173,6 +173,11 @@ spec:
                             x-kubernetes-int-or-string: true
                         type: object
                     type: object
+                    x-kubernetes-validations:
+                    - message: Replicas can only be set when either Storage or Resources
+                        is configured
+                      rule: '!(self.storage == null && self.resources == null) ||
+                        !has(self.replicas) || self.replicas == 0'
                   namespace:
                     default: opendatahub
                     description: |-

--- a/bundle/manifests/services.platform.opendatahub.io_monitorings.yaml
+++ b/bundle/manifests/services.platform.opendatahub.io_monitorings.yaml
@@ -56,8 +56,8 @@ spec:
                 description: metrics collection
                 properties:
                   replicas:
-                    description: Replicas specifies the number of replicas in monitoringstack
-                      , default is 2
+                    description: Replicas specifies the number of replicas in monitoringstack,
+                      default is 2 if not set
                     format: int32
                     type: integer
                   resources:
@@ -121,6 +121,11 @@ spec:
                         x-kubernetes-int-or-string: true
                     type: object
                 type: object
+                x-kubernetes-validations:
+                - message: Replicas can only be set when either Storage or Resources
+                    is configured
+                  rule: '!(self.storage == null && self.resources == null) || !has(self.replicas)
+                    || self.replicas == 0'
               namespace:
                 default: opendatahub
                 description: |-

--- a/bundle/manifests/services.platform.opendatahub.io_monitorings.yaml
+++ b/bundle/manifests/services.platform.opendatahub.io_monitorings.yaml
@@ -55,6 +55,11 @@ spec:
               metrics:
                 description: metrics collection
                 properties:
+                  replicas:
+                    description: Replicas specifies the number of replicas in monitoringstack
+                      , default is 2
+                    format: int32
+                    type: integer
                   resources:
                     description: MetricsResources defines the resource requests and
                       limits for the monitoring service

--- a/config/crd/bases/dscinitialization.opendatahub.io_dscinitializations.yaml
+++ b/config/crd/bases/dscinitialization.opendatahub.io_dscinitializations.yaml
@@ -109,7 +109,7 @@ spec:
                     properties:
                       replicas:
                         description: Replicas specifies the number of replicas in
-                          monitoringstack , default is 2
+                          monitoringstack, default is 2 if not set
                         format: int32
                         type: integer
                       resources:
@@ -173,6 +173,11 @@ spec:
                             x-kubernetes-int-or-string: true
                         type: object
                     type: object
+                    x-kubernetes-validations:
+                    - message: Replicas can only be set to non-zero value when either
+                        Storage or Resources is configured
+                      rule: '!(self.storage == null && self.resources == null) ||
+                        !has(self.replicas) || self.replicas == 0'
                   namespace:
                     default: opendatahub
                     description: |-

--- a/config/crd/bases/dscinitialization.opendatahub.io_dscinitializations.yaml
+++ b/config/crd/bases/dscinitialization.opendatahub.io_dscinitializations.yaml
@@ -107,6 +107,11 @@ spec:
                   metrics:
                     description: metrics collection
                     properties:
+                      replicas:
+                        description: Replicas specifies the number of replicas in
+                          monitoringstack , default is 2
+                        format: int32
+                        type: integer
                       resources:
                         description: MetricsResources defines the resource requests
                           and limits for the monitoring service

--- a/config/crd/bases/services.platform.opendatahub.io_monitorings.yaml
+++ b/config/crd/bases/services.platform.opendatahub.io_monitorings.yaml
@@ -55,6 +55,11 @@ spec:
               metrics:
                 description: metrics collection
                 properties:
+                  replicas:
+                    description: Replicas specifies the number of replicas in monitoringstack
+                      , default is 2
+                    format: int32
+                    type: integer
                   resources:
                     description: MetricsResources defines the resource requests and
                       limits for the monitoring service

--- a/config/crd/bases/services.platform.opendatahub.io_monitorings.yaml
+++ b/config/crd/bases/services.platform.opendatahub.io_monitorings.yaml
@@ -56,8 +56,8 @@ spec:
                 description: metrics collection
                 properties:
                   replicas:
-                    description: Replicas specifies the number of replicas in monitoringstack
-                      , default is 2
+                    description: Replicas specifies the number of replicas in monitoringstack,
+                      default is 2 if not set
                     format: int32
                     type: integer
                   resources:
@@ -121,6 +121,11 @@ spec:
                         x-kubernetes-int-or-string: true
                     type: object
                 type: object
+                x-kubernetes-validations:
+                - message: Replicas can only be set to non-zero value when either
+                    Storage or Resources is configured
+                  rule: '!(self.storage == null && self.resources == null) || !has(self.replicas)
+                    || self.replicas == 0'
               namespace:
                 default: opendatahub
                 description: |-

--- a/docs/api-overview.md
+++ b/docs/api-overview.md
@@ -2650,7 +2650,7 @@ _Appears in:_
 | --- | --- | --- | --- |
 | `storage` _[MetricsStorage](#metricsstorage)_ |  |  |  |
 | `resources` _[MetricsResources](#metricsresources)_ |  |  |  |
-| `replicas` _integer_ | Replicas specifies the number of replicas in monitoringstack , default is 2 |  |  |
+| `replicas` _integer_ | Replicas specifies the number of replicas in monitoringstack, default is 2 if not set |  |  |
 
 
 #### MetricsResources

--- a/docs/api-overview.md
+++ b/docs/api-overview.md
@@ -2650,6 +2650,7 @@ _Appears in:_
 | --- | --- | --- | --- |
 | `storage` _[MetricsStorage](#metricsstorage)_ |  |  |  |
 | `resources` _[MetricsResources](#metricsresources)_ |  |  |  |
+| `replicas` _integer_ | Replicas specifies the number of replicas in monitoringstack , default is 2 |  |  |
 
 
 #### MetricsResources

--- a/internal/controller/services/monitoring/monitoring_controller_actions.go
+++ b/internal/controller/services/monitoring/monitoring_controller_actions.go
@@ -93,7 +93,7 @@ func createMonitoringStack(ctx context.Context, rr *odhtypes.ReconciliationReque
 		return errors.New("instance is not of type *services.Monitoring")
 	}
 
-	if monitoring.Spec.Metrics != nil && (monitoring.Spec.Metrics.Resources != nil || monitoring.Spec.Metrics.Storage != nil) {
+	if monitoring.Spec.Metrics != nil && (monitoring.Spec.Metrics.Resources != nil || monitoring.Spec.Metrics.Storage != nil || monitoring.Spec.Metrics.Replicas != 0) {
 		if msExists, _ := cluster.HasCRD(ctx, rr.Client, gvk.MonitoringStack); !msExists {
 			return errors.New("MonitoringStack CRD not found")
 		}

--- a/internal/controller/services/monitoring/monitoring_controller_support.go
+++ b/internal/controller/services/monitoring/monitoring_controller_support.go
@@ -66,12 +66,7 @@ func getTemplateData(ctx context.Context, rr *odhtypes.ReconciliationRequest) (m
 		storageRetention = "1d"
 	}
 
-	var replicas int32
-	if metrics.Replicas == 0 { // zero-value
-		replicas = 2
-	} else {
-		replicas = metrics.Replicas
-	}
+	replicas := metrics.Replicas // take whatever value user set in DSCI, including 0, or if not set then default to 2
 
 	return map[string]any{
 		"CPULimit":            cpuLimit,

--- a/internal/controller/services/monitoring/monitoring_controller_support.go
+++ b/internal/controller/services/monitoring/monitoring_controller_support.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"embed"
 	"errors"
+	"strconv"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -65,6 +66,13 @@ func getTemplateData(ctx context.Context, rr *odhtypes.ReconciliationRequest) (m
 		storageRetention = "1d"
 	}
 
+	var replicas int32
+	if metrics.Replicas == 0 { // zero-value
+		replicas = 2
+	} else {
+		replicas = metrics.Replicas
+	}
+
 	return map[string]any{
 		"CPULimit":            cpuLimit,
 		"MemoryLimit":         memoryLimit,
@@ -74,6 +82,7 @@ func getTemplateData(ctx context.Context, rr *odhtypes.ReconciliationRequest) (m
 		"StorageRetention":    storageRetention,
 		"MonitoringStackName": monitoringStackName,
 		"Namespace":           monitoring.Spec.Namespace,
+		"Replicas":            strconv.Itoa(int(replicas)),
 	}, nil
 }
 

--- a/internal/controller/services/monitoring/resources/monitoring-stack.tmpl.yaml
+++ b/internal/controller/services/monitoring/resources/monitoring-stack.tmpl.yaml
@@ -13,7 +13,7 @@ spec:
       resources:
         requests: 
           storage: {{ .StorageSize }}
-    replicas: 2
+    replicas: {{ .Replicas }}
   resourceSelector: {}
   resources:
     limits:

--- a/tests/e2e/monitoring_test.go
+++ b/tests/e2e/monitoring_test.go
@@ -148,7 +148,7 @@ func (tc *MonitoringTestCtx) ValidateMonitoringStackCRMetricsConfiguration(t *te
 			// Validate memory limit defaults to 512Mi
 			jq.Match(`.spec.resources.limits.memory == "%s"`, "512Mi"),
 			// Validate replicas is set to 2
-			jq.Match(`.spec.prometheusConfig.replicas == "%d"`, 2),
+			jq.Match(`.spec.prometheusConfig.replicas == %d`, 2),
 			// Validate owner references
 			jq.Match(`.metadata.ownerReferences | length == 1`),
 			jq.Match(`.metadata.ownerReferences[0].kind == "%s"`, gvk.Monitoring.Kind),

--- a/tests/e2e/monitoring_test.go
+++ b/tests/e2e/monitoring_test.go
@@ -172,6 +172,11 @@ func (tc *MonitoringTestCtx) ValidateMonitoringStackCRMetricsConfiguration(t *te
 	tc.g.Expect(found).To(BeTrue())
 	tc.g.Expect(memoryLimit).To(Equal("512Mi"))
 
+	replicas, found, err := unstructured.NestedString(ms[0].Object, "spec", "prometheusConfig", "replicas")
+	tc.g.Expect(err).ToNot(HaveOccurred())
+	tc.g.Expect(found).To(BeTrue())
+	tc.g.Expect(replicas).To(Equal("2"))
+
 	// check owenr references for the MonitoringStack
 	ownerRefs, found, err := unstructured.NestedSlice(ms[0].Object, "metadata", "ownerReferences")
 	tc.g.Expect(err).ToNot(HaveOccurred())

--- a/tests/e2e/monitoring_test.go
+++ b/tests/e2e/monitoring_test.go
@@ -6,7 +6,6 @@ import (
 	operatorv1 "github.com/openshift/api/operator/v1"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
 
 	dsciv1 "github.com/opendatahub-io/opendatahub-operator/v2/api/dscinitialization/v1"
@@ -129,64 +128,34 @@ func (tc *MonitoringTestCtx) ValidateMonitoringStackCRMetricsWhenSet(t *testing.
 func (tc *MonitoringTestCtx) ValidateMonitoringStackCRMetricsConfiguration(t *testing.T) {
 	t.Helper()
 
-	// monitoring := &serviceApi.Monitoring{}
-	// tc.FetchTypedResource(monitoring, WithMinimalObject(gvk.Monitoring, types.NamespacedName{Name: "default-monitoring"}))
-
 	dsci := tc.FetchDSCInitialization()
 	monitoringStackName := getMonitoringStackName(dsci)
 
-	ms := tc.FetchResources(
-		WithMinimalObject(gvk.MonitoringStack, types.NamespacedName{Name: monitoringStackName}),
+	// Use EnsureResourceExists with jq matchers for cleaner validation
+	tc.EnsureResourceExists(
+		WithMinimalObject(gvk.MonitoringStack, types.NamespacedName{Name: monitoringStackName, Namespace: dsci.Spec.Monitoring.Namespace}),
+		WithCondition(And(
+			// Validate storage size is set to 5Gi
+			jq.Match(`.spec.prometheusConfig.persistentVolumeClaim.resources.requests.storage == "%s"`, "5Gi"),
+			// Validate storage retention is set to 1d
+			jq.Match(`.spec.retention == "%s"`, "1d"),
+			// Validate CPU request is set to 250m
+			jq.Match(`.spec.resources.requests.cpu == "%s"`, "250m"),
+			// Validate memory request is set to 350Mi
+			jq.Match(`.spec.resources.requests.memory == "%s"`, "350Mi"),
+			// Validate CPU limit defaults to 500m
+			jq.Match(`.spec.resources.limits.cpu == "%s"`, "500m"),
+			// Validate memory limit defaults to 512Mi
+			jq.Match(`.spec.resources.limits.memory == "%s"`, "512Mi"),
+			// Validate replicas is set to 2
+			jq.Match(`.spec.prometheusConfig.replicas == "%d"`, 2),
+			// Validate owner references
+			jq.Match(`.metadata.ownerReferences | length == 1`),
+			jq.Match(`.metadata.ownerReferences[0].kind == "%s"`, gvk.Monitoring.Kind),
+			jq.Match(`.metadata.ownerReferences[0].name == "%s"`, "default-monitoring"),
+		)),
+		WithCustomErrorMsg("MonitoringStack '%s' configuration validation failed", monitoringStackName),
 	)
-
-	// Validate the storage size is set to 5Gi
-	storageSize, found, err := unstructured.NestedString(ms[0].Object, "spec", "prometheusConfig", "persistentVolumeClaim", "resources", "requests", "storage")
-	tc.g.Expect(err).ToNot(HaveOccurred())
-	tc.g.Expect(found).To(BeTrue())
-	tc.g.Expect(storageSize).To(Equal("5Gi"))
-
-	storageRetention, found, err := unstructured.NestedString(ms[0].Object, "spec", "retention")
-	tc.g.Expect(err).ToNot(HaveOccurred())
-	tc.g.Expect(found).To(BeTrue())
-	tc.g.Expect(storageRetention).To(Equal("1d"))
-
-	// Validate the resources are set to the correct values
-	cpuRequest, found, err := unstructured.NestedString(ms[0].Object, "spec", "resources", "requests", "cpu")
-	tc.g.Expect(err).ToNot(HaveOccurred())
-	tc.g.Expect(found).To(BeTrue())
-	tc.g.Expect(cpuRequest).To(Equal("250m"))
-
-	memoryRequest, found, err := unstructured.NestedString(ms[0].Object, "spec", "resources", "requests", "memory")
-	tc.g.Expect(err).ToNot(HaveOccurred())
-	tc.g.Expect(found).To(BeTrue())
-	tc.g.Expect(memoryRequest).To(Equal("350Mi"))
-
-	// Validate the resources defaults are set to the correct values
-	cpuLimit, found, err := unstructured.NestedString(ms[0].Object, "spec", "resources", "limits", "cpu")
-	tc.g.Expect(err).ToNot(HaveOccurred())
-	tc.g.Expect(found).To(BeTrue())
-	tc.g.Expect(cpuLimit).To(Equal("500m"))
-
-	memoryLimit, found, err := unstructured.NestedString(ms[0].Object, "spec", "resources", "limits", "memory")
-	tc.g.Expect(err).ToNot(HaveOccurred())
-	tc.g.Expect(found).To(BeTrue())
-	tc.g.Expect(memoryLimit).To(Equal("512Mi"))
-
-	replicas, found, err := unstructured.NestedInt64(ms[0].Object, "spec", "prometheusConfig", "replicas")
-	tc.g.Expect(err).ToNot(HaveOccurred())
-	tc.g.Expect(found).To(BeTrue())
-	tc.g.Expect(replicas).To(Equal(int32(2)))
-
-	// check owenr references for the MonitoringStack
-	ownerRefs, found, err := unstructured.NestedSlice(ms[0].Object, "metadata", "ownerReferences")
-	tc.g.Expect(err).ToNot(HaveOccurred())
-	tc.g.Expect(found).To(BeTrue())
-	tc.g.Expect(ownerRefs).To(HaveLen(1))
-
-	ownerRef, found := ownerRefs[0].(map[string]interface{})
-	tc.g.Expect(found).To(BeTrue(), "Expected owner reference to be a map[string]interface{}")
-	tc.g.Expect(ownerRef["kind"]).To(Equal(gvk.Monitoring.Kind))
-	tc.g.Expect(ownerRef["name"]).To(Equal("default-monitoring"))
 }
 
 func getMonitoringStackName(dsci *dsciv1.DSCInitialization) string {

--- a/tests/e2e/monitoring_test.go
+++ b/tests/e2e/monitoring_test.go
@@ -172,10 +172,10 @@ func (tc *MonitoringTestCtx) ValidateMonitoringStackCRMetricsConfiguration(t *te
 	tc.g.Expect(found).To(BeTrue())
 	tc.g.Expect(memoryLimit).To(Equal("512Mi"))
 
-	replicas, found, err := unstructured.NestedString(ms[0].Object, "spec", "prometheusConfig", "replicas")
+	replicas, found, err := unstructured.NestedInt64(ms[0].Object, "spec", "prometheusConfig", "replicas")
 	tc.g.Expect(err).ToNot(HaveOccurred())
 	tc.g.Expect(found).To(BeTrue())
-	tc.g.Expect(replicas).To(Equal("2"))
+	tc.g.Expect(replicas).To(Equal(int32(2)))
 
 	// check owenr references for the MonitoringStack
 	ownerRefs, found, err := unstructured.NestedSlice(ms[0].Object, "metadata", "ownerReferences")


### PR DESCRIPTION
 <!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->
   - add validation on API : Replicas can only be set to non-zero value when either Storage or Resources is configured
    - add new testcase on replicas
    - new logic:
1.  in DSCI: if metrics.storage or metrics.resources are set but no replicas => replicas use 2 behind the scene
2.  in DSCI: no metrics.storage nor metrics.resource is set, but try to set replicas => failed validation when create/update DSCI CR
3.  in DSCI: if metrics.storage or metrics.resources are set and replicas is set too => user set value for replicas in MonitoringStack CR

<!--- Link your JIRA and related links here for reference. -->
ref https://issues.redhat.com/browse/RHOAIENG-28845 https://issues.redhat.com/browse/RHOAIENG-28830

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- create DSCI without .spec.monitoring
  no MonitoringStack CR created

- create DSCI with .spec.monitoring.metrics: {}
  no MonitoringStack CR created

- negative to create DSCI with 
```
  spec:
  applicationsNamespace: opendatahub
  monitoring:
    managementState: Managed
    namespace: opendatahub
    metrics:
      replicas: 1
```
get error: `Error "Invalid value: "object": no such key: storage evaluating rule: Replicas can only be set to non-zero value when either Storage or Resources is configured" for field "spec.monitoring.metrics".`

- positive to create DSCI with 
```
spec:
  applicationsNamespace: opendatahub
  monitoring:
    managementState: Managed
    namespace: opendatahub
    metrics:
      replicas: 0
```
no error on DSCI

- create DSCI without set replicas value
```
spec:
  applicationsNamespace: opendatahub
  monitoring:
    managementState: Managed
    metrics:
      storage:
        retention: 1d
   namespace: opendatahub
```
monitoringStack CR created 
```
spec:
  alertmanagerConfig:
    disabled: false
  logLevel: debug
  prometheusConfig:
    enableOtlpHttpReceiver: true
    persistentVolumeClaim:
      resources:
        requests:
          storage: 5Gi
    replicas: 2========================================> default
  resourceSelector: {}
  resources:
    limits:
      cpu: 500m
      memory: 512Mi
    requests:
      cpu: 100m
      memory: 256Mi
  retention: 1d
```

- create DSCI  with different replicas value
```
spec:
  applicationsNamespace: opendatahub
  monitoring:
    managementState: Managed
    metrics:
      storage:
        retention: 1d
        size: 5Gi
      replicas: 10 ==============================================> updated value
    namespace: opendatahub
```
get monitornigStack CR
```
spec:
  alertmanagerConfig:
    disabled: false
  logLevel: debug
  prometheusConfig:
    enableOtlpHttpReceiver: true
    persistentVolumeClaim:
      resources:
        requests:
          storage: 5Gi
    replicas: 10 ==============================================> updated value
  resourceSelector: {}
  resources:
    limits:
      cpu: 500m
      memory: 512Mi
    requests:
      cpu: 100m
      memory: 256Mi
  retention: 1d
```

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for configuring the number of replicas for the monitoring metrics component, with a default of 2 replicas.
  * Users can now specify the desired replica count in relevant custom resources and manifests.

* **Documentation**
  * Updated API documentation and example manifests to include the new `replicas` field for metrics configuration.

* **Tests**
  * Enhanced tests to validate the correct handling and value of the `replicas` field in monitoring configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->