### PR TITLE
Revert "RHOAIENG-39316 | build: uplift go version to 1.25 in go.mod"

### DIFF
--- a/cmd/component-codegen/go.mod
+++ b/cmd/component-codegen/go.mod
@@ -1,6 +1,6 @@
 module github.com/opendatahub-io/opendatahub-operator/v2/cmd/component-codegen
 
-go 1.25
+go 1.24
 
 require (
 	github.com/sirupsen/logrus v1.9.3

--- a/cmd/test-retry/go.mod
+++ b/cmd/test-retry/go.mod
@@ -1,6 +1,6 @@
 module github.com/opendatahub-io/opendatahub-operator/v2/cmd/test-retry
 
-go 1.25
+go 1.24.0
 
 require (
 	github.com/google/go-github/v67 v67.0.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/opendatahub-io/opendatahub-operator/v2
 
-go 1.25
+go 1.24.4
 
 require (
 	github.com/blang/semver/v4 v4.0.0


### PR DESCRIPTION
Reverts opendatahub-io/opendatahub-operator#2969 as it fails for the CPaas midstream MR pipeline:
`go: download go1.25 for linux/amd64: toolchain not available`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized Go toolchain versions to 1.24.x series across build modules. Updated configuration ensures consistent build environments and improved toolchain compatibility while maintaining existing project dependencies and streamlining version requirements for the development and build infrastructure.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->