### PR TITLE
update: do not create Auth CR if cluster is on OIDC mode

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -139,6 +139,7 @@ func init() { //nolint:gochecknoinits
 	utilruntime.Must(apiextensionsv1.AddToScheme(scheme))
 	utilruntime.Must(admissionregistrationv1.AddToScheme(scheme))
 	utilruntime.Must(promv1.AddToScheme(scheme))
+	utilruntime.Must(configv1.Install(scheme))
 	utilruntime.Must(operatorv1.Install(scheme))
 	utilruntime.Must(consolev1.AddToScheme(scheme))
 	utilruntime.Must(securityv1.Install(scheme))


### PR DESCRIPTION
As in OCP 4.20, user will be able to change Authentication CR after cluster has been setup, if they want to change from Oauth to OIDC and they should have abliity to change from OIDC back to Oauth.

the main reason for this PR is when user config to use OIDC, ODH operator should not need to create Auth CR by default (what is done for now is: create Auth CR regardless DSCI is created or not)  and set defult group (what is done for now is: set odh-admins as admin and allow any system:authenticated user to access) 
- on OIDC: do not create Auth CR if not exist, and delete it if exist (might be from previous run)
- on Oauth: create Auth CR if not exist
- rename `CreateAuth` to `ManageAuthCR` to handle different logic
- add a mock Auth CR in unit-test

<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->
the original check on Auth CR remains, as e2e env keep using oauth


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Authentication handling now respects integrated vs external auth: integrated flows create or preserve required auth configuration; external flows avoid creating and will remove managed auth when present.
  * Reduced unnecessary recreation of auth configuration when external identity providers are in use.

* **New Features**
  * Added automatic monitoring of cluster authentication settings to trigger updates when authentication mode changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->