### PR TITLE
RHOAIENG-35202: Add a RELATED_IMAGE hook for kube-auth-proxy

### DIFF
--- a/bundle/manifests/opendatahub-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/opendatahub-operator.clusterserviceversion.yaml
@@ -199,7 +199,7 @@ metadata:
     categories: AI/Machine Learning, Big Data
     certified: "False"
     containerImage: quay.io/opendatahub/opendatahub-operator:v3.0.0
-    createdAt: "2025-10-09T09:50:07Z"
+    createdAt: "2025-10-10T08:53:51Z"
     operators.operatorframework.io/builder: operator-sdk-v1.39.2
     operators.operatorframework.io/internal-objects: '["featuretrackers.features.opendatahub.io",
       "codeflares.components.platform.opendatahub.io", "dashboards.components.platform.opendatahub.io",
@@ -1653,6 +1653,8 @@ spec:
                   value: /opt/manifests
                 - name: ODH_PLATFORM_TYPE
                   value: OpenDataHub
+                - name: RELATED_IMAGE_ODH_KUBE_AUTH_PROXY_IMAGE
+                  value: quay.io/jtanner/kube-auth-proxy:latest
                 image: REPLACE_IMAGE:latest
                 imagePullPolicy: Always
                 livenessProbe:
@@ -1737,6 +1739,9 @@ spec:
   minKubeVersion: 1.25.0
   provider:
     name: ODH
+  relatedImages:
+  - image: quay.io/jtanner/kube-auth-proxy:latest
+    name: odh-kube-auth-proxy-image
   selector:
     matchLabels:
       component: opendatahub-operator

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -70,6 +70,10 @@ spec:
             value: /opt/manifests
           - name: ODH_PLATFORM_TYPE
             value: OpenDataHub
+          # Kube-auth-proxy image configuration
+          # For RHOAI: Overridden by CSV. For ODH: Uses jtanner's public image
+          - name: RELATED_IMAGE_ODH_KUBE_AUTH_PROXY_IMAGE
+            value: "quay.io/jtanner/kube-auth-proxy:latest"
         args:
         - --leader-elect
         - --operator-name=opendatahub

--- a/internal/controller/services/gateway/gateway_auth_actions.go
+++ b/internal/controller/services/gateway/gateway_auth_actions.go
@@ -328,7 +328,7 @@ func createKubeAuthProxyDeployment(rr *odhtypes.ReconciliationRequest, oidcConfi
 					Containers: []corev1.Container{
 						{
 							Name:  KubeAuthProxyName,
-							Image: KubeAuthProxyImage,
+							Image: getKubeAuthProxyImage(),
 							Ports: []corev1.ContainerPort{
 								{
 									ContainerPort: AuthProxyHTTPPort,

--- a/internal/controller/services/gateway/gateway_support.go
+++ b/internal/controller/services/gateway/gateway_support.go
@@ -3,6 +3,7 @@ package gateway
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -32,7 +33,6 @@ const (
 	KubeAuthProxySecretsName = "kube-auth-proxy-creds" //nolint:gosec // This is a resource name, not actual credentials
 	KubeAuthProxyTLSName     = "kube-auth-proxy-tls"
 	OAuthCallbackRouteName   = "oauth-callback-route"
-	KubeAuthProxyImage       = "quay.io/jtanner/kube-auth-proxy@sha256:434580fd42d73727d62566ff6d8336219a31b322798b48096ed167daaec42f07"
 
 	// Network configuration.
 	AuthProxyHTTPPort   = 4180
@@ -58,6 +58,18 @@ var (
 	// KubeAuthProxyLabels provides common labels for OAuth2 proxy resources.
 	KubeAuthProxyLabels = map[string]string{"app": KubeAuthProxyName}
 )
+
+// getKubeAuthProxyImage returns the kube-auth-proxy image from environment variable.
+// For RHOAI deployments, this comes from the CSV (via RHOAI-Build-Config/bundle/additional-images-patch.yaml).
+// For ODH deployments, this comes from config/manager/manager.yaml.
+// Falls back to a default image for local development/testing only.
+func getKubeAuthProxyImage() string {
+	if image := os.Getenv("RELATED_IMAGE_ODH_KUBE_AUTH_PROXY_IMAGE"); image != "" {
+		return image
+	}
+	// Fallback for local development only
+	return "quay.io/jtanner/kube-auth-proxy:latest"
+}
 
 // GetCertificateType returns a string representation of the certificate type.
 func GetCertificateType(gatewayConfig *serviceApi.GatewayConfig) string {


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
For gateway, e2e is still under discussion


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Allow overriding the kube-auth-proxy image via environment variable.
  * Expose the kube-auth-proxy image in relatedImages to aid mirroring and disconnected installs.

* **Chores**
  * Updated deployment manifests to reference the new image configuration.
  * Refreshed bundle metadata timestamps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->