### PR TITLE
feat: add GHA to auto build and push e2e tests image after each merge to main

### DIFF
--- a/.github/workflows/build-push-e2e-tests-image.yaml
+++ b/.github/workflows/build-push-e2e-tests-image.yaml
@@ -1,0 +1,59 @@
+name: Build and push E2E Test Image
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+env:
+  E2E_IMAGE_TAG_BASE: quay.io/${{ secrets.QUAY_ORG }}/opendatahub-operator-e2e
+
+jobs:
+  build-push-e2e-image:
+    name: Build and push E2E test image
+    runs-on: ubuntu-latest
+    env:
+      IMAGE_BUILDER: podman
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Quay.io login
+        uses: redhat-actions/podman-login@v1
+        env:
+          QUAY_ID: ${{ secrets.QUAY_ID }}
+          QUAY_TOKEN: ${{ secrets.QUAY_TOKEN }}
+        with:
+          registry: quay.io
+          username: ${{ env.QUAY_ID }}
+          password: ${{ env.QUAY_TOKEN }}
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Generate image tag
+        id: image-tag
+        run: |
+          # tag based on shortened commit SHA
+          COMMIT_SHA=$(echo ${{ github.sha }} | cut -c1-8)
+          echo "E2E_IMAGE_TAG=main-${COMMIT_SHA}" >> $GITHUB_OUTPUT
+
+      - name: Build and push E2E test image
+        env:
+          E2E_IMAGE: ${{ env.E2E_IMAGE_TAG_BASE }}:${{ steps.image-tag.outputs.E2E_IMAGE_TAG }}
+        run: |
+          echo "Building E2E test image: ${E2E_IMAGE}"
+          podman build \
+            --platform linux/amd64 \
+            -f Dockerfiles/e2e-tests/e2e-tests.Dockerfile \
+            -t "${E2E_IMAGE}" \
+            .
+          
+          echo "Pushing E2E test image: ${E2E_IMAGE}"
+          podman push "${E2E_IMAGE}"
+          
+          echo "E2E test image built and pushed successfully!"

--- a/Dockerfiles/e2e-tests/e2e-tests.Dockerfile
+++ b/Dockerfiles/e2e-tests/e2e-tests.Dockerfile
@@ -1,0 +1,48 @@
+# E2E Test Image with precompiled tests
+ARG GOLANG_VERSION=1.24
+
+################################################################################
+FROM registry.access.redhat.com/ubi9/go-toolset:$GOLANG_VERSION as builder
+ARG CGO_ENABLED=1
+ARG TARGETARCH
+USER root
+WORKDIR /workspace
+
+# Copy the Go Modules manifests
+COPY go.mod go.mod
+COPY go.sum go.sum
+
+RUN go mod download
+
+# Copy the go source needed for e2e tests
+COPY api/ api/
+COPY internal/ internal/
+COPY cmd/main.go cmd/main.go
+COPY pkg/ pkg/
+COPY tests/ tests/
+
+# build the e2e test binary + pre-compile the e2e tests
+RUN CGO_ENABLED=${CGO_ENABLED} GOOS=linux GOARCH=${TARGETARCH} go test -c ./tests/e2e/ -o e2e-tests
+
+# install gotestsum and build test2json
+RUN go install gotest.tools/gotestsum@latest \
+ && go build -o /opt/app-root/src/test2json cmd/test2json
+
+################################################################################
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+
+RUN microdnf update -y && \
+    curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" && \
+    chmod +x kubectl && \
+    mv kubectl /usr/local/bin/ && \
+    microdnf clean all
+
+WORKDIR /e2e
+
+COPY --from=builder /workspace/e2e-tests .
+COPY --from=builder /opt/app-root/src/go/bin/gotestsum /usr/local/bin/
+COPY --from=builder /opt/app-root/src/test2json /usr/local/bin/
+
+RUN chmod +x ./e2e-tests
+
+ENTRYPOINT ["./e2e-tests"]

--- a/Dockerfiles/e2e-tests/e2e-tests.Dockerfile.dockerignore
+++ b/Dockerfiles/e2e-tests/e2e-tests.Dockerfile.dockerignore
@@ -1,0 +1,11 @@
+# Dockerfile-specific .dockerignore for e2e-tests.Dockerfile
+# unlike the main .dockerignore file, this one allows the tests/ directory to be included for e2e test builds
+
+**/.git
+**/coverage
+**/*.md
+**/docs
+**/bin
+**/samples
+opt/manifests/**/scorecard
+opt/manifests/**/example-*


### PR DESCRIPTION
## Description
JIRA ref: [RHOAIENG-33454](https://issues.redhat.com/browse/RHOAIENG-33454)

## How Has This Been Tested?
Manually tested on my fork repo
1. add this action to main branch
2. create PR with test commit
3. merge PR
4. observe the action status and output
5. 

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->
This does not touch code, nor existing Dockerfiles. New dockerfile is being added for e2e test image building purposes in CI - no changes needed for the existing e2e test suite

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added an end-to-end (E2E) test container image using a multi-stage build that bundles required test utilities for consistent, reproducible runs.
  * Added tailored ignore rules to keep test images lean while ensuring necessary test assets are included.

* **Chores**
  * Added an automated workflow to build and publish the E2E test image on main-branch updates, tagging images by commit and pushing to the registry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->