### PR TITLE
 Fix connection webhook to skip validation for objects marked for deletion

### DIFF
--- a/internal/webhook/inferenceservice/mutating.go
+++ b/internal/webhook/inferenceservice/mutating.go
@@ -86,6 +86,10 @@ func (w *ConnectionWebhook) Handle(ctx context.Context, req admission.Request) a
 			return admission.Errored(http.StatusInternalServerError, err)
 		}
 
+		if !obj.GetDeletionTimestamp().IsZero() {
+			return admission.Allowed("Object marked for deletion, skipping connection logic")
+		}
+
 		// allowed connection types for connection validation on isvc.
 		allowedTypes := []string{
 			ConnectionTypeURI.String(),

--- a/tests/e2e/kserve_test.go
+++ b/tests/e2e/kserve_test.go
@@ -449,6 +449,7 @@ func (tc *KserveTestCtx) ValidateConnectionWebhookInjection(t *testing.T) {
 	t.Cleanup(func() {
 		tc.DeleteResource(
 			WithMinimalObject(gvk.Namespace, types.NamespacedName{Name: testNamespace}),
+			WithWaitForDeletion(true),
 		)
 	})
 


### PR DESCRIPTION
The connection webhook for InferenceService blocks deletion operations when referenced connection secrets are missing, causing the TrustyAI e2e test Delete_InferenceServices to fail with a 300-second timeout.

**Root Cause**
The connection webhook validates and injects connection secrets for both CREATE and UPDATE operations without checking if the object is marked for deletion. During InferenceService deletion:
1. Finalizer processing triggers UPDATE webhook calls even though the object has deletionTimestamp set
2. Connection validation fails when referenced secrets are already deleted (e.g., during namespace cascade deletion)
3. Webhook blocks the operation, preventing proper finalizer cleanup
4. Object remains stuck in deletion state.

## Summary by CodeRabbit

* **Tests**
  * Improved test cleanup process to ensure resources are deleted in the correct order, preventing potential issues during namespace deletion.
* **Bug Fixes**
  * Skipped connection validation for resources marked for deletion to avoid unnecessary processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->