### PR TITLE
adjust ext_authz timeout to 5s

### DIFF
--- a/api/services/v1alpha1/gateway_types.go
+++ b/api/services/v1alpha1/gateway_types.go
@@ -58,6 +58,13 @@ type GatewayConfigSpec struct {
 	// Cookie configuration for OAuth2 proxy (applies to both OIDC and OpenShift OAuth)
 	// +optional
 	Cookie *CookieConfig `json:"cookie,omitempty"`
+
+	// AuthTimeout is the duration Envoy waits for auth proxy responses.
+	// Requests timeout with 403 if exceeded.
+	// Overrides GATEWAY_AUTH_TIMEOUT env var. Default: "5s"
+	// +optional
+	// +kubebuilder:validation:Pattern=`^([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$`
+	AuthTimeout string `json:"authTimeout,omitempty"`
 }
 
 // OIDCConfig defines OIDC provider configuration

--- a/docs/api-overview.md
+++ b/docs/api-overview.md
@@ -2627,6 +2627,7 @@ _Appears in:_
 | `domain` _string_ | Domain configuration for the GatewayConfig<br />Example: apps.example.com |  |  |
 | `subdomain` _string_ | Subdomain configuration for the GatewayConfig |  | MaxLength: 63 <br />Pattern: `^([a-z0-9]([-a-z0-9]*[a-z0-9])?)$` <br /> |
 | `cookie` _[CookieConfig](#cookieconfig)_ | Cookie configuration for OAuth2 proxy (applies to both OIDC and OpenShift OAuth) |  |  |
+| `authTimeout` _string_ | AuthTimeout is the duration Envoy waits for auth proxy responses.<br />Requests timeout with 403 if exceeded.<br />Overrides GATEWAY_AUTH_TIMEOUT env var. Default: "5s" |  | Pattern: `^([0-9]+(\.[0-9]+)?(ns\|us\|µs\|ms\|s\|m\|h))+$` <br /> |
 
 
 #### GatewayConfigStatus

--- a/internal/controller/services/gateway/gateway_auth_actions.go
+++ b/internal/controller/services/gateway/gateway_auth_actions.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"strings"
 
 	"k8s.io/apimachinery/pkg/runtime/serializer"
@@ -71,18 +72,40 @@ func createKubeAuthProxyInfrastructure(ctx context.Context, rr *odhtypes.Reconci
 	return nil
 }
 
+// getGatewayAuthTimeout returns the auth timeout using:
+// API field > env var > default (5s).
+func getGatewayAuthTimeout(gatewayConfig *serviceApi.GatewayConfig) string {
+	if gatewayConfig != nil && gatewayConfig.Spec.AuthTimeout != "" {
+		return gatewayConfig.Spec.AuthTimeout
+	}
+
+	if timeout := os.Getenv("GATEWAY_AUTH_TIMEOUT"); timeout != "" {
+		return timeout
+	}
+
+	return "5s"
+}
+
 func createEnvoyFilter(ctx context.Context, rr *odhtypes.ReconciliationRequest) error {
+	gatewayConfig, ok := rr.Instance.(*serviceApi.GatewayConfig)
+	if !ok {
+		return errors.New("instance is not of type *services.GatewayConfig")
+	}
+
+	authTimeout := getGatewayAuthTimeout(gatewayConfig)
+
 	// using yaml templates due to complexity of k8s api struct for envoy filter
 	yamlContent, err := gatewayResources.ReadFile("resources/envoyfilter-authn.yaml")
 	if err != nil {
 		return fmt.Errorf("failed to read EnvoyFilter template: %w", err)
 	}
 
-	cookiePattern := OAuth2ProxyCookieName
-	yamlContent = []byte(strings.ReplaceAll(string(yamlContent), "{{.CookieName}}", cookiePattern))
+	yamlString := string(yamlContent)
+	yamlString = fmt.Sprintf(yamlString, authTimeout, authTimeout)
+	yamlString = strings.ReplaceAll(yamlString, "{{.CookieName}}", OAuth2ProxyCookieName)
 
 	decoder := serializer.NewCodecFactory(rr.Client.Scheme()).UniversalDeserializer()
-	unstructuredObjects, err := resources.Decode(decoder, yamlContent)
+	unstructuredObjects, err := resources.Decode(decoder, []byte(yamlString))
 	if err != nil {
 		return fmt.Errorf("failed to decode EnvoyFilter YAML: %w", err)
 	}

--- a/internal/controller/services/gateway/gateway_auth_actions_test.go
+++ b/internal/controller/services/gateway/gateway_auth_actions_test.go
@@ -26,6 +26,9 @@ func getEnvoyFilterLuaCode(t *testing.T) string {
 
 	rr := &odhtypes.ReconciliationRequest{
 		Client: setupTestClient(),
+		Instance: &serviceApi.GatewayConfig{
+			Spec: serviceApi.GatewayConfigSpec{},
+		},
 	}
 
 	err := createEnvoyFilter(ctx, rr)
@@ -213,6 +216,9 @@ func TestCreateEnvoyFilter(t *testing.T) {
 
 	rr := &odhtypes.ReconciliationRequest{
 		Client: setupTestClient(),
+		Instance: &serviceApi.GatewayConfig{
+			Spec: serviceApi.GatewayConfigSpec{},
+		},
 	}
 
 	err := createEnvoyFilter(ctx, rr)

--- a/internal/controller/services/gateway/resources/envoyfilter-authn.yaml
+++ b/internal/controller/services/gateway/resources/envoyfilter-authn.yaml
@@ -28,7 +28,7 @@ spec:
             server_uri:
               uri: https://kube-auth-proxy.openshift-ingress.svc.cluster.local:8443/oauth2/auth
               cluster: kube-auth-proxy
-              timeout: 5s
+              timeout: %s
             authorization_request:
               allowed_headers:
                 patterns:
@@ -84,7 +84,7 @@ spec:
                   -- Parse and filter cookies in a single pass
                   for cookie in cookie_header:gmatch("([^;]+)") do
                     -- Trim whitespace and extract cookie name
-                    local trimmed = cookie:match("^%s*(.-)%s*$")
+                    local trimmed = cookie:match("^%%s*(.-)%%s*$")
                     if trimmed ~= "" then
                       local cookie_name = trimmed:match("^([^=]+)")
                       -- Only keep cookies that don't match the OAuth2 proxy cookie pattern
@@ -112,7 +112,7 @@ spec:
       value:
         name: kube-auth-proxy
         type: STRICT_DNS
-        connect_timeout: 5s
+        connect_timeout: %s
         transport_socket:
           name: envoy.transport_sockets.tls
           typed_config:


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->
JIRA: [RHOAIENG-38254](https://issues.redhat.com/browse/RHOAIENG-38254)
JIRA: [RHOAIENG-38255](https://issues.redhat.com/browse/RHOAIENG-38255)

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->
No need


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a per-gateway configurable auth timeout (authTimeout) for the gateway auth proxy.

* **Bug Fixes**
  * Replaced hard-coded timeout values with the configurable authTimeout and improved cookie trimming to ensure consistent auth behavior.

* **Documentation**
  * Documented authTimeout, default (5s), env var override, and validation pattern.

* **Tests**
  * Updated tests to include gateway config instances for auth-related reconciliation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->