### PR TITLE
refactor: streamline operator startup sequence with leader election initialization

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -100,14 +100,13 @@ import (
 	sr "github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/services/registry"
 	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/services/setup"
 	"github.com/opendatahub-io/opendatahub-operator/v2/internal/webhook"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/bootstrap"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
-	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/initialinstall"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/logger"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/manager"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/operatorconfig"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/resources"
-	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/upgrade"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/flags"
 )
 
@@ -464,59 +463,25 @@ func main() { //nolint:funlen,maintidx,gocyclo
 		os.Exit(1)
 	}
 
-	// Check if user opted for disabling DSC configuration
-	switch {
-	case !flags.IsDSCIEnabled():
-		setupLog.Info("DSCI is disabled")
-	case oconfig.IsDSCICreationDisabled():
-		setupLog.Info("DSCI auto creation is disabled")
-	default:
-		createDefaultDSCIFunc := LeaderElectionRunnableFunc(func(ctx context.Context) error {
-			setupLog.Info("create default DSCI")
-			err := initialinstall.CreateDefaultDSCI(ctx, setupClient, platform, oconfig.MonitoringNamespace)
-			if err != nil {
-				setupLog.Error(err, "unable to create initial setup for the operator")
-			}
-			return err
-		})
-
-		err := mgr.Add(createDefaultDSCIFunc)
-		if err != nil {
-			setupLog.Error(err, "error scheduling DSCI creation")
-			os.Exit(1)
-		}
+	// Combined sequential initialization to avoid race conditions between
+	// cleanup and DSCI/DSC creation (RHOAIENG-48054).
+	leaderInitCfg := bootstrap.LeaderElectionInitConfig{
+		Platform:                  platform,
+		ManifestsBasePath:         oconfig.ManifestsBasePath,
+		MonitoringNamespace:       oconfig.MonitoringNamespace,
+		DSCIEnabled:               flags.IsDSCIEnabled(),
+		DSCEnabled:                flags.IsDSCEnabled(),
+		CreateDefaultDSCIDisabled: oconfig.IsDSCICreationDisabled(),
 	}
-
-	// Create default DSC CR for managed RHOAI
-	if platform == cluster.ManagedRhoai && flags.IsDSCEnabled() {
-		createDefaultDSCFunc := LeaderElectionRunnableFunc(func(ctx context.Context) error {
-			setupLog.Info("create default DSC")
-			err := initialinstall.CreateDefaultDSC(ctx, setupClient)
-			if err != nil {
-				setupLog.Error(err, "unable to create default DSC CR by the operator")
-			}
-			return err
-		})
-		err := mgr.Add(createDefaultDSCFunc)
-		if err != nil {
-			setupLog.Error(err, "error scheduling DSC creation")
-			os.Exit(1)
-		}
-	}
-
-	// Cleanup resources from previous v2 releases
-	cleanup := LeaderElectionRunnableFunc(func(ctx context.Context) error {
-		setupLog.Info("run upgrade task")
-		if err := upgrade.CleanupExistingResource(ctx, setupClient, oconfig.ManifestsBasePath); err != nil {
-			setupLog.Error(err, "unable to perform cleanup")
-			return err
-		}
-		return nil
+	leaderInitHooks := bootstrap.DefaultLeaderElectionInitHooks()
+	initFunc := LeaderElectionRunnableFunc(func(ctx context.Context) error {
+		return bootstrap.RunLeaderElectionInit(ctx, setupLog, setupClient, leaderInitCfg, leaderInitHooks)
 	})
 
-	err = mgr.Add(cleanup)
+	err = mgr.Add(initFunc)
 	if err != nil {
-		setupLog.Error(err, "error remove deprecated resources from previous version")
+		setupLog.Error(err, "error scheduling initialization")
+		os.Exit(1)
 	}
 
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {

--- a/pkg/bootstrap/leader_election_init.go
+++ b/pkg/bootstrap/leader_election_init.go
@@ -1,0 +1,115 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package bootstrap contains operator startup sequencing used after leader election.
+package bootstrap
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/go-logr/logr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/opendatahub-io/opendatahub-operator/v2/api/common"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/initialinstall"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/upgrade"
+)
+
+// LeaderElectionInitConfig carries flags/env-derived inputs for post-leader-election bootstrap.
+// See RHOAIENG-48054 (cleanup must complete before default DSCI/DSC creation).
+type LeaderElectionInitConfig struct {
+	Platform                  common.Platform
+	ManifestsBasePath         string
+	MonitoringNamespace       string
+	DSCIEnabled               bool
+	DSCEnabled                bool
+	CreateDefaultDSCIDisabled bool
+}
+
+// LeaderElectionInitHooks allows overriding install steps for tests.
+type LeaderElectionInitHooks struct {
+	CleanupExistingResource func(context.Context, client.Client, string) error
+	CreateDefaultDSCI       func(context.Context, client.Client, common.Platform, string) error
+	CreateDefaultDSC        func(context.Context, client.Client) error
+}
+
+// DefaultLeaderElectionInitHooks wires production implementations.
+func DefaultLeaderElectionInitHooks() LeaderElectionInitHooks {
+	return LeaderElectionInitHooks{
+		CleanupExistingResource: upgrade.CleanupExistingResource,
+		CreateDefaultDSCI:       initialinstall.CreateDefaultDSCI,
+		CreateDefaultDSC:        initialinstall.CreateDefaultDSC,
+	}
+}
+
+func validateLeaderElectionInitHooks(hooks LeaderElectionInitHooks) error {
+	if hooks.CleanupExistingResource == nil {
+		return errors.New("LeaderElectionInitHooks.CleanupExistingResource is nil")
+	}
+	if hooks.CreateDefaultDSCI == nil {
+		return errors.New("LeaderElectionInitHooks.CreateDefaultDSCI is nil")
+	}
+	if hooks.CreateDefaultDSC == nil {
+		return errors.New("LeaderElectionInitHooks.CreateDefaultDSC is nil")
+	}
+	return nil
+}
+
+// RunLeaderElectionInit performs post-leader-election initialization for the operator.
+// It first runs cleanup logic, then creates default DSCI and DSC resources if enabled.
+// Cleanup errors are logged but do not stop the process. If DSCI or DSC creation fails, the error is returned.
+//
+// Returns:
+//
+//	error - if DSCI or DSC creation fails, or hook validation fails
+func RunLeaderElectionInit(ctx context.Context, log logr.Logger, cli client.Client, cfg LeaderElectionInitConfig, hooks LeaderElectionInitHooks) error {
+	if err := validateLeaderElectionInitHooks(hooks); err != nil {
+		return err
+	}
+
+	log.Info("run upgrade task")
+
+	if err := hooks.CleanupExistingResource(ctx, cli, cfg.ManifestsBasePath); err != nil {
+		// no error returned, continue with DSCI/DSC creation even if cleanup fails
+		log.Error(err, "unable to cleanup existing resources")
+	}
+
+	switch {
+	case !cfg.DSCIEnabled:
+		log.Info("DSCI is disabled")
+	case cfg.CreateDefaultDSCIDisabled:
+		log.Info("default DSCI auto-creation is disabled")
+	default:
+		log.Info("create default DSCI CR")
+		if err := hooks.CreateDefaultDSCI(ctx, cli, cfg.Platform, cfg.MonitoringNamespace); err != nil {
+			log.Error(err, "unable to create default DSCI CR")
+			return fmt.Errorf("create default DSCI: %w", err)
+		}
+	}
+
+	if cfg.Platform == cluster.ManagedRhoai && cfg.DSCEnabled {
+		log.Info("create default DSC")
+		if err := hooks.CreateDefaultDSC(ctx, cli); err != nil {
+			log.Error(err, "unable to create default DSC CR")
+			return fmt.Errorf("create default DSC: %w", err)
+		}
+	}
+
+	return nil
+}

--- a/pkg/bootstrap/leader_election_init_test.go
+++ b/pkg/bootstrap/leader_election_init_test.go
@@ -1,0 +1,444 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package bootstrap_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/opendatahub-io/opendatahub-operator/v2/api/common"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/bootstrap"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
+)
+
+// MockClient is a mock implementation of client.Client for testing.
+type MockClient struct {
+	mock.Mock
+	client.Client
+}
+
+// TestDefaultLeaderElectionInitHooks tests that the default hooks are properly initialized.
+func TestDefaultLeaderElectionInitHooks(t *testing.T) {
+	hooks := bootstrap.DefaultLeaderElectionInitHooks()
+
+	assert.NotNil(t, hooks.CleanupExistingResource, "CleanupExistingResource hook should not be nil")
+	assert.NotNil(t, hooks.CreateDefaultDSCI, "CreateDefaultDSCI hook should not be nil")
+	assert.NotNil(t, hooks.CreateDefaultDSC, "CreateDefaultDSC hook should not be nil")
+}
+
+// TestValidateLeaderElectionInitHooks tests the hook validation function through RunLeaderElectionInit.
+func TestValidateLeaderElectionInitHooks(t *testing.T) {
+	ctx := context.Background()
+	log := logr.Discard()
+	mockClient := &MockClient{}
+
+	cfg := bootstrap.LeaderElectionInitConfig{
+		Platform:                  cluster.OpenDataHub,
+		ManifestsBasePath:         "/test/manifests",
+		MonitoringNamespace:       "test-monitoring",
+		DSCIEnabled:               true,
+		DSCEnabled:                false,
+		CreateDefaultDSCIDisabled: false,
+	}
+
+	tests := []struct {
+		name    string
+		hooks   bootstrap.LeaderElectionInitHooks
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name: "valid hooks",
+			hooks: bootstrap.LeaderElectionInitHooks{
+				CleanupExistingResource: func(context.Context, client.Client, string) error { return nil },
+				CreateDefaultDSCI:       func(context.Context, client.Client, common.Platform, string) error { return nil },
+				CreateDefaultDSC:        func(context.Context, client.Client) error { return nil },
+			},
+			wantErr: false,
+		},
+		{
+			name: "nil CleanupExistingResource",
+			hooks: bootstrap.LeaderElectionInitHooks{
+				CleanupExistingResource: nil,
+				CreateDefaultDSCI:       func(context.Context, client.Client, common.Platform, string) error { return nil },
+				CreateDefaultDSC:        func(context.Context, client.Client) error { return nil },
+			},
+			wantErr: true,
+			errMsg:  "LeaderElectionInitHooks.CleanupExistingResource is nil",
+		},
+		{
+			name: "nil CreateDefaultDSCI",
+			hooks: bootstrap.LeaderElectionInitHooks{
+				CleanupExistingResource: func(context.Context, client.Client, string) error { return nil },
+				CreateDefaultDSCI:       nil,
+				CreateDefaultDSC:        func(context.Context, client.Client) error { return nil },
+			},
+			wantErr: true,
+			errMsg:  "LeaderElectionInitHooks.CreateDefaultDSCI is nil",
+		},
+		{
+			name: "nil CreateDefaultDSC",
+			hooks: bootstrap.LeaderElectionInitHooks{
+				CleanupExistingResource: func(context.Context, client.Client, string) error { return nil },
+				CreateDefaultDSCI:       func(context.Context, client.Client, common.Platform, string) error { return nil },
+				CreateDefaultDSC:        nil,
+			},
+			wantErr: true,
+			errMsg:  "LeaderElectionInitHooks.CreateDefaultDSC is nil",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := bootstrap.RunLeaderElectionInit(ctx, log, mockClient, cfg, tt.hooks)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errMsg)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+// TestRunLeaderElectionInit tests the main initialization function.
+func TestRunLeaderElectionInit(t *testing.T) {
+	ctx := context.Background()
+	log := logr.Discard()
+	mockClient := &MockClient{}
+
+	tests := []struct {
+		name          string
+		cfg           bootstrap.LeaderElectionInitConfig
+		setupMocks    func(*testing.T, *MockClient) bootstrap.LeaderElectionInitHooks
+		expectedError string
+		expectedLogs  []string
+	}{
+		{
+			name: "successful initialization with all steps",
+			cfg: bootstrap.LeaderElectionInitConfig{
+				Platform:                  cluster.ManagedRhoai,
+				ManifestsBasePath:         "/test/manifests",
+				MonitoringNamespace:       "test-monitoring",
+				DSCIEnabled:               true,
+				DSCEnabled:                true,
+				CreateDefaultDSCIDisabled: false,
+			},
+			setupMocks: func(t *testing.T, mc *MockClient) bootstrap.LeaderElectionInitHooks {
+				t.Helper()
+				return bootstrap.LeaderElectionInitHooks{
+					CleanupExistingResource: func(ctx context.Context, cli client.Client, manifestsPath string) error {
+						assert.Equal(t, "/test/manifests", manifestsPath)
+						return nil
+					},
+					CreateDefaultDSCI: func(ctx context.Context, cli client.Client, platform common.Platform, monitoringNS string) error {
+						assert.Equal(t, cluster.ManagedRhoai, platform)
+						assert.Equal(t, "test-monitoring", monitoringNS)
+						return nil
+					},
+					CreateDefaultDSC: func(ctx context.Context, cli client.Client) error {
+						return nil
+					},
+				}
+			},
+			expectedError: "",
+		},
+		{
+			name: "DSCI disabled",
+			cfg: bootstrap.LeaderElectionInitConfig{
+				Platform:                  cluster.SelfManagedRhoai,
+				ManifestsBasePath:         "/test/manifests",
+				MonitoringNamespace:       "test-monitoring",
+				DSCIEnabled:               false,
+				DSCEnabled:                true,
+				CreateDefaultDSCIDisabled: false,
+			},
+			setupMocks: func(t *testing.T, mc *MockClient) bootstrap.LeaderElectionInitHooks {
+				t.Helper()
+				return bootstrap.LeaderElectionInitHooks{
+					CleanupExistingResource: func(ctx context.Context, cli client.Client, manifestsPath string) error {
+						return nil
+					},
+					CreateDefaultDSCI: func(ctx context.Context, cli client.Client, platform common.Platform, monitoringNS string) error {
+						t.Error("CreateDefaultDSCI should not be called when DSCI is disabled")
+						return nil
+					},
+					CreateDefaultDSC: func(ctx context.Context, cli client.Client) error {
+						t.Error("CreateDefaultDSC should not be called for non-ManagedRhoai platform")
+						return nil
+					},
+				}
+			},
+			expectedError: "",
+		},
+		{
+			name: "DSCI auto-creation disabled",
+			cfg: bootstrap.LeaderElectionInitConfig{
+				Platform:                  cluster.OpenDataHub,
+				ManifestsBasePath:         "/different/path",
+				MonitoringNamespace:       "different-monitoring",
+				DSCIEnabled:               true,
+				DSCEnabled:                false,
+				CreateDefaultDSCIDisabled: true,
+			},
+			setupMocks: func(t *testing.T, mc *MockClient) bootstrap.LeaderElectionInitHooks {
+				t.Helper()
+				return bootstrap.LeaderElectionInitHooks{
+					CleanupExistingResource: func(ctx context.Context, cli client.Client, manifestsPath string) error {
+						assert.Equal(t, "/different/path", manifestsPath)
+						return nil
+					},
+					CreateDefaultDSCI: func(ctx context.Context, cli client.Client, platform common.Platform, monitoringNS string) error {
+						t.Error("CreateDefaultDSCI should not be called when auto-creation is disabled")
+						return nil
+					},
+					CreateDefaultDSC: func(ctx context.Context, cli client.Client) error {
+						t.Error("CreateDefaultDSC should not be called when DSC is disabled")
+						return nil
+					},
+				}
+			},
+			expectedError: "",
+		},
+		{
+			name: "cleanup failure continues execution",
+			cfg: bootstrap.LeaderElectionInitConfig{
+				Platform:                  cluster.ManagedRhoai,
+				ManifestsBasePath:         "/test/manifests",
+				MonitoringNamespace:       "test-monitoring",
+				DSCIEnabled:               true,
+				DSCEnabled:                true,
+				CreateDefaultDSCIDisabled: false,
+			},
+			setupMocks: func(t *testing.T, mc *MockClient) bootstrap.LeaderElectionInitHooks {
+				t.Helper()
+				return bootstrap.LeaderElectionInitHooks{
+					CleanupExistingResource: func(ctx context.Context, cli client.Client, manifestsPath string) error {
+						return errors.New("cleanup failed")
+					},
+					CreateDefaultDSCI: func(ctx context.Context, cli client.Client, platform common.Platform, monitoringNS string) error {
+						// Should still be called even after cleanup failure
+						return nil
+					},
+					CreateDefaultDSC: func(ctx context.Context, cli client.Client) error {
+						return nil
+					},
+				}
+			},
+			expectedError: "", // No error returned despite cleanup failure
+		},
+		{
+			name: "DSCI creation failure returns error",
+			cfg: bootstrap.LeaderElectionInitConfig{
+				Platform:                  cluster.ManagedRhoai,
+				ManifestsBasePath:         "/test/manifests",
+				MonitoringNamespace:       "test-monitoring",
+				DSCIEnabled:               true,
+				DSCEnabled:                true,
+				CreateDefaultDSCIDisabled: false,
+			},
+			setupMocks: func(t *testing.T, mc *MockClient) bootstrap.LeaderElectionInitHooks {
+				t.Helper()
+				return bootstrap.LeaderElectionInitHooks{
+					CleanupExistingResource: func(ctx context.Context, cli client.Client, manifestsPath string) error {
+						return nil
+					},
+					CreateDefaultDSCI: func(ctx context.Context, cli client.Client, platform common.Platform, monitoringNS string) error {
+						return errors.New("DSCI creation failed")
+					},
+					CreateDefaultDSC: func(ctx context.Context, cli client.Client) error {
+						t.Error("CreateDefaultDSC should not be called if DSCI creation fails")
+						return nil
+					},
+				}
+			},
+			expectedError: "create default DSCI: DSCI creation failed",
+		},
+		{
+			name: "DSC creation failure returns error",
+			cfg: bootstrap.LeaderElectionInitConfig{
+				Platform:                  cluster.ManagedRhoai,
+				ManifestsBasePath:         "/test/manifests",
+				MonitoringNamespace:       "test-monitoring",
+				DSCIEnabled:               true,
+				DSCEnabled:                true,
+				CreateDefaultDSCIDisabled: false,
+			},
+			setupMocks: func(t *testing.T, mc *MockClient) bootstrap.LeaderElectionInitHooks {
+				t.Helper()
+				return bootstrap.LeaderElectionInitHooks{
+					CleanupExistingResource: func(ctx context.Context, cli client.Client, manifestsPath string) error {
+						return nil
+					},
+					CreateDefaultDSCI: func(ctx context.Context, cli client.Client, platform common.Platform, monitoringNS string) error {
+						return nil
+					},
+					CreateDefaultDSC: func(ctx context.Context, cli client.Client) error {
+						return errors.New("DSC creation failed")
+					},
+				}
+			},
+			expectedError: "create default DSC: DSC creation failed",
+		},
+		{
+			name: "DSC disabled for ManagedRhoai",
+			cfg: bootstrap.LeaderElectionInitConfig{
+				Platform:                  cluster.ManagedRhoai,
+				ManifestsBasePath:         "/test/manifests",
+				MonitoringNamespace:       "test-monitoring",
+				DSCIEnabled:               true,
+				DSCEnabled:                false,
+				CreateDefaultDSCIDisabled: false,
+			},
+			setupMocks: func(t *testing.T, mc *MockClient) bootstrap.LeaderElectionInitHooks {
+				t.Helper()
+				return bootstrap.LeaderElectionInitHooks{
+					CleanupExistingResource: func(ctx context.Context, cli client.Client, manifestsPath string) error {
+						return nil
+					},
+					CreateDefaultDSCI: func(ctx context.Context, cli client.Client, platform common.Platform, monitoringNS string) error {
+						return nil
+					},
+					CreateDefaultDSC: func(ctx context.Context, cli client.Client) error {
+						t.Error("CreateDefaultDSC should not be called when DSC is disabled")
+						return nil
+					},
+				}
+			},
+			expectedError: "",
+		},
+		{
+			name: "invalid hooks returns error",
+			cfg: bootstrap.LeaderElectionInitConfig{
+				Platform:                  cluster.ManagedRhoai,
+				ManifestsBasePath:         "/test/manifests",
+				MonitoringNamespace:       "test-monitoring",
+				DSCIEnabled:               true,
+				DSCEnabled:                true,
+				CreateDefaultDSCIDisabled: false,
+			},
+			setupMocks: func(t *testing.T, mc *MockClient) bootstrap.LeaderElectionInitHooks {
+				t.Helper()
+				return bootstrap.LeaderElectionInitHooks{
+					CleanupExistingResource: nil, // Invalid hook
+					CreateDefaultDSCI: func(ctx context.Context, cli client.Client, platform common.Platform, monitoringNS string) error {
+						return nil
+					},
+					CreateDefaultDSC: func(ctx context.Context, cli client.Client) error { return nil },
+				}
+			},
+			expectedError: "LeaderElectionInitHooks.CleanupExistingResource is nil",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hooks := tt.setupMocks(t, mockClient)
+			err := bootstrap.RunLeaderElectionInit(ctx, log, mockClient, tt.cfg, hooks)
+
+			if tt.expectedError != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectedError)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+// TestRunLeaderElectionInitSequencing tests that operations execute in the correct order.
+func TestRunLeaderElectionInitSequencing(t *testing.T) {
+	ctx := context.Background()
+	log := logr.Discard()
+	mockClient := &MockClient{}
+
+	var executionOrder []string
+
+	cfg := bootstrap.LeaderElectionInitConfig{
+		Platform:                  cluster.ManagedRhoai,
+		ManifestsBasePath:         "/test/manifests",
+		MonitoringNamespace:       "test-monitoring",
+		DSCIEnabled:               true,
+		DSCEnabled:                true,
+		CreateDefaultDSCIDisabled: false,
+	}
+
+	hooks := bootstrap.LeaderElectionInitHooks{
+		CleanupExistingResource: func(ctx context.Context, cli client.Client, manifestsPath string) error {
+			executionOrder = append(executionOrder, "cleanup")
+			return nil
+		},
+		CreateDefaultDSCI: func(ctx context.Context, cli client.Client, platform common.Platform, monitoringNS string) error {
+			executionOrder = append(executionOrder, "dsci")
+			return nil
+		},
+		CreateDefaultDSC: func(ctx context.Context, cli client.Client) error {
+			executionOrder = append(executionOrder, "dsc")
+			return nil
+		},
+	}
+
+	err := bootstrap.RunLeaderElectionInit(ctx, log, mockClient, cfg, hooks)
+	require.NoError(t, err)
+
+	// Verify the execution order: cleanup → DSCI → DSC
+	expectedOrder := []string{"cleanup", "dsci", "dsc"}
+	assert.Equal(t, expectedOrder, executionOrder, "Operations should execute in the correct sequence")
+}
+
+// TestLeaderElectionInitConfigValidation tests edge cases with configuration.
+func TestLeaderElectionInitConfigValidation(t *testing.T) {
+	ctx := context.Background()
+	log := logr.Discard()
+	mockClient := &MockClient{}
+
+	// Test with empty manifests path
+	cfg := bootstrap.LeaderElectionInitConfig{
+		Platform:                  cluster.OpenDataHub,
+		ManifestsBasePath:         "",
+		MonitoringNamespace:       "monitoring",
+		DSCIEnabled:               true,
+		DSCEnabled:                false,
+		CreateDefaultDSCIDisabled: false,
+	}
+
+	hooks := bootstrap.LeaderElectionInitHooks{
+		CleanupExistingResource: func(ctx context.Context, cli client.Client, manifestsPath string) error {
+			assert.Empty(t, manifestsPath, "Empty manifests path should be passed as-is")
+			return nil
+		},
+		CreateDefaultDSCI: func(ctx context.Context, cli client.Client, platform common.Platform, monitoringNS string) error {
+			assert.Equal(t, cluster.OpenDataHub, platform)
+			assert.Equal(t, "monitoring", monitoringNS)
+			return nil
+		},
+		CreateDefaultDSC: func(ctx context.Context, cli client.Client) error {
+			t.Error("CreateDefaultDSC should not be called for OpenDataHub platform")
+			return nil
+		},
+	}
+
+	err := bootstrap.RunLeaderElectionInit(ctx, log, mockClient, cfg, hooks)
+	require.NoError(t, err)
+}

--- a/pkg/utils/test/scheme/test_types.go
+++ b/pkg/utils/test/scheme/test_types.go
@@ -38,6 +38,7 @@ func (o *TestPlatformObject) GetConditions() []common.Condition { return o.Statu
 // SetConditions implements common.ConditionsAccessor.
 func (o *TestPlatformObject) SetConditions(c []common.Condition) { o.Status.SetConditions(c) }
 
+//nolint:ireturn // DeepCopyObject must return runtime.Object per k8s apimachinery contract.
 func (o *TestPlatformObject) DeepCopyObject() runtime.Object {
 	if o == nil {
 		return nil
@@ -58,6 +59,7 @@ type TestPlatformObjectList struct {
 	Items []TestPlatformObject `json:"items"`
 }
 
+//nolint:ireturn // DeepCopyObject must return runtime.Object per k8s apimachinery contract.
 func (l *TestPlatformObjectList) DeepCopyObject() runtime.Object {
 	if l == nil {
 		return nil

--- a/tests/e2e/v2tov3upgrade_test.go
+++ b/tests/e2e/v2tov3upgrade_test.go
@@ -82,6 +82,8 @@ func v2Tov3UpgradeTestSuite(t *testing.T) {
 		{"modelmeshserving resources preserved after support removal", v2Tov3UpgradeTestCtx.ValidateModelMeshServingResourcePreservation},
 		{"ray raise error if codeflare component present in the cluster", v2Tov3UpgradeTestCtx.ValidateRayRaiseErrorIfCodeFlarePresent},
 		{"servicemesh resources preserved after support removal", v2Tov3UpgradeTestCtx.ValidateServiceMeshResourcePreservation},
+		// RHOAIENG-48054: DSCI should stay Ready after suite scenarios (startup cleanup before default CR creation).
+		{"default DSCInitialization remains Ready after deprecated CRD scenarios", v2Tov3UpgradeTestCtx.ValidateDefaultDSCIRemainsReadyAfterDeprecatedCRDScenarios},
 	}
 
 	// Run the test suite.
@@ -317,6 +319,18 @@ func (tc *V2Tov3UpgradeTestCtx) createOperatorManagedServiceMesh(serviceMeshName
 	tc.EventuallyResourceCreatedOrUpdated(
 		WithObjectToCreate(existingServiceMesh),
 		WithCustomErrorMsg("Failed to create existing ServiceMesh service for preservation test"),
+	)
+}
+
+func (tc *V2Tov3UpgradeTestCtx) ValidateDefaultDSCIRemainsReadyAfterDeprecatedCRDScenarios(t *testing.T) {
+	t.Helper()
+
+	tc.EnsureResourceExists(
+		WithMinimalObject(gvk.DSCInitialization, tc.DSCInitializationNamespacedName),
+		WithCondition(jq.Match(`.status.phase == "%s"`, status.ConditionTypeReady)),
+		WithCustomErrorMsg("DSCI should remain Ready after v2->v3 deprecated CRD scenarios (RHOAIENG-48054)"),
+		WithEventuallyTimeout(tc.TestTimeouts.mediumEventuallyTimeout),
+		WithEventuallyPollingInterval(tc.TestTimeouts.defaultEventuallyPollInterval),
 	)
 }
 


### PR DESCRIPTION
- Introduced a new bootstrap package to handle post-leader-election tasks, ensuring cleanup occurs before default DSCI/DSC creation to prevent race conditions (RHOAIENG-48054).
- Updated the main function to utilize the new  bootstrap logic, simplifying the initialization flow.
- Added unit tests for the new bootstrap functionality to validate the order of operations during initialization.

This change enhances the reliability of the operator startup sequence and addresses potential issues with resource cleanup and creation timing.

<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description

https://redhat.atlassian.net/browse/RHOAIENG-48054

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [ ] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized post–leader-election initialization into a single leader-election driven flow with configurable init hooks, conditional default resource creation based on platform/feature flags, and clearer scheduling/error logging.

* **Tests**
  * Added unit tests covering hook validation, execution order, conditional skipping, and early-termination on errors.
  * Added e2e checks ensuring DSCInitialization reaches and remains Ready after startup and upgrade scenarios.

* **Style**
  * Minor comment and lint directive adjustments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->