### PR TITLE
[rhoai] feat: switch isvc connection annotation from type to protocol

### DIFF
--- a/internal/webhook/inferenceservice/mutating_test.go
+++ b/internal/webhook/inferenceservice/mutating_test.go
@@ -79,7 +79,7 @@ func createTestSecret(name, namespace, connectionType string, data map[string][]
 			Name:      name,
 			Namespace: namespace,
 			Annotations: map[string]string{
-				annotations.ConnectionTypeRef: connectionType,
+				annotations.ConnectionTypeProtocol: connectionType,
 			},
 		},
 		Data: data,
@@ -87,7 +87,22 @@ func createTestSecret(name, namespace, connectionType string, data map[string][]
 	return secret
 }
 
-func createTestInferenceService(name, namespace string, annotations map[string]string, predictorSpec map[string]interface{}) (*unstructured.Unstructured, error) {
+// createTestSecretWithAnnotationType creates a test secret with the specified annotation type.
+func createTestSecretWithAnnotationType(name, namespace, connectionType, annotationType string, data map[string][]byte) *corev1.Secret {
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Annotations: map[string]string{
+				annotationType: connectionType,
+			},
+		},
+		Data: data,
+	}
+	return secret
+}
+
+func createTestInferenceService(name, namespace string, annotations map[string]string, predictorSpec map[string]interface{}) (*unstructured.Unstructured, error) { //nolint:unparam
 	isvc := envtestutil.NewInferenceService(name, namespace)
 	unstructuredISVC, ok := isvc.(*unstructured.Unstructured)
 	if !ok {
@@ -136,7 +151,7 @@ func runTestCase(t *testing.T, tc TestCase) {
 			// Use the specified old secret type, or default to S3 if not specified
 			oldSecretType := tc.oldSecretType
 			if oldSecretType == "" {
-				oldSecretType = webhookutils.ConnectionTypeS3.String()
+				oldSecretType = webhookutils.ConnectionTypeProtocolS3.String()
 			}
 			oldSecret := createTestSecret(oldSecretName, tc.secretNamespace, oldSecretType, map[string][]byte{})
 			objects = append(objects, oldSecret)
@@ -204,7 +219,7 @@ func runTestCase(t *testing.T, tc TestCase) {
 	}
 }
 
-// oci-v1 - simple case for new injection without existing secrets.
+// oci - simple case for new injection without existing secrets.
 func hasImagePullSecretsPatch(expectedSecretName string) func([]jsonpatch.JsonPatchOperation) bool {
 	return func(patches []jsonpatch.JsonPatchOperation) bool {
 		for _, patch := range patches {
@@ -223,7 +238,7 @@ func hasImagePullSecretsPatch(expectedSecretName string) func([]jsonpatch.JsonPa
 	}
 }
 
-// uri-v1.
+// uri.
 func hasStorageUriPatch(expectedUri string) func([]jsonpatch.JsonPatchOperation) bool {
 	return func(patches []jsonpatch.JsonPatchOperation) bool {
 		for _, patch := range patches {
@@ -263,7 +278,7 @@ func hasStorageKeyPatch(expectedStorageKey string) func([]jsonpatch.JsonPatchOpe
 	}
 }
 
-// oci-v1.
+// oci.
 func hasImagePullSecretsCleanupPatch() func([]jsonpatch.JsonPatchOperation) bool {
 	return func(patches []jsonpatch.JsonPatchOperation) bool {
 		for _, patch := range patches {
@@ -275,7 +290,7 @@ func hasImagePullSecretsCleanupPatch() func([]jsonpatch.JsonPatchOperation) bool
 	}
 }
 
-// uri-v1.
+// uri.
 func hasStorageUriCleanupPatch() func([]jsonpatch.JsonPatchOperation) bool {
 	return func(patches []jsonpatch.JsonPatchOperation) bool {
 		for _, patch := range patches {
@@ -331,7 +346,7 @@ func TestServiceAccountNamePatching(t *testing.T) {
 	t.Run("serviceAccountName is not injected on create with OCI", func(t *testing.T) {
 		tc := TestCase{
 			name:            "serviceAccountName not injected on create with OCI",
-			secretType:      webhookutils.ConnectionTypeOCI.String(),
+			secretType:      webhookutils.ConnectionTypeProtocolOCI.String(),
 			secretNamespace: testNamespace,
 			annotations:     map[string]string{annotations.Connection: testSecret},
 			operation:       admissionv1.Create,
@@ -346,7 +361,7 @@ func TestServiceAccountNamePatching(t *testing.T) {
 	t.Run("serviceAccountName is not injected on create with URI", func(t *testing.T) {
 		tc := TestCase{
 			name:            "serviceAccountName not injected on create with URI",
-			secretType:      webhookutils.ConnectionTypeURI.String(),
+			secretType:      webhookutils.ConnectionTypeProtocolURI.String(),
 			secretNamespace: testNamespace,
 			secretData:      map[string][]byte{"URI": []byte("https://example.com/model")},
 			annotations:     map[string]string{annotations.Connection: testSecret},
@@ -362,7 +377,7 @@ func TestServiceAccountNamePatching(t *testing.T) {
 	t.Run("serviceAccountName is injected on create with S3", func(t *testing.T) {
 		tc := TestCase{
 			name:            "serviceAccountName injected on create with S3",
-			secretType:      webhookutils.ConnectionTypeS3.String(),
+			secretType:      webhookutils.ConnectionTypeProtocolS3.String(),
 			secretNamespace: testNamespace,
 			secretData:      map[string][]byte{},
 			annotations:     map[string]string{annotations.Connection: testSecret},
@@ -379,7 +394,7 @@ func TestServiceAccountNamePatching(t *testing.T) {
 	t.Run("serviceAccountName is injected on update with S3", func(t *testing.T) {
 		tc := TestCase{
 			name:             "serviceAccountName injected on update",
-			secretType:       webhookutils.ConnectionTypeS3.String(),
+			secretType:       webhookutils.ConnectionTypeProtocolS3.String(),
 			secretNamespace:  testNamespace,
 			annotations:      map[string]string{annotations.Connection: testSecret},
 			predictorSpec:    map[string]interface{}{"model": map[string]interface{}{}},
@@ -439,7 +454,7 @@ func TestConnectionWebhook(t *testing.T) {
 		},
 		{
 			name:            "to delete ISVC with allowed type should be passed",
-			secretType:      webhookutils.ConnectionTypeS3.String(),
+			secretType:      webhookutils.ConnectionTypeProtocolS3.String(),
 			annotations:     map[string]string{annotations.Connection: testSecret},
 			operation:       admissionv1.Delete,
 			expectedAllowed: true,
@@ -465,7 +480,7 @@ func TestConnectionWebhook(t *testing.T) {
 		},
 		{
 			name:               "annotation as OCI type, ISVC creation allowed with injection done",
-			secretType:         webhookutils.ConnectionTypeOCI.String(),
+			secretType:         webhookutils.ConnectionTypeProtocolOCI.String(),
 			secretNamespace:    testNamespace,
 			annotations:        map[string]string{annotations.Connection: testSecret},
 			operation:          admissionv1.Create,
@@ -474,7 +489,7 @@ func TestConnectionWebhook(t *testing.T) {
 		},
 		{
 			name:               "annotation as URI type with model in spec, ISVC creation allowed with injection done",
-			secretType:         webhookutils.ConnectionTypeURI.String(),
+			secretType:         webhookutils.ConnectionTypeProtocolURI.String(),
 			secretNamespace:    testNamespace,
 			secretData:         map[string][]byte{"URI": []byte("https://opendathub.io/model")},
 			annotations:        map[string]string{annotations.Connection: testSecret},
@@ -485,7 +500,7 @@ func TestConnectionWebhook(t *testing.T) {
 		},
 		{
 			name:               "annotation as S3 type, ISVC creation allowed with injection done",
-			secretType:         webhookutils.ConnectionTypeS3.String(),
+			secretType:         webhookutils.ConnectionTypeProtocolS3.String(),
 			secretNamespace:    testNamespace,
 			annotations:        map[string]string{annotations.Connection: testSecret},
 			predictorSpec:      map[string]interface{}{"model": map[string]interface{}{}},
@@ -495,7 +510,7 @@ func TestConnectionWebhook(t *testing.T) {
 		},
 		{
 			name:            "annotation as URI type without data.URI set, ISVC should not be allowed to create",
-			secretType:      webhookutils.ConnectionTypeURI.String(),
+			secretType:      webhookutils.ConnectionTypeProtocolURI.String(),
 			secretNamespace: testNamespace,
 			secretData:      map[string][]byte{},
 			annotations:     map[string]string{annotations.Connection: testSecret},
@@ -507,7 +522,7 @@ func TestConnectionWebhook(t *testing.T) {
 		// type cases for update
 		{
 			name:               "annotation as S3 type with existing storageUri, ISVC update allowed with replacement",
-			secretType:         webhookutils.ConnectionTypeS3.String(),
+			secretType:         webhookutils.ConnectionTypeProtocolS3.String(),
 			secretNamespace:    testNamespace,
 			secretData:         map[string][]byte{},
 			annotations:        map[string]string{annotations.Connection: testSecret},
@@ -518,7 +533,7 @@ func TestConnectionWebhook(t *testing.T) {
 		},
 		{
 			name:               "annotation as OCI type, ISVC update allowed with replacement",
-			secretType:         webhookutils.ConnectionTypeOCI.String(),
+			secretType:         webhookutils.ConnectionTypeProtocolOCI.String(),
 			secretNamespace:    testNamespace,
 			annotations:        map[string]string{annotations.Connection: testSecret},
 			predictorSpec:      map[string]interface{}{"model": map[string]interface{}{}},
@@ -528,7 +543,7 @@ func TestConnectionWebhook(t *testing.T) {
 		},
 		{
 			name:            "annotation as S3 type without model set, ISVC should not be allowed to create",
-			secretType:      webhookutils.ConnectionTypeS3.String(),
+			secretType:      webhookutils.ConnectionTypeProtocolS3.String(),
 			secretNamespace: testNamespace,
 			annotations:     map[string]string{annotations.Connection: testSecret},
 			predictorSpec:   map[string]interface{}{"name": "test-predictor"},
@@ -538,7 +553,7 @@ func TestConnectionWebhook(t *testing.T) {
 		},
 		{
 			name:               "annotation as URI type with new URI, ISVC should overwrite with new value in the patch",
-			secretType:         webhookutils.ConnectionTypeURI.String(),
+			secretType:         webhookutils.ConnectionTypeProtocolURI.String(),
 			secretNamespace:    testNamespace,
 			secretData:         map[string][]byte{"URI": []byte("s3://new-bucket/new-model")},
 			annotations:        map[string]string{annotations.Connection: testSecret},
@@ -565,7 +580,7 @@ func TestConnectionWebhook(t *testing.T) {
 					map[string]interface{}{"name": testSecret},
 				},
 			},
-			oldSecretType:      webhookutils.ConnectionTypeOCI.String(),
+			oldSecretType:      webhookutils.ConnectionTypeProtocolOCI.String(),
 			operation:          admissionv1.Update,
 			expectedAllowed:    true,
 			expectedPatchCheck: hasImagePullSecretsCleanupPatch(),
@@ -586,7 +601,7 @@ func TestConnectionWebhook(t *testing.T) {
 					"storageUri": testSecret,
 				},
 			},
-			oldSecretType:      webhookutils.ConnectionTypeURI.String(),
+			oldSecretType:      webhookutils.ConnectionTypeProtocolURI.String(),
 			operation:          admissionv1.Update,
 			expectedAllowed:    true,
 			expectedPatchCheck: hasStorageUriCleanupPatch(),
@@ -619,5 +634,279 @@ func TestConnectionWebhook(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			runTestCase(t, tc)
 		})
+	}
+}
+
+// TestDeprecatedConnectionTypeRefAnnotation tests backward compatibility with deprecated ConnectionTypeRef annotations.
+func TestDeprecatedConnectionTypeRefAnnotation(t *testing.T) {
+	testCases := []TestCase{
+		{
+			name:            "deprecated ConnectionTypeRef S3 annotation should work",
+			secretType:      webhookutils.ConnectionTypeRefS3.String(),
+			secretNamespace: testNamespace,
+			annotations:     map[string]string{annotations.Connection: testSecret},
+			predictorSpec:   map[string]interface{}{"model": map[string]interface{}{}},
+			operation:       admissionv1.Create,
+			expectedAllowed: true,
+			expectedPatchCheck: func(patches []jsonpatch.JsonPatchOperation) bool {
+				return hasStorageKeyPatch(testSecret)(patches) && hasServiceAccountNamePatch()(patches)
+			},
+		},
+		{
+			name:               "deprecated ConnectionTypeRef URI annotation should work",
+			secretType:         webhookutils.ConnectionTypeRefURI.String(),
+			secretNamespace:    testNamespace,
+			secretData:         map[string][]byte{"URI": []byte("https://example.com/model")},
+			annotations:        map[string]string{annotations.Connection: testSecret},
+			predictorSpec:      map[string]interface{}{"model": map[string]interface{}{}},
+			operation:          admissionv1.Create,
+			expectedAllowed:    true,
+			expectedPatchCheck: hasStorageUriPatch("https://example.com/model"),
+		},
+		{
+			name:               "deprecated ConnectionTypeRef OCI annotation should work",
+			secretType:         webhookutils.ConnectionTypeRefOCI.String(),
+			secretNamespace:    testNamespace,
+			annotations:        map[string]string{annotations.Connection: testSecret},
+			operation:          admissionv1.Create,
+			expectedAllowed:    true,
+			expectedPatchCheck: hasImagePullSecretsPatch(testSecret),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Use the special helper to create secret with ConnectionTypeRef annotation
+			runTestCaseWithCustomSecret(t, tc, func(name, namespace, connectionType string, data map[string][]byte) *corev1.Secret {
+				return createTestSecretWithAnnotationType(name, namespace, connectionType, annotations.ConnectionTypeRef, data)
+			})
+		})
+	}
+}
+
+// TestConnectionTypeValidationAllowed tests that operations are allowed when neither annotation exists.
+func TestConnectionTypeValidationAllowed(t *testing.T) {
+	testCases := []TestCase{
+		{
+			name:            "secret without connection type annotations should be allowed",
+			secretType:      "", // Will be handled specially in the custom secret creator
+			secretNamespace: testNamespace,
+			annotations:     map[string]string{annotations.Connection: testSecret},
+			operation:       admissionv1.Create,
+			expectedAllowed: true,
+			expectedMessage: "No connection injection performed",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Create secret without any connection type annotations
+			runTestCaseWithCustomSecret(t, tc, func(name, namespace, connectionType string, data map[string][]byte) *corev1.Secret {
+				return &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        name,
+						Namespace:   namespace,
+						Annotations: map[string]string{}, // No connection type annotations
+					},
+					Data: data,
+				}
+			})
+		})
+	}
+}
+
+// TestValidateInferenceServiceConnectionType tests the new ValidateInferenceServiceConnectionType function behavior.
+func TestValidateInferenceServiceConnectionType(t *testing.T) {
+	g := NewWithT(t)
+
+	// Test data setup
+	allowedTypes := map[string][]string{
+		annotations.ConnectionTypeProtocol: {
+			webhookutils.ConnectionTypeProtocolURI.String(),
+			webhookutils.ConnectionTypeProtocolS3.String(),
+			webhookutils.ConnectionTypeProtocolOCI.String(),
+		},
+		annotations.ConnectionTypeRef: {
+			webhookutils.ConnectionTypeRefURI.String(),
+			webhookutils.ConnectionTypeRefS3.String(),
+			webhookutils.ConnectionTypeRefOCI.String(),
+		},
+	}
+
+	testCases := []struct {
+		name               string
+		protocolAnnotation string
+		refAnnotation      string
+		expectedType       string
+		expectedValid      bool
+	}{
+		{
+			name:               "valid ConnectionTypeProtocol annotation",
+			protocolAnnotation: webhookutils.ConnectionTypeProtocolS3.String(),
+			refAnnotation:      "",
+			expectedType:       webhookutils.ConnectionTypeProtocolS3.String(),
+			expectedValid:      true,
+		},
+		{
+			name:               "empty protocol falls back to ref",
+			protocolAnnotation: "",
+			refAnnotation:      webhookutils.ConnectionTypeRefOCI.String(),
+			expectedType:       webhookutils.ConnectionTypeRefOCI.String(),
+			expectedValid:      true,
+		},
+		{
+			name:               "neither annotation exists",
+			protocolAnnotation: "",
+			refAnnotation:      "",
+			expectedType:       "",
+			expectedValid:      false,
+		},
+		{
+			name:               "invalid protocol type",
+			protocolAnnotation: "invalid-type",
+			refAnnotation:      "",
+			expectedType:       "invalid-type",
+			expectedValid:      false,
+		},
+		{
+			name:               "invalid ref type",
+			protocolAnnotation: "",
+			refAnnotation:      "invalid-ref-type",
+			expectedType:       "invalid-ref-type",
+			expectedValid:      false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Create secret metadata with the specified annotations
+			secretMeta := &metav1.PartialObjectMetadata{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        testSecret,
+					Namespace:   testNamespace,
+					Annotations: make(map[string]string),
+				},
+			}
+
+			if tc.protocolAnnotation != "" {
+				secretMeta.Annotations[annotations.ConnectionTypeProtocol] = tc.protocolAnnotation
+			}
+			if tc.refAnnotation != "" {
+				secretMeta.Annotations[annotations.ConnectionTypeRef] = tc.refAnnotation
+			}
+
+			// Call the function under test
+			connectionType, isValid := webhookutils.ValidateInferenceServiceConnectionType(secretMeta, allowedTypes)
+
+			// Verify results
+			g.Expect(connectionType).To(Equal(tc.expectedType), "Expected connection type: %s, got: %s", tc.expectedType, connectionType)
+			g.Expect(isValid).To(Equal(tc.expectedValid), "Expected valid: %v, got: %v", tc.expectedValid, isValid)
+		})
+	}
+}
+
+// runTestCaseWithCustomSecret runs a test case with a custom secret creation function.
+func runTestCaseWithCustomSecret(t *testing.T, tc TestCase, secretCreator func(name, namespace, connectionType string, data map[string][]byte) *corev1.Secret) {
+	t.Helper()
+	g := NewWithT(t)
+	sch, ctx := setupTestEnvironment(t)
+
+	var cli client.Client
+	var reader client.Reader
+	var objects []client.Object
+
+	// Create current secret if needed
+	if tc.secretType != "" || secretCreator != nil {
+		// Extract secret name from annotations, default to testSecret if not specified
+		secretName := testSecret
+		if tc.annotations != nil {
+			if name, exists := tc.annotations[annotations.Connection]; exists {
+				secretName = name
+			}
+		}
+
+		var secret *corev1.Secret
+		if secretCreator != nil {
+			secret = secretCreator(secretName, tc.secretNamespace, tc.secretType, tc.secretData)
+		} else {
+			secret = createTestSecret(secretName, tc.secretNamespace, tc.secretType, tc.secretData)
+		}
+		objects = append(objects, secret)
+	}
+
+	// Create old secret if needed for UPDATE operations
+	if tc.operation == admissionv1.Update && tc.oldAnnotations != nil {
+		if oldSecretName, exists := tc.oldAnnotations[annotations.Connection]; exists {
+			// Use the specified old secret type, or default to S3 if not specified
+			oldSecretType := tc.oldSecretType
+			if oldSecretType == "" {
+				oldSecretType = webhookutils.ConnectionTypeProtocolS3.String()
+			}
+			oldSecret := createTestSecret(oldSecretName, tc.secretNamespace, oldSecretType, map[string][]byte{})
+			objects = append(objects, oldSecret)
+		}
+	}
+
+	if len(objects) > 0 {
+		cli = fake.NewClientBuilder().WithScheme(sch).WithObjects(objects...).Build()
+		reader = fake.NewClientBuilder().WithScheme(sch).WithObjects(objects...).Build()
+	} else {
+		cli = fake.NewClientBuilder().WithScheme(sch).Build()
+		reader = fake.NewClientBuilder().WithScheme(sch).Build()
+	}
+
+	webhook := createWebhook(cli, reader, sch)
+
+	// Create current InferenceService
+	isvc, err := createTestInferenceService(testInferenceService, testNamespace, tc.annotations, tc.predictorSpec)
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	// Create old InferenceService for UPDATE operations
+	var oldISVC *unstructured.Unstructured
+	if tc.operation == admissionv1.Update {
+		oldISVC, err = createTestInferenceService(testInferenceService, testNamespace, tc.oldAnnotations, tc.oldPredictorSpec)
+		g.Expect(err).ShouldNot(HaveOccurred())
+	}
+
+	// Create admission request
+	isvcRaw, err := json.Marshal(isvc)
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	req := admission.Request{
+		AdmissionRequest: admissionv1.AdmissionRequest{
+			Operation: tc.operation,
+			Namespace: testNamespace,
+			Object: runtime.RawExtension{
+				Raw: isvcRaw,
+			},
+			Kind: metav1.GroupVersionKind{
+				Group:   gvk.InferenceServices.Group,
+				Version: gvk.InferenceServices.Version,
+				Kind:    gvk.InferenceServices.Kind,
+			},
+		},
+	}
+
+	// For UPDATE operations, set up the old object
+	if tc.operation == admissionv1.Update && oldISVC != nil {
+		oldIsvcRaw, err := json.Marshal(oldISVC)
+		g.Expect(err).ShouldNot(HaveOccurred())
+		req.OldObject = runtime.RawExtension{
+			Raw: oldIsvcRaw,
+		}
+	}
+
+	// Call the webhook
+	resp := webhook.Handle(ctx, req)
+
+	// Verify response
+	g.Expect(resp.Allowed).To(Equal(tc.expectedAllowed), "Expected allowed: %v, got: %v", tc.expectedAllowed, resp.Allowed)
+
+	if tc.expectedMessage != "" {
+		g.Expect(resp.Result.Message).To(ContainSubstring(tc.expectedMessage), "Expected message to contain: %s, got: %s", tc.expectedMessage, resp.Result.Message)
+	}
+
+	if tc.expectedPatchCheck != nil {
+		g.Expect(tc.expectedPatchCheck(resp.Patches)).To(BeTrue())
 	}
 }

--- a/pkg/metadata/annotations/annotations.go
+++ b/pkg/metadata/annotations/annotations.go
@@ -29,4 +29,8 @@ const (
 const Connection = "opendatahub.io/connections"
 
 // ConnectionTypeRef annotation for specifying the type of connection.
+// Deprecated: Use ConnectionTypeProtocol instead.
 const ConnectionTypeRef = "opendatahub.io/connection-type-ref"
+
+// ConnectionTypeProtocol annotation for specifying the type of connection.
+const ConnectionTypeProtocol = "opendatahub.io/connection-type-protocol"


### PR DESCRIPTION
## Description
sync #2532 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [ ] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->
