### PR TITLE
update: change log.Info() to log.V(1).Info() for webhook to reduce noise

### DIFF
--- a/internal/webhook/auth/validating.go
+++ b/internal/webhook/auth/validating.go
@@ -120,14 +120,14 @@ func (v *Validator) validateAuthGroups(ctx context.Context, req admission.Reques
 	if invalidAdminGroups := validateAdminGroups(auth.Spec.AdminGroups); len(invalidAdminGroups) > 0 {
 		msg := fmt.Sprintf("Invalid groups found in AdminGroups: %s. Groups cannot be '%s' or empty string",
 			strings.Join(invalidAdminGroups, ", "), SystemAuthenticatedGroup)
-		log.Info("Rejecting Auth resource due to invalid AdminGroups", "invalidGroups", invalidAdminGroups)
+		log.V(1).Info("Rejecting Auth resource due to invalid AdminGroups", "invalidGroups", invalidAdminGroups)
 		return admission.Denied(msg)
 	}
 
 	if invalidAllowedGroups := validateAllowedGroups(auth.Spec.AllowedGroups); len(invalidAllowedGroups) > 0 {
 		msg := fmt.Sprintf("Invalid groups found in AllowedGroups: %s. Groups cannot be empty string",
 			strings.Join(invalidAllowedGroups, ", "))
-		log.Info("Rejecting Auth resource due to invalid AllowedGroups", "invalidGroups", invalidAllowedGroups)
+		log.V(1).Info("Rejecting Auth resource due to invalid AllowedGroups", "invalidGroups", invalidAllowedGroups)
 		return admission.Denied(msg)
 	}
 

--- a/internal/webhook/datasciencecluster/defaulting.go
+++ b/internal/webhook/datasciencecluster/defaulting.go
@@ -82,7 +82,7 @@ func (d *Defaulter) applyDefaults(ctx context.Context, dsc *dscv1.DataScienceClu
 	modelRegistry := &dsc.Spec.Components.ModelRegistry
 	if modelRegistry.ManagementState == operatorv1.Managed {
 		if modelRegistry.RegistriesNamespace == "" {
-			log.Info("Setting default RegistriesNamespace for ModelRegistry", "default", modelregistryctrl.DefaultModelRegistriesNamespace)
+			log.V(1).Info("Setting default RegistriesNamespace for ModelRegistry", "default", modelregistryctrl.DefaultModelRegistriesNamespace)
 			modelRegistry.RegistriesNamespace = modelregistryctrl.DefaultModelRegistriesNamespace
 		}
 	}

--- a/internal/webhook/hardwareprofile/mutating.go
+++ b/internal/webhook/hardwareprofile/mutating.go
@@ -317,7 +317,7 @@ func (i *Injector) fetchHardwareProfile(ctx context.Context, namespace, name str
 func (i *Injector) applyHardwareProfileToWorkload(ctx context.Context, obj *unstructured.Unstructured, hwp *hwpv1alpha1.HardwareProfile) error {
 	log := logf.FromContext(ctx)
 
-	log.Info("applying hardware profile to workload", "workload", obj.GetName(), "kind", obj.GetKind(), "hardwareProfile", hwp.Name)
+	log.V(1).Info("applying hardware profile to workload", "workload", obj.GetName(), "kind", obj.GetKind(), "hardwareProfile", hwp.Name)
 
 	// Apply resource requirements to containers (only if there are identifiers)
 	if len(hwp.Spec.Identifiers) > 0 {

--- a/internal/webhook/inferenceservice/mutating.go
+++ b/internal/webhook/inferenceservice/mutating.go
@@ -138,7 +138,7 @@ func (w *ConnectionWebhook) performConnectionInjection(
 ) (bool, error) {
 	log := logf.FromContext(ctx)
 
-	log.Info("Decoded InferenceService object", "connectionType", connectionType, "operation", req.Operation)
+	log.V(1).Info("Decoded InferenceService object", "connectionType", connectionType, "operation", req.Operation)
 
 	// injection based on connection type
 	switch ConnectionType(connectionType) {
@@ -146,25 +146,25 @@ func (w *ConnectionWebhook) performConnectionInjection(
 		if err := w.injectOCIImagePullSecrets(decodedObj, secretName); err != nil {
 			return false, fmt.Errorf("failed to inject OCI imagePullSecrets: %w", err)
 		}
-		log.Info("Successfully injected OCI imagePullSecrets", "secretName", secretName)
+		log.V(1).Info("Successfully injected OCI imagePullSecrets", "secretName", secretName)
 		return true, nil
 
 	case ConnectionTypeURI:
 		if err := w.injectURIStorageUri(ctx, decodedObj, secretName, req.Namespace); err != nil {
 			return false, fmt.Errorf("failed to inject URI storageUri: %w", err)
 		}
-		log.Info("Successfully injected URI storageUri from secret", "secretName", secretName)
+		log.V(1).Info("Successfully injected URI storageUri from secret", "secretName", secretName)
 		return true, nil
 
 	case ConnectionTypeS3:
 		if err := w.injectS3StorageKey(decodedObj, secretName); err != nil {
 			return false, fmt.Errorf("failed to inject S3 storage.key: %w", err)
 		}
-		log.Info("Successfully injected S3 storage key", "secretName", secretName)
+		log.V(1).Info("Successfully injected S3 storage key", "secretName", secretName)
 		return true, nil
 
 	default: // this should not enter since ValidateConnectionAnnotation ensures valid types, but keep it for safety
-		log.Info("Unknown connection type, skipping injection", "connectionType", connectionType)
+		log.V(1).Info("Unknown connection type, skipping injection", "connectionType", connectionType)
 		return false, nil
 	}
 }


### PR DESCRIPTION
- only when set --zap-log-level=debug or env ZAP_LOG_LEVEL=debug

<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reduced the default verbosity of several informational log messages throughout the application. These messages will now only appear when verbose logging is enabled, resulting in less cluttered log output for end-users during normal operation. No changes were made to application functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->