### PR TITLE
ensure tls setting is correct in monitoring when false in dsci

### DIFF
--- a/internal/controller/dscinitialization/dscinitialization_controller.go
+++ b/internal/controller/dscinitialization/dscinitialization_controller.go
@@ -533,6 +533,10 @@ func (r *DSCInitializationReconciler) newMonitoringCR(ctx context.Context, dsci 
 
 	if tracesEnabled {
 		defaultMonitoring.Spec.Traces = dsci.Spec.Monitoring.Traces
+		// Without this, when TLS.Enabled is false, the TLS struct is not removed from the Monitoring CR and it causes an error.
+		if defaultMonitoring.Spec.Traces.TLS != nil && !defaultMonitoring.Spec.Traces.TLS.Enabled {
+			defaultMonitoring.Spec.Traces.TLS = nil
+		}
 	} else {
 		defaultMonitoring.Spec.Traces = nil
 	}


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->
The omitempty tag on TracesTLS.Enabled causes false to be omitted during JSON serialization, preventing server-side apply from updating the field. This fix nils out the TLS struct when disabled, which is semantically equivalent and properly removes the field.
<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- Deploy operator and monitoring requirements.
- Enable traces.
- Set traces.tls to `enabled: true`.
- Set traces.tls to `enabled: false`.
- Verify that the traces.tls field is correctly removed from the monitoring CR.

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [x] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->
This change fixes an edge case where a user may turn tls on and then off. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a configuration handling issue in trace monitoring where disabled TLS settings could persist in the Monitoring CR and potentially cause errors. The system now properly clears and removes inactive TLS configurations during trace monitoring initialization, preventing configuration-related failures and ensuring more reliable and stable monitoring operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->