### PR TITLE
added e2e test for hwprofile reconciliation

### DIFF
--- a/tests/e2e/dashboard_test.go
+++ b/tests/e2e/dashboard_test.go
@@ -42,6 +42,7 @@ func dashboardTestSuite(t *testing.T) {
 		{"Validate update operand resources", componentCtx.ValidateUpdateDeploymentsResources},
 		{"Validate dynamically watches operands", componentCtx.ValidateOperandsDynamicallyWatchedResources},
 		{"Validate CRDs reinstated", componentCtx.ValidateCRDReinstated},
+		{"Validate hardware profile reconcilliation", componentCtx.ValidateHardwareProfileReconciliation},
 		// TODO: Disabled until these tests have been hardened (RHOAIENG-27721)
 		// {"Validate deployment deletion recovery", componentCtx.ValidateDeploymentDeletionRecovery},
 		// {"Validate configmap deletion recovery", componentCtx.ValidateConfigMapDeletionRecovery},
@@ -106,4 +107,81 @@ func (tc *DashboardTestCtx) ValidateCRDReinstated(t *testing.T) {
 	}
 
 	tc.ValidateCRDsReinstated(t, crds)
+}
+
+func (tc *DashboardTestCtx) ValidateHardwareProfileReconciliation(t *testing.T) {
+	t.Helper()
+
+	testHWPName := "test-hwp-" + xid.New().String()
+
+	tc.EventuallyResourceCreatedOrUpdated(
+		WithMinimalObject(gvk.DashboardHardwareProfile, types.NamespacedName{Name: testHWPName, Namespace: tc.AppsNamespace}),
+		WithMutateFunc(
+			func(obj *unstructured.Unstructured) error {
+				spec := map[string]any{
+					"displayName": "Test Hardware Profile",
+					"enabled":     true,
+					"description": "Test hardware profile for e2e testing",
+					"nodeSelector": map[string]any{
+						"kubernetes.io/arch": "amd64",
+					},
+					"tolerations": []any{
+						map[string]any{
+							"key":      "test-key",
+							"operator": "Equal",
+							"value":    "test-value",
+							"effect":   "NoSchedule",
+						},
+					},
+				}
+				if err := unstructured.SetNestedMap(obj.Object, spec, "spec"); err != nil {
+					return err
+				}
+				return nil
+			},
+		),
+	)
+
+	tc.EnsureResourcesExist(
+		WithMinimalObject(gvk.HardwareProfile, types.NamespacedName{Name: testHWPName, Namespace: tc.AppsNamespace}),
+		WithCondition(
+			ContainElement(
+				And(
+					jq.Match(`.metadata.name == "%s"`, testHWPName),
+					jq.Match(`.metadata.annotations."opendatahub.io/migrated-from" == "hardwareprofiles.dashboard.opendatahub.io/%s"`, testHWPName),
+					jq.Match(`.metadata.annotations."opendatahub.io/display-name" == "Test Hardware Profile"`),
+					jq.Match(`.metadata.annotations."opendatahub.io/description" == "Test hardware profile for e2e testing"`),
+					jq.Match(`.metadata.annotations."opendatahub.io/disabled" == "false"`),
+					jq.Match(`.spec.scheduling.node.nodeSelector."kubernetes.io/arch" == "amd64"`),
+					jq.Match(`.spec.scheduling.node.tolerations[0].key == "test-key"`),
+				),
+			),
+		),
+	)
+
+	tc.EventuallyResourceCreatedOrUpdated(
+		WithMinimalObject(gvk.DashboardHardwareProfile, types.NamespacedName{Name: testHWPName, Namespace: tc.AppsNamespace}),
+		WithMutateFunc(
+			func(obj *unstructured.Unstructured) error {
+				resources.SetAnnotation(obj, "test-annotation", "test-value")
+				resources.SetAnnotation(obj, "another-test-annotation", "another-test-value")
+				return nil
+			},
+		),
+	)
+
+	tc.EnsureResourcesExist(
+		WithMinimalObject(gvk.HardwareProfile, types.NamespacedName{Name: testHWPName, Namespace: tc.AppsNamespace}),
+		WithCondition(
+			ContainElement(
+				And(
+					jq.Match(`.metadata.name == "%s"`, testHWPName),
+					jq.Match(`.metadata.annotations."test-annotation" == "test-value"`),
+					jq.Match(`.metadata.annotations."another-test-annotation" == "another-test-value"`),
+					jq.Match(`.metadata.annotations."opendatahub.io/migrated-from" == "hardwareprofiles.dashboard.opendatahub.io/%s"`, testHWPName),
+					jq.Match(`.metadata.annotations."opendatahub.io/display-name" == "Test Hardware Profile"`),
+				),
+			),
+		),
+	)
 }


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

Jira: [RHOAIENG-30441](https://issues.redhat.com/browse/RHOAIENG-30441)

This PR adds an E2E test to alidate that dashboard controller automatically migrates and continuously reconciles HardwareProfiles from dashboard.opendatahub.io to infrastructure.opendatahub.io API group.


## Description
<!--- Describe your changes in detail -->

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
`make e2e-test E2E_TEST_COMPONENT=dashboard`

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added a new end-to-end test to verify that changes to hardware profile resources in the dashboard are correctly reflected and reconciled in the corresponding system resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->