### PR TITLE
Rhoaieng 29719 | feat: cluster view of metrics via kube-rbac-proxy

### DIFF
--- a/internal/controller/services/monitoring/monitoring_controller.go
+++ b/internal/controller/services/monitoring/monitoring_controller.go
@@ -98,6 +98,7 @@ func (h *serviceHandler) NewReconciler(ctx context.Context, mgr ctrl.Manager) er
 		Owns(&appsv1.Deployment{}).
 		Owns(&batchv1.Job{}).
 		Owns(&corev1.ConfigMap{}).
+		Owns(&corev1.Secret{}).
 		Owns(&corev1.Service{}).
 		Owns(&corev1.ServiceAccount{}).
 		// operands - openshift
@@ -156,6 +157,7 @@ func (h *serviceHandler) NewReconciler(ctx context.Context, mgr ctrl.Manager) er
 		WithAction(deployPerses).
 		WithAction(deployPersesTempoIntegration).
 		WithAction(deployPersesPrometheusIntegration).
+		WithAction(deployNodeMetricsEndpoint).
 		WithAction(template.NewAction(
 			template.WithDataFn(getTemplateData),
 		)).

--- a/internal/controller/services/monitoring/monitoring_controller_support_test.go
+++ b/internal/controller/services/monitoring/monitoring_controller_support_test.go
@@ -884,7 +884,7 @@ func TestMonitoringStackThanosQuerierIntegration(t *testing.T) {
 			expectedTQConditionStatus: "True",
 			expectedMSTemplates:       8, // MonitoringStack + Alertmanager RBAC + PrometheusRoute +
 			// PrometheusServiceOverride + PrometheusNetworkPolicy + PrometheusWebTLSService +
-			// PrometheusRestricted + PrometheusRestrictedNetworkPolicy
+			// PrometheusNamespaceProxy + PrometheusNamespaceProxyNetworkPolicy
 			expectedTQTemplates: 2, // ThanosQuerier + ThanosQuerierRoute
 			description:         "When both CRDs are available and metrics configured, both should be deployed",
 		},

--- a/internal/controller/services/monitoring/node_metrics_test.go
+++ b/internal/controller/services/monitoring/node_metrics_test.go
@@ -1,0 +1,119 @@
+//nolint:testpackage // Need to test unexported function deployNodeMetricsEndpoint
+package monitoring
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	dsciv1 "github.com/opendatahub-io/opendatahub-operator/v2/api/dscinitialization/v1"
+	serviceApi "github.com/opendatahub-io/opendatahub-operator/v2/api/services/v1alpha1"
+	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/status"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/conditions"
+	odhtypes "github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
+)
+
+func TestDeployNodeMetricsEndpoint(t *testing.T) {
+	ctx := t.Context()
+
+	tests := []struct {
+		name                    string
+		hasMetricsConfig        bool
+		expectedCondition       bool
+		expectedTemplateCount   int
+		expectedConditionReason string
+	}{
+		{
+			name:                    "with metrics config",
+			hasMetricsConfig:        true,
+			expectedCondition:       true,
+			expectedTemplateCount:   1, // PrometheusClusterProxyTemplate only
+			expectedConditionReason: "",
+		},
+		{
+			name:                    "without metrics config",
+			hasMetricsConfig:        false,
+			expectedCondition:       false,
+			expectedTemplateCount:   0,
+			expectedConditionReason: status.MetricsNotConfiguredReason,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create Monitoring object
+			monitoring := &serviceApi.Monitoring{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "default-monitoring",
+					Namespace: "test-namespace",
+				},
+				Spec: serviceApi.MonitoringSpec{
+					MonitoringCommonSpec: serviceApi.MonitoringCommonSpec{
+						Namespace: "test-namespace",
+					},
+				},
+			}
+
+			// Add metrics config if required
+			if tt.hasMetricsConfig {
+				monitoring.Spec.Metrics = &serviceApi.Metrics{
+					Replicas: 1,
+				}
+			}
+
+			// Create fake client
+			scheme := runtime.NewScheme()
+			require.NoError(t, dsciv1.AddToScheme(scheme))
+			require.NoError(t, serviceApi.AddToScheme(scheme))
+
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(monitoring).
+				Build()
+
+			// Create reconciliation request
+			rr := &odhtypes.ReconciliationRequest{
+				Client:     fakeClient,
+				Instance:   monitoring,
+				Templates:  []odhtypes.TemplateInfo{},
+				Conditions: conditions.NewManager(monitoring, status.ConditionTypeReady),
+			}
+
+			// Test deployNodeMetricsEndpoint function
+			err := deployNodeMetricsEndpoint(ctx, rr)
+			require.NoError(t, err)
+
+			// Verify template count
+			assert.Len(t, rr.Templates, tt.expectedTemplateCount)
+
+			// Verify condition
+			condition := conditions.FindStatusCondition(rr.Instance, status.ConditionNodeMetricsEndpointAvailable)
+			require.NotNil(t, condition)
+
+			if tt.expectedCondition {
+				assert.Equal(t, metav1.ConditionTrue, condition.Status)
+			} else {
+				assert.Equal(t, metav1.ConditionFalse, condition.Status)
+				assert.Equal(t, tt.expectedConditionReason, condition.Reason)
+			}
+
+			// If templates are expected, verify they contain the right paths
+			if tt.expectedTemplateCount > 0 {
+				templatePaths := make([]string, len(rr.Templates))
+				for i, template := range rr.Templates {
+					templatePaths[i] = template.Path
+				}
+				assert.Contains(t, templatePaths, PrometheusClusterProxyTemplate)
+			}
+		})
+	}
+}
+
+func TestNodeMetricsEndpointTemplateConstants(t *testing.T) {
+	// Verify that the template constants are properly defined
+	assert.Equal(t, "resources/data-science-prometheus-cluster-proxy.tmpl.yaml", PrometheusClusterProxyTemplate)
+}

