### PR TITLE
RHOAIENG-49711: Support status check of KServe also in xKS environment

### DIFF
--- a/internal/controller/components/kserve/kserve_controller.go
+++ b/internal/controller/components/kserve/kserve_controller.go
@@ -21,7 +21,6 @@ import (
 	"strings"
 
 	templatev1 "github.com/openshift/api/template/v1"
-	"github.com/operator-framework/api/pkg/operators/v1alpha1"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	appsv1 "k8s.io/api/apps/v1"
@@ -32,11 +31,9 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
-	"github.com/opendatahub-io/opendatahub-operator/v2/api/common"
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/api/components/v1alpha1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
-	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/dependency"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/deploy"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/gc"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/render/kustomize"
@@ -52,7 +49,7 @@ import (
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/metadata/labels"
 )
 
-// NewComponentReconciler creates a ComponentReconciler for the Dashboard API.
+// NewComponentReconciler creates a ComponentReconciler for the Kserve API.
 func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.Manager) error {
 	versionPrefix := strings.ReplaceAll("v"+cluster.GetRelease().Version.String(), ".", "-")
 
@@ -98,10 +95,20 @@ func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.
 			reconciler.WithEventHandler(
 				handlers.ToNamed(componentApi.KserveInstanceName)),
 			reconciler.WithPredicates(
-				component.ForLabel(labels.ODH.Component(LegacyComponentName), labels.True),
+				predicate.Or(
+					component.ForLabel(labels.ODH.Component(LegacyComponentName), labels.True),
+					resources.CreatedOrUpdatedOrDeletedNameSuffixed(".networking.istio.io"),
+					resources.CreatedOrUpdatedOrDeletedNameSuffixed(".security.istio.io"),
+					resources.CreatedOrUpdatedOrDeletedNameSuffixed(".telemetry.istio.io"),
+					resources.CreatedOrUpdatedOrDeletedNameSuffixed(".extensions.istio.io"),
+					resources.CreatedOrUpdatedOrDeletedNameSuffixed(".cert-manager.io"),
+					resources.CreatedOrUpdatedOrDeletedNameSuffixed(".leaderworkerset.x-k8s.io"),
+					resources.CreatedOrUpdatedOrDeletedNamed(gvk.LeaderWorkerSetOperatorCRDname),
+					resources.CreatedOrUpdatedOrDeletedNamed(gvk.SubscriptionCRDname),
+				),
 			),
 		).
-		Watches(&v1alpha1.Subscription{},
+		WatchesGVK(gvk.Subscription,
 			reconciler.WithEventHandler(
 				handlers.ToNamed(componentApi.KserveInstanceName),
 			),
@@ -111,7 +118,7 @@ func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.
 					resources.CreatedOrUpdatedOrDeletedNamed(lwsOperatorSubscription),
 				),
 			),
-		).
+			reconciler.Dynamic(reconciler.CrdExists(gvk.Subscription))).
 		WatchesGVK(gvk.LeaderWorkerSetOperatorV1,
 			reconciler.WithEventHandler(
 				handlers.ToNamed(componentApi.KserveInstanceName),
@@ -120,17 +127,13 @@ func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.
 				dependent.New(dependent.WithWatchStatus(true)),
 			),
 			reconciler.Dynamic(reconciler.CrdExists(gvk.LeaderWorkerSetOperatorV1))).
+		// Watch for dependency CRDs (istio, cert-manager, leaderworkerset)
+		// so the controller re-reconciles when they appear or disappear.
 
 		// actions
-		WithAction(checkPreConditions).
 		WithAction(initialize).
-		WithAction(dependency.NewAction(
-			dependency.MonitorOperator(dependency.OperatorConfig{
-				OperatorGVK: gvk.LeaderWorkerSetOperatorV1,
-				Severity:    common.ConditionSeverityInfo,
-				Filter:      lwsConditionFilter,
-			}),
-		)).
+		WithAction(checkOperatorAndCRDDependencies()).
+		WithAction(checkSubscriptionDependencies()).
 		WithAction(releases.NewAction()).
 		WithAction(removeOwnershipFromUnmanagedResources).
 		WithAction(cleanUpTemplatedResources).

