### PR TITLE
RHOAIENG-29717 | feat: Deploy thanos querier frontend for metrics acces

### DIFF
--- a/bundle/manifests/opendatahub-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/opendatahub-operator.clusterserviceversion.yaml
@@ -199,11 +199,12 @@ metadata:
     categories: AI/Machine Learning, Big Data
     certified: "False"
     containerImage: quay.io/opendatahub/opendatahub-operator:v3.0.0
-    createdAt: "2025-10-05T19:42:41Z"
+    createdAt: "2025-10-09T09:50:07Z"
     operators.operatorframework.io/builder: operator-sdk-v1.39.2
     operators.operatorframework.io/internal-objects: '["featuretrackers.features.opendatahub.io",
-      "dashboards.components.platform.opendatahub.io", "datasciencepipelines.components.platform.opendatahub.io",
-      "kserves.components.platform.opendatahub.io", "kueues.components.platform.opendatahub.io", "modelregistries.components.platform.opendatahub.io",
+      "codeflares.components.platform.opendatahub.io", "dashboards.components.platform.opendatahub.io",
+      "datasciencepipelines.components.platform.opendatahub.io", "kserves.components.platform.opendatahub.io",
+      "kueues.components.platform.opendatahub.io", "modelregistries.components.platform.opendatahub.io",
       "rays.components.platform.opendatahub.io", "trainingoperators.components.platform.opendatahub.io",
       "trustyais.components.platform.opendatahub.io", "workbenches.components.platform.opendatahub.io",
       "gatewayconfigs.services.platform.opendatahub.io", "monitorings.services.platform.opendatahub.io",

--- a/internal/controller/services/monitoring/monitoring_controller_support_test.go
+++ b/internal/controller/services/monitoring/monitoring_controller_support_test.go
@@ -9,14 +9,21 @@ import (
 	operatorv1 "github.com/openshift/api/operator/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/opendatahub-io/opendatahub-operator/v2/api/common"
 	dsciv2 "github.com/opendatahub-io/opendatahub-operator/v2/api/dscinitialization/v2"
 	serviceApi "github.com/opendatahub-io/opendatahub-operator/v2/api/services/v1alpha1"
+	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/status"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/conditions"
 	odhtypes "github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
+	testScheme "github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/scheme"
 )
 
 func TestGetTemplateDataAcceleratorMetrics(t *testing.T) {
@@ -392,51 +399,304 @@ func TestGetTemplateDataAcceleratorMetricsWithMetricsConfiguration(t *testing.T)
 	assert.Contains(t, templateData, "StorageRetention")
 }
 
