### PR TITLE
Add SparkPi workload test to SparkOperator e2e tests

### DIFF
--- a/pkg/cluster/gvk/gvk.go
+++ b/pkg/cluster/gvk/gvk.go
@@ -722,4 +722,10 @@ var (
 		Version: "v1",
 		Kind:    "ClusterIssuer",
 	}
+
+	SparkApplication = schema.GroupVersionKind{
+		Group:   "sparkoperator.k8s.io",
+		Version: "v1beta2",
+		Kind:    "SparkApplication",
+	}
 )

--- a/tests/e2e/sparkoperator_test.go
+++ b/tests/e2e/sparkoperator_test.go
@@ -3,9 +3,14 @@ package e2e_test
 import (
 	"testing"
 
+	"github.com/rs/xid"
 	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
 
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/api/components/v1alpha1"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/matchers/jq"
 )
 
 type SparkOperatorTestCtx struct {
@@ -28,10 +33,123 @@ func sparkOperatorTestSuite(t *testing.T) {
 		{"Validate operands have OwnerReferences", componentCtx.ValidateOperandsOwnerReferences},
 		{"Validate update operand resources", componentCtx.ValidateUpdateDeploymentsResources},
 		{"Validate component releases", componentCtx.ValidateComponentReleases},
+		{"Validate SparkPi workload execution", componentCtx.ValidateSparkPiWorkload},
 		{"Validate resource deletion recovery", componentCtx.ValidateAllDeletionRecovery},
 		{"Validate component disabled", componentCtx.ValidateComponentDisabled},
 	}
 
 	// Run the test suite.
 	RunTestCases(t, testCases)
+}
+
+// ValidateSparkPiWorkload validates that a SparkApplication can run successfully.
+func (tc *SparkOperatorTestCtx) ValidateSparkPiWorkload(t *testing.T) {
+	t.Helper()
+
+	// Use a unique name to avoid conflicts with previous test runs
+	sparkAppName := "spark-pi-" + xid.New().String()
+	// Run in the applications namespace where spark-operator-spark SA exists
+	namespace := tc.AppsNamespace
+
+	t.Logf("Creating SparkApplication %s in namespace %s", sparkAppName, namespace)
+	sparkApp := tc.createSparkPiApplication(sparkAppName, namespace)
+
+	tc.EventuallyResourceCreatedOrUpdated(
+		WithObjectToCreate(sparkApp),
+		WithCustomErrorMsg("Failed to create SparkApplication %s", sparkAppName),
+	)
+
+	// Cleanup SparkApplication after test
+	defer func() {
+		t.Logf("Cleaning up SparkApplication %s", sparkAppName)
+		tc.DeleteResource(
+			WithMinimalObject(gvk.SparkApplication, types.NamespacedName{Name: sparkAppName, Namespace: namespace}),
+			WithIgnoreNotFound(true),
+			WithWaitForDeletion(true),
+		)
+	}()
+
+	t.Logf("Waiting for SparkApplication %s to complete", sparkAppName)
+	tc.EnsureResourceExists(
+		WithMinimalObject(gvk.SparkApplication, types.NamespacedName{Name: sparkAppName, Namespace: namespace}),
+		WithCondition(
+			jq.Match(`.status.applicationState.state == "COMPLETED"`),
+		),
+		WithCustomErrorMsg("SparkApplication %s did not complete successfully", sparkAppName),
+		WithEventuallyTimeout(tc.TestTimeouts.longEventuallyTimeout),
+		WithEventuallyPollingInterval(tc.TestTimeouts.defaultEventuallyPollInterval),
+	)
+
+	t.Logf("SparkApplication %s completed successfully", sparkAppName)
+}
+
+// createSparkPiApplication creates a SparkApplication CR for spark-pi test.
+func (tc *SparkOperatorTestCtx) createSparkPiApplication(name, namespace string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "sparkoperator.k8s.io/v1beta2",
+			"kind":       "SparkApplication",
+			"metadata": map[string]interface{}{
+				"name":      name,
+				"namespace": namespace,
+			},
+			"spec": map[string]interface{}{
+				"type":                "Scala",
+				"mode":                "cluster",
+				"image":               "apache/spark:3.5.7-java17-python3",
+				"imagePullPolicy":     "IfNotPresent",
+				"mainClass":           "org.apache.spark.examples.SparkPi",
+				"mainApplicationFile": "local:///opt/spark/examples/jars/spark-examples_2.12-3.5.7.jar",
+				"arguments":           []interface{}{"1000"},
+				"sparkVersion":        "3.5.7",
+				"restartPolicy": map[string]interface{}{
+					"type": "Never",
+				},
+				"sparkConf": map[string]interface{}{
+					"spark.driver.port":              "8080",
+					"spark.driver.blockManager.port": "8082",
+					"spark.blockManager.port":        "8081",
+					"spark.port.maxRetries":          "0",
+				},
+				// Volume for OpenShift compatibility - provides writable work directory
+				"volumes": []interface{}{
+					map[string]interface{}{
+						"name":     "spark-work-dir",
+						"emptyDir": map[string]interface{}{},
+					},
+				},
+				"driver": map[string]interface{}{
+					"labels": map[string]interface{}{
+						"version": "3.5.7",
+					},
+					"cores":           int64(1),
+					"coreLimit":       "1200m",
+					"memory":          "512m",
+					"serviceAccount":  "spark-operator-spark",
+					"securityContext": map[string]interface{}{},
+					"volumeMounts": []interface{}{
+						map[string]interface{}{
+							"name":      "spark-work-dir",
+							"mountPath": "/opt/spark/work-dir",
+						},
+					},
+				},
+				"executor": map[string]interface{}{
+					"labels": map[string]interface{}{
+						"version": "3.5.7",
+					},
+					"instances":       int64(1),
+					"cores":           int64(1),
+					"memory":          "512m",
+					"securityContext": map[string]interface{}{},
+					"volumeMounts": []interface{}{
+						map[string]interface{}{
+							"name":      "spark-work-dir",
+							"mountPath": "/opt/spark/work-dir",
+						},
+					},
+				},
+			},
+		},
+	}
 }


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

