### PR TITLE
feat: add prerequisite validation for MaaS operator reconciliation

### DIFF
--- a/internal/controller/components/modelsasservice/modelsasservice_controller.go
+++ b/internal/controller/components/modelsasservice/modelsasservice_controller.go
@@ -92,6 +92,7 @@ func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.
 			reconciler.WithPredicates(resources.CreatedOrUpdatedOrDeletedNamed(MaaSDBSecretName)),
 		).
 		WithAction(initialize).
+		WithAction(checkDependencies()).
 		WithAction(validatePrerequisites).
 		WithAction(validateGateway).
 		WithAction(customizeManifests).

--- a/internal/controller/components/modelsasservice/modelsasservice_controller.go
+++ b/internal/controller/components/modelsasservice/modelsasservice_controller.go
@@ -81,6 +81,16 @@ func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.
 			),
 			reconciler.WithPredicates(resources.Deleted()),
 		).
+		// Watch the maas-db-config Secret so reconciliation triggers when it is
+		// created, updated, or deleted — allowing the prerequisite check to
+		// clear or surface the error without waiting for periodic resync.
+		Watches(
+			&corev1.Secret{},
+			reconciler.WithEventHandler(
+				handlers.ToNamed(componentApi.ModelsAsServiceInstanceName),
+			),
+			reconciler.WithPredicates(resources.CreatedOrUpdatedOrDeletedNamed(MaaSDBSecretName)),
+		).
 		WithAction(initialize).
 		WithAction(validatePrerequisites).
 		WithAction(validateGateway).

--- a/internal/controller/components/modelsasservice/modelsasservice_controller.go
+++ b/internal/controller/components/modelsasservice/modelsasservice_controller.go
@@ -82,6 +82,7 @@ func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.
 			reconciler.WithPredicates(resources.Deleted()),
 		).
 		WithAction(initialize).
+		WithAction(validatePrerequisites).
 		WithAction(validateGateway).
 		WithAction(customizeManifests).
 		WithAction(kustomize.NewAction(

--- a/internal/controller/components/modelsasservice/modelsasservice_controller_prerequisites.go
+++ b/internal/controller/components/modelsasservice/modelsasservice_controller_prerequisites.go
@@ -92,7 +92,8 @@ func validatePrerequisites(ctx context.Context, rr *types.ReconciliationRequest)
 		log.V(1).Info("MaaS prerequisite warning", "check", "user-workload-monitoring", "message", msg)
 	}
 
-	// If there are blocking errors, set condition with Error severity (affects Ready state)
+	// If there are blocking errors, set PrerequisitesAvailable=False (affects Ready)
+	// and Degraded=True with all messages
 	if len(errors) > 0 {
 		allMessages := append(errors, warnings...) //nolint:gocritic // intentional append to new slice
 		aggregatedMessage := strings.Join(allMessages, "; ")
@@ -103,24 +104,39 @@ func validatePrerequisites(ctx context.Context, rr *types.ReconciliationRequest)
 			conditions.WithMessage("%s", aggregatedMessage),
 		)
 
+		rr.Conditions.MarkTrue(
+			status.ConditionTypeDegraded,
+			conditions.WithReason("PrerequisitesMissing"),
+			conditions.WithMessage("%s", aggregatedMessage),
+		)
+
 		return odherrors.NewStopError("blocking prerequisites missing: %s", aggregatedMessage)
 	}
 
-	// If there are only warnings, set Info severity (does not affect Ready state)
+	// If there are only warnings, keep Ready=True but set Degraded=True so admins
+	// can see that something needs attention. Non-blocking warnings (e.g. Authorino TLS,
+	// User Workload Monitoring) don't prevent the component from working but indicate
+	// degraded functionality.
 	if len(warnings) > 0 {
 		aggregatedMessage := strings.Join(warnings, "; ")
 
-		rr.Conditions.MarkFalse(
-			status.ConditionMaaSPrerequisitesAvailable,
+		rr.Conditions.MarkTrue(status.ConditionMaaSPrerequisitesAvailable)
+
+		rr.Conditions.MarkTrue(
+			status.ConditionTypeDegraded,
 			conditions.WithReason("PrerequisitesWarning"),
 			conditions.WithMessage("%s", aggregatedMessage),
-			conditions.WithSeverity(common.ConditionSeverityInfo),
 		)
 
 		return nil
 	}
 
 	rr.Conditions.MarkTrue(status.ConditionMaaSPrerequisitesAvailable)
+	rr.Conditions.MarkFalse(
+		status.ConditionTypeDegraded,
+		conditions.WithReason("PrerequisitesMet"),
+		conditions.WithMessage("All prerequisites are satisfied"),
+	)
 
 	return nil
 }

--- a/internal/controller/components/modelsasservice/modelsasservice_controller_prerequisites.go
+++ b/internal/controller/components/modelsasservice/modelsasservice_controller_prerequisites.go
@@ -54,16 +54,16 @@ func validatePrerequisites(ctx context.Context, rr *types.ReconciliationRequest)
 	var warnings []string
 	var errors []string
 
-	// Check 1: Kuadrant/RHCL stack (AuthConfig CRD from Authorino)
+	// Check 1: Kuadrant/RHCL stack (blocking — gateway can't authenticate without it)
 	if msg := checkKuadrantAvailable(ctx, rr); msg != "" {
-		warnings = append(warnings, msg)
-		log.V(1).Info("MaaS prerequisite warning", "check", "kuadrant", "message", msg)
+		errors = append(errors, msg)
+		log.Error(nil, "MaaS prerequisite error", "check", "kuadrant", "message", msg)
 	}
 
