### PR TITLE
fix: skipping replacement from previous deployment on kserve-controller-manager

### DIFF
--- a/internal/controller/components/kserve/kserve.go
+++ b/internal/controller/components/kserve/kserve.go
@@ -24,6 +24,7 @@ import (
 const (
 	componentName               = componentApi.KserveComponentName
 	kserveConfigMapName         = "inferenceservice-config"
+	isvcControllerDeployment    = "kserve-controller-manager"
 	kserveManifestSourcePath    = "overlays/odh"
 	kserveManifestSourcePathXKS = "overlays/odh-xks"
 

--- a/internal/controller/components/kserve/kserve_controller_actions.go
+++ b/internal/controller/components/kserve/kserve_controller_actions.go
@@ -2,6 +2,7 @@ package kserve
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -96,17 +97,18 @@ func customizeKserveConfigMap(_ context.Context, rr *odhtypes.ReconciliationRequ
 		return fmt.Errorf("resource instance %v is not a componentApi.Kserve", rr.Instance)
 	}
 
-	kserveConfigMap := corev1.ConfigMap{}
-	cmidx, err := getIndexedResource(rr.Resources, &kserveConfigMap, gvk.ConfigMap, kserveConfigMapName)
-	if err != nil {
-		return err
-	}
-
 	//nolint:staticcheck
 	serviceClusterIPNone := true
 	if k.Spec.RawDeploymentServiceConfig == componentApi.KserveRawHeaded {
 		// As default is Headless, only set false here if Headed is explicitly set
 		serviceClusterIPNone = false
+	}
+
+	// Update ConfigMap (required for both OpenShift and XKS)
+	kserveConfigMap := corev1.ConfigMap{}
+	cmidx, err := getIndexedResource(rr.Resources, &kserveConfigMap, gvk.ConfigMap, kserveConfigMapName)
+	if err != nil {
+		return err
 	}
 
 	if err := updateInferenceCM(&kserveConfigMap, serviceClusterIPNone); err != nil {
@@ -116,13 +118,21 @@ func customizeKserveConfigMap(_ context.Context, rr *odhtypes.ReconciliationRequ
 	if err = replaceResourceAtIndex(rr.Resources, cmidx, &kserveConfigMap); err != nil {
 		return err
 	}
-	kserveConfigHash, err := hashConfigMap(&kserveConfigMap)
+
+	// Check if kserve-controller-manager deployment exists in resources
+	// If not (e.g., XKS manifests), skip hash annotation
+	kserveDeployment := appsv1.Deployment{}
+	deployidx, err := getIndexedResource(rr.Resources, &kserveDeployment, gvk.Deployment, isvcControllerDeployment)
 	if err != nil {
+		// Only skip if deployment not found; propagate other errors
+		if errors.Is(err, ErrResourceNotFound) {
+			return nil
+		}
 		return err
 	}
 
-	kserveDeployment := appsv1.Deployment{}
-	deployidx, err := getIndexedResource(rr.Resources, &kserveDeployment, gvk.Deployment, "kserve-controller-manager")
+	// Add hash annotation to deployment to trigger restart on ConfigMap changes
+	kserveConfigHash, err := hashConfigMap(&kserveConfigMap)
 	if err != nil {
 		return err
 	}

--- a/internal/controller/components/kserve/kserve_controller_actions_test.go
+++ b/internal/controller/components/kserve/kserve_controller_actions_test.go
@@ -187,7 +187,7 @@ func TestCustomizeKserveConfigMap(t *testing.T) {
 
 		var updatedDeployment *appsv1.Deployment
 		for _, resource := range rr.Resources {
-			if resource.GetKind() == "Deployment" && resource.GetName() == "kserve-controller-manager" {
+			if resource.GetKind() == "Deployment" && resource.GetName() == isvcControllerDeployment {
 				updatedDeployment = &appsv1.Deployment{}
 				err = runtime.DefaultUnstructuredConverter.FromUnstructured(resource.Object, updatedDeployment)
 				g.Expect(err).ShouldNot(HaveOccurred())
@@ -221,14 +221,14 @@ func TestCustomizeKserveConfigMap(t *testing.T) {
 		g.Expect(err.Error()).Should(ContainSubstring(kserveConfigMapName))
 	})
 
-	t.Run("Test KServe deployment not found", func(t *testing.T) {
+	t.Run("Test KServe skips hash annotation when deployment is missing (e.g., XKS)", func(t *testing.T) {
 		kserve := &componentApi.Kserve{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: componentApi.KserveInstanceName,
 			},
 		}
 
-		// create reconciliation request with ConfigMap but without deployment
+		// create reconciliation request with ConfigMap but without deployment (simulates XKS manifests)
 		initialConfigMap := createTestConfigMap()
 		resources := []unstructured.Unstructured{
 			*convertToUnstructured(t, initialConfigMap),
@@ -239,10 +239,9 @@ func TestCustomizeKserveConfigMap(t *testing.T) {
 			Resources: resources,
 		}
 
+		// Should not error - ConfigMap is updated, but deployment hash annotation is skipped
 		err := customizeKserveConfigMap(ctx, rr)
-		g.Expect(err).Should(HaveOccurred())
-		g.Expect(err.Error()).Should(ContainSubstring("could not find"))
-		g.Expect(err.Error()).Should(ContainSubstring("kserve-controller-manager"))
+		g.Expect(err).ShouldNot(HaveOccurred())
 	})
 }
 
@@ -596,7 +595,7 @@ func createTestDeployment() *appsv1.Deployment {
 			Kind:       "Deployment",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "kserve-controller-manager",
+			Name: isvcControllerDeployment,
 		},
 		Spec: appsv1.DeploymentSpec{
 			Template: corev1.PodTemplateSpec{

--- a/internal/controller/components/kserve/kserve_support.go
+++ b/internal/controller/components/kserve/kserve_support.go
@@ -4,13 +4,14 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"maps"
 	"os"
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -27,6 +28,8 @@ import (
 )
 
 var (
+	ErrResourceNotFound = errors.New("resource not found")
+
 	imageParamMap = map[string]string{
 		"kserve-agent":                     "RELATED_IMAGE_ODH_KSERVE_AGENT_IMAGE",
 		"kserve-controller":                "RELATED_IMAGE_ODH_KSERVE_CONTROLLER_IMAGE",
@@ -128,7 +131,7 @@ func getIndexedResource(rs []unstructured.Unstructured, obj any, g schema.GroupV
 	}
 
 	if idx == -1 {
-		return -1, fmt.Errorf("could not find %T with name %v in resources list", obj, name)
+		return -1, fmt.Errorf("could not find %T with name %v in resources list: %w", obj, name, ErrResourceNotFound)
 	}
 
 	err := runtime.DefaultUnstructuredConverter.FromUnstructured(rs[idx].Object, obj)
@@ -180,7 +183,7 @@ func getAndRemoveOwnerReferences(
 	current := resources.GvkToUnstructured(res.GroupVersionKind())
 
 	lookupErr := cli.Get(ctx, client.ObjectKeyFromObject(&res), current)
-	if errors.IsNotFound(lookupErr) {
+	if k8serr.IsNotFound(lookupErr) {
 		return nil
 	}
 	if lookupErr != nil {


### PR DESCRIPTION
<!---
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

- xKS does not deployment it
- originally code was introduced when user shift from two deployment mode raw and advanced, that need retrigger controller pod restart to take effect

<!--- Link your JIRA and related links here for reference. -->
ref https://redhat.atlassian.net/browse/RHOAIENG-54376

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully
- [ ] New RELATED_IMAGE mappings are already listed in ODH-Build-Config and RHOAI-Build-Config, and links are included in PR description

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->
we do not have e2e env to test xks, skip it for now

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * The controller no longer treats a missing KServe deployment as an error; it skips deployment-specific annotation updates and proceeds without failing.

* **Tests**
  * Tests adjusted to cover the missing-deployment scenario and verify ConfigMap customization still occurs when deployment annotation is skipped.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->