### PR TITLE
[sync]test: add check llm-d external operators in e2e (#2876)

### DIFF
--- a/bundle/manifests/rhods-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/rhods-operator.clusterserviceversion.yaml
@@ -82,7 +82,7 @@ metadata:
     categories: AI/Machine Learning, Big Data
     certified: "False"
     containerImage: REPLACE_IMAGE:latest
-    createdAt: "2025-11-19T15:13:16Z"
+    createdAt: "2025-11-25T07:46:54Z"
     description: Operator for deployment and management of Red Hat OpenShift AI
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
@@ -922,6 +922,14 @@ spec:
           - update
           - watch
         - apiGroups:
+          - kuadrant.io
+          resources:
+          - kuadrants
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
           - kubeflow.org
           resources:
           - notebooks
@@ -1188,6 +1196,14 @@ spec:
           - get
           - list
           - patch
+          - watch
+        - apiGroups:
+          - operator.openshift.io
+          resources:
+          - leaderworkersetoperators
+          verbs:
+          - get
+          - list
           - watch
         - apiGroups:
           - operators.coreos.com

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -621,6 +621,14 @@ rules:
   - update
   - watch
 - apiGroups:
+  - kuadrant.io
+  resources:
+  - kuadrants
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - kubeflow.org
   resources:
   - notebooks
@@ -887,6 +895,14 @@ rules:
   - get
   - list
   - patch
+  - watch
+- apiGroups:
+  - operator.openshift.io
+  resources:
+  - leaderworkersetoperators
+  verbs:
+  - get
+  - list
   - watch
 - apiGroups:
   - operators.coreos.com

--- a/internal/controller/components/kserve/kserve_controller_actions.go
+++ b/internal/controller/components/kserve/kserve_controller_actions.go
@@ -77,7 +77,7 @@ func cleanUpTemplatedResources(ctx context.Context, rr *odhtypes.ReconciliationR
 func customizeKserveConfigMap(ctx context.Context, rr *odhtypes.ReconciliationRequest) error {
 	k, ok := rr.Instance.(*componentApi.Kserve)
 	if !ok {
-		return fmt.Errorf("resource instance %v is not a componentApi.Kserve)", rr.Instance)
+		return fmt.Errorf("resource instance %v is not a componentApi.Kserve", rr.Instance)
 	}
 
 	kserveConfigMap := corev1.ConfigMap{}

--- a/internal/controller/datasciencecluster/kubebuilder_rbac.go
+++ b/internal/controller/datasciencecluster/kubebuilder_rbac.go
@@ -232,6 +232,8 @@ package datasciencecluster
 // +kubebuilder:rbac:groups="serving.kserve.io",resources=llminferenceservices/status,verbs=get;list;watch
 // +kubebuilder:rbac:groups="inference.networking.x-k8s.io",resources=inferencepools,verbs=get;list;watch
 // +kubebuilder:rbac:groups="inference.networking.x-k8s.io",resources=inferencemodels,verbs=get;list;watch
+// +kubebuilder:rbac:groups="kuadrant.io",resources=kuadrants,verbs=get;list;watch
+// +kubebuilder:rbac:groups="operator.openshift.io",resources=leaderworkersetoperators,verbs=get;list;watch
 
 // WB
 // +kubebuilder:rbac:groups=components.platform.opendatahub.io,resources=workbenches,verbs=get;list;watch;create;update;patch;delete

--- a/pkg/cluster/gvk/gvk.go
+++ b/pkg/cluster/gvk/gvk.go
@@ -558,4 +558,34 @@ var (
 		Version: "v1",
 		Kind:    "ValidatingAdmissionPolicyBinding",
 	}
+
+	LeaderWorkerSetOperator = schema.GroupVersionKind{
+		Group:   "operator.openshift.io",
+		Version: "v1",
+		Kind:    "LeaderWorkerSetOperator",
+	}
+
+	AuthPolicyv1 = schema.GroupVersionKind{
+		Group:   "kuadrant.io",
+		Version: "v1",
+		Kind:    "AuthPolicy",
+	}
+
+	RateLimitPolicyv1 = schema.GroupVersionKind{
+		Group:   "kuadrant.io",
+		Version: "v1",
+		Kind:    "RateLimitPolicy",
+	}
+
+	AuthConfigv1beta3 = schema.GroupVersionKind{
+		Group:   "authorino.kuadrant.io",
+		Version: "v1beta3",
+		Kind:    "AuthConfig",
+	}
+
+	Kuadrantv1beta1 = schema.GroupVersionKind{
+		Group:   "kuadrant.io",
+		Version: "v1beta1",
+		Kind:    "Kuadrant",
+	}
 )

--- a/tests/e2e/helper_test.go
+++ b/tests/e2e/helper_test.go
@@ -55,10 +55,12 @@ const (
 	observabilityOpNamespace    = "openshift-cluster-observability-operator" // Namespace for the Cluster Observability Operator
 	tempoOpName                 = "tempo-product"                            // Name of the Tempo Operator
 	tempoOpNamespace            = "openshift-tempo-operator"                 // Namespace for the Tempo Operator
-	opentelemetryOpName         = "opentelemetry-product"                    // Name of the OpenTelemetry Operator
-	opentelemetryOpNamespace    = "openshift-opentelemetry-operator"         // Namespace for the OpenTelemetry Operator
 	controllerDeploymentODH     = "opendatahub-operator-controller-manager"  // Name of the ODH deployment
 	controllerDeploymentRhoai   = "rhods-operator"                           // Name of the Rhoai deployment
+	leaderWorkerSetOpName       = "leader-worker-set"                        // Name of the Leader Worker Set Operator
+	leaderWorkerSetNamespace    = "openshift-lws-operator"                   // Namespace for the Leader Worker Set Operator
+	leaderWorkerSetChannel      = "stable-v1.0"                              // Channel for the Leader Worker Set Operator
+	kuadrantOperator            = "rhcl-operator"                            // Name of the Red Hat Connectivity Link Operator subscription.
 )
 
 // Configuration and Miscellaneous Constants.


### PR DESCRIPTION
- fix log message
- add kuadrant and lws into RBCA
- add e2e test to install these 2 operators
- update gvk for all serving needed new kind

(cherry picked from commit 47bde07627e12e7738ea50161f9741bf5f06b1fb)
(cherry picked from commit 67120b60d22f2425638a3bc42a784303e490b5b7)

<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->
sync https://github.com/opendatahub-io/opendatahub-operator/pull/2876

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [ ] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->
