### PR TITLE
fix: enable moniotoring namespace for other platform if monitoring is enabled

### DIFF
--- a/internal/controller/dscinitialization/utils.go
+++ b/internal/controller/dscinitialization/utils.go
@@ -45,8 +45,7 @@ func (r *DSCInitializationReconciler) createOperatorResource(ctx context.Context
 		return err
 	}
 
-	// Patch monitoring namespace: only for Managed cluster
-	if platform == cluster.ManagedRhoai {
+	if dscInit.Spec.Monitoring.ManagementState == operatorv1.Managed || platform == cluster.SelfManagedRhoai {
 		if err := PatchMonitoringNS(ctx, r.Client, dscInit); err != nil {
 			log.Error(err, "error patch monitoring namespace")
 			return err


### PR DESCRIPTION
- ODH and self-managed : is monitoring is enabled
- managed : always

<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