--- a/internal/controller/components/kserve/kserve_controller_actions.go
+++ b/internal/controller/components/kserve/kserve_controller_actions.go
@@ -3,7 +3,6 @@ package kserve
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -18,8 +17,9 @@ import (
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/api/components/v1alpha1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/dependency"
 	odherrors "github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/errors"
-	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/conditions"
 	odhtypes "github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
 	odhdeploy "github.com/opendatahub-io/opendatahub-operator/v2/pkg/deploy"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/metadata/labels"
@@ -181,61 +181,116 @@ func versionedWellKnownLLMInferenceServiceConfigs(_ context.Context, version str
 	return nil
 }
 
-// checkPreConditions checks if there are optional operators that KServe could use.
-func checkPreConditions(ctx context.Context, rr *odhtypes.ReconciliationRequest) error {
-	k, ok := rr.Instance.(*componentApi.Kserve)
-	if !ok {
-		return fmt.Errorf("resource instance %v is not a componentApi.Kserve)", rr.Instance)
-	}
+func checkOperatorAndCRDDependencies() actions.Fn {
+	return dependency.NewAction(
+		dependency.MonitorOperator(dependency.OperatorConfig{
+			OperatorGVK: gvk.LeaderWorkerSetOperatorV1,
+			Severity:    common.ConditionSeverityInfo,
+			Filter:      lwsConditionFilter,
+		}),
+		// networking.istio.io.
+		dependency.MonitorCRD(dependency.CRDConfig{
+			GVK:          gvk.DestinationRule,
+			ClusterTypes: []string{cluster.ClusterTypeKubernetes},
+		}),
+		dependency.MonitorCRD(dependency.CRDConfig{
+			GVK:          gvk.EnvoyFilter,
+			ClusterTypes: []string{cluster.ClusterTypeKubernetes},
+		}),
+		dependency.MonitorCRD(dependency.CRDConfig{
+			GVK:          gvk.IstioGateway,
+			ClusterTypes: []string{cluster.ClusterTypeKubernetes},
+		}),
+		dependency.MonitorCRD(dependency.CRDConfig{
+			GVK:          gvk.ProxyConfig,
+			ClusterTypes: []string{cluster.ClusterTypeKubernetes},
+		}),
+		dependency.MonitorCRD(dependency.CRDConfig{
+			GVK:          gvk.ServiceEntry,
+			ClusterTypes: []string{cluster.ClusterTypeKubernetes},
+		}),
+		dependency.MonitorCRD(dependency.CRDConfig{
+			GVK:          gvk.Sidecar,
+			ClusterTypes: []string{cluster.ClusterTypeKubernetes},
+		}),
+		dependency.MonitorCRD(dependency.CRDConfig{
+			GVK:          gvk.WorkloadEntry,
+			ClusterTypes: []string{cluster.ClusterTypeKubernetes},
+		}),
+		dependency.MonitorCRD(dependency.CRDConfig{
+			GVK:          gvk.WorkloadGroup,
+			ClusterTypes: []string{cluster.ClusterTypeKubernetes},
+		}),
+		// security.istio.io.
+		dependency.MonitorCRD(dependency.CRDConfig{
+			GVK:          gvk.AuthorizationPolicy,
+			ClusterTypes: []string{cluster.ClusterTypeKubernetes},
+		}),
+		dependency.MonitorCRD(dependency.CRDConfig{
+			GVK:          gvk.PeerAuthentication,
+			ClusterTypes: []string{cluster.ClusterTypeKubernetes},
+		}),
+		dependency.MonitorCRD(dependency.CRDConfig{
+			GVK:          gvk.RequestAuthentication,
+			ClusterTypes: []string{cluster.ClusterTypeKubernetes},
+		}),
+		// telemetry.istio.io.
+		dependency.MonitorCRD(dependency.CRDConfig{
+			GVK:          gvk.Telemetry,
+			ClusterTypes: []string{cluster.ClusterTypeKubernetes},
+		}),
+		// extensions.istio.io.
+		dependency.MonitorCRD(dependency.CRDConfig{
+			GVK:          gvk.WasmPlugin,
+			ClusterTypes: []string{cluster.ClusterTypeKubernetes},
+		}),
+		// cert-manager.io.
+		dependency.MonitorCRD(dependency.CRDConfig{
+			GVK:          gvk.CertManagerCertificate,
+			ClusterTypes: []string{cluster.ClusterTypeKubernetes},
+		}),
+		dependency.MonitorCRD(dependency.CRDConfig{
+			GVK:          gvk.CertManagerCertificateRequest,
+			ClusterTypes: []string{cluster.ClusterTypeKubernetes},
+		}),
+		dependency.MonitorCRD(dependency.CRDConfig{
+			GVK:          gvk.CertManagerIssuer,
+			ClusterTypes: []string{cluster.ClusterTypeKubernetes},
+		}),
+		dependency.MonitorCRD(dependency.CRDConfig{
+			GVK:          gvk.CertManagerClusterIssuer,
+			ClusterTypes: []string{cluster.ClusterTypeKubernetes},
+		}),
+		// leaderworkerset.x-k8s.io.
+		dependency.MonitorCRD(dependency.CRDConfig{
+			GVK:          gvk.LeaderWorkerSetV1,
+			ClusterTypes: []string{cluster.ClusterTypeKubernetes},
+		}),
+	)
+}
 
-	rr.Conditions.MarkUnknown(LLMInferenceServiceDependencies)
-	rr.Conditions.MarkUnknown(LLMInferenceServiceWideEPDependencies)
-
-	rhclFound, err := cluster.SubscriptionExists(ctx, rr.Client, rhclOperatorSubscription)
-	if err != nil && !k8serr.IsNotFound(err) {
-		return fmt.Errorf("failed to check Red Hat Connectivity Link subscription: %w", err)
-	}
-	lwsFound, err := cluster.SubscriptionExists(ctx, rr.Client, lwsOperatorSubscription)
-	if err != nil && !k8serr.IsNotFound(err) {
-		return fmt.Errorf("failed to check Leader Worker Set subscription: %w", err)
-	}
-	// LLMInferenceService requires only the RHCL operator
-	if rhclFound {
-		conditions.SetStatusCondition(k, common.Condition{
-			Type:   LLMInferenceServiceDependencies,
-			Status: metav1.ConditionTrue,
-		})
-	} else {
-		conditions.SetStatusCondition(k, common.Condition{
-			Type:     LLMInferenceServiceDependencies,
-			Status:   metav1.ConditionFalse,
-			Reason:   subNotFound,
-			Message:  "Warning: Red Hat Connectivity Link is not installed, LLMInferenceService cannot be used",
-			Severity: common.ConditionSeverityInfo,
-		})
-	}
-	// Wide Expert Parallelism requires both RHCL and LWS operators
-	if rhclFound && lwsFound {
-		conditions.SetStatusCondition(k, common.Condition{
-			Type:   LLMInferenceServiceWideEPDependencies,
-			Status: metav1.ConditionTrue,
-		})
-	} else {
-		// Build message indicating which dependencies are missing
-		var missing []string
-		if !rhclFound {
-			missing = append(missing, "Red Hat Connectivity Link")
-		}
-		if !lwsFound {
-			missing = append(missing, "LeaderWorkerSet")
-		}
-		conditions.SetStatusCondition(k, common.Condition{
-			Type:     LLMInferenceServiceWideEPDependencies,
-			Status:   metav1.ConditionFalse,
-			Reason:   subNotFound,
-			Message:  fmt.Sprintf("Warning: %s not installed, Wide Expert Parallelism with LLMInferenceService cannot be used", strings.Join(missing, " and ")),
-			Severity: common.ConditionSeverityInfo,
-		})
-	}
-	return nil
+func checkSubscriptionDependencies() actions.Fn {
+	return dependency.NewSubscriptionAction(
+		dependency.CheckSubscriptionGroup(dependency.SubscriptionGroupConfig{
+			ConditionType: LLMInferenceServiceDependencies,
+			Subscriptions: []dependency.SubscriptionDependency{
+				{Name: rhclOperatorSubscription, DisplayName: "Red Hat Connectivity Link"},
+			},
+			ClusterTypes: []string{cluster.ClusterTypeOpenShift},
+			Reason:       subNotFound,
+			Message:      "Warning: %s is not installed, LLMInferenceService cannot be used",
+			Severity:     common.ConditionSeverityInfo,
+		}),
+		dependency.CheckSubscriptionGroup(dependency.SubscriptionGroupConfig{
+			ConditionType: LLMInferenceServiceWideEPDependencies,
+			Subscriptions: []dependency.SubscriptionDependency{
+				{Name: rhclOperatorSubscription, DisplayName: "Red Hat Connectivity Link"},
+				{Name: lwsOperatorSubscription, DisplayName: "LeaderWorkerSet"},
+			},
+			ClusterTypes: []string{cluster.ClusterTypeOpenShift},
+			Reason:       subNotFound,
+			Message:      "Warning: %s not installed, Wide Expert Parallelism with LLMInferenceService cannot be used",
+			Severity:     common.ConditionSeverityInfo,
+		}),
+	)
 }

--- a/internal/controller/components/kserve/kserve_controller_actions_test.go
+++ b/internal/controller/components/kserve/kserve_controller_actions_test.go
@@ -5,19 +5,27 @@ import (
 	"encoding/json"
 	"testing"
 
-	operatorv1 "github.com/openshift/api/operator/v1"
 	"github.com/operator-framework/api/pkg/operators/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	clientFake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/api/components/v1alpha1"
-	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/conditions"
+	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/status"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
+	cond "github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/conditions"
 	odhtypes "github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/metadata/labels"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/fakeclient"
+	testscheme "github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/scheme"
 
 	. "github.com/onsi/gomega"
 )
@@ -200,6 +208,329 @@ func TestCustomizeKserveConfigMap(t *testing.T) {
 	})
 }
 
