### PR TITLE
alerting validation should block unless storage or resources are set

### DIFF
--- a/api/services/v1alpha1/monitoring_types.go
+++ b/api/services/v1alpha1/monitoring_types.go
@@ -149,7 +149,7 @@ type Monitoring struct {
 }
 
 // MonitoringCommonSpec spec defines the shared desired state of Dashboard
-// +kubebuilder:validation:XValidation:rule="has(self.alerting) ? has(self.metrics.storage) : true",message="Alerting configuration requires metrics to be configured"
+// +kubebuilder:validation:XValidation:rule="has(self.alerting) ? has(self.metrics.storage) || has(self.metrics.resources) : true",message="Alerting configuration requires metrics.storage or metrics.resources to be configured"
 type MonitoringCommonSpec struct {
 	// monitoring spec exposed to DSCI api
 	// Namespace for monitoring if it is enabled

--- a/bundle/manifests/dscinitialization.opendatahub.io_dscinitializations.yaml
+++ b/bundle/manifests/dscinitialization.opendatahub.io_dscinitializations.yaml
@@ -265,8 +265,10 @@ spec:
                     type: object
                 type: object
                 x-kubernetes-validations:
-                - message: Alerting configuration requires metrics to be configured
-                  rule: 'has(self.alerting) ? has(self.metrics.storage) : true'
+                - message: Alerting configuration requires metrics.storage or metrics.resources
+                    to be configured
+                  rule: 'has(self.alerting) ? has(self.metrics.storage) || has(self.metrics.resources)
+                    : true'
               serviceMesh:
                 description: |-
                   Configures Service Mesh as networking layer for Data Science Clusters components.

--- a/bundle/manifests/services.platform.opendatahub.io_monitorings.yaml
+++ b/bundle/manifests/services.platform.opendatahub.io_monitorings.yaml
@@ -212,8 +212,10 @@ spec:
                 type: object
             type: object
             x-kubernetes-validations:
-            - message: Alerting configuration requires metrics to be configured
-              rule: 'has(self.alerting) ? has(self.metrics.storage) : true'
+            - message: Alerting configuration requires metrics.storage or metrics.resources
+                to be configured
+              rule: 'has(self.alerting) ? has(self.metrics.storage) || has(self.metrics.resources)
+                : true'
           status:
             description: MonitoringStatus defines the observed state of Monitoring
             properties:

--- a/config/crd/bases/dscinitialization.opendatahub.io_dscinitializations.yaml
+++ b/config/crd/bases/dscinitialization.opendatahub.io_dscinitializations.yaml
@@ -265,8 +265,10 @@ spec:
                     type: object
                 type: object
                 x-kubernetes-validations:
-                - message: Alerting configuration requires metrics to be configured
-                  rule: 'has(self.alerting) ? has(self.metrics.storage) : true'
+                - message: Alerting configuration requires metrics.storage or metrics.resources
+                    to be configured
+                  rule: 'has(self.alerting) ? has(self.metrics.storage) || has(self.metrics.resources)
+                    : true'
               serviceMesh:
                 description: |-
                   Configures Service Mesh as networking layer for Data Science Clusters components.

--- a/config/crd/bases/services.platform.opendatahub.io_monitorings.yaml
+++ b/config/crd/bases/services.platform.opendatahub.io_monitorings.yaml
@@ -212,8 +212,10 @@ spec:
                 type: object
             type: object
             x-kubernetes-validations:
-            - message: Alerting configuration requires metrics to be configured
-              rule: 'has(self.alerting) ? has(self.metrics.storage) : true'
+            - message: Alerting configuration requires metrics.storage or metrics.resources
+                to be configured
+              rule: 'has(self.alerting) ? has(self.metrics.storage) || has(self.metrics.resources)
+                : true'
           status:
             description: MonitoringStatus defines the observed state of Monitoring
             properties:


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

- The validation for alerting currently blocks unless metrics.storage is set to ensure the monitoringstack is actually deployed. We should also be checking if metrics.resources is set since that will also deploy the monitoringstack.
- The message displayed only mentioned metrics, it is now more descriptive.

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Install operator.

- Install cluster observability operator, red hat build of opentelemetry and tempo operator from operatorhub.
- Create a default DSCI.
- Set monitoring to managementState: Managed.

_Verify rejection of alerting alone_
- Try to add `alerting: {}` to the monitoring stanza.
- Verify that it is rejected.

_Verify rejection when metrics is empty_
- Add `metrics: {}` to the monitoring stanza.
- Try to add `alerting: {}` to the monitoring stanza.
- Verify that it is rejected.

_Verify success when metrics is set_
- Add qstorage: { size: 5}q to the metrics stanza.
- Try to add `alerting: {}` to the monitoring stanza.
- Verify it is now added.

_Verify success when resources is set_
- Reset metrics in monitoring stanza to `metrics: {}`
- Add `resources: { }` to the metrics stanza.
- Try to add `alerting: {}` to the monitoring stanza.
- Verify it is now added.

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Alerting configuration now supports either metrics.storage or metrics.resources in Monitoring and DSCInitialization CRDs.

- Bug Fixes
  - Updated validation rules to accept metrics.resources when alerting is enabled, preventing unnecessary validation failures.
  - Improved error message to clearly state that either metrics.storage or metrics.resources must be configured.

- Documentation
  - Validation message text updated for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->