### PR TITLE
feat(cloudmanager): skip ServiceMonitor CRD install when already present

### DIFF
--- a/cmd/cloudmanager/app/cache.go
+++ b/cmd/cloudmanager/app/cache.go
@@ -50,9 +50,12 @@ func DefaultCacheOptions(scheme *runtime.Scheme) (cache.Options, error) {
 		Scheme:            scheme,
 		DefaultNamespaces: nsConfig,
 		ByObject: map[client.Object]cache.ByObject{
-			&rbacv1.ClusterRole{}:             clusterScopedConfig,
-			&rbacv1.ClusterRoleBinding{}:      clusterScopedConfig,
-			&extv1.CustomResourceDefinition{}: clusterScopedConfig,
+			&rbacv1.ClusterRole{}:        clusterScopedConfig,
+			&rbacv1.ClusterRoleBinding{}: clusterScopedConfig,
+			// TODO: consider using a metadata-only cache for CRDs to reduce memory
+			// usage now that all CRDs are cached (not just labeled ones).
+			// See controller-runtime's support for metadata-only informers.
+			&extv1.CustomResourceDefinition{}: {},
 			resources.GvkToUnstructured(gvk.RoleBinding): {
 				Namespaces: roleBindingCacheNamespaces,
 			},

--- a/get_all_manifests.sh
+++ b/get_all_manifests.sh
@@ -61,10 +61,10 @@ declare -A RHOAI_COMPONENT_MANIFESTS=(
 
 # ODH Component Charts
 declare -A ODH_COMPONENT_CHARTS=(
-    ["cert-manager-operator"]="opendatahub-io:odh-gitops:main@f600f22bdec2fb6ee24ead6fa04b6b3d896781fb:charts/cert-manager-operator"
-    ["lws-operator"]="opendatahub-io:odh-gitops:main@f600f22bdec2fb6ee24ead6fa04b6b3d896781fb:charts/lws-operator"
-    ["sail-operator"]="opendatahub-io:odh-gitops:main@f600f22bdec2fb6ee24ead6fa04b6b3d896781fb:charts/sail-operator"
-    ["gateway-api"]="opendatahub-io:odh-gitops:main@f600f22bdec2fb6ee24ead6fa04b6b3d896781fb:charts/gateway-api"
+    ["cert-manager-operator"]="opendatahub-io:odh-gitops:main:charts/cert-manager-operator"
+    ["lws-operator"]="opendatahub-io:odh-gitops:main:charts/lws-operator"
+    ["sail-operator"]="opendatahub-io:odh-gitops:main:charts/sail-operator"
+    ["gateway-api"]="opendatahub-io:odh-gitops:main:charts/gateway-api"
 )
 
 # RHOAI Component Charts

--- a/internal/controller/cloudmanager/azure/azurekubernetesengine_controller.go
+++ b/internal/controller/cloudmanager/azure/azurekubernetesengine_controller.go
@@ -3,11 +3,15 @@ package azure
 import (
 	"context"
 
+	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	ccmv1alpha1 "github.com/opendatahub-io/opendatahub-operator/v2/api/cloudmanager/azure/v1alpha1"
+	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/cloudmanager/common"
 	certmanager "github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/dependency/certmanager"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/cloudmanager"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/handlers"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/predicates/resources"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/reconciler"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/metadata/labels"
 )
@@ -16,6 +20,11 @@ func NewReconciler(ctx context.Context, mgr ctrl.Manager) error {
 	resourceID := labels.NormalizePartOfValue(ccmv1alpha1.AzureKubernetesEngineKind)
 	_, err := reconciler.ReconcilerFor(mgr, &ccmv1alpha1.AzureKubernetesEngine{}).
 		WithDynamicOwnership().
+		Watches(
+			&extv1.CustomResourceDefinition{},
+			reconciler.WithEventHandler(handlers.ToNamed(ccmv1alpha1.AzureKubernetesEngineInstanceName)),
+			reconciler.WithPredicates(resources.CreatedOrUpdatedOrDeletedNamed(common.ServiceMonitorCRDName)),
+		).
 		WithAction(initialize).
 		ComposeWith(certmanager.Bootstrap[*ccmv1alpha1.AzureKubernetesEngine](
 			ccmv1alpha1.AzureKubernetesEngineInstanceName, certmanager.DefaultBootstrapConfig())).

--- a/internal/controller/cloudmanager/common/charts.go
+++ b/internal/controller/cloudmanager/common/charts.go
@@ -75,7 +75,7 @@ func allChartDefs() []chartDef {
 						"namespace": NamespaceLWSOperator,
 					}),
 				},
-				PreApply: []types.HookFn{},
+				PreApply: []types.HookFn{SkipCRDIfPresent(ServiceMonitorCRDName)},
 			},
 		},
 		{

--- a/internal/controller/cloudmanager/common/hooks.go
+++ b/internal/controller/cloudmanager/common/hooks.go
@@ -2,14 +2,19 @@ package common
 
 import (
 	"context"
+	"fmt"
 
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	k8stypes "k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/metadata/labels"
 )
 
 const (
@@ -17,6 +22,9 @@ const (
 
 	istioSidecarInjectorWebhook = "istio-sidecar-injector"
 	istioValidatorWebhook       = "istio-validator-istio-system"
+
+	// ServiceMonitorCRDName is the fully qualified name of the ServiceMonitor CRD.
+	ServiceMonitorCRDName = "servicemonitors.monitoring.coreos.com"
 )
 
 // AnnotateIstioWebhooksHook returns a PostApply hook that annotates Istio
@@ -47,6 +55,40 @@ func AnnotateIstioWebhooksHook() types.HookFn {
 		}
 
 		return hookErr
+	}
+}
+
+// SkipCRDIfPresent returns a PreApply hook that removes a CRD from the
+// rendered resources if it already exists in the cluster and is not managed
+// by this controller. This avoids SSA ForceOwnership conflicts with other
+// operators that may own the CRD (e.g., Prometheus Operator for ServiceMonitor).
+// If the CRD carries the infrastructure label it is kept in resources so it can
+// be updated via SSA. On clusters without the CRD, it is kept in resources and
+// deployed normally.
+func SkipCRDIfPresent(crdName string) types.HookFn {
+	return func(ctx context.Context, rr *types.ReconciliationRequest) error {
+		crd, err := cluster.GetCRD(ctx, rr.Client, crdName)
+		if err != nil {
+			if k8serr.IsNotFound(err) {
+				return nil
+			}
+
+			return fmt.Errorf("failed to check CRD %s: %w", crdName, err)
+		}
+
+		// If the CRD is managed by this controller, keep it in resources
+		// so it gets updated via SSA.
+		if _, ok := crd.GetLabels()[labels.InfrastructurePartOf]; ok {
+			return nil
+		}
+
+		logger := logf.FromContext(ctx)
+		logger.Info("CRD already exists, skipping installation", "crd", crdName)
+
+		return rr.RemoveResources(func(obj *unstructured.Unstructured) bool {
+			return obj.GetKind() == gvk.CustomResourceDefinition.Kind &&
+				obj.GetName() == crdName
+		})
 	}
 }
 

