### PR TITLE
fix(RHOAIENG-34533): resolve TrustyAI DSC validation error when patching DSC eval flags

### DIFF
--- a/api/components/v1alpha1/trustyai_types.go
+++ b/api/components/v1alpha1/trustyai_types.go
@@ -57,17 +57,19 @@ type TrustyAISpec struct {
 // TrustyAIEvalSpec defines evaluation configuration for TrustyAI
 type TrustyAIEvalSpec struct {
 	// LMEval configuration for model evaluations
-	LMEval TrustyAILMEvalSpec `json:"lmeval,omitempty"`
+	LMEval TrustyAILMEvalSpec `json:"lmeval"`
 }
 
 // TrustyAILMEvalSpec defines configuration for LMEval evaluations
 type TrustyAILMEvalSpec struct {
 	// PermitCodeExecution controls whether code execution is allowed during evaluations
-	// +kubebuilder:default=false
-	PermitCodeExecution bool `json:"permitCodeExecution,omitempty"`
+	// +kubebuilder:default="deny"
+	// +kubebuilder:validation:Enum=allow;deny
+	PermitCodeExecution string `json:"permitCodeExecution,omitempty"`
 	// PermitOnline controls whether online access is allowed during evaluations
-	// +kubebuilder:default=false
-	PermitOnline bool `json:"permitOnline,omitempty"`
+	// +kubebuilder:default="deny"
+	// +kubebuilder:validation:Enum=allow;deny
+	PermitOnline string `json:"permitOnline,omitempty"`
 }
 
 type TrustyAICommonSpec struct {

--- a/bundle/manifests/components.platform.opendatahub.io_trustyais.yaml
+++ b/bundle/manifests/components.platform.opendatahub.io_trustyais.yaml
@@ -81,16 +81,24 @@ spec:
                     description: LMEval configuration for model evaluations
                     properties:
                       permitCodeExecution:
-                        default: false
+                        default: deny
                         description: PermitCodeExecution controls whether code execution
                           is allowed during evaluations
-                        type: boolean
+                        enum:
+                        - allow
+                        - deny
+                        type: string
                       permitOnline:
-                        default: false
+                        default: deny
                         description: PermitOnline controls whether online access is
                           allowed during evaluations
-                        type: boolean
+                        enum:
+                        - allow
+                        - deny
+                        type: string
                     type: object
+                required:
+                - lmeval
                 type: object
             type: object
           status:

--- a/bundle/manifests/datasciencecluster.opendatahub.io_datascienceclusters.yaml
+++ b/bundle/manifests/datasciencecluster.opendatahub.io_datascienceclusters.yaml
@@ -742,16 +742,24 @@ spec:
                             description: LMEval configuration for model evaluations
                             properties:
                               permitCodeExecution:
-                                default: false
+                                default: deny
                                 description: PermitCodeExecution controls whether
                                   code execution is allowed during evaluations
-                                type: boolean
+                                enum:
+                                - allow
+                                - deny
+                                type: string
                               permitOnline:
-                                default: false
+                                default: deny
                                 description: PermitOnline controls whether online
                                   access is allowed during evaluations
-                                type: boolean
+                                enum:
+                                - allow
+                                - deny
+                                type: string
                             type: object
+                        required:
+                        - lmeval
                         type: object
                       managementState:
                         description: |-

--- a/bundle/manifests/opendatahub-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/opendatahub-operator.clusterserviceversion.yaml
@@ -147,8 +147,8 @@ metadata:
     capabilities: Full Lifecycle
     categories: AI/Machine Learning, Big Data
     certified: "False"
-    containerImage: quay.io/opendatahub/opendatahub-operator:v3.0.0
-    createdAt: "2025-09-23T09:55:05Z"
+    containerImage: quay.io/opendatahub/opendatahub-operator:v2.33.0
+    createdAt: "2025-09-24T15:33:34Z"
     operators.operatorframework.io/builder: operator-sdk-v1.39.2
     operators.operatorframework.io/internal-objects: '["featuretrackers.features.opendatahub.io",
       "codeflares.components.platform.opendatahub.io", "dashboards.components.platform.opendatahub.io",
@@ -162,7 +162,7 @@ metadata:
       "llamastackoperators.components.platform.opendatahub.io"]'
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
     repository: https://github.com/opendatahub-io/opendatahub-operator
-  name: opendatahub-operator.v3.0.0
+  name: opendatahub-operator.v2.33.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -1689,7 +1689,7 @@ spec:
   selector:
     matchLabels:
       component: opendatahub-operator
-  version: 3.0.0
+  version: 2.33.0
   webhookdefinitions:
   - admissionReviewVersions:
     - v1

--- a/bundle/manifests/opendatahub-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/opendatahub-operator.clusterserviceversion.yaml
@@ -113,7 +113,7 @@ metadata:
     capabilities: Full Lifecycle
     categories: AI/Machine Learning, Big Data
     certified: "False"
-    containerImage: quay.io/opendatahub/opendatahub-operator:v2.33.0
+    containerImage: quay.io/opendatahub/opendatahub-operator:v3.0.0
     createdAt: "2025-09-24T15:33:34Z"
     operators.operatorframework.io/builder: operator-sdk-v1.39.2
     operators.operatorframework.io/internal-objects: '["featuretrackers.features.opendatahub.io",
@@ -128,7 +128,7 @@ metadata:
       "llamastackoperators.components.platform.opendatahub.io"]'
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
     repository: https://github.com/opendatahub-io/opendatahub-operator
