### PR TITLE
fix: updated HWP upgrade logic to set NS when using custom-serving

### DIFF
--- a/pkg/upgrade/upgrade.go
+++ b/pkg/upgrade/upgrade.go
@@ -60,6 +60,7 @@ const (
 	hardwareProfileNameAnnotation      = "opendatahub.io/hardware-profile-name"
 	hardwareProfileNamespaceAnnotation = "opendatahub.io/hardware-profile-namespace"
 	containerSizeHWPPrefix             = "containersize-"
+	CustomServingHWPName               = "custom-serving"
 )
 
 var defaultResourceLimits = map[string]string{
@@ -863,7 +864,7 @@ func AttachHardwareProfileToNotebooks(ctx context.Context, cli client.Client, ap
 func CreateCustomServingHardwareProfile(ctx context.Context, cli client.Client, namespace string) error {
 	log := logf.FromContext(ctx)
 	// Check if custom-serving HardwareProfile CR already exists
-	_, customServingError := cluster.GetHardwareProfile(ctx, cli, "custom-serving", namespace)
+	_, customServingError := cluster.GetHardwareProfile(ctx, cli, CustomServingHWPName, namespace)
 	if client.IgnoreNotFound(customServingError) != nil {
 		return fmt.Errorf("failed to check HardwareProfile CR: custom-serving %w", customServingError)
 	}
@@ -875,12 +876,12 @@ func CreateCustomServingHardwareProfile(ctx context.Context, cli client.Client, 
 				Kind:       "HardwareProfile",
 			},
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "custom-serving",
+				Name:      CustomServingHWPName,
 				Namespace: namespace,
 				Annotations: map[string]string{
 					"opendatahub.io/dashboard-feature-visibility": "['model-serving']",
 					"opendatahub.io/modified-date":                time.Now().Format(time.RFC3339),
-					"opendatahub.io/display-name":                 "custom-serving",
+					"opendatahub.io/display-name":                 CustomServingHWPName,
 					"opendatahub.io/description":                  "",
 					"opendatahub.io/disabled":                     "false",
 					"opendatahub.io/managed":                      "false",
@@ -971,7 +972,7 @@ func AttachHardwareProfileToInferenceServices(ctx context.Context, cli client.Cl
 
 		// No AP found, try container size matching
 		// Default usign HWProfile CR "custom-serving", update only if we find a matching size
-		hwpName := "custom-serving"
+		hwpName := CustomServingHWPName
 		var matchedSize string
 
 		resources, err := getInferenceServiceResources(isvc)

--- a/pkg/upgrade/upgrade_test.go
+++ b/pkg/upgrade/upgrade_test.go
@@ -1532,7 +1532,7 @@ func TestAttachHardwareProfileToInferenceServices(t *testing.T) {
 		updatedIsvc.SetGroupVersionKind(gvk.InferenceServices)
 		err = cli.Get(ctx, client.ObjectKey{Name: "isvc-custom", Namespace: namespace}, updatedIsvc)
 		g.Expect(err).ShouldNot(HaveOccurred())
-		g.Expect(updatedIsvc.GetAnnotations()).To(HaveKeyWithValue("opendatahub.io/hardware-profile-name", "custom-serving"))
+		g.Expect(updatedIsvc.GetAnnotations()).To(HaveKeyWithValue("opendatahub.io/hardware-profile-name", upgrade.CustomServingHWPName))
 	})
 
 	t.Run("should use custom-serving for InferenceService without resources", func(t *testing.T) {
@@ -1552,7 +1552,7 @@ func TestAttachHardwareProfileToInferenceServices(t *testing.T) {
 		updatedIsvc.SetGroupVersionKind(gvk.InferenceServices)
 		err = cli.Get(ctx, client.ObjectKey{Name: "isvc-no-resources", Namespace: namespace}, updatedIsvc)
 		g.Expect(err).ShouldNot(HaveOccurred())
-		g.Expect(updatedIsvc.GetAnnotations()).To(HaveKeyWithValue("opendatahub.io/hardware-profile-name", "custom-serving"))
+		g.Expect(updatedIsvc.GetAnnotations()).To(HaveKeyWithValue("opendatahub.io/hardware-profile-name", upgrade.CustomServingHWPName))
 	})
 
 	t.Run("should skip InferenceService that already has HWP annotation", func(t *testing.T) {

--- a/pkg/upgrade/upgrade_utils.go
+++ b/pkg/upgrade/upgrade_utils.go
@@ -683,8 +683,9 @@ func setHardwareProfileAnnotation(ctx context.Context, cli client.Client, obj *u
 	}
 	annotations[hardwareProfileNameAnnotation] = hwpName
 
-	// If hardwareprofile name starts with the containersize- prefix, also set the HWP namespace annotation to the application namespace
-	if strings.HasPrefix(hwpName, containerSizeHWPPrefix) {
+	// If hardwareprofile starts with the containersize- prefix or if it's the custom-serving HWP
+	// Then also set the HWP namespace annotation to the application namespace
+	if strings.HasPrefix(hwpName, containerSizeHWPPrefix) || hwpName == CustomServingHWPName {
 		annotations[hardwareProfileNamespaceAnnotation] = namespace
 	}
 	obj.SetAnnotations(annotations)


### PR DESCRIPTION
## Description
JIRA: [RHOAIENG-33159](https://issues.redhat.com/browse/RHOAIENG-33159)

This PR updates the HWP migration logic so that we explicitly set the namespace when assigning the `custom-serving` to workloads.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [X] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
Minor fix that doesn't require e2e update


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized custom serving hardware profile naming by consolidating into a named constant, replacing individual hard-coded references for improved consistency across the system.

* **Behavior Enhancement**
  * Improved namespace annotation handling for custom serving hardware profiles to ensure proper synchronization with application namespaces.

* **Tests**
  * Updated test expectations to align with standardized naming conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->