### PR TITLE
Generate manifest before run unit test

### DIFF
--- a/.github/workflows/test-unit.yaml
+++ b/.github/workflows/test-unit.yaml
@@ -9,6 +9,9 @@ on:
       - 'internal/**'
       - 'pkg/**'
       - 'cmd/main.go'
+      - 'api/**'
+      - 'config/**'
+
 jobs:
   unit-test:
     name: Run tests and collect coverage on internal and pkg
@@ -25,7 +28,9 @@ jobs:
       - name: Run Unit Tests
         env:
           TEST_SRC: ./internal/... ./pkg/...
-        run: make unit-test
+        run: |
+          make manifests
+          make unit-test
 
       - name: Upload results to Codecov
         uses: codecov/codecov-action@v5.5.1

--- a/internal/controller/dscinitialization/suite_test.go
+++ b/internal/controller/dscinitialization/suite_test.go
@@ -102,6 +102,7 @@ var _ = BeforeSuite(func() {
 			ErrorIfPathMissing: true,
 			CleanUpAfterUse:    false,
 		},
+		ErrorIfCRDPathMissing: true,
 	}
 
 	var err error

--- a/pkg/utils/test/envt/envt.go
+++ b/pkg/utils/test/envt/envt.go
@@ -170,6 +170,7 @@ func New(opts ...OptionFn) (*EnvT, error) {
 			ErrorIfPathMissing: true,
 			CleanUpAfterUse:    false,
 		},
+		ErrorIfCRDPathMissing: true,
 	}
 
 	// If webhooks are registered, configure the webhook server


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description

This PR fixes unit test workflow, which after https://github.com/opendatahub-io/opendatahub-operator/pull/2329 does not contains CRD files.
To do it, various fixes are done:

- run `make manifests` command in workflow
- run unit tests also for changes in api and config folders
- since unit tests needs some external CRD, update the script to download all needed one
- update Makefile clean to remove all generated files
- fix envtest setup to fail if CRD path not exists
- to improve DevX, add clear message if CRD dir not exists when running `make unit-test`

Jira reference: https://issues.redhat.com/browse/RHOAIENG-34484

## How Has This Been Tested?

Run `make unit-test` correctly

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [x] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->
This PR fixes a unit test issues, and controller code was not updated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Unit tests now generate manifests before running and enforce CRD path presence to fail early if missing.
  * Test runtime configuration tightened with increased test runner safeguards.

* **CI/CD**
  * Workflow path filters expanded to trigger on additional repository areas (api and config).

* **Chores / Manifests**
  * Added automated fetching/management of external CRDs and cleanup of temporary artifacts; expanded clean targets to track generated files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->