### PR TITLE
[backport]: fix cleanup description in CSV and correct component name

### DIFF
--- a/bundle/manifests/rhods-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/rhods-operator.clusterserviceversion.yaml
@@ -110,7 +110,7 @@ metadata:
             "dashboard": {
               "managementState": "Managed"
             },
-            "datasciencepipelines": {
+            "aipipelines": {
               "managementState": "Managed"
             },
             "feastoperator": {
@@ -123,7 +123,7 @@ metadata:
               "managementState": "Removed"
             },
             "kueue": {
-              "managementState": "Managed"
+              "managementState": "Removed"
             },
             "modelregistry": {
               "managementState": "Managed",

--- a/config/manifests/bases/rhods-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/rhods-operator.clusterserviceversion.yaml
@@ -35,7 +35,7 @@ metadata:
             "dashboard": {
               "managementState": "Managed"
             },
-            "datasciencepipelines": {
+            "aipipelines": {
               "managementState": "Managed"
             },
             "feastoperator": {
@@ -48,7 +48,7 @@ metadata:
               "managementState": "Removed"
             },
             "kueue": {
-              "managementState": "Managed"
+              "managementState": "Removed"
             },
             "modelregistry": {
               "managementState": "Managed",

--- a/config/manifests/description-patch.yml
+++ b/config/manifests/description-patch.yml
@@ -19,8 +19,8 @@ spec:
     * Curated Workbench Images (including CUDA, PyTorch, TensorFlow, code-server, TrustyAI)
     * Ability to add Custom Images
     * Ability to leverage accelerators (such as NVIDIA GPU)
-    * Data Science Pipelines (including Elyra notebook interface)
-    * Model Serving using ModelMesh and Kserve.
+    * AI Pipelines (including Elyra notebook interface)
+    * Model Serving using Kserve.
     * Ability to use other runtimes for serving
     * Model Monitoring
     * Distributed workloads (KubeRay, Kueue, Training Operator)


### PR DESCRIPTION
- DSP is renamed to aipipeline
- kueue should set to Removed by default
- modelmesh should not be mentioned any more

https://github.com/red-hat-data-services/rhods-operator/pull/13427

<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

<!--- Link your JIRA and related links here for reference. -->
ref https://issues.redhat.com/browse/RHOAIENG-37984
and part of https://issues.redhat.com/browse/RHOAIENG-37945

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [ ] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->
