### PR TITLE
RHOAIENG-46504 | feat: add cert-manager CRD dependency monitoring action

### DIFF
--- a/internal/webhook/envtestutil/envtestutil.go
+++ b/internal/webhook/envtestutil/envtestutil.go
@@ -40,8 +40,8 @@ const DefaultWebhookTimeout = 30 * time.Second
 
 // defaultCRDInstallOptions provides consistent configuration for waiting on CRD establishment.
 var defaultCRDInstallOptions = envtest.CRDInstallOptions{
-	PollInterval: 100 * time.Millisecond,
-	MaxTime:      30 * time.Second,
+	PollInterval: envt.DefaultPollInterval,
+	MaxTime:      envt.DefaultMaxWait,
 }
 
 // =============================================================================

--- a/pkg/cluster/gvk/gvk.go
+++ b/pkg/cluster/gvk/gvk.go
@@ -704,4 +704,22 @@ var (
 		Version: corev1.SchemeGroupVersion.Version,
 		Kind:    "PersistentVolumeClaim",
 	}
+
+	CertManagerCertificate = schema.GroupVersionKind{
+		Group:   "cert-manager.io",
+		Version: "v1",
+		Kind:    "Certificate",
+	}
+
+	CertManagerIssuer = schema.GroupVersionKind{
+		Group:   "cert-manager.io",
+		Version: "v1",
+		Kind:    "Issuer",
+	}
+
+	CertManagerClusterIssuer = schema.GroupVersionKind{
+		Group:   "cert-manager.io",
+		Version: "v1",
+		Kind:    "ClusterIssuer",
+	}
 )

--- a/pkg/controller/actions/dependency/action_certmanager.go
+++ b/pkg/controller/actions/dependency/action_certmanager.go
@@ -1,0 +1,43 @@
+package dependency
+
+import (
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
+)
+
+// certManagerCRD* are the Kubernetes resource names of the three core cert-manager CRDs,
+// in the form <plural>.<group>.
+const (
+	certManagerCertificateCRD   = "certificates.cert-manager.io"
+	certManagerIssuerCRD        = "issuers.cert-manager.io"
+	certManagerClusterIssuerCRD = "clusterissuers.cert-manager.io"
+)
+
+// MonitorCertManagerCRDs returns an ActionOpts that checks whether the three core cert-manager
+// CRDs (Certificate, Issuer, ClusterIssuer) are registered on the cluster. If any CRD is absent,
+// DependenciesAvailable is set to False. Include this in any reconciler pipeline that requires
+// cert-manager to be installed before processing cert-manager resources.
+func MonitorCertManagerCRDs() ActionOpts {
+	return func(a *Action) {
+		a.crdConfigs = append(a.crdConfigs,
+			CRDConfig{GVK: gvk.CertManagerCertificate},
+			CRDConfig{GVK: gvk.CertManagerIssuer},
+			CRDConfig{GVK: gvk.CertManagerClusterIssuer},
+		)
+	}
+}
+
+// CertManagerCRDPredicate returns a predicate that matches CustomResourceDefinition events for
+// the three core cert-manager CRDs. Use with Watches(&extv1.CustomResourceDefinition{}, ...) to
+// trigger reconciliation when cert-manager is installed or uninstalled on the cluster.
+func CertManagerCRDPredicate() predicate.Predicate {
+	return predicate.NewPredicateFuncs(func(obj client.Object) bool {
+		switch obj.GetName() {
+		case certManagerCertificateCRD, certManagerIssuerCRD, certManagerClusterIssuerCRD:
+			return true
+		}
+		return false
+	})
+}

