### PR TITLE
RHOAIENG-33446: update support for setting namespace variables for e2e test suite

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,12 @@ ifeq ($(BUNDLE_IMG), )
 endif
 
 IMAGE_BUILDER ?= podman
+# Specifies the namespace where the operator pods are deployed (defaults to opendatahub-operator-system)
 OPERATOR_NAMESPACE ?= opendatahub-operator-system
+# Specifies the namespace where the component deployments are deployed (defaults to opendatahub)
+APPLICATIONS_NAMESPACE ?= opendatahub
+# Specifies the namespace where the workbenches are deployed (defaults to opendatahub)
+WORKBENCHES_NAMESPACE ?= opendatahub
 DEFAULT_MANIFESTS_PATH ?= opt/manifests
 CGO_ENABLED ?= 1
 USE_LOCAL = false
@@ -501,8 +506,17 @@ CLEANFILES += $(PROMETHEUS_ALERT_RULES)
 
 .PHONY: e2e-test
 e2e-test:
+# Specifies the namespace where the operator pods are deployed
 ifndef E2E_TEST_OPERATOR_NAMESPACE
 export E2E_TEST_OPERATOR_NAMESPACE = $(OPERATOR_NAMESPACE)
+endif
+# Specifies the namespace where the component deployments are deployed
+ifndef E2E_TEST_APPLICATIONS_NAMESPACE
+export E2E_TEST_APPLICATIONS_NAMESPACE = $(APPLICATIONS_NAMESPACE)
+endif
+# Specifies the namespace where the workbenches are deployed
+ifndef E2E_TEST_WORKBENCHES_NAMESPACE
+export E2E_TEST_WORKBENCHES_NAMESPACE = $(WORKBENCHES_NAMESPACE)
 endif
 ifdef ARTIFACT_DIR
 export JUNIT_OUTPUT_PATH = ${ARTIFACT_DIR}/junit_report.xml

--- a/README.md
+++ b/README.md
@@ -449,6 +449,8 @@ Evn vars can be set to configure e2e tests:
 |---------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------|
 | E2E_TEST_OPERATOR_NAMESPACE     | Namespace where the ODH operator is deployed.                                                                                                                                | `opendatahub-operator-system` |
 | E2E_TEST_APPLICATIONS_NAMESPACE | Namespace where the ODH applications are deployed.                                                                                                                           | `opendatahub`                 |
+| E2E_TEST_WORKBENCHES_NAMESPACE | Namespace where the workbenches are deployed. | `opendatahub` |
+| E2E_TEST_DSC_MONITORING_NAMESPACE | Namespace where the ODH monitoring is deployed. | `opendatahub` |
 | E2E_TEST_OPERATOR_CONTROLLER    | To configure the execution of tests related to the Operator POD, this is useful to run e2e tests for an operator running out of the cluster i.e. for debugging purposes      | `true`                        |
 | E2E_TEST_OPERATOR_RESILIENCE    | To configure the execution of operator resilience tests, useful for testing operator fault tolerance scenarios                                 | `true`                        |
 | E2E_TEST_WEBHOOK                | To configure the execution of tests related to the Operator WebHooks, this is useful to run e2e tests for an operator running out of the cluster i.e. for debugging purposes | `true`                        |
@@ -468,6 +470,8 @@ Alternatively the above configurations can be passed to e2e-tests as flags by se
 |----------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------|
 | --operator-namespace          | Namespace where the ODH operator is deployed.                                                                                                                                | `opendatahub-operator-system` |
 | --applications-namespace      | Namespace where the ODH applications are deployed.                                                                                                                           | `opendatahub`                 |
+| --workbenches-namespace | Namespace where the workbenches are deployed. | `opendatahub` |
+| --dsc-monitoring-namespace | Namespace where the ODH monitoring is deployed. | `opendatahub` |
 | --test-operator-controller    | To configure the execution of tests related to the Operator POD, this is useful to run e2e tests for an operator running out of the cluster i.e. for debugging purposes      | `true`                        |
 | --test-operator-resilience    | To configure the execution of operator resilience tests, useful for testing operator fault tolerance scenarios                                 | `true`                        |
 | --test-webhook                | To configure the execution of tests related to the Operator WebHooks, this is useful to run e2e tests for an operator running out of the cluster i.e. for debugging purposes | `true`                        |
@@ -478,6 +482,29 @@ Alternatively the above configurations can be passed to e2e-tests as flags by se
 | --test-service                | A repeatable (or comma separated no spaces) flag that control which services should be tested, by default all service specific test are executed                             | `all services`                |
 | --test-operator-v2tov3upgrade | To configure the execution of V2 to V3 upgrade tests, useful for testing V2 to V3 upgrade scenarios                                                                       | `true`                        |
 | --test-hardware-profile       | To configure the execution of hardware profile tests, useful for testing hardware profile functionality between v1 and v1alpah1                                               | `true`                        |
