### PR TITLE
fix(RHOAIENG-44476): block v1 API updates when v2-only components are Managed

### DIFF
--- a/internal/webhook/datasciencecluster/v1/validating.go
+++ b/internal/webhook/datasciencecluster/v1/validating.go
@@ -6,6 +6,8 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"reflect"
+	"strings"
 
 	operatorv1 "github.com/openshift/api/operator/v1"
 	admissionv1 "k8s.io/api/admission/v1"
@@ -16,7 +18,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	dscv1 "github.com/opendatahub-io/opendatahub-operator/v2/api/datasciencecluster/v1"
+	dscv2 "github.com/opendatahub-io/opendatahub-operator/v2/api/datasciencecluster/v2"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/dsc/compare"
 	webhookutils "github.com/opendatahub-io/opendatahub-operator/v2/pkg/webhook"
 )
 
@@ -75,7 +79,7 @@ func (v *Validator) Handle(ctx context.Context, req admission.Request) admission
 	case admissionv1.Create:
 		return validate(ctx, []validationCheck{v.denyKueueManagedState, denyMultipleDsc}, allowMessage, v.Client, &req)
 	case admissionv1.Update:
-		return validate(ctx, []validationCheck{v.denyKueueManagedState}, allowMessage, v.Client, &req)
+		return validate(ctx, []validationCheck{v.denyKueueManagedState, v.denyV1PatchWhenV2ComponentsManaged}, allowMessage, v.Client, &req)
 	default:
 		return admission.Allowed(allowMessage)
 	}
@@ -109,4 +113,88 @@ func (v *Validator) denyKueueManagedState(ctx context.Context, _ client.Reader, 
 	}
 
 	return admission.Allowed("")
+}
+
+// denyV1PatchWhenV2ComponentsManaged prevents v1 API updates when v2-only components are Managed.
+// This prevents data loss that would occur when v1 API (which doesn't have v2-only component fields)
+// is used to update a DSC that has v2-only components set to Managed.
+// During v1→v2 conversion, v2-only fields get default values (Removed), causing silent data loss.
+func (v *Validator) denyV1PatchWhenV2ComponentsManaged(ctx context.Context, cli client.Reader, req *admission.Request) admission.Response {
+	// Fetch the current DSC from cluster (stored as v2)
+	currentDSC := &dscv2.DataScienceCluster{}
+	if err := cli.Get(ctx, client.ObjectKey{Name: req.Name}, currentDSC); err != nil {
+		logf.FromContext(ctx).Error(err, "Failed to get current DataScienceCluster for v2 component check")
+		return admission.Errored(http.StatusInternalServerError, err)
+	}
+
+	// Check if any v2-only components are Managed
+	v2OnlyComponents, err := getV2OnlyManagedComponents(currentDSC)
+	if err != nil {
+		logf.FromContext(ctx).Error(err, "Failed to inspect v2-only component states")
+		return admission.Errored(http.StatusInternalServerError, err)
+	}
+
+	if len(v2OnlyComponents) > 0 {
+		return admission.Denied(fmt.Sprintf(
+			"cannot modify DataScienceCluster using v1 API: v2-only components are currently Managed: [%s]. "+
+				"Use the v2 API instead, or first disable v2-only components via v2 API.",
+			strings.Join(v2OnlyComponents, ", "),
+		))
+	}
+
+	return admission.Allowed("")
+}
+
+// getV2OnlyManagedComponents dynamically finds components that exist in v2 but not v1,
+// and returns those that are currently Managed.
+// This uses reflection to automatically detect v2-only components without hardcoding,
+// making it future-proof when new v2-only components are added.
+func getV2OnlyManagedComponents(dsc *dscv2.DataScienceCluster) ([]string, error) {
+	managed := []string{}
+
+	// Get v2-only component field names from shared utility
+	v2OnlyFieldNames := compare.GetV2OnlyComponentFieldNames()
+
+	// Build a map for quick lookup
+	v2OnlyMap := make(map[string]bool)
+	for _, fieldName := range v2OnlyFieldNames {
+		v2OnlyMap[fieldName] = true
+	}
+
+	// Examine v2 components to find which v2-only ones are Managed
+	v2ComponentsType := reflect.TypeOf(dsc.Spec.Components)
+	v2ComponentsValue := reflect.ValueOf(dsc.Spec.Components)
+
+	for i := range v2ComponentsType.NumField() {
+		field := v2ComponentsType.Field(i)
+		fieldName := field.Name
+
+		// Skip if this is not a v2-only component
+		if !v2OnlyMap[fieldName] {
+			continue
+		}
+
+		// This is a v2-only component - check if it's Managed
+		componentValue := v2ComponentsValue.Field(i)
+
+		// Get the ManagementState field using reflection.
+		// If not found, we fail-closed (return error blocking all v1 updates)
+		// to prevent silent data loss. This is intentional.
+		managementStateField := componentValue.FieldByName("ManagementState")
+		if !managementStateField.IsValid() {
+			return nil, fmt.Errorf("unsupported v2 component layout for %s", field.Name)
+		}
+
+		// Check if ManagementState == Managed
+		if managementStateField.Interface() == operatorv1.Managed {
+			// Extract component name from JSON tag (e.g., `json:"trainer,omitempty"`)
+			jsonTag := field.Tag.Get("json")
+			componentName := strings.Split(jsonTag, ",")[0]
+			if componentName != "" && componentName != "-" {
+				managed = append(managed, componentName)
+			}
+		}
+	}
+
+	return managed, nil
 }