--- a/internal/controller/services/monitoring/resources/data-science-prometheus-cluster-proxy.tmpl.yaml
+++ b/internal/controller/services/monitoring/resources/data-science-prometheus-cluster-proxy.tmpl.yaml
@@ -1,0 +1,202 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: data-science-prometheus-cluster-proxy
+  namespace: {{.Namespace}}
+  labels:
+    app: data-science-prometheus-cluster-proxy
+    platform.opendatahub.io/part-of: monitoring
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: data-science-prometheus-cluster-proxy
+  labels:
+    platform.opendatahub.io/part-of: monitoring
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-monitoring-view
+subjects:
+  - kind: ServiceAccount
+    name: data-science-prometheus-cluster-proxy
+    namespace: {{.Namespace}}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: data-science-prometheus-cluster-proxy-auth-delegator
+  labels:
+    platform.opendatahub.io/part-of: monitoring
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:auth-delegator
+subjects:
+  - kind: ServiceAccount
+    name: data-science-prometheus-cluster-proxy
+    namespace: {{.Namespace}}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: data-science-prometheus-cluster-proxy-kube-rbac-proxy
+  namespace: {{.Namespace}}
+  labels:
+    app: data-science-prometheus-cluster-proxy
+    platform.opendatahub.io/part-of: monitoring
+type: Opaque
+data: {}
+stringData:
+  config.yaml: |
+    authorization:
+      resourceAttributes:
+        apiGroup: metrics.k8s.io
+        resource: nodes
+        verb: get
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: data-science-prometheus-cluster-proxy
+  namespace: {{.Namespace}}
+  labels:
+    app: data-science-prometheus-cluster-proxy
+    platform.opendatahub.io/part-of: monitoring
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: data-science-prometheus-cluster-proxy
+  template:
+    metadata:
+      labels:
+        app: data-science-prometheus-cluster-proxy
+    spec:
+      serviceAccountName: data-science-prometheus-cluster-proxy
+      containers:
+        # kube-rbac-proxy for authentication and authorization based on NodeMetrics access
+        - name: kube-rbac-proxy
+          image: {{.KubeRBACProxyImage}}
+          args:
+            - --secure-listen-address=0.0.0.0:8443
+            - --upstream=https://prometheus-operated.{{.Namespace}}.svc:9090
+            - --config-file=/etc/kube-rbac-proxy/config.yaml
+            - --tls-cert-file=/etc/tls/private/tls.crt
+            - --tls-private-key-file=/etc/tls/private/tls.key
+            - --upstream-ca-file=/etc/prometheus-ca/service-ca.crt
+            - --upstream-client-cert-file=/etc/prometheus-client/tls.crt
+            - --upstream-client-key-file=/etc/prometheus-client/tls.key
+            - --logtostderr=true
+            - --v=1
+            # Allow only metrics endpoint
+            - --allow-paths=/metrics
+          ports:
+            - containerPort: 8443
+              name: https
+              protocol: TCP
+          resources:
+            limits:
+              cpu: 20m
+              memory: 40Mi
+            requests:
+              cpu: 10m
+              memory: 20Mi
+          terminationMessagePolicy: FallbackToLogsOnError
+          volumeMounts:
+            - name: kube-rbac-proxy-config
+              mountPath: /etc/kube-rbac-proxy
+              readOnly: true
+            - name: tls
+              mountPath: /etc/tls/private
+              readOnly: true
+            - name: prometheus-ca
+              mountPath: /etc/prometheus-ca
+              readOnly: true
+            - name: prometheus-client-cert
+              mountPath: /etc/prometheus-client
+              readOnly: true
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+          livenessProbe:
+            tcpSocket:
+              port: 8443
+            initialDelaySeconds: 5
+            periodSeconds: 30
+            failureThreshold: 4
+          readinessProbe:
+            tcpSocket:
+              port: 8443
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            failureThreshold: 20
+      volumes:
+        - name: kube-rbac-proxy-config
+          secret:
+            secretName: data-science-prometheus-cluster-proxy-kube-rbac-proxy
+        - name: tls
+          secret:
+            secretName: data-science-prometheus-cluster-proxy-tls
+        - name: prometheus-ca
+          configMap:
+            name: prometheus-web-tls-ca
+        - name: prometheus-client-cert
+          secret:
+            secretName: prometheus-operated-tls
+      nodeSelector:
+        kubernetes.io/os: linux
+      securityContext:
+        runAsNonRoot: true
+      tolerations:
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/master
+          operator: Exists
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/control-plane
+          operator: Exists
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: data-science-prometheus-cluster-proxy
+  namespace: {{.Namespace}}
+  labels:
+    app: data-science-prometheus-cluster-proxy
+    platform.opendatahub.io/part-of: monitoring
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: data-science-prometheus-cluster-proxy-tls
+spec:
+  type: ClusterIP
+  ports:
+    - name: https
+      port: 8443
+      protocol: TCP
+      targetPort: https
+  selector:
+    app: data-science-prometheus-cluster-proxy
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: data-science-prometheus-cluster-proxy
+  namespace: {{.Namespace}}
+  labels:
+    app: data-science-prometheus-cluster-proxy
+    platform.opendatahub.io/part-of: monitoring
+spec:
+  to:
+    kind: Service
+    name: data-science-prometheus-cluster-proxy
+    weight: 100
+  port:
+    targetPort: https
+  tls:
+    termination: reencrypt
+    insecureEdgeTerminationPolicy: Redirect
+  wildcardPolicy: None

