### PR TITLE
Add unit tests for ApplyParams, ApplyParamsWithFallback and OverlayName

### DIFF
--- a/pkg/cluster/cluster_config_internal_test.go
+++ b/pkg/cluster/cluster_config_internal_test.go
@@ -213,3 +213,41 @@ func TestSetApplicationNamespace(t *testing.T) {
 		})
 	}
 }
+
+func TestOverlayName(t *testing.T) {
+	testCases := []struct {
+		name           string
+		platform       common.Platform
+		expectedResult string
+	}{
+		{
+			name:           "OpenDataHub returns odh",
+			platform:       OpenDataHub,
+			expectedResult: "odh",
+		},
+		{
+			name:           "SelfManagedRhoai returns rhoai",
+			platform:       SelfManagedRhoai,
+			expectedResult: "rhoai",
+		},
+		{
+			name:           "ManagedRhoai returns rhoai",
+			platform:       ManagedRhoai,
+			expectedResult: "rhoai",
+		},
+		{
+			name:           "Unknown platform returns odh as default",
+			platform:       common.Platform("unknown-platform"),
+			expectedResult: "odh",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := OverlayName(tc.platform)
+			if result != tc.expectedResult {
+				t.Errorf("OverlayName(%q) = %q, want %q", tc.platform, result, tc.expectedResult)
+			}
+		})
+	}
+}