--- a/internal/controller/cloudmanager/common/hooks_test.go
+++ b/internal/controller/cloudmanager/common/hooks_test.go
@@ -5,19 +5,34 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
 	odhtypes "github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/metadata/labels"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/fakeclient"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/mocks"
+
+	. "github.com/onsi/gomega"
+)
+
+const (
+	testCRDGroup     = "test.example.com"
+	testCRDVersion   = "v1"
+	testCRDKind      = "Widget"
+	testCRDComponent = "test"
 )
 
 // TODO(OSSM-12397): Remove this test once the sail-operator ships a fix.
 func TestAnnotateIstioWebhooksHook(t *testing.T) {
 	t.Run("should annotate webhooks when they exist without annotation", func(t *testing.T) {
+		g := NewWithT(t)
+
 		mutatingWH := &admissionregistrationv1.MutatingWebhookConfiguration{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: istioSidecarInjectorWebhook,
@@ -30,26 +45,28 @@ func TestAnnotateIstioWebhooksHook(t *testing.T) {
 		}
 
 		cli, err := fakeclient.New(fakeclient.WithObjects(mutatingWH, validatingWH))
-		require.NoError(t, err)
+		g.Expect(err).ShouldNot(HaveOccurred())
 
 		rr := &odhtypes.ReconciliationRequest{Client: cli}
 
 		hook := AnnotateIstioWebhooksHook()
 		err = hook(context.Background(), rr)
-		require.NoError(t, err)
+		g.Expect(err).ShouldNot(HaveOccurred())
 
 		var updatedMutating admissionregistrationv1.MutatingWebhookConfiguration
 		err = cli.Get(context.Background(), types.NamespacedName{Name: istioSidecarInjectorWebhook}, &updatedMutating)
-		require.NoError(t, err)
-		assert.Equal(t, "true", updatedMutating.Annotations[sailOperatorIgnoreAnnotation])
+		g.Expect(err).ShouldNot(HaveOccurred())
+		g.Expect(updatedMutating.Annotations[sailOperatorIgnoreAnnotation]).Should(Equal("true"))
 
 		var updatedValidating admissionregistrationv1.ValidatingWebhookConfiguration
 		err = cli.Get(context.Background(), types.NamespacedName{Name: istioValidatorWebhook}, &updatedValidating)
-		require.NoError(t, err)
-		assert.Equal(t, "true", updatedValidating.Annotations[sailOperatorIgnoreAnnotation])
+		g.Expect(err).ShouldNot(HaveOccurred())
+		g.Expect(updatedValidating.Annotations[sailOperatorIgnoreAnnotation]).Should(Equal("true"))
 	})
 
 	t.Run("should be a no-op when webhooks already have the annotation", func(t *testing.T) {
+		g := NewWithT(t)
+
 		mutatingWH := &admissionregistrationv1.MutatingWebhookConfiguration{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: istioSidecarInjectorWebhook,
@@ -68,32 +85,36 @@ func TestAnnotateIstioWebhooksHook(t *testing.T) {
 		}
 
 		cli, err := fakeclient.New(fakeclient.WithObjects(mutatingWH, validatingWH))
-		require.NoError(t, err)
+		g.Expect(err).ShouldNot(HaveOccurred())
 
 		rr := &odhtypes.ReconciliationRequest{Client: cli}
 
 		hook := AnnotateIstioWebhooksHook()
 		err = hook(context.Background(), rr)
-		require.NoError(t, err)
+		g.Expect(err).ShouldNot(HaveOccurred())
 
 		var updatedMutating admissionregistrationv1.MutatingWebhookConfiguration
 		err = cli.Get(context.Background(), types.NamespacedName{Name: istioSidecarInjectorWebhook}, &updatedMutating)
-		require.NoError(t, err)
-		assert.Equal(t, "true", updatedMutating.Annotations[sailOperatorIgnoreAnnotation])
+		g.Expect(err).ShouldNot(HaveOccurred())
+		g.Expect(updatedMutating.Annotations[sailOperatorIgnoreAnnotation]).Should(Equal("true"))
 	})
 
 	t.Run("should be a no-op when webhooks do not exist", func(t *testing.T) {
+		g := NewWithT(t)
+
 		cli, err := fakeclient.New()
-		require.NoError(t, err)
+		g.Expect(err).ShouldNot(HaveOccurred())
 
 		rr := &odhtypes.ReconciliationRequest{Client: cli}
 
 		hook := AnnotateIstioWebhooksHook()
 		err = hook(context.Background(), rr)
-		require.NoError(t, err)
+		g.Expect(err).ShouldNot(HaveOccurred())
 	})
 
 	t.Run("should preserve existing annotations when adding the ignore annotation", func(t *testing.T) {
+		g := NewWithT(t)
+
 		mutatingWH := &admissionregistrationv1.MutatingWebhookConfiguration{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: istioSidecarInjectorWebhook,
@@ -104,18 +125,107 @@ func TestAnnotateIstioWebhooksHook(t *testing.T) {
 		}
 
 		cli, err := fakeclient.New(fakeclient.WithObjects(mutatingWH))
-		require.NoError(t, err)
+		g.Expect(err).ShouldNot(HaveOccurred())
 
 		rr := &odhtypes.ReconciliationRequest{Client: cli}
 
 		hook := AnnotateIstioWebhooksHook()
 		err = hook(context.Background(), rr)
-		require.NoError(t, err)
+		g.Expect(err).ShouldNot(HaveOccurred())
 
 		var updatedMutating admissionregistrationv1.MutatingWebhookConfiguration
 		err = cli.Get(context.Background(), types.NamespacedName{Name: istioSidecarInjectorWebhook}, &updatedMutating)
-		require.NoError(t, err)
-		assert.Equal(t, "true", updatedMutating.Annotations[sailOperatorIgnoreAnnotation])
-		assert.Equal(t, "existing-value", updatedMutating.Annotations["existing-annotation"])
+		g.Expect(err).ShouldNot(HaveOccurred())
+		g.Expect(updatedMutating.Annotations[sailOperatorIgnoreAnnotation]).Should(Equal("true"))
+		g.Expect(updatedMutating.Annotations["existing-annotation"]).Should(Equal("existing-value"))
 	})
+}
+
+func TestSkipCRDIfPresent(t *testing.T) {
+	// Use a fake CRD name unrelated to any real resource.
+	// mocks.NewMockCRD generates the name as "<plural>.<group>".
+	testCRDName := mocks.NewMockCRD(testCRDGroup, testCRDVersion, testCRDKind, testCRDComponent).Name
+
+	t.Run("should keep resources when CRD does not exist in cluster", func(t *testing.T) {
+		g := NewWithT(t)
+
+		cli, err := fakeclient.New()
+		g.Expect(err).ShouldNot(HaveOccurred())
+
+		rr := &odhtypes.ReconciliationRequest{Client: cli}
+		rr.Resources = newUnstructuredResources(t, cli)
+		initialCount := len(rr.Resources)
+
+		hook := SkipCRDIfPresent(testCRDName)
+		err = hook(context.Background(), rr)
+		g.Expect(err).ShouldNot(HaveOccurred())
+		g.Expect(rr.Resources).Should(HaveLen(initialCount))
+	})
+
+	t.Run("should remove CRD from resources when it exists without infrastructure label", func(t *testing.T) {
+		g := NewWithT(t)
+
+		crd := mocks.NewMockCRD(testCRDGroup, testCRDVersion, testCRDKind, testCRDComponent)
+
+		cli, err := fakeclient.New(fakeclient.WithObjects(crd))
+		g.Expect(err).ShouldNot(HaveOccurred())
+
+		rr := &odhtypes.ReconciliationRequest{Client: cli}
+		rr.Resources = newUnstructuredResources(t, cli)
+		initialCount := len(rr.Resources)
+
+		hook := SkipCRDIfPresent(testCRDName)
+		err = hook(context.Background(), rr)
+		g.Expect(err).ShouldNot(HaveOccurred())
+		g.Expect(rr.Resources).Should(HaveLen(initialCount - 1))
+
+		for _, res := range rr.Resources {
+			if res.GetKind() == gvk.CustomResourceDefinition.Kind {
+				g.Expect(res.GetName()).ShouldNot(Equal(testCRDName))
+			}
+		}
+	})
+
+	t.Run("should keep resources when CRD exists with infrastructure label", func(t *testing.T) {
+		g := NewWithT(t)
+
+		crd := mocks.NewMockCRD(testCRDGroup, testCRDVersion, testCRDKind, testCRDComponent)
+		crd.Labels[labels.InfrastructurePartOf] = "test-component"
+
+		cli, err := fakeclient.New(fakeclient.WithObjects(crd))
+		g.Expect(err).ShouldNot(HaveOccurred())
+
+		rr := &odhtypes.ReconciliationRequest{Client: cli}
+		rr.Resources = newUnstructuredResources(t, cli)
+		initialCount := len(rr.Resources)
+
+		hook := SkipCRDIfPresent(testCRDName)
+		err = hook(context.Background(), rr)
+		g.Expect(err).ShouldNot(HaveOccurred())
+		g.Expect(rr.Resources).Should(HaveLen(initialCount))
+	})
+}
+
+// newUnstructuredResources creates a slice of unstructured resources containing
+// a CRD and a ConfigMap for use in hook tests.
+func newUnstructuredResources(t *testing.T, cli client.Client) []unstructured.Unstructured {
+	t.Helper()
+
+	g := NewWithT(t)
+
+	rr := &odhtypes.ReconciliationRequest{Client: cli}
+
+	err := rr.AddResources(
+		mocks.NewMockCRD(testCRDGroup, testCRDVersion, testCRDKind, testCRDComponent),
+		mocks.NewMockCRD("other.example.com", "v1", "Gadget", "other"),
+		&corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-configmap",
+				Namespace: "default",
+			},
+		},
+	)
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	return rr.Resources
 }

--- a/internal/controller/cloudmanager/coreweave/coreweavekubernetesengine_controller.go
+++ b/internal/controller/cloudmanager/coreweave/coreweavekubernetesengine_controller.go
@@ -3,11 +3,15 @@ package coreweave
 import (
 	"context"
 
+	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	ccmv1alpha1 "github.com/opendatahub-io/opendatahub-operator/v2/api/cloudmanager/coreweave/v1alpha1"
+	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/cloudmanager/common"
 	certmanager "github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/dependency/certmanager"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/cloudmanager"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/handlers"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/predicates/resources"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/reconciler"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/metadata/labels"
 )
@@ -16,6 +20,11 @@ func NewReconciler(ctx context.Context, mgr ctrl.Manager) error {
 	resourceID := labels.NormalizePartOfValue(ccmv1alpha1.CoreWeaveKubernetesEngineKind)
 	_, err := reconciler.ReconcilerFor(mgr, &ccmv1alpha1.CoreWeaveKubernetesEngine{}).
 		WithDynamicOwnership().
+		Watches(
+			&extv1.CustomResourceDefinition{},
+			reconciler.WithEventHandler(handlers.ToNamed(ccmv1alpha1.CoreWeaveKubernetesEngineInstanceName)),
+			reconciler.WithPredicates(resources.CreatedOrUpdatedOrDeletedNamed(common.ServiceMonitorCRDName)),
+		).
 		WithAction(initialize).
 		ComposeWith(certmanager.Bootstrap[*ccmv1alpha1.CoreWeaveKubernetesEngine](
 			ccmv1alpha1.CoreWeaveKubernetesEngineInstanceName, certmanager.DefaultBootstrapConfig())).


### PR DESCRIPTION
## Description
- Add a `SkipCRDIfPresent` PreApply hook that removes a CRD from rendered resources when it already exists in the cluster and is not managed by this controller, preventing SSA ForceOwnership conflicts with other operators (e.g., Prometheus Operator owning the ServiceMonitor CRD).
- Apply the hook to the LWS operator chart for the `ServiceMonitor` CRD, and add CRD watches to both Azure and CoreWeave controllers so reconciliation is triggered when the ServiceMonitor CRD is created, updated, or deleted.
- Broaden the cloud manager CRD cache to watch all CRDs (not just labeled ones) to support the new CRD watches, and migrate existing hook tests from testify to gomega.

Jira task: <!-- Add link if applicable, e.g., https://issues.redhat.com/browse/RHOAIENG-XXXXX -->

## How Has This Been Tested?
- Unit tests added for `SkipCRDIfPresent` covering three scenarios: CRD absent (resources kept), CRD present without infrastructure label (CRD removed from resources), CRD present with infrastructure label (resources kept).
- Existing `AnnotateIstioWebhooksHook` tests migrated to gomega and verified passing.
- `make unit-test` passes.

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [x] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->
cloudmanager e2e tests will be added in following PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Prevent duplicate ServiceMonitor CRDs by skipping CRD resources when they already exist or are infrastructure-owned.
  * Controllers now observe ServiceMonitor CRD changes in real time to react to create/update/delete events.
  * CRD caching/handling optimized for more accurate CRD detection.

* **Tests**
  * Added tests validating CRD skip behavior and CRD-related reconciliation scenarios.

* **Chores**
  * Chart sources updated to track main for cert-manager-operator, lws-operator, sail-operator, and gateway-api.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->