--- a/internal/controller/services/monitoring/resources/data-science-prometheus-namespace-proxy-network-policy.tmpl.yaml
+++ b/internal/controller/services/monitoring/resources/data-science-prometheus-namespace-proxy-network-policy.tmpl.yaml
@@ -16,7 +16,7 @@ metadata:
 spec:
   podSelector:
     matchLabels:
-      app: data-science-prometheus-restricted
+      app: data-science-prometheus-namespace-proxy
   policyTypes:
     - Ingress
   ingress:

--- a/internal/controller/services/monitoring/resources/data-science-prometheus-namespace-proxy.tmpl.yaml
+++ b/internal/controller/services/monitoring/resources/data-science-prometheus-namespace-proxy.tmpl.yaml
@@ -2,16 +2,16 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: data-science-prometheus-restricted
+  name: data-science-prometheus-namespace-proxy
   namespace: {{.Namespace}}
   labels:
-    app: data-science-prometheus-restricted
+    app: data-science-prometheus-namespace-proxy
     platform.opendatahub.io/part-of: monitoring
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: data-science-prometheus-restricted
+  name: data-science-prometheus-namespace-proxy
   labels:
     platform.opendatahub.io/part-of: monitoring
 roleRef:
@@ -20,13 +20,13 @@ roleRef:
   name: cluster-monitoring-view
 subjects:
   - kind: ServiceAccount
-    name: data-science-prometheus-restricted
+    name: data-science-prometheus-namespace-proxy
     namespace: {{.Namespace}}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: data-science-prometheus-restricted-auth-delegator
+  name: data-science-prometheus-namespace-proxy-auth-delegator
   labels:
     platform.opendatahub.io/part-of: monitoring
 roleRef:
@@ -35,16 +35,16 @@ roleRef:
   name: system:auth-delegator
 subjects:
   - kind: ServiceAccount
-    name: data-science-prometheus-restricted
+    name: data-science-prometheus-namespace-proxy
     namespace: {{.Namespace}}
 ---
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: data-science-prometheus-restricted-config
+  name: data-science-prometheus-namespace-proxy-config
   namespace: {{.Namespace}}
   labels:
-    app: data-science-prometheus-restricted
+    app: data-science-prometheus-namespace-proxy
     platform.opendatahub.io/part-of: monitoring
 data:
   kube-rbac-proxy.yaml: |
@@ -65,22 +65,22 @@ data:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: data-science-prometheus-restricted
+  name: data-science-prometheus-namespace-proxy
   namespace: {{.Namespace}}
   labels:
-    app: data-science-prometheus-restricted
+    app: data-science-prometheus-namespace-proxy
     platform.opendatahub.io/part-of: monitoring
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: data-science-prometheus-restricted
+      app: data-science-prometheus-namespace-proxy
   template:
     metadata:
       labels:
-        app: data-science-prometheus-restricted
+        app: data-science-prometheus-namespace-proxy
     spec:
-      serviceAccountName: data-science-prometheus-restricted
+      serviceAccountName: data-science-prometheus-namespace-proxy
       containers:
         # kube-rbac-proxy for authentication and authorization
         - name: kube-rbac-proxy
@@ -156,10 +156,10 @@ spec:
       volumes:
         - name: config
           configMap:
-            name: data-science-prometheus-restricted-config
+            name: data-science-prometheus-namespace-proxy-config
         - name: tls
           secret:
-            secretName: data-science-prometheus-restricted-tls
+            secretName: data-science-prometheus-namespace-proxy-tls
         - name: client-ca
           configMap:
             name: prometheus-client-ca
@@ -178,13 +178,13 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: data-science-prometheus-restricted
+  name: data-science-prometheus-namespace-proxy
   namespace: {{.Namespace}}
   labels:
-    app: data-science-prometheus-restricted
+    app: data-science-prometheus-namespace-proxy
     platform.opendatahub.io/part-of: monitoring
   annotations:
-    service.beta.openshift.io/serving-cert-secret-name: data-science-prometheus-restricted-tls
+    service.beta.openshift.io/serving-cert-secret-name: data-science-prometheus-namespace-proxy-tls
 spec:
   type: ClusterIP
   ports:
