### PR TITLE
RHOAIENG-49704: Implement configuration to suppress management of platform components

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -19,7 +19,9 @@ package main
 import (
 	"context"
 	"fmt"
+	"maps"
 	"os"
+	"slices"
 	"strings"
 
 	ocappsv1 "github.com/openshift/api/apps/v1" //nolint:importas //reason: conflicts with appsv1 "k8s.io/api/apps/v1"
@@ -72,10 +74,31 @@ import (
 	infrav1 "github.com/opendatahub-io/opendatahub-operator/v2/api/infrastructure/v1"
 	infrav1alpha1 "github.com/opendatahub-io/opendatahub-operator/v2/api/infrastructure/v1alpha1"
 	serviceApi "github.com/opendatahub-io/opendatahub-operator/v2/api/services/v1alpha1"
+	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/components/dashboard"
+	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/components/datasciencepipelines"
+	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/components/feastoperator"
+	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/components/kserve"
+	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/components/kueue"
+	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/components/llamastackoperator"
+	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/components/mlflowoperator"
+	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/components/modelcontroller"
+	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/components/modelregistry"
+	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/components/modelsasservice"
+	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/components/ray"
 	cr "github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/components/registry"
+	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/components/sparkoperator"
+	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/components/trainer"
+	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/components/trainingoperator"
+	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/components/trustyai"
+	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/components/workbenches"
 	dscctrl "github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/datasciencecluster"
 	dscictrl "github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/dscinitialization"
+	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/services/auth"
+	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/services/certconfigmapgenerator"
+	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/services/gateway"
+	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/services/monitoring"
 	sr "github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/services/registry"
+	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/services/setup"
 	"github.com/opendatahub-io/opendatahub-operator/v2/internal/webhook"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
@@ -85,33 +108,38 @@ import (
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/resources"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/upgrade"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/flags"
-
-	_ "github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/components/dashboard"
-	_ "github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/components/datasciencepipelines"
-	_ "github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/components/feastoperator"
-	_ "github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/components/kserve"
-	_ "github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/components/kueue"
-	_ "github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/components/llamastackoperator"
-	_ "github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/components/mlflowoperator"
-	_ "github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/components/modelcontroller"
-	_ "github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/components/modelregistry"
-	_ "github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/components/modelsasservice"
-	_ "github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/components/ray"
-	_ "github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/components/sparkoperator"
-	_ "github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/components/trainer"
-	_ "github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/components/trainingoperator"
-	_ "github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/components/trustyai"
-	_ "github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/components/workbenches"
-	_ "github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/services/auth"
-	_ "github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/services/certconfigmapgenerator"
-	_ "github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/services/gateway"
-	_ "github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/services/monitoring"
-	_ "github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/services/setup"
 )
 
 var (
 	scheme   = runtime.NewScheme()
 	setupLog = ctrl.Log.WithName("setup")
+
+	existingComponents = map[string]cr.ComponentHandler{
+		componentApi.DashboardComponentName:            dashboard.NewHandler(),
+		componentApi.DataSciencePipelinesComponentName: datasciencepipelines.NewHandler(),
+		componentApi.FeastOperatorComponentName:        feastoperator.NewHandler(),
+		componentApi.KserveComponentName:               kserve.NewHandler(),
+		componentApi.KueueComponentName:                kueue.NewHandler(),
+		componentApi.LlamaStackOperatorComponentName:   llamastackoperator.NewHandler(),
+		componentApi.MLflowOperatorComponentName:       mlflowoperator.NewHandler(),
+		componentApi.ModelControllerComponentName:      modelcontroller.NewHandler(),
+		componentApi.ModelRegistryComponentName:        modelregistry.NewHandler(),
+		componentApi.ModelsAsServiceComponentName:      modelsasservice.NewHandler(),
+		componentApi.RayComponentName:                  ray.NewHandler(),
+		componentApi.SparkOperatorComponentName:        sparkoperator.NewHandler(),
+		componentApi.TrainerComponentName:              trainer.NewHandler(),
+		componentApi.TrainingOperatorComponentName:     trainingoperator.NewHandler(),
+		componentApi.TrustyAIComponentName:             trustyai.NewHandler(),
+		componentApi.WorkbenchesComponentName:          workbenches.NewHandler(),
+	}
+
+	existingServices = map[string]sr.ServiceHandler{
+		serviceApi.AuthServiceName:         auth.NewHandler(),
+		certconfigmapgenerator.ServiceName: certconfigmapgenerator.NewHandler(),
+		serviceApi.GatewayServiceName:      gateway.NewHandler(),
+		serviceApi.MonitoringServiceName:   monitoring.NewHandler(),
+		setup.ServiceName:                  setup.NewHandler(),
+	}
 )
 
 func init() { //nolint:gochecknoinits
@@ -185,6 +213,24 @@ func LoadConfig() (*OperatorConfig, error) {
 	return &operatorConfig, nil
 }
 
+func registerComponents() {
+	for name, handler := range existingComponents {
+		cr.Add(handler)
+		if !flags.IsComponentEnabled(name) {
+			cr.Disable(name)
+		}
+	}
+}
+
+func registerServices() {
+	for name, handler := range existingServices {
+		sr.Add(handler)
+		if !flags.IsServiceEnabled(name) {
+			sr.Disable(name)
+		}
+	}
+}
+
 func main() { //nolint:funlen,maintidx,gocyclo
 	// Viper settings
 	viper.SetEnvPrefix("ODH_MANAGER")
@@ -197,12 +243,26 @@ func main() { //nolint:funlen,maintidx,gocyclo
 		os.Exit(1)
 	}
 
+	// Register component/service suppression flags (before pflag.Parse)
+	if err := flags.RegisterComponentSuppressionFlags(slices.Collect(maps.Keys(existingComponents))); err != nil {
+		fmt.Printf("Error registering component suppression flags: %s", err.Error())
+		os.Exit(1)
+	}
+	if err := flags.RegisterServiceSuppressionFlags(slices.Collect(maps.Keys(existingServices))); err != nil {
+		fmt.Printf("Error registering service suppression flags: %s", err.Error())
+		os.Exit(1)
+	}
+
 	// parse and bind flags
 	pflag.Parse()
 	if err := viper.BindPFlags(pflag.CommandLine); err != nil {
 		fmt.Printf("Error in binding flags: %s", err.Error())
 		os.Exit(1)
 	}
+
+	// Register handlers and apply suppression flags disabling the corresponding component/service
+	registerComponents()
+	registerServices()
 
 	oconfig, err := LoadConfig()
 	if err != nil {
@@ -276,8 +336,8 @@ func main() { //nolint:funlen,maintidx,gocyclo
 	cacheOptions := cache.Options{
 		Scheme: scheme,
 		ByObject: map[client.Object]cache.ByObject{
-			// Cannot find a label on various screts, so we need to watch all secrets
-			// this include, monitoring, dashboard, trustcabundle default cert etc for these NS
+			// Cannot find a label on various secrets, so we need to watch all secrets
+			// this includes, monitoring, dashboard, trustcabundle default cert etc for these NS
 			&corev1.Secret{}: {
 				Namespaces: secretCache,
 			},
@@ -380,18 +440,26 @@ func main() { //nolint:funlen,maintidx,gocyclo
 		os.Exit(1)
 	}
 
-	if err = (&dscictrl.DSCInitializationReconciler{
-		Client:   mgr.GetClient(),
-		Scheme:   mgr.GetScheme(),
-		Recorder: mgr.GetEventRecorderFor("dscinitialization-controller"),
-	}).SetupWithManager(ctx, mgr); err != nil {
-		setupLog.Error(err, "unable to create controller", "controller", "DSCInitiatlization")
-		os.Exit(1)
+	if flags.IsDSCIEnabled() {
+		if err = (&dscictrl.DSCInitializationReconciler{
+			Client:   mgr.GetClient(),
+			Scheme:   mgr.GetScheme(),
+			Recorder: mgr.GetEventRecorderFor("dscinitialization-controller"),
+		}).SetupWithManager(ctx, mgr); err != nil {
+			setupLog.Error(err, "unable to create controller", "controller", "DSCInitiatlization")
+			os.Exit(1)
+		}
+	} else {
+		setupLog.Info("DSCI controller is suppressed")
 	}
 
-	if err = dscctrl.NewDataScienceClusterReconciler(ctx, mgr); err != nil {
-		setupLog.Error(err, "unable to create controller", "controller", "DataScienceCluster")
-		os.Exit(1)
+	if flags.IsDSCEnabled() {
+		if err = dscctrl.NewDataScienceClusterReconciler(ctx, mgr); err != nil {
+			setupLog.Error(err, "unable to create controller", "controller", "DataScienceCluster")
+			os.Exit(1)
+		}
+	} else {
+		setupLog.Info("DSC controller is suppressed")
 	}
 
 	// Initialize service reconcilers
@@ -408,9 +476,12 @@ func main() { //nolint:funlen,maintidx,gocyclo
 
 	// Check if user opted for disabling DSC configuration
 	disableDSCConfig, existDSCConfig := os.LookupEnv("DISABLE_DSC_CONFIG")
-	if existDSCConfig && disableDSCConfig != "false" {
+	switch {
+	case !flags.IsDSCIEnabled():
+		setupLog.Info("DSCI is disabled")
+	case existDSCConfig && disableDSCConfig != "false":
 		setupLog.Info("DSCI auto creation is disabled")
-	} else {
+	default:
 		createDefaultDSCIFunc := LeaderElectionRunnableFunc(func(ctx context.Context) error {
 			setupLog.Info("create default DSCI")
 			err := initialinstall.CreateDefaultDSCI(ctx, setupClient, platform, oconfig.MonitoringNamespace)
@@ -428,7 +499,7 @@ func main() { //nolint:funlen,maintidx,gocyclo
 	}
 
 	// Create default DSC CR for managed RHOAI
-	if platform == cluster.ManagedRhoai {
+	if platform == cluster.ManagedRhoai && flags.IsDSCEnabled() {
 		createDefaultDSCFunc := LeaderElectionRunnableFunc(func(ctx context.Context) error {
 			setupLog.Info("create default DSC")
 			err := initialinstall.CreateDefaultDSC(ctx, setupClient)

--- a/internal/controller/components/dashboard/dashboard.go
+++ b/internal/controller/components/dashboard/dashboard.go
@@ -14,7 +14,6 @@ import (
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/api/components/v1alpha1"
 	dscv2 "github.com/opendatahub-io/opendatahub-operator/v2/api/datasciencecluster/v2"
 	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/components"
-	cr "github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/components/registry"
 	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/status"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/conditions"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
@@ -25,9 +24,7 @@ import (
 
 type componentHandler struct{}
 
-func init() { //nolint:gochecknoinits
-	cr.Add(&componentHandler{})
-}
+func NewHandler() *componentHandler { return &componentHandler{} }
 
 func (s *componentHandler) GetName() string {
 	return componentApi.DashboardComponentName

--- a/internal/controller/components/dashboard/dashboard_controller_actions.go
+++ b/internal/controller/components/dashboard/dashboard_controller_actions.go
@@ -53,7 +53,7 @@ type DashboardHardwareProfileList struct {
 	Items []DashboardHardwareProfile `json:"items"`
 }
 
-func initialize(ctx context.Context, rr *odhtypes.ReconciliationRequest) error {
+func initialize(_ context.Context, rr *odhtypes.ReconciliationRequest) error { //nolint:unparam
 	rr.Manifests = []odhtypes.ManifestInfo{defaultManifestInfo(rr.Release.Name)}
 
 	return nil

--- a/internal/controller/components/datasciencepipelines/datasciencepipelines.go
+++ b/internal/controller/components/datasciencepipelines/datasciencepipelines.go
@@ -15,7 +15,6 @@ import (
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/api/components/v1alpha1"
 	dscv2 "github.com/opendatahub-io/opendatahub-operator/v2/api/datasciencecluster/v2"
 	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/components"
-	cr "github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/components/registry"
 	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/status"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/conditions"
@@ -26,9 +25,7 @@ import (
 
 type componentHandler struct{}
 
-func init() { //nolint:gochecknoinits
-	cr.Add(&componentHandler{})
-}
+func NewHandler() *componentHandler { return &componentHandler{} }
 
 func (s *componentHandler) GetName() string {
 	return componentApi.DataSciencePipelinesComponentName

--- a/internal/controller/components/datasciencepipelines/datasciencepipelines_controller_actions.go
+++ b/internal/controller/components/datasciencepipelines/datasciencepipelines_controller_actions.go
@@ -100,13 +100,13 @@ func checkPreConditions(ctx context.Context, rr *odhtypes.ReconciliationRequest)
 	return nil
 }
 
-func initialize(_ context.Context, rr *odhtypes.ReconciliationRequest) error {
+func initialize(_ context.Context, rr *odhtypes.ReconciliationRequest) error { //nolint:unparam
 	rr.Manifests = append(rr.Manifests, manifestPath(rr.Release.Name))
 
 	return nil
 }
 
-func argoWorkflowsControllersOptions(ctx context.Context, rr *odhtypes.ReconciliationRequest) error {
+func argoWorkflowsControllersOptions(_ context.Context, rr *odhtypes.ReconciliationRequest) error {
 	dsp, ok := rr.Instance.(*componentApi.DataSciencePipelines)
 	if !ok {
 		return fmt.Errorf("resource instance %v is not a componentApi.DataSciencePipelines)", rr.Instance)

--- a/internal/controller/components/feastoperator/feastoperator.go
+++ b/internal/controller/components/feastoperator/feastoperator.go
@@ -14,7 +14,6 @@ import (
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/api/components/v1alpha1"
 	dscv2 "github.com/opendatahub-io/opendatahub-operator/v2/api/datasciencecluster/v2"
 	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/components"
-	cr "github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/components/registry"
 	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/status"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/conditions"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
@@ -24,9 +23,7 @@ import (
 
 type componentHandler struct{}
 
-func init() { //nolint:gochecknoinits
-	cr.Add(&componentHandler{})
-}
+func NewHandler() *componentHandler { return &componentHandler{} }
 
 func (s *componentHandler) GetName() string {
 	return componentApi.FeastOperatorComponentName

--- a/internal/controller/components/feastoperator/feastoperator_controller_actions.go
+++ b/internal/controller/components/feastoperator/feastoperator_controller_actions.go
@@ -6,7 +6,7 @@ import (
 	odhtypes "github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
 )
 
-func initialize(ctx context.Context, rr *odhtypes.ReconciliationRequest) error {
+func initialize(_ context.Context, rr *odhtypes.ReconciliationRequest) error { //nolint:unparam
 	rr.Manifests = append(rr.Manifests, manifestPath(rr.Release.Name))
 	return nil
 }

--- a/internal/controller/components/kserve/kserve.go
+++ b/internal/controller/components/kserve/kserve.go
@@ -14,7 +14,6 @@ import (
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/api/components/v1alpha1"
 	dscv2 "github.com/opendatahub-io/opendatahub-operator/v2/api/datasciencecluster/v2"
 	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/components"
-	cr "github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/components/registry"
 	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/status"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/conditions"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
@@ -49,9 +48,7 @@ var (
 
 type componentHandler struct{}
 
-func init() { //nolint:gochecknoinits
-	cr.Add(&componentHandler{})
-}
+func NewHandler() *componentHandler { return &componentHandler{} }
 
 // Init to set oauth image.
 func (s *componentHandler) Init(platform common.Platform) error {

--- a/internal/controller/components/kserve/kserve_controller_actions.go
+++ b/internal/controller/components/kserve/kserve_controller_actions.go
@@ -31,7 +31,7 @@ const (
 	LLMInferenceServiceConfigWellKnownAnnotationValue = "true"
 )
 
-func initialize(_ context.Context, rr *odhtypes.ReconciliationRequest) error {
+func initialize(_ context.Context, rr *odhtypes.ReconciliationRequest) error { //nolint:unparam
 	rr.Manifests = []odhtypes.ManifestInfo{
 		kserveManifestInfo(kserveManifestSourcePath),
 		{
@@ -85,7 +85,7 @@ func cleanUpTemplatedResources(ctx context.Context, rr *odhtypes.ReconciliationR
 	return nil
 }
 
-func customizeKserveConfigMap(ctx context.Context, rr *odhtypes.ReconciliationRequest) error {
+func customizeKserveConfigMap(_ context.Context, rr *odhtypes.ReconciliationRequest) error {
 	k, ok := rr.Instance.(*componentApi.Kserve)
 	if !ok {
 		return fmt.Errorf("resource instance %v is not a componentApi.Kserve", rr.Instance)

--- a/internal/controller/components/kueue/kueue.go
+++ b/internal/controller/components/kueue/kueue.go
@@ -13,7 +13,6 @@ import (
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/api/components/v1alpha1"
 	dscv2 "github.com/opendatahub-io/opendatahub-operator/v2/api/datasciencecluster/v2"
 	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/components"
-	cr "github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/components/registry"
 	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/status"
 	odherrors "github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/errors"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/conditions"
@@ -34,9 +33,7 @@ var (
 
 type componentHandler struct{}
 
-func init() { //nolint:gochecknoinits
-	cr.Add(&componentHandler{})
-}
+func NewHandler() *componentHandler { return &componentHandler{} }
 
 func (s *componentHandler) GetName() string {
 	return componentApi.KueueComponentName

--- a/internal/controller/components/llamastackoperator/llamastackoperator.go
+++ b/internal/controller/components/llamastackoperator/llamastackoperator.go
@@ -14,7 +14,6 @@ import (
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/api/components/v1alpha1"
 	dscv2 "github.com/opendatahub-io/opendatahub-operator/v2/api/datasciencecluster/v2"
 	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/components"
-	cr "github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/components/registry"
 	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/status"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/conditions"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
@@ -24,9 +23,7 @@ import (
 
 type componentHandler struct{}
 
-func init() { //nolint:gochecknoinits
-	cr.Add(&componentHandler{})
-}
+func NewHandler() *componentHandler { return &componentHandler{} }
 
 func (s *componentHandler) GetName() string {
 	return componentApi.LlamaStackOperatorComponentName

--- a/internal/controller/components/llamastackoperator/llamastackoperator_actions.go
+++ b/internal/controller/components/llamastackoperator/llamastackoperator_actions.go
@@ -6,7 +6,7 @@ import (
 	odhtypes "github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
 )
 
-func initialize(ctx context.Context, rr *odhtypes.ReconciliationRequest) error {
+func initialize(_ context.Context, rr *odhtypes.ReconciliationRequest) error { //nolint:unparam
 	rr.Manifests = append(rr.Manifests, manifestPath(rr.Release.Name))
 	return nil
 }

--- a/internal/controller/components/mlflowoperator/mlflowoperator.go
+++ b/internal/controller/components/mlflowoperator/mlflowoperator.go
@@ -14,7 +14,6 @@ import (
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/api/components/v1alpha1"
 	dscv2 "github.com/opendatahub-io/opendatahub-operator/v2/api/datasciencecluster/v2"
 	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/components"
-	cr "github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/components/registry"
 	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/status"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/conditions"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
@@ -24,9 +23,7 @@ import (
 
 type componentHandler struct{}
 
-func init() { //nolint:gochecknoinits
-	cr.Add(&componentHandler{})
-}
+func NewHandler() *componentHandler { return &componentHandler{} }
 
 func (s *componentHandler) GetName() string {
 	return componentApi.MLflowOperatorComponentName

--- a/internal/controller/components/mlflowoperator/mlflowoperator_controller_actions.go
+++ b/internal/controller/components/mlflowoperator/mlflowoperator_controller_actions.go
@@ -25,7 +25,7 @@ import (
 	odhdeploy "github.com/opendatahub-io/opendatahub-operator/v2/pkg/deploy"
 )
 
-func initialize(ctx context.Context, rr *odhtypes.ReconciliationRequest) error {
+func initialize(_ context.Context, rr *odhtypes.ReconciliationRequest) error { //nolint:unparam
 	rr.Manifests = append(rr.Manifests, manifestPath(rr.Release.Name))
 	return nil
 }

--- a/internal/controller/components/modelcontroller/modelcontroller.go
+++ b/internal/controller/components/modelcontroller/modelcontroller.go
@@ -23,9 +23,7 @@ import (
 
 type componentHandler struct{}
 
-func init() { //nolint:gochecknoinits
-	cr.Add(&componentHandler{})
-}
+func NewHandler() *componentHandler { return &componentHandler{} }
 
 func (s *componentHandler) GetName() string {
 	return componentApi.ModelControllerComponentName

--- a/internal/controller/components/modelcontroller/modelcontroller_test.go
+++ b/internal/controller/components/modelcontroller/modelcontroller_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/opendatahub-io/opendatahub-operator/v2/api/common"
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/api/components/v1alpha1"
 	dscv2 "github.com/opendatahub-io/opendatahub-operator/v2/api/datasciencecluster/v2"
+	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/components/kserve"
+	cr "github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/components/registry"
 	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/status"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/conditions"
@@ -21,13 +23,17 @@ import (
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/fakeclient"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/matchers/jq"
 
-	// side import for component registry.
-	_ "github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/components/kserve"
-
 	. "github.com/onsi/gomega"
 )
 
+func setupTest(_ testing.TB) {
+	// This is needed because modelcontroller is enabled only if kserv is enabled,
+	// and for that at least kserve must be present in the components registry.
+	cr.Add(kserve.NewHandler())
+}
+
 func TestGetName(t *testing.T) {
+	setupTest(t)
 	g := NewWithT(t)
 	handler := &componentHandler{}
 
@@ -36,6 +42,7 @@ func TestGetName(t *testing.T) {
 }
 
 func TestNewCRObject(t *testing.T) {
+	setupTest(t)
 	handler := &componentHandler{}
 
 	tests := []struct {
@@ -95,6 +102,7 @@ func TestNewCRObject(t *testing.T) {
 }
 
 func TestIsEnabled(t *testing.T) {
+	setupTest(t)
 	handler := &componentHandler{}
 
 	tests := []struct {
@@ -134,6 +142,7 @@ func TestIsEnabled(t *testing.T) {
 }
 
 func TestUpdateDSCStatus(t *testing.T) {
+	setupTest(t)
 	handler := &componentHandler{}
 
 	t.Run("should handle enabled component with ready ModelController CR", func(t *testing.T) {

--- a/internal/controller/components/modelregistry/modelregistry.go
+++ b/internal/controller/components/modelregistry/modelregistry.go
@@ -14,7 +14,6 @@ import (
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/api/components/v1alpha1"
 	dscv2 "github.com/opendatahub-io/opendatahub-operator/v2/api/datasciencecluster/v2"
 	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/components"
-	cr "github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/components/registry"
 	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/status"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/conditions"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
@@ -25,9 +24,7 @@ import (
 
 type componentHandler struct{}
 
-func init() { //nolint:gochecknoinits
-	cr.Add(&componentHandler{})
-}
+func NewHandler() *componentHandler { return &componentHandler{} }
 
 func (s *componentHandler) GetName() string {
 	return componentApi.ModelRegistryComponentName

--- a/internal/controller/components/modelregistry/modelregistry_controller_actions.go
+++ b/internal/controller/components/modelregistry/modelregistry_controller_actions.go
@@ -13,7 +13,7 @@ import (
 	odhdeploy "github.com/opendatahub-io/opendatahub-operator/v2/pkg/deploy"
 )
 
-func initialize(ctx context.Context, rr *odhtypes.ReconciliationRequest) error {
+func initialize(_ context.Context, rr *odhtypes.ReconciliationRequest) error { //nolint:unparam
 	rr.Manifests = []odhtypes.ManifestInfo{
 		baseManifestInfo(BaseManifestsSourcePath),
 		extraManifestInfo(BaseManifestsSourcePath),
@@ -22,7 +22,7 @@ func initialize(ctx context.Context, rr *odhtypes.ReconciliationRequest) error {
 	return nil
 }
 
-func customizeManifests(ctx context.Context, rr *odhtypes.ReconciliationRequest) error {
+func customizeManifests(_ context.Context, rr *odhtypes.ReconciliationRequest) error {
 	mr, ok := rr.Instance.(*componentApi.ModelRegistry)
 	if !ok {
 		return fmt.Errorf("resource instance %v is not a componentApi.ModelRegistry)", rr.Instance)
@@ -66,7 +66,7 @@ func computeKustomizeVariable(rr *odhtypes.ReconciliationRequest) (map[string]st
 	}, nil
 }
 
-func configureDependencies(ctx context.Context, rr *odhtypes.ReconciliationRequest) error {
+func configureDependencies(_ context.Context, rr *odhtypes.ReconciliationRequest) error {
 	mr, ok := rr.Instance.(*componentApi.ModelRegistry)
 	if !ok {
 		return fmt.Errorf("resource instance %v is not a componentApi.ModelRegistry)", rr.Instance)

--- a/internal/controller/components/modelsasservice/modelsasservice.go
+++ b/internal/controller/components/modelsasservice/modelsasservice.go
@@ -29,7 +29,6 @@ import (
 	"github.com/opendatahub-io/opendatahub-operator/v2/api/common"
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/api/components/v1alpha1"
 	dscv2 "github.com/opendatahub-io/opendatahub-operator/v2/api/datasciencecluster/v2"
-	cr "github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/components/registry"
 	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/status"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/conditions"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
@@ -39,9 +38,7 @@ import (
 
 type componentHandler struct{}
 
-func init() { //nolint:gochecknoinits
-	cr.Add(&componentHandler{})
-}
+func NewHandler() *componentHandler { return &componentHandler{} }
 
 // GetName returns the component name for ModelsAsService.
 func (s *componentHandler) GetName() string {

--- a/internal/controller/components/modelsasservice/modelsasservice_controller_actions.go
+++ b/internal/controller/components/modelsasservice/modelsasservice_controller_actions.go
@@ -83,7 +83,7 @@ func validateGatewayExists(ctx context.Context, rr *types.ReconciliationRequest,
 }
 
 // initialize sets up the manifests for the ModelsAsService component.
-func initialize(_ context.Context, rr *types.ReconciliationRequest) error {
+func initialize(_ context.Context, rr *types.ReconciliationRequest) error { //nolint:unparam
 	rr.Manifests = []types.ManifestInfo{
 		baseManifestInfo(BaseManifestsSourcePath),
 	}

--- a/internal/controller/components/ray/ray.go
+++ b/internal/controller/components/ray/ray.go
@@ -14,7 +14,6 @@ import (
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/api/components/v1alpha1"
 	dscv2 "github.com/opendatahub-io/opendatahub-operator/v2/api/datasciencecluster/v2"
 	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/components"
-	cr "github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/components/registry"
 	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/status"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/conditions"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
@@ -24,9 +23,7 @@ import (
 
 type componentHandler struct{}
 
-func init() { //nolint:gochecknoinits
-	cr.Add(&componentHandler{})
-}
+func NewHandler() *componentHandler { return &componentHandler{} }
 
 func (s *componentHandler) GetName() string {
 	return componentApi.RayComponentName

--- a/internal/controller/components/registry/registry.go
+++ b/internal/controller/components/registry/registry.go
@@ -27,44 +27,88 @@ type ComponentHandler interface {
 	IsEnabled(dsc *dscv2.DataScienceCluster) bool
 }
 
-// Registry is a struct that maintains a list of registered ComponentHandlers.
+type handlerEntry struct {
+	handler ComponentHandler
+	enabled bool
+}
+
+// Registry is a struct that maintains a set of registered ComponentHandlers.
 type Registry struct {
-	handlers []ComponentHandler
+	entries map[string]handlerEntry
 }
 
 var r = &Registry{}
 
 // Add registers a new ComponentHandler to the registry.
-// not thread safe, supposed to be called during init.
+// not thread safe, supposed to be called during program initialization.
 func (r *Registry) Add(ch ComponentHandler) {
-	r.handlers = append(r.handlers, ch)
+	if r.entries == nil {
+		r.entries = make(map[string]handlerEntry)
+	}
+	r.entries[ch.GetName()] = handlerEntry{handler: ch, enabled: true}
+}
+
+// Enable sets the enabled state for the named handler to true.
+func (r *Registry) Enable(name string) {
+	r.setEnabled(name, true)
+}
+
+// Disable sets the enabled state for the named handler to false.
+func (r *Registry) Disable(name string) {
+	r.setEnabled(name, false)
+}
+
+// setEnabled sets the enabled state for the named handler.
+func (r *Registry) setEnabled(name string, enabled bool) {
+	if e, ok := r.entries[name]; ok {
+		e.enabled = enabled
+		r.entries[name] = e
+	}
+}
+
+// IsEnabled returns the internal enabled state for the named handler.
+func (r *Registry) IsEnabled(name string) bool {
+	e, ok := r.entries[name]
+	return ok && e.enabled
 }
 
 // ForEach iterates over all registered ComponentHandlers and applies the given function.
+// Handlers whose enabled flag is false are skipped.
 // If any handler returns an error, that error is collected and returned at the end.
 // With go1.23 probably https://go.dev/blog/range-functions can be used.
 func (r *Registry) ForEach(f func(ch ComponentHandler) error) error {
 	var errs *multierror.Error
-	for _, ch := range r.handlers {
-		errs = multierror.Append(errs, f(ch))
+	for _, e := range r.entries {
+		if !e.enabled {
+			continue
+		}
+		errs = multierror.Append(errs, f(e.handler))
 	}
 
 	return errs.ErrorOrNil()
 }
 
 // IsComponentEnabled checks if a component with the given name is enabled in the DataScienceCluster.
-// Returns false if the component is not found.
+// Returns false if the component is not found or if it is disabled in the registry.
 func (r *Registry) IsComponentEnabled(componentName string, dsc *dscv2.DataScienceCluster) bool {
-	for _, ch := range r.handlers {
-		if ch.GetName() == componentName {
-			return ch.IsEnabled(dsc)
-		}
-	}
-	return false
+	e, ok := r.entries[componentName]
+	return ok && e.enabled && e.handler.IsEnabled(dsc)
 }
 
 func Add(ch ComponentHandler) {
 	r.Add(ch)
+}
+
+func Enable(name string) {
+	r.setEnabled(name, true)
+}
+
+func Disable(name string) {
+	r.setEnabled(name, false)
+}
+
+func IsEnabled(name string) bool {
+	return r.IsEnabled(name)
 }
 
 func ForEach(f func(ch ComponentHandler) error) error {

--- a/internal/controller/components/registry/registry_test.go
+++ b/internal/controller/components/registry/registry_test.go
@@ -1,0 +1,118 @@
+package registry_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/opendatahub-io/opendatahub-operator/v2/api/common"
+	dscv2 "github.com/opendatahub-io/opendatahub-operator/v2/api/datasciencecluster/v2"
+	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/components/registry"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
+
+	. "github.com/onsi/gomega"
+)
+
+type fakeComponentHandler struct {
+	name    string
+	enabled bool
+}
+
+func (f *fakeComponentHandler) Init(_ common.Platform) error { return nil }
+func (f *fakeComponentHandler) GetName() string              { return f.name }
+func (f *fakeComponentHandler) NewCRObject(_ context.Context, _ client.Client, _ *dscv2.DataScienceCluster) (common.PlatformObject, error) {
+	return nil, nil
+}
+func (f *fakeComponentHandler) NewComponentReconciler(_ context.Context, _ ctrl.Manager) error {
+	return nil
+}
+func (f *fakeComponentHandler) UpdateDSCStatus(_ context.Context, _ *types.ReconciliationRequest) (metav1.ConditionStatus, error) {
+	return metav1.ConditionTrue, nil
+}
+func (f *fakeComponentHandler) IsEnabled(_ *dscv2.DataScienceCluster) bool {
+	return f.enabled
+}
+
+func TestForEachSkipsSuppressedComponents(t *testing.T) {
+	g := NewWithT(t)
+
+	reg := &registry.Registry{}
+	reg.Add(&fakeComponentHandler{name: "comp-a", enabled: true})
+	reg.Add(&fakeComponentHandler{name: "comp-b", enabled: true})
+	reg.Add(&fakeComponentHandler{name: "comp-c", enabled: true})
+
+	reg.Disable("comp-b")
+
+	var visited []string
+	err := reg.ForEach(func(ch registry.ComponentHandler) error {
+		visited = append(visited, ch.GetName())
+		return nil
+	})
+
+	g.Expect(err).ShouldNot(HaveOccurred())
+	g.Expect(visited).Should(HaveLen(2))
+	g.Expect(visited).Should(ContainElement("comp-a"))
+	g.Expect(visited).Should(ContainElement("comp-c"))
+	g.Expect(visited).ShouldNot(ContainElement("comp-b"))
+}
+
+func TestForEachVisitsAllWhenNoneSuppressed(t *testing.T) {
+	g := NewWithT(t)
+
+	reg := &registry.Registry{}
+	reg.Add(&fakeComponentHandler{name: "comp-x", enabled: true})
+	reg.Add(&fakeComponentHandler{name: "comp-y", enabled: true})
+
+	var visited []string
+	err := reg.ForEach(func(ch registry.ComponentHandler) error {
+		visited = append(visited, ch.GetName())
+		return nil
+	})
+
+	g.Expect(err).ShouldNot(HaveOccurred())
+	g.Expect(visited).Should(HaveLen(2))
+}
+
+func TestForEachCollectsErrors(t *testing.T) {
+	g := NewWithT(t)
+
+	reg := &registry.Registry{}
+	reg.Add(&fakeComponentHandler{name: "comp-err", enabled: true})
+
+	err := reg.ForEach(func(ch registry.ComponentHandler) error {
+		return errors.New("test error")
+	})
+
+	g.Expect(err).Should(HaveOccurred())
+}
+
+func TestIsComponentEnabledReturnsFalseWhenSuppressed(t *testing.T) {
+	g := NewWithT(t)
+
+	reg := &registry.Registry{}
+	reg.Add(&fakeComponentHandler{name: "comp-sup", enabled: true})
+
+	g.Expect(reg.IsComponentEnabled("comp-sup", nil)).Should(BeTrue(), "should be enabled when not suppressed")
+
+	reg.Disable("comp-sup")
+	g.Expect(reg.IsComponentEnabled("comp-sup", nil)).Should(BeFalse(), "should be disabled when suppressed")
+}
+
+func TestSetEnabled(t *testing.T) {
+	g := NewWithT(t)
+
+	reg := &registry.Registry{}
+	reg.Add(&fakeComponentHandler{name: "flagtest", enabled: true})
+
+	g.Expect(reg.IsEnabled("flagtest")).Should(BeTrue(), "should be enabled by default")
+
+	reg.Disable("flagtest")
+	g.Expect(reg.IsEnabled("flagtest")).Should(BeFalse(), "should be disabled after Disable()")
+
+	reg.Enable("flagtest")
+	g.Expect(reg.IsEnabled("flagtest")).Should(BeTrue(), "should be enabled after Enable()")
+}

--- a/internal/controller/components/sparkoperator/sparkoperator.go
+++ b/internal/controller/components/sparkoperator/sparkoperator.go
@@ -14,7 +14,6 @@ import (
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/api/components/v1alpha1"
 	dscv2 "github.com/opendatahub-io/opendatahub-operator/v2/api/datasciencecluster/v2"
 	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/components"
-	cr "github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/components/registry"
 	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/status"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/conditions"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
@@ -24,9 +23,7 @@ import (
 
 type componentHandler struct{}
 
-func init() { //nolint:gochecknoinits
-	cr.Add(&componentHandler{})
-}
+func NewHandler() *componentHandler { return &componentHandler{} }
 
 func (s *componentHandler) GetName() string {
 	return componentApi.SparkOperatorComponentName

--- a/internal/controller/components/sparkoperator/sparkoperator_controller_actions.go
+++ b/internal/controller/components/sparkoperator/sparkoperator_controller_actions.go
@@ -22,7 +22,7 @@ import (
 	odhtypes "github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
 )
 
-func initialize(ctx context.Context, rr *odhtypes.ReconciliationRequest) error {
+func initialize(_ context.Context, rr *odhtypes.ReconciliationRequest) error { //nolint:unparam
 	rr.Manifests = append(rr.Manifests, manifestPath(rr.Release.Name))
 	return nil
 }

--- a/internal/controller/components/trainer/trainer.go
+++ b/internal/controller/components/trainer/trainer.go
@@ -14,7 +14,6 @@ import (
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/api/components/v1alpha1"
 	dscv2 "github.com/opendatahub-io/opendatahub-operator/v2/api/datasciencecluster/v2"
 	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/components"
-	cr "github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/components/registry"
 	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/status"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/conditions"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
@@ -28,9 +27,7 @@ const (
 
 type componentHandler struct{}
 
-func init() { //nolint:gochecknoinits
-	cr.Add(&componentHandler{})
-}
+func NewHandler() *componentHandler { return &componentHandler{} }
 
 func (s *componentHandler) GetName() string {
 	return componentApi.TrainerComponentName

--- a/internal/controller/components/trainer/trainer_controller_actions.go
+++ b/internal/controller/components/trainer/trainer_controller_actions.go
@@ -80,7 +80,7 @@ func checkPreConditions(ctx context.Context, rr *odhtypes.ReconciliationRequest)
 	return nil
 }
 
-func initialize(ctx context.Context, rr *odhtypes.ReconciliationRequest) error {
+func initialize(_ context.Context, rr *odhtypes.ReconciliationRequest) error { //nolint:unparam
 	rr.Manifests = append(rr.Manifests, manifestPath())
 	return nil
 }

--- a/internal/controller/components/trainingoperator/trainingoperator.go
+++ b/internal/controller/components/trainingoperator/trainingoperator.go
@@ -14,7 +14,6 @@ import (
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/api/components/v1alpha1"
 	dscv2 "github.com/opendatahub-io/opendatahub-operator/v2/api/datasciencecluster/v2"
 	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/components"
-	cr "github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/components/registry"
 	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/status"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/conditions"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
@@ -24,9 +23,7 @@ import (
 
 type componentHandler struct{}
 
-func init() { //nolint:gochecknoinits
-	cr.Add(&componentHandler{})
-}
+func NewHandler() *componentHandler { return &componentHandler{} }
 
 func (s *componentHandler) GetName() string {
 	return componentApi.TrainingOperatorComponentName

--- a/internal/controller/components/trainingoperator/trainingoperator_controller_actions.go
+++ b/internal/controller/components/trainingoperator/trainingoperator_controller_actions.go
@@ -22,7 +22,7 @@ import (
 	odhtypes "github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
 )
 
-func initialize(ctx context.Context, rr *odhtypes.ReconciliationRequest) error {
+func initialize(_ context.Context, rr *odhtypes.ReconciliationRequest) error { //nolint:unparam
 	rr.Manifests = append(rr.Manifests, manifestPath())
 	return nil
 }

--- a/internal/controller/components/trustyai/trustyai.go
+++ b/internal/controller/components/trustyai/trustyai.go
@@ -14,7 +14,6 @@ import (
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/api/components/v1alpha1"
 	dscv2 "github.com/opendatahub-io/opendatahub-operator/v2/api/datasciencecluster/v2"
 	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/components"
-	cr "github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/components/registry"
 	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/status"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/conditions"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
@@ -30,9 +29,7 @@ const (
 
 type componentHandler struct{}
 
-func init() { //nolint:gochecknoinits
-	cr.Add(&componentHandler{})
-}
+func NewHandler() *componentHandler { return &componentHandler{} }
 
 func (s *componentHandler) GetName() string {
 	return componentApi.TrustyAIComponentName

--- a/internal/controller/components/trustyai/trustyai_controller_actions.go
+++ b/internal/controller/components/trustyai/trustyai_controller_actions.go
@@ -45,7 +45,7 @@ func checkPreConditions(ctx context.Context, rr *odhtypes.ReconciliationRequest)
 	return nil
 }
 
-func initialize(_ context.Context, rr *odhtypes.ReconciliationRequest) error {
+func initialize(_ context.Context, rr *odhtypes.ReconciliationRequest) error { //nolint:unparam
 	rr.Manifests = append(rr.Manifests, manifestsPath(rr.Release.Name))
 	return nil
 }

--- a/internal/controller/components/workbenches/workbenches.go
+++ b/internal/controller/components/workbenches/workbenches.go
@@ -14,7 +14,6 @@ import (
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/api/components/v1alpha1"
 	dscv2 "github.com/opendatahub-io/opendatahub-operator/v2/api/datasciencecluster/v2"
 	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/components"
-	cr "github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/components/registry"
 	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/status"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/conditions"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
@@ -24,9 +23,7 @@ import (
 
 type componentHandler struct{}
 
-func init() { //nolint:gochecknoinits
-	cr.Add(&componentHandler{})
-}
+func NewHandler() *componentHandler { return &componentHandler{} }
 
 func (s *componentHandler) GetName() string {
 	return componentApi.WorkbenchesComponentName

--- a/internal/controller/components/workbenches/workbenches_controller_actions.go
+++ b/internal/controller/components/workbenches/workbenches_controller_actions.go
@@ -12,7 +12,7 @@ import (
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/metadata/labels"
 )
 
-func initialize(ctx context.Context, rr *odhtypes.ReconciliationRequest) error {
+func initialize(_ context.Context, rr *odhtypes.ReconciliationRequest) error { //nolint:unparam
 	rr.Manifests = []odhtypes.ManifestInfo{
 		notebookControllerManifestInfo(notebookControllerManifestSourcePath),
 		kfNotebookControllerManifestInfo(kfNotebookControllerManifestSourcePath),
@@ -22,7 +22,7 @@ func initialize(ctx context.Context, rr *odhtypes.ReconciliationRequest) error {
 	return nil
 }
 
-func configureDependencies(ctx context.Context, rr *odhtypes.ReconciliationRequest) error {
+func configureDependencies(_ context.Context, rr *odhtypes.ReconciliationRequest) error {
 	workbench, ok := rr.Instance.(*componentApi.Workbenches)
 	if !ok {
 		return fmt.Errorf("resource instance %v is not a componentApi.Workbenches", rr.Instance)
@@ -51,7 +51,7 @@ func configureDependencies(ctx context.Context, rr *odhtypes.ReconciliationReque
 	return nil
 }
 
-func updateStatus(ctx context.Context, rr *odhtypes.ReconciliationRequest) error {
+func updateStatus(_ context.Context, rr *odhtypes.ReconciliationRequest) error {
 	workbench, ok := rr.Instance.(*componentApi.Workbenches)
 	if !ok {
 		return fmt.Errorf("resource instance %v is not a componentApi.Workbenches", rr.Instance)

--- a/internal/controller/services/auth/auth_controller.go
+++ b/internal/controller/services/auth/auth_controller.go
@@ -27,16 +27,12 @@ import (
 	"github.com/opendatahub-io/opendatahub-operator/v2/api/common"
 	dsciv2 "github.com/opendatahub-io/opendatahub-operator/v2/api/dscinitialization/v2"
 	serviceApi "github.com/opendatahub-io/opendatahub-operator/v2/api/services/v1alpha1"
-	sr "github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/services/registry"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/deploy"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/render/template"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/reconciler"
 )
 
-//nolint:gochecknoinits
-func init() {
-	sr.Add(&ServiceHandler{})
-}
+func NewHandler() *ServiceHandler { return &ServiceHandler{} }
 
 type ServiceHandler struct {
 }

--- a/internal/controller/services/certconfigmapgenerator/certconfigmapgenerator.go
+++ b/internal/controller/services/certconfigmapgenerator/certconfigmapgenerator.go
@@ -9,17 +9,13 @@ import (
 
 	"github.com/opendatahub-io/opendatahub-operator/v2/api/common"
 	dsciv2 "github.com/opendatahub-io/opendatahub-operator/v2/api/dscinitialization/v2"
-	sr "github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/services/registry"
 )
 
 const (
 	ServiceName = "certconfigmapgenerator"
 )
 
-//nolint:gochecknoinits
-func init() {
-	sr.Add(&serviceHandler{})
-}
+func NewHandler() *serviceHandler { return &serviceHandler{} }
 
 type serviceHandler struct {
 }

--- a/internal/controller/services/gateway/gateway.go
+++ b/internal/controller/services/gateway/gateway.go
@@ -5,13 +5,9 @@ import (
 
 	"github.com/opendatahub-io/opendatahub-operator/v2/api/common"
 	dsciv2 "github.com/opendatahub-io/opendatahub-operator/v2/api/dscinitialization/v2"
-	sr "github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/services/registry"
 )
 
-//nolint:gochecknoinits
-func init() {
-	sr.Add(&ServiceHandler{})
-}
+func NewHandler() *ServiceHandler { return &ServiceHandler{} }
 
 // ServiceHandler implements the ServiceHandler interface for Gateway services.
 // It manages the lifecycle of GatewayConfig resources and their associated infrastructure.

--- a/internal/controller/services/monitoring/monitoring_controller.go
+++ b/internal/controller/services/monitoring/monitoring_controller.go
@@ -35,7 +35,6 @@ import (
 	dscv2 "github.com/opendatahub-io/opendatahub-operator/v2/api/datasciencecluster/v2"
 	dsciv2 "github.com/opendatahub-io/opendatahub-operator/v2/api/dscinitialization/v2"
 	serviceApi "github.com/opendatahub-io/opendatahub-operator/v2/api/services/v1alpha1"
-	sr "github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/services/registry"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/deploy"
@@ -48,10 +47,7 @@ import (
 	odhtypes "github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
 )
 
-//nolint:gochecknoinits
-func init() {
-	sr.Add(&serviceHandler{})
-}
+func NewHandler() *serviceHandler { return &serviceHandler{} }
 
 type serviceHandler struct {
 }

--- a/internal/controller/services/monitoring/monitoring_controller_actions.go
+++ b/internal/controller/services/monitoring/monitoring_controller_actions.go
@@ -84,7 +84,7 @@ var componentRules = map[string]string{
 var resourcesFS embed.FS
 
 // initialize handles all pre-deployment configurations.
-func initialize(_ context.Context, rr *odhtypes.ReconciliationRequest) error {
+func initialize(_ context.Context, rr *odhtypes.ReconciliationRequest) error { //nolint:unparam
 	// Only set prometheus configmap path
 	rr.Manifests = []odhtypes.ManifestInfo{
 		{
@@ -644,7 +644,7 @@ func deployPersesPrometheusIntegration(ctx context.Context, rr *odhtypes.Reconci
 	return nil
 }
 
-func deployNodeMetricsEndpoint(ctx context.Context, rr *odhtypes.ReconciliationRequest) error {
+func deployNodeMetricsEndpoint(_ context.Context, rr *odhtypes.ReconciliationRequest) error {
 	monitoring, ok := rr.Instance.(*serviceApi.Monitoring)
 	if !ok {
 		return errors.New("instance is not of type *services.Monitoring")

--- a/internal/controller/services/registry/registry.go
+++ b/internal/controller/services/registry/registry.go
@@ -20,26 +20,62 @@ type ServiceHandler interface {
 	NewReconciler(ctx context.Context, mgr ctrl.Manager) error
 }
 
-// Registry is a struct that maintains a list of registered ServiceHandlers.
+type handlerEntry struct {
+	handler ServiceHandler
+	enabled bool
+}
+
+// Registry is a struct that maintains a set of registered ServiceHandlers.
 type Registry struct {
-	handlers []ServiceHandler
+	entries map[string]handlerEntry
 }
 
 var r = &Registry{}
 
 // Add registers a new ServiceHandler to the registry.
-// not thread safe, supposed to be called during init.
+// not thread safe, supposed to be called during program initialization.
 func (r *Registry) Add(ch ServiceHandler) {
-	r.handlers = append(r.handlers, ch)
+	if r.entries == nil {
+		r.entries = make(map[string]handlerEntry)
+	}
+	r.entries[ch.GetName()] = handlerEntry{handler: ch, enabled: true}
+}
+
+// Enable sets the enabled state for the named handler to true.
+func (r *Registry) Enable(name string) {
+	r.setEnabled(name, true)
+}
+
+// Disable sets the enabled state for the named handler to false.
+func (r *Registry) Disable(name string) {
+	r.setEnabled(name, false)
+}
+
+// setEnabled sets the enabled state for the named handler.
+func (r *Registry) setEnabled(name string, enabled bool) {
+	if e, ok := r.entries[name]; ok {
+		e.enabled = enabled
+		r.entries[name] = e
+	}
+}
+
+// IsEnabled returns the internal enabled state for the named handler.
+func (r *Registry) IsEnabled(name string) bool {
+	e, ok := r.entries[name]
+	return ok && e.enabled
 }
 
 // ForEach iterates over all registered ServiceHandlers and applies the given function.
+// Handlers whose enabled flag is false are skipped.
 // If any handler returns an error, that error is collected and returned at the end.
 // With go1.23 probably https://go.dev/blog/range-functions can be used.
 func (r *Registry) ForEach(f func(ch ServiceHandler) error) error {
 	var errs *multierror.Error
-	for _, ch := range r.handlers {
-		errs = multierror.Append(errs, f(ch))
+	for _, e := range r.entries {
+		if !e.enabled {
+			continue
+		}
+		errs = multierror.Append(errs, f(e.handler))
 	}
 
 	return errs.ErrorOrNil()
@@ -47,6 +83,18 @@ func (r *Registry) ForEach(f func(ch ServiceHandler) error) error {
 
 func Add(ch ServiceHandler) {
 	r.Add(ch)
+}
+
+func Enable(name string) {
+	r.setEnabled(name, true)
+}
+
+func Disable(name string) {
+	r.setEnabled(name, false)
+}
+
+func IsEnabled(name string) bool {
+	return r.IsEnabled(name)
 }
 
 func ForEach(f func(ch ServiceHandler) error) error {

--- a/internal/controller/services/registry/registry_test.go
+++ b/internal/controller/services/registry/registry_test.go
@@ -1,0 +1,97 @@
+package registry_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	operatorv1 "github.com/openshift/api/operator/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	"github.com/opendatahub-io/opendatahub-operator/v2/api/common"
+	dsciv2 "github.com/opendatahub-io/opendatahub-operator/v2/api/dscinitialization/v2"
+	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/services/registry"
+
+	. "github.com/onsi/gomega"
+)
+
+type fakeServiceHandler struct {
+	name string
+}
+
+func (f *fakeServiceHandler) Init(_ common.Platform) error { return nil }
+func (f *fakeServiceHandler) GetName() string              { return f.name }
+func (f *fakeServiceHandler) GetManagementState(_ common.Platform, _ *dsciv2.DSCInitialization) operatorv1.ManagementState {
+	return operatorv1.Managed
+}
+func (f *fakeServiceHandler) NewReconciler(_ context.Context, _ ctrl.Manager) error {
+	return nil
+}
+
+func TestForEachSkipsSuppressedServices(t *testing.T) {
+	g := NewWithT(t)
+
+	reg := &registry.Registry{}
+	reg.Add(&fakeServiceHandler{name: "svc-a"})
+	reg.Add(&fakeServiceHandler{name: "svc-b"})
+	reg.Add(&fakeServiceHandler{name: "svc-c"})
+
+	reg.Disable("svc-b")
+
+	var visited []string
+	err := reg.ForEach(func(ch registry.ServiceHandler) error {
+		visited = append(visited, ch.GetName())
+		return nil
+	})
+
+	g.Expect(err).ShouldNot(HaveOccurred())
+	g.Expect(visited).Should(HaveLen(2))
+	g.Expect(visited).Should(ContainElement("svc-a"))
+	g.Expect(visited).Should(ContainElement("svc-c"))
+	g.Expect(visited).ShouldNot(ContainElement("svc-b"))
+}
+
+func TestForEachVisitsAllWhenNoneSuppressed(t *testing.T) {
+	g := NewWithT(t)
+
+	reg := &registry.Registry{}
+	reg.Add(&fakeServiceHandler{name: "svc-x"})
+	reg.Add(&fakeServiceHandler{name: "svc-y"})
+
+	var visited []string
+	err := reg.ForEach(func(ch registry.ServiceHandler) error {
+		visited = append(visited, ch.GetName())
+		return nil
+	})
+
+	g.Expect(err).ShouldNot(HaveOccurred())
+	g.Expect(visited).Should(HaveLen(2))
+}
+
+func TestForEachCollectsErrors(t *testing.T) {
+	g := NewWithT(t)
+
+	reg := &registry.Registry{}
+	reg.Add(&fakeServiceHandler{name: "svc-err"})
+
+	err := reg.ForEach(func(ch registry.ServiceHandler) error {
+		return errors.New("test error")
+	})
+
+	g.Expect(err).Should(HaveOccurred())
+}
+
+func TestSetEnabled(t *testing.T) {
+	g := NewWithT(t)
+
+	reg := &registry.Registry{}
+	reg.Add(&fakeServiceHandler{name: "svcflagtest"})
+
+	g.Expect(reg.IsEnabled("svcflagtest")).Should(BeTrue(), "should be enabled by default")
+
+	reg.Disable("svcflagtest")
+	g.Expect(reg.IsEnabled("svcflagtest")).Should(BeFalse(), "should be disabled after Disable()")
+
+	reg.Enable("svcflagtest")
+	g.Expect(reg.IsEnabled("svcflagtest")).Should(BeTrue(), "should be enabled after Enable()")
+}

--- a/internal/controller/services/setup/setup.go
+++ b/internal/controller/services/setup/setup.go
@@ -9,17 +9,13 @@ import (
 
 	"github.com/opendatahub-io/opendatahub-operator/v2/api/common"
 	dsciv2 "github.com/opendatahub-io/opendatahub-operator/v2/api/dscinitialization/v2"
-	sr "github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/services/registry"
 )
 
 const (
 	ServiceName = "setupcontroller"
 )
 
-//nolint:gochecknoinits
-func init() {
-	sr.Add(&serviceHandler{})
-}
+func NewHandler() *serviceHandler { return &serviceHandler{} }
 
 type serviceHandler struct {
 }

--- a/internal/webhook/webhook.go
+++ b/internal/webhook/webhook.go
@@ -4,7 +4,12 @@ package webhook
 
 import (
 	ctrl "sigs.k8s.io/controller-runtime"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
+	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/api/components/v1alpha1"
+	serviceApi "github.com/opendatahub-io/opendatahub-operator/v2/api/services/v1alpha1"
+	cr "github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/components/registry"
+	sr "github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/services/registry"
 	"github.com/opendatahub-io/opendatahub-operator/v2/internal/webhook/dashboard"
 	dscv1webhook "github.com/opendatahub-io/opendatahub-operator/v2/internal/webhook/datasciencecluster/v1"
 	dscv2webhook "github.com/opendatahub-io/opendatahub-operator/v2/internal/webhook/datasciencecluster/v2"
@@ -15,27 +20,45 @@ import (
 	monitoringwebhook "github.com/opendatahub-io/opendatahub-operator/v2/internal/webhook/monitoring"
 	notebookwebhook "github.com/opendatahub-io/opendatahub-operator/v2/internal/webhook/notebook"
 	serving "github.com/opendatahub-io/opendatahub-operator/v2/internal/webhook/serving"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/flags"
 )
 
+var log = logf.Log.WithName("webhook-registration")
+
+type webhookEntry struct {
+	name     string
+	register func(ctrl.Manager) error
+	disabled func() bool
+}
+
 // RegisterAllWebhooks registers all webhook setup functions with the given manager.
+// Webhooks whose suppression flag is set are skipped.
 // Returns the first error encountered during registration, or nil if all succeed.
 func RegisterAllWebhooks(mgr ctrl.Manager) error {
-	webhookRegistrations := []func(ctrl.Manager) error{
-		dscv1webhook.RegisterWebhooks,
-		dscv2webhook.RegisterWebhooks,
-		dsciv1webhook.RegisterWebhooks,
-		dsciv2webhook.RegisterWebhooks,
-		hardwareprofilewebhook.RegisterWebhooks,
-		kueuewebhook.RegisterWebhooks,
-		monitoringwebhook.RegisterWebhooks,
-		serving.RegisterWebhooks,
-		notebookwebhook.RegisterWebhooks,
-		dashboard.RegisterWebhooks,
+	entries := []webhookEntry{
+		{name: "dsc-v1", register: dscv1webhook.RegisterWebhooks, disabled: func() bool { return !flags.IsDSCEnabled() }},
+		{name: "dsc-v2", register: dscv2webhook.RegisterWebhooks, disabled: func() bool { return !flags.IsDSCEnabled() }},
+		{name: "dsci-v1", register: dsciv1webhook.RegisterWebhooks, disabled: func() bool { return !flags.IsDSCIEnabled() }},
+		{name: "dsci-v2", register: dsciv2webhook.RegisterWebhooks, disabled: func() bool { return !flags.IsDSCIEnabled() }},
+		{name: "hardwareprofile", register: hardwareprofilewebhook.RegisterWebhooks, disabled: func() bool {
+			return !cr.IsEnabled(componentApi.KserveComponentName) && !cr.IsEnabled(componentApi.WorkbenchesComponentName)
+		}},
+		{name: "kueue", register: kueuewebhook.RegisterWebhooks, disabled: func() bool { return !cr.IsEnabled(componentApi.KueueComponentName) }},
+		{name: "monitoring", register: monitoringwebhook.RegisterWebhooks, disabled: func() bool { return !sr.IsEnabled(serviceApi.MonitoringServiceName) }},
+		{name: "serving", register: serving.RegisterWebhooks, disabled: func() bool { return !cr.IsEnabled(componentApi.KserveComponentName) }},
+		{name: "notebook", register: notebookwebhook.RegisterWebhooks, disabled: func() bool { return !cr.IsEnabled(componentApi.WorkbenchesComponentName) }},
+		{name: "dashboard", register: dashboard.RegisterWebhooks, disabled: func() bool { return !cr.IsEnabled(componentApi.DashboardComponentName) }},
 	}
-	for _, reg := range webhookRegistrations {
-		if err := reg(mgr); err != nil {
+
+	for _, e := range entries {
+		if e.disabled != nil && e.disabled() {
+			log.Info("webhook registration suppressed", "webhook", e.name)
+			continue
+		}
+		if err := e.register(mgr); err != nil {
 			return err
 		}
 	}
+
 	return nil
 }

--- a/pkg/utils/flags/flags.go
+++ b/pkg/utils/flags/flags.go
@@ -61,6 +61,10 @@ func AddOperatorFlagsAndEnvvars(envvarPrefix string) error {
 		return err
 	}
 
+	if err := addResourceSuppressionFlags(); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/pkg/utils/flags/suppression.go
+++ b/pkg/utils/flags/suppression.go
@@ -1,0 +1,93 @@
+package flags
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
+)
+
+// RegisterComponentSuppressionFlags registers suppression flags for a list of component names.
+func RegisterComponentSuppressionFlags(names []string) error {
+	for _, name := range names {
+		if err := registerComponentSuppressionFlag(name); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// RegisterServiceSuppressionFlags registers suppression flags for a list of service names.
+func RegisterServiceSuppressionFlags(names []string) error {
+	for _, name := range names {
+		if err := registerServiceSuppressionFlag(name); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// IsDSCEnabled returns true if the DSC resource is enabled.
+func IsDSCEnabled() bool {
+	return !viper.GetBool("disable-dsc-resource")
+}
+
+// IsDSCIEnabled returns true if the DSCI resource is enabled.
+func IsDSCIEnabled() bool {
+	return !viper.GetBool("disable-dsci-resource")
+}
+
+// IsComponentEnabled returns true if the named component is enabled.
+func IsComponentEnabled(name string) bool {
+	return !viper.GetBool(fmt.Sprintf("disable-%s-component", name))
+}
+
+// IsServiceEnabled returns true if the named service is enabled.
+func IsServiceEnabled(name string) bool {
+	return !viper.GetBool(fmt.Sprintf("disable-%s-service", name))
+}
+
+// AddResourceSuppressionFlags registers the DSC and DSCI resource suppression flags.
+// Each flag is bound to a corresponding RHAI_ environment variable.
+func addResourceSuppressionFlags() error {
+	pflag.Bool("disable-dsc-resource", false, "Suppress the DSC controller, webhooks, and auto-creation")
+	if err := viper.BindEnv("disable-dsc-resource", "RHAI_DISABLE_DSC_RESOURCE"); err != nil {
+		return err
+	}
+
+	pflag.Bool("disable-dsci-resource", false, "Suppress the DSCI controller, webhooks, and auto-creation")
+	if err := viper.BindEnv("disable-dsci-resource", "RHAI_DISABLE_DSCI_RESOURCE"); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// RegisterComponentSuppressionFlag registers a suppression flag for a component.
+// The flag name is "disable-{name}-component" and it is bound to the env var RHAI_DISABLE_{UPPER(name)}_COMPONENT.
+func registerComponentSuppressionFlag(name string) error {
+	flagName := fmt.Sprintf("disable-%s-component", name)
+	envVar := fmt.Sprintf("RHAI_DISABLE_%s_COMPONENT", strings.ToUpper(name))
+
+	pflag.Bool(flagName, false, fmt.Sprintf("Suppress the %s component reconciler and related webhooks", name))
+	if err := viper.BindEnv(flagName, envVar); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// RegisterServiceSuppressionFlag registers a suppression flag for a service.
+// The flag name is "disable-{name}-service" and it is bound to the env var RHAI_DISABLE_{UPPER(name)}_SERVICE.
+func registerServiceSuppressionFlag(name string) error {
+	flagName := fmt.Sprintf("disable-%s-service", name)
+	envVar := fmt.Sprintf("RHAI_DISABLE_%s_SERVICE", strings.ToUpper(name))
+
+	pflag.Bool(flagName, false, fmt.Sprintf("Suppress the %s service reconciler", name))
+	if err := viper.BindEnv(flagName, envVar); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/utils/flags/suppression_test.go
+++ b/pkg/utils/flags/suppression_test.go
@@ -1,0 +1,59 @@
+package flags_test
+
+import (
+	"testing"
+
+	"github.com/spf13/viper"
+
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/flags"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestRegisterComponentSuppressionFlag(t *testing.T) {
+	t.Cleanup(func() { viper.Reset() })
+	g := NewWithT(t)
+
+	err := flags.RegisterComponentSuppressionFlags([]string{"dashboard"})
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	g.Expect(flags.IsComponentEnabled("dashboard")).Should(BeTrue(), "should be enabled by default")
+
+	viper.Set("disable-dashboard-component", true)
+	g.Expect(flags.IsComponentEnabled("dashboard")).Should(BeFalse(), "should be disabled when flag is set")
+}
+
+func TestComponentSuppressionFlagEnvBinding(t *testing.T) {
+	t.Cleanup(func() { viper.Reset() })
+	g := NewWithT(t)
+
+	err := flags.RegisterComponentSuppressionFlags([]string{"kserve"})
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	t.Setenv("RHAI_DISABLE_KSERVE_COMPONENT", "true")
+	g.Expect(flags.IsComponentEnabled("kserve")).Should(BeFalse(), "should be disabled when env var is set")
+}
+
+func TestRegisterServiceSuppressionFlag(t *testing.T) {
+	t.Cleanup(func() { viper.Reset() })
+	g := NewWithT(t)
+
+	err := flags.RegisterServiceSuppressionFlags([]string{"auth"})
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	g.Expect(flags.IsServiceEnabled("auth")).Should(BeTrue(), "should be enabled by default")
+
+	viper.Set("disable-auth-service", true)
+	g.Expect(flags.IsServiceEnabled("auth")).Should(BeFalse(), "should be disabled when flag is set")
+}
+
+func TestServiceSuppressionFlagEnvBinding(t *testing.T) {
+	t.Cleanup(func() { viper.Reset() })
+	g := NewWithT(t)
+
+	err := flags.RegisterServiceSuppressionFlags([]string{"monitoring"})
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	t.Setenv("RHAI_DISABLE_MONITORING_SERVICE", "true")
+	g.Expect(flags.IsServiceEnabled("monitoring")).Should(BeFalse(), "should be disabled when env var is set")
+}

--- a/pkg/utils/test/testf/testf_witht_test.go
+++ b/pkg/utils/test/testf/testf_witht_test.go
@@ -27,7 +27,7 @@ import (
 // prepareTestConfigMap creates a unique ConfigMap and returns a matcher for it along with the unstructured object and key.
 // This is used for tests that create new ConfigMaps (e.g., TestCreate).
 //
-//nolint:ireturn
+//nolint:ireturn //reason: returns GomegaMatcher interface for test assertions
 func prepareTestConfigMap(g Gomega, template corev1.ConfigMap) (types.GomegaMatcher, *unstructured.Unstructured, client.ObjectKey) {
 	cm := template.DeepCopy()
 	cm.Name = xid.New().String()
@@ -52,7 +52,7 @@ func prepareTestConfigMap(g Gomega, template corev1.ConfigMap) (types.GomegaMatc
 // prepareUpdateTestConfigMap creates a ConfigMap from template and returns an unstructured object for update tests.
 // The matcher expects the transformer to have been applied.
 //
-//nolint:ireturn
+//nolint:ireturn //reason: returns GomegaMatcher interface for test assertions
 func prepareUpdateTestConfigMap(g Gomega, template corev1.ConfigMap, expectedMatcher types.GomegaMatcher) (*unstructured.Unstructured, types.GomegaMatcher) {
 	obj, err := resources.ToUnstructured(template.DeepCopy())
 	g.Expect(err).ShouldNot(HaveOccurred())
@@ -62,7 +62,7 @@ func prepareUpdateTestConfigMap(g Gomega, template corev1.ConfigMap, expectedMat
 // prepareExistingConfigMapTest creates a ConfigMap with pre-existing client and returns test setup for Update/Patch tests.
 // The ConfigMap already exists in the fake client, and the test applies a transformer to it.
 //
-//nolint:ireturn
+//nolint:ireturn //reason: returns GomegaMatcher interface for test assertions
 func prepareExistingConfigMapTest(g Gomega, cmName string) (types.GomegaMatcher, client.ObjectKey, testf.TransformFn, *testf.TestContext) {
 	cm := corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
  - Introduces CLI flags and RHAI_DISABLE_* environment variables to selectively suppress management of individual components, services, and DSC/DSCI resources at operator startup
  - Replaces init()-based auto-registration with explicit NewHandler() constructors and deterministic registration in main(), improving testability and control over handler lifecycle
  - Guards DSC/DSCI controller setup, webhook registration, and auto-creation behind suppression checks so that disabled subsystems are fully inert
<!--- Link your JIRA and related links here for reference. -->
https://issues.redhat.com/browse/RHOAIENG-49704

## How Has This Been Tested?
unit tests, and negative case with e2e  tests as well.

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [x] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->
existing e2e  tests already cover the negative case test i.e. that everything that exists still works. For additional tests that would be added later as part of the xKS work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Global and per-component/service suppression flags (and RHAI_DISABLE_* env vars) to selectively disable DSC/DSCI, components, services and conditionally schedule defaults; startup logs suppression state and webhooks skip suppressed entries.

* **Refactor**
  * Initialization now uses explicit, suppression-aware registration; registries track enabled/disabled state and skip suppressed items during startup.

* **Tests**
  * New unit tests for suppression flags and registry suppression behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->