### PR TITLE
Adding Components and Services e2e tests into Smoke or Tier1 categories

### DIFF
--- a/.github/workflows/ci-build-push-e2e-tests.yaml
+++ b/.github/workflows/ci-build-push-e2e-tests.yaml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+      - stable
 
 permissions:
   contents: read

--- a/Dockerfiles/e2e-tests/e2e-tests.Dockerfile
+++ b/Dockerfiles/e2e-tests/e2e-tests.Dockerfile
@@ -27,7 +27,7 @@ RUN CGO_ENABLED=${CGO_ENABLED} GOOS=linux GOARCH=${TARGETARCH} go test -c ./test
 ################################################################################
 FROM golang:$GOLANG_VERSION
 
-# ENV vars
+# ENV vars for the go test command options
 ENV E2E_TEST_OPERATOR_NAMESPACE=opendatahub-operators
 ENV E2E_TEST_APPLICATIONS_NAMESPACE=opendatahub
 ENV E2E_TEST_WORKBENCHES_NAMESPACE=opendatahub
@@ -64,4 +64,11 @@ RUN mkdir -p results
 # run main go command
 CMD gotestsum --junitfile-project-name odh-operator-e2e \
 --junitfile results/xunit_report.xml --format testname --raw-command \
--- test2json -p e2e ./e2e-tests --test.v=test2json --test.parallel=8
+-- test2json -p e2e ./e2e-tests --test.v=test2json --test.parallel=8 \
+--deletion-policy="$E2E_TEST_DELETION_POLICY" --clean-up-previous-resources="$E2E_TEST_CLEAN_UP_PREVIOUS_RESOURCES" \
+--test-operator-controller="$E2E_TEST_OPERATOR_CONTROLLER" --test-operator-resilience="$E2E_TEST_OPERATOR_RESILIENCE" \
+--test-operator-v2tov3upgrade="$E2E_TEST_OPERATOR_V2TOV3UPGRADE" --test-hardware-profile="$E2E_TEST_HARDWARE_PROFILE" \
+--test-webhook="$E2E_TEST_WEBHOOK" --test-components="$E2E_TEST_COMPONENTS" --test-services="$E2E_TEST_SERVICES" \
+--operator-namespace="$E2E_TEST_OPERATOR_NAMESPACE" --applications-namespace="$E2E_TEST_APPLICATIONS_NAMESPACE" \
+--workbenches-namespace="$E2E_TEST_WORKBENCHES_NAMESPACE" --dsc-monitoring-namespace="$E2E_TEST_DSC_MONITORING_NAMESPACE" \
+--fail-fast-on-error="$E2E_TEST_FAIL_FAST_ON_ERROR"

--- a/api/services/v1alpha1/gateway_types.go
+++ b/api/services/v1alpha1/gateway_types.go
@@ -17,16 +17,17 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"github.com/opendatahub-io/opendatahub-operator/v2/api/common"
-	infrav1 "github.com/opendatahub-io/opendatahub-operator/v2/api/infrastructure/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/opendatahub-io/opendatahub-operator/v2/api/common"
+	infrav1 "github.com/opendatahub-io/opendatahub-operator/v2/api/infrastructure/v1"
 )
 
 const (
 	GatewayServiceName = "gateway"
-	// GatewayInstanceName the name of the GatewayConfig instance singleton.
-	// value should match whats set in the XValidation below
+	// GatewayConfigName is the name of the GatewayConfig instance singleton.
+	// value should match what's set in the XValidation below
 	GatewayConfigName = "default-gateway"
 	GatewayConfigKind = "GatewayConfig"
 )

