### PR TITLE
Add Prometheus rules for MaaS quota metrics

### DIFF
--- a/internal/controller/components/kserve/monitoring/kserve-alerting.unit-tests.yaml
+++ b/internal/controller/components/kserve/monitoring/kserve-alerting.unit-tests.yaml
@@ -77,3 +77,65 @@ tests:
             exp_annotations:
               message: "High error budget burn for kserve-controller-manager (current value: 61 )."
               summary: Kserve Controller Probe Success Burn Rate
+
+  # MaaS quota limit hit rate tests
+  # Test 1: Should NOT fire (5% hit rate < 10% threshold)
+  - interval: 1m
+    input_series:
+      - series: authorized_calls{namespace="test-ns",service="test-svc",model="test-model"}
+        values: "0+100x12"
+      - series: limited_calls{namespace="test-ns",service="test-svc",model="test-model"}
+        values: "0+5x12"
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: KServeMaaSHighQuotaLimitHitRate
+        exp_alerts: []
+
+  # Test 2: Should fire (15% hit rate > 10% threshold)
+  # Need data spanning at least 10m + for duration (10m) = 20m total
+  - interval: 1m
+    input_series:
+      - series: authorized_calls{namespace="test-ns",service="test-svc",model="test-model"}
+        values: "0+100x25"
+      - series: limited_calls{namespace="test-ns",service="test-svc",model="test-model"}
+        values: "0+15x25"
+    alert_rule_test:
+      - eval_time: 20m
+        alertname: KServeMaaSHighQuotaLimitHitRate
+        exp_alerts:
+          - exp_labels:
+              alertname: KServeMaaSHighQuotaLimitHitRate
+              namespace: "test-ns"
+              service: "test-svc"
+              model: "test-model"
+              severity: warning
+              component: kserve
+              subsystem: maas
+            exp_annotations:
+              message: "Quota limit hit rate for model test-model in namespace test-ns is above 10% over the last 10 minutes. This indicates requests are being rate-limited frequently."
+              summary: "KServe/MaaS high quota limit hit rate (>10%)"
+
+  # MaaS sustained quota limit hits test
+  # Should fire (60% hit rate > 50% threshold)
+  # Need data spanning at least 30m + for duration (30m) = 60m total
+  - interval: 1m
+    input_series:
+      - series: authorized_calls{namespace="test-ns",service="test-svc",model="test-model"}
+        values: "0+100x65"
+      - series: limited_calls{namespace="test-ns",service="test-svc",model="test-model"}
+        values: "0+60x65"
+    alert_rule_test:
+      - eval_time: 60m
+        alertname: KServeMaaSSustainedQuotaLimitHits
+        exp_alerts:
+          - exp_labels:
+              alertname: KServeMaaSSustainedQuotaLimitHits
+              namespace: "test-ns"
+              service: "test-svc"
+              model: "test-model"
+              severity: critical
+              component: kserve
+              subsystem: maas
+            exp_annotations:
+              message: "Quota limit hit rate for model test-model in namespace test-ns is above 50% over the last 30 minutes. This indicates severe rate limiting that may require quota adjustment."
+              summary: "KServe/MaaS sustained quota limit hits (>50%)"

--- a/internal/controller/components/kserve/monitoring/kserve-prometheusrules.tmpl.yaml
+++ b/internal/controller/components/kserve/monitoring/kserve-prometheusrules.tmpl.yaml
@@ -84,3 +84,135 @@ spec:
           labels:
             instance: kserve-controller-manager
           record: probe_success:burnrate6h
