### PR TITLE
Provide additional precondition checks for Trainer component

### DIFF
--- a/internal/controller/components/trainer/trainer.go
+++ b/internal/controller/components/trainer/trainer.go
@@ -16,7 +16,6 @@ import (
 	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/components"
 	cr "github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/components/registry"
 	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/status"
-	odherrors "github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/errors"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/conditions"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
 	odhdeploy "github.com/opendatahub-io/opendatahub-operator/v2/pkg/deploy"
@@ -25,10 +24,6 @@ import (
 
 const (
 	jobSetOperator = "jobset-operator"
-)
-
-var (
-	ErrJobSetOperatorNotInstalled = odherrors.NewStopError(status.JobSetOperatorNotInstalledMessage)
 )
 
 type componentHandler struct{}

--- a/internal/controller/components/trainer/trainer_controller.go
+++ b/internal/controller/components/trainer/trainer_controller.go
@@ -25,6 +25,7 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/api/components/v1alpha1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
@@ -65,7 +66,10 @@ func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.
 				handlers.ToNamed(componentApi.TrainerInstanceName),
 			),
 			reconciler.WithPredicates(
-				dependent.New(dependent.WithWatchStatus(true)),
+				predicate.Or(
+					dependent.New(dependent.WithWatchStatus(true)),
+					resources.CreatedOrUpdatedOrDeletedNamed("cluster"),
+				),
 			),
 			reconciler.Dynamic(reconciler.CrdExists(gvk.JobSetOperatorV1))).
 		WithAction(checkPreConditions).

--- a/internal/controller/status/status.go
+++ b/internal/controller/status/status.go
@@ -181,7 +181,9 @@ To uninstall it, you should delete all RayClusters resources from the cluster, d
 // For JobSet operator checks.
 const (
 	JobSetOperatorNotInstalledMessage = "JobSet operator not installed, please install it first"
-	JobSetCRDMissingMessage           = "JobSet CRD does not exist, please create JobSetOperator CR to proceed"
+	JobSetCRDMissingMessage           = "JobSet CRD does not exist, please inspect JobSetOperator CR status conditions or JobSet controller Pod logs for more details"
+	JobSetOperatorCRNotFoundMessage   = "JobSetOperator CR with name 'cluster' not found, please create it first"
+	JobSetOperatorCRWrongNameMessage  = "JobSetOperator CR found with name '%s' (expected 'cluster'), please ensure the CR is named 'cluster'"
 )
 
 // setConditions is a helper function to set multiple conditions at once.


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->
Expand Trainer component precondition check, adding:
- Verify JobSetOperator CR with name "cluster" exists
- Verify JobSetOperator CR status contains condition "Available' with value "True"

Provide indicative error messages if conditions are not fulfilled.

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->
Minor changes adjusting messages for trainer component status, no behavior change affecting e2e tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Reconciler now also responds to create/update/delete events for the operator CR named "cluster", improving responsiveness.

* **Bug Fixes**
  * Improved pre-condition checks with clearer, distinct outcomes when the JobSet operator or its CR is missing or misnamed.

* **Documentation**
  * Status messages updated with more actionable guidance to inspect operator CR status or controller logs.

* **Tests**
  * Expanded scheme-aware tests covering operator presence, naming, availability, and pre-condition validation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->