--- a/pkg/deploy/envParams_test.go
+++ b/pkg/deploy/envParams_test.go
@@ -1,0 +1,452 @@
+package deploy
+
+import (
+	"errors"
+	"os"
+	"testing"
+
+	"github.com/spf13/afero"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestParamsApplier_ApplyParams(t *testing.T) {
+	testCases := []struct {
+		name           string
+		setupFS        func(afero.Fs)               // Setup filesystem state
+		envGetter      func(string) string          // Mock environment variable getter
+		componentPath  string                       // Input: component path
+		file           string                       // Input: params file name
+		imageParamsMap map[string]string            // Input: image params mapping
+		extraParams    []map[string]string          // Input: extra params maps
+		expectedError  bool                         // Expected: should return error
+		errorContains  string                       // Expected: error message contains
+		validateFS     func(*GomegaWithT, afero.Fs) // Validate filesystem state after
+	}{
+		{
+			name: "updates params from env variables",
+			setupFS: func(fs afero.Fs) {
+				_ = fs.MkdirAll("/component", 0755)
+				_ = afero.WriteFile(fs, "/component/params.env", []byte("IMAGE_A=old-value\n"), 0644)
+			},
+			envGetter: func(key string) string {
+				if key == "RELATED_IMAGE_A" {
+					return "new-value"
+				}
+				return ""
+			},
+			componentPath:  "/component",
+			file:           "params.env",
+			imageParamsMap: map[string]string{"IMAGE_A": "RELATED_IMAGE_A"},
+			expectedError:  false,
+			validateFS: func(g *GomegaWithT, fs afero.Fs) {
+				content, err := afero.ReadFile(fs, "/component/params.env")
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(string(content)).To(ContainSubstring("IMAGE_A=new-value"))
+			},
+		},
+		{
+			name: "updates params from extraParamsMaps",
+			setupFS: func(fs afero.Fs) {
+				_ = fs.MkdirAll("/component", 0755)
+				_ = afero.WriteFile(fs, "/component/params.env", []byte("KEY1=value1\nKEY2=value2\n"), 0644)
+			},
+			componentPath: "/component",
+			file:          "params.env",
+			extraParams: []map[string]string{
+				{"KEY1": "updated1"},
+				{"KEY2": "updated2"},
+			},
+			expectedError: false,
+			validateFS: func(g *GomegaWithT, fs afero.Fs) {
+				content, err := afero.ReadFile(fs, "/component/params.env")
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(string(content)).To(ContainSubstring("KEY1=updated1"))
+				g.Expect(string(content)).To(ContainSubstring("KEY2=updated2"))
+			},
+		},
+		{
+			name: "returns nil if params.env does not exist",
+			setupFS: func(fs afero.Fs) {
+				_ = fs.Mkdir("/component", 0755)
+			},
+			componentPath: "/component",
+			file:          "params.env",
+			expectedError: false,
+		},
+		{
+			name: "handles empty params.env file",
+			setupFS: func(fs afero.Fs) {
+				_ = fs.MkdirAll("/component", 0755)
+				_ = afero.WriteFile(fs, "/component/params.env", []byte(""), 0644)
+			},
+			componentPath: "/component",
+			file:          "params.env",
+			expectedError: false,
+		},
+		{
+			name: "combines env variables and extraParams",
+			setupFS: func(fs afero.Fs) {
+				_ = fs.MkdirAll("/component", 0755)
+				_ = afero.WriteFile(fs, "/component/params.env", []byte("IMAGE=old\nCONFIG=old\n"), 0644)
+			},
+			envGetter: func(key string) string {
+				if key == "RELATED_IMAGE" {
+					return "new-image"
+				}
+				return ""
+			},
+			componentPath:  "/component",
+			file:           "params.env",
+			imageParamsMap: map[string]string{"IMAGE": "RELATED_IMAGE"},
+			extraParams:    []map[string]string{{"CONFIG": "new-config"}},
+			expectedError:  false,
+			validateFS: func(g *GomegaWithT, fs afero.Fs) {
+				content, err := afero.ReadFile(fs, "/component/params.env")
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(string(content)).To(ContainSubstring("IMAGE=new-image"))
+				g.Expect(string(content)).To(ContainSubstring("CONFIG=new-config"))
+			},
+		},
+		{
+			name: "imageParamsMap key not in params.env - does not add new key",
+			setupFS: func(fs afero.Fs) {
+				_ = fs.MkdirAll("/component", 0755)
+				_ = afero.WriteFile(fs, "/component/params.env", []byte("EXISTING=value\n"), 0644)
+			},
+			envGetter: func(key string) string {
+				// Only return value for RELATED_IMAGE, not for empty string
+				if key == "RELATED_IMAGE" {
+					return "new-value"
+				}
+				return ""
+			},
+			componentPath:  "/component",
+			file:           "params.env",
+			imageParamsMap: map[string]string{"NONEXISTENT": "RELATED_IMAGE"},
+			expectedError:  false,
+			validateFS: func(g *GomegaWithT, fs afero.Fs) {
+				content, err := afero.ReadFile(fs, "/component/params.env")
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(string(content)).To(Equal("EXISTING=value\n"))
+				g.Expect(string(content)).NotTo(ContainSubstring("NONEXISTENT"))
+			},
+		},
+		{
+			name: "extraParams adds new key not in original file",
+			setupFS: func(fs afero.Fs) {
+				_ = fs.MkdirAll("/component", 0755)
+				_ = afero.WriteFile(fs, "/component/params.env", []byte("EXISTING=value\n"), 0644)
+			},
+			componentPath: "/component",
+			file:          "params.env",
+			extraParams:   []map[string]string{{"NEW_KEY": "new-value"}},
+			expectedError: false,
+			validateFS: func(g *GomegaWithT, fs afero.Fs) {
+				content, err := afero.ReadFile(fs, "/component/params.env")
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(string(content)).To(ContainSubstring("EXISTING=value"))
+				g.Expect(string(content)).To(ContainSubstring("NEW_KEY=new-value"))
+			},
+		},
+		{
+			name: "multiple extraParams maps - later overrides earlier",
+			setupFS: func(fs afero.Fs) {
+				_ = fs.MkdirAll("/component", 0755)
+				_ = afero.WriteFile(fs, "/component/params.env", []byte("KEY=original\n"), 0644)
+			},
+			componentPath: "/component",
+			file:          "params.env",
+			extraParams: []map[string]string{
+				{"KEY": "first"},
+				{"KEY": "second"},
+				{"KEY": "third"},
+			},
+			expectedError: false,
+			validateFS: func(g *GomegaWithT, fs afero.Fs) {
+				content, err := afero.ReadFile(fs, "/component/params.env")
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(string(content)).To(ContainSubstring("KEY=third"))
+			},
+		},
+		{
+			name: "params.env with lines without equals sign - ignored",
+			setupFS: func(fs afero.Fs) {
+				_ = fs.MkdirAll("/component", 0755)
+				_ = afero.WriteFile(fs, "/component/params.env", []byte("VALID=value\nINVALID_LINE\nANOTHER=test\n"), 0644)
+			},
+			componentPath: "/component",
+			file:          "params.env",
+			extraParams:   []map[string]string{{"VALID": "updated"}},
+			expectedError: false,
+			validateFS: func(g *GomegaWithT, fs afero.Fs) {
+				content, err := afero.ReadFile(fs, "/component/params.env")
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(string(content)).To(ContainSubstring("VALID=updated"))
+				g.Expect(string(content)).To(ContainSubstring("ANOTHER=test"))
+			},
+		},
+		{
+			name: "value contains equals sign - preserves full value",
+			setupFS: func(fs afero.Fs) {
+				_ = fs.MkdirAll("/component", 0755)
+				_ = afero.WriteFile(fs, "/component/params.env", []byte("URL=https://example.com?param=value\n"), 0644)
+			},
+			componentPath: "/component",
+			file:          "params.env",
+			expectedError: false,
+			validateFS: func(g *GomegaWithT, fs afero.Fs) {
+				content, err := afero.ReadFile(fs, "/component/params.env")
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(string(content)).To(Equal("URL=https://example.com?param=value\n"))
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+			memFs := afero.NewMemMapFs()
+
+			if tc.setupFS != nil {
+				tc.setupFS(memFs)
+			}
+
+			envGetter := tc.envGetter
+			if envGetter == nil {
+				envGetter = func(string) string { return "" }
+			}
+
+			applier := NewParamsApplier(
+				WithFS(memFs),
+				WithEnvGetter(envGetter),
+			)
+
+			err := applier.ApplyParams(tc.componentPath, tc.file, tc.imageParamsMap, tc.extraParams...)
+
+			if tc.expectedError {
+				g.Expect(err).To(HaveOccurred())
+				if tc.errorContains != "" {
+					g.Expect(err.Error()).To(ContainSubstring(tc.errorContains))
+				}
+			} else {
+				g.Expect(err).NotTo(HaveOccurred())
+			}
+
+			if tc.validateFS != nil {
+				tc.validateFS(g, memFs)
+			}
+		})
+	}
+}
+
+func TestParamsApplier_ApplyParamsWithFallback(t *testing.T) {
+	testCases := []struct {
+		name           string
+		setupFS        func(afero.Fs)               // Setup filesystem state
+		envGetter      func(string) string          // Mock environment variable getter
+		componentPath  string                       // Input: component path
+		overlayName    string                       // Input: overlay name (odh, rhoai)
+		imageParamsMap map[string]string            // Input: image params mapping
+		extraParams    []map[string]string          // Input: extra params maps
+		expectedPath   string                       // Expected: returned path
+		expectedError  bool                         // Expected: should return error
+		errorContains  string                       // Expected: error message contains
+		validateFS     func(*GomegaWithT, afero.Fs) // Validate filesystem state after
+	}{
+		{
+			name: "overlay exists - uses overlay",
+			setupFS: func(fs afero.Fs) {
+				_ = fs.MkdirAll("/component/overlays/odh", 0755)
+				_ = fs.MkdirAll("/component/base", 0755)
+				_ = afero.WriteFile(fs, "/component/overlays/odh/params.env", []byte("KEY=overlay\n"), 0644)
+				_ = afero.WriteFile(fs, "/component/base/params.env", []byte("KEY=base\n"), 0644)
+			},
+			componentPath: "/component",
+			overlayName:   "odh",
+			expectedPath:  "/component/overlays/odh/params.env",
+			expectedError: false,
+		},
+		{
+			name: "overlay missing, base exists - uses base",
+			setupFS: func(fs afero.Fs) {
+				_ = fs.MkdirAll("/component/base", 0755)
+				_ = afero.WriteFile(fs, "/component/base/params.env", []byte("KEY=base\n"), 0644)
+			},
+			componentPath: "/component",
+			overlayName:   "odh",
+			expectedPath:  "/component/base/params.env",
+			expectedError: false,
+		},
+		{
+			name: "both missing - returns error",
+			setupFS: func(fs afero.Fs) {
+				_ = fs.MkdirAll("/component", 0755)
+			},
+			componentPath: "/component",
+			overlayName:   "odh",
+			expectedError: true,
+			errorContains: "params.env not found",
+		},
+		{
+			name: "platform-specific params applied to overlay (odh)",
+			setupFS: func(fs afero.Fs) {
+				_ = fs.MkdirAll("/component/overlays/odh", 0755)
+				_ = afero.WriteFile(fs, "/component/overlays/odh/params.env", []byte("PLATFORM_VERSION=old\n"), 0644)
+			},
+			componentPath: "/component",
+			overlayName:   "odh",
+			extraParams: []map[string]string{
+				{"PLATFORM_VERSION": "2.0.0", "FIPS_ENABLED": "true"},
+			},
+			expectedPath:  "/component/overlays/odh/params.env",
+			expectedError: false,
+			validateFS: func(g *GomegaWithT, fs afero.Fs) {
+				content, err := afero.ReadFile(fs, "/component/overlays/odh/params.env")
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(string(content)).To(ContainSubstring("PLATFORM_VERSION=2.0.0"))
+				g.Expect(string(content)).To(ContainSubstring("FIPS_ENABLED=true"))
+			},
+		},
+		{
+			name: "platform-specific params applied to overlay (rhoai)",
+			setupFS: func(fs afero.Fs) {
+				_ = fs.MkdirAll("/component/overlays/rhoai", 0755)
+				_ = afero.WriteFile(fs, "/component/overlays/rhoai/params.env", []byte("PLATFORM_VERSION=old\n"), 0644)
+			},
+			componentPath: "/component",
+			overlayName:   "rhoai",
+			extraParams: []map[string]string{
+				{"PLATFORM_VERSION": "2.0.0"},
+			},
+			expectedPath:  "/component/overlays/rhoai/params.env",
+			expectedError: false,
+			validateFS: func(g *GomegaWithT, fs afero.Fs) {
+				content, err := afero.ReadFile(fs, "/component/overlays/rhoai/params.env")
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(string(content)).To(ContainSubstring("PLATFORM_VERSION=2.0.0"))
+			},
+		},
+		{
+			name: "applies params to base when overlay missing",
+			setupFS: func(fs afero.Fs) {
+				_ = fs.MkdirAll("/component/base", 0755)
+				_ = afero.WriteFile(fs, "/component/base/params.env", []byte("IMAGE=old\n"), 0644)
+			},
+			envGetter: func(key string) string {
+				if key == "RELATED_IMAGE" {
+					return "new-image"
+				}
+				return ""
+			},
+			componentPath:  "/component",
+			overlayName:    "odh",
+			imageParamsMap: map[string]string{"IMAGE": "RELATED_IMAGE"},
+			expectedPath:   "/component/base/params.env",
+			expectedError:  false,
+			validateFS: func(g *GomegaWithT, fs afero.Fs) {
+				content, err := afero.ReadFile(fs, "/component/base/params.env")
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(string(content)).To(ContainSubstring("IMAGE=new-image"))
+			},
+		},
+		{
+			name: "overlay dir exists but params.env missing - falls back to base",
+			setupFS: func(fs afero.Fs) {
+				_ = fs.MkdirAll("/component/overlays/odh", 0755)
+				_ = fs.MkdirAll("/component/base", 0755)
+				_ = afero.WriteFile(fs, "/component/base/params.env", []byte("KEY=base\n"), 0644)
+			},
+			componentPath: "/component",
+			overlayName:   "odh",
+			expectedPath:  "/component/base/params.env",
+			expectedError: false,
+		},
+		{
+			name: "base dir exists but params.env missing - returns error",
+			setupFS: func(fs afero.Fs) {
+				_ = fs.MkdirAll("/component/base", 0755)
+			},
+			componentPath: "/component",
+			overlayName:   "odh",
+			expectedError: true,
+			errorContains: "params.env not found",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+			memFs := afero.NewMemMapFs()
+
+			if tc.setupFS != nil {
+				tc.setupFS(memFs)
+			}
+
+			envGetter := tc.envGetter
+			if envGetter == nil {
+				envGetter = func(string) string { return "" }
+			}
+
+			applier := NewParamsApplier(
+				WithFS(memFs),
+				WithEnvGetter(envGetter),
+			)
+
+			path, err := applier.ApplyParamsWithFallback(
+				tc.componentPath, tc.overlayName, tc.imageParamsMap, tc.extraParams...)
+
+			if tc.expectedError {
+				g.Expect(err).To(HaveOccurred())
+				if tc.errorContains != "" {
+					g.Expect(err.Error()).To(ContainSubstring(tc.errorContains))
+				}
+			} else {
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(path).To(Equal(tc.expectedPath))
+			}
+
+			if tc.validateFS != nil {
+				tc.validateFS(g, memFs)
+			}
+		})
+	}
+}
+
+// errorFs wraps an afero.Fs and returns errors for specific paths on Stat calls.
+type errorFs struct {
+	afero.Fs
+
+	statErrorPath string
+	statError     error
+}
+
+func (e *errorFs) Stat(name string) (os.FileInfo, error) {
+	if name == e.statErrorPath {
+		return nil, e.statError
+	}
+	return e.Fs.Stat(name)
+}
+
+// Separate tests for I/O error cases that require custom filesystem wrappers.
+func TestApplyParamsWithFallback_OverlayStatIOError(t *testing.T) {
+	g := NewWithT(t)
+
+	baseFs := afero.NewMemMapFs()
+	_ = baseFs.MkdirAll("/component/overlays/odh", 0755)
+	_ = baseFs.MkdirAll("/component/base", 0755)
+	_ = afero.WriteFile(baseFs, "/component/base/params.env", []byte("KEY=base\n"), 0644)
+
+	errFs := &errorFs{
+		Fs:            baseFs,
+		statErrorPath: "/component/overlays/odh/params.env",
+		statError:     errors.New("permission denied"),
+	}
+
+	applier := NewParamsApplier(WithFS(errFs))
+
+	_, err := applier.ApplyParamsWithFallback("/component", "odh", nil)
+
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("failed to check overlay params file"))
+}


### PR DESCRIPTION

## Description
<!--- Describe your changes in detail -->
New unit tests that test business logic without filesystem dependencies.
- Add unit tests for `ApplyParams` and `ApplyParamsWithFallback` functions
- Add unit tests for `OverlayName` function in `pkg/cluster`

<!--- Link your JIRA and related links here for reference. -->
* https://issues.redhat.com/browse/RHOAIENG-37247
* https://issues.redhat.com/browse/RHOAIENG-44672

Related to #3096 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [ ] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->
