### PR TITLE
e2e optimization by changing how the e2e tests are executed in parallel

### DIFF
--- a/.github/workflows/pr-comment-on-e2e-check.yaml
+++ b/.github/workflows/pr-comment-on-e2e-check.yaml
@@ -104,7 +104,7 @@ jobs:
             No e2e tests were added/updated as part of this PR.
 
             **Action required from the PR author:** Please either:
-            1. Add or update e2e tests relevant to the PR changes in the `tests/e2e/` directory, OR
+            1. Add or update e2e tests relevant to the PR changes in the `tests/e2e/` or `Dockerfiles/e2e-tests/` directories, OR
             2. Evaluate the possibility of opting-out of this requirement:
                1. Inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md), to determine if the nature of the PR changes allows for skipping this requirement
                2. If opt-out is applicable, please proceed to provide justification in the PR description (`#### E2E update requirement opt-out justification` section)

--- a/.github/workflows/test-e2e-requirement-check.yaml
+++ b/.github/workflows/test-e2e-requirement-check.yaml
@@ -132,9 +132,9 @@ jobs:
                 per_page: 100,
               });
 
-              // Check if any files in tests/e2e directory were modified
+              // Check if any files in tests/e2e directory or the e2e Dockerfile were modified
               const e2eFilesModified = files.some(file =>
-                file.filename.startsWith('tests/e2e/') &&
+                (file.filename.startsWith('tests/e2e/') || file.filename.startsWith('Dockerfiles/e2e-tests/')) &&
                 ['added', 'modified', 'renamed'].includes(file.status)
               );
 

--- a/Dockerfiles/e2e-tests/e2e-tests.Dockerfile
+++ b/Dockerfiles/e2e-tests/e2e-tests.Dockerfile
@@ -51,7 +51,8 @@ RUN chmod +x ./e2e-tests
 
 RUN mkdir -p results
 
+# run main go command
 CMD gotestsum --junitfile-project-name odh-operator-e2e --junitfile results/xunit_report.xml --format testname --raw-command \
--- test2json -p e2e ./e2e-tests --test.parallel=1 --test.v=test2json --deletion-policy=never \
+-- test2json -p e2e ./e2e-tests --test.v=test2json --test.parallel=8 --deletion-policy=never \
 --operator-namespace=$E2E_TEST_OPERATOR_NAMESPACE --applications-namespace=$E2E_TEST_APPLICATIONS_NAMESPACE \
 --workbenches-namespace=$E2E_TEST_WORKBENCHES_NAMESPACE --dsc-monitoring-namespace=$E2E_TEST_DSC_MONITORING_NAMESPACE

--- a/tests/e2e/controller_test.go
+++ b/tests/e2e/controller_test.go
@@ -309,6 +309,11 @@ func TestOdhOperator(t *testing.T) {
 	mustRun(t, Components.String(), Components.Run)
 	mustRun(t, Services.String(), Services.Run)
 
+	// Run DSCI/DSC Webhook test suite
+	if testOpts.webhookTest {
+		mustRun(t, "DSCInitialization and DataScienceCluster Webhook E2E Tests", dscWebhookTestSuite)
+	}
+
 	// Run operator resilience test suites after functional tests
 	if testOpts.operatorResilienceTest {
 		mustRun(t, "Operator Resilience E2E Tests", operatorResilienceTestSuite)

--- a/tests/e2e/creation_test.go
+++ b/tests/e2e/creation_test.go
@@ -56,25 +56,30 @@ func dscManagementTestSuite(t *testing.T) {
 		{"Validate default NetworkPolicy exist", dscTestCtx.ValidateDefaultNetworkPolicyExists},
 	}
 
-	// Append webhook-specific tests.
-	if testOpts.webhookTest {
-		webhookTests := []TestCase{
-			{"Validate creation of more than one DSCInitialization instance", dscTestCtx.ValidateDSCIDuplication},
-			{"Validate creation of more than one DataScienceCluster instance", dscTestCtx.ValidateDSCDuplication},
-			{"Validate Model Registry Configuration Changes", dscTestCtx.ValidateModelRegistryConfig},
-		}
-
-		testCases = append(testCases, TestCase{
-			name: "Webhook",
-			testFn: func(t *testing.T) {
-				t.Helper()
-				RunTestCases(t, webhookTests, WithParallel())
-			},
-		})
-	}
-
 	// Run the test suite.
 	RunTestCases(t, testCases)
+}
+
+func dscWebhookTestSuite(t *testing.T) {
+	t.Helper()
+
+	// Initialize the test context.
+	tc, err := NewTestContext(t)
+	require.NoError(t, err, "Failed to initialize test context")
+
+	// Create an instance of test context.
+	dscTestCtx := DSCTestCtx{
+		TestContext: tc,
+	}
+
+	// Define dsci/dsc webhook-specific tests.
+	webhookTests := []TestCase{
+		{"Validate creation of more than one DSCInitialization instance", dscTestCtx.ValidateDSCIDuplication},
+		{"Validate creation of more than one DataScienceCluster instance", dscTestCtx.ValidateDSCDuplication},
+		{"Validate Model Registry Configuration Changes", dscTestCtx.ValidateModelRegistryConfig},
+	}
+
+	RunTestCases(t, webhookTests, WithParallel())
 }
 
 // ValidateOperatorsInstallation ensures the required operators are installed.


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

<!--- Link your JIRA and related links here for reference. -->
https://issues.redhat.com/browse/RHOAIENG-46189

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Executed the e2e test suite with different paralellization settings to check improvements:
- 1 thread: 50 minutes
- 2 threads: 43 minutes
- 4 threads: 39 minutes
- 8 threads: 36 minutes

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [ ] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Increased parallelism for the containerized end-to-end test runner and adjusted its invocation.
  * Expanded CI workflow checks and PR messaging to recognize an additional location for end-to-end test files.

* **Tests**
  * Extracted webhook end-to-end checks into a separate, parallel test suite.
  * Added a runtime toggle to run webhook E2E tests conditionally.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->