--- a/pkg/controller/actions/dependency/action_certmanager_test.go
+++ b/pkg/controller/actions/dependency/action_certmanager_test.go
@@ -1,0 +1,172 @@
+package dependency_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/rs/xid"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	k8serr "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+
+	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/api/components/v1alpha1"
+	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/status"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/dependency"
+	cond "github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/conditions"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/envt"
+
+	. "github.com/onsi/gomega"
+)
+
+// TestCertManagerCRDPredicate verifies that CertManagerCRDPredicate matches the three core
+// cert-manager CRDs and rejects unrelated objects.
+func TestCertManagerCRDPredicate(t *testing.T) {
+	pred := dependency.CertManagerCRDPredicate()
+
+	makeCRD := func(name string) *unstructured.Unstructured {
+		u := &unstructured.Unstructured{}
+		u.SetGroupVersionKind(schema.GroupVersionKind{
+			Group:   "apiextensions.k8s.io",
+			Version: "v1",
+			Kind:    "CustomResourceDefinition",
+		})
+		u.SetName(name)
+		return u
+	}
+
+	tests := []struct {
+		name     string
+		crdName  string
+		expected bool
+	}{
+		{name: "Certificate CRD matches", crdName: "certificates.cert-manager.io", expected: true},
+		{name: "Issuer CRD matches", crdName: "issuers.cert-manager.io", expected: true},
+		{name: "ClusterIssuer CRD matches", crdName: "clusterissuers.cert-manager.io", expected: true},
+		{name: "unrelated CRD does not match", crdName: "widgets.other.io", expected: false},
+		{name: "other cert-manager CRD does not match", crdName: "certificaterequests.cert-manager.io", expected: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			obj := makeCRD(tt.crdName)
+			g.Expect(pred.Create(event.CreateEvent{Object: obj})).To(Equal(tt.expected))
+			g.Expect(pred.Update(event.UpdateEvent{ObjectNew: obj})).To(Equal(tt.expected))
+			g.Expect(pred.Delete(event.DeleteEvent{Object: obj})).To(Equal(tt.expected))
+			g.Expect(pred.Generic(event.GenericEvent{Object: obj})).To(Equal(tt.expected))
+		})
+	}
+}
+
+// createCRD registers a CRD via envTest and wires up cleanup.
+func createCRD(t *testing.T, g *WithT, ctx context.Context, envTest *envt.EnvT,
+	gvkDef schema.GroupVersionKind, plural, singular string, scope apiextensionsv1.ResourceScope,
+) {
+	t.Helper()
+
+	crd, err := envTest.RegisterCRD(ctx, gvkDef, plural, singular, scope)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	t.Cleanup(func() {
+		g.Eventually(func() error {
+			return envTest.Client().Delete(ctx, crd)
+		}).Should(Or(
+			Not(HaveOccurred()),
+			MatchError(k8serr.IsNotFound, "IsNotFound"),
+		))
+	})
+}
+
+// TestMonitorCertManagerCRDs verifies the MonitorCertManagerCRDs convenience function, which
+// pre-configures monitoring for the three core cert-manager CRDs.
+//
+// Each subtest uses its own envtest instance rather than sharing one across subtests.
+// HasCRD relies on the REST mapper, whose discovery cache refreshes asynchronously after
+// CRD deletion. A shared instance cannot guarantee the mapper reflects zero CRDs at the
+// start of the "absent CRDs" case when other subtests registered CRDs beforehand.
+func TestMonitorCertManagerCRDs(t *testing.T) {
+	tests := []struct {
+		name                   string
+		setupCRDs              func(t *testing.T, g *WithT, ctx context.Context, envTest *envt.EnvT)
+		expectedAvailable      bool
+		expectedMsgContains    []string
+		expectedMsgNotContains []string
+	}{
+		{
+			name:              "absent CRDs yield degraded",
+			setupCRDs:         nil,
+			expectedAvailable: false,
+			expectedMsgContains: []string{
+				gvk.CertManagerCertificate.Kind,
+				gvk.CertManagerIssuer.Kind,
+				gvk.CertManagerClusterIssuer.Kind,
+			},
+		},
+		{
+			name: "present CRDs yield healthy",
+			setupCRDs: func(t *testing.T, g *WithT, ctx context.Context, envTest *envt.EnvT) {
+				t.Helper()
+				createCRD(t, g, ctx, envTest, gvk.CertManagerCertificate, "certificates", "certificate", apiextensionsv1.NamespaceScoped)
+				createCRD(t, g, ctx, envTest, gvk.CertManagerIssuer, "issuers", "issuer", apiextensionsv1.NamespaceScoped)
+				createCRD(t, g, ctx, envTest, gvk.CertManagerClusterIssuer, "clusterissuers", "clusterissuer", apiextensionsv1.ClusterScoped)
+			},
+			expectedAvailable: true,
+		},
+		{
+			name: "mix of present and absent CRDs",
+			setupCRDs: func(t *testing.T, g *WithT, ctx context.Context, envTest *envt.EnvT) {
+				t.Helper()
+				createCRD(t, g, ctx, envTest, gvk.CertManagerCertificate, "certificates", "certificate", apiextensionsv1.NamespaceScoped)
+				// Issuer and ClusterIssuer CRDs intentionally not created
+			},
+			expectedAvailable:      false,
+			expectedMsgContains:    []string{gvk.CertManagerIssuer.Kind, gvk.CertManagerClusterIssuer.Kind},
+			expectedMsgNotContains: []string{gvk.CertManagerCertificate.Kind + ": CRD not found"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			envTest, err := envt.New()
+			g.Expect(err).NotTo(HaveOccurred())
+			t.Cleanup(func() { _ = envTest.Stop() })
+
+			ctx := context.Background()
+			cli := envTest.Client()
+
+			if tt.setupCRDs != nil {
+				tt.setupCRDs(t, g, ctx, envTest)
+			}
+
+			instance := &componentApi.Kueue{ObjectMeta: metav1.ObjectMeta{Name: xid.New().String()}}
+			condManager := cond.NewManager(instance, status.ConditionDependenciesAvailable)
+			rr := &types.ReconciliationRequest{Client: cli, Instance: instance, Conditions: condManager}
+
+			action := dependency.NewAction(dependency.MonitorCertManagerCRDs())
+			err = action(ctx, rr)
+			g.Expect(err).NotTo(HaveOccurred())
+
+			gotCond := condManager.GetCondition(status.ConditionDependenciesAvailable)
+			g.Expect(gotCond).NotTo(BeNil())
+
+			if tt.expectedAvailable {
+				g.Expect(gotCond.Status).To(Equal(metav1.ConditionTrue))
+			} else {
+				g.Expect(gotCond.Status).To(Equal(metav1.ConditionFalse))
+				for _, s := range tt.expectedMsgContains {
+					g.Expect(gotCond.Message).To(ContainSubstring(s))
+				}
+				for _, s := range tt.expectedMsgNotContains {
+					g.Expect(gotCond.Message).NotTo(ContainSubstring(s))
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

Implements a reusable dependency monitoring action for cert-manager as part of [RHOAIENG-46504](https://issues.redhat.com/browse/RHOAIENG-46504).

A reconciler pipeline can include `MonitorCertManagerCRDs()` to validate that the three core cert-manager CRDs (Certificate, Issuer, ClusterIssuer) are registered on the cluster. If any are absent, the action surfaces `DependenciesAvailable=False` on the component CR, making the missing dependency visible to users rather than leaving them guessing.

### Changes

- **`pkg/cluster/gvk`**: Add GVK constants for `CertManagerCertificate`, `CertManagerIssuer`, and `CertManagerClusterIssuer`.
- **`pkg/controller/actions/dependency`**: Extend the existing dependency action with a `CRDConfig` struct and a `crdConfigs` processing loop in `run()`. CRD absence is treated as error severity (unlike optional operator dependencies). Add `MonitorCertManagerCRDs()` ActionOpts and `CertManagerCRDPredicate()` for use with `CustomResourceDefinition` watches.
- **`pkg/utils/test/envt`**: Add `RegisterCRD` test helper and shared `DefaultPollInterval`/`DefaultMaxWait` constants. Align `envtestutil` to use the same constants.

## How Has This Been Tested?

- Unit tests added in `pkg/controller/actions/dependency/action_certmanager_test.go`:
  - `TestCertManagerCRDPredicate`: verifies predicate matches the three cert-manager CRD names and rejects all others, across all four event types (Create, Update, Delete, Generic).
  - `TestMonitorCertManagerCRDs`: envtest-backed integration test covering absent CRDs (all three reported in condition message), all CRDs present (condition True), and a partial mix (only missing ones reported).
- All existing dependency action tests pass unmodified.
- Full unit test suite passes (`make unit-test`).

## Screenshot or short clip

N/A — no UI changes.

## Merge criteria

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [x] The developer has run the integration test pipeline and verified that it passed successfully

- [x] Skip requirement to update E2E test suite for this PR

#### E2E update requirement opt-out justification

The new `MonitorCertManagerCRDs()` action and `CertManagerCRDPredicate()` are not yet wired into any reconciler pipeline. They are reusable building blocks intended for use by a future cloud-controller service handler (RHOAIENG-47652). There is no live reconciliation cycle to observe in a cluster, so E2E coverage is not applicable for this story.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added cert-manager dependency monitoring to detect and report availability of Certificate, Issuer, and ClusterIssuer resources; dependency checks now contribute non-blocking readiness signaling.

* **Tests**
  * Added end-to-end tests covering CRD predicate matching and monitor behavior across absent/present/mixed scenarios.

* **Chores**
  * Improved test/runtime utilities: centralized polling defaults and a reusable CRD registration helper for tests and readiness checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->