### PR TITLE
Update golangci-lint to v2.5.0

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -21,7 +21,10 @@ linters:
     - varnamelen
     - wrapcheck
     - wsl
+    - wsl_v5
     - funcorder
+    - godoclint
+    - noinlineerr
   settings:
     errcheck:
       check-type-assertions: true

--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ YQ ?= $(LOCALBIN)/yq
 KUSTOMIZE_VERSION ?= v5.7.0
 CONTROLLER_TOOLS_VERSION ?= v0.17.3
 OPERATOR_SDK_VERSION ?= v1.39.2
-GOLANGCI_LINT_VERSION ?= v2.1.2
+GOLANGCI_LINT_VERSION ?= v2.5.0
 YQ_VERSION ?= v4.12.2
 #ENVTEST_K8S_VERSION is the version of Kubernetes to use for setting up ENVTEST binaries (i.e. 1.31)
 ENVTEST_K8S_VERSION ?= $(shell go list -m -f "{{ .Version }}" k8s.io/api | awk -F'[v.]' '{printf "1.%d", $$3}')

--- a/internal/controller/components/dashboard/dashboard_controller_actions.go
+++ b/internal/controller/components/dashboard/dashboard_controller_actions.go
@@ -33,7 +33,8 @@ import (
 type DashboardHardwareProfile struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
-	Spec              DashboardHardwareProfileSpec `json:"spec"`
+
+	Spec DashboardHardwareProfileSpec `json:"spec"`
 }
 
 type DashboardHardwareProfileSpec struct {
@@ -48,7 +49,8 @@ type DashboardHardwareProfileSpec struct {
 type DashboardHardwareProfileList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
-	Items           []DashboardHardwareProfile `json:"items"`
+
+	Items []DashboardHardwareProfile `json:"items"`
 }
 
 func initialize(ctx context.Context, rr *odhtypes.ReconciliationRequest) error {

--- a/internal/webhook/envtestutil/envtestutil.go
+++ b/internal/webhook/envtestutil/envtestutil.go
@@ -118,7 +118,7 @@ func SetupEnvAndClient(
 	}()
 
 	t.Log("Waiting for webhook server to be ready...")
-	if err := env.WaitForWebhookServer(timeout); err != nil {
+	if err := env.WaitForWebhookServer(ctx, timeout); err != nil {
 		t.Fatalf("webhook server not ready: %v", err)
 	}
 

--- a/internal/webhook/notebook/mutating_test.go
+++ b/internal/webhook/notebook/mutating_test.go
@@ -129,6 +129,7 @@ func createAdmissionRequest(t *testing.T, operation admissionv1.Operation, obj *
 // Helper struct to mock SubjectAccessReview behavior.
 type mockClient struct {
 	client.Client
+
 	allowPermissions map[string]bool
 }
 

--- a/pkg/cluster/cluster_config_test.go
+++ b/pkg/cluster/cluster_config_test.go
@@ -20,6 +20,7 @@ import (
 // erroringClient is a wrapper around a client.Client that allows us to inject errors.
 type erroringClient struct {
 	client.Client
+
 	err error
 }
 

--- a/pkg/controller/actions/cacher/cacher_test.go
+++ b/pkg/controller/actions/cacher/cacher_test.go
@@ -18,6 +18,7 @@ import (
 
 type testCacher struct {
 	mock.Mock
+
 	cacher *cacher.Cacher[resources.UnstructuredList]
 	rr     *types.ReconciliationRequest
 	ctx    context.Context //nolint:containedctx

--- a/pkg/controller/actions/gc/action_gc_test.go
+++ b/pkg/controller/actions/gc/action_gc_test.go
@@ -57,7 +57,7 @@ func TestGcAction(t *testing.T) {
 		_ = envTest.Stop()
 	})
 
-	ctx := context.Background() //nolint:usetesting
+	ctx := context.Background()
 	cli := envTest.Client()
 
 	tests := []struct {
@@ -356,7 +356,7 @@ func TestGcActionOwn(t *testing.T) {
 		_ = envTest.Stop()
 	})
 
-	ctx := context.Background() //nolint:usetesting
+	ctx := context.Background()
 	cli := envTest.Client()
 
 	tests := []struct {
@@ -500,7 +500,7 @@ func TestGcActionCluster(t *testing.T) {
 		_ = envTest.Stop()
 	})
 
-	ctx := context.Background() //nolint:usetesting
+	ctx := context.Background()
 	cli := envTest.Client()
 	nsn := xid.New().String()
 
@@ -640,7 +640,7 @@ func TestGcActionOnce(t *testing.T) {
 		_ = envTest.Stop()
 	})
 
-	ctx := context.Background() //nolint:usetesting
+	ctx := context.Background()
 	cli := envTest.Client()
 	nsn := xid.New().String()
 

--- a/pkg/controller/actions/resourcecacher/resourcecacher.go
+++ b/pkg/controller/actions/resourcecacher/resourcecacher.go
@@ -18,6 +18,7 @@ import (
 type Renderer func(ctx context.Context, rr *types.ReconciliationRequest) (resources.UnstructuredList, error)
 type ResourceCacher struct {
 	cacher.Cacher[resources.UnstructuredList]
+
 	name string
 }
 

--- a/pkg/controller/actions/resourcecacher/resourcecacher_test.go
+++ b/pkg/controller/actions/resourcecacher/resourcecacher_test.go
@@ -21,6 +21,7 @@ import (
 
 type testCacher struct {
 	mock.Mock
+
 	cacher    *resourcecacher.ResourceCacher
 	rr        *types.ReconciliationRequest
 	ctx       context.Context //nolint:containedctx

--- a/pkg/controller/predicates/dependent/dependent.go
+++ b/pkg/controller/predicates/dependent/dependent.go
@@ -50,11 +50,11 @@ func New(opts ...PredicateOption) *Predicate {
 }
 
 type Predicate struct {
+	predicate.Funcs
+
 	WatchDelete bool
 	WatchUpdate bool
 	WatchStatus bool
-
-	predicate.Funcs
 }
 
 func (p Predicate) Create(event.CreateEvent) bool {

--- a/pkg/controller/predicates/partial/partial.go
+++ b/pkg/controller/predicates/partial/partial.go
@@ -38,10 +38,10 @@ func New(opts ...PredicateOption) *Predicate {
 }
 
 type Predicate struct {
+	predicate.Funcs
+
 	WatchDelete bool
 	WatchUpdate bool
-
-	predicate.Funcs
 }
 
 func (p Predicate) Create(event.CreateEvent) bool {

--- a/pkg/utils/test/testf/testf_witht.go
+++ b/pkg/utils/test/testf/testf_witht.go
@@ -19,10 +19,10 @@ import (
 // WithT encapsulates the test context and the Kubernetes client, along with gomega's assertion methods.
 // It provides utility methods to interact with resources in a Kubernetes cluster and perform assertions on them.
 type WithT struct {
+	*gomega.WithT
+
 	ctx    context.Context
 	client client.Client
-
-	*gomega.WithT
 }
 
 // WithTOpts is a function type used to configure options for the WithT object.

--- a/tests/e2e/cfmap_deletion_test.go
+++ b/tests/e2e/cfmap_deletion_test.go
@@ -20,6 +20,7 @@ import (
 // CfgMapDeletionTestCtx holds the context for the config map deletion tests.
 type CfgMapDeletionTestCtx struct {
 	*TestContext
+
 	ConfigMapNamespacedName types.NamespacedName
 }
 

--- a/tests/e2e/components_test.go
+++ b/tests/e2e/components_test.go
@@ -28,6 +28,7 @@ import (
 // ComponentTestCtx holds the context for component tests.
 type ComponentTestCtx struct {
 	*TestContext
+
 	// Any additional fields specific to component tests
 	GVK            schema.GroupVersionKind
 	NamespacedName types.NamespacedName


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [x] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->

This updates the linter only, no e2e test required

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated linting tool version and configuration to streamline development workflows.
- Tests
  - Improved test utilities with context-aware waiting, enhanced mocks, and additional test fields for clearer scenarios.
  - Removed unnecessary annotations and performed minor test cleanups.
- Refactor
  - Minor internal restructuring (field reordering and small struct adjustments) with no behavioral changes.
- Style
  - Formatting tweaks and whitespace cleanups across test and internal files.
- Documentation
  - Updated inline comments to reflect new parameters and behaviors in test utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->