### PR TITLE
RHOAIENG-56112 | fix: Allow thanos querier to reach Promethues thanos…

### DIFF
--- a/internal/controller/services/monitoring/resources/data-science-prometheus-network-policy.tmpl.yaml
+++ b/internal/controller/services/monitoring/resources/data-science-prometheus-network-policy.tmpl.yaml
@@ -24,3 +24,11 @@ spec:
       ports:
         - protocol: TCP
           port: 9090
+    - from:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/part-of: ThanosQuerier
+              app.kubernetes.io/managed-by: observability-operator
+      ports:
+        - protocol: TCP
+          port: 10901

--- a/tests/e2e/monitoring_test.go
+++ b/tests/e2e/monitoring_test.go
@@ -212,6 +212,9 @@ func monitoringTestSuite(t *testing.T) {
 
 		// Subtest 2: With metrics
 		t.Run("Test ThanosQuerier deployment with metrics", monitoringServiceCtx.ValidateThanosQuerierDeployment)
+
+		// Subtest 3: NetworkPolicy allows Thanos Querier on gRPC port
+		t.Run("Test Prometheus NetworkPolicy allows Thanos Querier on gRPC port", monitoringServiceCtx.ValidatePrometheusNetworkPolicyAllowsThanosQuerier)
 	})
 
 	// ========================================================================
@@ -1771,6 +1774,52 @@ func (tc *MonitoringTestCtx) ValidateThanosQuerierNotDeployedWithoutMetrics(t *t
 
 	// Cleanup: Reset monitoring configuration
 	tc.resetMonitoringConfigToManaged()
+}
+
+// ValidatePrometheusNetworkPolicyAllowsThanosQuerier tests that the Prometheus instance NetworkPolicy
+// includes an ingress rule allowing the Thanos Querier to reach the Thanos Sidecar on gRPC port 10901.
+func (tc *MonitoringTestCtx) ValidatePrometheusNetworkPolicyAllowsThanosQuerier(t *testing.T) {
+	t.Helper()
+
+	tc.updateMonitoringConfig(
+		withManagementState(operatorv1.Managed),
+		tc.withMetricsConfig(),
+	)
+
+	tc.EnsureResourceExists(
+		WithMinimalObject(gvk.Monitoring, types.NamespacedName{Name: MonitoringCRName}),
+		WithCondition(And(
+			jq.Match(`.spec.metrics != null`),
+			jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, status.ConditionTypeReady, metav1.ConditionTrue),
+			jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, status.ConditionMonitoringStackAvailable, metav1.ConditionTrue),
+		)),
+		WithCustomErrorMsg("Monitoring resource should be ready with MonitoringStack available before checking NetworkPolicy"),
+	)
+
+	tc.EnsureResourceExists(
+		WithMinimalObject(gvk.NetworkPolicy, types.NamespacedName{
+			Name:      "data-science-prometheus-instance-ingress",
+			Namespace: tc.MonitoringNamespace,
+		}),
+		WithCondition(And(
+			jq.Match(`.metadata.labels["platform.opendatahub.io/part-of"] == "monitoring"`),
+			// Validate podSelector targets Prometheus pods
+			jq.Match(`.spec.podSelector.matchLabels["app.kubernetes.io/name"] == "prometheus"`),
+			jq.Match(`.spec.podSelector.matchLabels["app.kubernetes.io/instance"] == "data-science-monitoringstack"`),
+			jq.Match(`.spec.policyTypes[0] == "Ingress"`),
+			// Validate proxy ingress rule (port 9090)
+			jq.Match(`.spec.ingress[0].from[0].podSelector.matchLabels.app == "data-science-prometheus-namespace-proxy"`),
+			jq.Match(`.spec.ingress[0].from[1].podSelector.matchLabels.app == "data-science-prometheus-cluster-proxy"`),
+			jq.Match(`.spec.ingress[0].ports[0].protocol == "TCP"`),
+			jq.Match(`.spec.ingress[0].ports[0].port == 9090`),
+			// Validate Thanos Querier ingress rule (gRPC port 10901)
+			jq.Match(`.spec.ingress[1].from[0].podSelector.matchLabels["app.kubernetes.io/part-of"] == "ThanosQuerier"`),
+			jq.Match(`.spec.ingress[1].from[0].podSelector.matchLabels["app.kubernetes.io/managed-by"] == "observability-operator"`),
+			jq.Match(`.spec.ingress[1].ports[0].protocol == "TCP"`),
+			jq.Match(`.spec.ingress[1].ports[0].port == 10901`),
+		)),
+		WithCustomErrorMsg("Prometheus NetworkPolicy should allow Thanos Querier ingress on gRPC port 10901"),
+	)
 }
 
 // ValidatePrometheusSelfServiceMonitorTLSFix tests that the prometheus-self-fixed ServiceMonitor is deployed


### PR DESCRIPTION
… sidecar

<!---
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->
The data-science-prometheus-instance-ingress NetworkPolicy in the monitoring namespace prevents the Thanos Querier from connecting to the Prometheus Thanos Sidecar on gRPC port 10901. This makes the entire Thanos query path non-functional - all Perses datasources, dashboards, and API queries that go through Thanos return zero results, even though Prometheus itself is scraping targets successfully.The NetworkPolicy currently allows ingress to Prometheus pods only from the namespace-proxy and cluster-proxy pods on port 9090. The Thanos Querier pod (labeled app.kubernetes.io/part-of: ThanosQuerier) connects to the Thanos Sidecar container on each Prometheus pod via gRPC port 10901. 

This traffic is denied because:

The Querier pod labels don't match either allowed podSelectorPort 10901 is not in the allowed ports listThe data-science-prometheus-datasource PersesDatasource queries Thanos at <[http://thanos-querier-data-science-thanos-querier.<namespace>>.svc.cluster.local:10902.](http://thanos-querier-data-science-thanos-querier.%3Cnamespace%3E%3E.svc.cluster.local:10902.) Since the Querier cannot reach the Sidecar, this datasource returns empty data. All Perses dashboards that rely on the Prometheus datasource show "No data". The managed monitoring stack appears healthy (Prometheus scrapes targets, all pods Running, status conditions True), masking the fact that no metrics are queryable through the intended query path.Affected file: internal/controller/services/monitoring/resources/data-science-prometheus-network-policy.tmpl.yaml
<!--- Link your JIRA and related links here for reference. -->
https://redhat.atlassian.net/browse/RHOAIENG-56112 
## How Has This Been Tested?
- verified thanos metrics show up on prometheus dashboard when deploying standalone prometheus instance with the correct config following this doc: https://docs.google.com/document/d/11PBSs9FFv2ChXUAxW0nnjI08WOCFuYn-/edit?usp=sharing&ouid=106703574662584268813&rtpof=true&sd=true

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully
- [ ] New RELATED_IMAGE mappings are already listed in ODH-Build-Config and RHOAI-Build-Config, and links are included in PR description

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [ ] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Network policy updated to allow Thanos Querier to reach the Prometheus stack on gRPC port 10901 while preserving existing access.

* **Tests**
  * Added an end-to-end test that verifies the Prometheus network policy permits Thanos Querier ingress on the expected port and selectors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->