### PR TITLE
fix(RHOAIENG-36386): Correct RAGAS KFP image reference

### DIFF
--- a/internal/controller/components/trustyai/trustyai_support.go
+++ b/internal/controller/components/trustyai/trustyai_support.go
@@ -29,7 +29,7 @@ var (
 		"guardrails-orchestrator-image":      "RELATED_IMAGE_ODH_FMS_GUARDRAILS_ORCHESTRATOR_IMAGE",
 		"guardrails-sidecar-gateway-image":   "RELATED_IMAGE_ODH_TRUSTYAI_VLLM_ORCHESTRATOR_GATEWAY_IMAGE",
 		"guardrails-built-in-detector-image": "RELATED_IMAGE_ODH_BUILT_IN_DETECTOR_IMAGE",
-		"ragas-provider-image":               "RELATED_IMAGE_ODH_TRUSTYAI_RAGAS_PROVIDER_IMAGE",
+		"ragas-provider-image":               "RELATED_IMAGE_ODH_TRUSTYAI_RAGAS_LLS_PROVIDER_DSP_IMAGE",
 		"oauthProxyImage":                    "RELATED_IMAGE_OSE_OAUTH_PROXY_IMAGE",
 		"kube-rbac-proxy":                    "RELATED_IMAGE_OSE_KUBE_RBAC_PROXY_IMAGE",
 	}


### PR DESCRIPTION
## Description

Use the correct RAGAS image
Refer to: https://issues.redhat.com/browse/RHOAIENG-36386


## Merge criteria

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

- [x] Skip requirement to update E2E test suite for this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal provider image configuration mapping for TrustyAI components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->