### PR TITLE
RHOAIENG-41751: Isolate external operator degraded monitoring e2e tests

### DIFF
--- a/tests/e2e/controller_test.go
+++ b/tests/e2e/controller_test.go
@@ -148,6 +148,12 @@ var (
 				// ModelsAsService tests depends on KServe, so must not run with Kserve, ModelController or TrustyAI tests in parallel
 				componentApi.ModelsAsServiceComponentName: modelsAsServiceTestSuite,
 			},
+			{
+				// run external operator degraded monitoring tests isolated from other component tests
+				componentApi.KserveComponentName:  kserveDegradedMonitoringTestSuite,
+				componentApi.KueueComponentName:   kueueDegradedMonitoringTestSuite,
+				componentApi.TrainerComponentName: trainerDegradedMonitoringTestSuite,
+			},
 		},
 	}
 

--- a/tests/e2e/kserve_test.go
+++ b/tests/e2e/kserve_test.go
@@ -59,7 +59,6 @@ func kserveTestSuite(t *testing.T) {
 		{"Validate update operand resources", componentCtx.ValidateUpdateDeploymentsResources},
 		{"Validate component releases", componentCtx.ValidateComponentReleases},
 		{"Validate well-known LLMInferenceServiceConfig versioning", componentCtx.ValidateLLMInferenceServiceConfigVersioned},
-		{"Validate external operator degraded condition monitoring", componentCtx.ValidateExternalOperatorDegradedMonitoring},
 	}
 
 	// Add webhook tests if enabled
@@ -75,6 +74,25 @@ func kserveTestSuite(t *testing.T) {
 		TestCase{"Validate component disabled", componentCtx.ValidateComponentDisabled},
 	)
 	// Run the test suite.
+	RunTestCases(t, testCases)
+}
+
+// kserveDegradedMonitoringTestSuite runs only the external operator degraded monitoring tests.
+func kserveDegradedMonitoringTestSuite(t *testing.T) {
+	t.Helper()
+
+	ct, err := NewComponentTestCtx(t, &componentApi.Kserve{})
+	require.NoError(t, err)
+
+	componentCtx := KserveTestCtx{
+		ComponentTestCtx: ct,
+	}
+
+	testCases := []TestCase{
+		// we must enable the component first since this suite runs isolated from other component tests
+		{"Validate component enabled", componentCtx.ValidateComponentEnabled},
+		{"Validate external operator degraded condition monitoring", componentCtx.ValidateExternalOperatorDegradedMonitoring},
+	}
 	RunTestCases(t, testCases)
 }
 
