### PR TITLE
fix: update to dashboard controller to watch its ConfigMaps

### DIFF
--- a/internal/controller/components/dashboard/dashboard_controller.go
+++ b/internal/controller/components/dashboard/dashboard_controller.go
@@ -71,6 +71,12 @@ func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.
 		OwnsGVK(gvk.OdhApplication, reconciler.Dynamic()).
 		OwnsGVK(gvk.OdhDocument, reconciler.Dynamic()).
 		OwnsGVK(gvk.OdhQuickStart, reconciler.Dynamic()).
+		Watches(
+			&corev1.ConfigMap{},
+			reconciler.WithPredicates(
+				component.ForLabel(labels.PlatformPartOf, componentApi.DashboardComponentName),
+			),
+		).
 		// CRDs are not owned by the component and should be left on the cluster,
 		// so by default, the deploy action won't add all the annotation added to
 		// other resources. Hence, a custom handling is required in order to minimize


### PR DESCRIPTION
## Description
JIRA: [RHOAIENG-29983](https://issues.redhat.com/browse/RHOAIENG-29983)

This change updates the dashboard_controller to explicitly watch ConfigMaps with the label `platform.opendatahub.io/part-of: dashboard`. 

This is required to fix a bug that was spotted while developing [RHOAIENG-27721](https://issues.redhat.com/browse/RHOAIENG-27721) where the RHOAI operator does not immediately recreate the `model-catalog-sources` and `model-catalog-unmanaged-sources` ConfigMaps if they are deleted. 

**NOTE:** These two ConfigMaps are only included in the [dashboard manifests](https://github.com/opendatahub-io/odh-dashboard/tree/main/manifests/rhoai/shared/apps/model-catalog) when the operator is installed as RHOAI, these ConfigMaps are not created when ODH is installed. However I decided to include the fix on the `main` branch to prevent the branches from diverging further than they already are. If this is not the correct approach I will close this PR and just add the fix to the `rhoai` branch.

## How Has This Been Tested?
These changes were tested by building operator, bundle, and catalog images, then verifying that the DSC and DSCI CRs successfully reconcile.

The following images were used for testing and can be used for verification:
```
quay.io/ckyrillo/opendatahub-operator:v2.33.0
quay.io/ckyrillo/opendatahub-operator-bundle:v2.33.0
quay.io/ckyrillo/opendatahub-operator-catalog:v2.33.0
```

## Screenshot or short clip
N/A

## Merge criteria
- [X] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [X] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [X] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work
