### PR TITLE
feat: add cloud manager e2e tests and CI workflow

### DIFF
--- a/.github/workflows/test-cloudmanager-e2e.yaml
+++ b/.github/workflows/test-cloudmanager-e2e.yaml
@@ -1,0 +1,92 @@
+name: Cloud Manager E2E Tests
+on:
+  pull_request_target:
+    types: [opened, labeled, synchronize, reopened]
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+env:
+  IMG: localhost/odh-operator:e2e
+  IMAGE_BUILDER: docker
+
+jobs:
+  cloud-manager-e2e:
+    name: Cloud Manager E2E (${{ matrix.provider }})
+    # Label gate: only runs when a maintainer adds this label, preventing
+    # untrusted fork PRs from executing arbitrary code with repo secrets.
+    if: contains(github.event.pull_request.labels.*.name, 'run-cloudmanager-e2e')
+    runs-on: ubuntu-latest
+    env:
+      KIND_CLUSTER_NAME: kind-${{ matrix.provider }}
+    strategy:
+      fail-fast: false
+      matrix:
+        provider: [azure, coreweave]
+    steps:
+      - name: Checkout PR code
+        if: ${{ !env.ACT }}
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Set up Go
+        uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
+        with:
+          go-version-file: go.mod
+
+      - name: Prepare kind config with pull credentials
+        if: env.PULL_SECRET != ''
+        env:
+          PULL_SECRET: ${{ secrets.CCM_PULL_SECRET }}
+        run: |
+          echo "$PULL_SECRET" > "$RUNNER_TEMP/pull-secret.json"
+          echo '{"kind":"Cluster","apiVersion":"kind.x-k8s.io/v1alpha4","nodes":[{"role":"control-plane","extraMounts":[{"containerPath":"/var/lib/kubelet/config.json","hostPath":"'"$RUNNER_TEMP"'/pull-secret.json"}]}]}' \
+            > "$RUNNER_TEMP/kind-config.json"
+          echo "KIND_CONFIG=$RUNNER_TEMP/kind-config.json" >> "$GITHUB_ENV"
+
+      - name: Create kind cluster
+        uses: helm/kind-action@a1b0e391336a6ee6713a0583f8c6240d70863de3 # v1.12.0
+        with:
+          cluster_name: ${{ env.KIND_CLUSTER_NAME }}
+          wait: 120s
+          config: ${{ env.KIND_CONFIG }}
+
+      - name: Build operator image
+        run: make image-build
+
+      - name: Load image into kind
+        run: make image-kind-load
+
+      - name: Deploy cloud manager
+        run: make deploy-ccm-local-${{ matrix.provider }}
+
+      - name: Wait for cloud manager to be ready
+        run: |
+          kubectl rollout status deployment -n opendatahub-cloudmanager-system \
+            -l control-plane=controller-manager \
+            --timeout=120s
+
+      - name: Run e2e tests
+        env:
+          CLOUD_MANAGER_PROVIDER: ${{ matrix.provider }}
+        run: |
+          set -o pipefail
+          make e2e-test-ccm 2>&1 | tee test.log
+
+      - name: Collect operator logs on failure
+        if: failure()
+        run: |
+          kubectl logs -n opendatahub-cloudmanager-system \
+            -l control-plane=controller-manager \
+            --tail=500 || true
+
+      - name: Upload test log
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: test-log-${{ matrix.provider }}
+          path: test.log
+          retention-days: 7

--- a/Makefile
+++ b/Makefile
@@ -375,6 +375,14 @@ image-push: ## Push image with the manager.
 .PHONY: image
 image: image-build image-push ## Build and push image with the manager.
 
+.PHONY: image-kind-load
+image-kind-load:
+	$(IMAGE_BUILDER) save $(IMG) | kind load image-archive /dev/stdin $(if $(KIND_CLUSTER_NAME),--name $(KIND_CLUSTER_NAME))
+
+.PHONY: e2e-test-ccm
+e2e-test-ccm: ## Run cloud manager e2e tests (requires CLOUD_MANAGER_PROVIDER, e.g. azure)
+	go test -v -count=1 -timeout=30m ./tests/e2e/cloudmanager/
+
 ##@ Deployment
 
 ifndef ignore-not-found

