### PR TITLE
chore: remove unnecessary deployment mode configuration from KServe component

### DIFF
--- a/internal/controller/components/kserve/config.go
+++ b/internal/controller/components/kserve/config.go
@@ -2,7 +2,6 @@ package kserve
 
 // ConfigMap Keys.
 const (
-	DeployConfigName     = "deploy"
 	IngressConfigKeyName = "ingress"
 	ServiceConfigKeyName = "service"
 )

--- a/internal/controller/components/kserve/kserve_controller_actions_test.go
+++ b/internal/controller/components/kserve/kserve_controller_actions_test.go
@@ -52,12 +52,6 @@ func TestCustomizeKserveConfigMap(t *testing.T) {
 		err = runtime.DefaultUnstructuredConverter.FromUnstructured(rr.Resources[0].Object, updatedConfigMap)
 		g.Expect(err).ShouldNot(HaveOccurred())
 
-		// verify deploy config is set to RawDeployment
-		var deployConfig map[string]interface{}
-		err = json.Unmarshal([]byte(updatedConfigMap.Data[DeployConfigName]), &deployConfig)
-		g.Expect(err).ShouldNot(HaveOccurred())
-		g.Expect(deployConfig["defaultDeploymentMode"]).Should(Equal("RawDeployment"))
-
 		// verify ingress creation is disabled
 		var ingressData map[string]interface{}
 		err = json.Unmarshal([]byte(updatedConfigMap.Data[IngressConfigKeyName]), &ingressData)
@@ -102,11 +96,6 @@ func TestCustomizeKserveConfigMap(t *testing.T) {
 		updatedConfigMap := &corev1.ConfigMap{}
 		err = runtime.DefaultUnstructuredConverter.FromUnstructured(rr.Resources[0].Object, updatedConfigMap)
 		g.Expect(err).ShouldNot(HaveOccurred())
-
-		var deployConfig map[string]interface{}
-		err = json.Unmarshal([]byte(updatedConfigMap.Data[DeployConfigName]), &deployConfig)
-		g.Expect(err).ShouldNot(HaveOccurred())
-		g.Expect(deployConfig["defaultDeploymentMode"]).Should(Equal("RawDeployment"))
 
 		var ingressData map[string]interface{}
 		err = json.Unmarshal([]byte(updatedConfigMap.Data[IngressConfigKeyName]), &ingressData)
@@ -217,9 +206,6 @@ func createTestConfigMap() *corev1.ConfigMap {
 			Name: kserveConfigMapName,
 		},
 		Data: map[string]string{
-			DeployConfigName: `{
-				"defaultDeploymentMode": "RawDeployment"
-			}`,
 			IngressConfigKeyName: `{
 				"disableIngressCreation": false
 			}`,

--- a/internal/controller/components/kserve/kserve_support.go
+++ b/internal/controller/components/kserve/kserve_support.go
@@ -45,21 +45,10 @@ func kserveManifestInfo(sourcePath string) odhtypes.ManifestInfo {
 }
 
 func updateInferenceCM(inferenceServiceConfigMap *corev1.ConfigMap, isHeadless bool) error {
-	// deploy
-	// RawDeployment mode is the only supported mode
-	deployData := map[string]interface{}{
-		"defaultDeploymentMode": "RawDeployment",
-	}
-	deployDataBytes, err := json.MarshalIndent(deployData, "", " ")
-	if err != nil {
-		return fmt.Errorf("could not set values in configmap %s. %w", kserveConfigMapName, err)
-	}
-	inferenceServiceConfigMap.Data[DeployConfigName] = string(deployDataBytes)
-
 	// ingress
 	// RawDeployment mode is the only supported mode, so always disable ingress creation
 	var ingressData map[string]interface{}
-	if err = json.Unmarshal([]byte(inferenceServiceConfigMap.Data[IngressConfigKeyName]), &ingressData); err != nil {
+	if err := json.Unmarshal([]byte(inferenceServiceConfigMap.Data[IngressConfigKeyName]), &ingressData); err != nil {
 		return fmt.Errorf("error retrieving value for key '%s' from configmap %s. %w", IngressConfigKeyName, kserveConfigMapName, err)
 	}
 	ingressData["disableIngressCreation"] = true


### PR DESCRIPTION
## Description

This PR removes unnecessary deployment mode configuration from the KServe component code. Since `RawDeployment` is the only supported deployment mode, we don't need the `DeployConfig` abstraction or the `defaultDeploymentMode` field in the ConfigMap.

**Changes:**
- Removed `DeployConfig` struct and `getDeployConfig` function from `config.go`
- Simplified `updateInferenceCM` to directly set the hardcoded deployment mode value
- Updated tests to parse JSON directly using `map[string]interface{}` instead of the removed struct
- Removed `DeployConfigName` constant (no longer needed)
- Stopped setting `defaultDeploymentMode` in the inference ConfigMap entirely
- KServe will use RawDeployment by default without explicit configuration
- Updated tests to remove deploy config validation
- Removed deploy config from test ConfigMap creation

**Context:**
This is a follow-up cleanup to commit [8e20eeef](https://github.com/opendatahub-io/opendatahub-operator/commit/8e20eeef3015e854ce55c363768653c856529a2c), which removed the deployment mode field from the API. Since RawDeployment is the only supported mode, we don't need to explicitly set it in the ConfigMap since it's the default behavior.

The default deployment mode is also being set to RawDeployment in the KServe manifests (see [opendatahub-io/kserve#961](https://github.com/opendatahub-io/kserve/pull/961)), making this operator-side configuration redundant.


**JIRA:** https://issues.redhat.com/browse/RHOAIENG-37455

## How Has This Been Tested?

**Unit Tests:**
- All existing KServe unit tests pass successfully
- Ran: `go test -v ./internal/controller/components/kserve/... -timeout 30s`
- All 5 test cases in `TestCustomizeKserveConfigMap` pass
- Tests verify that the deployment mode is still correctly set to "RawDeployment"

**Test Coverage:**
- Tests verify ConfigMap deploy config is set correctly
- Tests verify ingress creation is disabled (as expected for RawDeployment mode)
- Tests verify headless/headed service configuration works correctly
- Tests verify ConfigMap hash annotation is added to deployment

**Verification:**
- Pre-commit hooks passed
- No linter errors introduced
- Code review shows 31 lines deleted, 9 lines added (net reduction of 22 lines)

## Screenshot or short clip

N/A - This is a code cleanup/refactoring change with no user-facing or functional changes.

## Merge criteria

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
This PR is purely a code refactoring/cleanup change with no functional impact.

Per the opt-out guidelines, this qualifies as a refactoring change that doesn't require E2E test updates since there are no functional changes to test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Removed legacy deployment-config parsing and handling; deployment configuration simplified to a standardized approach.
* **Tests**
  * Updated tests to remove reliance on the removed deployment-config entries and related assertions.
* **Maintenance**
  * Cleaned up config update logic and minor ingress handling adjustments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->