### PR TITLE
[RHOAIENG-28366] Add SCC access for llm-d

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -1020,6 +1020,21 @@ rules:
 - apiGroups:
   - security.openshift.io
   resourceNames:
+  - openshift-ai-llminferenceservice-scc
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - use
+  - watch
+- apiGroups:
+  - security.openshift.io
+  resourceNames:
   - restricted
   resources:
   - securitycontextconstraints

--- a/internal/controller/datasciencecluster/kubebuilder_rbac.go
+++ b/internal/controller/datasciencecluster/kubebuilder_rbac.go
@@ -200,6 +200,7 @@ package datasciencecluster
 /* LLM-d */
 // +kubebuilder:rbac:groups="serving.kserve.io",resources=llminferenceserviceconfigs,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="serving.kserve.io",resources=llminferenceserviceconfigs/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups="security.openshift.io",resources=securitycontextconstraints,verbs=get;list;watch;create;update;patch;delete;use,resourceNames=openshift-ai-llminferenceservice-scc
 
 // WB
 // +kubebuilder:rbac:groups=components.platform.opendatahub.io,resources=workbenches,verbs=get;list;watch;create;update;patch;delete


### PR DESCRIPTION
The DP<>EP deployment requires running with privileged, hostIPC, hostPID, so Kserve controller will bundle an SCC as part of the manifests.

Related to https://github.com/opendatahub-io/kserve/pull/802