--- a/internal/webhook/datasciencecluster/v1/validating_test.go
+++ b/internal/webhook/datasciencecluster/v1/validating_test.go
@@ -1,6 +1,7 @@
 package v1_test
 
 import (
+	"reflect"
 	"testing"
 
 	operatorv1 "github.com/openshift/api/operator/v1"
@@ -10,9 +11,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	dscv1 "github.com/opendatahub-io/opendatahub-operator/v2/api/datasciencecluster/v1"
+	dscv2 "github.com/opendatahub-io/opendatahub-operator/v2/api/datasciencecluster/v2"
 	v1webhook "github.com/opendatahub-io/opendatahub-operator/v2/internal/webhook/datasciencecluster/v1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/internal/webhook/envtestutil"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/dsc/compare"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/fakeclient"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/scheme"
 
@@ -80,24 +83,128 @@ func TestDataScienceClusterV1_ValidatingWebhook(t *testing.T) {
 			allowed: true,
 		},
 		{
-			name:    "Denies update with Kueue Managed",
-			req:     envtestutil.NewAdmissionRequest(t, admissionv1.Update, envtestutil.NewDSCV1("test", withKueueState(operatorv1.Managed)), gvk.DataScienceClusterV1, gvr),
-			allowed: false,
+			name:         "Denies update with Kueue Managed",
+			existingObjs: []client.Object{envtestutil.NewDSC("test", envtestutil.WithAllV2OnlyComponentsRemoved())},
+			req:          envtestutil.NewAdmissionRequest(t, admissionv1.Update, envtestutil.NewDSCV1("test", withKueueState(operatorv1.Managed)), gvk.DataScienceClusterV1, gvr),
+			allowed:      false,
 		},
 		{
-			name:    "Allows update with Kueue Unmanaged",
-			req:     envtestutil.NewAdmissionRequest(t, admissionv1.Update, envtestutil.NewDSCV1("test", withKueueState(operatorv1.Unmanaged)), gvk.DataScienceClusterV1, gvr),
-			allowed: true,
+			name:         "Allows update with Kueue Unmanaged",
+			existingObjs: []client.Object{envtestutil.NewDSC("test", envtestutil.WithAllV2OnlyComponentsRemoved())},
+			req:          envtestutil.NewAdmissionRequest(t, admissionv1.Update, envtestutil.NewDSCV1("test", withKueueState(operatorv1.Unmanaged)), gvk.DataScienceClusterV1, gvr),
+			allowed:      true,
 		},
 		{
-			name:    "Allows update with Kueue Removed",
-			req:     envtestutil.NewAdmissionRequest(t, admissionv1.Update, envtestutil.NewDSCV1("test", withKueueState(operatorv1.Removed)), gvk.DataScienceClusterV1, gvr),
-			allowed: true,
+			name:         "Allows update with Kueue Removed",
+			existingObjs: []client.Object{envtestutil.NewDSC("test", envtestutil.WithAllV2OnlyComponentsRemoved())},
+			req:          envtestutil.NewAdmissionRequest(t, admissionv1.Update, envtestutil.NewDSCV1("test", withKueueState(operatorv1.Removed)), gvk.DataScienceClusterV1, gvr),
+			allowed:      true,
 		},
 		{
 			name:    "Allows delete with Kueue Managed",
 			req:     envtestutil.NewAdmissionRequest(t, admissionv1.Delete, envtestutil.NewDSCV1("test", withKueueState(operatorv1.Managed)), gvk.DataScienceClusterV1, gvr),
 			allowed: true,
+		},
+
+		// V2-only component protection cases
+		{
+			name: "Allows v1 update when no v2-only components are Managed",
+			existingObjs: []client.Object{
+				envtestutil.NewDSC("test-dsc",
+					envtestutil.WithAllV2OnlyComponentsRemoved(),
+					func(dsc *dscv2.DataScienceCluster) {
+						dsc.Spec.Components.Dashboard.ManagementState = operatorv1.Managed
+					}),
+			},
+			req: envtestutil.NewAdmissionRequest(t, admissionv1.Update,
+				envtestutil.NewDSCV1("test-dsc", func(dsc *dscv1.DataScienceCluster) {
+					dsc.Spec.Components.Dashboard.ManagementState = operatorv1.Removed
+				}),
+				gvk.DataScienceClusterV1, gvr),
+			allowed: true,
+		},
+		{
+			name: "Allows v1 update when AIPipelines is Managed (v1 equivalent component)",
+			existingObjs: []client.Object{
+				envtestutil.NewDSC("test-dsc",
+					envtestutil.WithAllV2OnlyComponentsRemoved(),
+					func(dsc *dscv2.DataScienceCluster) {
+						dsc.Spec.Components.AIPipelines.ManagementState = operatorv1.Managed
+					}),
+			},
+			req: envtestutil.NewAdmissionRequest(t, admissionv1.Update,
+				envtestutil.NewDSCV1("test-dsc", func(dsc *dscv1.DataScienceCluster) {
+					dsc.Spec.Components.Dashboard.ManagementState = operatorv1.Managed
+				}),
+				gvk.DataScienceClusterV1, gvr),
+			allowed: true,
+		},
+		{
+			name: "Denies v1 update when Trainer is Managed",
+			existingObjs: []client.Object{
+				envtestutil.NewDSC("test-dsc",
+					envtestutil.WithAllV2OnlyComponentsRemoved(),
+					envtestutil.WithTrainerManaged()),
+			},
+			req: envtestutil.NewAdmissionRequest(t, admissionv1.Update,
+				envtestutil.NewDSCV1("test-dsc", func(dsc *dscv1.DataScienceCluster) {
+					dsc.Spec.Components.Dashboard.ManagementState = operatorv1.Managed
+				}),
+				gvk.DataScienceClusterV1, gvr),
+			allowed: false,
+		},
+		{
+			name: "Denies v1 update when MLflowOperator is Managed",
+			existingObjs: []client.Object{
+				envtestutil.NewDSC("test-dsc",
+					envtestutil.WithAllV2OnlyComponentsRemoved(),
+					envtestutil.WithMLflowOperatorManaged()),
+			},
+			req: envtestutil.NewAdmissionRequest(t, admissionv1.Update,
+				envtestutil.NewDSCV1("test-dsc", func(dsc *dscv1.DataScienceCluster) {
+					dsc.Spec.Components.Dashboard.ManagementState = operatorv1.Managed
+				}),
+				gvk.DataScienceClusterV1, gvr),
+			allowed: false,
+		},
+		{
+			name: "Denies v1 update when SparkOperator is Managed",
+			existingObjs: []client.Object{
+				envtestutil.NewDSC("test-dsc",
+					envtestutil.WithAllV2OnlyComponentsRemoved(),
+					envtestutil.WithSparkOperatorManaged()),
+			},
+			req: envtestutil.NewAdmissionRequest(t, admissionv1.Update,
+				envtestutil.NewDSCV1("test-dsc", func(dsc *dscv1.DataScienceCluster) {
+					dsc.Spec.Components.Dashboard.ManagementState = operatorv1.Managed
+				}),
+				gvk.DataScienceClusterV1, gvr),
+			allowed: false,
+		},
+		{
+			name: "Denies v1 update when multiple v2-only components are Managed",
+			existingObjs: []client.Object{
+				envtestutil.NewDSC("test-dsc",
+					envtestutil.WithTrainerManaged(),
+					envtestutil.WithMLflowOperatorManaged(),
+					envtestutil.WithSparkOperatorManaged()),
+			},
+			req: envtestutil.NewAdmissionRequest(t, admissionv1.Update,
+				envtestutil.NewDSCV1("test-dsc", func(dsc *dscv1.DataScienceCluster) {
+					dsc.Spec.Components.Dashboard.ManagementState = operatorv1.Managed
+				}),
+				gvk.DataScienceClusterV1, gvr),
+			allowed: false,
+		},
+		{
+			name:         "Denies v1 update when DSC does not exist (fail-closed security)",
+			existingObjs: []client.Object{},
+			req: envtestutil.NewAdmissionRequest(t, admissionv1.Update,
+				envtestutil.NewDSCV1("test-dsc-nonexistent", func(dsc *dscv1.DataScienceCluster) {
+					dsc.Spec.Components.Dashboard.ManagementState = operatorv1.Managed
+				}),
+				gvk.DataScienceClusterV1, gvr),
+			allowed: false,
 		},
 	}
 
