### PR TITLE
feat(gateway): Enable configurable domain with platform-specific 

### DIFF
--- a/api/services/v1alpha1/gateway_types.go
+++ b/api/services/v1alpha1/gateway_types.go
@@ -45,6 +45,7 @@ type GatewayConfigSpec struct {
 	Certificate *infrav1.CertificateSpec `json:"certificate,omitempty"`
 
 	// Domain configuration for the GatewayConfig
+	// Example: apps.example.com
 	// +optional
 	Domain string `json:"domain,omitempty"`
 }

--- a/bundle/manifests/opendatahub-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/opendatahub-operator.clusterserviceversion.yaml
@@ -114,7 +114,7 @@ metadata:
     categories: AI/Machine Learning, Big Data
     certified: "False"
     containerImage: quay.io/opendatahub/opendatahub-operator:v3.0.0
-    createdAt: "2025-09-25T11:07:15Z"
+    createdAt: "2025-09-25T15:33:43Z"
     operators.operatorframework.io/builder: operator-sdk-v1.39.2
     operators.operatorframework.io/internal-objects: '["featuretrackers.features.opendatahub.io",
       "codeflares.components.platform.opendatahub.io", "dashboards.components.platform.opendatahub.io",
@@ -1094,6 +1094,7 @@ spec:
         - apiGroups:
           - networking.istio.io
           resources:
+          - destinationrules
           - envoyfilters
           - gateways
           - virtualservices

--- a/bundle/manifests/services.platform.opendatahub.io_gatewayconfigs.yaml
+++ b/bundle/manifests/services.platform.opendatahub.io_gatewayconfigs.yaml
@@ -71,7 +71,9 @@ spec:
                     type: string
                 type: object
               domain:
