### PR TITLE
RHOAIENG-48771: add Kueue managementState validation webhook for DSC v2

### DIFF
--- a/internal/webhook/datasciencecluster/v1/validating_test.go
+++ b/internal/webhook/datasciencecluster/v1/validating_test.go
@@ -3,11 +3,13 @@ package v1_test
 import (
 	"testing"
 
+	operatorv1 "github.com/openshift/api/operator/v1"
 	admissionv1 "k8s.io/api/admission/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
+	dscv1 "github.com/opendatahub-io/opendatahub-operator/v2/api/datasciencecluster/v1"
 	v1webhook "github.com/opendatahub-io/opendatahub-operator/v2/internal/webhook/datasciencecluster/v1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/internal/webhook/envtestutil"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
@@ -18,11 +20,22 @@ import (
 )
 
 // TestDataScienceClusterV1_ValidatingWebhook exercises the validating webhook logic for DataScienceCluster v1 resources.
-// It verifies singleton enforcement and deletion rules using table-driven tests and a fake client.
+// It verifies singleton enforcement, deletion rules, and Kueue managementState validation using table-driven tests and a fake client.
 func TestDataScienceClusterV1_ValidatingWebhook(t *testing.T) {
 	t.Parallel()
-	g := NewWithT(t)
 	ctx := t.Context()
+
+	gvr := metav1.GroupVersionResource{
+		Group:    gvk.DataScienceClusterV1.Group,
+		Version:  gvk.DataScienceClusterV1.Version,
+		Resource: "datascienceclusters",
+	}
+
+	withKueueState := func(state operatorv1.ManagementState) func(*dscv1.DataScienceCluster) {
+		return func(dsc *dscv1.DataScienceCluster) {
+			dsc.Spec.Components.Kueue.ManagementState = state
+		}
+	}
 
 	cases := []struct {
 		name         string
@@ -30,54 +43,60 @@ func TestDataScienceClusterV1_ValidatingWebhook(t *testing.T) {
 		req          admission.Request
 		allowed      bool
 	}{
+		// Singleton and deletion cases
 		{
 			name:         "Allows creation if none exist",
 			existingObjs: nil,
-			req: envtestutil.NewAdmissionRequest(
-				t,
-				admissionv1.Create,
-				envtestutil.NewDSCV1("test-create"),
-				gvk.DataScienceClusterV1,
-				metav1.GroupVersionResource{
-					Group:    gvk.DataScienceClusterV1.Group,
-					Version:  gvk.DataScienceClusterV1.Version,
-					Resource: "datascienceclusters",
-				},
-			),
-			allowed: true,
+			req:          envtestutil.NewAdmissionRequest(t, admissionv1.Create, envtestutil.NewDSCV1("test-create"), gvk.DataScienceClusterV1, gvr),
+			allowed:      true,
 		},
 		{
-			name: "Denies creation if one already exists",
-			existingObjs: []client.Object{
-				envtestutil.NewDSC("existing"),
-			},
-			req: envtestutil.NewAdmissionRequest(
-				t,
-				admissionv1.Create,
-				envtestutil.NewDSCV1("test-create"),
-				gvk.DataScienceClusterV1,
-				metav1.GroupVersionResource{
-					Group:    gvk.DataScienceClusterV1.Group,
-					Version:  gvk.DataScienceClusterV1.Version,
-					Resource: "datascienceclusters",
-				},
-			),
-			allowed: false,
+			name:         "Denies creation if one already exists",
+			existingObjs: []client.Object{envtestutil.NewDSCV1("existing")},
+			req:          envtestutil.NewAdmissionRequest(t, admissionv1.Create, envtestutil.NewDSCV1("test-create"), gvk.DataScienceClusterV1, gvr),
+			allowed:      false,
 		},
 		{
 			name:         "Allows deletion always",
 			existingObjs: nil,
-			req: envtestutil.NewAdmissionRequest(
-				t,
-				admissionv1.Delete,
-				envtestutil.NewDSCV1("test-delete"),
-				gvk.DataScienceClusterV1,
-				metav1.GroupVersionResource{
-					Group:    gvk.DataScienceClusterV1.Group,
-					Version:  gvk.DataScienceClusterV1.Version,
-					Resource: "datascienceclusters",
-				},
-			),
+			req:          envtestutil.NewAdmissionRequest(t, admissionv1.Delete, envtestutil.NewDSCV1("test-delete"), gvk.DataScienceClusterV1, gvr),
+			allowed:      true,
+		},
+
+		// Kueue managementState validation cases
+		{
+			name:    "Denies create with Kueue Managed",
+			req:     envtestutil.NewAdmissionRequest(t, admissionv1.Create, envtestutil.NewDSCV1("test", withKueueState(operatorv1.Managed)), gvk.DataScienceClusterV1, gvr),
+			allowed: false,
+		},
+		{
+			name:    "Allows create with Kueue Unmanaged",
+			req:     envtestutil.NewAdmissionRequest(t, admissionv1.Create, envtestutil.NewDSCV1("test", withKueueState(operatorv1.Unmanaged)), gvk.DataScienceClusterV1, gvr),
+			allowed: true,
+		},
+		{
+			name:    "Allows create with Kueue Removed",
+			req:     envtestutil.NewAdmissionRequest(t, admissionv1.Create, envtestutil.NewDSCV1("test", withKueueState(operatorv1.Removed)), gvk.DataScienceClusterV1, gvr),
+			allowed: true,
+		},
+		{
+			name:    "Denies update with Kueue Managed",
+			req:     envtestutil.NewAdmissionRequest(t, admissionv1.Update, envtestutil.NewDSCV1("test", withKueueState(operatorv1.Managed)), gvk.DataScienceClusterV1, gvr),
+			allowed: false,
+		},
+		{
+			name:    "Allows update with Kueue Unmanaged",
+			req:     envtestutil.NewAdmissionRequest(t, admissionv1.Update, envtestutil.NewDSCV1("test", withKueueState(operatorv1.Unmanaged)), gvk.DataScienceClusterV1, gvr),
+			allowed: true,
+		},
+		{
+			name:    "Allows update with Kueue Removed",
+			req:     envtestutil.NewAdmissionRequest(t, admissionv1.Update, envtestutil.NewDSCV1("test", withKueueState(operatorv1.Removed)), gvk.DataScienceClusterV1, gvr),
+			allowed: true,
+		},
+		{
+			name:    "Allows delete with Kueue Managed",
+			req:     envtestutil.NewAdmissionRequest(t, admissionv1.Delete, envtestutil.NewDSCV1("test", withKueueState(operatorv1.Managed)), gvk.DataScienceClusterV1, gvr),
 			allowed: true,
 		},
 	}
@@ -85,6 +104,7 @@ func TestDataScienceClusterV1_ValidatingWebhook(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
+			g := NewWithT(t)
 			objs := append([]client.Object{}, tc.existingObjs...)
 			objs = append(objs, envtestutil.NewDSCIV1("dsci-for-dsc"))
 			sch, err := scheme.New()

--- a/internal/webhook/datasciencecluster/v2/register.go
+++ b/internal/webhook/datasciencecluster/v2/register.go
@@ -4,14 +4,16 @@ package v2
 
 import (
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
 // RegisterWebhooks registers the webhooks for DataScienceCluster v2.
 func RegisterWebhooks(mgr ctrl.Manager) error {
 	// Register the validating webhook
 	if err := (&Validator{
-		Client: mgr.GetAPIReader(),
-		Name:   "datasciencecluster-v2-validating",
+		Client:  mgr.GetAPIReader(),
+		Name:    "datasciencecluster-v2-validating",
+		Decoder: admission.NewDecoder(mgr.GetScheme()),
 	}).SetupWithManager(mgr); err != nil {
 		return err
 	}

--- a/internal/webhook/datasciencecluster/v2/validating_test.go
+++ b/internal/webhook/datasciencecluster/v2/validating_test.go
@@ -3,25 +3,39 @@ package v2_test
 import (
 	"testing"
 
+	operatorv1 "github.com/openshift/api/operator/v1"
 	admissionv1 "k8s.io/api/admission/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
+	dscv2 "github.com/opendatahub-io/opendatahub-operator/v2/api/datasciencecluster/v2"
 	v2webhook "github.com/opendatahub-io/opendatahub-operator/v2/internal/webhook/datasciencecluster/v2"
 	"github.com/opendatahub-io/opendatahub-operator/v2/internal/webhook/envtestutil"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/fakeclient"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/scheme"
 
 	. "github.com/onsi/gomega"
 )
 
 // TestDataScienceClusterV2_ValidatingWebhook exercises the validating webhook logic for DataScienceCluster v2 resources.
-// It verifies singleton enforcement and deletion rules using table-driven tests and a fake client.
+// It verifies singleton enforcement, deletion rules, and Kueue managementState validation using table-driven tests and a fake client.
 func TestDataScienceClusterV2_ValidatingWebhook(t *testing.T) {
 	t.Parallel()
-	g := NewWithT(t)
 	ctx := t.Context()
+
+	gvr := metav1.GroupVersionResource{
+		Group:    gvk.DataScienceCluster.Group,
+		Version:  gvk.DataScienceCluster.Version,
+		Resource: "datascienceclusters",
+	}
+
+	withKueueState := func(state operatorv1.ManagementState) func(*dscv2.DataScienceCluster) {
+		return func(dsc *dscv2.DataScienceCluster) {
+			dsc.Spec.Components.Kueue.ManagementState = state
+		}
+	}
 
 	cases := []struct {
 		name         string
@@ -29,54 +43,60 @@ func TestDataScienceClusterV2_ValidatingWebhook(t *testing.T) {
 		req          admission.Request
 		allowed      bool
 	}{
+		// Singleton and deletion cases
 		{
 			name:         "Allows creation if none exist",
 			existingObjs: nil,
-			req: envtestutil.NewAdmissionRequest(
-				t,
-				admissionv1.Create,
-				envtestutil.NewDSC("test-create"),
-				gvk.DataScienceCluster,
-				metav1.GroupVersionResource{
-					Group:    gvk.DataScienceCluster.Group,
-					Version:  gvk.DataScienceCluster.Version,
-					Resource: "datascienceclusters",
-				},
-			),
-			allowed: true,
+			req:          envtestutil.NewAdmissionRequest(t, admissionv1.Create, envtestutil.NewDSC("test-create"), gvk.DataScienceCluster, gvr),
+			allowed:      true,
 		},
 		{
-			name: "Denies creation if one already exists",
-			existingObjs: []client.Object{
-				envtestutil.NewDSC("existing"),
-			},
-			req: envtestutil.NewAdmissionRequest(
-				t,
-				admissionv1.Create,
-				envtestutil.NewDSC("test-create"),
-				gvk.DataScienceCluster,
-				metav1.GroupVersionResource{
-					Group:    gvk.DataScienceCluster.Group,
-					Version:  gvk.DataScienceCluster.Version,
-					Resource: "datascienceclusters",
-				},
-			),
-			allowed: false,
+			name:         "Denies creation if one already exists",
+			existingObjs: []client.Object{envtestutil.NewDSC("existing")},
+			req:          envtestutil.NewAdmissionRequest(t, admissionv1.Create, envtestutil.NewDSC("test-create"), gvk.DataScienceCluster, gvr),
+			allowed:      false,
 		},
 		{
 			name:         "Allows deletion always",
 			existingObjs: nil,
-			req: envtestutil.NewAdmissionRequest(
-				t,
-				admissionv1.Delete,
-				envtestutil.NewDSC("test-delete"),
-				gvk.DataScienceCluster,
-				metav1.GroupVersionResource{
-					Group:    gvk.DataScienceCluster.Group,
-					Version:  gvk.DataScienceCluster.Version,
-					Resource: "datascienceclusters",
-				},
-			),
+			req:          envtestutil.NewAdmissionRequest(t, admissionv1.Delete, envtestutil.NewDSC("test-delete"), gvk.DataScienceCluster, gvr),
+			allowed:      true,
+		},
+
+		// Kueue managementState validation cases
+		{
+			name:    "Denies create with Kueue Managed",
+			req:     envtestutil.NewAdmissionRequest(t, admissionv1.Create, envtestutil.NewDSC("test", withKueueState(operatorv1.Managed)), gvk.DataScienceCluster, gvr),
+			allowed: false,
+		},
+		{
+			name:    "Allows create with Kueue Unmanaged",
+			req:     envtestutil.NewAdmissionRequest(t, admissionv1.Create, envtestutil.NewDSC("test", withKueueState(operatorv1.Unmanaged)), gvk.DataScienceCluster, gvr),
+			allowed: true,
+		},
+		{
+			name:    "Allows create with Kueue Removed",
+			req:     envtestutil.NewAdmissionRequest(t, admissionv1.Create, envtestutil.NewDSC("test", withKueueState(operatorv1.Removed)), gvk.DataScienceCluster, gvr),
+			allowed: true,
+		},
+		{
+			name:    "Denies update with Kueue Managed",
+			req:     envtestutil.NewAdmissionRequest(t, admissionv1.Update, envtestutil.NewDSC("test", withKueueState(operatorv1.Managed)), gvk.DataScienceCluster, gvr),
+			allowed: false,
+		},
+		{
+			name:    "Allows update with Kueue Unmanaged",
+			req:     envtestutil.NewAdmissionRequest(t, admissionv1.Update, envtestutil.NewDSC("test", withKueueState(operatorv1.Unmanaged)), gvk.DataScienceCluster, gvr),
+			allowed: true,
+		},
+		{
+			name:    "Allows update with Kueue Removed",
+			req:     envtestutil.NewAdmissionRequest(t, admissionv1.Update, envtestutil.NewDSC("test", withKueueState(operatorv1.Removed)), gvk.DataScienceCluster, gvr),
+			allowed: true,
+		},
+		{
+			name:    "Allows delete with Kueue Managed",
+			req:     envtestutil.NewAdmissionRequest(t, admissionv1.Delete, envtestutil.NewDSC("test", withKueueState(operatorv1.Managed)), gvk.DataScienceCluster, gvr),
 			allowed: true,
 		},
 	}
@@ -84,13 +104,17 @@ func TestDataScienceClusterV2_ValidatingWebhook(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
+			g := NewWithT(t)
 			objs := append([]client.Object{}, tc.existingObjs...)
 			objs = append(objs, envtestutil.NewDSCI("dsci-for-dsc"))
-			cli, err := fakeclient.New(fakeclient.WithObjects(objs...))
+			sch, err := scheme.New()
+			g.Expect(err).ShouldNot(HaveOccurred())
+			cli, err := fakeclient.New(fakeclient.WithObjects(objs...), fakeclient.WithScheme(sch))
 			g.Expect(err).ShouldNot(HaveOccurred())
 			validator := &v2webhook.Validator{
-				Client: cli,
-				Name:   "test-v2",
+				Client:  cli,
+				Name:    "test-v2",
+				Decoder: admission.NewDecoder(sch),
 			}
 			resp := validator.Handle(ctx, tc.req)
 			t.Logf("Admission response: Allowed=%v, Result=%+v", resp.Allowed, resp.Result)


### PR DESCRIPTION
## Description

Add validation webhook for DSC v2 that rejects `kueue.managementState: Managed` on both create and update operations, matching the existing DSC v1 webhook behavior.

As part of the fix for [RHOAIENG-48690](https://issues.redhat.com/browse/RHOAIENG-48690) ([#3133](https://github.com/opendatahub-io/opendatahub-operator/pull/3133)), the `Managed` value was restored to the Kueue CRD enum to preserve backwards compatibility during OLM upgrades. For DSC v1, a validation webhook already rejects `Managed` at runtime. This PR adds the same validation for DSC v2.

**Jira**: [RHOAIENG-48771](https://issues.redhat.com/browse/RHOAIENG-48771)
**Caused by**: [RHOAIENG-48690](https://issues.redhat.com/browse/RHOAIENG-48690)
**Fix PR**: [#3133](https://github.com/opendatahub-io/opendatahub-operator/pull/3133)

### Changes

- **v2 validating webhook** (`v2/validating.go`): Added `Decoder` field, `denyManagementstateManaged` validation check, `validationCheck` type and `validate` helper, GVK guard, and updated kubebuilder marker to `verbs=create;update`
- **v2 register** (`v2/register.go`): Pass `admission.NewDecoder` to the Validator
- **v2 tests** (`v2/validating_test.go`): 9 test cases covering singleton enforcement, deletion, and all Kueue managementState values (Managed/Unmanaged/Removed) for both create and update
- **v1 comments** (`v1/validating.go`): Updated stale comments to reflect create+update handling
- **v1 tests** (`v1/validating_test.go`): Backfilled Kueue managementState tests (previously had zero coverage for `denyManagementstateManaged`), fixed Gomega `NewWithT` scoping in parallel subtests

## How Has This Been Tested?

- Unit tests: `make unit-test TEST_SRC=./internal/webhook/datasciencecluster/...` — all pass
- Full build: `make clean && make` — compiles and all test suites pass
- Manual cluster testing: deployed to CRC, verified:
  - `oc patch dsc default-dsc --type merge -p '{"spec":{"components":{"kueue":{"managementState":"Managed"}}}}'` → rejected by webhook
  - `oc edit dsc` with `Managed` → rejected by webhook
  - `oc edit dsc` with `Unmanaged`/`Removed` → allowed

## Screenshot or short clip

```
$ oc patch dsc default-dsc --type merge -p '{"spec":{"components":{"kueue":{"managementState":"Managed"}}}}'
Error from server (Forbidden): admission webhook "datasciencecluster-v2-validator.opendatahub.io" denied the request: Managed is no longer supported as a managementState
```

## Merge criteria

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [x] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

- [x] Skip requirement to update E2E test suite for this PR

#### E2E update requirement opt-out justification

This is a webhook validation change with comprehensive unit test coverage. No new API surface or component behavior is introduced.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Webhook validation now supports both create and update operations, enforces singleton constraints, denies when Kueue managementState is "Managed", and rejects unexpected group/version/kind.
  * Decoding errors and denial messages are surfaced more clearly.

* **Tests**
  * Expanded coverage across v1 and v2 for create/update flows, singleton enforcement, deletion rules, and managementState scenarios (Managed/Unmanaged/Removed).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->