### PR TITLE
feat(maas): detect and pass cluster audience for token review

### DIFF
--- a/internal/controller/components/modelsasservice/modelsasservice_controller.go
+++ b/internal/controller/components/modelsasservice/modelsasservice_controller.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 
+	configv1 "github.com/openshift/api/config/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
@@ -29,6 +30,7 @@ import (
 	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/api/components/v1alpha1"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/deploy"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/gc"
@@ -90,6 +92,16 @@ func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.
 				handlers.ToNamed(componentApi.ModelsAsServiceInstanceName),
 			),
 			reconciler.WithPredicates(resources.CreatedOrUpdatedOrDeletedNamed(MaaSDBSecretName)),
+		).
+		// Watch the OpenShift Authentication CR to detect changes to the cluster's
+		// service account issuer (e.g., on HyperShift/ROSA clusters). This ensures
+		// the AuthPolicy's kubernetesTokenReview audience is updated if it changes.
+		Watches(
+			&configv1.Authentication{},
+			reconciler.WithEventHandler(
+				handlers.ToNamed(componentApi.ModelsAsServiceInstanceName),
+			),
+			reconciler.WithPredicates(resources.CreatedOrUpdatedName(cluster.ClusterAuthenticationObj)),
 		).
 		WithAction(initialize).
 		WithAction(checkDependencies()).

--- a/internal/controller/components/modelsasservice/modelsasservice_controller_actions.go
+++ b/internal/controller/components/modelsasservice/modelsasservice_controller_actions.go
@@ -127,6 +127,12 @@ func customizeManifests(ctx context.Context, rr *types.ReconciliationRequest) er
 		log.V(4).Info("Configuring API key max expiration days", "value", *maas.Spec.APIKeys.MaxExpirationDays)
 	}
 
+	// Detect cluster audience from Authentication config (supports clusters with custom OIDC issuers)
+	if audience, err := cluster.GetClusterServiceAccountIssuer(ctx, rr.Client); err == nil && audience != "" {
+		params["cluster-audience"] = audience
+		log.Info("Using cluster-configured service account issuer for token review audience", "audience", audience)
+	}
+
 	if err := odhdeploy.ApplyParams(rr.Manifests[0].String(), "params.env", nil, params); err != nil {
 		return fmt.Errorf("failed to update params on path %s: %w", rr.Manifests[0].String(), err)
 	}

--- a/internal/controller/components/modelsasservice/modelsasservice_controller_actions.go
+++ b/internal/controller/components/modelsasservice/modelsasservice_controller_actions.go
@@ -127,10 +127,14 @@ func customizeManifests(ctx context.Context, rr *types.ReconciliationRequest) er
 		log.V(4).Info("Configuring API key max expiration days", "value", *maas.Spec.APIKeys.MaxExpirationDays)
 	}
 
