### PR TITLE
[rhoai] RHOAIENG-37620: the gatewayconfig CRD needs a "short name" field to override

### DIFF
--- a/api/services/v1alpha1/gateway_types.go
+++ b/api/services/v1alpha1/gateway_types.go
@@ -49,6 +49,12 @@ type GatewayConfigSpec struct {
 	// +optional
 	Domain string `json:"domain,omitempty"`
 
+	// Subdomain configuration for the GatewayConfig
+	// +optional
+	// +kubebuilder:validation:MaxLength=63
+	// +kubebuilder:validation:Pattern=`^([a-z0-9]([-a-z0-9]*[a-z0-9])?)$`
+	Subdomain string `json:"subdomain,omitempty"`
+
 	// Cookie configuration for OAuth2 proxy (applies to both OIDC and OpenShift OAuth)
 	// +optional
 	Cookie *CookieConfig `json:"cookie,omitempty"`

--- a/bundle/manifests/services.platform.opendatahub.io_gatewayconfigs.yaml
+++ b/bundle/manifests/services.platform.opendatahub.io_gatewayconfigs.yaml
@@ -136,6 +136,11 @@ spec:
                 - clientSecretRef
                 - issuerURL
                 type: object
+              subdomain:
+                description: Subdomain configuration for the GatewayConfig
+                maxLength: 63
+                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?)$
+                type: string
             type: object
           status:
             description: GatewayConfigStatus defines the observed state of GatewayConfig

--- a/config/crd/bases/services.platform.opendatahub.io_gatewayconfigs.yaml
+++ b/config/crd/bases/services.platform.opendatahub.io_gatewayconfigs.yaml
@@ -136,6 +136,11 @@ spec:
                 - clientSecretRef
                 - issuerURL
                 type: object
+              subdomain:
+                description: Subdomain configuration for the GatewayConfig
+                maxLength: 63
+                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?)$
+                type: string
             type: object
           status:
             description: GatewayConfigStatus defines the observed state of GatewayConfig

