### PR TITLE
fix: skip serverless ISVC during HWP migration

### DIFF
--- a/pkg/upgrade/upgrade.go
+++ b/pkg/upgrade/upgrade.go
@@ -52,6 +52,14 @@ const (
 	featureVisibilityModelServing         = `["model-serving"]`
 	featureVisibilityWorkbench            = `["workbench"]`
 	containerSizeHWPPrefix                = "containersize-"
+
+	// ServerlessMigrationSkipped event fields.
+	eventReasonServerlessMigrationSkipped = "ServerlessMigrationSkipped"
+	eventSourceComponent                  = "opendatahub-operator"
+
+	// KServe deployment mode annotation.
+	kserveDeploymentModeAnnotationKey = "serving.kserve.io/deploymentMode"
+	kserveDeploymentModeServerless    = "Serverless"
 )
 
 var defaultResourceLimits = map[string]string{
@@ -485,6 +493,30 @@ func AttachHardwareProfileToInferenceServices(ctx context.Context, cli client.Cl
 			continue
 		}
 
+		// Skip Serverless InferenceServices as they are not supported in RHOAI 3.x
+		// Attempting to update them causes KServe webhook to incorrectly reject with deploymentMode error
+		// Check both the annotation (primary source) and status field (fallback) to determine if ISVC is serverless
+		isServerless := false
+		deploymentModeAnnotation := isvcAnnotations[kserveDeploymentModeAnnotationKey]
+		deploymentModeStatus, statusFound, _ := unstructured.NestedString(isvc.Object, "status", "deploymentMode")
+
+		log.V(1).Info("Checking InferenceService deployment mode", "isvc", isvc.GetName(),
+			"deploymentModeAnnotation", deploymentModeAnnotation, "deploymentModeStatus", deploymentModeStatus, "statusFound", statusFound)
+
+		if deploymentModeAnnotation == kserveDeploymentModeServerless {
+			isServerless = true
+		} else if statusFound && deploymentModeStatus == kserveDeploymentModeServerless {
+			isServerless = true
+		}
+		if isServerless {
+			log.Info("Skipping HardwareProfile migration for Serverless InferenceService", "isvc", isvc.GetName(), "deploymentMode", kserveDeploymentModeServerless)
+			if err := recordUpgradeErrorEvent(ctx, cli, isvc, corev1.EventTypeWarning, eventReasonServerlessMigrationSkipped,
+				fmt.Sprintf("Skipping HardwareProfile migration for Serverless InferenceService %s (Serverless mode not supported in RHOAI 3.x)", isvc.GetName())); err != nil {
+				log.Error(err, "Failed to record event for Serverless InferenceService", "isvc", isvc.GetName())
+			}
+			continue
+		}
+
 		// Check ServingRuntime for AcceleratorProfile annotation and apply to InferenceService
 		servingRuntime, err := getSRFromISVC(ctx, cli, isvc)
 		if err == nil {
@@ -495,6 +527,16 @@ func AttachHardwareProfileToInferenceServices(ctx context.Context, cli client.Cl
 			if apName := runtimeAnnotations[acceleratorNameAnnotation]; apName != "" {
 				hwpName := fmt.Sprintf("%s-serving", strings.ReplaceAll(strings.ToLower(apName), " ", "-"))
 				if err := setHardwareProfileAnnotation(ctx, cli, isvc, hwpName, applicationNamespace); err != nil {
+					// If webhook rejects due to Serverless mode, record event and skip instead of error
+					errStr := err.Error()
+					if strings.Contains(errStr, "deploymentMode cannot be changed") || strings.Contains(errStr, "Serverless") {
+						log.Info("Skipping HardwareProfile migration for InferenceService due to Serverless mode", "isvc", isvc.GetName(), "error", errStr)
+						if eventErr := recordUpgradeErrorEvent(ctx, cli, isvc, corev1.EventTypeWarning, eventReasonServerlessMigrationSkipped,
+							fmt.Sprintf("Skipping HardwareProfile migration due to Serverless mode incompatibility: %s", errStr)); eventErr != nil {
+							log.Error(eventErr, "Failed to record event for Serverless InferenceService", "isvc", isvc.GetName())
+						}
+						continue
+					}
 					multiErr = multierror.Append(multiErr, fmt.Errorf("failed to set HardwareProfile annotation for InferenceService %s: %w", isvc.GetName(), err))
 					continue
 				}
@@ -505,7 +547,7 @@ func AttachHardwareProfileToInferenceServices(ctx context.Context, cli client.Cl
 		}
 
 		// No AP found, try container size matching
-		// Default usign HWProfile CR "custom-serving", update only if we find a matching size
+		// Default using HWProfile CR "custom-serving", update only if we find a matching size
 		hwpName := customServing
 		var matchedSize string
 
@@ -519,6 +561,16 @@ func AttachHardwareProfileToInferenceServices(ctx context.Context, cli client.Cl
 		}
 
 		if err := setHardwareProfileAnnotation(ctx, cli, isvc, hwpName, applicationNamespace); err != nil {
+			// If webhook rejects due to Serverless mode, record event and skip instead of error
+			errStr := err.Error()
+			if strings.Contains(errStr, "deploymentMode cannot be changed") || strings.Contains(errStr, "Serverless") {
+				log.Info("Skipping HardwareProfile migration for InferenceService due to Serverless mode", "isvc", isvc.GetName(), "error", errStr)
+				if eventErr := recordUpgradeErrorEvent(ctx, cli, isvc, corev1.EventTypeWarning, eventReasonServerlessMigrationSkipped,
+					fmt.Sprintf("Skipping HardwareProfile migration due to Serverless mode incompatibility: %s", errStr)); eventErr != nil {
+					log.Error(eventErr, "Failed to record event for Serverless InferenceService", "isvc", isvc.GetName())
+				}
+				continue
+			}
 			multiErr = multierror.Append(multiErr, fmt.Errorf("failed to set HardwareProfile annotation for InferenceService %s: %w", isvc.GetName(), err))
 		} else {
 			// Log after successful annotation setting


### PR DESCRIPTION
## Description
JIRA: [RHOAIENG-48349](https://issues.redhat.com/browse/RHOAIENG-48349)

This PR fixes an issue with the AcceleratorProfile to HardwareProfile migration logic that occurs during the 2.25 to 3.x upgrade. 

Prior to this change, if a user had failed to migrate all InferenceServices (that were using AcceleratorProfiles) away from serverless prior to triggering the upgrade to 3.x, the upgrade would fail because the kserve webhook doesn't allow the upgrade logic to modify the annotations on the affected InferenceServices. 

This change catches that scenario, emits an event and log notifying the user, and then skips to the next InferenceService to prevent blocking the upgrade from completing.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [X] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
Added unit tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Hardware profile migrations now properly skip InferenceServices configured in Serverless deployment mode, with warning events emitted.

* **Improvements**
  * Enhanced error event tracking and logging during upgrade operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->