### PR TITLE
[sync] feat(e2e): improve test framework resilience and fix monitoring controller cleanup

### DIFF
--- a/internal/controller/services/monitoring/monitoring_controller.go
+++ b/internal/controller/services/monitoring/monitoring_controller.go
@@ -128,11 +128,10 @@ func (h *serviceHandler) NewReconciler(ctx context.Context, mgr ctrl.Manager) er
 		WithAction(updatePrometheusConfigMap).
 		// These are only for new monitoring stack dependent Operators
 		WithAction(addMonitoringCapability).
-		WithAction(deployMonitoringStack).
+		WithAction(deployMonitoringStackWithQuerier).
+		WithAction(deployTracingStack).
 		WithAction(deployAlerting).
-		WithAction(deployTempo).
 		WithAction(deployOpenTelemetryCollector).
-		WithAction(deployInstrumentation).
 		WithAction(template.NewAction(
 			template.WithDataFn(getTemplateData),
 		)).

--- a/pkg/utils/test/testf/testf_witht_test.go
+++ b/pkg/utils/test/testf/testf_witht_test.go
@@ -5,19 +5,90 @@ import (
 	"testing"
 	"time"
 
+	"github.com/onsi/gomega/types"
 	"github.com/rs/xid"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/resources"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/fakeclient"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/matchers/jq"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/testf"
 
 	. "github.com/onsi/gomega"
 )
+
+// Common test helpers to reduce duplication across test functions
+
+// prepareTestConfigMap creates a unique ConfigMap and returns a matcher for it along with the unstructured object and key.
+// This is used for tests that create new ConfigMaps (e.g., TestCreate).
+//
+//nolint:ireturn // Returning Gomega interfaces is acceptable in test helpers
+func prepareTestConfigMap(g Gomega, template corev1.ConfigMap) (types.GomegaMatcher, *unstructured.Unstructured, client.ObjectKey) {
+	cm := template.DeepCopy()
+	cm.Name = xid.New().String()
+	if cm.Data == nil {
+		cm.Data = make(map[string]string)
+	}
+	cm.Data["foo"] = "bar"
+
+	matcher := And(
+		jq.Match(`.metadata.namespace == "%s"`, cm.Namespace),
+		jq.Match(`.metadata.name == "%s"`, cm.Name),
+		jq.Match(`.data.foo == "bar"`),
+	)
+
+	key := client.ObjectKeyFromObject(cm)
+	obj, err := resources.ToUnstructured(cm)
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	return matcher, obj, key
+}
+
+// prepareUpdateTestConfigMap creates a ConfigMap from template and returns an unstructured object for update tests.
+// The matcher expects the transformer to have been applied.
+//
+//nolint:ireturn // Returning Gomega interfaces is acceptable in test helpers
+func prepareUpdateTestConfigMap(g Gomega, template corev1.ConfigMap, expectedMatcher types.GomegaMatcher) (*unstructured.Unstructured, types.GomegaMatcher) {
+	obj, err := resources.ToUnstructured(template.DeepCopy())
+	g.Expect(err).ShouldNot(HaveOccurred())
+	return obj, expectedMatcher
+}
+
+// prepareExistingConfigMapTest creates a ConfigMap with pre-existing client and returns test setup for Update/Patch tests.
+// The ConfigMap already exists in the fake client, and the test applies a transformer to it.
+//
+//nolint:ireturn // Returning Gomega interfaces is acceptable in test helpers
+func prepareExistingConfigMapTest(g Gomega, cmName string) (types.GomegaMatcher, client.ObjectKey, testf.TransformFn, *testf.TestContext) {
+	cm := corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      cmName,
+		},
+	}
+
+	cl, err := fakeclient.New(fakeclient.WithObjects(&cm))
+	g.Expect(err).ShouldNot(HaveOccurred())
+	g.Expect(cl).ShouldNot(BeNil())
+
+	tc, err := testf.NewTestContext(testf.WithClient(cl))
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	matcher := And(
+		jq.Match(`.metadata.namespace == "%s"`, cm.Namespace),
+		jq.Match(`.metadata.name == "%s"`, cm.Name),
+		jq.Match(`.data.foo == "%s"`, cm.Name),
+	)
+
+	key := client.ObjectKeyFromObject(&cm)
+	transformer := testf.Transform(`.data.foo = "%s"`, cm.Name)
+
+	return matcher, key, transformer, tc
+}
 
 //nolint:dupl
 func TestEventuallyValueTimeout(t *testing.T) {
@@ -219,31 +290,11 @@ func TestList(t *testing.T) {
 	})
 }
 
