### PR TITLE
RHOAIENG-46694 | feat: tempo traces fix for perses dashboard

### DIFF
--- a/internal/controller/services/monitoring/monitoring_controller_support_test.go
+++ b/internal/controller/services/monitoring/monitoring_controller_support_test.go
@@ -1060,7 +1060,7 @@ func TestAddTracesTemplateData_TLS(t *testing.T) {
 			namespace:            "test-namespace",
 			expectedTLSEnabled:   false,
 			expectedHTTPProtocol: "http",
-			expectedPVEndpoint:   "https://tempo-data-science-tempomonolithic-gateway.test-namespace.svc.cluster.local:8080",
+			expectedPVEndpoint:   "https://tempo-data-science-tempomonolithic-gateway.test-namespace.svc.cluster.local:8080/api/traces/v1/test-namespace/tempo",
 		},
 		{
 			name: "PV backend with TLS explicitly disabled",
@@ -1078,7 +1078,7 @@ func TestAddTracesTemplateData_TLS(t *testing.T) {
 			namespace:            "test-namespace",
 			expectedTLSEnabled:   false,
 			expectedHTTPProtocol: "http",
-			expectedPVEndpoint:   "https://tempo-data-science-tempomonolithic-gateway.test-namespace.svc.cluster.local:8080",
+			expectedPVEndpoint:   "https://tempo-data-science-tempomonolithic-gateway.test-namespace.svc.cluster.local:8080/api/traces/v1/test-namespace/tempo",
 		},
 		{
 			name: "S3 backend with TLS disabled (default)",
@@ -1093,7 +1093,7 @@ func TestAddTracesTemplateData_TLS(t *testing.T) {
 			namespace:            "test-namespace",
 			expectedTLSEnabled:   false,
 			expectedHTTPProtocol: "http",
-			expectedS3Endpoint:   "https://tempo-data-science-tempostack-gateway.test-namespace.svc.cluster.local:8080",
+			expectedS3Endpoint:   "https://tempo-data-science-tempostack-gateway.test-namespace.svc.cluster.local:8080/api/traces/v1/test-namespace/tempo",
 		},
 		{
 			name: "S3 backend with TLS explicitly enabled",
@@ -1111,7 +1111,7 @@ func TestAddTracesTemplateData_TLS(t *testing.T) {
 			namespace:            "test-namespace",
 			expectedTLSEnabled:   true,
 			expectedHTTPProtocol: "https",
-			expectedS3Endpoint:   "https://tempo-data-science-tempostack-gateway.test-namespace.svc.cluster.local:8080",
+			expectedS3Endpoint:   "https://tempo-data-science-tempostack-gateway.test-namespace.svc.cluster.local:8080/api/traces/v1/test-namespace/tempo",
 		},
 	}
 

--- a/internal/controller/services/monitoring/resources/opentelemetry-collector.tmpl.yaml
+++ b/internal/controller/services/monitoring/resources/opentelemetry-collector.tmpl.yaml
@@ -167,16 +167,13 @@ spec:
       {{- end }}
       {{- if .Traces }}
       otlp/tempo:
+        # In multitenancy/openshift mode, traces are always sent through the gateway
+        # which uses TLS (service-CA signed cert) and requires bearer token auth.
         endpoint: {{.TempoEndpoint}}
-        {{- if .TempoTLSEnabled }}
         tls:
           ca_file: "/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt"
         auth:
           authenticator: bearertokenauth
-        {{- else }}
-        tls:
-          insecure: true
-        {{- end }}
         headers:
           # must be set to the tenant name from tempo CR
           X-Scope-OrgID: {{ .Namespace }}

--- a/internal/controller/services/monitoring/resources/perses-tempo-datasource.tmpl.yaml
+++ b/internal/controller/services/monitoring/resources/perses-tempo-datasource.tmpl.yaml
@@ -4,7 +4,8 @@ metadata:
   name: tempo-datasource
   namespace: {{.Namespace}}
 spec:
-{{- if .TempoTLSEnabled }}
+  # The Tempo gateway always uses HTTPS (service-CA signed cert) in multitenancy/openshift mode,
+  # so TLS verification is always required regardless of the user's explicit TLS setting.
   client:
     tls:
       enable: true
@@ -12,7 +13,6 @@ spec:
         type: configmap
         name: tempo-service-ca
         certPath: service-ca.crt
-{{- end }}
   config:
     default: false
     display:
@@ -24,6 +24,9 @@ spec:
         proxy:
           kind: HTTPProxy
           spec:
+            # Secret references the Perses secret created by the operator from client.tls config.
+            # This links the CA cert to the proxy, enabling TLS verification for the gateway.
+            secret: tempo-datasource-secret
             url: {{.TempoQueryEndpoint}}
             headers:
               X-Scope-OrgID: {{.Namespace}}

--- a/internal/controller/services/monitoring/resources/tempo-monolithic.tmpl.yaml
+++ b/internal/controller/services/monitoring/resources/tempo-monolithic.tmpl.yaml
@@ -23,24 +23,24 @@ spec:
       {{- if .Size }}
       size: "{{.Size}}"
       {{- end }}
-  {{- if .TempoTLSEnabled }}
+  {{- if and .TempoTLSEnabled .TempoCertificateSecret }}
+  # Ingestion TLS is only enabled when explicit certs are provided.
+  # In multitenancy/openshift mode, the gateway already handles external TLS,
+  # and enabling auto-provisioned receiver TLS conflicts with the gateway's
+  # localhost connections (mTLS cert CA mismatch).
   ingestion:
     otlp:
       grpc:
         tls:
           enabled: true
-          {{- if .TempoCertificateSecret }}
           certName: {{.TempoCertificateSecret}}
-          {{- end }}
           {{- if .TempoCAConfigMap }}
           caName: {{.TempoCAConfigMap}}
           {{- end }}
       http:
         tls:
           enabled: true
-          {{- if .TempoCertificateSecret }}
           certName: {{.TempoCertificateSecret}}
-          {{- end }}
           {{- if .TempoCAConfigMap }}
           caName: {{.TempoCAConfigMap}}
           {{- end }}


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
[RHOAIENG-46694](https://issues.redhat.com/browse/RHOAIENG-46694)

Fix to ensure tempo traces are accessible from the perses ui dashboard
- install distributed tracing plugin + ui monitoring plugin
- in console send fake trcaes request:
```
oc run curl-test --restart=Never --rm -i --image=curlimages/curl -- \
  -s -X POST http://data-science-collector-collector.opendatahub.svc:4318/v1/traces \
  -H "Content-Type: application/json" \
  -d '{"resourceSpans":[{"resource":{"attributes":[{"key":"service.name","value":{"stringValue":"perses-fix-verify"}}]},"scopeSpans":[{"scope":{"name":"test"},"spans":[{"traceId":"11223344556677881122334455667788","spanId":"1122334455667788","name":"perses-fix-test","kind":1,"startTimeUnixNano":"1739357000000000000","endTimeUnixNano":"1739357001000000000","status":{"code":1}}]}]}]}'
  ```
  - verify tempo can see traces:
  ```
  # Port-forward to the COO Perses server
oc port-forward svc/perses -n openshift-cluster-observability-operator 18090:8080 &
sleep 3

# Get a token (use cluster-admin or a user with Perses read access)
TOKEN=$(oc whoami -t)

# Query through the Perses proxy
curl -sk -H "Authorization: Bearer ${TOKEN}" \
  "https://localhost:18090/proxy/projects/opendatahub/datasources/tempo-datasource/api/search?q=%7B%7D&limit=5"

# Clean up the port-forward
kill %1
```
- should see something like 
```
{"traces":[{"traceID":"11223344556677881122334455667788","rootServiceName":"perses-fix-verify","rootTraceName":"perses-fix-test",...}],"metrics":{...}}
```
- go to observe -> perses dashboard 
- should see 
```
Minified MUI error #9; visit https://mui.com/production-error/?code=9&args%5B%5D=var%28--pf-v5-global--BackgroundColor--100%29 for the full message.
```

traces only visible in observe -> traces
<img width="1319" height="796" alt="Screenshot 2026-02-12 at 16 57 45" src="https://github.com/user-attachments/assets/1d089768-0f47-4860-8f23-68388dc95ee0" />


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [ ] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Trace ingestion now always uses TLS via the gateway to ensure secure transport and tenant-aware routing.

* **Refactor**
  * Monitoring endpoints updated to route through the gateway with tenant-scoped API paths.
  * TLS configuration made mandatory in multitenancy/OpenShift scenarios; gateway TLS behavior clarified.

* **Tests**
  * Updated tests to expect gateway tenant-path endpoints and mandatory TLS, including datasource TLS/secret validations.

* **Documentation**
  * Added explanatory comments about gateway routing and multitenancy TLS expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->