### PR TITLE
RHOAIENG-39251 | feat: renaming to use data-science prefix

### DIFF
--- a/internal/controller/services/auth/auth_controller_actions.go
+++ b/internal/controller/services/auth/auth_controller_actions.go
@@ -63,7 +63,7 @@ func bindRole(ctx context.Context, rr *odhtypes.ReconciliationRequest, groups []
 	groupsToBind := []rbacv1.Subject{}
 	for _, e := range groups {
 		// we want to disallow adding system:authenticated to the adminGroups
-		if roleName == "admingroup-role" && e == "system:authenticated" || e == "" {
+		if roleName == "data-science-admingroup-role" && e == "system:authenticated" || e == "" {
 			log := logf.FromContext(ctx)
 			log.Info("skipping adding invalid group to RoleBinding")
 			continue
@@ -100,7 +100,7 @@ func bindClusterRole(ctx context.Context, rr *odhtypes.ReconciliationRequest, gr
 	groupsToBind := []rbacv1.Subject{}
 	for _, e := range groups {
 		// we want to disallow adding system:authenticated to the adminGroups
-		if roleName == "admingroupcluster-role" && e == "system:authenticated" || e == "" {
+		if roleName == "data-science-admingroupcluster-role" && e == "system:authenticated" || e == "" {
 			log := logf.FromContext(ctx)
 			log.Info("skipping adding invalid group to ClusterRoleBinding")
 			continue
@@ -139,17 +139,17 @@ func managePermissions(ctx context.Context, rr *odhtypes.ReconciliationRequest) 
 		return errors.New("instance is not of type *services.Auth")
 	}
 
-	err := bindRole(ctx, rr, ai.Spec.AdminGroups, "admingroup-rolebinding", "admingroup-role")
+	err := bindRole(ctx, rr, ai.Spec.AdminGroups, "data-science-admingroup-rolebinding", "data-science-admingroup-role")
 	if err != nil {
 		return err
 	}
 
-	err = bindClusterRole(ctx, rr, ai.Spec.AdminGroups, "admingroupcluster-rolebinding", "admingroupcluster-role")
+	err = bindClusterRole(ctx, rr, ai.Spec.AdminGroups, "data-science-admingroupcluster-rolebinding", "data-science-admingroupcluster-role")
 	if err != nil {
 		return err
 	}
 
-	err = bindClusterRole(ctx, rr, ai.Spec.AllowedGroups, "allowedgroupcluster-rolebinding", "allowedgroupcluster-role")
+	err = bindClusterRole(ctx, rr, ai.Spec.AllowedGroups, "data-science-allowedgroupcluster-rolebinding", "data-science-allowedgroupcluster-role")
 	if err != nil {
 		return err
 	}

--- a/internal/controller/services/auth/auth_controller_actions_test.go
+++ b/internal/controller/services/auth/auth_controller_actions_test.go
@@ -113,14 +113,14 @@ func TestBindRoleValidation(t *testing.T) {
 		{
 			name:          "admin role skips system:authenticated",
 			groups:        []string{"admin1", "system:authenticated", "admin2"},
-			roleName:      "admingroup-role",
+			roleName:      "data-science-admingroup-role",
 			expectSkipped: []string{"system:authenticated"},
 			description:   "Should skip system:authenticated for admin roles",
 		},
 		{
 			name:          "admin role skips empty strings",
 			groups:        []string{"admin1", "", "admin2"},
-			roleName:      "admingroup-role",
+			roleName:      "data-science-admingroup-role",
 			expectSkipped: []string{""},
 			description:   "Should skip empty strings for admin roles",
 		},
@@ -330,11 +330,11 @@ func TestManagePermissions(t *testing.T) {
 	g.Expect(clusterRoleBindings).To(Equal(2), "Should create 2 ClusterRoleBindings")
 
 	// Verify that cluster-scoped roles are created
-	g.Expect(clusterRoleNames).To(ContainElement("admingroupcluster-role"), "Should create admin group cluster role")
-	g.Expect(clusterRoleNames).To(ContainElement("allowedgroupcluster-role"), "Should create allowed group cluster role")
+	g.Expect(clusterRoleNames).To(ContainElement("data-science-admingroupcluster-role"), "Should create admin group cluster role")
+	g.Expect(clusterRoleNames).To(ContainElement("data-science-allowedgroupcluster-role"), "Should create allowed group cluster role")
 
 	// Verify that namespace-scoped roles are created
-	g.Expect(roleNames).To(ContainElement("admingroup-role"), "Should create admin group role")
+	g.Expect(roleNames).To(ContainElement("data-science-admingroup-role"), "Should create admin group role")
 }
 
 // TestManagePermissionsMultipleGroups validates that the controller works correctly
@@ -398,8 +398,8 @@ func TestManagePermissionsMultipleGroups(t *testing.T) {
 
 	g.Expect(roleBindings).To(Equal(1), "Should create 1 RoleBinding")
 	g.Expect(clusterRoleBindings).To(Equal(2), "Should create 2 ClusterRoleBindings")
-	g.Expect(clusterRoleNames).To(ContainElement("admingroupcluster-role"), "Should create admin group cluster role")
-	g.Expect(clusterRoleNames).To(ContainElement("allowedgroupcluster-role"), "Should create allowed group cluster role")
+	g.Expect(clusterRoleNames).To(ContainElement("data-science-admingroupcluster-role"), "Should create admin group cluster role")
+	g.Expect(clusterRoleNames).To(ContainElement("data-science-allowedgroupcluster-role"), "Should create allowed group cluster role")
 	g.Expect(clusterRoleNames).ToNot(ContainElement("data-science-metrics-admin"), "Should not create metrics admin cluster role")
-	g.Expect(roleNames).To(ContainElement("admingroup-role"), "Should create admin group role")
+	g.Expect(roleNames).To(ContainElement("data-science-admingroup-role"), "Should create admin group role")
 }

--- a/internal/controller/services/auth/auth_controller_support.go
+++ b/internal/controller/services/auth/auth_controller_support.go
@@ -5,9 +5,9 @@ import (
 )
 
 const (
-	AdminGroupRoleTemplate          = "resources/admingroup-role.tmpl.yaml"
-	AdminGroupClusterRoleTemplate   = "resources/admingroup-clusterrole.tmpl.yaml"
-	AllowedGroupClusterRoleTemplate = "resources/allowedgroup-clusterrole.tmpl.yaml"
+	AdminGroupRoleTemplate          = "resources/data-science-admingroup-role.tmpl.yaml"
+	AdminGroupClusterRoleTemplate   = "resources/data-science-admingroup-clusterrole.tmpl.yaml"
+	AllowedGroupClusterRoleTemplate = "resources/data-science-allowedgroup-clusterrole.tmpl.yaml"
 )
 
 //go:embed resources

--- a/internal/controller/services/auth/resources/data-science-admingroup-clusterrole.tmpl.yaml
+++ b/internal/controller/services/auth/resources/data-science-admingroup-clusterrole.tmpl.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: admingroupcluster-role
+  name: data-science-admingroupcluster-role
 rules:
   - apiGroups:
       - services.platform.opendatahub.io
@@ -59,3 +59,4 @@ rules:
       - get
       - list
       - watch
+

--- a/internal/controller/services/auth/resources/data-science-admingroup-role.tmpl.yaml
+++ b/internal/controller/services/auth/resources/data-science-admingroup-role.tmpl.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: admingroup-role
+  name: data-science-admingroup-role
   namespace: {{.AppNamespace}}
 rules:
 - apiGroups:
@@ -134,3 +134,4 @@ rules:
     - create
     - patch
     - delete
+

--- a/internal/controller/services/auth/resources/data-science-allowedgroup-clusterrole.tmpl.yaml
+++ b/internal/controller/services/auth/resources/data-science-allowedgroup-clusterrole.tmpl.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: allowedgroupcluster-role
+  name: data-science-allowedgroupcluster-role
 rules:
 - apiGroups:
   - services.platform.opendatahub.io
@@ -17,3 +17,4 @@ rules:
   - auths/status
   verbs:
   - get
+

--- a/tests/e2e/authcontroller_test.go
+++ b/tests/e2e/authcontroller_test.go
@@ -27,16 +27,16 @@ const (
 	systemAuthenticatedGroup = "system:authenticated"
 
 	// Role names used for RBAC configuration.
-	adminGroupRoleName = "admingroup-role"
+	adminGroupRoleName = "data-science-admingroup-role"
 
 	// RoleBinding names to bind roles to specific groups.
-	adminGroupRoleBindingName = "admingroup-rolebinding"
+	adminGroupRoleBindingName = "data-science-admingroup-rolebinding"
 
 	// ClusterRole and ClusterRoleBinding names for group access at cluster level.
-	adminGroupClusterRoleName          = "admingroupcluster-role"
-	adminGroupClusterRoleBindingName   = "admingroupcluster-rolebinding"
-	allowedGroupClusterRoleName        = "allowedgroupcluster-role"
-	allowedGroupClusterRoleBindingName = "allowedgroupcluster-rolebinding"
+	adminGroupClusterRoleName          = "data-science-admingroupcluster-role"
+	adminGroupClusterRoleBindingName   = "data-science-admingroupcluster-rolebinding"
+	allowedGroupClusterRoleName        = "data-science-allowedgroupcluster-role"
+	allowedGroupClusterRoleBindingName = "data-science-allowedgroupcluster-rolebinding"
 )
 
 type AuthControllerTestCtx struct {


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [ ] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized naming conventions for role-based access control (RBAC) resources with a data-science prefix to ensure consistent naming across all authentication and permission management systems.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->