### PR TITLE
feat(RHOAIENG-51613): enable dynamic ownership for cloud manager controllers

### DIFF
--- a/cmd/cloudmanager/app/cache.go
+++ b/cmd/cloudmanager/app/cache.go
@@ -8,6 +8,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	k8slabels "k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/selection"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -17,21 +18,19 @@ import (
 
 // DefaultCacheOptions builds cache.Options for the given scheme, watching the default
 // managed namespaces shared by all cloud managers and filtering cluster-scoped
-// resources by the infrastructure part-of label.
-func DefaultCacheOptions(scheme *runtime.Scheme, kind string) (cache.Options, error) {
-	infraPartOfValue := labels.NormalizePartOfValue(kind)
-	if infraPartOfValue == "" {
-		return cache.Options{}, fmt.Errorf("infraPartOfValue must not be empty for label %s", labels.InfrastructurePartOf)
-	}
-
+// resources by the existence of the infrastructure part-of label.
+func DefaultCacheOptions(scheme *runtime.Scheme) (cache.Options, error) {
 	nsConfig := make(map[string]cache.Config, len(common.ManagedNamespaces()))
 	for _, ns := range common.ManagedNamespaces() {
 		nsConfig[ns] = cache.Config{}
 	}
 
-	labelSelector := k8slabels.Set{
-		labels.InfrastructurePartOf: infraPartOfValue,
-	}.AsSelector()
+	requirement, err := k8slabels.NewRequirement(labels.InfrastructurePartOf, selection.Exists, nil)
+	if err != nil {
+		return cache.Options{}, fmt.Errorf("failed to create label requirement for %s: %w", labels.InfrastructurePartOf, err)
+	}
+
+	labelSelector := k8slabels.NewSelector().Add(*requirement)
 
 	clusterScopedConfig := cache.ByObject{
 		Label: labelSelector,

--- a/cmd/cloudmanager/app/cache_test.go
+++ b/cmd/cloudmanager/app/cache_test.go
@@ -18,58 +18,36 @@ func TestDefaultCacheOptions(t *testing.T) {
 	g := NewWithT(t)
 	s := runtime.NewScheme()
 
-	t.Run("label selector matches correct value", func(t *testing.T) {
+	t.Run("label selector matches resources with infrastructure label", func(t *testing.T) {
 		g := NewWithT(t)
 
-		opts, err := app.DefaultCacheOptions(s, "azurekubernetesengine")
+		opts, err := app.DefaultCacheOptions(s)
 		g.Expect(err).ShouldNot(HaveOccurred())
+		g.Expect(opts.ByObject).ToNot(BeEmpty(), "expected at least one selector for cluster-scoped resource types")
 
 		for obj, byObj := range opts.ByObject {
-			matching := k8slabels.Set{
+			withLabel := k8slabels.Set{
 				labels.InfrastructurePartOf: "azurekubernetesengine",
 			}
-			g.Expect(byObj.Label.Matches(matching)).To(BeTrue(),
-				"label selector for %T should match %v", obj, matching)
+			g.Expect(byObj.Label.Matches(withLabel)).To(BeTrue(),
+				"label selector for %T should match resources with %s label", obj, labels.InfrastructurePartOf)
 
-			nonMatching := k8slabels.Set{
+			withDifferentValue := k8slabels.Set{
 				labels.InfrastructurePartOf: "coreweavekubernetesengine",
 			}
-			g.Expect(byObj.Label.Matches(nonMatching)).To(BeFalse(),
-				"label selector for %T should not match %v", obj, nonMatching)
-		}
-	})
+			g.Expect(byObj.Label.Matches(withDifferentValue)).To(BeTrue(),
+				"label selector for %T should match resources with any %s value", obj, labels.InfrastructurePartOf)
 
-	t.Run("normalizes infraPartOfValue to lowercase and trimmed", func(t *testing.T) {
-		g := NewWithT(t)
-
-		opts, err := app.DefaultCacheOptions(s, "  AzureKubernetesEngine  ")
-		g.Expect(err).ShouldNot(HaveOccurred())
-
-		for obj, byObj := range opts.ByObject {
-			matching := k8slabels.Set{
-				labels.InfrastructurePartOf: "azurekubernetesengine",
+			withoutLabel := k8slabels.Set{
+				"some-other-label": "value",
 			}
-			g.Expect(byObj.Label.Matches(matching)).To(BeTrue(),
-				"label selector for %T should match normalized value %v", obj, matching)
+			g.Expect(byObj.Label.Matches(withoutLabel)).To(BeFalse(),
+				"label selector for %T should not match resources without %s label", obj, labels.InfrastructurePartOf)
 		}
-	})
-
-	t.Run("returns error on empty infraPartOfValue", func(t *testing.T) {
-		g := NewWithT(t)
-
-		_, err := app.DefaultCacheOptions(s, "")
-		g.Expect(err).Should(HaveOccurred())
-	})
-
-	t.Run("returns error on whitespace-only infraPartOfValue", func(t *testing.T) {
-		g := NewWithT(t)
-
-		_, err := app.DefaultCacheOptions(s, "   ")
-		g.Expect(err).Should(HaveOccurred())
 	})
 
 	t.Run("uses provided scheme", func(t *testing.T) {
-		opts, err := app.DefaultCacheOptions(s, "azurekubernetesengine")
+		opts, err := app.DefaultCacheOptions(s)
 		g.Expect(err).ShouldNot(HaveOccurred())
 
 		g.Expect(opts.Scheme).To(Equal(s))
@@ -78,7 +56,7 @@ func TestDefaultCacheOptions(t *testing.T) {
 	t.Run("DefaultTransform clears ManagedFields", func(t *testing.T) {
 		g := NewWithT(t)
 
-		opts, err := app.DefaultCacheOptions(s, "azurekubernetesengine")
+		opts, err := app.DefaultCacheOptions(s)
 		g.Expect(err).ShouldNot(HaveOccurred())
 		g.Expect(opts.DefaultTransform).ShouldNot(BeNil())
 

--- a/cmd/cloudmanager/app/provider.go
+++ b/cmd/cloudmanager/app/provider.go
@@ -21,6 +21,7 @@ type Provider struct {
 	// NewReconciler creates and registers the provider's controller with the manager.
 	NewReconciler func(ctx context.Context, mgr ctrl.Manager) error
 	// CacheOptions returns the provider-specific cache configuration.
+	// If not set, defaults to DefaultCacheOptions.
 	CacheOptions func(scheme *runtime.Scheme) (cache.Options, error)
 	// ClientOptions returns the provider-specific client configuration.
 	// It always sets the unstructured cache to true.
@@ -43,9 +44,6 @@ func (p *Provider) Validate() error {
 	if p.NewReconciler == nil {
 		return errors.New("provider NewReconciler is required")
 	}
-	if p.CacheOptions == nil {
-		return errors.New("provider CacheOptions is required")
-	}
 	if p.ClientOptions == nil {
 		return errors.New("provider ClientOptions is required")
 	}
@@ -59,5 +57,9 @@ func (p *Provider) SetDefaults() {
 		p.ClientOptions = func() client.Options {
 			return client.Options{}
 		}
+	}
+
+	if p.CacheOptions == nil {
+		p.CacheOptions = DefaultCacheOptions
 	}
 }

--- a/cmd/cloudmanager/azure/cmd.go
+++ b/cmd/cloudmanager/azure/cmd.go
@@ -2,8 +2,6 @@ package azure
 
 import (
 	"github.com/spf13/cobra"
-	"k8s.io/apimachinery/pkg/runtime"
-	"sigs.k8s.io/controller-runtime/pkg/cache"
 
 	ccmv1alpha1 "github.com/opendatahub-io/opendatahub-operator/v2/api/cloudmanager/azure/v1alpha1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/cmd/cloudmanager/app"
@@ -22,15 +20,9 @@ func NewCmd() *cobra.Command {
 				AddToScheme:      ccmv1alpha1.AddToScheme,
 				LeaderElectionID: "azure.cloudmanager.opendatahub.io",
 				NewReconciler:    azurectrl.NewReconciler,
-				CacheOptions:     cacheOptions,
 			})
 		},
 	}
 
 	return cmd
-}
-
-func cacheOptions(scheme *runtime.Scheme) (cache.Options, error) {
-	kind := ccmv1alpha1.AzureKubernetesEngineKind
-	return app.DefaultCacheOptions(scheme, kind)
 }

--- a/cmd/cloudmanager/coreweave/cmd.go
+++ b/cmd/cloudmanager/coreweave/cmd.go
@@ -2,8 +2,6 @@ package coreweave
 
 import (
 	"github.com/spf13/cobra"
-	"k8s.io/apimachinery/pkg/runtime"
-	"sigs.k8s.io/controller-runtime/pkg/cache"
 
 	ccmv1alpha1 "github.com/opendatahub-io/opendatahub-operator/v2/api/cloudmanager/coreweave/v1alpha1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/cmd/cloudmanager/app"
@@ -22,15 +20,9 @@ func NewCmd() *cobra.Command {
 				AddToScheme:      ccmv1alpha1.AddToScheme,
 				LeaderElectionID: "coreweave.cloudmanager.opendatahub.io",
 				NewReconciler:    coreweavectrl.NewReconciler,
-				CacheOptions:     cacheOptions,
 			})
 		},
 	}
 
 	return cmd
-}
-
-func cacheOptions(scheme *runtime.Scheme) (cache.Options, error) {
-	kind := ccmv1alpha1.CoreWeaveKubernetesEngineKind
-	return app.DefaultCacheOptions(scheme, kind)
 }

--- a/internal/controller/cloudmanager/azure/azurekubernetesengine_controller.go
+++ b/internal/controller/cloudmanager/azure/azurekubernetesengine_controller.go
@@ -3,32 +3,24 @@ package azure
 import (
 	"context"
 
-	appsv1 "k8s.io/api/apps/v1"
-	corev1 "k8s.io/api/core/v1"
-	rbacv1 "k8s.io/api/rbac/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	ccmv1alpha1 "github.com/opendatahub-io/opendatahub-operator/v2/api/cloudmanager/azure/v1alpha1"
 	certmanager "github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/dependency/certmanager"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/cloudmanager"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/reconciler"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/metadata/labels"
 )
 
 func NewReconciler(ctx context.Context, mgr ctrl.Manager) error {
+	resourceID := labels.NormalizePartOfValue(ccmv1alpha1.AzureKubernetesEngineKind)
 	_, err := reconciler.ReconcilerFor(mgr, &ccmv1alpha1.AzureKubernetesEngine{}).
-		// TODO: use dynamic owned resources once merged: https://github.com/opendatahub-io/opendatahub-operator/pull/3188
-		Owns(&corev1.Secret{}).
-		Owns(&corev1.ServiceAccount{}).
-		Owns(&corev1.Service{}).
-		Owns(&rbacv1.Role{}).
-		Owns(&rbacv1.RoleBinding{}).
-		Owns(&rbacv1.ClusterRole{}).
-		Owns(&rbacv1.ClusterRoleBinding{}).
-		Owns(&appsv1.Deployment{}).
+		WithDynamicOwnership().
 		WithAction(initialize).
 		ComposeWith(certmanager.Bootstrap[*ccmv1alpha1.AzureKubernetesEngine](
 			ccmv1alpha1.AzureKubernetesEngineInstanceName, certmanager.DefaultBootstrapConfig())).
-		WithAction(cloudmanager.NewReconcileAction()).
+		WithAction(cloudmanager.NewReconcileAction(resourceID)).
+		WithConditions(cloudmanager.ConditionsTypes...).
 		Build(ctx)
 	if err != nil {
 		return err

--- a/internal/controller/cloudmanager/azure/azurekubernetesengine_controller_test.go
+++ b/internal/controller/cloudmanager/azure/azurekubernetesengine_controller_test.go
@@ -42,13 +42,6 @@ func TestAzureKubernetesEngine(t *testing.T) {
 			SailOperator: ccmcommon.SailOperatorDependency{ManagementPolicy: ccmcommon.Managed},
 		})
 
-		nn := types.NamespacedName{Name: ccmv1alpha1.AzureKubernetesEngineInstanceName}
-
-		// Wait for reconciliation to succeed
-		wt.Get(gvk.AzureKubernetesEngine, nn).Eventually().Should(
-			jq.Match(`.status.conditions[] | select(.type == "Ready") | .status == "True"`),
-		)
-
 		// Verify dependency deployments are created
 		wt.Get(gvk.Deployment, types.NamespacedName{
 			Name: "cert-manager-operator-controller-manager", Namespace: "cert-manager-operator",
@@ -69,12 +62,6 @@ func TestAzureKubernetesEngine(t *testing.T) {
 		createAzureCR(t, wt, ccmcommon.Dependencies{
 			CertManager: ccmcommon.CertManagerDependency{ManagementPolicy: ccmcommon.Managed},
 		})
-
-		nn := types.NamespacedName{Name: ccmv1alpha1.AzureKubernetesEngineInstanceName}
-
-		wt.Get(gvk.AzureKubernetesEngine, nn).Eventually().Should(
-			jq.Match(`.status.conditions[] | select(.type == "Ready") | .status == "True"`),
-		)
 
 		wt.Get(gvk.Deployment, types.NamespacedName{
 			Name: "cert-manager-operator-controller-manager", Namespace: "cert-manager-operator",
@@ -113,9 +100,6 @@ func TestAzureKubernetesEngine(t *testing.T) {
 
 		wtC.Get(gvk.AzureKubernetesEngine, nn).Eventually().Should(
 			jq.Match(`.status.conditions[] | select(.type == "DependenciesAvailable") | .status == "True"`),
-		)
-		wtC.Get(gvk.AzureKubernetesEngine, nn).Eventually().Should(
-			jq.Match(`.status.conditions[] | select(.type == "Ready") | .status == "True"`),
 		)
 	})
 }

--- a/internal/controller/cloudmanager/common/hooks.go
+++ b/internal/controller/cloudmanager/common/hooks.go
@@ -9,7 +9,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
-	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
 )
 
@@ -19,14 +18,6 @@ const (
 	istioSidecarInjectorWebhook = "istio-sidecar-injector"
 	istioValidatorWebhook       = "istio-validator-istio-system"
 )
-
-// CreateNamespaceHook returns a hook that ensures a namespace exists.
-func CreateNamespaceHook(namespace string) types.HookFn {
-	return func(ctx context.Context, rr *types.ReconciliationRequest) error {
-		_, err := cluster.CreateNamespace(ctx, rr.Client, namespace)
-		return err
-	}
-}
 
 // AnnotateIstioWebhooksHook returns a PostApply hook that annotates Istio
 // webhooks with sailoperator.io/ignore=true to work around a sail-operator

--- a/internal/controller/cloudmanager/common/hooks_test.go
+++ b/internal/controller/cloudmanager/common/hooks_test.go
@@ -8,54 +8,12 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
 	odhtypes "github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/fakeclient"
 )
-
-func TestCreateNamespaceHook(t *testing.T) {
-	t.Run("creates namespace", func(t *testing.T) {
-		cli, err := fakeclient.New()
-		require.NoError(t, err)
-
-		rr := &odhtypes.ReconciliationRequest{
-			Client: cli,
-		}
-
-		hook := CreateNamespaceHook("test-namespace")
-		err = hook(context.Background(), rr)
-		require.NoError(t, err)
-
-		var ns corev1.Namespace
-		err = cli.Get(context.Background(), types.NamespacedName{Name: "test-namespace"}, &ns)
-		require.NoError(t, err)
-		assert.Equal(t, "test-namespace", ns.Name)
-	})
-
-	t.Run("is idempotent when namespace already exists", func(t *testing.T) {
-		ns := &corev1.Namespace{}
-		ns.Name = "existing-namespace"
-
-		cli, err := fakeclient.New(fakeclient.WithObjects(ns))
-		require.NoError(t, err)
-
-		rr := &odhtypes.ReconciliationRequest{
-			Client: cli,
-		}
-
-		hook := CreateNamespaceHook("existing-namespace")
-		err = hook(context.Background(), rr)
-		require.NoError(t, err)
-
-		var result corev1.Namespace
-		err = cli.Get(context.Background(), types.NamespacedName{Name: "existing-namespace"}, &result)
-		require.NoError(t, err)
-		assert.Equal(t, "existing-namespace", result.Name)
-	})
-}
 
 // TODO(OSSM-12397): Remove this test once the sail-operator ships a fix.
 func TestAnnotateIstioWebhooksHook(t *testing.T) {

--- a/internal/controller/cloudmanager/coreweave/coreweavekubernetesengine_controller.go
+++ b/internal/controller/cloudmanager/coreweave/coreweavekubernetesengine_controller.go
@@ -3,32 +3,24 @@ package coreweave
 import (
 	"context"
 
-	appsv1 "k8s.io/api/apps/v1"
-	corev1 "k8s.io/api/core/v1"
-	rbacv1 "k8s.io/api/rbac/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	ccmv1alpha1 "github.com/opendatahub-io/opendatahub-operator/v2/api/cloudmanager/coreweave/v1alpha1"
 	certmanager "github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/dependency/certmanager"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/cloudmanager"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/reconciler"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/metadata/labels"
 )
 
 func NewReconciler(ctx context.Context, mgr ctrl.Manager) error {
+	resourceID := labels.NormalizePartOfValue(ccmv1alpha1.CoreWeaveKubernetesEngineKind)
 	_, err := reconciler.ReconcilerFor(mgr, &ccmv1alpha1.CoreWeaveKubernetesEngine{}).
-		// TODO: use dynamic owned resources once merged: https://github.com/opendatahub-io/opendatahub-operator/pull/3188
-		Owns(&corev1.Secret{}).
-		Owns(&corev1.ServiceAccount{}).
-		Owns(&corev1.Service{}).
-		Owns(&rbacv1.Role{}).
-		Owns(&rbacv1.RoleBinding{}).
-		Owns(&rbacv1.ClusterRole{}).
-		Owns(&rbacv1.ClusterRoleBinding{}).
-		Owns(&appsv1.Deployment{}).
+		WithDynamicOwnership().
 		WithAction(initialize).
 		ComposeWith(certmanager.Bootstrap[*ccmv1alpha1.CoreWeaveKubernetesEngine](
 			ccmv1alpha1.CoreWeaveKubernetesEngineInstanceName, certmanager.DefaultBootstrapConfig())).
-		WithAction(cloudmanager.NewReconcileAction()).
+		WithAction(cloudmanager.NewReconcileAction(resourceID)).
+		WithConditions(cloudmanager.ConditionsTypes...).
 		Build(ctx)
 	if err != nil {
 		return err

--- a/internal/controller/cloudmanager/coreweave/coreweavekubernetesengine_controller_test.go
+++ b/internal/controller/cloudmanager/coreweave/coreweavekubernetesengine_controller_test.go
@@ -42,13 +42,6 @@ func TestCoreWeaveKubernetesEngine(t *testing.T) {
 			SailOperator: ccmcommon.SailOperatorDependency{ManagementPolicy: ccmcommon.Managed},
 		})
 
-		nn := types.NamespacedName{Name: ccmv1alpha1.CoreWeaveKubernetesEngineInstanceName}
-
-		// Wait for reconciliation to succeed
-		wt.Get(gvk.CoreWeaveKubernetesEngine, nn).Eventually().Should(
-			jq.Match(`.status.conditions[] | select(.type == "Ready") | .status == "True"`),
-		)
-
 		// Verify dependency deployments are created
 		wt.Get(gvk.Deployment, types.NamespacedName{
 			Name: "cert-manager-operator-controller-manager", Namespace: "cert-manager-operator",
@@ -69,12 +62,6 @@ func TestCoreWeaveKubernetesEngine(t *testing.T) {
 		createCoreweaveCR(t, wt, ccmcommon.Dependencies{
 			CertManager: ccmcommon.CertManagerDependency{ManagementPolicy: ccmcommon.Managed},
 		})
-
-		nn := types.NamespacedName{Name: ccmv1alpha1.CoreWeaveKubernetesEngineInstanceName}
-
-		wt.Get(gvk.CoreWeaveKubernetesEngine, nn).Eventually().Should(
-			jq.Match(`.status.conditions[] | select(.type == "Ready") | .status == "True"`),
-		)
 
 		wt.Get(gvk.Deployment, types.NamespacedName{
 			Name: "cert-manager-operator-controller-manager", Namespace: "cert-manager-operator",
@@ -113,9 +100,6 @@ func TestCoreWeaveKubernetesEngine(t *testing.T) {
 
 		wtC.Get(gvk.CoreWeaveKubernetesEngine, nn).Eventually().Should(
 			jq.Match(`.status.conditions[] | select(.type == "DependenciesAvailable") | .status == "True"`),
-		)
-		wtC.Get(gvk.CoreWeaveKubernetesEngine, nn).Eventually().Should(
-			jq.Match(`.status.conditions[] | select(.type == "Ready") | .status == "True"`),
 		)
 	})
 }

--- a/pkg/controller/actions/dynamicownership/action_dynamic_ownership.go
+++ b/pkg/controller/actions/dynamicownership/action_dynamic_ownership.go
@@ -238,7 +238,11 @@ func (a *Action) run(ctx context.Context, rr *types.ReconciliationRequest) error
 			if customPredicates, ok := a.gvkPredicates[resGVK]; ok {
 				watchPredicates = customPredicates
 			} else {
-				watchPredicates = []predicate.Predicate{predicates.DefaultPredicate}
+				if resGVK == gvk.Deployment {
+					watchPredicates = []predicate.Predicate{predicates.DefaultDeploymentPredicate}
+				} else {
+					watchPredicates = []predicate.Predicate{predicates.DefaultPredicate}
+				}
 			}
 		} else {
 			// Watch only for deletion so the controller can recreate the resource if deleted.

--- a/pkg/controller/cloudmanager/action_reconcile.go
+++ b/pkg/controller/cloudmanager/action_reconcile.go
@@ -4,18 +4,25 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/status"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/deploy"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/render/helm"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/status/deployments"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/metadata/labels"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/resources"
 )
 
+var ConditionsTypes = []string{
+	status.ConditionDeploymentsAvailable,
+}
+
 // reconcileAction holds the configuration for the combined reconcile action.
 type reconcileAction struct {
 	helmOpts   []helm.ActionOpts
 	deployOpts []deploy.ActionOpts
+	resourceID string
 }
 
 // ReconcileActionOpts configures the combined reconcile action.
@@ -36,12 +43,21 @@ func WithDeployOptions(opts ...deploy.ActionOpts) ReconcileActionOpts {
 }
 
 // NewReconcileAction creates a combined action that:
-// 1. Renders Helm charts
-// 2. Runs PreApply hooks from HelmCharts
-// 3. Deploys resources via SSA
-// 4. Runs PostApply hooks from HelmCharts.
-func NewReconcileAction(opts ...ReconcileActionOpts) actions.Fn {
-	action := reconcileAction{}
+// - Renders Helm charts
+// - Runs PreApply hooks from HelmCharts
+// - Sets infrastructure labels on rendered resources
+// - Deploys resources via SSA
+// - Runs PostApply hooks from HelmCharts
+// - Checks deployment status.
+func NewReconcileAction(resourceID string, opts ...ReconcileActionOpts) actions.Fn {
+	resourceID = labels.NormalizePartOfValue(resourceID)
+	if resourceID == "" {
+		panic("resourceID is required")
+	}
+
+	action := reconcileAction{
+		resourceID: resourceID,
+	}
 
 	for _, opt := range opts {
 		opt(&action)
@@ -49,6 +65,12 @@ func NewReconcileAction(opts ...ReconcileActionOpts) actions.Fn {
 
 	helmRender := helm.NewAction(action.helmOpts...)
 	deployAction := deploy.NewAction(action.deployOpts...)
+	deploymentsAction := deployments.NewAction(
+		deployments.InNamespaceFn(func(_ context.Context, _ *types.ReconciliationRequest) (string, error) {
+			return "", nil
+		}),
+		deployments.WithSelectorLabel(labels.InfrastructurePartOf, action.resourceID),
+	)
 
 	return func(ctx context.Context, rr *types.ReconciliationRequest) error {
 		// Render Helm charts (populates rr.Resources)
@@ -65,12 +87,8 @@ func NewReconcileAction(opts ...ReconcileActionOpts) actions.Fn {
 		}
 
 		// Set infrastructure label on all rendered resources
-		kind, err := resources.KindForObject(rr.Client.Scheme(), rr.Instance)
-		if err != nil {
-			return fmt.Errorf("failed to get instance kind: %w", err)
-		}
 		for i := range rr.Resources {
-			resources.SetLabel(&rr.Resources[i], labels.InfrastructurePartOf, labels.NormalizePartOfValue(kind))
+			resources.SetLabel(&rr.Resources[i], labels.InfrastructurePartOf, action.resourceID)
 		}
 
 		// Deploy resources via SSA
@@ -84,6 +102,12 @@ func NewReconcileAction(opts ...ReconcileActionOpts) actions.Fn {
 		})
 		if err != nil {
 			return err
+		}
+
+		// Check deployments
+		// TODO: the monitoring should be set per dependency to improve user experience
+		if err := deploymentsAction(ctx, rr); err != nil {
+			return fmt.Errorf("deployments check failed: %w", err)
 		}
 
 		return nil

--- a/pkg/controller/cloudmanager/action_reconcile_integration_test.go
+++ b/pkg/controller/cloudmanager/action_reconcile_integration_test.go
@@ -19,9 +19,11 @@ import (
 
 	ccmv1alpha1 "github.com/opendatahub-io/opendatahub-operator/v2/api/cloudmanager/azure/v1alpha1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/api/common"
+	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/status"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/render/helm"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/cloudmanager"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/conditions"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/metadata/labels"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/resources"
@@ -31,19 +33,25 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-const testReleaseName = "test"
+const (
+	testReleaseName = "test"
+	testResourceID  = "testresourceid"
+)
 
 func newTestReconcileAction() func(context.Context, *types.ReconciliationRequest) error {
 	return cloudmanager.NewReconcileAction(
+		testResourceID,
 		cloudmanager.WithDeployOptions(),
 		cloudmanager.WithHelmOptions(helm.WithCache(false)),
 	)
 }
 
 func newTestReconciliationRequest(cl client.Client, charts []types.HelmChartInfo) *types.ReconciliationRequest {
-	return &types.ReconciliationRequest{
+	instance := &ccmv1alpha1.AzureKubernetesEngine{}
+
+	rr := &types.ReconciliationRequest{
 		Client:   cl,
-		Instance: &ccmv1alpha1.AzureKubernetesEngine{},
+		Instance: instance,
 		Controller: mocks.NewMockController(func(m *mocks.MockController) {
 			m.On("Owns", mock.Anything).Return(false)
 		}),
@@ -55,6 +63,10 @@ func newTestReconciliationRequest(cl client.Client, charts []types.HelmChartInfo
 		},
 		HelmCharts: charts,
 	}
+
+	rr.Conditions = conditions.NewManager(instance, status.ConditionTypeReady)
+
+	return rr
 }
 
 func checkTestChartDeployedResources(t *testing.T, g *WithT, ctx context.Context, cl client.Client, ns, releaseName string) {
@@ -289,7 +301,7 @@ func TestNewReconcileAction_SetsInfrastructureLabel(t *testing.T) {
 
 	for _, res := range rr.Resources {
 		g.Expect(resources.GetLabel(&res, labels.InfrastructurePartOf)).
-			Should(Equal("azurekubernetesengine"))
+			Should(Equal(testResourceID))
 	}
 }
 

--- a/pkg/controller/predicates/predicates.go
+++ b/pkg/controller/predicates/predicates.go
@@ -4,6 +4,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/predicates/generation"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/predicates/resources"
 )
 
 var (
@@ -15,6 +16,12 @@ var (
 	// metadata (labels, annotations) have changed.
 	DefaultPredicate = predicate.Or(
 		generation.New(),
+		predicate.LabelChangedPredicate{},
+		predicate.AnnotationChangedPredicate{},
+	)
+
+	DefaultDeploymentPredicate = predicate.Or(
+		resources.NewDeploymentPredicate(),
 		predicate.LabelChangedPredicate{},
 		predicate.AnnotationChangedPredicate{},
 	)


### PR DESCRIPTION
## Description
- Replace static `Owns()` declarations in Azure and CoreWeave cloud manager controllers with `WithDynamicOwnership()`, which automatically set deployed resources as owned.
- Simplify the cloud manager cache to filter by existence of the `infrastructure-part-of` label rather than matching a specific value, so a single cache configuration works for all cloud manager providers.
- Enhance `NewReconcileAction` to accept a `resourceID` parameter, add deployment availability status checks, and expose `ConditionsTypes` for consistent condition reporting.

Jira task: https://issues.redhat.com/browse/RHOAIENG-51613

## How Has This Been Tested?
- Updated existing unit tests for `DefaultCacheOptions` to validate label-existence matching.
- Updated integration tests for `NewReconcileAction` to verify the new `resourceID` parameter and infrastructure label assignment.
- Removed obsolete `CreateNamespaceHook` tests that are no longer needed.
- Verified with `make unit-test`.


## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [x] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->
e2e tests for cloud controller manager will be added in a following PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Switched to dynamic ownership and now filter/label resources by the presence of an infrastructure label.
  * Simplified cache configuration to a single-parameter default and made cache options optional.

* **Improvements**
  * Added deployment readiness verification to reconcile flows.
  * Added a deployment-specific event predicate to improve event filtering.

* **Chores**
  * Removed an internal namespace hook and its tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->