### PR TITLE
RHOAIENG-29717 | feat: Deploy thanos querier frontend for metrics acces

### DIFF
--- a/bundle/manifests/opendatahub-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/opendatahub-operator.clusterserviceversion.yaml
@@ -148,7 +148,7 @@ metadata:
     categories: AI/Machine Learning, Big Data
     certified: "False"
     containerImage: quay.io/opendatahub/opendatahub-operator:v2.33.0
-    createdAt: "2025-09-15T08:36:20Z"
+    createdAt: "2025-09-15T15:42:44Z"
     operators.operatorframework.io/builder: operator-sdk-v1.39.2
     operators.operatorframework.io/internal-objects: '["featuretrackers.features.opendatahub.io",
       "codeflares.components.platform.opendatahub.io", "dashboards.components.platform.opendatahub.io",
@@ -1080,6 +1080,7 @@ spec:
           - monitoringstacks
           - prometheusrules
           - servicemonitors
+          - thanosqueriers
           verbs:
           - create
           - delete
@@ -1094,6 +1095,7 @@ spec:
           - monitoringstacks/finalizers
           - prometheusrules/finalizers
           - servicemonitors/finalizers
+          - thanosqueriers/finalizers
           verbs:
           - update
         - apiGroups:
@@ -1102,6 +1104,7 @@ spec:
           - monitoringstacks/status
           - prometheusrules/status
           - servicemonitors/status
+          - thanosqueriers/status
           verbs:
           - get
           - patch
@@ -1669,7 +1672,7 @@ spec:
   selector:
     matchLabels:
       component: opendatahub-operator
-  version: 2.33.0
+  version: 2.35.0
   webhookdefinitions:
   - admissionReviewVersions:
     - v1

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -777,6 +777,7 @@ rules:
   - monitoringstacks
   - prometheusrules
   - servicemonitors
+  - thanosqueriers
   verbs:
   - create
   - delete
@@ -791,6 +792,7 @@ rules:
   - monitoringstacks/finalizers
   - prometheusrules/finalizers
   - servicemonitors/finalizers
+  - thanosqueriers/finalizers
   verbs:
   - update
 - apiGroups:
@@ -799,6 +801,7 @@ rules:
   - monitoringstacks/status
   - prometheusrules/status
   - servicemonitors/status
+  - thanosqueriers/status
   verbs:
   - get
   - patch

--- a/internal/controller/dscinitialization/kubebuilder_rbac.go
+++ b/internal/controller/dscinitialization/kubebuilder_rbac.go
@@ -61,6 +61,9 @@ package dscinitialization
 //+kubebuilder:rbac:groups=monitoring.rhobs,resources=prometheusrules,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=monitoring.rhobs,resources=prometheusrules/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=monitoring.rhobs,resources=prometheusrules/finalizers,verbs=update
+//+kubebuilder:rbac:groups=monitoring.rhobs,resources=thanosqueriers,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=monitoring.rhobs,resources=thanosqueriers/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=monitoring.rhobs,resources=thanosqueriers/finalizers,verbs=update
 
 //+kubebuilder:rbac:groups=opentelemetry.io,resources=opentelemetrycollectors,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=opentelemetry.io,resources=opentelemetrycollectors/status,verbs=get;update;patch

--- a/internal/controller/services/monitoring/monitoring_controller.go
+++ b/internal/controller/services/monitoring/monitoring_controller.go
@@ -99,6 +99,7 @@ func (h *serviceHandler) NewReconciler(ctx context.Context, mgr ctrl.Manager) er
 		OwnsGVK(gvk.OpenTelemetryCollector, reconciler.Dynamic(reconciler.CrdExists(gvk.OpenTelemetryCollector))).
 		OwnsGVK(gvk.ServiceMonitor, reconciler.Dynamic(reconciler.CrdExists(gvk.ServiceMonitor))).
 		OwnsGVK(gvk.PrometheusRule, reconciler.Dynamic(reconciler.CrdExists(gvk.PrometheusRule))).
+		OwnsGVK(gvk.ThanosQuerier, reconciler.Dynamic(reconciler.CrdExists(gvk.ThanosQuerier))).
 		// operands - watched
 		//
 		// By default the Watches functions adds:

