### PR TITLE
chore: skip HWP migration if dashboard HWP CRD missing

### DIFF
--- a/internal/controller/components/dashboard/dashboard_controller.go
+++ b/internal/controller/components/dashboard/dashboard_controller.go
@@ -94,7 +94,7 @@ func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.
 		), reconciler.WithPredicates(predicate.Funcs{
 			GenericFunc: func(tge event.TypedGenericEvent[client.Object]) bool { return false },
 			DeleteFunc:  func(tde event.TypedDeleteEvent[client.Object]) bool { return false },
-		}), reconciler.Dynamic()).
+		}), reconciler.Dynamic(reconciler.CrdExists(gvk.DashboardHardwareProfile))).
 		WithAction(initialize).
 		WithAction(devFlags).
 		WithAction(setKustomizedParams).


### PR DESCRIPTION
## Description
This PR updates the dashboard controller to gracefully skip the dashboard HWP to infra HWP migration action if the dashboard HWP is missing from the cluster.

## How Has This Been Tested?
I verified that the operator successfully and completely reconciles even if the dashboard HWP is missing from the cluster.

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [X] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [X] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work
- [X] The developer has run the integration test pipeline and verified that it passed successfully


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Migration and hardware-profile handling now skip when hardware-profile support is absent, preventing spurious failures and improving startup/upgrade stability.
  * Dynamic monitoring of hardware-profile resources is now conditional on those resources existing, reducing unnecessary watchers and error noise.

* **Tests**
  * Tests updated to cover scenarios where the hardware-profile resource is present, ensuring behavior is validated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->