### PR TITLE
 refactor: move function IsDefaultAuthMethod from Auth to IsIntegratedOAuth in cluster package

### DIFF
--- a/internal/controller/services/auth/auth.go
+++ b/internal/controller/services/auth/auth.go
@@ -1,36 +1,9 @@
 package auth
 
 import (
-	"context"
-
-	configv1 "github.com/openshift/api/config/v1"
-	k8serr "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/api/meta"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-
 	serviceApi "github.com/opendatahub-io/opendatahub-operator/v2/api/services/v1alpha1"
-	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
-	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
 )
 
 const (
 	ServiceName = serviceApi.AuthServiceName
 )
-
-// IsDefaultAuthMethod returns true if the default authentication method is IntegratedOAuth or empty.
-// This will give indication that Operator should create userGroups or not in the cluster.
-func IsDefaultAuthMethod(ctx context.Context, cli client.Client) (bool, error) {
-	authenticationobj := &configv1.Authentication{}
-	if err := cli.Get(ctx, client.ObjectKey{Name: cluster.ClusterAuthenticationObj, Namespace: ""}, authenticationobj); err != nil {
-		if meta.IsNoMatchError(err) { // when CRD is missing, convert error type
-			return false, k8serr.NewNotFound(schema.GroupResource{Group: gvk.Auth.Group}, cluster.ClusterAuthenticationObj)
-		}
-		return false, err
-	}
-
-	// for now, HPC support "" "None" "IntegratedOAuth"(default) "OIDC"
-	// other offering support "" "None" "IntegratedOAuth"(default)
-	// we only create userGroups for "IntegratedOAuth" or "" and leave other or new supported type value in the future
-	return authenticationobj.Spec.Type == configv1.AuthenticationTypeIntegratedOAuth || authenticationobj.Spec.Type == "", nil
-}

