### PR TITLE
RHOAIENG-41524: Trainer v1 component sample default set to Removed.

### DIFF
--- a/config/rhoai/samples/datasciencecluster_v2_datasciencecluster.yaml
+++ b/config/rhoai/samples/datasciencecluster_v2_datasciencecluster.yaml
@@ -17,9 +17,9 @@ spec:
     kueue:
       managementState: "Removed"
     trainingoperator:
-      managementState: "Managed"
-    trainer:
       managementState: "Removed"
+    trainer:
+      managementState: "Managed"
     ray:
       managementState: "Managed"
     workbenches:

--- a/config/samples/datasciencecluster_v2_datasciencecluster.yaml
+++ b/config/samples/datasciencecluster_v2_datasciencecluster.yaml
@@ -18,9 +18,9 @@ spec:
     kueue:
       managementState: "Removed"
     trainingoperator:
-      managementState: "Managed"
-    trainer:
       managementState: "Removed"
+    trainer:
+      managementState: "Managed"
     ray:
       managementState: "Managed"
     workbenches:


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
Change the sample DSC managementState to Removed for traineroperator component, see https://issues.redhat.com/browse/RHOAIENG-41524 and changed DSC managementState to Managed for trainer component, see https://issues.redhat.com/browse/RHOAIENG-42325

## How Has This Been Tested?
integration and e2e

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [x] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [X] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->
It is just a change in the default sample DSC value for traineroperator component

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Reworked cluster defaults: the training operator's management entry was removed.
  * The trainer component is now declared at top level and set to "Managed".
  * All other components and their management states remain unchanged.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->