### PR TITLE
fix: make ModelsAsService spec serialization to prevent DSC "Not Ready" status

### DIFF
--- a/internal/controller/components/modelsasservice/modelsasservice.go
+++ b/internal/controller/components/modelsasservice/modelsasservice.go
@@ -70,12 +70,9 @@ func (s *componentHandler) NewCRObject(dsc *dscv2.DataScienceCluster) common.Pla
 		managementState = maasConfig.ManagementState
 	}
 
-	// Configure Gateway spec - always use defaults (gateway is not user-configurable)
-	gatewaySpec := componentApi.GatewaySpec{
-		Namespace: DefaultGatewayNamespace,
-		Name:      DefaultGatewayName,
-	}
-
+	// Note: Gateway configuration is handled internally by the ModelsAsService controller.
+	// The spec is empty here because Gateway has json:"-" (not serialized).
+	// MarshalJSON ensures spec serializes as {} instead of null.
 	return &componentApi.ModelsAsService{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       componentApi.ModelsAsServiceKind,
@@ -86,9 +83,6 @@ func (s *componentHandler) NewCRObject(dsc *dscv2.DataScienceCluster) common.Pla
 			Annotations: map[string]string{
 				annotations.ManagementStateAnnotation: string(managementState),
 			},
-		},
-		Spec: componentApi.ModelsAsServiceSpec{
-			Gateway: gatewaySpec,
 		},
 	}
 }

--- a/internal/controller/components/modelsasservice/modelsasservice_test.go
+++ b/internal/controller/components/modelsasservice/modelsasservice_test.go
@@ -42,14 +42,10 @@ func TestNewCRObject(t *testing.T) {
 			jq.Match(`.kind == "%s"`, componentApi.ModelsAsServiceKind),
 			jq.Match(`.apiVersion == "%s"`, componentApi.GroupVersion),
 			jq.Match(`.metadata.annotations["%s"] == "%s"`, annotations.ManagementStateAnnotation, operatorv1.Managed),
-			// Gateway is internal-only, not exposed in spec
+			// Gateway is internal-only (json:"-"), not exposed in spec
+			// Spec serializes as empty object {} via MarshalJSON
+			jq.Match(`.spec == {}`),
 		)))
-
-		// Verify Gateway is set internally (not visible in JSON)
-		maasObj, ok := cr.(*componentApi.ModelsAsService)
-		g.Expect(ok).Should(BeTrue())
-		g.Expect(maasObj.Spec.Gateway.Namespace).Should(Equal(DefaultGatewayNamespace))
-		g.Expect(maasObj.Spec.Gateway.Name).Should(Equal(DefaultGatewayName))
 	})
 
 	t.Run("propagates management state from DSC to ModelsAsService annotations", func(t *testing.T) {


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
The ModelsAsServiceSpec struct contains a Gateway field with a json:"-" tag, making it internal-only and not exposed in the CRD schema. However, when this is the only field in the struct, Go's JSON marshaler serializes the entire spec as null instead of an empty object `{}`.

This caused CRD validation to fail with:
```
ModelsAsService.components.platform.opendatahub.io "default-modelsasservice" is invalid: 
spec: Invalid value: "null": spec in body must be of type object: "null"
```

As a result, the DataScienceCluster (DSC) remained in "Not Ready" status when ModelsAsService was enabled.

## Solution
Implemented a custom MarshalJSON() method on ModelsAsServiceSpec that always returns {}, ensuring the spec serializes as a valid empty object while keeping the Gateway field internal (json:"-").


## How Has This Been Tested?
* Built and deployed custom operator image with fix
* Deleted existing ModelsAsService CR to trigger recreation
* Verified DSC transitions from Ready=False (Error) to Ready=True

## Screenshot or short clip
<img width="988" height="685" alt="Screenshot 2026-01-21 at 5 13 40 AM" src="https://github.com/user-attachments/assets/5b4d0132-8bd3-4f71-b6d5-038b1762a67f" />


## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [x] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->
The existing tests have the gateway configuration configured.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced serialization handling of specification objects to ensure proper formatting and prevent validation errors that could occur in custom resource definitions.

* **Refactor**
  * Gateway configuration mechanism updated to exclusively use standardized default gateway namespace and name values. User-configurable custom gateway settings previously available in the specification are no longer supported.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->