### PR TITLE
update: move Prom Rule tests into component folder

### DIFF
--- a/.github/workflows/test-prometheus-unit.yaml
+++ b/.github/workflows/test-prometheus-unit.yaml
@@ -2,8 +2,10 @@ name: Run prometheus unit tests
 on:
   pull_request:
     paths:
-      - 'odh-config/monitoring/prometheus/**'
-      - 'tests/prometheus_unit_tests/**'
+      - 'internal/controller/components/**/monitoring/*-prometheusrules.tmpl.yaml'
+      - 'internal/controller/components/**/monitoring/*-alerting.unit-tests.yaml'
+      - 'tests/prometheus_unit_tests/scripts/**'
+      - 'Makefile'
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -162,10 +162,9 @@ IMAGE_BUILD_FLAGS += --build-arg CGO_ENABLED=$(CGO_ENABLED)
 IMAGE_BUILD_FLAGS += --platform $(PLATFORM)
 
 # Prometheus-Unit Tests Parameters
-PROMETHEUS_CONFIG_YAML = ./odh-config/monitoring/prometheus/apps/prometheus-configs.yaml
-PROMETHEUS_CONFIG_DIR = ./odh-config/monitoring/prometheus/apps
-PROMETHEUS_TEST_DIR = ./tests/prometheus_unit_tests
-PROMETHEUS_ALERT_TESTS = $(wildcard $(PROMETHEUS_TEST_DIR)/*.unit-tests.yaml)
+PROMETHEUS_RULES_DIR = ./internal/controller/components
+PROMETHEUS_RULE_TEMPLATES = $(shell find $(PROMETHEUS_RULES_DIR) -name "*-prometheusrules.tmpl.yaml" 2>/dev/null)
+PROMETHEUS_ALERT_TESTS = $(shell find $(PROMETHEUS_RULES_DIR) -name "*-alerting.unit-tests.yaml" 2>/dev/null)
 
 ALERT_SEVERITY = critical
 
@@ -544,20 +543,52 @@ unit-test: envtest ginkgo # directly use ginkgo since the framework is not compa
         		$(TEST_SRC)
 CLEANFILES += cover.out
 
-$(PROMETHEUS_TEST_DIR)/%.rules.yaml: $(PROMETHEUS_TEST_DIR)/%.unit-tests.yaml $(PROMETHEUS_CONFIG_YAML) $(YQ)
-	$(YQ) eval ".data.\"$(@F:.rules.yaml=.rules)\"" $(PROMETHEUS_CONFIG_YAML) > $@
+# Pattern rule to generate .rules.yaml from PrometheusRule templates
+# This finds the corresponding *-prometheusrules.tmpl.yaml in the same directory
+# and extracts the spec.groups section, replacing template variables
+# Note: We filter out recording rules (rules with 'record' field) to avoid conflicts with test input series
+%.rules.yaml: %.unit-tests.yaml $(YQ)
+	@RULE_FILE=$$(dirname $<)/$$(basename $< -alerting.unit-tests.yaml)-prometheusrules.tmpl.yaml; \
+	if [ ! -f "$$RULE_FILE" ]; then \
+		echo "Error: PrometheusRule template file not found: $$RULE_FILE"; \
+		exit 1; \
+	fi; \
+	echo "Generating $@ from $$RULE_FILE (alerts only, excluding recording rules)"; \
+	sed 's/{{\.Namespace}}/redhat-ods-monitoring/g; s/{{\.ApplicationNamespace}}/redhat-ods-applications/g; s/{{`{{`}}/{{/g; s/{{`}}`}}/}}/g' "$$RULE_FILE" | \
+		$(YQ) eval '.spec.groups' - | \
+		$(YQ) eval 'del(.[] | .rules[] | select(.alert == null))' - | \
+		$(YQ) eval '{"groups": .}' - > $@
 
 PROMETHEUS_ALERT_RULES := $(PROMETHEUS_ALERT_TESTS:.unit-tests.yaml=.rules.yaml)
 
+# Validate PrometheusRule syntax
+.PHONY: validate-prometheus-rules
+validate-prometheus-rules: $(YQ)
+	@echo "Validating PrometheusRule templates syntax..."
+	@for tmpl_file in $(PROMETHEUS_RULE_TEMPLATES); do \
+		echo "  Checking $$tmpl_file..."; \
+		sed 's/{{\.Namespace}}/redhat-ods-monitoring/g; s/{{\.ApplicationNamespace}}/redhat-ods-applications/g; s/{{`{{`}}/{{/g; s/{{`}}`}}/}}/g' "$$tmpl_file" | \
+			$(YQ) eval '.spec.groups' - | \
+			$(YQ) eval '{"groups": .}' - | \
+			promtool check rules --lint=none /dev/stdin > /dev/null || exit 1; \
+	done
+	@echo "✓ All PrometheusRule templates are syntactically valid"
+
 # Run prometheus-alert-unit-tests
+# Test each component separately to avoid duplicate recording rule conflicts
 .PHONY: test-alerts
-test-alerts: $(PROMETHEUS_ALERT_RULES)
-	promtool test rules $(PROMETHEUS_ALERT_TESTS)
+test-alerts: validate-prometheus-rules $(PROMETHEUS_ALERT_RULES)
+	@echo "Running Prometheus alert unit tests..."
+	@for test_file in $(PROMETHEUS_ALERT_TESTS); do \
+		echo "  Testing $$test_file..."; \
+		promtool test rules $$test_file || exit 1; \
+	done
+	@echo "✓ All Prometheus alert tests passed!"
 
 #Check for alerts without unit-tests
 .PHONY: check-prometheus-alert-unit-tests
 check-prometheus-alert-unit-tests: $(PROMETHEUS_ALERT_RULES)
-	./tests/prometheus_unit_tests/scripts/check_alert_tests.sh $(PROMETHEUS_CONFIG_YAML) $(PROMETHEUS_TEST_DIR) $(ALERT_SEVERITY)
+	./tests/prometheus_unit_tests/scripts/check_alert_tests.sh $(PROMETHEUS_RULES_DIR) $(ALERT_SEVERITY)
 CLEANFILES += $(PROMETHEUS_ALERT_RULES)
 
 .PHONY: e2e-test

--- a/internal/controller/components/.gitignore
+++ b/internal/controller/components/.gitignore
@@ -1,0 +1,1 @@
+*.rules.yaml

--- a/internal/controller/components/dashboard/monitoring/dashboard-alerting.unit-tests.yaml
+++ b/internal/controller/components/dashboard/monitoring/dashboard-alerting.unit-tests.yaml
@@ -1,5 +1,5 @@
 rule_files:
-  - rhods-dashboard-alerting.rules.yaml
+  - dashboard-alerting.rules.yaml
 
 evaluation_interval: 1m
 
@@ -40,8 +40,7 @@ tests:
               severity: critical
             exp_annotations:
               summary: "RHODS Dashboard Route Error Burn Rate"
-              message: "High error budget burn for rhods-dashboard (current value: 3)."
-              triage: 'https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/RHODS-Dashboard/rhods-error-burn-rate.md'
+              message: "High error budget burn for rhods-dashboard (current value: 3 )."
 
   - interval: 1m
     input_series:
@@ -60,8 +59,7 @@ tests:
               severity: critical
             exp_annotations:
               summary: "RHODS Dashboard Route Error Burn Rate"
-              message: "High error budget burn for rhods-dashboard (current value: 16)."
-              triage: 'https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/RHODS-Dashboard/rhods-error-burn-rate.md'
+              message: "High error budget burn for rhods-dashboard (current value: 16 )."
 
   - interval: 1m
     input_series:
@@ -80,8 +78,7 @@ tests:
               severity: warning
             exp_annotations:
               summary: "RHODS Dashboard Route Error Burn Rate"
-              message: "High error budget burn for rhods-dashboard (current value: 61)."
-              triage: 'https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/RHODS-Dashboard/rhods-error-burn-rate.md'
+              message: "High error budget burn for rhods-dashboard (current value: 61 )."
 
   # Probe success
   - interval: 1m
@@ -120,8 +117,7 @@ tests:
               severity: critical
             exp_annotations:
               summary: "RHODS Dashboard Probe Success Burn Rate"
-              message: "High error budget burn for rhods-dashboard (current value: 3)."
-              triage: 'https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/RHODS-Dashboard/rhods-dashboard-probe-success-burn-rate.md'
+              message: "High error budget burn for rhods-dashboard (current value: 3 )."
 
   - interval: 1m
     input_series:
@@ -140,8 +136,7 @@ tests:
               severity: critical
             exp_annotations:
               summary: "RHODS Dashboard Probe Success Burn Rate"
-              message: "High error budget burn for rhods-dashboard (current value: 16)."
-              triage: 'https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/RHODS-Dashboard/rhods-dashboard-probe-success-burn-rate.md'
+              message: "High error budget burn for rhods-dashboard (current value: 16 )."
 
   - interval: 1m
     input_series:
@@ -160,8 +155,7 @@ tests:
               severity: warning
             exp_annotations:
               summary: "RHODS Dashboard Probe Success Burn Rate"
-              message: "High error budget burn for rhods-dashboard (current value: 61)."
-              triage: 'https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/RHODS-Dashboard/rhods-dashboard-probe-success-burn-rate.md'
+              message: "High error budget burn for rhods-dashboard (current value: 61 )."
 
   - interval: 1m
     input_series:
@@ -180,5 +174,4 @@ tests:
               severity: warning
             exp_annotations:
               summary: "RHODS Dashboard Probe Success Burn Rate"
-              message: "High error budget burn for rhods-dashboard (current value: 181)."
-              triage: 'https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/RHODS-Dashboard/rhods-dashboard-probe-success-burn-rate.md'
+              message: "High error budget burn for rhods-dashboard (current value: 181 )."

--- a/internal/controller/components/datasciencepipelines/monitoring/datasciencepipelines-alerting.unit-tests.yaml
+++ b/internal/controller/components/datasciencepipelines/monitoring/datasciencepipelines-alerting.unit-tests.yaml
@@ -1,5 +1,5 @@
 rule_files:
-  - data-science-pipelines-operator-alerting.rules.yaml
+  - datasciencepipelines-alerting.rules.yaml
 
 evaluation_interval: 1m
 
@@ -39,8 +39,7 @@ tests:
               severity: info
             exp_annotations:
               summary: "Data Science Pipelines Application Route Error Burn Rate"
-              message: "High error budget burn for  (current value: 3)."
-              triage: 'https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Data-Science-Pipelines/data-science-pipelines-application-error-burn-rate.md'
+              message: "High error budget burn for  (current value: 3 )."
 
   - interval: 1m
     input_series:
@@ -58,8 +57,7 @@ tests:
               severity: info
             exp_annotations:
               summary: "Data Science Pipelines Application Route Error Burn Rate"
-              message: "High error budget burn for  (current value: 16)."
-              triage: 'https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Data-Science-Pipelines/data-science-pipelines-application-error-burn-rate.md'
+              message: "High error budget burn for  (current value: 16 )."
 
   - interval: 1m
     input_series:
@@ -77,8 +75,7 @@ tests:
               severity: info
             exp_annotations:
               summary: "Data Science Pipelines Application Route Error Burn Rate"
-              message: "High error budget burn for  (current value: 61)."
-              triage: 'https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Data-Science-Pipelines/data-science-pipelines-application-error-burn-rate.md'
+              message: "High error budget burn for  (current value: 61 )."
 
   - interval: 1m
     input_series:
@@ -96,8 +93,7 @@ tests:
               severity: info
             exp_annotations:
               summary: "Data Science Pipelines Application Route Error Burn Rate"
-              message: "High error budget burn for  (current value: 181)."
-              triage: 'https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Data-Science-Pipelines/data-science-pipelines-application-error-burn-rate.md'
+              message: "High error budget burn for  (current value: 181 )."
 
   # Probe success
   - interval: 1m
@@ -137,8 +133,7 @@ tests:
               severity: critical
             exp_annotations:
               summary: "Data Science Pipelines Operator Probe Success Burn Rate"
-              message: "High error budget burn for data-science-pipelines-operator (current value: 3)."
-              triage: 'https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Data-Science-Pipelines/data-science-pipelines-operator-probe-success-burn-rate.md'
+              message: "High error budget burn for data-science-pipelines-operator (current value: 3 )."
 
   - interval: 1m
     input_series:
@@ -157,8 +152,7 @@ tests:
               severity: critical
             exp_annotations:
               summary: "Data Science Pipelines Operator Probe Success Burn Rate"
-              message: "High error budget burn for data-science-pipelines-operator (current value: 16)."
-              triage: 'https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Data-Science-Pipelines/data-science-pipelines-operator-probe-success-burn-rate.md'
+              message: "High error budget burn for data-science-pipelines-operator (current value: 16 )."
 
   - interval: 1m
     input_series:
@@ -177,8 +171,7 @@ tests:
               severity: warning
             exp_annotations:
               summary: "Data Science Pipelines Operator Probe Success Burn Rate"
-              message: "High error budget burn for data-science-pipelines-operator (current value: 61)."
-              triage: 'https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Data-Science-Pipelines/data-science-pipelines-operator-probe-success-burn-rate.md'
+              message: "High error budget burn for data-science-pipelines-operator (current value: 61 )."
 
   # application unavailable
   - interval: 1m
@@ -203,7 +196,6 @@ tests:
               severity: info
             exp_annotations:
               message: "Data Science Pipelines Application is down!"
-              triage: 'https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Data-Science-Pipelines/data-science-pipelines-application-component-readiness-status.md'
               summary: The Data Science Pipelines Application CustomResource "dspa_instance_1" in namespace "dspa_namespace_a" has been NotReady for more than 5 minutes
       - eval_time: 2m
         alertname: Data Science Pipeline APIServer Unavailable
@@ -216,7 +208,6 @@ tests:
               severity: info
             exp_annotations:
               message: "Data Science Pipelines APIServer component is down!"
-              triage: 'https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Data-Science-Pipelines/data-science-pipelines-application-component-readiness-status.md'
               summary: A Data Science Pipelines APIServer pod owned by DSPA "dspa_instance_1" in namespace "dspa_namespace_a" has been NotReady for more than 5 minutes
       - eval_time: 2m
         alertname: Data Science Pipeline PersistenceAgent Unavailable
@@ -229,7 +220,6 @@ tests:
               severity: info
             exp_annotations:
               message: "Data Science Pipelines PersistenceAgent component is down!"
-              triage: 'https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Data-Science-Pipelines/data-science-pipelines-application-component-readiness-status.md'
               summary: A Data Science Pipelines PersistenceAgent pod owned by DSPA "dspa_instance_1" in namespace "dspa_namespace_a" has been NotReady for more than 5 minutes
       - eval_time: 2m
         alertname: Data Science Pipeline ScheduledWorkflows Unavailable
@@ -242,5 +232,4 @@ tests:
               severity: info
             exp_annotations:
               message: "Data Science Pipelines ScheduledWorkflows component is down!"
-              triage: 'https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Data-Science-Pipelines/data-science-pipelines-application-component-readiness-status.md'
               summary: A Data Science Pipelines ScheduledWorkflow controller pod owned by DSPA "dspa_instance_1" in namespace "dspa_namespace_a" has been NotReady for more than 5 minutes

--- a/internal/controller/components/feastoperator/monitoring/feastoperator-alerting.unit-tests.yaml
+++ b/internal/controller/components/feastoperator/monitoring/feastoperator-alerting.unit-tests.yaml
@@ -1,5 +1,5 @@
 rule_files:
-  - feast-operator-alerting.rules.yaml
+  - feastoperator-alerting.rules.yaml
 
 evaluation_interval: 1m
 
@@ -39,8 +39,7 @@ tests:
               severity: critical
             exp_annotations:
               summary: "Feast Operator Probe Success Burn Rate"
-              message: "High error budget burn for feast-operator-controller-manager (current value: 3)."
-              triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Feature-Store/rhoai-feast-operator-probe-success-burn-rate.md"
+              message: "High error budget burn for feast-operator-controller-manager (current value: 3 )."
 
   - interval: 1m
     input_series:
@@ -58,8 +57,7 @@ tests:
               severity: critical
             exp_annotations:
               summary: "Feast Operator Probe Success Burn Rate"
-              message: "High error budget burn for feast-operator-controller-manager (current value: 16)."
-              triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Feature-Store/rhoai-feast-operator-probe-success-burn-rate.md"
+              message: "High error budget burn for feast-operator-controller-manager (current value: 16 )."
 
   - interval: 1m
     input_series:
@@ -77,5 +75,4 @@ tests:
               severity: warning
             exp_annotations:
               summary: "Feast Operator Probe Success Burn Rate"
-              message: "High error budget burn for feast-operator-controller-manager (current value: 61)."
-              triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Feature-Store/rhoai-feast-operator-probe-success-burn-rate.md"
+              message: "High error budget burn for feast-operator-controller-manager (current value: 61 )."

--- a/internal/controller/components/kserve/monitoring/kserve-alerting.unit-tests.yaml
+++ b/internal/controller/components/kserve/monitoring/kserve-alerting.unit-tests.yaml
@@ -39,9 +39,8 @@ tests:
               instance: "kserve-controller-manager"
               severity: critical
             exp_annotations:
-              message: "High error budget burn for kserve-controller-manager (current value: 3)."
+              message: "High error budget burn for kserve-controller-manager (current value: 3 )."
               summary: Kserve Controller Probe Success Burn Rate
-              triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Model-Serving/rhods-kserve-controller-probe-success-burn-rate.md"
 
   - interval: 1m
     input_series:
@@ -58,9 +57,8 @@ tests:
               instance: "kserve-controller-manager"
               severity: critical
             exp_annotations:
-              message: "High error budget burn for kserve-controller-manager (current value: 16)."
+              message: "High error budget burn for kserve-controller-manager (current value: 16 )."
               summary: Kserve Controller Probe Success Burn Rate
-              triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Model-Serving/rhods-kserve-controller-probe-success-burn-rate.md"
 
   - interval: 1m
     input_series:
@@ -77,6 +75,5 @@ tests:
               instance: "kserve-controller-manager"
               severity: warning
             exp_annotations:
-              message: "High error budget burn for kserve-controller-manager (current value: 61)."
+              message: "High error budget burn for kserve-controller-manager (current value: 61 )."
               summary: Kserve Controller Probe Success Burn Rate
-              triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Model-Serving/rhods-kserve-controller-probe-success-burn-rate.md"

--- a/internal/controller/components/kueue/monitoring/kueue-alerting.unit-tests.yaml
+++ b/internal/controller/components/kueue/monitoring/kueue-alerting.unit-tests.yaml
@@ -26,7 +26,6 @@ tests:
             exp_annotations:
               description: This alert fires when the Kueue Operator is not running.
               summary: Alerting for Kueue Operator
-              triage: 'https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Distributed-Workloads/kueue-operator-availability.md'
 
   - interval: 1m
     input_series:
@@ -43,4 +42,3 @@ tests:
             exp_annotations:
               description: This alert fires when the Kueue Operator is not running.
               summary: Alerting for Kueue Operator
-              triage: 'https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Distributed-Workloads/kueue-operator-availability.md'

--- a/internal/controller/components/llamastackoperator/monitoring/llamastackoperator-alerting.unit-tests.yaml
+++ b/internal/controller/components/llamastackoperator/monitoring/llamastackoperator-alerting.unit-tests.yaml
@@ -1,5 +1,5 @@
 rule_files:
-  - llama-stack-k8s-operator-alerting.rules.yaml
+  - llamastackoperator-alerting.rules.yaml
 
 evaluation_interval: 1m
 
@@ -39,8 +39,7 @@ tests:
               severity: warning
             exp_annotations:
               summary: "Llama Stack K8s Operator Probe Success Burn Rate"
-              message: "High error budget burn for llama-stack-k8s-operator-controller-manager (current value: 3)."
-              triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Llama-Stack/rhoai-llama-stack-k8s-operator-probe-success-burn-rate.md"
+              message: "High error budget burn for llama-stack-k8s-operator-controller-manager (current value: 3 )."
 
   - interval: 1m
     input_series:
@@ -58,8 +57,7 @@ tests:
               severity: warning
             exp_annotations:
               summary: "Llama Stack K8s Operator Probe Success Burn Rate"
-              message: "High error budget burn for llama-stack-k8s-operator-controller-manager (current value: 16)."
-              triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Llama-Stack/rhoai-llama-stack-k8s-operator-probe-success-burn-rate.md"
+              message: "High error budget burn for llama-stack-k8s-operator-controller-manager (current value: 16 )."
   - interval: 1m
     input_series:
       - series: probe_success:burnrate2h{instance="llama-stack-k8s-operator-controller-manager"}
@@ -76,5 +74,4 @@ tests:
               severity: warning
             exp_annotations:
               summary: "Llama Stack K8s Operator Probe Success Burn Rate"
-              message: "High error budget burn for llama-stack-k8s-operator-controller-manager (current value: 61)."
-              triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Llama-Stack/rhoai-llama-stack-k8s-operator-probe-success-burn-rate.md"
+              message: "High error budget burn for llama-stack-k8s-operator-controller-manager (current value: 61 )."

--- a/internal/controller/components/modelcontroller/monitoring/modelcontroller-alerting.unit-tests.yaml
+++ b/internal/controller/components/modelcontroller/monitoring/modelcontroller-alerting.unit-tests.yaml
@@ -1,5 +1,5 @@
 rule_files:
-  - odh-model-controller-alerting.rules.yaml
+  - modelcontroller-alerting.rules.yaml
 
 evaluation_interval: 1m
 
@@ -40,8 +40,7 @@ tests:
               severity: critical
             exp_annotations:
               summary: "ODH Model Controller Probe Success Burn Rate"
-              message: "High error budget burn for odh-model-controller (current value: 3)."
-              triage: 'https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Model-Serving/rhods-odh-controller-probe-success-burn-rate.md'
+              message: "High error budget burn for odh-model-controller (current value: 3 )."
 
   - interval: 1m
     input_series:
@@ -60,8 +59,7 @@ tests:
               severity: critical
             exp_annotations:
               summary: "ODH Model Controller Probe Success Burn Rate"
-              message: "High error budget burn for odh-model-controller (current value: 16)."
-              triage: 'https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Model-Serving/rhods-odh-controller-probe-success-burn-rate.md'
+              message: "High error budget burn for odh-model-controller (current value: 16 )."
 
   - interval: 1m
     input_series:
@@ -80,5 +78,4 @@ tests:
               severity: warning
             exp_annotations:
               summary: "ODH Model Controller Probe Success Burn Rate"
-              message: "High error budget burn for odh-model-controller (current value: 61)."
-              triage: 'https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Model-Serving/rhods-odh-controller-probe-success-burn-rate.md'
+              message: "High error budget burn for odh-model-controller (current value: 61 )."

--- a/internal/controller/components/modelregistry/monitoring/modelregistry-alerting.unit-tests.yaml
+++ b/internal/controller/components/modelregistry/monitoring/modelregistry-alerting.unit-tests.yaml
@@ -1,5 +1,5 @@
 rule_files:
-  - model-registry-operator-alerting.rules.yaml
+  - modelregistry-alerting.rules.yaml
 
 evaluation_interval: 1m
 
@@ -38,8 +38,7 @@ tests:
               severity: critical
             exp_annotations:
               summary: "Model Registry Operator Probe Success Burn Rate"
-              message: "High error budget burn for model-registry-operator (current value: 3)."
-              triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Model-Serving/rhoai-model-registry-operator-probe-success-burn-rate.md"
+              message: "High error budget burn for model-registry-operator (current value: 3 )."
 
   - interval: 1m
     input_series: 
@@ -58,8 +57,7 @@ tests:
               severity: critical
             exp_annotations:
               summary: "Model Registry Operator Probe Success Burn Rate"
-              message: "High error budget burn for model-registry-operator (current value: 16)."
-              triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Model-Serving/rhoai-model-registry-operator-probe-success-burn-rate.md"
+              message: "High error budget burn for model-registry-operator (current value: 16 )."
 
   - interval: 1m
     input_series: 
@@ -78,5 +76,4 @@ tests:
               severity: warning
             exp_annotations:
               summary: "Model Registry Operator Probe Success Burn Rate"
-              message: "High error budget burn for model-registry-operator (current value: 61)."
-              triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Model-Serving/rhoai-model-registry-operator-probe-success-burn-rate.md"
+              message: "High error budget burn for model-registry-operator (current value: 61 )."

--- a/internal/controller/components/ray/monitoring/ray-alerting.unit-tests.yaml
+++ b/internal/controller/components/ray/monitoring/ray-alerting.unit-tests.yaml
@@ -26,7 +26,6 @@ tests:
             exp_annotations:
               description: This alert fires when the KubeRay Operator is not running.
               summary: Alerting for KubeRay Operator
-              triage: 'https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Distributed-Workloads/kuberay-operator-availability.md'
 
   - interval: 1m
     input_series:
@@ -43,4 +42,3 @@ tests:
             exp_annotations:
               description: This alert fires when the KubeRay Operator is not running.
               summary: Alerting for KubeRay Operator
-              triage: 'https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Distributed-Workloads/kuberay-operator-availability.md'

--- a/internal/controller/components/trainingoperator/monitoring/trainingoperator-alerting.unit-tests.yaml
+++ b/internal/controller/components/trainingoperator/monitoring/trainingoperator-alerting.unit-tests.yaml
@@ -26,7 +26,6 @@ tests:
             exp_annotations:
               description: "This alert fires when the KubeFlow Training Operator is not running."
               summary: Alerting for KubeFlow Training Operator
-              triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Distributed-Workloads/training-operator-availability.md"
 
   - interval: 1m
     input_series:
@@ -43,4 +42,3 @@ tests:
             exp_annotations:
               description: "This alert fires when the KubeFlow Training Operator is not running."
               summary: Alerting for KubeFlow Training Operator
-              triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Distributed-Workloads/training-operator-availability.md"

--- a/internal/controller/components/trustyai/monitoring/trustyai-alerting.unit-tests.yaml
+++ b/internal/controller/components/trustyai/monitoring/trustyai-alerting.unit-tests.yaml
@@ -39,8 +39,7 @@ tests:
               severity: critical
             exp_annotations:
               summary: "TrustyAI Controller Probe Success Burn Rate"
-              message: "High error budget burn for trustyai-service-operator-controller-manager (current value: 3)."
-              triage: 'https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Model-Serving/rhoai-trustyai-controller-probe-success-burn-rate.md'
+              message: "High error budget burn for trustyai-service-operator-controller-manager (current value: 3 )."
 
   - interval: 1m
     input_series:
@@ -58,8 +57,7 @@ tests:
               severity: critical
             exp_annotations:
               summary: "TrustyAI Controller Probe Success Burn Rate"
-              message: "High error budget burn for trustyai-service-operator-controller-manager (current value: 16)."
-              triage: 'https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Model-Serving/rhoai-trustyai-controller-probe-success-burn-rate.md'
+              message: "High error budget burn for trustyai-service-operator-controller-manager (current value: 16 )."
 
   - interval: 1m
     input_series:
@@ -77,5 +75,4 @@ tests:
               severity: warning
             exp_annotations:
               summary: "TrustyAI Controller Probe Success Burn Rate"
-              message: "High error budget burn for trustyai-service-operator-controller-manager (current value: 61)."
-              triage: 'https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Model-Serving/rhoai-trustyai-controller-probe-success-burn-rate.md'
+              message: "High error budget burn for trustyai-service-operator-controller-manager (current value: 61 )."

--- a/internal/controller/components/workbenches/monitoring/workbenches-alerting.unit-tests.yaml
+++ b/internal/controller/components/workbenches/monitoring/workbenches-alerting.unit-tests.yaml
@@ -34,7 +34,6 @@ tests:
             exp_annotations:
               summary: "User notebook pvc usage above 90%"
               message: "The user notebook jupyterhub-nb-1a is using 90% of its Volume. You might want to decrease the amount of data stored on the server or you can reach out to your cluster admin to increase the storage capacity to prevent disruptions and loss of data. Please back up your data before increasing the storage limit."
-              triage: 'https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/tree/main/RHODS'
 
   - interval: 1m
     input_series:
@@ -54,7 +53,6 @@ tests:
             exp_annotations:
               summary: "User notebook pvc usage at 100%"
               message: "The user notebook jupyterhub-nb-1a is using 100% of its Volume. You might want to decrease the amount of data stored on the server or you can reach out to your cluster admin to increase the storage capacity to prevent disruptions and loss of data. Please back up your data before increasing the storage limit."
-              triage: 'https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/tree/main/RHODS'
 
   # Probe success
   - interval: 1m
@@ -92,8 +90,7 @@ tests:
               severity: critical
             exp_annotations:
               summary: "RHODS Jupyter Probe Success Burn Rate"
-              message: "High error budget burn for notebook-spawner (current value: 3)."
-              triage: 'https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Jupyter/rhods-jupyter-probe-success-burn-rate.md'
+              message: "High error budget burn for notebook-spawner (current value: 3 )."
 
   - interval: 1m
     input_series:
@@ -111,8 +108,7 @@ tests:
               severity: critical
             exp_annotations:
               summary: "RHODS Jupyter Probe Success Burn Rate"
-              message: "High error budget burn for notebook-spawner (current value: 16)."
-              triage: 'https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Jupyter/rhods-jupyter-probe-success-burn-rate.md'
+              message: "High error budget burn for notebook-spawner (current value: 16 )."
 
   - interval: 1m
     input_series:
@@ -130,8 +126,7 @@ tests:
               severity: warning
             exp_annotations:
               summary: "RHODS Jupyter Probe Success Burn Rate"
-              message: "High error budget burn for notebook-spawner (current value: 61)."
-              triage: 'https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Jupyter/rhods-jupyter-probe-success-burn-rate.md'
+              message: "High error budget burn for notebook-spawner (current value: 61 )."
 
   - interval: 1m
     input_series:
@@ -149,8 +144,7 @@ tests:
               severity: warning
             exp_annotations:
               summary: "RHODS Jupyter Probe Success Burn Rate"
-              message: "High error budget burn for notebook-spawner (current value: 181)."
-              triage: 'https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Jupyter/rhods-jupyter-probe-success-burn-rate.md'
+              message: "High error budget burn for notebook-spawner (current value: 181 )."
 
   # ODH notebook controllers running
   - interval: 1m
@@ -175,7 +169,6 @@ tests:
             exp_annotations:
               summary: ODH notebook controller pod is not running
               message: 'ODH notebook controller is down!'
-              triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Jupyter/rhods-odh-notebook-controller-alert.md"
 
   # Kubeflow notebook controllers running
   - interval: 1m
@@ -200,4 +193,3 @@ tests:
             exp_annotations:
               summary: Kubeflow notebook controller pod is not running
               message: 'Kubeflow Notebook controller is down!'
-              triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Jupyter/rhods-kfnbc-notebook-controller-alert.md"


### PR DESCRIPTION

    update: move Prom Rule tests into component folder
    
    - test on the PrometheusRule CR not the old Prom config files
    - remove triage which is only for SRE
    - rename rule files to match component name
    - remove deadmansnitch which is only for SRE

<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
run "make test-alerts"


## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->
this is update unit test for monitoring

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Reworked Prometheus alert rule and test infrastructure to discover and validate per-component rule templates.
  * Updated alert rule naming and discovery across components; added ignore for generated rule outputs.
  * Adjusted CI triggers to match the new rules-based layout.
* **Bug Fixes / Tests**
  * Enhanced alert unit test discovery and execution; normalized test message formatting and removed external triage links from test expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->