### PR TITLE
feat: Add E2E tests for MaaS component

### DIFF
--- a/tests/e2e/components_test.go
+++ b/tests/e2e/components_test.go
@@ -31,6 +31,10 @@ type ComponentTestCtx struct {
 	// Any additional fields specific to component tests
 	GVK            schema.GroupVersionKind
 	NamespacedName types.NamespacedName
+
+	// Subcomponent information (optional, only set for subcomponents)
+	ParentKind            string // Kind of the parent component (e.g., "Kserve")
+	SubComponentFieldName string // JSON field name of the subcomponent in parent's spec (e.g., "modelsAsService")
 }
 
 // CRD represents a custom resource definition with a name and version.
@@ -58,6 +62,21 @@ func NewComponentTestCtx(t *testing.T, object common.PlatformObject) (*Component
 	}
 
 	return &componentCtx, nil
+}
+
+// NewSubComponentTestCtx initializes a new component test context for a subcomponent.
+// parentKind is the kind of the parent component (e.g., "Kserve").
+// subComponentFieldName is the JSON field name of the subcomponent in the parent's spec (e.g., "modelsAsService").
+func NewSubComponentTestCtx(t *testing.T, object common.PlatformObject, parentKind string, subComponentFieldName string) (*ComponentTestCtx, error) { //nolint:thelper
+	componentCtx, err := NewComponentTestCtx(t, object)
+	if err != nil {
+		return nil, err
+	}
+
+	componentCtx.ParentKind = parentKind
+	componentCtx.SubComponentFieldName = subComponentFieldName
+
+	return componentCtx, nil
 }
 
 // ValidateComponentEnabled ensures that the component is enabled and its status is "Ready".
@@ -249,6 +268,146 @@ func (tc *ComponentTestCtx) ValidateComponentReleases(t *testing.T) {
 			),
 		),
 	)
+}
+
+// EnsureParentComponentEnabled ensures that the parent component is enabled and ready before enabling a subcomponent.
+func (tc *ComponentTestCtx) EnsureParentComponentEnabled(t *testing.T) {
+	t.Helper()
+
+	if tc.ParentKind == "" {
+		t.Fatal("EnsureParentComponentEnabled called on a component without parent information.")
+	}
+
+	parentComponentName := strings.ToLower(tc.ParentKind)
+
+	// Enable the parent component
+	tc.UpdateComponentStateInDataScienceClusterWithKind(operatorv1.Managed, tc.ParentKind)
+
+	tc.EnsureResourceExists(
+		WithMinimalObject(gvk.DataScienceCluster, tc.DataScienceClusterNamespacedName),
+		WithCondition(
+			And(
+				// Ensure the parent component's management state is "Managed"
+				jq.Match(`.spec.components.%s.managementState == "%s"`, parentComponentName, operatorv1.Managed),
+				// Ensure the parent component is ready
+				jq.Match(`.status.conditions[] | select(.type == "%sReady") | .status == "%s"`, tc.ParentKind, metav1.ConditionTrue),
+			),
+		),
+		WithCustomErrorMsg("Parent component should be enabled and ready"),
+	)
+}
+
+// UpdateSubComponentStateInDataScienceCluster updates the management state of a subcomponent in the DataScienceCluster.
+func (tc *ComponentTestCtx) UpdateSubComponentStateInDataScienceCluster(t *testing.T, state operatorv1.ManagementState) {
+	t.Helper()
+
+	if tc.ParentKind == "" || tc.SubComponentFieldName == "" {
+		t.Fatal("UpdateSubComponentStateInDataScienceCluster called on a component without parent/subcomponent information.")
+	}
+
+	parentComponentName := strings.ToLower(tc.ParentKind)
+
+	// Update the subcomponent's management state
+	tc.EventuallyResourcePatched(
+		WithMinimalObject(gvk.DataScienceCluster, tc.DataScienceClusterNamespacedName),
+		WithMutateFunc(testf.Transform(`.spec.components.%s.%s.managementState = "%s"`, parentComponentName, tc.SubComponentFieldName, state)),
+		WithCondition(
+			jq.Match(`.spec.components.%s.%s.managementState == "%s"`, parentComponentName, tc.SubComponentFieldName, state),
+		),
+	)
+}
+
+// ValidateSubComponentEnabled ensures that a subcomponent is enabled and its status is "Ready".
+func (tc *ComponentTestCtx) ValidateSubComponentEnabled(t *testing.T) {
+	t.Helper()
+
+	if tc.ParentKind == "" || tc.SubComponentFieldName == "" {
+		t.Fatal("ValidateSubComponentEnabled called on a component without parent/subcomponent information.")
+	}
+
+	// First, ensure the parent component is enabled and ready
+	tc.EnsureParentComponentEnabled(t)
+
+	// Enable the subcomponent
+	tc.UpdateSubComponentStateInDataScienceCluster(t, operatorv1.Managed)
+
+	// Ensure the subcomponent resource exists and is marked "Ready"
+	tc.EnsureResourcesExist(
+		WithMinimalObject(tc.GVK, tc.NamespacedName),
+		WithCondition(
+			And(
+				HaveLen(1),
+				HaveEach(And(
+					jq.Match(`.metadata.ownerReferences[0].kind == "%s"`, gvk.DataScienceCluster.Kind),
+					jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, status.ConditionTypeReady, metav1.ConditionTrue),
+					jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, status.ConditionTypeProvisioningSucceeded, metav1.ConditionTrue),
+				)),
+			),
+		),
+	)
+}
+
+// ValidateSubComponentReleases ensures that the subcomponent releases exist and have valid fields.
+func (tc *ComponentTestCtx) ValidateSubComponentReleases(t *testing.T) {
+	t.Helper()
+
+	if tc.ParentKind == "" || tc.SubComponentFieldName == "" {
+		t.Fatal("ValidateSubComponentReleases called on a component without parent/subcomponent information.")
+	}
+
+	parentComponentName := strings.ToLower(tc.ParentKind)
+
+	// Ensure the DataScienceCluster exists and the parent component's conditions are met
+	tc.EnsureResourceExists(
+		WithMinimalObject(gvk.DataScienceCluster, tc.DataScienceClusterNamespacedName),
+		WithCondition(
+			And(
+				// Ensure the parent component's management state is "Managed"
+				jq.Match(`.spec.components.%s.managementState == "%s"`, parentComponentName, operatorv1.Managed),
+				// Ensure the subcomponent's management state is "Managed"
+				jq.Match(`.spec.components.%s.%s.managementState == "%s"`, parentComponentName, tc.SubComponentFieldName, operatorv1.Managed),
+				// Validate that the releases field contains at least one release for the parent component
+				jq.Match(`.status.components.%s.releases | length > 0`, parentComponentName),
+				// Validate the fields (name, version, repoUrl) for each release
+				And(
+					jq.Match(`.status.components.%s.releases[].name != ""`, parentComponentName),
+					jq.Match(`.status.components.%s.releases[].version != ""`, parentComponentName),
+					jq.Match(`.status.components.%s.releases[].repoUrl != ""`, parentComponentName),
+				),
+			),
+		),
+	)
+}
+
+// ValidateSubComponentDisabled ensures that a subcomponent is disabled and its resources are deleted.
+func (tc *ComponentTestCtx) ValidateSubComponentDisabled(t *testing.T) {
+	t.Helper()
+
+	if tc.ParentKind == "" || tc.SubComponentFieldName == "" {
+		t.Fatal("ValidateSubComponentDisabled called on a component without parent/subcomponent information.")
+	}
+
+	// Ensure that the resources associated with the subcomponent exist
+	tc.EnsureResourcesExist(WithMinimalObject(tc.GVK, tc.NamespacedName))
+
+	// Disable the subcomponent
+	tc.UpdateSubComponentStateInDataScienceCluster(t, operatorv1.Removed)
+
+	// Ensure that any Deployment resources for the subcomponent are not present
+	tc.EnsureResourcesGone(
+		WithMinimalObject(gvk.Deployment, types.NamespacedName{Namespace: tc.AppsNamespace}),
+		WithListOptions(
+			&client.ListOptions{
+				LabelSelector: k8slabels.Set{
+					labels.PlatformPartOf: strings.ToLower(tc.GVK.Kind),
+				}.AsSelector(),
+			},
+		),
+		WithEventuallyTimeout(tc.TestTimeouts.mediumEventuallyTimeout),
+	)
+
+	// Ensure that the resources associated with the subcomponent do not exist
+	tc.EnsureResourcesGone(WithMinimalObject(tc.GVK, tc.NamespacedName))
 }
 
 // ValidateComponentCondition ensures that the specified component instance has the expected condition set to "True".

