### PR TITLE
RHOAIENG-53946 | fix: Remove the redundant stored version check

### DIFF
--- a/internal/controller/components/dashboard/dashboard_controller_actions_test.go
+++ b/internal/controller/components/dashboard/dashboard_controller_actions_test.go
@@ -43,13 +43,9 @@ func TestMigrateHardwareProfiles(t *testing.T) {
 	fakeSchema.AddKnownTypeWithName(gvk.HardwareProfile, &infrav1.HardwareProfile{})
 	fakeSchema.AddKnownTypeWithName(gvk.HardwareProfile.GroupVersion().WithKind("HardwareProfileList"), &infrav1.HardwareProfileList{})
 
-	// Create a CRD for Dashboard HardwareProfile to make HasCRD check pass
 	dashboardHWPCRD := &apiextensionsv1.CustomResourceDefinition{
 		ObjectMeta: v1.ObjectMeta{
 			Name: "hardwareprofiles.dashboard.opendatahub.io",
-		},
-		Status: apiextensionsv1.CustomResourceDefinitionStatus{
-			StoredVersions: []string{gvk.DashboardHardwareProfile.Version},
 		},
 	}
 

--- a/internal/controller/components/kserve/kserve_controller_actions_test.go
+++ b/internal/controller/components/kserve/kserve_controller_actions_test.go
@@ -619,7 +619,7 @@ func convertToUnstructured(t *testing.T, obj runtime.Object) *unstructured.Unstr
 }
 
 // fakeclientWithCRDs builds a fake client whose RESTMapper knows about the
