### PR TITLE
[sync] feat: add default HWProfile CR "default-profile" (#2461)

### DIFF
--- a/bundle/manifests/rhods-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/rhods-operator.clusterserviceversion.yaml
@@ -107,40 +107,6 @@ metadata:
               "managementState": "Managed"
             }
           }
-        },
-        {
-          "apiVersion": "infrastructure.opendatahub.io/v1",
-          "kind": "HardwareProfile",
-          "metadata": {
-            "annotations": {
-              "opendatahub.io/dashboard-feature-visibility": "[]",
-              "opendatahub.io/description": "Provides a baseline hardware profile with 2 CPUs and 4Gi memory by default, adjustable up to 4 CPUs and 8Gi memory.",
-              "opendatahub.io/disabled": "false",
-              "opendatahub.io/display-name": "default-profile"
-            },
-            "name": "default-profile",
-            "namespace": "opendatahub"
-          },
-          "spec": {
-            "identifiers": [
-              {
-                "defaultCount": 2,
-                "displayName": "CPU",
-                "identifier": "cpu",
-                "maxCount": 4,
-                "minCount": 1,
-                "resourceType": "CPU"
-              },
-              {
-                "defaultCount": "4Gi",
-                "displayName": "Memory",
-                "identifier": "memory",
-                "maxCount": "8Gi",
-                "minCount": "2Gi",
-                "resourceType": "Memory"
-              }
-            ]
-          }
         }
       ]
     capabilities: Full Lifecycle

--- a/config/hardwareprofiles/hardwareprofiles.yaml
+++ b/config/hardwareprofiles/hardwareprofiles.yaml
@@ -6,6 +6,7 @@ metadata:
     opendatahub.io/description: 'Provides a baseline hardware profile with 2 CPUs and 4Gi memory by default, adjustable up to 4 CPUs and 8Gi memory.'
     opendatahub.io/disabled: 'false'
     opendatahub.io/display-name: default-profile
+    opendatahub.io/managed: "false"
   name: default-profile
   namespace: opendatahub
 spec:

--- a/config/hardwareprofiles/kustomization.yaml
+++ b/config/hardwareprofiles/kustomization.yaml
@@ -3,3 +3,4 @@ kind: Kustomization
 
 resources:
 - vap
+- hardwareprofiles.yaml

--- a/config/manifests/kustomization.yaml
+++ b/config/manifests/kustomization.yaml
@@ -9,7 +9,6 @@ resources:
 - ../prometheus
 - ../samples # to generate CSV alm-example
 - ../scorecard
-- ../hardwareprofiles
 
 patches:
 - path: description-patch.yml

--- a/config/samples/kustomization.yaml
+++ b/config/samples/kustomization.yaml
@@ -6,4 +6,3 @@ resources:
 - datasciencecluster_v1_datasciencecluster.yaml
 - dscinitialization_v1_dscinitialization.yaml
 - services_v1alpha1_auth.yaml
-- hardwareprofile_v1_hardwareprofile.yaml

--- a/internal/controller/dscinitialization/hardwareprofile.go
+++ b/internal/controller/dscinitialization/hardwareprofile.go
@@ -5,8 +5,10 @@ import (
 	"fmt"
 	"path/filepath"
 
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
+	"github.com/opendatahub-io/opendatahub-operator/v2/api/common"
 	dsciv1 "github.com/opendatahub-io/opendatahub-operator/v2/api/dscinitialization/v1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
@@ -40,5 +42,34 @@ func (r *DSCInitializationReconciler) CreateVAP(ctx context.Context, dscInit *ds
 	}
 
 	log.V(1).Info("Successfully deployed VAP/VAPB resources")
+	return nil
+}
+
+// deploy hardware profile CR with dsci as owner, but allow user change by annotation set to false.
+func (r *DSCInitializationReconciler) ManageDefaultHWProfileCR(ctx context.Context, dscInit *dsciv1.DSCInitialization, platform common.Platform) error {
+	log := logf.FromContext(ctx)
+
+	if platform == "" { // this is for test to skip creation.
+		log.V(1).Info("Skipping HardwareProfile CR creation if platform is not set")
+		return nil
+	}
+
+	// Check if default HardwareProfile CR already exists
+	_, err := cluster.GetHardwareProfile(ctx, r.Client, "default-profile", dscInit.Spec.ApplicationsNamespace)
+	if err == nil {
+		log.V(1).Info("HardwareProfile CR 'default-profile' already exists")
+		return nil
+	}
+	if client.IgnoreNotFound(err) != nil {
+		return fmt.Errorf("failed to check default HardwareProfile CR: %w", err)
+	}
+
+	// deploy hardware profile CR with dsci as owner, but allow user change by have annotation in the default.
+	hwProfilePath := filepath.Join(deploy.DefaultManifestPath, "hardwareprofiles")
+	if err := deploy.DeployManifestsFromPath(ctx, r.Client, dscInit, hwProfilePath, dscInit.Spec.ApplicationsNamespace, "hardwareprofile", true); err != nil {
+		return fmt.Errorf("failed to deploy HardwareProfile CR from path %s: %w", hwProfilePath, err)
+	}
+
+	log.V(1).Info("Successfully deployed HardwareProfile CR default-profile")
 	return nil
 }

