### PR TITLE
RHOAIENG-49732 | Enrich JUnit XML with failure classification

### DIFF
--- a/Dockerfiles/e2e-tests/e2e-tests.Dockerfile
+++ b/Dockerfiles/e2e-tests/e2e-tests.Dockerfile
@@ -20,11 +20,15 @@ RUN go mod download
 COPY api/ api/
 COPY internal/ internal/
 COPY cmd/main.go cmd/main.go
+COPY cmd/test-retry/ cmd/test-retry/
 COPY pkg/ pkg/
 COPY tests/ tests/
 
 # build the e2e test binary + pre-compile the e2e tests
 RUN CGO_ENABLED=${CGO_ENABLED} GOOS=linux GOARCH=${TARGETARCH} go test -c ./tests/e2e/ -o e2e-tests
+
+# Build test-retry CLI for JUnit enrichment
+RUN cd cmd/test-retry && CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go build -o ../../test-retry .
 
 ################################################################################
 FROM golang:$GOLANG_VERSION
@@ -42,9 +46,10 @@ RUN go install gotest.tools/gotestsum@latest \
 WORKDIR /e2e
 
 COPY --from=builder /workspace/e2e-tests .
+COPY --from=builder /workspace/test-retry /go/bin/test-retry
 COPY tests/e2e/scripts/run_e2e_tests.sh /e2e/run_e2e_tests.sh
 
-RUN chmod +x ./e2e-tests /e2e/run_e2e_tests.sh
+RUN chmod +x ./e2e-tests /e2e/run_e2e_tests.sh /go/bin/test-retry
 
 RUN mkdir -p results
 

--- a/cmd/test-retry/README.md
+++ b/cmd/test-retry/README.md
@@ -64,3 +64,6 @@ go build -o test-retry .
 - `--github-pr`: GitHub pull request number to notify on test failures
 - `--failure-label`: Label to add to PR when tests fail (optional)
 - `--failure-comment`: Comment to add to PR when tests fail (optional)
+
+## JUnit XML Failure Classification
+The CLI enriches JUnit XML output with failure classification properties when tests fail. This enables CI dashboards and BigQuery to distinguish infrastructure failures from test logic failures.

--- a/cmd/test-retry/pkg/cli/e2e.go
+++ b/cmd/test-retry/pkg/cli/e2e.go
@@ -15,6 +15,7 @@ func NewE2ECommand(cfg *config.Config) *cobra.Command {
 	var testFlags string
 	var testPath string
 	var workingDir string
+	var command string
 	var maxRetries int
 	var neverSkip []string
 	var skipAtPrefix []string
@@ -52,6 +53,7 @@ Example: test-retry e2e -- -run TestFoo -v`,
 				TestFlags:         finalTestFlags,
 				TestPath:          testPath,
 				WorkingDir:        workingDir,
+				Command:           command,
 				NeverSkipPrefixes: neverSkip,
 				SkipAtPrefixes:    skipAtPrefix,
 				PROptions:         prOpts,
@@ -63,9 +65,10 @@ Example: test-retry e2e -- -run TestFoo -v`,
 		},
 	}
 
-	cmd.Flags().StringVar(&testFilter, "filter", "^TestOdhOperator/", "Filter tests to run (regex pattern)")
+	cmd.Flags().StringVar(&testFilter, "filter", "^TestOdhOperator", "Filter tests to run (regex pattern)")
 	cmd.Flags().StringVar(&testPath, "path", "./tests/e2e/", "Path to e2e tests")
 	cmd.Flags().StringVar(&workingDir, "working-dir", "", "Working directory for running go test (default: current directory)")
+	cmd.Flags().StringVar(&command, "command", "", "Custom command to run tests (default: go test). Use for precompiled binaries.")
 	cmd.Flags().IntVar(&maxRetries, "max-retries", 3, "Maximum number of retries for failed tests")
 	cmd.Flags().StringSliceVar(&neverSkip, "never-skip", []string{"TestOdhOperator/DSCInitialization_and_DataScienceCluster_management_E2E_Tests", "TestOdhOperator/DataScienceCluster"}, "Test prefixes that should never be skipped (always run, repeatable)")
 	cmd.Flags().StringSliceVar(&skipAtPrefix, "skip-at-prefix", []string{"TestOdhOperator/services/*/", "TestOdhOperator/components/*/", "TestOdhOperator/"}, "Test prefixes where tests should be extracted at prefix + 1 level (repeatable)")

--- a/cmd/test-retry/pkg/formatter/junit.go
+++ b/cmd/test-retry/pkg/formatter/junit.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"os"
 	"sort"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/opendatahub-io/opendatahub-operator/v2/cmd/test-retry/pkg/types"
@@ -21,16 +23,28 @@ type TestSuite struct {
 
 // TestCase represents a JUnit XML test case
 type TestCase struct {
-	Name     string    `xml:"name,attr"`
-	Duration string    `xml:"time,attr"`
-	Failure  *Failure  `xml:"failure,omitempty"`
-	Time     time.Time `xml:"-"`
+	Name       string      `xml:"name,attr"`
+	Duration   string      `xml:"time,attr"`
+	Failure    *Failure    `xml:"failure,omitempty"`
+	Properties *Properties `xml:"properties,omitempty"`
+	Time       time.Time   `xml:"-"`
 }
 
 // Failure represents a JUnit XML test failure
 type Failure struct {
 	Message string `xml:"message,attr,omitempty"`
 	Content string `xml:",chardata"`
+}
+
+// Properties represents JUnit XML <properties> element
+type Properties struct {
+	Property []Property `xml:"property"`
+}
+
+// Property represents a single <property> element with name/value attributes
+type Property struct {
+	Name  string `xml:"name,attr"`
+	Value string `xml:"value,attr"`
 }
 
 // JUnitExportOptions holds configuration for JUnit export
@@ -89,7 +103,8 @@ func convertToJUnitSuite(result *types.TestResult, suiteName string) TestSuite {
 				Message: fmt.Sprintf("Test %s failed", test.Name),
 				Content: test.FailureOutput,
 			},
-			Time: test.Time,
+			Properties: buildClassificationProperties(test.Classification),
+			Time:       test.Time,
 		}
 
 		unorderedTestCases = append(unorderedTestCases, tc)
