### PR TITLE
fixed bug where dup bearer token was added via cli access

### DIFF
--- a/internal/controller/services/gateway/resources/envoyfilter-authn.yaml
+++ b/internal/controller/services/gateway/resources/envoyfilter-authn.yaml
@@ -62,7 +62,7 @@ spec:
               local access_token = request_handle:headers():get("x-auth-request-access-token")
               if access_token then
                 request_handle:headers():add("x-forwarded-access-token", access_token)
-                request_handle:headers():add("authorization", "Bearer " .. access_token)
+                request_handle:headers():replace("authorization", "Bearer " .. access_token)
               end
             end
   - applyTo: CLUSTER


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->
Bug: Duplicate Authorization Header Causing 401 Unauthorized

  Problem: CLI Bearer token requests failed with 401. The Lua filter used `headers():add()` which appended to the existing Authorization header, creating a malformed header: Authorization: Bearer token,Bearer token

  Solution: Changed to `headers():replace()` to ensure a single valid Authorization header for both browser (cookie) and CLI (Bearer token) authentication.
<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->
No need


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensures requests use a single, correctly formatted Authorization header with the Bearer token, preventing duplicates that could lead to authentication failures.

* **Refactor**
  * Simplified Envoy configuration by removing an unused cluster-level patch, reducing complexity and potential side effects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->