### PR TITLE
chore: remove redundant e2e test case

### DIFF
--- a/tests/e2e/servicemesh_test.go
+++ b/tests/e2e/servicemesh_test.go
@@ -146,8 +146,6 @@ func serviceMeshControllerTestSuite(t *testing.T) {
 		{"Validate ServiceMesh transition to removed", smCtx.ValidateServiceMeshTransitionToRemoved},
 		// test removal scenario of Legacy ServiceMesh-related FeatureTrackers being present
 		{"Validate Legacy ServiceMesh FeatureTrackers removal", smCtx.ValidateLegacyServiceMeshFeatureTrackersRemoval},
-		// test removing ServiceMesh spec from DSCI / not providing it at all
-		{"Validate setting empty ServiceMesh spec", smCtx.ValidateNoServiceMeshSpecInDSCI},
 		// test cases for missing dependent operators
 		{"Validate Authorino operator not installed", smCtx.ValidateAuthorinoOperatorNotInstalled},
 	}


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [x] The developer has run the integration test pipeline and verified that it passed successfully


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Removed an outdated end-to-end scenario that validated an empty Service Mesh configuration, aligning the suite with current product behavior.
  * Streamlines CI runs and reduces maintenance overhead, improving test reliability and signal quality. No impact on end-user functionality or features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->