### PR TITLE
feat: add webhook for notebook on create/update

### DIFF
--- a/bundle/manifests/opendatahub-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/opendatahub-operator.clusterserviceversion.yaml
@@ -114,7 +114,7 @@ metadata:
     categories: AI/Machine Learning, Big Data
     certified: "False"
     containerImage: quay.io/opendatahub/opendatahub-operator:v2.33.0
-    createdAt: "2025-07-28T18:05:57Z"
+    createdAt: "2025-07-30T16:43:22Z"
     operators.operatorframework.io/builder: operator-sdk-v1.39.2
     operators.operatorframework.io/internal-objects: '["featuretrackers.features.opendatahub.io",
       "codeflares.components.platform.opendatahub.io", "dashboards.components.platform.opendatahub.io",
@@ -126,7 +126,7 @@ metadata:
       "feastoperators.components.platform.opendatahub.io", "llamastackoperators.components.platform.opendatahub.io"]'
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
     repository: https://github.com/opendatahub-io/opendatahub-operator
-  name: opendatahub-operator.v2.31.0
+  name: opendatahub-operator.v2.33.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -1580,7 +1580,7 @@ spec:
   selector:
     matchLabels:
       component: opendatahub-operator
-  version: 2.31.0
+  version: 2.33.0
   webhookdefinitions:
   - admissionReviewVersions:
     - v1

--- a/bundle/manifests/opendatahub-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/opendatahub-operator.clusterserviceversion.yaml
@@ -126,7 +126,7 @@ metadata:
       "feastoperators.components.platform.opendatahub.io", "llamastackoperators.components.platform.opendatahub.io"]'
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
     repository: https://github.com/opendatahub-io/opendatahub-operator
-  name: opendatahub-operator.v2.33.0
+  name: opendatahub-operator.v2.31.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -1580,7 +1580,7 @@ spec:
   selector:
     matchLabels:
       component: opendatahub-operator
-  version: 2.33.0
+  version: 2.31.0
   webhookdefinitions:
   - admissionReviewVersions:
     - v1
@@ -1622,6 +1622,26 @@ spec:
     targetPort: 9443
     type: MutatingAdmissionWebhook
     webhookPath: /platform-connection-isvc
+  - admissionReviewVersions:
+    - v1
+    containerPort: 443
+    deploymentName: opendatahub-operator-controller-manager
+    failurePolicy: Fail
+    generateName: connection-notebook.opendatahub.io
+    rules:
+    - apiGroups:
+      - kubeflow.org
+      apiVersions:
+      - v1
+      operations:
+      - CREATE
+      - UPDATE
+      resources:
+      - notebooks
+    sideEffects: None
+    targetPort: 9443
+    type: MutatingAdmissionWebhook
+    webhookPath: /platform-connection-notebook
   - admissionReviewVersions:
     - v1
     containerPort: 443

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -84,6 +84,26 @@ webhooks:
     resources:
     - inferenceservices
   sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /platform-connection-notebook
+  failurePolicy: Fail
+  name: connection-notebook.opendatahub.io
+  rules:
+  - apiGroups:
+    - kubeflow.org
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - notebooks
+  sideEffects: None
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration

--- a/internal/webhook/envtestutil/webhook_registration.go
+++ b/internal/webhook/envtestutil/webhook_registration.go
@@ -7,6 +7,7 @@ import (
 	hardwareprofilewebhook "github.com/opendatahub-io/opendatahub-operator/v2/internal/webhook/hardwareprofile"
 	inferenceservicewebhook "github.com/opendatahub-io/opendatahub-operator/v2/internal/webhook/inferenceservice"
 	kueuewebhook "github.com/opendatahub-io/opendatahub-operator/v2/internal/webhook/kueue"
+	notebookwebhook "github.com/opendatahub-io/opendatahub-operator/v2/internal/webhook/notebook"
 )
 
 // RegisterWebhooks registers hardware profile, Kueue, and connection webhooks for integration testing.
