### PR TITLE
added a bunch of reorganization stuff in the e2e tests to adapt them into a existing scenario

### DIFF
--- a/Dockerfiles/e2e-tests/e2e-tests.Dockerfile
+++ b/Dockerfiles/e2e-tests/e2e-tests.Dockerfile
@@ -35,6 +35,13 @@ ENV E2E_TEST_DSC_MONITORING_NAMESPACE=opendatahub
 ENV E2E_TEST_CLEAN_UP_PREVIOUS_RESOURCES=false
 ENV E2E_TEST_DELETION_POLICY=never
 ENV E2E_TEST_FAIL_FAST_ON_ERROR=false
+ENV E2E_TEST_OPERATOR_CONTROLLER=true
+ENV E2E_TEST_OPERATOR_RESILIENCE=true
+ENV E2E_TEST_OPERATOR_V2TOV3UPGRADE=true
+ENV E2E_TEST_HARDWARE_PROFILE=true
+ENV E2E_TEST_WEBHOOK=true
+ENV E2E_TEST_COMPONENTS=true
+ENV E2E_TEST_SERVICES=true
 
 RUN apt-get update -y && apt-get upgrade -y && \
     curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" && \
@@ -57,8 +64,4 @@ RUN mkdir -p results
 # run main go command
 CMD gotestsum --junitfile-project-name odh-operator-e2e \
 --junitfile results/xunit_report.xml --format testname --raw-command \
--- test2json -p e2e ./e2e-tests --test.v=test2json --test.parallel=8 \
---deletion-policy=$E2E_TEST_DELETION_POLICY --clean-up-previous-resources=$E2E_TEST_CLEAN_UP_PREVIOUS_RESOURCES \
---operator-namespace=$E2E_TEST_OPERATOR_NAMESPACE --applications-namespace=$E2E_TEST_APPLICATIONS_NAMESPACE \
---workbenches-namespace=$E2E_TEST_WORKBENCHES_NAMESPACE --dsc-monitoring-namespace=$E2E_TEST_DSC_MONITORING_NAMESPACE \
---fail-fast-on-error=$E2E_TEST_FAIL_FAST_ON_ERROR
+-- test2json -p e2e ./e2e-tests --test.v=test2json --test.parallel=8