-                description: Domain configuration for the GatewayConfig
+                description: |-
+                  Domain configuration for the GatewayConfig
+                  Example: apps.example.com
                 type: string
               oidc:
                 description: OIDC configuration (used when cluster is in OIDC authentication

--- a/config/crd/bases/services.platform.opendatahub.io_gatewayconfigs.yaml
+++ b/config/crd/bases/services.platform.opendatahub.io_gatewayconfigs.yaml
@@ -71,7 +71,9 @@ spec:
                     type: string
                 type: object
               domain:
-                description: Domain configuration for the GatewayConfig
+                description: |-
+                  Domain configuration for the GatewayConfig
+                  Example: apps.example.com
                 type: string
               oidc:
                 description: OIDC configuration (used when cluster is in OIDC authentication

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -822,6 +822,7 @@ rules:
 - apiGroups:
   - networking.istio.io
   resources:
+  - destinationrules
   - envoyfilters
   - gateways
   - virtualservices

--- a/docs/api-overview.md
+++ b/docs/api-overview.md
@@ -3144,7 +3144,7 @@ _Appears in:_
 | --- | --- | --- | --- |
 | `oidc` _[OIDCConfig](#oidcconfig)_ | OIDC configuration (used when cluster is in OIDC authentication mode) |  |  |
 | `certificate` _[CertificateSpec](#certificatespec)_ | Certificate management |  |  |
-| `domain` _string_ | Domain configuration for the GatewayConfig |  |  |
+| `domain` _string_ | Domain configuration for the GatewayConfig<br />Example: apps.example.com |  |  |
 
 
 #### GatewayConfigStatus

--- a/internal/controller/dscinitialization/kubebuilder_rbac.go
+++ b/internal/controller/dscinitialization/kubebuilder_rbac.go
@@ -21,6 +21,7 @@ package dscinitialization
 // +kubebuilder:rbac:groups="networking.istio.io",resources=virtualservices,verbs=*
 // +kubebuilder:rbac:groups="networking.istio.io",resources=gateways,verbs=*
 // +kubebuilder:rbac:groups="networking.istio.io",resources=envoyfilters,verbs=*
+// +kubebuilder:rbac:groups="networking.istio.io",resources=destinationrules,verbs=*
 // +kubebuilder:rbac:groups="security.istio.io",resources=authorizationpolicies,verbs=*
 // +kubebuilder:rbac:groups="authorino.kuadrant.io",resources=authconfigs,verbs=*
 // +kubebuilder:rbac:groups="operator.authorino.kuadrant.io",resources=authorinos,verbs=*

--- a/internal/controller/services/gateway/gateway_controller.go
+++ b/internal/controller/services/gateway/gateway_controller.go
@@ -57,6 +57,11 @@ func (h *ServiceHandler) GetManagementState(platform common.Platform, _ *dsciv1.
 func (h *ServiceHandler) NewReconciler(ctx context.Context, mgr ctrl.Manager) error {
 	_, err := reconciler.ReconcilerFor(mgr, &serviceApi.GatewayConfig{}).
 		OwnsGVK(gvk.GatewayClass).
+		OwnsGVK(gvk.KubernetesGateway).
+		OwnsGVK(gvk.EnvoyFilter,
+			reconciler.Dynamic(reconciler.CrdExists(gvk.EnvoyFilter))).
+		OwnsGVK(gvk.DestinationRule,
+			reconciler.Dynamic(reconciler.CrdExists(gvk.DestinationRule))).
 		WithAction(createGatewayInfrastructure).
 		WithAction(createKubeAuthProxyInfrastructure).
 		WithAction(createEnvoyFilter).

--- a/internal/controller/services/gateway/gateway_controller_actions_test.go
+++ b/internal/controller/services/gateway/gateway_controller_actions_test.go
@@ -2,84 +2,641 @@
 package gateway
 
 import (
+	"fmt"
 	"testing"
 
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	infrav1 "github.com/opendatahub-io/opendatahub-operator/v2/api/infrastructure/v1"
 	serviceApi "github.com/opendatahub-io/opendatahub-operator/v2/api/services/v1alpha1"
+	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/status"
 	odhtypes "github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
 
 	. "github.com/onsi/gomega"
 )
 
-func TestCreateListeners(t *testing.T) {
-	g := NewWithT(t)
+const (
+	// Test constants.
+	testCertSecret        = "test-cert-secret"
+	testDomain            = "gateway.example.com"
+	testGatewayName       = "test-gateway"
+	testGatewayNameNoCert = "test-gateway-no-cert"
+	odhTestCert           = "odh-cert"
+	odhTestDomain         = "data-science-gateway.apps.cluster.example.com"
+	expectedHTTPSPort     = gwapiv1.PortNumber(443)
+	expectedHTTPSProtocol = gwapiv1.HTTPSProtocolType
+	expectedListenerName  = "https"
 
-	t.Run("creates HTTPS listener when certificate provided", func(t *testing.T) {
-		listeners := createListeners("test-cert-secret", "apps.test-cluster.com")
+	// Auth-specific test constants.
+	testOIDCIssuerURL = "https://auth.example.com"
+	testAuthDomain    = "apps.example.com"
+)
 
-		g.Expect(listeners).To(HaveLen(1))
-		g.Expect(string(listeners[0].Name)).To(Equal("https"))
-		g.Expect(listeners[0].Protocol).To(Equal(gwapiv1.HTTPSProtocolType))
-		g.Expect(listeners[0].Port).To(Equal(gwapiv1.PortNumber(443)))
-		g.Expect(listeners[0].Hostname).NotTo(BeNil())
-		g.Expect(string(*listeners[0].Hostname)).To(Equal("apps.test-cluster.com"))
-		g.Expect(listeners[0].TLS).NotTo(BeNil())
-		g.Expect(listeners[0].TLS.CertificateRefs).To(HaveLen(1))
-		g.Expect(string(listeners[0].TLS.CertificateRefs[0].Name)).To(Equal("test-cert-secret"))
-	})
-
-	t.Run("creates no listeners when no certificate", func(t *testing.T) {
-		listeners := createListeners("", "apps.test-cluster.com")
-
-		g.Expect(listeners).To(BeEmpty())
-	})
+// setupTestClient creates a fake client with the required scheme for Gateway API tests.
+func setupTestClient() client.Client {
+	scheme := runtime.NewScheme()
+	utilruntime.Must(corev1.AddToScheme(scheme))
+	utilruntime.Must(gwapiv1.Install(scheme))
+	utilruntime.Must(serviceApi.AddToScheme(scheme))
+	return fake.NewClientBuilder().WithScheme(scheme).Build()
 }
 
+// setupTestClientWithObjects creates a fake client with pre-existing objects.
+func setupTestClientWithObjects(objects ...client.Object) client.Client {
+	scheme := runtime.NewScheme()
+	utilruntime.Must(corev1.AddToScheme(scheme))
+	utilruntime.Must(gwapiv1.Install(scheme))
+	utilruntime.Must(serviceApi.AddToScheme(scheme))
+	return fake.NewClientBuilder().WithScheme(scheme).WithObjects(objects...).Build()
+}
+
+// gatewayConfigWithCert creates a test GatewayConfig with certificate spec.
+func gatewayConfigWithCert(name string, certType infrav1.CertType, secretName ...string) *serviceApi.GatewayConfig {
+	gc := &serviceApi.GatewayConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec: serviceApi.GatewayConfigSpec{
+			Certificate: &infrav1.CertificateSpec{Type: certType},
+		},
+	}
+	if len(secretName) > 0 && secretName[0] != "" {
+		gc.Spec.Certificate.SecretName = secretName[0]
+	}
+	return gc
+}
+
+// gatewayConfigNoCert creates a test GatewayConfig without certificate spec.
+func gatewayConfigNoCert(name string) *serviceApi.GatewayConfig {
+	return &serviceApi.GatewayConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec:       serviceApi.GatewayConfigSpec{},
+	}
+}
+
+// createTestGatewayConfig creates a test GatewayConfig for testing.
+func createTestGatewayConfig(name, domain string, certType infrav1.CertType) *serviceApi.GatewayConfig {
+	return &serviceApi.GatewayConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Spec: serviceApi.GatewayConfigSpec{
+			Domain: domain,
+			Certificate: &infrav1.CertificateSpec{
+				Type: certType,
+			},
+		},
+	}
+}
+
+// convertToGatewayClass converts unstructured resource to typed GatewayClass.
+func convertToGatewayClass(g *WithT, resource *unstructured.Unstructured) *gwapiv1.GatewayClass {
+	gatewayClass := &gwapiv1.GatewayClass{}
+	err := runtime.DefaultUnstructuredConverter.FromUnstructured(resource.Object, gatewayClass)
+	g.Expect(err).NotTo(HaveOccurred())
+	return gatewayClass
+}
+
+// convertToGateway converts unstructured resource to typed Gateway.
+func convertToGateway(g *WithT, resource *unstructured.Unstructured) *gwapiv1.Gateway {
+	gateway := &gwapiv1.Gateway{}
+	err := runtime.DefaultUnstructuredConverter.FromUnstructured(resource.Object, gateway)
+	g.Expect(err).NotTo(HaveOccurred())
+	return gateway
+}
+
+// TestCreateGatewayClass tests the createGatewayClass controller action function.
 func TestCreateGatewayClass(t *testing.T) {
+	t.Parallel()
 	g := NewWithT(t)
 
-	scheme := runtime.NewScheme()
-	utilruntime.Must(gwapiv1.Install(scheme))
-	client := fake.NewClientBuilder().WithScheme(scheme).Build()
-
 	rr := &odhtypes.ReconciliationRequest{
-		Client: client,
+		Client: setupTestClient(),
 	}
 
 	err := createGatewayClass(rr)
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(rr.Resources).To(HaveLen(1))
+
+	// Convert unstructured to typed GatewayClass
+	gatewayClass := convertToGatewayClass(g, &rr.Resources[0])
+
+	// Verify the GatewayClass resource has correct properties using typed access
+	g.Expect(gatewayClass.GetName()).To(Equal(GatewayClassName))
+	g.Expect(gatewayClass.Kind).To(Equal("GatewayClass"))
+	g.Expect(string(gatewayClass.Spec.ControllerName)).To(Equal(GatewayControllerName))
 }
 
-func TestGetCertificateType(t *testing.T) {
-	g := NewWithT(t)
+// TestCreateGateway tests the createGateway controller action function with different scenarios.
+func TestCreateGateway(t *testing.T) {
+	t.Parallel()
 
-	t.Run("returns default when certificate is nil", func(t *testing.T) {
-		gateway := &serviceApi.GatewayConfig{
-			Spec: serviceApi.GatewayConfigSpec{
-				Certificate: nil,
+	tests := []struct {
+		cert      string
+		domain    string
+		name      string
+		listeners int
+	}{
+		{testCertSecret, testDomain, testGatewayName, 1},
+		{"", testDomain, testGatewayNameNoCert, 0},
+		{odhTestCert, odhTestDomain, DefaultGatewayName, 1},
+	}
+
+	for _, test := range tests {
+		name := fmt.Sprintf("%s_%d_listeners", test.name, test.listeners)
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			g := NewWithT(t)
+
+			rr := &odhtypes.ReconciliationRequest{Client: setupTestClient()}
+			err := createGateway(rr, test.cert, test.domain, test.name)
+
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(rr.Resources).To(HaveLen(1))
+
+			gateway := convertToGateway(g, &rr.Resources[0])
+			g.Expect(gateway.GetName()).To(Equal(test.name))
+			g.Expect(gateway.GetNamespace()).To(Equal(GatewayNamespace))
+			g.Expect(gateway.Spec.Listeners).To(HaveLen(test.listeners))
+
+			if test.listeners > 0 {
+				listener := gateway.Spec.Listeners[0]
+				g.Expect(string(*listener.Hostname)).To(Equal(test.domain))
+				g.Expect(string(listener.Name)).To(Equal("https"))
+				if test.cert != "" {
+					g.Expect(string(listener.TLS.CertificateRefs[0].Name)).To(Equal(test.cert))
+				}
+			}
+		})
+	}
+}
+
+// TestHandleCertificates tests the handleCertificates function with different certificate types.
+func TestHandleCertificates(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		config *serviceApi.GatewayConfig
+		secret string
+		hasErr bool
+	}{
+		{"provided_with_secret", gatewayConfigWithCert("gw", infrav1.Provided, "my-secret"), "my-secret", false},
+		{"provided_no_secret", gatewayConfigWithCert("gw", infrav1.Provided), "gw-tls", false},
+		{"nil_certificate", gatewayConfigNoCert("gw"), "gw-tls", true},
+		{"unsupported_type", gatewayConfigWithCert("gw", "BadType"), "", true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewWithT(t)
+
+			rr := &odhtypes.ReconciliationRequest{Client: setupTestClient()}
+			secret, err := handleCertificates(t.Context(), rr, test.config, testDomain)
+
+			if test.hasErr {
+				g.Expect(err).To(HaveOccurred())
+			} else {
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(secret).To(Equal(test.secret))
+			}
+		})
+	}
+}
+
+// TestSyncGatewayConfigStatus tests the syncGatewayConfigStatus function.
+func TestSyncGatewayConfigStatus(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name              string
+		gatewayConfig     *serviceApi.GatewayConfig
+		gateway           *gwapiv1.Gateway
+		expectedCondition metav1.ConditionStatus
+		expectedReason    string
+		expectedMessage   string
+		gatewayNotFound   bool
+		description       string
+	}{
+		{
+			name: "gateway ready condition true",
+			gatewayConfig: &serviceApi.GatewayConfig{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-gateway"},
 			},
-		}
-
-		certType := getCertificateType(gateway)
-		g.Expect(certType).To(Equal(string(infrav1.OpenshiftDefaultIngress)))
-	})
-
-	t.Run("returns certificate type when specified", func(t *testing.T) {
-		gateway := &serviceApi.GatewayConfig{
-			Spec: serviceApi.GatewayConfigSpec{
-				Certificate: &infrav1.CertificateSpec{
-					Type: infrav1.SelfSigned,
+			gateway: &gwapiv1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      DefaultGatewayName,
+					Namespace: GatewayNamespace,
+				},
+				Status: gwapiv1.GatewayStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:   string(gwapiv1.GatewayConditionAccepted),
+							Status: metav1.ConditionTrue,
+						},
+					},
 				},
 			},
-		}
+			expectedCondition: metav1.ConditionTrue,
+			expectedReason:    status.ReadyReason,
+			expectedMessage:   status.GatewayReadyMessage,
+			description:       "should set ready condition when gateway is accepted",
+		},
+		{
+			name: "gateway not ready condition false",
+			gatewayConfig: &serviceApi.GatewayConfig{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-gateway"},
+			},
+			gateway: &gwapiv1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      DefaultGatewayName,
+					Namespace: GatewayNamespace,
+				},
+				Status: gwapiv1.GatewayStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:   string(gwapiv1.GatewayConditionAccepted),
+							Status: metav1.ConditionFalse,
+						},
+					},
+				},
+			},
+			expectedCondition: metav1.ConditionFalse,
+			expectedReason:    status.NotReadyReason,
+			expectedMessage:   status.GatewayNotReadyMessage,
+			description:       "should set not ready condition when gateway is not accepted",
+		},
+		{
+			name: "gateway not found",
+			gatewayConfig: &serviceApi.GatewayConfig{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-gateway"},
+			},
+			gatewayNotFound:   true,
+			expectedCondition: metav1.ConditionFalse,
+			expectedReason:    status.NotReadyReason,
+			expectedMessage:   status.GatewayNotFoundMessage,
+			description:       "should set not found condition when gateway doesn't exist",
+		},
+	}
 