@@ -18,7 +19,7 @@ import (
 //
 // Use this function when:
 //   - Testing hardware profile injection functionality (which creates Notebooks)
-//   - Testing InferenceService creation with hardware profiles
+//   - Testing InferenceService or Notebook creation with hardware profiles
 //   - Testing any workflow that creates resources matching multiple webhook selectors
 //   - You need all webhooks to be available to avoid "webhook endpoint not found" errors
 func RegisterWebhooks(mgr manager.Manager) error {
@@ -49,6 +50,16 @@ func RegisterWebhooks(mgr manager.Manager) error {
 		Name:    "connection-isvc",
 	}
 	if err := isvcConnectionWebhook.SetupWithManager(mgr); err != nil {
+		return err
+	}
+
+	// Register Connection webhook for Notebook
+	notebookConnectionWebhook := &notebookwebhook.NotebookWebhook{
+		Client:  mgr.GetClient(),
+		Decoder: admission.NewDecoder(mgr.GetScheme()),
+		Name:    "notebook-webhook",
+	}
+	if err := notebookConnectionWebhook.SetupWithManager(mgr); err != nil {
 		return err
 	}
 

--- a/internal/webhook/notebook/integration_test.go
+++ b/internal/webhook/notebook/integration_test.go
@@ -1,0 +1,199 @@
+package notebook_test
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/rs/xid"
+	corev1 "k8s.io/api/core/v1"
+	k8serr "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/opendatahub-io/opendatahub-operator/v2/internal/webhook/envtestutil"
+	notebookwebhook "github.com/opendatahub-io/opendatahub-operator/v2/internal/webhook/notebook"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/metadata/annotations"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/envt"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestNotebookWebhook_Integration(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name                 string
+		setupSecrets         []string
+		connectionAnnotation string
+		expectAllowed        bool
+		expectDeniedError    string
+		validateInjection    bool
+	}{
+		{
+			name:                 "no connection annotation - should allow",
+			setupSecrets:         nil,
+			connectionAnnotation: "",
+			expectAllowed:        true,
+			validateInjection:    false,
+		},
+		{
+			name:                 "empty connection annotation - should allow",
+			setupSecrets:         nil,
+			connectionAnnotation: "   ", // whitespace only
+			expectAllowed:        true,
+			validateInjection:    false,
+		},
+		{
+			name:                 "invalid annotation format - missing namespace - should deny",
+			setupSecrets:         nil,
+			connectionAnnotation: "invalid-format",
+			expectAllowed:        false,
+			expectDeniedError:    "failed to parse connections annotation",
+		},
+		{
+			name:                 "invalid annotation format - empty name - should deny",
+			setupSecrets:         nil,
+			connectionAnnotation: "test-namespace/",
+			expectAllowed:        false,
+			expectDeniedError:    "failed to parse connections annotation",
+		},
+		{
+			name:                 "invalid annotation format - empty namespace - should deny",
+			setupSecrets:         nil,
+			connectionAnnotation: "/secret-name",
+			expectAllowed:        false,
+			expectDeniedError:    "failed to parse connections annotation",
+		},
+		{
+			name:                 "valid single secret - should allow and inject",
+			setupSecrets:         []string{"my-connection-secret"},
+			connectionAnnotation: "NAMESPACE/my-connection-secret", // NAMESPACE will be replaced
+			expectAllowed:        true,
+			validateInjection:    true,
+		},
+		{
+			name:                 "valid multiple secrets - should allow and inject",
+			setupSecrets:         []string{"secret-1", "secret-2"},
+			connectionAnnotation: "NAMESPACE/secret-1,NAMESPACE/secret-2", // NAMESPACE will be replaced
+			expectAllowed:        true,
+			validateInjection:    true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewWithT(t)
+
+			// Register both notebook webhook and hardware profile webhook to avoid missing webhook error
+			ctx, env, teardown := envtestutil.SetupEnvAndClientWithCRDs(
+				t,
+				[]envt.RegisterWebhooksFn{
+					envtestutil.RegisterWebhooks,
+				},
+				envtestutil.DefaultWebhookTimeout,
+				envtestutil.WithNotebook(),
+			)
+			t.Cleanup(teardown)
+
+			k8sClient := env.Client()
+			ns := xid.New().String()
+
+			// Create test namespace
+			testNamespace := &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{Name: ns},
+			}
+			g.Expect(k8sClient.Create(ctx, testNamespace)).To(Succeed())
+
+			// Create secrets if specified in test case
+			for _, secretName := range tc.setupSecrets {
+				secret := &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      secretName,
+						Namespace: ns,
+					},
+					Type: corev1.SecretTypeOpaque,
+					Data: map[string][]byte{
+						"connection-url": []byte("https://example.com"),
+						"username":       []byte("testuser"),
+						"password":       []byte("testpass"),
+					},
+				}
+				g.Expect(k8sClient.Create(ctx, secret)).To(Succeed())
+			}
+
+			// Create notebook with connection annotation (if specified)
+			notebookName := "test-notebook"
+			var notebook client.Object
+			if tc.connectionAnnotation != "" {
+				// Replace NAMESPACE placeholder with actual namespace
+				connectionValue := strings.ReplaceAll(tc.connectionAnnotation, "NAMESPACE", ns)
+				notebook = envtestutil.NewNotebook(notebookName, ns,
+					envtestutil.WithAnnotation(annotations.Connection, connectionValue),
+				)
+			} else {
+				notebook = envtestutil.NewNotebook(notebookName, ns)
+			}
+
+			// Attempt to create the notebook
+			err := k8sClient.Create(ctx, notebook)
+
+			if tc.expectAllowed {
+				g.Expect(err).To(Succeed(), fmt.Sprintf("Expected creation to be allowed but got: %v", err))
+
+				if tc.validateInjection {
+					// Verify injection occurred by checking the created notebook
+					createdNotebook := &unstructured.Unstructured{}
+					createdNotebook.SetAPIVersion("kubeflow.org/v1")
+					createdNotebook.SetKind("Notebook")
+
+					key := types.NamespacedName{Name: notebookName, Namespace: ns}
+					g.Expect(k8sClient.Get(ctx, key, createdNotebook)).To(Succeed())
+
+					// Verify that secrets were injected as envFrom entries
+					containers, found, injectionErr := unstructured.NestedSlice(createdNotebook.Object, notebookwebhook.NotebookContainersPath...)
+					g.Expect(injectionErr).ShouldNot(HaveOccurred())
+					g.Expect(found).Should(BeTrue())
+					g.Expect(containers).Should(HaveLen(1))
+
+					container, ok := containers[0].(map[string]interface{})
+					g.Expect(ok).Should(BeTrue())
+
+					envFrom, found, envFromErr := unstructured.NestedSlice(container, "envFrom")
+					g.Expect(envFromErr).ShouldNot(HaveOccurred())
+					g.Expect(found).Should(BeTrue())
+					g.Expect(envFrom).Should(HaveLen(len(tc.setupSecrets)), "Expected number of envFrom entries to match number of secrets")
+
+					// Verify each secret is referenced
+					secretNames := make([]string, 0, len(envFrom))
+					for _, entry := range envFrom {
+						entryMap, ok := entry.(map[string]interface{})
+						g.Expect(ok).Should(BeTrue())
+
+						secretRef, found, err := unstructured.NestedStringMap(entryMap, "secretRef")
+						g.Expect(err).ShouldNot(HaveOccurred())
+						g.Expect(found).Should(BeTrue())
+
+						secretName, found := secretRef["name"]
+						g.Expect(found).Should(BeTrue())
+						secretNames = append(secretNames, secretName)
+					}
+
+					g.Expect(secretNames).Should(ContainElements(tc.setupSecrets))
+				}
+			} else {
+				g.Expect(err).To(HaveOccurred(), "Expected creation to be denied but it was allowed")
+				statusErr := &k8serr.StatusError{}
+				ok := errors.As(err, &statusErr)
+				g.Expect(ok).To(BeTrue(), "Expected error to be of type StatusError")
+				g.Expect(statusErr.Status().Code).To(Equal(int32(http.StatusForbidden)))
+				g.Expect(statusErr.Status().Message).To(ContainSubstring(tc.expectDeniedError))
+			}
+		})
+	}
+}

