### PR TITLE
set_default_replicas_to_2_for_collector

### DIFF
--- a/api/services/v1alpha1/monitoring_types.go
+++ b/api/services/v1alpha1/monitoring_types.go
@@ -171,6 +171,7 @@ type Monitoring struct {
 
 // MonitoringCommonSpec spec defines the shared desired state of Dashboard
 // +kubebuilder:validation:XValidation:rule="has(self.alerting) ? has(self.metrics.storage) || has(self.metrics.resources) : true",message="Alerting configuration requires metrics.storage or metrics.resources to be configured"
+// +kubebuilder:validation:XValidation:rule="!has(self.collectorReplicas) || (self.collectorReplicas > 0 && (self.metrics != null || self.traces != null))",message="CollectorReplicas can only be set when metrics or traces are enabled, and must be > 0"
 type MonitoringCommonSpec struct {
 	// monitoring spec exposed to DSCI api
 	// Namespace for monitoring if it is enabled
@@ -185,6 +186,8 @@ type MonitoringCommonSpec struct {
 	Traces *Traces `json:"traces,omitempty"`
 	// Alerting configuration for Prometheus
 	Alerting *Alerting `json:"alerting,omitempty"`
+	// CollectorReplicas specifies the number of replicas in opentelemetry-collector, default is 2 if not set
+	CollectorReplicas int32 `json:"collectorReplicas,omitempty"`
 }
 
 //+kubebuilder:object:root=true

--- a/bundle/manifests/dscinitialization.opendatahub.io_dscinitializations.yaml
+++ b/bundle/manifests/dscinitialization.opendatahub.io_dscinitializations.yaml
@@ -93,6 +93,11 @@ spec:
                   alerting:
                     description: Alerting configuration for Prometheus
                     type: object
+                  collectorReplicas:
+                    description: CollectorReplicas specifies the number of replicas
+                      in opentelemetry-collector, default is 2 if not set
+                    format: int32
+                    type: integer
                   managementState:
                     description: |-
                       Set to one of the following values:
@@ -296,6 +301,10 @@ spec:
                     to be configured
                   rule: 'has(self.alerting) ? has(self.metrics.storage) || has(self.metrics.resources)
                     : true'
+                - message: CollectorReplicas can only be set when metrics or traces
+                    are enabled, and must be > 0
+                  rule: '!has(self.collectorReplicas) || (self.collectorReplicas >
+                    0 && (self.metrics != null || self.traces != null))'
               serviceMesh:
                 description: |-
                   Configures Service Mesh as networking layer for Data Science Clusters components.

--- a/bundle/manifests/services.platform.opendatahub.io_monitorings.yaml
+++ b/bundle/manifests/services.platform.opendatahub.io_monitorings.yaml
@@ -55,6 +55,11 @@ spec:
               alerting:
                 description: Alerting configuration for Prometheus
                 type: object
+              collectorReplicas:
+                description: CollectorReplicas specifies the number of replicas in
+                  opentelemetry-collector, default is 2 if not set
+                format: int32
+                type: integer
               metrics:
                 description: metrics collection
                 properties:
@@ -243,6 +248,10 @@ spec:
                 to be configured
               rule: 'has(self.alerting) ? has(self.metrics.storage) || has(self.metrics.resources)
                 : true'
+            - message: CollectorReplicas can only be set when metrics or traces are
+                enabled, and must be > 0
+              rule: '!has(self.collectorReplicas) || (self.collectorReplicas > 0 &&
+                (self.metrics != null || self.traces != null))'
           status:
             description: MonitoringStatus defines the observed state of Monitoring
             properties:

--- a/config/crd/bases/dscinitialization.opendatahub.io_dscinitializations.yaml
+++ b/config/crd/bases/dscinitialization.opendatahub.io_dscinitializations.yaml
@@ -93,6 +93,11 @@ spec:
                   alerting:
                     description: Alerting configuration for Prometheus
                     type: object
+                  collectorReplicas:
+                    description: CollectorReplicas specifies the number of replicas
+                      in opentelemetry-collector, default is 2 if not set
+                    format: int32
+                    type: integer
                   managementState:
                     description: |-
                       Set to one of the following values:
