### PR TITLE
test $@ passed to the main command in the e2e dockerfile

### DIFF
--- a/Dockerfiles/e2e-tests/e2e-tests.Dockerfile
+++ b/Dockerfiles/e2e-tests/e2e-tests.Dockerfile
@@ -27,23 +27,6 @@ RUN CGO_ENABLED=${CGO_ENABLED} GOOS=linux GOARCH=${TARGETARCH} go test -c ./test
 ################################################################################
 FROM golang:$GOLANG_VERSION
 
-# ENV vars for the go test command options
-ENV E2E_TEST_OPERATOR_NAMESPACE=opendatahub-operators
-ENV E2E_TEST_APPLICATIONS_NAMESPACE=opendatahub
-ENV E2E_TEST_WORKBENCHES_NAMESPACE=opendatahub
-ENV E2E_TEST_DSC_MONITORING_NAMESPACE=opendatahub
-ENV E2E_TEST_CLEAN_UP_PREVIOUS_RESOURCES=false
-ENV E2E_TEST_DELETION_POLICY=never
-ENV E2E_TEST_FAIL_FAST_ON_ERROR=false
-ENV E2E_TEST_OPERATOR_CONTROLLER=true
-ENV E2E_TEST_OPERATOR_RESILIENCE=true
-ENV E2E_TEST_OPERATOR_V2TOV3UPGRADE=true
-ENV E2E_TEST_HARDWARE_PROFILE=true
-ENV E2E_TEST_WEBHOOK=true
-ENV E2E_TEST_COMPONENTS=true
-ENV E2E_TEST_SERVICES=true
-ENV E2E_TEST_TAG=All
-
 RUN apt-get update -y && apt-get upgrade -y && \
     curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" && \
     chmod +x kubectl && \
@@ -57,19 +40,11 @@ RUN go install gotest.tools/gotestsum@latest \
 WORKDIR /e2e
 
 COPY --from=builder /workspace/e2e-tests .
+COPY tests/e2e/scripts/run_e2e_tests.sh /e2e/run_e2e_tests.sh
 
-RUN chmod +x ./e2e-tests
+RUN chmod +x ./e2e-tests /e2e/run_e2e_tests.sh
 
 RUN mkdir -p results
 
 # run main go command
-CMD gotestsum --junitfile-project-name odh-operator-e2e \
---junitfile results/xunit_report.xml --format testname --raw-command \
--- test2json -p e2e ./e2e-tests --test.v=test2json --test.parallel=8 \
---deletion-policy="$E2E_TEST_DELETION_POLICY" --clean-up-previous-resources="$E2E_TEST_CLEAN_UP_PREVIOUS_RESOURCES" \
---test-operator-controller="$E2E_TEST_OPERATOR_CONTROLLER" --test-operator-resilience="$E2E_TEST_OPERATOR_RESILIENCE" \
---test-operator-v2tov3upgrade="$E2E_TEST_OPERATOR_V2TOV3UPGRADE" --test-hardware-profile="$E2E_TEST_HARDWARE_PROFILE" \
---test-webhook="$E2E_TEST_WEBHOOK" --test-components="$E2E_TEST_COMPONENTS" --test-services="$E2E_TEST_SERVICES" \
---operator-namespace="$E2E_TEST_OPERATOR_NAMESPACE" --applications-namespace="$E2E_TEST_APPLICATIONS_NAMESPACE" \
---workbenches-namespace="$E2E_TEST_WORKBENCHES_NAMESPACE" --dsc-monitoring-namespace="$E2E_TEST_DSC_MONITORING_NAMESPACE" \
---fail-fast-on-error="$E2E_TEST_FAIL_FAST_ON_ERROR" --tag="$E2E_TEST_TAG"
+ENTRYPOINT ["/e2e/run_e2e_tests.sh"]

