### PR TITLE
prometheus test should check monitoring namespace not apps namespace

### DIFF
--- a/tests/e2e/monitoring_test.go
+++ b/tests/e2e/monitoring_test.go
@@ -780,16 +780,18 @@ func (tc *MonitoringTestCtx) ValidatePrometheusRuleCreation(t *testing.T) {
 
 	// Ensure the prometheus rules exist
 	tc.EnsureResourceExists(
-		WithMinimalObject(gvk.PrometheusRule, types.NamespacedName{Name: "dashboard-prometheusrules", Namespace: dsci.Spec.ApplicationsNamespace}),
+		WithMinimalObject(gvk.PrometheusRule, types.NamespacedName{Name: "dashboard-prometheusrules", Namespace: dsci.Spec.Monitoring.Namespace}),
 	)
 
 	tc.EnsureResourceExists(
-		WithMinimalObject(gvk.PrometheusRule, types.NamespacedName{Name: "operator-prometheusrules", Namespace: dsci.Spec.ApplicationsNamespace}),
+		WithMinimalObject(gvk.PrometheusRule, types.NamespacedName{Name: "operator-prometheusrules", Namespace: dsci.Spec.Monitoring.Namespace}),
 	)
 }
 
 func (tc *MonitoringTestCtx) ValidatePrometheusRuleDeletion(t *testing.T) {
 	t.Helper()
+
+	dsci := tc.FetchDSCInitialization()
 
 	// Update DSC to disable dashboard component
 	tc.EventuallyResourceCreatedOrUpdated(
@@ -801,7 +803,7 @@ func (tc *MonitoringTestCtx) ValidatePrometheusRuleDeletion(t *testing.T) {
 
 	// Ensure the dashboard-prometheusrules is deleted
 	tc.EnsureResourceGone(
-		WithMinimalObject(gvk.PrometheusRule, types.NamespacedName{Name: "dashboard-prometheusrules", Namespace: tc.AppsNamespace}),
+		WithMinimalObject(gvk.PrometheusRule, types.NamespacedName{Name: "dashboard-prometheusrules", Namespace: dsci.Spec.Monitoring.Namespace}),
 	)
 
 	// Cleanup: Remove alerting configuration from DSCInitialization to prevent validation issues


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->
The prometheus tests where checking the apps namespace for the presence of the prometheusrules, they should ahve been checking the monitoring namepace. This isn't a problem with the default e2e test as both namespaces are opendatahub but causes failures in other configurations, eg. https://github.com/opendatahub-io/opendatahub-operator/pull/2392
<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prometheus rules and dashboards are now validated and managed in the Monitoring namespace rather than Applications.
  * Deletion and cleanup of Prometheus rules correctly use the configured Monitoring namespace.
  * Default dashboard checks now target the Monitoring namespace for consistent monitoring resource placement.

* **Tests**
  * Updated end-to-end tests to reflect Monitoring namespace ownership for rules and dashboards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->