### PR TITLE
feat: replace platform labels by infrastructure labels in CCM-related resources

### DIFF
--- a/internal/controller/cloudmanager/azure/azurekubernetesengine_controller_test.go
+++ b/internal/controller/cloudmanager/azure/azurekubernetesengine_controller_test.go
@@ -205,9 +205,9 @@ func TestAzureKubernetesEngineGC(t *testing.T) {
 					labels.InfrastructurePartOf: "azurekubernetesengine",
 				},
 				Annotations: map[string]string{
-					annotations.InstanceUID: string(ake.GetUID()),
+					labels.ODHInfrastructurePrefix + annotations.SuffixInstanceUID: string(ake.GetUID()),
 					// A generation far in the past — will never match the current CR generation.
-					annotations.InstanceGeneration: strconv.FormatInt(-1, 10),
+					labels.ODHInfrastructurePrefix + annotations.SuffixInstanceGeneration: strconv.FormatInt(-1, 10),
 				},
 				OwnerReferences: []metav1.OwnerReference{{
 					APIVersion: gvk.AzureKubernetesEngine.GroupVersion().String(),

--- a/internal/controller/cloudmanager/coreweave/coreweavekubernetesengine_controller_test.go
+++ b/internal/controller/cloudmanager/coreweave/coreweavekubernetesengine_controller_test.go
@@ -258,9 +258,9 @@ func TestCoreWeaveKubernetesEngineGC(t *testing.T) {
 					labels.InfrastructurePartOf: "coreweavekubernetesengine",
 				},
 				Annotations: map[string]string{
-					annotations.InstanceUID: string(cke.GetUID()),
+					labels.ODHInfrastructurePrefix + annotations.SuffixInstanceUID: string(cke.GetUID()),
 					// A generation far in the past — will never match the current CR generation.
-					annotations.InstanceGeneration: strconv.FormatInt(-1, 10),
+					labels.ODHInfrastructurePrefix + annotations.SuffixInstanceGeneration: strconv.FormatInt(-1, 10),
 				},
 				OwnerReferences: []metav1.OwnerReference{{
 					APIVersion: gvk.CoreWeaveKubernetesEngine.GroupVersion().String(),

--- a/pkg/controller/actions/deploy/action_deploy.go
+++ b/pkg/controller/actions/deploy/action_deploy.go
@@ -47,12 +47,14 @@ func (s SortFn) Then(then SortFn) SortFn {
 // Action deploys the resources that are included in the ReconciliationRequest using
 // the same create or patch machinery implemented as part of deploy.DeployManifestsFromPath.
 type Action struct {
-	fieldOwner  string
-	deployMode  Mode
-	labels      map[string]string
-	annotations map[string]string
-	cache       *Cache
-	sortFn      SortFn
+	fieldOwner       string
+	deployMode       Mode
+	partOfLabelKey   string
+	annotationPrefix string
+	labels           map[string]string
+	annotations      map[string]string
+	cache            *Cache
+	sortFn           SortFn
 }
 
 type ActionOpts func(*Action)
@@ -66,6 +68,18 @@ func WithFieldOwner(value string) ActionOpts {
 func WithMode(value Mode) ActionOpts {
 	return func(action *Action) {
 		action.deployMode = value
+	}
+}
+
+func WithPartOfLabel(key string) ActionOpts {
+	return func(action *Action) {
+		action.partOfLabelKey = key
+	}
+}
+
+func WithAnnotationPrefix(prefix string) ActionOpts {
+	return func(action *Action) {
+		action.annotationPrefix = prefix
 	}
 }
 
@@ -128,6 +142,22 @@ func WithApplyOrder() ActionOpts {
 	return WithSortFn(resources.SortByApplyOrder)
 }
 
+// resolveFieldOwner returns the effective field owner for the reconciled
+// instance.  When a.fieldOwner is explicitly configured it is returned
+// as-is; otherwise the owner is derived from the instance's Kind.
+func (a *Action) resolveFieldOwner(rr *odhTypes.ReconciliationRequest) (string, error) {
+	if a.fieldOwner != "" {
+		return a.fieldOwner, nil
+	}
+
+	kind, err := resources.KindForObject(rr.Client.Scheme(), rr.Instance)
+	if err != nil {
+		return "", err
+	}
+
+	return strings.ToLower(kind), nil
+}
+
 func (a *Action) run(ctx context.Context, rr *odhTypes.ReconciliationRequest) error {
 	if a.sortFn != nil {
 		sorted, err := a.sortFn(ctx, rr.Resources)
@@ -142,12 +172,11 @@ func (a *Action) run(ctx context.Context, rr *odhTypes.ReconciliationRequest) er
 		a.cache.Sync()
 	}
 
-	kind, err := resources.KindForObject(rr.Client.Scheme(), rr.Instance)
+	controllerName, err := a.resolveFieldOwner(rr)
 	if err != nil {
 		return err
 	}
 
-	controllerName := strings.ToLower(kind)
 	igvk := rr.Instance.GetObjectKind().GroupVersionKind()
 
 	for i := range rr.Resources {
@@ -241,7 +270,21 @@ func (a *Action) deployCRD(
 ) (bool, error) {
 	resources.SetLabels(&obj, a.labels)
 	resources.SetAnnotations(&obj, a.annotations)
-	resources.SetLabel(&obj, labels.PlatformPartOf, labels.Platform)
+
+	if resources.GetLabel(&obj, a.partOfLabelKey) == "" {
+		if a.partOfLabelKey == labels.PlatformPartOf {
+			resources.SetLabel(&obj, a.partOfLabelKey, labels.Platform)
+		} else {
+			fo, err := a.resolveFieldOwner(rr)
+			if err != nil {
+				return false, err
+			}
+
+			if fo != "" {
+				resources.SetLabel(&obj, a.partOfLabelKey, fo)
+			}
+		}
+	}
 
 	shouldSkip, err := a.ShouldSkip(current, &obj)
 	if err != nil {
@@ -301,26 +344,21 @@ func (a *Action) deploy(
 	obj unstructured.Unstructured,
 	current *unstructured.Unstructured,
 ) (bool, error) {
-	fo := a.fieldOwner
-	if fo == "" {
-		kind, err := resources.KindForObject(rr.Client.Scheme(), rr.Instance)
-		if err != nil {
-			return false, err
-		}
-
-		fo = strings.ToLower(kind)
+	fo, err := a.resolveFieldOwner(rr)
+	if err != nil {
+		return false, err
 	}
 
 	resources.SetLabels(&obj, a.labels)
 	resources.SetAnnotations(&obj, a.annotations)
-	resources.SetAnnotation(&obj, annotations.InstanceGeneration, strconv.FormatInt(rr.Instance.GetGeneration(), 10))
-	resources.SetAnnotation(&obj, annotations.InstanceName, rr.Instance.GetName())
-	resources.SetAnnotation(&obj, annotations.InstanceUID, string(rr.Instance.GetUID()))
-	resources.SetAnnotation(&obj, annotations.PlatformType, string(rr.Release.Name))
-	resources.SetAnnotation(&obj, annotations.PlatformVersion, rr.Release.Version.String())
+	resources.SetAnnotation(&obj, a.annotationPrefix+annotations.SuffixInstanceGeneration, strconv.FormatInt(rr.Instance.GetGeneration(), 10))
+	resources.SetAnnotation(&obj, a.annotationPrefix+annotations.SuffixInstanceName, rr.Instance.GetName())
+	resources.SetAnnotation(&obj, a.annotationPrefix+annotations.SuffixInstanceUID, string(rr.Instance.GetUID()))
+	resources.SetAnnotation(&obj, a.annotationPrefix+annotations.SuffixType, string(rr.Release.Name))
+	resources.SetAnnotation(&obj, a.annotationPrefix+annotations.SuffixVersion, rr.Release.Version.String())
 
-	if resources.GetLabel(&obj, labels.PlatformPartOf) == "" && fo != "" {
-		resources.SetLabel(&obj, labels.PlatformPartOf, fo)
+	if resources.GetLabel(&obj, a.partOfLabelKey) == "" && fo != "" {
+		resources.SetLabel(&obj, a.partOfLabelKey, fo)
 	}
 
 	shouldSkip, err := a.ShouldSkip(current, &obj)
@@ -583,7 +621,9 @@ func (a *Action) shouldOwn(rr *odhTypes.ReconciliationRequest, objGVK schema.Gro
 
 func NewAction(opts ...ActionOpts) actions.Fn {
 	action := Action{
-		deployMode: ModeSSA,
+		deployMode:       ModeSSA,
+		partOfLabelKey:   labels.PlatformPartOf,
+		annotationPrefix: labels.ODHPlatformPrefix,
 	}
 
 	for _, opt := range opts {

--- a/pkg/controller/actions/deploy/action_deploy_test.go
+++ b/pkg/controller/actions/deploy/action_deploy_test.go
@@ -1637,3 +1637,211 @@ func TestWithApplyOrder(t *testing.T) {
 	err = cl.Get(ctx, apimachinery.NamespacedName{Name: obj2.GetName()}, resources.GvkToUnstructured(gvk.Namespace))
 	g.Expect(err).ShouldNot(HaveOccurred())
 }
+
+func TestDeployWithPartOfLabel(t *testing.T) {
+	g := NewWithT(t)
+
+	ctx := t.Context()
+	ns := xid.New().String()
+	customLabelKey := "custom.example.io/part-of"
+
+	cl, err := fakeclient.New()
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	action := deploy.NewAction(
+		deploy.WithMode(deploy.ModePatch),
+		deploy.WithPartOfLabel(customLabelKey),
+	)
+
+	obj1, err := resources.ToUnstructured(&appsv1.Deployment{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: appsv1.SchemeGroupVersion.String(),
+			Kind:       "Deployment",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      xid.New().String(),
+			Namespace: ns,
+		},
+	})
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	rr := types.ReconciliationRequest{
+		Client: cl,
+		Instance: &componentApi.Dashboard{
+			ObjectMeta: metav1.ObjectMeta{
+				Generation: 1,
+			},
+		},
+		Release: common.Release{
+			Name: cluster.OpenDataHub,
+			Version: version.OperatorVersion{Version: semver.Version{
+				Major: 1, Minor: 2, Patch: 3,
+			}}},
+		Resources: []unstructured.Unstructured{*obj1},
+		Controller: mocks.NewMockController(func(m *mocks.MockController) {
+			m.On("Owns", mock.Anything).Return(false)
+		}),
+	}
+
+	err = action(ctx, &rr)
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	err = cl.Get(ctx, client.ObjectKeyFromObject(obj1), obj1)
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	g.Expect(obj1).Should(And(
+		jq.Match(`.metadata.labels."%s" == "%s"`, customLabelKey, strings.ToLower(componentApi.DashboardKind)),
+		Not(jq.Match(`.metadata.labels | has("%s")`, labels.PlatformPartOf)),
+	))
+}
+
+func TestDeployWithAnnotationPrefix(t *testing.T) {
+	g := NewWithT(t)
+
+	ctx := t.Context()
+	ns := xid.New().String()
+
+	cl, err := fakeclient.New()
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	action := deploy.NewAction(
+		deploy.WithMode(deploy.ModePatch),
+		deploy.WithAnnotationPrefix(labels.ODHInfrastructurePrefix),
+	)
+
+	obj1, err := resources.ToUnstructured(&appsv1.Deployment{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: appsv1.SchemeGroupVersion.String(),
+			Kind:       "Deployment",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      xid.New().String(),
+			Namespace: ns,
+		},
+	})
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	rr := types.ReconciliationRequest{
+		Client: cl,
+		Instance: &componentApi.Dashboard{
+			ObjectMeta: metav1.ObjectMeta{
+				Generation: 1,
+			},
+		},
+		Release: common.Release{
+			Name: cluster.OpenDataHub,
+			Version: version.OperatorVersion{Version: semver.Version{
+				Major: 1, Minor: 2, Patch: 3,
+			}}},
+		Resources: []unstructured.Unstructured{*obj1},
+		Controller: mocks.NewMockController(func(m *mocks.MockController) {
+			m.On("Owns", mock.Anything).Return(false)
+		}),
+	}
+
+	err = action(ctx, &rr)
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	err = cl.Get(ctx, client.ObjectKeyFromObject(obj1), obj1)
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	g.Expect(obj1).Should(And(
+		jq.Match(`.metadata.annotations."%s" == "%s"`,
+			labels.ODHInfrastructurePrefix+annotations.SuffixInstanceGeneration,
+			strconv.FormatInt(rr.Instance.GetGeneration(), 10)),
+		jq.Match(`.metadata.annotations."%s" == "%s"`,
+			labels.ODHInfrastructurePrefix+annotations.SuffixInstanceName,
+			rr.Instance.GetName()),
+		jq.Match(`.metadata.annotations."%s" == "%s"`,
+			labels.ODHInfrastructurePrefix+annotations.SuffixInstanceUID,
+			string(rr.Instance.GetUID())),
+		jq.Match(`.metadata.annotations."%s" == "%s"`,
+			labels.ODHInfrastructurePrefix+annotations.SuffixType,
+			string(cluster.OpenDataHub)),
+		jq.Match(`.metadata.annotations."%s" == "%s"`,
+			labels.ODHInfrastructurePrefix+annotations.SuffixVersion,
+			"1.2.3"),
+		Not(jq.Match(`.metadata.annotations | has("%s")`, annotations.InstanceGeneration)),
+		Not(jq.Match(`.metadata.annotations | has("%s")`, annotations.PlatformType)),
+		Not(jq.Match(`.metadata.annotations | has("%s")`, annotations.PlatformVersion)),
+	))
+}
+
+func TestDeployCRDWithPartOfLabel(t *testing.T) {
+	g := NewWithT(t)
+
+	ctx := t.Context()
+	customLabelKey := "custom.example.io/part-of"
+
+	cl, err := fakeclient.New()
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	action := deploy.NewAction(
+		deploy.WithMode(deploy.ModePatch),
+		deploy.WithPartOfLabel(customLabelKey),
+	)
+
+	crd, err := resources.ToUnstructured(&apiextensionsv1.CustomResourceDefinition{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: apiextensionsv1.SchemeGroupVersion.String(),
+			Kind:       "CustomResourceDefinition",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "testresources.test.opendatahub.io",
+		},
+		Spec: apiextensionsv1.CustomResourceDefinitionSpec{
+			Group: "test.opendatahub.io",
+			Names: apiextensionsv1.CustomResourceDefinitionNames{
+				Kind:     "TestResource",
+				ListKind: "TestResourceList",
+				Plural:   "testresources",
+				Singular: "testresource",
+			},
+			Scope: apiextensionsv1.NamespaceScoped,
+			Versions: []apiextensionsv1.CustomResourceDefinitionVersion{
+				{
+					Name:    "v1",
+					Served:  true,
+					Storage: true,
+					Schema: &apiextensionsv1.CustomResourceValidation{
+						OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
+							Type: "object",
+						},
+					},
+				},
+			},
+		},
+	})
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	rr := types.ReconciliationRequest{
+		Client: cl,
+		Instance: &componentApi.Dashboard{
+			ObjectMeta: metav1.ObjectMeta{
+				Generation: 1,
+			},
+		},
+		Release: common.Release{
+			Name: cluster.OpenDataHub,
+			Version: version.OperatorVersion{Version: semver.Version{
+				Major: 1, Minor: 2, Patch: 3,
+			}},
+		},
+		Resources: []unstructured.Unstructured{*crd},
+		Controller: mocks.NewMockController(func(m *mocks.MockController) {
+			m.On("Owns", mock.Anything).Return(false)
+		}),
+	}
+
+	err = action(ctx, &rr)
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	out := resources.GvkToUnstructured(gvk.CustomResourceDefinition)
+	err = cl.Get(ctx, apimachinery.NamespacedName{Name: crd.GetName()}, out)
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	g.Expect(out).Should(And(
+		jq.Match(`.metadata.labels."%s" == "%s"`, customLabelKey, "dashboard"),
+		Not(jq.Match(`.metadata.labels | has("%s")`, labels.PlatformPartOf)),
+	))
+}

--- a/pkg/controller/actions/gc/action_gc.go
+++ b/pkg/controller/actions/gc/action_gc.go
@@ -30,6 +30,7 @@ type TypePredicateFn func(*odhTypes.ReconciliationRequest, schema.GroupVersionKi
 type ActionOpts func(*Action)
 
 type Action struct {
+	partOfLabelKey    string
 	labels            map[string]string
 	selector          labels.Selector
 	propagationPolicy client.PropagationPolicy
@@ -57,6 +58,14 @@ func WithLabels(values map[string]string) ActionOpts {
 		}
 
 		maps.Copy(action.labels, values)
+	}
+}
+
+// WithPartOfLabel overrides the label key used by getOrComputeSelector to find
+// resources owned by this controller.
+func WithPartOfLabel(key string) ActionOpts {
+	return func(action *Action) {
+		action.partOfLabelKey = key
 	}
 }
 
@@ -315,21 +324,15 @@ func (a *Action) delete(
 	return nil
 }
 
-// getOrComputeSelector returns the existing label selector if provided, or, it generates
-// a new selector using the provided value and 'platform.opendatahub.io/part-of' as a key.
-//
-// Parameters:
-//   - controllerName: the name of the controller to associate with the selector.
-//
-// Returns:
-//   - labels.Selector: either the cached selector or a newly constructed one.
+// getOrComputeSelector returns the existing label selector if provided, or generates
+// a new selector using the configured partOfLabelKey and the provided value.
 func (a *Action) getOrComputeSelector(partOf string) labels.Selector {
 	if a.selector != nil {
 		return a.selector
 	}
 
 	return labels.SelectorFromSet(map[string]string{
-		odhLabels.PlatformPartOf: partOf,
+		a.partOfLabelKey: partOf,
 	})
 }
 
@@ -339,7 +342,9 @@ func (a *Action) isUnremovable(gvk schema.GroupVersionKind) bool {
 }
 
 func NewAction(opts ...ActionOpts) actions.Fn {
-	action := Action{}
+	action := Action{
+		partOfLabelKey: odhLabels.PlatformPartOf,
+	}
 	action.objectPredicateFn = DefaultObjectPredicate
 	action.typePredicateFn = DefaultTypePredicate
 	action.onlyOwned = true

--- a/pkg/controller/actions/gc/action_gc_test.go
+++ b/pkg/controller/actions/gc/action_gc_test.go
@@ -608,6 +608,133 @@ func TestGcActionCluster(t *testing.T) {
 	g.Expect(ct).Should(BeNumerically("==", 2))
 }
 
+func TestGcActionWithPartOfLabel(t *testing.T) {
+	g := NewWithT(t)
+
+	envTest, err := envt.New()
+	g.Expect(err).NotTo(HaveOccurred())
+
+	t.Cleanup(func() {
+		_ = envTest.Stop()
+	})
+
+	ctx := context.Background()
+	cli := envTest.Client()
+	nsn := xid.New().String()
+	customLabelKey := "custom.example.io/part-of"
+
+	ns := corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: nsn,
+		},
+	}
+
+	g.Expect(cli.Create(ctx, &ns)).NotTo(HaveOccurred())
+
+	rr := types.ReconciliationRequest{
+		Client: cli,
+		Instance: &componentApi.Dashboard{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: componentApi.GroupVersion.String(),
+				Kind:       componentApi.DashboardKind,
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: componentApi.DashboardInstanceName,
+			},
+		},
+		Release: common.Release{
+			Name: cluster.OpenDataHub,
+			Version: version.OperatorVersion{
+				Version: semver.Version{Major: 0, Minor: 1, Patch: 0},
+			},
+		},
+		Generated: true,
+		Controller: mocks.NewMockController(func(m *mocks.MockController) {
+			m.On("GetClient").Return(envTest.Client())
+			m.On("GetDynamicClient").Return(envTest.DynamicClient())
+			m.On("GetDiscoveryClient").Return(envTest.DiscoveryClient())
+			m.On("Owns", mock.Anything).Return(false)
+		}),
+	}
+
+	g.Expect(cli.Create(ctx, rr.Instance)).NotTo(HaveOccurred())
+
+	t.Cleanup(func() {
+		g.Expect(cli.Delete(ctx, rr.Instance)).Should(Or(
+			Not(HaveOccurred()),
+			MatchError(k8serr.IsNotFound, "IsNotFound"),
+		))
+	})
+
+	staleAnnotations := map[string]string{
+		annotations.InstanceGeneration: strconv.FormatInt(rr.Instance.GetGeneration(), 10),
+		annotations.InstanceUID:        xid.New().String(),
+		annotations.PlatformVersion:    rr.Release.Version.String(),
+		annotations.PlatformType:       string(cluster.OpenDataHub),
+	}
+
+	cmCustom := corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "gc-cm-custom-label",
+			Namespace:   nsn,
+			Annotations: maps.Clone(staleAnnotations),
+			Labels: map[string]string{
+				customLabelKey: strings.ToLower(componentApi.DashboardKind),
+			},
+		},
+	}
+
+	g.Expect(controllerutil.SetOwnerReference(rr.Instance, &cmCustom, cli.Scheme())).
+		NotTo(HaveOccurred())
+
+	g.Expect(cli.Create(ctx, &cmCustom)).NotTo(HaveOccurred())
+
+	t.Cleanup(func() {
+		g.Expect(cli.Delete(ctx, &cmCustom)).Should(Or(
+			Not(HaveOccurred()),
+			MatchError(k8serr.IsNotFound, "IsNotFound"),
+		))
+	})
+
+	cmDefault := corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "gc-cm-default-label",
+			Namespace:   nsn,
+			Annotations: maps.Clone(staleAnnotations),
+			Labels: map[string]string{
+				labels.PlatformPartOf: strings.ToLower(componentApi.DashboardKind),
+			},
+		},
+	}
+
+	g.Expect(controllerutil.SetOwnerReference(rr.Instance, &cmDefault, cli.Scheme())).
+		NotTo(HaveOccurred())
+
+	g.Expect(cli.Create(ctx, &cmDefault)).NotTo(HaveOccurred())
+
+	t.Cleanup(func() {
+		g.Expect(cli.Delete(ctx, &cmDefault)).Should(Or(
+			Not(HaveOccurred()),
+			MatchError(k8serr.IsNotFound, "IsNotFound"),
+		))
+	})
+
+	a := gc.NewAction(
+		gc.WithDeletePropagationPolicy(metav1.DeletePropagationBackground),
+		gc.InNamespace(nsn),
+		gc.WithPartOfLabel(customLabelKey),
+	)
+
+	err = a(ctx, &rr)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	err = cli.Get(ctx, ctrlCli.ObjectKeyFromObject(&cmCustom), &corev1.ConfigMap{})
+	g.Expect(err).To(MatchError(k8serr.IsNotFound, "IsNotFound"))
+
+	err = cli.Get(ctx, ctrlCli.ObjectKeyFromObject(&cmDefault), &corev1.ConfigMap{})
+	g.Expect(err).NotTo(HaveOccurred())
+}
+
 func TestGcActionOnce(t *testing.T) {
 	g := NewWithT(t)
 

--- a/pkg/controller/actions/status/deployments/action_deployments_available.go
+++ b/pkg/controller/actions/status/deployments/action_deployments_available.go
@@ -19,8 +19,9 @@ import (
 )
 
 type Action struct {
-	labels      map[string]string
-	namespaceFn actions.Getter[string]
+	partOfLabelKey string
+	labels         map[string]string
+	namespaceFn    actions.Getter[string]
 }
 
 type ActionOpts func(*Action)
@@ -34,6 +35,14 @@ func WithSelectorLabel(k string, v string) ActionOpts {
 func WithSelectorLabels(values map[string]string) ActionOpts {
 	return func(action *Action) {
 		maps.Copy(action.labels, values)
+	}
+}
+
+// WithPartOfLabel overrides the label key used to discover Deployments belonging
+// to this controller for availability checks.
+func WithPartOfLabel(key string) ActionOpts {
+	return func(action *Action) {
+		action.partOfLabelKey = key
 	}
 }
 
@@ -58,13 +67,13 @@ func (a *Action) run(ctx context.Context, rr *types.ReconciliationRequest) error
 	l := make(map[string]string, len(a.labels))
 	maps.Copy(l, a.labels)
 
-	if l[labels.PlatformPartOf] == "" {
+	if l[a.partOfLabelKey] == "" {
 		kind, err := resources.KindForObject(rr.Client.Scheme(), rr.Instance)
 		if err != nil {
 			return err
 		}
 
-		l[labels.PlatformPartOf] = strings.ToLower(kind)
+		l[a.partOfLabelKey] = strings.ToLower(kind)
 	}
 
 	obj, ok := rr.Instance.(types.ResourceObject)
@@ -115,7 +124,8 @@ func (a *Action) run(ctx context.Context, rr *types.ReconciliationRequest) error
 
 func NewAction(opts ...ActionOpts) actions.Fn {
 	action := Action{
-		labels: map[string]string{},
+		partOfLabelKey: labels.PlatformPartOf,
+		labels:         map[string]string{},
 		namespaceFn: func(ctx context.Context, rr *types.ReconciliationRequest) (string, error) {
 			return cluster.ApplicationNamespace(ctx, rr.Client)
 		},

--- a/pkg/controller/actions/status/deployments/action_deployments_available_test.go
+++ b/pkg/controller/actions/status/deployments/action_deployments_available_test.go
@@ -274,6 +274,58 @@ func TestDeploymentsAvailableReadyAutoSelector(t *testing.T) {
 	)
 }
 
+func TestDeploymentsAvailableActionWithPartOfLabel(t *testing.T) {
+	g := NewWithT(t)
+
+	ctx := t.Context()
+	ns := xid.New().String()
+	customLabelKey := "custom.example.io/part-of"
+
+	cl, err := fakeclient.New(
+		fakeclient.WithObjects(
+			&appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-deployment",
+					Namespace: ns,
+					Labels: map[string]string{
+						customLabelKey: strings.ToLower(componentApi.DashboardKind),
+					},
+				},
+				Status: appsv1.DeploymentStatus{
+					Replicas:      1,
+					ReadyReplicas: 1,
+				},
+			},
+		),
+	)
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	action := deployments.NewAction(
+		deployments.WithPartOfLabel(customLabelKey),
+		deployments.InNamespace(ns),
+	)
+
+	rr := types.ReconciliationRequest{
+		Client:   cl,
+		Instance: &componentApi.Dashboard{},
+		Release:  common.Release{Name: cluster.OpenDataHub},
+	}
+
+	rr.Conditions = conditions.NewManager(rr.Instance, status.ConditionTypeReady)
+
+	err = action(ctx, &rr)
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	g.Expect(rr.Instance).Should(
+		WithTransform(
+			matchers.ExtractStatusCondition(status.ConditionDeploymentsAvailable),
+			gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+				"Status": Equal(metav1.ConditionTrue),
+			}),
+		),
+	)
+}
+
 func TestDeploymentsAvailableActionNotReadyNotFound(t *testing.T) {
 	g := NewWithT(t)
 

--- a/pkg/controller/cloudmanager/action_gc.go
+++ b/pkg/controller/cloudmanager/action_gc.go
@@ -13,7 +13,7 @@ import (
 	certmanager "github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/dependency/certmanager"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/gc"
 	odhTypes "github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
-	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/metadata/annotations"
+	odhAnnotations "github.com/opendatahub-io/opendatahub-operator/v2/pkg/metadata/annotations"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/metadata/labels"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/resources"
 )
@@ -39,6 +39,12 @@ type ProtectedObject struct {
 //   - Missing InstanceUID or InstanceGeneration annotations: keep (not a CCM resource).
 //   - UID mismatch with the current CR: delete (orphaned from a different CR instance).
 //   - Generation mismatch with the current CR: delete (stale resource).
+//
+// To handle upgrades from the old annotation prefix (platform.opendatahub.io) to the
+// new one (infrastructure.opendatahub.io), the predicate falls back to reading the old
+// annotations when the new ones are absent. This ensures resources deployed by the old
+// version are still subject to GC even if SSA did not re-apply them (e.g. a resource
+// removed from the Helm chart between versions).
 func newGCPredicate(protectedObjects []ProtectedObject) gc.ObjectPredicateFn {
 	log := logf.Log.WithName("ccm-gc")
 	protected := make(map[ProtectedObject]struct{}, len(protectedObjects))
@@ -54,8 +60,17 @@ func newGCPredicate(protectedObjects []ProtectedObject) gc.ObjectPredicateFn {
 			return false, nil
 		}
 
-		iUID := resources.GetAnnotation(&obj, annotations.InstanceUID)
-		iGeneration := resources.GetAnnotation(&obj, annotations.InstanceGeneration)
+		iUID := resources.GetAnnotation(&obj, labels.ODHInfrastructurePrefix+odhAnnotations.SuffixInstanceUID)
+		iGeneration := resources.GetAnnotation(&obj, labels.ODHInfrastructurePrefix+odhAnnotations.SuffixInstanceGeneration)
+
+		// Fall back to old platform annotations as well, to ensure that GC is aware of potential leftover
+		// resources deployed before the infrastructure annotation migration.
+		if iUID == "" {
+			iUID = resources.GetAnnotation(&obj, labels.ODHPlatformPrefix+odhAnnotations.SuffixInstanceUID)
+		}
+		if iGeneration == "" {
+			iGeneration = resources.GetAnnotation(&obj, labels.ODHPlatformPrefix+odhAnnotations.SuffixInstanceGeneration)
+		}
 
 		if iUID == "" || iGeneration == "" {
 			return false, nil

--- a/pkg/controller/cloudmanager/action_gc_test.go
+++ b/pkg/controller/cloudmanager/action_gc_test.go
@@ -11,7 +11,8 @@ import (
 
 	ccmv1alpha1 "github.com/opendatahub-io/opendatahub-operator/v2/api/cloudmanager/azure/v1alpha1"
 	odhTypes "github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
-	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/metadata/annotations"
+	odhAnnotations "github.com/opendatahub-io/opendatahub-operator/v2/pkg/metadata/annotations"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/metadata/labels"
 
 	. "github.com/onsi/gomega"
 )
@@ -53,8 +54,16 @@ func simpleObj(anns map[string]string) unstructured.Unstructured {
 // ccmAnns returns the standard cloud manager annotations for the test UID and generation.
 func ccmAnns(uid string, generation string) map[string]string {
 	return map[string]string{
-		annotations.InstanceUID:        uid,
-		annotations.InstanceGeneration: generation,
+		labels.ODHInfrastructurePrefix + odhAnnotations.SuffixInstanceUID:        uid,
+		labels.ODHInfrastructurePrefix + odhAnnotations.SuffixInstanceGeneration: generation,
+	}
+}
+
+// legacyCCMAnns returns the old platform.opendatahub.io annotations for the test UID and generation.
+func legacyCCMAnns(uid string, generation string) map[string]string {
+	return map[string]string{
+		labels.ODHPlatformPrefix + odhAnnotations.SuffixInstanceUID:        uid,
+		labels.ODHPlatformPrefix + odhAnnotations.SuffixInstanceGeneration: generation,
 	}
 }
 
@@ -80,12 +89,12 @@ func TestNewGCPredicate(t *testing.T) {
 		},
 		{
 			name:       "missing UID annotation only — keep",
-			obj:        simpleObj(map[string]string{annotations.InstanceGeneration: "5"}),
+			obj:        simpleObj(map[string]string{labels.ODHInfrastructurePrefix + odhAnnotations.SuffixInstanceGeneration: "5"}),
 			wantDelete: false,
 		},
 		{
 			name:       "missing generation annotation only — keep",
-			obj:        simpleObj(map[string]string{annotations.InstanceUID: string(testUID)}),
+			obj:        simpleObj(map[string]string{labels.ODHInfrastructurePrefix + odhAnnotations.SuffixInstanceUID: string(testUID)}),
 			wantDelete: false,
 		},
 		{
@@ -94,8 +103,11 @@ func TestNewGCPredicate(t *testing.T) {
 			wantDelete: false,
 		},
 		{
-			name:       "empty-string generation annotation — keep",
-			obj:        simpleObj(map[string]string{annotations.InstanceUID: string(testUID), annotations.InstanceGeneration: ""}),
+			name: "empty-string generation annotation — keep",
+			obj: simpleObj(map[string]string{
+				labels.ODHInfrastructurePrefix + odhAnnotations.SuffixInstanceUID:        string(testUID),
+				labels.ODHInfrastructurePrefix + odhAnnotations.SuffixInstanceGeneration: "",
+			}),
 			wantDelete: false,
 		},
 		{
@@ -152,6 +164,27 @@ func TestNewGCPredicate(t *testing.T) {
 		{
 			name:       "malformed InstanceGeneration — skip (do not delete)",
 			obj:        simpleObj(ccmAnns(string(testUID), "not-a-number")),
+			wantDelete: false,
+		},
+		// Legacy platform.opendatahub.io annotation fallback cases.
+		{
+			name:       "legacy annotations: UID matches, generation matches — keep",
+			obj:        simpleObj(legacyCCMAnns(string(testUID), "5")),
+			wantDelete: false,
+		},
+		{
+			name:       "legacy annotations: UID mismatch — delete",
+			obj:        simpleObj(legacyCCMAnns("different-uid", "5")),
+			wantDelete: true,
+		},
+		{
+			name:       "legacy annotations: UID matches, generation mismatch — delete",
+			obj:        simpleObj(legacyCCMAnns(string(testUID), "3")),
+			wantDelete: true,
+		},
+		{
+			name:       "legacy annotations: malformed generation — skip (do not delete)",
+			obj:        simpleObj(legacyCCMAnns(string(testUID), "not-a-number")),
 			wantDelete: false,
 		},
 	}

--- a/pkg/controller/cloudmanager/action_reconcile.go
+++ b/pkg/controller/cloudmanager/action_reconcile.go
@@ -12,7 +12,6 @@ import (
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/status/deployments"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/metadata/labels"
-	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/resources"
 )
 
 var ConditionsTypes = []string{
@@ -46,7 +45,6 @@ func WithDeployOptions(opts ...deploy.ActionOpts) ReconcileActionOpts {
 // NewReconcileAction creates a combined action that:
 // - Renders Helm charts
 // - Runs PreApply hooks from HelmCharts
-// - Sets infrastructure labels on rendered resources
 // - Deploys resources via SSA
 // - Runs PostApply hooks from HelmCharts
 // - Checks deployment status.
@@ -65,11 +63,16 @@ func NewReconcileAction(resourceID string, opts ...ReconcileActionOpts) (actions
 	}
 
 	helmRender := helm.NewAction(action.helmOpts...)
-	deployAction := deploy.NewAction(append(action.deployOpts, deploy.WithApplyOrder())...)
+	deployAction := deploy.NewAction(append(action.deployOpts,
+		deploy.WithApplyOrder(),
+		deploy.WithPartOfLabel(labels.InfrastructurePartOf),
+		deploy.WithAnnotationPrefix(labels.ODHInfrastructurePrefix),
+	)...)
 	deploymentsAction := deployments.NewAction(
 		deployments.InNamespaceFn(func(_ context.Context, _ *types.ReconciliationRequest) (string, error) {
 			return "", nil
 		}),
+		deployments.WithPartOfLabel(labels.InfrastructurePartOf),
 		deployments.WithSelectorLabel(labels.InfrastructurePartOf, action.resourceID),
 	)
 
@@ -85,11 +88,6 @@ func NewReconcileAction(resourceID string, opts ...ReconcileActionOpts) (actions
 		})
 		if err != nil {
 			return err
-		}
-
-		// Set infrastructure label on all rendered resources
-		for i := range rr.Resources {
-			resources.SetLabel(&rr.Resources[i], labels.InfrastructurePartOf, action.resourceID)
 		}
 
 		// Deploy resources via SSA

--- a/pkg/controller/cloudmanager/action_reconcile_integration_test.go
+++ b/pkg/controller/cloudmanager/action_reconcile_integration_test.go
@@ -26,17 +26,19 @@ import (
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/conditions"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/metadata/labels"
-	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/resources"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/fakeclient"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/mocks"
 
 	. "github.com/onsi/gomega"
 )
 
-const (
-	testReleaseName = "test"
-	testResourceID  = "testresourceid"
-)
+const testReleaseName = "test"
+
+// only azurekubernetesengine is used as resourceID for the test suite as coreweave setup is analogous to azure at the moment
+//
+// in case more CCM controllers with their own configuration options were added in the future,
+// the test suite should be expanded upon accordingly.
+var testResourceID = labels.NormalizePartOfValue(ccmv1alpha1.AzureKubernetesEngineKind)
 
 func newTestReconcileAction(t *testing.T) func(context.Context, *types.ReconciliationRequest) error {
 	t.Helper()
@@ -303,10 +305,11 @@ func TestNewReconcileAction_SetsInfrastructureLabel(t *testing.T) {
 	g.Expect(err).ShouldNot(HaveOccurred())
 	g.Expect(rr.Resources).Should(HaveLen(1))
 
-	for _, res := range rr.Resources {
-		g.Expect(resources.GetLabel(&res, labels.InfrastructurePartOf)).
-			Should(Equal(testResourceID))
-	}
+	cm := &corev1.ConfigMap{}
+	err = cl.Get(ctx, client.ObjectKey{Namespace: ns, Name: fmt.Sprintf("%s-config", testReleaseName)}, cm)
+	g.Expect(err).ShouldNot(HaveOccurred())
+	g.Expect(cm.Labels).Should(HaveKeyWithValue(labels.InfrastructurePartOf, "azurekubernetesengine"))
+	g.Expect(cm.Labels).ShouldNot(HaveKey(labels.PlatformPartOf))
 }
 
 func TestNewReconcileAction_MultipleCharts(t *testing.T) {

--- a/pkg/controller/reconciler/reconciler_support.go
+++ b/pkg/controller/reconciler/reconciler_support.go
@@ -307,11 +307,10 @@ func (b *ReconcilerBuilder[T]) Watches(object client.Object, opts ...WatchOpts) 
 		in.eventHandler = handlers.AnnotationToName(annotations.InstanceName)
 	}
 
+	// CCM controllers supply explicit Watches predicates, so this default does not apply to them
 	if len(in.predicates) == 0 {
 		in.predicates = append(in.predicates, predicate.And(
 			predicates.DefaultPredicate,
-			// use the platform.opendatahub.io/part-of label to filter
-			// events not related to the owner type
 			component.ForLabel(labels.PlatformPartOf, strings.ToLower(b.input.gvk.Kind)),
 		))
 	}

--- a/pkg/metadata/annotations/annotations.go
+++ b/pkg/metadata/annotations/annotations.go
@@ -18,11 +18,19 @@ const (
 const ManagementStateAnnotation = "component.opendatahub.io/management-state"
 
 const (
-	PlatformVersion    = "platform.opendatahub.io/version"
-	PlatformType       = "platform.opendatahub.io/type"
-	InstanceGeneration = "platform.opendatahub.io/instance.generation"
-	InstanceName       = "platform.opendatahub.io/instance.name"
-	InstanceUID        = "platform.opendatahub.io/instance.uid"
+	SuffixVersion            = "/version"
+	SuffixType               = "/type"
+	SuffixInstanceGeneration = "/instance.generation"
+	SuffixInstanceName       = "/instance.name"
+	SuffixInstanceUID        = "/instance.uid"
+)
+
+const (
+	PlatformVersion    = "platform.opendatahub.io" + SuffixVersion
+	PlatformType       = "platform.opendatahub.io" + SuffixType
+	InstanceGeneration = "platform.opendatahub.io" + SuffixInstanceGeneration
+	InstanceName       = "platform.opendatahub.io" + SuffixInstanceName
+	InstanceUID        = "platform.opendatahub.io" + SuffixInstanceUID
 )
 
 // Connection annotation for referencing secrets containing connection information.

--- a/tests/e2e/cloudmanager/cloudmanager_test.go
+++ b/tests/e2e/cloudmanager/cloudmanager_test.go
@@ -118,7 +118,10 @@ func TestCloudManager(t *testing.T) { //nolint:maintidx // sequential subtests s
 
 					wt.Get(gvk.Deployment, nn).Eventually().Should(And(
 						jq.Match(`.metadata.labels."%s" == "%s"`, labels.InfrastructurePartOf, partOfValue),
-						jq.Match(`.metadata.annotations."%s" == "%s"`, annotations.InstanceName, provider.InstanceName),
+						Not(jq.Match(`.metadata.labels | has("%s")`, labels.PlatformPartOf)),
+						jq.Match(`.metadata.annotations."%s" == "%s"`,
+							labels.ODHInfrastructurePrefix+annotations.SuffixInstanceName, provider.InstanceName),
+						Not(jq.Match(`.metadata.annotations | has("%s")`, annotations.InstanceName)),
 					))
 				})
 			}
@@ -387,8 +390,8 @@ func TestCloudManager(t *testing.T) { //nolint:maintidx // sequential subtests s
 				labels.InfrastructurePartOf: strings.ToLower(provider.GVK.Kind),
 			})
 			staleCM.SetAnnotations(map[string]string{
-				annotations.InstanceUID:        string(cr.GetUID()),
-				annotations.InstanceGeneration: "-1",
+				labels.ODHInfrastructurePrefix + annotations.SuffixInstanceUID:        string(cr.GetUID()),
+				labels.ODHInfrastructurePrefix + annotations.SuffixInstanceGeneration: "-1",
 			})
 			_ = unstructured.SetNestedSlice(staleCM.Object, []any{
 				map[string]any{


### PR DESCRIPTION
## Description
JIRA ref: [RHOAIENG-52338](https://redhat.atlassian.net/browse/RHOAIENG-52338)

This PR brings changes to
- cloud controller manager
- deploy action
- garbage collector action

to de-couple CCM resources from being attached with the `platform.opendatahub.io/part-of` label

## How Has This Been Tested?
- Running Cloud manager on Kind cluster, applying sample AzureKubernetesEngine CR, checking that there are no resources with platform partOf label
- new unit tests for partOf label override
- e2e check for Helm rendered resources updated

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [ ] New RELATED_IMAGE mappings are already listed in ODH-Build-Config and RHOAI-Build-Config, and links are included in PR description

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [ ] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable "part-of" label key and configurable annotation prefix with sensible defaults; deployments, GC, and status checks respect configured keys. Field-owner resolution for deployments is centralized. Infrastructure deployments now use the infrastructure-prefixed annotation keys and only set part-of labels when absent.

* **Tests**
  * Added/updated unit, integration, and e2e tests covering custom part-of keys, annotation prefixes, CRD vs non-CRD deploys, GC behavior, and updated assertions for infrastructure labels and absent default platform label.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->