+func TestCheckSubscriptionDependencies(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	const happyCondition = "Ready"
+
+	cluster.SetClusterInfo(cluster.ClusterInfo{Type: cluster.ClusterTypeOpenShift})
+	t.Cleanup(func() { cluster.SetClusterInfo(cluster.ClusterInfo{}) })
+
+	t.Run("RHCL subscription absent sets LLMInferenceServiceDependencies to False", func(t *testing.T) {
+		cli, err := fakeclient.New()
+		g.Expect(err).ShouldNot(HaveOccurred())
+
+		instance := &componentApi.Kserve{
+			ObjectMeta: metav1.ObjectMeta{Name: componentApi.KserveInstanceName},
+		}
+
+		condManager := cond.NewManager(instance, happyCondition,
+			LLMInferenceServiceDependencies, LLMInferenceServiceWideEPDependencies)
+
+		rr := &odhtypes.ReconciliationRequest{
+			Client:     cli,
+			Instance:   instance,
+			Conditions: condManager,
+		}
+
+		action := checkSubscriptionDependencies()
+		err = action(ctx, rr)
+		g.Expect(err).ShouldNot(HaveOccurred())
+
+		got := condManager.GetCondition(LLMInferenceServiceDependencies)
+		g.Expect(got).ShouldNot(BeNil())
+		g.Expect(got.Status).Should(Equal(metav1.ConditionFalse))
+		g.Expect(got.Message).Should(ContainSubstring("Red Hat Connectivity Link"))
+	})
+
+	t.Run("RHCL subscription present sets LLMInferenceServiceDependencies to True", func(t *testing.T) {
+		rhclSub := &v1alpha1.Subscription{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      rhclOperatorSubscription,
+				Namespace: "openshift-operators",
+			},
+		}
+		cli, err := fakeclient.New(fakeclient.WithObjects(rhclSub))
+		g.Expect(err).ShouldNot(HaveOccurred())
+
+		instance := &componentApi.Kserve{
+			ObjectMeta: metav1.ObjectMeta{Name: componentApi.KserveInstanceName},
+		}
+
+		condManager := cond.NewManager(instance, happyCondition,
+			LLMInferenceServiceDependencies, LLMInferenceServiceWideEPDependencies)
+
+		rr := &odhtypes.ReconciliationRequest{
+			Client:     cli,
+			Instance:   instance,
+			Conditions: condManager,
+		}
+
+		action := checkSubscriptionDependencies()
+		err = action(ctx, rr)
+		g.Expect(err).ShouldNot(HaveOccurred())
+
+		got := condManager.GetCondition(LLMInferenceServiceDependencies)
+		g.Expect(got).ShouldNot(BeNil())
+		g.Expect(got.Status).Should(Equal(metav1.ConditionTrue))
+	})
+
+	t.Run("Only LWS absent sets LLMInferenceServiceWideEPDependencies to False", func(t *testing.T) {
+		rhclSub := &v1alpha1.Subscription{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      rhclOperatorSubscription,
+				Namespace: "openshift-operators",
+			},
+		}
+		cli, err := fakeclient.New(fakeclient.WithObjects(rhclSub))
+		g.Expect(err).ShouldNot(HaveOccurred())
+
+		instance := &componentApi.Kserve{
+			ObjectMeta: metav1.ObjectMeta{Name: componentApi.KserveInstanceName},
+		}
+
+		condManager := cond.NewManager(instance, happyCondition,
+			LLMInferenceServiceDependencies, LLMInferenceServiceWideEPDependencies)
+
+		rr := &odhtypes.ReconciliationRequest{
+			Client:     cli,
+			Instance:   instance,
+			Conditions: condManager,
+		}
+
+		action := checkSubscriptionDependencies()
+		err = action(ctx, rr)
+		g.Expect(err).ShouldNot(HaveOccurred())
+
+		// RHCL is present, so LLMInferenceServiceDependencies should be True
+		got := condManager.GetCondition(LLMInferenceServiceDependencies)
+		g.Expect(got).ShouldNot(BeNil())
+		g.Expect(got.Status).Should(Equal(metav1.ConditionTrue))
+
+		// LWS is absent, so LLMInferenceServiceWideEPDependencies should be False
+		gotWide := condManager.GetCondition(LLMInferenceServiceWideEPDependencies)
+		g.Expect(gotWide).ShouldNot(BeNil())
+		g.Expect(gotWide.Status).Should(Equal(metav1.ConditionFalse))
+		g.Expect(gotWide.Message).Should(ContainSubstring("LeaderWorkerSet"))
+		g.Expect(gotWide.Message).ShouldNot(ContainSubstring("Red Hat Connectivity Link"))
+	})
+
+	t.Run("Both RHCL and LWS present sets both conditions to True", func(t *testing.T) {
+		rhclSub := &v1alpha1.Subscription{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      rhclOperatorSubscription,
+				Namespace: "openshift-operators",
+			},
+		}
+		lwsSub := &v1alpha1.Subscription{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      lwsOperatorSubscription,
+				Namespace: "openshift-operators",
+			},
+		}
+		cli, err := fakeclient.New(fakeclient.WithObjects(rhclSub, lwsSub))
+		g.Expect(err).ShouldNot(HaveOccurred())
+
+		instance := &componentApi.Kserve{
+			ObjectMeta: metav1.ObjectMeta{Name: componentApi.KserveInstanceName},
+		}
+
+		condManager := cond.NewManager(instance, happyCondition,
+			LLMInferenceServiceDependencies, LLMInferenceServiceWideEPDependencies)
+
+		rr := &odhtypes.ReconciliationRequest{
+			Client:     cli,
+			Instance:   instance,
+			Conditions: condManager,
+		}
+
+		action := checkSubscriptionDependencies()
+		err = action(ctx, rr)
+		g.Expect(err).ShouldNot(HaveOccurred())
+
+		got := condManager.GetCondition(LLMInferenceServiceDependencies)
+		g.Expect(got).ShouldNot(BeNil())
+		g.Expect(got.Status).Should(Equal(metav1.ConditionTrue))
+
+		gotWide := condManager.GetCondition(LLMInferenceServiceWideEPDependencies)
+		g.Expect(gotWide).ShouldNot(BeNil())
+		g.Expect(gotWide.Status).Should(Equal(metav1.ConditionTrue))
+	})
+
+	t.Run("Non-OpenShift cluster skips checks and don't add conditions", func(t *testing.T) {
+		cluster.SetClusterInfo(cluster.ClusterInfo{Type: cluster.ClusterTypeKubernetes})
+		t.Cleanup(func() { cluster.SetClusterInfo(cluster.ClusterInfo{Type: cluster.ClusterTypeOpenShift}) })
+
+		cli, err := fakeclient.New()
+		g.Expect(err).ShouldNot(HaveOccurred())
+
+		instance := &componentApi.Kserve{
+			ObjectMeta: metav1.ObjectMeta{Name: componentApi.KserveInstanceName},
+		}
+
+		condManager := cond.NewManager(instance, happyCondition)
+
+		rr := &odhtypes.ReconciliationRequest{
+			Client:     cli,
+			Instance:   instance,
+			Conditions: condManager,
+		}
+
+		// No subscriptions present, but cluster is Kubernetes so checks should be skipped
+		action := checkSubscriptionDependencies()
+		err = action(ctx, rr)
+		g.Expect(err).ShouldNot(HaveOccurred())
+
+		got := condManager.GetCondition(LLMInferenceServiceDependencies)
+		g.Expect(got).Should(BeNil())
+
+		gotWide := condManager.GetCondition(LLMInferenceServiceWideEPDependencies)
+		g.Expect(gotWide).Should(BeNil())
+	})
+}
+
+func TestCheckOperatorAndCRDDependencies(t *testing.T) {
+	const happyCondition = "Ready"
+
+	// All CRD GVKs that the action monitors on Kubernetes clusters.
+	monitoredCRDGVKs := []string{
+		gvk.DestinationRule.Kind,
+		gvk.EnvoyFilter.Kind,
+		gvk.IstioGateway.Kind,
+		gvk.ProxyConfig.Kind,
+		gvk.ServiceEntry.Kind,
+		gvk.Sidecar.Kind,
+		gvk.WorkloadEntry.Kind,
+		gvk.WorkloadGroup.Kind,
+		gvk.AuthorizationPolicy.Kind,
+		gvk.PeerAuthentication.Kind,
+		gvk.RequestAuthentication.Kind,
+		gvk.Telemetry.Kind,
+		gvk.WasmPlugin.Kind,
+		gvk.CertManagerCertificate.Kind,
+		gvk.CertManagerCertificateRequest.Kind,
+		gvk.CertManagerIssuer.Kind,
+		gvk.CertManagerClusterIssuer.Kind,
+		gvk.LeaderWorkerSetV1.Kind,
+	}
+
+	t.Run("Kubernetes cluster with missing CRDs sets DependenciesAvailable to False", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		cluster.SetClusterInfo(cluster.ClusterInfo{Type: cluster.ClusterTypeKubernetes})
+		t.Cleanup(func() { cluster.SetClusterInfo(cluster.ClusterInfo{}) })
+
+		cli, err := fakeclient.New()
+		g.Expect(err).ShouldNot(HaveOccurred())
+
+		instance := &componentApi.Kserve{
+			ObjectMeta: metav1.ObjectMeta{Name: componentApi.KserveInstanceName},
+		}
+
+		condManager := cond.NewManager(instance, happyCondition, status.ConditionDependenciesAvailable)
+		rr := &odhtypes.ReconciliationRequest{
+			Client:     cli,
+			Instance:   instance,
+			Conditions: condManager,
+		}
+
+		action := checkOperatorAndCRDDependencies()
+		err = action(ctx, rr)
+		g.Expect(err).ShouldNot(HaveOccurred())
+
+		got := condManager.GetCondition(status.ConditionDependenciesAvailable)
+		g.Expect(got).ShouldNot(BeNil())
+		g.Expect(got.Status).Should(Equal(metav1.ConditionFalse))
+
+		for _, kind := range monitoredCRDGVKs {
+			g.Expect(got.Message).Should(ContainSubstring(kind), "expected message to mention %s", kind)
+		}
+	})
+
+	t.Run("Kubernetes cluster with all CRDs present sets DependenciesAvailable to True", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		cluster.SetClusterInfo(cluster.ClusterInfo{Type: cluster.ClusterTypeKubernetes})
+		t.Cleanup(func() { cluster.SetClusterInfo(cluster.ClusterInfo{}) })
+
+		allMonitoredGVKs := []schema.GroupVersionKind{
+			gvk.DestinationRule,
+			gvk.EnvoyFilter,
+			gvk.IstioGateway,
+			gvk.ProxyConfig,
+			gvk.ServiceEntry,
+			gvk.Sidecar,
+			gvk.WorkloadEntry,
+			gvk.WorkloadGroup,
+			gvk.AuthorizationPolicy,
+			gvk.PeerAuthentication,
+			gvk.RequestAuthentication,
+			gvk.Telemetry,
+			gvk.WasmPlugin,
+			gvk.CertManagerCertificate,
+			gvk.CertManagerCertificateRequest,
+			gvk.CertManagerIssuer,
+			gvk.CertManagerClusterIssuer,
+			gvk.LeaderWorkerSetV1,
+		}
+
+		cli, err := fakeclientWithCRDs(allMonitoredGVKs)
+		g.Expect(err).ShouldNot(HaveOccurred())
+
+		instance := &componentApi.Kserve{
+			ObjectMeta: metav1.ObjectMeta{Name: componentApi.KserveInstanceName},
+		}
+
+		condManager := cond.NewManager(instance, happyCondition, status.ConditionDependenciesAvailable)
+		rr := &odhtypes.ReconciliationRequest{
+			Client:     cli,
+			Instance:   instance,
+			Conditions: condManager,
+		}
+
+		action := checkOperatorAndCRDDependencies()
+		err = action(ctx, rr)
+		g.Expect(err).ShouldNot(HaveOccurred())
+
+		got := condManager.GetCondition(status.ConditionDependenciesAvailable)
+		g.Expect(got).ShouldNot(BeNil())
+		g.Expect(got.Status).Should(Equal(metav1.ConditionTrue))
+	})
+
+	t.Run("OpenShift cluster skips CRD checks and sets DependenciesAvailable to True", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		cluster.SetClusterInfo(cluster.ClusterInfo{Type: cluster.ClusterTypeOpenShift})
+		t.Cleanup(func() { cluster.SetClusterInfo(cluster.ClusterInfo{}) })
+
+		cli, err := fakeclient.New()
+		g.Expect(err).ShouldNot(HaveOccurred())
+
+		instance := &componentApi.Kserve{
+			ObjectMeta: metav1.ObjectMeta{Name: componentApi.KserveInstanceName},
+		}
+
+		condManager := cond.NewManager(instance, happyCondition, status.ConditionDependenciesAvailable)
+		rr := &odhtypes.ReconciliationRequest{
+			Client:     cli,
+			Instance:   instance,
+			Conditions: condManager,
+		}
+
+		action := checkOperatorAndCRDDependencies()
+		err = action(ctx, rr)
+		g.Expect(err).ShouldNot(HaveOccurred())
+
+		got := condManager.GetCondition(status.ConditionDependenciesAvailable)
+		g.Expect(got).ShouldNot(BeNil())
+		g.Expect(got.Status).Should(Equal(metav1.ConditionTrue))
+	})
+}
+
 func createTestConfigMap() *corev1.ConfigMap {
 	return &corev1.ConfigMap{
 		TypeMeta: metav1.TypeMeta{
@@ -218,97 +549,6 @@ func createTestConfigMap() *corev1.ConfigMap {
 			}`,
 		},
 	}
-}
-
-func Test_checkPreConditions(t *testing.T) {
-	g := NewWithT(t)
-	ctx := t.Context()
-	dsc := createDSCWithKserve(operatorv1.Managed)
-	kserve := createKserveCR(true)
-
-	t.Run("Test rhcl subscription is absent", func(t *testing.T) {
-		cli, err := fakeclient.New(fakeclient.WithObjects(kserve, dsc))
-		g.Expect(err).ShouldNot(HaveOccurred())
-
-		rr := &odhtypes.ReconciliationRequest{
-			Instance:   kserve,
-			Client:     cli,
-			Conditions: conditions.NewManager(kserve, LLMInferenceServiceDependencies),
-		}
-
-		err = checkPreConditions(ctx, rr)
-		g.Expect(err).ShouldNot(HaveOccurred())
-		cs := rr.Conditions.GetCondition(LLMInferenceServiceDependencies)
-		g.Expect(cs.Status).Should(Equal(metav1.ConditionFalse))
-	})
-
-	t.Run("Test rhcl subscription is present", func(t *testing.T) {
-		rhclSub := &v1alpha1.Subscription{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: rhclOperatorSubscription,
-			},
-		}
-		cli, err := fakeclient.New(fakeclient.WithObjects(kserve, dsc, rhclSub))
-		g.Expect(err).ShouldNot(HaveOccurred())
-
-		rr := &odhtypes.ReconciliationRequest{
-			Instance:   kserve,
-			Client:     cli,
-			Conditions: conditions.NewManager(kserve, LLMInferenceServiceDependencies),
-		}
-
-		err = checkPreConditions(ctx, rr)
-		g.Expect(err).ShouldNot(HaveOccurred())
-		cs := rr.Conditions.GetCondition(LLMInferenceServiceDependencies)
-		g.Expect(cs.Status).Should(Equal(metav1.ConditionTrue))
-	})
-
-	t.Run("Test only lws subscription is absent", func(t *testing.T) {
-		rhclSub := &v1alpha1.Subscription{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: rhclOperatorSubscription,
-			},
-		}
-		cli, err := fakeclient.New(fakeclient.WithObjects(kserve, dsc, rhclSub))
-		g.Expect(err).ShouldNot(HaveOccurred())
-
-		rr := &odhtypes.ReconciliationRequest{
-			Instance:   kserve,
-			Client:     cli,
-			Conditions: conditions.NewManager(kserve, LLMInferenceServiceWideEPDependencies),
-		}
-
-		err = checkPreConditions(ctx, rr)
-		g.Expect(err).ShouldNot(HaveOccurred())
-		cs := rr.Conditions.GetCondition(LLMInferenceServiceWideEPDependencies)
-		g.Expect(cs.Status).Should(Equal(metav1.ConditionFalse))
-	})
-
-	t.Run("Test when rhcl + lws subscription are present", func(t *testing.T) {
-		rhclSub := &v1alpha1.Subscription{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: rhclOperatorSubscription,
-			},
-		}
-		lwsSub := &v1alpha1.Subscription{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: lwsOperatorSubscription,
-			},
-		}
-		cli, err := fakeclient.New(fakeclient.WithObjects(kserve, dsc, rhclSub, lwsSub))
-		g.Expect(err).ShouldNot(HaveOccurred())
-
-		rr := &odhtypes.ReconciliationRequest{
-			Instance:   kserve,
-			Client:     cli,
-			Conditions: conditions.NewManager(kserve, LLMInferenceServiceWideEPDependencies),
-		}
-
-		err = checkPreConditions(ctx, rr)
-		g.Expect(err).ShouldNot(HaveOccurred())
-		cs := rr.Conditions.GetCondition(LLMInferenceServiceWideEPDependencies)
-		g.Expect(cs.Status).Should(Equal(metav1.ConditionTrue))
-	})
 }
 
 func createTestDeployment() *appsv1.Deployment {
@@ -339,4 +579,40 @@ func convertToUnstructured(t *testing.T, obj runtime.Object) *unstructured.Unstr
 		t.Fatalf("Failed to convert object to unstructured: %v", err)
 	}
 	return &unstructured.Unstructured{Object: u}
+}
+
+// fakeclientWithCRDs builds a fake client whose RESTMapper knows about the
+// given GVKs and that contains matching CRD objects with StoredVersions set,
+// so that cluster.HasCRD returns true for each of them.
+func fakeclientWithCRDs(gvks []schema.GroupVersionKind) (client.Client, error) {
+	s, err := testscheme.New()
+	if err != nil {
+		return nil, err
+	}
+
+	fakeMapper := meta.NewDefaultRESTMapper(s.PreferredVersionAllGroups())
+	for kt := range s.AllKnownTypes() {
+		fakeMapper.Add(kt, meta.RESTScopeNamespace)
+	}
+
+	crdObjs := make([]client.Object, 0, len(gvks))
+	for _, item := range gvks {
+		fakeMapper.Add(item, meta.RESTScopeNamespace)
+
+		plural, _ := meta.UnsafeGuessKindToResource(item)
+		crdName := plural.Resource + "." + item.Group
+
+		crdObjs = append(crdObjs, &apiextensionsv1.CustomResourceDefinition{
+			ObjectMeta: metav1.ObjectMeta{Name: crdName},
+			Status: apiextensionsv1.CustomResourceDefinitionStatus{
+				StoredVersions: []string{item.Version},
+			},
+		})
+	}
+
+	return clientFake.NewClientBuilder().
+		WithScheme(s).
+		WithRESTMapper(fakeMapper).
+		WithObjects(crdObjs...).
+		Build(), nil
 }

--- a/pkg/cluster/cluster_config.go
+++ b/pkg/cluster/cluster_config.go
@@ -143,6 +143,12 @@ func GetClusterInfo() ClusterInfo {
 	return clusterConfig.ClusterInfo
 }
 
+// SetClusterInfo overrides the cluster information. Intended for use in tests
+// to control the cluster type without requiring a live cluster.
+func SetClusterInfo(info ClusterInfo) {
+	clusterConfig.ClusterInfo = info
+}
+
 func GetDomain(ctx context.Context, c client.Client) (string, error) {
 	ingress := &unstructured.Unstructured{}
 	ingress.SetGroupVersionKind(gvk.OpenshiftIngress)

--- a/pkg/cluster/gvk/gvk.go
+++ b/pkg/cluster/gvk/gvk.go
@@ -26,6 +26,11 @@ import (
 	serviceApi "github.com/opendatahub-io/opendatahub-operator/v2/api/services/v1alpha1"
 )
 
+const (
+	LeaderWorkerSetOperatorCRDname = "leaderworkersetoperators.operator.openshift.io"
+	SubscriptionCRDname            = "subscriptions.operators.coreos.com"
+)
+
 var (
 	Namespace = schema.GroupVersionKind{
 		Group:   "",
@@ -363,6 +368,8 @@ var (
 		Kind:    "Lease",
 	}
 
+	// networking.istio.io.
+
 	DestinationRule = schema.GroupVersionKind{
 		Group:   "networking.istio.io",
 		Version: "v1",
@@ -375,6 +382,44 @@ var (
 		Kind:    "EnvoyFilter",
 	}
 
+	IstioGateway = schema.GroupVersionKind{
+		Group:   "networking.istio.io",
+		Version: "v1",
+		Kind:    "Gateway",
+	}
+
+	ProxyConfig = schema.GroupVersionKind{
+		Group:   "networking.istio.io",
+		Version: "v1beta1",
+		Kind:    "ProxyConfig",
+	}
+
+	ServiceEntry = schema.GroupVersionKind{
+		Group:   "networking.istio.io",
+		Version: "v1",
+		Kind:    "ServiceEntry",
+	}
+
+	Sidecar = schema.GroupVersionKind{
+		Group:   "networking.istio.io",
+		Version: "v1",
+		Kind:    "Sidecar",
+	}
+
+	WorkloadEntry = schema.GroupVersionKind{
+		Group:   "networking.istio.io",
+		Version: "v1",
+		Kind:    "WorkloadEntry",
+	}
+
+	WorkloadGroup = schema.GroupVersionKind{
+		Group:   "networking.istio.io",
+		Version: "v1",
+		Kind:    "WorkloadGroup",
+	}
+
+	// security.istio.io.
+
 	AuthorizationPolicy = schema.GroupVersionKind{
 		Group:   "security.istio.io",
 		Version: "v1",
@@ -385,6 +430,34 @@ var (
 		Group:   "security.istio.io",
 		Version: "v1beta1",
 		Kind:    "AuthorizationPolicy",
+	}
+
+	PeerAuthentication = schema.GroupVersionKind{
+		Group:   "security.istio.io",
+		Version: "v1",
+		Kind:    "PeerAuthentication",
+	}
+
+	RequestAuthentication = schema.GroupVersionKind{
+		Group:   "security.istio.io",
+		Version: "v1",
+		Kind:    "RequestAuthentication",
+	}
+
+	// telemetry.istio.io.
+
+	Telemetry = schema.GroupVersionKind{
+		Group:   "telemetry.istio.io",
+		Version: "v1",
+		Kind:    "Telemetry",
+	}
+
+	// extensions.istio.io.
+
+	WasmPlugin = schema.GroupVersionKind{
+		Group:   "extensions.istio.io",
+		Version: "v1alpha1",
+		Kind:    "WasmPlugin",
 	}
 
 	GatewayConfig = schema.GroupVersionKind{
@@ -423,6 +496,16 @@ var (
 		Kind:    serviceApi.AuthKind,
 	}
 
+	// leaderworkerset.x-k8s.io.
+
+	LeaderWorkerSetV1 = schema.GroupVersionKind{
+		Group:   "leaderworkerset.x-k8s.io",
+		Version: "v1",
+		Kind:    "LeaderWorkerSet",
+	}
+
+	// kueue.x-k8s.io.
+
 	MultiKueueConfigV1Alpha1 = schema.GroupVersionKind{
 		Group:   "kueue.x-k8s.io",
 		Version: "v1alpha1",
@@ -433,24 +516,6 @@ var (
 		Group:   "kueue.x-k8s.io",
 		Version: "v1alpha1",
 		Kind:    "MultiKueueCluster",
-	}
-
-	KueueConfigV1 = schema.GroupVersionKind{
-		Group:   "kueue.openshift.io",
-		Version: "v1",
-		Kind:    "Kueue",
-	}
-
-	LeaderWorkerSetOperatorV1 = schema.GroupVersionKind{
-		Group:   "operator.openshift.io",
-		Version: "v1",
-		Kind:    "LeaderWorkerSetOperator",
-	}
-
-	JobSetOperatorV1 = schema.GroupVersionKind{
-		Group:   "operator.openshift.io",
-		Version: "v1",
-		Kind:    "JobSetOperator",
 	}
 
 	LocalQueue = schema.GroupVersionKind{
@@ -469,6 +534,26 @@ var (
 		Group:   "kueue.x-k8s.io",
 		Version: "v1beta1",
 		Kind:    "ResourceFlavor",
+	}
+
+	KueueConfigV1 = schema.GroupVersionKind{
+		Group:   "kueue.openshift.io",
+		Version: "v1",
+		Kind:    "Kueue",
+	}
+
+	// operator.openshift.io.
+
+	LeaderWorkerSetOperatorV1 = schema.GroupVersionKind{
+		Group:   "operator.openshift.io",
+		Version: "v1",
+		Kind:    "LeaderWorkerSetOperator",
+	}
+
+	JobSetOperatorV1 = schema.GroupVersionKind{
+		Group:   "operator.openshift.io",
+		Version: "v1",
+		Kind:    "JobSetOperator",
 	}
 
 	InferenceServices = schema.GroupVersionKind{
@@ -705,10 +790,18 @@ var (
 		Kind:    "PersistentVolumeClaim",
 	}
 
+	// cert-manager.io.
+
 	CertManagerCertificate = schema.GroupVersionKind{
 		Group:   "cert-manager.io",
 		Version: "v1",
 		Kind:    "Certificate",
+	}
+
+	CertManagerCertificateRequest = schema.GroupVersionKind{
+		Group:   "cert-manager.io",
+		Version: "v1",
+		Kind:    "CertificateRequest",
 	}
 
 	CertManagerIssuer = schema.GroupVersionKind{

--- a/pkg/controller/actions/dependency/action_operator.go
+++ b/pkg/controller/actions/dependency/action_operator.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
 
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
@@ -54,6 +55,11 @@ type OperatorConfig struct {
 	// If nil, DefaultDegradedConditionFilter is used.
 	Filter DegradedConditionFilterFunc
 
+	// ClusterTypes restricts this check to run only on specific cluster types
+	// (e.g. cluster.ClusterTypeOpenShift). If empty, the check runs on all
+	// cluster types.
+	ClusterTypes []string
+
 	// Severity determines how degraded conditions affect component readiness.
 	// Use ConditionSeverityError ("") for required dependencies (affects Ready).
 	// Use ConditionSeverityInfo for optional dependencies (informational only).
@@ -65,6 +71,11 @@ type OperatorConfig struct {
 type CRDConfig struct {
 	// GVK identifies the CRD to check for cluster registration.
 	GVK schema.GroupVersionKind
+
+	// ClusterTypes restricts this check to run only on specific cluster types
+	// (e.g. cluster.ClusterTypeOpenShift). If empty, the check runs on all
+	// cluster types.
+	ClusterTypes []string
 
 	// Severity determines how a missing CRD affects component readiness.
 	// Use ConditionSeverityError (default) for required CRDs that block the component.
@@ -112,8 +123,13 @@ func Combine(opts ...ActionOpts) ActionOpts {
 func (a *action) run(ctx context.Context, rr *odhtypes.ReconciliationRequest) error {
 	var allDegraded []string
 	hasErrorSeverity := false
+	clusterType := cluster.GetClusterInfo().Type
 
 	for _, config := range a.configs {
+		if len(config.ClusterTypes) > 0 && !slices.Contains(config.ClusterTypes, clusterType) {
+			continue
+		}
+
 		degraded := a.collectDegradedConditions(ctx, rr, config)
 		if len(degraded) > 0 {
 			allDegraded = append(allDegraded, degraded...)
@@ -124,6 +140,10 @@ func (a *action) run(ctx context.Context, rr *odhtypes.ReconciliationRequest) er
 	}
 
 	for _, config := range a.crdConfigs {
+		if len(config.ClusterTypes) > 0 && !slices.Contains(config.ClusterTypes, clusterType) {
+			continue
+		}
+
 		has, err := cluster.HasCRD(ctx, rr.Client, config.GVK)
 		if err != nil {
 			// Log and continue - monitoring failures should not block reconciliation.

--- a/pkg/controller/actions/dependency/action_operator_test.go
+++ b/pkg/controller/actions/dependency/action_operator_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/opendatahub-io/opendatahub-operator/v2/api/common"
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/api/components/v1alpha1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/status"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/dependency"
 	cond "github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/conditions"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
@@ -563,6 +564,164 @@ func TestMonitorCRD(t *testing.T) {
 				g.Expect(gotCond.Status).To(Equal(metav1.ConditionFalse))
 				g.Expect(gotCond.Message).To(ContainSubstring(testCRDGVK.Kind))
 				g.Expect(gotCond.Severity).To(Equal(tt.expectedSeverity))
+			}
+		})
+	}
+}
+
+func TestMonitorOperator_ClusterTypeFiltering(t *testing.T) {
+	g := NewWithT(t)
+
+	envTest, err := envt.New()
+	g.Expect(err).NotTo(HaveOccurred())
+	t.Cleanup(func() { _ = envTest.Stop() })
+
+	ctx := context.Background()
+	cli := envTest.Client()
+
+	createTestOperatorCRD(t, g, ctx, envTest)
+
+	tests := []struct {
+		name               string
+		clusterType        string
+		configClusterTypes []string
+		expectedAvailable  bool
+	}{
+		{
+			name:               "degraded operator with matching ClusterType is detected",
+			clusterType:        cluster.ClusterTypeOpenShift,
+			configClusterTypes: []string{cluster.ClusterTypeOpenShift},
+			expectedAvailable:  false,
+		},
+		{
+			name:               "degraded operator with non-matching ClusterType is skipped",
+			clusterType:        cluster.ClusterTypeKubernetes,
+			configClusterTypes: []string{cluster.ClusterTypeOpenShift},
+			expectedAvailable:  true,
+		},
+		{
+			name:               "degraded operator with empty ClusterTypes always runs",
+			clusterType:        cluster.ClusterTypeKubernetes,
+			configClusterTypes: nil,
+			expectedAvailable:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			cluster.SetClusterInfo(cluster.ClusterInfo{Type: tt.clusterType})
+			t.Cleanup(func() { cluster.SetClusterInfo(cluster.ClusterInfo{}) })
+
+			nsn := xid.New().String()
+			ns := corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: nsn}}
+			g.Expect(cli.Create(ctx, &ns)).NotTo(HaveOccurred())
+			t.Cleanup(func() { _ = cli.Delete(ctx, &ns) })
+
+			operatorCR := createOperatorCR(xid.New().String(), nsn, testOperatorGVK)
+			setCondition(g, operatorCR, "Degraded", "True", "TestFailed", "Test failure message")
+			createAndUpdateStatus(ctx, g, cli, operatorCR)
+			t.Cleanup(func() { _ = cli.Delete(ctx, operatorCR) })
+
+			instance := &componentApi.Kueue{ObjectMeta: metav1.ObjectMeta{Name: xid.New().String()}}
+			condManager := cond.NewManager(instance, status.ConditionDependenciesAvailable)
+			rr := &types.ReconciliationRequest{Client: cli, Instance: instance, Conditions: condManager}
+
+			action := dependency.NewAction(dependency.MonitorOperator(dependency.OperatorConfig{
+				OperatorGVK:  testOperatorGVK,
+				CRName:       operatorCR.GetName(),
+				CRNamespace:  nsn,
+				ClusterTypes: tt.configClusterTypes,
+			}))
+
+			err := action(ctx, rr)
+			g.Expect(err).NotTo(HaveOccurred())
+
+			gotCond := condManager.GetCondition(status.ConditionDependenciesAvailable)
+			g.Expect(gotCond).NotTo(BeNil())
+
+			if tt.expectedAvailable {
+				g.Expect(gotCond.Status).To(Equal(metav1.ConditionTrue))
+			} else {
+				g.Expect(gotCond.Status).To(Equal(metav1.ConditionFalse))
+				g.Expect(gotCond.Message).To(ContainSubstring("Degraded=True"))
+			}
+		})
+	}
+}
+
+// TestMonitorCRD_ClusterTypeFiltering verifies that CRD checks respect ClusterTypes filtering.
+//
+// Each subtest uses its own envtest instance because HasCRD relies on the REST mapper,
+// whose discovery cache refreshes asynchronously after CRD deletion.
+func TestMonitorCRD_ClusterTypeFiltering(t *testing.T) {
+	testCRDGVK := schema.GroupVersionKind{
+		Group:   "test.opendatahub.io",
+		Version: "v1",
+		Kind:    "TestClusterTypeResource",
+	}
+
+	tests := []struct {
+		name               string
+		clusterType        string
+		configClusterTypes []string
+		expectedAvailable  bool
+	}{
+		{
+			name:               "absent CRD with matching ClusterType is detected",
+			clusterType:        cluster.ClusterTypeOpenShift,
+			configClusterTypes: []string{cluster.ClusterTypeOpenShift},
+			expectedAvailable:  false,
+		},
+		{
+			name:               "absent CRD with non-matching ClusterType is skipped",
+			clusterType:        cluster.ClusterTypeKubernetes,
+			configClusterTypes: []string{cluster.ClusterTypeOpenShift},
+			expectedAvailable:  true,
+		},
+		{
+			name:               "absent CRD with empty ClusterTypes always runs",
+			clusterType:        cluster.ClusterTypeKubernetes,
+			configClusterTypes: nil,
+			expectedAvailable:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			cluster.SetClusterInfo(cluster.ClusterInfo{Type: tt.clusterType})
+			t.Cleanup(func() { cluster.SetClusterInfo(cluster.ClusterInfo{}) })
+
+			envTest, err := envt.New()
+			g.Expect(err).NotTo(HaveOccurred())
+			t.Cleanup(func() { _ = envTest.Stop() })
+
+			ctx := context.Background()
+			cli := envTest.Client()
+
+			instance := &scheme.TestPlatformObject{ObjectMeta: metav1.ObjectMeta{Name: xid.New().String()}}
+			condManager := cond.NewManager(instance, status.ConditionDependenciesAvailable)
+			rr := &types.ReconciliationRequest{Client: cli, Instance: instance, Conditions: condManager}
+
+			action := dependency.NewAction(dependency.MonitorCRD(dependency.CRDConfig{
+				GVK:          testCRDGVK,
+				ClusterTypes: tt.configClusterTypes,
+			}))
+
+			err = action(ctx, rr)
+			g.Expect(err).NotTo(HaveOccurred())
+
+			gotCond := condManager.GetCondition(status.ConditionDependenciesAvailable)
+			g.Expect(gotCond).NotTo(BeNil())
+
+			if tt.expectedAvailable {
+				g.Expect(gotCond.Status).To(Equal(metav1.ConditionTrue))
+			} else {
+				g.Expect(gotCond.Status).To(Equal(metav1.ConditionFalse))
+				g.Expect(gotCond.Message).To(ContainSubstring(testCRDGVK.Kind))
 			}
 		})
 	}

--- a/pkg/controller/actions/dependency/action_subscription.go
+++ b/pkg/controller/actions/dependency/action_subscription.go
@@ -1,0 +1,124 @@
+package dependency
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/opendatahub-io/opendatahub-operator/v2/api/common"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions"
+	cond "github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/conditions"
+	odhtypes "github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
+)
+
+// SubscriptionDependency identifies a single OLM subscription to check.
+type SubscriptionDependency struct {
+	// Name is the OLM subscription name to look for (e.g. "rhcl-operator").
+	Name string
+
+	// DisplayName is the human-readable name for error messages (e.g. "Red Hat Connectivity Link").
+	DisplayName string
+}
+
+// SubscriptionGroupConfig defines a group of subscriptions that map to a single condition.
+// All subscriptions in the group must be present for the condition to be True.
+type SubscriptionGroupConfig struct {
+	// ConditionType is the condition to set based on subscription presence.
+	ConditionType string
+
+	// Subscriptions is the list of subscriptions ALL of which must be present
+	// for the group to be satisfied.
+	Subscriptions []SubscriptionDependency
+
+	// ClusterTypes restricts this group to run only on specific cluster types
+	// (e.g. cluster.ClusterTypeOpenShift). If empty, the check runs on all
+	// cluster types.
+	ClusterTypes []string
+
+	// Reason is the reason string when subscriptions are missing.
+	Reason string
+
+	// Message is a fmt template receiving %s with the joined missing display names.
+	Message string
+
+	// Severity determines the condition severity when subscriptions are missing.
+	// Use ConditionSeverityInfo for optional dependencies (informational only).
+	// Default: ConditionSeverityError
+	Severity common.ConditionSeverity
+}
+
+// SubscriptionAction checks OLM subscriptions and sets per-group conditions on the component status.
+type SubscriptionAction struct {
+	groups []SubscriptionGroupConfig
+}
+
+// SubscriptionActionOpts is a functional option for configuring the SubscriptionAction.
+type SubscriptionActionOpts func(*SubscriptionAction)
+
+// CheckSubscriptionGroup adds a subscription group to check.
+// Each group maps to a separate condition on the component status.
+func CheckSubscriptionGroup(config SubscriptionGroupConfig) SubscriptionActionOpts {
+	return func(a *SubscriptionAction) {
+		if config.Severity == "" {
+			config.Severity = common.ConditionSeverityError
+		}
+		a.groups = append(a.groups, config)
+	}
+}
+
+// NewSubscriptionAction creates an action that checks for OLM subscriptions
+// and sets per-group conditions on the component status.
+//
+// Unlike NewAction which aggregates all checks into a single DependenciesAvailable
+// condition, each subscription group produces its own independent condition,
+// allowing fine-grained feature-level dependency tracking.
+func NewSubscriptionAction(opts ...SubscriptionActionOpts) actions.Fn {
+	action := SubscriptionAction{}
+
+	for _, opt := range opts {
+		opt(&action)
+	}
+
+	return action.run
+}
+
+func (a *SubscriptionAction) run(ctx context.Context, rr *odhtypes.ReconciliationRequest) error {
+	clusterType := cluster.GetClusterInfo().Type
+
+	for i := range a.groups {
+		group := &a.groups[i]
+
+		if len(group.ClusterTypes) > 0 && !slices.Contains(group.ClusterTypes, clusterType) {
+			// the condition is not set if the clusterer type does not match.
+			continue
+		}
+
+		rr.Conditions.MarkUnknown(group.ConditionType)
+
+		var missing []string
+		for _, sub := range group.Subscriptions {
+			found, err := cluster.SubscriptionExists(ctx, rr.Client, sub.Name)
+			if err != nil {
+				return fmt.Errorf("failed to check %s subscription: %w", sub.DisplayName, err)
+			}
+			if !found {
+				missing = append(missing, sub.DisplayName)
+			}
+		}
+
+		if len(missing) == 0 {
+			rr.Conditions.MarkTrue(group.ConditionType)
+		} else {
+			rr.Conditions.MarkFalse(
+				group.ConditionType,
+				cond.WithSeverity(group.Severity),
+				cond.WithReason(group.Reason),
+				cond.WithMessage(group.Message, strings.Join(missing, " and ")),
+			)
+		}
+	}
+
+	return nil
+}

--- a/pkg/controller/actions/dependency/action_subscription_test.go
+++ b/pkg/controller/actions/dependency/action_subscription_test.go
@@ -1,0 +1,392 @@
+package dependency_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/operator-framework/api/pkg/operators/v1alpha1"
+	"github.com/rs/xid"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	"github.com/opendatahub-io/opendatahub-operator/v2/api/common"
+	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/api/components/v1alpha1"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/dependency"
+	cond "github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/conditions"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/fakeclient"
+
+	. "github.com/onsi/gomega"
+)
+
+var errTest = errors.New("test error")
+
+const (
+	testHappyCondition    = "Ready"
+	testConditionType     = "TestSubscriptionDeps"
+	testConditionTypeWide = "TestSubscriptionDepsWide"
+)
+
+func TestSubscriptionAction_AllPresent(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	sub1 := &v1alpha1.Subscription{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "operator-a",
+			Namespace: "openshift-operators",
+		},
+	}
+	cli, err := fakeclient.New(fakeclient.WithObjects(sub1))
+	g.Expect(err).NotTo(HaveOccurred())
+
+	instance := &componentApi.Kserve{
+		ObjectMeta: metav1.ObjectMeta{Name: xid.New().String()},
+	}
+
+	condManager := cond.NewManager(instance, testHappyCondition, testConditionType)
+	rr := &types.ReconciliationRequest{
+		Client:     cli,
+		Instance:   instance,
+		Conditions: condManager,
+	}
+
+	action := dependency.NewSubscriptionAction(
+		dependency.CheckSubscriptionGroup(dependency.SubscriptionGroupConfig{
+			ConditionType: testConditionType,
+			Subscriptions: []dependency.SubscriptionDependency{
+				{Name: "operator-a", DisplayName: "Operator A"},
+			},
+			Reason:   "SubscriptionNotFound",
+			Message:  "Warning: %s not installed",
+			Severity: common.ConditionSeverityInfo,
+		}),
+	)
+
+	err = action(ctx, rr)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	got := condManager.GetCondition(testConditionType)
+	g.Expect(got).NotTo(BeNil())
+	g.Expect(got.Status).To(Equal(metav1.ConditionTrue))
+}
+
+func TestSubscriptionAction_OneMissing(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	cli, err := fakeclient.New()
+	g.Expect(err).NotTo(HaveOccurred())
+
+	instance := &componentApi.Kserve{
+		ObjectMeta: metav1.ObjectMeta{Name: xid.New().String()},
+	}
+
+	condManager := cond.NewManager(instance, testHappyCondition, testConditionType)
+	rr := &types.ReconciliationRequest{
+		Client:     cli,
+		Instance:   instance,
+		Conditions: condManager,
+	}
+
+	action := dependency.NewSubscriptionAction(
+		dependency.CheckSubscriptionGroup(dependency.SubscriptionGroupConfig{
+			ConditionType: testConditionType,
+			Subscriptions: []dependency.SubscriptionDependency{
+				{Name: "operator-missing", DisplayName: "Missing Operator"},
+			},
+			Reason:   "SubscriptionNotFound",
+			Message:  "Warning: %s is not installed",
+			Severity: common.ConditionSeverityInfo,
+		}),
+	)
+
+	err = action(ctx, rr)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	got := condManager.GetCondition(testConditionType)
+	g.Expect(got).NotTo(BeNil())
+	g.Expect(got.Status).To(Equal(metav1.ConditionFalse))
+	g.Expect(got.Reason).To(Equal("SubscriptionNotFound"))
+	g.Expect(got.Message).To(ContainSubstring("Missing Operator"))
+	g.Expect(got.Severity).To(Equal(common.ConditionSeverityInfo))
+}
+
+func TestSubscriptionAction_MultipleGroups(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	sub1 := &v1alpha1.Subscription{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "operator-a",
+			Namespace: "openshift-operators",
+		},
+	}
+	cli, err := fakeclient.New(fakeclient.WithObjects(sub1))
+	g.Expect(err).NotTo(HaveOccurred())
+
+	instance := &componentApi.Kserve{
+		ObjectMeta: metav1.ObjectMeta{Name: xid.New().String()},
+	}
+
+	condManager := cond.NewManager(instance, testHappyCondition, testConditionType, testConditionTypeWide)
+	rr := &types.ReconciliationRequest{
+		Client:     cli,
+		Instance:   instance,
+		Conditions: condManager,
+	}
+
+	action := dependency.NewSubscriptionAction(
+		// Group 1: only requires operator-a (present)
+		dependency.CheckSubscriptionGroup(dependency.SubscriptionGroupConfig{
+			ConditionType: testConditionType,
+			Subscriptions: []dependency.SubscriptionDependency{
+				{Name: "operator-a", DisplayName: "Operator A"},
+			},
+			Reason:   "SubscriptionNotFound",
+			Message:  "Warning: %s not installed",
+			Severity: common.ConditionSeverityInfo,
+		}),
+		// Group 2: requires both operator-a and operator-b (operator-b missing)
+		dependency.CheckSubscriptionGroup(dependency.SubscriptionGroupConfig{
+			ConditionType: testConditionTypeWide,
+			Subscriptions: []dependency.SubscriptionDependency{
+				{Name: "operator-a", DisplayName: "Operator A"},
+				{Name: "operator-b", DisplayName: "Operator B"},
+			},
+			Reason:   "SubscriptionNotFound",
+			Message:  "Warning: %s not installed, feature X cannot be used",
+			Severity: common.ConditionSeverityInfo,
+		}),
+	)
+
+	err = action(ctx, rr)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	// Group 1 should be satisfied
+	got1 := condManager.GetCondition(testConditionType)
+	g.Expect(got1).NotTo(BeNil())
+	g.Expect(got1.Status).To(Equal(metav1.ConditionTrue))
+
+	// Group 2 should be missing operator-b
+	got2 := condManager.GetCondition(testConditionTypeWide)
+	g.Expect(got2).NotTo(BeNil())
+	g.Expect(got2.Status).To(Equal(metav1.ConditionFalse))
+	g.Expect(got2.Message).To(ContainSubstring("Operator B"))
+	g.Expect(got2.Message).NotTo(ContainSubstring("Operator A"))
+}
+
+func TestSubscriptionAction_MultipleMissing(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	cli, err := fakeclient.New()
+	g.Expect(err).NotTo(HaveOccurred())
+
+	instance := &componentApi.Kserve{
+		ObjectMeta: metav1.ObjectMeta{Name: xid.New().String()},
+	}
+
+	condManager := cond.NewManager(instance, testHappyCondition, testConditionType)
+	rr := &types.ReconciliationRequest{
+		Client:     cli,
+		Instance:   instance,
+		Conditions: condManager,
+	}
+
+	action := dependency.NewSubscriptionAction(
+		dependency.CheckSubscriptionGroup(dependency.SubscriptionGroupConfig{
+			ConditionType: testConditionType,
+			Subscriptions: []dependency.SubscriptionDependency{
+				{Name: "operator-x", DisplayName: "Operator X"},
+				{Name: "operator-y", DisplayName: "Operator Y"},
+			},
+			Reason:   "SubscriptionNotFound",
+			Message:  "Warning: %s not installed",
+			Severity: common.ConditionSeverityInfo,
+		}),
+	)
+
+	err = action(ctx, rr)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	got := condManager.GetCondition(testConditionType)
+	g.Expect(got).NotTo(BeNil())
+	g.Expect(got.Status).To(Equal(metav1.ConditionFalse))
+	g.Expect(got.Message).To(ContainSubstring("Operator X"))
+	g.Expect(got.Message).To(ContainSubstring("Operator Y"))
+	g.Expect(got.Message).To(ContainSubstring(" and "))
+}
+
+func TestSubscriptionAction_ListError(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	cli, err := fakeclient.New(fakeclient.WithInterceptorFuncs(interceptor.Funcs{
+		List: func(_ context.Context, _ client.WithWatch, _ client.ObjectList, _ ...client.ListOption) error {
+			return errTest
+		},
+	}))
+	g.Expect(err).NotTo(HaveOccurred())
+
+	instance := &componentApi.Kserve{
+		ObjectMeta: metav1.ObjectMeta{Name: xid.New().String()},
+	}
+
+	condManager := cond.NewManager(instance, testHappyCondition, testConditionType)
+	rr := &types.ReconciliationRequest{
+		Client:     cli,
+		Instance:   instance,
+		Conditions: condManager,
+	}
+
+	action := dependency.NewSubscriptionAction(
+		dependency.CheckSubscriptionGroup(dependency.SubscriptionGroupConfig{
+			ConditionType: testConditionType,
+			Subscriptions: []dependency.SubscriptionDependency{
+				{Name: "operator-a", DisplayName: "Operator A"},
+			},
+			Reason:   "SubscriptionNotFound",
+			Message:  "Warning: %s not installed",
+			Severity: common.ConditionSeverityInfo,
+		}),
+	)
+
+	err = action(ctx, rr)
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("failed to check Operator A subscription"))
+}
+
+func TestSubscriptionAction_ClusterTypeMatches(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	cluster.SetClusterInfo(cluster.ClusterInfo{Type: cluster.ClusterTypeOpenShift})
+	t.Cleanup(func() { cluster.SetClusterInfo(cluster.ClusterInfo{}) })
+
+	cli, err := fakeclient.New()
+	g.Expect(err).NotTo(HaveOccurred())
+
+	instance := &componentApi.Kserve{
+		ObjectMeta: metav1.ObjectMeta{Name: xid.New().String()},
+	}
+
+	condManager := cond.NewManager(instance, testHappyCondition, testConditionType)
+	rr := &types.ReconciliationRequest{
+		Client:     cli,
+		Instance:   instance,
+		Conditions: condManager,
+	}
+
+	// Group restricted to "OpenShift", cluster type is "OpenShift" → check runs, subscription missing
+	action := dependency.NewSubscriptionAction(
+		dependency.CheckSubscriptionGroup(dependency.SubscriptionGroupConfig{
+			ConditionType: testConditionType,
+			Subscriptions: []dependency.SubscriptionDependency{
+				{Name: "operator-missing", DisplayName: "Missing Operator"},
+			},
+			ClusterTypes: []string{cluster.ClusterTypeOpenShift},
+			Reason:       "SubscriptionNotFound",
+			Message:      "Warning: %s not installed",
+			Severity:     common.ConditionSeverityInfo,
+		}),
+	)
+
+	err = action(ctx, rr)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	got := condManager.GetCondition(testConditionType)
+	g.Expect(got).NotTo(BeNil())
+	g.Expect(got.Status).To(Equal(metav1.ConditionFalse))
+	g.Expect(got.Message).To(ContainSubstring("Missing Operator"))
+}
+
+func TestSubscriptionAction_ClusterTypeNoMatch(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	cluster.SetClusterInfo(cluster.ClusterInfo{Type: cluster.ClusterTypeKubernetes})
+	t.Cleanup(func() { cluster.SetClusterInfo(cluster.ClusterInfo{}) })
+
+	cli, err := fakeclient.New()
+	g.Expect(err).NotTo(HaveOccurred())
+
+	instance := &componentApi.Kserve{
+		ObjectMeta: metav1.ObjectMeta{Name: xid.New().String()},
+	}
+
+	condManager := cond.NewManager(instance, testHappyCondition, testConditionType)
+	rr := &types.ReconciliationRequest{
+		Client:     cli,
+		Instance:   instance,
+		Conditions: condManager,
+	}
+
+	// Group restricted to "OpenShift", cluster type is "Kubernetes" → check skipped, condition not set
+	action := dependency.NewSubscriptionAction(
+		dependency.CheckSubscriptionGroup(dependency.SubscriptionGroupConfig{
+			ConditionType: testConditionType,
+			Subscriptions: []dependency.SubscriptionDependency{
+				{Name: "operator-missing", DisplayName: "Missing Operator"},
+			},
+			ClusterTypes: []string{cluster.ClusterTypeOpenShift},
+			Reason:       "SubscriptionNotFound",
+			Message:      "Warning: %s not installed",
+			Severity:     common.ConditionSeverityInfo,
+		}),
+	)
+
+	err = action(ctx, rr)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	// Condition remains in its initial Unknown state (not explicitly set by the action)
+	got := condManager.GetCondition(testConditionType)
+	g.Expect(got).NotTo(BeNil())
+	g.Expect(got.Status).To(Equal(metav1.ConditionUnknown))
+}
+
+func TestSubscriptionAction_ClusterTypeEmpty(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	cluster.SetClusterInfo(cluster.ClusterInfo{Type: cluster.ClusterTypeKubernetes})
+	t.Cleanup(func() { cluster.SetClusterInfo(cluster.ClusterInfo{}) })
+
+	cli, err := fakeclient.New()
+	g.Expect(err).NotTo(HaveOccurred())
+
+	instance := &componentApi.Kserve{
+		ObjectMeta: metav1.ObjectMeta{Name: xid.New().String()},
+	}
+
+	condManager := cond.NewManager(instance, testHappyCondition, testConditionType)
+	rr := &types.ReconciliationRequest{
+		Client:     cli,
+		Instance:   instance,
+		Conditions: condManager,
+	}
+
+	// No ClusterTypes restriction → check always runs regardless of cluster type
+	action := dependency.NewSubscriptionAction(
+		dependency.CheckSubscriptionGroup(dependency.SubscriptionGroupConfig{
+			ConditionType: testConditionType,
+			Subscriptions: []dependency.SubscriptionDependency{
+				{Name: "operator-missing", DisplayName: "Missing Operator"},
+			},
+			Reason:   "SubscriptionNotFound",
+			Message:  "Warning: %s not installed",
+			Severity: common.ConditionSeverityInfo,
+		}),
+	)
+
+	err = action(ctx, rr)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	got := condManager.GetCondition(testConditionType)
+	g.Expect(got).NotTo(BeNil())
+	g.Expect(got.Status).To(Equal(metav1.ConditionFalse))
+	g.Expect(got.Message).To(ContainSubstring("Missing Operator"))
+}

--- a/pkg/controller/predicates/resources/resources.go
+++ b/pkg/controller/predicates/resources/resources.go
@@ -276,6 +276,23 @@ func CreatedOrUpdatedOrDeletedNamePrefixed(namePrefix string) predicate.Predicat
 		DeleteFunc: func(e event.TypedDeleteEvent[client.Object]) bool {
 			return strings.HasPrefix(e.Object.GetName(), namePrefix)
 		},
+		GenericFunc: func(e event.TypedGenericEvent[client.Object]) bool {
+			return false
+		},
+	}
+}
+
+func CreatedOrUpdatedOrDeletedNameSuffixed(nameSuffix string) predicate.Predicate {
+	return predicate.Funcs{
+		CreateFunc: func(e event.TypedCreateEvent[client.Object]) bool {
+			return strings.HasSuffix(e.Object.GetName(), nameSuffix)
+		},
+		UpdateFunc: func(e event.TypedUpdateEvent[client.Object]) bool {
+			return strings.HasSuffix(e.ObjectNew.GetName(), nameSuffix)
+		},
+		DeleteFunc: func(e event.TypedDeleteEvent[client.Object]) bool {
+			return strings.HasSuffix(e.Object.GetName(), nameSuffix)
+		},
 	}
 }
 

--- a/pkg/controller/predicates/resources/resources_test.go
+++ b/pkg/controller/predicates/resources/resources_test.go
@@ -937,16 +937,21 @@ func TestCreatedOrUpdatedOrDeletedNamePrefixed(t *testing.T) {
 		testCreate:      true,
 		testUpdate:      true,
 		testDelete:      true,
-		testGeneric:     false, // Generic always returns true
+		testGeneric:     false, // Generic always returns false, tested below
 	})
 
-	// FIXME: is correct to always return true with Generic predicate?
 	t.Run("Generic", func(t *testing.T) {
 		t.Parallel()
 
 		g := NewWithT(t)
 
-		g.Expect(pred.Generic(event.GenericEvent{})).To(BeTrue())
+		g.Expect(pred.Generic(event.GenericEvent{
+			Object: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "test-pod"}},
+		})).To(BeFalse())
+
+		g.Expect(pred.Generic(event.GenericEvent{
+			Object: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "other-pod"}},
+		})).To(BeFalse())
 	})
 }
 


### PR DESCRIPTION
## Description

  - Extract KServe's inline operator/CRD/subscription dependency checks into generic, reusable actions (dependency.MonitorOperator, dependency.MonitorCRD, dependency.CheckSubscriptions) that can be adopted by other component controllers.
  - Add action_subscription.go with SubscriptionGroupConfig to declaratively check groups of OLM subscriptions and set conditions accordingly.
  - Extend pkg/cluster/gvk with Istio, Gateway API, and other CRD GVKs needed by KServe (e.g. DestinationRule, EnvoyFilter, AuthorizationPolicy, Gateway).
  - Add SubscriptionGVK helper in cluster_config.go and a HasSubscription predicate in resources.go.
  - Move dependency condition logic out of the KServe controller into the action framework, simplifying kserve_controller.go and kserve_controller_actions.go.

see: https://issues.redhat.com/browse/RHOAIENG-49711

## How Has This Been Tested?
unit and e2e  tests

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [x] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [X] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->
existing e2e test test the negative case (i.e. that nothing existing brakes) for positive case testing that would be done as part of the xks support effort.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CRD-aware dependency watches expanded (Istio, cert-manager, leaderworkerset, etc.), new subscription-group dependency checks, runtime cluster-info setter for tests, and name-suffix event filtering.

* **Bug Fixes**
  * More accurate dependency reporting with aggregated messages and cluster-type gating to skip irrelevant checks on Kubernetes vs OpenShift.

* **Tests**
  * Expanded coverage for operator/CRD/subscription scenarios, cluster-type filtering, and the new dependency-check behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->