### PR TITLE
RHOAIENG-32984 | fix : notebook webhook deleting non-connection secrets from envFrom

### DIFF
--- a/internal/webhook/notebook/mutating.go
+++ b/internal/webhook/notebook/mutating.go
@@ -30,6 +30,11 @@ var (
 	NotebookContainersPath = []string{"spec", "template", "spec", "containers"}
 )
 
+const (
+	Create string = "create"
+	Delete string = "delete"
+)
+
 //+kubebuilder:webhook:path=/platform-connection-notebook,mutating=true,failurePolicy=fail,groups=kubeflow.org,resources=notebooks,verbs=create;update,versions=v1,name=connection-notebook.opendatahub.io,sideEffects=None,admissionReviewVersions=v1
 //nolint:lll
 
@@ -39,6 +44,11 @@ type NotebookWebhook struct {
 	APIReader client.Reader // used to read secrets in namespaces that are not cached
 	Decoder   admission.Decoder
 	Name      string
+}
+
+type NotebookSecretReference struct {
+	Secret corev1.SecretReference
+	Action string // create or delete, used to determine if the secret should be added or removed from the envFrom
 }
 
 // Assert that NotebookWebhook implements admission.Handler interface.
@@ -77,17 +87,18 @@ func (w *NotebookWebhook) Handle(ctx context.Context, req admission.Request) adm
 
 	switch req.Operation {
 	case admissionv1.Create, admissionv1.Update:
-		validationResp, shouldInject, secretRefs := w.validateNotebookConnectionAnnotation(ctx, notebook, &req)
+		validationResp, shouldInject, notebookSecretRefs := w.validateNotebookConnectionAnnotation(ctx, notebook, &req)
 		if !validationResp.Allowed {
 			return validationResp
 		}
 
 		// Skip proceeding to injection if shouldInject is false or the secretRefs nil
-		if !shouldInject || secretRefs == nil {
+		if !shouldInject || notebookSecretRefs == nil {
 			return admission.Allowed(fmt.Sprintf("Connection annotation validation passed in namespace %s for %s, no injection needed", req.Namespace, req.Kind.Kind))
 		}
 
-		injectionPerformed, obj, err := w.performConnectionInjection(notebook, secretRefs)
+		// Perform connection injection
+		injectionPerformed, obj, err := w.performConnectionInjection(notebook, notebookSecretRefs)
 		if err != nil {
 			log.Error(err, "Failed to perform connection injection")
 			return admission.Errored(http.StatusInternalServerError, err)
@@ -117,11 +128,11 @@ func (w *NotebookWebhook) validateNotebookConnectionAnnotation(
 	ctx context.Context,
 	nb *unstructured.Unstructured,
 	req *admission.Request,
-) (admission.Response, bool, []corev1.SecretReference) {
+) (admission.Response, bool, []NotebookSecretReference) {
 	log := logf.FromContext(ctx)
 
 	annotationValue := resources.GetAnnotation(nb, annotations.Connection)
-	if annotationValue == "" {
+	if req.Operation == admissionv1.Create && annotationValue == "" {
 		return admission.Allowed(fmt.Sprintf("Annotation '%s' not present or empty value, skipping validation", annotations.Connection)), false, nil
 	}
 
@@ -148,7 +159,42 @@ func (w *NotebookWebhook) validateNotebookConnectionAnnotation(
 		return admission.Denied(fmt.Sprintf("user does not have permission to access the following connection secret(s): %s", strings.Join(permissionsErrors, ", "))), false, nil
 	}
 
-	return admission.Allowed("Connection permissions validated successfully"), true, connectionSecrets
+	notebookSecretRefs, err := w.getNotebookSecretRefs(ctx, req, connectionSecrets)
+	if err != nil {
+		return admission.Errored(http.StatusInternalServerError, fmt.Errorf("failed to get notebook secret references: %w", err)), false, nil
+	}
+
+	return admission.Allowed("Connection permissions validated successfully"), true, notebookSecretRefs
+}
+
+func (w *NotebookWebhook) getNotebookSecretRefs(ctx context.Context, req *admission.Request, secretRefs []corev1.SecretReference) ([]NotebookSecretReference, error) {
+	var notebookSecretRefs []NotebookSecretReference
+
+	// Only UPDATE operation has old object and potential connection secrets that may need to be removed
+	if req.Operation == admissionv1.Update {
+		oldSecretRefs, err := w.getOldConnectionSecrets(ctx, req)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get old secret references: %w", err)
+		}
+
+		secretActions := determineSecretActions(oldSecretRefs, secretRefs)
+		// Append old secret refs to the new secret refs to handle the case where a secret is removed
+		secretRefs := append(secretRefs, oldSecretRefs...)
+		for _, secretRef := range secretRefs {
+			notebookSecretRefs = append(notebookSecretRefs, NotebookSecretReference{
+				Secret: secretRef,
+				Action: secretActions[secretRefKey(secretRef)],
+			})
+		}
+	} else {
+		for _, secretRef := range secretRefs {
+			notebookSecretRefs = append(notebookSecretRefs, NotebookSecretReference{
+				Secret: secretRef,
+				Action: Create,
+			})
+		}
+	}
+	return notebookSecretRefs, nil
 }
 
 // parseConnectionsAnnotation parses the connections annotation value into a list of secret references.
@@ -192,10 +238,26 @@ func parseConnectionsAnnotation(value string) ([]corev1.SecretReference, error) 
 // checkSecretsExistsAndUserHasPermissions checks that each connection secret exists
 // It also verifies that the user has permission to "get" the specified secrets using SubjectAccessReviews.
 func (w *NotebookWebhook) checkSecretsExistsAndUserHasPermissions(ctx context.Context, req *admission.Request, secretRefs []corev1.SecretReference) ([]string, []string, error) {
-	log := logf.FromContext(ctx)
-
 	var secretExistsErrors []string
 	var permissionErrors []string
+
+	// Check if the secret exists
+	secretExistsErrors, err := w.checkSecretExists(ctx, req, secretRefs)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to check secret exists: %w", err)
+	}
+
+	permissionErrors, err = w.checkUserHasPermission(ctx, req, secretRefs)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to check user has permission: %w", err)
+	}
+
+	return secretExistsErrors, permissionErrors, nil
+}
+
+func (w *NotebookWebhook) checkSecretExists(ctx context.Context, req *admission.Request, secretRefs []corev1.SecretReference) ([]string, error) {
+	log := logf.FromContext(ctx)
+	var secretExistsErrors []string
 
 	for _, secretRef := range secretRefs {
 		// First check if the secret is in the same namespace as the notebook
@@ -213,9 +275,19 @@ func (w *NotebookWebhook) checkSecretsExistsAndUserHasPermissions(ctx context.Co
 				continue
 			}
 			log.Error(err, "failed to check if secret exists", "secret", secretRef.Name, "namespace", secretRef.Namespace)
-			return nil, nil, fmt.Errorf("failed to check if secret exists: %w", err)
+			return nil, fmt.Errorf("failed to check if secret exists: %w", err)
 		}
+	}
 
+	return secretExistsErrors, nil
+}
+
+func (w *NotebookWebhook) checkUserHasPermission(ctx context.Context, req *admission.Request, secretRefs []corev1.SecretReference) ([]string, error) {
+	log := logf.FromContext(ctx)
+
+	var permissionErrors []string
+
+	for _, secretRef := range secretRefs {
 		// Create a SubjectAccessReview to check if the user can "get" the secret
 		log.V(1).Info("checking permission for secret", "secret", secretRef.Name, "namespace", secretRef.Namespace)
 		sar := &authorizationv1.SubjectAccessReview{
@@ -236,7 +308,7 @@ func (w *NotebookWebhook) checkSecretsExistsAndUserHasPermissions(ctx context.Co
 		// Send the SubjectAccessReview to the API server to verify permission
 		if err := w.Client.Create(ctx, sar); err != nil {
 			log.Error(err, "failed to create SubjectAccessReview", "secret", secretRef.Name, "namespace", secretRef.Namespace)
-			return nil, nil, fmt.Errorf("failed to create SubjectAccessReview: %w", err)
+			return nil, fmt.Errorf("failed to create SubjectAccessReview: %w", err)
 		}
 
 		// Check the result
@@ -253,10 +325,10 @@ func (w *NotebookWebhook) checkSecretsExistsAndUserHasPermissions(ctx context.Co
 		log.V(1).Info("user has permission to access secret", "secret", secretRef.Name, "namespace", secretRef.Namespace)
 	}
 
-	return secretExistsErrors, permissionErrors, nil
+	return permissionErrors, nil
 }
 
-func (w *NotebookWebhook) performConnectionInjection(nb *unstructured.Unstructured, secretRefs []corev1.SecretReference) (bool, *unstructured.Unstructured, error) {
+func (w *NotebookWebhook) performConnectionInjection(nb *unstructured.Unstructured, notebookSecretRefs []NotebookSecretReference) (bool, *unstructured.Unstructured, error) {
 	// Get the notebook containers
 	containers, found, err := unstructured.NestedSlice(nb.Object, NotebookContainersPath...)
 	if err != nil {
@@ -272,32 +344,11 @@ func (w *NotebookWebhook) performConnectionInjection(nb *unstructured.Unstructur
 		return false, nil, errors.New("first container is not a map[string]interface{}")
 	}
 
-	// Get existing envFrom from the container
 	existingEnvFrom, _ := container["envFrom"].([]interface{})
-
-	// Keep only non-secretRef entries (like configMapRef)
-	var preservedEntries []interface{}
-	for _, entry := range existingEnvFrom {
-		if entryMap, ok := entry.(map[string]interface{}); ok {
-			if _, hasSecretRef := entryMap["secretRef"]; !hasSecretRef {
-				preservedEntries = append(preservedEntries, entry)
-			}
-		}
+	for _, nbSecretRef := range notebookSecretRefs {
+		existingEnvFrom = handleConnectionSecret(nbSecretRef, existingEnvFrom)
 	}
-
-	// Add all connection secrets
-	newEnvFrom := preservedEntries
-	for _, secretRef := range secretRefs {
-		secretEntry := map[string]interface{}{
-			"secretRef": map[string]interface{}{
-				"name": secretRef.Name,
-			},
-		}
-		newEnvFrom = append(newEnvFrom, secretEntry)
-	}
-
-	// Set the updated envFrom back to the container
-	container["envFrom"] = newEnvFrom
+	container["envFrom"] = existingEnvFrom
 
 	// Update the first container in the containers array
 	containers[0] = container
@@ -308,4 +359,100 @@ func (w *NotebookWebhook) performConnectionInjection(nb *unstructured.Unstructur
 	}
 
 	return true, nb, nil
+}
+
+// determineSecretActions compares old and current secret references to determine
+// which secrets need to be created, updated, or deleted.
+func determineSecretActions(oldSecretRefs, currentSecretRefs []corev1.SecretReference) map[string]string {
+	actions := make(map[string]string)
+
+	// Create maps for easier lookup
+	oldSecretsMap := make(map[string]corev1.SecretReference)
+	currentSecretsMap := make(map[string]corev1.SecretReference)
+
+	// Populate old secrets map
+	for _, secretRef := range oldSecretRefs {
+		key := secretRefKey(secretRef)
+		oldSecretsMap[key] = secretRef
+	}
+
+	// Populate current secrets map and determine actions
+	for _, secretRef := range currentSecretRefs {
+		key := secretRefKey(secretRef)
+		currentSecretsMap[key] = secretRef
+
+		if _, existsInOld := oldSecretsMap[key]; !existsInOld {
+			// Secret is new - mark for creation
+			actions[key] = Create
+		}
+	}
+
+	// Check for secrets that were removed (exist in old but not in current)
+	for _, oldSecretRef := range oldSecretRefs {
+		key := secretRefKey(oldSecretRef)
+		if _, existsInCurrent := currentSecretsMap[key]; !existsInCurrent {
+			// Secret was removed - mark for deletion
+			actions[key] = Delete
+		}
+	}
+
+	return actions
+}
+
+// secretRefKey creates a unique key for a secret reference.
+func secretRefKey(secretRef corev1.SecretReference) string {
+	return fmt.Sprintf("%s/%s", secretRef.Namespace, secretRef.Name)
+}
+
+// handleConnectionSecret adds or removes a connection secret from the envFrom based on the secret action.
+func handleConnectionSecret(nbSecretRef NotebookSecretReference, existingEnvFrom []interface{}) []interface{} {
+	switch nbSecretRef.Action {
+	case Create:
+		secretEntry := map[string]interface{}{
+			"secretRef": map[string]interface{}{
+				"name": nbSecretRef.Secret.Name,
+			},
+		}
+		existingEnvFrom = append(existingEnvFrom, secretEntry)
+	case Delete:
+		for i, entry := range existingEnvFrom {
+			if entryMap, ok := entry.(map[string]interface{}); ok {
+				if secretRef, hasSecret := entryMap["secretRef"]; hasSecret {
+					if secretRefMap, ok := secretRef.(map[string]interface{}); ok {
+						if name, hasName := secretRefMap["name"]; hasName && name == nbSecretRef.Secret.Name {
+							existingEnvFrom = append(existingEnvFrom[:i], existingEnvFrom[i+1:]...)
+							break
+						}
+					}
+				}
+			}
+		}
+	}
+	return existingEnvFrom
+}
+
+// getOldSecretRefs extracts connection secret references from the old notebook object
+// for UPDATE operations to determine which secrets are being added/removed.
+func (w *NotebookWebhook) getOldConnectionSecrets(ctx context.Context, req *admission.Request) ([]corev1.SecretReference, error) {
+	log := logf.FromContext(ctx)
+	// Decode the old notebook object
+	oldNotebook := &unstructured.Unstructured{}
+	if err := w.Decoder.DecodeRaw(req.OldObject, oldNotebook); err != nil {
+		log.Error(err, "failed to decode old notebook object")
+		return nil, fmt.Errorf("failed to decode old notebook object: %w", err)
+	}
+
+	oldAnnotationValue := resources.GetAnnotation(oldNotebook, annotations.Connection)
+	if oldAnnotationValue == "" {
+		return []corev1.SecretReference{}, nil
+	}
+
+	oldSecretRefs, err := parseConnectionsAnnotation(oldAnnotationValue)
+	if err != nil {
+		log.Error(err, "failed to parse old secret references", "annotationValue", oldAnnotationValue)
+		return nil, fmt.Errorf("failed to parse old secret references: %w", err)
+	}
+
+	log.V(1).Info("Successfully parsed old secret references", "count", len(oldSecretRefs), "secretRefs", oldSecretRefs)
+	return oldSecretRefs, nil
 }


### PR DESCRIPTION
## Description
[RHOAIENG-32984](https://issues.redhat.com/browse/RHOAIENG-32984)

Fixed notebook webhook deleting non`opendatahub.io/connections` annotation secrets from envFrom when processing the connections annotation. Now we also remove any hanging connections secret in envFrom if the user removes them from annotation.

## How Has This Been Tested?


## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [] The developer has run the integration test pipeline and verified that it passed successfully
