### PR TITLE
feat: add support to pass Oauth proxy image for downstream

### DIFF
--- a/internal/controller/components/workbenches/workbenches.go
+++ b/internal/controller/components/workbenches/workbenches.go
@@ -54,6 +54,7 @@ func (s *componentHandler) Init(platform common.Platform) error {
 	nbcManifestInfo := notebookControllerManifestInfo(notebookControllerManifestSourcePath)
 	if err := odhdeploy.ApplyParams(nbcManifestInfo.String(), "params.env", map[string]string{
 		"odh-notebook-controller-image": "RELATED_IMAGE_ODH_NOTEBOOK_CONTROLLER_IMAGE",
+		"oauth-proxy-image":             "RELATED_IMAGE_OSE_OAUTH_PROXY_IMAGE",
 	}); err != nil {
 		return fmt.Errorf("failed to update params.env from %s : %w", nbcManifestInfo.String(), err)
 	}


### PR DESCRIPTION
Add support to override OAuth proxy image for odh notebook controller

DO NOT MERGE until https://github.com/opendatahub-io/kubeflow/pull/671 is merged

https://issues.redhat.com/browse/RHOAIENG-31618
https://issues.redhat.com/browse/RHOAIENG-31730

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added support to configure the OAuth proxy image used by the notebook controller via environment parameters.
  - Enhances deployment flexibility for different environments, including private registries and air-gapped setups.
- Bug Fixes
  - None.
- Documentation
  - None.
- Refactor
  - None.
- Tests
  - None.
- Chores
  - None.
- Revert
  - None.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->