@@ -254,7 +272,6 @@ func (tc *KserveTestCtx) ensureLWSBaseline(t *testing.T) *unstructured.Unstructu
 // External Operator CR > Kserve Component CR > DataScienceCluster CR.
 func (tc *KserveTestCtx) ValidateExternalOperatorDegradedMonitoring(t *testing.T) {
 	t.Helper()
-	t.Skip("RHOAIENG-41751: Skipping flaky external operator degraded monitoring test - under investigation")
 
 	// condition types monitored by the Kserve Component
 	testCases := []degradedConditionTestCase{

--- a/tests/e2e/kueue_test.go
+++ b/tests/e2e/kueue_test.go
@@ -83,7 +83,6 @@ func kueueTestSuite(t *testing.T) {
 		{"Validate component unmanaged error with ocp kueue-operator not installed", componentCtx.ValidateKueueUnmanagedWithoutOcpKueueOperator},
 		{"Validate component removed to unmanaged transition", componentCtx.ValidateKueueRemovedToUnmanagedTransition},
 		{"Validate component unmanaged to removed transition", componentCtx.ValidateKueueUnmanagedToRemovedTransition},
-		{"Validate external operator degraded condition monitoring", componentCtx.ValidateExternalOperatorDegradedMonitoring},
 	}
 
 	// Add webhook tests if enabled
@@ -100,6 +99,56 @@ func kueueTestSuite(t *testing.T) {
 
 	// Run the test suite.
 	RunTestCases(t, testCases)
+}
+
+// kueueDegradedMonitoringTestSuite runs only the external operator degraded monitoring tests.
+func kueueDegradedMonitoringTestSuite(t *testing.T) {
+	t.Helper()
+	t.Skip("Skipping: flaky due to namespace stuck in Terminating state. See RHOAIENG-46773 and RHOAIENG-46774.")
+
+	ct, err := NewComponentTestCtx(t, &componentApi.Kueue{})
+	require.NoError(t, err)
+
+	componentCtx := KueueTestCtx{
+		ComponentTestCtx: ct,
+	}
+
+	testCases := []TestCase{
+		{"Validate component enabled", componentCtx.EnsureKueueReady},
+		{"Validate external operator degraded condition monitoring", componentCtx.ValidateExternalOperatorDegradedMonitoring},
+	}
+	RunTestCases(t, testCases)
+}
+
+// EnsureKueueReady ensures the Kueue component is enabled and ready.
+func (tc *KueueTestCtx) EnsureKueueReady(t *testing.T) {
+	t.Helper()
+
+	componentName := strings.ToLower(tc.GVK.Kind)
+
+	t.Logf("Ensuring OCP Kueue Operator is installed (namespace=%s, name=%s).", kueueOcpOperatorNamespace, kueueOpName)
+	tc.EnsureOperatorInstalledWithGlobalOperatorGroupAndChannel(
+		types.NamespacedName{Name: kueueOpName, Namespace: kueueOcpOperatorNamespace},
+		kueueOcpOperatorChannel,
+	)
+
+	t.Logf("Ensuring Kueue operator is running (namespace=%s).", kueueOcpOperatorNamespace)
+	tc.scaleKueueOperator(t, 1)
+
+	t.Logf("Setting Kueue component to Unmanaged and waiting for KueueReady=True.")
+	stateUnmanaged := operatorv1.Unmanaged
+	conditionsUnmanagedReady := []gTypes.GomegaMatcher{
+		jq.Match(`.spec.components.%s.managementState == "%s"`, componentName, stateUnmanaged),
+		jq.Match(`.status.conditions[] | select(.type == "%sReady") | .status == "%s"`, tc.GVK.Kind, metav1.ConditionTrue),
+	}
+
+	tc.EventuallyResourcePatched(
+		WithMinimalObject(gvk.DataScienceCluster, tc.DataScienceClusterNamespacedName),
+		WithMutateFunc(testf.Transform(`.spec.components.%s.managementState = "%s"`, componentName, stateUnmanaged)),
+		WithCondition(And(conditionsUnmanagedReady...)),
+	)
+
+	t.Log("Kueue component is ready.")
 }
 
 // ValidateKueueUnmanagedWithoutOcpKueueOperator ensures that if the component is in Unmanaged state and ocp kueue operator is not installed, then its status is "Not Ready".
@@ -786,7 +835,6 @@ integrations:
 // but the operator can't reset conditions we inject.
 func (tc *KueueTestCtx) ValidateExternalOperatorDegradedMonitoring(t *testing.T) {
 	t.Helper()
-	t.Skip("RHOAIENG-41751: Skipping flaky external operator degraded monitoring test - under investigation")
 
 	// condition types monitored by the Kueue Component
 	testCases := []degradedConditionTestCase{
@@ -806,44 +854,6 @@ func (tc *KueueTestCtx) ValidateExternalOperatorDegradedMonitoring(t *testing.T)
 			conditionStatus: metav1.ConditionFalse,
 		},
 	}
-
-	t.Log("Resetting environment for external operator monitoring test (Component=Removed).")
-	tc.UpdateComponentStateInDataScienceCluster(operatorv1.Removed)
-	tc.cleanupKueueTestResources(t)
-
-	t.Logf("Ensuring Kueue OCP operator is installed (namespace=%s, name=%s).", kueueOcpOperatorNamespace, kueueOpName)
-	tc.EnsureOperatorInstalledWithGlobalOperatorGroupAndChannel(
-		types.NamespacedName{Name: kueueOpName, Namespace: kueueOcpOperatorNamespace},
-		kueueOcpOperatorChannel,
-	)
-
-	t.Logf("Creating managed test namespace with Kueue management annotation (namespace=%s).", kueueTestManagedNamespace)
-	tc.setupNamespace(kueueTestManagedNamespace, KueueManagedLabels)
-
-	t.Logf("Creating Kueue ConfigMap required for component reconciliation (namespace=%s, name=%s).", tc.AppsNamespace, kueue.KueueConfigMapName)
-	tc.createKueueConfigMap(t)
-
-	t.Logf("Enabling Kueue component by setting to Unmanaged mode (namespace=%s, name=%s).", tc.AppsNamespace, componentApi.KueueInstanceName)
-	tc.UpdateComponentStateInDataScienceCluster(operatorv1.Unmanaged)
-
-	// Kueue operator auto-creates its CR, so the component should be healthy initially
-	t.Logf("Verifying Kueue component is initially healthy (DependenciesAvailable=True) (namespace=%s, name=%s).", tc.AppsNamespace, componentApi.KueueInstanceName)
-	kueueNN := types.NamespacedName{Name: componentApi.KueueInstanceName}
-	tc.EnsureResourceExists(
-		WithMinimalObject(tc.GVK, kueueNN),
-		WithCondition(
-			jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, status.ConditionDependenciesAvailable, metav1.ConditionTrue),
-		),
-	)
-
-	t.Logf("Verifying DSC is healthy (KueueReady=True) before degradation tests (namespace=%s, name=%s).",
-		tc.DataScienceClusterNamespacedName.Namespace, tc.DataScienceClusterNamespacedName.Name)
-	tc.EnsureResourceExists(
-		WithMinimalObject(gvk.DataScienceCluster, tc.DataScienceClusterNamespacedName),
-		WithCondition(
-			jq.Match(`.status.conditions[] | select(.type == "%sReady") | .status == "%s"`, tc.GVK.Kind, metav1.ConditionTrue),
-		),
-	)
 
 	t.Logf("Scaling down Kueue operator deployment to prevent condition reset (namespace=%s, name=%s).", kueueOcpOperatorNamespace, kueueOperatorDeploymentNN.Name)
 	originalReplicas := tc.scaleKueueOperator(t, 0)

--- a/tests/e2e/trainer_test.go
+++ b/tests/e2e/trainer_test.go
@@ -36,12 +36,30 @@ func trainerTestSuite(t *testing.T) {
 		{"Validate operands have OwnerReferences", componentCtx.ValidateOperandsOwnerReferences},
 		{"Validate update operand resources", componentCtx.ValidateUpdateDeploymentsResources},
 		{"Validate component releases", componentCtx.ValidateComponentReleases},
-		{"Validate external operator degraded condition monitoring", componentCtx.ValidateExternalOperatorDegradedMonitoring},
 		{"Validate resource deletion recovery", componentCtx.ValidateAllDeletionRecovery},
 		{"Validate component disabled", componentCtx.ValidateComponentDisabled},
 	}
 
 	// Run the test suite.
+	RunTestCases(t, testCases)
+}
+
+// trainerDegradedMonitoringTestSuite runs only the external operator degraded monitoring tests.
+func trainerDegradedMonitoringTestSuite(t *testing.T) {
+	t.Helper()
+
+	ct, err := NewComponentTestCtx(t, &componentApi.Trainer{})
+	require.NoError(t, err)
+
+	componentCtx := TrainerTestCtx{
+		ComponentTestCtx: ct,
+	}
+
+	testCases := []TestCase{
+		// we must enable the component first since this suite runs isolated from other component tests
+		{"Validate component enabled", componentCtx.ValidateComponentEnabled},
+		{"Validate external operator degraded condition monitoring", componentCtx.ValidateExternalOperatorDegradedMonitoring},
+	}
 	RunTestCases(t, testCases)
 }
 
