### PR TITLE
set the default mode for kube-auth-proxy

### DIFF
--- a/internal/controller/services/gateway/gateway_auth_actions.go
+++ b/internal/controller/services/gateway/gateway_auth_actions.go
@@ -324,6 +324,7 @@ func createKubeAuthProxyDeployment(rr *odhtypes.ReconciliationRequest, oidcConfi
 								{Name: EnvClientID, ValueFrom: createSecretKeySelector(EnvClientID)},
 								{Name: EnvClientSecret, ValueFrom: createSecretKeySelector(EnvClientSecret)},
 								{Name: EnvCookieSecret, ValueFrom: createSecretKeySelector(EnvCookieSecret)},
+								{Name: "PROXY_MODE", Value: "auth"},
 							},
 							VolumeMounts: []corev1.VolumeMount{
 								{


### PR DESCRIPTION
This is in preparation for https://github.com/opendatahub-io/kube-auth-proxy/pull/10

#### E2E update requirement opt-out justification

- [x] Skip requirement to update E2E test suite for this PR

There is no functional change to the operator or it's underlying managed infa until we merge https://github.com/opendatahub-io/kube-auth-proxy/pull/10 and get new images built. We have to merge this PR first though so that we don't start up the proxy in the new default "authz" mode.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated kube-auth proxy configuration to run in "auth" mode via a new environment variable.
  * This change standardizes the proxy’s runtime behavior for authentication flows.
  * No impact to ports, volumes, or other deployment settings; existing integrations continue to work as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->