--- a/pkg/cluster/gvk/gvk.go
+++ b/pkg/cluster/gvk/gvk.go
@@ -461,6 +461,14 @@ var (
 		Kind:    "WasmPlugin",
 	}
 
+	// sailoperator.io.
+
+	Istio = schema.GroupVersionKind{
+		Group:   "sailoperator.io",
+		Version: "v1",
+		Kind:    "Istio",
+	}
+
 	GatewayConfig = schema.GroupVersionKind{
 		Group:   serviceApi.GroupVersion.Group,
 		Version: serviceApi.GroupVersion.Version,

--- a/tests/e2e/cloudmanager/cloudmanager_test.go
+++ b/tests/e2e/cloudmanager/cloudmanager_test.go
@@ -1,0 +1,376 @@
+package cloudmanager_test
+
+import (
+	"strings"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	ccmapi "github.com/opendatahub-io/opendatahub-operator/v2/api/cloudmanager/common"
+	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/cloudmanager/common"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/metadata/annotations"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/metadata/labels"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/matchers/jq"
+
+	. "github.com/onsi/gomega"
+)
+
+// TestCloudManager_InvalidNameRejected verifies that the CEL validation rule
+// on the CRD rejects CRs with names other than the expected singleton name.
+// This test does not need a CR to be created first.
+func TestCloudManager_InvalidNameRejected(t *testing.T) {
+	wt := tc.NewWithT(t)
+
+	cr := &unstructured.Unstructured{}
+	cr.SetGroupVersionKind(provider.GVK)
+	cr.SetName("wrong-name")
+	cr.Object["spec"] = map[string]any{
+		"dependencies": allManaged(),
+	}
+
+	err := wt.Client().Create(wt.Context(), cr)
+	wt.Expect(err).To(HaveOccurred())
+}
+
+// TestCloudManager runs all cloud manager e2e tests sequentially under a single
+// CR lifecycle. Tests are ordered so that the CR is created once and reused as
+// long as possible, minimizing repeated create/teardown cycles:
+//
+//  1. DeploymentsAvailable — verify initial deploy
+//  2. ReadOnlyValidation  — status, labels, workload checks, self-healing
+//  3. StatusAfterSpecChange — mutates spec but restores to all-Managed
+//  4. UnmanagedNotReconciled — switches cert-manager to Unmanaged
+//  5. GarbageCollectionOnDelete — deletes the CR (must be last)
+func TestCloudManager(t *testing.T) { //nolint:maintidx // sequential subtests sharing one CR lifecycle are clearer inline
+	wt := tc.NewWithT(t)
+
+	cr := newCloudManagerCR(allManaged())
+	wt.Create(cr, k8sEngineCrNn()).Eventually().Should(Not(BeNil()))
+
+	// Safety net: if any test fails before GarbageCollectionOnDelete runs,
+	// clean up the CR so the next local run starts fresh.
+	t.Cleanup(func() {
+		_ = wt.Client().Delete(wt.Context(), newCloudManagerCR(allManaged()))
+	})
+
+	waitForReady(wt)
+
+	// --- 1. DeploymentsAvailable ---
+	// Verifies that dependency namespaces and deployments are created,
+	// with deployments reaching Available status.
+	t.Run("DeploymentsAvailable", func(t *testing.T) {
+		wt := tc.NewWithT(t)
+
+		for _, ns := range common.ManagedNamespaces() {
+			t.Run("namespace/"+ns, func(t *testing.T) {
+				wt := tc.NewWithT(t)
+				wt.Get(gvk.Namespace, types.NamespacedName{Name: ns}).
+					Eventually().
+					Should(Not(BeNil()))
+			})
+		}
+
+		waitForDeploymentsAvailable(wt)
+	})
+
+	// --- 2. ReadOnlyValidation ---
+	// Groups tests that do not mutate the engine CR: status checks, label/annotation
+	// verification, workload validation, and deployment self-healing.
+	t.Run("ReadOnlyValidation", func(t *testing.T) {
+		t.Run("StatusConditions", func(t *testing.T) {
+			t.Run("Ready condition", func(t *testing.T) {
+				wt := tc.NewWithT(t)
+				wt.Get(provider.GVK, k8sEngineCrNn()).Eventually().Should(And(
+					jq.Match(`.status.conditions[] | select(.type == "Ready") | .status == "True"`),
+					jq.Match(`.status.conditions[] | select(.type == "Ready") | has("lastTransitionTime")`),
+				))
+			})
+
+			t.Run("ProvisioningSucceeded condition", func(t *testing.T) {
+				wt := tc.NewWithT(t)
+				wt.Get(provider.GVK, k8sEngineCrNn()).Eventually().Should(And(
+					jq.Match(`.status.conditions[] | select(.type == "ProvisioningSucceeded") | .status == "True"`),
+					jq.Match(`.status.conditions[] | select(.type == "ProvisioningSucceeded") | has("lastTransitionTime")`),
+					jq.Match(`.status.conditions[] | select(.type == "ProvisioningSucceeded") | .observedGeneration > 0`),
+				))
+			})
+
+			t.Run("phase and observedGeneration", func(t *testing.T) {
+				wt := tc.NewWithT(t)
+				wt.Get(provider.GVK, k8sEngineCrNn()).Eventually().Should(And(
+					jq.Match(`.status.phase == "Ready"`),
+					jq.Match(`.status.observedGeneration == .metadata.generation`),
+				))
+			})
+		})
+
+		t.Run("HelmRenderedResources", func(t *testing.T) {
+			partOfValue := strings.ToLower(provider.GVK.Kind)
+
+			for _, dep := range managedDependencyDeployments {
+				t.Run(dep.Name, func(t *testing.T) {
+					wt := tc.NewWithT(t)
+					nn := types.NamespacedName{Name: dep.Name, Namespace: dep.Namespace}
+
+					wt.Get(gvk.Deployment, nn).Eventually().Should(And(
+						jq.Match(`.metadata.labels."%s" == "%s"`, labels.InfrastructurePartOf, partOfValue),
+						jq.Match(`.metadata.annotations."%s" == "%s"`, annotations.InstanceName, provider.InstanceName),
+					))
+				})
+			}
+		})
+
+		t.Run("ServiceAccountsCreated", func(t *testing.T) {
+			for _, dep := range managedDependencyDeployments {
+				t.Run(dep.Name, func(t *testing.T) {
+					wt := tc.NewWithT(t)
+					wt.List(gvk.ServiceAccount,
+						client.InNamespace(dep.Namespace),
+						client.MatchingLabels{labels.InfrastructurePartOf: strings.ToLower(provider.GVK.Kind)},
+					).Eventually().Should(Not(BeEmpty()))
+				})
+			}
+		})
+
+		t.Run("CertManagerIssuesCertificates", func(t *testing.T) {
+			t.Run("selfsigned ClusterIssuer is ready", func(t *testing.T) {
+				wt := tc.NewWithT(t)
+				wt.Get(gvk.CertManagerClusterIssuer, types.NamespacedName{
+					Name: "opendatahub-selfsigned-issuer",
+				}).Eventually().Should(
+					jq.Match(`.status.conditions[] | select(.type == "Ready") | .status == "True"`),
+				)
+			})
+
+			t.Run("root CA Certificate is issued", func(t *testing.T) {
+				wt := tc.NewWithT(t)
+				wt.Get(gvk.CertManagerCertificate, types.NamespacedName{
+					Name: "opendatahub-ca", Namespace: "cert-manager",
+				}).Eventually().Should(
+					jq.Match(`.status.conditions[] | select(.type == "Ready") | .status == "True"`),
+				)
+			})
+
+			t.Run("CA-backed ClusterIssuer is ready", func(t *testing.T) {
+				wt := tc.NewWithT(t)
+				wt.Get(gvk.CertManagerClusterIssuer, types.NamespacedName{
+					Name: "opendatahub-ca-issuer",
+				}).Eventually().Should(
+					jq.Match(`.status.conditions[] | select(.type == "Ready") | .status == "True"`),
+				)
+			})
+
+			t.Run("CA Secret is created", func(t *testing.T) {
+				wt := tc.NewWithT(t)
+				wt.Get(gvk.Secret, types.NamespacedName{
+					Name: "opendatahub-ca", Namespace: "cert-manager",
+				}).Eventually().Should(Not(BeNil()))
+			})
+		})
+
+		t.Run("LWSOperatorFunctional", func(t *testing.T) {
+			t.Run("LeaderWorkerSetOperator CR exists", func(t *testing.T) {
+				wt := tc.NewWithT(t)
+				wt.Get(gvk.LeaderWorkerSetOperatorV1, types.NamespacedName{
+					Name: "cluster",
+				}).Eventually().Should(Not(BeNil()))
+			})
+
+			t.Run("LeaderWorkerSet CRD is installed", func(t *testing.T) {
+				wt := tc.NewWithT(t)
+				wt.Get(gvk.CustomResourceDefinition, types.NamespacedName{
+					Name: "leaderworkersets.leaderworkerset.x-k8s.io",
+				}).Eventually().Should(Not(BeNil()))
+			})
+		})
+
+		t.Run("GatewayAPICRDsInstalled", func(t *testing.T) {
+			gatewayAPICRDs := []string{
+				"backendtlspolicies.gateway.networking.k8s.io",
+				"gatewayclasses.gateway.networking.k8s.io",
+				"gateways.gateway.networking.k8s.io",
+				"grpcroutes.gateway.networking.k8s.io",
+				"httproutes.gateway.networking.k8s.io",
+				"referencegrants.gateway.networking.k8s.io",
+			}
+
+			for _, crdName := range gatewayAPICRDs {
+				t.Run(crdName, func(t *testing.T) {
+					wt := tc.NewWithT(t)
+					wt.Get(gvk.CustomResourceDefinition, types.NamespacedName{
+						Name: crdName,
+					}).Eventually().Should(Not(BeNil()))
+				})
+			}
+		})
+
+		t.Run("SailOperatorFunctional", func(t *testing.T) {
+			t.Run("Istio CR is healthy", func(t *testing.T) {
+				wt := tc.NewWithT(t)
+				wt.Get(gvk.Istio, types.NamespacedName{
+					Name: "default", Namespace: "istio-system",
+				}).Eventually().Should(
+					jq.Match(`.status.conditions[] | select(.type == "Ready") | .status == "True"`),
+				)
+			})
+		})
+
+		// DeploymentSelfHealing: deletes each managed deployment and verifies the
+		// controller recreates it with a new UID. The engine CR itself is not mutated.
+		t.Run("DeploymentSelfHealing", func(t *testing.T) {
+			for _, dep := range managedDependencyDeployments {
+				t.Run(dep.Name, func(t *testing.T) {
+					wt := tc.NewWithT(t)
+					nn := types.NamespacedName{Name: dep.Name, Namespace: dep.Namespace}
+
+					// Capture the original UID before deleting.
+					original := wt.Get(gvk.Deployment, nn).Eventually().Should(Not(BeNil()))
+					originalUID := string(original.GetUID())
+
+					wt.Delete(gvk.Deployment, nn).Eventually().Should(Succeed())
+
+					// The controller should recreate it with a new UID.
+					wt.Get(gvk.Deployment, nn).Eventually().Should(And(
+						jq.Match(`.metadata.uid != "%s"`, originalUID),
+						jq.Match(`.status.conditions[] | select(.type == "Available") | .status == "True"`),
+					))
+				})
+			}
+		})
+	})
+
+	// --- 3. StatusAfterSpecChange ---
+	// Verifies that updating the CR spec triggers re-reconciliation and the
+	// status reflects the new generation. Mutates the spec (Managed→Unmanaged→Managed)
+	// but restores it, so subsequent tests can still use the same CR.
+	t.Run("StatusAfterSpecChange", func(t *testing.T) {
+		wt := tc.NewWithT(t)
+
+		cr := wt.Get(provider.GVK, k8sEngineCrNn()).Eventually().Should(Not(BeNil()))
+		gen1, _, _ := unstructured.NestedInt64(cr.Object, "metadata", "generation")
+
+		// First mutation: switch sailOperator to Unmanaged.
+		wt.Patch(provider.GVK, k8sEngineCrNn(), func(obj *unstructured.Unstructured) error {
+			return unstructured.SetNestedField(
+				obj.Object, string(ccmapi.Unmanaged),
+				"spec", "dependencies", "sailOperator", "managementPolicy",
+			)
+		}).Eventually().Should(Not(BeNil()))
+
+		wt.Get(provider.GVK, k8sEngineCrNn()).Eventually().Should(And(
+			jq.Match(`.metadata.generation > %d`, gen1),
+			jq.Match(`.status.observedGeneration == .metadata.generation`),
+			jq.Match(`.status.phase == "Ready"`),
+		))
+
+		// Second mutation: switch it back to Managed.
+		cr = wt.Get(provider.GVK, k8sEngineCrNn()).Eventually().Should(Not(BeNil()))
+		gen2, _, _ := unstructured.NestedInt64(cr.Object, "metadata", "generation")
+
+		wt.Patch(provider.GVK, k8sEngineCrNn(), func(obj *unstructured.Unstructured) error {
+			return unstructured.SetNestedField(
+				obj.Object, string(ccmapi.Managed),
+				"spec", "dependencies", "sailOperator", "managementPolicy",
+			)
+		}).Eventually().Should(Not(BeNil()))
+
+		wt.Get(provider.GVK, k8sEngineCrNn()).Eventually().Should(And(
+			jq.Match(`.metadata.generation > %d`, gen2),
+			jq.Match(`.status.observedGeneration == .metadata.generation`),
+			jq.Match(`.status.phase == "Ready"`),
+		))
+	})
+
+	// --- 4. UnmanagedNotReconciled ---
+	// Switches cert-manager to Unmanaged, then deletes its deployment and
+	// verifies the controller does NOT recreate it. Leaves the CR modified.
+	t.Run("UnmanagedNotReconciled", func(t *testing.T) {
+		wt := tc.NewWithT(t)
+
+		cr := wt.Get(provider.GVK, k8sEngineCrNn()).Eventually().Should(Not(BeNil()))
+		gen, _, _ := unstructured.NestedInt64(cr.Object, "metadata", "generation")
+
+		wt.Patch(provider.GVK, k8sEngineCrNn(), func(obj *unstructured.Unstructured) error {
+			return unstructured.SetNestedField(
+				obj.Object, string(ccmapi.Unmanaged),
+				"spec", "dependencies", "certManager", "managementPolicy",
+			)
+		}).Eventually().Should(Not(BeNil()))
+
+		wt.Get(provider.GVK, k8sEngineCrNn()).Eventually().Should(And(
+			jq.Match(`.metadata.generation > %d`, gen),
+			jq.Match(`.status.observedGeneration == .metadata.generation`),
+			jq.Match(`.status.phase == "Ready"`),
+		))
+
+		// Delete the cert-manager deployment.
+		target := managedDependencyDeployments[0]
+		wt.Expect(target.Name).To(ContainSubstring("cert-manager"), "expected first managed deployment to be cert-manager")
+		nn := types.NamespacedName{Name: target.Name, Namespace: target.Namespace}
+		wt.Delete(gvk.Deployment, nn).Eventually().Should(Succeed())
+		wt.Get(gvk.Deployment, nn).Eventually().Should(BeNil())
+
+		// It should NOT come back — the controller is no longer managing it.
+		consistentlyGone(wt, nn)
+
+		// The other deployments should still be running.
+		for _, dep := range managedDependencyDeployments[1:] {
+			wt.Get(gvk.Deployment, types.NamespacedName{
+				Name: dep.Name, Namespace: dep.Namespace,
+			}).Eventually().Should(Not(BeNil()))
+		}
+	})
+
+	// --- 5. GarbageCollectionOnDelete ---
+	// Deletes the CR and verifies all owned resources are cleaned up.
+	// Must be the last test since it destroys the CR.
+	t.Run("GarbageCollectionOnDelete", func(t *testing.T) {
+		wt := tc.NewWithT(t)
+
+		// Restore all dependencies to Managed (previous tests may have changed
+		// some to Unmanaged) and wait for all deployments to come back.
+		wt.Patch(provider.GVK, k8sEngineCrNn(), func(obj *unstructured.Unstructured) error {
+			return unstructured.SetNestedField(obj.Object, allManaged(), "spec", "dependencies")
+		}).Eventually().Should(Not(BeNil()))
+
+		waitForReady(wt)
+		waitForDeploymentsAvailable(wt)
+
+		// Verify deployments have owner references pointing to the CR.
+		for _, dep := range managedDependencyDeployments {
+			wt.Get(gvk.Deployment, types.NamespacedName{
+				Name: dep.Name, Namespace: dep.Namespace,
+			}).Eventually().Should(
+				jq.Match(`.metadata.ownerReferences | length > 0`),
+			)
+		}
+
+		// Verify namespaces have owner references pointing to the CR.
+		for _, ns := range common.ManagedNamespaces() {
+			wt.Get(gvk.Namespace, types.NamespacedName{Name: ns}).
+				Eventually().Should(
+				jq.Match(`.metadata.ownerReferences | length > 0`),
+			)
+		}
+
+		// Delete the CR.
+		wt.Delete(provider.GVK, k8sEngineCrNn()).Eventually().Should(Succeed())
+		wt.Get(provider.GVK, k8sEngineCrNn()).Eventually().Should(BeNil())
+
+		// All owned deployments should be garbage-collected.
+		for _, dep := range managedDependencyDeployments {
+			wt.Get(gvk.Deployment, types.NamespacedName{
+				Name: dep.Name, Namespace: dep.Namespace,
+			}).Eventually().Should(BeNil())
+		}
+
+		// All owned namespaces should be garbage-collected.
+		for _, ns := range common.ManagedNamespaces() {
+			wt.Get(gvk.Namespace, types.NamespacedName{Name: ns}).
+				Eventually().Should(BeNil())
+		}
+	})
+}

--- a/tests/e2e/cloudmanager/helper_test.go
+++ b/tests/e2e/cloudmanager/helper_test.go
@@ -1,0 +1,79 @@
+package cloudmanager_test
+
+import (
+	"time"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
+
+	ccmapi "github.com/opendatahub-io/opendatahub-operator/v2/api/cloudmanager/common"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/matchers/jq"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/testf"
+
+	. "github.com/onsi/gomega"
+)
+
+type deploymentRef struct {
+	Name      string
+	Namespace string
+}
+
+var managedDependencyDeployments = []deploymentRef{
+	{Name: "cert-manager-operator-controller-manager", Namespace: "cert-manager-operator"},
+	{Name: "openshift-lws-operator", Namespace: "openshift-lws-operator"},
+	{Name: "servicemesh-operator3", Namespace: "istio-system"},
+}
+
+func newCloudManagerCR(deps map[string]any) *unstructured.Unstructured {
+	obj := &unstructured.Unstructured{}
+	obj.SetGroupVersionKind(provider.GVK)
+	obj.SetName(provider.InstanceName)
+	obj.Object["spec"] = map[string]any{
+		"dependencies": deps,
+	}
+	return obj
+}
+
+func allManaged() map[string]any {
+	managed := string(ccmapi.Managed)
+	return map[string]any{
+		"certManager":  map[string]any{"managementPolicy": managed},
+		"lws":          map[string]any{"managementPolicy": managed},
+		"sailOperator": map[string]any{"managementPolicy": managed},
+		"gatewayAPI":   map[string]any{"managementPolicy": managed},
+	}
+}
+
+func k8sEngineCrNn() types.NamespacedName {
+	return types.NamespacedName{Name: provider.InstanceName}
+}
+
+// waitForReady waits until the CR has Ready=True in its status conditions.
+func waitForReady(wt *testf.WithT) {
+	wt.Get(provider.GVK, k8sEngineCrNn()).Eventually().Should(
+		jq.Match(`.status.conditions[] | select(.type == "Ready") | .status == "True"`),
+	)
+}
+
+// waitForDeploymentsAvailable waits until all managed dependency deployments
+// have the Available=True condition, meaning they're actually running.
+func waitForDeploymentsAvailable(wt *testf.WithT) {
+	for _, dep := range managedDependencyDeployments {
+		wt.Get(gvk.Deployment, types.NamespacedName{
+			Name: dep.Name, Namespace: dep.Namespace,
+		}).Eventually().Should(
+			jq.Match(`.status.conditions[] | select(.type == "Available") | .status == "True"`),
+		)
+	}
+}
+
+// consistentlyGone asserts that a deployment stays absent for a reasonable duration,
+// confirming the controller is not recreating it.
+func consistentlyGone(wt *testf.WithT, nn types.NamespacedName) {
+	wt.Get(gvk.Deployment, nn).
+		Consistently().
+		WithTimeout(30 * time.Second).
+		WithPolling(5 * time.Second).
+		Should(BeNil())
+}

--- a/tests/e2e/cloudmanager/provider_test.go
+++ b/tests/e2e/cloudmanager/provider_test.go
@@ -1,0 +1,28 @@
+package cloudmanager_test
+
+import (
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	azurev1alpha1 "github.com/opendatahub-io/opendatahub-operator/v2/api/cloudmanager/azure/v1alpha1"
+	coreweavev1alpha1 "github.com/opendatahub-io/opendatahub-operator/v2/api/cloudmanager/coreweave/v1alpha1"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
+)
+
+type ProviderConfig struct {
+	Name         string
+	GVK          schema.GroupVersionKind
+	InstanceName string
+}
+
+var providers = map[string]ProviderConfig{
+	"azure": {
+		Name:         "azure",
+		GVK:          gvk.AzureKubernetesEngine,
+		InstanceName: azurev1alpha1.AzureKubernetesEngineInstanceName,
+	},
+	"coreweave": {
+		Name:         "coreweave",
+		GVK:          gvk.CoreWeaveKubernetesEngine,
+		InstanceName: coreweavev1alpha1.CoreWeaveKubernetesEngineInstanceName,
+	},
+}

--- a/tests/e2e/cloudmanager/suite_test.go
+++ b/tests/e2e/cloudmanager/suite_test.go
@@ -1,0 +1,107 @@
+package cloudmanager_test
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	k8serr "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/testf"
+)
+
+const rhaiOperatorNamespace = "opendatahub-operator-system"
+
+var (
+	tc       *testf.TestContext
+	provider ProviderConfig
+)
+
+func TestMain(m *testing.M) {
+	providerName := os.Getenv("CLOUD_MANAGER_PROVIDER")
+	if providerName == "" {
+		fmt.Println("CLOUD_MANAGER_PROVIDER not set, skipping cloud manager e2e tests")
+		os.Exit(0)
+	}
+
+	p, ok := providers[providerName]
+	if !ok {
+		valid := make([]string, 0, len(providers))
+		for _, v := range providers {
+			valid = append(valid, v.Name)
+		}
+		fmt.Fprintf(os.Stderr, "unknown CLOUD_MANAGER_PROVIDER %q (valid: %v)\n", providerName, strings.Join(valid, ", "))
+		os.Exit(1)
+	}
+	provider = p
+
+	var err error
+	tc, err = testf.NewTestContext(
+		testf.WithTOptions(
+			testf.WithEventuallyTimeout(5*time.Minute),
+			testf.WithEventuallyPollingInterval(2*time.Second),
+		),
+	)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to create test context: %v\n", err)
+		os.Exit(1)
+	}
+
+	if err := preflightCheck(); err != nil {
+		fmt.Fprintf(os.Stderr, "preflight check failed: %v\n", err)
+		os.Exit(1)
+	}
+
+	// precreate operator ns (would be created by helm chart, but we are installing directly)
+	operatorNs := &unstructured.Unstructured{}
+	operatorNs.SetGroupVersionKind(gvk.Namespace)
+	operatorNs.SetName(rhaiOperatorNamespace)
+	if err := tc.Client().Create(tc.Context(), operatorNs); err != nil && !k8serr.IsAlreadyExists(err) {
+		fmt.Fprintf(os.Stderr, "failed to create operator namespace: %v\n", err)
+		os.Exit(1)
+	}
+
+	os.Exit(m.Run())
+}
+
+// preflightCheck verifies that the cloud manager CRD is installed on the cluster.
+// This distinguishes "cloud manager not deployed" from actual test failures.
+func preflightCheck() error {
+	crdName := strings.ToLower(provider.GVK.Kind) + "s." + provider.GVK.Group
+
+	crd := &unstructured.Unstructured{}
+	crd.SetGroupVersionKind(gvk.CustomResourceDefinition)
+
+	err := tc.Client().Get(tc.Context(), types.NamespacedName{Name: crdName}, crd)
+	if err != nil {
+		return fmt.Errorf(
+			"CRD %q not found — is the cloud manager deployed?\n\n"+
+				"  The e2e tests expect the cloud manager operator to be running on the cluster.\n"+
+				"  Deploy it first, then re-run the tests.\n\n"+
+				"  Error: %w", crdName, err,
+		)
+	}
+
+	// Fail if a leftover CR exists from a previous run.
+	existing := &unstructured.Unstructured{}
+	existing.SetGroupVersionKind(provider.GVK)
+
+	nn := types.NamespacedName{Name: provider.InstanceName}
+	err = tc.Client().Get(tc.Context(), nn, existing)
+
+	switch {
+	case k8serr.IsNotFound(err):
+		// clean slate
+	case err != nil:
+		return fmt.Errorf("failed to check for leftover CR %q: %w", provider.InstanceName, err)
+	default:
+		return fmt.Errorf("leftover %s %q exists — delete it before running the tests", provider.GVK.Kind, provider.InstanceName)
+	}
+
+	return nil
+}


