### PR TITLE
owners: add rinaldodev to platform alias

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -21,6 +21,7 @@ aliases:
     - MarianMacik
     - mlassak
     - resoluteCoder
+    - rinaldodev
     - robotmaxtron
     - sefroberg
     - StevenTobin


### PR DESCRIPTION
## Description

Adds `rinaldodev` (myself) to the `platform` alias in `OWNERS_ALIASES`.

## How Has This Been Tested?

N/A

## Screenshot or short clip

N/A

## Merge criteria

N/A

#### E2E update requirement opt-out justification

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal aliases configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->