### PR TITLE
feat(RHOAIENG-36192): surface external operator failures via conditions

### DIFF
--- a/internal/controller/components/kserve/kserve.go
+++ b/internal/controller/components/kserve/kserve.go
@@ -43,6 +43,7 @@ const (
 var (
 	conditionTypes = []string{
 		status.ConditionDeploymentsAvailable,
+		status.ConditionDependenciesAvailable,
 	}
 )
 

--- a/internal/controller/components/kserve/kserve_support.go
+++ b/internal/controller/components/kserve/kserve_support.go
@@ -38,6 +38,12 @@ var (
 	}
 )
 
+const (
+	lwsConditionDegraded                       = "Degraded"
+	lwsConditionTargetConfigControllerDegraded = "TargetConfigControllerDegraded"
+	lwsConditionAvailable                      = "Available"
+)
+
 func kserveManifestInfo(sourcePath string) odhtypes.ManifestInfo {
 	return odhtypes.ManifestInfo{
 		Path:       odhdeploy.DefaultManifestPath,
@@ -168,4 +174,16 @@ func isForDependency(s string) func(u *unstructured.Unstructured) bool {
 func isKserveOwnerRef(or metav1.OwnerReference) bool {
 	return or.APIVersion == componentApi.GroupVersion.String() &&
 		or.Kind == componentApi.KserveKind
+}
+
+// lwsConditionFilter monitors LeaderWorkerSet operator conditions for degraded state.
+func lwsConditionFilter(condType, condStatus string) bool {
+	switch condType {
+	case lwsConditionDegraded, lwsConditionTargetConfigControllerDegraded:
+		return condStatus == string(metav1.ConditionTrue)
+	case lwsConditionAvailable:
+		return condStatus == string(metav1.ConditionFalse)
+	default:
+		return false
+	}
 }

--- a/internal/controller/components/kserve/kserve_test.go
+++ b/internal/controller/components/kserve/kserve_test.go
@@ -264,6 +264,75 @@ func createKserveCR(ready bool) *componentApi.Kserve {
 	return &c
 }
 
+func TestLwsConditionFilter(t *testing.T) {
+	tests := []struct {
+		name           string
+		conditionType  string
+		conditionValue string
+		shouldDegrade  bool
+	}{
+		// Degraded conditions
+		{
+			name:           "Degraded=True triggers degradation",
+			conditionType:  "Degraded",
+			conditionValue: "True",
+			shouldDegrade:  true,
+		},
+		{
+			name:           "TargetConfigControllerDegraded=True triggers degradation",
+			conditionType:  "TargetConfigControllerDegraded",
+			conditionValue: "True",
+			shouldDegrade:  true,
+		},
+		{
+			name:           "Available=False triggers degradation",
+			conditionType:  "Available",
+			conditionValue: "False",
+			shouldDegrade:  true,
+		},
+		// Healthy conditions
+		{
+			name:           "Degraded=False is healthy",
+			conditionType:  "Degraded",
+			conditionValue: "False",
+			shouldDegrade:  false,
+		},
+		{
+			name:           "TargetConfigControllerDegraded=False is healthy",
+			conditionType:  "TargetConfigControllerDegraded",
+			conditionValue: "False",
+			shouldDegrade:  false,
+		},
+		{
+			name:           "Available=True is healthy",
+			conditionType:  "Available",
+			conditionValue: "True",
+			shouldDegrade:  false,
+		},
+		// Conditions not in filter (should be ignored)
+		{
+			name:           "Progressing=True is ignored",
+			conditionType:  "Progressing",
+			conditionValue: "True",
+			shouldDegrade:  false,
+		},
+		{
+			name:           "Unknown condition type is ignored",
+			conditionType:  "SomeOtherCondition",
+			conditionValue: "True",
+			shouldDegrade:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			result := lwsConditionFilter(tt.conditionType, tt.conditionValue)
+			g.Expect(result).To(Equal(tt.shouldDegrade))
+		})
+	}
+}
+
 func TestVersionedWellKnownLLMInferenceServiceConfigs(t *testing.T) {
 	tests := []struct {
 		name           string

--- a/internal/controller/components/trainer/trainer_support.go
+++ b/internal/controller/components/trainer/trainer_support.go
@@ -1,6 +1,8 @@
 package trainer
 
 import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/api/components/v1alpha1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/status"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
@@ -11,6 +13,11 @@ const (
 	ComponentName = componentApi.TrainerComponentName
 
 	ReadyConditionType = componentApi.TrainerKind + status.ReadySuffix
+
+	jobSetConditionDegraded                       = "Degraded"
+	jobSetConditionTargetConfigControllerDegraded = "TargetConfigControllerDegraded"
+	jobSetConditionStaticResourcesDegraded        = "JobSetOperatorStaticResourcesDegraded"
+	jobSetConditionAvailable                      = "Available"
 )
 
 var (
@@ -22,6 +29,7 @@ var (
 
 	conditionTypes = []string{
 		status.ConditionDeploymentsAvailable,
+		status.ConditionDependenciesAvailable,
 	}
 )
 
@@ -30,5 +38,17 @@ func manifestPath() types.ManifestInfo {
 		Path:       odhdeploy.DefaultManifestPath,
 		ContextDir: ComponentName,
 		SourcePath: "rhoai",
+	}
+}
+
+// jobSetConditionFilter monitors JobSet operator conditions for degraded state.
+func jobSetConditionFilter(condType, condStatus string) bool {
+	switch condType {
+	case jobSetConditionDegraded, jobSetConditionTargetConfigControllerDegraded, jobSetConditionStaticResourcesDegraded:
+		return condStatus == string(metav1.ConditionTrue)
+	case jobSetConditionAvailable:
+		return condStatus == string(metav1.ConditionFalse)
+	default:
+		return false
 	}
 }

--- a/internal/controller/datasciencecluster/kubebuilder_rbac.go
+++ b/internal/controller/datasciencecluster/kubebuilder_rbac.go
@@ -234,6 +234,7 @@ package datasciencecluster
 // +kubebuilder:rbac:groups="inference.networking.x-k8s.io",resources=inferencemodels,verbs=get;list;watch
 // +kubebuilder:rbac:groups="kuadrant.io",resources=kuadrants,verbs=get;list;watch
 // +kubebuilder:rbac:groups="operator.openshift.io",resources=leaderworkersetoperators,verbs=get;list;watch
+// +kubebuilder:rbac:groups="operator.openshift.io",resources=jobsetoperators,verbs=get;list;watch
 
 // WB
 // +kubebuilder:rbac:groups=components.platform.opendatahub.io,resources=workbenches,verbs=get;list;watch;create;update;patch;delete

--- a/internal/controller/status/status.go
+++ b/internal/controller/status/status.go
@@ -79,6 +79,7 @@ const (
 	ConditionTypeProvisioningSucceeded           = "ProvisioningSucceeded"
 	ConditionDeploymentsNotAvailableReason       = "DeploymentsNotReady"
 	ConditionDeploymentsAvailable                = "DeploymentsAvailable"
+	ConditionDependenciesAvailable               = "DependenciesAvailable"
 	ConditionArgoWorkflowAvailable               = "ArgoWorkflowAvailable"
 	ConditionTypeComponentsReady                 = "ComponentsReady"
 	ConditionMonitoringAvailable                 = "MonitoringAvailable"

--- a/pkg/cluster/gvk/gvk.go
+++ b/pkg/cluster/gvk/gvk.go
@@ -422,6 +422,18 @@ var (
 		Kind:    "Kueue",
 	}
 
+	LeaderWorkerSetOperatorV1 = schema.GroupVersionKind{
+		Group:   "operator.openshift.io",
+		Version: "v1",
+		Kind:    "LeaderWorkerSetOperator",
+	}
+
+	JobSetOperatorV1 = schema.GroupVersionKind{
+		Group:   "operator.openshift.io",
+		Version: "v1",
+		Kind:    "JobSetOperator",
+	}
+
 	LocalQueue = schema.GroupVersionKind{
 		Group:   "kueue.x-k8s.io",
 		Version: "v1beta1",
@@ -618,12 +630,6 @@ var (
 		Group:   "admissionregistration.k8s.io",
 		Version: "v1",
 		Kind:    "ValidatingAdmissionPolicyBinding",
-	}
-
-	LeaderWorkerSetOperator = schema.GroupVersionKind{
-		Group:   "operator.openshift.io",
-		Version: "v1",
-		Kind:    "LeaderWorkerSetOperator",
 	}
 
 	AuthPolicyv1 = schema.GroupVersionKind{

--- a/pkg/controller/actions/dependency/action_operator.go
+++ b/pkg/controller/actions/dependency/action_operator.go
@@ -1,0 +1,269 @@
+package dependency
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	k8serr "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlLog "sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/opendatahub-io/opendatahub-operator/v2/api/common"
+	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/status"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions"
+	cond "github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/conditions"
+	odhtypes "github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
+)
+
+const (
+	dependencyDegradedReason = "DependencyDegraded"
+
+	degradedConditionType  = "Degraded"
+	availableConditionType = "Available"
+	readyConditionType     = "Ready"
+)
+
+// DegradedConditionFilterFunc defines a function that returns true if the condition indicates a degraded state.
+type DegradedConditionFilterFunc func(conditionType string, status string) bool
+
+// OperatorConfig defines configuration for monitoring a dependent operator.
+type OperatorConfig struct {
+	// OperatorGVK is the GVK of the dependent operator CR
+	OperatorGVK schema.GroupVersionKind
+
+	// CRName is the name of the dependent operator CR.
+	// If left empty, the action will monitor the first CR in the namespace.
+	CRName string
+
+	// CRNamespace is the namespace where the operator CR lives.
+	// Leave empty for cluster-scoped resources.
+	CRNamespace string
+
+	// Filter allows customizing how degraded conditions are evaluated.
+	// If nil, DefaultDegradedConditionFilter is used.
+	Filter DegradedConditionFilterFunc
+
+	// Severity determines how degraded conditions affect component readiness.
+	// Use ConditionSeverityError ("") for required dependencies (affects Ready).
+	// Use ConditionSeverityInfo for optional dependencies (informational only).
+	// Default: ConditionSeverityError
+	Severity common.ConditionSeverity
+}
+
+// Action monitors dependent operators for degraded conditions and propagates them to the component CR.
+type Action struct {
+	configs []OperatorConfig
+}
+
+// ActionOpts is a functional option for configuring the Action.
+type ActionOpts func(*Action)
+
+// MonitorOperator adds an operator to monitor for degraded conditions.
+func MonitorOperator(config OperatorConfig) ActionOpts {
+	return func(a *Action) {
+		a.configs = append(a.configs, config)
+	}
+}
+
+// run propagates upstream operator health to component status.
+// It aggregates degraded conditions from all configured operators into a single
+// DependenciesAvailable condition, allowing users to see upstream failures
+// that may be blocking their component from working correctly.
+func (a *Action) run(ctx context.Context, rr *odhtypes.ReconciliationRequest) error {
+	var allDegraded []string
+	hasErrorSeverity := false
+
+	for _, config := range a.configs {
+		degraded := a.collectDegradedConditions(ctx, rr, config)
+		if len(degraded) > 0 {
+			allDegraded = append(allDegraded, degraded...)
+			// Error severity is "" (default), Info is "Info"
+			if config.Severity == "" || config.Severity == common.ConditionSeverityError {
+				hasErrorSeverity = true
+			}
+		}
+	}
+
+	if len(allDegraded) > 0 {
+		severity := common.ConditionSeverityInfo
+		if hasErrorSeverity {
+			severity = common.ConditionSeverityError
+		}
+		rr.Conditions.MarkFalse(
+			status.ConditionDependenciesAvailable,
+			cond.WithSeverity(severity),
+			cond.WithReason(dependencyDegradedReason),
+			cond.WithMessage("Dependencies degraded: %s", strings.Join(allDegraded, "; ")),
+		)
+	} else {
+		rr.Conditions.MarkTrue(status.ConditionDependenciesAvailable)
+	}
+
+	return nil
+}
+
+// collectDegradedConditions detects when an external operator dependency is unhealthy.
+// Returns an empty slice if the operator is healthy, not installed, or cannot be checked.
+// Errors are logged instead of returned so that monitoring don't break reconciliation.
+func (a *Action) collectDegradedConditions(ctx context.Context, rr *odhtypes.ReconciliationRequest, config OperatorConfig) []string {
+	externalCR := &unstructured.Unstructured{}
+	externalCR.SetGroupVersionKind(config.OperatorGVK)
+
+	var err error
+	if config.CRName == "" {
+		err = a.getFirstCR(ctx, rr, config, externalCR)
+	} else {
+		err = rr.Client.Get(ctx, types.NamespacedName{
+			Name:      config.CRName,
+			Namespace: config.CRNamespace,
+		}, externalCR)
+	}
+
+	if k8serr.IsNotFound(err) || meta.IsNoMatchError(err) {
+		// Operator or CRD not installed - not degraded
+		return nil
+	}
+	if err != nil {
+		// Log and continue - monitoring failures should not break reconciliation
+		logger := ctrlLog.FromContext(ctx)
+		logger.V(3).Info("Failed to get operator CR for dependency monitoring",
+			"gvk", config.OperatorGVK.String(),
+			"error", err.Error())
+		return nil
+	}
+
+	// Extract operator health conditions to detect degradation patterns
+	conditions, found, err := unstructured.NestedSlice(externalCR.Object, "status", "conditions")
+	if err != nil {
+		// Log and continue - malformed status should not break reconciliation
+		logger := ctrlLog.FromContext(ctx)
+		logger.V(3).Info("Failed to parse conditions from operator CR",
+			"gvk", config.OperatorGVK.String(),
+			"error", err.Error())
+		return nil
+	}
+	if !found {
+		// No conditions - operator is healthy
+		return nil
+	}
+
+	filter := config.Filter
+	if filter == nil {
+		filter = DefaultDegradedConditionFilter
+	}
+
+	// Aggregate failing conditions for the user-facing error message.
+
+	// Include the specific CR name (namespace/name when available) to make the
+	// surfaced dependency error actionable if multiple CRs of the same Kind are present.
+	crIdentifier := externalCR.GetName()
+	if config.CRNamespace != "" && crIdentifier != "" {
+		crIdentifier = fmt.Sprintf("%s/%s", config.CRNamespace, crIdentifier)
+	}
+
+	var degradedConditions []string
+	for _, c := range conditions {
+		condMap, ok := c.(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		condType, _, _ := unstructured.NestedString(condMap, "type")
+		condStatus, _, _ := unstructured.NestedString(condMap, "status")
+
+		if filter(condType, condStatus) {
+			reason, _, _ := unstructured.NestedString(condMap, "reason")
+			message, _, _ := unstructured.NestedString(condMap, "message")
+
+			// Include operator name and CR identifier so users know more explicitly which dependency failed
+			condPrefix := config.OperatorGVK.Kind
+			if crIdentifier != "" {
+				condPrefix = fmt.Sprintf("%s %s", condPrefix, crIdentifier)
+			}
+			condDetail := fmt.Sprintf("%s: %s=%s", condPrefix, condType, condStatus)
+			if reason != "" {
+				condDetail += fmt.Sprintf(" (%s)", reason)
+			}
+			if message != "" {
+				condDetail += fmt.Sprintf(": %s", message)
+			}
+			degradedConditions = append(degradedConditions, condDetail)
+		}
+	}
+
+	return degradedConditions
+}
+
+func (a *Action) getFirstCR(ctx context.Context, rr *odhtypes.ReconciliationRequest, config OperatorConfig, out *unstructured.Unstructured) error {
+	// Support both namespace-scoped and cluster-scoped operator CRs:
+	// namespace-scoped operators set CRNamespace, cluster-scoped ones leave it empty.
+	list := &unstructured.UnstructuredList{}
+	list.SetGroupVersionKind(config.OperatorGVK)
+
+	// Use a minimal limit to detect when multiple CRs exist without pulling large lists.
+	// If more than one is returned, selection is arbitrary and we log a warning further down.
+	lo := []client.ListOption{client.Limit(2)}
+	if config.CRNamespace != "" {
+		lo = append(lo, client.InNamespace(config.CRNamespace))
+	}
+
+	// Note: without a CRName we rely on the API server returning “some” item.
+	// Limit avoids large list payloads; order is undefined, so this is a
+	// best-effort fallback for cases where callers do not specify CRName.
+	// The alternative would be to fetch all items, but that could be expensive.
+	if err := rr.Client.List(ctx, list, lo...); err != nil {
+		return err
+	}
+
+	if len(list.Items) == 0 {
+		return k8serr.NewNotFound(schema.GroupResource{
+			Group:    config.OperatorGVK.Group,
+			Resource: config.OperatorGVK.Kind,
+		}, "")
+	}
+
+	// If multiple CRs are present, selection is arbitrary; log a warning.
+	if len(list.Items) > 1 {
+		logger := ctrlLog.FromContext(ctx)
+		logger.Info("Dependency monitoring found multiple CRs; relying on first returned item (selection may be arbitrary)",
+			"gvk", config.OperatorGVK.String(),
+			"namespace", config.CRNamespace)
+	}
+
+	*out = list.Items[0]
+	return nil
+}
+
+// DefaultDegradedConditionFilter handles some standard Kubernetes operator health patterns.
+func DefaultDegradedConditionFilter(condType, condStatus string) bool {
+	if condType == degradedConditionType && condStatus == string(metav1.ConditionTrue) {
+		return true
+	}
+	if (condType == availableConditionType || condType == readyConditionType) && condStatus == string(metav1.ConditionFalse) {
+		return true
+	}
+
+	return false
+}
+
+// NewAction creates an action that surfaces external operator failures to users.
+//
+// RHOAI components depend on external operators (Kueue, JobSet, LeaderWorkerSet).
+// When these operators are degraded, the RHOAI component cannot function properly.
+// This action monitors their health and blocks component readiness when dependencies
+// fail, surfacing the upstream error to users rather than leaving them guessing.
+func NewAction(opts ...ActionOpts) actions.Fn {
+	action := Action{}
+
+	for _, opt := range opts {
+		opt(&action)
+	}
+
+	return action.run
+}

--- a/pkg/controller/actions/dependency/action_operator_test.go
+++ b/pkg/controller/actions/dependency/action_operator_test.go
@@ -1,0 +1,476 @@
+package dependency_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/rs/xid"
+	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	k8serr "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/api/components/v1alpha1"
+	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/status"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/dependency"
+	cond "github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/conditions"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/envt"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/testf"
+
+	. "github.com/onsi/gomega"
+)
+
+//nolint:gochecknoinits
+func init() {
+	log.SetLogger(zap.New(zap.UseDevMode(true)))
+}
+
+var testOperatorGVK = schema.GroupVersionKind{
+	Group:   "test.opendatahub.io",
+	Version: "v1",
+	Kind:    "TestOperator",
+}
+
+func TestDependencyAction(t *testing.T) {
+	g := NewWithT(t)
+
+	envTest, err := envt.New()
+	g.Expect(err).NotTo(HaveOccurred())
+
+	t.Cleanup(func() {
+		_ = envTest.Stop()
+	})
+
+	ctx := context.Background()
+	cli := envTest.Client()
+
+	// Create CRD once for all test cases
+	createTestOperatorCRD(t, g, ctx, cli)
+
+	tests := []struct {
+		name                string
+		setupOperatorCR     func(g *WithT, ns string) *unstructured.Unstructured
+		filter              dependency.DegradedConditionFilterFunc
+		expectedAvailable   bool
+		expectedMsgContains []string
+	}{
+		{
+			name: "Degraded=True",
+			setupOperatorCR: func(g *WithT, ns string) *unstructured.Unstructured {
+				operatorCR := createOperatorCR(xid.New().String(), ns, testOperatorGVK)
+				setCondition(g, operatorCR, "Degraded", "True", "TestFailed", "Test failure message")
+				createAndUpdateStatus(ctx, g, cli, operatorCR)
+				return operatorCR
+			},
+			expectedAvailable:   false,
+			expectedMsgContains: []string{"Dependencies degraded", testOperatorGVK.Kind, "Degraded=True", "TestFailed", "Test failure message"},
+		},
+		{
+			name: "Ready=False",
+			setupOperatorCR: func(g *WithT, ns string) *unstructured.Unstructured {
+				operatorCR := createOperatorCR(xid.New().String(), ns, testOperatorGVK)
+				setCondition(g, operatorCR, "Ready", "False", "NotReady", "Waiting for something")
+				createAndUpdateStatus(ctx, g, cli, operatorCR)
+				return operatorCR
+			},
+			expectedAvailable:   false,
+			expectedMsgContains: []string{"Dependencies degraded", testOperatorGVK.Kind, "Ready=False", "NotReady", "Waiting for something"},
+		},
+		{
+			name: "Available=False",
+			setupOperatorCR: func(g *WithT, ns string) *unstructured.Unstructured {
+				operatorCR := createOperatorCR(xid.New().String(), ns, testOperatorGVK)
+				setCondition(g, operatorCR, "Available", "False", "Unavailable", "Service unavailable")
+				createAndUpdateStatus(ctx, g, cli, operatorCR)
+				return operatorCR
+			},
+			expectedAvailable:   false,
+			expectedMsgContains: []string{"Dependencies degraded", testOperatorGVK.Kind, "Available=False", "Unavailable", "Service unavailable"},
+		},
+		{
+			name: "healthy (Ready=True)",
+			setupOperatorCR: func(g *WithT, ns string) *unstructured.Unstructured {
+				operatorCR := createOperatorCR(xid.New().String(), ns, testOperatorGVK)
+				setCondition(g, operatorCR, "Ready", "True", "Ready", "All good")
+				createAndUpdateStatus(ctx, g, cli, operatorCR)
+				return operatorCR
+			},
+			expectedAvailable: true,
+		},
+		{
+			name: "healthy (Degraded=False)",
+			setupOperatorCR: func(g *WithT, ns string) *unstructured.Unstructured {
+				operatorCR := createOperatorCR(xid.New().String(), ns, testOperatorGVK)
+				setCondition(g, operatorCR, "Degraded", "False", "AsExpected", "All is well")
+				createAndUpdateStatus(ctx, g, cli, operatorCR)
+				return operatorCR
+			},
+			expectedAvailable: true,
+		},
+		{
+			name: "operator not found",
+			setupOperatorCR: func(g *WithT, ns string) *unstructured.Unstructured {
+				return nil
+			},
+			expectedAvailable: true,
+		},
+		{
+			name: "operator without conditions",
+			setupOperatorCR: func(g *WithT, ns string) *unstructured.Unstructured {
+				operatorCR := createOperatorCR(xid.New().String(), ns, testOperatorGVK)
+				err := cli.Create(ctx, operatorCR)
+				g.Expect(err).NotTo(HaveOccurred())
+				return operatorCR
+			},
+			expectedAvailable: true,
+		},
+		{
+			name: "custom filter",
+			setupOperatorCR: func(g *WithT, ns string) *unstructured.Unstructured {
+				operatorCR := createOperatorCR(xid.New().String(), ns, testOperatorGVK)
+				setCondition(g, operatorCR, "CustomError", "True", "ErrorOccurred", "Custom error")
+				createAndUpdateStatus(ctx, g, cli, operatorCR)
+				return operatorCR
+			},
+			filter: func(condType, status string) bool {
+				return condType == "CustomError" && status == "True"
+			},
+			expectedAvailable:   false,
+			expectedMsgContains: []string{"Dependencies degraded", testOperatorGVK.Kind, "CustomError=True", "ErrorOccurred", "Custom error"},
+		},
+		{
+			name: "multiple degraded conditions",
+			setupOperatorCR: func(g *WithT, ns string) *unstructured.Unstructured {
+				operatorCR := createOperatorCR(xid.New().String(), ns, testOperatorGVK)
+				setMultipleConditions(g, operatorCR, []metav1.Condition{
+					{Type: "Degraded", Status: metav1.ConditionTrue, Reason: "Error1", Message: "First error"},
+					{Type: "Available", Status: metav1.ConditionFalse, Reason: "Unavail", Message: "Second error"},
+					{Type: "Ready", Status: metav1.ConditionTrue, Reason: "Ready", Message: "Healthy"},
+				})
+				createAndUpdateStatus(ctx, g, cli, operatorCR)
+				return operatorCR
+			},
+			expectedAvailable:   false,
+			expectedMsgContains: []string{"Dependencies degraded", "Degraded=True", "First error", "Available=False", "Second error"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			nsn := xid.New().String()
+
+			ns := corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: nsn,
+				},
+			}
+			g.Expect(cli.Create(ctx, &ns)).NotTo(HaveOccurred())
+
+			var operatorCR *unstructured.Unstructured
+			if tt.setupOperatorCR != nil {
+				operatorCR = tt.setupOperatorCR(g, nsn)
+			}
+
+			t.Cleanup(func() {
+				if operatorCR != nil {
+					_ = cli.Delete(ctx, operatorCR)
+				}
+				_ = cli.Delete(ctx, &ns)
+			})
+
+			instance := &componentApi.Kueue{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: xid.New().String(),
+				},
+			}
+
+			config := dependency.OperatorConfig{
+				OperatorGVK: testOperatorGVK,
+				CRNamespace: nsn,
+				Filter:      tt.filter,
+			}
+			if operatorCR != nil {
+				config.CRName = operatorCR.GetName()
+			} else {
+				config.CRName = "missing-operator"
+			}
+
+			condManager := cond.NewManager(instance, status.ConditionDependenciesAvailable)
+			rr := &types.ReconciliationRequest{
+				Client:     cli,
+				Instance:   instance,
+				Conditions: condManager,
+			}
+
+			action := dependency.NewAction(dependency.MonitorOperator(config))
+			err := action(ctx, rr)
+			g.Expect(err).NotTo(HaveOccurred())
+
+			cond := condManager.GetCondition(status.ConditionDependenciesAvailable)
+			g.Expect(cond).NotTo(BeNil())
+
+			if tt.expectedAvailable {
+				g.Expect(cond.Status).To(Equal(metav1.ConditionTrue))
+			} else {
+				g.Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+				g.Expect(cond.Reason).To(Equal("DependencyDegraded"))
+				for _, substr := range tt.expectedMsgContains {
+					g.Expect(cond.Message).To(ContainSubstring(substr))
+				}
+			}
+		})
+	}
+}
+
+func TestDependencyAction_MultipleOperators(t *testing.T) {
+	g := NewWithT(t)
+
+	envTest, err := envt.New()
+	g.Expect(err).NotTo(HaveOccurred())
+
+	t.Cleanup(func() {
+		_ = envTest.Stop()
+	})
+
+	ctx := context.Background()
+	cli := envTest.Client()
+	nsn := xid.New().String()
+
+	ns := corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: nsn,
+		},
+	}
+	g.Expect(cli.Create(ctx, &ns)).NotTo(HaveOccurred())
+
+	createTestOperatorCRD(t, g, ctx, cli)
+
+	operator1 := createOperatorCR(xid.New().String(), nsn, testOperatorGVK)
+	setCondition(g, operator1, "Ready", "True", "Ready", "Ready")
+	createAndUpdateStatus(ctx, g, cli, operator1)
+	t.Cleanup(func() { _ = cli.Delete(ctx, operator1) })
+
+	operator2 := createOperatorCR(xid.New().String(), nsn, testOperatorGVK)
+	setCondition(g, operator2, "Degraded", "True", "Failed", "Something went wrong")
+	createAndUpdateStatus(ctx, g, cli, operator2)
+	t.Cleanup(func() { _ = cli.Delete(ctx, operator2) })
+
+	instance := &componentApi.Kueue{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: xid.New().String(),
+		},
+	}
+
+	condManager := cond.NewManager(instance, status.ConditionDependenciesAvailable)
+	rr := &types.ReconciliationRequest{
+		Client:     cli,
+		Instance:   instance,
+		Conditions: condManager,
+	}
+
+	action := dependency.NewAction(
+		dependency.MonitorOperator(dependency.OperatorConfig{
+			OperatorGVK: testOperatorGVK,
+			CRName:      operator1.GetName(),
+			CRNamespace: nsn,
+		}),
+		dependency.MonitorOperator(dependency.OperatorConfig{
+			OperatorGVK: testOperatorGVK,
+			CRName:      operator2.GetName(),
+			CRNamespace: nsn,
+		}),
+	)
+
+	err = action(ctx, rr)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	cond := condManager.GetCondition(status.ConditionDependenciesAvailable)
+	g.Expect(cond).NotTo(BeNil())
+	g.Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+	g.Expect(cond.Reason).To(Equal("DependencyDegraded"))
+	g.Expect(cond.Message).To(ContainSubstring(testOperatorGVK.Kind))
+	g.Expect(cond.Message).To(ContainSubstring("Degraded=True"))
+}
+
+func TestDependencyAction_VariableCRName(t *testing.T) {
+	g := NewWithT(t)
+
+	envTest, err := envt.New()
+	g.Expect(err).NotTo(HaveOccurred())
+
+	t.Cleanup(func() {
+		_ = envTest.Stop()
+	})
+
+	ctx := context.Background()
+	cli := envTest.Client()
+	nsn := xid.New().String()
+
+	ns := corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: nsn,
+		},
+	}
+	g.Expect(cli.Create(ctx, &ns)).NotTo(HaveOccurred())
+
+	createTestOperatorCRD(t, g, ctx, cli)
+
+	operatorCR := createOperatorCR(xid.New().String(), nsn, testOperatorGVK)
+	setCondition(g, operatorCR, "Degraded", "True", "TestReason", "Test message")
+	createAndUpdateStatus(ctx, g, cli, operatorCR)
+	t.Cleanup(func() { _ = cli.Delete(ctx, operatorCR) })
+
+	instance := &componentApi.Kueue{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: xid.New().String(),
+		},
+	}
+
+	condManager := cond.NewManager(instance, status.ConditionDependenciesAvailable)
+	rr := &types.ReconciliationRequest{
+		Client:     cli,
+		Instance:   instance,
+		Conditions: condManager,
+	}
+
+	action := dependency.NewAction(
+		dependency.MonitorOperator(dependency.OperatorConfig{
+			OperatorGVK: testOperatorGVK,
+			CRNamespace: nsn,
+		}),
+	)
+
+	err = action(ctx, rr)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	cond := condManager.GetCondition(status.ConditionDependenciesAvailable)
+	g.Expect(cond).NotTo(BeNil())
+	g.Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+}
+
+// Helper functions
+
+func createTestOperatorCRD(t *testing.T, g *WithT, ctx context.Context, cli client.Client) {
+	t.Helper()
+
+	crd := apiextensionsv1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "testoperators." + testOperatorGVK.Group,
+		},
+		Spec: apiextensionsv1.CustomResourceDefinitionSpec{
+			Group: testOperatorGVK.Group,
+			Names: apiextensionsv1.CustomResourceDefinitionNames{
+				Kind:     testOperatorGVK.Kind,
+				ListKind: testOperatorGVK.Kind + "List",
+				Plural:   "testoperators",
+				Singular: "testoperator",
+			},
+			Scope: apiextensionsv1.NamespaceScoped,
+			Versions: []apiextensionsv1.CustomResourceDefinitionVersion{
+				{
+					Name:    testOperatorGVK.Version,
+					Served:  true,
+					Storage: true,
+					Schema: &apiextensionsv1.CustomResourceValidation{
+						OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
+							Type: "object",
+							Properties: map[string]apiextensionsv1.JSONSchemaProps{
+								"spec": {
+									Type:                   "object",
+									XPreserveUnknownFields: pointer(true),
+								},
+								"status": {
+									Type:                   "object",
+									XPreserveUnknownFields: pointer(true),
+								},
+							},
+						},
+					},
+					Subresources: &apiextensionsv1.CustomResourceSubresources{
+						Status: &apiextensionsv1.CustomResourceSubresourceStatus{},
+					},
+				},
+			},
+		},
+	}
+
+	t.Cleanup(func() {
+		g.Eventually(func() error {
+			return cli.Delete(ctx, &crd)
+		}).Should(Or(
+			Not(HaveOccurred()),
+			MatchError(k8serr.IsNotFound, "IsNotFound"),
+		))
+	})
+
+	err := cli.Create(ctx, &crd)
+	if err != nil && !k8serr.IsAlreadyExists(err) {
+		g.Expect(err).NotTo(HaveOccurred())
+	}
+
+	// Wait for CRD to be established
+	g.Eventually(func() bool {
+		err := cli.Get(ctx, client.ObjectKeyFromObject(&crd), &crd)
+		if err != nil {
+			return false
+		}
+		for _, cond := range crd.Status.Conditions {
+			if cond.Type == apiextensionsv1.Established && cond.Status == apiextensionsv1.ConditionTrue {
+				return true
+			}
+		}
+		return false
+	}).Should(BeTrue(), "CRD should be established")
+}
+
+func pointer[T any](v T) *T {
+	return &v
+}
+
+func createOperatorCR(name, namespace string, gvk schema.GroupVersionKind) *unstructured.Unstructured {
+	cr := &unstructured.Unstructured{}
+	cr.SetGroupVersionKind(gvk)
+	cr.SetName(name)
+	cr.SetNamespace(namespace)
+	return cr
+}
+
+func setCondition(g *WithT, cr *unstructured.Unstructured, cType, status, reason, message string) {
+	condition := metav1.Condition{
+		Type:               cType,
+		Status:             metav1.ConditionStatus(status),
+		Reason:             reason,
+		Message:            message,
+		LastTransitionTime: metav1.Now(),
+	}
+	err := testf.SetTypedConditions(cr, []metav1.Condition{condition})
+	g.Expect(err).NotTo(HaveOccurred())
+}
+
+func setMultipleConditions(g *WithT, cr *unstructured.Unstructured, conditions []metav1.Condition) {
+	err := testf.SetTypedConditions(cr, conditions)
+	g.Expect(err).NotTo(HaveOccurred())
+}
+
+func createAndUpdateStatus(ctx context.Context, g *WithT, cli client.Client, cr *unstructured.Unstructured) {
+	// Store the status before creation (it will be stripped)
+	statusObj, hasStatus, _ := unstructured.NestedMap(cr.Object, "status")
+
+	// Create the CR (status is ignored)
+	err := cli.Create(ctx, cr)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	if hasStatus {
+		// Re-apply the status and update it
+		_ = unstructured.SetNestedMap(cr.Object, statusObj, "status")
+		err = cli.Status().Update(ctx, cr)
+		g.Expect(err).NotTo(HaveOccurred())
+	}
+}

