### PR TITLE
fix: correct GatewayConfig validation error handling for OIDC config

### DIFF
--- a/internal/controller/services/gateway/gateway_auth_actions.go
+++ b/internal/controller/services/gateway/gateway_auth_actions.go
@@ -35,13 +35,6 @@ const (
 	AuthModeNone            AuthMode = "None"
 )
 
-// setErrorConditionAndReturn is a helper to set error condition and return error.
-func setErrorConditionAndReturn(gatewayConfig *serviceApi.GatewayConfig, message string, err error) error {
-	condition := CreateErrorCondition(message, err)
-	gatewayConfig.SetConditions([]common.Condition{condition})
-	return err
-}
-
 func createKubeAuthProxyInfrastructure(ctx context.Context, rr *odhtypes.ReconciliationRequest) error {
 	l := logf.FromContext(ctx).WithName("createAuthProxy")
 
@@ -63,16 +56,12 @@ func createKubeAuthProxyInfrastructure(ctx context.Context, rr *odhtypes.Reconci
 		return fmt.Errorf("failed to detect cluster authentication mode: %w", err)
 	}
 
-	l.V(1).Info("detected cluster authentication mode", "mode", authMode)
-
 	if errorCondition := validateOIDCConfig(authMode, gatewayConfig.Spec.OIDC); errorCondition != nil {
-		gatewayConfig.SetConditions([]common.Condition{*errorCondition})
-		return nil
+		return fmt.Errorf("%s", errorCondition.Message)
 	}
 
 	if condition := checkAuthModeNone(authMode); condition != nil {
-		gatewayConfig.SetConditions([]common.Condition{*condition})
-		return nil
+		return fmt.Errorf("%s", condition.Message)
 	}
 
 	var oidcConfig *serviceApi.OIDCConfig
@@ -83,31 +72,22 @@ func createKubeAuthProxyInfrastructure(ctx context.Context, rr *odhtypes.Reconci
 	// get or generate secrets for kube-auth-proxy (handles OAuth and OIDC modes)
 	clientSecret, cookieSecret, err := getOrGenerateSecrets(ctx, rr, authMode)
 	if err != nil {
-		return setErrorConditionAndReturn(gatewayConfig, "Failed to get or generate secrets", err)
+		return fmt.Errorf("failed to get or generate secrets: %w", err)
 	}
 
 	if err := deployKubeAuthProxy(ctx, rr, oidcConfig, clientSecret, cookieSecret, domain); err != nil {
-		return setErrorConditionAndReturn(gatewayConfig, "Failed to deploy auth proxy", err)
+		return fmt.Errorf("failed to deploy auth proxy: %w", err)
 	}
 
 	if authMode == AuthModeIntegratedOAuth {
 		if err := createOAuthClient(ctx, rr, clientSecret); err != nil {
-			return setErrorConditionAndReturn(gatewayConfig, "Failed to create OAuth client", err)
+			return fmt.Errorf("failed to create OAuth client: %w", err)
 		}
 	}
 
 	if err := createOAuthCallbackRoute(rr); err != nil {
-		return setErrorConditionAndReturn(gatewayConfig, "Failed to create OAuth callback route", err)
+		return fmt.Errorf("failed to create OAuth callback route: %w", err)
 	}
-
-	// Dashboard routing is now user's responsibility - removed createDashboardRoute and createReferenceGrant
-
-	gatewayConfig.SetConditions([]common.Condition{{
-		Type:    status.ConditionTypeReady,
-		Status:  metav1.ConditionTrue,
-		Reason:  status.ReadyReason,
-		Message: "Auth proxy deployed successfully",
-	}})
 
 	return nil
 }

--- a/internal/controller/services/gateway/gateway_controller_actions.go
+++ b/internal/controller/services/gateway/gateway_controller_actions.go
@@ -34,6 +34,7 @@ import (
 	serviceApi "github.com/opendatahub-io/opendatahub-operator/v2/api/services/v1alpha1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/status"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
+	cond "github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/conditions"
 	odhtypes "github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/resources"
 )
@@ -252,13 +253,11 @@ func syncGatewayConfigStatus(ctx context.Context, rr *odhtypes.ReconciliationReq
 	}, gateway)
 	if err != nil {
 		if client.IgnoreNotFound(err) == nil {
-			gatewayConfig.SetConditions([]common.Condition{
-				{
-					Type:    status.ConditionTypeReady,
-					Status:  metav1.ConditionFalse,
-					Reason:  status.NotReadyReason,
-					Message: status.GatewayNotFoundMessage,
-				},
+			cond.SetStatusCondition(gatewayConfig, common.Condition{
+				Type:    status.ConditionTypeReady,
+				Status:  metav1.ConditionFalse,
+				Reason:  status.NotReadyReason,
+				Message: status.GatewayNotFoundMessage,
 			})
 			return nil
 		}
@@ -279,13 +278,11 @@ func syncGatewayConfigStatus(ctx context.Context, rr *odhtypes.ReconciliationReq
 		message = status.GatewayReadyMessage
 	}
 
-	gatewayConfig.SetConditions([]common.Condition{
-		{
-			Type:    status.ConditionTypeReady,
-			Status:  conditionStatus,
-			Reason:  reason,
-			Message: message,
-		},
+	cond.SetStatusCondition(gatewayConfig, common.Condition{
+		Type:    status.ConditionTypeReady,
+		Status:  conditionStatus,
+		Reason:  reason,
+		Message: message,
 	})
 
 	return nil

--- a/internal/controller/services/gateway/gateway_controller_actions_test.go
+++ b/internal/controller/services/gateway/gateway_controller_actions_test.go
@@ -2,7 +2,6 @@
 package gateway
 
 import (
-	"errors"
 	"fmt"
 	"testing"
 
@@ -767,31 +766,4 @@ func TestGetOIDCClientSecretNotFound(t *testing.T) {
 	g.Expect(err).To(HaveOccurred())
 	g.Expect(err.Error()).To(ContainSubstring("failed to get OIDC client secret"))
 	g.Expect(result).To(Equal(""))
-}
-
-// TestSetErrorConditionAndReturn tests the error condition helper function.
-func TestSetErrorConditionAndReturn(t *testing.T) {
-	t.Parallel()
-	g := NewWithT(t)
-
-	gatewayConfig := &serviceApi.GatewayConfig{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "test-gateway",
-		},
-	}
-
-	testError := errors.New("test error occurred")
-	resultErr := setErrorConditionAndReturn(gatewayConfig, "Test operation failed", testError)
-
-	// Verify the returned error is the same as input
-	g.Expect(resultErr).To(Equal(testError))
-
-	// Verify condition was set correctly
-	conditions := gatewayConfig.GetConditions()
-	g.Expect(conditions).To(HaveLen(1))
-	condition := conditions[0]
-	g.Expect(condition.Type).To(Equal(status.ConditionTypeReady))
-	g.Expect(condition.Status).To(Equal(metav1.ConditionFalse))
-	g.Expect(condition.Reason).To(Equal(status.NotReadyReason))
-	g.Expect(condition.Message).To(Equal("Test operation failed: test error occurred"))
 }

--- a/internal/controller/services/gateway/gateway_support.go
+++ b/internal/controller/services/gateway/gateway_support.go
@@ -6,14 +6,11 @@ import (
 	"os"
 	"strings"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
 
-	"github.com/opendatahub-io/opendatahub-operator/v2/api/common"
 	infrav1 "github.com/opendatahub-io/opendatahub-operator/v2/api/infrastructure/v1"
 	serviceApi "github.com/opendatahub-io/opendatahub-operator/v2/api/services/v1alpha1"
-	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/status"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
 )
 
@@ -172,19 +169,4 @@ func CreateListeners(certSecretName string, domain string) []gwapiv1.Listener {
 
 	listeners = append(listeners, httpsListener)
 	return listeners
-}
-
-// CreateErrorCondition creates a standardized error condition for gateway operations.
-func CreateErrorCondition(message string, err error) common.Condition {
-	fullMessage := message
-	if err != nil {
-		fullMessage = fmt.Sprintf("%s: %v", message, err)
-	}
-
-	return common.Condition{
-		Type:    status.ConditionTypeReady,
-		Status:  metav1.ConditionFalse,
-		Reason:  status.NotReadyReason,
-		Message: fullMessage,
-	}
 }


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->
## Summary

  Fixed an issue where GatewayConfig would incorrectly show as Ready when OIDC
  configuration was missing on OIDC-enabled clusters.

  ## Problem

  When a GatewayConfig was created without OIDC configuration on a cluster running
   in OIDC authentication mode, the status would show `Ready: True` instead of
  reporting a validation error. This misled users into thinking their gateway was
  properly configured when it would actually fail at runtime.

  ## Solution

  Changed the validation logic to return errors directly instead of manually
  setting status conditions. The reconciler framework now properly handles these
  errors and sets the appropriate Ready/Failed conditions automatically.

Also cleaned up the `setErrorConditionAndReturn` helper function, `CreateErrorCondition` utility, and their corresponding tests, as these were no longer needed with
  the new error handling approach.

<!--- Link your JIRA and related links here for reference. -->

JIRA: [RHOAIENG-35857](https://issues.redhat.com/browse/RHOAIENG-35857)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
  Verified that:
  - GatewayConfig shows `Ready: False` with error message when OIDC config is
  missing on OIDC clusters
  - GatewayConfig shows `Ready: True` when OIDC config is properly provided
  - Gateway authentication works correctly with valid configuration

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->
Updated tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved failure reporting during gateway authentication setup by returning explicit errors instead of masking issues behind readiness conditions, yielding clearer logs and status feedback.

* **Refactor**
  * Centralized status-condition updates for more consistent and maintainable condition management.

* **Tests**
  * Removed obsolete tests tied to deprecated condition-based error handling.

* **Chores**
  * Removed legacy helper for constructing standardized error conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->