--- a/tests/e2e/controller_test.go
+++ b/tests/e2e/controller_test.go
@@ -133,6 +133,7 @@ var (
 				componentApi.FeastOperatorComponentName:        feastOperatorTestSuite,
 				componentApi.LlamaStackOperatorComponentName:   llamastackOperatorTestSuite,
 				componentApi.MLflowOperatorComponentName:       mlflowOperatorTestSuite,
+				componentApi.ModelsAsServiceComponentName:      modelsAsServiceTestSuite,
 			},
 			{
 				// Kueue tests depends on Workbenches, so must not run with Workbenches tests in parallel

--- a/tests/e2e/modelsasservice_test.go
+++ b/tests/e2e/modelsasservice_test.go
@@ -1,0 +1,41 @@
+package e2e_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/api/components/v1alpha1"
+)
+
+type ModelsAsServiceTestCtx struct {
+	*ComponentTestCtx
+}
+
+const (
+	// Subcomponent field name in JSON (matches the field name in KserveCommonSpec).
+	// This must match the JSON tag in KserveCommonSpec.ModelsAsService.
+	modelsAsServiceFieldName = "modelsAsService"
+)
+
+func modelsAsServiceTestSuite(t *testing.T) {
+	t.Helper()
+
+	ct, err := NewSubComponentTestCtx(t, &componentApi.ModelsAsService{}, componentApi.KserveKind, modelsAsServiceFieldName)
+	require.NoError(t, err)
+
+	componentCtx := ModelsAsServiceTestCtx{
+		ComponentTestCtx: ct,
+	}
+
+	testCases := []TestCase{
+		{"Validate subcomponent enabled", componentCtx.ValidateSubComponentEnabled},
+		{"Validate operands have OwnerReferences", componentCtx.ValidateOperandsOwnerReferences},
+		{"Validate update operand resources", componentCtx.ValidateUpdateDeploymentsResources},
+		{"Validate subcomponent releases", componentCtx.ValidateSubComponentReleases},
+		{"Validate resource deletion recovery", componentCtx.ValidateAllDeletionRecovery},
+		{"Validate subcomponent disabled", componentCtx.ValidateSubComponentDisabled},
+	}
+
+	RunTestCases(t, testCases)
+}


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->
Adds E2E tests for the MaaS component. It also adds some common functionality for testing sub components since MaaS is a subcomponent of kserve.

<!--- Link your JIRA and related links here for reference. -->
Related to: https://issues.redhat.com/browse/RHOAIENG-38246

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Ran make e2e-tests on ROSA cluster, the MaaS tests passed.

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [ ] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->