--- a/tests/e2e/scripts/run_e2e_tests.sh
+++ b/tests/e2e/scripts/run_e2e_tests.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+set -euo pipefail
+
+# Validation functions
+validate_bool() {
+    local var_name=$1
+    local value=${!var_name}
+    case "$value" in
+        true|false|0|1) return 0 ;;
+        *) echo "Error: $var_name must be true/false or 0/1, got '$value'" >&2; exit 1 ;;
+    esac
+}
+
+validate_namespace() {
+    local var_name=$1
+    local value=${!var_name}
+    # K8s namespace regex: lowercase alphanumeric characters or '-', must start and end with alphanumeric
+    if [[ ! "$value" =~ ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$ ]]; then
+        echo "Error: $var_name must be a valid Kubernetes namespace, got '$value'" >&2; exit 1
+    fi
+}
+
+validate_deletion_policy() {
+    local var_name=$1
+    local value=${!var_name}
+    case "$value" in
+        never|always|on-success) return 0 ;;
+        *) echo "Error: $var_name must be 'never', 'always', or 'on-success', got '$value'" >&2; exit 1 ;;
+    esac
+}
+
+validate_tag() {
+    local var_name=$1
+    local value=${!var_name}
+    # Tags limited to alphanumeric, '-' and '_'
+    if [[ ! "$value" =~ ^[a-zA-Z0-9_-]+$ ]]; then
+        echo "Error: $var_name contains unsafe characters, got '$value'" >&2; exit 1
+    fi
+}
+
+# Set defaults and validate
+: "${E2E_TEST_DELETION_POLICY:=never}"
+validate_deletion_policy E2E_TEST_DELETION_POLICY
+
+: "${E2E_TEST_CLEAN_UP_PREVIOUS_RESOURCES:=false}"
+validate_bool E2E_TEST_CLEAN_UP_PREVIOUS_RESOURCES
+
+: "${E2E_TEST_OPERATOR_CONTROLLER:=true}"
+validate_bool E2E_TEST_OPERATOR_CONTROLLER
+
+: "${E2E_TEST_OPERATOR_RESILIENCE:=true}"
+validate_bool E2E_TEST_OPERATOR_RESILIENCE
+
+: "${E2E_TEST_OPERATOR_V2TOV3UPGRADE:=true}"
+validate_bool E2E_TEST_OPERATOR_V2TOV3UPGRADE
+
+: "${E2E_TEST_HARDWARE_PROFILE:=true}"
+validate_bool E2E_TEST_HARDWARE_PROFILE
+
+: "${E2E_TEST_WEBHOOK:=true}"
+validate_bool E2E_TEST_WEBHOOK
+
+: "${E2E_TEST_COMPONENTS:=true}"
+validate_bool E2E_TEST_COMPONENTS
+
+: "${E2E_TEST_SERVICES:=true}"
+validate_bool E2E_TEST_SERVICES
+
+: "${E2E_TEST_OPERATOR_NAMESPACE:=opendatahub-operators}"
+validate_namespace E2E_TEST_OPERATOR_NAMESPACE
+
+: "${E2E_TEST_APPLICATIONS_NAMESPACE:=opendatahub}"
+validate_namespace E2E_TEST_APPLICATIONS_NAMESPACE
+
+: "${E2E_TEST_WORKBENCHES_NAMESPACE:=opendatahub}"
+validate_namespace E2E_TEST_WORKBENCHES_NAMESPACE
+
+: "${E2E_TEST_DSC_MONITORING_NAMESPACE:=opendatahub}"
+validate_namespace E2E_TEST_DSC_MONITORING_NAMESPACE
+
+: "${E2E_TEST_FAIL_FAST_ON_ERROR:=false}"
+validate_bool E2E_TEST_FAIL_FAST_ON_ERROR
+
+: "${E2E_TEST_TAG:=All}"
+validate_tag E2E_TEST_TAG
+
+# Run gotestsum with the environment variables and any additional arguments
+exec gotestsum --junitfile-project-name odh-operator-e2e \
+  --junitfile results/xunit_report.xml --format testname --raw-command \
+  -- test2json -p e2e ./e2e-tests --test.v=test2json --test.parallel=8 \
+  --deletion-policy="$E2E_TEST_DELETION_POLICY" --clean-up-previous-resources="$E2E_TEST_CLEAN_UP_PREVIOUS_RESOURCES" \
+  --test-operator-controller="$E2E_TEST_OPERATOR_CONTROLLER" --test-operator-resilience="$E2E_TEST_OPERATOR_RESILIENCE" \
+  --test-operator-v2tov3upgrade="$E2E_TEST_OPERATOR_V2TOV3UPGRADE" --test-hardware-profile="$E2E_TEST_HARDWARE_PROFILE" \
+  --test-webhook="$E2E_TEST_WEBHOOK" --test-components="$E2E_TEST_COMPONENTS" --test-services="$E2E_TEST_SERVICES" \
+  --operator-namespace="$E2E_TEST_OPERATOR_NAMESPACE" --applications-namespace="$E2E_TEST_APPLICATIONS_NAMESPACE" \
+  --workbenches-namespace="$E2E_TEST_WORKBENCHES_NAMESPACE" --dsc-monitoring-namespace="$E2E_TEST_DSC_MONITORING_NAMESPACE" \
+  --fail-fast-on-error="$E2E_TEST_FAIL_FAST_ON_ERROR" --tag="$E2E_TEST_TAG" "$@"


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->
As part of https://issues.redhat.com/browse/RHOAIENG-50645, we need to support passing custom params to the podman run command to execute the tests inside the container, so we need to make this adaption to be able to pass the custom params.
<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [ ] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Enhanced end-to-end test execution with improved validation of configuration parameters and clearer error reporting during test initialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->