### PR TITLE
[RHOAIENG-34316] Validate RHCL is installed when kserve is managed

### DIFF
--- a/internal/controller/components/kserve/kserve.go
+++ b/internal/controller/components/kserve/kserve.go
@@ -31,6 +31,7 @@ const (
 	kserveConfigMapName      = "inferenceservice-config"
 	kserveManifestSourcePath = "overlays/odh"
 	leaderWorkerSetOperator  = "leader-worker-set"
+	kuadrantOperator         = "kuadrant-operator"
 	// LegacyComponentName is the name of the component that is assigned to deployments
 	// via Kustomize. Since a deployment selector is immutable, we can't upgrade existing
 	// deployment to the new component name, so keep it around till we figure out a solution.
@@ -47,12 +48,13 @@ var (
 )
 
 var (
-	ErrServiceMeshNotConfigured            = odherrors.NewStopError(status.ServiceMeshNeedConfiguredMessage)
-	ErrServiceMeshNotReady                 = odherrors.NewStopError(status.ServiceMeshNotReadyMessage)
-	ErrServiceMeshOperatorNotInstalled     = odherrors.NewStopError(status.ServiceMeshOperatorNotInstalledMessage)
-	ErrServerlessOperatorNotInstalled      = odherrors.NewStopError(status.ServerlessOperatorNotInstalledMessage)
-	ErrServerlessUnsupportedCertType       = odherrors.NewStopError(status.ServerlessUnsupportedCertMessage)
-	ErrLeaderWorkerSetOperatorNotInstalled = odherrors.NewStopError(status.LeaderWorkerSetOperatorNotInstalledMessage)
+	ErrServiceMeshNotConfigured             = odherrors.NewStopError(status.ServiceMeshNeedConfiguredMessage)
+	ErrServiceMeshNotReady                  = odherrors.NewStopError(status.ServiceMeshNotReadyMessage)
+	ErrServiceMeshOperatorNotInstalled      = odherrors.NewStopError(status.ServiceMeshOperatorNotInstalledMessage)
+	ErrServerlessOperatorNotInstalled       = odherrors.NewStopError(status.ServerlessOperatorNotInstalledMessage)
+	ErrServerlessUnsupportedCertType        = odherrors.NewStopError(status.ServerlessUnsupportedCertMessage)
+	ErrLeaderWorkerSetOperatorNotInstalled  = odherrors.NewStopError(status.LeaderWorkerSetOperatorNotInstalledMessage)
+	ErrConnectivityLinkOperatorNotInstalled = odherrors.NewStopError(status.ConnectivityLinkOperatorNotInstalledMessage)
 )
 
 type componentHandler struct{}

--- a/internal/controller/components/kserve/kserve_controller.go
+++ b/internal/controller/components/kserve/kserve_controller.go
@@ -111,6 +111,8 @@ func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.
 		).
 		WatchesGVK(gvk.LeaderWorkerSetOperator,
 			reconciler.Dynamic(reconciler.CrdExists(gvk.LeaderWorkerSetOperator))).
+		WatchesGVK(gvk.ConnectivityLinkOperator,
+			reconciler.Dynamic(reconciler.CrdExists(gvk.ConnectivityLinkOperator))).
 		// actions
 		WithAction(checkPreConditions).
 		WithAction(initialize).

--- a/internal/controller/components/kserve/kserve_controller_actions.go
+++ b/internal/controller/components/kserve/kserve_controller_actions.go
@@ -82,6 +82,14 @@ func checkPreConditions(ctx context.Context, rr *odhtypes.ReconciliationRequest)
 		operatorsErr = multierror.Append(operatorsErr, ErrLeaderWorkerSetOperatorNotInstalled)
 	}
 