@@ -193,4 +193,4 @@ spec:
       protocol: TCP
       targetPort: https
   selector:
-    app: data-science-prometheus-restricted
+    app: data-science-prometheus-namespace-proxy

--- a/internal/controller/services/monitoring/resources/data-science-prometheus-network-policy.tmpl.yaml
+++ b/internal/controller/services/monitoring/resources/data-science-prometheus-network-policy.tmpl.yaml
@@ -17,7 +17,10 @@ spec:
     - from:
         - podSelector:
             matchLabels:
-              app: data-science-prometheus-restricted
+              app: data-science-prometheus-namespace-proxy
+        - podSelector:
+            matchLabels:
+              app: data-science-prometheus-cluster-proxy
       ports:
         - protocol: TCP
           port: 9090

--- a/internal/controller/services/monitoring/resources/data-science-prometheus-route.tmpl.yaml
+++ b/internal/controller/services/monitoring/resources/data-science-prometheus-route.tmpl.yaml
@@ -4,13 +4,13 @@ metadata:
   name: data-science-prometheus-route
   namespace: {{.Namespace}}
   labels:
-    app: data-science-prometheus-restricted
+    app: data-science-prometheus-namespace-proxy
     platform.opendatahub.io/part-of: monitoring
 spec:
   path: /
   to:
     kind: Service
-    name: data-science-prometheus-restricted
+    name: data-science-prometheus-namespace-proxy
     weight: 100
   port:
     targetPort: https

--- a/internal/controller/services/monitoring/resources/data-science-prometheus-service-override.tmpl.yaml
+++ b/internal/controller/services/monitoring/resources/data-science-prometheus-service-override.tmpl.yaml
@@ -2,10 +2,10 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: data-science-prometheus-restricted-service
+  name: data-science-prometheus-namespace-proxy-service
   namespace: {{.Namespace}}
   labels:
-    app: data-science-prometheus-restricted
+    app: data-science-prometheus-namespace-proxy
     platform.opendatahub.io/part-of: monitoring
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: data-science-monitoringstack
@@ -13,7 +13,7 @@ metadata:
     monitoring.opendatahub.io/secure-proxy: "true"
     monitoring.opendatahub.io/secure-proxy-version: "v2"
     monitoring.opendatahub.io/tls-enforced: "true"
-    service.beta.openshift.io/serving-cert-secret-name: data-science-prometheus-restricted-service-tls
+    service.beta.openshift.io/serving-cert-secret-name: data-science-prometheus-namespace-proxy-service-tls
 spec:
   type: ClusterIP
   ports:
@@ -22,4 +22,4 @@ spec:
       protocol: TCP
       targetPort: https # Points to the secure proxy port 8443
   selector:
-    app: data-science-prometheus-restricted
+    app: data-science-prometheus-namespace-proxy

--- a/internal/controller/status/status.go
+++ b/internal/controller/status/status.go
@@ -91,6 +91,7 @@ const (
 	ConditionPersesAvailable                     = "PersesAvailable"
 	ConditionPersesTempoDataSourceAvailable      = "PersesTempoDataSourceAvailable"
 	ConditionPersesPrometheusDataSourceAvailable = "PersesPrometheusDataSourceAvailable"
+	ConditionNodeMetricsEndpointAvailable        = "NodeMetricsEndpointAvailable"
 )
 
 const (

--- a/tests/e2e/monitoring_test.go
+++ b/tests/e2e/monitoring_test.go
@@ -124,6 +124,8 @@ func monitoringTestSuite(t *testing.T) {
 		{"Validate monitoring service disabled", monitoringServiceCtx.ValidateMonitoringServiceDisabled},
 		{"Test Namespace Restricted Metrics Access", monitoringServiceCtx.ValidatePrometheusRestrictedResourceConfiguration},
 		{"Test Prometheus Secure Proxy Authentication", monitoringServiceCtx.ValidatePrometheusSecureProxyAuthentication},
+		{"Test Node Metrics Endpoint Deployment", monitoringServiceCtx.ValidateNodeMetricsEndpointDeployment},
+		{"Test Node Metrics Endpoint RBAC Configuration", monitoringServiceCtx.ValidateNodeMetricsEndpointRBACConfiguration},
 	}
 
 	// Run the test suite.
@@ -1480,7 +1482,7 @@ func (tc *MonitoringTestCtx) ValidatePersesDatasourceConfiguration(t *testing.T)
 	)
 }
 
-func (tc *MonitoringTestCtx) waitForPrometheusRestrictedPrerequisites(t *testing.T, namespace string) {
+func (tc *MonitoringTestCtx) waitForPrometheusNamespaceProxyPrerequisites(t *testing.T, namespace string) {
 	t.Helper()
 
 	// 1. Wait for MonitoringStack CRD to exist and be established (required by controller)
@@ -1494,39 +1496,39 @@ func (tc *MonitoringTestCtx) waitForPrometheusRestrictedPrerequisites(t *testing
 			Namespace: namespace,
 		}),
 		WithCondition(jq.Match(`.status.conditions[] | select(.type == "Available") | .status == "True"`)),
-		WithCustomErrorMsg("MonitoringStack should be Available before prometheus-restricted deployment"),
+		WithCustomErrorMsg("MonitoringStack should be Available before prometheus-namespace-proxy deployment"),
 	)
 
 	t.Logf("MonitoringStack CR is Available")
 
