### PR TITLE
update:  cleanup unnecessary upgrade logic + move functions

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -256,7 +256,7 @@ func main() { //nolint:funlen,maintidx,gocyclo
 	}
 
 	// get old release version before we create default DSCI CR
-	oldReleaseVersion, _ := upgrade.GetDeployedRelease(ctx, setupClient)
+	oldReleaseVersion, _ := cluster.GetDeployedRelease(ctx, setupClient)
 
 	secretCache, err := createSecretCacheConfig(platform)
 	if err != nil {

--- a/pkg/cluster/cluster_config.go
+++ b/pkg/cluster/cluster_config.go
@@ -98,6 +98,46 @@ func GetRelease() common.Release {
 	return clusterConfig.Release
 }
 
+// GetDeployedRelease retrieves the currently deployed release version from the cluster.
+// It first attempts to get the release from the DSCInitialization (DSCI) instance,
+// and if not found, falls back to the DataScienceCluster (DSC) instance.
+//
+// This function is useful during upgrades to determine what version is currently deployed
+// before applying any changes.
+//
+// Parameters:
+//   - ctx: The context for the request
+//   - cli: The Kubernetes client used to retrieve resources
+//
+// Returns:
+//   - common.Release: The deployed release information, or an empty Release if not found
+//   - error: An error if the retrieval fails for reasons other than "not found"
+func GetDeployedRelease(ctx context.Context, cli client.Client) (common.Release, error) {
+	dsciInstance, err := GetDSCI(ctx, cli)
+	switch {
+	case k8serr.IsNotFound(err):
+		break
+	case err != nil:
+		return common.Release{}, err
+	default:
+		return dsciInstance.Status.Release, nil
+	}
+
+	// no DSCI CR found, try with DSC CR
+	dscInstances, err := GetDSC(ctx, cli)
+	switch {
+	case k8serr.IsNotFound(err):
+		break
+	case err != nil:
+		return common.Release{}, err
+	default:
+		return dscInstances.Status.Release, nil
+	}
+
+	// could be a clean installation or both CRs are deleted already
+	return common.Release{}, nil
+}
+
 func GetClusterInfo() ClusterInfo {
 	return clusterConfig.ClusterInfo
 }

--- a/pkg/cluster/resources.go
+++ b/pkg/cluster/resources.go
@@ -173,6 +173,25 @@ func GetHardwareProfile(ctx context.Context, cli client.Client, name, namespace 
 	return hwProfile, nil
 }
 
+// CreateHardwareProfile creates a HardwareProfile resource in the cluster.
+// If the resource already exists, it returns nil (idempotent operation).
+//
+// Parameters:
+//   - ctx: The context for the request
+//   - cli: The Kubernetes client used to create the resource
+//   - hwp: The HardwareProfile to create
+//
+// Returns:
+//   - error: An error if the creation fails for reasons other than "already exists"
+func CreateHardwareProfile(ctx context.Context, cli client.Client, hwp *infrav1.HardwareProfile) error {
+	if err := cli.Create(ctx, hwp); err != nil {
+		if !k8serr.IsAlreadyExists(err) {
+			return fmt.Errorf("failed to create HardwareProfile '%s/%s': %w", hwp.Namespace, hwp.Name, err)
+		}
+	}
+	return nil
+}
+
 // UpdatePodSecurityRolebinding update default rolebinding which is created in applications namespace by manifests
 // being used by different components and SRE monitoring.
 func UpdatePodSecurityRolebinding(ctx context.Context, cli client.Client, namespace string, serviceAccountsList ...string) error {

--- a/pkg/upgrade/upgrade.go
+++ b/pkg/upgrade/upgrade.go
@@ -7,23 +7,16 @@ import (
 	"fmt"
 	"reflect"
 	"strings"
-	"time"
 
 	"github.com/hashicorp/go-multierror"
 	operatorv1 "github.com/openshift/api/operator/v1"
-	templatev1 "github.com/openshift/api/template/v1"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	appsv1 "k8s.io/api/apps/v1"
-	batchv1 "k8s.io/api/batch/v1"
-	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
-	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -32,34 +25,33 @@ import (
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/api/components/v1alpha1"
 	dscv2 "github.com/opendatahub-io/opendatahub-operator/v2/api/datasciencecluster/v2"
 	dsciv2 "github.com/opendatahub-io/opendatahub-operator/v2/api/dscinitialization/v2"
-	featuresv1 "github.com/opendatahub-io/opendatahub-operator/v2/api/features/v1"
 	infrav1 "github.com/opendatahub-io/opendatahub-operator/v2/api/infrastructure/v1"
 	serviceApi "github.com/opendatahub-io/opendatahub-operator/v2/api/services/v1alpha1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
-	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/metadata/labels"
 )
 
-type ResourceSpec struct {
-	Gvk       schema.GroupVersionKind
-	Namespace string
-	// path to the field, like "metadata", "name"
-	Path []string
-	// set of values for the field to match object, any one matches
-	Values []string
-}
-
 const (
-	defaultMinMemory                   = "1Mi"
-	defaultMinCpu                      = "1"
-	odhDashboardConfigPath             = "/dashboard/rhoai/shared/odhdashboardconfig/odhdashboardconfig.yaml"
-	serving                            = "serving"
-	notebooks                          = "notebooks"
-	acceleratorNameAnnotation          = "opendatahub.io/accelerator-name"
-	lastSizeSelectionAnnotation        = "notebooks.opendatahub.io/last-size-selection"
-	hardwareProfileNameAnnotation      = "opendatahub.io/hardware-profile-name"
-	hardwareProfileNamespaceAnnotation = "opendatahub.io/hardware-profile-namespace"
-	containerSizeHWPPrefix             = "containersize-"
+	defaultMinMemory                      = "1Mi"
+	defaultMinCpu                         = "1"
+	odhDashboardConfigPath                = "/dashboard/rhoai/shared/odhdashboardconfig/odhdashboardconfig.yaml"
+	odhDashboardConfigName                = "odh-dashboard-config"
+	serving                               = "serving"
+	notebooks                             = "notebooks"
+	customServing                         = "custom-serving"
+	acceleratorNameAnnotation             = "opendatahub.io/accelerator-name"
+	lastSizeSelectionAnnotation           = "notebooks.opendatahub.io/last-size-selection"
+	hardwareProfileNameAnnotation         = "opendatahub.io/hardware-profile-name"
+	hardwareProfileNamespaceAnnotation    = "opendatahub.io/hardware-profile-namespace"
+	hardwareProfileManagedAnnotation      = "opendatahub.io/managed"
+	hardwareProfileVisibilityAnnotation   = "opendatahub.io/dashboard-feature-visibility"
+	hardwareProfileModifiedDateAnnotation = "opendatahub.io/modified-date"
+	hardwareProfileDisplayNameAnnotation  = "opendatahub.io/display-name"
+	hardwareProfileDescriptionAnnotation  = "opendatahub.io/description"
+	hardwareProfileDisabledAnnotation     = "opendatahub.io/disabled"
+	featureVisibilityModelServing         = `["model-serving"]`
+	featureVisibilityWorkbench            = `["workbench"]`
+	containerSizeHWPPrefix                = "containersize-"
 )
 
 var defaultResourceLimits = map[string]string{
@@ -178,45 +170,6 @@ func CreateDefaultDSCI(ctx context.Context, cli client.Client, _ common.Platform
 	return nil
 }
 
-func getJPHOdhDocumentResources(namespace string, matchedName []string) []ResourceSpec {
-	metadataName := []string{"metadata", "name"}
-	return []ResourceSpec{
-		{
-			Gvk:       gvk.OdhDocument,
-			Namespace: namespace,
-			Path:      metadataName,
-			Values:    matchedName,
-		},
-	}
-}
-
-func getDashboardWatsonResources(ns string) []ResourceSpec {
-	metadataName := []string{"metadata", "name"}
-	specAppName := []string{"spec", "appName"}
-	appName := []string{"watson-studio"}
-
-	return []ResourceSpec{
-		{
-			Gvk:       gvk.OdhQuickStart,
-			Namespace: ns,
-			Path:      specAppName,
-			Values:    appName,
-		},
-		{
-			Gvk:       gvk.OdhDocument,
-			Namespace: ns,
-			Path:      specAppName,
-			Values:    appName,
-		},
-		{
-			Gvk:       gvk.OdhApplication,
-			Namespace: ns,
-			Path:      metadataName,
-			Values:    appName,
-		},
-	}
-}
-
 // TODO: remove function once we have a generic solution across all components.
 func CleanupExistingResource(ctx context.Context,
 	cli client.Client,
@@ -233,46 +186,11 @@ func CleanupExistingResource(ctx context.Context,
 		return nil
 	}
 	d := &dsciList.Items[0]
-	// Handling for dashboard OdhApplication Jupyterhub CR, see jira #443
-	multiErr = multierror.Append(multiErr, removOdhApplicationsCR(ctx, cli, gvk.OdhApplication, "jupyterhub", d.Spec.ApplicationsNamespace))
-
-	// cleanup for github.com/opendatahub-io/pull/888
-	deprecatedFeatureTrackers := []string{d.Spec.ApplicationsNamespace + "-kserve-temporary-fixes"}
-	multiErr = multierror.Append(multiErr, deleteDeprecatedResources(ctx, cli, d.Spec.ApplicationsNamespace, deprecatedFeatureTrackers, &featuresv1.FeatureTrackerList{}))
 
 	// Cleanup of deprecated default RoleBinding resources
 	deprecatedDefaultRoleBinding := []string{d.Spec.ApplicationsNamespace}
 	multiErr = multierror.Append(multiErr, deleteDeprecatedResources(ctx, cli, d.Spec.ApplicationsNamespace, deprecatedDefaultRoleBinding, &rbacv1.RoleBindingList{}))
 
-	// Handling for dashboard OdhDocument Jupyterhub CR, see jira #443 comments
-	odhDocJPH := getJPHOdhDocumentResources(
-		d.Spec.ApplicationsNamespace,
-		[]string{
-			"jupyterhub-install-python-packages",
-			"jupyterhub-update-server-settings",
-			"jupyterhub-view-installed-packages",
-			"jupyterhub-use-s3-bucket-data",
-		})
-	multiErr = multierror.Append(multiErr, deleteResources(ctx, cli, &odhDocJPH))
-	// only apply on RHOAI since ODH has a different way to create this CR by dashboard
-	if platform == cluster.SelfManagedRhoai || platform == cluster.ManagedRhoai {
-		if err := upgradeODCCR(ctx, cli, "odh-dashboard-config", d.Spec.ApplicationsNamespace, oldReleaseVersion); err != nil {
-			return err
-		}
-	}
-	// remove modelreg proxy container from deployment in ODH
-	if platform == cluster.OpenDataHub {
-		if err := removeRBACProxyModelRegistry(ctx, cli, "model-registry-operator", "kube-rbac-proxy", d.Spec.ApplicationsNamespace); err != nil {
-			return err
-		}
-	}
-
-	// to take a reference
-	toDelete := getDashboardWatsonResources(d.Spec.ApplicationsNamespace)
-	multiErr = multierror.Append(multiErr, deleteResources(ctx, cli, &toDelete))
-
-	// cleanup nvidia nim integration
-	multiErr = multierror.Append(multiErr, cleanupNimIntegration(ctx, cli, oldReleaseVersion, d.Spec.ApplicationsNamespace))
 	// cleanup model controller legacy deployment
 	multiErr = multierror.Append(multiErr, cleanupModelControllerLegacyDeployment(ctx, cli, d.Spec.ApplicationsNamespace))
 	// cleanup deprecated kueue ValidatingAdmissionPolicyBinding
@@ -285,55 +203,6 @@ func CleanupExistingResource(ctx context.Context,
 	}
 
 	return multiErr.ErrorOrNil()
-}
-
-func deleteResources(ctx context.Context, c client.Client, resources *[]ResourceSpec) error {
-	var errors *multierror.Error
-
-	for _, res := range *resources {
-		err := deleteOneResource(ctx, c, res)
-		errors = multierror.Append(errors, err)
-	}
-
-	return errors.ErrorOrNil()
-}
-
-func deleteOneResource(ctx context.Context, c client.Client, res ResourceSpec) error {
-	log := logf.FromContext(ctx)
-	list := &unstructured.UnstructuredList{}
-	list.SetGroupVersionKind(res.Gvk)
-
-	err := c.List(ctx, list, client.InNamespace(res.Namespace))
-	if err != nil {
-		if meta.IsNoMatchError(err) {
-			log.Info("CRD not found, will not delete", "gvk", res.Gvk.String())
-			return nil
-		}
-		return fmt.Errorf("failed to list %s: %w", res.Gvk.Kind, err)
-	}
-
-	for _, item := range list.Items {
-		v, ok, err := unstructured.NestedString(item.Object, res.Path...)
-		if err != nil {
-			return fmt.Errorf("failed to get field %v for %s %s/%s: %w", res.Path, res.Gvk.Kind, res.Namespace, item.GetName(), err)
-		}
-
-		if !ok {
-			return fmt.Errorf("unexisting path to delete: %v", res.Path)
-		}
-
-		for _, toDelete := range res.Values {
-			if v == toDelete {
-				err = c.Delete(ctx, &item)
-				if err != nil {
-					return fmt.Errorf("failed to delete %s %s/%s: %w", res.Gvk.Kind, res.Namespace, item.GetName(), err)
-				}
-				log.Info("Deleted object", "name", item.GetName(), "gvk", res.Gvk.String(), "namespace", res.Namespace)
-			}
-		}
-	}
-
-	return nil
 }
 
 func deleteDeprecatedResources(ctx context.Context, cli client.Client, namespace string, resourceList []string, resourceType client.ObjectList) error {
@@ -362,230 +231,6 @@ func deleteDeprecatedResources(ctx context.Context, cli client.Client, namespace
 		}
 	}
 	return multiErr.ErrorOrNil()
-}
-
-func removOdhApplicationsCR(ctx context.Context, cli client.Client, gvk schema.GroupVersionKind, instanceName string, applicationNS string) error {
-	// first check if CRD in cluster
-	crd := &apiextv1.CustomResourceDefinition{}
-	if err := cli.Get(ctx, client.ObjectKey{Name: "odhapplications.dashboard.opendatahub.io"}, crd); err != nil {
-		return client.IgnoreNotFound(err)
-	}
-
-	// then check if CR in cluster to delete
-	odhObject := &unstructured.Unstructured{}
-	odhObject.SetGroupVersionKind(gvk)
-	if err := cli.Get(ctx, client.ObjectKey{
-		Namespace: applicationNS,
-		Name:      instanceName,
-	}, odhObject); err != nil {
-		return client.IgnoreNotFound(err)
-	}
-	if err := cli.Delete(ctx, odhObject); err != nil {
-		return fmt.Errorf("error deleting CR %s : %w", instanceName, err)
-	}
-
-	return nil
-}
-
-// upgradODCCR handles different cases:
-// 1. unset ownerreference for CR odh-dashboard-config
-// 2. flip TrustyAI BiasMetrics to false (.spec.dashboardConfig.disableBiasMetrics) if it is lower release version than input 'release'.
-// 3. flip ModelRegistry to false (.spec.dashboardConfig.disableModelRegistry) if it is lower release version than input 'release'.
-func upgradeODCCR(ctx context.Context, cli client.Client, instanceName string, applicationNS string, release common.Release) error {
-	crd := &apiextv1.CustomResourceDefinition{}
-	if err := cli.Get(ctx, client.ObjectKey{Name: "odhdashboardconfigs.opendatahub.io"}, crd); err != nil {
-		return client.IgnoreNotFound(err)
-	}
-	odhObject := &unstructured.Unstructured{}
-	odhObject.SetGroupVersionKind(gvk.OdhDashboardConfig)
-	if err := cli.Get(ctx, client.ObjectKey{
-		Namespace: applicationNS,
-		Name:      instanceName,
-	}, odhObject); err != nil {
-		return client.IgnoreNotFound(err)
-	}
-
-	if err := unsetOwnerReference(ctx, cli, instanceName, odhObject); err != nil {
-		return err
-	}
-
-	if err := updateODCBiasMetrics(ctx, cli, instanceName, release, odhObject); err != nil {
-		return err
-	}
-
-	return updateODCModelRegistry(ctx, cli, instanceName, release, odhObject)
-}
-
-func unsetOwnerReference(ctx context.Context, cli client.Client, instanceName string, odhObject *unstructured.Unstructured) error {
-	if odhObject.GetOwnerReferences() != nil {
-		// set to nil as updates
-		odhObject.SetOwnerReferences(nil)
-		if err := cli.Update(ctx, odhObject); err != nil {
-			return fmt.Errorf("error unset ownerreference for CR %s : %w", instanceName, err)
-		}
-	}
-	return nil
-}
-
-func updateODCBiasMetrics(ctx context.Context, cli client.Client, instanceName string, oldRelease common.Release, odhObject *unstructured.Unstructured) error {
-	log := logf.FromContext(ctx)
-	// "from version" as oldRelease, if return "0.0.0" meaning running on 2.10- release/dummy CI build
-	// if oldRelease is lower than 2.14.0(e.g 2.13.x-a), flip disableBiasMetrics to false (even the field did not exist)
-	if oldRelease.Version.Minor < 14 {
-		log.Info("Upgrade force BiasMetrics to false due to old release < 2.14.0", "instance", instanceName)
-		// flip TrustyAI BiasMetrics to false (.spec.dashboardConfig.disableBiasMetrics)
-		disableBiasMetricsValue := []byte(`{"spec": {"dashboardConfig": {"disableBiasMetrics": false}}}`)
-		if err := cli.Patch(ctx, odhObject, client.RawPatch(types.MergePatchType, disableBiasMetricsValue)); err != nil {
-			return fmt.Errorf("error enable BiasMetrics in CR %s : %w", instanceName, err)
-		}
-		return nil
-	}
-	log.Info("Upgrade does not force BiasMetrics to false due to from release >= 2.14.0")
-	return nil
-}
-
-func updateODCModelRegistry(ctx context.Context, cli client.Client, instanceName string, oldRelease common.Release, odhObject *unstructured.Unstructured) error {
-	log := logf.FromContext(ctx)
-	// "from version" as oldRelease, if return "0.0.0" meaning running on 2.10- release/dummy CI build
-	// if oldRelease is lower than 2.14.0(e.g 2.13.x-a), flip disableModelRegistry to false (even the field did not exist)
-	if oldRelease.Version.Minor < 14 {
-		log.Info("Upgrade force ModelRegistry to false due to old release < 2.14.0", "instance", instanceName)
-		disableModelRegistryValue := []byte(`{"spec": {"dashboardConfig": {"disableModelRegistry": false}}}`)
-		if err := cli.Patch(ctx, odhObject, client.RawPatch(types.MergePatchType, disableModelRegistryValue)); err != nil {
-			return fmt.Errorf("error enable ModelRegistry in CR %s : %w", instanceName, err)
-		}
-		return nil
-	}
-	log.Info("Upgrade does not force ModelRegistry to false due to from release >= 2.14.0")
-	return nil
-}
-
-// workaround for RHOAIENG-15328
-// TODO: this can be removed from ODH 2.22.
-func removeRBACProxyModelRegistry(ctx context.Context, cli client.Client, componentName string, containerName string, applicationNS string) error {
-	log := logf.FromContext(ctx)
-	deploymentList := &appsv1.DeploymentList{}
-	if err := cli.List(ctx, deploymentList, client.InNamespace(applicationNS), client.HasLabels{labels.ODH.Component(componentName)}); err != nil {
-		return fmt.Errorf("error fetching list of deployments: %w", err)
-	}
-
-	if len(deploymentList.Items) != 1 { // ModelRegistry operator is not deployed
-		return nil
-	}
-	mrDeployment := deploymentList.Items[0]
-	mrContainerList := mrDeployment.Spec.Template.Spec.Containers
-	// if only one container in deployment, we are already on newer deployment, no need more action
-	if len(mrContainerList) == 1 {
-		return nil
-	}
-
-	log.Info("Upgrade force ModelRegistry to remove container from deployment")
-	for i, container := range mrContainerList {
-		if container.Name == containerName {
-			removeUnusedKubeRbacProxy := []byte(fmt.Sprintf("[{\"op\": \"remove\", \"path\": \"/spec/template/spec/containers/%d\"}]", i))
-			if err := cli.Patch(ctx, &mrDeployment, client.RawPatch(types.JSONPatchType, removeUnusedKubeRbacProxy)); err != nil {
-				return fmt.Errorf("error removing ModelRegistry %s container from deployment: %w", containerName, err)
-			}
-			break
-		}
-	}
-	return nil
-}
-
-func GetDeployedRelease(ctx context.Context, cli client.Client) (common.Release, error) {
-	dsciInstance, err := cluster.GetDSCI(ctx, cli)
-	switch {
-	case k8serr.IsNotFound(err):
-		break
-	case err != nil:
-		return common.Release{}, err
-	default:
-		return dsciInstance.Status.Release, nil
-	}
-
-	// no DSCI CR found, try with DSC CR
-	dscInstances, err := cluster.GetDSC(ctx, cli)
-	switch {
-	case k8serr.IsNotFound(err):
-		break
-	case err != nil:
-		return common.Release{}, err
-	default:
-		return dscInstances.Status.Release, nil
-	}
-
-	// could be a clean installation or both CRs are deleted already
-	return common.Release{}, nil
-}
-
-func cleanupNimIntegration(ctx context.Context, cli client.Client, oldRelease common.Release, applicationNS string) error {
-	var errs *multierror.Error
-
-	if oldRelease.Version.Minor >= 14 && oldRelease.Version.Minor <= 16 {
-		log := logf.FromContext(ctx)
-		type objForDel struct {
-			obj        client.Object
-			name, desc string
-		}
-
-		// the following objects created by TP (14-15) and by the first GA (16)
-		deleteObjs := []objForDel{
-			{
-				obj:  &corev1.ConfigMap{},
-				name: "nvidia-nim-images-data",
-				desc: "data ConfigMap",
-			},
-			{
-				obj:  &templatev1.Template{},
-				name: "nvidia-nim-serving-template",
-				desc: "runtime Template",
-			},
-			{
-				obj:  &corev1.Secret{},
-				name: "nvidia-nim-image-pull",
-				desc: "pull Secret",
-			},
-		}
-
-		// the following objects created by TP (14-15)
-		if oldRelease.Version.Minor < 16 {
-			deleteObjs = append(deleteObjs,
-				objForDel{
-					obj:  &batchv1.CronJob{},
-					name: "nvidia-nim-periodic-validator",
-					desc: "validator CronJob",
-				},
-				objForDel{
-					obj:  &corev1.ConfigMap{},
-					name: "nvidia-nim-validation-result",
-					desc: "validation result ConfigMap",
-				},
-				// the api key is also used by GA (16), but cleanup is only required for TP->GA switch
-				objForDel{
-					obj:  &corev1.Secret{},
-					name: "nvidia-nim-access",
-					desc: "API key Secret",
-				})
-		}
-
-		for _, delObj := range deleteObjs {
-			if gErr := cli.Get(ctx, types.NamespacedName{Name: delObj.name, Namespace: applicationNS}, delObj.obj); gErr != nil {
-				if !k8serr.IsNotFound(gErr) {
-					log.V(1).Error(gErr, "failed to get NIM", "desc", delObj.desc, "name", delObj.name)
-					errs = multierror.Append(errs, gErr)
-				}
-			} else {
-				if dErr := cli.Delete(ctx, delObj.obj); dErr != nil {
-					log.Error(dErr, "failed to remove NIM", "desc", delObj.desc, "name", delObj.name)
-					errs = multierror.Append(errs, dErr)
-				} else {
-					log.Info("removed NIM successfully", "desc", delObj.desc)
-				}
-			}
-		}
-	}
-
-	return errs.ErrorOrNil()
 }
 
 // When upgrading from version 2.16 to 2.17, the odh-model-controller
@@ -679,7 +324,7 @@ func MigrateToInfraHardwareProfiles(ctx context.Context, cli client.Client, appl
 		return nil
 	}
 
-	// Get OdhDashboardConfig once for all migration functions
+	// Get OdhDashboardConfig to extract container sizes
 	odhConfig, found, err := getOdhDashboardConfig(ctx, cli, applicationNS)
 	if err != nil {
 		return fmt.Errorf("failed to get OdhDashboardConfig: %w", err)
@@ -699,7 +344,7 @@ func MigrateToInfraHardwareProfiles(ctx context.Context, cli client.Client, appl
 	multiErr = multierror.Append(multiErr, AttachHardwareProfileToNotebooks(ctx, cli, applicationNS, odhConfig))
 
 	// 4. Attach HardwareProfile annotations to existing InferenceServices but create custom-serving HWP first.
-	multiErr = multierror.Append(multiErr, CreateCustomServingHardwareProfile(ctx, cli, applicationNS))
+	multiErr = multierror.Append(multiErr, createCustomServingHardwareProfile(ctx, cli, applicationNS))
 	multiErr = multierror.Append(multiErr, AttachHardwareProfileToInferenceServices(ctx, cli, applicationNS, odhConfig))
 
 	return multiErr.ErrorOrNil()
@@ -860,31 +505,27 @@ func AttachHardwareProfileToNotebooks(ctx context.Context, cli client.Client, ap
 	return multiErr.ErrorOrNil()
 }
 
-func CreateCustomServingHardwareProfile(ctx context.Context, cli client.Client, namespace string) error {
+func createCustomServingHardwareProfile(ctx context.Context, cli client.Client, namespace string) error {
 	log := logf.FromContext(ctx)
 	// Check if custom-serving HardwareProfile CR already exists
-	_, customServingError := cluster.GetHardwareProfile(ctx, cli, "custom-serving", namespace)
+	_, customServingError := cluster.GetHardwareProfile(ctx, cli, customServing, namespace)
 	if client.IgnoreNotFound(customServingError) != nil {
-		return fmt.Errorf("failed to check HardwareProfile CR: custom-serving %w", customServingError)
+		return fmt.Errorf("failed to check HardwareProfile CR: %s %w", customServing, customServingError)
 	}
 	if k8serr.IsNotFound(customServingError) {
 		// Create custom-serving HardwareProfile programmatically
+		annotations := createHardwareProfileAnnotations(serving, customServing, "", false)
+		annotations[hardwareProfileManagedAnnotation] = "false"
+
 		hwp := &infrav1.HardwareProfile{
 			TypeMeta: metav1.TypeMeta{
 				APIVersion: infrav1.GroupVersion.String(),
 				Kind:       "HardwareProfile",
 			},
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "custom-serving",
-				Namespace: namespace,
-				Annotations: map[string]string{
-					"opendatahub.io/dashboard-feature-visibility": `["model-serving"]`,
-					"opendatahub.io/modified-date":                time.Now().Format(time.RFC3339),
-					"opendatahub.io/display-name":                 "custom-serving",
-					"opendatahub.io/description":                  "",
-					"opendatahub.io/disabled":                     "false",
-					"opendatahub.io/managed":                      "false",
-				},
+				Name:        customServing,
+				Namespace:   namespace,
+				Annotations: annotations,
 			},
 			Spec: infrav1.HardwareProfileSpec{
 				Identifiers: []infrav1.HardwareIdentifier{
@@ -906,12 +547,10 @@ func CreateCustomServingHardwareProfile(ctx context.Context, cli client.Client, 
 			},
 		}
 
-		if err := cli.Create(ctx, hwp); err != nil {
-			if !k8serr.IsAlreadyExists(err) {
-				return fmt.Errorf("failed to create custom-serving HardwareProfile v1: %w", err)
-			}
+		if err := cluster.CreateHardwareProfile(ctx, cli, hwp); err != nil {
+			return err
 		}
-		log.Info("Successfully created custom-serving HardwareProfile", "namespace", namespace)
+		log.Info("Successfully created HardwareProfile", "name", customServing, "namespace", namespace)
 	}
 	return nil
 }
@@ -971,7 +610,7 @@ func AttachHardwareProfileToInferenceServices(ctx context.Context, cli client.Cl
 
 		// No AP found, try container size matching
 		// Default usign HWProfile CR "custom-serving", update only if we find a matching size
-		hwpName := "custom-serving"
+		hwpName := customServing
 		var matchedSize string
 
 		resources, err := getInferenceServiceResources(isvc)
@@ -990,7 +629,7 @@ func AttachHardwareProfileToInferenceServices(ctx context.Context, cli client.Cl
 			if matchedSize != "" {
 				log.Info("Set HardwareProfile annotation for InferenceService based on container size match", "isvc", isvc.GetName(), "size", matchedSize, "hardwareProfile", hwpName)
 			} else {
-				log.Info("Set HardwareProfile annotation for InferenceService with custom-serving HardwareProfile", "isvc", isvc.GetName(), "hardwareProfile", hwpName)
+				log.Info("Set HardwareProfile annotation for InferenceService with "+customServing+" HardwareProfile", "isvc", isvc.GetName(), "hardwareProfile", hwpName)
 			}
 		}
 	}


### PR DESCRIPTION
- remove functions and calls used in the v2 upgrade, but not needed any more for v3
1. jupyterhub resource cleanup
2. rbac for modelreg
3. envoyfilter file for serving
4. waterson resource
5. patch odhdashboardconfig for trusty enablement

- move some functions into resources pkg can be reuse later
- create support functions for hwprofile migration

<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->
cleanup code, no e2e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of deployed-release detection during initialization.

* **New Features**
  * Idempotent hardware profile creation to avoid duplicate errors.
  * Batch deletion utilities for targeted cluster resources and a utility to clear owner references.

* **Refactor**
  * Streamlined hardware-profile creation and annotation flows with centralized naming and visibility settings.
  * Removed legacy cleanup paths and consolidated upgrade-related configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->