### PR TITLE
add gh action to create an e2e image for each PR when the tests are updated

### DIFF
--- a/.github/workflows/ci-build-push-e2e-tests-on-pr.yaml
+++ b/.github/workflows/ci-build-push-e2e-tests-on-pr.yaml
@@ -1,0 +1,69 @@
+name: Build and push E2E Test Image On PR
+on:
+  pull_request_target:
+    types: [ opened, synchronize, reopened ]
+    branches:
+      - main
+    paths:
+      - 'tests/e2e/**'
+      - 'cmd/main.go'
+      - 'Dockerfiles/e2e-tests/e2e-tests.Dockerfile'
+
+permissions:
+  contents: read
+
+env:
+  E2E_BASE_IMAGE: quay.io/${{ secrets.QUAY_ORG }}/opendatahub-operator-e2e
+  E2E_PR_IMAGE_TAG: pr-${{ github.event.number }}
+
+jobs:
+  get-merge-commit:
+    name: Get merge commit
+    uses: ./.github/workflows/get-merge-commit.yaml
+
+  build-push-e2e-image-on-pr:
+    name: Build and push E2E Test Image On PR
+    runs-on: ubuntu-latest
+    needs: get-merge-commit
+    env:
+      IMAGE_BUILDER: podman
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        if: needs.get-merge-commit.outputs.mergedSha
+        with:
+          ref: ${{ needs.get-merge-commit.outputs.mergedSha }}
+
+      - name: Quay.io login
+        uses: redhat-actions/podman-login@4934294ad0449894bcd1e9f191899d7292469603 # v1.7
+        if: needs.get-merge-commit.outputs.mergedSha
+        env:
+          QUAY_ID: ${{ secrets.QUAY_ID }}
+          QUAY_TOKEN: ${{ secrets.QUAY_TOKEN }}
+        with:
+          registry: quay.io
+          username: ${{ env.QUAY_ID }}
+          password: ${{ env.QUAY_TOKEN }}
+
+      - name: Set up Go
+        uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
+        if: needs.get-merge-commit.outputs.mergedSha
+        with:
+          go-version-file: go.mod
+
+      - name: Build and push E2E test image
+        if: needs.get-merge-commit.outputs.mergedSha
+        env:
+          E2E_IMAGE: ${{ env.E2E_BASE_IMAGE }}:${{ env.E2E_PR_IMAGE_TAG }}
+        run: |
+          echo "Building E2E test image: ${E2E_IMAGE}"
+          podman build \
+            --platform linux/amd64 \
+            -f Dockerfiles/e2e-tests/e2e-tests.Dockerfile \
+            -t "${E2E_IMAGE}" -t "${E2E_IMAGE}" \
+            .
+
+          echo "Pushing E2E test image: ${E2E_IMAGE}"
+          podman push "${E2E_IMAGE}"
+
+          echo "E2E test image built and pushed successfully!"


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

<!--- Link your JIRA and related links here for reference. -->
https://issues.redhat.com/browse/RHOAIENG-46256

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->

Adding a new GHA does not require any new E2E test


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a CI workflow to build and push end-to-end test container images for pull requests on main (E2E-related paths). The workflow obtains the merged commit, sets up the Go toolchain, performs a secure container registry login, builds and tags images with PR-specific identifiers, pushes the images, and reports status.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->