### PR TITLE
RHOAIENG-34261: Enable structured YAML for metrics exporters

### DIFF
--- a/api/services/v1alpha1/monitoring_types.go
+++ b/api/services/v1alpha1/monitoring_types.go
@@ -51,13 +51,15 @@ type Metrics struct {
 	// +kubebuilder:validation:Minimum=0
 	Replicas int32 `json:"replicas,omitempty"`
 	// Exporters defines custom metrics exporters for sending metrics to external observability tools.
-	// Each key-value pair represents an exporter name and its configuration.
+	// Each key represents the exporter name, and the value contains the exporter configuration.
+	// The configuration follows the OpenTelemetry Collector exporter format.
 	// Reserved names 'prometheus' and 'otlp/tempo' cannot be used as they conflict with built-in exporters.
+	// Maximum 10 exporters allowed, each config must be less than 10KB (enforced at reconciliation time).
 	// +optional
 	// +kubebuilder:validation:XValidation:rule="!('prometheus' in self)",message="exporter name 'prometheus' is reserved and cannot be used"
 	// +kubebuilder:validation:XValidation:rule="!('otlp/tempo' in self)",message="exporter name 'otlp/tempo' is reserved and cannot be used"
-	// +kubebuilder:validation:XValidation:rule="self.all(k, self[k] != '')",message="exporter configuration values must be non-empty strings"
-	Exporters map[string]string `json:"exporters,omitempty"`
+	// +kubebuilder:validation:XValidation:rule="size(self) <= 10",message="maximum 10 exporters allowed"
+	Exporters map[string]runtime.RawExtension `json:"exporters,omitempty"`
 }
 
 // MetricsStorage defines the storage configuration for the monitoring service

--- a/api/services/v1alpha1/zz_generated.deepcopy.go
+++ b/api/services/v1alpha1/zz_generated.deepcopy.go
@@ -272,9 +272,9 @@ func (in *Metrics) DeepCopyInto(out *Metrics) {
 	}
 	if in.Exporters != nil {
 		in, out := &in.Exporters, &out.Exporters
-		*out = make(map[string]string, len(*in))
+		*out = make(map[string]runtime.RawExtension, len(*in))
 		for key, val := range *in {
-			(*out)[key] = val
+			(*out)[key] = *val.DeepCopy()
 		}
 	}
 }

--- a/bundle/manifests/dscinitialization.opendatahub.io_dscinitializations.yaml
+++ b/bundle/manifests/dscinitialization.opendatahub.io_dscinitializations.yaml
@@ -128,11 +128,14 @@ spec:
                     properties:
                       exporters:
                         additionalProperties:
-                          type: string
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
                         description: |-
                           Exporters defines custom metrics exporters for sending metrics to external observability tools.
-                          Each key-value pair represents an exporter name and its configuration.
+                          Each key represents the exporter name, and the value contains the exporter configuration.
+                          The configuration follows the OpenTelemetry Collector exporter format.
                           Reserved names 'prometheus' and 'otlp/tempo' cannot be used as they conflict with built-in exporters.
+                          Maximum 10 exporters allowed, each config must be less than 10KB (enforced at reconciliation time).
                         type: object
                         x-kubernetes-validations:
                         - message: exporter name 'prometheus' is reserved and cannot
@@ -141,9 +144,8 @@ spec:
                         - message: exporter name 'otlp/tempo' is reserved and cannot
                             be used
                           rule: '!(''otlp/tempo'' in self)'
-                        - message: exporter configuration values must be non-empty
-                            strings
-                          rule: self.all(k, self[k] != '')
+                        - message: maximum 10 exporters allowed
+                          rule: size(self) <= 10
                       replicas:
                         description: |-
                           Replicas specifies the number of replicas in monitoringstack. If not set, it defaults
@@ -631,11 +633,14 @@ spec:
                     properties:
                       exporters:
                         additionalProperties:
-                          type: string
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
                         description: |-
                           Exporters defines custom metrics exporters for sending metrics to external observability tools.
-                          Each key-value pair represents an exporter name and its configuration.
+                          Each key represents the exporter name, and the value contains the exporter configuration.
+                          The configuration follows the OpenTelemetry Collector exporter format.
                           Reserved names 'prometheus' and 'otlp/tempo' cannot be used as they conflict with built-in exporters.
+                          Maximum 10 exporters allowed, each config must be less than 10KB (enforced at reconciliation time).
                         type: object
                         x-kubernetes-validations:
                         - message: exporter name 'prometheus' is reserved and cannot
@@ -644,9 +649,8 @@ spec:
                         - message: exporter name 'otlp/tempo' is reserved and cannot
                             be used
                           rule: '!(''otlp/tempo'' in self)'
-                        - message: exporter configuration values must be non-empty
-                            strings
-                          rule: self.all(k, self[k] != '')
+                        - message: maximum 10 exporters allowed
+                          rule: size(self) <= 10
                       replicas:
                         description: |-
                           Replicas specifies the number of replicas in monitoringstack. If not set, it defaults

