### PR TITLE
Fix namespaces in Makefile for rhoai mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,8 @@ ifeq ($(ODH_PLATFORM_TYPE), OpenDataHub)
 	APPLICATIONS_NAMESPACE ?= opendatahub
 	# Specifies the namespace where the workbenches are deployed (defaults to opendatahub)
 	WORKBENCHES_NAMESPACE ?= opendatahub
+	# Specifies the namespace where monitoring is deployed (defaults to opendatahub)
+	MONITORING_NAMESPACE ?= opendatahub
 	CHANNELS ?= fast
 	ROLE_NAME=controller-manager-role
 	BUNDLE_DIR ?= odh-bundle
@@ -56,12 +58,14 @@ else
 	ifeq ($(VERSION), )
 		VERSION = 3.2.0
 	endif
-	# Specifies the namespace where the operator pods are deployed (defaults to opendatahub-operator-system)
-	OPERATOR_NAMESPACE ?= opendatahub-operator-system
-	# Specifies the namespace where the component deployments are deployed (defaults to opendatahub)
+	# Specifies the namespace where the operator pods are deployed (defaults to redhat-ods-operator)
+	OPERATOR_NAMESPACE ?= redhat-ods-operator
+	# Specifies the namespace where the component deployments are deployed (defaults to redhat-ods-applications)
 	APPLICATIONS_NAMESPACE ?= redhat-ods-applications
-	# Specifies the namespace where the workbenches are deployed (defaults to opendatahub)
+	# Specifies the namespace where the workbenches are deployed (defaults to rhods-notebooks)
 	WORKBENCHES_NAMESPACE ?= rhods-notebooks
+	# Specifies the namespace where monitoring is deployed (defaults to redhat-ods-monitoring)
+	MONITORING_NAMESPACE ?= redhat-ods-monitoring
 	CHANNELS ?= alpha,stable,fast
 	DEFAULT_CHANNEL ?= stable
 	ROLE_NAME=rhods-operator-role
@@ -615,6 +619,10 @@ endif
 # Specifies the namespace where the workbenches are deployed
 ifndef E2E_TEST_WORKBENCHES_NAMESPACE
 export E2E_TEST_WORKBENCHES_NAMESPACE = $(WORKBENCHES_NAMESPACE)
+endif
+# Specifies the namespace where monitoring is deployed
+ifndef E2E_TEST_MONITORING_NAMESPACE
+export E2E_TEST_MONITORING_NAMESPACE = $(MONITORING_NAMESPACE)
 endif
 ifdef ARTIFACT_DIR
 export JUNIT_OUTPUT_PATH = ${ARTIFACT_DIR}/junit_report.xml


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [x] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->
build change only

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated default deployment namespaces for operator, applications, and workbench components to new platform-specific defaults.
  * Added a configurable monitoring namespace with environment-specific defaults.
  * Exported a monitoring namespace variable for end-to-end test environments so tests use the configured monitoring namespace.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->