### PR TITLE
Adjust Trainer v2 precondition to check JobSet CRD

### DIFF
--- a/internal/controller/components/trainer/trainer_controller_actions.go
+++ b/internal/controller/components/trainer/trainer_controller_actions.go
@@ -19,7 +19,9 @@ package trainer
 import (
 	"context"
 
+	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/status"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
 	odherrors "github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/errors"
 	odhtypes "github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
 )
@@ -31,6 +33,15 @@ func checkPreConditions(ctx context.Context, rr *odhtypes.ReconciliationRequest)
 		}
 
 		return ErrJobSetOperatorNotInstalled
+	}
+
+	jobset, err := cluster.HasCRD(ctx, rr.Client, gvk.JobSetv1alpha2)
+	if err != nil {
+		return odherrors.NewStopError("failed to check %s CRDs version: %w", gvk.JobSetv1alpha2, err)
+	}
+
+	if !jobset {
+		return odherrors.NewStopError(status.JobSetCRDMissingMessage)
 	}
 
 	return nil

--- a/internal/controller/components/trainer/trainer_controller_actions_test.go
+++ b/internal/controller/components/trainer/trainer_controller_actions_test.go
@@ -4,11 +4,18 @@ package trainer
 import (
 	"testing"
 
+	ofapiv2 "github.com/operator-framework/api/pkg/operators/v2"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/api/components/v1alpha1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/status"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/conditions"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/fakeclient"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/scheme"
 
 	. "github.com/onsi/gomega"
 )
@@ -33,4 +40,73 @@ func TestCheckPreConditions_Managed_JobSetOperatorNotInstalled(t *testing.T) {
 	err = checkPreConditions(ctx, &rr)
 	g.Expect(err).Should(HaveOccurred())
 	g.Expect(err).To(MatchError(ContainSubstring(status.JobSetOperatorNotInstalledMessage)))
+}
+
+func TestCheckPreConditions_Managed_JobSetCRDNotInstalled(t *testing.T) {
+	ctx := t.Context()
+	g := NewWithT(t)
+
+	cli, err := fakeclient.New(
+		fakeclient.WithObjects(
+			&ofapiv2.OperatorCondition{ObjectMeta: metav1.ObjectMeta{
+				Name: jobSetOperator,
+			}},
+		),
+	)
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	trainer := componentApi.Trainer{
+		Spec: componentApi.TrainerSpec{},
+	}
+
+	rr := types.ReconciliationRequest{
+		Client:     cli,
+		Instance:   &trainer,
+		Conditions: conditions.NewManager(&trainer, status.ConditionTypeReady),
+	}
+
+	err = checkPreConditions(ctx, &rr)
+	g.Expect(err).Should(HaveOccurred())
+	g.Expect(err).To(MatchError(ContainSubstring(status.JobSetCRDMissingMessage)))
+}
+
+func TestCheckPreConditions_Managed_JobSetCRDInstalled(t *testing.T) {
+	ctx := t.Context()
+	g := NewWithT(t)
+
+	fakeSchema, err := scheme.New()
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	fakeSchema.AddKnownTypeWithName(gvk.JobSetv1alpha2, &unstructured.Unstructured{})
+
+	jobSetCRD := &apiextensionsv1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "jobsets.jobset.x-k8s.io",
+		},
+		Status: apiextensionsv1.CustomResourceDefinitionStatus{
+			StoredVersions: []string{gvk.JobSetv1alpha2.Version},
+		},
+	}
+	jobSetOperatorCondition := &ofapiv2.OperatorCondition{ObjectMeta: metav1.ObjectMeta{
+		Name: jobSetOperator,
+	}}
+
+	cli, err := fakeclient.New(
+		fakeclient.WithScheme(fakeSchema),
+		fakeclient.WithObjects(jobSetCRD, jobSetOperatorCondition),
+	)
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	trainer := componentApi.Trainer{
+		Spec: componentApi.TrainerSpec{},
+	}
+
+	rr := types.ReconciliationRequest{
+		Client:     cli,
+		Instance:   &trainer,
+		Conditions: conditions.NewManager(&trainer, status.ConditionTypeReady),
+	}
+
+	err = checkPreConditions(ctx, &rr)
+	g.Expect(err).ShouldNot(HaveOccurred())
 }

