### PR TITLE
(fix): Fix the release to community workflow failing with perm issues

### DIFF
--- a/.github/scripts/create-community-pr.sh
+++ b/.github/scripts/create-community-pr.sh
@@ -4,18 +4,18 @@
 
 set -euo pipefail
 
-: "${GITHUB_TOKEN:?GITHUB_TOKEN is required}"
 : "${VERSION:?VERSION is required}"
 : "${COMMUNITY_FORK:?COMMUNITY_FORK is required}"
 : "${COMMUNITY_UPSTREAM:?COMMUNITY_UPSTREAM is required}"
 : "${BUNDLE_DIR:?BUNDLE_DIR is required (path to community-operators-prod directory)}"
+: "${BRANCH_PREFIX:?BRANCH_PREFIX is required}"
+: "${COMMITTER_NAME:?COMMITTER_NAME is required}"
+: "${COMMITTER_EMAIL:?COMMITTER_EMAIL is required}"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 "${SCRIPT_DIR}/validate-semver.sh" "v${VERSION}"
 
-BRANCH_NAME="odh-operator-${VERSION}"
-COMMITTER_NAME="ODH Release Bot"
-COMMITTER_EMAIL="noreply@opendatahub.io"
+BRANCH_NAME="${BRANCH_PREFIX}${VERSION}"
 
 echo "    Creating PR from ${COMMUNITY_FORK} to ${COMMUNITY_UPSTREAM}"
 echo "    Version: ${VERSION}"
@@ -42,39 +42,30 @@ echo " Committing: ${COMMIT_MSG}"
 git commit -s -m "${COMMIT_MSG}"
 
 echo " Pushing to fork: ${COMMUNITY_FORK}:${BRANCH_NAME}"
-git push --force-with-lease "https://x-access-token:${GITHUB_TOKEN}@github.com/${COMMUNITY_FORK}.git" "${BRANCH_NAME}"
+
+git push --force-with-lease origin "${BRANCH_NAME}"
 
 echo " Creating pull request"
 
 PR_TITLE="operator opendatahub-operator (${VERSION})"
 PR_HEAD="${COMMUNITY_FORK%%/*}:${BRANCH_NAME}"
-UPSTREAM_REPO="${COMMUNITY_UPSTREAM}"
 
-PAYLOAD=$(cat <<EOF
-{
-  "title": "${PR_TITLE}",
-  "head": "${PR_HEAD}",
-  "base": "main"
-}
-EOF
-)
+PR_URL=$(gh pr create \
+  --repo "${COMMUNITY_UPSTREAM}" \
+  --title "${PR_TITLE}" \
+  --head "${PR_HEAD}" \
+  --base main \
+  --body "" \
+  --json url \
+  --jq '.url')
 
-RESPONSE=$(curl -f -s -X POST \
-  -H "Authorization: Bearer ${GITHUB_TOKEN}" \
-  -H "Accept: application/vnd.github+json" \
-  -H "X-GitHub-Api-Version: 2022-11-28" \
-  "https://api.github.com/repos/${UPSTREAM_REPO}/pulls" \
-  -d "${PAYLOAD}")
-
-if ! echo "${RESPONSE}" | jq -e '.html_url and .number' > /dev/null 2>&1; then
-  echo "Error: Invalid API response structure" >&2
-  echo "Response:" >&2
-  echo "${RESPONSE}" | jq . 2>/dev/null || echo "${RESPONSE}" >&2
+if [ -z "${PR_URL}" ]; then
+  echo "Error: Failed to create pull request" >&2
   exit 1
 fi
 
-PR_URL=$(echo "${RESPONSE}" | jq -r '.html_url')
-PR_NUMBER=$(echo "${RESPONSE}" | jq -r '.number')
+# Extract PR number from URL (e.g., https://github.com/owner/repo/pull/123 -> 123)
+PR_NUMBER=$(echo "${PR_URL}" | grep -oE '[0-9]+$')
 
 echo "    Successfully created PR"
 echo "    URL: ${PR_URL}"

--- a/.github/workflows/release-community.yaml
+++ b/.github/workflows/release-community.yaml
@@ -22,6 +22,9 @@ env:
   OPENSHIFT_VERSIONS: ${{ github.event.inputs.openshift-versions }}
   COMMUNITY_FORK: opendatahub-io/community-operators-prod
   COMMUNITY_UPSTREAM: redhat-openshift-ecosystem/community-operators-prod
+  BRANCH_PREFIX: odh-operator-
+  COMMITTER_NAME: ODH Release Bot
+  COMMITTER_EMAIL: noreply@opendatahub.io
 
 jobs:
   create-community-release:
@@ -72,12 +75,22 @@ jobs:
         VERSION="${{ env.VERSION }}"
         ./.github/scripts/validate-bundle-csv.sh "$VERSION"
 
-    - name: Checkout community-operators-prod upstream
+    - name: Generate GitHub App Token
+      id: generate-token
+      uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
+      with:
+        app-id: ${{ secrets.ODH_RELEASE_BOT_APP_ID }}
+        private-key: ${{ secrets.ODH_RELEASE_BOT_PRIVATE_KEY }}
+        owner: opendatahub-io
+        repositories: community-operators-prod
+
+    - name: Checkout community-operators-prod fork
       uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
       with:
-        repository: ${{ env.COMMUNITY_UPSTREAM }}
+        repository: ${{ env.COMMUNITY_FORK }}
         path: community-operators-prod
         fetch-depth: 0
+        token: ${{ steps.generate-token.outputs.token }}
 
     - name: Copy bundle to community-operators-prod
       run: |
@@ -110,15 +123,6 @@ jobs:
           "$PREVIOUS_VERSION" \
           "$OPENSHIFT_VERSIONS"
 
-    - name: Generate GitHub App Token
-      id: generate-token
-      uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
-      with:
-        app-id: ${{ secrets.ODH_RELEASE_BOT_APP_ID }}
-        private-key: ${{ secrets.ODH_RELEASE_BOT_PRIVATE_KEY }}
-        owner: opendatahub-io
-        repositories: community-operators-prod
-
     - name: Create Pull Request
       id: create-pr
       env:
@@ -127,6 +131,9 @@ jobs:
         COMMUNITY_FORK: ${{ env.COMMUNITY_FORK }}
         COMMUNITY_UPSTREAM: ${{ env.COMMUNITY_UPSTREAM }}
         BUNDLE_DIR: community-operators-prod
+        BRANCH_PREFIX: ${{ env.BRANCH_PREFIX }}
+        COMMITTER_NAME: ${{ env.COMMITTER_NAME }}
+        COMMITTER_EMAIL: ${{ env.COMMITTER_EMAIL }}
       run: |
         ./opendatahub-operator/.github/scripts/create-community-pr.sh
     - name: Summary


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
This fixes the "resource not accessible by integration" which occurs when using the create-pull-request action by Peter Evans. The action expects the gh app to be installed in the usptream rather than the fork.
This script has been inspired from the [sail-operator](https://github.com/openshift-service-mesh/sail-operator/blob/main/hack/operatorhub/publish-bundle.sh) only difference being - instead of using a bot account , we use a gh app to generate the token at runtime(this is recommended by Devops).
Rest of the tasks remain the same.

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [ ] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an automated script to create pull requests from the community fork to upstream.

* **Chores**
  * Release workflow now invokes the script and exposes required environment variables.
  * PR URL and number continue to be emitted when available.
  * PR creation failures now surface via the script's exit status instead of action outputs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->