### PR TITLE
Clarify which CSV needs to be patched while doing component dev

### DIFF
--- a/hack/component-dev/README.md
+++ b/hack/component-dev/README.md
@@ -30,7 +30,7 @@ This uses the PVC name, so if you've changed that, then change it in the patch f
 The example in the `component-dev-csv-patch.json` file mounts the volume to the dashboard manifests location at `/opt/manifests/dashboard`.
 Update as appropriate for your component.
 
-Note also that the CSV is a namespaced resource that is duplicated into every namespace for some reason, so you need to make sure that you specify the correct namespace for the operator here, so that it's patching the correct one:
+Note also that the CSV is a namespaced resource that is duplicated into every namespace for some reason, so you need to make sure that you specify the operator's installation namespace here (where its Subscription resource exists), so that it's patching the correct one:
 
 ``` shell
 # Change to correct name and namespace for CSV


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
@grdryn a while ago I got a feedback that it wasn't clear which CSV should be patched, so I tried to make it more clear in the doc you wrote. Feel free to suggest better wording.


## How Has This Been Tested?
No testing needed, documentation change based on the user feedback.

## Screenshot or short clip
N/A

## Merge criteria

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [x] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
Documentation change, no E2E needed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified installation namespace guidance for operator configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->