### PR TITLE
chore: use generic Getter[T] instead of StringGetter

### DIFF
--- a/pkg/controller/actions/actions.go
+++ b/pkg/controller/actions/actions.go
@@ -18,8 +18,7 @@ const (
 
 type Fn func(ctx context.Context, rr *types.ReconciliationRequest) error
 
-// TODO replace with type alias in GO 1.24.
-type StringGetter func(context.Context, *types.ReconciliationRequest) (string, error)
+type Getter[T any] func(context.Context, *types.ReconciliationRequest) (T, error)
 
 func (f Fn) String() string {
 	fn := runtime.FuncForPC(reflect.ValueOf(f).Pointer())

--- a/pkg/controller/actions/gc/action_gc.go
+++ b/pkg/controller/actions/gc/action_gc.go
@@ -35,7 +35,7 @@ type Action struct {
 	objectPredicateFn ObjectPredicateFn
 	typePredicateFn   TypePredicateFn
 	onlyOwned         bool
-	namespaceFn       actions.StringGetter
+	namespaceFn       actions.Getter[string]
 }
 
 func WithLabel(name string, value string) ActionOpts {
@@ -102,7 +102,7 @@ func InNamespace(ns string) ActionOpts {
 	}
 }
 
-func InNamespaceFn(fn actions.StringGetter) ActionOpts {
+func InNamespaceFn(fn actions.Getter[string]) ActionOpts {
 	return func(action *Action) {
 		if fn == nil {
 			return

--- a/pkg/controller/actions/status/deployments/action_deployments_available.go
+++ b/pkg/controller/actions/status/deployments/action_deployments_available.go
@@ -18,7 +18,7 @@ import (
 
 type Action struct {
 	labels      map[string]string
-	namespaceFn actions.StringGetter
+	namespaceFn actions.Getter[string]
 }
 
 type ActionOpts func(*Action)
@@ -45,7 +45,7 @@ func InNamespace(ns string) ActionOpts {
 	}
 }
 
-func InNamespaceFn(fn actions.StringGetter) ActionOpts {
+func InNamespaceFn(fn actions.Getter[string]) ActionOpts {
 	return func(action *Action) {
 		if fn == nil {
 			return


### PR DESCRIPTION
Update StringGetter to use Go generics, allowing the type to work with
any return type instead of being limited to strings.

<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [ ] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->
