### PR TITLE
chore: remove unused const

### DIFF
--- a/api/common/types.go
+++ b/api/common/types.go
@@ -26,9 +26,8 @@ type ManagementSpec struct {
 type ConditionSeverity string
 
 const (
-	ConditionSeverityError   ConditionSeverity = ""
-	ConditionSeverityWarning ConditionSeverity = "Warning"
-	ConditionSeverityInfo    ConditionSeverity = "Info"
+	ConditionSeverityError ConditionSeverity = ""
+	ConditionSeverityInfo  ConditionSeverity = "Info"
 
 	ConditionReasonError = "Error"
 )

--- a/api/features/v1/features_types.go
+++ b/api/features/v1/features_types.go
@@ -57,12 +57,6 @@ var ConditionReason = struct {
 	FeatureCreated:   "FeatureCreated",
 }
 
-const (
-	ComponentType OwnerType = "Component"
-	DSCIType      OwnerType = "DSCI"
-	UnknownType   OwnerType = "Unknown"
-)
-
 func (s *FeatureTracker) ToOwnerReference() metav1.OwnerReference {
 	return metav1.OwnerReference{
 		APIVersion: s.APIVersion,

--- a/api/services/v1alpha1/gateway_types.go
+++ b/api/services/v1alpha1/gateway_types.go
@@ -28,7 +28,7 @@ const (
 	// GatewayInstanceName the name of the GatewayConfig instance singleton.
 	// value should match whats set in the XValidation below
 	GatewayInstanceName = "default-gateway"
-	GatewayKind         = "GatewayConfig"
+	GatewayConfigKind   = "GatewayConfig"
 )
 
 // Check that the component implements common.PlatformObject.

--- a/internal/controller/status/status.go
+++ b/internal/controller/status/status.go
@@ -40,24 +40,9 @@ func (w *conditionsWrapper) SetConditions(conditions []common.Condition) {
 
 // These constants represent the overall Phase as used by .Status.Phase.
 const (
-	// PhaseIgnored is used when a resource is ignored
-	// is an example of a constant that is not used anywhere in the code.
-	PhaseIgnored = "Ignored"
 	// PhaseNotReady is used when waiting for system to be ready after reconcile is successful
 	// is an example of a constant that is not used anywhere in the code.
 	PhaseNotReady = "Not Ready"
-	// PhaseClusterExpanding is used when cluster is expanding capacity
-	// is an example of a constant that is not used anywhere in the code.
-	PhaseClusterExpanding = "Expanding Capacity"
-	// PhaseDeleting is used when cluster is deleting
-	// is an example of a constant that is not used anywhere in the code.
-	PhaseDeleting = "Deleting"
-	// PhaseConnecting is used when cluster is connecting to external cluster
-	// is an example of a constant that is not used anywhere in the code.
-	PhaseConnecting = "Connecting"
-	// PhaseOnboarding is used when consumer is Onboarding
-	// is an example of a constant that is not used anywhere in the code.
-	PhaseOnboarding = "Onboarding"
 
 	// PhaseProgressing is used when SetProgressingCondition() is called.
 	PhaseProgressing = "Progressing"
@@ -70,11 +55,10 @@ const (
 // List of constants to show different reconciliation messages and statuses.
 const (
 	// ReconcileFailed is used when multiple DSCI instance exists or DSC reconcile failed/removal failed.
-	ReconcileFailed                       = "ReconcileFailed"
-	ReconcileInit                         = "ReconcileInit"
-	ReconcileCompleted                    = "ReconcileCompleted"
-	ReconcileCompletedWithComponentErrors = "ReconcileCompletedWithComponentErrors"
-	ReconcileCompletedMessage             = "Reconcile completed successfully"
+	ReconcileFailed           = "ReconcileFailed"
+	ReconcileInit             = "ReconcileInit"
+	ReconcileCompleted        = "ReconcileCompleted"
+	ReconcileCompletedMessage = "Reconcile completed successfully"
 )
 
 const (
@@ -95,8 +79,6 @@ const (
 	ConditionTypeProvisioningSucceeded       = "ProvisioningSucceeded"
 	ConditionDeploymentsNotAvailableReason   = "DeploymentsNotReady"
 	ConditionDeploymentsAvailable            = "DeploymentsAvailable"
-	ConditionServerlessAvailable             = "ServerlessAvailable"
-	ConditionServiceMeshAvailable            = "ServiceMeshAvailable"
 	ConditionArgoWorkflowAvailable           = "ArgoWorkflowAvailable"
 	ConditionTypeComponentsReady             = "ComponentsReady"
 	ConditionServingAvailable                = "ServingAvailable"
@@ -124,11 +106,8 @@ const (
 	ArgoWorkflowExist         string = "ArgoWorkflowExist"
 	NoManagedComponentsReason        = "NoManagedComponents"
 
-	DegradedReason  = "Degraded"
 	AvailableReason = "Available"
-	UnknownReason   = "Unknown"
 	NotReadyReason  = "NotReady"
-	ErrorReason     = "Error"
 	ReadyReason     = "Ready"
 )
 
@@ -170,7 +149,6 @@ const (
 
 	KueueOperatorAlreadyInstalleReason   = "KueueOperatorAlreadyInstalled"
 	KueueOperatorAlreadyInstalledMessage = "Kueue operator already installed, uninstall it or change kueue component state to Unmanaged"
-	KueueOperatorNotInstalleReason       = "KueueOperatorNotInstalleReason"
 	KueueOperatorNotInstalledMessage     = "Kueue operator not installed, install it or change kueue component state to Managed"
 )
 

--- a/pkg/cluster/gvk/gvk.go
+++ b/pkg/cluster/gvk/gvk.go
@@ -376,7 +376,7 @@ var (
 	GatewayConfig = schema.GroupVersionKind{
 		Group:   serviceApi.GroupVersion.Group,
 		Version: serviceApi.GroupVersion.Version,
-		Kind:    serviceApi.GatewayKind,
+		Kind:    serviceApi.GatewayConfigKind,
 	}
 
 	GatewayClass = schema.GroupVersionKind{


### PR DESCRIPTION
- rename GatewayKind to GatewayConfigKind

<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->
no code change, only cleanup

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Renamed Gateway kind to “GatewayConfig” for consistent naming across the platform.
  - Standardized identification of GatewayConfig in the system.

- Chores
  - Pruned unused status phases and condition reasons to simplify and clarify status reporting.

- Notes
  - No changes to default behavior or runtime operations; these updates streamline terminology and reduce surface complexity for future improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->