### PR TITLE
[sync] fix(RHOAIENG-34533): resolve TrustyAI DSC validation error when patching DSC eval flags (#2525)

### DIFF
--- a/api/components/v1alpha1/trustyai_types.go
+++ b/api/components/v1alpha1/trustyai_types.go
@@ -57,17 +57,19 @@ type TrustyAISpec struct {
 // TrustyAIEvalSpec defines evaluation configuration for TrustyAI
 type TrustyAIEvalSpec struct {
 	// LMEval configuration for model evaluations
-	LMEval TrustyAILMEvalSpec `json:"lmeval,omitempty"`
+	LMEval TrustyAILMEvalSpec `json:"lmeval"`
 }
 
 // TrustyAILMEvalSpec defines configuration for LMEval evaluations
 type TrustyAILMEvalSpec struct {
 	// PermitCodeExecution controls whether code execution is allowed during evaluations
-	// +kubebuilder:default=false
-	PermitCodeExecution bool `json:"permitCodeExecution,omitempty"`
+	// +kubebuilder:default="deny"
+	// +kubebuilder:validation:Enum=allow;deny
+	PermitCodeExecution string `json:"permitCodeExecution,omitempty"`
 	// PermitOnline controls whether online access is allowed during evaluations
-	// +kubebuilder:default=false
-	PermitOnline bool `json:"permitOnline,omitempty"`
+	// +kubebuilder:default="deny"
+	// +kubebuilder:validation:Enum=allow;deny
+	PermitOnline string `json:"permitOnline,omitempty"`
 }
 
 type TrustyAICommonSpec struct {

--- a/bundle/manifests/components.platform.opendatahub.io_trustyais.yaml
+++ b/bundle/manifests/components.platform.opendatahub.io_trustyais.yaml
@@ -81,16 +81,24 @@ spec:
                     description: LMEval configuration for model evaluations
                     properties:
                       permitCodeExecution:
-                        default: false
+                        default: deny
                         description: PermitCodeExecution controls whether code execution
                           is allowed during evaluations
-                        type: boolean
+                        enum:
+                        - allow
+                        - deny
+                        type: string
                       permitOnline:
-                        default: false
+                        default: deny
                         description: PermitOnline controls whether online access is
                           allowed during evaluations
-                        type: boolean
+                        enum:
+                        - allow
+                        - deny
+                        type: string
                     type: object
+                required:
+                - lmeval
                 type: object
             type: object
           status:

--- a/bundle/manifests/datasciencecluster.opendatahub.io_datascienceclusters.yaml
+++ b/bundle/manifests/datasciencecluster.opendatahub.io_datascienceclusters.yaml
@@ -742,16 +742,24 @@ spec:
                             description: LMEval configuration for model evaluations
                             properties:
                               permitCodeExecution:
-                                default: false
+                                default: deny
                                 description: PermitCodeExecution controls whether
                                   code execution is allowed during evaluations
-                                type: boolean
+                                enum:
+                                - allow
+                                - deny
+                                type: string
                               permitOnline:
-                                default: false
+                                default: deny
                                 description: PermitOnline controls whether online
                                   access is allowed during evaluations
-                                type: boolean
+                                enum:
+                                - allow
+                                - deny
+                                type: string
                             type: object
+                        required:
+                        - lmeval
                         type: object
                       managementState:
                         description: |-

--- a/config/crd/bases/components.platform.opendatahub.io_trustyais.yaml
+++ b/config/crd/bases/components.platform.opendatahub.io_trustyais.yaml
@@ -81,16 +81,24 @@ spec:
                     description: LMEval configuration for model evaluations
                     properties:
                       permitCodeExecution:
-                        default: false
+                        default: deny
                         description: PermitCodeExecution controls whether code execution
                           is allowed during evaluations
-                        type: boolean
+                        enum:
+                        - allow
+                        - deny
+                        type: string
                       permitOnline:
-                        default: false
+                        default: deny
                         description: PermitOnline controls whether online access is
                           allowed during evaluations
-                        type: boolean
+                        enum:
+                        - allow
+                        - deny
+                        type: string
                     type: object
+                required:
+                - lmeval
                 type: object
             type: object
           status:

--- a/config/crd/bases/datasciencecluster.opendatahub.io_datascienceclusters.yaml
+++ b/config/crd/bases/datasciencecluster.opendatahub.io_datascienceclusters.yaml
@@ -742,16 +742,24 @@ spec:
                             description: LMEval configuration for model evaluations
                             properties:
                               permitCodeExecution:
-                                default: false
+                                default: deny
                                 description: PermitCodeExecution controls whether
                                   code execution is allowed during evaluations
-                                type: boolean
+                                enum:
+                                - allow
+                                - deny
+                                type: string
                               permitOnline:
-                                default: false
+                                default: deny
                                 description: PermitOnline controls whether online
                                   access is allowed during evaluations
-                                type: boolean
+                                enum:
+                                - allow
+                                - deny
+                                type: string
                             type: object
+                        required:
+                        - lmeval
                         type: object
                       managementState:
                         description: |-

--- a/docs/api-overview.md
+++ b/docs/api-overview.md
@@ -2055,8 +2055,8 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `permitCodeExecution` _boolean_ | PermitCodeExecution controls whether code execution is allowed during evaluations | false |  |
-| `permitOnline` _boolean_ | PermitOnline controls whether online access is allowed during evaluations | false |  |
+| `permitCodeExecution` _string_ | PermitCodeExecution controls whether code execution is allowed during evaluations | deny | Enum: [allow deny] <br /> |
+| `permitOnline` _string_ | PermitOnline controls whether online access is allowed during evaluations | deny | Enum: [allow deny] <br /> |
 
 
 #### TrustyAIList

--- a/internal/controller/components/trustyai/trustyai_controller_actions.go
+++ b/internal/controller/components/trustyai/trustyai_controller_actions.go
@@ -82,6 +82,10 @@ func createConfigMap(ctx context.Context, rr *odhtypes.ReconciliationRequest) er
 		return fmt.Errorf("resource instance %v is not a componentApi.TrustyAI)", rr.Instance)
 	}
 
+	// Convert to boolean for configmap
+	permitCodeExecution := trustyai.Spec.Eval.LMEval.PermitCodeExecution == EvalPermissionAllow
+	permitOnline := trustyai.Spec.Eval.LMEval.PermitOnline == EvalPermissionAllow
+
 	// Create extra ConfigMap for DSC configuration
 	configMap := &corev1.ConfigMap{
 		TypeMeta: metav1.TypeMeta{
@@ -96,10 +100,8 @@ func createConfigMap(ctx context.Context, rr *odhtypes.ReconciliationRequest) er
 		Data: make(map[string]string),
 	}
 
-	configMap.Data["eval.lmeval.permitCodeExecution"] =
-		strconv.FormatBool(trustyai.Spec.Eval.LMEval.PermitCodeExecution)
-	configMap.Data["eval.lmeval.permitOnline"] =
-		strconv.FormatBool(trustyai.Spec.Eval.LMEval.PermitOnline)
+	configMap.Data["eval.lmeval.permitCodeExecution"] = strconv.FormatBool(permitCodeExecution)
+	configMap.Data["eval.lmeval.permitOnline"] = strconv.FormatBool(permitOnline)
 
 	return rr.AddResources(configMap)
 }


### PR DESCRIPTION

* fix(RHOAIENG-34533): resolve TrustyAI DSC validation error when patching DSC eval flags

This change resolves RHOAIENG-34533 by converting TrustyAI evaluation configuration fields from boolean to enum string values.

Changes:
- Convert PermitCodeExecution and PermitOnline from bool to string with enum validation (allow/deny)
- Add proper default handling and constants for evaluation permissions
- Update CRDs, bundle manifests, and test expectations
- Maintain backward compatibility in ConfigMap generation

* add updated API

* Simplify CM value assignment, revert image name to v3.0.0

(cherry picked from commit a133c7a00a9c3ad4716de822fe19cec3dd677144)

<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [ ] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->
