### PR TITLE
fix: fixed quotes for HWP visibility annotation

### DIFF
--- a/pkg/upgrade/upgrade.go
+++ b/pkg/upgrade/upgrade.go
@@ -878,7 +878,7 @@ func CreateCustomServingHardwareProfile(ctx context.Context, cli client.Client, 
 				Name:      "custom-serving",
 				Namespace: namespace,
 				Annotations: map[string]string{
-					"opendatahub.io/dashboard-feature-visibility": "['model-serving']",
+					"opendatahub.io/dashboard-feature-visibility": `["model-serving"]`,
 					"opendatahub.io/modified-date":                time.Now().Format(time.RFC3339),
 					"opendatahub.io/display-name":                 "custom-serving",
 					"opendatahub.io/description":                  "",

--- a/pkg/upgrade/upgrade_test.go
+++ b/pkg/upgrade/upgrade_test.go
@@ -565,9 +565,9 @@ func validateAcceleratorProfileHardwareProfile(g *WithT, hwp *infrav1.HardwarePr
 	annotations := hwp.GetAnnotations()
 	g.Expect(annotations).ToNot(BeNil())
 	g.Expect(annotations).To(HaveKey("opendatahub.io/dashboard-feature-visibility"))
-	expectedVisibility := "['model-serving']"
+	expectedVisibility := `["model-serving"]`
 	if profileType == notebooksProfileType {
-		expectedVisibility = "['workbench']"
+		expectedVisibility = `["workbench"]`
 	}
 	g.Expect(annotations["opendatahub.io/dashboard-feature-visibility"]).To(Equal(expectedVisibility))
 	g.Expect(annotations).To(HaveKey("opendatahub.io/modified-date"))
@@ -752,9 +752,9 @@ func validateContainerSizeHardwareProfile(g *WithT, hwp *infrav1.HardwareProfile
 	annotations := hwp.GetAnnotations()
 	g.Expect(annotations).ToNot(BeNil())
 	g.Expect(annotations).To(HaveKey("opendatahub.io/dashboard-feature-visibility"))
-	expectedVisibility := "['model-serving']"
+	expectedVisibility := `["model-serving"]`
 	if sizeType == notebooksProfileType {
-		expectedVisibility = "['workbench']"
+		expectedVisibility = `["workbench"]`
 	}
 	g.Expect(annotations["opendatahub.io/dashboard-feature-visibility"]).To(Equal(expectedVisibility))
 	g.Expect(annotations).To(HaveKey("opendatahub.io/modified-date"))

--- a/pkg/upgrade/upgrade_utils.go
+++ b/pkg/upgrade/upgrade_utils.go
@@ -559,9 +559,9 @@ func generateHardwareProfileFromContainerSize(ctx context.Context, size Containe
 // getFeatureVisibility returns the dashboard feature visibility string for a profile type.
 func getFeatureVisibility(profileType string) string {
 	if profileType == serving {
-		return "['model-serving']"
+		return `["model-serving"]`
 	}
-	return "['workbench']"
+	return `["workbench"]`
 }
 
 // getNotebooks retrieves all Notebook resources in the given namespace.


### PR DESCRIPTION
## Description
JIRA: [RHOAIENG-33158](https://issues.redhat.com/browse/RHOAIENG-33158) and [RHOAIENG-33159](https://issues.redhat.com/browse/RHOAIENG-33159)

This PR fixes the `opendatahub.io/dashboard-feature-visibility` annotation on all HWPs which was previously set to `opendatahub.io/dashboard-feature-visibility: '[''model-serving'']'` when it should be set to `opendatahub.io/dashboard-feature-visibility: '["model-serving"]'`. The incorrect value was using 2 single quotes `'` instead of 1 double quote `"`.

## How Has This Been Tested?
Tested the changes manually on local cluster.

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [X] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [X] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work
- [X] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [X] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
Minor annotation change. I updated unit tests accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Corrected hardware profile feature visibility annotations to use valid JSON syntax.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->