### PR TITLE
RHOAIENG-33891: DSC v1 should not be created or updated with Kueue component state set to Managed

### DIFF
--- a/bundle/manifests/opendatahub-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/opendatahub-operator.clusterserviceversion.yaml
@@ -219,7 +219,7 @@ metadata:
     categories: AI/Machine Learning, Big Data
     certified: "False"
     containerImage: quay.io/opendatahub/opendatahub-operator:v3.0.0
-    createdAt: "2025-10-01T08:57:33Z"
+    createdAt: "2025-10-03T15:35:23Z"
     operators.operatorframework.io/builder: operator-sdk-v1.39.2
     operators.operatorframework.io/internal-objects: '["featuretrackers.features.opendatahub.io",
       "codeflares.components.platform.opendatahub.io", "dashboards.components.platform.opendatahub.io",
@@ -293,7 +293,9 @@ spec:
       kind: GatewayConfig
       name: gatewayconfigs.services.platform.opendatahub.io
       version: v1alpha1
-    - kind: HardwareProfile
+    - description: HardwareProfile is the Schema for the hardwareprofiles API.
+      displayName: Hardware Profile
+      kind: HardwareProfile
       name: hardwareprofiles.infrastructure.opendatahub.io
       version: v1
     - description: HardwareProfile is the Schema for the hardwareprofiles API.
@@ -1852,6 +1854,7 @@ spec:
     deploymentName: opendatahub-operator-controller-manager
     failurePolicy: Fail
     generateName: datasciencecluster-v1-defaulter.opendatahub.io
+    matchPolicy: Exact
     rules:
     - apiGroups:
       - datasciencecluster.opendatahub.io
@@ -1872,6 +1875,7 @@ spec:
     deploymentName: opendatahub-operator-controller-manager
     failurePolicy: Fail
     generateName: datasciencecluster-v1-validator.opendatahub.io
+    matchPolicy: Exact
     rules:
     - apiGroups:
       - datasciencecluster.opendatahub.io
@@ -1879,6 +1883,7 @@ spec:
       - v1
       operations:
       - CREATE
+      - UPDATE
       resources:
       - datascienceclusters
     sideEffects: None
@@ -1891,6 +1896,7 @@ spec:
     deploymentName: opendatahub-operator-controller-manager
     failurePolicy: Fail
     generateName: datasciencecluster-v2-defaulter.opendatahub.io
+    matchPolicy: Exact
     rules:
     - apiGroups:
       - datasciencecluster.opendatahub.io
@@ -1911,6 +1917,7 @@ spec:
     deploymentName: opendatahub-operator-controller-manager
     failurePolicy: Fail
     generateName: datasciencecluster-v2-validator.opendatahub.io
+    matchPolicy: Exact
     rules:
     - apiGroups:
       - datasciencecluster.opendatahub.io
@@ -1930,6 +1937,7 @@ spec:
     deploymentName: opendatahub-operator-controller-manager
     failurePolicy: Fail
     generateName: dscinitialization-v1-validator.opendatahub.io
+    matchPolicy: Exact
     rules:
     - apiGroups:
       - dscinitialization.opendatahub.io
@@ -1950,6 +1958,7 @@ spec:
     deploymentName: opendatahub-operator-controller-manager
     failurePolicy: Fail
     generateName: dscinitialization-v2-validator.opendatahub.io
+    matchPolicy: Exact
     rules:
     - apiGroups:
       - dscinitialization.opendatahub.io

--- a/config/manifests/bases/opendatahub-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/opendatahub-operator.clusterserviceversion.yaml
@@ -25,6 +25,11 @@ spec:
   apiservicedefinitions: {}
   customresourcedefinitions:
     owned:
+    - description: HardwareProfile is the Schema for the hardwareprofiles API.
+      displayName: Hardware Profile
+      kind: HardwareProfile
+      name: hardwareprofiles.infrastructure.opendatahub.io
+      version: v1alpha1
     - description: Auth is the Schema for the auths API
       displayName: Auth
       kind: Auth
