### PR TITLE
Take ContextDir from devFlags if given else to default

### DIFF
--- a/internal/controller/components/feastoperator/feastoperator_controller_actions.go
+++ b/internal/controller/components/feastoperator/feastoperator_controller_actions.go
@@ -30,7 +30,12 @@ func devFlags(ctx context.Context, rr *odhtypes.ReconciliationRequest) error {
 		}
 		if manifestConfig.SourcePath != "" {
 			rr.Manifests[0].Path = odhdeploy.DefaultManifestPath
-			rr.Manifests[0].ContextDir = ComponentName
+			// Choose ContextDir: use manifestConfig.ContextDir if provided, otherwise ComponentName
+			if manifestConfig.ContextDir != "" {
+				rr.Manifests[0].ContextDir = manifestConfig.ContextDir
+			} else {
+				rr.Manifests[0].ContextDir = ComponentName
+			}
 			rr.Manifests[0].SourcePath = manifestConfig.SourcePath
 		}
 	}


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

<!--- Link your JIRA and related links here for reference. -->
The ContextDir in DevFlags is defaulted to ComponentName which is not always applies to all the operators.  Like for feastoperator the directory path is different that is `infra/feast-operator` rather than just the component name `feastoperator`.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Havent tested that fixed it based on the error getting deploying the feastoperator from devFlags:
```
error creating file /opt/manifests/feastoperator: open /opt/manifests/feastoperator: is a directory
```
## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-manifest configurable context directory when a source path is provided, allowing finer-grained control across multiple manifests. Other manifest settings (path, source) and download behavior are unchanged. If a manifest’s context directory is not specified, it now falls back to the component name to preserve expected behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->