### PR TITLE
RHOAIENG-37563 | fix: BugBash-Deploy cache should be able to handle the fact that an object has 2 owners

### DIFF
--- a/pkg/controller/actions/deploy/action_deploy.go
+++ b/pkg/controller/actions/deploy/action_deploy.go
@@ -337,6 +337,11 @@ func (a *Action) deploy(
 	default:
 		owned := a.shouldOwn(rr, obj.GroupVersionKind())
 		if owned {
+			// Clear any template-defined ownerReferences before setting the
+			// controller reference. For resource types declared in Owns(), the
+			// deploy action is the single source of truth for ownership.
+			obj.SetOwnerReferences(nil)
+
 			if err := ctrl.SetControllerReference(rr.Instance, &obj, rr.Client.Scheme()); err != nil {
 				return false, err
 			}

--- a/pkg/controller/actions/deploy/action_deploy_support.go
+++ b/pkg/controller/actions/deploy/action_deploy_support.go
@@ -29,7 +29,7 @@ func ownedTypeIsNot(ownerType *schema.GroupVersionKind) func(or metav1.OwnerRefe
 
 	gv := ownerType.GroupVersion().String()
 	return func(or metav1.OwnerReference) bool {
-		return ownerType.Kind != or.Kind && gv != or.APIVersion
+		return ownerType.Kind != or.Kind || gv != or.APIVersion
 	}
 }
 

--- a/pkg/controller/actions/deploy/action_deploy_support_test.go
+++ b/pkg/controller/actions/deploy/action_deploy_support_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/onsi/gomega/types"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
 
@@ -78,4 +79,76 @@ func TestIsLegacyOwnerRef(t *testing.T) {
 			g.Expect(result).To(tt.matcher)
 		})
 	}
+}
+
+func TestOwnedTypeIsNot(t *testing.T) {
+	t.Parallel()
+
+	g := NewWithT(t)
+
+	ownerGVK := schema.GroupVersionKind{
+		Group:   "services.platform.opendatahub.io",
+		Version: "v1alpha1",
+		Kind:    "Monitoring",
+	}
+
+	tests := []struct {
+		name     string
+		ownerRef metav1.OwnerReference
+		matcher  types.GomegaMatcher
+	}{
+		{
+			name: "same kind and apiVersion → not removed",
+			ownerRef: metav1.OwnerReference{
+				APIVersion: ownerGVK.GroupVersion().String(),
+				Kind:       ownerGVK.Kind,
+			},
+			matcher: BeFalse(),
+		},
+		{
+			name: "different kind and different apiVersion → removed",
+			ownerRef: metav1.OwnerReference{
+				APIVersion: gvk.DataScienceCluster.GroupVersion().String(),
+				Kind:       gvk.DataScienceCluster.Kind,
+			},
+			matcher: BeTrue(),
+		},
+		{
+			name: "same apiVersion but different kind → removed",
+			ownerRef: metav1.OwnerReference{
+				APIVersion: ownerGVK.GroupVersion().String(),
+				Kind:       "OtherService",
+			},
+			matcher: BeTrue(),
+		},
+		{
+			name: "different apiVersion but same kind → removed",
+			ownerRef: metav1.OwnerReference{
+				APIVersion: "other.group/v1",
+				Kind:       ownerGVK.Kind,
+			},
+			matcher: BeTrue(),
+		},
+	}
+
+	predicate := ownedTypeIsNot(&ownerGVK)
+
+	for i := range tests {
+		tt := tests[i]
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			g.Expect(predicate(tt.ownerRef)).To(tt.matcher)
+		})
+	}
+}
+
+func TestOwnedTypeIsNotNilReturnsAlwaysFalse(t *testing.T) {
+	t.Parallel()
+	g := NewWithT(t)
+
+	predicate := ownedTypeIsNot(nil)
+	g.Expect(predicate(metav1.OwnerReference{
+		APIVersion: "v1",
+		Kind:       "ConfigMap",
+	})).To(BeFalse())
 }