-	// Check 2: Authorino TLS configuration
+	// Check 2: Authorino TLS configuration (blocking — gateway can't authenticate without TLS)
 	if msg := checkAuthorinoTLS(ctx, rr); msg != "" {
-		warnings = append(warnings, msg)
-		log.V(1).Info("MaaS prerequisite warning", "check", "authorino-tls", "message", msg)
+		errors = append(errors, msg)
+		log.Error(nil, "MaaS prerequisite error", "check", "authorino-tls", "message", msg)
 	}
 
 	// Check 3: Database Secret (blocking — maas-api cannot start without it)

--- a/internal/controller/components/modelsasservice/modelsasservice_controller_prerequisites.go
+++ b/internal/controller/components/modelsasservice/modelsasservice_controller_prerequisites.go
@@ -34,7 +34,6 @@ import (
 	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/status"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
-	odherrors "github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/errors"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/conditions"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
 )
@@ -95,7 +94,7 @@ func validatePrerequisites(ctx context.Context, rr *types.ReconciliationRequest)
 			conditions.WithMessage("%s", aggregatedMessage),
 		)
 
-		return odherrors.NewStopError("blocking prerequisites missing: %s", aggregatedMessage)
+		return nil
 	}
 
 	// If there are only warnings, set Info severity (does not affect Ready state)
@@ -189,8 +188,10 @@ func checkDatabaseSecret(ctx context.Context, rr *types.ReconciliationRequest) s
 
 	if err != nil {
 		if k8serr.IsNotFound(err) {
-			return fmt.Sprintf("Required secret '%s' not found in namespace '%s'.",
-				MaaSDBSecretName, appNamespace)
+			return fmt.Sprintf("database Secret '%s' not found in namespace '%s'. "+
+				"Create the Secret with key '%s' containing the PostgreSQL connection URL. "+
+				"MaaS API cannot start without a database connection",
+				MaaSDBSecretName, appNamespace, MaaSDBSecretKey)
 		}
 		return fmt.Sprintf("failed to check database Secret '%s' in namespace '%s': %v",
 			MaaSDBSecretName, appNamespace, err)

--- a/internal/controller/components/modelsasservice/modelsasservice_controller_prerequisites.go
+++ b/internal/controller/components/modelsasservice/modelsasservice_controller_prerequisites.go
@@ -34,6 +34,7 @@ import (
 	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/status"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
+	odherrors "github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/errors"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/conditions"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
 )
@@ -94,7 +95,7 @@ func validatePrerequisites(ctx context.Context, rr *types.ReconciliationRequest)
 			conditions.WithMessage("%s", aggregatedMessage),
 		)
 
-		return nil
+		return odherrors.NewStopError("blocking prerequisites missing: %s", aggregatedMessage)
 	}
 
 	// If there are only warnings, set Info severity (does not affect Ready state)
