### PR TITLE
Fix e2e resilience test to work also for rhoai

### DIFF
--- a/tests/e2e/helper_test.go
+++ b/tests/e2e/helper_test.go
@@ -425,6 +425,10 @@ func ParseTestFlags() error {
 // getControllerDeploymentName returns deployment name based on platform.
 func (tc *TestContext) getControllerDeploymentName() string {
 	platform := tc.FetchPlatformRelease()
+	return getControllerDeploymentNameByPlatform(platform)
+}
+
+func getControllerDeploymentNameByPlatform(platform common.Platform) string {
 	switch platform {
 	case cluster.SelfManagedRhoai, cluster.ManagedRhoai:
 		return controllerDeploymentRhoai

--- a/tests/e2e/resilience_test.go
+++ b/tests/e2e/resilience_test.go
@@ -191,8 +191,8 @@ func (tc *OperatorResilienceTestCtx) ValidateComponentsDeploymentFailure(t *test
 		WithMinimalObject(gvk.DataScienceCluster, tc.DataScienceClusterNamespacedName),
 		WithCondition(
 			jq.Match(
-				`any(.status.conditions[]; 
-            .type == "%s" and .status == "%s" and 
+				`any(.status.conditions[];
+            .type == "%s" and .status == "%s" and
             (.message as $msg | %s | all(.[]; ($msg | contains(.)))))`,
 				status.ConditionTypeComponentsReady,
 				metav1.ConditionFalse,
@@ -260,17 +260,17 @@ func (tc *OperatorResilienceTestCtx) ValidateMissingComponentsCRDHandling(t *tes
 	tc.EnsureResourceExists(
 		WithMinimalObject(gvk.DataScienceCluster, tc.DataScienceClusterNamespacedName),
 		WithCondition(And(
-			jq.Match(`.status.conditions[] 
-			| select(.type == "%s") 
+			jq.Match(`.status.conditions[]
+			| select(.type == "%s")
 			| .status == "%s"`, "Ready", metav1.ConditionFalse),
-			jq.Match(`.status.conditions[] 
-			| select(.type == "%s") 
+			jq.Match(`.status.conditions[]
+			| select(.type == "%s")
 			| .status == "%s"`, "ProvisioningSucceeded", metav1.ConditionFalse),
-			jq.Match(`.status.conditions[] 
-			| select(.type == "%s") 
+			jq.Match(`.status.conditions[]
+			| select(.type == "%s")
 			| .status == "%s"`, "ComponentsReady", metav1.ConditionFalse),
-			jq.Match(`.status.conditions[] 
-			| select(.type == "%s") 
+			jq.Match(`.status.conditions[]
+			| select(.type == "%s")
 			| .status == "%s"`, componentKind+"Ready", metav1.ConditionFalse),
 		)),
 		WithCustomErrorMsg("DSC should be unhealthy due to missing CRD"),
@@ -298,8 +298,13 @@ func (tc *OperatorResilienceTestCtx) ValidateRBACRestrictionHandling(t *testing.
 	// Get the predictable ServiceAccount name based on deployment name
 	deploymentName := tc.getControllerDeploymentName()
 
+	operatorDeployment := tc.FetchResource(
+		WithMinimalObject(gvk.Deployment, types.NamespacedName{Namespace: tc.OperatorNamespace, Name: tc.getControllerDeploymentName()}),
+	)
+	tc.g.Expect(operatorDeployment).NotTo(BeNil(), "Operator deployment not found")
+
 	// Find the ClusterRoleBinding that references our ServiceAccount
-	crbBackups, crbNames := tc.findAndBackupAllCRBsForServiceAccount(deploymentName)
+	crbBackups, crbNames := tc.findAndBackupAllCRBsForServiceAccount(operatorDeployment)
 	if len(crbBackups) == 0 {
 		t.Fatalf("No ClusterRoleBinding found for ServiceAccount %s", deploymentName)
 	}
@@ -313,10 +318,9 @@ func (tc *OperatorResilienceTestCtx) ValidateRBACRestrictionHandling(t *testing.
 		tc.DeleteResource(WithMinimalObject(gvk.ClusterRoleBinding, types.NamespacedName{Name: crbName}))
 	}
 
-	// Extract the operator name from deployment name
-	// e.g., "opendatahub-operator-controller-manager" -> "opendatahub-operator"
-	// or "rhods-operator-controller-manager" -> "rhods-operator"
-	operatorName := strings.TrimSuffix(deploymentName, "-controller-manager")
+	// Extract the pods label name from operator deployment labels
+	operatorName, ok := operatorDeployment.GetLabels()["name"]
+	tc.g.Expect(ok).To(BeTrue(), "name not found in operator deployment")
 
 	// Delete the Operator Pods individually (API doesn't support bulk pod deletion)
 	t.Log("Deleting operator Pods to force a restart")
@@ -327,8 +331,7 @@ func (tc *OperatorResilienceTestCtx) ValidateRBACRestrictionHandling(t *testing.
 		WithListOptions(&client.ListOptions{
 			Namespace: tc.OperatorNamespace,
 			LabelSelector: labels.SelectorFromSet(map[string]string{
-				"control-plane": "controller-manager",
-				"name":          operatorName,
+				"name": operatorName,
 			}),
 		}),
 	)
@@ -524,10 +527,14 @@ func updateAllComponentsTransform(components []string, state operatorv1.Manageme
 }
 
 // findAndBackupAllCRBsForServiceAccount finds all ClusterRoleBindings referencing the given ServiceAccount and returns backup copies with their names.
-func (tc *OperatorResilienceTestCtx) findAndBackupAllCRBsForServiceAccount(expectedSAName string) ([]*unstructured.Unstructured, []string) {
+func (tc *OperatorResilienceTestCtx) findAndBackupAllCRBsForServiceAccount(operatorDeployment *unstructured.Unstructured) ([]*unstructured.Unstructured, []string) {
 	crbs := tc.FetchResources(
 		WithMinimalObject(gvk.ClusterRoleBinding, types.NamespacedName{}),
 	)
+
+	saName, ok, err := unstructured.NestedString(operatorDeployment.Object, "spec", "template", "spec", "serviceAccountName")
+	tc.g.Expect(err).NotTo(HaveOccurred(), "Failed to get serviceAccountName from operator deployment")
+	tc.g.Expect(ok).To(BeTrue(), "serviceAccountName not found in operator deployment")
 
 	var crbBackups []*unstructured.Unstructured
 	var crbNames []string
@@ -555,7 +562,7 @@ func (tc *OperatorResilienceTestCtx) findAndBackupAllCRBsForServiceAccount(expec
 				continue
 			}
 
-			if name, _ := subj["name"].(string); name == expectedSAName {
+			if name, _ := subj["name"].(string); name == saName {
 				crbNames = append(crbNames, obj.GetName())
 				crbBackups = append(crbBackups, resources.StripServerMetadata(&obj))
 				break


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
Fix `TestOdhOperator/Operator_Resilience_E2E_Tests/Validate_RBAC_restriction_handling` to be more resilient, and work also in rhoai.

Also, fix a debug problem running in rhoai, which points to the ODH operator name instead of the correct one.

Jira task: http://issues.redhat.com/browse/RHOAIENG-36390

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [x] The developer has run the integration test pipeline and verified that it passed successfully

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test utilities for more reliable resource detection and platform-aware configuration.
  * Refined resilience tests to derive operator identity from live deployments, strengthening RBAC and pod-targeting checks.
  * Enhanced diagnostic and error-handling in end-to-end tests for more robust validation and clearer failure signals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->