--- a/pkg/controller/actions/deploy/action_deploy_test.go
+++ b/pkg/controller/actions/deploy/action_deploy_test.go
@@ -1139,6 +1139,83 @@ func TestDeployDynamicOwnership_FallsBackToStaticOwnership(t *testing.T) {
 	g.Expect(sec.GetOwnerReferences()).Should(BeEmpty(), "Non-owned GVK should not have owner reference")
 }
 
+func TestDeployStripsTemplateOwnerReferences(t *testing.T) {
+	g := NewWithT(t)
+
+	ctx := t.Context()
+	ns := xid.New().String()
+
+	cl, err := fakeclient.New()
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	err = cl.Create(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}})
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	instance := &componentApi.Dashboard{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       componentApi.DashboardInstanceName,
+			UID:        "test-uid-12345",
+			Generation: 1,
+		},
+	}
+	instance.SetGroupVersionKind(gvk.Dashboard)
+
+	// Simulate a template-rendered ConfigMap that already has ownerReferences
+	templateOwnerRef := metav1.OwnerReference{
+		APIVersion: gvk.Dashboard.GroupVersion().String(),
+		Kind:       gvk.Dashboard.Kind,
+		Name:       instance.Name,
+		UID:        instance.UID,
+	}
+
+	configMap, err := resources.ToUnstructured(&corev1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: corev1.SchemeGroupVersion.String(),
+			Kind:       "ConfigMap",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "test-cm",
+			Namespace:       ns,
+			OwnerReferences: []metav1.OwnerReference{templateOwnerRef},
+		},
+	})
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	rr := types.ReconciliationRequest{
+		Client:   cl,
+		Instance: instance,
+		Release: common.Release{
+			Name: cluster.OpenDataHub,
+			Version: version.OperatorVersion{Version: semver.Version{
+				Major: 1, Minor: 2, Patch: 3,
+			}},
+		},
+		Resources: []unstructured.Unstructured{*configMap},
+		Controller: mocks.NewMockController(func(m *mocks.MockController) {
+			m.On("Owns", gvk.ConfigMap).Return(true)
+		}),
+	}
+
+	action := deploy.NewAction(deploy.WithMode(deploy.ModePatch))
+	err = action(ctx, &rr)
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	cm := resources.GvkToUnstructured(gvk.ConfigMap)
+	err = cl.Get(ctx, apimachinery.NamespacedName{Namespace: ns, Name: "test-cm"}, cm)
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	// Verify exactly one ownerReference set by SetControllerReference
+	// (with controller=true), NOT the template-defined one (without controller field).
+	ownerRefs := cm.GetOwnerReferences()
+	g.Expect(ownerRefs).Should(HaveLen(1))
+	g.Expect(ownerRefs[0].Kind).Should(Equal(gvk.Dashboard.Kind))
+	g.Expect(ownerRefs[0].Name).Should(Equal(instance.Name))
+	g.Expect(ownerRefs[0].UID).Should(Equal(instance.UID))
+	g.Expect(*ownerRefs[0].Controller).Should(BeTrue(),
+		"ownerReference should be a controller reference set by SetControllerReference, not a template-defined one")
+	g.Expect(*ownerRefs[0].BlockOwnerDeletion).Should(BeTrue())
+}
+
 func TestDeployDynamicOwnership_CRDsExcludedByDefault(t *testing.T) {
 	g := NewWithT(t)
 


### PR DESCRIPTION


<!---
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->
The monitoring controller enters an infinite reconciliation loop causing API rate limit errors and operator pod crashes.
<!--- Link your JIRA and related links here for reference. -->
https://redhat.atlassian.net/browse/RHOAIENG-37563
## How Has This Been Tested?
Tested via Claude validation - bug bash

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully
- [ ] New RELATED_IMAGE mappings are already listed in ODH-Build-Config and RHOAI-Build-Config, and links are included in PR description

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement --> Non-functional refactoring with existing test coverage
<!--- This section can be left empty if you're not opting out of the E2E requirement -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Deployment now clears and replaces preexisting template owner references so controller-owned resources are correctly attributed.
  * Ownership comparison logic corrected to detect mismatches when either Kind or API version differs.

* **Tests**
  * Added tests ensuring owner-reference replacement during deploy.
  * Added tests verifying ownership type comparison behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->