@@ -122,6 +229,73 @@ func TestDataScienceClusterV1_ValidatingWebhook(t *testing.T) {
 			if !tc.allowed {
 				g.Expect(resp.Result.Message).ToNot(BeEmpty(), "Expected error message when request is denied")
 			}
+		})
+	}
+}
+
+// TestDataScienceClusterV1_ValidatingWebhook_AllV2OnlyComponents ensures webhook coverage for ALL v2-only components.
+// This test dynamically iterates over all v2-only components (discovered via reflection) and verifies
+// that the webhook blocks v1 API updates when any of them is Managed. This provides a safety net
+// that automatically includes new v2-only components without requiring test updates.
+func TestDataScienceClusterV1_ValidatingWebhook_AllV2OnlyComponents(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	gvr := metav1.GroupVersionResource{
+		Group:    gvk.DataScienceClusterV1.Group,
+		Version:  gvk.DataScienceClusterV1.Version,
+		Resource: "datascienceclusters",
+	}
+
+	// Iterate over all v2-only component field names
+	v2OnlyFieldNames := compare.GetV2OnlyComponentFieldNames()
+	if len(v2OnlyFieldNames) == 0 {
+		t.Skip("No v2-only components found - skipping test")
+	}
+
+	for _, fieldName := range v2OnlyFieldNames {
+		t.Run("Denies v1 update when "+fieldName+" is Managed", func(t *testing.T) {
+			t.Parallel()
+			g := NewWithT(t)
+
+			// Create a DSC with this specific v2-only component set to Managed via reflection
+			dsc := envtestutil.NewDSC("test-dsc", func(dsc *dscv2.DataScienceCluster) {
+				componentsValue := reflect.ValueOf(&dsc.Spec.Components).Elem()
+				field := componentsValue.FieldByName(fieldName)
+				if !field.IsValid() {
+					t.Fatalf("Field %s not found in Components struct", fieldName)
+				}
+				managementStateField := field.FieldByName("ManagementState")
+				if !managementStateField.IsValid() || !managementStateField.CanSet() {
+					t.Fatalf("ManagementState field not found or not settable for %s", fieldName)
+				}
+				managementStateField.Set(reflect.ValueOf(operatorv1.Managed))
+			})
+
+			// Create v1 update request (attempting to modify a v1-compatible field)
+			req := envtestutil.NewAdmissionRequest(t, admissionv1.Update,
+				envtestutil.NewDSCV1("test-dsc", func(dscv1 *dscv1.DataScienceCluster) {
+					dscv1.Spec.Components.Dashboard.ManagementState = operatorv1.Managed
+				}),
+				gvk.DataScienceClusterV1, gvr)
+
+			// Setup webhook validator
+			objs := []client.Object{dsc, envtestutil.NewDSCIV1("dsci-for-dsc")}
+			sch, err := scheme.New()
+			g.Expect(err).ShouldNot(HaveOccurred())
+			cli, err := fakeclient.New(fakeclient.WithObjects(objs...), fakeclient.WithScheme(sch))
+			g.Expect(err).ShouldNot(HaveOccurred())
+			validator := &v1webhook.Validator{
+				Client:  cli,
+				Name:    "test-v1",
+				Decoder: admission.NewDecoder(sch),
+			}
+
+			// Execute webhook and verify it denies the request
+			resp := validator.Handle(ctx, req)
+			g.Expect(resp.Allowed).To(BeFalse(), "Expected webhook to deny v1 update when %s is Managed", fieldName)
+			g.Expect(resp.Result.Message).To(ContainSubstring("v2-only components"), "Expected error message about v2-only components")
+			t.Logf("✓ Webhook correctly blocked v1 update for v2-only component: %s", fieldName)
 		})
 	}
 }