--- a/docs/api-overview.md
+++ b/docs/api-overview.md
@@ -2625,6 +2625,7 @@ _Appears in:_
 | `oidc` _[OIDCConfig](#oidcconfig)_ | OIDC configuration (used when cluster is in OIDC authentication mode) |  |  |
 | `certificate` _[CertificateSpec](#certificatespec)_ | Certificate management |  |  |
 | `domain` _string_ | Domain configuration for the GatewayConfig<br />Example: apps.example.com |  |  |
+| `subdomain` _string_ | Subdomain configuration for the GatewayConfig |  | MaxLength: 63 <br />Pattern: `^([a-z0-9]([-a-z0-9]*[a-z0-9])?)$` <br /> |
 | `cookie` _[CookieConfig](#cookieconfig)_ | Cookie configuration for OAuth2 proxy (applies to both OIDC and OpenShift OAuth) |  |  |
 
 

--- a/internal/controller/services/gateway/gateway_support.go
+++ b/internal/controller/services/gateway/gateway_support.go
@@ -114,36 +114,45 @@ func getCertificateType(gatewayConfig *serviceApi.GatewayConfig) string {
 	return string(gatewayConfig.Spec.Certificate.Type)
 }
 
-// buildGatewayDomain combines gateway name with base domain.
-func buildGatewayDomain(baseDomain string) string {
+// buildGatewayDomain combines subdomain with base domain.
+// If subdomain is empty or whitespace, uses DefaultGatewayName as fallback.
+func buildGatewayDomain(subdomain, baseDomain string) string {
+	// Trim whitespace and use provided subdomain or fallback to default gateway name
+	hostname := strings.TrimSpace(subdomain)
+	if hostname == "" {
+		hostname = DefaultGatewayName
+	}
 	// Use string concatenation for better performance in frequently called function
-	return DefaultGatewayName + "." + baseDomain
+	return hostname + "." + baseDomain
 }
 
 // getClusterDomain gets cluster domain - extracted common logic.
-func getClusterDomain(ctx context.Context, client client.Client) (string, error) {
+func getClusterDomain(ctx context.Context, client client.Client, subdomain string) (string, error) {
 	clusterDomain, err := cluster.GetDomain(ctx, client)
 	if err != nil {
 		return "", fmt.Errorf("failed to get cluster domain: %w", err)
 	}
-	return buildGatewayDomain(clusterDomain), nil
+	return buildGatewayDomain(subdomain, clusterDomain), nil
 }
 
 func resolveDomain(ctx context.Context, client client.Client,
 	gatewayConfig *serviceApi.GatewayConfig) (string, error) {
 	// Input validation
 	if gatewayConfig == nil {
-		return getClusterDomain(ctx, client)
+		return getClusterDomain(ctx, client, "")
 	}
+
+	// Extract subdomain from GatewayConfig if provided
+	subdomain := strings.TrimSpace(gatewayConfig.Spec.Subdomain)
 
 	// Check if user has overridden the domain
 	baseDomain := strings.TrimSpace(gatewayConfig.Spec.Domain)
 	if baseDomain != "" {
-		return buildGatewayDomain(baseDomain), nil
+		return buildGatewayDomain(subdomain, baseDomain), nil
 	}
 
-	// No domain override, use cluster domain
-	return getClusterDomain(ctx, client)
+	// No domain override, use cluster domain with subdomain
+	return getClusterDomain(ctx, client, subdomain)
 }
 
 // GetGatewayDomain reads GatewayConfig and passes it to resolveDomain.
@@ -154,18 +163,21 @@ func GetGatewayDomain(ctx context.Context, cli client.Client) (string, error) {
 	gatewayConfig := &serviceApi.GatewayConfig{}
 	err := cli.Get(ctx, client.ObjectKey{Name: serviceApi.GatewayInstanceName}, gatewayConfig)
 	if err != nil {
-		// GatewayConfig doesn't exist, use cluster domain directly
-		return getClusterDomain(ctx, cli)
+		// GatewayConfig doesn't exist, use cluster domain directly with default subdomain
+		return getClusterDomain(ctx, cli, "")
 	}
+
+	// Extract subdomain from GatewayConfig if provided
+	subdomain := strings.TrimSpace(gatewayConfig.Spec.Subdomain)
 
 	// Check if user has overridden the domain (inline ResolveDomain logic to avoid redundant calls)
 	baseDomain := strings.TrimSpace(gatewayConfig.Spec.Domain)
 	if baseDomain != "" {
-		return buildGatewayDomain(baseDomain), nil
+		return buildGatewayDomain(subdomain, baseDomain), nil
 	}
 
-	// No domain override, use cluster domain
-	return getClusterDomain(ctx, cli)
+	// No domain override, use cluster domain with subdomain
+	return getClusterDomain(ctx, cli, subdomain)
 }
 
 // createListeners creates the Gateway listeners configuration.

--- a/internal/controller/services/gateway/gateway_util_test.go
+++ b/internal/controller/services/gateway/gateway_util_test.go
@@ -121,12 +121,18 @@ func createTestGatewayConfig(name, domain string, certType infrav1.CertType) *se
 
 // createTestGatewayConfigSupport creates a GatewayConfig for support function testing.
 func createTestGatewayConfigSupport(domain string, certSpec *infrav1.CertificateSpec) *serviceApi.GatewayConfig {
+	return createTestGatewayConfigSupportWithSubdomain(domain, "", certSpec)
+}
+
+// createTestGatewayConfigSupportWithSubdomain creates a GatewayConfig with subdomain for support function testing.
+func createTestGatewayConfigSupportWithSubdomain(domain, subdomain string, certSpec *infrav1.CertificateSpec) *serviceApi.GatewayConfig {
 	return &serviceApi.GatewayConfig{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: serviceApi.GatewayInstanceName,
 		},
 		Spec: serviceApi.GatewayConfigSpec{
 			Domain:      domain,
+			Subdomain:   subdomain,
 			Certificate: certSpec,
 		},
 	}


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [ ] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->
