### PR TITLE
RHOAIENG-50079 | fix: Add workaround for Tempo Operator TLS  serving cert bug

### DIFF
--- a/internal/controller/services/monitoring/resources/tempo-monolithic.tmpl.yaml
+++ b/internal/controller/services/monitoring/resources/tempo-monolithic.tmpl.yaml
@@ -50,7 +50,7 @@ spec:
       compactor:
         compaction:
           block_retention: {{.TracesRetention}}  # default 90days
-      {{- if .TempoCertificateSecret }}
+      {{- if .TempoUseCustomCert }}
       # Only configure HTTP TLS when explicit cert is provided
       # Otherwise, let Tempo operator handle it via OpenShift serving certs
       server:


### PR DESCRIPTION


<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->
Implements workaround for Tempo Operator v0.19 serving cert bug where TempoMonolithic pod fails to start when TLS is enabled without custom certificates. Tempo Operator incorrectly infers cert name as `tempo-{name}-serving-cert` instead of `tempo-{name}-gateway-serving-cert` when gateway mode is enabled.

<!--- Link your JIRA and related links here for reference. -->
https://issues.redhat.com/browse/RHOAIENG-50079
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Built operator image with the workaround
2. Deployed to test cluster
3. Enabled TLS for traces in DSCI without providing custom certificates:
   ```yaml
   spec:
     monitoring:
       traces:
         storage:
           backend: pv
           size: 10Gi
         tls:
           enabled: true
      ```
 4. Verified TempoMonolithic pod starts successfully:
* All 3 containers running (tempo, tempo-gateway, tempo-gateway-opa)
* No certificate mount errors
## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [ ] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced TLS certificate handling for monitoring services with improved support for custom certificate configurations.
  * Added automatic fallback mechanism for persistent volume storage backends to ensure consistent TLS setup when custom certificates are not explicitly specified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->