--- a/bundle/manifests/services.platform.opendatahub.io_monitorings.yaml
+++ b/bundle/manifests/services.platform.opendatahub.io_monitorings.yaml
@@ -65,11 +65,14 @@ spec:
                 properties:
                   exporters:
                     additionalProperties:
-                      type: string
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
                     description: |-
                       Exporters defines custom metrics exporters for sending metrics to external observability tools.
-                      Each key-value pair represents an exporter name and its configuration.
+                      Each key represents the exporter name, and the value contains the exporter configuration.
+                      The configuration follows the OpenTelemetry Collector exporter format.
                       Reserved names 'prometheus' and 'otlp/tempo' cannot be used as they conflict with built-in exporters.
+                      Maximum 10 exporters allowed, each config must be less than 10KB (enforced at reconciliation time).
                     type: object
                     x-kubernetes-validations:
                     - message: exporter name 'prometheus' is reserved and cannot be
@@ -78,8 +81,8 @@ spec:
                     - message: exporter name 'otlp/tempo' is reserved and cannot be
                         used
                       rule: '!(''otlp/tempo'' in self)'
-                    - message: exporter configuration values must be non-empty strings
-                      rule: self.all(k, self[k] != '')
+                    - message: maximum 10 exporters allowed
+                      rule: size(self) <= 10
                   replicas:
                     description: |-
                       Replicas specifies the number of replicas in monitoringstack. If not set, it defaults

--- a/config/crd/bases/dscinitialization.opendatahub.io_dscinitializations.yaml
+++ b/config/crd/bases/dscinitialization.opendatahub.io_dscinitializations.yaml
@@ -117,11 +117,14 @@ spec:
                     properties:
                       exporters:
                         additionalProperties:
-                          type: string
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
                         description: |-
                           Exporters defines custom metrics exporters for sending metrics to external observability tools.
-                          Each key-value pair represents an exporter name and its configuration.
+                          Each key represents the exporter name, and the value contains the exporter configuration.
+                          The configuration follows the OpenTelemetry Collector exporter format.
                           Reserved names 'prometheus' and 'otlp/tempo' cannot be used as they conflict with built-in exporters.
+                          Maximum 10 exporters allowed, each config must be less than 10KB (enforced at reconciliation time).
                         type: object
                         x-kubernetes-validations:
                         - message: exporter name 'prometheus' is reserved and cannot
@@ -130,9 +133,8 @@ spec:
                         - message: exporter name 'otlp/tempo' is reserved and cannot
                             be used
                           rule: '!(''otlp/tempo'' in self)'
-                        - message: exporter configuration values must be non-empty
-                            strings
-                          rule: self.all(k, self[k] != '')
+                        - message: maximum 10 exporters allowed
+                          rule: size(self) <= 10
                       replicas:
                         description: |-
                           Replicas specifies the number of replicas in monitoringstack. If not set, it defaults
@@ -620,11 +622,14 @@ spec:
                     properties:
                       exporters:
                         additionalProperties:
-                          type: string
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
                         description: |-
                           Exporters defines custom metrics exporters for sending metrics to external observability tools.
-                          Each key-value pair represents an exporter name and its configuration.
+                          Each key represents the exporter name, and the value contains the exporter configuration.
+                          The configuration follows the OpenTelemetry Collector exporter format.
                           Reserved names 'prometheus' and 'otlp/tempo' cannot be used as they conflict with built-in exporters.
+                          Maximum 10 exporters allowed, each config must be less than 10KB (enforced at reconciliation time).
                         type: object
                         x-kubernetes-validations:
                         - message: exporter name 'prometheus' is reserved and cannot
@@ -633,9 +638,8 @@ spec:
                         - message: exporter name 'otlp/tempo' is reserved and cannot
                             be used
                           rule: '!(''otlp/tempo'' in self)'
-                        - message: exporter configuration values must be non-empty
-                            strings
-                          rule: self.all(k, self[k] != '')
+                        - message: maximum 10 exporters allowed
+                          rule: size(self) <= 10
                       replicas:
                         description: |-
                           Replicas specifies the number of replicas in monitoringstack. If not set, it defaults

--- a/config/crd/bases/services.platform.opendatahub.io_monitorings.yaml
+++ b/config/crd/bases/services.platform.opendatahub.io_monitorings.yaml
@@ -65,11 +65,14 @@ spec:
                 properties:
                   exporters:
                     additionalProperties:
-                      type: string
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
                     description: |-
                       Exporters defines custom metrics exporters for sending metrics to external observability tools.
-                      Each key-value pair represents an exporter name and its configuration.
+                      Each key represents the exporter name, and the value contains the exporter configuration.
+                      The configuration follows the OpenTelemetry Collector exporter format.
                       Reserved names 'prometheus' and 'otlp/tempo' cannot be used as they conflict with built-in exporters.
