### PR TITLE
Remove servicemesh not installed check.

### DIFF
--- a/tests/e2e/servicemesh_test.go
+++ b/tests/e2e/servicemesh_test.go
@@ -149,7 +149,6 @@ func serviceMeshControllerTestSuite(t *testing.T) {
 		// test removing ServiceMesh spec from DSCI / not providing it at all
 		{"Validate setting empty ServiceMesh spec", smCtx.ValidateNoServiceMeshSpecInDSCI},
 		// test cases for missing dependent operators
-		{"Validate ServiceMesh operator not installed", smCtx.ValidateServiceMeshOperatorNotInstalled},
 		{"Validate Authorino operator not installed", smCtx.ValidateAuthorinoOperatorNotInstalled},
 	}
 
@@ -531,39 +530,6 @@ func (tc *ServiceMeshTestCtx) ValidateNoServiceMeshSpecInDSCI(t *testing.T) {
 	)
 
 	// post-test:restore DSCI ServiceMesh spec to default config
-	tc.setupAndValidateServiceMeshEnvironment(t, DependentOperatorsTestConfig{
-		EnsureServiceMeshOperatorInstalled: true,
-		EnsureAuthorinoOperatorInstalled:   true,
-	})
-}
-
-func (tc *ServiceMeshTestCtx) ValidateServiceMeshOperatorNotInstalled(t *testing.T) {
-	t.Helper()
-
-	// pre-test: cleanup ServiceMesh and its resources
-	// to emulate starting conditions for the clean ServiceMesh installation
-	tc.EventuallyResourceCreatedOrUpdated(
-		WithMinimalObject(gvk.DSCInitialization, tc.DSCInitializationNamespacedName),
-		WithMutateFunc(testf.Transform(`.spec.serviceMesh.managementState = "%s"`, operatorv1.Removed)),
-	)
-	tc.ensureServiceMeshGone(t)
-
-	// attempt installing ServiceMesh with missing ServiceMesh operator, and validate state
-	tc.setupAndValidateServiceMeshEnvironment(t, DependentOperatorsTestConfig{
-		EnsureServiceMeshOperatorInstalled: false,
-		EnsureAuthorinoOperatorInstalled:   false,
-	})
-
-	// ensure ServiceMesh resources were not created
-	tc.ensureServiceMeshResourcesGone(t)
-
-	// post-test:cleanup ServiceMesh and its resources again, for post-test recovery purposes
-	tc.EventuallyResourceCreatedOrUpdated(
-		WithMinimalObject(gvk.DSCInitialization, tc.DSCInitializationNamespacedName),
-		WithMutateFunc(testf.Transform(`.spec.serviceMesh.managementState = "%s"`, operatorv1.Removed)),
-	)
-	tc.ensureServiceMeshGone(t)
-	// post-test: restore DSCI ServiceMesh spec to default config
 	tc.setupAndValidateServiceMeshEnvironment(t, DependentOperatorsTestConfig{
 		EnsureServiceMeshOperatorInstalled: true,
 		EnsureAuthorinoOperatorInstalled:   true,


### PR DESCRIPTION
After adding the gatewayconfig CRD and controller, ODH and RHOAI will always have servicemesh installed automatically by the openshift ingress controller. It will not be possible to get into a state without OSSM 3.x installed.

Related prow PR: https://github.com/openshift/release/pull/69086

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Removed an obsolete check for the ServiceMesh operator not being installed to streamline the end-to-end suite.
  * Retained and focused coverage on relevant Authorino-related scenarios.
  * Improves test clarity and maintainability, reducing potential false negatives.
  * Slightly optimizes CI execution time by trimming redundant cases.
  * No changes to product functionality or user workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->