### PR TITLE
udpate: deny by notebook webhook if connection annotation contains serect from a different namespace

### DIFF
--- a/internal/webhook/notebook/mutating_test.go
+++ b/internal/webhook/notebook/mutating_test.go
@@ -26,6 +26,7 @@ import (
 
 const (
 	testNamespace    = "test-namespace"
+	testNamespace2   = "test-namespace2"
 	testNotebook     = "test-notebook"
 	testSecret1      = "secret1"
 	testSecret2      = "secret2"
@@ -267,6 +268,18 @@ func TestNotebookWebhook_Handle_Permissions(t *testing.T) {
 			expectedMessage:   "some of the connection secret(s) do not exist",
 			shouldHavePatches: false,
 			forbiddenSecrets:  []string{fmt.Sprintf("%s/%s", testNamespace, testSecret2)},
+		},
+		{
+			name:        "secret in a different namespace than Notebook CR's",
+			connections: fmt.Sprintf("%s/%s,%s/%s", testNamespace, testSecret1, testNamespace2, testSecret2),
+			allowPermissions: map[string]bool{
+				testSecret1: true,
+				testSecret2: true,
+			},
+			expectedAllowed:   false,
+			expectedMessage:   "some of the connection secret(s) do not exist",
+			shouldHavePatches: false,
+			forbiddenSecrets:  []string{fmt.Sprintf("%s/%s", testNamespace2, testSecret2)},
 		},
 	}
 


### PR DESCRIPTION
- we might enable this later once we support cross-namespace case
- for now, this should deny, as notebok.spec.template.spec.pod.envfrom only support secret in the same ns

<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->
detail: https://redhat-internal.slack.com/archives/C08T1K4FQVC/p1754662006693049

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
