### PR TITLE
feat: RHOAIENG-29291 - notfiy kserve misconfiguration

### DIFF
--- a/internal/controller/components/kserve/kserve.go
+++ b/internal/controller/components/kserve/kserve.go
@@ -121,6 +121,16 @@ func (s *componentHandler) UpdateDSCStatus(ctx context.Context, rr *types.Reconc
 		dsc.Status.InstalledComponents[LegacyComponentName] = true
 		dsc.Status.Components.Kserve.KserveCommonStatus = c.Status.KserveCommonStatus.DeepCopy()
 
+		if dsc.Spec.Components.Kserve.Serving.ManagementState == operatorv1.Managed &&
+			dsc.Spec.Components.Kserve.DefaultDeploymentMode == componentApi.RawDeployment {
+			rr.Conditions.MarkFalse(
+				"ConfigurationOptimal",
+				conditions.WithReason("ConflictingDeploymentMode"),
+				conditions.WithMessage("Serving is managed but defaultDeploymentMode is set to RawDeployment - this may not provide the expected serverless experience"),
+				conditions.WithSeverity(common.ConditionSeverityWarning),
+			)
+		}
+
 		if rc := conditions.FindStatusCondition(c.GetStatus(), status.ConditionTypeReady); rc != nil {
 			rr.Conditions.MarkFrom(ReadyConditionType, *rc)
 			cs = rc.Status

--- a/internal/controller/components/kserve/kserve_controller_actions.go
+++ b/internal/controller/components/kserve/kserve_controller_actions.go
@@ -375,6 +375,15 @@ func customizeKserveConfigMap(ctx context.Context, rr *odhtypes.ReconciliationRe
 			// if the default mode is explicitly specified, respect that
 			defaultmode = k.Spec.DefaultDeploymentMode
 		}
+
+		// Warn about suboptimal configuration when using RawDeployment with Managed serving
+		if defaultmode == componentApi.RawDeployment && k.Spec.Serving.ManagementState == operatorv1.Managed {
+			logger.Info("KServe configuration may be suboptimal",
+				"defaultDeploymentMode", string(defaultmode),
+				"serving.managementState", string(k.Spec.Serving.ManagementState),
+				"recommendation", "Consider setting serving.managementState to Removed to save resources")
+		}
+
 		if err := updateInferenceCM(&kserveConfigMap, defaultmode, serviceClusterIPNone); err != nil {
 			return err
 		}


### PR DESCRIPTION
## Description
Added logic to generate log and DSC Status when the ManagementState is "Managed" and DefaultDeploymentMode is "RawDeployment" to prevent user mis information and cluster resource wastage.
https://issues.redhat.com/browse/RHOAIENG-29291
https://issues.redhat.com/browse/RHOAIENG-27724

## How Has This Been Tested?
Added unit test for the DSCStatus change.