@@ -296,6 +301,10 @@ spec:
                     to be configured
                   rule: 'has(self.alerting) ? has(self.metrics.storage) || has(self.metrics.resources)
                     : true'
+                - message: CollectorReplicas can only be set when metrics or traces
+                    are enabled, and must be > 0
+                  rule: '!has(self.collectorReplicas) || (self.collectorReplicas >
+                    0 && (self.metrics != null || self.traces != null))'
               serviceMesh:
                 description: |-
                   Configures Service Mesh as networking layer for Data Science Clusters components.

--- a/config/crd/bases/services.platform.opendatahub.io_monitorings.yaml
+++ b/config/crd/bases/services.platform.opendatahub.io_monitorings.yaml
@@ -55,6 +55,11 @@ spec:
               alerting:
                 description: Alerting configuration for Prometheus
                 type: object
+              collectorReplicas:
+                description: CollectorReplicas specifies the number of replicas in
+                  opentelemetry-collector, default is 2 if not set
+                format: int32
+                type: integer
               metrics:
                 description: metrics collection
                 properties:
@@ -243,6 +248,10 @@ spec:
                 to be configured
               rule: 'has(self.alerting) ? has(self.metrics.storage) || has(self.metrics.resources)
                 : true'
+            - message: CollectorReplicas can only be set when metrics or traces are
+                enabled, and must be > 0
+              rule: '!has(self.collectorReplicas) || (self.collectorReplicas > 0 &&
+                (self.metrics != null || self.traces != null))'
           status:
             description: MonitoringStatus defines the observed state of Monitoring
             properties:

