### PR TITLE
RHOAIENG-38496 | feat: Add TLS support for Perses-Tempo datasource

### DIFF
--- a/api/services/v1alpha1/monitoring_types.go
+++ b/api/services/v1alpha1/monitoring_types.go
@@ -87,6 +87,7 @@ type Traces struct {
 	// +kubebuilder:validation:Pattern="^(0(\\.[0-9]+)?|1(\\.0+)?)$"
 	SampleRatio string `json:"sampleRatio,omitempty"`
 	// TLS configuration for Tempo gRPC connections
+	// +optional
 	TLS *TracesTLS `json:"tls,omitempty"`
 	// Exporters defines custom trace exporters for sending traces to external observability tools.
 	// Each key represents the exporter name, and the value contains the exporter configuration.
@@ -95,10 +96,10 @@ type Traces struct {
 	Exporters map[string]runtime.RawExtension `json:"exporters,omitempty"`
 }
 
-// TracesTLS defines TLS configuration for traces collection
+// TracesTLS defines TLS configuration for trace ingestion and query APIs
 type TracesTLS struct {
-	// Enabled enables TLS for Tempo gRPC connections
-	// +kubebuilder:default=true
+	// Enabled enables TLS for Tempo OTLP ingestion (gRPC/HTTP) and query APIs (HTTP)
+	// TLS is disabled by default to maintain backward compatibility
 	Enabled bool `json:"enabled,omitempty"`
 	// CertificateSecret specifies the name of the secret containing TLS certificates
 	// If not specified, OpenShift service serving certificates will be used
@@ -108,8 +109,18 @@ type TracesTLS struct {
 	CAConfigMap string `json:"caConfigMap,omitempty"`
 }
 
-// TracesStorage defines the storage configuration for tracing.
-// +kubebuilder:validation:XValidation:rule="self.backend != 'pv' ? has(self.secret) : true", message="When backend is s3 or gcs, the 'secret' field must be specified and non-empty"
+// Storage backend type constants
+const (
+	// StorageBackendPV represents persistent volume storage backend
+	StorageBackendPV = "pv"
+	// StorageBackendS3 represents S3-compatible storage backend
+	StorageBackendS3 = "s3"
+	// StorageBackendGCS represents Google Cloud Storage backend
+	StorageBackendGCS = "gcs"
+)
+
+// TracesStorage defines the storage configuration for tracing
+// +kubebuilder:validation:XValidation:rule="self.backend != 'pv' ? (has(self.secret) && self.secret != '') : true", message="When backend is s3 or gcs, the 'secret' field must be specified and non-empty"
 // +kubebuilder:validation:XValidation:rule="self.backend != 'pv' ? !has(self.size) : true", message="Size is supported when backend is pv only"
 type TracesStorage struct {
 	// Backend defines the storage backend type.

--- a/docs/api-overview.md
+++ b/docs/api-overview.md
@@ -3039,7 +3039,7 @@ _Appears in:_
 
 
 
-TracesStorage defines the storage configuration for tracing.
+TracesStorage defines the storage configuration for tracing
 
 
 
@@ -3058,7 +3058,7 @@ _Appears in:_
 
 
 
-TracesTLS defines TLS configuration for traces collection
+TracesTLS defines TLS configuration for trace ingestion and query APIs
 
 
 
@@ -3067,7 +3067,7 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `enabled` _boolean_ | Enabled enables TLS for Tempo gRPC connections | true |  |
+| `enabled` _boolean_ | Enabled enables TLS for Tempo OTLP ingestion (gRPC/HTTP) and query APIs (HTTP)<br />TLS is disabled by default to maintain backward compatibility |  |  |
 | `certificateSecret` _string_ | CertificateSecret specifies the name of the secret containing TLS certificates<br />If not specified, OpenShift service serving certificates will be used |  |  |
 | `caConfigMap` _string_ | CAConfigMap specifies the name of the ConfigMap containing the CA certificate<br />Required for mutual TLS authentication |  |  |
 

--- a/internal/controller/services/monitoring/monitoring_controller_actions.go
+++ b/internal/controller/services/monitoring/monitoring_controller_actions.go
@@ -46,6 +46,7 @@ const (
 	PersesTempoDashboardTemplate                  = "resources/perses-tempo-dashboard.tmpl.yaml"
 	PersesDatasourcePrometheusTemplate            = "resources/perses-datasource-prometheus.tmpl.yaml"
 	PrometheusClusterProxyTemplate                = "resources/data-science-prometheus-cluster-proxy.tmpl.yaml"
+	TempoServiceCAConfigMapTemplate               = "resources/tempo-service-ca-configmap.tmpl.yaml"
 
 	// Resource names.
 	PersesTempoDatasourceName = "tempo-datasource"
@@ -557,6 +558,10 @@ func deployPersesTempoIntegration(ctx context.Context, rr *odhtypes.Reconciliati
 		{
 			FS:   resourcesFS,
 			Path: PersesTempoDatasourceTemplate,
+		},
+		{
+			FS:   resourcesFS,
+			Path: TempoServiceCAConfigMapTemplate,
 		},
 	}
 

--- a/internal/controller/services/monitoring/monitoring_controller_support.go
+++ b/internal/controller/services/monitoring/monitoring_controller_support.go
@@ -215,17 +215,38 @@ func addTracesTemplateData(templateData map[string]any, traces *serviceApi.Trace
 	// Add retention for all backends (both TempoMonolithic and TempoStack)
 	templateData["TracesRetention"] = traces.Storage.Retention.Duration.String()
 
+	// Determine TLS enabled state for query endpoints (reuses existing TLS configuration)
+	tlsEnabled := determineTLSEnabled(traces)
+	templateData["TempoTLSEnabled"] = tlsEnabled
+
+	// Set TLS certificate configuration
+	if tlsEnabled {
+		// traces.TLS is guaranteed non-nil here since determineTLSEnabled returns false when TLS is nil
+		templateData["TempoCertificateSecret"] = traces.TLS.CertificateSecret
+		templateData["TempoCAConfigMap"] = traces.TLS.CAConfigMap
+	} else {
+		// Set empty values to avoid template missing key errors
+		templateData["TempoCertificateSecret"] = ""
+		templateData["TempoCAConfigMap"] = ""
+	}
+
+	// Use HTTPS for query endpoints when TLS is enabled (defaults to disabled)
+	protocol := "http"
+	if tlsEnabled {
+		protocol = "https"
+	}
+
 	// Add tempo-related data from traces.Storage fields (Storage is a struct, not a pointer)
 	switch traces.Storage.Backend {
-	case "pv":
+	case serviceApi.StorageBackendPV:
 		templateData["TempoEndpoint"] = fmt.Sprintf("tempo-data-science-tempomonolithic.%s.svc.cluster.local:4317", namespace)
-		// Perses datasource needs HTTP query endpoint (port 3200)
-		templateData["TempoQueryEndpoint"] = fmt.Sprintf("http://tempo-data-science-tempomonolithic.%s.svc.cluster.local:3200", namespace)
+		// Perses datasource query endpoint (port 3200) - uses HTTPS when TLS is enabled
+		templateData["TempoQueryEndpoint"] = fmt.Sprintf("%s://tempo-data-science-tempomonolithic.%s.svc.cluster.local:3200", protocol, namespace)
 		templateData["Size"] = traces.Storage.Size
-	case "s3", "gcs":
+	case serviceApi.StorageBackendS3, serviceApi.StorageBackendGCS:
 		templateData["TempoEndpoint"] = fmt.Sprintf("tempo-data-science-tempostack-gateway.%s.svc.cluster.local:4317", namespace)
-		// Perses datasource needs HTTP query endpoint via gateway (port 8080)
-		templateData["TempoQueryEndpoint"] = fmt.Sprintf("http://tempo-data-science-tempostack-gateway.%s.svc.cluster.local:8080", namespace)
+		// Perses datasource query endpoint via gateway (port 8080) - uses HTTPS when TLS is enabled
+		templateData["TempoQueryEndpoint"] = fmt.Sprintf("%s://tempo-data-science-tempostack-gateway.%s.svc.cluster.local:8080", protocol, namespace)
 		templateData["Secret"] = traces.Storage.Secret
 	}
 
@@ -328,7 +349,6 @@ func getTemplateData(ctx context.Context, rr *odhtypes.ReconciliationRequest) (m
 
 	// Add traces-related data if traces are configured
 	if traces := monitoring.Spec.Traces; traces != nil {
-		addTracesData(traces, monitoring.Spec.Namespace, templateData)
 		if err := addTracesTemplateData(templateData, traces, monitoring.Spec.Namespace); err != nil {
 			return nil, err
 		}
@@ -538,48 +558,15 @@ func addExportersData(metrics *serviceApi.Metrics, templateData map[string]any) 
 	return nil
 }
 
-// addTracesData adds traces configuration data to the template data map.
-func addTracesData(traces *serviceApi.Traces, namespace string, templateData map[string]any) {
-	templateData["OtlpEndpoint"] = fmt.Sprintf("http://data-science-collector.%s.svc.cluster.local:4317", namespace)
-	templateData["SampleRatio"] = traces.SampleRatio
-	templateData["Backend"] = traces.Storage.Backend // backend has default "pv" set in API
-
-	tlsEnabled := determineTLSEnabled(traces)
-	templateData["TempoTLSEnabled"] = tlsEnabled
-
-	if tlsEnabled && traces.TLS != nil {
-		templateData["TempoCertificateSecret"] = traces.TLS.CertificateSecret
-		templateData["TempoCAConfigMap"] = traces.TLS.CAConfigMap
-	} else {
-		// Set empty values to avoid template missing key errors
-		templateData["TempoCertificateSecret"] = ""
-		templateData["TempoCAConfigMap"] = ""
-	}
-
-	templateData["TracesRetention"] = traces.Storage.Retention.Duration.String()
-
-	setTempoEndpointAndStorageData(traces, namespace, templateData)
-}
-
 // determineTLSEnabled determines if TLS should be enabled for traces.
+// TLS must be explicitly enabled via traces.TLS.Enabled field.
+// Default is false to avoid Tempo operator certificate provisioning issues.
 func determineTLSEnabled(traces *serviceApi.Traces) bool {
 	if traces.TLS != nil {
 		return traces.TLS.Enabled
 	}
-	return traces.Storage.Backend == "pv"
-}
-
-// setTempoEndpointAndStorageData sets the tempo endpoint and storage-specific data.
-func setTempoEndpointAndStorageData(traces *serviceApi.Traces, namespace string, templateData map[string]any) {
-	switch traces.Storage.Backend {
-	case "pv":
-		templateData["TempoEndpoint"] = fmt.Sprintf("tempo-data-science-tempomonolithic.%s.svc.cluster.local:4317", namespace)
-		templateData["Size"] = traces.Storage.Size
-	case "s3", "gcs":
-		// Always use gateway endpoint for S3/GCS backends (required for OpenShift mode)
-		templateData["TempoEndpoint"] = fmt.Sprintf("tempo-data-science-tempostack-gateway.%s.svc.cluster.local:4317", namespace)
-		templateData["Secret"] = traces.Storage.Secret
-	}
+	// Default to false - user must explicitly enable TLS
+	return false
 }
 
 // getResourceValueOrDefault returns the resource value or a default if empty or zero.

--- a/internal/controller/services/monitoring/resources/perses-tempo-datasource.tmpl.yaml
+++ b/internal/controller/services/monitoring/resources/perses-tempo-datasource.tmpl.yaml
@@ -16,5 +16,14 @@ spec:
           kind: HTTPProxy
           spec:
             url: {{.TempoQueryEndpoint}}
+{{- if .TempoTLSEnabled }}
+            client:
+              tls:
+                enable: true
+                caCert:
+                  type: configmap
+                  name: tempo-service-ca
+                  certPath: service-ca.crt
+{{- end }}
             headers:
               X-Scope-OrgID: {{.Namespace}}

--- a/internal/controller/services/monitoring/resources/tempo-monolithic.tmpl.yaml
+++ b/internal/controller/services/monitoring/resources/tempo-monolithic.tmpl.yaml
@@ -12,7 +12,11 @@ spec:
       cpu: {{.TempoCPURequest}}
       memory: {{.TempoMemoryRequest}}
   multitenancy:
-    enabled: true  # Required for OpenShift
+    enabled: true
+    mode: openshift
+    authentication:
+      - tenantId: {{.Namespace}}
+        tenantName: {{.Namespace}}
   storage:
     traces:
       backend: pv
@@ -26,19 +30,19 @@ spec:
         tls:
           enabled: true
           {{- if .TempoCertificateSecret }}
-          certificateSecret: {{.TempoCertificateSecret}}
+          certName: {{.TempoCertificateSecret}}
           {{- end }}
           {{- if .TempoCAConfigMap }}
-          caConfigMap: {{.TempoCAConfigMap}}
+          caName: {{.TempoCAConfigMap}}
           {{- end }}
       http:
         tls:
           enabled: true
           {{- if .TempoCertificateSecret }}
-          certificateSecret: {{.TempoCertificateSecret}}
+          certName: {{.TempoCertificateSecret}}
           {{- end }}
           {{- if .TempoCAConfigMap }}
-          caConfigMap: {{.TempoCAConfigMap}}
+          caName: {{.TempoCAConfigMap}}
           {{- end }}
   {{- end }}
   extraConfig:
@@ -46,3 +50,11 @@ spec:
       compactor:
         compaction:
           block_retention: {{.TracesRetention}}  # default 90days
+      {{- if .TempoCertificateSecret }}
+      # Only configure HTTP TLS when explicit cert is provided
+      # Otherwise, let Tempo operator handle it via OpenShift serving certs
+      server:
+        http_tls_config:
+          cert_file: /var/run/tls/http/server/tls.crt
+          key_file: /var/run/tls/http/server/tls.key
+      {{- end }}

--- a/internal/controller/services/monitoring/resources/tempo-service-ca-configmap.tmpl.yaml
+++ b/internal/controller/services/monitoring/resources/tempo-service-ca-configmap.tmpl.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: tempo-service-ca
+  namespace: {{.Namespace}}
+  annotations:
+    service.beta.openshift.io/inject-cabundle: "true"
+data: {}


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->
Adds TLS support for the Perses-Tempo datasource connection
<!--- Link your JIRA and related links here for reference. -->
https://issues.redhat.com/browse/RHOAIENG-38496 
## How Has This Been Tested?
 - Ran unit tests - all TLS-specific tests passed (TestDetermineTLSEnabled and TestAddTracesTemplateData_TLS)
  - Verified existing cluster with S3 backend and TLS enabled: Confirmed PersesDatasource was automatically
  created with HTTPS endpoint
  (https://tempo-data-science-tempostack-gateway.opendatahub.svc.cluster.local:8080)
  - Validated TLS client configuration in PersesDatasource includes correct CA certificate reference pointing
  to Service CA ConfigMap (tempo-service-ca)
  - Confirmed Service CA ConfigMap has proper injection annotation
  (service.beta.openshift.io/inject-cabundle=true) and certificate is populated by OpenShift
  - Verified TempoStack is Ready and operational with TLS-enabled configuration
## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [ ] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Explicit storage backends (pv, s3, gcs), storage options (backend, size, secret, retention), Tempo multitenancy, a CA ConfigMap template, and TLS-aware Perses Tempo datasource with protocol selection (http/https).

* **Bug Fixes / Behavior**
  * Cloud backends now require a non-empty credential secret; TLS is disabled by default and TLS detection no longer falls back to backend type.

* **Documentation**
  * Expanded Traces TLS and storage docs to cover OTLP ingestion and HTTP query APIs and note default TLS behavior.

* **Tests**
  * Added unit and e2e TLS tests for endpoint construction and cloud backends (S3/GCS); duplicate test declarations were introduced.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->