### PR TITLE
fix(build): handle missing git-lfs during manifest fetching

### DIFF
--- a/get_all_manifests.sh
+++ b/get_all_manifests.sh
@@ -164,6 +164,10 @@ function git_fetch_ref()
     mkdir -p $dir
     pushd $dir &>/dev/null
     git init -q
+    # Disable LFS filter to avoid failures when git-lfs is not installed
+    git config --local filter.lfs.smudge cat
+    git config --local filter.lfs.process cat
+    git config --local filter.lfs.required false
 
     # Check if ref is in tracking format: branch@sha
     if [[ $ref =~ ^([a-zA-Z0-9_./-]+)@([a-f0-9]{7,40})$ ]]; then


### PR DESCRIPTION
<!---
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description

Repos using Git LFS (e.g. notebooks) caused `git reset --hard` to fail silently when git-lfs was not installed, because the LFS filter process could not be found. The error was masked by stderr redirection, making it appear as if the pinned commit SHA didn't exist.

Disables the LFS smudge filter in temporary clone directories so manifest fetching works regardless of git-lfs availability.


## How Has This Been Tested?
`./get_all_manifests.sh`

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully
- [ ] New RELATED_IMAGE mappings are already listed in ODH-Build-Config and RHOAI-Build-Config, and links are included in PR description

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification

Changes manifest fetching logic to work when `git-lfs` is not installed (as it's not need for this logic to work)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced git operation handling to work reliably when optional tools are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->