### PR TITLE
chore: upgrade odh-gitops sha and rhaii docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ and configure these applications.
     - [Supported Providers](#supported-providers)
     - [CCM Deployment](#ccm-deployment)
   - [RHAII Mode](#rhaii-mode)
+    - [Prerequisites](#prerequisites-1)
     - [Supported Providers](#supported-providers-1)
     - [RHAII Deployment](#rhaii-deployment)
   - [Test with customized manifests](#test-with-customized-manifests)
@@ -508,6 +509,13 @@ spec:
 RHAII (Red Hat AI Inference) is a deployment mode that runs a subset of the operator focused exclusively on **KServe**. This is useful when you only need model serving capabilities without the full Open Data Hub stack.
 
 In RHAII mode, the operator deploys only the KServe component CRD and its associated webhooks (connection-isvc and connection-llmisvc mutation webhooks).
+
+#### Prerequisites
+
+RHAII mode requires **cert-manager** to be available in the cluster. This dependency can be satisfied in one of two ways:
+
+1. **`CoreWeaveKubernetesEngine` CR**: Deploy the appropriate Cloud Manager (Azure or CoreWeave) and create the corresponding `AzureKubernetesEngine` or `CoreWeaveKubernetesEngine` CR with `certManager.managementPolicy: Managed`. The Cloud Manager will install and manage cert-manager automatically along with other dependencies. To deploy a Cloud Manager, see [CCM Deployment](#ccm-deployment).
+2. **Installing cert-manager manually**: Install cert-manager directly in the cluster before deploying the RHAII operator.
 
 #### Supported Providers
 

--- a/get_all_manifests.sh
+++ b/get_all_manifests.sh
@@ -63,10 +63,10 @@ declare -A RHOAI_COMPONENT_MANIFESTS=(
 
 # ODH Component Charts
 declare -A ODH_COMPONENT_CHARTS=(
-    ["cert-manager-operator"]="opendatahub-io:odh-gitops:main@9587eccb5310d4bee6a56515a8dee7b6e186ba46:charts/dependencies/cert-manager-operator"
-    ["lws-operator"]="opendatahub-io:odh-gitops:main@9587eccb5310d4bee6a56515a8dee7b6e186ba46:charts/dependencies/lws-operator"
-    ["sail-operator"]="opendatahub-io:odh-gitops:main@9587eccb5310d4bee6a56515a8dee7b6e186ba46:charts/dependencies/sail-operator"
-    ["gateway-api"]="opendatahub-io:odh-gitops:main@9587eccb5310d4bee6a56515a8dee7b6e186ba46:charts/dependencies/gateway-api"
+    ["cert-manager-operator"]="opendatahub-io:odh-gitops:main@6b5e24e3d1713375e8a944730134e99ca51d1052:charts/dependencies/cert-manager-operator"
+    ["lws-operator"]="opendatahub-io:odh-gitops:main@6b5e24e3d1713375e8a944730134e99ca51d1052:charts/dependencies/lws-operator"
+    ["sail-operator"]="opendatahub-io:odh-gitops:main@6b5e24e3d1713375e8a944730134e99ca51d1052:charts/dependencies/sail-operator"
+    ["gateway-api"]="opendatahub-io:odh-gitops:main@6b5e24e3d1713375e8a944730134e99ca51d1052:charts/dependencies/gateway-api"
 )
 
 # RHOAI Component Charts


### PR DESCRIPTION
<!---
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
Upgrade odh-gitops commit sha and RHAII installation docs

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [x] The developer has run the integration test pipeline and verified that it passed successfully
- [x] New RELATED_IMAGE mappings are already listed in ODH-Build-Config and RHOAI-Build-Config, and links are included in PR description

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [ ] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a RHAII Mode "Prerequisites" subsection describing cert-manager requirements and two supported setup paths (Cloud Manager–managed or manual). Fixed the Release Workflow Guide ending to include a trailing newline.

* **Chores**
  * Updated component chart source pins for cert-manager-operator, lws-operator, sail-operator, and gateway-api.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->