### PR TITLE
RHOAIENG-53866: Add kustomize variable support for Workbenches component

### DIFF
--- a/internal/controller/components/workbenches/workbenches_controller.go
+++ b/internal/controller/components/workbenches/workbenches_controller.go
@@ -62,12 +62,18 @@ func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.
 				component.ForLabel(labels.ODH.Component(LegacyComponentName), labels.True)),
 		).
 		Watches(&corev1.Namespace{}).
+		Watches(
+			&componentApi.MLflowOperator{},
+			reconciler.WithEventHandler(handlers.ToNamed(componentApi.WorkbenchesInstanceName)),
+		).
 		WithAction(initialize).
 		WithAction(releases.NewAction(
 			releases.WithMetadataFilePath(
 				path.Join(odhdeploy.DefaultManifestPath, ComponentName, kfNotebookControllerPath, releases.ComponentMetadataFilename)))).
 		WithAction(configureDependencies).
+		WithAction(setKustomizedParams).
 		WithAction(kustomize.NewAction(
+			kustomize.WithCache(false),
 			kustomize.WithLabel(labels.ODH.Component(LegacyComponentName), labels.True),
 			kustomize.WithLabel(labels.K8SCommon.PartOf, LegacyComponentName),
 		)).

--- a/internal/controller/components/workbenches/workbenches_controller_actions.go
+++ b/internal/controller/components/workbenches/workbenches_controller_actions.go
@@ -3,12 +3,14 @@ package workbenches
 import (
 	"context"
 	"fmt"
+	"path"
 
 	corev1 "k8s.io/api/core/v1"
 
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/api/components/v1alpha1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
 	odhtypes "github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
+	odhdeploy "github.com/opendatahub-io/opendatahub-operator/v2/pkg/deploy"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/metadata/labels"
 )
 
@@ -58,5 +60,19 @@ func updateStatus(_ context.Context, rr *odhtypes.ReconciliationRequest) error {
 	}
 	workbench.Status.WorkbenchNamespace = workbench.Spec.WorkbenchNamespace
 
+	return nil
+}
+
+func setKustomizedParams(ctx context.Context, rr *odhtypes.ReconciliationRequest) error {
+	extraParamsMap, err := ComputeKustomizeVariable(ctx, rr.Client, rr.Release.Name)
+	if err != nil {
+		return fmt.Errorf("failed to set variable for url, section-title etc: %w", err)
+	}
+
+	paramsPath := path.Join(odhdeploy.DefaultManifestPath, notebookControllerContextDir, notebookControllerManifestSourcePath)
+
+	if err := odhdeploy.ApplyParams(paramsPath, "params.env", nil, extraParamsMap); err != nil {
+		return fmt.Errorf("failed to update params.env from %s : %w", paramsPath, err)
+	}
 	return nil
 }

