### PR TITLE
Remove duplicated reconciler crd existence check

### DIFF
--- a/internal/controller/components/kserve/kserve_controller.go
+++ b/internal/controller/components/kserve/kserve_controller.go
@@ -34,7 +34,6 @@ import (
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/api/components/v1alpha1"
 	dsciv1 "github.com/opendatahub-io/opendatahub-operator/v2/api/dscinitialization/v1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
-	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/deploy"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/gc"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/render/kustomize"
@@ -73,16 +72,16 @@ func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.
 		Owns(&appsv1.Deployment{}, reconciler.WithPredicates(resources.NewDeploymentPredicate())).
 
 		// operands - dynamically owned
-		OwnsGVK(gvk.IstioGateway, reconciler.Dynamic(actions.IfGVKInstalled(gvk.IstioGateway))).
-		OwnsGVK(gvk.EnvoyFilter, reconciler.Dynamic(actions.IfGVKInstalled(gvk.EnvoyFilter))).
-		OwnsGVK(gvk.KnativeServing, reconciler.Dynamic(actions.IfGVKInstalled(gvk.KnativeServing))).
-		OwnsGVK(gvk.ServiceMeshMember, reconciler.Dynamic(actions.IfGVKInstalled(gvk.ServiceMeshMember))).
-		OwnsGVK(gvk.AuthorizationPolicy, reconciler.Dynamic(actions.IfGVKInstalled(gvk.AuthorizationPolicy))).
-		OwnsGVK(gvk.AuthorizationPolicyv1beta1, reconciler.Dynamic(actions.IfGVKInstalled(gvk.AuthorizationPolicyv1beta1))).
-		OwnsGVK(gvk.InferencePoolV1alpha2, reconciler.Dynamic(actions.IfGVKInstalled(gvk.InferencePoolV1alpha2))).
-		OwnsGVK(gvk.InferenceModelV1alpha2, reconciler.Dynamic(actions.IfGVKInstalled(gvk.InferenceModelV1alpha2))).
-		OwnsGVK(gvk.LLMInferenceServiceConfigV1Alpha1, reconciler.Dynamic(actions.IfGVKInstalled(gvk.LLMInferenceServiceConfigV1Alpha1))).
-		OwnsGVK(gvk.LLMInferenceServiceV1Alpha1, reconciler.Dynamic(actions.IfGVKInstalled(gvk.LLMInferenceServiceV1Alpha1))).
+		OwnsGVK(gvk.IstioGateway, reconciler.Dynamic(reconciler.CrdExists(gvk.IstioGateway))).
+		OwnsGVK(gvk.EnvoyFilter, reconciler.Dynamic(reconciler.CrdExists(gvk.EnvoyFilter))).
+		OwnsGVK(gvk.KnativeServing, reconciler.Dynamic(reconciler.CrdExists(gvk.KnativeServing))).
+		OwnsGVK(gvk.ServiceMeshMember, reconciler.Dynamic(reconciler.CrdExists(gvk.ServiceMeshMember))).
+		OwnsGVK(gvk.AuthorizationPolicy, reconciler.Dynamic(reconciler.CrdExists(gvk.AuthorizationPolicy))).
+		OwnsGVK(gvk.AuthorizationPolicyv1beta1, reconciler.Dynamic(reconciler.CrdExists(gvk.AuthorizationPolicyv1beta1))).
+		OwnsGVK(gvk.InferencePoolV1alpha2, reconciler.Dynamic(reconciler.CrdExists(gvk.InferencePoolV1alpha2))).
+		OwnsGVK(gvk.InferenceModelV1alpha2, reconciler.Dynamic(reconciler.CrdExists(gvk.InferenceModelV1alpha2))).
+		OwnsGVK(gvk.LLMInferenceServiceConfigV1Alpha1, reconciler.Dynamic(reconciler.CrdExists(gvk.LLMInferenceServiceConfigV1Alpha1))).
+		OwnsGVK(gvk.LLMInferenceServiceV1Alpha1, reconciler.Dynamic(reconciler.CrdExists(gvk.LLMInferenceServiceV1Alpha1))).
 
 		// operands - watched
 		//

--- a/internal/controller/services/servicemesh/servicemesh_controller.go
+++ b/internal/controller/services/servicemesh/servicemesh_controller.go
@@ -13,7 +13,6 @@ import (
 	serviceApi "github.com/opendatahub-io/opendatahub-operator/v2/api/services/v1alpha1"
 	sr "github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/services/registry"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
-	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/deploy"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/render/template"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/predicates/dependent"
@@ -49,14 +48,14 @@ func (h *serviceHandler) NewReconciler(ctx context.Context, mgr ctrl.Manager) er
 		Owns(&corev1.ConfigMap{}).
 		// monitoring-related resources
 		OwnsGVK(gvk.PodMonitorServiceMesh,
-			reconciler.Dynamic(actions.IfGVKInstalled(gvk.PodMonitorServiceMesh))).
+			reconciler.Dynamic(reconciler.CrdExists(gvk.PodMonitorServiceMesh))).
 		OwnsGVK(gvk.ServiceMonitorServiceMesh,
-			reconciler.Dynamic(actions.IfGVKInstalled(gvk.ServiceMonitorServiceMesh))).
+			reconciler.Dynamic(reconciler.CrdExists(gvk.ServiceMonitorServiceMesh))).
 		// authorino-related resources
 		OwnsGVK(gvk.ServiceMeshMember,
-			reconciler.Dynamic(actions.IfGVKInstalled(gvk.ServiceMeshMember))).
+			reconciler.Dynamic(reconciler.CrdExists(gvk.ServiceMeshMember))).
 		OwnsGVK(gvk.Authorino,
-			reconciler.Dynamic(actions.IfGVKInstalled(gvk.Authorino)),
+			reconciler.Dynamic(reconciler.CrdExists(gvk.Authorino)),
 			reconciler.WithPredicates(dependent.Predicate{
 				WatchDelete: true,
 				WatchUpdate: true,
@@ -64,7 +63,7 @@ func (h *serviceHandler) NewReconciler(ctx context.Context, mgr ctrl.Manager) er
 			})).
 		// watch for SMCP readiness
 		WatchesGVK(gvk.ServiceMeshControlPlane,
-			reconciler.Dynamic(actions.IfGVKInstalled(gvk.ServiceMeshControlPlane)),
+			reconciler.Dynamic(reconciler.CrdExists(gvk.ServiceMeshControlPlane)),
 			reconciler.WithPredicates(NewSMCPReadyPredicate()),
 		).
 		WithAction(checkPreconditions).

