### PR TITLE
Use variable for manifest folder in get_all_manifests.sh

### DIFF
--- a/get_all_manifests.sh
+++ b/get_all_manifests.sh
@@ -161,9 +161,6 @@ download_manifest() {
     cp -rf ${repo_dir}/${source_path}/* ${DST_MANIFESTS_DIR}/${target_path}
 }
 
-# Cleanup existing manifests
-rm -rf ${DST_MANIFESTS_DIR}/*
-
 # Track background job PIDs +declare -a pids=()
 # Use parallel processing
 for key in "${!COMPONENT_MANIFESTS[@]}"; do


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

Upgrade kuberay sha to fix e2e tests.
Remove manifests in `get_all_manifests.sh` script to avoid old unmanaged folders.

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [x] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [ ] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Introduced a configurable DST_MANIFESTS_DIR to control manifest storage location.
  * Replaced hardcoded ./opt/manifests usage so downloads, copies, and links use the configured destination.
  * Ensured manifests are cleaned before downloads to avoid stale files.
  * Updated copy and symlink logic to consistently operate under the new destination and avoid referencing the old path.
  * Improved handling for adjacent local checkouts so local manifests are used and linked correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->