### PR TITLE
RHOAIENG-47119: convert all resources to unstructured for client read

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -97,7 +97,7 @@ spec:
         # More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
         resources:
           limits:
-            cpu: 500m
+            cpu: 1000m
             memory: 4Gi
           requests:
             cpu: 100m

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -1,0 +1,180 @@
+package client
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+// UnstructuredClient wraps a controller-runtime client to use unstructured
+// resources for Get/List by default, with exemptions for specific GVKs.
+// This ensures a unified caching strategy where all non-exempted resources
+// go through the unstructured cache path.
+type Client struct {
+	inner client.Client
+}
+
+// Option configures the UnstructuredClient.
+type Option func(*Client)
+
+// New creates a new Client that wraps the given client.
+// By default, all Get/List operations use unstructured resources unless the GVK
+// is exempted via WithTypedGVKs.
+func New(inner client.Client, opts ...Option) *Client {
+	c := &Client{
+		inner: inner,
+	}
+	for _, opt := range opts {
+		opt(c)
+	}
+	return c
+}
+
+// Get retrieves an object for the given key.
+// To ensure consistent cache access:
+//   - If caller passes typed object: use unstructured for cache and return typed object
+//   - If caller passes unstructured: use unstructured for cache and return unstructured object
+func (c *Client) Get(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+	log := logf.FromContext(ctx)
+
+	gvk, err := apiutil.GVKForObject(obj, c.Scheme())
+	if err != nil {
+		return fmt.Errorf("failed to get GVK: %w", err)
+	}
+
+	_, isUnstructured := obj.(*unstructured.Unstructured)
+
+	switch {
+	case !isUnstructured:
+		// Caller passed typed → use unstructured for cache
+		log.V(1).Info("Client.Get: typed input, non-exempted GVK - using unstructured cache with conversion",
+			"gvk", gvk, "key", key, "inputType", "typed", "cacheType", "unstructured", "converted", true)
+		u := &unstructured.Unstructured{}
+		u.SetGroupVersionKind(gvk)
+		if err := c.inner.Get(ctx, key, u, opts...); err != nil {
+			return err
+		}
+		// Convert unstructured result back to typed
+		if err := runtime.DefaultUnstructuredConverter.FromUnstructured(u.Object, obj); err != nil {
+			return fmt.Errorf("failed to convert unstructured to typed: %w", err)
+		}
+		obj.GetObjectKind().SetGroupVersionKind(gvk)
+		return nil
+
+	default:
+		// No conversion needed - input type matches cache type
+		log.V(1).Info("Client.Get: no conversion needed - input type matches cache type",
+			"gvk", gvk, "key", key, "isUnstructured", isUnstructured, "converted", false)
+		return c.inner.Get(ctx, key, obj, opts...)
+	}
+}
+
+// List retrieves a list of objects.
+// To ensure consistent cache access:
+//   - If caller passes typed list: use unstructured for cache and return typed list
+//   - If caller passes unstructured list: use unstructured for cache and return unstructured list
+func (c *Client) List(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+	log := logf.FromContext(ctx)
+
+	gvk, err := apiutil.GVKForObject(list, c.Scheme())
+	if err != nil {
+		return fmt.Errorf("failed to get GVK for list: %w", err)
+	}
+
+	_, isUnstructuredList := list.(*unstructured.UnstructuredList)
+
+	switch {
+	case !isUnstructuredList:
+		// Caller passed typed list → use unstructured for cache
+		log.V(1).Info("Client.List: typed input, non-exempted GVK - using unstructured cache with conversion",
+			"gvk", gvk, "inputType", "typed", "cacheType", "unstructured", "converted", true)
+		ul := &unstructured.UnstructuredList{}
+		ul.SetGroupVersionKind(gvk)
+		if err := c.inner.List(ctx, ul, opts...); err != nil {
+			return err
+		}
+		// Convert unstructured result back to typed
+		if err := runtime.DefaultUnstructuredConverter.FromUnstructured(ul.UnstructuredContent(), list); err != nil {
+			return fmt.Errorf("failed to convert unstructured to typed: %w", err)
+		}
+		list.GetObjectKind().SetGroupVersionKind(gvk)
+		return nil
+
+	default:
+		// No conversion needed - input type matches cache type
+		log.V(1).Info("Client.List: no conversion needed - input type matches cache type",
+			"gvk", gvk, "isUnstructuredList", isUnstructuredList, "converted", false)
+		return c.inner.List(ctx, list, opts...)
+	}
+}
+
+// Create saves the object in the Kubernetes cluster.
+func (c *Client) Create(ctx context.Context, obj client.Object, opts ...client.CreateOption) error {
+	return c.inner.Create(ctx, obj, opts...)
+}
+
+// Delete deletes the given object from the Kubernetes cluster.
+func (c *Client) Delete(ctx context.Context, obj client.Object, opts ...client.DeleteOption) error {
+	return c.inner.Delete(ctx, obj, opts...)
+}
+
+// Update updates the given object in the Kubernetes cluster.
+func (c *Client) Update(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+	return c.inner.Update(ctx, obj, opts...)
+}
+
+// Patch patches the given object in the Kubernetes cluster.
+func (c *Client) Patch(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+	return c.inner.Patch(ctx, obj, patch, opts...)
+}
+
+// DeleteAllOf deletes all objects of the given type matching the given options.
+func (c *Client) DeleteAllOf(ctx context.Context, obj client.Object, opts ...client.DeleteAllOfOption) error {
+	return c.inner.DeleteAllOf(ctx, obj, opts...)
+}
+
+// Status returns a client for the status subresource.
+//
+//nolint:ireturn // Required by client.Client interface
+func (c *Client) Status() client.SubResourceWriter {
+	return c.inner.Status()
+}
+
+// SubResource returns a client for the named subresource.
+//
+//nolint:ireturn // Required by client.Client interface
+func (c *Client) SubResource(subResource string) client.SubResourceClient {
+	return c.inner.SubResource(subResource)
+}
+
+// Scheme returns the scheme this client is using.
+func (c *Client) Scheme() *runtime.Scheme {
+	return c.inner.Scheme()
+}
+
+// RESTMapper returns the REST mapper this client is using.
+//
+//nolint:ireturn // Required by client.Client interface
+func (c *Client) RESTMapper() meta.RESTMapper {
+	return c.inner.RESTMapper()
+}
+
+// GroupVersionKindFor returns the GroupVersionKind for the given object.
+func (c *Client) GroupVersionKindFor(obj runtime.Object) (schema.GroupVersionKind, error) {
+	return c.inner.GroupVersionKindFor(obj)
+}
+
+// IsObjectNamespaced returns true if the GroupVersionKind of the object is namespaced.
+func (c *Client) IsObjectNamespaced(obj runtime.Object) (bool, error) {
+	return c.inner.IsObjectNamespaced(obj)
+}
+
+// Ensure Client implements client.Client at compile time.
+var _ client.Client = (*Client)(nil)

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -1,0 +1,352 @@
+package client_test
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	opclient "github.com/opendatahub-io/opendatahub-operator/v2/pkg/client"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/fakeclient"
+
+	. "github.com/onsi/gomega"
+)
+
+// spyClient records what object types are passed to the inner client.
+// This is used to verify that the Client wrapper correctly converts
+// typed objects to unstructured before calling the inner client,
+// ensuring consistent cache usage and preventing the stale informer bug.
+type spyClient struct {
+	client.Client
+
+	getCalls  []client.Object
+	listCalls []client.ObjectList
+}
+
+func (s *spyClient) Get(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+	s.getCalls = append(s.getCalls, obj)
+	return s.Client.Get(ctx, key, obj, opts...)
+}
+
+func (s *spyClient) List(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+	s.listCalls = append(s.listCalls, list)
+	return s.Client.List(ctx, list, opts...)
+}
+
+func TestClient_Get_Typed(t *testing.T) {
+	// Test: Caller passes typed object → use unstructured for cache
+	g := NewWithT(t)
+
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-cm",
+			Namespace: "default",
+		},
+		Data: map[string]string{
+			"key": "value",
+		},
+	}
+
+	fakeClient, err := fakeclient.New(fakeclient.WithObjects(cm))
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	spy := &spyClient{Client: fakeClient}
+	wrappedClient := opclient.New(spy)
+
+	// Get as typed - should convert via unstructured internally
+	result := &corev1.ConfigMap{}
+	err = wrappedClient.Get(context.Background(), types.NamespacedName{Name: "test-cm", Namespace: "default"}, result)
+
+	g.Expect(err).ShouldNot(HaveOccurred())
+	g.Expect(result.Name).Should(Equal("test-cm"))
+	g.Expect(result.Namespace).Should(Equal("default"))
+	g.Expect(result.Data["key"]).Should(Equal("value"))
+
+	g.Expect(spy.getCalls).Should(HaveLen(1), "expected exactly one call to inner client")
+
+	// Verify the inner client received an unstructured object
+	_, isUnstructured := spy.getCalls[0].(*unstructured.Unstructured)
+	g.Expect(isUnstructured).Should(BeTrue(),
+		"expected unstructured object to be passed to inner client for cache consistency")
+}
+
+func TestClient_Get_Unstructured(t *testing.T) {
+	// Test: Caller passes unstructured → use unstructured directly (no conversion)
+	g := NewWithT(t)
+
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-cm",
+			Namespace: "default",
+		},
+		Data: map[string]string{
+			"key": "value",
+		},
+	}
+
+	fakeClient, err := fakeclient.New(fakeclient.WithObjects(cm))
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	spy := &spyClient{Client: fakeClient}
+
+	wrappedClient := opclient.New(spy)
+
+	// Get as unstructured - should use unstructured directly
+	result := &unstructured.Unstructured{}
+	result.SetGroupVersionKind(gvk.ConfigMap)
+	err = wrappedClient.Get(context.Background(), types.NamespacedName{Name: "test-cm", Namespace: "default"}, result)
+
+	g.Expect(err).ShouldNot(HaveOccurred())
+	g.Expect(result.GetName()).Should(Equal("test-cm"))
+
+	g.Expect(spy.getCalls).Should(HaveLen(1))
+
+	// Verify the inner client received the same unstructured object
+	passedObj, isUnstructured := spy.getCalls[0].(*unstructured.Unstructured)
+	g.Expect(isUnstructured).Should(BeTrue())
+	g.Expect(passedObj).Should(Equal(result), "unstructured input should pass through directly")
+}
+
+func TestClient_Get_NotFound(t *testing.T) {
+	// Test: Error propagation from inner client
+	g := NewWithT(t)
+
+	fakeClient, err := fakeclient.New()
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	wrappedClient := opclient.New(fakeClient)
+
+	result := &corev1.ConfigMap{}
+	err = wrappedClient.Get(context.Background(), types.NamespacedName{Name: "nonexistent", Namespace: "default"}, result)
+
+	g.Expect(err).Should(HaveOccurred())
+	g.Expect(err.Error()).Should(ContainSubstring("not found"))
+}
+
+func TestClient_List_Typed(t *testing.T) {
+	// Test: Caller passes typed list → use unstructured for cache
+	g := NewWithT(t)
+
+	cm1 := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-cm-1",
+			Namespace: "default",
+		},
+	}
+	cm2 := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-cm-2",
+			Namespace: "default",
+		},
+	}
+
+	fakeClient, err := fakeclient.New(fakeclient.WithObjects(cm1, cm2))
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	spy := &spyClient{Client: fakeClient}
+	wrappedClient := opclient.New(spy)
+
+	// List as typed - should convert via unstructured internally
+	result := &corev1.ConfigMapList{}
+	err = wrappedClient.List(context.Background(), result, client.InNamespace("default"))
+
+	g.Expect(err).ShouldNot(HaveOccurred())
+	g.Expect(result.Items).Should(HaveLen(2))
+	g.Expect(result.Items[0].GetName()).Should(Equal("test-cm-1"))
+	g.Expect(result.Items[1].GetName()).Should(Equal("test-cm-2"))
+
+	g.Expect(spy.listCalls).Should(HaveLen(1), "expected exactly one call to inner client")
+
+	// Verify the inner client received an unstructured list
+	_, isUnstructuredList := spy.listCalls[0].(*unstructured.UnstructuredList)
+	g.Expect(isUnstructuredList).Should(BeTrue(),
+		"expected unstructured list to be passed to inner client for cache consistency")
+}
+
+func TestClient_List_Unstructured(t *testing.T) {
+	// Test: Caller passes unstructured → use unstructured for cache
+	g := NewWithT(t)
+
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-cm",
+			Namespace: "default",
+		},
+		Data: map[string]string{
+			"key": "value",
+		},
+	}
+
+	fakeClient, err := fakeclient.New(fakeclient.WithObjects(cm))
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	spy := &spyClient{Client: fakeClient}
+	wrappedClient := opclient.New(spy)
+
+	// List as unstructured - should use unstructured directly
+	configMapGVK := schema.GroupVersionKind{
+		Group:   "",
+		Version: "v1",
+		Kind:    "ConfigMapList",
+	}
+	result := &unstructured.UnstructuredList{}
+	result.SetGroupVersionKind(configMapGVK)
+	err = wrappedClient.List(context.Background(), result, client.InNamespace("default"))
+
+	g.Expect(err).ShouldNot(HaveOccurred())
+	g.Expect(result.Items).Should(HaveLen(1))
+	g.Expect(result.Items[0].GetName()).Should(Equal("test-cm"))
+
+	g.Expect(spy.listCalls).Should(HaveLen(1), "expected exactly one call to inner client")
+
+	// Verify the inner client received an unstructured list
+	_, isUnstructuredList := spy.listCalls[0].(*unstructured.UnstructuredList)
+	g.Expect(isUnstructuredList).Should(BeTrue(),
+		"expected unstructured list to be passed to inner client for cache consistency")
+}
+
+func TestClient_Create_Delegates(t *testing.T) {
+	g := NewWithT(t)
+
+	fakeClient, err := fakeclient.New()
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	wrappedClient := opclient.New(fakeClient)
+
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "new-cm",
+			Namespace: "default",
+		},
+	}
+
+	err = wrappedClient.Create(context.Background(), cm)
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	// Verify it was created
+	result := &corev1.ConfigMap{}
+	err = wrappedClient.Get(context.Background(), types.NamespacedName{Name: "new-cm", Namespace: "default"}, result)
+	g.Expect(err).ShouldNot(HaveOccurred())
+	g.Expect(result.Name).Should(Equal("new-cm"))
+}
+
+func TestClient_Update_Delegates(t *testing.T) {
+	// Test: Update operation delegates to inner client
+	g := NewWithT(t)
+
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-cm",
+			Namespace: "default",
+		},
+		Data: map[string]string{
+			"key": "original",
+		},
+	}
+
+	fakeClient, err := fakeclient.New(fakeclient.WithObjects(cm))
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	wrappedClient := opclient.New(fakeClient)
+
+	// Get and update
+	toUpdate := &corev1.ConfigMap{}
+	err = wrappedClient.Get(context.Background(), types.NamespacedName{Name: "test-cm", Namespace: "default"}, toUpdate)
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	toUpdate.Data["key"] = "updated"
+	err = wrappedClient.Update(context.Background(), toUpdate)
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	// Verify update
+	result := &corev1.ConfigMap{}
+	err = wrappedClient.Get(context.Background(), types.NamespacedName{Name: "test-cm", Namespace: "default"}, result)
+	g.Expect(err).ShouldNot(HaveOccurred())
+	g.Expect(result.Data["key"]).Should(Equal("updated"))
+}
+
+func TestClient_Delete_Delegates(t *testing.T) {
+	// Test: Delete operation delegates to inner client
+	g := NewWithT(t)
+
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-cm",
+			Namespace: "default",
+		},
+	}
+
+	fakeClient, err := fakeclient.New(fakeclient.WithObjects(cm))
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	wrappedClient := opclient.New(fakeClient)
+
+	err = wrappedClient.Delete(context.Background(), cm)
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	// Verify deletion
+	result := &corev1.ConfigMap{}
+	err = wrappedClient.Get(context.Background(), types.NamespacedName{Name: "test-cm", Namespace: "default"}, result)
+	g.Expect(err).Should(HaveOccurred())
+	g.Expect(err.Error()).Should(ContainSubstring("not found"))
+}
+
+func TestClient_MetadataPreserved(t *testing.T) {
+	// Test: Metadata like ResourceVersion, UID are preserved during conversion
+	g := NewWithT(t)
+
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "test-cm",
+			Namespace:       "default",
+			UID:             "test-uid-123",
+			ResourceVersion: "12345",
+			Labels: map[string]string{
+				"app": "test",
+			},
+			Annotations: map[string]string{
+				"note": "important",
+			},
+		},
+		Data: map[string]string{
+			"key": "value",
+		},
+	}
+
+	fakeClient, err := fakeclient.New(fakeclient.WithObjects(cm))
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	// Create wrapped client with NO exemptions (will convert via unstructured)
+	wrappedClient := opclient.New(fakeClient)
+
+	result := &corev1.ConfigMap{}
+	err = wrappedClient.Get(context.Background(), types.NamespacedName{Name: "test-cm", Namespace: "default"}, result)
+
+	g.Expect(err).ShouldNot(HaveOccurred())
+	g.Expect(string(result.UID)).Should(Equal("test-uid-123"))
+	g.Expect(result.ResourceVersion).Should(Equal("12345"))
+	g.Expect(result.Labels["app"]).Should(Equal("test"))
+	g.Expect(result.Annotations["note"]).Should(Equal("important"))
+}
+
+func TestClient_Scheme(t *testing.T) {
+	g := NewWithT(t)
+
+	fakeClient, err := fakeclient.New()
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	wrappedClient := opclient.New(fakeClient)
+
+	g.Expect(wrappedClient.Scheme()).Should(Equal(fakeClient.Scheme()))
+}
+
+func TestClient_ImplementsClientInterface(t *testing.T) {
+	// Compile-time check that UnstructuredClient implements client.Client
+	var _ client.Client = (*opclient.Client)(nil)
+}

