### PR TITLE
fix: increase unit test timeout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -576,7 +576,7 @@ unit-test: envtest ginkgo # directly use ginkgo since the framework is not compa
     	${GINKGO} -r \
         		--procs=8 \
         		--compilers=2 \
-        		--timeout=15m \
+        		--timeout=20m \
         		--poll-progress-after=30s \
         		--poll-progress-interval=5s \
         		--randomize-all \


### PR DESCRIPTION
## Description
This PR increases the unit test timeout from 15 minutes to 20 minutes. I observed that the unit tests were timing out just before completing on multiple PRs. This timeout issue is flaky and only occurs some of the time so a 5 minute increase should be sufficient.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [X] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
Minor Makefile change that doesn't require e2e


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test execution timeout configuration to improve test suite reliability during extended test runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->