### PR TITLE
[FIX] add exception to networkpolicy to allow observability 

### DIFF
--- a/internal/controller/dscinitialization/utils.go
+++ b/internal/controller/dscinitialization/utils.go
@@ -204,7 +204,8 @@ func ReconcileDefaultNetworkPolicy(
 				From: createNetworkPolicyPeer(labels.CustomizedAppNamespace, labels.True)}, {
 				From: createNetworkPolicyPeer("network.openshift.io/policy-group", "ingress")}, {
 				From: createNetworkPolicyPeer("kubernetes.io/metadata.name", "openshift-host-network")}, {
-				From: createNetworkPolicyPeer("kubernetes.io/metadata.name", "openshift-monitoring")},
+				From: createNetworkPolicyPeer("kubernetes.io/metadata.name", "openshift-monitoring")}, {
+				From: createNetworkPolicyPeer("kubernetes.io/metadata.name", "openshift-cluster-observability-operator")},
 			},
 			PolicyTypes: []networkingv1.PolicyType{
 				networkingv1.PolicyTypeIngress,

--- a/internal/controller/services/monitoring/resources/tempo-stack.tmpl.yaml
+++ b/internal/controller/services/monitoring/resources/tempo-stack.tmpl.yaml
@@ -14,6 +14,9 @@ spec:
         memory: {{.TempoMemoryRequest}}
   tenants:
     mode: openshift
+    authentication:
+      - tenantId: {{.Namespace}}
+        tenantName: {{.Namespace}}
   retention:
     global:
       traces: {{.TracesRetention}} # default 90days


### PR DESCRIPTION
…ces plugin

<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

- Add tenant and id to tempostack
- Add rule in networkpolicy to allow traffic from openshift-cluster-observability-operator namespace so the UIplugin for distributed-tracing can communicate correctly.


*To Verify*
* Deploy ODH operator and dependant observability operators.
* Set monitoring to `managementState: Managed` in DSCI.
* Enable metrics and traces.
* Create UIPlugin with `name: distributed-tracing` and `spec.type: DistributedTracing`
* Confirm the traces tab appears under `observe > traces`
* COnfirm you can select `opendatahub/data-science-tempomonolithic` from the dropdown.
<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->
This fixes a communication issue with an optional UIplugin, no e2e test required.