### PR TITLE
test: add parallel components and services test execution

### DIFF
--- a/cmd/test-retry/pkg/runner/integration_test.go
+++ b/cmd/test-retry/pkg/runner/integration_test.go
@@ -138,6 +138,22 @@ func TestRunnerIntegration(t *testing.T) {
 				{Name: "TestDuplicated/two_of_me#01", HasFailure: true},
 			},
 		},
+		{
+			name:           "parallel tests",
+			testPath:       "./testdata/parallel",
+			skipAtPrefixes: []string{"TestParallel/"},
+			expectedResults: []testCaseOutput{
+				{Name: "TestParallel", HasFailure: true},
+				{Name: "TestParallel/Test1", HasFailure: false},
+				{Name: "TestParallel/Test2", HasFailure: true},
+				{Name: "TestParallel/Test3", HasFailure: false},
+				{Name: "TestParallel", HasFailure: true},
+				{Name: "TestParallel/Test2", HasFailure: true},
+				{Name: "TestParallel", HasFailure: true},
+				{Name: "TestParallel/Test2", HasFailure: true},
+			},
+			expectedError: "2 tests failed after retries",
+		},
 	}
 
 	for _, testCase := range testCases {

--- a/cmd/test-retry/pkg/runner/testdata/parallel/parallel_test.go
+++ b/cmd/test-retry/pkg/runner/testdata/parallel/parallel_test.go
@@ -1,0 +1,24 @@
+package parallel
+
+import (
+	"testing"
+	"time"
+)
+
+func TestParallel(t *testing.T) {
+	t.Run("Test1", func(t *testing.T) {
+		t.Parallel()
+		time.Sleep(1 * time.Second)
+		t.Log("Test1")
+	})
+
+	t.Run("Test2", func(t *testing.T) {
+		t.Parallel()
+		t.Fail()
+	})
+
+	t.Run("Test3", func(t *testing.T) {
+		t.Parallel()
+		t.Log("Test3")
+	})
+}

--- a/tests/e2e/components_test.go
+++ b/tests/e2e/components_test.go
@@ -275,16 +275,19 @@ func (tc *ComponentTestCtx) UpdateComponentStateInDataScienceClusterWithKind(sta
 		jq.Match(`.status.conditions[] | select(.type == "%sReady") | .status == "%s"`, conditionKind, readyCondition),
 	}
 
+	// TODO: Commented out because this check does not work with parallel component tests.
+	// Verify it is still needed, otherwise remove it. A new test only for those conditions is added in resilience tests.
+	//
 	// If the state is "Managed", add additional checks for provisioning and components readiness.
-	if state == operatorv1.Managed {
-		conditions = append(conditions,
-			// Validate the "ProvisioningSucceeded" condition
-			jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, status.ConditionTypeProvisioningSucceeded, readyCondition),
+	// if state == operatorv1.Managed {
+	// 	conditions = append(conditions,
+	// 		// Validate the "ProvisioningSucceeded" condition
+	// 		jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, status.ConditionTypeProvisioningSucceeded, readyCondition),
 
-			// Validate the "ComponentsReady" condition
-			jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, status.ConditionTypeComponentsReady, readyCondition),
-		)
-	}
+	// 		// Validate the "ComponentsReady" condition
+	// 		jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, status.ConditionTypeComponentsReady, readyCondition),
+	// 	)
+	// }
 
 	// Update the management state of the component in the DataScienceCluster.
 	tc.EventuallyResourcePatched(

--- a/tests/e2e/kueue_test.go
+++ b/tests/e2e/kueue_test.go
@@ -253,11 +253,6 @@ func (tc *KueueTestCtx) ValidateKueueUnmanagedToRemovedTransition(t *testing.T) 
 		WithCondition(And(conditionsRemovedReady...)),
 	)
 
-	tc.EventuallyResourcePatched(
-		WithMinimalObject(gvk.DataScienceCluster, tc.DataScienceClusterNamespacedName),
-		WithCondition(And(conditionsRemovedReady...)),
-	)
-
 	// Validate default resources are still there
 	tc.ensureClusterAndLocalQueueExist(kueueTestManagedNamespace)
 
