### PR TITLE
(fix): Adapt release automation to the new make file changes

### DIFF
--- a/.github/scripts/update-versions.sh
+++ b/.github/scripts/update-versions.sh
@@ -4,10 +4,10 @@ set -euo
 
 NEW_VERSION=$1
 
-CURRENT_VERSION=$(cat Makefile | grep -w "VERSION ?=" | cut -d ' ' -f 3)
 CSV_FILE=config/manifests/bases/opendatahub-operator.clusterserviceversion.yaml
-sed -i -e "s/^VERSION ?=.*/VERSION ?= $NEW_VERSION/g" Makefile
+# Only update the main VERSION variable inside the ifeq block, not other VERSION variables
+sed -i -e "/^ifeq.*VERSION/,/^endif/{s/[[:space:]]*VERSION = .*/\tVERSION = $NEW_VERSION/;}" Makefile
 sed -i -e "s|containerImage.*|containerImage: quay.io/opendatahub/opendatahub-operator:v$NEW_VERSION|g" $CSV_FILE
 sed -i -e "s|createdAt.*|createdAt: \"$(date +"%Y-%-m-%dT00:00:00Z")\"|g" $CSV_FILE
 sed -i -e "s|name: opendatahub-operator.v.*|name: opendatahub-operator.v$NEW_VERSION|g" $CSV_FILE
-sed -i -e "s|version: $CURRENT_VERSION.*|version: $NEW_VERSION|g" $CSV_FILE
+sed -i -e "s|version: [0-9][0-9.]*|version: $NEW_VERSION|g" $CSV_FILE

--- a/.github/workflows/release-staging.yaml
+++ b/.github/workflows/release-staging.yaml
@@ -135,5 +135,5 @@ jobs:
           {
             "component": "opendatahub-operator",
             "release_branch": "odh-${{ env.VERSION }}",
-            "version": "v${{ env.VERSION }}"
+            "version": "${{ env.VERSION }}"
           }


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
This PR intends to fix the release automation in accordance with the new changes that were done in the Makefile - as a part of the generated files removal

## How Has This Been Tested?
ODH release 3.1.0 was made with this changes.

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [ ] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal version management and release workflow automation to use refined version formatting and targeted update mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->