### PR TITLE
RHOAIENG-34173: prevent secret data leakage in operator error logs

### DIFF
--- a/internal/controller/components/kserve/kserve_support.go
+++ b/internal/controller/components/kserve/kserve_support.go
@@ -208,7 +208,7 @@ func getIndexedResource(rs []unstructured.Unstructured, obj any, g schema.GroupV
 
 	err := runtime.DefaultUnstructuredConverter.FromUnstructured(rs[idx].Object, obj)
 	if err != nil {
-		return idx, fmt.Errorf("failed converting to %T from unstructured %v: %w", obj, rs[idx].Object, err)
+		return idx, fmt.Errorf("failed converting to %T from resource %s: %w", obj, resources.FormatObjectReference(&rs[idx]), err)
 	}
 
 	return idx, nil

--- a/pkg/resources/resources_test.go
+++ b/pkg/resources/resources_test.go
@@ -314,6 +314,35 @@ func TestObjectFromUnstructured(t *testing.T) {
 	})
 }
 
+func TestFormatObjectReference(t *testing.T) {
+	cases := []struct {
+		name      string
+		gvk       schema.GroupVersionKind
+		namespace string
+		objName   string
+		expected  string
+	}{
+		{name: "namespaced", gvk: gvk.Deployment, namespace: "myns", objName: "mydeploy", expected: "apps/v1, Kind=Deployment myns/mydeploy"},
+		{name: "cluster-scoped", gvk: gvk.ClusterRole, namespace: "", objName: "cluster-admin", expected: "rbac.authorization.k8s.io/v1, Kind=ClusterRole cluster-admin"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			u := &unstructured.Unstructured{}
+			u.SetGroupVersionKind(tc.gvk)
+			if tc.namespace != "" {
+				u.SetNamespace(tc.namespace)
+			}
+			u.SetName(tc.objName)
+
+			actual := resources.FormatObjectReference(u)
+			if actual != tc.expected {
+				t.Fatalf("unexpected reference: got %q, want %q", actual, tc.expected)
+			}
+		})
+	}
+}
+
 func TestHasCRD(t *testing.T) {
 	g := NewWithT(t)
 	ctx := t.Context()


### PR DESCRIPTION
### Problem
When KServe e2e tests use invalid secret names (like `&invalid-secret-name` in `kserve_test.go:589`), the operator logs the entire Secret object including sensitive data such as TLS certificates and private keys. This causes e2e test artifacts to hide the entire operator log to prevent credential exposure, making debugging extremely difficult.

### Root Cause
The `resources.Apply()` function logs the full unstructured object on patch failures using `fmt.Errorf("unable to patch object %s: %w", u, err)`, where the `%s` formatting of object `u` exposes the complete Secret data including base64-encoded certificates and keys.

### Solution
Simple fix: Remove the object `u` from the error message format string, keeping only the error details:
- **Before**: `fmt.Errorf("unable to patch object %s: %w", u, err)`
- **After**: `fmt.Errorf("unable to patch object: %w", err)`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a public helper that formats compact object references (GVK plus optional namespace/name) for messaging.

* **Style**
  * Replaced full-object payloads in error messages with the compact object reference for patching, status-patching, and conversion errors to avoid exposing sensitive data while preserving debugging context.

* **Tests**
  * Added unit tests validating compact reference formatting for namespaced and cluster-scoped resources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [X] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification:
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->
This PR updates log messages to ensure that no sensitive security information is exposed.