### PR TITLE
RHOAIENG-38003: Skip oauth2_proxy cooike in upstream request

### DIFF
--- a/internal/controller/services/gateway/gateway_auth_actions.go
+++ b/internal/controller/services/gateway/gateway_auth_actions.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -76,6 +77,9 @@ func createEnvoyFilter(ctx context.Context, rr *odhtypes.ReconciliationRequest) 
 	if err != nil {
 		return fmt.Errorf("failed to read EnvoyFilter template: %w", err)
 	}
+
+	cookiePattern := OAuth2ProxyCookieName
+	yamlContent = []byte(strings.ReplaceAll(string(yamlContent), "{{.CookieName}}", cookiePattern))
 
 	decoder := serializer.NewCodecFactory(rr.Client.Scheme()).UniversalDeserializer()
 	unstructuredObjects, err := resources.Decode(decoder, yamlContent)

--- a/internal/controller/services/gateway/gateway_auth_actions_test.go
+++ b/internal/controller/services/gateway/gateway_auth_actions_test.go
@@ -2,9 +2,13 @@
 package gateway
 
 import (
+	"fmt"
 	"testing"
 
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
 	serviceApi "github.com/opendatahub-io/opendatahub-operator/v2/api/services/v1alpha1"
+	odhtypes "github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
 
 	. "github.com/onsi/gomega"
 )
@@ -13,6 +17,44 @@ const (
 	testProxyDomain    = "data-science-gateway.apps.test-cluster.com"
 	testProxyIssuerURL = "https://keycloak.example.com/realms/test"
 )