--- a/internal/controller/components/workbenches/workbenches_support.go
+++ b/internal/controller/components/workbenches/workbenches_support.go
@@ -1,10 +1,19 @@
 package workbenches
 
 import (
+	"context"
+	"fmt"
 	"path"
+	"strconv"
+	"strings"
+
+	operatorv1 "github.com/openshift/api/operator/v1"
+	k8serr "k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/opendatahub-io/opendatahub-operator/v2/api/common"
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/api/components/v1alpha1"
+	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/services/gateway"
 	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/status"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
 	odhtypes "github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
@@ -31,6 +40,12 @@ const (
 )
 
 var (
+	sectionTitle = map[common.Platform]string{
+		cluster.SelfManagedRhoai: "OpenShift Self Managed Services",
+		cluster.ManagedRhoai:     "OpenShift Managed Services",
+		cluster.OpenDataHub:      "OpenShift Open Data Hub",
+	}
+
 	notebookControllerContextDir   = path.Join(ComponentName, notebookControllerPath)
 	kfNotebookControllerContextDir = path.Join(ComponentName, kfNotebookControllerPath)
 	notebookContextDir             = path.Join(ComponentName, notebooksPath)
@@ -79,4 +94,50 @@ func notebookImagesManifestInfo(sourcePath string) odhtypes.ManifestInfo {
 		ContextDir: notebookContextDir,
 		SourcePath: sourcePath,
 	}
+}
+
+func ComputeKustomizeVariable(ctx context.Context, cli client.Client, platform common.Platform) (map[string]string, error) {
+	mlflowEnabled, err := isMLflowEnabled(ctx, cli)
+	if err != nil {
+		return nil, fmt.Errorf("error checking MLflow status: %w", err)
+	}
+
+	title, ok := sectionTitle[platform]
+	if !ok {
+		title = sectionTitle[cluster.SelfManagedRhoai]
+	}
+
+	consoleLinkDomain, err := gateway.GetGatewayDomain(ctx, cli)
+	if err != nil {
+		return nil, fmt.Errorf("error getting gateway domain: %w", err)
+	}
+
+	// When gateway domain is empty (e.g., Gateway not ready yet), we return an empty
+	// gateway-url instead of failing. This allows odh-notebook-controller to use its
+	// fallback mechanism while still receiving other values like mlflow-enabled.
+	gatewayURL := ""
+	if consoleLinkDomain != "" {
+		if strings.ContainsAny(consoleLinkDomain, "\n\r=") {
+			return nil, fmt.Errorf("invalid gateway domain %q: contains illegal characters", consoleLinkDomain)
+		}
+		gatewayURL = consoleLinkDomain
+	}
+
+	return map[string]string{
+		"gateway-url":    gatewayURL,
+		"section-title":  title,
+		"mlflow-enabled": strconv.FormatBool(mlflowEnabled),
+	}, nil
+}
+
+func isMLflowEnabled(ctx context.Context, cli client.Client) (bool, error) {
+	dsc, err := cluster.GetDSC(ctx, cli)
+	if err != nil {
+		if k8serr.IsNotFound(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("failed to get DataScienceCluster: %w", err)
+	}
+
+	return dsc.Spec.Components.MLflowOperator.ManagementState == operatorv1.Managed, nil
 }

--- a/internal/controller/components/workbenches/workbenches_support_test.go
+++ b/internal/controller/components/workbenches/workbenches_support_test.go
@@ -1,0 +1,287 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package workbenches_test
+
+import (
+	"testing"
+
+	operatorv1 "github.com/openshift/api/operator/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/opendatahub-io/opendatahub-operator/v2/api/common"
+	dscv2 "github.com/opendatahub-io/opendatahub-operator/v2/api/datasciencecluster/v2"
+	serviceApi "github.com/opendatahub-io/opendatahub-operator/v2/api/services/v1alpha1"
+	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/components/workbenches"
+	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/services/gateway"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/fakeclient"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestComputeKustomizeVariable(t *testing.T) {
+	t.Parallel()
+
+	const (
+		defaultDomain = "apps.example.com"
+		customDomain  = "custom.domain.com"
+	)
+
+	var (
+		customGatewayConfig = func() *serviceApi.GatewayConfig {
+			gc := &serviceApi.GatewayConfig{}
+			gc.SetName(serviceApi.GatewayConfigName)
+			gc.Spec.Domain = customDomain
+			return gc
+		}
+		defaultGatewayConfig = func() *serviceApi.GatewayConfig {
+			gc := &serviceApi.GatewayConfig{}
+			gc.SetName(serviceApi.GatewayConfigName)
+			return gc
+		}
+	)
+
+	tests := []struct {
+		name                  string
+		platform              common.Platform
+		expectedURL           string
+		expectedTitle         string
+		expectedMLflowEnabled string
+		gatewayConfigFunc     func() *serviceApi.GatewayConfig
+		mlflowManagementState operatorv1.ManagementState
+		clusterDomain         string
+		expectError           bool
+	}{
+		{
+			name:                  "OpenDataHub platform with default domain and MLflow managed",
+			platform:              cluster.OpenDataHub,
+			expectedURL:           gateway.DefaultGatewaySubdomain + "." + defaultDomain,
+			expectedTitle:         "OpenShift Open Data Hub",
+			expectedMLflowEnabled: "true",
+			gatewayConfigFunc:     defaultGatewayConfig,
+			mlflowManagementState: operatorv1.Managed,
+			clusterDomain:         defaultDomain,
+		},
+		{
+			name:                  "RHOAI platform with custom domain and MLflow removed",
+			platform:              cluster.SelfManagedRhoai,
+			expectedURL:           gateway.DefaultGatewaySubdomain + "." + customDomain,
+			expectedTitle:         "OpenShift Self Managed Services",
+			expectedMLflowEnabled: "false",
+			gatewayConfigFunc:     customGatewayConfig,
+			mlflowManagementState: operatorv1.Removed,
+			clusterDomain:         defaultDomain,
+		},
+		{
+			name:                  "ManagedRhoai platform with custom domain and MLflow managed",
+			platform:              cluster.ManagedRhoai,
+			expectedURL:           gateway.DefaultGatewaySubdomain + "." + customDomain,
+			expectedTitle:         "OpenShift Managed Services",
+			expectedMLflowEnabled: "true",
+			gatewayConfigFunc:     customGatewayConfig,
+			mlflowManagementState: operatorv1.Managed,
+			clusterDomain:         defaultDomain,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewWithT(t)
+			ctx := t.Context()
+
+			objects := make([]client.Object, 0, 3)
+
+			if gc := tt.gatewayConfigFunc(); gc != nil {
+				objects = append(objects, gc)
+			}
+
+			if tt.clusterDomain != "" {
+				ingress := createMockOpenShiftIngress(tt.clusterDomain)
+				objects = append(objects, ingress)
+			}
+
+			dsc := createMockDSC(tt.mlflowManagementState)
+			objects = append(objects, dsc)
+
+			cli, err := fakeclient.New(fakeclient.WithObjects(objects...))
+			g.Expect(err).ShouldNot(HaveOccurred())
+
+			result, err := workbenches.ComputeKustomizeVariable(ctx, cli, tt.platform)
+
+			if tt.expectError {
+				g.Expect(err).Should(HaveOccurred())
+				return
+			}
+
+			g.Expect(err).ShouldNot(HaveOccurred())
+			g.Expect(result).Should(HaveKeyWithValue("gateway-url", tt.expectedURL))
+			g.Expect(result).Should(HaveKeyWithValue("section-title", tt.expectedTitle))
+			g.Expect(result).Should(HaveKeyWithValue("mlflow-enabled", tt.expectedMLflowEnabled))
+		})
+	}
+}
+
+func TestComputeKustomizeVariableError(t *testing.T) {
+	t.Parallel()
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	cli, err := fakeclient.New()
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	_, err = workbenches.ComputeKustomizeVariable(ctx, cli, cluster.OpenDataHub)
+	g.Expect(err).Should(HaveOccurred(), "Should fail when cluster domain cannot be determined")
+	g.Expect(err.Error()).Should(ContainSubstring("error getting gateway domain"), "Error should contain expected message")
+}
+
+func TestComputeKustomizeVariableEmptyDomain(t *testing.T) {
+	t.Parallel()
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	// Create a Gateway CR with an empty hostname to simulate empty domain scenario
+	emptyHostname := gwapiv1.Hostname("")
+	gw := &gwapiv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      gateway.DefaultGatewayName,
+			Namespace: gateway.GatewayNamespace,
+		},
+		Spec: gwapiv1.GatewaySpec{
+			Listeners: []gwapiv1.Listener{
+				{
+					Hostname: &emptyHostname,
+				},
+			},
+		},
+	}
+
+	gc := &serviceApi.GatewayConfig{}
+	gc.SetName(serviceApi.GatewayConfigName)
+
+	dsc := createMockDSC(operatorv1.Managed)
+
+	cli, err := fakeclient.New(fakeclient.WithObjects(gw, gc, dsc))
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	result, err := workbenches.ComputeKustomizeVariable(ctx, cli, cluster.OpenDataHub)
+	g.Expect(err).ShouldNot(HaveOccurred(), "Empty domain should not cause error")
+	g.Expect(result).Should(HaveKeyWithValue("gateway-url", ""),
+		"Empty domain should result in empty gateway-url")
+	g.Expect(result).Should(HaveKeyWithValue("mlflow-enabled", "true"),
+		"MLflow should still be computed correctly")
+	g.Expect(result).Should(HaveKeyWithValue("section-title", "OpenShift Open Data Hub"),
+		"Section title should still be computed correctly")
+}
+
+func TestComputeKustomizeVariableInvalidDomain(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		domain string
+	}{
+		{
+			name:   "domain with newline",
+			domain: "evil.com\nmalicious-key=value",
+		},
+		{
+			name:   "domain with carriage return",
+			domain: "evil.com\rmalicious-key=value",
+		},
+		{
+			name:   "domain with equals sign",
+			domain: "evil.com=malicious",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewWithT(t)
+			ctx := t.Context()
+
+			gc := &serviceApi.GatewayConfig{}
+			gc.SetName(serviceApi.GatewayConfigName)
+			gc.Spec.Domain = tt.domain
+
+			dsc := createMockDSC(operatorv1.Managed)
+
+			cli, err := fakeclient.New(fakeclient.WithObjects(gc, dsc))
+			g.Expect(err).ShouldNot(HaveOccurred())
+
+			_, err = workbenches.ComputeKustomizeVariable(ctx, cli, cluster.OpenDataHub)
+			g.Expect(err).Should(HaveOccurred(), "Should reject domain with illegal characters")
+			g.Expect(err.Error()).Should(ContainSubstring("invalid gateway domain"))
+			g.Expect(err.Error()).Should(ContainSubstring("contains illegal characters"))
+		})
+	}
+}
+
+func TestComputeKustomizeVariableUnknownPlatformFallback(t *testing.T) {
+	t.Parallel()
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	const defaultDomain = "apps.example.com"
+
+	gc := &serviceApi.GatewayConfig{}
+	gc.SetName(serviceApi.GatewayConfigName)
+
+	ingress := createMockOpenShiftIngress(defaultDomain)
+	dsc := createMockDSC(operatorv1.Managed)
+
+	cli, err := fakeclient.New(fakeclient.WithObjects(gc, ingress, dsc))
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	unknownPlatform := common.Platform("unknown-platform")
+	result, err := workbenches.ComputeKustomizeVariable(ctx, cli, unknownPlatform)
+	g.Expect(err).ShouldNot(HaveOccurred(), "Unknown platform should use fallback")
+	g.Expect(result).Should(HaveKeyWithValue("section-title", "OpenShift Self Managed Services"),
+		"Unknown platform should fallback to SelfManagedRhoai section title")
+}
+
+func createMockOpenShiftIngress(domain string) client.Object {
+	if domain == "" {
+		domain = "default.example.com"
+	}
+
+	obj := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "config.openshift.io/v1",
+			"kind":       "Ingress",
+			"metadata": map[string]interface{}{
+				"name": "cluster",
+			},
+			"spec": map[string]interface{}{
+				"domain": domain,
+			},
+		},
+	}
+
+	return obj
+}
+
+func createMockDSC(mlflowState operatorv1.ManagementState) *dscv2.DataScienceCluster {
+	dsc := &dscv2.DataScienceCluster{}
+	dsc.SetName("default-dsc")
+	dsc.Spec.Components.MLflowOperator.ManagementState = mlflowState
+	return dsc
+}

