### PR TITLE
RHOAIENG-49485: make PrometheusRule operations non-blocking

### DIFF
--- a/internal/controller/services/monitoring/monitoring_controller_actions.go
+++ b/internal/controller/services/monitoring/monitoring_controller_actions.go
@@ -465,10 +465,6 @@ func deployAlerting(ctx context.Context, rr *odhtypes.ReconciliationRequest) err
 		}
 	}
 
-	if len(addErrors) > 0 || len(cleanupErrors) > 0 {
-		return errors.New("errors occurred while adding or cleaning up prometheus rules for components")
-	}
-
 	return nil
 }
 


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->
This change removes the check for errors to not block reconciliation when there are errors adding or cleaning up prom rules for a component.

<!--- Link your JIRA and related links here for reference. -->
https://issues.redhat.com/browse/RHOAIENG-49485

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This was tested in a few steps:
- Deploy image based on main
- Create DSCi with alerting configured
- Create DSC with MaaS or MLFlow enabled
- Watch reconciliation fail due to prom rules not being configured:
```
cgoodfre@cgoodfre-mac opendatahub-operator % oc get monitoring default-monitoring -o yaml | grep -A 20 status
status:
  conditions:
  - lastTransitionTime: "2026-02-17T13:55:36Z"
    message: errors occurred while adding or cleaning up prometheus rules for components
    reason: Error
    status: "False"
    type: Ready
  - lastTransitionTime: "2026-02-17T13:55:36Z"
    message: errors occurred while adding or cleaning up prometheus rules for components
    observedGeneration: 1
    reason: Error
    status: "False"
```
- Build and deploy image from this branch
- Watch reconciliation succeed even with missing prom rules
```
cgoodfre@cgoodfre-mac opendatahub-operator % oc get monitoring default-monitoring -o yaml | grep -A 20 status
status:
  conditions:
  - lastTransitionTime: "2026-02-17T14:19:43Z"
    status: "True"
    type: Ready
  - lastTransitionTime: "2026-02-17T14:19:48Z"
    observedGeneration: 1
    status: "True"
    type: ProvisioningSucceeded
```
- Verify that there is a log message upon reconciliation indicating the missing prom rules
```
{                                                                                                                                                                                       
    "level":"error",                                                                                                                                                                      
    "ts":"2026-02-17T14:41:47Z",                                                                                                                                                          
    "logger":"action.github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/services/monitoring.deployAlerting",                                                           
    "msg":"Failed to add prometheus rules for component",                                                                                                                                 
    "error":"failed to add prometheus rules for component modelsasservice: prometheus rules file for component modelsasservice not found",                                                
    "stacktrace":"...monitoring_controller_actions.go:438..."
  }
```
## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
This is a bugfix that should not require E2E updates
<!--- This section can be left empty if you're not opting out of the E2E requirement -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Monitoring configuration errors no longer cause reconciliation/deploy to fail; individual component errors are logged for visibility while overall processing continues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->