### PR TITLE
update notebooks manifest hash for gateway support

### DIFF
--- a/get_all_manifests.sh
+++ b/get_all_manifests.sh
@@ -12,8 +12,8 @@ GITHUB_URL="https://github.com"
 # 3. "branch@commit-sha" - tracks branch but pinned to specific commit (e.g., main@a1b2c3d4)
 declare -A COMPONENT_MANIFESTS=(
     ["dashboard"]="opendatahub-io:odh-dashboard:main@e356f9630874efe5cd1b2c96fddc15b1cdfdf8bd:manifests"
-    ["workbenches/kf-notebook-controller"]="opendatahub-io:kubeflow:main@4c581eb93299dde716e7791ebe5f90d43919a52f:components/notebook-controller/config"
-    ["workbenches/odh-notebook-controller"]="opendatahub-io:kubeflow:main@4c581eb93299dde716e7791ebe5f90d43919a52f:components/odh-notebook-controller/config"
+    ["workbenches/kf-notebook-controller"]="opendatahub-io:kubeflow:main@bf6b20b5a4cf689c0c3fa06f99dfbdcf6674d51f:components/notebook-controller/config"
+    ["workbenches/odh-notebook-controller"]="opendatahub-io:kubeflow:main@bf6b20b5a4cf689c0c3fa06f99dfbdcf6674d51f:components/odh-notebook-controller/config"
     ["workbenches/notebooks"]="opendatahub-io:notebooks:main@40a15f26ca1f3af8135ddbadee43708501cd19b1:manifests"
     ["kserve"]="opendatahub-io:kserve:release-v0.15@1381fab8f77e7d5b211f634506a7a09e97345655:config"
     ["ray"]="opendatahub-io:kuberay:dev@d751b14faddf13b141d0d26f6ced640ec23030b3:ray-operator/config"


### PR DESCRIPTION
Bumps the pinned SHA for the notebook controller to https://github.com/opendatahub-io/kubeflow/commit/bf6b20b5a4cf689c0c3fa06f99dfbdcf6674d51f

This should hopefully fix e2e tests that are throwing `flag provided but not defined: -oauth-proxy-image` errors

```
flag provided but not defined: -oauth-proxy-image
Usage of /manager:
  -debug-log
        Enable debug logging mode.
  -health-probe-bind-address string
        The address the probe endpoint binds to. (default ":8081")
  -kube-rbac-proxy-image string
        Image of the kube-rbac-proxy sidecar container. (required)
  -kubeconfig string
        Paths to a kubeconfig. Only required if out-of-cluster.
  -leader-elect
        Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager.
  -metrics-bind-address string
        The address the metric endpoint binds to. (default ":8080")
  -webhook-cert-dir string
        Directory that contains the server key and certificate for the webhook server. (default "/tmp/k8s-webhook-server/serving-certs")
  -webhook-port int
        Port that the webhook server serves at. (default 8443)
  -zap-devel
        Development Mode defaults(encoder=consoleEncoder,logLevel=Debug,stackTraceLevel=Warn). Production Mode defaults(encoder=jsonEncoder,logLevel=Info,stackTraceLevel=Error)
  -zap-encoder value
        Zap log encoding (one of 'json' or 'console')
  -zap-log-level value
        Zap Level to configure the verbosity of logging. Can be one of 'debug', 'info', 'error', 'panic'or any integer value > 0 which corresponds to custom debug levels of increasing verbosity
  -zap-stacktrace-level value
        Zap Level at and above which stacktraces are captured (one of 'info', 'error', 'panic').
  -zap-time-encoding value
        Zap time encoding (one of 'epoch', 'millis', 'nano', 'iso8601', 'rfc3339' or 'rfc3339nano'). Defaults to 'epoch'.
```