### PR TITLE
[sync]Fix ModelRegistry CEL validation for omitted managementState field (#2903)

### DIFF
--- a/api/components/v1alpha1/modelregistry_types.go
+++ b/api/components/v1alpha1/modelregistry_types.go
@@ -110,7 +110,7 @@ func init() {
 }
 
 // +kubebuilder:object:generate=true
-// +kubebuilder:validation:XValidation:rule="(self.managementState != 'Managed') || (oldSelf.registriesNamespace == '') || (oldSelf.managementState != 'Managed')|| (self.registriesNamespace == oldSelf.registriesNamespace)",message="RegistriesNamespace is immutable when model registry is Managed"
+// +kubebuilder:validation:XValidation:rule="(!has(self.managementState) || self.managementState != 'Managed') || (oldSelf.registriesNamespace == '') || (!has(oldSelf.managementState) || oldSelf.managementState != 'Managed') || (self.registriesNamespace == oldSelf.registriesNamespace)",message="RegistriesNamespace is immutable when model registry is Managed"
 //nolint:lll
 
 // DSCModelRegistry contains all the configuration exposed in DSC instance for ModelRegistry component

--- a/bundle/manifests/datasciencecluster.opendatahub.io_datascienceclusters.yaml
+++ b/bundle/manifests/datasciencecluster.opendatahub.io_datascienceclusters.yaml
@@ -297,8 +297,9 @@ spec:
                     x-kubernetes-validations:
                     - message: RegistriesNamespace is immutable when model registry
                         is Managed
-                      rule: (self.managementState != 'Managed') || (oldSelf.registriesNamespace
-                        == '') || (oldSelf.managementState != 'Managed')|| (self.registriesNamespace
+                      rule: (!has(self.managementState) || self.managementState !=
+                        'Managed') || (oldSelf.registriesNamespace == '') || (!has(oldSelf.managementState)
+                        || oldSelf.managementState != 'Managed') || (self.registriesNamespace
                         == oldSelf.registriesNamespace)
                   ray:
                     description: Ray component configuration.
@@ -1233,8 +1234,9 @@ spec:
                     x-kubernetes-validations:
                     - message: RegistriesNamespace is immutable when model registry
                         is Managed
-                      rule: (self.managementState != 'Managed') || (oldSelf.registriesNamespace
-                        == '') || (oldSelf.managementState != 'Managed')|| (self.registriesNamespace
+                      rule: (!has(self.managementState) || self.managementState !=
+                        'Managed') || (oldSelf.registriesNamespace == '') || (!has(oldSelf.managementState)
+                        || oldSelf.managementState != 'Managed') || (self.registriesNamespace
                         == oldSelf.registriesNamespace)
                   ray:
                     description: Ray component configuration.

--- a/bundle/manifests/rhods-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/rhods-operator.clusterserviceversion.yaml
@@ -82,7 +82,7 @@ metadata:
     categories: AI/Machine Learning, Big Data
     certified: "False"
     containerImage: REPLACE_IMAGE:latest
-    createdAt: "2025-11-25T14:57:09Z"
+    createdAt: "2025-11-27T14:14:22Z"
     description: Operator for deployment and management of Red Hat OpenShift AI
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"

--- a/config/crd/bases/datasciencecluster.opendatahub.io_datascienceclusters.yaml
+++ b/config/crd/bases/datasciencecluster.opendatahub.io_datascienceclusters.yaml
@@ -286,8 +286,9 @@ spec:
                     x-kubernetes-validations:
                     - message: RegistriesNamespace is immutable when model registry
                         is Managed
-                      rule: (self.managementState != 'Managed') || (oldSelf.registriesNamespace
-                        == '') || (oldSelf.managementState != 'Managed')|| (self.registriesNamespace
+                      rule: (!has(self.managementState) || self.managementState !=
+                        'Managed') || (oldSelf.registriesNamespace == '') || (!has(oldSelf.managementState)
+                        || oldSelf.managementState != 'Managed') || (self.registriesNamespace
                         == oldSelf.registriesNamespace)
                   ray:
                     description: Ray component configuration.
@@ -1222,8 +1223,9 @@ spec:
                     x-kubernetes-validations:
                     - message: RegistriesNamespace is immutable when model registry
                         is Managed
-                      rule: (self.managementState != 'Managed') || (oldSelf.registriesNamespace
-                        == '') || (oldSelf.managementState != 'Managed')|| (self.registriesNamespace
+                      rule: (!has(self.managementState) || self.managementState !=
+                        'Managed') || (oldSelf.registriesNamespace == '') || (!has(oldSelf.managementState)
+                        || oldSelf.managementState != 'Managed') || (self.registriesNamespace
                         == oldSelf.registriesNamespace)
                   ray:
                     description: Ray component configuration.


### PR DESCRIPTION
* fix: Fix ModelRegistry CEL validation for omitted managementState field
* fix: remove e2e tests
---------

ref https://issues.redhat.com/browse/RHOAIENG-39618
(cherry picked from commit 804aaf95f05b5d0fdeb4cea78e3ff2d11a4817e2)

<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [ ] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->