+type monitoringIntegrationTestCase struct {
+	name                      string
+	hasMetricsConfig          bool
+	hasMonitoringStackCRD     bool
+	hasThanosQuerierCRD       bool
+	expectedMSConditionStatus string
+	expectedTQConditionStatus string
+	expectedMSTemplates       int
+	expectedTQTemplates       int
+	description               string
+}
+
+func createMonitoringStackCRD() *extv1.CustomResourceDefinition {
+	return &extv1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "monitoringstacks.monitoring.rhobs",
+		},
+		Spec: extv1.CustomResourceDefinitionSpec{
+			Group: "monitoring.rhobs",
+			Versions: []extv1.CustomResourceDefinitionVersion{
+				{
+					Name:    "v1alpha1",
+					Served:  true,
+					Storage: true,
+					Schema: &extv1.CustomResourceValidation{
+						OpenAPIV3Schema: &extv1.JSONSchemaProps{
+							Type: "object",
+						},
+					},
+				},
+			},
+			Scope: extv1.NamespaceScoped,
+			Names: extv1.CustomResourceDefinitionNames{
+				Plural: "monitoringstacks",
+				Kind:   "MonitoringStack",
+			},
+		},
+		Status: extv1.CustomResourceDefinitionStatus{
+			StoredVersions: []string{"v1alpha1"},
+			Conditions: []extv1.CustomResourceDefinitionCondition{
+				{
+					Type:   extv1.Established,
+					Status: extv1.ConditionTrue,
+				},
+			},
+		},
+	}
+}
+
+func createThanosQuerierCRD() *extv1.CustomResourceDefinition {
+	return &extv1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "thanosqueriers.monitoring.rhobs",
+		},
+		Spec: extv1.CustomResourceDefinitionSpec{
+			Group: "monitoring.rhobs",
+			Versions: []extv1.CustomResourceDefinitionVersion{
+				{
+					Name:    "v1alpha1",
+					Served:  true,
+					Storage: true,
+					Schema: &extv1.CustomResourceValidation{
+						OpenAPIV3Schema: &extv1.JSONSchemaProps{
+							Type: "object",
+						},
+					},
+				},
+			},
+			Scope: extv1.NamespaceScoped,
+			Names: extv1.CustomResourceDefinitionNames{
+				Plural: "thanosqueriers",
+				Kind:   "ThanosQuerier",
+			},
+		},
+		Status: extv1.CustomResourceDefinitionStatus{
+			StoredVersions: []string{"v1alpha1"},
+			Conditions: []extv1.CustomResourceDefinitionCondition{
+				{
+					Type:   extv1.Established,
+					Status: extv1.ConditionTrue,
+				},
+			},
+		},
+	}
+}
+
+func setupTestObjects(tt monitoringIntegrationTestCase) []client.Object {
+	monitoring := &serviceApi.Monitoring{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "default-monitoring",
+		},
+		Spec: serviceApi.MonitoringSpec{
+			MonitoringCommonSpec: serviceApi.MonitoringCommonSpec{
+				Namespace: "test-namespace",
+			},
+		},
+	}
+
+	if tt.hasMetricsConfig {
+		monitoring.Spec.Metrics = &serviceApi.Metrics{
+			Replicas: 1,
+		}
+	}
+
+	objects := []client.Object{monitoring}
+
+	if tt.hasMonitoringStackCRD {
+		objects = append(objects, createMonitoringStackCRD())
+	}
+
+	if tt.hasThanosQuerierCRD {
+		objects = append(objects, createThanosQuerierCRD())
+	}
+
+	return objects
+}
+
+func setupFakeClient(objects []client.Object, tt monitoringIntegrationTestCase) (client.Client, error) {
+	scheme, err := testScheme.New()
+	if err != nil {
+		return nil, err
+	}
+
+	fakeMapper := meta.NewDefaultRESTMapper(scheme.PreferredVersionAllGroups())
+
+	for kt := range scheme.AllKnownTypes() {
+		switch kt {
+		// k8s
+		case gvk.CustomResourceDefinition:
+			fakeMapper.Add(kt, meta.RESTScopeRoot)
+		case gvk.ClusterRole:
+			fakeMapper.Add(kt, meta.RESTScopeRoot)
+		// ODH
+		case gvk.DataScienceCluster:
+			fakeMapper.Add(kt, meta.RESTScopeRoot)
+		case gvk.DSCInitialization:
+			fakeMapper.Add(kt, meta.RESTScopeRoot)
+		default:
+			fakeMapper.Add(kt, meta.RESTScopeNamespace)
+		}
+	}
+
+	// Add external CRDs to the RESTMapper
+	if tt.hasMonitoringStackCRD {
+		fakeMapper.Add(gvk.MonitoringStack, meta.RESTScopeNamespace)
+	}
+	if tt.hasThanosQuerierCRD {
+		fakeMapper.Add(gvk.ThanosQuerier, meta.RESTScopeNamespace)
+	}
+
+	return fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithRESTMapper(fakeMapper).
+		WithObjects(objects...).
+		Build(), nil
+}
+
+func validateConditions(t *testing.T, rr *odhtypes.ReconciliationRequest, tt monitoringIntegrationTestCase) {
+	t.Helper()
+	msCondition := rr.Conditions.GetCondition(status.ConditionMonitoringStackAvailable)
+	assert.NotNil(t, msCondition, "MonitoringStack condition should always be set")
+	assert.Equal(t, tt.expectedMSConditionStatus, string(msCondition.Status),
+		"MonitoringStack condition status should match expected")
+
+	thanosCondition := rr.Conditions.GetCondition(status.ConditionThanosQuerierAvailable)
+	assert.NotNil(t, thanosCondition,
+		"ThanosQuerier condition should always be set (atomic deployment with MonitoringStack)")
+	assert.Equal(t, tt.expectedTQConditionStatus, string(thanosCondition.Status),
+		"ThanosQuerier condition status should match expected")
+}
+
+func validateTemplates(t *testing.T, rr *odhtypes.ReconciliationRequest, tt monitoringIntegrationTestCase, initialTemplateCount int) {
+	t.Helper()
+	finalTemplateCount := len(rr.Templates)
+	expectedTotalTemplates := initialTemplateCount + tt.expectedMSTemplates + tt.expectedTQTemplates
+	assert.Equal(t, expectedTotalTemplates, finalTemplateCount,
+		"Expected %d total templates (%d initial + %d MS + %d TQ), got %d",
+		expectedTotalTemplates, initialTemplateCount, tt.expectedMSTemplates, tt.expectedTQTemplates, finalTemplateCount)
+
+	templatePaths := make([]string, 0, len(rr.Templates))
+	for _, template := range rr.Templates {
+		templatePaths = append(templatePaths, template.Path)
+	}
+
+	if tt.expectedMSTemplates > 0 {
+		assert.Contains(t, templatePaths, MonitoringStackTemplate,
+			"MonitoringStack template should be added when MS condition is True")
+		assert.Contains(t, templatePaths, MonitoringStackAlertmanagerRBACTemplate,
+			"Alertmanager RBAC template should be added when MS condition is True")
+		assert.Contains(t, templatePaths, PrometheusRouteTemplate,
+			"PrometheusRoute template should be added when MS condition is True")
+	} else {
+		assert.NotContains(t, templatePaths, MonitoringStackTemplate,
+			"MonitoringStack template should not be added when MS condition is not True")
+		assert.NotContains(t, templatePaths, MonitoringStackAlertmanagerRBACTemplate,
+			"Alertmanager RBAC template should not be added when MS condition is not True")
+		assert.NotContains(t, templatePaths, PrometheusRouteTemplate,
+			"PrometheusRoute template should not be added when MS condition is not True")
+	}
+
+	if tt.expectedTQTemplates > 0 {
+		assert.Contains(t, templatePaths, ThanosQuerierTemplate,
+			"ThanosQuerier template should be added when TQ condition is True")
+		assert.Contains(t, templatePaths, ThanosQuerierRouteTemplate,
+			"ThanosQuerierRoute template should be added when TQ condition is True")
+	} else {
+		assert.NotContains(t, templatePaths, ThanosQuerierTemplate,
+			"ThanosQuerier template should not be added when TQ condition is not True")
+		assert.NotContains(t, templatePaths, ThanosQuerierRouteTemplate,
+			"ThanosQuerierRoute template should not be added when TQ condition is not True")
+	}
+}
+
 func TestMonitoringStackThanosQuerierIntegration(t *testing.T) {
-	tests := []struct {
-		name             string
-		hasMetricsConfig bool
-		description      string
-	}{
+	ctx := t.Context()
+
+	tests := []monitoringIntegrationTestCase{
 		{
-			name:             "Monitoring stack calls ThanosQuerier when metrics configured",
-			hasMetricsConfig: true,
-			description:      "Should call deployThanosQuerier from deployMonitoringStack when metrics are configured",
+			name:                      "Both CRDs available with metrics - both deployed",
+			hasMetricsConfig:          true,
+			hasMonitoringStackCRD:     true,
+			hasThanosQuerierCRD:       true,
+			expectedMSConditionStatus: "True",
+			expectedTQConditionStatus: "True",
+			expectedMSTemplates:       3, // MonitoringStack + Alertmanager RBAC + PrometheusRoute
+			expectedTQTemplates:       2, // ThanosQuerier + ThanosQuerierRoute
+			description:               "When both CRDs are available and metrics configured, both should be deployed",
 		},
 		{
-			name:             "Monitoring stack calls ThanosQuerier when metrics not configured",
-			hasMetricsConfig: false,
-			description:      "Should call deployThanosQuerier from deployMonitoringStack even when metrics are not configured for proper condition handling",
+			name:                      "Only MonitoringStack CRD available with metrics - both conditions false, atomic deployment",
+			hasMetricsConfig:          true,
+			hasMonitoringStackCRD:     true,
+			hasThanosQuerierCRD:       false,
+			expectedMSConditionStatus: "False",
+			expectedTQConditionStatus: "False",
+			expectedMSTemplates:       0,
+			expectedTQTemplates:       0,
+			description:               "When only MonitoringStack CRD is available, neither should be deployed (atomic deployment)",
+		},
+		{
+			name:                      "Only ThanosQuerier CRD available with metrics - both conditions false, atomic deployment",
+			hasMetricsConfig:          true,
+			hasMonitoringStackCRD:     false,
+			hasThanosQuerierCRD:       true,
+			expectedMSConditionStatus: "False",
+			expectedTQConditionStatus: "False",
+			expectedMSTemplates:       0,
+			expectedTQTemplates:       0,
+			description:               "When only ThanosQuerier CRD is available, neither should be deployed (atomic deployment)",
+		},
+		{
+			name:                      "No CRDs available with metrics - both conditions false, no templates",
+			hasMetricsConfig:          true,
+			hasMonitoringStackCRD:     false,
+			hasThanosQuerierCRD:       false,
+			expectedMSConditionStatus: "False",
+			expectedTQConditionStatus: "False",
+			expectedMSTemplates:       0,
+			expectedTQTemplates:       0,
+			description:               "When no CRDs are available, conditions should be false but no errors",
+		},
+		{
+			name:                      "No metrics configuration - both conditions false",
+			hasMetricsConfig:          false,
+			hasMonitoringStackCRD:     true,
+			hasThanosQuerierCRD:       true,
+			expectedMSConditionStatus: "False",
+			expectedTQConditionStatus: "False",
+			expectedMSTemplates:       0,
+			expectedTQTemplates:       0,
+			description:               "When no metrics configured, neither MonitoringStack nor ThanosQuerier should be deployed",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Create Monitoring object
-			monitoring := &serviceApi.Monitoring{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "default-monitoring",
-				},
-				Spec: serviceApi.MonitoringSpec{
-					MonitoringCommonSpec: serviceApi.MonitoringCommonSpec{
-						Namespace: "test-namespace",
-					},
-				},
+			objects := setupTestObjects(tt)
+
+			fakeClient, err := setupFakeClient(objects, tt)
+			require.NoError(t, err, "Failed to create fake client")
+
+			monitoring, ok := objects[0].(*serviceApi.Monitoring)
+			require.True(t, ok, "First object should be monitoring instance")
+
+			rr := &odhtypes.ReconciliationRequest{
+				Client:     fakeClient,
+				Instance:   monitoring,
+				Templates:  []odhtypes.TemplateInfo{},
+				Conditions: conditions.NewManager(monitoring, status.ConditionTypeReady),
 			}
 
-			// Add metrics config if required
-			if tt.hasMetricsConfig {
-				monitoring.Spec.Metrics = &serviceApi.Metrics{
-					Replicas: 1,
-				}
-			}
+			initialTemplateCount := len(rr.Templates)
 
-			assert.NotNil(t, monitoring, "Monitoring object should be created")
-			if tt.hasMetricsConfig {
-				assert.NotNil(t, monitoring.Spec.Metrics, "Metrics should be configured when expected")
-			} else {
-				assert.Nil(t, monitoring.Spec.Metrics, "Metrics should not be configured when not expected")
-			}
+			err = deployMonitoringStackWithQuerier(ctx, rr)
+			require.NoError(t, err, "deployMonitoringStackWithQuerier should not return error")
+
+			validateConditions(t, rr, tt)
+			validateTemplates(t, rr, tt, initialTemplateCount)
 		})
 	}
 }

