### PR TITLE
RHOAIENG-25594 | feat: adding prometheus datasource to perses dashboard

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -69,6 +69,10 @@ spec:
           # For RHOAI: Overridden by CSV. For ODH: Uses jtanner's public image
           - name: RELATED_IMAGE_ODH_KUBE_AUTH_PROXY_IMAGE
             value: quay.io/opendatahub/odh-kube-auth-proxy:latest
+          # Perses image configuration
+          # For RHOAI: Overridden by CSV. For ODH: Uses public quay.io image
+          - name: RELATED_IMAGE_ODH_PERSES_IMAGE
+            value: quay.io/opendatahub/perses:0.50.0
         args:
         - --leader-elect
         - --operator-name=opendatahub

--- a/internal/controller/dscinitialization/kubebuilder_rbac.go
+++ b/internal/controller/dscinitialization/kubebuilder_rbac.go
@@ -71,6 +71,12 @@ package dscinitialization
 //+kubebuilder:rbac:groups=perses.dev,resources=perses/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=perses.dev,resources=perses/finalizers,verbs=update
 
+//+kubebuilder:rbac:groups=perses.dev,resources=persesdatasources,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=perses.dev,resources=persesdatasources/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=perses.dev,resources=persesdatasources/finalizers,verbs=update
+
+//+kubebuilder:rbac:groups=operator.openshift.io,resources=consoles,verbs=get;list;watch;update;patch
+
 //+kubebuilder:rbac:groups=opentelemetry.io,resources=opentelemetrycollectors,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=opentelemetry.io,resources=opentelemetrycollectors/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=opentelemetry.io,resources=opentelemetrycollectors/finalizers,verbs=update

--- a/internal/controller/services/monitoring/monitoring_controller.go
+++ b/internal/controller/services/monitoring/monitoring_controller.go
@@ -101,6 +101,7 @@ func (h *serviceHandler) NewReconciler(ctx context.Context, mgr ctrl.Manager) er
 		OwnsGVK(gvk.PrometheusRule, reconciler.Dynamic(reconciler.CrdExists(gvk.PrometheusRule))).
 		OwnsGVK(gvk.ThanosQuerier, reconciler.Dynamic(reconciler.CrdExists(gvk.ThanosQuerier))).
 		OwnsGVK(gvk.Perses, reconciler.Dynamic(reconciler.CrdExists(gvk.Perses))).
+		OwnsGVK(gvk.PersesDatasource, reconciler.Dynamic(reconciler.CrdExists(gvk.PersesDatasource))).
 		// operands - watched
 		//
 		// By default the Watches functions adds:
@@ -134,6 +135,7 @@ func (h *serviceHandler) NewReconciler(ctx context.Context, mgr ctrl.Manager) er
 		WithAction(deployAlerting).
 		WithAction(deployOpenTelemetryCollector).
 		WithAction(deployPerses).
+		WithAction(deployPersesDatasource).
 		WithAction(template.NewAction(
 			template.WithDataFn(getTemplateData),
 		)).

--- a/internal/controller/services/monitoring/monitoring_controller_support.go
+++ b/internal/controller/services/monitoring/monitoring_controller_support.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"os"
 	"regexp"
 	"sort"
 	"strconv"
@@ -236,6 +237,7 @@ func getTemplateData(ctx context.Context, rr *odhtypes.ReconciliationRequest) (m
 		"ApplicationNamespace": appNamespace,
 		"MetricsExporters":     make(map[string]string),
 		"MetricsExporterNames": []string{},
+		"PersesImage":          getPersesImage(),
 	}
 
 	// Add metrics-related data if metrics are configured