--- a/tests/e2e/helper_test.go
+++ b/tests/e2e/helper_test.go
@@ -63,10 +63,13 @@ const (
 	leaderWorkerSetOpName       = "leader-worker-set"                        // Name of the Leader Worker Set Operator
 	leaderWorkerSetNamespace    = "openshift-lws-operator"                   // Namespace for the Leader Worker Set Operator
 	leaderWorkerSetChannel      = "stable-v1.0"                              // Channel for the Leader Worker Set Operator
+	kueueOcpOperatorNamespace   = "openshift-kueue-operator"                 // Namespace for the OCP Kueue Operator
+	kueueOcpOperatorChannel     = "stable-v1.1"                              // Channel for the OCP Kueue Operator
 	kuadrantOpName              = "rhcl-operator"                            // Name of the Red Hat Connectivity Link Operator subscription.
 	kuadrantNamespace           = "kuadrant-system"                          // Namespace for the Red Hat Connectivity Link Operator.
 	dashboardRouteNameODH       = "odh-dashboard"                            // Name of the ODH dashboard route
 	dashboardRouteNameRhoai     = "rhods-dashboard"                          // Name of the Rhoai dashboard route
+
 )
 
 // Configuration and Miscellaneous Constants.

--- a/tests/e2e/kserve_test.go
+++ b/tests/e2e/kserve_test.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	k8slabels "k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -14,6 +16,7 @@ import (
 	"github.com/opendatahub-io/opendatahub-operator/v2/api/common"
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/api/components/v1alpha1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/components/kserve"
+	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/status"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/metadata/annotations"
@@ -22,6 +25,12 @@ import (
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/testf"
 
 	. "github.com/onsi/gomega"
+)
+
+const (
+	// lwsOperatorDeploymentName is the name of the LWS operator deployment within
+	// the CSV. We use this when patching the CSV to scale the operator.
+	lwsOperatorDeploymentName = "openshift-lws-operator"
 )
 
 type KserveTestCtx struct {
@@ -53,6 +62,7 @@ func kserveTestSuite(t *testing.T) {
 		{"Validate update operand resources", componentCtx.ValidateUpdateDeploymentsResources},
 		{"Validate component releases", componentCtx.ValidateComponentReleases},
 		{"Validate well-known LLMInferenceServiceConfig versioning", componentCtx.ValidateLLMInferenceServiceConfigVersioned},
+		{"Validate external operator degraded condition monitoring", componentCtx.ValidateExternalOperatorDegradedMonitoring},
 	}
 
 	// Add webhook tests if enabled
@@ -221,4 +231,193 @@ func (tc *KserveTestCtx) ValidateLLMInferenceServiceConfigVersioned(t *testing.T
 		)),
 		WithCustomErrorMsg("All well-known LLMInferenceServiceConfig resources should have names starting with a semver version (vX-Y-Z-)"),
 	)
