### PR TITLE
collector validation should check metrics resources or storage

### DIFF
--- a/api/services/v1alpha1/monitoring_types.go
+++ b/api/services/v1alpha1/monitoring_types.go
@@ -171,7 +171,7 @@ type Monitoring struct {
 
 // MonitoringCommonSpec spec defines the shared desired state of Dashboard
 // +kubebuilder:validation:XValidation:rule="has(self.alerting) ? has(self.metrics.storage) || has(self.metrics.resources) : true",message="Alerting configuration requires metrics.storage or metrics.resources to be configured"
-// +kubebuilder:validation:XValidation:rule="!has(self.collectorReplicas) || (self.collectorReplicas > 0 && (self.metrics != null || self.traces != null))",message="CollectorReplicas can only be set when metrics or traces are enabled, and must be > 0"
+// +kubebuilder:validation:XValidation:rule="!has(self.collectorReplicas) || (self.collectorReplicas > 0 && ((self.metrics.resources != null || self.metrics.storage != null) || self.traces != null))",message="CollectorReplicas can only be set when metrics.resources, metrics.storage or traces are configured, and must be > 0"
 type MonitoringCommonSpec struct {
 	// monitoring spec exposed to DSCI api
 	// Namespace for monitoring if it is enabled

--- a/config/crd/bases/dscinitialization.opendatahub.io_dscinitializations.yaml
+++ b/config/crd/bases/dscinitialization.opendatahub.io_dscinitializations.yaml
@@ -301,10 +301,11 @@ spec:
                     to be configured
                   rule: 'has(self.alerting) ? has(self.metrics.storage) || has(self.metrics.resources)
                     : true'
-                - message: CollectorReplicas can only be set when metrics or traces
-                    are enabled, and must be > 0
+                - message: CollectorReplicas can only be set when metrics.resources,
+                    metrics.storage or traces are configured, and must be > 0
                   rule: '!has(self.collectorReplicas) || (self.collectorReplicas >
-                    0 && (self.metrics != null || self.traces != null))'
+                    0 && ((self.metrics.resources != null || self.metrics.storage
+                    != null) || self.traces != null))'
               serviceMesh:
                 description: |-
                   Configures Service Mesh as networking layer for Data Science Clusters components.

--- a/config/crd/bases/services.platform.opendatahub.io_monitorings.yaml
+++ b/config/crd/bases/services.platform.opendatahub.io_monitorings.yaml
@@ -248,10 +248,11 @@ spec:
                 to be configured
               rule: 'has(self.alerting) ? has(self.metrics.storage) || has(self.metrics.resources)
                 : true'
-            - message: CollectorReplicas can only be set when metrics or traces are
-                enabled, and must be > 0
+            - message: CollectorReplicas can only be set when metrics.resources, metrics.storage
+                or traces are configured, and must be > 0
               rule: '!has(self.collectorReplicas) || (self.collectorReplicas > 0 &&
-                (self.metrics != null || self.traces != null))'
+                ((self.metrics.resources != null || self.metrics.storage != null)
+                || self.traces != null))'
           status:
             description: MonitoringStatus defines the observed state of Monitoring
             properties:


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->
Change collectorReplicas validation to check for `metrics.resources` or `metrics.storage` as well as traces.
<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- Install operator
- Install cluster observability operator, red hat build of opentelemetry and tempo operator from operatorhub
- Create a default DSCI.
- Verify that the collectorReplicas field is not present in DSCI.
- Set monitoring to managementState: Managed
- Try to set the `collectorReplicas` field to a value >0
- Verify that it is rejected with an error message referencing metrics.resource, storage or traces needing to be configured.
- Add metrics and size stanza
``` 	
	metrics: {
       storage: {
         size: 5
       }
     }
 ```
- Verify that 2 collectors are deployed.
- Verify that collectorReplicas is 2 in the monitoring CR.
- Add collectorReplicasfield to DSCI and set to some other number.
- Verify the change is copied into the monitoring CR.

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->
Changes to the validation rule don't require a change to the e2e test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Refined validation for Collector Replicas: it can only be set (>0) when metrics.resources, metrics.storage, or traces are configured.
  * Applied and harmonized this validation across relevant CRDs to prevent invalid configurations.
  * Updated the user-facing validation message to clearly describe the new prerequisites for setting Collector Replicas.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->