### PR TITLE
chore: re-enable maas E2E tests

### DIFF
--- a/tests/e2e/modelsasservice_test.go
+++ b/tests/e2e/modelsasservice_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/components/modelsasservice"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/matchers/jq"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/testf"
 )
 
@@ -139,9 +140,15 @@ func (tc *ModelsAsServiceTestCtx) createMaaSPostgres(t *testing.T) {
 		WithCustomErrorMsg("Failed to create maas-db-config Secret"),
 	)
 
-	// Wait for the postgres pod to be ready before proceeding, since maas-api
-	// reads the database on startup.
-	tc.EnsureDeploymentReady(types.NamespacedName{Name: maasPostgresName, Namespace: ns}, 1)
+	// Wait for the postgres deployment to become available before proceeding,
+	// since maas-api reads the database on startup. Use EnsureResourceExists
+	// (which polls via Eventually) rather than EnsureDeploymentReady (point-in-time)
+	// because the image pull may take time on first run.
+	tc.EnsureResourceExists(
+		WithMinimalObject(gvk.Deployment, types.NamespacedName{Name: maasPostgresName, Namespace: ns}),
+		WithCondition(jq.Match(`.status.conditions[] | select(.type == "Available") | .status == "True"`)),
+		WithCustomErrorMsg("PostgreSQL Deployment %s/%s should be available", ns, maasPostgresName),
+	)
 
 	t.Logf("MaaS PostgreSQL instance and maas-db-config secret created in namespace %s", ns)
 }


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->
Removes the skip from the MaaS E2E tests now that the manifest has been updated.
<!--- Link your JIRA and related links here for reference. -->
https://issues.redhat.com/browse/RHOAIENG-51479

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Letting CI E2E tests run and ran locally with postgres addition

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Enabled Models-as-a-Service end-to-end tests in CI.
  * Tests now provision a lightweight PostgreSQL instance, create the DB connection config before the gateway starts, wait for DB readiness, and remove the previous hard-coded test skip.
  * Added orchestration helper to mirror deployment sequencing for reliable test startup.

* **Documentation**
  * Updated setup notes to document the new PostgreSQL prerequisite and the required startup sequencing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->