@@ -120,7 +121,8 @@ func validatePrerequisites(ctx context.Context, rr *types.ReconciliationRequest)
 func checkKuadrantAvailable(ctx context.Context, rr *types.ReconciliationRequest) string {
 	has, err := cluster.HasCRD(ctx, rr.Client, gvk.AuthConfigv1beta3)
 	if err != nil {
-		return fmt.Sprintf("failed to check Kuadrant/RHCL availability: %v", err)
+		logf.FromContext(ctx).Error(err, "failed to check Kuadrant/RHCL availability")
+		return "failed to check Kuadrant/RHCL availability due to a cluster API error"
 	}
 	if !has {
 		return "Kuadrant/RHCL stack not installed: AuthConfig CRD (authorino.kuadrant.io) not found. " +
@@ -135,9 +137,10 @@ func checkKuadrantAvailable(ctx context.Context, rr *types.ReconciliationRequest
 // If multiple Authorino instances exist, the check passes if any one has TLS enabled.
 func checkAuthorinoTLS(ctx context.Context, rr *types.ReconciliationRequest) string {
 	// First check if the Authorino CRD exists
-	has, err := cluster.HasCRD(ctx, rr.Client, gvk.Authorinov1beta2)
+	has, err := cluster.HasCRD(ctx, rr.Client, gvk.Authorinov1beta1)
 	if err != nil {
-		return fmt.Sprintf("failed to check Authorino CRD availability: %v", err)
+		logf.FromContext(ctx).Error(err, "failed to check Authorino CRD availability")
+		return "failed to check Authorino CRD availability due to a cluster API error"
 	}
 	if !has {
 		// Authorino CRD not present — skip TLS check (Kuadrant check handles the dependency)
@@ -146,9 +149,10 @@ func checkAuthorinoTLS(ctx context.Context, rr *types.ReconciliationRequest) str
 
 	// List all Authorino instances across namespaces
 	authorinoList := &unstructured.UnstructuredList{}
-	authorinoList.SetGroupVersionKind(gvk.Authorinov1beta2)
+	authorinoList.SetGroupVersionKind(gvk.Authorinov1beta1)
 	if err := rr.Client.List(ctx, authorinoList, &client.ListOptions{}); err != nil {
-		return fmt.Sprintf("failed to list Authorino instances: %v", err)
+		logf.FromContext(ctx).Error(err, "failed to list Authorino instances")
+		return "failed to list Authorino instances due to a cluster API error"
 	}
 
 	if len(authorinoList.Items) == 0 {
@@ -177,7 +181,8 @@ func checkAuthorinoTLS(ctx context.Context, rr *types.ReconciliationRequest) str
 func checkDatabaseSecret(ctx context.Context, rr *types.ReconciliationRequest) string {
 	appNamespace, err := cluster.ApplicationNamespace(ctx, rr.Client)
 	if err != nil {
-		return fmt.Sprintf("failed to determine application namespace: %v", err)
+		logf.FromContext(ctx).Error(err, "failed to determine application namespace")
+		return "failed to determine application namespace due to a cluster API error"
 	}
 
 	secret := &corev1.Secret{}
@@ -193,8 +198,9 @@ func checkDatabaseSecret(ctx context.Context, rr *types.ReconciliationRequest) s
 				"MaaS API cannot start without a database connection",
 				MaaSDBSecretName, appNamespace, MaaSDBSecretKey)
 		}
-		return fmt.Sprintf("failed to check database Secret '%s' in namespace '%s': %v",
-			MaaSDBSecretName, appNamespace, err)
+		logf.FromContext(ctx).Error(err, "failed to check database Secret", "name", MaaSDBSecretName, "namespace", appNamespace)
+		return fmt.Sprintf("failed to check database Secret '%s' in namespace '%s' due to a cluster API error",
+			MaaSDBSecretName, appNamespace)
 	}
 
 	if _, ok := secret.Data[MaaSDBSecretKey]; !ok {
@@ -221,8 +227,9 @@ func checkUserWorkloadMonitoring(ctx context.Context, rr *types.ReconciliationRe
 				"Showback/FinOps usage views will not work without User Workload Monitoring enabled"
 		}
 		// Access errors (e.g., RBAC) should not block — log and continue
-		return fmt.Sprintf("unable to verify User Workload Monitoring status: %v. "+
-			"Ensure User Workload Monitoring is enabled for showback functionality", err)
+		logf.FromContext(ctx).Error(err, "unable to verify User Workload Monitoring status")
+		return "unable to verify User Workload Monitoring status due to a cluster API error. " +
+			"Ensure User Workload Monitoring is enabled for showback functionality"
 	}
 
 	configData, ok := cm.Data["config.yaml"]
@@ -254,7 +261,8 @@ func checkUserWorkloadMonitoring(ctx context.Context, rr *types.ReconciliationRe
 func checkKuadrantMonitoring(ctx context.Context, rr *types.ReconciliationRequest) string {
 	has, err := cluster.HasCRD(ctx, rr.Client, gvk.TelemetryPolicyv1alpha1)
 	if err != nil {
-		return fmt.Sprintf("failed to check Kuadrant monitoring availability: %v", err)
+		logf.FromContext(ctx).Error(err, "failed to check Kuadrant monitoring availability")
+		return "failed to check Kuadrant monitoring availability due to a cluster API error"
 	}
 	if !has {
 		return "Kuadrant monitoring not available: TelemetryPolicy CRD (extensions.kuadrant.io) not found. " +

--- a/internal/controller/components/modelsasservice/modelsasservice_controller_prerequisites.go
+++ b/internal/controller/components/modelsasservice/modelsasservice_controller_prerequisites.go
@@ -34,15 +34,33 @@ import (
 	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/status"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/dependency"
 	odherrors "github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/errors"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/conditions"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
 )
 
-// validatePrerequisites checks that required platform prerequisites are present and
-// surfaces clear warnings when they are missing. Checks are either blocking (error
-// severity, affects Ready state) or non-blocking (info severity, visible but does
-// not prevent reconciliation).
+// checkDependencies uses the dependency action framework to monitor CRD availability.
+// This sets the DependenciesAvailable condition based on CRD presence.
+func checkDependencies() actions.Fn {
+	return dependency.NewAction(
+		// Kuadrant/RHCL stack — required for gateway authentication
+		dependency.MonitorCRD(dependency.CRDConfig{
+			GVK: gvk.AuthConfigv1beta3,
+		}),
+		// Kuadrant monitoring — optional, only affects showback/FinOps views
+		dependency.MonitorCRD(dependency.CRDConfig{
+			GVK:      gvk.TelemetryPolicyv1alpha1,
+			Severity: common.ConditionSeverityInfo,
+		}),
+	)
+}
+
+// validatePrerequisites checks platform prerequisites that require custom validation
+// beyond simple CRD presence checks (which are handled by checkDependencies).
+// Checks are either blocking (error severity, affects Ready state) or non-blocking
+// (info severity, visible but does not prevent reconciliation).
 func validatePrerequisites(ctx context.Context, rr *types.ReconciliationRequest) error {
 	log := logf.FromContext(ctx)
 
@@ -54,34 +72,22 @@ func validatePrerequisites(ctx context.Context, rr *types.ReconciliationRequest)
 	var warnings []string
 	var errors []string
 
-	// Check 1: Kuadrant/RHCL stack (blocking — gateway can't authenticate without it)
-	if msg := checkKuadrantAvailable(ctx, rr); msg != "" {
-		errors = append(errors, msg)
-		log.Error(nil, "MaaS prerequisite error", "check", "kuadrant", "message", msg)
-	}
-
-	// Check 2: Authorino TLS configuration (blocking — gateway can't authenticate without TLS)
+	// Check 1: Authorino TLS configuration (blocking — gateway can't authenticate without TLS)
 	if msg := checkAuthorinoTLS(ctx, rr); msg != "" {
 		errors = append(errors, msg)
 		log.Error(nil, "MaaS prerequisite error", "check", "authorino-tls", "message", msg)
 	}
 
-	// Check 3: Database Secret (blocking — maas-api cannot start without it)
+	// Check 2: Database Secret (blocking — maas-api cannot start without it)
 	if msg := checkDatabaseSecret(ctx, rr); msg != "" {
 		errors = append(errors, msg)
 		log.Error(nil, "MaaS prerequisite error", "check", "database-secret", "message", msg)
 	}
 
-	// Check 4: User Workload Monitoring
+	// Check 3: User Workload Monitoring (non-blocking — only affects showback views)
 	if msg := checkUserWorkloadMonitoring(ctx, rr); msg != "" {
 		warnings = append(warnings, msg)
 		log.V(1).Info("MaaS prerequisite warning", "check", "user-workload-monitoring", "message", msg)
-	}
-
-	// Check 5: Kuadrant monitoring (TelemetryPolicy CRD)
-	if msg := checkKuadrantMonitoring(ctx, rr); msg != "" {
-		warnings = append(warnings, msg)
-		log.V(1).Info("MaaS prerequisite warning", "check", "kuadrant-monitoring", "message", msg)
 	}
 
 	// If there are blocking errors, set condition with Error severity (affects Ready state)
@@ -115,20 +121,6 @@ func validatePrerequisites(ctx context.Context, rr *types.ReconciliationRequest)
 	rr.Conditions.MarkTrue(status.ConditionMaaSPrerequisitesAvailable)
 
 	return nil
-}
-
-// checkKuadrantAvailable verifies the Kuadrant/RHCL stack is installed by checking for the AuthConfig CRD.
-func checkKuadrantAvailable(ctx context.Context, rr *types.ReconciliationRequest) string {
-	has, err := cluster.HasCRD(ctx, rr.Client, gvk.AuthConfigv1beta3)
-	if err != nil {
-		logf.FromContext(ctx).Error(err, "failed to check Kuadrant/RHCL availability")
-		return "failed to check Kuadrant/RHCL availability due to a cluster API error"
-	}
-	if !has {
-		return "Kuadrant/RHCL stack not installed: AuthConfig CRD (authorino.kuadrant.io) not found. " +
-			"Install the Kuadrant operator to enable authentication and authorization"
-	}
-	return ""
 }
 
 // checkAuthorinoTLS verifies that at least one Authorino instance has TLS enabled
@@ -226,7 +218,7 @@ func checkUserWorkloadMonitoring(ctx context.Context, rr *types.ReconciliationRe
 			return "User Workload Monitoring not configured: ConfigMap 'cluster-monitoring-config' not found in 'openshift-monitoring'. " +
 				"Showback/FinOps usage views will not work without User Workload Monitoring enabled"
 		}
-		// Access errors (e.g., RBAC) should not block — log and continue
+		// Access errors (e.g., RBAC) — surface as a warning so the user knows verification failed
 		logf.FromContext(ctx).Error(err, "unable to verify User Workload Monitoring status")
 		return "unable to verify User Workload Monitoring status due to a cluster API error. " +
 			"Ensure User Workload Monitoring is enabled for showback functionality"
@@ -253,20 +245,5 @@ func checkUserWorkloadMonitoring(ctx context.Context, rr *types.ReconciliationRe
 			"Showback/FinOps usage views will not work without it"
 	}
 
-	return ""
-}
-
-// checkKuadrantMonitoring checks if Kuadrant monitoring is available by verifying
-// the TelemetryPolicy CRD is present.
-func checkKuadrantMonitoring(ctx context.Context, rr *types.ReconciliationRequest) string {
-	has, err := cluster.HasCRD(ctx, rr.Client, gvk.TelemetryPolicyv1alpha1)
-	if err != nil {
-		logf.FromContext(ctx).Error(err, "failed to check Kuadrant monitoring availability")
-		return "failed to check Kuadrant monitoring availability due to a cluster API error"
-	}
-	if !has {
-		return "Kuadrant monitoring not available: TelemetryPolicy CRD (extensions.kuadrant.io) not found. " +
-			"Showback/FinOps usage views will not work without Kuadrant monitoring enabled"
-	}
 	return ""
 }

--- a/internal/controller/components/modelsasservice/modelsasservice_controller_prerequisites.go
+++ b/internal/controller/components/modelsasservice/modelsasservice_controller_prerequisites.go
@@ -34,6 +34,7 @@ import (
 	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/status"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
+	odherrors "github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/errors"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/conditions"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
 )
@@ -94,7 +95,7 @@ func validatePrerequisites(ctx context.Context, rr *types.ReconciliationRequest)
 			conditions.WithMessage("%s", aggregatedMessage),
 		)
 
-		return nil
+		return odherrors.NewStopError("blocking prerequisites missing: %s", aggregatedMessage)
 	}
 
 	// If there are only warnings, set Info severity (does not affect Ready state)
@@ -188,10 +189,8 @@ func checkDatabaseSecret(ctx context.Context, rr *types.ReconciliationRequest) s
 
 	if err != nil {
 		if k8serr.IsNotFound(err) {
-			return fmt.Sprintf("database Secret '%s' not found in namespace '%s'. "+
-				"Create the Secret with key '%s' containing the PostgreSQL connection URL. "+
-				"MaaS API cannot start without a database connection",
-				MaaSDBSecretName, appNamespace, MaaSDBSecretKey)
+			return fmt.Sprintf("Required secret '%s' not found in namespace '%s'.",
+				MaaSDBSecretName, appNamespace)
 		}
 		return fmt.Sprintf("failed to check database Secret '%s' in namespace '%s': %v",
 			MaaSDBSecretName, appNamespace, err)

--- a/internal/controller/components/modelsasservice/modelsasservice_controller_prerequisites.go
+++ b/internal/controller/components/modelsasservice/modelsasservice_controller_prerequisites.go
@@ -1,0 +1,264 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package modelsasservice
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	k8serr "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	k8stypes "k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/yaml"
+
+	"github.com/opendatahub-io/opendatahub-operator/v2/api/common"
+	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/api/components/v1alpha1"
+	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/status"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/conditions"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
+)
+
+// validatePrerequisites checks that required platform prerequisites are present and
+// surfaces clear warnings when they are missing. Checks are either blocking (error
+// severity, affects Ready state) or non-blocking (info severity, visible but does
+// not prevent reconciliation).
+func validatePrerequisites(ctx context.Context, rr *types.ReconciliationRequest) error {
+	log := logf.FromContext(ctx)
+
+	_, ok := rr.Instance.(*componentApi.ModelsAsService)
+	if !ok {
+		return fmt.Errorf("resource instance %v is not a componentApi.ModelsAsService", rr.Instance)
+	}
+
+	var warnings []string
+	var errors []string
+
+	// Check 1: Kuadrant/RHCL stack (AuthConfig CRD from Authorino)
+	if msg := checkKuadrantAvailable(ctx, rr); msg != "" {
+		warnings = append(warnings, msg)
+		log.V(1).Info("Prerequisite warning", "check", "kuadrant", "message", msg)
+	}
+
+	// Check 2: Authorino TLS configuration
+	if msg := checkAuthorinoTLS(ctx, rr); msg != "" {
+		warnings = append(warnings, msg)
+		log.V(1).Info("Prerequisite warning", "check", "authorino-tls", "message", msg)
+	}
+
+	// Check 3: Database Secret (blocking — maas-api cannot start without it)
+	if msg := checkDatabaseSecret(ctx, rr); msg != "" {
+		errors = append(errors, msg)
+		log.Info("Prerequisite error", "check", "database-secret", "message", msg)
+	}
+
+	// Check 4: User Workload Monitoring
+	if msg := checkUserWorkloadMonitoring(ctx, rr); msg != "" {
+		warnings = append(warnings, msg)
+		log.V(1).Info("Prerequisite warning", "check", "user-workload-monitoring", "message", msg)
+	}
+
+	// Check 5: Kuadrant monitoring (TelemetryPolicy CRD)
+	if msg := checkKuadrantMonitoring(ctx, rr); msg != "" {
+		warnings = append(warnings, msg)
+		log.V(1).Info("Prerequisite warning", "check", "kuadrant-monitoring", "message", msg)
+	}
+
+	// If there are blocking errors, set condition with Error severity (affects Ready state)
+	if len(errors) > 0 {
+		allMessages := append(errors, warnings...) //nolint:gocritic // intentional append to new slice
+		aggregatedMessage := strings.Join(allMessages, "; ")
+
+		rr.Conditions.MarkFalse(
+			status.ConditionPrerequisitesAvailable,
+			conditions.WithReason("PrerequisitesMissing"),
+			conditions.WithMessage("%s", aggregatedMessage),
+		)
+
+		return nil
+	}
+
+	// If there are only warnings, set Info severity (does not affect Ready state)
+	if len(warnings) > 0 {
+		aggregatedMessage := strings.Join(warnings, "; ")
+
+		rr.Conditions.MarkFalse(
+			status.ConditionPrerequisitesAvailable,
+			conditions.WithReason("PrerequisitesWarning"),
+			conditions.WithMessage("%s", aggregatedMessage),
+			conditions.WithSeverity(common.ConditionSeverityInfo),
+		)
+
+		return nil
+	}
+
+	rr.Conditions.MarkTrue(status.ConditionPrerequisitesAvailable)
+
+	return nil
+}
+
+// checkKuadrantAvailable verifies the Kuadrant/RHCL stack is installed by checking for the AuthConfig CRD.
+func checkKuadrantAvailable(ctx context.Context, rr *types.ReconciliationRequest) string {
+	has, err := cluster.HasCRD(ctx, rr.Client, gvk.AuthConfigv1beta3)
+	if err != nil {
+		return fmt.Sprintf("failed to check Kuadrant/RHCL availability: %v", err)
+	}
+	if !has {
+		return "Kuadrant/RHCL stack not installed: AuthConfig CRD (authorino.kuadrant.io) not found. " +
+			"Install the Kuadrant operator to enable authentication and authorization"
+	}
+	return ""
+}
+
+// checkAuthorinoTLS verifies that at least one Authorino instance has TLS enabled
+// on its listener by inspecting spec.listener.tls.enabled and spec.listener.tls.certSecretRef.
+// If the Authorino CRD is not installed, the check is skipped (Kuadrant check covers that).
+// If multiple Authorino instances exist, the check passes if any one has TLS enabled.
+func checkAuthorinoTLS(ctx context.Context, rr *types.ReconciliationRequest) string {
+	// First check if the Authorino CRD exists
+	has, err := cluster.HasCRD(ctx, rr.Client, gvk.Authorinov1beta2)
+	if err != nil {
+		return fmt.Sprintf("failed to check Authorino CRD availability: %v", err)
+	}
+	if !has {
+		// Authorino CRD not present — skip TLS check (Kuadrant check handles the dependency)
+		return ""
+	}
+
+	// List all Authorino instances across namespaces
+	authorinoList := &unstructured.UnstructuredList{}
+	authorinoList.SetGroupVersionKind(gvk.Authorinov1beta2)
+	if err := rr.Client.List(ctx, authorinoList, &client.ListOptions{}); err != nil {
+		return fmt.Sprintf("failed to list Authorino instances: %v", err)
+	}
+
+	if len(authorinoList.Items) == 0 {
+		return "no Authorino instances found. " +
+			"Authorino must be deployed and configured with TLS for MaaS authentication"
+	}
+
+	// Check if any Authorino instance has TLS enabled
+	for i := range authorinoList.Items {
+		item := &authorinoList.Items[i]
+		enabled, _, _ := unstructured.NestedBool(item.Object, "spec", "listener", "tls", "enabled")
+		certName, _, _ := unstructured.NestedString(item.Object, "spec", "listener", "tls", "certSecretRef", "name")
+		if enabled && certName != "" {
+			return ""
+		}
+	}
+
+	return "Authorino TLS is not configured: no Authorino instance has listener.tls.enabled=true with a certSecretRef. " +
+		"Patch Authorino with spec.listener.tls.enabled=true and spec.listener.tls.certSecretRef to enable TLS. " +
+		"See https://docs.kuadrant.io/1.0.x/authorino/docs/user-guides/mtls-authentication/"
+}
+
+// checkDatabaseSecret validates that the required database connection Secret exists
+// in the application namespace with the expected key. This is a blocking check —
+// maas-api cannot start without a valid database connection.
+func checkDatabaseSecret(ctx context.Context, rr *types.ReconciliationRequest) string {
+	appNamespace, err := cluster.ApplicationNamespace(ctx, rr.Client)
+	if err != nil {
+		return fmt.Sprintf("failed to determine application namespace: %v", err)
+	}
+
+	secret := &corev1.Secret{}
+	err = rr.Client.Get(ctx, k8stypes.NamespacedName{
+		Namespace: appNamespace,
+		Name:      MaaSDBSecretName,
+	}, secret)
+
+	if err != nil {
+		if k8serr.IsNotFound(err) {
+			return fmt.Sprintf("database Secret '%s' not found in namespace '%s'. "+
+				"Create the Secret with key '%s' containing the PostgreSQL connection URL. "+
+				"MaaS API cannot start without a database connection",
+				MaaSDBSecretName, appNamespace, MaaSDBSecretKey)
+		}
+		return fmt.Sprintf("failed to check database Secret '%s' in namespace '%s': %v",
+			MaaSDBSecretName, appNamespace, err)
+	}
+
+	if _, ok := secret.Data[MaaSDBSecretKey]; !ok {
+		return fmt.Sprintf("database Secret '%s' in namespace '%s' is missing required key '%s'. "+
+			"The Secret must contain a valid PostgreSQL connection URL",
+			MaaSDBSecretName, appNamespace, MaaSDBSecretKey)
+	}
+
+	return ""
+}
+
+// checkUserWorkloadMonitoring checks if User Workload Monitoring is enabled by inspecting
+// the cluster-monitoring-config ConfigMap in the openshift-monitoring namespace.
+func checkUserWorkloadMonitoring(ctx context.Context, rr *types.ReconciliationRequest) string {
+	cm := &corev1.ConfigMap{}
+	err := rr.Client.Get(ctx, k8stypes.NamespacedName{
+		Namespace: MonitoringNamespace,
+		Name:      ClusterMonitoringConfigName,
+	}, cm)
+
+	if err != nil {
+		if k8serr.IsNotFound(err) {
+			return "User Workload Monitoring not configured: ConfigMap 'cluster-monitoring-config' not found in 'openshift-monitoring'. " +
+				"Showback/FinOps usage views will not work without User Workload Monitoring enabled"
+		}
+		// Access errors (e.g., RBAC) should not block — log and continue
+		return fmt.Sprintf("unable to verify User Workload Monitoring status: %v. "+
+			"Ensure User Workload Monitoring is enabled for showback functionality", err)
+	}
+
+	configData, ok := cm.Data["config.yaml"]
+	if !ok {
+		return "User Workload Monitoring is not enabled. " +
+			"Set enableUserWorkload: true in 'cluster-monitoring-config' ConfigMap in 'openshift-monitoring' namespace. " +
+			"Showback/FinOps usage views will not work without it"
+	}
+
+	var cfg struct {
+		EnableUserWorkload bool `yaml:"enableUserWorkload"`
+	}
+	if err := yaml.Unmarshal([]byte(configData), &cfg); err != nil {
+		return "User Workload Monitoring config is invalid in 'cluster-monitoring-config'. " +
+			"Ensure config.yaml is valid YAML and sets enableUserWorkload: true"
+	}
+
+	if !cfg.EnableUserWorkload {
+		return "User Workload Monitoring is not enabled. " +
+			"Set enableUserWorkload: true in 'cluster-monitoring-config' ConfigMap in 'openshift-monitoring' namespace. " +
+			"Showback/FinOps usage views will not work without it"
+	}
+
+	return ""
+}
+
+// checkKuadrantMonitoring checks if Kuadrant monitoring is available by verifying
+// the TelemetryPolicy CRD is present.
+func checkKuadrantMonitoring(ctx context.Context, rr *types.ReconciliationRequest) string {
+	has, err := cluster.HasCRD(ctx, rr.Client, gvk.TelemetryPolicyv1alpha1)
+	if err != nil {
+		return fmt.Sprintf("failed to check Kuadrant monitoring availability: %v", err)
+	}
+	if !has {
+		return "Kuadrant monitoring not available: TelemetryPolicy CRD (extensions.kuadrant.io) not found. " +
+			"Showback/FinOps usage views will not work without Kuadrant monitoring enabled"
+	}
+	return ""
+}

--- a/internal/controller/components/modelsasservice/modelsasservice_controller_prerequisites.go
+++ b/internal/controller/components/modelsasservice/modelsasservice_controller_prerequisites.go
@@ -72,10 +72,12 @@ func validatePrerequisites(ctx context.Context, rr *types.ReconciliationRequest)
 	var warnings []string
 	var errors []string
 
-	// Check 1: Authorino TLS configuration (blocking — gateway can't authenticate without TLS)
+	// Check 1: Authorino TLS configuration (non-blocking — RHCL is a separate operator and
+	// customers may configure Authorino in ways we don't detect; a false positive here
+	// should not block the DSC from being marked as Ready)
 	if msg := checkAuthorinoTLS(ctx, rr); msg != "" {
-		errors = append(errors, msg)
-		log.Error(nil, "MaaS prerequisite error", "check", "authorino-tls", "message", msg)
+		warnings = append(warnings, msg)
+		log.V(1).Info("MaaS prerequisite warning", "check", "authorino-tls", "message", msg)
 	}
 
 	// Check 2: Database Secret (blocking — maas-api cannot start without it)

--- a/internal/controller/components/modelsasservice/modelsasservice_controller_prerequisites.go
+++ b/internal/controller/components/modelsasservice/modelsasservice_controller_prerequisites.go
@@ -57,31 +57,31 @@ func validatePrerequisites(ctx context.Context, rr *types.ReconciliationRequest)
 	// Check 1: Kuadrant/RHCL stack (AuthConfig CRD from Authorino)
 	if msg := checkKuadrantAvailable(ctx, rr); msg != "" {
 		warnings = append(warnings, msg)
-		log.V(1).Info("Prerequisite warning", "check", "kuadrant", "message", msg)
+		log.V(1).Info("MaaS prerequisite warning", "check", "kuadrant", "message", msg)
 	}
 
 	// Check 2: Authorino TLS configuration
 	if msg := checkAuthorinoTLS(ctx, rr); msg != "" {
 		warnings = append(warnings, msg)
-		log.V(1).Info("Prerequisite warning", "check", "authorino-tls", "message", msg)
+		log.V(1).Info("MaaS prerequisite warning", "check", "authorino-tls", "message", msg)
 	}
 
 	// Check 3: Database Secret (blocking — maas-api cannot start without it)
 	if msg := checkDatabaseSecret(ctx, rr); msg != "" {
 		errors = append(errors, msg)
-		log.Info("Prerequisite error", "check", "database-secret", "message", msg)
+		log.Error(nil, "MaaS prerequisite error", "check", "database-secret", "message", msg)
 	}
 
 	// Check 4: User Workload Monitoring
 	if msg := checkUserWorkloadMonitoring(ctx, rr); msg != "" {
 		warnings = append(warnings, msg)
-		log.V(1).Info("Prerequisite warning", "check", "user-workload-monitoring", "message", msg)
+		log.V(1).Info("MaaS prerequisite warning", "check", "user-workload-monitoring", "message", msg)
 	}
 
 	// Check 5: Kuadrant monitoring (TelemetryPolicy CRD)
 	if msg := checkKuadrantMonitoring(ctx, rr); msg != "" {
 		warnings = append(warnings, msg)
-		log.V(1).Info("Prerequisite warning", "check", "kuadrant-monitoring", "message", msg)
+		log.V(1).Info("MaaS prerequisite warning", "check", "kuadrant-monitoring", "message", msg)
 	}
 
 	// If there are blocking errors, set condition with Error severity (affects Ready state)
@@ -90,7 +90,7 @@ func validatePrerequisites(ctx context.Context, rr *types.ReconciliationRequest)
 		aggregatedMessage := strings.Join(allMessages, "; ")
 
 		rr.Conditions.MarkFalse(
-			status.ConditionPrerequisitesAvailable,
+			status.ConditionMaaSPrerequisitesAvailable,
 			conditions.WithReason("PrerequisitesMissing"),
 			conditions.WithMessage("%s", aggregatedMessage),
 		)
@@ -103,7 +103,7 @@ func validatePrerequisites(ctx context.Context, rr *types.ReconciliationRequest)
 		aggregatedMessage := strings.Join(warnings, "; ")
 
 		rr.Conditions.MarkFalse(
-			status.ConditionPrerequisitesAvailable,
+			status.ConditionMaaSPrerequisitesAvailable,
 			conditions.WithReason("PrerequisitesWarning"),
 			conditions.WithMessage("%s", aggregatedMessage),
 			conditions.WithSeverity(common.ConditionSeverityInfo),
@@ -112,7 +112,7 @@ func validatePrerequisites(ctx context.Context, rr *types.ReconciliationRequest)
 		return nil
 	}
 
-	rr.Conditions.MarkTrue(status.ConditionPrerequisitesAvailable)
+	rr.Conditions.MarkTrue(status.ConditionMaaSPrerequisitesAvailable)
 
 	return nil
 }

--- a/internal/controller/components/modelsasservice/modelsasservice_support.go
+++ b/internal/controller/components/modelsasservice/modelsasservice_support.go
@@ -85,6 +85,7 @@ var (
 	}
 
 	conditionTypes = []string{
+		status.ConditionDependenciesAvailable,
 		status.ConditionMaaSPrerequisitesAvailable,
 		status.ConditionDeploymentsAvailable,
 	}

--- a/internal/controller/components/modelsasservice/modelsasservice_support.go
+++ b/internal/controller/components/modelsasservice/modelsasservice_support.go
@@ -85,7 +85,7 @@ var (
 	}
 
 	conditionTypes = []string{
-		status.ConditionPrerequisitesAvailable,
+		status.ConditionMaaSPrerequisitesAvailable,
 		status.ConditionDeploymentsAvailable,
 	}
 )

--- a/internal/controller/components/modelsasservice/modelsasservice_support.go
+++ b/internal/controller/components/modelsasservice/modelsasservice_support.go
@@ -56,6 +56,18 @@ const (
 
 	// MaaSAPIDeploymentName is the name of the maas-api Deployment.
 	MaaSAPIDeploymentName = "maas-api"
+
+	// MaaSDBSecretName is the name of the Secret containing the database connection URL.
+	MaaSDBSecretName = "maas-db-config" //nolint:gosec // secret name reference, not a credential
+
+	// MaaSDBSecretKey is the key within the DB config Secret that holds the connection URL.
+	MaaSDBSecretKey = "DB_CONNECTION_URL"
+
+	// MonitoringNamespace is the namespace where cluster monitoring configuration is stored.
+	MonitoringNamespace = "openshift-monitoring"
+
+	// ClusterMonitoringConfigName is the name of the ConfigMap for cluster monitoring configuration.
+	ClusterMonitoringConfigName = "cluster-monitoring-config"
 )
 
 var (
@@ -73,6 +85,7 @@ var (
 	}
 
 	conditionTypes = []string{
+		status.ConditionPrerequisitesAvailable,
 		status.ConditionDeploymentsAvailable,
 	}
 )

--- a/internal/controller/datasciencecluster/kubebuilder_rbac.go
+++ b/internal/controller/datasciencecluster/kubebuilder_rbac.go
@@ -333,6 +333,7 @@ package datasciencecluster
 // +kubebuilder:rbac:groups=components.platform.opendatahub.io,resources=modelsasservices/finalizers,verbs=update
 // +kubebuilder:rbac:groups=kuadrant.io,resources=authpolicies;tokenratelimitpolicies;ratelimitpolicies;telemetrypolicies,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=extensions.kuadrant.io,resources=telemetrypolicies,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=operator.authorino.kuadrant.io,resources=authorinos,verbs=get;list
 
 // SparkOperator
 // +kubebuilder:rbac:groups=components.platform.opendatahub.io,resources=sparkoperators,verbs=get;list;watch;create;update;patch;delete

--- a/internal/controller/status/status.go
+++ b/internal/controller/status/status.go
@@ -78,7 +78,7 @@ const (
 	// Component-specific condition types.
 	ConditionTypeProvisioningSucceeded           = "ProvisioningSucceeded"
 	ConditionDeploymentsNotAvailableReason       = "DeploymentsNotReady"
-	ConditionPrerequisitesAvailable              = "PrerequisitesAvailable"
+	ConditionMaaSPrerequisitesAvailable          = "MaaSPrerequisitesAvailable"
 	ConditionDeploymentsAvailable                = "DeploymentsAvailable"
 	ConditionDependenciesAvailable               = "DependenciesAvailable"
 	ConditionArgoWorkflowAvailable               = "ArgoWorkflowAvailable"

--- a/internal/controller/status/status.go
+++ b/internal/controller/status/status.go
@@ -78,6 +78,7 @@ const (
 	// Component-specific condition types.
 	ConditionTypeProvisioningSucceeded           = "ProvisioningSucceeded"
 	ConditionDeploymentsNotAvailableReason       = "DeploymentsNotReady"
+	ConditionPrerequisitesAvailable              = "PrerequisitesAvailable"
 	ConditionDeploymentsAvailable                = "DeploymentsAvailable"
 	ConditionDependenciesAvailable               = "DependenciesAvailable"
 	ConditionArgoWorkflowAvailable               = "ArgoWorkflowAvailable"

--- a/pkg/cluster/gvk/gvk.go
+++ b/pkg/cluster/gvk/gvk.go
@@ -823,9 +823,9 @@ var (
 		Kind:    "AuthConfig",
 	}
 
-	Authorinov1beta2 = schema.GroupVersionKind{
+	Authorinov1beta1 = schema.GroupVersionKind{
 		Group:   "operator.authorino.kuadrant.io",
-		Version: "v1beta2",
+		Version: "v1beta1",
 		Kind:    "Authorino",
 	}
 

--- a/pkg/cluster/gvk/gvk.go
+++ b/pkg/cluster/gvk/gvk.go
@@ -823,6 +823,12 @@ var (
 		Kind:    "AuthConfig",
 	}
 
+	Authorinov1beta2 = schema.GroupVersionKind{
+		Group:   "operator.authorino.kuadrant.io",
+		Version: "v1beta2",
+		Kind:    "Authorino",
+	}
+
 	Kuadrantv1beta1 = schema.GroupVersionKind{
 		Group:   "kuadrant.io",
 		Version: "v1beta1",


### PR DESCRIPTION
<!---
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
    Validate required platform prerequisites during MaaS reconciliation and
    surface clear warnings/errors via status conditions:
    
    - Kuadrant/RHCL stack (AuthConfig CRD) — warning if missing
    - cert-manager TLS (Certificate CRD) — warning if missing
    - Database secret (maas-db-config) — blocks unless overridden
    - User Workload Monitoring — warning if not enabled
    - Kuadrant monitoring (TelemetryPolicy CRD) — warning if missing
    
    Adds spec.skipPrerequisiteValidation override to allow reconciliation
    to proceed when blocking prerequisites are absent.

<!--- Describe your changes in detail -->

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully
- [ ] New RELATED_IMAGE mappings are already listed in ODH-Build-Config and RHOAI-Build-Config, and links are included in PR description

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
The prerequisite validation only adds status conditions to the ModelsAsService CR during reconciliation, it doesn't change any deployed resources, APIs, or user-facing behavior. Therefore, it does not require E2E test updates.



<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added non-blocking prerequisite validation for Kuadrant/Authorino TLS, certs, database configuration, user-workload monitoring, and telemetry policy.
  * Introduced a PrerequisitesAvailable status condition to surface validation results without blocking reconciliation.
  * Reordered reconciliation so prerequisite validation runs earlier for faster diagnostic visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->