### PR TITLE
Remove installedComponents field from DataScienceCluster v2 API

### DIFF
--- a/api/datasciencecluster/v2/datasciencecluster_types.go
+++ b/api/datasciencecluster/v2/datasciencecluster_types.go
@@ -111,9 +111,6 @@ type DataScienceClusterStatus struct {
 	RelatedObjects []corev1.ObjectReference `json:"relatedObjects,omitempty"`
 	ErrorMessage   string                   `json:"errorMessage,omitempty"`
 
-	// List of components with status if installed or not
-	InstalledComponents map[string]bool `json:"installedComponents,omitempty"`
-
 	// Expose component's specific status
 	// +optional
 	Components ComponentsStatus `json:"components"`

--- a/api/datasciencecluster/v2/zz_generated.deepcopy.go
+++ b/api/datasciencecluster/v2/zz_generated.deepcopy.go
@@ -161,13 +161,6 @@ func (in *DataScienceClusterStatus) DeepCopyInto(out *DataScienceClusterStatus) 
 		*out = make([]v1.ObjectReference, len(*in))
 		copy(*out, *in)
 	}
-	if in.InstalledComponents != nil {
-		in, out := &in.InstalledComponents, &out.InstalledComponents
-		*out = make(map[string]bool, len(*in))
-		for key, val := range *in {
-			(*out)[key] = val
-		}
-	}
 	in.Components.DeepCopyInto(&out.Components)
 	in.Release.DeepCopyInto(&out.Release)
 }

--- a/bundle/manifests/datasciencecluster.opendatahub.io_datascienceclusters.yaml
+++ b/bundle/manifests/datasciencecluster.opendatahub.io_datascienceclusters.yaml
@@ -1797,11 +1797,6 @@ spec:
                 x-kubernetes-list-type: atomic
               errorMessage:
                 type: string
-              installedComponents:
-                additionalProperties:
-                  type: boolean
-                description: List of components with status if installed or not
-                type: object
               observedGeneration:
                 description: The generation observed by the resource controller.
                 format: int64

--- a/bundle/manifests/opendatahub-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/opendatahub-operator.clusterserviceversion.yaml
@@ -83,7 +83,7 @@ metadata:
     categories: AI/Machine Learning, Big Data
     certified: "False"
     containerImage: quay.io/opendatahub/opendatahub-operator:v3.0.0
-    createdAt: "2025-10-17T07:33:27Z"
+    createdAt: "2025-10-17T15:44:33Z"
     operators.operatorframework.io/builder: operator-sdk-v1.39.2
     operators.operatorframework.io/internal-objects: '["featuretrackers.features.opendatahub.io",
       "dashboards.components.platform.opendatahub.io", "datasciencepipelines.components.platform.opendatahub.io",

--- a/cmd/component-codegen/templates/component_handler.go.tmpl
+++ b/cmd/component-codegen/templates/component_handler.go.tmpl
@@ -75,7 +75,6 @@ func (s *componentHandler) UpdateDSCStatus(ctx context.Context, rr *types.Reconc
 		return cs, errors.New("failed to convert to DataScienceCluster")
 	}
 
-	dsc.Status.InstalledComponents[LegacyComponentName] = false
 	dsc.Status.Components.{{ .Component }}.ManagementSpec.ManagementState = s.GetManagementState(dsc)
 	dsc.Status.Components.{{ .Component }}.{{ .Component }}CommonStatus = nil
 
