### PR TITLE
feat(RHOAIENG-35049): add support to pass RAGAS KFP image for downstream

### DIFF
--- a/internal/controller/components/trustyai/trustyai_support.go
+++ b/internal/controller/components/trustyai/trustyai_support.go
@@ -29,6 +29,7 @@ var (
 		"guardrails-orchestrator-image":      "RELATED_IMAGE_ODH_FMS_GUARDRAILS_ORCHESTRATOR_IMAGE",
 		"guardrails-sidecar-gateway-image":   "RELATED_IMAGE_ODH_TRUSTYAI_VLLM_ORCHESTRATOR_GATEWAY_IMAGE",
 		"guardrails-built-in-detector-image": "RELATED_IMAGE_ODH_BUILT_IN_DETECTOR_IMAGE",
+		"ragas-provider-image":               "RELATED_IMAGE_ODH_TRUSTYAI_RAGAS_PROVIDER_IMAGE",
 		"oauthProxyImage":                    "RELATED_IMAGE_OSE_OAUTH_PROXY_IMAGE",
 	}
 


### PR DESCRIPTION
## Description

This PR implements image replacement for the `ragas-provider-image` parameter in the TrustyAI operator.
Related JIRAs and PRs:

- https://github.com/trustyai-explainability/trustyai-service-operator/pull/565
- https://issues.redhat.com/browse/RHOAIENG-35049

## Merge criteria

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [ ] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.
