### PR TITLE
[3.3] changed envoy filter to use EDS instead of strict DNS

### DIFF
--- a/internal/controller/services/gateway/resources/envoyfilter-authn.tmpl.yaml
+++ b/internal/controller/services/gateway/resources/envoyfilter-authn.tmpl.yaml
@@ -29,7 +29,8 @@ spec:
           http_service:
             server_uri:
               uri: https://{{.KubeAuthProxyServiceName}}.{{.GatewayNamespace}}.svc.cluster.local:{{.GatewayHTTPSPort}}/oauth2/auth
-              cluster: {{.KubeAuthProxyServiceName}}
+              # Use Istio's auto-created EDS cluster for better load balancing across all pods
+              cluster: outbound|{{.GatewayHTTPSPort}}||{{.KubeAuthProxyServiceName}}.{{.GatewayNamespace}}.svc.cluster.local
               timeout: {{.AuthProxyTimeout}}
             authorization_request:
               allowed_headers:
@@ -106,21 +107,3 @@ spec:
               end
               -- If no auth token present, preserve cookies (needed for ext_authz authentication)
             end
-  - applyTo: CLUSTER
-    match:
-      context: GATEWAY
-    patch:
-      operation: ADD
-      value:
-        name: {{.KubeAuthProxyServiceName}}
-        type: EDS
-        connect_timeout: {{.AuthProxyTimeout}}
-        transport_socket:
-          name: envoy.transport_sockets.tls
-          typed_config:
-            "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
-            common_tls_context:
-              validation_context:
-                trusted_ca:
-                  filename: /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt
-            sni: {{.KubeAuthProxyServiceName}}.{{.GatewayNamespace}}.svc.cluster.local

--- a/tests/e2e/gateway_test.go
+++ b/tests/e2e/gateway_test.go
@@ -408,7 +408,8 @@ func (tc *GatewayTestCtx) ValidateEnvoyFilter(t *testing.T) {
 	authProxyFQDN := getServiceFQDN(kubeAuthProxyName, gatewayNamespace)
 	authProxyHostPort := net.JoinHostPort(authProxyFQDN, strconv.Itoa(kubeAuthProxyHTTPSPort))
 	authProxyURI := "https://" + authProxyHostPort + "/oauth2/auth"
-	serviceCAPath := "/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt"
+	// Istio auto-creates EDS clusters with this naming pattern for better load balancing
+	istioEDSClusterName := fmt.Sprintf("outbound|%d||%s", kubeAuthProxyHTTPSPort, authProxyFQDN)
 
 	tc.EnsureResourceExists(
 		WithMinimalObject(gvk.EnvoyFilter, types.NamespacedName{
@@ -419,8 +420,7 @@ func (tc *GatewayTestCtx) ValidateEnvoyFilter(t *testing.T) {
 			// workload selector
 			jq.Match(`.spec.workloadSelector.labels."%s" == "%s"`, labels.GatewayAPI.GatewayName, gatewayName),
 
-			// config patches length
-			jq.Match(`.spec.configPatches | length == 3`),
+			jq.Match(`.spec.configPatches | length == 2`),
 
 			// Patch 1: ext_authz
 			jq.Match(`.spec.configPatches[0].applyTo == "HTTP_FILTER"`),
@@ -428,8 +428,8 @@ func (tc *GatewayTestCtx) ValidateEnvoyFilter(t *testing.T) {
 			jq.Match(`.spec.configPatches[0].patch.operation == "INSERT_BEFORE"`),
 			jq.Match(`.spec.configPatches[0].patch.value.name == "envoy.filters.http.ext_authz"`),
 
-			// ext_authz config - server/uri and timeout
-			jq.Match(`.spec.configPatches[0].patch.value.typed_config.http_service.server_uri.cluster == "%s"`, kubeAuthProxyName),
+			// ext_authz config - uses Istio's EDS cluster for better load balancing across all pods
+			jq.Match(`.spec.configPatches[0].patch.value.typed_config.http_service.server_uri.cluster == "%s"`, istioEDSClusterName),
 			jq.Match(`.spec.configPatches[0].patch.value.typed_config.http_service.server_uri.timeout == "5s"`),
 			jq.Match(`.spec.configPatches[0].patch.value.typed_config.http_service.server_uri.uri == "%s"`, authProxyURI),
 
@@ -446,24 +446,6 @@ func (tc *GatewayTestCtx) ValidateEnvoyFilter(t *testing.T) {
 			jq.Match(`.spec.configPatches[1].patch.value.typed_config.inline_code | contains("x-auth-request-access-token")`),
 			jq.Match(`.spec.configPatches[1].patch.value.typed_config.inline_code | contains("Bearer")`),
 			jq.Match(`.spec.configPatches[1].patch.value.typed_config.inline_code | contains("authorization")`),
-
-			// Patch 3: Cluster for kube-auth-proxy with EDS
-			jq.Match(`.spec.configPatches[2].applyTo == "CLUSTER"`),
-			jq.Match(`.spec.configPatches[2].match.context == "GATEWAY"`),
-			jq.Match(`.spec.configPatches[2].patch.operation == "ADD"`),
-			jq.Match(`.spec.configPatches[2].patch.value.name == "%s"`, kubeAuthProxyName),
-			jq.Match(`.spec.configPatches[2].patch.value.type == "EDS"`),
-			jq.Match(`.spec.configPatches[2].patch.value.connect_timeout == "5s"`),
-
-			// EDS configuration validation - ensure no static endpoint config
-			jq.Match(`.spec.configPatches[2].patch.value | has("load_assignment") | not`),
-			jq.Match(`.spec.configPatches[2].patch.value | has("hosts") | not`),
-
-			// TLS config for cluster
-			jq.Match(`.spec.configPatches[2].patch.value.transport_socket.name == "envoy.transport_sockets.tls"`),
-			jq.Match(`.spec.configPatches[2].patch.value.transport_socket.typed_config."@type" == "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext"`),
-			jq.Match(`.spec.configPatches[2].patch.value.transport_socket.typed_config.common_tls_context.validation_context.trusted_ca.filename == "%s"`, serviceCAPath),
-			jq.Match(`.spec.configPatches[2].patch.value.transport_socket.typed_config.sni == "%s"`, authProxyFQDN),
 		)),
 		WithCustomErrorMsg("EnvoyFilter should be properly configured for authentication"),
 	)


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->
Why the needed changes?
  - STRICT_DNS required manually specifying the service FQDN and port in load_assignment, which Envoy would resolve via DNS
  - EDS (Endpoint Discovery Service) automatically discovers all pod endpoints behind the kube-auth-proxy service through Kubernetes service discovery
  - With EDS, Envoy will:
    - Automatically detect all healthy kube-auth-proxy pods
    - Distribute load across all available pods
    - Handle pod scaling (up/down) dynamically
    - Remove unhealthy pods from the load balancing pool automatically


<!--- Link your JIRA and related links here for reference. -->
JIRA: [RHOAIENG-40620](https://issues.redhat.com/browse/RHOAIENG-40620)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [ ] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Switched to Istio EDS-based outbound clusters for dynamic endpoint discovery.

* **Bug Fixes**
  * Removed static/DNS-based cluster configuration in favor of EDS to simplify service resolution.

* **Tests**
  * Added end-to-end validation for EDS endpoint discovery and updated EnvoyFilter validation accordingly.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->