### PR TITLE
test: verify helm crds/ directory resources are rendered

### DIFF
--- a/pkg/controller/actions/render/helm/action_render_manifests_test.go
+++ b/pkg/controller/actions/render/helm/action_render_manifests_test.go
@@ -180,6 +180,51 @@ func TestRenderMultipleHelmCharts(t *testing.T) {
 	))
 }
 
+func TestCRDInCrdsDirIsNotTemplated(t *testing.T) {
+	g := NewWithT(t)
+
+	ctx := t.Context()
+	ns := xid.New().String()
+	chartDir := filepath.Join("testdata", "with-crds-dir")
+
+	action := helm.NewAction(
+		helm.WithCache(false),
+	)
+
+	rr := types.ReconciliationRequest{
+		Instance: &ccmv1alpha1.AzureKubernetesEngine{},
+		HelmCharts: []types.HelmChartInfo{{
+			Source: helmRenderer.Source{
+				Chart:       chartDir,
+				ReleaseName: "test-crds-dir",
+				Values: helmRenderer.Values(map[string]any{
+					"namespace": ns,
+				}),
+			},
+		}},
+	}
+
+	err := action(ctx, &rr)
+
+	g.Expect(err).ShouldNot(HaveOccurred())
+	g.Expect(rr.Resources).Should(HaveLen(2))
+
+	// CRDs from crds/ directory are not template-rendered by the Helm engine,
+	// they are decoded as raw YAML. They should appear first in the output.
+	g.Expect(rr.Resources[0]).Should(And(
+		jq.Match(`.kind == "CustomResourceDefinition"`),
+		jq.Match(`.metadata.name == "testresources.test.opendatahub.io"`),
+	))
+
+	// Templates from templates/ directory are rendered through the Helm engine
+	g.Expect(rr.Resources[1]).Should(And(
+		jq.Match(`.kind == "TestResource"`),
+		jq.Match(`.metadata.namespace == "%s"`, ns),
+		jq.Match(`.metadata.name == "test-crds-dir-instance"`),
+		jq.Match(`.spec.message == "Hello from test-crds-dir"`),
+	))
+}
+
 func TestCRDAndCRRender(t *testing.T) {
 	g := NewWithT(t)
 

--- a/pkg/controller/actions/render/helm/testdata/with-crds-dir/Chart.yaml
+++ b/pkg/controller/actions/render/helm/testdata/with-crds-dir/Chart.yaml
@@ -1,0 +1,3 @@
+apiVersion: v2
+name: with-crds-dir
+version: 0.1.0

--- a/pkg/controller/actions/render/helm/testdata/with-crds-dir/crds/crd.yaml
+++ b/pkg/controller/actions/render/helm/testdata/with-crds-dir/crds/crd.yaml
@@ -1,0 +1,25 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: testresources.test.opendatahub.io
+spec:
+  group: test.opendatahub.io
+  names:
+    kind: TestResource
+    listKind: TestResourceList
+    plural: testresources
+    singular: testresource
+  scope: Namespaced
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                message:
+                  type: string

--- a/pkg/controller/actions/render/helm/testdata/with-crds-dir/templates/cr.yaml
+++ b/pkg/controller/actions/render/helm/testdata/with-crds-dir/templates/cr.yaml
@@ -1,0 +1,7 @@
+apiVersion: test.opendatahub.io/v1alpha1
+kind: TestResource
+metadata:
+  name: {{ .Release.Name }}-instance
+  namespace: {{ .Values.namespace }}
+spec:
+  message: "Hello from {{ .Release.Name }}"

--- a/pkg/controller/actions/render/helm/testdata/with-crds-dir/values.yaml
+++ b/pkg/controller/actions/render/helm/testdata/with-crds-dir/values.yaml
@@ -1,0 +1,1 @@
+namespace: default


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
- Add a unit test to verify that CRDs placed in a Helm chart's `crds/` directory are correctly included in the rendered output as raw YAML (not template-rendered), alongside template-rendered resources from `templates/`.
- Adds a `with-crds-dir` test chart fixture containing a CRD in `crds/` and a templated CR in `templates/` to validate ordering and rendering behavior.

## How Has This Been Tested?
Run the new unit test:

```bash
make unit-test TEST_SRC="./pkg/controller/actions/render/helm/..."
```

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [x] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->
This PR only adds an unit test, no e2e are required

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a test verifying CRDs placed in a chart's crds directory are not Helm-templated, are emitted as raw YAML, and appear before templated resources.
  * Included test chart data (chart metadata, CRD definition, templated custom resource, and values) to validate rendering behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->