### PR TITLE
fix: when servicemesh is set to Removed in DSCI, should not continue check

### DIFF
--- a/internal/controller/services/servicemesh/servicemesh_controller_actions.go
+++ b/internal/controller/services/servicemesh/servicemesh_controller_actions.go
@@ -54,6 +54,22 @@ func checkPreconditions(ctx context.Context, rr *odhtypes.ReconciliationRequest)
 		return nil
 	}
 
+	if sm.Spec.ManagementState == operatorv1.Removed {
+		rr.Conditions.MarkFalse(
+			status.CapabilityServiceMesh,
+			conditions.WithReason(status.RemovedReason),
+			conditions.WithMessage("ServiceMesh is set to Removed"),
+			conditions.WithSeverity(common.ConditionSeverityInfo),
+		)
+		rr.Conditions.MarkFalse(
+			status.CapabilityServiceMeshAuthorization,
+			conditions.WithReason(status.RemovedReason),
+			conditions.WithMessage("ServiceMesh is set to Removed, ServiceMesh Authorization is therefore also Removed"),
+			conditions.WithSeverity(common.ConditionSeverityInfo),
+		)
+		return nil
+	}
+
 	// ensure ServiceMesh v2 operator is installed as pre-requisite
 	if err := checkServiceMeshOperator(ctx, rr); err != nil {
 		rr.Conditions.MarkFalse(


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

error:
`"level":"error","ts":"2025-09-10T11:17:29Z","msg":"Reconciler error","controller":"servicemesh","controllerGroup":"services.platform.opendatahub.io","controllerKind":"ServiceMesh","ServiceMesh":{"name":"default-servicemesh"},"namespace":"","name":"default-servicemesh","reconcileID":"a90c95eb-020f-499c-96a1-0ffbc47d8acb","error":"failed to get ServiceMeshControlPlane: no matches for kind \"ServiceMeshControlPlane\" in version \"maistra.io/v2\"","stacktrace":"sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler\n\t/opt/app-root/src/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.4/pkg/internal/controller/controller.go:347\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem\n\t/opt/app-root/src/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.4/pkg/internal/controller/controller.go:294\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func2.2\n\t/opt/app-root/src/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.4/pkg/internal/controller/controller.go:255"}`
even DSCI has Removed for servicemesh

the fix is to: 
 - the deleteion operation is handled by gc when flip to Removed
- but we still need to consider if user create DSCI with Removed at init.value
we no need this into rhoai branch but for stable-2.x

<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->



<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Correctly handles Service Mesh set to Removed: the system now halts further checks, marks Service Mesh and its authorization as disabled, and shows clear status messages.
  - Prevents unnecessary operator prerequisite checks, reducing misleading warnings and errors.
  - Status and health views accurately reflect the Removed state, improving clarity for administrators and reducing noise in logs and alerts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->