### PR TITLE
[RHOAIENG-57147] fix lua envoyfilter to prevent 431 HTTP error

### DIFF
--- a/internal/controller/services/gateway/resources/envoyfilter-authn.tmpl.yaml
+++ b/internal/controller/services/gateway/resources/envoyfilter-authn.tmpl.yaml
@@ -106,7 +106,7 @@ spec:
                   for cookie in cookie_header:gmatch("([^;]+)") do
                     -- Trim whitespace and extract cookie name
                     local trimmed = cookie:match("^%%s*(.-)%%s*$")
-                    if trimmed ~= "" then
+                    if trimmed and trimmed ~= "" then
                       local cookie_name = trimmed:match("^([^=]+)")
                       -- Only keep cookies that don't match the OAuth2 proxy cookie pattern
                       if cookie_name and not cookie_name:match(cookie_pattern) then

--- a/internal/controller/services/gateway/resources/envoyfilter-authn.tmpl.yaml
+++ b/internal/controller/services/gateway/resources/envoyfilter-authn.tmpl.yaml
@@ -105,7 +105,7 @@ spec:
                   -- Parse and filter cookies in a single pass
                   for cookie in cookie_header:gmatch("([^;]+)") do
                     -- Trim whitespace and extract cookie name
-                    local trimmed = cookie:match("^%%s*(.-)%%s*$")
+                    local trimmed = cookie:match("^%s*(.-)%s*$")
                     if trimmed and trimmed ~= "" then
                       local cookie_name = trimmed:match("^([^=]+)")
                       -- Only keep cookies that don't match the OAuth2 proxy cookie pattern


### PR DESCRIPTION
This change prevents the script to fail prematurily.

## Description
Created with help of cursor AI. I tested this change manually on a BYOIDC cluster in our standard QE environment. Withtout this change, I wasn't able to log into the RHOAI dashboard at all as my browser failed with the:

```
{"error":"Request Header Fields Too Large","message":"Exceeded maximum allowed HTTP header size","statusCode":431}
```

Based on the debugging, it was because the auth cookie wasn't stripped from the request and as such the request than exceeded the max header limit.

https://redhat.atlassian.net/browse/RHOAIENG-57147

## How Has This Been Tested?
Didn't do any build - just did the same change as described in the workaround section of the issue.

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully
- [ ] New RELATED_IMAGE mappings are already listed in ODH-Build-Config and RHOAI-Build-Config, and links are included in PR description

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
no plan for E2E tests now


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cookie parsing and filtering robustness: trimming and empty-value checks were hardened to avoid edge-case failures when cookies are missing or malformed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->