### PR TITLE
feat: add ApplyParamsWithFallback for unified params.env handling

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.68.0
 	github.com/prometheus/client_golang v1.23.2
 	github.com/rs/xid v1.6.0
+	github.com/spf13/afero v1.15.0
 	github.com/spf13/pflag v1.0.10
 	github.com/spf13/viper v1.20.1
 	github.com/stretchr/testify v1.11.1
@@ -75,7 +76,6 @@ require (
 	github.com/sagikazarmark/locafero v0.7.0 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/sourcegraph/conc v0.3.0 // indirect
-	github.com/spf13/afero v1.12.0 // indirect
 	github.com/spf13/cast v1.7.1 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -139,8 +139,8 @@ github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/sourcegraph/conc v0.3.0 h1:OQTbbt6P72L20UqAkXXuLOj79LfEanQ+YQFNpLA9ySo=
 github.com/sourcegraph/conc v0.3.0/go.mod h1:Sdozi7LEKbFPqYX2/J+iBAM6HpqSLTASQIKqDmF7Mt0=
-github.com/spf13/afero v1.12.0 h1:UcOPyRBYczmFn6yvphxkn9ZEOY65cpwGKb5mL36mrqs=
-github.com/spf13/afero v1.12.0/go.mod h1:ZTlWwG4/ahT8W7T0WQ5uYmjI9duaLQGy3Q2OAl4sk/4=
+github.com/spf13/afero v1.15.0 h1:b/YBCLWAJdFWJTN9cLhiXXcD7mzKn9Dm86dNnfyQw1I=
+github.com/spf13/afero v1.15.0/go.mod h1:NC2ByUVxtQs4b3sIUphxK0NioZnmxgyCrfzeuq8lxMg=
 github.com/spf13/cast v1.7.1 h1:cuNEagBQEHWN1FnbGEjCXL2szYEXqfJPbP2HNUaca9Y=
 github.com/spf13/cast v1.7.1/go.mod h1:ancEpBxwJDODSW/UG4rDrAqiKolqNNh2DX3mk86cAdo=
 github.com/spf13/pflag v1.0.10 h1:4EBh2KAYBwaONj6b2Ye1GiHfwjqyROoF4RwYO+vPwFk=

--- a/internal/controller/components/datasciencepipelines/datasciencepipelines.go
+++ b/internal/controller/components/datasciencepipelines/datasciencepipelines.go
@@ -3,8 +3,6 @@ package datasciencepipelines
 import (
 	"context"
 	"errors"
-	"fmt"
-	"strconv"
 
 	operatorv1 "github.com/openshift/api/operator/v1"
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
@@ -17,10 +15,8 @@ import (
 	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/components"
 	cr "github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/components/registry"
 	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/status"
-	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/conditions"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
-	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/deploy"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/metadata/annotations"
 )
 
@@ -34,17 +30,7 @@ func (s *componentHandler) GetName() string {
 	return componentApi.DataSciencePipelinesComponentName
 }
 
-func (s *componentHandler) Init(_ common.Platform) error {
-	release := cluster.GetRelease()
-	clusterInfo := cluster.GetClusterInfo()
-	extraParams := map[string]string{
-		platformVersionParamsKey: release.Version.String(),
-		fipsEnabledParamsKey:     strconv.FormatBool(clusterInfo.FipsEnabled),
-	}
-	if err := deploy.ApplyParams(paramsPath, "params.env", imageParamMap, extraParams); err != nil {
-		return fmt.Errorf("failed to update images on path %s: %w", paramsPath, err)
-	}
-
+func (s *componentHandler) Init(platform common.Platform) error {
 	return nil
 }
 

--- a/internal/controller/components/datasciencepipelines/datasciencepipelines_support.go
+++ b/internal/controller/components/datasciencepipelines/datasciencepipelines_support.go
@@ -1,8 +1,6 @@
 package datasciencepipelines
 
 import (
-	"path"
-
 	"github.com/opendatahub-io/opendatahub-operator/v2/api/common"
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/api/components/v1alpha1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/status"
@@ -64,8 +62,6 @@ var (
 		status.ConditionArgoWorkflowAvailable,
 		status.ConditionDeploymentsAvailable,
 	}
-
-	paramsPath = path.Join(odhdeploy.DefaultManifestPath, ComponentName, "base")
 )
 
 func manifestPath(p common.Platform) types.ManifestInfo {

--- a/internal/controller/components/feastoperator/feastoperator.go
+++ b/internal/controller/components/feastoperator/feastoperator.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"path/filepath"
 
 	operatorv1 "github.com/openshift/api/operator/v1"
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
@@ -16,6 +17,7 @@ import (
 	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/components"
 	cr "github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/components/registry"
 	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/status"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/conditions"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
 	odhdeploy "github.com/opendatahub-io/opendatahub-operator/v2/pkg/deploy"
@@ -50,9 +52,12 @@ func (s *componentHandler) NewCRObject(_ context.Context, _ client.Client, dsc *
 	}, nil
 }
 
-func (s *componentHandler) Init(p common.Platform) error {
-	if err := odhdeploy.ApplyParams(manifestPath(p).String(), "params.env", imageParamMap); err != nil {
-		return fmt.Errorf("failed to update images on path %s: %w", manifestPath(p), err)
+func (s *componentHandler) Init(platform common.Platform) error {
+	componentPath := filepath.Join(odhdeploy.DefaultManifestPath, ComponentName)
+	overlayName := cluster.OverlayName(platform)
+
+	if _, err := odhdeploy.ApplyParamsWithFallback(componentPath, overlayName, imageParamMap); err != nil {
+		return fmt.Errorf("failed to update params for %s: %w", ComponentName, err)
 	}
 
 	return nil

--- a/internal/controller/components/llamastackoperator/llamastackoperator.go
+++ b/internal/controller/components/llamastackoperator/llamastackoperator.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"path/filepath"
 
 	operatorv1 "github.com/openshift/api/operator/v1"
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
@@ -16,6 +17,7 @@ import (
 	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/components"
 	cr "github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/components/registry"
 	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/status"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/conditions"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
 	odhdeploy "github.com/opendatahub-io/opendatahub-operator/v2/pkg/deploy"
@@ -50,9 +52,12 @@ func (s *componentHandler) NewCRObject(_ context.Context, _ client.Client, dsc *
 	}, nil
 }
 
-func (s *componentHandler) Init(p common.Platform) error {
-	if err := odhdeploy.ApplyParams(manifestPath(p).String(), "params.env", imageParamMap); err != nil {
-		return fmt.Errorf("failed to update images on path %s: %w", manifestPath(p), err)
+func (s *componentHandler) Init(platform common.Platform) error {
+	componentPath := filepath.Join(odhdeploy.DefaultManifestPath, ComponentName)
+	overlayName := cluster.OverlayName(platform)
+
+	if _, err := odhdeploy.ApplyParamsWithFallback(componentPath, overlayName, imageParamMap); err != nil {
+		return fmt.Errorf("failed to update params for %s: %w", ComponentName, err)
 	}
 
 	return nil

--- a/internal/controller/components/mlflowoperator/mlflowoperator_support.go
+++ b/internal/controller/components/mlflowoperator/mlflowoperator_support.go
@@ -3,7 +3,6 @@ package mlflowoperator
 import (
 	"context"
 	"fmt"
-	"path"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -42,8 +41,6 @@ var (
 	conditionTypes = []string{
 		status.ConditionDeploymentsAvailable,
 	}
-
-	paramsPath = path.Join(odhdeploy.DefaultManifestPath, ComponentName, "base")
 )
 
 func manifestPath(p common.Platform) types.ManifestInfo {

--- a/internal/controller/components/modelsasservice/modelsasservice_support.go
+++ b/internal/controller/components/modelsasservice/modelsasservice_support.go
@@ -32,7 +32,10 @@ const (
 	DefaultGatewayNamespace = "openshift-ingress"
 	DefaultGatewayName      = "maas-default-gateway"
 
-	// Manifest paths.
+	// ManifestContextDir is the directory name under the manifests path.
+	ManifestContextDir = "maas"
+
+	// BaseManifestsSourcePath is the overlay path for Kustomize manifests.
 	BaseManifestsSourcePath = "overlays/odh"
 
 	// GatewayAuthPolicyName is the name of the AuthPolicy resource that configures
@@ -66,7 +69,7 @@ var (
 func baseManifestInfo(sourcePath string) odhtypes.ManifestInfo {
 	return odhtypes.ManifestInfo{
 		Path:       deploy.DefaultManifestPath,
-		ContextDir: "maas",
+		ContextDir: ManifestContextDir,
 		SourcePath: sourcePath,
 	}
 }

--- a/internal/controller/components/trustyai/trustyai.go
+++ b/internal/controller/components/trustyai/trustyai.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"path/filepath"
 
 	operatorv1 "github.com/openshift/api/operator/v1"
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
@@ -16,6 +17,7 @@ import (
 	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/components"
 	cr "github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/components/registry"
 	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/status"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/conditions"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
 	odhdeploy "github.com/opendatahub-io/opendatahub-operator/v2/pkg/deploy"
@@ -71,10 +73,11 @@ func (s *componentHandler) NewCRObject(_ context.Context, _ client.Client, dsc *
 }
 
 func (s *componentHandler) Init(platform common.Platform) error {
-	mp := manifestsPath(platform)
+	componentPath := filepath.Join(odhdeploy.DefaultManifestPath, ComponentName)
+	overlayName := cluster.OverlayName(platform)
 
-	if err := odhdeploy.ApplyParams(mp.String(), "params.env", imageParamMap); err != nil {
-		return fmt.Errorf("failed to update images on path %s: %w", mp, err)
+	if _, err := odhdeploy.ApplyParamsWithFallback(componentPath, overlayName, imageParamMap); err != nil {
+		return fmt.Errorf("failed to update params for %s: %w", ComponentName, err)
 	}
 
 	return nil

--- a/pkg/cluster/cluster_config.go
+++ b/pkg/cluster/cluster_config.go
@@ -498,3 +498,16 @@ func IsIntegratedOAuth(ctx context.Context, cli client.Reader) (bool, error) {
 	}
 	return authMode == AuthModeIntegratedOAuth, nil
 }
+
+// OverlayName returns platform name.
+func OverlayName(platform common.Platform) string {
+	switch platform {
+	case SelfManagedRhoai, ManagedRhoai:
+		return "rhoai"
+	case OpenDataHub:
+		return "odh"
+	default:
+		logf.Log.Info("unexpected platform type, defaulting overlay to 'odh'", "platform", platform)
+		return "odh"
+	}
+}

--- a/pkg/cluster/cluster_config_internal_test.go
+++ b/pkg/cluster/cluster_config_internal_test.go
@@ -213,3 +213,41 @@ func TestSetApplicationNamespace(t *testing.T) {
 		})
 	}
 }
+
+func TestOverlayName(t *testing.T) {
+	testCases := []struct {
+		name           string
+		platform       common.Platform
+		expectedResult string
+	}{
+		{
+			name:           "OpenDataHub returns odh",
+			platform:       OpenDataHub,
+			expectedResult: "odh",
+		},
+		{
+			name:           "SelfManagedRhoai returns rhoai",
+			platform:       SelfManagedRhoai,
+			expectedResult: "rhoai",
+		},
+		{
+			name:           "ManagedRhoai returns rhoai",
+			platform:       ManagedRhoai,
+			expectedResult: "rhoai",
+		},
+		{
+			name:           "Unknown platform returns odh as default",
+			platform:       common.Platform("unknown-platform"),
+			expectedResult: "odh",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := OverlayName(tc.platform)
+			if result != tc.expectedResult {
+				t.Errorf("OverlayName(%q) = %q, want %q", tc.platform, result, tc.expectedResult)
+			}
+		})
+	}
+}

--- a/pkg/deploy/envParams_integration_test.go
+++ b/pkg/deploy/envParams_integration_test.go
@@ -1,0 +1,89 @@
+package deploy_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/spf13/afero"
+
+	"github.com/opendatahub-io/opendatahub-operator/v2/api/common"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/deploy"
+)
+
+// TestApplyParamsWithFallback_Integration is an integration test for ApplyParamsWithFallback.
+func TestApplyParamsWithFallback_Integration(t *testing.T) {
+	testCases := []struct {
+		name                 string
+		platform             common.Platform
+		expectedOverlay      string
+		expectedPlatformLine string
+	}{
+		{
+			name:                 "OpenDataHub uses odh overlay and params.env",
+			platform:             cluster.OpenDataHub,
+			expectedOverlay:      "odh",
+			expectedPlatformLine: "PLATFORM=odh",
+		},
+		{
+			name:                 "SelfManagedRhoai uses rhoai overlay and params.env",
+			platform:             cluster.SelfManagedRhoai,
+			expectedOverlay:      "rhoai",
+			expectedPlatformLine: "PLATFORM=rhoai",
+		},
+		{
+			name:                 "ManagedRhoai uses rhoai overlay and params.env",
+			platform:             cluster.ManagedRhoai,
+			expectedOverlay:      "rhoai",
+			expectedPlatformLine: "PLATFORM=rhoai",
+		},
+	}
+
+	fs := afero.NewMemMapFs()
+	componentPath := "/opt/manifests/test-component"
+
+	_ = fs.MkdirAll(componentPath+"/base", 0755)
+	_ = afero.WriteFile(fs, componentPath+"/base/params.env", []byte("PLATFORM=base\n"), 0644)
+	_ = fs.MkdirAll(componentPath+"/overlays/odh", 0755)
+	_ = afero.WriteFile(fs, componentPath+"/overlays/odh/params.env", []byte("PLATFORM=odh\n"), 0644)
+	_ = fs.MkdirAll(componentPath+"/overlays/rhoai", 0755)
+	_ = afero.WriteFile(fs, componentPath+"/overlays/rhoai/params.env", []byte("PLATFORM=rhoai\n"), 0644)
+
+	applier := deploy.NewParamsApplier(deploy.WithFS(fs))
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			overlayName := cluster.OverlayName(tc.platform)
+			if overlayName != tc.expectedOverlay {
+				t.Fatalf("OverlayName(platform) = %q, want %q", overlayName, tc.expectedOverlay)
+			}
+
+			paramsPath, err := applier.ApplyParamsWithFallback(componentPath, overlayName, nil)
+			if err != nil {
+				t.Fatalf("ApplyParamsWithFallback: %v", err)
+			}
+
+			expectedPath := componentPath + "/overlays/" + tc.expectedOverlay + "/params.env"
+			if paramsPath != expectedPath {
+				t.Errorf("params path = %q, want %q", paramsPath, expectedPath)
+			}
+
+			content, err := afero.ReadFile(fs, paramsPath)
+			if err != nil {
+				t.Fatalf("read params file: %v", err)
+			}
+			if !integrationContainsLine(string(content), tc.expectedPlatformLine) {
+				t.Errorf("params content does not contain %q, got:\n%s", tc.expectedPlatformLine, string(content))
+			}
+		})
+	}
+}
+
+func integrationContainsLine(content, expected string) bool {
+	for _, line := range strings.Split(content, "\n") {
+		if strings.TrimSpace(line) == expected {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/deploy/envParams_test.go
+++ b/pkg/deploy/envParams_test.go
@@ -1,0 +1,456 @@
+package deploy_test
+
+import (
+	"errors"
+	"os"
+	"testing"
+
+	"github.com/spf13/afero"
+
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/deploy"
+
+	. "github.com/onsi/gomega"
+)
+
+const relatedImageEnvVar = "RELATED_IMAGE"
+
+func TestParamsApplier_ApplyParams(t *testing.T) {
+	testCases := []struct {
+		name           string
+		setupFS        func(afero.Fs)               // Setup filesystem state
+		envGetter      func(string) string          // Mock environment variable getter
+		componentPath  string                       // Input: component path
+		file           string                       // Input: params file name
+		imageParamsMap map[string]string            // Input: image params mapping
+		extraParams    []map[string]string          // Input: extra params maps
+		expectedError  bool                         // Expected: should return error
+		errorContains  string                       // Expected: error message contains
+		validateFS     func(*GomegaWithT, afero.Fs) // Validate filesystem state after
+	}{
+		{
+			name: "updates params from env variables",
+			setupFS: func(fs afero.Fs) {
+				_ = fs.MkdirAll("/component", 0755)
+				_ = afero.WriteFile(fs, "/component/params.env", []byte("IMAGE_A=old-value\n"), 0644)
+			},
+			envGetter: func(key string) string {
+				if key == "RELATED_IMAGE_A" {
+					return "new-value"
+				}
+				return ""
+			},
+			componentPath:  "/component",
+			file:           "params.env",
+			imageParamsMap: map[string]string{"IMAGE_A": "RELATED_IMAGE_A"},
+			expectedError:  false,
+			validateFS: func(g *GomegaWithT, fs afero.Fs) {
+				content, err := afero.ReadFile(fs, "/component/params.env")
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(string(content)).To(ContainSubstring("IMAGE_A=new-value"))
+			},
+		},
+		{
+			name: "updates params from extraParamsMaps",
+			setupFS: func(fs afero.Fs) {
+				_ = fs.MkdirAll("/component", 0755)
+				_ = afero.WriteFile(fs, "/component/params.env", []byte("KEY1=value1\nKEY2=value2\n"), 0644)
+			},
+			componentPath: "/component",
+			file:          "params.env",
+			extraParams: []map[string]string{
+				{"KEY1": "updated1"},
+				{"KEY2": "updated2"},
+			},
+			expectedError: false,
+			validateFS: func(g *GomegaWithT, fs afero.Fs) {
+				content, err := afero.ReadFile(fs, "/component/params.env")
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(string(content)).To(ContainSubstring("KEY1=updated1"))
+				g.Expect(string(content)).To(ContainSubstring("KEY2=updated2"))
+			},
+		},
+		{
+			name: "returns nil if params.env does not exist",
+			setupFS: func(fs afero.Fs) {
+				_ = fs.Mkdir("/component", 0755)
+			},
+			componentPath: "/component",
+			file:          "params.env",
+			expectedError: false,
+		},
+		{
+			name: "handles empty params.env file",
+			setupFS: func(fs afero.Fs) {
+				_ = fs.MkdirAll("/component", 0755)
+				_ = afero.WriteFile(fs, "/component/params.env", []byte(""), 0644)
+			},
+			componentPath: "/component",
+			file:          "params.env",
+			expectedError: false,
+		},
+		{
+			name: "combines env variables and extraParams",
+			setupFS: func(fs afero.Fs) {
+				_ = fs.MkdirAll("/component", 0755)
+				_ = afero.WriteFile(fs, "/component/params.env", []byte("IMAGE=old\nCONFIG=old\n"), 0644)
+			},
+			envGetter: func(key string) string {
+				if key == relatedImageEnvVar {
+					return "new-image"
+				}
+				return ""
+			},
+			componentPath:  "/component",
+			file:           "params.env",
+			imageParamsMap: map[string]string{"IMAGE": relatedImageEnvVar},
+			extraParams:    []map[string]string{{"CONFIG": "new-config"}},
+			expectedError:  false,
+			validateFS: func(g *GomegaWithT, fs afero.Fs) {
+				content, err := afero.ReadFile(fs, "/component/params.env")
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(string(content)).To(ContainSubstring("IMAGE=new-image"))
+				g.Expect(string(content)).To(ContainSubstring("CONFIG=new-config"))
+			},
+		},
+		{
+			name: "imageParamsMap key not in params.env - does not add new key",
+			setupFS: func(fs afero.Fs) {
+				_ = fs.MkdirAll("/component", 0755)
+				_ = afero.WriteFile(fs, "/component/params.env", []byte("EXISTING=value\n"), 0644)
+			},
+			envGetter: func(key string) string {
+				// Only return value for relatedImageEnvVar, not for empty string
+				if key == relatedImageEnvVar {
+					return "new-value"
+				}
+				return ""
+			},
+			componentPath:  "/component",
+			file:           "params.env",
+			imageParamsMap: map[string]string{"NONEXISTENT": relatedImageEnvVar},
+			expectedError:  false,
+			validateFS: func(g *GomegaWithT, fs afero.Fs) {
+				content, err := afero.ReadFile(fs, "/component/params.env")
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(string(content)).To(Equal("EXISTING=value\n"))
+				g.Expect(string(content)).NotTo(ContainSubstring("NONEXISTENT"))
+			},
+		},
+		{
+			name: "extraParams adds new key not in original file",
+			setupFS: func(fs afero.Fs) {
+				_ = fs.MkdirAll("/component", 0755)
+				_ = afero.WriteFile(fs, "/component/params.env", []byte("EXISTING=value\n"), 0644)
+			},
+			componentPath: "/component",
+			file:          "params.env",
+			extraParams:   []map[string]string{{"NEW_KEY": "new-value"}},
+			expectedError: false,
+			validateFS: func(g *GomegaWithT, fs afero.Fs) {
+				content, err := afero.ReadFile(fs, "/component/params.env")
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(string(content)).To(ContainSubstring("EXISTING=value"))
+				g.Expect(string(content)).To(ContainSubstring("NEW_KEY=new-value"))
+			},
+		},
+		{
+			name: "multiple extraParams maps - later overrides earlier",
+			setupFS: func(fs afero.Fs) {
+				_ = fs.MkdirAll("/component", 0755)
+				_ = afero.WriteFile(fs, "/component/params.env", []byte("KEY=original\n"), 0644)
+			},
+			componentPath: "/component",
+			file:          "params.env",
+			extraParams: []map[string]string{
+				{"KEY": "first"},
+				{"KEY": "second"},
+				{"KEY": "third"},
+			},
+			expectedError: false,
+			validateFS: func(g *GomegaWithT, fs afero.Fs) {
+				content, err := afero.ReadFile(fs, "/component/params.env")
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(string(content)).To(ContainSubstring("KEY=third"))
+			},
+		},
+		{
+			name: "params.env with lines without equals sign - ignored",
+			setupFS: func(fs afero.Fs) {
+				_ = fs.MkdirAll("/component", 0755)
+				_ = afero.WriteFile(fs, "/component/params.env", []byte("VALID=value\nINVALID_LINE\nANOTHER=test\n"), 0644)
+			},
+			componentPath: "/component",
+			file:          "params.env",
+			extraParams:   []map[string]string{{"VALID": "updated"}},
+			expectedError: false,
+			validateFS: func(g *GomegaWithT, fs afero.Fs) {
+				content, err := afero.ReadFile(fs, "/component/params.env")
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(string(content)).To(ContainSubstring("VALID=updated"))
+				g.Expect(string(content)).To(ContainSubstring("ANOTHER=test"))
+			},
+		},
+		{
+			name: "value contains equals sign - preserves full value",
+			setupFS: func(fs afero.Fs) {
+				_ = fs.MkdirAll("/component", 0755)
+				_ = afero.WriteFile(fs, "/component/params.env", []byte("URL=https://example.com?param=value\n"), 0644)
+			},
+			componentPath: "/component",
+			file:          "params.env",
+			expectedError: false,
+			validateFS: func(g *GomegaWithT, fs afero.Fs) {
+				content, err := afero.ReadFile(fs, "/component/params.env")
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(string(content)).To(Equal("URL=https://example.com?param=value\n"))
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+			memFs := afero.NewMemMapFs()
+
+			if tc.setupFS != nil {
+				tc.setupFS(memFs)
+			}
+
+			envGetter := tc.envGetter
+			if envGetter == nil {
+				envGetter = func(string) string { return "" }
+			}
+
+			applier := deploy.NewParamsApplier(
+				deploy.WithFS(memFs),
+				deploy.WithEnvGetter(envGetter),
+			)
+
+			err := applier.ApplyParams(tc.componentPath, tc.file, tc.imageParamsMap, tc.extraParams...)
+
+			if tc.expectedError {
+				g.Expect(err).To(HaveOccurred())
+				if tc.errorContains != "" {
+					g.Expect(err.Error()).To(ContainSubstring(tc.errorContains))
+				}
+			} else {
+				g.Expect(err).NotTo(HaveOccurred())
+			}
+
+			if tc.validateFS != nil {
+				tc.validateFS(g, memFs)
+			}
+		})
+	}
+}
+
+func TestParamsApplier_ApplyParamsWithFallback(t *testing.T) {
+	testCases := []struct {
+		name           string
+		setupFS        func(afero.Fs)               // Setup filesystem state
+		envGetter      func(string) string          // Mock environment variable getter
+		componentPath  string                       // Input: component path
+		overlayName    string                       // Input: overlay name (odh, rhoai)
+		imageParamsMap map[string]string            // Input: image params mapping
+		extraParams    []map[string]string          // Input: extra params maps
+		expectedPath   string                       // Expected: returned path
+		expectedError  bool                         // Expected: should return error
+		errorContains  string                       // Expected: error message contains
+		validateFS     func(*GomegaWithT, afero.Fs) // Validate filesystem state after
+	}{
+		{
+			name: "overlay exists - uses overlay",
+			setupFS: func(fs afero.Fs) {
+				_ = fs.MkdirAll("/component/overlays/odh", 0755)
+				_ = fs.MkdirAll("/component/base", 0755)
+				_ = afero.WriteFile(fs, "/component/overlays/odh/params.env", []byte("KEY=overlay\n"), 0644)
+				_ = afero.WriteFile(fs, "/component/base/params.env", []byte("KEY=base\n"), 0644)
+			},
+			componentPath: "/component",
+			overlayName:   "odh",
+			expectedPath:  "/component/overlays/odh/params.env",
+			expectedError: false,
+		},
+		{
+			name: "overlay missing, base exists - uses base",
+			setupFS: func(fs afero.Fs) {
+				_ = fs.MkdirAll("/component/base", 0755)
+				_ = afero.WriteFile(fs, "/component/base/params.env", []byte("KEY=base\n"), 0644)
+			},
+			componentPath: "/component",
+			overlayName:   "odh",
+			expectedPath:  "/component/base/params.env",
+			expectedError: false,
+		},
+		{
+			name: "both missing - returns error",
+			setupFS: func(fs afero.Fs) {
+				_ = fs.MkdirAll("/component", 0755)
+			},
+			componentPath: "/component",
+			overlayName:   "odh",
+			expectedError: true,
+			errorContains: "params.env not found",
+		},
+		{
+			name: "platform-specific params applied to overlay (odh)",
+			setupFS: func(fs afero.Fs) {
+				_ = fs.MkdirAll("/component/overlays/odh", 0755)
+				_ = afero.WriteFile(fs, "/component/overlays/odh/params.env", []byte("PLATFORM_VERSION=old\n"), 0644)
+			},
+			componentPath: "/component",
+			overlayName:   "odh",
+			extraParams: []map[string]string{
+				{"PLATFORM_VERSION": "2.0.0", "FIPS_ENABLED": "true"},
+			},
+			expectedPath:  "/component/overlays/odh/params.env",
+			expectedError: false,
+			validateFS: func(g *GomegaWithT, fs afero.Fs) {
+				content, err := afero.ReadFile(fs, "/component/overlays/odh/params.env")
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(string(content)).To(ContainSubstring("PLATFORM_VERSION=2.0.0"))
+				g.Expect(string(content)).To(ContainSubstring("FIPS_ENABLED=true"))
+			},
+		},
+		{
+			name: "platform-specific params applied to overlay (rhoai)",
+			setupFS: func(fs afero.Fs) {
+				_ = fs.MkdirAll("/component/overlays/rhoai", 0755)
+				_ = afero.WriteFile(fs, "/component/overlays/rhoai/params.env", []byte("PLATFORM_VERSION=old\n"), 0644)
+			},
+			componentPath: "/component",
+			overlayName:   "rhoai",
+			extraParams: []map[string]string{
+				{"PLATFORM_VERSION": "2.0.0"},
+			},
+			expectedPath:  "/component/overlays/rhoai/params.env",
+			expectedError: false,
+			validateFS: func(g *GomegaWithT, fs afero.Fs) {
+				content, err := afero.ReadFile(fs, "/component/overlays/rhoai/params.env")
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(string(content)).To(ContainSubstring("PLATFORM_VERSION=2.0.0"))
+			},
+		},
+		{
+			name: "applies params to base when overlay missing",
+			setupFS: func(fs afero.Fs) {
+				_ = fs.MkdirAll("/component/base", 0755)
+				_ = afero.WriteFile(fs, "/component/base/params.env", []byte("IMAGE=old\n"), 0644)
+			},
+			envGetter: func(key string) string {
+				if key == "RELATED_IMAGE" {
+					return "new-image"
+				}
+				return ""
+			},
+			componentPath:  "/component",
+			overlayName:    "odh",
+			imageParamsMap: map[string]string{"IMAGE": "RELATED_IMAGE"},
+			expectedPath:   "/component/base/params.env",
+			expectedError:  false,
+			validateFS: func(g *GomegaWithT, fs afero.Fs) {
+				content, err := afero.ReadFile(fs, "/component/base/params.env")
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(string(content)).To(ContainSubstring("IMAGE=new-image"))
+			},
+		},
+		{
+			name: "overlay dir exists but params.env missing - falls back to base",
+			setupFS: func(fs afero.Fs) {
+				_ = fs.MkdirAll("/component/overlays/odh", 0755)
+				_ = fs.MkdirAll("/component/base", 0755)
+				_ = afero.WriteFile(fs, "/component/base/params.env", []byte("KEY=base\n"), 0644)
+			},
+			componentPath: "/component",
+			overlayName:   "odh",
+			expectedPath:  "/component/base/params.env",
+			expectedError: false,
+		},
+		{
+			name: "base dir exists but params.env missing - returns error",
+			setupFS: func(fs afero.Fs) {
+				_ = fs.MkdirAll("/component/base", 0755)
+			},
+			componentPath: "/component",
+			overlayName:   "odh",
+			expectedError: true,
+			errorContains: "params.env not found",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+			memFs := afero.NewMemMapFs()
+
+			if tc.setupFS != nil {
+				tc.setupFS(memFs)
+			}
+
+			envGetter := tc.envGetter
+			if envGetter == nil {
+				envGetter = func(string) string { return "" }
+			}
+
+			applier := deploy.NewParamsApplier(
+				deploy.WithFS(memFs),
+				deploy.WithEnvGetter(envGetter),
+			)
+
+			path, err := applier.ApplyParamsWithFallback(
+				tc.componentPath, tc.overlayName, tc.imageParamsMap, tc.extraParams...)
+
+			if tc.expectedError {
+				g.Expect(err).To(HaveOccurred())
+				if tc.errorContains != "" {
+					g.Expect(err.Error()).To(ContainSubstring(tc.errorContains))
+				}
+			} else {
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(path).To(Equal(tc.expectedPath))
+			}
+
+			if tc.validateFS != nil {
+				tc.validateFS(g, memFs)
+			}
+		})
+	}
+}
+
+// errorFs wraps an afero.Fs and returns errors for specific paths on Stat calls.
+type errorFs struct {
+	afero.Fs
+
+	statErrorPath string
+	statError     error
+}
+
+func (e *errorFs) Stat(name string) (os.FileInfo, error) {
+	if name == e.statErrorPath {
+		return nil, e.statError
+	}
+	return e.Fs.Stat(name)
+}
+
+// Separate tests for I/O error cases that require custom filesystem wrappers.
+func TestApplyParamsWithFallback_OverlayStatIOError(t *testing.T) {
+	g := NewWithT(t)
+
+	baseFs := afero.NewMemMapFs()
+	_ = baseFs.MkdirAll("/component/overlays/odh", 0755)
+	_ = baseFs.MkdirAll("/component/base", 0755)
+	_ = afero.WriteFile(baseFs, "/component/base/params.env", []byte("KEY=base\n"), 0644)
+
+	errFs := &errorFs{
+		Fs:            baseFs,
+		statErrorPath: "/component/overlays/odh/params.env",
+		statError:     errors.New("permission denied"),
+	}
+
+	applier := deploy.NewParamsApplier(deploy.WithFS(errFs))
+
+	_, err := applier.ApplyParamsWithFallback("/component", "odh", nil)
+
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("failed to check overlay params file"))
+}


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
New uniform mechanism for applying component parameters with platform-aware overlay selection and base fallback support.

Refactor ApplyParams and ApplyParamsWithFallback to use afero.Fs
filesystem abstraction for improved testability.

Add unit tests for ApplyParams and ApplyParamsWithFallback 
Add unit tests for OverlayName function in pkg/cluster
Add integration tests to test component initialization with different platforms to verify correct params.env selected

### New Functions

**`ApplyParamsWithFallback()`** in `pkg/deploy/envParams.go`:
- Checks for `overlays/[odh|rhoai]/params.env` based on platform
- Falls back to `base/params.env` if platform overlay doesn't exist
- Applies related image env var substitutions
- Supports extra params injection

**`OverlayName()`** in `pkg/cluster/cluster_config.go`:
- Maps platform (OpenDataHub, SelfManagedRhoai, ManagedRhoai) to overlay name ("odh" or "rhoai")

### Components Updated

| Component | Method | Reason |
|-----------|--------|--------|
| datasciencepipelines | `ApplyParamsWithFallback` | Has base fallback |
| feastoperator | `ApplyParamsWithFallback` | Has both overlays |
| llamastackoperator | `ApplyParamsWithFallback` | Has both overlays |
| mlflowoperator | `ApplyParamsWithFallback` | Has base fallback |
| modelcontroller | `ApplyParamsWithFallback` | Has base fallback |
| trustyai | `ApplyParamsWithFallback` | Has both overlays |
| workbenches | `ApplyParamsWithFallback` | Partial (notebook controllers) |

### Components Unchanged (Non-Standard Structures)

| Component | Reason |
|-----------|--------|
| kserve | Only has `overlays/odh/` |
| modelregistry | Only has `overlays/odh/` |
| modelsasservice | Only has `overlays/odh/` |
| ray | Uses `openshift/` path |
| trainer | Uses `rhoai/` path |
| trainingoperator | Uses `rhoai/` path |
| dashboard | 3-way split (odh, rhoai/onprem, rhoai/addon) |

<!--- Link your JIRA and related links here for reference. -->
* https://issues.redhat.com/browse/RHOAIENG-44672
* https://issues.redhat.com/browse/RHOAIENG-37247

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested with e2e, unit and integration tests and manual check for manifest creation

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [ ] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->
No new e2e tested needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved parameter application handling with fallback mechanisms for different deployment configurations.
  * Enhanced error messaging to reference component names for better troubleshooting.
  * Refactored parameter applier with filesystem abstraction for improved testability.

* **Tests**
  * Added comprehensive unit and integration tests for parameter application workflows.

* **Chores**
  * Updated dependencies to support enhanced filesystem abstraction capabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->