### PR TITLE
Enable ValidateServiceMeshControlPlane test after RHOAIENG-29225 was …

### DIFF
--- a/tests/e2e/creation_test.go
+++ b/tests/e2e/creation_test.go
@@ -9,6 +9,7 @@ import (
 	"sort"
 	"strings"
 	"testing"
+	"time"
 
 	gTypes "github.com/onsi/gomega/types"
 	operatorv1 "github.com/openshift/api/operator/v1"
@@ -65,8 +66,7 @@ func dscManagementTestSuite(t *testing.T) {
 		{"Validate creation of DSCInitialization instance", dscTestCtx.ValidateDSCICreation},
 		{"Validate creation of DataScienceCluster instance", dscTestCtx.ValidateDSCCreation},
 		{"Validate ServiceMeshSpec in DSCInitialization instance", dscTestCtx.ValidateServiceMeshSpecInDSCI},
-		//TODO: disabled until RHOAIENG-29225 is resolved
-		// {"Validate ServiceMeshControlPlane exists and is recreated upon deletion.", dscTestCtx.ValidateServiceMeshControlPlane},
+		{"Validate ServiceMeshControlPlane exists and is recreated upon deletion.", dscTestCtx.ValidateServiceMeshControlPlane},
 		{"Validate Knative resource", dscTestCtx.ValidateKnativeSpecInDSC},
 		{"Validate owned namespaces exist", dscTestCtx.ValidateOwnedNamespacesAllExist},
 		{"Validate default NetworkPolicy exist", dscTestCtx.ValidateDefaultNetworkPolicyExists},
@@ -223,25 +223,12 @@ func (tc *DSCTestCtx) ValidateServiceMeshControlPlane(t *testing.T) {
 
 	smcp := types.NamespacedName{Name: serviceMeshControlPlane, Namespace: serviceMeshNamespace}
 
-	// Ensure service mesh feature tracker is in phase ready
-	tc.EnsureResourceExists(
-		WithMinimalObject(gvk.FeatureTracker, types.NamespacedName{Name: "opendatahub-mesh-control-plane-creation"}),
-		WithCondition(jq.Match(`.status.phase == "Ready"`)))
-
 	// Check ServiceMeshControlPlane was created.
-	tc.EnsureResourceExists(
-		WithMinimalObject(gvk.ServiceMeshControlPlane, smcp),
-	)
-
 	// Delete it.
-	tc.DeleteResource(
-		WithMinimalObject(gvk.ServiceMeshControlPlane, smcp),
-		WithWaitForDeletion(true),
-	)
-
 	// Check eventually got recreated.
-	tc.EnsureResourceExistsConsistently(
+	tc.EnsureResourceDeletedThenRecreated(
 		WithMinimalObject(gvk.ServiceMeshControlPlane, smcp),
+		WithGracePeriod(1*time.Second),
 	)
 }
 


### PR DESCRIPTION
…resolved

We can re-enable this test after [RHOAIENG-29225](https://issues.redhat.com/browse/RHOAIENG-29225) has been resolved.

## Description
<!--- Describe your changes in detail -->

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully
