### PR TITLE
Update workflow to point to correct branch

### DIFF
--- a/.github/workflows/ci-build-push-images-on-pr.yaml
+++ b/.github/workflows/ci-build-push-images-on-pr.yaml
@@ -2,6 +2,8 @@ name: Build and push operator images on PR update
 on:
   pull_request_target:
     types: [ opened, synchronize, reopened ]
+    branches:
+      - main
     paths:
       - 'bundle/**'
       - 'config/**'

--- a/.github/workflows/test-integration.yaml
+++ b/.github/workflows/test-integration.yaml
@@ -3,6 +3,8 @@ on:
   pull_request_target:
     # action steps require 'run-integration-tests' label to be present, otherwise it's skipped
     types: [ synchronize, reopened ]
+    branches:
+      - main
     paths:
       - 'bundle/**'
       - 'config/**'

--- a/.github/workflows/update-manifest-shas.yml
+++ b/.github/workflows/update-manifest-shas.yml
@@ -13,6 +13,8 @@ permissions:
 jobs:
   update-manifest-shas:
     runs-on: ubuntu-latest
+    # Job only runs if the current branch reference is 'refs/heads/main'.
+    if: github.ref == 'refs/heads/main'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
This PR update workflow to point to correct branches, so that those workflows can be synced with rhoai.

This changes are already in rhoai branches.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [x] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->
Only changed github actions workflow, without change operator code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated PR workflow triggers to include only pull requests targeting the main branch (opened, synchronized, reopened).
  * Narrowed integration test workflow to run only for pull requests targeting the main branch.
  * Restricted the manifest update job to execute only on the main branch.
  * Overall impact: workflows now run in the intended contexts and avoid executing on non-main branches or unrelated PRs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->