-	// Detect cluster audience from Authentication config (supports clusters with custom OIDC issuers)
-	if audience, err := cluster.GetClusterServiceAccountIssuer(ctx, rr.Client); err == nil && audience != "" {
+	// Detect cluster audience for HyperShift/ROSA (non-default OIDC issuer)
+	audience, err := cluster.GetClusterServiceAccountIssuer(ctx, rr.Client)
+	if err != nil {
+		return fmt.Errorf("failed to detect cluster service account issuer: %w", err)
+	}
+	if audience != "" {
 		params["cluster-audience"] = audience
-		log.Info("Using cluster-configured service account issuer for token review audience", "audience", audience)
+		log.Info("Detected non-default cluster audience", "audience", audience)
 	}
 
 	if err := odhdeploy.ApplyParams(rr.Manifests[0].String(), "params.env", nil, params); err != nil {

--- a/pkg/cluster/cluster_config.go
+++ b/pkg/cluster/cluster_config.go
@@ -559,3 +559,18 @@ func IsIntegratedOAuth(ctx context.Context, cli client.Reader) (bool, error) {
 	}
 	return authMode == AuthModeIntegratedOAuth, nil
 }
+
+// GetClusterServiceAccountIssuer retrieves the service account issuer from
+// OpenShift Authentication config. Used for kubernetesTokenReview audiences
+// on clusters with custom OIDC providers (e.g., HyperShift, ROSA, or other configurations).
+// Returns empty string if not set or not running on OpenShift.
+func GetClusterServiceAccountIssuer(ctx context.Context, cli client.Reader) (string, error) {
+	auth := &configv1.Authentication{}
+	if err := cli.Get(ctx, client.ObjectKey{Name: ClusterAuthenticationObj}, auth); err != nil {
+		if meta.IsNoMatchError(err) || k8serr.IsNotFound(err) {
+			return "", nil
+		}
+		return "", fmt.Errorf("failed to get cluster authentication config: %w", err)
+	}
+	return auth.Spec.ServiceAccountIssuer, nil
+}

--- a/pkg/cluster/cluster_config.go
+++ b/pkg/cluster/cluster_config.go
@@ -562,8 +562,8 @@ func IsIntegratedOAuth(ctx context.Context, cli client.Reader) (bool, error) {
 
 // GetClusterServiceAccountIssuer retrieves the service account issuer from
 // OpenShift Authentication config. Used for kubernetesTokenReview audiences
-// on clusters with custom OIDC providers (e.g., HyperShift, ROSA, or other configurations).
-// Returns empty string if not set or not running on OpenShift.
+// on HyperShift/ROSA clusters which use a custom OIDC provider URL.
+// Returns empty string if not found or not running on OpenShift.
 func GetClusterServiceAccountIssuer(ctx context.Context, cli client.Reader) (string, error) {
 	auth := &configv1.Authentication{}
 	if err := cli.Get(ctx, client.ObjectKey{Name: ClusterAuthenticationObj}, auth); err != nil {

--- a/pkg/cluster/cluster_config_test.go
+++ b/pkg/cluster/cluster_config_test.go
@@ -440,6 +440,7 @@ func TestIsIntegratedOAuth(t *testing.T) {
 }
 
 func TestGetClusterServiceAccountIssuer(t *testing.T) {
+	// Register the configv1 scheme
 	scheme := runtime.NewScheme()
 	err := configv1.AddToScheme(scheme)
 	if err != nil {
@@ -449,38 +450,48 @@ func TestGetClusterServiceAccountIssuer(t *testing.T) {
 	testCases := []struct {
 		name           string
 		authObject     *configv1.Authentication
+		clientErr      error
 		expectedIssuer string
 		expectedError  bool
 	}{
 		{
-			name: "returns issuer when set",
+			name: "HyperShift/ROSA cluster with custom issuer",
 			authObject: &configv1.Authentication{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: cluster.ClusterAuthenticationObj,
 				},
 				Spec: configv1.AuthenticationSpec{
-					ServiceAccountIssuer: "https://oidc.rosa.example.com",
+					ServiceAccountIssuer: "https://rh-oidc.s3.us-east-1.amazonaws.com/abc123",
 				},
 			},
-			expectedIssuer: "https://oidc.rosa.example.com",
+			expectedIssuer: "https://rh-oidc.s3.us-east-1.amazonaws.com/abc123",
 			expectedError:  false,
 		},
 		{
-			name: "returns empty when issuer not set",
+			name: "Standard OpenShift cluster (empty issuer)",
 			authObject: &configv1.Authentication{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: cluster.ClusterAuthenticationObj,
 				},
-				Spec: configv1.AuthenticationSpec{},
+				Spec: configv1.AuthenticationSpec{
+					ServiceAccountIssuer: "",
+				},
 			},
 			expectedIssuer: "",
 			expectedError:  false,
 		},
 		{
-			name:           "returns empty when Authentication CR not found",
+			name:           "Authentication object not found (non-OpenShift)",
 			authObject:     nil,
 			expectedIssuer: "",
-			expectedError:  false,
+			expectedError:  false, // NotFound returns empty string, nil error
+		},
+		{
+			name:           "Client error (RBAC issue)",
+			authObject:     nil,
+			clientErr:      errors.New("forbidden: User cannot get resource"),
+			expectedIssuer: "",
+			expectedError:  true,
 		},
 	}
 
@@ -488,12 +499,20 @@ func TestGetClusterServiceAccountIssuer(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := context.Background()
 
+			var fakeClient client.Client
 			objs := []runtime.Object{}
 			if tc.authObject != nil {
 				objs = append(objs, tc.authObject)
 			}
 
-			fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(objs...).Build()
+			fakeClient = fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(objs...).Build()
+
+			if tc.clientErr != nil {
+				fakeClient = &erroringClient{
+					Client: fakeClient,
+					err:    tc.clientErr,
+				}
+			}
 
 			result, err := cluster.GetClusterServiceAccountIssuer(ctx, fakeClient)
 

--- a/pkg/cluster/cluster_config_test.go
+++ b/pkg/cluster/cluster_config_test.go
@@ -439,6 +439,80 @@ func TestIsIntegratedOAuth(t *testing.T) {
 	}
 }
 
+func TestGetClusterServiceAccountIssuer(t *testing.T) {
+	scheme := runtime.NewScheme()
+	err := configv1.AddToScheme(scheme)
+	if err != nil {
+		t.Fatalf("failed to add configv1 scheme: %v", err)
+	}
+
+	testCases := []struct {
+		name           string
+		authObject     *configv1.Authentication
+		expectedIssuer string
+		expectedError  bool
+	}{
+		{
+			name: "returns issuer when set",
+			authObject: &configv1.Authentication{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: cluster.ClusterAuthenticationObj,
+				},
+				Spec: configv1.AuthenticationSpec{
+					ServiceAccountIssuer: "https://oidc.rosa.example.com",
+				},
+			},
+			expectedIssuer: "https://oidc.rosa.example.com",
+			expectedError:  false,
+		},
+		{
+			name: "returns empty when issuer not set",
+			authObject: &configv1.Authentication{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: cluster.ClusterAuthenticationObj,
+				},
+				Spec: configv1.AuthenticationSpec{},
+			},
+			expectedIssuer: "",
+			expectedError:  false,
+		},
+		{
+			name:           "returns empty when Authentication CR not found",
+			authObject:     nil,
+			expectedIssuer: "",
+			expectedError:  false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+
+			objs := []runtime.Object{}
+			if tc.authObject != nil {
+				objs = append(objs, tc.authObject)
+			}
+
+			fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(objs...).Build()
+
+			result, err := cluster.GetClusterServiceAccountIssuer(ctx, fakeClient)
+
+			if tc.expectedError {
+				if err == nil {
+					t.Errorf("GetClusterServiceAccountIssuer() expected error but got nil")
+				}
+			} else {
+				if err != nil {
+					t.Errorf("GetClusterServiceAccountIssuer() unexpected error: %v", err)
+				}
+				if result != tc.expectedIssuer {
+					t.Errorf("GetClusterServiceAccountIssuer() = %q, want %q", result, tc.expectedIssuer)
+				}
+			}
+		})
+	}
+}
+
 func TestGetDomain(t *testing.T) {
 	testCases := []struct {
 		name           string


### PR DESCRIPTION
<!---
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
Add support for clusters with custom OIDC issuers (e.g., HyperShift, ROSA) by detecting the `serviceAccountIssuer` from `Authentication/cluster` and passing it to MaaS manifests as the `cluster-audience` parameter.

**Problem:** The `maas-api-auth-policy` AuthPolicy ships with a default `kubernetesTokenReview.audiences` of `https://kubernetes.default.svc`. On clusters with custom OIDC providers, OpenShift token authentication fails because the audience doesn't match. 

**Solution:** The operator now auto-detects the cluster's service account issuer from the OpenShift `Authentication` config and passes it to the MaaS manifests. The kustomize replacement in models-as-a-service then patches the AuthPolicy with the correct audience.

https://redhat.atlassian.net/browse/RHOAIENG-56368

## How Has This Been Tested?
* Unit tests
* Manual verification
```
# After deployment, verify AuthPolicy has correct audience
kubectl get authpolicy maas-api-auth-policy -o jsonpath='{.spec.rules.authentication.openshift-identities.kubernetesTokenReview.audiences[0]}'
```

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [x] The developer has run the integration test pipeline and verified that it passed successfully
- [ ] New RELATED_IMAGE mappings are already listed in ODH-Build-Config and RHOAI-Build-Config, and links are included in PR description

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
This change adds a new parameter passthrough from cluster config to MaaS manifests. The core functionality is covered by:
* Unit tests for GetClusterServiceAccountIssuer() (added in this PR)
* The existing kustomize replacement mechanism in models-as-a-service



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Rendering now detects a cluster's non-default service-account issuer/audience and injects the detected audience into deployment parameters.
  * The controller now reacts to cluster authentication changes so rendered parameters stay in sync with the cluster issuer.
  * If issuer detection fails, parameter rendering halts with an error to avoid applying incomplete parameters.

* **Tests**
  * Added unit tests covering present, empty, absent, and error scenarios for issuer detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->