-	t.Logf("All prerequisites met for prometheus-restricted deployment")
+	t.Logf("All prerequisites met for prometheus-namespace-proxy deployment")
 }
 
-// validatePrometheusRestrictedResourcesCommon validates common data-science-prometheus-restricted resources that are shared between tests.
-func (tc *MonitoringTestCtx) validatePrometheusRestrictedResourcesCommon(t *testing.T, namespace string) {
+// validatePrometheusNamespaceProxyResourcesCommon validates common data-science-prometheus-namespace-proxy resources that are shared between tests.
+func (tc *MonitoringTestCtx) validatePrometheusNamespaceProxyResourcesCommon(t *testing.T, namespace string) {
 	t.Helper()
 
 	// Wait for prerequisites before checking deployment
-	// The controller only deploys prometheus-restricted when MonitoringStack is available
-	tc.waitForPrometheusRestrictedPrerequisites(t, namespace)
+	// The controller only deploys prometheus-namespace-proxy when MonitoringStack is available
+	tc.waitForPrometheusNamespaceProxyPrerequisites(t, namespace)
 
-	// Verify the data-science-prometheus-restricted deployment is created
+	// Verify the data-science-prometheus-namespace-proxy deployment is created
 	tc.EnsureResourceExists(
 		WithMinimalObject(gvk.Deployment, types.NamespacedName{
-			Name:      "data-science-prometheus-restricted",
+			Name:      "data-science-prometheus-namespace-proxy",
 			Namespace: namespace,
 		}),
 		WithCondition(And(
 			jq.Match(`.status.readyReplicas == 1`),
 			jq.Match(`.spec.template.spec.containers | length == 2`), // kube-rbac-proxy + prom-label-proxy
 		)),
-		WithCustomErrorMsg("data-science-prometheus-restricted deployment should be created and ready"),
+		WithCustomErrorMsg("data-science-prometheus-namespace-proxy deployment should be created and ready"),
 	)
 
 	// Verify the service account exists with proper RBAC
 	tc.EnsureResourceExists(
 		WithMinimalObject(gvk.ServiceAccount, types.NamespacedName{
-			Name:      "data-science-prometheus-restricted",
+			Name:      "data-science-prometheus-namespace-proxy",
 			Namespace: namespace,
 		}),
 	)
@@ -1534,11 +1536,11 @@ func (tc *MonitoringTestCtx) validatePrometheusRestrictedResourcesCommon(t *test
 	// Verify the ClusterRoleBinding exists for prometheus metrics reader
 	tc.EnsureResourceExists(
 		WithMinimalObject(gvk.ClusterRoleBinding, types.NamespacedName{
-			Name: "data-science-prometheus-restricted",
+			Name: "data-science-prometheus-namespace-proxy",
 		}),
 		WithCondition(And(
 			jq.Match(`.roleRef.name == "cluster-monitoring-view"`),
-			jq.Match(`.subjects[0].name == "data-science-prometheus-restricted"`),
+			jq.Match(`.subjects[0].name == "data-science-prometheus-namespace-proxy"`),
 			jq.Match(`.subjects[0].namespace == "%s"`, namespace),
 		)),
 	)
@@ -1546,13 +1548,13 @@ func (tc *MonitoringTestCtx) validatePrometheusRestrictedResourcesCommon(t *test
 	// Verify the service is created with proper annotations for TLS
 	tc.EnsureResourceExists(
 		WithMinimalObject(gvk.Service, types.NamespacedName{
-			Name:      "data-science-prometheus-restricted",
+			Name:      "data-science-prometheus-namespace-proxy",
 			Namespace: namespace,
 		}),
 		WithCondition(And(
 			jq.Match(`.spec.ports[0].port == 8443`),
 			jq.Match(`.spec.ports[0].name == "https"`),
-			jq.Match(`.metadata.annotations."service.beta.openshift.io/serving-cert-secret-name" == "data-science-prometheus-restricted-tls"`),
+			jq.Match(`.metadata.annotations."service.beta.openshift.io/serving-cert-secret-name" == "data-science-prometheus-namespace-proxy-tls"`),
 		)),
 	)
 
@@ -1563,7 +1565,7 @@ func (tc *MonitoringTestCtx) validatePrometheusRestrictedResourcesCommon(t *test
 			Namespace: namespace,
 		}),
 		WithCondition(And(
-			jq.Match(`.spec.to.name == "data-science-prometheus-restricted"`),
+			jq.Match(`.spec.to.name == "data-science-prometheus-namespace-proxy"`),
 			jq.Match(`.spec.tls.termination == "reencrypt"`),
 			jq.Match(`.spec.tls.insecureEdgeTerminationPolicy == "Redirect"`),
 		)),
@@ -1585,8 +1587,8 @@ func (tc *MonitoringTestCtx) ValidatePrometheusRestrictedResourceConfiguration(t
 		)),
 	)
 
-	// Validate common data-science-prometheus-restricted resources
-	tc.validatePrometheusRestrictedResourcesCommon(t, dsci.Spec.Monitoring.Namespace)
+	// Validate common data-science-prometheus-namespace-proxy resources
+	tc.validatePrometheusNamespaceProxyResourcesCommon(t, dsci.Spec.Monitoring.Namespace)
 }
 
 // ValidatePrometheusSecureProxyAuthentication tests the Prometheus secure proxy authentication and authorization.
