### PR TITLE
fix: HWProfile from Dashbaord should not be included in any newer release

### DIFF
--- a/internal/controller/components/dashboard/dashboard_controller_actions.go
+++ b/internal/controller/components/dashboard/dashboard_controller_actions.go
@@ -160,12 +160,23 @@ func updateStatus(ctx context.Context, rr *odhtypes.ReconciliationRequest) error
 }
 
 func reconcileHardwareProfiles(ctx context.Context, rr *odhtypes.ReconciliationRequest) error {
+	// Check if the DashboardHardwareProfile CRD exists (old releases dashbaord ship this CRD)
+	exists, err := cluster.HasCRD(ctx, rr.Client, gvk.DashboardHardwareProfile)
+	if err != nil {
+		return fmt.Errorf("failed to check dashboard HardwareProfile CRD: %w", err)
+	}
+
+	// If the CRD doesn't exist, there's nothing to migrate
+	if !exists {
+		return nil
+	}
+
 	dashboardHardwareProfiles := &unstructured.UnstructuredList{}
 	dashboardHardwareProfiles.SetGroupVersionKind(gvk.DashboardHardwareProfile)
 
-	err := rr.Client.List(ctx, dashboardHardwareProfiles)
+	err = rr.Client.List(ctx, dashboardHardwareProfiles)
 	if err != nil {
-		return fmt.Errorf("failed to list dashboard hardware profiles: %w", err)
+		return fmt.Errorf("failed to list dashboard HardwareProfile CR: %w", err)
 	}
 
 	logger := log.FromContext(ctx)


### PR DESCRIPTION

<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->
e2e now failed on dashboard not ready
need fix that error before we can go further

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling when the DashboardHardwareProfile resource is not available, preventing unnecessary processing and reducing error messages when the resource is missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->