@@ -80,7 +85,7 @@ spec:
       displayName: Hardware Profile
       kind: HardwareProfile
       name: hardwareprofiles.infrastructure.opendatahub.io
-      version: v1alpha1
+      version: v1
     - description: Kserve is the Schema for the kserves API
       displayName: Kserve
       kind: Kserve

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -12,6 +12,7 @@ webhooks:
       namespace: system
       path: /mutate-datasciencecluster-v1
   failurePolicy: Fail
+  matchPolicy: Exact
   name: datasciencecluster-v1-defaulter.opendatahub.io
   rules:
   - apiGroups:
@@ -32,6 +33,7 @@ webhooks:
       namespace: system
       path: /mutate-datasciencecluster-v2
   failurePolicy: Fail
+  matchPolicy: Exact
   name: datasciencecluster-v2-defaulter.opendatahub.io
   rules:
   - apiGroups:
@@ -178,6 +180,7 @@ webhooks:
       namespace: system
       path: /validate-datasciencecluster-v1
   failurePolicy: Fail
+  matchPolicy: Exact
   name: datasciencecluster-v1-validator.opendatahub.io
   rules:
   - apiGroups:
@@ -186,6 +189,7 @@ webhooks:
     - v1
     operations:
     - CREATE
+    - UPDATE
     resources:
     - datascienceclusters
   sideEffects: None
@@ -197,6 +201,7 @@ webhooks:
       namespace: system
       path: /validate-datasciencecluster-v2
   failurePolicy: Fail
+  matchPolicy: Exact
   name: datasciencecluster-v2-validator.opendatahub.io
   rules:
   - apiGroups:
@@ -216,6 +221,7 @@ webhooks:
       namespace: system
       path: /validate-dscinitialization-v1
   failurePolicy: Fail
+  matchPolicy: Exact
   name: dscinitialization-v1-validator.opendatahub.io
   rules:
   - apiGroups:
@@ -236,6 +242,7 @@ webhooks:
       namespace: system
       path: /validate-dscinitialization-v2
   failurePolicy: Fail
+  matchPolicy: Exact
   name: dscinitialization-v2-validator.opendatahub.io
   rules:
   - apiGroups:

--- a/internal/webhook/datasciencecluster/v1/defaulting.go
+++ b/internal/webhook/datasciencecluster/v1/defaulting.go
@@ -20,7 +20,7 @@ import (
 	webhookutils "github.com/opendatahub-io/opendatahub-operator/v2/pkg/webhook"
 )
 
-//+kubebuilder:webhook:path=/mutate-datasciencecluster-v1,mutating=true,failurePolicy=fail,sideEffects=None,groups=datasciencecluster.opendatahub.io,resources=datascienceclusters,verbs=create;update,versions=v1,name=datasciencecluster-v1-defaulter.opendatahub.io,admissionReviewVersions=v1
+//+kubebuilder:webhook:path=/mutate-datasciencecluster-v1,matchPolicy=Exact,mutating=true,failurePolicy=fail,sideEffects=None,groups=datasciencecluster.opendatahub.io,resources=datascienceclusters,verbs=create;update,versions=v1,name=datasciencecluster-v1-defaulter.opendatahub.io,admissionReviewVersions=v1
 //nolint:lll
 
 // Defaulter implements webhook.CustomDefaulter for DataScienceCluster v1 resources.

--- a/internal/webhook/datasciencecluster/v1/register.go
+++ b/internal/webhook/datasciencecluster/v1/register.go
@@ -4,6 +4,7 @@ package v1
 
 import (
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	dscv1 "github.com/opendatahub-io/opendatahub-operator/v2/api/datasciencecluster/v1"
 )
