### PR TITLE
Use custom manifests without devFlags

### DIFF
--- a/Dockerfiles/Dockerfile
+++ b/Dockerfiles/Dockerfile
@@ -62,6 +62,11 @@ FROM --platform=$TARGETPLATFORM registry.access.redhat.com/ubi9/ubi-minimal:late
 WORKDIR /
 COPY --from=builder /workspace/manager .
 COPY --chown=1001:0 --from=manifests /opt/manifests /opt/manifests
+
+# tar installed to allow easy use of "oc cp" for component dev use cases.
+# See hack/component-dev/README.md in the source repo for more info.
+RUN microdnf install -y tar && microdnf clean all
+
 # Recursive change all files
 RUN chown -R 1001:0 /opt/manifests &&\
     chmod -R g=u /opt/manifests

--- a/Dockerfiles/Dockerfile
+++ b/Dockerfiles/Dockerfile
@@ -68,8 +68,7 @@ COPY --chown=1001:0 --from=manifests /opt/manifests /opt/manifests
 RUN microdnf install -y tar && microdnf clean all
 
 # Recursive change all files
-RUN chown -R 1001:0 /opt/manifests &&\
-    chmod -R g=u /opt/manifests
+RUN chmod -R g=u /opt/manifests
 USER 1001
 
 ENTRYPOINT ["/manager"]

--- a/hack/component-dev/README.md
+++ b/hack/component-dev/README.md
@@ -1,0 +1,90 @@
+# Using custom manifests with OLM operator
+
+Use custom manifests for development with an ODH operator deployed by OLM, by mounting a volume and copying the manifests into it.
+
+## Not for production use
+
+This is a development convenience flow, and is not at all supported in any production setting.
+
+## Pre-requisites
+
+- [x] ODH operator deployed by OLM and running in the cluster
+- [x] Operator is in a "Succeeded" state in OLM
+
+## Steps
+
+### Create a PersistentVolumeClaim
+
+Note that the example PVC in `pvc.yaml` here is called `my-component-manifests`.
+Consider naming that for your component, and creating one for each component that you need custom manifests for.
+
+``` shell
+# namespace here should be wherever operator is deployed
+oc create -f pvc.yaml -n openshift-operators
+```
+
+### Patch ClusterServiceVersion
+
+This uses the PVC name, so if you've changed that, then change it in the patch file also.
+
+The example in the `component-dev-csv-patch.json` file mounts the volume to the dashboard manifests location at `/opt/manifests/dashboard`.
+Update as appropriate for your component.
+
+Note also that the CSV is a namespaced resource that is duplicated into every namespace for some reason, so you need to make sure that you specify the correct namespace for the operator here, so that it's patching the correct one:
+
+``` shell
+# Change to correct name and namespace for CSV
+CSV=$(oc get csv -n openshift-operators -o name | grep opendatahub-operator | head -n1 | cut -d/ -f2)
+oc patch csv "$CSV" -n openshift-operators --type json --patch-file csv-patch.json
+```
+
+### Wait for operator pod readiness
+
+Use appropriate label and namespace for ODH or RHOAI or whatever your version is:
+
+``` shell
+oc wait --for='jsonpath={.status.conditions[?(@.type=="Ready")].status}=True' po -l name=opendatahub-operator -n openshift-operators
+```
+
+### Copy manifests into volume, through pod
+
+From the relevant component repo (or wherever your custom manifests are stored), use `oc cp` to copy into the pod at the volume path.
+This is done in a loop in this dashboard example, since the same structure is desired in the manifests location in the container, so we don't want to have an extra "manifests" path part.
+
+``` bash
+oc cp manifests/. $(oc get po -l name=opendatahub-operator -n openshift-operators -o jsonpath="{.items[0].metadata.namespace}/{.items[0].metadata.name}"):/opt/manifests/dashboard
+```
+
+### Restart operator pod to pick up on new manifests
+
+``` shell
+oc rollout restart deploy -n openshift-operators -l name=opendatahub-operator
+```
+
+## Explanation of csv-patch.json
+
+The csv-patch.json is unfortunately not idempotent yet, the experience around this flow will hopefully improve over time.
+It patches the CSV, which will cause the operator Deployment to get updated appropriately.
+
+### Set replicas to 1
+
+This is needed because usually the PVC will be RWO, meaning that it can't be mounted to multiple pods.
+
+### Set "recreate" deployment strategy
+
+This is needed because usually the PVC will be RWO, meaning that it can't be mounted to multiple pods (and there would be multiple for a short period of time with the default rolling strategy).
+
+### Add an fsGroup to pod security context
+
+This is needed for the container user uid to be able to write to the volume (for `oc cp`)
+
+### Add volumeMount to container
+
+This specifies which volume to mount, and at which path.
+The "name" value here should match the name of the volume that's specified in the "volumes" section.
+The "mountPath" should be set to the location that the operator expects to read manifests for this component.
+
+### Add volume to pod template
+
+This is where the PVC name is specified for the Pod.
+The "name" here should match the "name" of the volume in the container's "volumeMount".

--- a/hack/component-dev/csv-patch.json
+++ b/hack/component-dev/csv-patch.json
@@ -1,0 +1,35 @@
+[
+  {
+    "op": "add",
+    "path": "/spec/install/spec/deployments/0/spec/replicas",
+    "value": 1
+  },
+  {
+    "op": "add",
+    "path": "/spec/install/spec/deployments/0/spec/strategy",
+    "value": { "type": "Recreate" }
+  },
+  {
+    "op": "add",
+    "path": "/spec/install/spec/deployments/0/spec/template/spec/securityContext/fsGroup",
+    "value": 1001
+  },
+  {
+    "op": "add",
+    "path": "/spec/install/spec/deployments/0/spec/template/spec/containers/0/volumeMounts/-",
+    "value": {
+      "name": "dashboard-manifests",
+      "mountPath": "/opt/manifests/dashboard"
+    }
+  },
+  {
+    "op": "add",
+    "path": "/spec/install/spec/deployments/0/spec/template/spec/volumes/-",
+    "value": {
+      "name": "dashboard-manifests",
+      "persistentVolumeClaim": {
+        "claimName": "my-component-manifests"
+      }
+    }
+  }
+]

--- a/hack/component-dev/pvc.yaml
+++ b/hack/component-dev/pvc.yaml
@@ -1,0 +1,11 @@
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: my-component-manifests
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+  volumeMode: Filesystem


### PR DESCRIPTION

<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->
Jira: https://issues.redhat.com/browse/RHOAIENG-31642

This gives instructions for an alternative approach to using custom manifests with the operator, which don't require the use of "devFlags" in the DSC.

The intention is that this will allow us to remove the devFlags functionality for 3.0.

This is a primitive approach for now. I expect that folks will start to build better development patterns rather than needing to modify the patch file for their component, etc. They can even have their own approaches in their own repositories, and this may just be an example.

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally, against both ODH and RHOAI in a cluster

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enable using custom component manifests via a PVC-based workflow with provided PVC and patch manifests.

* **Documentation**
  * Added a step-by-step guide for developing with custom manifests on an OLM-deployed operator, including prerequisites, patching, copying manifests, and restart steps.

* **Chores**
  * Runtime image now includes tar to support oc cp and cleans package cache.
  * Adjusted permissions handling for the operator manifests directory (separate chmod step).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->