### PR TITLE
[sync]update: change default retention from 1d to 90d for tracer (#2253)

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,7 +309,7 @@ spec:
         memorylimit: 512Mi
         memoryrequest: 256Mi
       storage:
-        retention: 1d
+        retention: 90d
         size: 5Gi
     traces:
       storage:

--- a/api/services/v1alpha1/monitoring_types.go
+++ b/api/services/v1alpha1/monitoring_types.go
@@ -55,7 +55,7 @@ type MetricsStorage struct {
 	// +kubebuilder:default="5Gi"
 	Size resource.Quantity `json:"size,omitempty"`
 	// Retention specifies how long metrics data should be retained (e.g., "1d", "2w")
-	// +kubebuilder:default="1d"
+	// +kubebuilder:default="90d"
 	Retention string `json:"retention,omitempty"`
 }
 

--- a/bundle/manifests/dscinitialization.opendatahub.io_dscinitializations.yaml
+++ b/bundle/manifests/dscinitialization.opendatahub.io_dscinitializations.yaml
@@ -158,7 +158,7 @@ spec:
                           for the monitoring service
                         properties:
                           retention:
-                            default: 1d
+                            default: 90d
                             description: Retention specifies how long metrics data
                               should be retained (e.g., "1d", "2w")
                             type: string

--- a/bundle/manifests/services.platform.opendatahub.io_monitorings.yaml
+++ b/bundle/manifests/services.platform.opendatahub.io_monitorings.yaml
@@ -106,7 +106,7 @@ spec:
                       for the monitoring service
                     properties:
                       retention:
-                        default: 1d
+                        default: 90d
                         description: Retention specifies how long metrics data should
                           be retained (e.g., "1d", "2w")
                         type: string

--- a/config/crd/bases/dscinitialization.opendatahub.io_dscinitializations.yaml
+++ b/config/crd/bases/dscinitialization.opendatahub.io_dscinitializations.yaml
@@ -158,7 +158,7 @@ spec:
                           for the monitoring service
                         properties:
                           retention:
-                            default: 1d
+                            default: 90d
                             description: Retention specifies how long metrics data
                               should be retained (e.g., "1d", "2w")
                             type: string

--- a/config/crd/bases/services.platform.opendatahub.io_monitorings.yaml
+++ b/config/crd/bases/services.platform.opendatahub.io_monitorings.yaml
@@ -106,7 +106,7 @@ spec:
                       for the monitoring service
                     properties:
                       retention:
-                        default: 1d
+                        default: 90d
                         description: Retention specifies how long metrics data should
                           be retained (e.g., "1d", "2w")
                         type: string

--- a/docs/api-overview.md
+++ b/docs/api-overview.md
@@ -2904,7 +2904,7 @@ _Appears in:_
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
 | `size` _[Quantity](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#quantity-resource-api)_ | Size specifies the storage size for the MonitoringStack (e.g, "5Gi", "10Mi") | 5Gi |  |
-| `retention` _string_ | Retention specifies how long metrics data should be retained (e.g., "1d", "2w") | 1d |  |
+| `retention` _string_ | Retention specifies how long metrics data should be retained (e.g., "1d", "2w") | 90d |  |
 
 
 #### Monitoring

--- a/internal/controller/services/monitoring/monitoring_controller_support.go
+++ b/internal/controller/services/monitoring/monitoring_controller_support.go
@@ -82,7 +82,7 @@ func getTemplateData(ctx context.Context, rr *odhtypes.ReconciliationRequest) (m
 
 			retention := metrics.Storage.Retention
 			if retention == "" {
-				retention = "1d"
+				retention = "90d"
 			}
 			templateData["StorageRetention"] = retention
 		} else {

--- a/tests/e2e/monitoring_test.go
+++ b/tests/e2e/monitoring_test.go
@@ -148,7 +148,7 @@ func (tc *MonitoringTestCtx) ValidateMonitoringStackCRMetricsConfiguration(t *te
 			// Validate storage size is set to 5Gi
 			jq.Match(`.spec.prometheusConfig.persistentVolumeClaim.resources.requests.storage == "%s"`, "5Gi"),
 			// Validate storage retention is set to 1d
-			jq.Match(`.spec.retention == "%s"`, "1d"),
+			jq.Match(`.spec.retention == "%s"`, "90d"),
 			// Validate CPU request is set to 250m
 			jq.Match(`.spec.resources.requests.cpu == "%s"`, "250m"),
 			// Validate memory request is set to 350Mi
@@ -176,7 +176,7 @@ func (tc *MonitoringTestCtx) ValidateMonitoringStackCRMetricsReplicasUpdate(t *t
 	// Update DSCI to set replicas to 1 (must include either storage or resources due to CEL validation rule)
 	tc.EventuallyResourceCreatedOrUpdated(
 		WithMinimalObject(gvk.DSCInitialization, tc.DSCInitializationNamespacedName),
-		WithMutateFunc(testf.Transform(`.spec.monitoring.metrics = %s`, `{storage: {size: "5Gi", retention: "1d"}, replicas: 1}`)),
+		WithMutateFunc(testf.Transform(`.spec.monitoring.metrics = %s`, `{storage: {size: "5Gi", retention: "90d"}, replicas: 1}`)),
 	)
 	tc.EnsureResourceExists(
 		WithMinimalObject(gvk.MonitoringStack, types.NamespacedName{Name: "data-science-monitoringstack", Namespace: dsci.Spec.Monitoring.Namespace}),
@@ -280,7 +280,7 @@ func setMonitoringMetrics() testf.TransformFn {
 		metricsConfig := map[string]interface{}{
 			"storage": map[string]interface{}{
 				"size":      "5Gi",
-				"retention": "1d",
+				"retention": "90d",
 			},
 			"resources": map[string]interface{}{
 				"cpurequest":    "250m",


### PR DESCRIPTION
(cherry picked from commit 7ad39c9ded4485cefe8d0395dec5d3b65972c7ec)

<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

<!--- Link your JIRA and related links here for reference. -->
ref: https://issues.redhat.com/browse/RHOAIENG-29720

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
