### PR TITLE
fix: release automation logic for RELATED_IMAGES

### DIFF
--- a/.github/scripts/get-release-branches.js
+++ b/.github/scripts/get-release-branches.js
@@ -48,60 +48,61 @@ module.exports = async ({ github, core }) => {
 
         for (const issue of result.data) {
             const issueCommentBody = issue.body_text;
-            if (!issueCommentBody.includes("#Release#")) {
-                continue;
-            }
-
             const lines = issueCommentBody.split("\n");
-            const releaseIdx = lines.indexOf("#Release#");
-            const componentLines = lines.slice(releaseIdx + 1);
 
-            for (const component of componentLines) {
-                if (!regex.test(component)) {
-                    continue;
-                }
+            // Process #Release# section if present
+            if (issueCommentBody.includes("#Release#")) {
+                const releaseIdx = lines.indexOf("#Release#");
+                const componentLines = lines.slice(releaseIdx + 1);
 
-                const [componentName, branchOrTagUrl] = component.split("|");
-                const splitArr = branchOrTagUrl.trim().split("/");
-
-                let idx = null;
-                if (splitArr.includes("tag")) {
-                    idx = splitArr.indexOf("tag");
-                } else if (splitArr.includes("tree")) {
-                    idx = splitArr.indexOf("tree");
-                }
-
-                const branchName = splitArr.slice(idx + 1).join("/");
-                const repoOrg = splitArr[3];
-                const repoName = splitArr[4];
-                const trimmedComponentName = componentName.trim();
-                console.log(`Processing component: ${trimmedComponentName}`);
-
-                const commitSha = await getLatestCommitSha(github, repoOrg, repoName, branchName);
-
-                // Handle special case for notebook-controller
-                if (trimmedComponentName === "workbenches/notebook-controller") {
-                    core.exportVariable("component_spec_odh-notebook-controller".toLowerCase(), branchName);
-                    core.exportVariable("component_spec_kf-notebook-controller".toLowerCase(), branchName);
-                    core.exportVariable("component_org_odh-notebook-controller".toLowerCase(), repoOrg);
-                    core.exportVariable("component_org_kf-notebook-controller".toLowerCase(), repoOrg);
-
-                    if (commitSha) {
-                        core.exportVariable("component_sha_odh-notebook-controller".toLowerCase(), commitSha);
-                        core.exportVariable("component_sha_kf-notebook-controller".toLowerCase(), commitSha);
+                for (const component of componentLines) {
+                    if (!regex.test(component)) {
+                        continue;
                     }
-                } else {
-                    const normalizedName = trimmedComponentName.toLowerCase().replace(/\//g, '-');
-                    core.exportVariable("component_spec_" + normalizedName, branchName);
-                    core.exportVariable("component_org_" + normalizedName, repoOrg);
 
-                    if (commitSha) {
-                        core.exportVariable("component_sha_" + normalizedName, commitSha);
-                        console.log(`Set SHA for ${trimmedComponentName}: ${commitSha.substring(0, 8)}`);
+                    const [componentName, branchOrTagUrl] = component.split("|");
+                    const splitArr = branchOrTagUrl.trim().split("/");
+
+                    let idx = null;
+                    if (splitArr.includes("tag")) {
+                        idx = splitArr.indexOf("tag");
+                    } else if (splitArr.includes("tree")) {
+                        idx = splitArr.indexOf("tree");
+                    }
+
+                    const branchName = splitArr.slice(idx + 1).join("/");
+                    const repoOrg = splitArr[3];
+                    const repoName = splitArr[4];
+                    const trimmedComponentName = componentName.trim();
+                    console.log(`Processing component: ${trimmedComponentName}`);
+
+                    const commitSha = await getLatestCommitSha(github, repoOrg, repoName, branchName);
+
+                    // Handle special case for notebook-controller
+                    if (trimmedComponentName === "workbenches/notebook-controller") {
+                        core.exportVariable("component_spec_odh-notebook-controller".toLowerCase(), branchName);
+                        core.exportVariable("component_spec_kf-notebook-controller".toLowerCase(), branchName);
+                        core.exportVariable("component_org_odh-notebook-controller".toLowerCase(), repoOrg);
+                        core.exportVariable("component_org_kf-notebook-controller".toLowerCase(), repoOrg);
+
+                        if (commitSha) {
+                            core.exportVariable("component_sha_odh-notebook-controller".toLowerCase(), commitSha);
+                            core.exportVariable("component_sha_kf-notebook-controller".toLowerCase(), commitSha);
+                        }
+                    } else {
+                        const normalizedName = trimmedComponentName.toLowerCase().replace(/\//g, '-');
+                        core.exportVariable("component_spec_" + normalizedName, branchName);
+                        core.exportVariable("component_org_" + normalizedName, repoOrg);
+
+                        if (commitSha) {
+                            core.exportVariable("component_sha_" + normalizedName, commitSha);
+                            console.log(`Set SHA for ${trimmedComponentName}: ${commitSha.substring(0, 8)}`);
+                        }
                     }
                 }
             }
 
+            // Process #Images# section if present (independent of #Release#)
             if (issueCommentBody.includes("#Images#")) {
                 console.log("Found #Images# section in tracker comment");
 


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
Fix logic to process RELATED_IMAGES. Previously the logic expected both #Release#  anad #Images#. Now it can process separate headers in tracker

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [ ] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced release automation with improved component metadata processing and extraction.
  * Added support for new image section processing in release workflows.
  * Optimized release script for better sequential section handling and environment variable management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->