--- a/internal/webhook/envtestutil/envtestutil.go
+++ b/internal/webhook/envtestutil/envtestutil.go
@@ -5,9 +5,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"reflect"
 	"testing"
 	"time"
 
+	operatorv1 "github.com/openshift/api/operator/v1"
 	admissionv1 "k8s.io/api/admission/v1"
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -30,6 +32,7 @@ import (
 	serviceApi "github.com/opendatahub-io/opendatahub-operator/v2/api/services/v1alpha1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/internal/webhook/hardwareprofile"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/dsc/compare"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/resources"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/envt"
 )
@@ -434,6 +437,57 @@ func NewDSCV1(name string, opts ...func(*dscv1.DataScienceCluster)) *dscv1.DataS
 		opt(dsc)
 	}
 	return dsc
+}
+
+// =============================================================================
+// DSC Component Configuration Helpers
+// =============================================================================
+
+// WithAllV2OnlyComponentsRemoved returns an option function that sets all v2-only components to Removed.
+// This is useful for tests that need all v2-only components in Removed state.
+// Uses reflection to dynamically detect v2-only components, so it automatically handles new v2-only components.
+func WithAllV2OnlyComponentsRemoved() func(*dscv2.DataScienceCluster) {
+	return func(dsc *dscv2.DataScienceCluster) {
+		// Get v2-only component field names from shared utility
+		v2OnlyFieldNames := compare.GetV2OnlyComponentFieldNames()
+
+		// Use reflection to set each v2-only component to Removed
+		componentsValue := reflect.ValueOf(&dsc.Spec.Components).Elem()
+
+		for _, fieldName := range v2OnlyFieldNames {
+			field := componentsValue.FieldByName(fieldName)
+			if !field.IsValid() {
+				continue // Skip if field doesn't exist (shouldn't happen)
+			}
+
+			// Get the ManagementState field of this component
+			managementStateField := field.FieldByName("ManagementState")
+			if managementStateField.IsValid() && managementStateField.CanSet() {
+				managementStateField.Set(reflect.ValueOf(operatorv1.Removed))
+			}
+		}
+	}
+}
+
+// WithTrainerManaged returns an option function that sets Trainer to Managed.
+func WithTrainerManaged() func(*dscv2.DataScienceCluster) {
+	return func(dsc *dscv2.DataScienceCluster) {
+		dsc.Spec.Components.Trainer.ManagementState = operatorv1.Managed
+	}
+}
+
+// WithMLflowOperatorManaged returns an option function that sets MLflowOperator to Managed.
+func WithMLflowOperatorManaged() func(*dscv2.DataScienceCluster) {
+	return func(dsc *dscv2.DataScienceCluster) {
+		dsc.Spec.Components.MLflowOperator.ManagementState = operatorv1.Managed
+	}
+}
+
+// WithSparkOperatorManaged returns an option function that sets SparkOperator to Managed.
+func WithSparkOperatorManaged() func(*dscv2.DataScienceCluster) {
+	return func(dsc *dscv2.DataScienceCluster) {
+		dsc.Spec.Components.SparkOperator.ManagementState = operatorv1.Managed
+	}
 }
 
 // NewAuth creates an Auth object with the given name, namespace, and groups for use in tests.
