### PR TITLE
RHOAIENG-34457 | feat: add SNO-aware OpenTelemetry collector replica defaults

### DIFF
--- a/api/services/v1alpha1/monitoring_types.go
+++ b/api/services/v1alpha1/monitoring_types.go
@@ -188,7 +188,8 @@ type MonitoringCommonSpec struct {
 	Traces *Traces `json:"traces,omitempty"`
 	// Alerting configuration for Prometheus
 	Alerting *Alerting `json:"alerting,omitempty"`
-	// CollectorReplicas specifies the number of replicas in opentelemetry-collector, default is 2 if not set
+	// CollectorReplicas specifies the number of replicas in opentelemetry-collector. If not set, it defaults
+	// to 1 on single-node clusters and 2 on multi-node clusters.
 	CollectorReplicas int32 `json:"collectorReplicas,omitempty"`
 }
 

--- a/config/crd/bases/dscinitialization.opendatahub.io_dscinitializations.yaml
+++ b/config/crd/bases/dscinitialization.opendatahub.io_dscinitializations.yaml
@@ -94,8 +94,9 @@ spec:
                     description: Alerting configuration for Prometheus
                     type: object
                   collectorReplicas:
-                    description: CollectorReplicas specifies the number of replicas
-                      in opentelemetry-collector, default is 2 if not set
+                    description: |-
+                      CollectorReplicas specifies the number of replicas in opentelemetry-collector. If not set, it defaults
+                      to 1 on single-node clusters and 2 on multi-node clusters.
                     format: int32
                     type: integer
                   managementState:
@@ -599,8 +600,9 @@ spec:
                     description: Alerting configuration for Prometheus
                     type: object
                   collectorReplicas:
-                    description: CollectorReplicas specifies the number of replicas
-                      in opentelemetry-collector, default is 2 if not set
+                    description: |-
+                      CollectorReplicas specifies the number of replicas in opentelemetry-collector. If not set, it defaults
+                      to 1 on single-node clusters and 2 on multi-node clusters.
                     format: int32
                     type: integer
                   managementState:

--- a/config/crd/bases/services.platform.opendatahub.io_monitorings.yaml
+++ b/config/crd/bases/services.platform.opendatahub.io_monitorings.yaml
@@ -56,8 +56,9 @@ spec:
                 description: Alerting configuration for Prometheus
                 type: object
               collectorReplicas:
-                description: CollectorReplicas specifies the number of replicas in
-                  opentelemetry-collector, default is 2 if not set
+                description: |-
+                  CollectorReplicas specifies the number of replicas in opentelemetry-collector. If not set, it defaults
+                  to 1 on single-node clusters and 2 on multi-node clusters.
                 format: int32
                 type: integer
               metrics:

