### PR TITLE
fix: updated HWP migration to skip workloads without kueue label in kueue enabled NS

### DIFF
--- a/pkg/upgrade/upgrade_helpers_test.go
+++ b/pkg/upgrade/upgrade_helpers_test.go
@@ -17,6 +17,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	infrav1 "github.com/opendatahub-io/opendatahub-operator/v2/api/infrastructure/v1"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/upgrade"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/fakeclient"
@@ -281,6 +282,35 @@ func createMalformedAcceleratorProfile(t *testing.T, namespace string) *unstruct
 
 	// Missing spec field
 	return ap
+}
+
+// createTestKueueManagedNamespace returns a Namespace with Kueue management labels set.
+// Used for RHOAIENG-50667 tests where the webhook would require queue-name on workloads.
+func createTestKueueManagedNamespace(name string) *corev1.Namespace {
+	ns := &corev1.Namespace{}
+	ns.SetName(name)
+	ns.Labels = map[string]string{
+		cluster.KueueManagedLabelKey: "true",
+	}
+	return ns
+}
+
+// createTestKueueManagedNamespaceLegacy returns a Namespace with the legacy Kueue label only
+// (kueue-managed = "true"). Used to verify RHOAIENG-50667 behavior when namespace uses legacy label.
+func createTestKueueManagedNamespaceLegacy(name string) *corev1.Namespace {
+	ns := &corev1.Namespace{}
+	ns.SetName(name)
+	ns.Labels = map[string]string{
+		cluster.KueueLegacyManagedLabelKey: "true",
+	}
+	return ns
+}
+
+// createTestNamespace returns a Namespace without Kueue labels (normal namespace).
+func createTestNamespace(name string) *corev1.Namespace {
+	ns := &corev1.Namespace{}
+	ns.SetName(name)
+	return ns
 }
 
 func createTestNotebook(namespace, name string) *unstructured.Unstructured {


### PR DESCRIPTION
## Description
JIRA: [RHOAIENG-50667](https://issues.redhat.com/browse/RHOAIENG-50667)

This PR  fixes RHOAIENG-50667, where the operator could enter CrashLoopBackOff during RHOAI 3.3 upgrade because the HardwareProfile migration updated Notebooks or InferenceServices that live in a Kueue-managed namespace but do not have the required `kueue.x-k8s.io/queue-name labe`l, causing the Kueue validating webhook to reject the update. 

The fix detects these cases (using both the current and legacy Kueue namespace labels), skips HWP annotation migration for them, logs a message to the `rhods-operator` Pod, emits a `HardwareProfileMigrationSkipped` event, and does not fail the upgrade so the operator stays healthy. A reactive path also treats webhook rejection errors as a skip so the upgrade is not blocked if the proactive check is bypassed.

## How Has This Been Tested?
**Steps to Reproduce Original Bug:**

1. Install RHOAI 2.25.1
2. Create a Notebook and ISVC that use either an AcceleratorProfile or standard container size
3. Install RHBoK from Software Catalog
4. Set DSC `.spec.components.kueue.managementState` to `Unmanaged`
5. Add kueue label to the NS that the workloads are in using either: `kueue.openshift.io/managed: 'true'` or `kueue-managed: 'true'`
6. Upgrade to 3.3
7. Observe that the rhods-operator Pods are crash looping

**Steps to Demonstrate Fix:**
1. Install RHOAI 2.25.1
2. Create a Notebook and ISVC that use either an AcceleratorProfile or standard container size
3. Install RHBoK from Software Catalog
4. Set DSC `.spec.components.kueue.managementState` to `Unmanaged`
5. Add kueue label to the NS that the workloads are in using either: `kueue.openshift.io/managed: 'true'` or `kueue-managed: 'true'`
6. Upgrade to 3.3
7. As soon as the RHOAI 3.3 CSV appears, run the following commands to patch in a custom image that includes this fix:
```bash
# Disable OLM operator from overriding the rhods-operator image
oc patch clusterversion version --type=merge -p '{
  "spec": {
    "overrides": [
      {
        "group": "apps/v1",
        "kind": "Deployment",
        "name": "olm-operator",
        "namespace": "openshift-operator-lifecycle-manager",
        "unmanaged": true
      },
      {
        "group": "apps/v1",
        "kind": "Deployment",
        "name": "catalog-operator",
        "namespace": "openshift-operator-lifecycle-manager",
        "unmanaged": true
      }
    ]
  }
}'

# Patch the rhods-operator CSV to use custom image that includes fix
OPERATOR_IMAGE="quay.io/ckyrillo/opendatahub-operator:v3.3.0"
RHOAI_CSV=$(oc get csv -n redhat-ods-operator | grep rhods-operator | awk '{print $1}')
JSON_PATCH='[{"op": "replace", "path": "/spec/install/spec/deployments/0/spec/template/spec/containers/0/image", "value": "'"$OPERATOR_IMAGE"'"}]'
oc patch csv $RHOAI_CSV -n redhat-ods-operator --type=json --patch="$JSON_PATCH"
oc wait --for=condition=Available=true Deployment/rhods-operator -n redhat-ods-operator --timeout=150s
```
8. Observe that the upgrade completes
9. Observe that the events are emitted:
```bash
oc get events --field-selector reason=HardwareProfileMigrationSkipped -A
```

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [X] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [X] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work
- [X] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [X] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
Added unit tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced hardware profile migration to respect Kueue queue labels in managed namespaces, skipping migration when labels are absent.
  * Improved detection and handling of serverless InferenceServices.
  * Centralized error handling for webhook rejections.

* **Tests**
  * Extensive test coverage added for Kueue-managed namespace and serverless InferenceService scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->