### PR TITLE
switch maas to BoW stable branch

### DIFF
--- a/get_all_manifests.sh
+++ b/get_all_manifests.sh
@@ -28,7 +28,7 @@ declare -A ODH_COMPONENT_MANIFESTS=(
     ["feastoperator"]="opendatahub-io:feast:stable@0c85e244d3182b4570164f6d66c8b106a207c070:infra/feast-operator/config"
     ["llamastackoperator"]="opendatahub-io:llama-stack-k8s-operator:odh@76895fce0f00a3a7e147b7f5689a7d1b4ed5b6c9:config"
     ["trainer"]="opendatahub-io:trainer:stable@53fdd48b9156c382b60b33aa4b2f56a44c23377d:manifests"
-    ["maas"]="opendatahub-io:maas-billing:main@ae050cb6297ba2b3f35515b0adeadb1a5cd1afa9:deployment"
+    ["maas"]="opendatahub-io:models-as-a-service:stable@ca4793d207f67cca07918562628b2261dc2344c0:deployment"
     ["mlflowoperator"]="opendatahub-io:mlflow-operator:main@85463288e7740629c8ed3754da91c81cec57d380:config"
     ["sparkoperator"]="opendatahub-io:spark-operator:main@141b447586a54ed1882b6e8bf26c11fa52a18514:config"
 )


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->
Switch the maas component manifest source to the renamed `models-as-a-service` repository on the `stable` branch.

<!--- Link your JIRA and related links here for reference. -->
[RHOAIENG-35334](https://issues.redhat.com/browse/RHOAIENG-35334)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested with - 
```
./get_all_manifests.sh --maas="opendatahub-io:models-as-a-service:stable@ca4793d207f67cca07918562628b2261dc2344c0:deployment"
```

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->
Clones successfully
```
Cloning repo trustyai: opendatahub-io:trustyai-service-operator:incubation@25e144dd0f4c311c53cbe069fed18fb93fdb3a7d:config
Cloning repo maas: opendatahub-io:models-as-a-service:stable@ca4793d207f67cca07918562628b2261dc2344c0:deployment
Cloning repo mlflowoperator: opendatahub-io:mlflow-operator:main@f0359caef15175199d91110e0748555e0e36364f:config
Clon
```

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [ ] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the Models as a Service component to point to the new source repository and stable release, so deployments now use the updated stable manifest.
  * No runtime behavior, error handling, or control-flow changes; this is a configuration-only update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->