### PR TITLE
chore: e2e update requirement GH action: edit regex for justification section title, ensure guidelines are consistent

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -39,6 +39,6 @@ To opt-out of this requirement:
 - [ ] Skip requirement to update E2E test suite for this PR
 4. Submit/save these changes to the PR description. This will automatically trigger the check.
 
-#### E2E update requirement opt-out justification:
+#### E2E update requirement opt-out justification
 <!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
 <!--- This section can be left empty if you're not opting out of the E2E requirement -->

--- a/.github/workflows/check-e2e-update-requirement.yaml
+++ b/.github/workflows/check-e2e-update-requirement.yaml
@@ -64,7 +64,7 @@ jobs:
               
               const validateJustification = (text) => {
                 // Create regex for the PR description title level (#### is used in PR description)
-                const titleRegex = new RegExp(`^\\s*####\\s*E2E update requirement opt-out justification:\\s*$`, 'im');
+                const titleRegex = new RegExp(`^\\s*####\\s*E2E update requirement opt-out justification\\s*:?\\s*$`, 'im');
                 const titleMatch = text.match(titleRegex);
                 
                 if (!titleMatch) {
@@ -76,7 +76,7 @@ jobs:
                 const contentAfterTitle = text.substring(titleIndex);
                 
                 // find the next title at same or higher depth => this will determine the end of the justification content
-                const nextTitleRegex = /^\s*#{1,4}\s+/m;
+                const nextTitleRegex = /^\s*#{1,4}\s*\S+/m;
                 const nextTitleMatch = contentAfterTitle.match(nextTitleRegex);
                 
                 let justificationContent;

--- a/.github/workflows/comment-on-e2e-check.yaml
+++ b/.github/workflows/comment-on-e2e-check.yaml
@@ -107,7 +107,7 @@ jobs:
             1. Add or update e2e tests relevant to the PR changes in the `tests/e2e/` directory, OR
             2. Evaluate the possibility of opting-out of this requirement:
                1. Inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md), to determine if the nature of the PR changes allows for skipping this requirement
-               2. If opt-out is applicable, please proceed to provide justification in the PR description (`#### E2E update requirement opt-out justification:` section)
+               2. If opt-out is applicable, please proceed to provide justification in the PR description (`#### E2E update requirement opt-out justification` section)
                   - **Note:** In case your PR description does not adhere to our PR template and is missing the `### E2E test suite update requirement` section (or any of its subsections), you can find the original PR template in `.github/PULL_REQUEST_TEMPLATE.md`, and restore the missing section from there
                3. After adding the justification, check the "Skip requirement to update E2E test suite for this PR" checkbox
                4. Submit/save changes to the PR description. The check will be triggered automatically and should pass


### PR DESCRIPTION
## Description
- changes regex used for detecting opt-out justification section title (`#### E2E update requirement opt-out justification`) to not require presence of `:` at the end of the title, now accepts title both with and without it (so should be backwards compatible for the few PRs that used the previous version of the template)
- fixed inconsistencies between guideline steps, guides and PR template now consistently mention only `#### E2E update requirement opt-out justification` title without `:` at the end