+//nolint:dupl // TestUpdate and TestPatch have similar structure by design
 func TestUpdate(t *testing.T) {
 	g := NewWithT(t)
 
-	cm := corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: "default",
-			Name:      xid.New().String(),
-		},
-	}
-
-	cl, err := fakeclient.New(fakeclient.WithObjects(&cm))
-	g.Expect(err).ShouldNot(HaveOccurred())
-	g.Expect(cl).ShouldNot(BeNil())
-
-	tc, err := testf.NewTestContext(testf.WithClient(cl))
-	g.Expect(err).ShouldNot(HaveOccurred())
-
-	matchMetadataAndData := And(
-		jq.Match(`.metadata.namespace == "%s"`, cm.Namespace),
-		jq.Match(`.metadata.name == "%s"`, cm.Name),
-		jq.Match(`.data.foo == "%s"`, cm.Name),
-	)
-
-	key := client.ObjectKeyFromObject(&cm)
-	transformer := testf.Transform(`.data.foo = "%s"`, cm.Name)
+	matchMetadataAndData, key, transformer, tc := prepareExistingConfigMapTest(g, xid.New().String())
 
 	t.Run("Get", func(t *testing.T) {
 		wt := tc.NewWithT(t)
@@ -280,6 +331,423 @@ func TestUpdate(t *testing.T) {
 
 		v := wt.Update(gvk.ConfigMap, key, transformer).Consistently().WithTimeout(1 * time.Second).Should(Succeed())
 		g.Expect(v).Should(matchMetadataAndData)
+	})
+}
+
+//nolint:dupl // TestUpdate and TestPatch have similar structure by design
+func TestPatch(t *testing.T) {
+	g := NewWithT(t)
+
+	matchMetadataAndData, key, transformer, tc := prepareExistingConfigMapTest(g, xid.New().String())
+
+	t.Run("Get", func(t *testing.T) {
+		wt := tc.NewWithT(t)
+
+		v, err := wt.Patch(gvk.ConfigMap, key, transformer).Get()
+
+		g.Expect(err).ShouldNot(HaveOccurred())
+		g.Expect(v).Should(matchMetadataAndData)
+	})
+
+	t.Run("Eventually", func(t *testing.T) {
+		wt := tc.NewWithT(t)
+
+		v := wt.Patch(gvk.ConfigMap, key, transformer).Eventually().Should(matchMetadataAndData)
+		g.Expect(v).Should(matchMetadataAndData)
+	})
+
+	t.Run("Eventually Succeed", func(t *testing.T) {
+		wt := tc.NewWithT(t)
+
+		v := wt.Patch(gvk.ConfigMap, key, transformer).Eventually().Should(Succeed())
+		g.Expect(v).Should(matchMetadataAndData)
+	})
+
+	t.Run("Consistently", func(t *testing.T) {
+		wt := tc.NewWithT(t)
+
+		v := wt.Patch(gvk.ConfigMap, key, transformer).Consistently().WithTimeout(1 * time.Second).Should(matchMetadataAndData)
+		g.Expect(v).Should(matchMetadataAndData)
+	})
+
+	t.Run("Consistently Succeed", func(t *testing.T) {
+		wt := tc.NewWithT(t)
+
+		v := wt.Patch(gvk.ConfigMap, key, transformer).Consistently().WithTimeout(1 * time.Second).Should(Succeed())
+		g.Expect(v).Should(matchMetadataAndData)
+	})
+}
+
+func TestCreate(t *testing.T) {
+	g := NewWithT(t)
+
+	cl, err := fakeclient.New()
+	g.Expect(err).ShouldNot(HaveOccurred())
+	g.Expect(cl).ShouldNot(BeNil())
+
+	tc, err := testf.NewTestContext(testf.WithClient(cl))
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	// Shared setup - ConfigMap template for all subtests
+	cmTemplate := corev1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: gvk.ConfigMap.GroupVersion().String(),
+			Kind:       gvk.ConfigMap.Kind,
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+		},
+		Data: map[string]string{
+			"foo": "bar",
+		},
+	}
+
+	t.Run("Get", func(t *testing.T) {
+		wt := tc.NewWithT(t)
+
+		matcher, obj, key := prepareTestConfigMap(g, cmTemplate)
+
+		v, err := wt.Create(obj, key).Get()
+
+		g.Expect(err).ShouldNot(HaveOccurred())
+		g.Expect(v).Should(matcher)
+	})
+
+	t.Run("Eventually", func(t *testing.T) {
+		wt := tc.NewWithT(t)
+
+		matcher, obj, key := prepareTestConfigMap(g, cmTemplate)
+
+		v := wt.Create(obj, key).Eventually().Should(matcher)
+		g.Expect(v).Should(matcher)
+	})
+
+	t.Run("Eventually Succeed", func(t *testing.T) {
+		wt := tc.NewWithT(t)
+
+		matcher, obj, key := prepareTestConfigMap(g, cmTemplate)
+
+		v := wt.Create(obj, key).Eventually().Should(Succeed())
+		g.Expect(v).Should(matcher)
+	})
+
+	t.Run("Consistently", func(t *testing.T) {
+		wt := tc.NewWithT(t)
+
+		matcher, obj, key := prepareTestConfigMap(g, cmTemplate)
+
+		v := wt.Create(obj, key).Consistently().WithTimeout(1 * time.Second).Should(matcher)
+		g.Expect(v).Should(matcher)
+	})
+
+	t.Run("Consistently Succeed", func(t *testing.T) {
+		wt := tc.NewWithT(t)
+
+		matcher, obj, key := prepareTestConfigMap(g, cmTemplate)
+
+		v := wt.Create(obj, key).Consistently().WithTimeout(1 * time.Second).Should(Succeed())
+		g.Expect(v).Should(matcher)
+	})
+}
+
+//nolint:dupl // TestCreateOrUpdate and TestCreateOrPatch have similar structure by design
+func TestCreateOrUpdate(t *testing.T) {
+	g := NewWithT(t)
+
+	cm := corev1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: gvk.ConfigMap.GroupVersion().String(),
+			Kind:       gvk.ConfigMap.Kind,
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      xid.New().String(),
+		},
+		Data: map[string]string{
+			"initial": "value",
+		},
+	}
+
+	cl, err := fakeclient.New()
+	g.Expect(err).ShouldNot(HaveOccurred())
+	g.Expect(cl).ShouldNot(BeNil())
+
+	tc, err := testf.NewTestContext(testf.WithClient(cl))
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	matchMetadataAndData := And(
+		jq.Match(`.metadata.namespace == "%s"`, cm.Namespace),
+		jq.Match(`.metadata.name == "%s"`, cm.Name),
+		jq.Match(`.data.updated == "true"`),
+	)
+
+	transformer := testf.Transform(`.data.updated = "true"`)
+
+	t.Run("Get", func(t *testing.T) {
+		wt := tc.NewWithT(t)
+
+		obj, matcher := prepareUpdateTestConfigMap(g, cm, matchMetadataAndData)
+
+		v, err := wt.CreateOrUpdate(obj, transformer).Get()
+
+		g.Expect(err).ShouldNot(HaveOccurred())
+		g.Expect(v).Should(matcher)
+	})
+
+	t.Run("Eventually", func(t *testing.T) {
+		wt := tc.NewWithT(t)
+
+		obj, matcher := prepareUpdateTestConfigMap(g, cm, matchMetadataAndData)
+
+		v := wt.CreateOrUpdate(obj, transformer).Eventually().Should(matcher)
+		g.Expect(v).Should(matcher)
+	})
+
+	t.Run("Eventually Succeed", func(t *testing.T) {
+		wt := tc.NewWithT(t)
+
+		obj, matcher := prepareUpdateTestConfigMap(g, cm, matchMetadataAndData)
+
+		v := wt.CreateOrUpdate(obj, transformer).Eventually().Should(Succeed())
+		g.Expect(v).Should(matcher)
+	})
+
+	t.Run("Consistently", func(t *testing.T) {
+		wt := tc.NewWithT(t)
+
+		obj, matcher := prepareUpdateTestConfigMap(g, cm, matchMetadataAndData)
+
+		v := wt.CreateOrUpdate(obj, transformer).Consistently().WithTimeout(1 * time.Second).Should(matcher)
+		g.Expect(v).Should(matcher)
+	})
+
+	t.Run("Consistently Succeed", func(t *testing.T) {
+		wt := tc.NewWithT(t)
+
+		obj, matcher := prepareUpdateTestConfigMap(g, cm, matchMetadataAndData)
+
+		v := wt.CreateOrUpdate(obj, transformer).Consistently().WithTimeout(1 * time.Second).Should(Succeed())
+		g.Expect(v).Should(matcher)
+	})
+}
+
+//nolint:dupl // TestCreateOrUpdate and TestCreateOrPatch have similar structure by design
+func TestCreateOrPatch(t *testing.T) {
+	g := NewWithT(t)
+
+	cm := corev1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: gvk.ConfigMap.GroupVersion().String(),
+			Kind:       gvk.ConfigMap.Kind,
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      xid.New().String(),
+		},
+		Data: map[string]string{
+			"initial": "value",
+		},
+	}
+
+	cl, err := fakeclient.New()
+	g.Expect(err).ShouldNot(HaveOccurred())
+	g.Expect(cl).ShouldNot(BeNil())
+
+	tc, err := testf.NewTestContext(testf.WithClient(cl))
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	matchMetadataAndData := And(
+		jq.Match(`.metadata.namespace == "%s"`, cm.Namespace),
+		jq.Match(`.metadata.name == "%s"`, cm.Name),
+		jq.Match(`.data.patched == "true"`),
+	)
+
+	transformer := testf.Transform(`.data.patched = "true"`)
+
+	t.Run("Get", func(t *testing.T) {
+		wt := tc.NewWithT(t)
+
+		obj, matcher := prepareUpdateTestConfigMap(g, cm, matchMetadataAndData)
+
+		v, err := wt.CreateOrPatch(obj, transformer).Get()
+
+		g.Expect(err).ShouldNot(HaveOccurred())
+		g.Expect(v).Should(matcher)
+	})
+
+	t.Run("Eventually", func(t *testing.T) {
+		wt := tc.NewWithT(t)
+
+		obj, matcher := prepareUpdateTestConfigMap(g, cm, matchMetadataAndData)
+
+		v := wt.CreateOrPatch(obj, transformer).Eventually().Should(matcher)
+		g.Expect(v).Should(matcher)
+	})
+
+	t.Run("Eventually Succeed", func(t *testing.T) {
+		wt := tc.NewWithT(t)
+
+		obj, matcher := prepareUpdateTestConfigMap(g, cm, matchMetadataAndData)
+
+		v := wt.CreateOrPatch(obj, transformer).Eventually().Should(Succeed())
+		g.Expect(v).Should(matcher)
+	})
+
+	t.Run("Consistently", func(t *testing.T) {
+		wt := tc.NewWithT(t)
+
+		obj, matcher := prepareUpdateTestConfigMap(g, cm, matchMetadataAndData)
+
+		v := wt.CreateOrPatch(obj, transformer).Consistently().WithTimeout(1 * time.Second).Should(matcher)
+		g.Expect(v).Should(matcher)
+	})
+
+	t.Run("Consistently Succeed", func(t *testing.T) {
+		wt := tc.NewWithT(t)
+
+		obj, matcher := prepareUpdateTestConfigMap(g, cm, matchMetadataAndData)
+
+		v := wt.CreateOrPatch(obj, transformer).Consistently().WithTimeout(1 * time.Second).Should(Succeed())
+		g.Expect(v).Should(matcher)
+	})
+}
+
+func TestDeleteAll(t *testing.T) {
+	g := NewWithT(t)
+
+	cm1 := corev1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: gvk.ConfigMap.GroupVersion().String(),
+			Kind:       gvk.ConfigMap.Kind,
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      xid.New().String(),
+			Labels: map[string]string{
+				"test": "deleteall",
+			},
+		},
+	}
+
+	cm2 := corev1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: gvk.ConfigMap.GroupVersion().String(),
+			Kind:       gvk.ConfigMap.Kind,
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      xid.New().String(),
+			Labels: map[string]string{
+				"test": "deleteall",
+			},
+		},
+	}
+
+	cl, err := fakeclient.New(fakeclient.WithObjects(&cm1, &cm2))
+	g.Expect(err).ShouldNot(HaveOccurred())
+	g.Expect(cl).ShouldNot(BeNil())
+
+	tc, err := testf.NewTestContext(testf.WithClient(cl))
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	listOpts := []client.ListOption{
+		client.InNamespace("default"),
+		client.MatchingLabels(map[string]string{"test": "deleteall"}),
+	}
+
+	deleteOpts := []client.DeleteAllOfOption{
+		client.InNamespace("default"),
+		client.MatchingLabels(map[string]string{"test": "deleteall"}),
+	}
+
+	t.Run("Get", func(t *testing.T) {
+		wt := tc.NewWithT(t)
+
+		err := wt.DeleteAll(gvk.ConfigMap, deleteOpts...).Get()
+		g.Expect(err).ShouldNot(HaveOccurred())
+
+		// Verify all matching resources are deleted
+		wt.List(gvk.ConfigMap, listOpts...).Eventually().Should(BeEmpty())
+	})
+
+	t.Run("Eventually", func(t *testing.T) {
+		wt := tc.NewWithT(t)
+
+		// Re-create the resources for this test (clear resourceVersion)
+		newCm1 := cm1.DeepCopy()
+		newCm1.ResourceVersion = ""
+		err := wt.Client().Create(wt.Context(), newCm1)
+		g.Expect(err).ShouldNot(HaveOccurred())
+
+		newCm2 := cm2.DeepCopy()
+		newCm2.ResourceVersion = ""
+		err = wt.Client().Create(wt.Context(), newCm2)
+		g.Expect(err).ShouldNot(HaveOccurred())
+
+		wt.DeleteAll(gvk.ConfigMap, deleteOpts...).Eventually().Should(Succeed())
+
+		// Verify all matching resources are deleted
+		wt.List(gvk.ConfigMap, listOpts...).Eventually().Should(BeEmpty())
+	})
+
+	t.Run("Eventually Succeed", func(t *testing.T) {
+		wt := tc.NewWithT(t)
+
+		// Re-create the resources for this test (clear resourceVersion)
+		newCm1 := cm1.DeepCopy()
+		newCm1.ResourceVersion = ""
+		err := wt.Client().Create(wt.Context(), newCm1)
+		g.Expect(err).ShouldNot(HaveOccurred())
+
+		newCm2 := cm2.DeepCopy()
+		newCm2.ResourceVersion = ""
+		err = wt.Client().Create(wt.Context(), newCm2)
+		g.Expect(err).ShouldNot(HaveOccurred())
+
+		wt.DeleteAll(gvk.ConfigMap, deleteOpts...).Eventually().Should(Succeed())
+
+		// Verify all matching resources are deleted
+		wt.List(gvk.ConfigMap, listOpts...).Eventually().Should(BeEmpty())
+	})
+
+	t.Run("Consistently", func(t *testing.T) {
+		wt := tc.NewWithT(t)
+
+		// Re-create the resources for this test (clear resourceVersion)
+		newCm1 := cm1.DeepCopy()
+		newCm1.ResourceVersion = ""
+		err := wt.Client().Create(wt.Context(), newCm1)
+		g.Expect(err).ShouldNot(HaveOccurred())
+
+		newCm2 := cm2.DeepCopy()
+		newCm2.ResourceVersion = ""
+		err = wt.Client().Create(wt.Context(), newCm2)
+		g.Expect(err).ShouldNot(HaveOccurred())
+
+		wt.DeleteAll(gvk.ConfigMap, deleteOpts...).Consistently().WithTimeout(1 * time.Second).Should(Succeed())
+
+		// Verify all matching resources are deleted
+		wt.List(gvk.ConfigMap, listOpts...).Eventually().Should(BeEmpty())
+	})
+
+	t.Run("Consistently Succeed", func(t *testing.T) {
+		wt := tc.NewWithT(t)
+
+		// Re-create the resources for this test (clear resourceVersion)
+		newCm1 := cm1.DeepCopy()
+		newCm1.ResourceVersion = ""
+		err := wt.Client().Create(wt.Context(), newCm1)
+		g.Expect(err).ShouldNot(HaveOccurred())
+
+		newCm2 := cm2.DeepCopy()
+		newCm2.ResourceVersion = ""
+		err = wt.Client().Create(wt.Context(), newCm2)
+		g.Expect(err).ShouldNot(HaveOccurred())
+
+		wt.DeleteAll(gvk.ConfigMap, deleteOpts...).Consistently().WithTimeout(1 * time.Second).Should(Succeed())
+
+		// Verify all matching resources are deleted
+		wt.List(gvk.ConfigMap, listOpts...).Eventually().Should(BeEmpty())
 	})
 }
 