@@ -900,4 +902,16 @@ func contains(slice []string, item string) bool {
 
 func intPtr(i int) *int {
 	return &i
+}
+
+// getPersesImage returns the Perses container image to use.
+// For ODH: uses publicly accessible image from quay.io/opendatahub
+// For RHOAI: uses registry.redhat.io image (can be overridden via RELATED_IMAGE_ODH_PERSES_IMAGE)
+// Can be overridden for all platforms via RELATED_IMAGE_ODH_PERSES_IMAGE environment variable.
+func getPersesImage() string {
+	if image := os.Getenv("RELATED_IMAGE_ODH_PERSES_IMAGE"); image != "" {
+		return image
+	}
+
+	return "registry.redhat.io/cluster-observability-operator/perses-0-50-rhel9:1.2.2-1752686994"
 }

--- a/internal/controller/services/monitoring/resources/collector-servicemonitors.tmpl.yaml
+++ b/internal/controller/services/monitoring/resources/collector-servicemonitors.tmpl.yaml
@@ -36,3 +36,22 @@ spec:
       app.kubernetes.io/managed-by: opentelemetry-operator
       app.kubernetes.io/part-of: opentelemetry
       operator.opentelemetry.io/collector-service-type: base
+---
+apiVersion: monitoring.rhobs/v1
+kind: ServiceMonitor
+metadata:
+  name: opendatahub-operator-metrics
+  namespace: {{.Namespace}}
+spec:
+  endpoints:
+    - port: https
+      scheme: https
+      tlsConfig:
+        insecureSkipVerify: true
+      bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+  namespaceSelector:
+    matchNames:
+      - opendatahub-operator-system
+  selector:
+    matchLabels:
+      control-plane: controller-manager

--- a/internal/controller/services/monitoring/resources/perses-dashboard-overview.tmpl.yaml
+++ b/internal/controller/services/monitoring/resources/perses-dashboard-overview.tmpl.yaml
@@ -1,0 +1,127 @@
+apiVersion: perses.dev/v1alpha1
+kind: PersesDashboard
+metadata:
+  name: data-science-overview
+  namespace: {{.Namespace}}
+  labels:
+    app.kubernetes.io/part-of: data-science-monitoring
+spec:
+  display:
+    name: "Data Science Platform Overview"
+    description: "Overview dashboard for OpenShift AI / Open Data Hub platform"
+  duration: 1h
+  refreshInterval: 30s
+  panels:
+    component-reconciliations:
+      kind: Panel
+      spec:
+        display:
+          name: "Component Reconciliations"
+        plugin:
+          kind: TimeSeriesChart
+          spec:
+            legend:
+              position: bottom
+            yAxis:
+              show: true
+        queries:
+          - kind: TimeSeriesQuery
+            spec:
+              plugin:
+                kind: PrometheusTimeSeriesQuery
+                spec:
+                  query: "sum by (controller) (rate(controller_runtime_reconcile_total[5m]))"
+    reconciliation-errors:
+      kind: Panel
+      spec:
+        display:
+          name: "Reconciliation Errors"
+        plugin:
+          kind: TimeSeriesChart
+          spec:
+            legend:
+              position: bottom
+            yAxis:
+              show: true
+        queries:
+          - kind: TimeSeriesQuery
+            spec:
+              plugin:
+                kind: PrometheusTimeSeriesQuery
+                spec:
+                  query: "sum by (controller) (rate(controller_runtime_reconcile_errors_total[5m]))"
+    prometheus-memory:
+      kind: Panel
+      spec:
+        display:
+          name: "Prometheus Memory Usage"
+        plugin:
+          kind: TimeSeriesChart
+          spec:
+            legend:
+              position: bottom
+            yAxis:
+              show: true
+              label: "Bytes"
+        queries:
+          - kind: TimeSeriesQuery
+            spec:
+              plugin:
+                kind: PrometheusTimeSeriesQuery
+                spec:
+                  query: 'process_resident_memory_bytes{job="prometheus-self"}'
+    collector-cpu:
+      kind: Panel
+      spec:
+        display:
+          name: "Collector CPU Usage"
+        plugin:
+          kind: TimeSeriesChart
+          spec:
+            legend:
+              position: bottom
+            yAxis:
+              show: true
+              label: "CPU seconds/sec"
+        queries:
+          - kind: TimeSeriesQuery
+            spec:
+              plugin:
+                kind: PrometheusTimeSeriesQuery
+                spec:
+                  query: "rate(otelcol_process_cpu_seconds_total[5m])"
+  layouts:
+    - kind: Grid
+      spec:
+        display:
+          title: "Platform Health"
+        items:
+          - x: 0
+            "y": 0
+            width: 12
+            height: 10
+            content:
+              $ref: "#/spec/panels/component-reconciliations"
+          - x: 12
+            "y": 0
+            width: 12
+            height: 10
+            content:
+              $ref: "#/spec/panels/reconciliation-errors"
+    - kind: Grid
+      spec:
+        display:
+          title: "Resource Usage"
+        items:
+          - x: 0
+            "y": 0
+            width: 12
+            height: 10
+            content:
+              $ref: "#/spec/panels/prometheus-memory"
+          - x: 12
+            "y": 0
+            width: 12
+            height: 10
+            content:
+              $ref: "#/spec/panels/collector-cpu"

--- a/internal/controller/services/monitoring/resources/perses-datasource-prometheus.tmpl.yaml
+++ b/internal/controller/services/monitoring/resources/perses-datasource-prometheus.tmpl.yaml
@@ -1,0 +1,17 @@
+apiVersion: perses.dev/v1alpha1
+kind: PersesDatasource
+metadata:
+  name: data-science-prometheus-datasource
+  namespace: {{.Namespace}}
+spec:
+  config:
+    default: true
+    display:
+      name: "Data Science Prometheus Datasource"
+    plugin:
+      kind: "PrometheusDatasource"
+      spec:
+        proxy:
+          kind: HTTPProxy
+          spec:
+            url: http://thanos-querier-data-science-thanos-querier.{{.Namespace}}.svc.cluster.local:10902

--- a/internal/controller/services/monitoring/resources/perses-monitoring-uiplugin.tmpl.yaml
+++ b/internal/controller/services/monitoring/resources/perses-monitoring-uiplugin.tmpl.yaml
@@ -1,0 +1,10 @@
+apiVersion: observability.openshift.io/v1alpha1
+kind: UIPlugin
+metadata:
+  name: monitoring
+spec:
+  type: Monitoring
+  monitoring:
+    perses:
+      enabled: true
+

--- a/internal/controller/services/monitoring/resources/perses.tmpl.yaml
+++ b/internal/controller/services/monitoring/resources/perses.tmpl.yaml
@@ -4,9 +4,35 @@ metadata:
   name: data-science-perses
   namespace: {{.Namespace}}
 spec:
-  containerPort: 8080
+  metadata:
+    labels:
+      instance: data-science-perses
+      app.kubernetes.io/name: perses
+      app.kubernetes.io/part-of: data-science-monitoring
   config:
     database:
       file:
+        folder: "/perses"
         extension: "yaml"
-        folder: "/var/lib/perses"
+    schemas:
+      panels_path: "/etc/perses/cue/schemas/panels"
+      queries_path: "/etc/perses/cue/schemas/queries"
+      datasources_path: "/etc/perses/cue/schemas/datasources"
+      variables_path: "/etc/perses/cue/schemas/variables"
+    ephemeral_dashboard:
+      enable: true
+      cleanup_interval: "1s"
+  image: {{.PersesImage}}
+  containerPort: 8080
+  livenessProbe:
+    initialDelaySeconds: 10
+    periodSeconds: 10
+    timeoutSeconds: 5
+    successThreshold: 1
+    failureThreshold: 5
+  readinessProbe:
+    initialDelaySeconds: 10
+    periodSeconds: 10
+    timeoutSeconds: 5
+    successThreshold: 1
+    failureThreshold: 5

--- a/internal/controller/status/status.go
+++ b/internal/controller/status/status.go
@@ -89,6 +89,7 @@ const (
 	ConditionAlertingAvailable               = "AlertingAvailable"
 	ConditionThanosQuerierAvailable          = "ThanosQuerierAvailable"
 	ConditionPersesAvailable                 = "PersesAvailable"
+	ConditionPersesDatasourceAvailable       = "PersesDatasourceAvailable"
 )
 
 const (

--- a/pkg/cluster/gvk/gvk.go
+++ b/pkg/cluster/gvk/gvk.go
@@ -547,6 +547,24 @@ var (
 		Kind:    "Perses",
 	}
 
+	PersesDatasource = schema.GroupVersionKind{
+		Group:   "perses.dev",
+		Version: "v1alpha1",
+		Kind:    "PersesDatasource",
+	}
+
+	PersesDashboard = schema.GroupVersionKind{
+		Group:   "perses.dev",
+		Version: "v1alpha1",
+		Kind:    "PersesDashboard",
+	}
+
+	UIPlugin = schema.GroupVersionKind{
+		Group:   "observability.openshift.io",
+		Version: "v1alpha1",
+		Kind:    "UIPlugin",
+	}
+
 	ServiceMesh = schema.GroupVersionKind{
 		Group:   serviceApi.GroupVersion.Group,
 		Version: serviceApi.GroupVersion.Version,

--- a/tests/e2e/monitoring_test.go
+++ b/tests/e2e/monitoring_test.go
@@ -33,6 +33,7 @@ const (
 	ThanosQuerierName          = "data-science-thanos-querier"
 	ThanosQuerierRouteName     = "data-science-thanos-querier-route"
 	PersesName                 = "data-science-perses"
+	PersesDatasourceName       = "data-science-prometheus-datasource"
 )
 
 // Constants for common test values.
@@ -112,6 +113,8 @@ func monitoringTestSuite(t *testing.T) {
 		{"Test Perses deployment when monitoring is managed", monitoringServiceCtx.ValidatePersesCRCreation},
 		{"Test Perses CR configuration", monitoringServiceCtx.ValidatePersesCRConfiguration},
 		{"Test Perses lifecycle", monitoringServiceCtx.ValidatePersesLifecycle},
+		{"Test PersesDatasource deployment with Prometheus", monitoringServiceCtx.ValidatePersesDatasourceWithPrometheus},
+		{"Test PersesDatasource lifecycle", monitoringServiceCtx.ValidatePersesDatasourceLifecycle},
 		{"Validate CEL blocks invalid monitoring configs", monitoringServiceCtx.ValidateCELBlocksInvalidMonitoringConfigs},
 		{"Validate CEL allows valid monitoring configs", monitoringServiceCtx.ValidateCELAllowsValidMonitoringConfigs},
 		{"Validate monitoring service disabled", monitoringServiceCtx.ValidateMonitoringServiceDisabled},
@@ -666,7 +669,7 @@ func (tc *MonitoringTestCtx) ValidatePersesCRCreation(t *testing.T) {
 		WithCondition(And(
 			monitoringOwnerReferencesCondition,
 			jq.Match(`.spec.containerPort == 8080`),
-			jq.Match(`.spec.config.database.file.folder == "/var/lib/perses"`),
+			jq.Match(`.spec.config.database.file.folder == "/perses"`),
 			jq.Match(`.spec.config.database.file.extension == "yaml"`),
 		)),
 		WithCustomErrorMsg("Perses CR should be created with correct configuration when monitoring is managed"),
@@ -747,6 +750,96 @@ func (tc *MonitoringTestCtx) ValidatePersesLifecycle(t *testing.T) {
 	)
 }
 
+// ValidatePersesDatasourceWithPrometheus validates that Prometheus datasource is created when both Perses and MonitoringStack are deployed.
+func (tc *MonitoringTestCtx) ValidatePersesDatasourceWithPrometheus(t *testing.T) {
+	t.Helper()
+
+	// Enable monitoring with metrics configuration to deploy both Perses and Prometheus
+	tc.updateMonitoringConfig(
+		withManagementState(operatorv1.Managed),
+		tc.withMetricsConfig(),
+	)
+
+	// Wait for Monitoring CR to be ready with both Perses and Prometheus
+	tc.EnsureResourceExists(
+		WithMinimalObject(gvk.Monitoring, types.NamespacedName{Name: MonitoringCRName}),
+		WithCondition(And(
+			jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, status.ConditionPersesAvailable, metav1.ConditionTrue),
+			jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, status.ConditionMonitoringStackAvailable, metav1.ConditionTrue),
+			jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, status.ConditionPersesDatasourceAvailable, metav1.ConditionTrue),
+		)),
+		WithCustomErrorMsg("Monitoring CR should have all conditions (Perses, MonitoringStack, PersesDatasource) set to True"),
+	)
+
+	// Verify PersesDatasource CR is created
+	tc.EnsureResourceExists(
+		WithMinimalObject(gvk.PersesDatasource, types.NamespacedName{Name: PersesDatasourceName, Namespace: tc.MonitoringNamespace}),
+		WithCondition(And(
+			// Validate owner references
+			monitoringOwnerReferencesCondition,
+			// Validate datasource is set as default
+			jq.Match(`.spec.config.default == true`),
+			// Validate plugin kind is PrometheusDatasource
+			jq.Match(`.spec.config.plugin.kind == "PrometheusDatasource"`),
+			// Validate Prometheus URL points to Thanos Querier using proxy configuration
+			jq.Match(`.spec.config.plugin.spec.proxy.kind == "HTTPProxy"`),
+			jq.Match(`.spec.config.plugin.spec.proxy.spec.url | contains("thanos-querier-data-science-thanos-querier")`),
+			jq.Match(`.spec.config.plugin.spec.proxy.spec.url | contains("%s")`, tc.MonitoringNamespace),
+		)),
+		WithCustomErrorMsg("PersesDatasource CR should be created with correct Thanos Querier proxy configuration"),
+	)
+}
+
+// ValidatePersesDatasourceLifecycle tests the complete lifecycle of PersesDatasource deployment and cleanup.
+func (tc *MonitoringTestCtx) ValidatePersesDatasourceLifecycle(t *testing.T) {
+	t.Helper()
+
+	// Step 1: Enable monitoring with metrics to deploy datasource
+	tc.updateMonitoringConfig(
+		withManagementState(operatorv1.Managed),
+		tc.withMetricsConfig(),
+	)
+
+	// Verify datasource is created
+	tc.EnsureResourceExists(
+		WithMinimalObject(gvk.PersesDatasource, types.NamespacedName{Name: PersesDatasourceName, Namespace: tc.MonitoringNamespace}),
+		WithCondition(jq.Match(`.metadata.name == "%s"`, PersesDatasourceName)),
+		WithCustomErrorMsg("PersesDatasource should exist when metrics are configured"),
+	)
+
+	// Step 2: Remove metrics configuration and verify datasource is deleted
+	tc.updateMonitoringConfig(
+		withManagementState(operatorv1.Managed),
+		withNoMetrics(),
+	)
+
+	// Verify PersesDatasourceAvailable condition is False
+	tc.EnsureResourceExists(
+		WithMinimalObject(gvk.Monitoring, types.NamespacedName{Name: MonitoringCRName}),
+		WithCondition(
+			jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, status.ConditionPersesDatasourceAvailable, metav1.ConditionFalse),
+		),
+		WithCustomErrorMsg("Monitoring CR should have PersesDatasourceAvailable condition set to False when metrics are not configured"),
+	)
+
+	// Verify datasource is deleted
+	tc.EnsureResourceGone(
+		WithMinimalObject(gvk.PersesDatasource, types.NamespacedName{Name: PersesDatasourceName, Namespace: tc.MonitoringNamespace}),
+	)
+
+	// Step 3: Re-enable metrics and verify datasource is recreated
+	tc.updateMonitoringConfig(
+		withManagementState(operatorv1.Managed),
+		tc.withMetricsConfig(),
+	)
+
+	tc.EnsureResourceExists(
+		WithMinimalObject(gvk.PersesDatasource, types.NamespacedName{Name: PersesDatasourceName, Namespace: tc.MonitoringNamespace}),
+		WithCondition(jq.Match(`.metadata.name == "%s"`, PersesDatasourceName)),
+		WithCustomErrorMsg("PersesDatasource should be recreated when metrics are re-enabled"),
+	)
+}
+
 // ValidateMonitoringServiceDisabled ensures monitoring service can be disabled and resources are cleaned up.
 func (tc *MonitoringTestCtx) ValidateMonitoringServiceDisabled(t *testing.T) {
 	t.Helper()
@@ -766,6 +859,7 @@ func (tc *MonitoringTestCtx) ValidateMonitoringServiceDisabled(t *testing.T) {
 		{gvk.OpenTelemetryCollector, OpenTelemetryCollectorName},
 		{gvk.Instrumentation, InstrumentationName},
 		{gvk.Perses, PersesName},
+		{gvk.PersesDatasource, PersesDatasourceName},
 	} {
 		tc.EnsureResourcesGone(
 			WithMinimalObject(resource.gvk, types.NamespacedName{


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
Adding prometheus metrics to perses dashboard

https://issues.redhat.com/browse/RHOAIENG-25594

## How Has This Been Tested?
- deploy managed cluster
- enable metrics in dsci
- wait for pods to provision in redhat-ods-namespace +  verify perses dashboard gets created with valid metrics.

## Screenshot or short clip
<img width="1619" height="681" alt="image" src="https://github.com/user-attachments/assets/b520245b-9e49-4abe-8df1-78cfd4edfa8d" />

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [ ] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Integrated Perses monitoring: Data Science Platform Overview dashboard, Prometheus-backed datasource, monitoring UI plugin, Perses CR deployment, and a ServiceMonitor for operator metrics.

* **Chores**
  * Updated RBAC/permissions to include Perses-related resources and added configurable Perses image via environment variable.

* **Tests**
  * Added end-to-end tests validating Perses and PersesDatasource deployment, configuration, lifecycle, and cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->