### PR TITLE
RHOAIENG-31536 - OpenTelemetry and Cluster Observability operators are required to be installed despite no observability configured

### DIFF
--- a/internal/controller/services/monitoring/monitoring_controller_actions.go
+++ b/internal/controller/services/monitoring/monitoring_controller_actions.go
@@ -108,45 +108,44 @@ func deployMonitoringStack(ctx context.Context, rr *odhtypes.ReconciliationReque
 		return errors.New("instance is not of type *services.Monitoring")
 	}
 
-	if monitoring.Spec.Metrics != nil && (monitoring.Spec.Metrics.Resources != nil || monitoring.Spec.Metrics.Storage != nil) {
-		msExists, err := cluster.HasCRD(ctx, rr.Client, gvk.MonitoringStack)
-		if err != nil {
-			return fmt.Errorf("failed to check if CRD MonitoringStack exists: %w", err)
-		}
-		if !msExists {
-			// CRD not available, skip monitoring stack deployment (this is expected when monitoring stack operator is not installed)
-			rr.Conditions.MarkFalse(
-				status.ConditionMonitoringStackAvailable,
-				conditions.WithReason(gvk.MonitoringStack.Kind+"CRDNotFoundReason"),
-				conditions.WithMessage(gvk.MonitoringStack.Kind+" CRD Not Found"),
-			)
-			return nil
-		}
-
-		rr.Conditions.MarkTrue(status.ConditionMonitoringStackAvailable)
-
-		template := []odhtypes.TemplateInfo{
-			{
-				FS:   resourcesFS,
-				Path: MonitoringStackTemplate,
-			},
-			{
-				FS:   resourcesFS,
-				Path: PrometheusRouteTemplate,
-			},
-		}
-
-		rr.Templates = append(rr.Templates, template...)
-
+	// No monitoring stack configuration
+	if monitoring.Spec.Metrics == nil {
+		rr.Conditions.MarkFalse(
+			status.ConditionMonitoringStackAvailable,
+			conditions.WithReason(status.MetricsNotConfiguredReason),
+			conditions.WithMessage(status.MetricsNotConfiguredMessage),
+		)
 		return nil
 	}
 
-	// No monitoring stack configuration
-	rr.Conditions.MarkFalse(
-		status.ConditionMonitoringStackAvailable,
-		conditions.WithReason(status.MetricsNotConfiguredReason),
-		conditions.WithMessage(status.MetricsNotConfiguredMessage),
-	)
+	msExists, err := cluster.HasCRD(ctx, rr.Client, gvk.MonitoringStack)
+	if err != nil {
+		return fmt.Errorf("failed to check if CRD MonitoringStack exists: %w", err)
+	}
+	if !msExists {
+		// CRD not available, skip monitoring stack deployment (this is expected when monitoring stack operator is not installed)
+		rr.Conditions.MarkFalse(
+			status.ConditionMonitoringStackAvailable,
+			conditions.WithReason(gvk.MonitoringStack.Kind+"CRDNotFoundReason"),
+			conditions.WithMessage(gvk.MonitoringStack.Kind+" CRD Not Found"),
+		)
+		return nil
+	}
+
+	rr.Conditions.MarkTrue(status.ConditionMonitoringStackAvailable)
+
+	template := []odhtypes.TemplateInfo{
+		{
+			FS:   resourcesFS,
+			Path: MonitoringStackTemplate,
+		},
+		{
+			FS:   resourcesFS,
+			Path: PrometheusRouteTemplate,
+		},
+	}
+
+	rr.Templates = append(rr.Templates, template...)
 
 	return nil
 }
