### PR TITLE
chore: uplift version + renegerate bundle + set metrics: {} into default DSCI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 2.30.0
+VERSION ?= 2.31.0
 # IMAGE_TAG_BASE defines the opendatahub.io namespace and part of the image name for remote images.
 # This variable is used to construct full image tags for bundle and catalog images.
 #

--- a/bundle/manifests/dscinitialization.opendatahub.io_dscinitializations.yaml
+++ b/bundle/manifests/dscinitialization.opendatahub.io_dscinitializations.yaml
@@ -174,8 +174,8 @@ spec:
                         type: object
                     type: object
                     x-kubernetes-validations:
-                    - message: Replicas can only be set when either Storage or Resources
-                        is configured
+                    - message: Replicas can only be set to non-zero value when either
+                        Storage or Resources is configured
                       rule: '!(self.storage == null && self.resources == null) ||
                         !has(self.replicas) || self.replicas == 0'
                   namespace:

--- a/bundle/manifests/opendatahub-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/opendatahub-operator.clusterserviceversion.yaml
@@ -92,6 +92,7 @@ metadata:
             "applicationsNamespace": "opendatahub",
             "monitoring": {
               "managementState": "Managed",
+              "metrics": {},
               "namespace": "opendatahub"
             },
             "serviceMesh": {
@@ -112,8 +113,8 @@ metadata:
     capabilities: Full Lifecycle
     categories: AI/Machine Learning, Big Data
     certified: "False"
-    containerImage: quay.io/opendatahub/opendatahub-operator:v2.30.0
-    createdAt: "2025-06-27T13:34:05Z"
+    containerImage: quay.io/opendatahub/opendatahub-operator:v2.31.0
+    createdAt: "2025-07-11T06:55:33Z"
     operators.operatorframework.io/builder: operator-sdk-v1.39.2
     operators.operatorframework.io/internal-objects: '["featuretrackers.features.opendatahub.io",
       "codeflares.components.platform.opendatahub.io", "dashboards.components.platform.opendatahub.io",
@@ -125,7 +126,7 @@ metadata:
       "feastoperators.components.platform.opendatahub.io", "llamastackoperators.components.platform.opendatahub.io"]'
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
     repository: https://github.com/opendatahub-io/opendatahub-operator
-  name: opendatahub-operator.v2.30.0
+  name: opendatahub-operator.v2.31.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -1450,7 +1451,7 @@ spec:
   selector:
     matchLabels:
       component: opendatahub-operator
-  version: 2.30.0
+  version: 2.31.0
   webhookdefinitions:
   - admissionReviewVersions:
     - v1

--- a/bundle/manifests/services.platform.opendatahub.io_monitorings.yaml
+++ b/bundle/manifests/services.platform.opendatahub.io_monitorings.yaml
@@ -122,8 +122,8 @@ spec:
                     type: object
                 type: object
                 x-kubernetes-validations:
-                - message: Replicas can only be set when either Storage or Resources
-                    is configured
+                - message: Replicas can only be set to non-zero value when either
+                    Storage or Resources is configured
                   rule: '!(self.storage == null && self.resources == null) || !has(self.replicas)
                     || self.replicas == 0'
               namespace:

--- a/config/manifests/bases/opendatahub-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/opendatahub-operator.clusterserviceversion.yaml
@@ -6,7 +6,7 @@ metadata:
     capabilities: Full Lifecycle
     categories: AI/Machine Learning, Big Data
     certified: "False"
-    containerImage: quay.io/opendatahub/opendatahub-operator:v2.30.0
+    containerImage: quay.io/opendatahub/opendatahub-operator:v2.31.0
     createdAt: "2025-6-10T00:00:00Z"
     operators.operatorframework.io/internal-objects: '["featuretrackers.features.opendatahub.io",
       "codeflares.components.platform.opendatahub.io", "dashboards.components.platform.opendatahub.io",
@@ -17,7 +17,7 @@ metadata:
       "workbenches.components.platform.opendatahub.io", "monitorings.services.platform.opendatahub.io","modelcontrollers.components.platform.opendatahub.io",
       "feastoperators.components.platform.opendatahub.io", "llamastackoperators.components.platform.opendatahub.io"]'
     repository: https://github.com/opendatahub-io/opendatahub-operator
-  name: opendatahub-operator.v2.30.0
+  name: opendatahub-operator.v2.31.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -158,4 +158,4 @@ spec:
   selector:
     matchLabels:
       component: opendatahub-operator
-  version: 2.30.0
+  version: 2.31.0

--- a/config/samples/dscinitialization_v1_dscinitialization.yaml
+++ b/config/samples/dscinitialization_v1_dscinitialization.yaml
@@ -12,6 +12,7 @@ spec:
   monitoring:
     managementState: "Managed"
     namespace: 'opendatahub'
+    metrics: {}
   applicationsNamespace: 'opendatahub'
   serviceMesh:
     controlPlane:

--- a/pkg/upgrade/upgrade.go
+++ b/pkg/upgrade/upgrade.go
@@ -226,6 +226,7 @@ func CreateDefaultDSCI(ctx context.Context, cli client.Client, _ common.Platform
 			ManagementSpec: common.ManagementSpec{ManagementState: operatorv1.Managed},
 			MonitoringCommonSpec: serviceApi.MonitoringCommonSpec{
 				Namespace: monNamespace,
+				Metrics:   &serviceApi.Metrics{},
 			},
 		},
 		ServiceMesh: &infrav1.ServiceMeshSpec{


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->
main change in the PR is about the default value in DSCI:
since we have defautl values set in the API this is causing any new cluster create DSCI from YAML like this
<img width="477" height="730" alt="Screenshot From 2025-07-11 09-17-16" src="https://github.com/user-attachments/assets/f37d216a-14bc-46de-9048-e6d752be0ba6" />
even we did not specify value in sample.
this PR is to explicity set it to {} for TP, we can remove this once get GA

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
build should give init Yaml as
<img width="407" height="755" alt="Screenshot From 2025-07-11 09-19-52" src="https://github.com/user-attachments/assets/52d4d32a-ac7d-440b-a1d4-7cb0b110f532" />


## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an empty `metrics` field under the monitoring section in DSCInitialization resource examples and default specifications.

* **Improvements**
  * Clarified validation messages for the `replicas` field, specifying that non-zero values require either Storage or Resources to be configured.
  * Updated operator version and related metadata to 2.31.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->