--- a/pkg/cluster/gvk/gvk.go
+++ b/pkg/cluster/gvk/gvk.go
@@ -345,6 +345,12 @@ var (
 		Kind:    componentApi.SparkOperatorKind,
 	}
 
+	ModelsAsService = schema.GroupVersionKind{
+		Group:   componentApi.GroupVersion.Group,
+		Version: componentApi.GroupVersion.Version,
+		Kind:    componentApi.ModelsAsServiceKind,
+	}
+
 	CustomResourceDefinition = schema.GroupVersionKind{
 		Group:   "apiextensions.k8s.io",
 		Version: "v1",
@@ -679,5 +685,11 @@ var (
 		Group:   "mlflow.opendatahub.io",
 		Version: "v1",
 		Kind:    "MLflow",
+	}
+
+	PersistentVolumeClaim = schema.GroupVersionKind{
+		Group:   corev1.SchemeGroupVersion.Group,
+		Version: corev1.SchemeGroupVersion.Version,
+		Kind:    "PersistentVolumeClaim",
 	}
 )

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -1,0 +1,34 @@
+package manager
+
+import (
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	opclient "github.com/opendatahub-io/opendatahub-operator/v2/pkg/client"
+)
+
+// Manager wraps a controller-runtime manager to return a custom client
+// from GetClient(). This allows replacing the default client with a
+// wrapped client (e.g., UnstructuredClient) while preserving all other
+// manager functionality.
+type Manager struct {
+	manager.Manager
+
+	wrappedClient *opclient.Client
+}
+
+// New creates a new Manager that wraps the given manager and
+// returns the wrapped client from GetClient().
+func New(mgr manager.Manager) *Manager {
+	wrappedClient := opclient.New(mgr.GetClient())
+
+	return &Manager{
+		Manager:       mgr,
+		wrappedClient: wrappedClient,
+	}
+}
+
+// GetClient returns the wrapped client instead of the default manager client.
+func (m *Manager) GetClient() client.Client {
+	return m.wrappedClient
+}