@@ -273,14 +268,14 @@ func (tc *KueueTestCtx) ValidateWebhookValidations(t *testing.T) {
 	// Enable Workbenches component to ensure Notebook CRD is available for webhook tests
 	// This is required because webhook tests use Notebook objects which need the Notebook CRD
 	// installed by the Workbenches component
-	tc.UpdateComponentStateInDataScienceClusterWithKind(operatorv1.Managed, "Workbenches")
+	tc.UpdateComponentStateInDataScienceClusterWithKind(operatorv1.Managed, componentApi.WorkbenchesKind)
 
 	// Run webhook validation tests as subtests
 	t.Run("Kueue webhook validation", tc.ValidateKueueWebhookValidation)
 	t.Run("Hardware profile webhook validation", tc.ValidateHardwareProfileWebhookValidation)
 
 	// Ensure Workbenches is disabled after tests, even if they fail
-	tc.UpdateComponentStateInDataScienceClusterWithKind(operatorv1.Removed, "Workbenches")
+	tc.UpdateComponentStateInDataScienceClusterWithKind(operatorv1.Removed, componentApi.WorkbenchesKind)
 
 	// Remove Kueue test resources
 	cleanupKueueTestResources(t, tc.TestContext)

--- a/tests/e2e/monitoring_test.go
+++ b/tests/e2e/monitoring_test.go
@@ -692,7 +692,10 @@ func (tc *MonitoringTestCtx) ensureMonitoringCleanSlate(t *testing.T, secretName
 	tc.resetMonitoringConfigToRemoved()
 
 	// Wait for all monitoring resources to be cleaned up
-	tc.EnsureResourcesGone(WithMinimalObject(gvk.Monitoring, types.NamespacedName{Name: MonitoringCRName}))
+	tc.EnsureResourcesGone(
+		WithMinimalObject(gvk.Monitoring, types.NamespacedName{Name: MonitoringCRName}),
+		WithWaitForDeletion(true),
+	)
 
 	// Clean up TempoStack and associated secret (if provided)
 	tc.cleanupTempoStackAndSecret(secretName)
@@ -1101,11 +1104,11 @@ func (tc *MonitoringTestCtx) ValidateThanosQuerierNotDeployedWithoutMetrics(t *t
 		WithCustomErrorMsg("ThanosQuerier condition should be False with reason MetricsNotConfigured when metrics are not configured"),
 	)
 
-	tc.EnsureResourceDoesNotExist(
+	tc.EnsureResourceGone(
 		WithMinimalObject(gvk.ThanosQuerier, types.NamespacedName{Name: ThanosQuerierName, Namespace: tc.MonitoringNamespace}),
 	)
 
-	tc.EnsureResourceDoesNotExist(
+	tc.EnsureResourceGone(
 		WithMinimalObject(gvk.Route, types.NamespacedName{Name: ThanosQuerierRouteName, Namespace: tc.MonitoringNamespace}),
 	)
 


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
Run e2e tests for components and services in parallel.

This will speed up the e2e, with locally a reduction of ~20m of time for each run. The components itself will go from ~26m to ~10m.
Also, this change will run both components and services tests in alphabetical order, to improve repeatability across runs.

There is a flag on the `TestGroup` struct to enable/disable entirely the parallelization. We could also evolve this to be configurable by cli options and during the cli retry avoid set it to false.

Jira task: https://issues.redhat.com/browse/RHOAIENG-37402

## How Has This Been Tested?
Run e2e tests locally various times, with also different test options:
- `-count=3 -timeout=60m` to verify with a lot of sequent run will works correctly
- `-race` to verify no race conditions between different components/services runs

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [x] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [ ] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added grouped and parallel test execution with per-group subtests and options.
  * Added a new parallel test exercising retries and per-test expectations.
  * Added a resilience test validating components deployment success.
  * Improved cleanup to wait for resource deletion where needed.

* **Bug Fixes**
  * Simplified component readiness validation logic.
  * Removed redundant resource-patching steps and aligned negative existence checks to a "gone" pattern.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->