### PR TITLE
implemented destination rule for TLS to upstream services

### DIFF
--- a/internal/controller/services/gateway/gateway_controller.go
+++ b/internal/controller/services/gateway/gateway_controller.go
@@ -60,6 +60,7 @@ func (h *ServiceHandler) NewReconciler(ctx context.Context, mgr ctrl.Manager) er
 		WithAction(createGatewayInfrastructure).
 		WithAction(createKubeAuthProxyInfrastructure).
 		WithAction(createEnvoyFilter).
+		WithAction(createDestinationRule).
 		WithAction(template.NewAction()).
 		WithAction(deploy.NewAction(
 			deploy.WithCache(),

--- a/internal/controller/services/gateway/resources/destinationrule-tls.yaml
+++ b/internal/controller/services/gateway/resources/destinationrule-tls.yaml
@@ -1,0 +1,21 @@
+apiVersion: networking.istio.io/v1
+kind: DestinationRule
+metadata:
+  name: odh-tls-rule
+  namespace: openshift-ingress
+  labels:
+    app.kubernetes.io/part-of: odh-gateway
+spec:
+  host: '*'
+  trafficPolicy:
+    portLevelSettings:
+    - port:
+        number: 8443
+      tls:
+        mode: SIMPLE
+        insecureSkipVerify: true
+    - port:
+        number: 443
+      tls:
+        mode: SIMPLE
+        insecureSkipVerify: true


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->
JIRA: [RHOAIENG-34804](https://issues.redhat.com/browse/RHOAIENG-34804)

Integrates DestinationRule creation into the gateway controller to handle TLS connections to HTTPS backends (ports 8443, 443). 

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
  Testing Environment:
  - ROSA cluster with ODH operator deployed
  - Gateway controller with [demo echo server](https://github.com/jctanner/odh-security-2.0/blob/main/test.configs/echo.yaml) using kube-rbac-proxy on port 8443

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->
Tests will be covered in this [PR](https://github.com/opendatahub-io/opendatahub-operator/pull/2522) or after that is merged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Automatically configures TLS for gateway traffic on ports 443 and 8443, improving compatibility for services behind the platform ingress.
  - Applies a default traffic policy to streamline encrypted connections without manual setup.
  - Activates on deployment with no user action required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->