-		certType := getCertificateType(gateway)
-		g.Expect(certType).To(Equal(string(infrav1.SelfSigned)))
-	})
+	for _, tc := range testCases {
+		// capture range var for parallel subtests
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewWithT(t)
+			ctx := t.Context()
+
+			var client client.Client
+			if tc.gatewayNotFound {
+				client = setupTestClient()
+			} else {
+				client = setupTestClientWithObjects(tc.gateway)
+			}
+
+			rr := &odhtypes.ReconciliationRequest{
+				Client:   client,
+				Instance: tc.gatewayConfig,
+			}
+
+			err := syncGatewayConfigStatus(ctx, rr)
+			g.Expect(err).NotTo(HaveOccurred(), tc.description)
+
+			// Verify the condition was set correctly
+			conditions := tc.gatewayConfig.GetConditions()
+			g.Expect(conditions).To(HaveLen(1))
+			condition := conditions[0]
+			g.Expect(condition.Type).To(Equal(status.ConditionTypeReady))
+			g.Expect(condition.Status).To(Equal(tc.expectedCondition))
+			g.Expect(condition.Reason).To(Equal(tc.expectedReason))
+			g.Expect(condition.Message).To(Equal(tc.expectedMessage))
+		})
+	}
+}
+
+// TestSyncGatewayConfigStatusInvalidInstance tests error handling for invalid instance type.
+func TestSyncGatewayConfigStatusInvalidInstance(t *testing.T) {
+	t.Parallel()
+	g := NewWithT(t)
+
+	ctx := t.Context()
+	rr := &odhtypes.ReconciliationRequest{
+		Client:   setupTestClient(),
+		Instance: &serviceApi.Auth{}, // Wrong type
+	}
+
+	err := syncGatewayConfigStatus(ctx, rr)
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("instance is not of type *services.GatewayConfig"))
+}
+
+// TestCreateGatewayInfrastructureInvalidInstance tests error handling for invalid instance type.
+func TestCreateGatewayInfrastructureInvalidInstance(t *testing.T) {
+	t.Parallel()
+	g := NewWithT(t)
+
+	ctx := t.Context()
+	rr := &odhtypes.ReconciliationRequest{
+		Client:   setupTestClient(),
+		Instance: &serviceApi.Auth{}, // Wrong type
+	}
+
+	err := createGatewayInfrastructure(ctx, rr)
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("instance is not of type *services.GatewayConfig"))
+}
+
+// TestCreateGatewayInfrastructureWithProvidedCertificate tests the main orchestrator function with provided certificate.
+func TestCreateGatewayInfrastructureWithProvidedCertificate(t *testing.T) {
+	t.Parallel()
+	g := NewWithT(t)
+
+	ctx := t.Context()
+	gatewayConfig := createTestGatewayConfig("test-gateway", testDomain, infrav1.Provided)
+	gatewayConfig.Spec.Certificate.SecretName = testCertSecret
+
+	rr := &odhtypes.ReconciliationRequest{
+		Client:   setupTestClient(),
+		Instance: gatewayConfig,
+	}
+
+	err := createGatewayInfrastructure(ctx, rr)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	// Should create GatewayClass and Gateway resources
+	g.Expect(rr.Resources).To(HaveLen(2))
+
+	// Verify GatewayClass
+	gatewayClass := convertToGatewayClass(g, &rr.Resources[0])
+	g.Expect(gatewayClass.GetName()).To(Equal(GatewayClassName))
+
+	// Verify Gateway
+	gateway := convertToGateway(g, &rr.Resources[1])
+	expectedGatewayName := DefaultGatewayName
+	g.Expect(gateway.GetName()).To(Equal(expectedGatewayName))
+	g.Expect(gateway.GetNamespace()).To(Equal(GatewayNamespace))
+}
+
+// TestValidateOIDCConfig tests the OIDC configuration validation logic.
+func TestValidateOIDCConfig(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name        string
+		authMode    AuthMode
+		oidcConfig  *serviceApi.OIDCConfig
+		expectError bool
+		description string
+	}{
+		{
+			name:        "OIDC mode with valid config",
+			authMode:    AuthModeOIDC,
+			oidcConfig:  &serviceApi.OIDCConfig{IssuerURL: testOIDCIssuerURL},
+			expectError: false,
+			description: "should pass when OIDC mode has valid configuration",
+		},
+		{
+			name:        "OIDC mode with missing config",
+			authMode:    AuthModeOIDC,
+			oidcConfig:  nil,
+			expectError: true,
+			description: "should fail when OIDC mode has no configuration",
+		},
+		{
+			name:        "IntegratedOAuth mode",
+			authMode:    AuthModeIntegratedOAuth,
+			oidcConfig:  nil,
+			expectError: false,
+			description: "should pass for IntegratedOAuth mode regardless of OIDC config",
+		},
+		{
+			name:        "None mode",
+			authMode:    AuthModeNone,
+			oidcConfig:  nil,
+			expectError: false,
+			description: "should pass for None mode regardless of OIDC config",
+		},
+	}
+
+	for _, tc := range testCases {
+		// capture range var for parallel subtests
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewWithT(t)
+			condition := validateOIDCConfig(tc.authMode, tc.oidcConfig)
+
+			if tc.expectError {
+				g.Expect(condition).NotTo(BeNil(), tc.description)
+				g.Expect(condition.Type).To(Equal(status.ConditionTypeReady))
+				g.Expect(condition.Status).To(Equal(metav1.ConditionFalse))
+				g.Expect(condition.Reason).To(Equal(status.NotReadyReason))
+				g.Expect(condition.Message).To(ContainSubstring("OIDC"))
+			} else {
+				g.Expect(condition).To(BeNil(), tc.description)
+			}
+		})
+	}
+}
+
+// TestCheckAuthModeNone tests the None authentication mode validation logic.
+func TestCheckAuthModeNone(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name        string
+		authMode    AuthMode
+		expectError bool
+		description string
+	}{
+		{
+			name:        "None auth mode",
+			authMode:    AuthModeNone,
+			expectError: true,
+			description: "should return condition when auth mode is None",
+		},
+		{
+			name:        "IntegratedOAuth auth mode",
+			authMode:    AuthModeIntegratedOAuth,
+			expectError: false,
+			description: "should return nil for IntegratedOAuth mode",
+		},
+		{
+			name:        "OIDC auth mode",
+			authMode:    AuthModeOIDC,
+			expectError: false,
+			description: "should return nil for OIDC mode",
+		},
+	}
+
+	for _, tc := range testCases {
+		// capture range var for parallel subtests
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewWithT(t)
+			condition := checkAuthModeNone(tc.authMode)
+
+			if tc.expectError {
+				g.Expect(condition).NotTo(BeNil(), tc.description)
+				g.Expect(condition.Type).To(Equal(status.ConditionTypeReady))
+				g.Expect(condition.Status).To(Equal(metav1.ConditionFalse))
+				g.Expect(condition.Reason).To(Equal(status.NotReadyReason))
+				g.Expect(condition.Message).To(ContainSubstring("external authentication"))
+			} else {
+				g.Expect(condition).To(BeNil(), tc.description)
+			}
+		})
+	}
+}
+
+// TestCreateKubeAuthProxyService tests the auth proxy service creation logic.
+func TestCreateKubeAuthProxyService(t *testing.T) {
+	t.Parallel()
+	g := NewWithT(t)
+
+	rr := &odhtypes.ReconciliationRequest{
+		Client: setupTestClient(),
+	}
+
+	err := createKubeAuthProxyService(rr)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(rr.Resources).To(HaveLen(1))
+
+	// Convert unstructured to typed Service
+	serviceResource := &rr.Resources[0]
+	service := &corev1.Service{}
+	err = runtime.DefaultUnstructuredConverter.FromUnstructured(serviceResource.Object, service)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	// Verify service properties
+	g.Expect(service.GetName()).To(Equal(KubeAuthProxyName))
+	g.Expect(service.GetNamespace()).To(Equal(GatewayNamespace))
+	g.Expect(service.Labels).To(Equal(KubeAuthProxyLabels))
+	g.Expect(service.Spec.Selector).To(Equal(KubeAuthProxyLabels))
+
+	// Verify annotations
+	expectedAnnotations := map[string]string{
+		"service.beta.openshift.io/serving-cert-secret-name": KubeAuthProxyTLSName,
+	}
+	g.Expect(service.Annotations).To(Equal(expectedAnnotations))
+
+	// Verify port configuration
+	g.Expect(service.Spec.Ports).To(HaveLen(1))
+	port := service.Spec.Ports[0]
+	g.Expect(port.Name).To(Equal("https"))
+	g.Expect(port.Port).To(Equal(int32(AuthProxyHTTPSPort)))
+	g.Expect(port.TargetPort).To(Equal(intstr.FromInt(AuthProxyHTTPSPort)))
+}
+
+// TestCreateOAuthCallbackRoute tests the OAuth callback route creation logic.
+func TestCreateOAuthCallbackRoute(t *testing.T) {
+	t.Parallel()
+	g := NewWithT(t)
+
+	rr := &odhtypes.ReconciliationRequest{
+		Client: setupTestClient(),
+	}
+
+	err := createOAuthCallbackRoute(rr)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(rr.Resources).To(HaveLen(1))
+
+	// Convert unstructured to typed HTTPRoute
+	routeResource := &rr.Resources[0]
+	httpRoute := &gwapiv1.HTTPRoute{}
+	err = runtime.DefaultUnstructuredConverter.FromUnstructured(routeResource.Object, httpRoute)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	// Verify HTTPRoute properties
+	g.Expect(httpRoute.GetName()).To(Equal(OAuthCallbackRouteName))
+	g.Expect(httpRoute.GetNamespace()).To(Equal(GatewayNamespace))
+
+	// Verify ParentRefs (gateway reference)
+	g.Expect(httpRoute.Spec.ParentRefs).To(HaveLen(1))
+	parentRef := httpRoute.Spec.ParentRefs[0]
+	expectedGatewayName := DefaultGatewayName
+	g.Expect(string(parentRef.Name)).To(Equal(expectedGatewayName))
+	g.Expect(string(*parentRef.Namespace)).To(Equal(GatewayNamespace))
+
+	// Verify routing rules
+	g.Expect(httpRoute.Spec.Rules).To(HaveLen(1))
+	rule := httpRoute.Spec.Rules[0]
+
+	// Verify path matching
+	g.Expect(rule.Matches).To(HaveLen(1))
+	match := rule.Matches[0]
+	g.Expect(match.Path).NotTo(BeNil())
+	g.Expect(*match.Path.Value).To(Equal(AuthProxyOAuth2Path))
+	g.Expect(*match.Path.Type).To(Equal(gwapiv1.PathMatchPathPrefix))
+
+	// Verify backend refs
+	g.Expect(rule.BackendRefs).To(HaveLen(1))
+	backendRef := rule.BackendRefs[0]
+	g.Expect(string(backendRef.Name)).To(Equal(KubeAuthProxyName))
+	g.Expect(*backendRef.Port).To(Equal(gwapiv1.PortNumber(AuthProxyHTTPSPort)))
+}
+
+// TestBuildOAuth2ProxyArgsOpenShift tests OAuth2 proxy arguments for OpenShift mode.
+func TestBuildOAuth2ProxyArgsOpenShift(t *testing.T) {
+	t.Parallel()
+	g := NewWithT(t)
+
+	args := buildOAuth2ProxyArgs(nil, "data-science-gateway.apps.example.com") // nil = OpenShift mode
+
+	// Verify base arguments are present
+	g.Expect(args).To(ContainElement(ContainSubstring("--http-address=0.0.0.0:")))
+	g.Expect(args).To(ContainElement("--email-domain=*"))
+	g.Expect(args).To(ContainElement("--upstream=static://200"))
+	g.Expect(args).To(ContainElement("--skip-provider-button"))
+	g.Expect(args).To(ContainElement("--pass-access-token=true"))
+	g.Expect(args).To(ContainElement("--set-xauthrequest=true"))
+	g.Expect(args).To(ContainElement(ContainSubstring("--redirect-url=https://")))
+
+	// Verify OpenShift-specific arguments
+	g.Expect(args).To(ContainElement("--provider=openshift"))
+	g.Expect(args).To(ContainElement("--scope=user:full"))
+	g.Expect(args).To(ContainElement(ContainSubstring("--tls-cert-file=" + TLSCertsMountPath)))
+	g.Expect(args).To(ContainElement(ContainSubstring("--tls-key-file=" + TLSCertsMountPath)))
+	g.Expect(args).To(ContainElement(ContainSubstring("--https-address=0.0.0.0:")))
+
+	// Verify OIDC-specific arguments are NOT present
+	g.Expect(args).NotTo(ContainElement("--provider=oidc"))
+	g.Expect(args).NotTo(ContainElement(ContainSubstring("--oidc-issuer-url=")))
+}
+
+// TestBuildOAuth2ProxyArgsOIDC tests OAuth2 proxy arguments for OIDC mode.
+func TestBuildOAuth2ProxyArgsOIDC(t *testing.T) {
+	t.Parallel()
+	g := NewWithT(t)
+
+	oidcConfig := &serviceApi.OIDCConfig{
+		IssuerURL: testOIDCIssuerURL,
+	}
+
+	args := buildOAuth2ProxyArgs(oidcConfig, "data-science-gateway.apps.example.com")
+
+	// Verify base arguments are present
+	g.Expect(args).To(ContainElement(ContainSubstring("--http-address=0.0.0.0:")))
+	g.Expect(args).To(ContainElement("--email-domain=*"))
+	g.Expect(args).To(ContainElement("--upstream=static://200"))
+	g.Expect(args).To(ContainElement("--skip-provider-button"))
+	g.Expect(args).To(ContainElement("--pass-access-token=true"))
+	g.Expect(args).To(ContainElement("--set-xauthrequest=true"))
+	g.Expect(args).To(ContainElement(ContainSubstring("--redirect-url=https://")))
+
+	// Verify OIDC-specific arguments
+	g.Expect(args).To(ContainElement("--provider=oidc"))
+	g.Expect(args).To(ContainElement("--oidc-issuer-url=" + testOIDCIssuerURL))
+	g.Expect(args).To(ContainElement("--ssl-insecure-skip-verify=true"))
+
+	// Verify OpenShift-specific arguments are NOT present
+	g.Expect(args).NotTo(ContainElement("--provider=openshift"))
+	g.Expect(args).NotTo(ContainElement("--scope=user:full"))
+	g.Expect(args).NotTo(ContainElement(ContainSubstring("--tls-cert-file=")))
+	g.Expect(args).NotTo(ContainElement(ContainSubstring("--https-address=")))
 }