--- a/tests/e2e/workbenches_test.go
+++ b/tests/e2e/workbenches_test.go
@@ -3,6 +3,7 @@ package e2e_test
 import (
 	"testing"
 
+	operatorv1 "github.com/openshift/api/operator/v1"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -35,6 +36,7 @@ func workbenchesTestSuite(t *testing.T) {
 		{"Validate operands have OwnerReferences", componentCtx.ValidateOperandsOwnerReferences},
 		{"Validate update operand resources", componentCtx.ValidateUpdateDeploymentsResources},
 		{"Validate component releases", componentCtx.ValidateComponentReleases},
+		{"Validate MLflow integration", componentCtx.ValidateMLflowIntegration},
 		{"Validate resource deletion recovery", componentCtx.ValidateAllDeletionRecovery},
 		{"Validate component disabled", componentCtx.ValidateComponentDisabled},
 	}
@@ -70,4 +72,78 @@ func (tc *WorkbenchesTestCtx) ValidateWorkbenchesNamespaceConfiguration(t *testi
 			),
 		),
 	)
+}
+
+func (tc *WorkbenchesTestCtx) ValidateMLflowIntegration(t *testing.T) {
+	t.Helper()
+
+	skipUnless(t, Tier2)
+
+	g := tc.NewWithT(t)
+
+	const notebookControllerParamsConfigMap = "odh-notebook-controller-image-parameters"
+
+	// Get the current DSC
+	dsc := tc.FetchDataScienceCluster()
+
+	// Verify MLflowOperator is in Removed state (default for e2e tests)
+	g.Expect(dsc.Spec.Components.MLflowOperator.ManagementState).To(Equal(operatorv1.Removed),
+		"MLflowOperator should be in Removed state by default")
+
+	// Ensure the Workbenches component is still ready with MLflowOperator in Removed state
+	tc.EnsureResourceExists(
+		WithMinimalObject(gvk.Workbenches, types.NamespacedName{Name: componentApi.WorkbenchesInstanceName}),
+		WithCondition(jq.Match(`.status.conditions[] | select(.type == "Ready") | .status == "True"`)),
+	)
+
+	// Verify the notebook controller deployment exists and is available
+	tc.EnsureResourceExists(
+		WithMinimalObject(gvk.Deployment, types.NamespacedName{
+			Name:      "notebook-controller-deployment",
+			Namespace: tc.AppsNamespace,
+		}),
+		WithCondition(jq.Match(`.status.conditions[] | select(.type == "Available") | .status == "True"`)),
+	)
+
+	// Verify mlflow-enabled is "false" when MLflowOperator is Removed
+	tc.EnsureResourceExists(
+		WithMinimalObject(gvk.ConfigMap, types.NamespacedName{
+			Name:      notebookControllerParamsConfigMap,
+			Namespace: tc.AppsNamespace,
+		}),
+		WithCondition(jq.Match(`.data["mlflow-enabled"] == "false"`)),
+		WithCustomErrorMsg("mlflow-enabled should be 'false' when MLflowOperator is Removed"),
+	)
+
+	t.Log("Verified mlflow-enabled is 'false' when MLflowOperator is Removed")
+
+	// Test the Managed path: enable MLflowOperator and verify mlflow-enabled becomes "true"
+	tc.UpdateComponentStateInDataScienceClusterWithKind(operatorv1.Managed, componentApi.MLflowOperatorKind)
+
+	// Verify mlflow-enabled is "true" when MLflowOperator is Managed
+	tc.EnsureResourceExists(
+		WithMinimalObject(gvk.ConfigMap, types.NamespacedName{
+			Name:      notebookControllerParamsConfigMap,
+			Namespace: tc.AppsNamespace,
+		}),
+		WithCondition(jq.Match(`.data["mlflow-enabled"] == "true"`)),
+		WithCustomErrorMsg("mlflow-enabled should be 'true' when MLflowOperator is Managed"),
+	)
+
+	t.Log("Verified mlflow-enabled is 'true' when MLflowOperator is Managed")
+
+	// Restore MLflowOperator to Removed state
+	tc.UpdateComponentStateInDataScienceClusterWithKind(operatorv1.Removed, componentApi.MLflowOperatorKind)
+
+	// Verify mlflow-enabled returns to "false" when MLflowOperator is Removed again
+	tc.EnsureResourceExists(
+		WithMinimalObject(gvk.ConfigMap, types.NamespacedName{
+			Name:      notebookControllerParamsConfigMap,
+			Namespace: tc.AppsNamespace,
+		}),
+		WithCondition(jq.Match(`.data["mlflow-enabled"] == "false"`)),
+		WithCustomErrorMsg("mlflow-enabled should return to 'false' when MLflowOperator is Removed again"),
+	)
+
+	t.Log("Workbenches component successfully integrates with MLflowOperator state changes")
 }


