### PR TITLE
Maas auth polices alignment

### DIFF
--- a/internal/controller/components/modelsasservice/modelsasservice_controller_actions.go
+++ b/internal/controller/components/modelsasservice/modelsasservice_controller_actions.go
@@ -170,6 +170,7 @@ func configureGatewayNamespaceResources(ctx context.Context, rr *types.Reconcili
 		"gatewayName", gatewayName)
 
 	authPolicyFound := false
+	tokenRateLimitDefaultDenyPolicyFound := false
 	destinationRuleFound := false
 
 	for idx := range rr.Resources {
@@ -177,9 +178,15 @@ func configureGatewayNamespaceResources(ctx context.Context, rr *types.Reconcili
 		resourceGVK := resource.GroupVersionKind()
 
 		switch {
-		case resourceGVK == gvk.AuthPolicyv1 && resource.GetName() == GatewayAuthPolicyName:
+		case resourceGVK == gvk.AuthPolicyv1 && resource.GetName() == GatewayDefaultAuthPolicyName:
 			authPolicyFound = true
 			if err := configureAuthPolicy(log, resource, gatewayNamespace, gatewayName); err != nil {
+				return err
+			}
+
+		case resourceGVK == gvk.TokenRateLimitPolicyv1alpha1 && resource.GetName() == GatewayTokenRateLimitDefaultDenyPolicyName:
+			tokenRateLimitDefaultDenyPolicyFound = true
+			if err := configureTokenRateLimitPolicyRule(log, resource, gatewayNamespace, gatewayName); err != nil {
 				return err
 			}
 
@@ -191,8 +198,14 @@ func configureGatewayNamespaceResources(ctx context.Context, rr *types.Reconcili
 
 	if !authPolicyFound {
 		log.V(1).Info("AuthPolicy not found in rendered resources",
-			"expectedName", GatewayAuthPolicyName,
+			"expectedName", GatewayDefaultAuthPolicyName,
 			"expectedGVK", gvk.AuthPolicyv1.String())
+	}
+
+	if !tokenRateLimitDefaultDenyPolicyFound {
+		log.V(1).Info("TokenRateLimitPolicy not found in rendered resources",
+			"expectedName", GatewayTokenRateLimitDefaultDenyPolicyName,
+			"expectedGVK", gvk.TokenRateLimitPolicyv1alpha1.String())
 	}
 
 	if !destinationRuleFound {
@@ -344,6 +357,23 @@ func patchAuthPolicyWithOIDC(log logr.Logger, resource *unstructured.Unstructure
 
 	log.Info("Patched maas-api AuthPolicy with external OIDC configuration",
 		"issuerUrl", oidc.IssuerURL, "clientId", oidc.ClientID)
+
+	return nil
+}
+
+func configureTokenRateLimitPolicyRule(log logr.Logger, resource *unstructured.Unstructured, gatewayNamespace string, gatewayName string) error {
+	log.V(4).Info("Configuring TokenRateLimitPolicy",
+		"name", resource.GetName(),
+		"originalNamespace", resource.GetNamespace(),
+		"newNamespace", gatewayNamespace,
+		"newTargetGateway", gatewayName)
+
+	resource.SetNamespace(gatewayNamespace)
+
+	if err := unstructured.SetNestedField(resource.Object, gatewayName, "spec", "targetRef", "name"); err != nil {
+		return fmt.Errorf("failed to set spec.targetRef.name on TokenRateLimitPolicy: %w", err)
+	}
+
 	return nil
 }
 

--- a/internal/controller/components/modelsasservice/modelsasservice_controller_actions_test.go
+++ b/internal/controller/components/modelsasservice/modelsasservice_controller_actions_test.go
@@ -200,7 +200,7 @@ func TestConfigureGatewayNamespaceResources(t *testing.T) {
 				},
 			}
 
-			authPolicy := createAuthPolicy(GatewayAuthPolicyName, "wrong-namespace", "old-gateway")
+			authPolicy := createAuthPolicy(GatewayDefaultAuthPolicyName, "wrong-namespace", "old-gateway")
 
 			rr := &types.ReconciliationRequest{
 				Instance:  maas,
@@ -291,7 +291,7 @@ func TestConfigureGatewayNamespaceResources(t *testing.T) {
 			}
 
 			// Mix of resources
-			gatewayAuthPolicy := createAuthPolicy(GatewayAuthPolicyName, "old-namespace", "old-gateway")
+			gatewayAuthPolicy := createAuthPolicy(GatewayDefaultAuthPolicyName, "old-namespace", "old-gateway")
 			otherAuthPolicy := createAuthPolicy("other-policy", "keep-namespace", "keep-gateway")
 			configMap := &unstructured.Unstructured{}
 			configMap.SetAPIVersion("v1")
@@ -393,7 +393,7 @@ func TestConfigureGatewayNamespaceResources(t *testing.T) {
 				},
 			}
 
-			authPolicy := createAuthPolicy(GatewayAuthPolicyName, "old-namespace", "old-gateway")
+			authPolicy := createAuthPolicy(GatewayDefaultAuthPolicyName, "old-namespace", "old-gateway")
 			destinationRule := createDestinationRule(GatewayDestinationRuleName, "old-namespace")
 			configMap := &unstructured.Unstructured{}
 			configMap.SetAPIVersion("v1")
@@ -1498,7 +1498,7 @@ func TestConfigureExternalOIDC(t *testing.T) {
 			},
 		}
 
-		gatewayPolicy := createAuthPolicy(GatewayAuthPolicyName, "openshift-ingress", "gateway")
+		gatewayPolicy := createAuthPolicy(GatewayDefaultAuthPolicyName, "openshift-ingress", "gateway")
 		maasAPIPolicy := createAuthPolicy(MaaSAPIAuthPolicyName, "opendatahub", "maas-api-route")
 
 		rr := &types.ReconciliationRequest{

--- a/internal/controller/components/modelsasservice/modelsasservice_controller_actions_test.go
+++ b/internal/controller/components/modelsasservice/modelsasservice_controller_actions_test.go
@@ -183,41 +183,84 @@ func TestGatewayValidation(t *testing.T) {
 	})
 }
 
+// testPolicyUpdate is a helper function to test policy namespace and targetRef updates.
+func testPolicyUpdate(t *testing.T, g *WithT, policyName string, createFunc func(name, namespace, gateway string) unstructured.Unstructured) {
+	t.Helper()
+
+	maas := &componentApi.ModelsAsService{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: componentApi.ModelsAsServiceInstanceName,
+		},
+		Spec: componentApi.ModelsAsServiceSpec{
+			GatewayRef: componentApi.GatewayRef{
+				Namespace: "custom-gateway-ns",
+				Name:      "custom-gateway",
+			},
+		},
+	}
+
+	policy := createFunc(policyName, "wrong-namespace", "old-gateway")
+
+	rr := &types.ReconciliationRequest{
+		Instance:  maas,
+		Resources: []unstructured.Unstructured{policy},
+	}
+
+	err := configureGatewayNamespaceResources(t.Context(), rr)
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	// Verify namespace was updated
+	g.Expect(rr.Resources[0].GetNamespace()).Should(Equal("custom-gateway-ns"))
+
+	// Verify targetRef.name was updated
+	targetRefName, found, err := unstructured.NestedString(rr.Resources[0].Object, "spec", "targetRef", "name")
+	g.Expect(err).ShouldNot(HaveOccurred())
+	g.Expect(found).Should(BeTrue())
+	g.Expect(targetRefName).Should(Equal("custom-gateway"))
+}
+
+// testPolicyNoModify is a helper function to test that policies with different names are not modified.
+func testPolicyNoModify(t *testing.T, g *WithT, createFunc func(name, namespace, gateway string) unstructured.Unstructured) {
+	t.Helper()
+
+	maas := &componentApi.ModelsAsService{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: componentApi.ModelsAsServiceInstanceName,
+		},
+		Spec: componentApi.ModelsAsServiceSpec{
+			GatewayRef: componentApi.GatewayRef{
+				Namespace: "custom-gateway-ns",
+				Name:      "custom-gateway",
+			},
+		},
+	}
+
+	otherPolicy := createFunc("other-policy", "original-namespace", "original-gateway")
+
+	rr := &types.ReconciliationRequest{
+		Instance:  maas,
+		Resources: []unstructured.Unstructured{otherPolicy},
+	}
+
+	err := configureGatewayNamespaceResources(t.Context(), rr)
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	// Verify namespace was NOT updated
+	g.Expect(rr.Resources[0].GetNamespace()).Should(Equal("original-namespace"))
+
+	// Verify targetRef.name was NOT updated
+	targetRefName, found, err := unstructured.NestedString(rr.Resources[0].Object, "spec", "targetRef", "name")
+	g.Expect(err).ShouldNot(HaveOccurred())
+	g.Expect(found).Should(BeTrue())
+	g.Expect(targetRefName).Should(Equal("original-gateway"))
+}
+
 func TestConfigureGatewayNamespaceResources(t *testing.T) {
 	g := NewWithT(t)
 
 	t.Run("Configure Gateway AuthPolicy", func(t *testing.T) {
 		t.Run("should update AuthPolicy namespace and targetRef when found", func(t *testing.T) {
-			maas := &componentApi.ModelsAsService{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: componentApi.ModelsAsServiceInstanceName,
-				},
-				Spec: componentApi.ModelsAsServiceSpec{
-					GatewayRef: componentApi.GatewayRef{
-						Namespace: "custom-gateway-ns",
-						Name:      "custom-gateway",
-					},
-				},
-			}
-
-			authPolicy := createAuthPolicy(GatewayDefaultAuthPolicyName, "wrong-namespace", "old-gateway")
-
-			rr := &types.ReconciliationRequest{
-				Instance:  maas,
-				Resources: []unstructured.Unstructured{authPolicy},
-			}
-
-			err := configureGatewayNamespaceResources(t.Context(), rr)
-			g.Expect(err).ShouldNot(HaveOccurred())
-
-			// Verify namespace was updated
-			g.Expect(rr.Resources[0].GetNamespace()).Should(Equal("custom-gateway-ns"))
-
-			// Verify targetRef.name was updated
-			targetRefName, found, err := unstructured.NestedString(rr.Resources[0].Object, "spec", "targetRef", "name")
-			g.Expect(err).ShouldNot(HaveOccurred())
-			g.Expect(found).Should(BeTrue())
-			g.Expect(targetRefName).Should(Equal("custom-gateway"))
+			testPolicyUpdate(t, g, GatewayDefaultAuthPolicyName, createAuthPolicy)
 		})
 
 		t.Run("should succeed silently when AuthPolicy is not found in resources", func(t *testing.T) {
@@ -244,37 +287,7 @@ func TestConfigureGatewayNamespaceResources(t *testing.T) {
 		})
 
 		t.Run("should not modify AuthPolicy with different name", func(t *testing.T) {
-			maas := &componentApi.ModelsAsService{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: componentApi.ModelsAsServiceInstanceName,
-				},
-				Spec: componentApi.ModelsAsServiceSpec{
-					GatewayRef: componentApi.GatewayRef{
-						Namespace: "custom-gateway-ns",
-						Name:      "custom-gateway",
-					},
-				},
-			}
-
-			// AuthPolicy with a different name should not be modified
-			otherAuthPolicy := createAuthPolicy("other-auth-policy", "original-namespace", "original-gateway")
-
-			rr := &types.ReconciliationRequest{
-				Instance:  maas,
-				Resources: []unstructured.Unstructured{otherAuthPolicy},
-			}
-
-			err := configureGatewayNamespaceResources(t.Context(), rr)
-			g.Expect(err).ShouldNot(HaveOccurred())
-
-			// Verify namespace was NOT updated
-			g.Expect(rr.Resources[0].GetNamespace()).Should(Equal("original-namespace"))
-
-			// Verify targetRef.name was NOT updated
-			targetRefName, found, err := unstructured.NestedString(rr.Resources[0].Object, "spec", "targetRef", "name")
-			g.Expect(err).ShouldNot(HaveOccurred())
-			g.Expect(found).Should(BeTrue())
-			g.Expect(targetRefName).Should(Equal("original-gateway"))
+			testPolicyNoModify(t, g, createAuthPolicy)
 		})
 
 		t.Run("should only modify matching AuthPolicy when multiple resources present", func(t *testing.T) {
@@ -379,8 +392,18 @@ func TestConfigureGatewayNamespaceResources(t *testing.T) {
 		})
 	})
 
-	t.Run("Configure Both AuthPolicy and DestinationRule", func(t *testing.T) {
-		t.Run("should update both AuthPolicy and DestinationRule namespaces", func(t *testing.T) {
+	t.Run("Configure Gateway TokenRateLimitPolicy", func(t *testing.T) {
+		t.Run("should update TokenRateLimitPolicy namespace and targetRef when found", func(t *testing.T) {
+			testPolicyUpdate(t, g, GatewayTokenRateLimitDefaultDenyPolicyName, createTokenRateLimitPolicy)
+		})
+
+		t.Run("should not modify TokenRateLimitPolicy with different name", func(t *testing.T) {
+			testPolicyNoModify(t, g, createTokenRateLimitPolicy)
+		})
+	})
+
+	t.Run("Configure Multiple Gateway Resources", func(t *testing.T) {
+		t.Run("should update AuthPolicy, TokenRateLimitPolicy, and DestinationRule namespaces", func(t *testing.T) {
 			maas := &componentApi.ModelsAsService{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: componentApi.ModelsAsServiceInstanceName,
@@ -394,6 +417,7 @@ func TestConfigureGatewayNamespaceResources(t *testing.T) {
 			}
 
 			authPolicy := createAuthPolicy(GatewayDefaultAuthPolicyName, "old-namespace", "old-gateway")
+			tokenRateLimitPolicy := createTokenRateLimitPolicy(GatewayTokenRateLimitDefaultDenyPolicyName, "old-namespace", "old-gateway")
 			destinationRule := createDestinationRule(GatewayDestinationRuleName, "old-namespace")
 			configMap := &unstructured.Unstructured{}
 			configMap.SetAPIVersion("v1")
@@ -403,7 +427,7 @@ func TestConfigureGatewayNamespaceResources(t *testing.T) {
 
 			rr := &types.ReconciliationRequest{
 				Instance:  maas,
-				Resources: []unstructured.Unstructured{authPolicy, destinationRule, *configMap},
+				Resources: []unstructured.Unstructured{authPolicy, tokenRateLimitPolicy, destinationRule, *configMap},
 			}
 
 			err := configureGatewayNamespaceResources(t.Context(), rr)
@@ -411,14 +435,19 @@ func TestConfigureGatewayNamespaceResources(t *testing.T) {
 
 			// AuthPolicy should be updated
 			g.Expect(rr.Resources[0].GetNamespace()).Should(Equal("target-gateway-ns"))
-			targetRefName, _, _ := unstructured.NestedString(rr.Resources[0].Object, "spec", "targetRef", "name")
-			g.Expect(targetRefName).Should(Equal("target-gateway"))
+			authTargetRefName, _, _ := unstructured.NestedString(rr.Resources[0].Object, "spec", "targetRef", "name")
+			g.Expect(authTargetRefName).Should(Equal("target-gateway"))
+
+			// TokenRateLimitPolicy should be updated
+			g.Expect(rr.Resources[1].GetNamespace()).Should(Equal("target-gateway-ns"))
+			tokenTargetRefName, _, _ := unstructured.NestedString(rr.Resources[1].Object, "spec", "targetRef", "name")
+			g.Expect(tokenTargetRefName).Should(Equal("target-gateway"))
 
 			// DestinationRule should be updated
-			g.Expect(rr.Resources[1].GetNamespace()).Should(Equal("target-gateway-ns"))
+			g.Expect(rr.Resources[2].GetNamespace()).Should(Equal("target-gateway-ns"))
 
 			// ConfigMap should be unchanged
-			g.Expect(rr.Resources[2].GetNamespace()).Should(Equal("app-namespace"))
+			g.Expect(rr.Resources[3].GetNamespace()).Should(Equal("app-namespace"))
 		})
 	})
 }
@@ -449,6 +478,21 @@ func createDestinationRule(name, namespace string) unstructured.Unstructured {
 	_ = unstructured.SetNestedField(destinationRule.Object, "*.local", "spec", "host")
 
 	return destinationRule
+}
+
+// createTokenRateLimitPolicy creates an unstructured TokenRateLimitPolicy resource for testing.
+func createTokenRateLimitPolicy(name, namespace, targetGatewayName string) unstructured.Unstructured {
+	policy := unstructured.Unstructured{}
+	policy.SetGroupVersionKind(gvk.TokenRateLimitPolicyv1alpha1)
+	policy.SetName(name)
+	policy.SetNamespace(namespace)
+
+	// Set spec.targetRef
+	_ = unstructured.SetNestedField(policy.Object, targetGatewayName, "spec", "targetRef", "name")
+	_ = unstructured.SetNestedField(policy.Object, "Gateway", "spec", "targetRef", "kind")
+	_ = unstructured.SetNestedField(policy.Object, "gateway.networking.k8s.io", "spec", "targetRef", "group")
+
+	return policy
 }
 
 // createFakeClientWithGateway creates a fake client with a Gateway resource.

--- a/internal/controller/components/modelsasservice/modelsasservice_support.go
+++ b/internal/controller/components/modelsasservice/modelsasservice_support.go
@@ -35,10 +35,13 @@ const (
 	// Manifest paths.
 	BaseManifestsSourcePath = "overlays/odh"
 
-	// GatewayAuthPolicyName is the name of the AuthPolicy resource that configures
+	// GatewayDefaultAuthPolicyName is the name of the AuthPolicy resource that configures
 	// authentication for the MaaS gateway. This resource needs to be deployed to
 	// the same namespace as the gateway it targets.
-	GatewayAuthPolicyName = "gateway-auth-policy"
+	GatewayDefaultAuthPolicyName = "gateway-default-auth"
+
+	// Same but for token rate limit.
+	GatewayTokenRateLimitDefaultDenyPolicyName = "gateway-default-deny"
 
 	// MaaSAPIAuthPolicyName is the name of the AuthPolicy that configures
 	// authentication for the maas-api HTTPRoute (API keys, OpenShift, optional OIDC).

--- a/pkg/cluster/gvk/gvk.go
+++ b/pkg/cluster/gvk/gvk.go
@@ -805,6 +805,12 @@ var (
 		Kind:    "AuthPolicy",
 	}
 
+	TokenRateLimitPolicyv1alpha1 = schema.GroupVersionKind{
+		Group:   "kuadrant.io",
+		Version: "v1alpha1",
+		Kind:    "TokenRateLimitPolicy",
+	}
+
 	RateLimitPolicyv1 = schema.GroupVersionKind{
 		Group:   "kuadrant.io",
 		Version: "v1",


### PR DESCRIPTION
## Description
Currently the model as a service component is broken according to the desired manifests seen in the get_all_manifests for maas. This happens because of naming inconsistency and this fixes it.
regards the auth policy from the manifests under the odh overlay from maas repo under /base/maas-controller/policies

[Jira](https://redhat.atlassian.net/browse/RHOAIENG-55189)

## How Has This Been Tested?
Updated tests to include correct naming and the expected not tested TLRP

## Screenshot or short clip
<img width="980" height="393" alt="image" src="https://github.com/user-attachments/assets/b19eb4c0-b41e-46a2-bea6-9a736582fbe2" />

### E2E test suite update requirement

- [x] Skip requirement to update E2E test suite for this PR

#### E2E update requirement opt-out justification:

This PR fixes naming inconsistencies for Kuadrant gateway policies (AuthPolicy and TokenRateLimitPolicy) to align with the actual manifest definitions. The changes are:

1. **Constant renaming**: `GatewayAuthPolicyName` → `GatewayDefaultAuthPolicyName` to match manifest name `gateway-default-auth`
2. **Added TokenRateLimitPolicy support**: Added GVK definition and configuration logic for `gateway-default-deny` TokenRateLimitPolicy, mirroring the existing AuthPolicy pattern
3. **Refactored duplicate test code**: Eliminated code duplication in unit tests using helper functions

**Why E2E updates are not required:**

- The changes are internal implementation details (constant names, configuration logic)
- Comprehensive unit test coverage validates the new TokenRateLimitPolicy configuration logic (73.5% coverage)
- The existing e2e test suite validates component lifecycle via generic methods (`ValidateSubComponentEnabled`, `ValidateOperandsOwnerReferences`) that check for resource creation and owner references
- E2E tests do not explicitly validate individual gateway policy resources (AuthPolicy, TokenRateLimitPolicy, DestinationRule) - they rely on generic resource validation
- Adding specific gateway policy validation to e2e tests is out of scope for this alignment fix


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Gateways now detect and apply a default-deny token rate-limit policy when present to enforce rate-limiting defaults.

* **Updates**
  * Standardized default gateway authentication policy reference for consistent behavior.

* **Bug Fixes**
  * Improved logging and handling so gateway policy application and reporting are more reliable.

* **Tests**
  * Expanded tests to cover token rate-limit policy handling and multi-resource scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->