### PR TITLE
added test-tag mechanism to filter tests by tag

### DIFF
--- a/Dockerfiles/e2e-tests/e2e-tests.Dockerfile
+++ b/Dockerfiles/e2e-tests/e2e-tests.Dockerfile
@@ -42,6 +42,7 @@ ENV E2E_TEST_HARDWARE_PROFILE=true
 ENV E2E_TEST_WEBHOOK=true
 ENV E2E_TEST_COMPONENTS=true
 ENV E2E_TEST_SERVICES=true
+ENV E2E_TEST_TAG=All
 
 RUN apt-get update -y && apt-get upgrade -y && \
     curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" && \
@@ -71,4 +72,4 @@ CMD gotestsum --junitfile-project-name odh-operator-e2e \
 --test-webhook="$E2E_TEST_WEBHOOK" --test-components="$E2E_TEST_COMPONENTS" --test-services="$E2E_TEST_SERVICES" \
 --operator-namespace="$E2E_TEST_OPERATOR_NAMESPACE" --applications-namespace="$E2E_TEST_APPLICATIONS_NAMESPACE" \
 --workbenches-namespace="$E2E_TEST_WORKBENCHES_NAMESPACE" --dsc-monitoring-namespace="$E2E_TEST_DSC_MONITORING_NAMESPACE" \
---fail-fast-on-error="$E2E_TEST_FAIL_FAST_ON_ERROR"
+--fail-fast-on-error="$E2E_TEST_FAIL_FAST_ON_ERROR" --tag="$E2E_TEST_TAG"

--- a/README.md
+++ b/README.md
@@ -736,6 +736,7 @@ Evn vars can be set to configure e2e tests:
 | E2E_TEST_HARDWARE_PROFILE            | To configure the execution of hardware profile tests, useful for testing hardware profile functionality for v1 and v1alpha1                                                                                  | `true`                        |
 | E2E_TEST_CLEAN_UP_PREVIOUS_RESOURCES | To configure the cleaning-up of the previous resources in the cluster. This flag is quite useful to test custom scenarios, as well as running the tests after upgrade, to keep the previous DSC and test it. | `true`                        |
 | E2E_TEST_FAIL_FAST_ON_ERROR          | To configure the fail fast of the e2e tests when a test is failing.                                                                                                                                          | `true`                        |
+| E2E_TEST_TAG                         | Tag to run tests for. Options: `All`, `Smoke`, `Tier1`.                                                                                                                                                      | `All`                         |
 | E2E_TEST_FLAGS                       | Alternatively the above configurations can be passed to e2e-tests as flags using this env var (see flags table below)                                                                                        |                               |
 
 Alternatively the above configurations can be passed to e2e-tests as flags by setting up `E2E_TEST_FLAGS` variable. Following table lists all the available flags:
@@ -758,6 +759,7 @@ Alternatively the above configurations can be passed to e2e-tests as flags by se
 | --test-hardware-profile       | To configure the execution of hardware profile tests, useful for testing hardware profile functionality between v1 and v1alpha1                                                                              | `true`                        |
 | --clean-up-previous-resources | To configure the cleaning-up of the previous resources in the cluster. This flag is quite useful to test custom scenarios, as well as running the tests after upgrade, to keep the previous DSC and test it. | `true`                        |
 | --fail-fast-on-error          | To configure the fail fast of the e2e tests when a test is failing.                                                                                                                                          | `true`                        |
+| --tag                         | Tag to run tests for. Options: `All`, `Smoke`, `Tier1`.                                                                                                                                                      | `All`                         |
 
 <details>
 <summary>Running E2E tests with custom application namespace</summary>

