### PR TITLE
Implement observability manifest deployment to dashboard resources (#3177)

### DIFF
--- a/internal/controller/components/dashboard/dashboard_controller.go
+++ b/internal/controller/components/dashboard/dashboard_controller.go
@@ -24,6 +24,7 @@ import (
 	routev1 "github.com/openshift/api/route/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -67,6 +68,8 @@ func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.
 		Owns(&routev1.Route{}).
 		Owns(&gwapiv1.HTTPRoute{}).
 		Owns(&consolev1.ConsoleLink{}).
+		// NetworkPolicy for cross-namespace communication (e.g., dashboard to perses)
+		Owns(&networkingv1.NetworkPolicy{}).
 		// Those APIs are provided by the component itself hence they should
 		// be watched dynamically
 		OwnsGVK(gvk.DashboardAcceleratorProfile, reconciler.Dynamic(reconciler.CrdExists(gvk.DashboardAcceleratorProfile))).

--- a/internal/controller/components/dashboard/dashboard_controller_actions_test.go
+++ b/internal/controller/components/dashboard/dashboard_controller_actions_test.go
@@ -12,7 +12,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/opendatahub-io/opendatahub-operator/v2/api/common"
+	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/api/components/v1alpha1"
+	dsciv2 "github.com/opendatahub-io/opendatahub-operator/v2/api/dscinitialization/v2"
 	infrav1 "github.com/opendatahub-io/opendatahub-operator/v2/api/infrastructure/v1"
+	serviceApi "github.com/opendatahub-io/opendatahub-operator/v2/api/services/v1alpha1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
@@ -151,13 +154,100 @@ func TestCreateInfraHardwareProfile(t *testing.T) {
 }
 
 func TestDeployObservabilityManifests_WithPersesCRD(t *testing.T) {
+	tests := []struct {
+		name     string
+		platform common.Platform
+	}{
+		{
+			name:     "RHOAI platform attempts deployment when CRD exists",
+			platform: cluster.SelfManagedRhoai,
+		},
+		{
+			name:     "ODH platform attempts deployment when CRD exists",
+			platform: cluster.OpenDataHub,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := t.Context()
+			g := NewWithT(t)
+
+			fakeSchema, err := scheme.New()
+			g.Expect(err).ShouldNot(HaveOccurred())
+
+			// Register PersesDashboard GVK with the schema so the REST mapper knows about it
+			persesDashboardListGVK := schema.GroupVersionKind{
+				Group:   "perses.dev",
+				Version: "v1alpha1",
+				Kind:    "PersesDashboardList",
+			}
+			fakeSchema.AddKnownTypeWithName(gvk.PersesDashboard, &unstructured.Unstructured{})
+			fakeSchema.AddKnownTypeWithName(persesDashboardListGVK, &unstructured.UnstructuredList{})
+
+			// Create a CRD for PersesDashboard to make HasCRD check pass
+			persesDashboardCRD := &apiextensionsv1.CustomResourceDefinition{
+				ObjectMeta: v1.ObjectMeta{
+					Name: "persesdashboards.perses.dev",
+				},
+				Status: apiextensionsv1.CustomResourceDefinitionStatus{
+					StoredVersions: []string{"v1alpha1"},
+				},
+			}
+
+			cli, err := fakeclient.New(
+				fakeclient.WithObjects(persesDashboardCRD),
+				fakeclient.WithScheme(fakeSchema),
+			)
+			g.Expect(err).ShouldNot(HaveOccurred())
+
+			rr := &types.ReconciliationRequest{
+				Client:    cli,
+				Instance:  &componentApi.Dashboard{},
+				Release:   common.Release{Name: tt.platform},
+				Manifests: []types.ManifestInfo{},
+			}
+
+			// This test verifies the function attempts to deploy when CRD exists.
+			// In test environment, DeployManifestsFromPath will fail because manifest files don't exist.
+			// This is expected - the important thing is that the function reaches the deploy call.
+			err = deployObservabilityManifests(ctx, rr)
+			g.Expect(err).Should(HaveOccurred())
+			g.Expect(err.Error()).Should(ContainSubstring("failed to deploy observability manifests"))
+		})
+	}
+}
+
+func TestDeployObservabilityManifests_WithoutPersesCRD(t *testing.T) {
 	ctx := t.Context()
 	g := NewWithT(t)
 
 	fakeSchema, err := scheme.New()
 	g.Expect(err).ShouldNot(HaveOccurred())
 
-	// Register PersesDashboard GVK with the schema so the REST mapper knows about it
+	cli, err := fakeclient.New(
+		fakeclient.WithScheme(fakeSchema),
+	)
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	rr := &types.ReconciliationRequest{
+		Client:  cli,
+		Release: common.Release{Name: cluster.SelfManagedRhoai},
+	}
+
+	// When PersesDashboard CRD doesn't exist, function should return early without error
+	err = deployObservabilityManifests(ctx, rr)
+	g.Expect(err).ShouldNot(HaveOccurred())
+}
+
+func TestDeployObservabilityManifests_SkippedForEmptyMonitoringNamespace(t *testing.T) {
+	ctx := t.Context()
+	g := NewWithT(t)
+
+	fakeSchema, err := scheme.New()
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	// Register PersesDashboard GVK with the schema
 	persesDashboardListGVK := schema.GroupVersionKind{
 		Group:   "perses.dev",
 		Version: "v1alpha1",
@@ -176,56 +266,32 @@ func TestDeployObservabilityManifests_WithPersesCRD(t *testing.T) {
 		},
 	}
 
+	// Create a DSCI with empty monitoring namespace
+	dsci := &dsciv2.DSCInitialization{
+		ObjectMeta: v1.ObjectMeta{
+			Name: "default-dsci",
+		},
+		Spec: dsciv2.DSCInitializationSpec{
+			Monitoring: serviceApi.DSCIMonitoring{
+				MonitoringCommonSpec: serviceApi.MonitoringCommonSpec{
+					Namespace: "", // Empty monitoring namespace
+				},
+			},
+		},
+	}
+
 	cli, err := fakeclient.New(
-		fakeclient.WithObjects(persesDashboardCRD),
+		fakeclient.WithObjects(persesDashboardCRD, dsci),
 		fakeclient.WithScheme(fakeSchema),
 	)
 	g.Expect(err).ShouldNot(HaveOccurred())
 
 	rr := &types.ReconciliationRequest{
-		Client:    cli,
-		Manifests: []types.ManifestInfo{},
+		Client:  cli,
+		Release: common.Release{Name: cluster.SelfManagedRhoai},
 	}
 
+	// When monitoring namespace is empty, function should return early without error
 	err = deployObservabilityManifests(ctx, rr)
 	g.Expect(err).ShouldNot(HaveOccurred())
-	g.Expect(rr.Manifests).Should(HaveLen(1))
-	g.Expect(rr.Manifests[0].SourcePath).Should(Equal("observability"))
-}
-
-func TestDeployObservabilityManifests_WithoutPersesCRD(t *testing.T) {
-	ctx := t.Context()
-	g := NewWithT(t)
-
-	fakeSchema, err := scheme.New()
-	g.Expect(err).ShouldNot(HaveOccurred())
-
-	cli, err := fakeclient.New(
-		fakeclient.WithScheme(fakeSchema),
-	)
-	g.Expect(err).ShouldNot(HaveOccurred())
-
-	rr := &types.ReconciliationRequest{
-		Client:    cli,
-		Manifests: []types.ManifestInfo{},
-	}
-
-	err = deployObservabilityManifests(ctx, rr)
-	g.Expect(err).ShouldNot(HaveOccurred())
-	g.Expect(rr.Manifests).Should(BeEmpty())
-}
-
-func TestDeployObservabilityManifests_SkippedForODH(t *testing.T) {
-	ctx := t.Context()
-	g := NewWithT(t)
-
-	// Minimal setup - should skip before any CRD check
-	rr := &types.ReconciliationRequest{
-		Release:   common.Release{Name: cluster.OpenDataHub},
-		Manifests: []types.ManifestInfo{},
-	}
-
-	err := deployObservabilityManifests(ctx, rr)
-	g.Expect(err).ShouldNot(HaveOccurred())
-	g.Expect(rr.Manifests).Should(BeEmpty())
 }

--- a/internal/controller/components/dashboard/dashboard_support.go
+++ b/internal/controller/components/dashboard/dashboard_support.go
@@ -38,6 +38,12 @@ var (
 		cluster.OpenDataHub:      "/odh",
 	}
 
+	observabilitySourcePaths = map[common.Platform]string{
+		cluster.SelfManagedRhoai: "observability/rhoai",
+		cluster.ManagedRhoai:     "observability/rhoai",
+		cluster.OpenDataHub:      "observability/odh",
+	}
+
 	imagesMap = map[string]string{
 		"odh-dashboard-image":     "RELATED_IMAGE_ODH_DASHBOARD_IMAGE",
 		"model-registry-ui-image": "RELATED_IMAGE_ODH_MOD_ARCH_MODEL_REGISTRY_IMAGE",
@@ -67,11 +73,11 @@ func bffManifestsPath() odhtypes.ManifestInfo {
 	}
 }
 
-func observabilityManifestInfo() odhtypes.ManifestInfo {
+func observabilityManifestInfo(platform common.Platform) odhtypes.ManifestInfo {
 	return odhtypes.ManifestInfo{
 		Path:       odhdeploy.DefaultManifestPath,
 		ContextDir: ComponentName,
-		SourcePath: "observability",
+		SourcePath: observabilitySourcePaths[platform],
 	}
 }
 


### PR DESCRIPTION
Implement observability manifest deployment to dashboard resources (#3177)

* Implement observability manifest deployment to monitoring namespace and update tests

* Add safety check for empty monitoring namespace in deployObservabilityManifests function and corresponding test

* Refactor deployObservabilityManifests to support platform-specific observability manifest paths and update related tests

* fix: add Instance to test ReconciliationRequest for robustness

Addresses CodeRabbit suggestion to ensure test is more robust by providing a valid Dashboard instance in the ReconciliationRequest.

<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->
Cherry pick of #3177 for 3.4 e.a.1, I thought it was already tracked by the auto-merger.

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [X] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->
