### PR TITLE
fix: surface CRD deploy errors instead of silently swallowing them

### DIFF
--- a/pkg/controller/actions/deploy/action_deploy.go
+++ b/pkg/controller/actions/deploy/action_deploy.go
@@ -265,8 +265,17 @@ func (a *Action) deployCRD(
 	}
 
 	if err != nil {
-		return false, client.IgnoreNotFound(err)
+		logf.FromContext(ctx).Error(err, "failed to deploy CRD",
+			"name", obj.GetName(),
+			"mode", a.deployMode,
+		)
+		return false, fmt.Errorf("failed to deploy CRD %s: %w", obj.GetName(), err)
 	}
+
+	logf.FromContext(ctx).V(1).Info("successfully deployed CRD",
+		"name", obj.GetName(),
+		"mode", a.deployMode,
+	)
 
 	if a.cache != nil {
 		err := a.cache.Add(deployedObj, origObj)


### PR DESCRIPTION
## Description

`deployCRD()` in `pkg/controller/actions/deploy/action_deploy.go:271` uses `client.IgnoreNotFound(err)` which silently discards any NotFound-shaped error from CRD deployment. This causes CRD creation failures to go unreported — large CRDs (e.g. KServe's 1-2MB inferenceservices/llminferenceservices CRDs) fail without any visible error, blocking component readiness with a misleading error about missing CR types.

The same `IgnoreNotFound` pattern was already identified as problematic and removed from the sibling `deploy()` method in PR #2257 (RHOAIENG-31497), but the fix was never applied to `deployCRD()`.

This PR:
- Removes `client.IgnoreNotFound(err)` so CRD deploy errors propagate
- Adds structured logging (`Error` on failure, `V(1)` on success) for CRD deploy outcomes

JIRA: [RHOAIENG-56819](https://redhat.atlassian.net/browse/RHOAIENG-56819)

Related: PR #2257 (commit 52e03fe8) which applied the same fix to `deploy()`

## How Has This Been Tested?

- Deployed operator with this fix on a ROSA 4.19 cluster
- Created DSCI + DSC with `kserve.managementState: Managed`
- Verified all three large KServe CRDs (`inferenceservices`, `llminferenceservices`, `llminferenceserviceconfigs`) deploy successfully
- KserveReady: True, ModelControllerReady: True, overall DSC Ready: True
- Ran `make fmt` — no changes
- Ran `make lint` — 0 issues
- Ran `make vet` — clean

## Screenshot or short clip

N/A — internal error handling fix

## Merge criteria

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [x] The developer has run the integration test pipeline and verified that it passed successfully
- [x] New RELATED_IMAGE mappings are already listed in ODH-Build-Config and RHOAI-Build-Config, and links are included in PR description

### E2E test suite update requirement

- [x] Skip requirement to update E2E test suite for this PR

#### E2E update requirement opt-out justification

This is a one-line error handling fix (replacing `client.IgnoreNotFound(err)` with `err`) plus logging. It does not change any functional behavior — it only makes existing errors visible instead of silently swallowed. No new features, APIs, or code paths are introduced. The identical fix was already applied to the sibling `deploy()` method in PR #2257 without E2E changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for Custom Resource Definition (CRD) deployments: failed deployments now return a clear, detailed error including the CRD name and deployment mode instead of being ignored.
  * Enhanced logging for CRD operations: successful deployments are now logged for better visibility into deployment outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->