+
+      - name: kserve-maas.rules
+        rules:
+          # 1) Recording rule: per-model QPS over 5 minutes
+          - record: kserve:maas_request_qps:rate5m
+            expr: |
+              sum by (namespace, service, model) (
+                rate(request_predict_seconds_count[5m])
+              )
+
+          # 2) Recording rule: authorized calls rate over 5 minutes
+          - record: kserve:maas_authorized_calls:rate5m
+            expr: |
+              sum by (namespace, service, model) (
+                rate(authorized_calls[5m])
+              )
+
+          # 3) Recording rule: authorized hits rate over 5 minutes
+          - record: kserve:maas_authorized_hits:rate5m
+            expr: |
+              sum by (namespace, service, model) (
+                rate(authorized_hits[5m])
+              )
+
+          # 4) Recording rule: limited calls rate over 5 minutes
+          - record: kserve:maas_limited_calls:rate5m
+            expr: |
+              sum by (namespace, service, model) (
+                rate(limited_calls[5m])
+              )
+
+          # 5) Recording rule: quota limit hit ratio (limited_calls / authorized_calls)
+          - record: kserve:maas_quota_limit_hit_ratio:rate5m
+            expr: |
+              (
+                sum by (namespace, service, model) (
+                  rate(limited_calls[5m])
+                )
+                /
+                sum by (namespace, service, model) (
+                  rate(authorized_calls[5m])
+                )
+              )
+
+          # 6) Alert: high prediction latency (p95 > 2s for 5m)
+          - alert: KServeMaaSHighLatencyP95
+            expr: |
+              histogram_quantile(
+                0.95,
+                sum by (le, namespace, service, model) (
+                  rate(request_predict_seconds_bucket[5m])
+                )
+              ) > 2
+            for: 5m
+            labels:
+              severity: warning
+              component: kserve
+              subsystem: maas
+            annotations:
+              message: '95th percentile prediction latency for model {{`{{`}}$labels.model{{`}}`}} in namespace {{`{{`}}$labels.namespace{{`}}`}} is above 2 seconds for at least 5 minutes.'
+              summary: "KServe/MaaS high prediction latency (p95 > 2s)"
+
+          # 7) Alert: high non-success response ratio (>5% for 10m)
+          - alert: KServeMaaSHighErrorRate
+            expr: |
+              (
+                sum by (namespace, service, model) (
+                  rate(request_predict_seconds_count{response_code!~"2..|3.."}[10m])
+                )
+                /
+                sum by (namespace, service, model) (
+                  rate(request_predict_seconds_count[10m])
+                )
+              ) > 0.05
+            for: 10m
+            labels:
+              severity: warning
+              component: kserve
+              subsystem: maas
+            annotations:
+              message: 'Error rate for model {{`{{`}}$labels.model{{`}}`}} in namespace {{`{{`}}$labels.namespace{{`}}`}} is above 5% over the last 10 minutes.'
+              summary: "KServe/MaaS high error rate (>5%)"
+
+          # 8) Alert: high quota limit hit rate (>10% for 10m)
+          - alert: KServeMaaSHighQuotaLimitHitRate
+            expr: |
+              (
+                sum by (namespace, service, model) (
+                  rate(limited_calls[10m])
+                )
+                /
+                sum by (namespace, service, model) (
+                  rate(authorized_calls[10m])
+                )
+              ) > 0.10
+              and
+              sum by (namespace, service, model) (
+                rate(authorized_calls[10m])
+              ) > 0
+            for: 10m
+            labels:
+              severity: warning
+              component: kserve
+              subsystem: maas
+            annotations:
+              message: 'Quota limit hit rate for model {{`{{`}}$labels.model{{`}}`}} in namespace {{`{{`}}$labels.namespace{{`}}`}} is above 10% over the last 10 minutes. This indicates requests are being rate-limited frequently.'
+              summary: "KServe/MaaS high quota limit hit rate (>10%)"
+
+          # 9) Alert: sustained quota limit hits (>50% for 30m)
+          - alert: KServeMaaSSustainedQuotaLimitHits
+            expr: |
+              (
+                sum by (namespace, service, model) (
+                  rate(limited_calls[30m])
+                )
+                /
+                sum by (namespace, service, model) (
+                  rate(authorized_calls[30m])
+                )
+              ) > 0.50
+              and
+              sum by (namespace, service, model) (
+                rate(authorized_calls[30m])
+              ) > 0
+            for: 30m
+            labels:
+              severity: critical
+              component: kserve
+              subsystem: maas
+            annotations:
+              message: 'Quota limit hit rate for model {{`{{`}}$labels.model{{`}}`}} in namespace {{`{{`}}$labels.namespace{{`}}`}} is above 50% over the last 30 minutes. This indicates severe rate limiting that may require quota adjustment.'
+              summary: "KServe/MaaS sustained quota limit hits (>50%)"


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->
Add recording and alerting rules for MaaS metrics (authorized_calls, authorized_hits, limited_calls) to monitor quota usage and rate limiting.

- Recording rules for authorized_calls, authorized_hits, limited_calls rates
- Recording rule for quota limit hit ratio
- Alert for high quota limit hit rate (>10% for 10m)
- Alert for sustained quota limit hits (>50% for 30m)

All rules aggregate by namespace, service, and model for per-model visibility.


<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->
Adding prometheus rules doesn't require a change to the e2e tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added five Prometheus recording rules computing 5‑minute rates for MaaS metrics (QPS, authorized calls, authorized hits, limited calls, quota‑hit ratio) and four alerts for high latency (p95), elevated error rates, short‑term quota spikes, and sustained quota‑limit issues, each with thresholds, durations, labels, and runbook guidance.

* **Tests**
  * Added unit tests covering quota‑hit scenarios: no‑alert, warning, and sustained critical alert cases.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->