--- a/internal/webhook/notebook/mutating.go
+++ b/internal/webhook/notebook/mutating.go
@@ -1,0 +1,310 @@
+//go:build !nowebhook
+
+package notebook
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+
+	admissionv1 "k8s.io/api/admission/v1"
+	authorizationv1 "k8s.io/api/authorization/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/metadata/annotations"
+	webhookutils "github.com/opendatahub-io/opendatahub-operator/v2/pkg/webhook"
+)
+
+var (
+	NotebookContainersPath = []string{"spec", "template", "spec", "containers"}
+)
+
+//+kubebuilder:webhook:path=/platform-connection-notebook,mutating=true,failurePolicy=fail,groups=kubeflow.org,resources=notebooks,verbs=create;update,versions=v1,name=connection-notebook.opendatahub.io,sideEffects=None,admissionReviewVersions=v1
+//nolint:lll
+
+// Validator implements webhook.AdmissionHandler for Notebook connection validation webhooks.
+type NotebookWebhook struct {
+	Client  client.Client
+	Decoder admission.Decoder
+	Name    string
+}
+
+// Assert that NotebookWebhook implements admission.Handler interface.
+var _ admission.Handler = &NotebookWebhook{}
+
+func (w *NotebookWebhook) SetupWithManager(mgr ctrl.Manager) error {
+	hookServer := mgr.GetWebhookServer()
+	hookServer.Register("/platform-connection-notebook", &webhook.Admission{
+		Handler:        w,
+		LogConstructor: webhookutils.NewWebhookLogConstructor(w.Name),
+	})
+	return nil
+}
+
+func (w *NotebookWebhook) Handle(ctx context.Context, req admission.Request) admission.Response {
+	log := logf.FromContext(ctx)
+
+	if w.Decoder == nil {
+		log.Error(nil, "Decoder is nil - webhook not properly initialized")
+		return admission.Errored(http.StatusInternalServerError, errors.New("webhook decoder not initialized"))
+	}
+
+	// Validate that we're processing the correct Kind
+	if req.Kind.Kind != gvk.Notebook.Kind {
+		err := fmt.Errorf("unexpected kind: %s", req.Kind.Kind)
+		log.Error(err, "got wrong kind", "group", req.Kind.Group, "version", req.Kind.Version, "kind", req.Kind.Kind)
+		return admission.Errored(http.StatusBadRequest, err)
+	}
+
+	var resp admission.Response
+
+	switch req.Operation {
+	case admissionv1.Create, admissionv1.Update:
+		validationResp, shouldInject, secretRefs := w.validateNotebookConnectionAnnotation(ctx, &req)
+		if !validationResp.Allowed {
+			return validationResp
+		}
+
+		// Only proceed with injection if the annotation is valid and shouldInject is true
+		if !shouldInject {
+			return admission.Allowed(fmt.Sprintf("Connection annotation validation passed in namespace %s for %s, no injection needed", req.Namespace, req.Kind.Kind))
+		}
+
+		injectionPerformed, obj, err := w.performConnectionInjection(req, secretRefs)
+		if err != nil {
+			log.Error(err, "Failed to perform connection injection")
+			return admission.Errored(http.StatusInternalServerError, err)
+		}
+
+		if injectionPerformed {
+			marshaledObj, err := json.Marshal(obj)
+			if err != nil {
+				log.Error(err, "Failed to marshal modified object")
+				return admission.Errored(http.StatusInternalServerError, err)
+			}
+			return admission.PatchResponseFromRaw(req.Object.Raw, marshaledObj)
+		}
+
+	default:
+		resp = admission.Allowed(fmt.Sprintf("Operation %s on %s allowed", req.Operation, req.Kind.Kind))
+	}
+
+	return resp
+}
+
+// validateNotebookConnectionAnnotation validates the connection annotation "opendatahub.io/connections"
+// If the annotation exists and has a non-empty value, it validates that the value references valid secret(s).
+// Additionally, it checks that user requesting the notebook operation has the required permissions to get the secret(s)
+// If the annotation doesn't exist or is empty, it allows the operation.
+func (w *NotebookWebhook) validateNotebookConnectionAnnotation(ctx context.Context, req *admission.Request) (admission.Response, bool, []corev1.SecretReference) {
+	log := logf.FromContext(ctx)
+
+	// Decode the object from the request
+	obj := &unstructured.Unstructured{}
+	if err := w.Decoder.Decode(*req, obj); err != nil {
+		log.Error(err, "failed to decode object")
+		return admission.Errored(http.StatusBadRequest, fmt.Errorf("failed to decode object: %w", err)), false, nil
+	}
+
+	// Get the connections annotation
+	objAnnotations := obj.GetAnnotations()
+	if objAnnotations == nil {
+		// No annotations - allow the request
+		return admission.Allowed("No annotations found - connections validation skipped"), false, nil
+	}
+
+	connectionsValue, found := objAnnotations[annotations.Connection]
+	if !found {
+		// No connections annotation - allow the request
+		return admission.Allowed("No connections annotation found - connections validation skipped"), false, nil
+	}
+
+	if strings.TrimSpace(connectionsValue) == "" {
+		// Empty connections annotation - allow the request
+		return admission.Allowed("Empty connections annotation - connections validation skipped"), false, nil
+	}
+
+	// Parse the connections annotation
+	connectionSecrets, err := parseConnectionsAnnotation(connectionsValue)
+	if err != nil {
+		log.Error(err, "failed to parse connections annotation", "connectionsValue", connectionsValue)
+		return admission.Denied(fmt.Sprintf("failed to parse connections annotation: %v", err)), false, nil
+	}
+
+	// Validate permissions for each connection secret
+	var permissionErrors []string
+	secretRefs := make([]corev1.SecretReference, 0)
+	for _, secretRef := range connectionSecrets {
+		log.V(1).Info("checking permission for secret", "secret", secretRef.Name, "namespace", secretRef.Namespace)
+		hasPermission, err := w.checkSecretPermission(ctx, req, secretRef)
+		if err != nil {
+			log.Error(err, "error checking permission for secret", "secret", secretRef.Name, "namespace", secretRef.Namespace)
+			return admission.Errored(http.StatusInternalServerError, fmt.Errorf("error checking permission for secret %s/%s: %w", secretRef.Namespace, secretRef.Name, err)), false, nil
+		}
+
+		if !hasPermission {
+			permissionErrors = append(permissionErrors, fmt.Sprintf("%s/%s", secretRef.Namespace, secretRef.Name))
+		}
+
+		secretRefs = append(secretRefs, secretRef)
+	}
+
+	if len(permissionErrors) > 0 {
+		return admission.Denied(fmt.Sprintf("user does not have permission to access the following connection secrets: %s", strings.Join(permissionErrors, ", "))), false, nil
+	}
+
+	return admission.Allowed("Connection permissions validated successfully"), true, secretRefs
+}
+
+// parseConnectionsAnnotation parses the connections annotation value into a list of secret references.
+// The annotation value should be a comma-separated list of fully qualified secret names (namespace/name).
+func parseConnectionsAnnotation(value string) ([]corev1.SecretReference, error) {
+	if strings.TrimSpace(value) == "" {
+		return nil, nil
+	}
+
+	parts := strings.Split(value, ",")
+	secretRefs := make([]corev1.SecretReference, 0)
+
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+
+		// Parse namespace/name format
+		secretParts := strings.Split(part, "/")
+		if len(secretParts) != 2 {
+			return nil, fmt.Errorf("invalid secret reference format '%s' - expected 'namespace/name'", part)
+		}
+
+		namespace := strings.TrimSpace(secretParts[0])
+		name := strings.TrimSpace(secretParts[1])
+
+		if namespace == "" || name == "" {
+			return nil, fmt.Errorf("invalid secret reference '%s' - namespace and name cannot be empty", part)
+		}
+
+		secretRefs = append(secretRefs, corev1.SecretReference{
+			Name:      name,
+			Namespace: namespace,
+		})
+	}
+
+	return secretRefs, nil
+}
+
+// checkSecretPermission checks if the user has permission to "get" the specified secret using SubjectAccessReview.
+func (w *NotebookWebhook) checkSecretPermission(ctx context.Context, req *admission.Request, secretRef corev1.SecretReference) (bool, error) {
+	log := logf.FromContext(ctx)
+
+	// Create a SubjectAccessReview to check if the user can "get" the secret
+	sar := &authorizationv1.SubjectAccessReview{
+		Spec: authorizationv1.SubjectAccessReviewSpec{
+			User:   req.UserInfo.Username,
+			Groups: req.UserInfo.Groups,
+			ResourceAttributes: &authorizationv1.ResourceAttributes{
+				Namespace: secretRef.Namespace,
+				Verb:      "get",
+				Group:     "",
+				Version:   "v1",
+				Resource:  "secrets",
+				Name:      secretRef.Name,
+			},
+		},
+	}
+
+	// Send the SubjectAccessReview to the API server
+	if err := w.Client.Create(ctx, sar); err != nil {
+		log.Error(err, "failed to create SubjectAccessReview", "secret", secretRef.Name, "namespace", secretRef.Namespace)
+		return false, fmt.Errorf("failed to create SubjectAccessReview: %w", err)
+	}
+
+	// Check the result
+	if !sar.Status.Allowed {
+		log.V(1).Info("user does not have permission to access secret",
+			"secret", secretRef.Name,
+			"namespace", secretRef.Namespace,
+			"reason", sar.Status.Reason,
+			"evaluationError", sar.Status.EvaluationError,
+		)
+
+		return false, nil
+	}
+
+	log.V(1).Info("user has permission to access secret", "secret", secretRef.Name, "namespace", secretRef.Namespace)
+	return true, nil
+}
+
+func (w *NotebookWebhook) performConnectionInjection(req admission.Request, secretRefs []corev1.SecretReference) (bool, *unstructured.Unstructured, error) {
+	obj := &unstructured.Unstructured{}
+	if err := w.Decoder.Decode(req, obj); err != nil {
+		return false, nil, fmt.Errorf("failed to decode Notebook object: %w", err)
+	}
+
+	if len(secretRefs) == 0 {
+		return false, obj, nil
+	}
+
+	// Get the notebook containers
+	containers, found, err := unstructured.NestedSlice(obj.Object, NotebookContainersPath...)
+	if err != nil {
+		return false, nil, fmt.Errorf("failed to get containers array: %w", err)
+	}
+	if !found || len(containers) == 0 {
+		return false, nil, errors.New("no containers found in notebook")
+	}
+
+	// The notebook only has one container, so we can get the envFrom from the first container
+	container, ok := containers[0].(map[string]interface{})
+	if !ok {
+		return false, nil, errors.New("first container is not a map[string]interface{}")
+	}
+
+	// Get existing envFrom from the container
+	existingEnvFrom, _ := container["envFrom"].([]interface{})
+
+	// Keep only non-secretRef entries (like configMapRef)
+	var preservedEntries []interface{}
+	for _, entry := range existingEnvFrom {
+		if entryMap, ok := entry.(map[string]interface{}); ok {
+			if _, hasSecretRef := entryMap["secretRef"]; !hasSecretRef {
+				preservedEntries = append(preservedEntries, entry)
+			}
+		}
+	}
+
+	// Add all connection secrets
+	newEnvFrom := preservedEntries
+	for _, secretRef := range secretRefs {
+		secretEntry := map[string]interface{}{
+			"secretRef": map[string]interface{}{
+				"name": secretRef.Name,
+			},
+		}
+		newEnvFrom = append(newEnvFrom, secretEntry)
+	}
+
+	// Set the updated envFrom back to the container
+	container["envFrom"] = newEnvFrom
+
+	// Update the first container in the containers array
+	containers[0] = container
+
+	// Set the modified containers array back to the object
+	if err := unstructured.SetNestedSlice(obj.Object, containers, NotebookContainersPath...); err != nil {
+		return false, nil, fmt.Errorf("failed to set containers array: %w", err)
+	}
+
+	return true, obj, nil
+}

