### PR TITLE
e2e: Improve test functions to avoid overriding global timeout

### DIFF
--- a/tests/e2e/resource_applier_test.go
+++ b/tests/e2e/resource_applier_test.go
@@ -200,7 +200,9 @@ func eventuallyResourceApplied(
 	// Use Eventually to retry getting the resource until it appears
 	var u *unstructured.Unstructured
 
-	ro.tc.g.Eventually(ensureResourceAppliedGomegaFunction(ro, &u, applyResourceFn)).Should(Succeed())
+	eventually := ro.tc.g.Eventually(ensureResourceAppliedGomegaFunction(ro, &u, applyResourceFn))
+
+	ro.applyEventuallyTimeouts(eventually).Should(Succeed())
 
 	return u
 }
@@ -227,14 +229,18 @@ func consistentlyResourceApplied(
 	// If a mutation function is provided, apply it ONCE first using Eventually
 	if ro.MutateFunc != nil {
 		// Apply the mutation once and wait for it to succeed
-		ro.tc.g.Eventually(ensureResourceAppliedGomegaFunction(ro, &u, applyResourceFn)).Should(Succeed())
+		eventually := ro.tc.g.Eventually(ensureResourceAppliedGomegaFunction(ro, &u, applyResourceFn))
+
+		ro.applyEventuallyTimeouts(eventually).Should(Succeed())
 
 		// Clear the mutation function to avoid re-applying it during consistency checks
 		ro.MutateFunc = nil
 	}
 
 	// Use Consistently to verify the resource condition remains stable over time (read-only)
-	ro.tc.g.Consistently(ensureResourceAppliedGomegaFunction(ro, &u, applyResourceFn)).Should(Succeed())
+	consistently := ro.tc.g.Consistently(ensureResourceAppliedGomegaFunction(ro, &u, applyResourceFn))
+
+	ro.applyConsistentlyTimeouts(consistently).Should(Succeed())
 
 	return u
 }


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
Changed how e2e helper functions for eventually/consistently manage the timeout, to update it only for the specific assertion, avoiding to set it as default for the test suite.

Jira task: https://issues.redhat.com/browse/RHOAIENG-49132

## How Has This Been Tested?
Run e2e tests locally

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [x] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [ ] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added per-operation timeout and polling controls for assertion checks, enabling per-check customization.
  * Test flows now route assertions through these per-operation controls instead of mutating global test settings, improving isolation.
  * Assertion wrappers are used consistently for creation, deletion, mutation, and consistency checks to honor per-operation timing.
  * No public test APIs were changed; behavior and error semantics remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->