--- a/internal/controller/services/gateway/gateway_controller_test.go
+++ b/internal/controller/services/gateway/gateway_controller_test.go
@@ -1,0 +1,154 @@
+package gateway_test
+
+import (
+	"testing"
+
+	operatorv1 "github.com/openshift/api/operator/v1"
+
+	"github.com/opendatahub-io/opendatahub-operator/v2/api/common"
+	dsciv1 "github.com/opendatahub-io/opendatahub-operator/v2/api/dscinitialization/v1"
+	serviceApi "github.com/opendatahub-io/opendatahub-operator/v2/api/services/v1alpha1"
+	gatewayctrl "github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/services/gateway"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
+
+	. "github.com/onsi/gomega"
+)
+
+// newServiceHandler creates a new Gateway ServiceHandler for testing.
+func newServiceHandler() *gatewayctrl.ServiceHandler {
+	return &gatewayctrl.ServiceHandler{}
+}
+
+// allPlatforms returns all supported platforms for comprehensive testing.
+func allPlatforms() []struct {
+	name     string
+	platform common.Platform
+} {
+	return []struct {
+		name     string
+		platform common.Platform
+	}{
+		{"OpenDataHub", cluster.OpenDataHub},
+		{"SelfManagedRhoai", cluster.SelfManagedRhoai},
+		{"ManagedRhoai", cluster.ManagedRhoai},
+	}
+}
+
+func TestServiceHandler_GetName(t *testing.T) {
+	t.Parallel()
+	g := NewWithT(t)
+	handler := newServiceHandler()
+
+	name := handler.GetName()
+	g.Expect(name).Should(Equal(serviceApi.GatewayServiceName))
+}
+
+func TestServiceHandler_Init(t *testing.T) {
+	t.Parallel()
+	handler := newServiceHandler()
+
+	for _, platform := range allPlatforms() {
+		// capture loop variable
+		t.Run("should initialize successfully for "+platform.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewWithT(t)
+
+			err := handler.Init(platform.platform)
+			g.Expect(err).ShouldNot(HaveOccurred(), platform.name+" platform should initialize without errors")
+		})
+	}
+}
+
+func TestServiceHandler_GetManagementState(t *testing.T) {
+	t.Parallel()
+	handler := newServiceHandler()
+
+	tests := []struct {
+		name string
+		dsci *dsciv1.DSCInitialization
+	}{
+		{"with empty DSCInitialization", &dsciv1.DSCInitialization{}},
+		{"with nil DSCInitialization", nil},
+		{"with configured DSCInitialization", &dsciv1.DSCInitialization{
+			Spec: dsciv1.DSCInitializationSpec{
+				ApplicationsNamespace: "test-namespace",
+			},
+		}},
+	}
+
+	// Test all platforms return Managed state
+	for _, platform := range allPlatforms() {
+		// capture loop variable
+		t.Run("should return Managed for "+platform.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewWithT(t)
+
+			state := handler.GetManagementState(platform.platform, &dsciv1.DSCInitialization{})
+			g.Expect(state).Should(Equal(operatorv1.Managed), platform.name+" should always be managed")
+		})
+	}
+
+	// Test different DSCI configurations
+	for _, tt := range tests {
+		// capture loop variable
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewWithT(t)
+
+			state := handler.GetManagementState(cluster.OpenDataHub, tt.dsci)
+			g.Expect(state).Should(Equal(operatorv1.Managed), "Should always return Managed regardless of DSCI config")
+		})
+	}
+}
+
+func TestServiceHandler_NewReconciler(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+	handler := newServiceHandler()
+
+	t.Run("should handle nil manager gracefully", func(t *testing.T) {
+		t.Parallel()
+		g := NewWithT(t)
+
+		defer func() {
+			if r := recover(); r != nil {
+				g.Expect(r).ShouldNot(BeNil(), "Should recover from nil manager panic")
+			}
+		}()
+
+		_ = handler.NewReconciler(ctx, nil)
+	})
+}
+
+func TestServiceHandler_Implements_ServiceInterface(t *testing.T) {
+	t.Parallel()
+	g := NewWithT(t)
+	handler := newServiceHandler()
+
+	// Verify all required methods exist and work correctly
+	err := handler.Init(cluster.OpenDataHub)
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	name := handler.GetName()
+	g.Expect(name).Should(Equal(serviceApi.GatewayServiceName))
+
+	state := handler.GetManagementState(cluster.OpenDataHub, &dsciv1.DSCInitialization{})
+	g.Expect(state).Should(Equal(operatorv1.Managed))
+
+	// Test NewReconciler method exists (will panic with nil manager)
+	defer func() {
+		r := recover()
+		g.Expect(r).ShouldNot(BeNil())
+	}()
+	_ = handler.NewReconciler(t.Context(), nil)
+}
+
+func TestServiceHandler_ServiceName_Consistency(t *testing.T) {
+	t.Parallel()
+	g := NewWithT(t)
+	handler := newServiceHandler()
+
+	handlerName := handler.GetName()
+	g.Expect(handlerName).Should(Equal(serviceApi.GatewayServiceName))
+	g.Expect(handlerName).ShouldNot(BeEmpty())
+}

