### PR TITLE
RHOAIENG-49735 | refactor(e2e): replace global timeout mutation with hierarchical timeout archtecture

### DIFF
--- a/tests/e2e/components_test.go
+++ b/tests/e2e/components_test.go
@@ -137,7 +137,7 @@ func (tc *ComponentTestCtx) ValidateComponentDisabled(t *testing.T) {
 				}.AsSelector(),
 			},
 		),
-		WithEventuallyTimeout(tc.TestTimeouts.mediumEventuallyTimeout),
+		WithEventuallyTimeout(tc.TestTimeouts.componentReadinessTimeout),
 	)
 
 	// Ensure that the resources associated with the component do not exist
@@ -446,7 +446,7 @@ func (tc *ComponentTestCtx) ValidateSubComponentDisabled(t *testing.T) {
 				}.AsSelector(),
 			},
 		),
-		WithEventuallyTimeout(tc.TestTimeouts.mediumEventuallyTimeout),
+		WithEventuallyTimeout(tc.TestTimeouts.componentReadinessTimeout),
 	)
 
 	// Ensure that the resources associated with the subcomponent do not exist
@@ -579,10 +579,13 @@ func (tc *ComponentTestCtx) ValidateAllDeletionRecovery(t *testing.T) {
 
 	skipUnless(t, Smoke, Tier1)
 
-	// Increase the global eventually timeout for deletion recovery tests
-	// Use longEventuallyTimeout to handle controller performance under load and complex resource dependencies
-	reset := tc.OverrideEventuallyTimeout(tc.TestTimeouts.longEventuallyTimeout, tc.TestTimeouts.defaultEventuallyPollInterval)
-	defer reset() // Make sure it's reset after all tests run
+	// Set per-operation timeout defaults for deletion recovery tests.
+	savedOpts := tc.DefaultResourceOpts
+	tc.DefaultResourceOpts = []ResourceOpts{
+		WithEventuallyTimeout(tc.TestTimeouts.deletionRecoveryTimeout),
+		WithEventuallyPollingInterval(tc.TestTimeouts.defaultEventuallyPollInterval),
+	}
+	defer func() { tc.DefaultResourceOpts = savedOpts }()
 
 	// Test order explanation:
 	// 1. ConfigMaps/Services - these are stateless resources with no dependencies

--- a/tests/e2e/controller_test.go
+++ b/tests/e2e/controller_test.go
@@ -104,6 +104,7 @@ type TestGroup struct {
 }
 
 type TestTimeouts struct {
+	// Generic tiers
 	defaultEventuallyTimeout        time.Duration
 	shortEventuallyTimeout          time.Duration
 	mediumEventuallyTimeout         time.Duration
@@ -111,6 +112,15 @@ type TestTimeouts struct {
 	defaultEventuallyPollInterval   time.Duration
 	defaultConsistentlyTimeout      time.Duration
 	defaultConsistentlyPollInterval time.Duration
+
+	// Named operation-specific tiers
+	crCreationTimeout         time.Duration // DSCI/DSC creation and readiness
+	componentReadinessTimeout time.Duration // Component enabled/disabled checks
+	monitoringStackTimeout    time.Duration // Monitoring stack readiness (Prometheus, Tempo, OLM-dependent)
+	authGatewayTimeout        time.Duration // Auth/gateway configuration checks
+	deletionRecoveryTimeout   time.Duration // Resource deletion and controller recreation
+	olmOperationTimeout       time.Duration // CSV succeeded, InstallPlan approval
+	operandReadinessTimeout   time.Duration // Operand deployments reaching ready state
 }
 
 type TestCase struct {
@@ -414,6 +424,7 @@ func TestMain(m *testing.M) {
 	// Defaults
 	// Gomega default values for Eventually/Consistently can be found here:
 	// https://onsi.github.io/gomega/#making-asynchronous-assertions
+	// Generic tiers
 	viper.SetDefault("defaultEventuallyTimeout", "5m")        // Timeout used for Eventually; overrides Gomega's default of 1 second.
 	viper.SetDefault("shortEventuallyTimeout", "10s")         // Timeout used for Eventually; overrides Gomega's default of 1 second.
 	viper.SetDefault("mediumEventuallyTimeout", "7m")         // Medium timeout: for readiness checks (e.g., ClusterServiceVersion, DataScienceCluster).
@@ -421,6 +432,15 @@ func TestMain(m *testing.M) {
 	viper.SetDefault("defaultEventuallyPollInterval", "10s")  // Polling interval for Eventually; overrides Gomega's default of 10 milliseconds.
 	viper.SetDefault("defaultConsistentlyTimeout", "20s")     // Duration used for Consistently; overrides Gomega's default of 2 seconds.
 	viper.SetDefault("defaultConsistentlyPollInterval", "5s") // Polling interval for Consistently; overrides Gomega's default of 50 milliseconds.
+
+	// Named operation-specific tiers — defaults based on CI observability data
+	viper.SetDefault("crCreationTimeout", "2m")         // DSCI/DSC creation and readiness (P99=71s, observed avg ~10s).
+	viper.SetDefault("componentReadinessTimeout", "3m") // Component enabled/disabled checks (P99=93s, outliers at 243s).
+	viper.SetDefault("monitoringStackTimeout", "7m")    // Monitoring stack readiness (P99=292s, TLS_Fix/ThanosQuerier pass at 5-6min).
+	viper.SetDefault("authGatewayTimeout", "5m")        // Auth/gateway checks (72 passes exceed 2min, max 265s — do not reduce).
+	viper.SetDefault("deletionRecoveryTimeout", "90s")  // Resource deletion and controller recreation (P99=46s, nothing above 90s).
+	viper.SetDefault("olmOperationTimeout", "2m")       // CSV succeeded, InstallPlan approval (P99=81s, nothing above 120s).
+	viper.SetDefault("operandReadinessTimeout", "2m")   // Operand deployments reaching ready state (P99=56s, outliers at 90s).
 
 	// Flags
 	pflag.String("operator-namespace", "opendatahub-operator-system", "Namespace where the odh operator is deployed")
@@ -493,6 +513,7 @@ func TestMain(m *testing.M) {
 	}
 
 	testOpts.TestTimeouts = TestTimeouts{
+		// Generic tiers
 		defaultEventuallyTimeout:        viper.GetDuration("defaultEventuallyTimeout"),
 		shortEventuallyTimeout:          viper.GetDuration("shortEventuallyTimeout"),
 		mediumEventuallyTimeout:         viper.GetDuration("mediumEventuallyTimeout"),
@@ -500,6 +521,14 @@ func TestMain(m *testing.M) {
 		defaultEventuallyPollInterval:   viper.GetDuration("defaultEventuallyPollInterval"),
 		defaultConsistentlyTimeout:      viper.GetDuration("defaultConsistentlyTimeout"),
 		defaultConsistentlyPollInterval: viper.GetDuration("defaultConsistentlyPollInterval"),
+		// Named operation-specific tiers
+		crCreationTimeout:         viper.GetDuration("crCreationTimeout"),
+		componentReadinessTimeout: viper.GetDuration("componentReadinessTimeout"),
+		monitoringStackTimeout:    viper.GetDuration("monitoringStackTimeout"),
+		authGatewayTimeout:        viper.GetDuration("authGatewayTimeout"),
+		deletionRecoveryTimeout:   viper.GetDuration("deletionRecoveryTimeout"),
+		olmOperationTimeout:       viper.GetDuration("olmOperationTimeout"),
+		operandReadinessTimeout:   viper.GetDuration("operandReadinessTimeout"),
 	}
 	testOpts.tag = viper.GetString("tag")
 	if !slices.Contains(allowedTags, TestTag(testOpts.tag)) {

--- a/tests/e2e/creation_test.go
+++ b/tests/e2e/creation_test.go
@@ -135,8 +135,8 @@ func (tc *DSCTestCtx) ValidateDSCICreation(t *testing.T) {
 		WithCondition(jq.Match(`.status.phase == "%s"`, status.ConditionTypeReady)),
 		WithCustomErrorMsg("Failed to create DSCInitialization resource %s", tc.DSCInitializationNamespacedName.Name),
 
-		// Increase time required to get DSCI created
-		WithEventuallyTimeout(tc.TestTimeouts.longEventuallyTimeout),
+		// CR creation can be slow due to webhook setup and initial reconciliation
+		WithEventuallyTimeout(tc.TestTimeouts.crCreationTimeout),
 		WithEventuallyPollingInterval(tc.TestTimeouts.defaultEventuallyPollInterval),
 	)
 }
@@ -152,8 +152,8 @@ func (tc *DSCTestCtx) ValidateDSCCreation(t *testing.T) {
 		WithCondition(jq.Match(`.status.phase == "%s"`, status.ConditionTypeReady)),
 		WithCustomErrorMsg("Failed to create DataScienceCluster resource %s", tc.DataScienceClusterNamespacedName.Name),
 
-		// Increase time required to get DSC created
-		WithEventuallyTimeout(tc.TestTimeouts.mediumEventuallyTimeout),
+		// CR creation can be slow due to component reconciliation
+		WithEventuallyTimeout(tc.TestTimeouts.crCreationTimeout),
 		WithEventuallyPollingInterval(tc.TestTimeouts.defaultEventuallyPollInterval),
 	)
 }

--- a/tests/e2e/kserve_test.go
+++ b/tests/e2e/kserve_test.go
@@ -43,9 +43,12 @@ func kserveTestSuite(t *testing.T) {
 		ComponentTestCtx: ct,
 	}
 
-	// Increase the global eventually timeout
-	reset := componentCtx.OverrideEventuallyTimeout(ct.TestTimeouts.longEventuallyTimeout, ct.TestTimeouts.defaultEventuallyPollInterval)
-	defer reset() // Make sure it's reset after all tests run
+	// Set per-operation timeout defaults for all operations in this suite.
+	// KServe initialization involves complex CRD/feature gate setup that requires longer timeouts.
+	componentCtx.DefaultResourceOpts = []ResourceOpts{
+		WithEventuallyTimeout(ct.TestTimeouts.longEventuallyTimeout),
+		WithEventuallyPollingInterval(ct.TestTimeouts.defaultEventuallyPollInterval),
+	}
 
 	// Define test cases.
 	testCases := make([]TestCase, 0, 11)
@@ -79,6 +82,13 @@ func kserveDegradedMonitoringTestSuite(t *testing.T) {
 
 	componentCtx := KserveTestCtx{
 		ComponentTestCtx: ct,
+	}
+
+	// Set per-operation timeout defaults — KServe initialization is slow (CRD/feature gate setup).
+	// Without this, operations fall back to the 5m baseline and flake in slower CI environments.
+	componentCtx.DefaultResourceOpts = []ResourceOpts{
+		WithEventuallyTimeout(ct.TestTimeouts.longEventuallyTimeout),
+		WithEventuallyPollingInterval(ct.TestTimeouts.defaultEventuallyPollInterval),
 	}
 
 	testCases := []TestCase{

--- a/tests/e2e/modelcontroller_test.go
+++ b/tests/e2e/modelcontroller_test.go
@@ -52,9 +52,11 @@ func modelControllerTestSuite(t *testing.T) {
 		{"Validate component disabled", componentCtx.ValidateComponentDisabled},
 	}
 
-	// Increase the global eventually timeout
-	reset := componentCtx.OverrideEventuallyTimeout(ct.TestTimeouts.mediumEventuallyTimeout, ct.TestTimeouts.defaultEventuallyPollInterval)
-	defer reset() // Make sure it's reset after all tests run
+	// Set per-operation timeout defaults for all operations in this suite.
+	componentCtx.DefaultResourceOpts = []ResourceOpts{
+		WithEventuallyTimeout(ct.TestTimeouts.mediumEventuallyTimeout),
+		WithEventuallyPollingInterval(ct.TestTimeouts.defaultEventuallyPollInterval),
+	}
 
 	// Run the test suite.
 	RunTestCases(t, testCases)

--- a/tests/e2e/modelsasservice_test.go
+++ b/tests/e2e/modelsasservice_test.go
@@ -59,10 +59,13 @@ func modelsAsServiceTestSuite(t *testing.T) {
 		ComponentTestCtx: ct,
 	}
 
+	// Set per-operation timeout defaults for all operations in this suite.
 	// MaaS startup involves multiple dependencies (postgres, gateway, maas-controller leader election,
 	// ServiceAccount/TLS cert provisioning) that can take longer than the default 5m timeout.
-	reset := componentCtx.OverrideEventuallyTimeout(ct.TestTimeouts.longEventuallyTimeout, ct.TestTimeouts.defaultEventuallyPollInterval)
-	defer reset()
+	componentCtx.DefaultResourceOpts = []ResourceOpts{
+		WithEventuallyTimeout(ct.TestTimeouts.longEventuallyTimeout),
+		WithEventuallyPollingInterval(ct.TestTimeouts.defaultEventuallyPollInterval),
+	}
 
 	// Setup: Create prerequisites and enable the subcomponent.
 	// PostgreSQL must be created before enabling the component because

--- a/tests/e2e/monitoring_test.go
+++ b/tests/e2e/monitoring_test.go
@@ -99,10 +99,12 @@ func monitoringTestSuite(t *testing.T) {
 		expectedDefaultReplicas: expectedReplicas,
 	}
 
-	// Increase the global eventually timeout for monitoring tests involve complex operator dependencies (OpenTelemetry, Tempo, etc.)
-	// that can take longer to reconcile, especially under load or in slower environments.
-	reset := tc.OverrideEventuallyTimeout(tc.TestTimeouts.longEventuallyTimeout, tc.TestTimeouts.defaultEventuallyPollInterval)
-	defer reset() // Make sure it's reset after all tests run
+	// Set per-operation timeout defaults for monitoring tests that involve complex operator
+	// dependencies (OpenTelemetry, Tempo, etc.) that can take longer to reconcile.
+	tc.DefaultResourceOpts = []ResourceOpts{
+		WithEventuallyTimeout(tc.TestTimeouts.monitoringStackTimeout),
+		WithEventuallyPollingInterval(tc.TestTimeouts.defaultEventuallyPollInterval),
+	}
 
 	// ========================================================================
 	// Pre-requisite: Ensure required monitoring operators are installed
@@ -1335,7 +1337,7 @@ func (tc *MonitoringTestCtx) validateTempoStackCreationWithBackend(t *testing.T,
 				jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, status.ConditionTypeReady, metav1.ConditionTrue),
 			),
 		),
-		WithEventuallyTimeout(tc.TestTimeouts.longEventuallyTimeout),
+		WithEventuallyTimeout(tc.TestTimeouts.monitoringStackTimeout),
 		WithCustomErrorMsg("TempoStack should be created by controller with %s backend, but was not found or has incorrect backend type", backend),
 	)
 
@@ -2187,7 +2189,7 @@ func (tc *MonitoringTestCtx) waitForPrometheusNamespaceProxyPrerequisites(t *tes
 			Namespace: namespace,
 		}),
 		WithCondition(jq.Match(`.status.conditions[] | select(.type == "Available") | .status == "True"`)),
-		WithEventuallyTimeout(tc.TestTimeouts.longEventuallyTimeout),
+		WithEventuallyTimeout(tc.TestTimeouts.monitoringStackTimeout),
 		WithCustomErrorMsg("MonitoringStack should be Available before prometheus-namespace-proxy deployment"),
 	)
 
@@ -2572,7 +2574,7 @@ func (tc *MonitoringTestCtx) validatePersesDatasourceTLSWithCloudBackend(t *test
 				jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, status.ConditionTypeReady, metav1.ConditionTrue),
 			),
 		),
