### PR TITLE
Improve skip logic with parallel groups

### DIFF
--- a/cmd/test-retry/README.md
+++ b/cmd/test-retry/README.md
@@ -36,6 +36,10 @@ go build -o test-retry .
 # Filter specific tests
 ./test-retry e2e --filter "^TestOdhOperator.*Dashboard"
 
+# Filter tests using wildcards (glob patterns)
+./test-retry e2e --filter "TestOdhOperator/components/*"
+./test-retry e2e --filter "TestOdhOperator/*/basic_test"
+
 # Run with custom test runner options
 ./test-retry e2e -- "-count=3 -timeout=30m"
 ```
@@ -46,7 +50,9 @@ go build -o test-retry .
 - `--verbose`: Enable verbose output
 
 #### E2E Test Flags
-- `--filter`: Filter tests to run using regex pattern (default: "^TestOdhOperator/")
+- `--filter`: Filter tests to run using test name or glob wildcard pattern (default: "^TestOdhOperator/")
+  - Supports test name: `"TestOdhOperator/components`
+  - Supports wildcards: `"TestOdhOperator/components/*"`, `"TestOdhOperator/*/basic_test"`
 - `--path`: Path to e2e tests (default: "./tests/e2e/")
 - `--working-dir`: Working directory for running go test (default: current directory)
 - `--never-skip`: Test prefixes that should never be skipped (default: ["TestOdhOperator/DSCInitialization_and_DataScienceCluster_management_E2E_Tests/"])

