### PR TITLE
add_IMAGES_PIPELINES_COMPONENT

### DIFF
--- a/build/operands-map.yaml
+++ b/build/operands-map.yaml
@@ -236,3 +236,6 @@ relatedImages:
     - name: RELATED_IMAGE_ODH_MODEL_SERVING_API_IMAGE
       value: quay.io/opendatahub/odh-model-serving-api@sha256:40088eb920950a621d3d14e2acae520f15aaadfcc42b4cf1e674f9dc000c816f
       component: odh-model-serving-api
+    - name: RELATED_IMAGE_ODH_PIPELINES_COMPONENTS_IMAGE
+      value: quay.io/opendatahub/odh-pipelines-components@sha256:ca9c1e7df18c110e7a7e7ccbfa94bc66fb789ca7d041342e1c9a687b6a448c46
+      component: odh-pipelines-components

--- a/internal/controller/components/datasciencepipelines/datasciencepipelines_support.go
+++ b/internal/controller/components/datasciencepipelines/datasciencepipelines_support.go
@@ -52,6 +52,7 @@ var (
 		"IMAGES_TOOLBOX":                 "RELATED_IMAGE_DSP_TOOLBOX_IMAGE",
 		"IMAGES_RHELAI":                  "RELATED_IMAGE_DSP_INSTRUCTLAB_NVIDIA_IMAGE",
 		"kube-rbac-proxy":                "RELATED_IMAGE_OSE_KUBE_RBAC_PROXY_IMAGE",
+		"IMAGES_PIPELINES_COMPONENTS":    "RELATED_IMAGE_ODH_PIPELINES_COMPONENTS_IMAGE",
 	}
 
 	overlaysSourcePaths = map[common.Platform]string{


### PR DESCRIPTION
<!---
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->
Add related image wiring for new DSPO image.

https://redhat-internal.slack.com/archives/C0A2GC6JRPH/p1775584013260379
<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [x] The developer has run the integration test pipeline and verified that it passed successfully
- [x] New RELATED_IMAGE mappings are already listed in ODH-Build-Config and RHOAI-Build-Config, and links are included in PR description

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->
New image doesn't need any e2e changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for ODH Pipelines Components integration by including the official container image reference for the pipelines components and wiring it into the image configuration so the components are available at runtime.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->