--- a/pkg/controller/actions/actions_support.go
+++ b/pkg/controller/actions/actions_support.go
@@ -3,9 +3,6 @@ package actions
 import (
 	"context"
 
-	"k8s.io/apimachinery/pkg/runtime/schema"
-	ctrl "sigs.k8s.io/controller-runtime"
-
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
 	odhTypes "github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
 )
@@ -21,15 +18,4 @@ func OperatorNamespace(_ context.Context, _ *odhTypes.ReconciliationRequest) (st
 	}
 
 	return ns, nil
-}
-
-func IfGVKInstalled(kvg schema.GroupVersionKind) func(context.Context, *odhTypes.ReconciliationRequest) bool {
-	return func(ctx context.Context, rr *odhTypes.ReconciliationRequest) bool {
-		hasCRD, err := cluster.HasCRD(ctx, rr.Client, kvg)
-		if err != nil {
-			ctrl.Log.Error(err, "error checking if CRD installed", "GVK", kvg)
-			return false
-		}
-		return hasCRD
-	}
 }


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description

There were two different functions performing the same check. To avoid duplication/ambiguity, in this PR I kept only one of them.

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [x] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification:
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->
This is a code refactor of already tested code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized controller gating to rely on CRD existence across multiple integrations, unifying dynamic ownership and watch behavior.

* **Chores**
  * Removed a deprecated gating helper and unused imports, simplifying internal dependencies.

* **Bug Fixes**
  * Improved reliability when optional CRDs are absent, reducing unnecessary reconciliations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->