### PR TITLE
fix: add namespace into envFrom in Notebook for webhook connection-notebook.opendatahub.io

### DIFF
--- a/internal/webhook/notebook/mutating.go
+++ b/internal/webhook/notebook/mutating.go
@@ -282,7 +282,8 @@ func (w *NotebookWebhook) performConnectionInjection(nb *unstructured.Unstructur
 	for _, secretRef := range secretRefs {
 		secretEntry := map[string]interface{}{
 			"secretRef": map[string]interface{}{
-				"name": secretRef.Name,
+				"name":      secretRef.Name,
+				"namespace": secretRef.Namespace,
 			},
 		}
 		newEnvFrom = append(newEnvFrom, secretEntry)


### PR DESCRIPTION


- need namespace to be set, otherwise, it fall back to use the same namespace at runtime for pod might not exist or wrong content

<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

<!--- Link your JIRA and related links here for reference. -->
[RHOAIENG-30279](https://issues.redhat.com/browse/RHOAIENG-30279)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
