### PR TITLE
[RHOAIENG-31328] Followup - Checking ENV not yet set

### DIFF
--- a/pkg/cluster/cluster_config.go
+++ b/pkg/cluster/cluster_config.go
@@ -330,14 +330,14 @@ func setManagedMonitoringNamespace(ctx context.Context, cli client.Client) error
 	if err != nil {
 		return err
 	}
-
-	switch platform {
-	case ManagedRhoai:
-		viper.Set("dsc-monitoring-namespace", DefaultMonitoringNamespaceRHOAI)
-	case SelfManagedRhoai:
-		viper.Set("dsc-monitoring-namespace", DefaultMonitoringNamespaceRHOAI)
-	default:
-		viper.Set("dsc-monitoring-namespace", DefaultMonitoringNamespaceODH)
+	ok := viper.IsSet("dsc-monitoring-namespace")
+	if !ok {
+		switch platform {
+		case ManagedRhoai, SelfManagedRhoai:
+			viper.Set("dsc-monitoring-namespace", DefaultMonitoringNamespaceRHOAI)
+		default:
+			viper.Set("dsc-monitoring-namespace", DefaultMonitoringNamespaceODH)
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->
Followup to https://github.com/opendatahub-io/opendatahub-operator/pull/2305
Checking env has not been set prior to setting namespace env directly. 

<!--- Link your JIRA and related links here for reference. -->
[RHOAIENG-31328](https://issues.redhat.com/browse/RHOAIENG-31328) 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Platform-aware default monitoring namespace: RHOAI (managed and self-managed) now defaults to the RHOAI monitoring namespace; other platforms default to the ODH monitoring namespace.

* **Bug Fixes**
  * Existing monitoring namespace settings are now respected and no longer overwritten by defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->