### PR TITLE
feat: deploy MaaS dashboard(s)

### DIFF
--- a/internal/controller/components/modelsasservice/modelsasservice_controller.go
+++ b/internal/controller/components/modelsasservice/modelsasservice_controller.go
@@ -27,6 +27,8 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/api/components/v1alpha1"
@@ -73,7 +75,15 @@ func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.
 			reconciler.WithEventHandler(
 				handlers.ToNamed(componentApi.ModelsAsServiceInstanceName)),
 			reconciler.WithPredicates(
-				component.ForLabel(labels.ODH.Component(ComponentName), labels.True)),
+				predicate.Or(
+					component.ForLabel(labels.ODH.Component(ComponentName), labels.True),
+					// Watch PersesDashboard CRD to trigger reconciliation when COO is installed
+					// This enables automatic deployment of observability dashboards when COO is installed
+					predicate.NewPredicateFuncs(func(obj client.Object) bool {
+						return obj.GetName() == "persesdashboards.perses.dev"
+					}),
+				),
+			),
 		).
 		// Note: The component manifests define a configmap with the annotation
 		// opendatahub.io/managed: "false". Adding this watch allows the controller to
@@ -118,6 +128,8 @@ func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.
 		WithAction(configureExternalOIDC).
 		WithAction(configureTelemetryPolicy).
 		WithAction(configureIstioTelemetry).
+		WithAction(validatePersesResources).
+		WithAction(configurePersesResources).
 		WithAction(configureConfigHashAnnotation).
 		WithAction(deploy.NewAction(
 			deploy.WithCache(),

--- a/internal/controller/components/modelsasservice/modelsasservice_controller_actions.go
+++ b/internal/controller/components/modelsasservice/modelsasservice_controller_actions.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	k8stypes "k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
 
@@ -375,6 +376,72 @@ func configureTelemetryPolicy(ctx context.Context, rr *types.ReconciliationReque
 	}
 
 	return configureTelemetryPolicyCore(ctx, rr)
+}
+
+// validatePersesResources ensures PersesDashboard and PersesDatasource objects from rendered
+// manifests are only applied when the PersesDashboard CRD is installed.
+//
+// When the CRD is missing, those resources are removed from rr so the subsequent deploy action
+// does not fail with an unsupported API. When the CRD exists, Perses resources remain in
+// rr.Resources and are applied by deploy.NewAction like other manifests.
+func validatePersesResources(ctx context.Context, rr *types.ReconciliationRequest) error {
+	log := logf.FromContext(ctx)
+
+	// Check if PersesDashboard CRD exists in either v1alpha1 or v1alpha2 (COO installed)
+	if crdAvailable, err := cluster.HasCRD(ctx, rr.Client, gvk.PersesDashboardV1Alpha1); err != nil {
+		return fmt.Errorf("failed to check PersesDashboardV1Alpha1 CRD availability: %w", err)
+	} else if crdAvailable {
+		return nil
+	}
+
+	if crdAvailable, err := cluster.HasCRD(ctx, rr.Client, gvk.PersesDashboardV1Alpha2); err != nil {
+		return fmt.Errorf("failed to check PersesDashboardV1Alpha2 CRD availability: %w", err)
+	} else if crdAvailable {
+		return nil
+	}
+
+	log.V(2).Info("PersesDashboard CRD not available, skipping Perses resources")
+	skipPersesResources(rr)
+
+	return nil
+}
+
+// skipPersesResources drops perses.dev resources from the reconciliation request when the
+// Perses API is not available (any API version).
+func skipPersesResources(rr *types.ReconciliationRequest) {
+	persesGroup := gvk.PersesDashboard.Group
+	out := rr.Resources[:0]
+	for i := range rr.Resources {
+		gvkObj := rr.Resources[i].GroupVersionKind()
+		if gvkObj.Group != persesGroup {
+			out = append(out, rr.Resources[i])
+		}
+	}
+	rr.Resources = out
+}
+
+// configurePersesResources sets the ModelsAsService instance as controller owner of PersesDashboard
+// and PersesDatasource resources still present in rr (after validatePersesDashboards). This ensures
+// they are garbage-collected with MaaS and recognized as managed children when the deploy action runs.
+func configurePersesResources(_ context.Context, rr *types.ReconciliationRequest) error {
+	maas, ok := rr.Instance.(*componentApi.ModelsAsService)
+	if !ok {
+		return fmt.Errorf("resource instance %v is not a componentApi.ModelsAsService", rr.Instance)
+	}
+
+	persesGroup := gvk.PersesDashboard.Group
+	for i := range rr.Resources {
+		res := &rr.Resources[i]
+		objGVK := res.GroupVersionKind()
+		if objGVK.Group == persesGroup {
+			if err := ctrl.SetControllerReference(maas, res, rr.Client.Scheme()); err != nil {
+				return fmt.Errorf("failed to set controller reference on %s %s/%s: %w",
+					objGVK.Kind, res.GetNamespace(), res.GetName(), err)
+			}
+		}
+	}
+
+	return nil
 }
 
 // configureTelemetryPolicyCore contains the core business logic for creating TelemetryPolicy resources.

--- a/internal/controller/components/modelsasservice/modelsasservice_controller_actions_test.go
+++ b/internal/controller/components/modelsasservice/modelsasservice_controller_actions_test.go
@@ -748,6 +748,97 @@ func TestBuildTelemetryLabels(t *testing.T) {
 	})
 }
 