-// given GVKs and that contains matching CRD objects with StoredVersions set,
+// given GVKs and that contains matching CRD objects,
 // so that cluster.HasCRD returns true for each of them.
 func fakeclientWithCRDs(gvks []schema.GroupVersionKind) (client.Client, error) {
 	s, err := testscheme.New()
@@ -641,9 +641,6 @@ func fakeclientWithCRDs(gvks []schema.GroupVersionKind) (client.Client, error) {
 
 		crdObjs = append(crdObjs, &apiextensionsv1.CustomResourceDefinition{
 			ObjectMeta: metav1.ObjectMeta{Name: crdName},
-			Status: apiextensionsv1.CustomResourceDefinitionStatus{
-				StoredVersions: []string{item.Version},
-			},
 		})
 	}
 

--- a/internal/controller/components/trainer/trainer_controller_actions_test.go
+++ b/internal/controller/components/trainer/trainer_controller_actions_test.go
@@ -266,9 +266,6 @@ func TestCheckPreConditions_Success(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "jobsets.jobset.x-k8s.io",
 		},
-		Status: apiextensionsv1.CustomResourceDefinitionStatus{
-			StoredVersions: []string{gvk.JobSetv1alpha2.Version},
-		},
 	}
 	jobSetOperatorCondition := &ofapiv2.OperatorCondition{ObjectMeta: metav1.ObjectMeta{
 		Name: fmt.Sprintf("%s.%s", jobSetOperator, jobSetOperatorRndVersion),

--- a/internal/controller/services/monitoring/monitoring_controller_support_test.go
+++ b/internal/controller/services/monitoring/monitoring_controller_support_test.go
@@ -698,7 +698,6 @@ func createMonitoringStackCRD() *extv1.CustomResourceDefinition {
 			},
 		},
 		Status: extv1.CustomResourceDefinitionStatus{
-			StoredVersions: []string{"v1alpha1"},
 			Conditions: []extv1.CustomResourceDefinitionCondition{
 				{
 					Type:   extv1.Established,
@@ -735,7 +734,6 @@ func createThanosQuerierCRD() *extv1.CustomResourceDefinition {
 			},
 		},
 		Status: extv1.CustomResourceDefinitionStatus{
-			StoredVersions: []string{"v1alpha1"},
 			Conditions: []extv1.CustomResourceDefinitionCondition{
 				{
 					Type:   extv1.Established,

--- a/internal/controller/status/status.go
+++ b/internal/controller/status/status.go
@@ -124,11 +124,7 @@ const (
 	DataSciencePipelinesArgoWorkflowsCRDMissingMessage = "Argo Workflows controllers are not managed by this operator, but the CRD is missing"
 )
 
-// For Kueue MultiKueue CRD.
 const (
-	MultiKueueCRDReason  = "MultiKueueCRDV1Alpha1Exist"
-	MultiKueueCRDMessage = "Kueue CRDs MultiKueueConfig v1alpha1 and/or MultiKueueCluster v1alpha1 exist, please remove them to proceed"
-
 	KueueStateManagedNotSupported        = "KueueStateManagedNotSupported"
 	KueueStateManagedNotSupportedMessage = "Kueue managementState Managed is not supported, please use Removed or Unmanaged"
 	KueueOperatorNotInstalleReason       = "KueueOperatorNotInstalleReason"

--- a/pkg/cluster/gvk/gvk.go
+++ b/pkg/cluster/gvk/gvk.go
@@ -507,18 +507,6 @@ var (
 
 	// kueue.x-k8s.io.
 
-	MultiKueueConfigV1Alpha1 = schema.GroupVersionKind{
-		Group:   "kueue.x-k8s.io",
-		Version: "v1alpha1",
-		Kind:    "MultiKueueConfig",
-	}
-
-	MultikueueClusterV1Alpha1 = schema.GroupVersionKind{
-		Group:   "kueue.x-k8s.io",
-		Version: "v1alpha1",
-		Kind:    "MultiKueueCluster",
-	}
-
 	LocalQueue = schema.GroupVersionKind{
 		Group:   "kueue.x-k8s.io",
 		Version: "v1beta1",

--- a/pkg/cluster/resources_test.go
+++ b/pkg/cluster/resources_test.go
@@ -258,6 +258,9 @@ func TestHasCRDWithVersion(t *testing.T) {
 	t.Run("should return false when RESTMapper resolves but CRD object is missing", func(t *testing.T) {
 		g := NewWithT(t)
 
+		// fakeclient registers Dashboard in its RESTMapper via the scheme,
+		// but we don't create the CRD object — simulates a stale cache
+		// after CRD deletion.
 		cli, err := fakeclient.New()
 		g.Expect(err).ShouldNot(HaveOccurred())
 

--- a/pkg/controller/actions/dependency/action_operator.go
+++ b/pkg/controller/actions/dependency/action_operator.go
@@ -7,8 +7,6 @@ import (
 	"slices"
 	"strings"
 
-	"k8s.io/apiextensions-apiserver/pkg/apihelpers"
-	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -146,7 +144,7 @@ func (a *action) run(ctx context.Context, rr *odhtypes.ReconciliationRequest) er
 			continue
 		}
 
-		has, err := hasCRDWithVersion(ctx, rr.Client, config.GVK.GroupKind(), config.GVK.Version)
+		has, err := cluster.HasCRD(ctx, rr.Client, config.GVK)
 		if err != nil {
 			// Log and continue - monitoring failures should not block reconciliation.
 			logger := ctrlLog.FromContext(ctx)
@@ -335,30 +333,4 @@ func NewAction(opts ...ActionOpts) actions.Fn {
 	}
 
 	return a.run
-}
-
-// TODO: use the cluster.HasCRD function instead. But that function also checks
-// the CRD stored version, which should be the one checked. To understand why that
-// check.
-// Actually, it's failing the check on security.istio.io, since the stored version is v1beta1
-// but KServe monitor is on v1.
-func hasCRDWithVersion(ctx context.Context, cli client.Client, gk schema.GroupKind, version string) (bool, error) {
-	m, err := cli.RESTMapper().RESTMapping(gk, version)
-	if err != nil {
-		if meta.IsNoMatchError(err) {
-			return false, nil
-		}
-
-		return false, err
-	}
-
-	crd, err := cluster.GetCRD(ctx, cli, m.Resource.GroupResource().String())
-	switch {
-	case err != nil:
-		return false, client.IgnoreNotFound(err)
-	case apihelpers.IsCRDConditionTrue(&crd, apiextensionsv1.Terminating):
-		return false, nil
-	default:
-		return true, nil
-	}
 }

--- a/pkg/controller/actions/sanitycheck/sanitycheck_test.go
+++ b/pkg/controller/actions/sanitycheck/sanitycheck_test.go
@@ -80,7 +80,6 @@ func TestPerformV3UpgradeSanityChecks(t *testing.T) {
 			errorMessage := "TestFake resources present"
 
 			mockCRD := mocks.NewMockCRD("components.platform.opendatahub.io", "v1alpha1", "TestFake", "fakeName")
-			mockCRD.Status.StoredVersions = append(mockCRD.Status.StoredVersions, "v1alpha1")
 
 			cli := tc.setupClient(g, mockCRD)
 

--- a/pkg/resources/resources_test.go
+++ b/pkg/resources/resources_test.go
@@ -372,9 +372,6 @@ func TestHasCRD(t *testing.T) {
 				Storage: true,
 			}},
 		},
-		Status: apiextensionsv1.CustomResourceDefinitionStatus{
-			StoredVersions: []string{crdGVK.Version},
-		},
 	}
 
 	cli, err := fakeclient.New(


### PR DESCRIPTION
## Description

Follow-up cleanup to #3296 (RHOAIENG-54104), which removed the `StoredVersions` check from `HasCRDWithVersion` and introduced dynamic Perses API version switching.

This PR completes the cleanup by:

1. **Removing the duplicated private `hasCRDWithVersion` workaround** in `pkg/controller/actions/dependency/action_operator.go` — this function was created as a workaround because `cluster.HasCRDWithVersion` previously gave false negatives when `StoredVersions` differed from the served version (e.g. Istio's `security.istio.io` stores `v1beta1` while the GVK specifies `v1`). Now that the upstream function is fixed, the duplicated function and its associated TODO comment are removed, and the call site is replaced with `cluster.HasCRD`.

2. **Removing unused Kueue MultiKueue code** — deletes `MultiKueueConfigV1Alpha1` and `MultikueueClusterV1Alpha1` GVK constants from `pkg/cluster/gvk/gvk.go`, and removes `MultiKueueCRDReason`/`MultiKueueCRDMessage` status constants from `internal/controller/status/status.go`, as these are no longer referenced anywhere.

3. **Cleaning up test fixtures** — removes `Status.StoredVersions` from fake `CustomResourceDefinition` objects across test files, since `HasCRDWithVersion` no longer checks this field. Adds a clarifying comment to the stale RESTMapper cache test case.

Depends on: #3296 (merged)

https://redhat.atlassian.net/browse/RHOAIENG-53946

## How Has This Been Tested?

- All unit tests pass (`go test ./...`)
- `make lint` passes
- No behavioral changes — this is purely cleanup of dead code and unnecessary test fixture data

## Merge criteria

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [x] The developer has run the integration test pipeline and verified that it passed successfully
- [ ] New RELATED_IMAGE mappings are already listed in ODH-Build-Config and RHOAI-Build-Config, and links are included in PR description

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:

1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification

This PR is a cleanup of dead code and test fixtures only — no behavioral changes. The `StoredVersions` check removal and dynamic version switching were already shipped in #3296. No e2e test changes are needed.