### PR TITLE
Add clusterrole for allowedgroups

### DIFF
--- a/internal/controller/services/auth/auth_controller_actions.go
+++ b/internal/controller/services/auth/auth_controller_actions.go
@@ -122,7 +122,7 @@ func bindClusterRole(ctx context.Context, rr *odhtypes.ReconciliationRequest, gr
 	}
 	err := rr.AddResources(crb)
 	if err != nil {
-		return errors.New("error creating RoleBinding for group")
+		return errors.New("error creating ClusterRoleBinding for group")
 	}
 
 	return nil

--- a/internal/controller/services/auth/auth_controller_actions.go
+++ b/internal/controller/services/auth/auth_controller_actions.go
@@ -43,11 +43,11 @@ func initialize(ctx context.Context, rr *odhtypes.ReconciliationRequest) error {
 		},
 		{
 			FS:   resourcesFS,
-			Path: AllowedGroupRoleTemplate,
+			Path: AdminGroupClusterRoleTemplate,
 		},
 		{
 			FS:   resourcesFS,
-			Path: AdminGroupClusterRoleTemplate,
+			Path: AllowedGroupClusterRoleTemplate,
 		},
 	}
 
@@ -144,7 +144,7 @@ func managePermissions(ctx context.Context, rr *odhtypes.ReconciliationRequest) 
 		return err
 	}
 
-	err = bindRole(ctx, rr, ai.Spec.AllowedGroups, "allowedgroup-rolebinding", "allowedgroup-role")
+	err = bindClusterRole(ctx, rr, ai.Spec.AllowedGroups, "allowedgroupcluster-rolebinding", "allowedgroupcluster-role")
 	if err != nil {
 		return err
 	}

--- a/internal/controller/services/auth/auth_controller_actions_test.go
+++ b/internal/controller/services/auth/auth_controller_actions_test.go
@@ -36,8 +36,8 @@ func TestInitialize(t *testing.T) {
 	// Verify templates were added
 	g.Expect(rr.Templates).To(HaveLen(3))
 	g.Expect(rr.Templates[0].Path).To(Equal(AdminGroupRoleTemplate))
-	g.Expect(rr.Templates[1].Path).To(Equal(AllowedGroupRoleTemplate))
-	g.Expect(rr.Templates[2].Path).To(Equal(AdminGroupClusterRoleTemplate))
+	g.Expect(rr.Templates[1].Path).To(Equal(AdminGroupClusterRoleTemplate))
+	g.Expect(rr.Templates[2].Path).To(Equal(AllowedGroupClusterRoleTemplate))
 }
 
 // TestBindRoleValidation validates the security filtering logic in the bindRole function.
@@ -172,7 +172,7 @@ func TestManagePermissionsBasic(t *testing.T) {
 	err := managePermissions(ctx, rr)
 	g.Expect(err).ToNot(HaveOccurred(), "Should create all required RBAC resources")
 
-	// Verify resources were created (3 total: 2 RoleBindings + 1 ClusterRoleBinding)
+	// Verify resources were created (3 total: 1 RoleBindings + 2 ClusterRoleBinding)
 	g.Expect(rr.Resources).To(HaveLen(3), "Should create 3 RBAC resources")
 
 	// Count different resource types
@@ -188,8 +188,8 @@ func TestManagePermissionsBasic(t *testing.T) {
 		}
 	}
 
-	g.Expect(roleBindings).To(Equal(2), "Should create 2 RoleBindings")
-	g.Expect(clusterRoleBindings).To(Equal(1), "Should create 1 ClusterRoleBinding")
+	g.Expect(roleBindings).To(Equal(1), "Should create 1 RoleBindings")
+	g.Expect(clusterRoleBindings).To(Equal(2), "Should create 2 ClusterRoleBinding")
 }
 
 // TestManagePermissionsInvalidInstance validates error handling when the controller

--- a/internal/controller/services/auth/auth_controller_support.go
+++ b/internal/controller/services/auth/auth_controller_support.go
@@ -5,9 +5,9 @@ import (
 )
 
 const (
-	AdminGroupRoleTemplate        = "resources/admingroup-role.tmpl.yaml"
-	AllowedGroupRoleTemplate      = "resources/allowedgroup-role.tmpl.yaml"
-	AdminGroupClusterRoleTemplate = "resources/admingroup-clusterrole.tmpl.yaml"
+	AdminGroupRoleTemplate          = "resources/admingroup-role.tmpl.yaml"
+	AdminGroupClusterRoleTemplate   = "resources/admingroup-clusterrole.tmpl.yaml"
+	AllowedGroupClusterRoleTemplate = "resources/allowedgroup-clusterrole.tmpl.yaml"
 )
 
 //go:embed resources

--- a/internal/controller/services/auth/resources/allowedgroup-clusterrole.tmpl.yaml
+++ b/internal/controller/services/auth/resources/allowedgroup-clusterrole.tmpl.yaml
@@ -1,8 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
+kind: ClusterRole
 metadata:
-  name: allowedgroup-role
-  namespace: {{.DSCI.Spec.ApplicationsNamespace}}
+  name: allowedgroupcluster-role
 rules:
 - apiGroups:
   - services.platform.opendatahub.io
@@ -13,7 +12,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - services.opendatahub.io
+  - services.platform.opendatahub.io
   resources:
   - auths/status
   verbs:

