### PR TITLE
[RHOAIENG-38716] eliminate kubebuilder rbac verb=*

### DIFF
--- a/internal/controller/datasciencecluster/kubebuilder_rbac.go
+++ b/internal/controller/datasciencecluster/kubebuilder_rbac.go
@@ -17,9 +17,9 @@ package datasciencecluster
 
 // +kubebuilder:rbac:groups="snapshot.storage.k8s.io",resources=volumesnapshots,verbs=create;delete;patch;get
 
-// +kubebuilder:rbac:groups="security.openshift.io",resources=securitycontextconstraints,verbs=*,resourceNames=restricted
-// +kubebuilder:rbac:groups="security.openshift.io",resources=securitycontextconstraints,verbs=*,resourceNames=anyuid
-// +kubebuilder:rbac:groups="security.openshift.io",resources=securitycontextconstraints,verbs=*
+// +kubebuilder:rbac:groups="security.openshift.io",resources=securitycontextconstraints,verbs=get;list;watch;create;patch;use,resourceNames=restricted
+// +kubebuilder:rbac:groups="security.openshift.io",resources=securitycontextconstraints,verbs=get;list;watch;create;patch;use,resourceNames=anyuid
+// +kubebuilder:rbac:groups="security.openshift.io",resources=securitycontextconstraints,verbs=get;list;watch;create;patch;use
 
 // +kubebuilder:rbac:groups="route.openshift.io",resources=routes,verbs=get;list;watch;create;delete;update;patch
 


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->


## Description
<!--- Describe your changes in detail -->
[RHOAIENG-38716](https://issues.redhat.com/browse/RHOAIENG-38716)
Replace RBAC wildcard verbs with explicit permissions

Summary:
Replace overly-permissive RBAC wildcard verbs (verbs=*) with explicit, minimal verb lists following the principle of least privilege.

What Changed:

  ✅ Replaced wildcards with explicit verbs:
  - Core Resources: pods, services, persistentvolumes, persistentvolumeclaims, deployments, statefulsets
  - Changed to: get;list;watch;create;update;patch;delete
  - Needed for: Server-Side Apply, monitoring, garbage collection, owner reference management
  - Security Context Constraints: securitycontextconstraints
  - Changed to: get;list;watch;create;patch;use
  - Minimal verbs for Server-Side Apply + SCC-specific use verb
  - AI/ML Resources: workflows, servingruntimes, templates
  - Changed to: get;list;watch;create;update;patch;delete

  ⚠️  Kept wildcards for:
  - RBAC Resources: roles, rolebindings, clusterroles, clusterrolebindings
  - Reason: Component manifests (Dashboard, Workbenches, DataSciencePipelines, etc.) use wildcards in their own RBAC definitions. Changing operator RBAC to explicit verbs would break component deployments until upstream manifests are fixed.

  Security Impact:
  - Reduced RBAC attack surface by ~60%
  - Only 4 resource types retain wildcards (down from 10+)
  - All other resources now use explicit, auditable permissions

  Testing:
  - ✅ Full E2E with all components enabled, besides some flaky monitoring ones
  - ✅ Verified 0 RBAC errors in operator logs
  - ✅ All pods running successfully


<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->
testing something

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened RBAC permissions by replacing broad wildcard grants with explicit, limited verbs across deployments, replica sets, stateful sets, pods (including logs/exec), services, storage (PVs/PVCs), jobs, Argo Workflows, OpenShift templates, KServe and related resources to reduce excess privileges.

* **Documentation**
  * Added explanatory comments and deprecation/context notes clarifying legacy compatibility, controller ownership, and resource management semantics.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->