### PR TITLE
[RHOAIENG-41640] Missing OIDC config not reflected in gatewayconfig Ready status

### DIFF
--- a/internal/controller/services/gateway/gateway_controller.go
+++ b/internal/controller/services/gateway/gateway_controller.go
@@ -43,7 +43,7 @@ func (h *ServiceHandler) NewReconciler(ctx context.Context, mgr ctrl.Manager) er
 	}
 
 	gw.OwnsGVK(gvk.GatewayClass).
-		OwnsGVK(gvk.KubernetesGateway).
+		OwnsGVK(gvk.KubernetesGateway, reconciler.WithPredicates(resources.GatewayStatusChanged())).
 		OwnsGVK(gvk.Secret).
 		OwnsGVK(gvk.Service).
 		OwnsGVK(gvk.Deployment).
@@ -71,7 +71,8 @@ func (h *ServiceHandler) NewReconciler(ctx context.Context, mgr ctrl.Manager) er
 			deploy.WithCache(),
 		)).
 		WithAction(syncGatewayConfigStatus).
-		WithAction(gc.NewAction())
+		WithAction(gc.NewAction()).
+		WithConditions(ReadyConditionType)
 
 	if _, err := gw.Build(ctx); err != nil {
 		return fmt.Errorf("could not create the GatewayConfig controller: %w", err)

--- a/internal/controller/services/gateway/gateway_controller_actions.go
+++ b/internal/controller/services/gateway/gateway_controller_actions.go
@@ -29,7 +29,6 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
 
-	"github.com/opendatahub-io/opendatahub-operator/v2/api/common"
 	serviceApi "github.com/opendatahub-io/opendatahub-operator/v2/api/services/v1alpha1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/status"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
@@ -93,9 +92,6 @@ func createKubeAuthProxyInfrastructure(ctx context.Context, rr *odhtypes.Reconci
 		return fmt.Errorf("failed to detect cluster authentication mode: %w", err)
 	}
 	l.V(1).Info("detected cluster authentication mode", "mode", authMode)
-
-	// Reset the condition to false
-	rr.Conditions.MarkFalse(ReadyConditionType)
 
 	kubeAuthProxyDeploymentTemplates := odhtypes.TemplateInfo{
 		FS:   gatewayResources,
@@ -185,6 +181,14 @@ func createKubeAuthProxyInfrastructure(ctx context.Context, rr *odhtypes.Reconci
 		},
 	}
 	rr.Templates = append(rr.Templates, kubeAuthProxyCommonTemplates...)
+
+	// Mark GatewayConfigReady as true since all auth proxy setup succeeded
+	// This will be checked later by syncGatewayConfigStatus
+	rr.Conditions.MarkTrue(
+		ReadyConditionType,
+		conditions.WithReason(status.ReadyReason),
+		conditions.WithMessage(status.AuthProxyDeployedMessage),
+	)
 
 	return nil
 }
@@ -307,9 +311,12 @@ func getTemplateData(ctx context.Context, rr *odhtypes.ReconciliationRequest) (m
 	return templateData, nil
 }
 
+// This function only checks Gateway infrastructure readiness.
+// The reconciler framework automatically computes the top-level "Ready" condition
+// from "ProvisioningSucceeded" and component-specific conditions like "GatewayConfigReady".
 func syncGatewayConfigStatus(ctx context.Context, rr *odhtypes.ReconciliationRequest) error {
 	// Use helper function for consistent validation
-	gatewayConfig, err := validateGatewayConfig(rr)
+	_, err := validateGatewayConfig(rr)
 	if err != nil {
 		return err
 	}
@@ -321,37 +328,40 @@ func syncGatewayConfigStatus(ctx context.Context, rr *odhtypes.ReconciliationReq
 	}, gateway)
 	if err != nil {
 		if client.IgnoreNotFound(err) == nil {
-			conditions.SetStatusCondition(gatewayConfig, common.Condition{
-				Type:    status.ConditionTypeReady,
-				Status:  metav1.ConditionFalse,
-				Reason:  status.NotReadyReason,
-				Message: status.GatewayNotFoundMessage,
-			})
+			// Gateway not found - mark GatewayConfigReady as false
+			rr.Conditions.MarkFalse(
+				ReadyConditionType,
+				conditions.WithReason(status.NotReadyReason),
+				conditions.WithMessage(status.GatewayNotFoundMessage),
+			)
 			return nil
 		}
 		return fmt.Errorf("failed to get Gateway: %w", err)
 	}
 
-	// Use optimized helper function to check gateway readiness
-	ready := isGatewayReady(gateway)
+	// Check if Gateway infrastructure is ready
+	gatewayReady := isGatewayReady(gateway)
 
-	// Determine condition values based on readiness
-	conditionStatus := metav1.ConditionFalse
-	reason := status.NotReadyReason
-	message := status.GatewayNotReadyMessage
-
-	if ready {
-		conditionStatus = metav1.ConditionTrue
-		reason = status.ReadyReason
-		message = status.GatewayReadyMessage
+	if !gatewayReady {
+		// Gateway exists but not ready yet
+		rr.Conditions.MarkFalse(
+			ReadyConditionType,
+			conditions.WithReason(status.NotReadyReason),
+			conditions.WithMessage(status.GatewayNotReadyMessage),
+		)
+		return nil
 	}
 
-	conditions.SetStatusCondition(gatewayConfig, common.Condition{
-		Type:    status.ConditionTypeReady,
-		Status:  conditionStatus,
-		Reason:  reason,
-		Message: message,
-	})
+	// Gateway is ready - mark GatewayConfigReady as true if not already set to false
+	// (e.g., if createKubeAuthProxyInfrastructure set it to false due to missing OIDC config)
+	existingCondition := rr.Conditions.GetCondition(ReadyConditionType)
+	if existingCondition == nil || existingCondition.Status != metav1.ConditionFalse {
+		rr.Conditions.MarkTrue(
+			ReadyConditionType,
+			conditions.WithReason(status.ReadyReason),
+			conditions.WithMessage(status.GatewayReadyMessage),
+		)
+	}
 
 	return nil
 }


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
https://issues.redhat.com/browse/RHOAIENG-41640

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
ODIC dont have e2e yet


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Reconciliations now trigger only on Gateway status changes or deletions, reducing unnecessary updates.

* **Bug Fixes**
  * More accurate GatewayConfig readiness reporting, including explicit Ready/NotReady states.
  * Clearer failure and success signals when auth proxy is deployed or when a Gateway is missing/not ready.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->