+func TestValidatePersesResources(t *testing.T) {
+	g := NewWithT(t)
+
+	t.Run("should remove Perses resources when PersesDashboard CRD is not available", func(t *testing.T) {
+		cli := createFakeClientWithoutGateway()
+
+		dashboard := unstructured.Unstructured{}
+		dashboard.SetGroupVersionKind(gvk.PersesDashboardV1Alpha2)
+		dashboard.SetName("usage-dashboard")
+		dashboard.SetNamespace("monitoring")
+
+		datasource := unstructured.Unstructured{}
+		datasource.SetGroupVersionKind(gvk.PersesDatasourceV1Alpha1)
+		datasource.SetName("prom-datasource")
+		datasource.SetNamespace("monitoring")
+
+		configMap := unstructured.Unstructured{}
+		configMap.SetGroupVersionKind(gvk.ConfigMap)
+		configMap.SetName("other-config")
+		configMap.SetNamespace("default")
+
+		rr := &types.ReconciliationRequest{
+			Client:    cli,
+			Resources: []unstructured.Unstructured{dashboard, datasource, configMap},
+		}
+
+		err := validatePersesResources(t.Context(), rr)
+		g.Expect(err).ShouldNot(HaveOccurred())
+		g.Expect(rr.Resources).Should(HaveLen(1))
+		g.Expect(rr.Resources[0].GetName()).Should(Equal("other-config"))
+	})
+}
+
+func TestConfigurePersesResources(t *testing.T) {
+	g := NewWithT(t)
+
+	t.Run("should set ModelsAsService as controller owner on Perses resources", func(t *testing.T) {
+		cli, err := fakeclient.New()
+		g.Expect(err).ShouldNot(HaveOccurred())
+
+		maas := &componentApi.ModelsAsService{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "components.platform.opendatahub.io/v1alpha1",
+				Kind:       "ModelsAsService",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: componentApi.ModelsAsServiceInstanceName,
+				UID:  "maas-uid",
+			},
+		}
+
+		dashboard := unstructured.Unstructured{}
+		dashboard.SetGroupVersionKind(gvk.PersesDashboardV1Alpha2)
+		dashboard.SetName("usage-dashboard")
+		dashboard.SetNamespace("monitoring")
+
+		datasource := unstructured.Unstructured{}
+		datasource.SetGroupVersionKind(gvk.PersesDatasourceV1Alpha2)
+		datasource.SetName("prom-datasource")
+		datasource.SetNamespace("monitoring")
+
+		configMap := unstructured.Unstructured{}
+		configMap.SetGroupVersionKind(gvk.ConfigMap)
+		configMap.SetName("other-config")
+		configMap.SetNamespace("default")
+
+		rr := &types.ReconciliationRequest{
+			Instance:  maas,
+			Client:    cli,
+			Resources: []unstructured.Unstructured{dashboard, datasource, configMap},
+		}
+
+		err = configurePersesResources(t.Context(), rr)
+		g.Expect(err).ShouldNot(HaveOccurred())
+
+		refs := rr.Resources[0].GetOwnerReferences()
+		g.Expect(refs).Should(HaveLen(1))
+		g.Expect(refs[0].Kind).Should(Equal("ModelsAsService"))
+		g.Expect(refs[0].Name).Should(Equal(componentApi.ModelsAsServiceInstanceName))
+		g.Expect(string(refs[0].UID)).Should(Equal("maas-uid"))
+		g.Expect(refs[0].Controller).ShouldNot(BeNil())
+		g.Expect(*refs[0].Controller).Should(BeTrue())
+
+		refsDS := rr.Resources[1].GetOwnerReferences()
+		g.Expect(refsDS).Should(HaveLen(1))
+		g.Expect(refsDS[0].Kind).Should(Equal("ModelsAsService"))
+
+		g.Expect(rr.Resources[2].GetOwnerReferences()).Should(BeEmpty())
+	})
+}
+
 //nolint:dupl,maintidx // Similar test structure to TestConfigureIstioTelemetry is intentional for test clarity
 func TestConfigureTelemetryPolicy(t *testing.T) {
 	g := NewWithT(t)


### PR DESCRIPTION
<!---
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->
It is expected that sub-components would deploy their dashboards so we are going to change the MaaS operator to deploy its usage dashboard, however, it could be that the cluster observability operator (COO) is not deployed at this point and so the Perses CRDs (Dashboard, Datasource) will be missing, leading to an error during deployment. In order to avoid this, adding a check for the existence of the Perses Dashboard CRD, and filter out Perses resources from the reconciliation request when it is not available.

<!--- Link your JIRA and related links here for reference. -->
https://redhat.atlassian.net/browse/RHOAIENG-51459

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
It was tested manually using a custom image of the operator that takes the manifests from MAAS, including [this change](https://github.com/opendatahub-io/models-as-a-service/pull/686).
Without these changes, deploying MAAS while COO was missing resulted in an error during deployment
With these changes and still without COO, the Perses resources were not applied.
With these changes and COO deployed, the Perses resources were deployed with MAAS CR as their controller reference.

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->
<img width="2850" height="1538" alt="image" src="https://github.com/user-attachments/assets/8e7448ee-1d9d-43e9-8fa5-071b92a62bc7" />

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [x] The developer has run the integration test pipeline and verified that it passed successfully
- [ ] New RELATED_IMAGE mappings are already listed in ODH-Build-Config and RHOAI-Build-Config, and links are included in PR description

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->
This PR includes minor changes to the MAAS operator, the significant part is done on the MAAS side and should be tested there

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Perses resources are validated and automatically linked to the ModelsAsService instance during reconciliation.
* **Behavior**
  * Reconciliation now triggers for Perses-related resources by label or specific resource name to ensure timely handling.
* **Tests**
  * Added unit tests covering Perses resource validation and ownership configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->