### PR TITLE
e2e tests improvements to avoid flaky results and avoid mismatches in…

### DIFF
--- a/tests/e2e/cleanup_test.go
+++ b/tests/e2e/cleanup_test.go
@@ -97,7 +97,7 @@ func cleanupKueueTestResources(t *testing.T, tc *TestContext) {
 
 		// For CRD-dependent resources, skip finalizer removal to avoid fetching non-existent resources
 		removeFinalizersOnDelete := true
-		if resource.gvk.Kind == gvk.KueueConfigV1.Kind || resource.gvk.Kind == gvk.ClusterQueue.Kind {
+		if resource.gvk.Kind == gvk.ClusterQueue.Kind || resource.gvk.Kind == gvk.KueueConfigV1.Kind {
 			removeFinalizersOnDelete = false
 		}
 

--- a/tests/e2e/creation_test.go
+++ b/tests/e2e/creation_test.go
@@ -49,7 +49,6 @@ func dscManagementTestSuite(t *testing.T) {
 
 	// Define test cases.
 	testCases := []TestCase{
-		{"Ensure required operators with custom channels are installed", dscTestCtx.ValidateOperatorsWithCustomChannelsInstallation},
 		{"Ensure required operators are installed", dscTestCtx.ValidateOperatorsInstallation},
 		{"Ensure required resources are created", dscTestCtx.ValidateResourcesCreation},
 		{"Validate creation of DSCInitialization instance", dscTestCtx.ValidateDSCICreation},
@@ -80,44 +79,6 @@ func dscManagementTestSuite(t *testing.T) {
 	RunTestCases(t, testCases)
 }
 
-func (tc *DSCTestCtx) ValidateOperatorsWithCustomChannelsInstallation(t *testing.T) {
-	t.Helper()
-
-	// Define operators to be installed.
-	operators := []struct {
-		nn                  types.NamespacedName
-		skipOperatorGroup   bool
-		globalOperatorGroup bool
-		channel             string
-	}{
-		{nn: types.NamespacedName{Name: leaderWorkerSetOpName, Namespace: leaderWorkerSetNamespace},
-			skipOperatorGroup: false, globalOperatorGroup: false, channel: leaderWorkerSetChannel},
-		{nn: types.NamespacedName{Name: jobSetOpName, Namespace: jobSetOpNamespace},
-			skipOperatorGroup: false, globalOperatorGroup: false, channel: jobSetOpChannel},
-	}
-
-	// Create and run test cases in parallel.
-	testCases := make([]TestCase, len(operators))
-	for i, op := range operators {
-		testCases[i] = TestCase{
-			name: fmt.Sprintf("Ensure %s is installed", op.nn.Name),
-			testFn: func(t *testing.T) {
-				t.Helper()
-				switch {
-				case op.skipOperatorGroup:
-					tc.EnsureOperatorInstalledWithChannel(op.nn, op.channel)
-				case op.globalOperatorGroup:
-					tc.EnsureOperatorInstalledWithGlobalOperatorGroupAndChannel(op.nn, op.channel)
-				default:
-					tc.EnsureOperatorInstalledWithLocalOperatorGroupAndChannel(op.nn, op.channel)
-				}
-			},
-		}
-	}
-
-	RunTestCases(t, testCases, WithParallel())
-}
-
 // ValidateOperatorsInstallation ensures the required operators are installed.
 func (tc *DSCTestCtx) ValidateOperatorsInstallation(t *testing.T) {
 	t.Helper()
@@ -134,6 +95,8 @@ func (tc *DSCTestCtx) ValidateOperatorsInstallation(t *testing.T) {
 		{nn: types.NamespacedName{Name: opentelemetryOpName, Namespace: opentelemetryOpNamespace}, skipOperatorGroup: false, globalOperatorGroup: true, channel: defaultOperatorChannel},
 		{nn: types.NamespacedName{Name: tempoOpName, Namespace: tempoOpNamespace}, skipOperatorGroup: false, globalOperatorGroup: true, channel: defaultOperatorChannel},
 		{nn: types.NamespacedName{Name: kuadrantOpName, Namespace: kuadrantNamespace}, skipOperatorGroup: false, globalOperatorGroup: true, channel: defaultOperatorChannel},
+		{nn: types.NamespacedName{Name: leaderWorkerSetOpName, Namespace: leaderWorkerSetNamespace}, skipOperatorGroup: false, globalOperatorGroup: false, channel: leaderWorkerSetChannel}, //nolint:lll
+		{nn: types.NamespacedName{Name: jobSetOpName, Namespace: jobSetOpNamespace}, skipOperatorGroup: false, globalOperatorGroup: false, channel: jobSetOpChannel},
 	}
 
 	// Create and run test cases in parallel.

--- a/tests/e2e/helper_test.go
+++ b/tests/e2e/helper_test.go
@@ -64,7 +64,7 @@ const (
 	leaderWorkerSetNamespace    = "openshift-lws-operator"                   // Namespace for the Leader Worker Set Operator
 	leaderWorkerSetChannel      = "stable-v1.0"                              // Channel for the Leader Worker Set Operator
 	kueueOcpOperatorNamespace   = "openshift-kueue-operator"                 // Namespace for the OCP Kueue Operator
-	kueueOcpOperatorChannel     = "stable-v1.1"                              // Channel for the OCP Kueue Operator
+	kueueOcpOperatorChannel     = "stable-v1.2"                              // Channel for the OCP Kueue Operator
 	kuadrantOpName              = "rhcl-operator"                            // Name of the Red Hat Connectivity Link Operator subscription.
 	kuadrantNamespace           = "kuadrant-system"                          // Namespace for the Red Hat Connectivity Link Operator.
 	dashboardRouteNameODH       = "odh-dashboard"                            // Name of the ODH dashboard route


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->
This PR handles some enhancements in the e2e tests:
- Remove finalizers when deleting Kueue resources to avoid stuck in deletion
- Added a robust solution to check if an operator is installed in the cluster, checking the csv, og, sub and namespace
- Remove duplicated method to install operators with custom channels. Added them into the main method to install the dependant operators.

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [ ] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Removed a redundant custom-channel operator test and consolidated its checks into the main installation validation; two additional operators are now validated there and a public test helper was removed.

* **Refactor**
  * Reworked install/uninstall test flows to be health-first with synchronous, typed retrievals and readiness-focused helpers.

* **New Features**
  * Added health-oriented utilities and expanded test-context APIs for fetching operator-related resources and ensuring operator health.

* **Bug Fixes**
  * Adjusted cleanup conditional ordering for finalizer removal behavior.

* **Chore**
  * Bumped operator channel from stable-v1.1 to stable-v1.2.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->