### PR TITLE
RHOAENG-29721 | feat: Adding tls to otel collector

### DIFF
--- a/config/monitoring/base/rhods-servicemonitor.yaml
+++ b/config/monitoring/base/rhods-servicemonitor.yaml
@@ -8,12 +8,12 @@ metadata:
     team: rhods
 spec:
   endpoints:
-    - authorization:
-        type: Bearer
-        credentialsFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      bearerTokenSecret:
+        key: ""
       honorLabels: true
       params:
-        "match[]":
+        'match[]':
           - '{__name__= "rhods_total_users"}'
           - '{__name__= "rhods_active_users"}'
           - '{__name__= "rhods_aggregate_availability"}'
@@ -23,7 +23,7 @@ spec:
       scheme: https
       tlsConfig:
         caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
-        serverName: "prometheus.redhat-ods-monitoring.svc"
+        serverName: prometheus.redhat-ods-monitoring.svc
       scrapeTimeout: 10s
       interval: 30s
   namespaceSelector:

--- a/internal/controller/services/monitoring/resources/collector-prometheus-service.tmpl.yaml
+++ b/internal/controller/services/monitoring/resources/collector-prometheus-service.tmpl.yaml
@@ -1,0 +1,30 @@
+# Service for OpenTelemetry Collector Prometheus exporter with TLS support.
+# This service is separate from the auto-generated collector service to enable
+# TLS via OpenShift's service-ca operator through the serving-cert-secret-name annotation.
+# The service-ca operator automatically provisions and rotates TLS certificates for this endpoint.
+apiVersion: v1
+kind: Service
+metadata:
+  name: data-science-collector-prometheus
+  namespace: {{.Namespace}}
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: data-science-collector-tls
+  labels:
+    app.kubernetes.io/component: opentelemetry-collector
+    app.kubernetes.io/instance: {{.Namespace}}.data-science-collector
+    app.kubernetes.io/managed-by: opentelemetry-operator
+    app.kubernetes.io/name: data-science-collector-prometheus
+    app.kubernetes.io/part-of: opentelemetry
+spec:
+  ports:
+  - name: prometheus
+    port: 8889
+    protocol: TCP
+    targetPort: 8889
+  selector:
+    app.kubernetes.io/component: opentelemetry-collector
+    app.kubernetes.io/instance: {{.Namespace}}.data-science-collector
+    app.kubernetes.io/managed-by: opentelemetry-operator
+    app.kubernetes.io/part-of: opentelemetry
+  type: ClusterIP
+

--- a/internal/controller/services/monitoring/resources/collector-servicemonitors.tmpl.yaml
+++ b/internal/controller/services/monitoring/resources/collector-servicemonitors.tmpl.yaml
@@ -1,3 +1,4 @@
+# ServiceMonitor for collector's own telemetry metrics (always deployed for health monitoring)
 apiVersion: monitoring.rhobs/v1
 kind: ServiceMonitor
 metadata:
@@ -5,11 +6,9 @@ metadata:
   namespace: {{.Namespace}}
 spec:
   endpoints:
+  # Collector's own telemetry metrics (internal monitoring) - uses HTTP
     - port: monitoring
-      scheme: https
-      tlsConfig:
-        caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
-        serverName: "data-science-collector-collector-monitoring.{{.Namespace}}.svc"
+      scheme: http
       bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
   namespaceSelector:
     matchNames:
@@ -20,9 +19,12 @@ spec:
       app.kubernetes.io/instance: {{.Namespace}}.data-science-collector
       app.kubernetes.io/managed-by: opentelemetry-operator
       app.kubernetes.io/part-of: opentelemetry
-      operator.opentelemetry.io/collector-service-type: base
+      operator.opentelemetry.io/collector-service-type: monitoring
 
 ---
+# ServiceMonitor for user application metrics via Prometheus exporter
+# Only deployed when metrics collection is enabled (.Metrics != nil)
+{{- if .Metrics }}
 apiVersion: monitoring.rhobs/v1
 kind: ServiceMonitor
 metadata:
@@ -34,7 +36,7 @@ spec:
       scheme: https
       tlsConfig:
         caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
-        serverName: "data-science-collector-collector-monitoring.{{.Namespace}}.svc"
+        serverName: "data-science-collector-prometheus.{{.Namespace}}.svc"
       bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
   namespaceSelector:
     matchNames:
@@ -44,8 +46,9 @@ spec:
       app.kubernetes.io/component: opentelemetry-collector
       app.kubernetes.io/instance: {{.Namespace}}.data-science-collector
       app.kubernetes.io/managed-by: opentelemetry-operator
+      app.kubernetes.io/name: data-science-collector-prometheus
       app.kubernetes.io/part-of: opentelemetry
-      operator.opentelemetry.io/collector-service-type: base
+{{- end }}
 ---
 apiVersion: monitoring.rhobs/v1
 kind: ServiceMonitor
@@ -65,3 +68,4 @@ spec:
   selector:
     matchLabels:
       control-plane: controller-manager
+

--- a/internal/controller/services/monitoring/resources/opentelemetry-collector.tmpl.yaml
+++ b/internal/controller/services/monitoring/resources/opentelemetry-collector.tmpl.yaml
@@ -13,15 +13,16 @@ spec:
     requests:
       cpu: {{.CollectorCPURequest}}
       memory: {{.CollectorMemoryRequest}}