### PR DESCRIPTION
## Description
Add end-to-end test suite for the cloud manager operator covering deployment lifecycle, garbage collection, self-healing, status conditions, Helm metadata, and workload validation (cert-manager, LWS, sail-operator).

Add pull_request_target GitHub Action that runs the e2e tests on a kind cluster with matrix strategy for azure and coreweave providers, gated behind a `run-cloudmanager-e2e` label for fork PR security.


## How Has This Been Tested?
* ran both azure and coreweave tests locally on latest main
* ran the github action locally using `act`.

## Screenshot or short clip
N/A

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [x] The developer has run the integration test pipeline and verified that it passed successfully
- [x] New RELATED_IMAGE mappings are already listed in ODH-Build-Config and RHOAI-Build-Config, and links are included in PR description

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [ ] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a comprehensive CloudManager end-to-end test suite covering deployment availability, self-healing, garbage collection on delete, unmanaged dependency behavior, CRD validation, status reporting, Helm-rendered metadata, namespace/resource creation, spec-change handling, certificate issuance, Gateway API/operator presence, and other functional workload checks.

* **Chores**
  * Added an opt-in, label-gated CI workflow with a multi-provider matrix to run CloudManager E2E tests, collect logs, and upload per-provider artifacts.
  * Added Make targets to load built images into local clusters, run the CloudManager E2E tests, and restart the controller deployment.

* **New Features**
  * Introduced an Istio GroupVersionKind constant for use in tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->