### PR TITLE
fix(RHOAIENG-53488): add operator certificate creation in cert-manager bootstrap

### DIFF
--- a/cmd/cloudmanager/app/cache.go
+++ b/cmd/cloudmanager/app/cache.go
@@ -36,16 +36,20 @@ func DefaultCacheOptions(scheme *runtime.Scheme) (cache.Options, error) {
 		Label: labelSelector,
 	}
 
+	defaultCacheConfig := cache.Config{LabelSelector: labelSelector}
+
 	roleBindingCacheOption := cacheOptionsWithAdditionalNamespaces(managedNamespaces, map[string]cache.Config{
-		common.NamespaceKubeSystem: {LabelSelector: labelSelector},
+		common.NamespaceKubeSystem: defaultCacheConfig,
 	})
 
 	defaultNsConfig := make(map[string]cache.Config, len(managedNamespaces))
 	for _, ns := range managedNamespaces {
-		defaultNsConfig[ns] = cache.Config{}
+		defaultNsConfig[ns] = defaultCacheConfig
 	}
-	defaultNsConfig[certmanager.DefaultBootstrapConfig().CertManagerNamespace] = cache.Config{
-		LabelSelector: labelSelector,
+	bootstrapConfig := certmanager.DefaultBootstrapConfig()
+	defaultNsConfig[bootstrapConfig.CertManagerNamespace] = defaultCacheConfig
+	if operatorConfig := certmanager.BootstrapOperatorCertConfig(); operatorConfig.Namespace != "" {
+		defaultNsConfig[operatorConfig.Namespace] = defaultCacheConfig
 	}
 
 	return cache.Options{

--- a/cmd/cloudmanager/app/run.go
+++ b/cmd/cloudmanager/app/run.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/spf13/cobra"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -15,6 +16,7 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	ctrlmetrics "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
+	certmanager "github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/dependency/certmanager"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/logger"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/manager"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/operatorconfig"
@@ -36,6 +38,10 @@ func Run(_ *cobra.Command, provider Provider) error {
 
 	if err := provider.Validate(); err != nil {
 		return fmt.Errorf("invalid provider configuration: %w", err)
+	}
+
+	if err := validateRequiredEnvVars(); err != nil {
+		return err
 	}
 
 	scheme := newScheme(provider.AddToScheme)
@@ -92,6 +98,20 @@ func Run(_ *cobra.Command, provider Provider) error {
 		return fmt.Errorf("problem running manager: %w", err)
 	}
 
+	return nil
+}
+
+// requiredEnvVars lists environment variables that must be set for any cloud manager provider.
+var requiredEnvVars = []string{
+	certmanager.EnvOperatorNamespace,
+}
+
+func validateRequiredEnvVars() error {
+	for _, env := range requiredEnvVars {
+		if os.Getenv(env) == "" {
+			return fmt.Errorf("required environment variable %s is not set", env)
+		}
+	}
 	return nil
 }
 

--- a/internal/controller/cloudmanager/azure/azurekubernetesengine_controller.go
+++ b/internal/controller/cloudmanager/azure/azurekubernetesengine_controller.go
@@ -27,8 +27,10 @@ func NewReconciler(ctx context.Context, mgr ctrl.Manager) error {
 		).
 		WithAction(initialize).
 		ComposeWith(certmanager.Bootstrap[*ccmv1alpha1.AzureKubernetesEngine](
-			ccmv1alpha1.AzureKubernetesEngineInstanceName, certmanager.DefaultBootstrapConfig())).
-		WithAction(cloudmanager.NewReconcileAction(resourceID)).
+			ccmv1alpha1.AzureKubernetesEngineInstanceName,
+			certmanager.DefaultBootstrapConfig(certmanager.WithOperatorCert()),
+		)).
+		WithActionE(cloudmanager.NewReconcileAction(resourceID)).
 		WithConditions(cloudmanager.ConditionsTypes...).
 		Build(ctx)
 	if err != nil {

--- a/internal/controller/cloudmanager/azure/azurekubernetesengine_controller_test.go
+++ b/internal/controller/cloudmanager/azure/azurekubernetesengine_controller_test.go
@@ -2,43 +2,54 @@ package azure_test
 
 import (
 	"context"
-	"fmt"
 	"io"
 	"testing"
-	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/rest"
-	"k8s.io/utils/ptr"
-	ctrl "sigs.k8s.io/controller-runtime"
-	ctrlconfig "sigs.k8s.io/controller-runtime/pkg/config"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
-	ctrlmetrics "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
 	ccmv1alpha1 "github.com/opendatahub-io/opendatahub-operator/v2/api/cloudmanager/azure/v1alpha1"
 	ccmcommon "github.com/opendatahub-io/opendatahub-operator/v2/api/cloudmanager/common"
 	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/cloudmanager/azure"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/metadata/labels"
+	ccmtest "github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/cloudmanager"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/envt"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/matchers/jq"
-	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/testf"
 
 	. "github.com/onsi/gomega"
 )
 
+var azureCfg = ccmtest.ControllerTestConfig{
+	CRDSubdir:     "azure",
+	NewReconciler: azure.NewReconciler,
+	NewCR: func(deps ccmcommon.Dependencies) client.Object {
+		return &ccmv1alpha1.AzureKubernetesEngine{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: ccmv1alpha1.AzureKubernetesEngineInstanceName,
+			},
+			Spec: ccmv1alpha1.AzureKubernetesEngineSpec{
+				Dependencies: deps,
+			},
+		}
+	},
+	InstanceName: ccmv1alpha1.AzureKubernetesEngineInstanceName,
+	InfraLabel:   "azurekubernetesengine",
+	GVK:          gvk.AzureKubernetesEngine,
+}
+
 func TestAzureKubernetesEngine(t *testing.T) {
-	requireCharts(t)
+	ccmtest.RequireCharts(t)
 
 	t.Run("deploys managed dependencies", func(t *testing.T) {
 		wt := tc.NewWithT(t)
 
-		createAzureCR(t, wt, ccmcommon.Dependencies{
+		ccmtest.CreateCR(t, wt, azureCfg, ccmcommon.Dependencies{
 			GatewayAPI:   ccmcommon.GatewayAPIDependency{ManagementPolicy: ccmcommon.Managed},
 			CertManager:  ccmcommon.CertManagerDependency{ManagementPolicy: ccmcommon.Managed},
 			LWS:          ccmcommon.LWSDependency{ManagementPolicy: ccmcommon.Managed},
@@ -62,7 +73,7 @@ func TestAzureKubernetesEngine(t *testing.T) {
 	t.Run("sets infrastructure label on deployed resources", func(t *testing.T) {
 		wt := tc.NewWithT(t)
 
-		createAzureCR(t, wt, ccmcommon.Dependencies{
+		ccmtest.CreateCR(t, wt, azureCfg, ccmcommon.Dependencies{
 			CertManager: ccmcommon.CertManagerDependency{ManagementPolicy: ccmcommon.Managed},
 		})
 
@@ -75,7 +86,7 @@ func TestAzureKubernetesEngine(t *testing.T) {
 
 	t.Run("creates PKI bootstrap resources when cert-manager is installed", func(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
-		et, wtC := startIsolatedAzureController(t, ctx)
+		et, wtC := ccmtest.StartIsolatedController(t, ctx, azureCfg)
 		t.Cleanup(cancel) // stop the manager before the test environment (registered after et.Stop, so it runs first)
 
 		_, err := et.RegisterCertManagerCRDs(ctx, envt.WithPermissiveSchema())
@@ -86,7 +97,7 @@ func TestAzureKubernetesEngine(t *testing.T) {
 			wtC.Expect(err).NotTo(HaveOccurred())
 		}
 
-		createAzureCR(t, wtC, ccmcommon.Dependencies{
+		ccmtest.CreateCR(t, wtC, azureCfg, ccmcommon.Dependencies{
 			CertManager:  ccmcommon.CertManagerDependency{ManagementPolicy: ccmcommon.Managed},
 			LWS:          ccmcommon.LWSDependency{ManagementPolicy: ccmcommon.Managed},
 			SailOperator: ccmcommon.SailOperatorDependency{ManagementPolicy: ccmcommon.Managed},
@@ -110,18 +121,17 @@ func TestAzureKubernetesEngine(t *testing.T) {
 // TestAzureKubernetesEngineWithoutCertManager tests cert-manager CRD absence and dynamic
 // registration. Each sub-test uses an isolated envtest to start with zero cert-manager CRDs.
 func TestAzureKubernetesEngineWithoutCertManager(t *testing.T) {
-	requireCharts(t)
+	ccmtest.RequireCharts(t)
 
 	logf.SetLogger(zap.New(zap.WriteTo(io.Discard), zap.UseDevMode(true)))
 
 	t.Run("reports DependenciesAvailable=False and Ready=False when cert-manager CRDs absent", func(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
-		et, wtC := startIsolatedAzureController(t, ctx)
+		_, wtC := ccmtest.StartIsolatedController(t, ctx, azureCfg)
 		t.Cleanup(cancel) // stop the manager before the test environment (registered after et.Stop, so it runs first)
-		_ = et
 
 		nn := types.NamespacedName{Name: ccmv1alpha1.AzureKubernetesEngineInstanceName}
-		createAzureCR(t, wtC, ccmcommon.Dependencies{
+		ccmtest.CreateCR(t, wtC, azureCfg, ccmcommon.Dependencies{
 			CertManager: ccmcommon.CertManagerDependency{ManagementPolicy: ccmcommon.Managed},
 		})
 
@@ -135,11 +145,11 @@ func TestAzureKubernetesEngineWithoutCertManager(t *testing.T) {
 
 	t.Run("reconciles PKI resources after cert-manager CRDs appear", func(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
-		et, wtC := startIsolatedAzureController(t, ctx)
+		et, wtC := ccmtest.StartIsolatedController(t, ctx, azureCfg)
 		t.Cleanup(cancel) // stop the manager before the test environment (registered after et.Stop, so it runs first)
 		nn := types.NamespacedName{Name: ccmv1alpha1.AzureKubernetesEngineInstanceName}
 
-		createAzureCR(t, wtC, ccmcommon.Dependencies{
+		ccmtest.CreateCR(t, wtC, azureCfg, ccmcommon.Dependencies{
 			CertManager: ccmcommon.CertManagerDependency{ManagementPolicy: ccmcommon.Managed},
 		})
 
@@ -165,87 +175,4 @@ func TestAzureKubernetesEngineWithoutCertManager(t *testing.T) {
 		wtC.Get(gvk.CertManagerClusterIssuer, types.NamespacedName{Name: "opendatahub-ca-issuer"}).
 			Eventually().ShouldNot(BeNil())
 	})
-}
-
-// startIsolatedAzureController starts a fresh, isolated test environment with the Azure
-// controller running. Each call creates its own Kubernetes API server, completely separate
-// from the shared suite environment. Use this for tests that need specific cluster state
-// (e.g., no cert-manager CRDs installed).
-func startIsolatedAzureController(t *testing.T, ctx context.Context) (*envt.EnvT, *testf.WithT) {
-	t.Helper()
-
-	et, err := envt.New()
-	if err != nil {
-		t.Fatalf("failed to create isolated test environment: %v", err)
-	}
-	t.Cleanup(func() { _ = et.Stop() })
-
-	isolatedTC, err := newAzureTestContext(ctx, et.Config(), et.Scheme())
-	if err != nil {
-		t.Fatalf("failed to create test context: %v", err)
-	}
-
-	// skipNameValidation=true: the Azure controller name is already registered by the main suite.
-	if err := startAzureManager(ctx, et.Config(), et.Scheme(), true); err != nil {
-		t.Fatalf("failed to start azure manager: %v", err)
-	}
-
-	return et, isolatedTC.NewWithT(t)
-}
-
-func newAzureTestContext(ctx context.Context, cfg *rest.Config, s *runtime.Scheme) (*testf.TestContext, error) {
-	return testf.NewTestContext(
-		testf.WithRestConfig(cfg),
-		testf.WithScheme(s),
-		testf.WithContext(ctx),
-		testf.WithTOptions(
-			testf.WithEventuallyTimeout(2*time.Minute),
-			testf.WithEventuallyPollingInterval(250*time.Millisecond),
-		),
-	)
-}
-
-// startAzureManager creates a controller-runtime manager with the Azure reconciler registered
-// and starts it in the background. The manager runs until ctx is cancelled.
-// Set skipNameValidation to true when the same controller name is already registered
-// (e.g., when the main suite has already started the controller).
-func startAzureManager(ctx context.Context, cfg *rest.Config, s *runtime.Scheme, skipNameValidation bool) error {
-	opts := ctrl.Options{
-		Scheme:         s,
-		LeaderElection: false,
-		Metrics:        ctrlmetrics.Options{BindAddress: "0"},
-	}
-	if skipNameValidation {
-		opts.Controller = ctrlconfig.Controller{SkipNameValidation: ptr.To(true)}
-	}
-
-	mgr, err := ctrl.NewManager(cfg, opts)
-	if err != nil {
-		return fmt.Errorf("create manager: %w", err)
-	}
-	if err := azure.NewReconciler(ctx, mgr); err != nil {
-		return fmt.Errorf("register reconciler: %w", err)
-	}
-	go func() {
-		if err := mgr.Start(ctx); err != nil {
-			logf.Log.Error(err, "manager stopped with error")
-		}
-	}()
-	return nil
-}
-
-func createAzureCR(t *testing.T, wt *testf.WithT, deps ccmcommon.Dependencies) {
-	t.Helper()
-
-	ake := &ccmv1alpha1.AzureKubernetesEngine{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: ccmv1alpha1.AzureKubernetesEngineInstanceName,
-		},
-		Spec: ccmv1alpha1.AzureKubernetesEngineSpec{
-			Dependencies: deps,
-		},
-	}
-
-	wt.Expect(wt.Client().Create(wt.Context(), ake)).Should(Succeed())
-	envt.CleanupDelete(t, NewWithT(t), wt.Context(), wt.Client(), ake)
 }

--- a/internal/controller/cloudmanager/azure/suite_test.go
+++ b/internal/controller/cloudmanager/azure/suite_test.go
@@ -1,110 +1,14 @@
 package azure_test
 
 import (
-	"context"
-	"errors"
-	"io"
-	"os"
-	"path/filepath"
 	"testing"
 
-	"sigs.k8s.io/controller-runtime/pkg/envtest"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
-
-	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/cloudmanager/common"
-	testscheme "github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/scheme"
+	ccmtest "github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/cloudmanager"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/testf"
-	"github.com/opendatahub-io/opendatahub-operator/v2/tests/envtestutil"
 )
 
-var (
-	tc             *testf.TestContext
-	chartsNotFound bool
-)
-
-func requireCharts(t *testing.T) {
-	t.Helper()
-
-	if chartsNotFound {
-		t.Fatal("opt/charts not populated, run 'make get-manifests'")
-	}
-}
+var tc *testf.TestContext
 
 func TestMain(m *testing.M) {
-	logf.SetLogger(zap.New(zap.WriteTo(io.Discard), zap.UseDevMode(true)))
-
-	teardown := setupEnv()
-	code := m.Run()
-	teardown()
-
-	os.Exit(code)
-}
-
-func setupEnv() func() {
-	rootPath, pathErr := envtestutil.FindProjectRoot()
-	if pathErr != nil {
-		logf.Log.Error(pathErr, "failed to find project root")
-		os.Exit(1)
-	}
-
-	// Point DefaultChartsPath to the real charts bundled in opt/charts.
-	chartsPath := filepath.Join(rootPath, "opt", "charts")
-	entries, err := os.ReadDir(chartsPath)
-	if err != nil && !os.IsNotExist(err) {
-		logf.Log.Error(err, "failed to read opt/charts directory")
-		os.Exit(1)
-	}
-	if len(entries) == 0 || (len(entries) == 1 && entries[0].Name() == ".gitkeep") {
-		logf.Log.Error(errors.New("opt/charts is not populated"), "run 'make get-manifests' first")
-		chartsNotFound = true
-
-		return func() {}
-	}
-
-	ctx, cancel := context.WithCancel(context.Background())
-
-	common.DefaultChartsPath = chartsPath
-
-	s, err := testscheme.New()
-	if err != nil {
-		logf.Log.Error(err, "failed to create scheme")
-		os.Exit(1)
-	}
-
-	envTestEnv := &envtest.Environment{
-		CRDInstallOptions: envtest.CRDInstallOptions{
-			Scheme: s,
-			Paths: []string{
-				filepath.Join(rootPath, "config", "cloudmanager", "azure", "crd", "bases"),
-			},
-			ErrorIfPathMissing: true,
-			CleanUpAfterUse:    false,
-		},
-		ErrorIfCRDPathMissing: true,
-	}
-
-	cfg, err := envTestEnv.Start()
-	if err != nil {
-		logf.Log.Error(err, "failed to start test environment")
-		os.Exit(1)
-	}
-
-	tc, err = newAzureTestContext(ctx, cfg, s)
-	if err != nil {
-		logf.Log.Error(err, "failed to create test context")
-		os.Exit(1)
-	}
-
-	if err := startAzureManager(ctx, cfg, s, false); err != nil {
-		logf.Log.Error(err, "failed to start manager")
-		os.Exit(1)
-	}
-
-	return func() {
-		cancel()
-		if err := envTestEnv.Stop(); err != nil {
-			logf.Log.Error(err, "failed to stop test environment")
-		}
-	}
+	ccmtest.RunTestMain(m, &tc, azureCfg)
 }

--- a/internal/controller/cloudmanager/coreweave/coreweavekubernetesengine_controller.go
+++ b/internal/controller/cloudmanager/coreweave/coreweavekubernetesengine_controller.go
@@ -27,8 +27,10 @@ func NewReconciler(ctx context.Context, mgr ctrl.Manager) error {
 		).
 		WithAction(initialize).
 		ComposeWith(certmanager.Bootstrap[*ccmv1alpha1.CoreWeaveKubernetesEngine](
-			ccmv1alpha1.CoreWeaveKubernetesEngineInstanceName, certmanager.DefaultBootstrapConfig())).
-		WithAction(cloudmanager.NewReconcileAction(resourceID)).
+			ccmv1alpha1.CoreWeaveKubernetesEngineInstanceName,
+			certmanager.DefaultBootstrapConfig(certmanager.WithOperatorCert()),
+		)).
+		WithActionE(cloudmanager.NewReconcileAction(resourceID)).
 		WithConditions(cloudmanager.ConditionsTypes...).
 		Build(ctx)
 	if err != nil {

--- a/internal/controller/cloudmanager/coreweave/coreweavekubernetesengine_controller_test.go
+++ b/internal/controller/cloudmanager/coreweave/coreweavekubernetesengine_controller_test.go
@@ -2,43 +2,54 @@ package coreweave_test
 
 import (
 	"context"
-	"fmt"
 	"io"
 	"testing"
-	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/rest"
-	"k8s.io/utils/ptr"
-	ctrl "sigs.k8s.io/controller-runtime"
-	ctrlconfig "sigs.k8s.io/controller-runtime/pkg/config"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
-	ctrlmetrics "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
 	ccmcommon "github.com/opendatahub-io/opendatahub-operator/v2/api/cloudmanager/common"
 	ccmv1alpha1 "github.com/opendatahub-io/opendatahub-operator/v2/api/cloudmanager/coreweave/v1alpha1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/cloudmanager/coreweave"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/metadata/labels"
+	ccmtest "github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/cloudmanager"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/envt"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/matchers/jq"
-	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/testf"
 
 	. "github.com/onsi/gomega"
 )
 
+var coreweaveCfg = ccmtest.ControllerTestConfig{
+	CRDSubdir:     "coreweave",
+	NewReconciler: coreweave.NewReconciler,
+	NewCR: func(deps ccmcommon.Dependencies) client.Object {
+		return &ccmv1alpha1.CoreWeaveKubernetesEngine{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: ccmv1alpha1.CoreWeaveKubernetesEngineInstanceName,
+			},
+			Spec: ccmv1alpha1.CoreWeaveKubernetesEngineSpec{
+				Dependencies: deps,
+			},
+		}
+	},
+	InstanceName: ccmv1alpha1.CoreWeaveKubernetesEngineInstanceName,
+	InfraLabel:   "coreweavekubernetesengine",
+	GVK:          gvk.CoreWeaveKubernetesEngine,
+}
+
 func TestCoreWeaveKubernetesEngine(t *testing.T) {
-	requireCharts(t)
+	ccmtest.RequireCharts(t)
 
 	t.Run("deploys managed dependencies", func(t *testing.T) {
 		wt := tc.NewWithT(t)
 
-		createCoreweaveCR(t, wt, ccmcommon.Dependencies{
+		ccmtest.CreateCR(t, wt, coreweaveCfg, ccmcommon.Dependencies{
 			GatewayAPI:   ccmcommon.GatewayAPIDependency{ManagementPolicy: ccmcommon.Managed},
 			CertManager:  ccmcommon.CertManagerDependency{ManagementPolicy: ccmcommon.Managed},
 			LWS:          ccmcommon.LWSDependency{ManagementPolicy: ccmcommon.Managed},
@@ -62,7 +73,7 @@ func TestCoreWeaveKubernetesEngine(t *testing.T) {
 	t.Run("sets infrastructure label on deployed resources", func(t *testing.T) {
 		wt := tc.NewWithT(t)
 
-		createCoreweaveCR(t, wt, ccmcommon.Dependencies{
+		ccmtest.CreateCR(t, wt, coreweaveCfg, ccmcommon.Dependencies{
 			CertManager: ccmcommon.CertManagerDependency{ManagementPolicy: ccmcommon.Managed},
 		})
 
@@ -75,7 +86,7 @@ func TestCoreWeaveKubernetesEngine(t *testing.T) {
 
 	t.Run("creates PKI bootstrap resources when cert-manager is installed", func(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
-		et, wtC := startIsolatedCoreweaveController(t, ctx)
+		et, wtC := ccmtest.StartIsolatedController(t, ctx, coreweaveCfg)
 		t.Cleanup(cancel) // stop the manager before the test environment (registered after et.Stop, so it runs first)
 
 		_, err := et.RegisterCertManagerCRDs(ctx, envt.WithPermissiveSchema())
@@ -86,7 +97,7 @@ func TestCoreWeaveKubernetesEngine(t *testing.T) {
 			wtC.Expect(err).NotTo(HaveOccurred())
 		}
 
-		createCoreweaveCR(t, wtC, ccmcommon.Dependencies{
+		ccmtest.CreateCR(t, wtC, coreweaveCfg, ccmcommon.Dependencies{
 			CertManager:  ccmcommon.CertManagerDependency{ManagementPolicy: ccmcommon.Managed},
 			LWS:          ccmcommon.LWSDependency{ManagementPolicy: ccmcommon.Managed},
 			SailOperator: ccmcommon.SailOperatorDependency{ManagementPolicy: ccmcommon.Managed},
@@ -110,18 +121,17 @@ func TestCoreWeaveKubernetesEngine(t *testing.T) {
 // TestCoreWeaveKubernetesEngineWithoutCertManager tests cert-manager CRD absence and dynamic
 // registration. Each sub-test uses an isolated envtest to start with zero cert-manager CRDs.
 func TestCoreWeaveKubernetesEngineWithoutCertManager(t *testing.T) {
-	requireCharts(t)
+	ccmtest.RequireCharts(t)
 
 	logf.SetLogger(zap.New(zap.WriteTo(io.Discard), zap.UseDevMode(true)))
 
 	t.Run("reports DependenciesAvailable=False and Ready=False when cert-manager CRDs absent", func(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
-		et, wtC := startIsolatedCoreweaveController(t, ctx)
+		_, wtC := ccmtest.StartIsolatedController(t, ctx, coreweaveCfg)
 		t.Cleanup(cancel) // stop the manager before the test environment (registered after et.Stop, so it runs first)
-		_ = et
 
 		nn := types.NamespacedName{Name: ccmv1alpha1.CoreWeaveKubernetesEngineInstanceName}
-		createCoreweaveCR(t, wtC, ccmcommon.Dependencies{
+		ccmtest.CreateCR(t, wtC, coreweaveCfg, ccmcommon.Dependencies{
 			CertManager: ccmcommon.CertManagerDependency{ManagementPolicy: ccmcommon.Managed},
 		})
 
@@ -135,12 +145,12 @@ func TestCoreWeaveKubernetesEngineWithoutCertManager(t *testing.T) {
 
 	t.Run("reconciles PKI resources after cert-manager CRDs appear", func(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
-		et, wtC := startIsolatedCoreweaveController(t, ctx)
+		et, wtC := ccmtest.StartIsolatedController(t, ctx, coreweaveCfg)
 		t.Cleanup(cancel) // stop the manager before the test environment (registered after et.Stop, so it runs first)
 
 		nn := types.NamespacedName{Name: ccmv1alpha1.CoreWeaveKubernetesEngineInstanceName}
 
-		createCoreweaveCR(t, wtC, ccmcommon.Dependencies{
+		ccmtest.CreateCR(t, wtC, coreweaveCfg, ccmcommon.Dependencies{
 			CertManager: ccmcommon.CertManagerDependency{ManagementPolicy: ccmcommon.Managed},
 		})
 
@@ -166,87 +176,4 @@ func TestCoreWeaveKubernetesEngineWithoutCertManager(t *testing.T) {
 		wtC.Get(gvk.CertManagerClusterIssuer, types.NamespacedName{Name: "opendatahub-ca-issuer"}).
 			Eventually().ShouldNot(BeNil())
 	})
-}
-
-// startIsolatedCoreweaveController starts a fresh, isolated test environment with the CoreWeave
-// controller running. Each call creates its own Kubernetes API server, completely separate
-// from the shared suite environment. Use this for tests that need specific cluster state
-// (e.g., no cert-manager CRDs installed).
-func startIsolatedCoreweaveController(t *testing.T, ctx context.Context) (*envt.EnvT, *testf.WithT) {
-	t.Helper()
-
-	et, err := envt.New()
-	if err != nil {
-		t.Fatalf("failed to create isolated test environment: %v", err)
-	}
-	t.Cleanup(func() { _ = et.Stop() })
-
-	isolatedTC, err := newCoreweaveTestContext(ctx, et.Config(), et.Scheme())
-	if err != nil {
-		t.Fatalf("failed to create test context: %v", err)
-	}
-
-	// skipNameValidation=true: the CoreWeave controller name is already registered by the main suite.
-	if err := startCoreweaveManager(ctx, et.Config(), et.Scheme(), true); err != nil {
-		t.Fatalf("failed to start coreweave manager: %v", err)
-	}
-
-	return et, isolatedTC.NewWithT(t)
-}
-
-func newCoreweaveTestContext(ctx context.Context, cfg *rest.Config, s *runtime.Scheme) (*testf.TestContext, error) {
-	return testf.NewTestContext(
-		testf.WithRestConfig(cfg),
-		testf.WithScheme(s),
-		testf.WithContext(ctx),
-		testf.WithTOptions(
-			testf.WithEventuallyTimeout(2*time.Minute),
-			testf.WithEventuallyPollingInterval(250*time.Millisecond),
-		),
-	)
-}
-
-// startCoreweaveManager creates a controller-runtime manager with the CoreWeave reconciler
-// registered and starts it in the background. The manager runs until ctx is cancelled.
-// Set skipNameValidation to true when the same controller name is already registered
-// (e.g., when the main suite has already started the controller).
-func startCoreweaveManager(ctx context.Context, cfg *rest.Config, s *runtime.Scheme, skipNameValidation bool) error {
-	opts := ctrl.Options{
-		Scheme:         s,
-		LeaderElection: false,
-		Metrics:        ctrlmetrics.Options{BindAddress: "0"},
-	}
-	if skipNameValidation {
-		opts.Controller = ctrlconfig.Controller{SkipNameValidation: ptr.To(true)}
-	}
-
-	mgr, err := ctrl.NewManager(cfg, opts)
-	if err != nil {
-		return fmt.Errorf("create manager: %w", err)
-	}
-	if err := coreweave.NewReconciler(ctx, mgr); err != nil {
-		return fmt.Errorf("register reconciler: %w", err)
-	}
-	go func() {
-		if err := mgr.Start(ctx); err != nil {
-			logf.Log.Error(err, "manager stopped with error")
-		}
-	}()
-	return nil
-}
-
-func createCoreweaveCR(t *testing.T, wt *testf.WithT, deps ccmcommon.Dependencies) {
-	t.Helper()
-
-	cwe := &ccmv1alpha1.CoreWeaveKubernetesEngine{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: ccmv1alpha1.CoreWeaveKubernetesEngineInstanceName,
-		},
-		Spec: ccmv1alpha1.CoreWeaveKubernetesEngineSpec{
-			Dependencies: deps,
-		},
-	}
-
-	wt.Expect(wt.Client().Create(wt.Context(), cwe)).Should(Succeed())
-	envt.CleanupDelete(t, NewWithT(t), wt.Context(), wt.Client(), cwe)
 }

--- a/internal/controller/cloudmanager/coreweave/suite_test.go
+++ b/internal/controller/cloudmanager/coreweave/suite_test.go
@@ -1,110 +1,14 @@
 package coreweave_test
 
 import (
-	"context"
-	"errors"
-	"io"
-	"os"
-	"path/filepath"
 	"testing"
 
-	"sigs.k8s.io/controller-runtime/pkg/envtest"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
-
-	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/cloudmanager/common"
-	testscheme "github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/scheme"
+	ccmtest "github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/cloudmanager"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/testf"
-	"github.com/opendatahub-io/opendatahub-operator/v2/tests/envtestutil"
 )
 
-var (
-	tc             *testf.TestContext
-	chartsNotFound bool
-)
-
-func requireCharts(t *testing.T) {
-	t.Helper()
-
-	if chartsNotFound {
-		t.Fatal("opt/charts not populated, run 'make get-manifests'")
-	}
-}
+var tc *testf.TestContext
 
 func TestMain(m *testing.M) {
-	logf.SetLogger(zap.New(zap.WriteTo(io.Discard), zap.UseDevMode(true)))
-
-	teardown := setupEnv()
-	code := m.Run()
-	teardown()
-
-	os.Exit(code)
-}
-
-func setupEnv() func() {
-	rootPath, pathErr := envtestutil.FindProjectRoot()
-	if pathErr != nil {
-		logf.Log.Error(pathErr, "failed to find project root")
-		os.Exit(1)
-	}
-
-	// Point DefaultChartsPath to the real charts bundled in opt/charts.
-	chartsPath := filepath.Join(rootPath, "opt", "charts")
-	entries, err := os.ReadDir(chartsPath)
-	if err != nil && !os.IsNotExist(err) {
-		logf.Log.Error(err, "failed to read opt/charts directory")
-		os.Exit(1)
-	}
-	if len(entries) == 0 || (len(entries) == 1 && entries[0].Name() == ".gitkeep") {
-		logf.Log.Error(errors.New("opt/charts is not populated"), "run 'make get-manifests' first")
-		chartsNotFound = true
-
-		return func() {}
-	}
-
-	ctx, cancel := context.WithCancel(context.Background())
-
-	common.DefaultChartsPath = chartsPath
-
-	s, err := testscheme.New()
-	if err != nil {
-		logf.Log.Error(err, "failed to create scheme")
-		os.Exit(1)
-	}
-
-	envTestEnv := &envtest.Environment{
-		CRDInstallOptions: envtest.CRDInstallOptions{
-			Scheme: s,
-			Paths: []string{
-				filepath.Join(rootPath, "config", "cloudmanager", "coreweave", "crd", "bases"),
-			},
-			ErrorIfPathMissing: true,
-			CleanUpAfterUse:    false,
-		},
-		ErrorIfCRDPathMissing: true,
-	}
-
-	cfg, err := envTestEnv.Start()
-	if err != nil {
-		logf.Log.Error(err, "failed to start test environment")
-		os.Exit(1)
-	}
-
-	tc, err = newCoreweaveTestContext(ctx, cfg, s)
-	if err != nil {
-		logf.Log.Error(err, "failed to create test context")
-		os.Exit(1)
-	}
-
-	if err := startCoreweaveManager(ctx, cfg, s, false); err != nil {
-		logf.Log.Error(err, "failed to start manager")
-		os.Exit(1)
-	}
-
-	return func() {
-		cancel()
-		if err := envTestEnv.Stop(); err != nil {
-			logf.Log.Error(err, "failed to stop test environment")
-		}
-	}
+	ccmtest.RunTestMain(m, &tc, coreweaveCfg)
 }

--- a/pkg/controller/actions/dependency/certmanager/bootstrap.go
+++ b/pkg/controller/actions/dependency/certmanager/bootstrap.go
@@ -8,12 +8,17 @@
 //
 //   - CA-backed ClusterIssuer: references the Secret that cert-manager creates for the
 //     root CA Certificate. Other components use this issuer to get their own certificates.
+//
+// When the operator namespace is configured, the bootstrap
+// also creates a webhook serving Certificate issued by the CA-backed ClusterIssuer.
 
 package certmanager
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"os"
 
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -42,6 +47,26 @@ const (
 	certManagerClusterIssuerCRD = "clusterissuers.cert-manager.io"
 )
 
+var OperatorNamespace = os.Getenv(EnvOperatorNamespace)
+
+// OperatorCertConfig groups the configuration for the operator's webhook serving certificate.
+// When Namespace is empty, no webhook Certificate is created.
+type OperatorCertConfig struct {
+	// Namespace is the namespace where the operator is deployed.
+	// When empty, no webhook Certificate is created.
+	Namespace string
+
+	// WebhookCertName is the name of the cert-manager Certificate resource for the webhook.
+	WebhookCertName string
+
+	// WebhookCertSecretName is the name of the Secret that cert-manager populates
+	// with the webhook TLS certificate. Must match the operator deployment's volume mount.
+	WebhookCertSecretName string
+
+	// WebhookServiceName is the name of the webhook Service, used to construct DNS SANs.
+	WebhookServiceName string
+}
+
 // BootstrapConfig holds the resource names to create a PKI trust chain using cert-manager.
 // The default values from [DefaultBootstrapConfig] should be good for most cases, overriding only for testing.
 type BootstrapConfig struct {
@@ -58,17 +83,59 @@ type BootstrapConfig struct {
 	// CAIssuerName is the name of the CA-backed ClusterIssuer. Other components use this
 	// issuer to get their own certificates.
 	CAIssuerName string
+
+	// OperatorCertConfig holds the configuration for the operator's webhook serving certificate.
+	// When OperatorCertConfig.Namespace is empty, no webhook Certificate is created.
+	OperatorCertConfig *OperatorCertConfig
+}
+
+// BootstrapConfigOpt is a functional option for [DefaultBootstrapConfig].
+type BootstrapConfigOpt func(*BootstrapConfig)
+
+// WithOperatorCert enables creation of the operator's webhook serving Certificate
+// using the defaults from DefaultOperatorCertConfig.
+func WithOperatorCert() BootstrapConfigOpt {
+	return func(c *BootstrapConfig) {
+		c.OperatorCertConfig = BootstrapOperatorCertConfig()
+	}
 }
 
 // DefaultBootstrapConfig returns the standard ODH PKI bootstrap configuration.
 // These names are part of the API contract with downstream components.
-func DefaultBootstrapConfig() BootstrapConfig {
-	return BootstrapConfig{
+//
+// By default, Operator is nil and no webhook Certificate is created.
+// Use [WithOperatorCert] to enable the operator webhook certificate.
+func DefaultBootstrapConfig(opts ...BootstrapConfigOpt) BootstrapConfig {
+	config := BootstrapConfig{
 		IssuerName:           "opendatahub-selfsigned-issuer",
 		CertName:             "opendatahub-ca",
 		CertManagerNamespace: "cert-manager",
 		CAIssuerName:         "opendatahub-ca-issuer",
 	}
+	for _, opt := range opts {
+		opt(&config)
+	}
+	return config
+}
+
+// BootstrapOperatorCertConfig returns the default operator webhook certificate configuration,
+// reading overrides from environment variables. The caller must set Namespace (or use
+// RHAI_OPERATOR_NAMESPACE) before attaching it to a BootstrapConfig.
+func BootstrapOperatorCertConfig() *OperatorCertConfig {
+	return &OperatorCertConfig{
+		Namespace:             OperatorNamespace,
+		WebhookCertName:       "opendatahub-operator-webhook-cert",
+		WebhookCertSecretName: envOrDefault(EnvOperatorWebhookCertSecretName, "opendatahub-operator-controller-webhook-cert"),
+		WebhookServiceName:    envOrDefault(EnvOperatorWebhookServiceName, "opendatahub-operator-webhook-service"),
+	}
+}
+
+// envOrDefault returns the value of the named environment variable or fallback if unset/empty.
+func envOrDefault(key, fallback string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return fallback
 }
 
 // Environment variable names for overriding the default cert-manager PKI configuration.
@@ -81,6 +148,10 @@ const (
 	EnvCertManagerNS     = "RHAI_CA_SECRET_NAMESPACE"
 	EnvIstioCACertPath   = "RHAI_ISTIO_CA_CERTIFICATE_PATH"
 	DefaultIssuerRefKind = "ClusterIssuer"
+
+	EnvOperatorNamespace             = "RHAI_OPERATOR_NAMESPACE"
+	EnvOperatorWebhookCertSecretName = "RHAI_WEBHOOK_CERT_SECRET_NAME" //nolint:gosec
+	EnvOperatorWebhookServiceName    = "RHAI_WEBHOOK_SERVICE_NAME"
 )
 
 // NewBootstrapAction returns a reusable pipeline action that adds the cert-manager PKI trust
@@ -91,9 +162,14 @@ const (
 // - a self-signed ClusterIssuer
 // - a root CA Certificate
 // - a CA-backed ClusterIssuer
+// - (optional) a webhook serving Certificate, when Operator.Namespace is set
 //
 // The action is a no-op when cert-manager CRDs (ClusterIssuer or Certificate) are absent on the cluster.
-func NewBootstrapAction(config BootstrapConfig) actions.Fn {
+func NewBootstrapAction(config BootstrapConfig) (actions.Fn, error) {
+	if config.OperatorCertConfig != nil && config.OperatorCertConfig.Namespace == "" {
+		return nil, errors.New("operator namespace must not be empty when operator cert config generation is set")
+	}
+
 	return func(ctx context.Context, rr *types.ReconciliationRequest) error {
 		hasClusterIssuer, err := cluster.HasCRD(ctx, rr.Client, gvk.CertManagerClusterIssuer)
 		if err != nil {
@@ -122,8 +198,18 @@ func NewBootstrapAction(config BootstrapConfig) actions.Fn {
 			return err
 		}
 
-		return rr.AddResources(issuer, caCert, caIssuer)
-	}
+		resources := []client.Object{issuer, caCert, caIssuer}
+
+		if config.OperatorCertConfig != nil {
+			webhookCert, err := createWebhookCertificate(config)
+			if err != nil {
+				return err
+			}
+			resources = append(resources, webhookCert)
+		}
+
+		return rr.AddResources(resources...)
+	}, nil
 }
 
 // createSelfSignedIssuer returns the bootstrap ClusterIssuer that signs the root CA certificate.
@@ -159,6 +245,30 @@ func createRootCACertificate(config BootstrapConfig) (*unstructured.Unstructured
 		},
 	}, "spec"); err != nil {
 		return nil, fmt.Errorf("failed to set spec on root CA Certificate: %w", err)
+	}
+	return u, nil
+}
+
+// createWebhookCertificate returns a cert-manager Certificate for the operator's webhook
+// serving TLS. It is issued by the CA-backed ClusterIssuer from the bootstrap chain.
+func createWebhookCertificate(config BootstrapConfig) (*unstructured.Unstructured, error) {
+	u := &unstructured.Unstructured{}
+	u.SetGroupVersionKind(gvk.CertManagerCertificate)
+	u.SetName(config.OperatorCertConfig.WebhookCertName)
+	u.SetNamespace(config.OperatorCertConfig.Namespace)
+	if err := unstructured.SetNestedMap(u.Object, map[string]any{
+		"secretName": config.OperatorCertConfig.WebhookCertSecretName,
+		"dnsNames": []any{
+			fmt.Sprintf("%s.%s.svc", config.OperatorCertConfig.WebhookServiceName, config.OperatorCertConfig.Namespace),
+			fmt.Sprintf("%s.%s.svc.cluster.local", config.OperatorCertConfig.WebhookServiceName, config.OperatorCertConfig.Namespace),
+		},
+		"issuerRef": map[string]any{
+			"name":  config.CAIssuerName,
+			"kind":  gvk.CertManagerClusterIssuer.Kind,
+			"group": gvk.CertManagerClusterIssuer.Group,
+		},
+	}, "spec"); err != nil {
+		return nil, fmt.Errorf("failed to set spec on webhook Certificate: %w", err)
 	}
 	return u, nil
 }
@@ -233,7 +343,7 @@ func Bootstrap[T common.PlatformObject](instanceName string, config BootstrapCon
 			reconciler.WithPredicates(CRDPredicate()),
 		).
 			WithAction(dependency.NewAction(MonitorCRDs())).
-			WithAction(NewBootstrapAction(config)).
+			WithActionE(NewBootstrapAction(config)).
 			WithConditions(status.ConditionDependenciesAvailable)
 	}
 }

--- a/pkg/controller/actions/dependency/certmanager/bootstrap_test.go
+++ b/pkg/controller/actions/dependency/certmanager/bootstrap_test.go
@@ -2,6 +2,7 @@ package certmanager_test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/rs/xid"
@@ -59,6 +60,13 @@ func getRootCACertificate(ctx context.Context, cli client.Client, name, namespac
 	return u, cli.Get(ctx, client.ObjectKey{Name: name, Namespace: namespace}, u)
 }
 
+// getWebhookCertificate fetches the webhook cert-manager Certificate by name and namespace.
+func getWebhookCertificate(ctx context.Context, cli client.Client, name, namespace string) (*unstructured.Unstructured, error) {
+	u := &unstructured.Unstructured{}
+	u.SetGroupVersionKind(gvk.CertManagerCertificate)
+	return u, cli.Get(ctx, client.ObjectKey{Name: name, Namespace: namespace}, u)
+}
+
 // TestBootstrapCertManagerPKI verifies that NewBootstrapAction adds the cert-manager PKI trust
 // chain resources to the reconciliation request, which are then applied by the deploy action.
 //
@@ -80,7 +88,8 @@ func TestBootstrapCertManagerPKI(t *testing.T) {
 		ctx := context.Background()
 		rr := &types.ReconciliationRequest{Client: envTest.Client()}
 
-		action := certmanager.NewBootstrapAction(config)
+		action, err := certmanager.NewBootstrapAction(config)
+		g.Expect(err).NotTo(HaveOccurred())
 		err = action(ctx, rr)
 		g.Expect(err).NotTo(HaveOccurred())
 		g.Expect(rr.Resources).To(BeEmpty(), "no resources should be queued when CRDs are absent")
@@ -107,7 +116,8 @@ func TestBootstrapCertManagerPKI(t *testing.T) {
 		m.On("Owns", mock.Anything).Return(false)
 	})
 
-	bootstrapAction := certmanager.NewBootstrapAction(config)
+	bootstrapAction, err := certmanager.NewBootstrapAction(config)
+	g.Expect(err).NotTo(HaveOccurred())
 	deployAction := deploy.NewAction(deploy.WithFieldOwner("test-certmanager-bootstrap"))
 
 	// runPipeline creates a fresh reconciliation request and runs bootstrap followed by deploy.
@@ -229,5 +239,122 @@ func TestBootstrapCertManagerPKI(t *testing.T) {
 
 		_, err = getClusterIssuer(ctx, cli, config.CAIssuerName)
 		g.Expect(err).NotTo(HaveOccurred(), "CA-backed ClusterIssuer should be recreated by the pipeline")
+	})
+
+	t.Run("does not create webhook Certificate when Operator is nil", func(t *testing.T) {
+		g := NewWithT(t)
+
+		rr := &types.ReconciliationRequest{Client: cli, Instance: instance, Controller: controller}
+		action, err := certmanager.NewBootstrapAction(config)
+		g.Expect(err).NotTo(HaveOccurred())
+		err = action(ctx, rr)
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(rr.Resources).To(HaveLen(3), "only the 3 PKI resources should be queued")
+	})
+}
+
+// TestBootstrapWebhookCertificate verifies that NewBootstrapAction creates the operator webhook
+// Certificate when Operator is configured.
+func TestBootstrapWebhookCertificate(t *testing.T) {
+	operatorNamespace := "test-operator-ns-" + xid.New().String()
+
+	config := certmanager.DefaultBootstrapConfig(certmanager.WithOperatorCert())
+	config.OperatorCertConfig.Namespace = operatorNamespace
+
+	g := NewWithT(t)
+
+	envTest, err := envt.New()
+	g.Expect(err).NotTo(HaveOccurred())
+	t.Cleanup(func() { _ = envTest.Stop() })
+
+	ctx := context.Background()
+	cli := envTest.Client()
+
+	createBootstrapCRDs(t, g, ctx, envTest)
+	createBootstrapNamespace(t, g, ctx, cli, config.CertManagerNamespace)
+	createBootstrapNamespace(t, g, ctx, cli, operatorNamespace)
+
+	instance := &scheme.TestPlatformObject{ObjectMeta: metav1.ObjectMeta{Name: xid.New().String()}}
+	controller := mocks.NewMockController(func(m *mocks.MockController) {
+		m.On("Owns", mock.Anything).Return(false)
+	})
+
+	bootstrapAction, err := certmanager.NewBootstrapAction(config)
+	g.Expect(err).NotTo(HaveOccurred())
+	deployAction := deploy.NewAction(deploy.WithFieldOwner("test-webhook-cert"))
+
+	runPipeline := func() error {
+		rr := &types.ReconciliationRequest{Client: cli, Instance: instance, Controller: controller}
+		if err := bootstrapAction(ctx, rr); err != nil {
+			return err
+		}
+		return deployAction(ctx, rr)
+	}
+
+	g.Expect(runPipeline()).NotTo(HaveOccurred())
+
+	t.Run("creates webhook Certificate with correct spec", func(t *testing.T) {
+		g := NewWithT(t)
+
+		cert, err := getWebhookCertificate(ctx, cli, config.OperatorCertConfig.WebhookCertName, operatorNamespace)
+		g.Expect(err).NotTo(HaveOccurred())
+
+		secretName, _, err := unstructured.NestedString(cert.Object, "spec", "secretName")
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(secretName).To(Equal(config.OperatorCertConfig.WebhookCertSecretName))
+
+		issuerRefName, _, err := unstructured.NestedString(cert.Object, "spec", "issuerRef", "name")
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(issuerRefName).To(Equal(config.CAIssuerName))
+
+		issuerRefKind, _, err := unstructured.NestedString(cert.Object, "spec", "issuerRef", "kind")
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(issuerRefKind).To(Equal("ClusterIssuer"))
+
+		dnsNames, _, err := unstructured.NestedStringSlice(cert.Object, "spec", "dnsNames")
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(dnsNames).To(ConsistOf(
+			fmt.Sprintf("%s.%s.svc", config.OperatorCertConfig.WebhookServiceName, operatorNamespace),
+			fmt.Sprintf("%s.%s.svc.cluster.local", config.OperatorCertConfig.WebhookServiceName, operatorNamespace),
+		))
+	})
+
+	t.Run("idempotent when applied twice", func(t *testing.T) {
+		g := NewWithT(t)
+
+		g.Expect(runPipeline()).NotTo(HaveOccurred())
+
+		_, err := getWebhookCertificate(ctx, cli, config.OperatorCertConfig.WebhookCertName, operatorNamespace)
+		g.Expect(err).NotTo(HaveOccurred())
+	})
+
+	t.Run("recreates externally deleted webhook Certificate", func(t *testing.T) {
+		g := NewWithT(t)
+
+		cert := &unstructured.Unstructured{}
+		cert.SetGroupVersionKind(gvk.CertManagerCertificate)
+		cert.SetName(config.OperatorCertConfig.WebhookCertName)
+		cert.SetNamespace(operatorNamespace)
+		err := cli.Delete(ctx, cert)
+		g.Expect(err).NotTo(HaveOccurred())
+
+		_, err = getWebhookCertificate(ctx, cli, config.OperatorCertConfig.WebhookCertName, operatorNamespace)
+		g.Expect(k8serr.IsNotFound(err)).To(BeTrue(), "webhook Certificate should be gone after deletion")
+
+		g.Expect(runPipeline()).NotTo(HaveOccurred())
+
+		_, err = getWebhookCertificate(ctx, cli, config.OperatorCertConfig.WebhookCertName, operatorNamespace)
+		g.Expect(err).NotTo(HaveOccurred(), "webhook Certificate should be recreated by the pipeline")
+	})
+
+	t.Run("returns error when operator namespace is empty", func(t *testing.T) {
+		g := NewWithT(t)
+
+		emptyNSConfig := certmanager.DefaultBootstrapConfig(certmanager.WithOperatorCert())
+		emptyNSConfig.OperatorCertConfig.Namespace = ""
+
+		_, err := certmanager.NewBootstrapAction(emptyNSConfig)
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("operator namespace must not be empty"))
 	})
 }

--- a/pkg/controller/cloudmanager/action_reconcile.go
+++ b/pkg/controller/cloudmanager/action_reconcile.go
@@ -2,6 +2,7 @@ package cloudmanager
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/status"
@@ -49,10 +50,10 @@ func WithDeployOptions(opts ...deploy.ActionOpts) ReconcileActionOpts {
 // - Deploys resources via SSA
 // - Runs PostApply hooks from HelmCharts
 // - Checks deployment status.
-func NewReconcileAction(resourceID string, opts ...ReconcileActionOpts) actions.Fn {
+func NewReconcileAction(resourceID string, opts ...ReconcileActionOpts) (actions.Fn, error) {
 	resourceID = labels.NormalizePartOfValue(resourceID)
 	if resourceID == "" {
-		panic("resourceID is required")
+		return nil, errors.New("resourceID is required")
 	}
 
 	action := reconcileAction{
@@ -111,5 +112,5 @@ func NewReconcileAction(resourceID string, opts ...ReconcileActionOpts) actions.
 		}
 
 		return nil
-	}
+	}, nil
 }

--- a/pkg/controller/cloudmanager/action_reconcile_integration_test.go
+++ b/pkg/controller/cloudmanager/action_reconcile_integration_test.go
@@ -38,12 +38,16 @@ const (
 	testResourceID  = "testresourceid"
 )
 
-func newTestReconcileAction() func(context.Context, *types.ReconciliationRequest) error {
-	return cloudmanager.NewReconcileAction(
+func newTestReconcileAction(t *testing.T) func(context.Context, *types.ReconciliationRequest) error {
+	t.Helper()
+	g := NewWithT(t)
+	action, err := cloudmanager.NewReconcileAction(
 		testResourceID,
 		cloudmanager.WithDeployOptions(),
 		cloudmanager.WithHelmOptions(helm.WithCache(false)),
 	)
+	g.Expect(err).NotTo(HaveOccurred())
+	return action
 }
 
 func newTestReconciliationRequest(cl client.Client, charts []types.HelmChartInfo) *types.ReconciliationRequest {
@@ -86,7 +90,7 @@ func TestNewReconcileAction_RendersAndDeploys(t *testing.T) {
 	cl, err := fakeclient.New()
 	g.Expect(err).ShouldNot(HaveOccurred())
 
-	action := newTestReconcileAction()
+	action := newTestReconcileAction(t)
 	rr := newTestReconciliationRequest(cl, []types.HelmChartInfo{{
 		Source: helmRenderer.Source{
 			Chart:       filepath.Join("testdata", "test-chart"),
@@ -115,7 +119,7 @@ func TestNewReconcileAction_ExecutesPreApplyHooks(t *testing.T) {
 	var resourceCountAtPreHook int
 	var resourceNotDeployedAtPreHook bool
 
-	action := newTestReconcileAction()
+	action := newTestReconcileAction(t)
 	rr := newTestReconciliationRequest(cl, []types.HelmChartInfo{{
 		Source: helmRenderer.Source{
 			Chart:       filepath.Join("testdata", "test-chart"),
@@ -154,7 +158,7 @@ func TestNewReconcileAction_ExecutesPostApplyHooks(t *testing.T) {
 	cl, err := fakeclient.New()
 	g.Expect(err).ShouldNot(HaveOccurred())
 
-	action := newTestReconcileAction()
+	action := newTestReconcileAction(t)
 	rr := newTestReconciliationRequest(cl, []types.HelmChartInfo{{
 		Source: helmRenderer.Source{
 			Chart:       filepath.Join("testdata", "test-chart"),
@@ -181,7 +185,7 @@ func TestNewReconcileAction_PreApplyHookCanModifyResources(t *testing.T) {
 	cl, err := fakeclient.New()
 	g.Expect(err).ShouldNot(HaveOccurred())
 
-	action := newTestReconcileAction()
+	action := newTestReconcileAction(t)
 	rr := newTestReconciliationRequest(cl, []types.HelmChartInfo{{
 		Source: helmRenderer.Source{
 			Chart:       filepath.Join("testdata", "test-chart"),
@@ -223,7 +227,7 @@ func TestNewReconcileAction_PreApplyHookErrorStopsPipeline(t *testing.T) {
 
 	hookErr := errors.New("pre-apply failed")
 
-	action := newTestReconcileAction()
+	action := newTestReconcileAction(t)
 	rr := newTestReconciliationRequest(cl, []types.HelmChartInfo{{
 		Source: helmRenderer.Source{
 			Chart:       filepath.Join("testdata", "test-chart"),
@@ -257,7 +261,7 @@ func TestNewReconcileAction_PostApplyHookErrorPropagates(t *testing.T) {
 
 	hookErr := errors.New("post-apply failed")
 
-	action := newTestReconcileAction()
+	action := newTestReconcileAction(t)
 	rr := newTestReconciliationRequest(cl, []types.HelmChartInfo{{
 		Source: helmRenderer.Source{
 			Chart:       filepath.Join("testdata", "test-chart"),
@@ -285,7 +289,7 @@ func TestNewReconcileAction_SetsInfrastructureLabel(t *testing.T) {
 	cl, err := fakeclient.New()
 	g.Expect(err).ShouldNot(HaveOccurred())
 
-	action := newTestReconcileAction()
+	action := newTestReconcileAction(t)
 	rr := newTestReconciliationRequest(cl, []types.HelmChartInfo{{
 		Source: helmRenderer.Source{
 			Chart:       filepath.Join("testdata", "test-chart"),
@@ -318,7 +322,7 @@ func TestNewReconcileAction_MultipleCharts(t *testing.T) {
 
 	var hookOrder []string
 
-	action := newTestReconcileAction()
+	action := newTestReconcileAction(t)
 	rr := newTestReconciliationRequest(cl, []types.HelmChartInfo{
 		{
 			Source: helmRenderer.Source{
@@ -366,4 +370,11 @@ func TestNewReconcileAction_MultipleCharts(t *testing.T) {
 		"chart-one-pre", "chart-two-pre",
 		"chart-one-post", "chart-two-post",
 	}))
+}
+
+func TestNewReconcileAction_RejectsEmptyResourceID(t *testing.T) {
+	g := NewWithT(t)
+	action, err := cloudmanager.NewReconcileAction("   ")
+	g.Expect(err).To(MatchError(ContainSubstring("resourceID is required")))
+	g.Expect(action).To(BeNil())
 }

--- a/pkg/controller/reconciler/reconciler_support.go
+++ b/pkg/controller/reconciler/reconciler_support.go
@@ -153,6 +153,21 @@ func (b *ReconcilerBuilder[T]) WithAction(value actions.Fn) *ReconcilerBuilder[T
 	return b
 }
 
+// WithActionE is like WithAction but accepts a (Fn, error) pair from action
+// constructors. If err is non-nil, the error is collected and surfaced by Build().
+func (b *ReconcilerBuilder[T]) WithActionE(value actions.Fn, err error) *ReconcilerBuilder[T] {
+	if err != nil {
+		b.errors = multierror.Append(b.errors, err)
+		return b
+	}
+	if value == nil {
+		b.errors = multierror.Append(b.errors, errors.New("WithActionE: action must not be nil"))
+		return b
+	}
+	b.actions = append(b.actions, value)
+	return b
+}
+
 func (b *ReconcilerBuilder[T]) WithFinalizer(value actions.Fn) *ReconcilerBuilder[T] {
 	b.finalizers = append(b.finalizers, value)
 	return b

--- a/pkg/controller/reconciler/reconciler_test.go
+++ b/pkg/controller/reconciler/reconciler_test.go
@@ -357,6 +357,33 @@ func TestReconcilerBuilder_ComposeWith(t *testing.T) {
 	})
 }
 
+func TestReconcilerBuilder_WithActionE(t *testing.T) {
+	t.Run("adds action when no error", func(t *testing.T) {
+		g := NewWithT(t)
+		noop := func(_ context.Context, _ *odhtype.ReconciliationRequest) error { return nil }
+		b := &ReconcilerBuilder[*componentApi.Dashboard]{}
+		b.WithActionE(noop, nil)
+		g.Expect(b.actions).To(HaveLen(1))
+		g.Expect(b.errors).ToNot(HaveOccurred())
+	})
+
+	t.Run("accumulates error and skips action", func(t *testing.T) {
+		g := NewWithT(t)
+		b := &ReconcilerBuilder[*componentApi.Dashboard]{}
+		b.WithActionE(nil, errors.New("action init failed"))
+		g.Expect(b.actions).To(BeEmpty())
+		g.Expect(b.errors).To(HaveOccurred())
+	})
+
+	t.Run("error surfaces in Build()", func(t *testing.T) {
+		g := NewWithT(t)
+		b := &ReconcilerBuilder[*componentApi.Dashboard]{}
+		b.WithActionE(nil, errors.New("action init failed"))
+		_, buildErr := b.Build(context.Background())
+		g.Expect(buildErr).To(MatchError(ContainSubstring("action init failed")))
+	})
+}
+
 func TestNewReconciler_WithDynamicOwnership(t *testing.T) {
 	g := NewWithT(t)
 

--- a/pkg/utils/test/cloudmanager/helpers.go
+++ b/pkg/utils/test/cloudmanager/helpers.go
@@ -1,0 +1,246 @@
+package cloudmanager
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlconfig "sigs.k8s.io/controller-runtime/pkg/config"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	ctrlmanager "sigs.k8s.io/controller-runtime/pkg/manager"
+
+	ccmcommon "github.com/opendatahub-io/opendatahub-operator/v2/api/cloudmanager/common"
+	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/cloudmanager/common"
+	certmanager "github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/dependency/certmanager"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/envt"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/testf"
+	"github.com/opendatahub-io/opendatahub-operator/v2/tests/envtestutil"
+)
+
+// ControllerTestConfig holds cloud-provider-specific values needed by the shared test helpers.
+type ControllerTestConfig struct {
+	// CRDSubdir is the subdirectory under config/cloudmanager/ containing CRD bases
+	// (e.g., "azure" or "coreweave").
+	CRDSubdir string
+
+	// NewReconciler registers the cloud-specific reconciler with the manager.
+	NewReconciler func(context.Context, ctrl.Manager) error
+
+	// NewCR creates a new CR instance with the given dependencies.
+	NewCR func(ccmcommon.Dependencies) client.Object
+
+	// InstanceName is the singleton CR instance name
+	// (e.g., AzureKubernetesEngineInstanceName).
+	InstanceName string
+
+	// InfraLabel is the expected infrastructure label value
+	// (e.g., "azurekubernetesengine").
+	InfraLabel string
+
+	// GVK is the GroupVersionKind of the cloud-specific CR.
+	GVK schema.GroupVersionKind
+}
+
+const TestOperatorNamespace = "test-operator-ns"
+
+var chartsNotFound bool
+
+// RequireCharts fails the test with a helpful message if charts were not found during setup.
+func RequireCharts(t *testing.T) {
+	t.Helper()
+
+	if chartsNotFound {
+		t.Fatal("opt/charts not populated, run 'make get-manifests'")
+	}
+}
+
+// SetupEnvTest creates a new envtest environment with CRDs loaded from
+// config/cloudmanager/<crdSubdir>/crd/bases. Additional envt.OptionFn values
+// (e.g. envt.WithManager, envt.WithRegisterControllers) are forwarded to
+// envt.New so the caller can opt into a manager that matches the production
+// bootstrap (Unstructured cache, opmanager wrapper).
+func SetupEnvTest(crdSubdir string, opts ...envt.OptionFn) (*envt.EnvT, error) {
+	rootPath, err := envtestutil.FindProjectRoot()
+	if err != nil {
+		return nil, fmt.Errorf("failed to find project root: %w", err)
+	}
+
+	base := []envt.OptionFn{
+		envt.WithCRDPaths(
+			filepath.Join(rootPath, "config", "cloudmanager", crdSubdir, "crd", "bases"),
+		),
+	}
+
+	return envt.New(append(base, opts...)...)
+}
+
+// NewTestContext creates a testf.TestContext configured for the given envtest environment.
+func NewTestContext(ctx context.Context, et *envt.EnvT) (*testf.TestContext, error) {
+	return testf.NewTestContext(
+		testf.WithRestConfig(et.Config()),
+		testf.WithScheme(et.Scheme()),
+		testf.WithContext(ctx),
+		testf.WithTOptions(
+			testf.WithEventuallyTimeout(2*time.Minute),
+			testf.WithEventuallyPollingInterval(250*time.Millisecond),
+		),
+	)
+}
+
+// StartManager creates the operator namespace and starts the EnvT-provided
+// manager. The manager must have been created during SetupEnvTest (via
+// envt.WithManager / envt.WithRegisterControllers) so it uses the same
+// Unstructured cache and opmanager wrapper as production.
+//
+// Startup errors are propagated: the function blocks until the manager is
+// elected (ready) or returns immediately if Start fails.
+func StartManager(ctx context.Context, et *envt.EnvT) error {
+	namespace := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: TestOperatorNamespace,
+		},
+	}
+	if err := et.Client().Create(ctx, namespace); err != nil {
+		return fmt.Errorf("failed to create namespace: %w", err)
+	}
+
+	mgr := et.Manager()
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- mgr.Start(ctx)
+	}()
+
+	select {
+	case err := <-errCh:
+		return fmt.Errorf("manager stopped unexpectedly: %w", err)
+	case <-mgr.Elected():
+		return nil
+	}
+}
+
+// StartIsolatedController starts a fresh, isolated test environment with the controller
+// from cfg running. Each call creates its own Kubernetes API server. Use this for tests
+// that need specific cluster state (e.g., no cert-manager CRDs installed).
+func StartIsolatedController(t *testing.T, ctx context.Context, cfg ControllerTestConfig) (*envt.EnvT, *testf.WithT) {
+	t.Helper()
+
+	RequireCharts(t)
+
+	certmanager.OperatorNamespace = TestOperatorNamespace
+
+	et, err := SetupEnvTest(cfg.CRDSubdir,
+		envt.WithManager(ctrl.Options{
+			Controller: ctrlconfig.Controller{SkipNameValidation: ptr.To(true)},
+		}),
+		envt.WithRegisterControllers(func(mgr ctrlmanager.Manager) error {
+			return cfg.NewReconciler(ctx, mgr)
+		}),
+	)
+	if err != nil {
+		t.Fatalf("failed to create isolated test environment: %v", err)
+	}
+	t.Cleanup(func() { _ = et.Stop() })
+
+	isolatedTC, err := NewTestContext(ctx, et)
+	if err != nil {
+		t.Fatalf("failed to create test context: %v", err)
+	}
+
+	if err := StartManager(ctx, et); err != nil {
+		t.Fatalf("failed to start manager: %v", err)
+	}
+
+	return et, isolatedTC.NewWithT(t)
+}
+
+// CreateCR creates the cloud-specific CR using cfg.NewCR and registers cleanup.
+func CreateCR(t *testing.T, wt *testf.WithT, cfg ControllerTestConfig, deps ccmcommon.Dependencies) {
+	t.Helper()
+
+	obj := cfg.NewCR(deps)
+	wt.Expect(wt.Client().Create(wt.Context(), obj)).Should(gomega.Succeed())
+	envt.CleanupDelete(t, gomega.NewWithT(t), wt.Context(), wt.Client(), obj)
+}
+
+// RunTestMain executes the common TestMain boilerplate for cloud controller integration tests.
+// It sets up the charts path, envtest environment, test context, and manager, then runs
+// the tests. The tc pointer is populated before tests run so it can be used as a
+// package-level variable.
+//
+// Usage in suite_test.go:
+//
+//	var tc *testf.TestContext
+//	func TestMain(m *testing.M) {
+//	    cloudmanager.RunTestMain(m, &tc, cfg)
+//	}
+func RunTestMain(m *testing.M, tc **testf.TestContext, cfg ControllerTestConfig) {
+	logf.SetLogger(zap.New(zap.UseDevMode(true)))
+
+	rootPath, pathErr := envtestutil.FindProjectRoot()
+	if pathErr != nil {
+		logf.Log.Error(pathErr, "failed to find project root")
+		os.Exit(1)
+	}
+
+	chartsPath := filepath.Join(rootPath, "opt", "charts")
+	entries, err := os.ReadDir(chartsPath)
+	if err != nil && !os.IsNotExist(err) {
+		logf.Log.Error(err, "failed to read opt/charts directory")
+		os.Exit(1)
+	}
+	if len(entries) == 0 || (len(entries) == 1 && entries[0].Name() == ".gitkeep") {
+		logf.Log.Info("opt/charts is not populated, run 'make get-manifests' first; skipping controller tests")
+		chartsNotFound = true
+		os.Exit(m.Run())
+	}
+
+	common.DefaultChartsPath = chartsPath
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	certmanager.OperatorNamespace = TestOperatorNamespace
+
+	et, err := SetupEnvTest(cfg.CRDSubdir,
+		envt.WithRegisterControllers(func(mgr ctrlmanager.Manager) error {
+			return cfg.NewReconciler(ctx, mgr)
+		}),
+	)
+	if err != nil {
+		logf.Log.Error(err, "failed to setup test environment")
+		os.Exit(1)
+	}
+
+	testCtx, err := NewTestContext(ctx, et)
+	if err != nil {
+		logf.Log.Error(err, "failed to create test context")
+		os.Exit(1)
+	}
+
+	*tc = testCtx
+
+	if err := StartManager(ctx, et); err != nil {
+		logf.Log.Error(err, "failed to start manager")
+		os.Exit(1)
+	}
+
+	code := m.Run()
+
+	cancel()
+	if err := et.Stop(); err != nil {
+		logf.Log.Error(err, "failed to stop test environment")
+	}
+
+	os.Exit(code)
+}

--- a/pkg/utils/test/envt/envt.go
+++ b/pkg/utils/test/envt/envt.go
@@ -158,6 +158,14 @@ func WithRegisterControllers(funcs ...RegisterControllersFn) OptionFn {
 	}
 }
 
+// WithCRDPaths sets custom paths for loading CRD manifests.
+// If not set, defaults to "<project_root>/config/crd/bases".
+func WithCRDPaths(paths ...string) OptionFn {
+	return func(in *EnvT) {
+		in.crdPaths = paths
+	}
+}
+
 // New creates and configures a new EnvT test environment.
 // Applies all provided OptionFn options, sets up CRDs, webhooks, and the envtest environment.
 // Returns the configured EnvT, or an error if setup fails.
@@ -184,12 +192,15 @@ func New(opts ...OptionFn) (*EnvT, error) {
 		result.root = root
 	}
 
+	crdPaths := result.crdPaths
+	if len(crdPaths) == 0 {
+		crdPaths = []string{filepath.Join(result.root, "config", "crd", "bases")}
+	}
+
 	result.Env = envtest.Environment{
 		CRDInstallOptions: envtest.CRDInstallOptions{
-			Scheme: result.s,
-			Paths: []string{
-				filepath.Join(result.root, "config", "crd", "bases"),
-			},
+			Scheme:             result.s,
+			Paths:              crdPaths,
 			ErrorIfPathMissing: true,
 			CleanUpAfterUse:    false,
 		},
@@ -242,6 +253,7 @@ func New(opts ...OptionFn) (*EnvT, error) {
 
 type EnvT struct {
 	root                string
+	crdPaths            []string
 	withManager         bool
 	managerOpts         *manager.Options
 	registerWebhooks    []RegisterWebhooksFn


### PR DESCRIPTION
## Description
- Add operator webhook serving Certificate creation to the cert-manager PKI bootstrap chain, issued by the CA-backed ClusterIssuer. This ensures the operator's webhook TLS certificate is managed by cert-manager alongside the existing PKI trust chain.
- Introduce `WithOperatorCert()` functional option and `OperatorCertConfig` to configure webhook certificate creation (namespace, cert name, secret name, service name), reading defaults from environment variables.
- Refactor `NewBootstrapAction` and `NewReconcileAction` to return `(actions.Fn, error)` instead of panicking, and add `WithActionE` to `ReconcilerBuilder` to handle the new signature ergonomically.

Jira task: https://issues.redhat.com/browse/RHOAIENG-53488

## How Has This Been Tested?
- Unit tests added for webhook Certificate creation: verifies correct spec (secretName, dnsNames, issuerRef), idempotency, recreation after external deletion, and error on empty namespace.
- Unit tests added for `WithActionE` on `ReconcilerBuilder`: verifies action registration, error accumulation, and error surfacing in `Build()`.
- Existing bootstrap tests updated to use the new `(Fn, error)` return signature.


## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [x] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->
e2e for cloud manager will be added in following PRs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional operator webhook certificate support driven by environment configuration; certificate created conditionally.

* **Chores**
  * Startup validates required environment variables and fails fast if missing.
  * Centralized cache defaults applied for consistent label-based filtering across namespaces.
  * Action/reconcile initialization now surfaces and propagates setup errors; reconciler wiring accepts error-aware actions.

* **Refactor**
  * Consolidated and simplified cloud-manager test utilities and isolated test orchestration.

* **Tests**
  * Expanded tests for webhook certificate creation, idempotence, error handling, and reconciler initialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->