### PR TITLE
Add hardwareProfileTestSuite to Tier3 and fix unnecessary Tier3 decla…

### DIFF
--- a/tests/e2e/v2tov3upgrade_test.go
+++ b/tests/e2e/v2tov3upgrade_test.go
@@ -95,6 +95,8 @@ func v2Tov3UpgradeTestSuite(t *testing.T) {
 func hardwareProfileTestSuite(t *testing.T) {
 	t.Helper()
 
+	skipUnless(t, Tier3)
+
 	tc, err := NewTestContext(t)
 	require.NoError(t, err)
 
@@ -520,8 +522,6 @@ func (tc *V2Tov3UpgradeTestCtx) updateComponentStateInDataScienceCluster(t *test
 // DataScienceCluster v1 resources with Kueue managementState set to "Managed".
 func (tc *V2Tov3UpgradeTestCtx) ValidateDeniesKueueManaged(t *testing.T) {
 	t.Helper()
-
-	skipUnless(t, Tier3)
 
 	// Clean up any existing DataScienceCluster resources before starting
 	cleanupCoreOperatorResources(t, tc.TestContext)


### PR DESCRIPTION
…ration

<!---
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
As a part of #3286 `HardwareProfileV1Alpha1ToV1VersionUpgrade` and `HardwareProfileV1ToV1Alpha1VersionConversion` had their `skipUnless` call removed but it was not put back into their parent `hardwareProfileTestSuite`.

Also, `ValidateDeniesKueueManaged` test didn't have its `skipUnless` removed when moving this config to the parent `v2Tov3UpgradeDeletingDscDsciTestSuite`.

## How Has This Been Tested?
Locally.

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [x] The developer has run the integration test pipeline and verified that it passed successfully
- [ ] New RELATED_IMAGE mappings are already listed in ODH-Build-Config and RHOAI-Build-Config, and links are included in PR description

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [ ] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Modified test execution gates for upgrade validation tests to adjust when specific test cases run across different tier levels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->