@@ -17,8 +18,9 @@ func RegisterWebhooks(mgr ctrl.Manager) error {
 
 	// Register the validating webhook
 	if err := (&Validator{
-		Client: mgr.GetAPIReader(),
-		Name:   "datasciencecluster-v1-validating",
+		Client:  mgr.GetAPIReader(),
+		Name:    "datasciencecluster-v1-validating",
+		Decoder: admission.NewDecoder(mgr.GetScheme()),
 	}).SetupWithManager(mgr); err != nil {
 		return err
 	}

--- a/internal/webhook/datasciencecluster/v1/validating.go
+++ b/internal/webhook/datasciencecluster/v1/validating.go
@@ -5,7 +5,9 @@ package v1
 import (
 	"context"
 	"fmt"
+	"net/http"
 
+	operatorv1 "github.com/openshift/api/operator/v1"
 	admissionv1 "k8s.io/api/admission/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -13,18 +15,20 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
+	dscv1 "github.com/opendatahub-io/opendatahub-operator/v2/api/datasciencecluster/v1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
 	webhookutils "github.com/opendatahub-io/opendatahub-operator/v2/pkg/webhook"
 )
 
-//+kubebuilder:webhook:path=/validate-datasciencecluster-v1,mutating=false,failurePolicy=fail,sideEffects=None,groups=datasciencecluster.opendatahub.io,resources=datascienceclusters,verbs=create,versions=v1,name=datasciencecluster-v1-validator.opendatahub.io,admissionReviewVersions=v1
+//+kubebuilder:webhook:path=/validate-datasciencecluster-v1,matchPolicy=Exact,mutating=false,failurePolicy=fail,sideEffects=None,groups=datasciencecluster.opendatahub.io,resources=datascienceclusters,verbs=create;update,versions=v1,name=datasciencecluster-v1-validator.opendatahub.io,admissionReviewVersions=v1
 //nolint:lll
 
 // Validator implements webhook.AdmissionHandler for DataScienceCluster v1 validation webhooks.
 // It enforces singleton creation rules for DataScienceCluster resources and always allows their deletion.
 type Validator struct {
-	Client client.Reader
-	Name   string
+	Client  client.Reader
+	Name    string
+	Decoder admission.Decoder
 }
 
 // Assert that Validator implements admission.Handler interface.
@@ -59,18 +63,50 @@ func (v *Validator) Handle(ctx context.Context, req admission.Request) admission
 	log := logf.FromContext(ctx)
 	ctx = logf.IntoContext(ctx, log)
 
-	var resp admission.Response
+	allowMessage := fmt.Sprintf("Operation %s on %s v1 allowed", req.Operation, req.Kind.Kind)
+
+	if req.Kind.Kind != gvk.DataScienceClusterV1.Kind || req.Kind.Group != gvk.DataScienceClusterV1.Group || req.Kind.Version != gvk.DataScienceClusterV1.Version {
+		err := fmt.Errorf("unexpected gvk: %v; expecting: %v", req.Kind, gvk.DataScienceClusterV1)
+		logf.FromContext(ctx).Error(err, "got wrong group/version/kind")
+		return admission.Errored(http.StatusBadRequest, err)
+	}
 
 	switch req.Operation {
 	case admissionv1.Create:
-		resp = webhookutils.ValidateSingletonCreation(ctx, v.Client, &req, gvk.DataScienceCluster)
+		return validate([]validationCheck{v.denyManagementstateManaged, denyMultipleDsc}, allowMessage, ctx, v.Client, &req)
+	case admissionv1.Update:
+		return validate([]validationCheck{v.denyManagementstateManaged}, allowMessage, ctx, v.Client, &req)
 	default:
-		resp.Allowed = true // initialize Allowed to be true in case Operation falls into "default" case
+		return admission.Allowed(allowMessage) // initialize Allowed to be true in case Operation falls into "default" case
+	}
+}
+
+type validationCheck func(context.Context, client.Reader, *admission.Request) admission.Response
+
+func validate(checks []validationCheck, allowedMessage string, ctx context.Context, client client.Reader, request *admission.Request) admission.Response {
+	for _, check := range checks {
+		resp := check(ctx, client, request)
+		if !resp.Allowed {
+			return resp
+		}
 	}
 
-	if !resp.Allowed {
-		return resp
+	return admission.Allowed(allowedMessage)
+}
+
+func denyMultipleDsc(ctx context.Context, client client.Reader, req *admission.Request) admission.Response {
+	return webhookutils.ValidateSingletonCreation(ctx, client, req, gvk.DataScienceCluster)
+}
+
+func (v *Validator) denyManagementstateManaged(ctx context.Context, client client.Reader, req *admission.Request) admission.Response {
+	dcsV1 := &dscv1.DataScienceCluster{}
+	if err := v.Decoder.DecodeRaw(req.Object, dcsV1); err != nil {
+		logf.FromContext(ctx).Error(err, "Error converting request object to "+gvk.DataScienceClusterV1.String())
+		return admission.Errored(http.StatusBadRequest, err)
+	}
+	if dcsV1.Spec.Components.Kueue.ManagementState == operatorv1.Managed {
+		return admission.Denied("Managed is no longer supported as a managementState")
 	}
 
-	return admission.Allowed(fmt.Sprintf("Operation %s on %s v1 allowed", req.Operation, req.Kind.Kind))
+	return admission.Allowed("")
 }

--- a/internal/webhook/datasciencecluster/v2/defaulting.go
+++ b/internal/webhook/datasciencecluster/v2/defaulting.go
@@ -20,7 +20,7 @@ import (
 	webhookutils "github.com/opendatahub-io/opendatahub-operator/v2/pkg/webhook"
 )
 
-//+kubebuilder:webhook:path=/mutate-datasciencecluster-v2,mutating=true,failurePolicy=fail,sideEffects=None,groups=datasciencecluster.opendatahub.io,resources=datascienceclusters,verbs=create;update,versions=v2,name=datasciencecluster-v2-defaulter.opendatahub.io,admissionReviewVersions=v1
+//+kubebuilder:webhook:path=/mutate-datasciencecluster-v2,matchPolicy=Exact,mutating=true,failurePolicy=fail,sideEffects=None,groups=datasciencecluster.opendatahub.io,resources=datascienceclusters,verbs=create;update,versions=v2,name=datasciencecluster-v2-defaulter.opendatahub.io,admissionReviewVersions=v1
 //nolint:lll
 
 // Defaulter implements webhook.CustomDefaulter for DataScienceCluster v2 resources.

--- a/internal/webhook/datasciencecluster/v2/validating.go
+++ b/internal/webhook/datasciencecluster/v2/validating.go
@@ -17,7 +17,7 @@ import (
 	webhookutils "github.com/opendatahub-io/opendatahub-operator/v2/pkg/webhook"
 )
 
-//+kubebuilder:webhook:path=/validate-datasciencecluster-v2,mutating=false,failurePolicy=fail,sideEffects=None,groups=datasciencecluster.opendatahub.io,resources=datascienceclusters,verbs=create,versions=v2,name=datasciencecluster-v2-validator.opendatahub.io,admissionReviewVersions=v1
+//+kubebuilder:webhook:path=/validate-datasciencecluster-v2,matchPolicy=Exact,mutating=false,failurePolicy=fail,sideEffects=None,groups=datasciencecluster.opendatahub.io,resources=datascienceclusters,verbs=create,versions=v2,name=datasciencecluster-v2-validator.opendatahub.io,admissionReviewVersions=v1
 //nolint:lll
 
 // Validator implements webhook.AdmissionHandler for DataScienceCluster v2 validation webhooks.

--- a/internal/webhook/dscinitialization/v1/validating.go
+++ b/internal/webhook/dscinitialization/v1/validating.go
@@ -17,7 +17,7 @@ import (
 	webhookutils "github.com/opendatahub-io/opendatahub-operator/v2/pkg/webhook"
 )
 
-//+kubebuilder:webhook:path=/validate-dscinitialization-v1,mutating=false,failurePolicy=fail,sideEffects=None,groups=dscinitialization.opendatahub.io,resources=dscinitializations,verbs=create;delete,versions=v1,name=dscinitialization-v1-validator.opendatahub.io,admissionReviewVersions=v1
+//+kubebuilder:webhook:path=/validate-dscinitialization-v1,matchPolicy=Exact,mutating=false,failurePolicy=fail,sideEffects=None,groups=dscinitialization.opendatahub.io,resources=dscinitializations,verbs=create;delete,versions=v1,name=dscinitialization-v1-validator.opendatahub.io,admissionReviewVersions=v1
 //nolint:lll
 
 // Validator implements webhook.AdmissionHandler for DSCInitialization v1 validation webhooks.

--- a/internal/webhook/dscinitialization/v2/validating.go
+++ b/internal/webhook/dscinitialization/v2/validating.go
@@ -17,7 +17,7 @@ import (
 	webhookutils "github.com/opendatahub-io/opendatahub-operator/v2/pkg/webhook"
 )
 
-//+kubebuilder:webhook:path=/validate-dscinitialization-v2,mutating=false,failurePolicy=fail,sideEffects=None,groups=dscinitialization.opendatahub.io,resources=dscinitializations,verbs=create;delete,versions=v2,name=dscinitialization-v2-validator.opendatahub.io,admissionReviewVersions=v1
+//+kubebuilder:webhook:path=/validate-dscinitialization-v2,matchPolicy=Exact,mutating=false,failurePolicy=fail,sideEffects=None,groups=dscinitialization.opendatahub.io,resources=dscinitializations,verbs=create;delete,versions=v2,name=dscinitialization-v2-validator.opendatahub.io,admissionReviewVersions=v1
 //nolint:lll
 
 // Validator implements webhook.AdmissionHandler for DSCInitialization v2 validation webhooks.

--- a/pkg/webhook/utils.go
+++ b/pkg/webhook/utils.go
@@ -176,7 +176,7 @@ func CountObjects(ctx context.Context, cli client.Reader, gvk schema.GroupVersio
 //
 // Returns:
 //   - admission.Response: Denied if objects exist, Allowed otherwise, or Errored on failure.
-func DenyCountGtZero(ctx context.Context, cli client.Reader, gvk schema.GroupVersionKind, msg string) admission.Response {
+func DenyCountGtZero(ctx context.Context, cli client.Reader, gvk schema.GroupVersionKind, denyMessage string) admission.Response {
 	count, err := CountObjects(ctx, cli, gvk)
 	if err != nil {
 		logf.FromContext(ctx).Error(err, "error listing objects")
@@ -184,7 +184,7 @@ func DenyCountGtZero(ctx context.Context, cli client.Reader, gvk schema.GroupVer
 	}
 
 	if count > 0 {
-		return admission.Denied(msg)
+		return admission.Denied(denyMessage)
 	}
 
 	return admission.Allowed("")


### PR DESCRIPTION
## Description

- Changed validation webhook of DSC v1to deny create and update requests with `Spec.Components.Kueue.ManagementState == Managed`
- Added tests

see https://issues.redhat.com/browse/RHOAIENG-33891

## How Has This Been Tested?
unit and e2e tests

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed - [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [x] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [ ] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Admission webhooks now use Exact match policy and apply stricter matching; validators also cover update/delete operations for relevant resources.
  - Hardware Profile CRD added to the operator metadata (display name, description, kind, version).

- **Behavior Changes**
  - Creating or updating a DataScienceCluster v1 with Kueue managementState=Managed is denied; Unmanaged, Removed, or unspecified states are allowed.

- **Tests**
  - E2E tests expanded to validate webhook behavior across Kueue states (Managed, Unmanaged, Removed, absent).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->