### PR TITLE
Revert "update: to support olmv1 we need to replace operatorcondition with subscription"

### DIFF
--- a/bundle/manifests/opendatahub-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/opendatahub-operator.clusterserviceversion.yaml
@@ -83,7 +83,7 @@ metadata:
     categories: AI/Machine Learning, Big Data
     certified: "False"
     containerImage: quay.io/opendatahub/opendatahub-operator:v3.0.0
-    createdAt: "2025-10-27T16:45:27Z"
+    createdAt: "2025-10-23T10:24:07Z"
     operators.operatorframework.io/builder: operator-sdk-v1.39.2
     operators.operatorframework.io/internal-objects: '["featuretrackers.features.opendatahub.io",
       "dashboards.components.platform.opendatahub.io", "datasciencepipelines.components.platform.opendatahub.io",
@@ -95,7 +95,7 @@ metadata:
       "feastoperators.components.platform.opendatahub.io", "llamastackoperators.components.platform.opendatahub.io"]'
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
     repository: https://github.com/opendatahub-io/opendatahub-operator
-  name: opendatahub-operator.v3.2.0
+  name: opendatahub-operator.v3.0.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -1127,6 +1127,7 @@ spec:
           - operators.coreos.com
           resources:
           - catalogsources
+          - operatorconditions
           verbs:
           - get
           - list
@@ -1525,7 +1526,7 @@ spec:
   selector:
     matchLabels:
       component: opendatahub-operator
-  version: 3.2.0
+  version: 3.0.0
   webhookdefinitions:
   - admissionReviewVersions:
     - v1

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -891,6 +891,7 @@ rules:
   - operators.coreos.com
   resources:
   - catalogsources
+  - operatorconditions
   verbs:
   - get
   - list

--- a/internal/controller/components/kueue/kueue_controller.go
+++ b/internal/controller/components/kueue/kueue_controller.go
@@ -96,11 +96,11 @@ func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.
 				handlers.ToNamed(componentApi.KueueInstanceName),
 			),
 			reconciler.Dynamic(reconciler.CrdExists(gvk.KueueConfigV1))).
