### PR TITLE
chore: logging webhook for notebook with HWProfile

### DIFF
--- a/internal/webhook/hardwareprofile/integration_test.go
+++ b/internal/webhook/hardwareprofile/integration_test.go
@@ -310,7 +310,7 @@ func testNonExistentHardwareProfile(g Gomega, ctx context.Context, k8sClient cli
 	// This should fail because the hardware profile doesn't exist
 	err := k8sClient.Create(ctx, notebook)
 	g.Expect(err).Should(HaveOccurred())
-	g.Expect(err.Error()).Should(ContainSubstring("failed to get hardware profile 'nonexistent-profile'"))
+	g.Expect(err.Error()).Should(ContainSubstring("hardware profile 'nonexistent-profile' not found"))
 }
 
 // testCrossNamespaceHardwareProfile tests webhook behavior when hardware profile is in a different namespace.

--- a/internal/webhook/hardwareprofile/mutating_test.go
+++ b/internal/webhook/hardwareprofile/mutating_test.go
@@ -196,7 +196,7 @@ func TestHardwareProfile_DeniesWhenProfileNotFound(t *testing.T) {
 
 	resp := injector.Handle(ctx, req)
 	g.Expect(resp.Allowed).Should(BeFalse())
-	g.Expect(resp.Result.Message).Should(ContainSubstring("failed to get hardware profile 'nonexistent'"))
+	g.Expect(resp.Result.Message).Should(ContainSubstring("hardware profile 'nonexistent' not found"))
 }
 
 // TestHardwareProfile_ResourceInjection_Notebook tests that hardware profiles with resource requirements are applied correctly to Notebook workloads.
@@ -880,7 +880,7 @@ func TestHardwareProfile_ErrorPaths(t *testing.T) {
 			injector:      createWebhookInjector(fake.NewClientBuilder().WithScheme(sch).Build(), sch),
 			workload:      envtestutil.NewNotebook(testNotebook, testNamespace, envtestutil.WithHardwareProfile("non-existent")),
 			expectAllowed: false,
-			expectMessage: "failed to get hardware profile 'non-existent'",
+			expectMessage: "hardware profile 'non-existent' not found",
 		},
 		{
 			name: "empty hardware profile configuration",

--- a/tests/e2e/test_context_test.go
+++ b/tests/e2e/test_context_test.go
@@ -1414,10 +1414,11 @@ func (tc *TestContext) createInstallPlan(name string, ns string, csvNames []stri
 //   - operationType (string): A descriptive name for the operation type.
 //   - ro (*ResourceOptions): Resource options containing validation criteria.
 func (tc *TestContext) validateWebhookError(g Gomega, err error, operationType string, ro *ResourceOptions) {
-	// Expect the error to be a Forbidden (HTTP 403) from the webhook validation
-	g.Expect(k8serr.IsForbidden(err)).To(BeTrue(),
+	// admission.Denied() returns HTTP 403 Forbidden, admission.Errored() returns 400/500
+	isValidWebhookError := k8serr.IsForbidden(err) || k8serr.IsBadRequest(err) || k8serr.IsInternalError(err)
+	g.Expect(isValidWebhookError).To(BeTrue(),
 		defaultErrorMessageIfNone(
-			"Expected Forbidden error from webhook validation for %s, got: %v",
+			"Expected webhook validation error (403 Forbidden, 400 Bad Request, or 500 Internal Server Error) for %s, got: %v",
 			[]any{operationType, err},
 			ro.CustomErrorArgs,
 		)...)


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->
- different for not able to find HWProfile VS client Get() failed

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification:
not code change

#### E2E update requirement opt-out justification:
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Webhook error handling refined: missing hardware profiles now return 400 Bad Request with a clear "hardware profile '<name>' not found" message; other retrieval errors return 500 Internal Server Error. Logging improved to include request context for traceability.

* **Tests**
  * Unit, integration, and e2e tests updated to expect and accept the new webhook error semantics (400, 500 — and 403 still accepted in e2e) and the revised not-found messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->