--- a/tests/e2e/controller_test.go
+++ b/tests/e2e/controller_test.go
@@ -300,6 +300,8 @@ func TestOdhOperator(t *testing.T) {
 	// Remove any leftover resources from previous test runs before starting if the cleanup flag is enabled
 	if testOpts.cleanUpPreviousResources {
 		CleanupPreviousTestResources(t)
+		// Run DSCI/DSC management test suite
+		mustRun(t, "DSCInitialization and DataScienceCluster management E2E Tests", dscManagementTestSuite)
 	}
 
 	if testOpts.operatorControllerTest {
@@ -307,8 +309,8 @@ func TestOdhOperator(t *testing.T) {
 		mustRun(t, "Operator Manager E2E Tests", odhOperatorTestSuite)
 	}
 
-	// Run DSCI/DSC test suites
-	mustRun(t, "DSCInitialization and DataScienceCluster management E2E Tests", dscManagementTestSuite)
+	// Run DSCI/DSC test validation test suite
+	mustRun(t, "DSCInitialization and DataScienceCluster validation E2E Tests", dscValidationTestSuite)
 
 	// Run components and services test suites
 	mustRun(t, Components.String(), Components.Run)
@@ -402,7 +404,7 @@ func TestMain(m *testing.M) {
 	checkEnvVarBindingError(viper.BindEnv("deletion-policy", viper.GetEnvPrefix()+"_DELETION_POLICY"))
 
 	pflag.Bool("fail-fast-on-error", true, "fail fast on error")
-	checkEnvVarBindingError(viper.BindEnv("fail-fast-on-error", viper.GetEnvPrefix()+"_FAST_FAIL_ON_ERROR"))
+	checkEnvVarBindingError(viper.BindEnv("fail-fast-on-error", viper.GetEnvPrefix()+"_FAIL_FAST_ON_ERROR"))
 	pflag.Bool("clean-up-previous-resources", true, "clean up previous resources before running tests")
 	checkEnvVarBindingError(viper.BindEnv("clean-up-previous-resources", viper.GetEnvPrefix()+"_CLEAN_UP_PREVIOUS_RESOURCES"))
 	pflag.Bool("test-operator-controller", true, "run operator controller tests")

--- a/tests/e2e/helper_test.go
+++ b/tests/e2e/helper_test.go
@@ -13,6 +13,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
 	"github.com/opendatahub-io/opendatahub-operator/v2/api/common"
@@ -89,6 +90,13 @@ const (
 	resourceFetchErrorMsg        = "Error occurred while fetching the resource '%s' of kind '%s': %v"
 	unexpectedErrorMismatchMsg   = "Expected error '%v' to match the actual error '%v' for resource of kind '%s'."
 )
+
+type Operator struct {
+	nn                  types.NamespacedName
+	skipOperatorGroup   bool
+	globalOperatorGroup bool
+	channel             string
+}
 
 // TestCaseOpts defines a function type that can be used to modify how individual test cases are executed.
 type TestCaseOpts func(t *testing.T)
@@ -516,6 +524,31 @@ func ParseTestFlags() error {
 func (tc *TestContext) getControllerDeploymentName() string {
 	platform := tc.FetchPlatformRelease()
 	return getControllerDeploymentNameByPlatform(platform)
+}
+
+// ensureOperatorsAreInstalled ensures the specified operators are installed using parallel test cases.
+func (tc *TestContext) ensureOperatorsAreInstalled(t *testing.T, operators []Operator) {
+	t.Helper()
+	// Create and run test cases in parallel.
+	testCases := make([]TestCase, len(operators))
+	for i, op := range operators {
+		testCases[i] = TestCase{
+			name: fmt.Sprintf("Ensure %s is installed", op.nn.Name),
+			testFn: func(t *testing.T) {
+				t.Helper()
+				switch {
+				case op.skipOperatorGroup:
+					tc.EnsureOperatorInstalledWithChannel(op.nn, op.channel)
+				case op.globalOperatorGroup:
+					tc.EnsureOperatorInstalledWithGlobalOperatorGroupAndChannel(op.nn, op.channel)
+				default:
+					tc.EnsureOperatorInstalledWithLocalOperatorGroupAndChannel(op.nn, op.channel)
+				}
+			},
+		}
+	}
+
+	RunTestCases(t, testCases, WithParallel())
 }
 
 func getControllerDeploymentNameByPlatform(platform common.Platform) string {

--- a/tests/e2e/monitoring_test.go
+++ b/tests/e2e/monitoring_test.go
@@ -98,6 +98,7 @@ func monitoringTestSuite(t *testing.T) {
 
 	// Define test cases.
 	testCases := []TestCase{
+		{name: "Ensure required monitoring operators are installed", testFn: monitoringServiceCtx.ValidateMonitoringOperatorsInstallation},
 		{"Auto creation of Monitoring CR", monitoringServiceCtx.ValidateMonitoringCRCreation},
 		{"Test Monitoring CR content default value", monitoringServiceCtx.ValidateMonitoringCRDefaultContent},
 		{"Test Traces default content", monitoringServiceCtx.ValidateMonitoringCRDefaultTracesContent},
@@ -143,6 +144,20 @@ func monitoringTestSuite(t *testing.T) {
 
 	// Run the test suite.
 	RunTestCases(t, testCases)
+}
+
+// ValidateMonitoringOperatorsInstallation ensures the required monitoring operators are installed.
+func (tc *MonitoringTestCtx) ValidateMonitoringOperatorsInstallation(t *testing.T) {
+	t.Helper()
+
+	// Define operators to be installed.
+	operators := []Operator{
+		{nn: types.NamespacedName{Name: observabilityOpName, Namespace: observabilityOpNamespace}, skipOperatorGroup: false, globalOperatorGroup: true, channel: defaultOperatorChannel},
+		{nn: types.NamespacedName{Name: opentelemetryOpName, Namespace: opentelemetryOpNamespace}, skipOperatorGroup: false, globalOperatorGroup: true, channel: defaultOperatorChannel},
+		{nn: types.NamespacedName{Name: tempoOpName, Namespace: tempoOpNamespace}, skipOperatorGroup: false, globalOperatorGroup: true, channel: defaultOperatorChannel},
+	}
+
+	tc.ensureOperatorsAreInstalled(t, operators)
 }
 
 // ValidateMonitoringCRCreation ensures that exactly one Monitoring CR exists and status to Ready.


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->
Added a bunch of stuff to adapt the e2e tests in existing scenarios. We want to keep the DSCI, DSC and dependant operator that were already present in the cluster.

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [ ] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a dedicated DSC validation suite and reorganized management tests
  * Enhanced parallel execution across multiple E2E suites for faster runs
  * Added validation for monitoring and operator installation workflows
* **Chores**
  * Exposed additional E2E feature-flag environment variables and simplified test invocation flags
<!-- end of auto-generated comment: release notes by coderabbit.ai -->