--- a/internal/controller/dscinitialization/suite_test.go
+++ b/internal/controller/dscinitialization/suite_test.go
@@ -47,6 +47,7 @@ import (
 
 	dscv1 "github.com/opendatahub-io/opendatahub-operator/v2/api/datasciencecluster/v1"
 	dsciv1 "github.com/opendatahub-io/opendatahub-operator/v2/api/dscinitialization/v1"
+	infrav1 "github.com/opendatahub-io/opendatahub-operator/v2/api/infrastructure/v1"
 	serviceApi "github.com/opendatahub-io/opendatahub-operator/v2/api/services/v1alpha1"
 	dscictrl "github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/dscinitialization"
 	"github.com/opendatahub-io/opendatahub-operator/v2/tests/envtestutil"
@@ -124,6 +125,7 @@ var _ = BeforeSuite(func() {
 	utilruntime.Must(configv1.Install(testScheme))
 	utilruntime.Must(serviceApi.AddToScheme(testScheme))
 	utilruntime.Must(monitoringv1.AddToScheme(testScheme))
+	utilruntime.Must(infrav1.AddToScheme(testScheme))
 	// +kubebuilder:scaffold:scheme
 
 	cli, err := client.New(cfg, client.Options{Scheme: testScheme})

--- a/pkg/cluster/resources.go
+++ b/pkg/cluster/resources.go
@@ -23,6 +23,7 @@ import (
 
 	dscv1 "github.com/opendatahub-io/opendatahub-operator/v2/api/datasciencecluster/v1"
 	dsciv1 "github.com/opendatahub-io/opendatahub-operator/v2/api/dscinitialization/v1"
+	infrav1 "github.com/opendatahub-io/opendatahub-operator/v2/api/infrastructure/v1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/resources"
 )
@@ -134,6 +135,19 @@ func GetDSCI(ctx context.Context, cli client.Client) (*dsciv1.DSCInitialization,
 	default:
 		return nil, fmt.Errorf("failed to get a valid %s instance, expected to find 1 instance, found %d", gvk.DSCInitialization, len(instances.Items))
 	}
+}
+
+// GetHardwareProfile retrieves a specific HardwareProfile instance by name and namespace.
+func GetHardwareProfile(ctx context.Context, cli client.Client, name, namespace string) (*infrav1.HardwareProfile, error) {
+	hwProfile := &infrav1.HardwareProfile{}
+	err := cli.Get(ctx, client.ObjectKey{
+		Name:      name,
+		Namespace: namespace,
+	}, hwProfile)
+	if err != nil {
+		return nil, err
+	}
+	return hwProfile, nil
 }
 
 // UpdatePodSecurityRolebinding update default rolebinding which is created in applications namespace by manifests

--- a/pkg/utils/test/envt/envt.go
+++ b/pkg/utils/test/envt/envt.go
@@ -262,7 +262,6 @@ func (et *EnvT) ReadFile(elem ...string) ([]byte, error) {
 }
 
 // Manager returns the controller-runtime manager for the test environment, if one was created.
-
 func (et *EnvT) Manager() manager.Manager {
 	return et.mgr
 }

--- a/tests/e2e/creation_test.go
+++ b/tests/e2e/creation_test.go
@@ -70,6 +70,7 @@ func dscManagementTestSuite(t *testing.T) {
 		// {"Validate ServiceMeshControlPlane exists and is recreated upon deletion.", dscTestCtx.ValidateServiceMeshControlPlane},
 		{"Validate VAP/VAPB creation after DSCI creation", dscTestCtx.ValidateVAPCreationAfterDSCI},
 		{"Validate Knative resource", dscTestCtx.ValidateKnativeSpecInDSC},
+		{"Validate HardwareProfile resource", dscTestCtx.ValidateHardwareProfileCR},
 		{"Validate owned namespaces exist", dscTestCtx.ValidateOwnedNamespacesAllExist},
 		{"Validate default NetworkPolicy exist", dscTestCtx.ValidateDefaultNetworkPolicyExists},
 		{"Validate Observability operators are installed", dscTestCtx.ValidateObservabilityOperatorsInstallation},
@@ -583,5 +584,54 @@ func (tc *DSCTestCtx) ValidateVAPCreationAfterDSCI(t *testing.T) {
 		WithCondition(Succeed()),
 		WithCustomErrorMsg("Failed to revert Dashboard after VAP test"),
 		WithEventuallyTimeout(tc.TestTimeouts.mediumEventuallyTimeout),
+	)
+}
+
+func (tc *DSCTestCtx) ValidateHardwareProfileCR(t *testing.T) {
+	t.Helper()
+
+	// verifed default hardwareprofile exists and api version is correct on v1.
+	tc.EnsureResourceExists(
+		WithMinimalObject(gvk.HardwareProfile, types.NamespacedName{Name: "default-profile", Namespace: tc.AppsNamespace}),
+		WithCondition(And(
+			jq.Match(`.spec.identifiers[0].defaultCount == 2`),
+			jq.Match(`.metadata.annotations["opendatahub.io/managed"] == "false"`),
+			jq.Match(`.apiVersion == "infrastructure.opendatahub.io/v1"`),
+		)),
+		WithCustomErrorMsg("Default hardwareprofile should have defaultCount=2, managed=false, and use v1 API version"),
+	)
+
+	// update default hardwareprofile to different value and check it is updated.
+	tc.EnsureResourceCreatedOrPatched(
+		WithMinimalObject(gvk.HardwareProfile, types.NamespacedName{Name: "default-profile", Namespace: tc.AppsNamespace}),
+		WithMutateFunc(testf.Transform(`
+			.spec.identifiers[0].defaultCount = 4 |
+			.metadata.annotations["opendatahub.io/managed"] = "false"
+		`)),
+		WithCondition(And(
+			Succeed(),
+			jq.Match(`.spec.identifiers[0].defaultCount == 4`),
+			jq.Match(`.metadata.annotations["opendatahub.io/managed"] == "false"`),
+		)),
+		WithCustomErrorMsg("Failed to update defaultCount from 2 to 4"),
+	)
+	tc.EnsureResourceExists(
+		WithMinimalObject(gvk.HardwareProfile, types.NamespacedName{Name: "default-profile", Namespace: tc.AppsNamespace}),
+		WithCondition(jq.Match(`.spec.identifiers[0].defaultCount == 4`)),
+		WithCustomErrorMsg("Should have defaultCount to 4 but now got %s", jq.Match(`.spec.identifiers[0].defaultCount`)),
+	)
+
+	// delete default hardwareprofile and check it is recreated with default values.
+	tc.DeleteResource(
+		WithMinimalObject(gvk.HardwareProfile, types.NamespacedName{Name: "default-profile", Namespace: tc.AppsNamespace}),
+	)
+
+	tc.EventuallyResourceCreatedOrUpdated(
+		WithMinimalObject(gvk.HardwareProfile, types.NamespacedName{Name: "default-profile", Namespace: tc.AppsNamespace}),
+		WithCondition(And(
+			jq.Match(`.spec.identifiers[0].defaultCount == 2`),
+			jq.Match(`.metadata.annotations["opendatahub.io/managed"] == "false"`),
+		)),
+		WithCustomErrorMsg("Hardware profile was not recreated with default values"),
 	)
 }


### PR DESCRIPTION
* feat: add default HWProfile CR "default-profile"

- remove the sample one we added before, with this PR it will create one in the cluster
- user will be able to change this default-profile CR, operator wont reconcile
- if user change DSCI or DSCI gets reconciled, it should not reset default-profile CR with user modified value.
- if user delete this default-profile CR, operator will create a new one with default values



---------


(cherry picked from commit 47598b42a873d500a05b584d77cc2d1687920a29)

<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->
sync https://github.com/opendatahub-io/opendatahub-operator/pull/2461

<!--- Link your JIRA and related links here for reference. -->
ref https://issues.redhat.com/browse/RHOAIENG-33160

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [ ] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->
