### PR TITLE
Fix dashboard redirect e2e tests

### DIFF
--- a/tests/e2e/gateway_redirect_test.go
+++ b/tests/e2e/gateway_redirect_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/services/gateway"
@@ -17,31 +16,20 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestDashboardRedirects(t *testing.T) {
-	testDashboardRedirects(t)
-}
-
-func testDashboardRedirects(t *testing.T) {
+func (tc *GatewayTestCtx) DashboardRedirectTestSuite(t *testing.T) {
 	t.Helper()
 
-	ctx, err := NewTestContext(t)
-	require.NoError(t, err)
-
-	gatewayCtx := &GatewayTestCtx{
-		TestContext: ctx,
-	}
-
 	// Skip all tests if not in OcpRoute mode
-	if !gatewayCtx.isOcpRouteMode(t) {
+	if !tc.isOcpRouteMode(t) {
 		t.Skip("Dashboard redirects are only created in OcpRoute ingress mode")
 	}
 
 	testCases := []TestCase{
-		{"Validate dashboard redirect ConfigMap", gatewayCtx.ValidateDashboardRedirectConfigMap},
-		{"Validate dashboard redirect Deployment", gatewayCtx.ValidateDashboardRedirectDeployment},
-		{"Validate dashboard redirect Service", gatewayCtx.ValidateDashboardRedirectService},
-		{"Validate dashboard redirect Routes", gatewayCtx.ValidateDashboardRedirectRoutes},
-		{"Validate dashboard redirect HTTP functionality", gatewayCtx.ValidateDashboardRedirectHTTP},
+		{"ConfigMap", tc.ValidateDashboardRedirectConfigMap},
+		{"Deployment", tc.ValidateDashboardRedirectDeployment},
+		{"Service", tc.ValidateDashboardRedirectService},
+		{"Routes", tc.ValidateDashboardRedirectRoutes},
+		{"HTTP functionality", tc.ValidateDashboardRedirectHTTP},
 	}
 
 	RunTestCases(t, testCases)
@@ -143,7 +131,7 @@ func (tc *GatewayTestCtx) ValidateDashboardRedirectDeployment(t *testing.T) {
 			// Security context
 			jq.Match(`.spec.template.spec.containers[0].securityContext.allowPrivilegeEscalation == false`),
 			jq.Match(`.spec.template.spec.containers[0].securityContext.runAsNonRoot == true`),
-			jq.Match(`.spec.template.spec.containers[0].securityContext.capabilities.drop[] | select(. == "ALL")`),
+			jq.Match(`.spec.template.spec.containers[0].securityContext.capabilities.drop | any(. == "ALL")`),
 			jq.Match(`.spec.template.spec.containers[0].securityContext.seccompProfile.type == "RuntimeDefault"`),
 		)),
 		WithCustomErrorMsg("dashboard-redirect Deployment should exist with correct nginx S2I configuration"),

--- a/tests/e2e/gateway_test.go
+++ b/tests/e2e/gateway_test.go
@@ -95,6 +95,7 @@ func gatewayTestSuite(t *testing.T) {
 		{"Validate EDS endpoint discovery", gatewayCtx.ValidateEDSEndpointDiscovery},
 		{"Validate Gateway ready status", gatewayCtx.ValidateGatewayReadyStatus},
 		{"Validate unauthenticated access redirects to login", gatewayCtx.ValidateUnauthenticatedRedirect},
+		{"Validate dashboard redirect resources", gatewayCtx.DashboardRedirectTestSuite},
 	}
 
 	RunTestCases(t, testCases)


### PR DESCRIPTION

## Description
* previously were not run since they were not part of TestOdhOperator hierarchy
* deployment test was failing on capabilities drop due to the way jq matcher works


## How Has This Been Tested?
* built and deployed operator image from https://github.com/opendatahub-io/opendatahub-operator/pull/3175 (fix for configmap ownerReference)
* `go test -v -run  "TestOdhOperator/services/group_1/gateway" ./tests/e2e`

## Screenshot or short clip


## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [x] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [ ] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Consolidated gateway redirect entry points into a single suite method to streamline execution.
  * Added end-to-end coverage for dashboard redirect validation and related navigation/auth flows.
  * Simplified control flow by relying on a shared test context across cases.
  * Strengthened deployment security assertions by improving capability verification for redirect-related resources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->