### PR TITLE
RHOAIENG-52189 | feat: Enable readOnlyRootFilesystem for opendatahub-operator controller-manager 

### DIFF
--- a/.github/config/security-baseline.yaml
+++ b/.github/config/security-baseline.yaml
@@ -21,16 +21,6 @@ kube-linter:
     acknowledged_by: opendatahub-operator-maintainers
     acknowledged_date: "2026-01-12"
 
-  - check: no-read-only-root-fs
-    object:
-      kind: Deployment
-      name: opendatahub-operator-controller-manager
-      namespace: opendatahub-operator-system
-    reason: "Operator modifies baked-in manifests under /opt/manifests at runtime (e.g., prometheus-configs.yaml, alertmanager-configs.yaml) during component reconciliation"
-    recommended_improvement: "Mount /opt/manifests as emptyDir at startup or convert manifests into read-only ConfigMaps to enable readOnlyRootFilesystem: true"
-    acknowledged_by: opendatahub-operator-maintainers
-    acknowledged_date: "2026-01-12"
-
 gitleaks: []
 trufflehog: []
 semgrep: []

--- a/Dockerfiles/Dockerfile
+++ b/Dockerfiles/Dockerfile
@@ -63,7 +63,7 @@ FROM --platform=$TARGETPLATFORM registry.access.redhat.com/ubi9/ubi-minimal:late
 WORKDIR /
 COPY --from=builder /workspace/manager .
 COPY --from=builder /workspace/cloudmanager .
-COPY --chown=1001:0 --from=manifests /opt/manifests /opt/manifests
+COPY --chown=1001:0 --from=manifests /opt/manifests /opt/manifests-template
 COPY --chown=1001:0 --from=manifests /opt/charts /opt/charts
 
 # tar installed to allow easy use of "oc cp" for component dev use cases.
@@ -71,7 +71,7 @@ COPY --chown=1001:0 --from=manifests /opt/charts /opt/charts
 RUN microdnf install -y tar && microdnf clean all
 
 # Recursive change all files
-RUN chmod -R g=u /opt/manifests /opt/charts
+RUN chmod -R g=u /opt/manifests-template /opt/charts
 USER 1001
 
 ENTRYPOINT ["/manager"]

--- a/Dockerfiles/rhoai.Dockerfile
+++ b/Dockerfiles/rhoai.Dockerfile
@@ -73,7 +73,7 @@ FROM --platform=$TARGETPLATFORM registry.access.redhat.com/ubi9/ubi-minimal:late
 WORKDIR /
 COPY --from=builder /workspace/manager .
 COPY --from=builder /workspace/cloudmanager .
-COPY --chown=1001:0 --from=manifests /opt/manifests /opt/manifests
+COPY --chown=1001:0 --from=manifests /opt/manifests /opt/manifests-template
 COPY --chown=1001:0 --from=manifests /opt/charts /opt/charts
 
 # tar installed to allow easy use of "oc cp" for component dev use cases.
@@ -81,7 +81,7 @@ COPY --chown=1001:0 --from=manifests /opt/charts /opt/charts
 RUN microdnf install -y tar && microdnf clean all
 
 # Recursive change all files
-RUN chmod -R g=u /opt/manifests /opt/charts
+RUN chmod -R g=u /opt/manifests-template /opt/charts
 USER 1001
 
 ENTRYPOINT ["/manager"]

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -51,6 +51,27 @@ spec:
         runAsNonRoot: true
         seccompProfile:
           type: RuntimeDefault
+      initContainers:
+      - name: copy-manifests
+        image: REPLACE_IMAGE:latest
+        imagePullPolicy: Always
+        command: ["cp", "-r", "--preserve=mode,timestamps", "/opt/manifests-template/.", "/opt/manifests/"]
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+              - "ALL"
+        resources:
+          requests:
+            cpu: 10m
+            memory: 64Mi
+          limits:
+            cpu: 100m
+            memory: 256Mi
+        volumeMounts:
+        - name: manifests
+          mountPath: /opt/manifests
       containers:
       - command:
         - /manager
@@ -78,6 +99,7 @@ spec:
             name: http
         securityContext:
           allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
           capabilities:
             drop:
               - "ALL"
@@ -102,5 +124,11 @@ spec:
           requests:
             cpu: 100m
             memory: 780Mi
+        volumeMounts:
+        - name: manifests
+          mountPath: /opt/manifests
+      volumes:
+      - name: manifests
+        emptyDir: {}
       serviceAccountName: controller-manager
       terminationGracePeriodSeconds: 10

--- a/config/rhoai/manager/manager.yaml
+++ b/config/rhoai/manager/manager.yaml
@@ -48,6 +48,27 @@ spec:
         runAsNonRoot: true
         seccompProfile:
           type: RuntimeDefault
+      initContainers:
+      - name: copy-manifests
+        image: REPLACE_IMAGE:latest-rhoai
+        imagePullPolicy: Always
+        command: ["cp", "-r", "--preserve=mode,timestamps", "/opt/manifests-template/.", "/opt/manifests/"]
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+              - "ALL"
+        resources:
+          requests:
+            cpu: 10m
+            memory: 64Mi
+          limits:
+            cpu: 100m
+            memory: 256Mi
+        volumeMounts:
+        - name: manifests
+          mountPath: /opt/manifests
       containers:
       - name: rhods-operator
         command:
@@ -70,6 +91,7 @@ spec:
         imagePullPolicy: Always
         securityContext:
           allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
           capabilities:
             drop:
               - "ALL"
@@ -94,5 +116,11 @@ spec:
           requests:
             cpu: 500m
             memory: 256Mi
+        volumeMounts:
+        - name: manifests
+          mountPath: /opt/manifests
+      volumes:
+      - name: manifests
+        emptyDir: {}
       serviceAccountName: redhat-ods-operator-controller-manager
       terminationGracePeriodSeconds: 10


### PR DESCRIPTION


<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
Enable readOnlyRootFilesystem for opendatahub-operator controller-manager
https://issues.redhat.com/browse/RHOAIENG-52189 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->

No code changes relating to code functionality


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an init step that copies manifest templates into a shared runtime manifests volume so the manager has predictable manifests at startup.

* **Chores**
  * Strengthened container security: read-only root filesystem, dropped capabilities, and disabled privilege escalation.
  * Exposed a runtime manifests path via environment variable for consistent access.
  * Adjusted packaging to use a dedicated manifests template location and updated related image handling.
* **Chore**
  * Updated security baseline configuration to remove a specific read-only-rootfs check.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->