### PR TITLE
RHOAIENG-45566: fix(trustyai): prevent continuous reconciles from unrelated CRD events

### DIFF
--- a/internal/controller/components/trustyai/trustyai_controller.go
+++ b/internal/controller/components/trustyai/trustyai_controller.go
@@ -62,6 +62,18 @@ func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.
 						return e.Object.GetName() == "inferenceservices.serving.kserve.io" &&
 							e.Object.GetLabels()[labels.ODH.Component(componentApi.KserveComponentName)] == labels.True
 					},
+					UpdateFunc: func(e event.UpdateEvent) bool {
+						// Only match Create events, not Update events
+						return false
+					},
+					DeleteFunc: func(e event.DeleteEvent) bool {
+						// Only match Create events, not Delete events
+						return false
+					},
+					GenericFunc: func(e event.GenericEvent) bool {
+						// Only match Create events, not Generic events
+						return false
+					},
 				},
 			)),
 		).

--- a/internal/controller/datasciencecluster/kubebuilder_rbac.go
+++ b/internal/controller/datasciencecluster/kubebuilder_rbac.go
@@ -259,6 +259,7 @@ package datasciencecluster
 // OpenVino still need buildconfig
 // +kubebuilder:rbac:groups="build.openshift.io",resources=builds,verbs=create;patch;delete;list;watch;get
 // +kubebuilder:rbac:groups="build.openshift.io",resources=buildconfigs/instantiate,verbs=create;patch;delete;get;list;watch
+// +kubebuilder:rbac:groups="inference.networking.k8s.io",resources=inferencepools,verbs=get;list;watch
 // +kubebuilder:rbac:groups="build.openshift.io",resources=buildconfigs,verbs=list;watch;create;patch;delete;get;update
 
 // DataSciencePipelines


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
The TrustyAI controller was experiencing continuous reconciliation loops (~3 per second) on BYOIDC clusters, causing unnecessary resource consumption and log spam.

## Root Cause

The CRD watch predicate in the TrustyAI controller only defined `CreateFunc` to match when the `inferenceservices.serving.kserve.io` CRD is created. However, in controller-runtime, when `UpdateFunc`, `DeleteFunc`, and `GenericFunc` are not explicitly defined in `predicate.Funcs`, they default to returning `true`. This caused **all** CRD update and delete events in the cluster to trigger reconciles.

On BYOIDC clusters, `openstackmachines.infrastructure.cluster.x-k8s.io` and `openstackmachinetemplates.infrastructure.cluster.x-k8s.io` CRDs are updated multiple times per second, causing the continuous polling behavior.


<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
Its is an urgent blocker fix, not added any e2e


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Optimized TrustyAI component event handling to process only creation events, improving system efficiency by eliminating unnecessary handling of update, delete, and generic events for more stable, predictable behavior.
  * Extended access permissions for inference pool resources to support enhanced resource management and visibility across the platform.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->