### PR TITLE
update: remove CRB from OCP API, to only use it from rbac.authorization.k8s.io

### DIFF
--- a/bundle/manifests/opendatahub-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/opendatahub-operator.clusterserviceversion.yaml
@@ -114,7 +114,7 @@ metadata:
     categories: AI/Machine Learning, Big Data
     certified: "False"
     containerImage: quay.io/opendatahub/opendatahub-operator:v2.31.0
-    createdAt: "2025-07-11T06:55:33Z"
+    createdAt: "2025-07-15T15:42:11Z"
     operators.operatorframework.io/builder: operator-sdk-v1.39.2
     operators.operatorframework.io/internal-objects: '["featuretrackers.features.opendatahub.io",
       "codeflares.components.platform.opendatahub.io", "dashboards.components.platform.opendatahub.io",
@@ -349,16 +349,6 @@ spec:
           verbs:
           - create
           - get
-        - apiGroups:
-          - authorization.openshift.io
-          - rbac.authorization.k8s.io
-          resources:
-          - clusterrolebindings
-          - clusterroles
-          - rolebindings
-          - roles
-          verbs:
-          - '*'
         - apiGroups:
           - autoscaling
           resources:
@@ -1121,6 +1111,15 @@ spec:
           - patch
           - update
           - watch
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - clusterrolebindings
+          - clusterroles
+          - rolebindings
+          - roles
+          verbs:
+          - '*'
         - apiGroups:
           - route.openshift.io
           resources:

--- a/config/monitoring/prometheus/base/prometheus-rolebinding-scraper.yaml
+++ b/config/monitoring/prometheus/base/prometheus-rolebinding-scraper.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: authorization.openshift.io/v1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: prometheus-scraper

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -99,16 +99,6 @@ rules:
   - create
   - get
 - apiGroups:
-  - authorization.openshift.io
-  - rbac.authorization.k8s.io
-  resources:
-  - clusterrolebindings
-  - clusterroles
-  - rolebindings
-  - roles
-  verbs:
-  - '*'
-- apiGroups:
   - autoscaling
   resources:
   - horizontalpodautoscalers
@@ -870,6 +860,15 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterrolebindings
+  - clusterroles
+  - rolebindings
+  - roles
+  verbs:
+  - '*'
 - apiGroups:
   - route.openshift.io
   resources:

--- a/internal/controller/datasciencecluster/kubebuilder_rbac.go
+++ b/internal/controller/datasciencecluster/kubebuilder_rbac.go
@@ -91,11 +91,6 @@ package datasciencecluster
 
 // +kubebuilder:rbac:groups="cert-manager.io",resources=certificates;issuers,verbs=create;patch
 
-// +kubebuilder:rbac:groups="authorization.openshift.io",resources=roles,verbs=*
-// +kubebuilder:rbac:groups="authorization.openshift.io",resources=rolebindings,verbs=*
-// +kubebuilder:rbac:groups="authorization.openshift.io",resources=clusterroles,verbs=*
-// +kubebuilder:rbac:groups="authorization.openshift.io",resources=clusterrolebindings,verbs=*
-
 // +kubebuilder:rbac:groups="apps",resources=replicasets,verbs=*
 // +kubebuilder:rbac:groups="*",resources=replicasets,verbs=*
 

--- a/pkg/cluster/gvk/gvk.go
+++ b/pkg/cluster/gvk/gvk.go
@@ -86,12 +86,6 @@ var (
 		Kind:    "Deployment",
 	}
 
-	OpenShiftClusterRole = schema.GroupVersionKind{
-		Group:   "authorization.openshift.io",
-		Version: "v1",
-		Kind:    "ClusterRole",
-	}
-
 	ClusterRole = schema.GroupVersionKind{
 		Group:   rbacv1.SchemeGroupVersion.Group,
 		Version: rbacv1.SchemeGroupVersion.Version,


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->
remove refernce where uses authorization.openshift.io
to only use  rbac.authorization.k8s.io

<!--- Link your JIRA and related links here for reference. -->
ref : https://issues.redhat.com/browse/RHOAIENG-28852 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated permissions to remove references to the deprecated OpenShift API group and standardize on the Kubernetes RBAC API group for role and role binding management.
  * Updated resource definitions to use the standard Kubernetes RBAC API version.
  * Cleaned up internal configurations and metadata to reflect these changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->