### PR DESCRIPTION
<!---
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

This PR adds support for dynamic kustomize variables in the Workbenches component, similar to the existing implementation in MLflowOperator and Dashboard components.
#### Changes

- `workbenches_support.go`
    - Added ComputeKustomizeVariable function that computes:
        - gateway-url: The gateway domain URL (e.g., https://odh-gateway.apps.example.com/)
        - section-title: Platform-specific title (OpenShift Open Data Hub / OpenShift Self Managed Services / OpenShift Managed Services)
        - mlflow-enabled: "true" or "false" based on whether MLflowOperator is managed in the DataScienceCluster
    - Added isMLflowEnabled helper function to check MLflowOperator management state from DSC
    - Added sectionTitle map for platform-specific titles
- `workbenches_controller_actions.go`
    - Added setKustomizedParams action that applies the computed variables to the notebook controller's params.env
- `workbenches_controller.go`
    - Registered setKustomizedParams action in the reconciler chain
- `workbenches_support_test.go (new file)`
    - Added comprehensive tests for ComputeKustomizeVariable covering:
        - Different platforms (OpenDataHub, SelfManagedRhoai, ManagedRhoai)
        - MLflow enabled/disabled scenarios
        - Error handling
- `tests/e2e/workbenches_test.go`
    - Added new test case ValidateMLflowIntegration that:
    - Verifies MLflowOperator management state is accessible
    - Ensures Workbenches component remains ready with MLflowOperator state
    - Validates the notebook controller deployment is available

### Summary

  - Added ComputeKustomizeVariable function to compute dynamic kustomize variables for the notebook controller manifests
  - Added setKustomizedParams reconciler action to apply the computed variables to params.env
  - Variables include gateway URL, section title (platform-specific), and MLflow enabled status

This PR is generated with help of `Cursor - Claude-4.5-opus model`

### Test plan

[x] Unit tests pass (go test ./internal/controller/components/workbenches/... -v -run TestComputeKustomizeVariable)
[x] Verify params.env is correctly updated during reconciliation
[x] Verify the kustomize variables are properly substituted in the manifests

<!--- Link your JIRA and related links here for reference. -->
Related-to: https://redhat.atlassian.net/browse/RHOAIENG-53866

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested in openshift cluster with following commands:

```
make image-build image-push IMG=quay.io/harshad16/opendatahub-operator:rhoai-3.4

make bundle bundle-build bundle-push \
  IMAGE_TAG_BASE=quay.io/harshad16/opendatahub-operator \
  IMG_TAG=rhoai-3.4 \
  BUNDLE_IMG=quay.io/harshad16/opendatahub-operator-bundle:rhoai-3.4 \
  ODH_PLATFORM_TYPE=rhoai

./bin/operator-sdk cleanup rhods-operator -n redhat-ods-operator
./bin/operator-sdk run bundle quay.io/harshad16/opendatahub-operator-bundle:rhoai-3.4 \
  --namespace redhat-ods-operator \
  --decompression-image quay.io/project-codeflare/busybox:1.36
```

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

When mlflow-operator: managedState: Removed

<img width="1920" height="1080" alt="Screenshot from 2026-03-20 04-55-55" src="https://github.com/user-attachments/assets/11161609-5aac-4d18-a71a-fe65eee8feb1" />
<img width="1920" height="1080" alt="Screenshot from 2026-03-20 02-13-17" src="https://github.com/user-attachments/assets/00800054-582d-40ea-93ba-9cfd02845642" />


When mlflow-operator: managedState: Managed

<img width="1920" height="1080" alt="Screenshot from 2026-03-20 04-41-19" src="https://github.com/user-attachments/assets/5b1a02b1-3f1f-4677-aa3e-595a872dc3be" />
<img width="1920" height="1080" alt="Screenshot from 2026-03-20 04-40-59" src="https://github.com/user-attachments/assets/22286c59-4708-44d5-a211-39c3a6b1cec9" />

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [x] The developer has run the integration test pipeline and verified that it passed successfully
- [x] New RELATED_IMAGE mappings are already listed in ODH-Build-Config and RHOAI-Build-Config, and links are included in PR description

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [ ] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * MLflow integration for Workbenches with automatic enablement detection from cluster state
  * Workbenches now apply computed kustomize parameters, set gateway URL, and show platform-specific section titles

* **Tests**
  * Unit tests validating kustomize variable computation, validation, and edge cases
  * End-to-end test validating MLflow enablement toggling and Workbenches readiness
<!-- end of auto-generated comment: release notes by coderabbit.ai -->