### PR TITLE
Add kube-linter to checks Kubernetes manifests against various best practices, with a focus on production readiness and security

### DIFF
--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -23,3 +23,15 @@ jobs:
       - name: lint
         run:
           make lint
+  kube-linter:
+    name: kube-linter
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Go env
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - name: kube-lint
+        run:
+          make kube-lint

--- a/.kube-linter.yaml
+++ b/.kube-linter.yaml
@@ -1,0 +1,18 @@
+checks:
+  # if doNotAutoAddDefaults is true, default checks are not automatically added.
+  doNotAutoAddDefaults: true
+
+  # addAllBuiltIn, if set, adds all built-in checks. This allows users to
+  # explicitly opt-out of checks that are not relevant using Exclude.
+  # Takes precedence over doNotAutoAddDefaults, if both are set.
+  addAllBuiltIn: false
+
+  include:
+    - "privileged-container"
+    - "privileged-ports"
+    - "run-as-non-root"
+    - "cluster-admin-role-binding"
+    - "no-liveness-probe"
+    - "no-readiness-probe"
+    - "unset-cpu-requirements"
+    - "unset-memory-requirements"

--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,7 @@ CONTROLLER_TOOLS_VERSION ?= v0.17.3
 OPERATOR_SDK_VERSION ?= v1.39.2
 GOLANGCI_LINT_VERSION ?= v2.5.0
 YQ_VERSION ?= v4.12.2
+KUBE_LINTER_VERSION ?= v0.7.6
 #ENVTEST_K8S_VERSION is the version of Kubernetes to use for setting up ENVTEST binaries (i.e. 1.31)
 ENVTEST_K8S_VERSION ?= $(shell go list -m -f "{{ .Version }}" k8s.io/api | awk -F'[v.]' '{printf "1.%d", $$3}')
 #ENVTEST_VERSION is the version of controller-runtime release branch to fetch the envtest setup script (i.e. release-0.20)
@@ -171,6 +172,13 @@ lint: golangci-lint ## Run golangci-lint against code.
 lint-fix: golangci-lint ## Run golangci-lint against code.
 	$(GOLANGCI_LINT) run --fix
 	$(GOLANGCI_LINT) fmt
+
+.PHONY: kube-lint
+kube-lint: prepare ## Run kube-linter against rendered manifests.
+	@TMP_FILE=$$(mktemp /tmp/kube-lint.XXXXXX.yaml) && \
+	$(KUSTOMIZE) build --load-restrictor LoadRestrictionsNone config/manifests > $$TMP_FILE && \
+	go run golang.stackrox.io/kube-linter/cmd/kube-linter@$(KUBE_LINTER_VERSION) lint --config .kube-linter.yaml $$TMP_FILE && \
+	rm -f $$TMP_FILE
 
 .PHONY: get-manifests
 get-manifests: ## Fetch components manifests from remote git repo


### PR DESCRIPTION
See:
- https://docs.kubelinter.io/
- https://github.com/stackrox/kube-linter

<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->

This add an additional linter, no e2e tests required 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Added automated Kubernetes manifest linting in CI to catch misconfigurations early.
  - Included a standardized kube-linter configuration emphasizing security and resource best practices (non-root, probes, limits, privileged checks).
  - Added a local make command and CI job to run kube-linter for faster developer feedback.
  - Improves reliability and consistency of Kubernetes deployments without affecting runtime behavior or user workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->