### PR TITLE
Add support for downstream trusty-ai image overrides

### DIFF
--- a/internal/controller/components/trustyai/trustyai_support.go
+++ b/internal/controller/components/trustyai/trustyai_support.go
@@ -22,9 +22,14 @@ const (
 
 var (
 	imageParamMap = map[string]string{
-		"trustyaiServiceImage":  "RELATED_IMAGE_ODH_TRUSTYAI_SERVICE_IMAGE",
-		"trustyaiOperatorImage": "RELATED_IMAGE_ODH_TRUSTYAI_SERVICE_OPERATOR_IMAGE",
-		"oauthProxyImage":       "RELATED_IMAGE_OSE_OAUTH_PROXY_IMAGE",
+		"trustyaiServiceImage":               "RELATED_IMAGE_ODH_TRUSTYAI_SERVICE_IMAGE",
+		"trustyaiOperatorImage":              "RELATED_IMAGE_ODH_TRUSTYAI_SERVICE_OPERATOR_IMAGE",
+		"lmes-driver-image":                  "RELATED_IMAGE_ODH_TA_LMES_DRIVER_IMAGE",
+		"lmes-pod-image":                     "RELATED_IMAGE_ODH_TA_LMES_JOB_IMAGE",
+		"guardrails-orchestrator-image":      "RELATED_IMAGE_ODH_FMS_GUARDRAILS_ORCHESTRATOR_IMAGE",
+		"guardrails-sidecar-gateway-image":   "RELATED_IMAGE_ODH_TRUSTYAI_VLLM_ORCHESTRATOR_GATEWAY_IMAGE",
+		"guardrails-built-in-detector-image": "RELATED_IMAGE_ODH_BUILT_IN_DETECTOR_IMAGE",
+		"oauthProxyImage":                    "RELATED_IMAGE_OSE_OAUTH_PROXY_IMAGE",
 	}
 
 	overlaysSourcePaths = map[common.Platform]string{


### PR DESCRIPTION
Ref: https://issues.redhat.com/browse/RHOAIENG-30270

Modify the platform operator to override trusty-ai images references in params.env from the below environment variables:

1. RELATED_IMAGE_ODH_TA_LMES_DRIVER_IMAGE
2. RELATED_IMAGE_ODH_TA_LMES_JOB_IMAGE
3. RELATED_IMAGE_ODH_FMS_GUARDRAILS_ORCHESTRATOR_IMAGE
4. RELATED_IMAGE_ODH_TRUSTYAI_VLLM_ORCHESTRATOR_GATEWAY_IMAGE
5. RELATED_IMAGE_ODH_TRUSTYAI_GUARDRAILS_REGEX_DETECTOR_IMAGE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring five additional images through environment variables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->