### PR TITLE
RHOAIENG-52543: Add istio.io/rev label to Gateway DestinationRule for OSSM webhook scoping

### DIFF
--- a/internal/controller/services/gateway/gateway_controller_actions.go
+++ b/internal/controller/services/gateway/gateway_controller_actions.go
@@ -336,6 +336,8 @@ func getTemplateData(ctx context.Context, rr *odhtypes.ReconciliationRequest) (m
 		"ComponentLabelValue":      ComponentLabelValue,
 		"PartOfLabelKey":           labels.K8SCommon.PartOf,
 		"PartOfLabelValue":         PartOfLabelValue,
+		"IstioRevisionLabel":       IstioRevisionLabel,
+		"IstioRevisionValue":       IstioRevisionValue,
 		"PartOfGatewayConfig":      PartOfGatewayConfig,
 		"GatewayNameLabelKey":      labels.GatewayAPI.GatewayName,
 		"LegacySubdomain":          legacyInfo.LegacySubdomain,

--- a/internal/controller/services/gateway/gateway_integration_helpers_test.go
+++ b/internal/controller/services/gateway/gateway_integration_helpers_test.go
@@ -77,6 +77,7 @@ import (
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/manager"
+	metadatalabels "github.com/opendatahub-io/opendatahub-operator/v2/pkg/metadata/labels"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/resources"
 	testscheme "github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/scheme"
 	"github.com/opendatahub-io/opendatahub-operator/v2/tests/envtestutil"
@@ -177,6 +178,16 @@ func assertOwnedByGatewayConfig(g *WithT, obj client.Object) {
 		}
 	}
 	g.Expect(found).To(BeTrue(), "resource should be owned by GatewayConfig %s", serviceApi.GatewayConfigName)
+}
+
+func assertHasIstioRevisionLabel(g *WithT, obj *unstructured.Unstructured) map[string]string {
+	labels, found, err := unstructured.NestedStringMap(obj.Object, "metadata", "labels")
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(found).To(BeTrue(), "%s should have metadata.labels", obj.GetKind())
+	g.Expect(labels).To(HaveKey(gateway.IstioRevisionLabel))
+	g.Expect(labels[gateway.IstioRevisionLabel]).To(Equal(gateway.IstioRevisionValue),
+		"%s must have istio.io/rev=%s so OSSM webhook validates it", obj.GetKind(), gateway.IstioRevisionValue)
+	return labels
 }
 
 // TestEnvContext holds envtest context, cancel, env, client, and scheme for one auth mode.
@@ -917,6 +928,10 @@ func RunEnvoyFilterCreationTest(t *testing.T, setup TestSetup) {
 	}, ef)).To(Succeed())
 	assertOwnedByGatewayConfig(g, ef)
 
+	labels := assertHasIstioRevisionLabel(g, ef)
+	g.Expect(labels).To(HaveKeyWithValue(metadatalabels.K8SCommon.PartOf, gateway.PartOfLabelValue),
+		"EnvoyFilter should match DestinationRule: app.kubernetes.io/part-of for consistent Istio resource grouping")
+
 	selector, found, err := unstructured.NestedStringMap(ef.Object, "spec", "workloadSelector", "labels")
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(found).To(BeTrue())
@@ -1615,6 +1630,8 @@ func RunDestinationRuleCreationTest(t *testing.T, setup TestSetup) {
 		Namespace: gateway.GatewayNamespace,
 	}, dr)).To(Succeed())
 	assertOwnedByGatewayConfig(g, dr)
+
+	assertHasIstioRevisionLabel(g, dr)
 
 	// Verify host is wildcard
 	host, found, err := unstructured.NestedString(dr.Object, "spec", "host")

--- a/internal/controller/services/gateway/resources/envoyfilter-authn.tmpl.yaml
+++ b/internal/controller/services/gateway/resources/envoyfilter-authn.tmpl.yaml
@@ -4,7 +4,9 @@ metadata:
   name: {{.EnvoyFilter}}
   namespace: {{.GatewayNamespace}}
   labels:
+    {{.PartOfLabelKey}}: {{.PartOfLabelValue}}
     {{.ComponentLabelKey}}: {{.ComponentLabelValue}}
+    {{.IstioRevisionLabel}}: {{.IstioRevisionValue}}
 spec:
   workloadSelector:
     labels:

--- a/internal/controller/services/gateway/resources/kube-auth-proxy-destinationrule-tls.tmpl.yaml
+++ b/internal/controller/services/gateway/resources/kube-auth-proxy-destinationrule-tls.tmpl.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
     {{.PartOfLabelKey}}: {{.PartOfLabelValue}}
     {{.ComponentLabelKey}}: {{.ComponentLabelValue}}
+    {{.IstioRevisionLabel}}: {{.IstioRevisionValue}}
 spec:
   host: "*"
   trafficPolicy:

--- a/tests/e2e/gateway_test.go
+++ b/tests/e2e/gateway_test.go
@@ -487,6 +487,8 @@ func (tc *GatewayTestCtx) ValidateEnvoyFilter(t *testing.T) {
 			Namespace: gatewayNamespace,
 		}),
 		WithCondition(And(
+			jq.Match(`.metadata.labels["%s"] == "%s"`, labels.K8SCommon.PartOf, gateway.PartOfLabelValue),
+
 			// workload selector
 			jq.Match(`.spec.workloadSelector.labels."%s" == "%s"`, labels.GatewayAPI.GatewayName, gatewayName),
 


### PR DESCRIPTION
## PR description

###  What

Add the `istio.io/rev: openshift-gateway` label to the DestinationRule created by the gateway controller (data-science-tls-rule in openshift-ingress).
Pass IstioRevisionLabel and IstioRevisionValue from the existing constants in gateway_support.go into the DestinationRule template data in gateway_controller_actions.go.

### Why

When another Istio (e.g. Aspen Mesh or an istioctl install) is on the cluster, it deploys a default validating webhook that selects resources without a revision label (istio.io/rev). Our DestinationRule was created with no revision label, so the API server sent it to that default webhook, which rejected it (“unrecognized type”) and blocked creation. OSSM’s webhook (objectSelector istio.io/rev: openshift-gateway) never saw the resource because the label was missing.

###  Adding istio.io/rev: openshift-gateway ensures:

The default (other Istio) webhook no longer matches our DestinationRule, so we avoid that rejection.
The API server sends the DestinationRule to OSSM’s webhook, which validates and allows it.
Testing

DestinationRule is created with the new label; istiod-openshift-gateway logs show it in config pushes `(e.g. “Push debounce … for config DestinationRule/openshift-ingress/data-science-tls-rule”)`.
On a cluster with only OSSM, gateway and DestinationRule behavior unchanged.
Resolves the GatewayConfig/DestinationRule failure when a second Istio (e.g. Aspen Mesh) is installed.
JIRA

[RHOAIENG-52543](https://issues.redhat.com/browse/RHOAIENG-52543) — Missing revision label on DestinationRule created by operator



### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
A simple bug fix adding integration test for this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensure Istio revision labels are applied to gateway-related resources so resources are correctly recognized across multiple Istio revisions.

* **Tests**
  * Added/updated tests to verify Istio revision and "part-of" labels are present on created gateway resources (EnvoyFilter, DestinationRule) during creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->