-  name: opendatahub-operator.v2.33.0
+  name: opendatahub-operator.v3.0.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -1655,7 +1655,7 @@ spec:
   selector:
     matchLabels:
       component: opendatahub-operator
-  version: 2.33.0
+  version: 3.0.0
   webhookdefinitions:
   - admissionReviewVersions:
     - v1

--- a/config/crd/bases/components.platform.opendatahub.io_trustyais.yaml
+++ b/config/crd/bases/components.platform.opendatahub.io_trustyais.yaml
@@ -81,16 +81,24 @@ spec:
                     description: LMEval configuration for model evaluations
                     properties:
                       permitCodeExecution:
-                        default: false
+                        default: deny
                         description: PermitCodeExecution controls whether code execution
                           is allowed during evaluations
-                        type: boolean
+                        enum:
+                        - allow
+                        - deny
+                        type: string
                       permitOnline:
-                        default: false
+                        default: deny
                         description: PermitOnline controls whether online access is
                           allowed during evaluations
-                        type: boolean
+                        enum:
+                        - allow
+                        - deny
+                        type: string
                     type: object
+                required:
+                - lmeval
                 type: object
             type: object
           status:

--- a/config/crd/bases/datasciencecluster.opendatahub.io_datascienceclusters.yaml
+++ b/config/crd/bases/datasciencecluster.opendatahub.io_datascienceclusters.yaml
@@ -742,16 +742,24 @@ spec:
                             description: LMEval configuration for model evaluations
                             properties:
                               permitCodeExecution:
-                                default: false
+                                default: deny
                                 description: PermitCodeExecution controls whether
                                   code execution is allowed during evaluations
-                                type: boolean
+                                enum:
+                                - allow
+                                - deny
+                                type: string
                               permitOnline:
-                                default: false
+                                default: deny
                                 description: PermitOnline controls whether online
                                   access is allowed during evaluations
-                                type: boolean
+                                enum:
+                                - allow
+                                - deny
+                                type: string
                             type: object
+                        required:
+                        - lmeval
                         type: object
                       managementState:
                         description: |-

--- a/docs/api-overview.md
+++ b/docs/api-overview.md
@@ -2056,8 +2056,8 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `permitCodeExecution` _boolean_ | PermitCodeExecution controls whether code execution is allowed during evaluations | false |  |
-| `permitOnline` _boolean_ | PermitOnline controls whether online access is allowed during evaluations | false |  |
+| `permitCodeExecution` _string_ | PermitCodeExecution controls whether code execution is allowed during evaluations | deny | Enum: [allow deny] <br /> |
+| `permitOnline` _string_ | PermitOnline controls whether online access is allowed during evaluations | deny | Enum: [allow deny] <br /> |
 
 
 #### TrustyAIList

--- a/internal/controller/components/trustyai/trustyai_controller_actions.go
+++ b/internal/controller/components/trustyai/trustyai_controller_actions.go
@@ -82,21 +82,9 @@ func createConfigMap(ctx context.Context, rr *odhtypes.ReconciliationRequest) er
 		return fmt.Errorf("resource instance %v is not a componentApi.TrustyAI)", rr.Instance)
 	}
 
-	// Extract values and convert string to boolean for configmap
-	permitCodeExecutionStr := trustyai.Spec.Eval.LMEval.PermitCodeExecution
-	permitOnlineStr := trustyai.Spec.Eval.LMEval.PermitOnline
-
-	// Default to "deny" if empty
-	if permitCodeExecutionStr == "" {
-		permitCodeExecutionStr = EvalPermissionDeny
-	}
-	if permitOnlineStr == "" {
-		permitOnlineStr = EvalPermissionDeny
-	}
-
 	// Convert to boolean for configmap
-	permitCodeExecution := permitCodeExecutionStr == EvalPermissionAllow
-	permitOnline := permitOnlineStr == EvalPermissionAllow
+	permitCodeExecution := trustyai.Spec.Eval.LMEval.PermitCodeExecution == EvalPermissionAllow
+	permitOnline := trustyai.Spec.Eval.LMEval.PermitOnline == EvalPermissionAllow
 
 	// Create extra ConfigMap for DSC configuration
 	configMap := &corev1.ConfigMap{


### PR DESCRIPTION
Refer to [RHOAIENG-34533](https://issues.redhat.com/browse/RHOAIENG-34533).

Remove `omitempty` tags from TrustyAI eval fields and change TrustyAI evaluation configuration fields from boolean to enum string values to ensure proper JSON serialisation and CRD validation.

## Description

Fixed DSC validation error when cycling TrustyAI eval settings from `true` -> `false` -> `true`. 
The issue occurred because `omitempty` JSON tags caused the lmeval object to be serialised as `null` when both permit flags were false, which caused CRD validation failures (that expected a proper object type).

Solution: Removed `omitempty` tags from TrustyAI eval fields and changed `PermitCodeExecution` and `PermitOnline` from bool to string with enum validation (allow/deny) to ensure proper serialisation.

## How Has This Been Tested?

- Operator tests pass
- Confirmed CRD validation accepts both`allow` and `deny` values
- Tested DSC patching from`allow` to `deny` values works without errors on a OpenShift cluster
- DSC works without errors when `eval` field is missing (defaults are added)


## Merge criteria

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - TrustyAI eval: lmeval is now required; permitCodeExecution and permitOnline are string enums ("allow"/"deny") defaulting to "deny".
  - CRDs and manifests updated to enforce the new schema and defaults; operator metadata timestamp refreshed.

- Tests
  - Added tests verifying permit fields are present and default to "deny" in serialized configurations.

- Documentation
  - API docs updated to reflect string-based permission fields, allowed values, and new defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->