--- a/internal/controller/status/status.go
+++ b/internal/controller/status/status.go
@@ -180,6 +180,7 @@ To uninstall it, you should delete all RayClusters resources from the cluster, d
 // For JobSet operator checks.
 const (
 	JobSetOperatorNotInstalledMessage = "JobSet operator not installed, please install it first"
+	JobSetCRDMissingMessage           = "JobSet CRD does not exist, please create JobSetOperator CR to proceed"
 )
 
 // setConditions is a helper function to set multiple conditions at once.

--- a/pkg/cluster/gvk/gvk.go
+++ b/pkg/cluster/gvk/gvk.go
@@ -637,4 +637,10 @@ var (
 		Version: "v1beta1",
 		Kind:    "Kuadrant",
 	}
+
+	JobSetv1alpha2 = schema.GroupVersionKind{
+		Group:   "jobset.x-k8s.io",
+		Version: "v1alpha2",
+		Kind:    "JobSet",
+	}
 )

--- a/tests/e2e/creation_test.go
+++ b/tests/e2e/creation_test.go
@@ -51,6 +51,7 @@ func dscManagementTestSuite(t *testing.T) {
 	testCases := []TestCase{
 		{"Ensure required operators with custom channels are installed", dscTestCtx.ValidateOperatorsWithCustomChannelsInstallation},
 		{"Ensure required operators are installed", dscTestCtx.ValidateOperatorsInstallation},
+		{"Ensure required resources are created", dscTestCtx.ValidateResourcesCreation},
 		{"Validate creation of DSCInitialization instance", dscTestCtx.ValidateDSCICreation},
 		{"Validate creation of DataScienceCluster instance", dscTestCtx.ValidateDSCCreation},
 		{"Validate HardwareProfile resource", dscTestCtx.ValidateHardwareProfileCR},
@@ -155,6 +156,17 @@ func (tc *DSCTestCtx) ValidateOperatorsInstallation(t *testing.T) {
 	}
 
 	RunTestCases(t, testCases, WithParallel())
+}
+
+// ValidateResourcesCreation validates the creation of the required resources.
+func (tc *DSCTestCtx) ValidateResourcesCreation(t *testing.T) {
+	t.Helper()
+
+	tc.EventuallyResourceCreatedOrUpdated(
+		WithObjectToCreate(CreateJobSetOperator()),
+		WithCondition(jq.Match(`.status.conditions[] | select(.type == "Available") | .status == "True"`)),
+		WithCustomErrorMsg("Failed to create JobSetOperator resource"),
+	)
 }
 
 // ValidateDSCICreation validates the creation of a DSCInitialization.

--- a/tests/e2e/helper_test.go
+++ b/tests/e2e/helper_test.go
@@ -402,6 +402,23 @@ func CreateHardwareProfile(name, namespace, apiVersion string) *unstructured.Uns
 	return hwProfile
 }
 
+// CreateJobSetOperator creates a JobSetOperator CR.
+func CreateJobSetOperator() *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "operator.openshift.io/v1",
+			"kind":       "JobSetOperator",
+			"metadata": map[string]interface{}{
+				"name": "cluster",
+			},
+			"spec": map[string]interface{}{
+				"logLevel":         "Normal",
+				"operatorLogLevel": "Normal",
+			},
+		},
+	}
+}
+
 // CreateNamespaceWithLabels creates a namespace manifest with optional labels for use with WithObjectToCreate.
 func CreateNamespaceWithLabels(name string, labels map[string]string) *corev1.Namespace {
 	ns := &corev1.Namespace{


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->
Trainer v2 controller requires JobSet CRD to be available to start properly.
Adding JobSet CRD check to trainer component preconditions to properly indicate JobSet CRD unavailability in DSC status.

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [ ] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Initialization now verifies the JobSet CRD exists and returns a clear, actionable message if missing.

* **Tests**
  * Added unit tests for both missing and present JobSet CRD scenarios.
  * Added end-to-end validation to ensure required JobSetOperator resources are created.

* **Misc**
  * Added a visible status message constant and new resource identifier for JobSet to support checks and tests.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->