### PR TITLE
Allow configuring scope and profile claim skipping for OIDC

### DIFF
--- a/api/services/v1alpha1/gateway_types.go
+++ b/api/services/v1alpha1/gateway_types.go
@@ -160,6 +160,20 @@ type OIDCConfig struct {
 	// If not specified, defaults to openshift-ingress
 	// +optional
 	SecretNamespace string `json:"secretNamespace,omitempty"`
+
+	// Scope is the OAuth scope specification.
+	// If not specified, defaults to "openid profile email".
+	// For Entra ID, set to "openid profile email {client-id}/.default"
+	// to receive an access token scoped to your application.
+	// +optional
+	Scope string `json:"scope,omitempty"`
+
+	// SkipClaimsFromProfileURL skips fetching claims from the OIDC profile URL (userinfo endpoint).
+	// Set to true when the access token is not scoped to the profile endpoint's API
+	// (e.g., when using Entra ID with a custom scope, the access token cannot call Microsoft Graph).
+	// Claims are still extracted from the ID token.
+	// +optional
+	SkipClaimsFromProfileURL bool `json:"skipClaimsFromProfileURL,omitempty"`
 }
 
 // CookieConfig defines cookie settings for OAuth2 proxy

--- a/internal/controller/services/gateway/gateway_controller_actions.go
+++ b/internal/controller/services/gateway/gateway_controller_actions.go
@@ -348,6 +348,8 @@ func getTemplateData(ctx context.Context, rr *odhtypes.ReconciliationRequest) (m
 	// Add OIDC-specific fields only if OIDC config is present
 	if gatewayConfig.Spec.OIDC != nil {
 		templateData["OIDCIssuerURL"] = gatewayConfig.Spec.OIDC.IssuerURL
+		templateData["OIDCScope"] = gatewayConfig.Spec.OIDC.Scope
+		templateData["SkipClaimsFromProfileURL"] = gatewayConfig.Spec.OIDC.SkipClaimsFromProfileURL
 	}
 
 	// Add provider CA certificate configuration if specified

--- a/internal/controller/services/gateway/resources/kube-auth-proxy-oidc-deployment.tmpl.yaml
+++ b/internal/controller/services/gateway/resources/kube-auth-proxy-oidc-deployment.tmpl.yaml
@@ -115,5 +115,11 @@ spec:
             - "--cookie-domain={{.GatewayHostname}}"
             - "--provider=oidc"
             - "--oidc-issuer-url={{.OIDCIssuerURL}}"
+            {{- if .OIDCScope }}
+            - "--scope={{.OIDCScope}}"
+            {{- end }}
+            {{- if .SkipClaimsFromProfileURL }}
+            - "--skip-claims-from-profile-url=true"
+            {{- end }}
             - "--skip-oidc-discovery=false"
             - "--ssl-insecure-skip-verify={{.InsecureSkipVerify}}"


### PR DESCRIPTION


<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
Add two new fields in gateway config oidc spec to allow entra-specific configuration:
* `scope` - needs to include `<clientId>/.default` to get a properly scoped access token
* `skipClaimsFromProfileURL` - must be set to false when using entra, since the client-scoped access token cannot be used to get profile info

## How Has This Been Tested?
* Rebased this commit on 3.3
* built and pushed an operator image
* patched the gatewayconfig CRD
* replaced the image in the CSV
* patched the gatewayconfig with the new configuration
* verified logging to dashboard now works

## Screenshot or short clip
entra user logged into dashboard:
<img width="325" height="74" alt="image" src="https://github.com/user-attachments/assets/d63b493b-9ec9-481a-a0b3-beb7b7a2befb" />

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [ ] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->