-		WithEventuallyTimeout(tc.TestTimeouts.longEventuallyTimeout),
+		WithEventuallyTimeout(tc.TestTimeouts.monitoringStackTimeout),
 		WithCustomErrorMsg("TempoStack should be ready with %s backend before checking PersesDatasource", backend),
 	)
 
@@ -2596,7 +2598,7 @@ func (tc *MonitoringTestCtx) validatePersesDatasourceTLSWithCloudBackend(t *test
 				jq.Match(`.spec.config.plugin.spec.proxy.spec.secret == "tempo-datasource-secret"`),
 			),
 		),
-		WithEventuallyTimeout(tc.TestTimeouts.longEventuallyTimeout),
+		WithEventuallyTimeout(tc.TestTimeouts.monitoringStackTimeout),
 		WithCustomErrorMsg("PersesDatasource should have TLS enabled for %s backend", backend),
 	)
 

--- a/tests/e2e/test_context_test.go
+++ b/tests/e2e/test_context_test.go
@@ -76,6 +76,10 @@ type TestContext struct {
 
 	// Namespaced name of the DataScienceCluster custom resource used for testing.
 	DataScienceClusterNamespacedName types.NamespacedName
+
+	// DefaultResourceOpts are applied as a baseline to every NewResourceOptions call.
+	// Individual per-operation opts (e.g., WithEventuallyTimeout) override these defaults.
+	DefaultResourceOpts []ResourceOpts
 }
 
 // NewTestContext creates and initializes a new TestContext instance.
