### PR TITLE
Removing Env variable from manifests

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -65,10 +65,6 @@ spec:
             value: /opt/manifests
           - name: ODH_PLATFORM_TYPE
             value: OpenDataHub
-          # Kube-auth-proxy image configuration
-          # For RHOAI: Overridden by CSV. For ODH: Uses jtanner's public image
-          - name: RELATED_IMAGE_ODH_KUBE_AUTH_PROXY_IMAGE
-            value: quay.io/opendatahub/odh-kube-auth-proxy:latest
           # Perses image configuration (for monitoring dashboards)
           # For RHOAI: Overridden by CSV. For ODH: Uses Red Hat COO image
           # Note: Must stay compatible with cluster-observability-operator version

--- a/config/rhoai/manager/manager.yaml
+++ b/config/rhoai/manager/manager.yaml
@@ -65,9 +65,6 @@ spec:
             value: /opt/manifests
           # - name: ODH_PLATFORM_TYPE
           #   value: SelfManagedRHOAI
-          # Kube-auth-proxy image configuration
-          - name: RELATED_IMAGE_ODH_KUBE_AUTH_PROXY_IMAGE
-            value: "quay.io/rhoai/odh-kube-auth-proxy-rhel9:latest"
         # NOTE: image is provided in CI by pullspec substitution, and by make/kustomize for local builds
         image: REPLACE_IMAGE:latest-rhoai
         imagePullPolicy: Always

--- a/internal/controller/services/gateway/gateway_support.go
+++ b/internal/controller/services/gateway/gateway_support.go
@@ -103,8 +103,8 @@ func getKubeAuthProxyImage() string {
 	if image := os.Getenv("RELATED_IMAGE_ODH_KUBE_AUTH_PROXY_IMAGE"); image != "" {
 		return image
 	}
-	// Fallback for local development only
-	return "quay.io/jtanner/kube-auth-proxy:latest"
+	// Fallback for ODH development
+	return "quay.io/opendatahub/odh-kube-auth-proxy:latest"
 }
 
 // getCertificateType returns a string representation of the certificate type.


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
existing gateway e2e will cover all cases


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed kube-auth-proxy image environment variable configurations from deployment specifications.
  * Updated default authentication proxy image source to official registry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->