### PR TITLE
docs: add instructions for running integration tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ and configure these applications.
   - [Example DataScienceCluster](#example-datasciencecluster)
   - [Run functional Tests](#run-functional-tests)
   - [Run e2e Tests](#run-e2e-tests)
+  - [Run integration tests (Jenkins pipeline)](#run-integration-tests-jenkins-pipeline)
   - [API Overview](#api-overview)
   - [Component Integration](#component-integration)
   - [Troubleshooting](#troubleshooting)
@@ -531,6 +532,10 @@ Additionally specific env vars can be used to configure tests timeouts
 | E2E_TEST_DEFAULTEVENTUALLYPOLLINTERVAL   | Polling interval for Eventually; overrides Gomega's default of 10 milliseconds.         | `2s`          |
 | E2E_TEST_DEFAULTCONSISTENTLYTIMEOUT      | Duration used for Consistently; overrides Gomega's default of 2 seconds.                | `10s`         |
 | E2E_TEST_DEFAULTCONSISTENTLYPOLLINTERVAL | Polling interval for Consistently; overrides Gomega's default of 50 milliseconds.       | `2s`          |
+
+## Run Integration tests (Jenkins pipeline)
+
+For instructions on how to run the integration test Jenkins pipeline, please refer to [the following document](docs/integration-testing.md)
 
 ## Run Prometheus Unit Tests for Alerts
 

--- a/docs/integration-testing.md
+++ b/docs/integration-testing.md
@@ -1,0 +1,101 @@
+# How to run Integration Tests
+
+The integration test Jenkins pipeline provides an
+additional testing layer for pull requests that target the `main`
+branch.
+
+Unlike other automated tests (such as lint, unit, and e2e tests),
+this integration test pipeline is **not automatically triggered** on a new pull request.
+The main reason for this setup are resource usage and performance considerations.
+For more details and usage guidelines, please refer to [the dedicated section](#resource-usage-and-performance-considerations).
+
+## When Integration Tests are Required
+
+Integration tests are **MANDATORY** for pull requests that modify:
+
+- **Core Controller Logic** (`internal/controller/` changes)
+- **API Definitions** (`api/` directory changes)
+- **Webhook Implementations** (`internal/webhook/` changes)
+- **Bundle Manifests** (`bundle/` directory changes)
+- **Operator Configuration** (`config/` directory changes)
+- **Feature Framework** (`pkg/feature/` changes)
+
+Integration tests are **RECOMMENDED** for:
+- Multi-component feature implementations
+- Performance optimizations
+- External dependency updates
+- Documentation changes affecting workflows
+
+## Resource usage and performance considerations
+
+While using integration tests, please respect the following considerations and guidelines:
+
+### Pipeline resource usage
+- Integration tests pipeline consumes significant cluster resources 
+- Typical execution time: around 60 minutes
+- Uses dedicated OpenShift clusters for testing
+  - RHOAI Platform team owns two pre-configured clusters dedicated to integration testing
+  - each test pipeline instance will be added to one of those clusters based on their respective availability
+    - having those running clusters saves significant amount of time, as needing to allocate a new cluster for each pipeline instance would be additionally time-consuming (+60 minutes)
+
+### Developer guidelines
+- **Batch Related Changes**: Group related changes in a single PR to avoid multiple pipeline runs
+- **Local Testing First**: Run unit tests locally before triggering integration tests
+- **Component-Specific Impact**: Consider if your changes truly require full integration testing
+
+### Rate limiting
+- Only one integration test per PR at a time
+- Multiple PRs may queue during high activity periods
+- Plan accordingly for release deadlines
+
+## Integration Test Architecture
+
+The general outline of the integration test process is:
+
+1. **Prow Command**: `/label run-integration-tests` applies the label
+2. **GitHub Actions**: Builds operator, bundle, and catalog images with PR-specific tags
+3. **Image Registry**: Pushes to quay.io (e.g., `quay.io/org/opendatahub-operator-catalog:pr-123`)
+4. **Jenkins Trigger**: GitHub bot automatically comments `/test-integration`
+5. **OpenShift Testing**: Jenkins deploys and tests on dedicated cluster
+6. **Results**: Jenkins reports back with test results and artifacts
+
+For precise step-by-step user guide, please refer to [the section below](#user-guide).
+
+## User Guide
+**To run the integration tests pipeline on a PR, please follow the steps below:**
+
+1. **Label the PR as ready for integration tests**: comment `/label run-integration-tests` on the PR
+2. **Wait for the bot**: `openshift-ci bot` will add the label to your PR
+3. **Trigger the tests**: once PR is labeled, any new commit push into the PR branch will trigger the integration tests pipeline
+4. **Monitor the image building process**: Keep an eye on the `Build Catalog FBC and run Integration tests` GitHub Action. 
+Once this action succeeds, 
+   `github-actions bot` will comment on the PR, which will automatically trigger the Jenkins pipeline
+   - **Troubleshooting:** please refer to [the dedicated troubleshooting section](#image-buildpush-action-issues)
+5. **Monitor the test process**: Once test pipeline starts in Jenkins, `rhods-ci-bot` will comment that the 
+tests have started, and provide a link to the Jenkins pipeline run details page
+   - **Note:** Accessing the Jenkins pipeline run details requires active Red Hat VPN connection and login via SSO
+   - **Troubleshooting:** please refer to [the dedicated troubleshooting sections](#jenkins-pipeline-not-triggering)
+
+## Troubleshooting Common Issues
+
+### Image build/push action issues
+- Ensure the correct version tag was obtained
+    - The version tag is obtained dynamically via a GitHub API call
+        - This ensures that the correct latest tag will be used to construct image URLs
+    - Expected format is`v<X>.<Y>.<Z>-pr-<pr_number>`
+        - For example:`v2.32.0-pr-1`
+- Ensure no conflicting image builds are happening at the same time for the same PR
+- Verify `quay.io` registry permissions and quotas
+- Check for base image availability and versions
+- Ensure PR metadata was uploaded successfully as GitHub artifact
+
+### Jenkins pipeline not triggering
+- Verify the `/label run-integration-tests` command was successful
+- Check that your changes affect monitored paths (`bundle/`, `cmd/`, `config/`, `internal/`, `pkg/`)
+- Ensure the GitHub Action `Build Catalog FBC and run Integration tests` completed successfully
+- Look for the automated `/test-integration` comment from the `github-actions bot`
+
+### Jenkins Pipeline failures
+- Check Jenkins console logs for specific component failures
+- Verify catalog image was built and pushed to `quay.io` successfully
+- Review OpenShift cluster connectivity and permissions


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
Added a document with the instructions on how to run ODH Operator Integration tests.

JIRA ref: [RHOAIENG-30173](https://issues.redhat.com/browse/RHOAIENG-30173)

## How Has This Been Tested?
No testing needed, no code interaction

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new README section with a table of contents entry for running ODH Operator Integration tests via Jenkins.
  * Introduced detailed documentation on manually running integration tests, covering triggers, requirements, architecture, user guide, and troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->