### PR TITLE
add ClusterRole for maas-api to list/watch MaaS CRs

### DIFF
--- a/internal/controller/components/modelsasservice/modelsasservice_controller.go
+++ b/internal/controller/components/modelsasservice/modelsasservice_controller.go
@@ -85,6 +85,7 @@ func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.
 		)).
 		// WithAction(releases.NewAction()). // TODO: Do we need this? How to fix annotation of "platform.opendatahub.io/version:0.0.0"
 		WithAction(configureGatewayNamespaceResources).
+		WithAction(manageMaasApiRBAC).
 		WithAction(deploy.NewAction(
 			deploy.WithCache(),
 		)).

--- a/internal/controller/components/modelsasservice/modelsasservice_controller_actions.go
+++ b/internal/controller/components/modelsasservice/modelsasservice_controller_actions.go
@@ -22,7 +22,9 @@ import (
 	"fmt"
 
 	"github.com/go-logr/logr"
+	rbacv1 "k8s.io/api/rbac/v1"
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	k8stypes "k8s.io/apimachinery/pkg/types"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -33,6 +35,7 @@ import (
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
 	odhdeploy "github.com/opendatahub-io/opendatahub-operator/v2/pkg/deploy"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/metadata/labels"
 )
 
 // validateGateway validates the Gateway specification in the ModelsAsService resource.
@@ -200,4 +203,57 @@ func configureDestinationRule(log logr.Logger, resource *unstructured.Unstructur
 		"newNamespace", gatewayNamespace)
 
 	resource.SetNamespace(gatewayNamespace)
+}
+
+// manageMaasApiRBAC adds a ClusterRole and ClusterRoleBinding so the maas-api ServiceAccount
+// can list/get/watch maassubscriptions and maasmodels (maas.opendatahub.io) at cluster scope.
+// This fixes RBAC when the MaaS manifests do not grant these permissions.
+func manageMaasApiRBAC(ctx context.Context, rr *types.ReconciliationRequest) error {
+	appNamespace, err := cluster.ApplicationNamespace(ctx, rr.Client)
+	if err != nil {
+		return err
+	}
+
+	cr := &rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: MaasApiClusterRoleName,
+			Labels: map[string]string{
+				labels.ODH.Component(ComponentName): labels.True,
+			},
+		},
+		Rules: []rbacv1.PolicyRule{
+			{
+				APIGroups: []string{MaasCRDAPIGroup},
+				Resources: []string{"maassubscriptions", "maasmodels"},
+				Verbs:     []string{"list", "get", "watch"},
+			},
+		},
+	}
+
+	crb := &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: MaasApiClusterRoleBindingName,
+			Labels: map[string]string{
+				labels.ODH.Component(ComponentName): labels.True,
+			},
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:      rbacv1.ServiceAccountKind,
+				Namespace: appNamespace,
+				Name:      MaasApiServiceAccountName,
+				APIGroup:  "",
+			},
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: gvk.ClusterRole.Group,
+			Kind:     gvk.ClusterRole.Kind,
+			Name:     MaasApiClusterRoleName,
+		},
+	}
+
+	if err := rr.AddResources(cr, crb); err != nil {
+		return fmt.Errorf("failed to add maas-api RBAC resources: %w", err)
+	}
+	return nil
 }

--- a/internal/controller/components/modelsasservice/modelsasservice_support.go
+++ b/internal/controller/components/modelsasservice/modelsasservice_support.go
@@ -44,6 +44,15 @@ const (
 	// configures TLS for the MaaS gateway. This resource needs to be deployed to
 	// the same namespace as the gateway it targets.
 	GatewayDestinationRuleName = "maas-api-backend-tls"
+
+	// MaasApiServiceAccountName is the name of the ServiceAccount used by the maas-api deployment.
+	MaasApiServiceAccountName = "maas-api"
+	// MaasApiClusterRoleName is the name of the ClusterRole that grants maas-api list/get/watch on MaaS CRs.
+	MaasApiClusterRoleName = "maas-api-cluster-role"
+	// MaasApiClusterRoleBindingName is the name of the ClusterRoleBinding that binds the role to maas-api SA.
+	MaasApiClusterRoleBindingName = "maas-api-cluster-role-binding"
+	// MaasCRDAPIGroup is the API group for MaaS custom resources (maassubscriptions, maasmodels).
+	MaasCRDAPIGroup = "maas.opendatahub.io"
 )
 
 var (


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
fix(modelsasservice): grant maas-api SA permissions for maassubscriptions and maasmodels

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
e2e fix


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added RBAC (Role-Based Access Control) support for the MaaS API component, including ClusterRole and ClusterRoleBinding resources. The MaaS API can now properly access required resources with appropriate cluster-level permissions for listing, getting, and watching MaaS resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->