### PR TITLE
RHOAIENG-33734: Add standardization of monitoring resource names phase 1

### DIFF
--- a/config/monitoring/base/cluster-monitor-rolebinding.yaml
+++ b/config/monitoring/base/cluster-monitor-rolebinding.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: cluster-monitor-rhods-reader
+  name: data-science-cluster-monitor-reader
   namespace: redhat-ods-monitoring
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/config/monitoring/base/rhods-prometheus-role.yaml
+++ b/config/monitoring/base/rhods-prometheus-role.yaml
@@ -2,7 +2,7 @@
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: rhods-prometheus-cluster-monitoring-viewer
+  name: data-science-prometheus-cluster-monitoring-viewer
   namespace: redhat-ods-monitoring
 rules:
   - verbs:

--- a/config/monitoring/base/rhods-prometheus-rolebinding.yaml
+++ b/config/monitoring/base/rhods-prometheus-rolebinding.yaml
@@ -1,8 +1,8 @@
-# this is rolebingding to rhods-prometheus-cluster-monitoring-viewer for cluster-monitoring to read rhods prometheus service
+# this is rolebingding to data-science-prometheus-cluster-monitoring-viewer for cluster-monitoring to read rhods prometheus service
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: rhods-prometheus-cluster-monitoring-viewer-binding
+  name: data-science-prometheus-cluster-monitoring-viewer-binding
   namespace: redhat-ods-monitoring
 subjects:
   - kind: ServiceAccount
@@ -11,4 +11,4 @@ subjects:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: rhods-prometheus-cluster-monitoring-viewer
+  name: data-science-prometheus-cluster-monitoring-viewer

--- a/config/monitoring/base/rhods-prometheusrules.yaml
+++ b/config/monitoring/base/rhods-prometheusrules.yaml
@@ -10,7 +10,7 @@ metadata:
     prometheus: k8s
     role: recording-rules
     app: rhods
-  name: rhods-rules
+  name: data-science-rules
   namespace: redhat-ods-monitoring
 spec:
   groups:

--- a/config/monitoring/base/rhods-servicemonitor.yaml
+++ b/config/monitoring/base/rhods-servicemonitor.yaml
@@ -1,7 +1,7 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: rhods-monitor-federation
+  name: data-science-monitor-federation
   namespace: redhat-ods-monitoring
   labels:
     monitor-component: rhods-resources

--- a/config/monitoring/prometheus/base/prometheus-cm-service-ca.yaml
+++ b/config/monitoring/prometheus/base/prometheus-cm-service-ca.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: prometheus-service-ca
+  name: data-science-prometheus-service-ca
   namespace: redhat-ods-monitoring
   annotations:
     service.beta.openshift.io/inject-cabundle: "true"

--- a/config/monitoring/prometheus/base/prometheus-deployment.yaml
+++ b/config/monitoring/prometheus/base/prometheus-deployment.yaml
@@ -134,7 +134,7 @@ spec:
           name: prometheus-secret
 
         - mountPath: /etc/prometheus/ca
-          name: prometheus-service-ca
+          name: data-science-prometheus-service-ca
 
       - name: alertmanager-proxy
         args:
@@ -259,9 +259,9 @@ spec:
         configMap:
           defaultMode: 420
           name: prometheus
-      - name: prometheus-service-ca
+      - name: data-science-prometheus-service-ca
         configMap:
-          name: prometheus-service-ca
+          name: data-science-prometheus-service-ca
       - name: prometheus-secret
         secret:
           secretName: prometheus-secret

--- a/config/monitoring/prometheus/base/prometheus-rolebinding-scc.yaml
+++ b/config/monitoring/prometheus/base/prometheus-rolebinding-scc.yaml
@@ -1,7 +1,7 @@
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
- name: redhat-ods-monitoring
+ name: data-science-monitoring
 subjects:
  - kind: Group
    apiGroup: rbac.authorization.k8s.io

--- a/config/monitoring/prometheus/base/prometheus-sa.yaml
+++ b/config/monitoring/prometheus/base/prometheus-sa.yaml
@@ -3,5 +3,5 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: prometheus-reader
+  name: data-science-prometheus-reader
   namespace: redhat-ods-monitoring


### PR DESCRIPTION

## Description
<!--- Describe your changes in detail -->

The goal is to standardize all legacy monitoring resource names to the data-science-* convention.

Phase 1: Address 8 low-risk resources that are either always deployed or part of the legacy stack but have no breaking dependencies. This provides immediate, safe progress.


#### Scope:
PrometheusRule: rhods-rules
ServiceMonitor: rhods-monitor-federation
Role: rhods-prometheus-cluster-monitoring-viewer
RoleBinding: rhods-prometheus-cluster-monitoring-viewer-binding
RoleBinding: cluster-monitor-rhods-reader
RoleBinding: redhat-ods-monitoring
ServiceAccount: prometheus-reader
ConfigMap: prometheus-service-ca


<!--- Link your JIRA and related links here for reference. -->
* https://issues.redhat.com/browse/RHOAIENG-33734

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [ ] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->