--- a/docs/api-overview.md
+++ b/docs/api-overview.md
@@ -2867,6 +2867,7 @@ _Appears in:_
 | `metrics` _[Metrics](#metrics)_ | metrics collection |  |  |
 | `traces` _[Traces](#traces)_ | Tracing configuration for OpenTelemetry instrumentation |  |  |
 | `alerting` _[Alerting](#alerting)_ | Alerting configuration for Prometheus |  |  |
+| `collectorReplicas` _integer_ | CollectorReplicas specifies the number of replicas in opentelemetry-collector, default is 2 if not set |  |  |
 
 
 #### Metrics
@@ -2966,6 +2967,7 @@ _Appears in:_
 | `metrics` _[Metrics](#metrics)_ | metrics collection |  |  |
 | `traces` _[Traces](#traces)_ | Tracing configuration for OpenTelemetry instrumentation |  |  |
 | `alerting` _[Alerting](#alerting)_ | Alerting configuration for Prometheus |  |  |
+| `collectorReplicas` _integer_ | CollectorReplicas specifies the number of replicas in opentelemetry-collector, default is 2 if not set |  |  |
 
 
 #### MonitoringList
@@ -3005,6 +3007,7 @@ _Appears in:_
 | `metrics` _[Metrics](#metrics)_ | metrics collection |  |  |
 | `traces` _[Traces](#traces)_ | Tracing configuration for OpenTelemetry instrumentation |  |  |
 | `alerting` _[Alerting](#alerting)_ | Alerting configuration for Prometheus |  |  |
+| `collectorReplicas` _integer_ | CollectorReplicas specifies the number of replicas in opentelemetry-collector, default is 2 if not set |  |  |
 
 
 #### MonitoringStatus

--- a/internal/controller/dscinitialization/dscinitialization_controller.go
+++ b/internal/controller/dscinitialization/dscinitialization_controller.go
@@ -461,17 +461,30 @@ func (r *DSCInitializationReconciler) newMonitoringCR(ctx context.Context, dsci 
 		},
 	}
 
-	if dsci.Spec.Monitoring.Metrics != nil {
-		// when metrics has values set in resoures or storage. skip replicas since it cannot be 0 from CEL validation
-		if dsci.Spec.Monitoring.Metrics.Storage != nil || dsci.Spec.Monitoring.Metrics.Resources != nil {
-			defaultMonitoring.Spec.Metrics = dsci.Spec.Monitoring.Metrics
-		} else { // if metrics is set to metrics:{} to avoid  invalid value "null" to Apply() existing Monitoring CR
-			defaultMonitoring.Spec.Metrics = nil // explictliy set to nil, same as not set but for better readability
-		}
+	metricsEnabled := dsci.Spec.Monitoring.Metrics != nil && (dsci.Spec.Monitoring.Metrics.Storage != nil || dsci.Spec.Monitoring.Metrics.Resources != nil)
+	tracesEnabled := dsci.Spec.Monitoring.Traces != nil
+
+	if metricsEnabled {
+		defaultMonitoring.Spec.Metrics = dsci.Spec.Monitoring.Metrics
+	} else {
+		defaultMonitoring.Spec.Metrics = nil
 	}
 
-	defaultMonitoring.Spec.Traces = dsci.Spec.Monitoring.Traces
+	if tracesEnabled {
+		defaultMonitoring.Spec.Traces = dsci.Spec.Monitoring.Traces
+	} else {
+		defaultMonitoring.Spec.Traces = nil
+	}
+
 	defaultMonitoring.Spec.Alerting = dsci.Spec.Monitoring.Alerting
+
+	if metricsEnabled || tracesEnabled {
+		if dsci.Spec.Monitoring.CollectorReplicas != 0 {
+			defaultMonitoring.Spec.CollectorReplicas = dsci.Spec.Monitoring.CollectorReplicas
+		} else {
+			defaultMonitoring.Spec.CollectorReplicas = 2
+		}
+	}
 
 	if err := controllerutil.SetOwnerReference(dsci, defaultMonitoring, r.Client.Scheme()); err != nil {
 		return err

--- a/internal/controller/services/monitoring/monitoring_controller_support.go
+++ b/internal/controller/services/monitoring/monitoring_controller_support.go
@@ -172,6 +172,8 @@ func getTemplateData(ctx context.Context, rr *odhtypes.ReconciliationRequest) (m
 		}
 	}
 
+	templateData["CollectorReplicas"] = monitoring.Spec.CollectorReplicas
+
 	return templateData, nil
 }
 

--- a/internal/controller/services/monitoring/resources/opentelemetry-collector.tmpl.yaml
+++ b/internal/controller/services/monitoring/resources/opentelemetry-collector.tmpl.yaml
@@ -4,6 +4,7 @@ metadata:
   name: data-science-collector
   namespace: {{.Namespace}}
 spec:
+  replicas: {{.CollectorReplicas}}
   mode: deployment
   config:
     extensions:


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->
Make replicas setting for otel collector configurable.

- Add a collectorReplicas field.
	- Value defaults to 2.
- If user has set some other value in the DSCI repect that value and do not change it.
- Disallow setting 0.
- If metrics or traces isn't set then don't allow setting the value.

_Testing_

- Install operator
- Install cluster observability operator, red hat build of opentelemetry and tempo operator from operatorhub
- Create a default DSCI.
- Verify that the collectorReplicas field is not present in DSCI.
- Set monitoring to `managementState: Managed`
- Add metrics and size stanza
```    
	metrics: {
      storage: {
        size: 5
      }
    }
```
- Verify that 2 collectors are deployed.
- Verify that collectorReplicas is 2 in the monitoring CR.
- Add collectorReplicasfield to DSCI and set to some other number.
- Verify the change is copied into the monitoring CR.

<!--- Link your JIRA and related links here for reference. -->
[RHOAIENG-29724](https://issues.redhat.com/browse/RHOAIENG-29724)
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added collectorReplicas to configure OpenTelemetry Collector replica count; defaults to 2 when metrics or traces are enabled and applied to rendered collector resources.

- **Validation**
  - CRDs enforce collectorReplicas > 0 and only allow setting it when metrics or traces are enabled; DSCInitialization schema includes matching cross-field validations.

- **Documentation**
  - API docs updated to include collectorReplicas.

- **Tests**
  - E2E tests added to validate defaulting and overrides of collectorReplicas.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->