### PR TITLE
splitted tier tests into tier1, tier2 and tier3

### DIFF
--- a/tests/e2e/cfmap_deletion_test.go
+++ b/tests/e2e/cfmap_deletion_test.go
@@ -58,7 +58,7 @@ func cfgMapDeletionTestSuite(t *testing.T) {
 func (tc *CfgMapDeletionTestCtx) ValidateDSCDeletionUsingConfigMap(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, Tier1)
+	skipUnless(t, Tier3)
 
 	// Create or update the deletion config map
 	enableDeletion := "false"
@@ -89,7 +89,7 @@ func (tc *CfgMapDeletionTestCtx) ValidateDSCDeletionUsingConfigMap(t *testing.T)
 func (tc *CfgMapDeletionTestCtx) ValidateOwnedNamespacesAllExist(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, Tier1)
+	skipUnless(t, Tier3)
 
 	// Ensure namespaces with the owned namespace label exist
 	tc.EnsureResourcesExist(

--- a/tests/e2e/controller_test.go
+++ b/tests/e2e/controller_test.go
@@ -404,7 +404,11 @@ func TestMain(m *testing.M) {
 		"Specify when to delete DataScienceCluster, DSCInitialization, and controllers. Options: always, on-failure, never.")
 	checkEnvVarBindingError(viper.BindEnv("deletion-policy", viper.GetEnvPrefix()+"_DELETION_POLICY"))
 
-	pflag.String("tag", "All", "Tag to run tests for. Options: All, Smoke, Tier1")
+	tagNames := make([]string, 0, len(allowedTags))
+	for _, tag := range allowedTags {
+		tagNames = append(tagNames, string(tag))
+	}
+	pflag.String("tag", "All", "Tag to run tests for. Options: "+strings.Join(tagNames, ", "))
 	checkEnvVarBindingError(viper.BindEnv("tag", viper.GetEnvPrefix()+"_TAG"))
 
 	pflag.Bool("fail-fast-on-error", true, "fail fast on error")

--- a/tests/e2e/creation_test.go
+++ b/tests/e2e/creation_test.go
@@ -35,6 +35,9 @@ type DSCTestCtx struct {
 func dscManagementTestSuite(t *testing.T) {
 	t.Helper()
 
+	// disruptive tests are only supported on tier3 clusters
+	skipUnless(t, Tier3)
+
 	// Initialize the test context.
 	tc, err := NewTestContext(t)
 	require.NoError(t, err, "Failed to initialize test context")
@@ -106,8 +109,6 @@ func dscWebhookTestSuite(t *testing.T) {
 func (tc *DSCTestCtx) ValidateOperatorsInstallation(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, Smoke)
-
 	// Define operators to be installed.
 	operators := []Operator{
 		{nn: types.NamespacedName{Name: certManagerOpName, Namespace: certManagerOpNamespace}, skipOperatorGroup: false, globalOperatorGroup: true, channel: certManagerOpChannel},
@@ -123,8 +124,6 @@ func (tc *DSCTestCtx) ValidateOperatorsInstallation(t *testing.T) {
 func (tc *DSCTestCtx) ValidateResourcesCreation(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, Smoke)
-
 	tc.EventuallyResourceCreatedOrUpdated(
 		WithObjectToCreate(CreateJobSetOperator()),
 		WithCondition(jq.Match(`.status.conditions[] | select(.type == "Available") | .status == "True"`)),
@@ -135,8 +134,6 @@ func (tc *DSCTestCtx) ValidateResourcesCreation(t *testing.T) {
 // ValidateDSCICreation validates the creation of a DSCInitialization.
 func (tc *DSCTestCtx) ValidateDSCICreation(t *testing.T) {
 	t.Helper()
-
-	skipUnless(t, Smoke)
 
 	tc.EventuallyResourceCreatedOrUpdated(
 		WithObjectToCreate(CreateDSCI(tc.DSCInitializationNamespacedName.Name, tc.AppsNamespace, tc.MonitoringNamespace)),
@@ -152,8 +149,6 @@ func (tc *DSCTestCtx) ValidateDSCICreation(t *testing.T) {
 // ValidateDSCCreation validates the creation of a DataScienceCluster.
 func (tc *DSCTestCtx) ValidateDSCCreation(t *testing.T) {
 	t.Helper()
-
-	skipUnless(t, Smoke)
 
 	tc.EventuallyResourceCreatedOrUpdated(
 		WithObjectToCreate(CreateDSC(tc.DataScienceClusterNamespacedName.Name, tc.WorkbenchesNamespace)),

--- a/tests/e2e/deletion_test.go
+++ b/tests/e2e/deletion_test.go
@@ -39,7 +39,7 @@ func deletionTestSuite(t *testing.T) {
 func (tc *DeletionTestCtx) TestDSCDeletion(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, Tier1)
+	skipUnless(t, Tier3)
 
 	// Delete the DataScienceCluster instance
 	tc.DeleteResource(WithMinimalObject(gvk.DataScienceCluster, tc.DataScienceClusterNamespacedName))
@@ -49,7 +49,7 @@ func (tc *DeletionTestCtx) TestDSCDeletion(t *testing.T) {
 func (tc *DeletionTestCtx) TestDSCIDeletion(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, Tier1)
+	skipUnless(t, Tier3)
 
 	// Delete the DSCInitialization instance
 	tc.DeleteResource(WithMinimalObject(gvk.DSCInitialization, tc.DSCInitializationNamespacedName))

--- a/tests/e2e/monitoring_test.go
+++ b/tests/e2e/monitoring_test.go
@@ -74,6 +74,9 @@ type MonitoringTestCtx struct {
 func monitoringTestSuite(t *testing.T) {
 	t.Helper()
 
+	// The whole monitoring test-suite is part of Tier2 tests
+	skipUnless(t, Tier2)
+
 	// Initialize the test context.
 	tc, err := NewTestContext(t)
 	require.NoError(t, err)
@@ -150,8 +153,6 @@ func monitoringTestSuite(t *testing.T) {
 func (tc *MonitoringTestCtx) ValidateMonitoringOperatorsInstallation(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, Tier1)
-
 	// Define operators to be installed.
 	operators := []Operator{
 		{nn: types.NamespacedName{Name: observabilityOpName, Namespace: observabilityOpNamespace}, skipOperatorGroup: false, globalOperatorGroup: true, channel: defaultOperatorChannel},
@@ -165,8 +166,6 @@ func (tc *MonitoringTestCtx) ValidateMonitoringOperatorsInstallation(t *testing.
 // ValidateMonitoringCRCreation ensures that exactly one Monitoring CR exists and status to Ready.
 func (tc *MonitoringTestCtx) ValidateMonitoringCRCreation(t *testing.T) {
 	t.Helper()
-
-	skipUnless(t, Tier1)
 
 	tc.updateMonitoringConfig(withManagementState(operatorv1.Managed))
 
@@ -189,8 +188,6 @@ func (tc *MonitoringTestCtx) ValidateMonitoringCRCreation(t *testing.T) {
 func (tc *MonitoringTestCtx) ValidateMonitoringCRDefaultContent(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, Tier1)
-
 	// Ensure that the Monitoring resource exists.
 	tc.EnsureResourceExists(
 		WithMinimalObject(gvk.Monitoring, types.NamespacedName{Name: MonitoringCRName}),
@@ -212,8 +209,6 @@ func (tc *MonitoringTestCtx) ValidateMonitoringCRDefaultContent(t *testing.T) {
 // ValidateMonitoringStackCRMetricsWhenSet validates that MonitoringStack CR is created with correct metrics configuration when metrics are set in DSCI.
 func (tc *MonitoringTestCtx) ValidateMonitoringStackCRMetricsWhenSet(t *testing.T) {
 	t.Helper()
-
-	skipUnless(t, Tier1)
 
 	// Update DSCI to set metrics - ensure managementState remains Managed
 	tc.updateMonitoringConfig(
@@ -238,8 +233,6 @@ func (tc *MonitoringTestCtx) ValidateMonitoringStackCRMetricsWhenSet(t *testing.
 // ValidateMonitoringStackCRMetricsConfiguration verifies that MonitoringStack CR contains the correct metrics storage size, retention, and resource limits.
 func (tc *MonitoringTestCtx) ValidateMonitoringStackCRMetricsConfiguration(t *testing.T) {
 	t.Helper()
-
-	skipUnless(t, Tier1)
 
 	// Use EnsureResourceExists with jq matchers for cleaner validation
 	tc.EnsureResourceExists(
@@ -266,8 +259,6 @@ func (tc *MonitoringTestCtx) ValidateMonitoringStackCRMetricsConfiguration(t *te
 func (tc *MonitoringTestCtx) ValidateMonitoringStackCRMetricsReplicasUpdate(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, Tier1)
-
 	// Update DSCI to set replicas to 1 (must include either storage or resources due to CEL validation rule)
 	replicasTransforms := append(
 		[]testf.TransformFn{
@@ -292,8 +283,6 @@ func (tc *MonitoringTestCtx) ValidateMonitoringStackCRMetricsReplicasUpdate(t *t
 // ValidateCELBlocksInvalidMonitoringConfigs tests that CEL validation blocks invalid monitoring configurations.
 func (tc *MonitoringTestCtx) ValidateCELBlocksInvalidMonitoringConfigs(t *testing.T) {
 	t.Helper()
-
-	skipUnless(t, Tier1)
 
 	testCases := []struct {
 		name        string
@@ -347,8 +336,6 @@ func (tc *MonitoringTestCtx) ValidateCELBlocksInvalidMonitoringConfigs(t *testin
 func (tc *MonitoringTestCtx) ValidateCELAllowsValidMonitoringConfigs(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, Tier1)
-
 	testCases := []struct {
 		name        string
 		transforms  []testf.TransformFn
@@ -389,8 +376,6 @@ func (tc *MonitoringTestCtx) ValidateCELAllowsValidMonitoringConfigs(t *testing.
 // ValidateOpenTelemetryCollectorConfigurations consolidates all OpenTelemetry Collector configuration tests.
 func (tc *MonitoringTestCtx) ValidateOpenTelemetryCollectorConfigurations(t *testing.T) {
 	t.Helper()
-
-	skipUnless(t, Tier1)
 
 	testCases := []struct {
 		name                string
@@ -491,7 +476,6 @@ func (tc *MonitoringTestCtx) ValidateOpenTelemetryCollectorConfigurations(t *tes
 func (tc *MonitoringTestCtx) ValidateMetricsTLSAlwaysEnabled(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, Tier1)
 	tc.updateMonitoringConfig(
 		withManagementState(operatorv1.Managed),
 		tc.withMetricsConfig(),
@@ -560,8 +544,6 @@ func (tc *MonitoringTestCtx) ValidateMetricsTLSAlwaysEnabled(t *testing.T) {
 func (tc *MonitoringTestCtx) ValidateMonitoringCRCollectorReplicas(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, Tier1)
-
 	defaultReplicas := tc.expectedDefaultReplicas
 	testReplicas := defaultReplicas + 1 // Test with one more replica than default
 
@@ -598,8 +580,6 @@ func (tc *MonitoringTestCtx) ValidateMonitoringCRCollectorReplicas(t *testing.T)
 func (tc *MonitoringTestCtx) ValidateMonitoringCRDefaultTracesContent(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, Tier1)
-
 	// Ensure monitoring is enabled (might have been disabled by previous test)
 	tc.updateMonitoringConfig(withManagementState(operatorv1.Managed))
 
@@ -617,8 +597,6 @@ func (tc *MonitoringTestCtx) ValidateMonitoringCRDefaultTracesContent(t *testing
 // ValidateTempoMonolithicCRCreation tests creation of TempoMonolithic CR with PV backend and custom retention.
 func (tc *MonitoringTestCtx) ValidateTempoMonolithicCRCreation(t *testing.T) {
 	t.Helper()
-
-	skipUnless(t, Tier1)
 
 	// Update DSCI to set traces with PV backend
 	tc.updateMonitoringConfig(
@@ -666,8 +644,6 @@ func (tc *MonitoringTestCtx) ValidateTempoMonolithicCRCreation(t *testing.T) {
 func (tc *MonitoringTestCtx) ValidateTempoStackCRCreationWithCloudStorage(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, Tier1)
-
 	testCases := []struct {
 		name                string
 		backend             string
@@ -702,8 +678,6 @@ func (tc *MonitoringTestCtx) ValidateTempoStackCRCreationWithCloudStorage(t *tes
 
 func (tc *MonitoringTestCtx) ValidateInstrumentationCRTracesLifecycle(t *testing.T) {
 	t.Helper()
-
-	skipUnless(t, Tier1)
 
 	// Ensure clean slate before starting
 	tc.ensureMonitoringCleanSlate(t, "")
@@ -754,8 +728,6 @@ func (tc *MonitoringTestCtx) ValidateInstrumentationCRTracesLifecycle(t *testing
 func (tc *MonitoringTestCtx) ValidateTracesExportersReservedNameValidation(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, Tier1)
-
 	// Attempt to set traces configuration with a reserved exporter name
 	tc.updateMonitoringConfig(
 		withManagementState(operatorv1.Managed),
@@ -781,8 +753,6 @@ func (tc *MonitoringTestCtx) ValidateTracesExportersReservedNameValidation(t *te
 // ValidatePrometheusRulesLifecycle validates that Prometheus rules are created when monitoring and dashboard are enabled, and deleted when both are disabled.
 func (tc *MonitoringTestCtx) ValidatePrometheusRulesLifecycle(t *testing.T) {
 	t.Helper()
-
-	skipUnless(t, Tier1)
 
 	// First, ensure dashboard is disabled to establish a known initial state.
 	tc.UpdateComponentStateInDataScienceClusterWithKind(operatorv1.Removed, gvk.Dashboard.Kind)
@@ -815,8 +785,6 @@ func (tc *MonitoringTestCtx) ValidatePrometheusRulesLifecycle(t *testing.T) {
 func (tc *MonitoringTestCtx) ValidatePersesCRCreation(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, Tier1)
-
 	tc.updateMonitoringConfig(
 		withManagementState(operatorv1.Managed),
 		tc.withMetricsConfig(),
@@ -836,8 +804,6 @@ func (tc *MonitoringTestCtx) ValidatePersesCRCreation(t *testing.T) {
 
 func (tc *MonitoringTestCtx) ValidatePersesCRConfiguration(t *testing.T) {
 	t.Helper()
-
-	skipUnless(t, Tier1)
 
 	tc.EnsureResourceExists(
 		WithMinimalObject(gvk.Perses, types.NamespacedName{Name: PersesName, Namespace: tc.MonitoringNamespace}),
@@ -872,8 +838,6 @@ func (tc *MonitoringTestCtx) ValidatePersesCRConfiguration(t *testing.T) {
 
 func (tc *MonitoringTestCtx) ValidatePersesLifecycle(t *testing.T) {
 	t.Helper()
-
-	skipUnless(t, Tier1)
 
 	tc.updateMonitoringConfig(
 		withManagementState(operatorv1.Managed),
@@ -921,8 +885,6 @@ func (tc *MonitoringTestCtx) ValidatePersesLifecycle(t *testing.T) {
 func (tc *MonitoringTestCtx) ValidatePersesNotDeployedWithoutMetricsOrTraces(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, Tier1)
-
 	tc.ensureMonitoringCleanSlate(t, "")
 
 	tc.updateMonitoringConfig(
@@ -961,8 +923,6 @@ func (tc *MonitoringTestCtx) ValidatePersesNotDeployedWithoutMetricsOrTraces(t *
 func (tc *MonitoringTestCtx) ValidatePersesNetworkPolicy(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, Tier1)
-
 	tc.updateMonitoringConfig(
 		withManagementState(operatorv1.Managed),
 		tc.withMetricsConfig(),
@@ -986,8 +946,6 @@ func (tc *MonitoringTestCtx) ValidatePersesNetworkPolicy(t *testing.T) {
 // ValidatePersesDatasourceWithPrometheus validates that Prometheus datasource is created when both Perses and MonitoringStack are deployed.
 func (tc *MonitoringTestCtx) ValidatePersesDatasourceWithPrometheus(t *testing.T) {
 	t.Helper()
-
-	skipUnless(t, Tier1)
 
 	// Enable monitoring with metrics configuration to deploy both Perses and Prometheus
 	tc.updateMonitoringConfig(
@@ -1049,8 +1007,6 @@ func (tc *MonitoringTestCtx) ValidatePersesDatasourceWithPrometheus(t *testing.T
 // ValidatePersesDatasourceLifecycle tests the complete lifecycle of PersesDatasource deployment and cleanup.
 func (tc *MonitoringTestCtx) ValidatePersesDatasourceLifecycle(t *testing.T) {
 	t.Helper()
-
-	skipUnless(t, Tier1)
 
 	// Step 1: Enable monitoring with metrics to deploy datasource
 	tc.updateMonitoringConfig(
@@ -1119,8 +1075,6 @@ func (tc *MonitoringTestCtx) ValidatePersesDatasourceLifecycle(t *testing.T) {
 // ValidateMonitoringServiceDisabled ensures monitoring service can be disabled and resources are cleaned up.
 func (tc *MonitoringTestCtx) ValidateMonitoringServiceDisabled(t *testing.T) {
 	t.Helper()
-
-	skipUnless(t, Tier1)
 
 	// Ensure clean slate - previous tests may have left TempoMonolithic with TLS enabled
 	// and already in deletion state, which prevents our controller from updating it
@@ -1503,8 +1457,6 @@ func withMonitoringTraces(backend, secret, size, retention string) testf.Transfo
 func (tc *MonitoringTestCtx) ValidateThanosQuerierDeployment(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, Tier1)
-
 	// Ensure clean slate before starting
 	tc.ensureMonitoringCleanSlate(t, "")
 
@@ -1559,8 +1511,6 @@ func (tc *MonitoringTestCtx) ValidateThanosQuerierDeployment(t *testing.T) {
 func (tc *MonitoringTestCtx) ValidateThanosQuerierNotDeployedWithoutMetrics(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, Tier1)
-
 	// Ensure clean slate before starting
 	tc.ensureMonitoringCleanSlate(t, "")
 
@@ -1605,8 +1555,6 @@ func (tc *MonitoringTestCtx) ValidateThanosQuerierNotDeployedWithoutMetrics(t *t
 // and properly configured with the correct serverName to fix TLS SANs mismatch issues.
 func (tc *MonitoringTestCtx) ValidatePrometheusSelfServiceMonitorTLSFix(t *testing.T) {
 	t.Helper()
-
-	skipUnless(t, Tier1)
 
 	tc.updateMonitoringConfig(
 		withManagementState(operatorv1.Managed),
@@ -1678,8 +1626,6 @@ func (tc *MonitoringTestCtx) ValidatePrometheusSelfServiceMonitorTLSFix(t *testi
 func (tc *MonitoringTestCtx) ValidatePersesDatasourceCreationWithTraces(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, Tier1)
-
 	// Skip if PersesDatasource CRD is not installed
 	ctx := context.Background()
 	exists, err := cluster.HasCRD(ctx, tc.Client(), gvk.PersesDatasource)
@@ -1743,8 +1689,6 @@ func (tc *MonitoringTestCtx) ValidatePersesDatasourceCreationWithTraces(t *testi
 // ValidatePersesDatasourceConfiguration tests the configuration of the Perses datasource.
 func (tc *MonitoringTestCtx) ValidatePersesDatasourceConfiguration(t *testing.T) {
 	t.Helper()
-
-	skipUnless(t, Tier1)
 
 	// Skip if PersesDatasource CRD is not installed
 	ctx := context.Background()
@@ -1911,8 +1855,6 @@ func (tc *MonitoringTestCtx) validatePrometheusNamespaceProxyResourcesCommon(t *
 func (tc *MonitoringTestCtx) ValidatePrometheusRestrictedResourceConfiguration(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, Tier1)
-
 	dsci := tc.FetchDSCInitialization()
 
 	// Ensure metrics are configured
@@ -1932,8 +1874,6 @@ func (tc *MonitoringTestCtx) ValidatePrometheusRestrictedResourceConfiguration(t
 // ValidatePrometheusSecureProxyAuthentication tests the Prometheus secure proxy authentication and authorization.
 func (tc *MonitoringTestCtx) ValidatePrometheusSecureProxyAuthentication(t *testing.T) {
 	t.Helper()
-
-	skipUnless(t, Tier1)
 
 	dsci := tc.FetchDSCInitialization()
 
@@ -2003,8 +1943,6 @@ func (tc *MonitoringTestCtx) ValidatePrometheusSecureProxyAuthentication(t *test
 // ValidateNodeMetricsEndpointDeployment tests that the node-metrics-endpoint is deployed when metrics are configured.
 func (tc *MonitoringTestCtx) ValidateNodeMetricsEndpointDeployment(t *testing.T) {
 	t.Helper()
-
-	skipUnless(t, Tier1)
 
 	dsci := tc.FetchDSCInitialization()
 
@@ -2076,8 +2014,6 @@ func (tc *MonitoringTestCtx) ValidateNodeMetricsEndpointDeployment(t *testing.T)
 
 func (tc *MonitoringTestCtx) ValidateNodeMetricsEndpointRBACConfiguration(t *testing.T) {
 	t.Helper()
-
-	skipUnless(t, Tier1)
 
 	dsci := tc.FetchDSCInitialization()
 
@@ -2265,7 +2201,6 @@ func (tc *MonitoringTestCtx) validatePersesDatasourceTLSWithCloudBackend(t *test
 func (tc *MonitoringTestCtx) ValidatePersesDatasourceTLSWithS3Backend(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, Tier1)
 	tc.validatePersesDatasourceTLSWithCloudBackend(t, "s3")
 }
 
@@ -2273,6 +2208,5 @@ func (tc *MonitoringTestCtx) ValidatePersesDatasourceTLSWithS3Backend(t *testing
 func (tc *MonitoringTestCtx) ValidatePersesDatasourceTLSWithGCSBackend(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, Tier1)
 	tc.validatePersesDatasourceTLSWithCloudBackend(t, "gcs")
 }

--- a/tests/e2e/scripts/run_e2e_tests.sh
+++ b/tests/e2e/scripts/run_e2e_tests.sh
@@ -32,10 +32,11 @@ validate_deletion_policy() {
 validate_tag() {
     local var_name=$1
     local value=${!var_name}
-    # Tags limited to alphanumeric, '-' and '_'
-    if [[ ! "$value" =~ ^[a-zA-Z0-9_-]+$ ]]; then
-        echo "Error: $var_name contains unsafe characters, got '$value'" >&2; exit 1
-    fi
+    # Tags limited to All, Smoke, Tier1, Tier2 and Tier3
+    case "$value" in
+        All|Smoke|Tier1|Tier2|Tier3) return 0 ;;
+        *) echo "Error: $var_name must be 'All', 'Smoke', 'Tier1', 'Tier2' or 'Tier3', got '$value'" >&2; exit 1 ;;
+    esac
 }
 
 # Set defaults and validate

--- a/tests/e2e/test_tag_test.go
+++ b/tests/e2e/test_tag_test.go
@@ -8,9 +8,11 @@ const (
 	All   TestTag = "All"
 	Smoke TestTag = "Smoke"
 	Tier1 TestTag = "Tier1"
+	Tier2 TestTag = "Tier2"
+	Tier3 TestTag = "Tier3"
 )
 
-var allowedTags = []TestTag{All, Smoke, Tier1}
+var allowedTags = []TestTag{All, Smoke, Tier1, Tier2, Tier3}
 
 func skipUnless(t *testing.T, tags ...TestTag) {
 	t.Helper()

--- a/tests/e2e/v2tov3upgrade_test.go
+++ b/tests/e2e/v2tov3upgrade_test.go
@@ -62,6 +62,8 @@ type V2Tov3UpgradeTestCtx struct {
 func v2Tov3UpgradeTestSuite(t *testing.T) {
 	t.Helper()
 
+	skipUnless(t, Tier1)
+
 	tc, err := NewTestContext(t)
 	require.NoError(t, err)
 
@@ -142,15 +144,11 @@ func v2Tov3UpgradeDeletingDscDsciTestSuite(t *testing.T) {
 func (tc *V2Tov3UpgradeTestCtx) ValidateCodeFlareResourcePreservation(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, Tier1)
-
 	tc.validateComponentResourcePreservation(t, gvk.CodeFlare, defaultCodeFlareComponentName)
 }
 
 func (tc *V2Tov3UpgradeTestCtx) ValidateModelMeshServingResourcePreservation(t *testing.T) {
 	t.Helper()
-
-	skipUnless(t, Tier1)
 
 	tc.validateComponentResourcePreservation(t, gvk.ModelMeshServing, defaultModelMeshServingComponentName)
 }
@@ -158,7 +156,7 @@ func (tc *V2Tov3UpgradeTestCtx) ValidateModelMeshServingResourcePreservation(t *
 func (tc *V2Tov3UpgradeTestCtx) DatascienceclusterV1CreationAndRead(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, Tier1)
+	skipUnless(t, Tier3)
 
 	// Clean up any existing DataScienceCluster and DSCInitialization resources before starting
 	cleanupCoreOperatorResources(t, tc.TestContext)
@@ -223,7 +221,7 @@ func (tc *V2Tov3UpgradeTestCtx) DatascienceclusterV1CreationAndRead(t *testing.T
 func (tc *V2Tov3UpgradeTestCtx) DscinitializationV1CreationAndRead(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, Tier1)
+	skipUnless(t, Tier3)
 
 	// Clean up any existing DataScienceCluster and DSCInitialization resources before starting
 	cleanupCoreOperatorResources(t, tc.TestContext)
@@ -294,7 +292,7 @@ func (tc *V2Tov3UpgradeTestCtx) DscinitializationV1CreationAndRead(t *testing.T)
 func (tc *V2Tov3UpgradeTestCtx) HardwareProfileV1Alpha1ToV1VersionUpgrade(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, Tier1)
+	skipUnless(t, Tier3)
 
 	hardwareProfileName := "test-hardware-profile-v1alpha1-to-v1"
 
@@ -351,7 +349,7 @@ func (tc *V2Tov3UpgradeTestCtx) HardwareProfileV1Alpha1ToV1VersionUpgrade(t *tes
 func (tc *V2Tov3UpgradeTestCtx) HardwareProfileV1ToV1Alpha1VersionConversion(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, Tier1)
+	skipUnless(t, Tier3)
 
 	hardwareProfileName := "test-hardware-profile-v1-to-v1alpha1"
 
@@ -425,8 +423,6 @@ func (tc *V2Tov3UpgradeTestCtx) validateComponentResourcePreservation(t *testing
 
 func (tc *V2Tov3UpgradeTestCtx) ValidateRayRaiseErrorIfCodeFlarePresent(t *testing.T) {
 	t.Helper()
-
-	skipUnless(t, Tier1)
 
 	dsc := tc.FetchDataScienceCluster()
 	existingComponent := tc.operatorManagedComponent(gvk.CodeFlare, defaultCodeFlareComponentName, dsc)
@@ -531,7 +527,7 @@ func (tc *V2Tov3UpgradeTestCtx) updateComponentStateInDataScienceCluster(t *test
 func (tc *V2Tov3UpgradeTestCtx) ValidateDeniesKueueManaged(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, Tier1)
+	skipUnless(t, Tier3)
 
 	// Clean up any existing DataScienceCluster resources before starting
 	cleanupCoreOperatorResources(t, tc.TestContext)
@@ -581,6 +577,7 @@ func (tc *V2Tov3UpgradeTestCtx) ValidateDeniesKueueManaged(t *testing.T) {
 func (tc *V2Tov3UpgradeTestCtx) ValidateDeniesKueueManagedUpdate(t *testing.T) {
 	t.Helper()
 
+	skipUnless(t, Tier3)
 	// Clean up any existing DataScienceCluster resources before starting
 	cleanupCoreOperatorResources(t, tc.TestContext)
 
@@ -667,7 +664,7 @@ func (tc *V2Tov3UpgradeTestCtx) ValidateDeniesKueueManagedUpdate(t *testing.T) {
 func (tc *V2Tov3UpgradeTestCtx) ValidateAllowsKueueUnmanaged(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, Tier1)
+	skipUnless(t, Tier3)
 
 	// Clean up any existing DataScienceCluster resources before starting
 	cleanupCoreOperatorResources(t, tc.TestContext)
@@ -735,7 +732,7 @@ func (tc *V2Tov3UpgradeTestCtx) ValidateAllowsKueueUnmanaged(t *testing.T) {
 func (tc *V2Tov3UpgradeTestCtx) ValidateAllowsKueueRemoved(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, Tier1)
+	skipUnless(t, Tier3)
 
 	// Clean up any existing DataScienceCluster resources before starting
 	cleanupCoreOperatorResources(t, tc.TestContext)
@@ -803,7 +800,7 @@ func (tc *V2Tov3UpgradeTestCtx) ValidateAllowsKueueRemoved(t *testing.T) {
 func (tc *V2Tov3UpgradeTestCtx) ValidateAllowsWithoutKueue(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, Tier1)
+	skipUnless(t, Tier3)
 
 	// Clean up any existing DataScienceCluster resources before starting
 	cleanupCoreOperatorResources(t, tc.TestContext)
@@ -868,8 +865,6 @@ func (tc *V2Tov3UpgradeTestCtx) createCRD(crdsToCreate []CRDToCreate) {
 
 func (tc *V2Tov3UpgradeTestCtx) ValidateServiceMeshResourcePreservation(t *testing.T) {
 	t.Helper()
-
-	skipUnless(t, Tier1)
 
 	nn := types.NamespacedName{
 		Name: defaultServiceMeshName,
@@ -944,7 +939,7 @@ func (tc *V2Tov3UpgradeTestCtx) triggerDSCIReconciliation(t *testing.T) {
 func (tc *V2Tov3UpgradeTestCtx) ValidateArgoWorkflowsControllersDatasciencepipelinesDSCV1(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, Tier1)
+	skipUnless(t, Tier3)
 
 	// Clean up any existing DataScienceCluster resources before starting
 	cleanupCoreOperatorResources(t, tc.TestContext)
@@ -1008,7 +1003,7 @@ func (tc *V2Tov3UpgradeTestCtx) ValidateArgoWorkflowsControllersDatasciencepipel
 func (tc *V2Tov3UpgradeTestCtx) ValidateV2OnlyComponentsResetWhenPatchingViaV1API(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, Tier1)
+	skipUnless(t, Tier3)
 
 	// Clean up any existing DataScienceCluster resources before starting
 	cleanupCoreOperatorResources(t, tc.TestContext)


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->
Splitting Tier1 tests into Tier1, Tier2 and Tier3.

Monitoring tests are moved to Tier2 and the disruptive tests to Tier3. Tier3 tests are executed with the deletion policy as always.

<!--- Link your JIRA and related links here for reference. -->
Related ticket: https://issues.redhat.com/browse/RHOAIENG-51458

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [ ] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added Tier2 and Tier3 tags and expanded allowed tag list; help text now built from allowed tags.
  * Reclassified many end-to-end tests to Tier2/Tier3 and updated gating/skip guards.
  * Introduced a monitoring webhook setup step and removed the separate monitoring admission-components test suite.
* **Chores**
  * Test runner validation tightened to explicitly allow All, Smoke, Tier1, Tier2, Tier3.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->