### PR TITLE
RHOAIENG-25595 | feat: Configure Tempo Datasource for Perses

### DIFF
--- a/internal/controller/dscinitialization/kubebuilder_rbac.go
+++ b/internal/controller/dscinitialization/kubebuilder_rbac.go
@@ -54,6 +54,12 @@ package dscinitialization
 /* Observability */
 // +kubebuilder:rbac:groups=tempo.grafana.com,resources=tempostacks,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=tempo.grafana.com,resources=tempomonolithics,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=perses.dev,resources=persesdashboards,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=perses.dev,resources=persesdashboards/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=perses.dev,resources=persesdashboards/finalizers,verbs=update
+//+kubebuilder:rbac:groups=perses.dev,resources=persesdatasources,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=perses.dev,resources=persesdatasources/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=perses.dev,resources=persesdatasources/finalizers,verbs=update
 //+kubebuilder:rbac:groups=monitoring.rhobs,resources=servicemonitors,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=monitoring.rhobs,resources=servicemonitors/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=monitoring.rhobs,resources=servicemonitors/finalizers,verbs=update

--- a/internal/controller/services/monitoring/monitoring_controller.go
+++ b/internal/controller/services/monitoring/monitoring_controller.go
@@ -101,6 +101,8 @@ func (h *serviceHandler) NewReconciler(ctx context.Context, mgr ctrl.Manager) er
 		OwnsGVK(gvk.PrometheusRule, reconciler.Dynamic(reconciler.CrdExists(gvk.PrometheusRule))).
 		OwnsGVK(gvk.ThanosQuerier, reconciler.Dynamic(reconciler.CrdExists(gvk.ThanosQuerier))).
 		OwnsGVK(gvk.Perses, reconciler.Dynamic(reconciler.CrdExists(gvk.Perses))).
+		OwnsGVK(gvk.PersesDatasource, reconciler.Dynamic(reconciler.CrdExists(gvk.PersesDatasource))).
+		OwnsGVK(gvk.PersesDashboard, reconciler.Dynamic(reconciler.CrdExists(gvk.PersesDashboard))).
 		// operands - watched
 		//
 		// By default the Watches functions adds:
@@ -134,6 +136,7 @@ func (h *serviceHandler) NewReconciler(ctx context.Context, mgr ctrl.Manager) er
 		WithAction(deployAlerting).
 		WithAction(deployOpenTelemetryCollector).
 		WithAction(deployPerses).
+		WithAction(deployPersesDatasource).
 		WithAction(template.NewAction(
 			template.WithDataFn(getTemplateData),
 		)).

--- a/internal/controller/services/monitoring/monitoring_controller_actions.go
+++ b/internal/controller/services/monitoring/monitoring_controller_actions.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -35,6 +36,12 @@ const (
 	ThanosQuerierTemplate                   = "resources/thanos-querier-cr.tmpl.yaml"
 	ThanosQuerierRouteTemplate              = "resources/thanos-querier-route.tmpl.yaml"
 	PersesTemplate                          = "resources/perses.tmpl.yaml"
+	PersesTempoDatasourceTemplate           = "resources/perses-tempo-datasource.tmpl.yaml"
+	PersesTempoDashboardTemplate            = "resources/perses-tempo-dashboard.tmpl.yaml"
+
+	// Resource names.
+	PersesTempoDatasourceName = "tempo-datasource"
+	PersesTempoDashboardName  = "data-science-tempo-traces"
 )
 
 // CRDRequirement defines a required CRD and its associated condition for monitoring components.
@@ -448,6 +455,96 @@ func deployPerses(ctx context.Context, rr *odhtypes.ReconciliationRequest) error
 		},
 	}
 	rr.Templates = append(rr.Templates, template...)
