### PR TITLE
[rhoai] Removing Env variable from manifests

### DIFF
--- a/bundle/manifests/rhods-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/rhods-operator.clusterserviceversion.yaml
@@ -82,7 +82,7 @@ metadata:
     categories: AI/Machine Learning, Big Data
     certified: "False"
     containerImage: REPLACE_IMAGE:latest
-    createdAt: "2025-11-07T14:58:02Z"
+    createdAt: "2025-11-19T15:13:16Z"
     description: Operator for deployment and management of Red Hat OpenShift AI
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
@@ -1495,8 +1495,6 @@ spec:
                       fieldPath: metadata.namespace
                 - name: DEFAULT_MANIFESTS_PATH
                   value: /opt/manifests
-                - name: RELATED_IMAGE_ODH_KUBE_AUTH_PROXY_IMAGE
-                  value: quay.io/rhoai/odh-kube-auth-proxy-rhel9:latest
                 image: REPLACE_IMAGE:latest
                 imagePullPolicy: Always
                 livenessProbe:
@@ -1595,9 +1593,6 @@ spec:
   minKubeVersion: 1.25.0
   provider:
     name: Red Hat
-  relatedImages:
-  - image: quay.io/rhoai/odh-kube-auth-proxy-rhel9:latest
-    name: odh-kube-auth-proxy-image
   version: 3.2.0
   webhookdefinitions:
   - admissionReviewVersions:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -65,9 +65,6 @@ spec:
             value: /opt/manifests
           # - name: ODH_PLATFORM_TYPE
           #   value: SelfManagedRHOAI
-          # Kube-auth-proxy image configuration
-          - name: RELATED_IMAGE_ODH_KUBE_AUTH_PROXY_IMAGE
-            value: "quay.io/rhoai/odh-kube-auth-proxy-rhel9:latest"
         image: controller:latest
         imagePullPolicy: Always
         securityContext:

--- a/internal/controller/services/gateway/gateway_auth_actions.go
+++ b/internal/controller/services/gateway/gateway_auth_actions.go
@@ -55,9 +55,7 @@ func createKubeAuthProxyInfrastructure(ctx context.Context, rr *odhtypes.Reconci
 		return fmt.Errorf("failed to get or generate secrets: %w", err)
 	}
 
-	// Pass subdomain to deployKubeAuthProxy for image selection
-	subdomain := gatewayConfig.Spec.Subdomain
-	if err := deployKubeAuthProxy(ctx, rr, oidcConfig, gatewayConfig.Spec.Cookie, clientSecret, cookieSecret, domain, subdomain); err != nil {
+	if err := deployKubeAuthProxy(ctx, rr, oidcConfig, gatewayConfig.Spec.Cookie, clientSecret, cookieSecret, domain); err != nil {
 		return fmt.Errorf("failed to deploy auth proxy: %w", err)
 	}
 

--- a/internal/controller/services/gateway/gateway_support_test.go
+++ b/internal/controller/services/gateway/gateway_support_test.go
@@ -932,10 +932,10 @@ func TestSecretHashAnnotationChangeTriggers(t *testing.T) {
 	rr2 := &odhtypes.ReconciliationRequest{Client: client2}
 
 	// Create two deployments with different secrets
-	err1 := createKubeAuthProxyDeployment(ctx, rr1, nil, nil, expectedODHDomain, "")
+	err1 := createKubeAuthProxyDeployment(ctx, rr1, nil, nil, expectedODHDomain)
 	g.Expect(err1).NotTo(HaveOccurred())
 
-	err2 := createKubeAuthProxyDeployment(ctx, rr2, nil, nil, expectedODHDomain, "")
+	err2 := createKubeAuthProxyDeployment(ctx, rr2, nil, nil, expectedODHDomain)
 	g.Expect(err2).NotTo(HaveOccurred())
 
 	// Convert both to typed Deployments
@@ -967,7 +967,7 @@ func TestSecretHashAnnotationWithoutSecret(t *testing.T) {
 	rr := &odhtypes.ReconciliationRequest{Client: client}
 
 	// Create deployment without secret - should succeed with empty hash
-	err := createKubeAuthProxyDeployment(ctx, rr, nil, nil, expectedODHDomain, "")
+	err := createKubeAuthProxyDeployment(ctx, rr, nil, nil, expectedODHDomain)
 	g.Expect(err).NotTo(HaveOccurred(), "deployment creation should succeed even when secret doesn't exist")
 	g.Expect(rr.Resources).To(HaveLen(1))
 


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
Existing gateway e2e are more than enough to test
