### PR TITLE
feat: Add URL namespace transformer to fix service URLs in manifests

### DIFF
--- a/pkg/deploy/deploy.go
+++ b/pkg/deploy/deploy.go
@@ -104,6 +104,13 @@ func DeployManifestsFromPathWithLabels(
 		return fmt.Errorf("failed applying namespace plugin when preparing Kustomize resources. %w", err)
 	}
 
+	// Transform URLs containing namespace patterns (e.g., .opendatahub.svc.cluster.local)
+	// to use the actual target namespace
+	urlNsPlugin := plugins.CreateURLNamespaceTransformerPlugin(namespace)
+	if err := urlNsPlugin.Transform(resMap); err != nil {
+		return fmt.Errorf("failed applying URL namespace plugin when preparing Kustomize resources. %w", err)
+	}
+
 	resourceLabels := map[string]string{
 		labels.ODH.Component(componentName): "true",
 		labels.K8SCommon.PartOf:             componentName,

--- a/pkg/manifests/kustomize/kustomize_engine.go
+++ b/pkg/manifests/kustomize/kustomize_engine.go
@@ -45,6 +45,13 @@ func (e *Engine) Render(path string, opts ...RenderOptsFn) ([]unstructured.Unstr
 		if err := plugin.Transform(resMap); err != nil {
 			return nil, fmt.Errorf("failed applying namespace plugin when preparing Kustomize resources. %w", err)
 		}
+
+		// Transform URLs containing namespace patterns (e.g., .opendatahub.svc.cluster.local)
+		// to use the actual target namespace
+		urlNsPlugin := plugins.CreateURLNamespaceTransformerPlugin(ro.ns)
+		if err := urlNsPlugin.Transform(resMap); err != nil {
+			return nil, fmt.Errorf("failed applying URL namespace plugin when preparing Kustomize resources. %w", err)
+		}
 	}
 
 	if len(ro.labels) != 0 {

--- a/pkg/plugins/urlNamespacePlugin.go
+++ b/pkg/plugins/urlNamespacePlugin.go
@@ -1,0 +1,164 @@
+package plugins
+
+import (
+	"strings"
+
+	"sigs.k8s.io/kustomize/api/resmap"
+	"sigs.k8s.io/kustomize/api/resource"
+	"sigs.k8s.io/kustomize/kyaml/kio"
+	kyaml "sigs.k8s.io/kustomize/kyaml/yaml"
+)
+
+// DefaultSourceNamespace is the default namespace placeholder used in manifests
+// that should be replaced with the actual target namespace.
+const DefaultSourceNamespace = "opendatahub"
+
+// URLNamespaceTransformerPlugin transforms URLs in resources that contain
+// namespace references in the format ".<namespace>.svc.cluster.local".
+// This is useful when manifests contain hardcoded namespace references in URLs
+// that need to be updated to match the deployment namespace.
+type URLNamespaceTransformerPlugin struct {
+	// SourceNamespace is the namespace to replace in URLs.
+	// If empty, DefaultSourceNamespace ("opendatahub") is used.
+	SourceNamespace string
+
+	// TargetNamespace is the namespace to use in the transformed URLs.
+	TargetNamespace string
+}
+
+var _ resmap.Transformer = &URLNamespaceTransformerPlugin{}
+
+// Transform applies the URL namespace transformation to all resources in the ResMap.
+func (p *URLNamespaceTransformerPlugin) Transform(m resmap.ResMap) error {
+	sourceNs := p.SourceNamespace
+	if sourceNs == "" {
+		sourceNs = DefaultSourceNamespace
+	}
+
+	if p.TargetNamespace == "" || sourceNs == p.TargetNamespace {
+		return nil
+	}
+
+	filter := &urlNamespaceFilter{
+		sourceNamespace: sourceNs,
+		targetNamespace: p.TargetNamespace,
+	}
+
+	return m.ApplyFilter(filter)
+}
+
+// TransformResource applies the URL namespace transformation to a single resource.
+func (p *URLNamespaceTransformerPlugin) TransformResource(r *resource.Resource) error {
+	sourceNs := p.SourceNamespace
+	if sourceNs == "" {
+		sourceNs = DefaultSourceNamespace
+	}
+
+	if p.TargetNamespace == "" || sourceNs == p.TargetNamespace {
+		// Nothing to transform
+		return nil
+	}
+
+	filter := &urlNamespaceFilter{
+		sourceNamespace: sourceNs,
+		targetNamespace: p.TargetNamespace,
+	}
+
+	nodes := []*kyaml.RNode{&r.RNode}
+	_, err := filter.Filter(nodes)
+	return err
+}
+
+// urlNamespaceFilter is a kio.Filter that transforms URLs containing namespace patterns.
+type urlNamespaceFilter struct {
+	sourceNamespace string
+	targetNamespace string
+}
+
+var _ kio.Filter = &urlNamespaceFilter{}
+
+// Filter applies the URL namespace transformation to all nodes.
+func (f *urlNamespaceFilter) Filter(nodes []*kyaml.RNode) ([]*kyaml.RNode, error) {
+	return kio.FilterAll(kyaml.FilterFunc(f.transformNode)).Filter(nodes)
+}
+
+// transformNode recursively transforms all string values in a node.
+func (f *urlNamespaceFilter) transformNode(node *kyaml.RNode) (*kyaml.RNode, error) {
+	return node, node.VisitFields(func(field *kyaml.MapNode) error {
+		return f.visitValue(field.Value)
+	})
+}
+
+// visitValue recursively visits and transforms values.
+func (f *urlNamespaceFilter) visitValue(node *kyaml.RNode) error {
+	if node == nil {
+		return nil
+	}
+
+	switch node.YNode().Kind {
+	case kyaml.ScalarNode:
+		// Transform scalar (string) values
+		f.transformScalar(node)
+	case kyaml.MappingNode:
+		// Recursively visit map entries
+		return node.VisitFields(func(field *kyaml.MapNode) error {
+			return f.visitValue(field.Value)
+		})
+	case kyaml.SequenceNode:
+		// Recursively visit sequence elements
+		elements, err := node.Elements()
+		if err != nil {
+			return err
+		}
+		for _, elem := range elements {
+			if err := f.visitValue(elem); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// transformScalar transforms a scalar node if it contains a URL with namespace pattern.
+func (f *urlNamespaceFilter) transformScalar(node *kyaml.RNode) {
+	value := node.YNode().Value
+	if value == "" {
+		return
+	}
+
+	// Replace patterns like .opendatahub.svc.cluster.local with .targetNamespace.svc.cluster.local
+	sourcePattern := "." + f.sourceNamespace + ".svc.cluster.local"
+	targetPattern := "." + f.targetNamespace + ".svc.cluster.local"
+
+	if strings.Contains(value, sourcePattern) {
+		newValue := strings.ReplaceAll(value, sourcePattern, targetPattern)
+		node.YNode().Value = newValue
+	}
+}
+
+// CreateURLNamespaceTransformerPlugin creates a plugin that transforms URLs containing
+// namespace patterns from a source namespace to a target namespace.
+//
+// This is useful when manifests contain hardcoded URLs like:
+//
+//	http://service.opendatahub.svc.cluster.local:8080/api
+//
+// And need to be transformed to:
+//
+//	http://service.redhat-ods-applications.svc.cluster.local:8080/api
+func CreateURLNamespaceTransformerPlugin(targetNamespace string) *URLNamespaceTransformerPlugin {
+	return &URLNamespaceTransformerPlugin{
+		SourceNamespace: DefaultSourceNamespace,
+		TargetNamespace: targetNamespace,
+	}
+}
+
+// CreateURLNamespaceTransformerPluginWithSource creates a plugin that transforms URLs
+// from a custom source namespace to a target namespace.
+func CreateURLNamespaceTransformerPluginWithSource(sourceNamespace, targetNamespace string) *URLNamespaceTransformerPlugin {
+	return &URLNamespaceTransformerPlugin{
+		SourceNamespace: sourceNamespace,
+		TargetNamespace: targetNamespace,
+	}
+}

--- a/pkg/plugins/urlNamespacePlugin_test.go
+++ b/pkg/plugins/urlNamespacePlugin_test.go
@@ -1,0 +1,252 @@
+package plugins_test
+
+import (
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/plugins"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("URL Namespace plugin", func() {
+	It("Should transform URLs with opendatahub namespace to target namespace", func() {
+		res, err := factory.FromBytes([]byte(`
+apiVersion: kuadrant.io/v1beta3
+kind: AuthPolicy
+metadata:
+  name: gateway-auth-policy
+  namespace: istio-system
+spec:
+  rules:
+    metadata:
+      matchedTier:
+        http:
+          url: https://maas-api.opendatahub.svc.cluster.local:8443/v1/tiers/lookup
+`))
+		Expect(err).NotTo(HaveOccurred())
+
+		plugin := plugins.CreateURLNamespaceTransformerPlugin("redhat-ods-applications")
+		err = plugin.TransformResource(res)
+		Expect(err).NotTo(HaveOccurred())
+
+		expected := `
+apiVersion: kuadrant.io/v1beta3
+kind: AuthPolicy
+metadata:
+  name: gateway-auth-policy
+  namespace: istio-system
+spec:
+  rules:
+    metadata:
+      matchedTier:
+        http:
+          url: https://maas-api.redhat-ods-applications.svc.cluster.local:8443/v1/tiers/lookup
+`
+		Expect(res.MustYaml()).To(MatchYAML(expected))
+	})
+
+	It("Should transform URLs with custom source namespace", func() {
+		res, err := factory.FromBytes([]byte(`
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-config
+data:
+  api-url: http://service.custom-namespace.svc.cluster.local:8080/api
+  other-key: "some value"
+`))
+		Expect(err).NotTo(HaveOccurred())
+
+		plugin := plugins.CreateURLNamespaceTransformerPluginWithSource("custom-namespace", "target-ns")
+		err = plugin.TransformResource(res)
+		Expect(err).NotTo(HaveOccurred())
+
+		expected := `
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-config
+data:
+  api-url: http://service.target-ns.svc.cluster.local:8080/api
+  other-key: "some value"
+`
+		Expect(res.MustYaml()).To(MatchYAML(expected))
+	})
+
+	It("Should transform multiple URLs in the same resource", func() {
+		res, err := factory.FromBytes([]byte(`
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-config
+data:
+  primary-api: http://api1.opendatahub.svc.cluster.local:8080/v1
+  secondary-api: http://api2.opendatahub.svc.cluster.local:9090/v2
+  external-url: https://example.com/api
+`))
+		Expect(err).NotTo(HaveOccurred())
+
+		plugin := plugins.CreateURLNamespaceTransformerPlugin("my-namespace")
+		err = plugin.TransformResource(res)
+		Expect(err).NotTo(HaveOccurred())
+
+		expected := `
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-config
+data:
+  primary-api: http://api1.my-namespace.svc.cluster.local:8080/v1
+  secondary-api: http://api2.my-namespace.svc.cluster.local:9090/v2
+  external-url: https://example.com/api
+`
+		Expect(res.MustYaml()).To(MatchYAML(expected))
+	})
+
+	It("Should handle nested structures", func() {
+		res, err := factory.FromBytes([]byte(`
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-deployment
+spec:
+  template:
+    spec:
+      containers:
+      - name: app
+        env:
+        - name: API_URL
+          value: http://backend.opendatahub.svc.cluster.local:8080
+        - name: OTHER_VAR
+          value: "test"
+`))
+		Expect(err).NotTo(HaveOccurred())
+
+		plugin := plugins.CreateURLNamespaceTransformerPlugin("prod-namespace")
+		err = plugin.TransformResource(res)
+		Expect(err).NotTo(HaveOccurred())
+
+		expected := `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-deployment
+spec:
+  template:
+    spec:
+      containers:
+      - name: app
+        env:
+        - name: API_URL
+          value: http://backend.prod-namespace.svc.cluster.local:8080
+        - name: OTHER_VAR
+          value: "test"
+`
+		Expect(res.MustYaml()).To(MatchYAML(expected))
+	})
+
+	It("Should not transform when source equals target", func() {
+		res, err := factory.FromBytes([]byte(`
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-config
+data:
+  url: http://service.opendatahub.svc.cluster.local:8080
+`))
+		Expect(err).NotTo(HaveOccurred())
+
+		plugin := plugins.CreateURLNamespaceTransformerPlugin("opendatahub")
+		err = plugin.TransformResource(res)
+		Expect(err).NotTo(HaveOccurred())
+
+		expected := `
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-config
+data:
+  url: http://service.opendatahub.svc.cluster.local:8080
+`
+		Expect(res.MustYaml()).To(MatchYAML(expected))
+	})
+
+	It("Should not transform URLs with different namespace patterns", func() {
+		res, err := factory.FromBytes([]byte(`
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-config
+data:
+  url: http://service.other-namespace.svc.cluster.local:8080
+`))
+		Expect(err).NotTo(HaveOccurred())
+
+		plugin := plugins.CreateURLNamespaceTransformerPlugin("target-ns")
+		err = plugin.TransformResource(res)
+		Expect(err).NotTo(HaveOccurred())
+
+		// URL should remain unchanged because it uses "other-namespace", not "opendatahub"
+		expected := `
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-config
+data:
+  url: http://service.other-namespace.svc.cluster.local:8080
+`
+		Expect(res.MustYaml()).To(MatchYAML(expected))
+	})
+
+	It("Should handle empty target namespace (no transformation)", func() {
+		res, err := factory.FromBytes([]byte(`
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-config
+data:
+  url: http://service.opendatahub.svc.cluster.local:8080
+`))
+		Expect(err).NotTo(HaveOccurred())
+
+		plugin := plugins.CreateURLNamespaceTransformerPlugin("")
+		err = plugin.TransformResource(res)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Should remain unchanged
+		expected := `
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-config
+data:
+  url: http://service.opendatahub.svc.cluster.local:8080
+`
+		Expect(res.MustYaml()).To(MatchYAML(expected))
+	})
+
+	It("Should handle URL in string with additional content", func() {
+		res, err := factory.FromBytes([]byte(`
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-config
+data:
+  complex: "Connect to http://api.opendatahub.svc.cluster.local:8080/v1/endpoint for API access"
+`))
+		Expect(err).NotTo(HaveOccurred())
+
+		plugin := plugins.CreateURLNamespaceTransformerPlugin("rhoai")
+		err = plugin.TransformResource(res)
+		Expect(err).NotTo(HaveOccurred())
+
+		expected := `
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-config
+data:
+  complex: "Connect to http://api.rhoai.svc.cluster.local:8080/v1/endpoint for API access"
+`
+		Expect(res.MustYaml()).To(MatchYAML(expected))
+	})
+})


### PR DESCRIPTION
JIRA - https://issues.redhat.com/projects/RHOAIENG/issues/RHOAIENG-47922

## Problem

When deploying MaaS (Models-as-a-Service) components to RHOAI environments, the `AuthPolicy` resource contains hardcoded URLs with the `opendatahub` namespace that don't get transformed to match the actual deployment namespace.

**Example of the issue:**

The MaaS `AuthPolicy` manifest contains:

```yaml
spec:
  rules:
    metadata:
      matchedTier:
        http:
          url: https://maas-api.opendatahub.svc.cluster.local:8443/v1/tiers/lookup
```

When deployed to RHOAI where the application namespace is `redhat-ods-applications`:

- The standard namespace plugin correctly sets `metadata.namespace`
- But the URL string `.opendatahub.svc.cluster.local` remains unchanged
- This causes the AuthPolicy to point to a non-existent service endpoint

**Root Cause:**

The existing `NamespaceTransformerPlugin` only handles specific field paths like `metadata/namespace` and `subjects/namespace`. It doesn't transform namespace references embedded within URL strings.

## Solution

This PR introduces a `URLNamespaceTransformerPlugin` that:

1. **Scans all string values** in rendered resources recursively (including nested maps and sequences)
2. **Detects URL patterns** containing `.<namespace>.svc.cluster.local`
3. **Replaces the source namespace** (default: `opendatahub`) with the target namespace

**Example transformation:**

```
Before: https://maas-api.opendatahub.svc.cluster.local:8443/v1/tiers/lookup
After:  https://maas-api.redhat-ods-applications.svc.cluster.local:8443/v1/tiers/lookup
```

## Testing

Added 8 unit tests covering:

- Basic URL transformation
- Custom source namespace
- Multiple URLs in same resource
- Nested structures (Deployments, ConfigMaps)
- No-op when source equals target
- Non-matching patterns preserved
- Empty target namespace handling
- URLs embedded in longer strings

+ tested manually on my OC cluster (using temp image of opendatahub-operator)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatic URL namespace transformation during resource deployment now normalizes hardcoded namespace references in URLs to match the target namespace, improving resource consistency across deployment environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->