### PR TITLE
RHOAIENG-48690: restore Managed in Kueue CRD for OLM upgrades

### DIFF
--- a/api/components/v1alpha1/kueue_types.go
+++ b/api/components/v1alpha1/kueue_types.go
@@ -105,12 +105,15 @@ func (c *Kueue) SetReleaseStatus(releases []common.ComponentRelease) {
 type KueueManagementSpec struct {
 	// Set to one of the following values:
 	//
+	// - "Managed"   : present for backwards compatibility with OLM upgrades, but not supported at runtime.
+	//                 The operator will reject this value. Use "Unmanaged" or "Removed" instead.
+	//
 	// - "Unmanaged" : the operator will not deploy or manage the component's lifecycle, but may create supporting configuration resources.
 	//
 	// - "Removed"   : the operator is actively managing the component and will not install it,
 	//                 or if it is installed, the operator will try to remove it
 	//
-	// +kubebuilder:validation:Enum=Unmanaged;Removed
+	// +kubebuilder:validation:Enum=Managed;Unmanaged;Removed
 	ManagementState operatorv1.ManagementState `json:"managementState,omitempty"`
 }
 

--- a/docs/api-overview.md
+++ b/docs/api-overview.md
@@ -206,7 +206,7 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `managementState` _[ManagementState](https://pkg.go.dev/github.com/openshift/api@v0.0.0-20250812222054-88b2b21555f3/operator/v1#ManagementState)_ | Set to one of the following values:<br />- "Unmanaged" : the operator will not deploy or manage the component's lifecycle, but may create supporting configuration resources.<br />- "Removed"   : the operator is actively managing the component and will not install it,<br />                or if it is installed, the operator will try to remove it |  | Enum: [Unmanaged Removed] <br /> |
+| `managementState` _[ManagementState](https://pkg.go.dev/github.com/openshift/api@v0.0.0-20250812222054-88b2b21555f3/operator/v1#ManagementState)_ | Set to one of the following values:<br />- "Managed"   : present for backwards compatibility with OLM upgrades, but not supported at runtime.<br />                The operator will reject this value. Use "Unmanaged" or "Removed" instead.<br />- "Unmanaged" : the operator will not deploy or manage the component's lifecycle, but may create supporting configuration resources.<br />- "Removed"   : the operator is actively managing the component and will not install it,<br />                or if it is installed, the operator will try to remove it |  | Enum: [Managed Unmanaged Removed] <br /> |
 | `defaultLocalQueueName` _string_ | Configures the automatically created, in the managed namespaces, local queue name. | default |  |
 | `defaultClusterQueueName` _string_ | Configures the automatically created cluster queue name. | default |  |
 
@@ -225,7 +225,7 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `managementState` _[ManagementState](https://pkg.go.dev/github.com/openshift/api@v0.0.0-20250812222054-88b2b21555f3/operator/v1#ManagementState)_ | Set to one of the following values:<br />- "Unmanaged" : the operator will not deploy or manage the component's lifecycle, but may create supporting configuration resources.<br />- "Removed"   : the operator is actively managing the component and will not install it,<br />                or if it is installed, the operator will try to remove it |  | Enum: [Unmanaged Removed] <br /> |
+| `managementState` _[ManagementState](https://pkg.go.dev/github.com/openshift/api@v0.0.0-20250812222054-88b2b21555f3/operator/v1#ManagementState)_ | Set to one of the following values:<br />- "Managed"   : present for backwards compatibility with OLM upgrades, but not supported at runtime.<br />                The operator will reject this value. Use "Unmanaged" or "Removed" instead.<br />- "Unmanaged" : the operator will not deploy or manage the component's lifecycle, but may create supporting configuration resources.<br />- "Removed"   : the operator is actively managing the component and will not install it,<br />                or if it is installed, the operator will try to remove it |  | Enum: [Managed Unmanaged Removed] <br /> |
 
 
 #### DSCLlamaStackOperator
@@ -1008,7 +1008,7 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `managementState` _[ManagementState](https://pkg.go.dev/github.com/openshift/api@v0.0.0-20250812222054-88b2b21555f3/operator/v1#ManagementState)_ | Set to one of the following values:<br />- "Unmanaged" : the operator will not deploy or manage the component's lifecycle, but may create supporting configuration resources.<br />- "Removed"   : the operator is actively managing the component and will not install it,<br />                or if it is installed, the operator will try to remove it |  | Enum: [Unmanaged Removed] <br /> |
+| `managementState` _[ManagementState](https://pkg.go.dev/github.com/openshift/api@v0.0.0-20250812222054-88b2b21555f3/operator/v1#ManagementState)_ | Set to one of the following values:<br />- "Managed"   : present for backwards compatibility with OLM upgrades, but not supported at runtime.<br />                The operator will reject this value. Use "Unmanaged" or "Removed" instead.<br />- "Unmanaged" : the operator will not deploy or manage the component's lifecycle, but may create supporting configuration resources.<br />- "Removed"   : the operator is actively managing the component and will not install it,<br />                or if it is installed, the operator will try to remove it |  | Enum: [Managed Unmanaged Removed] <br /> |
 
 
 #### KueueSpec
@@ -1024,7 +1024,7 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `managementState` _[ManagementState](https://pkg.go.dev/github.com/openshift/api@v0.0.0-20250812222054-88b2b21555f3/operator/v1#ManagementState)_ | Set to one of the following values:<br />- "Unmanaged" : the operator will not deploy or manage the component's lifecycle, but may create supporting configuration resources.<br />- "Removed"   : the operator is actively managing the component and will not install it,<br />                or if it is installed, the operator will try to remove it |  | Enum: [Unmanaged Removed] <br /> |
+| `managementState` _[ManagementState](https://pkg.go.dev/github.com/openshift/api@v0.0.0-20250812222054-88b2b21555f3/operator/v1#ManagementState)_ | Set to one of the following values:<br />- "Managed"   : present for backwards compatibility with OLM upgrades, but not supported at runtime.<br />                The operator will reject this value. Use "Unmanaged" or "Removed" instead.<br />- "Unmanaged" : the operator will not deploy or manage the component's lifecycle, but may create supporting configuration resources.<br />- "Removed"   : the operator is actively managing the component and will not install it,<br />                or if it is installed, the operator will try to remove it |  | Enum: [Managed Unmanaged Removed] <br /> |
 | `defaultLocalQueueName` _string_ | Configures the automatically created, in the managed namespaces, local queue name. | default |  |
 | `defaultClusterQueueName` _string_ | Configures the automatically created cluster queue name. | default |  |
 


### PR DESCRIPTION
## Description

When upgrading from RHOAI 2.25 to 3.3, OLM validates existing CRs against the new CRD schema **before** installing the new operator. The Kueue CRD was changed to only allow `Unmanaged`/`Removed`, causing upgrades to fail for clusters with `kueue.managementState=Managed`.

**Error message:**
```
error validating existing CRs against new CRD's schema for "kueues.components.platform.opendatahub.io":
.spec.managementState: Unsupported value: "Managed": supported values: "Unmanaged", "Removed"
```

This restores `Managed` to the CRD enum for backwards compatibility. The value is still rejected at runtime by the controller (in `checkPreConditions`), but allowing it in the schema lets OLM complete the upgrade so users can then change to `Unmanaged` or `Removed`.

**Jira:** [RHOAIENG-48690](https://issues.redhat.com/browse/RHOAIENG-48690)

## How Has This Been Tested?

- Verified the generated CRD now includes `Managed` in the enum
- Runtime rejection of `Managed` state is unchanged (existing `checkPreConditions` logic)
- [Local (CRC) reproducer](https://gitlab.cee.redhat.com/rpitzerj/rhoaieng-48690-reproducer)

## Screenshot or short clip

N/A - CRD schema change only

## Merge criteria

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

- [x] Skip requirement to update E2E test suite for this PR

#### E2E update requirement opt-out justification

This is a CRD schema-only change that adds a previously-allowed value back to the enum for OLM upgrade compatibility. The runtime behavior is unchanged - the `Managed` state is still rejected by the controller's `checkPreConditions` function, which is already covered by existing tests in `kueue_controller_actions_test.go`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Configuration Updates**
  * Expanded allowed managementState values to include "Managed" for backward compatibility; runtime use of "Managed" is not supported—use "Unmanaged" or "Removed" instead.
* **Documentation**
  * Updated API and doc pages to reflect the added "Managed" option and guidance across relevant components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->