### PR TITLE
RHOAIENG-51556: Support IMAGES_JOBS_ASYNC_UPLOAD in dashboard manifests

### DIFF
--- a/internal/controller/components/dashboard/dashboard_support.go
+++ b/internal/controller/components/dashboard/dashboard_support.go
@@ -45,13 +45,14 @@ var (
 	}
 
 	imagesMap = map[string]string{
-		"odh-dashboard-image":     "RELATED_IMAGE_ODH_DASHBOARD_IMAGE",
-		"model-registry-ui-image": "RELATED_IMAGE_ODH_MOD_ARCH_MODEL_REGISTRY_IMAGE",
-		"gen-ai-ui-image":         "RELATED_IMAGE_ODH_MOD_ARCH_GEN_AI_IMAGE",
-		"mlflow-ui-image":         "RELATED_IMAGE_ODH_MOD_ARCH_MLFLOW_IMAGE",
-		"maas-ui-image":           "RELATED_IMAGE_ODH_MOD_ARCH_MAAS_IMAGE",
-		"eval-hub-ui-image":       "RELATED_IMAGE_ODH_MOD_ARCH_EVAL_HUB_IMAGE",
-		"kube-rbac-proxy":         "RELATED_IMAGE_OSE_KUBE_RBAC_PROXY_IMAGE",
+		"odh-dashboard-image":      "RELATED_IMAGE_ODH_DASHBOARD_IMAGE",
+		"model-registry-ui-image":  "RELATED_IMAGE_ODH_MOD_ARCH_MODEL_REGISTRY_IMAGE",
+		"gen-ai-ui-image":          "RELATED_IMAGE_ODH_MOD_ARCH_GEN_AI_IMAGE",
+		"mlflow-ui-image":          "RELATED_IMAGE_ODH_MOD_ARCH_MLFLOW_IMAGE",
+		"maas-ui-image":            "RELATED_IMAGE_ODH_MOD_ARCH_MAAS_IMAGE",
+		"eval-hub-ui-image":        "RELATED_IMAGE_ODH_MOD_ARCH_EVAL_HUB_IMAGE",
+		"kube-rbac-proxy":          "RELATED_IMAGE_OSE_KUBE_RBAC_PROXY_IMAGE",
+		"images-jobs-async-upload": "RELATED_IMAGE_ODH_MODEL_REGISTRY_JOB_ASYNC_UPLOAD_IMAGE",
 	}
 
 	conditionTypes = []string{


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
Adds support for the Model Registry async-upload job image in the dashboard manifests so ODH/RHOAI can inject the correct image via the operator instead of relying on the upstream default.

## Context
The Dashboard runs a job (RHAISTRAT-813) that uses an image to move a model from one location to another. That image is hardcoded upstream.
For midstream (ODH) and downstream (RHOAI), the image must be configurable so the product can use its own images.
Image values:
```
Upstream: ghcr.io/kubeflow/model-registry/job/async-upload:latest
Midstream (ODH): quay.io/opendatahub/model-registry-job-async-upload
Downstream (RHOAI): rhoai/odh-model-registry-job-async-upload-rhel9
```
## Changes
internal/controller/components/dashboard/dashboard_support.go
Added images-jobs-async-upload to the dashboard imagesMap, mapped to the env var RELATED_IMAGE_ODH_MODEL_REGISTRY_JOB_ASYNC_UPLOAD_IMAGE.
When that env var is set (by the product bundle), the operator injects its value into the dashboard manifests’ params.env during ApplyParams, in the same way as odh-dashboard-image.

## How it works
The dashboard’s params.env must define the key images-jobs-async-upload (handled in odh-dashboard, e.g. [PR #6466](https://github.com/opendatahub-io/odh-dashboard/pull/6466)).
ODH/RHOAI builds set RELATED_IMAGE_ODH_MODEL_REGISTRY_JOB_ASYNC_UPLOAD_IMAGE in the operator deployment (bundle/CSV).
The operator reads that env and overwrites images-jobs-async-upload in the dashboard params.env when applying manifests.

## Dependencies / follow-up
odh-dashboard: The images-jobs-async-upload param must be present in the dashboard’s params.env (e.g. via [odh-dashboard PR #6466](https://github.com/opendatahub-io/odh-dashboard/pull/6466) or equivalent).
Product builds (ODH/RHOAI): Set RELATED_IMAGE_ODH_MODEL_REGISTRY_JOB_ASYNC_UPLOAD_IMAGE in the operator bundle for midstream/downstream image values.

## Testing
Operator builds and existing dashboard flow unchanged.
When RELATED_IMAGE_ODH_MODEL_REGISTRY_JOB_ASYNC_UPLOAD_IMAGE is set, the value is written into the dashboard params.env for the deployed manifests.

JIRA: https://issues.redhat.com/browse/RHOAIENG-51556

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
Very minor prams.env change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for async upload operations for job-related image resources, enabling background uploads, improved upload reliability, and smoother user experience when submitting or updating job artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->