### PR TITLE
Separate webhook paths for hardware profile injection

### DIFF
--- a/bundle/manifests/opendatahub-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/opendatahub-operator.clusterserviceversion.yaml
@@ -1789,7 +1789,7 @@ spec:
     sideEffects: None
     targetPort: 9443
     type: MutatingAdmissionWebhook
-    webhookPath: /mutate-hardware-profile
+    webhookPath: /mutate-hardware-profile-isvc
   - admissionReviewVersions:
     - v1
     containerPort: 443
@@ -1809,7 +1809,7 @@ spec:
     sideEffects: None
     targetPort: 9443
     type: MutatingAdmissionWebhook
-    webhookPath: /mutate-hardware-profile
+    webhookPath: /mutate-hardware-profile-notebook
   - admissionReviewVersions:
     - v1
     containerPort: 443

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -30,7 +30,7 @@ webhooks:
     service:
       name: webhook-service
       namespace: system
-      path: /mutate-hardware-profile
+      path: /mutate-hardware-profile-isvc
   failurePolicy: Fail
   name: hardwareprofile-kserve-injector.opendatahub.io
   rules:
@@ -50,7 +50,7 @@ webhooks:
     service:
       name: webhook-service
       namespace: system
-      path: /mutate-hardware-profile
+      path: /mutate-hardware-profile-notebook
   failurePolicy: Fail
   name: hardwareprofile-notebook-injector.opendatahub.io
   rules:

--- a/internal/webhook/hardwareprofile/mutating.go
+++ b/internal/webhook/hardwareprofile/mutating.go
@@ -57,8 +57,8 @@ var WorkloadConfigs = map[string]WorkloadConfig{
 	},
 }
 
-//+kubebuilder:webhook:path=/mutate-hardware-profile,mutating=true,failurePolicy=fail,groups=kubeflow.org,resources=notebooks,verbs=create;update,versions=v1,name=hardwareprofile-notebook-injector.opendatahub.io,sideEffects=None,admissionReviewVersions=v1
-//+kubebuilder:webhook:path=/mutate-hardware-profile,mutating=true,failurePolicy=fail,groups=serving.kserve.io,resources=inferenceservices,verbs=create;update,versions=v1beta1,name=hardwareprofile-kserve-injector.opendatahub.io,sideEffects=None,admissionReviewVersions=v1
+//+kubebuilder:webhook:path=/mutate-hardware-profile-notebook,mutating=true,failurePolicy=fail,groups=kubeflow.org,resources=notebooks,verbs=create;update,versions=v1,name=hardwareprofile-notebook-injector.opendatahub.io,sideEffects=None,admissionReviewVersions=v1
+//+kubebuilder:webhook:path=/mutate-hardware-profile-isvc,mutating=true,failurePolicy=fail,groups=serving.kserve.io,resources=inferenceservices,verbs=create;update,versions=v1beta1,name=hardwareprofile-kserve-injector.opendatahub.io,sideEffects=None,admissionReviewVersions=v1
 //nolint:lll
 
 // Injector implements a mutating admission webhook for hardware profile injection.
@@ -81,8 +81,13 @@ var _ admission.Handler = &Injector{}
 func (i *Injector) SetupWithManager(mgr ctrl.Manager) error {
 	hookServer := mgr.GetWebhookServer()
 
-	// Register single webhook path for both Notebooks and InferenceServices
-	hookServer.Register("/mutate-hardware-profile", &webhook.Admission{
+	// Register separate webhook paths for Notebooks and InferenceServices
+	hookServer.Register("/mutate-hardware-profile-notebook", &webhook.Admission{
+		Handler:        i,
+		LogConstructor: webhookutils.NewWebhookLogConstructor(i.Name),
+	})
+
+	hookServer.Register("/mutate-hardware-profile-isvc", &webhook.Admission{
 		Handler:        i,
 		LogConstructor: webhookutils.NewWebhookLogConstructor(i.Name),
 	})


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->
Split hardware profile webhook into separate paths to fix routing conflict  
- changed /mutate-hardware-profile to /mutate-hardware-profile-isvc and /mutate-hardware-profile-notebook 
- Fixes hardware profile injection for InferenceService

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Created a custom image with the changes, deployed to a cluster and verified that hardware profile injection works for InferenceService.  
## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* Improvements
  * Split hardware profile mutation into two dedicated webhooks with separate endpoints for Notebooks and InferenceServices to improve routing and reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->