### PR TITLE
chore: fix default HWP description

### DIFF
--- a/config/hardwareprofiles/default-profile.yaml
+++ b/config/hardwareprofiles/default-profile.yaml
@@ -3,7 +3,7 @@ kind: HardwareProfile
 metadata:
   annotations:
     opendatahub.io/dashboard-feature-visibility: '[]'
-    opendatahub.io/description: 'Provides a baseline hardware profile with 2 CPUs and 4Gi memory by default, adjustable up to 4 CPUs and 8Gi memory.'
+    opendatahub.io/description: 'This profile offers 2 CPUs and 4 GiB of memory. You can customize these resources up to 4 CPUs and 8 GiB of memory.'
     opendatahub.io/disabled: 'false'
     opendatahub.io/display-name: default-profile
     opendatahub.io/managed: "false"


### PR DESCRIPTION
## Description
This is a minor change to update the default HardwareProfile description. It was previously this:
`Provides a baseline hardware profile with 2 CPUs and 4Gi memory by default, adjustable up to 4 CPUs and 8Gi memory.`

When it should have been this:
`This profile offers 2 CPUs and 4 GiB of memory. You can customize these resources up to 4 CPUs and 8 GiB of memory.`

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<img width="1904" height="923" alt="image" src="https://github.com/user-attachments/assets/bfb49359-c439-4c8d-b19a-48535e159d0d" />

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [X] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [X] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work
- [X] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [X] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
Cosmetic change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Clarified hardware profile description for readability.
  * Updated memory unit formatting (e.g., "4 GiB") and wording to specify resource defaults (2 CPUs, 4 GiB) and configurable maximums (up to 4 CPUs, 8 GiB).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->