### PR TITLE
(fix): Fix release automation to update #images#

### DIFF
--- a/.github/scripts/get-release-branches.js
+++ b/.github/scripts/get-release-branches.js
@@ -114,23 +114,28 @@ module.exports = async ({ github, core }) => {
                 const imageRefRegex = /^[a-z0-9.\-]+(?::[0-9]+)?\/[a-zA-Z0-9_.\-\/]+(?::[a-zA-Z0-9_.\-]+|@[a-z0-9]+:[a-f0-9]+)$/;
 
                 for (const imageLine of imageLines) {
-                    const trimmedLine = imageLine.trim();
+                    let trimmedLine = imageLine.trim();
 
                     // Skip empty lines
                     if (trimmedLine === "") {
                         continue;
                     }
 
+                    // Strip leading '- ' if present (GitHub markdown bullet format)
+                    if (trimmedLine.startsWith('- ')) {
+                        trimmedLine = trimmedLine.substring(2).trim();
+                    }
+
                     const parts = trimmedLine.split("|");
                     if (parts.length !== 2) {
-                        break;
+                        continue;
                     }
 
                     const imageName = parts[0].trim();
                     const imageReference = parts[1].trim();
 
                     if (!imageNameRegex.test(imageName) || !imageRefRegex.test(imageReference)) {
-                        break;
+                        continue;
                     }
 
                     console.log(`Processing operator image: ${imageName} -> ${imageReference}`);


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
Fix a minor issue in release automation where the automation failed to recognize the #images# entry for kube-auth-prxy automatically and update the manager.yaml so that the RELATED_IMAGE is updated correctly.

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [ ] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved robustness of the release branch identification process to better handle edge cases during processing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->