### PR TITLE
fix: modify ServiceMesh controller to prevent race conditions to ensure authorino Pod contains istio-proxy container

### DIFF
--- a/internal/controller/services/servicemesh/servicemesh.go
+++ b/internal/controller/services/servicemesh/servicemesh.go
@@ -27,6 +27,8 @@ const (
 
 	authProviderName = "authorino"
 	authorinoLabel   = "security.opendatahub.io/authorization-group=default"
+
+	serviceMeshMemberName = "default" // matches the name specified in the SMM template
 )
 
 const (

--- a/internal/controller/services/servicemesh/servicemesh_controller_actions.go
+++ b/internal/controller/services/servicemesh/servicemesh_controller_actions.go
@@ -206,6 +206,22 @@ func initializeAuthorino(ctx context.Context, rr *odhtypes.ReconciliationRequest
 		return nil
 	}
 
+	// wait for SMCP to be ready before initializing Authorino
+	// to ensure the Istio sidecar injection works properly
+	smcp, err := getSMCP(ctx, rr)
+	if err != nil {
+		if k8serr.IsNotFound(err) {
+			log.Info("SMCP not found yet, deferring Authorino initialization")
+			return nil
+		}
+		log.Info("Unable to get SMCP, deferring Authorino initialization", "error", err)
+		return nil
+	}
+	if ready, _ := isSMCPReady(smcp); !ready {
+		log.Info("SMCP not ready yet, deferring Authorino initialization until SMCP is ready")
+		return nil
+	}
+
 	// ensure Authorino operator is installed as pre-requisite
 	authorinoOperatorFound, err := cluster.SubscriptionExists(ctx, rr.Client, authorinoOperatorName)
 	if err != nil {
@@ -241,15 +257,31 @@ func initializeAuthorino(ctx context.Context, rr *odhtypes.ReconciliationRequest
 		return fmt.Errorf("failed to create Authorino namespace %s: %w", authorinoNamespace, err)
 	}
 
+	// add the SMM template first to ensure environment is ready for Authorino
+	rr.Templates = append(
+		rr.Templates,
+		odhtypes.TemplateInfo{
+			FS:   resourcesFS,
+			Path: authorinoServiceMeshMemberTemplate,
+		},
+	)
+
+	// only add Authorino CR and Authorino-related SMCP patch after SMM is Ready
+	smmReady, err := isServiceMeshMemberReady(ctx, rr, serviceMeshMemberName, authorinoNamespace)
+	if err != nil {
+		log.Info("Unable to check ServiceMeshMember readiness, deferring Authorino CR creation", "error", err)
+		return nil
+	}
+	if !smmReady {
+		log.Info("ServiceMeshMember not ready yet, deferring Authorino CR creation until namespace is fully synced with mesh")
+		return nil
+	}
+
 	rr.Templates = append(
 		rr.Templates,
 		odhtypes.TemplateInfo{
 			FS:   resourcesFS,
 			Path: authorinoTemplate,
-		},
-		odhtypes.TemplateInfo{
-			FS:   resourcesFS,
-			Path: authorinoServiceMeshMemberTemplate,
 		},
 		odhtypes.TemplateInfo{
 			FS:   resourcesFS,
@@ -373,25 +405,18 @@ func checkSMCPReadiness(ctx context.Context, rr *odhtypes.ReconciliationRequest)
 		return nil
 	}
 
-	smcp := &unstructured.Unstructured{}
-	smcp.SetGroupVersionKind(gvk.ServiceMeshControlPlane)
-	err := rr.Client.Get(ctx, client.ObjectKey{
-		Name:      sm.Spec.ControlPlane.Name,
-		Namespace: sm.Spec.ControlPlane.Namespace,
-	}, smcp)
-
-	if err != nil && !k8serr.IsNotFound(err) {
+	smcp, err := getSMCP(ctx, rr)
+	if err != nil {
+		if k8serr.IsNotFound(err) {
+			rr.Conditions.MarkFalse(
+				status.CapabilityServiceMesh,
+				conditions.WithReason(status.NotReadyReason),
+				conditions.WithMessage("ServiceMeshControlPlane not found, SMCP may be initializing: %v", err),
+				conditions.WithSeverity(common.ConditionSeverityInfo),
+			)
+			return nil
+		}
 		return fmt.Errorf("failed to get ServiceMeshControlPlane: %w", err)
-	}
-
-	if k8serr.IsNotFound(err) {
-		rr.Conditions.MarkFalse(
-			status.CapabilityServiceMesh,
-			conditions.WithReason(status.NotReadyReason),
-			conditions.WithMessage("ServiceMeshControlPlane not found, SMCP may be initializing: %v", err),
-			conditions.WithSeverity(common.ConditionSeverityInfo),
-		)
-		return nil
 	}
 
 	ready, message := isSMCPReady(smcp)
@@ -487,6 +512,8 @@ func checkAuthorinoReadiness(ctx context.Context, rr *odhtypes.ReconciliationReq
 }
 
 func patchAuthorinoDeployment(ctx context.Context, rr *odhtypes.ReconciliationRequest) error {
+	log := logf.FromContext(ctx)
+
 	sm, ok := rr.Instance.(*serviceApi.ServiceMesh)
 	if !ok {
 		return fmt.Errorf("resource instance %v is not a serviceApi.ServiceMesh)", rr.Instance)
@@ -497,7 +524,7 @@ func patchAuthorinoDeployment(ctx context.Context, rr *odhtypes.ReconciliationRe
 		return nil
 	}
 
-	authorino, err := getAutorinoResource(ctx, rr)
+	authorino, err := getAuthorinoResource(ctx, rr)
 
 	if k8serr.IsNotFound(err) || meta.IsNoMatchError(err) {
 		// nothing to do, authorino cr or crd do not exist
@@ -506,6 +533,27 @@ func patchAuthorinoDeployment(ctx context.Context, rr *odhtypes.ReconciliationRe
 	if err != nil {
 		return err
 	}
+
+	authorinoDeployment, err := getAuthorinoDeployment(ctx, rr, authorino.GetName(), authorino.GetNamespace())
+	if err != nil {
+		if k8serr.IsNotFound(err) {
+			// Authorino Deployment not yet created by Authorino operator, nothing to do yet
+			log.Info("Authorino Deployment not found, waiting for Authorino operator to create it",
+				"name", authorino.GetName(), "namespace", authorino.GetNamespace())
+			return nil
+		}
+		return fmt.Errorf("failed to get Authorino Deployment: %w", err)
+	}
+
+	// check if the sidecar injection label is already present, to determine if patch is needed
+	if hasIstioSidecarInjectionLabel(authorinoDeployment) {
+		log.Info("Authorino Deployment already has sidecar injection label, skipping patch",
+			"name", authorino.GetName(), "namespace", authorino.GetNamespace())
+		return nil
+	}
+
+	log.Info("Patching Authorino Deployment with sidecar injection label",
+		"name", authorino.GetName(), "namespace", authorino.GetNamespace())
 
 	patch := createAuthorinoDeploymentPatch(authorino.GetName(), authorino.GetNamespace())
 	data, errJSON := patch.MarshalJSON()
@@ -520,23 +568,16 @@ func patchAuthorinoDeployment(ctx context.Context, rr *odhtypes.ReconciliationRe
 }
 
 func cleanupSMCP(ctx context.Context, rr *odhtypes.ReconciliationRequest) error {
-	sm, ok := rr.Instance.(*serviceApi.ServiceMesh)
-	if !ok {
-		return fmt.Errorf("resource instance %v is not a serviceApi.ServiceMesh)", rr.Instance)
-	}
-
-	smcp := &unstructured.Unstructured{}
-	smcp.SetGroupVersionKind(gvk.ServiceMeshControlPlane)
-	err := rr.Client.Get(ctx, client.ObjectKey{
-		Name:      sm.Spec.ControlPlane.Name,
-		Namespace: sm.Spec.ControlPlane.Namespace,
-	}, smcp)
-
-	if k8serr.IsNotFound(err) {
-		// SMCP not found, skipping deletion
-		return nil
-	}
+	smcp, err := getSMCP(ctx, rr)
 	if err != nil {
+		if k8serr.IsNotFound(err) {
+			// SMCP not found, skipping deletion
+			return nil
+		}
+		// If CRD doesn't exist (NoMatchError), skip cleanup gracefully
+		if meta.IsNoMatchError(err) {
+			return nil
+		}
 		return fmt.Errorf("failed to get ServiceMeshControlPlane: %w", err)
 	}
 

--- a/internal/controller/services/servicemesh/servicemesh_support.go
+++ b/internal/controller/services/servicemesh/servicemesh_support.go
@@ -9,7 +9,9 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
@@ -20,8 +22,28 @@ import (
 	odhtypes "github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
 )
 
+const (
+	conditionTypeReady  = "Ready"
+	conditionStatusTrue = "True"
+
+	istioSidecarInjectLabel = "sidecar.istio.io/inject"
+)
+
 type AuthorinoDeploymentPredicate struct {
 	predicate.Funcs
+}
+
+func (AuthorinoDeploymentPredicate) Create(e event.CreateEvent) bool {
+	if e.Object == nil {
+		return false
+	}
+
+	deployment, ok := e.Object.(*appsv1.Deployment)
+	if !ok {
+		return false
+	}
+
+	return deployment.GetName() == authProviderName
 }
 
 func (AuthorinoDeploymentPredicate) Update(e event.UpdateEvent) bool {
@@ -39,13 +61,17 @@ func (AuthorinoDeploymentPredicate) Update(e event.UpdateEvent) bool {
 		return false
 	}
 
-	if newDeployment.GetName() != "authorino" {
+	if newDeployment.GetName() != authProviderName {
 		return false
 	}
 
+	oldHasSidecarInjectionLabel := hasIstioSidecarInjectionLabel(oldDeployment)
+	newHasSidecarInjectionLabel := hasIstioSidecarInjectionLabel(newDeployment)
+
 	return oldDeployment.Generation != newDeployment.Generation ||
 		oldDeployment.Status.Replicas != newDeployment.Status.Replicas ||
-		oldDeployment.Status.ReadyReplicas != newDeployment.Status.ReadyReplicas
+		oldDeployment.Status.ReadyReplicas != newDeployment.Status.ReadyReplicas ||
+		(oldHasSidecarInjectionLabel && !newHasSidecarInjectionLabel)
 }
 
 func NewAuthorinoDeploymentPredicate() *AuthorinoDeploymentPredicate {
@@ -186,8 +212,8 @@ func isSMCPReady(smcp *unstructured.Unstructured) (bool, string) {
 			lastConditionMessage = fmt.Sprintf("%v", message)
 		}
 
-		if condType == "Ready" {
-			if condStatus == "True" {
+		if condType == conditionTypeReady {
+			if condStatus == conditionStatusTrue {
 				return true, "SMCP Ready condition is True"
 			}
 
@@ -199,6 +225,59 @@ func isSMCPReady(smcp *unstructured.Unstructured) (bool, string) {
 	}
 
 	return false, "SMCP Ready condition not found, SMCP may be initializing"
+}
+
+func getSMCP(ctx context.Context, rr *odhtypes.ReconciliationRequest) (*unstructured.Unstructured, error) {
+	sm, ok := rr.Instance.(*serviceApi.ServiceMesh)
+	if !ok {
+		return nil, fmt.Errorf("resource instance %v is not a serviceApi.ServiceMesh)", rr.Instance)
+	}
+
+	smcp := &unstructured.Unstructured{}
+	smcp.SetGroupVersionKind(gvk.ServiceMeshControlPlane)
+	err := rr.Client.Get(ctx, client.ObjectKey{
+		Name:      sm.Spec.ControlPlane.Name,
+		Namespace: sm.Spec.ControlPlane.Namespace,
+	}, smcp)
+
+	return smcp, err
+}
+
+func isServiceMeshMemberReady(ctx context.Context, rr *odhtypes.ReconciliationRequest, name, namespace string) (bool, error) {
+	smm := &unstructured.Unstructured{}
+	smm.SetGroupVersionKind(gvk.ServiceMeshMember)
+	err := rr.Client.Get(ctx, client.ObjectKey{
+		Name:      name,
+		Namespace: namespace,
+	}, smm)
+
+	if err != nil {
+		if k8serr.IsNotFound(err) {
+			return false, nil
+		}
+		return false, err
+	}
+
+	conditions, found, err := unstructured.NestedSlice(smm.Object, "status", "conditions")
+	if err != nil {
+		return false, err
+	}
+
+	if !found {
+		return false, nil
+	}
+
+	for _, condition := range conditions {
+		conditionMap, ok := condition.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if conditionMap["type"] == conditionTypeReady && conditionMap["status"] == conditionStatusTrue {
+			return true, nil
+		}
+	}
+
+	return false, nil
 }
 
 func isAuthorinoReady(authorino *unstructured.Unstructured) (bool, error) {
@@ -225,7 +304,7 @@ func isAuthorinoReady(authorino *unstructured.Unstructured) (bool, error) {
 			continue
 		}
 
-		if condType == "Ready" && condStatus == "True" {
+		if condType == conditionTypeReady && condStatus == conditionStatusTrue {
 			return true, nil
 		}
 	}
@@ -233,7 +312,7 @@ func isAuthorinoReady(authorino *unstructured.Unstructured) (bool, error) {
 	return false, errors.New("no Authorino Ready condition found, Authorino may be initializing")
 }
 
-func getAutorinoResource(ctx context.Context, rr *odhtypes.ReconciliationRequest) (*unstructured.Unstructured, error) {
+func getAuthorinoResource(ctx context.Context, rr *odhtypes.ReconciliationRequest) (*unstructured.Unstructured, error) {
 	authorinoNamespace, err := getAuthorinoNamespace(rr)
 	if err != nil {
 		return nil, err
@@ -263,7 +342,7 @@ func createAuthorinoDeploymentPatch(name string, namespace string) *unstructured
 			"template": map[string]interface{}{
 				"metadata": map[string]interface{}{
 					"labels": map[string]interface{}{
-						"sidecar.istio.io/inject": "true",
+						istioSidecarInjectLabel: "true",
 					},
 				},
 			},
@@ -271,4 +350,33 @@ func createAuthorinoDeploymentPatch(name string, namespace string) *unstructured
 	}
 
 	return authorinoDeploymentPatch
+}
+
+func getAuthorinoDeployment(ctx context.Context, rr *odhtypes.ReconciliationRequest, name, namespace string) (*appsv1.Deployment, error) {
+	deploymentResource := rr.Controller.GetDynamicClient().Resource(gvk.Deployment.GroupVersion().WithResource("deployments")).Namespace(namespace)
+
+	u, err := deploymentResource.Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	deployment := &appsv1.Deployment{}
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(u.Object, deployment); err != nil {
+		return nil, fmt.Errorf("failed to convert unstructured to Deployment: %w", err)
+	}
+
+	return deployment, nil
+}
+
+func hasIstioSidecarInjectionLabel(deployment *appsv1.Deployment) bool {
+	if deployment == nil {
+		return false
+	}
+
+	labels := deployment.Spec.Template.Labels
+	if labels == nil {
+		return false
+	}
+
+	return labels[istioSidecarInjectLabel] == "true"
 }


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

JIRA ref: [RHOAIENG-36947](https://issues.redhat.com/browse/RHOAIENG-36947)
Unlike what the ticket states, this bug was not reproducible in 100% of cases.

Changes made to the ServiceMesh controller to prevent potential race conditions between RHOAI operator and Authorino/OSSMv2 operators, to ensure that the authorino Pod will contain istio-proxy container as expected:
- added checks for Authorino Deployment to ensure that the patch responsible for adding `sidecar.istio.io/inject:'true'`  label happens
- added readiness checks for ServiceMeshControlPlane and ServiceMeshMember instance during Authorino setup, to prevent potential race condition

## How Has This Been Tested?
Tested on my PSI cluster (OCP 4.19.21)

Catalog image: `quay.io/mlassak/opendatahub-operator-catalog:v2.25.2`

1. Install dependencies - Authorino and OSSMv2
2. RHOAI 2.25 installation via olminstall using the catalog image above
3. Check on cluster:
    - authorino Pod to have 2 containers (authorino and istio-proxy) as expected
    - authorino Pod and Deployment have `sidecar.istio.io/inject:'true'` label as expected
4. Repeated the process multiple times

## Screenshot or short clip
<img width="401" height="335" alt="image" src="https://github.com/user-attachments/assets/63102caf-76f0-4440-8f2c-ece1e41cfc0a" />

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
5. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
6. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
This should not be changing the expected functionality
