### PR TITLE
fix: updated spark image map var

### DIFF
--- a/build/operands-map.yaml
+++ b/build/operands-map.yaml
@@ -230,6 +230,6 @@ relatedImages:
     - name: RELATED_IMAGE_ODH_MOD_ARCH_MAAS_IMAGE
       value: quay.io/opendatahub/mod-arch-maas@sha256:b884966ed030a9c8abaace0491ee1ae3f075a9060ebaa1953c5d0bce028a8e1a
       component: odh-mod-arch-maas
-    - name: RELATED_IMAGE_SPARK_OPERATOR_IMAGE
+    - name: RELATED_IMAGE_ODH_SPARK_OPERATOR_IMAGE
       value: quay.io/opendatahub/spark-operator@sha256:79676b7bdf6ce0dd59bc0a9e82169f773a552ce20d87bb73d911e3bdbc10611a
       component: odh-spark-operator

--- a/internal/controller/components/sparkoperator/sparkoperator_support.go
+++ b/internal/controller/components/sparkoperator/sparkoperator_support.go
@@ -26,8 +26,8 @@ var (
 	// Maps variables in params.env files to RELATED_IMAGE_* environment variables
 	// that are injected by the operator at runtime.
 	imageParamMap = map[string]string{
-		"SPARK_OPERATOR_CONTROLLER_IMAGE": "RELATED_IMAGE_SPARK_OPERATOR_IMAGE",
-		"SPARK_OPERATOR_WEBHOOK_IMAGE":    "RELATED_IMAGE_SPARK_OPERATOR_IMAGE",
+		"SPARK_OPERATOR_CONTROLLER_IMAGE": "RELATED_IMAGE_ODH_SPARK_OPERATOR_IMAGE",
+		"SPARK_OPERATOR_WEBHOOK_IMAGE":    "RELATED_IMAGE_ODH_SPARK_OPERATOR_IMAGE",
 	}
 
 	conditionTypes = []string{


### PR DESCRIPTION
## Description
JIRA: [RHOAIENG-52785](https://issues.redhat.com/browse/RHOAIENG-52785)

This PR updates the image map name for spark from `RELATED_IMAGE_SPARK_OPERATOR_IMAGE` to `RELATED_IMAGE_ODH_SPARK_OPERATOR_IMAGE`

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [X] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
Minor change not requiring e2e


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Renamed a public image reference key to a new identifier to align naming across releases.
  * Updated image reference usage so published image entries match the renamed key, ensuring deployments use the updated identifier.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->