### PR TITLE
test: cleanup test + create a dummy object for kueue to test allowedkind

### DIFF
--- a/internal/webhook/kueue/validation_test.go
+++ b/internal/webhook/kueue/validation_test.go
@@ -96,7 +96,8 @@ func TestKueueWebhook_DeniesUnexpectedKind(t *testing.T) {
 	}
 
 	// Create a test object with an unexpected kind
-	testObj := envtestutil.NewNotebook("test-unexpected", testNamespace)
+	unexpectedGVK := schema.GroupVersionKind{Group: "unexpected.io", Version: "v1", Kind: "UnexpectedKind"}
+	testObj := envtestutil.NewWorkloadObject(unexpectedGVK, "test-unexpected", testNamespace)
 
 	// Create request with an unexpected kind (using a different Group/Version/Kind)
 	req := envtestutil.NewAdmissionRequest(
@@ -155,7 +156,7 @@ func TestKueueWebhook_AcceptsExpectedKinds(t *testing.T) {
 				Resource: "notebooks",
 			},
 			objFunc: func() client.Object {
-				return envtestutil.NewNotebook("test-notebook", testNamespace, func(obj client.Object) {
+				return envtestutil.NewWorkloadObject(gvk.Notebook, "test-notebook", testNamespace, func(obj client.Object) {
 					obj.SetLabels(map[string]string{objLabelQueueName: validQueueName})
 				})
 			},
@@ -169,7 +170,7 @@ func TestKueueWebhook_AcceptsExpectedKinds(t *testing.T) {
 				Resource: "pytorchjobs",
 			},
 			objFunc: func() client.Object {
-				return envtestutil.NewNotebook("test-pytorchjob", testNamespace, func(obj client.Object) {
+				return envtestutil.NewWorkloadObject(gvk.PyTorchJob, "test-pytorchjob", testNamespace, func(obj client.Object) {
 					obj.SetLabels(map[string]string{objLabelQueueName: validQueueName})
 				})
 			},
@@ -183,7 +184,7 @@ func TestKueueWebhook_AcceptsExpectedKinds(t *testing.T) {
 				Resource: "rayjobs",
 			},
 			objFunc: func() client.Object {
-				return envtestutil.NewNotebook("test-rayjob-v1alpha1", testNamespace, func(obj client.Object) {
+				return envtestutil.NewWorkloadObject(gvk.RayJobV1Alpha1, "test-rayjob-v1alpha1", testNamespace, func(obj client.Object) {
 					obj.SetLabels(map[string]string{objLabelQueueName: validQueueName})
 				})
 			},
@@ -197,7 +198,7 @@ func TestKueueWebhook_AcceptsExpectedKinds(t *testing.T) {
 				Resource: "rayclusters",
 			},
 			objFunc: func() client.Object {
-				return envtestutil.NewNotebook("test-raycluster-v1alpha1", testNamespace, func(obj client.Object) {
+				return envtestutil.NewWorkloadObject(gvk.RayClusterV1Alpha1, "test-raycluster-v1alpha1", testNamespace, func(obj client.Object) {
 					obj.SetLabels(map[string]string{objLabelQueueName: validQueueName})
 				})
 			},
@@ -211,7 +212,7 @@ func TestKueueWebhook_AcceptsExpectedKinds(t *testing.T) {
 				Resource: "rayjobs",
 			},
 			objFunc: func() client.Object {
-				return envtestutil.NewNotebook("test-rayjob-v1", testNamespace, func(obj client.Object) {
+				return envtestutil.NewWorkloadObject(gvk.RayJobV1, "test-rayjob-v1", testNamespace, func(obj client.Object) {
 					obj.SetLabels(map[string]string{objLabelQueueName: validQueueName})
 				})
 			},
@@ -225,7 +226,7 @@ func TestKueueWebhook_AcceptsExpectedKinds(t *testing.T) {
 				Resource: "rayclusters",
 			},
 			objFunc: func() client.Object {
-				return envtestutil.NewNotebook("test-raycluster-v1", testNamespace, func(obj client.Object) {
+				return envtestutil.NewWorkloadObject(gvk.RayClusterV1, "test-raycluster-v1", testNamespace, func(obj client.Object) {
 					obj.SetLabels(map[string]string{objLabelQueueName: validQueueName})
 				})
 			},
@@ -239,7 +240,7 @@ func TestKueueWebhook_AcceptsExpectedKinds(t *testing.T) {
 				Resource: "inferenceservices",
 			},
 			objFunc: func() client.Object {
-				return envtestutil.NewNotebook("test-inferenceservice", testNamespace, func(obj client.Object) {
+				return envtestutil.NewWorkloadObject(gvk.InferenceServices, "test-inferenceservice", testNamespace, func(obj client.Object) {
 					obj.SetLabels(map[string]string{objLabelQueueName: validQueueName})
 				})
 			},
@@ -253,7 +254,7 @@ func TestKueueWebhook_AcceptsExpectedKinds(t *testing.T) {
 				Resource: "llminferenceservices",
 			},
 			objFunc: func() client.Object {
-				return envtestutil.NewNotebook("test-llmisvc", testNamespace, func(obj client.Object) {
+				return envtestutil.NewWorkloadObject(gvk.LLMInferenceServiceV1Alpha1, "test-llmisvc", testNamespace, func(obj client.Object) {
 					obj.SetLabels(map[string]string{objLabelQueueName: validQueueName})
 				})
 			},

--- a/tests/e2e/creation_test.go
+++ b/tests/e2e/creation_test.go
@@ -56,8 +56,6 @@ func dscManagementTestSuite(t *testing.T) {
 		{"Ensure required operators are installed", dscTestCtx.ValidateOperatorsInstallation},
 		{"Validate creation of DSCInitialization instance", dscTestCtx.ValidateDSCICreation},
 		{"Validate creation of DataScienceCluster instance", dscTestCtx.ValidateDSCCreation},
-		{"Validate ServiceMeshSpec in DSCInitialization instance", dscTestCtx.ValidateServiceMeshSpecInDSCI},
-		{"Validate Knative resource", dscTestCtx.ValidateKnativeSpecInDSC},
 		{"Validate HardwareProfile resource", dscTestCtx.ValidateHardwareProfileCR},
 		{"Validate owned namespaces exist", dscTestCtx.ValidateOwnedNamespacesAllExist},
 		{"Validate default NetworkPolicy exist", dscTestCtx.ValidateDefaultNetworkPolicyExists},
@@ -93,12 +91,9 @@ func (tc *DSCTestCtx) ValidateOperatorsInstallation(t *testing.T) {
 		nn                types.NamespacedName
 		skipOperatorGroup bool
 	}{
-		{nn: types.NamespacedName{Name: serviceMeshOpName, Namespace: openshiftOperatorsNamespace}, skipOperatorGroup: true},
-		{nn: types.NamespacedName{Name: serverlessOpName, Namespace: serverlessOperatorNamespace}, skipOperatorGroup: false},
-		{nn: types.NamespacedName{Name: authorinoOpName, Namespace: openshiftOperatorsNamespace}, skipOperatorGroup: true},
 		{nn: types.NamespacedName{Name: observabilityOpName, Namespace: observabilityOpNamespace}, skipOperatorGroup: false},
 		{nn: types.NamespacedName{Name: tempoOpName, Namespace: tempoOpNamespace}, skipOperatorGroup: false},
-		{nn: types.NamespacedName{Name: telemetryOpName, Namespace: telemetryOpNamespace}, skipOperatorGroup: false},
+		{nn: types.NamespacedName{Name: opentelemetryOpName, Namespace: opentelemetryOpNamespace}, skipOperatorGroup: false},
 	}
 
 	// Create and run test cases in parallel.
@@ -152,7 +147,7 @@ func (tc *DSCTestCtx) ValidateServiceMeshSpecInDSCI(t *testing.T) {
 
 	// expected ServiceMeshSpec.
 	expServiceMeshSpec := &infrav1.ServiceMeshSpec{
-		ManagementState: operatorv1.Managed,
+		ManagementState: operatorv1.Removed,
 		ControlPlane: infrav1.ControlPlaneSpec{
 			Name:              serviceMeshControlPlane,
 			Namespace:         serviceMeshNamespace,

--- a/tests/e2e/helper_test.go
+++ b/tests/e2e/helper_test.go
@@ -39,19 +39,11 @@ const (
 	controllerCacheRefreshDelay = 5 * time.Second
 
 	// Operators constants.
-	defaultOperatorChannel       = "stable"                           // The default channel to install/check operators
-	serviceMeshOpName            = "servicemeshoperator"              // Name of the Service Mesh Operator
-	serverlessOpName             = "serverless-operator"              // Name of the Serverless Operator
-	authorinoOpName              = "authorino-operator"               // Name of the Serverless Operator
-	kueueOpName                  = "kueue-operator"                   // Name of the Kueue Operator
-	telemetryOpName              = "opentelemetry-product"            // Name of the Telemetry Operator
-	openshiftOperatorsNamespace  = "openshift-operators"              // Namespace for OpenShift Operators
-	serverlessOperatorNamespace  = "openshift-serverless"             // Namespace for the Serverless Operator
-	telemetryOpNamespace         = "openshift-opentelemetry-operator" // Namespace for the Telemetry Operator
-	serviceMeshControlPlane      = "data-science-smcp"                // Service Mesh control plane name
-	serviceMeshNamespace         = "istio-system"                     // Namespace for Istio Service Mesh control plane
-	serviceMeshMetricsCollection = "Istio"                            // Metrics collection for Service Mesh (e.g., Istio)
-	serviceMeshMemberName        = "default"
+	defaultOperatorChannel       = "stable"                                   // The default channel to install/check operators
+	kueueOpName                  = "kueue-operator"                           // Name of the Kueue Operator
+	serviceMeshControlPlane      = "data-science-smcp"                        // Service Mesh control plane name
+	serviceMeshNamespace         = "istio-system"                             // Namespace for Istio Service Mesh control plane
+	serviceMeshMetricsCollection = "Istio"                                    // Metrics collection for Service Mesh (e.g., Istio)
 	observabilityOpName          = "cluster-observability-operator"           // Name of the Cluster Observability Operator
 	observabilityOpNamespace     = "openshift-cluster-observability-operator" // Namespace for the Cluster Observability Operator
 	tempoOpName                  = "tempo-product"                            // Name of the Tempo Operator
@@ -172,7 +164,7 @@ func CreateDSCI(name, groupVersion string, appNamespace, monitoringNamespace str
 				CustomCABundle:  "",
 			},
 			ServiceMesh: &infrav1.ServiceMeshSpec{
-				ManagementState: operatorv1.Managed,
+				ManagementState: operatorv1.Removed,
 				ControlPlane: infrav1.ControlPlaneSpec{
 					Name:              serviceMeshControlPlane,
 					Namespace:         serviceMeshNamespace,
@@ -221,9 +213,9 @@ func CreateDSC(name string, groupVersion string) *dscv2.DataScienceCluster {
 						ManagementState: operatorv1.Removed,
 					},
 					KserveCommonSpec: componentApi.KserveCommonSpec{
-						DefaultDeploymentMode: componentApi.Serverless,
+						DefaultDeploymentMode: componentApi.RawDeployment,
 						Serving: infrav1.ServingSpec{
-							ManagementState: operatorv1.Managed,
+							ManagementState: operatorv1.Removed,
 							Name:            knativeServingNamespace,
 							IngressGateway: infrav1.GatewaySpec{
 								Certificate: infrav1.CertificateSpec{

--- a/tests/e2e/kserve_test.go
+++ b/tests/e2e/kserve_test.go
@@ -62,25 +62,22 @@ func kserveTestSuite(t *testing.T) {
 
 	// TODO: removed once we know what's left on the cluster that's causing the tests
 	//       to fail because of "existing KNativeServing resource was found"
-	t.Run("Setup Serverless", componentCtx.SetUpServerless)
+	// t.Run("Setup Serverless", componentCtx.SetUpServerless)
 
 	// Define test cases.
 	testCases := []TestCase{
 		{"Validate component enabled", componentCtx.ValidateComponentEnabled},
-		{"Validate serving enabled", componentCtx.ValidateServingEnabled},
+		// {"Validate serving enabled", componentCtx.ValidateServingEnabled},
 		{"Validate component spec", componentCtx.ValidateSpec},
-		{"Validate component conditions", componentCtx.ValidateConditions},
-		{"Validate KnativeServing resource exists and is recreated upon deletion", componentCtx.ValidateKnativeServing},
+		// {"Validate component conditions", componentCtx.ValidateConditions}, this is a wrong case, only can be tested if we  set  serverless to Managed.
 		{"Validate model controller", componentCtx.ValidateModelControllerInstance},
 		{"Validate operands have OwnerReferences", componentCtx.ValidateOperandsOwnerReferences},
-		{"Validate no FeatureTracker OwnerReferences", componentCtx.ValidateNoKServeFeatureTrackerOwnerReferences},
-		{"Validate no Kserve FeatureTrackers", componentCtx.ValidateNoKserveFeatureTrackers},
-		{"Validate default certs", componentCtx.ValidateDefaultCertsAvailable},
-		{"Validate custom certificate created for OpenshiftDefaultIngress", componentCtx.ValidateCustomCertificateCreation},
-		{"Validate invalid custom certificate creation for OpenshiftDefaultIngress", componentCtx.ValidateInvalidCustomCertificateCreation},
+		// {"Validate no FeatureTracker OwnerReferences", componentCtx.ValidateNoKServeFeatureTrackerOwnerReferences},
+		// {"Validate no Kserve FeatureTrackers", componentCtx.ValidateNoKserveFeatureTrackers},
+		// {"Validate default certs", componentCtx.ValidateDefaultCertsAvailable},
+		// {"Validate custom certificate created for OpenshiftDefaultIngress", componentCtx.ValidateCustomCertificateCreation},
+		// {"Validate invalid custom certificate creation for OpenshiftDefaultIngress", componentCtx.ValidateInvalidCustomCertificateCreation},
 		{"Validate update operand resources", componentCtx.ValidateUpdateDeploymentsResources},
-		{"Validate serving transition to Unmanaged", componentCtx.ValidateServingTransitionToUnmanaged},
-		{"Validate serving transition to Removed", componentCtx.ValidateServingTransitionToRemoved},
 		{"Validate component releases", componentCtx.ValidateComponentReleases},
 		{"Validate resource deletion recovery", componentCtx.ValidateAllDeletionRecovery},
 	}

--- a/tests/e2e/kueue_test.go
+++ b/tests/e2e/kueue_test.go
@@ -68,15 +68,15 @@ func kueueTestSuite(t *testing.T) {
 		ComponentTestCtx: ct,
 	}
 
-	// Define core test cases
+	// Define core test cases - skip tests requiring "Managed" state since embedded Kueue is not available
 	testCases := []TestCase{
-		{"Validate component enabled", componentCtx.ValidateComponentEnabled},
-		{"Validate operands have OwnerReferences", componentCtx.ValidateOperandsOwnerReferences},
-		{"Validate update operand resources", componentCtx.ValidateUpdateDeploymentsResources},
-		{"Validate CRDs reinstated", componentCtx.ValidateCRDReinstated},
-		{"Validate pre check", componentCtx.ValidateKueuePreCheck},
-		{"Validate component releases", componentCtx.ValidateComponentReleases},
-		{"Validate resource deletion recovery", componentCtx.ValidateAllDeletionRecovery},
+		// {"Validate component enabled", componentCtx.ValidateComponentEnabled}, // Requires Managed state
+		// {"Validate operands have OwnerReferences", componentCtx.ValidateOperandsOwnerReferences}, // Requires Managed state
+		// {"Validate update operand resources", componentCtx.ValidateUpdateDeploymentsResources}, // Requires Managed state
+		// {"Validate CRDs reinstated", componentCtx.ValidateCRDReinstated}, // Requires Managed state
+		// {"Validate pre check", componentCtx.ValidateKueuePreCheck}, // Requires Managed state
+		// {"Validate component releases", componentCtx.ValidateComponentReleases}, // Requires Managed state
+		// {"Validate resource deletion recovery", componentCtx.ValidateAllDeletionRecovery}, // Requires Managed state
 	}
 
 	// Only add OCP Kueue operator test if OCP version is 4.18 or above
@@ -84,16 +84,18 @@ func kueueTestSuite(t *testing.T) {
 	componentCtx.g.Expect(err).ShouldNot(HaveOccurred(), "Failed to check OCP version")
 	if meets {
 		testCases = append(testCases,
-			TestCase{"Validate component managed error with ocp kueue-operator installed", componentCtx.ValidateKueueManagedWithOcpKueueOperator},
-			TestCase{"Validate component unmanaged error with ocp kueue-operator not installed", componentCtx.ValidateKueueUnmanagedWithoutOcpKueueOperator},
-			TestCase{"Validate component managed to unmanaged transition", componentCtx.ValidateKueueManagedToUnmanagedTransition},
-			TestCase{"Validate component managed to removed to unmanaged transition with config migration", componentCtx.ValidateKueueManagedToRemovedToUnmanagedTransition(true)},
-			TestCase{"Validate component managed to removed to unmanaged transition without config migration", componentCtx.ValidateKueueManagedToRemovedToUnmanagedTransition(false)},
-			TestCase{"Validate component unmanaged to managed transition", componentCtx.ValidateKueueUnmanagedToManagedTransition},
+			// TestCase{"Validate component managed error with ocp kueue-operator installed", componentCtx.ValidateKueueManagedWithOcpKueueOperator}, // Requires rhbok installation
+			TestCase{"Validate component unmanaged error with ocp kueue-operator not installed", componentCtx.ValidateKueueUnmanagedWithoutOcpKueueOperator}, // Can run without rhbok
+			// TestCase{"Validate component managed to unmanaged transition", componentCtx.ValidateKueueManagedToUnmanagedTransition}, // Requires rhbok installation and Managed state
+			// TestCase{"Validate component managed to removed to unmanaged transition with config migration",
+			//          componentCtx.ValidateKueueManagedToRemovedToUnmanagedTransition(true)}, // Requires rhbok installation and Managed state
+			// TestCase{"Validate component managed to removed to unmanaged transition without config migration",
+			//          componentCtx.ValidateKueueManagedToRemovedToUnmanagedTransition(false)}, // Requires rhbok installation and Managed state
+			// TestCase{"Validate component unmanaged to managed transition", componentCtx.ValidateKueueUnmanagedToManagedTransition}, // Requires rhbok installation and Managed state
 		)
 	}
 
-	// Add webhook tests if enabled
+	// Add webhook tests if enabled - these work even with Kueue unmanaged, only need Workbenches managed
 	if testOpts.webhookTest {
 		testCases = append(testCases,
 			// Enable Workbenches component to ensure Notebook CRD is available for webhook tests


### PR DESCRIPTION
- set ossm to Removed in DSCI, so we can skip test
- set knative to Removed in DSC, so we can skip kserve tests

<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [ ] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Tests
  - Added a generic workload-object helper for webhook tests and updated validation tests to use it, including a case for unexpected resource kinds.
  - Removed or temporarily disabled multiple KServe, Service Mesh, and Kueue validation/e2e cases; reduced active Kueue e2e tests and gated some tests by version/flags.

- Chores
  - Adjusted e2e setups: Service Mesh management state set to Removed, default serving/deployment modes updated.
  - Streamlined operator-related test constants and added Kueue operator name.

No user-facing functional changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->