--- a/cmd/test-retry/pkg/cli/e2e.go
+++ b/cmd/test-retry/pkg/cli/e2e.go
@@ -68,7 +68,7 @@ Example: test-retry e2e -- -run TestFoo -v`,
 	cmd.Flags().StringVar(&workingDir, "working-dir", "", "Working directory for running go test (default: current directory)")
 	cmd.Flags().IntVar(&maxRetries, "max-retries", 3, "Maximum number of retries for failed tests")
 	cmd.Flags().StringSliceVar(&neverSkip, "never-skip", []string{"TestOdhOperator/DSCInitialization_and_DataScienceCluster_management_E2E_Tests", "TestOdhOperator/DataScienceCluster"}, "Test prefixes that should never be skipped (always run, repeatable)")
-	cmd.Flags().StringSliceVar(&skipAtPrefix, "skip-at-prefix", []string{"TestOdhOperator/services/", "TestOdhOperator/components/", "TestOdhOperator/"}, "Test prefixes where tests should be extracted at prefix + 1 level (repeatable)")
+	cmd.Flags().StringSliceVar(&skipAtPrefix, "skip-at-prefix", []string{"TestOdhOperator/services/*/", "TestOdhOperator/components/*/", "TestOdhOperator/"}, "Test prefixes where tests should be extracted at prefix + 1 level (repeatable)")
 	cmd.Flags().StringVar(&junitOutput, "junit-output", "", "Path to JUnit XML output file (optional)")
 
 	// GitHub PR notification flags

--- a/cmd/test-retry/pkg/runner/e2e_test.go
+++ b/cmd/test-retry/pkg/runner/e2e_test.go
@@ -235,6 +235,65 @@ func TestBuildSkipFilter(t *testing.T) {
 			},
 			expected: "^TestOdhOperator$/^components$/^component1$",
 		},
+		{
+			name: "components with sub groups",
+			opts: types.E2ETestOptions{
+				SkipAtPrefixes: []string{"TestOdhOperator/components/*/", "TestOdhOperator/"},
+			},
+			aggregatedTestResult: &types.TestResult{PassedTest: []types.TestCase{
+				{Name: "TestOdhOperator/components/group_1/dashboard"},
+				{Name: "TestOdhOperator/components/group_1/dashboard/subtest1"},
+				{Name: "TestOdhOperator/components/group_1/dashboard/subtest2"},
+				{Name: "TestOdhOperator/components/group_1/kueue/subtest1"},
+				{Name: "TestOdhOperator/components/group_1/kueue/subtest2"},
+				{Name: "TestOdhOperator/components/group_2/kserve"},
+				{Name: "TestOdhOperator/components/group_2/kserve/subtest1"},
+				{Name: "TestOdhOperator/components/group_2/kserve/subtest2"},
+				{Name: "TestOdhOperator/components/group_3"},
+				{Name: "TestOdhOperator/components/group_3/trustyai"},
+				{Name: "TestOdhOperator/components/group_3/trustyai/subtest1"},
+				{Name: "TestOdhOperator/components/group_3/trustyai/subtest2"},
+			}},
+			expected: "^TestOdhOperator$/^components$/^group_1$/^dashboard$|^TestOdhOperator$/^components$/^group_2$/^kserve$|^TestOdhOperator$/^components$/^group_3$|^TestOdhOperator$/^components$/^group_3$/^trustyai$",
+		},
+		{
+			name: "only components skipped",
+			opts: types.E2ETestOptions{
+				SkipAtPrefixes: []string{"TestOdhOperator/components"},
+			},
+			aggregatedTestResult: &types.TestResult{PassedTest: []types.TestCase{
+				{Name: "TestOdhOperator"},
+				{Name: "TestOdhOperator/components"},
+				{Name: "TestOdhOperator/components/dashboard"},
+				{Name: "TestOdhOperator/components/dashboard/subtest"},
+			}},
+			expected: "^TestOdhOperator$/^components$|^TestOdhOperator$/^components$/^dashboard$",
+		},
+		{
+			name: "wildcard not in the end of the prefix",
+			opts: types.E2ETestOptions{
+				SkipAtPrefixes: []string{"TestOdhOperator/*/group_1"},
+			},
+			aggregatedTestResult: &types.TestResult{PassedTest: []types.TestCase{
+				{Name: "TestOdhOperator/components/group_1/dashboard"},
+				{Name: "TestOdhOperator/components/group_1/dashboard/subtest1"},
+				{Name: "TestOdhOperator/components/group_1/dashboard/subtest2"},
+				{Name: "TestOdhOperator/components/group_1/kueue/subtest1"},
+				{Name: "TestOdhOperator/components/group_1/kueue/subtest2"},
+				{Name: "TestOdhOperator/components/group_2"},
+				{Name: "TestOdhOperator/components/group_2/kserve"},
+				{Name: "TestOdhOperator/components/group_2/kserve/subtest1"},
+				{Name: "TestOdhOperator/services/group_1/auth"},
+				{Name: "TestOdhOperator/services/group_1/auth/subtest1"},
+				{Name: "TestOdhOperator/services/group_1/auth/subtest2"},
+				{Name: "TestOdhOperator/services/group_1/monitoring/subtest1"},
+				{Name: "TestOdhOperator/services/group_1/monitoring/subtest2"},
+				{Name: "TestOdhOperator/components/group_2"},
+				{Name: "TestOdhOperator/components/group_2/gateway"},
+				{Name: "TestOdhOperator/components/group_2/gateway/subtest1"},
+			}},
+			expected: "^TestOdhOperator$/^components$/^group_1$/^dashboard$|^TestOdhOperator$/^services$/^group_1$/^auth$",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description

With parallel testing, 'skip on retry' isn't working correctly because it doesn't account for the additional 'group' level for components and services in the filter parameters. For example, if one component test in a group fails, all tests in that specific group are retried.

To fix this, this PR adds support for the `*` wildcard for dynamic group names. This allows matching any name at a specific test level, which we use to properly support the group level for component and service tests.

Jira task: https://issues.redhat.com/browse/RHOAIENG-37402

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [x] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [ ] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded --filter flag docs with examples showing test names and glob wildcards.

* **New Features**
  * --filter flag accepts glob wildcard patterns (e.g., "TestOdhOperator/components/*").

* **Improvements**
  * Default skip/filter prefixes updated to use wildcards for broader grouping of services and components.

* **Tests**
  * Added E2E test cases covering wildcard-based skip/filter behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->