### PR TITLE
chore(envtest): add retry logic for flaky webhook server startup

### DIFF
--- a/pkg/utils/test/envt/envt.go
+++ b/pkg/utils/test/envt/envt.go
@@ -291,12 +291,11 @@ func (et *EnvT) Manager() manager.Manager {
 // WaitForWebhookServer waits until the webhook server managed by this EnvT is ready by dialing the port using TLS.
 //
 // Parameters:
-//   - ctx: A non-nil context passed to the underlying Dialer
-//   - timeout: The maximum duration to wait for the server to become ready.
+//   - ctx: A non-nil context passed to the underlying Dialer; the context is used to cancel the polling loop.
 //
 // Returns:
 //   - error: If the server is not ready within the timeout or a connection error occurs.
-func (et *EnvT) WaitForWebhookServer(ctx context.Context, timeout time.Duration) error {
+func (et *EnvT) WaitForWebhookServer(ctx context.Context) error {
 	host := et.Env.WebhookInstallOptions.LocalServingHost
 	port := et.Env.WebhookInstallOptions.LocalServingPort
 	if host == "" || port == 0 {
@@ -304,24 +303,34 @@ func (et *EnvT) WaitForWebhookServer(ctx context.Context, timeout time.Duration)
 	}
 
 	addrPort := fmt.Sprintf("%s:%d", host, port)
-	deadline := time.Now().Add(timeout)
 
-	for time.Now().Before(deadline) {
-		tlsDialer := &tls.Dialer{
-			Config: &tls.Config{
-				InsecureSkipVerify: true, // #nosec G402
-				MinVersion:         tls.VersionTLS12,
-			},
-			NetDialer: &net.Dialer{Timeout: time.Second},
-		}
+	// setup ticker for polling the webhook server
+	ticker := time.NewTicker(100 * time.Millisecond)
+	defer ticker.Stop()
 
+	// setup dialer
+	tlsDialer := &tls.Dialer{
+		Config: &tls.Config{
+			InsecureSkipVerify: true, // #nosec G402
+			MinVersion:         tls.VersionTLS12,
+		},
+		NetDialer: &net.Dialer{Timeout: 1 * time.Second},
+	}
+
+	// keep trying until the context is cancelled or the webhook server is ready
+	for {
 		conn, err := tlsDialer.DialContext(ctx, "tcp", addrPort)
 		if err == nil {
 			return conn.Close()
 		}
-		time.Sleep(100 * time.Millisecond)
+
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("webhook server not ready (%v) before context cancelled: %w", err.Error(), ctx.Err())
+		case <-ticker.C:
+			continue
+		}
 	}
-	return fmt.Errorf("webhook server not ready after %s", timeout)
 }
 
 // BypassHandler wraps a handler and allows bypassing validation based on a custom function.


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

Envtest webhook server startup can be flaky, causing intermittent test failures.

When a large number of CPUs are available, GOMAXPROCS defaults to that high number. If other resources do not scale equally, e.g. max open files limit, intermittent failures may happen.

This change adds automatic retries with exponential backoff to handle these transient startup failures more gracefully.

Changes:
- Add retry loop in SetupEnvAndClient with exponential backoff.
- Refactor WaitForWebhookServer to use the same context-based timeout cancellation.

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Running `make unit-test`

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

```
Ginkgo ran 51 suites in 7m35.700640634s
Test Suite Passed
```

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [x] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->

This changes the webhook setup for running unit tests, doesn't add or change functionality.