### PR TITLE
Add support in makefile to darwin sed using gsed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -177,11 +177,22 @@ get-manifests: ## Fetch components manifests from remote git repo
 	./get_all_manifests.sh
 CLEANFILES += opt/manifests/*
 
+# Detect OS for sed in-place flag differences
+ifeq ($(shell uname -s),Darwin)
+    # Check if gsed is installed on macOS
+    ifeq ($(shell which gsed),)
+        $(error gsed not found. Please install it using: brew install gnu-sed)
+    endif
+    SED_COMMAND = gsed
+else
+    SED_COMMAND = sed
+endif
+
 .PHONY: api-docs
 api-docs: crd-ref-docs ## Creates API docs using https://github.com/elastic/crd-ref-docs, render managementstate with marker
 	$(CRD_REF_DOCS) --source-path ./ --output-path ./docs/api-overview.md --renderer markdown --config ./crd-ref-docs.config.yaml && \
 	grep -Ev '\.io/[^v][^1].*)$$' ./docs/api-overview.md > temp.md && mv ./temp.md ./docs/api-overview.md && \
-	sed -i "s|](#managementstate)|](https://pkg.go.dev/github.com/openshift/api@v0.0.0-20250812222054-88b2b21555f3/operator/v1#ManagementState)|g" ./docs/api-overview.md
+	$(SED_COMMAND) -i "s|](#managementstate)|](https://pkg.go.dev/github.com/openshift/api@v0.0.0-20250812222054-88b2b21555f3/operator/v1#ManagementState)|g" ./docs/api-overview.md
 
 .PHONY: ginkgo
 ginkgo: $(GINKGO)


### PR DESCRIPTION
## Description

In macOS, the default version of `sed` (BSD sed) behaves differently from GNU sed.
For example, running `sed -i ...` will raise an error, because BSD sed always expects an argument for the `-i` option.
To achieve the same effect as GNU sed `-i`, you need to use `sed -i '' ...`.

There are also other possible changes, so the proposed solution is to use `gsed` on macOS, to make the same commands work.

There are 2 different ways to achieve this:

- change the Makefile as proposed here (and to replicate in other scripts using `sed`, if needed)
- update documentation (I suggest `CONTRIBUTING.md` and/or `docs/troubleshooting.md` file) to guide developers on how to install GNU sed to OSX and use it as default instead of system `sed`

## How Has This Been Tested?
Tested the script on OSX.

Before:

```sh
sed: 1: "./docs/api-overview.md": invalid command code .
make: *** [api-docs] Error 1
```

After: It works correctly updating file.

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [x] The developer has run the integration test pipeline and verified that it passed successfully
