### PR TITLE
set defaults based on metric log data from perf test

### DIFF
--- a/internal/controller/services/gateway/gateway_support.go
+++ b/internal/controller/services/gateway/gateway_support.go
@@ -14,6 +14,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -620,6 +621,16 @@ func createKubeAuthProxyDeployment(
 								{Name: EnvClientSecret, ValueFrom: createSecretKeySelector(EnvClientSecret)},
 								{Name: EnvCookieSecret, ValueFrom: createSecretKeySelector(EnvCookieSecret)},
 								{Name: "PROXY_MODE", Value: "auth"},
+							},
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("10m"),
+									corev1.ResourceMemory: resource.MustParse("32Mi"),
+								},
+								Limits: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("50m"),
+									corev1.ResourceMemory: resource.MustParse("64Mi"),
+								},
 							},
 							VolumeMounts: []corev1.VolumeMount{
 								{


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->
  ### Summary
  Add resource requests and limits to kube-auth-proxy deployment based on production metrics analysis.

  ### Changes
  - Set CPU request: 10m, limit: 50m
  - Set memory request: 32Mi, limit: 64Mi
  - Values derived from OAuth and OIDC benchmark metrics showing peak usage of ~11m CPU and ~23.5 MB memory

Metric data:
- https://github.com/resoluteCoder/RHOAIENG-Heimdall/blob/main/perf-testing/3.x/oidc/oidc-3x-metrics.log
- https://github.com/resoluteCoder/RHOAIENG-Heimdall/blob/main/perf-testing/3.x/oauth/oauth-3x-metrics.log

<!--- Link your JIRA and related links here for reference. -->
JIRA: [RHOAIENG-36927](https://issues.redhat.com/browse/RHOAIENG-36927)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->
No need, just setting default resource data


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated resource specifications for improved stability and resource management. CPU and memory requests and limits were added to the authentication proxy container, resulting in more predictable resource usage and operational stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->