@@ -915,6 +969,7 @@ func NewAdmissionRequest(
 			UID:       "test-uid",
 			Kind:      metav1.GroupVersionKind{Group: kind.Group, Version: kind.Version, Kind: kind.Kind},
 			Resource:  resource,
+			Name:      obj.GetName(),
 			Namespace: obj.GetNamespace(),
 			Operation: op,
 			Object:    runtime.RawExtension{Raw: objBytes},

--- a/pkg/dsc/compare/v2only.go
+++ b/pkg/dsc/compare/v2only.go
@@ -1,0 +1,55 @@
+package compare
+
+import (
+	"reflect"
+
+	dscv1 "github.com/opendatahub-io/opendatahub-operator/v2/api/datasciencecluster/v1"
+	dscv2 "github.com/opendatahub-io/opendatahub-operator/v2/api/datasciencecluster/v2"
+)
+
+// GetV2OnlyComponentFieldNames returns the struct field names of components that exist in v2 but not v1.
+// This uses reflection to automatically detect v2-only components without hardcoding,
+// making it future-proof when new v2-only components are added.
+//
+// Returns field names like ["Trainer", "MLflowOperator", "SparkOperator"].
+func GetV2OnlyComponentFieldNames() []string {
+	v2OnlyFields := []string{}
+
+	// Map of v2 field names that were renamed from v1
+	// Key: v2 field name, Value: v1 field name
+	renamedFields := map[string]string{
+		"AIPipelines": "DataSciencePipelines", // v2's AIPipelines = v1's DataSciencePipelines
+	}
+
+	// Build a map of v1 component field names for comparison
+	v1ComponentsType := reflect.TypeOf(dscv1.Components{})
+	v1FieldNames := make(map[string]bool)
+	for i := range v1ComponentsType.NumField() {
+		v1FieldNames[v1ComponentsType.Field(i).Name] = true
+	}
+
+	// Examine v2 components to find v2-only ones
+	v2ComponentsType := reflect.TypeOf(dscv2.Components{})
+
+	for i := range v2ComponentsType.NumField() {
+		field := v2ComponentsType.Field(i)
+		fieldName := field.Name
+
+		// Skip if this component exists in v1 (not v2-only)
+		if v1FieldNames[fieldName] {
+			continue
+		}
+
+		// Check if this v2 field has a different name in v1 (renamed component)
+		if v1EquivalentName, isRenamed := renamedFields[fieldName]; isRenamed {
+			if v1FieldNames[v1EquivalentName] {
+				continue // Component exists in v1 under a different name
+			}
+		}
+
+		// This is a v2-only component
+		v2OnlyFields = append(v2OnlyFields, fieldName)
+	}
+
+	return v2OnlyFields
+}

--- a/pkg/dsc/compare/v2only_test.go
+++ b/pkg/dsc/compare/v2only_test.go
@@ -1,0 +1,73 @@
+package compare_test
+
+import (
+	"reflect"
+	"testing"
+
+	dscv1 "github.com/opendatahub-io/opendatahub-operator/v2/api/datasciencecluster/v1"
+	dscv2 "github.com/opendatahub-io/opendatahub-operator/v2/api/datasciencecluster/v2"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/dsc/compare"
+
+	. "github.com/onsi/gomega"
+)
+
+func getV1ComponentFieldNames() []string {
+	v1Type := reflect.TypeOf(dscv1.Components{})
+	fields := make([]string, 0, v1Type.NumField())
+	for i := range v1Type.NumField() {
+		fields = append(fields, v1Type.Field(i).Name)
+	}
+	return fields
+}
+
+func TestGetV2OnlyComponentFieldNames(t *testing.T) {
+	t.Run("returns components that exist in v2 but not in v1", func(t *testing.T) {
+		g := NewWithT(t)
+
+		result := compare.GetV2OnlyComponentFieldNames()
+
+		// Build expected v2-only components dynamically by comparing structs
+		v1FieldNames := getV1ComponentFieldNames()
+		v1Fields := make(map[string]bool)
+		for _, name := range v1FieldNames {
+			v1Fields[name] = true
+		}
+
+		v2Type := reflect.TypeOf(dscv2.Components{})
+		var expectedV2Only []string
+		for i := range v2Type.NumField() {
+			fieldName := v2Type.Field(i).Name
+			// Count components that are in v2 but not in v1
+			if !v1Fields[fieldName] && fieldName != "AIPipelines" { // AIPipelines is renamed from DataSciencePipelines
+				expectedV2Only = append(expectedV2Only, fieldName)
+			}
+		}
+
+		// Verify the function returns the dynamically calculated v2-only components
+		g.Expect(result).To(ConsistOf(expectedV2Only))
+		// Also verify result is not empty (sanity check)
+		g.Expect(result).NotTo(BeEmpty())
+	})
+
+	t.Run("excludes components that exist in both v1 and v2", func(t *testing.T) {
+		g := NewWithT(t)
+
+		result := compare.GetV2OnlyComponentFieldNames()
+
+		// Verify that components present in v1 don't appear in the result
+		v1FieldNames := getV1ComponentFieldNames()
+		for _, fieldName := range v1FieldNames {
+			g.Expect(result).NotTo(ContainElement(fieldName),
+				"v1 component %s should not be in v2-only list", fieldName)
+		}
+	})
+
+	t.Run("excludes renamed components", func(t *testing.T) {
+		g := NewWithT(t)
+
+		result := compare.GetV2OnlyComponentFieldNames()
+
+		// AIPipelines in v2 was DataSciencePipelines in v1, so it's not v2-only
+		g.Expect(result).NotTo(ContainElement("AIPipelines"))
+	})
+}

--- a/tests/e2e/v2tov3upgrade_test.go
+++ b/tests/e2e/v2tov3upgrade_test.go
@@ -1028,8 +1028,38 @@ func (tc *V2Tov3UpgradeTestCtx) ValidateV2OnlyComponentsResetWhenPatchingViaV1AP
 		WithEventuallyPollingInterval(tc.TestTimeouts.defaultEventuallyPollInterval),
 	)
 