--- a/tests/e2e/authcontroller_test.go
+++ b/tests/e2e/authcontroller_test.go
@@ -76,6 +76,8 @@ func authControllerTestSuite(t *testing.T) {
 func (tc *AuthControllerTestCtx) ValidateAuthSystemInitialization(t *testing.T) {
 	t.Helper()
 
+	skipUnless(t, []TestTag{Smoke})
+
 	expectedAdminGroup := tc.getExpectedAdminGroupForPlatform()
 
 	// 1. Validate that exactly one Auth CR exists with correct default content
@@ -121,6 +123,8 @@ func (tc *AuthControllerTestCtx) ValidateAuthSystemInitialization(t *testing.T) 
 func (tc *AuthControllerTestCtx) ValidateAddingGroups(t *testing.T) {
 	t.Helper()
 
+	skipUnless(t, []TestTag{Tier1})
+
 	testAdminGroup := "aTestAdminGroup"
 	testAllowedGroup := "aTestAllowedGroup"
 
@@ -146,6 +150,8 @@ func (tc *AuthControllerTestCtx) ValidateAddingGroups(t *testing.T) {
 // ValidateRemovingGroups removes groups from Auth CR and validates the changes.
 func (tc *AuthControllerTestCtx) ValidateRemovingGroups(t *testing.T) {
 	t.Helper()
+
+	skipUnless(t, []TestTag{Tier1})
 
 	// Get the expected admin group for the current platform
 	expectedGroup := tc.getExpectedAdminGroupForPlatform()
@@ -176,6 +182,8 @@ func (tc *AuthControllerTestCtx) ValidateRemovingGroups(t *testing.T) {
 // CEL validation by attempting to update the existing Auth resource with invalid values.
 func (tc *AuthControllerTestCtx) ValidateCELBlocksInvalidGroupsViaUpdate(t *testing.T) {
 	t.Helper()
+
+	skipUnless(t, []TestTag{Tier1})
 
 	// Test cases for different invalid update scenarios
 	testCases := []struct {
@@ -220,6 +228,8 @@ func (tc *AuthControllerTestCtx) ValidateCELBlocksInvalidGroupsViaUpdate(t *test
 // Since Auth resources must be named "auth", we test by updating the existing resource.
 func (tc *AuthControllerTestCtx) ValidateCELAllowsValidGroups(t *testing.T) {
 	t.Helper()
+
+	skipUnless(t, []TestTag{Tier1})
 
 	testCases := []struct {
 		name        string

--- a/tests/e2e/cfmap_deletion_test.go
+++ b/tests/e2e/cfmap_deletion_test.go
@@ -46,8 +46,8 @@ func cfgMapDeletionTestSuite(t *testing.T) {
 
 	// Define test cases
 	testCases := []TestCase{
-		{name: "Validate creation of configmap with deletion disabled", testFn: cfgMapDeletionTestCtx.ValidateDSCDeletionUsingConfigMap},
-		{name: "Validate that owned namespaces are not deleted", testFn: cfgMapDeletionTestCtx.ValidateOwnedNamespacesAllExist},
+		{"Validate creation of configmap with deletion disabled", cfgMapDeletionTestCtx.ValidateDSCDeletionUsingConfigMap},
+		{"Validate that owned namespaces are not deleted", cfgMapDeletionTestCtx.ValidateOwnedNamespacesAllExist},
 	}
 
 	// Run the test suite
@@ -57,6 +57,8 @@ func cfgMapDeletionTestSuite(t *testing.T) {
 // ValidateDSCDeletionUsingConfigMap tests the deletion of DataScienceCluster based on the config map setting.
 func (tc *CfgMapDeletionTestCtx) ValidateDSCDeletionUsingConfigMap(t *testing.T) {
 	t.Helper()
+
+	skipUnless(t, []TestTag{Tier1})
 
 	// Create or update the deletion config map
 	enableDeletion := "false"
@@ -86,6 +88,8 @@ func (tc *CfgMapDeletionTestCtx) ValidateDSCDeletionUsingConfigMap(t *testing.T)
 // ValidateOwnedNamespacesAllExist verifies that the owned namespaces exist.
 func (tc *CfgMapDeletionTestCtx) ValidateOwnedNamespacesAllExist(t *testing.T) {
 	t.Helper()
+
+	skipUnless(t, []TestTag{Tier1})
 
 	// Ensure namespaces with the owned namespace label exist
 	tc.EnsureResourcesExist(

--- a/tests/e2e/components_test.go
+++ b/tests/e2e/components_test.go
@@ -84,6 +84,8 @@ func NewSubComponentTestCtx(t *testing.T, object common.PlatformObject, parentKi
 func (tc *ComponentTestCtx) ValidateComponentEnabled(t *testing.T) {
 	t.Helper()
 
+	skipUnless(t, []TestTag{Smoke, Tier1})
+
 	// As these tests can be executed in a non-cleaned scenario, we need to move the component first to Removed.
 	tc.UpdateComponentStateInDataScienceCluster(operatorv1.Removed)
 
@@ -110,6 +112,8 @@ func (tc *ComponentTestCtx) ValidateComponentEnabled(t *testing.T) {
 // ValidateComponentDisabled ensures that the component is disabled and its resources are deleted.
 func (tc *ComponentTestCtx) ValidateComponentDisabled(t *testing.T) {
 	t.Helper()
+
+	skipUnless(t, []TestTag{Smoke, Tier1})
 
 	// Ensure that the resources associated with the component exist
 	tc.EnsureResourcesExist(WithMinimalObject(tc.GVK, tc.NamespacedName))
@@ -138,6 +142,8 @@ func (tc *ComponentTestCtx) ValidateComponentDisabled(t *testing.T) {
 func (tc *ComponentTestCtx) ValidateOperandsOwnerReferences(t *testing.T) {
 	t.Helper()
 
+	skipUnless(t, []TestTag{Smoke})
+
 	// Ensure that the Deployment resources exist with the proper owner references
 	tc.EnsureResourcesExist(
 		WithMinimalObject(gvk.Deployment, types.NamespacedName{Namespace: tc.AppsNamespace}),
@@ -161,6 +167,8 @@ func (tc *ComponentTestCtx) ValidateOperandsOwnerReferences(t *testing.T) {
 func (tc *ComponentTestCtx) ValidateS3SecretCheckBucketExist(t *testing.T) {
 	t.Helper()
 
+	skipUnless(t, []TestTag{Tier1})
+
 	// Ensure the component is actually enabled before checking for the VAP
 	// This handles cases where the component might have been temporarily disabled
 	// by other test suites (e.g., ModelController, TrustyAI) and needs time to reconcile
@@ -177,6 +185,8 @@ func (tc *ComponentTestCtx) ValidateS3SecretCheckBucketExist(t *testing.T) {
 // ValidateUpdateDeploymentsResources verifies the update of deployment replicas for the component.
 func (tc *ComponentTestCtx) ValidateUpdateDeploymentsResources(t *testing.T) {
 	t.Helper()
+
+	skipUnless(t, []TestTag{Smoke})
 
 	// Ensure that deployments exist for the component
 	deployments := tc.EnsureResourcesExist(
@@ -242,6 +252,8 @@ func (tc *ComponentTestCtx) ValidateCRDsReinstated(t *testing.T, crds []CRD) {
 // ValidateComponentReleases ensures that the component releases exist and have valid fields.
 func (tc *ComponentTestCtx) ValidateComponentReleases(t *testing.T) {
 	t.Helper()
+
+	skipUnless(t, []TestTag{Smoke})
 
 	componentName := strings.ToLower(tc.GVK.Kind)
 
@@ -333,6 +345,8 @@ func (tc *ComponentTestCtx) UpdateSubComponentStateInDataScienceCluster(t *testi
 func (tc *ComponentTestCtx) ValidateSubComponentEnabled(t *testing.T) {
 	t.Helper()
 
+	skipUnless(t, []TestTag{Smoke})
+
 	if tc.ParentKind == "" || tc.SubComponentFieldName == "" {
 		t.Fatal("ValidateSubComponentEnabled called on a component without parent/subcomponent information.")
 	}
@@ -362,6 +376,8 @@ func (tc *ComponentTestCtx) ValidateSubComponentEnabled(t *testing.T) {
 // ValidateSubComponentReleases ensures that the subcomponent releases exist and have valid fields.
 func (tc *ComponentTestCtx) ValidateSubComponentReleases(t *testing.T) {
 	t.Helper()
+
+	skipUnless(t, []TestTag{Smoke})
 
 	if tc.ParentKind == "" || tc.SubComponentFieldName == "" {
 		t.Fatal("ValidateSubComponentReleases called on a component without parent/subcomponent information.")
@@ -477,6 +493,8 @@ func (tc *ComponentTestCtx) ValidateCRDReinstatement(name string, version string
 func (tc *ComponentTestCtx) ValidateModelControllerInstance(t *testing.T) {
 	t.Helper()
 
+	skipUnless(t, []TestTag{Smoke})
+
 	// Ensure ModelController resource exists with the expected owner references and status phase.
 	tc.EnsureResourceExists(
 		WithMinimalObject(gvk.ModelController, types.NamespacedName{Name: componentApi.ModelControllerInstanceName}),
@@ -500,6 +518,8 @@ func (tc *ComponentTestCtx) ValidateModelControllerInstance(t *testing.T) {
 // The order of tests is carefully designed to handle dependencies and avoid timing issues.
 func (tc *ComponentTestCtx) ValidateAllDeletionRecovery(t *testing.T) {
 	t.Helper()
+
+	skipUnless(t, []TestTag{Smoke, Tier1})
 
 	// Increase the global eventually timeout for deletion recovery tests
 	// Use longEventuallyTimeout to handle controller performance under load and complex resource dependencies

--- a/tests/e2e/creation_test.go
+++ b/tests/e2e/creation_test.go
@@ -106,6 +106,8 @@ func dscWebhookTestSuite(t *testing.T) {
 func (tc *DSCTestCtx) ValidateOperatorsInstallation(t *testing.T) {
 	t.Helper()
 
+	skipUnless(t, []TestTag{Smoke})
+
 	// Define operators to be installed.
 	operators := []Operator{
 		{nn: types.NamespacedName{Name: certManagerOpName, Namespace: certManagerOpNamespace}, skipOperatorGroup: false, globalOperatorGroup: true, channel: certManagerOpChannel},
@@ -121,6 +123,8 @@ func (tc *DSCTestCtx) ValidateOperatorsInstallation(t *testing.T) {
 func (tc *DSCTestCtx) ValidateResourcesCreation(t *testing.T) {
 	t.Helper()
 
+	skipUnless(t, []TestTag{Smoke})
+
 	tc.EventuallyResourceCreatedOrUpdated(
 		WithObjectToCreate(CreateJobSetOperator()),
 		WithCondition(jq.Match(`.status.conditions[] | select(.type == "Available") | .status == "True"`)),
@@ -131,6 +135,8 @@ func (tc *DSCTestCtx) ValidateResourcesCreation(t *testing.T) {
 // ValidateDSCICreation validates the creation of a DSCInitialization.
 func (tc *DSCTestCtx) ValidateDSCICreation(t *testing.T) {
 	t.Helper()
+
+	skipUnless(t, []TestTag{Smoke})
 
 	tc.EventuallyResourceCreatedOrUpdated(
 		WithObjectToCreate(CreateDSCI(tc.DSCInitializationNamespacedName.Name, tc.AppsNamespace, tc.MonitoringNamespace)),
@@ -147,6 +153,8 @@ func (tc *DSCTestCtx) ValidateDSCICreation(t *testing.T) {
 func (tc *DSCTestCtx) ValidateDSCCreation(t *testing.T) {
 	t.Helper()
 
+	skipUnless(t, []TestTag{Smoke})
+
 	tc.EventuallyResourceCreatedOrUpdated(
 		WithObjectToCreate(CreateDSC(tc.DataScienceClusterNamespacedName.Name, tc.WorkbenchesNamespace)),
 		WithCondition(jq.Match(`.status.phase == "%s"`, status.ConditionTypeReady)),
@@ -161,6 +169,8 @@ func (tc *DSCTestCtx) ValidateDSCCreation(t *testing.T) {
 // ValidateOwnedNamespacesAllExist verifies that the owned namespaces exist.
 func (tc *DSCTestCtx) ValidateOwnedNamespacesAllExist(t *testing.T) {
 	t.Helper()
+
+	skipUnless(t, []TestTag{Smoke})
 
 	// Ensure namespaces with the owned namespace label exist.
 	tc.EnsureResourcesExist(
@@ -180,6 +190,8 @@ func (tc *DSCTestCtx) ValidateOwnedNamespacesAllExist(t *testing.T) {
 func (tc *DSCTestCtx) ValidateDefaultNetworkPolicyExists(t *testing.T) {
 	t.Helper()
 
+	skipUnless(t, []TestTag{Smoke})
+
 	dsci := tc.FetchDSCInitialization()
 
 	// Ensure namespaces with the owned namespace label exist.
@@ -193,6 +205,8 @@ func (tc *DSCTestCtx) ValidateDefaultNetworkPolicyExists(t *testing.T) {
 func (tc *DSCTestCtx) ValidateDSCIDuplication(t *testing.T) {
 	t.Helper()
 
+	skipUnless(t, []TestTag{Smoke})
+
 	dup := CreateDSCI(dsciInstanceNameDuplicate, tc.AppsNamespace, tc.MonitoringNamespace)
 	tc.EnsureResourceIsUnique(dup, "Error validating DSCInitialization duplication")
 
@@ -204,6 +218,8 @@ func (tc *DSCTestCtx) ValidateDSCIDuplication(t *testing.T) {
 func (tc *DSCTestCtx) ValidateDSCDuplication(t *testing.T) {
 	t.Helper()
 
+	skipUnless(t, []TestTag{Smoke})
+
 	dsc := CreateDSC(dscInstanceNameDuplicate, tc.WorkbenchesNamespace)
 	tc.EnsureResourceIsUnique(dsc, "Error validating DataScienceCluster duplication")
 
@@ -214,6 +230,8 @@ func (tc *DSCTestCtx) ValidateDSCDuplication(t *testing.T) {
 // ValidateModelRegistryConfig validates the ModelRegistry configuration changes based on ManagementState.
 func (tc *DSCTestCtx) ValidateModelRegistryConfig(t *testing.T) {
 	t.Helper()
+
+	skipUnless(t, []TestTag{Tier1})
 
 	// Retrieve the DataScienceCluster object.
 	dsc := tc.FetchDataScienceCluster()
@@ -258,6 +276,8 @@ func (tc *DSCTestCtx) UpdateRegistriesNamespace(targetNamespace, expectedValue s
 
 func (tc *DSCTestCtx) ValidateHardwareProfileCR(t *testing.T) {
 	t.Helper()
+
+	skipUnless(t, []TestTag{Smoke})
 
 	// verifed default hardwareprofile exists and api version is correct on v1.
 	tc.EnsureResourceExists(

--- a/tests/e2e/dashboard_test.go
+++ b/tests/e2e/dashboard_test.go
@@ -56,6 +56,8 @@ func dashboardTestSuite(t *testing.T) {
 func (tc *DashboardTestCtx) ValidateOperandsDynamicallyWatchedResources(t *testing.T) {
 	t.Helper()
 
+	skipUnless(t, []TestTag{Smoke})
+
 	// Generate unique platform type values
 	newPt := xid.New().String()
 	oldPt := ""
@@ -94,6 +96,8 @@ func (tc *DashboardTestCtx) ValidateOperandsDynamicallyWatchedResources(t *testi
 func (tc *DashboardTestCtx) ValidateCRDReinstated(t *testing.T) {
 	t.Helper()
 
+	skipUnless(t, []TestTag{Tier1})
+
 	crds := []CRD{
 		{Name: "odhapplications.dashboard.opendatahub.io", Version: ""},
 		{Name: "odhdocuments.dashboard.opendatahub.io", Version: ""},
@@ -119,6 +123,8 @@ func (tc *DashboardTestCtx) ValidateAllDeletionRecovery(t *testing.T) {
 func (tc *DashboardTestCtx) ValidateHardwareProfileCreationBlockedByWebHook(t *testing.T) {
 	t.Helper()
 
+	skipUnless(t, []TestTag{Tier1})
+
 	testHWPName := "test-hwp-" + xid.New().String()
 	// Create the HardwareProfile object
 	// not use EventuallyResourceCreatedOrUpdated to skip timeout and should expect failure
@@ -138,6 +144,8 @@ func (tc *DashboardTestCtx) ValidateHardwareProfileCreationBlockedByWebHook(t *t
 // todo: remove this when CRD is not included
 func (tc *DashboardTestCtx) ValidateAcceleratorProfileCreationBlockedByWebHook(t *testing.T) {
 	t.Helper()
+
+	skipUnless(t, []TestTag{Tier1})
 
 	testAPName := "test-ap-" + xid.New().String()
 	apProfile := &unstructured.Unstructured{}

--- a/tests/e2e/datasciencepipelines_test.go
+++ b/tests/e2e/datasciencepipelines_test.go
@@ -49,6 +49,8 @@ func dataSciencePipelinesTestSuite(t *testing.T) {
 func (tc *DataSciencePipelinesTestCtx) ValidateConditions(t *testing.T) {
 	t.Helper()
 
+	skipUnless(t, []TestTag{Smoke})
+
 	// Ensure the DataSciencePipelines resource has the "ArgoWorkflowAvailable" condition set to "True".
 	tc.ValidateComponentCondition(
 		gvk.DataSciencePipelines,
@@ -61,6 +63,8 @@ func (tc *DataSciencePipelinesTestCtx) ValidateConditions(t *testing.T) {
 // argoWorkflowsControllersSpec options are set to "Removed" when using v2 API (aipipelines field).
 func (tc *DataSciencePipelinesTestCtx) ValidateArgoWorkflowsControllersOptions(t *testing.T) {
 	t.Helper()
+
+	skipUnless(t, []TestTag{Tier1})
 
 	tc.EventuallyResourcePatched(
 		WithMinimalObject(gvk.DataScienceCluster, tc.DataScienceClusterNamespacedName),

--- a/tests/e2e/deletion_test.go
+++ b/tests/e2e/deletion_test.go
@@ -39,6 +39,8 @@ func deletionTestSuite(t *testing.T) {
 func (tc *DeletionTestCtx) TestDSCDeletion(t *testing.T) {
 	t.Helper()
 
+	skipUnless(t, []TestTag{Tier1})
+
 	// Delete the DataScienceCluster instance
 	tc.DeleteResource(WithMinimalObject(gvk.DataScienceCluster, tc.DataScienceClusterNamespacedName))
 }
@@ -46,6 +48,8 @@ func (tc *DeletionTestCtx) TestDSCDeletion(t *testing.T) {
 // TestDSCIDeletion deletes the DSCInitialization instance if it exists.
 func (tc *DeletionTestCtx) TestDSCIDeletion(t *testing.T) {
 	t.Helper()
+
+	skipUnless(t, []TestTag{Tier1})
 
 	// Delete the DSCInitialization instance
 	tc.DeleteResource(WithMinimalObject(gvk.DSCInitialization, tc.DSCInitializationNamespacedName))

--- a/tests/e2e/gateway_redirect_test.go
+++ b/tests/e2e/gateway_redirect_test.go
@@ -19,17 +19,19 @@ import (
 func (tc *GatewayTestCtx) DashboardRedirectTestSuite(t *testing.T) {
 	t.Helper()
 
+	skipUnless(t, []TestTag{Tier1})
+
 	// Skip all tests if not in OcpRoute mode
 	if !tc.isOcpRouteMode(t) {
 		t.Skip("Dashboard redirects are only created in OcpRoute ingress mode")
 	}
 
 	testCases := []TestCase{
-		{"ConfigMap", tc.ValidateDashboardRedirectConfigMap},
-		{"Deployment", tc.ValidateDashboardRedirectDeployment},
-		{"Service", tc.ValidateDashboardRedirectService},
-		{"Routes", tc.ValidateDashboardRedirectRoutes},
-		{"HTTP functionality", tc.ValidateDashboardRedirectHTTP},
+		{"Validate dashboard redirect ConfigMap", tc.ValidateDashboardRedirectConfigMap},
+		{"Validate dashboard redirect Deployment", tc.ValidateDashboardRedirectDeployment},
+		{"Validate dashboard redirect Service", tc.ValidateDashboardRedirectService},
+		{"Validate dashboard redirect Routes", tc.ValidateDashboardRedirectRoutes},
+		{"Validate dashboard redirect HTTP functionality", tc.ValidateDashboardRedirectHTTP},
 	}
 
 	RunTestCases(t, testCases)
@@ -39,6 +41,8 @@ func (tc *GatewayTestCtx) DashboardRedirectTestSuite(t *testing.T) {
 func (tc *GatewayTestCtx) ValidateDashboardRedirectConfigMap(t *testing.T) {
 	t.Helper()
 	t.Log("Validating dashboard redirect ConfigMap")
+
+	skipUnless(t, []TestTag{Tier1})
 
 	appNamespace := tc.AppsNamespace
 	expectedGatewayHostname := tc.getExpectedGatewayHostname(t)
@@ -81,6 +85,7 @@ func (tc *GatewayTestCtx) ValidateDashboardRedirectConfigMap(t *testing.T) {
 // - Proper security context and resource limits.
 func (tc *GatewayTestCtx) ValidateDashboardRedirectDeployment(t *testing.T) {
 	t.Helper()
+	skipUnless(t, []TestTag{Tier1})
 	t.Log("Validating dashboard redirect Deployment")
 
 	appNamespace := tc.AppsNamespace
@@ -146,6 +151,7 @@ func (tc *GatewayTestCtx) ValidateDashboardRedirectDeployment(t *testing.T) {
 // ValidateDashboardRedirectService validates the redirect service configuration.
 func (tc *GatewayTestCtx) ValidateDashboardRedirectService(t *testing.T) {
 	t.Helper()
+	skipUnless(t, []TestTag{Tier1})
 	t.Log("Validating dashboard redirect Service")
 
 	appNamespace := tc.AppsNamespace
@@ -192,6 +198,7 @@ func (tc *GatewayTestCtx) ValidateDashboardRedirectService(t *testing.T) {
 // - Routes have GatewayConfig owner references (verifies SSA ownership takeover).
 func (tc *GatewayTestCtx) ValidateDashboardRedirectRoutes(t *testing.T) {
 	t.Helper()
+	skipUnless(t, []TestTag{Tier1})
 	t.Log("Validating dashboard redirect Routes")
 
 	appNamespace := tc.AppsNamespace
@@ -277,6 +284,7 @@ func (tc *GatewayTestCtx) ValidateDashboardRedirectRoutes(t *testing.T) {
 // - Path is preserved in redirect ($request_uri works correctly).
 func (tc *GatewayTestCtx) ValidateDashboardRedirectHTTP(t *testing.T) {
 	t.Helper()
+	skipUnless(t, []TestTag{Tier1})
 	t.Log("Validating dashboard redirect HTTP functionality")
 
 	dashboardRouteName := getDashboardRouteNameByPlatform(tc.FetchPlatformRelease())

--- a/tests/e2e/gateway_test.go
+++ b/tests/e2e/gateway_test.go
@@ -83,6 +83,7 @@ func gatewayTestSuite(t *testing.T) {
 		TestContext: ctx,
 	}
 
+	// Define test cases.
 	testCases := []TestCase{
 		{"Validate GatewayConfig creation", gatewayCtx.ValidateGatewayConfig},
 		{"Validate Gateway infrastructure", gatewayCtx.ValidateGatewayInfrastructure},
@@ -116,6 +117,8 @@ func makeCookieDomain(hostname string) string {
 // ValidateGatewayConfig ensures the GatewayConfig CR exists and is properly configured.
 func (tc *GatewayTestCtx) ValidateGatewayConfig(t *testing.T) {
 	t.Helper()
+
+	skipUnless(t, []TestTag{Smoke})
 	t.Log("Validating GatewayConfig resource")
 
 	// Common validation: Ready status and ownership
@@ -135,6 +138,8 @@ func (tc *GatewayTestCtx) ValidateGatewayConfig(t *testing.T) {
 // ValidateGatewayInfrastructure validates Gateway API resources (GatewayClass, Gateway, TLS).
 func (tc *GatewayTestCtx) ValidateGatewayInfrastructure(t *testing.T) {
 	t.Helper()
+
+	skipUnless(t, []TestTag{Tier1})
 	t.Log("Validating Gateway infrastructure resources")
 
 	t.Log("Validating GatewayClass resource")
@@ -179,6 +184,8 @@ func (tc *GatewayTestCtx) ValidateGatewayInfrastructure(t *testing.T) {
 // ValidateOAuthClientAndSecret validates OpenShift OAuth client and proxy secret creation.
 func (tc *GatewayTestCtx) ValidateOAuthClientAndSecret(t *testing.T) {
 	t.Helper()
+
+	skipUnless(t, []TestTag{Tier1})
 	t.Log("Validating OAuth client and secret creation")
 
 	expectedGatewayHostname := tc.getExpectedGatewayHostname(t)
@@ -236,6 +243,8 @@ func (tc *GatewayTestCtx) ValidateOAuthClientAndSecret(t *testing.T) {
 // - TLS certificates are properly mounted.
 func (tc *GatewayTestCtx) ValidateAuthProxyDeployment(t *testing.T) {
 	t.Helper()
+
+	skipUnless(t, []TestTag{Tier1})
 	t.Log("Validating kube-auth-proxy deployment and service")
 
 	expectedGatewayHostname := tc.getExpectedGatewayHostname(t)
@@ -371,6 +380,8 @@ func (tc *GatewayTestCtx) ValidateAuthProxyDeployment(t *testing.T) {
 // - Scaling behavior is configured for stable scale-down and rapid scale-up.
 func (tc *GatewayTestCtx) ValidateHPA(t *testing.T) {
 	t.Helper()
+
+	skipUnless(t, []TestTag{Tier1})
 	t.Log("Validating HorizontalPodAutoscaler for kube-auth-proxy")
 
 	tc.EnsureResourceExists(
@@ -414,6 +425,8 @@ func (tc *GatewayTestCtx) ValidateHPA(t *testing.T) {
 // ValidateOAuthCallbackRoute validates the OAuth callback HTTPRoute configuration.
 func (tc *GatewayTestCtx) ValidateOAuthCallbackRoute(t *testing.T) {
 	t.Helper()
+
+	skipUnless(t, []TestTag{Tier1})
 	t.Log("Validating OAuth callback HTTPRoute")
 
 	tc.EnsureResourceExists(
@@ -458,6 +471,8 @@ func (tc *GatewayTestCtx) ValidateOAuthCallbackRoute(t *testing.T) {
 // ValidateEnvoyFilter validates the EnvoyFilter for external authorization.
 func (tc *GatewayTestCtx) ValidateEnvoyFilter(t *testing.T) {
 	t.Helper()
+
+	skipUnless(t, []TestTag{Tier1})
 	t.Log("Validating EnvoyFilter for authentication")
 
 	authProxyFQDN := getServiceFQDN(kubeAuthProxyName, gatewayNamespace)
@@ -517,6 +532,8 @@ func (tc *GatewayTestCtx) ValidateEnvoyFilter(t *testing.T) {
 // - Service is properly configured for EDS to discover endpoints.
 func (tc *GatewayTestCtx) ValidateEDSEndpointDiscovery(t *testing.T) {
 	t.Helper()
+
+	skipUnless(t, []TestTag{Tier1})
 	t.Log("Validating EDS service configuration for kube-auth-proxy")
 
 	tc.EnsureResourceExists(
@@ -538,6 +555,8 @@ func (tc *GatewayTestCtx) ValidateEDSEndpointDiscovery(t *testing.T) {
 // ValidateGatewayReadyStatus validates Gateway resource is fully operational and ready to route traffic.
 func (tc *GatewayTestCtx) ValidateGatewayReadyStatus(t *testing.T) {
 	t.Helper()
+
+	skipUnless(t, []TestTag{Smoke})
 	t.Log("Validating Gateway ready status")
 
 	// Core validation: Gateway is Accepted, Programmed, and has routes attached
@@ -570,6 +589,8 @@ func (tc *GatewayTestCtx) ValidateGatewayReadyStatus(t *testing.T) {
 // that is attached to the Gateway, providing a real route to test authentication against.
 func (tc *GatewayTestCtx) ValidateUnauthenticatedRedirect(t *testing.T) {
 	t.Helper()
+
+	skipUnless(t, []TestTag{Tier1})
 
 	tc.UpdateComponentStateInDataScienceClusterWithKind(operatorv1.Managed, componentApi.DashboardKind)
 	defer tc.UpdateComponentStateInDataScienceClusterWithKind(operatorv1.Removed, componentApi.DashboardKind)
@@ -763,6 +784,8 @@ func getServiceFQDN(serviceName, namespace string) string {
 // ValidateNetworkPolicy validates the NetworkPolicy resource for kube-auth-proxy.
 func (tc *GatewayTestCtx) ValidateNetworkPolicy(t *testing.T) {
 	t.Helper()
+
+	skipUnless(t, []TestTag{Tier1})
 	t.Log("Validating NetworkPolicy for kube-auth-proxy")
 
 	tc.EnsureResourceExists(

--- a/tests/e2e/hardwareprofile_test.go
+++ b/tests/e2e/hardwareprofile_test.go
@@ -58,6 +58,8 @@ func hardwareProfileWorkloadTestSuite(t *testing.T) {
 func (tc *HardwareProfileWorkloadTestCtx) ValidateHWPToleration(t *testing.T) {
 	t.Helper()
 
+	skipUnless(t, []TestTag{Tier1})
+
 	workloadName := "test-notebook-toleration"
 
 	// Create an empty hardware profile (empty-profile)
@@ -131,6 +133,8 @@ func (tc *HardwareProfileWorkloadTestCtx) ValidateHWPToleration(t *testing.T) {
 func (tc *HardwareProfileWorkloadTestCtx) ValidateHWPKueue(t *testing.T) {
 	t.Helper()
 
+	skipUnless(t, []TestTag{Tier1})
+
 	workloadName := "test-notebook-kueue"
 	// Create an empty hardware profile (empty-profile)
 	hwpEmpty := tc.createEmptyHardwareProfile("empty-hwp-test-kueue")
@@ -188,6 +192,8 @@ func (tc *HardwareProfileWorkloadTestCtx) ValidateHWPKueue(t *testing.T) {
 // the HWP-applied tolerations and nodeSelector are cleaned up, but manually-added ones are preserved.
 func (tc *HardwareProfileWorkloadTestCtx) ValidateHWPAnnotationRemoval(t *testing.T) {
 	t.Helper()
+
+	skipUnless(t, []TestTag{Tier1})
 
 	workloadName := "test-notebook-hwp-removal"
 
@@ -272,6 +278,8 @@ func (tc *HardwareProfileWorkloadTestCtx) ValidateHWPAnnotationRemoval(t *testin
 func (tc *HardwareProfileWorkloadTestCtx) ValidateManualTolerationPreservation(t *testing.T) {
 	t.Helper()
 
+	skipUnless(t, []TestTag{Tier1})
+
 	workloadName := "test-notebook-manual-tol"
 
 	// Create a hardware profile with tolerations
@@ -338,6 +346,8 @@ func (tc *HardwareProfileWorkloadTestCtx) ValidateManualTolerationPreservation(t
 func (tc *HardwareProfileWorkloadTestCtx) ValidateHWPProfileSwitching(t *testing.T) {
 	t.Helper()
 
+	skipUnless(t, []TestTag{Tier1})
+
 	workloadName := "test-notebook-profile-switch"
 
 	// Create two different hardware profiles with different tolerations
@@ -401,6 +411,8 @@ func (tc *HardwareProfileWorkloadTestCtx) ValidateHWPProfileSwitching(t *testing
 // from a workload with Kueue scheduling, the kueue.x-k8s.io/queue-name label is removed.
 func (tc *HardwareProfileWorkloadTestCtx) ValidateKueueLabelRemovalOnHWPRemoval(t *testing.T) {
 	t.Helper()
+
+	skipUnless(t, []TestTag{Tier1})
 
 	workloadName := "test-notebook-kueue-removal"
 

--- a/tests/e2e/kserve_test.go
+++ b/tests/e2e/kserve_test.go
@@ -100,6 +100,8 @@ func kserveDegradedMonitoringTestSuite(t *testing.T) {
 func (tc *KserveTestCtx) ValidateSpec(t *testing.T) {
 	t.Helper()
 
+	skipUnless(t, []TestTag{Smoke})
+
 	// Retrieve the DataScienceCluster instance.
 	dsc := tc.FetchDataScienceCluster()
 
@@ -116,6 +118,8 @@ func (tc *KserveTestCtx) ValidateSpec(t *testing.T) {
 // ValidateNoKserveFeatureTrackers ensures there are no FeatureTrackers for Kserve.
 func (tc *KserveTestCtx) ValidateNoKserveFeatureTrackers(t *testing.T) {
 	t.Helper()
+
+	skipUnless(t, []TestTag{Smoke})
 
 	tc.EnsureResourcesDoNotExist(
 		WithMinimalObject(gvk.FeatureTracker, tc.NamespacedName),
@@ -135,6 +139,8 @@ func (tc *KserveTestCtx) ValidateNoKserveFeatureTrackers(t *testing.T) {
 // secrets into InferenceService resources with existing imagePullSecrets.
 func (tc *KserveTestCtx) ValidateConnectionWebhookInjection(t *testing.T) {
 	t.Helper()
+
+	skipUnless(t, []TestTag{Tier1})
 
 	// Ensure KServe is in Managed state to enable webhook functionality
 	tc.ValidateComponentEnabled(t)
@@ -207,6 +213,8 @@ func (tc *KserveTestCtx) createConnectionSecret(secretName, namespace string) {
 func (tc *KserveTestCtx) ValidateLLMInferenceServiceConfigVersioned(t *testing.T) {
 	t.Helper()
 
+	skipUnless(t, []TestTag{Tier1})
+
 	// Validate that all well-known LLMInferenceServiceConfig resources have versioned names
 	// Expected format: vX-Y-Z-<config-name> where X, Y, Z are numbers
 	// Only check resources with the well-known-config annotation set to true
@@ -272,6 +280,8 @@ func (tc *KserveTestCtx) ensureLWSBaseline(t *testing.T) *unstructured.Unstructu
 // External Operator CR > Kserve Component CR > DataScienceCluster CR.
 func (tc *KserveTestCtx) ValidateExternalOperatorDegradedMonitoring(t *testing.T) {
 	t.Helper()
+
+	skipUnless(t, []TestTag{Tier1})
 
 	// condition types monitored by the Kserve Component
 	testCases := []degradedConditionTestCase{

--- a/tests/e2e/kueue_test.go
+++ b/tests/e2e/kueue_test.go
@@ -125,6 +125,8 @@ func kueueDegradedMonitoringTestSuite(t *testing.T) {
 func (tc *KueueTestCtx) EnsureKueueReady(t *testing.T) {
 	t.Helper()
 
+	skipUnless(t, []TestTag{Tier1})
+
 	componentName := strings.ToLower(tc.GVK.Kind)
 
 	t.Logf("Ensuring OCP Kueue Operator is installed (namespace=%s, name=%s).", kueueOcpOperatorNamespace, kueueOpName)
@@ -155,6 +157,8 @@ func (tc *KueueTestCtx) EnsureKueueReady(t *testing.T) {
 // ValidateKueueUnmanagedWithoutOcpKueueOperator ensures that if the component is in Unmanaged state and ocp kueue operator is not installed, then its status is "Not Ready".
 func (tc *KueueTestCtx) ValidateKueueUnmanagedWithoutOcpKueueOperator(t *testing.T) {
 	t.Helper()
+
+	skipUnless(t, []TestTag{Tier1})
 
 	componentName := strings.ToLower(tc.GVK.Kind)
 
@@ -194,6 +198,8 @@ func (tc *KueueTestCtx) ValidateKueueUnmanagedWithoutOcpKueueOperator(t *testing
 // ValidateComponentEnabled ensures the transition between Removed and Unmanaged state happens as expected.
 func (tc *KueueTestCtx) ValidateKueueRemovedToUnmanagedTransition(t *testing.T) {
 	t.Helper()
+
+	skipUnless(t, []TestTag{Smoke})
 
 	managedNS := "test-kueue-managed-" + xid.New().String()
 	componentName := strings.ToLower(tc.GVK.Kind)
@@ -286,6 +292,8 @@ func (tc *KueueTestCtx) ValidateKueueRemovedToUnmanagedTransition(t *testing.T) 
 func (tc *KueueTestCtx) ValidateKueueUnmanagedToRemovedTransition(t *testing.T) {
 	t.Helper()
 
+	skipUnless(t, []TestTag{Smoke})
+
 	managedNS := "test-kueue-managed-" + xid.New().String()
 	componentName := strings.ToLower(tc.GVK.Kind)
 
@@ -364,6 +372,8 @@ func (tc *KueueTestCtx) ValidateKueueUnmanagedToRemovedTransition(t *testing.T) 
 // with proper Workbenches component setup/teardown.
 func (tc *KueueTestCtx) ValidateWebhookValidations(t *testing.T) {
 	t.Helper()
+
+	skipUnless(t, []TestTag{Tier1})
 
 	t.Logf("Setting Workbenches component to Managed to install Notebook CRD for webhook tests.")
 	// Enable Workbenches component to ensure Notebook CRD is available for webhook tests
@@ -769,6 +779,8 @@ func (tc *KueueTestCtx) ensureClusterAndLocalQueueExist(localQueueNamespaceName 
 func (tc *KueueTestCtx) ValidateKueueComponentDisabled(t *testing.T) {
 	t.Helper()
 
+	skipUnless(t, []TestTag{Smoke, Tier1})
+
 	t.Logf("Setting DSC component %s to Removed state.", componentApi.KueueInstanceName)
 	// Ensure that DataScienceCluster exists and its component state is "Removed", with the "Ready" condition false.
 	tc.UpdateComponentStateInDataScienceCluster(operatorv1.Removed)
@@ -845,6 +857,8 @@ integrations:
 // but the operator can't reset conditions we inject.
 func (tc *KueueTestCtx) ValidateExternalOperatorDegradedMonitoring(t *testing.T) {
 	t.Helper()
+
+	skipUnless(t, []TestTag{Tier1})
 
 	managedNS := "test-kueue-managed-" + xid.New().String()
 

--- a/tests/e2e/modelregistry_test.go
+++ b/tests/e2e/modelregistry_test.go
@@ -45,6 +45,8 @@ func modelRegistryTestSuite(t *testing.T) {
 func (tc *ModelRegistryTestCtx) ValidateSpec(t *testing.T) {
 	t.Helper()
 
+	skipUnless(t, []TestTag{Smoke})
+
 	// Retrieve the DataScienceCluster instance.
 	dsc := tc.FetchDataScienceCluster()
 
@@ -58,6 +60,8 @@ func (tc *ModelRegistryTestCtx) ValidateSpec(t *testing.T) {
 // ValidateCRDReinstated ensures that required CRDs are reinstated if deleted.
 func (tc *ModelRegistryTestCtx) ValidateCRDReinstated(t *testing.T) {
 	t.Helper()
+
+	skipUnless(t, []TestTag{Tier1})
 
 	crds := []CRD{
 		{Name: "modelregistries.modelregistry.opendatahub.io", Version: ""},

--- a/tests/e2e/monitoring_test.go
+++ b/tests/e2e/monitoring_test.go
@@ -98,7 +98,7 @@ func monitoringTestSuite(t *testing.T) {
 
 	// Define test cases.
 	testCases := []TestCase{
-		{name: "Ensure required monitoring operators are installed", testFn: monitoringServiceCtx.ValidateMonitoringOperatorsInstallation},
+		{"Ensure required monitoring operators are installed", monitoringServiceCtx.ValidateMonitoringOperatorsInstallation},
 		{"Auto creation of Monitoring CR", monitoringServiceCtx.ValidateMonitoringCRCreation},
 		{"Test Monitoring CR content default value", monitoringServiceCtx.ValidateMonitoringCRDefaultContent},
 		{"Test Traces default content", monitoringServiceCtx.ValidateMonitoringCRDefaultTracesContent},
@@ -150,6 +150,8 @@ func monitoringTestSuite(t *testing.T) {
 func (tc *MonitoringTestCtx) ValidateMonitoringOperatorsInstallation(t *testing.T) {
 	t.Helper()
 
+	skipUnless(t, []TestTag{Tier1})
+
 	// Define operators to be installed.
 	operators := []Operator{
 		{nn: types.NamespacedName{Name: observabilityOpName, Namespace: observabilityOpNamespace}, skipOperatorGroup: false, globalOperatorGroup: true, channel: defaultOperatorChannel},
@@ -163,6 +165,8 @@ func (tc *MonitoringTestCtx) ValidateMonitoringOperatorsInstallation(t *testing.
 // ValidateMonitoringCRCreation ensures that exactly one Monitoring CR exists and status to Ready.
 func (tc *MonitoringTestCtx) ValidateMonitoringCRCreation(t *testing.T) {
 	t.Helper()
+
+	skipUnless(t, []TestTag{Tier1})
 
 	tc.updateMonitoringConfig(withManagementState(operatorv1.Managed))
 
@@ -185,6 +189,8 @@ func (tc *MonitoringTestCtx) ValidateMonitoringCRCreation(t *testing.T) {
 func (tc *MonitoringTestCtx) ValidateMonitoringCRDefaultContent(t *testing.T) {
 	t.Helper()
 
+	skipUnless(t, []TestTag{Tier1})
+
 	// Ensure that the Monitoring resource exists.
 	tc.EnsureResourceExists(
 		WithMinimalObject(gvk.Monitoring, types.NamespacedName{Name: MonitoringCRName}),
@@ -206,6 +212,8 @@ func (tc *MonitoringTestCtx) ValidateMonitoringCRDefaultContent(t *testing.T) {
 // ValidateMonitoringStackCRMetricsWhenSet validates that MonitoringStack CR is created with correct metrics configuration when metrics are set in DSCI.
 func (tc *MonitoringTestCtx) ValidateMonitoringStackCRMetricsWhenSet(t *testing.T) {
 	t.Helper()
+
+	skipUnless(t, []TestTag{Tier1})
 
 	// Update DSCI to set metrics - ensure managementState remains Managed
 	tc.updateMonitoringConfig(
@@ -230,6 +238,8 @@ func (tc *MonitoringTestCtx) ValidateMonitoringStackCRMetricsWhenSet(t *testing.
 // ValidateMonitoringStackCRMetricsConfiguration verifies that MonitoringStack CR contains the correct metrics storage size, retention, and resource limits.
 func (tc *MonitoringTestCtx) ValidateMonitoringStackCRMetricsConfiguration(t *testing.T) {
 	t.Helper()
+
+	skipUnless(t, []TestTag{Tier1})
 
 	// Use EnsureResourceExists with jq matchers for cleaner validation
 	tc.EnsureResourceExists(
@@ -256,6 +266,8 @@ func (tc *MonitoringTestCtx) ValidateMonitoringStackCRMetricsConfiguration(t *te
 func (tc *MonitoringTestCtx) ValidateMonitoringStackCRMetricsReplicasUpdate(t *testing.T) {
 	t.Helper()
 
+	skipUnless(t, []TestTag{Tier1})
+
 	// Update DSCI to set replicas to 1 (must include either storage or resources due to CEL validation rule)
 	replicasTransforms := append(
 		[]testf.TransformFn{
@@ -280,6 +292,8 @@ func (tc *MonitoringTestCtx) ValidateMonitoringStackCRMetricsReplicasUpdate(t *t
 // ValidateCELBlocksInvalidMonitoringConfigs tests that CEL validation blocks invalid monitoring configurations.
 func (tc *MonitoringTestCtx) ValidateCELBlocksInvalidMonitoringConfigs(t *testing.T) {
 	t.Helper()
+
+	skipUnless(t, []TestTag{Tier1})
 
 	testCases := []struct {
 		name        string
@@ -333,6 +347,8 @@ func (tc *MonitoringTestCtx) ValidateCELBlocksInvalidMonitoringConfigs(t *testin
 func (tc *MonitoringTestCtx) ValidateCELAllowsValidMonitoringConfigs(t *testing.T) {
 	t.Helper()
 
+	skipUnless(t, []TestTag{Tier1})
+
 	testCases := []struct {
 		name        string
 		transforms  []testf.TransformFn
@@ -373,6 +389,8 @@ func (tc *MonitoringTestCtx) ValidateCELAllowsValidMonitoringConfigs(t *testing.
 // ValidateOpenTelemetryCollectorConfigurations consolidates all OpenTelemetry Collector configuration tests.
 func (tc *MonitoringTestCtx) ValidateOpenTelemetryCollectorConfigurations(t *testing.T) {
 	t.Helper()
+
+	skipUnless(t, []TestTag{Tier1})
 
 	testCases := []struct {
 		name                string
@@ -472,6 +490,8 @@ func (tc *MonitoringTestCtx) ValidateOpenTelemetryCollectorConfigurations(t *tes
 // ValidateMetricsTLSAlwaysEnabled validates that TLS is always enabled for the OpenTelemetry Collector Prometheus exporter.
 func (tc *MonitoringTestCtx) ValidateMetricsTLSAlwaysEnabled(t *testing.T) {
 	t.Helper()
+
+	skipUnless(t, []TestTag{Tier1})
 	tc.updateMonitoringConfig(
 		withManagementState(operatorv1.Managed),
 		tc.withMetricsConfig(),
@@ -540,6 +560,8 @@ func (tc *MonitoringTestCtx) ValidateMetricsTLSAlwaysEnabled(t *testing.T) {
 func (tc *MonitoringTestCtx) ValidateMonitoringCRCollectorReplicas(t *testing.T) {
 	t.Helper()
 
+	skipUnless(t, []TestTag{Tier1})
+
 	defaultReplicas := tc.expectedDefaultReplicas
 	testReplicas := defaultReplicas + 1 // Test with one more replica than default
 
@@ -576,6 +598,8 @@ func (tc *MonitoringTestCtx) ValidateMonitoringCRCollectorReplicas(t *testing.T)
 func (tc *MonitoringTestCtx) ValidateMonitoringCRDefaultTracesContent(t *testing.T) {
 	t.Helper()
 
+	skipUnless(t, []TestTag{Tier1})
+
 	// Ensure monitoring is enabled (might have been disabled by previous test)
 	tc.updateMonitoringConfig(withManagementState(operatorv1.Managed))
 
@@ -593,6 +617,8 @@ func (tc *MonitoringTestCtx) ValidateMonitoringCRDefaultTracesContent(t *testing
 // ValidateTempoMonolithicCRCreation tests creation of TempoMonolithic CR with PV backend and custom retention.
 func (tc *MonitoringTestCtx) ValidateTempoMonolithicCRCreation(t *testing.T) {
 	t.Helper()
+
+	skipUnless(t, []TestTag{Tier1})
 
 	// Update DSCI to set traces with PV backend
 	tc.updateMonitoringConfig(
@@ -640,6 +666,8 @@ func (tc *MonitoringTestCtx) ValidateTempoMonolithicCRCreation(t *testing.T) {
 func (tc *MonitoringTestCtx) ValidateTempoStackCRCreationWithCloudStorage(t *testing.T) {
 	t.Helper()
 
+	skipUnless(t, []TestTag{Tier1})
+
 	testCases := []struct {
 		name                string
 		backend             string
@@ -674,6 +702,8 @@ func (tc *MonitoringTestCtx) ValidateTempoStackCRCreationWithCloudStorage(t *tes
 
 func (tc *MonitoringTestCtx) ValidateInstrumentationCRTracesLifecycle(t *testing.T) {
 	t.Helper()
+
+	skipUnless(t, []TestTag{Tier1})
 
 	// Ensure clean slate before starting
 	tc.ensureMonitoringCleanSlate(t, "")
@@ -724,6 +754,8 @@ func (tc *MonitoringTestCtx) ValidateInstrumentationCRTracesLifecycle(t *testing
 func (tc *MonitoringTestCtx) ValidateTracesExportersReservedNameValidation(t *testing.T) {
 	t.Helper()
 
+	skipUnless(t, []TestTag{Tier1})
+
 	// Attempt to set traces configuration with a reserved exporter name
 	tc.updateMonitoringConfig(
 		withManagementState(operatorv1.Managed),
@@ -749,6 +781,8 @@ func (tc *MonitoringTestCtx) ValidateTracesExportersReservedNameValidation(t *te
 // ValidatePrometheusRulesLifecycle validates that Prometheus rules are created when monitoring and dashboard are enabled, and deleted when both are disabled.
 func (tc *MonitoringTestCtx) ValidatePrometheusRulesLifecycle(t *testing.T) {
 	t.Helper()
+
+	skipUnless(t, []TestTag{Tier1})
 
 	// First, ensure dashboard is disabled to establish a known initial state.
 	tc.UpdateComponentStateInDataScienceClusterWithKind(operatorv1.Removed, gvk.Dashboard.Kind)
@@ -781,6 +815,8 @@ func (tc *MonitoringTestCtx) ValidatePrometheusRulesLifecycle(t *testing.T) {
 func (tc *MonitoringTestCtx) ValidatePersesCRCreation(t *testing.T) {
 	t.Helper()
 
+	skipUnless(t, []TestTag{Tier1})
+
 	tc.updateMonitoringConfig(
 		withManagementState(operatorv1.Managed),
 		tc.withMetricsConfig(),
@@ -800,6 +836,8 @@ func (tc *MonitoringTestCtx) ValidatePersesCRCreation(t *testing.T) {
 
 func (tc *MonitoringTestCtx) ValidatePersesCRConfiguration(t *testing.T) {
 	t.Helper()
+
+	skipUnless(t, []TestTag{Tier1})
 
 	tc.EnsureResourceExists(
 		WithMinimalObject(gvk.Perses, types.NamespacedName{Name: PersesName, Namespace: tc.MonitoringNamespace}),
@@ -834,6 +872,8 @@ func (tc *MonitoringTestCtx) ValidatePersesCRConfiguration(t *testing.T) {
 
 func (tc *MonitoringTestCtx) ValidatePersesLifecycle(t *testing.T) {
 	t.Helper()
+
+	skipUnless(t, []TestTag{Tier1})
 
 	tc.updateMonitoringConfig(
 		withManagementState(operatorv1.Managed),
@@ -881,6 +921,8 @@ func (tc *MonitoringTestCtx) ValidatePersesLifecycle(t *testing.T) {
 func (tc *MonitoringTestCtx) ValidatePersesNotDeployedWithoutMetricsOrTraces(t *testing.T) {
 	t.Helper()
 
+	skipUnless(t, []TestTag{Tier1})
+
 	tc.ensureMonitoringCleanSlate(t, "")
 
 	tc.updateMonitoringConfig(
@@ -919,6 +961,8 @@ func (tc *MonitoringTestCtx) ValidatePersesNotDeployedWithoutMetricsOrTraces(t *
 func (tc *MonitoringTestCtx) ValidatePersesNetworkPolicy(t *testing.T) {
 	t.Helper()
 
+	skipUnless(t, []TestTag{Tier1})
+
 	tc.updateMonitoringConfig(
 		withManagementState(operatorv1.Managed),
 		tc.withMetricsConfig(),
@@ -942,6 +986,8 @@ func (tc *MonitoringTestCtx) ValidatePersesNetworkPolicy(t *testing.T) {
 // ValidatePersesDatasourceWithPrometheus validates that Prometheus datasource is created when both Perses and MonitoringStack are deployed.
 func (tc *MonitoringTestCtx) ValidatePersesDatasourceWithPrometheus(t *testing.T) {
 	t.Helper()
+
+	skipUnless(t, []TestTag{Tier1})
 
 	// Enable monitoring with metrics configuration to deploy both Perses and Prometheus
 	tc.updateMonitoringConfig(
@@ -1003,6 +1049,8 @@ func (tc *MonitoringTestCtx) ValidatePersesDatasourceWithPrometheus(t *testing.T
 // ValidatePersesDatasourceLifecycle tests the complete lifecycle of PersesDatasource deployment and cleanup.
 func (tc *MonitoringTestCtx) ValidatePersesDatasourceLifecycle(t *testing.T) {
 	t.Helper()
+
+	skipUnless(t, []TestTag{Tier1})
 
 	// Step 1: Enable monitoring with metrics to deploy datasource
 	tc.updateMonitoringConfig(
@@ -1071,6 +1119,8 @@ func (tc *MonitoringTestCtx) ValidatePersesDatasourceLifecycle(t *testing.T) {
 // ValidateMonitoringServiceDisabled ensures monitoring service can be disabled and resources are cleaned up.
 func (tc *MonitoringTestCtx) ValidateMonitoringServiceDisabled(t *testing.T) {
 	t.Helper()
+
+	skipUnless(t, []TestTag{Tier1})
 
 	// Ensure clean slate - previous tests may have left TempoMonolithic with TLS enabled
 	// and already in deletion state, which prevents our controller from updating it
@@ -1453,6 +1503,8 @@ func withMonitoringTraces(backend, secret, size, retention string) testf.Transfo
 func (tc *MonitoringTestCtx) ValidateThanosQuerierDeployment(t *testing.T) {
 	t.Helper()
 
+	skipUnless(t, []TestTag{Tier1})
+
 	// Ensure clean slate before starting
 	tc.ensureMonitoringCleanSlate(t, "")
 
@@ -1507,6 +1559,8 @@ func (tc *MonitoringTestCtx) ValidateThanosQuerierDeployment(t *testing.T) {
 func (tc *MonitoringTestCtx) ValidateThanosQuerierNotDeployedWithoutMetrics(t *testing.T) {
 	t.Helper()
 
+	skipUnless(t, []TestTag{Tier1})
+
 	// Ensure clean slate before starting
 	tc.ensureMonitoringCleanSlate(t, "")
 
@@ -1551,6 +1605,8 @@ func (tc *MonitoringTestCtx) ValidateThanosQuerierNotDeployedWithoutMetrics(t *t
 // and properly configured with the correct serverName to fix TLS SANs mismatch issues.
 func (tc *MonitoringTestCtx) ValidatePrometheusSelfServiceMonitorTLSFix(t *testing.T) {
 	t.Helper()
+
+	skipUnless(t, []TestTag{Tier1})
 
 	tc.updateMonitoringConfig(
 		withManagementState(operatorv1.Managed),
@@ -1622,6 +1678,8 @@ func (tc *MonitoringTestCtx) ValidatePrometheusSelfServiceMonitorTLSFix(t *testi
 func (tc *MonitoringTestCtx) ValidatePersesDatasourceCreationWithTraces(t *testing.T) {
 	t.Helper()
 
+	skipUnless(t, []TestTag{Tier1})
+
 	// Skip if PersesDatasource CRD is not installed
 	ctx := context.Background()
 	exists, err := cluster.HasCRD(ctx, tc.Client(), gvk.PersesDatasource)
@@ -1685,6 +1743,8 @@ func (tc *MonitoringTestCtx) ValidatePersesDatasourceCreationWithTraces(t *testi
 // ValidatePersesDatasourceConfiguration tests the configuration of the Perses datasource.
 func (tc *MonitoringTestCtx) ValidatePersesDatasourceConfiguration(t *testing.T) {
 	t.Helper()
+
+	skipUnless(t, []TestTag{Tier1})
 
 	// Skip if PersesDatasource CRD is not installed
 	ctx := context.Background()
@@ -1851,6 +1911,8 @@ func (tc *MonitoringTestCtx) validatePrometheusNamespaceProxyResourcesCommon(t *
 func (tc *MonitoringTestCtx) ValidatePrometheusRestrictedResourceConfiguration(t *testing.T) {
 	t.Helper()
 
+	skipUnless(t, []TestTag{Tier1})
+
 	dsci := tc.FetchDSCInitialization()
 
 	// Ensure metrics are configured
@@ -1870,6 +1932,8 @@ func (tc *MonitoringTestCtx) ValidatePrometheusRestrictedResourceConfiguration(t
 // ValidatePrometheusSecureProxyAuthentication tests the Prometheus secure proxy authentication and authorization.
 func (tc *MonitoringTestCtx) ValidatePrometheusSecureProxyAuthentication(t *testing.T) {
 	t.Helper()
+
+	skipUnless(t, []TestTag{Tier1})
 
 	dsci := tc.FetchDSCInitialization()
 
@@ -1939,6 +2003,8 @@ func (tc *MonitoringTestCtx) ValidatePrometheusSecureProxyAuthentication(t *test
 // ValidateNodeMetricsEndpointDeployment tests that the node-metrics-endpoint is deployed when metrics are configured.
 func (tc *MonitoringTestCtx) ValidateNodeMetricsEndpointDeployment(t *testing.T) {
 	t.Helper()
+
+	skipUnless(t, []TestTag{Tier1})
 
 	dsci := tc.FetchDSCInitialization()
 
@@ -2010,6 +2076,8 @@ func (tc *MonitoringTestCtx) ValidateNodeMetricsEndpointDeployment(t *testing.T)
 
 func (tc *MonitoringTestCtx) ValidateNodeMetricsEndpointRBACConfiguration(t *testing.T) {
 	t.Helper()
+
+	skipUnless(t, []TestTag{Tier1})
 
 	dsci := tc.FetchDSCInitialization()
 
@@ -2196,11 +2264,15 @@ func (tc *MonitoringTestCtx) validatePersesDatasourceTLSWithCloudBackend(t *test
 // ValidatePersesDatasourceTLSWithS3Backend tests that TLS is enabled for S3 backend.
 func (tc *MonitoringTestCtx) ValidatePersesDatasourceTLSWithS3Backend(t *testing.T) {
 	t.Helper()
+
+	skipUnless(t, []TestTag{Tier1})
 	tc.validatePersesDatasourceTLSWithCloudBackend(t, "s3")
 }
 
 // ValidatePersesDatasourceTLSWithGCSBackend tests that TLS is enabled for GCS backend.
 func (tc *MonitoringTestCtx) ValidatePersesDatasourceTLSWithGCSBackend(t *testing.T) {
 	t.Helper()
+
+	skipUnless(t, []TestTag{Tier1})
 	tc.validatePersesDatasourceTLSWithCloudBackend(t, "gcs")
 }

--- a/tests/e2e/odh_manager_test.go
+++ b/tests/e2e/odh_manager_test.go
@@ -24,7 +24,7 @@ func odhOperatorTestSuite(t *testing.T) {
 
 	// Define test cases.
 	testCases := []TestCase{
-		{name: "Validate CRDs owned by the operator", testFn: operatorTestCtx.ValidateOwnedCRDs},
+		{"Validate CRDs owned by the operator", operatorTestCtx.ValidateOwnedCRDs},
 	}
 
 	// Run the test suite.
@@ -53,6 +53,7 @@ func (tc *OperatorTestCtx) ValidateOwnedCRDs(t *testing.T) {
 		{"DataSciencePipelines CRD", "datasciencepipelines.components.platform.opendatahub.io"},
 		{"Workbenches CRD", "workbenches.components.platform.opendatahub.io"},
 		{"Kserve CRD", "kserves.components.platform.opendatahub.io"},
+		{"Models As A Service CRD", "modelsasservices.components.platform.opendatahub.io"},
 		{"ModelController CRD", "modelcontrollers.components.platform.opendatahub.io"},
 		{"Monitoring CRD", "monitorings.services.platform.opendatahub.io"},
 		{"LlamaStackOperator CRD", "llamastackoperators.components.platform.opendatahub.io"},

--- a/tests/e2e/resilience_test.go
+++ b/tests/e2e/resilience_test.go
@@ -71,6 +71,8 @@ func operatorResilienceTestSuite(t *testing.T) {
 func (tc *OperatorResilienceTestCtx) ValidateOperatorDeployment(t *testing.T) {
 	t.Helper()
 
+	skipUnless(t, []TestTag{Tier1})
+
 	deploymentName := tc.getControllerDeploymentName()
 
 	// Verify if the operator deployment is created and healthy
@@ -83,6 +85,8 @@ func (tc *OperatorResilienceTestCtx) ValidateOperatorDeployment(t *testing.T) {
 // ValidateLeaderElectionBehavior validates that leader election works correctly when the current leader pod is deleted.
 func (tc *OperatorResilienceTestCtx) ValidateLeaderElectionBehavior(t *testing.T) {
 	t.Helper()
+
+	skipUnless(t, []TestTag{Tier1})
 
 	// Find and delete current leader
 	originalLeader := tc.findLeaderPodFromLeases()
@@ -112,6 +116,8 @@ func (tc *OperatorResilienceTestCtx) ValidateLeaderElectionBehavior(t *testing.T
 func (tc *OperatorResilienceTestCtx) ValidateComponentsDeploymentSuccess(t *testing.T) {
 	t.Helper()
 
+	skipUnless(t, []TestTag{Tier1})
+
 	componentName := componentApi.DashboardComponentName
 
 	tc.EventuallyResourcePatched(
@@ -127,6 +133,8 @@ func (tc *OperatorResilienceTestCtx) ValidateComponentsDeploymentSuccess(t *test
 // ValidateComponentsDeploymentFailure simulates component deployment failure using restrictive resource quota.
 func (tc *OperatorResilienceTestCtx) ValidateComponentsDeploymentFailure(t *testing.T) {
 	t.Helper()
+
+	skipUnless(t, []TestTag{Tier1})
 
 	// To handle upstream/downstream i trimmed prefix(odh) from few controller names
 	componentToControllerMap := map[string]string{
@@ -241,6 +249,8 @@ func (tc *OperatorResilienceTestCtx) ValidateComponentsDeploymentFailure(t *test
 func (tc *OperatorResilienceTestCtx) ValidateMissingComponentsCRDHandling(t *testing.T) {
 	t.Helper()
 
+	skipUnless(t, []TestTag{Tier1})
+
 	crdTestingName := "dashboards.components.platform.opendatahub.io"
 	crd := tc.FetchResource(
 		WithMinimalObject(gvk.CustomResourceDefinition, types.NamespacedName{Name: crdTestingName}),
@@ -312,6 +322,8 @@ func (tc *OperatorResilienceTestCtx) ValidateMissingComponentsCRDHandling(t *tes
 
 func (tc *OperatorResilienceTestCtx) ValidateRBACRestrictionHandling(t *testing.T) {
 	t.Helper()
+
+	skipUnless(t, []TestTag{Tier1})
 
 	// Get the predictable ServiceAccount name based on deployment name
 	deploymentName := tc.getControllerDeploymentName()

--- a/tests/e2e/test_tag_test.go
+++ b/tests/e2e/test_tag_test.go
@@ -1,0 +1,16 @@
+package e2e_test
+
+import "testing"
+
+type TestTag string
+
+const (
+	Smoke TestTag = "Smoke"
+	Tier1 TestTag = "Tier1"
+)
+
+func skipUnless(t *testing.T, tags []TestTag) {
+	// TBD
+	t.Helper()
+	t.Logf("Skipping test unless tags match: %v", tags)
+}

--- a/tests/e2e/trainer_test.go
+++ b/tests/e2e/trainer_test.go
@@ -72,6 +72,8 @@ func trainerDegradedMonitoringTestSuite(t *testing.T) {
 func (tc *TrainerTestCtx) ValidateExternalOperatorDegradedMonitoring(t *testing.T) {
 	t.Helper()
 
+	skipUnless(t, []TestTag{Tier1})
+
 	testCases := []degradedConditionTestCase{
 		{
 			name:            "Degraded=True triggers component degradation",

--- a/tests/e2e/trustyai_test.go
+++ b/tests/e2e/trustyai_test.go
@@ -82,6 +82,8 @@ func (tc *TrustyAITestCtx) ValidateComponentDisabled(t *testing.T) {
 func (tc *TrustyAITestCtx) ValidateTrustyAIPreCheck(t *testing.T) {
 	t.Helper()
 
+	skipUnless(t, []TestTag{Tier1})
+
 	// Step 1: Disable KServe → TrustyAI should detect missing dependency
 	tc.setKserveState(operatorv1.Removed, false)
 

--- a/tests/e2e/v2tov3upgrade_test.go
+++ b/tests/e2e/v2tov3upgrade_test.go
@@ -142,17 +142,23 @@ func v2Tov3UpgradeDeletingDscDsciTestSuite(t *testing.T) {
 func (tc *V2Tov3UpgradeTestCtx) ValidateCodeFlareResourcePreservation(t *testing.T) {
 	t.Helper()
 
+	skipUnless(t, []TestTag{Tier1})
+
 	tc.validateComponentResourcePreservation(t, gvk.CodeFlare, defaultCodeFlareComponentName)
 }
 
 func (tc *V2Tov3UpgradeTestCtx) ValidateModelMeshServingResourcePreservation(t *testing.T) {
 	t.Helper()
 
+	skipUnless(t, []TestTag{Tier1})
+
 	tc.validateComponentResourcePreservation(t, gvk.ModelMeshServing, defaultModelMeshServingComponentName)
 }
 
 func (tc *V2Tov3UpgradeTestCtx) DatascienceclusterV1CreationAndRead(t *testing.T) {
 	t.Helper()
+
+	skipUnless(t, []TestTag{Tier1})
 
 	// Clean up any existing DataScienceCluster and DSCInitialization resources before starting
 	cleanupCoreOperatorResources(t, tc.TestContext)
@@ -216,6 +222,8 @@ func (tc *V2Tov3UpgradeTestCtx) DatascienceclusterV1CreationAndRead(t *testing.T
 
 func (tc *V2Tov3UpgradeTestCtx) DscinitializationV1CreationAndRead(t *testing.T) {
 	t.Helper()
+
+	skipUnless(t, []TestTag{Tier1})
 
 	// Clean up any existing DataScienceCluster and DSCInitialization resources before starting
 	cleanupCoreOperatorResources(t, tc.TestContext)
@@ -286,6 +294,8 @@ func (tc *V2Tov3UpgradeTestCtx) DscinitializationV1CreationAndRead(t *testing.T)
 func (tc *V2Tov3UpgradeTestCtx) HardwareProfileV1Alpha1ToV1VersionUpgrade(t *testing.T) {
 	t.Helper()
 
+	skipUnless(t, []TestTag{Tier1})
+
 	hardwareProfileName := "test-hardware-profile-v1alpha1-to-v1"
 
 	// should be able to create v1alpha1 HWProfile resource.
@@ -340,6 +350,8 @@ func (tc *V2Tov3UpgradeTestCtx) HardwareProfileV1Alpha1ToV1VersionUpgrade(t *tes
 
 func (tc *V2Tov3UpgradeTestCtx) HardwareProfileV1ToV1Alpha1VersionConversion(t *testing.T) {
 	t.Helper()
+
+	skipUnless(t, []TestTag{Tier1})
 
 	hardwareProfileName := "test-hardware-profile-v1-to-v1alpha1"
 
@@ -413,6 +425,8 @@ func (tc *V2Tov3UpgradeTestCtx) validateComponentResourcePreservation(t *testing
 
 func (tc *V2Tov3UpgradeTestCtx) ValidateRayRaiseErrorIfCodeFlarePresent(t *testing.T) {
 	t.Helper()
+
+	skipUnless(t, []TestTag{Tier1})
 
 	dsc := tc.FetchDataScienceCluster()
 	existingComponent := tc.operatorManagedComponent(gvk.CodeFlare, defaultCodeFlareComponentName, dsc)
@@ -516,6 +530,8 @@ func (tc *V2Tov3UpgradeTestCtx) updateComponentStateInDataScienceCluster(t *test
 // DataScienceCluster v1 resources with Kueue managementState set to "Managed".
 func (tc *V2Tov3UpgradeTestCtx) ValidateDeniesKueueManaged(t *testing.T) {
 	t.Helper()
+
+	skipUnless(t, []TestTag{Tier1})
 
 	// Clean up any existing DataScienceCluster resources before starting
 	cleanupCoreOperatorResources(t, tc.TestContext)
@@ -651,6 +667,8 @@ func (tc *V2Tov3UpgradeTestCtx) ValidateDeniesKueueManagedUpdate(t *testing.T) {
 func (tc *V2Tov3UpgradeTestCtx) ValidateAllowsKueueUnmanaged(t *testing.T) {
 	t.Helper()
 
+	skipUnless(t, []TestTag{Tier1})
+
 	// Clean up any existing DataScienceCluster resources before starting
 	cleanupCoreOperatorResources(t, tc.TestContext)
 
@@ -716,6 +734,8 @@ func (tc *V2Tov3UpgradeTestCtx) ValidateAllowsKueueUnmanaged(t *testing.T) {
 // DataScienceCluster v1 resources with Kueue managementState set to "Removed".
 func (tc *V2Tov3UpgradeTestCtx) ValidateAllowsKueueRemoved(t *testing.T) {
 	t.Helper()
+
+	skipUnless(t, []TestTag{Tier1})
 
 	// Clean up any existing DataScienceCluster resources before starting
 	cleanupCoreOperatorResources(t, tc.TestContext)
@@ -783,6 +803,8 @@ func (tc *V2Tov3UpgradeTestCtx) ValidateAllowsKueueRemoved(t *testing.T) {
 func (tc *V2Tov3UpgradeTestCtx) ValidateAllowsWithoutKueue(t *testing.T) {
 	t.Helper()
 
+	skipUnless(t, []TestTag{Tier1})
+
 	// Clean up any existing DataScienceCluster resources before starting
 	cleanupCoreOperatorResources(t, tc.TestContext)
 
@@ -846,6 +868,8 @@ func (tc *V2Tov3UpgradeTestCtx) createCRD(crdsToCreate []CRDToCreate) {
 
 func (tc *V2Tov3UpgradeTestCtx) ValidateServiceMeshResourcePreservation(t *testing.T) {
 	t.Helper()
+
+	skipUnless(t, []TestTag{Tier1})
 
 	nn := types.NamespacedName{
 		Name: defaultServiceMeshName,
@@ -920,6 +944,8 @@ func (tc *V2Tov3UpgradeTestCtx) triggerDSCIReconciliation(t *testing.T) {
 func (tc *V2Tov3UpgradeTestCtx) ValidateArgoWorkflowsControllersDatasciencepipelinesDSCV1(t *testing.T) {
 	t.Helper()
 
+	skipUnless(t, []TestTag{Tier1})
+
 	// Clean up any existing DataScienceCluster resources before starting
 	cleanupCoreOperatorResources(t, tc.TestContext)
 
@@ -981,6 +1007,8 @@ func (tc *V2Tov3UpgradeTestCtx) ValidateArgoWorkflowsControllersDatasciencepipel
 // Users who need to use v2-only components should use the v2 API for all operations.
 func (tc *V2Tov3UpgradeTestCtx) ValidateV2OnlyComponentsResetWhenPatchingViaV1API(t *testing.T) {
 	t.Helper()
+
+	skipUnless(t, []TestTag{Tier1})
 
 	// Clean up any existing DataScienceCluster resources before starting
 	cleanupCoreOperatorResources(t, tc.TestContext)

--- a/tests/e2e/workbenches_test.go
+++ b/tests/e2e/workbenches_test.go
@@ -46,6 +46,8 @@ func workbenchesTestSuite(t *testing.T) {
 func (tc *WorkbenchesTestCtx) ValidateWorkbenchesNamespaceConfiguration(t *testing.T) {
 	t.Helper()
 
+	skipUnless(t, []TestTag{Tier1})
+
 	// ensure the workbenches namespace exists and has the expected label
 	tc.EnsureResourceExists(
 		WithMinimalObject(gvk.Namespace, types.NamespacedName{Name: tc.WorkbenchesNamespace}),


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

<!--- Link your JIRA and related links here for reference. -->
https://issues.redhat.com/browse/RHOAIENG-49900

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [ ] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added per-test tags (e.g., "Smoke", "Sanity") across many e2e suites for selective runs and faster feedback.
  * Expanded e2e test runner command to accept additional environment-driven test flags and namespace options.

* **Documentation**
  * Clarified GatewayConfigName description for improved readability.

* **Chores**
  * Added an end-to-end check for the Models As A Service CRD.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->