### PR TITLE
chore: improve monitoring retry to make it work for a specific group

### DIFF
--- a/cmd/test-retry/pkg/cli/e2e.go
+++ b/cmd/test-retry/pkg/cli/e2e.go
@@ -71,7 +71,12 @@ Example: test-retry e2e -- -run TestFoo -v`,
 	cmd.Flags().StringVar(&command, "command", "", "Custom command to run tests (default: go test). Use for precompiled binaries.")
 	cmd.Flags().IntVar(&maxRetries, "max-retries", 3, "Maximum number of retries for failed tests")
 	cmd.Flags().StringSliceVar(&neverSkip, "never-skip", []string{"TestOdhOperator/DSCInitialization_and_DataScienceCluster_management_E2E_Tests", "TestOdhOperator/DataScienceCluster"}, "Test prefixes that should never be skipped (always run, repeatable)")
-	cmd.Flags().StringSliceVar(&skipAtPrefix, "skip-at-prefix", []string{"TestOdhOperator/services/*/", "TestOdhOperator/components/*/", "TestOdhOperator/"}, "Test prefixes where tests should be extracted at prefix + 1 level (repeatable)")
+	cmd.Flags().StringSliceVar(&skipAtPrefix, "skip-at-prefix", []string{
+		"TestOdhOperator/services/*/monitoring", // Extract monitoring tests at group level for efficient retry
+		"TestOdhOperator/services/*/",           // Extract other services at service level
+		"TestOdhOperator/components/*/",         // Extract components at component level
+		"TestOdhOperator/",                      // Fallback: extract at root level
+	}, "Test prefixes where tests should be extracted at prefix + 1 level (repeatable)")
 	cmd.Flags().StringVar(&junitOutput, "junit-output", "", "Path to JUnit XML output file (optional)")
 
 	// GitHub PR notification flags

--- a/cmd/test-retry/pkg/runner/e2e_test.go
+++ b/cmd/test-retry/pkg/runner/e2e_test.go
@@ -294,6 +294,60 @@ func TestBuildSkipFilter(t *testing.T) {
 			}},
 			expected: "^TestOdhOperator$/^components$/^group_1$/^dashboard$|^TestOdhOperator$/^services$/^group_1$/^auth$",
 		},
+		{
+			name: "monitoring-specific pattern for group level extraction",
+			opts: types.E2ETestOptions{
+				SkipAtPrefixes: []string{
+					"TestOdhOperator/services/*/monitoring",
+					"TestOdhOperator/services/*/",
+					"TestOdhOperator/",
+				},
+			},
+			aggregatedTestResult: &types.TestResult{PassedTest: []types.TestCase{
+				{Name: "TestOdhOperator/services/group 1/monitoring/Group 1: Base Configuration"},
+				{Name: "TestOdhOperator/services/group 1/monitoring/Group 1: Base Configuration/Auto creation of Monitoring CR"},
+				{Name: "TestOdhOperator/services/group 1/monitoring/Group 1: Base Configuration/Test Monitoring CR content default value"},
+				{Name: "TestOdhOperator/services/group 1/monitoring/Group 2: Metrics & MonitoringStack"},
+				{Name: "TestOdhOperator/services/group 1/monitoring/Group 2: Metrics & MonitoringStack/Test Metrics MonitoringStack CR Creation"},
+				{Name: "TestOdhOperator/services/group 1/monitoring/Group 2: Metrics & MonitoringStack/Test Metrics MonitoringStack CR Configuration"},
+			}},
+			expected: "^TestOdhOperator$/^services$/^group 1$/^monitoring$/^Group 1: Base Configuration$|^TestOdhOperator$/^services$/^group 1$/^monitoring$/^Group 2: Metrics & MonitoringStack$",
+		},
+		{
+			name: "monitoring-specific pattern with mixed monitoring and other service tests",
+			opts: types.E2ETestOptions{
+				SkipAtPrefixes: []string{
+					"TestOdhOperator/services/*/monitoring",
+					"TestOdhOperator/services/*/",
+					"TestOdhOperator/",
+				},
+			},
+			aggregatedTestResult: &types.TestResult{PassedTest: []types.TestCase{
+				{Name: "TestOdhOperator/services/group 1/monitoring/Group 1: Base Configuration"},
+				{Name: "TestOdhOperator/services/group 1/monitoring/Group 1: Base Configuration/Test A"},
+				{Name: "TestOdhOperator/services/group 1/auth"},
+				{Name: "TestOdhOperator/services/group 1/auth/Test B"},
+				{Name: "TestOdhOperator/services/group 1/gateway"},
+				{Name: "TestOdhOperator/services/group 1/gateway/Test C"},
+			}},
+			expected: "^TestOdhOperator$/^services$/^group 1$/^auth$|^TestOdhOperator$/^services$/^group 1$/^gateway$|^TestOdhOperator$/^services$/^group 1$/^monitoring$/^Group 1: Base Configuration$",
+		},
+		{
+			name: "monitoring-specific pattern takes precedence over general pattern",
+			opts: types.E2ETestOptions{
+				SkipAtPrefixes: []string{
+					"TestOdhOperator/services/*/monitoring", // More specific (4 parts), should match first
+					"TestOdhOperator/services/*/",           // Less specific (3 parts)
+					"TestOdhOperator/",
+				},
+			},
+			aggregatedTestResult: &types.TestResult{PassedTest: []types.TestCase{
+				{Name: "TestOdhOperator/services/group 1/monitoring/Group 5: Thanos Querier"},
+				{Name: "TestOdhOperator/services/group 1/monitoring/Group 5: Thanos Querier/Test ThanosQuerier deployment with metrics"},
+			}},
+			// Should extract at Group level (monitoring pattern), not at monitoring level (general pattern)
+			expected: "^TestOdhOperator$/^services$/^group 1$/^monitoring$/^Group 5: Thanos Querier$",
+		},
 	}
 
 	for _, tt := range tests {
@@ -483,6 +537,76 @@ func TestExtractTestLevel(t *testing.T) {
 			},
 			testName:   "TestFirstLevel",
 			wantLevel:  "TestFirstLevel",
+			shouldSkip: true,
+		},
+		{
+			name: "monitoring-specific pattern for group level extraction",
+			opts: types.E2ETestOptions{
+				NeverSkipPrefixes: []string{},
+				SkipAtPrefixes: []string{
+					"TestOdhOperator/services/*/monitoring",
+					"TestOdhOperator/services/*/",
+					"TestOdhOperator/",
+				},
+			},
+			testName:   "TestOdhOperator/services/group 1/monitoring/Group 1: Base Configuration/Auto creation of Monitoring CR",
+			wantLevel:  "TestOdhOperator/services/group 1/monitoring/Group 1: Base Configuration",
+			shouldSkip: true,
+		},
+		{
+			name: "monitoring-specific pattern extracts at group level not monitoring level",
+			opts: types.E2ETestOptions{
+				NeverSkipPrefixes: []string{},
+				SkipAtPrefixes: []string{
+					"TestOdhOperator/services/*/monitoring",
+					"TestOdhOperator/services/*/",
+					"TestOdhOperator/",
+				},
+			},
+			testName:   "TestOdhOperator/services/group 1/monitoring/Group 5: Thanos Querier/Test ThanosQuerier deployment",
+			wantLevel:  "TestOdhOperator/services/group 1/monitoring/Group 5: Thanos Querier",
+			shouldSkip: true,
+		},
+		{
+			name: "monitoring-specific pattern with special characters in group name",
+			opts: types.E2ETestOptions{
+				NeverSkipPrefixes: []string{},
+				SkipAtPrefixes: []string{
+					"TestOdhOperator/services/*/monitoring",
+					"TestOdhOperator/services/*/",
+					"TestOdhOperator/",
+				},
+			},
+			testName:   "TestOdhOperator/services/group 1/monitoring/Group 2: Metrics & MonitoringStack/Test CR Creation",
+			wantLevel:  "TestOdhOperator/services/group 1/monitoring/Group 2: Metrics & MonitoringStack",
+			shouldSkip: true,
+		},
+		{
+			name: "other service tests use general pattern not monitoring-specific",
+			opts: types.E2ETestOptions{
+				NeverSkipPrefixes: []string{},
+				SkipAtPrefixes: []string{
+					"TestOdhOperator/services/*/monitoring",
+					"TestOdhOperator/services/*/",
+					"TestOdhOperator/",
+				},
+			},
+			testName:   "TestOdhOperator/services/group 1/auth/Test Auth",
+			wantLevel:  "TestOdhOperator/services/group 1/auth",
+			shouldSkip: true,
+		},
+		{
+			name: "monitoring-specific pattern (longer) wins over general pattern",
+			opts: types.E2ETestOptions{
+				NeverSkipPrefixes: []string{},
+				SkipAtPrefixes: []string{
+					"TestOdhOperator/services/*/monitoring", // 4 parts with wildcard
+					"TestOdhOperator/services/*/",           // 3 parts with wildcard
+					"TestOdhOperator/",                      // 1 part
+				},
+			},
+			testName:   "TestOdhOperator/services/group 1/monitoring/Group 8: Perses/Test Perses",
+			wantLevel:  "TestOdhOperator/services/group 1/monitoring/Group 8: Perses",
 			shouldSkip: true,
 		},
 	}

--- a/tests/e2e/monitoring_test.go
+++ b/tests/e2e/monitoring_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	gTypes "github.com/onsi/gomega/types"
 	operatorv1 "github.com/openshift/api/operator/v1"
@@ -1277,6 +1278,7 @@ func (tc *MonitoringTestCtx) cleanupTempoStackAndSecret(secretName string) {
 		WithWaitForDeletion(true),
 		WithRemoveFinalizersOnDelete(true),
 		WithIgnoreNotFound(true),
+		WithEventuallyTimeout(15*time.Minute),
 	)
 
 	// Only delete secret if one is specified


### PR DESCRIPTION
<!---
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
Improve monitoring retry of e2e tests, to allow skip retry for already passed groups.
Also, increased a timeout for tempostack which locally took more than 10m to be deleted.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully
- [ ] New RELATED_IMAGE mappings are already listed in ODH-Build-Config and RHOAI-Build-Config, and links are included in PR description

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [ ] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated monitoring-specific skip pattern to e2e test skip defaults for more precise test grouping.

* **Bug Fixes**
  * Increased timeout for monitoring cleanup to improve stability of test teardown.

* **Tests**
  * Added and expanded tests validating skip-prefix handling, precedence of more specific prefixes, and extraction of monitoring group paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->