### PR TITLE
RHOAIENG-38505 | build: update image placeholder strategy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -278,7 +278,7 @@ prepare: manifests kustomize manager-kustomization
 manager-kustomization: config/manager/kustomization.yaml.in
 	cd config/manager \
 		&& cp -f kustomization.yaml.in kustomization.yaml \
-		&& $(KUSTOMIZE) edit set image controller=$(IMG)
+		&& $(KUSTOMIZE) edit set image REPLACE_IMAGE=$(IMG)
 
 .PHONY: install
 install: prepare ## Install CRDs into the K8s cluster specified in ~/.kube/config.

--- a/config/manager/kustomization.yaml.in
+++ b/config/manager/kustomization.yaml.in
@@ -6,6 +6,3 @@ generatorOptions:
 
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-images:
-- name: controller
-  newName: REPLACE_IMAGE

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -72,7 +72,8 @@ spec:
         args:
         - --leader-elect
         - --operator-name=opendatahub
-        image: controller:latest
+        # NOTE: image is provided in CI by pullspec substitution, and by make/kustomize for local builds
+        image: REPLACE_IMAGE:latest
         imagePullPolicy: Always
         name: manager
         ports:


### PR DESCRIPTION
## Description
Jira: [RHOAIENG-38505](https://issues.redhat.com/browse/RHOAIENG-38505)

Change the kustomize image reference from a hardcoded "controller" name to a "REPLACE_IMAGE" placeholder.

The previous strategy didn't work properly for CI, because the [substitution logic](https://github.com/openshift/ci-tools/blob/2401b722f08b32d2a6926e1d918ef010ef37992c/pkg/steps/bundle_source.go#L90) modifies YAML files in the repo.

<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

<!--- Describe your changes in detail -->

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Ran `make bundle-build` locally, verified bundle contents have `image: ` set according to my `IMG`/`IMAGE_BASE_TAG`, etc settings.
2. Hope to use CI logs to verify what image gets deployed.

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [x] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
3. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
4. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
5. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->
build change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated manager container image replacement mechanism to use a direct image substitution approach instead of field-based transformation, enabling more flexible image resolution for CI/pullspec and local builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->