--- a/tests/e2e/authcontroller_test.go
+++ b/tests/e2e/authcontroller_test.go
@@ -76,7 +76,7 @@ func authControllerTestSuite(t *testing.T) {
 func (tc *AuthControllerTestCtx) ValidateAuthSystemInitialization(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, []TestTag{Smoke})
+	skipUnless(t, Smoke)
 
 	expectedAdminGroup := tc.getExpectedAdminGroupForPlatform()
 
@@ -123,7 +123,7 @@ func (tc *AuthControllerTestCtx) ValidateAuthSystemInitialization(t *testing.T) 
 func (tc *AuthControllerTestCtx) ValidateAddingGroups(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, []TestTag{Tier1})
+	skipUnless(t, Tier1)
 
 	testAdminGroup := "aTestAdminGroup"
 	testAllowedGroup := "aTestAllowedGroup"
@@ -151,7 +151,7 @@ func (tc *AuthControllerTestCtx) ValidateAddingGroups(t *testing.T) {
 func (tc *AuthControllerTestCtx) ValidateRemovingGroups(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, []TestTag{Tier1})
+	skipUnless(t, Tier1)
 
 	// Get the expected admin group for the current platform
 	expectedGroup := tc.getExpectedAdminGroupForPlatform()
@@ -183,7 +183,7 @@ func (tc *AuthControllerTestCtx) ValidateRemovingGroups(t *testing.T) {
 func (tc *AuthControllerTestCtx) ValidateCELBlocksInvalidGroupsViaUpdate(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, []TestTag{Tier1})
+	skipUnless(t, Tier1)
 
 	// Test cases for different invalid update scenarios
 	testCases := []struct {
@@ -229,7 +229,7 @@ func (tc *AuthControllerTestCtx) ValidateCELBlocksInvalidGroupsViaUpdate(t *test
 func (tc *AuthControllerTestCtx) ValidateCELAllowsValidGroups(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, []TestTag{Tier1})
+	skipUnless(t, Tier1)
 
 	testCases := []struct {
 		name        string

--- a/tests/e2e/cfmap_deletion_test.go
+++ b/tests/e2e/cfmap_deletion_test.go
@@ -58,7 +58,7 @@ func cfgMapDeletionTestSuite(t *testing.T) {
 func (tc *CfgMapDeletionTestCtx) ValidateDSCDeletionUsingConfigMap(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, []TestTag{Tier1})
+	skipUnless(t, Tier1)
 
 	// Create or update the deletion config map
 	enableDeletion := "false"
@@ -89,7 +89,7 @@ func (tc *CfgMapDeletionTestCtx) ValidateDSCDeletionUsingConfigMap(t *testing.T)
 func (tc *CfgMapDeletionTestCtx) ValidateOwnedNamespacesAllExist(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, []TestTag{Tier1})
+	skipUnless(t, Tier1)
 
 	// Ensure namespaces with the owned namespace label exist
 	tc.EnsureResourcesExist(

--- a/tests/e2e/components_test.go
+++ b/tests/e2e/components_test.go
@@ -84,7 +84,7 @@ func NewSubComponentTestCtx(t *testing.T, object common.PlatformObject, parentKi
 func (tc *ComponentTestCtx) ValidateComponentEnabled(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, []TestTag{Smoke, Tier1})
+	skipUnless(t, Smoke, Tier1)
 
 	// As these tests can be executed in a non-cleaned scenario, we need to move the component first to Removed.
 	tc.UpdateComponentStateInDataScienceCluster(operatorv1.Removed)
@@ -113,7 +113,7 @@ func (tc *ComponentTestCtx) ValidateComponentEnabled(t *testing.T) {
 func (tc *ComponentTestCtx) ValidateComponentDisabled(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, []TestTag{Smoke, Tier1})
+	skipUnless(t, Smoke, Tier1)
 
 	// Ensure that the resources associated with the component exist
 	tc.EnsureResourcesExist(WithMinimalObject(tc.GVK, tc.NamespacedName))
@@ -142,7 +142,7 @@ func (tc *ComponentTestCtx) ValidateComponentDisabled(t *testing.T) {
 func (tc *ComponentTestCtx) ValidateOperandsOwnerReferences(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, []TestTag{Smoke})
+	skipUnless(t, Smoke)
 
 	// Ensure that the Deployment resources exist with the proper owner references
 	tc.EnsureResourcesExist(
@@ -167,7 +167,7 @@ func (tc *ComponentTestCtx) ValidateOperandsOwnerReferences(t *testing.T) {
 func (tc *ComponentTestCtx) ValidateS3SecretCheckBucketExist(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, []TestTag{Tier1})
+	skipUnless(t, Tier1)
 
 	// Ensure the component is actually enabled before checking for the VAP
 	// This handles cases where the component might have been temporarily disabled
@@ -186,7 +186,7 @@ func (tc *ComponentTestCtx) ValidateS3SecretCheckBucketExist(t *testing.T) {
 func (tc *ComponentTestCtx) ValidateUpdateDeploymentsResources(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, []TestTag{Smoke})
+	skipUnless(t, Smoke)
 
 	// Ensure that deployments exist for the component
 	deployments := tc.EnsureResourcesExist(
@@ -253,7 +253,7 @@ func (tc *ComponentTestCtx) ValidateCRDsReinstated(t *testing.T, crds []CRD) {
 func (tc *ComponentTestCtx) ValidateComponentReleases(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, []TestTag{Smoke})
+	skipUnless(t, Smoke)
 
 	componentName := strings.ToLower(tc.GVK.Kind)
 
@@ -345,7 +345,7 @@ func (tc *ComponentTestCtx) UpdateSubComponentStateInDataScienceCluster(t *testi
 func (tc *ComponentTestCtx) ValidateSubComponentEnabled(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, []TestTag{Smoke})
+	skipUnless(t, Smoke, Tier1)
 
 	if tc.ParentKind == "" || tc.SubComponentFieldName == "" {
 		t.Fatal("ValidateSubComponentEnabled called on a component without parent/subcomponent information.")
@@ -377,7 +377,7 @@ func (tc *ComponentTestCtx) ValidateSubComponentEnabled(t *testing.T) {
 func (tc *ComponentTestCtx) ValidateSubComponentReleases(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, []TestTag{Smoke})
+	skipUnless(t, Smoke)
 
 	if tc.ParentKind == "" || tc.SubComponentFieldName == "" {
 		t.Fatal("ValidateSubComponentReleases called on a component without parent/subcomponent information.")
@@ -411,6 +411,8 @@ func (tc *ComponentTestCtx) ValidateSubComponentReleases(t *testing.T) {
 // ValidateSubComponentDisabled ensures that a subcomponent is disabled and its resources are deleted.
 func (tc *ComponentTestCtx) ValidateSubComponentDisabled(t *testing.T) {
 	t.Helper()
+
+	skipUnless(t, Smoke, Tier1)
 
 	if tc.ParentKind == "" || tc.SubComponentFieldName == "" {
 		t.Fatal("ValidateSubComponentDisabled called on a component without parent/subcomponent information.")
@@ -493,7 +495,7 @@ func (tc *ComponentTestCtx) ValidateCRDReinstatement(name string, version string
 func (tc *ComponentTestCtx) ValidateModelControllerInstance(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, []TestTag{Smoke})
+	skipUnless(t, Smoke)
 
 	// Ensure ModelController resource exists with the expected owner references and status phase.
 	tc.EnsureResourceExists(
@@ -519,7 +521,7 @@ func (tc *ComponentTestCtx) ValidateModelControllerInstance(t *testing.T) {
 func (tc *ComponentTestCtx) ValidateAllDeletionRecovery(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, []TestTag{Smoke, Tier1})
+	skipUnless(t, Smoke, Tier1)
 
 	// Increase the global eventually timeout for deletion recovery tests
 	// Use longEventuallyTimeout to handle controller performance under load and complex resource dependencies

--- a/tests/e2e/controller_test.go
+++ b/tests/e2e/controller_test.go
@@ -74,6 +74,7 @@ func ParseDeletionPolicy(dp string) (DeletionPolicy, error) {
 
 // Struct to store test configurations.
 type TestContextConfig struct {
+	tag                  string
 	operatorNamespace    string
 	appsNamespace        string
 	workbenchesNamespace string
@@ -403,6 +404,9 @@ func TestMain(m *testing.M) {
 		"Specify when to delete DataScienceCluster, DSCInitialization, and controllers. Options: always, on-failure, never.")
 	checkEnvVarBindingError(viper.BindEnv("deletion-policy", viper.GetEnvPrefix()+"_DELETION_POLICY"))
 
+	pflag.String("tag", "All", "Tag to run tests for. Options: All, Smoke, Tier1")
+	checkEnvVarBindingError(viper.BindEnv("tag", viper.GetEnvPrefix()+"_TAG"))
+
 	pflag.Bool("fail-fast-on-error", true, "fail fast on error")
 	checkEnvVarBindingError(viper.BindEnv("fail-fast-on-error", viper.GetEnvPrefix()+"_FAIL_FAST_ON_ERROR"))
 	pflag.Bool("clean-up-previous-resources", true, "clean up previous resources before running tests")
@@ -454,6 +458,11 @@ func TestMain(m *testing.M) {
 		defaultEventuallyPollInterval:   viper.GetDuration("defaultEventuallyPollInterval"),
 		defaultConsistentlyTimeout:      viper.GetDuration("defaultConsistentlyTimeout"),
 		defaultConsistentlyPollInterval: viper.GetDuration("defaultConsistentlyPollInterval"),
+	}
+	testOpts.tag = viper.GetString("tag")
+	if !slices.Contains(allowedTags, TestTag(testOpts.tag)) {
+		fmt.Printf("Unknown tag: %s. Valid tags are: %v\n", testOpts.tag, allowedTags)
+		os.Exit(1)
 	}
 	testOpts.operatorNamespace = viper.GetString("operator-namespace")
 	testOpts.appsNamespace = viper.GetString("applications-namespace")

--- a/tests/e2e/creation_test.go
+++ b/tests/e2e/creation_test.go
@@ -106,7 +106,7 @@ func dscWebhookTestSuite(t *testing.T) {
 func (tc *DSCTestCtx) ValidateOperatorsInstallation(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, []TestTag{Smoke})
+	skipUnless(t, Smoke)
 
 	// Define operators to be installed.
 	operators := []Operator{
@@ -123,7 +123,7 @@ func (tc *DSCTestCtx) ValidateOperatorsInstallation(t *testing.T) {
 func (tc *DSCTestCtx) ValidateResourcesCreation(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, []TestTag{Smoke})
+	skipUnless(t, Smoke)
 
 	tc.EventuallyResourceCreatedOrUpdated(
 		WithObjectToCreate(CreateJobSetOperator()),
@@ -136,7 +136,7 @@ func (tc *DSCTestCtx) ValidateResourcesCreation(t *testing.T) {
 func (tc *DSCTestCtx) ValidateDSCICreation(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, []TestTag{Smoke})
+	skipUnless(t, Smoke)
 
 	tc.EventuallyResourceCreatedOrUpdated(
 		WithObjectToCreate(CreateDSCI(tc.DSCInitializationNamespacedName.Name, tc.AppsNamespace, tc.MonitoringNamespace)),
@@ -153,7 +153,7 @@ func (tc *DSCTestCtx) ValidateDSCICreation(t *testing.T) {
 func (tc *DSCTestCtx) ValidateDSCCreation(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, []TestTag{Smoke})
+	skipUnless(t, Smoke)
 
 	tc.EventuallyResourceCreatedOrUpdated(
 		WithObjectToCreate(CreateDSC(tc.DataScienceClusterNamespacedName.Name, tc.WorkbenchesNamespace)),
@@ -170,7 +170,7 @@ func (tc *DSCTestCtx) ValidateDSCCreation(t *testing.T) {
 func (tc *DSCTestCtx) ValidateOwnedNamespacesAllExist(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, []TestTag{Smoke})
+	skipUnless(t, Smoke)
 
 	// Ensure namespaces with the owned namespace label exist.
 	tc.EnsureResourcesExist(
@@ -190,7 +190,7 @@ func (tc *DSCTestCtx) ValidateOwnedNamespacesAllExist(t *testing.T) {
 func (tc *DSCTestCtx) ValidateDefaultNetworkPolicyExists(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, []TestTag{Smoke})
+	skipUnless(t, Smoke)
 
 	dsci := tc.FetchDSCInitialization()
 
@@ -205,7 +205,7 @@ func (tc *DSCTestCtx) ValidateDefaultNetworkPolicyExists(t *testing.T) {
 func (tc *DSCTestCtx) ValidateDSCIDuplication(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, []TestTag{Smoke})
+	skipUnless(t, Smoke)
 
 	dup := CreateDSCI(dsciInstanceNameDuplicate, tc.AppsNamespace, tc.MonitoringNamespace)
 	tc.EnsureResourceIsUnique(dup, "Error validating DSCInitialization duplication")
@@ -218,7 +218,7 @@ func (tc *DSCTestCtx) ValidateDSCIDuplication(t *testing.T) {
 func (tc *DSCTestCtx) ValidateDSCDuplication(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, []TestTag{Smoke})
+	skipUnless(t, Smoke)
 
 	dsc := CreateDSC(dscInstanceNameDuplicate, tc.WorkbenchesNamespace)
 	tc.EnsureResourceIsUnique(dsc, "Error validating DataScienceCluster duplication")
@@ -231,7 +231,7 @@ func (tc *DSCTestCtx) ValidateDSCDuplication(t *testing.T) {
 func (tc *DSCTestCtx) ValidateModelRegistryConfig(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, []TestTag{Tier1})
+	skipUnless(t, Tier1)
 
 	// Retrieve the DataScienceCluster object.
 	dsc := tc.FetchDataScienceCluster()
@@ -277,7 +277,7 @@ func (tc *DSCTestCtx) UpdateRegistriesNamespace(targetNamespace, expectedValue s
 func (tc *DSCTestCtx) ValidateHardwareProfileCR(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, []TestTag{Smoke})
+	skipUnless(t, Smoke)
 
 	// verifed default hardwareprofile exists and api version is correct on v1.
 	tc.EnsureResourceExists(

--- a/tests/e2e/dashboard_test.go
+++ b/tests/e2e/dashboard_test.go
@@ -56,7 +56,7 @@ func dashboardTestSuite(t *testing.T) {
 func (tc *DashboardTestCtx) ValidateOperandsDynamicallyWatchedResources(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, []TestTag{Smoke})
+	skipUnless(t, Smoke)
 
 	// Generate unique platform type values
 	newPt := xid.New().String()
@@ -96,7 +96,7 @@ func (tc *DashboardTestCtx) ValidateOperandsDynamicallyWatchedResources(t *testi
 func (tc *DashboardTestCtx) ValidateCRDReinstated(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, []TestTag{Tier1})
+	skipUnless(t, Tier1)
 
 	crds := []CRD{
 		{Name: "odhapplications.dashboard.opendatahub.io", Version: ""},
@@ -123,7 +123,7 @@ func (tc *DashboardTestCtx) ValidateAllDeletionRecovery(t *testing.T) {
 func (tc *DashboardTestCtx) ValidateHardwareProfileCreationBlockedByWebHook(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, []TestTag{Tier1})
+	skipUnless(t, Tier1)
 
 	testHWPName := "test-hwp-" + xid.New().String()
 	// Create the HardwareProfile object
@@ -145,7 +145,7 @@ func (tc *DashboardTestCtx) ValidateHardwareProfileCreationBlockedByWebHook(t *t
 func (tc *DashboardTestCtx) ValidateAcceleratorProfileCreationBlockedByWebHook(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, []TestTag{Tier1})
+	skipUnless(t, Tier1)
 
 	testAPName := "test-ap-" + xid.New().String()
 	apProfile := &unstructured.Unstructured{}

--- a/tests/e2e/datasciencepipelines_test.go
+++ b/tests/e2e/datasciencepipelines_test.go
@@ -49,7 +49,7 @@ func dataSciencePipelinesTestSuite(t *testing.T) {
 func (tc *DataSciencePipelinesTestCtx) ValidateConditions(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, []TestTag{Smoke})
+	skipUnless(t, Smoke)
 
 	// Ensure the DataSciencePipelines resource has the "ArgoWorkflowAvailable" condition set to "True".
 	tc.ValidateComponentCondition(
@@ -64,7 +64,7 @@ func (tc *DataSciencePipelinesTestCtx) ValidateConditions(t *testing.T) {
 func (tc *DataSciencePipelinesTestCtx) ValidateArgoWorkflowsControllersOptions(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, []TestTag{Tier1})
+	skipUnless(t, Tier1)
 
 	tc.EventuallyResourcePatched(
 		WithMinimalObject(gvk.DataScienceCluster, tc.DataScienceClusterNamespacedName),

--- a/tests/e2e/deletion_test.go
+++ b/tests/e2e/deletion_test.go
@@ -39,7 +39,7 @@ func deletionTestSuite(t *testing.T) {
 func (tc *DeletionTestCtx) TestDSCDeletion(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, []TestTag{Tier1})
+	skipUnless(t, Tier1)
 
 	// Delete the DataScienceCluster instance
 	tc.DeleteResource(WithMinimalObject(gvk.DataScienceCluster, tc.DataScienceClusterNamespacedName))
@@ -49,7 +49,7 @@ func (tc *DeletionTestCtx) TestDSCDeletion(t *testing.T) {
 func (tc *DeletionTestCtx) TestDSCIDeletion(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, []TestTag{Tier1})
+	skipUnless(t, Tier1)
 
 	// Delete the DSCInitialization instance
 	tc.DeleteResource(WithMinimalObject(gvk.DSCInitialization, tc.DSCInitializationNamespacedName))

--- a/tests/e2e/gateway_redirect_test.go
+++ b/tests/e2e/gateway_redirect_test.go
@@ -19,7 +19,7 @@ import (
 func (tc *GatewayTestCtx) DashboardRedirectTestSuite(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, []TestTag{Tier1})
+	skipUnless(t, Tier1)
 
 	// Skip all tests if not in OcpRoute mode
 	if !tc.isOcpRouteMode(t) {
@@ -42,7 +42,7 @@ func (tc *GatewayTestCtx) ValidateDashboardRedirectConfigMap(t *testing.T) {
 	t.Helper()
 	t.Log("Validating dashboard redirect ConfigMap")
 
-	skipUnless(t, []TestTag{Tier1})
+	skipUnless(t, Tier1)
 
 	appNamespace := tc.AppsNamespace
 	expectedGatewayHostname := tc.getExpectedGatewayHostname(t)
@@ -85,7 +85,7 @@ func (tc *GatewayTestCtx) ValidateDashboardRedirectConfigMap(t *testing.T) {
 // - Proper security context and resource limits.
 func (tc *GatewayTestCtx) ValidateDashboardRedirectDeployment(t *testing.T) {
 	t.Helper()
-	skipUnless(t, []TestTag{Tier1})
+	skipUnless(t, Tier1)
 	t.Log("Validating dashboard redirect Deployment")
 
 	appNamespace := tc.AppsNamespace
@@ -151,7 +151,7 @@ func (tc *GatewayTestCtx) ValidateDashboardRedirectDeployment(t *testing.T) {
 // ValidateDashboardRedirectService validates the redirect service configuration.
 func (tc *GatewayTestCtx) ValidateDashboardRedirectService(t *testing.T) {
 	t.Helper()
-	skipUnless(t, []TestTag{Tier1})
+	skipUnless(t, Tier1)
 	t.Log("Validating dashboard redirect Service")
 
 	appNamespace := tc.AppsNamespace
@@ -198,7 +198,7 @@ func (tc *GatewayTestCtx) ValidateDashboardRedirectService(t *testing.T) {
 // - Routes have GatewayConfig owner references (verifies SSA ownership takeover).
 func (tc *GatewayTestCtx) ValidateDashboardRedirectRoutes(t *testing.T) {
 	t.Helper()
-	skipUnless(t, []TestTag{Tier1})
+	skipUnless(t, Tier1)
 	t.Log("Validating dashboard redirect Routes")
 
 	appNamespace := tc.AppsNamespace
@@ -284,7 +284,7 @@ func (tc *GatewayTestCtx) ValidateDashboardRedirectRoutes(t *testing.T) {
 // - Path is preserved in redirect ($request_uri works correctly).
 func (tc *GatewayTestCtx) ValidateDashboardRedirectHTTP(t *testing.T) {
 	t.Helper()
-	skipUnless(t, []TestTag{Tier1})
+	skipUnless(t, Tier1)
 	t.Log("Validating dashboard redirect HTTP functionality")
 
 	dashboardRouteName := getDashboardRouteNameByPlatform(tc.FetchPlatformRelease())

--- a/tests/e2e/gateway_test.go
+++ b/tests/e2e/gateway_test.go
@@ -118,7 +118,7 @@ func makeCookieDomain(hostname string) string {
 func (tc *GatewayTestCtx) ValidateGatewayConfig(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, []TestTag{Smoke})
+	skipUnless(t, Smoke)
 	t.Log("Validating GatewayConfig resource")
 
 	// Common validation: Ready status and ownership
@@ -139,7 +139,7 @@ func (tc *GatewayTestCtx) ValidateGatewayConfig(t *testing.T) {
 func (tc *GatewayTestCtx) ValidateGatewayInfrastructure(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, []TestTag{Tier1})
+	skipUnless(t, Tier1)
 	t.Log("Validating Gateway infrastructure resources")
 
 	t.Log("Validating GatewayClass resource")
@@ -185,7 +185,7 @@ func (tc *GatewayTestCtx) ValidateGatewayInfrastructure(t *testing.T) {
 func (tc *GatewayTestCtx) ValidateOAuthClientAndSecret(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, []TestTag{Tier1})
+	skipUnless(t, Tier1)
 	t.Log("Validating OAuth client and secret creation")
 
 	expectedGatewayHostname := tc.getExpectedGatewayHostname(t)
@@ -244,7 +244,7 @@ func (tc *GatewayTestCtx) ValidateOAuthClientAndSecret(t *testing.T) {
 func (tc *GatewayTestCtx) ValidateAuthProxyDeployment(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, []TestTag{Tier1})
+	skipUnless(t, Tier1)
 	t.Log("Validating kube-auth-proxy deployment and service")
 
 	expectedGatewayHostname := tc.getExpectedGatewayHostname(t)
@@ -381,7 +381,7 @@ func (tc *GatewayTestCtx) ValidateAuthProxyDeployment(t *testing.T) {
 func (tc *GatewayTestCtx) ValidateHPA(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, []TestTag{Tier1})
+	skipUnless(t, Tier1)
 	t.Log("Validating HorizontalPodAutoscaler for kube-auth-proxy")
 
 	tc.EnsureResourceExists(
@@ -426,7 +426,7 @@ func (tc *GatewayTestCtx) ValidateHPA(t *testing.T) {
 func (tc *GatewayTestCtx) ValidateOAuthCallbackRoute(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, []TestTag{Tier1})
+	skipUnless(t, Tier1)
 	t.Log("Validating OAuth callback HTTPRoute")
 
 	tc.EnsureResourceExists(
@@ -472,7 +472,7 @@ func (tc *GatewayTestCtx) ValidateOAuthCallbackRoute(t *testing.T) {
 func (tc *GatewayTestCtx) ValidateEnvoyFilter(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, []TestTag{Tier1})
+	skipUnless(t, Tier1)
 	t.Log("Validating EnvoyFilter for authentication")
 
 	authProxyFQDN := getServiceFQDN(kubeAuthProxyName, gatewayNamespace)
@@ -533,7 +533,7 @@ func (tc *GatewayTestCtx) ValidateEnvoyFilter(t *testing.T) {
 func (tc *GatewayTestCtx) ValidateEDSEndpointDiscovery(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, []TestTag{Tier1})
+	skipUnless(t, Tier1)
 	t.Log("Validating EDS service configuration for kube-auth-proxy")
 
 	tc.EnsureResourceExists(
@@ -556,7 +556,7 @@ func (tc *GatewayTestCtx) ValidateEDSEndpointDiscovery(t *testing.T) {
 func (tc *GatewayTestCtx) ValidateGatewayReadyStatus(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, []TestTag{Smoke})
+	skipUnless(t, Smoke)
 	t.Log("Validating Gateway ready status")
 
 	// Core validation: Gateway is Accepted, Programmed, and has routes attached
@@ -590,7 +590,7 @@ func (tc *GatewayTestCtx) ValidateGatewayReadyStatus(t *testing.T) {
 func (tc *GatewayTestCtx) ValidateUnauthenticatedRedirect(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, []TestTag{Tier1})
+	skipUnless(t, Tier1)
 
 	tc.UpdateComponentStateInDataScienceClusterWithKind(operatorv1.Managed, componentApi.DashboardKind)
 	defer tc.UpdateComponentStateInDataScienceClusterWithKind(operatorv1.Removed, componentApi.DashboardKind)
@@ -785,7 +785,7 @@ func getServiceFQDN(serviceName, namespace string) string {
 func (tc *GatewayTestCtx) ValidateNetworkPolicy(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, []TestTag{Tier1})
+	skipUnless(t, Tier1)
 	t.Log("Validating NetworkPolicy for kube-auth-proxy")
 
 	tc.EnsureResourceExists(

--- a/tests/e2e/hardwareprofile_test.go
+++ b/tests/e2e/hardwareprofile_test.go
@@ -58,7 +58,7 @@ func hardwareProfileWorkloadTestSuite(t *testing.T) {
 func (tc *HardwareProfileWorkloadTestCtx) ValidateHWPToleration(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, []TestTag{Tier1})
+	skipUnless(t, Tier1)
 
 	workloadName := "test-notebook-toleration"
 
@@ -133,7 +133,7 @@ func (tc *HardwareProfileWorkloadTestCtx) ValidateHWPToleration(t *testing.T) {
 func (tc *HardwareProfileWorkloadTestCtx) ValidateHWPKueue(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, []TestTag{Tier1})
+	skipUnless(t, Tier1)
 
 	workloadName := "test-notebook-kueue"
 	// Create an empty hardware profile (empty-profile)
@@ -193,7 +193,7 @@ func (tc *HardwareProfileWorkloadTestCtx) ValidateHWPKueue(t *testing.T) {
 func (tc *HardwareProfileWorkloadTestCtx) ValidateHWPAnnotationRemoval(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, []TestTag{Tier1})
+	skipUnless(t, Tier1)
 
 	workloadName := "test-notebook-hwp-removal"
 
@@ -278,7 +278,7 @@ func (tc *HardwareProfileWorkloadTestCtx) ValidateHWPAnnotationRemoval(t *testin
 func (tc *HardwareProfileWorkloadTestCtx) ValidateManualTolerationPreservation(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, []TestTag{Tier1})
+	skipUnless(t, Tier1)
 
 	workloadName := "test-notebook-manual-tol"
 
@@ -346,7 +346,7 @@ func (tc *HardwareProfileWorkloadTestCtx) ValidateManualTolerationPreservation(t
 func (tc *HardwareProfileWorkloadTestCtx) ValidateHWPProfileSwitching(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, []TestTag{Tier1})
+	skipUnless(t, Tier1)
 
 	workloadName := "test-notebook-profile-switch"
 
@@ -412,7 +412,7 @@ func (tc *HardwareProfileWorkloadTestCtx) ValidateHWPProfileSwitching(t *testing
 func (tc *HardwareProfileWorkloadTestCtx) ValidateKueueLabelRemovalOnHWPRemoval(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, []TestTag{Tier1})
+	skipUnless(t, Tier1)
 
 	workloadName := "test-notebook-kueue-removal"
 

--- a/tests/e2e/kserve_test.go
+++ b/tests/e2e/kserve_test.go
@@ -100,7 +100,7 @@ func kserveDegradedMonitoringTestSuite(t *testing.T) {
 func (tc *KserveTestCtx) ValidateSpec(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, []TestTag{Smoke})
+	skipUnless(t, Smoke)
 
 	// Retrieve the DataScienceCluster instance.
 	dsc := tc.FetchDataScienceCluster()
@@ -119,7 +119,7 @@ func (tc *KserveTestCtx) ValidateSpec(t *testing.T) {
 func (tc *KserveTestCtx) ValidateNoKserveFeatureTrackers(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, []TestTag{Smoke})
+	skipUnless(t, Smoke)
 
 	tc.EnsureResourcesDoNotExist(
 		WithMinimalObject(gvk.FeatureTracker, tc.NamespacedName),
@@ -140,7 +140,7 @@ func (tc *KserveTestCtx) ValidateNoKserveFeatureTrackers(t *testing.T) {
 func (tc *KserveTestCtx) ValidateConnectionWebhookInjection(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, []TestTag{Tier1})
+	skipUnless(t, Tier1)
 
 	// Ensure KServe is in Managed state to enable webhook functionality
 	tc.ValidateComponentEnabled(t)
@@ -213,7 +213,7 @@ func (tc *KserveTestCtx) createConnectionSecret(secretName, namespace string) {
 func (tc *KserveTestCtx) ValidateLLMInferenceServiceConfigVersioned(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, []TestTag{Tier1})
+	skipUnless(t, Tier1)
 
 	// Validate that all well-known LLMInferenceServiceConfig resources have versioned names
 	// Expected format: vX-Y-Z-<config-name> where X, Y, Z are numbers
@@ -281,7 +281,7 @@ func (tc *KserveTestCtx) ensureLWSBaseline(t *testing.T) *unstructured.Unstructu
 func (tc *KserveTestCtx) ValidateExternalOperatorDegradedMonitoring(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, []TestTag{Tier1})
+	skipUnless(t, Tier1)
 
 	// condition types monitored by the Kserve Component
 	testCases := []degradedConditionTestCase{

--- a/tests/e2e/kueue_test.go
+++ b/tests/e2e/kueue_test.go
@@ -125,7 +125,7 @@ func kueueDegradedMonitoringTestSuite(t *testing.T) {
 func (tc *KueueTestCtx) EnsureKueueReady(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, []TestTag{Tier1})
+	skipUnless(t, Tier1)
 
 	componentName := strings.ToLower(tc.GVK.Kind)
 
@@ -158,7 +158,7 @@ func (tc *KueueTestCtx) EnsureKueueReady(t *testing.T) {
 func (tc *KueueTestCtx) ValidateKueueUnmanagedWithoutOcpKueueOperator(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, []TestTag{Tier1})
+	skipUnless(t, Tier1)
 
 	componentName := strings.ToLower(tc.GVK.Kind)
 
@@ -199,7 +199,7 @@ func (tc *KueueTestCtx) ValidateKueueUnmanagedWithoutOcpKueueOperator(t *testing
 func (tc *KueueTestCtx) ValidateKueueRemovedToUnmanagedTransition(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, []TestTag{Smoke})
+	skipUnless(t, Smoke)
 
 	managedNS := "test-kueue-managed-" + xid.New().String()
 	componentName := strings.ToLower(tc.GVK.Kind)
@@ -292,7 +292,7 @@ func (tc *KueueTestCtx) ValidateKueueRemovedToUnmanagedTransition(t *testing.T) 
 func (tc *KueueTestCtx) ValidateKueueUnmanagedToRemovedTransition(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, []TestTag{Smoke})
+	skipUnless(t, Smoke)
 
 	managedNS := "test-kueue-managed-" + xid.New().String()
 	componentName := strings.ToLower(tc.GVK.Kind)
@@ -373,7 +373,7 @@ func (tc *KueueTestCtx) ValidateKueueUnmanagedToRemovedTransition(t *testing.T) 
 func (tc *KueueTestCtx) ValidateWebhookValidations(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, []TestTag{Tier1})
+	skipUnless(t, Tier1)
 
 	t.Logf("Setting Workbenches component to Managed to install Notebook CRD for webhook tests.")
 	// Enable Workbenches component to ensure Notebook CRD is available for webhook tests
@@ -779,7 +779,7 @@ func (tc *KueueTestCtx) ensureClusterAndLocalQueueExist(localQueueNamespaceName 
 func (tc *KueueTestCtx) ValidateKueueComponentDisabled(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, []TestTag{Smoke, Tier1})
+	skipUnless(t, Smoke, Tier1)
 
 	t.Logf("Setting DSC component %s to Removed state.", componentApi.KueueInstanceName)
 	// Ensure that DataScienceCluster exists and its component state is "Removed", with the "Ready" condition false.
@@ -858,7 +858,7 @@ integrations:
 func (tc *KueueTestCtx) ValidateExternalOperatorDegradedMonitoring(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, []TestTag{Tier1})
+	skipUnless(t, Tier1)
 
 	managedNS := "test-kueue-managed-" + xid.New().String()
 

--- a/tests/e2e/modelcontroller_test.go
+++ b/tests/e2e/modelcontroller_test.go
@@ -57,6 +57,8 @@ func modelControllerTestSuite(t *testing.T) {
 func (tc *ModelControllerTestCtx) ValidateComponentEnabled(t *testing.T) {
 	t.Helper()
 
+	skipUnless(t, Smoke, Tier1)
+
 	// Ensure Kserve and ModelRegistry components are set as Managed in DataScienceCluster.
 	tc.EventuallyResourcePatched(
 		WithMinimalObject(gvk.DataScienceCluster, tc.DataScienceClusterNamespacedName),
@@ -81,6 +83,8 @@ func (tc *ModelControllerTestCtx) ValidateComponentEnabled(t *testing.T) {
 // ValidateComponentDisabled validates that the components are disabled.
 func (tc *ModelControllerTestCtx) ValidateComponentDisabled(t *testing.T) {
 	t.Helper()
+
+	skipUnless(t, Smoke, Tier1)
 
 	// Ensure Kserve and ModelRegistry components are set as Removed in DataScienceCluster.
 	tc.EventuallyResourcePatched(

--- a/tests/e2e/modelregistry_test.go
+++ b/tests/e2e/modelregistry_test.go
@@ -45,7 +45,7 @@ func modelRegistryTestSuite(t *testing.T) {
 func (tc *ModelRegistryTestCtx) ValidateSpec(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, []TestTag{Smoke})
+	skipUnless(t, Smoke)
 
 	// Retrieve the DataScienceCluster instance.
 	dsc := tc.FetchDataScienceCluster()
@@ -61,7 +61,7 @@ func (tc *ModelRegistryTestCtx) ValidateSpec(t *testing.T) {
 func (tc *ModelRegistryTestCtx) ValidateCRDReinstated(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, []TestTag{Tier1})
+	skipUnless(t, Tier1)
 
 	crds := []CRD{
 		{Name: "modelregistries.modelregistry.opendatahub.io", Version: ""},

--- a/tests/e2e/monitoring_test.go
+++ b/tests/e2e/monitoring_test.go
@@ -150,7 +150,7 @@ func monitoringTestSuite(t *testing.T) {
 func (tc *MonitoringTestCtx) ValidateMonitoringOperatorsInstallation(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, []TestTag{Tier1})
+	skipUnless(t, Tier1)
 
 	// Define operators to be installed.
 	operators := []Operator{
@@ -166,7 +166,7 @@ func (tc *MonitoringTestCtx) ValidateMonitoringOperatorsInstallation(t *testing.
 func (tc *MonitoringTestCtx) ValidateMonitoringCRCreation(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, []TestTag{Tier1})
+	skipUnless(t, Tier1)
 
 	tc.updateMonitoringConfig(withManagementState(operatorv1.Managed))
 
@@ -189,7 +189,7 @@ func (tc *MonitoringTestCtx) ValidateMonitoringCRCreation(t *testing.T) {
 func (tc *MonitoringTestCtx) ValidateMonitoringCRDefaultContent(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, []TestTag{Tier1})
+	skipUnless(t, Tier1)
 
 	// Ensure that the Monitoring resource exists.
 	tc.EnsureResourceExists(
@@ -213,7 +213,7 @@ func (tc *MonitoringTestCtx) ValidateMonitoringCRDefaultContent(t *testing.T) {
 func (tc *MonitoringTestCtx) ValidateMonitoringStackCRMetricsWhenSet(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, []TestTag{Tier1})
+	skipUnless(t, Tier1)
 
 	// Update DSCI to set metrics - ensure managementState remains Managed
 	tc.updateMonitoringConfig(
@@ -239,7 +239,7 @@ func (tc *MonitoringTestCtx) ValidateMonitoringStackCRMetricsWhenSet(t *testing.
 func (tc *MonitoringTestCtx) ValidateMonitoringStackCRMetricsConfiguration(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, []TestTag{Tier1})
+	skipUnless(t, Tier1)
 
 	// Use EnsureResourceExists with jq matchers for cleaner validation
 	tc.EnsureResourceExists(
@@ -266,7 +266,7 @@ func (tc *MonitoringTestCtx) ValidateMonitoringStackCRMetricsConfiguration(t *te
 func (tc *MonitoringTestCtx) ValidateMonitoringStackCRMetricsReplicasUpdate(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, []TestTag{Tier1})
+	skipUnless(t, Tier1)
 
 	// Update DSCI to set replicas to 1 (must include either storage or resources due to CEL validation rule)
 	replicasTransforms := append(
@@ -293,7 +293,7 @@ func (tc *MonitoringTestCtx) ValidateMonitoringStackCRMetricsReplicasUpdate(t *t
 func (tc *MonitoringTestCtx) ValidateCELBlocksInvalidMonitoringConfigs(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, []TestTag{Tier1})
+	skipUnless(t, Tier1)
 
 	testCases := []struct {
 		name        string
@@ -347,7 +347,7 @@ func (tc *MonitoringTestCtx) ValidateCELBlocksInvalidMonitoringConfigs(t *testin
 func (tc *MonitoringTestCtx) ValidateCELAllowsValidMonitoringConfigs(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, []TestTag{Tier1})
+	skipUnless(t, Tier1)
 
 	testCases := []struct {
 		name        string
@@ -390,7 +390,7 @@ func (tc *MonitoringTestCtx) ValidateCELAllowsValidMonitoringConfigs(t *testing.
 func (tc *MonitoringTestCtx) ValidateOpenTelemetryCollectorConfigurations(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, []TestTag{Tier1})
+	skipUnless(t, Tier1)
 
 	testCases := []struct {
 		name                string
@@ -491,7 +491,7 @@ func (tc *MonitoringTestCtx) ValidateOpenTelemetryCollectorConfigurations(t *tes
 func (tc *MonitoringTestCtx) ValidateMetricsTLSAlwaysEnabled(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, []TestTag{Tier1})
+	skipUnless(t, Tier1)
 	tc.updateMonitoringConfig(
 		withManagementState(operatorv1.Managed),
 		tc.withMetricsConfig(),
@@ -560,7 +560,7 @@ func (tc *MonitoringTestCtx) ValidateMetricsTLSAlwaysEnabled(t *testing.T) {
 func (tc *MonitoringTestCtx) ValidateMonitoringCRCollectorReplicas(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, []TestTag{Tier1})
+	skipUnless(t, Tier1)
 
 	defaultReplicas := tc.expectedDefaultReplicas
 	testReplicas := defaultReplicas + 1 // Test with one more replica than default
@@ -598,7 +598,7 @@ func (tc *MonitoringTestCtx) ValidateMonitoringCRCollectorReplicas(t *testing.T)
 func (tc *MonitoringTestCtx) ValidateMonitoringCRDefaultTracesContent(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, []TestTag{Tier1})
+	skipUnless(t, Tier1)
 
 	// Ensure monitoring is enabled (might have been disabled by previous test)
 	tc.updateMonitoringConfig(withManagementState(operatorv1.Managed))
@@ -618,7 +618,7 @@ func (tc *MonitoringTestCtx) ValidateMonitoringCRDefaultTracesContent(t *testing
 func (tc *MonitoringTestCtx) ValidateTempoMonolithicCRCreation(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, []TestTag{Tier1})
+	skipUnless(t, Tier1)
 
 	// Update DSCI to set traces with PV backend
 	tc.updateMonitoringConfig(
@@ -666,7 +666,7 @@ func (tc *MonitoringTestCtx) ValidateTempoMonolithicCRCreation(t *testing.T) {
 func (tc *MonitoringTestCtx) ValidateTempoStackCRCreationWithCloudStorage(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, []TestTag{Tier1})
+	skipUnless(t, Tier1)
 
 	testCases := []struct {
 		name                string
@@ -703,7 +703,7 @@ func (tc *MonitoringTestCtx) ValidateTempoStackCRCreationWithCloudStorage(t *tes
 func (tc *MonitoringTestCtx) ValidateInstrumentationCRTracesLifecycle(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, []TestTag{Tier1})
+	skipUnless(t, Tier1)
 
 	// Ensure clean slate before starting
 	tc.ensureMonitoringCleanSlate(t, "")
@@ -754,7 +754,7 @@ func (tc *MonitoringTestCtx) ValidateInstrumentationCRTracesLifecycle(t *testing
 func (tc *MonitoringTestCtx) ValidateTracesExportersReservedNameValidation(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, []TestTag{Tier1})
+	skipUnless(t, Tier1)
 
 	// Attempt to set traces configuration with a reserved exporter name
 	tc.updateMonitoringConfig(
@@ -782,7 +782,7 @@ func (tc *MonitoringTestCtx) ValidateTracesExportersReservedNameValidation(t *te
 func (tc *MonitoringTestCtx) ValidatePrometheusRulesLifecycle(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, []TestTag{Tier1})
+	skipUnless(t, Tier1)
 
 	// First, ensure dashboard is disabled to establish a known initial state.
 	tc.UpdateComponentStateInDataScienceClusterWithKind(operatorv1.Removed, gvk.Dashboard.Kind)
@@ -815,7 +815,7 @@ func (tc *MonitoringTestCtx) ValidatePrometheusRulesLifecycle(t *testing.T) {
 func (tc *MonitoringTestCtx) ValidatePersesCRCreation(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, []TestTag{Tier1})
+	skipUnless(t, Tier1)
 
 	tc.updateMonitoringConfig(
 		withManagementState(operatorv1.Managed),
@@ -837,7 +837,7 @@ func (tc *MonitoringTestCtx) ValidatePersesCRCreation(t *testing.T) {
 func (tc *MonitoringTestCtx) ValidatePersesCRConfiguration(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, []TestTag{Tier1})
+	skipUnless(t, Tier1)
 
 	tc.EnsureResourceExists(
 		WithMinimalObject(gvk.Perses, types.NamespacedName{Name: PersesName, Namespace: tc.MonitoringNamespace}),
@@ -873,7 +873,7 @@ func (tc *MonitoringTestCtx) ValidatePersesCRConfiguration(t *testing.T) {
 func (tc *MonitoringTestCtx) ValidatePersesLifecycle(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, []TestTag{Tier1})
+	skipUnless(t, Tier1)
 
 	tc.updateMonitoringConfig(
 		withManagementState(operatorv1.Managed),
@@ -921,7 +921,7 @@ func (tc *MonitoringTestCtx) ValidatePersesLifecycle(t *testing.T) {
 func (tc *MonitoringTestCtx) ValidatePersesNotDeployedWithoutMetricsOrTraces(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, []TestTag{Tier1})
+	skipUnless(t, Tier1)
 
 	tc.ensureMonitoringCleanSlate(t, "")
 
@@ -961,7 +961,7 @@ func (tc *MonitoringTestCtx) ValidatePersesNotDeployedWithoutMetricsOrTraces(t *
 func (tc *MonitoringTestCtx) ValidatePersesNetworkPolicy(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, []TestTag{Tier1})
+	skipUnless(t, Tier1)
 
 	tc.updateMonitoringConfig(
 		withManagementState(operatorv1.Managed),
@@ -987,7 +987,7 @@ func (tc *MonitoringTestCtx) ValidatePersesNetworkPolicy(t *testing.T) {
 func (tc *MonitoringTestCtx) ValidatePersesDatasourceWithPrometheus(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, []TestTag{Tier1})
+	skipUnless(t, Tier1)
 
 	// Enable monitoring with metrics configuration to deploy both Perses and Prometheus
 	tc.updateMonitoringConfig(
@@ -1050,7 +1050,7 @@ func (tc *MonitoringTestCtx) ValidatePersesDatasourceWithPrometheus(t *testing.T
 func (tc *MonitoringTestCtx) ValidatePersesDatasourceLifecycle(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, []TestTag{Tier1})
+	skipUnless(t, Tier1)
 
 	// Step 1: Enable monitoring with metrics to deploy datasource
 	tc.updateMonitoringConfig(
@@ -1120,7 +1120,7 @@ func (tc *MonitoringTestCtx) ValidatePersesDatasourceLifecycle(t *testing.T) {
 func (tc *MonitoringTestCtx) ValidateMonitoringServiceDisabled(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, []TestTag{Tier1})
+	skipUnless(t, Tier1)
 
 	// Ensure clean slate - previous tests may have left TempoMonolithic with TLS enabled
 	// and already in deletion state, which prevents our controller from updating it
@@ -1503,7 +1503,7 @@ func withMonitoringTraces(backend, secret, size, retention string) testf.Transfo
 func (tc *MonitoringTestCtx) ValidateThanosQuerierDeployment(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, []TestTag{Tier1})
+	skipUnless(t, Tier1)
 
 	// Ensure clean slate before starting
 	tc.ensureMonitoringCleanSlate(t, "")
@@ -1559,7 +1559,7 @@ func (tc *MonitoringTestCtx) ValidateThanosQuerierDeployment(t *testing.T) {
 func (tc *MonitoringTestCtx) ValidateThanosQuerierNotDeployedWithoutMetrics(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, []TestTag{Tier1})
+	skipUnless(t, Tier1)
 
 	// Ensure clean slate before starting
 	tc.ensureMonitoringCleanSlate(t, "")
@@ -1606,7 +1606,7 @@ func (tc *MonitoringTestCtx) ValidateThanosQuerierNotDeployedWithoutMetrics(t *t
 func (tc *MonitoringTestCtx) ValidatePrometheusSelfServiceMonitorTLSFix(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, []TestTag{Tier1})
+	skipUnless(t, Tier1)
 
 	tc.updateMonitoringConfig(
 		withManagementState(operatorv1.Managed),
@@ -1678,7 +1678,7 @@ func (tc *MonitoringTestCtx) ValidatePrometheusSelfServiceMonitorTLSFix(t *testi
 func (tc *MonitoringTestCtx) ValidatePersesDatasourceCreationWithTraces(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, []TestTag{Tier1})
+	skipUnless(t, Tier1)
 
 	// Skip if PersesDatasource CRD is not installed
 	ctx := context.Background()
@@ -1744,7 +1744,7 @@ func (tc *MonitoringTestCtx) ValidatePersesDatasourceCreationWithTraces(t *testi
 func (tc *MonitoringTestCtx) ValidatePersesDatasourceConfiguration(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, []TestTag{Tier1})
+	skipUnless(t, Tier1)
 
 	// Skip if PersesDatasource CRD is not installed
 	ctx := context.Background()
@@ -1911,7 +1911,7 @@ func (tc *MonitoringTestCtx) validatePrometheusNamespaceProxyResourcesCommon(t *
 func (tc *MonitoringTestCtx) ValidatePrometheusRestrictedResourceConfiguration(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, []TestTag{Tier1})
+	skipUnless(t, Tier1)
 
 	dsci := tc.FetchDSCInitialization()
 
@@ -1933,7 +1933,7 @@ func (tc *MonitoringTestCtx) ValidatePrometheusRestrictedResourceConfiguration(t
 func (tc *MonitoringTestCtx) ValidatePrometheusSecureProxyAuthentication(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, []TestTag{Tier1})
+	skipUnless(t, Tier1)
 
 	dsci := tc.FetchDSCInitialization()
 
@@ -2004,7 +2004,7 @@ func (tc *MonitoringTestCtx) ValidatePrometheusSecureProxyAuthentication(t *test
 func (tc *MonitoringTestCtx) ValidateNodeMetricsEndpointDeployment(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, []TestTag{Tier1})
+	skipUnless(t, Tier1)
 
 	dsci := tc.FetchDSCInitialization()
 
@@ -2077,7 +2077,7 @@ func (tc *MonitoringTestCtx) ValidateNodeMetricsEndpointDeployment(t *testing.T)
 func (tc *MonitoringTestCtx) ValidateNodeMetricsEndpointRBACConfiguration(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, []TestTag{Tier1})
+	skipUnless(t, Tier1)
 
 	dsci := tc.FetchDSCInitialization()
 
@@ -2265,7 +2265,7 @@ func (tc *MonitoringTestCtx) validatePersesDatasourceTLSWithCloudBackend(t *test
 func (tc *MonitoringTestCtx) ValidatePersesDatasourceTLSWithS3Backend(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, []TestTag{Tier1})
+	skipUnless(t, Tier1)
 	tc.validatePersesDatasourceTLSWithCloudBackend(t, "s3")
 }
 
@@ -2273,6 +2273,6 @@ func (tc *MonitoringTestCtx) ValidatePersesDatasourceTLSWithS3Backend(t *testing
 func (tc *MonitoringTestCtx) ValidatePersesDatasourceTLSWithGCSBackend(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, []TestTag{Tier1})
+	skipUnless(t, Tier1)
 	tc.validatePersesDatasourceTLSWithCloudBackend(t, "gcs")
 }

--- a/tests/e2e/resilience_test.go
+++ b/tests/e2e/resilience_test.go
@@ -71,7 +71,7 @@ func operatorResilienceTestSuite(t *testing.T) {
 func (tc *OperatorResilienceTestCtx) ValidateOperatorDeployment(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, []TestTag{Tier1})
+	skipUnless(t, Tier1)
 
 	deploymentName := tc.getControllerDeploymentName()
 
@@ -86,7 +86,7 @@ func (tc *OperatorResilienceTestCtx) ValidateOperatorDeployment(t *testing.T) {
 func (tc *OperatorResilienceTestCtx) ValidateLeaderElectionBehavior(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, []TestTag{Tier1})
+	skipUnless(t, Tier1)
 
 	// Find and delete current leader
 	originalLeader := tc.findLeaderPodFromLeases()
@@ -116,7 +116,7 @@ func (tc *OperatorResilienceTestCtx) ValidateLeaderElectionBehavior(t *testing.T
 func (tc *OperatorResilienceTestCtx) ValidateComponentsDeploymentSuccess(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, []TestTag{Tier1})
+	skipUnless(t, Tier1)
 
 	componentName := componentApi.DashboardComponentName
 
@@ -134,7 +134,7 @@ func (tc *OperatorResilienceTestCtx) ValidateComponentsDeploymentSuccess(t *test
 func (tc *OperatorResilienceTestCtx) ValidateComponentsDeploymentFailure(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, []TestTag{Tier1})
+	skipUnless(t, Tier1)
 
 	// To handle upstream/downstream i trimmed prefix(odh) from few controller names
 	componentToControllerMap := map[string]string{
@@ -249,7 +249,7 @@ func (tc *OperatorResilienceTestCtx) ValidateComponentsDeploymentFailure(t *test
 func (tc *OperatorResilienceTestCtx) ValidateMissingComponentsCRDHandling(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, []TestTag{Tier1})
+	skipUnless(t, Tier1)
 
 	crdTestingName := "dashboards.components.platform.opendatahub.io"
 	crd := tc.FetchResource(
@@ -323,7 +323,7 @@ func (tc *OperatorResilienceTestCtx) ValidateMissingComponentsCRDHandling(t *tes
 func (tc *OperatorResilienceTestCtx) ValidateRBACRestrictionHandling(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, []TestTag{Tier1})
+	skipUnless(t, Tier1)
 
 	// Get the predictable ServiceAccount name based on deployment name
 	deploymentName := tc.getControllerDeploymentName()

--- a/tests/e2e/test_tag_test.go
+++ b/tests/e2e/test_tag_test.go
@@ -5,12 +5,28 @@ import "testing"
 type TestTag string
 
 const (
+	All   TestTag = "All"
 	Smoke TestTag = "Smoke"
 	Tier1 TestTag = "Tier1"
 )
 
-func skipUnless(t *testing.T, tags []TestTag) {
-	// TBD
+var allowedTags = []TestTag{All, Smoke, Tier1}
+
+func skipUnless(t *testing.T, tags ...TestTag) {
 	t.Helper()
-	t.Logf("Skipping test unless tags match: %v", tags)
+	// if the 'All' tag is selected, return early to run all tests
+	if TestTag(testOpts.tag) == All {
+		return
+	}
+	skipTest := true
+	for _, tag := range tags {
+		if tag == TestTag(testOpts.tag) {
+			skipTest = false
+			break
+		}
+	}
+
+	if skipTest {
+		t.Skipf("Skipping test: passed tag: %s, test tags: %v", testOpts.tag, tags)
+	}
 }

--- a/tests/e2e/trainer_test.go
+++ b/tests/e2e/trainer_test.go
@@ -72,7 +72,7 @@ func trainerDegradedMonitoringTestSuite(t *testing.T) {
 func (tc *TrainerTestCtx) ValidateExternalOperatorDegradedMonitoring(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, []TestTag{Tier1})
+	skipUnless(t, Tier1)
 
 	testCases := []degradedConditionTestCase{
 		{

--- a/tests/e2e/trustyai_test.go
+++ b/tests/e2e/trustyai_test.go
@@ -82,7 +82,7 @@ func (tc *TrustyAITestCtx) ValidateComponentDisabled(t *testing.T) {
 func (tc *TrustyAITestCtx) ValidateTrustyAIPreCheck(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, []TestTag{Tier1})
+	skipUnless(t, Tier1)
 
 	// Step 1: Disable KServe → TrustyAI should detect missing dependency
 	tc.setKserveState(operatorv1.Removed, false)

--- a/tests/e2e/v2tov3upgrade_test.go
+++ b/tests/e2e/v2tov3upgrade_test.go
@@ -142,7 +142,7 @@ func v2Tov3UpgradeDeletingDscDsciTestSuite(t *testing.T) {
 func (tc *V2Tov3UpgradeTestCtx) ValidateCodeFlareResourcePreservation(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, []TestTag{Tier1})
+	skipUnless(t, Tier1)
 
 	tc.validateComponentResourcePreservation(t, gvk.CodeFlare, defaultCodeFlareComponentName)
 }
@@ -150,7 +150,7 @@ func (tc *V2Tov3UpgradeTestCtx) ValidateCodeFlareResourcePreservation(t *testing
 func (tc *V2Tov3UpgradeTestCtx) ValidateModelMeshServingResourcePreservation(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, []TestTag{Tier1})
+	skipUnless(t, Tier1)
 
 	tc.validateComponentResourcePreservation(t, gvk.ModelMeshServing, defaultModelMeshServingComponentName)
 }
@@ -158,7 +158,7 @@ func (tc *V2Tov3UpgradeTestCtx) ValidateModelMeshServingResourcePreservation(t *
 func (tc *V2Tov3UpgradeTestCtx) DatascienceclusterV1CreationAndRead(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, []TestTag{Tier1})
+	skipUnless(t, Tier1)
 
 	// Clean up any existing DataScienceCluster and DSCInitialization resources before starting
 	cleanupCoreOperatorResources(t, tc.TestContext)
@@ -223,7 +223,7 @@ func (tc *V2Tov3UpgradeTestCtx) DatascienceclusterV1CreationAndRead(t *testing.T
 func (tc *V2Tov3UpgradeTestCtx) DscinitializationV1CreationAndRead(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, []TestTag{Tier1})
+	skipUnless(t, Tier1)
 
 	// Clean up any existing DataScienceCluster and DSCInitialization resources before starting
 	cleanupCoreOperatorResources(t, tc.TestContext)
@@ -294,7 +294,7 @@ func (tc *V2Tov3UpgradeTestCtx) DscinitializationV1CreationAndRead(t *testing.T)
 func (tc *V2Tov3UpgradeTestCtx) HardwareProfileV1Alpha1ToV1VersionUpgrade(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, []TestTag{Tier1})
+	skipUnless(t, Tier1)
 
 	hardwareProfileName := "test-hardware-profile-v1alpha1-to-v1"
 
@@ -351,7 +351,7 @@ func (tc *V2Tov3UpgradeTestCtx) HardwareProfileV1Alpha1ToV1VersionUpgrade(t *tes
 func (tc *V2Tov3UpgradeTestCtx) HardwareProfileV1ToV1Alpha1VersionConversion(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, []TestTag{Tier1})
+	skipUnless(t, Tier1)
 
 	hardwareProfileName := "test-hardware-profile-v1-to-v1alpha1"
 
@@ -426,7 +426,7 @@ func (tc *V2Tov3UpgradeTestCtx) validateComponentResourcePreservation(t *testing
 func (tc *V2Tov3UpgradeTestCtx) ValidateRayRaiseErrorIfCodeFlarePresent(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, []TestTag{Tier1})
+	skipUnless(t, Tier1)
 
 	dsc := tc.FetchDataScienceCluster()
 	existingComponent := tc.operatorManagedComponent(gvk.CodeFlare, defaultCodeFlareComponentName, dsc)
@@ -531,7 +531,7 @@ func (tc *V2Tov3UpgradeTestCtx) updateComponentStateInDataScienceCluster(t *test
 func (tc *V2Tov3UpgradeTestCtx) ValidateDeniesKueueManaged(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, []TestTag{Tier1})
+	skipUnless(t, Tier1)
 
 	// Clean up any existing DataScienceCluster resources before starting
 	cleanupCoreOperatorResources(t, tc.TestContext)
@@ -667,7 +667,7 @@ func (tc *V2Tov3UpgradeTestCtx) ValidateDeniesKueueManagedUpdate(t *testing.T) {
 func (tc *V2Tov3UpgradeTestCtx) ValidateAllowsKueueUnmanaged(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, []TestTag{Tier1})
+	skipUnless(t, Tier1)
 
 	// Clean up any existing DataScienceCluster resources before starting
 	cleanupCoreOperatorResources(t, tc.TestContext)
@@ -735,7 +735,7 @@ func (tc *V2Tov3UpgradeTestCtx) ValidateAllowsKueueUnmanaged(t *testing.T) {
 func (tc *V2Tov3UpgradeTestCtx) ValidateAllowsKueueRemoved(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, []TestTag{Tier1})
+	skipUnless(t, Tier1)
 
 	// Clean up any existing DataScienceCluster resources before starting
 	cleanupCoreOperatorResources(t, tc.TestContext)
@@ -803,7 +803,7 @@ func (tc *V2Tov3UpgradeTestCtx) ValidateAllowsKueueRemoved(t *testing.T) {
 func (tc *V2Tov3UpgradeTestCtx) ValidateAllowsWithoutKueue(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, []TestTag{Tier1})
+	skipUnless(t, Tier1)
 
 	// Clean up any existing DataScienceCluster resources before starting
 	cleanupCoreOperatorResources(t, tc.TestContext)
@@ -869,7 +869,7 @@ func (tc *V2Tov3UpgradeTestCtx) createCRD(crdsToCreate []CRDToCreate) {
 func (tc *V2Tov3UpgradeTestCtx) ValidateServiceMeshResourcePreservation(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, []TestTag{Tier1})
+	skipUnless(t, Tier1)
 
 	nn := types.NamespacedName{
 		Name: defaultServiceMeshName,
@@ -944,7 +944,7 @@ func (tc *V2Tov3UpgradeTestCtx) triggerDSCIReconciliation(t *testing.T) {
 func (tc *V2Tov3UpgradeTestCtx) ValidateArgoWorkflowsControllersDatasciencepipelinesDSCV1(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, []TestTag{Tier1})
+	skipUnless(t, Tier1)
 
 	// Clean up any existing DataScienceCluster resources before starting
 	cleanupCoreOperatorResources(t, tc.TestContext)
@@ -1008,7 +1008,7 @@ func (tc *V2Tov3UpgradeTestCtx) ValidateArgoWorkflowsControllersDatasciencepipel
 func (tc *V2Tov3UpgradeTestCtx) ValidateV2OnlyComponentsResetWhenPatchingViaV1API(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, []TestTag{Tier1})
+	skipUnless(t, Tier1)
 
 	// Clean up any existing DataScienceCluster resources before starting
 	cleanupCoreOperatorResources(t, tc.TestContext)

--- a/tests/e2e/workbenches_test.go
+++ b/tests/e2e/workbenches_test.go
@@ -46,7 +46,7 @@ func workbenchesTestSuite(t *testing.T) {
 func (tc *WorkbenchesTestCtx) ValidateWorkbenchesNamespaceConfiguration(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, []TestTag{Tier1})
+	skipUnless(t, Tier1)
 
 	// ensure the workbenches namespace exists and has the expected label
 	tc.EnsureResourceExists(


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

<!--- Link your JIRA and related links here for reference. -->
https://issues.redhat.com/browse/RHOAIENG-49901

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [ ] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * E2E tests can be filtered by tag (All, Smoke, Tier1) via a new --tag flag or E2E_TEST_TAG env var; "All" runs all tests and other tags enable selective execution.
  * Test harness respects the selected tag and skips tests that don't match.

* **Documentation**
  * E2E docs and flags/env var table updated with tag filtering options and defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->