### PR TITLE
RHOAIENG-45480 | feat: changing default perses dashboard

### DIFF
--- a/internal/controller/services/monitoring/monitoring_controller_actions.go
+++ b/internal/controller/services/monitoring/monitoring_controller_actions.go
@@ -45,6 +45,7 @@ const (
 	PersesTempoDatasourceTemplate                 = "resources/perses-tempo-datasource.tmpl.yaml"
 	PersesTempoDashboardTemplate                  = "resources/perses-tempo-dashboard.tmpl.yaml"
 	PersesDatasourcePrometheusTemplate            = "resources/perses-datasource-prometheus.tmpl.yaml"
+	PersesDatasourceClusterPrometheusTemplate     = "resources/perses-datasource-cluster-prometheus.tmpl.yaml"
 	PrometheusClusterProxyTemplate                = "resources/data-science-prometheus-cluster-proxy.tmpl.yaml"
 	TempoServiceCAConfigMapTemplate               = "resources/tempo-service-ca-configmap.tmpl.yaml"
 	PersesOperatorAccessNetworkPolicyTemplate     = "resources/perses-operator-access-network-policy.tmpl.yaml"
@@ -613,6 +614,12 @@ func deployPersesPrometheusIntegration(ctx context.Context, rr *odhtypes.Reconci
 		{
 			FS:   resourcesFS,
 			Path: PersesDatasourcePrometheusTemplate,
+		},
+		// Cluster-wide metrics datasource (from OpenShift Monitoring Thanos Querier)
+		// This is the default datasource until decentralized collection is implemented
+		{
+			FS:   resourcesFS,
+			Path: PersesDatasourceClusterPrometheusTemplate,
 		},
 	}
 	rr.Templates = append(rr.Templates, templates...)

--- a/internal/controller/services/monitoring/resources/perses-datasource-cluster-prometheus.tmpl.yaml
+++ b/internal/controller/services/monitoring/resources/perses-datasource-cluster-prometheus.tmpl.yaml
@@ -1,0 +1,57 @@
+# Cluster Prometheus Datasource for Perses
+#
+# This is a short-term workaround to provide access to cluster-wide metrics
+# via the OpenShift Monitoring stack's Thanos Querier.
+#
+# This datasource points to the cluster's Thanos Querier (in openshift-monitoring)
+# which aggregates metrics from all Prometheus instances in the cluster.
+#
+# This will be replaced/updated once decentralized metrics collection is implemented.
+#
+# The configuration uses:
+# - ConfigMap-based TLS CA (prometheus-web-tls-ca with OpenShift service CA)
+# - A secret for bearer token authentication to Thanos Querier
+#
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cluster-prometheus-datasource-secret
+  namespace: {{.Namespace}}
+  labels:
+    platform.opendatahub.io/part-of: monitoring
+  annotations:
+    kubernetes.io/service-account.name: data-science-prometheus-cluster-proxy
+type: kubernetes.io/service-account-token
+---
+apiVersion: perses.dev/v1alpha1
+kind: PersesDatasource
+metadata:
+  name: cluster-prometheus-datasource
+  namespace: {{.Namespace}}
+  labels:
+    platform.opendatahub.io/part-of: monitoring
+  annotations:
+    platform.opendatahub.io/description: "Cluster-wide Prometheus metrics via OpenShift Monitoring Thanos Querier"
+spec:
+  client:
+    tls:
+      enable: true
+      caCert:
+        type: configmap
+        name: prometheus-web-tls-ca
+        certPath: service-ca.crt
+  config:
+    default: true
+    display:
+      name: "Cluster Prometheus"
+      description: "OpenShift Monitoring Thanos Querier - provides cluster-wide metrics"
+    plugin:
+      kind: "PrometheusDatasource"
+      spec:
+        proxy:
+          kind: HTTPProxy
+          spec:
+            # Secret contains bearer token for Thanos Querier authentication
+            secret: cluster-prometheus-datasource-secret
+            url: https://thanos-querier.openshift-monitoring.svc:9091

--- a/internal/controller/services/monitoring/resources/perses-datasource-prometheus.tmpl.yaml
+++ b/internal/controller/services/monitoring/resources/perses-datasource-prometheus.tmpl.yaml
@@ -3,11 +3,17 @@ kind: PersesDatasource
 metadata:
   name: data-science-prometheus-datasource
   namespace: {{.Namespace}}
+  labels:
+    platform.opendatahub.io/part-of: monitoring
+  annotations:
+    platform.opendatahub.io/description: "Data Science specific metrics from the local MonitoringStack"
 spec:
   config:
-    default: true
+    # default: false - Cluster Prometheus is the default until decentralized collection is implemented
+    default: false
     display:
-      name: "Data Science Prometheus Datasource"
+      name: "Data Science Prometheus"
+      description: "Data Science MonitoringStack Thanos Querier - provides DS workload metrics"
     plugin:
       kind: "PrometheusDatasource"
       spec:


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
(TEMPORARY) [RHOAIENG-45480](https://issues.redhat.com/browse/RHOAIENG-45480)
Changing default perses dashboard to point towards cluster wide thanos endpoint until component migartion work is completed https://issues.redhat.com/browse/RHOAIENG-38493

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [ ] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a cluster-wide Prometheus datasource resource for cluster metrics.

* **Improvements**
  * Updated the existing Prometheus datasource with enhanced labels, annotations, display name/description, and set its default active state to false.

* **Tests**
  * Added/expanded end-to-end tests to validate creation, lifecycle, TLS/authentication and cleanup for both datasources.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->