-		WatchesGVK(gvk.Subscription,
+		WatchesGVK(gvk.OperatorCondition,
 			reconciler.WithEventHandler(
 				handlers.ToNamed(componentApi.KueueInstanceName),
 			),
-			reconciler.WithPredicates(resources.SubscriptionPackagePrefixed(kueueOperator))).
+			reconciler.WithPredicates(resources.CreatedOrUpdatedOrDeletedNamePrefixed(kueueOperator))).
 		Watches(
 			&extv1.CustomResourceDefinition{},
 			reconciler.WithEventHandler(

--- a/internal/controller/components/kueue/kueue_controller_actions_test.go
+++ b/internal/controller/components/kueue/kueue_controller_actions_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	operatorv1 "github.com/openshift/api/operator/v1"
-	ofapiv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
+	ofapiv2 "github.com/operator-framework/api/pkg/operators/v2"
 	"github.com/rs/xid"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -61,15 +61,9 @@ func TestCheckPreConditions_Managed_KueueOperatorAlreadyInstalled(t *testing.T) 
 
 	cli, err := fakeclient.New(
 		fakeclient.WithObjects(
-			&ofapiv1alpha1.Subscription{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      kueueOperator,
-					Namespace: kueueOperatorNamespace,
-				},
-				Spec: &ofapiv1alpha1.SubscriptionSpec{
-					Package: kueueOperator,
-				},
-			},
+			&ofapiv2.OperatorCondition{ObjectMeta: metav1.ObjectMeta{
+				Name: kueueOperator,
+			}},
 		),
 	)
 	g.Expect(err).ShouldNot(HaveOccurred())

--- a/internal/controller/datasciencecluster/kubebuilder_rbac.go
+++ b/internal/controller/datasciencecluster/kubebuilder_rbac.go
@@ -10,6 +10,7 @@ package datasciencecluster
 // +kubebuilder:rbac:groups="operators.coreos.com",resources=clusterserviceversions,verbs=get;list;watch;delete;update
 // +kubebuilder:rbac:groups="operators.coreos.com",resources=customresourcedefinitions,verbs=create;get;patch;delete
 // +kubebuilder:rbac:groups="operators.coreos.com",resources=subscriptions,verbs=get;list;watch;delete
+// +kubebuilder:rbac:groups="operators.coreos.com",resources=operatorconditions,verbs=get;list;watch
 // +kubebuilder:rbac:groups="operators.coreos.com",resources=catalogsources,verbs=get;list;watch
 
 // +kubebuilder:rbac:groups="apiextensions.k8s.io",resources=customresourcedefinitions,verbs=get;list;watch;create;patch;delete;update

--- a/internal/controller/services/monitoring/monitoring_controller_support.go
+++ b/internal/controller/services/monitoring/monitoring_controller_support.go
@@ -29,12 +29,10 @@ import (
 )
 
 const (
-	// Dependent operator package names used to detect if operators are installed via OLM Subscriptions.
-	// These values match the subscription package name (spec.name field in subscription YAML).
-	// Updated for OLMv1 compatibility (no longer using OperatorConditions).
-	opentelemetryOperator        = "opentelemetry-product"
+	// Dependent operators names. match the one in the operatorcondition..
+	opentelemetryOperator        = "opentelemetry-operator"
 	clusterObservabilityOperator = "cluster-observability-operator"
-	tempoOperator                = "tempo-product"
+	tempoOperator                = "tempo-operator"
 
 	defaultCPULimit      = "500m"
 	defaultMemoryLimit   = "512Mi"

--- a/pkg/cluster/gvk/gvk.go
+++ b/pkg/cluster/gvk/gvk.go
@@ -451,6 +451,12 @@ var (
 		Kind:    "InferenceModel",
 	}
 
+	OperatorCondition = schema.GroupVersionKind{
+		Group:   "operators.coreos.com",
+		Version: "v2",
+		Kind:    "OperatorCondition",
+	}
+
 	NetworkPolicy = schema.GroupVersionKind{
 		Group:   networkingv1.SchemeGroupVersion.Group,
 		Version: networkingv1.SchemeGroupVersion.Version,

--- a/pkg/controller/predicates/resources/resources.go
+++ b/pkg/controller/predicates/resources/resources.go
@@ -4,7 +4,6 @@ import (
 	"reflect"
 	"strings"
 
-	ofapiv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -192,40 +191,6 @@ func CreatedOrUpdatedOrDeletedNamePrefixed(namePrefix string) predicate.Predicat
 		},
 		DeleteFunc: func(e event.TypedDeleteEvent[client.Object]) bool {
 			return strings.HasPrefix(e.Object.GetName(), namePrefix)
-		},
-	}
-}
-
-// SubscriptionPackagePrefixed creates a predicate that matches Subscriptions based on their package name (.spec.name).
-// which identifies the actual operator being installed.
-//
-// Parameters:
-//   - packagePrefix: The prefix to match against the subscription's package name.
-//
-// Returns:
-//   - A predicate that filters Create/Update/Delete events for Subscriptions with matching package names
-func SubscriptionPackagePrefixed(packagePrefix string) predicate.Predicate {
-	return predicate.Funcs{
-		CreateFunc: func(e event.TypedCreateEvent[client.Object]) bool {
-			sub, ok := e.Object.(*ofapiv1alpha1.Subscription)
-			if !ok {
-				return false
-			}
-			return strings.HasPrefix(sub.Spec.Package, packagePrefix)
-		},
-		UpdateFunc: func(e event.TypedUpdateEvent[client.Object]) bool {
-			sub, ok := e.ObjectNew.(*ofapiv1alpha1.Subscription)
-			if !ok {
-				return false
-			}
-			return strings.HasPrefix(sub.Spec.Package, packagePrefix)
-		},
-		DeleteFunc: func(e event.TypedDeleteEvent[client.Object]) bool {
-			sub, ok := e.Object.(*ofapiv1alpha1.Subscription)
-			if !ok {
-				return false
-			}
-			return strings.HasPrefix(sub.Spec.Package, packagePrefix)
 		},
 	}
 }


### PR DESCRIPTION
Reverts opendatahub-io/opendatahub-operator#2766


reason:
- subscription wont exist in olmv1 so the purpose with this PR to migrate from v0 to v1 wont help. we will keep using operatorcondition when v0 and v1 coexist for long time. https://redhat-internal.slack.com/archives/C097W1N3UQ6/p1761723892422729 
- also the version bump in the PR should be done from Makefile properly https://redhat-internal.slack.com/archives/C05PTTMRL4X/p1761750184930399

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Downgraded operator version from 3.2.0 to 3.0.0
  * Updated internal operator detection and monitoring mechanisms
  * Adjusted operator naming conventions for dependent services

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->
no need