### PR TITLE
test: increase resource timeout and fix dsc debug

### DIFF
--- a/tests/e2e/components_test.go
+++ b/tests/e2e/components_test.go
@@ -104,6 +104,7 @@ func (tc *ComponentTestCtx) ValidateComponentDisabled(t *testing.T) {
 				}.AsSelector(),
 			},
 		),
+		WithEventuallyTimeout(tc.TestTimeouts.mediumEventuallyTimeout),
 	)
 
 	// Ensure that the resources associated with the component do not exist

--- a/tests/e2e/debug_utils_test.go
+++ b/tests/e2e/debug_utils_test.go
@@ -598,7 +598,7 @@ func debugDSCIStatus() {
 	// Check DSCI (prerequisite for DSC)
 	dsci := &unstructured.Unstructured{}
 	dsci.SetGroupVersionKind(gvk.DSCInitialization)
-	err := globalDebugClient.Get(context.TODO(), types.NamespacedName{Name: "default-dsci"}, dsci)
+	err := globalDebugClient.Get(context.TODO(), types.NamespacedName{Name: dsciInstanceName}, dsci)
 	if err != nil && !errors.IsNotFound(err) {
 		log.Printf("Failed to get DSCI: %v", err)
 		return
@@ -615,7 +615,7 @@ func debugDSCIStatus() {
 	// Check DSC (singleton resource - depends on DSCI)
 	dsc := &unstructured.Unstructured{}
 	dsc.SetGroupVersionKind(gvk.DataScienceCluster)
-	err = globalDebugClient.Get(context.TODO(), types.NamespacedName{Name: "default-dsc"}, dsc)
+	err = globalDebugClient.Get(context.TODO(), types.NamespacedName{Name: dscInstanceName}, dsc)
 	if err != nil && !errors.IsNotFound(err) {
 		log.Printf("Failed to get DSC: %v", err)
 		return

--- a/tests/e2e/monitoring_test.go
+++ b/tests/e2e/monitoring_test.go
@@ -717,7 +717,7 @@ func (tc *MonitoringTestCtx) ValidateMonitoringServiceDisabled(t *testing.T) {
 	// Verify MonitoringStack is deleted
 	tc.EnsureResourcesGone(
 		WithMinimalObject(gvk.MonitoringStack, types.NamespacedName{Name: MonitoringStackName, Namespace: tc.MonitoringNamespace}),
-		WithEventuallyTimeout(tc.TestTimeouts.mediumEventuallyTimeout),
+		WithEventuallyTimeout(tc.TestTimeouts.longEventuallyTimeout),
 		WithCustomErrorMsg("MonitoringStack should be deleted when metrics and alerting are removed"),
 	)
 
@@ -979,7 +979,7 @@ func withMetricsConfig() testf.TransformFn {
             "retention": "%s"
         },
         "resources": {
-            "cpurequest": "%s", 
+            "cpurequest": "%s",
             "memoryrequest": "%s"
         },
         "replicas": %d

--- a/tests/e2e/test_context_test.go
+++ b/tests/e2e/test_context_test.go
@@ -234,16 +234,6 @@ func (tc *TestContext) EnsureResourceExistsConsistently(opts ...ResourceOpts) *u
 
 // EventuallyResourceCreatedOrUpdated ensures that a given Kubernetes resource exists.
 // If the resource is missing, it will be created; if it already exists, it will be updated
-// using the provided mutation function. Conditions in ResourceOpts are evaluated with eventually.
-//
-// Parameters:
-//   - opts (...ResourceOpts): Optional functional arguments that customize the behavior of the operation.
-//
-// Returns:
-//   - *unstructured.Unstructured: The existing or newly created (updated) resource object.
-//
-// EventuallyResourceCreatedOrUpdated ensures that a given Kubernetes resource exists.
-// If the resource is missing, it will be created; if it already exists, it will be updated
 // using the provided mutation function. This function retries until the operation succeeds.
 //
 // Behavior is controlled by the following optional flags:


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description

Experienced some e2e runs where the problem is the presence in the cluster of deleted resources:

- https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/opendatahub-io_opendatahub-operator/2468/pull-ci-opendatahub-io-opendatahub-operator-main-opendatahub-operator-e2e/1968953856947654656
- https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/opendatahub-io_opendatahub-operator/2483/pull-ci-opendatahub-io-opendatahub-operator-main-opendatahub-operator-e2e/1968953948857438208
- https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/opendatahub-io_opendatahub-operator/2471/pull-ci-opendatahub-io-opendatahub-operator-main-opendatahub-operator-e2e/1969022431163060224

Furthermore, fixes e2e dcs and dsci debug logs and typo.