### PR TITLE
[RHOAIENG-49069] Refactor hardware profile resource application logic for Notebooks

### DIFF
--- a/internal/webhook/envtestutil/envtestutil.go
+++ b/internal/webhook/envtestutil/envtestutil.go
@@ -595,7 +595,7 @@ func NewLLMInferenceService(name, namespace string, opts ...ObjectOption) client
 	// this is set in case HWprofile require resource changes, it is not necessary for Connection API
 	containers := []interface{}{
 		map[string]interface{}{
-			"name":  "llm-container",
+			"name":  "main",
 			"image": "kserve/llm-container:latest",
 		},
 	}


### PR DESCRIPTION
## Description
https://issues.redhat.com/browse/RHOAIENG-49069

- Update resource injection logic to apply resources only to the main container in Notebooks, excluding sidecars.
- Introduce a new function to determine the main container indices for resource application.
- Enhance tests to cover scenarios where multiple containers exist, ensuring correct behavior when no container matches the Notebook name.
- Adjust error handling and logging for better clarity during resource application failures.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->
E2E Test Suite Update Justification
The existing E2E test suite in `tests/e2e/hardwareprofile_test.go` already provides comprehensive coverage for the changes in this PR:

Existing E2E Coverage:
- Hardware Profile E2E Tests validate version conversion (v1alpha1 ↔ v1)
- Hardware Profile Workload E2E Tests validate resource application behavior across 6 scenarios:
  - Toleration handling
  - Kueue scheduling with local queues
  - Annotation removal when profiles are removed
  - Manual toleration preservation
  - Profile switching
  - Kueue label cleanup

**Why No New E2E Tests Required:**
This PR refines the container selection logic for Notebooks (applying resources to main container only, excluding sidecars) and clarifies resource limit semantics (DefaultCount for GPU requests/limits, MaxCount for standard resource limits). The existing workload E2E tests already validate that hardware profile resources are correctly applied to workloads, including the exact behavior this PR implements.

**Verification:**
All 54 E2E tests (including the 6 Hardware Profile Workload tests) passed successfully on a live cluster with these changes deployed, confirming that the refactored logic maintains the expected end-to-end behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Resource injection now targets only the main application container for notebooks and LLM services; sidecars are skipped.
  * Context-aware handling ensures resource application is more precise and supports injecting into workloads that lack explicit containers.

* **Bug Fixes**
  * Validation mismatches emit non-blocking warnings instead of rejecting workloads.
  * Limits semantics refined: extended devices mirror requests; CPU/memory limits use explicit max when provided.

* **Tests**
  * Expanded tests covering container targeting, warning behavior, and mixed-resource limit scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->