+	if found, err := cluster.OperatorExists(ctx, rr.Client, kuadrantOperator); err != nil || !found {
+		if err != nil {
+			return odherrors.NewStopErrorW(err)
+		}
+
+		operatorsErr = multierror.Append(operatorsErr, ErrConnectivityLinkOperatorNotInstalled)
+	}
+
 	if operatorsErr != nil {
 		rr.Conditions.MarkFalse(
 			status.ConditionServingAvailable,

--- a/internal/controller/components/kserve/kserve_support.go
+++ b/internal/controller/components/kserve/kserve_support.go
@@ -54,10 +54,16 @@ var isRequiredOperators = predicate.Funcs{
 		return false
 	},
 	CreateFunc: func(e event.CreateEvent) bool {
-		return strings.HasPrefix(e.Object.GetName(), serverlessOperator) || strings.HasPrefix(e.Object.GetName(), serviceMeshOperator) || strings.HasPrefix(e.Object.GetName(), leaderWorkerSetOperator) //nolint:lll
+		return strings.HasPrefix(e.Object.GetName(), serverlessOperator) ||
+			strings.HasPrefix(e.Object.GetName(), serviceMeshOperator) ||
+			strings.HasPrefix(e.Object.GetName(), leaderWorkerSetOperator) ||
+			strings.HasPrefix(e.Object.GetName(), kuadrantOperator)
 	},
 	DeleteFunc: func(e event.DeleteEvent) bool {
-		return strings.HasPrefix(e.Object.GetName(), serverlessOperator) || strings.HasPrefix(e.Object.GetName(), serviceMeshOperator) || strings.HasPrefix(e.Object.GetName(), leaderWorkerSetOperator) //nolint:lll
+		return strings.HasPrefix(e.Object.GetName(), serverlessOperator) ||
+			strings.HasPrefix(e.Object.GetName(), serviceMeshOperator) ||
+			strings.HasPrefix(e.Object.GetName(), leaderWorkerSetOperator) ||
+			strings.HasPrefix(e.Object.GetName(), kuadrantOperator)
 	},
 	GenericFunc: func(e event.GenericEvent) bool {
 		return false

--- a/internal/controller/status/status.go
+++ b/internal/controller/status/status.go
@@ -131,7 +131,8 @@ const (
 
 	ServerlessUnsupportedCertMessage = "Serverless certificate type is not supported"
 
-	LeaderWorkerSetOperatorNotInstalledMessage = "LeaderWorkerSet operator must be installed for this component's configuration"
+	LeaderWorkerSetOperatorNotInstalledMessage  = "LeaderWorkerSet operator must be installed for this component's configuration"
+	ConnectivityLinkOperatorNotInstalledMessage = "Red Hat Connectivity Link operator must be installed for this component's configuration"
 )
 
 const (

--- a/pkg/cluster/gvk/gvk.go
+++ b/pkg/cluster/gvk/gvk.go
@@ -612,4 +612,10 @@ var (
 		Version: "v1",
 		Kind:    "LeaderWorkerSetOperator",
 	}
+
+	ConnectivityLinkOperator = schema.GroupVersionKind{
+		Group:   "kuadrant.io",
+		Version: "v1beta1",
+		Kind:    "Kuadrant",
+	}
 )

--- a/tests/e2e/creation_test.go
+++ b/tests/e2e/creation_test.go
@@ -98,6 +98,7 @@ func (tc *DSCTestCtx) ValidateOperatorsInstallation(t *testing.T) {
 		{nn: types.NamespacedName{Name: observabilityOpName, Namespace: observabilityOpNamespace}, skipOperatorGroup: false},
 		{nn: types.NamespacedName{Name: tempoOpName, Namespace: tempoOpNamespace}, skipOperatorGroup: false},
 		{nn: types.NamespacedName{Name: telemetryOpName, Namespace: telemetryOpNamespace}, skipOperatorGroup: false},
+		{nn: types.NamespacedName{Name: kuadrantOperator, Namespace: openshiftOperatorsNamespace}, skipOperatorGroup: true},
 	}
 
 	// Create and run test cases in parallel.
@@ -139,7 +140,7 @@ func (tc *DSCTestCtx) ValidateOperatorsWithCustomChannelsInstallation(t *testing
 		}
 	}
 
-	RunTestCases(t, testCases, WithParallel())
+	RunTestCases(t, testCases)
 }
 
 // ValidateDSCICreation validates the creation of a DSCInitialization.

--- a/tests/e2e/helper_test.go
+++ b/tests/e2e/helper_test.go
@@ -46,6 +46,7 @@ const (
 	serverlessOpName             = "serverless-operator"              // Name of the Serverless Operator
 	authorinoOpName              = "authorino-operator"               // Name of the Serverless Operator
 	leaderWorkerSetOpName        = "leader-worker-set"                // Name of the Leader Worker Set Operator
+	kuadrantOperator             = "kuadrant-operator"                // Name of the Red Hat Connectivity Link Operator
 	kueueOpName                  = "kueue-operator"                   // Name of the Kueue Operator
 	telemetryOpName              = "opentelemetry-product"            // Name of the Telemetry Operator
 	openshiftOperatorsNamespace  = "openshift-operators"              // Namespace for OpenShift Operators


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->
Adding the Red Hat Connectivity Link Operator to the KServe preconditions check.
<!--- Link your JIRA and related links here for reference. -->
https://issues.redhat.com/browse/RHOAIENG-34316
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Logic is cribbed from adding the LWS operator, which was tested on a 4.19 cluster and seems to work as expected.
Unit tests added and updated.
E2E tests updated.

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [ ] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added precondition checks for additional required operators with clear status messages when missing.
  - Introduced a new status condition: LeaderWorkerSetAvailable.
  - Expanded operator monitoring to include more operator types for reconciliation events.

- Refactor
  - Broadened handling of operator-related events to recognize more required operators.

- Tests
  - Added end-to-end scenarios for installing operators with custom channels.
  - Expanded test coverage for operator presence and status conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->