### PR TITLE
fix: update spark env vars

### DIFF
--- a/get_all_manifests.sh
+++ b/get_all_manifests.sh
@@ -30,7 +30,7 @@ declare -A ODH_COMPONENT_MANIFESTS=(
     ["trainer"]="opendatahub-io:trainer:main@fc484ac82c87abea4e15d1ac8502146106a7fdbe:manifests"
     ["maas"]="opendatahub-io:maas-billing:main@30f93ad170ff45e8b7ef2e686bde26e5f9ad8907:deployment"
     ["mlflowoperator"]="opendatahub-io:mlflow-operator:main@35bdb14fdb75ae8ca3aac885f34bcbcd0832ab50:config"
-    ["sparkoperator"]="opendatahub-io:spark-operator:main@706671cae59deff0d83e06d43a28ed38c7645519:config"
+    ["sparkoperator"]="opendatahub-io:spark-operator:main@2242dc8dfe7320ec8eac3a48ad0c3e05d9f63467:config"
 )
 
 # RHOAI Component Manifests

--- a/internal/controller/components/sparkoperator/sparkoperator_support.go
+++ b/internal/controller/components/sparkoperator/sparkoperator_support.go
@@ -26,8 +26,8 @@ var (
 	// Maps variables in params.env files to RELATED_IMAGE_* environment variables
 	// that are injected by the operator at runtime.
 	imageParamMap = map[string]string{
-		"SPARK_OPERATOR_CONTROLLER_IMAGE": "RELATED_IMAGE_SPARK_OPERATOR",
-		"SPARK_OPERATOR_WEBHOOK_IMAGE":    "RELATED_IMAGE_SPARK_OPERATOR",
+		"SPARK_OPERATOR_CONTROLLER_IMAGE": "RELATED_IMAGE_SPARK_OPERATOR_IMAGE",
+		"SPARK_OPERATOR_WEBHOOK_IMAGE":    "RELATED_IMAGE_SPARK_OPERATOR_IMAGE",
 	}
 
 	conditionTypes = []string{


### PR DESCRIPTION
## Description
JIRA: [RHOAIENG-45115](https://issues.redhat.com/browse/RHOAIENG-45115)

This PR updates the [sparkoperator image env vars](https://github.com/opendatahub-io/opendatahub-operator/blob/f2e88fd7fcfdce10ce416023b8531022c649b76b/internal/controller/components/sparkoperator/sparkoperator_support.go#L29-L30) from `RELATED_IMAGE_SPARK_OPERATOR` to `RELATED_IMAGE_SPARK_OPERATOR_IMAGE` in order to stay consistent with the pattern that all other components use.

The manifests were updated in the spark-operator component repo in this PR.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [X] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [X] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [X] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
Existing e2e tests cover this change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Spark Operator component manifest reference and image configuration parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->