### PR TITLE
fix: add llmisvc kueue test case

### DIFF
--- a/internal/webhook/hardwareprofile/integration_test.go
+++ b/internal/webhook/hardwareprofile/integration_test.go
@@ -250,7 +250,7 @@ func testHardwareProfileWithKueueForWorkload(g Gomega, ctx context.Context, k8sC
 		g.Expect(resources.HasLabel(workload, expectedLabelKey, queueName)).Should(BeTrue())
 	} else {
 		// This branch should no longer be used since all workloads use labels
-		actualQueueName := resources.GetAnnotation(workload, "kueue.x-k8s.io/queue-name")
+		actualQueueName := resources.GetAnnotation(workload, WorkloadLabelKueueQueueName)
 		g.Expect(actualQueueName).Should(Equal(queueName))
 	}
 }
@@ -421,7 +421,7 @@ func TestHardwareProfileWebhook_Notebook(t *testing.T) {
 						return envtestutil.NewNotebook("test-notebook-kueue", ns,
 							envtestutil.WithHardwareProfile("kueue-profile"))
 					},
-					"gpu-queue", "kueue.x-k8s.io/queue-name")
+					"gpu-queue", WorkloadLabelKueueQueueName)
 			},
 		},
 		{
@@ -539,6 +539,17 @@ func TestHardwareProfileWebhook_LlmInferenceService(t *testing.T) {
 					config.NodeSelectorPath, config.TolerationsPath)
 			},
 		},
+		{
+			name: "llminferenceservice - hardware profile with kueue scheduling",
+			test: func(g Gomega, ctx context.Context, k8sClient client.Client, ns string) {
+				testHardwareProfileWithKueueForWorkload(g, ctx, k8sClient, ns,
+					func() client.Object {
+						return envtestutil.NewLLMInferenceService("test-llmisvc-kueue", ns,
+							envtestutil.WithHardwareProfile("kueue-profile"))
+					},
+					"test-queue", WorkloadLabelKueueQueueName)
+			},
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -622,7 +633,7 @@ func TestHardwareProfileWebhook_InferenceService(t *testing.T) {
 						return envtestutil.NewInferenceService("test-inference-service-kueue", ns,
 							envtestutil.WithHardwareProfile("kueue-profile"))
 					},
-					"test-queue", "kueue.x-k8s.io/queue-name")
+					"test-queue", WorkloadLabelKueueQueueName)
 			},
 		},
 		{


### PR DESCRIPTION
## Description
This PR adds a small test case to validate the HardwareProfile kueue label injection for LLMInferenceServices.

## How Has This Been Tested?
I ran the new test locally and it passed

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [X] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [X] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work
- [X] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [X] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
Adding integration test case.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Standardized usage of the workload annotation key across webhook integration tests for Notebooks, InferenceService, and LLM Inference Service.
  * Added a new LLM Inference Service test path to exercise scheduling behavior with the standardized key.
  * Replaced scattered string literals with a shared definition to improve consistency in test assertions.
  * No user-facing changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->