+
+// getEnvoyFilterLuaCode is a helper function to extract Lua inline_code from EnvoyFilter for testing.
+func getEnvoyFilterLuaCode(t *testing.T) string {
+	t.Helper()
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	rr := &odhtypes.ReconciliationRequest{
+		Client: setupTestClient(),
+	}
+
+	err := createEnvoyFilter(ctx, rr)
+	g.Expect(err).NotTo(HaveOccurred(), "should create EnvoyFilter successfully")
+	g.Expect(rr.Resources).To(HaveLen(1), "should create exactly one EnvoyFilter resource")
+
+	// Get configPatches array
+	configPatches, found, err := unstructured.NestedSlice(
+		rr.Resources[0].Object,
+		"spec", "configPatches",
+	)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(found).To(BeTrue(), "configPatches should exist")
+	g.Expect(configPatches).To(HaveLen(3), "should have 3 config patches (ext_authz, lua, cluster)")
+
+	// Get the Lua filter (second patch, index 1)
+	luaPatch, ok := configPatches[1].(map[string]interface{})
+	g.Expect(ok).To(BeTrue(), "Lua patch should be a map")
+
+	// Extract inline_code
+	inlineCode, found, err := unstructured.NestedString(
+		luaPatch,
+		"patch", "value", "typed_config", "inline_code",
+	)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(found).To(BeTrue(), "Lua filter inline_code should exist")
+
+	return inlineCode
+}
 
 // TestGetCookieSettings tests the cookie settings helper function.
 func TestGetCookieSettings(t *testing.T) {
@@ -103,7 +145,7 @@ func TestBuildBaseOAuth2ProxyArgs(t *testing.T) {
 	g.Expect(args).To(ContainElement("--cookie-secure=true"), "HTTPS only")
 	g.Expect(args).To(ContainElement("--cookie-httponly=true"), "XSS protection")
 	g.Expect(args).To(ContainElement("--cookie-samesite=lax"), "CSRF protection")
-	g.Expect(args).To(ContainElement("--cookie-name=_oauth2_proxy"))
+	g.Expect(args).To(ContainElement(fmt.Sprintf("--cookie-name=%s", OAuth2ProxyCookieName)))
 	g.Expect(args).To(ContainElement("--cookie-domain=" + testProxyDomain))
 
 	// Security features
@@ -161,4 +203,150 @@ func TestBuildOpenShiftOAuthArgs(t *testing.T) {
 	g.Expect(args).To(HaveLen(2), "should have 2 OpenShift OAuth arguments")
 	g.Expect(args).To(ContainElement("--provider=openshift"))
 	g.Expect(args).To(ContainElement("--scope=user:full"))
+}
+
+// TestCreateEnvoyFilter tests the EnvoyFilter creation with cookie stripping logic.
+func TestCreateEnvoyFilter(t *testing.T) {
+	t.Parallel()
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	rr := &odhtypes.ReconciliationRequest{
+		Client: setupTestClient(),
+	}
+
+	err := createEnvoyFilter(ctx, rr)
+	g.Expect(err).NotTo(HaveOccurred(), "should create EnvoyFilter successfully")
+	g.Expect(rr.Resources).To(HaveLen(1), "should create exactly one EnvoyFilter resource")
+
+	envoyFilter := rr.Resources[0]
+	g.Expect(envoyFilter.GetKind()).To(Equal("EnvoyFilter"))
+	g.Expect(envoyFilter.GetName()).To(Equal("authn-filter"))
+	g.Expect(envoyFilter.GetNamespace()).To(Equal("openshift-ingress"))
+}
+
+// TestCreateEnvoyFilterCookieNameReplacement tests that cookie name placeholder is correctly replaced.
+func TestCreateEnvoyFilterCookieNameReplacement(t *testing.T) {
+	t.Parallel()
+	g := NewWithT(t)
+
+	inlineCode := getEnvoyFilterLuaCode(t)
+
+	// Verify cookie name placeholder is replaced with actual cookie name
+	g.Expect(inlineCode).NotTo(ContainSubstring("{{.CookieName}}"), "cookie name placeholder should be replaced")
+	g.Expect(inlineCode).To(ContainSubstring(OAuth2ProxyCookieName), "should contain actual cookie name: %s", OAuth2ProxyCookieName)
+
+	// Verify the Lua pattern uses the correct cookie name
+	expectedPattern := "^" + OAuth2ProxyCookieName
+	g.Expect(inlineCode).To(ContainSubstring(expectedPattern), "Lua pattern should match cookie name with ^ anchor")
+}
+
+// TestEnvoyFilterCookieStrippingLogic tests that the Lua code correctly strips OAuth2 proxy cookies.
+func TestEnvoyFilterCookieStrippingLogic(t *testing.T) {
+	t.Parallel()
+	g := NewWithT(t)
+
+	inlineCode := getEnvoyFilterLuaCode(t)
+
+	// Verify key cookie stripping logic components are present
+	g.Expect(inlineCode).To(ContainSubstring("x-auth-request-access-token"),
+		"should check for auth token before stripping cookies")
+	g.Expect(inlineCode).To(ContainSubstring("cookie_header"),
+		"should get cookie header")
+	g.Expect(inlineCode).To(ContainSubstring("filtered_cookies"),
+		"should filter cookies")
+	g.Expect(inlineCode).To(ContainSubstring("cookie:match"),
+		"should parse cookies using pattern matching")
+	g.Expect(inlineCode).To(ContainSubstring("headers():replace(\"cookie\""),
+		"should replace cookie header with filtered cookies")
+	g.Expect(inlineCode).To(ContainSubstring("headers():remove(\"cookie\")"),
+		"should remove cookie header if all cookies are filtered")
+
+	// Verify the logic only strips cookies when auth token is present
+	g.Expect(inlineCode).To(ContainSubstring("if access_token then"),
+		"should only process cookies when auth token exists")
+	g.Expect(inlineCode).To(ContainSubstring("If no auth token present, preserve cookies"),
+		"should preserve cookies for ext_authz call")
+}
+
+// TestEnvoyFilterCookiePatternMatchesSplitCookies tests that the cookie pattern matches split cookies.
+func TestEnvoyFilterCookiePatternMatchesSplitCookies(t *testing.T) {
+	t.Parallel()
+	g := NewWithT(t)
+
+	inlineCode := getEnvoyFilterLuaCode(t)
+
+	// Verify the pattern uses ^ anchor to match cookies starting with the cookie name
+	// This ensures split cookies like _oauth2_proxy_1, _oauth2_proxy_2 are matched
+	expectedPattern := "^" + OAuth2ProxyCookieName
+	g.Expect(inlineCode).To(ContainSubstring(expectedPattern),
+		"pattern should use ^ anchor to match cookies starting with cookie name")
+
+	// Verify comments mention split cookies
+	g.Expect(inlineCode).To(ContainSubstring("_oauth2_proxy_1"),
+		"should mention split cookies in comments")
+	g.Expect(inlineCode).To(ContainSubstring("split cookies"),
+		"should document split cookie handling")
+}
+
+// TestEnvoyFilterPreservesCookiesForAuthProxy tests that cookies are preserved for ext_authz calls.
+func TestEnvoyFilterPreservesCookiesForAuthProxy(t *testing.T) {
+	t.Parallel()
+	g := NewWithT(t)
+
+	inlineCode := getEnvoyFilterLuaCode(t)
+
+	// Verify cookies are preserved when no auth token is present (for ext_authz call)
+	g.Expect(inlineCode).To(ContainSubstring("If no auth token present, preserve cookies"),
+		"should preserve cookies for ext_authz authentication")
+	g.Expect(inlineCode).To(ContainSubstring("if access_token then"),
+		"should only strip cookies when auth token is present")
+	g.Expect(inlineCode).To(ContainSubstring("ext_authz call to auth proxy"),
+		"should document that cookies are needed for ext_authz")
+}
+
+// TestEnvoyFilterSetsAuthorizationHeader tests that the Lua filter sets Authorization header for upstream.
+func TestEnvoyFilterSetsAuthorizationHeader(t *testing.T) {
+	t.Parallel()
+	g := NewWithT(t)
+
+	inlineCode := getEnvoyFilterLuaCode(t)
+
+	// Verify Authorization header is set for upstream services
+	g.Expect(inlineCode).To(ContainSubstring("authorization"),
+		"should set Authorization header")
+	g.Expect(inlineCode).To(ContainSubstring("Bearer"),
+		"should use Bearer token format")
+	g.Expect(inlineCode).To(ContainSubstring("x-forwarded-access-token"),
+		"should also set x-forwarded-access-token header")
+	g.Expect(inlineCode).To(ContainSubstring("Set headers for upstream services"),
+		"should document header setting for upstream")
+}
+
+// TestEnvoyFilterRemovesCookieFromUpstreamRequests tests that _oauth2_proxy cookie is removed before forwarding to upstream.
+func TestEnvoyFilterRemovesCookieFromUpstreamRequests(t *testing.T) {
+	t.Parallel()
+	g := NewWithT(t)
+
+	inlineCode := getEnvoyFilterLuaCode(t)
+
+	// Verify the cookie stripping logic ensures upstream services don't receive _oauth2_proxy cookies
+	// The logic should only strip cookies when forwarding to upstream (after auth succeeds)
+	g.Expect(inlineCode).To(ContainSubstring("Strip OAuth2 proxy cookies only when forwarding to upstream services"),
+		"should document that cookies are stripped only for upstream requests")
+	g.Expect(inlineCode).To(ContainSubstring("Only keep cookies that don't match the OAuth2 proxy cookie pattern"),
+		"should filter out OAuth2 proxy cookies")
+	g.Expect(inlineCode).To(ContainSubstring("not cookie_name:match(cookie_pattern)"),
+		"should use pattern matching to exclude OAuth2 proxy cookies")
+
+	// Verify the pattern matches all variations (main cookie and split cookies)
+	expectedPattern := "^" + OAuth2ProxyCookieName
+	g.Expect(inlineCode).To(ContainSubstring(expectedPattern),
+		"pattern should match cookies starting with %s (including split cookies)", OAuth2ProxyCookieName)
+
+	// Verify cookies are only stripped after authentication (when access_token exists)
+	g.Expect(inlineCode).To(ContainSubstring("if access_token then"),
+		"should only strip cookies after authentication succeeds")
+	g.Expect(inlineCode).To(ContainSubstring("we're now forwarding to upstream services"),
+		"should confirm cookies are stripped when forwarding to upstream")
 }

--- a/internal/controller/services/gateway/gateway_support.go
+++ b/internal/controller/services/gateway/gateway_support.go
@@ -71,6 +71,9 @@ const (
 	EnvClientSecret = "OAUTH2_PROXY_CLIENT_SECRET" //nolint:gosec // This is an environment variable name, not a secret
 	EnvCookieSecret = "OAUTH2_PROXY_COOKIE_SECRET" //nolint:gosec // This is an environment variable name, not a secret
 
+	// OAuth2 proxy cookie name - used in both proxy args and EnvoyFilter Lua filter.
+	OAuth2ProxyCookieName = "_oauth2_proxy"
+
 	AuthModeIntegratedOAuth AuthMode = "IntegratedOAuth"
 	AuthModeOIDC            AuthMode = "OIDC"
 	AuthModeNone            AuthMode = "None"
@@ -709,7 +712,7 @@ func buildBaseOAuth2ProxyArgs(cookieConfig *serviceApi.CookieConfig, domain stri
 		"--cookie-secure=true",                                            // HTTPS only
 		"--cookie-httponly=true",                                          // XSS protection
 		"--cookie-samesite=lax",                                           // CSRF protection
-		"--cookie-name=_oauth2_proxy",                                     // Custom cookie name
+		fmt.Sprintf("--cookie-name=%s", OAuth2ProxyCookieName),            // Custom cookie name (used in EnvoyFilter Lua filter)
 		"--cookie-domain=" + domain,                                       // Cookie domain is the domain of the gateway
 		fmt.Sprintf("--metrics-address=0.0.0.0:%d", AuthProxyMetricsPort), // Expose metrics on unauthenticated port
 	}

--- a/internal/controller/services/gateway/resources/envoyfilter-authn.yaml
+++ b/internal/controller/services/gateway/resources/envoyfilter-authn.yaml
@@ -59,11 +59,50 @@ spec:
           "@type": "type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua"
           inline_code: |
             function envoy_on_request(request_handle)
+              -- Extract access token from ext_authz response (set by ext_authz filter after auth)
               local access_token = request_handle:headers():get("x-auth-request-access-token")
+              
+              -- Only process requests that have been authenticated (have auth headers)
+              -- This ensures we don't strip cookies during ext_authz call to auth proxy
+              -- The presence of x-auth-request-access-token indicates authentication succeeded
+              -- and we're now forwarding to upstream services, not to the auth proxy
               if access_token then
+                -- Set headers for upstream services
                 request_handle:headers():add("x-forwarded-access-token", access_token)
                 request_handle:headers():replace("authorization", "Bearer " .. access_token)
+                
+                -- Strip OAuth2 proxy cookies only when forwarding to upstream services
+                -- Cookie name is injected at runtime from OAuth2ProxyCookieName constant (gateway_support.go:75)
+                -- Pattern matches cookies starting with the cookie name, handling variations like:
+                --   - _oauth2_proxy (main cookie)
+                --   - _oauth2_proxy_1, _oauth2_proxy_2 (split cookies if cookie size exceeds limits)
+                local cookie_header = request_handle:headers():get("cookie")
+                if cookie_header then
+                  local filtered_cookies = {}
+                  local cookie_pattern = "^{{.CookieName}}"
+                  
+                  -- Parse and filter cookies in a single pass
+                  for cookie in cookie_header:gmatch("([^;]+)") do
+                    -- Trim whitespace and extract cookie name
+                    local trimmed = cookie:match("^%s*(.-)%s*$")
+                    if trimmed ~= "" then
+                      local cookie_name = trimmed:match("^([^=]+)")
+                      -- Only keep cookies that don't match the OAuth2 proxy cookie pattern
+                      if cookie_name and not cookie_name:match(cookie_pattern) then
+                        table.insert(filtered_cookies, trimmed)
+                      end
+                    end
+                  end
+                  
+                  -- Update or remove Cookie header based on filtered results
+                  if #filtered_cookies > 0 then
+                    request_handle:headers():replace("cookie", table.concat(filtered_cookies, "; "))
+                  else
+                    request_handle:headers():remove("cookie")
+                  end
+                end
               end
+              -- If no auth token present, preserve cookies (needed for ext_authz authentication)
             end
   - applyTo: CLUSTER
     match:


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

https://issues.redhat.com/browse/RHOAIENG-38003

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
https://github.com/opendatahub-io/opendatahub-operator/pull/2753


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * OAuth2 proxy auth: dynamic cookie-name support, forwarding of access tokens to upstream, and conditional stripping of proxy cookies when tokens are present (cookies preserved when no token).

* **Tests**
  * Expanded auth tests covering dynamic cookie names, cookie-stripping logic, token forwarding, pattern matching, and related edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->