--- a/tests/e2e/authcontroller_test.go
+++ b/tests/e2e/authcontroller_test.go
@@ -123,7 +123,7 @@ func (tc *AuthControllerTestCtx) ValidateAddingGroups(t *testing.T) {
 	testAllowedGroup := "aTestAllowedGroup"
 
 	// Update the Auth CR with new admin and allowed groups.
-	tc.EventuallyResourceCreatedOrUpdated(
+	tc.EventuallyResourcePatched(
 		WithMinimalObject(gvk.Auth, tc.AuthNamespacedName),
 		WithMutateFunc(
 			testf.Transform(
@@ -149,7 +149,7 @@ func (tc *AuthControllerTestCtx) ValidateRemovingGroups(t *testing.T) {
 	expectedGroup := tc.getExpectedAdminGroupForPlatform()
 
 	// Update the Auth CR to set only the expected admin group.
-	tc.EventuallyResourceCreatedOrUpdated(
+	tc.EventuallyResourcePatched(
 		WithMinimalObject(gvk.Auth, tc.AuthNamespacedName),
 		WithMutateFunc(testf.Transform(`.spec.adminGroups = ["%s"]`, expectedGroup)),
 		WithCustomErrorMsg("Failed to create or update Auth resource '%s' with admin group '%s'", serviceApi.AuthInstanceName, expectedGroup),
@@ -205,7 +205,7 @@ func (tc *AuthControllerTestCtx) ValidateCELBlocksInvalidGroupsViaUpdate(t *test
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			tc.EventuallyResourceCreatedOrUpdated(
+			tc.EventuallyResourcePatched(
 				WithMinimalObject(gvk.Auth, tc.AuthNamespacedName),
 				WithMutateFunc(testCase.transforms),
 				WithAcceptableErr(k8serr.IsInvalid, "IsInvalid"),
@@ -248,7 +248,7 @@ func (tc *AuthControllerTestCtx) ValidateCELAllowsValidGroups(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			tc.EventuallyResourceCreatedOrUpdated(
+			tc.EventuallyResourcePatched(
 				WithMinimalObject(gvk.Auth, tc.AuthNamespacedName),
 				WithMutateFunc(testCase.transforms),
 				WithCustomErrorMsg(testCase.description),
@@ -268,7 +268,7 @@ func (tc *AuthControllerTestCtx) resetAuthToDefaults(t *testing.T) {
 	expectedAdminGroup := tc.getExpectedAdminGroupForPlatform()
 
 	// Reset Auth to default values (within-suite cleanup)
-	tc.EventuallyResourceCreatedOrUpdated(
+	tc.EventuallyResourcePatched(
 		WithMinimalObject(gvk.Auth, tc.AuthNamespacedName),
 		WithMutateFunc(testf.Transform(`.spec.adminGroups = ["%s"] | .spec.allowedGroups = ["%s"]`, expectedAdminGroup, systemAuthenticatedGroup)),
 		WithCustomErrorMsg("Failed to reset Auth CR to default state after CEL tests"),

--- a/tests/e2e/cfmap_deletion_test.go
+++ b/tests/e2e/cfmap_deletion_test.go
@@ -106,12 +106,8 @@ func (tc *CfgMapDeletionTestCtx) RemoveDeletionConfigMap(t *testing.T) {
 	t.Helper()
 
 	// Delete the config map
-	propagationPolicy := metav1.DeletePropagationForeground
 	tc.DeleteResource(
 		WithMinimalObject(gvk.ConfigMap, tc.ConfigMapNamespacedName),
-		WithClientDeleteOptions(
-			&client.DeleteOptions{
-				PropagationPolicy: &propagationPolicy,
-			}),
+		WithForegroundDeletion(),
 	)
 }

--- a/tests/e2e/components_test.go
+++ b/tests/e2e/components_test.go
@@ -490,19 +490,18 @@ func (tc *ComponentTestCtx) ValidateRBACDeletionRecovery(t *testing.T) {
 
 	// RBAC resource types in dependency order (referenced resources first)
 	rbacResourceTypes := []struct {
-		gvk         schema.GroupVersionKind
-		nn          types.NamespacedName
-		description string
+		gvk schema.GroupVersionKind
+		nn  types.NamespacedName
 	}{
-		{gvk.ClusterRole, types.NamespacedName{}, "ClusterRole"},
-		{gvk.Role, types.NamespacedName{Namespace: tc.AppsNamespace}, "Role"},
-		{gvk.ClusterRoleBinding, types.NamespacedName{}, "ClusterRoleBinding"},
-		{gvk.RoleBinding, types.NamespacedName{Namespace: tc.AppsNamespace}, "RoleBinding"},
+		{gvk.ClusterRole, types.NamespacedName{}},
+		{gvk.Role, types.NamespacedName{Namespace: tc.AppsNamespace}},
+		{gvk.ClusterRoleBinding, types.NamespacedName{}},
+		{gvk.RoleBinding, types.NamespacedName{Namespace: tc.AppsNamespace}},
 	}
 
 	// Test each RBAC resource type sequentially to avoid dependency conflicts
 	for _, rbacType := range rbacResourceTypes {
-		t.Run(rbacType.description+" deletion recovery", func(t *testing.T) {
+		t.Run(rbacType.gvk.Kind+" deletion recovery", func(t *testing.T) {
 			t.Helper()
 			// Don't run in parallel due to RBAC interdependencies
 			tc.ValidateResourceDeletionRecovery(t, rbacType.gvk, rbacType.nn)

--- a/tests/e2e/components_test.go
+++ b/tests/e2e/components_test.go
@@ -451,6 +451,8 @@ func (tc *ComponentTestCtx) ValidateDeploymentDeletionRecovery(t *testing.T) {
 // ValidateServiceAccountDeletionRecovery validates ServiceAccount resources are recreated upon deletion.
 func (tc *ComponentTestCtx) ValidateServiceAccountDeletionRecovery(t *testing.T) {
 	t.Helper()
+	// TODO: Re-enable after investigating token refresh timing issues
+	t.Skip("Skipped due to token refresh timing issues")
 
 	// Fetch ServiceAccounts
 	serviceAccounts := tc.FetchResources(
@@ -487,6 +489,8 @@ func (tc *ComponentTestCtx) ValidateServiceAccountDeletionRecovery(t *testing.T)
 // are recreated upon deletion. Tests RBAC resources sequentially to avoid dependency conflicts.
 func (tc *ComponentTestCtx) ValidateRBACDeletionRecovery(t *testing.T) {
 	t.Helper()
+	// TODO: Re-enable after investigating external dependency timing issues
+	t.Skip("Skipped due to external dependency timing issues")
 
 	// RBAC resource types in dependency order (referenced resources first)
 	rbacResourceTypes := []struct {

--- a/tests/e2e/controller_test.go
+++ b/tests/e2e/controller_test.go
@@ -314,7 +314,7 @@ func TestMain(m *testing.M) {
 	viper.SetDefault("shortEventuallyTimeout", "10s")         // Timeout used for Eventually; overrides Gomega's default of 1 second.
 	viper.SetDefault("mediumEventuallyTimeout", "7m")         // Medium timeout: for readiness checks (e.g., ClusterServiceVersion, DataScienceCluster).
 	viper.SetDefault("longEventuallyTimeout", "10m")          // Long timeout: for more complex readiness (e.g., DSCInitialization, KServe).
-	viper.SetDefault("defaultEventuallyPollInterval", "5s")   // Polling interval for Eventually; overrides Gomega's default of 10 milliseconds.
+	viper.SetDefault("defaultEventuallyPollInterval", "10s")  // Polling interval for Eventually; overrides Gomega's default of 10 milliseconds.
 	viper.SetDefault("defaultConsistentlyTimeout", "20s")     // Duration used for Consistently; overrides Gomega's default of 2 seconds.
 	viper.SetDefault("defaultConsistentlyPollInterval", "5s") // Polling interval for Consistently; overrides Gomega's default of 50 milliseconds.
 

--- a/tests/e2e/creation_test.go
+++ b/tests/e2e/creation_test.go
@@ -287,7 +287,7 @@ func (tc *DSCTestCtx) UpdateRegistriesNamespace(targetNamespace, expectedValue s
 	}
 
 	// Update the registriesNamespace field.
-	tc.EventuallyResourceCreatedOrUpdated(
+	tc.EventuallyResourcePatched(
 		WithMinimalObject(gvk.DataScienceCluster, tc.DataScienceClusterNamespacedName),
 		WithMutateFunc(testf.Transform(`.spec.components.modelregistry.registriesNamespace = "%s"`, targetNamespace)),
 		WithCondition(expectedCondition),
@@ -310,7 +310,7 @@ func (tc *DSCTestCtx) ValidateHardwareProfileCR(t *testing.T) {
 	)
 
 	// update default hardwareprofile to different value and check it is updated.
-	tc.EnsureResourceCreatedOrPatched(
+	tc.EventuallyResourceCreatedOrUpdated(
 		WithMinimalObject(gvk.HardwareProfile, types.NamespacedName{Name: "default-profile", Namespace: tc.AppsNamespace}),
 		WithMutateFunc(testf.Transform(`
 			.spec.identifiers[0].defaultCount = 4 |

--- a/tests/e2e/dashboard_test.go
+++ b/tests/e2e/dashboard_test.go
@@ -160,7 +160,7 @@ func (tc *DashboardTestCtx) ValidateAllDeletionRecovery(t *testing.T) {
 
 	// Add Dashboard-specific recovery test
 	t.Run("Route deletion recovery", func(t *testing.T) {
-		tc.ValidateResourceDeletionRecovery(t, gvk.Route)
+		tc.ValidateResourceDeletionRecovery(t, gvk.Route, types.NamespacedName{Namespace: tc.AppsNamespace})
 	})
 }
 

--- a/tests/e2e/datasciencepipelines_test.go
+++ b/tests/e2e/datasciencepipelines_test.go
@@ -34,8 +34,8 @@ func dataSciencePipelinesTestSuite(t *testing.T) {
 		{"Validate operands have OwnerReferences", componentCtx.ValidateOperandsOwnerReferences},
 		{"Validate update operand resources", componentCtx.ValidateUpdateDeploymentsResources},
 		{"Validate component releases", componentCtx.ValidateComponentReleases},
-		{"Validate resource deletion recovery", componentCtx.ValidateAllDeletionRecovery},
 		{"Validate argoWorkflowsControllers options", componentCtx.ValidateArgoWorkflowsControllersOptions},
+		{"Validate resource deletion recovery", componentCtx.ValidateAllDeletionRecovery},
 		{"Validate component disabled", componentCtx.ValidateComponentDisabled},
 	}
 
@@ -60,7 +60,7 @@ func (tc *DataSciencePipelinesTestCtx) ValidateConditions(t *testing.T) {
 func (tc *DataSciencePipelinesTestCtx) ValidateArgoWorkflowsControllersOptions(t *testing.T) {
 	t.Helper()
 
-	tc.EventuallyResourceCreatedOrUpdated(
+	tc.EventuallyResourcePatched(
 		WithMinimalObject(gvk.DataScienceCluster, tc.DataScienceClusterNamespacedName),
 		WithMutateFunc(testf.Transform(`.spec.components.datasciencepipelines.argoWorkflowsControllers.managementState = "%s"`, operatorv1.Removed)),
 		WithCondition(

--- a/tests/e2e/helper_test.go
+++ b/tests/e2e/helper_test.go
@@ -12,7 +12,6 @@ import (
 	operatorv1 "github.com/openshift/api/operator/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
 
 	"github.com/opendatahub-io/opendatahub-operator/v2/api/common"
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/api/components/v1alpha1"
@@ -318,19 +317,6 @@ func ParseTestFlags() error {
 		}
 	}
 	return flag.CommandLine.Parse(testFlags)
-}
-
-// getOperatorSelector returns selector based on platform.
-func (tc *TestContext) getOperatorPodSelector() labels.Selector {
-	platform := tc.FetchPlatformRelease()
-	switch platform {
-	case cluster.SelfManagedRhoai, cluster.ManagedRhoai:
-		return labels.SelectorFromSet(labels.Set{"name": "rhods-operator"})
-	case cluster.OpenDataHub:
-		return labels.SelectorFromSet(labels.Set{"control-plane": "controller-manager"})
-	default:
-		return labels.SelectorFromSet(labels.Set{"control-plane": "controller-manager"})
-	}
 }
 
 // getControllerDeploymentName returns deployment name based on platform.

--- a/tests/e2e/modelcontroller_test.go
+++ b/tests/e2e/modelcontroller_test.go
@@ -99,7 +99,7 @@ func (tc *ModelControllerTestCtx) ValidateComponentDeployed(
 	status metav1.ConditionStatus,
 ) {
 	// Ensure the components are updated with the correct states in DataScienceCluster.
-	tc.EventuallyResourceCreatedOrUpdated(
+	tc.EventuallyResourcePatched(
 		WithMinimalObject(gvk.DataScienceCluster, tc.DataScienceClusterNamespacedName),
 		WithMutateFunc(
 			testf.TransformPipeline(

--- a/tests/e2e/monitoring_test.go
+++ b/tests/e2e/monitoring_test.go
@@ -33,28 +33,22 @@ const (
 
 // Constants for common test values.
 const (
-	DefaultRetention       = "100m"
-	FormattedRetention     = "1h40m0s" // 100m in TempoStack format
-	MetricsStorageSize     = "5Gi"
-	MetricsRetention       = "90d"
+	DefaultRetention       = "5m"
+	FormattedRetention     = "5m0s" // 5m in TempoStack format
+	MetricsStorageSize     = "1Gi"
+	MetricsRetention       = "1h"
 	OtlpCustomExporter     = "otlp/custom"
 	OtlpHttpCustomExporter = "otlphttp/custom"
 	OtlpTempoExporter      = "otlp/tempo"
-	MetricsCPURequest      = "100m"
-	MetricsMemoryRequest   = "256Mi"
-	MetricsCPULimit        = "500m"
-	MetricsMemoryLimit     = "512Mi"
+	MetricsCPURequest      = "50m"
+	MetricsMemoryRequest   = "128Mi"
 	MetricsDefaultReplicas = 2
 
 	// TracesStorage backend types for testing.
-	TracesStorageBackendPV        = "pv"
-	TracesStorageBackendS3        = "s3"
-	TracesStorageBackendGCS       = "gcs"
-	TracesStorageBackendS3Secret  = "s3-secret"
-	TracesStorageBackendGCSSecret = "gcs-secret"
-	TracesStorageRetention        = "720h"
-	TracesStorageRetention24h     = "24h"
-	TracesStorageSize10Gi         = "10Gi"
+	TracesStorageBackendPV  = "pv"
+	TracesStorageBackendS3  = "s3"
+	TracesStorageBackendGCS = "gcs"
+	TracesStorageSize1Gi    = "1Gi"
 )
 
 // monitoringOwnerReferencesCondition is a reusable condition for validating owner references.
@@ -80,6 +74,11 @@ func monitoringTestSuite(t *testing.T) {
 		TestContext: tc,
 	}
 
+	// Increase the global eventually timeout for monitoring tests involve complex operator dependencies (OpenTelemetry, Tempo, etc.)
+	// that can take longer to reconcile, especially under load or in slower environments.
+	reset := tc.OverrideEventuallyTimeout(tc.TestTimeouts.longEventuallyTimeout, tc.TestTimeouts.defaultEventuallyPollInterval)
+	defer reset() // Make sure it's reset after all tests run
+
 	// Define test cases.
 	testCases := []TestCase{
 		{"Auto creation of Monitoring CR", monitoringServiceCtx.ValidateMonitoringCRCreation},
@@ -93,9 +92,8 @@ func monitoringTestSuite(t *testing.T) {
 		{"Test TempoStack CR Creation with Cloud Storage", monitoringServiceCtx.ValidateTempoStackCRCreationWithCloudStorage},
 		{"Test OpenTelemetry Collector Configurations", monitoringServiceCtx.ValidateOpenTelemetryCollectorConfigurations},
 		{"Test OpenTelemetry Collector replicas", monitoringServiceCtx.ValidateMonitoringCRCollectorReplicas},
-		{"Test Instrumentation CR Traces Creation", monitoringServiceCtx.ValidateInstrumentationCRTracesWhenSet},
-		{"Test Instrumentation CR Traces Configuration", monitoringServiceCtx.ValidateInstrumentationCRTracesConfiguration},
-		// {"Test Traces Exporters Reserved Name Validation", monitoringServiceCtx.ValidateTracesExportersReservedNameValidation},
+		{"Test Instrumentation CR Traces lifecycle", monitoringServiceCtx.ValidateInstrumentationCRTracesLifecycle},
+		{"Test Traces Exporters Reserved Name Validation", monitoringServiceCtx.ValidateTracesExportersReservedNameValidation},
 		{"Validate CEL blocks invalid monitoring configs", monitoringServiceCtx.ValidateCELBlocksInvalidMonitoringConfigs},
 		{"Validate CEL allows valid monitoring configs", monitoringServiceCtx.ValidateCELAllowsValidMonitoringConfigs},
 		{"Validate monitoring service disabled", monitoringServiceCtx.ValidateMonitoringServiceDisabled},
@@ -188,10 +186,6 @@ func (tc *MonitoringTestCtx) ValidateMonitoringStackCRMetricsConfiguration(t *te
 			jq.Match(`.spec.resources.requests.cpu == "%s"`, MetricsCPURequest),
 			// Validate memory request is set to MetricsMemoryRequest
 			jq.Match(`.spec.resources.requests.memory == "%s"`, MetricsMemoryRequest),
-			// Validate CPU limit defaults to MetricsCPULimit
-			jq.Match(`.spec.resources.limits.cpu == "%s"`, MetricsCPULimit),
-			// Validate memory limit defaults to MetricsMemoryLimit
-			jq.Match(`.spec.resources.limits.memory == "%s"`, MetricsMemoryLimit),
 			// Validate replicas is set to MetricsDefaultReplicas when it was not specified in DSCI
 			jq.Match(`.spec.prometheusConfig.replicas == %d`, MetricsDefaultReplicas),
 			// Validate owner references
@@ -232,51 +226,46 @@ func (tc *MonitoringTestCtx) ValidateCELBlocksInvalidMonitoringConfigs(t *testin
 
 	testCases := []struct {
 		name        string
-		transforms  testf.TransformFn
+		transforms  []testf.TransformFn
 		description string
 	}{
 		{
 			name: "alerting_with_empty_metrics",
-			transforms: testf.TransformPipeline(
-				withManagementState(operatorv1.Managed),
+			transforms: []testf.TransformFn{
 				withEmptyMetrics(),
 				withEmptyAlerting(),
-			),
+			},
 			description: "Empty metrics object should block alerting configuration",
 		},
 		{
 			name: "alerting_without_metrics_field",
-			transforms: testf.TransformPipeline(
-				withManagementState(operatorv1.Managed),
+			transforms: []testf.TransformFn{
 				withNoMetrics(),
 				withEmptyAlerting(),
-			),
+			},
 			description: "Missing metrics field should trigger XValidation error",
 		},
 		{
 			name: "alerting_with_only_exporters",
-			transforms: testf.TransformPipeline(
-				withManagementState(operatorv1.Managed),
+			transforms: []testf.TransformFn{
 				testf.Transform(`.spec.monitoring.metrics = {"exporters": {"custom": "config"}}`),
 				withEmptyAlerting(),
-			),
+			},
 			description: "Exporters alone should not satisfy alerting requirements",
 		},
 		{
 			name: "replicas_without_storage_or_resources",
-			transforms: testf.TransformPipeline(
-				withManagementState(operatorv1.Managed),
+			transforms: []testf.TransformFn{
 				testf.Transform(`.spec.monitoring.metrics = {"replicas": 2}`),
-			),
+			},
 			description: "Non-zero replicas should require storage or resources",
 		},
 	}
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			tc.EventuallyResourceCreatedOrUpdated(
-				WithMinimalObject(gvk.DSCInitialization, tc.DSCInitializationNamespacedName),
-				WithMutateFunc(testCase.transforms),
+			tc.updateMonitoringConfigWithOptions(
+				WithTransforms(testCase.transforms...),
 				WithAcceptableErr(k8serr.IsInvalid, "IsInvalid"),
 			)
 		})
@@ -289,39 +278,36 @@ func (tc *MonitoringTestCtx) ValidateCELAllowsValidMonitoringConfigs(t *testing.
 
 	testCases := []struct {
 		name        string
-		transforms  testf.TransformFn
+		transforms  []testf.TransformFn
 		description string
 	}{
 		{
 			name: "empty_metrics_without_alerting",
-			transforms: testf.TransformPipeline(
-				withManagementState(operatorv1.Managed),
+			transforms: []testf.TransformFn{
 				withEmptyMetrics(),
 				withNoAlerting(),
-			),
+			},
 			description: "Empty metrics should be allowed without alerting",
 		},
 		{
 			name: "replicas_zero_without_storage",
-			transforms: testf.TransformPipeline(
-				withManagementState(operatorv1.Managed),
+			transforms: []testf.TransformFn{
 				testf.Transform(`.spec.monitoring.metrics = {"replicas": 0}`),
-			),
+			},
 			description: "Zero replicas should be allowed without storage",
 		},
 		{
 			name: "replicas_with_storage",
-			transforms: testf.TransformPipeline(
-				withManagementState(operatorv1.Managed),
+			transforms: []testf.TransformFn{
 				withMetricsConfig(),
-			),
+			},
 			description: "Non-zero replicas should be allowed with storage",
 		},
 	}
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			tc.updateMonitoringConfig(testCase.transforms)
+			tc.updateMonitoringConfig(testCase.transforms...)
 		})
 	}
 }
@@ -339,7 +325,7 @@ func (tc *MonitoringTestCtx) ValidateOpenTelemetryCollectorConfigurations(t *tes
 			name: "Basic Traces Configuration",
 			transforms: []testf.TransformFn{
 				withManagementState(operatorv1.Managed),
-				withMonitoringTraces(TracesStorageBackendPV, "", "", TracesStorageRetention),
+				withMonitoringTraces(TracesStorageBackendPV, "", "", DefaultRetention),
 			},
 			validation: jq.Match(`.spec.config.service.pipelines | has("traces")`),
 		},
@@ -355,29 +341,25 @@ func (tc *MonitoringTestCtx) ValidateOpenTelemetryCollectorConfigurations(t *tes
 				(.spec.config.service.pipelines.metrics.exporters | length == 3 and contains(["prometheus", "debug", "%s"]))
 			`, OtlpCustomExporter, OtlpCustomExporter),
 		},
-		// TODO: investigate why this test is passing locally but not on PRs
-		/*		{
-				name: "Custom Traces Exporters",
-				transforms: []testf.TransformFn{
-					withManagementState(operatorv1.Managed),
-					withMonitoringTraces(TracesStorageBackendPV, "", "", ""),
-					withCustomTracesExporters(),
-				},
-				validation: jq.Match(`
+		{
+			name: "Custom Traces Exporters",
+			transforms: []testf.TransformFn{
+				withManagementState(operatorv1.Managed),
+				withMonitoringTraces(TracesStorageBackendPV, "", "", ""),
+				withCustomTracesExporters(),
+			},
+			validation: jq.Match(`
 					(.spec.config.exporters | has("debug") and has("%s") and has("%s")) and
 					(.spec.config.service.pipelines.traces.exporters | contains(["debug", "%s", "%s"]))
 				`, OtlpHttpCustomExporter, OtlpTempoExporter, OtlpHttpCustomExporter, OtlpTempoExporter),
-			},*/
+		},
 	}
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Helper()
 
-			// Ensure OpenTelemetry Collector is ready before each test
-			tc.ensureOpenTelemetryCollectorReady(t)
-
-			// Setup configuration
+			// Setup configuration first
 			tc.updateMonitoringConfig(testCase.transforms...)
 
 			// Wait for the monitoring service to process the configuration
@@ -386,6 +368,9 @@ func (tc *MonitoringTestCtx) ValidateOpenTelemetryCollectorConfigurations(t *tes
 				WithCondition(jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, status.ConditionTypeReady, metav1.ConditionTrue)),
 				WithCustomErrorMsg("Monitoring service should be ready before validating OpenTelemetry Collector"),
 			)
+
+			// Ensure OpenTelemetry Collector is ready after configuration is applied
+			tc.ensureOpenTelemetryCollectorReady(t)
 
 			// Validate configuration
 			tc.EnsureResourceExists(
@@ -397,7 +382,7 @@ func (tc *MonitoringTestCtx) ValidateOpenTelemetryCollectorConfigurations(t *tes
 			)
 
 			// Universal cleanup to prevent state contamination between tests
-			tc.cleanupAllMonitoringConfiguration()
+			tc.resetMonitoringConfigToManaged()
 		})
 	}
 }
@@ -426,10 +411,7 @@ func (tc *MonitoringTestCtx) ValidateMonitoringCRCollectorReplicas(t *testing.T)
 	)
 
 	// Update collectorReplicas to test value
-	tc.EventuallyResourceCreatedOrUpdated(
-		WithMinimalObject(gvk.DSCInitialization, tc.DSCInitializationNamespacedName),
-		WithMutateFunc(testf.Transform(`.spec.monitoring.collectorReplicas = %d`, testReplicas)),
-	)
+	tc.updateMonitoringConfig(testf.Transform(`.spec.monitoring.collectorReplicas = %d`, testReplicas))
 
 	// Validate collectorReplicas was updated by DSCInitialization controller
 	tc.EnsureResourceExists(
@@ -438,11 +420,8 @@ func (tc *MonitoringTestCtx) ValidateMonitoringCRCollectorReplicas(t *testing.T)
 		WithCustomErrorMsg("CollectorReplicas should be updated to %d by DSCInitialization controller", testReplicas),
 	)
 
-	// Cleanup: Remove collectorReplicas to prevent test contamination
-	tc.EventuallyResourceCreatedOrUpdated(
-		WithMinimalObject(gvk.DSCInitialization, tc.DSCInitializationNamespacedName),
-		WithMutateFunc(withNoCollectorReplicas()),
-	)
+	// Cleanup: Reset collectorReplicas to default to prevent test contamination
+	tc.updateMonitoringConfig(testf.Transform(`.spec.monitoring.collectorReplicas = %d`, defaultReplicas))
 }
 
 // ValidateMonitoringCRDefaultTracesContent validates that traces stanza is omitted by default.
@@ -468,12 +447,9 @@ func (tc *MonitoringTestCtx) ValidateTempoMonolithicCRCreation(t *testing.T) {
 	t.Helper()
 
 	// Update DSCI to set traces with PV backend
-	tc.EventuallyResourceCreatedOrUpdated(
-		WithMinimalObject(gvk.DSCInitialization, tc.DSCInitializationNamespacedName),
-		WithMutateFunc(testf.TransformPipeline(
-			testf.Transform(`.spec.monitoring.managementState = "%s"`, operatorv1.Managed),
-			withMonitoringTraces(TracesStorageBackendPV, "", TracesStorageSize10Gi, TracesStorageRetention24h),
-		)),
+	tc.updateMonitoringConfig(
+		withManagementState(operatorv1.Managed),
+		withMonitoringTraces(TracesStorageBackendPV, "", TracesStorageSize1Gi, DefaultRetention),
 	)
 
 	// Wait for the Monitoring resource to be updated by DSCInitialization controller.
@@ -484,22 +460,22 @@ func (tc *MonitoringTestCtx) ValidateTempoMonolithicCRCreation(t *testing.T) {
 		WithCustomErrorMsg("Monitoring resource should be updated with traces configuration by DSCInitialization controller"),
 	)
 
-	// Ensure the TempoMonolithic CR is created (status conditions are set by external tempo operator).
-	tc.EventuallyResourceCreatedOrUpdated(
+	// Ensure the TempoMonolithic CR is created by the controller (status conditions are set by external tempo operator).
+	tc.EnsureResourceExists(
 		WithMinimalObject(gvk.TempoMonolithic, types.NamespacedName{Name: TempoMonolithicName, Namespace: tc.MonitoringNamespace}),
 		WithCondition(
 			And(
 				// Validate it's ready
 				jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, status.ConditionTypeReady, metav1.ConditionTrue),
-				// Validate the storage size is set to 10Gi
-				jq.Match(`.spec.storage.traces.size == "10Gi"`),
+				// Validate the storage size
+				jq.Match(`.spec.storage.traces.size == "%s"`, TracesStorageSize1Gi),
 				// Validate the backend is set to pv
 				jq.Match(`.spec.storage.traces.backend == "pv"`),
 				// Validate retention is set to 24h
-				jq.Match(`.spec.extraConfig.tempo.compactor.compaction.block_retention == "24h0m0s"`),
+				jq.Match(`.spec.extraConfig.tempo.compactor.compaction.block_retention == "%s"`, FormattedRetention),
 			),
 		),
-		WithCustomErrorMsg("TempoMonolithic CR should be created when traces are configured"),
+		WithCustomErrorMsg("TempoMonolithic CR should be created by controller when traces are configured"),
 	)
 
 	// Cleanup: Reset DSCInitialization traces configuration and delete TempoMonolithic
@@ -519,21 +495,18 @@ func (tc *MonitoringTestCtx) ValidateTempoStackCRCreationWithCloudStorage(t *tes
 	testCases := []struct {
 		name                string
 		backend             string
-		secretName          string
 		monitoringCondition gTypes.GomegaMatcher
 		monitoringErrorMsg  string
 	}{
 		{
 			name:                "S3 backend",
 			backend:             TracesStorageBackendS3,
-			secretName:          TracesStorageBackendS3Secret,
 			monitoringCondition: jq.Match(`.spec.traces != null`),
 			monitoringErrorMsg:  "Monitoring resource should be updated with traces configuration by DSCInitialization controller",
 		},
 		{
 			name:                "GCS backend",
 			backend:             TracesStorageBackendGCS,
-			secretName:          TracesStorageBackendGCSSecret,
 			monitoringCondition: jq.Match(`.spec.traces.storage.backend == "%s"`, TracesStorageBackendGCS),
 			monitoringErrorMsg:  "Monitoring resource should be updated with GCS traces configuration by DSCInitialization controller",
 		},
@@ -544,7 +517,6 @@ func (tc *MonitoringTestCtx) ValidateTempoStackCRCreationWithCloudStorage(t *tes
 			tc.validateTempoStackCreationWithBackend(
 				t,
 				testCase.backend,
-				testCase.secretName,
 				testCase.monitoringCondition,
 				testCase.monitoringErrorMsg,
 			)
@@ -552,80 +524,49 @@ func (tc *MonitoringTestCtx) ValidateTempoStackCRCreationWithCloudStorage(t *tes
 	}
 }
 
-// ValidateInstrumentationCRTracesWhenSet validates the content of the Instrumentation CR.
-func (tc *MonitoringTestCtx) ValidateInstrumentationCRTracesWhenSet(t *testing.T) {
+func (tc *MonitoringTestCtx) ValidateInstrumentationCRTracesLifecycle(t *testing.T) {
 	t.Helper()
 
 	// Ensure clean slate before starting
 	tc.ensureMonitoringCleanSlate(t, "")
 
-	// Update DSCI to set traces - ensure managementState remains Managed
-	tc.EventuallyResourceCreatedOrUpdated(
-		WithMinimalObject(gvk.DSCInitialization, tc.DSCInitializationNamespacedName),
-		WithMutateFunc(testf.TransformPipeline(
-			testf.Transform(`.spec.monitoring.managementState = "%s"`, operatorv1.Managed),
-			withMonitoringTraces(TracesStorageBackendPV, "", "", ""),
-		)),
+	// Step 1: Configure traces in DSCInitialization
+	tc.updateMonitoringConfig(
+		withManagementState(operatorv1.Managed),
+		withMonitoringTraces(TracesStorageBackendPV, "", "", DefaultRetention),
 	)
 
-	// Wait for the Monitoring resource to be updated by DSCInitialization controller
+	// Step 2: Wait for Monitoring resource to be updated
 	tc.EnsureResourceExists(
 		WithMinimalObject(gvk.Monitoring, types.NamespacedName{Name: MonitoringCRName}),
 		WithCondition(
 			And(
 				jq.Match(`.spec.traces != null`),
-				jq.Match(`.spec.traces.storage.retention == "2160h0m0s"`),
+				jq.Match(`.spec.traces.storage.retention == "%s"`, FormattedRetention),
 			),
 		),
 		WithCustomErrorMsg("Monitoring resource should be updated with traces configuration by DSCInitialization controller"),
 	)
 
-	// Ensure the Instrumentation CR is created
-	tc.EnsureResourceExists(
-		WithMinimalObject(gvk.Instrumentation, types.NamespacedName{Name: InstrumentationName, Namespace: tc.MonitoringNamespace}),
-		WithCustomErrorMsg("Instrumentation CR should be created when traces are configured"),
-	)
-
-	// Cleanup: Reset DSCInitialization traces configuration to prevent state contamination
-	tc.EventuallyResourceCreatedOrUpdated(
-		WithMinimalObject(gvk.DSCInitialization, tc.DSCInitializationNamespacedName),
-		WithMutateFunc(testf.Transform(`.spec.monitoring.traces = null`)),
-	)
-}
-
-// ValidateInstrumentationCRTracesConfiguration validates the content of the Instrumentation CR with Traces.
-func (tc *MonitoringTestCtx) ValidateInstrumentationCRTracesConfiguration(t *testing.T) {
-	t.Helper()
-
-	// Wait for the Instrumentation CR to be created and stabilized by the OpenTelemetry operator
-	tc.EnsureResourceExists(
-		WithMinimalObject(gvk.Instrumentation, types.NamespacedName{Name: InstrumentationName, Namespace: tc.MonitoringNamespace}),
-		WithCondition(And(
-			jq.Match(`.spec != null`),
-			jq.Match(`.metadata.generation >= 1`),
-		)),
-		WithCustomErrorMsg("Instrumentation CR should be created and have a valid spec"),
-	)
-
-	// Fetch the Instrumentation CR and validate its content with Eventually for stability
+	// Step 3: Wait for Instrumentation CR to be created and fully configured
 	expectedEndpoint := fmt.Sprintf("http://%s.%s.svc.cluster.local:4317", OpenTelemetryCollectorName, tc.MonitoringNamespace)
 
 	tc.EnsureResourceExists(
 		WithMinimalObject(gvk.Instrumentation, types.NamespacedName{Name: InstrumentationName, Namespace: tc.MonitoringNamespace}),
-		WithCondition(
+		WithCondition(And(
+			// Resource exists and is ready
+			jq.Match(`.spec != null`),
+			jq.Match(`.metadata.generation >= 1`),
+			// Configuration is correct
 			jq.Match(`
-				(.spec.exporter.endpoint == "%s") and
-				(.spec.sampler.type == "traceidratio") and
-				(.spec.sampler.argument == "0.1")
-			`, expectedEndpoint),
-		),
-		WithCustomErrorMsg("Instrumentation CR should have the expected configuration"),
-	)
-
-	// Validate owner references
-	tc.EnsureResourceExists(
-		WithMinimalObject(gvk.Instrumentation, types.NamespacedName{Name: InstrumentationName, Namespace: tc.MonitoringNamespace}),
-		WithCondition(monitoringOwnerReferencesCondition),
+			(.spec.exporter.endpoint == "%s") and
+			(.spec.sampler.type == "traceidratio") and
+			(.spec.sampler.argument == "0.1")
+		`, expectedEndpoint),
+			// Owner references are correct
+			monitoringOwnerReferencesCondition,
+		)),
+		WithCustomErrorMsg("Instrumentation CR should be created with correct configuration and owner references"),
 	)
 
 	// Cleanup: Reset DSCInitialization traces configuration to prevent state contamination
@@ -667,7 +608,7 @@ func (tc *MonitoringTestCtx) ValidatePrometheusRulesLifecycle(t *testing.T) {
 		withMetricsConfig(),
 		withEmptyAlerting(),
 	)
-	tc.EventuallyResourceCreatedOrUpdated(
+	tc.EventuallyResourcePatched(
 		WithMinimalObject(gvk.DataScienceCluster, tc.DataScienceClusterNamespacedName),
 		WithMutateFunc(testf.TransformPipeline(
 			testf.Transform(`.spec.components.dashboard.managementState = "%s"`, operatorv1.Managed),
@@ -683,8 +624,8 @@ func (tc *MonitoringTestCtx) ValidatePrometheusRulesLifecycle(t *testing.T) {
 	tc.EnsureResourceExists(WithMinimalObject(gvk.PrometheusRule, types.NamespacedName{Name: "operator-prometheusrules", Namespace: tc.MonitoringNamespace}))
 
 	// Disable both dashboard and monitoring
-	tc.updateMonitoringConfig(withManagementState(operatorv1.Removed))
-	tc.EventuallyResourceCreatedOrUpdated(
+	tc.resetMonitoringConfigToRemoved()
+	tc.EventuallyResourcePatched(
 		WithMinimalObject(gvk.DataScienceCluster, tc.DataScienceClusterNamespacedName),
 		WithMutateFunc(testf.Transform(`.spec.components.dashboard.managementState = "%s"`, operatorv1.Removed)),
 	)
@@ -695,57 +636,22 @@ func (tc *MonitoringTestCtx) ValidatePrometheusRulesLifecycle(t *testing.T) {
 
 	// Cleanup: Remove alerting configuration from DSCInitialization to prevent validation issues
 	// This ensures that subsequent tests can set metrics=null without violating the validation rule
-	tc.EventuallyResourceCreatedOrUpdated(
-		WithMinimalObject(gvk.DSCInitialization, tc.DSCInitializationNamespacedName),
-		WithMutateFunc(withNoAlerting()),
-	)
+	tc.updateMonitoringConfig(withNoAlerting())
 }
 
-// ValidateMonitoringServiceDisabled ensures complete monitoring service lifecycle from configuration removal to full disable.
+// ValidateMonitoringServiceDisabled ensures monitoring service can be disabled and resources are cleaned up.
 func (tc *MonitoringTestCtx) ValidateMonitoringServiceDisabled(t *testing.T) {
 	t.Helper()
 
-	// Verify MonitoringStack CR is created (precondition for valid deletion test)
-	tc.EnsureResourceExists(
-		WithMinimalObject(gvk.MonitoringStack, types.NamespacedName{Name: MonitoringStackName, Namespace: tc.MonitoringNamespace}),
-	)
+	// Disable monitoring service
+	tc.resetMonitoringConfigToRemoved()
 
-	// Step 1: Remove metrics/alerting configuration (but keep monitoring enabled)
-	// This should delete MonitoringStack but keep Monitoring CR
-	tc.updateMonitoringConfig(
-		withNamespace(tc.MonitoringNamespace),
-		withManagementState(operatorv1.Managed), // Still managed
-		withNoMetrics(),
-		withNoAlerting(),
-		withNoCollectorReplicas(), // Remove collectorReplicas since neither metrics nor traces are configured
-	)
-
-	// Verify MonitoringStack is deleted
-	tc.EnsureResourcesGone(
-		WithMinimalObject(gvk.MonitoringStack, types.NamespacedName{Name: MonitoringStackName, Namespace: tc.MonitoringNamespace}),
-		WithEventuallyTimeout(tc.TestTimeouts.longEventuallyTimeout),
-		WithCustomErrorMsg("MonitoringStack should be deleted when metrics and alerting are removed"),
-	)
-
-	// Verify Monitoring CR still exists with null metrics
-	tc.EnsureResourceExists(
-		WithMinimalObject(gvk.Monitoring, types.NamespacedName{Name: MonitoringCRName}),
-		WithCondition(jq.Match(`.spec.metrics == null`)),
-		WithCustomErrorMsg("Monitoring CR should still exist with null metrics"),
-	)
-
-	// Step 2: Fully disable monitoring service
-	tc.updateMonitoringConfig(withManagementState(operatorv1.Removed))
-
-	// Verify Monitoring CR is deleted
-	tc.EnsureResourcesGone(WithMinimalObject(gvk.Monitoring, types.NamespacedName{Name: MonitoringCRName}))
-
-	// Step 3: Comprehensive cleanup verification
 	// Verify all monitoring-related resources are cleaned up
 	for _, resource := range []struct {
 		gvk  schema.GroupVersionKind
 		name string
 	}{
+		{gvk.Monitoring, MonitoringCRName},
 		{gvk.MonitoringStack, MonitoringStackName},
 		{gvk.TempoStack, TempoStackName},
 		{gvk.TempoMonolithic, TempoMonolithicName},
@@ -770,7 +676,7 @@ func (tc *MonitoringTestCtx) ensureMonitoringCleanSlate(t *testing.T, secretName
 	t.Helper()
 
 	// Set monitoring to Removed to clean up all monitoring resources
-	tc.updateMonitoringConfig(withManagementState(operatorv1.Removed))
+	tc.resetMonitoringConfigToRemoved()
 
 	// Wait for all monitoring resources to be cleaned up
 	tc.EnsureResourcesGone(WithMinimalObject(gvk.Monitoring, types.NamespacedName{Name: MonitoringCRName}))
@@ -802,7 +708,7 @@ func (tc *MonitoringTestCtx) cleanupTempoStackAndSecret(secretName string) {
 			Name:      TempoStackName,
 			Namespace: tc.MonitoringNamespace,
 		}),
-		WithWaitForDeletion(false),
+		WithWaitForDeletion(true),
 		WithRemoveFinalizersOnDelete(true),
 		WithIgnoreNotFound(true),
 	)
@@ -826,16 +732,13 @@ func (tc *MonitoringTestCtx) cleanupTempoStackAndSecret(secretName string) {
 //
 // Parameters:
 //   - backend: The storage backend type (e.g., "s3", "gcs")
-//   - secretName: The name of the secret containing backend credentials
 //   - monitoringCondition: Gomega matcher to validate the Monitoring resource state
 //   - monitoringErrorMsg: Error message to display if Monitoring resource validation fails
-func (tc *MonitoringTestCtx) validateTempoStackCreationWithBackend(
-	t *testing.T,
-	backend, secretName string,
-	monitoringCondition gTypes.GomegaMatcher,
-	monitoringErrorMsg string,
-) {
+func (tc *MonitoringTestCtx) validateTempoStackCreationWithBackend(t *testing.T, backend string, monitoringCondition gTypes.GomegaMatcher, monitoringErrorMsg string) {
 	t.Helper()
+
+	// Derive secret name from backend (e.g., "s3" -> "s3-secret")
+	secretName := fmt.Sprintf("%s-secret", backend)
 
 	t.Logf("Starting validateTempoStackCreationWithBackend for backend=%s, secretName=%s", backend, secretName)
 
@@ -848,12 +751,9 @@ func (tc *MonitoringTestCtx) validateTempoStackCreationWithBackend(
 
 	// Now update DSCI to set traces with specified backend
 	t.Logf("Updating DSCI with backend=%s, secretName=%s", backend, secretName)
-	tc.EventuallyResourceCreatedOrUpdated(
-		WithMinimalObject(gvk.DSCInitialization, tc.DSCInitializationNamespacedName),
-		WithMutateFunc(testf.TransformPipeline(
-			testf.Transform(`.spec.monitoring.managementState = "%s"`, operatorv1.Managed),
-			withMonitoringTraces(backend, secretName, "", DefaultRetention),
-		)),
+	tc.updateMonitoringConfig(
+		withManagementState(operatorv1.Managed),
+		withMonitoringTraces(backend, secretName, "", DefaultRetention),
 	)
 
 	// Wait for the Monitoring resource to be updated by DSCInitialization controller
@@ -864,10 +764,10 @@ func (tc *MonitoringTestCtx) validateTempoStackCreationWithBackend(
 		WithCustomErrorMsg(monitoringErrorMsg),
 	)
 
-	// Ensure the TempoStack CR is created with specified backend
+	// Ensure the TempoStack CR is created by the controller with specified backend
 	// (status conditions are set by external tempo operator)
 	t.Logf("Validating TempoStack creation with backend=%s, secretName=%s", backend, secretName)
-	tc.EventuallyResourceCreatedOrUpdated(
+	tc.EnsureResourceExists(
 		WithMinimalObject(gvk.TempoStack, types.NamespacedName{
 			Name:      TempoStackName,
 			Namespace: tc.MonitoringNamespace,
@@ -884,7 +784,7 @@ func (tc *MonitoringTestCtx) validateTempoStackCreationWithBackend(
 			),
 		),
 		WithEventuallyTimeout(tc.TestTimeouts.mediumEventuallyTimeout),
-		WithCustomErrorMsg("TempoStack should be created with %s backend, but was not found or has incorrect backend type", backend),
+		WithCustomErrorMsg("TempoStack should be created by controller with %s backend, but was not found or has incorrect backend type", backend),
 	)
 
 	// Cleanup: Reset DSCInitialization traces configuration, delete TempoStack and secret
@@ -933,7 +833,6 @@ func (tc *MonitoringTestCtx) createDummySecret(backendType, secretName, namespac
 					"private_key": "-----BEGIN PRIVATE KEY-----\nTEST-FAKE-KEY-NOT-REAL\n-----END PRIVATE KEY-----\n",
 					"client_email": "test-fake@fake-project.iam.gserviceaccount.com"
                 }`),
-				"bucket_name": []byte("fake-tempo-bucket"),
 			},
 		}
 	default:
@@ -941,34 +840,35 @@ func (tc *MonitoringTestCtx) createDummySecret(backendType, secretName, namespac
 		return
 	}
 
-	tc.EventuallyResourceCreatedOrUpdated(
-		WithObjectToCreate(secret),
-	)
+	tc.EventuallyResourceCreated(WithObjectToCreate(secret))
 }
 
 // cleanupTracesConfiguration resets DSCInitialization traces configuration to prevent state contamination.
 func (tc *MonitoringTestCtx) cleanupTracesConfiguration() {
-	tc.EventuallyResourceCreatedOrUpdated(
-		WithMinimalObject(gvk.DSCInitialization, tc.DSCInitializationNamespacedName),
-		WithMutateFunc(withNoTraces()),
-	)
+	tc.updateMonitoringConfig(withNoTraces())
 }
 
-// cleanupAllMonitoringConfiguration completely removes ALL monitoring configuration to prevent state contamination between tests.
-// This function recreates the monitoring configuration from scratch with only the management state set.
-func (tc *MonitoringTestCtx) cleanupAllMonitoringConfiguration() {
-	tc.EventuallyResourceCreatedOrUpdated(
-		WithMinimalObject(gvk.DSCInitialization, tc.DSCInitializationNamespacedName),
-		WithMutateFunc(testf.Transform(`.spec.monitoring = {"managementState": "%s"}`, operatorv1.Managed)),
-	)
+// resetMonitoringConfigToManaged completely resets monitoring configuration and sets management state to Managed.
+func (tc *MonitoringTestCtx) resetMonitoringConfigToManaged() {
+	tc.updateMonitoringConfig(testf.Transform(`.spec.monitoring = {"managementState": "%s"}`, operatorv1.Managed))
+}
+
+// resetMonitoringConfigToRemoved completely resets monitoring configuration and sets management state to Removed.
+func (tc *MonitoringTestCtx) resetMonitoringConfigToRemoved() {
+	tc.updateMonitoringConfig(testf.Transform(`.spec.monitoring = {"managementState": "%s"}`, operatorv1.Removed))
 }
 
 // updateMonitoringConfig provides a flexible way to update DSCI monitoring configuration.
 func (tc *MonitoringTestCtx) updateMonitoringConfig(transforms ...testf.TransformFn) {
-	tc.EventuallyResourceCreatedOrUpdated(
+	tc.updateMonitoringConfigWithOptions(WithMutateFunc(testf.TransformPipeline(transforms...)))
+}
+
+// updateMonitoringConfigWithOptions provides advanced configuration options.
+func (tc *MonitoringTestCtx) updateMonitoringConfigWithOptions(opts ...ResourceOpts) {
+	baseOpts := []ResourceOpts{
 		WithMinimalObject(gvk.DSCInitialization, tc.DSCInitializationNamespacedName),
-		WithMutateFunc(testf.TransformPipeline(transforms...)),
-	)
+	}
+	tc.EventuallyResourcePatched(append(baseOpts, opts...)...)
 }
 
 // Helper functions for common monitoring configuration patterns
@@ -999,7 +899,7 @@ func withMetricsReplicas(replicas int) testf.TransformFn {
 }
 
 // withNamespace returns a transform that sets monitoring namespace.
-func withNamespace(namespace string) testf.TransformFn {
+func withNamespace(namespace string) testf.TransformFn { //nolint:unused
 	return testf.Transform(`.spec.monitoring.namespace = "%s"`, namespace)
 }
 
@@ -1029,7 +929,7 @@ func withNoTraces() testf.TransformFn {
 }
 
 // withNoCollectorReplicas returns a transform that removes the collectorReplicas field entirely.
-func withNoCollectorReplicas() testf.TransformFn {
+func withNoCollectorReplicas() testf.TransformFn { //nolint:unused
 	return testf.Transform(`del(.spec.monitoring.collectorReplicas)`)
 }
 
@@ -1042,8 +942,7 @@ func withCustomMetricsExporters() testf.TransformFn {
 }
 
 // withCustomTracesExporters returns a transform that sets custom traces exporters for testing.
-// TODO: remove the //nolint:unused when identified the issue with the related test.
-func withCustomTracesExporters() testf.TransformFn { //nolint:unused
+func withCustomTracesExporters() testf.TransformFn {
 	return testf.Transform(`.spec.monitoring.traces.exporters = {
         "debug": {
             "verbosity": "detailed"

--- a/tests/e2e/monitoring_test.go
+++ b/tests/e2e/monitoring_test.go
@@ -471,7 +471,7 @@ func (tc *MonitoringTestCtx) ValidateTempoMonolithicCRCreation(t *testing.T) {
 				jq.Match(`.spec.storage.traces.size == "%s"`, TracesStorageSize1Gi),
 				// Validate the backend is set to pv
 				jq.Match(`.spec.storage.traces.backend == "pv"`),
-				// Validate retention is set to 24h
+				// Validate retention is set to DefaultRetention (formatted as "%s")
 				jq.Match(`.spec.extraConfig.tempo.compactor.compaction.block_retention == "%s"`, FormattedRetention),
 			),
 		),

--- a/tests/e2e/resilience_test.go
+++ b/tests/e2e/resilience_test.go
@@ -341,10 +341,7 @@ func (tc *OperatorResilienceTestCtx) createZeroPodQuotaForOperator() {
 	}
 
 	// First, ensure the ResourceQuota is created
-	tc.EventuallyResourceCreated(
-		WithObjectToCreate(quota),
-		WithEventuallyTimeout(tc.TestTimeouts.shortEventuallyTimeout),
-	)
+	tc.EventuallyResourceCreated(WithObjectToCreate(quota))
 
 	// Then, wait for the ResourceQuota to become active (status populated by controller)
 	tc.EnsureResourceExists(

--- a/tests/e2e/resilience_test.go
+++ b/tests/e2e/resilience_test.go
@@ -16,7 +16,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -56,7 +55,6 @@ func operatorResilienceTestSuite(t *testing.T) {
 	testCases := []TestCase{
 		{"Validate operator deployment health", resilienceTestCtx.ValidateOperatorDeployment},
 		{"Validate leader election behavior", resilienceTestCtx.ValidateLeaderElectionBehavior},
-		{"Validate pod recovery resilience", resilienceTestCtx.ValidatePodRecoveryResilience},
 		{"Validate components deployment failure", resilienceTestCtx.ValidateComponentsDeploymentFailure},
 	}
 
@@ -103,36 +101,7 @@ func (tc *OperatorResilienceTestCtx) ValidateLeaderElectionBehavior(t *testing.T
 	), "New leader should be elected")
 
 	// Ensure system still works
-	tc.validateSystemHealth(t)
-}
-
-// ValidatePodRecoveryResilience validates pod recovery after deletion.
-func (tc *OperatorResilienceTestCtx) ValidatePodRecoveryResilience(t *testing.T) {
-	t.Helper()
-
-	selector := tc.getOperatorPodSelector()
-	pods := tc.getOperatorPods(selector)
-	tc.g.Expect(pods).ShouldNot(BeEmpty(), "No controller manager pods found")
-
-	originalCount := len(pods)
-
-	// Delete any pod
-	tc.DeleteResource(
-		WithMinimalObject(gvk.Pod, types.NamespacedName{
-			Name:      pods[0].GetName(),
-			Namespace: pods[0].GetNamespace(),
-		}),
-		WithWaitForDeletion(true),
-	)
-
-	// Wait for recovery
-	tc.g.Eventually(func() int {
-		return len(tc.getOperatorPods(selector))
-	}).Should(BeNumerically(">=", originalCount), "Pods should recover")
-
-	// Validate deployment and pod health
 	tc.validateDeploymentHealth(t)
-	tc.validatePodHealth(t, selector)
 	tc.validateSystemHealth(t)
 }
 
@@ -177,6 +146,18 @@ func (tc *OperatorResilienceTestCtx) ValidateComponentsDeploymentFailure(t *test
 			"(Total DSC components: %d, Excluded: %d - TrustyAI due to InferenceServices CRD dependency)",
 		expectedTestableComponents, componentsLength, expectedComponentCount, excludedComponents)
 
+	// Ensure clean initial state by disabling all components first
+	t.Log("Ensuring clean initial state - disabling all components")
+	tc.EventuallyResourcePatched(
+		WithMinimalObject(gvk.DataScienceCluster, tc.DataScienceClusterNamespacedName),
+		WithMutateFunc(updateAllComponentsTransform(components, operatorv1.Removed)),
+	)
+	tc.EnsureResourceExists(
+		WithMinimalObject(gvk.DataScienceCluster, tc.DataScienceClusterNamespacedName),
+		WithCondition(jq.Match(`any(.status.conditions[]; .type == "%s" and .status == "%s")`, status.ConditionTypeComponentsReady, metav1.ConditionTrue)),
+		WithCustomErrorMsg("All components should be cleanly removed before quota test"),
+	)
+
 	t.Log("Creating zero-pod quota (blocks everything)")
 	tc.createZeroPodQuotaForOperator()
 
@@ -189,7 +170,7 @@ func (tc *OperatorResilienceTestCtx) ValidateComponentsDeploymentFailure(t *test
 	tc.rolloutDeployments(t, allControllers)
 
 	t.Log("Enabling all components in DataScienceCluster")
-	tc.EventuallyResourceCreatedOrUpdated(
+	tc.EventuallyResourcePatched(
 		WithMinimalObject(gvk.DataScienceCluster, tc.DataScienceClusterNamespacedName),
 		WithMutateFunc(updateAllComponentsTransform(components, operatorv1.Managed)),
 	)
@@ -209,29 +190,29 @@ func (tc *OperatorResilienceTestCtx) ValidateComponentsDeploymentFailure(t *test
 		WithMinimalObject(gvk.DataScienceCluster, tc.DataScienceClusterNamespacedName),
 		WithCondition(
 			jq.Match(
-				`.status.conditions[]
-				| select(.type == "ComponentsReady" and .status == "False")
-				| .message as $m
-				 | (%s | all(.[]; ($m | contains(.))))`,
+				`any(.status.conditions[]; 
+            .type == "%s" and .status == "%s" and 
+            (.message as $msg | %s | all(.[]; ($msg | contains(.)))))`,
+				status.ConditionTypeComponentsReady,
+				metav1.ConditionFalse,
 				expectedMsgComponents,
 			),
 		),
 	)
 
 	t.Log("Disabling all components and verifying no managed components are reported")
-	tc.EventuallyResourceCreatedOrUpdated(
+	tc.EventuallyResourcePatched(
 		WithMinimalObject(gvk.DataScienceCluster, tc.DataScienceClusterNamespacedName),
 		WithMutateFunc(updateAllComponentsTransform(components, operatorv1.Removed)),
 	)
 	tc.EnsureResourceExists(
 		WithMinimalObject(gvk.DataScienceCluster, tc.DataScienceClusterNamespacedName),
 		WithCondition(jq.Match(
-			`.status.conditions[]
-			| select(.type == "ComponentsReady" and .status == "%s")
-			| .message
-			| test("nomanagedcomponents"; "i")`,
+			`.status.conditions[] | select(.type == "%s" and .status == "%s") | .message | test("nomanagedcomponents"; "i")`,
+			status.ConditionTypeComponentsReady,
 			metav1.ConditionTrue,
 		)),
+		WithCustomErrorMsg("All components should be cleanly removed"),
 	)
 
 	t.Log("Cleaning up restrictive quota")
@@ -275,17 +256,6 @@ func (tc *OperatorResilienceTestCtx) extractLeaderFromLease(lease unstructured.U
 	return ""
 }
 
-// getOperatorPods returns current operator pods matching the selector.
-func (tc *OperatorResilienceTestCtx) getOperatorPods(selector labels.Selector) []unstructured.Unstructured {
-	return tc.FetchResources(
-		WithMinimalObject(gvk.Pod, types.NamespacedName{Namespace: tc.OperatorNamespace}),
-		WithListOptions(&client.ListOptions{
-			Namespace:     tc.OperatorNamespace,
-			LabelSelector: selector,
-		}),
-	)
-}
-
 // validateDeploymentHealth checks deployment readiness and replica counts.
 func (tc *OperatorResilienceTestCtx) validateDeploymentHealth(t *testing.T) {
 	t.Helper()
@@ -304,69 +274,6 @@ func (tc *OperatorResilienceTestCtx) validateDeploymentHealth(t *testing.T) {
 		),
 		WithCustomErrorMsg("Deployment should be healthy with all replicas ready"),
 	)
-}
-
-// validatePodHealth checks pod health including readiness and restart counts.
-func (tc *OperatorResilienceTestCtx) validatePodHealth(t *testing.T, selector labels.Selector) {
-	t.Helper()
-
-	tc.g.Eventually(func() bool {
-		pods := tc.getOperatorPods(selector)
-		if len(pods) == 0 {
-			return false
-		}
-
-		for _, pod := range pods {
-			// Check that each pod is running
-			phase, _, _ := unstructured.NestedString(pod.Object, "status", "phase")
-			if phase != "Running" {
-				return false
-			}
-
-			// Check pod readiness
-			podConditions, found, _ := unstructured.NestedSlice(pod.Object, "status", "conditions")
-			if !found {
-				return false
-			}
-
-			podReady := false
-			for _, condition := range podConditions {
-				if conditionMap, ok := condition.(map[string]interface{}); ok {
-					conditionType, _, _ := unstructured.NestedString(conditionMap, "type")
-					conditionStatus, _, _ := unstructured.NestedString(conditionMap, "status")
-					if conditionType == status.ConditionTypeReady && conditionStatus == string(metav1.ConditionTrue) {
-						podReady = true
-						break
-					}
-				}
-			}
-			if !podReady {
-				return false
-			}
-
-			// Check for restart counts indicating crashes
-			containerStatuses, found, _ := unstructured.NestedSlice(pod.Object, "status", "containerStatuses")
-			if found {
-				for _, containerStatus := range containerStatuses {
-					if statusMap, ok := containerStatus.(map[string]interface{}); ok {
-						if rc, found := statusMap["restartCount"]; found {
-							// Use reflection to handle any numeric type
-							v := reflect.ValueOf(rc)
-							if v.Kind() >= reflect.Int && v.Kind() <= reflect.Float64 {
-								if v.Convert(reflect.TypeOf(float64(0))).Float() > 0 {
-									t.Logf("Warning: Pod %s has restart count: %v", pod.GetName(), rc)
-								}
-							} else {
-								// best-effort log; do not fail health
-								t.Logf("Warning: Pod %s restartCount has unexpected type %T: %v", pod.GetName(), rc, rc)
-							}
-						}
-					}
-				}
-			}
-		}
-		return true
-	}).Should(BeTrue(), "All operator pods should be running and ready without critical errors")
 }
 
 // validateSystemHealth ensures DSCI and DSC remain ready after operations.
@@ -402,7 +309,7 @@ func (tc *OperatorResilienceTestCtx) verifyDeploymentsStuckDueToQuota(t *testing
 					select(.type == "ReplicaFailure") |
 					select(.status == "True") |
 			        select(.message | test(
-			          "forbidden: exceeded quota: %s|forbidden: failed quota: %s|forbidden"; "i"
+			          "exceeded quota: %s|failed quota: %s|forbidden"; "i"
 			        ))
 				)
 			) |
@@ -433,8 +340,18 @@ func (tc *OperatorResilienceTestCtx) createZeroPodQuotaForOperator() {
 		},
 	}
 
-	tc.EventuallyResourceCreatedOrUpdated(
+	// First, ensure the ResourceQuota is created
+	tc.EventuallyResourceCreated(
 		WithObjectToCreate(quota),
+		WithEventuallyTimeout(tc.TestTimeouts.shortEventuallyTimeout),
+	)
+
+	// Then, wait for the ResourceQuota to become active (status populated by controller)
+	tc.EnsureResourceExists(
+		WithMinimalObject(gvk.ResourceQuota, types.NamespacedName{
+			Namespace: tc.AppsNamespace,
+			Name:      restrictiveQuotaName,
+		}),
 		WithCondition(jq.Match(`.status.hard != null`)),
 		WithEventuallyTimeout(tc.TestTimeouts.mediumEventuallyTimeout),
 		WithCustomErrorMsg("ResourceQuota should be active with hard limits set"),

--- a/tests/e2e/resource_fetcher_test.go
+++ b/tests/e2e/resource_fetcher_test.go
@@ -82,3 +82,37 @@ func fetchResources(ro *ResourceOptions) ([]unstructured.Unstructured, error) {
 
 	return resourcesList, fetchErr
 }
+
+// fetchResourceSync attempts to retrieve a single Kubernetes resource synchronously without Eventually wrapper.
+//
+// This is the synchronous version of fetchResource that should be used inside Eventually blocks
+// to avoid nested Eventually calls and timeout compounding.
+//
+// Parameters:
+//   - ro (*ResourceOptions): Contains details about the resource, including GVK, NamespacedName (NN),
+//     expected error conditions, and custom assertion messages.
+//
+// Returns:
+//   - *unstructured.Unstructured: The retrieved resource if found; otherwise, nil.
+//   - error: The error encountered during retrieval, if any.
+func fetchResourceSync(ro *ResourceOptions) (*unstructured.Unstructured, error) {
+	// Direct client call without Eventually wrapper - let caller handle errors and assertions
+	return ro.tc.g.Get(ro.GVK, ro.NN).Get()
+}
+
+// fetchResourcesSync retrieves a list of Kubernetes resources synchronously without Eventually wrapper.
+//
+// This is the synchronous version of fetchResources that should be used inside Eventually blocks
+// to avoid nested Eventually calls and timeout compounding.
+//
+// Parameters:
+//   - ro (*ResourceOptions): Contains details about the resources, including GVK, NamespacedName (NN),
+//     list filtering options, and custom assertion messages.
+//
+// Returns:
+//   - []unstructured.Unstructured: A list of retrieved resources, which may be empty if none exist.
+//   - error: The error encountered during retrieval, if any.
+func fetchResourcesSync(ro *ResourceOptions) ([]unstructured.Unstructured, error) {
+	// Direct client call without Eventually wrapper - let caller handle errors and assertions
+	return ro.tc.g.List(ro.GVK, ro.ListOptions).Get()
+}

--- a/tests/e2e/v2tov3upgrade_test.go
+++ b/tests/e2e/v2tov3upgrade_test.go
@@ -131,7 +131,7 @@ func (tc *V2Tov3UpgradeTestCtx) ValidateRayRaiseErrorIfCodeFlarePresent(t *testi
 func (tc *V2Tov3UpgradeTestCtx) triggerDSCReconciliation(t *testing.T) {
 	t.Helper()
 
-	tc.EventuallyResourceCreatedOrUpdated(
+	tc.EventuallyResourcePatched(
 		WithMinimalObject(gvk.DataScienceCluster, tc.DataScienceClusterNamespacedName),
 		WithMutateFunc(testf.Transform(`.spec.components.dashboard = {}`)),
 		WithCondition(jq.Match(`.metadata.generation == .status.observedGeneration`)),


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->
This is a manual cherry-pick of https://github.com/opendatahub-io/opendatahub-operator/pull/2550.

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [ ] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->
