### PR TITLE
RHOAIENG-43530 | feat(monitoring): update Perses image to 1.3.1

### DIFF
--- a/internal/controller/services/monitoring/monitoring_controller_support.go
+++ b/internal/controller/services/monitoring/monitoring_controller_support.go
@@ -66,13 +66,13 @@ var componentIDRE = regexp.MustCompile(`^[A-Za-z][A-Za-z0-9_]*(?:/[A-Za-z0-9][A-
 //
 // Note: This image version must stay compatible with the Cluster Observability Operator (COO) version
 // that we depend on. When upgrading COO, verify Perses image compatibility and update accordingly.
-// The current image is compatible with COO 1.2.2.
+// The current image is compatible with COO 1.3.1.
 func getPersesImage() string {
-	if image := os.Getenv("RELATED_IMAGE_PERSES"); image != "" {
+	if image := os.Getenv("RELATED_IMAGE_PERSES_IMAGE"); image != "" {
 		return image
 	}
 
-	return "registry.redhat.io/cluster-observability-operator/perses-0-50-rhel9:1.2.2-1752686994"
+	return "registry.redhat.io/cluster-observability-operator/perses-rhel9:1.3.1-1765876130"
 }
 
 // isLocalServiceEndpoint checks if an endpoint URL is for a local/in-cluster service.


### PR DESCRIPTION
Update Perses container image to version 1.3.1 (compatible with COO 1.3.1) and correct environment variable name from RELATED_IMAGE_PERSES to RELATED_IMAGE_PERSES_IMAGE for consistency.

<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->
Update default Perses image to one from COO 1.3.1, and change the env var reference to match red-hat-data-services/RHOAI-Build-Config#12645

<!--- Link your JIRA and related links here for reference. -->
Fixes: [RHOAIENG-43530](https://issues.redhat.com/browse/RHOAIENG-43530)
Relates to: [RHOAIENG-41583](https://issues.redhat.com/browse/RHOAIENG-41583)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Deploy ODH to a cluster.
2. Change to the `openshift-operators` project: `oc project openshift-operators`
3. Scale down the operator: `oc patch -n openshift-operators deployment opendatahub-operator-controller-manager --subresource='scale' --type='merge' -p '{"spec":{"replicas":0}}'`
4. Create a DSCI like this:
```shell
cat <<EOF | oc apply -f -
apiVersion: dscinitialization.opendatahub.io/v2
kind: DSCInitialization
metadata:
  labels:
    app.kubernetes.io/name: dscinitialization
  name: default-dsci
spec:
  applicationsNamespace: opendatahub
  monitoring:
    managementState: Managed
    metrics: {}
    namespace: opendatahub
    traces:
      sampleRatio: '0.1'
      storage:     
        backend: pv     
        retention: 2160h0m0s
        size: 10G
  trustedCABundle:
    customCABundle: ''
    managementState: Managed
EOF
```
6. Run `make run-nowebhook`
7. Verify the perses image used in the perses deployment: `oc get -n opendatahub statefulsets.apps data-science-perses -o yaml | grep image:`
8. Stop the local operator deployment, and rerun with the env var set to an older image and repeat verification to see that the updated env var works:
```shell
RELATED_IMAGE_PERSES_IMAGE=registry.redhat.io/cluster-observability-operator/perses-0-50-rhel9:1.2.2-1752686994 make run-nowebhook
```

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [x] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
10. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
11. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
12. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->
Related image env var/default value update only

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Perses monitoring image to version 1.3.1, improving compatibility with the latest cluster observability operator release.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->