### PR TITLE
RHOAIENG-34457 | chore: optimize SNO detection using Infrastructure ControlPlaneTopology

### DIFF
--- a/internal/controller/dscinitialization/kubebuilder_rbac.go
+++ b/internal/controller/dscinitialization/kubebuilder_rbac.go
@@ -8,7 +8,7 @@ package dscinitialization
 // +kubebuilder:rbac:groups="features.opendatahub.io",resources=featuretrackers/finalizers,verbs=update;patch;get
 
 /* Auth */
-// +kubebuilder:rbac:groups="config.openshift.io",resources=authentications,verbs=get;watch;list
+// +kubebuilder:rbac:groups="config.openshift.io",resources=authentications;infrastructures,verbs=get;watch;list
 
 // TODO: move to monitoring own file
 // +kubebuilder:rbac:groups="route.openshift.io",resources=routers/metrics,verbs=get

--- a/pkg/cluster/cluster_config.go
+++ b/pkg/cluster/cluster_config.go
@@ -160,32 +160,17 @@ func IsActiveNamespace(ns *corev1.Namespace) bool {
 	return ns.Status.Phase == corev1.NamespaceActive
 }
 
-// IsSingleNodeCluster determines if the cluster is a single-node cluster by counting the actual nodes.
+// IsSingleNodeCluster determines if the cluster is a single-node cluster by checking the ControlPlaneTopology.
 func IsSingleNodeCluster(ctx context.Context, cli client.Client) bool {
-	nodeList := &corev1.NodeList{}
-	if err := cli.List(ctx, nodeList); err != nil {
-		logf.FromContext(ctx).Info("could not list nodes, defaulting to multi-node behavior", "error", err)
+	infra := &configv1.Infrastructure{}
+	if err := cli.Get(ctx, types.NamespacedName{Name: "cluster"}, infra); err != nil {
+		logf.FromContext(ctx).Info("could not get infrastructure, defaulting to multi-node behavior", "error", err)
 		return false
 	}
 
-	// Count only nodes that are ready and not marked for deletion
-	var readyNodeCount int
-	for _, node := range nodeList.Items {
-		if node.DeletionTimestamp == nil {
-			for _, condition := range node.Status.Conditions {
-				if condition.Type == corev1.NodeReady && condition.Status == corev1.ConditionTrue {
-					readyNodeCount++
-					break
-				}
-			}
-		}
-		if readyNodeCount > 1 {
-			break
-		}
-	}
-
-	logf.FromContext(ctx).V(1).Info("detected cluster size", "totalNodes", len(nodeList.Items), "readyNodes", readyNodeCount)
-	return readyNodeCount <= 1
+	isSNO := infra.Status.ControlPlaneTopology == configv1.SingleReplicaTopologyMode
+	logf.FromContext(ctx).V(1).Info("detected cluster topology", "controlPlaneTopology", infra.Status.ControlPlaneTopology, "isSNO", isSNO)
+	return isSNO
 }
 
 // GetClusterServiceVersion retries CSV only from the defined namespace.


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
This PR optimizes the single-node cluster detection used for setting OpenTelemetry collector and monitoring stack replica defaults. Instead of counting nodes, now it use OpenShift's canonical `Infrastructure` API. For controller to access Infrstructure the RBAC permissions was needed.


<!--- Link your JIRA and related links here for reference. -->
* https://issues.redhat.com/browse/RHOAIENG-34457

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested using e2e tests
* quay.io/rh-ee-froman/opendatahub-operator:RHOAIENG-34457-feat

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->
no new e2e tests needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved single-node cluster detection to use topology-based identification instead of node enumeration.
  * Enhanced controller permissions for infrastructure and authentication operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->