### PR TITLE
RHOAIENG-57511 | fix: Add WVA removed to ValidateComponentDisabled

### DIFF
--- a/tests/e2e/modelcontroller_test.go
+++ b/tests/e2e/modelcontroller_test.go
@@ -185,12 +185,12 @@ func (tc *ModelControllerTestCtx) ValidateComponentDisabled(t *testing.T) {
 
 	skipUnless(t, Smoke, Tier1)
 
-	// Ensure Kserve and ModelRegistry components are set as Removed in DataScienceCluster.
-	// in this case we can leave WVA to any value
+	// Ensure Kserve, WVA, and ModelRegistry components are set as Removed in DataScienceCluster.
 	tc.EventuallyResourcePatched(
 		WithMinimalObject(gvk.DataScienceCluster, tc.DataScienceClusterNamespacedName),
 		WithMutateFunc(
 			testf.TransformPipeline(
+				testf.Transform(`.spec.components.%s.wva.managementState = "%s"`, componentApi.KserveComponentName, operatorv1.Removed),
 				testf.Transform(`.spec.components.%s.managementState = "%s"`, componentApi.KserveComponentName, operatorv1.Removed),
 				testf.Transform(`.spec.components.%s.managementState = "%s"`, componentApi.ModelRegistryComponentName, operatorv1.Removed),
 			),


### PR DESCRIPTION
<!---
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->
ValidateComponentDisabled in the ModelController e2e test sets kserve.managementState = Removed but leaves kserve.wva.managementState = Managed. The comment says "we can leave WVA to any value" - but that's wrong. When group_4's modelsasservice test re-enables KServe, NewCRObject copies dsc.Spec.Components.Kserve.WVA into the new ModelController CR, so WVA deploys again and fails again. This is why the failure cascades from group_2 through group_4, resilience tests, and upgrade tests
<!--- Link your JIRA and related links here for reference. -->
https://redhat.atlassian.net/browse/RHOAIENG-57511
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully
- [ ] New RELATED_IMAGE mappings are already listed in ODH-Build-Config and RHOAI-Build-Config, and links are included in PR description

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [ ] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced component configuration validation testing to ensure consistent management state handling across all components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->