+                      Maximum 10 exporters allowed, each config must be less than 10KB (enforced at reconciliation time).
                     type: object
                     x-kubernetes-validations:
                     - message: exporter name 'prometheus' is reserved and cannot be
@@ -78,8 +81,8 @@ spec:
                     - message: exporter name 'otlp/tempo' is reserved and cannot be
                         used
                       rule: '!(''otlp/tempo'' in self)'
-                    - message: exporter configuration values must be non-empty strings
-                      rule: self.all(k, self[k] != '')
+                    - message: maximum 10 exporters allowed
+                      rule: size(self) <= 10
                   replicas:
                     description: |-
                       Replicas specifies the number of replicas in monitoringstack. If not set, it defaults

--- a/docs/api-overview.md
+++ b/docs/api-overview.md
@@ -2647,7 +2647,7 @@ _Appears in:_
 | `storage` _[MetricsStorage](#metricsstorage)_ |  |  |  |
 | `resources` _[MetricsResources](#metricsresources)_ |  |  |  |
 | `replicas` _integer_ | Replicas specifies the number of replicas in monitoringstack. If not set, it defaults<br />to 1 on single-node clusters and 2 on multi-node clusters. |  | Minimum: 0 <br /> |
-| `exporters` _object (keys:string, values:string)_ | Exporters defines custom metrics exporters for sending metrics to external observability tools.<br />Each key-value pair represents an exporter name and its configuration.<br />Reserved names 'prometheus' and 'otlp/tempo' cannot be used as they conflict with built-in exporters. |  |  |
+| `exporters` _object (keys:string, values:[RawExtension](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#rawextension-runtime-pkg))_ | Exporters defines custom metrics exporters for sending metrics to external observability tools.<br />Each key represents the exporter name, and the value contains the exporter configuration.<br />The configuration follows the OpenTelemetry Collector exporter format.<br />Reserved names 'prometheus' and 'otlp/tempo' cannot be used as they conflict with built-in exporters.<br />Maximum 10 exporters allowed, each config must be less than 10KB (enforced at reconciliation time). |  |  |
 
 
 #### MetricsResources

--- a/internal/controller/services/monitoring/monitoring_controller_support_test.go
+++ b/internal/controller/services/monitoring/monitoring_controller_support_test.go
@@ -2,6 +2,7 @@
 package monitoring
 
 import (
+	"fmt"
 	"reflect"
 	"strings"
 	"testing"
@@ -25,6 +26,45 @@ import (
 	odhtypes "github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
 	testScheme "github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/scheme"
 )
+
+// stringToRawExtension converts a YAML string to a runtime.RawExtension for testing.
+func stringToRawExtension(yamlStr string) runtime.RawExtension {
+	return runtime.RawExtension{Raw: []byte(yamlStr)}
+}
+
+// generateLargeConfig creates a YAML config with the specified number of fields for testing.
+func generateLargeConfig(numFields int) string {
+	fields := make([]string, 0, numFields)
+	for i := range numFields {
+		fields = append(fields, fmt.Sprintf("field%d: value%d", i, i))
+	}
+	return strings.Join(fields, "\n")
+}
+
+// generateDeepNestedConfig creates a deeply nested YAML config for testing.
+func generateDeepNestedConfig(depth int) string {
+	config := "endpoint: http://example.com"
+	for i := range depth {
+		config = fmt.Sprintf("level%d:\n  %s", i, strings.ReplaceAll(config, "\n", "\n  "))
+	}
+	return config
+}
+
+// generateLargeArrayConfig creates a YAML config with a large array for testing.
+func generateLargeArrayConfig(arraySize int) string {
+	items := make([]string, 0, arraySize)
+	for i := range arraySize {
+		items = append(items, fmt.Sprintf("- item%d", i))
+	}
+	return fmt.Sprintf("items:\n%s", strings.Join(items, "\n"))
+}
+
+// generateLargeSizeConfig generates a config that exceeds the size limit.
+func generateLargeSizeConfig(targetSize int) string {
+	// Create a config with a large string value to exceed size limit
+	largeValue := strings.Repeat("a", targetSize)
+	return fmt.Sprintf("endpoint: https://example.com\nlarge_field: %s", largeValue)
+}
 
 func TestGetTemplateDataAcceleratorMetrics(t *testing.T) {
 	ctx := t.Context()
@@ -127,201 +167,376 @@ func TestGetTemplateDataAcceleratorMetrics(t *testing.T) {
 	}
 }
 
+// runMetricsExporterTest creates a test environment and runs getTemplateData.
+func runMetricsExporterTest(t *testing.T, exporters map[string]runtime.RawExtension) (map[string]interface{}, error) {
+	t.Helper()
+	mon := &serviceApi.Monitoring{
+		Spec: serviceApi.MonitoringSpec{
+			MonitoringCommonSpec: serviceApi.MonitoringCommonSpec{
+				Namespace: "test-namespace",
+				Metrics: &serviceApi.Metrics{
+					Exporters: exporters,
+				},
+			},
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, dsciv2.AddToScheme(scheme))
+	require.NoError(t, serviceApi.AddToScheme(scheme))
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	rr := &odhtypes.ReconciliationRequest{
+		Client:   fakeClient,
+		Instance: mon,
+		DSCI: &dsciv2.DSCInitialization{
+			Spec: dsciv2.DSCInitializationSpec{
+				ApplicationsNamespace: "test-app-namespace",
+			},
+		},
+	}
+
+	return getTemplateData(t.Context(), rr)
+}
+
+// validateMetricsExporterResult validates test results against expected values.
+func validateMetricsExporterResult(t *testing.T, tt struct {
+	name                 string
+	exporters            map[string]runtime.RawExtension
+	expectError          bool
+	errorMsg             string
+	expectedParsedConfig map[string]string
+	expectedNames        []string
+}, templateData map[string]interface{}, err error) {
+	t.Helper()
+
+	if tt.expectError {
+		if err == nil {
+			t.Errorf("Expected error but got none")
+		} else if !strings.Contains(err.Error(), tt.errorMsg) {
+			t.Errorf("Expected error to contain '%s', got: %v", tt.errorMsg, err)
+		}
+		return
+	}
+
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+		return
+	}
+
+	exporters, ok := templateData["MetricsExporters"]
+	if !ok {
+		t.Error("MetricsExporters should always be in template data")
+		return
+	}
+	exporterMap, ok := exporters.(map[string]string)
+	if !ok {
+		t.Error("MetricsExporters should be a map[string]string")
+		return
+	}
+	names, ok := templateData["MetricsExporterNames"]
+	if !ok {
+		t.Error("MetricsExporterNames should always be in template data")
+		return
+	}
+	namesList, ok := names.([]string)
+	if !ok {
+		t.Error("MetricsExporterNames should be a []string")
+		return
+	}
+
+	if tt.expectedParsedConfig == nil && tt.expectedNames == nil {
+		if len(exporterMap) != 0 {
+			t.Errorf("Expected empty exporters map for early return case, got %+v", exporterMap)
+		}
+		if len(namesList) != 0 {
+			t.Errorf("Expected empty names list for early return case, got %+v", namesList)
+		}
+		return
+	}
+
+	if tt.expectedParsedConfig != nil {
+		if len(exporterMap) != len(tt.expectedParsedConfig) {
+			t.Errorf("Expected %d exporters, got %d", len(tt.expectedParsedConfig), len(exporterMap))
+		}
+		if len(namesList) != len(tt.expectedNames) {
+			t.Errorf("Expected %d exporter names, got %d", len(tt.expectedNames), len(namesList))
+		}
+		if !reflect.DeepEqual(exporterMap, tt.expectedParsedConfig) {
+			t.Errorf("Parsed configuration doesn't match expected.\nGot: %+v\nExpected: %+v", exporterMap, tt.expectedParsedConfig)
+		}
+	}
+
+	if tt.expectedNames != nil {
+		if len(namesList) != len(tt.expectedNames) {
+			t.Fatalf("Expected %d exporter names, got %d", len(tt.expectedNames), len(namesList))
+		}
+		for i := range tt.expectedNames {
+			if namesList[i] != tt.expectedNames[i] {
+				t.Fatalf("Exporter names not sorted as expected.\nExpected: %v\nActual:   %v", tt.expectedNames, namesList)
+			}
+		}
+	}
+}
+
 func TestCustomMetricsExporters(t *testing.T) {
 	tests := []struct {
 		name                 string
-		exporters            map[string]string
+		exporters            map[string]runtime.RawExtension
 		expectError          bool
 		errorMsg             string
-		expectedParsedConfig map[string]interface{} // Add expected parsed output
-		expectedNames        []string               // Add expected names
+		expectedParsedConfig map[string]string // YAML strings like traces
+		expectedNames        []string          // Add expected names
 	}{
 		{
 			name: "valid custom exporters",
-			exporters: map[string]string{
-				"logging":     "loglevel: debug",
-				"otlp/jaeger": "endpoint: http://jaeger:4317\ntls:\n  insecure: true",
+			exporters: map[string]runtime.RawExtension{
+				"debug":       stringToRawExtension("verbosity: detailed"),
+				"otlp/jaeger": stringToRawExtension("endpoint: https://jaeger:4317\ntls:\n  insecure: false"),
 			},
 			expectError: false,
-			expectedParsedConfig: map[string]interface{}{
-				"logging": map[string]interface{}{
-					"loglevel": "debug",
-				},
-				"otlp/jaeger": map[string]interface{}{
-					"endpoint": "http://jaeger:4317",
-					"tls": map[string]interface{}{
-						"insecure": true,
-					},
-				},
+			expectedParsedConfig: map[string]string{
+				"debug":       "verbosity: detailed",
+				"otlp/jaeger": "endpoint: https://jaeger:4317\ntls:\n    insecure: false",
 			},
-			expectedNames: []string{"logging", "otlp/jaeger"}, // Note: sorted order
+			expectedNames: []string{"debug", "otlp/jaeger"}, // Note: sorted order
 		},
 		{
-			name:                 "empty exporters map",
-			exporters:            map[string]string{},
-			expectError:          false,
-			expectedParsedConfig: map[string]interface{}{},
-			expectedNames:        []string{},
+			name:        "empty exporters map",
+			exporters:   map[string]runtime.RawExtension{},
+			expectError: false,
+			// addExportersData now always sets template data (consistent with traces)
+			expectedParsedConfig: map[string]string{}, // Empty but set
+			expectedNames:        []string{},          // Empty but set
 		},
 		{
-			name:                 "nil exporters (metrics defined but no exporters)",
-			exporters:            nil,
-			expectError:          false,
-			expectedParsedConfig: map[string]interface{}{},
-			expectedNames:        []string{},
+			name:        "nil exporters (metrics defined but no exporters)",
+			exporters:   nil,
+			expectError: false,
+			// addExportersData now always sets template data (consistent with traces)
+			expectedParsedConfig: map[string]string{}, // Empty but set
+			expectedNames:        []string{},          // Empty but set
 		},
 		{
 			name: "reserved name prometheus",
-			exporters: map[string]string{
-				"prometheus": "endpoint: http://example.com",
+			exporters: map[string]runtime.RawExtension{
+				"prometheus": stringToRawExtension("endpoint: http://example.com"),
 			},
 			expectError: true,
 			errorMsg:    "reserved",
 		},
 		{
 			name: "reserved name otlp/tempo",
-			exporters: map[string]string{
-				"otlp/tempo": "endpoint: http://tempo.example.com",
+			exporters: map[string]runtime.RawExtension{
+				"otlp/tempo": stringToRawExtension("endpoint: http://tempo.example.com"),
 			},
 			expectError: true,
 			errorMsg:    "reserved",
 		},
 		{
 			name: "invalid YAML",
-			exporters: map[string]string{
-				"logging": "loglevel: [unclosed",
+			exporters: map[string]runtime.RawExtension{
+				"debug": stringToRawExtension("verbosity: [unclosed"),
 			},
 			expectError: true,
-			errorMsg:    "invalid YAML",
+			errorMsg:    "failed to unmarshal exporter config",
 		},
 		{
 			name: "empty YAML string",
-			exporters: map[string]string{
-				"logging": "",
+			exporters: map[string]runtime.RawExtension{
+				"debug": stringToRawExtension(""),
 			},
-			expectError: true,
-			errorMsg:    "must be a YAML mapping/object",
+			expectError:          false,               // validateExporters skips empty configs
+			expectedParsedConfig: map[string]string{}, // Empty but set
+			expectedNames:        []string{},
 		},
 		{
 			name: "whitespace-only YAML string",
-			exporters: map[string]string{
-				"logging": "   \n  ",
+			exporters: map[string]runtime.RawExtension{
+				"debug": stringToRawExtension("   \n  "),
 			},
-			expectError: true,
-			errorMsg:    "must be a YAML mapping/object",
+			expectError: false, // validateExporters parses whitespace as empty map
+			expectedParsedConfig: map[string]string{
+				"debug": "{}",
+			},
+			expectedNames: []string{"debug"},
 		},
 		{
 			name: "scalar YAML (not object)",
-			exporters: map[string]string{
-				"logging": "debug", // This is a scalar, not an object
+			exporters: map[string]runtime.RawExtension{
+				"debug": stringToRawExtension("debug"), // This is a scalar, not an object
 			},
 			expectError: true,
-			errorMsg:    "must be a YAML mapping/object",
+			errorMsg:    "failed to unmarshal exporter config",
 		},
 		{
 			name: "list YAML (not object)",
-			exporters: map[string]string{
-				"logging": "- endpoint: http://example:4317",
+			exporters: map[string]runtime.RawExtension{
+				"debug": stringToRawExtension("- endpoint: http://example:4317"),
 			},
 			expectError: true,
-			errorMsg:    "must be a YAML mapping/object",
+			errorMsg:    "failed to unmarshal exporter config",
+		},
+		{
+			name: "config with too many fields",
+			exporters: map[string]runtime.RawExtension{
+				"debug": stringToRawExtension(generateLargeConfig(51)), // Exceeds maxConfigFields (50)
+			},
+			expectError: true,
+			errorMsg:    "has too many fields",
+		},
+		{
+			name: "config with too deep nesting",
+			exporters: map[string]runtime.RawExtension{
+				"debug": stringToRawExtension(generateDeepNestedConfig(11)), // Exceeds maxNestingDepth (10)
+			},
+			expectError: true,
+			errorMsg:    "config nesting too deep",
+		},
+		{
+			name: "config with string value too long",
+			exporters: map[string]runtime.RawExtension{
+				"debug": stringToRawExtension(fmt.Sprintf("endpoint: %s", strings.Repeat("a", 1025))), // Exceeds maxStringLength (1024)
+			},
+			expectError: true,
+			errorMsg:    "string value too long",
+		},
+		{
+			name: "config with array too long",
+			exporters: map[string]runtime.RawExtension{
+				"debug": stringToRawExtension(generateLargeArrayConfig(101)), // Exceeds maxArrayLength (100)
+			},
+			expectError: true,
+			errorMsg:    "array too long",
+		},
+		{
+			name: "schema validation - missing required field",
+			exporters: map[string]runtime.RawExtension{
+				"otlp/test": stringToRawExtension("headers:\n  auth: token"), // Missing required 'endpoint'
+			},
+			expectError: true,
+			errorMsg:    "missing required field: endpoint",
+		},
+		{
+			name: "schema validation - disallowed field",
+			exporters: map[string]runtime.RawExtension{
+				"otlp/test": stringToRawExtension("endpoint: https://example.com\ninvalid_field: value"),
+			},
+			expectError: true,
+			errorMsg:    "contains disallowed field: invalid_field",
+		},
+		{
+			name: "schema validation - invalid compression",
+			exporters: map[string]runtime.RawExtension{
+				"otlp/test": stringToRawExtension("endpoint: https://example.com\ncompression: invalid"),
+			},
+			expectError: true,
+			errorMsg:    "must be one of [gzip snappy zstd none]",
+		},
+		{
+			name: "schema validation - invalid verbosity",
+			exporters: map[string]runtime.RawExtension{
+				"debug": stringToRawExtension("verbosity: invalid"),
+			},
+			expectError: true,
+			errorMsg:    "must be one of [basic normal detailed]",
+		},
+		{
+			name: "schema validation - insecure endpoint blocked",
+			exporters: map[string]runtime.RawExtension{
+				"otlp/test": stringToRawExtension("endpoint: http://external-service.com"),
+			},
+			expectError: true,
+			errorMsg:    "insecure HTTP endpoints not allowed for external services",
+		},
+		{
+			name: "schema validation - localhost HTTP allowed",
+			exporters: map[string]runtime.RawExtension{
+				"otlp/test": stringToRawExtension("endpoint: http://localhost:4317"),
+			},
+			expectError: false,
+			expectedParsedConfig: map[string]string{
+				"otlp/test": "endpoint: http://localhost:4317",
+			},
+			expectedNames: []string{"otlp/test"},
+		},
+		{
+			name: "invalid exporter name - component ID format",
+			exporters: map[string]runtime.RawExtension{
+				"123invalid": stringToRawExtension("endpoint: https://example.com"), // Invalid: starts with number
+			},
+			expectError: true,
+			errorMsg:    "must match OpenTelemetry component ID format",
+		},
+		{
+			name: "invalid exporter name - special characters",
+			exporters: map[string]runtime.RawExtension{
+				"bad@name": stringToRawExtension("endpoint: https://example.com"), // Invalid: contains @
+			},
+			expectError: true,
+			errorMsg:    "must match OpenTelemetry component ID format",
+		},
+		{
+			name: "invalid endpoint URL pattern",
+			exporters: map[string]runtime.RawExtension{
+				"otlp/test": stringToRawExtension("endpoint: not-a-url"), // Invalid URL format
+			},
+			expectError: true,
+			errorMsg:    "does not match required pattern",
+		},
+		{
+			name: "field type mismatch - endpoint as number",
+			exporters: map[string]runtime.RawExtension{
+				"otlp/test": stringToRawExtension("endpoint: 12345"), // Should be string, not number
+			},
+			expectError: true,
+			errorMsg:    "expected string",
+		},
+		{
+			name: "exporter size exceeds 10KB limit",
+			exporters: map[string]runtime.RawExtension{
+				"otlp/test": stringToRawExtension(generateLargeSizeConfig(11000)), // Exceeds 10KB
+			},
+			expectError: true,
+			errorMsg:    "exceeds maximum size",
+		},
+		{
+			name: "total exporter size exceeds 50KB limit",
+			exporters: map[string]runtime.RawExtension{
+				"otlp/test1": stringToRawExtension(generateLargeSizeConfig(20000)),
+				"otlp/test2": stringToRawExtension(generateLargeSizeConfig(20000)),
+				"otlp/test3": stringToRawExtension(generateLargeSizeConfig(20000)), // Total > 50KB
+			},
+			expectError: true,
+			errorMsg:    "total exporter config size exceeds maximum",
+		},
+		{
+			name: "prometheusremotewrite exporter validation",
+			exporters: map[string]runtime.RawExtension{
+				"prometheusremotewrite": stringToRawExtension(`endpoint: https://prometheus.example.com/api/v1/write
+headers:
+  authorization: "Bearer token123"
+tls:
+  insecure: false`),
+			},
+			expectError: false,
+			expectedParsedConfig: map[string]string{
+				"prometheusremotewrite": `endpoint: https://prometheus.example.com/api/v1/write
+headers:
+    authorization: Bearer token123
+tls:
+    insecure: false`,
+			},
+			expectedNames: []string{"prometheusremotewrite"},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			mon := &serviceApi.Monitoring{
-				Spec: serviceApi.MonitoringSpec{
-					MonitoringCommonSpec: serviceApi.MonitoringCommonSpec{
-						Namespace: "test-namespace",
-						Metrics: &serviceApi.Metrics{
-							Exporters: tt.exporters,
-						},
-					},
-				},
-			}
+			templateData, err := runMetricsExporterTest(t, tt.exporters)
 
-			// Create fake client
-			scheme := runtime.NewScheme()
-			require.NoError(t, dsciv2.AddToScheme(scheme))
-			require.NoError(t, serviceApi.AddToScheme(scheme))
-
-			fakeClient := fake.NewClientBuilder().
-				WithScheme(scheme).
-				Build()
-
-			rr := &odhtypes.ReconciliationRequest{
-				Client:   fakeClient,
-				Instance: mon,
-				DSCI: &dsciv2.DSCInitialization{
-					Spec: dsciv2.DSCInitializationSpec{
-						ApplicationsNamespace: "test-app-namespace",
-					},
-				},
-			}
-
-			templateData, err := getTemplateData(t.Context(), rr)
-
-			if tt.expectError {
-				if err == nil {
-					t.Errorf("Expected error but got none")
-				} else if !strings.Contains(err.Error(), tt.errorMsg) {
-					t.Errorf("Expected error to contain '%s', got: %v", tt.errorMsg, err)
-				}
-			} else {
-				if err != nil {
-					t.Errorf("Unexpected error: %v", err)
-				}
-
-				// Always verify template data exists (even if empty)
-				exporters, ok := templateData["MetricsExporters"]
-				if !ok {
-					t.Error("MetricsExporters should always be in template data")
-					return
-				}
-				exporterMap, ok := exporters.(map[string]interface{})
-				if !ok {
-					t.Error("MetricsExporters should be a map[string]interface{}")
-					return
-				}
-				names, ok := templateData["MetricsExporterNames"]
-				if !ok {
-					t.Error("MetricsExporterNames should always be in template data")
-					return
-				}
-				namesList, ok := names.([]string)
-				if !ok {
-					t.Error("MetricsExporterNames should be a []string")
-					return
-				}
-
-				// For cases with actual exporters, verify content
-				if tt.expectedParsedConfig != nil {
-					// Validate counts match expected
-					if len(exporterMap) != len(tt.expectedParsedConfig) {
-						t.Errorf("Expected %d exporters, got %d", len(tt.expectedParsedConfig), len(exporterMap))
-					}
-					if len(namesList) != len(tt.expectedNames) {
-						t.Errorf("Expected %d exporter names, got %d", len(tt.expectedNames), len(namesList))
-					}
-					// Validate parsed configuration matches expected (deep comparison)
-					if !reflect.DeepEqual(exporterMap, tt.expectedParsedConfig) {
-						t.Errorf("Parsed configuration doesn't match expected.\nGot: %+v\nExpected: %+v", exporterMap, tt.expectedParsedConfig)
-					}
-				}
-
-				// Names are expected to be sorted deterministically
-				if tt.expectedNames != nil {
-					if len(namesList) != len(tt.expectedNames) {
-						t.Fatalf("Expected %d exporter names, got %d", len(tt.expectedNames), len(namesList))
-					}
-					for i := range tt.expectedNames {
-						if namesList[i] != tt.expectedNames[i] {
-							t.Fatalf("Exporter names not sorted as expected.\nExpected: %v\nActual:   %v", tt.expectedNames, namesList)
-						}
-					}
-				}
-			}
+			validateMetricsExporterResult(t, tt, templateData, err)
 		})
 	}
 }
@@ -697,6 +912,56 @@ func TestMonitoringStackThanosQuerierIntegration(t *testing.T) {
 
 			validateConditions(t, rr, tt)
 			validateTemplates(t, rr, tt, initialTemplateCount)
+		})
+	}
+}
+
+func TestIsLocalServiceEndpoint(t *testing.T) {
+	tests := []struct {
+		name     string
+		endpoint string
+		expected bool
+	}{
+		// Localhost variants
+		{"localhost with port", "http://localhost:4317", true},
+		{"localhost without port", "http://localhost", true},
+		{"loopback IPv4", "http://127.0.0.1:4317", true},
+		{"loopback IPv6", "http://[::1]:4317", true},
+
+		// Cluster-local services
+		{"full cluster domain", "http://service.namespace.svc.cluster.local:4317", true},
+		{"short cluster domain", "http://service.namespace.svc:4317", true},
+		{"single-label service", "http://custom-backend:4317", true},
+		{"single-label without port", "http://prometheus", true},
+
+		// External services (should be false)
+		{"external FQDN", "http://example.com:4317", false},
+		{"external subdomain", "http://metrics.example.com", false},
+		{"external HTTPS", "https://external-service.com:4317", false},
+		{"IP address", "http://192.168.1.100:4317", false},
+
+		// Security: External URLs with .svc in path should NOT be treated as local
+		{"malicious: .svc in path", "http://attacker.com/foo.svc", false},
+		{"malicious: .svc.cluster.local in path", "http://evil.com/api/.svc.cluster.local", false},
+		{"malicious: .svc in query", "http://attacker.com?param=.svc", false},
+
+		// Security: External URLs with localhost/loopback in path/query should NOT be treated as local
+		{"malicious: localhost in path", "http://evil.com/api/localhost", false},
+		{"malicious: 127.0.0.1 in path", "http://attacker.com/redirect/127.0.0.1", false},
+		{"malicious: ::1 in query", "http://bad.com?target=::1", false},
+
+		// Security: External IPv6 addresses should NOT be treated as local
+		{"malicious: external IPv6", "http://[2001:4860:4860::8888]:4317", false},
+		{"malicious: external IPv6 no port", "http://[2001:db8::1]", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := isLocalServiceEndpoint(tt.endpoint)
+			if result != tt.expected {
+				t.Errorf("isLocalServiceEndpoint(%q) = %v, expected %v",
+					tt.endpoint, result, tt.expected)
+			}
 		})
 	}
 }

--- a/internal/controller/services/monitoring/resources/opentelemetry-collector.tmpl.yaml
+++ b/internal/controller/services/monitoring/resources/opentelemetry-collector.tmpl.yaml
@@ -141,7 +141,7 @@ spec:
       {{- if .MetricsExporterNames }}
       {{- range .MetricsExporterNames }}
       {{ . }}:
-{{ index $.MetricsExporters . | toYaml | nindent 8 }}
+{{ index $.MetricsExporters . | indent 8 }}
       {{- end }}
       {{- end }}
       {{- end }}

--- a/tests/e2e/monitoring_test.go
+++ b/tests/e2e/monitoring_test.go
@@ -941,8 +941,15 @@ func withNoCollectorReplicas() testf.TransformFn {
 // withCustomMetricsExporters returns a transform that sets custom metrics exporters.
 func withCustomMetricsExporters() testf.TransformFn {
 	return testf.Transform(`.spec.monitoring.metrics.exporters = {
-		"debug": "verbosity: detailed",
-        "%s": "endpoint: http://custom-backend:4317\ntls:\n  insecure: true"
+		"debug": {
+			"verbosity": "detailed"
+		},
+        "%s": {
+			"endpoint": "http://custom-backend:4317",
+			"tls": {
+				"insecure": true
+			}
+		}
 	}`, OtlpCustomExporter)
 }
 


### PR DESCRIPTION

<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->
Fix inconsistency between metrics and traces exporters by enabling structured YAML for metrics.

**Changes:**
- Updated Metrics.Exporters from map[string]string to map[string]runtime.RawExtension
- Unified controller logic to reuse existing traces validation
- Updated tests to use structured YAML and debug exporter



https://issues.redhat.com/browse/RHOAIENG-34261
## How Has This Been Tested?
* Ran tests
* Deployed cluster in managed mode: Built custom operator image and deployed to OpenShift cluster
* Added structured YAML metrics config to DSCI:
```yaml
exporters:
  debug:
    verbosity: detailed
  otlphttp/custom:
    endpoint: "http://custom-backend:4318"
    headers:
      api-key: "test-key"
```
* Verified data-science-collector and opendatahub-operator pods: No errors, structured YAML configs generated correctly
* Validated reserved name blocking and Confirmed structured YAML configs generate correctly (fixing the UX inconsistency vs traces)
* verified E2E test passes with structured YAML format
## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Exporter configs now accept structured objects in OpenTelemetry Collector format for metrics and traces.
  - Added in-cluster/local endpoint detection for exporter endpoints.

- Improvements
  - Enforced limits: up to 10 exporters; each config <10KB (checked at reconcile).
  - Stronger validation: type, depth, size, name-format checks; reserved names blocked.
  - Deterministic exporter ordering and improved exporter rendering in generated configs.

- Tests
  - Expanded unit and e2e tests covering size, depth, schema, endpoint, and YAML cases.

- Documentation
  - API and CRD docs updated to reflect format and constraints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->