--- a/internal/controller/services/monitoring/resources/monitoringstack-alertmanager-rbac.tmpl.yaml
+++ b/internal/controller/services/monitoring/resources/monitoringstack-alertmanager-rbac.tmpl.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: data-science-monitoringstack-alertmanager-prometheus-metrics-reader
+  labels:
+    platform.opendatahub.io/part-of: monitoring
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: odh:prometheus-metrics-reader
+subjects:
+  - kind: ServiceAccount
+    name: data-science-monitoringstack-alertmanager
+    namespace: {{.Namespace}}

--- a/tests/e2e/monitoring_test.go
+++ b/tests/e2e/monitoring_test.go
@@ -29,6 +29,8 @@ const (
 	TempoMonolithicName        = "data-science-tempomonolithic"
 	TempoStackName             = "data-science-tempostack"
 	InstrumentationName        = "data-science-instrumentation"
+	ThanosQuerierName          = "data-science-thanos-querier"
+	ThanosQuerierRouteName     = "data-science-thanos-querier-route"
 )
 
 // Constants for common test values.
@@ -94,6 +96,8 @@ func monitoringTestSuite(t *testing.T) {
 		{"Test OpenTelemetry Collector replicas", monitoringServiceCtx.ValidateMonitoringCRCollectorReplicas},
 		{"Test Instrumentation CR Traces lifecycle", monitoringServiceCtx.ValidateInstrumentationCRTracesLifecycle},
 		{"Test Traces Exporters Reserved Name Validation", monitoringServiceCtx.ValidateTracesExportersReservedNameValidation},
+		{"Test ThanosQuerier deployment with metrics", monitoringServiceCtx.ValidateThanosQuerierDeployment},
+		{"Test ThanosQuerier not deployed without metrics", monitoringServiceCtx.ValidateThanosQuerierNotDeployedWithoutMetrics},
 		{"Validate CEL blocks invalid monitoring configs", monitoringServiceCtx.ValidateCELBlocksInvalidMonitoringConfigs},
 		{"Validate CEL allows valid monitoring configs", monitoringServiceCtx.ValidateCELAllowsValidMonitoringConfigs},
 		{"Validate monitoring service disabled", monitoringServiceCtx.ValidateMonitoringServiceDisabled},
@@ -994,4 +998,102 @@ func withMonitoringTraces(backend, secret, size, retention string) testf.Transfo
 	}
 
 	return testf.TransformPipeline(transforms...)
