### PR TITLE
update: add ServiceAccount creation and biding for Inferenceservice Connection API

### DIFF
--- a/bundle/manifests/opendatahub-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/opendatahub-operator.clusterserviceversion.yaml
@@ -1621,7 +1621,7 @@ spec:
       - UPDATE
       resources:
       - inferenceservices
-    sideEffects: None
+    sideEffects: NoneOnDryRun
     targetPort: 9443
     type: MutatingAdmissionWebhook
     webhookPath: /platform-connection-isvc

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -83,7 +83,7 @@ webhooks:
     - UPDATE
     resources:
     - inferenceservices
-  sideEffects: None
+  sideEffects: NoneOnDryRun
 - admissionReviewVersions:
   - v1
   clientConfig:

--- a/internal/webhook/envtestutil/webhook_registration.go
+++ b/internal/webhook/envtestutil/webhook_registration.go
@@ -45,9 +45,10 @@ func RegisterWebhooks(mgr manager.Manager) error {
 
 	// Register Connection webhook for InferenceService
 	isvcConnectionWebhook := &inferenceservicewebhook.ConnectionWebhook{
-		Client:  mgr.GetAPIReader(),
-		Decoder: admission.NewDecoder(mgr.GetScheme()),
-		Name:    "connection-isvc",
+		Client:     mgr.GetAPIReader(),
+		APICreator: mgr.GetClient(),
+		Decoder:    admission.NewDecoder(mgr.GetScheme()),
+		Name:       "connection-isvc",
 	}
 	if err := isvcConnectionWebhook.SetupWithManager(mgr); err != nil {
 		return err

--- a/internal/webhook/envtestutil/webhook_registration.go
+++ b/internal/webhook/envtestutil/webhook_registration.go
@@ -45,10 +45,10 @@ func RegisterWebhooks(mgr manager.Manager) error {
 
 	// Register Connection webhook for InferenceService
 	isvcConnectionWebhook := &inferenceservicewebhook.ConnectionWebhook{
-		Client:     mgr.GetAPIReader(),
-		APICreator: mgr.GetClient(),
-		Decoder:    admission.NewDecoder(mgr.GetScheme()),
-		Name:       "connection-isvc",
+		Client:    mgr.GetClient(),
+		APIReader: mgr.GetAPIReader(),
+		Decoder:   admission.NewDecoder(mgr.GetScheme()),
+		Name:      "connection-isvc",
 	}
 	if err := isvcConnectionWebhook.SetupWithManager(mgr); err != nil {
 		return err

--- a/internal/webhook/inferenceservice/mutating.go
+++ b/internal/webhook/inferenceservice/mutating.go
@@ -118,7 +118,7 @@ func (w *ConnectionWebhook) Handle(ctx context.Context, req admission.Request) a
 		}
 
 		// validate the connection annotation and determine the action to take
-		validationResp, action, secretName, connectionType := webhookutils.ValidateInferenceServiceConnectionAnnotation(ctx, w.Client, obj, req, allowedTypes)
+		validationResp, action, secretName, connectionType := webhookutils.ValidateInferenceServiceConnectionAnnotation(ctx, w.APIReader, obj, req, allowedTypes)
 		if !validationResp.Allowed {
 			return validationResp
 		}
@@ -380,7 +380,7 @@ func (w *ConnectionWebhook) injectOCIImagePullSecrets(obj *unstructured.Unstruct
 func (w *ConnectionWebhook) injectURIStorageUri(ctx context.Context, obj *unstructured.Unstructured, secretName, namespace string) error {
 	// Fetch the secret to get the URI data
 	secret := &corev1.Secret{}
-	if err := w.Client.Get(ctx, types.NamespacedName{Name: secretName, Namespace: namespace}, secret); err != nil {
+	if err := w.APIReader.Get(ctx, types.NamespacedName{Name: secretName, Namespace: namespace}, secret); err != nil {
 		return fmt.Errorf("failed to get secret %s: %w", secretName, err)
 	}
 

--- a/internal/webhook/inferenceservice/mutating_test.go
+++ b/internal/webhook/inferenceservice/mutating_test.go
@@ -57,7 +57,7 @@ func setupTestEnvironment(t *testing.T) (*runtime.Scheme, context.Context) {
 func createWebhook(cli client.Client, sch *runtime.Scheme) *inferenceservice.ConnectionWebhook {
 	webhook := &inferenceservice.ConnectionWebhook{
 		Client:     cli,
-		APICreater: cli, // Ensure ServiceAccount creation works in tests
+		APICreator: cli, // Ensure ServiceAccount creation works in tests
 		Decoder:    admission.NewDecoder(sch),
 		Name:       "glueisvc-test",
 	}

--- a/internal/webhook/inferenceservice/mutating_test.go
+++ b/internal/webhook/inferenceservice/mutating_test.go
@@ -56,9 +56,10 @@ func setupTestEnvironment(t *testing.T) (*runtime.Scheme, context.Context) {
 
 func createWebhook(cli client.Client, sch *runtime.Scheme) *inferenceservice.ConnectionWebhook {
 	webhook := &inferenceservice.ConnectionWebhook{
-		Client:  cli,
-		Decoder: admission.NewDecoder(sch),
-		Name:    "glueisvc-test",
+		Client:     cli,
+		APICreater: cli, // Ensure ServiceAccount creation works in tests
+		Decoder:    admission.NewDecoder(sch),
+		Name:       "glueisvc-test",
 	}
 	return webhook
 }
@@ -249,6 +250,77 @@ func hasStorageKeyCleanupPatch() func([]jsonpatch.JsonPatchOperation) bool {
 		}
 		return false
 	}
+}
+
+func hasServiceAccountNamePatch(expectedSAName string) func([]jsonpatch.JsonPatchOperation) bool {
+	return func(patches []jsonpatch.JsonPatchOperation) bool {
+		for _, patch := range patches {
+			if patch.Path == "/spec/predictor/serviceAccountName" && patch.Value == expectedSAName {
+				return true
+			}
+		}
+		return false
+	}
+}
+
+func hasServiceAccountNameRemovePatch() func([]jsonpatch.JsonPatchOperation) bool {
+	return func(patches []jsonpatch.JsonPatchOperation) bool {
+		for _, patch := range patches {
+			if patch.Path == "/spec/predictor/serviceAccountName" && patch.Operation == OperationRemove {
+				return true
+			}
+		}
+		return false
+	}
+}
+
+func TestServiceAccountNamePatching(t *testing.T) {
+	t.Run("serviceAccountName is injected on create with OCI", func(t *testing.T) {
+		tc := TestCase{
+			name:            "serviceAccountName injected on create",
+			secretType:      inferenceservice.ConnectionTypeOCI.String(),
+			secretNamespace: testNamespace,
+			annotations:     map[string]string{annotations.Connection: testSecret},
+			operation:       admissionv1.Create,
+			expectedAllowed: true,
+			expectedPatchCheck: func(patches []jsonpatch.JsonPatchOperation) bool {
+				return hasServiceAccountNamePatch(testSecret + "-sa")(patches)
+			},
+		}
+		runTestCase(t, tc)
+	})
+	t.Run("serviceAccountName is injected on update with S3", func(t *testing.T) {
+		tc := TestCase{
+			name:            "serviceAccountName injected on update",
+			secretType:      inferenceservice.ConnectionTypeS3.String(),
+			secretNamespace: testNamespace,
+			annotations:     map[string]string{annotations.Connection: testSecret},
+			predictorSpec:   map[string]interface{}{"model": map[string]interface{}{}},
+			operation:       admissionv1.Update,
+			expectedAllowed: true,
+			expectedPatchCheck: func(patches []jsonpatch.JsonPatchOperation) bool {
+				return hasServiceAccountNamePatch(testSecret + "-sa")(patches)
+			},
+		}
+		runTestCase(t, tc)
+	})
+	t.Run("serviceAccountName is removed on annotation removal", func(t *testing.T) {
+		tc := TestCase{
+			name:            "serviceAccountName removed on annotation removal",
+			secretType:      "",
+			secretNamespace: testNamespace,
+			annotations:     map[string]string{}, // annotation removed
+			predictorSpec: map[string]interface{}{
+				"serviceAccountName": testSecret + "-sa",
+			},
+			operation:       admissionv1.Update,
+			expectedAllowed: true,
+			expectedPatchCheck: func(patches []jsonpatch.JsonPatchOperation) bool {
+				return hasServiceAccountNameRemovePatch()(patches)
+			},
+		}
+		runTestCase(t, tc)
+	})
 }
 
 func TestConnectionWebhook(t *testing.T) {

--- a/internal/webhook/inferenceservice/register.go
+++ b/internal/webhook/inferenceservice/register.go
@@ -10,10 +10,10 @@ import (
 // RegisterWebhooks registers the combined connection webhook that handles both validation and mutation.
 func RegisterWebhooks(mgr ctrl.Manager) error {
 	if err := (&ConnectionWebhook{
-		Client:     mgr.GetAPIReader(),
-		APICreator: mgr.GetClient(),
-		Decoder:    admission.NewDecoder(mgr.GetScheme()),
-		Name:       "connection-isvc",
+		APIReader: mgr.GetAPIReader(),
+		Client:    mgr.GetClient(),
+		Decoder:   admission.NewDecoder(mgr.GetScheme()),
+		Name:      "connection-isvc",
 	}).SetupWithManager(mgr); err != nil {
 		return err
 	}

--- a/internal/webhook/inferenceservice/register.go
+++ b/internal/webhook/inferenceservice/register.go
@@ -10,9 +10,10 @@ import (
 // RegisterWebhooks registers the combined connection webhook that handles both validation and mutation.
 func RegisterWebhooks(mgr ctrl.Manager) error {
 	if err := (&ConnectionWebhook{
-		Client:  mgr.GetAPIReader(),
-		Decoder: admission.NewDecoder(mgr.GetScheme()),
-		Name:    "connection-isvc",
+		Client:     mgr.GetAPIReader(),
+		APICreator: mgr.GetClient(),
+		Decoder:    admission.NewDecoder(mgr.GetScheme()),
+		Name:       "connection-isvc",
 	}).SetupWithManager(mgr); err != nil {
 		return err
 	}


### PR DESCRIPTION
- regardless which conntion-type-ref, always create a SA and set .spec.predictor.ServiceAccount to it
- when remove annotation, keep SA in the cluster, but remove the .spec.predictor.ServiceAccount

<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

<!--- Link your JIRA and related links here for reference. -->
ref https://issues.redhat.com/browse/RHOAIENG-33129

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
local buid: quay.io/wenzhou/opendatahub-operator:2.34.32988-3
`oc create ns glue`

create secret
```
apiVersion: v1
kind: Secret
metadata:
  name: s3-example
  namespace: glue
  annotations:
    opendatahub.io/connection-type-ref: s3
    opendatahub.io/connection-type: s3
data:
  AWS_ACCESS_KEY_ID: MQ==
  AWS_DEFAULT_REGION: NA==
  AWS_S3_BUCKET: NQ==
  AWS_S3_ENDPOINT: Mw==
  AWS_SECRET_ACCESS_KEY: Mg==
type: Opaque
```
create isvc
```
apiVersion: serving.kserve.io/v1beta1
kind: InferenceService
metadata:
  annotations:
    opendatahub.io/connections: s3-example
  namespace: glue
  name: isvc-glue-s3
spec:
  predictor:
    model:
      modelFormat:
        name: vLLM
      name: 'mistral'
```
verify

SA created "s3-example-sa"
```
apiVersion: v1
metadata:
  name: s3-example-sa
  namespace: glue
 ...
secrets:
  - name: s3-example
  - name: s3-example-sa-dockercfg-j6fz6
imagePullSecrets:
  - name: s3-example-sa-dockercfg-j6fz6
```

isvc updated "isvc-glue-s3"
```
apiVersion: serving.kserve.io/v1beta1
kind: InferenceService
metadata:
  annotations:
    opendatahub.io/connections: s3-example
....
  name: isvc-glue-s3
  namespace: glue
spec:
  predictor:
    model:
      modelFormat:
        name: vLLM
      name: mistral
      storage:
        key: s3-example
    serviceAccountName: s3-example-sa
```
## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pre-create a ServiceAccount named "<secret>-sa" for referenced secrets and inject its name into predictor.serviceAccountName on create/update (skips creation in dry-run).
  * Added a reusable utility to create ServiceAccounts.

* **Bug Fixes**
  * Removing the injection annotation now removes the injected predictor.serviceAccountName and marks cleanup complete; ServiceAccount is retained.

* **Chores**
  * Webhook sideEffects updated to respect dry-run (NoneOnDryRun).

* **Tests**
  * Added tests for inserting and removing predictor.serviceAccountName.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->