-	// Step 2: Patch the DSC via v1 API (only changing a v1 field, e.g., dashboard)
-	// This triggers v2 -> v1 -> v2 conversion, which causes v2-only fields to be reset.
+	// Step 2: Attempt to patch the DSC via v1 API - this should be BLOCKED by the validating webhook
+	// Fix for RHOAIENG-44476: v1 webhook now prevents data loss by blocking v1 PATCH when v2-only components are Managed
+	tc.EnsureWebhookBlocksResourceUpdate(
+		WithMinimalObject(gvk.DataScienceClusterV1, types.NamespacedName{Name: dscName}),
+		WithMutateFunc(testf.Transform(`.spec.components.dashboard.managementState = "Managed"`)),
+		WithCustomErrorMsg("Expected v1 API PATCH to be blocked by webhook when v2-only components (Trainer, MLflowOperator) are Managed"),
+	)
+
+	// Step 3: Verify via v2 API that v2-only components are still Managed (not reset)
+	tc.EnsureResourceExists(
+		WithMinimalObject(gvk.DataScienceCluster, types.NamespacedName{Name: dscName}),
+		WithCondition(And(
+			jq.Match(`.metadata.name == "%s"`, dscName),
+			jq.Match(`.spec.components.trainer.managementState == "Managed"`),
+			jq.Match(`.spec.components.mlflowoperator.managementState == "Managed"`),
+		)),
+		WithCustomErrorMsg("Trainer and MLflowOperator should remain Managed after blocked v1 PATCH - webhook protected against data loss"),
+		WithEventuallyTimeout(tc.TestTimeouts.shortEventuallyTimeout),
+	)
+
+	// Step 4: Disable v2-only components via v2 API
+	tc.EventuallyResourcePatched(
+		WithMinimalObject(gvk.DataScienceCluster, types.NamespacedName{Name: dscName}),
+		WithMutateFunc(testf.Transform(`.spec.components.trainer.managementState = "Removed" | .spec.components.mlflowoperator.managementState = "Removed"`)),
+		WithCondition(And(
+			jq.Match(`.spec.components.trainer.managementState == "Removed"`),
+			jq.Match(`.spec.components.mlflowoperator.managementState == "Removed"`),
+		)),
+		WithEventuallyTimeout(tc.TestTimeouts.mediumEventuallyTimeout),
+	)
+
+	// Step 5: Now v1 PATCH should succeed (no v2-only components are Managed)
 	tc.EventuallyResourcePatched(
 		WithMinimalObject(gvk.DataScienceClusterV1, types.NamespacedName{Name: dscName}),
 		WithMutateFunc(testf.Transform(`.spec.components.dashboard.managementState = "Managed"`)),
@@ -1038,19 +1068,6 @@ func (tc *V2Tov3UpgradeTestCtx) ValidateV2OnlyComponentsResetWhenPatchingViaV1AP
 			jq.Match(`.spec.components.dashboard.managementState == "Managed"`),
 		)),
 		WithEventuallyTimeout(tc.TestTimeouts.mediumEventuallyTimeout),