--- a/pkg/manager/manager_test.go
+++ b/pkg/manager/manager_test.go
@@ -1,0 +1,61 @@
+package manager_test
+
+import (
+	"testing"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlmanager "sigs.k8s.io/controller-runtime/pkg/manager"
+
+	opclient "github.com/opendatahub-io/opendatahub-operator/v2/pkg/client"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/manager"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/fakeclient"
+
+	. "github.com/onsi/gomega"
+)
+
+// mockManager implements manager.Manager interface for testing.
+// Embeds ctrlmanager.Manager to satisfy the interface; only methods needed by tests are implemented.
+//
+
+type mockManager struct {
+	ctrlmanager.Manager
+
+	client client.Client
+}
+
+func (m *mockManager) GetClient() client.Client {
+	return m.client
+}
+
+func TestNew_CreatesManagerWithWrappedClient(t *testing.T) {
+	g := NewWithT(t)
+
+	fakeClient, err := fakeclient.New()
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	mockMgr := &mockManager{client: fakeClient}
+	wrappedMgr := manager.New(mockMgr)
+
+	g.Expect(wrappedMgr).ShouldNot(BeNil())
+}
+
+func TestGetClient_ReturnsWrappedClient(t *testing.T) {
+	g := NewWithT(t)
+
+	fakeClient, err := fakeclient.New()
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	mockMgr := &mockManager{client: fakeClient}
+	wrappedMgr := manager.New(mockMgr)
+
+	returnedClient := wrappedMgr.GetClient()
+
+	// It should be an *opclient.Client
+	_, ok := returnedClient.(*opclient.Client)
+	g.Expect(ok).Should(BeTrue(), "GetClient should return *opclient.Client")
+}
+
+func TestManager_ImplementsManagerInterface(t *testing.T) {
+	// Compile-time check that Manager implements manager.Manager interface
+	var _ ctrlmanager.Manager = (*manager.Manager)(nil)
+}