+
+	return nil
+}
+
+func deployPersesDatasource(ctx context.Context, rr *odhtypes.ReconciliationRequest) error {
+	monitoring, ok := rr.Instance.(*serviceApi.Monitoring)
+	if !ok {
+		return errors.New("instance is not of type *services.Monitoring")
+	}
+
+	// Check if PersesDatasource CRD exists first
+	persesDatasourceExists, err := cluster.HasCRD(ctx, rr.Client, gvk.PersesDatasource)
+	if err != nil {
+		return fmt.Errorf("failed to check if PersesDatasource CRD exists: %w", err)
+	}
+
+	// Check if PersesDashboard CRD exists
+	persesDashboardExists, err := cluster.HasCRD(ctx, rr.Client, gvk.PersesDashboard)
+	if err != nil {
+		return fmt.Errorf("failed to check if PersesDashboard CRD exists: %w", err)
+	}
+
+	// Only create Perses datasource if traces are configured
+	if monitoring.Spec.Traces == nil {
+		// Clean up existing datasource if its CRD exists
+		if persesDatasourceExists {
+			// Delete datasource
+			datasource := &unstructured.Unstructured{}
+			datasource.SetGroupVersionKind(gvk.PersesDatasource)
+			datasource.SetName(PersesTempoDatasourceName)
+			datasource.SetNamespace(monitoring.Spec.Namespace)
+
+			if err := rr.Client.Delete(ctx, datasource); err != nil {
+				if !k8serr.IsNotFound(err) {
+					return fmt.Errorf("failed to delete PersesDatasource: %w", err)
+				}
+			}
+		}
+
+		// Clean up existing dashboard if its CRD exists
+		if persesDashboardExists {
+			// Delete dashboard
+			dashboard := &unstructured.Unstructured{}
+			dashboard.SetGroupVersionKind(gvk.PersesDashboard)
+			dashboard.SetName(PersesTempoDashboardName)
+			dashboard.SetNamespace(monitoring.Spec.Namespace)
+
+			if err := rr.Client.Delete(ctx, dashboard); err != nil {
+				if !k8serr.IsNotFound(err) {
+					return fmt.Errorf("failed to delete PersesDashboard: %w", err)
+				}
+			}
+		}
+
+		rr.Conditions.MarkFalse(
+			status.ConditionPersesTempoDataSourceAvailable,
+			conditions.WithReason(status.TracesNotConfiguredReason),
+			conditions.WithMessage(status.TracesNotConfiguredMessage),
+		)
+		return nil
+	}
+
+	if !persesDatasourceExists {
+		rr.Conditions.MarkFalse(
+			status.ConditionPersesTempoDataSourceAvailable,
+			conditions.WithReason(gvk.PersesDatasource.Kind+"CRDNotFoundReason"),
+			conditions.WithMessage("%s CRD Not Found", gvk.PersesDatasource.Kind),
+		)
+		return nil
+	}
+
+	rr.Conditions.MarkTrue(status.ConditionPersesTempoDataSourceAvailable)
+
+	// Deploy datasource template (always deploy if CRD exists)
+	templates := []odhtypes.TemplateInfo{
+		{
+			FS:   resourcesFS,
+			Path: PersesTempoDatasourceTemplate,
+		},
+	}
+
+	// Only deploy dashboard template if its CRD exists
+	if persesDashboardExists {
+		templates = append(templates, odhtypes.TemplateInfo{
+			FS:   resourcesFS,
+			Path: PersesTempoDashboardTemplate,
+		})
+	}
+
+	rr.Templates = append(rr.Templates, templates...)
 
 	return nil
 }

