### PR TITLE
update: cleanup kueue controller image + remove support on Managed status

### DIFF
--- a/internal/controller/components/kueue/kueue.go
+++ b/internal/controller/components/kueue/kueue.go
@@ -68,6 +68,8 @@ func (s *componentHandler) Init(platform common.Platform) error {
 
 func (s *componentHandler) IsEnabled(dsc *dscv2.DataScienceCluster) bool {
 	switch dsc.Spec.Components.Kueue.ManagementState {
+	case operatorv1.Managed:
+		return true
 	case operatorv1.Unmanaged:
 		return true
 	default:

--- a/internal/controller/components/kueue/kueue_test.go
+++ b/internal/controller/components/kueue/kueue_test.go
@@ -35,7 +35,7 @@ func TestNewCRObject(t *testing.T) {
 	handler := &componentHandler{}
 
 	g := NewWithT(t)
-	dsc := createDSCWithKueue(operatorv1.Unmanaged)
+	dsc := createDSCWithKueue(operatorv1.Managed)
 
 	cr := handler.NewCRObject(dsc)
 	g.Expect(cr).ShouldNot(BeNil())
@@ -45,7 +45,7 @@ func TestNewCRObject(t *testing.T) {
 		jq.Match(`.metadata.name == "%s"`, componentApi.KueueInstanceName),
 		jq.Match(`.kind == "%s"`, componentApi.KueueKind),
 		jq.Match(`.apiVersion == "%s"`, componentApi.GroupVersion),
-		jq.Match(`.metadata.annotations["%s"] == "%s"`, annotations.ManagementStateAnnotation, operatorv1.Unmanaged),
+		jq.Match(`.metadata.annotations["%s"] == "%s"`, annotations.ManagementStateAnnotation, operatorv1.Managed),
 	)))
 }
 
@@ -58,9 +58,9 @@ func TestIsEnabled(t *testing.T) {
 		matcher gt.GomegaMatcher
 	}{
 		{
-			name:    "should return false when management state is Managed",
+			name:    "should return true when management state is Managed",
 			state:   operatorv1.Managed,
-			matcher: BeFalse(),
+			matcher: BeTrue(),
 		},
 		{
 			name:    "should return true when management state is Unmanaged",
@@ -95,7 +95,7 @@ func TestUpdateDSCStatus(t *testing.T) {
 		g := NewWithT(t)
 		ctx := t.Context()
 
-		dsc := createDSCWithKueue(operatorv1.Unmanaged)
+		dsc := createDSCWithKueue(operatorv1.Managed)
 		kueue := createKueueComponentCR(true)
 
 		cli, err := fakeclient.New(fakeclient.WithObjects(dsc, kueue))
@@ -111,7 +111,7 @@ func TestUpdateDSCStatus(t *testing.T) {
 		g.Expect(cs).Should(Equal(metav1.ConditionTrue))
 
 		g.Expect(dsc).Should(WithTransform(json.Marshal, And(
-			jq.Match(`.status.components.kueue.managementState == "%s"`, operatorv1.Unmanaged),
+			jq.Match(`.status.components.kueue.managementState == "%s"`, operatorv1.Managed),
 			jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, ReadyConditionType, metav1.ConditionTrue),
 			jq.Match(`.status.conditions[] | select(.type == "%s") | .reason == "%s"`, ReadyConditionType, status.ReadyReason),
 			jq.Match(`.status.conditions[] | select(.type == "%s") | .message == "Component is ready"`, ReadyConditionType)),
@@ -149,7 +149,7 @@ func TestUpdateDSCStatus(t *testing.T) {
 		g := NewWithT(t)
 		ctx := t.Context()
 
-		dsc := createDSCWithKueue(operatorv1.Unmanaged)
+		dsc := createDSCWithKueue(operatorv1.Managed)
 		kueue := createKueueComponentCR(false)
 
 		cli, err := fakeclient.New(fakeclient.WithObjects(dsc, kueue))
@@ -165,7 +165,7 @@ func TestUpdateDSCStatus(t *testing.T) {
 		g.Expect(cs).Should(Equal(metav1.ConditionFalse))
 
 		g.Expect(dsc).Should(WithTransform(json.Marshal, And(
-			jq.Match(`.status.components.kueue.managementState == "%s"`, operatorv1.Unmanaged),
+			jq.Match(`.status.components.kueue.managementState == "%s"`, operatorv1.Managed),
 			jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, ReadyConditionType, metav1.ConditionFalse),
 			jq.Match(`.status.conditions[] | select(.type == "%s") | .reason == "%s"`, ReadyConditionType, status.NotReadyReason),
 			jq.Match(`.status.conditions[] | select(.type == "%s") | .message == "Component is not ready"`, ReadyConditionType)),


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->
- remove replacement for kueue image by operator
- remove Managed as supported value + update unit test --- TBD need confirm

<!--- Link your JIRA and related links here for reference. -->
part of https://issues.redhat.com/browse/RHOAIENG-36272 for kueue image

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->
already e2e cover unamanged and removed cases


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed unused internal dependencies and dead code paths to streamline the codebase and improve system efficiency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->