--- a/tests/e2e/modelsasservice_test.go
+++ b/tests/e2e/modelsasservice_test.go
@@ -50,11 +50,9 @@ func modelsAsServiceTestSuite(t *testing.T) {
 	testCases := []TestCase{
 		{"Validate subcomponent enabled", componentCtx.ValidateSubComponentEnabled},
 		{"Validate operands have OwnerReferences", componentCtx.ValidateOperandsOwnerReferences},
-		// TODO: Re-enable after https://issues.redhat.com/browse/RHOAIENG-47119 resolved
-		// {"Validate update operand resources", componentCtx.ValidateUpdateDeploymentsResources},
+		{"Validate update operand resources", componentCtx.ValidateUpdateDeploymentsResources},
 		{"Validate subcomponent releases", componentCtx.ValidateSubComponentReleases},
-		// TODO: Re-enable after https://issues.redhat.com/browse/RHOAIENG-47119 resolved
-		// {"Validate resource deletion recovery", componentCtx.ValidateAllDeletionRecovery},
+		{"Validate resource deletion recovery", componentCtx.ValidateAllDeletionRecovery},
 		{"Validate subcomponent disabled", componentCtx.ValidateSubComponentDisabled},
 	}
 


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
Create a read client to override the Get/List methods to always use unstructured resources, keeping coherence with the resource type used during invocation:
- if user reads using unstructured resources, it uses unstructured to perform the call and returns unstructured
- if user reads using typed resources, it uses unstructured to perform the call and returns typed resources (here there is the conversion)

Also, all watches/owns/for of the manager are changed to always use unstructured resources.

Jira task: https://issues.redhat.com/browse/RHOAIENG-47119

### Performance

Before the update, I checked the used resources running e2e tests. 

#### Baseline

```
  ┌─────────────────┬──────────────┬──────────────┬──────────────┬──────────────┬──────────────┐
  │ Metric          │ Min          │ Max          │ Average      │ Std Dev      │ Std Error    │
  ├─────────────────┼──────────────┼──────────────┼──────────────┼──────────────┼──────────────┤
  │ CPU (cores)     │ 0.0030       │ 0.4990       │ 0.0689       │ 0.0944       │ 0.0078       │
  │ Memory          │ 719.00Mi     │ 1.54Gi       │ 1.17Gi       │ 163.38Mi     │ 13.52Mi      │
  └─────────────────┴──────────────┴──────────────┴──────────────┴──────────────┴──────────────┘
  Configured limits: CPU=500m, Memory=4Gi
  Data points: 146
```

and upgrade CPU limits since it goes close to the limit:

```
  ┌─────────────────┬──────────────┬──────────────┬──────────────┬──────────────┬──────────────┐
  │ Metric          │ Min          │ Max          │ Average      │ Std Dev      │ Std Error    │
  ├─────────────────┼──────────────┼──────────────┼──────────────┼──────────────┼──────────────┤
  │ CPU (cores)     │ 0.0020       │ 0.7770       │ 0.0800       │ 0.1029       │ 0.0066       │
  │ Memory          │ 812.00Mi     │ 1.49Gi       │ 1.13Gi       │ 116.63Mi     │ 7.44Mi       │
  └─────────────────┴──────────────┴──────────────┴──────────────┴──────────────┴──────────────┘
  Configured limits: CPU=1, Memory=4Gi
  Data points: 246
```

#### Only unstructured

```
  ┌─────────────────┬──────────────┬──────────────┬──────────────┬──────────────┬──────────────┐
  │ Metric          │ Min          │ Max          │ Average      │ Std Dev      │ Std Error    │
  ├─────────────────┼──────────────┼──────────────┼──────────────┼──────────────┼──────────────┤
  │ CPU (cores)     │ 0.0020       │ 0.8540       │ 0.0763       │ 0.1135       │ 0.0084       │
  │ Memory          │ 493.00Mi     │ 1.10Gi       │ 807.37Mi     │ 84.15Mi      │ 6.24Mi       │
  └─────────────────┴──────────────┴──────────────┴──────────────┴──────────────┴──────────────┘
  Configured limits: CPU=1, Memory=4Gi
  Data points: 182
```

As showed in those tests, it seems that there is decreased usage of memory, and the usage of cpu remains at the same level.

### Future possible improvements

1. Only use `OwnsGVK` and `WatchesGVK` in controller, to uniform the definition (since now under the hood unstructured is always used)
2. Update predicates to first check unstructured resources (or also remove typed support)

## How Has This Been Tested?
Running e2e tests. Uncomment MaaS tests with high failure rate due to the stale cache issue.

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [x] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
3. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
4. Check the checkbox below:
- [ ] Skip requirement to update E2E test suite for this PR
5. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Wrapped manager and client provide unified unstructured caching and allow registering watches/ownerships by resource kind (GVK).
  * Added additional known resource kinds to GVK mappings.

* **Tests**
  * Comprehensive unit tests for the wrapper client and reconciler watch behavior.
  * Re-enabled end-to-end tests for models-as-service.

* **Chores**
  * Increased manager container CPU limit from 500m to 1000m.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->