This PR enhances the SparkOperator e2e test suite by adding a test that validates SparkApplication execution using the classic spark-pi example.

**Changes:**
- Add `SparkApplication` GVK to `pkg/cluster/gvk/gvk.go`
- Add `ValidateSparkPiWorkload` test case to `tests/e2e/sparkoperator_test.go` that:
  - Creates a SparkApplication running spark-pi (1000 iterations)
  - Uses `spark-operator-spark` ServiceAccount (already deployed by the operator)
  - Uses `apache/spark:3.5.7-java17-python3` image
  - Adds `emptyDir` volume for `/opt/spark/work-dir` (OpenShift compatibility - provides writable directory for Spark's JAR staging)
  - Waits for job completion with `COMPLETED` status
  - Cleans up SparkApplication after test

**Reference:** https://github.com/opendatahub-io/spark-operator/tree/main/examples/openshift

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

1. **Manual SparkApplication verification on OpenShift cluster:**
   - Deployed ODH operator with SparkOperator component enabled
   - Created SparkApplication with the test configuration
   - Verified status transitioned: `""` → `SUBMITTED` → `RUNNING` → `COMPLETED`
   - Confirmed driver logs showed: `Pi is roughly 3.1417145514171456`

2. **Build verification:**
   - Ran `go test -c ./tests/e2e/` to verify compilation succeeds

3. **Test environment:**
   - OpenShift cluster with ODH operator deployed
   - SparkOperator component in `Managed` state
   - `spark-operator-spark` ServiceAccount present in `opendatahub` namespace

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Recognize SparkApplication (Spark Operator v1beta2) so Spark workloads are supported.

* **Tests**
  * Added end-to-end SparkPi tests: deploy a Spark job, wait for completion, verify success, and clean up to ensure reliable SparkApplication behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->