@@ -53,7 +71,6 @@ func trainerTestSuite(t *testing.T) {
 // External Operator CR > Trainer Component CR > DataScienceCluster CR.
 func (tc *TrainerTestCtx) ValidateExternalOperatorDegradedMonitoring(t *testing.T) {
 	t.Helper()
-	t.Skip("RHOAIENG-41751: Skipping flaky external operator degraded monitoring test - under investigation")
 
 	testCases := []degradedConditionTestCase{
 		{


### PR DESCRIPTION
## Description

Isolate the external operator degraded monitoring e2e tests in a new scenario, to prevent flacky parallel test interferences.

The `ValidateExternalOperatorDegradedMonitoring` tests for Kserve, Kueue, and Trainer manipulate the external operators by scaling external operators and injecting/clearing conditions.

These tests caused flakiness when run in parallel with other component tests and this intends to fix the flakiness.

Jira: [RHOAIENG-41751](https://issues.redhat.com/browse/RHOAIENG-41751)

## How Has This Been Tested?

Ran the new tests locally on CRC.

## Screenshot or short clip

N/A

## Merge criteria

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

- [] Skip requirement to update E2E test suite for this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Reorganized degraded-monitoring tests for Kserve, Kueue, and Trainer into isolated suites.
  * Removed those cases from main component suites to reduce coupling and improve isolation.
  * Re-enabled previously skipped degraded-monitoring cases so they now run in their dedicated suites.
  * Added a readiness helper for Kueue to prepare the component before its degraded tests.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->