### PR TITLE
fix: HWProfile webhook on wrong path for ISVC

### DIFF
--- a/internal/webhook/envtestutil/envtestutil.go
+++ b/internal/webhook/envtestutil/envtestutil.go
@@ -401,14 +401,13 @@ func NewInferenceService(name, namespace string, opts ...ObjectOption) client.Ob
 	inferenceService.SetNamespace(namespace)
 
 	// Set basic spec structure needed for webhook testing
-	containers := []interface{}{
-		map[string]interface{}{
-			"name":  "kserve-container",
-			"image": "kserve/model-server:latest",
-		},
+	// Create a model object instead of containers for isvc
+	model := map[string]interface{}{
+		"name":  "isvc-model",
+		"image": "kserve/model-server:latest",
 	}
-	if err := unstructured.SetNestedSlice(inferenceService.Object, containers, "spec", "predictor", "podSpec", "containers"); err != nil {
-		panic(fmt.Sprintf("failed to set inference service containers: %v", err))
+	if err := unstructured.SetNestedMap(inferenceService.Object, model, "spec", "predictor", "model"); err != nil {
+		panic(fmt.Sprintf("failed to set inferenceservice .spec.predictor.model: %v", err))
 	}
 
 	for _, opt := range opts {

--- a/internal/webhook/hardwareprofile/mutating.go
+++ b/internal/webhook/hardwareprofile/mutating.go
@@ -51,9 +51,9 @@ var WorkloadConfigs = map[string]WorkloadConfig{
 		TolerationsPath:  []string{"spec", "template", "spec", "tolerations"},
 	},
 	gvk.InferenceServices.Kind: {
-		ContainersPath:   []string{"spec", "predictor", "podSpec", "containers"},
-		NodeSelectorPath: []string{"spec", "predictor", "podSpec", "nodeSelector"},
-		TolerationsPath:  []string{"spec", "predictor", "podSpec", "tolerations"},
+		ContainersPath:   []string{"spec", "predictor", "model"},
+		NodeSelectorPath: []string{"spec", "predictor", "nodeSelector"},
+		TolerationsPath:  []string{"spec", "predictor", "tolerations"},
 	},
 }
 
@@ -385,9 +385,44 @@ func (i *Injector) applyResourceRequirementsToWorkload(obj *unstructured.Unstruc
 	if err != nil {
 		return err
 	}
+	// Handle different workload types explicitly
+	switch obj.GetKind() {
+	case gvk.InferenceServices.Kind:
+		// For InferenceServices, apply resources to the model object
+		return i.applyResourceRequirementsToInferenceServiceModel(obj, hwp, config.ContainersPath)
+	case gvk.Notebook.Kind:
+		// For Notebooks, apply resources to containers
+		return i.applyResourceRequirementsToContainers(obj, hwp, config.ContainersPath)
+	default: // TODO: add llmisvc
+		// For any other workload types, apply resources to containers as default behavior
+		return i.applyResourceRequirementsToContainers(obj, hwp, config.ContainersPath)
+	}
+}
 
+// for isvc.
+func (i *Injector) applyResourceRequirementsToInferenceServiceModel(obj *unstructured.Unstructured, hwp *hwpv1alpha1.HardwareProfile, modelPath []string) error {
+	// Get the model object from the InferenceService
+	model, found, err := unstructured.NestedMap(obj.Object, modelPath...)
+	if err != nil {
+		return fmt.Errorf("failed to get model: %w", err)
+	}
+	if !found {
+		return nil // No model found
+	}
+
+	// Apply resource requirements to the model object
+	if err := i.applyIdentifiersToContainer(model, hwp.Spec.Identifiers); err != nil {
+		return fmt.Errorf("failed to apply resources to model: %w", err)
+	}
+
+	// Update the object with modified model
+	return unstructured.SetNestedMap(obj.Object, model, modelPath...)
+}
+
+// for notebooks.
+func (i *Injector) applyResourceRequirementsToContainers(obj *unstructured.Unstructured, hwp *hwpv1alpha1.HardwareProfile, containersPath []string) error {
 	// Get containers from the workload
-	containers, found, err := unstructured.NestedSlice(obj.Object, config.ContainersPath...)
+	containers, found, err := unstructured.NestedSlice(obj.Object, containersPath...)
 	if err != nil {
 		return fmt.Errorf("failed to get containers: %w", err)
 	}
@@ -403,7 +438,7 @@ func (i *Injector) applyResourceRequirementsToWorkload(obj *unstructured.Unstruc
 	}
 
 	// Update the object with modified containers
-	return unstructured.SetNestedSlice(obj.Object, containers, config.ContainersPath...)
+	return unstructured.SetNestedSlice(obj.Object, containers, containersPath...)
 }
 
 // applyIdentifiersToContainer applies resource requirements to a single container.
@@ -434,18 +469,37 @@ func (i *Injector) applyIdentifiersToContainer(container interface{}, identifier
 		return err
 	}
 
-	// Apply hardware profile resource requirements only for identifiers that don't already exist
-	if err := i.applyIdentifiersToRequests(requests, identifiers); err != nil {
+	// For requests - always applies DefaultCount
+	if err := i.applyIdentifiersToRequests(requests, identifiers, func(id hwpv1alpha1.HardwareIdentifier) (intstr.IntOrString, bool) {
+		return id.DefaultCount, true
+	}); err != nil {
 		return err
 	}
 
-	// Update container with modified resources
+	// Get or create limits section
+	limits, err := webhookutils.GetOrCreateNestedMap(resourcesMap, "limits")
+	if err != nil {
+		return err
+	}
+
+	// For limits - only applies MaxCount if it exists in HWProfile
+	if err := i.applyIdentifiersToRequests(limits, identifiers, func(id hwpv1alpha1.HardwareIdentifier) (intstr.IntOrString, bool) {
+		if id.MaxCount == nil {
+			return intstr.IntOrString{}, false
+		}
+		return *id.MaxCount, true
+	}); err != nil {
+		return err
+	}
+
+	// Update modified resources
 	resourcesMap["requests"] = requests
+	resourcesMap["limits"] = limits
 	containerMap["resources"] = resourcesMap
 	return nil
 }
 
-// applyIdentifiersToRequests applies hardware identifiers to a container's resource requests map.
+// applyIdentifiersToRequests applies hardware identifiers to resource requests map.
 // This method implements the core logic for selectively adding resource requirements
 // while preserving existing specifications.
 //
@@ -461,14 +515,21 @@ func (i *Injector) applyIdentifiersToContainer(container interface{}, identifier
 //
 // Returns:
 //   - error: Any error encountered during identifier application or quantity conversion
-func (i *Injector) applyIdentifiersToRequests(requests map[string]interface{}, identifiers []hwpv1alpha1.HardwareIdentifier) error {
+func (i *Injector) applyIdentifiersToRequests(
+	requests map[string]interface{},
+	identifiers []hwpv1alpha1.HardwareIdentifier,
+	valueExtractor func(hwpv1alpha1.HardwareIdentifier) (intstr.IntOrString, bool),
+) error {
 	for _, identifier := range identifiers {
 		// Skip if the resource identifier already exists
 		if _, exists := requests[identifier.Identifier]; exists {
 			continue
 		}
-
-		quantity, err := convertIntOrStringToQuantity(identifier.DefaultCount)
+		value, shouldApply := valueExtractor(identifier)
+		if !shouldApply {
+			continue
+		}
+		quantity, err := convertIntOrStringToQuantity(value)
 		if err != nil {
 			return fmt.Errorf("failed to convert resource quantity for %s: %w", identifier.Identifier, err)
 		}

--- a/internal/webhook/hardwareprofile/mutating_test.go
+++ b/internal/webhook/hardwareprofile/mutating_test.go
@@ -58,37 +58,9 @@ func createWebhookInjector(cli client.Client, sch *runtime.Scheme) *hardwareprof
 
 // Helper functions for test simplification.
 
-// WorkloadTestConfig holds configuration for testing different workload types.
-type WorkloadTestConfig struct {
-	CreateWorkload func(name, namespace string, options ...envtestutil.ObjectOption) client.Object
-	ContainersPath []string
-	GVK            schema.GroupVersionKind
-	ResourceName   string
-}
-
-// getNotebookConfig returns test configuration for Notebook workloads.
-func getNotebookConfig() WorkloadTestConfig {
-	return WorkloadTestConfig{
-		CreateWorkload: envtestutil.NewNotebook,
-		ContainersPath: []string{"spec", "template", "spec", "containers"},
-		GVK:            gvk.Notebook,
-		ResourceName:   "notebooks",
-	}
-}
-
-// getInferenceServiceConfig returns test configuration for InferenceService workloads.
-func getInferenceServiceConfig() WorkloadTestConfig {
-	return WorkloadTestConfig{
-		CreateWorkload: envtestutil.NewInferenceService,
-		ContainersPath: []string{"spec", "predictor", "podSpec", "containers"},
-		GVK:            gvk.InferenceServices,
-		ResourceName:   "inferenceservices",
-	}
-}
-
-// setContainerResourcesForWorkload sets container resources for any workload type using the provided container path.
-func setContainerResourcesForWorkload(workload *unstructured.Unstructured, containersPath []string, resourceType, resourceKey, value string) {
-	containers, _, err := unstructured.NestedSlice(workload.Object, containersPath...)
+// setContainerResources sets container resources for notebook workloads.
+func setContainerResources(notebook *unstructured.Unstructured, resourceType, resourceKey, value string) {
+	containers, _, err := unstructured.NestedSlice(notebook.Object, "spec", "template", "spec", "containers")
 	if err != nil {
 		return
 	}
@@ -104,17 +76,7 @@ func setContainerResourcesForWorkload(workload *unstructured.Unstructured, conta
 			resourceKey: value,
 		},
 	}
-	_ = unstructured.SetNestedSlice(workload.Object, containers, containersPath...)
-}
-
-// setMultipleContainersForWorkload sets multiple containers for any workload type using the provided container path.
-func setMultipleContainersForWorkload(workload *unstructured.Unstructured, containersPath []string, containers []interface{}) {
-	_ = unstructured.SetNestedSlice(workload.Object, containers, containersPath...)
-}
-
-// setContainerResources is kept for backward compatibility with existing notebook tests.
-func setContainerResources(notebook *unstructured.Unstructured, resourceType, resourceKey, value string) {
-	setContainerResourcesForWorkload(notebook, []string{"spec", "template", "spec", "containers"}, resourceType, resourceKey, value)
+	_ = unstructured.SetNestedSlice(notebook.Object, containers, "spec", "template", "spec", "containers")
 }
 
 func hasResourcePatches(patches []jsonpatch.JsonPatchOperation) bool {
@@ -237,177 +199,268 @@ func TestHardwareProfile_DeniesWhenProfileNotFound(t *testing.T) {
 	g.Expect(resp.Result.Message).Should(ContainSubstring("failed to get hardware profile 'nonexistent'"))
 }
 
-// TestHardwareProfile_ResourceInjection tests that hardware profiles with resource requirements are applied correctly to both Notebook and InferenceService workloads.
-func TestHardwareProfile_ResourceInjection(t *testing.T) {
+// TestHardwareProfile_ResourceInjection_Notebook tests that hardware profiles with resource requirements are applied correctly to Notebook workloads.
+func TestHardwareProfile_ResourceInjection_Notebook(t *testing.T) {
 	t.Parallel()
 	g := NewWithT(t)
 	sch, ctx := setupTestEnvironment(t)
 
-	// Create hardware profile with CPU and memory identifiers
+	// Create hardware profile with CPU and memory identifiers (including limits)
 	hwp := envtestutil.NewHardwareProfile(testHardwareProfile, testNamespace,
-		envtestutil.WithCPUIdentifier("0", "4"),
-		envtestutil.WithMemoryIdentifier("0", "8Gi"),
+		envtestutil.WithCPUIdentifier("0", "4", "8"),         // min: 0, default: 4, max: 8
+		envtestutil.WithMemoryIdentifier("0", "8Gi", "16Gi"), // min: 0, default: 8Gi, max: 16Gi
 	)
 
 	cli := fake.NewClientBuilder().WithScheme(sch).WithObjects(hwp).Build()
 	injector := createWebhookInjector(cli, sch)
 
-	workloadConfigs := []WorkloadTestConfig{
-		getNotebookConfig(),
-		getInferenceServiceConfig(),
-	}
+	testCases := []struct {
+		name                string
+		setupWorkload       func() *unstructured.Unstructured
+		expectResourcePatch bool
+	}{
+		{
+			name: "applies resources when none exist",
+			setupWorkload: func() *unstructured.Unstructured {
+				workload := envtestutil.NewNotebook(testNotebook, testNamespace, envtestutil.WithHardwareProfile(testHardwareProfile))
+				workloadUnstructured, ok := workload.(*unstructured.Unstructured)
+				if !ok {
+					return nil
+				}
+				return workloadUnstructured
+			},
+			expectResourcePatch: true,
+		},
+		{
+			name: "preserves existing resources",
+			setupWorkload: func() *unstructured.Unstructured {
+				workload, ok := envtestutil.NewNotebook(testNotebook, testNamespace, envtestutil.WithHardwareProfile(testHardwareProfile)).(*unstructured.Unstructured)
+				g.Expect(ok).Should(BeTrue(), "workload should be unstructured")
 
-	for _, config := range workloadConfigs {
-		t.Run(config.ResourceName, func(t *testing.T) {
-			t.Parallel()
-
-			testCases := []struct {
-				name                string
-				setupWorkload       func() *unstructured.Unstructured
-				expectResourcePatch bool
-			}{
-				{
-					name: "applies resources when none exist",
-					setupWorkload: func() *unstructured.Unstructured {
-						workload := config.CreateWorkload(testNotebook, testNamespace, envtestutil.WithHardwareProfile(testHardwareProfile))
-						workloadUnstructured, ok := workload.(*unstructured.Unstructured)
-						if !ok {
-							return nil
-						}
-						return workloadUnstructured
+				// Set existing resources that should be preserved
+				containers, _, _ := unstructured.NestedSlice(workload.Object, "spec", "template", "spec", "containers")
+				containerMap, ok := containers[0].(map[string]interface{})
+				g.Expect(ok).Should(BeTrue(), "container should be a map")
+				containerMap["resources"] = map[string]interface{}{
+					"requests": map[string]interface{}{
+						"cpu":    "2",
+						"memory": "4Gi",
 					},
-					expectResourcePatch: true,
-				},
-				{
-					name: "preserves existing resources",
-					setupWorkload: func() *unstructured.Unstructured {
-						workload, ok := config.CreateWorkload(testNotebook, testNamespace, envtestutil.WithHardwareProfile(testHardwareProfile)).(*unstructured.Unstructured)
-						g.Expect(ok).Should(BeTrue(), "workload should be unstructured")
-
-						// Set existing resources that should be preserved
-						containers, _, _ := unstructured.NestedSlice(workload.Object, config.ContainersPath...)
-						containerMap, ok := containers[0].(map[string]interface{})
-						g.Expect(ok).Should(BeTrue(), "container should be a map")
-						containerMap["resources"] = map[string]interface{}{
-							"requests": map[string]interface{}{
-								"cpu":    "2",
-								"memory": "4Gi",
-							},
-							"limits": map[string]interface{}{
-								"cpu":    "4",
-								"memory": "8Gi",
-							},
-						}
-						_ = unstructured.SetNestedSlice(workload.Object, containers, config.ContainersPath...)
-						return workload
+					"limits": map[string]interface{}{
+						"cpu":    "4",
+						"memory": "8Gi",
 					},
-					expectResourcePatch: false,
-				},
-				{
-					name: "applies only missing resources when single container has partial resources",
-					setupWorkload: func() *unstructured.Unstructured {
-						workload, ok := config.CreateWorkload(testNotebook, testNamespace, envtestutil.WithHardwareProfile(testHardwareProfile)).(*unstructured.Unstructured)
-						g.Expect(ok).Should(BeTrue(), "workload should be unstructured")
+				}
+				_ = unstructured.SetNestedSlice(workload.Object, containers, "spec", "template", "spec", "containers")
+				return workload
+			},
+			expectResourcePatch: false,
+		},
+		{
+			name: "applies only missing resources when single container has partial resources",
+			setupWorkload: func() *unstructured.Unstructured {
+				workload, ok := envtestutil.NewNotebook(testNotebook, testNamespace, envtestutil.WithHardwareProfile(testHardwareProfile)).(*unstructured.Unstructured)
+				g.Expect(ok).Should(BeTrue(), "workload should be unstructured")
 
-						// Set only CPU request, memory should be applied from HWP
-						containers, _, _ := unstructured.NestedSlice(workload.Object, config.ContainersPath...)
-						containerMap, ok := containers[0].(map[string]interface{})
-						g.Expect(ok).Should(BeTrue(), "container should be a map")
-						containerMap["resources"] = map[string]interface{}{
+				// Set only CPU request, memory should be applied from HWP
+				containers, _, _ := unstructured.NestedSlice(workload.Object, "spec", "template", "spec", "containers")
+				containerMap, ok := containers[0].(map[string]interface{})
+				g.Expect(ok).Should(BeTrue(), "container should be a map")
+				containerMap["resources"] = map[string]interface{}{
+					"requests": map[string]interface{}{
+						"cpu": "1",
+					},
+				}
+				_ = unstructured.SetNestedSlice(workload.Object, containers, "spec", "template", "spec", "containers")
+				return workload
+			},
+			expectResourcePatch: true,
+		},
+		{
+			name: "applies resources to containers without them when multiple containers exist",
+			setupWorkload: func() *unstructured.Unstructured {
+				workload, ok := envtestutil.NewNotebook(testNotebook, testNamespace, envtestutil.WithHardwareProfile(testHardwareProfile)).(*unstructured.Unstructured)
+				g.Expect(ok).Should(BeTrue(), "workload should be unstructured")
+
+				// For Notebooks, create two containers - first has CPU, second has memory, both should get missing resources
+				containers := []interface{}{
+					map[string]interface{}{
+						"name":  "main-container",
+						"image": "notebook:latest",
+						"resources": map[string]interface{}{
 							"requests": map[string]interface{}{
 								"cpu": "1",
+								// Missing memory - should get HWP memory
 							},
-						}
-						_ = unstructured.SetNestedSlice(workload.Object, containers, config.ContainersPath...)
-						return workload
-					},
-					expectResourcePatch: true,
-				},
-				{
-					name: "applies resources to containers without them when multiple containers exist",
-					setupWorkload: func() *unstructured.Unstructured {
-						workload, ok := config.CreateWorkload(testNotebook, testNamespace, envtestutil.WithHardwareProfile(testHardwareProfile)).(*unstructured.Unstructured)
-						g.Expect(ok).Should(BeTrue(), "workload should be unstructured")
-
-						// Create two containers - first has CPU, second has memory, both should get missing resources
-						var containers []interface{}
-						if config.GVK.Kind == gvk.Notebook.Kind {
-							containers = []interface{}{
-								map[string]interface{}{
-									"name":  "main-container",
-									"image": "notebook:latest",
-									"resources": map[string]interface{}{
-										"requests": map[string]interface{}{
-											"cpu": "1",
-											// Missing memory - should get HWP memory
-										},
-									},
-								},
-								map[string]interface{}{
-									"name":  "sidecar-container",
-									"image": "sidecar:latest",
-									"resources": map[string]interface{}{
-										"requests": map[string]interface{}{
-											"memory": "2Gi",
-											// Missing CPU - should get HWP CPU
-										},
-									},
-								},
-							}
-						} else {
-							containers = []interface{}{
-								map[string]interface{}{
-									"name":  "main-container",
-									"image": "tensorflow/serving:latest",
-									"resources": map[string]interface{}{
-										"requests": map[string]interface{}{
-											"cpu": "1",
-											// Missing memory - should get HWP memory
-										},
-									},
-								},
-								map[string]interface{}{
-									"name":  "sidecar-container",
-									"image": "istio/proxyv2:latest",
-									"resources": map[string]interface{}{
-										"requests": map[string]interface{}{
-											"memory": "2Gi",
-											// Missing CPU - should get HWP CPU
-										},
-									},
-								},
-							}
-						}
-						setMultipleContainersForWorkload(workload, config.ContainersPath, containers)
-						return workload
-					},
-					expectResourcePatch: true,
-				},
-			}
-
-			for _, tc := range testCases {
-				t.Run(tc.name, func(t *testing.T) {
-					t.Parallel()
-
-					workload := tc.setupWorkload()
-
-					req := envtestutil.NewAdmissionRequest(
-						t,
-						admissionv1.Create,
-						workload,
-						config.GVK,
-						metav1.GroupVersionResource{
-							Group:    config.GVK.Group,
-							Version:  config.GVK.Version,
-							Resource: config.ResourceName,
 						},
-					)
+					},
+					map[string]interface{}{
+						"name":  "sidecar-container",
+						"image": "sidecar:latest",
+						"resources": map[string]interface{}{
+							"requests": map[string]interface{}{
+								"memory": "2Gi",
+								// Missing CPU - should get HWP CPU
+							},
+						},
+					},
+				}
+				_ = unstructured.SetNestedSlice(workload.Object, containers, "spec", "template", "spec", "containers")
+				return workload
+			},
+			expectResourcePatch: true,
+		},
+	}
 
-					resp := injector.Handle(ctx, req)
-					g.Expect(resp.Allowed).Should(BeTrue())
-					g.Expect(hasResourcePatches(resp.Patches)).Should(Equal(tc.expectResourcePatch))
-				})
-			}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			workload := tc.setupWorkload()
+
+			req := envtestutil.NewAdmissionRequest(
+				t,
+				admissionv1.Create,
+				workload,
+				gvk.Notebook,
+				metav1.GroupVersionResource{
+					Group:    gvk.Notebook.Group,
+					Version:  gvk.Notebook.Version,
+					Resource: "notebooks",
+				},
+			)
+
+			resp := injector.Handle(ctx, req)
+			g.Expect(resp.Allowed).Should(BeTrue())
+			g.Expect(hasResourcePatches(resp.Patches)).Should(Equal(tc.expectResourcePatch))
+		})
+	}
+}
+
+// TestHardwareProfile_ResourceInjection_InferenceService tests that hardware profiles with resource requirements are applied correctly to InferenceService workloads.
+func TestHardwareProfile_ResourceInjection_InferenceService(t *testing.T) {
+	t.Parallel()
+	g := NewWithT(t)
+	sch, ctx := setupTestEnvironment(t)
+
+	// Create hardware profile with CPU and memory identifiers (including limits)
+	hwp := envtestutil.NewHardwareProfile(testHardwareProfile, testNamespace,
+		envtestutil.WithCPUIdentifier("0", "4", "8"),         // min: 0, default: 4, max: 8
+		envtestutil.WithMemoryIdentifier("0", "8Gi", "16Gi"), // min: 0, default: 8Gi, max: 16Gi
+	)
+
+	cli := fake.NewClientBuilder().WithScheme(sch).WithObjects(hwp).Build()
+	injector := createWebhookInjector(cli, sch)
+
+	testCases := []struct {
+		name                string
+		setupWorkload       func() *unstructured.Unstructured
+		expectResourcePatch bool
+	}{
+		{
+			name: "applies resources when none exist",
+			setupWorkload: func() *unstructured.Unstructured {
+				workload := envtestutil.NewInferenceService(testInferenceService, testNamespace, envtestutil.WithHardwareProfile(testHardwareProfile))
+				workloadUnstructured, ok := workload.(*unstructured.Unstructured)
+				if !ok {
+					return nil
+				}
+				return workloadUnstructured
+			},
+			expectResourcePatch: true,
+		},
+		{
+			name: "preserves existing resources",
+			setupWorkload: func() *unstructured.Unstructured {
+				workload, ok := envtestutil.NewInferenceService(testInferenceService, testNamespace, envtestutil.WithHardwareProfile(testHardwareProfile)).(*unstructured.Unstructured)
+				g.Expect(ok).Should(BeTrue(), "workload should be unstructured")
+
+				// Set existing resources that should be preserved
+				model, _, _ := unstructured.NestedMap(workload.Object, "spec", "predictor", "model")
+				if model == nil {
+					model = make(map[string]interface{})
+				}
+				model["resources"] = map[string]interface{}{
+					"requests": map[string]interface{}{
+						"cpu":    "2",
+						"memory": "4Gi",
+					},
+					"limits": map[string]interface{}{
+						"cpu":    "4",
+						"memory": "8Gi",
+					},
+				}
+				_ = unstructured.SetNestedMap(workload.Object, model, "spec", "predictor", "model")
+				return workload
+			},
+			expectResourcePatch: false,
+		},
+		{
+			name: "applies only missing resources when model has partial resources",
+			setupWorkload: func() *unstructured.Unstructured {
+				workload, ok := envtestutil.NewInferenceService(testInferenceService, testNamespace, envtestutil.WithHardwareProfile(testHardwareProfile)).(*unstructured.Unstructured)
+				g.Expect(ok).Should(BeTrue(), "workload should be unstructured")
+
+				// Set only CPU request, memory should be applied from HWP
+				model, _, _ := unstructured.NestedMap(workload.Object, "spec", "predictor", "model")
+				if model == nil {
+					model = make(map[string]interface{})
+				}
+				model["resources"] = map[string]interface{}{
+					"requests": map[string]interface{}{
+						"cpu": "1",
+					},
+				}
+				_ = unstructured.SetNestedMap(workload.Object, model, "spec", "predictor", "model")
+				return workload
+			},
+			expectResourcePatch: true,
+		},
+		{
+			name: "applies resources to model without them",
+			setupWorkload: func() *unstructured.Unstructured {
+				workload, ok := envtestutil.NewInferenceService(testInferenceService, testNamespace, envtestutil.WithHardwareProfile(testHardwareProfile)).(*unstructured.Unstructured)
+				g.Expect(ok).Should(BeTrue(), "workload should be unstructured")
+
+				// For InferenceServices, work with the model object - set partial resources
+				model := map[string]interface{}{
+					"name":  "test-model",
+					"image": "tensorflow/serving:latest",
+					"resources": map[string]interface{}{
+						"requests": map[string]interface{}{
+							"cpu": "1",
+							// Missing memory - should get HWP memory
+						},
+					},
+				}
+				_ = unstructured.SetNestedMap(workload.Object, model, "spec", "predictor", "model")
+				return workload
+			},
+			expectResourcePatch: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			workload := tc.setupWorkload()
+
+			req := envtestutil.NewAdmissionRequest(
+				t,
+				admissionv1.Create,
+				workload,
+				gvk.InferenceServices,
+				metav1.GroupVersionResource{
+					Group:    gvk.InferenceServices.Group,
+					Version:  gvk.InferenceServices.Version,
+					Resource: "inferenceservices",
+				},
+			)
+
+			resp := injector.Handle(ctx, req)
+			g.Expect(resp.Allowed).Should(BeTrue())
+			g.Expect(hasResourcePatches(resp.Patches)).Should(Equal(tc.expectResourcePatch))
 		})
 	}
 }
@@ -478,121 +531,179 @@ func TestHardwareProfile_SetsNamespaceAnnotation(t *testing.T) {
 	g.Expect(resp.Patches).Should(Not(BeEmpty()))
 }
 
-// TestHardwareProfile_SchedulingConfiguration tests that hardware profiles with different
-// scheduling configurations are applied correctly to both Notebook and InferenceService workloads.
-func TestHardwareProfile_SchedulingConfiguration(t *testing.T) {
+// TestHardwareProfile_SchedulingConfiguration_Notebook tests that hardware profiles with different
+// scheduling configurations are applied correctly to Notebook workloads.
+func TestHardwareProfile_SchedulingConfiguration_Notebook(t *testing.T) {
 	t.Parallel()
 	g := NewWithT(t)
 	sch, ctx := setupTestEnvironment(t)
 
-	workloadConfigs := []WorkloadTestConfig{
-		getNotebookConfig(),
-		getInferenceServiceConfig(),
+	testCases := []struct {
+		name          string
+		hwpOptions    []envtestutil.ObjectOption
+		setupWorkload func() *unstructured.Unstructured
+		expectPatches bool
+	}{
+		{
+			name: "applies node scheduling to clean workload",
+			hwpOptions: []envtestutil.ObjectOption{
+				envtestutil.WithCPUIdentifier("2", "2"),
+				envtestutil.WithNodeScheduling(
+					map[string]string{"node-type": "gpu-node"},
+					[]corev1.Toleration{{
+						Key:      "nvidia.com/gpu",
+						Operator: corev1.TolerationOpEqual,
+						Value:    "true",
+						Effect:   corev1.TaintEffectNoSchedule,
+					}},
+				),
+			},
+			setupWorkload: func() *unstructured.Unstructured {
+				workload, ok := envtestutil.NewNotebook(testNotebook, testNamespace, envtestutil.WithHardwareProfile(testHardwareProfile)).(*unstructured.Unstructured)
+				g.Expect(ok).Should(BeTrue(), "workload should be unstructured")
+				return workload
+			},
+			expectPatches: true,
+		},
+		{
+			name: "applies kueue scheduling to clean workload",
+			hwpOptions: []envtestutil.ObjectOption{
+				envtestutil.WithMemoryIdentifier("4Gi", "4Gi"),
+				envtestutil.WithKueueScheduling(testQueue, "high-priority"),
+			},
+			setupWorkload: func() *unstructured.Unstructured {
+				workload, ok := envtestutil.NewNotebook(testNotebook, testNamespace, envtestutil.WithHardwareProfile(testHardwareProfile)).(*unstructured.Unstructured)
+				g.Expect(ok).Should(BeTrue(), "workload should be unstructured")
+				return workload
+			},
+			expectPatches: true,
+		},
+		{
+			name: "applies kueue scheduling even when resources exist",
+			hwpOptions: []envtestutil.ObjectOption{
+				envtestutil.WithCPUIdentifier("4", "4"),
+				envtestutil.WithKueueScheduling(testQueue),
+			},
+			setupWorkload: func() *unstructured.Unstructured {
+				workload, ok := envtestutil.NewNotebook(testNotebook, testNamespace, envtestutil.WithHardwareProfile(testHardwareProfile)).(*unstructured.Unstructured)
+				g.Expect(ok).Should(BeTrue(), "workload should be unstructured")
+				// Add existing CPU requests (this should prevent resource injection but allow scheduling)
+				setContainerResources(workload, "requests", "cpu", "2")
+				return workload
+			},
+			expectPatches: true,
+		},
 	}
 
-	for _, config := range workloadConfigs {
-		t.Run(config.ResourceName, func(t *testing.T) {
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			testCases := []struct {
-				name          string
-				hwpOptions    []envtestutil.ObjectOption
-				setupWorkload func() *unstructured.Unstructured
-				expectPatches bool
-			}{
-				{
-					name: "applies node scheduling to clean workload",
-					hwpOptions: []envtestutil.ObjectOption{
-						envtestutil.WithCPUIdentifier("2", "2"),
-						envtestutil.WithNodeScheduling(
-							map[string]string{"node-type": "gpu-node"},
-							[]corev1.Toleration{{
-								Key:      "nvidia.com/gpu",
-								Operator: corev1.TolerationOpEqual,
-								Value:    "true",
-								Effect:   corev1.TaintEffectNoSchedule,
-							}},
-						),
-					},
-					setupWorkload: func() *unstructured.Unstructured {
-						workload, ok := config.CreateWorkload(testNotebook, testNamespace, envtestutil.WithHardwareProfile(testHardwareProfile)).(*unstructured.Unstructured)
-						g.Expect(ok).Should(BeTrue(), "workload should be unstructured")
-						return workload
-					},
-					expectPatches: true,
+			hwp := envtestutil.NewHardwareProfile(testHardwareProfile, testNamespace, tc.hwpOptions...)
+			cli := fake.NewClientBuilder().WithScheme(sch).WithObjects(hwp).Build()
+			injector := createWebhookInjector(cli, sch)
+
+			workload := tc.setupWorkload()
+
+			req := envtestutil.NewAdmissionRequest(
+				t,
+				admissionv1.Create,
+				workload,
+				gvk.Notebook,
+				metav1.GroupVersionResource{
+					Group:    gvk.Notebook.Group,
+					Version:  gvk.Notebook.Version,
+					Resource: "notebooks",
 				},
-				{
-					name: "applies kueue scheduling to clean workload",
-					hwpOptions: []envtestutil.ObjectOption{
-						envtestutil.WithMemoryIdentifier("4Gi", "4Gi"),
-						envtestutil.WithKueueScheduling(testQueue, "high-priority"),
-					},
-					setupWorkload: func() *unstructured.Unstructured {
-						workload, ok := config.CreateWorkload(testNotebook, testNamespace, envtestutil.WithHardwareProfile(testHardwareProfile)).(*unstructured.Unstructured)
-						g.Expect(ok).Should(BeTrue(), "workload should be unstructured")
-						return workload
-					},
-					expectPatches: true,
-				},
-			}
+			)
 
-			// Add notebook-specific test case for existing resources
-			if config.GVK.Kind == gvk.Notebook.Kind {
-				testCases = append(testCases, struct {
-					name          string
-					hwpOptions    []envtestutil.ObjectOption
-					setupWorkload func() *unstructured.Unstructured
-					expectPatches bool
-				}{
-					name: "applies kueue scheduling even when resources exist",
-					hwpOptions: []envtestutil.ObjectOption{
-						envtestutil.WithCPUIdentifier("4", "4"),
-						envtestutil.WithKueueScheduling(testQueue),
-					},
-					setupWorkload: func() *unstructured.Unstructured {
-						workload, ok := config.CreateWorkload(testNotebook, testNamespace, envtestutil.WithHardwareProfile(testHardwareProfile)).(*unstructured.Unstructured)
-						g.Expect(ok).Should(BeTrue(), "workload should be unstructured")
-						// Add existing CPU requests (this should prevent resource injection but allow scheduling)
-						setContainerResources(workload, "requests", "cpu", "2")
-						return workload
-					},
-					expectPatches: true,
-				})
-			}
-
-			for _, tc := range testCases {
-				t.Run(tc.name, func(t *testing.T) {
-					t.Parallel()
-
-					hwp := envtestutil.NewHardwareProfile(testHardwareProfile, testNamespace, tc.hwpOptions...)
-					cli := fake.NewClientBuilder().WithScheme(sch).WithObjects(hwp).Build()
-					injector := createWebhookInjector(cli, sch)
-
-					workload := tc.setupWorkload()
-
-					req := envtestutil.NewAdmissionRequest(
-						t,
-						admissionv1.Create,
-						workload,
-						config.GVK,
-						metav1.GroupVersionResource{
-							Group:    config.GVK.Group,
-							Version:  config.GVK.Version,
-							Resource: config.ResourceName,
-						},
-					)
-
-					resp := injector.Handle(ctx, req)
-					g.Expect(resp.Allowed).Should(BeTrue())
-					g.Expect(resp.Patches).Should(Not(BeEmpty()))
-				})
-			}
+			resp := injector.Handle(ctx, req)
+			g.Expect(resp.Allowed).Should(BeTrue())
+			g.Expect(resp.Patches).Should(Not(BeEmpty()))
 		})
 	}
 }
 
-// TestHardwareProfile_SupportsCrossNamespaceAccess tests that hardware profiles can be accessed from different namespaces for both Notebook and InferenceService workloads.
-func TestHardwareProfile_SupportsCrossNamespaceAccess(t *testing.T) {
+// TestHardwareProfile_SchedulingConfiguration_InferenceService tests that hardware profiles with different
+// scheduling configurations are applied correctly to InferenceService workloads.
+func TestHardwareProfile_SchedulingConfiguration_InferenceService(t *testing.T) {
+	t.Parallel()
+	g := NewWithT(t)
+	sch, ctx := setupTestEnvironment(t)
+
+	testCases := []struct {
+		name          string
+		hwpOptions    []envtestutil.ObjectOption
+		setupWorkload func() *unstructured.Unstructured
+		expectPatches bool
+	}{
+		{
+			name: "applies node scheduling to clean workload",
+			hwpOptions: []envtestutil.ObjectOption{
+				envtestutil.WithCPUIdentifier("2", "2"),
+				envtestutil.WithNodeScheduling(
+					map[string]string{"node-type": "gpu-node"},
+					[]corev1.Toleration{{
+						Key:      "nvidia.com/gpu",
+						Operator: corev1.TolerationOpEqual,
+						Value:    "true",
+						Effect:   corev1.TaintEffectNoSchedule,
+					}},
+				),
+			},
+			setupWorkload: func() *unstructured.Unstructured {
+				workload, ok := envtestutil.NewInferenceService(testInferenceService, testNamespace, envtestutil.WithHardwareProfile(testHardwareProfile)).(*unstructured.Unstructured)
+				g.Expect(ok).Should(BeTrue(), "workload should be unstructured")
+				return workload
+			},
+			expectPatches: true,
+		},
+		{
+			name: "applies kueue scheduling to clean workload",
+			hwpOptions: []envtestutil.ObjectOption{
+				envtestutil.WithMemoryIdentifier("4Gi", "4Gi"),
+				envtestutil.WithKueueScheduling(testQueue, "high-priority"),
+			},
+			setupWorkload: func() *unstructured.Unstructured {
+				workload, ok := envtestutil.NewInferenceService(testInferenceService, testNamespace, envtestutil.WithHardwareProfile(testHardwareProfile)).(*unstructured.Unstructured)
+				g.Expect(ok).Should(BeTrue(), "workload should be unstructured")
+				return workload
+			},
+			expectPatches: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			hwp := envtestutil.NewHardwareProfile(testHardwareProfile, testNamespace, tc.hwpOptions...)
+			cli := fake.NewClientBuilder().WithScheme(sch).WithObjects(hwp).Build()
+			injector := createWebhookInjector(cli, sch)
+
+			workload := tc.setupWorkload()
+
+			req := envtestutil.NewAdmissionRequest(
+				t,
+				admissionv1.Create,
+				workload,
+				gvk.InferenceServices,
+				metav1.GroupVersionResource{
+					Group:    gvk.InferenceServices.Group,
+					Version:  gvk.InferenceServices.Version,
+					Resource: "inferenceservices",
+				},
+			)
+
+			resp := injector.Handle(ctx, req)
+			g.Expect(resp.Allowed).Should(BeTrue())
+			g.Expect(resp.Patches).Should(Not(BeEmpty()))
+		})
+	}
+}
+
+// TestHardwareProfile_SupportsCrossNamespaceAccess_Notebook tests that hardware profiles can be accessed from different namespaces for Notebook workloads.
+func TestHardwareProfile_SupportsCrossNamespaceAccess_Notebook(t *testing.T) {
 	t.Parallel()
 	g := NewWithT(t)
 	sch, ctx := setupTestEnvironment(t)
@@ -608,51 +719,71 @@ func TestHardwareProfile_SupportsCrossNamespaceAccess(t *testing.T) {
 	cli := fake.NewClientBuilder().WithScheme(sch).WithObjects(hwp).Build()
 	injector := createWebhookInjector(cli, sch)
 
-	workloadConfigs := []WorkloadTestConfig{
-		getNotebookConfig(),
-		getInferenceServiceConfig(),
-	}
+	workload := envtestutil.NewNotebook(testNotebook, workloadNamespace,
+		envtestutil.WithHardwareProfile(testHardwareProfile),
+		envtestutil.WithHardwareProfileNamespace(hwpNamespace),
+	)
 
-	for _, config := range workloadConfigs {
-		t.Run(config.ResourceName, func(t *testing.T) {
-			t.Parallel()
+	req := envtestutil.NewAdmissionRequest(
+		t,
+		admissionv1.Create,
+		workload,
+		gvk.Notebook,
+		metav1.GroupVersionResource{
+			Group:    gvk.Notebook.Group,
+			Version:  gvk.Notebook.Version,
+			Resource: "notebooks",
+		},
+	)
 
-			var workload client.Object
-			if config.GVK.Kind == gvk.Notebook.Kind {
-				workload = config.CreateWorkload(testNotebook, workloadNamespace,
-					envtestutil.WithHardwareProfile(testHardwareProfile),
-					envtestutil.WithHardwareProfileNamespace(hwpNamespace),
-				)
-			} else {
-				// InferenceService uses a different pattern for cross-namespace annotation
-				workload = config.CreateWorkload(testInferenceService, workloadNamespace, func(obj client.Object) {
-					annotations := obj.GetAnnotations()
-					if annotations == nil {
-						annotations = make(map[string]string)
-					}
-					annotations["opendatahub.io/hardware-profile-name"] = testHardwareProfile
-					annotations["opendatahub.io/hardware-profile-namespace"] = hwpNamespace
-					obj.SetAnnotations(annotations)
-				})
-			}
+	resp := injector.Handle(ctx, req)
+	g.Expect(resp.Allowed).Should(BeTrue())
+	g.Expect(resp.Patches).Should(Not(BeEmpty()))
+}
 
-			req := envtestutil.NewAdmissionRequest(
-				t,
-				admissionv1.Create,
-				workload,
-				config.GVK,
-				metav1.GroupVersionResource{
-					Group:    config.GVK.Group,
-					Version:  config.GVK.Version,
-					Resource: config.ResourceName,
-				},
-			)
+// TestHardwareProfile_SupportsCrossNamespaceAccess_InferenceService tests that hardware profiles can be accessed from different namespaces for InferenceService workloads.
+func TestHardwareProfile_SupportsCrossNamespaceAccess_InferenceService(t *testing.T) {
+	t.Parallel()
+	g := NewWithT(t)
+	sch, ctx := setupTestEnvironment(t)
 
-			resp := injector.Handle(ctx, req)
-			g.Expect(resp.Allowed).Should(BeTrue())
-			g.Expect(resp.Patches).Should(Not(BeEmpty()))
-		})
-	}
+	hwpNamespace := "hwp-namespace"
+	workloadNamespace := "workload-namespace"
+
+	// Create hardware profile in different namespace
+	hwp := envtestutil.NewHardwareProfile(testHardwareProfile, hwpNamespace,
+		envtestutil.WithGPUIdentifier("nvidia.com/gpu", "1", "1"),
+	)
+
+	cli := fake.NewClientBuilder().WithScheme(sch).WithObjects(hwp).Build()
+	injector := createWebhookInjector(cli, sch)
+
+	// InferenceService uses a different pattern for cross-namespace annotation
+	workload := envtestutil.NewInferenceService(testInferenceService, workloadNamespace, func(obj client.Object) {
+		annotations := obj.GetAnnotations()
+		if annotations == nil {
+			annotations = make(map[string]string)
+		}
+		annotations["opendatahub.io/hardware-profile-name"] = testHardwareProfile
+		annotations["opendatahub.io/hardware-profile-namespace"] = hwpNamespace
+		obj.SetAnnotations(annotations)
+	})
+
+	req := envtestutil.NewAdmissionRequest(
+		t,
+		admissionv1.Create,
+		workload,
+		gvk.InferenceServices,
+		metav1.GroupVersionResource{
+			Group:    gvk.InferenceServices.Group,
+			Version:  gvk.InferenceServices.Version,
+			Resource: "inferenceservices",
+		},
+	)
+
+	resp := injector.Handle(ctx, req)
+	g.Expect(resp.Allowed).Should(BeTrue())
+	g.Expect(resp.Patches).Should(Not(BeEmpty()))
 }
 
 // TestHardwareProfile_HandlesUpdateOperations tests that update operations are handled correctly.
@@ -800,6 +931,134 @@ func TestHardwareProfile_ErrorPaths(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestHardwareProfile_ResourceLimits_Notebook tests that hardware profiles with MaxCount are applied as limits for Notebook workloads.
+func TestHardwareProfile_ResourceLimits_Notebook(t *testing.T) {
+	t.Parallel()
+	g := NewWithT(t)
+	sch, ctx := setupTestEnvironment(t)
+
+	// Create hardware profile with CPU and memory identifiers that include limits
+	hwp := envtestutil.NewHardwareProfile(testHardwareProfile, testNamespace,
+		envtestutil.WithCPUIdentifier("1", "2", "4"),                   // min: 1, default: 2, max: 4
+		envtestutil.WithMemoryIdentifier("1Gi", "2Gi", "4Gi"),          // min: 1Gi, default: 2Gi, max: 4Gi
+		envtestutil.WithGPUIdentifier("nvidia.com/gpu", "0", "1", "2"), // min: 0, default: 1, max: 2
+	)
+
+	cli := fake.NewClientBuilder().WithScheme(sch).WithObjects(hwp).Build()
+	injector := createWebhookInjector(cli, sch)
+
+	workload := envtestutil.NewNotebook(testNotebook, testNamespace, envtestutil.WithHardwareProfile(testHardwareProfile))
+	workloadUnstructured, ok := workload.(*unstructured.Unstructured)
+	g.Expect(ok).Should(BeTrue(), "workload should be unstructured")
+
+	req := envtestutil.NewAdmissionRequest(
+		t,
+		admissionv1.Create,
+		workloadUnstructured,
+		gvk.Notebook,
+		metav1.GroupVersionResource{
+			Group:    gvk.Notebook.Group,
+			Version:  gvk.Notebook.Version,
+			Resource: "notebooks",
+		},
+	)
+
+	resp := injector.Handle(ctx, req)
+	g.Expect(resp.Allowed).Should(BeTrue())
+	g.Expect(resp.Patches).Should(Not(BeEmpty()))
+
+	// Verify that resources were applied
+	hasResourcesPatch := false
+	for _, patch := range resp.Patches {
+		if strings.Contains(patch.Path, "/resources") {
+			hasResourcesPatch = true
+
+			// Check if the patch value contains both requests and limits
+			if resourcesMap, ok := patch.Value.(map[string]interface{}); ok {
+				hasRequests := false
+				hasLimits := false
+
+				if requests, ok := resourcesMap["requests"].(map[string]interface{}); ok && len(requests) > 0 {
+					hasRequests = true
+				}
+				if limits, ok := resourcesMap["limits"].(map[string]interface{}); ok && len(limits) > 0 {
+					hasLimits = true
+				}
+
+				g.Expect(hasRequests).Should(BeTrue(), "Resources patch should contain requests")
+				g.Expect(hasLimits).Should(BeTrue(), "Resources patch should contain limits")
+			}
+			break
+		}
+	}
+
+	g.Expect(hasResourcesPatch).Should(BeTrue(), "Should have resources patch")
+}
+
+// TestHardwareProfile_ResourceLimits_InferenceService tests that hardware profiles with MaxCount are applied as limits for InferenceService workloads.
+func TestHardwareProfile_ResourceLimits_InferenceService(t *testing.T) {
+	t.Parallel()
+	g := NewWithT(t)
+	sch, ctx := setupTestEnvironment(t)
+
+	// Create hardware profile with CPU and memory identifiers without limits
+	hwp := envtestutil.NewHardwareProfile(testHardwareProfile, testNamespace,
+		envtestutil.WithCPUIdentifier("1", "2"),                // min: 1, default: 2 (no max)
+		envtestutil.WithMemoryIdentifier("1Gi", "2Gi"),         // min: 1Gi, default: 2Gi (no max)
+		envtestutil.WithGPUIdentifier("adm.com/gpu", "0", "1"), // min: 0, default: 1 (no max)
+	)
+
+	cli := fake.NewClientBuilder().WithScheme(sch).WithObjects(hwp).Build()
+	injector := createWebhookInjector(cli, sch)
+
+	workload := envtestutil.NewInferenceService(testInferenceService, testNamespace, envtestutil.WithHardwareProfile(testHardwareProfile))
+	workloadUnstructured, ok := workload.(*unstructured.Unstructured)
+	g.Expect(ok).Should(BeTrue(), "workload should be unstructured")
+
+	req := envtestutil.NewAdmissionRequest(
+		t,
+		admissionv1.Create,
+		workloadUnstructured,
+		gvk.InferenceServices,
+		metav1.GroupVersionResource{
+			Group:    gvk.InferenceServices.Group,
+			Version:  gvk.InferenceServices.Version,
+			Resource: "inferenceservices",
+		},
+	)
+
+	resp := injector.Handle(ctx, req)
+	g.Expect(resp.Allowed).Should(BeTrue())
+	g.Expect(resp.Patches).Should(Not(BeEmpty()))
+
+	// Verify that resources were applied
+	hasResourcesPatch := false
+	for _, patch := range resp.Patches {
+		if strings.Contains(patch.Path, "/resources") {
+			hasResourcesPatch = true
+
+			// Check if the patch value contains both requests and limits
+			if resourcesMap, ok := patch.Value.(map[string]interface{}); ok {
+				hasRequests := false
+				hasLimits := false
+
+				if requests, ok := resourcesMap["requests"].(map[string]interface{}); ok && len(requests) > 0 {
+					hasRequests = true
+				}
+				if limits, ok := resourcesMap["limits"].(map[string]interface{}); ok && len(limits) > 0 {
+					hasLimits = true
+				}
+
+				g.Expect(hasRequests).Should(BeTrue(), "Resources patch should contain requests")
+				g.Expect(hasLimits).Should(BeFalse(), "Resources patch should not contain limits when max values are not set")
+			}
+			break
+		}
+	}
+
+	g.Expect(hasResourcesPatch).Should(BeTrue(), "Should have resources patch")
 }
 
 // TestHardwareProfile_ConvertIntOrStringToQuantity tests the quantity conversion utility.

--- a/internal/webhook/inferenceservice/mutating_test.go
+++ b/internal/webhook/inferenceservice/mutating_test.go
@@ -441,6 +441,7 @@ func TestConnectionWebhook(t *testing.T) {
 			secretType:      inferenceservice.ConnectionTypeS3.String(),
 			secretNamespace: testNamespace,
 			annotations:     map[string]string{annotations.Connection: testSecret},
+			predictorSpec:   map[string]interface{}{"name": "test-predictor"},
 			operation:       admissionv1.Create,
 			expectedAllowed: false,
 			expectedMessage: "found no spec.predictor.model set in resource",


### PR DESCRIPTION
- it should use` .spec.predictor.model `then add `resources.requests` (use defaultCount) and `resources.limits`(if maxCount is set in HWProfile)
- if values already exists, we do not use HWProfile's value to overwrite as UPDATE operation
- it should use `.spec.predictor.nodeSelector `and `.spec.predictor.tolerations`
- split unit-tests to two parts for notebook and isvc

<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

<!--- Link your JIRA and related links here for reference. -->
related to but not directly for https://issues.redhat.com/browse/RHOAIENG-33131
slack https://redhat-internal.slack.com/archives/C09CQC6DL72/p1757339723783079

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
create HWProfile CR
```
---
apiVersion: infrastructure.opendatahub.io/v1alpha1
kind: HardwareProfile
metadata:
  annotations:
    opendatahub.io/dashboard-feature-visibility: '[]'
    opendatahub.io/description: 'Provides a baseline hardware profile with 2 CPUs and 4Gi memory by default, adjustable up to 4 CPUs and 8Gi memory.'
    opendatahub.io/disabled: 'false'
    opendatahub.io/display-name: default-profile
  name: default-profile
  namespace: opendatahub
spec:
  identifiers:
    - defaultCount: 2
      displayName: CPU
      identifier: cpu
      maxCount: 4
      minCount: 1
      resourceType: CPU
    - defaultCount: 2Gi
      displayName: Memory
      identifier: memory
      maxCount: 4Gi
      minCount: 1Gi
      resourceType: Memory
  scheduling:
    node:
      nodeSelector:
        jharmison.dev/gpu-type: l40s
      tolerations:
        - effect: NoSchedule
          key: nvidia.com/gpu
          operator: Equal
          value: l40s
    type: Node
```
create ISVC CR
```
---
apiVersion: serving.kserve.io/v1beta1
kind: InferenceService
metadata:
  annotations:
    opendatahub.io/hardware-profile-name: default-profile
    opendatahub.io/hardware-profile-namespace: opendatahub
  name: haha
  namespace: glue-test
  labels:
    opendatahub.io/dashboard: 'true'
spec:
  predictor:
    model:
      modelFormat:
        name: vLLM
      name: mistral
     resources:
        requests:
          cpu: '4'
```

should see ISVC CR get injected with 
```
spec:
  predictor:
    model:
      modelFormat:
        name: vLLM
      name: mistral
      resources:
        limits:
          cpu: '4'
          memory: 4Gi
        requests:
          cpu: '4'
          memory: 2Gi
    nodeSelector:
      jharmison.dev/gpu-type: l40s
    tolerations:
      - effect: NoSchedule
        key: nvidia.com/gpu
        operator: Equal
        value: l40s
```

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Hardware profiles now apply resource limits (CPU, memory, GPU) when max values are configured and support a new model-based spec for InferenceService resource and scheduling injection.
  * Scheduling settings are applied at the predictor level for InferenceServices.

* **Bug Fixes**
  * Mutation logic is more resilient: missing model/containers paths no longer cause errors.

* **Tests**
  * Expanded per-kind test suites for Notebooks and InferenceServices covering resource limits, scheduling, and cross-namespace scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->