### PR TITLE
fix(test): prevent cloudmanager tests from crashing ginkgo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,8 @@ scripts/gke/build/**
 opt/
 
 cover.out
+covmeta*
+covcounters*
 
 config/manager/kustomization.yaml
 config/rhoai/manager/kustomization.yaml

--- a/internal/controller/cloudmanager/azure/azurekubernetesengine_controller_test.go
+++ b/internal/controller/cloudmanager/azure/azurekubernetesengine_controller_test.go
@@ -33,6 +33,8 @@ import (
 )
 
 func TestAzureKubernetesEngine(t *testing.T) {
+	requireCharts(t)
+
 	t.Run("deploys managed dependencies", func(t *testing.T) {
 		wt := tc.NewWithT(t)
 
@@ -108,6 +110,8 @@ func TestAzureKubernetesEngine(t *testing.T) {
 // TestAzureKubernetesEngineWithoutCertManager tests cert-manager CRD absence and dynamic
 // registration. Each sub-test uses an isolated envtest to start with zero cert-manager CRDs.
 func TestAzureKubernetesEngineWithoutCertManager(t *testing.T) {
+	requireCharts(t)
+
 	logf.SetLogger(zap.New(zap.WriteTo(io.Discard), zap.UseDevMode(true)))
 
 	t.Run("reports DependenciesAvailable=False and Ready=False when cert-manager CRDs absent", func(t *testing.T) {

--- a/internal/controller/cloudmanager/azure/suite_test.go
+++ b/internal/controller/cloudmanager/azure/suite_test.go
@@ -2,6 +2,7 @@ package azure_test
 
 import (
 	"context"
+	"errors"
 	"io"
 	"os"
 	"path/filepath"
@@ -17,13 +18,30 @@ import (
 	"github.com/opendatahub-io/opendatahub-operator/v2/tests/envtestutil"
 )
 
-var tc *testf.TestContext
+var (
+	tc             *testf.TestContext
+	chartsNotFound bool
+)
+
+func requireCharts(t *testing.T) {
+	t.Helper()
+
+	if chartsNotFound {
+		t.Fatal("opt/charts not populated, run 'make get-manifests'")
+	}
+}
 
 func TestMain(m *testing.M) {
-	ctx, cancel := context.WithCancel(context.Background())
-
 	logf.SetLogger(zap.New(zap.WriteTo(io.Discard), zap.UseDevMode(true)))
 
+	teardown := setupEnv()
+	code := m.Run()
+	teardown()
+
+	os.Exit(code)
+}
+
+func setupEnv() func() {
 	rootPath, pathErr := envtestutil.FindProjectRoot()
 	if pathErr != nil {
 		logf.Log.Error(pathErr, "failed to find project root")
@@ -32,10 +50,19 @@ func TestMain(m *testing.M) {
 
 	// Point DefaultChartsPath to the real charts bundled in opt/charts.
 	chartsPath := filepath.Join(rootPath, "opt", "charts")
-	if _, err := os.Stat(chartsPath); os.IsNotExist(err) {
-		logf.Log.Error(err, "opt/charts directory not found, run 'make get-manifests' first")
+	entries, err := os.ReadDir(chartsPath)
+	if err != nil && !os.IsNotExist(err) {
+		logf.Log.Error(err, "failed to read opt/charts directory")
 		os.Exit(1)
 	}
+	if len(entries) == 0 || (len(entries) == 1 && entries[0].Name() == ".gitkeep") {
+		logf.Log.Error(errors.New("opt/charts is not populated"), "run 'make get-manifests' first")
+		chartsNotFound = true
+
+		return func() {}
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
 
 	common.DefaultChartsPath = chartsPath
 
@@ -74,12 +101,10 @@ func TestMain(m *testing.M) {
 		os.Exit(1)
 	}
 
-	code := m.Run()
-
-	cancel()
-	if err := envTestEnv.Stop(); err != nil {
-		logf.Log.Error(err, "failed to stop test environment")
+	return func() {
+		cancel()
+		if err := envTestEnv.Stop(); err != nil {
+			logf.Log.Error(err, "failed to stop test environment")
+		}
 	}
-
-	os.Exit(code)
 }

--- a/internal/controller/cloudmanager/coreweave/coreweavekubernetesengine_controller_test.go
+++ b/internal/controller/cloudmanager/coreweave/coreweavekubernetesengine_controller_test.go
@@ -33,6 +33,8 @@ import (
 )
 
 func TestCoreWeaveKubernetesEngine(t *testing.T) {
+	requireCharts(t)
+
 	t.Run("deploys managed dependencies", func(t *testing.T) {
 		wt := tc.NewWithT(t)
 
@@ -108,6 +110,8 @@ func TestCoreWeaveKubernetesEngine(t *testing.T) {
 // TestCoreWeaveKubernetesEngineWithoutCertManager tests cert-manager CRD absence and dynamic
 // registration. Each sub-test uses an isolated envtest to start with zero cert-manager CRDs.
 func TestCoreWeaveKubernetesEngineWithoutCertManager(t *testing.T) {
+	requireCharts(t)
+
 	logf.SetLogger(zap.New(zap.WriteTo(io.Discard), zap.UseDevMode(true)))
 
 	t.Run("reports DependenciesAvailable=False and Ready=False when cert-manager CRDs absent", func(t *testing.T) {

--- a/internal/controller/cloudmanager/coreweave/suite_test.go
+++ b/internal/controller/cloudmanager/coreweave/suite_test.go
@@ -2,6 +2,7 @@ package coreweave_test
 
 import (
 	"context"
+	"errors"
 	"io"
 	"os"
 	"path/filepath"
@@ -17,13 +18,30 @@ import (
 	"github.com/opendatahub-io/opendatahub-operator/v2/tests/envtestutil"
 )
 
-var tc *testf.TestContext
+var (
+	tc             *testf.TestContext
+	chartsNotFound bool
+)
+
+func requireCharts(t *testing.T) {
+	t.Helper()
+
+	if chartsNotFound {
+		t.Fatal("opt/charts not populated, run 'make get-manifests'")
+	}
+}
 
 func TestMain(m *testing.M) {
-	ctx, cancel := context.WithCancel(context.Background())
-
 	logf.SetLogger(zap.New(zap.WriteTo(io.Discard), zap.UseDevMode(true)))
 
+	teardown := setupEnv()
+	code := m.Run()
+	teardown()
+
+	os.Exit(code)
+}
+
+func setupEnv() func() {
 	rootPath, pathErr := envtestutil.FindProjectRoot()
 	if pathErr != nil {
 		logf.Log.Error(pathErr, "failed to find project root")
@@ -32,10 +50,19 @@ func TestMain(m *testing.M) {
 
 	// Point DefaultChartsPath to the real charts bundled in opt/charts.
 	chartsPath := filepath.Join(rootPath, "opt", "charts")
-	if _, err := os.Stat(chartsPath); os.IsNotExist(err) {
-		logf.Log.Error(err, "opt/charts directory not found, run 'make get-manifests' first")
+	entries, err := os.ReadDir(chartsPath)
+	if err != nil && !os.IsNotExist(err) {
+		logf.Log.Error(err, "failed to read opt/charts directory")
 		os.Exit(1)
 	}
+	if len(entries) == 0 || (len(entries) == 1 && entries[0].Name() == ".gitkeep") {
+		logf.Log.Error(errors.New("opt/charts is not populated"), "run 'make get-manifests' first")
+		chartsNotFound = true
+
+		return func() {}
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
 
 	common.DefaultChartsPath = chartsPath
 
@@ -74,12 +101,10 @@ func TestMain(m *testing.M) {
 		os.Exit(1)
 	}
 
-	code := m.Run()
-
-	cancel()
-	if err := envTestEnv.Stop(); err != nil {
-		logf.Log.Error(err, "failed to stop test environment")
+	return func() {
+		cancel()
+		if err := envTestEnv.Stop(); err != nil {
+			logf.Log.Error(err, "failed to stop test environment")
+		}
 	}
-
-	os.Exit(code)
 }


### PR DESCRIPTION
## Description

The azure and coreweave cloudmanager test suites called os.Exit(1) in TestMain when opt/charts was missing. 

This killed the process before ginkgo could write cover.out, causing a misleading "could not finalize profiles" error instead of surfacing the actual problem.

Defers the failure to individual test functions via t.Fatal so the coverage profile is written and the real error message is visible.

## How Has This Been Tested?
`make test`

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully
- [ ] New RELATED_IMAGE mappings are already listed in ODH-Build-Config and RHOAI-Build-Config, and links are included in PR description

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification

Fixes test setup


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test setup and teardown procedures to validate chart prerequisites before test execution.

* **Chores**
  * Updated version control configuration to ignore additional build artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->