### PR TITLE
fix: add watch on Dashboard's AProfile/HWProfile by DSCI

### DIFF
--- a/internal/controller/dscinitialization/hardwareprofile.go
+++ b/internal/controller/dscinitialization/hardwareprofile.go
@@ -30,7 +30,7 @@ func (r *DSCInitializationReconciler) CreateVAP(ctx context.Context, dscInit *ds
 
 	// proceed if any CRDs exist
 	if !apCRDExists && !dhpCRDExists {
-		log.V(1).Info("Both CRD not exist, skipping handling for HardwareProfile")
+		log.V(1).Info("Both CRDs not exist, skipping creation for VAP/VAPB")
 		return nil
 	}
 


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->
problem
when test VAPB_creation_after_DSCI_creation, it creates a race-condition
- when DSCI first created, our cluster does not have AP/HWProfile CRD from dashboard, so the createVAP() not get called. our test is trying to turn dashboard on, in order to make the CRD exists, but DSCI does not watch such CRD, so it wont get VAP/VAPB created, unless something else changes DSCI/or remove and re-create it, this time DSCI sees CRD and will create VAP/VAPB. so in a chance, test can fail or pass.
- in reality, once we enter 3.0 we should not have these CRD still from dashboard, so the VAP/VAPB shoud only be craeted when the first time DSCI is being created. 

this PR:
- add watch on these two CRD on create/update, so VAP/VAPB need to be created
- this is needed for the testcase on dashboard once it is enabled and still ship these two CRD
- we probably can remove this logic alongwith the dashbaord tests on VAP/VAPB once dashboard cleanup CRD from their manifests



<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->
we alread have test VAPB_creation_after_DSCI_creation 
