### PR TITLE
feat: update CCM cache to watch for RoleBinding in kube-system namespace

### DIFF
--- a/cmd/cloudmanager/app/cache.go
+++ b/cmd/cloudmanager/app/cache.go
@@ -13,7 +13,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/cloudmanager/common"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/metadata/labels"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/resources"
 )
 
 // DefaultCacheOptions builds cache.Options for the given scheme, watching the default
@@ -36,6 +38,14 @@ func DefaultCacheOptions(scheme *runtime.Scheme) (cache.Options, error) {
 		Label: labelSelector,
 	}
 
+	roleBindingCacheNamespaces := make(map[string]cache.Config, len(nsConfig)+1)
+	for ns, cfg := range nsConfig {
+		roleBindingCacheNamespaces[ns] = cfg
+	}
+	roleBindingCacheNamespaces[common.NamespaceKubeSystem] = cache.Config{
+		LabelSelector: labelSelector,
+	}
+
 	return cache.Options{
 		Scheme:            scheme,
 		DefaultNamespaces: nsConfig,
@@ -43,6 +53,9 @@ func DefaultCacheOptions(scheme *runtime.Scheme) (cache.Options, error) {
 			&rbacv1.ClusterRole{}:             clusterScopedConfig,
 			&rbacv1.ClusterRoleBinding{}:      clusterScopedConfig,
 			&extv1.CustomResourceDefinition{}: clusterScopedConfig,
+			resources.GvkToUnstructured(gvk.RoleBinding): {
+				Namespaces: roleBindingCacheNamespaces,
+			},
 		},
 		DefaultTransform: func(in any) (any, error) {
 			// Nilcheck managed fields to avoid hitting https://github.com/kubernetes/kubernetes/issues/124337

--- a/cmd/cloudmanager/app/cache_test.go
+++ b/cmd/cloudmanager/app/cache_test.go
@@ -7,8 +7,13 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8slabels "k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/opendatahub-io/opendatahub-operator/v2/cmd/cloudmanager/app"
+	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/cloudmanager/common"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/metadata/labels"
 
 	. "github.com/onsi/gomega"
@@ -26,6 +31,14 @@ func TestDefaultCacheOptions(t *testing.T) {
 		g.Expect(opts.ByObject).ToNot(BeEmpty(), "expected at least one selector for cluster-scoped resource types")
 
 		for obj, byObj := range opts.ByObject {
+			if obj.GetObjectKind().GroupVersionKind() == gvk.RoleBinding {
+				g.Expect(byObj.Label).To(BeNil(),
+					"RoleBinding should use per-namespace label selectors, not a top-level label selector")
+				continue
+			}
+			g.Expect(byObj.Label).ToNot(BeNil(),
+				"label selector for %T should not be nil", obj)
+
 			withLabel := k8slabels.Set{
 				labels.InfrastructurePartOf: "azurekubernetesengine",
 			}
@@ -70,4 +83,72 @@ func TestDefaultCacheOptions(t *testing.T) {
 		g.Expect(ok).To(BeTrue())
 		g.Expect(transformed.GetManagedFields()).To(BeNil())
 	})
+
+	t.Run("RoleBinding cache covers managed namespaces and kube-system", func(t *testing.T) {
+		g := NewWithT(t)
+
+		opts, err := app.DefaultCacheOptions(s)
+		g.Expect(err).ShouldNot(HaveOccurred())
+
+		rbByObj := findByObjectGVK(g, opts.ByObject, gvk.RoleBinding)
+
+		expectedNS := append(common.ManagedNamespaces(), common.NamespaceKubeSystem)
+		g.Expect(rbByObj.Namespaces).To(HaveLen(len(expectedNS)))
+		for _, ns := range expectedNS {
+			g.Expect(rbByObj.Namespaces).To(HaveKey(ns),
+				"RoleBinding namespaces should include %s", ns)
+		}
+	})
+
+	t.Run("RoleBinding cache filters kube-system namespace by label selector", func(t *testing.T) {
+		g := NewWithT(t)
+
+		opts, err := app.DefaultCacheOptions(s)
+		g.Expect(err).ShouldNot(HaveOccurred())
+
+		rbByObj := findByObjectGVK(g, opts.ByObject, gvk.RoleBinding)
+		ksConfig := rbByObj.Namespaces[common.NamespaceKubeSystem]
+
+		g.Expect(ksConfig.LabelSelector).ShouldNot(BeNil(),
+			"kube-system config should have a label selector")
+
+		matching := k8slabels.Set{
+			labels.InfrastructurePartOf: "azurekubernetesengine",
+		}
+		g.Expect(ksConfig.LabelSelector.Matches(matching)).To(BeTrue(),
+			"kube-system label selector should match %v", matching)
+
+		nonMatching := k8slabels.Set{
+			"test-label": "test-value",
+		}
+		g.Expect(ksConfig.LabelSelector.Matches(nonMatching)).To(BeFalse(),
+			"kube-system label selector should not match resources without %s label", labels.InfrastructurePartOf)
+	})
+
+	t.Run("RoleBinding cache does not filter managed namespaces by label selector", func(t *testing.T) {
+		g := NewWithT(t)
+
+		opts, err := app.DefaultCacheOptions(s)
+		g.Expect(err).ShouldNot(HaveOccurred())
+
+		rbByObj := findByObjectGVK(g, opts.ByObject, gvk.RoleBinding)
+
+		for _, ns := range common.ManagedNamespaces() {
+			nsConfig := rbByObj.Namespaces[ns]
+			g.Expect(nsConfig.LabelSelector).To(BeNil(),
+				"managed namespace %s should not have a label selector", ns)
+		}
+	})
+}
+
+func findByObjectGVK(g Gomega, byObject map[client.Object]cache.ByObject, target schema.GroupVersionKind) cache.ByObject {
+	for obj, byObj := range byObject {
+		if obj.GetObjectKind().GroupVersionKind() == target {
+			return byObj
+		}
+	}
+
+	g.Expect(true).To(BeFalse(), "expected GVK %s to be present in ByObject", target)
+
+	return cache.ByObject{}
 }

--- a/internal/controller/cloudmanager/common/charts.go
+++ b/internal/controller/cloudmanager/common/charts.go
@@ -18,6 +18,7 @@ const (
 	NamespaceCertManagerOperator = "cert-manager-operator"
 	NamespaceLWSOperator         = "openshift-lws-operator"
 	NamespaceSailOperator        = "istio-system"
+	NamespaceKubeSystem          = "kube-system"
 )
 
 // chartDef describes a single Helm chart together with its target namespace


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
Update Cloud Controller Manager cache config to watch for labeled `RoleBinding` in `kube-system` namespace.

JIRA ref: [RHOAIENG-51788](https://issues.redhat.com/browse/RHOAIENG-51788)

## How Has This Been Tested?
Unit tests + manually tested on Kind cluster (setup CCM, create labeled RoleBinding in kube-system ns, check that reconcile was triggered)

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
E2E test suite for CCM is planned to be added in a later phase, non-xKS-related workflows remain unchanged by this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved RoleBinding caching to support per-namespace label-selector configuration and to consistently include the cluster system namespace (kube-system) in cache evaluation.
* **Tests**
  * Added tests validating RoleBinding cache behavior, enforcement of per-namespace label selectors, kube-system filtering by selector, and differences between managed namespaces and the system namespace.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->