--- a/docs/api-overview.md
+++ b/docs/api-overview.md
@@ -2585,7 +2585,7 @@ _Appears in:_
 | `metrics` _[Metrics](#metrics)_ | metrics collection |  |  |
 | `traces` _[Traces](#traces)_ | Tracing configuration for OpenTelemetry instrumentation |  |  |
 | `alerting` _[Alerting](#alerting)_ | Alerting configuration for Prometheus |  |  |
-| `collectorReplicas` _integer_ | CollectorReplicas specifies the number of replicas in opentelemetry-collector, default is 2 if not set |  |  |
+| `collectorReplicas` _integer_ | CollectorReplicas specifies the number of replicas in opentelemetry-collector. If not set, it defaults<br />to 1 on single-node clusters and 2 on multi-node clusters. |  |  |
 
 
 #### GatewayConfig
@@ -2742,7 +2742,7 @@ _Appears in:_
 | `metrics` _[Metrics](#metrics)_ | metrics collection |  |  |
 | `traces` _[Traces](#traces)_ | Tracing configuration for OpenTelemetry instrumentation |  |  |
 | `alerting` _[Alerting](#alerting)_ | Alerting configuration for Prometheus |  |  |
-| `collectorReplicas` _integer_ | CollectorReplicas specifies the number of replicas in opentelemetry-collector, default is 2 if not set |  |  |
+| `collectorReplicas` _integer_ | CollectorReplicas specifies the number of replicas in opentelemetry-collector. If not set, it defaults<br />to 1 on single-node clusters and 2 on multi-node clusters. |  |  |
 
 
 #### MonitoringSpec
@@ -2762,7 +2762,7 @@ _Appears in:_
 | `metrics` _[Metrics](#metrics)_ | metrics collection |  |  |
 | `traces` _[Traces](#traces)_ | Tracing configuration for OpenTelemetry instrumentation |  |  |
 | `alerting` _[Alerting](#alerting)_ | Alerting configuration for Prometheus |  |  |
-| `collectorReplicas` _integer_ | CollectorReplicas specifies the number of replicas in opentelemetry-collector, default is 2 if not set |  |  |
+| `collectorReplicas` _integer_ | CollectorReplicas specifies the number of replicas in opentelemetry-collector. If not set, it defaults<br />to 1 on single-node clusters and 2 on multi-node clusters. |  |  |
 
 
 #### MonitoringStatus

--- a/internal/controller/dscinitialization/dscinitialization_controller.go
+++ b/internal/controller/dscinitialization/dscinitialization_controller.go
@@ -514,7 +514,12 @@ func (r *DSCInitializationReconciler) newMonitoringCR(ctx context.Context, dsci 
 		if dsci.Spec.Monitoring.CollectorReplicas != 0 {
 			defaultMonitoring.Spec.CollectorReplicas = dsci.Spec.Monitoring.CollectorReplicas
 		} else {
-			defaultMonitoring.Spec.CollectorReplicas = 2
+			isSNO := cluster.IsSingleNodeCluster(ctx, r.Client)
+			if isSNO {
+				defaultMonitoring.Spec.CollectorReplicas = 1
+			} else {
+				defaultMonitoring.Spec.CollectorReplicas = 2
+			}
 		}
 	}
 

--- a/internal/controller/services/monitoring/monitoring_controller_support.go
+++ b/internal/controller/services/monitoring/monitoring_controller_support.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/hashicorp/go-multierror"
 	"gopkg.in/yaml.v3"
-	corev1 "k8s.io/api/core/v1"
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -253,35 +252,6 @@ func getTemplateData(ctx context.Context, rr *odhtypes.ReconciliationRequest) (m
 	return templateData, nil
 }
 
-// isSingleNodeCluster determines if the cluster is a single-node cluster by counting the actual nodes.
-func isSingleNodeCluster(ctx context.Context, rr *odhtypes.ReconciliationRequest) bool {
-	nodeList := &corev1.NodeList{}
-	if err := rr.Client.List(ctx, nodeList); err != nil {
-		logf.FromContext(ctx).Info("could not list nodes, defaulting to multi-node behavior", "error", err)
-		return false
-	}
-
-	// Count only nodes that are ready and not marked for deletion
-	// We only need to know if there are more than 1 ready nodes, so we can break early
-	var readyNodeCount int
-	for _, node := range nodeList.Items {
-		if node.DeletionTimestamp == nil {
-			for _, condition := range node.Status.Conditions {
-				if condition.Type == corev1.NodeReady && condition.Status == corev1.ConditionTrue {
-					readyNodeCount++
-					break
-				}
-			}
-		}
-		if readyNodeCount > 1 {
-			break
-		}
-	}
-
-	logf.FromContext(ctx).V(1).Info("detected cluster size", "totalNodes", len(nodeList.Items), "readyNodes", readyNodeCount)
-	return readyNodeCount <= 1
-}
-
 func addMonitoringCapability(ctx context.Context, rr *odhtypes.ReconciliationRequest) error {
 	log := logf.FromContext(ctx)
 
@@ -420,7 +390,7 @@ func addReplicasData(ctx context.Context, rr *odhtypes.ReconciliationRequest, me
 	// - if metrics is configured (storage or resources) but no explicit replicas, use SNO-aware defaults
 	// - otherwise, rely on MonitoringStack CRD defaults
 	allowedByConfig := metrics.Storage != nil || metrics.Resources != nil
-	isSNO := isSingleNodeCluster(ctx, rr)
+	isSNO := cluster.IsSingleNodeCluster(ctx, rr.Client)
 
 	switch {
 	case metrics.Replicas != 0 && allowedByConfig:

--- a/pkg/cluster/cluster_config.go
+++ b/pkg/cluster/cluster_config.go
@@ -160,6 +160,34 @@ func IsActiveNamespace(ns *corev1.Namespace) bool {
 	return ns.Status.Phase == corev1.NamespaceActive
 }
 
+// IsSingleNodeCluster determines if the cluster is a single-node cluster by counting the actual nodes.
+func IsSingleNodeCluster(ctx context.Context, cli client.Client) bool {
+	nodeList := &corev1.NodeList{}
+	if err := cli.List(ctx, nodeList); err != nil {
+		logf.FromContext(ctx).Info("could not list nodes, defaulting to multi-node behavior", "error", err)
+		return false
+	}
+
+	// Count only nodes that are ready and not marked for deletion
+	var readyNodeCount int
+	for _, node := range nodeList.Items {
+		if node.DeletionTimestamp == nil {
+			for _, condition := range node.Status.Conditions {
+				if condition.Type == corev1.NodeReady && condition.Status == corev1.ConditionTrue {
+					readyNodeCount++
+					break
+				}
+			}
+		}
+		if readyNodeCount > 1 {
+			break
+		}
+	}
+
+	logf.FromContext(ctx).V(1).Info("detected cluster size", "totalNodes", len(nodeList.Items), "readyNodes", readyNodeCount)
+	return readyNodeCount <= 1
+}
+
 // GetClusterServiceVersion retries CSV only from the defined namespace.
 func GetClusterServiceVersion(ctx context.Context, c client.Client, namespace string) (*ofapiv1alpha1.ClusterServiceVersion, error) {
 	clusterServiceVersionList := &ofapiv1alpha1.ClusterServiceVersionList{}

--- a/tests/e2e/monitoring_test.go
+++ b/tests/e2e/monitoring_test.go
@@ -14,6 +14,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/status"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/matchers/jq"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/testf"
@@ -44,8 +45,6 @@ const (
 	OtlpTempoExporter      = "otlp/tempo"
 	MetricsCPURequest      = "50m"
 	MetricsMemoryRequest   = "128Mi"
-	MetricsDefaultReplicas = 2
-
 	// TracesStorage backend types for testing.
 	TracesStorageBackendPV  = "pv"
 	TracesStorageBackendS3  = "s3"
@@ -62,6 +61,9 @@ var monitoringOwnerReferencesCondition = And(
 
 type MonitoringTestCtx struct {
 	*TestContext
+
+	// expectedDefaultReplicas stores the expected replica count based on cluster size, 1 for single-node clusters, 2 for multi-node.
+	expectedDefaultReplicas int
 }
 
 func monitoringTestSuite(t *testing.T) {
@@ -71,9 +73,17 @@ func monitoringTestSuite(t *testing.T) {
 	tc, err := NewTestContext(t)
 	require.NoError(t, err)
 
+	// Detect cluster size once for all tests
+	isSNO := cluster.IsSingleNodeCluster(tc.Context(), tc.Client())
+	expectedReplicas := 2 // Default for multi-node
+	if isSNO {
+		expectedReplicas = 1
+	}
+
 	// Create an instance of test context.
 	monitoringServiceCtx := MonitoringTestCtx{
-		TestContext: tc,
+		TestContext:             tc,
+		expectedDefaultReplicas: expectedReplicas,
 	}
 
 	// Increase the global eventually timeout for monitoring tests involve complex operator dependencies (OpenTelemetry, Tempo, etc.)
@@ -157,7 +167,7 @@ func (tc *MonitoringTestCtx) ValidateMonitoringStackCRMetricsWhenSet(t *testing.
 	// Update DSCI to set metrics - ensure managementState remains Managed
 	tc.updateMonitoringConfig(
 		withManagementState(operatorv1.Managed),
-		withMetricsConfig(),
+		tc.withMetricsConfig(),
 	)
 
 	// Wait for the Monitoring resource to be updated by DSCInitialization controller
@@ -190,8 +200,8 @@ func (tc *MonitoringTestCtx) ValidateMonitoringStackCRMetricsConfiguration(t *te
 			jq.Match(`.spec.resources.requests.cpu == "%s"`, MetricsCPURequest),
 			// Validate memory request is set to MetricsMemoryRequest
 			jq.Match(`.spec.resources.requests.memory == "%s"`, MetricsMemoryRequest),
-			// Validate replicas is set to MetricsDefaultReplicas when it was not specified in DSCI
-			jq.Match(`.spec.prometheusConfig.replicas == %d`, MetricsDefaultReplicas),
+			// Validate replicas is set to the cluster-appropriate default value (1 for SNO, 2 for multi-node)
+			jq.Match(`.spec.prometheusConfig.replicas == %d`, tc.expectedDefaultReplicas),
 			// Validate owner references
 			monitoringOwnerReferencesCondition,
 		)),
@@ -304,7 +314,7 @@ func (tc *MonitoringTestCtx) ValidateCELAllowsValidMonitoringConfigs(t *testing.
 		{
 			name: "replicas_with_storage",
 			transforms: []testf.TransformFn{
-				withMetricsConfig(),
+				tc.withMetricsConfig(),
 			},
 			description: "Non-zero replicas should be allowed with storage",
 		},
@@ -338,7 +348,7 @@ func (tc *MonitoringTestCtx) ValidateOpenTelemetryCollectorConfigurations(t *tes
 			name: "Custom Metrics Exporters",
 			transforms: []testf.TransformFn{
 				withManagementState(operatorv1.Managed),
-				withMetricsConfig(),
+				tc.withMetricsConfig(),
 				withCustomMetricsExporters(),
 			},
 			validation: jq.Match(`
@@ -395,15 +405,13 @@ func (tc *MonitoringTestCtx) ValidateOpenTelemetryCollectorConfigurations(t *tes
 func (tc *MonitoringTestCtx) ValidateMonitoringCRCollectorReplicas(t *testing.T) {
 	t.Helper()
 
-	const (
-		defaultReplicas = 2
-		testReplicas    = 3
-	)
+	defaultReplicas := tc.expectedDefaultReplicas
+	testReplicas := defaultReplicas + 1 // Test with one more replica than default
 
 	// Setup monitoring configuration to allow collectorReplicas testing
 	tc.updateMonitoringConfig(
 		withManagementState(operatorv1.Managed),
-		withMetricsConfig(),
+		tc.withMetricsConfig(),
 	)
 
 	monitoringCR := WithMinimalObject(gvk.Monitoring, types.NamespacedName{Name: MonitoringCRName})
@@ -610,7 +618,7 @@ func (tc *MonitoringTestCtx) ValidatePrometheusRulesLifecycle(t *testing.T) {
 	// Enable alerting + dashboard → Prometheus rules created
 	tc.updateMonitoringConfig(
 		withManagementState(operatorv1.Managed),
-		withMetricsConfig(),
+		tc.withMetricsConfig(),
 		withEmptyAlerting(),
 	)
 	tc.EventuallyResourcePatched(
@@ -884,7 +892,7 @@ func withManagementState(state operatorv1.ManagementState) testf.TransformFn {
 }
 
 // withMetricsConfig returns a single transform for setting up metrics configuration using pipeline.
-func withMetricsConfig() testf.TransformFn {
+func (tc *MonitoringTestCtx) withMetricsConfig() testf.TransformFn {
 	return testf.Transform(`.spec.monitoring.metrics = {
         "storage": {
             "size": "%s",
@@ -895,7 +903,7 @@ func withMetricsConfig() testf.TransformFn {
             "memoryrequest": "%s"
         },
         "replicas": %d
-    }`, MetricsStorageSize, MetricsRetention, MetricsCPURequest, MetricsMemoryRequest, MetricsDefaultReplicas)
+    }`, MetricsStorageSize, MetricsRetention, MetricsCPURequest, MetricsMemoryRequest, tc.expectedDefaultReplicas)
 }
 
 // withMetricsReplicas returns a transform that sets metrics replicas.
@@ -1016,7 +1024,7 @@ func (tc *MonitoringTestCtx) ValidateThanosQuerierDeployment(t *testing.T) {
 
 	tc.updateMonitoringConfig(
 		withManagementState(operatorv1.Managed),
-		withMetricsConfig(),
+		tc.withMetricsConfig(),
 	)
 
 	tc.EnsureResourceExists(


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Set Otel CollectorReplicas default to 1 for single-node clusters and 2 for multi-node clusters so that RHOAI continues to deploy successfully, also changeing related e2e tests.

<!--- Link your JIRA and related links here for reference. -->
* https://issues.redhat.com/browse/RHOAIENG-34457

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested with e2e tests on single-node and multi-node clusters, source image:
* quay.io/rh-ee-froman/opendatahub-operator:RHOAIENG-34457 

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [ ] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Collector replicas now default based on cluster topology: 1 on single-node clusters and 2 on multi-node clusters (replacing the previous fixed default of 2).

* **Documentation**
  * API docs and CRD descriptions updated to reflect the cluster-aware collectorReplicas default.

* **Tests**
  * Monitoring tests updated to validate default replica behavior for single-node and multi-node clusters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->