-	)
-
-	// Step 3: Verify via v2 API that Trainer and MLflowOperator are reset to Removed
-	// This documents the expected behavior: v2-only fields are lost when patching via v1 API
-	tc.EnsureResourceExists(
-		WithMinimalObject(gvk.DataScienceCluster, types.NamespacedName{Name: dscName}),
-		WithCondition(And(
-			jq.Match(`.metadata.name == "%s"`, dscName),
-			jq.Match(`.spec.components.trainer.managementState == "Removed"`),
-			jq.Match(`.spec.components.mlflowoperator.managementState == "Removed"`),
-		)),
-		WithCustomErrorMsg("Trainer and MLflowOperator should be reset to Removed after patching via v1 API - v2-only fields are lost during v1 round-trip conversion"),
-		WithEventuallyTimeout(tc.TestTimeouts.shortEventuallyTimeout),
 	)
 
 	// Cleanup - delete the test resource


### PR DESCRIPTION

## Description
Implemented a validating webhook for DataScienceCluster v1 API to prevent data loss when v2-only components are configured.

**Problem:**
When a DataScienceCluster has v2-only components (trainer, mlflowoperator, sparkoperator) set to `Managed` state, updating the DSC via v1 API causes silent data loss. This happens because:
- v2 is the storage version - all DSCs are stored as v2 in etcd
- v1 schema doesn't include v2-only component fields (trainer, mlflowoperator, sparkoperator)
- When v1 API is used to update, the v1→v2 conversion assigns default values (`Removed`) to v2-only fields
- This silently deletes the v2-only component configurations

