### PR TITLE
fix: resolve issues running cloudmanager and operator in xKS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -569,7 +569,7 @@ test: unit-test e2e-test
 .PHONY: unit-test
 unit-test: envtest ginkgo # directly use ginkgo since the framework is not compatible with go test parallel
 	@if [ ! -d "$(CONFIG_DIR)/crd/bases" ]; then \
-		echo "Error: $(CONFIG_DIR)/crd/bases folder does not exist. Please run 'make manifests' first."; \
+		echo "Error: $(CONFIG_DIR)/crd/bases folder does not exist. Please run 'make manifests-all' first."; \
 		exit 1; \
 	fi
 	OPERATOR_NAMESPACE=$(OPERATOR_NAMESPACE) KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" \

--- a/cmd/cloudmanager/app/cache.go
+++ b/cmd/cloudmanager/app/cache.go
@@ -24,10 +24,6 @@ import (
 // resources by the existence of the infrastructure part-of label.
 func DefaultCacheOptions(scheme *runtime.Scheme) (cache.Options, error) {
 	managedNamespaces := common.ManagedNamespaces()
-	nsConfig := make(map[string]cache.Config, len(managedNamespaces))
-	for _, ns := range managedNamespaces {
-		nsConfig[ns] = cache.Config{}
-	}
 
 	requirement, err := k8slabels.NewRequirement(labels.InfrastructurePartOf, selection.Exists, nil)
 	if err != nil {
@@ -44,23 +40,25 @@ func DefaultCacheOptions(scheme *runtime.Scheme) (cache.Options, error) {
 		common.NamespaceKubeSystem: {LabelSelector: labelSelector},
 	})
 
-	certManagerNamespace := certmanager.DefaultBootstrapConfig().CertManagerNamespace
-	certManagerCacheOption := cacheOptionsWithAdditionalNamespaces(managedNamespaces, map[string]cache.Config{
-		certManagerNamespace: {},
-	})
+	defaultNsConfig := make(map[string]cache.Config, len(managedNamespaces))
+	for _, ns := range managedNamespaces {
+		defaultNsConfig[ns] = cache.Config{}
+	}
+	defaultNsConfig[certmanager.DefaultBootstrapConfig().CertManagerNamespace] = cache.Config{
+		LabelSelector: labelSelector,
+	}
 
 	return cache.Options{
 		Scheme:            scheme,
-		DefaultNamespaces: nsConfig,
+		DefaultNamespaces: defaultNsConfig,
 		ByObject: map[client.Object]cache.ByObject{
 			&rbacv1.ClusterRole{}:        clusterScopedConfig,
 			&rbacv1.ClusterRoleBinding{}: clusterScopedConfig,
 			// TODO: consider using a metadata-only cache for CRDs to reduce memory
 			// usage now that all CRDs are cached (not just labeled ones).
 			// See controller-runtime's support for metadata-only informers.
-			&extv1.CustomResourceDefinition{}:                       {},
-			resources.GvkToUnstructured(gvk.RoleBinding):            roleBindingCacheOption,
-			resources.GvkToUnstructured(gvk.CertManagerCertificate): certManagerCacheOption,
+			&extv1.CustomResourceDefinition{}:            {},
+			resources.GvkToUnstructured(gvk.RoleBinding): roleBindingCacheOption,
 		},
 		DefaultTransform: func(in any) (any, error) {
 			// Nilcheck managed fields to avoid hitting https://github.com/kubernetes/kubernetes/issues/124337

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -50,6 +50,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -309,26 +310,8 @@ func main() { //nolint:funlen,maintidx,gocyclo
 			&corev1.ConfigMap{}: {
 				Namespaces: oDHCache,
 			},
-			// For domain to get OpenshiftIngress and default cert
-			&operatorv1.IngressController{}: {
-				Field: fields.Set{"metadata.name": "default"}.AsSelector(),
-			},
-			// For authentication CR "cluster"
-			&configv1.Authentication{}: {
-				Field: fields.Set{"metadata.name": cluster.ClusterAuthenticationObj}.AsSelector(),
-			},
 			// for prometheus and black-box deployment and ones we owns
 			&appsv1.Deployment{}: {
-				Namespaces: oDHCache,
-			},
-			// kueue + monitoring need prometheusrules
-			&promv1.PrometheusRule{}: {
-				Namespaces: oDHCache,
-			},
-			&promv1.ServiceMonitor{}: {
-				Namespaces: oDHCache,
-			},
-			&routev1.Route{}: {
 				Namespaces: oDHCache,
 			},
 			&networkingv1.NetworkPolicy{}: {
@@ -350,6 +333,23 @@ func main() { //nolint:funlen,maintidx,gocyclo
 			return in, nil
 		},
 	}
+
+	// OpenShift-specific cache filters: only register when running on OpenShift
+	if cluster.GetClusterInfo().Type == cluster.ClusterTypeOpenShift {
+		cacheOptions.ByObject[&operatorv1.IngressController{}] = cache.ByObject{
+			Field: fields.Set{"metadata.name": "default"}.AsSelector(),
+		}
+		cacheOptions.ByObject[&configv1.Authentication{}] = cache.ByObject{
+			Field: fields.Set{"metadata.name": cluster.ClusterAuthenticationObj}.AsSelector(),
+		}
+		cacheOptions.ByObject[&routev1.Route{}] = cache.ByObject{
+			Namespaces: oDHCache,
+		}
+	}
+
+	// Prometheus operator cache filters: only register when the API is available
+	addCacheIfAvailable(setupClient, cacheOptions.ByObject, &promv1.PrometheusRule{}, gvk.PrometheusRule, cache.ByObject{Namespaces: oDHCache})
+	addCacheIfAvailable(setupClient, cacheOptions.ByObject, &promv1.ServiceMonitor{}, gvk.ServiceMonitor, cache.ByObject{Namespaces: oDHCache})
 
 	ctrlMgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{ // single pod does not need to have LeaderElection
 		Scheme: scheme,
@@ -575,6 +575,15 @@ func createODHGeneralCacheConfig(platform common.Platform) (map[string]cache.Con
 	namespaceConfigs["openshift-ingress"] = cache.Config{}   // for gateway auth proxy resources
 
 	return namespaceConfigs, nil
+}
+
+// addCacheIfAvailable adds obj to the ByObject cache map only when its API is
+// present on the cluster. This prevents startup failures on clusters that do
+// not have the corresponding CRD installed (e.g. Prometheus operator on vanilla K8s).
+func addCacheIfAvailable(cli client.Client, byObject map[client.Object]cache.ByObject, obj client.Object, g schema.GroupVersionKind, opts cache.ByObject) {
+	if ok, _ := cluster.IsAPIAvailable(cli, g); ok {
+		byObject[obj] = opts
+	}
 }
 
 func CreateComponentReconcilers(ctx context.Context, mgr *manager.Manager) error {

--- a/internal/controller/components/kserve/kserve_controller.go
+++ b/internal/controller/components/kserve/kserve_controller.go
@@ -154,6 +154,7 @@ func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.
 		}).
 		WithAction(deploy.NewAction(
 			deploy.WithCache(),
+			deploy.WithApplyOrder(),
 		)).
 		WithAction(deployments.NewAction()).
 		// must be the final action

--- a/pkg/controller/actions/dependency/action_operator.go
+++ b/pkg/controller/actions/dependency/action_operator.go
@@ -7,6 +7,8 @@ import (
 	"slices"
 	"strings"
 
+	"k8s.io/apiextensions-apiserver/pkg/apihelpers"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -144,7 +146,7 @@ func (a *action) run(ctx context.Context, rr *odhtypes.ReconciliationRequest) er
 			continue
 		}
 
-		has, err := cluster.HasCRD(ctx, rr.Client, config.GVK)
+		has, err := hasCRDWithVersion(ctx, rr.Client, config.GVK.GroupKind(), config.GVK.Version)
 		if err != nil {
 			// Log and continue - monitoring failures should not block reconciliation.
 			logger := ctrlLog.FromContext(ctx)
@@ -333,4 +335,30 @@ func NewAction(opts ...ActionOpts) actions.Fn {
 	}
 
 	return a.run
+}
+
+// TODO: use the cluster.HasCRD function instead. But that function also checks
+// the CRD stored version, which should be the one checked. To understand why that
+// check.
+// Actually, it's failing the check on security.istio.io, since the stored version is v1beta1
+// but KServe monitor is on v1.
+func hasCRDWithVersion(ctx context.Context, cli client.Client, gk schema.GroupKind, version string) (bool, error) {
+	m, err := cli.RESTMapper().RESTMapping(gk, version)
+	if err != nil {
+		if meta.IsNoMatchError(err) {
+			return false, nil
+		}
+
+		return false, err
+	}
+
+	crd, err := cluster.GetCRD(ctx, cli, m.Resource.GroupResource().String())
+	switch {
+	case err != nil:
+		return false, client.IgnoreNotFound(err)
+	case apihelpers.IsCRDConditionTrue(&crd, apiextensionsv1.Terminating):
+		return false, nil
+	default:
+		return true, nil
+	}
 }

--- a/pkg/upgrade/upgrade.go
+++ b/pkg/upgrade/upgrade.go
@@ -24,7 +24,6 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/api/components/v1alpha1"
-	dsciv2 "github.com/opendatahub-io/opendatahub-operator/v2/api/dscinitialization/v2"
 	infrav1 "github.com/opendatahub-io/opendatahub-operator/v2/api/infrastructure/v1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/services/gateway"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
@@ -77,22 +76,21 @@ func CleanupExistingResource(ctx context.Context,
 	cli client.Client,
 ) error {
 	var multiErr *multierror.Error
-	// get DSCI CR to get application namespace
-	dsciList := &dsciv2.DSCInitializationList{}
-	if err := cli.List(ctx, dsciList); err != nil {
+	// get application namespace
+	applicationNS, err := cluster.ApplicationNamespace(ctx, cli)
+	if err != nil {
+		if k8serr.IsNotFound(err) {
+			return nil
+		}
 		return err
 	}
-	if len(dsciList.Items) == 0 {
-		return nil
-	}
-	d := &dsciList.Items[0]
 
 	// Cleanup of deprecated default RoleBinding resources
-	deprecatedDefaultRoleBinding := []string{d.Spec.ApplicationsNamespace}
-	multiErr = multierror.Append(multiErr, deleteDeprecatedResources(ctx, cli, d.Spec.ApplicationsNamespace, deprecatedDefaultRoleBinding, &rbacv1.RoleBindingList{}))
+	deprecatedDefaultRoleBinding := []string{applicationNS}
+	multiErr = multierror.Append(multiErr, deleteDeprecatedResources(ctx, cli, applicationNS, deprecatedDefaultRoleBinding, &rbacv1.RoleBindingList{}))
 
 	// cleanup model controller legacy deployment
-	multiErr = multierror.Append(multiErr, cleanupModelControllerLegacyDeployment(ctx, cli, d.Spec.ApplicationsNamespace))
+	multiErr = multierror.Append(multiErr, cleanupModelControllerLegacyDeployment(ctx, cli, applicationNS))
 	// cleanup deprecated kueue ValidatingAdmissionPolicyBinding
 	multiErr = multierror.Append(multiErr, cleanupDeprecatedKueueVAPB(ctx, cli))
 
@@ -109,7 +107,7 @@ func CleanupExistingResource(ctx context.Context,
 			multiErr = multierror.Append(multiErr, fmt.Errorf("failed to check AcceleratorProfile CRD: %w", err))
 		} else if hasAccelProfile {
 			// Both CRDs exist, run migration (it's idempotent)
-			multiErr = multierror.Append(multiErr, MigrateToInfraHardwareProfiles(ctx, cli, d.Spec.ApplicationsNamespace))
+			multiErr = multierror.Append(multiErr, MigrateToInfraHardwareProfiles(ctx, cli, applicationNS))
 		}
 	}
 


### PR DESCRIPTION
## Description
- Fix operator startup failures on non-OpenShift (xKS) clusters by conditionally registering OpenShift-specific and Prometheus operator cache filters only when their APIs are available
- Fix cloudmanager cache configuration to include cert-manager namespace in default namespaces with proper label selector, and remove separate cert-manager certificate cache entry
- Replace DSCI CR lookup in upgrade cleanup with `cluster.ApplicationNamespace` helper, and add `deploy.WithApplyOrder()` to KServe reconciler

## How Has This Been Tested?
- Manual testing on xKS (non-OpenShift) cluster to verify operator and cloudmanager start successfully
- Verified on OpenShift cluster to confirm no regressions


## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [x] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->
Not needed, will be added in a following PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved system robustness when certain Kubernetes APIs are unavailable, preventing startup failures when optional feature CRDs are missing.
  * Enhanced cache configuration and dependency monitoring to gracefully handle missing APIs instead of requiring all optional features.

* **Chores**
  * Updated internal dependency monitoring mechanisms for improved reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->