### PR TITLE
Fixed codegen to add dsc changes to v2

### DIFF
--- a/cmd/component-codegen/README.md
+++ b/cmd/component-codegen/README.md
@@ -25,7 +25,7 @@ A folder named after the component inside `internal/controller/components` conta
    - component.go
 
 3. API Updates
-Adds an entry of the component in `api/datasciencecluster/v1/datasciencecluster_types.go` within the spec section.
+Adds an entry of the component in `api/datasciencecluster/v2/datasciencecluster_types.go` within the spec section.
 
 4. RBAC Configuration
 Updates the file `internal/controller/datasciencecluster/kubebuilder_rbac.go` with necessary Kubebuilder RBAC markers.

--- a/cmd/component-codegen/cmd/generator/generator.go
+++ b/cmd/component-codegen/cmd/generator/generator.go
@@ -10,7 +10,7 @@ const (
 	cmdDir          = "cmd/component-codegen"
 	ApisDir         = "api/components/v1alpha1"
 	Controllers     = "internal/controller/components"
-	DscTypesPath    = "api/datasciencecluster/v1/datasciencecluster_types.go"
+	DscTypesPath    = "api/datasciencecluster/v2/datasciencecluster_types.go"
 	templatesDir    = cmdDir + "/templates"
 	mainFilePath    = "cmd/main.go"
 	projectFilePath = "PROJECT"


### PR DESCRIPTION
## Description
Fixed codegen cli to generate boilerplate code for dsc under new v2 folder instead of v1

## How Has This Been Tested?
Manually verified the boilerplate code is put under /v2 folder
 
## Merge criteria

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [ x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
Codegen is part of the internal dev tool, doesn't require e2e test at all.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated API version references in the README to point to the newer datasciencecluster v2 types.

* **Chores**
  * Updated the code generator configuration to target datasciencecluster v2 types instead of v1.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->