+}
+
+// ensureLWSBaseline clears LWS conditions, asserts Kserve component and DSC health.
+// Returns the LWS CR for use in test assertions.
+func (tc *KserveTestCtx) ensureLWSBaseline(t *testing.T) *unstructured.Unstructured {
+	t.Helper()
+
+	kserveNN := types.NamespacedName{Name: componentApi.KserveInstanceName}
+	lwsCR := tc.FetchSingleResourceOfKind(gvk.LeaderWorkerSetOperatorV1, leaderWorkerSetNamespace)
+
+	tc.ClearAllConditionsFromResourceStatus(lwsCR)
+	tc.EnsureResourceExists(
+		WithMinimalObject(tc.GVK, kserveNN),
+		WithCondition(jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, status.ConditionDependenciesAvailable, metav1.ConditionTrue)),
+		WithCondition(jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, status.ConditionTypeReady, metav1.ConditionTrue)),
+	)
+	tc.EnsureResourceExists(
+		WithMinimalObject(gvk.DataScienceCluster, tc.DataScienceClusterNamespacedName),
+		WithCondition(jq.Match(`.status.conditions[] | select(.type == "%sReady") | .status == "%s"`, tc.GVK.Kind, metav1.ConditionTrue)),
+	)
+
+	return lwsCR
+}
+
+// ValidateExternalOperatorDegradedMonitoring ensures that when the external LeaderWorkerSet operator CR
+// has degraded conditions, they properly propagate to the component CR and DSC CR,
+// and that recovery is properly reflected as well.
+//
+// Validates the full condition propagation chain:
+// External Operator CR > Kserve Component CR > DataScienceCluster CR.
+func (tc *KserveTestCtx) ValidateExternalOperatorDegradedMonitoring(t *testing.T) {
+	t.Helper()
+
+	// condition types monitored by the Kserve Component
+	testCases := []degradedConditionTestCase{
+		{
+			name:            "Degraded=True triggers component degradation",
+			conditionType:   "Degraded",
+			conditionStatus: metav1.ConditionTrue,
+		},
+		{
+			name:            "TargetConfigControllerDegraded=True triggers component degradation",
+			conditionType:   "TargetConfigControllerDegraded",
+			conditionStatus: metav1.ConditionTrue,
+		},
+		{
+			name:            "Available=False triggers component degradation",
+			conditionType:   "Available",
+			conditionStatus: metav1.ConditionFalse,
+		},
+	}
+
+	kserveNN := types.NamespacedName{Name: componentApi.KserveInstanceName}
+
+	// Scale external operator only; per-case helpers handle condition clears
+	t.Logf("Ensuring LWS operator deployment is scaled down to prevent condition reset (namespace=%s, name=%s).", leaderWorkerSetNamespace, lwsOperatorDeploymentName)
+	originalReplicas := tc.scaleLWSOperator(t, 0)
+
+	t.Logf("Verifying Kserve component is healthy without LeaderWorkerSetOperator CR (namespace=%s, name=%s).", tc.AppsNamespace, kserveNN.Name)
+	tc.EnsureResourceExists(
+		WithMinimalObject(tc.GVK, kserveNN),
+		WithCondition(
+			jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, status.ConditionDependenciesAvailable, metav1.ConditionTrue),
+		),
+	)
+
+	t.Logf("Creating LeaderWorkerSetOperator CR for condition propagation tests (namespace=%s, name=%s).", leaderWorkerSetNamespace, "cluster")
+	tc.EventuallyResourceCreatedOrUpdated(
+		WithMinimalObject(gvk.LeaderWorkerSetOperatorV1, types.NamespacedName{Name: "cluster", Namespace: leaderWorkerSetNamespace}),
+		WithMutateFunc(func(obj *unstructured.Unstructured) error {
+			return unstructured.SetNestedField(obj.Object, "Managed", "spec", "managementState")
+		}),
+		WithCustomErrorMsg("Failed to create LeaderWorkerSetOperator CR for degraded monitoring test"),
+	)
+
+	t.Logf("Verifying Kserve component is healthy with LeaderWorkerSetOperator CR present (namespace=%s, name=%s).", tc.AppsNamespace, kserveNN.Name)
+	tc.EnsureResourceExists(
+		WithMinimalObject(tc.GVK, kserveNN),
+		WithCondition(
+			jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, status.ConditionDependenciesAvailable, metav1.ConditionTrue),
+		),
+	)
+
+	t.Logf("Verifying DSC is healthy before tests (namespace=%s, name=%s).", tc.DataScienceClusterNamespacedName.Namespace, tc.DataScienceClusterNamespacedName.Name)
+	tc.EnsureResourceExists(
+		WithMinimalObject(gvk.DataScienceCluster, tc.DataScienceClusterNamespacedName),
+		WithCondition(
+			jq.Match(`.status.conditions[] | select(.type == "%sReady") | .status == "%s"`, tc.GVK.Kind, metav1.ConditionTrue),
+		),
+	)
+
+	// Run each test case (inject condition, verify, clear condition, verify recovery)
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			tc.runDegradedConditionTest(t, testCase)
+		})
+	}
+
+	t.Logf("Scaling LWS operator deployment back up (namespace=%s, name=%s).", leaderWorkerSetNamespace, lwsOperatorDeploymentName)
+	tc.scaleLWSOperator(t, originalReplicas)
+
+	t.Log("All external operator degraded condition monitoring tests passed")
+}
+
+// scaleLWSOperator scales the LWS operator deployment by patching the CSV.
+// blocks until the deployment reaches the target replica count.
+func (tc *KserveTestCtx) scaleLWSOperator(t *testing.T, replicas int32) int32 {
+	t.Helper()
+
+	t.Logf("Scaling LWS operator via CSV in namespace %s to %d replicas.", leaderWorkerSetNamespace, replicas)
+	originalReplicas := tc.ScaleCSVDeploymentReplicas(
+		leaderWorkerSetNamespace,
+		"leader-worker-set",
+		lwsOperatorDeploymentName,
+		replicas,
+	)
+	t.Logf("LWS operator deployment scaled to %d replicas in namespace %s.", replicas, leaderWorkerSetNamespace)
+	return originalReplicas
+}
+
+// runDegradedConditionTest runs a single degraded condition test case.
+// It injects a condition, verifies propagation, then recovers and verifies cleanup.
+func (tc *KserveTestCtx) runDegradedConditionTest(t *testing.T, testCase degradedConditionTestCase) {
+	t.Helper()
+
+	t.Logf("Running test case: %s (Condition: %s=%s)", testCase.name, testCase.conditionType, testCase.conditionStatus)
+
+	kserveNN := types.NamespacedName{Name: componentApi.KserveInstanceName}
+
+	// Establish baseline (clears conditions, asserts healthy)
+	lwsCR := tc.ensureLWSBaseline(t)
+
+	t.Logf("Simulating external operator degradation: Injecting %s=%s into operator CR.", testCase.conditionType, testCase.conditionStatus)
+	tc.InjectConditionIntoResourceStatus(
+		lwsCR,
+		testCase.conditionType,
+		testCase.conditionStatus,
+		"TestInjected",
+		"Simulated condition for e2e test: "+testCase.conditionType+"="+string(testCase.conditionStatus),
+	)
+
+	t.Logf("Verifying Kserve component CR (%s) records dependency degradation (info severity).", kserveNN)
+	tc.EnsureResourceExists(
+		WithMinimalObject(tc.GVK, kserveNN),
+		WithCondition(
+			And(
+				jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, status.ConditionDependenciesAvailable, metav1.ConditionFalse),
+				jq.Match(`.status.conditions[] | select(.type == "%s") | .reason == "%s"`, status.ConditionDependenciesAvailable, "DependencyDegraded"),
+				jq.Match(`.status.conditions[] | select(.type == "%s") | .message | contains("Dependencies degraded")`, status.ConditionDependenciesAvailable),
+				jq.Match(`.status.conditions[] | select(.type == "%s") | .message | contains("%s")`, status.ConditionDependenciesAvailable, testCase.conditionType),
+				// Informational dependency: Ready should remain True
+				jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, status.ConditionTypeReady, metav1.ConditionTrue),
+			),
+		),
+	)
+
+	t.Logf("Verifying DSC CR (%s) still shows KserveReady=True (info-level dependency doesn't flip Ready).", tc.DataScienceClusterNamespacedName)
+	tc.EnsureResourceExists(
+		WithMinimalObject(gvk.DataScienceCluster, tc.DataScienceClusterNamespacedName),
+		WithCondition(
+			// KserveReady should stay True for info-level dependency
+			jq.Match(`.status.conditions[] | select(.type == "%sReady") | .status == "%s"`, tc.GVK.Kind, metav1.ConditionTrue),
+		),
+	)
+
+	t.Logf("Clearing injected condition %s from operator CR to test recovery.", testCase.conditionType)
+	lwsCR = tc.FetchSingleResourceOfKind(gvk.LeaderWorkerSetOperatorV1, leaderWorkerSetNamespace)
+	tc.RemoveConditionFromResourceStatus(lwsCR, testCase.conditionType)
+
+	t.Logf("Verifying Kserve component CR (%s) recovers (DependenciesAvailable=True, Ready=True).", kserveNN)
+	tc.EnsureResourceExists(
+		WithMinimalObject(tc.GVK, kserveNN),
+		WithCondition(
+			And(
+				jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, status.ConditionDependenciesAvailable, metav1.ConditionTrue),
+				jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, status.ConditionTypeReady, metav1.ConditionTrue),
+			),
+		),
+	)
+
+	t.Logf("Verifying DSC CR (%s) recovers (KserveReady=True).", tc.DataScienceClusterNamespacedName)
+	tc.EnsureResourceExists(
+		WithMinimalObject(gvk.DataScienceCluster, tc.DataScienceClusterNamespacedName),
+		WithCondition(
+			jq.Match(`.status.conditions[] | select(.type == "%sReady") | .status == "%s"`, tc.GVK.Kind, metav1.ConditionTrue),
+		),
+	)
+
+	t.Logf("Test case passed: %s", testCase.name)
 }