@@ -83,7 +82,6 @@ func (s *componentHandler) UpdateDSCStatus(ctx context.Context, rr *types.Reconc
 
 	switch s.GetManagementState(dsc) {
 	case operatorv1.Managed:
-		dsc.Status.InstalledComponents[LegacyComponentName] = true
 		dsc.Status.Components.{{ .Component }}.{{ .Component }}CommonStatus = c.Status.{{ .Component }}CommonStatus.DeepCopy()
 
 		if rc := conditions.FindStatusCondition(c.GetStatus(), status.ConditionTypeReady); rc != nil {

--- a/config/crd/bases/datasciencecluster.opendatahub.io_datascienceclusters.yaml
+++ b/config/crd/bases/datasciencecluster.opendatahub.io_datascienceclusters.yaml
@@ -1786,11 +1786,6 @@ spec:
                 x-kubernetes-list-type: atomic
               errorMessage:
                 type: string
-              installedComponents:
-                additionalProperties:
-                  type: boolean
-                description: List of components with status if installed or not
-                type: object
               observedGeneration:
                 description: The generation observed by the resource controller.
                 format: int64

--- a/docs/api-overview.md
+++ b/docs/api-overview.md
@@ -1879,7 +1879,6 @@ _Appears in:_
 | `conditions` _[Condition](#condition) array_ |  |  |  |
 | `relatedObjects` _[ObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#objectreference-v1-core) array_ | RelatedObjects is a list of objects created and maintained by this operator.<br />Object references will be added to this list after they have been created AND found in the cluster. |  |  |
 | `errorMessage` _string_ |  |  |  |
-| `installedComponents` _object (keys:string, values:boolean)_ | List of components with status if installed or not |  |  |
 | `components` _[ComponentsStatus](#componentsstatus)_ | Expose component's specific status |  |  |
 | `release` _[Release](#release)_ | Version and release type |  |  |
 

--- a/internal/controller/components/dashboard/dashboard.go
+++ b/internal/controller/components/dashboard/dashboard.go
@@ -86,14 +86,12 @@ func (s *componentHandler) UpdateDSCStatus(ctx context.Context, rr *types.Reconc
 
 	ms := components.NormalizeManagementState(dsc.Spec.Components.Dashboard.ManagementState)
 
-	dsc.Status.InstalledComponents[LegacyComponentNameUpstream] = false
 	dsc.Status.Components.Dashboard.ManagementState = ms
 	dsc.Status.Components.Dashboard.DashboardCommonStatus = nil
 
 	rr.Conditions.MarkFalse(ReadyConditionType)
 
 	if s.IsEnabled(dsc) {
-		dsc.Status.InstalledComponents[LegacyComponentNameUpstream] = true
 		dsc.Status.Components.Dashboard.DashboardCommonStatus = c.Status.DashboardCommonStatus.DeepCopy()
 
 		if rc := conditions.FindStatusCondition(c.GetStatus(), status.ConditionTypeReady); rc != nil {

--- a/internal/controller/components/dashboard/dashboard_test.go
+++ b/internal/controller/components/dashboard/dashboard_test.go
@@ -115,7 +115,6 @@ func TestUpdateDSCStatus(t *testing.T) {
 		g.Expect(cs).Should(Equal(metav1.ConditionTrue))
 
 		g.Expect(dsc).Should(WithTransform(json.Marshal, And(
-			jq.Match(`.status.installedComponents."%s" == true`, LegacyComponentNameUpstream),
 			jq.Match(`.status.components.dashboard.managementState == "%s"`, operatorv1.Managed),
 			jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, ReadyConditionType, metav1.ConditionTrue),
 			jq.Match(`.status.conditions[] | select(.type == "%s") | .reason == "%s"`, ReadyConditionType, status.ReadyReason),
@@ -143,7 +142,6 @@ func TestUpdateDSCStatus(t *testing.T) {
 		g.Expect(cs).Should(Equal(metav1.ConditionFalse))
 
 		g.Expect(dsc).Should(WithTransform(json.Marshal, And(
-			jq.Match(`.status.installedComponents."%s" == true`, LegacyComponentNameUpstream),
 			jq.Match(`.status.components.dashboard.managementState == "%s"`, operatorv1.Managed),
 			jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, ReadyConditionType, metav1.ConditionFalse),
 			jq.Match(`.status.conditions[] | select(.type == "%s") | .reason == "%s"`, ReadyConditionType, status.NotReadyReason),
@@ -170,7 +168,6 @@ func TestUpdateDSCStatus(t *testing.T) {
 		g.Expect(cs).Should(Equal(metav1.ConditionUnknown))
 
 		g.Expect(dsc).Should(WithTransform(json.Marshal, And(
-			jq.Match(`.status.installedComponents."%s" == false`, LegacyComponentNameUpstream),
 			jq.Match(`.status.components.dashboard.managementState == "%s"`, operatorv1.Removed),
 			jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, ReadyConditionType, metav1.ConditionFalse),
 			jq.Match(`.status.conditions[] | select(.type == "%s") | .reason == "%s"`, ReadyConditionType, operatorv1.Removed),
@@ -197,7 +194,6 @@ func TestUpdateDSCStatus(t *testing.T) {
 		g.Expect(cs).Should(Equal(metav1.ConditionUnknown))
 
 		g.Expect(dsc).Should(WithTransform(json.Marshal, And(
-			jq.Match(`.status.installedComponents."%s" == false`, LegacyComponentNameUpstream),
 			jq.Match(`.status.components.dashboard.managementState == "%s"`, operatorv1.Removed),
 			jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, ReadyConditionType, metav1.ConditionFalse),
 			jq.Match(`.status.conditions[] | select(.type == "%s") | .reason == "%s"`, ReadyConditionType, operatorv1.Removed),
@@ -327,7 +323,6 @@ func createDSCWithDashboard(managementState operatorv1.ManagementState) *dscv2.D
 	dsc.SetName("test-dsc")
 
 	dsc.Spec.Components.Dashboard.ManagementState = managementState
-	dsc.Status.InstalledComponents = make(map[string]bool)
 
 	return &dsc
 }

--- a/internal/controller/components/datasciencepipelines/datasciencepipelines.go
+++ b/internal/controller/components/datasciencepipelines/datasciencepipelines.go
@@ -87,14 +87,12 @@ func (s *componentHandler) UpdateDSCStatus(ctx context.Context, rr *types.Reconc
 
 	ms := components.NormalizeManagementState(dsc.Spec.Components.AIPipelines.ManagementState)
 
-	dsc.Status.InstalledComponents[InstalledComponentName] = false
 	dsc.Status.Components.AIPipelines.ManagementState = ms
 	dsc.Status.Components.AIPipelines.DataSciencePipelinesCommonStatus = nil
 
 	rr.Conditions.MarkFalse(ReadyConditionType)
 
 	if s.IsEnabled(dsc) {
-		dsc.Status.InstalledComponents[InstalledComponentName] = true
 		dsc.Status.Components.AIPipelines.DataSciencePipelinesCommonStatus = c.Status.DataSciencePipelinesCommonStatus.DeepCopy()
 
 		if rc := conditions.FindStatusCondition(c.GetStatus(), status.ConditionTypeReady); rc != nil {

--- a/internal/controller/components/datasciencepipelines/datasciencepipelines_support.go
+++ b/internal/controller/components/datasciencepipelines/datasciencepipelines_support.go
@@ -25,10 +25,6 @@ const (
 	// deployment to the new component name, so keep it around till we figure out a solution.
 	LegacyComponentName = "data-science-pipelines-operator"
 
-	// InstalledComponentName is the name used for tracking installation status in DSC.
-	// This reflects the new component name (aipipelines) for status reporting.
-	InstalledComponentName = "aipipelines"
-
 	platformVersionParamsKey          = "PLATFORMVERSION"
 	fipsEnabledParamsKey              = "FIPSENABLED"
 	argoWorkflowsControllersParamsKey = "ARGOWORKFLOWSCONTROLLERS"

--- a/internal/controller/components/datasciencepipelines/datasciencepipelines_test.go
+++ b/internal/controller/components/datasciencepipelines/datasciencepipelines_test.go
@@ -111,7 +111,6 @@ func TestUpdateDSCStatus(t *testing.T) {
 		g.Expect(cs).Should(Equal(metav1.ConditionTrue))
 
 		g.Expect(dsc).Should(WithTransform(json.Marshal, And(
-			jq.Match(`.status.installedComponents."%s" == true`, InstalledComponentName),
 			jq.Match(`.status.components.aipipelines.managementState == "%s"`, operatorv1.Managed),
 			jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, ReadyConditionType, metav1.ConditionTrue),
 			jq.Match(`.status.conditions[] | select(.type == "%s") | .reason == "%s"`, ReadyConditionType, status.ReadyReason),
@@ -139,7 +138,6 @@ func TestUpdateDSCStatus(t *testing.T) {
 		g.Expect(cs).Should(Equal(metav1.ConditionFalse))
 
 		g.Expect(dsc).Should(WithTransform(json.Marshal, And(
-			jq.Match(`.status.installedComponents."%s" == true`, InstalledComponentName),
 			jq.Match(`.status.components.aipipelines.managementState == "%s"`, operatorv1.Managed),
 			jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, ReadyConditionType, metav1.ConditionFalse),
 			jq.Match(`.status.conditions[] | select(.type == "%s") | .reason == "%s"`, ReadyConditionType, status.NotReadyReason),
@@ -166,7 +164,6 @@ func TestUpdateDSCStatus(t *testing.T) {
 		g.Expect(cs).Should(Equal(metav1.ConditionUnknown))
 
 		g.Expect(dsc).Should(WithTransform(json.Marshal, And(
-			jq.Match(`.status.installedComponents."%s" == false`, InstalledComponentName),
 			jq.Match(`.status.components.aipipelines.managementState == "%s"`, operatorv1.Removed),
 			jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, ReadyConditionType, metav1.ConditionFalse),
 			jq.Match(`.status.conditions[] | select(.type == "%s") | .reason == "%s"`, ReadyConditionType, operatorv1.Removed),
@@ -193,7 +190,6 @@ func TestUpdateDSCStatus(t *testing.T) {
 		g.Expect(cs).Should(Equal(metav1.ConditionUnknown))
 
 		g.Expect(dsc).Should(WithTransform(json.Marshal, And(
-			jq.Match(`.status.installedComponents."%s" == false`, InstalledComponentName),
 			jq.Match(`.status.components.aipipelines.managementState == "%s"`, operatorv1.Removed),
 			jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, ReadyConditionType, metav1.ConditionFalse),
 			jq.Match(`.status.conditions[] | select(.type == "%s") | .reason == "%s"`, ReadyConditionType, operatorv1.Removed),
@@ -209,7 +205,6 @@ func createDSCWithDataSciencePipelines(managementState operatorv1.ManagementStat
 	dsc.SetName("test-dsc")
 
 	dsc.Spec.Components.AIPipelines.ManagementState = managementState
-	dsc.Status.InstalledComponents = make(map[string]bool)
 
 	return &dsc
 }

--- a/internal/controller/components/feastoperator/feastoperator.go
+++ b/internal/controller/components/feastoperator/feastoperator.go
@@ -79,14 +79,12 @@ func (s *componentHandler) UpdateDSCStatus(ctx context.Context, rr *types.Reconc
 
 	ms := components.NormalizeManagementState(dsc.Spec.Components.FeastOperator.ManagementState)
 
-	dsc.Status.InstalledComponents[ComponentName] = false
 	dsc.Status.Components.FeastOperator.ManagementState = ms
 	dsc.Status.Components.FeastOperator.FeastOperatorCommonStatus = nil
 
 	rr.Conditions.MarkFalse(ReadyConditionType)
 
 	if s.IsEnabled(dsc) {
-		dsc.Status.InstalledComponents[ComponentName] = true
 		dsc.Status.Components.FeastOperator.FeastOperatorCommonStatus = c.Status.FeastOperatorCommonStatus.DeepCopy()
 
 		if rc := conditions.FindStatusCondition(c.GetStatus(), status.ConditionTypeReady); rc != nil {

--- a/internal/controller/components/feastoperator/feastoperator_test.go
+++ b/internal/controller/components/feastoperator/feastoperator_test.go
@@ -111,7 +111,6 @@ func TestUpdateDSCStatus(t *testing.T) {
 		g.Expect(cs).Should(Equal(metav1.ConditionTrue))
 
 		g.Expect(dsc).Should(WithTransform(json.Marshal, And(
-			jq.Match(`.status.installedComponents."%s" == true`, ComponentName),
 			jq.Match(`.status.components.feastoperator.managementState == "%s"`, operatorv1.Managed),
 			jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, ReadyConditionType, metav1.ConditionTrue),
 			jq.Match(`.status.conditions[] | select(.type == "%s") | .reason == "%s"`, ReadyConditionType, status.ReadyReason),
@@ -139,7 +138,6 @@ func TestUpdateDSCStatus(t *testing.T) {
 		g.Expect(cs).Should(Equal(metav1.ConditionFalse))
 
 		g.Expect(dsc).Should(WithTransform(json.Marshal, And(
-			jq.Match(`.status.installedComponents."%s" == true`, ComponentName),
 			jq.Match(`.status.components.feastoperator.managementState == "%s"`, operatorv1.Managed),
 			jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, ReadyConditionType, metav1.ConditionFalse),
 			jq.Match(`.status.conditions[] | select(.type == "%s") | .reason == "%s"`, ReadyConditionType, status.NotReadyReason),
@@ -166,7 +164,6 @@ func TestUpdateDSCStatus(t *testing.T) {
 		g.Expect(cs).Should(Equal(metav1.ConditionUnknown))
 
 		g.Expect(dsc).Should(WithTransform(json.Marshal, And(
-			jq.Match(`.status.installedComponents."%s" == false`, ComponentName),
 			jq.Match(`.status.components.feastoperator.managementState == "%s"`, operatorv1.Removed),
 			jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, ReadyConditionType, metav1.ConditionFalse),
 			jq.Match(`.status.conditions[] | select(.type == "%s") | .reason == "%s"`, ReadyConditionType, operatorv1.Removed),
@@ -193,7 +190,6 @@ func TestUpdateDSCStatus(t *testing.T) {
 		g.Expect(cs).Should(Equal(metav1.ConditionUnknown))
 
 		g.Expect(dsc).Should(WithTransform(json.Marshal, And(
-			jq.Match(`.status.installedComponents."%s" == false`, ComponentName),
 			jq.Match(`.status.components.feastoperator.managementState == "%s"`, operatorv1.Removed),
 			jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, ReadyConditionType, metav1.ConditionFalse),
 			jq.Match(`.status.conditions[] | select(.type == "%s") | .reason == "%s"`, ReadyConditionType, operatorv1.Removed),
@@ -209,7 +205,6 @@ func createDSCWithFeastOperator(managementState operatorv1.ManagementState) *dsc
 	dsc.SetName("test-dsc")
 
 	dsc.Spec.Components.FeastOperator.ManagementState = managementState
-	dsc.Status.InstalledComponents = make(map[string]bool)
 
 	return &dsc
 }

--- a/internal/controller/components/kserve/kserve.go
+++ b/internal/controller/components/kserve/kserve.go
@@ -101,14 +101,12 @@ func (s *componentHandler) UpdateDSCStatus(ctx context.Context, rr *types.Reconc
 
 	ms := components.NormalizeManagementState(dsc.Spec.Components.Kserve.ManagementState)
 
-	dsc.Status.InstalledComponents[LegacyComponentName] = false
 	dsc.Status.Components.Kserve.ManagementState = ms
 	dsc.Status.Components.Kserve.KserveCommonStatus = nil
 
 	rr.Conditions.MarkFalse(ReadyConditionType)
 
 	if s.IsEnabled(dsc) {
-		dsc.Status.InstalledComponents[LegacyComponentName] = true
 		dsc.Status.Components.Kserve.KserveCommonStatus = c.Status.KserveCommonStatus.DeepCopy()
 
 		if rc := conditions.FindStatusCondition(c.GetStatus(), status.ConditionTypeReady); rc != nil {

--- a/internal/controller/components/kserve/kserve_test.go
+++ b/internal/controller/components/kserve/kserve_test.go
@@ -111,7 +111,6 @@ func TestUpdateDSCStatus(t *testing.T) {
 		g.Expect(cs).Should(Equal(metav1.ConditionTrue))
 
 		g.Expect(dsc).Should(WithTransform(json.Marshal, And(
-			jq.Match(`.status.installedComponents."%s" == true`, LegacyComponentName),
 			jq.Match(`.status.components.kserve.managementState == "%s"`, operatorv1.Managed),
 			jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, ReadyConditionType, metav1.ConditionTrue),
 			jq.Match(`.status.conditions[] | select(.type == "%s") | .reason == "%s"`, ReadyConditionType, status.ReadyReason),
@@ -139,7 +138,6 @@ func TestUpdateDSCStatus(t *testing.T) {
 		g.Expect(cs).Should(Equal(metav1.ConditionFalse))
 
 		g.Expect(dsc).Should(WithTransform(json.Marshal, And(
-			jq.Match(`.status.installedComponents."%s" == true`, LegacyComponentName),
 			jq.Match(`.status.components.kserve.managementState == "%s"`, operatorv1.Managed),
 			jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, ReadyConditionType, metav1.ConditionFalse),
 			jq.Match(`.status.conditions[] | select(.type == "%s") | .reason == "%s"`, ReadyConditionType, status.NotReadyReason),
@@ -166,7 +164,6 @@ func TestUpdateDSCStatus(t *testing.T) {
 		g.Expect(cs).Should(Equal(metav1.ConditionUnknown))
 
 		g.Expect(dsc).Should(WithTransform(json.Marshal, And(
-			jq.Match(`.status.installedComponents."%s" == false`, LegacyComponentName),
 			jq.Match(`.status.components.kserve.managementState == "%s"`, operatorv1.Removed),
 			jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, ReadyConditionType, metav1.ConditionFalse),
 			jq.Match(`.status.conditions[] | select(.type == "%s") | .reason == "%s"`, ReadyConditionType, operatorv1.Removed),
@@ -193,7 +190,6 @@ func TestUpdateDSCStatus(t *testing.T) {
 		g.Expect(cs).Should(Equal(metav1.ConditionUnknown))
 
 		g.Expect(dsc).Should(WithTransform(json.Marshal, And(
-			jq.Match(`.status.installedComponents."%s" == false`, LegacyComponentName),
 			jq.Match(`.status.components.kserve.managementState == "%s"`, operatorv1.Removed),
 			jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, ReadyConditionType, metav1.ConditionFalse),
 			jq.Match(`.status.conditions[] | select(.type == "%s") | .reason == "%s"`, ReadyConditionType, operatorv1.Removed),
@@ -209,7 +205,6 @@ func createDSCWithKserve(managementState operatorv1.ManagementState) *dscv2.Data
 	dsc.SetName("test-dsc")
 
 	dsc.Spec.Components.Kserve.ManagementState = managementState
-	dsc.Status.InstalledComponents = make(map[string]bool)
 
 	return &dsc
 }

--- a/internal/controller/components/kueue/kueue.go
+++ b/internal/controller/components/kueue/kueue.go
@@ -100,14 +100,12 @@ func (s *componentHandler) UpdateDSCStatus(ctx context.Context, rr *types.Reconc
 
 	ms := components.NormalizeManagementState(dsc.Spec.Components.Kueue.ManagementState)
 
-	dsc.Status.InstalledComponents[LegacyComponentName] = false
 	dsc.Status.Components.Kueue.ManagementState = ms
 	dsc.Status.Components.Kueue.KueueCommonStatus = nil
 
 	rr.Conditions.MarkFalse(ReadyConditionType)
 
 	if s.IsEnabled(dsc) {
-		dsc.Status.InstalledComponents[LegacyComponentName] = true
 		dsc.Status.Components.Kueue.KueueCommonStatus = c.Status.KueueCommonStatus.DeepCopy()
 
 		if rc := conditions.FindStatusCondition(c.GetStatus(), status.ConditionTypeReady); rc != nil {

--- a/internal/controller/components/kueue/kueue_test.go
+++ b/internal/controller/components/kueue/kueue_test.go
@@ -111,7 +111,6 @@ func TestUpdateDSCStatus(t *testing.T) {
 		g.Expect(cs).Should(Equal(metav1.ConditionTrue))
 
 		g.Expect(dsc).Should(WithTransform(json.Marshal, And(
-			jq.Match(`.status.installedComponents."%s" == true`, LegacyComponentName),
 			jq.Match(`.status.components.kueue.managementState == "%s"`, operatorv1.Managed),
 			jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, ReadyConditionType, metav1.ConditionTrue),
 			jq.Match(`.status.conditions[] | select(.type == "%s") | .reason == "%s"`, ReadyConditionType, status.ReadyReason),
@@ -139,7 +138,6 @@ func TestUpdateDSCStatus(t *testing.T) {
 		g.Expect(cs).Should(Equal(metav1.ConditionTrue))
 
 		g.Expect(dsc).Should(WithTransform(json.Marshal, And(
-			jq.Match(`.status.installedComponents."%s" == true`, LegacyComponentName),
 			jq.Match(`.status.components.kueue.managementState == "%s"`, operatorv1.Unmanaged),
 			jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, ReadyConditionType, metav1.ConditionTrue),
 			jq.Match(`.status.conditions[] | select(.type == "%s") | .reason == "%s"`, ReadyConditionType, status.ReadyReason),
@@ -167,7 +165,6 @@ func TestUpdateDSCStatus(t *testing.T) {
 		g.Expect(cs).Should(Equal(metav1.ConditionFalse))
 
 		g.Expect(dsc).Should(WithTransform(json.Marshal, And(
-			jq.Match(`.status.installedComponents."%s" == true`, LegacyComponentName),
 			jq.Match(`.status.components.kueue.managementState == "%s"`, operatorv1.Managed),
 			jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, ReadyConditionType, metav1.ConditionFalse),
 			jq.Match(`.status.conditions[] | select(.type == "%s") | .reason == "%s"`, ReadyConditionType, status.NotReadyReason),
@@ -194,7 +191,6 @@ func TestUpdateDSCStatus(t *testing.T) {
 		g.Expect(cs).Should(Equal(metav1.ConditionUnknown))
 
 		g.Expect(dsc).Should(WithTransform(json.Marshal, And(
-			jq.Match(`.status.installedComponents."%s" == false`, LegacyComponentName),
 			jq.Match(`.status.components.kueue.managementState == "%s"`, operatorv1.Removed),
 			jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, ReadyConditionType, metav1.ConditionFalse),
 			jq.Match(`.status.conditions[] | select(.type == "%s") | .reason == "%s"`, ReadyConditionType, operatorv1.Removed),
@@ -221,7 +217,6 @@ func TestUpdateDSCStatus(t *testing.T) {
 		g.Expect(cs).Should(Equal(metav1.ConditionUnknown))
 
 		g.Expect(dsc).Should(WithTransform(json.Marshal, And(
-			jq.Match(`.status.installedComponents."%s" == false`, LegacyComponentName),
 			jq.Match(`.status.components.kueue.managementState == "%s"`, operatorv1.Removed),
 			jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, ReadyConditionType, metav1.ConditionFalse),
 			jq.Match(`.status.conditions[] | select(.type == "%s") | .reason == "%s"`, ReadyConditionType, operatorv1.Removed),
@@ -237,7 +232,6 @@ func createDSCWithKueue(managementState operatorv1.ManagementState) *dscv2.DataS
 	dsc.SetName("test-dsc")
 
 	dsc.Spec.Components.Kueue.ManagementState = managementState
-	dsc.Status.InstalledComponents = make(map[string]bool)
 
 	return &dsc
 }

--- a/internal/controller/components/llamastackoperator/llamastackoperator.go
+++ b/internal/controller/components/llamastackoperator/llamastackoperator.go
@@ -79,14 +79,12 @@ func (s *componentHandler) UpdateDSCStatus(ctx context.Context, rr *types.Reconc
 
 	ms := components.NormalizeManagementState(dsc.Spec.Components.LlamaStackOperator.ManagementState)
 
-	dsc.Status.InstalledComponents[ComponentName] = false
 	dsc.Status.Components.LlamaStackOperator.ManagementState = ms
 	dsc.Status.Components.LlamaStackOperator.LlamaStackOperatorCommonStatus = nil
 
 	rr.Conditions.MarkFalse(ReadyConditionType)
 
 	if s.IsEnabled(dsc) {
-		dsc.Status.InstalledComponents[ComponentName] = true
 		dsc.Status.Components.LlamaStackOperator.LlamaStackOperatorCommonStatus = c.Status.LlamaStackOperatorCommonStatus.DeepCopy()
 
 		if rc := conditions.FindStatusCondition(c.GetStatus(), status.ConditionTypeReady); rc != nil {

--- a/internal/controller/components/modelcontroller/modelcontroller_test.go
+++ b/internal/controller/components/modelcontroller/modelcontroller_test.go
@@ -219,7 +219,6 @@ func createDSCWithModelController(kserveState, modelregistryState operatorv1.Man
 
 	dsc.Spec.Components.Kserve.ManagementState = kserveState
 	dsc.Spec.Components.ModelRegistry.ManagementState = modelregistryState
-	dsc.Status.InstalledComponents = make(map[string]bool)
 
 	return &dsc
 }

--- a/internal/controller/components/modelregistry/modelregistry.go
+++ b/internal/controller/components/modelregistry/modelregistry.go
@@ -81,14 +81,12 @@ func (s *componentHandler) UpdateDSCStatus(ctx context.Context, rr *types.Reconc
 
 	ms := components.NormalizeManagementState(dsc.Spec.Components.ModelRegistry.ManagementState)
 
-	dsc.Status.InstalledComponents[LegacyComponentName] = false
 	dsc.Status.Components.ModelRegistry.ManagementState = ms
 	dsc.Status.Components.ModelRegistry.ModelRegistryCommonStatus = nil
 
 	rr.Conditions.MarkFalse(ReadyConditionType)
 
 	if s.IsEnabled(dsc) {
-		dsc.Status.InstalledComponents[LegacyComponentName] = true
 		dsc.Status.Components.ModelRegistry.ModelRegistryCommonStatus = c.Status.ModelRegistryCommonStatus.DeepCopy()
 
 		if rc := conditions.FindStatusCondition(c.GetStatus(), status.ConditionTypeReady); rc != nil {

--- a/internal/controller/components/modelregistry/modelregistry_test.go
+++ b/internal/controller/components/modelregistry/modelregistry_test.go
@@ -111,7 +111,6 @@ func TestUpdateDSCStatus(t *testing.T) {
 		g.Expect(cs).Should(Equal(metav1.ConditionTrue))
 
 		g.Expect(dsc).Should(WithTransform(json.Marshal, And(
-			jq.Match(`.status.installedComponents."%s" == true`, LegacyComponentName),
 			jq.Match(`.status.components.modelregistry.managementState == "%s"`, operatorv1.Managed),
 			jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, ReadyConditionType, metav1.ConditionTrue),
 			jq.Match(`.status.conditions[] | select(.type == "%s") | .reason == "%s"`, ReadyConditionType, status.ReadyReason),
@@ -139,7 +138,6 @@ func TestUpdateDSCStatus(t *testing.T) {
 		g.Expect(cs).Should(Equal(metav1.ConditionFalse))
 
 		g.Expect(dsc).Should(WithTransform(json.Marshal, And(
-			jq.Match(`.status.installedComponents."%s" == true`, LegacyComponentName),
 			jq.Match(`.status.components.modelregistry.managementState == "%s"`, operatorv1.Managed),
 			jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, ReadyConditionType, metav1.ConditionFalse),
 			jq.Match(`.status.conditions[] | select(.type == "%s") | .reason == "%s"`, ReadyConditionType, status.NotReadyReason),
@@ -166,7 +164,6 @@ func TestUpdateDSCStatus(t *testing.T) {
 		g.Expect(cs).Should(Equal(metav1.ConditionUnknown))
 
 		g.Expect(dsc).Should(WithTransform(json.Marshal, And(
-			jq.Match(`.status.installedComponents."%s" == false`, LegacyComponentName),
 			jq.Match(`.status.components.modelregistry.managementState == "%s"`, operatorv1.Removed),
 			jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, ReadyConditionType, metav1.ConditionFalse),
 			jq.Match(`.status.conditions[] | select(.type == "%s") | .reason == "%s"`, ReadyConditionType, operatorv1.Removed),
@@ -193,7 +190,6 @@ func TestUpdateDSCStatus(t *testing.T) {
 		g.Expect(cs).Should(Equal(metav1.ConditionUnknown))
 
 		g.Expect(dsc).Should(WithTransform(json.Marshal, And(
-			jq.Match(`.status.installedComponents."%s" == false`, LegacyComponentName),
 			jq.Match(`.status.components.modelregistry.managementState == "%s"`, operatorv1.Removed),
 			jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, ReadyConditionType, metav1.ConditionFalse),
 			jq.Match(`.status.conditions[] | select(.type == "%s") | .reason == "%s"`, ReadyConditionType, operatorv1.Removed),
@@ -209,7 +205,6 @@ func createDSCWithModelRegistry(managementState operatorv1.ManagementState) *dsc
 	dsc.SetName("test-dsc")
 
 	dsc.Spec.Components.ModelRegistry.ManagementState = managementState
-	dsc.Status.InstalledComponents = make(map[string]bool)
 
 	return &dsc
 }

--- a/internal/controller/components/ray/ray.go
+++ b/internal/controller/components/ray/ray.go
@@ -79,14 +79,12 @@ func (s *componentHandler) UpdateDSCStatus(ctx context.Context, rr *types.Reconc
 
 	ms := components.NormalizeManagementState(dsc.Spec.Components.Ray.ManagementState)
 
-	dsc.Status.InstalledComponents[LegacyComponentName] = false
 	dsc.Status.Components.Ray.ManagementState = ms
 	dsc.Status.Components.Ray.RayCommonStatus = nil
 
 	rr.Conditions.MarkFalse(ReadyConditionType)
 
 	if s.IsEnabled(dsc) {
-		dsc.Status.InstalledComponents[LegacyComponentName] = true
 		dsc.Status.Components.Ray.RayCommonStatus = c.Status.RayCommonStatus.DeepCopy()
 
 		if rc := conditions.FindStatusCondition(c.GetStatus(), status.ConditionTypeReady); rc != nil {

--- a/internal/controller/components/ray/ray_test.go
+++ b/internal/controller/components/ray/ray_test.go
@@ -111,7 +111,6 @@ func TestUpdateDSCStatus(t *testing.T) {
 		g.Expect(cs).Should(Equal(metav1.ConditionTrue))
 
 		g.Expect(dsc).Should(WithTransform(json.Marshal, And(
-			jq.Match(`.status.installedComponents."%s" == true`, LegacyComponentName),
 			jq.Match(`.status.components.ray.managementState == "%s"`, operatorv1.Managed),
 			jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, ReadyConditionType, metav1.ConditionTrue),
 			jq.Match(`.status.conditions[] | select(.type == "%s") | .reason == "%s"`, ReadyConditionType, status.ReadyReason),
@@ -139,7 +138,6 @@ func TestUpdateDSCStatus(t *testing.T) {
 		g.Expect(cs).Should(Equal(metav1.ConditionFalse))
 
 		g.Expect(dsc).Should(WithTransform(json.Marshal, And(
-			jq.Match(`.status.installedComponents."%s" == true`, LegacyComponentName),
 			jq.Match(`.status.components.ray.managementState == "%s"`, operatorv1.Managed),
 			jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, ReadyConditionType, metav1.ConditionFalse),
 			jq.Match(`.status.conditions[] | select(.type == "%s") | .reason == "%s"`, ReadyConditionType, status.NotReadyReason),
@@ -166,7 +164,6 @@ func TestUpdateDSCStatus(t *testing.T) {
 		g.Expect(cs).Should(Equal(metav1.ConditionUnknown))
 
 		g.Expect(dsc).Should(WithTransform(json.Marshal, And(
-			jq.Match(`.status.installedComponents."%s" == false`, LegacyComponentName),
 			jq.Match(`.status.components.ray.managementState == "%s"`, operatorv1.Removed),
 			jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, ReadyConditionType, metav1.ConditionFalse),
 			jq.Match(`.status.conditions[] | select(.type == "%s") | .reason == "%s"`, ReadyConditionType, operatorv1.Removed),
@@ -193,7 +190,6 @@ func TestUpdateDSCStatus(t *testing.T) {
 		g.Expect(cs).Should(Equal(metav1.ConditionUnknown))
 
 		g.Expect(dsc).Should(WithTransform(json.Marshal, And(
-			jq.Match(`.status.installedComponents."%s" == false`, LegacyComponentName),
 			jq.Match(`.status.components.ray.managementState == "%s"`, operatorv1.Removed),
 			jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, ReadyConditionType, metav1.ConditionFalse),
 			jq.Match(`.status.conditions[] | select(.type == "%s") | .reason == "%s"`, ReadyConditionType, operatorv1.Removed),
@@ -228,7 +224,6 @@ func TestUpdateDSCStatus(t *testing.T) {
 		g.Expect(cs).Should(Equal(metav1.ConditionFalse))
 
 		g.Expect(dsc).Should(WithTransform(json.Marshal, And(
-			jq.Match(`.status.installedComponents."%s" == true`, LegacyComponentName),
 			jq.Match(`.status.components.ray.managementState == "%s"`, operatorv1.Managed),
 			jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, ReadyConditionType, metav1.ConditionFalse),
 			jq.Match(`.status.conditions[] | select(.type == "%s") | .reason == "%s"`, ReadyConditionType, "Error"),
@@ -243,7 +238,6 @@ func createDSCWithRay(managementState operatorv1.ManagementState) *dscv2.DataSci
 	dsc.SetName("test-dsc")
 
 	dsc.Spec.Components.Ray.ManagementState = managementState
-	dsc.Status.InstalledComponents = make(map[string]bool)
 
 	return &dsc
 }

--- a/internal/controller/components/trainingoperator/trainingoperator.go
+++ b/internal/controller/components/trainingoperator/trainingoperator.go
@@ -79,14 +79,12 @@ func (s *componentHandler) UpdateDSCStatus(ctx context.Context, rr *types.Reconc
 
 	ms := components.NormalizeManagementState(dsc.Spec.Components.TrainingOperator.ManagementState)
 
-	dsc.Status.InstalledComponents[LegacyComponentName] = false
 	dsc.Status.Components.TrainingOperator.ManagementState = ms
 	dsc.Status.Components.TrainingOperator.TrainingOperatorCommonStatus = nil
 
 	rr.Conditions.MarkFalse(ReadyConditionType)
 
 	if s.IsEnabled(dsc) {
-		dsc.Status.InstalledComponents[LegacyComponentName] = true
 		dsc.Status.Components.TrainingOperator.TrainingOperatorCommonStatus = c.Status.TrainingOperatorCommonStatus.DeepCopy()
 
 		if rc := conditions.FindStatusCondition(c.GetStatus(), status.ConditionTypeReady); rc != nil {

--- a/internal/controller/components/trainingoperator/trainingoperator_test.go
+++ b/internal/controller/components/trainingoperator/trainingoperator_test.go
@@ -111,7 +111,6 @@ func TestUpdateDSCStatus(t *testing.T) {
 		g.Expect(cs).Should(Equal(metav1.ConditionTrue))
 
 		g.Expect(dsc).Should(WithTransform(json.Marshal, And(
-			jq.Match(`.status.installedComponents."%s" == true`, LegacyComponentName),
 			jq.Match(`.status.components.trainingoperator.managementState == "%s"`, operatorv1.Managed),
 			jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, ReadyConditionType, metav1.ConditionTrue),
 			jq.Match(`.status.conditions[] | select(.type == "%s") | .reason == "%s"`, ReadyConditionType, status.ReadyReason),
@@ -139,7 +138,6 @@ func TestUpdateDSCStatus(t *testing.T) {
 		g.Expect(cs).Should(Equal(metav1.ConditionFalse))
 
 		g.Expect(dsc).Should(WithTransform(json.Marshal, And(
-			jq.Match(`.status.installedComponents."%s" == true`, LegacyComponentName),
 			jq.Match(`.status.components.trainingoperator.managementState == "%s"`, operatorv1.Managed),
 			jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, ReadyConditionType, metav1.ConditionFalse),
 			jq.Match(`.status.conditions[] | select(.type == "%s") | .reason == "%s"`, ReadyConditionType, status.NotReadyReason),
@@ -166,7 +164,6 @@ func TestUpdateDSCStatus(t *testing.T) {
 		g.Expect(cs).Should(Equal(metav1.ConditionUnknown))
 
 		g.Expect(dsc).Should(WithTransform(json.Marshal, And(
-			jq.Match(`.status.installedComponents."%s" == false`, LegacyComponentName),
 			jq.Match(`.status.components.trainingoperator.managementState == "%s"`, operatorv1.Removed),
 			jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, ReadyConditionType, metav1.ConditionFalse),
 			jq.Match(`.status.conditions[] | select(.type == "%s") | .reason == "%s"`, ReadyConditionType, operatorv1.Removed),
@@ -193,7 +190,6 @@ func TestUpdateDSCStatus(t *testing.T) {
 		g.Expect(cs).Should(Equal(metav1.ConditionUnknown))
 
 		g.Expect(dsc).Should(WithTransform(json.Marshal, And(
-			jq.Match(`.status.installedComponents."%s" == false`, LegacyComponentName),
 			jq.Match(`.status.components.trainingoperator.managementState == "%s"`, operatorv1.Removed),
 			jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, ReadyConditionType, metav1.ConditionFalse),
 			jq.Match(`.status.conditions[] | select(.type == "%s") | .reason == "%s"`, ReadyConditionType, operatorv1.Removed),
@@ -209,7 +205,6 @@ func createDSCWithTrainingOperator(managementState operatorv1.ManagementState) *
 	dsc.SetName("test-dsc")
 
 	dsc.Spec.Components.TrainingOperator.ManagementState = managementState
-	dsc.Status.InstalledComponents = make(map[string]bool)
 
 	return &dsc
 }

--- a/internal/controller/components/trustyai/trustyai.go
+++ b/internal/controller/components/trustyai/trustyai.go
@@ -101,14 +101,12 @@ func (s *componentHandler) UpdateDSCStatus(ctx context.Context, rr *types.Reconc
 
 	ms := components.NormalizeManagementState(dsc.Spec.Components.TrustyAI.ManagementState)
 
-	dsc.Status.InstalledComponents[LegacyComponentName] = false
 	dsc.Status.Components.TrustyAI.ManagementState = ms
 	dsc.Status.Components.TrustyAI.TrustyAICommonStatus = nil
 
 	rr.Conditions.MarkFalse(ReadyConditionType)
 
 	if s.IsEnabled(dsc) {
-		dsc.Status.InstalledComponents[LegacyComponentName] = true
 		dsc.Status.Components.TrustyAI.TrustyAICommonStatus = c.Status.TrustyAICommonStatus.DeepCopy()
 
 		if rc := conditions.FindStatusCondition(c.GetStatus(), status.ConditionTypeReady); rc != nil {

--- a/internal/controller/components/trustyai/trustyai_test.go
+++ b/internal/controller/components/trustyai/trustyai_test.go
@@ -231,7 +231,6 @@ func TestUpdateDSCStatus(t *testing.T) {
 		g.Expect(cs).Should(Equal(metav1.ConditionTrue))
 
 		g.Expect(dsc).Should(WithTransform(json.Marshal, And(
-			jq.Match(`.status.installedComponents."%s" == true`, LegacyComponentName),
 			jq.Match(`.status.components.trustyai.managementState == "%s"`, operatorv1.Managed),
 			jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, ReadyConditionType, metav1.ConditionTrue),
 			jq.Match(`.status.conditions[] | select(.type == "%s") | .reason == "%s"`, ReadyConditionType, status.ReadyReason),
@@ -259,7 +258,6 @@ func TestUpdateDSCStatus(t *testing.T) {
 		g.Expect(cs).Should(Equal(metav1.ConditionFalse))
 
 		g.Expect(dsc).Should(WithTransform(json.Marshal, And(
-			jq.Match(`.status.installedComponents."%s" == true`, LegacyComponentName),
 			jq.Match(`.status.components.trustyai.managementState == "%s"`, operatorv1.Managed),
 			jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, ReadyConditionType, metav1.ConditionFalse),
 			jq.Match(`.status.conditions[] | select(.type == "%s") | .reason == "%s"`, ReadyConditionType, status.NotReadyReason),
@@ -286,7 +284,6 @@ func TestUpdateDSCStatus(t *testing.T) {
 		g.Expect(cs).Should(Equal(metav1.ConditionUnknown))
 
 		g.Expect(dsc).Should(WithTransform(json.Marshal, And(
-			jq.Match(`.status.installedComponents."%s" == false`, LegacyComponentName),
 			jq.Match(`.status.components.trustyai.managementState == "%s"`, operatorv1.Removed),
 			jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, ReadyConditionType, metav1.ConditionFalse),
 			jq.Match(`.status.conditions[] | select(.type == "%s") | .reason == "%s"`, ReadyConditionType, operatorv1.Removed),
@@ -313,7 +310,6 @@ func TestUpdateDSCStatus(t *testing.T) {
 		g.Expect(cs).Should(Equal(metav1.ConditionUnknown))
 
 		g.Expect(dsc).Should(WithTransform(json.Marshal, And(
-			jq.Match(`.status.installedComponents."%s" == false`, LegacyComponentName),
 			jq.Match(`.status.components.trustyai.managementState == "%s"`, operatorv1.Removed),
 			jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, ReadyConditionType, metav1.ConditionFalse),
 			jq.Match(`.status.conditions[] | select(.type == "%s") | .reason == "%s"`, ReadyConditionType, operatorv1.Removed),
@@ -329,7 +325,6 @@ func createDSCWithTrustyAI(managementState operatorv1.ManagementState) *dscv2.Da
 	dsc.SetName("test-dsc")
 
 	dsc.Spec.Components.TrustyAI.ManagementState = managementState
-	dsc.Status.InstalledComponents = make(map[string]bool)
 
 	return &dsc
 }

--- a/internal/controller/components/workbenches/workbenches.go
+++ b/internal/controller/components/workbenches/workbenches.go
@@ -137,14 +137,12 @@ func (s *componentHandler) UpdateDSCStatus(ctx context.Context, rr *types.Reconc
 
 	ms := components.NormalizeManagementState(dsc.Spec.Components.Workbenches.ManagementState)
 
-	dsc.Status.InstalledComponents[LegacyComponentName] = false
 	dsc.Status.Components.Workbenches.ManagementState = ms
 	dsc.Status.Components.Workbenches.WorkbenchesCommonStatus = nil
 
 	rr.Conditions.MarkFalse(ReadyConditionType)
 
 	if s.IsEnabled(dsc) {
-		dsc.Status.InstalledComponents[LegacyComponentName] = true
 		dsc.Status.Components.Workbenches.WorkbenchesCommonStatus = c.Status.WorkbenchesCommonStatus.DeepCopy()
 
 		if rc := conditions.FindStatusCondition(c.GetStatus(), status.ConditionTypeReady); rc != nil {

--- a/internal/controller/components/workbenches/workbenches_test.go
+++ b/internal/controller/components/workbenches/workbenches_test.go
@@ -111,7 +111,6 @@ func TestUpdateDSCStatus(t *testing.T) {
 		g.Expect(cs).Should(Equal(metav1.ConditionTrue))
 
 		g.Expect(dsc).Should(WithTransform(json.Marshal, And(
-			jq.Match(`.status.installedComponents."%s" == true`, LegacyComponentName),
 			jq.Match(`.status.components.workbenches.managementState == "%s"`, operatorv1.Managed),
 			jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, ReadyConditionType, metav1.ConditionTrue),
 			jq.Match(`.status.conditions[] | select(.type == "%s") | .reason == "%s"`, ReadyConditionType, status.ReadyReason),
@@ -139,7 +138,6 @@ func TestUpdateDSCStatus(t *testing.T) {
 		g.Expect(cs).Should(Equal(metav1.ConditionFalse))
 
 		g.Expect(dsc).Should(WithTransform(json.Marshal, And(
-			jq.Match(`.status.installedComponents."%s" == true`, LegacyComponentName),
 			jq.Match(`.status.components.workbenches.managementState == "%s"`, operatorv1.Managed),
 			jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, ReadyConditionType, metav1.ConditionFalse),
 			jq.Match(`.status.conditions[] | select(.type == "%s") | .reason == "%s"`, ReadyConditionType, status.NotReadyReason),
@@ -166,7 +164,6 @@ func TestUpdateDSCStatus(t *testing.T) {
 		g.Expect(cs).Should(Equal(metav1.ConditionUnknown))
 
 		g.Expect(dsc).Should(WithTransform(json.Marshal, And(
-			jq.Match(`.status.installedComponents."%s" == false`, LegacyComponentName),
 			jq.Match(`.status.components.workbenches.managementState == "%s"`, operatorv1.Removed),
 			jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, ReadyConditionType, metav1.ConditionFalse),
 			jq.Match(`.status.conditions[] | select(.type == "%s") | .reason == "%s"`, ReadyConditionType, operatorv1.Removed),
@@ -193,7 +190,6 @@ func TestUpdateDSCStatus(t *testing.T) {
 		g.Expect(cs).Should(Equal(metav1.ConditionUnknown))
 
 		g.Expect(dsc).Should(WithTransform(json.Marshal, And(
-			jq.Match(`.status.installedComponents."%s" == false`, LegacyComponentName),
 			jq.Match(`.status.components.workbenches.managementState == "%s"`, operatorv1.Removed),
 			jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, ReadyConditionType, metav1.ConditionFalse),
 			jq.Match(`.status.conditions[] | select(.type == "%s") | .reason == "%s"`, ReadyConditionType, operatorv1.Removed),
@@ -209,7 +205,6 @@ func createDSCWithWorkbenches(managementState operatorv1.ManagementState) *dscv2
 	dsc.SetName("test-dsc")
 
 	dsc.Spec.Components.Workbenches.ManagementState = managementState
-	dsc.Status.InstalledComponents = make(map[string]bool)
 
 	return &dsc
 }

--- a/internal/controller/datasciencecluster/datasciencecluster_controller_actions.go
+++ b/internal/controller/datasciencecluster/datasciencecluster_controller_actions.go
@@ -26,10 +26,6 @@ func initialize(ctx context.Context, rr *odhtype.ReconciliationRequest) error {
 		return fmt.Errorf("resource instance %v is not a dscv2.DataScienceCluster)", rr.Instance)
 	}
 
-	if instance.Status.InstalledComponents == nil {
-		instance.Status.InstalledComponents = make(map[string]bool)
-	}
-
 	// TODO: remove after https://issues.redhat.com/browse/RHOAIENG-15920
 	if controllerutil.RemoveFinalizer(instance, finalizerName) {
 		if err := rr.Client.Update(ctx, instance); err != nil {
@@ -77,10 +73,6 @@ func provisionComponents(_ context.Context, rr *odhtype.ReconciliationRequest) e
 		return fmt.Errorf("resource instance %v is not a dscv2.DataScienceCluster)", rr.Instance)
 	}
 
-	if instance.Status.InstalledComponents == nil {
-		instance.Status.InstalledComponents = make(map[string]bool)
-	}
-
 	// force gc to run
 	rr.Generated = true
 
@@ -108,10 +100,6 @@ func updateStatus(ctx context.Context, rr *odhtype.ReconciliationRequest) error 
 	instance, ok := rr.Instance.(*dscv2.DataScienceCluster)
 	if !ok {
 		return fmt.Errorf("resource instance %v is not a dscv2.DataScienceCluster)", rr.Instance)
-	}
-
-	if instance.Status.InstalledComponents == nil {
-		instance.Status.InstalledComponents = make(map[string]bool)
 	}
 
 	instance.Status.Release = rr.Release


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
This PR removes the redundant `installedComponents` field from the DataScienceCluster v2 API while maintaining full backward compatibility for v1 users.

**Key Changes:**
- Remove `InstalledComponents` field from v2 `DataScienceClusterStatus`
- Keep `InstalledComponents` field in v1 for backward compatibility
- Update conversion logic to construct v1 `InstalledComponents` from v2 component `ManagementState`
- Add `constructInstalledComponentsFromV2Status()` function to build `InstalledComponents` map
- Add `getV1ComponentName()` helper for component name mapping between versions
- Update conversion tests with new construction logic
- Fix integration tests to properly test v2→v1 conversion behavior
- Remove `InstalledComponents` assignments from component handlers and templates

**Rationale:** The `InstalledComponents` field in v2 was redundant since component status already tracks management state through `ManagementState`. This change simplifies the v2 API while maintaining full backward compatibility for v1 users through automatic conversion during webhook processing.

**JIRA:** [RHOAIENG-36418](https://issues.redhat.com/browse/RHOAIENG-36418)

## How Has This Been Tested?
**Unit Tests:**
- All conversion logic unit tests pass (7/7)
- `TestGetV1ComponentName` - Tests component name mapping
- `TestConstructInstalledComponentsFromV2Status` - Tests construction from v2 status
- `TestConvertFrom_ConstructsInstalledComponents` - Tests full v2→v1 conversion
- All condition conversion tests pass

**Integration Tests:**
- All webhook integration tests pass (9/9 total)
- `TestDataScienceClusterV1V2_ConversionWebhook` - Tests bidirectional conversion (5/5 subtests)
- `TestDataScienceClusterV1_Integration` - Tests v1 webhook functionality (4/4 subtests)

**Testing Environment:**
- Local development environment with envtest
- Go 1.24 with Kubebuilder assets
- All tests run with `KUBEBUILDER_ASSETS` properly configured

**Manual Testing:**
- Verified v1 DSC objects still have `InstalledComponents` field
- Verified v2 DSC objects no longer have `InstalledComponents` field  
- Verified conversion webhook properly constructs v1 `InstalledComponents` from v2 component status
- Verified backward compatibility for existing v1 users

## Screenshot or short clip
N/A - This is an API change with no UI impact.

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
This PR makes an internal API change that removes a redundant field from v2 while maintaining full backward compatibility for v1 users through conversion webhooks. The change:

1. **No functional behavior change** - Component management still works identically
2. **Backward compatible** - v1 users see no difference in functionality
3. **Internal API cleanup** - Removes redundant data that was already tracked elsewhere
4. **Comprehensive unit/integration testing** - All conversion logic thoroughly tested with webhook integration tests
5. **No user-facing feature changes** - No new workflows or user interactions to test

The existing E2E tests will continue to work as they primarily test component functionality, not the internal structure of the `InstalledComponents` field.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **API Changes**
  * Removed `InstalledComponents` field from DataScienceCluster status. Component installation state is now derived from individual component management states.
  * Updated DataScienceCluster CRD schema to reflect the removal of the `installedComponents` status property.

* **Refactor**
  * Improved component status tracking to use component ManagementState instead of a separate installation map.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->