### PR TITLE
Add Intel Gaudi vLLM image override support for KServe

### DIFF
--- a/internal/controller/components/kserve/kserve_support.go
+++ b/internal/controller/components/kserve/kserve_support.go
@@ -41,7 +41,7 @@ var (
 		"kserve-llm-d-nvidia-cuda":         "RELATED_IMAGE_RHAIIS_VLLM_CUDA_IMAGE",
 		"kserve-llm-d-amd-rocm":            "RELATED_IMAGE_RHAIIS_VLLM_ROCM_IMAGE",
 		"kserve-llm-d-ibm-spyre":           "RELATED_IMAGE_RHAIIS_VLLM_SPYRE_IMAGE",
-		"kserve-llm-d-intel-gaudi":         "RELATED_IMAGE_RHAIIS_VLLM_GAUDI_IMAGE",
+		"kserve-llm-d-intel-gaudi":         "RELATED_IMAGE_RHAII_VLLM_GAUDI_IMAGE",
 		"kserve-llm-d-inference-scheduler": "RELATED_IMAGE_ODH_LLM_D_INFERENCE_SCHEDULER_IMAGE",
 		"kserve-llm-d-routing-sidecar":     "RELATED_IMAGE_ODH_LLM_D_ROUTING_SIDECAR_IMAGE",
 		"kube-rbac-proxy":                  "RELATED_IMAGE_OSE_KUBE_RBAC_PROXY_IMAGE",

--- a/internal/controller/components/kserve/kserve_support.go
+++ b/internal/controller/components/kserve/kserve_support.go
@@ -41,6 +41,7 @@ var (
 		"kserve-llm-d-nvidia-cuda":         "RELATED_IMAGE_RHAIIS_VLLM_CUDA_IMAGE",
 		"kserve-llm-d-amd-rocm":            "RELATED_IMAGE_RHAIIS_VLLM_ROCM_IMAGE",
 		"kserve-llm-d-ibm-spyre":           "RELATED_IMAGE_RHAIIS_VLLM_SPYRE_IMAGE",
+		"kserve-llm-d-intel-gaudi":         "RELATED_IMAGE_RHAIIS_VLLM_GAUDI_IMAGE",
 		"kserve-llm-d-inference-scheduler": "RELATED_IMAGE_ODH_LLM_D_INFERENCE_SCHEDULER_IMAGE",
 		"kserve-llm-d-routing-sidecar":     "RELATED_IMAGE_ODH_LLM_D_ROUTING_SIDECAR_IMAGE",
 		"kube-rbac-proxy":                  "RELATED_IMAGE_OSE_KUBE_RBAC_PROXY_IMAGE",


### PR DESCRIPTION
## Description

Add Intel Gaudi vLLM image override to kserve `imageParamMap`.

This adds a `kserve-llm-d-intel-gaudi` to `RELATED_IMAGE_RHAIIS_VLLM_GAUDI_IMAGE` mapping, following the same pattern as the existing CUDA, ROCm, and Spyre entries. This is the operator-side change needed to support the Intel Gaudi (habana.ai/gaudi) accelerator-specific `LLMInferenceServiceConfig` being added in kserve.

- Image: `registry.redhat.io/rhaii-early-access/vllm-gaudi-rhel9` (Tech Preview, amd64, shipped in RHAIIS 3.4.0-ea.2)
- Dependent kserve PR: https://github.com/opendatahub-io/kserve/pull/1331

## How Has This Been Tested?

- `go vet ./...` - passes clean
- `go test ./internal/controller/components/kserve/...` - all tests pass
- Verified the new entry follows the exact pattern of existing accelerator image overrides

## Screenshot or short clip

N/A - single-line map entry addition, no UI changes.

## Merge criteria

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully
- [ ] New RELATED_IMAGE mappings are already listed in ODH-Build-Config and RHOAI-Build-Config, and links are included in PR description

**Follow-up:** `RELATED_IMAGE_RHAIIS_VLLM_GAUDI_IMAGE` needs to be added to:
- [ ] [opendatahub-io/ODH-Build-Config](https://github.com/opendatahub-io/ODH-Build-Config) - `bundle/additional-images-patch.yaml`
- [ ] [red-hat-data-services/RHOAI-Build-Config](https://github.com/red-hat-data-services/RHOAI-Build-Config) (branch `rhoai-3.4`) - `bundle/additional-images-patch.yaml`

### E2E test suite update requirement

- [x] Skip requirement to update E2E test suite for this PR

#### E2E update requirement opt-out justification

This change adds a single key-value entry to `imageParamMap` - a static configuration map. It introduces no new logic, no new code paths, and no behavioral changes. The existing E2E tests for kserve image injection cover this mechanism. This follows the same pattern as the Spyre image override PR (#3172) which also did not require E2E updates.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Intel Gaudi hardware in KServe large language model deployments by registering the Gaudi runtime image mapping to enable Gaudi-based LLM serving.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->