### PR TITLE
feat: add maas-controller operand image to ModelsAsService component

### DIFF
--- a/build/operands-map.yaml
+++ b/build/operands-map.yaml
@@ -179,6 +179,10 @@ relatedImages:
     - name: RELATED_IMAGE_ODH_MAAS_API_IMAGE
       value: quay.io/opendatahub/maas-api@sha256:e83852905c7c4f65699daaad9d1f90e56f8f6b7477e6a11d76f31ae91b711197
       component: odh-maas-api
+    # Placeholder: real digest will be populated by Konflux once the first maas-controller build completes
+    - name: RELATED_IMAGE_ODH_MAAS_CONTROLLER_IMAGE
+      value: quay.io/opendatahub/maas-controller@sha256:0000000000000000000000000000000000000000000000000000000000000000
+      component: odh-maas-controller
     - name: RELATED_IMAGE_ODH_TRUSTYAI_RAGAS_LLS_PROVIDER_DSP_IMAGE
       value: quay.io/opendatahub/llama-stack-provider-ragas@sha256:627f4d4c2910869f4da07db7eaddd8cec89e862d71f90bdf14b61fbbb4935be0
       component: odh-trustyai-ragas-lls-provider-dsp

--- a/internal/controller/components/modelsasservice/modelsasservice_support.go
+++ b/internal/controller/components/modelsasservice/modelsasservice_support.go
@@ -49,7 +49,8 @@ const (
 var (
 	// Image parameter mappings for manifest substitution.
 	imagesMap = map[string]string{
-		"maas-api-image": "RELATED_IMAGE_ODH_MAAS_API_IMAGE",
+		"maas-api-image":        "RELATED_IMAGE_ODH_MAAS_API_IMAGE",
+		"maas-controller-image": "RELATED_IMAGE_ODH_MAAS_CONTROLLER_IMAGE",
 	}
 
 	// Additional parameters for manifest customization.


### PR DESCRIPTION


<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
Add RELATED_IMAGE_ODH_MAAS_CONTROLLER_IMAGE to the operands map and the imagesMap in the ModelsAsService component handler so that the maas-controller image is substituted into deployment manifests and the controller pod starts alongside maas-api when managementState is set to Managed.

<!--- Describe your changes in detail -->

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [ ] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configuration and image support for the Models as a Service (MAAS) Controller component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->