### PR TITLE
RHOAIENG-50350: Add IBM Spyre overrides to kserve support

### DIFF
--- a/internal/controller/components/kserve/kserve_support.go
+++ b/internal/controller/components/kserve/kserve_support.go
@@ -35,6 +35,7 @@ var (
 		"kserve-llm-d":                     "RELATED_IMAGE_RHAIIS_VLLM_CUDA_IMAGE", // Default image (Nvidia CUDA)
 		"kserve-llm-d-nvidia-cuda":         "RELATED_IMAGE_RHAIIS_VLLM_CUDA_IMAGE",
 		"kserve-llm-d-amd-rocm":            "RELATED_IMAGE_RHAIIS_VLLM_ROCM_IMAGE",
+		"kserve-llm-d-ibm-spyre":           "RELATED_IMAGE_RHAIIS_VLLM_SPYRE_IMAGE",
 		"kserve-llm-d-inference-scheduler": "RELATED_IMAGE_ODH_LLM_D_INFERENCE_SCHEDULER_IMAGE",
 		"kserve-llm-d-routing-sidecar":     "RELATED_IMAGE_ODH_LLM_D_ROUTING_SIDECAR_IMAGE",
 		"kube-rbac-proxy":                  "RELATED_IMAGE_OSE_KUBE_RBAC_PROXY_IMAGE",


### PR DESCRIPTION
## Description

[RHOAIENG-50350](https://issues.redhat.com/browse/RHOAIENG-50350)
Adds an operator-side image override entry for the new IBM Spyre accelerator-specific `LLMInferenceServiceConfig` template introduced in [opendatahub-io/kserve#1130](https://github.com/opendatahub-io/kserve/pull/1130).

The kserve PR adds a new `params.env` key `kserve-llm-d-ibm-spyre` for the IBM Spyre vLLM image variant. The operator needs a corresponding `imageParamMap` entry so it can inject the correct `RELATED_IMAGE_*` environment variable value into `params.env` at deploy time.

**Changes:**
- Added one new entry to `imageParamMap` in `internal/controller/components/kserve/kserve_support.go`:
  - `kserve-llm-d-ibm-spyre` mapped to `RELATED_IMAGE_RHAIIS_VLLM_SPYRE_IMAGE`

Note: `kserve-llm-d-nvidia-cuda` and `kserve-llm-d-amd-rocm` were already present in the map. Google TPU was dropped from the kserve PR scope and is not included here.

The `RELATED_IMAGE_*` env var naming follows the established `RELATED_IMAGE_RHAIIS_VLLM_{ACCELERATOR}_IMAGE` convention, consistent with the existing CUDA and ROCm entries in kserve and the Spyre entry already present in modelcontroller.

**Related links:**
- Kserve PR: https://github.com/opendatahub-io/kserve/pull/1130
- JIRA: [RHOAIENG-50060](https://issues.redhat.com/browse/RHOAIENG-50060)

## How Has This Been Tested?

- `go vet ./...` passes with no issues
- All kserve unit tests pass (`go test ./internal/controller/components/kserve/...`)
- Verified that existing CUDA default (`kserve-llm-d`) and ROCm (`kserve-llm-d-amd-rocm`) entries are unaffected
- Verified the new entry follows the same `ApplyParams` injection pattern used by all other image overrides

## Screenshot or short clip

N/A - config-only change with no UI impact.

## Merge criteria

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

- [x] Skip requirement to update E2E test suite for this PR

#### E2E update requirement opt-out justification

This change adds one entry to a static map (`imageParamMap`) used for image injection. It introduces no new controller logic, no new API surface, and no behavioral changes. The existing `ApplyParams` mechanism and its test coverage apply equally to the new entry. Per the opt-out guidelines, config-only changes that do not alter runtime behavior do not require E2E updates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for an additional KServe image variant (IBM Spyre LLM), enabling deployment and use of that model variant through the platform’s KServe integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->