### PR TITLE
KServe component should be installed with correct manifests for xKS

### DIFF
--- a/internal/controller/components/kserve/kserve_controller.go
+++ b/internal/controller/components/kserve/kserve_controller.go
@@ -20,8 +20,6 @@ import (
 	"context"
 	"strings"
 
-	templatev1 "github.com/openshift/api/template/v1"
-	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -63,17 +61,18 @@ func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.
 		Owns(&rbacv1.RoleBinding{}).
 		Owns(&rbacv1.ClusterRole{}).
 		Owns(&rbacv1.ClusterRoleBinding{}).
-		// The ovms template gets a new resourceVersion periodically without any other
-		// changes. The compareHashPredicate ensures that we don't needlessly enqueue
-		// requests if there are no changes that we don't care about.
-		Owns(&templatev1.Template{}, reconciler.WithPredicates(hash.Updated())).
 		Owns(&networkingv1.NetworkPolicy{}).
-		Owns(&monitoringv1.ServiceMonitor{}).
 		Owns(&admissionregistrationv1.MutatingWebhookConfiguration{}).
 		Owns(&admissionregistrationv1.ValidatingWebhookConfiguration{}).
 		Owns(&admissionregistrationv1.ValidatingAdmissionPolicy{}).
 		Owns(&admissionregistrationv1.ValidatingAdmissionPolicyBinding{}).
 		Owns(&appsv1.Deployment{}, reconciler.WithPredicates(resources.NewDeploymentPredicate())).
+
+		// The ovms template gets a new resourceVersion periodically without any other
+		// changes. The compareHashPredicate ensures that we don't needlessly enqueue
+		// requests if there are no changes that we don't care about.
+		OwnsGVK(gvk.OpenshiftTemplate, reconciler.WithPredicates(hash.Updated()), reconciler.Dynamic(reconciler.ClusterIsOpenShift())).
+		OwnsGVK(gvk.CoreosServiceMonitor, reconciler.Dynamic(reconciler.CrdExists(gvk.CoreosServiceMonitor))).
 
 		// operands - dynamically owned
 		OwnsGVK(gvk.InferencePoolV1alpha2, reconciler.Dynamic(reconciler.CrdExists(gvk.InferencePoolV1alpha2))).

--- a/internal/controller/components/kserve/kserve_controller_actions.go
+++ b/internal/controller/components/kserve/kserve_controller_actions.go
@@ -32,8 +32,13 @@ const (
 )
 
 func initialize(_ context.Context, rr *odhtypes.ReconciliationRequest) error { //nolint:unparam
+	sourcePath := kserveManifestSourcePath
+	if cluster.GetClusterInfo().Type == cluster.ClusterTypeKubernetes {
+		sourcePath = kserveManifestSourcePathXKS
+	}
+
 	rr.Manifests = []odhtypes.ManifestInfo{
-		kserveManifestInfo(kserveManifestSourcePath),
+		kserveManifestInfo(sourcePath),
 		{
 			Path:       odhdeploy.DefaultManifestPath,
 			ContextDir: "connectionAPI",

--- a/internal/controller/components/kserve/kserve_controller_actions_test.go
+++ b/internal/controller/components/kserve/kserve_controller_actions_test.go
@@ -30,6 +30,44 @@ import (
 	. "github.com/onsi/gomega"
 )
 
+func TestInitialize(t *testing.T) {
+	tests := []struct {
+		name               string
+		clusterType        string
+		expectedSourcePath string
+	}{
+		{
+			name:               "OpenShift cluster uses default ODH manifest source path",
+			clusterType:        cluster.ClusterTypeOpenShift,
+			expectedSourcePath: kserveManifestSourcePath,
+		},
+		{
+			name:               "Kubernetes cluster uses xKS manifest source path",
+			clusterType:        cluster.ClusterTypeKubernetes,
+			expectedSourcePath: kserveManifestSourcePathXKS,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			ctx := t.Context()
+
+			cluster.SetClusterInfo(cluster.ClusterInfo{Type: tt.clusterType})
+			t.Cleanup(func() { cluster.SetClusterInfo(cluster.ClusterInfo{}) })
+
+			rr := &odhtypes.ReconciliationRequest{}
+
+			err := initialize(ctx, rr)
+			g.Expect(err).ShouldNot(HaveOccurred())
+			g.Expect(rr.Manifests).Should(HaveLen(2))
+			g.Expect(rr.Manifests[0].SourcePath).Should(Equal(tt.expectedSourcePath))
+			g.Expect(rr.Manifests[0].ContextDir).Should(Equal(componentName))
+			g.Expect(rr.Manifests[1].ContextDir).Should(Equal("connectionAPI"))
+		})
+	}
+}
+
 func TestCustomizeKserveConfigMap(t *testing.T) {
 	g := NewWithT(t)
 	ctx := t.Context()

--- a/pkg/cluster/gvk/gvk.go
+++ b/pkg/cluster/gvk/gvk.go
@@ -682,6 +682,12 @@ var (
 		Kind:    "Instrumentation",
 	}
 
+	OpenshiftTemplate = schema.GroupVersionKind{
+		Group:   "template.openshift.io",
+		Version: "v1",
+		Kind:    "Template",
+	}
+
 	ServiceMonitor = schema.GroupVersionKind{
 		Group:   "monitoring.rhobs",
 		Version: "v1",

--- a/pkg/controller/reconciler/reconciler_support.go
+++ b/pkg/controller/reconciler/reconciler_support.go
@@ -75,7 +75,7 @@ func Dynamic(predicates ...DynamicPredicate) WatchOpts {
 	}
 }
 
-// crdExists is a DynamicPredicate that cheks if a given crd identified by its gvk exists.
+// crdExists is a DynamicPredicate that checks if a given crd identified by its gvk exists.
 func CrdExists(crdGvk schema.GroupVersionKind) DynamicPredicate {
 	return func(ctx context.Context, request *types.ReconciliationRequest) bool {
 		if hasCrd, err := cluster.HasCRD(ctx, request.Client, crdGvk); err != nil {
@@ -83,6 +83,14 @@ func CrdExists(crdGvk schema.GroupVersionKind) DynamicPredicate {
 		} else {
 			return hasCrd
 		}
+	}
+}
+
+// ClusterIsOpenShift is a DynamicPredicate that returns true when the operator
+// is running on an OpenShift cluster.
+func ClusterIsOpenShift() DynamicPredicate {
+	return func(_ context.Context, _ *types.ReconciliationRequest) bool {
+		return cluster.GetClusterInfo().Type == cluster.ClusterTypeOpenShift
 	}
 }
 


### PR DESCRIPTION
## Description
Updates KServe controller resource ownerships/watches based on platform.

JIRA ref: [RHOAIENG-49689](https://issues.redhat.com/browse/RHOAIENG-49689)

Other relevant changes (e.g. xKS platform const, xKS manifest injection for KServe) were already introduced in past PRs

## How Has This Been Tested?
So far, ran the operator against Kind cluster, with DSC, DSCI and components disabled (except KServe) to see if the controller is running and is not failing on errors related to missing OpenShift-specific resources

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
xKS-related changes are not covered by e2e yet at this phase, shouldn't affect existing operator logic


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Platform-aware resource management: template and monitoring resources are now conditionally managed based on platform (OpenShift) or CRD availability; deployment handling unchanged.
  * Platform-based manifest selection: manifest source path now varies by platform to pick appropriate manifests.

* **Tests**
  * Added unit tests verifying manifest source selection and initialization behavior across platforms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->