+  {{- if .Metrics }}
   volumeMounts:
-    - name: tls-certs
-      mountPath: /etc/otel-collector/tls
-      readOnly: true
+  - name: tls-certs
+    mountPath: /etc/otel-collector/tls
+    readOnly: true
   volumes:
-    - name: tls-certs
-      secret:
-        secretName: data-science-collector-tls
-        optional: true
+  - name: tls-certs
+    secret:
+      secretName: data-science-collector-tls
+  {{- end }}
   config:
     extensions:
       bearertokenauth:
@@ -189,10 +190,12 @@ spec:
     service:
       telemetry:
         metrics:
-          address: 0.0.0.0:8888
-          tls:
-            cert_file: "/etc/otel-collector/tls/tls.crt"
-            key_file: "/etc/otel-collector/tls/tls.key"
+          readers:
+            - pull:
+                exporter:
+                  prometheus:
+                    host: '0.0.0.0'
+                    port: 8888
       extensions: [bearertokenauth]
       {{- if or .Traces .Metrics }}
       pipelines:
@@ -207,6 +210,5 @@ spec:
           receivers: [prometheus, otlp]
           processors: [memory_limiter, k8sattributes, resourcedetection, batch]
           exporters: [prometheus{{- if .MetricsExporterNames }}{{- range .MetricsExporterNames }}, {{ . }}{{- end }}{{- end }}]
-      {{- end }}
       {{- end }}
       {{- end }}

--- a/internal/controller/services/monitoring/resources/prometheus-web-tls-service.tmpl.yaml
+++ b/internal/controller/services/monitoring/resources/prometheus-web-tls-service.tmpl.yaml
@@ -15,7 +15,7 @@ metadata:
 #    cert controller to generate TLS certificates
 # 3. This manifest is applied using Server-Side Apply (SSA), which merges this definition
 #    with the MonitoringStack-created Service without conflicts
-# 4. The minimal spec (empty ports, ClusterIP type) ensures the Service passes validation
+# 4. The minimal spec (placeholder port, ClusterIP type) ensures the Service passes validation
 #    if applied before MonitoringStack creates it, preventing transient errors on fresh installs
 # 5. When MonitoringStack reconciles, it updates the spec with the actual port configuration
 # 6. Each controller (MonitoringStack Operator and ODH Operator) manages different fields,
@@ -28,5 +28,9 @@ metadata:
   annotations:
     service.beta.openshift.io/serving-cert-secret-name: prometheus-operated-tls
 spec:
-  ports: []
+  ports:
+    - name: web
+      port: 9090
+      protocol: TCP
+      targetPort: web
   type: ClusterIP


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.


-->

https://issues.redhat.com/browse/RHOAIENG-29721

## Description
Adding tls field to metrics in for otel collector

## How Has This Been Tested?

2. Verify Service-CA Annotation
kubectl get opentelemetrycollector data-science-collector -n redhat-ods-monitoring \  -o jsonpath='{.metadata.annotations.service\.beta\.openshift\.io/serving-cert-secret-name}'
Result: data-science-collector-tls
3. Check TLS Secret
kubectl get secret data-science-collector-tls -n redhat-ods-monitoring
Result: Secret exists, expires <date>
4. Verify Prometheus Exporter TLS Config
kubectl get opentelemetrycollector data-science-collector -n redhat-ods-monitoring \  -o jsonpath='{.spec.config.exporters.prometheus}' | jq .
Result: TLS cert and key files configured
5. Check TLS Certificate is Mounted
POD=$(kubectl get pods -n redhat-ods-monitoring -l app.kubernetes.io/component=opentelemetry-collector -o jsonpath='{.items[0].metadata.name}')kubectl exec -n redhat-ods-monitoring $POD -- ls -la /etc/otel-collector/tls/
Result: tls.crt and tls.key present
6. Verify ServiceMonitor Uses HTTPS
kubectl get servicemonitor.monitoring.rhobs data-science-prometheus-monitor -n redhat-ods-monitoring \  -o jsonpath='{.spec.endpoints[0].scheme}'
Result: https
7. Test HTTPS Endpoint (Live Test)
kubectl run test-https --image=curlimages/curl:latest --rm -i --restart=Never -n redhat-ods-monitoring -- \  curl -v --cacert /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt \  https://data-science-collector-collector.redhat-ods-monitoring.svc:8889/metrics 2>&1 | head -30
Result: HTTP 200 - HTTPS is working!
8. View Certificate Details
kubectl get secret data-science-collector-tls -n redhat-ods-monitoring \  -o jsonpath='{.data.tls\.crt}' | base64 -d | openssl x509 -noout -text | grep -E 'Subject:|Not After'
9. Check Collector Logs
kubectl logs -n redhat-ods-monitoring -l app.kubernetes.io/component=opentelemetry-collector --tail=50


## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [ ] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated Prometheus metrics Service and a conditional Prometheus ServiceMonitor (rendered when metrics enabled); existing collector ServiceMonitor remains for internal telemetry.
  * Added an additional operator metrics ServiceMonitor.

* **Security**
  * Prometheus endpoints now use HTTPS/TLS with service-ca provisioned certificates and bearer-token authentication; collector internal telemetry continues over HTTP with bearer token.

* **Tests**
  * Added end-to-end test validating TLS is enabled for the Prometheus exporter and its ServiceMonitor.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->