@@ -1595,30 +1597,30 @@ func (tc *MonitoringTestCtx) ValidatePrometheusSecureProxyAuthentication(t *test
 
 	dsci := tc.FetchDSCInitialization()
 
-	// Validate common data-science-prometheus-restricted resources
-	tc.validatePrometheusRestrictedResourcesCommon(t, dsci.Spec.Monitoring.Namespace)
+	// Validate common data-science-prometheus-namespace-proxy resources
+	tc.validatePrometheusNamespaceProxyResourcesCommon(t, dsci.Spec.Monitoring.Namespace)
 
-	// Verify the data-science-prometheus-restricted deployment contains kube-rbac-proxy with specific details
+	// Verify the data-science-prometheus-namespace-proxy deployment contains kube-rbac-proxy with specific details
 	tc.EnsureResourceExists(
 		WithMinimalObject(gvk.Deployment, types.NamespacedName{
-			Name:      "data-science-prometheus-restricted",
+			Name:      "data-science-prometheus-namespace-proxy",
 			Namespace: dsci.Spec.Monitoring.Namespace,
 		}),
 		WithCondition(And(
 			jq.Match(`.spec.template.spec.containers[0].name == "kube-rbac-proxy"`),
 			jq.Match(`.spec.template.spec.containers[0].image | contains("kube-rbac-proxy")`),
 		)),
-		WithCustomErrorMsg("data-science-prometheus-restricted deployment should contain kube-rbac-proxy container"),
+		WithCustomErrorMsg("data-science-prometheus-namespace-proxy deployment should contain kube-rbac-proxy container"),
 	)
 
 	// Verify the auth-delegator ClusterRoleBinding exists
 	tc.EnsureResourceExists(
 		WithMinimalObject(gvk.ClusterRoleBinding, types.NamespacedName{
-			Name: "data-science-prometheus-restricted-auth-delegator",
+			Name: "data-science-prometheus-namespace-proxy-auth-delegator",
 		}),
 		WithCondition(And(
 			jq.Match(`.roleRef.name == "system:auth-delegator"`),
-			jq.Match(`.subjects[0].name == "data-science-prometheus-restricted"`),
+			jq.Match(`.subjects[0].name == "data-science-prometheus-namespace-proxy"`),
 			jq.Match(`.subjects[0].namespace == "%s"`, dsci.Spec.Monitoring.Namespace),
 		)),
 	)
@@ -1626,7 +1628,7 @@ func (tc *MonitoringTestCtx) ValidatePrometheusSecureProxyAuthentication(t *test
 	// Verify the ConfigMap for kube-rbac-proxy configuration exists
 	tc.EnsureResourceExists(
 		WithMinimalObject(gvk.ConfigMap, types.NamespacedName{
-			Name:      "data-science-prometheus-restricted-config",
+			Name:      "data-science-prometheus-namespace-proxy-config",
 			Namespace: dsci.Spec.Monitoring.Namespace,
 		}),
 		WithCondition(jq.Match(`.data."kube-rbac-proxy.yaml" | contains("authorization")`)),
@@ -1635,7 +1637,7 @@ func (tc *MonitoringTestCtx) ValidatePrometheusSecureProxyAuthentication(t *test
 	// Verify that the kube-rbac-proxy container has the correct upstream configuration
 	tc.EnsureResourceExists(
 		WithMinimalObject(gvk.Deployment, types.NamespacedName{
-			Name:      "data-science-prometheus-restricted",
+			Name:      "data-science-prometheus-namespace-proxy",
 			Namespace: dsci.Spec.Monitoring.Namespace,
 		}),
 		WithCondition(And(
@@ -1649,12 +1651,179 @@ func (tc *MonitoringTestCtx) ValidatePrometheusSecureProxyAuthentication(t *test
 	// Verify that the auth-delegator ClusterRoleBinding exists (uses built-in system:auth-delegator ClusterRole)
 	tc.EnsureResourceExists(
 		WithMinimalObject(gvk.ClusterRoleBinding, types.NamespacedName{
-			Name: "data-science-prometheus-restricted-auth-delegator",
+			Name: "data-science-prometheus-namespace-proxy-auth-delegator",
 		}),
 		WithCondition(And(
 			jq.Match(`.roleRef.name == "system:auth-delegator"`),
-			jq.Match(`.subjects[0].name == "data-science-prometheus-restricted"`),
+			jq.Match(`.subjects[0].name == "data-science-prometheus-namespace-proxy"`),
 		)),
 		WithCustomErrorMsg("ClusterRoleBinding should reference system:auth-delegator for authentication and authorization"),
+	)
+}
+
+// ValidateNodeMetricsEndpointDeployment tests that the node-metrics-endpoint is deployed when metrics are configured.
+func (tc *MonitoringTestCtx) ValidateNodeMetricsEndpointDeployment(t *testing.T) {
+	t.Helper()
+
+	dsci := tc.FetchDSCInitialization()
+
+	// Ensure metrics are configured
+	tc.updateMonitoringConfig(
+		withManagementState(operatorv1.Managed),
+		tc.withMetricsConfig(),
+	)
+
+	// Wait for the Monitoring resource to be updated
+	tc.EnsureResourceExists(
+		WithMinimalObject(gvk.Monitoring, types.NamespacedName{Name: MonitoringCRName}),
+		WithCondition(And(
+			jq.Match(`.spec.metrics != null`),
+			jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, status.ConditionTypeReady, metav1.ConditionTrue),
+			jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, status.ConditionNodeMetricsEndpointAvailable, metav1.ConditionTrue),
+		)),
+		WithCustomErrorMsg("Monitoring resource should be updated with metrics configuration and NodeMetricsEndpoint should be available"),
+	)
+
+	// Verify the data-science-prometheus-cluster-proxy deployment is created
+	tc.EnsureResourceExists(
+		WithMinimalObject(gvk.Deployment, types.NamespacedName{
+			Name:      "data-science-prometheus-cluster-proxy",
+			Namespace: dsci.Spec.Monitoring.Namespace,
+		}),
+		WithCondition(And(
+			jq.Match(`.status.readyReplicas == 1`),
+			jq.Match(`.spec.template.spec.containers | length == 1`), // kube-rbac-proxy only
+			jq.Match(`.spec.template.spec.containers[0].name == "kube-rbac-proxy"`),
+		)),
+		WithCustomErrorMsg("data-science-prometheus-cluster-proxy deployment should be created and ready with kube-rbac-proxy"),
+	)
+
+	// Verify the service account exists
+	tc.EnsureResourceExists(
+		WithMinimalObject(gvk.ServiceAccount, types.NamespacedName{
+			Name:      "data-science-prometheus-cluster-proxy",
+			Namespace: dsci.Spec.Monitoring.Namespace,
+		}),
+	)
+
+	// Verify the service is created with proper annotations for TLS
+	tc.EnsureResourceExists(
+		WithMinimalObject(gvk.Service, types.NamespacedName{
+			Name:      "data-science-prometheus-cluster-proxy",
+			Namespace: dsci.Spec.Monitoring.Namespace,
+		}),
+		WithCondition(And(
+			jq.Match(`.spec.ports[0].port == 8443`),
+			jq.Match(`.spec.ports[0].name == "https"`),
+			jq.Match(`.metadata.annotations."service.beta.openshift.io/serving-cert-secret-name" == "data-science-prometheus-cluster-proxy-tls"`),
+		)),
+	)
+
+	// Verify the route is created for external access
+	tc.EnsureResourceExists(
+		WithMinimalObject(gvk.Route, types.NamespacedName{
+			Name:      "data-science-prometheus-cluster-proxy",
+			Namespace: dsci.Spec.Monitoring.Namespace,
+		}),
+		WithCondition(And(
+			jq.Match(`.spec.to.name == "data-science-prometheus-cluster-proxy"`),
+			jq.Match(`.spec.tls.termination == "reencrypt"`),
+			jq.Match(`.spec.tls.insecureEdgeTerminationPolicy == "Redirect"`),
+		)),
+	)
+}
+
+func (tc *MonitoringTestCtx) ValidateNodeMetricsEndpointRBACConfiguration(t *testing.T) {
+	t.Helper()
+
+	dsci := tc.FetchDSCInitialization()
+
+	tc.updateMonitoringConfig(
+		withManagementState(operatorv1.Managed),
+		tc.withMetricsConfig(),
+	)
+
+	tc.EnsureResourceExists(
+		WithMinimalObject(gvk.ClusterRoleBinding, types.NamespacedName{
+			Name: "data-science-prometheus-cluster-proxy",
+		}),
+		WithCondition(And(
+			jq.Match(`.roleRef.name == "cluster-monitoring-view"`),
+			jq.Match(`.subjects[0].name == "data-science-prometheus-cluster-proxy"`),
+			jq.Match(`.subjects[0].namespace == "%s"`, dsci.Spec.Monitoring.Namespace),
+		)),
+		WithCustomErrorMsg("ClusterRoleBinding should use cluster-monitoring-view role for NodeMetrics access"),
+	)
+
+	// Verify the auth-delegator ClusterRoleBinding exists
+	tc.EnsureResourceExists(
+		WithMinimalObject(gvk.ClusterRoleBinding, types.NamespacedName{
+			Name: "data-science-prometheus-cluster-proxy-auth-delegator",
+		}),
+		WithCondition(And(
+			jq.Match(`.roleRef.name == "system:auth-delegator"`),
+			jq.Match(`.subjects[0].name == "data-science-prometheus-cluster-proxy"`),
+			jq.Match(`.subjects[0].namespace == "%s"`, dsci.Spec.Monitoring.Namespace),
+		)),
+	)
+
+	// Verify the Secret for kube-rbac-proxy configuration exists with correct resourceAttributes
+	tc.EnsureResourceExists(
+		WithMinimalObject(gvk.Secret, types.NamespacedName{
+			Name:      "data-science-prometheus-cluster-proxy-kube-rbac-proxy",
+			Namespace: dsci.Spec.Monitoring.Namespace,
+		}),
+		WithCondition(And(
+			jq.Match(`.data."config.yaml" | @base64d | contains("authorization")`),
+			jq.Match(`.data."config.yaml" | @base64d | contains("metrics.k8s.io")`),
+			jq.Match(`.data."config.yaml" | @base64d | contains("resource: nodes")`),
+		)),
+		WithCustomErrorMsg("kube-rbac-proxy config should enforce NodeMetrics access (metrics.k8s.io/nodes)"),
+	)
+
+	// Verify that the kube-rbac-proxy container has the correct upstream configuration
+	tc.EnsureResourceExists(
+		WithMinimalObject(gvk.Deployment, types.NamespacedName{
+			Name:      "data-science-prometheus-cluster-proxy",
+			Namespace: dsci.Spec.Monitoring.Namespace,
+		}),
+		WithCondition(And(
+			jq.Match(`.spec.template.spec.containers[0].args | map(select(contains("--upstream="))) | length == 1`),
+			jq.Match(`.spec.template.spec.containers[0].args | map(select(contains("--upstream=https://prometheus-operated"))) | length == 1`),
+			jq.Match(`.spec.template.spec.containers[0].args | map(select(contains("--secure-listen-address=0.0.0.0:8443"))) | length == 1`),
+			jq.Match(`.spec.template.spec.containers[0].args | map(select(contains("--config-file=/etc/kube-rbac-proxy/config.yaml"))) | length == 1`),
+			jq.Match(`.spec.template.spec.containers[0].args | map(select(contains("--upstream-ca-file=/etc/prometheus-ca/service-ca.crt"))) | length == 1`),
+			jq.Match(`.spec.template.spec.containers[0].args | map(select(contains("--upstream-client-cert-file=/etc/prometheus-client/tls.crt"))) | length == 1`),
+			jq.Match(`.spec.template.spec.containers[0].args | map(select(contains("--upstream-client-key-file=/etc/prometheus-client/tls.key"))) | length == 1`),
+		)),
+		WithCustomErrorMsg("kube-rbac-proxy should be configured with correct upstream (HTTPS to prometheus-operated) and mTLS client certificates"),
+	)
+
+	// Verify that the deployment uses kube-rbac-proxy image
+	tc.EnsureResourceExists(
+		WithMinimalObject(gvk.Deployment, types.NamespacedName{
+			Name:      "data-science-prometheus-cluster-proxy",
+			Namespace: dsci.Spec.Monitoring.Namespace,
+		}),
+		WithCondition(And(
+			jq.Match(`.spec.template.spec.containers[0].name == "kube-rbac-proxy"`),
+			jq.Match(`.spec.template.spec.containers[0].image | contains("kube-rbac-proxy")`),
+		)),
+		WithCustomErrorMsg("data-science-prometheus-cluster-proxy deployment should contain kube-rbac-proxy container"),
+	)
+
+	// Verify the deployment has correct volume mounts for mTLS to Prometheus
+	tc.EnsureResourceExists(
+		WithMinimalObject(gvk.Deployment, types.NamespacedName{
+			Name:      "data-science-prometheus-cluster-proxy",
+			Namespace: dsci.Spec.Monitoring.Namespace,
+		}),
+		WithCondition(And(
+			jq.Match(`.spec.template.spec.volumes[] | select(.name == "prometheus-ca") | .configMap.name == "prometheus-web-tls-ca"`),
+			jq.Match(`.spec.template.spec.volumes[] | select(.name == "prometheus-client-cert") | .secret.secretName == "prometheus-operated-tls"`),
+			jq.Match(`.spec.template.spec.containers[0].volumeMounts[] | select(.name == "prometheus-ca") | .mountPath == "/etc/prometheus-ca"`),
+			jq.Match(`.spec.template.spec.containers[0].volumeMounts[] | select(.name == "prometheus-client-cert") | .mountPath == "/etc/prometheus-client"`),
+		)),
+		WithCustomErrorMsg("deployment should have volumes and mounts for mTLS to Prometheus"),
 	)
 }


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
grants users with valid rbac permissions access to node metrics using kube-rbac-proxy
jira: https://issues.redhat.com/browse/RHOAIENG-29719

## How Has This Been Tested?
- Create a managed cluster +  apply dsci with managed enabled
- create 2 users
- grant one user `oc adm policy add-cluster-role-to-user view <user>`
- attempt to curl node metrics (should be successful)
```
TOKEN=$(oc whoami -t) && curl -k -H "Authorization: Bearer $TOKEN" https://data-science-node-metrics-endpoint-redhat-ods-monitoring.apps.rosa.<cluster>.p3.openshiftapps.com/metrics
```
- attempt to curl with other user (should get forbidden) 

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [ ] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Conditional Node Metrics endpoint deployment with a new NodeMetricsEndpointAvailable readiness condition; Prometheus exposes namespace-proxy and cluster-proxy components.

* **Tests**
  * Added unit and end-to-end tests for Node Metrics endpoint, templates, RBAC, TLS, and status signaling.
  * Expanded RBAC/group tests to cover three admin/allowed groups and validate subject→group mappings.

* **Chores**
  * Renamed and updated Prometheus proxy resources, network policies, services, and routes for consistency and secure access.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->