### PR TITLE
Update controller-runtime dependency and refactor event recording

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -411,7 +411,7 @@ func main() { //nolint:funlen,maintidx,gocyclo
 		if err = (&dscictrl.DSCInitializationReconciler{
 			Client:   mgr.GetClient(),
 			Scheme:   mgr.GetScheme(),
-			Recorder: mgr.GetEventRecorderFor("dscinitialization-controller"),
+			Recorder: mgr.GetEventRecorder("dscinitialization-controller"),
 		}).SetupWithManager(ctx, mgr); err != nil {
 			setupLog.Error(err, "unable to create controller", "controller", "DSCInitiatlization")
 			os.Exit(1)

--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,7 @@ require (
 	k8s.io/client-go v0.35.2
 	k8s.io/klog/v2 v2.130.1
 	k8s.io/utils v0.0.0-20260210185600-b8788abfbbc2
-	sigs.k8s.io/controller-runtime v0.22.4
+	sigs.k8s.io/controller-runtime v0.23.3
 	sigs.k8s.io/gateway-api v1.3.0
 	sigs.k8s.io/kustomize/api v0.21.1
 	sigs.k8s.io/kustomize/kyaml v0.21.1

--- a/go.sum
+++ b/go.sum
@@ -329,8 +329,8 @@ k8s.io/utils v0.0.0-20260210185600-b8788abfbbc2 h1:AZYQSJemyQB5eRxqcPky+/7EdBj0x
 k8s.io/utils v0.0.0-20260210185600-b8788abfbbc2/go.mod h1:xDxuJ0whA3d0I4mf/C4ppKHxXynQ+fxnkmQH0vTHnuk=
 oras.land/oras-go/v2 v2.6.0 h1:X4ELRsiGkrbeox69+9tzTu492FMUu7zJQW6eJU+I2oc=
 oras.land/oras-go/v2 v2.6.0/go.mod h1:magiQDfG6H1O9APp+rOsvCPcW1GD2MM7vgnKY0Y+u1o=
-sigs.k8s.io/controller-runtime v0.22.4 h1:GEjV7KV3TY8e+tJ2LCTxUTanW4z/FmNB7l327UfMq9A=
-sigs.k8s.io/controller-runtime v0.22.4/go.mod h1:+QX1XUpTXN4mLoblf4tqr5CQcyHPAki2HLXqQMY6vh8=
+sigs.k8s.io/controller-runtime v0.23.3 h1:VjB/vhoPoA9l1kEKZHBMnQF33tdCLQKJtydy4iqwZ80=
+sigs.k8s.io/controller-runtime v0.23.3/go.mod h1:B6COOxKptp+YaUT5q4l6LqUJTRpizbgf9KSRNdQGns0=
 sigs.k8s.io/gateway-api v1.3.0 h1:q6okN+/UKDATola4JY7zXzx40WO4VISk7i9DIfOvr9M=
 sigs.k8s.io/gateway-api v1.3.0/go.mod h1:d8NV8nJbaRbEKem+5IuxkL8gJGOZ+FJ+NvOIltV8gDk=
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 h1:IpInykpT6ceI+QxKBbEflcR5EXP7sU1kvOlxwZh5txg=

--- a/internal/controller/cloudmanager/common/kubebuilder_rbac.go
+++ b/internal/controller/cloudmanager/common/kubebuilder_rbac.go
@@ -12,11 +12,6 @@ package common
 
 // +kubebuilder:rbac:groups="coordination.k8s.io",resources=leases,verbs=get;list;watch;create;update;patch;delete
 
-// Events
-// TODO: this should be removed once controller-runtime >= 0.23.0
-// +kubebuilder:rbac:groups="core",resources=events,verbs=get;create;watch;update;list;patch
-// +kubebuilder:rbac:groups="events.k8s.io",resources=events,verbs=list;watch;patch;get
-
 // RBAC
 // +kubebuilder:rbac:groups="rbac.authorization.k8s.io",resources=roles,verbs=create;watch;list
 // +kubebuilder:rbac:groups="rbac.authorization.k8s.io",resources=clusterroles,verbs=create;watch;list;get;

--- a/internal/controller/dscinitialization/dscinitialization_controller.go
+++ b/internal/controller/dscinitialization/dscinitialization_controller.go
@@ -30,7 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/tools/events"
 	"k8s.io/client-go/util/retry"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -66,7 +66,7 @@ const (
 type DSCInitializationReconciler struct {
 	Client   client.Client
 	Scheme   *runtime.Scheme
-	Recorder record.EventRecorder
+	Recorder events.EventRecorder
 }
 
 // Reconcile contains controller logic specific to DSCInitialization instance updates.
@@ -88,7 +88,8 @@ func (r *DSCInitializationReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		ref := &corev1.ObjectReference{Name: req.Name, Namespace: req.Namespace}
 		ref.SetGroupVersionKind(gvk.DSCInitialization)
 
-		r.Recorder.Eventf(ref, corev1.EventTypeWarning, "DSCInitializationReconcileError", "Failed to retrieve DSCInitialization instance")
+		r.Recorder.Eventf(ref, nil, corev1.EventTypeWarning, "DSCInitializationReconcileError", "Reconcile",
+			"Failed to retrieve DSCInitialization instance: %v", err)
 
 		return ctrl.Result{}, err
 	}
@@ -144,8 +145,8 @@ func (r *DSCInitializationReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		})
 		if err != nil {
 			log.Error(err, "Failed to add conditions to status of DSCInitialization resource.", "DSCInitialization", req.Namespace, "Request.Name", req.Name)
-			r.Recorder.Eventf(instance, corev1.EventTypeWarning, "DSCInitializationReconcileError",
-				"%s for instance %s", message, instance.Name)
+			r.Recorder.Eventf(instance, nil, corev1.EventTypeWarning, "DSCInitializationReconcileError", "Reconcile",
+				"%s for instance %s: %v", message, instance.Name, err)
 
 			return reconcile.Result{}, err
 		}
@@ -159,8 +160,8 @@ func (r *DSCInitializationReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		})
 		if err != nil {
 			log.Error(err, "Failed to update release version for DSCInitialization resource.", "DSCInitialization", req.Namespace, "Request.Name", req.Name)
-			r.Recorder.Eventf(instance, corev1.EventTypeWarning, "DSCInitializationReconcileError",
-				"%s for instance %s", message, instance.Name)
+			r.Recorder.Eventf(instance, nil, corev1.EventTypeWarning, "DSCInitializationReconcileError", "Reconcile",
+				"%s for instance %s: %v", message, instance.Name, err)
 			return reconcile.Result{}, err
 		}
 	}
@@ -173,12 +174,12 @@ func (r *DSCInitializationReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		}); err != nil {
 			log.Error(err, "Failed to update DSCInitialization conditions", "DSCInitialization", req.Namespace, "Request.Name", req.Name)
 
-			r.Recorder.Eventf(instance, corev1.EventTypeWarning, "DSCInitializationReconcileError",
+			r.Recorder.Eventf(instance, nil, corev1.EventTypeWarning, "DSCInitializationReconcileError", "Reconcile",
 				"%s for instance %s", err.Error(), instance.Name)
 		}
 
 		// no need to log error as it was already logged in createOperatorResource
-		r.Recorder.Eventf(instance, corev1.EventTypeWarning, "DSCInitializationReconcileError",
+		r.Recorder.Eventf(instance, nil, corev1.EventTypeWarning, "DSCInitializationReconcileError", "Reconcile",
 			"failed to create operator resources for instance %s: %s", instance.Name, err.Error())
 
 		return reconcile.Result{}, err
@@ -234,7 +235,8 @@ func (r *DSCInitializationReconciler) Reconcile(ctx context.Context, req ctrl.Re
 			osdConfigsPath := filepath.Join(deploy.DefaultManifestPath, "osd-configs")
 			if err = deploy.DeployManifestsFromPath(ctx, r.Client, instance, osdConfigsPath, instance.Spec.ApplicationsNamespace, "osd", true); err != nil {
 				log.Error(err, "Failed to apply osd specific configs from manifests", "Manifests path", osdConfigsPath)
-				r.Recorder.Eventf(instance, corev1.EventTypeWarning, "DSCInitializationReconcileError", "Failed to apply "+osdConfigsPath)
+				r.Recorder.Eventf(instance, nil, corev1.EventTypeWarning, "DSCInitializationReconcileError", "Reconcile",
+					"Failed to apply %s: %v", osdConfigsPath, err)
 
 				return reconcile.Result{}, err
 			}
@@ -312,7 +314,8 @@ func (r *DSCInitializationReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		})
 		if err != nil {
 			log.Error(err, "failed to update DSCInitialization status after successfully completed reconciliation")
-			r.Recorder.Eventf(instance, corev1.EventTypeWarning, "DSCInitializationReconcileError", "Failed to update DSCInitialization status")
+			r.Recorder.Eventf(instance, nil, corev1.EventTypeWarning, "DSCInitializationReconcileError", "Reconcile",
+				"Failed to update DSCInitialization status: %v", err)
 		}
 
 		return ctrl.Result{}, nil

--- a/internal/controller/dscinitialization/suite_test.go
+++ b/internal/controller/dscinitialization/suite_test.go
@@ -162,7 +162,7 @@ var _ = BeforeSuite(func() {
 	err = (&dscictrl.DSCInitializationReconciler{
 		Client:   k8sClient,
 		Scheme:   testScheme,
-		Recorder: mgr.GetEventRecorderFor("dscinitialization-controller"),
+		Recorder: mgr.GetEventRecorder("dscinitialization-controller"),
 	}).SetupWithManager(gCtx, mgr)
 
 	Expect(err).ToNot(HaveOccurred())

--- a/internal/webhook/datasciencecluster/v1/defaulting.go
+++ b/internal/webhook/datasciencecluster/v1/defaulting.go
@@ -12,7 +12,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	dscv1 "github.com/opendatahub-io/opendatahub-operator/v2/api/datasciencecluster/v1"
@@ -23,15 +22,15 @@ import (
 //+kubebuilder:webhook:path=/mutate-datasciencecluster-v1,matchPolicy=Exact,mutating=true,failurePolicy=fail,sideEffects=None,groups=datasciencecluster.opendatahub.io,resources=datascienceclusters,verbs=create;update,versions=v1,name=datasciencecluster-v1-defaulter.opendatahub.io,admissionReviewVersions=v1
 //nolint:lll
 
-// Defaulter implements webhook.CustomDefaulter for DataScienceCluster v1 resources.
+// Defaulter implements admission.Defaulter for DataScienceCluster v1 resources.
 // It sets default values for fields in the DataScienceCluster CR, such as ModelRegistry.RegistriesNamespace.
 type Defaulter struct {
 	// Name is used for logging and webhook identification.
 	Name string
 }
 
-// just assert that Defaulter implements webhook.CustomDefaulter.
-var _ webhook.CustomDefaulter = &Defaulter{}
+// just assert that Defaulter implements admission.Defaulter.
+var _ admission.Defaulter[runtime.Object] = &Defaulter{}
 
 // SetupWithManager registers the defaulting webhook with the provided controller-runtime manager.
 //

--- a/internal/webhook/datasciencecluster/v1/register.go
+++ b/internal/webhook/datasciencecluster/v1/register.go
@@ -12,7 +12,7 @@ import (
 // RegisterWebhooks registers the webhooks for DataScienceCluster v1.
 func RegisterWebhooks(mgr ctrl.Manager) error {
 	// Register the conversion webhook
-	if err := ctrl.NewWebhookManagedBy(mgr).For(&dscv1.DataScienceCluster{}).Complete(); err != nil {
+	if err := ctrl.NewWebhookManagedBy(mgr, &dscv1.DataScienceCluster{}).Complete(); err != nil {
 		return err
 	}
 

--- a/internal/webhook/datasciencecluster/v2/defaulting.go
+++ b/internal/webhook/datasciencecluster/v2/defaulting.go
@@ -12,7 +12,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	dscv2 "github.com/opendatahub-io/opendatahub-operator/v2/api/datasciencecluster/v2"
@@ -23,15 +22,15 @@ import (
 //+kubebuilder:webhook:path=/mutate-datasciencecluster-v2,matchPolicy=Exact,mutating=true,failurePolicy=fail,sideEffects=None,groups=datasciencecluster.opendatahub.io,resources=datascienceclusters,verbs=create;update,versions=v2,name=datasciencecluster-v2-defaulter.opendatahub.io,admissionReviewVersions=v1
 //nolint:lll
 
-// Defaulter implements webhook.CustomDefaulter for DataScienceCluster v2 resources.
+// Defaulter implements admission.Defaulter for DataScienceCluster v2 resources.
 // It sets default values for fields in the DataScienceCluster CR, such as ModelRegistry.RegistriesNamespace.
 type Defaulter struct {
 	// Name is used for logging and webhook identification.
 	Name string
 }
 
-// just assert that Defaulter implements webhook.CustomDefaulter.
-var _ webhook.CustomDefaulter = &Defaulter{}
+// just assert that Defaulter implements admission.Defaulter.
+var _ admission.Defaulter[runtime.Object] = &Defaulter{}
 
 // SetupWithManager registers the defaulting webhook with the provided controller-runtime manager.
 //

--- a/internal/webhook/dscinitialization/v1/register.go
+++ b/internal/webhook/dscinitialization/v1/register.go
@@ -11,7 +11,7 @@ import (
 // RegisterWebhooks registers the webhooks for DSCInitialization v1.
 func RegisterWebhooks(mgr ctrl.Manager) error {
 	// Register the conversion webhook
-	if err := ctrl.NewWebhookManagedBy(mgr).For(&dsciv1.DSCInitialization{}).Complete(); err != nil {
+	if err := ctrl.NewWebhookManagedBy(mgr, &dsciv1.DSCInitialization{}).Complete(); err != nil {
 		return err
 	}
 

--- a/pkg/controller/reconciler/reconciler.go
+++ b/pkg/controller/reconciler/reconciler.go
@@ -14,7 +14,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/dynamic"
-	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/tools/events"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -76,7 +76,7 @@ type Reconciler struct {
 	Finalizer  []actions.Fn
 	Log        logr.Logger
 	Controller controller.Controller
-	Recorder   record.EventRecorder
+	Recorder   events.EventRecorder
 	Release    common.Release
 
 	name                        string
@@ -103,7 +103,7 @@ func NewReconciler[T common.PlatformObject](mgr manager.Manager, name string, ob
 		Client:   mgr.GetClient(),
 		Scheme:   mgr.GetScheme(),
 		Log:      ctrl.Log.WithName("controllers").WithName(name),
-		Recorder: mgr.GetEventRecorderFor(name),
+		Recorder: mgr.GetEventRecorder(name),
 		Release:  cluster.GetRelease(),
 		name:     name,
 		instanceFactory: func() (common.PlatformObject, error) {
@@ -384,10 +384,12 @@ func (r *Reconciler) apply(ctx context.Context, res common.PlatformObject) error
 	)
 
 	if err != nil && !k8serr.IsNotFound(err) {
-		r.Recorder.Event(
+		r.Recorder.Eventf(
 			res,
+			nil,
 			corev1.EventTypeNormal,
 			"ReconcileError",
+			"Reconcile",
 			err.Error(),
 		)
 
@@ -395,10 +397,12 @@ func (r *Reconciler) apply(ctx context.Context, res common.PlatformObject) error
 	}
 
 	if provisionErr != nil {
-		r.Recorder.Event(
+		r.Recorder.Eventf(
 			res,
+			nil,
 			corev1.EventTypeWarning,
 			"ProvisioningError",
+			"Provision",
 			provisionErr.Error(),
 		)
 

--- a/pkg/controller/reconciler/reconciler_finalizer_test.go
+++ b/pkg/controller/reconciler/reconciler_finalizer_test.go
@@ -14,6 +14,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/events"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -26,6 +27,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/conversion"
 
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/api/components/v1alpha1"
 	dsciv2 "github.com/opendatahub-io/opendatahub-operator/v2/api/dscinitialization/v2"
@@ -61,6 +63,9 @@ func (f *MockManager) GetFieldIndexer() client.FieldIndexer { return nil }
 func (f *MockManager) GetEventRecorderFor(name string) record.EventRecorder { return nil }
 
 //nolint:ireturn // Returns stdlib interface required by manager.Manager
+func (f *MockManager) GetEventRecorder(name string) events.EventRecorder { return nil }
+
+//nolint:ireturn // Returns stdlib interface required by manager.Manager
 func (f *MockManager) GetCache() cache.Cache                                    { return nil }
 func (f *MockManager) GetLogger() logr.Logger                                   { return ctrl.Log }
 func (f *MockManager) Add(runnable manager.Runnable) error                      { return nil }
@@ -81,6 +86,9 @@ func (f *MockManager) GetHTTPClient() *http.Client { return &http.Client{} }
 
 //nolint:ireturn
 func (f *MockManager) GetWebhookServer() webhook.Server { return nil }
+
+//nolint:ireturn
+func (f *MockManager) GetConverterRegistry() conversion.Registry { return nil }
 
 //nolint:ireturn
 func setupTest(mockDashboard *componentApi.Dashboard) (context.Context, *MockManager, client.WithWatch) {

--- a/pkg/controller/reconciler/reconciler_test.go
+++ b/pkg/controller/reconciler/reconciler_test.go
@@ -23,7 +23,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/tools/events"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -62,7 +62,7 @@ func createReconciler(cli client.Client) *Reconciler {
 		Scheme:   cli.Scheme(),
 		Log:      ctrl.Log.WithName("controllers").WithName("test"),
 		Release:  cluster.GetRelease(),
-		Recorder: record.NewFakeRecorder(100),
+		Recorder: events.NewFakeRecorder(100),
 		name:     "test",
 		instanceFactory: func() (common.PlatformObject, error) {
 			i := &componentApi.Dashboard{

--- a/pkg/resources/resources.go
+++ b/pkg/resources/resources.go
@@ -543,7 +543,7 @@ func Apply(ctx context.Context, cli client.Client, in client.Object, opts ...cli
 	unstructured.RemoveNestedField(u.Object, "metadata", "resourceVersion")
 	unstructured.RemoveNestedField(u.Object, "status")
 
-	err = cli.Patch(ctx, u, client.Apply, opts...)
+	err = cli.Patch(ctx, u, client.Apply, opts...) //nolint:staticcheck // TODO: migrate to cli.Apply() with client.ApplyOption once all callers are updated
 	if err != nil {
 		// Include GVK and namespace/name for debugging context without logging sensitive object data
 		objRef := FormatObjectReference(u)
@@ -594,7 +594,7 @@ func ApplyStatus(ctx context.Context, cli client.Client, in client.Object, opts 
 	unstructured.RemoveNestedField(u.Object, "metadata", "managedFields")
 	unstructured.RemoveNestedField(u.Object, "metadata", "resourceVersion")
 
-	err = cli.Status().Patch(ctx, u, client.Apply, opts...)
+	err = cli.Status().Patch(ctx, u, client.Apply, opts...) //nolint:staticcheck // TODO: migrate to cli.Status().Apply() once all callers updated
 	switch {
 	case k8serr.IsNotFound(err): // Cannot be removed like in Apply func because reconciler_finalizer_test.go would then throw an error, needs extensive test rewrite
 		return nil

--- a/tests/e2e/test_context_test.go
+++ b/tests/e2e/test_context_test.go
@@ -1412,7 +1412,7 @@ func (tc *TestContext) ApproveInstallPlan(plan *ofapi.InstallPlan) {
 	}
 
 	// Apply the patch to approve the InstallPlan
-	err := tc.Client().Patch(tc.Context(), obj, client.Apply, opt)
+	err := tc.Client().Patch(tc.Context(), obj, client.Apply, opt) //nolint:staticcheck // TODO: migrate to cli.Apply() with client.ApplyOption
 	tc.g.Expect(err).
 		NotTo(
 			HaveOccurred(),


### PR DESCRIPTION
## Description
- Bump sigs.k8s.io/controller-runtime from v0.22.4 to v0.23.3 in go.mod and go.sum.
- Refactor event recording in DSCInitializationReconciler to use the new EventRecorder interface.
- Update related tests and RBAC annotations to align with the new event handling approach.

This change enhances compatibility with the latest controller-runtime features and improves event logging consistency.

https://redhat.atlassian.net/browse/RHOAIENG-51625

## How Has This Been Tested?
Made sure, unit and e2e tests are passing and manually ran the operator in a ROSA cluster to verify.

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully
- [ ] New RELATED_IMAGE mappings are already listed in ODH-Build-Config and RHOAI-Build-Config, and links are included in PR description

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [ ] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated controller-runtime dependency to v0.23.3.
  * Migrated internal event recording to the newer Kubernetes events API.
  * Simplified webhook registration calls for more consistent controller setup.
  * Removed obsolete RBAC entries related to Kubernetes Events.
  * Updated tests/mocks to align with event recording changes.

* **Bug Fixes**
  * Improved emitted event messages to include underlying error details for clearer troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->