### PR TITLE
fix: limit e2e update requirement check GH action only to the main branch and improve docs/error outputs

### DIFF
--- a/.github/workflows/check-e2e-update-requirement.yaml
+++ b/.github/workflows/check-e2e-update-requirement.yaml
@@ -9,6 +9,7 @@ on:
       - 'internal/**'
       - 'pkg/**'
       - 'cmd/main.go'
+    branches: [ 'main' ]
 
 permissions:
   contents: read
@@ -101,7 +102,7 @@ jobs:
               console.log(`Justification found in PR description: ${prDescriptionHasJustification}`);
               
               if (!prDescriptionHasJustification) {
-                console.log('❌ FAILURE: PR author opted-out of the E2E test suite update requirement, but no justification was found in PR description');
+                console.log('❌ FAILURE: PR author opted-out of the E2E test suite update requirement, but no justification was found in PR description. A GitHub bot will add a comment on the PR with error report and instructions on how to proceed...');
                 checkResult = {
                   status: 'failure',
                   reason: 'PR author opted-out of the E2E test suite update requirement, but no justification was found in PR description',
@@ -121,7 +122,7 @@ jobs:
             } else {
               // skip e2e update requirement checkbox is not checked
               // => verify e2e tests were added/updated
-              console.log('Requirement to update E2E test suite was is not set to be skipped, checking for e2e test updates in the PR...');
+              console.log('Requirement to update E2E test suite was not set to be skipped, checking for e2e test updates in the PR...');
               
               const { data: files } = await github.rest.pulls.listFiles({
                 owner,
@@ -139,7 +140,7 @@ jobs:
               console.log('Modified files:', files.map(f => f.filename).join(', '));
               
               if (!e2eFilesModified) {
-                console.log('❌ FAILURE: No e2e tests updated and skip checkbox not checked');
+                console.log('❌ FAILURE: No e2e tests updated and skip checkbox not checked. A GitHub bot will add a comment on the PR with error report and instructions on how to proceed...');
                 checkResult = {
                   status: 'failure',
                   reason: 'No e2e tests updated and skip checkbox not checked',

--- a/.github/workflows/comment-on-e2e-check.yaml
+++ b/.github/workflows/comment-on-e2e-check.yaml
@@ -87,7 +87,7 @@ jobs:
 
             **Action required from the PR author:**
             1. Edit the PR description and add your justification in the `#### E2E update requirement opt-out justification` section
-               - **Note:** In case you deleted the `### E2E test suite update requirement` part of the original template description (or any of it subparts), you can find the original template in `.github/PULL_REQUEST_TEMPLATE.md`, and restore the deleted part from there
+               - **Note:** In case your PR description does not adhere to our PR template and is missing the `### E2E test suite update requirement` section (or any of its subsections), you can find the original PR template in `.github/PULL_REQUEST_TEMPLATE.md`, and restore the missing section from there
             2. Submit the PR description changes. This will automatically re-trigger the check
 
             **For more info, please refer to:** [workflow run details](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.event.workflow_run.id }})
@@ -108,7 +108,7 @@ jobs:
             2. Evaluate the possibility of opting-out of this requirement:
                1. Inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md), to determine if the nature of the PR changes allows for skipping this requirement
                2. If opt-out is applicable, please proceed to provide justification in the PR description (`#### E2E update requirement opt-out justification:` section)
-                  - **Note:** In case you previously deleted the `### E2E test suite update requirement` part of the original template description (or any of it subparts), you can find the original template in `.github/PULL_REQUEST_TEMPLATE.md`, and restore the deleted part from there
+                  - **Note:** In case your PR description does not adhere to our PR template and is missing the `### E2E test suite update requirement` section (or any of its subsections), you can find the original PR template in `.github/PULL_REQUEST_TEMPLATE.md`, and restore the missing section from there
                3. After adding the justification, check the "Skip requirement to update E2E test suite for this PR" checkbox
                4. Submit/save changes to the PR description. The check will be triggered automatically and should pass
 

--- a/docs/e2e-update-requirement-guidelines.md
+++ b/docs/e2e-update-requirement-guidelines.md
@@ -24,10 +24,10 @@ It is possible to opt-out of this check with proper justification. Please refer 
 - Changes affecting user workflows or UI
 
 ### Opt-out guide
-**Note:** This particular guide is also present in the PR template/description
+**Note:** This particular guide is also present in the default PR template description. In case you are looking to opt-out of the requirement, **it is highly recommended that your PR description adheres to the default PR template** - particularly, please keep the `### E2E test suite update requirement` section and set it up according to the steps below
 
 1. Inspect the above-mentioned guidelines, to determine if the nature of the PR changes allows for skipping this requirement
 2. Provide justification in the PR description under the `#### E2E update requirement opt-out justification` section
-   - **Note:** In case you previusly deleted the `### E2E test suite update requirement` part of the original template description (or any of it subparts), you can find the original template in `.github/PULL_REQUEST_TEMPLATE.md`, and restore the deleted part from there
+   - **Note:** In case your PR description does not adhere to our PR template and is missing the `### E2E test suite update requirement` section (or any of its subsections), you can find the original PR template in `.github/PULL_REQUEST_TEMPLATE.md`, and restore the missing section from there
 3. Check the `Skip requirement to update E2E test suite for this PR` checkbox
 4. Submit/save these changes to the PR description. This will automatically trigger the check.


### PR DESCRIPTION
follow-up to #2426

## Description
- explicitly limits this action to be triggered only on PRs targeted to `main`
- various improvements to documentation and error outputs related to this GH action