### PR TITLE
RHOAIENG-34457 | chore: update bundle manifests for SNO-aware collector replicas

### DIFF
--- a/bundle/manifests/dscinitialization.opendatahub.io_dscinitializations.yaml
+++ b/bundle/manifests/dscinitialization.opendatahub.io_dscinitializations.yaml
@@ -105,8 +105,9 @@ spec:
                     description: Alerting configuration for Prometheus
                     type: object
                   collectorReplicas:
-                    description: CollectorReplicas specifies the number of replicas
-                      in opentelemetry-collector, default is 2 if not set
+                    description: |-
+                      CollectorReplicas specifies the number of replicas in opentelemetry-collector. If not set, it defaults
+                      to 1 on single-node clusters and 2 on multi-node clusters.
                     format: int32
                     type: integer
                   managementState:
@@ -610,8 +611,9 @@ spec:
                     description: Alerting configuration for Prometheus
                     type: object
                   collectorReplicas:
-                    description: CollectorReplicas specifies the number of replicas
-                      in opentelemetry-collector, default is 2 if not set
+                    description: |-
+                      CollectorReplicas specifies the number of replicas in opentelemetry-collector. If not set, it defaults
+                      to 1 on single-node clusters and 2 on multi-node clusters.
                     format: int32
                     type: integer
                   managementState:

--- a/bundle/manifests/services.platform.opendatahub.io_monitorings.yaml
+++ b/bundle/manifests/services.platform.opendatahub.io_monitorings.yaml
@@ -56,8 +56,9 @@ spec:
                 description: Alerting configuration for Prometheus
                 type: object
               collectorReplicas:
-                description: CollectorReplicas specifies the number of replicas in
-                  opentelemetry-collector, default is 2 if not set
+                description: |-
+                  CollectorReplicas specifies the number of replicas in opentelemetry-collector. If not set, it defaults
+                  to 1 on single-node clusters and 2 on multi-node clusters.
                 format: int32
                 type: integer
               metrics:


### PR DESCRIPTION
## Description
Update the generated bundle manifests to reflect the SNO-aware default replica logic for the OpenTelemetry collector.

These changes were generated by running `make bundle` after updating the codebase.

Related to #2738 


<!--- Link your JIRA and related links here for reference. -->
* https://issues.redhat.com/browse/RHOAIENG-34457

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->
no need for new e2e tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified monitoring configuration: when collector replica count is not explicitly specified, documentation now states single-node clusters default to 1 replica and multi-node clusters default to 2 replicas. This provides clearer guidance for administrators configuring monitoring infrastructure based on cluster topology and capacity requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->