--- a/internal/controller/services/gateway/gateway_support.go
+++ b/internal/controller/services/gateway/gateway_support.go
@@ -1,0 +1,133 @@
+package gateway
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/opendatahub-io/opendatahub-operator/v2/api/common"
+	infrav1 "github.com/opendatahub-io/opendatahub-operator/v2/api/infrastructure/v1"
+	serviceApi "github.com/opendatahub-io/opendatahub-operator/v2/api/services/v1alpha1"
+	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/status"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
+)
+
+const (
+	// GatewayNamespace is the namespace where Gateway resources are deployed.
+	GatewayNamespace = "openshift-ingress"
+
+	// GatewayClassName is the name of the GatewayClass used for data science gateways.
+	GatewayClassName = "data-science-gateway-class"
+
+	// GatewayControllerName is the OpenShift Gateway API controller name.
+	GatewayControllerName = "openshift.io/gateway-controller/v1"
+
+	// Auth-related constants.
+	AuthClientID = "odh"
+
+	// Auth proxy constants.
+	KubeAuthProxyName        = "kube-auth-proxy"
+	KubeAuthProxySecretsName = "kube-auth-proxy-creds" //nolint:gosec // This is a resource name, not actual credentials
+	KubeAuthProxyTLSName     = "kube-auth-proxy-tls"
+	OAuthCallbackRouteName   = "oauth-callback-route"
+
+	// Auth proxy configuration.
+	AuthProxyHTTPPort   = 4180
+	AuthProxyHTTPSPort  = 8443
+	AuthProxyOAuth2Path = "/oauth2"
+	TLSCertsVolumeName  = "tls-certs"
+	TLSCertsMountPath   = "/etc/tls/private"
+
+	// Secret generation lengths.
+	ClientSecretLength     = 24
+	CookieSecretLength     = 32
+	DefaultClientSecretKey = "clientSecret"
+
+	// Default gateway name used across all platforms.
+	DefaultGatewayName = "data-science-gateway"
+
+	// TODO: Replace with the correct image.
+	KubeAuthProxyImage = "quay.io/jtanner/kube-auth-proxy@sha256:434580fd42d73727d62566ff6d8336219a31b322798b48096ed167daaec42f07"
+)
+
+var (
+	// Common labels for auth proxy resources.
+	KubeAuthProxyLabels = map[string]string{"app": KubeAuthProxyName}
+)
+
+// GetCertificateType returns a string representation of the certificate type.
+func GetCertificateType(gatewayConfig *serviceApi.GatewayConfig) string {
+	if gatewayConfig.Spec.Certificate == nil {
+		return string(infrav1.OpenshiftDefaultIngress)
+	}
+	return string(gatewayConfig.Spec.Certificate.Type)
+}
+
+func ResolveDomain(ctx context.Context, client client.Client,
+	gatewayConfig *serviceApi.GatewayConfig, gatewayName string) (string, error) {
+	// Determine base domain
+	baseDomain := strings.TrimSpace(gatewayConfig.Spec.Domain)
+	if baseDomain == "" {
+		var err error
+		baseDomain, err = cluster.GetDomain(ctx, client)
+		if err != nil {
+			return "", fmt.Errorf("failed to get cluster domain: %w", err)
+		}
+	}
+
+	// Combine gateway name with base domain
+	// e.g. data-science-gateway.apps.example.com
+	return fmt.Sprintf("%s.%s", gatewayName, baseDomain), nil
+}
+
+// CreateListeners creates the Gateway listeners configuration.
+func CreateListeners(certSecretName string, domain string) []gwapiv1.Listener {
+	listeners := []gwapiv1.Listener{}
+
+	if certSecretName != "" {
+		from := gwapiv1.NamespacesFromAll
+		httpsMode := gwapiv1.TLSModeTerminate
+		hostname := gwapiv1.Hostname(domain)
+		httpsListener := gwapiv1.Listener{
+			Name:     "https",
+			Protocol: gwapiv1.HTTPSProtocolType,
+			Port:     443,
+			Hostname: &hostname,
+			TLS: &gwapiv1.GatewayTLSConfig{
+				Mode: &httpsMode,
+				CertificateRefs: []gwapiv1.SecretObjectReference{
+					{
+						Name: gwapiv1.ObjectName(certSecretName),
+					},
+				},
+			},
+			AllowedRoutes: &gwapiv1.AllowedRoutes{
+				Namespaces: &gwapiv1.RouteNamespaces{
+					From: &from,
+				},
+			},
+		}
+		listeners = append(listeners, httpsListener)
+	}
+
+	return listeners
+}
+
+// CreateErrorCondition creates a standardized error condition for gateway operations.
+func CreateErrorCondition(message string, err error) common.Condition {
+	fullMessage := message
+	if err != nil {
+		fullMessage = fmt.Sprintf("%s: %v", message, err)
+	}
+
+	return common.Condition{
+		Type:    status.ConditionTypeReady,
+		Status:  metav1.ConditionFalse,
+		Reason:  status.NotReadyReason,
+		Message: fullMessage,
+	}
+}

