### PR TITLE
test: add cleanup when --fail-fast is used we still get leftover cleanup

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -91,6 +91,7 @@ linters:
         - kubernetes.Interface
         - gomega.AsyncAssertion
         - labels.Selector
+        - manager.Manager
     lll:
       line-length: 180
     nolintlint:

--- a/internal/controller/components/suite_test.go
+++ b/internal/controller/components/suite_test.go
@@ -62,6 +62,14 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 	Expect(cfg).NotTo(BeNil())
 
+	DeferCleanup(func() {
+		By("DeferCleanup: tearing down the test environment")
+		if testEnv != nil {
+			err := testEnv.Stop()
+			Expect(err).NotTo(HaveOccurred())
+		}
+	})
+
 	err = componentApi.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 

--- a/internal/controller/datasciencecluster/suite_test.go
+++ b/internal/controller/datasciencecluster/suite_test.go
@@ -63,6 +63,14 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 	Expect(cfg).NotTo(BeNil())
 
+	DeferCleanup(func() {
+		By("DeferCleanup: tearing down the test environment")
+		if testEnv != nil {
+			err := testEnv.Stop()
+			Expect(err).NotTo(HaveOccurred())
+		}
+	})
+
 	err = dscv1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 

--- a/internal/controller/dscinitialization/suite_test.go
+++ b/internal/controller/dscinitialization/suite_test.go
@@ -107,6 +107,17 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 	Expect(cfg).NotTo(BeNil())
 
+	DeferCleanup(func() {
+		By("DeferCleanup: cancelling context and tearing down test environment")
+		if gCancel != nil {
+			gCancel()
+		}
+		if testEnv != nil {
+			err := testEnv.Stop()
+			Expect(err).NotTo(HaveOccurred())
+		}
+	})
+
 	utilruntime.Must(clientgoscheme.AddToScheme(testScheme))
 	utilruntime.Must(dsciv1.AddToScheme(testScheme))
 	utilruntime.Must(dscv1.AddToScheme(testScheme))

--- a/internal/controller/services/suite_test.go
+++ b/internal/controller/services/suite_test.go
@@ -62,6 +62,14 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 	Expect(cfg).NotTo(BeNil())
 
+	DeferCleanup(func() {
+		By("DeferCleanup: tearing down the test environment")
+		if testEnv != nil {
+			err := testEnv.Stop()
+			Expect(err).NotTo(HaveOccurred())
+		}
+	})
+
 	err = serviceApi.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 

--- a/pkg/utils/test/envt/envt.go
+++ b/pkg/utils/test/envt/envt.go
@@ -262,8 +262,7 @@ func (et *EnvT) ReadFile(elem ...string) ([]byte, error) {
 }
 
 // Manager returns the controller-runtime manager for the test environment, if one was created.
-//
-//nolint:ireturn
+
 func (et *EnvT) Manager() manager.Manager {
 	return et.mgr
 }

--- a/tests/integration/features/features_suite_int_test.go
+++ b/tests/integration/features/features_suite_int_test.go
@@ -70,6 +70,13 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 	Expect(config).NotTo(BeNil())
 
+	DeferCleanup(func() {
+		By("DeferCleanup: tearing down the test environment")
+		if envTest != nil {
+			Expect(envTest.Stop()).To(Succeed())
+		}
+	})
+
 	err = featurev1.AddToScheme(testScheme)
 	Expect(err).NotTo(HaveOccurred())
 


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->
since we introduced --fail-fast in unit-test, there might be test stopped immedatily after the first failure, then 
var _ = AfterSuite(func() is not called as testEnv.stop() wont be called
this could left process where unit-test is runnng e.g local env.


<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully
