### PR TITLE
[sync] RHOAIENG-29717 | feat: Deploy thanos querier frontend for metrics acces

### DIFF
--- a/bundle/manifests/rhods-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/rhods-operator.clusterserviceversion.yaml
@@ -1126,6 +1126,7 @@ spec:
           - monitoringstacks
           - prometheusrules
           - servicemonitors
+          - thanosqueriers
           verbs:
           - create
           - delete
@@ -1140,6 +1141,7 @@ spec:
           - monitoringstacks/finalizers
           - prometheusrules/finalizers
           - servicemonitors/finalizers
+          - thanosqueriers/finalizers
           verbs:
           - update
         - apiGroups:
@@ -1148,6 +1150,7 @@ spec:
           - monitoringstacks/status
           - prometheusrules/status
           - servicemonitors/status
+          - thanosqueriers/status
           verbs:
           - get
           - patch

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -779,6 +779,7 @@ rules:
   - monitoringstacks
   - prometheusrules
   - servicemonitors
+  - thanosqueriers
   verbs:
   - create
   - delete
@@ -793,6 +794,7 @@ rules:
   - monitoringstacks/finalizers
   - prometheusrules/finalizers
   - servicemonitors/finalizers
+  - thanosqueriers/finalizers
   verbs:
   - update
 - apiGroups:
@@ -801,6 +803,7 @@ rules:
   - monitoringstacks/status
   - prometheusrules/status
   - servicemonitors/status
+  - thanosqueriers/status
   verbs:
   - get
   - patch

--- a/internal/controller/dscinitialization/kubebuilder_rbac.go
+++ b/internal/controller/dscinitialization/kubebuilder_rbac.go
@@ -61,6 +61,9 @@ package dscinitialization
 //+kubebuilder:rbac:groups=monitoring.rhobs,resources=prometheusrules,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=monitoring.rhobs,resources=prometheusrules/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=monitoring.rhobs,resources=prometheusrules/finalizers,verbs=update
+//+kubebuilder:rbac:groups=monitoring.rhobs,resources=thanosqueriers,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=monitoring.rhobs,resources=thanosqueriers/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=monitoring.rhobs,resources=thanosqueriers/finalizers,verbs=update
 
 //+kubebuilder:rbac:groups=opentelemetry.io,resources=opentelemetrycollectors,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=opentelemetry.io,resources=opentelemetrycollectors/status,verbs=get;update;patch

--- a/internal/controller/services/monitoring/monitoring_controller.go
+++ b/internal/controller/services/monitoring/monitoring_controller.go
@@ -99,6 +99,7 @@ func (h *serviceHandler) NewReconciler(ctx context.Context, mgr ctrl.Manager) er
 		OwnsGVK(gvk.OpenTelemetryCollector, reconciler.Dynamic(reconciler.CrdExists(gvk.OpenTelemetryCollector))).
 		OwnsGVK(gvk.ServiceMonitor, reconciler.Dynamic(reconciler.CrdExists(gvk.ServiceMonitor))).
 		OwnsGVK(gvk.PrometheusRule, reconciler.Dynamic(reconciler.CrdExists(gvk.PrometheusRule))).
+		OwnsGVK(gvk.ThanosQuerier, reconciler.Dynamic(reconciler.CrdExists(gvk.ThanosQuerier))).
 		// operands - watched
 		//
 		// By default the Watches functions adds:

--- a/internal/controller/services/monitoring/resources/thanos-querier-cr.tmpl.yaml
+++ b/internal/controller/services/monitoring/resources/thanos-querier-cr.tmpl.yaml
@@ -1,0 +1,20 @@
+apiVersion: monitoring.rhobs/v1alpha1
+kind: ThanosQuerier
+metadata:
+  name: data-science-thanos-querier
+  namespace: {{.Namespace}}
+  labels:
+    app: thanos-querier
+    app.kubernetes.io/name: thanos-querier
+    app.kubernetes.io/component: querier
+    app.kubernetes.io/part-of: data-science-monitoring
+spec:
+  selector:
+    matchLabels:
+      platform.opendatahub.io/part-of: monitoring
+  namespaceSelector:
+    matchNames:
+      - {{.Namespace}}
+  replicaLabels:
+    - prometheus_replica
+    - rule_replica

--- a/internal/controller/services/monitoring/resources/thanos-querier-route.tmpl.yaml
+++ b/internal/controller/services/monitoring/resources/thanos-querier-route.tmpl.yaml
@@ -1,0 +1,22 @@
+kind: Route
+apiVersion: route.openshift.io/v1
+metadata:
+  name: data-science-thanos-querier-route
+  namespace: {{.Namespace}}
+  labels:
+    app: thanos-querier
+    app.kubernetes.io/name: thanos-querier
+    app.kubernetes.io/component: querier
+    app.kubernetes.io/part-of: data-science-monitoring
+spec:
+  path: /
+  to:
+    kind: Service
+    name: thanos-querier-data-science-thanos-querier
+    weight: 100
+  port:
+    targetPort: http
+  wildcardPolicy: None
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect

--- a/internal/controller/status/status.go
+++ b/internal/controller/status/status.go
@@ -106,6 +106,7 @@ const (
 	ConditionOpenTelemetryCollectorAvailable = "OpenTelemetryCollectorAvailable"
 	ConditionInstrumentationAvailable        = "InstrumentationAvailable"
 	ConditionAlertingAvailable               = "AlertingAvailable"
+	ConditionThanosQuerierAvailable          = "ThanosQuerierAvailable"
 )
 
 const (

--- a/pkg/cluster/gvk/gvk.go
+++ b/pkg/cluster/gvk/gvk.go
@@ -507,6 +507,12 @@ var (
 		Kind:    "PrometheusRule",
 	}
 
+	ThanosQuerier = schema.GroupVersionKind{
+		Group:   "monitoring.rhobs",
+		Version: "v1alpha1",
+		Kind:    "ThanosQuerier",
+	}
+
 	ServiceMesh = schema.GroupVersionKind{
 		Group:   serviceApi.GroupVersion.Group,
 		Version: serviceApi.GroupVersion.Version,


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
https://github.com/opendatahub-io/opendatahub-operator/pull/2448

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [ ] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->