--- a/internal/controller/services/monitoring/monitoring_controller_support.go
+++ b/internal/controller/services/monitoring/monitoring_controller_support.go
@@ -205,9 +205,13 @@ func addTracesTemplateData(templateData map[string]any, traces *serviceApi.Trace
 	switch traces.Storage.Backend {
 	case "pv":
 		templateData["TempoEndpoint"] = fmt.Sprintf("tempo-data-science-tempomonolithic.%s.svc.cluster.local:4317", namespace)
+		// Perses datasource needs HTTP query endpoint (port 3200)
+		templateData["TempoQueryEndpoint"] = fmt.Sprintf("http://tempo-data-science-tempomonolithic.%s.svc.cluster.local:3200", namespace)
 		templateData["Size"] = traces.Storage.Size
 	case "s3", "gcs":
 		templateData["TempoEndpoint"] = fmt.Sprintf("tempo-data-science-tempostack-gateway.%s.svc.cluster.local:4317", namespace)
+		// Perses datasource needs HTTP query endpoint via gateway (port 8080)
+		templateData["TempoQueryEndpoint"] = fmt.Sprintf("http://tempo-data-science-tempostack-gateway.%s.svc.cluster.local:8080", namespace)
 		templateData["Secret"] = traces.Storage.Secret
 	}
 

--- a/internal/controller/services/monitoring/resources/perses-tempo-dashboard.tmpl.yaml
+++ b/internal/controller/services/monitoring/resources/perses-tempo-dashboard.tmpl.yaml
@@ -1,0 +1,40 @@
+apiVersion: perses.dev/v1alpha1
+kind: PersesDashboard
+metadata:
+  name: data-science-tempo-traces
+  namespace: {{.Namespace}}
+spec:
+  display:
+    name: "RHOAI Distributed Tracing"
+  duration: "1h"
+  layouts:
+    - kind: Grid
+      spec:
+        display:
+          title: "Trace Visualization"
+        items:
+          - x: 0
+            y: 0
+            width: 24
+            height: 12
+            content:
+              $ref: "#/spec/panels/traces"
+  panels:
+    traces:
+      kind: Panel
+      spec:
+        display:
+          name: "Distributed Traces"
+        plugin:
+          kind: TraceTable
+          spec: {}
+        queries:
+          - kind: TraceQuery
+            spec:
+              plugin:
+                kind: TempoTraceQuery
+                spec:
+                  query: "{}"
+                  datasource:
+                    kind: TempoDatasource
+                    name: tempo-datasource

--- a/internal/controller/services/monitoring/resources/perses-tempo-datasource.tmpl.yaml
+++ b/internal/controller/services/monitoring/resources/perses-tempo-datasource.tmpl.yaml
@@ -1,0 +1,20 @@
+apiVersion: perses.dev/v1alpha1
+kind: PersesDatasource
+metadata:
+  name: tempo-datasource
+  namespace: {{.Namespace}}
+spec:
+  config:
+    default: false
+    display:
+      name: "RHOAI Tempo Datasource"
+      description: "Tempo datasource for distributed tracing in RHOAI"
+    plugin:
+      kind: "TempoDatasource"
+      spec:
+        proxy:
+          kind: HTTPProxy
+          spec:
+            url: {{.TempoQueryEndpoint}}
+            headers:
+              X-Scope-OrgID: {{.Namespace}}

--- a/internal/controller/status/status.go
+++ b/internal/controller/status/status.go
@@ -89,6 +89,7 @@ const (
 	ConditionAlertingAvailable               = "AlertingAvailable"
 	ConditionThanosQuerierAvailable          = "ThanosQuerierAvailable"
 	ConditionPersesAvailable                 = "PersesAvailable"
+	ConditionPersesTempoDataSourceAvailable  = "PersesTempoDataSourceAvailable"
 )
 
 const (

--- a/pkg/cluster/gvk/gvk.go
+++ b/pkg/cluster/gvk/gvk.go
@@ -559,6 +559,18 @@ var (
 		Kind:    "ThanosQuerier",
 	}
 
+	PersesDatasource = schema.GroupVersionKind{
+		Group:   "perses.dev",
+		Version: "v1alpha1",
+		Kind:    "PersesDatasource",
+	}
+
+	PersesDashboard = schema.GroupVersionKind{
+		Group:   "perses.dev",
+		Version: "v1alpha1",
+		Kind:    "PersesDashboard",
+	}
+
 	ValidatingAdmissionPolicy = schema.GroupVersionKind{
 		Group:   "admissionregistration.k8s.io",
 		Version: "v1",


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->
This PR implements the integration between Perses and the RHOAI-managed Tempo instance.
* Adds automatic PersesDatasource creation in Perses when traces are enabled in RHOAI
* Provides conditional logic: creates Tempo datasource when monitoring.traces is configured, removes it when not
* Supports both PV (port 3200) and S3/GCS (port 8080) Tempo storage backends

<!--- Link your JIRA and related links here for reference. -->
https://issues.redhat.com/browse/RHOAIENG-25595
## How Has This Been Tested?

* Ran tests
* Deployed cluster in managed mode: Built custom operator image with Perses-Tempo integration and deployed to OpenShift cluster
* Verified that the operator automatically created the PersesDatasource with the correct plugin and endpoint URL.
* Removed traces config from DSCI and verified the PersesDatasource was deleted and its status condition was correctly set to False.
* Validated handling of missing PersesDatasource CRD and confirmed correct endpoint generation for both PV and S3/GCS backends.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [ ] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Perses datasource and dashboard support for distributed tracing visualization when traces are configured
  * Automatic deployment and owner-management of Perses resources, with cleanup when traces are disabled
  * Added a status indicator for Perses Tempo datasource availability
  * Enabled automatic Tempo query endpoint configuration for trace data access

* **Tests**
  * Added end-to-end tests for Perses datasource creation and configuration validation
<!-- end of auto-generated comment: release notes by coderabbit.ai -->