### PR TITLE
Revert "update: temp. disable e2e test on dashboard"

### DIFF
--- a/tests/e2e/controller_test.go
+++ b/tests/e2e/controller_test.go
@@ -116,7 +116,7 @@ var (
 		name:    "components",
 		enabled: true,
 		scenarios: map[string]TestFn{
-			//	componentApi.DashboardComponentName:            dashboardTestSuite,
+			componentApi.DashboardComponentName:            dashboardTestSuite,
 			componentApi.RayComponentName:                  rayTestSuite,
 			componentApi.ModelRegistryComponentName:        modelRegistryTestSuite,
 			componentApi.TrustyAIComponentName:             trustyAITestSuite,

--- a/tests/e2e/creation_test.go
+++ b/tests/e2e/creation_test.go
@@ -54,7 +54,7 @@ func dscManagementTestSuite(t *testing.T) {
 		{"Validate creation of DSCInitialization instance", dscTestCtx.ValidateDSCICreation},
 		{"Validate creation of DataScienceCluster instance", dscTestCtx.ValidateDSCCreation},
 		{"Validate ServiceMeshSpec in DSCInitialization instance", dscTestCtx.ValidateServiceMeshSpecInDSCI},
-		// {"Validate VAP/VAPB creation after DSCI creation", dscTestCtx.ValidateVAPCreationAfterDSCI},
+		{"Validate VAP/VAPB creation after DSCI creation", dscTestCtx.ValidateVAPCreationAfterDSCI},
 		{"Validate Knative resource", dscTestCtx.ValidateKnativeSpecInDSC},
 		{"Validate owned namespaces exist", dscTestCtx.ValidateOwnedNamespacesAllExist},
 		{"Validate default NetworkPolicy exist", dscTestCtx.ValidateDefaultNetworkPolicyExists},

--- a/tests/e2e/dashboard_test.go
+++ b/tests/e2e/dashboard_test.go
@@ -5,11 +5,13 @@ import (
 	"testing"
 
 	"github.com/rs/xid"
+	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	k8slabels "k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/api/components/v1alpha1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/metadata/annotations"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/metadata/labels"
@@ -23,32 +25,32 @@ type DashboardTestCtx struct {
 	*ComponentTestCtx
 }
 
-// func dashboardTestSuite(t *testing.T) {
-// 	t.Helper()
+func dashboardTestSuite(t *testing.T) {
+	t.Helper()
 
-// 	ct, err := NewComponentTestCtx(t, &componentApi.Dashboard{})
-// 	require.NoError(t, err)
+	ct, err := NewComponentTestCtx(t, &componentApi.Dashboard{})
+	require.NoError(t, err)
 
-// 	componentCtx := DashboardTestCtx{
-// 		ComponentTestCtx: ct,
-// 	}
+	componentCtx := DashboardTestCtx{
+		ComponentTestCtx: ct,
+	}
 
-// 	// Define test cases.
-// 	testCases := []TestCase{
-// 		{"Validate component enabled", componentCtx.ValidateComponentEnabled},
-// 		{"Validate operands have OwnerReferences", componentCtx.ValidateOperandsOwnerReferences},
-// 		{"Validate update operand resources", componentCtx.ValidateUpdateDeploymentsResources},
-// 		{"Validate dynamically watches operands", componentCtx.ValidateOperandsDynamicallyWatchedResources},
-// 		{"Validate CRDs reinstated", componentCtx.ValidateCRDReinstated},
-// 		{"Validate hardware profile creation blocked by VAP", componentCtx.ValidateHardwareProfileCreationBlockedByVAP},
-// 		{"Validate accelerator profile creation blocked by VAP", componentCtx.ValidateAcceleratorProfileCreationBlockedByVAP},
-// 		{"Validate resource deletion recovery", componentCtx.ValidateAllDeletionRecovery},
-// 		{"Validate component disabled", componentCtx.ValidateComponentDisabled},
-// 	}
+	// Define test cases.
+	testCases := []TestCase{
+		{"Validate component enabled", componentCtx.ValidateComponentEnabled},
+		{"Validate operands have OwnerReferences", componentCtx.ValidateOperandsOwnerReferences},
+		{"Validate update operand resources", componentCtx.ValidateUpdateDeploymentsResources},
+		{"Validate dynamically watches operands", componentCtx.ValidateOperandsDynamicallyWatchedResources},
+		{"Validate CRDs reinstated", componentCtx.ValidateCRDReinstated},
+		{"Validate hardware profile creation blocked by VAP", componentCtx.ValidateHardwareProfileCreationBlockedByVAP},
+		{"Validate accelerator profile creation blocked by VAP", componentCtx.ValidateAcceleratorProfileCreationBlockedByVAP},
+		{"Validate resource deletion recovery", componentCtx.ValidateAllDeletionRecovery},
+		{"Validate component disabled", componentCtx.ValidateComponentDisabled},
+	}
 
-// 	// Run the test suite.
-// 	RunTestCases(t, testCases)
-// }
+	// Run the test suite.
+	RunTestCases(t, testCases)
+}
 
 // ValidateOperandsDynamicallyWatchedResources ensures that operands are correctly watched for dynamic updates.
 func (tc *DashboardTestCtx) ValidateOperandsDynamicallyWatchedResources(t *testing.T) {

--- a/tests/e2e/monitoring_test.go
+++ b/tests/e2e/monitoring_test.go
@@ -88,7 +88,7 @@ func monitoringTestSuite(t *testing.T) {
 		{"Test Metrics MonitoringStack CR Creation", monitoringServiceCtx.ValidateMonitoringStackCRMetricsWhenSet},
 		{"Test Metrics MonitoringStack CR Configuration", monitoringServiceCtx.ValidateMonitoringStackCRMetricsConfiguration},
 		{"Test Metrics Replicas Configuration", monitoringServiceCtx.ValidateMonitoringStackCRMetricsReplicasUpdate},
-		// {"Test Prometheus rules lifecycle", monitoringServiceCtx.ValidatePrometheusRulesLifecycle},
+		{"Test Prometheus rules lifecycle", monitoringServiceCtx.ValidatePrometheusRulesLifecycle},
 		{"Test TempoMonolithic CR Creation with PV backend", monitoringServiceCtx.ValidateTempoMonolithicCRCreation},
 		{"Test TempoStack CR Creation with Cloud Storage", monitoringServiceCtx.ValidateTempoStackCRCreationWithCloudStorage},
 		{"Test OpenTelemetry Collector Configurations", monitoringServiceCtx.ValidateOpenTelemetryCollectorConfigurations},


### PR DESCRIPTION
Reverts opendatahub-io/opendatahub-operator#2499


dashboard fix is in, we should keep testing dashboard on our main

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Re-enabled several e2e test cases and suites (Dashboard scenarios, DSC creation VAP/VAPB validation, Prometheus rules lifecycle).
  - Previously skipped cases now run as part of regular test execution.
  - Expands automated coverage and improves regression detection while preserving existing test behavior and filtering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->