### PR TITLE
fix: remove appwrapper from kueue supported framework configuration

### DIFF
--- a/internal/controller/components/kueue/kueue_config.go
+++ b/internal/controller/components/kueue/kueue_config.go
@@ -21,19 +21,18 @@ import (
 
 var (
 	frameworkMapping = map[string]string{
-		"pod":                                      "Pod",
-		"deployment":                               "Deployment",
-		"statefulset":                              "StatefulSet",
-		"batch/job":                                "BatchJob",
-		"ray.io/rayjob":                            "RayJob",
-		"ray.io/raycluster":                        "RayCluster",
-		"jobset.x-k8s.io/jobset":                   "JobSet",
-		"kubeflow.org/mpijob":                      "MPIJob",
-		"kubeflow.org/paddlejob":                   "PaddleJob",
-		"kubeflow.org/pytorchjob":                  "PyTorchJob",
-		"kubeflow.org/tfjob":                       "TFJob",
-		"kubeflow.org/xgboostjob":                  "XGBoostJob",
-		"workload.codeflare.dev/appwrapper":        "AppWrapper",
+		"pod":                     "Pod",
+		"deployment":              "Deployment",
+		"statefulset":             "StatefulSet",
+		"batch/job":               "BatchJob",
+		"ray.io/rayjob":           "RayJob",
+		"ray.io/raycluster":       "RayCluster",
+		"jobset.x-k8s.io/jobset":  "JobSet",
+		"kubeflow.org/mpijob":     "MPIJob",
+		"kubeflow.org/paddlejob":  "PaddleJob",
+		"kubeflow.org/pytorchjob": "PyTorchJob",
+		"kubeflow.org/tfjob":      "TFJob",
+		"kubeflow.org/xgboostjob": "XGBoostJob",
 		"leaderworkerset.x-k8s.io/leaderworkerset": "LeaderWorkerSet",
 	}
 )

--- a/internal/controller/components/kueue/kueue_config_test.go
+++ b/internal/controller/components/kueue/kueue_config_test.go
@@ -81,7 +81,6 @@ spec:
   config:
     integrations:
       frameworks:
-        - AppWrapper
         - BatchJob
         - Deployment
         - JobSet

--- a/tests/e2e/kueue_test.go
+++ b/tests/e2e/kueue_test.go
@@ -172,7 +172,7 @@ func (tc *KueueTestCtx) ValidateKueueRemovedToUnmanagedTransition(t *testing.T) 
 		WithMinimalObject(gvk.KueueConfigV1, types.NamespacedName{Name: kueue.KueueCRName}),
 		WithCondition(And(
 			jq.Match(`([
-				"AppWrapper", "BatchJob", "Deployment", "JobSet", "LeaderWorkerSet", "MPIJob",
+				"BatchJob", "Deployment", "JobSet", "LeaderWorkerSet", "MPIJob",
 				"PaddleJob", "Pod", "PyTorchJob", "RayCluster", "RayJob", "StatefulSet", "TFJob",
 				"XGBoostJob"
 			] - .spec.config.integrations.frameworks) | length == 0`),


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description

Remove AppWrapper from kueue supported framework, as it is not supported anymore. 
It would be always possible to modify the Kueue configuration manually to add it.

Jira task: https://issues.redhat.com/browse/RHOAIENG-37336

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [x] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [ ] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for LeaderWorkerSet framework integration in Kueue configuration.

* **Breaking Changes**
  * Removed support for AppWrapper framework. Update your Kueue configurations accordingly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->