### PR TITLE
(fix): Temporary fix for sail operator infinite reconcillation loop

### DIFF
--- a/internal/controller/components/kserve/kserve_controller.go
+++ b/internal/controller/components/kserve/kserve_controller.go
@@ -153,6 +153,7 @@ func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.
 		WithAction(deploy.NewAction(
 			deploy.WithCache(),
 		)).
+		WithAction(annotateIstioWebhooks).
 		WithAction(deployments.NewAction()).
 		// must be the final action
 		WithAction(gc.NewAction(gc.WithUnremovables(gvk.LLMInferenceServiceConfigV1Alpha1))).

--- a/internal/controller/components/kserve/kserve_controller_actions.go
+++ b/internal/controller/components/kserve/kserve_controller_actions.go
@@ -5,12 +5,14 @@ import (
 	"fmt"
 	"strings"
 
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -29,6 +31,11 @@ import (
 const (
 	LLMInferenceServiceConfigWellKnownAnnotationKey   = "serving.kserve.io/well-known-config"
 	LLMInferenceServiceConfigWellKnownAnnotationValue = "true"
+
+	sailOperatorIgnoreAnnotation = "sailoperator.io/ignore"
+
+	istioSidecarInjectorWebhook = "istio-sidecar-injector"
+	istioValidatorWebhook       = "istio-validator-istio-system"
 )
 
 func initialize(_ context.Context, rr *odhtypes.ReconciliationRequest) error { //nolint:unparam
@@ -178,6 +185,74 @@ func versionedWellKnownLLMInferenceServiceConfigs(_ context.Context, version str
 			rr.Resources[i] = *u
 		}
 	}
+	return nil
+}
+
+// annotateIstioWebhooks works around a sail-operator bug (OSSM-12397) where webhook
+// configuration updates trigger an infinite Helm reinstall loop on vanilla Kubernetes.
+// It adds the sailoperator.io/ignore=true annotation to the two webhooks that istiod
+// creates (istio-sidecar-injector and istio-validator-istio-system), telling the
+// sail-operator to stop watching them.
+//
+// TODO(OSSM-12397): Remove this workaround once the sail-operator ships a fix.
+// Tracking: https://issues.redhat.com/browse/RHOAIENG-52246
+//
+// Only runs on xKS platforms where the sail-operator is used.
+// Annotation failures are logged but do not block reconciliation, since this
+// is a workaround rather than a core requirement.
+func annotateIstioWebhooks(ctx context.Context, rr *odhtypes.ReconciliationRequest) error {
+	if rr.Release.Name != cluster.XKS {
+		return nil
+	}
+
+	logger := logf.FromContext(ctx)
+
+	// Errors are intentionally not returned here because this is a temporary
+	// workaround (see TODO above). Failing to annotate a webhook should not
+	// block KServe reconciliation; the annotation will be retried on the next
+	// reconciliation loop.
+	if err := ensureSailOperatorIgnoreAnnotation(
+		ctx, rr.Client, istioSidecarInjectorWebhook, &admissionregistrationv1.MutatingWebhookConfiguration{},
+	); err != nil {
+		logger.Error(err, "Failed to annotate webhook (non-fatal)", "name", istioSidecarInjectorWebhook)
+	}
+
+	if err := ensureSailOperatorIgnoreAnnotation(
+		ctx, rr.Client, istioValidatorWebhook, &admissionregistrationv1.ValidatingWebhookConfiguration{},
+	); err != nil {
+		logger.Error(err, "Failed to annotate webhook (non-fatal)", "name", istioValidatorWebhook)
+	}
+
+	return nil
+}
+
+func ensureSailOperatorIgnoreAnnotation(ctx context.Context, c client.Client, name string, obj client.Object) error {
+	logger := logf.FromContext(ctx)
+
+	if err := c.Get(ctx, types.NamespacedName{Name: name}, obj); err != nil {
+		if k8serr.IsNotFound(err) {
+			return nil
+		}
+		return err
+	}
+
+	annotations := obj.GetAnnotations()
+	if annotations[sailOperatorIgnoreAnnotation] == "true" {
+		return nil
+	}
+
+	annotationPatch := client.RawPatch(types.MergePatchType,
+		[]byte(`{"metadata":{"annotations":{"`+sailOperatorIgnoreAnnotation+`":"true"}}}`))
+
+	if err := c.Patch(ctx, obj, annotationPatch); err != nil {
+		return err
+	}
+
+	logger.Info("Annotated webhook with sailoperator.io/ignore=true",
+		"kind", obj.GetObjectKind().GroupVersionKind().Kind,
+		"name", name,
+	)
+
 	return nil
 }
 

--- a/internal/controller/components/kserve/kserve_controller_actions_test.go
+++ b/internal/controller/components/kserve/kserve_controller_actions_test.go
@@ -7,13 +7,17 @@ import (
 
 	operatorv1 "github.com/openshift/api/operator/v1"
 	"github.com/operator-framework/api/pkg/operators/v1alpha1"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 
+	"github.com/opendatahub-io/opendatahub-operator/v2/api/common"
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/api/components/v1alpha1"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/conditions"
 	odhtypes "github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/metadata/labels"
@@ -339,4 +343,161 @@ func convertToUnstructured(t *testing.T, obj runtime.Object) *unstructured.Unstr
 		t.Fatalf("Failed to convert object to unstructured: %v", err)
 	}
 	return &unstructured.Unstructured{Object: u}
+}
+
+func TestAnnotateIstioWebhooks(t *testing.T) {
+	xksRelease := common.Release{Name: cluster.XKS}
+
+	t.Run("should skip on non-xKS platforms", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		mutatingWH := &admissionregistrationv1.MutatingWebhookConfiguration{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: istioSidecarInjectorWebhook,
+			},
+		}
+
+		cli, err := fakeclient.New(fakeclient.WithObjects(mutatingWH))
+		g.Expect(err).ShouldNot(HaveOccurred())
+
+		rr := &odhtypes.ReconciliationRequest{
+			Client:  cli,
+			Release: common.Release{Name: cluster.SelfManagedRhoai},
+		}
+
+		err = annotateIstioWebhooks(ctx, rr)
+		g.Expect(err).ShouldNot(HaveOccurred())
+
+		// Verify webhook was NOT annotated
+		updatedMutating := &admissionregistrationv1.MutatingWebhookConfiguration{}
+		err = cli.Get(ctx, types.NamespacedName{Name: istioSidecarInjectorWebhook}, updatedMutating)
+		g.Expect(err).ShouldNot(HaveOccurred())
+		g.Expect(updatedMutating.Annotations).ShouldNot(HaveKey(sailOperatorIgnoreAnnotation))
+	})
+
+	t.Run("should annotate webhooks on xKS when they exist without annotation", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		mutatingWH := &admissionregistrationv1.MutatingWebhookConfiguration{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: istioSidecarInjectorWebhook,
+			},
+		}
+		validatingWH := &admissionregistrationv1.ValidatingWebhookConfiguration{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: istioValidatorWebhook,
+			},
+		}
+
+		cli, err := fakeclient.New(fakeclient.WithObjects(mutatingWH, validatingWH))
+		g.Expect(err).ShouldNot(HaveOccurred())
+
+		rr := &odhtypes.ReconciliationRequest{
+			Client:  cli,
+			Release: xksRelease,
+		}
+
+		err = annotateIstioWebhooks(ctx, rr)
+		g.Expect(err).ShouldNot(HaveOccurred())
+
+		// Verify mutating webhook was annotated
+		updatedMutating := &admissionregistrationv1.MutatingWebhookConfiguration{}
+		err = cli.Get(ctx, types.NamespacedName{Name: istioSidecarInjectorWebhook}, updatedMutating)
+		g.Expect(err).ShouldNot(HaveOccurred())
+		g.Expect(updatedMutating.Annotations).Should(HaveKeyWithValue(sailOperatorIgnoreAnnotation, "true"))
+
+		// Verify validating webhook was annotated
+		updatedValidating := &admissionregistrationv1.ValidatingWebhookConfiguration{}
+		err = cli.Get(ctx, types.NamespacedName{Name: istioValidatorWebhook}, updatedValidating)
+		g.Expect(err).ShouldNot(HaveOccurred())
+		g.Expect(updatedValidating.Annotations).Should(HaveKeyWithValue(sailOperatorIgnoreAnnotation, "true"))
+	})
+
+	t.Run("should be a no-op when webhooks already have the annotation", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		mutatingWH := &admissionregistrationv1.MutatingWebhookConfiguration{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: istioSidecarInjectorWebhook,
+				Annotations: map[string]string{
+					sailOperatorIgnoreAnnotation: "true",
+				},
+			},
+		}
+		validatingWH := &admissionregistrationv1.ValidatingWebhookConfiguration{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: istioValidatorWebhook,
+				Annotations: map[string]string{
+					sailOperatorIgnoreAnnotation: "true",
+				},
+			},
+		}
+
+		cli, err := fakeclient.New(fakeclient.WithObjects(mutatingWH, validatingWH))
+		g.Expect(err).ShouldNot(HaveOccurred())
+
+		rr := &odhtypes.ReconciliationRequest{
+			Client:  cli,
+			Release: xksRelease,
+		}
+
+		err = annotateIstioWebhooks(ctx, rr)
+		g.Expect(err).ShouldNot(HaveOccurred())
+
+		// Verify annotations are still present
+		updatedMutating := &admissionregistrationv1.MutatingWebhookConfiguration{}
+		err = cli.Get(ctx, types.NamespacedName{Name: istioSidecarInjectorWebhook}, updatedMutating)
+		g.Expect(err).ShouldNot(HaveOccurred())
+		g.Expect(updatedMutating.Annotations).Should(HaveKeyWithValue(sailOperatorIgnoreAnnotation, "true"))
+	})
+
+	t.Run("should be a no-op when webhooks do not exist on xKS", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		cli, err := fakeclient.New()
+		g.Expect(err).ShouldNot(HaveOccurred())
+
+		rr := &odhtypes.ReconciliationRequest{
+			Client:  cli,
+			Release: xksRelease,
+		}
+
+		err = annotateIstioWebhooks(ctx, rr)
+		g.Expect(err).ShouldNot(HaveOccurred())
+	})
+
+	t.Run("should preserve existing annotations when adding the ignore annotation", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		mutatingWH := &admissionregistrationv1.MutatingWebhookConfiguration{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: istioSidecarInjectorWebhook,
+				Annotations: map[string]string{
+					"existing-annotation": "existing-value",
+				},
+			},
+		}
+
+		cli, err := fakeclient.New(fakeclient.WithObjects(mutatingWH))
+		g.Expect(err).ShouldNot(HaveOccurred())
+
+		rr := &odhtypes.ReconciliationRequest{
+			Client:  cli,
+			Release: xksRelease,
+		}
+
+		err = annotateIstioWebhooks(ctx, rr)
+		g.Expect(err).ShouldNot(HaveOccurred())
+
+		updatedMutating := &admissionregistrationv1.MutatingWebhookConfiguration{}
+		err = cli.Get(ctx, types.NamespacedName{Name: istioSidecarInjectorWebhook}, updatedMutating)
+		g.Expect(err).ShouldNot(HaveOccurred())
+		g.Expect(updatedMutating.Annotations).Should(HaveKeyWithValue(sailOperatorIgnoreAnnotation, "true"))
+		g.Expect(updatedMutating.Annotations).Should(HaveKeyWithValue("existing-annotation", "existing-value"))
+	})
 }


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
Add a temporary fix to annotate sail operator webhooks to prevent inifinte reconcillation loop.
https://issues.redhat.com/browse/OSSM-12397

https://issues.redhat.com/browse/RHOAIENG-52246

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [ ] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic annotation of Istio webhooks to resolve a sail-operator compatibility issue on xKS platform deployments. Webhooks are configured non-blocking and reconciliation proceeds without interruption.

* **Tests**
  * Added test coverage for Istio webhook annotation behavior across platform configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->