### PR TITLE
[sync] update: move Prom Rule tests into component folder (#2858)

### DIFF
--- a/.github/workflows/test-prometheus-unit.yaml
+++ b/.github/workflows/test-prometheus-unit.yaml
@@ -2,8 +2,10 @@ name: Run prometheus unit tests
 on:
   pull_request:
     paths:
-      - 'config/monitoring/prometheus/**'
-      - 'tests/prometheus_unit_tests/**'
+      - 'internal/controller/components/**/monitoring/*-prometheusrules.tmpl.yaml'
+      - 'internal/controller/components/**/monitoring/*-alerting.unit-tests.yaml'
+      - 'tests/prometheus_unit_tests/scripts/**'
+      - 'Makefile'
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/internal/controller/components/.gitignore
+++ b/internal/controller/components/.gitignore
@@ -1,0 +1,1 @@
+*.rules.yaml

--- a/internal/controller/components/dashboard/monitoring/dashboard-alerting.unit-tests.yaml
+++ b/internal/controller/components/dashboard/monitoring/dashboard-alerting.unit-tests.yaml
@@ -1,5 +1,5 @@
 rule_files:
-  - rhods-dashboard-alerting.rules.yaml
+  - dashboard-alerting.rules.yaml
 
 evaluation_interval: 1m
 
@@ -20,13 +20,7 @@ tests:
         values: "0x60"
     alert_rule_test:
       - eval_time: 1h
-        alertname: RHODS Dashboard Route Error 5m and 1h Burn Rate high
-        exp_alerts: []
-      - eval_time: 1h
-        alertname: RHODS Dashboard Route Error 30m and 6h Burn Rate high
-        exp_alerts: []
-      - eval_time: 1h
-        alertname: RHODS Dashboard Route Error 2h and 1d Burn Rate high
+        alertname: RHODS Dashboard Route Error Burn Rate
         exp_alerts: []
 
   - interval: 1m
@@ -37,17 +31,16 @@ tests:
         values: "1+1x60"
     alert_rule_test:
       - eval_time: 2m
-        alertname: RHODS Dashboard Route Error 5m and 1h Burn Rate high
+        alertname: RHODS Dashboard Route Error Burn Rate
         exp_alerts:
           - exp_labels:
-              alertname: RHODS Dashboard Route Error 5m and 1h Burn Rate high
+              alertname: RHODS Dashboard Route Error Burn Rate
               namespace: "redhat-ods-applications"
               route: "rhods-dashboard"
               severity: critical
             exp_annotations:
-              summary: "RHODS Dashboard Route Error 5m and 1h Burn Rate high"
-              message: "High error budget burn for rhods-dashboard (current value: 3)."
-              triage: 'https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/RHODS-Dashboard/rhods-error-burn-rate.md'
+              summary: "RHODS Dashboard Route Error Burn Rate"
+              message: "High error budget burn for rhods-dashboard (current value: 3 )."
 
   - interval: 1m
     input_series:
@@ -57,17 +50,16 @@ tests:
         values: "1+1x60"
     alert_rule_test:
       - eval_time: 15m
-        alertname: RHODS Dashboard Route Error 30m and 6h Burn Rate high
+        alertname: RHODS Dashboard Route Error Burn Rate
         exp_alerts:
           - exp_labels:
-              alertname: RHODS Dashboard Route Error 30m and 6h Burn Rate high
+              alertname: RHODS Dashboard Route Error Burn Rate
               namespace: "redhat-ods-applications"
               route: "rhods-dashboard"
               severity: critical
             exp_annotations:
-              summary: "RHODS Dashboard Route Error 30m and 6h Burn Rate high"
-              message: "High error budget burn for rhods-dashboard (current value: 16)."
-              triage: 'https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/RHODS-Dashboard/rhods-error-burn-rate.md'
+              summary: "RHODS Dashboard Route Error Burn Rate"
+              message: "High error budget burn for rhods-dashboard (current value: 16 )."
 
   - interval: 1m
     input_series:
@@ -77,17 +69,16 @@ tests:
         values: "1+1x60"
     alert_rule_test:
       - eval_time: 1h
-        alertname: RHODS Dashboard Route Error 2h and 1d Burn Rate high
+        alertname: RHODS Dashboard Route Error Burn Rate
         exp_alerts:
           - exp_labels:
-              alertname: RHODS Dashboard Route Error 2h and 1d Burn Rate high
+              alertname: RHODS Dashboard Route Error Burn Rate
               namespace: "redhat-ods-applications"
               route: "rhods-dashboard"
               severity: warning
             exp_annotations:
-              summary: "RHODS Dashboard Route Error 2h and 1d Burn Rate high"
-              message: "High error budget burn for rhods-dashboard (current value: 61)."
-              triage: 'https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/RHODS-Dashboard/rhods-error-burn-rate.md'
+              summary: "RHODS Dashboard Route Error Burn Rate"
+              message: "High error budget burn for rhods-dashboard (current value: 61 )."
 
   # Probe success
   - interval: 1m
@@ -106,16 +97,7 @@ tests:
         values: "0x60"
     alert_rule_test:
       - eval_time: 3h
-        alertname: RHODS Dashboard Probe Success 5m and 1h Burn Rate high
-        exp_alerts: []
-      - eval_time: 3h
-        alertname: RHODS Dashboard Probe Success 30m and 6h Burn Rate high
-        exp_alerts: []
-      - eval_time: 3h
-        alertname: RHODS Dashboard Probe Success 2h and 1d Burn Rate high
-        exp_alerts: []
-      - eval_time: 3h
-        alertname: RHODS Dashboard Probe Success 6h and 3d Burn Rate high
+        alertname: RHODS Dashboard Probe Success Burn Rate
         exp_alerts: []
 
   - interval: 1m
@@ -126,17 +108,16 @@ tests:
         values: "1+1x60"
     alert_rule_test:
       - eval_time: 2m
-        alertname: RHODS Dashboard Probe Success 5m and 1h Burn Rate high
+        alertname: RHODS Dashboard Probe Success Burn Rate
         exp_alerts:
           - exp_labels:
-              alertname: RHODS Dashboard Probe Success 5m and 1h Burn Rate high
+              alertname: RHODS Dashboard Probe Success Burn Rate
               name: "rhods-dashboard"
               namespace: "redhat-ods-applications"
               severity: critical
             exp_annotations:
-              summary: "RHODS Dashboard Probe Success 5m and 1h Burn Rate high"
-              message: "High error budget burn for rhods-dashboard (current value: 3)."
-              triage: 'https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/RHODS-Dashboard/rhods-dashboard-probe-success-burn-rate.md'
+              summary: "RHODS Dashboard Probe Success Burn Rate"
+              message: "High error budget burn for rhods-dashboard (current value: 3 )."
 
   - interval: 1m
     input_series:
@@ -146,17 +127,16 @@ tests:
         values: "1+1x60"
     alert_rule_test:
       - eval_time: 15m
-        alertname: RHODS Dashboard Probe Success 30m and 6h Burn Rate high
+        alertname: RHODS Dashboard Probe Success Burn Rate
         exp_alerts:
           - exp_labels:
-              alertname: RHODS Dashboard Probe Success 30m and 6h Burn Rate high
+              alertname: RHODS Dashboard Probe Success Burn Rate
               name: "rhods-dashboard"
               namespace: "redhat-ods-applications"
               severity: critical
             exp_annotations:
-              summary: "RHODS Dashboard Probe Success 30m and 6h Burn Rate high"
-              message: "High error budget burn for rhods-dashboard (current value: 16)."
-              triage: 'https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/RHODS-Dashboard/rhods-dashboard-probe-success-burn-rate.md'
+              summary: "RHODS Dashboard Probe Success Burn Rate"
+              message: "High error budget burn for rhods-dashboard (current value: 16 )."
 
   - interval: 1m
     input_series:
@@ -166,17 +146,16 @@ tests:
         values: "1+1x60"
     alert_rule_test:
       - eval_time: 1h
-        alertname: RHODS Dashboard Probe Success 2h and 1d Burn Rate high
+        alertname: RHODS Dashboard Probe Success Burn Rate
         exp_alerts:
           - exp_labels:
-              alertname: RRHODS Dashboard Probe Success 2h and 1d Burn Rate high
+              alertname: RHODS Dashboard Probe Success Burn Rate
               name: "rhods-dashboard"
               namespace: "redhat-ods-applications"
               severity: warning
             exp_annotations:
-              summary: "RHODS Dashboard Probe Success 2h and 1d Burn Rate high"
-              message: "High error budget burn for rhods-dashboard (current value: 61)."
-              triage: 'https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/RHODS-Dashboard/rhods-dashboard-probe-success-burn-rate.md'
+              summary: "RHODS Dashboard Probe Success Burn Rate"
+              message: "High error budget burn for rhods-dashboard (current value: 61 )."
 
   - interval: 1m
     input_series:
@@ -186,14 +165,13 @@ tests:
         values: "1+1x200"
     alert_rule_test:
       - eval_time: 3h
-        alertname: RHODS Dashboard Probe Success 6h and 3d Burn Rate high
+        alertname: RHODS Dashboard Probe Success Burn Rate
         exp_alerts:
           - exp_labels:
-              alertname: RHODS Dashboard Probe Success 6h and 3d Burn Rate high
+              alertname: RHODS Dashboard Probe Success Burn Rate
               name: "rhods-dashboard"
               namespace: "redhat-ods-applications"
               severity: warning
             exp_annotations:
-              summary: "RHODS Dashboard Probe Success 6h and 3d Burn Rate high"
-              message: "High error budget burn for rhods-dashboard (current value: 181)."
-              triage: 'https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/RHODS-Dashboard/rhods-dashboard-probe-success-burn-rate.md'
+              summary: "RHODS Dashboard Probe Success Burn Rate"
+              message: "High error budget burn for rhods-dashboard (current value: 181 )."

--- a/internal/controller/components/datasciencepipelines/monitoring/datasciencepipelines-alerting.unit-tests.yaml
+++ b/internal/controller/components/datasciencepipelines/monitoring/datasciencepipelines-alerting.unit-tests.yaml
@@ -1,5 +1,5 @@
 rule_files:
-  - data-science-pipelines-operator-alerting.rules.yaml
+  - datasciencepipelines-alerting.rules.yaml
 
 evaluation_interval: 1m
 
@@ -18,20 +18,9 @@ tests:
         values: "0x60"
       - series: haproxy_backend_http_responses_total:burnrate1d{component="dsp"}
         values: "0x60"
-      - series: haproxy_backend_http_responses_total:burnrate3d{component="dsp"}
-        values: "0x60"
     alert_rule_test:
       - eval_time: 1h
-        alertname: Data Science Pipelines Application Route Error 5m and 1h Burn Rate high
-        exp_alerts: []
-      - eval_time: 1h
-        alertname: Data Science Pipelines Application Route Error 30m and 6h Burn Rate high
-        exp_alerts: []
-      - eval_time: 1h
-        alertname: Data Science Pipelines Application Route Error 2h and 1d Burn Rate high
-        exp_alerts: []
-      - eval_time: 1h
-        alertname: Data Science Pipelines Application Route Error 6h and 3d Burn Rate high
+        alertname: Data Science Pipelines Application Route Error Burn Rate
         exp_alerts: []
 
   - interval: 1m
@@ -42,16 +31,15 @@ tests:
         values: "1+1x60"
     alert_rule_test:
       - eval_time: 2m
-        alertname: Data Science Pipelines Application Route Error 5m and 1h Burn Rate high
+        alertname: Data Science Pipelines Application Route Error Burn Rate
         exp_alerts:
           - exp_labels:
-              alertname: Data Science Pipelines Application Route Error 5m and 1h Burn Rate high
+              alertname: Data Science Pipelines Application Route Error Burn Rate
               namespace: "redhat-ods-applications"
               severity: info
             exp_annotations:
-              summary: "Data Science Pipelines Application Route Error 5m and 1h Burn Rate high"
-              message: "High error budget burn for  (current value: 3)."
-              triage: 'https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Data-Science-Pipelines/data-science-pipelines-application-error-burn-rate.md'
+              summary: "Data Science Pipelines Application Route Error Burn Rate"
+              message: "High error budget burn for  (current value: 3 )."
 
   - interval: 1m
     input_series:
@@ -61,16 +49,15 @@ tests:
         values: "1+1x60"
     alert_rule_test:
       - eval_time: 15m
-        alertname: Data Science Pipelines Application Route Error 30m and 6h Burn Rate high
+        alertname: Data Science Pipelines Application Route Error Burn Rate
         exp_alerts:
           - exp_labels:
-              alertname: Data Science Pipelines Application Route Error 30m and 6h Burn Rate high
+              alertname: Data Science Pipelines Application Route Error Burn Rate
               namespace: "redhat-ods-applications"
               severity: info
             exp_annotations:
-              summary: "Data Science Pipelines Application Route Error 30m and 6h Burn Rate high"
-              message: "High error budget burn for  (current value: 16)."
-              triage: 'https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Data-Science-Pipelines/data-science-pipelines-application-error-burn-rate.md'
+              summary: "Data Science Pipelines Application Route Error Burn Rate"
+              message: "High error budget burn for  (current value: 16 )."
 
   - interval: 1m
     input_series:
@@ -80,16 +67,15 @@ tests:
         values: "1+1x60"
     alert_rule_test:
       - eval_time: 1h
-        alertname: Data Science Pipelines Application Route Error 2h and 1d Burn Rate high
+        alertname: Data Science Pipelines Application Route Error Burn Rate
         exp_alerts:
           - exp_labels:
-              alertname: Data Science Pipelines Application Route Error 2h and 1d Burn Rate high
+              alertname: Data Science Pipelines Application Route Error Burn Rate
               namespace: "redhat-ods-applications"
               severity: info
             exp_annotations:
-              summary: "Data Science Pipelines Application Route Error 2h and 1d Burn Rate high"
-              message: "High error budget burn for  (current value: 61)."
-              triage: 'https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Data-Science-Pipelines/data-science-pipelines-application-error-burn-rate.md'
+              summary: "Data Science Pipelines Application Route Error Burn Rate"
+              message: "High error budget burn for  (current value: 61 )."
 
   - interval: 1m
     input_series:
@@ -99,16 +85,15 @@ tests:
         values: "1+1x200"
     alert_rule_test:
       - eval_time: 3h
-        alertname: Data Science Pipelines Application Route Error 6h and 3d Burn Rate high
+        alertname: Data Science Pipelines Application Route Error Burn Rate
         exp_alerts:
           - exp_labels:
-              alertname: Data Science Pipelines Application Route Error 6h and 3d Burn Rate high
+              alertname: Data Science Pipelines Application Route Error Burn Rate
               namespace: "redhat-ods-applications"
               severity: info
             exp_annotations:
-              summary: "Data Science Pipelines Application Route Error 6h and 3d Burn Rate high"
-              message: "High error budget burn for  (current value: 181)."
-              triage: 'https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Data-Science-Pipelines/data-science-pipelines-application-error-burn-rate.md'
+              summary: "Data Science Pipelines Application Route Error Burn Rate"
+              message: "High error budget burn for  (current value: 181 )."
 
   # Probe success
   - interval: 1m
@@ -127,13 +112,7 @@ tests:
         values: "0x60"
     alert_rule_test:
       - eval_time: 3h
-        alertname: Data Science Pipelines Operator Probe Success 5m and 1h Burn Rate high
-        exp_alerts: []
-      - eval_time: 3h
-        alertname: Data Science Pipelines Operator Probe Success 30m and 6h Burn Rate high
-        exp_alerts: []
-      - eval_time: 3h
-        alertname: Data Science Pipelines Operator Probe Success 2h and 1d Burn Rate high
+        alertname: Data Science Pipelines Operator Probe Success Burn Rate
         exp_alerts: []
 
 
@@ -145,17 +124,16 @@ tests:
         values: "1+1x60"
     alert_rule_test:
       - eval_time: 2m
-        alertname: Data Science Pipelines Operator Probe Success 5m and 1h Burn Rate high
+        alertname: Data Science Pipelines Operator Probe Success Burn Rate
         exp_alerts:
           - exp_labels:
-              alertname: Data Science Pipelines Operator Probe Success 5m and 1h Burn Rate high
+              alertname: Data Science Pipelines Operator Probe Success Burn Rate
               instance: "data-science-pipelines-operator"
               namespace: "redhat-ods-applications"
               severity: critical
             exp_annotations:
-              summary: "Data Science Pipelines Operator Probe Success 5m and 1h Burn Rate high"
-              message: "High error budget burn for data-science-pipelines-operator (current value: 3)."
-              triage: 'https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Data-Science-Pipelines/data-science-pipelines-operator-probe-success-burn-rate.md'
+              summary: "Data Science Pipelines Operator Probe Success Burn Rate"
+              message: "High error budget burn for data-science-pipelines-operator (current value: 3 )."
 
   - interval: 1m
     input_series:
@@ -165,17 +143,16 @@ tests:
         values: "1+1x60"
     alert_rule_test:
       - eval_time: 15m
-        alertname: Data Science Pipelines Operator Probe Success 30m and 6h Burn Rate high
+        alertname: Data Science Pipelines Operator Probe Success Burn Rate
         exp_alerts:
           - exp_labels:
-              alertname: Data Science Pipelines Operator Probe Success 30m and 6h Burn Rate high
+              alertname: Data Science Pipelines Operator Probe Success Burn Rate
               instance: "data-science-pipelines-operator"
               namespace: "redhat-ods-applications"
               severity: critical
             exp_annotations:
-              summary: "Data Science Pipelines Operator Probe Success 30m and 6h Burn Rate high"
-              message: "High error budget burn for data-science-pipelines-operator (current value: 16)."
-              triage: 'https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Data-Science-Pipelines/data-science-pipelines-operator-probe-success-burn-rate.md'
+              summary: "Data Science Pipelines Operator Probe Success Burn Rate"
+              message: "High error budget burn for data-science-pipelines-operator (current value: 16 )."
 
   - interval: 1m
     input_series:
@@ -185,17 +162,16 @@ tests:
         values: "1+1x60"
     alert_rule_test:
       - eval_time: 1h
-        alertname: Data Science Pipelines Operator Probe Success 2h and 1d Burn Rate high
+        alertname: Data Science Pipelines Operator Probe Success Burn Rate
         exp_alerts:
           - exp_labels:
-              alertname: Data Science Pipelines Operator Probe Success 2h and 1d Burn Rate high
+              alertname: Data Science Pipelines Operator Probe Success Burn Rate
               instance: "data-science-pipelines-operator"
               namespace: "redhat-ods-applications"
               severity: warning
             exp_annotations:
-              summary: "Data Science Pipelines Operator Probe Success 2h and 1d Burn Rate high"
-              message: "High error budget burn for data-science-pipelines-operator (current value: 61)."
-              triage: 'https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Data-Science-Pipelines/data-science-pipelines-operator-probe-success-burn-rate.md'
+              summary: "Data Science Pipelines Operator Probe Success Burn Rate"
+              message: "High error budget burn for data-science-pipelines-operator (current value: 61 )."
 
   # application unavailable
   - interval: 1m
@@ -220,7 +196,6 @@ tests:
               severity: info
             exp_annotations:
               message: "Data Science Pipelines Application is down!"
-              triage: 'https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Data-Science-Pipelines/data-science-pipelines-application-component-readiness-status.md'
               summary: The Data Science Pipelines Application CustomResource "dspa_instance_1" in namespace "dspa_namespace_a" has been NotReady for more than 5 minutes
       - eval_time: 2m
         alertname: Data Science Pipeline APIServer Unavailable
@@ -233,7 +208,6 @@ tests:
               severity: info
             exp_annotations:
               message: "Data Science Pipelines APIServer component is down!"
-              triage: 'https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Data-Science-Pipelines/data-science-pipelines-application-component-readiness-status.md'
               summary: A Data Science Pipelines APIServer pod owned by DSPA "dspa_instance_1" in namespace "dspa_namespace_a" has been NotReady for more than 5 minutes
       - eval_time: 2m
         alertname: Data Science Pipeline PersistenceAgent Unavailable
@@ -246,7 +220,6 @@ tests:
               severity: info
             exp_annotations:
               message: "Data Science Pipelines PersistenceAgent component is down!"
-              triage: 'https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Data-Science-Pipelines/data-science-pipelines-application-component-readiness-status.md'
               summary: A Data Science Pipelines PersistenceAgent pod owned by DSPA "dspa_instance_1" in namespace "dspa_namespace_a" has been NotReady for more than 5 minutes
       - eval_time: 2m
         alertname: Data Science Pipeline ScheduledWorkflows Unavailable
@@ -259,5 +232,4 @@ tests:
               severity: info
             exp_annotations:
               message: "Data Science Pipelines ScheduledWorkflows component is down!"
-              triage: 'https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Data-Science-Pipelines/data-science-pipelines-application-component-readiness-status.md'
               summary: A Data Science Pipelines ScheduledWorkflow controller pod owned by DSPA "dspa_instance_1" in namespace "dspa_namespace_a" has been NotReady for more than 5 minutes

--- a/internal/controller/components/feastoperator/monitoring/feastoperator-alerting.unit-tests.yaml
+++ b/internal/controller/components/feastoperator/monitoring/feastoperator-alerting.unit-tests.yaml
@@ -1,5 +1,5 @@
 rule_files:
-  - feast-operator-alerting.rules.yaml
+  - feastoperator-alerting.rules.yaml
 
 evaluation_interval: 1m
 
@@ -39,8 +39,7 @@ tests:
               severity: critical
             exp_annotations:
               summary: "Feast Operator Probe Success Burn Rate"
-              message: "High error budget burn for feast-operator-controller-manager (current value: 3)."
-              triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Feature-Store/rhoai-feast-operator-probe-success-burn-rate.md"
+              message: "High error budget burn for feast-operator-controller-manager (current value: 3 )."
 
   - interval: 1m
     input_series:
@@ -58,8 +57,7 @@ tests:
               severity: critical
             exp_annotations:
               summary: "Feast Operator Probe Success Burn Rate"
-              message: "High error budget burn for feast-operator-controller-manager (current value: 16)."
-              triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Feature-Store/rhoai-feast-operator-probe-success-burn-rate.md"
+              message: "High error budget burn for feast-operator-controller-manager (current value: 16 )."
 
   - interval: 1m
     input_series:
@@ -77,5 +75,4 @@ tests:
               severity: warning
             exp_annotations:
               summary: "Feast Operator Probe Success Burn Rate"
-              message: "High error budget burn for feast-operator-controller-manager (current value: 61)."
-              triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Feature-Store/rhoai-feast-operator-probe-success-burn-rate.md"
+              message: "High error budget burn for feast-operator-controller-manager (current value: 61 )."

--- a/internal/controller/components/kserve/monitoring/kserve-alerting.unit-tests.yaml
+++ b/internal/controller/components/kserve/monitoring/kserve-alerting.unit-tests.yaml
@@ -21,14 +21,8 @@ tests:
         values: "0x60"
     alert_rule_test:
       - eval_time: 1h
-        alertname: Kserve Controller Probe Success 5m and 1h Burn Rate high
+        alertname: Kserve Controller Probe Success Burn Rate
         exp_alerts: []
-      - eval_time: 1h
-        alertname: Kserve Controller Probe Success 30m and 6h Burn Rate high
-        exp_alerts: []
-      - eval_time: 1h
-        alertname: Kserve Controller Probe Success 2h and 1d Burn Rate high
-        exp_alerts: [] 
 
   - interval: 1m
     input_series:
@@ -38,16 +32,15 @@ tests:
         values: "1+1x60"
     alert_rule_test:
       - eval_time: 2m
-        alertname: Kserve Controller Probe Success 5m and 1h Burn Rate high
+        alertname: Kserve Controller Probe Success Burn Rate
         exp_alerts:
           - exp_labels:
-              alertname: Kserve Controller Probe Success 5m and 1h Burn Rate high
+              alertname: Kserve Controller Probe Success Burn Rate
               instance: "kserve-controller-manager"
               severity: critical
             exp_annotations:
-              message: "High error budget burn for kserve-controller-manager (current value: 3)."
-              summary: Kserve Controller Probe Success 5m and 1h Burn Rate high
-              triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Model-Serving/rhods-kserve-controller-probe-success-burn-rate.md"
+              message: "High error budget burn for kserve-controller-manager (current value: 3 )."
+              summary: Kserve Controller Probe Success Burn Rate
 
   - interval: 1m
     input_series:
@@ -57,16 +50,15 @@ tests:
         values: "1+1x60"
     alert_rule_test:
       - eval_time: 15m
-        alertname: Kserve Controller Probe Success 30m and 6h Burn Rate high
+        alertname: Kserve Controller Probe Success Burn Rate
         exp_alerts:
           - exp_labels:
-              alertname: Kserve Controller Probe Success 30m and 6h Burn Rate high
+              alertname: Kserve Controller Probe Success Burn Rate
               instance: "kserve-controller-manager"
               severity: critical
             exp_annotations:
-              message: "High error budget burn for kserve-controller-manager (current value: 16)."
-              summary: Kserve Controller Probe Success 30m and 6h Burn Rate high
-              triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Model-Serving/rhods-kserve-controller-probe-success-burn-rate.md"
+              message: "High error budget burn for kserve-controller-manager (current value: 16 )."
+              summary: Kserve Controller Probe Success Burn Rate
 
   - interval: 1m
     input_series:
@@ -76,13 +68,12 @@ tests:
         values: "1+1x60"
     alert_rule_test:
       - eval_time: 1h
-        alertname: Kserve Controller Probe Success 2h and 1d Burn Rate high
+        alertname: Kserve Controller Probe Success Burn Rate
         exp_alerts:
           - exp_labels:
-              alertname: Kserve Controller Probe Success 2h and 1d Burn Rate high
+              alertname: Kserve Controller Probe Success Burn Rate
               instance: "kserve-controller-manager"
               severity: warning
             exp_annotations:
-              message: "High error budget burn for kserve-controller-manager (current value: 61)."
-              summary: Kserve Controller Probe Success 2h and 1d Burn Rate high
-              triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Model-Serving/rhods-kserve-controller-probe-success-burn-rate.md"
+              message: "High error budget burn for kserve-controller-manager (current value: 61 )."
+              summary: Kserve Controller Probe Success Burn Rate

--- a/internal/controller/components/kueue/monitoring/kueue-alerting.unit-tests.yaml
+++ b/internal/controller/components/kueue/monitoring/kueue-alerting.unit-tests.yaml
@@ -26,7 +26,6 @@ tests:
             exp_annotations:
               description: This alert fires when the Kueue Operator is not running.
               summary: Alerting for Kueue Operator
-              triage: 'https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Distributed-Workloads/kueue-operator-availability.md'
 
   - interval: 1m
     input_series:
@@ -43,4 +42,3 @@ tests:
             exp_annotations:
               description: This alert fires when the Kueue Operator is not running.
               summary: Alerting for Kueue Operator
-              triage: 'https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Distributed-Workloads/kueue-operator-availability.md'

--- a/internal/controller/components/llamastackoperator/monitoring/llamastackoperator-alerting.unit-tests.yaml
+++ b/internal/controller/components/llamastackoperator/monitoring/llamastackoperator-alerting.unit-tests.yaml
@@ -1,5 +1,5 @@
 rule_files:
-  - llama-stack-k8s-operator-alerting.rules.yaml
+  - llamastackoperator-alerting.rules.yaml
 
 evaluation_interval: 1m
 
@@ -39,8 +39,7 @@ tests:
               severity: warning
             exp_annotations:
               summary: "Llama Stack K8s Operator Probe Success Burn Rate"
-              message: "High error budget burn for llama-stack-k8s-operator-controller-manager (current value: 3)."
-              triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Llama-Stack/rhoai-llama-stack-k8s-operator-probe-success-burn-rate.md"
+              message: "High error budget burn for llama-stack-k8s-operator-controller-manager (current value: 3 )."
 
   - interval: 1m
     input_series:
@@ -58,8 +57,7 @@ tests:
               severity: warning
             exp_annotations:
               summary: "Llama Stack K8s Operator Probe Success Burn Rate"
-              message: "High error budget burn for llama-stack-k8s-operator-controller-manager (current value: 16)."
-              triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Llama-Stack/rhoai-llama-stack-k8s-operator-probe-success-burn-rate.md"
+              message: "High error budget burn for llama-stack-k8s-operator-controller-manager (current value: 16 )."
   - interval: 1m
     input_series:
       - series: probe_success:burnrate2h{instance="llama-stack-k8s-operator-controller-manager"}
@@ -76,5 +74,4 @@ tests:
               severity: warning
             exp_annotations:
               summary: "Llama Stack K8s Operator Probe Success Burn Rate"
-              message: "High error budget burn for llama-stack-k8s-operator-controller-manager (current value: 61)."
-              triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Llama-Stack/rhoai-llama-stack-k8s-operator-probe-success-burn-rate.md"
+              message: "High error budget burn for llama-stack-k8s-operator-controller-manager (current value: 61 )."

--- a/internal/controller/components/modelcontroller/monitoring/modelcontroller-alerting.unit-tests.yaml
+++ b/internal/controller/components/modelcontroller/monitoring/modelcontroller-alerting.unit-tests.yaml
@@ -1,5 +1,5 @@
 rule_files:
-  - odh-model-controller-alerting.rules.yaml
+  - modelcontroller-alerting.rules.yaml
 
 evaluation_interval: 1m
 
@@ -20,13 +20,7 @@ tests:
         values: "0x60"
     alert_rule_test:
       - eval_time: 1h
-        alertname: ODH Model Controller Probe Success 5m and 1h Burn Rate high
-        exp_alerts: []
-      - eval_time: 1h
-        alertname: ODH Model Controller Probe Success 30m and 6h Burn Rate high
-        exp_alerts: []
-      - eval_time: 1h
-        alertname: ODH Model Controller Probe Success 2h and 1d Burn Rate high
+        alertname: ODH Model Controller Probe Success Burn Rate
         exp_alerts: []
 
   - interval: 1m
@@ -37,17 +31,16 @@ tests:
         values: "1+1x60"
     alert_rule_test:
       - eval_time: 2m
-        alertname: ODH Model Controller Probe Success 5m and 1h Burn Rate high
+        alertname: ODH Model Controller Probe Success Burn Rate
         exp_alerts:
           - exp_labels:
-              alertname: ODH Model Controller Probe Success 5m and 1h Burn Rate high
+              alertname: ODH Model Controller Probe Success Burn Rate
               namespace: "redhat-ods-applications"
               instance: "odh-model-controller"
               severity: critical
             exp_annotations:
-              summary: "ODH Model Controller Probe Success 5m and 1h Burn Rate high"
-              message: "High error budget burn for odh-model-controller (current value: 3)."
-              triage: 'https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Model-Serving/rhods-odh-controller-probe-success-burn-rate.md'
+              summary: "ODH Model Controller Probe Success Burn Rate"
+              message: "High error budget burn for odh-model-controller (current value: 3 )."
 
   - interval: 1m
     input_series:
@@ -57,17 +50,16 @@ tests:
         values: "1+1x60"
     alert_rule_test:
       - eval_time: 15m
-        alertname: ODH Model Controller Probe Success 30m and 6h Burn Rate high
+        alertname: ODH Model Controller Probe Success Burn Rate
         exp_alerts:
           - exp_labels:
-              alertname: ODH Model Controller Probe Success 30m and 6h Burn Rate high
+              alertname: ODH Model Controller Probe Success Burn Rate
               namespace: "redhat-ods-applications"
               instance: "odh-model-controller"
               severity: critical
             exp_annotations:
-              summary: "ODH Model Controller Probe Success 30m and 6h Burn Rate high"
-              message: "High error budget burn for odh-model-controller (current value: 16)."
-              triage: 'https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Model-Serving/rhods-odh-controller-probe-success-burn-rate.md'
+              summary: "ODH Model Controller Probe Success Burn Rate"
+              message: "High error budget burn for odh-model-controller (current value: 16 )."
 
   - interval: 1m
     input_series:
@@ -77,14 +69,13 @@ tests:
         values: "1+1x60"
     alert_rule_test:
       - eval_time: 1h
-        alertname: ODH Model Controller Probe Success 2h and 1d Burn Rate high
+        alertname: ODH Model Controller Probe Success Burn Rate
         exp_alerts:
           - exp_labels:
-              alertname: ODH Model Controller Probe Success 2h and 1d Burn Rate high
+              alertname: ODH Model Controller Probe Success Burn Rate
               namespace: "redhat-ods-applications"
               instance: "odh-model-controller"
               severity: warning
             exp_annotations:
-              summary: "ODH Model Controller Probe Success 2h and 1d Burn Rate high"
-              message: "High error budget burn for odh-model-controller (current value: 61)."
-              triage: 'https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Model-Serving/rhods-odh-controller-probe-success-burn-rate.md'
+              summary: "ODH Model Controller Probe Success Burn Rate"
+              message: "High error budget burn for odh-model-controller (current value: 61 )."

--- a/internal/controller/components/ray/monitoring/ray-alerting.unit-tests.yaml
+++ b/internal/controller/components/ray/monitoring/ray-alerting.unit-tests.yaml
@@ -26,7 +26,6 @@ tests:
             exp_annotations:
               description: This alert fires when the KubeRay Operator is not running.
               summary: Alerting for KubeRay Operator
-              triage: 'https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Distributed-Workloads/kuberay-operator-availability.md'
 
   - interval: 1m
     input_series:
@@ -43,4 +42,3 @@ tests:
             exp_annotations:
               description: This alert fires when the KubeRay Operator is not running.
               summary: Alerting for KubeRay Operator
-              triage: 'https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Distributed-Workloads/kuberay-operator-availability.md'

--- a/internal/controller/components/trainingoperator/monitoring/trainingoperator-alerting.unit-tests.yaml
+++ b/internal/controller/components/trainingoperator/monitoring/trainingoperator-alerting.unit-tests.yaml
@@ -26,7 +26,6 @@ tests:
             exp_annotations:
               description: "This alert fires when the KubeFlow Training Operator is not running."
               summary: Alerting for KubeFlow Training Operator
-              triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Distributed-Workloads/training-operator-availability.md"
 
   - interval: 1m
     input_series:
@@ -43,4 +42,3 @@ tests:
             exp_annotations:
               description: "This alert fires when the KubeFlow Training Operator is not running."
               summary: Alerting for KubeFlow Training Operator
-              triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Distributed-Workloads/training-operator-availability.md"

--- a/internal/controller/components/trustyai/monitoring/trustyai-alerting.unit-tests.yaml
+++ b/internal/controller/components/trustyai/monitoring/trustyai-alerting.unit-tests.yaml
@@ -20,13 +20,7 @@ tests:
         values: "0x60"
     alert_rule_test:
       - eval_time: 1h
-        alertname: TrustyAI Controller Probe Success 5m and 1h Burn Rate high
-        exp_alerts: []
-      - eval_time: 1h
-        alertname: TrustyAI Controller Probe Success 30m and 6h Burn Rate high
-        exp_alerts: []
-      - eval_time: 1h
-        alertname: TrustyAI Controller Probe Success 2h and 1d Burn Rate high
+        alertname: TrustyAI Controller Probe Success Burn Rate
         exp_alerts: []
 
   - interval: 1m
@@ -37,16 +31,15 @@ tests:
         values: "1+1x60"
     alert_rule_test:
       - eval_time: 2m
-        alertname: TrustyAI Controller Probe Success 5m and 1h Burn Rate high
+        alertname: TrustyAI Controller Probe Success Burn Rate
         exp_alerts:
           - exp_labels:
-              alertname: TrustyAI Controller Probe Success 5m and 1h Burn Rate high
+              alertname: TrustyAI Controller Probe Success Burn Rate
               instance: "trustyai-service-operator-controller-manager"
               severity: critical
             exp_annotations:
-              summary: "TrustyAI Controller Probe Success 5m and 1h Burn Rate high"
-              message: "High error budget burn for trustyai-service-operator-controller-manager (current value: 3)."
-              triage: 'https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Model-Serving/rhoai-trustyai-controller-probe-success-burn-rate.md'
+              summary: "TrustyAI Controller Probe Success Burn Rate"
+              message: "High error budget burn for trustyai-service-operator-controller-manager (current value: 3 )."
 
   - interval: 1m
     input_series:
@@ -56,16 +49,15 @@ tests:
         values: "1+1x60"
     alert_rule_test:
       - eval_time: 15m
-        alertname: TrustyAI Controller Probe Success 30m and 6h Burn Rate high
+        alertname: TrustyAI Controller Probe Success Burn Rate
         exp_alerts:
           - exp_labels:
-              alertname: TrustyAI Controller Probe Success 30m and 6h Burn Rate high
+              alertname: TrustyAI Controller Probe Success Burn Rate
               instance: "trustyai-service-operator-controller-manager"
               severity: critical
             exp_annotations:
-              summary: "TrustyAI Controller Probe Success 30m and 6h Burn Rate high"
-              message: "High error budget burn for trustyai-service-operator-controller-manager (current value: 16)."
-              triage: 'https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Model-Serving/rhoai-trustyai-controller-probe-success-burn-rate.md'
+              summary: "TrustyAI Controller Probe Success Burn Rate"
+              message: "High error budget burn for trustyai-service-operator-controller-manager (current value: 16 )."
 
   - interval: 1m
     input_series:
@@ -75,13 +67,12 @@ tests:
         values: "1+1x60"
     alert_rule_test:
       - eval_time: 1h
-        alertname: TrustyAI Controller Probe Success 2h and 1d Burn Rate high
+        alertname: TrustyAI Controller Probe Success Burn Rate
         exp_alerts:
           - exp_labels:
-              alertname: TrustyAI Controller Probe Success 2h and 1d Burn Rate high
+              alertname: TrustyAI Controller Probe Success Burn Rate
               instance: "trustyai-service-operator-controller-manager"
               severity: warning
             exp_annotations:
-              summary: "TrustyAI Controller Probe Success 2h and 1d Burn Rate high"
-              message: "High error budget burn for trustyai-service-operator-controller-manager (current value: 61)."
-              triage: 'https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Model-Serving/rhoai-trustyai-controller-probe-success-burn-rate.md'
+              summary: "TrustyAI Controller Probe Success Burn Rate"
+              message: "High error budget burn for trustyai-service-operator-controller-manager (current value: 61 )."

--- a/internal/controller/components/workbenches/monitoring/workbenches-alerting.unit-tests.yaml
+++ b/internal/controller/components/workbenches/monitoring/workbenches-alerting.unit-tests.yaml
@@ -34,7 +34,6 @@ tests:
             exp_annotations:
               summary: "User notebook pvc usage above 90%"
               message: "The user notebook jupyterhub-nb-1a is using 90% of its Volume. You might want to decrease the amount of data stored on the server or you can reach out to your cluster admin to increase the storage capacity to prevent disruptions and loss of data. Please back up your data before increasing the storage limit."
-              triage: 'https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/tree/main/RHODS'
 
   - interval: 1m
     input_series:
@@ -54,7 +53,6 @@ tests:
             exp_annotations:
               summary: "User notebook pvc usage at 100%"
               message: "The user notebook jupyterhub-nb-1a is using 100% of its Volume. You might want to decrease the amount of data stored on the server or you can reach out to your cluster admin to increase the storage capacity to prevent disruptions and loss of data. Please back up your data before increasing the storage limit."
-              triage: 'https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/tree/main/RHODS'
 
   # Probe success
   - interval: 1m
@@ -73,16 +71,7 @@ tests:
         values: "0x60"
     alert_rule_test:
       - eval_time: 1h
-        alertname: RHODS Jupyter Probe Success 5m and 1h Burn Rate high
-        exp_alerts: []
-      - eval_time: 1h
-        alertname: RHODS Jupyter Probe Success 30m and 6h Burn Rate high
-        exp_alerts: []
-      - eval_time: 1h
-        alertname: RHODS Jupyter Probe Success 2h and 1d Burn Rate high
-        exp_alerts: []
-      - eval_time: 1h
-        alertname: RHODS Jupyter Probe Success 6h and 3d Burn Rate high
+        alertname: RHODS Jupyter Probe Success Burn Rate
         exp_alerts: []
 
   - interval: 1m
@@ -93,16 +82,15 @@ tests:
         values: "1+1x60"
     alert_rule_test:
       - eval_time: 2m
-        alertname: RHODS Jupyter Probe Success 5m and 1h Burn Rate high
+        alertname: RHODS Jupyter Probe Success Burn Rate
         exp_alerts:
           - exp_labels:
-              alertname: RHODS Jupyter Probe Success 5m and 1h Burn Rate high
+              alertname: RHODS Jupyter Probe Success Burn Rate
               instance: "notebook-spawner"
               severity: critical
             exp_annotations:
-              summary: "RHODS Jupyter Probe Success 5m and 1h Burn Rate high"
-              message: "High error budget burn for notebook-spawner (current value: 3)."
-              triage: 'https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Jupyter/rhods-jupyter-probe-success-burn-rate.md'
+              summary: "RHODS Jupyter Probe Success Burn Rate"
+              message: "High error budget burn for notebook-spawner (current value: 3 )."
 
   - interval: 1m
     input_series:
@@ -112,16 +100,15 @@ tests:
         values: "1+1x60"
     alert_rule_test:
       - eval_time: 15m
-        alertname: RHODS Jupyter Probe Success 30m and 6h Burn Rate high
+        alertname: RHODS Jupyter Probe Success Burn Rate
         exp_alerts:
           - exp_labels:
-              alertname: RHODS Jupyter Probe Success 30m and 6h Burn Rate high
+              alertname: RHODS Jupyter Probe Success Burn Rate
               instance: "notebook-spawner"
               severity: critical
             exp_annotations:
-              summary: "RHODS Jupyter Probe Success 30m and 6h Burn Rate high"
-              message: "High error budget burn for notebook-spawner (current value: 16)."
-              triage: 'https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Jupyter/rhods-jupyter-probe-success-burn-rate.md'
+              summary: "RHODS Jupyter Probe Success Burn Rate"
+              message: "High error budget burn for notebook-spawner (current value: 16 )."
 
   - interval: 1m
     input_series:
@@ -131,16 +118,15 @@ tests:
         values: "1+1x60"
     alert_rule_test:
       - eval_time: 1h
-        alertname: RHODS Jupyter Probe Success 2h and 1d Burn Rate high
+        alertname: RHODS Jupyter Probe Success Burn Rate
         exp_alerts:
           - exp_labels:
-              alertname: RHODS Jupyter Probe Success 2h and 1d Burn Rate high
+              alertname: RHODS Jupyter Probe Success Burn Rate
               instance: "notebook-spawner"
               severity: warning
             exp_annotations:
-              summary: "RHODS Jupyter Probe Success 2h and 1d Burn Rate high"
-              message: "High error budget burn for notebook-spawner (current value: 61)."
-              triage: 'https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Jupyter/rhods-jupyter-probe-success-burn-rate.md'
+              summary: "RHODS Jupyter Probe Success Burn Rate"
+              message: "High error budget burn for notebook-spawner (current value: 61 )."
 
   - interval: 1m
     input_series:
@@ -150,16 +136,15 @@ tests:
         values: "1+1x200"
     alert_rule_test:
       - eval_time: 3h
-        alertname: RHODS Jupyter Probe Success 6h and 3d Burn Rate high
+        alertname: RHODS Jupyter Probe Success Burn Rate
         exp_alerts:
           - exp_labels:
-              alertname: RHODS Jupyter Probe Success 6h and 3d Burn Rate high
+              alertname: RHODS Jupyter Probe Success Burn Rate
               instance: "notebook-spawner"
               severity: warning
             exp_annotations:
-              summary: "RHODS Jupyter Probe Success 6h and 3d Burn Rate high"
-              message: "High error budget burn for notebook-spawner (current value: 181)."
-              triage: 'https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Jupyter/rhods-jupyter-probe-success-burn-rate.md'
+              summary: "RHODS Jupyter Probe Success Burn Rate"
+              message: "High error budget burn for notebook-spawner (current value: 181 )."
 
   # ODH notebook controllers running
   - interval: 1m
@@ -184,7 +169,6 @@ tests:
             exp_annotations:
               summary: ODH notebook controller pod is not running
               message: 'ODH notebook controller is down!'
-              triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Jupyter/rhods-odh-notebook-controller-alert.md"
 
   # Kubeflow notebook controllers running
   - interval: 1m
@@ -209,4 +193,3 @@ tests:
             exp_annotations:
               summary: Kubeflow notebook controller pod is not running
               message: 'Kubeflow Notebook controller is down!'
-              triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Jupyter/rhods-kfnbc-notebook-controller-alert.md"


### PR DESCRIPTION
- test on the PrometheusRule CR not the old Prom config files
- remove triage which is only for SRE
- rename rule files to match component name
- remove deadmansnitch which is only for SRE


(cherry picked from commit 2e10081adb26a86de493f4dc50014059139bc05f)

<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [ ] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->
