### PR TITLE
test: revert "temp. disable e2e test on dashboard" from PR2507 and fix VAP/VAPB e2e tests

### DIFF
--- a/tests/e2e/controller_test.go
+++ b/tests/e2e/controller_test.go
@@ -116,7 +116,7 @@ var (
 		name:    "components",
 		enabled: true,
 		scenarios: map[string]TestFn{
-			//	componentApi.DashboardComponentName:            dashboardTestSuite,
+			componentApi.DashboardComponentName:            dashboardTestSuite,
 			componentApi.RayComponentName:                  rayTestSuite,
 			componentApi.ModelRegistryComponentName:        modelRegistryTestSuite,
 			componentApi.TrustyAIComponentName:             trustyAITestSuite,

--- a/tests/e2e/creation_test.go
+++ b/tests/e2e/creation_test.go
@@ -54,7 +54,7 @@ func dscManagementTestSuite(t *testing.T) {
 		{"Validate creation of DSCInitialization instance", dscTestCtx.ValidateDSCICreation},
 		{"Validate creation of DataScienceCluster instance", dscTestCtx.ValidateDSCCreation},
 		{"Validate ServiceMeshSpec in DSCInitialization instance", dscTestCtx.ValidateServiceMeshSpecInDSCI},
-		// {"Validate VAP/VAPB creation after DSCI creation", dscTestCtx.ValidateVAPCreationAfterDSCI},
+		{"Validate VAP/VAPB creation after DSCI creation", dscTestCtx.ValidateVAPCreationAfterDSCI},
 		{"Validate Knative resource", dscTestCtx.ValidateKnativeSpecInDSC},
 		{"Validate HardwareProfile resource", dscTestCtx.ValidateHardwareProfileCR},
 		{"Validate owned namespaces exist", dscTestCtx.ValidateOwnedNamespacesAllExist},

--- a/tests/e2e/dashboard_test.go
+++ b/tests/e2e/dashboard_test.go
@@ -5,11 +5,13 @@ import (
 	"testing"
 
 	"github.com/rs/xid"
+	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	k8slabels "k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/api/components/v1alpha1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/metadata/annotations"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/metadata/labels"
@@ -23,32 +25,32 @@ type DashboardTestCtx struct {
 	*ComponentTestCtx
 }
 
-// func dashboardTestSuite(t *testing.T) {
-// 	t.Helper()
+func dashboardTestSuite(t *testing.T) {
+	t.Helper()
 
-// 	ct, err := NewComponentTestCtx(t, &componentApi.Dashboard{})
-// 	require.NoError(t, err)
+	ct, err := NewComponentTestCtx(t, &componentApi.Dashboard{})
+	require.NoError(t, err)
 
-// 	componentCtx := DashboardTestCtx{
-// 		ComponentTestCtx: ct,
-// 	}
+	componentCtx := DashboardTestCtx{
+		ComponentTestCtx: ct,
+	}
 
-// 	// Define test cases.
-// 	testCases := []TestCase{
-// 		{"Validate component enabled", componentCtx.ValidateComponentEnabled},
-// 		{"Validate operands have OwnerReferences", componentCtx.ValidateOperandsOwnerReferences},
-// 		{"Validate update operand resources", componentCtx.ValidateUpdateDeploymentsResources},
-// 		{"Validate dynamically watches operands", componentCtx.ValidateOperandsDynamicallyWatchedResources},
-// 		{"Validate CRDs reinstated", componentCtx.ValidateCRDReinstated},
-// 		{"Validate hardware profile creation blocked by VAP", componentCtx.ValidateHardwareProfileCreationBlockedByVAP},
-// 		{"Validate accelerator profile creation blocked by VAP", componentCtx.ValidateAcceleratorProfileCreationBlockedByVAP},
-// 		{"Validate resource deletion recovery", componentCtx.ValidateAllDeletionRecovery},
-// 		{"Validate component disabled", componentCtx.ValidateComponentDisabled},
-// 	}
+	// Define test cases.
+	testCases := []TestCase{
+		{"Validate component enabled", componentCtx.ValidateComponentEnabled},
+		{"Validate operands have OwnerReferences", componentCtx.ValidateOperandsOwnerReferences},
+		{"Validate update operand resources", componentCtx.ValidateUpdateDeploymentsResources},
+		{"Validate dynamically watches operands", componentCtx.ValidateOperandsDynamicallyWatchedResources},
+		{"Validate CRDs reinstated", componentCtx.ValidateCRDReinstated},
+		{"Validate hardware profile creation blocked by VAP", componentCtx.ValidateHardwareProfileCreationBlockedByVAP},
+		{"Validate accelerator profile creation blocked by VAP", componentCtx.ValidateAcceleratorProfileCreationBlockedByVAP},
+		{"Validate resource deletion recovery", componentCtx.ValidateAllDeletionRecovery},
+		{"Validate component disabled", componentCtx.ValidateComponentDisabled},
+	}
 
-// 	// Run the test suite.
-// 	RunTestCases(t, testCases)
-// }
+	// Run the test suite.
+	RunTestCases(t, testCases)
+}
 
 // ValidateOperandsDynamicallyWatchedResources ensures that operands are correctly watched for dynamic updates.
 func (tc *DashboardTestCtx) ValidateOperandsDynamicallyWatchedResources(t *testing.T) {

--- a/tests/e2e/dashboard_test.go
+++ b/tests/e2e/dashboard_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	k8slabels "k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -38,6 +39,7 @@ func dashboardTestSuite(t *testing.T) {
 	// Define test cases.
 	testCases := []TestCase{
 		{"Validate component enabled", componentCtx.ValidateComponentEnabled},
+		{"Validate VAP created", componentCtx.ValidateVAPCreated}, // TODO: Remove this when CRD is not included
 		{"Validate operands have OwnerReferences", componentCtx.ValidateOperandsOwnerReferences},
 		{"Validate update operand resources", componentCtx.ValidateUpdateDeploymentsResources},
 		{"Validate dynamically watches operands", componentCtx.ValidateOperandsDynamicallyWatchedResources},
@@ -115,6 +117,51 @@ func (tc *DashboardTestCtx) ValidateAllDeletionRecovery(t *testing.T) {
 	t.Run("Route deletion recovery", func(t *testing.T) {
 		tc.ValidateResourceDeletionRecovery(t, gvk.Route)
 	})
+}
+
+// ValidateVAPCreated verifies that VAP/VAPB resources are created.
+func (tc *DashboardTestCtx) ValidateVAPCreated(t *testing.T) {
+	t.Helper()
+
+	dsci := tc.FetchDSCInitialization()
+	tc.g.Expect(dsci).NotTo(BeNil(), "DSCI should exist")
+
+	// Validate VAP/VAPB resources exist and are owned by DSCI
+	vapResources := []struct {
+		name string
+		gvk  schema.GroupVersionKind
+	}{
+		{"block-dashboard-acceleratorprofile-cr", gvk.ValidatingAdmissionPolicy},
+		{"block-dashboard-acceleratorprofile-cr-binding", gvk.ValidatingAdmissionPolicyBinding},
+		{"block-dashboard-hardwareprofile-cr", gvk.ValidatingAdmissionPolicy},
+		{"block-dashboard-hardwareprofile-cr-binding", gvk.ValidatingAdmissionPolicyBinding},
+	}
+
+	for _, resource := range vapResources {
+		tc.EnsureResourceExists(
+			WithMinimalObject(resource.gvk, types.NamespacedName{Name: resource.name}),
+			WithCondition(And(
+				jq.Match(`.metadata.name == "%s"`, resource.name),
+				jq.Match(`.metadata.ownerReferences[0].kind == "%s"`, gvk.DSCInitialization.Kind),
+			)),
+			WithCustomErrorMsg("%s should exist and be owned by DSCI", resource.name),
+		)
+	}
+
+	// Delete one and verify it gets recreated
+	vapToDelete := vapResources[0]
+	tc.DeleteResource(WithMinimalObject(vapToDelete.gvk, types.NamespacedName{Name: vapToDelete.name}))
+
+	// Verify the deleted VAP gets recreated with ownerreference to DSCI
+	tc.EventuallyResourceCreatedOrUpdated(
+		WithMinimalObject(vapToDelete.gvk, types.NamespacedName{Name: vapToDelete.name}),
+		WithCondition(And(
+			jq.Match(`.metadata.name == "%s"`, vapToDelete.name),
+			jq.Match(`.metadata.ownerReferences[0].kind == "%s"`, gvk.DSCInitialization.Kind),
+		)),
+		WithCustomErrorMsg("%s should be recreated after deletion", vapToDelete.name),
+		WithEventuallyTimeout(tc.TestTimeouts.mediumEventuallyTimeout),
+	)
 }
 
 // todo: remove this when CRD is not included

--- a/tests/e2e/monitoring_test.go
+++ b/tests/e2e/monitoring_test.go
@@ -88,7 +88,7 @@ func monitoringTestSuite(t *testing.T) {
 		{"Test Metrics MonitoringStack CR Creation", monitoringServiceCtx.ValidateMonitoringStackCRMetricsWhenSet},
 		{"Test Metrics MonitoringStack CR Configuration", monitoringServiceCtx.ValidateMonitoringStackCRMetricsConfiguration},
 		{"Test Metrics Replicas Configuration", monitoringServiceCtx.ValidateMonitoringStackCRMetricsReplicasUpdate},
-		// {"Test Prometheus rules lifecycle", monitoringServiceCtx.ValidatePrometheusRulesLifecycle},
+		{"Test Prometheus rules lifecycle", monitoringServiceCtx.ValidatePrometheusRulesLifecycle},
 		{"Test TempoMonolithic CR Creation with PV backend", monitoringServiceCtx.ValidateTempoMonolithicCRCreation},
 		{"Test TempoStack CR Creation with Cloud Storage", monitoringServiceCtx.ValidateTempoStackCRCreationWithCloudStorage},
 		{"Test OpenTelemetry Collector Configurations", monitoringServiceCtx.ValidateOpenTelemetryCollectorConfigurations},


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

- re-enable previously disabled dashboard test
- move test on vap/vapb from DSCI to dashboard

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [ ] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->
dont i have e2e change already ? 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Re-enabled Dashboard component test suite.
  - Added validation for VAP/VAPB creation and ownership within Dashboard tests, including recreation behavior checks.
  - Removed VAP/VAPB creation-after-DSCI test from the DSCI management suite.
  - Re-enabled Prometheus rules lifecycle test in the monitoring suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->