--- a/internal/webhook/notebook/mutating_test.go
+++ b/internal/webhook/notebook/mutating_test.go
@@ -1,0 +1,505 @@
+package notebook_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"gomodules.xyz/jsonpatch/v2"
+	admissionv1 "k8s.io/api/admission/v1"
+	authorizationv1 "k8s.io/api/authorization/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	"github.com/opendatahub-io/opendatahub-operator/v2/internal/webhook/envtestutil"
+	"github.com/opendatahub-io/opendatahub-operator/v2/internal/webhook/notebook"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/metadata/annotations"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/scheme"
+
+	. "github.com/onsi/gomega"
+)
+
+const (
+	testNamespace    = "test-namespace"
+	testNotebook     = "test-notebook"
+	testSecret1      = "secret1"
+	testSecret2      = "secret2"
+	addOperation     = "add"
+	replaceOperation = "replace"
+)
+
+// Helper function to create a test webhook.
+func createTestWebhook(t *testing.T, cli client.Client) *notebook.NotebookWebhook {
+	t.Helper()
+	g := NewWithT(t)
+
+	sch, err := scheme.New()
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	return &notebook.NotebookWebhook{
+		Client:  cli,
+		Decoder: admission.NewDecoder(sch),
+		Name:    "test-webhook",
+	}
+}
+
+// Helper function to create a basic notebook object.
+func createNotebook(options ...func(*unstructured.Unstructured)) *unstructured.Unstructured {
+	notebook := &unstructured.Unstructured{}
+	notebook.SetGroupVersionKind(gvk.Notebook)
+	notebook.SetName(testNotebook)
+	notebook.SetNamespace(testNamespace)
+
+	spec := map[string]interface{}{
+		"template": map[string]interface{}{
+			"spec": map[string]interface{}{
+				"containers": []interface{}{
+					map[string]interface{}{
+						"name":  "notebook",
+						"image": "notebook:latest",
+					},
+				},
+			},
+		},
+	}
+	notebook.Object["spec"] = spec
+
+	for _, opt := range options {
+		opt(notebook)
+	}
+
+	return notebook
+}
+
+// Helper function to add annotations to a notebook.
+func withAnnotations(annotations map[string]string) func(*unstructured.Unstructured) {
+	return func(notebook *unstructured.Unstructured) {
+		notebook.SetAnnotations(annotations)
+	}
+}
+
+// Helper function to add existing envFrom to a notebook.
+func withExistingEnvFrom(envFrom []interface{}) func(*unstructured.Unstructured) {
+	return func(nb *unstructured.Unstructured) {
+		containers, _, _ := unstructured.NestedSlice(nb.Object, notebook.NotebookContainersPath...)
+		if len(containers) > 0 {
+			if container, ok := containers[0].(map[string]interface{}); ok {
+				container["envFrom"] = envFrom
+				containers[0] = container
+				_ = unstructured.SetNestedSlice(nb.Object, containers, notebook.NotebookContainersPath...)
+			}
+		}
+	}
+}
+
+// Helper function to create admission request.
+func createAdmissionRequest(t *testing.T, operation admissionv1.Operation, obj *unstructured.Unstructured) admission.Request {
+	t.Helper()
+	return envtestutil.NewAdmissionRequest(
+		t,
+		operation,
+		obj,
+		gvk.Notebook,
+		metav1.GroupVersionResource{
+			Group:    gvk.Notebook.Group,
+			Version:  gvk.Notebook.Version,
+			Resource: "notebooks",
+		},
+	)
+}
+
+// Helper struct to mock SubjectAccessReview behavior.
+type mockClient struct {
+	client.Client
+	allowPermissions map[string]bool
+}
+
+func (m *mockClient) Create(ctx context.Context, obj client.Object, opts ...client.CreateOption) error {
+	if sar, ok := obj.(*authorizationv1.SubjectAccessReview); ok {
+		secretName := sar.Spec.ResourceAttributes.Name
+		allowed, exists := m.allowPermissions[secretName]
+		sar.Status = authorizationv1.SubjectAccessReviewStatus{
+			Allowed: exists && allowed,
+		}
+		if !allowed {
+			sar.Status.Reason = "insufficient permissions"
+		}
+		return nil
+	}
+	return m.Client.Create(ctx, obj, opts...)
+}
+
+func TestNotebookWebhook_Handle_BasicValidation(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name               string
+		annotations        map[string]string
+		expectedAllowed    bool
+		expectedMessage    string
+		expectedPatchesLen int
+	}{
+		{
+			name:               "no annotations",
+			annotations:        nil,
+			expectedAllowed:    true,
+			expectedMessage:    "no injection needed",
+			expectedPatchesLen: 0,
+		},
+		{
+			name: "empty connections annotation",
+			annotations: map[string]string{
+				annotations.Connection: "",
+			},
+			expectedAllowed:    true,
+			expectedMessage:    "no injection needed",
+			expectedPatchesLen: 0,
+		},
+		{
+			name: "invalid annotation format - missing namespace",
+			annotations: map[string]string{
+				annotations.Connection: "invalid-format",
+			},
+			expectedAllowed:    false,
+			expectedMessage:    "failed to parse connections annotation",
+			expectedPatchesLen: 0,
+		},
+		{
+			name: "invalid annotation format - empty name",
+			annotations: map[string]string{
+				annotations.Connection: fmt.Sprintf("%s/", testNamespace),
+			},
+			expectedAllowed:    false,
+			expectedMessage:    "failed to parse connections annotation",
+			expectedPatchesLen: 0,
+		},
+		{
+			name: "invalid annotation format - empty namespace",
+			annotations: map[string]string{
+				annotations.Connection: fmt.Sprintf("/%s", testSecret1),
+			},
+			expectedAllowed:    false,
+			expectedMessage:    "failed to parse connections annotation",
+			expectedPatchesLen: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewWithT(t)
+
+			cli := fake.NewClientBuilder().Build()
+			webhook := createTestWebhook(t, cli)
+
+			notebook := createNotebook(withAnnotations(tt.annotations))
+			req := createAdmissionRequest(t, admissionv1.Create, notebook)
+
+			resp := webhook.Handle(context.Background(), req)
+
+			g.Expect(resp.Allowed).Should(Equal(tt.expectedAllowed))
+			g.Expect(resp.Patches).Should(HaveLen(tt.expectedPatchesLen))
+			g.Expect(resp.Result.Message).Should(ContainSubstring(tt.expectedMessage))
+		})
+	}
+}
+
+func TestNotebookWebhook_Handle_Permissions(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name              string
+		connections       string
+		allowPermissions  map[string]bool
+		expectedAllowed   bool
+		expectedMessage   string
+		shouldHavePatches bool
+		forbiddenSecrets  []string
+	}{
+		{
+			name:        "successful injection with single secret",
+			connections: fmt.Sprintf("%s/%s", testNamespace, testSecret1),
+			allowPermissions: map[string]bool{
+				testSecret1: true,
+			},
+			expectedAllowed:   true,
+			shouldHavePatches: true,
+		},
+		{
+			name:        "permission denied for single secret",
+			connections: fmt.Sprintf("%s/%s", testNamespace, testSecret1),
+			allowPermissions: map[string]bool{
+				testSecret1: false,
+			},
+			expectedAllowed:   false,
+			expectedMessage:   "user does not have permission to access the following connection secrets",
+			shouldHavePatches: false,
+			forbiddenSecrets:  []string{fmt.Sprintf("%s/%s", testNamespace, testSecret1)},
+		},
+		{
+			name:        "mixed permissions for multiple secrets",
+			connections: fmt.Sprintf("%s/%s,%s/%s", testNamespace, testSecret1, testNamespace, testSecret2),
+			allowPermissions: map[string]bool{
+				testSecret1: true,
+				testSecret2: false,
+			},
+			expectedAllowed:   false,
+			expectedMessage:   "user does not have permission to access the following connection secrets",
+			shouldHavePatches: false,
+			forbiddenSecrets:  []string{fmt.Sprintf("%s/%s", testNamespace, testSecret2)},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewWithT(t)
+
+			baseCli := fake.NewClientBuilder().Build()
+			cli := &mockClient{
+				Client:           baseCli,
+				allowPermissions: tt.allowPermissions,
+			}
+
+			webhook := createTestWebhook(t, cli)
+
+			notebook := createNotebook(withAnnotations(map[string]string{
+				annotations.Connection: tt.connections,
+			}))
+			req := createAdmissionRequest(t, admissionv1.Create, notebook)
+
+			resp := webhook.Handle(context.Background(), req)
+
+			g.Expect(resp.Allowed).Should(Equal(tt.expectedAllowed))
+
+			if tt.shouldHavePatches {
+				g.Expect(resp.Patches).ShouldNot(BeEmpty())
+			} else {
+				g.Expect(resp.Patches).Should(BeEmpty())
+			}
+
+			if tt.expectedMessage != "" {
+				g.Expect(resp.Result.Message).Should(ContainSubstring(tt.expectedMessage))
+			}
+
+			for _, forbidden := range tt.forbiddenSecrets {
+				g.Expect(resp.Result.Message).Should(ContainSubstring(forbidden))
+			}
+		})
+	}
+}
+
+func TestNotebookWebhook_Handle_Operations(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name              string
+		operation         admissionv1.Operation
+		expectedAllowed   bool
+		expectedMessage   string
+		shouldHavePatches bool
+	}{
+		{
+			name:              "create operation with valid permissions",
+			operation:         admissionv1.Create,
+			expectedAllowed:   true,
+			shouldHavePatches: true,
+		},
+		{
+			name:              "update operation with valid permissions",
+			operation:         admissionv1.Update,
+			expectedAllowed:   true,
+			shouldHavePatches: true,
+		},
+		{
+			name:              "delete operation",
+			operation:         admissionv1.Delete,
+			expectedAllowed:   true,
+			expectedMessage:   "Operation DELETE on Notebook allowed",
+			shouldHavePatches: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewWithT(t)
+
+			baseCli := fake.NewClientBuilder().Build()
+			cli := &mockClient{
+				Client: baseCli,
+				allowPermissions: map[string]bool{
+					testSecret1: true,
+				},
+			}
+
+			webhook := createTestWebhook(t, cli)
+
+			notebook := createNotebook(withAnnotations(map[string]string{
+				annotations.Connection: fmt.Sprintf("%s/%s", testNamespace, testSecret1),
+			}))
+			req := createAdmissionRequest(t, tt.operation, notebook)
+
+			resp := webhook.Handle(context.Background(), req)
+
+			g.Expect(resp.Allowed).Should(Equal(tt.expectedAllowed))
+
+			if tt.shouldHavePatches {
+				g.Expect(resp.Patches).ShouldNot(BeEmpty())
+			} else {
+				g.Expect(resp.Patches).Should(BeEmpty())
+			}
+
+			if tt.expectedMessage != "" {
+				g.Expect(resp.Result.Message).Should(ContainSubstring(tt.expectedMessage))
+			}
+		})
+	}
+}
+
+func TestNotebookWebhook_Handle_EnvFromInjection(t *testing.T) {
+	t.Parallel()
+
+	baseCli := fake.NewClientBuilder().Build()
+	cli := &mockClient{
+		Client: baseCli,
+		allowPermissions: map[string]bool{
+			testSecret1: true,
+			testSecret2: true,
+		},
+	}
+
+	webhook := createTestWebhook(t, cli)
+
+	// Helper function to check if a patch value contains a secretRef with the given name
+	containsSecretRef := func(value interface{}, secretName string) bool {
+		if envFromArray, ok := value.([]interface{}); ok {
+			for _, entry := range envFromArray {
+				if entryMap, ok := entry.(map[string]interface{}); ok {
+					if secretRef, hasSecret := entryMap["secretRef"]; hasSecret {
+						if secretRefMap, ok := secretRef.(map[string]interface{}); ok {
+							if name, hasName := secretRefMap["name"]; hasName && name == secretName {
+								return true
+							}
+						}
+					}
+				}
+			}
+		} else if entryMap, ok := value.(map[string]interface{}); ok {
+			if secretRef, hasSecret := entryMap["secretRef"]; hasSecret {
+				if secretRefMap, ok := secretRef.(map[string]interface{}); ok {
+					if name, hasName := secretRefMap["name"]; hasName && name == secretName {
+						return true
+					}
+				}
+			}
+		}
+		return false
+	}
+
+	tests := []struct {
+		name           string
+		notebook       *unstructured.Unstructured
+		expectedChecks []func(jsonpatch.JsonPatchOperation) bool
+	}{
+		{
+			name: "inject single secret",
+			notebook: createNotebook(withAnnotations(map[string]string{
+				annotations.Connection: fmt.Sprintf("%s/%s", testNamespace, testSecret1),
+			})),
+			expectedChecks: []func(jsonpatch.JsonPatchOperation) bool{
+				func(patch jsonpatch.JsonPatchOperation) bool {
+					return patch.Operation == addOperation &&
+						patch.Path == "/spec/template/spec/containers/0/envFrom" &&
+						containsSecretRef(patch.Value, testSecret1)
+				},
+			},
+		},
+		{
+			name: "inject multiple secrets",
+			notebook: createNotebook(withAnnotations(map[string]string{
+				annotations.Connection: fmt.Sprintf("%s/%s,%s/%s", testNamespace, testSecret1, testNamespace, testSecret2),
+			})),
+			expectedChecks: []func(jsonpatch.JsonPatchOperation) bool{
+				func(patch jsonpatch.JsonPatchOperation) bool {
+					return patch.Operation == addOperation &&
+						patch.Path == "/spec/template/spec/containers/0/envFrom" &&
+						containsSecretRef(patch.Value, testSecret1) &&
+						containsSecretRef(patch.Value, testSecret2)
+				},
+			},
+		},
+		{
+			name: "preserve existing configMapRef and inject secret",
+			notebook: createNotebook(
+				withAnnotations(map[string]string{
+					annotations.Connection: fmt.Sprintf("%s/%s", testNamespace, testSecret1),
+				}),
+				withExistingEnvFrom([]interface{}{
+					map[string]interface{}{
+						"configMapRef": map[string]interface{}{
+							"name": "existing-config",
+						},
+					},
+				}),
+			),
+			expectedChecks: []func(jsonpatch.JsonPatchOperation) bool{
+				func(patch jsonpatch.JsonPatchOperation) bool {
+					return patch.Operation == addOperation &&
+						patch.Path == "/spec/template/spec/containers/0/envFrom/1" &&
+						containsSecretRef(patch.Value, testSecret1)
+				},
+			},
+		},
+		{
+			name: "replace existing secretRef with new one",
+			notebook: createNotebook(
+				withAnnotations(map[string]string{
+					annotations.Connection: fmt.Sprintf("%s/%s", testNamespace, testSecret1),
+				}),
+				withExistingEnvFrom([]interface{}{
+					map[string]interface{}{
+						"secretRef": map[string]interface{}{
+							"name": "old-secret",
+						},
+					},
+				}),
+			),
+			expectedChecks: []func(jsonpatch.JsonPatchOperation) bool{
+				func(patch jsonpatch.JsonPatchOperation) bool {
+					return patch.Operation == replaceOperation &&
+						patch.Path == "/spec/template/spec/containers/0/envFrom/0/secretRef/name" &&
+						patch.Value == testSecret1
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewWithT(t)
+
+			req := createAdmissionRequest(t, admissionv1.Create, tt.notebook)
+			resp := webhook.Handle(context.Background(), req)
+
+			g.Expect(resp.Allowed).Should(BeTrue())
+			g.Expect(resp.Patches).ShouldNot(BeEmpty())
+
+			verifyExpectedPatches(t, resp.Patches, tt.expectedChecks)
+		})
+	}
+}
+
+// Helper function to verify expected patches.
+func verifyExpectedPatches(t *testing.T, actualPatches []jsonpatch.JsonPatchOperation, expectedPatchChecks []func(jsonpatch.JsonPatchOperation) bool) {
+	t.Helper()
+	g := NewWithT(t)
+
+	g.Expect(actualPatches).Should(HaveLen(len(expectedPatchChecks)), "Expected number of patches to match")
+
+	for i, check := range expectedPatchChecks {
+		g.Expect(check(actualPatches[i])).Should(BeTrue(), fmt.Sprintf("Patch %d failed validation", i))
+	}
+}

--- a/internal/webhook/notebook/register.go
+++ b/internal/webhook/notebook/register.go
@@ -1,0 +1,21 @@
+//go:build !nowebhook
+
+package notebook
+
+import (
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+// RegisterWebhooks registers the combined connection webhook that handles both validation and mutation for notebooks.
+func RegisterWebhooks(mgr ctrl.Manager) error {
+	if err := (&NotebookWebhook{
+		Client:  mgr.GetClient(),
+		Decoder: admission.NewDecoder(mgr.GetScheme()),
+		Name:    "notebook-webhook",
+	}).SetupWithManager(mgr); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/internal/webhook/webhook.go
+++ b/internal/webhook/webhook.go
@@ -11,6 +11,7 @@ import (
 	hardwareprofilewebhook "github.com/opendatahub-io/opendatahub-operator/v2/internal/webhook/hardwareprofile"
 	isvc "github.com/opendatahub-io/opendatahub-operator/v2/internal/webhook/inferenceservice"
 	kueuewebhook "github.com/opendatahub-io/opendatahub-operator/v2/internal/webhook/kueue"
+	notebookwebhook "github.com/opendatahub-io/opendatahub-operator/v2/internal/webhook/notebook"
 )
 
 // RegisterAllWebhooks registers all webhook setup functions with the given manager.
@@ -23,6 +24,7 @@ func RegisterAllWebhooks(mgr ctrl.Manager) error {
 		hardwareprofilewebhook.RegisterWebhooks,
 		kueuewebhook.RegisterWebhooks,
 		isvc.RegisterWebhooks,
+		notebookwebhook.RegisterWebhooks,
 	}
 	for _, reg := range webhookRegistrations {
 		if err := reg(mgr); err != nil {


### PR DESCRIPTION
## Description
JIRA: [RHOAIENG-30279](https://issues.redhat.com/browse/RHOAIENG-30279)

This PR adds a webhook that validates and mutates Notebook resources that have a connection annotation (`opendatahub.io/connections`).

The webhook checks that the annotation is properly formatted meaning the value is a comma separated list of fully qualified secret names. The webhook also checks that the user requesting the Notebook resource is able to `get` each of the secrets that they are trying to inject into the workload. Once the annotation has been validated, the webhook injects the Secrets into the Notebook following the [dashboard's ADR](https://github.com/opendatahub-io/architecture-decision-records/blob/main/documentation/components/dashboard/features/connections.md#workbench-connections).

## How Has This Been Tested?
These changes were tested by building operator, bundle, and catalog images, then verifying that the DSC and DSCI CRs successfully reconcile.

The following images were used for testing and can be used for verification:
```
quay.io/ckyrillo/opendatahub-operator:v2.33.0
quay.io/ckyrillo/opendatahub-operator-bundle:v2.33.0
quay.io/ckyrillo/opendatahub-operator-catalog:v2.33.0
```

I confirmed that the webhook admits the following scenarios:
* Create/Update operations with a valid annotation
* Create/Update operations with no annotation
* Create/Update operations with an empty annotation, i.e. `opendatahub.io/connections: ""`
* Any delete operations

I confirmed that the webhook denies the following scenarios:
* Create/Update operations where the annotation is improperly formatted
* Create/Update operations where the annotation is missing the secret name
* Create/Update operations where the annotation is missing the secret namespace
* Create/Update operations where the user doesn't have permission to get the listed secret

## Screenshot or short clip
Webhook denies notebook because of improperly formatted annotation:
<img width="1622" height="794" alt="30279-bad-annotation-error" src="https://github.com/user-attachments/assets/d00dd1dd-854f-4337-8d01-70df6ca17500" />

Webhook denies notebook because of missing secret name:
<img width="1622" height="794" alt="30279-no-name-error" src="https://github.com/user-attachments/assets/0a5cc74d-7f9e-4f65-afa4-75c59f64907c" />

Webhook denies notebook because of missing secret namespace:
<img width="1622" height="794" alt="30279-no-ns-error" src="https://github.com/user-attachments/assets/d10307ae-fe42-442e-839d-0ac309d91e78" />

Webhook denies notebook because user doesn't have permission to get secret:
<img width="1622" height="794" alt="30279-no-permission-error" src="https://github.com/user-attachments/assets/f51b0841-efc4-479d-b131-f8385a3952f2" />

## Merge criteria
- [X] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [X] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [X] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work
