### PR TITLE
fix(RHOAIENG-50800): certconfigenerator and setup controller stale cache issue

### DIFF
--- a/internal/controller/services/setup/setup_controller_test.go
+++ b/internal/controller/services/setup/setup_controller_test.go
@@ -1,0 +1,121 @@
+//nolint:testpackage
+package setup
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/upgrade"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestFilterDeleteConfigMapPredicateWithTypedAndUnstructured(t *testing.T) {
+	const operatorNs = "test-operator-ns"
+
+	r := &SetupControllerReconciler{}
+	preds := r.filterDeleteConfigMap(operatorNs)
+
+	tests := []struct {
+		name string
+		obj  client.Object
+		want bool
+	}{
+		{
+			name: "typed ConfigMap with correct namespace and label",
+			obj: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "delete-cm",
+					Namespace: operatorNs,
+					Labels:    map[string]string{upgrade.DeleteConfigMapLabel: "true"},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "typed ConfigMap wrong namespace",
+			obj: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "delete-cm",
+					Namespace: "other-ns",
+					Labels:    map[string]string{upgrade.DeleteConfigMapLabel: "true"},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "typed ConfigMap missing label",
+			obj: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "delete-cm",
+					Namespace: operatorNs,
+				},
+			},
+			want: false,
+		},
+		{
+			name: "unstructured ConfigMap with correct namespace and label",
+			obj: func() client.Object {
+				u := &unstructured.Unstructured{}
+				u.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("ConfigMap"))
+				u.SetName("delete-cm")
+				u.SetNamespace(operatorNs)
+				u.SetLabels(map[string]string{upgrade.DeleteConfigMapLabel: "true"})
+				return u
+			}(),
+			want: true,
+		},
+		{
+			name: "unstructured ConfigMap wrong namespace",
+			obj: func() client.Object {
+				u := &unstructured.Unstructured{}
+				u.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("ConfigMap"))
+				u.SetName("delete-cm")
+				u.SetNamespace("other-ns")
+				u.SetLabels(map[string]string{upgrade.DeleteConfigMapLabel: "true"})
+				return u
+			}(),
+			want: false,
+		},
+		{
+			name: "unstructured ConfigMap missing label",
+			obj: func() client.Object {
+				u := &unstructured.Unstructured{}
+				u.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("ConfigMap"))
+				u.SetName("delete-cm")
+				u.SetNamespace(operatorNs)
+				return u
+			}(),
+			want: false,
+		},
+		{
+			name: "unstructured non-ConfigMap with correct namespace and label",
+			obj: func() client.Object {
+				u := &unstructured.Unstructured{}
+				u.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("Secret"))
+				u.SetName("delete-cm")
+				u.SetNamespace(operatorNs)
+				u.SetLabels(map[string]string{upgrade.DeleteConfigMapLabel: "true"})
+				return u
+			}(),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			g.Expect(preds.Create(event.CreateEvent{Object: tt.obj})).
+				To(Equal(tt.want), "CreateFunc")
+
+			g.Expect(preds.Update(event.UpdateEvent{ObjectNew: tt.obj})).
+				To(Equal(tt.want), "UpdateFunc")
+		})
+	}
+}


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
With #3140 it's introduced a unstructured client used in the manager, to avoid the stale cache issue using both typed and unstructured types.
certconfiggenerator and setup controllers were not updated, this PR will fix the behaviour.

Jira task: https://issues.redhat.com/browse/RHOAIENG-51298

## How Has This Been Tested?
- Locally tested with a script to create ns and verify that the ca configmap is correctly created in all namespaces. Before the change, it hit a race condition in which not all namespaces had it created correctly
- Changed unit test setup to use the new client, and setup correctly the unstructured cache on envtest as in production controller configuration. This make tests fails, now are always working

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [x] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->
certconfigenerator is tested using envtest in unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Broadened controllers to handle both typed and unstructured resources for ConfigMaps and custom resources.
  * Added internal logic to uniformly extract Trusted CA bundles from different resource representations.

* **Tests**
  * Added tests validating predicate behavior for both typed and unstructured objects across namespaces and labels.

* **Chores**
  * Manager creation now defaults to unstructured caching and is wrapped by the operational manager.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->