### PR TITLE
RHOAIENG-31643 - otel-collector is not deployed when only traces are …

### DIFF
--- a/internal/controller/services/monitoring/monitoring_controller_actions.go
+++ b/internal/controller/services/monitoring/monitoring_controller_actions.go
@@ -156,13 +156,13 @@ func deployOpenTelemetryCollector(ctx context.Context, rr *odhtypes.Reconciliati
 		return errors.New("instance is not of type *services.Monitoring")
 	}
 
-	// Read metrics configuration directly from Monitoring CR
-	if monitoring.Spec.Metrics == nil {
-		// No metrics configuration - skip OpenTelemetry collector deployment for metrics
+	// Read metrics and traces configuration directly from Monitoring CR
+	if monitoring.Spec.Metrics == nil && monitoring.Spec.Traces == nil {
+		// No metrics and traces configuration - skip OpenTelemetry collector deployment
 		rr.Conditions.MarkFalse(
 			status.ConditionOpenTelemetryCollectorAvailable,
-			conditions.WithReason(status.MetricsNotConfiguredReason),
-			conditions.WithMessage(status.MetricsNotConfiguredMessage),
+			conditions.WithReason(status.MetricsNotConfiguredReason+"And"+status.TracesNotConfiguredReason),
+			conditions.WithMessage(status.MetricsNotConfiguredMessage+"\n"+status.TracesNotConfiguredMessage),
 		)
 		return nil
 	}


### PR DESCRIPTION
…enabled


## Description
**JIRA:** [RHOAIENG-31643](https://issues.redhat.com/browse/RHOAIENG-31643)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of OpenTelemetry collector deployment by ensuring it is only deployed when either metrics or traces are configured, preventing unnecessary deployments when both are absent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->