### PR TITLE
fix: correct Unmanaged ManagementState description

### DIFF
--- a/api/components/v1alpha1/kueue_types.go
+++ b/api/components/v1alpha1/kueue_types.go
@@ -105,8 +105,7 @@ func (c *Kueue) SetReleaseStatus(releases []common.ComponentRelease) {
 type KueueManagementSpec struct {
 	// Set to one of the following values:
 	//
-	// - "Unmanaged" : the operator is actively managing the component and trying to keep it active.
-	//                 It will only upgrade the component if it is safe to do so
+	// - "Unmanaged" : the operator will not deploy or manage the component's lifecycle, but may create supporting configuration resources.
 	//
 	// - "Removed"   : the operator is actively managing the component and will not install it,
 	//                 or if it is installed, the operator will try to remove it

--- a/api/datasciencecluster/v1/datasciencecluster_types.go
+++ b/api/datasciencecluster/v1/datasciencecluster_types.go
@@ -49,8 +49,7 @@ type KueueManagementSpecV1 struct {
 	//                 It will only upgrade the component if it is safe to do so
 	//
 	//
-	// - "Unmanaged" : the operator is actively managing the component and trying to keep it active.
-	//                 It will only upgrade the component if it is safe to do so
+	// - "Unmanaged" : the operator will not deploy or manage the component's lifecycle, but may create supporting configuration resources.
 	//
 	// - "Removed"   : the operator is actively managing the component and will not install it,
 	//                 or if it is installed, the operator will try to remove it

--- a/bundle/manifests/components.platform.opendatahub.io_kueues.yaml
+++ b/bundle/manifests/components.platform.opendatahub.io_kueues.yaml
@@ -61,8 +61,7 @@ spec:
                 description: |-
                   Set to one of the following values:
 
-                  - "Unmanaged" : the operator is actively managing the component and trying to keep it active.
-                                  It will only upgrade the component if it is safe to do so
+                  - "Unmanaged" : the operator will not deploy or manage the component's lifecycle, but may create supporting configuration resources.
 
                   - "Removed"   : the operator is actively managing the component and will not install it,
                                   or if it is installed, the operator will try to remove it

--- a/bundle/manifests/datasciencecluster.opendatahub.io_datascienceclusters.yaml
+++ b/bundle/manifests/datasciencecluster.opendatahub.io_datascienceclusters.yaml
@@ -221,8 +221,7 @@ spec:
                           - "Managed"   : the operator is actively managing the component and trying to keep it active.
                                           It will only upgrade the component if it is safe to do so
 
-                          - "Unmanaged" : the operator is actively managing the component and trying to keep it active.
-                                          It will only upgrade the component if it is safe to do so
+                          - "Unmanaged" : the operator will not deploy or manage the component's lifecycle, but may create supporting configuration resources.
 
                           - "Removed"   : the operator is actively managing the component and will not install it,
                                           or if it is installed, the operator will try to remove it
@@ -588,8 +587,7 @@ spec:
                         description: |-
                           Set to one of the following values:
 
-                          - "Unmanaged" : the operator is actively managing the component and trying to keep it active.
-                                          It will only upgrade the component if it is safe to do so
+                          - "Unmanaged" : the operator will not deploy or manage the component's lifecycle, but may create supporting configuration resources.
 
                           - "Removed"   : the operator is actively managing the component and will not install it,
                                           or if it is installed, the operator will try to remove it
@@ -1177,8 +1175,7 @@ spec:
                         description: |-
                           Set to one of the following values:
 
-                          - "Unmanaged" : the operator is actively managing the component and trying to keep it active.
-                                          It will only upgrade the component if it is safe to do so
+                          - "Unmanaged" : the operator will not deploy or manage the component's lifecycle, but may create supporting configuration resources.
 
                           - "Removed"   : the operator is actively managing the component and will not install it,
                                           or if it is installed, the operator will try to remove it
@@ -1489,8 +1486,7 @@ spec:
                         description: |-
                           Set to one of the following values:
 
-                          - "Unmanaged" : the operator is actively managing the component and trying to keep it active.
-                                          It will only upgrade the component if it is safe to do so
+                          - "Unmanaged" : the operator will not deploy or manage the component's lifecycle, but may create supporting configuration resources.
 
                           - "Removed"   : the operator is actively managing the component and will not install it,
                                           or if it is installed, the operator will try to remove it

--- a/bundle/manifests/opendatahub-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/opendatahub-operator.clusterserviceversion.yaml
@@ -83,7 +83,7 @@ metadata:
     categories: AI/Machine Learning, Big Data
     certified: "False"
     containerImage: quay.io/opendatahub/opendatahub-operator:v3.0.0
-    createdAt: "2025-10-22T13:59:23Z"
+    createdAt: "2025-10-23T10:24:07Z"
     operators.operatorframework.io/builder: operator-sdk-v1.39.2
     operators.operatorframework.io/internal-objects: '["featuretrackers.features.opendatahub.io",
       "dashboards.components.platform.opendatahub.io", "datasciencepipelines.components.platform.opendatahub.io",

--- a/config/crd/bases/components.platform.opendatahub.io_kueues.yaml
+++ b/config/crd/bases/components.platform.opendatahub.io_kueues.yaml
@@ -61,8 +61,7 @@ spec:
                 description: |-
                   Set to one of the following values:
 
-                  - "Unmanaged" : the operator is actively managing the component and trying to keep it active.
-                                  It will only upgrade the component if it is safe to do so
+                  - "Unmanaged" : the operator will not deploy or manage the component's lifecycle, but may create supporting configuration resources.
 
                   - "Removed"   : the operator is actively managing the component and will not install it,
                                   or if it is installed, the operator will try to remove it

--- a/config/crd/bases/datasciencecluster.opendatahub.io_datascienceclusters.yaml
+++ b/config/crd/bases/datasciencecluster.opendatahub.io_datascienceclusters.yaml
@@ -210,8 +210,7 @@ spec:
                           - "Managed"   : the operator is actively managing the component and trying to keep it active.
                                           It will only upgrade the component if it is safe to do so
 
-                          - "Unmanaged" : the operator is actively managing the component and trying to keep it active.
-                                          It will only upgrade the component if it is safe to do so
+                          - "Unmanaged" : the operator will not deploy or manage the component's lifecycle, but may create supporting configuration resources.
 
                           - "Removed"   : the operator is actively managing the component and will not install it,
                                           or if it is installed, the operator will try to remove it
@@ -577,8 +576,7 @@ spec:
                         description: |-
                           Set to one of the following values:
 
-                          - "Unmanaged" : the operator is actively managing the component and trying to keep it active.
-                                          It will only upgrade the component if it is safe to do so
+                          - "Unmanaged" : the operator will not deploy or manage the component's lifecycle, but may create supporting configuration resources.
 
                           - "Removed"   : the operator is actively managing the component and will not install it,
                                           or if it is installed, the operator will try to remove it
@@ -1166,8 +1164,7 @@ spec:
                         description: |-
                           Set to one of the following values:
 
-                          - "Unmanaged" : the operator is actively managing the component and trying to keep it active.
-                                          It will only upgrade the component if it is safe to do so
+                          - "Unmanaged" : the operator will not deploy or manage the component's lifecycle, but may create supporting configuration resources.
 
                           - "Removed"   : the operator is actively managing the component and will not install it,
                                           or if it is installed, the operator will try to remove it
@@ -1478,8 +1475,7 @@ spec:
                         description: |-
                           Set to one of the following values:
 
-                          - "Unmanaged" : the operator is actively managing the component and trying to keep it active.
-                                          It will only upgrade the component if it is safe to do so
+                          - "Unmanaged" : the operator will not deploy or manage the component's lifecycle, but may create supporting configuration resources.
 
                           - "Removed"   : the operator is actively managing the component and will not install it,
                                           or if it is installed, the operator will try to remove it

--- a/docs/api-overview.md
+++ b/docs/api-overview.md
@@ -201,7 +201,7 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `managementState` _[ManagementState](https://pkg.go.dev/github.com/openshift/api@v0.0.0-20250812222054-88b2b21555f3/operator/v1#ManagementState)_ | Set to one of the following values:<br />- "Unmanaged" : the operator is actively managing the component and trying to keep it active.<br />                It will only upgrade the component if it is safe to do so<br />- "Removed"   : the operator is actively managing the component and will not install it,<br />                or if it is installed, the operator will try to remove it |  | Enum: [Unmanaged Removed] <br /> |
+| `managementState` _[ManagementState](https://pkg.go.dev/github.com/openshift/api@v0.0.0-20250812222054-88b2b21555f3/operator/v1#ManagementState)_ | Set to one of the following values:<br />- "Unmanaged" : the operator will not deploy or manage the component's lifecycle, but may create supporting configuration resources.<br />- "Removed"   : the operator is actively managing the component and will not install it,<br />                or if it is installed, the operator will try to remove it |  | Enum: [Unmanaged Removed] <br /> |
 | `defaultLocalQueueName` _string_ | Configures the automatically created, in the managed namespaces, local queue name. | default |  |
 | `defaultClusterQueueName` _string_ | Configures the automatically created cluster queue name. | default |  |
 
@@ -220,7 +220,7 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `managementState` _[ManagementState](https://pkg.go.dev/github.com/openshift/api@v0.0.0-20250812222054-88b2b21555f3/operator/v1#ManagementState)_ | Set to one of the following values:<br />- "Unmanaged" : the operator is actively managing the component and trying to keep it active.<br />                It will only upgrade the component if it is safe to do so<br />- "Removed"   : the operator is actively managing the component and will not install it,<br />                or if it is installed, the operator will try to remove it |  | Enum: [Unmanaged Removed] <br /> |
+| `managementState` _[ManagementState](https://pkg.go.dev/github.com/openshift/api@v0.0.0-20250812222054-88b2b21555f3/operator/v1#ManagementState)_ | Set to one of the following values:<br />- "Unmanaged" : the operator will not deploy or manage the component's lifecycle, but may create supporting configuration resources.<br />- "Removed"   : the operator is actively managing the component and will not install it,<br />                or if it is installed, the operator will try to remove it |  | Enum: [Unmanaged Removed] <br /> |
 
 
 #### DSCLlamaStackOperator
@@ -867,7 +867,7 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `managementState` _[ManagementState](https://pkg.go.dev/github.com/openshift/api@v0.0.0-20250812222054-88b2b21555f3/operator/v1#ManagementState)_ | Set to one of the following values:<br />- "Unmanaged" : the operator is actively managing the component and trying to keep it active.<br />                It will only upgrade the component if it is safe to do so<br />- "Removed"   : the operator is actively managing the component and will not install it,<br />                or if it is installed, the operator will try to remove it |  | Enum: [Unmanaged Removed] <br /> |
+| `managementState` _[ManagementState](https://pkg.go.dev/github.com/openshift/api@v0.0.0-20250812222054-88b2b21555f3/operator/v1#ManagementState)_ | Set to one of the following values:<br />- "Unmanaged" : the operator will not deploy or manage the component's lifecycle, but may create supporting configuration resources.<br />- "Removed"   : the operator is actively managing the component and will not install it,<br />                or if it is installed, the operator will try to remove it |  | Enum: [Unmanaged Removed] <br /> |
 
 
 #### KueueSpec
@@ -883,7 +883,7 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `managementState` _[ManagementState](https://pkg.go.dev/github.com/openshift/api@v0.0.0-20250812222054-88b2b21555f3/operator/v1#ManagementState)_ | Set to one of the following values:<br />- "Unmanaged" : the operator is actively managing the component and trying to keep it active.<br />                It will only upgrade the component if it is safe to do so<br />- "Removed"   : the operator is actively managing the component and will not install it,<br />                or if it is installed, the operator will try to remove it |  | Enum: [Unmanaged Removed] <br /> |
+| `managementState` _[ManagementState](https://pkg.go.dev/github.com/openshift/api@v0.0.0-20250812222054-88b2b21555f3/operator/v1#ManagementState)_ | Set to one of the following values:<br />- "Unmanaged" : the operator will not deploy or manage the component's lifecycle, but may create supporting configuration resources.<br />- "Removed"   : the operator is actively managing the component and will not install it,<br />                or if it is installed, the operator will try to remove it |  | Enum: [Unmanaged Removed] <br /> |
 | `defaultLocalQueueName` _string_ | Configures the automatically created, in the managed namespaces, local queue name. | default |  |
 | `defaultClusterQueueName` _string_ | Configures the automatically created cluster queue name. | default |  |
 
@@ -1681,7 +1681,7 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `managementState` _[ManagementState](https://pkg.go.dev/github.com/openshift/api@v0.0.0-20250812222054-88b2b21555f3/operator/v1#ManagementState)_ | Set to one of the following values:<br />- "Managed"   : the operator is actively managing the component and trying to keep it active.<br />                It will only upgrade the component if it is safe to do so<br />- "Unmanaged" : the operator is actively managing the component and trying to keep it active.<br />                It will only upgrade the component if it is safe to do so<br />- "Removed"   : the operator is actively managing the component and will not install it,<br />                or if it is installed, the operator will try to remove it |  | Enum: [Managed Unmanaged Removed] <br /> |
+| `managementState` _[ManagementState](https://pkg.go.dev/github.com/openshift/api@v0.0.0-20250812222054-88b2b21555f3/operator/v1#ManagementState)_ | Set to one of the following values:<br />- "Managed"   : the operator is actively managing the component and trying to keep it active.<br />                It will only upgrade the component if it is safe to do so<br />- "Unmanaged" : the operator will not deploy or manage the component's lifecycle, but may create supporting configuration resources.<br />- "Removed"   : the operator is actively managing the component and will not install it,<br />                or if it is installed, the operator will try to remove it |  | Enum: [Managed Unmanaged Removed] <br /> |
 | `defaultLocalQueueName` _string_ | Configures the automatically created, in the managed namespaces, local queue name. | default |  |
 | `defaultClusterQueueName` _string_ | Configures the automatically created cluster queue name. | default |  |
 
@@ -1759,7 +1759,7 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `managementState` _[ManagementState](https://pkg.go.dev/github.com/openshift/api@v0.0.0-20250812222054-88b2b21555f3/operator/v1#ManagementState)_ | Set to one of the following values:<br />- "Managed"   : the operator is actively managing the component and trying to keep it active.<br />                It will only upgrade the component if it is safe to do so<br />- "Unmanaged" : the operator is actively managing the component and trying to keep it active.<br />                It will only upgrade the component if it is safe to do so<br />- "Removed"   : the operator is actively managing the component and will not install it,<br />                or if it is installed, the operator will try to remove it |  | Enum: [Managed Unmanaged Removed] <br /> |
+| `managementState` _[ManagementState](https://pkg.go.dev/github.com/openshift/api@v0.0.0-20250812222054-88b2b21555f3/operator/v1#ManagementState)_ | Set to one of the following values:<br />- "Managed"   : the operator is actively managing the component and trying to keep it active.<br />                It will only upgrade the component if it is safe to do so<br />- "Unmanaged" : the operator will not deploy or manage the component's lifecycle, but may create supporting configuration resources.<br />- "Removed"   : the operator is actively managing the component and will not install it,<br />                or if it is installed, the operator will try to remove it |  | Enum: [Managed Unmanaged Removed] <br /> |
 
 
 


### PR DESCRIPTION
## Description

Fixes the incorrect description of the "Unmanaged" ManagementState in API documentation.

**Before (incorrect):**
> "the operator is actively managing the component and trying to keep it active"

**After (correct):**
> "the operator will not deploy or manage the component's lifecycle, but may create supporting configuration resources"

This accurately reflects the actual behavior where the operator doesn't deploy/manage the component itself but may create supporting resources (e.g., ClusterQueues, LocalQueues).

**Related JIRA:** [RHOAIENG-32465](https://issues.redhat.com/browse/RHOAIENG-32465)

## How Has This Been Tested?

- Ran `make generate manifests api-docs` and `make bundle` to regenerate all files
- Verified the description was updated correctly in all CRDs and API documentation

## Screenshot or short clip

N/A - Documentation-only change.

## Merge criteria

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

- [x] Skip requirement to update E2E test suite for this PR

#### E2E update requirement opt-out justification

Documentation-only change.