### PR TITLE
update: set modelreg + feast to Removed in CreateDefaultDSC

### DIFF
--- a/pkg/upgrade/upgrade.go
+++ b/pkg/upgrade/upgrade.go
@@ -196,13 +196,13 @@ func CreateDefaultDSC(ctx context.Context, cli client.Client) error {
 					ManagementSpec: common.ManagementSpec{ManagementState: operatorv1.Managed},
 				},
 				ModelRegistry: componentApi.DSCModelRegistry{
-					ManagementSpec: common.ManagementSpec{ManagementState: operatorv1.Managed},
+					ManagementSpec: common.ManagementSpec{ManagementState: operatorv1.Removed},
 				},
 				TrainingOperator: componentApi.DSCTrainingOperator{
 					ManagementSpec: common.ManagementSpec{ManagementState: operatorv1.Managed},
 				},
 				FeastOperator: componentApi.DSCFeastOperator{
-					ManagementSpec: common.ManagementSpec{ManagementState: operatorv1.Managed},
+					ManagementSpec: common.ManagementSpec{ManagementState: operatorv1.Removed},
 				},
 				LlamaStackOperator: componentApi.DSCLlamaStackOperator{
 					ManagementSpec: common.ManagementSpec{ManagementState: operatorv1.Removed},


### PR DESCRIPTION
- this func is only called on Managed Cluster
- to make code on both main and rhoai same, set it back to Removed on main, wont take effect on ODH build
- we can later remove this func totally and  use addon to handle default states on components

<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

<!--- Link your JIRA and related links here for reference. -->
ref 
https://issues.redhat.com/browse/RHOAIENG-31326 
https://issues.redhat.com/browse/RHOAIENG-31325

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Behavior Changes**
  * New Data Science Cluster defaults no longer provision Model Registry and Feast Operator; they are disabled by default and must be explicitly enabled.
  * LlamaStack Operator remains disabled by default.
  * All other components continue to be provisioned by default.
  * This affects newly generated cluster configurations and reduces the default installation footprint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->