### PR TITLE
add missing apigroup and kind in roleref

### DIFF
--- a/config/monitoring/prometheus/base/prometheus-rolebinding-scraper.yaml
+++ b/config/monitoring/prometheus/base/prometheus-rolebinding-scraper.yaml
@@ -4,6 +4,8 @@ kind: ClusterRoleBinding
 metadata:
   name: prometheus-scraper
 roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
   name: prometheus-scraper
 subjects:
 - kind: ServiceAccount


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

- Roleref is missing apigroup and kind

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- `cd config/monitoring/prometheus/base`.
- Run command `kubectl -k .`.
- Verify error shows.
- Checkout this branch.
- Run same command.
- Error does not show and rolebinding creates successfully.

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated monitoring configuration to clarify role reference details for Prometheus scraper permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->