@@ -155,6 +154,17 @@ func deployOpenTelemetryCollector(ctx context.Context, rr *odhtypes.Reconciliati
 	monitoring, ok := rr.Instance.(*serviceApi.Monitoring)
 	if !ok {
 		return errors.New("instance is not of type *services.Monitoring")
+	}
+
+	// Read metrics configuration directly from Monitoring CR
+	if monitoring.Spec.Metrics == nil {
+		// No metrics configuration - skip OpenTelemetry collector deployment for metrics
+		rr.Conditions.MarkFalse(
+			status.ConditionOpenTelemetryCollectorAvailable,
+			conditions.WithReason(status.MetricsNotConfiguredReason),
+			conditions.WithMessage(status.MetricsNotConfiguredMessage),
+		)
+		return nil
 	}
 
 	otcExists, err := cluster.HasCRD(ctx, rr.Client, gvk.OpenTelemetryCollector)
@@ -175,30 +185,21 @@ func deployOpenTelemetryCollector(ctx context.Context, rr *odhtypes.Reconciliati
 		status.ConditionOpenTelemetryCollectorAvailable,
 	)
 
-	if monitoring.Spec.Metrics != nil {
-		template := []odhtypes.TemplateInfo{
-			{
-				FS:   resourcesFS,
-				Path: OpenTelemetryCollectorTemplate,
-			},
-			{
-				FS:   resourcesFS,
-				Path: CollectorRBACTemplate,
-			},
-			{
-				FS:   resourcesFS,
-				Path: CollectorServiceMonitorsTemplate,
-			},
-		}
-		rr.Templates = append(rr.Templates, template...)
-	} else {
-		// No metrics configuration - skip OpenTelemetry collector deployment for metrics
-		rr.Conditions.MarkFalse(
-			status.ConditionOpenTelemetryCollectorAvailable,
-			conditions.WithReason(status.MetricsNotConfiguredReason),
-			conditions.WithMessage(status.MetricsNotConfiguredMessage),
-		)
+	template := []odhtypes.TemplateInfo{
+		{
+			FS:   resourcesFS,
+			Path: OpenTelemetryCollectorTemplate,
+		},
+		{
+			FS:   resourcesFS,
+			Path: CollectorRBACTemplate,
+		},
+		{
+			FS:   resourcesFS,
+			Path: CollectorServiceMonitorsTemplate,
+		},
 	}
+	rr.Templates = append(rr.Templates, template...)
 
 	return nil
 }

--- a/internal/controller/services/monitoring/monitoring_controller_support.go
+++ b/internal/controller/services/monitoring/monitoring_controller_support.go
@@ -145,10 +145,14 @@ func addMonitoringCapability(ctx context.Context, rr *odhtypes.ReconciliationReq
 }
 
 func checkMonitoringPreconditions(ctx context.Context, rr *odhtypes.ReconciliationRequest) error {
+	monitoring, ok := rr.Instance.(*serviceApi.Monitoring)
+	if !ok {
+		return errors.New("instance is not of type services.Monitoring")
+	}
 	var allErrors *multierror.Error
 
 	// Check for opentelemetry-product operator if either metrics or traces are enabled
-	if rr.DSCI.Spec.Monitoring.Metrics != nil || rr.DSCI.Spec.Monitoring.Traces != nil {
+	if monitoring.Spec.Metrics != nil || monitoring.Spec.Traces != nil {
 		if found, err := cluster.OperatorExists(ctx, rr.Client, opentelemetryOperator); err != nil || !found {
 			if err != nil {
 				return odherrors.NewStopErrorW(err)
@@ -158,7 +162,7 @@ func checkMonitoringPreconditions(ctx context.Context, rr *odhtypes.Reconciliati
 	}
 
 	// Check for cluster-observability-operator if metrics are enabled
-	if rr.DSCI.Spec.Monitoring.Metrics != nil {
+	if monitoring.Spec.Metrics != nil {
 		if found, err := cluster.OperatorExists(ctx, rr.Client, clusterObservabilityOperator); err != nil || !found {
 			if err != nil {
 				return odherrors.NewStopErrorW(err)
@@ -168,7 +172,7 @@ func checkMonitoringPreconditions(ctx context.Context, rr *odhtypes.Reconciliati
 	}
 
 	// Check for tempo-product operator if traces are enabled
-	if rr.DSCI.Spec.Monitoring.Traces != nil {
+	if monitoring.Spec.Traces != nil {
 		if found, err := cluster.OperatorExists(ctx, rr.Client, tempoOperator); err != nil || !found {
 			if err != nil {
 				return odherrors.NewStopErrorW(err)

--- a/internal/controller/status/status.go
+++ b/internal/controller/status/status.go
@@ -103,7 +103,7 @@ const (
 	ConditionMonitoringAvailable             = "MonitoringAvailable"
 	ConditionMonitoringStackAvailable        = "MonitoringStackAvailable"
 	ConditionTempoAvailable                  = "TempoAvailable"
-	ConditionOpenTelemetryCollectorAvailable = "OpenTelemetryCollectorCRDAvailable"
+	ConditionOpenTelemetryCollectorAvailable = "OpenTelemetryCollectorAvailable"
 	ConditionInstrumentationAvailable        = "InstrumentationAvailable"
 )
 


### PR DESCRIPTION
## Description
**JIRA:** [RHOAIENG-31536](https://issues.redhat.com/browse/RHOAIENG-31536)

This PR mainly:
* Fixes issue where even if no observability is configured, i.e. metrics and traces are empty (or metrics: {}) in DSCI, Monitoring CR is Not Ready because it lists 2 errors to install OpenTelemetry and Cluster Observability operators. This happens right after installation, so even if no observability runs, operator requires 2 out of 3 dependent operators to be present.
* Fixes separation of concerns as now monitoring controller's check for dependent operators is done by reading Monitoring CR instead of DSCI.
* Aligned monitoring controller's actions, so they follow the same approach for easier maintenance:
    * Verification of rr.Instance type to be Monitoring CR, if it isn't, end.
    * If not configured (metrics/traces), mark status as not configured and end.
    * Check for relevant CRD presence, if not present, end.
    * If CRD is present, mark status as available.
    * Append templates.
* OpenTelemetryCollectorCRDAvailable condition name changed to OpenTelemetryCollectorAvailable to align with other condition names.

All is done in 3 commits for better separation.

## How Has This Been Tested?
Locally by uninstalling the dependent operators and checking conditions displayed. Trying to deploy different combination of metrics/traces.

## Screenshot or short clip
N/A

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined monitoring stack and OpenTelemetry Collector deployment logic for clearer metrics configuration and CRD checks.
  * Centralized and clarified monitoring specification handling in precondition checks.

* **Style**
  * Updated a status constant to improve naming consistency for OpenTelemetry Collector availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->