### PR TITLE
feat: switch isvc connection annotation from type to protocol

### DIFF
--- a/internal/webhook/inferenceservice/mutating.go
+++ b/internal/webhook/inferenceservice/mutating.go
@@ -91,9 +91,9 @@ func (w *ConnectionWebhook) Handle(ctx context.Context, req admission.Request) a
 				webhookutils.ConnectionTypeProtocolOCI.String(),
 			},
 			annotations.ConnectionTypeRef: {
-				webhookutils.ConnectionTypeRefURI.String(), //nolint:staticcheck // deprecated but supported for backward compatibility.
-				webhookutils.ConnectionTypeRefS3.String(),  //nolint:staticcheck // deprecated but supported for backward compatibility.
-				webhookutils.ConnectionTypeRefOCI.String(), //nolint:staticcheck // deprecated but supported for backward compatibility.
+				webhookutils.ConnectionTypeRefURI.String(),
+				webhookutils.ConnectionTypeRefS3.String(),
+				webhookutils.ConnectionTypeRefOCI.String(),
 			},
 		}
 
@@ -260,21 +260,21 @@ func (w *ConnectionWebhook) performConnectionInjection(
 
 	// injection based on connection type
 	switch connectionType {
-	case webhookutils.ConnectionTypeProtocolOCI.String(), webhookutils.ConnectionTypeRefOCI.String(): //nolint:staticcheck
+	case webhookutils.ConnectionTypeProtocolOCI.String(), webhookutils.ConnectionTypeRefOCI.String():
 		if err := w.injectOCIImagePullSecrets(decodedObj, secretName); err != nil {
 			return false, fmt.Errorf("failed to inject OCI imagePullSecrets: %w", err)
 		}
 		log.V(1).Info("Successfully injected OCI imagePullSecrets", "secretName", secretName)
 		return true, nil
 
-	case webhookutils.ConnectionTypeProtocolURI.String(), webhookutils.ConnectionTypeRefURI.String(): //nolint:staticcheck
+	case webhookutils.ConnectionTypeProtocolURI.String(), webhookutils.ConnectionTypeRefURI.String():
 		if err := w.injectURIStorageUri(ctx, decodedObj, secretName, req.Namespace); err != nil {
 			return false, fmt.Errorf("failed to inject URI storageUri: %w", err)
 		}
 		log.V(1).Info("Successfully injected URI storageUri from secret", "secretName", secretName)
 		return true, nil
 
-	case webhookutils.ConnectionTypeProtocolS3.String(), webhookutils.ConnectionTypeRefS3.String(): //nolint:staticcheck
+	case webhookutils.ConnectionTypeProtocolS3.String(), webhookutils.ConnectionTypeRefS3.String():
 		// inject ServiceAccount only for S3 connections
 		if err := w.handleSA(decodedObj, secretName+"-sa"); err != nil {
 			log.Error(err, "Failed to inject ServiceAccount")
@@ -335,21 +335,21 @@ func (w *ConnectionWebhook) performConnectionCleanup(
 		}
 		log.V(1).Info("Successfully cleaned up S3 storage key", "name", req.Name, "namespace", req.Namespace)
 
-	case webhookutils.ConnectionTypeProtocolOCI.String(), webhookutils.ConnectionTypeRefOCI.String(): //nolint:staticcheck
+	case webhookutils.ConnectionTypeProtocolOCI.String(), webhookutils.ConnectionTypeRefOCI.String():
 		if err := w.cleanupOCIImagePullSecrets(decodedObj); err != nil {
 			log.Error(err, "Failed to cleanup OCI imagePullSecrets", "name", req.Name, "namespace", req.Namespace)
 			return false, fmt.Errorf("failed to cleanup OCI imagePullSecrets: %w", err)
 		}
 		log.V(1).Info("Successfully cleaned up OCI imagePullSecrets", "name", req.Name, "namespace", req.Namespace)
 
-	case webhookutils.ConnectionTypeProtocolURI.String(), webhookutils.ConnectionTypeRefURI.String(): //nolint:staticcheck
+	case webhookutils.ConnectionTypeProtocolURI.String(), webhookutils.ConnectionTypeRefURI.String():
 		if err := w.cleanupURIStorageUri(decodedObj); err != nil {
 			log.Error(err, "Failed to cleanup URI storageUri", "name", req.Name, "namespace", req.Namespace)
 			return false, fmt.Errorf("failed to cleanup URI storageUri: %w", err)
 		}
 		log.V(1).Info("Successfully cleaned up URI storageUri", "name", req.Name, "namespace", req.Namespace)
 
-	case webhookutils.ConnectionTypeProtocolS3.String(), webhookutils.ConnectionTypeRefS3.String(): //nolint:staticcheck
+	case webhookutils.ConnectionTypeProtocolS3.String(), webhookutils.ConnectionTypeRefS3.String():
 		// remove ServiceAccountName injection, if we need it in replacement, we ill add it back later.
 		if err := w.handleSA(decodedObj, ""); err != nil {
 			log.Error(err, "Failed to cleanup ServiceAccountName")

--- a/internal/webhook/inferenceservice/mutating.go
+++ b/internal/webhook/inferenceservice/mutating.go
@@ -84,10 +84,17 @@ func (w *ConnectionWebhook) Handle(ctx context.Context, req admission.Request) a
 	switch req.Operation {
 	case admissionv1.Create, admissionv1.Update:
 		// allowed connection types for connection validation on isvc.
-		allowedTypes := []string{
-			webhookutils.ConnectionTypeURI.String(),
-			webhookutils.ConnectionTypeS3.String(),
-			webhookutils.ConnectionTypeOCI.String(),
+		allowedTypes := map[string][]string{
+			annotations.ConnectionTypeProtocol: {
+				webhookutils.ConnectionTypeProtocolURI.String(),
+				webhookutils.ConnectionTypeProtocolS3.String(),
+				webhookutils.ConnectionTypeProtocolOCI.String(),
+			},
+			annotations.ConnectionTypeRef: {
+				webhookutils.ConnectionTypeRefURI.String(), //nolint:staticcheck // deprecated but supported for backward compatibility.
+				webhookutils.ConnectionTypeRefS3.String(),  //nolint:staticcheck // deprecated but supported for backward compatibility.
+				webhookutils.ConnectionTypeRefOCI.String(), //nolint:staticcheck // deprecated but supported for backward compatibility.
+			},
 		}
 
 		// validate the connection annotation and get secret and type, actual action (create/injenct, remove, replace) is moved out of here.
@@ -253,21 +260,21 @@ func (w *ConnectionWebhook) performConnectionInjection(
 
 	// injection based on connection type
 	switch connectionType {
-	case webhookutils.ConnectionTypeOCI.String():
+	case webhookutils.ConnectionTypeProtocolOCI.String(), webhookutils.ConnectionTypeRefOCI.String(): //nolint:staticcheck
 		if err := w.injectOCIImagePullSecrets(decodedObj, secretName); err != nil {
 			return false, fmt.Errorf("failed to inject OCI imagePullSecrets: %w", err)
 		}
 		log.V(1).Info("Successfully injected OCI imagePullSecrets", "secretName", secretName)
 		return true, nil
 
-	case webhookutils.ConnectionTypeURI.String():
+	case webhookutils.ConnectionTypeProtocolURI.String(), webhookutils.ConnectionTypeRefURI.String(): //nolint:staticcheck
 		if err := w.injectURIStorageUri(ctx, decodedObj, secretName, req.Namespace); err != nil {
 			return false, fmt.Errorf("failed to inject URI storageUri: %w", err)
 		}
 		log.V(1).Info("Successfully injected URI storageUri from secret", "secretName", secretName)
 		return true, nil
 
-	case webhookutils.ConnectionTypeS3.String():
+	case webhookutils.ConnectionTypeProtocolS3.String(), webhookutils.ConnectionTypeRefS3.String(): //nolint:staticcheck
 		// inject ServiceAccount only for S3 connections
 		if err := w.handleSA(decodedObj, secretName+"-sa"); err != nil {
 			log.Error(err, "Failed to inject ServiceAccount")
@@ -328,21 +335,21 @@ func (w *ConnectionWebhook) performConnectionCleanup(
 		}
 		log.V(1).Info("Successfully cleaned up S3 storage key", "name", req.Name, "namespace", req.Namespace)
 
-	case webhookutils.ConnectionTypeOCI.String():
+	case webhookutils.ConnectionTypeProtocolOCI.String(), webhookutils.ConnectionTypeRefOCI.String(): //nolint:staticcheck
 		if err := w.cleanupOCIImagePullSecrets(decodedObj); err != nil {
 			log.Error(err, "Failed to cleanup OCI imagePullSecrets", "name", req.Name, "namespace", req.Namespace)
 			return false, fmt.Errorf("failed to cleanup OCI imagePullSecrets: %w", err)
 		}
 		log.V(1).Info("Successfully cleaned up OCI imagePullSecrets", "name", req.Name, "namespace", req.Namespace)
 
-	case webhookutils.ConnectionTypeURI.String():
+	case webhookutils.ConnectionTypeProtocolURI.String(), webhookutils.ConnectionTypeRefURI.String(): //nolint:staticcheck
 		if err := w.cleanupURIStorageUri(decodedObj); err != nil {
 			log.Error(err, "Failed to cleanup URI storageUri", "name", req.Name, "namespace", req.Namespace)
 			return false, fmt.Errorf("failed to cleanup URI storageUri: %w", err)
 		}
 		log.V(1).Info("Successfully cleaned up URI storageUri", "name", req.Name, "namespace", req.Namespace)
 
-	case webhookutils.ConnectionTypeS3.String():
+	case webhookutils.ConnectionTypeProtocolS3.String(), webhookutils.ConnectionTypeRefS3.String(): //nolint:staticcheck
 		// remove ServiceAccountName injection, if we need it in replacement, we ill add it back later.
 		if err := w.handleSA(decodedObj, ""); err != nil {
 			log.Error(err, "Failed to cleanup ServiceAccountName")
@@ -506,6 +513,6 @@ func (w *ConnectionWebhook) getOldConnectionInfo(ctx context.Context, req admiss
 		return "", "", fmt.Errorf("failed to get old secret metadata: %w", err)
 	}
 
-	oldConnectionType := resources.GetAnnotation(secretMeta, annotations.ConnectionTypeRef)
+	oldConnectionType := resources.GetAnnotation(secretMeta, annotations.ConnectionTypeProtocol)
 	return oldAnnotationValue, oldConnectionType, nil
 }

--- a/internal/webhook/inferenceservice/mutating_test.go
+++ b/internal/webhook/inferenceservice/mutating_test.go
@@ -642,7 +642,7 @@ func TestDeprecatedConnectionTypeRefAnnotation(t *testing.T) {
 	testCases := []TestCase{
 		{
 			name:            "deprecated ConnectionTypeRef S3 annotation should work",
-			secretType:      webhookutils.ConnectionTypeRefS3.String(), //nolint:staticcheck
+			secretType:      webhookutils.ConnectionTypeRefS3.String(),
 			secretNamespace: testNamespace,
 			annotations:     map[string]string{annotations.Connection: testSecret},
 			predictorSpec:   map[string]interface{}{"model": map[string]interface{}{}},
@@ -654,7 +654,7 @@ func TestDeprecatedConnectionTypeRefAnnotation(t *testing.T) {
 		},
 		{
 			name:               "deprecated ConnectionTypeRef URI annotation should work",
-			secretType:         webhookutils.ConnectionTypeRefURI.String(), //nolint:staticcheck
+			secretType:         webhookutils.ConnectionTypeRefURI.String(),
 			secretNamespace:    testNamespace,
 			secretData:         map[string][]byte{"URI": []byte("https://example.com/model")},
 			annotations:        map[string]string{annotations.Connection: testSecret},
@@ -665,7 +665,7 @@ func TestDeprecatedConnectionTypeRefAnnotation(t *testing.T) {
 		},
 		{
 			name:               "deprecated ConnectionTypeRef OCI annotation should work",
-			secretType:         webhookutils.ConnectionTypeRefOCI.String(), //nolint:staticcheck
+			secretType:         webhookutils.ConnectionTypeRefOCI.String(),
 			secretNamespace:    testNamespace,
 			annotations:        map[string]string{annotations.Connection: testSecret},
 			operation:          admissionv1.Create,
@@ -684,17 +684,17 @@ func TestDeprecatedConnectionTypeRefAnnotation(t *testing.T) {
 	}
 }
 
-// TestConnectionTypeValidationDenial tests that operations are denied when neither annotation exists.
-func TestConnectionTypeValidationDenial(t *testing.T) {
+// TestConnectionTypeValidationAllowed tests that operations are allowed when neither annotation exists.
+func TestConnectionTypeValidationAllowed(t *testing.T) {
 	testCases := []TestCase{
 		{
-			name:            "secret without connection type annotations should be denied",
+			name:            "secret without connection type annotations should be allowed",
 			secretType:      "", // Will be handled specially in the custom secret creator
 			secretNamespace: testNamespace,
 			annotations:     map[string]string{annotations.Connection: testSecret},
 			operation:       admissionv1.Create,
-			expectedAllowed: false,
-			expectedMessage: "does not have",
+			expectedAllowed: true,
+			expectedMessage: "No connection injection performed",
 		},
 	}
 
@@ -727,9 +727,9 @@ func TestValidateInferenceServiceConnectionType(t *testing.T) {
 			webhookutils.ConnectionTypeProtocolOCI.String(),
 		},
 		annotations.ConnectionTypeRef: {
-			webhookutils.ConnectionTypeRefURI.String(), //nolint:staticcheck
-			webhookutils.ConnectionTypeRefS3.String(),  //nolint:staticcheck
-			webhookutils.ConnectionTypeRefOCI.String(), //nolint:staticcheck
+			webhookutils.ConnectionTypeRefURI.String(),
+			webhookutils.ConnectionTypeRefS3.String(),
+			webhookutils.ConnectionTypeRefOCI.String(),
 		},
 	}
 
@@ -750,8 +750,8 @@ func TestValidateInferenceServiceConnectionType(t *testing.T) {
 		{
 			name:               "empty protocol falls back to ref",
 			protocolAnnotation: "",
-			refAnnotation:      webhookutils.ConnectionTypeRefOCI.String(), //nolint:staticcheck
-			expectedType:       webhookutils.ConnectionTypeRefOCI.String(), //nolint:staticcheck
+			refAnnotation:      webhookutils.ConnectionTypeRefOCI.String(),
+			expectedType:       webhookutils.ConnectionTypeRefOCI.String(),
 			expectedValid:      true,
 		},
 		{

--- a/pkg/metadata/annotations/annotations.go
+++ b/pkg/metadata/annotations/annotations.go
@@ -29,4 +29,8 @@ const (
 const Connection = "opendatahub.io/connections"
 
 // ConnectionTypeRef annotation for specifying the type of connection.
+// Deprecated: Use ConnectionTypeProtocol instead.
 const ConnectionTypeRef = "opendatahub.io/connection-type-ref"
+
+// ConnectionTypeProtocol annotation for specifying the type of connection.
+const ConnectionTypeProtocol = "opendatahub.io/connection-type-protocol"

--- a/pkg/webhook/utils.go
+++ b/pkg/webhook/utils.go
@@ -43,12 +43,26 @@ func (ca ConnectionAction) String() string {
 type ConnectionType string
 
 const (
-	// ConnectionTypeURI represents uri connections.
-	ConnectionTypeURI ConnectionType = "uri-v1"
-	// ConnectionTypeS3 represents s3 connections.
-	ConnectionTypeS3 ConnectionType = "s3"
-	// ConnectionTypeOCI represents oci connections.
-	ConnectionTypeOCI ConnectionType = "oci-v1"
+	// ConnectionTypeProtocolURI represents uri connections.
+	ConnectionTypeProtocolURI ConnectionType = "uri"
+	// ConnectionTypeProtocolS3 represents s3 connections.
+	ConnectionTypeProtocolS3 ConnectionType = "s3"
+	// ConnectionTypeProtocolOCI represents oci connections.
+	ConnectionTypeProtocolOCI ConnectionType = "oci"
+)
+
+// Deprecated: ConnectionTypeRef constants are deprecated in favor of ConnectionTypeProtocol constants.
+// Use ConnectionTypeProtocolURI, ConnectionTypeProtocolS3, and ConnectionTypeProtocolOCI instead.
+const (
+	// ConnectionTypeRefURI represents uri connections.
+	// Deprecated: Use ConnectionTypeProtocolURI instead.
+	ConnectionTypeRefURI ConnectionType = "uri-v1"
+	// ConnectionTypeRefS3 represents s3 connections.
+	// Deprecated: Use ConnectionTypeProtocolS3 instead.
+	ConnectionTypeRefS3 ConnectionType = "s3"
+	// ConnectionTypeRefOCI represents oci connections.
+	// Deprecated: Use ConnectionTypeProtocolOCI instead.
+	ConnectionTypeRefOCI ConnectionType = "oci-v1"
 )
 
 func (ct ConnectionType) String() string {
@@ -83,12 +97,12 @@ func HandleServiceAccountCreation(ctx context.Context, cli client.Client, secret
 	log := logf.FromContext(ctx)
 
 	switch {
-	case connectionType == ConnectionTypeS3.String() && !isDryRun:
+	case (connectionType == ConnectionTypeProtocolS3.String() || connectionType == ConnectionTypeRefS3.String()) && !isDryRun:
 		if err := CreateServiceAccount(ctx, cli, secretName, namespace); err != nil {
 			log.Error(err, "Failed to create ServiceAccount for new S3 connection")
 			return err
 		}
-	case connectionType == ConnectionTypeS3.String() && isDryRun:
+	case (connectionType == ConnectionTypeProtocolS3.String() || connectionType == ConnectionTypeRefS3.String()) && isDryRun:
 		log.V(1).Info("Skipping ServiceAccount creation in dry-run mode", "secretName", secretName)
 	default:
 		log.V(1).Info("Skipping ServiceAccount creation for non-S3 connection type", "connectionType", connectionType, "secretName", secretName)
@@ -205,17 +219,18 @@ func DecodeUnstructured(decoder admission.Decoder, req admission.Request) (*unst
 }
 
 // ValidateInferenceServiceConnectionAnnotation validates the connection annotation  "opendatahub.io/connections"
-// If the annotation exists and has a non-empty value, it validates that the value references
-// a valid secret in the same namespace. Additionally, it checks the secret's connection type
-// annotation and rejects requests with invalid configurations. (see allowedTypes)
-// If the annotation doesn't exist or is empty, it allows the operation.
+// If the connection annotation doesn't exist or is empty, it allows the operation.
+// If the connection annotation exists and has a non-empty value, it validates that the value references
+// a valid secret in the same namespace.
+// Additionally it checks the secret connection type. If it can't find the connection type, it denies the operation.
+// If the connection type is unknown, it allows the operation but skips the injection.
 //
 // Parameters:
 //   - ctx: Context for the API call (logger is extracted from here).
 //   - cli: The controller-runtime reader to use for getting secrets.
 //   - decodedObj: The decoded unstructured object.
 //   - req: The admission request being processed.
-//   - allowedTypes: List of allowed connection types for validation.
+//   - allowedTypes: Map of allowed connection types for validation.
 //
 // Returns:
 //   - admission.Response: The validation result
@@ -225,11 +240,11 @@ func ValidateInferenceServiceConnectionAnnotation(ctx context.Context,
 	cli client.Reader,
 	decodedObj *unstructured.Unstructured,
 	req admission.Request,
-	allowedTypes []string,
+	allowedTypes map[string][]string,
 ) (admission.Response, string, string) {
 	log := logf.FromContext(ctx)
 
-	// Check if the annotation "opendatahub.io/connections" exists and has a non-empty value, allow operation but return empty secret info
+	// Check if the annotation "opendatahub.io/connections" exists and if it has an empty value, allow operation but return empty secret info
 	annotationValue := resources.GetAnnotation(decodedObj, annotations.Connection)
 	if annotationValue == "" {
 		return admission.Allowed(fmt.Sprintf("Annotation '%s' not present or empty value", annotations.Connection)), "", ""
@@ -246,23 +261,58 @@ func ValidateInferenceServiceConnectionAnnotation(ctx context.Context,
 		return admission.Errored(http.StatusInternalServerError, fmt.Errorf("failed to validate secret: %w", err)), "", ""
 	}
 
-	// Additional validation: check the secret's connections-type-ref annotation exists and has a non-empty value
-	connectionType := resources.GetAnnotation(secretMeta, annotations.ConnectionTypeRef)
+	// Validate the connection type
+	connectionType, isValidType := ValidateInferenceServiceConnectionType(secretMeta, allowedTypes)
+
+	// If neither connection type is missing, deny the operation
 	if connectionType == "" {
-		return admission.Allowed(fmt.Sprintf("Secret '%s' does not have '%s' annotation", annotationValue, annotations.ConnectionTypeRef)), "", ""
+		return admission.Denied(fmt.Sprintf("Secret '%s' does not have '%s' or '%s' annotation",
+			annotationValue, annotations.ConnectionTypeProtocol, annotations.ConnectionTypeRef)), "", ""
 	}
 
-	// Validate that the connection type is one of the allowed values
-	isValidType := slices.Contains(allowedTypes, connectionType)
-
+	// Allow unknown connection types but log a warning and don't perform injection
 	if !isValidType {
-		// Allow unknown connection types but log a warning and don't perform injection
 		log.Info("Unknown connection type found, allowing operation but skipping injection", "connectionType", connectionType, "allowedTypes", allowedTypes)
 		return admission.Allowed(fmt.Sprintf("Annotation '%s' validation on secret '%s' with unknown type '%s' in namespace '%s'",
 			annotations.Connection, annotationValue, connectionType, req.Namespace)), "", ""
 	}
+
 	// Allow the operation and return secret info
 	return admission.Allowed("Connection annotation validation passed"), secretMeta.Name, connectionType
+}
+
+// ValidateInferenceServiceConnectionType fetches the connection type from the secret metadata and validates it against the allowed types.
+// It first checks the secret's connection type protocol annotation "opendatahub.io/connection-type-protocol".
+// If the connection type protocol annotation doesn't exist, it falls back to the deprecated connection type ref
+// annotation "opendatahub.io/connection-type-ref".
+// If neither annotation exists, it returns an empty connection type.
+//
+// Parameters:
+//   - secretMeta: The secret metadata to validate.
+//   - allowedTypes: Map of allowed connection types for validation.
+//
+// Returns:
+//   - string: The connection type (empty if no annotation)
+//   - bool: True if the connection type is in the allowed types, false otherwise
+func ValidateInferenceServiceConnectionType(secretMeta *metav1.PartialObjectMetadata, allowedTypes map[string][]string) (string, bool) {
+	// First check the connection type protocol annotation
+	connectionType := resources.GetAnnotation(secretMeta, annotations.ConnectionTypeProtocol)
+	if connectionType != "" {
+		// If it exists, check that the connection type is one of the allowed values
+		isValidType := slices.Contains(allowedTypes[annotations.ConnectionTypeProtocol], connectionType)
+		return connectionType, isValidType
+	}
+
+	// If the connection type protocol annotation doesn't exist, check the deprecated connection type ref annotation
+	connectionType = resources.GetAnnotation(secretMeta, annotations.ConnectionTypeRef)
+	if connectionType != "" {
+		// If it exists, check that the connection type is one of the allowed values
+		isValidType := slices.Contains(allowedTypes[annotations.ConnectionTypeRef], connectionType)
+		return connectionType, isValidType
+	}
+
+	// If neither annotation exists, return empty connection type
+	return "", false
 }
 
 // DetermineConnectionChangeAction determines what action to take for UPDATE operations

--- a/tests/e2e/kserve_test.go
+++ b/tests/e2e/kserve_test.go
@@ -464,7 +464,7 @@ func (tc *KserveTestCtx) createConnectionSecret(secretName, namespace string) {
 		WithMinimalObject(gvk.Secret, types.NamespacedName{Name: secretName, Namespace: namespace}),
 		WithMutateFunc(testf.TransformPipeline(
 			// Set connection type annotation
-			testf.Transform(`.metadata.annotations."%s" = "%s"`, annotations.ConnectionTypeRef, "oci-v1"),
+			testf.Transform(`.metadata.annotations."%s" = "%s"`, annotations.ConnectionTypeProtocol, "oci"),
 			// Set secret type
 			testf.Transform(`.type = "%s"`, string(corev1.SecretTypeOpaque)),
 			// Set secret data


### PR DESCRIPTION
## Description
JIRA: [RHOAIENG-34106](https://issues.redhat.com/browse/RHOAIENG-34106)

The dashboard UI currently support custom connections however the foundation team's connections API does not. When a custom connection is created, the dashboard annotates the connection secret with opendatahub.io/connection-type-ref: {custom-connection-name} which doesn't work with our current implementation because we expect the value of `opendatahub.io/connection-type-ref` to be either `uri-v1`, `s3`, or `oci-v1`.

To get around this, the dashboard will still duck type connection secrets and then  annotate the secret with a new annotation`opendatahub.io/connection-type-protocol` which will have a value of either "uri", "s3", or "oci". This PR changes our existing InferenceService webhook to support this new annotation and values while still supporting the old annotation to preserve backwards compatibility.

## How Has This Been Tested?
These changes were tested by building operator, bundle, and catalog images, then verifying that the DSC and DSCI CRs successfully reconcile.

The following images were used for testing and can be used for verification:
```
quay.io/ckyrillo/opendatahub-operator:v2.33.0
quay.io/ckyrillo/opendatahub-operator-bundle:v2.33.0
quay.io/ckyrillo/opendatahub-operator-catalog:v2.33.0
```

I also performed the following verification:

<details>
  <summary>Valid Protocol Annotation</summary>
  I confirmed that after creating the following YAML with a valid connection type protocol annotation

    kind: Secret
    apiVersion: v1
    metadata:
      name: s3-type-protocol
      namespace: a-test
      annotations:
        opendatahub.io/connection-type-protocol: s3
    data:
      URI: aHR0cHM6Ly9xdWF5LmlvL2NreXJpbGxvL29jcC1tY3Atc2VydmVyOmltcHJvdmVk
      AWS_ACCESS_KEY_ID: MQ==
      AWS_DEFAULT_REGION: NA==
      AWS_S3_BUCKET: NQ==
      AWS_S3_ENDPOINT: Mw==
      AWS_SECRET_ACCESS_KEY: Mg==
    type: Opaque
    ---
    apiVersion: serving.kserve.io/v1beta1
    kind: InferenceService
    metadata:
      annotations:
        opendatahub.io/connections: s3-type-protocol
      namespace: a-test
      name: isvc-s3-protocol
    spec:
      predictor:
        model:
          modelFormat:
            name: vLLM
          name: 'mistral'

The webhook correctly injects the connection secret data into the `InferenceService` CR like this:

    apiVersion: serving.kserve.io/v1beta1
    kind: InferenceService
    metadata:
      annotations:
        opendatahub.io/connections: s3-type-protocol
      name: isvc-s3-protocol
      namespace: a-test
    spec:
      predictor:
        automountServiceAccountToken: false
        model:
          modelFormat:
            name: vLLM
          name: mistral
          resources: {}
          storage:
            key: s3-type-protocol
          serviceAccountName: s3-type-protocol-sa

</details>

<details>
  <summary>Valid (Deprecated) Ref Annotation</summary>
  I confirmed that after creating the following YAML with a valid connection type ref annotation

    kind: Secret
    apiVersion: v1
    metadata:
      name: uri-type-ref
      namespace: a-test
      annotations:
        opendatahub.io/connection-type-ref: uri-v1
    data:
      URI: aHR0cHM6Ly9xdWF5LmlvL2NreXJpbGxvL29jcC1tY3Atc2VydmVyOmltcHJvdmVk
    type: Opaque
    ---
    apiVersion: serving.kserve.io/v1beta1
    kind: InferenceService
    metadata:
      annotations:
        opendatahub.io/connections: uri-type-ref
      namespace: a-test
      name: isvc-uri-ref
    spec:
      predictor:
        model:
          modelFormat:
            name: vLLM
          name: 'mistral'

The webhook correctly injects the connection secret data into the `InferenceService` CR like this:

    apiVersion: serving.kserve.io/v1beta1
    kind: InferenceService
    metadata:
      annotations:
        opendatahub.io/connections: uri-type-ref
      name: isvc-uri-ref
      namespace: a-test
    spec:
      predictor:
        automountServiceAccountToken: false
        model:
          modelFormat:
            name: vLLM
          name: mistral
          resources: {}
          storageUri: 'https://quay.io/ckyrillo/ocp-mcp-server:improved'

</details>

I also verified that when neither annotation is present on the connection secret, the create/update request is still allowed.

## Screenshot or short clip
N/A

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [X] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [X] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work
- [X] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [ ] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Connection annotations now use protocol-style values (e.g., "oci", "uri", "s3") while retaining backward-compatible legacy annotations; validation prefers protocol and service-account handling supports both.
  * Unknown/unsupported types are allowed but will skip injection (operation proceeds with logging).

* **Documentation**
  * Guidance updated to recommend protocol annotations and simplified connection values.

* **Tests**
  * Unit and e2e coverage expanded for protocol annotations, legacy fallback, validation cases, and added test helpers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->