--- a/internal/controller/services/auth/auth_controller_actions.go
+++ b/internal/controller/services/auth/auth_controller_actions.go
@@ -184,7 +184,7 @@ func addUserGroup(ctx context.Context, rr *odhtypes.ReconciliationRequest, userG
 }
 
 func createDefaultGroup(ctx context.Context, rr *odhtypes.ReconciliationRequest) error {
-	ok, err := IsDefaultAuthMethod(ctx, rr.Client)
+	ok, err := cluster.IsIntegratedOAuth(ctx, rr.Client)
 	if err != nil {
 		return err
 	}

--- a/internal/controller/services/auth/auth_controller_test.go
+++ b/internal/controller/services/auth/auth_controller_test.go
@@ -105,7 +105,7 @@ func TestServiceHandler_Init(t *testing.T) {
 	g.Expect(err).ShouldNot(HaveOccurred())
 }
 
-// TestIsDefaultAuthMethod validates the OpenShift authentication method detection logic.
+// TestIsIntegratedOAuth validates the OpenShift authentication method detection logic.
 // This function determines whether the operator should create default admin groups
 // based on the cluster's authentication configuration. The test ensures:
 //
@@ -123,7 +123,7 @@ func TestServiceHandler_Init(t *testing.T) {
 //
 // This is critical for security because it determines whether the operator will
 // automatically create admin groups that could grant elevated access.
-func TestIsDefaultAuthMethod(t *testing.T) {
+func TestIsIntegratedOAuth(t *testing.T) {
 	ctx := t.Context()
 
 	tests := []struct {
@@ -214,7 +214,7 @@ func TestIsDefaultAuthMethod(t *testing.T) {
 			}
 			g.Expect(err).ShouldNot(HaveOccurred())
 
-			result, err := auth.IsDefaultAuthMethod(ctx, cli)
+			result, err := cluster.IsIntegratedOAuth(ctx, cli)
 
 			if tt.expectError {
 				g.Expect(err).Should(HaveOccurred(), tt.description)

--- a/internal/controller/services/gateway/gateway_controller.go
+++ b/internal/controller/services/gateway/gateway_controller.go
@@ -29,8 +29,8 @@ import (
 	"github.com/opendatahub-io/opendatahub-operator/v2/api/common"
 	dsciv2 "github.com/opendatahub-io/opendatahub-operator/v2/api/dscinitialization/v2"
 	serviceApi "github.com/opendatahub-io/opendatahub-operator/v2/api/services/v1alpha1"
-	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/services/auth"
 	sr "github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/services/registry"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/deploy"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/gc"
@@ -91,7 +91,7 @@ func (h *ServiceHandler) NewReconciler(ctx context.Context, mgr ctrl.Manager) er
 
 	// Only watch OAuthClient if cluster uses IntegratedOAuth (not OIDC or None)
 	// This prevents errors in ROSA environments where OAuthClient CRD doesn't exist
-	if isIntegratedOAuth, err := auth.IsDefaultAuthMethod(ctx, mgr.GetClient()); err == nil && isIntegratedOAuth {
+	if isIntegratedOAuth, err := cluster.IsIntegratedOAuth(ctx, mgr.GetClient()); err == nil && isIntegratedOAuth {
 		reconcilerBuilder = reconcilerBuilder.OwnsGVK(gvk.OAuthClient) // OpenShift OAuth integration
 	}
 

--- a/pkg/cluster/cluster_config.go
+++ b/pkg/cluster/cluster_config.go
@@ -15,6 +15,7 @@ import (
 	"github.com/spf13/viper"
 	corev1 "k8s.io/api/core/v1"
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
@@ -447,4 +448,46 @@ func GetApplicationNamespace() string {
 	default:
 		return "opendatahub"
 	}
+}
+
+// AuthenticationMode represents the cluster authentication mode.
+type AuthenticationMode string
+
+const (
+	AuthModeIntegratedOAuth AuthenticationMode = "IntegratedOAuth"
+	AuthModeOIDC            AuthenticationMode = "OIDC"
+	AuthModeNone            AuthenticationMode = "None"
+)
+
+// GetClusterAuthenticationMode retrieves and returns the cluster authentication mode.
+func GetClusterAuthenticationMode(ctx context.Context, cli client.Reader) (AuthenticationMode, error) {
+	auth := &configv1.Authentication{}
+	if err := cli.Get(ctx, client.ObjectKey{Name: ClusterAuthenticationObj}, auth); err != nil {
+		if meta.IsNoMatchError(err) { // when CRD is missing, convert error type
+			return "", k8serr.NewNotFound(schema.GroupResource{Group: gvk.Auth.Group}, ClusterAuthenticationObj)
+		}
+		return "", fmt.Errorf("failed to get cluster authentication config: %w", err)
+	}
+
+	switch auth.Spec.Type {
+	case "OIDC":
+		return AuthModeOIDC, nil
+	case configv1.AuthenticationTypeNone:
+		return AuthModeNone, nil
+	case "", configv1.AuthenticationTypeIntegratedOAuth:
+		// IntegratedOAuth is the default for empty string and explicit IntegratedOAuth
+		return AuthModeIntegratedOAuth, nil
+	default:
+		// Custom/unknown auth types are not IntegratedOAuth
+		return AuthModeNone, nil
+	}
+}
+
+// IsIntegratedOAuth returns true if the cluster uses IntegratedOAuth authentication mode which is the default in OCP.
+func IsIntegratedOAuth(ctx context.Context, cli client.Reader) (bool, error) {
+	authMode, err := GetClusterAuthenticationMode(ctx, cli)
+	if err != nil {
+		return false, err
+	}
+	return authMode == AuthModeIntegratedOAuth, nil
 }

--- a/pkg/cluster/cluster_config_test.go
+++ b/pkg/cluster/cluster_config_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"testing"
 
+	configv1 "github.com/openshift/api/config/v1"
 	corev1 "k8s.io/api/core/v1"
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -193,6 +194,244 @@ invalid: yaml`,
 				}
 			} else if err != nil {
 				t.Errorf("IsFIPSEnabled() error = %v, want nil", err)
+			}
+		})
+	}
+}
+
+func TestGetClusterAuthenticationMode(t *testing.T) {
+	// Register the configv1 scheme
+	scheme := runtime.NewScheme()
+	err := configv1.AddToScheme(scheme)
+	if err != nil {
+		t.Fatalf("failed to add configv1 scheme: %v", err)
+	}
+
+	testCases := []struct {
+		name          string
+		authObject    *configv1.Authentication
+		expectedMode  cluster.AuthenticationMode
+		expectedError bool
+		errorType     string
+	}{
+		{
+			name: "IntegratedOAuth type",
+			authObject: &configv1.Authentication{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: cluster.ClusterAuthenticationObj,
+				},
+				Spec: configv1.AuthenticationSpec{
+					Type: configv1.AuthenticationTypeIntegratedOAuth,
+				},
+			},
+			expectedMode:  cluster.AuthModeIntegratedOAuth,
+			expectedError: false,
+		},
+		{
+			name: "Empty type (defaults to IntegratedOAuth)",
+			authObject: &configv1.Authentication{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: cluster.ClusterAuthenticationObj,
+				},
+				Spec: configv1.AuthenticationSpec{
+					Type: "",
+				},
+			},
+			expectedMode:  cluster.AuthModeIntegratedOAuth,
+			expectedError: false,
+		},
+		{
+			name: "OIDC type",
+			authObject: &configv1.Authentication{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: cluster.ClusterAuthenticationObj,
+				},
+				Spec: configv1.AuthenticationSpec{
+					Type: "OIDC",
+				},
+			},
+			expectedMode:  cluster.AuthModeOIDC,
+			expectedError: false,
+		},
+		{
+			name: "None type",
+			authObject: &configv1.Authentication{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: cluster.ClusterAuthenticationObj,
+				},
+				Spec: configv1.AuthenticationSpec{
+					Type: configv1.AuthenticationTypeNone,
+				},
+			},
+			expectedMode:  cluster.AuthModeNone,
+			expectedError: false,
+		},
+		{
+			name: "Custom type (defaults to None)",
+			authObject: &configv1.Authentication{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: cluster.ClusterAuthenticationObj,
+				},
+				Spec: configv1.AuthenticationSpec{
+					Type: "CustomAuth",
+				},
+			},
+			expectedMode:  cluster.AuthModeNone,
+			expectedError: false,
+		},
+		{
+			name:          "Authentication object not found",
+			authObject:    nil,
+			expectedMode:  "",
+			expectedError: true,
+			errorType:     "notfound",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+
+			var fakeClient client.Client
+			objs := []runtime.Object{}
+			if tc.authObject != nil {
+				objs = append(objs, tc.authObject)
+			}
+
+			fakeClient = fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(objs...).Build()
+
+			result, err := cluster.GetClusterAuthenticationMode(ctx, fakeClient)
+
+			if tc.expectedError {
+				if err == nil {
+					t.Errorf("GetClusterAuthenticationMode() expected error but got nil")
+				} else if tc.errorType == "notfound" && !k8serr.IsNotFound(err) {
+					t.Errorf("GetClusterAuthenticationMode() expected NotFound error but got %v", err)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("GetClusterAuthenticationMode() unexpected error: %v", err)
+				}
+				if result != tc.expectedMode {
+					t.Errorf("GetClusterAuthenticationMode() = %v, want %v", result, tc.expectedMode)
+				}
+			}
+		})
+	}
+}
+
+func TestIsIntegratedOAuth(t *testing.T) {
+	// Register the configv1 scheme
+	scheme := runtime.NewScheme()
+	err := configv1.AddToScheme(scheme)
+	if err != nil {
+		t.Fatalf("failed to add configv1 scheme: %v", err)
+	}
+
+	testCases := []struct {
+		name           string
+		authObject     *configv1.Authentication
+		expectedResult bool
+		expectedError  bool
+	}{
+		{
+			name: "IntegratedOAuth type returns true",
+			authObject: &configv1.Authentication{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: cluster.ClusterAuthenticationObj,
+				},
+				Spec: configv1.AuthenticationSpec{
+					Type: configv1.AuthenticationTypeIntegratedOAuth,
+				},
+			},
+			expectedResult: true,
+			expectedError:  false,
+		},
+		{
+			name: "Empty type returns true (defaults to IntegratedOAuth)",
+			authObject: &configv1.Authentication{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: cluster.ClusterAuthenticationObj,
+				},
+				Spec: configv1.AuthenticationSpec{
+					Type: "",
+				},
+			},
+			expectedResult: true,
+			expectedError:  false,
+		},
+		{
+			name: "OIDC type returns false",
+			authObject: &configv1.Authentication{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: cluster.ClusterAuthenticationObj,
+				},
+				Spec: configv1.AuthenticationSpec{
+					Type: "OIDC",
+				},
+			},
+			expectedResult: false,
+			expectedError:  false,
+		},
+		{
+			name: "None type returns false",
+			authObject: &configv1.Authentication{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: cluster.ClusterAuthenticationObj,
+				},
+				Spec: configv1.AuthenticationSpec{
+					Type: configv1.AuthenticationTypeNone,
+				},
+			},
+			expectedResult: false,
+			expectedError:  false,
+		},
+		{
+			name: "Custom type returns false",
+			authObject: &configv1.Authentication{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: cluster.ClusterAuthenticationObj,
+				},
+				Spec: configv1.AuthenticationSpec{
+					Type: "CustomAuth",
+				},
+			},
+			expectedResult: false,
+			expectedError:  false,
+		},
+		{
+			name:           "Authentication object not found returns error",
+			authObject:     nil,
+			expectedResult: false,
+			expectedError:  true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+
+			var fakeClient client.Client
+			objs := []runtime.Object{}
+			if tc.authObject != nil {
+				objs = append(objs, tc.authObject)
+			}
+
+			fakeClient = fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(objs...).Build()
+
+			result, err := cluster.IsIntegratedOAuth(ctx, fakeClient)
+
+			if tc.expectedError {
+				if err == nil {
+					t.Errorf("IsIntegratedOAuth() expected error but got nil")
+				}
+			} else {
+				if err != nil {
+					t.Errorf("IsIntegratedOAuth() unexpected error: %v", err)
+				}
+				if result != tc.expectedResult {
+					t.Errorf("IsIntegratedOAuth() = %v, want %v", result, tc.expectedResult)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->
break out PR https://github.com/opendatahub-io/opendatahub-operator/pull/2539 part III

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.
5. 

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->
refactor a function 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Centralized cluster authentication detection into a unified, consistent mechanism
  * Introduced support for identifying and handling multiple distinct authentication modes within the cluster
  * Updated system components throughout the application to use the new consolidated authentication detection approach
  * Enhanced error handling to properly address scenarios with missing or unavailable authentication configuration

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->