### PR TITLE
chore: cleanup comments and remove unused status for ArgoCD

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -49,11 +49,6 @@ spec:
                 - linux
       securityContext:
         runAsNonRoot: true
-        # TODO(user): For common cases that do not require escalating privileges
-        # it is recommended to ensure that all your Pods/Containers are restrictive.
-        # More info: https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted
-        # Please uncomment the following code if your project does NOT have to work on old Kubernetes
-        # versions < 1.19 or on vendors versions which do NOT support this field by default (i.e. Openshift < 4.11 ).
         seccompProfile:
           type: RuntimeDefault
       containers:

--- a/internal/controller/status/status.go
+++ b/internal/controller/status/status.go
@@ -91,10 +91,6 @@ const (
 )
 
 const (
-	CapabilityDSPv2Argo string = "CapabilityDSPv2Argo"
-)
-
-const (
 	MissingOperatorReason     string = "MissingOperator"
 	ConfiguredReason          string = "Configured"
 	RemovedReason             string = "Removed"
@@ -296,7 +292,6 @@ func SetCompleteCondition(conditions *[]common.Condition, reason string, message
 			Message: message,
 		},
 	})
-	cond.RemoveStatusCondition(wrapper, CapabilityDSPv2Argo)
 }
 
 // SetCondition is a general purpose function to update any type of condition.


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->
remove comments following https://github.com/opendatahub-io/opendatahub-operator/pull/2770#discussion_r2476084702
remove argo condition, which was originally removed in https://github.com/opendatahub-io/opendatahub-operator/pull/1496/ removed SetExistingArgoCondition 

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->
no functional change, just remove dead code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed unnecessary commented guidance blocks from deployment configuration files to enhance code clarity and improve long-term maintainability.

* **Refactor**
  * Removed obsolete status capability references and associated internal runtime logic from core systems. These changes streamline the codebase, reduce technical debt, and improve overall system maintainability without impacting any user-facing functionality or core system behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->