### PR TITLE
added validation for clientid/issuerurl

### DIFF
--- a/internal/controller/services/gateway/gateway_controller_actions_test.go
+++ b/internal/controller/services/gateway/gateway_controller_actions_test.go
@@ -398,9 +398,15 @@ func TestValidateOIDCConfig(t *testing.T) {
 		description string
 	}{
 		{
-			name:        "OIDC mode with valid config",
-			authMode:    AuthModeOIDC,
-			oidcConfig:  &serviceApi.OIDCConfig{IssuerURL: testOIDCIssuerURL},
+			name:     "OIDC mode with valid config",
+			authMode: AuthModeOIDC,
+			oidcConfig: &serviceApi.OIDCConfig{
+				IssuerURL: testOIDCIssuerURL,
+				ClientID:  "test-client",
+				ClientSecretRef: corev1.SecretKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{Name: "test-secret"},
+				},
+			},
 			expectError: false,
 			description: "should pass when OIDC mode has valid configuration",
 		},
@@ -410,6 +416,32 @@ func TestValidateOIDCConfig(t *testing.T) {
 			oidcConfig:  nil,
 			expectError: true,
 			description: "should fail when OIDC mode has no configuration",
+		},
+		{
+			name:     "OIDC mode with empty clientID",
+			authMode: AuthModeOIDC,
+			oidcConfig: &serviceApi.OIDCConfig{
+				IssuerURL: testOIDCIssuerURL,
+				ClientID:  "",
+				ClientSecretRef: corev1.SecretKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{Name: "test-secret"},
+				},
+			},
+			expectError: true,
+			description: "should fail when clientID is empty",
+		},
+		{
+			name:     "OIDC mode with all fields empty",
+			authMode: AuthModeOIDC,
+			oidcConfig: &serviceApi.OIDCConfig{
+				IssuerURL: "",
+				ClientID:  "",
+				ClientSecretRef: corev1.SecretKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{Name: ""},
+				},
+			},
+			expectError: true,
+			description: "should fail when all required fields are empty",
 		},
 		{
 			name:        "IntegratedOAuth mode",

--- a/internal/controller/status/status.go
+++ b/internal/controller/status/status.go
@@ -165,6 +165,9 @@ const (
 	AuthProxyFailedCallbackRouteMessage      = "Failed to create auth callback route"
 	AuthProxyFailedGenerateSecretMessage     = "Failed to generate client secret"
 	AuthProxyOIDCModeWithoutConfigMessage    = "Cluster is in OIDC mode but GatewayConfig has no OIDC configuration"
+	AuthProxyOIDCClientIDEmptyMessage        = "OIDC clientID cannot be empty"
+	AuthProxyOIDCIssuerURLEmptyMessage       = "OIDC issuerURL cannot be empty"
+	AuthProxyOIDCSecretRefNameEmptyMessage   = "OIDC clientSecretRef.name cannot be empty" //nolint:gosec // This is an error message, not a credential
 	AuthProxyExternalAuthNoDeploymentMessage = "Cluster uses external authentication, no gateway auth proxy deployed"
 )
 


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->
  Adds validation to reject empty OIDC configuration fields (clientID, issuerURL,
  clientSecretRef.name) before gateway deployment. Previously, the gateway would
  deploy successfully with empty credentials, causing authentication failures. Now
   returns a clear error message listing all invalid fields.

<!--- Link your JIRA and related links here for reference. -->
JIRA: [RHOAIENG-36397](https://issues.redhat.com/browse/RHOAIENG-36397)
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->
extended tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * OIDC auth validation now enforces and checks ClientID, issuer URL, and secret reference individually, returning clear, field-specific error messages when configuration is incomplete.
* **Tests**
  * Expanded test coverage for OIDC validation to include a valid config and multiple negative cases for missing fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->