### PR TITLE
RHOAIENG-25538 | test: Adding removed tests

### DIFF
--- a/tests/e2e/monitoring_test.go
+++ b/tests/e2e/monitoring_test.go
@@ -7,12 +7,12 @@ import (
 	gTypes "github.com/onsi/gomega/types"
 	operatorv1 "github.com/openshift/api/operator/v1"
 	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
 
 	dsciv1 "github.com/opendatahub-io/opendatahub-operator/v2/api/dscinitialization/v1"
-	serviceApi "github.com/opendatahub-io/opendatahub-operator/v2/api/services/v1alpha1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/services/monitoring"
 	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/status"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
@@ -52,9 +52,7 @@ func monitoringTestSuite(t *testing.T) {
 		{"Test Metrics Replicas Configuration", monitoringServiceCtx.ValidateMonitoringStackCRMetricsReplicasUpdate},
 		{"Test Traces default content", monitoringServiceCtx.ValidateMonitoringCRDefaultTracesContent},
 		{"Test TempoMonolithic CR Creation with PV backend", monitoringServiceCtx.ValidateTempoMonolithicCRCreation},
-		{"Test TempoMonolithic CR Configuration", monitoringServiceCtx.ValidateTempoMonolithicCRConfiguration},
-		{"Test TempoStack CR Creation with S3 backend", monitoringServiceCtx.ValidateTempoStackCRCreation},
-		{"Test TempoStack CR Configuration", monitoringServiceCtx.ValidateTempoStackCRConfiguration},
+		{"Test TempoStack CR Creation with S3 backend", monitoringServiceCtx.ValidateTempoStackCRCreationWithS3},
 		{"Test TempoStack CR Creation with GCS backend", monitoringServiceCtx.ValidateTempoStackCRCreationWithGCS},
 		{"Test OpenTelemetry Collector Deployment", monitoringServiceCtx.ValidateOpenTelemetryCollectorDeployment},
 		{"Test OpenTelemetry Collector Traces Configuration", monitoringServiceCtx.ValidateOpenTelemetryCollectorTracesConfiguration},
@@ -95,18 +93,16 @@ func (tc *MonitoringTestCtx) ValidateMonitoringCRDefaultContent(t *testing.T) {
 	dsci := tc.FetchDSCInitialization()
 
 	// Ensure that the Monitoring resource exists.
-	monitoring := &serviceApi.Monitoring{}
-	tc.FetchTypedResource(monitoring, WithMinimalObject(gvk.Monitoring, types.NamespacedName{Name: "default-monitoring"}))
-
-	// Validate that the Monitoring CR's namespace matches the DSCInitialization spec.
-	tc.g.Expect(monitoring.Spec.MonitoringCommonSpec.Namespace).
-		To(Equal(dsci.Spec.Monitoring.Namespace),
-			"Monitoring CR's namespace mismatch: Expected namespace '%v' as per DSCInitialization, but found '%v' in Monitoring CR.",
-			dsci.Spec.Monitoring.Namespace, monitoring.Spec.Namespace)
-
-	// Validate metrics is nil when not set in DSCI
-	tc.g.Expect(monitoring.Spec.Metrics).
-		To(BeNil(), "Expected metrics to be nil when not set in DSCI")
+	tc.EnsureResourceExists(
+		WithMinimalObject(gvk.Monitoring, types.NamespacedName{Name: "default-monitoring"}),
+		WithCondition(
+			And(
+				jq.Match(`.spec.namespace == "%s"`, dsci.Spec.Monitoring.Namespace),
+				jq.Match(`.spec.metrics == null`),
+			),
+		),
+		WithCustomErrorMsg("Monitoring CR should have expected namespace and null metrics"),
+	)
 
 	// Validate MontoringStack CR is not created
 	tc.EnsureResourcesGone(
@@ -136,11 +132,10 @@ func (tc *MonitoringTestCtx) ValidateMonitoringStackCRMetricsWhenSet(t *testing.
 	)
 
 	// ensure the MonitoringStack CR is created (status conditions are set by external monitoring operator)
-	ms := tc.EnsureResourceExists(
+	tc.EnsureResourceExists(
 		WithMinimalObject(gvk.MonitoringStack, types.NamespacedName{Name: "data-science-monitoringstack", Namespace: dsci.Spec.Monitoring.Namespace}),
 		WithCondition(jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, status.ConditionTypeAvailable, metav1.ConditionTrue)),
 	)
-	tc.g.Expect(ms).ToNot(BeNil())
 }
 
 func (tc *MonitoringTestCtx) ValidateMonitoringStackCRMetricsConfiguration(t *testing.T) {
@@ -223,9 +218,11 @@ func (tc *MonitoringTestCtx) ValidateMonitoringStackCRDeleted(t *testing.T) {
 		WithMinimalObject(gvk.Monitoring, types.NamespacedName{Name: "default-monitoring"}),
 	)
 
-	monitoring := &serviceApi.Monitoring{}
-	tc.FetchTypedResource(monitoring, WithMinimalObject(gvk.Monitoring, types.NamespacedName{Name: "default-monitoring"}))
-	tc.g.Expect(monitoring.Spec.Metrics).To(BeNil(), "Expected 'metrics' to be nil in Monitoring CR")
+	tc.EnsureResourceExists(
+		WithMinimalObject(gvk.Monitoring, types.NamespacedName{Name: "default-monitoring"}),
+		WithCondition(jq.Match(`.spec.metrics == null`)),
+		WithCustomErrorMsg("Monitoring CR should have null metrics"),
+	)
 }
 
 func (tc *MonitoringTestCtx) ValidateMonitoringCRDeleted(t *testing.T) {
@@ -345,13 +342,11 @@ func (tc *MonitoringTestCtx) ValidateMonitoringCRDefaultTracesContent(t *testing
 	)
 
 	// Ensure that the Monitoring resource exists.
-	monitoring := &serviceApi.Monitoring{}
-	tc.FetchTypedResource(monitoring, WithMinimalObject(gvk.Monitoring, types.NamespacedName{Name: "default-monitoring"}))
-
-	// Validate the traces stanza is omitted by default
-	tc.g.Expect(monitoring.Spec.Traces).
-		To(BeNil(),
-			"Expected traces stanza to be omitted by default")
+	tc.EnsureResourceExists(
+		WithMinimalObject(gvk.Monitoring, types.NamespacedName{Name: "default-monitoring"}),
+		WithCondition(jq.Match(`.spec.traces == null`)),
+		WithCustomErrorMsg("Expected traces stanza to be omitted by default"),
+	)
 }
 
 // ValidateTempoMonolithicCRCreation tests creation of TempoMonolithic CR with PV backend.
@@ -379,38 +374,24 @@ func (tc *MonitoringTestCtx) ValidateTempoMonolithicCRCreation(t *testing.T) {
 	)
 
 	// Ensure the TempoMonolithic CR is created (status conditions are set by external tempo operator).
-	tempoMonolithic := tc.EnsureResourceExists(
+	tc.EventuallyResourceCreatedOrUpdated(
 		WithMinimalObject(gvk.TempoMonolithic, types.NamespacedName{Name: tempoMonolithicName, Namespace: dsci.Spec.Monitoring.Namespace}),
+		WithCondition(
+			And(
+				// Validate it's ready
+				jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, status.ConditionTypeReady, metav1.ConditionTrue),
+				// Validate the storage size is set to 10Gi
+				jq.Match(`.spec.storage.traces.size == "10Gi"`),
+				// Validate the backend is set to pv
+				jq.Match(`.spec.storage.traces.backend == "pv"`),
+			),
+		),
+		WithCustomErrorMsg("TempoMonolithic CR should be created when traces are configured"),
 	)
-	tc.g.Expect(tempoMonolithic).ToNot(BeNil())
 }
 
-// ValidateTempoMonolithicCRConfiguration tests configuration of TempoMonolithic CR.
-func (tc *MonitoringTestCtx) ValidateTempoMonolithicCRConfiguration(t *testing.T) {
-	t.Helper()
-
-	dsci := tc.FetchDSCInitialization()
-	tempoMonolithicName := getTempoMonolithicName(dsci)
-
-	tempoMonolithic := tc.FetchResources(
-		WithMinimalObject(gvk.TempoMonolithic, types.NamespacedName{Name: tempoMonolithicName, Namespace: dsci.Spec.Monitoring.Namespace}),
-	)
-
-	// Validate the storage size is set to 10Gi.
-	storageSize, found, err := unstructured.NestedString(tempoMonolithic[0].Object, "spec", "storage", "traces", "size")
-	tc.g.Expect(err).ToNot(HaveOccurred())
-	tc.g.Expect(found).To(BeTrue())
-	tc.g.Expect(storageSize).To(Equal("10Gi"))
-
-	// Validate the backend is set to pv.
-	backend, found, err := unstructured.NestedString(tempoMonolithic[0].Object, "spec", "storage", "traces", "backend")
-	tc.g.Expect(err).ToNot(HaveOccurred())
-	tc.g.Expect(found).To(BeTrue())
-	tc.g.Expect(backend).To(Equal("pv"))
-}
-
-// ValidateTempoStackCRCreation tests creation of TempoStack CR with S3 backend.
-func (tc *MonitoringTestCtx) ValidateTempoStackCRCreation(t *testing.T) {
+// ValidateTempoStackCRCreationWithS3 tests creation of TempoStack CR with S3 backend.
+func (tc *MonitoringTestCtx) ValidateTempoStackCRCreationWithS3(t *testing.T) {
 	t.Helper()
 
 	tc.validateTempoStackCreationWithBackend(
@@ -422,61 +403,91 @@ func (tc *MonitoringTestCtx) ValidateTempoStackCRCreation(t *testing.T) {
 	)
 }
 
-// ValidateTempoStackCRConfiguration tests configuration of TempoStack CR.
-func (tc *MonitoringTestCtx) ValidateTempoStackCRConfiguration(t *testing.T) {
-	t.Helper()
-
-	dsci := tc.FetchDSCInitialization()
-	tempoStackName := getTempoStackName(dsci)
-
-	// Fetch existing TempoStack instead of creating new one
-	tempoStack := tc.FetchResources(
-		WithMinimalObject(gvk.TempoStack, types.NamespacedName{
-			Name:      tempoStackName,
-			Namespace: dsci.Spec.Monitoring.Namespace,
-		}),
-	)
-	tc.g.Expect(tempoStack).To(HaveLen(1))
-
-	// Use helper function for validation logic
-	tc.validateTempoStackDetails(t, &tempoStack[0], "s3", "s3-secret")
-}
-
 // ValidateTempoStackCRCreationWithGCS tests creation of TempoStack CR with GCS backend.
 func (tc *MonitoringTestCtx) ValidateTempoStackCRCreationWithGCS(t *testing.T) {
 	t.Helper()
 
-	tc.validateTempoStackCreationWithBackendDetails(
-		t,
+	// First, perform the basic TempoStack creation validation
+	tc.validateTempoStackCreationWithBackend(t,
 		"gcs",
 		"gcs-secret",
 		jq.Match(`.spec.traces.storage.backend == "gcs"`),
-		"Monitoring resource should be updated with GCS traces configuration by DSCInitialization controller",
+		"Monitoring resource should be updated with GCS traces configuration by DSCInitialization controller")
+}
+
+// ValidateInstrumentationCRTracesWhenSet validates the content of the Instrumentation CR.
+func (tc *MonitoringTestCtx) ValidateInstrumentationCRTracesWhenSet(t *testing.T) {
+	t.Helper()
+
+	dsci := tc.FetchDSCInitialization()
+
+	// Update DSCI to set traces - ensure managementState remains Managed
+	tc.EventuallyResourceCreatedOrUpdated(
+		WithMinimalObject(gvk.DSCInitialization, tc.DSCInitializationNamespacedName),
+		WithMutateFunc(testf.TransformPipeline(
+			testf.Transform(`.spec.monitoring.managementState = "%s"`, operatorv1.Managed),
+			setMonitoringTraces("pv", "", ""),
+		)),
+	)
+
+	// Wait for the Monitoring resource to be updated by DSCInitialization controller
+	tc.EnsureResourceExists(
+		WithMinimalObject(gvk.Monitoring, types.NamespacedName{Name: "default-monitoring"}),
+		WithCondition(jq.Match(`.spec.traces != null`)),
+		WithCustomErrorMsg("Monitoring resource should be updated with traces configuration by DSCInitialization controller"),
+	)
+
+	// Ensure the Instrumentation CR is created
+	tc.EnsureResourceExists(
+		WithMinimalObject(gvk.Instrumentation, types.NamespacedName{Name: monitoring.InstrumentationName, Namespace: dsci.Spec.Monitoring.Namespace}),
+		WithCustomErrorMsg("Instrumentation CR should be created when traces are configured"),
 	)
 }
 
-// validateTempoStackDetails validates the detailed configuration of a TempoStack resource.
-// This helper function checks that the backend type and secret name are correctly set
-// in the TempoStack specification.
-//
-// Parameters:
-//   - tempoStack: The TempoStack resource to validate
-//   - expectedBackend: The expected storage backend type (e.g., "s3", "gcs")
-//   - expectedSecretName: The expected name of the secret containing backend credentials
-func (tc *MonitoringTestCtx) validateTempoStackDetails(t *testing.T, tempoStack *unstructured.Unstructured, expectedBackend, expectedSecretName string) {
+// ValidateInstrumentationCRTracesConfiguration validates the content of the Instrumentation CR with Traces.
+func (tc *MonitoringTestCtx) ValidateInstrumentationCRTracesConfiguration(t *testing.T) {
 	t.Helper()
 
-	// Validate the backend is set correctly
-	actualBackend, found, err := unstructured.NestedString(tempoStack.Object, "spec", "storage", "secret", "type")
-	tc.g.Expect(err).ToNot(HaveOccurred())
-	tc.g.Expect(found).To(BeTrue())
-	tc.g.Expect(actualBackend).To(Equal(expectedBackend))
+	dsci := tc.FetchDSCInitialization()
 
-	// Validate the secret name is set correctly
-	actualSecretName, found, err := unstructured.NestedString(tempoStack.Object, "spec", "storage", "secret", "name")
-	tc.g.Expect(err).ToNot(HaveOccurred())
-	tc.g.Expect(found).To(BeTrue())
-	tc.g.Expect(actualSecretName).To(Equal(expectedSecretName))
+	// Wait for the Instrumentation CR to be created and stabilized by the OpenTelemetry operator
+	tc.EnsureResourceExists(
+		WithMinimalObject(gvk.Instrumentation, types.NamespacedName{Name: monitoring.InstrumentationName, Namespace: dsci.Spec.Monitoring.Namespace}),
+		WithCondition(And(
+			jq.Match(`.spec != null`),
+			jq.Match(`.metadata.generation >= 1`),
+		)),
+		WithCustomErrorMsg("Instrumentation CR should be created and have a valid spec"),
+	)
+
+	// Fetch the Instrumentation CR and validate its content with Eventually for stability
+	expectedEndpoint := fmt.Sprintf("http://data-science-collector.%s.svc.cluster.local:4317", dsci.Spec.Monitoring.Namespace)
+
+	tc.EnsureResourceExists(
+		WithMinimalObject(gvk.Instrumentation, types.NamespacedName{Name: monitoring.InstrumentationName, Namespace: dsci.Spec.Monitoring.Namespace}),
+		WithCondition(
+			And(
+				// Validate the exporter endpoint is set correctly
+				jq.Match(`.spec.exporter.endpoint == "%s"`, expectedEndpoint),
+				// Validate the sampler configuration
+				jq.Match(`.spec.sampler.type == "%s"`, monitoring.DefaultSamplerType),
+				jq.Match(`.spec.sampler.argument == "0.1"`),
+			),
+		),
+		WithCustomErrorMsg("Instrumentation CR should have the expected configuration"),
+	)
+
+	// Validate owner references
+	tc.EnsureResourceExists(
+		WithMinimalObject(gvk.Instrumentation, types.NamespacedName{Name: monitoring.InstrumentationName, Namespace: dsci.Spec.Monitoring.Namespace}),
+		WithCondition(
+			And(
+				jq.Match(`.metadata.ownerReferences | length == 1`),
+				jq.Match(`.metadata.ownerReferences[0].kind == "%s"`, gvk.Monitoring.Kind),
+				jq.Match(`.metadata.ownerReferences[0].name == "%s"`, "default-monitoring"),
+			),
+		),
+	)
 }
 
 // validateTempoStackCreationWithBackend validates TempoStack creation with the specified backend.
@@ -495,7 +506,7 @@ func (tc *MonitoringTestCtx) validateTempoStackCreationWithBackend(
 	backend, secretName string,
 	monitoringCondition gTypes.GomegaMatcher,
 	monitoringErrorMsg string,
-) *unstructured.Unstructured {
+) {
 	t.Helper()
 
 	dsci := tc.FetchDSCInitialization()
@@ -517,132 +528,81 @@ func (tc *MonitoringTestCtx) validateTempoStackCreationWithBackend(
 		WithCustomErrorMsg(monitoringErrorMsg),
 	)
 
+	// Create dummy secret
+	tc.createDummySecret(backend, secretName, dsci.Spec.Monitoring.Namespace)
+
 	// Ensure the TempoStack CR is created with specified backend
 	// (status conditions are set by external tempo operator)
-	tempoStack := tc.EnsureResourceExists(
+	tc.EventuallyResourceCreatedOrUpdated(
 		WithMinimalObject(gvk.TempoStack, types.NamespacedName{
 			Name:      tempoStackName,
 			Namespace: dsci.Spec.Monitoring.Namespace,
 		}),
-		WithCondition(jq.Match(`.spec.storage.secret.type == "%s"`, backend)),
+		WithCondition(
+			And(
+				// Validate the backend is set correctly
+				jq.Match(`.spec.storage.secret.type == "%s"`, backend),
+				jq.Match(`.spec.storage.secret.name == "%s"`, secretName),
+				// Validate that the Tempo operator has accepted and reconciled the resource
+				jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, status.ConditionTypeReady, metav1.ConditionTrue),
+			),
+		),
 		WithCustomErrorMsg(
 			"TempoStack should be created with %s backend, but was not found or has incorrect backend type",
 			backend,
 		),
 	)
 
-	return tempoStack
+	// Making sure it get deleted at the end of the test
+	tc.DeleteResource(
+		WithMinimalObject(gvk.Secret, types.NamespacedName{Name: secretName, Namespace: dsci.Spec.Monitoring.Namespace}),
+		WithWaitForDeletion(true),
+	)
 }
 
-// validateTempoStackCreationWithBackendDetails validates TempoStack creation with detailed configuration validation.
-// This function calls validateTempoStackCreationWithBackend and additionally validates that the backend
-// and secret name are correctly set in the TempoStack specification.
-//
-// Parameters:
-//   - backend: The storage backend type (e.g., "s3", "gcs")
-//   - secretName: The name of the secret containing backend credentials
-//   - monitoringCondition: Gomega matcher to validate the Monitoring resource state
-//   - monitoringErrorMsg: Error message to display if Monitoring resource validation fails
-//
-// Returns the created TempoStack resource for additional validation by the caller.
-func (tc *MonitoringTestCtx) validateTempoStackCreationWithBackendDetails(
-	t *testing.T,
-	backend, secretName string,
-	monitoringCondition gTypes.GomegaMatcher,
-	monitoringErrorMsg string) *unstructured.Unstructured {
-	t.Helper()
+// createDummySecret creates a dummy secret for TempoStack testing (S3 or GCS).
+func (tc *MonitoringTestCtx) createDummySecret(backendType, secretName, namespace string) {
+	var secret *corev1.Secret
 
-	// First, perform the basic TempoStack creation validation
-	tempoStack := tc.validateTempoStackCreationWithBackend(t, backend, secretName, monitoringCondition, monitoringErrorMsg)
+	switch backendType {
+	case "s3":
+		secret = &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      secretName,
+				Namespace: namespace,
+			},
+			Type: corev1.SecretTypeOpaque,
+			Data: map[string][]byte{
+				"access_key_id":     []byte("fake-access-key"),
+				"access_key_secret": []byte("fake-secret-key"),
+				"bucket":            []byte("fake-bucket"),
+				"endpoint":          []byte("https://s3.amazonaws.com"),
+				// No region field - causes TempoStack validation conflicts
+			},
+		}
+	case "gcs":
+		secret = &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      secretName,
+				Namespace: namespace,
+			},
+			Type: corev1.SecretTypeOpaque,
+			Data: map[string][]byte{
+				"key.json": []byte(`{
+					"type": "service_account",
+					"project_id": "fake-test-project-not-real",
+					"private_key_id": "test-key-id-fake",
+					"private_key": "-----BEGIN PRIVATE KEY-----\nTEST-FAKE-KEY-NOT-REAL\n-----END PRIVATE KEY-----\n",
+					"client_email": "test-fake@fake-project.iam.gserviceaccount.com"
+                }`),
+			},
+		}
+	default:
+		tc.g.Fail(fmt.Sprintf("Unsupported backend type: %s", backendType))
+		return
+	}
 
-	// Use helper function for detailed validation
-	tc.validateTempoStackDetails(t, tempoStack, backend, secretName)
-
-	return tempoStack
-}
-
-func (tc *MonitoringTestCtx) ValidateInstrumentationCRTracesWhenSet(t *testing.T) {
-	t.Helper()
-
-	dsci := tc.FetchDSCInitialization()
-
-	// Update DSCI to set traces - ensure managementState remains Managed
 	tc.EventuallyResourceCreatedOrUpdated(
-		WithMinimalObject(gvk.DSCInitialization, tc.DSCInitializationNamespacedName),
-		WithMutateFunc(testf.TransformPipeline(
-			testf.Transform(`.spec.monitoring.managementState = "%s"`, operatorv1.Managed),
-			setMonitoringTraces(),
-		)),
+		WithObjectToCreate(secret),
 	)
-
-	// Wait for the Monitoring resource to be updated by DSCInitialization controller
-	tc.EnsureResourceExists(
-		WithMinimalObject(gvk.Monitoring, types.NamespacedName{Name: "default-monitoring"}),
-		WithCondition(jq.Match(`.spec.traces != null`)),
-		WithCustomErrorMsg("Monitoring resource should be updated with traces configuration by DSCInitialization controller"),
-	)
-
-	// Ensure the Instrumentation CR is created
-	instrumentation := tc.EnsureResourceExists(
-		WithMinimalObject(gvk.Instrumentation, types.NamespacedName{Name: monitoring.InstrumentationName, Namespace: dsci.Spec.Monitoring.Namespace}),
-		WithCustomErrorMsg("Instrumentation CR should be created when traces are configured"),
-	)
-	tc.g.Expect(instrumentation).ToNot(BeNil())
-}
-
-// ValidateInstrumentationCRTracesConfiguration validates the content of the Instrumentation CR.
-func (tc *MonitoringTestCtx) ValidateInstrumentationCRTracesConfiguration(t *testing.T) {
-	t.Helper()
-
-	dsci := tc.FetchDSCInitialization()
-
-	// Wait for the Instrumentation CR to be created and stabilized by the OpenTelemetry operator
-	tc.EnsureResourceExists(
-		WithMinimalObject(gvk.Instrumentation, types.NamespacedName{Name: monitoring.InstrumentationName, Namespace: dsci.Spec.Monitoring.Namespace}),
-		WithCondition(And(
-			jq.Match(`.spec != null`),
-			jq.Match(`.metadata.generation >= 1`),
-		)),
-		WithCustomErrorMsg("Instrumentation CR should be created and have a valid spec"),
-	)
-
-	// Fetch the Instrumentation CR and validate its content with Eventually for stability
-	expectedEndpoint := fmt.Sprintf("http://data-science-collector.%s.svc.cluster.local:4317", dsci.Spec.Monitoring.Namespace)
-
-	tc.g.Eventually(func(g Gomega) {
-		instrumentation := tc.FetchResources(
-			WithMinimalObject(gvk.Instrumentation, types.NamespacedName{Name: monitoring.InstrumentationName, Namespace: dsci.Spec.Monitoring.Namespace}),
-		)
-		g.Expect(instrumentation).To(HaveLen(1))
-
-		// Validate the exporter endpoint is set correctly
-		endpoint, found, err := unstructured.NestedString(instrumentation[0].Object, "spec", "exporter", "endpoint")
-		g.Expect(err).ToNot(HaveOccurred())
-		g.Expect(found).To(BeTrue(), "Expected 'spec.exporter.endpoint' field to be found in Instrumentation CR")
-		g.Expect(endpoint).To(Equal(expectedEndpoint))
-
-		// Validate the sampler configuration
-		samplerType, found, err := unstructured.NestedString(instrumentation[0].Object, "spec", "sampler", "type")
-		g.Expect(err).ToNot(HaveOccurred())
-		g.Expect(found).To(BeTrue(), "Expected 'spec.sampler.type' field to be found in Instrumentation CR")
-		g.Expect(samplerType).To(Equal(monitoring.DefaultSamplerType))
-
-		samplerArgument, found, err := unstructured.NestedString(instrumentation[0].Object, "spec", "sampler", "argument")
-		g.Expect(err).ToNot(HaveOccurred())
-		g.Expect(found).To(BeTrue(), "Expected 'spec.sampler.argument' field to be found in Instrumentation CR")
-		g.Expect(samplerArgument).To(Equal("0.1"))
-	}).Should(Succeed(), "Instrumentation CR should have the expected configuration")
-
-	// Fetch again for owner reference validation
-	instrumentation := tc.FetchResources(
-		WithMinimalObject(gvk.Instrumentation, types.NamespacedName{Name: monitoring.InstrumentationName, Namespace: dsci.Spec.Monitoring.Namespace}),
-	)
-	tc.g.Expect(instrumentation).To(HaveLen(1))
-
-	// Validate owner references
-	tc.g.Expect(instrumentation[0].Object).To(And(
-		jq.Match(`.metadata.ownerReferences | length == 1`),
-		jq.Match(`.metadata.ownerReferences[0].kind == "%s"`, gvk.Monitoring.Kind),
-		jq.Match(`.metadata.ownerReferences[0].name == "%s"`, "default-monitoring"),
-	))
 }


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added new end-to-end tests to verify the creation and configuration of Instrumentation resources when traces are enabled in monitoring.
  * Enhanced validation to ensure correct exporter endpoint, sampler settings, and ownership references for Instrumentation resources.
  * Improved test clarity and conciseness by adopting declarative resource existence and field validation methods.
  * Introduced tests for TempoStack resource creation with S3 and GCS backends using dummy secrets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->