### PR TITLE
fix: unsupported kind in HWProfile should still allow creation/update

### DIFF
--- a/internal/webhook/hardwareprofile/mutating_test.go
+++ b/internal/webhook/hardwareprofile/mutating_test.go
@@ -717,7 +717,7 @@ func TestHardwareProfile_ErrorPaths(t *testing.T) {
 			expectMessage: "webhook decoder not initialized",
 		},
 		{
-			name:     "unexpected kind",
+			name:     "unsupported kind is allowed without mutation",
 			injector: createWebhookInjector(fake.NewClientBuilder().WithScheme(sch).Build(), sch),
 			workload: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
@@ -725,8 +725,8 @@ func TestHardwareProfile_ErrorPaths(t *testing.T) {
 					Namespace: testNamespace,
 				},
 			},
-			expectAllowed: false,
-			expectMessage: "unexpected kind: Pod",
+			expectAllowed: true,
+			expectMessage: "Resource kind Pod not supported for hardware profile injection",
 		},
 		{
 			name:     "missing hardware profile namespace",


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->
i think in reality, webhook wont even get kicked in on a unsupported kind (e.g a pod)
but since we have iesExpectedKind() => do we really need this one? 
the creation / updates should be allowed, just we do not do any injection on that 

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Mutating webhook for hardware profiles no longer rejects unsupported resource kinds; such resources are now admitted without mutation and include an informational message instead of returning a 400 error.

* **Documentation**
  * Updated docs and tests to clarify that unsupported kinds are allowed (no injection) and emit an explanatory message.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->