### PR TITLE
RHOAIENG-25593 | fix: removing image from manager file

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -65,11 +65,6 @@ spec:
             value: /opt/manifests
           - name: ODH_PLATFORM_TYPE
             value: OpenDataHub
-          # Perses image configuration (for monitoring dashboards)
-          # For RHOAI: Overridden by CSV. For ODH: Uses Red Hat COO image
-          # Note: Must stay compatible with cluster-observability-operator version
-          - name: RELATED_IMAGE_PERSES
-            value: registry.redhat.io/cluster-observability-operator/perses-0-50-rhel9:1.2.2-1752686994
         args:
         - --leader-elect
         - --operator-name=opendatahub

--- a/internal/controller/services/monitoring/monitoring_controller_support.go
+++ b/internal/controller/services/monitoring/monitoring_controller_support.go
@@ -60,10 +60,9 @@ const (
 
 var componentIDRE = regexp.MustCompile(`^[A-Za-z][A-Za-z0-9_]*(?:/[A-Za-z0-9][A-Za-z0-9_-]*)?$`)
 
-// getPersesImage returns the Perses image from environment variable.
-// For RHOAI deployments, this comes from the CSV (via RHOAI-Build-Config/bundle/additional-images-patch.yaml).
-// For ODH deployments, this comes from config/manager/manager.yaml.
-// Falls back to a default image for local development/testing only.
+// getPersesImage returns the Perses image from environment variable or default.
+// For RHOAI deployments, this is set via the CSV (via RHOAI-Build-Config/bundle/additional-images-patch.yaml).
+// For ODH deployments, this uses the default value below.
 //
 // Note: This image version must stay compatible with the Cluster Observability Operator (COO) version
 // that we depend on. When upgrading COO, verify Perses image compatibility and update accordingly.


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
fix for odh nightly check patch run
removing image from manager.yaml file since it gets set in monitoring controller anyway

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
e2e tests already exist


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced Perses image configuration with environment variable support and default fallback mechanism for improved deployment flexibility and configurability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->