### PR TITLE
RHOAIENG-27721 - Added e2e tests to validate resources are recreated upon deletion

### DIFF
--- a/internal/controller/components/ray/ray_controller.go
+++ b/internal/controller/components/ray/ray_controller.go
@@ -50,6 +50,7 @@ func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.
 		Owns(&rbacv1.Role{}).
 		Owns(&rbacv1.RoleBinding{}).
 		Owns(&corev1.ServiceAccount{}).
+		Owns(&corev1.Service{}).
 		Owns(&appsv1.Deployment{}, reconciler.WithPredicates(resources.NewDeploymentPredicate())).
 		Owns(&securityv1.SecurityContextConstraints{}).
 		Watches(

--- a/internal/controller/components/trainingoperator/trainingoperator_controller.go
+++ b/internal/controller/components/trainingoperator/trainingoperator_controller.go
@@ -48,6 +48,7 @@ func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.
 		Owns(&rbacv1.ClusterRoleBinding{}).
 		Owns(&rbacv1.ClusterRole{}).
 		Owns(&corev1.ServiceAccount{}).
+		Owns(&corev1.Service{}).
 		Owns(&appsv1.Deployment{}, reconciler.WithPredicates(resources.NewDeploymentPredicate())).
 		Watches(
 			&extv1.CustomResourceDefinition{},

--- a/pkg/cluster/gvk/gvk.go
+++ b/pkg/cluster/gvk/gvk.go
@@ -2,6 +2,7 @@ package gvk
 
 import (
 	configv1 "github.com/openshift/api/config/v1"
+	routev1 "github.com/openshift/api/route/v1"
 	operatorsv1 "github.com/operator-framework/api/pkg/operators/v1"
 	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
@@ -116,6 +117,12 @@ var (
 		Kind:    "RoleBinding",
 	}
 
+	ServiceAccount = schema.GroupVersionKind{
+		Group:   corev1.SchemeGroupVersion.Group,
+		Version: corev1.SchemeGroupVersion.Version,
+		Kind:    "ServiceAccount",
+	}
+
 	Secret = schema.GroupVersionKind{
 		Group:   corev1.SchemeGroupVersion.Group,
 		Version: corev1.SchemeGroupVersion.Version,
@@ -126,6 +133,18 @@ var (
 		Group:   corev1.SchemeGroupVersion.Group,
 		Version: corev1.SchemeGroupVersion.Version,
 		Kind:    "ConfigMap",
+	}
+
+	Service = schema.GroupVersionKind{
+		Group:   corev1.SchemeGroupVersion.Group,
+		Version: corev1.SchemeGroupVersion.Version,
+		Kind:    "Service",
+	}
+
+	Route = schema.GroupVersionKind{
+		Group:   routev1.SchemeGroupVersion.Group,
+		Version: routev1.SchemeGroupVersion.Version,
+		Kind:    "Route",
 	}
 
 	KnativeServing = schema.GroupVersionKind{

--- a/tests/e2e/codeflare_test.go
+++ b/tests/e2e/codeflare_test.go
@@ -28,6 +28,11 @@ func codeflareTestSuite(t *testing.T) {
 		{"Validate operands have OwnerReferences", componentCtx.ValidateOperandsOwnerReferences},
 		{"Validate update operand resources", componentCtx.ValidateUpdateDeploymentsResources},
 		{"Validate component releases", componentCtx.ValidateComponentReleases},
+		{"Validate deployment deletion recovery", componentCtx.ValidateDeploymentDeletionRecovery},
+		{"Validate configmap deletion recovery", componentCtx.ValidateConfigMapDeletionRecovery},
+		{"Validate service deletion recovery", componentCtx.ValidateServiceDeletionRecovery},
+		{"Validate serviceaccount deletion recovery", componentCtx.ValidateServiceAccountDeletionRecovery},
+		{"Validate rbac deletion recovery", componentCtx.ValidateRBACDeletionRecovery},
 		{"Validate component disabled", componentCtx.ValidateComponentDisabled},
 	}
 

--- a/tests/e2e/components_test.go
+++ b/tests/e2e/components_test.go
@@ -352,3 +352,302 @@ func (tc *ComponentTestCtx) ValidateModelControllerInstance(t *testing.T) {
 		modelcontroller.ReadyConditionType,
 	)
 }
+
+// ValidateDeploymentDeletionRecovery validates Deployment resources are recreated upon deletion.
+func (tc *ComponentTestCtx) ValidateDeploymentDeletionRecovery(t *testing.T) {
+	t.Helper()
+
+	// Fetch Deployments
+	deployments := tc.FetchResources(
+		WithMinimalObject(gvk.Deployment, types.NamespacedName{Namespace: tc.AppsNamespace}),
+		WithListOptions(
+			&client.ListOptions{
+				Namespace: tc.AppsNamespace,
+				LabelSelector: k8slabels.Set{
+					labels.PlatformPartOf: strings.ToLower(tc.GVK.Kind),
+				}.AsSelector(),
+			},
+		),
+	)
+
+	// For each Deployment, delete it and verify it gets recreated
+	for _, deployment := range deployments {
+		t.Run("deployment_"+deployment.GetName(), func(t *testing.T) {
+			t.Helper()
+
+			// Delete the Deployment
+			tc.DeleteResource(
+				WithMinimalObject(gvk.Deployment, resources.NamespacedNameFromObject(&deployment)),
+			)
+
+			// Verify the Deployment is recreated
+			tc.EnsureResourceExists(
+				WithMinimalObject(gvk.Deployment, resources.NamespacedNameFromObject(&deployment)),
+				WithCondition(jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, status.ConditionTypeAvailable, metav1.ConditionTrue)),
+			)
+		})
+	}
+}
+
+// ValidateConfigMapDeletionRecovery validates ConfigMap resources are recreated upon deletion.
+func (tc *ComponentTestCtx) ValidateConfigMapDeletionRecovery(t *testing.T) {
+	t.Helper()
+
+	// Fetch ConfigMaps
+	configMaps := tc.FetchResources(
+		WithMinimalObject(gvk.ConfigMap, types.NamespacedName{Namespace: tc.AppsNamespace}),
+		WithListOptions(
+			&client.ListOptions{
+				Namespace: tc.AppsNamespace,
+				LabelSelector: k8slabels.Set{
+					labels.PlatformPartOf: strings.ToLower(tc.GVK.Kind),
+				}.AsSelector(),
+			},
+		),
+	)
+
+	// For each ConfigMap, delete it and verify it gets recreated
+	for _, configMap := range configMaps {
+		t.Run("configMap_"+configMap.GetName(), func(t *testing.T) {
+			t.Helper()
+
+			// Delete the ConfigMap
+			tc.DeleteResource(
+				WithMinimalObject(gvk.ConfigMap, resources.NamespacedNameFromObject(&configMap)),
+			)
+
+			// Verify the ConfigMap is recreated
+			tc.EnsureResourceExists(
+				WithMinimalObject(gvk.ConfigMap, resources.NamespacedNameFromObject(&configMap)),
+			)
+		})
+	}
+}
+
+// ValidateServiceDeletionRecovery validates Service resources are recreated upon deletion.
+func (tc *ComponentTestCtx) ValidateServiceDeletionRecovery(t *testing.T) {
+	t.Helper()
+
+	// Fetch Services
+	services := tc.FetchResources(
+		WithMinimalObject(gvk.Service, types.NamespacedName{Namespace: tc.AppsNamespace}),
+		WithListOptions(
+			&client.ListOptions{
+				Namespace: tc.AppsNamespace,
+				LabelSelector: k8slabels.Set{
+					labels.PlatformPartOf: strings.ToLower(tc.GVK.Kind),
+				}.AsSelector(),
+			},
+		),
+	)
+
+	// For each Service, delete it and verify it gets recreated
+	for _, service := range services {
+		t.Run("service_"+service.GetName(), func(t *testing.T) {
+			t.Helper()
+
+			// Delete the Service
+			tc.DeleteResource(
+				WithMinimalObject(gvk.Service, resources.NamespacedNameFromObject(&service)),
+			)
+
+			// Verify the Service is recreated
+			tc.EnsureResourceExists(
+				WithMinimalObject(gvk.Service, resources.NamespacedNameFromObject(&service)),
+			)
+		})
+	}
+}
+
+// ValidateRouteDeletionRecovery validates Route resources are recreated upon deletion.
+func (tc *ComponentTestCtx) ValidateRouteDeletionRecovery(t *testing.T) {
+	t.Helper()
+
+	// Fetch Routes
+	routes := tc.FetchResources(
+		WithMinimalObject(gvk.Route, types.NamespacedName{Namespace: tc.AppsNamespace}),
+		WithListOptions(
+			&client.ListOptions{
+				Namespace: tc.AppsNamespace,
+				LabelSelector: k8slabels.Set{
+					labels.PlatformPartOf: strings.ToLower(tc.GVK.Kind),
+				}.AsSelector(),
+			},
+		),
+	)
+
+	// For each Route, delete it and verify it gets recreated
+	for _, route := range routes {
+		t.Run("route_"+route.GetName(), func(t *testing.T) {
+			t.Helper()
+
+			// Delete the Route
+			tc.DeleteResource(
+				WithMinimalObject(gvk.Route, resources.NamespacedNameFromObject(&route)),
+			)
+
+			// Verify the Route is recreated
+			tc.EnsureResourceExists(
+				WithMinimalObject(gvk.Route, resources.NamespacedNameFromObject(&route)),
+			)
+		})
+	}
+}
+
+// ValidateServiceAccountDeletionRecovery validates ServiceAccount resources are recreated upon deletion.
+func (tc *ComponentTestCtx) ValidateServiceAccountDeletionRecovery(t *testing.T) {
+	t.Helper()
+
+	// Fetch ServiceAccounts
+	serviceAccounts := tc.FetchResources(
+		WithMinimalObject(gvk.ServiceAccount, types.NamespacedName{Namespace: tc.AppsNamespace}),
+		WithListOptions(
+			&client.ListOptions{
+				Namespace: tc.AppsNamespace,
+				LabelSelector: k8slabels.Set{
+					labels.PlatformPartOf: strings.ToLower(tc.GVK.Kind),
+				}.AsSelector(),
+			},
+		),
+	)
+
+	// For each ServiceAccount, delete it and verify it gets recreated
+	for _, serviceAccount := range serviceAccounts {
+		t.Run("serviceAccount_"+serviceAccount.GetName(), func(t *testing.T) {
+			t.Helper()
+
+			// Delete the ServiceAccount
+			tc.DeleteResource(
+				WithMinimalObject(gvk.ServiceAccount, resources.NamespacedNameFromObject(&serviceAccount)),
+			)
+
+			// Verify the ServiceAccount is recreated
+			tc.EnsureResourceExists(
+				WithMinimalObject(gvk.ServiceAccount, resources.NamespacedNameFromObject(&serviceAccount)),
+			)
+		})
+	}
+}
+
+// ValidateRBACDeletionRecovery validates ClusterRole, ClusterRoleBinding, Role, and RoleBinding resources are recreated upon deletion.
+func (tc *ComponentTestCtx) ValidateRBACDeletionRecovery(t *testing.T) {
+	t.Helper()
+
+	// Fetch ClusterRoles
+	clusterRoles := tc.FetchResources(
+		WithMinimalObject(gvk.ClusterRole, types.NamespacedName{Namespace: tc.AppsNamespace}),
+		WithListOptions(
+			&client.ListOptions{
+				LabelSelector: k8slabels.Set{
+					labels.PlatformPartOf: strings.ToLower(tc.GVK.Kind),
+				}.AsSelector(),
+			},
+		),
+	)
+
+	// For each ClusterRole, delete it and verify it gets recreated
+	for _, clusterRole := range clusterRoles {
+		t.Run("clusterRole_"+clusterRole.GetName(), func(t *testing.T) {
+			t.Helper()
+
+			// Delete the ClusterRole
+			tc.DeleteResource(
+				WithMinimalObject(gvk.ClusterRole, resources.NamespacedNameFromObject(&clusterRole)),
+			)
+
+			// Verify the ClusterRole is recreated
+			tc.EnsureResourceExists(
+				WithMinimalObject(gvk.ClusterRole, resources.NamespacedNameFromObject(&clusterRole)),
+			)
+		})
+	}
+
+	// Fetch ClusterRoleBindings
+	clusterRoleBindings := tc.FetchResources(
+		WithMinimalObject(gvk.ClusterRoleBinding, types.NamespacedName{Namespace: tc.AppsNamespace}),
+		WithListOptions(
+			&client.ListOptions{
+				LabelSelector: k8slabels.Set{
+					labels.PlatformPartOf: strings.ToLower(tc.GVK.Kind),
+				}.AsSelector(),
+			},
+		),
+	)
+
+	// For each ClusterRoleBinding, delete it and verify it gets recreated
+	for _, clusterRoleBinding := range clusterRoleBindings {
+		t.Run("clusterRoleBinding_"+clusterRoleBinding.GetName(), func(t *testing.T) {
+			t.Helper()
+
+			// Delete the ClusterRoleBinding
+			tc.DeleteResource(
+				WithMinimalObject(gvk.ClusterRoleBinding, resources.NamespacedNameFromObject(&clusterRoleBinding)),
+			)
+
+			// Verify the ClusterRoleBinding is recreated
+			tc.EnsureResourceExists(
+				WithMinimalObject(gvk.ClusterRoleBinding, resources.NamespacedNameFromObject(&clusterRoleBinding)),
+			)
+		})
+	}
+
+	// Fetch Roles
+	roles := tc.FetchResources(
+		WithMinimalObject(gvk.Role, types.NamespacedName{Namespace: tc.AppsNamespace}),
+		WithListOptions(
+			&client.ListOptions{
+				Namespace: tc.AppsNamespace,
+				LabelSelector: k8slabels.Set{
+					labels.PlatformPartOf: strings.ToLower(tc.GVK.Kind),
+				}.AsSelector(),
+			},
+		),
+	)
+
+	// For each Role, delete it and verify it gets recreated
+	for _, role := range roles {
+		t.Run("role_"+role.GetName(), func(t *testing.T) {
+			t.Helper()
+
+			// Delete the Role
+			tc.DeleteResource(
+				WithMinimalObject(gvk.Role, resources.NamespacedNameFromObject(&role)),
+			)
+
+			// Verify the Role is recreated
+			tc.EnsureResourceExists(
+				WithMinimalObject(gvk.Role, resources.NamespacedNameFromObject(&role)),
+			)
+		})
+	}
+
+	// Fetch RoleBindings
+	roleBindings := tc.FetchResources(
+		WithMinimalObject(gvk.RoleBinding, types.NamespacedName{Namespace: tc.AppsNamespace}),
+		WithListOptions(
+			&client.ListOptions{
+				Namespace: tc.AppsNamespace,
+				LabelSelector: k8slabels.Set{
+					labels.PlatformPartOf: strings.ToLower(tc.GVK.Kind),
+				}.AsSelector(),
+			},
+		),
+	)
+
+	// For each RoleBinding, delete it and verify it gets recreated
+	for _, roleBinding := range roleBindings {
+		t.Run("roleBinding_"+roleBinding.GetName(), func(t *testing.T) {
+			t.Helper()
+
+			// Delete the RoleBinding
+			tc.DeleteResource(
+				WithMinimalObject(gvk.RoleBinding, resources.NamespacedNameFromObject(&roleBinding)),
+			)
+
+			// Verify the RoleBinding is recreated
+			tc.EnsureResourceExists(
+				WithMinimalObject(gvk.RoleBinding, resources.NamespacedNameFromObject(&roleBinding)),
+			)
+		})
+	}
+}

--- a/tests/e2e/dashboard_test.go
+++ b/tests/e2e/dashboard_test.go
@@ -42,6 +42,12 @@ func dashboardTestSuite(t *testing.T) {
 		{"Validate update operand resources", componentCtx.ValidateUpdateDeploymentsResources},
 		{"Validate dynamically watches operands", componentCtx.ValidateOperandsDynamicallyWatchedResources},
 		{"Validate CRDs reinstated", componentCtx.ValidateCRDReinstated},
+		{"Validate deployment deletion recovery", componentCtx.ValidateDeploymentDeletionRecovery},
+		{"Validate configmap deletion recovery", componentCtx.ValidateConfigMapDeletionRecovery},
+		{"Validate service deletion recovery", componentCtx.ValidateServiceDeletionRecovery},
+		{"Validate route deletion recovery", componentCtx.ValidateRouteDeletionRecovery},
+		{"Validate serviceaccount deletion recovery", componentCtx.ValidateServiceAccountDeletionRecovery},
+		{"Validate rbac deletion recovery", componentCtx.ValidateRBACDeletionRecovery},
 		{"Validate component disabled", componentCtx.ValidateComponentDisabled},
 	}
 

--- a/tests/e2e/datasciencepipelines_test.go
+++ b/tests/e2e/datasciencepipelines_test.go
@@ -34,6 +34,11 @@ func dataSciencePipelinesTestSuite(t *testing.T) {
 		{"Validate operands have OwnerReferences", componentCtx.ValidateOperandsOwnerReferences},
 		{"Validate update operand resources", componentCtx.ValidateUpdateDeploymentsResources},
 		{"Validate component releases", componentCtx.ValidateComponentReleases},
+		{"Validate deployment deletion recovery", componentCtx.ValidateDeploymentDeletionRecovery},
+		{"Validate configmap deletion recovery", componentCtx.ValidateConfigMapDeletionRecovery},
+		{"Validate service deletion recovery", componentCtx.ValidateServiceDeletionRecovery},
+		{"Validate serviceaccount deletion recovery", componentCtx.ValidateServiceAccountDeletionRecovery},
+		{"Validate rbac deletion recovery", componentCtx.ValidateRBACDeletionRecovery},
 		{"Validate component disabled", componentCtx.ValidateComponentDisabled},
 		{"Validate argoWorkflowsControllers options", componentCtx.ValidateArgoWorkflowsControllersOptions},
 	}

--- a/tests/e2e/feastoperator_test.go
+++ b/tests/e2e/feastoperator_test.go
@@ -28,6 +28,11 @@ func feastOperatorTestSuite(t *testing.T) {
 		{"Validate operands have OwnerReferences", componentCtx.ValidateOperandsOwnerReferences},
 		{"Validate update operand resources", componentCtx.ValidateUpdateDeploymentsResources},
 		{"Validate component releases", componentCtx.ValidateComponentReleases},
+		{"Validate deployment deletion recovery", componentCtx.ValidateDeploymentDeletionRecovery},
+		{"Validate configmap deletion recovery", componentCtx.ValidateConfigMapDeletionRecovery},
+		{"Validate service deletion recovery", componentCtx.ValidateServiceDeletionRecovery},
+		{"Validate serviceaccount deletion recovery", componentCtx.ValidateServiceAccountDeletionRecovery},
+		{"Validate rbac deletion recovery", componentCtx.ValidateRBACDeletionRecovery},
 		{"Validate component disabled", componentCtx.ValidateComponentDisabled},
 	}
 

--- a/tests/e2e/kserve_test.go
+++ b/tests/e2e/kserve_test.go
@@ -82,6 +82,11 @@ func kserveTestSuite(t *testing.T) {
 		{"Validate serving transition to Unmanaged", componentCtx.ValidateServingTransitionToUnmanaged},
 		{"Validate serving transition to Removed", componentCtx.ValidateServingTransitionToRemoved},
 		{"Validate component releases", componentCtx.ValidateComponentReleases},
+		{"Validate deployment deletion recovery", componentCtx.ValidateDeploymentDeletionRecovery},
+		{"Validate configmap deletion recovery", componentCtx.ValidateConfigMapDeletionRecovery},
+		{"Validate service deletion recovery", componentCtx.ValidateServiceDeletionRecovery},
+		{"Validate serviceaccount deletion recovery", componentCtx.ValidateServiceAccountDeletionRecovery},
+		{"Validate rbac deletion recovery", componentCtx.ValidateRBACDeletionRecovery},
 		{"Validate component disabled", componentCtx.ValidateComponentDisabled},
 	}
 

--- a/tests/e2e/kueue_test.go
+++ b/tests/e2e/kueue_test.go
@@ -47,6 +47,11 @@ func kueueTestSuite(t *testing.T) {
 		{"Validate CRDs reinstated", componentCtx.ValidateCRDReinstated},
 		{"Validate pre check", componentCtx.ValidateKueuePreCheck},
 		{"Validate component releases", componentCtx.ValidateComponentReleases},
+		{"Validate deployment deletion recovery", componentCtx.ValidateDeploymentDeletionRecovery},
+		{"Validate configmap deletion recovery", componentCtx.ValidateConfigMapDeletionRecovery},
+		{"Validate service deletion recovery", componentCtx.ValidateServiceDeletionRecovery},
+		{"Validate serviceaccount deletion recovery", componentCtx.ValidateServiceAccountDeletionRecovery},
+		{"Validate rbac deletion recovery", componentCtx.ValidateRBACDeletionRecovery},
 		{"Validate component disabled", componentCtx.ValidateComponentDisabled},
 	}
 

--- a/tests/e2e/llamastackoperator_test.go
+++ b/tests/e2e/llamastackoperator_test.go
@@ -28,6 +28,11 @@ func llamastackOperatorTestSuite(t *testing.T) {
 		{"Validate operands have OwnerReferences", componentCtx.ValidateOperandsOwnerReferences},
 		{"Validate update operand resources", componentCtx.ValidateUpdateDeploymentsResources},
 		{"Validate component releases", componentCtx.ValidateComponentReleases},
+		{"Validate deployment deletion recovery", componentCtx.ValidateDeploymentDeletionRecovery},
+		{"Validate configmap deletion recovery", componentCtx.ValidateConfigMapDeletionRecovery},
+		{"Validate service deletion recovery", componentCtx.ValidateServiceDeletionRecovery},
+		{"Validate serviceaccount deletion recovery", componentCtx.ValidateServiceAccountDeletionRecovery},
+		{"Validate rbac deletion recovery", componentCtx.ValidateRBACDeletionRecovery},
 		{"Validate component disabled", componentCtx.ValidateComponentDisabled},
 	}
 

--- a/tests/e2e/modelcontroller_test.go
+++ b/tests/e2e/modelcontroller_test.go
@@ -41,6 +41,11 @@ func modelControllerTestSuite(t *testing.T) {
 		{"Validate component enabled", componentCtx.ValidateComponentEnabled},
 		{"Validate operands have OwnerReferences", componentCtx.ValidateOperandsOwnerReferences},
 		{"Validate update operand resources", componentCtx.ValidateUpdateDeploymentsResources},
+		{"Validate deployment deletion recovery", componentCtx.ValidateDeploymentDeletionRecovery},
+		{"Validate configmap deletion recovery", componentCtx.ValidateConfigMapDeletionRecovery},
+		{"Validate service deletion recovery", componentCtx.ValidateServiceDeletionRecovery},
+		{"Validate serviceaccount deletion recovery", componentCtx.ValidateServiceAccountDeletionRecovery},
+		{"Validate rbac deletion recovery", componentCtx.ValidateRBACDeletionRecovery},
 		{"Validate component disabled", componentCtx.ValidateComponentDisabled},
 	}
 

--- a/tests/e2e/modelmeshserving_test.go
+++ b/tests/e2e/modelmeshserving_test.go
@@ -29,6 +29,11 @@ func modelMeshServingTestSuite(t *testing.T) {
 		{"Validate operands have OwnerReferences", componentCtx.ValidateOperandsOwnerReferences},
 		{"Validate update operand resources", componentCtx.ValidateUpdateDeploymentsResources},
 		{"Validate component releases", componentCtx.ValidateComponentReleases},
+		{"Validate deployment deletion recovery", componentCtx.ValidateDeploymentDeletionRecovery},
+		{"Validate configmap deletion recovery", componentCtx.ValidateConfigMapDeletionRecovery},
+		{"Validate service deletion recovery", componentCtx.ValidateServiceDeletionRecovery},
+		{"Validate serviceaccount deletion recovery", componentCtx.ValidateServiceAccountDeletionRecovery},
+		{"Validate rbac deletion recovery", componentCtx.ValidateRBACDeletionRecovery},
 		{"Validate component disabled", componentCtx.ValidateComponentDisabled},
 	}
 

--- a/tests/e2e/modelregistry_test.go
+++ b/tests/e2e/modelregistry_test.go
@@ -40,6 +40,11 @@ func modelRegistryTestSuite(t *testing.T) {
 		{"Validate cert should be created from default DSCI when servicmesh is Managed", componentCtx.ValidateModelRegistryCert},
 		{"Validate SMM only created if servicemesh is Managed", componentCtx.ValidateSMM},
 		{"Validate component releases", componentCtx.ValidateComponentReleases},
+		{"Validate deployment deletion recovery", componentCtx.ValidateDeploymentDeletionRecovery},
+		{"Validate configmap deletion recovery", componentCtx.ValidateConfigMapDeletionRecovery},
+		{"Validate service deletion recovery", componentCtx.ValidateServiceDeletionRecovery},
+		{"Validate serviceaccount deletion recovery", componentCtx.ValidateServiceAccountDeletionRecovery},
+		{"Validate rbac deletion recovery", componentCtx.ValidateRBACDeletionRecovery},
 		{"Validate component disabled", componentCtx.ValidateComponentDisabled},
 	}
 

--- a/tests/e2e/ray_test.go
+++ b/tests/e2e/ray_test.go
@@ -28,6 +28,11 @@ func rayTestSuite(t *testing.T) {
 		{"Validate operands have OwnerReferences", componentCtx.ValidateOperandsOwnerReferences},
 		{"Validate update operand resources", componentCtx.ValidateUpdateDeploymentsResources},
 		{"Validate component releases", componentCtx.ValidateComponentReleases},
+		{"Validate deployment deletion recovery", componentCtx.ValidateDeploymentDeletionRecovery},
+		{"Validate configmap deletion recovery", componentCtx.ValidateConfigMapDeletionRecovery},
+		{"Validate service deletion recovery", componentCtx.ValidateServiceDeletionRecovery},
+		{"Validate serviceaccount deletion recovery", componentCtx.ValidateServiceAccountDeletionRecovery},
+		{"Validate rbac deletion recovery", componentCtx.ValidateRBACDeletionRecovery},
 		{"Validate component disabled", componentCtx.ValidateComponentDisabled},
 	}
 

--- a/tests/e2e/trainingoperator_test.go
+++ b/tests/e2e/trainingoperator_test.go
@@ -28,6 +28,11 @@ func trainingOperatorTestSuite(t *testing.T) {
 		{"Validate operands have OwnerReferences", componentCtx.ValidateOperandsOwnerReferences},
 		{"Validate update operand resources", componentCtx.ValidateUpdateDeploymentsResources},
 		{"Validate component releases", componentCtx.ValidateComponentReleases},
+		{"Validate deployment deletion recovery", componentCtx.ValidateDeploymentDeletionRecovery},
+		{"Validate configmap deletion recovery", componentCtx.ValidateConfigMapDeletionRecovery},
+		{"Validate service deletion recovery", componentCtx.ValidateServiceDeletionRecovery},
+		{"Validate serviceaccount deletion recovery", componentCtx.ValidateServiceAccountDeletionRecovery},
+		{"Validate rbac deletion recovery", componentCtx.ValidateRBACDeletionRecovery},
 		{"Validate component disabled", componentCtx.ValidateComponentDisabled},
 	}
 

--- a/tests/e2e/trustyai_test.go
+++ b/tests/e2e/trustyai_test.go
@@ -41,6 +41,11 @@ func trustyAITestSuite(t *testing.T) {
 		{"Validate update operand resources", componentCtx.ValidateUpdateDeploymentsResources},
 		{"Validate component releases", componentCtx.ValidateComponentReleases},
 		{"Validate pre check", componentCtx.ValidateTrustyAIPreCheck},
+		{"Validate deployment deletion recovery", componentCtx.ValidateDeploymentDeletionRecovery},
+		{"Validate configmap deletion recovery", componentCtx.ValidateConfigMapDeletionRecovery},
+		{"Validate service deletion recovery", componentCtx.ValidateServiceDeletionRecovery},
+		{"Validate serviceaccount deletion recovery", componentCtx.ValidateServiceAccountDeletionRecovery},
+		{"Validate rbac deletion recovery", componentCtx.ValidateRBACDeletionRecovery},
 		{"Validate component disabled", componentCtx.ValidateComponentDisabled},
 	}
 

--- a/tests/e2e/workbenches_test.go
+++ b/tests/e2e/workbenches_test.go
@@ -30,6 +30,11 @@ func workbenchesTestSuite(t *testing.T) {
 		{"Validate operands have OwnerReferences", componentCtx.ValidateOperandsOwnerReferences},
 		{"Validate update operand resources", componentCtx.ValidateUpdateDeploymentsResources},
 		{"Validate component releases", componentCtx.ValidateComponentReleases},
+		{"Validate deployment deletion recovery", componentCtx.ValidateDeploymentDeletionRecovery},
+		{"Validate configmap deletion recovery", componentCtx.ValidateConfigMapDeletionRecovery},
+		{"Validate service deletion recovery", componentCtx.ValidateServiceDeletionRecovery},
+		{"Validate serviceaccount deletion recovery", componentCtx.ValidateServiceAccountDeletionRecovery},
+		{"Validate rbac deletion recovery", componentCtx.ValidateRBACDeletionRecovery},
 		{"Validate component disabled", componentCtx.ValidateComponentDisabled},
 	}
 


### PR DESCRIPTION
## Description
JIRA: [RHOAIENG-27721](https://issues.redhat.com/browse/RHOAIENG-27721)

This PR adds tests to the e2e test suite that verify that the odh-operator recreates the following types of resources that it manages when those resources are deleted:
- Deployments
- ConfigMaps
- Services
- Routes
- ServiceAccounts
- ClusterRoles
- ClusterRoleBindings
- Roles
- RoleBindings

This PR also fixes an issue where the `ray_controller` and `trainingoperator_controller` weren't watching Services when they should have been. This is required for the operator to recreate the `kuberay-operator` and `kubeflow-training-operator` Services if they get deleted.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced controllers to manage and track Kubernetes Service resources for improved reconciliation.
  * Expanded support for additional Kubernetes and OpenShift resource types.

* **Tests**
  * Added comprehensive end-to-end tests to validate automatic recovery after deletion of deployments, configmaps, services, service accounts, and RBAC resources across multiple components.
  * Improved test coverage for resource resilience and system recovery scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->