### PR TITLE
RHOAIENG-41637: [WIP] Remove skip for versioned well know LLMInferenceServiceConfig

### DIFF
--- a/tests/e2e/kserve_test.go
+++ b/tests/e2e/kserve_test.go
@@ -1,7 +1,6 @@
 package e2e_test
 
 import (
-	"slices"
 	"strings"
 	"testing"
 
@@ -11,10 +10,8 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/opendatahub-io/opendatahub-operator/v2/api/common"
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/api/components/v1alpha1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/components/kserve"
-	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/metadata/annotations"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/metadata/labels"
@@ -181,12 +178,6 @@ func (tc *KserveTestCtx) createConnectionSecret(secretName, namespace string) {
 // have names prefixed with a semver version.
 func (tc *KserveTestCtx) ValidateLLMInferenceServiceConfigVersioned(t *testing.T) {
 	t.Helper()
-
-	if slices.Contains([]common.Platform{cluster.ManagedRhoai, cluster.SelfManagedRhoai}, tc.FetchPlatformRelease()) {
-		t.Skip("Kserve changes for this test is not synced to RHOAI branch yet, " +
-			"remove skip once https://github.com/opendatahub-io/kserve/commit/41864a46c3b0a573674820c966666e09c16549d9 " +
-			"is propagated to RHOAI.")
-	}
 
 	// Validate that all well-known LLMInferenceServiceConfig resources have versioned names
 	// Expected format: vX-Y-Z-<config-name> where X, Y, Z are numbers


### PR DESCRIPTION
Once Kserve is synced to RHOAI main/3.2 branch, we can start running these new tests.

Related:
- https://redhat-internal.slack.com/archives/C064Z5S84F3/p1765355190716369
- https://issues.redhat.com/browse/RHOAIENG-41637
- https://github.com/opendatahub-io/opendatahub-operator/pull/2949