### PR TITLE
revert changes to federation servicemonitor

### DIFF
--- a/config/monitoring/base/rhods-servicemonitor.yaml
+++ b/config/monitoring/base/rhods-servicemonitor.yaml
@@ -8,12 +8,12 @@ metadata:
     team: rhods
 spec:
   endpoints:
-    - authorization:
-        type: Bearer
-        credentialsFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      bearerTokenSecret:
+        key: ""
       honorLabels: true
       params:
-        "match[]":
+        'match[]':
           - '{__name__= "rhods_total_users"}'
           - '{__name__= "rhods_active_users"}'
           - '{__name__= "rhods_aggregate_availability"}'
@@ -23,7 +23,7 @@ spec:
       scheme: https
       tlsConfig:
         caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
-        serverName: "prometheus.redhat-ods-monitoring.svc"
+        serverName: prometheus.redhat-ods-monitoring.svc
       scrapeTimeout: 10s
       interval: 30s
   namespaceSelector:


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->
Revert changes to `configmonitoring/base/rhods-serviocemonitor.yaml` made in https://github.com/opendatahub-io/opendatahub-operator/pull/2285
<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Federated monitoring now includes firing alert metrics (excluding DeadManSnitch), improving visibility into active alerts.
- Bug Fixes
  - Updated ServiceMonitor authentication to use the service account token directly, improving reliability of metrics scraping across clusters.
- Chores
  - Minor configuration cleanups for consistency and stabilized TLS name handling; no user-facing behavioral changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->