### PR TITLE
feat: handle connection API deletion case for InferenceService

### DIFF
--- a/pkg/webhook/utils.go
+++ b/pkg/webhook/utils.go
@@ -21,6 +21,21 @@ import (
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/resources"
 )
 
+type ConnectionAction string
+
+const (
+	// ConnectionActionInject represents injecting connection.
+	ConnectionActionInject ConnectionAction = "inject"
+	// ConnectionActionRemove represents removing previously injected connection.
+	ConnectionActionRemove ConnectionAction = "remove"
+	// ConnectionActionNone represents no action needed.
+	ConnectionActionNone ConnectionAction = "none"
+)
+
+func (ca ConnectionAction) String() string {
+	return string(ca)
+}
+
 // NewWebhookLogConstructor returns a log constructor function for admission webhooks that adds the webhook name to the logger context for each admission request.
 //
 // Parameters:
@@ -128,7 +143,7 @@ func DecodeUnstructured(decoder admission.Decoder, req admission.Request) (*unst
 	return obj, nil
 }
 
-// ValidateInferenceServiceConnectionAnnotation validates the connection annotation  "opendatahub.io/connections"
+// ValidateInferenceServiceConnectionAnnotationAction validates the connection annotation  "opendatahub.io/connections"
 // If the annotation exists and has a non-empty value, it validates that the value references
 // a valid secret in the same namespace. Additionally, it checks the secret's connection type
 // annotation and rejects requests with invalid configurations. (see allowedTypes)
@@ -143,21 +158,27 @@ func DecodeUnstructured(decoder admission.Decoder, req admission.Request) (*unst
 //
 // Returns:
 //   - admission.Response: The validation result
-//   - bool: true if injection should be performed (only for known valid connection types)
-//   - string: The validated secret name (only valid when injection should be performed)
-//   - string: The connection type (only valid when injection should be performed)
+//   - ConnectionAction: The action to be taken (inject, remove, or none)
+//   - string: The validated secret name (only valid when action is inject)
+//   - string: The connection type (only valid when action is inject)
 func ValidateInferenceServiceConnectionAnnotation(ctx context.Context,
 	cli client.Reader,
 	decodedObj *unstructured.Unstructured,
 	req admission.Request,
 	allowedTypes []string,
-) (admission.Response, bool, string, string) {
+) (admission.Response, ConnectionAction, string, string) {
 	log := logf.FromContext(ctx)
 
 	// Check if the annotation "opendatahub.io/connections" exists and has a non-empty value
 	annotationValue := resources.GetAnnotation(decodedObj, annotations.Connection)
 	if annotationValue == "" {
-		return admission.Allowed(fmt.Sprintf("Annotation '%s' not present or empty value, skipping validation", annotations.Connection)), false, "", ""
+		// removal case
+		if req.Operation == "UPDATE" {
+			return admission.Allowed(fmt.Sprintf("Annotation '%s' not present or empty value, cleanup if present already", annotations.Connection)), ConnectionActionRemove, "", ""
+		}
+		if req.Operation == "CREATE" {
+			return admission.Allowed(fmt.Sprintf("Annotation '%s' not present or empty value, skipping validation", annotations.Connection)), ConnectionActionNone, "", ""
+		}
 	}
 
 	// Get the secret's metadata only (PartialObjectMetadata) to check annotations
@@ -165,17 +186,18 @@ func ValidateInferenceServiceConnectionAnnotation(ctx context.Context,
 	if err := cli.Get(ctx, types.NamespacedName{Name: annotationValue, Namespace: req.Namespace}, secretMeta); err != nil {
 		if k8serr.IsNotFound(err) {
 			return admission.Denied(fmt.Sprintf("Secret '%s' referenced in annotation '%s' not found in namespace '%s'",
-				annotationValue, annotations.Connection, req.Namespace)), false, "", ""
+				annotationValue, annotations.Connection, req.Namespace)), ConnectionActionNone, "", ""
 		}
 		log.Error(err, "failed to get secret metadata", "secretName", annotationValue, "namespace", req.Namespace)
-		return admission.Errored(http.StatusInternalServerError, fmt.Errorf("failed to validate secret: %w", err)), false, "", ""
+		return admission.Errored(http.StatusInternalServerError, fmt.Errorf("failed to validate secret: %w", err)), ConnectionActionNone, "", ""
 	}
 
 	// Additional validation: check the secret's connections-type-ref annotation exists and has a non-empty value
 	connectionType := resources.GetAnnotation(secretMeta, annotations.ConnectionTypeRef)
 	if connectionType == "" {
-		return admission.Allowed(fmt.Sprintf("Secret '%s' does not have '%s' annotation", annotationValue, annotations.ConnectionTypeRef)), false, "", ""
+		return admission.Allowed(fmt.Sprintf("Secret '%s' does not have '%s' annotation", annotationValue, annotations.ConnectionTypeRef)), ConnectionActionNone, "", ""
 	}
+
 	// Validate that the connection type is one of the allowed values
 	isValidType := slices.Contains(allowedTypes, connectionType)
 
@@ -183,11 +205,11 @@ func ValidateInferenceServiceConnectionAnnotation(ctx context.Context,
 		// Allow unknown connection types but log a warning and don't perform injection
 		log.Info("Unknown connection type found, allowing operation but skipping injection", "connectionType", connectionType, "allowedTypes", allowedTypes)
 		return admission.Allowed(fmt.Sprintf("Annotation '%s' validation on secret '%s' with unknown type '%s' in namespace '%s'",
-			annotations.Connection, annotationValue, connectionType, req.Namespace)), false, "", ""
+			annotations.Connection, annotationValue, connectionType, req.Namespace)), ConnectionActionNone, "", ""
 	}
 
 	// Allow the operation and indicate that injection should be performed
-	return admission.Allowed("Connection annotation validation passed"), true, secretMeta.Name, connectionType
+	return admission.Allowed("Connection annotation validation passed"), ConnectionActionInject, secretMeta.Name, connectionType
 }
 
 // GetOrCreateNestedMap safely retrieves or creates a nested map within an unstructured object.


### PR DESCRIPTION
- when annotation opendatahub.io/connection-type-ref is removed from isvc
- oci: .spec.predictor.imagePullSecrets set to []
- uri: .spec.preditor.mode.storageUri is deleted
- s3: .spec.predictor.model.storage is removed
all these will be performed since we do not know which was originally set before Update, and might be some leftover

<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

<!--- Link your JIRA and related links here for reference. -->
ref https://issues.redhat.com/browse/RHOAIENG-32828  part I

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
local build: quay.io/wenzhou/opendatahub-operator:2.34.0-827

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Automatic cleanup of previously injected connection settings when the connection annotation is removed (covers image pull secrets, storage URI, and S3 storage keys).
  - Action-based handling (inject, remove, none) for clearer, more predictable webhook behavior and messages.
- Bug Fixes
  - Delete operations are explicitly allowed, preventing unintended denials.
  - Unknown or unsupported actions are safely allowed with informative messages.
- Tests
  - Added test coverage for cleanup scenarios and updated expectations to reflect new action-based responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->