@@ -135,42 +139,10 @@ func (tc *TestContext) Logf(format string, args ...any) {
 	tc.logger.Logf(format, args...)
 }
 
-// OverrideEventuallyTimeout temporarily changes the Eventually timeout and polling period.
-func (tc *TestContext) OverrideEventuallyTimeout(timeout, pollInterval time.Duration) func() {
-	// Save current timeout values (you'll need to store these manually)
-	previousTimeout := tc.g.DurationBundle.EventuallyTimeout
-	previousPollInterval := tc.g.DurationBundle.EventuallyPollingInterval
-
-	// Override with new values
-	tc.g.SetDefaultEventuallyTimeout(timeout)
-	tc.g.SetDefaultEventuallyPollingInterval(pollInterval)
-
-	// Return a function to reset them back
-	return func() {
-		// Override with new values
-		tc.g.SetDefaultEventuallyTimeout(previousTimeout)
-		tc.g.SetDefaultEventuallyPollingInterval(previousPollInterval)
-	}
-}
-
 // NewResourceOptions creates and returns a ResourceOptions object
 // It configures a ResourceOptions object by applying the provided ResourceOpts.
 func (tc *TestContext) NewResourceOptions(opts ...ResourceOpts) *ResourceOptions {
 	ro := &ResourceOptions{tc: tc}
-	for _, opt := range opts {
-		opt(ro)
-	}
-
-	// Ensure ObjFn is set and fetch the object.
-	if ro.Obj == nil && ro.ObjFn != nil {
-		// If Obj is not provided, call ObjFn to get the object.
-		ro.Obj = ro.ObjFn(tc)
-	}
-
-	// Ensure that Obj is not nil before returning the options.
-	if ro.Obj == nil {
-		panic("Obj must be set in ResourceOptions") // Panics if Obj is nil to enforce validation.
-	}
 
 	// Ensure ListOptions is not nil before using it
 	if ro.ListOptions == nil {
@@ -190,6 +162,25 @@ func (tc *TestContext) NewResourceOptions(opts ...ResourceOpts) *ResourceOptions
 	// Ensure IgnoreNotFound is true by default
 	ro.IgnoreNotFound = true
 
+	// Apply context-level defaults first (can be overridden by explicit opts)
+	for _, opt := range tc.DefaultResourceOpts {
+		opt(ro)
+	}
+	for _, opt := range opts {
+		opt(ro)
+	}
+
+	// Ensure ObjFn is set and fetch the object.
+	if ro.Obj == nil && ro.ObjFn != nil {
+		// If Obj is not provided, call ObjFn to get the object.
+		ro.Obj = ro.ObjFn(tc)
+	}
+
+	// Ensure that Obj is not nil before returning the options.
+	if ro.Obj == nil {
+		panic("Obj must be set in ResourceOptions") // Panics if Obj is nil to enforce validation.
+	}
+
 	return ro
 }
 
@@ -208,8 +199,13 @@ func (tc *TestContext) EnsureResourceExists(opts ...ResourceOpts) *unstructured.
 	var u *unstructured.Unstructured
 
 	eventually := tc.g.Eventually(func(g Gomega) {
-		// Use fetchResource to attempt to fetch the resource with retries
-		u, _ = fetchResource(ro)
+		// Use fetchResourceSync to avoid nested Eventually calls
+		var fetchErr error
+		u, fetchErr = fetchResourceSync(ro)
+		g.Expect(fetchErr).NotTo(
+			HaveOccurred(),
+			defaultErrorMessageIfNone(resourceFetchErrorMsg, []any{ro.ResourceID, ro.GVK.Kind, fetchErr}, ro.CustomErrorArgs)...,
+		)
 
 		// Ensure that the resource object is not nil
 		g.Expect(u).NotTo(
@@ -248,8 +244,13 @@ func (tc *TestContext) EnsureResourceExistsConsistently(opts ...ResourceOpts) *u
 
 	// Ensure the resource exists and matches the condition consistently over the specified period.
 	consistently := tc.g.Consistently(func(g Gomega) {
-		// Use fetchResource to attempt to fetch the resource with retries
-		u, _ = fetchResource(ro)
+		// Use fetchResourceSync to avoid nested Eventually inside Consistently
+		var fetchErr error
+		u, fetchErr = fetchResourceSync(ro)
+		g.Expect(fetchErr).NotTo(
+			HaveOccurred(),
+			defaultErrorMessageIfNone(resourceFetchErrorMsg, []any{ro.ResourceID, ro.GVK.Kind, fetchErr}, ro.CustomErrorArgs)...,
+		)
 
 		// Ensure that the resource object is not nil
 		g.Expect(u).NotTo(
@@ -502,6 +503,8 @@ func (tc *TestContext) EnsureResourceDoesNotExist(opts ...ResourceOpts) {
 	// Validate the error if an expected error is set
 	if ro.AcceptableErrMatcher != nil {
 		tc.g.Expect(err).To(ro.AcceptableErrMatcher, unexpectedErrorMismatchMsg, ro.AcceptableErrMatcher, err, ro.GVK.Kind)
+	} else {
+		tc.g.Expect(err).To(BeNil(), unexpectedErrorMismatchMsg, ro.GVK.Kind, err)
 	}
 }
 
@@ -935,7 +938,7 @@ func (tc *TestContext) isOperatorHealthy(nn types.NamespacedName) bool {
 		return false
 	}
 
-	csv, err := fetchResource(
+	csv, err := fetchResourceSync(
 		tc.NewResourceOptions(
 			WithMinimalObject(gvk.ClusterServiceVersion, types.NamespacedName{
 				Namespace: nn.Namespace,
@@ -1019,7 +1022,7 @@ func (tc *TestContext) ensureCSVSucceeded(nn types.NamespacedName) {
 		g.Expect(csv).NotTo(BeNil(), "CSV %s/%s not found", nn.Namespace, csvName)
 		g.Expect(csv.Status.Phase).To(Equal(ofapi.CSVPhaseSucceeded),
 			"CSV %s is not Succeeded: %s", csvName, csv.Status.Phase)
-	}).WithTimeout(tc.TestTimeouts.longEventuallyTimeout).
+	}).WithTimeout(tc.TestTimeouts.olmOperationTimeout).
 		WithPolling(tc.TestTimeouts.defaultEventuallyPollInterval).
 		Should(Succeed())
 }
@@ -1062,7 +1065,7 @@ func (tc *TestContext) ensureInstallPlan(nn types.NamespacedName, channelName st
 			Equal(ofapi.CSVPhaseSucceeded),
 			"CSV %s did not reach 'Succeeded' phase", resourceID,
 		)
-	}).WithTimeout(tc.TestTimeouts.mediumEventuallyTimeout).
+	}).WithTimeout(tc.TestTimeouts.olmOperationTimeout).
 		WithPolling(tc.TestTimeouts.defaultEventuallyPollInterval).
 		Should(Succeed())
 }
@@ -1767,11 +1770,16 @@ func (tc *TestContext) convertToResource(u *unstructured.Unstructured, obj clien
 // Returns:
 //   - error: An error if the resource is found, or nil if the resource does not exist.
 func (tc *TestContext) ensureResourceDoesNotExist(g Gomega, ro *ResourceOptions) error {
-	// Fetch the resource using fetchResource.
-	u, err := fetchResource(ro)
+	// Use fetchResourceSync to avoid nested Eventually calls.
+	// When called from EnsureResourceGone (inside Eventually), the outer Eventually handles retries.
+	u, err := fetchResourceSync(ro)
 
-	// If we have an error, let the caller handle it
 	if err != nil {
+		// For deletion checks, NotFound/NoMatch means the resource (or its CRD) is gone (success)
+		if ro.IgnoreNotFound && (k8serr.IsNotFound(err) || meta.IsNoMatchError(err)) {
+			return nil
+		}
+		// Transient errors bubble up so the caller (or outer Eventually) can retry
 		return err
 	}
 
@@ -1792,15 +1800,14 @@ func (tc *TestContext) ensureResourceDoesNotExist(g Gomega, ro *ResourceOptions)
 // Returns:
 //   - error: An error if the resource is found in the cluster, or nil if the resource does not exist.
 func (tc *TestContext) ensureResourcesDoNotExist(g Gomega, ro *ResourceOptions) error {
-	resourcesList, err := fetchResources(ro)
+	resourcesList, err := fetchResourcesSync(ro)
 
-	// Handle "not found" errors based on IgnoreNotFound setting
-	if ro.IgnoreNotFound && k8serr.IsNotFound(err) {
-		// For deletion scenarios, "not found" means success - resource is gone
+	// Handle "not found"/"no match" errors based on IgnoreNotFound setting
+	if ro.IgnoreNotFound && (k8serr.IsNotFound(err) || meta.IsNoMatchError(err)) {
+		// For deletion scenarios, "not found" or missing CRD means success - resource is gone
 		return nil
 	}
 
-	// If we have an error that's not "not found", let the caller handle it
 	if err != nil {
 		return err
 	}

--- a/tests/e2e/trustyai_test.go
+++ b/tests/e2e/trustyai_test.go
@@ -151,8 +151,12 @@ func (tc *TrustyAITestCtx) ValidateTrustyAIPreCheck(t *testing.T) {
 // and feature gate configuration that can be slow in CI environments.
 func (tc *TrustyAITestCtx) setKserveState(state operatorv1.ManagementState, shouldExist bool) {
 	// TODO: remove timeout override once we understand why Kserve takes so long in CI
-	reset := tc.OverrideEventuallyTimeout(tc.TestTimeouts.longEventuallyTimeout, tc.TestTimeouts.defaultEventuallyPollInterval)
-	defer reset()
+	savedOpts := tc.DefaultResourceOpts
+	tc.DefaultResourceOpts = []ResourceOpts{
+		WithEventuallyTimeout(tc.TestTimeouts.longEventuallyTimeout),
+		WithEventuallyPollingInterval(tc.TestTimeouts.defaultEventuallyPollInterval),
+	}
+	defer func() { tc.DefaultResourceOpts = savedOpts }()
 
 	tc.UpdateComponentStateInDataScienceClusterWithKind(state, gvk.Kserve.Kind)
 

--- a/tests/e2e/workbenches_test.go
+++ b/tests/e2e/workbenches_test.go
@@ -154,8 +154,12 @@ func (tc *WorkbenchesTestCtx) ValidateAllDeletionRecovery(t *testing.T) {
 
 	skipUnless(t, Smoke, Tier1)
 
-	reset := tc.OverrideEventuallyTimeout(tc.TestTimeouts.longEventuallyTimeout, tc.TestTimeouts.defaultEventuallyPollInterval)
-	defer reset()
+	savedOpts := tc.DefaultResourceOpts
+	tc.DefaultResourceOpts = []ResourceOpts{
+		WithEventuallyTimeout(tc.TestTimeouts.deletionRecoveryTimeout),
+		WithEventuallyPollingInterval(tc.TestTimeouts.defaultEventuallyPollInterval),
+	}
+	defer func() { tc.DefaultResourceOpts = savedOpts }()
 
 	testCases := []TestCase{
 		{"ConfigMap deletion recovery", tc.validateConfigMapDeletionRecovery},


### PR DESCRIPTION

## Description
<!--- Describe your changes in detail -->
  - Removed `OverrideEventuallyTimeout()` — no test modifies global timeout
    state after initialization
  - Added `DefaultResourceOpts` field on `TestContext` as a non-mutating,
    per-suite timeout mechanism with save/restore via defer
  - Defined 7 named operation-specific timeout tiers based on P99 data from
    ~500 CI builds (e.g., `crCreationTimeout`=2m,
    `monitoringStackTimeout`=7m)
  - Wired named tiers to their call sites: creation, component readiness,
    deletion recovery, OLM operations, and monitoring stack
  - Replaced `fetchResource()`/`fetchResources()` with synchronous variants
    inside Eventually/Consistently blocks to eliminate nested timeout compounding
  - Fixed `isOperatorHealthy` to use `fetchResourceSync` for fast failure
    instead of 5m internal Eventually retry
  - Added `tests/e2e/TIMEOUT_ARCHITECTURE.md` design document covering
    hierarchy, defaults, enforcement mechanisms, and tuning guide

  #### Timeout Hierarchy

  Suite (go test -timeout 60m)  →  hard kill, not bypassable
  Per-Operation (WithEventuallyTimeout)  →  highest precedence within a test
  Context Default (DefaultResourceOpts)  →  suite-scoped baseline
  Gomega Baseline (5m)  →  set once at init, never mutated


<!--- Link your JIRA and related links here for reference. -->
#### Timeout Architecture Design doc
* https://docs.google.com/document/d/1AAkNEwycB8YqThccrRikd7ol0zITqZ6u/edit?usp=sharing&ouid=117399322002595787389&rtpof=true&sd=true

#### Jira
* https://redhat.atlassian.net/browse/RHOAIENG-49735

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
* Run full e2e suite
* no `SetDefaultEventuall` and `OverrideEventuallyTimeout` function used

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [x] The developer has run the integration test pipeline and verified that it passed successfully
- [ ] New RELATED_IMAGE mappings are already listed in ODH-Build-Config and RHOAI-Build-Config, and links are included in PR description

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [ ] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added operation-specific timeout tiers and suite-level default timeout/polling options for more predictable waits.
  * Applied targeted timeouts for resource creation, component/operand readiness, monitoring stacks, auth/gateway flows, deletion recovery, and OLM operations.
  * Replaced global timeout override patterns with scoped default-option propagation and reliable restoration.
  * Tightened resource fetch, existence and deletion checks to surface real errors and improve test reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->