### PR TITLE
Instruct humans and agents about internal CRDs

### DIFF
--- a/.rules/review-instructions.md
+++ b/.rules/review-instructions.md
@@ -33,3 +33,10 @@ Always flag these regardless of context:
 - `InsecureSkipVerify: true` in non-test code
 - Wildcard verbs or resources in RBAC rules
 - Secrets, tokens, or credentials logged at any verbosity level
+- User-facing component configuration added only to an internal component CRD spec (`XxxSpec`)
+  without a corresponding field in `DSCXxx` (via `XxxCommonSpec`). Any field a user must set to
+  configure component behaviour belongs in `CommonSpec` so it is reachable through the DSC API.
+  The only legitimate use of internal-only spec fields (those in `XxxSpec` but NOT in
+  `XxxCommonSpec`) is for values written exclusively by the operator itself (e.g. the gateway
+  domain stamped from `GatewayConfig.Status.Domain`). See `docs/COMPONENT_INTEGRATION.md` for
+  the correct pattern.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -222,6 +222,12 @@ IsEnabled(dsc *dscv2.DataScienceCluster) bool
 4. **Management states**: `Managed` (deployed), `Removed` (cleaned up), empty/`{}` (treated as Removed)
 5. **Platform detection**: Use build tags `-tags=odh` or `-tags=rhoai`
 6. **Action execution order matters**: Sequential execution, stops on first error
+7. **DSC API surfacing**: Any component configuration field that a user must set belongs in
+   `XxxCommonSpec` and must be inlined into both `XxxSpec` and `DSCXxx`. Fields present in
+   `XxxSpec` but absent from `XxxCommonSpec` must only be written by the operator itself (e.g.
+   values propagated from `GatewayConfig`). Never add user-facing fields to the internal-only
+   section of a component spec without a DSC-level counterpart — internal CRDs are hidden from
+   the OperatorHub UI and are not the expected user-facing API surface.
 
 ## Platform-Specific Considerations
 

--- a/docs/COMPONENT_INTEGRATION.md
+++ b/docs/COMPONENT_INTEGRATION.md
@@ -59,6 +59,11 @@ type ExampleComponentSpec struct {
 	ExampleComponentCommonSpec `json:",inline"`
 
 	// new component spec exposed only to internal api
+	// IMPORTANT: fields here must only be written by the operator itself (e.g. values
+	// discovered at run time based on cluster config). Never place user-facing configuration
+	// here — anything a user must set belongs in ExampleComponentCommonSpec so it is
+	// reachable through the DSC API. Internal CRDs are hidden from the OperatorHub UI
+	// and are not the expected user-facing API surface.
   	// ( refer/define here if applicable to the new component )
 }
 
@@ -146,7 +151,7 @@ Alternatively, you can refer to the existing integrated component APIs located w
 
 #### Define internal resources for the new component
 
-Component CRDs can be marked as internal to hide them from users in the OperatorHub UI. While some internal resources can still be edited by users if needed, resources visible in the UI represent the primary configuration points that users are expected to interact with. Most component resources should be internal unless they require direct user configuration. 
+Component CRDs can be marked as internal to hide them from users in the OperatorHub UI. Internal component CRDs are **not** the expected user-facing API surface — the DataScienceCluster (DSC) is. Any configuration field that a user must set must be surfaced through the DSC spec via `DSCExampleComponent` (using `ExampleComponentCommonSpec`). Fields that live only on the internal `ExampleComponentSpec` (outside of `CommonSpec`) must be values written exclusively by the operator itself, such as infrastructure details propagated from `GatewayConfig`. Most component resources should be internal; this means users are NOT expected to edit them directly.
 
 To mark your component as internal, update `config/manifests/bases/opendatahub-operator.clusterserviceversion.yaml` and `config/rhoai/manifests/bases/rhods-operator.clusterserviceversion.yaml`to add your component's CRD to the `operators.operatorframework.io/internal-objects` annotation:
 
@@ -249,7 +254,7 @@ func (s *componentHandler) GetManagementState(dsc *dscv1.DataScienceCluster) ope
 
 func (s *componentHandler) NewCRObject(dsc *dscv1.DataScienceCluster) common.PlatformObject
 
-func (s *componentHandler) Init(platform common.Platform) error 
+func (s *componentHandler) Init(platform common.Platform) error
 
 func (s *componentHandler) UpdateDSCStatus(ctx context.Context, rr *types.ReconciliationRequest) (metav1.ConditionStatus, error)
 ```


### PR DESCRIPTION
<!---
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->
The internal CRDs should not be modified by users, since those are owned by the DSC. If user input is needed for field values, then those fields should be specified in the DSC.

Giving users the ability to modify them will make it needlessly complicated for users to know when they should modify the DSC and when they should modify the internal CRs that are created as a result.

If we start having new fields modifiable by users accidentally, then it will be difficult to give that control back to the DSC: it would have no easy way of knowing whether the changes that it's about to reset were user modified.

Related PR where problem discussed: https://github.com/opendatahub-io/opendatahub-operator/pull/3362#discussion_r3029177524

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully
- [x] New RELATED_IMAGE mappings are already listed in ODH-Build-Config and RHOAI-Build-Config, and links are included in PR description

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated component integration and review guidelines to clarify how user-configurable settings should be properly exposed and validated across system API surfaces, ensuring consistency and appropriate access control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->