### PR TITLE
RHOAIENG-27732 | fix: Adding regresion test to test suite

### DIFF
--- a/tests/e2e/controller_test.go
+++ b/tests/e2e/controller_test.go
@@ -260,6 +260,9 @@ func TestOdhOperator(t *testing.T) {
 	mustRun(t, Components.String(), Components.Run)
 	mustRun(t, Services.String(), Services.Run)
 
+	// Run regression test suites
+	mustRun(t, "KServe Authorino Regression Tests", kserveAuthorinoTestSuite)
+
 	// Deletion logic based on deletionPolicy
 	switch testOpts.deletionPolicy {
 	case DeletionPolicyAlways:

--- a/tests/e2e/kserve_authorino_test.go
+++ b/tests/e2e/kserve_authorino_test.go
@@ -40,6 +40,38 @@ var authRelatedResources = []struct {
 	{gvk.AuthorizationPolicy, types.NamespacedName{Namespace: "istio-system", Name: "kserve-predictor"}},
 }
 
+func kserveAuthorinoTestSuite(t *testing.T) {
+	t.Helper()
+
+	ctx, err := NewTestContext(t)
+	require.NoError(t, err)
+
+	testCtx := KserveAuthorinoTestCtx{
+		TestContext: ctx,
+	}
+
+	// Setup cleanup function similar to cleanup_test.go
+	t.Cleanup(func() {
+		testCtx.CleanupTestResources(t)
+	})
+
+	testCases := []TestCase{
+		{"Cleanup existing resources", testCtx.CleanupTestResources},
+		{"Uninstall Authorino operator", testCtx.UninstallAuthorinoOperator},
+		{"Verify required operators are installed", testCtx.VerifyRequiredOperatorsInstalled},
+		{"Setup DSCI with ServiceMesh", testCtx.SetupDSCIWithServiceMesh},
+		{"Setup KServe with Serverless mode", testCtx.SetupKServeServerlessMode},
+		{"Verify Authorino is not installed", testCtx.VerifyAuthorinoNotInstalled},
+		{"Verify KServe is Ready", testCtx.VerifyKServeReady},
+		{"Validate auth resources are not created in Serverless mode", testCtx.ValidateAuthResourcesNotCreatedServerless},
+		{"Setup KServe with Raw deployment mode", testCtx.SetupKServeRawMode},
+		{"Verify KServe is Ready in Raw mode", testCtx.VerifyKServeReady},
+		{"Validate auth resources are not created in Raw mode", testCtx.ValidateAuthResourcesNotCreatedRaw},
+	}
+
+	RunTestCases(t, testCases)
+}
+
 // TestKserveAuthorinoRegression tests the regression scenario where auth-related resources
 // were created even when Authorino was not installed (RHOAI 2.19.0 issue).
 func TestKserveAuthorinoRegression(t *testing.T) {


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
Adding missing test to test suite

jira: https://issues.redhat.com/browse/RHOAIENG-27732

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Tests
  - Added an end-to-end regression test suite for KServe and Authorino integration, now included in operator E2E runs.
  - Covers install/uninstall flows, Service Mesh setup, serverless and raw deployment modes, readiness checks, and ensures authentication resources are not created when not expected.
  - Automates cleanup and resource verification to improve reliability and guard against regressions.
  - No user-facing behavior changes; this enhances test coverage and confidence in releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->