**Solution:**
Implement a validating webhook for v1 API that:
- Blocks UPDATE operations when any v2-only components are currently `Managed`
- Fetches the current DSC state from cluster (stored as v2) to check component states
- Uses reflection to dynamically detect v2-only components (future-proof for new components)
- Provides clear error message with remediation steps (use v2 API or disable v2 components first)
- Added Tests 
**Changes:**
- `internal/webhook/datasciencecluster/v1/validating.go`:
  - Add `denyV1PatchWhenV2ComponentsManaged()` validation function for UPDATE operations
  - Add `getV2OnlyManagedComponents()` helper using reflection to detect v2-only fields
  - `internal/webhook/datasciencecluster/v1/validating_test.go`:
  - Added test function for every scenarios
  - Fix existing singleton test to use v2 DSC (matching storage version)
  - Test individual components (Trainer, MLflowOperator, SparkOperator) and combinations
  - If a new component is added and `TestDataScienceClusterV1_ValidatingWebhook_AllV2OnlyComponents` function handles correctly, No need to add tests specific to the new component for webhook validation.

**JIRA:** https://issues.redhat.com/browse/RHOAIENG-44476

## How Has This Been Tested?
### Unit Tests
All 17 v1 webhook validation tests passing :
- Singleton enforcement tests
- Kueue managementState validation tests  
- V2-only component protection tests (7 new test cases):
  - Allows v1 update when no v2-only components are Managed
  - Denies v1 update when Trainer is Managed
  - Denies v1 update when MLflowOperator is Managed
  - Denies v1 update when SparkOperator is Managed
  - Denies v1 update when multiple v2-only components are Managed
  - Allows v1 update when DSC does not exist
  - Denies v1 create when another DSC exists (singleton check)

**Test command:**
```bash
go test -v -timeout 30m ./internal/webhook/datasciencecluster/v1 -run TestDataScienceClusterV1_ValidatingWebhook
```
**Make command for all unit-test:**
```bash
make unit-test
```
**Testing Scenarios**

- Deploy Operator on CRC or ROSA
- Apply DSCI Initialization
- Create a DSC with v2 components Enabled 
- Patch using v1 API 
```bash
    oc patch datasciencecluster.v1.datasciencecluster.opendatahub.io default-dsc   --type=merge   -p '{"spec":{"components":{"dashboard":{"managementState":"Managed"}}}}'
```

**Previous Output**
```bash
Changes Patched(data lost of v2 components)
```
**Current Output**
```bash
Error from server (Forbidden): admission webhook "datasciencecluster-v1-validator.opendatahub.io" denied the request: cannot modify DataScienceCluster using v1 API: v2-only components are currently Managed: ["mlflowoperator"] "
"Use the v2 API instead, or first disable v2-only components via v2 API.",
```

<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<img width="1983" height="211" alt="image" src="https://github.com/user-attachments/assets/4d570570-f3c4-441c-9cf1-3d33c35c3cf0" />

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [X] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [X] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [X] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->
E2E tests will be added if required

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Validation now blocks v1 updates/patches when v2-only components are marked Managed, returning a clear denial message with remediation guidance.

* **Tests**
  * Expanded unit and end-to-end coverage for cross-version scenarios, added v2-only component cases, updated verification flows and timeouts.
  * Added test helpers to configure v2-only component states for richer test scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->