### PR TITLE
[RHOAIENG-31328] set dsc-monitoring-namespace env as part of cluster config

### DIFF
--- a/pkg/cluster/const.go
+++ b/pkg/cluster/const.go
@@ -15,6 +15,11 @@ const (
 	// DefaultNotebooksNamespaceRHOAI defines default namespace for notebooks.
 	DefaultNotebooksNamespaceRHOAI = "rhods-notebooks"
 
+	// DefaultMonitoringNamespaceODH defines default namespace for monitoring.
+	DefaultMonitoringNamespaceODH = "opendatahub"
+	// DefaultMonitoringNamespaceRHOAI defines default namespace for monitoring.
+	DefaultMonitoringNamespaceRHOAI = "redhat-ods-monitoring"
+
 	// Default cluster-scope Authentication CR name.
 	ClusterAuthenticationObj = "cluster"
 


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->
New function added to cluster-config, to run just after the initial env vars are set, that will set the default or managed namespace when it is detected. 

Resolves the need to set the namespace for other branches. 

<!--- Link your JIRA and related links here for reference. -->
https://issues.redhat.com/browse/RHOAIENG-31328

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested on my 4.19 dev cluster.

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatically configures the monitoring namespace early during startup based on the detected platform.
  * On RHOAI platforms, the default monitoring namespace is set to "redhat-ods-monitoring."
  * On other platforms, the default monitoring namespace is set to "opendatahub."
<!-- end of auto-generated comment: release notes by coderabbit.ai -->