### PR TITLE
fix: hardened deletion and recreation e2e tests

### DIFF
--- a/tests/e2e/codeflare_test.go
+++ b/tests/e2e/codeflare_test.go
@@ -28,12 +28,11 @@ func codeflareTestSuite(t *testing.T) {
 		{"Validate operands have OwnerReferences", componentCtx.ValidateOperandsOwnerReferences},
 		{"Validate update operand resources", componentCtx.ValidateUpdateDeploymentsResources},
 		{"Validate component releases", componentCtx.ValidateComponentReleases},
-		// TODO: Disabled until these tests have been hardened (RHOAIENG-27721)
-		// {"Validate deployment deletion recovery", componentCtx.ValidateDeploymentDeletionRecovery},
-		// {"Validate configmap deletion recovery", componentCtx.ValidateConfigMapDeletionRecovery},
-		// {"Validate service deletion recovery", componentCtx.ValidateServiceDeletionRecovery},
-		// {"Validate serviceaccount deletion recovery", componentCtx.ValidateServiceAccountDeletionRecovery},
+		{"Validate deployment deletion recovery", componentCtx.ValidateDeploymentDeletionRecovery},
+		{"Validate configmap deletion recovery", componentCtx.ValidateConfigMapDeletionRecovery},
+		{"Validate service deletion recovery", componentCtx.ValidateServiceDeletionRecovery},
 		// {"Validate rbac deletion recovery", componentCtx.ValidateRBACDeletionRecovery},
+		{"Validate serviceaccount deletion recovery", componentCtx.ValidateServiceAccountDeletionRecovery},
 		{"Validate component disabled", componentCtx.ValidateComponentDisabled},
 	}
 

--- a/tests/e2e/components_test.go
+++ b/tests/e2e/components_test.go
@@ -370,21 +370,36 @@ func (tc *ComponentTestCtx) ValidateDeploymentDeletionRecovery(t *testing.T) {
 		),
 	)
 