--- a/internal/controller/services/gateway/gateway_support_test.go
+++ b/internal/controller/services/gateway/gateway_support_test.go
@@ -1,0 +1,336 @@
+//nolint:testpackage
+package gateway
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	infrav1 "github.com/opendatahub-io/opendatahub-operator/v2/api/infrastructure/v1"
+	serviceApi "github.com/opendatahub-io/opendatahub-operator/v2/api/services/v1alpha1"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
+
+	. "github.com/onsi/gomega"
+)
+
+const (
+	// Test constants for gateway support functions.
+	testCertSecretSupport = "test-cert-secret"
+	testDomainSupport     = "data-science-gateway.apps.test-cluster.com"
+	testClusterDomain     = "apps.cluster.example.com"
+	testUserDomain        = "apps.example.com"
+	customCertSecret      = "my-cert"
+	unknownPlatform       = "unknown-platform"
+
+	// Expected values constants.
+	expectedHTTPSListenerName    = "https"
+	expectedHTTPSPortSupport     = gwapiv1.PortNumber(443)
+	expectedHTTPSProtocolSupport = gwapiv1.HTTPSProtocolType
+	expectedODHDomain            = "data-science-gateway.apps.example.com"
+	expectedClusterDomain        = "data-science-gateway.apps.cluster.example.com"
+)
+
+// setupSupportTestClient creates a fake client with required schemes for support function tests.
+func setupSupportTestClient() client.Client {
+	scheme := runtime.NewScheme()
+	utilruntime.Must(serviceApi.AddToScheme(scheme))
+	return fake.NewClientBuilder().WithScheme(scheme).Build()
+}
+
+// setupSupportTestClientWithClusterIngress creates a fake client with a mock cluster ingress object.
+func setupSupportTestClientWithClusterIngress(domain string) client.Client {
+	scheme := runtime.NewScheme()
+	utilruntime.Must(serviceApi.AddToScheme(scheme))
+
+	clusterIngress := &unstructured.Unstructured{}
+	clusterIngress.SetGroupVersionKind(gvk.OpenshiftIngress)
+	clusterIngress.SetName("cluster")
+
+	// Set the spec.domain field
+	_ = unstructured.SetNestedField(clusterIngress.Object, domain, "spec", "domain")
+
+	return fake.NewClientBuilder().WithScheme(scheme).WithObjects(clusterIngress).Build()
+}
+
+// createTestGatewayConfigSupport creates a GatewayConfig for support function testing.
+func createTestGatewayConfigSupport(domain string, certSpec *infrav1.CertificateSpec) *serviceApi.GatewayConfig {
+	return &serviceApi.GatewayConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: serviceApi.GatewayInstanceName,
+		},
+		Spec: serviceApi.GatewayConfigSpec{
+			Domain:      domain,
+			Certificate: certSpec,
+		},
+	}
+}
+
+// TestCreateListeners tests the CreateListeners helper function.
+func TestCreateListeners(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name        string
+		certSecret  string
+		domain      string
+		expectCount int
+		description string
+	}{
+		{
+			name:        "creates HTTPS listener when certificate provided",
+			certSecret:  testCertSecretSupport,
+			domain:      testDomainSupport,
+			expectCount: 1,
+			description: "should create one HTTPS listener with certificate",
+		},
+		{
+			name:        "creates no listeners when no certificate",
+			certSecret:  "",
+			domain:      testDomainSupport,
+			expectCount: 0,
+			description: "should create no listeners without certificate",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewWithT(t)
+			listeners := CreateListeners(tc.certSecret, tc.domain)
+
+			g.Expect(listeners).To(HaveLen(tc.expectCount), tc.description)
+
+			if tc.expectCount > 0 {
+				listener := listeners[0]
+				g.Expect(string(listener.Name)).To(Equal(expectedHTTPSListenerName))
+				g.Expect(listener.Protocol).To(Equal(expectedHTTPSProtocolSupport))
+				g.Expect(listener.Port).To(Equal(expectedHTTPSPortSupport))
+				g.Expect(listener.Hostname).NotTo(BeNil())
+				g.Expect(string(*listener.Hostname)).To(Equal(tc.domain))
+				g.Expect(listener.TLS).NotTo(BeNil())
+				g.Expect(listener.TLS.CertificateRefs).To(HaveLen(1))
+				g.Expect(string(listener.TLS.CertificateRefs[0].Name)).To(Equal(tc.certSecret))
+			}
+		})
+	}
+}
+
+// TestGetCertificateType tests the GetCertificateType helper function.
+func TestGetCertificateType(t *testing.T) {
+	t.Parallel()
+	g := NewWithT(t)
+
+	testCases := []struct {
+		name            string
+		certificateSpec *infrav1.CertificateSpec
+		expectedType    string
+		description     string
+	}{
+		{
+			name:            "returns default when certificate is nil",
+			certificateSpec: nil,
+			expectedType:    string(infrav1.OpenshiftDefaultIngress),
+			description:     "should return OpenShift default when no certificate specified",
+		},
+		{
+			name: "returns certificate type when specified",
+			certificateSpec: &infrav1.CertificateSpec{
+				Type: infrav1.SelfSigned,
+			},
+			expectedType: string(infrav1.SelfSigned),
+			description:  "should return the specified certificate type",
+		},
+		{
+			name: "returns provided certificate type",
+			certificateSpec: &infrav1.CertificateSpec{
+				Type:       infrav1.Provided,
+				SecretName: customCertSecret,
+			},
+			expectedType: string(infrav1.Provided),
+			description:  "should return provided certificate type",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			gateway := createTestGatewayConfigSupport(testDomainSupport, tc.certificateSpec)
+
+			certType := GetCertificateType(gateway)
+			g.Expect(certType).To(Equal(tc.expectedType), tc.description)
+		})
+	}
+}
+
+// TestResolveDomain tests the ResolveDomain helper function.
+func TestResolveDomain(t *testing.T) {
+	t.Parallel()
+	g := NewWithT(t)
+
+	testCases := []struct {
+		name              string
+		specDomain        string
+		clusterDomain     string
+		gatewayName       string
+		useClusterIngress bool
+		expectedDomain    string
+		expectError       bool
+		description       string
+	}{
+		{
+			name:              "user provided domain",
+			specDomain:        testUserDomain,
+			gatewayName:       DefaultGatewayName,
+			useClusterIngress: false,
+			expectedDomain:    expectedODHDomain,
+			expectError:       false,
+			description:       "should use user-provided domain and prepend gateway name",
+		},
+		{
+			name:              "empty domain falls back to cluster domain",
+			specDomain:        "",
+			clusterDomain:     testClusterDomain,
+			gatewayName:       DefaultGatewayName,
+			useClusterIngress: true,
+			expectedDomain:    expectedClusterDomain,
+			expectError:       false,
+			description:       "should fall back to cluster domain when spec domain is empty",
+		},
+		{
+			name:              "cluster domain retrieval fails",
+			specDomain:        "",
+			gatewayName:       DefaultGatewayName,
+			useClusterIngress: false,
+			expectedDomain:    "",
+			expectError:       true,
+			description:       "should return error when cluster domain retrieval fails",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := t.Context()
+
+			// Create test gateway config using helper
+			gatewayConfig := createTestGatewayConfigSupport(tc.specDomain, nil)
+
+			// Setup client with or without cluster ingress using helpers
+			var client client.Client
+			if tc.useClusterIngress && tc.clusterDomain != "" {
+				client = setupSupportTestClientWithClusterIngress(tc.clusterDomain)
+			} else {
+				client = setupSupportTestClient()
+			}
+
+			domain, err := ResolveDomain(ctx, client, gatewayConfig, tc.gatewayName)
+
+			if tc.expectError {
+				g.Expect(err).To(HaveOccurred(), tc.description)
+				g.Expect(domain).To(Equal(""), "domain should be empty on error")
+			} else {
+				g.Expect(err).ToNot(HaveOccurred(), tc.description)
+				g.Expect(domain).To(Equal(tc.expectedDomain), tc.description)
+			}
+		})
+	}
+}
+
+// TestCreateListenersEdgeCases tests edge cases for the CreateListeners function.
+func TestCreateListenersEdgeCases(t *testing.T) {
+	t.Parallel()
+	g := NewWithT(t)
+
+	testCases := []struct {
+		name        string
+		certSecret  string
+		domain      string
+		expectCount int
+		description string
+	}{
+		{
+			name:        "whitespace-only certificate secret",
+			certSecret:  "   ",
+			domain:      testDomainSupport,
+			expectCount: 1, // Whitespace is treated as valid certificate name
+			description: "should create listener with whitespace certificate name",
+		},
+		{
+			name:        "empty domain with certificate",
+			certSecret:  testCertSecretSupport,
+			domain:      "",
+			expectCount: 1, // Empty domain still creates listener
+			description: "should create listener even with empty domain",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			listeners := CreateListeners(tc.certSecret, tc.domain)
+
+			g.Expect(listeners).To(HaveLen(tc.expectCount), tc.description)
+
+			if tc.expectCount > 0 {
+				listener := listeners[0]
+				g.Expect(string(listener.Name)).To(Equal(expectedHTTPSListenerName))
+				g.Expect(listener.Protocol).To(Equal(expectedHTTPSProtocolSupport))
+				g.Expect(listener.Port).To(Equal(expectedHTTPSPortSupport))
+
+				// Hostname should be present even if domain is empty
+				g.Expect(listener.Hostname).NotTo(BeNil())
+				g.Expect(string(*listener.Hostname)).To(Equal(tc.domain))
+			}
+		})
+	}
+}
+
+// TestResolveDomainEdgeCases tests additional edge cases for domain resolution.
+func TestResolveDomainEdgeCases(t *testing.T) {
+	t.Parallel()
+	g := NewWithT(t)
+
+	testCases := []struct {
+		name             string
+		specDomain       string
+		gatewayName      string
+		expectedContains string
+		description      string
+	}{
+		{
+			name:             "long gateway name with domain",
+			specDomain:       testUserDomain,
+			gatewayName:      "very-long-gateway-name-for-testing",
+			expectedContains: "very-long-gateway-name-for-testing",
+			description:      "should handle long gateway names correctly",
+		},
+		{
+			name:             "domain with subdomain",
+			specDomain:       "api.v1.apps.example.com",
+			gatewayName:      DefaultGatewayName,
+			expectedContains: "data-science-gateway.api.v1.apps.example.com",
+			description:      "should handle complex subdomain structures",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := t.Context()
+
+			gatewayConfig := createTestGatewayConfigSupport(tc.specDomain, nil)
+			client := setupSupportTestClient()
+
+			domain, err := ResolveDomain(ctx, client, gatewayConfig, tc.gatewayName)
+
+			g.Expect(err).ToNot(HaveOccurred(), tc.description)
+			g.Expect(domain).To(ContainSubstring(tc.expectedContains), tc.description)
+		})
+	}
+}

