### PR TITLE
add override for new workbenches

### DIFF
--- a/internal/controller/components/workbenches/workbenches.go
+++ b/internal/controller/components/workbenches/workbenches.go
@@ -97,6 +97,7 @@ func (s *componentHandler) Init(platform common.Platform) error {
 		"odh-workbench-jupyter-tensorflow-cuda-py312-ubi9-n": "RELATED_IMAGE_ODH_WORKBENCH_JUPYTER_TENSORFLOW_CUDA_PY312_IMAGE",
 		// Jupyter Workbench Images - TensorFlow ROCm
 		"odh-workbench-jupyter-tensorflow-rocm-py311-ubi9-n": "RELATED_IMAGE_ODH_WORKBENCH_JUPYTER_TENSORFLOW_ROCM_PY311_IMAGE",
+		"odh-workbench-jupyter-tensorflow-rocm-py312-ubi9-n": "RELATED_IMAGE_ODH_WORKBENCH_JUPYTER_TENSORFLOW_ROCM_PY312_IMAGE",
 
 		// Jupyter Workbench Images - TrustyAI CPU
 		"odh-workbench-jupyter-trustyai-cpu-py311-ubi9-n": "RELATED_IMAGE_ODH_WORKBENCH_JUPYTER_TRUSTYAI_CPU_PY311_IMAGE",
@@ -113,6 +114,7 @@ func (s *componentHandler) Init(platform common.Platform) error {
 		"odh-pipeline-runtime-tensorflow-cuda-py311-ubi9-n": "RELATED_IMAGE_ODH_PIPELINE_RUNTIME_TENSORFLOW_CUDA_PY311_IMAGE",
 		"odh-pipeline-runtime-tensorflow-cuda-py312-ubi9-n": "RELATED_IMAGE_ODH_PIPELINE_RUNTIME_TENSORFLOW_CUDA_PY312_IMAGE",
 		"odh-pipeline-runtime-tensorflow-rocm-py311-ubi9-n": "RELATED_IMAGE_ODH_PIPELINE_RUNTIME_TENSORFLOW_ROCM_PY311_IMAGE",
+		"odh-pipeline-runtime-tensorflow-rocm-py312-ubi9-n": "RELATED_IMAGE_ODH_PIPELINE_RUNTIME_TENSORFLOW_ROCM_PY312_IMAGE",
 		// Pipeline Runtime Images - PyTorch CUDA
 		"odh-pipeline-runtime-pytorch-cuda-py311-ubi9-n": "RELATED_IMAGE_ODH_PIPELINE_RUNTIME_PYTORCH_CUDA_PY311_IMAGE",
 		"odh-pipeline-runtime-pytorch-cuda-py312-ubi9-n": "RELATED_IMAGE_ODH_PIPELINE_RUNTIME_PYTORCH_CUDA_PY312_IMAGE",


### PR DESCRIPTION
Ref: https://issues.redhat.com/browse/RHOAIENG-32708

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added TensorFlow ROCm (Python 3.12) Jupyter notebook image option in Workbenches, available during environment selection.
  - Added TensorFlow ROCm (Python 3.12) pipeline runtime image option for executing pipelines.
  - These new images expand GPU-accelerated TensorFlow support on the latest platform stack, enabling users to create notebooks and run pipelines with Python 3.12 on ROCm-enabled hardware.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->