--- a/tests/e2e/kueue_test.go
+++ b/tests/e2e/kueue_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	k8slabels "k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -17,6 +18,7 @@ import (
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/api/components/v1alpha1"
 	infrav1 "github.com/opendatahub-io/opendatahub-operator/v2/api/infrastructure/v1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/components/kueue"
+	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/status"
 	"github.com/opendatahub-io/opendatahub-operator/v2/internal/webhook/envtestutil"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
@@ -27,9 +29,19 @@ import (
 	. "github.com/onsi/gomega"
 )
 
+// degradedConditionTestCase defines a test case for external operator degraded condition monitoring.
+// Used by component tests that validate condition propagation from external operators.
+type degradedConditionTestCase struct {
+	name            string
+	conditionType   string
+	conditionStatus metav1.ConditionStatus
+}
+
+type KueueTestCtx struct {
+	*ComponentTestCtx
+}
+
 const (
-	kueueOcpOperatorNamespace           = "openshift-kueue-operator" // Namespace for the Kueue Operator
-	kueueOcpOperatorChannel             = "stable-v1.1"
 	kueueTestManagedNamespace           = "test-kueue-managed-ns"
 	kueueTestLegacyManagedNamespace     = "test-legacy-kueue-managed-ns"
 	kueueTestWebhookNonManagedNamespace = "test-kueue-webhook-non-managed-ns"
@@ -46,11 +58,15 @@ var (
 	KueueLegacyManagedLabels = map[string]string{
 		cluster.KueueLegacyManagedLabelKey: "true",
 	}
-)
 
-type KueueTestCtx struct {
-	*ComponentTestCtx
-}
+	// kueueOperatorDeploymentNN is the NamespacedName for the OCP Kueue operator deployment.
+	// We scale this down during condition injection to prevent it from resetting conditions.
+	// This is the operator that writes to the Kueue CR status - not the workload controller.
+	kueueOperatorDeploymentNN = types.NamespacedName{
+		Name:      "openshift-kueue-operator",
+		Namespace: kueueOcpOperatorNamespace,
+	}
+)
 
 func kueueTestSuite(t *testing.T) {
 	t.Helper()
@@ -67,6 +83,7 @@ func kueueTestSuite(t *testing.T) {
 		{"Validate component unmanaged error with ocp kueue-operator not installed", componentCtx.ValidateKueueUnmanagedWithoutOcpKueueOperator},
 		{"Validate component removed to unmanaged transition", componentCtx.ValidateKueueRemovedToUnmanagedTransition},
 		{"Validate component unmanaged to removed transition", componentCtx.ValidateKueueUnmanagedToRemovedTransition},
+		{"Validate external operator degraded condition monitoring", componentCtx.ValidateExternalOperatorDegradedMonitoring},
 	}
 
 	// Add webhook tests if enabled
@@ -91,10 +108,12 @@ func (tc *KueueTestCtx) ValidateKueueUnmanagedWithoutOcpKueueOperator(t *testing
 
 	componentName := strings.ToLower(tc.GVK.Kind)
 
+	t.Logf("Setting Kueue component (%s) to Removed mode to start with a clean state.", componentApi.KueueInstanceName)
 	// since the test may be executed on a non-clean state, let clean it up
 	// so first set the component as removed ...
 	tc.UpdateComponentStateInDataScienceCluster(operatorv1.Removed)
 
+	t.Logf("Cleaning up any existing Kueue test resources.")
 	// ... and then cleanup tests resources
 	cleanupKueueTestResources(t, tc.TestContext)
 
@@ -109,6 +128,8 @@ func (tc *KueueTestCtx) ValidateKueueUnmanagedWithoutOcpKueueOperator(t *testing
 		jq.Match(`.status.conditions[] | select(.type == "%sReady") | .status == "%s"`, tc.GVK.Kind, metav1.ConditionFalse),
 	}
 
+	t.Logf("Updating DSC %s to set Kueue managementState to Unmanaged.", tc.DataScienceClusterNamespacedName.Name)
+	t.Logf("Verifying Kueue component stays NotReady (Ready=False) because OCP Kueue Operator is missing.")
 	tc.ConsistentlyResourceCreatedOrUpdated(
 		WithMinimalObject(gvk.DataScienceCluster, tc.DataScienceClusterNamespacedName),
 		WithMutateFunc(testf.Transform(`.spec.components.%s.managementState = "%s"`, componentName, stateUnmanaged)),
@@ -122,13 +143,16 @@ func (tc *KueueTestCtx) ValidateKueueRemovedToUnmanagedTransition(t *testing.T) 
 
 	componentName := strings.ToLower(tc.GVK.Kind)
 
+	t.Logf("Setting Kueue component (%s) to Removed mode to start with a clean state.", componentApi.KueueInstanceName)
 	// since the test may be executed on a non-clean state, let clean it up
 	// so first set the component as removed ...
 	tc.UpdateComponentStateInDataScienceCluster(operatorv1.Removed)
 
+	t.Logf("Cleaning up any existing Kueue test resources.")
 	// ... and then cleanup tests resources
 	cleanupKueueTestResources(t, tc.TestContext)
 
+	t.Logf("Creating test namespace (%s) with Kueue management annotation.", kueueTestManagedNamespace)
 	// Create a test namespace with Kueue management annotation
 	tc.setupNamespace(kueueTestManagedNamespace, KueueManagedLabels)
 
@@ -142,9 +166,11 @@ func (tc *KueueTestCtx) ValidateKueueRemovedToUnmanagedTransition(t *testing.T) 
 		jq.Match(`.status.conditions[] | select(.type == "%sReady") | .status == "%s"`, tc.GVK.Kind, metav1.ConditionFalse),
 	}
 
+	t.Logf("Creating Kueue ConfigMap (%s) to verify default Kueue resource is created correctly.", kueue.KueueConfigMapName)
 	// Create Kueue ConfigMap to verify default Kueue resource is created correctly
 	tc.createKueueConfigMap(t)
 
+	t.Logf("Updating the management state of the component in the DataScienceCluster to Unmanaged (expecting NotReady initially due to missing operator).")
 	// Update the management state of the component in the DataScienceCluster.
 	tc.EventuallyResourcePatched(
 		WithMinimalObject(gvk.DataScienceCluster, tc.DataScienceClusterNamespacedName),
@@ -152,6 +178,7 @@ func (tc *KueueTestCtx) ValidateKueueRemovedToUnmanagedTransition(t *testing.T) 
 		WithCondition(And(conditionsUnmanagedNotReady...)),
 	)
 
+	t.Logf("Installing OCP Kueue Operator (%s/%s) to enable Kueue component readiness.", kueueOcpOperatorNamespace, kueueOpName)
 	// Install ocp kueue-operator
 	tc.EnsureOperatorInstalledWithGlobalOperatorGroupAndChannel(types.NamespacedName{Name: kueueOpName, Namespace: kueueOcpOperatorNamespace}, kueueOcpOperatorChannel)
 
@@ -162,11 +189,13 @@ func (tc *KueueTestCtx) ValidateKueueRemovedToUnmanagedTransition(t *testing.T) 
 		jq.Match(`.status.conditions[] | select(.type == "%sReady") | .status == "%s"`, tc.GVK.Kind, metav1.ConditionTrue),
 	}
 
+	t.Logf("Verifying the component in the DataScienceCluster transitions to Ready state.")
 	tc.EventuallyResourcePatched(
 		WithMinimalObject(gvk.DataScienceCluster, tc.DataScienceClusterNamespacedName),
 		WithCondition(And(conditionsUnmanagedReady...)),
 	)
 
+	t.Logf("Verifying Kueue configuration (%s) is created with all expected frameworks.", kueue.KueueCRName)
 	// Validate that Kueue configuration is created with all expected frameworks
 	tc.EnsureResourceExists(
 		WithMinimalObject(gvk.KueueConfigV1, types.NamespacedName{Name: kueue.KueueCRName}),
@@ -180,14 +209,17 @@ func (tc *KueueTestCtx) ValidateKueueRemovedToUnmanagedTransition(t *testing.T) 
 		WithEventuallyTimeout(tc.TestTimeouts.shortEventuallyTimeout),
 	)
 
+	t.Logf("Verifying default ClusterQueue and LocalQueue resources are created in namespace %s.", kueueTestManagedNamespace)
 	// Default resources should be created
 	tc.ensureClusterAndLocalQueueExist(kueueTestManagedNamespace)
 
+	t.Logf("Verifying default resource flavor (%s) is created.", kueue.DefaultFlavorName)
 	// Validate that default resource flavor is created
 	tc.EnsureResourceExists(
 		WithMinimalObject(gvk.ResourceFlavor, types.NamespacedName{Name: kueue.DefaultFlavorName}),
 	)
 
+	t.Logf("Deleting Kueue ConfigMap (%s) to clean up test resources.", kueue.KueueConfigMapName)
 	tc.DeleteResource(
 		WithMinimalObject(gvk.ConfigMap, types.NamespacedName{Name: kueue.KueueConfigMapName, Namespace: tc.AppsNamespace}),
 		WithIgnoreNotFound(true),
@@ -201,16 +233,21 @@ func (tc *KueueTestCtx) ValidateKueueUnmanagedToRemovedTransition(t *testing.T) 
 
 	componentName := strings.ToLower(tc.GVK.Kind)
 
+	t.Logf("Setting Kueue component (%s) to Removed mode to start with a clean state.", componentApi.KueueInstanceName)
 	// since the test may be executed on a non-clean state, let clean it up
 	// so first set the component as removed ...
 	tc.UpdateComponentStateInDataScienceCluster(operatorv1.Removed)
 
+	t.Logf("Cleaning up any existing Kueue test resources.")
 	// ... and then cleanup tests resources
 	cleanupKueueTestResources(t, tc.TestContext)
 
+	t.Logf("Installing OCP Kueue Operator (%s/%s) before testing Unmanaged state.", kueueOcpOperatorNamespace, kueueOpName)
 	// UNMANAGED
 	// Install ocp kueue-operator
 	tc.EnsureOperatorInstalledWithGlobalOperatorGroupAndChannel(types.NamespacedName{Name: kueueOpName, Namespace: kueueOcpOperatorNamespace}, kueueOcpOperatorChannel)
+
+	t.Logf("Defining expected conditions for Unmanaged state (Ready=True).")
 	stateUnmanaged := operatorv1.Unmanaged
 	conditionsUnmanaged := []gTypes.GomegaMatcher{
 		// Validate that the component's management state is updated correctly
@@ -219,6 +256,7 @@ func (tc *KueueTestCtx) ValidateKueueUnmanagedToRemovedTransition(t *testing.T) 
 		jq.Match(`.status.conditions[] | select(.type == "%sReady") | .status == "%s"`, tc.GVK.Kind, metav1.ConditionTrue),
 	}
 
+	t.Logf("Updating DSC %s to set Kueue managementState to Unmanaged.", tc.DataScienceClusterNamespacedName.Name)
 	// Update the management state of the component in the DataScienceCluster.
 	tc.EventuallyResourcePatched(
 		WithMinimalObject(gvk.DataScienceCluster, tc.DataScienceClusterNamespacedName),
@@ -226,12 +264,15 @@ func (tc *KueueTestCtx) ValidateKueueUnmanagedToRemovedTransition(t *testing.T) 
 		WithCondition(And(conditionsUnmanaged...)),
 	)
 
+	t.Logf("Creating test namespace (%s) with Kueue management annotation.", kueueTestManagedNamespace)
 	// Create a test namespace with Kueue management annotation
 	tc.setupNamespace(kueueTestManagedNamespace, KueueManagedLabels)
 
+	t.Logf("Verifying default Kueue resources exist in namespace %s.", kueueTestManagedNamespace)
 	// Default resources should be created
 	tc.ensureClusterAndLocalQueueExist(kueueTestManagedNamespace)
 
+	t.Logf("Verifying default resource flavor (%s) is created.", kueue.DefaultFlavorName)
 	// Validate that default resource flavor is created
 	tc.EnsureResourceExists(
 		WithMinimalObject(gvk.ResourceFlavor, types.NamespacedName{Name: kueue.DefaultFlavorName}),
@@ -246,6 +287,7 @@ func (tc *KueueTestCtx) ValidateKueueUnmanagedToRemovedTransition(t *testing.T) 
 		jq.Match(`.status.conditions[] | select(.type == "%sReady") | .status == "%s"`, tc.GVK.Kind, metav1.ConditionTrue),
 	}
 
+	t.Logf("Updating DSC %s to set Kueue managementState to Removed.", tc.DataScienceClusterNamespacedName.Name)
 	// Update the management state of the component in the DataScienceCluster to Removed.
 	tc.EventuallyResourcePatched(
 		WithMinimalObject(gvk.DataScienceCluster, tc.DataScienceClusterNamespacedName),
@@ -253,9 +295,11 @@ func (tc *KueueTestCtx) ValidateKueueUnmanagedToRemovedTransition(t *testing.T) 
 		WithCondition(And(conditionsRemovedReady...)),
 	)
 
+	t.Logf("Verifying default resources are still present in namespace %s.", kueueTestManagedNamespace)
 	// Validate default resources are still there
 	tc.ensureClusterAndLocalQueueExist(kueueTestManagedNamespace)
 
+	t.Logf("Cleaning up Kueue test resources.")
 	// Remove Kueue test resources
 	cleanupKueueTestResources(t, tc.TestContext)
 }
@@ -265,18 +309,22 @@ func (tc *KueueTestCtx) ValidateKueueUnmanagedToRemovedTransition(t *testing.T) 
 func (tc *KueueTestCtx) ValidateWebhookValidations(t *testing.T) {
 	t.Helper()
 
+	t.Logf("Setting Workbenches component to Managed to install Notebook CRD for webhook tests.")
 	// Enable Workbenches component to ensure Notebook CRD is available for webhook tests
 	// This is required because webhook tests use Notebook objects which need the Notebook CRD
 	// installed by the Workbenches component
 	tc.UpdateComponentStateInDataScienceClusterWithKind(operatorv1.Managed, componentApi.WorkbenchesKind)
 
+	t.Logf("Running Kueue and Hardware Profile webhook validation subtests.")
 	// Run webhook validation tests as subtests
 	t.Run("Kueue webhook validation", tc.ValidateKueueWebhookValidation)
 	t.Run("Hardware profile webhook validation", tc.ValidateHardwareProfileWebhookValidation)
 
+	t.Logf("Setting Workbenches component to Removed to cleanup Notebook CRD.")
 	// Ensure Workbenches is disabled after tests, even if they fail
 	tc.UpdateComponentStateInDataScienceClusterWithKind(operatorv1.Removed, componentApi.WorkbenchesKind)
 
+	t.Logf("Cleaning up Kueue test resources.")
 	// Remove Kueue test resources
 	cleanupKueueTestResources(t, tc.TestContext)
 }
@@ -285,14 +333,19 @@ func (tc *KueueTestCtx) ValidateWebhookValidations(t *testing.T) {
 func (tc *KueueTestCtx) ValidateKueueWebhookValidation(t *testing.T) {
 	t.Helper()
 
+	t.Logf("Installing OCP Kueue Operator (%s/%s) to enable webhook validation.", kueueOcpOperatorNamespace, kueueOpName)
 	// Install ocp kueue-operator
 	tc.EnsureOperatorInstalledWithGlobalOperatorGroupAndChannel(types.NamespacedName{Name: kueueOpName, Namespace: kueueOcpOperatorNamespace}, kueueOcpOperatorChannel)
+
+	t.Logf("Setting Kueue component to Unmanaged state.")
 	// Ensure Kueue is in Unmanaged state
 	tc.UpdateComponentStateInDataScienceCluster(operatorv1.Unmanaged)
 
+	t.Logf("Creating managed test namespace (%s) with Kueue management annotation.", kueueTestManagedNamespace)
 	// Ensure the managed namespace exists
 	tc.setupNamespace(kueueTestManagedNamespace, KueueManagedLabels)
 
+	t.Logf("Creating non-managed test namespace (%s) for webhook exclusion testing.", kueueTestWebhookNonManagedNamespace)
 	// Create a non-managed namespace for testing
 	tc.EventuallyResourceCreatedOrUpdated(
 		WithObjectToCreate(CreateNamespaceWithLabels(kueueTestWebhookNonManagedNamespace, map[string]string{"test-type": "kqueue"})),
@@ -305,11 +358,13 @@ func (tc *KueueTestCtx) ValidateKueueWebhookValidation(t *testing.T) {
 		return func(t *testing.T) {
 			t.Helper()
 
+			t.Logf("Creating test Notebook (%s) in namespace (%s).", name, namespace)
 			// Create notebook with labels if provided
 			notebook := envtestutil.NewNotebook(name, namespace, envtestutil.WithLabels(labels))
 
 			// Handle blocking case first (exceptional path)
 			if shouldBlock {
+				t.Logf("Verifying webhook blocks creation of invalid Notebook (expected error: %s).", expectedError)
 				tc.EnsureWebhookBlocksResourceCreation(
 					WithObjectToCreate(notebook),
 					WithInvalidValue(expectedError),
@@ -319,6 +374,7 @@ func (tc *KueueTestCtx) ValidateKueueWebhookValidation(t *testing.T) {
 			}
 
 			// Happy path - webhook allows the resource
+			t.Logf("Verifying webhook allows creation of valid Notebook.")
 			tc.EventuallyResourceCreatedOrUpdated(
 				WithObjectToCreate(notebook),
 				WithCustomErrorMsg(errorMsg),
@@ -326,6 +382,7 @@ func (tc *KueueTestCtx) ValidateKueueWebhookValidation(t *testing.T) {
 		}
 	}
 
+	t.Logf("Defining and running Kueue webhook validation test cases.")
 	// Define test cases
 	testCases := []TestCase{
 		{
@@ -374,6 +431,7 @@ func (tc *KueueTestCtx) ValidateKueueWebhookValidation(t *testing.T) {
 		},
 	}
 
+	t.Logf("Executing %d webhook validation test cases.", len(testCases))
 	// Run the test cases
 	RunTestCases(t, testCases)
 }
@@ -382,6 +440,7 @@ func (tc *KueueTestCtx) ValidateKueueWebhookValidation(t *testing.T) {
 func (tc *KueueTestCtx) ValidateHardwareProfileWebhookValidation(t *testing.T) {
 	t.Helper()
 
+	t.Logf("Creating non-managed namespace (%s) for hardware profile testing.", kueueTestHardwareProfileNamespace)
 	// Create a non-managed namespace for hardware profile testing (avoids Kueue validation interference)
 	tc.setupNamespace(kueueTestHardwareProfileNamespace)
 
@@ -469,11 +528,13 @@ func (tc *KueueTestCtx) ValidateHardwareProfileWebhookValidation(t *testing.T) {
 		return func(t *testing.T) {
 			t.Helper()
 
+			t.Logf("Running HardwareProfile test case: %s", testCase.name)
 			// Use the dedicated hardware profile test namespace (non-managed to avoid Kueue validation)
 			testNamespace := kueueTestHardwareProfileNamespace
 
 			// Create hardware profile if spec is provided
 			if testCase.profileSpec != nil {
+				t.Logf("Creating HardwareProfile %s in namespace %s.", testCase.profileName, testNamespace)
 				hwp := envtestutil.NewHardwareProfile(testCase.profileName, testNamespace, envtestutil.WithHardwareProfileSpec(*testCase.profileSpec))
 				tc.EventuallyResourceCreatedOrUpdated(
 					WithObjectToCreate(hwp),
@@ -481,11 +542,13 @@ func (tc *KueueTestCtx) ValidateHardwareProfileWebhookValidation(t *testing.T) {
 				)
 			}
 
+			t.Logf("Creating Notebook workload %s referencing profile %s.", testCase.workloadName, testCase.profileName)
 			// Create notebook workload
 			notebook := envtestutil.NewNotebook(testCase.workloadName, testNamespace, envtestutil.WithHardwareProfile(testCase.profileName))
 
 			// Handle blocking case first (exceptional path)
 			if testCase.shouldBlock {
+				t.Logf("Verifying webhook blocks creation of invalid Notebook (expected error: %s).", testCase.expectedError)
 				tc.EnsureWebhookBlocksResourceCreation(
 					WithObjectToCreate(notebook),
 					WithInvalidValue(testCase.expectedError),
@@ -494,6 +557,7 @@ func (tc *KueueTestCtx) ValidateHardwareProfileWebhookValidation(t *testing.T) {
 				return
 			}
 
+			t.Logf("Verifying webhook allows creation of valid Notebook and resources are injected/scheduled correctly.")
 			// Happy path - webhook allows the resource
 			tc.EventuallyResourceCreatedOrUpdated(
 				WithObjectToCreate(notebook),
@@ -503,6 +567,7 @@ func (tc *KueueTestCtx) ValidateHardwareProfileWebhookValidation(t *testing.T) {
 		}
 	}
 
+	t.Logf("Defining and running HardwareProfile webhook validation test cases.")
 	// Define test cases
 	testCases := []TestCase{
 		{
@@ -587,6 +652,7 @@ func (tc *KueueTestCtx) ValidateHardwareProfileWebhookValidation(t *testing.T) {
 		},
 	}
 
+	t.Logf("Executing %d HardwareProfile test cases.", len(testCases))
 	// Run the test cases
 	RunTestCases(t, testCases)
 }
@@ -644,9 +710,11 @@ func (tc *KueueTestCtx) ensureClusterAndLocalQueueExist(localQueueNamespaceName 
 func (tc *KueueTestCtx) ValidateKueueComponentDisabled(t *testing.T) {
 	t.Helper()
 
+	t.Logf("Setting DSC component %s to Removed state.", componentApi.KueueInstanceName)
 	// Ensure that DataScienceCluster exists and its component state is "Removed", with the "Ready" condition false.
 	tc.UpdateComponentStateInDataScienceCluster(operatorv1.Removed)
 
+	t.Logf("Verifying no Deployments remain in namespace %s with part-of=%s label.", tc.AppsNamespace, strings.ToLower(tc.GVK.Kind))
 	// Ensure that any Deployment resources for the component are not present
 	tc.EnsureResourcesGone(
 		WithMinimalObject(gvk.Deployment, types.NamespacedName{Namespace: tc.AppsNamespace}),
@@ -660,12 +728,15 @@ func (tc *KueueTestCtx) ValidateKueueComponentDisabled(t *testing.T) {
 		WithEventuallyTimeout(tc.TestTimeouts.mediumEventuallyTimeout),
 	)
 
+	t.Logf("Ensuring the component CR %s/%s is removed.", tc.NamespacedName.Namespace, tc.NamespacedName.Name)
 	// Ensure that the resources associated with the component do not exist
 	tc.EnsureResourcesGone(WithMinimalObject(tc.GVK, tc.NamespacedName))
 }
 
 func (tc *KueueTestCtx) createKueueConfigMap(t *testing.T) {
 	t.Helper()
+
+	t.Logf("Creating Kueue ConfigMap (%s) in namespace (%s).", kueue.KueueConfigMapName, tc.AppsNamespace)
 
 	kueueConfigMapYAML := `apiVersion: config.kueue.x-k8s.io/v1beta1
 kind: Configuration
@@ -701,4 +772,198 @@ integrations:
 		WithObjectToCreate(kueueConfigMap),
 		WithCustomErrorMsg("Failed to create Kueue ConfigMap '%s'", kueue.KueueConfigMapName),
 	)
+}
+
+// ValidateExternalOperatorDegradedMonitoring ensures that when the external Kueue operator CR
+// has degraded conditions, they properly propagate to both the component CR and the DSC CR,
+// and that recovery is properly reflected as well.
+//
+// Validates the full condition propagation chain:
+// External Operator CR > Kueue Component CR > DataScienceCluster CR
+//
+// Keep the real Kueue operator installed but scale its deployment to 0 during
+// condition injection. This way OperatorExists() still passes (OLM's OperatorCondition exists),
+// but the operator can't reset conditions we inject.
+func (tc *KueueTestCtx) ValidateExternalOperatorDegradedMonitoring(t *testing.T) {
+	t.Helper()
+
+	// condition types monitored by the Kueue Component
+	testCases := []degradedConditionTestCase{
+		{
+			name:            "Degraded=True triggers component degradation",
+			conditionType:   "Degraded",
+			conditionStatus: metav1.ConditionTrue,
+		},
+		{
+			name:            "Available=False triggers component degradation",
+			conditionType:   "Available",
+			conditionStatus: metav1.ConditionFalse,
+		},
+		{
+			name:            "CertManagerAvailable=False triggers component degradation",
+			conditionType:   "CertManagerAvailable",
+			conditionStatus: metav1.ConditionFalse,
+		},
+	}
+
+	t.Log("Resetting environment for external operator monitoring test (Component=Removed).")
+	tc.UpdateComponentStateInDataScienceCluster(operatorv1.Removed)
+	cleanupKueueTestResources(t, tc.TestContext)
+
+	t.Logf("Ensuring Kueue OCP operator is installed (namespace=%s, name=%s).", kueueOcpOperatorNamespace, kueueOpName)
+	tc.EnsureOperatorInstalledWithGlobalOperatorGroupAndChannel(
+		types.NamespacedName{Name: kueueOpName, Namespace: kueueOcpOperatorNamespace},
+		kueueOcpOperatorChannel,
+	)
+
+	t.Logf("Creating managed test namespace with Kueue management annotation (namespace=%s).", kueueTestManagedNamespace)
+	tc.setupNamespace(kueueTestManagedNamespace, KueueManagedLabels)
+
+	t.Logf("Creating Kueue ConfigMap required for component reconciliation (namespace=%s, name=%s).", tc.AppsNamespace, kueue.KueueConfigMapName)
+	tc.createKueueConfigMap(t)
+
+	t.Logf("Enabling Kueue component by setting to Unmanaged mode (namespace=%s, name=%s).", tc.AppsNamespace, componentApi.KueueInstanceName)
+	tc.UpdateComponentStateInDataScienceCluster(operatorv1.Unmanaged)
+
+	// Kueue operator auto-creates its CR, so the component should be healthy initially
+	t.Logf("Verifying Kueue component is initially healthy (DependenciesAvailable=True) (namespace=%s, name=%s).", tc.AppsNamespace, componentApi.KueueInstanceName)
+	kueueNN := types.NamespacedName{Name: componentApi.KueueInstanceName}
+	tc.EnsureResourceExists(
+		WithMinimalObject(tc.GVK, kueueNN),
+		WithCondition(
+			jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, status.ConditionDependenciesAvailable, metav1.ConditionTrue),
+		),
+	)
+
+	t.Logf("Verifying DSC is healthy (KueueReady=True) before degradation tests (namespace=%s, name=%s).",
+		tc.DataScienceClusterNamespacedName.Namespace, tc.DataScienceClusterNamespacedName.Name)
+	tc.EnsureResourceExists(
+		WithMinimalObject(gvk.DataScienceCluster, tc.DataScienceClusterNamespacedName),
+		WithCondition(
+			jq.Match(`.status.conditions[] | select(.type == "%sReady") | .status == "%s"`, tc.GVK.Kind, metav1.ConditionTrue),
+		),
+	)
+
+	t.Logf("Scaling down Kueue operator deployment to prevent condition reset (namespace=%s, name=%s).", kueueOcpOperatorNamespace, kueueOperatorDeploymentNN.Name)
+	originalReplicas := tc.scaleKueueOperator(t, 0)
+
+	// Run each test case (inject condition, verify, clear condition, verify recovery)
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			tc.runDegradedConditionTestCase(t, testCase)
+		})
+	}
+
+	t.Logf("Scaling Kueue operator deployment back up (namespace=%s, name=%s).", kueueOcpOperatorNamespace, kueueOperatorDeploymentNN.Name)
+	tc.scaleKueueOperator(t, originalReplicas)
+
+	t.Log("All external operator degraded condition monitoring tests passed successfully.")
+}
+
+// ensureKueueBaseline clears Kueue operator conditions, asserts component/DSC healthy.
+// Returns the Kueue CR for use in test assertions.
+func (tc *KueueTestCtx) ensureKueueBaseline(t *testing.T) *unstructured.Unstructured {
+	t.Helper()
+
+	kueueNN := types.NamespacedName{Name: componentApi.KueueInstanceName}
+	kueueCR := tc.FetchSingleResourceOfKind(gvk.KueueConfigV1, "")
+
+	tc.ClearAllConditionsFromResourceStatus(kueueCR)
+	tc.EnsureResourceExists(
+		WithMinimalObject(tc.GVK, kueueNN),
+		WithCondition(jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, status.ConditionDependenciesAvailable, metav1.ConditionTrue)),
+		WithCondition(jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, status.ConditionTypeReady, metav1.ConditionTrue)),
+	)
+	tc.EnsureResourceExists(
+		WithMinimalObject(gvk.DataScienceCluster, tc.DataScienceClusterNamespacedName),
+		WithCondition(jq.Match(`.status.conditions[] | select(.type == "%sReady") | .status == "%s"`, tc.GVK.Kind, metav1.ConditionTrue)),
+	)
+
+	return kueueCR
+}
+
+// scaleKueueOperator scales the Kueue operator deployment by patching the CSV.
+// blocks until the deployment reaches the target replica count.
+func (tc *KueueTestCtx) scaleKueueOperator(t *testing.T, replicas int32) int32 {
+	t.Helper()
+
+	t.Logf("Scaling Kueue operator via CSV in namespace %s to %d replicas.", kueueOcpOperatorNamespace, replicas)
+	originalReplicas := tc.ScaleCSVDeploymentReplicas(
+		kueueOcpOperatorNamespace,
+		"kueue",
+		kueueOperatorDeploymentNN.Name,
+		replicas,
+	)
+	t.Logf("Kueue operator deployment scaled to %d replicas in namespace %s.", replicas, kueueOcpOperatorNamespace)
+	return originalReplicas
+}
+
+// runDegradedConditionTestCase runs a single degraded condition test case.
+// It injects a condition into the Kueue operator CR, verifies propagation to the component CR and DSC,
+// then clears the condition and verifies recovery.
+func (tc *KueueTestCtx) runDegradedConditionTestCase(t *testing.T, testCase degradedConditionTestCase) {
+	t.Helper()
+
+	t.Logf("Running test case: %s (Condition: %s=%s)", testCase.name, testCase.conditionType, testCase.conditionStatus)
+
+	kueueNN := types.NamespacedName{Name: componentApi.KueueInstanceName}
+
+	// Establish baseline (clears conditions, asserts healthy)
+	kueueCR := tc.ensureKueueBaseline(t)
+
+	t.Logf("Simulating external operator degradation: Injecting %s=%s into operator CR.", testCase.conditionType, testCase.conditionStatus)
+	tc.InjectConditionIntoResourceStatus(
+		kueueCR,
+		testCase.conditionType,
+		testCase.conditionStatus,
+		"TestInjected",
+		"Simulated condition for e2e test: "+testCase.conditionType+"="+string(testCase.conditionStatus),
+	)
+
+	t.Logf("Verifying Kueue component CR (%s) reacts by setting DependenciesAvailable=False and Ready=False.", kueueNN)
+	tc.EnsureResourceExists(
+		WithMinimalObject(tc.GVK, kueueNN),
+		WithCondition(
+			And(
+				jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, status.ConditionDependenciesAvailable, metav1.ConditionFalse),
+				jq.Match(`.status.conditions[] | select(.type == "%s") | .reason == "%s"`, status.ConditionDependenciesAvailable, "DependencyDegraded"),
+				jq.Match(`.status.conditions[] | select(.type == "%s") | .message | contains("Dependencies degraded")`, status.ConditionDependenciesAvailable),
+				jq.Match(`.status.conditions[] | select(.type == "%s") | .message | contains("%s")`, status.ConditionDependenciesAvailable, testCase.conditionType),
+				jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, status.ConditionTypeReady, metav1.ConditionFalse),
+			),
+		),
+	)
+
+	t.Logf("Verifying DSC CR (%s) reflects the component's degraded state (KueueReady=False).", tc.DataScienceClusterNamespacedName)
+	tc.EnsureResourceExists(
+		WithMinimalObject(gvk.DataScienceCluster, tc.DataScienceClusterNamespacedName),
+		WithCondition(
+			jq.Match(`.status.conditions[] | select(.type == "%sReady") | .status == "%s"`, tc.GVK.Kind, metav1.ConditionFalse),
+		),
+	)
+
+	t.Logf("Clearing injected condition %s from operator CR to test recovery.", testCase.conditionType)
+	kueueCR = tc.FetchSingleResourceOfKind(gvk.KueueConfigV1, "")
+	tc.RemoveConditionFromResourceStatus(kueueCR, testCase.conditionType)
+
+	t.Logf("Verifying Kueue component CR (%s) recovers (DependenciesAvailable=True, Ready=True).", kueueNN)
+	tc.EnsureResourceExists(
+		WithMinimalObject(tc.GVK, kueueNN),
+		WithCondition(
+			And(
+				jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, status.ConditionDependenciesAvailable, metav1.ConditionTrue),
+				jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, status.ConditionTypeReady, metav1.ConditionTrue),
+			),
+		),
+	)
+
+	t.Logf("Verifying DSC CR (%s) recovers (KueueReady=True).", tc.DataScienceClusterNamespacedName)
+	tc.EnsureResourceExists(
+		WithMinimalObject(gvk.DataScienceCluster, tc.DataScienceClusterNamespacedName),
+		WithCondition(
+			jq.Match(`.status.conditions[] | select(.type == "%sReady") | .status == "%s"`, tc.GVK.Kind, metav1.ConditionTrue),
+		),
+	)
+
+	t.Logf("Test case passed: %s", testCase.name)
 }

--- a/tests/e2e/trainer_test.go
+++ b/tests/e2e/trainer_test.go
@@ -4,8 +4,16 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
 
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/api/components/v1alpha1"
+	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/status"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/matchers/jq"
+
+	. "github.com/onsi/gomega"
 )
 
 type TrainerTestCtx struct {
@@ -28,10 +36,206 @@ func trainerTestSuite(t *testing.T) {
 		{"Validate operands have OwnerReferences", componentCtx.ValidateOperandsOwnerReferences},
 		{"Validate update operand resources", componentCtx.ValidateUpdateDeploymentsResources},
 		{"Validate component releases", componentCtx.ValidateComponentReleases},
+		{"Validate external operator degraded condition monitoring", componentCtx.ValidateExternalOperatorDegradedMonitoring},
 		{"Validate resource deletion recovery", componentCtx.ValidateAllDeletionRecovery},
 		{"Validate component disabled", componentCtx.ValidateComponentDisabled},
 	}
 
 	// Run the test suite.
 	RunTestCases(t, testCases)
+}
+
+// ValidateExternalOperatorDegradedMonitoring ensures that when the external JobSet operator CR
+// has degraded conditions, they properly propagate to the component CR and DSC CR,
+// and that recovery is properly reflected as well.
+//
+// Validates the full condition propagation chain:
+// External Operator CR > Trainer Component CR > DataScienceCluster CR.
+func (tc *TrainerTestCtx) ValidateExternalOperatorDegradedMonitoring(t *testing.T) {
+	t.Helper()
+
+	testCases := []degradedConditionTestCase{
+		{
+			name:            "Degraded=True triggers component degradation",
+			conditionType:   "Degraded",
+			conditionStatus: metav1.ConditionTrue,
+		},
+		{
+			name:            "TargetConfigControllerDegraded=True triggers component degradation",
+			conditionType:   "TargetConfigControllerDegraded",
+			conditionStatus: metav1.ConditionTrue,
+		},
+		{
+			name:            "JobSetOperatorStaticResourcesDegraded=True triggers component degradation",
+			conditionType:   "JobSetOperatorStaticResourcesDegraded",
+			conditionStatus: metav1.ConditionTrue,
+		},
+		{
+			name:            "Available=False triggers component degradation",
+			conditionType:   "Available",
+			conditionStatus: metav1.ConditionFalse,
+		},
+	}
+
+	trainerNN := types.NamespacedName{Name: componentApi.TrainerInstanceName}
+
+	t.Log("Verifying Trainer component is healthy even without JobSetOperator CR.")
+	tc.EnsureResourceExists(
+		WithMinimalObject(tc.GVK, trainerNN),
+		WithCondition(
+			jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, status.ConditionDependenciesAvailable, metav1.ConditionTrue),
+		),
+	)
+
+	t.Log("Creating JobSetOperator CR for condition propagation tests.")
+	tc.EventuallyResourceCreatedOrUpdated(
+		WithMinimalObject(gvk.JobSetOperatorV1, types.NamespacedName{Name: "cluster", Namespace: jobSetOpNamespace}),
+		WithMutateFunc(func(obj *unstructured.Unstructured) error {
+			return unstructured.SetNestedField(obj.Object, "Managed", "spec", "managementState")
+		}),
+		WithCustomErrorMsg("Failed to create JobSetOperator CR for degraded monitoring test"),
+	)
+
+	t.Log("Scenario 2: Verifying Trainer component is healthy with JobSetOperator CR present (no degraded conditions).")
+	tc.EnsureResourceExists(
+		WithMinimalObject(tc.GVK, trainerNN),
+		WithCondition(
+			jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, status.ConditionDependenciesAvailable, metav1.ConditionTrue),
+		),
+	)
+
+	t.Logf("Verifying DSC is healthy before tests (namespace=%s, name=%s).", tc.DataScienceClusterNamespacedName.Namespace, tc.DataScienceClusterNamespacedName.Name)
+	tc.EnsureResourceExists(
+		WithMinimalObject(gvk.DataScienceCluster, tc.DataScienceClusterNamespacedName),
+		WithCondition(
+			jq.Match(`.status.conditions[] | select(.type == "%sReady") | .status == "%s"`, tc.GVK.Kind, metav1.ConditionTrue),
+		),
+	)
+
+	t.Log("Scaling down JobSet operator deployment to prevent condition reset.")
+	originalReplicas := tc.scaleJobSetOperator(t, 0)
+
+	// Run each test case (inject condition, verify, clear condition, verify recovery)
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			tc.runDegradedConditionTest(t, testCase)
+		})
+	}
+
+	t.Log("Scaling JobSet operator deployment back up.")
+	tc.scaleJobSetOperator(t, originalReplicas)
+
+	t.Log("All external operator degraded condition monitoring tests passed")
+}
+
+// ensureJobSetBaseline clears JobSet conditions, asserts Trainer component/DSC health.
+// Returns the JobSet CR for use in test assertions.
+func (tc *TrainerTestCtx) ensureJobSetBaseline(t *testing.T) *unstructured.Unstructured {
+	t.Helper()
+
+	trainerNN := types.NamespacedName{Name: componentApi.TrainerInstanceName}
+	jobSetCR := tc.FetchSingleResourceOfKind(gvk.JobSetOperatorV1, jobSetOpNamespace)
+
+	tc.ClearAllConditionsFromResourceStatus(jobSetCR)
+	tc.EnsureResourceExists(
+		WithMinimalObject(tc.GVK, trainerNN),
+		WithCondition(jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, status.ConditionDependenciesAvailable, metav1.ConditionTrue)),
+		WithCondition(jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, status.ConditionTypeReady, metav1.ConditionTrue)),
+	)
+	tc.EnsureResourceExists(
+		WithMinimalObject(gvk.DataScienceCluster, tc.DataScienceClusterNamespacedName),
+		WithCondition(jq.Match(`.status.conditions[] | select(.type == "%sReady") | .status == "%s"`, tc.GVK.Kind, metav1.ConditionTrue)),
+	)
+
+	return jobSetCR
+}
+
+// jobSetOperatorDeploymentName is the name of the JobSet operator deployment within
+// the CSV. We use this when patching the CSV to scale the operator.
+const jobSetOperatorDeploymentName = "jobset-operator"
+
+// scaleJobSetOperator scales the JobSet operator deployment by patching the CSV.
+// OLM will enforce the replica count, preventing manual overrides.
+// Returns the original replica count before scaling.
+func (tc *TrainerTestCtx) scaleJobSetOperator(t *testing.T, replicas int32) int32 {
+	t.Helper()
+
+	t.Logf("Scaling JobSet operator via CSV in namespace %s to %d replicas.", jobSetOpNamespace, replicas)
+	originalReplicas := tc.ScaleCSVDeploymentReplicas(
+		jobSetOpNamespace,
+		"jobset",
+		jobSetOperatorDeploymentName,
+		replicas,
+	)
+	t.Logf("JobSet operator deployment scaled to %d replicas in namespace %s.", replicas, jobSetOpNamespace)
+	return originalReplicas
+}
+
+// runDegradedConditionTest runs a single degraded condition test case.
+// It injects a condition, verifies propagation, then recovers and verifies cleanup.
+func (tc *TrainerTestCtx) runDegradedConditionTest(t *testing.T, testCase degradedConditionTestCase) {
+	t.Helper()
+
+	t.Logf("Running test case: %s (Condition: %s=%s)", testCase.name, testCase.conditionType, testCase.conditionStatus)
+
+	trainerNN := types.NamespacedName{Name: componentApi.TrainerInstanceName}
+
+	// Establish baseline (clears conditions, asserts healthy)
+	jobSetCR := tc.ensureJobSetBaseline(t)
+
+	t.Logf("Simulating external operator degradation: Injecting %s=%s into operator CR.", testCase.conditionType, testCase.conditionStatus)
+	tc.InjectConditionIntoResourceStatus(
+		jobSetCR,
+		testCase.conditionType,
+		testCase.conditionStatus,
+		"TestInjected",
+		"Simulated condition for e2e test: "+testCase.conditionType+"="+string(testCase.conditionStatus),
+	)
+
+	t.Logf("Verifying Trainer component CR (%s) reacts by setting DependenciesAvailable=False and Ready=False.", trainerNN)
+	tc.EnsureResourceExists(
+		WithMinimalObject(tc.GVK, trainerNN),
+		WithCondition(
+			And(
+				jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, status.ConditionDependenciesAvailable, metav1.ConditionFalse),
+				jq.Match(`.status.conditions[] | select(.type == "%s") | .reason == "%s"`, status.ConditionDependenciesAvailable, "DependencyDegraded"),
+				jq.Match(`.status.conditions[] | select(.type == "%s") | .message | contains("Dependencies degraded")`, status.ConditionDependenciesAvailable),
+				jq.Match(`.status.conditions[] | select(.type == "%s") | .message | contains("%s")`, status.ConditionDependenciesAvailable, testCase.conditionType),
+				jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, status.ConditionTypeReady, metav1.ConditionFalse),
+			),
+		),
+	)
+
+	t.Logf("Verifying DSC CR (%s) reflects the component's degraded state (TrainerReady=False).", tc.DataScienceClusterNamespacedName)
+	tc.EnsureResourceExists(
+		WithMinimalObject(gvk.DataScienceCluster, tc.DataScienceClusterNamespacedName),
+		WithCondition(
+			jq.Match(`.status.conditions[] | select(.type == "%sReady") | .status == "%s"`, tc.GVK.Kind, metav1.ConditionFalse),
+		),
+	)
+
+	t.Logf("Clearing injected condition %s from operator CR to test recovery.", testCase.conditionType)
+	jobSetCR = tc.FetchSingleResourceOfKind(gvk.JobSetOperatorV1, jobSetOpNamespace)
+	tc.RemoveConditionFromResourceStatus(jobSetCR, testCase.conditionType)
+
+	t.Logf("Verifying Trainer component CR (%s) recovers (DependenciesAvailable=True, Ready=True).", trainerNN)
+	tc.EnsureResourceExists(
+		WithMinimalObject(tc.GVK, trainerNN),
+		WithCondition(
+			And(
+				jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, status.ConditionDependenciesAvailable, metav1.ConditionTrue),
+				jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, status.ConditionTypeReady, metav1.ConditionTrue),
+			),
+		),
+	)
+
+	t.Logf("Verifying DSC CR (%s) recovers (TrainerReady=True).", tc.DataScienceClusterNamespacedName)
+	tc.EnsureResourceExists(
+		WithMinimalObject(gvk.DataScienceCluster, tc.DataScienceClusterNamespacedName),
+		WithCondition(
+			jq.Match(`.status.conditions[] | select(.type == "%sReady") | .status == "%s"`, tc.GVK.Kind, metav1.ConditionTrue),
+		),
+	)
+
+	t.Logf("Test case passed: %s", testCase.name)
 }


### PR DESCRIPTION
## Description

Add dependency monitoring to propagate external operator degraded conditions to RHOAI components, giving users visibility into upstream operator issues that may be blocking their workloads.

### Changes

- Add `dependency.NewAction()` in `pkg/controller/actions/dependency/` that monitors external operator CRs for degraded conditions and sets the `DependenciesAvailable` condition on component CRs accordingly
- Add `ConditionDependenciesAvailable` constant to status conditions
- Integrate dependency monitoring into:
   -  Kueue (monitors Kueue operator)
   - Trainer (monitors JobSet operator)
   - KServe (monitors LWS operator)
- Add comprehensive unit tests for the dependency action
- Add e2e tests that validate condition propagation by patching operator CSVs to simulate degraded states

### Condition Propagation

1. External Operator CR (Degraded=True, Available=False, etc.)
    dependency.NewAction() detects degraded conditions
3. Component CR (DependenciesAvailable=False)
    findUnhappyDependent() affects Ready
5. Component CR (Ready=False)
    UpdateDSCStatus() reads Ready
7. DSC (ComponentReady=False)

<!--- Link your JIRA and related links here for reference. -->

### Issues

https://issues.redhat.com/browse/RHOAIENG-39245
https://issues.redhat.com/browse/RHOAIENG-36192

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

New unit tests and e2e tests.
e2e tests ran locally with CRC.

```
PASS
ok  	github.com/opendatahub-io/opendatahub-operator/v2/tests/e2e	948.891s
Initial run: 147 passed, 0 failed, 0 skipped
✅ All tests passed!
```

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [x] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [ ] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Components now monitor external operators and expose a consolidated DependenciesAvailable readiness condition.

* **Tests**
  * Added unit and extensive end-to-end tests validating detection, propagation, and recovery of degraded external-operator conditions.
  * Expanded test utilities for injecting, reading, and refreshing resource status and for scaling operator deployments during tests.

* **Chores**
  * Added operator identifiers and RBAC markers to support external operator monitoring.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->