### PR TITLE
[sync]  feat: add warning when create/update connectin API secret on S3 type but no AWS_S3_BUCKET or with "" as value

### DIFF
--- a/Dockerfiles/Dockerfile
+++ b/Dockerfiles/Dockerfile
@@ -31,6 +31,10 @@ COPY config/osd-configs/ /opt/manifests/osd-configs
 RUN rm -f /opt/manifests/hardwareprofiles
 COPY config/hardwareprofiles/ /opt/manifests/hardwareprofiles
 
+# Copy connectionAPI removing any possibly pre-existing symlinks
+RUN rm -f /opt/manifests/connectionAPI
+COPY config/connectionAPI/ /opt/manifests/connectionAPI
+
 ################################################################################
 FROM --platform=$BUILDPLATFORM registry.access.redhat.com/ubi9/go-toolset:$GOLANG_VERSION as builder
 ARG CGO_ENABLED=1

--- a/config/connectionAPI/kustomization.yaml
+++ b/config/connectionAPI/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- secret_s3_validation.yaml

--- a/config/connectionAPI/secret_s3_validation.yaml
+++ b/config/connectionAPI/secret_s3_validation.yaml
@@ -1,0 +1,37 @@
+---
+# ValidatingAdmissionPolicy to warn when S3 connection secrets are missing AWS_S3_BUCKET
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: connectionapi-check-s3-bucket
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+      - apiGroups: [""]
+        apiVersions: ["v1"]
+        operations: ["CREATE", "UPDATE"]
+        resources: ["secrets"]
+  validations:
+    # Warn if secret has S3 connection type (either annotation) but missing or empty AWS_S3_BUCKET
+    - expression: >-
+        !has(object.metadata.annotations) ||
+        !(
+          ('opendatahub.io/connection-type-protocol' in object.metadata.annotations &&
+           object.metadata.annotations['opendatahub.io/connection-type-protocol'] == 's3') ||
+          ('opendatahub.io/connection-type-ref' in object.metadata.annotations &&
+           object.metadata.annotations['opendatahub.io/connection-type-ref'] == 's3')
+        ) ||
+        (has(object.data) && 'AWS_S3_BUCKET' in object.data && size(object.data.AWS_S3_BUCKET) > 0)
+      messageExpression: >-
+        "Secret '" + object.metadata.name + "' has S3 connection type annotation but is missing 'AWS_S3_BUCKET' data key or with empty string as value"
+      reason: Invalid
+
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: connectionapi-check-s3-bucket-binding
+spec:
+  policyName: connectionapi-check-s3-bucket
+  validationActions: ["Warn"]  # Only warn, don't deny creation or update and dont care which namespace the secret is in.

--- a/config/manifests/kustomization.yaml
+++ b/config/manifests/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
 - ../prometheus
 - ../samples # to generate CSV alm-example
 - ../scorecard
+- ../connectionAPI
 
 patches:
 - path: description-patch.yml

--- a/get_all_manifests.sh
+++ b/get_all_manifests.sh
@@ -35,6 +35,7 @@ declare -A PLATFORM_MANIFESTS=(
     ["osd-configs"]="config/osd-configs"
     ["monitoring"]="config/monitoring"
     ["hardwareprofiles"]="config/hardwareprofiles"
+    ["connectionAPI"]="config/connectionAPI"
 )
 
 # Allow overwriting repo using flags component=repo

--- a/internal/controller/components/kserve/kserve_controller.go
+++ b/internal/controller/components/kserve/kserve_controller.go
@@ -64,6 +64,8 @@ func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.
 		Owns(&monitoringv1.ServiceMonitor{}).
 		Owns(&admissionregistrationv1.MutatingWebhookConfiguration{}).
 		Owns(&admissionregistrationv1.ValidatingWebhookConfiguration{}).
+		Owns(&admissionregistrationv1.ValidatingAdmissionPolicy{}).
+		Owns(&admissionregistrationv1.ValidatingAdmissionPolicyBinding{}).
 		Owns(&appsv1.Deployment{}, reconciler.WithPredicates(resources.NewDeploymentPredicate())).
 
 		// operands - dynamically owned

--- a/internal/controller/components/kserve/kserve_controller_actions.go
+++ b/internal/controller/components/kserve/kserve_controller_actions.go
@@ -16,12 +16,17 @@ import (
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
 	odherrors "github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/errors"
 	odhtypes "github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
+	odhdeploy "github.com/opendatahub-io/opendatahub-operator/v2/pkg/deploy"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/metadata/labels"
 )
 
 func initialize(_ context.Context, rr *odhtypes.ReconciliationRequest) error {
 	rr.Manifests = []odhtypes.ManifestInfo{
 		kserveManifestInfo(kserveManifestSourcePath),
+		{
+			Path:       odhdeploy.DefaultManifestPath,
+			ContextDir: "connectionAPI",
+		},
 	}
 
 	return nil

--- a/tests/e2e/components_test.go
+++ b/tests/e2e/components_test.go
@@ -136,6 +136,22 @@ func (tc *ComponentTestCtx) ValidateOperandsOwnerReferences(t *testing.T) {
 	)
 }
 
+func (tc *ComponentTestCtx) ValidateS3SecretCheckBucketExist(t *testing.T) {
+	t.Helper()
+
+	// Ensure the component is actually enabled before checking for the VAP
+	// This handles cases where the component might have been temporarily disabled
+	// by other test suites (e.g., ModelController, TrustyAI) and needs time to reconcile
+	tc.ValidateComponentEnabled(t)
+
+	tc.EnsureResourceExists(
+		WithMinimalObject(gvk.ValidatingAdmissionPolicy, types.NamespacedName{Name: "connectionapi-check-s3-bucket"}),
+	)
+	tc.EnsureResourceExists(
+		WithMinimalObject(gvk.ValidatingAdmissionPolicyBinding, types.NamespacedName{Name: "connectionapi-check-s3-bucket-binding"}),
+	)
+}
+
 // ValidateUpdateDeploymentsResources verifies the update of deployment replicas for the component.
 func (tc *ComponentTestCtx) ValidateUpdateDeploymentsResources(t *testing.T) {
 	t.Helper()

--- a/tests/e2e/kserve_test.go
+++ b/tests/e2e/kserve_test.go
@@ -41,6 +41,7 @@ func kserveTestSuite(t *testing.T) {
 	// Define test cases.
 	testCases := []TestCase{
 		{"Validate component enabled", componentCtx.ValidateComponentEnabled},
+		{"Validate VAP created when kserve is enabled", componentCtx.ValidateS3SecretCheckBucketExist},
 		{"Validate component spec", componentCtx.ValidateSpec},
 		{"Validate model controller", componentCtx.ValidateModelControllerInstance},
 		{"Validate operands have OwnerReferences", componentCtx.ValidateOperandsOwnerReferences},


### PR DESCRIPTION

(cherry picked from commit 5779bffbc7d627f47eb970d3631101c570502624)
https://github.com/opendatahub-io/opendatahub-operator/pull/2732

<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [ ] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->
