### PR TITLE
test: skip flaky external operator degraded monitoring tests

### DIFF
--- a/tests/e2e/kserve_test.go
+++ b/tests/e2e/kserve_test.go
@@ -263,6 +263,7 @@ func (tc *KserveTestCtx) ensureLWSBaseline(t *testing.T) *unstructured.Unstructu
 // External Operator CR > Kserve Component CR > DataScienceCluster CR.
 func (tc *KserveTestCtx) ValidateExternalOperatorDegradedMonitoring(t *testing.T) {
 	t.Helper()
+	t.Skip("RHOAIENG-41751: Skipping flaky external operator degraded monitoring test - under investigation")
 
 	// condition types monitored by the Kserve Component
 	testCases := []degradedConditionTestCase{

--- a/tests/e2e/kueue_test.go
+++ b/tests/e2e/kueue_test.go
@@ -786,6 +786,7 @@ integrations:
 // but the operator can't reset conditions we inject.
 func (tc *KueueTestCtx) ValidateExternalOperatorDegradedMonitoring(t *testing.T) {
 	t.Helper()
+	t.Skip("RHOAIENG-41751: Skipping flaky external operator degraded monitoring test - under investigation")
 
 	// condition types monitored by the Kueue Component
 	testCases := []degradedConditionTestCase{

--- a/tests/e2e/trainer_test.go
+++ b/tests/e2e/trainer_test.go
@@ -53,6 +53,7 @@ func trainerTestSuite(t *testing.T) {
 // External Operator CR > Trainer Component CR > DataScienceCluster CR.
 func (tc *TrainerTestCtx) ValidateExternalOperatorDegradedMonitoring(t *testing.T) {
 	t.Helper()
+	t.Skip("RHOAIENG-41751: Skipping flaky external operator degraded monitoring test - under investigation")
 
 	testCases := []degradedConditionTestCase{
 		{


### PR DESCRIPTION
## Description

Skip flaky external operator degraded monitoring e2e tests introduced by RHOAIENG-36192. These tests are causing intermittent failures and disrupting other PRs while the root cause is investigated.

**Changes:**
- Added `t.Skip()` to `ValidateExternalOperatorDegradedMonitoring` in:
  - `tests/e2e/kueue_test.go`
  - `tests/e2e/trainer_test.go`
  - `tests/e2e/kserve_test.go`

**Related:** RHOAIENG-36192

## How Has This Been Tested?

This is a test skip - no functional changes.

## Screenshot or short clip

N/A

## Merge criteria

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

- [x] Skip requirement to update E2E test suite for this PR

#### E2E update requirement opt-out justification

This PR specifically skips existing flaky e2e tests - no new functionality is being added. The tests will be re-enabled once the flakiness is resolved.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Marked external-operator degraded-monitoring end-to-end tests as flaky and skipped their execution across multiple test suites to improve test-suite stability and reduce intermittent failures.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->