### PR TITLE
fix: update mlflowoperator params.env path

### DIFF
--- a/internal/controller/components/mlflowoperator/mlflowoperator.go
+++ b/internal/controller/components/mlflowoperator/mlflowoperator.go
@@ -51,8 +51,8 @@ func (s *componentHandler) NewCRObject(dsc *dscv2.DataScienceCluster) common.Pla
 }
 
 func (s *componentHandler) Init(platform common.Platform) error {
-	if err := odhdeploy.ApplyParams(manifestPath(platform).String(), "params.env", imageParamMap); err != nil {
-		return fmt.Errorf("failed to update images on path %s: %w", manifestPath(platform), err)
+	if err := odhdeploy.ApplyParams(paramsPath, "params.env", imageParamMap); err != nil {
+		return fmt.Errorf("failed to update images on path %s: %w", paramsPath, err)
 	}
 
 	return nil

--- a/internal/controller/components/mlflowoperator/mlflowoperator_support.go
+++ b/internal/controller/components/mlflowoperator/mlflowoperator_support.go
@@ -3,6 +3,7 @@ package mlflowoperator
 import (
 	"context"
 	"fmt"
+	"path"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -41,6 +42,8 @@ var (
 	conditionTypes = []string{
 		status.ConditionDeploymentsAvailable,
 	}
+
+	paramsPath = path.Join(odhdeploy.DefaultManifestPath, ComponentName, "base")
 )
 
 func manifestPath(p common.Platform) types.ManifestInfo {


### PR DESCRIPTION
## Description
JIRA: [RHOAIENG-44511](https://issues.redhat.com/browse/RHOAIENG-44511)

This PR fixes the path that the operator looks for when substituting in the `params.env` values for the mlflowoperator component.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [X] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
Minor config change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Standardized parameter/manifest path usage to a common base, improving consistency across platforms.
  * Aligned initialization logic to use the standardized path source, reducing variation in path handling and error messages.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->