### PR TITLE
fix: optimize failed test rerun

### DIFF
--- a/cmd/test-retry/pkg/runner/e2e_test.go
+++ b/cmd/test-retry/pkg/runner/e2e_test.go
@@ -34,21 +34,21 @@ func TestBuildSkipFilter(t *testing.T) {
 	}
 
 	tests := []struct {
-		name       string
-		opts       types.E2ETestOptions
-		testResult *types.TestResult
-		expected   string
+		name                 string
+		opts                 types.E2ETestOptions
+		aggregatedTestResult *types.TestResult
+		lastTestResult       *types.TestResult
+		expected             string
 	}{
 		{
-			name:       "no passed tests",
-			opts:       defaultOpts,
-			testResult: &types.TestResult{},
-			expected:   "",
+			name:     "no passed tests",
+			opts:     defaultOpts,
+			expected: "",
 		},
 		{
 			name: "single passed test",
 			opts: defaultOpts,
-			testResult: &types.TestResult{PassedTest: []types.TestCase{
+			aggregatedTestResult: &types.TestResult{PassedTest: []types.TestCase{
 				{Name: "TestOdhOperator/Feature1/test_case"},
 			}},
 			expected: "^TestOdhOperator$/^Feature1$",
@@ -56,7 +56,7 @@ func TestBuildSkipFilter(t *testing.T) {
 		{
 			name: "multiple passed tests",
 			opts: defaultOpts,
-			testResult: &types.TestResult{PassedTest: []types.TestCase{
+			aggregatedTestResult: &types.TestResult{PassedTest: []types.TestCase{
 				{Name: "TestOdhOperator/Feature1"},
 				{Name: "TestOdhOperator/Feature1/test_case"},
 				{Name: "TestOdhOperator/Feature2"},
@@ -66,7 +66,7 @@ func TestBuildSkipFilter(t *testing.T) {
 		{
 			name: "service test - should use third level",
 			opts: defaultOpts,
-			testResult: &types.TestResult{PassedTest: []types.TestCase{
+			aggregatedTestResult: &types.TestResult{PassedTest: []types.TestCase{
 				{Name: "TestOdhOperator/services/auth/subtest"},
 			}},
 			expected: "^TestOdhOperator$/^services$/^auth$",
@@ -74,7 +74,7 @@ func TestBuildSkipFilter(t *testing.T) {
 		{
 			name: "component test - should use third level",
 			opts: defaultOpts,
-			testResult: &types.TestResult{PassedTest: []types.TestCase{
+			aggregatedTestResult: &types.TestResult{PassedTest: []types.TestCase{
 				{Name: "TestOdhOperator/components/dashboard/subtest"},
 			}},
 			expected: "^TestOdhOperator$/^components$/^dashboard$",
@@ -82,7 +82,7 @@ func TestBuildSkipFilter(t *testing.T) {
 		{
 			name: "dsc initialization test - should not be skipped",
 			opts: defaultOpts,
-			testResult: &types.TestResult{PassedTest: []types.TestCase{
+			aggregatedTestResult: &types.TestResult{PassedTest: []types.TestCase{
 				{Name: "TestOdhOperator/DSCInitialization_and_DataScienceCluster_management_E2E_Tests/test1"},
 			}},
 			expected: "",
@@ -90,7 +90,7 @@ func TestBuildSkipFilter(t *testing.T) {
 		{
 			name: "mix of service and component tests",
 			opts: defaultOpts,
-			testResult: &types.TestResult{PassedTest: []types.TestCase{
+			aggregatedTestResult: &types.TestResult{PassedTest: []types.TestCase{
 				{Name: "TestOdhOperator/services/auth/subtest1"},
 				{Name: "TestOdhOperator/services/auth/subtest2"},
 				{Name: "TestOdhOperator/components/dashboard/subtest"},
@@ -100,7 +100,7 @@ func TestBuildSkipFilter(t *testing.T) {
 		{
 			name: "test with special regex characters",
 			opts: defaultOpts,
-			testResult: &types.TestResult{PassedTest: []types.TestCase{
+			aggregatedTestResult: &types.TestResult{PassedTest: []types.TestCase{
 				{Name: "TestOdhOperator/Feature(with)special[chars]"},
 			}},
 			expected: `^TestOdhOperator$/^Feature\(with\)special\[chars\]$`,
@@ -108,7 +108,7 @@ func TestBuildSkipFilter(t *testing.T) {
 		{
 			name: "mix including dsc initialization",
 			opts: defaultOpts,
-			testResult: &types.TestResult{PassedTest: []types.TestCase{
+			aggregatedTestResult: &types.TestResult{PassedTest: []types.TestCase{
 				{Name: "TestOdhOperator/Feature1"},
 				{Name: "TestOdhOperator/DSCInitialization_and_DataScienceCluster_management_E2E_Tests/test1"},
 				{Name: "TestOdhOperator/Feature2"},
@@ -118,7 +118,7 @@ func TestBuildSkipFilter(t *testing.T) {
 		{
 			name: "with multiple test cases",
 			opts: defaultOpts,
-			testResult: &types.TestResult{PassedTest: []types.TestCase{
+			aggregatedTestResult: &types.TestResult{PassedTest: []types.TestCase{
 				{Name: "TestOdhOperator/Feature1"},
 				{Name: "TestOdhOperator/Feature1/test_case"},
 				{Name: "TestOdhOperator/Feature1/test_case/subtest"},
@@ -131,10 +131,12 @@ func TestBuildSkipFilter(t *testing.T) {
 		{
 			name: "sibling tests - one passes, one fails - should not skip group",
 			opts: defaultOpts,
-			testResult: &types.TestResult{
+			aggregatedTestResult: &types.TestResult{
 				PassedTest: []types.TestCase{
 					{Name: "TestOdhOperator/Feature1/sibling1"},
 				},
+			},
+			lastTestResult: &types.TestResult{
 				FailedTest: []types.TestCase{
 					{Name: "TestOdhOperator/Feature1/sibling2"},
 				},
@@ -144,7 +146,7 @@ func TestBuildSkipFilter(t *testing.T) {
 		{
 			name: "sibling tests - both pass - should skip entire group",
 			opts: defaultOpts,
-			testResult: &types.TestResult{
+			aggregatedTestResult: &types.TestResult{
 				PassedTest: []types.TestCase{
 					{Name: "TestOdhOperator/Feature1/sibling1"},
 					{Name: "TestOdhOperator/Feature1/sibling2"},
@@ -155,13 +157,15 @@ func TestBuildSkipFilter(t *testing.T) {
 		{
 			name: "multiple groups with mixed results",
 			opts: defaultOpts,
-			testResult: &types.TestResult{
+			aggregatedTestResult: &types.TestResult{
 				PassedTest: []types.TestCase{
 					{Name: "TestOdhOperator/Feature1/sibling1"},
 					{Name: "TestOdhOperator/Feature2/test1"},
 					{Name: "TestOdhOperator/Feature2/test2"},
 					{Name: "TestOdhOperator/Feature3/testA"},
 				},
+			},
+			lastTestResult: &types.TestResult{
 				FailedTest: []types.TestCase{
 					{Name: "TestOdhOperator/Feature1/sibling2"},
 					{Name: "TestOdhOperator/Feature3/testB"},
@@ -175,15 +179,37 @@ func TestBuildSkipFilter(t *testing.T) {
 		{
 			name: "service tests with siblings - one passes, one fails",
 			opts: defaultOpts,
-			testResult: &types.TestResult{
+			aggregatedTestResult: &types.TestResult{
 				PassedTest: []types.TestCase{
 					{Name: "TestOdhOperator/services/auth/subtest1"},
 				},
+			},
+			lastTestResult: &types.TestResult{
 				FailedTest: []types.TestCase{
 					{Name: "TestOdhOperator/services/auth/subtest2"},
 				},
 			},
 			expected: "",
+		},
+		{
+			name: "second retry, aggregated with previous failed tests and failed tests also in last run",
+			opts: defaultOpts,
+			aggregatedTestResult: &types.TestResult{
+				PassedTest: []types.TestCase{
+					{Name: "TestOdhOperator/services/auth/subtest1"},
+					{Name: "TestOdhOperator/services/auth/subtest2"},
+					{Name: "TestOdhOperator/services/auth/subtest3"},
+				},
+				FailedTest: []types.TestCase{
+					{Name: "TestOdhOperator/services/foobar/a_test"},
+				},
+			},
+			lastTestResult: &types.TestResult{
+				FailedTest: []types.TestCase{
+					{Name: "TestOdhOperator/services/foobar/a_test"},
+				},
+			},
+			expected: "^TestOdhOperator$/^services$/^auth$",
 		},
 	}
 
@@ -193,7 +219,7 @@ func TestBuildSkipFilter(t *testing.T) {
 				opts: tt.opts,
 			}
 
-			result := runner.buildSkipFilter(tt.testResult)
+			result := runner.buildSkipFilter(tt.aggregatedTestResult, tt.lastTestResult)
 			require.Equal(t, tt.expected, result)
 		})
 	}

--- a/cmd/test-retry/pkg/runner/integration_test.go
+++ b/cmd/test-retry/pkg/runner/integration_test.go
@@ -61,13 +61,16 @@ func TestRunnerIntegration(t *testing.T) {
 		{
 			name:           "flaky tests pass after retry - with skip at prefix set",
 			testPath:       "./testdata/flaky",
-			skipAtPrefixes: []string{"TestNonFlaky"},
+			skipAtPrefixes: []string{"TestNonFlaky", "TestFlaky1", "TestFlaky2", "TestFlaky3"},
 			expectedResults: []testCaseOutput{
 				{Name: "TestFlaky1", HasFailure: true},
 				{Name: "TestFlaky2", HasFailure: true},
+				{Name: "TestFlaky3", HasFailure: true},
 				{Name: "TestNonFlaky", HasFailure: false},
 				{Name: "TestFlaky1", HasFailure: false},
 				{Name: "TestFlaky2", HasFailure: false},
+				{Name: "TestFlaky3", HasFailure: true},
+				{Name: "TestFlaky3", HasFailure: false},
 			},
 		},
 		{
@@ -76,9 +79,15 @@ func TestRunnerIntegration(t *testing.T) {
 			expectedResults: []testCaseOutput{
 				{Name: "TestFlaky1", HasFailure: true},
 				{Name: "TestFlaky2", HasFailure: true},
+				{Name: "TestFlaky3", HasFailure: true},
 				{Name: "TestNonFlaky", HasFailure: false},
 				{Name: "TestFlaky1", HasFailure: false},
 				{Name: "TestFlaky2", HasFailure: false},
+				{Name: "TestFlaky3", HasFailure: true},
+				{Name: "TestNonFlaky", HasFailure: false},
+				{Name: "TestFlaky1", HasFailure: false},
+				{Name: "TestFlaky2", HasFailure: false},
+				{Name: "TestFlaky3", HasFailure: false},
 				{Name: "TestNonFlaky", HasFailure: false},
 			},
 		},
@@ -194,7 +203,7 @@ func TestGitHubNotificationOnFlakyTests(t *testing.T) {
 	testPath := "./testdata/flaky"
 
 	opts := types.E2ETestOptions{
-		MaxRetries:        1,
+		MaxRetries:        2,
 		TestPath:          testPath,
 		Config:            &config.Config{Verbose: false},
 		NeverSkipPrefixes: []string{},


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
Before this PR, if a test fails in one run, it will be repeated in all subsequent run also when it passes.
With this PR, once a test passes it will not rerun. This will decrease the number of tests to run, and the time to await.

Jira task: https://issues.redhat.com/browse/RHOAIENG-34877

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [x] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->
Only CLI test runner updated, no e2e needed to be updated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - More precise retry skip filtering using both aggregated and last-run results, reducing unnecessary reruns and focusing retries on likely failures.
  - Improved handling of flaky tests across multiple attempts.

- Tests
  - Expanded flaky scenarios with an additional test case to better simulate real-world flakiness.
  - Updated integration tests to reflect refined skip behavior and increased retry attempts in notification flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->