--- a/tests/e2e/authcontroller_test.go
+++ b/tests/e2e/authcontroller_test.go
@@ -27,16 +27,16 @@ const (
 	systemAuthenticatedGroup = "system:authenticated"
 
 	// Role names used for RBAC configuration.
-	adminGroupRoleName   = "admingroup-role"
-	allowedGroupRoleName = "allowedgroup-role"
+	adminGroupRoleName = "admingroup-role"
 
 	// RoleBinding names to bind roles to specific groups.
-	adminGroupRoleBindingName   = "admingroup-rolebinding"
-	allowedGroupRoleBindingName = "allowedgroup-rolebinding"
+	adminGroupRoleBindingName = "admingroup-rolebinding"
 
 	// ClusterRole and ClusterRoleBinding names for admin group access at cluster level.
-	adminGroupClusterRoleName        = "admingroupcluster-role"
-	adminGroupClusterRoleBindingName = "admingroupcluster-rolebinding"
+	adminGroupClusterRoleName          = "admingroupcluster-role"
+	adminGroupClusterRoleBindingName   = "admingroupcluster-rolebinding"
+	allowedGroupClusterRoleName        = "allowedgroupcluster-role"
+	allowedGroupClusterRoleBindingName = "allowedgroupcluster-rolebinding"
 )
 
 type AuthControllerTestCtx struct {
@@ -97,22 +97,24 @@ func (tc *AuthControllerTestCtx) ValidateAuthSystemInitialization(t *testing.T) 
 	)
 
 	// 2. Validate RBAC infrastructure - Roles are created
-	roles := []string{adminGroupRoleName, allowedGroupRoleName}
+	roles := []string{adminGroupRoleName}
 	for _, roleName := range roles {
 		tc.validateRBACResource(gvk.Role, roleName)
 	}
 
 	// 3. Validate RBAC infrastructure - RoleBindings are created
-	roleBindings := []string{adminGroupRoleBindingName, allowedGroupRoleBindingName}
+	roleBindings := []string{adminGroupRoleBindingName}
 	for _, roleBinding := range roleBindings {
 		tc.validateRBACResource(gvk.RoleBinding, roleBinding)
 	}
 
 	// 4. Validate cluster-level RBAC infrastructure - ClusterRole is created
 	tc.validateRBACResource(gvk.ClusterRole, adminGroupClusterRoleName)
+	tc.validateRBACResource(gvk.ClusterRole, allowedGroupClusterRoleName)
 
 	// 5. Validate cluster-level RBAC infrastructure - ClusterRoleBinding is created
 	tc.validateRBACResource(gvk.ClusterRoleBinding, adminGroupClusterRoleBindingName)
+	tc.validateRBACResource(gvk.ClusterRoleBinding, allowedGroupClusterRoleBindingName)
 }
 
 // ValidateAddingGroups adds groups and validates.
@@ -137,7 +139,7 @@ func (tc *AuthControllerTestCtx) ValidateAddingGroups(t *testing.T) {
 		WithCondition(jq.Match(`.subjects | map(.name) | index("%s") != null`, testAdminGroup)))
 	tc.validateRBACResource(gvk.ClusterRoleBinding, adminGroupClusterRoleBindingName,
 		WithCondition(jq.Match(`.subjects | map(.name) | index("%s") != null`, testAdminGroup)))
-	tc.validateRBACResource(gvk.RoleBinding, allowedGroupRoleBindingName,
+	tc.validateRBACResource(gvk.ClusterRoleBinding, allowedGroupClusterRoleBindingName,
 		WithCondition(jq.Match(`.subjects | map(.name) | index("%s") != null`, testAllowedGroup)))
 }
 

--- a/tests/e2e/authcontroller_test.go
+++ b/tests/e2e/authcontroller_test.go
@@ -32,7 +32,7 @@ const (
 	// RoleBinding names to bind roles to specific groups.
 	adminGroupRoleBindingName = "admingroup-rolebinding"
 
-	// ClusterRole and ClusterRoleBinding names for admin group access at cluster level.
+	// ClusterRole and ClusterRoleBinding names for group access at cluster level.
 	adminGroupClusterRoleName          = "admingroupcluster-role"
 	adminGroupClusterRoleBindingName   = "admingroupcluster-rolebinding"
 	allowedGroupClusterRoleName        = "allowedgroupcluster-role"


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->
The dashboard team want to use an SAR for the allowedgroup. Currently a namespaced role is added to the allowedgroups, we also need a clusterrole so the dashboard can do an SAR to check that the user can view the auth resource which is a cluster scoped resource.
<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- Deploy the operator
- Validate that the auth resource exists and the default system:authenticated is in the allowedgroups list.
- Validate that the `allowedgroupcluster-rolebinding` exists.
- Validate that the `allowedgroupcluster-role` exists and contains the required permissions, ie, Get, list, watch for auth resources.
- Validate that the `system:authenticated` group is listed in the rolebinding.
- Add a new group to the allowedgroup list.
- Validate the group is correctly added to the `allowedgroupcluster-rolebinding`.

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [ ] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification:
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a cluster-wide "Allowed Group" role and switched allowed-group bindings to cluster-scoped for broader access.

- **Chores**
  - Revised RBAC template/constant usage and adjusted initialization to emit RBAC resources in a new order.

- **Tests**
  - Updated unit and e2e tests to validate cluster-level role and cluster-scoped bindings and adjusted assertions.

- **Bug Fixes**
  - Corrected binding error messaging to reference cluster-scoped bindings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->