--- a/internal/controller/services/monitoring/resources/thanos-querier-cr.tmpl.yaml
+++ b/internal/controller/services/monitoring/resources/thanos-querier-cr.tmpl.yaml
@@ -1,0 +1,20 @@
+apiVersion: monitoring.rhobs/v1alpha1
+kind: ThanosQuerier
+metadata:
+  name: data-science-thanos-querier
+  namespace: {{.Namespace}}
+  labels:
+    app: thanos-querier
+    app.kubernetes.io/name: thanos-querier
+    app.kubernetes.io/component: querier
+    app.kubernetes.io/part-of: data-science-monitoring
+spec:
+  selector:
+    matchLabels:
+      platform.opendatahub.io/part-of: monitoring
+  namespaceSelector:
+    matchNames:
+      - {{.Namespace}}
+  replicaLabels:
+    - prometheus_replica
+    - rule_replica

--- a/internal/controller/services/monitoring/resources/thanos-querier-route.tmpl.yaml
+++ b/internal/controller/services/monitoring/resources/thanos-querier-route.tmpl.yaml
@@ -1,0 +1,22 @@
+kind: Route
+apiVersion: route.openshift.io/v1
+metadata:
+  name: data-science-thanos-querier-route
+  namespace: {{.Namespace}}
+  labels:
+    app: thanos-querier
+    app.kubernetes.io/name: thanos-querier
+    app.kubernetes.io/component: querier
+    app.kubernetes.io/part-of: data-science-monitoring
+spec:
+  path: /
+  to:
+    kind: Service
+    name: thanos-querier-data-science-thanos-querier
+    weight: 100
+  port:
+    targetPort: http
+  wildcardPolicy: None
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect

--- a/internal/controller/status/status.go
+++ b/internal/controller/status/status.go
@@ -106,6 +106,7 @@ const (
 	ConditionOpenTelemetryCollectorAvailable = "OpenTelemetryCollectorAvailable"
 	ConditionInstrumentationAvailable        = "InstrumentationAvailable"
 	ConditionAlertingAvailable               = "AlertingAvailable"
+	ConditionThanosQuerierAvailable          = "ThanosQuerierAvailable"
 )
 
 const (

--- a/pkg/cluster/gvk/gvk.go
+++ b/pkg/cluster/gvk/gvk.go
@@ -501,6 +501,12 @@ var (
 		Kind:    "PrometheusRule",
 	}
 
+	ThanosQuerier = schema.GroupVersionKind{
+		Group:   "monitoring.rhobs",
+		Version: "v1alpha1",
+		Kind:    "ThanosQuerier",
+	}
+
 	ServiceMesh = schema.GroupVersionKind{
 		Group:   serviceApi.GroupVersion.Group,
 		Version: serviceApi.GroupVersion.Version,


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
when monitoring is managed and metrics are enabled, a thanos querier instance is deployed

[jira](https://issues.redhat.com/browse/RHOAIENG-29717)

## How Has This Been Tested?
Check crds exist
- `kubectl get crd thanosqueriers.monitoring.rhobs`
Check if thanos querier instance was created:
- `kubectl get thanosqueriers -n redhat-ods-monitoring`
Get thanos route details:
- `kubectl get route data-science-thanos-querier-route -n redhat-ods-monitoring` -o yaml`
Check thanos service exists:
- `kubectl get service thanos-querier-data-science-thanos-querier -n redhat-ods-monitoring`
Verify pods exist and check pod logs on cluster
Verify frontend route access
- `THANOS_URL=$(kubectl get route data-science-thanos-querier-route -n redhat-ods-monitoring -o jsonpath='{.spec.host}')`
- ` curl -k https://$THANOS_URL `
Verify rbac permissions
- `kubectl auth can-i create thanosqueriers --as=system:serviceaccount:opendatahub-operator-system:opendatahub-operator-controller-manager` should be yes
- ` kubectl auth can-i list thanosqueriers --as=system:serviceaccount:opendatahub-operator-system:opendatahub-operator-controller-manager` should be yes

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional Thanos Querier deployment when monitoring metrics are enabled.
  * Exposes an OpenShift route for accessing Thanos Querier.
  * New status condition to report Thanos Querier availability.

* **Chores**
  * Updated cluster RBAC/permissions and operator manifests to allow managing Thanos Querier resources.

* **Tests**
  * Added unit tests for template generation and gating logic of Thanos Querier deployment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->