### PR TITLE
RHOAIENG-45060 | feat: adding custom prometheus service monitor

### DIFF
--- a/config/manifests/bases/opendatahub-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/opendatahub-operator.clusterserviceversion.yaml
@@ -29,6 +29,11 @@ spec:
       kind: HardwareProfile
       name: hardwareprofiles.infrastructure.opendatahub.io
       version: v1alpha1
+    - description: ModelsAsService is the Schema for the modelsasservices API
+      displayName: Models As Service
+      kind: ModelsAsService
+      name: modelsasservices.components.platform.opendatahub.io
+      version: v1alpha1
     - description: Auth is the Schema for the auths API
       displayName: Auth
       kind: Auth
@@ -99,11 +104,6 @@ spec:
       displayName: MLflow Operator
       kind: MLflowOperator
       name: mlflowoperators.components.platform.opendatahub.io
-      version: v1alpha1
-    - description: ModelsAsService is the Schema for the modelsasservices API
-      displayName: Models As Service
-      kind: ModelsAsService
-      name: modelsasservices.components.platform.opendatahub.io
       version: v1alpha1
     - description: ModelRegistry is the Schema for the modelregistries API
       displayName: Model Registry

--- a/internal/controller/services/monitoring/monitoring_controller_actions.go
+++ b/internal/controller/services/monitoring/monitoring_controller_actions.go
@@ -39,6 +39,7 @@ const (
 	PrometheusServiceOverrideTemplate             = "resources/data-science-prometheus-service-override.tmpl.yaml"
 	PrometheusNetworkPolicyTemplate               = "resources/data-science-prometheus-network-policy.tmpl.yaml"
 	PrometheusWebTLSServiceTemplate               = "resources/prometheus-web-tls-service.tmpl.yaml"
+	PrometheusSelfServiceMonitorTemplate          = "resources/prometheus-self-servicemonitor.tmpl.yaml"
 	ThanosQuerierTemplate                         = "resources/thanos-querier-cr.tmpl.yaml"
 	ThanosQuerierRouteTemplate                    = "resources/thanos-querier-route.tmpl.yaml"
 	PersesTemplate                                = "resources/perses.tmpl.yaml"
@@ -203,6 +204,7 @@ func deployMonitoringStackWithQuerierAndRestrictions(ctx context.Context, rr *od
 	templates := []odhtypes.TemplateInfo{
 		{FS: resourcesFS, Path: PrometheusWebTLSServiceTemplate},
 		{FS: resourcesFS, Path: MonitoringStackTemplate},
+		{FS: resourcesFS, Path: PrometheusSelfServiceMonitorTemplate},
 		{FS: resourcesFS, Path: MonitoringStackAlertmanagerRBACTemplate},
 		{FS: resourcesFS, Path: PrometheusRouteTemplate},
 		{FS: resourcesFS, Path: PrometheusServiceOverrideTemplate},

--- a/internal/controller/services/monitoring/resources/prometheus-self-servicemonitor.tmpl.yaml
+++ b/internal/controller/services/monitoring/resources/prometheus-self-servicemonitor.tmpl.yaml
@@ -1,0 +1,34 @@
+# Custom ServiceMonitor for Prometheus self-scraping with correct TLS serverName
+# This works around the TLS SAN mismatch where the auto-generated prometheus-self
+# ServiceMonitor targets data-science-monitoringstack-prometheus but the cert has
+# SANs for prometheus-operated.*
+#
+# We target the same service as prometheus-self (data-science-monitoringstack-prometheus)
+# but override the serverName to use prometheus-operated which matches the certificate SANs.
+apiVersion: monitoring.rhobs/v1
+kind: ServiceMonitor
+metadata:
+  name: prometheus-self-fixed
+  namespace: {{.Namespace}}
+  labels:
+    platform.opendatahub.io/part-of: monitoring
+spec:
+  endpoints:
+    - port: web
+      scheme: https
+      tlsConfig:
+        ca:
+          configMap:
+            name: prometheus-web-tls-ca
+            key: service-ca.crt
+        serverName: "prometheus-operated.{{.Namespace}}.svc"
+      bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      relabelings:
+        - targetLabel: job
+          replacement: prometheus-self-fixed
+  namespaceSelector:
+    matchNames:
+      - {{.Namespace}}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: data-science-monitoringstack-prometheus

--- a/tests/e2e/monitoring_test.go
+++ b/tests/e2e/monitoring_test.go
@@ -112,6 +112,7 @@ func monitoringTestSuite(t *testing.T) {
 		{"Test Traces Exporters Reserved Name Validation", monitoringServiceCtx.ValidateTracesExportersReservedNameValidation},
 		{"Test ThanosQuerier deployment with metrics", monitoringServiceCtx.ValidateThanosQuerierDeployment},
 		{"Test ThanosQuerier not deployed without metrics", monitoringServiceCtx.ValidateThanosQuerierNotDeployedWithoutMetrics},
+		{"Test Prometheus Self ServiceMonitor TLS Fix", monitoringServiceCtx.ValidatePrometheusSelfServiceMonitorTLSFix},
 		{"Test Perses deployment when monitoring is managed", monitoringServiceCtx.ValidatePersesCRCreation},
 		{"Test Perses CR configuration", monitoringServiceCtx.ValidatePersesCRConfiguration},
 		{"Test Perses lifecycle", monitoringServiceCtx.ValidatePersesLifecycle},
@@ -1484,6 +1485,77 @@ func (tc *MonitoringTestCtx) ValidateThanosQuerierNotDeployedWithoutMetrics(t *t
 	)
 
 	// Cleanup: Reset monitoring configuration
+	tc.resetMonitoringConfigToManaged()
+}
+
+// ValidatePrometheusSelfServiceMonitorTLSFix tests that the prometheus-self-fixed ServiceMonitor is deployed
+// and properly configured with the correct serverName to fix TLS SANs mismatch issues.
+func (tc *MonitoringTestCtx) ValidatePrometheusSelfServiceMonitorTLSFix(t *testing.T) {
+	t.Helper()
+
+	tc.updateMonitoringConfig(
+		withManagementState(operatorv1.Managed),
+		tc.withMetricsConfig(),
+	)
+
+	tc.EnsureResourceExists(
+		WithMinimalObject(gvk.Monitoring, types.NamespacedName{Name: MonitoringCRName}),
+		WithCondition(And(
+			jq.Match(`.spec.metrics != null`),
+			jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, status.ConditionTypeReady, metav1.ConditionTrue),
+			jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, status.ConditionMonitoringStackAvailable, metav1.ConditionTrue),
+		)),
+		WithCustomErrorMsg("Monitoring resource should be ready with MonitoringStack available"),
+	)
+
+	// Verify the prometheus-self-fixed ServiceMonitor is created with correct TLS configuration
+	tc.EnsureResourceExists(
+		WithMinimalObject(gvk.ServiceMonitor, types.NamespacedName{Name: "prometheus-self-fixed", Namespace: tc.MonitoringNamespace}),
+		WithCondition(And(
+			// Validate it has the correct serverName that matches the certificate SANs
+			jq.Match(`.spec.endpoints[0].tlsConfig.serverName == "prometheus-operated.%s.svc"`, tc.MonitoringNamespace),
+			// Validate it targets the correct service
+			jq.Match(`.spec.selector.matchLabels."app.kubernetes.io/name" == "data-science-monitoringstack-prometheus"`),
+			// Validate it uses HTTPS
+			jq.Match(`.spec.endpoints[0].scheme == "https"`),
+			// Validate it references the correct CA configmap
+			jq.Match(`.spec.endpoints[0].tlsConfig.ca.configMap.name == "prometheus-web-tls-ca"`),
+			// Validate platform label
+			jq.Match(`.metadata.labels."platform.opendatahub.io/part-of" == "monitoring"`),
+			// Validate owner references point to Monitoring CR
+			monitoringOwnerReferencesCondition,
+		)),
+		WithCustomErrorMsg("prometheus-self-fixed ServiceMonitor should be created with correct TLS configuration"),
+	)
+
+	// Verify the prometheus-web-tls-ca ConfigMap exists (used by ServiceMonitor for TLS)
+	tc.EnsureResourceExists(
+		WithMinimalObject(gvk.ConfigMap, types.NamespacedName{Name: "prometheus-web-tls-ca", Namespace: tc.MonitoringNamespace}),
+		WithCondition(And(
+			// Validate it has the service-ca injection annotation
+			jq.Match(`.metadata.annotations."service.beta.openshift.io/inject-cabundle" == "true"`),
+		)),
+		WithCustomErrorMsg("prometheus-web-tls-ca ConfigMap should exist with CA injection annotation"),
+	)
+
+	// Verify the prometheus-operated service has TLS cert secret annotation
+	tc.EnsureResourceExists(
+		WithMinimalObject(gvk.Service, types.NamespacedName{Name: "prometheus-operated", Namespace: tc.MonitoringNamespace}),
+		WithCondition(And(
+			jq.Match(`.metadata.annotations."service.beta.openshift.io/serving-cert-secret-name" == "prometheus-operated-tls"`),
+		)),
+		WithCustomErrorMsg("prometheus-operated Service should have serving-cert-secret-name annotation for TLS"),
+	)
+
+	// Verify Prometheus StatefulSet is ready
+	tc.EnsureResourceExists(
+		WithMinimalObject(gvk.StatefulSet, types.NamespacedName{Name: "prometheus-data-science-monitoringstack", Namespace: tc.MonitoringNamespace}),
+		WithCondition(And(
+			jq.Match(`.status.readyReplicas >= 1`),
+		)),
+		WithCustomErrorMsg("Prometheus StatefulSet should have at least one ready replica, indicating healthy operation"),
+	)
+
 	tc.resetMonitoringConfigToManaged()
 }
 


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
[RHOAIENG-45060](https://issues.redhat.com/browse/RHOAIENG-45060)
The auto-generated `prometheus-self` ServiceMonitor created by the Observability Operator: 
This ServiceMonitor targets the wrong service `data-science-monitoringstack-prometheus` which doesn't have the cert annotation, hence the TLS SAN mismatch.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [ ] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
Fix mainly config based


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Prometheus ServiceMonitor template for self-scraping within the Prometheus namespace.

* **Bug Fixes**
  * Fixed TLS serverName used by the ServiceMonitor to match certificate SANs, preventing TLS-related scrape failures.

* **Tests**
  * Added unit and e2e tests validating the ServiceMonitor template, content, inclusion logic, and deployment ordering with TLS.

* **Chores**
  * Adjusted operator manifest CRD entry for ModelsAsService.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->