### PR TITLE
feat: RHOAIENG-29291 - notfiy kserve suboptimal configuration

### DIFF
--- a/internal/controller/components/kserve/kserve.go
+++ b/internal/controller/components/kserve/kserve.go
@@ -43,7 +43,6 @@ var (
 	conditionTypes = []string{
 		status.ConditionServingAvailable,
 		status.ConditionDeploymentsAvailable,
-		status.ConditionKserveConfigurationOptimal,
 	}
 )
 

--- a/internal/controller/components/kserve/kserve_controller.go
+++ b/internal/controller/components/kserve/kserve_controller.go
@@ -131,6 +131,7 @@ func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.
 		WithAction(initialize).
 		WithAction(devFlags).
 		WithAction(releases.NewAction()).
+		WithAction(checkConfigurationOptimality).
 		WithAction(addTemplateFiles).
 		WithAction(template.NewAction(
 			template.WithDataFn(getTemplateData),

--- a/internal/controller/status/status.go
+++ b/internal/controller/status/status.go
@@ -106,7 +106,6 @@ const (
 	ConditionOpenTelemetryCollectorAvailable = "OpenTelemetryCollectorAvailable"
 	ConditionInstrumentationAvailable        = "InstrumentationAvailable"
 	ConditionAlertingAvailable               = "AlertingAvailable"
-	ConditionKserveConfigurationOptimal      = "KserveConfigurationOptimal"
 )
 
 const (
@@ -195,10 +194,12 @@ const (
 	OpenTelemetryCollectorOperatorMissingMessage = "OpenTelemetryCollector operator must be installed for OpenTelemetry configuration"
 )
 
-// For KServe configuration checks.
 const (
-	ConfigurationSubOptimalReason  string = "ConfigurationSubOptimal"
-	ConfigurationSubOptimalMessage string = "Serving is managed but defaultDeploymentMode is set to RawDeployment - this may not provide the expected serverless experience"
+	ConditionConfigurationOptimal        = "ConfigurationOptimal"
+	ConfigurationOptimalReason           = "ConfigurationOptimal"
+	ConfigurationOptimalMessage          = "No configuration issues identified"
+	ConfigurationSubOptimalReason        = "ConfigurationSubOptimal"
+	KServeConfigurationSubOptimalMessage = "Serving is Managed, but defaultDeploymentMode is 'RawDeployment'. Consider switching defaultDeploymentMode to 'Serverless' or setting Serving to Unmanaged to optimize resource usage."
 )
 
 // setConditions is a helper function to set multiple conditions at once.


### PR DESCRIPTION
## Description
Added logic to generate log and Kserve Status when Kserve ManagementState is "Managed" and DefaultDeploymentMode is "RawDeployment" to prevent user misinformation and cluster resource wastage. The Kserver status will bubble up to DSC Status.

[RHOAIENG-29291](https://issues.redhat.com/browse/RHOAIENG-29291)

## How Has This Been Tested?
Added unit test for the new code changes done.

## Merge criteria
- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds a configuration health check for KServe that sets a "ConfigurationOptimal" status condition during reconciliation.
  * Emits a warning and guidance when serving is managed but default deployment mode is RawDeployment, recommending Serverless or Unmanaged; otherwise reports configuration as optimal.

* **Tests**
  * Added unit tests covering optimal, suboptimal, and acceptable configuration scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->