### PR TITLE
RHOAIENG-27559: Fix webhook CABundle injection and service naming - POC

### DIFF
--- a/internal/controller/dscinitialization/dscinitialization_test.go
+++ b/internal/controller/dscinitialization/dscinitialization_test.go
@@ -98,7 +98,7 @@ var _ = Describe("DataScienceCluster initialization", func() {
 			vwc := &admissionregistrationv1.ValidatingWebhookConfiguration{}
 			Eventually(func() bool {
 				err := k8sClient.Get(ctx, client.ObjectKey{
-					Name: webhook.ValidatingWebhookConfigurationName,
+					Name: webhook.ValidatingWebhookConfigName,
 				}, vwc)
 				return err == nil
 			}, timeout, interval).Should(BeTrue(), "Expected ValidatingWebhookConfiguration to be present")

--- a/internal/controller/dscinitialization/suite_test.go
+++ b/internal/controller/dscinitialization/suite_test.go
@@ -143,8 +143,8 @@ var _ = BeforeSuite(func() {
 	webhookInstallOptions := &testEnv.WebhookInstallOptions
 
 	// Set env for webhook to work
-	os.Setenv("ENVTEST_WEBHOOK_LOCAL_PORT", strconv.Itoa(webhookInstallOptions.LocalServingPort))
-	os.Setenv("ENVTEST_WEBHOOK_LOCAL_CERT_DIR", webhookInstallOptions.LocalServingCertDir)
+	os.Setenv(webhook.EnvtestWebhookLocalPort, strconv.Itoa(webhookInstallOptions.LocalServingPort))
+	os.Setenv(webhook.EnvtestWebhookLocalCertDir, webhookInstallOptions.LocalServingCertDir)
 
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		Scheme:         testScheme,
@@ -187,6 +187,4 @@ var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	err := testEnv.Stop()
 	Expect(err).NotTo(HaveOccurred())
-	os.Unsetenv("ENVTEST_WEBHOOK_LOCAL_PORT")
-	os.Unsetenv("ENVTEST_WEBHOOK_LOCAL_CERT_DIR")
 })

--- a/internal/webhook/kueue/integration_test.go
+++ b/internal/webhook/kueue/integration_test.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"os"
 	"testing"
 	"time"
 
@@ -30,13 +29,6 @@ var (
 )
 
 func TestKueueWebhook_Integration(t *testing.T) {
-	t.Parallel()
-
-	t.Cleanup(func() {
-		os.Unsetenv("ENVTEST_WEBHOOK_LOCAL_PORT")
-		os.Unsetenv("ENVTEST_WEBHOOK_LOCAL_CERT_DIR")
-	})
-
 	testCases := []struct {
 		name              string
 		kueueState        operatorv1.ManagementState

--- a/internal/webhook/manager.go
+++ b/internal/webhook/manager.go
@@ -8,16 +8,20 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"strings"
+	"sync"
+	"time"
 
+	"github.com/go-logr/logr"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	kueuewebhook "github.com/opendatahub-io/opendatahub-operator/v2/internal/webhook/kueue"
-	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
 	gvk "github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
 )
 
@@ -26,259 +30,455 @@ import (
 // - ray.io/v1: rayjobs, rayclusters
 // - serving.kserve.io/v1beta1: inferenceservices
 
+// Webhook service and configuration names.
 const (
-	WebhookServiceName                 = "opendatahub-operator-webhook-service"
-	ValidatingWebhookConfigurationName = "opendatahub-operator-validating-webhook-configuration"
-	AdmissionReviewVersion             = "v1"
-	WebhookManagerName                 = "WebhookManager"
+	AdmissionReviewVersion      = "v1"
+	WebhookManagerName          = "WebhookManager"
+	ValidatingWebhookConfigName = "kueuelabels-validator.opendatahub.io"
 )
 
+// Webhook specific names.
 const (
-	// Webhook names.
 	KserveKueuelabelsValidatorName   = "kserve-kueuelabels-validator.opendatahub.io"
 	KubeflowKueuelabelsValidatorName = "kubeflow-kueuelabels-validator.opendatahub.io"
 	RayKueuelabelsValidatorName      = "ray-kueuelabels-validator.opendatahub.io"
 )
 
+// Webhook specific labels.
 const (
-	// InjectCabundleAnnotation is the annotation to inject the CA bundle into the webhook.
-	InjectCabundleAnnotation = "service.beta.openshift.io/inject-cabundle"
 	// KueueManagedLabelKey indicates a namespace is managed by Kueue.
 	KueueManagedLabelKey = "kueue.openshift.io/managed"
 	// KueueLegacyManagedLabelKey is the legacy label key used to indicate a namespace is managed by Kueue.
 	KueueLegacyManagedLabelKey = "kueue-managed"
 )
 
-func newWebhookClientConfigForEnvtest(path string, localPort string, localCertDir string) admissionregistrationv1.WebhookClientConfig {
-	// Detected running under envtest/integration tests
-	// Read the CA bundle from the local cert directory
-	certPath := filepath.Join(localCertDir, "tls.crt")
-	cert, err := os.ReadFile(certPath)
-	if err != nil {
-		panic(fmt.Sprintf("failed to read webhook cert at %s: %v", certPath, err))
-	}
+// Envtest mode environment variables.
+const (
+	EnvtestWebhookLocalPort    = "ENVTEST_WEBHOOK_LOCAL_PORT"
+	EnvtestWebhookLocalCertDir = "ENVTEST_WEBHOOK_LOCAL_CERT_DIR"
+)
 
-	// Construct the URL with the local port and path
-	url := "https://" + net.JoinHostPort("localhost", localPort) + path
-	return admissionregistrationv1.WebhookClientConfig{
-		URL:      &url,
-		CABundle: cert,
+// clientConfigCacheTTL defines how long the clientConfig is cached.
+const clientConfigCacheTTL = 5 * time.Minute
+
+// Pre-compiled constants to reduce allocations.
+var (
+	sideEffectsNone   = admissionregistrationv1.SideEffectClassNone
+	failurePolicyFail = admissionregistrationv1.Fail
+	createUpdateOps   = []admissionregistrationv1.OperationType{admissionregistrationv1.Create, admissionregistrationv1.Update}
+	admissionVersions = []string{AdmissionReviewVersion}
+	trueValues        = []string{"true"}
+	labelSelectorOpIn = metav1.LabelSelectorOpIn
+	// TODO: Remove this once we have a better way to fetch clientConfig.
+	// Include webhook names to fetch clientConfig.
+	IncludeWebhookNames = []string{"validating-webhook-configuration", "opendatahub.io"}
+	// Exclude webhook names to fetch clientConfig.
+	ExcludeWebhookNames = []string{"validating.odh-model-controller.opendatahub.io"}
+)
+
+// envVars holds cached environment variable values.
+type envVars struct {
+	localPort     string
+	localCertDir  string
+	isEnvtestMode bool
+}
+
+// getEnvVars returns current environment variables.
+func getEnvVars() envVars {
+	localPort := os.Getenv(EnvtestWebhookLocalPort)
+	localCertDir := os.Getenv(EnvtestWebhookLocalCertDir)
+	return envVars{
+		localPort:     localPort,
+		localCertDir:  localCertDir,
+		isEnvtestMode: localPort != "",
 	}
 }
 
-// newWebhookClientConfig creates a ClientConfig for the webhook.
-//
-// Parameters:
-//   - path: The path to the webhook
-//   - namespace: The namespace where the webhook is located
-//
-// Returns:
-//   - admissionregistrationv1.WebhookClientConfig: The ClientConfig for the webhook
-func newWebhookClientConfig(
-	path string,
-	namespace string,
-) admissionregistrationv1.WebhookClientConfig {
-	// Envtest mode: use URL with CA bundle
-	localPort := os.Getenv("ENVTEST_WEBHOOK_LOCAL_PORT")
-	localCertDir := os.Getenv("ENVTEST_WEBHOOK_LOCAL_CERT_DIR")
+// webhookSpec defines the specification for a single webhook.
+type webhookSpec struct {
+	name      string
+	apiGroups []string
+	versions  []string
+	resources []string
+}
 
-	if localPort != "" && localCertDir != "" {
-		return newWebhookClientConfigForEnvtest(path, localPort, localCertDir)
+// kueueWebhookSpecs contains all the webhook specifications for Kueue validation.
+var kueueWebhookSpecs = []webhookSpec{
+	{
+		name:      KserveKueuelabelsValidatorName,
+		apiGroups: []string{gvk.InferenceServices.Group},
+		versions:  []string{gvk.InferenceServices.Version},
+		resources: []string{"inferenceservices"},
+	},
+	{
+		name:      KubeflowKueuelabelsValidatorName,
+		apiGroups: []string{"kubeflow.org"},
+		versions:  []string{"v1"},
+		resources: []string{"pytorchjobs", "notebooks"},
+	},
+	{
+		name:      RayKueuelabelsValidatorName,
+		apiGroups: []string{"ray.io"},
+		versions:  []string{"v1"},
+		resources: []string{"rayjobs", "rayclusters"},
+	},
+}
+
+// clientConfigCache provides a simple in-memory cache for clientConfig to reduce API calls.
+type clientConfigCache struct {
+	mu     sync.RWMutex
+	config *admissionregistrationv1.WebhookClientConfig
+	expiry time.Time
+}
+
+// globalClientConfigCache is a global cache instance for clientConfig.
+var globalClientConfigCache = &clientConfigCache{}
+
+// isValid checks if the cached clientConfig is still valid
+func (c *clientConfigCache) isValid() bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.config != nil &&
+		time.Now().Before(c.expiry)
+}
+
+// get returns the cached clientConfig if valid.
+func (c *clientConfigCache) get() *admissionregistrationv1.WebhookClientConfig {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	// Return a copy to prevent external modifications
+	if c.config != nil {
+		// Perform a deep copy of the clientConfig
+		copiedConfig := &admissionregistrationv1.WebhookClientConfig{
+			CABundle: make([]byte, len(c.config.CABundle)),
+			Service:  nil,
+			URL:      nil,
+		}
+		copy(copiedConfig.CABundle, c.config.CABundle)
+		if c.config.Service != nil {
+			copiedConfig.Service = &admissionregistrationv1.ServiceReference{
+				Name:      c.config.Service.Name,
+				Namespace: c.config.Service.Namespace,
+				Path:      c.config.Service.Path,
+				Port:      c.config.Service.Port,
+			}
+		}
+		if c.config.URL != nil {
+			copiedConfig.URL = c.config.URL
+		}
+		return copiedConfig
 	}
+	return nil
+}
 
-	// Production mode: use ServiceRef with CA injection
-	return admissionregistrationv1.WebhookClientConfig{
-		Service: &admissionregistrationv1.ServiceReference{
-			Name:      WebhookServiceName,
-			Namespace: namespace,
-			Path:      &path,
-		},
+// set stores a new clientConfig in the cache.
+func (c *clientConfigCache) set(cfg *admissionregistrationv1.WebhookClientConfig) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	// Store a copy to prevent external modifications
+	c.config = &admissionregistrationv1.WebhookClientConfig{
+		CABundle: make([]byte, len(cfg.CABundle)),
+		Service:  nil,
+		URL:      nil,
+	}
+	copy(c.config.CABundle, cfg.CABundle)
+	if cfg.Service != nil {
+		c.config.Service = &admissionregistrationv1.ServiceReference{
+			Name:      cfg.Service.Name,
+			Namespace: cfg.Service.Namespace,
+			Path:      cfg.Service.Path,
+			Port:      cfg.Service.Port,
+		}
+	}
+	if cfg.URL != nil {
+		c.config.URL = cfg.URL
+	}
+	c.expiry = time.Now().Add(clientConfigCacheTTL)
+}
+
+// WebhookOption is a function type for configuring ValidatingWebhook instances.
+type WebhookOption func(*admissionregistrationv1.ValidatingWebhook)
+
+// WithName sets the webhook name.
+func WithName(name string) WebhookOption {
+	return func(w *admissionregistrationv1.ValidatingWebhook) {
+		w.Name = name
 	}
 }
 
-// newValidatingWebhook creates a base ValidatingWebhook object.
-//
-// Parameters:
-//   - name: The name of the webhook
-//   - namespace: The namespace where the webhook is located
-//   - path: The path to the webhook
-//   - rules: The rules for the webhook
-//   - namespaceSelector: The namespace selector for the webhook
-//
-// Returns:
-//   - admissionregistrationv1.ValidatingWebhook: The ValidatingWebhook object
-func newValidatingWebhook(
-	name string,
-	namespace string,
-	path string,
-	rules []admissionregistrationv1.RuleWithOperations,
-	namespaceSelector *metav1.LabelSelector,
-) admissionregistrationv1.ValidatingWebhook {
-	sideEffects := admissionregistrationv1.SideEffectClassNone
-	failurePolicyFail := admissionregistrationv1.Fail
-	return admissionregistrationv1.ValidatingWebhook{
-		Name:                    name,
-		AdmissionReviewVersions: []string{AdmissionReviewVersion},
-		ClientConfig:            newWebhookClientConfig(path, namespace),
+// WithClientConfig sets the webhook client configuration.
+func WithClientConfig(cfg *admissionregistrationv1.WebhookClientConfig) WebhookOption {
+	return func(w *admissionregistrationv1.ValidatingWebhook) {
+		w.ClientConfig = *cfg
+	}
+}
+
+// WithRules sets the webhook rules for specific API resources.
+func WithRules(apiGroups, versions, resources []string) WebhookOption {
+	return func(w *admissionregistrationv1.ValidatingWebhook) {
+		w.Rules = []admissionregistrationv1.RuleWithOperations{
+			{
+				Operations: createUpdateOps,
+				Rule: admissionregistrationv1.Rule{
+					APIGroups:   apiGroups,
+					APIVersions: versions,
+					Resources:   resources,
+				},
+			},
+		}
+	}
+}
+
+// WithNamespaceSelector sets the namespace selector for the webhook.
+func WithNamespaceSelector(labelKey string) WebhookOption {
+	return func(w *admissionregistrationv1.ValidatingWebhook) {
+		w.NamespaceSelector = &metav1.LabelSelector{
+			MatchExpressions: []metav1.LabelSelectorRequirement{
+				{Key: labelKey, Operator: labelSelectorOpIn, Values: trueValues},
+			},
+		}
+	}
+}
+
+// NewValidatingWebhook creates a ValidatingWebhook with the given options.
+func NewValidatingWebhook(options ...WebhookOption) admissionregistrationv1.ValidatingWebhook {
+	webhook := admissionregistrationv1.ValidatingWebhook{
+		AdmissionReviewVersions: admissionVersions,
 		FailurePolicy:           &failurePolicyFail,
-		Rules:                   rules,
-		SideEffects:             &sideEffects,
-		NamespaceSelector:       namespaceSelector,
+		SideEffects:             &sideEffectsNone,
 	}
+	// Apply all options
+	for _, option := range options {
+		option(&webhook)
+	}
+	return webhook
 }
 
-// getDesiredKueueValidatingWebhooks defines the Kueue-related validating webhooks.
-// This implements the OR logic for namespace selection by creating multiple webhook entries explicitly.
-// Parameters:
-//   - namespace: The namespace where the webhook is located
-//   - labelKey: The label key to use for the namespace selector (e.g., KueueManagedLabelKey or KueueManagedOldLabelKey)
-//   - suffix: A suffix to append to the webhook name for uniqueness "-legacy"
-//
-// Returns:
-//   - []admissionregistrationv1.ValidatingWebhook: A slice of ValidatingWebhook objects for Kueue
-//
-// caBundle parameter has been removed as per your request.
-func getDesiredKueueValidatingWebhooks(namespace string, labelKey string, suffix string) []admissionregistrationv1.ValidatingWebhook {
-	return []admissionregistrationv1.ValidatingWebhook{
-		newValidatingWebhook(
-			KserveKueuelabelsValidatorName+suffix,
-			namespace,
-			kueuewebhook.ValidateKueuePath,
-			[]admissionregistrationv1.RuleWithOperations{
-				{
-					Operations: []admissionregistrationv1.OperationType{admissionregistrationv1.Create, admissionregistrationv1.Update},
-					Rule: admissionregistrationv1.Rule{
-						APIGroups:   []string{gvk.InferenceServices.Group},
-						APIVersions: []string{gvk.InferenceServices.Version},
-						Resources:   []string{"inferenceservices"},
-					},
-				},
-			},
-			&metav1.LabelSelector{
-				MatchExpressions: []metav1.LabelSelectorRequirement{
-					{Key: labelKey, Operator: metav1.LabelSelectorOpIn, Values: []string{"true"}},
-				},
-			},
-		),
-
-		newValidatingWebhook(
-			KubeflowKueuelabelsValidatorName+suffix,
-			namespace,
-			kueuewebhook.ValidateKueuePath,
-			[]admissionregistrationv1.RuleWithOperations{
-				{
-					Operations: []admissionregistrationv1.OperationType{admissionregistrationv1.Create, admissionregistrationv1.Update},
-					Rule: admissionregistrationv1.Rule{
-						APIGroups:   []string{gvk.Notebook.Group},
-						APIVersions: []string{gvk.Notebook.Version},
-						Resources:   []string{"pytorchjobs", "notebooks"},
-					},
-				},
-			},
-			&metav1.LabelSelector{
-				MatchExpressions: []metav1.LabelSelectorRequirement{
-					{Key: labelKey, Operator: metav1.LabelSelectorOpIn, Values: []string{"true"}},
-				},
-			},
-		),
-
-		newValidatingWebhook(
-			RayKueuelabelsValidatorName+suffix,
-			namespace,
-			kueuewebhook.ValidateKueuePath,
-			[]admissionregistrationv1.RuleWithOperations{
-				{
-					Operations: []admissionregistrationv1.OperationType{admissionregistrationv1.Create, admissionregistrationv1.Update},
-					Rule: admissionregistrationv1.Rule{
-						APIGroups:   []string{gvk.Ray.Group},
-						APIVersions: []string{gvk.Ray.Version},
-						Resources:   []string{"rayjobs", "rayclusters"},
-					},
-				},
-			},
-			&metav1.LabelSelector{
-				MatchExpressions: []metav1.LabelSelectorRequirement{
-					{Key: labelKey, Operator: metav1.LabelSelectorOpIn, Values: []string{"true"}},
-				},
-			},
-		),
-	}
-}
-
-// DesiredValidatingWebhookConfiguration defines the desired state of the ValidatingWebhookConfiguration.
-//
-// Parameters:
-//   - namespace: The namespace where the webhook is located
-//
-// Returns:
-//   - *admissionregistrationv1.ValidatingWebhookConfiguration: The ValidatingWebhookConfiguration object
-func DesiredValidatingWebhookConfiguration(namespace string) *admissionregistrationv1.ValidatingWebhookConfiguration {
+// NewValidatingWebhookConfiguration defines the desired state of the ValidatingWebhookConfiguration.
+func NewValidatingWebhookConfiguration(
+	clientConfig *admissionregistrationv1.WebhookClientConfig,
+) *admissionregistrationv1.ValidatingWebhookConfiguration {
 	vwc := &admissionregistrationv1.ValidatingWebhookConfiguration{
-		// TypeMeta is required for the SSA
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "ValidatingWebhookConfiguration",
 			APIVersion: "admissionregistration.k8s.io/v1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name: ValidatingWebhookConfigurationName,
-			Annotations: map[string]string{
-				InjectCabundleAnnotation: "true",
-			},
+			Name: ValidatingWebhookConfigName,
 		},
 		Webhooks: []admissionregistrationv1.ValidatingWebhook{},
 	}
 
-	vwc.Webhooks = append(vwc.Webhooks, getDesiredKueueValidatingWebhooks(namespace, KueueManagedLabelKey, "")...)
-	// TODO: Remove this once we drop support for the legacy label
-	vwc.Webhooks = append(vwc.Webhooks, getDesiredKueueValidatingWebhooks(namespace, KueueLegacyManagedLabelKey, "-legacy")...)
+	for _, spec := range kueueWebhookSpecs {
+		webhook := NewValidatingWebhook(
+			WithName(spec.name),
+			WithClientConfig(clientConfig),
+			WithRules(spec.apiGroups, spec.versions, spec.resources),
+			WithNamespaceSelector(KueueManagedLabelKey),
+		)
+		vwc.Webhooks = append(vwc.Webhooks, webhook)
+	}
+
+	// Include legacy label webhooks
+	for _, spec := range kueueWebhookSpecs {
+		webhook := NewValidatingWebhook(
+			WithName(spec.name+"-legacy"),
+			WithClientConfig(clientConfig),
+			WithRules(spec.apiGroups, spec.versions, spec.resources),
+			WithNamespaceSelector(KueueLegacyManagedLabelKey),
+		)
+		vwc.Webhooks = append(vwc.Webhooks, webhook)
+	}
 
 	return vwc
 }
 
-// ReconcileWebhooks manages the creation and update of MutatingWebhookConfiguration and ValidatingWebhookConfiguration resources.
-// It takes the owner object (e.g., DSCInitialization instance) to set owner references for garbage collection.
-//
-// Parameters:
-//   - ctx: The context for the API call
-//   - c: The client to use for the API call
-//   - scheme: The scheme to use for the API call
-//   - owner: The owner object to set owner references for garbage collection
-//
-// Returns:
-//   - error: Any error encountered while reconciling the webhooks
-func ReconcileWebhooks(ctx context.Context, c client.Client, scheme *runtime.Scheme, owner metav1.Object) error {
-	log := logf.FromContext(ctx).WithName(WebhookManagerName)
+// getClientConfigForEnvtest returns the client config for the envtest mode.
+func GetClientConfigForEnvtest(localCertDir string, localPort string) *admissionregistrationv1.WebhookClientConfig {
+	url := "https://" + net.JoinHostPort("localhost", localPort) + kueuewebhook.ValidateKueuePath
+	caBundle := readEnvtestCert(localCertDir)
 
-	operatorNs, err := cluster.GetOperatorNamespace()
-	if err != nil || operatorNs == "" {
-		// falling back for testing and envtest cases
-		operatorNs = os.Getenv("OPERATOR_NAMESPACE")
+	return &admissionregistrationv1.WebhookClientConfig{
+		URL:      &url,
+		CABundle: caBundle,
+	}
+}
+
+func readEnvtestCert(localCertDir string) []byte {
+	certPath := filepath.Join(localCertDir, "tls.crt")
+	caBundle, err := os.ReadFile(certPath)
+	if err != nil {
+		panic(fmt.Sprintf("failed to read webhook cert at %s: %v", certPath, err))
+	}
+	return caBundle
+}
+
+// getSourceClientConfig retrieves the source client config, either from envtest or from an existing ValidatingWebhookConfiguration.
+func getSourceClientConfig(
+	ctx context.Context, c client.Client, log logr.Logger,
+) (*admissionregistrationv1.WebhookClientConfig, error) {
+	env := getEnvVars()
+	if env.isEnvtestMode {
+		return GetClientConfigForEnvtest(env.localCertDir, env.localPort), nil
 	}
 
-	// Define desired MutatingWebhookConfiguration and ValidatingWebhookConfiguration
-	validatingWebhookConfig := DesiredValidatingWebhookConfiguration(operatorNs)
+	if globalClientConfigCache.isValid() {
+		log.Info("Using cached clientConfig for webhook reconciliation")
+		return globalClientConfigCache.get(), nil
+	}
 
-	// Set owner references to the owner object (e.g., DSCInitialization instance)
-	// Kubernetes will delete these webhooks when the owner object is deleted.
-	if err := controllerutil.SetOwnerReference(owner, validatingWebhookConfig, scheme); err != nil {
+	existingVWCs, err := listValidatingWebhookConfigurations(ctx, c, log)
+	if err != nil {
+		return nil, err
+	}
+
+	return extractClientConfigFromVWCs(existingVWCs, log), nil
+}
+
+func listValidatingWebhookConfigurations(
+	ctx context.Context, c client.Client, log logr.Logger,
+) (*admissionregistrationv1.ValidatingWebhookConfigurationList, error) {
+	vwcList := &admissionregistrationv1.ValidatingWebhookConfigurationList{}
+	if err := c.List(ctx, vwcList); err != nil {
+		log.Error(err, "Failed to list ValidatingWebhookConfigurations")
+		return nil, err
+	}
+	return vwcList, nil
+}
+
+func extractClientConfigFromVWCs(
+	vwcList *admissionregistrationv1.ValidatingWebhookConfigurationList,
+	log logr.Logger,
+) *admissionregistrationv1.WebhookClientConfig {
+	for _, vwc := range vwcList.Items {
+		// Skip webhook configurations that are in exclude lists or
+		// not in include lists or the current webhook configuration.
+		if !matchesAnySubstring(vwc.Name, IncludeWebhookNames) ||
+			matchesAnySubstring(vwc.Name, ExcludeWebhookNames) ||
+			vwc.Name == ValidatingWebhookConfigName {
+			continue
+		}
+
+		log.Info("Found source ValidatingWebhookConfiguration", "name", vwc.Name)
+
+		if len(vwc.Webhooks) == 0 {
+			log.Info("Source ValidatingWebhookConfiguration has no webhooks", "name", vwc.Name)
+			continue
+		}
+
+		clientConfig := vwc.Webhooks[0].ClientConfig
+		if !hasValidClientConfig(clientConfig) {
+			log.Info("Source ValidatingWebhookConfiguration has invalid or missing clientConfig", "name", vwc.Name)
+			continue
+		}
+
+		adjustedClientConfig := buildAdjustedClientConfig(clientConfig)
+		globalClientConfigCache.set(adjustedClientConfig)
+
+		log.Info("Successfully extracted clientConfig from source webhook", "sourceWebhookName", vwc.Webhooks[0].Name)
+		return adjustedClientConfig
+	}
+
+	return nil
+}
+
+func hasValidClientConfig(clientConfig admissionregistrationv1.WebhookClientConfig) bool {
+	return len(clientConfig.CABundle) > 0 || clientConfig.Service != nil || clientConfig.URL != nil
+}
+
+func buildAdjustedClientConfig(original admissionregistrationv1.WebhookClientConfig) *admissionregistrationv1.WebhookClientConfig {
+	pathStr := kueuewebhook.ValidateKueuePath
+	return &admissionregistrationv1.WebhookClientConfig{
+		CABundle: original.CABundle,
+		Service: func() *admissionregistrationv1.ServiceReference {
+			if original.Service == nil {
+				return nil
+			}
+			return &admissionregistrationv1.ServiceReference{
+				Name:      original.Service.Name,
+				Namespace: original.Service.Namespace,
+				Path:      &pathStr,
+				Port:      original.Service.Port,
+			}
+		}(),
+		URL: original.URL,
+	}
+}
+
+// ReconcileWebhooks manages the creation and update of MutatingWebhookConfiguration and ValidatingWebhookConfiguration resources.
+// It takes the owner object (e.g., DSCInitialization instance) to set owner references for garbage collection.
+func ReconcileWebhooks(ctx context.Context, c client.Client, scheme *runtime.Scheme, owner metav1.Object) (ctrl.Result, error) {
+	log := logf.FromContext(ctx).WithName(WebhookManagerName)
+
+	// Get the source client config
+	sourceClientConfig, err := getSourceClientConfig(ctx, c, log)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	if sourceClientConfig == nil {
+		log.Info(
+			"No ValidatingWebhookConfiguration found with substring 'opendatahub' and a valid clientConfig. Requeuing...",
+		)
+		return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
+	}
+
+	// Create the new ValidatingWebhookConfiguration using the extracted clientConfig
+	newValidatingWebhookConfig := NewValidatingWebhookConfiguration(sourceClientConfig)
+
+	// Set owner references
+	if err := setOwnerReference(owner, newValidatingWebhookConfig, scheme, log); err != nil {
+		return ctrl.Result{}, err
+	}
+
+	// Apply webhook configuration
+	if err := applyWebhookConfiguration(ctx, c, newValidatingWebhookConfig, log); err != nil {
+		return ctrl.Result{}, err
+	}
+
+	log.Info(
+		"New webhook configuration reconciled successfully.",
+		"name", ValidatingWebhookConfigName,
+	)
+	return ctrl.Result{}, nil
+}
+
+// setOwnerReference sets the owner reference on the webhook configuration.
+func setOwnerReference(
+	owner metav1.Object,
+	config *admissionregistrationv1.ValidatingWebhookConfiguration,
+	scheme *runtime.Scheme,
+	log logr.Logger,
+) error {
+	if err := controllerutil.SetOwnerReference(owner, config, scheme); err != nil {
 		log.Error(err, "Failed to set owner reference for ValidatingWebhookConfiguration")
 		return err
 	}
+	return nil
+}
 
+// applyWebhookConfiguration applies the webhook configuration using server-side apply.
+func applyWebhookConfiguration(ctx context.Context, c client.Client, config *admissionregistrationv1.ValidatingWebhookConfiguration, log logr.Logger) error {
+	// Create the ValidatingWebhookConfiguration
+	// Important: For SSA, you should pass a desired object without ResourceVersion or ManagedFields
+	config.SetResourceVersion("")
+	config.SetManagedFields(nil)
 	applyOpts := []client.PatchOption{
 		client.ForceOwnership,
 		client.FieldOwner(WebhookManagerName),
 	}
-
-	// Create the ValidatingWebhookConfiguration
-	// Important: For SSA, you should pass a desired object without ResourceVersion or ManagedFields
-	validatingWebhookConfig.SetResourceVersion("")
-	validatingWebhookConfig.SetManagedFields(nil)
-	if err := c.Patch(ctx, validatingWebhookConfig, client.Apply, applyOpts...); err != nil {
+	if err := c.Patch(ctx, config, client.Apply, applyOpts...); err != nil {
 		log.Error(err, "Failed to apply ValidatingWebhookConfiguration via SSA")
 		return err
 	}
-
-	log.Info("Webhook configurations reconciled successfully.")
 	return nil
+}
+
+// matchesAnySubstring checks if the given name contains any of the provided substrings.
+func matchesAnySubstring(name string, substrings []string) bool {
+	for _, sub := range substrings {
+		if strings.Contains(name, sub) {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
## Description
This PR addresses issues introduced in [#2123](https://github.com/opendatahub-io/opendatahub-operator/pull/2123).
**Background:**

**When using a WebhookDefinition in a CSV, OLM automatically:**
* Creates a new service and certificate secret for webhook configurations.
* Uses TLS from this generated secret as the CA bundle in webhook configurations.

**OLM-based webhook configuration:**
* Service Name: opendatahub-operator-controller-manager-service
* Secret Name: opendatahub-operator-controller-manager-service-cert (<service-name>-cert)
* Deployment Volume: webhook-cert

**Using make deploy:**

* Service Name: opendatahub-operator-webhook-service
* Secret Name: opendatahub-operator-controller-webhook-cert
* Deployment Volume: cert

**Problem:**
**For reconcile-based Kueue webhooks:**
* The webhook configuration must use the OLM-generated CA bundle secret (-service-cert) when installed via OperatorHub.
* For local make deploy, it needs to use the -webhook-cert secret.
* Due to different service and secret names across deployment methods, webhook reconciliation(code-based kueue webhook config creation) could not reliably set up the webhook configurations.

**Solution in this PR:**
**Standardized service and secret naming to align with the OLM convention:**
* Service created using the controller name.
* Secret named as <service-name>-cert.
* Renamed the volume from cert to webhook-cert:
* Ensures no extra volume is created during OLM installs.
* During make deploy, webhook-cert is mounted to consume the certificate secret.
* During OLM installs, OLM overwrites the same volume with its generated certificate secret.
* This ensures consistent service, secret, and volume management across both OLM and make deploy installations, enabling reliable webhook configuration reconciliation in all deployment paths.

Issue: [RHOAIENG-27559](https://issues.redhat.com/browse/RHOAIENG-27559)

## How Has This Been Tested?
✅ Verified that ValidatingWebhookConfiguration and MutatingWebhookConfiguration are auto-created when the DSCInitialization CR is created.
✅ Updated all webhook-related unit and integration tests to align with these changes.
✅ Validated webhook behavior using installation via OperatorHub (catalogsource).
✅ Validated webhook behavior by deploying the operator image via make deploy.

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
