### PR TITLE
Remove segment.io configuration and related resources

### DIFF
--- a/config/monitoring/segment/kustomization.yaml
+++ b/config/monitoring/segment/kustomization.yaml
@@ -1,5 +1,0 @@
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
-resources:
-  - segment-key-config.yaml
-  - segment-key-secret.yaml

--- a/config/monitoring/segment/segment-key-config.yaml
+++ b/config/monitoring/segment/segment-key-config.yaml
@@ -1,6 +1,0 @@
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: odh-segment-key-config
-data:
-  segmentKeyEnabled: "true"

--- a/config/monitoring/segment/segment-key-secret.yaml
+++ b/config/monitoring/segment/segment-key-secret.yaml
@@ -1,7 +1,0 @@
-apiVersion: v1
-kind: Secret
-metadata:
-  name: odh-segment-key
-type: Opaque
-data:
-   segmentKey: S1JVaG9BSUVwV2xHdXo0c1dpeGFlMXZBWEtLR2xENUs=

--- a/internal/controller/dscinitialization/dscinitialization_controller.go
+++ b/internal/controller/dscinitialization/dscinitialization_controller.go
@@ -217,10 +217,6 @@ func (r *DSCInitializationReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		case cluster.SelfManagedRhoai:
 			if instance.Spec.Monitoring.ManagementState == operatorv1.Managed {
 				log.Info("Monitoring enabled", "cluster", "Self-Managed Mode")
-				if err = r.configureSegmentIO(ctx, instance); err != nil {
-					return reconcile.Result{}, err
-				}
-
 				if err = r.newMonitoringCR(ctx, instance); err != nil {
 					return ctrl.Result{}, err
 				}


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->
Closes: https://issues.redhat.com/browse/RHOAIENG-21427
Remove segment.io configuration and related resources.

This pull request removes all configuration and deployment logic related to Segment.io monitoring from the codebase. The changes eliminate both the Kubernetes manifests and the operator logic responsible for deploying Segment.io resources, simplifying the monitoring setup.

Removal of Segment.io monitoring configuration:

* Deleted Segment.io manifests: Removed `segment-key-config.yaml`, `segment-key-secret.yaml`, and their references from `kustomization.yaml`, eliminating the Segment.io ConfigMap and Secret from the monitoring configuration. [[1]](diffhunk://#diff-2eac55cfce669232018dbe3313859e18ade6e2dc1cfba9147b8eda4fa27bf0eaL1-L5) [[2]](diffhunk://#diff-d04952716883c4b7a4a569fa646fac81c86f10d0d881eefa080ed5a5be4f36c3L1-L6) [[3]](diffhunk://#diff-eee9068e5c00152cc92de543b0d293db852dd030cdf7b58c6d4bebe7ae67478cL1-L7)

Operator logic cleanup:

* Removed Segment.io deployment logic: Deleted the `configureSegmentIO` method and all calls to it in `dscinitialization_controller.go` and `monitoring.go`, so Segment.io resources are no longer deployed or managed by the operator. [[1]](diffhunk://#diff-5e7e1fe619dc60ec3c83c86094d9a66d7eeb979a3b4caa25252c73f07f0713a3L220-L223) [[2]](diffhunk://#diff-91c33edd213e2beac35911b0cea818b62af884ed72fb936a4940416e5a6c553bL436-L470)

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Ensure the manifests are no longer deployed in a cluster.

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [X] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [X] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [X] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->
This PR is a pure removal/refactor that:

Deletes unused segment.io manifest files (segment-key-config.yaml, segment-key-secret.yaml, and their kustomization)
Removes the configureSegmentIO function and its call sites from the DSCInitialization controller
Since:
* No new functionality is introduced
* No existing behavior is modified—only dead code paths are removed
* The removed segment.io resources were not exercised by existing E2E tests
* This is a straightforward deletion with no logic changes that could introduce regressions
Unit tests and static analysis are sufficient to verify this change compiles and doesn't break existing tests.