-	// For each Deployment, delete it and verify it gets recreated
+	// Skip test if no deployments are found
+	if len(deployments) == 0 {
+		t.Skip("No deployments found for component, skipping deletion recovery test")
+		return
+	}
+
+	// For each Deployment, delete it and verify it gets recreated with robust deletion-recreation testing
 	for _, deployment := range deployments {
 		t.Run("deployment_"+deployment.GetName(), func(t *testing.T) {
 			t.Helper()
 
-			// Delete the Deployment
-			tc.DeleteResource(
+			// Use robust deletion-recreation pattern that handles race conditions and verifies actual recreation
+			recreatedDeployment := tc.EnsureResourceDeletedThenRecreated(
 				WithMinimalObject(gvk.Deployment, resources.NamespacedNameFromObject(&deployment)),
+				WithGracePeriod(2*time.Second), // Allow controller time to process deletion
 			)
 
-			// Verify the Deployment is recreated
-			tc.EnsureResourceExists(
-				WithMinimalObject(gvk.Deployment, resources.NamespacedNameFromObject(&deployment)),
-				WithCondition(jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, status.ConditionTypeAvailable, metav1.ConditionTrue)),
-			)
+			// Verify the recreated Deployment has proper conditions
+			tc.g.Eventually(func(g Gomega) {
+				current := tc.EnsureResourceExists(
+					WithMinimalObject(gvk.Deployment, resources.NamespacedNameFromObject(recreatedDeployment)),
+				)
+
+				// Check that the deployment is available
+				g.Expect(current).To(
+					jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`,
+						status.ConditionTypeAvailable, metav1.ConditionTrue),
+					"Recreated deployment should have Available condition",
+				)
+			}).WithTimeout(2 * time.Minute).Should(Succeed())
 		})
 	}
 }
@@ -406,19 +421,21 @@ func (tc *ComponentTestCtx) ValidateConfigMapDeletionRecovery(t *testing.T) {
 		),
 	)
 
-	// For each ConfigMap, delete it and verify it gets recreated
+	// Skip test if no configmaps are found
+	if len(configMaps) == 0 {
+		t.Skip("No configmaps found for component, skipping deletion recovery test")
+		return
+	}
+
+	// For each ConfigMap, delete it and verify it gets recreated with robust deletion-recreation testing
 	for _, configMap := range configMaps {
 		t.Run("configMap_"+configMap.GetName(), func(t *testing.T) {
 			t.Helper()
 
-			// Delete the ConfigMap
-			tc.DeleteResource(
+			// Use robust deletion-recreation pattern that handles race conditions and verifies actual recreation
+			tc.EnsureResourceDeletedThenRecreated(
 				WithMinimalObject(gvk.ConfigMap, resources.NamespacedNameFromObject(&configMap)),
-			)
-
-			// Verify the ConfigMap is recreated
-			tc.EnsureResourceExists(
-				WithMinimalObject(gvk.ConfigMap, resources.NamespacedNameFromObject(&configMap)),
+				WithGracePeriod(1*time.Second), // ConfigMaps typically recreate faster than Deployments
 			)
 		})
 	}
@@ -441,19 +458,21 @@ func (tc *ComponentTestCtx) ValidateServiceDeletionRecovery(t *testing.T) {
 		),
 	)
 
-	// For each Service, delete it and verify it gets recreated
+	// Skip test if no services are found
+	if len(services) == 0 {
+		t.Skip("No services found for component, skipping deletion recovery test")
+		return
+	}
+
+	// For each Service, delete it and verify it gets recreated with robust deletion-recreation testing
 	for _, service := range services {
 		t.Run("service_"+service.GetName(), func(t *testing.T) {
 			t.Helper()
 
-			// Delete the Service
-			tc.DeleteResource(
+			// Use robust deletion-recreation pattern that handles race conditions and verifies actual recreation
+			tc.EnsureResourceDeletedThenRecreated(
 				WithMinimalObject(gvk.Service, resources.NamespacedNameFromObject(&service)),
-			)
-
-			// Verify the Service is recreated
-			tc.EnsureResourceExists(
-				WithMinimalObject(gvk.Service, resources.NamespacedNameFromObject(&service)),
+				WithGracePeriod(1*time.Second), // Services typically recreate quickly
 			)
 		})
 	}
@@ -476,19 +495,21 @@ func (tc *ComponentTestCtx) ValidateRouteDeletionRecovery(t *testing.T) {
 		),
 	)
 
-	// For each Route, delete it and verify it gets recreated
+	// Skip test if no routes are found
+	if len(routes) == 0 {
+		t.Skip("No routes found for component, skipping deletion recovery test")
+		return
+	}
+
+	// For each Route, delete it and verify it gets recreated with robust deletion-recreation testing
 	for _, route := range routes {
 		t.Run("route_"+route.GetName(), func(t *testing.T) {
 			t.Helper()
 
-			// Delete the Route
-			tc.DeleteResource(
+			// Use robust deletion-recreation pattern that handles race conditions and verifies actual recreation
+			tc.EnsureResourceDeletedThenRecreated(
 				WithMinimalObject(gvk.Route, resources.NamespacedNameFromObject(&route)),
-			)
-
-			// Verify the Route is recreated
-			tc.EnsureResourceExists(
-				WithMinimalObject(gvk.Route, resources.NamespacedNameFromObject(&route)),
+				WithGracePeriod(1*time.Second), // Routes typically recreate quickly
 			)
 		})
 	}
@@ -511,19 +532,21 @@ func (tc *ComponentTestCtx) ValidateServiceAccountDeletionRecovery(t *testing.T)
 		),
 	)
 
-	// For each ServiceAccount, delete it and verify it gets recreated
+	// Skip test if no service accounts are found
+	if len(serviceAccounts) == 0 {
+		t.Skip("No service accounts found for component, skipping deletion recovery test")
+		return
+	}
+
+	// For each ServiceAccount, delete it and verify it gets recreated with robust deletion-recreation testing
 	for _, serviceAccount := range serviceAccounts {
 		t.Run("serviceAccount_"+serviceAccount.GetName(), func(t *testing.T) {
 			t.Helper()
 
-			// Delete the ServiceAccount
-			tc.DeleteResource(
+			// Use robust deletion-recreation pattern that handles race conditions and verifies actual recreation
+			tc.EnsureResourceDeletedThenRecreated(
 				WithMinimalObject(gvk.ServiceAccount, resources.NamespacedNameFromObject(&serviceAccount)),
-			)
-
-			// Verify the ServiceAccount is recreated
-			tc.EnsureResourceExists(
-				WithMinimalObject(gvk.ServiceAccount, resources.NamespacedNameFromObject(&serviceAccount)),
+				WithGracePeriod(1*time.Second), // ServiceAccounts typically recreate quickly
 			)
 		})
 	}
@@ -533,121 +556,53 @@ func (tc *ComponentTestCtx) ValidateServiceAccountDeletionRecovery(t *testing.T)
 func (tc *ComponentTestCtx) ValidateRBACDeletionRecovery(t *testing.T) {
 	t.Helper()
 
-	// Fetch ClusterRoles
-	clusterRoles := tc.FetchResources(
-		WithMinimalObject(gvk.ClusterRole, types.NamespacedName{Namespace: tc.AppsNamespace}),
-		WithListOptions(
-			&client.ListOptions{
-				LabelSelector: k8slabels.Set{
-					labels.PlatformPartOf: strings.ToLower(tc.GVK.Kind),
-				}.AsSelector(),
-			},
-		),
-	)
-
-	// For each ClusterRole, delete it and verify it gets recreated
-	for _, clusterRole := range clusterRoles {
-		t.Run("clusterRole_"+clusterRole.GetName(), func(t *testing.T) {
-			t.Helper()
-
-			// Delete the ClusterRole
-			tc.DeleteResource(
-				WithMinimalObject(gvk.ClusterRole, resources.NamespacedNameFromObject(&clusterRole)),
-			)
-
-			// Verify the ClusterRole is recreated
-			tc.EnsureResourceExists(
-				WithMinimalObject(gvk.ClusterRole, resources.NamespacedNameFromObject(&clusterRole)),
-			)
-		})
+	// Define the RBAC resource types to test
+	rbacResourceTypes := []struct {
+		name      string
+		gvk       schema.GroupVersionKind
+		namespace string // empty string for cluster-scoped resources
+	}{
+		{"ClusterRole", gvk.ClusterRole, ""},
+		{"ClusterRoleBinding", gvk.ClusterRoleBinding, ""},
+		{"Role", gvk.Role, tc.AppsNamespace},
+		{"RoleBinding", gvk.RoleBinding, tc.AppsNamespace},
 	}
 
-	// Fetch ClusterRoleBindings
-	clusterRoleBindings := tc.FetchResources(
-		WithMinimalObject(gvk.ClusterRoleBinding, types.NamespacedName{Namespace: tc.AppsNamespace}),
-		WithListOptions(
-			&client.ListOptions{
-				LabelSelector: k8slabels.Set{
-					labels.PlatformPartOf: strings.ToLower(tc.GVK.Kind),
-				}.AsSelector(),
-			},
-		),
-	)
-
-	// For each ClusterRoleBinding, delete it and verify it gets recreated
-	for _, clusterRoleBinding := range clusterRoleBindings {
-		t.Run("clusterRoleBinding_"+clusterRoleBinding.GetName(), func(t *testing.T) {
+	// Test each RBAC resource type
+	for _, rbacType := range rbacResourceTypes {
+		t.Run(rbacType.name+"DeletionRecovery", func(t *testing.T) {
 			t.Helper()
 
-			// Delete the ClusterRoleBinding
-			tc.DeleteResource(
-				WithMinimalObject(gvk.ClusterRoleBinding, resources.NamespacedNameFromObject(&clusterRoleBinding)),
+			// Fetch existing resources of this type
+			existingResources := tc.FetchResources(
+				WithMinimalObject(rbacType.gvk, types.NamespacedName{Namespace: rbacType.namespace}),
+				WithListOptions(
+					&client.ListOptions{
+						Namespace: rbacType.namespace,
+						LabelSelector: k8slabels.Set{
+							labels.PlatformPartOf: strings.ToLower(tc.GVK.Kind),
+						}.AsSelector(),
+					},
+				),
 			)
 
-			// Verify the ClusterRoleBinding is recreated
-			tc.EnsureResourceExists(
-				WithMinimalObject(gvk.ClusterRoleBinding, resources.NamespacedNameFromObject(&clusterRoleBinding)),
-			)
-		})
-	}
+			if len(existingResources) == 0 {
+				t.Logf("No %s resources found for component %s, skipping", rbacType.name, tc.GVK.Kind)
+				return
+			}
 
-	// Fetch Roles
-	roles := tc.FetchResources(
-		WithMinimalObject(gvk.Role, types.NamespacedName{Namespace: tc.AppsNamespace}),
-		WithListOptions(
-			&client.ListOptions{
-				Namespace: tc.AppsNamespace,
-				LabelSelector: k8slabels.Set{
-					labels.PlatformPartOf: strings.ToLower(tc.GVK.Kind),
-				}.AsSelector(),
-			},
-		),
-	)
+			// For each resource, test individual deletion-recreation with robust pattern
+			for _, resource := range existingResources {
+				t.Run(rbacType.name+"_"+resource.GetName(), func(t *testing.T) {
+					t.Helper()
 
-	// For each Role, delete it and verify it gets recreated
-	for _, role := range roles {
-		t.Run("role_"+role.GetName(), func(t *testing.T) {
-			t.Helper()
-
-			// Delete the Role
-			tc.DeleteResource(
-				WithMinimalObject(gvk.Role, resources.NamespacedNameFromObject(&role)),
-			)
-
-			// Verify the Role is recreated
-			tc.EnsureResourceExists(
-				WithMinimalObject(gvk.Role, resources.NamespacedNameFromObject(&role)),
-			)
-		})
-	}
-
-	// Fetch RoleBindings
-	roleBindings := tc.FetchResources(
-		WithMinimalObject(gvk.RoleBinding, types.NamespacedName{Namespace: tc.AppsNamespace}),
-		WithListOptions(
-			&client.ListOptions{
-				Namespace: tc.AppsNamespace,
-				LabelSelector: k8slabels.Set{
-					labels.PlatformPartOf: strings.ToLower(tc.GVK.Kind),
-				}.AsSelector(),
-			},
-		),
-	)
-
-	// For each RoleBinding, delete it and verify it gets recreated
-	for _, roleBinding := range roleBindings {
-		t.Run("roleBinding_"+roleBinding.GetName(), func(t *testing.T) {
-			t.Helper()
-
-			// Delete the RoleBinding
-			tc.DeleteResource(
-				WithMinimalObject(gvk.RoleBinding, resources.NamespacedNameFromObject(&roleBinding)),
-			)
-
-			// Verify the RoleBinding is recreated
-			tc.EnsureResourceExists(
-				WithMinimalObject(gvk.RoleBinding, resources.NamespacedNameFromObject(&roleBinding)),
-			)
+					// Use robust deletion-recreation pattern that handles race conditions and verifies actual recreation
+					tc.EnsureResourceDeletedThenRecreated(
+						WithMinimalObject(rbacType.gvk, resources.NamespacedNameFromObject(&resource)),
+						WithGracePeriod(2*time.Second), // RBAC resources may need more time for proper recreation
+					)
+				})
+			}
 		})
 	}
 }

--- a/tests/e2e/dashboard_test.go
+++ b/tests/e2e/dashboard_test.go
@@ -43,13 +43,12 @@ func dashboardTestSuite(t *testing.T) {
 		{"Validate dynamically watches operands", componentCtx.ValidateOperandsDynamicallyWatchedResources},
 		{"Validate CRDs reinstated", componentCtx.ValidateCRDReinstated},
 		{"Validate hardware profile reconcilliation", componentCtx.ValidateHardwareProfileReconciliation},
-		// TODO: Disabled until these tests have been hardened (RHOAIENG-27721)
-		// {"Validate deployment deletion recovery", componentCtx.ValidateDeploymentDeletionRecovery},
-		// {"Validate configmap deletion recovery", componentCtx.ValidateConfigMapDeletionRecovery},
-		// {"Validate service deletion recovery", componentCtx.ValidateServiceDeletionRecovery},
-		// {"Validate route deletion recovery", componentCtx.ValidateRouteDeletionRecovery},
-		// {"Validate serviceaccount deletion recovery", componentCtx.ValidateServiceAccountDeletionRecovery},
+		{"Validate deployment deletion recovery", componentCtx.ValidateDeploymentDeletionRecovery},
+		{"Validate configmap deletion recovery", componentCtx.ValidateConfigMapDeletionRecovery},
+		{"Validate service deletion recovery", componentCtx.ValidateServiceDeletionRecovery},
+		{"Validate route deletion recovery", componentCtx.ValidateRouteDeletionRecovery},
 		// {"Validate rbac deletion recovery", componentCtx.ValidateRBACDeletionRecovery},
+		{"Validate serviceaccount deletion recovery", componentCtx.ValidateServiceAccountDeletionRecovery},
 		{"Validate component disabled", componentCtx.ValidateComponentDisabled},
 	}
 

--- a/tests/e2e/datasciencepipelines_test.go
+++ b/tests/e2e/datasciencepipelines_test.go
@@ -34,12 +34,11 @@ func dataSciencePipelinesTestSuite(t *testing.T) {
 		{"Validate operands have OwnerReferences", componentCtx.ValidateOperandsOwnerReferences},
 		{"Validate update operand resources", componentCtx.ValidateUpdateDeploymentsResources},
 		{"Validate component releases", componentCtx.ValidateComponentReleases},
-		// TODO: Disabled until these tests have been hardened (RHOAIENG-27721)
-		// {"Validate deployment deletion recovery", componentCtx.ValidateDeploymentDeletionRecovery},
-		// {"Validate configmap deletion recovery", componentCtx.ValidateConfigMapDeletionRecovery},
-		// {"Validate service deletion recovery", componentCtx.ValidateServiceDeletionRecovery},
-		// {"Validate serviceaccount deletion recovery", componentCtx.ValidateServiceAccountDeletionRecovery},
+		{"Validate deployment deletion recovery", componentCtx.ValidateDeploymentDeletionRecovery},
+		{"Validate configmap deletion recovery", componentCtx.ValidateConfigMapDeletionRecovery},
+		{"Validate service deletion recovery", componentCtx.ValidateServiceDeletionRecovery},
 		// {"Validate rbac deletion recovery", componentCtx.ValidateRBACDeletionRecovery},
+		{"Validate serviceaccount deletion recovery", componentCtx.ValidateServiceAccountDeletionRecovery},
 		{"Validate component disabled", componentCtx.ValidateComponentDisabled},
 		{"Validate argoWorkflowsControllers options", componentCtx.ValidateArgoWorkflowsControllersOptions},
 	}

--- a/tests/e2e/feastoperator_test.go
+++ b/tests/e2e/feastoperator_test.go
@@ -28,12 +28,11 @@ func feastOperatorTestSuite(t *testing.T) {
 		{"Validate operands have OwnerReferences", componentCtx.ValidateOperandsOwnerReferences},
 		{"Validate update operand resources", componentCtx.ValidateUpdateDeploymentsResources},
 		{"Validate component releases", componentCtx.ValidateComponentReleases},
-		// TODO: Disabled until these tests have been hardened (RHOAIENG-27721)
-		// {"Validate deployment deletion recovery", componentCtx.ValidateDeploymentDeletionRecovery},
-		// {"Validate configmap deletion recovery", componentCtx.ValidateConfigMapDeletionRecovery},
-		// {"Validate service deletion recovery", componentCtx.ValidateServiceDeletionRecovery},
-		// {"Validate serviceaccount deletion recovery", componentCtx.ValidateServiceAccountDeletionRecovery},
+		{"Validate deployment deletion recovery", componentCtx.ValidateDeploymentDeletionRecovery},
+		{"Validate configmap deletion recovery", componentCtx.ValidateConfigMapDeletionRecovery},
+		{"Validate service deletion recovery", componentCtx.ValidateServiceDeletionRecovery},
 		// {"Validate rbac deletion recovery", componentCtx.ValidateRBACDeletionRecovery},
+		{"Validate serviceaccount deletion recovery", componentCtx.ValidateServiceAccountDeletionRecovery},
 		{"Validate component disabled", componentCtx.ValidateComponentDisabled},
 	}
 

--- a/tests/e2e/kserve_test.go
+++ b/tests/e2e/kserve_test.go
@@ -89,12 +89,11 @@ func kserveTestSuite(t *testing.T) {
 		{"Validate serving transition to Unmanaged", componentCtx.ValidateServingTransitionToUnmanaged},
 		{"Validate serving transition to Removed", componentCtx.ValidateServingTransitionToRemoved},
 		{"Validate component releases", componentCtx.ValidateComponentReleases},
-		// TODO: Disabled until these tests have been hardened (RHOAIENG-27721)
-		// {"Validate deployment deletion recovery", componentCtx.ValidateDeploymentDeletionRecovery},
-		// {"Validate configmap deletion recovery", componentCtx.ValidateConfigMapDeletionRecovery},
-		// {"Validate service deletion recovery", componentCtx.ValidateServiceDeletionRecovery},
-		// {"Validate serviceaccount deletion recovery", componentCtx.ValidateServiceAccountDeletionRecovery},
+		{"Validate deployment deletion recovery", componentCtx.ValidateDeploymentDeletionRecovery},
+		{"Validate configmap deletion recovery", componentCtx.ValidateConfigMapDeletionRecovery},
+		{"Validate service deletion recovery", componentCtx.ValidateServiceDeletionRecovery},
 		// {"Validate rbac deletion recovery", componentCtx.ValidateRBACDeletionRecovery},
+		{"Validate serviceaccount deletion recovery", componentCtx.ValidateServiceAccountDeletionRecovery},
 		{"Validate component disabled", componentCtx.ValidateComponentDisabled},
 	}
 

--- a/tests/e2e/kueue_test.go
+++ b/tests/e2e/kueue_test.go
@@ -66,12 +66,12 @@ func kueueTestSuite(t *testing.T) {
 		{"Validate CRDs reinstated", componentCtx.ValidateCRDReinstated},
 		{"Validate pre check", componentCtx.ValidateKueuePreCheck},
 		{"Validate component releases", componentCtx.ValidateComponentReleases},
-		// TODO: Disabled until these tests have been hardened (RHOAIENG-27721)
-		// {"Validate deployment deletion recovery", componentCtx.ValidateDeploymentDeletionRecovery},
-		// {"Validate configmap deletion recovery", componentCtx.ValidateConfigMapDeletionRecovery},
-		// {"Validate service deletion recovery", componentCtx.ValidateServiceDeletionRecovery},
-		// {"Validate serviceaccount deletion recovery", componentCtx.ValidateServiceAccountDeletionRecovery},
+		{"Validate deployment deletion recovery", componentCtx.ValidateDeploymentDeletionRecovery},
+		{"Validate configmap deletion recovery", componentCtx.ValidateConfigMapDeletionRecovery},
+		{"Validate service deletion recovery", componentCtx.ValidateServiceDeletionRecovery},
+		// TODO: disabled until RHOAIENG-32503 is resolved
 		// {"Validate rbac deletion recovery", componentCtx.ValidateRBACDeletionRecovery},
+		// {"Validate serviceaccount deletion recovery", componentCtx.ValidateServiceAccountDeletionRecovery},
 	}
 
 	// Only add OCP Kueue operator test if OCP version is 4.18 or above

--- a/tests/e2e/llamastackoperator_test.go
+++ b/tests/e2e/llamastackoperator_test.go
@@ -28,12 +28,11 @@ func llamastackOperatorTestSuite(t *testing.T) {
 		{"Validate operands have OwnerReferences", componentCtx.ValidateOperandsOwnerReferences},
 		{"Validate update operand resources", componentCtx.ValidateUpdateDeploymentsResources},
 		{"Validate component releases", componentCtx.ValidateComponentReleases},
-		// TODO: Disabled until these tests have been hardened (RHOAIENG-27721)
-		// {"Validate deployment deletion recovery", componentCtx.ValidateDeploymentDeletionRecovery},
-		// {"Validate configmap deletion recovery", componentCtx.ValidateConfigMapDeletionRecovery},
-		// {"Validate service deletion recovery", componentCtx.ValidateServiceDeletionRecovery},
-		// {"Validate serviceaccount deletion recovery", componentCtx.ValidateServiceAccountDeletionRecovery},
+		{"Validate deployment deletion recovery", componentCtx.ValidateDeploymentDeletionRecovery},
+		{"Validate configmap deletion recovery", componentCtx.ValidateConfigMapDeletionRecovery},
+		{"Validate service deletion recovery", componentCtx.ValidateServiceDeletionRecovery},
 		// {"Validate rbac deletion recovery", componentCtx.ValidateRBACDeletionRecovery},
+		{"Validate serviceaccount deletion recovery", componentCtx.ValidateServiceAccountDeletionRecovery},
 		{"Validate component disabled", componentCtx.ValidateComponentDisabled},
 	}
 

--- a/tests/e2e/modelcontroller_test.go
+++ b/tests/e2e/modelcontroller_test.go
@@ -41,12 +41,11 @@ func modelControllerTestSuite(t *testing.T) {
 		{"Validate component enabled", componentCtx.ValidateComponentEnabled},
 		{"Validate operands have OwnerReferences", componentCtx.ValidateOperandsOwnerReferences},
 		{"Validate update operand resources", componentCtx.ValidateUpdateDeploymentsResources},
-		// TODO: Disabled until these tests have been hardened (RHOAIENG-27721)
-		// {"Validate deployment deletion recovery", componentCtx.ValidateDeploymentDeletionRecovery},
-		// {"Validate configmap deletion recovery", componentCtx.ValidateConfigMapDeletionRecovery},
-		// {"Validate service deletion recovery", componentCtx.ValidateServiceDeletionRecovery},
-		// {"Validate serviceaccount deletion recovery", componentCtx.ValidateServiceAccountDeletionRecovery},
+		{"Validate deployment deletion recovery", componentCtx.ValidateDeploymentDeletionRecovery},
+		{"Validate configmap deletion recovery", componentCtx.ValidateConfigMapDeletionRecovery},
+		{"Validate service deletion recovery", componentCtx.ValidateServiceDeletionRecovery},
 		// {"Validate rbac deletion recovery", componentCtx.ValidateRBACDeletionRecovery},
+		{"Validate serviceaccount deletion recovery", componentCtx.ValidateServiceAccountDeletionRecovery},
 		{"Validate component disabled", componentCtx.ValidateComponentDisabled},
 	}
 

--- a/tests/e2e/modelmeshserving_test.go
+++ b/tests/e2e/modelmeshserving_test.go
@@ -29,12 +29,11 @@ func modelMeshServingTestSuite(t *testing.T) {
 		{"Validate operands have OwnerReferences", componentCtx.ValidateOperandsOwnerReferences},
 		{"Validate update operand resources", componentCtx.ValidateUpdateDeploymentsResources},
 		{"Validate component releases", componentCtx.ValidateComponentReleases},
-		// TODO: Disabled until these tests have been hardened (RHOAIENG-27721)
-		// {"Validate deployment deletion recovery", componentCtx.ValidateDeploymentDeletionRecovery},
-		// {"Validate configmap deletion recovery", componentCtx.ValidateConfigMapDeletionRecovery},
-		// {"Validate service deletion recovery", componentCtx.ValidateServiceDeletionRecovery},
-		// {"Validate serviceaccount deletion recovery", componentCtx.ValidateServiceAccountDeletionRecovery},
+		{"Validate deployment deletion recovery", componentCtx.ValidateDeploymentDeletionRecovery},
+		{"Validate configmap deletion recovery", componentCtx.ValidateConfigMapDeletionRecovery},
+		{"Validate service deletion recovery", componentCtx.ValidateServiceDeletionRecovery},
 		// {"Validate rbac deletion recovery", componentCtx.ValidateRBACDeletionRecovery},
+		{"Validate serviceaccount deletion recovery", componentCtx.ValidateServiceAccountDeletionRecovery},
 		{"Validate component disabled", componentCtx.ValidateComponentDisabled},
 	}
 

--- a/tests/e2e/modelregistry_test.go
+++ b/tests/e2e/modelregistry_test.go
@@ -33,12 +33,11 @@ func modelRegistryTestSuite(t *testing.T) {
 		{"Validate update operand resources", componentCtx.ValidateUpdateDeploymentsResources},
 		{"Validate CRDs reinstated", componentCtx.ValidateCRDReinstated},
 		{"Validate component releases", componentCtx.ValidateComponentReleases},
-		// TODO: Disabled until these tests have been hardened (RHOAIENG-27721)
-		// {"Validate deployment deletion recovery", componentCtx.ValidateDeploymentDeletionRecovery},
-		// {"Validate configmap deletion recovery", componentCtx.ValidateConfigMapDeletionRecovery},
-		// {"Validate service deletion recovery", componentCtx.ValidateServiceDeletionRecovery},
-		// {"Validate serviceaccount deletion recovery", componentCtx.ValidateServiceAccountDeletionRecovery},
+		{"Validate deployment deletion recovery", componentCtx.ValidateDeploymentDeletionRecovery},
+		{"Validate configmap deletion recovery", componentCtx.ValidateConfigMapDeletionRecovery},
+		{"Validate service deletion recovery", componentCtx.ValidateServiceDeletionRecovery},
 		// {"Validate rbac deletion recovery", componentCtx.ValidateRBACDeletionRecovery},
+		{"Validate serviceaccount deletion recovery", componentCtx.ValidateServiceAccountDeletionRecovery},
 		{"Validate component disabled", componentCtx.ValidateComponentDisabled},
 	}
 

--- a/tests/e2e/ray_test.go
+++ b/tests/e2e/ray_test.go
@@ -28,12 +28,11 @@ func rayTestSuite(t *testing.T) {
 		{"Validate operands have OwnerReferences", componentCtx.ValidateOperandsOwnerReferences},
 		{"Validate update operand resources", componentCtx.ValidateUpdateDeploymentsResources},
 		{"Validate component releases", componentCtx.ValidateComponentReleases},
-		// TODO: Disabled until these tests have been hardened (RHOAIENG-27721)
-		// {"Validate deployment deletion recovery", componentCtx.ValidateDeploymentDeletionRecovery},
-		// {"Validate configmap deletion recovery", componentCtx.ValidateConfigMapDeletionRecovery},
-		// {"Validate service deletion recovery", componentCtx.ValidateServiceDeletionRecovery},
-		// {"Validate serviceaccount deletion recovery", componentCtx.ValidateServiceAccountDeletionRecovery},
+		{"Validate deployment deletion recovery", componentCtx.ValidateDeploymentDeletionRecovery},
+		{"Validate configmap deletion recovery", componentCtx.ValidateConfigMapDeletionRecovery},
+		{"Validate service deletion recovery", componentCtx.ValidateServiceDeletionRecovery},
 		// {"Validate rbac deletion recovery", componentCtx.ValidateRBACDeletionRecovery},
+		{"Validate serviceaccount deletion recovery", componentCtx.ValidateServiceAccountDeletionRecovery},
 		{"Validate component disabled", componentCtx.ValidateComponentDisabled},
 	}
 

--- a/tests/e2e/resource_options_test.go
+++ b/tests/e2e/resource_options_test.go
@@ -84,6 +84,10 @@ type ResourceOptions struct {
 	// If true, the DeleteResource function will block until the resource is confirmed to be gone.
 	WaitForDeletion bool
 
+	// GracePeriod specifies a waiting period before starting resource existence checks.
+	// This helps avoid race conditions where controllers need time to process deletion events.
+	GracePeriod time.Duration
+
 	// Webhook validation fields for testing
 	// InvalidValue holds the description of the invalid value being tested in webhook validation
 	InvalidValue string
@@ -186,6 +190,14 @@ func WithClientDeleteOptions(deleteOptions *client.DeleteOptions) ResourceOpts {
 func WithWaitForDeletion(wait bool) ResourceOpts {
 	return func(ro *ResourceOptions) {
 		ro.WaitForDeletion = wait
+	}
+}
+
+// WithGracePeriod adds a grace period before starting to check for resource existence.
+// This helps avoid race conditions where controllers need time to process deletion events.
+func WithGracePeriod(duration time.Duration) ResourceOpts {
+	return func(ro *ResourceOptions) {
+		ro.GracePeriod = duration
 	}
 }
 

--- a/tests/e2e/test_context_test.go
+++ b/tests/e2e/test_context_test.go
@@ -704,6 +704,44 @@ func (tc *TestContext) DeleteResource(opts ...ResourceOpts) {
 	}
 }
 
+// EnsureResourceDeletedThenRecreated provides a robust deletion-recreation test pattern
+// that handles the race condition between client deletion and controller recreation.
+func (tc *TestContext) EnsureResourceDeletedThenRecreated(opts ...ResourceOpts) *unstructured.Unstructured {
+	ro := tc.NewResourceOptions(opts...)
+
+	// Step 1: Capture original resource metadata
+	originalResource := tc.EnsureResourceExists(opts...)
+	originalUID := string(originalResource.GetUID())
+	originalResourceVersion := originalResource.GetResourceVersion()
+
+	// Step 2: Delete the resource using standard deletion
+	tc.DeleteResource(opts...)
+
+	// Step 3: Wait for controller to recreate with new identity
+	var recreatedResource *unstructured.Unstructured
+	tc.g.Eventually(func(g Gomega) {
+		// Apply grace period if specified
+		if ro.GracePeriod > 0 {
+			time.Sleep(ro.GracePeriod)
+		}
+
+		recreatedResource = tc.EnsureResourceExists(opts...)
+
+		// Verify it's actually a new resource (different UID)
+		newUID := string(recreatedResource.GetUID())
+		newResourceVersion := recreatedResource.GetResourceVersion()
+
+		g.Expect(newUID).NotTo(Equal(originalUID),
+			"Recreated resource should have different UID. Original: %s, New: %s", originalUID, newUID)
+		g.Expect(newResourceVersion).NotTo(Equal(originalResourceVersion),
+			"Recreated resource should have different ResourceVersion. Original: %s, New: %s",
+			originalResourceVersion, newResourceVersion)
+	}).Should(Succeed(),
+		"Resource %s %s was not properly recreated with new identity", ro.GVK.Kind, ro.ResourceID)
+
+	return recreatedResource
+}
+
 // FetchInstallPlanName retrieves the name of the InstallPlan associated with a subscription.
 // It ensures that the subscription exists (or is created) and then retrieves the InstallPlan name.
 // This function does not return an error, it will panic if anything goes wrong (such as a missing InstallPlanRef).

--- a/tests/e2e/trainingoperator_test.go
+++ b/tests/e2e/trainingoperator_test.go
@@ -28,12 +28,11 @@ func trainingOperatorTestSuite(t *testing.T) {
 		{"Validate operands have OwnerReferences", componentCtx.ValidateOperandsOwnerReferences},
 		{"Validate update operand resources", componentCtx.ValidateUpdateDeploymentsResources},
 		{"Validate component releases", componentCtx.ValidateComponentReleases},
-		// TODO: Disabled until these tests have been hardened (RHOAIENG-27721)
-		// {"Validate deployment deletion recovery", componentCtx.ValidateDeploymentDeletionRecovery},
-		// {"Validate configmap deletion recovery", componentCtx.ValidateConfigMapDeletionRecovery},
-		// {"Validate service deletion recovery", componentCtx.ValidateServiceDeletionRecovery},
-		// {"Validate serviceaccount deletion recovery", componentCtx.ValidateServiceAccountDeletionRecovery},
+		{"Validate deployment deletion recovery", componentCtx.ValidateDeploymentDeletionRecovery},
+		{"Validate configmap deletion recovery", componentCtx.ValidateConfigMapDeletionRecovery},
+		{"Validate service deletion recovery", componentCtx.ValidateServiceDeletionRecovery},
 		// {"Validate rbac deletion recovery", componentCtx.ValidateRBACDeletionRecovery},
+		{"Validate serviceaccount deletion recovery", componentCtx.ValidateServiceAccountDeletionRecovery},
 		{"Validate component disabled", componentCtx.ValidateComponentDisabled},
 	}
 

--- a/tests/e2e/trustyai_test.go
+++ b/tests/e2e/trustyai_test.go
@@ -41,12 +41,11 @@ func trustyAITestSuite(t *testing.T) {
 		{"Validate update operand resources", componentCtx.ValidateUpdateDeploymentsResources},
 		{"Validate component releases", componentCtx.ValidateComponentReleases},
 		{"Validate pre check", componentCtx.ValidateTrustyAIPreCheck},
-		// TODO: Disabled until these tests have been hardened (RHOAIENG-27721)
-		// {"Validate deployment deletion recovery", componentCtx.ValidateDeploymentDeletionRecovery},
-		// {"Validate configmap deletion recovery", componentCtx.ValidateConfigMapDeletionRecovery},
-		// {"Validate service deletion recovery", componentCtx.ValidateServiceDeletionRecovery},
-		// {"Validate serviceaccount deletion recovery", componentCtx.ValidateServiceAccountDeletionRecovery},
+		{"Validate deployment deletion recovery", componentCtx.ValidateDeploymentDeletionRecovery},
+		{"Validate configmap deletion recovery", componentCtx.ValidateConfigMapDeletionRecovery},
+		{"Validate service deletion recovery", componentCtx.ValidateServiceDeletionRecovery},
 		// {"Validate rbac deletion recovery", componentCtx.ValidateRBACDeletionRecovery},
+		{"Validate serviceaccount deletion recovery", componentCtx.ValidateServiceAccountDeletionRecovery},
 		{"Validate component disabled", componentCtx.ValidateComponentDisabled},
 	}
 

--- a/tests/e2e/workbenches_test.go
+++ b/tests/e2e/workbenches_test.go
@@ -30,12 +30,11 @@ func workbenchesTestSuite(t *testing.T) {
 		{"Validate operands have OwnerReferences", componentCtx.ValidateOperandsOwnerReferences},
 		{"Validate update operand resources", componentCtx.ValidateUpdateDeploymentsResources},
 		{"Validate component releases", componentCtx.ValidateComponentReleases},
-		// TODO: Disabled until these tests have been hardened (RHOAIENG-27721)
-		// {"Validate deployment deletion recovery", componentCtx.ValidateDeploymentDeletionRecovery},
-		// {"Validate configmap deletion recovery", componentCtx.ValidateConfigMapDeletionRecovery},
-		// {"Validate service deletion recovery", componentCtx.ValidateServiceDeletionRecovery},
-		// {"Validate serviceaccount deletion recovery", componentCtx.ValidateServiceAccountDeletionRecovery},
+		{"Validate deployment deletion recovery", componentCtx.ValidateDeploymentDeletionRecovery},
+		{"Validate configmap deletion recovery", componentCtx.ValidateConfigMapDeletionRecovery},
+		{"Validate service deletion recovery", componentCtx.ValidateServiceDeletionRecovery},
 		// {"Validate rbac deletion recovery", componentCtx.ValidateRBACDeletionRecovery},
+		{"Validate serviceaccount deletion recovery", componentCtx.ValidateServiceAccountDeletionRecovery},
 		{"Validate component disabled", componentCtx.ValidateComponentDisabled},
 	}
 


### PR DESCRIPTION
## Description
JIRA: [RHOAIENG-31320](https://issues.redhat.com/browse/RHOAIENG-31320)

This PR uncomments most of the resource deletion and recreation e2e tests on the `main` branch. It also adds some improvements to the test to simplify and harden them:
* Added new helper functions `EnsureResourceDeletedThenRecreated()` and `ensureResourceDeletionAcknowledged()` which were written by @ugiordan. These functions provide a more robust mechanism to validate the deletion-recreation by better handling race conditions.
* Slightly re-arranged test order
* Tweaked timeouts

Note that the ServiceAccount deletion-recreation test is still commented out for the kueue component due to a known bug that is tracked by [RHOAIENG-32503](https://issues.redhat.com/browse/RHOAIENG-32503). Also note that this PR still leaves the RBAC deletion-recreation tests commented out as they are still too flaky. These will be improved in a follow-up PR.

## How Has This Been Tested?
These changes were tested by building operator, bundle, and catalog images, then running the full e2e test suite locally which passed.

The following images were used for testing and can be used for verification:
```
quay.io/ckyrillo/opendatahub-operator:v2.33.0
quay.io/ckyrillo/opendatahub-operator-bundle:v2.33.0
quay.io/ckyrillo/opendatahub-operator-catalog:v2.33.0
```

## Screenshot or short clip
N/A

## Merge criteria
- [X] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [X] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [X] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Re-enabled many deletion-recovery end-to-end tests across components (deployment, configmap, service, serviceaccount, route where applicable); RBAC recovery remains disabled in several suites.
  - Adopted a delete-and-recreate verification flow with configurable grace periods to reduce flakiness and race conditions.
  - Added per-resource pre-checks to skip when no resources exist and introduced data-driven subtests for broader RBAC scenarios where applicable.
  - Harmonized test ordering and expanded reliability helpers across suites.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->