### PR TITLE
push the e2e test image with the tag main instead of adding the commit hash

### DIFF
--- a/.github/workflows/ci-build-push-e2e-tests.yaml
+++ b/.github/workflows/ci-build-push-e2e-tests.yaml
@@ -9,6 +9,7 @@ permissions:
 
 env:
   E2E_IMAGE_TAG_BASE: quay.io/${{ secrets.QUAY_ORG }}/opendatahub-operator-e2e
+  E2E_IMAGE_TAG: main
 
 jobs:
   build-push-e2e-image:
@@ -40,11 +41,11 @@ jobs:
         run: |
           # tag based on shortened commit SHA
           COMMIT_SHA=$(echo ${{ github.sha }} | cut -c1-8)
-          echo "E2E_IMAGE_TAG=main-${COMMIT_SHA}" >> $GITHUB_OUTPUT
+          echo "E2E_IMAGE_TAG_COMMIT=main-${COMMIT_SHA}" >> $GITHUB_OUTPUT
 
-      - name: Build and push E2E test image
+      - name: Build and push E2E test image (main)
         env:
-          E2E_IMAGE: ${{ env.E2E_IMAGE_TAG_BASE }}:${{ steps.image-tag.outputs.E2E_IMAGE_TAG }}
+          E2E_IMAGE: ${{ env.E2E_IMAGE_TAG_BASE }}:${{ env.E2E_IMAGE_TAG }}
         run: |
           echo "Building E2E test image: ${E2E_IMAGE}"
           podman build \
@@ -56,4 +57,20 @@ jobs:
           echo "Pushing E2E test image: ${E2E_IMAGE}"
           podman push "${E2E_IMAGE}"
           
-          echo "E2E test image built and pushed successfully!"
+          echo "E2E test image (main) built and pushed successfully!"
+
+      - name: Build and push E2E test image (commit hash)
+        env:
+          E2E_IMAGE: ${{ env.E2E_IMAGE_TAG_BASE }}:${{ steps.image-tag.outputs.E2E_IMAGE_TAG_COMMIT }}
+        run: |
+          echo "Building E2E test image: ${E2E_IMAGE}"
+          podman build \
+            --platform linux/amd64 \
+            -f Dockerfiles/e2e-tests/e2e-tests.Dockerfile \
+            -t "${E2E_IMAGE}" \
+            .
+          
+          echo "Pushing E2E test image: ${E2E_IMAGE}"
+          podman push "${E2E_IMAGE}"
+          
+          echo "E2E test image (commit hash) built and pushed successfully!"


### PR DESCRIPTION

<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->
This PR updates the tag of the e2e tests image that is pushed to quay.io to have a "main" tag that references the latest pushed image

<!--- Link your JIRA and related links here for reference. -->
https://issues.redhat.com/browse/RHOAIENG-32566

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [ x ] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI image publishing now creates both a stable "main" image tag and a separate commit-specific image, using distinct build/push steps.
  * Tag handling and success messages were clarified so releases and commit builds are reported separately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->