+}
+
+// ValidateThanosQuerierDeployment tests that ThanosQuerier CR and Route are created when metrics are configured and ThanosQuerier CRD is available.
+func (tc *MonitoringTestCtx) ValidateThanosQuerierDeployment(t *testing.T) {
+	t.Helper()
+
+	// Ensure clean slate before starting
+	tc.ensureMonitoringCleanSlate(t, "")
+
+	tc.updateMonitoringConfig(
+		withManagementState(operatorv1.Managed),
+		withMetricsConfig(),
+	)
+
+	tc.EnsureResourceExists(
+		WithMinimalObject(gvk.Monitoring, types.NamespacedName{Name: MonitoringCRName}),
+		WithCondition(And(
+			jq.Match(`.spec.metrics != null`),
+			jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, status.ConditionTypeReady, metav1.ConditionTrue),
+			jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, status.ConditionThanosQuerierAvailable, metav1.ConditionTrue),
+		)),
+		WithCustomErrorMsg("Monitoring resource should be updated with metrics configuration and ThanosQuerier should be available"),
+	)
+
+	// Ensure the ThanosQuerier CR is created
+	tc.EnsureResourceExists(
+		WithMinimalObject(gvk.ThanosQuerier, types.NamespacedName{Name: ThanosQuerierName, Namespace: tc.MonitoringNamespace}),
+		WithCondition(And(
+			jq.Match(`.spec.selector.matchLabels."platform.opendatahub.io/part-of" == "monitoring"`),
+			jq.Match(`.spec.namespaceSelector.matchNames | contains(["%s"])`, tc.MonitoringNamespace),
+			jq.Match(`.spec.replicaLabels | contains(["prometheus_replica", "rule_replica"])`),
+			monitoringOwnerReferencesCondition,
+		)),
+		WithCustomErrorMsg("ThanosQuerier CR should be created when metrics are configured"),
+	)
+
+	// Ensure the ThanosQuerier Route is created (OpenShift specific)
+	tc.EnsureResourceExists(
+		WithMinimalObject(gvk.Route, types.NamespacedName{Name: ThanosQuerierRouteName, Namespace: tc.MonitoringNamespace}),
+		WithCondition(And(
+			// Validate route points to correct service
+			jq.Match(`.spec.to.name == "thanos-querier-data-science-thanos-querier"`),
+			jq.Match(`.spec.tls.termination == "edge"`),
+			jq.Match(`.spec.tls.insecureEdgeTerminationPolicy == "Redirect"`),
+			jq.Match(`.metadata.labels.app == "thanos-querier"`),
+			jq.Match(`.metadata.labels."app.kubernetes.io/name" == "thanos-querier"`),
+			jq.Match(`.metadata.labels."app.kubernetes.io/component" == "querier"`),
+			jq.Match(`.metadata.labels."app.kubernetes.io/part-of" == "data-science-monitoring"`),
+			monitoringOwnerReferencesCondition,
+		)),
+		WithCustomErrorMsg("ThanosQuerier Route should be created when metrics are configured"),
+	)
+
+	// Cleanup: Reset monitoring configuration
+	tc.resetMonitoringConfigToManaged()
+}
+
+func (tc *MonitoringTestCtx) ValidateThanosQuerierNotDeployedWithoutMetrics(t *testing.T) {
+	t.Helper()
+
+	// Ensure clean slate before starting
+	tc.ensureMonitoringCleanSlate(t, "")
+
+	tc.updateMonitoringConfig(
+		withManagementState(operatorv1.Managed),
+		withNoMetrics(),
+	)
+
+	tc.EnsureResourceExists(
+		WithMinimalObject(gvk.Monitoring, types.NamespacedName{Name: MonitoringCRName}),
+		WithCondition(And(
+			jq.Match(`.spec.metrics == null`),
+			jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, status.ConditionTypeReady, metav1.ConditionTrue),
+		)),
+		WithCustomErrorMsg("Monitoring resource should be created without metrics configuration"),
+	)
+
+	// Validate that ThanosQuerier condition is False with reason MetricsNotConfigured
+	tc.EnsureResourceExists(
+		WithMinimalObject(gvk.Monitoring, types.NamespacedName{Name: MonitoringCRName}),
+		WithCondition(jq.Match(
+			`[.status.conditions[] | select(.type=="%s" and .status=="False" and .reason=="%s")] | length==1`,
+			status.ConditionThanosQuerierAvailable,
+			status.MetricsNotConfiguredReason,
+		)),
+		WithCustomErrorMsg("ThanosQuerier condition should be False with reason MetricsNotConfigured when metrics are not configured"),
+	)
+
+	tc.EnsureResourceDoesNotExist(
+		WithMinimalObject(gvk.ThanosQuerier, types.NamespacedName{Name: ThanosQuerierName, Namespace: tc.MonitoringNamespace}),
+	)
+
+	tc.EnsureResourceDoesNotExist(
+		WithMinimalObject(gvk.Route, types.NamespacedName{Name: ThanosQuerierRouteName, Namespace: tc.MonitoringNamespace}),
+	)
+
+	// Cleanup: Reset monitoring configuration
+	tc.resetMonitoringConfigToManaged()
 }


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
Adding missing test case 
related to https://github.com/opendatahub-io/opendatahub-operator/pull/2448
https://issues.redhat.com/browse/RHOAIENG-29717 
<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [ ] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Monitoring now includes Alertmanager RBAC (ClusterRoleBinding) and is added to monitoring templates.

* **Behavior**
  * CRD validation uses atomic deployment: missing CRDs mark related monitoring conditions False with a combined message.

* **Tests**
  * Expanded integration and end-to-end monitoring tests, including Thanos Querier deployment/no-deployment scenarios and reusable test scaffolding/validations.

* **Chores**
  * Operator bundle metadata updated and internal component list expanded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->