### PR TITLE
override cpu x86 image in params.env

### DIFF
--- a/internal/controller/components/modelcontroller/modelcontroller_support.go
+++ b/internal/controller/components/modelcontroller/modelcontroller_support.go
@@ -26,6 +26,7 @@ var (
 		"mlserver-image":          "RELATED_IMAGE_ODH_MLSERVER_IMAGE",
 		"vllm-cuda-image":         "RELATED_IMAGE_RHAIIS_VLLM_CUDA_IMAGE",
 		"vllm-cpu-image":          "RELATED_IMAGE_ODH_VLLM_CPU_IMAGE",
+		"vllm-cpu-x86-image":      "RELATED_IMAGE_RHAIIS_VLLM_CPU_IMAGE",
 		"vllm-gaudi-image":        "RELATED_IMAGE_ODH_VLLM_GAUDI_IMAGE",
 		"vllm-rocm-image":         "RELATED_IMAGE_RHAIIS_VLLM_ROCM_IMAGE",
 		"vllm-spyre-image":        "RELATED_IMAGE_RHAIIS_VLLM_SPYRE_IMAGE",


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->
Currently in RHOAI 3.3 RC2, the new vLLM CPU (x86) ServingRuntime for KServe in  Dashboard > Settings is using the wrong image [quay.io/vllm/vllm:latest.](http://quay.io/vllm/vllm:latest). The correct image should be in registry.redhat.io like the other runtimes.

Slack thread – > https://redhat-internal.slack.com/archives/C0A6R461R46/p1771521890695219?thread_ts=1768340946.628849&cid=C0A6R461R46

Image: [quay.io/rhoai/rhoai-fbc-fragment:rhoai-3.3@sha256:a6c5dd08d9a2b75af89dc5a1aa2b1d1b652d4ef5651ae38dfac2b0fd810d4678](http://quay.io/rhoai/rhoai-fbc-fragment:rhoai-3.3@sha256:a6c5dd08d9a2b75af89dc5a1aa2b1d1b652d4ef5651ae38dfac2b0fd810d4678)
Commit: [75ee612](https://github.com/red-hat-data-services/RHOAI-Build-Config/commit/75ee612d9976679edba820aa0820886dea592e5b)
Build: [rhoai-fbc-fragment-v3-3-on-push-7qkmj](https://konflux-ui.apps.stone-prod-p02.hjvn.p1.openshiftapps.com/ns/rhoai-tenant/pipelinerun/rhoai-fbc-fragment-v3-3-on-push-7qkmj)

<!--- Link your JIRA and related links here for reference. -->
Jira: https://issues.redhat.com/browse/RHOAIENG-50798

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [x] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement --> This change only adjusts an image mapping entry. No functional behavior or workflows change; existing E2E coverage remains applicable.

<!--- This section can be left empty if you're not opting out of the E2E requirement -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added support for additional image configuration variant.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->