### PR TITLE
chore: fix integration tests comment trigger action

### DIFF
--- a/.github/workflows/add-pr-comment-test-trigger.yaml
+++ b/.github/workflows/add-pr-comment-test-trigger.yaml
@@ -5,28 +5,55 @@ on:
     types:
       - completed
 
-permissions:
-  pull-requests: write
-
 jobs:
-  add-pr-comment-to-trigger-tests:
-    name: Add PR comment to trigger integration tests
+  download-artifact-data:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
-    if: github.event.workflow_run.conclusion == 'success'
+    outputs:
+      pr_number: ${{ steps.artifact-data.outputs.pr_number }}
     steps:
-      - name: Add PR comment
+      - name: Download artifact
+        id: artifact-download-pr-info
         uses: actions/github-script@v7
         with:
           script: |
-            const owner = context.repo.owner;
-            const repo = context.repo.repo;
-            const issue_number = ${{ github.event.workflow_run.pull_requests[0].number }};
-              
-            const body = "/test-integration";
-              
-            await github.rest.issues.createComment({
-              owner,
-              repo,
-              issue_number,
-              body,
+            let allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: context.payload.workflow_run.id,
             });
+            
+            let matchArtifact = allArtifacts.data.artifacts.find(artifact => artifact.name == "pr_info");
+            if (!matchArtifact) {
+              core.setFailed("Could not find 'pr_info' artifact. Ensure that 'Build Catalog FBC and run Integration tests' had created it.");
+              return;
+            }
+
+            let download = await github.rest.actions.downloadArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: matchArtifact.id,
+               archive_format: 'zip',
+            });
+            let fs = require('fs');
+            fs.writeFileSync(`${process.env.GITHUB_WORKSPACE}/pr_info.zip`, Buffer.from(download.data));
+      - name: Unzip artifact
+        run: unzip pr_info.zip
+      - name: Extract data
+        id: artifact-data
+        run: |
+          echo "pr_number=$(head -n 1 pr_info.txt)" >> $GITHUB_OUTPUT
+
+  add-pr-comment-to-trigger-tests:
+    name: Add PR comment to trigger integration tests
+    needs: download-artifact-data
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Add comment to trigger integration tests
+        uses: thollander/actions-comment-pull-request@v3.0.1
+        with:
+          message: |
+            /test-integration
+          pr-number: ${{ needs.download-artifact-data.outputs.pr_number }}

--- a/.github/workflows/run-integration-tests.yaml
+++ b/.github/workflows/run-integration-tests.yaml
@@ -2,7 +2,7 @@ name: Build Catalog FBC and run Integration tests
 on:
   pull_request_target:
     # action steps require 'run-integration-tests' label to be present, otherwise it's skipped
-    types: [ synchronize, reopened, labeled ]
+    types: [ synchronize, reopened ]
     paths:
       - 'bundle/**'
       - 'cmd/**'
@@ -29,10 +29,6 @@ jobs:
   create-catalog-image:
     name: Build/push catalog image
     runs-on: ubuntu-latest
-    if: |
-      (github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'run-integration-tests')) ||
-      (github.event.action == 'reopened' && contains(github.event.pull_request.labels.*.name, 'run-integration-tests')) ||
-      (github.event.action == 'labeled' && github.event.label.name == 'run-integration-tests')
     needs: get-merge-commit
     env:
       IMAGE_BUILDER: podman
@@ -105,6 +101,18 @@ jobs:
           echo "version tag: ${{ env.VERSION_TAG }}"
           make catalog-build 
           make catalog-push
+      
+      - name: Save the PR data for GitHub artifact upload
+        run: |
+          echo ${{ github.event.number }} > pr_info.txt
+
+      - name: Upload the PR data as GitHub artifact
+        id: artifact-upload-pr-info
+        uses: actions/upload-artifact@v4
+        with:
+          name: pr_info
+          path: ./pr_info.txt
+          retention-days: 1
 
       - name: Report success and give further instructions
         run: |


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
Follow-up to #2139

Should fix the problem where the dependent action responsible for posting a test trigger PR comment was not working due to missing PR number. This solution now passes this PR number from the parent action via GH artifact

## How Has This Been Tested?
Tested locally on my fork

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
