### PR TITLE
feat: make more flex for the application namespace by getter and setter

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -18,7 +18,6 @@ package main
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -82,7 +81,6 @@ import (
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/logger"
-	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/metadata/labels"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/resources"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/upgrade"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/flags"
@@ -260,13 +258,13 @@ func main() { //nolint:funlen,maintidx,gocyclo
 	// get old release version before we create default DSCI CR
 	oldReleaseVersion, _ := upgrade.GetDeployedRelease(ctx, setupClient)
 
-	secretCache, err := createSecretCacheConfig(ctx, setupClient, platform)
+	secretCache, err := createSecretCacheConfig(platform)
 	if err != nil {
 		setupLog.Error(err, "unable to get application namespace into cache")
 		os.Exit(1)
 	}
 
-	oDHCache, err := createODHGeneralCacheConfig(ctx, setupClient, platform)
+	oDHCache, err := createODHGeneralCacheConfig(platform)
 	if err != nil {
 		setupLog.Error(err, "unable to get application namespace into cache")
 		os.Exit(1)
@@ -504,7 +502,7 @@ func main() { //nolint:funlen,maintidx,gocyclo
 	}
 }
 
-func getCommonCache(ctx context.Context, cli client.Client, platform common.Platform) (map[string]cache.Config, error) {
+func getCommonCache(platform common.Platform) (map[string]cache.Config, error) {
 	namespaceConfigs := map[string]cache.Config{}
 
 	// networkpolicy need operator namespace
@@ -516,39 +514,20 @@ func getCommonCache(ctx context.Context, cli client.Client, platform common.Plat
 	namespaceConfigs[operatorNs] = cache.Config{}
 	namespaceConfigs["redhat-ods-monitoring"] = cache.Config{}
 
-	if platform == cluster.ManagedRhoai {
-		namespaceConfigs["redhat-ods-applications"] = cache.Config{}
-		namespaceConfigs[cluster.NamespaceConsoleLink] = cache.Config{}
-		return namespaceConfigs, nil
-	} else {
-		// get the managed application's namespaces
-		cNamespaceList := &corev1.NamespaceList{}
-		labelSelector := client.MatchingLabels{
-			labels.CustomizedAppNamespace: labels.True,
-		}
-		if err := cli.List(ctx, cNamespaceList, labelSelector); err != nil {
-			return nil, err
-		}
+	// Get application namespace from cluster config
+	appNamespace := cluster.GetApplicationNamespace()
+	namespaceConfigs[appNamespace] = cache.Config{}
 
-		switch len(cNamespaceList.Items) {
-		case 0:
-			if platform == cluster.SelfManagedRhoai {
-				namespaceConfigs["redhat-ods-applications"] = cache.Config{}
-			} else {
-				namespaceConfigs["opendatahub"] = cache.Config{}
-			}
-			return namespaceConfigs, nil
-		case 1:
-			namespaceConfigs[cNamespaceList.Items[0].Name] = cache.Config{}
-			return namespaceConfigs, nil
-		default:
-			return nil, errors.New("only support max. one namespace with label: opendatahub.io/application-namespace: true")
-		}
+	// Add console link namespace for managed RHOAI
+	if platform == cluster.ManagedRhoai {
+		namespaceConfigs[cluster.NamespaceConsoleLink] = cache.Config{}
 	}
+
+	return namespaceConfigs, nil
 }
 
-func createSecretCacheConfig(ctx context.Context, cli client.Client, platform common.Platform) (map[string]cache.Config, error) {
-	namespaceConfigs, err := getCommonCache(ctx, cli, platform)
+func createSecretCacheConfig(platform common.Platform) (map[string]cache.Config, error) {
+	namespaceConfigs, err := getCommonCache(platform)
 	if err != nil {
 		return nil, err
 	}
@@ -558,8 +537,8 @@ func createSecretCacheConfig(ctx context.Context, cli client.Client, platform co
 	return namespaceConfigs, nil
 }
 
-func createODHGeneralCacheConfig(ctx context.Context, cli client.Client, platform common.Platform) (map[string]cache.Config, error) {
-	namespaceConfigs, err := getCommonCache(ctx, cli, platform)
+func createODHGeneralCacheConfig(platform common.Platform) (map[string]cache.Config, error) {
+	namespaceConfigs, err := getCommonCache(platform)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cluster/cluster_config.go
+++ b/pkg/cluster/cluster_config.go
@@ -33,9 +33,10 @@ type ClusterInfo struct {
 }
 
 var clusterConfig struct {
-	Namespace   string
-	Release     common.Release
-	ClusterInfo ClusterInfo
+	Namespace            string
+	ApplicationNamespace string
+	Release              common.Release
+	ClusterInfo          ClusterInfo
 }
 
 type InstallConfig struct {
@@ -68,6 +69,12 @@ func Init(ctx context.Context, cli client.Client) error {
 	if err != nil {
 		return err
 	}
+
+	err = setApplicationNamespace(ctx, cli)
+	if err != nil {
+		return err
+	}
+
 	printClusterConfig(log)
 	return nil
 }
@@ -75,6 +82,7 @@ func Init(ctx context.Context, cli client.Client) error {
 func printClusterConfig(log logr.Logger) {
 	log.Info("Cluster config",
 		"Operator Namespace", clusterConfig.Namespace,
+		"Application Namespace", clusterConfig.ApplicationNamespace,
 		"Release", clusterConfig.Release,
 		"Cluster", clusterConfig.ClusterInfo)
 }
@@ -348,4 +356,55 @@ func setManagedMonitoringNamespace(ctx context.Context, cli client.Client) error
 		viper.SetDefault("dsc-monitoring-namespace", DefaultMonitoringNamespaceODH)
 	}
 	return nil
+}
+
+func setApplicationNamespace(ctx context.Context, cli client.Client) error {
+	platform := clusterConfig.Release.Name
+	defaultRHOAIApplicationNamespace := "redhat-ods-applications"
+
+	if platform == ManagedRhoai {
+		clusterConfig.ApplicationNamespace = defaultRHOAIApplicationNamespace
+		return nil
+	}
+	namespaceList := &corev1.NamespaceList{}
+	labelSelector := client.MatchingLabels{
+		"opendatahub.io/application-namespace": "true",
+	}
+
+	if err := cli.List(ctx, namespaceList, labelSelector); err != nil {
+		return err
+	}
+
+	switch len(namespaceList.Items) {
+	case 0:
+		// No labeled namespace found, use platform default
+		if platform == SelfManagedRhoai {
+			clusterConfig.ApplicationNamespace = defaultRHOAIApplicationNamespace
+		} else {
+			clusterConfig.ApplicationNamespace = "opendatahub"
+		}
+	case 1:
+		// One labeled namespace found, use it
+		clusterConfig.ApplicationNamespace = namespaceList.Items[0].Name
+	default:
+		// Multiple labeled namespaces found, this is an error
+		return errors.New("only one namespace with label opendatahub.io/application-namespace: true is supported")
+	}
+
+	return nil
+}
+
+// GetApplicationNamespace returns the application namespace for the platform.
+// It returns a cached value from clusterConfig if available, otherwise determines it dynamically.
+func GetApplicationNamespace() string {
+	if clusterConfig.ApplicationNamespace != "" {
+		return clusterConfig.ApplicationNamespace
+	}
+
+	switch clusterConfig.Release.Name {
+	case SelfManagedRhoai, ManagedRhoai:
+		return "redhat-ods-applications"
+	default:
+		return "opendatahub"
+	}
 }

--- a/pkg/cluster/cluster_config_internal_test.go
+++ b/pkg/cluster/cluster_config_internal_test.go
@@ -1,0 +1,215 @@
+package cluster
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/opendatahub-io/opendatahub-operator/v2/api/common"
+)
+
+func TestGetApplicationNamespace(t *testing.T) {
+	testCases := []struct {
+		name              string
+		platform          common.Platform
+		appNamespace      string
+		expectedNamespace string
+	}{
+		{
+			name:              "Returns user defined namespace for OpenDataHub",
+			platform:          OpenDataHub,
+			appNamespace:      "custom-odh-ns",
+			expectedNamespace: "custom-odh-ns",
+		},
+		{
+			name:              "Returns user defined namespace for SelfManagedRhoai",
+			platform:          SelfManagedRhoai,
+			appNamespace:      "custom-rhoai-ns",
+			expectedNamespace: "custom-rhoai-ns",
+		},
+		{
+			name:              "Fallback to default for OpenDataHub",
+			platform:          OpenDataHub,
+			appNamespace:      "",
+			expectedNamespace: "opendatahub",
+		},
+		{
+			name:              "Fallback to default for SelfManagedRhoai",
+			platform:          SelfManagedRhoai,
+			appNamespace:      "",
+			expectedNamespace: "redhat-ods-applications",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Directly set the internal clusterConfig
+			clusterConfig.Release.Name = tc.platform
+			clusterConfig.ApplicationNamespace = tc.appNamespace
+			defer func() {
+				// Reset after test
+				clusterConfig.ApplicationNamespace = ""
+				clusterConfig.Release.Name = ""
+			}()
+
+			result := GetApplicationNamespace()
+			if result != tc.expectedNamespace {
+				t.Errorf("GetApplicationNamespace() = %q, want %q", result, tc.expectedNamespace)
+			}
+		})
+	}
+}
+
+func TestSetApplicationNamespace(t *testing.T) {
+	testCases := []struct {
+		name               string
+		platform           common.Platform
+		existingNamespaces []corev1.Namespace
+		expectedNamespace  string
+		expectError        bool
+		errorMsg           string
+	}{
+		{
+			name:     "ManagedRhoai always uses redhat-ods-applications",
+			platform: ManagedRhoai,
+			existingNamespaces: []corev1.Namespace{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "custom-labeled-ns",
+						Labels: map[string]string{
+							"opendatahub.io/application-namespace": "true",
+						},
+					},
+				},
+			},
+			expectedNamespace: "redhat-ods-applications",
+			expectError:       false,
+		},
+		{
+			name:     "OpenDataHub with labeled namespace",
+			platform: OpenDataHub,
+			existingNamespaces: []corev1.Namespace{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "custom-odh-ns",
+						Labels: map[string]string{
+							"opendatahub.io/application-namespace": "true",
+						},
+					},
+				},
+			},
+			expectedNamespace: "custom-odh-ns",
+			expectError:       false,
+		},
+		{
+			name:               "OpenDataHub without labeled namespace uses default",
+			platform:           OpenDataHub,
+			existingNamespaces: []corev1.Namespace{},
+			expectedNamespace:  "opendatahub",
+			expectError:        false,
+		},
+		{
+			name:     "SelfManagedRhoai with labeled namespace",
+			platform: SelfManagedRhoai,
+			existingNamespaces: []corev1.Namespace{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "custom-rhoai-ns",
+						Labels: map[string]string{
+							"opendatahub.io/application-namespace": "true",
+						},
+					},
+				},
+			},
+			expectedNamespace: "custom-rhoai-ns",
+			expectError:       false,
+		},
+		{
+			name:               "SelfManagedRhoai without labeled namespace uses default",
+			platform:           SelfManagedRhoai,
+			existingNamespaces: []corev1.Namespace{},
+			expectedNamespace:  "redhat-ods-applications",
+			expectError:        false,
+		},
+		{
+			name:     "Error when multiple labeled namespaces exist",
+			platform: OpenDataHub,
+			existingNamespaces: []corev1.Namespace{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "namespace-1",
+						Labels: map[string]string{
+							"opendatahub.io/application-namespace": "true",
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "namespace-2",
+						Labels: map[string]string{
+							"opendatahub.io/application-namespace": "true",
+						},
+					},
+				},
+			},
+			expectError: true,
+			errorMsg:    "only one namespace with label opendatahub.io/application-namespace: true is supported",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Setup: Create fake client with namespaces
+			scheme := runtime.NewScheme()
+			_ = corev1.AddToScheme(scheme)
+
+			objs := make([]client.Object, len(tc.existingNamespaces))
+			for i := range tc.existingNamespaces {
+				objs[i] = &tc.existingNamespaces[i]
+			}
+
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(objs...).
+				Build()
+
+			// Setup cluster config with platform
+			clusterConfig.Release.Name = tc.platform
+			defer func() {
+				// Reset after test
+				clusterConfig.ApplicationNamespace = ""
+				clusterConfig.Release.Name = ""
+			}()
+
+			// Execute - call internal function directly
+			ctx := context.Background()
+			err := setApplicationNamespace(ctx, fakeClient)
+
+			// Assert error
+			if tc.expectError {
+				if err == nil {
+					t.Errorf("Expected error but got nil")
+				} else if err.Error() != tc.errorMsg {
+					t.Errorf("Expected error %q, got %q", tc.errorMsg, err.Error())
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("Unexpected error: %v", err)
+				return
+			}
+
+			// Assert namespace
+			result := GetApplicationNamespace()
+			if result != tc.expectedNamespace {
+				t.Errorf("Application namespace = %q, want %q", result, tc.expectedNamespace)
+			}
+		})
+	}
+}


### PR DESCRIPTION
(cherry picked from commit 01c7d6f6ecb0f49b3c906720982fe152e10a5ef3)

<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

- move old logic from main.go into setApplicationNamespace()
- also set the applicaiton namepsace as clusterConfig

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->

unit test
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Centralized application namespace handling with platform-specific defaults for improved consistency.
  * Enhanced cache configuration to include additional system namespaces for better integration.

* **Bug Fixes**
  * Removed dynamic namespace discovery logic that could result in errors with multiple or missing namespaces.

* **Tests**
  * Added comprehensive test suite for application namespace determination across different platform types.

* **Refactor**
  * Simplified cache configuration functions by streamlining parameters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->