### PR TITLE
fix: serviceaccount should only be created and injected into ISVC if type is s3

### DIFF
--- a/internal/webhook/inferenceservice/mutating_test.go
+++ b/internal/webhook/inferenceservice/mutating_test.go
@@ -278,16 +278,16 @@ func hasServiceAccountNameRemovePatch() func([]jsonpatch.JsonPatchOperation) boo
 }
 
 func TestServiceAccountNamePatching(t *testing.T) {
-	t.Run("serviceAccountName is injected on create with OCI", func(t *testing.T) {
+	t.Run("no serviceAccountName is injected on create if type is not S3", func(t *testing.T) {
 		tc := TestCase{
-			name:            "serviceAccountName injected on create",
+			name:            "no serviceAccountName injected on create with OCI",
 			secretType:      inferenceservice.ConnectionTypeOCI.String(),
 			secretNamespace: testNamespace,
 			annotations:     map[string]string{annotations.Connection: testSecret},
 			operation:       admissionv1.Create,
 			expectedAllowed: true,
 			expectedPatchCheck: func(patches []jsonpatch.JsonPatchOperation) bool {
-				return hasServiceAccountNamePatch(testSecret + "-sa")(patches)
+				return !hasServiceAccountNamePatch(testSecret + "-sa")(patches)
 			},
 		}
 		runTestCase(t, tc)


### PR DESCRIPTION
**this change has been included in https://github.com/opendatahub-io/opendatahub-operator/pull/2433 which fixed another issue, we can get reivew on 2433 instead**

<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->
- move SA creation and injection to S3 only
- dry-run is for the case if user does "oc apply --dry-run" in this case we should not create serviceaccount in the cluster
- update testcase on OCI, which should not have injection done but creation still allowed
follow up PR https://github.com/opendatahub-io/opendatahub-operator/pull/2376
slack https://redhat-internal.slack.com/archives/C08T1K4FQVC/p1757344672841239

<!--- Link your JIRA and related links here for reference. -->
ref https://issues.redhat.com/browse/RHOAIENG-33129

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - ServiceAccounts are no longer auto-created or injected for non-S3 connections, preventing unexpected patches on create.
  - For S3 connections, a ServiceAccount is created/injected as needed, then the S3 storage key is injected. Dry-run skips creation with logging.
  - Improved error reporting when ServiceAccount creation or injection fails.

- Tests
  - Updated expectations to confirm no ServiceAccount is injected on create for non-S3 connections; S3-related update/removal tests remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->