--- a/internal/controller/services/gateway/resources/destinationrule-tls.yaml
+++ b/internal/controller/services/gateway/resources/destinationrule-tls.yaml
@@ -4,7 +4,7 @@ metadata:
   name: odh-tls-rule
   namespace: openshift-ingress
   labels:
-    app.kubernetes.io/part-of: odh-gateway
+    app.kubernetes.io/part-of: data-science-gateway
 spec:
   host: '*'
   trafficPolicy:

--- a/internal/controller/services/gateway/resources/envoyfilter-authn.yaml
+++ b/internal/controller/services/gateway/resources/envoyfilter-authn.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   workloadSelector:
     labels:
-      gateway.networking.k8s.io/gateway-name: odh-gateway
+      gateway.networking.k8s.io/gateway-name: data-science-gateway
   configPatches:
   - applyTo: HTTP_FILTER
     match:

--- a/pkg/cluster/gvk/gvk.go
+++ b/pkg/cluster/gvk/gvk.go
@@ -328,6 +328,12 @@ var (
 		Kind:    "EnvoyFilter",
 	}
 
+	DestinationRule = schema.GroupVersionKind{
+		Group:   "networking.istio.io",
+		Version: "v1",
+		Kind:    "DestinationRule",
+	}
+
 	AuthorizationPolicy = schema.GroupVersionKind{
 		Group:   "security.istio.io",
 		Version: "v1",


### PR DESCRIPTION

<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement
The Gateway is still under development. Implementing end-to-end coverage for OpenShift Auth and OIDC is a complex process that will require additional time.

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
The Gateway is still under development. Implementing end-to-end coverage for OpenShift Auth and OIDC is a complex process that will require additional time.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added support for managing Istio DestinationRules when available, expanding gateway networking capabilities.
  - Operator permissions and manifests updated to include DestinationRules.
- Documentation
  - Clarified GatewayConfig domain field with a concrete example (apps.example.com) across docs and CRD descriptions.
- Chores
  - Updated gateway-related resource labels to “data-science-gateway” for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->