+
+<details>
+<summary>Running E2E tests with custom application namespace</summary>
+
+If you intend to use non-default application namespace while running E2E tests, additional setup is required:
+1. create the custom application namespace
+```shell
+oc create namespace <your-custom-app-namespace>
+```
+2. ensure your custom namespace has the required label
+```shell
+oc label namespace <your-custom-app-namespace> opendatahub.io/application-namespace=true
+```
+3. deploy the operator
+```shell
+make deploy IMG=<your-operator-image>
+```
+4. run e2e test suite
+```shell
+make e2e-test -e E2E_TEST_APPLICATIONS_NAMESPACE=<your-custom-app-namespace> -e ...
+```
+5. once done with the tests, ensure to clean up the custom namespace
+</details>
 
 Example command to run full test suite skipping the DataScienceCluster deletion (useful to troubleshooting tests failures):
 

--- a/tests/e2e/controller_test.go
+++ b/tests/e2e/controller_test.go
@@ -73,10 +73,11 @@ func ParseDeletionPolicy(dp string) (DeletionPolicy, error) {
 
 // Struct to store test configurations.
 type TestContextConfig struct {
-	operatorNamespace   string
-	appsNamespace       string
-	monitoringNamespace string
-	deletionPolicy      DeletionPolicy
+	operatorNamespace    string
+	appsNamespace        string
+	workbenchesNamespace string
+	monitoringNamespace  string
+	deletionPolicy       DeletionPolicy
 
 	operatorControllerTest bool
 	operatorResilienceTest bool
@@ -368,6 +369,8 @@ func TestMain(m *testing.M) {
 	checkEnvVarBindingError(viper.BindEnv("operator-namespace", viper.GetEnvPrefix()+"_OPERATOR_NAMESPACE"))
 	pflag.String("applications-namespace", "opendatahub", "Namespace where the odh applications are deployed")
 	checkEnvVarBindingError(viper.BindEnv("applications-namespace", viper.GetEnvPrefix()+"_APPLICATIONS_NAMESPACE"))
+	pflag.String("workbenches-namespace", "opendatahub", "Namespace where the workbenches are deployed")
+	checkEnvVarBindingError(viper.BindEnv("workbenches-namespace", viper.GetEnvPrefix()+"_WORKBENCHES_NAMESPACE"))
 	pflag.String("dsc-monitoring-namespace", "opendatahub", "Namespace where the odh monitoring is deployed")
 	checkEnvVarBindingError(viper.BindEnv("dsc-monitoring-namespace", viper.GetEnvPrefix()+"_DSC_MONITORING_NAMESPACE"))
 	pflag.String("deletion-policy", "always",
@@ -424,6 +427,7 @@ func TestMain(m *testing.M) {
 	}
 	testOpts.operatorNamespace = viper.GetString("operator-namespace")
 	testOpts.appsNamespace = viper.GetString("applications-namespace")
+	testOpts.workbenchesNamespace = viper.GetString("workbenches-namespace")
 	testOpts.monitoringNamespace = viper.GetString("dsc-monitoring-namespace")
 	var err error
 	if testOpts.deletionPolicy, err = ParseDeletionPolicy(viper.GetString("deletion-policy")); err != nil {

--- a/tests/e2e/creation_test.go
+++ b/tests/e2e/creation_test.go
@@ -129,7 +129,7 @@ func (tc *DSCTestCtx) ValidateDSCCreation(t *testing.T) {
 	t.Helper()
 
 	tc.EventuallyResourceCreatedOrUpdated(
-		WithObjectToCreate(CreateDSC(tc.DataScienceClusterNamespacedName.Name)),
+		WithObjectToCreate(CreateDSC(tc.DataScienceClusterNamespacedName.Name, tc.WorkbenchesNamespace)),
 		WithCondition(jq.Match(`.status.phase == "%s"`, status.ConditionTypeReady)),
 		WithCustomErrorMsg("Failed to create DataScienceCluster resource %s", tc.DataScienceClusterNamespacedName.Name),
 
@@ -185,10 +185,10 @@ func (tc *DSCTestCtx) ValidateDSCIDuplication(t *testing.T) {
 func (tc *DSCTestCtx) ValidateDSCDuplication(t *testing.T) {
 	t.Helper()
 
-	dsc := CreateDSC(dscInstanceNameDuplicate)
+	dsc := CreateDSC(dscInstanceNameDuplicate, tc.WorkbenchesNamespace)
 	tc.EnsureResourceIsUnique(dsc, "Error validating DataScienceCluster duplication")
 
-	dsv1 := CreateDSCv1(dscInstanceNameDuplicate)
+	dsv1 := CreateDSCv1(dscInstanceNameDuplicate, tc.WorkbenchesNamespace)
 	tc.EnsureResourceIsUnique(dsv1, "Error validating DataScienceCluster duplication v1")
 }
 

--- a/tests/e2e/helper_test.go
+++ b/tests/e2e/helper_test.go
@@ -175,7 +175,7 @@ func CreateDSCI(name, groupVersion string, appNamespace, monitoringNamespace str
 }
 
 // CreateDSC creates a DataScienceCluster CR.
-func CreateDSC(name string) *dscv2.DataScienceCluster {
+func CreateDSC(name string, workbenchesNamespace string) *dscv2.DataScienceCluster {
 	return &dscv2.DataScienceCluster{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "DataScienceCluster",
@@ -195,6 +195,9 @@ func CreateDSC(name string) *dscv2.DataScienceCluster {
 				Workbenches: componentApi.DSCWorkbenches{
 					ManagementSpec: common.ManagementSpec{
 						ManagementState: operatorv1.Removed,
+					},
+					WorkbenchesCommonSpec: componentApi.WorkbenchesCommonSpec{
+						WorkbenchNamespace: workbenchesNamespace,
 					},
 				},
 				AIPipelines: componentApi.DSCDataSciencePipelines{
@@ -251,7 +254,7 @@ func CreateDSC(name string) *dscv2.DataScienceCluster {
 	}
 }
 
-func CreateDSCv1(name string) *dscv1.DataScienceCluster {
+func CreateDSCv1(name string, workbenchesNamespace string) *dscv1.DataScienceCluster {
 	return &dscv1.DataScienceCluster{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "DataScienceCluster",
@@ -270,6 +273,9 @@ func CreateDSCv1(name string) *dscv1.DataScienceCluster {
 				Workbenches: componentApi.DSCWorkbenches{
 					ManagementSpec: common.ManagementSpec{
 						ManagementState: operatorv1.Removed,
+					},
+					WorkbenchesCommonSpec: componentApi.WorkbenchesCommonSpec{
+						WorkbenchNamespace: workbenchesNamespace,
 					},
 				},
 				ModelMeshServing: componentApi.DSCModelMeshServing{

--- a/tests/e2e/test_context_test.go
+++ b/tests/e2e/test_context_test.go
@@ -51,6 +51,9 @@ type TestContext struct {
 	// Namespace where application workloads are deployed.
 	AppsNamespace string
 
+	// Namespace where the workbenches are deployed.
+	WorkbenchesNamespace string
+
 	// Namespace where the monitoring components are deployed.
 	MonitoringNamespace string
 
@@ -97,6 +100,7 @@ func NewTestContext(t *testing.T) (*TestContext, error) { //nolint:thelper
 		DataScienceClusterNamespacedName: types.NamespacedName{Name: dscInstanceName},
 		OperatorNamespace:                testOpts.operatorNamespace,
 		AppsNamespace:                    testOpts.appsNamespace,
+		WorkbenchesNamespace:             testOpts.workbenchesNamespace,
 		MonitoringNamespace:              testOpts.monitoringNamespace,
 		TestTimeouts:                     testOpts.TestTimeouts,
 	}, nil

--- a/tests/e2e/v2tov3upgrade_test.go
+++ b/tests/e2e/v2tov3upgrade_test.go
@@ -159,7 +159,7 @@ func (tc *V2Tov3UpgradeTestCtx) DatascienceclusterV1CreationAndRead(t *testing.T
 	dscName := testDSCV1Name
 
 	// Create a DataScienceCluster v1 resource
-	dscV1 := CreateDSCv1(dscName)
+	dscV1 := CreateDSCv1(dscName, tc.WorkbenchesNamespace)
 
 	// Create the v1 DataScienceCluster resource and verify it's created correctly
 	tc.EventuallyResourceCreatedOrUpdated(


### PR DESCRIPTION
Changes:
- add support to set a custom workbenches namespace when running `make e2e-test`
- analogically, made setting application ns more explicit
- update README to reflect the changes above + add usage instructions for custom app namespace case

The ability to set these parameters is required by a QE pipeline.

<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
JIRA ref: [RHOAIENG-33446](https://issues.redhat.com/browse/RHOAIENG-33446)

## How Has This Been Tested?
Locally tested by running e2e against my cluster with the relevant parameters set, checked DSCI and DSC instances created during e2e test suite run are configured with the custom namespaces

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [ ] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced configurable namespace variables for operator, applications, and workbenches deployments with environment variable and CLI flag support.

* **Documentation**
  * Updated end-to-end testing documentation with new namespace configuration options and instructions for running tests with custom namespaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->