@@ -122,4 +137,32 @@ func convertToJUnitSuite(result *types.TestResult, suiteName string) TestSuite {
 // formatDuration formats a duration to a string in seconds with decimals
 func formatDuration(d time.Duration) string {
 	return fmt.Sprintf("%.3f", d.Seconds())
+}
+
+// buildClassificationProperties creates JUnit properties from FailureClassification.
+// Returns nil if the classification is nil (test has no classification).
+//
+// Property naming convention:
+//   - failure.category: "infrastructure", "test", "unknown"
+//   - failure.subcategory: specific cause (e.g., "image-pull", "pod-startup")
+//   - failure.error_code: numeric error identifier
+//   - failure.confidence: "high", "medium", "low"
+//   - failure.evidence: semicolon-separated evidence strings
+func buildClassificationProperties(fc *types.FailureClassification) *Properties {
+	if fc == nil {
+		return nil
+	}
+
+	// Format evidence: join array with semicolons for single property value
+	evidenceStr := strings.Join(fc.Evidence, "; ")
+
+	return &Properties{
+		Property: []Property{
+			{Name: "failure.category", Value: fc.Category},
+			{Name: "failure.subcategory", Value: fc.Subcategory},
+			{Name: "failure.error_code", Value: strconv.Itoa(fc.ErrorCode)},
+			{Name: "failure.confidence", Value: fc.Confidence},
+			{Name: "failure.evidence", Value: evidenceStr},
+		},
+	}
 }

--- a/cmd/test-retry/pkg/formatter/junit_test.go
+++ b/cmd/test-retry/pkg/formatter/junit_test.go
@@ -253,6 +253,160 @@ func TestExportToJUnit(t *testing.T) {
 			wantErr:     true,
 			errContains: "output path is required",
 		},
+		{
+			name: "failed test with infrastructure classification",
+			result: &types.TestResult{
+				PassedTest: []types.TestCase{},
+				FailedTest: []types.TestCase{
+					{
+						ID:            1,
+						Name:          "TestDashboard/basic_test",
+						Package:       "example.com/e2e",
+						Duration:      45 * time.Second,
+						FailureOutput: "Dashboard not ready",
+						Time:          time.Now(),
+						Classification: &types.FailureClassification{
+							Category:    "infrastructure",
+							Subcategory: "image-pull",
+							ErrorCode:   1001,
+							Evidence:    []string{"container dashboard/oauth-proxy waiting: ImagePullBackOff", "event Pod/dashboard: BackOff"},
+							Confidence:  "medium",
+						},
+					},
+				},
+			},
+			verifySuite: func(t *testing.T, suite TestSuite) {
+				require.Equal(t, 1, suite.Tests)
+				require.Equal(t, 1, suite.Failures)
+				require.Len(t, suite.TestCases, 1)
+
+				tc := suite.TestCases[0]
+				require.Equal(t, "TestDashboard/basic_test", tc.Name)
+				require.NotNil(t, tc.Failure)
+				require.NotNil(t, tc.Properties)
+				require.Len(t, tc.Properties.Property, 5)
+
+				// Build map for easier assertions
+				props := make(map[string]string)
+				for _, p := range tc.Properties.Property {
+					props[p.Name] = p.Value
+				}
+
+				require.Equal(t, "infrastructure", props["failure.category"])
+				require.Equal(t, "image-pull", props["failure.subcategory"])
+				require.Equal(t, "1001", props["failure.error_code"])
+				require.Equal(t, "medium", props["failure.confidence"])
+				require.Equal(t, "container dashboard/oauth-proxy waiting: ImagePullBackOff; event Pod/dashboard: BackOff", props["failure.evidence"])
+			},
+		},
+		{
+			name: "failed test with test classification",
+			result: &types.TestResult{
+				FailedTest: []types.TestCase{
+					{
+						Name:     "TestModelMesh/deployment",
+						Duration: 30 * time.Second,
+						Classification: &types.FailureClassification{
+							Category:    "test",
+							Subcategory: "test-failure",
+							ErrorCode:   2001,
+							Evidence:    []string{"cluster appears healthy, failure is test-related"},
+							Confidence:  "medium",
+						},
+					},
+				},
+			},
+			verifySuite: func(t *testing.T, suite TestSuite) {
+				tc := suite.TestCases[0]
+				require.NotNil(t, tc.Properties)
+
+				props := make(map[string]string)
+				for _, p := range tc.Properties.Property {
+					props[p.Name] = p.Value
+				}
+
+				require.Equal(t, "test", props["failure.category"])
+				require.Equal(t, "test-failure", props["failure.subcategory"])
+				require.Equal(t, "2001", props["failure.error_code"])
+			},
+		},
+		{
+			name: "failed test without classification",
+			result: &types.TestResult{
+				FailedTest: []types.TestCase{
+					{
+						Name:           "TestOldTest",
+						Duration:       10 * time.Second,
+						Classification: nil,
+					},
+				},
+			},
+			verifySuite: func(t *testing.T, suite TestSuite) {
+				tc := suite.TestCases[0]
+				require.Nil(t, tc.Properties) // No properties when no classification
+			},
+		},
+		{
+			name: "multiple retries with different classifications",
+			result: &types.TestResult{
+				FailedTest: []types.TestCase{
+					{
+						Name:     "TestFlaky",
+						Duration: 20 * time.Second,
+						Time:     time.Now().Add(-10 * time.Second),
+						Classification: &types.FailureClassification{
+							Category:    "infrastructure",
+							Subcategory: "image-pull",
+							ErrorCode:   1001,
+							Evidence:    []string{"ImagePullBackOff"},
+							Confidence:  "medium",
+						},
+					},
+					{
+						Name:     "TestFlaky",
+						Duration: 25 * time.Second,
+						Time:     time.Now().Add(-5 * time.Second),
+						Classification: &types.FailureClassification{
+							Category:    "infrastructure",
+							Subcategory: "pod-startup",
+							ErrorCode:   1002,
+							Evidence:    []string{"CrashLoopBackOff"},
+							Confidence:  "high",
+						},
+					},
+				},
+				PassedTest: []types.TestCase{
+					{
+						Name:     "TestFlaky",
+						Duration: 22 * time.Second,
+						Time:     time.Now(),
+					},
+				},
+			},
+			verifySuite: func(t *testing.T, suite TestSuite) {
+				require.Equal(t, 3, suite.Tests)
+				require.Equal(t, 2, suite.Failures)
+
+				// First failure: image-pull
+				props1 := make(map[string]string)
+				for _, p := range suite.TestCases[0].Properties.Property {
+					props1[p.Name] = p.Value
+				}
+				require.Equal(t, "image-pull", props1["failure.subcategory"])
+				require.Equal(t, "1001", props1["failure.error_code"])
+
+				// Second failure: pod-startup
+				props2 := make(map[string]string)
+				for _, p := range suite.TestCases[1].Properties.Property {
+					props2[p.Name] = p.Value
+				}
+				require.Equal(t, "pod-startup", props2["failure.subcategory"])
+				require.Equal(t, "1002", props2["failure.error_code"])
+
+				// Third (passed): no properties
+				require.Nil(t, suite.TestCases[2].Properties)
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/cmd/test-retry/pkg/parser/event.go
+++ b/cmd/test-retry/pkg/parser/event.go
@@ -8,6 +8,7 @@ import (
 
 type eventHandler struct {
 	formatter testjson.EventFormatter
+	tracker   *classificationTracker
 }
 
 func (h *eventHandler) Err(text string) error {
@@ -16,6 +17,11 @@ func (h *eventHandler) Err(text string) error {
 }
 
 func (h *eventHandler) Event(event testjson.TestEvent, execution *testjson.Execution) error {
+	// Track classifications before formatting
+	if h.tracker != nil {
+		h.tracker.handleEvent(event)
+	}
+
 	err := h.formatter.Format(event, execution)
 	if err != nil {
 		return fmt.Errorf("failed to format event: %w", err)

--- a/cmd/test-retry/pkg/parser/parser.go
+++ b/cmd/test-retry/pkg/parser/parser.go
@@ -1,14 +1,21 @@
 package parser
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
 	"strings"
+	"sync"
 
 	"gotest.tools/gotestsum/testjson"
 
 	"github.com/opendatahub-io/opendatahub-operator/v2/cmd/test-retry/pkg/types"
+)
+
+const (
+	// ClassificationPrefix is the prefix for classification JSON lines in test output
+	ClassificationPrefix = "FAILURE_CLASSIFICATION: "
 )
 
 type ParseConfig struct {
@@ -16,11 +23,97 @@ type ParseConfig struct {
 	Stderr io.Reader
 }
 
+// classificationTracker monitors test execution and extracts classification data
+// from FAILURE_CLASSIFICATION: JSON lines in test output.
+type classificationTracker struct {
+	mu              sync.Mutex
+	currentTest     string                                    // currently running test name
+	classifications map[string]*types.FailureClassification // test name → classification
+}
+
+// newClassificationTracker creates a new classification tracker
+func newClassificationTracker() *classificationTracker {
+	return &classificationTracker{
+		classifications: make(map[string]*types.FailureClassification),
+	}
+}
+
+// parseClassificationLine extracts FailureClassification from a FAILURE_CLASSIFICATION: JSON line.
+// Returns nil if the line is not a classification line or if parsing fails.
+func parseClassificationLine(line string) (*types.FailureClassification, error) {
+	if !strings.HasPrefix(line, ClassificationPrefix) {
+		return nil, nil // not a classification line
+	}
+
+	jsonStr := strings.TrimPrefix(line, ClassificationPrefix)
+	var fc types.FailureClassification
+
+	if err := json.Unmarshal([]byte(jsonStr), &fc); err != nil {
+		return nil, fmt.Errorf("failed to parse classification JSON: %w", err)
+	}
+
+	return &fc, nil
+}
+
+// handleEvent processes test events and extracts classifications from output.
+// This tracks which test is currently running and associates classification
+// output with the correct test name.
+func (t *classificationTracker) handleEvent(event testjson.TestEvent) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	switch event.Action {
+	case testjson.ActionRun:
+		// Test started - remember the test name
+		// event.Test is the test name (string)
+		t.currentTest = event.Test
+
+	case testjson.ActionOutput:
+		// Test produced output - check for classification
+		fc, err := parseClassificationLine(event.Output)
+		if err != nil {
+			// Log error but don't fail - classification is optional enhancement
+			fmt.Fprintf(os.Stderr, "Warning: failed to parse classification: %v\n", err)
+			return
+		}
+		if fc != nil {
+			// Associate classification with the current test
+			// Use event.Test if available, otherwise fall back to currentTest
+			testName := event.Test
+			if testName == "" {
+				testName = t.currentTest
+			}
+			if testName != "" {
+				t.classifications[testName] = fc
+			}
+		}
+
+	case testjson.ActionFail, testjson.ActionPass, testjson.ActionSkip:
+		// Test finished - clear current test
+		if event.Test == t.currentTest {
+			t.currentTest = ""
+		}
+	}
+}
+
+// getClassification retrieves the classification for a test name.
+// Returns nil if no classification exists for this test.
+func (t *classificationTracker) getClassification(testName string) *types.FailureClassification {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.classifications[testName]
+}
+
 // ParseGoTestJSON parses go test -json output using testjson library
 func ParseGoTestJSON(cfg ParseConfig) (*types.TestResult, error) {
 	formatter := testjson.NewEventFormatter(os.Stdout, "standard-verbose", testjson.FormatOptions{})
+
+	// Create classification tracker to extract FAILURE_CLASSIFICATION: lines
+	tracker := newClassificationTracker()
+
 	handler := &eventHandler{
 		formatter: formatter,
+		tracker:   tracker,
 	}
 
 	// Use ScanTestOutput to parse and get execution results
@@ -52,14 +145,21 @@ func ParseGoTestJSON(cfg ParseConfig) (*types.TestResult, error) {
 		}
 
 		for _, test := range pkg.Failed {
-			testResult.FailedTest = append(testResult.FailedTest, types.TestCase{
+			testCase := types.TestCase{
 				ID:            test.ID,
 				Name:          test.Test.Name(),
 				Package:       test.Package,
 				Duration:      test.Elapsed,
 				FailureOutput: strings.Join(pkg.OutputLines(test), ""),
 				Time:          test.Time,
-			})
+			}
+
+			// Attach classification if available for this test
+			if classification := tracker.getClassification(test.Test.Name()); classification != nil {
+				testCase.Classification = classification
+			}
+
+			testResult.FailedTest = append(testResult.FailedTest, testCase)
 		}
 
 		for _, test := range pkg.Passed {

--- a/cmd/test-retry/pkg/parser/parser_test.go
+++ b/cmd/test-retry/pkg/parser/parser_test.go
@@ -124,3 +124,196 @@ func TestParseGoTestJSONRealFixtures(t *testing.T) {
 		})
 	}
 }
+
+func TestParseClassificationLine(t *testing.T) {
+	tests := []struct {
+		name    string
+		line    string
+		want    *types.FailureClassification
+		wantErr bool
+	}{
+		{
+			name: "infrastructure classification",
+			line: `FAILURE_CLASSIFICATION: {"category":"infrastructure","subcategory":"image-pull","error_code":1001,"evidence":["container dashboard/oauth-proxy waiting: ImagePullBackOff"],"confidence":"medium"}`,
+			want: &types.FailureClassification{
+				Category:    "infrastructure",
+				Subcategory: "image-pull",
+				ErrorCode:   1001,
+				Evidence:    []string{"container dashboard/oauth-proxy waiting: ImagePullBackOff"},
+				Confidence:  "medium",
+			},
+			wantErr: false,
+		},
+		{
+			name: "test classification",
+			line: `FAILURE_CLASSIFICATION: {"category":"test","subcategory":"test-failure","error_code":2001,"evidence":["cluster appears healthy, failure is test-related"],"confidence":"medium"}`,
+			want: &types.FailureClassification{
+				Category:    "test",
+				Subcategory: "test-failure",
+				ErrorCode:   2001,
+				Evidence:    []string{"cluster appears healthy, failure is test-related"},
+				Confidence:  "medium",
+			},
+			wantErr: false,
+		},
+		{
+			name: "unknown classification",
+			line: `FAILURE_CLASSIFICATION: {"category":"unknown","subcategory":"unclassifiable","error_code":3000,"evidence":["no matching classification rule"],"confidence":"low"}`,
+			want: &types.FailureClassification{
+				Category:    "unknown",
+				Subcategory: "unclassifiable",
+				ErrorCode:   3000,
+				Evidence:    []string{"no matching classification rule"},
+				Confidence:  "low",
+			},
+			wantErr: false,
+		},
+		{
+			name: "multiple evidence items",
+			line: `FAILURE_CLASSIFICATION: {"category":"infrastructure","subcategory":"pod-startup","error_code":1002,"evidence":["container foo waiting: CrashLoopBackOff","container bar terminated: Error"],"confidence":"high"}`,
+			want: &types.FailureClassification{
+				Category:    "infrastructure",
+				Subcategory: "pod-startup",
+				ErrorCode:   1002,
+				Evidence:    []string{"container foo waiting: CrashLoopBackOff", "container bar terminated: Error"},
+				Confidence:  "high",
+			},
+			wantErr: false,
+		},
+		{
+			name:    "not a classification line",
+			line:    "=== RUN   TestDashboard",
+			want:    nil,
+			wantErr: false,
+		},
+		{
+			name:    "invalid JSON",
+			line:    `FAILURE_CLASSIFICATION: {invalid json}`,
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name:    "empty evidence array",
+			line:    `FAILURE_CLASSIFICATION: {"category":"infrastructure","subcategory":"network","error_code":1003,"evidence":[],"confidence":"low"}`,
+			want: &types.FailureClassification{
+				Category:    "infrastructure",
+				Subcategory: "network",
+				ErrorCode:   1003,
+				Evidence:    []string{},
+				Confidence:  "low",
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseClassificationLine(tt.line)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestParseGoTestJSON_WithClassification(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected *types.TestResult
+	}{
+		{
+			name: "failed test with infrastructure classification",
+			input: `{"Time":"2026-03-09T10:00:00Z","Action":"run","Package":"example.com/e2e","Test":"TestDashboard"}
+{"Time":"2026-03-09T10:00:01Z","Action":"output","Package":"example.com/e2e","Test":"TestDashboard","Output":"=== RUN   TestDashboard\n"}
+{"Time":"2026-03-09T10:00:45Z","Action":"output","Package":"example.com/e2e","Test":"TestDashboard","Output":"    dashboard_test.go:123: Dashboard not ready\n"}
+{"Time":"2026-03-09T10:00:45.1Z","Action":"output","Package":"example.com/e2e","Test":"TestDashboard","Output":"FAILURE_CLASSIFICATION: {\"category\":\"infrastructure\",\"subcategory\":\"image-pull\",\"error_code\":1001,\"evidence\":[\"container dashboard/oauth-proxy waiting: ImagePullBackOff\"],\"confidence\":\"medium\"}\n"}
+{"Time":"2026-03-09T10:00:45.2Z","Action":"fail","Package":"example.com/e2e","Test":"TestDashboard","Elapsed":45.2}`,
+			expected: &types.TestResult{
+				PassedTest: []types.TestCase{},
+				FailedTest: []types.TestCase{
+					{
+						ID:            1,
+						Package:       "example.com/e2e",
+						Name:          "TestDashboard",
+						Duration:      45200 * time.Millisecond,
+						FailureOutput: "=== RUN   TestDashboard\n    dashboard_test.go:123: Dashboard not ready\nFAILURE_CLASSIFICATION: {\"category\":\"infrastructure\",\"subcategory\":\"image-pull\",\"error_code\":1001,\"evidence\":[\"container dashboard/oauth-proxy waiting: ImagePullBackOff\"],\"confidence\":\"medium\"}\n",
+						Time:          time.Date(2026, 3, 9, 10, 0, 0, 0, time.UTC),
+						Classification: &types.FailureClassification{
+							Category:    "infrastructure",
+							Subcategory: "image-pull",
+							ErrorCode:   1001,
+							Evidence:    []string{"container dashboard/oauth-proxy waiting: ImagePullBackOff"},
+							Confidence:  "medium",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "failed test with test classification",
+			input: `{"Time":"2026-03-09T10:00:00Z","Action":"run","Package":"example.com/e2e","Test":"TestModelMesh"}
+{"Time":"2026-03-09T10:00:01Z","Action":"output","Package":"example.com/e2e","Test":"TestModelMesh","Output":"=== RUN   TestModelMesh\n"}
+{"Time":"2026-03-09T10:00:10Z","Action":"output","Package":"example.com/e2e","Test":"TestModelMesh","Output":"    modelmesh_test.go:89: Assertion failed\n"}
+{"Time":"2026-03-09T10:00:10.1Z","Action":"output","Package":"example.com/e2e","Test":"TestModelMesh","Output":"FAILURE_CLASSIFICATION: {\"category\":\"test\",\"subcategory\":\"test-failure\",\"error_code\":2001,\"evidence\":[\"cluster appears healthy\"],\"confidence\":\"medium\"}\n"}
+{"Time":"2026-03-09T10:00:10.2Z","Action":"fail","Package":"example.com/e2e","Test":"TestModelMesh","Elapsed":10.2}`,
+			expected: &types.TestResult{
+				PassedTest: []types.TestCase{},
+				FailedTest: []types.TestCase{
+					{
+						ID:            1,
+						Package:       "example.com/e2e",
+						Name:          "TestModelMesh",
+						Duration:      10200 * time.Millisecond,
+						FailureOutput: "=== RUN   TestModelMesh\n    modelmesh_test.go:89: Assertion failed\nFAILURE_CLASSIFICATION: {\"category\":\"test\",\"subcategory\":\"test-failure\",\"error_code\":2001,\"evidence\":[\"cluster appears healthy\"],\"confidence\":\"medium\"}\n",
+						Time:          time.Date(2026, 3, 9, 10, 0, 0, 0, time.UTC),
+						Classification: &types.FailureClassification{
+							Category:    "test",
+							Subcategory: "test-failure",
+							ErrorCode:   2001,
+							Evidence:    []string{"cluster appears healthy"},
+							Confidence:  "medium",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "failed test without classification",
+			input: `{"Time":"2026-03-09T10:00:00Z","Action":"run","Package":"example.com/e2e","Test":"TestOldTest"}
+{"Time":"2026-03-09T10:00:01Z","Action":"output","Package":"example.com/e2e","Test":"TestOldTest","Output":"=== RUN   TestOldTest\n"}
+{"Time":"2026-03-09T10:00:05Z","Action":"output","Package":"example.com/e2e","Test":"TestOldTest","Output":"    old_test.go:50: Failed\n"}
+{"Time":"2026-03-09T10:00:05.1Z","Action":"fail","Package":"example.com/e2e","Test":"TestOldTest","Elapsed":5.1}`,
+			expected: &types.TestResult{
+				PassedTest: []types.TestCase{},
+				FailedTest: []types.TestCase{
+					{
+						ID:             1,
+						Package:        "example.com/e2e",
+						Name:           "TestOldTest",
+						Duration:       5100 * time.Millisecond,
+						FailureOutput:  "=== RUN   TestOldTest\n    old_test.go:50: Failed\n",
+						Time:           time.Date(2026, 3, 9, 10, 0, 0, 0, time.UTC),
+						Classification: nil, // No classification for this test
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := ParseGoTestJSON(ParseConfig{
+				Stdout: bytes.NewBuffer([]byte(tt.input)),
+			})
+
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/cmd/test-retry/pkg/runner/e2e.go
+++ b/cmd/test-retry/pkg/runner/e2e.go
@@ -126,25 +126,46 @@ func (r *E2ETestRunner) Run() error {
 	return nil
 }
 
-// runE2ETests executes e2e tests using go test
+// runE2ETests executes e2e tests using go test or a custom command
 func (r *E2ETestRunner) runE2ETests(skipTestFilter string) (*types.TestResult, error) {
-	// Build go test command
-	args := []string{"test"}
+	// Determine command and build base args
+	cmdName := "go"
+	var args []string
+	isCustomCommand := r.opts.Command != ""
 
-	// Add test path
-	args = append(args, r.opts.TestPath)
+	if isCustomCommand {
+		// Custom command mode (e.g., precompiled binary ./e2e-tests)
+		cmdName = r.opts.Command
+		args = []string{} // Binary doesn't need "test" subcommand or path
+	} else {
+		// Default: go test mode
+		args = []string{"test", r.opts.TestPath}
+	}
 
-	// Add test filter
+	// Add common test flags
+	// Note: precompiled binaries use -test.* flags, go test uses short forms
 	if r.opts.TestFilter != "" {
-		args = append(args, "-run", r.opts.TestFilter)
+		if isCustomCommand {
+			args = append(args, "-test.run", r.opts.TestFilter)
+		} else {
+			args = append(args, "-run", r.opts.TestFilter)
+		}
 	}
 
 	if skipTestFilter != "" {
-		args = append(args, "-skip", skipTestFilter)
+		if isCustomCommand {
+			args = append(args, "-test.skip", skipTestFilter)
+		} else {
+			args = append(args, "-skip", skipTestFilter)
+		}
 	}
 
-	// Add verbose output, json output, and count flag to avoid test caching
-	args = append(args, "-v", "-json", "-count=1")
+	// Add verbose output and count flag to avoid test caching
+	if isCustomCommand {
+		args = append(args, "-test.v", "-test.count=1")
+	} else {
+		args = append(args, "-v", "-json", "-count=1")
+	}
 
 	// Add custom test flags
 	if r.opts.TestFlags != "" {
@@ -152,29 +173,88 @@ func (r *E2ETestRunner) runE2ETests(skipTestFilter string) (*types.TestResult, e
 		args = append(args, customFlags...)
 	}
 
-	if r.opts.Config.Verbose {
-		fmt.Printf("Running: go %s\n", strings.Join(args, " "))
-	}
-	// Execute command
-	cmd := exec.Command("go", args...)
-
-	// Set working directory if explicitly provided, otherwise use current directory
-	if r.opts.WorkingDir != "" {
-		cmd.Dir = r.opts.WorkingDir
-	}
-
 	var stdout, stderr io.Reader
 	var err error
-	stdout, err = cmd.StdoutPipe()
-	if err != nil {
-		return nil, err
-	}
-	stderr, err = cmd.StderrPipe()
-	if err != nil {
-		return nil, err
-	}
-	if err := cmd.Start(); err != nil {
-		return nil, fmt.Errorf("failed to run %s: %w", strings.Join(cmd.Args, " "), err)
+	var cmd *exec.Cmd
+	var testCmd *exec.Cmd // Track test binary separately for cleanup
+
+	if isCustomCommand {
+		// For precompiled binaries, pipe through test2json to get JSON output.
+		// Architecture:
+		//   Test binary stdout → test2json → parser (converts verbose output to JSON)
+		//   Test binary stderr → parser directly (preserves diagnostic messages)
+		// This dual-pipe approach ensures:
+		//   - FAILURE_CLASSIFICATION JSON is captured from stdout
+		//   - Error messages (panics, failures) are preserved from stderr
+		if r.opts.Config.Verbose {
+			fmt.Printf("Running: %s %s | go tool test2json\n", cmdName, strings.Join(args, " "))
+		}
+
+		// Create the test binary command
+		testCmd = exec.Command(cmdName, args...)
+		if r.opts.WorkingDir != "" {
+			testCmd.Dir = r.opts.WorkingDir
+		}
+
+		// Create test2json command
+		test2jsonCmd := exec.Command("go", "tool", "test2json", "-t", "-p", "e2e")
+
+		// Pipe test binary stdout to test2json for JSON conversion
+		testStdout, err := testCmd.StdoutPipe()
+		if err != nil {
+			return nil, fmt.Errorf("failed to create stdout pipe: %w", err)
+		}
+		test2jsonCmd.Stdin = testStdout
+
+		// Capture stderr from test binary directly (bypasses test2json)
+		stderr, err = testCmd.StderrPipe()
+		if err != nil {
+			return nil, fmt.Errorf("failed to create stderr pipe: %w", err)
+		}
+
+		// Start the test binary first
+		if err := testCmd.Start(); err != nil {
+			return nil, fmt.Errorf("failed to start test binary '%s': %w\nCheck that the binary exists and is executable", cmdName, err)
+		}
+
+		// Get stdout from test2json (which processes test binary's stdout)
+		stdout, err = test2jsonCmd.StdoutPipe()
+		if err != nil {
+			testCmd.Wait() // Clean up test binary
+			return nil, fmt.Errorf("failed to create test2json stdout pipe: %w", err)
+		}
+
+		// Start test2json
+		if err := test2jsonCmd.Start(); err != nil {
+			testCmd.Wait() // Clean up test binary
+			return nil, fmt.Errorf("failed to start test2json: %w\nEnsure 'go tool test2json' is available", err)
+		}
+
+		cmd = test2jsonCmd
+	} else {
+		// Default: go test with JSON output
+		if r.opts.Config.Verbose {
+			fmt.Printf("Running: %s %s\n", cmdName, strings.Join(args, " "))
+		}
+		cmd = exec.Command(cmdName, args...)
+
+		// Set working directory if explicitly provided
+		if r.opts.WorkingDir != "" {
+			cmd.Dir = r.opts.WorkingDir
+		}
+
+		stdout, err = cmd.StdoutPipe()
+		if err != nil {
+			return nil, fmt.Errorf("failed to create stdout pipe: %w", err)
+		}
+		stderr, err = cmd.StderrPipe()
+		if err != nil {
+			return nil, fmt.Errorf("failed to create stderr pipe: %w", err)
+		}
+
+		if err := cmd.Start(); err != nil {
+			return nil, fmt.Errorf("failed to run %s: %w", strings.Join(cmd.Args, " "), err)
+		}
 	}
 
 	// Parse JSON output for final summary (without duplicate output)
@@ -183,13 +263,30 @@ func (r *E2ETestRunner) runE2ETests(skipTestFilter string) (*types.TestResult, e
 		Stderr: stderr,
 	})
 	if err != nil {
-		return nil, err
+		// Reap child processes even on parse failure to prevent zombies
+		cmd.Wait()
+		if testCmd != nil {
+			testCmd.Wait()
+		}
+		return nil, fmt.Errorf("failed to parse test output: %w", err)
 	}
 
+	// Wait for test2json (or go test) to complete
 	if exitErr := cmd.Wait(); isExitError(exitErr) {
+		if testCmd != nil {
+			testCmd.Wait() // Also wait for test binary
+		}
 		return nil, exitErr
 	}
-	return testResult, err
+
+	// Wait for test binary if running in custom command mode
+	if testCmd != nil {
+		if exitErr := testCmd.Wait(); isExitError(exitErr) {
+			return nil, exitErr
+		}
+	}
+
+	return testResult, nil
 }
 
 func isExitError(err error) bool {

--- a/cmd/test-retry/pkg/types/types.go
+++ b/cmd/test-retry/pkg/types/types.go
@@ -6,6 +6,29 @@ import (
 	"github.com/opendatahub-io/opendatahub-operator/v2/cmd/test-retry/pkg/config"
 )
 
+// FailureClassification categorizes test failures based on cluster diagnostics.
+// The E2E test framework emits classification data as JSON to stdout when tests fail.
+// This type is used to parse and store that classification data.
+//
+// NOTE: This struct mirrors tests/e2e/pkg/failureclassifier.FailureClassification
+// and must stay in sync. Changes to field names, types, or JSON tags require
+// corresponding updates in both locations to maintain the data contract.
+//
+// The classification framework emits JSON in the format:
+// FAILURE_CLASSIFICATION: {"category":"infrastructure","subcategory":"image-pull",...}
+//
+// Error code ranges:
+//   - 1000-1999: Infrastructure failures (image-pull, pod-startup, network, quota, node, storage)
+//   - 2000-2999: Test logic failures
+//   - 3000+: Unknown/unclassifiable
+type FailureClassification struct {
+	Category    string   `json:"category"`    // "infrastructure", "test", "unknown"
+	Subcategory string   `json:"subcategory"` // e.g., "image-pull", "pod-startup", "test-failure"
+	ErrorCode   int      `json:"error_code"`  // numeric error identifier
+	Evidence    []string `json:"evidence"`    // supporting diagnostic messages
+	Confidence  string   `json:"confidence"`  // "high", "medium", "low"
+}
+
 // TestResult represents the result of test run
 type TestResult struct {
 	PassedTest []TestCase
@@ -32,6 +55,7 @@ type E2ETestOptions struct {
 	TestFlags  string
 	TestPath   string
 	WorkingDir string
+	Command    string // Path to precompiled test binary (e.g., "./e2e-tests"). Defaults to "go test" if empty. Arguments passed via TestFlags.
 	Config     *config.Config
 	// test prefixes that should never be skipped (always run)
 	NeverSkipPrefixes []string
@@ -43,10 +67,11 @@ type E2ETestOptions struct {
 
 // TestCase represents a single test case (passed or failed)
 type TestCase struct {
-	ID            int
-	Name          string
-	Package       string
-	Duration      time.Duration
-	FailureOutput string    `json:",omitempty"`
-	Time          time.Time `json:",omitempty"`
+	ID             int
+	Name           string
+	Package        string
+	Duration       time.Duration
+	FailureOutput  string                  `json:",omitempty"`
+	Time           time.Time               `json:",omitempty"`
+	Classification *FailureClassification  `json:",omitempty"` // Parsed from FAILURE_CLASSIFICATION: JSON output
 }

--- a/tests/e2e/scripts/run_e2e_tests.sh
+++ b/tests/e2e/scripts/run_e2e_tests.sh
@@ -85,15 +85,61 @@ validate_namespace E2E_TEST_DSC_MONITORING_NAMESPACE
 : "${E2E_TEST_TAG:=All}"
 validate_tag E2E_TEST_TAG
 
-# Run gotestsum with the environment variables and any additional arguments
-exec gotestsum --junitfile-project-name odh-operator-e2e \
-  --junitfile results/xunit_report.xml --format testname --raw-command \
-  -- test2json -t -p e2e ./e2e-tests --test.v=test2json --test.parallel=8 \
-  --deletion-policy="$E2E_TEST_DELETION_POLICY" --clean-up-previous-resources="$E2E_TEST_CLEAN_UP_PREVIOUS_RESOURCES" \
-  --test-operator-controller="$E2E_TEST_OPERATOR_CONTROLLER" --test-dependant-operators-management="$E2E_TEST_DEPENDANT_OPERATORS_MANAGEMENT" \
-  --test-dsc-management="$E2E_TEST_DSC_MANAGEMENT" --test-operator-resilience="$E2E_TEST_OPERATOR_RESILIENCE" \
-  --test-operator-v2tov3upgrade="$E2E_TEST_OPERATOR_V2TOV3UPGRADE" \
-  --test-webhook="$E2E_TEST_WEBHOOK" --test-components="$E2E_TEST_COMPONENTS" --test-services="$E2E_TEST_SERVICES" \
-  --operator-namespace="$E2E_TEST_OPERATOR_NAMESPACE" --applications-namespace="$E2E_TEST_APPLICATIONS_NAMESPACE" \
-  --workbenches-namespace="$E2E_TEST_WORKBENCHES_NAMESPACE" --dsc-monitoring-namespace="$E2E_TEST_DSC_MONITORING_NAMESPACE" \
-  --tag="$E2E_TEST_TAG" "$@"
+# Toggle for JUnit XML enrichment with failure classification
+: "${USE_TEST_RETRY:=false}"
+validate_bool USE_TEST_RETRY
+
+# Choose test runner based on USE_TEST_RETRY flag
+if [ "$USE_TEST_RETRY" = "true" ] || [ "$USE_TEST_RETRY" = "1" ]; then
+  echo "Using test-retry for JUnit enrichment with failure classification"
+
+  # Run with test-retry (enriched JUnit XML with <properties>)
+  # Note: No --filter flag (uses custom e2e flags like --tag, --test-operator-controller instead)
+  exec test-retry e2e \
+    --command ./e2e-tests \
+    --filter "" \
+    --path /e2e \
+    --max-retries 3 \
+    --junit-output results/xunit_report.xml \
+    --verbose \
+    -- --test.parallel=8 \
+    --deletion-policy="$E2E_TEST_DELETION_POLICY" \
+    --clean-up-previous-resources="$E2E_TEST_CLEAN_UP_PREVIOUS_RESOURCES" \
+    --test-operator-controller="$E2E_TEST_OPERATOR_CONTROLLER" \
+    --test-dependant-operators-management="$E2E_TEST_DEPENDANT_OPERATORS_MANAGEMENT" \
+    --test-dsc-management="$E2E_TEST_DSC_MANAGEMENT" \
+    --test-operator-resilience="$E2E_TEST_OPERATOR_RESILIENCE" \
+    --test-operator-v2tov3upgrade="$E2E_TEST_OPERATOR_V2TOV3UPGRADE" \
+    --test-webhook="$E2E_TEST_WEBHOOK" \
+    --test-components="$E2E_TEST_COMPONENTS" \
+    --test-services="$E2E_TEST_SERVICES" \
+    --operator-namespace="$E2E_TEST_OPERATOR_NAMESPACE" \
+    --applications-namespace="$E2E_TEST_APPLICATIONS_NAMESPACE" \
+    --workbenches-namespace="$E2E_TEST_WORKBENCHES_NAMESPACE" \
+    --dsc-monitoring-namespace="$E2E_TEST_DSC_MONITORING_NAMESPACE" \
+    --tag="$E2E_TEST_TAG" \
+    "$@"
+else
+  echo "Using gotestsum (standard JUnit XML, no enrichment)"
+
+  # Run with gotestsum (existing behavior - DEFAULT)
+  exec gotestsum --junitfile-project-name odh-operator-e2e \
+    --junitfile results/xunit_report.xml --format testname --raw-command \
+    -- test2json -t -p e2e ./e2e-tests --test.v=test2json --test.parallel=8 \
+    --deletion-policy="$E2E_TEST_DELETION_POLICY" \
+    --clean-up-previous-resources="$E2E_TEST_CLEAN_UP_PREVIOUS_RESOURCES" \
+    --test-operator-controller="$E2E_TEST_OPERATOR_CONTROLLER" \
+    --test-dependant-operators-management="$E2E_TEST_DEPENDANT_OPERATORS_MANAGEMENT" \
+    --test-dsc-management="$E2E_TEST_DSC_MANAGEMENT" \
+    --test-operator-resilience="$E2E_TEST_OPERATOR_RESILIENCE" \
+    --test-operator-v2tov3upgrade="$E2E_TEST_OPERATOR_V2TOV3UPGRADE" \
+    --test-webhook="$E2E_TEST_WEBHOOK" \
+    --test-components="$E2E_TEST_COMPONENTS" \
+    --test-services="$E2E_TEST_SERVICES" \
+    --operator-namespace="$E2E_TEST_OPERATOR_NAMESPACE" \
+    --applications-namespace="$E2E_TEST_APPLICATIONS_NAMESPACE" \
+    --workbenches-namespace="$E2E_TEST_WORKBENCHES_NAMESPACE" \
+    --dsc-monitoring-namespace="$E2E_TEST_DSC_MONITORING_NAMESPACE" \
+    --tag="$E2E_TEST_TAG" \
+    "$@"
+fi


### PR DESCRIPTION
## Description

Enriches JUnit XML test results with failure classification metadata using `<properties>` elements. When E2E tests fail, the enriched XML includes structured data about WHY the test failed (infrastructure vs test logic), enabling BigQuery dashboards to distinguish between real test failures and infrastructure issues.
https://redhat.atlassian.net/browse/RHOAIENG-49732 

## How Has This Been Tested?
* Added comprehensive tests for classification parsing and JUnit generation
* Synthetic test with 4 failure scenarios verified all 5 properties generated correctly and confirmed enriched XML output
## Merge criteria

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully
- [ ] New RELATED_IMAGE mappings are already listed in ODH-Build-Config and RHOAI-Build-Config, and links are included in PR description

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
Infrastructure-only change (JUnit enrichment tool). Feature is opt-in with USE_TEST_RETRY=false by default. Comprehensive unit tests added. No changes to operator logic or component behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Test failures now include failure classification metadata in JUnit XML for improved CI/dashboard analysis
  * Added support for running tests via a custom test command
  * Environment toggle to enable the new test-retry workflow for e2e runs

* **Documentation**
  * Added failure classification guidance to test-retry docs

* **Tests**
  * Extended tests covering classification parsing and enriched JUnit output

* **Chores**
  * Test-run tooling included in CI/test image and startup scripts updated accordingly
<!-- end of auto-generated comment: release notes by coderabbit.ai -->