### PR TITLE
Added pod_logs tool to retrieve container logs

### DIFF
--- a/cmd/mcp-server/go.mod
+++ b/cmd/mcp-server/go.mod
@@ -5,6 +5,8 @@ go 1.25.7
 require (
 	github.com/mark3labs/mcp-go v0.32.0
 	github.com/opendatahub-io/opendatahub-operator/v2/pkg/clusterhealth v0.0.0
+	k8s.io/api v0.35.2
+	k8s.io/apimachinery v0.35.2
 	k8s.io/client-go v0.35.2
 	sigs.k8s.io/controller-runtime v0.22.4
 )
@@ -43,8 +45,6 @@ require (
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	k8s.io/api v0.35.2 // indirect
-	k8s.io/apimachinery v0.35.2 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20250910181357-589584f1c912 // indirect
 	k8s.io/utils v0.0.0-20251002143259-bc988d571ff4 // indirect

--- a/cmd/mcp-server/helpers.go
+++ b/cmd/mcp-server/helpers.go
@@ -32,6 +32,31 @@ func stringParam(req mcp.CallToolRequest, name, fallback string) string {
 	return fallback
 }
 
+// numberParam extracts a numeric param from an MCP request, returning fallback if missing or non-positive.
+func numberParam(req mcp.CallToolRequest, name string, fallback int64) int64 {
+	args, ok := req.Params.Arguments.(map[string]any)
+	if !ok {
+		return fallback
+	}
+	var val float64
+	switch n := args[name].(type) {
+	case float64:
+		val = n
+	case float32:
+		val = float64(n)
+	case int:
+		val = float64(n)
+	case int64:
+		val = float64(n)
+	default:
+		return fallback
+	}
+	if val > 0 {
+		return int64(val)
+	}
+	return fallback
+}
+
 // getEnvDefault returns the env var value if set, otherwise fallback.
 func getEnvDefault(key, fallback string) string {
 	if v := os.Getenv(key); v != "" {

--- a/cmd/mcp-server/main.go
+++ b/cmd/mcp-server/main.go
@@ -3,9 +3,12 @@ package main
 import (
 	"log"
 	"os"
+	"time"
 
 	"github.com/mark3labs/mcp-go/server"
+	"k8s.io/client-go/kubernetes"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	ctrl "sigs.k8s.io/controller-runtime/pkg/client/config"
 )
@@ -25,9 +28,19 @@ func main() {
 		log.Fatalf("mcp-server: kube client: %v", err)
 	}
 
+	clientsetCfg := rest.CopyConfig(kubeConfig)
+	if clientsetCfg.Timeout == 0 {
+		clientsetCfg.Timeout = 30 * time.Second
+	}
+	clientset, err := kubernetes.NewForConfig(clientsetCfg)
+	if err != nil {
+		log.Fatalf("mcp-server: clientset: %v", err)
+	}
+
 	s := server.NewMCPServer("opendatahub-health", "0.1.0")
 
 	registerPlatformHealth(s, kubeClient)
+	registerPodLogs(s, clientset)
 
 	if err := server.ServeStdio(s); err != nil {
 		log.Fatalf("mcp-server: serve: %v", err)

--- a/cmd/mcp-server/tool_pod_logs.go
+++ b/cmd/mcp-server/tool_pod_logs.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+	corev1 "k8s.io/api/core/v1"
+	k8serr "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/client-go/kubernetes"
+)
+
+const maxLogBytes int64 = 50 * 1024 // 50KB
+
+// registerPodLogs adds the pod_logs tool to the MCP server.
+func registerPodLogs(s *server.MCPServer, clientset kubernetes.Interface) {
+	tool := mcp.NewTool("pod_logs",
+		mcp.WithDescription("Retrieve recent logs for a specific pod/container. "+
+			"Uses the Kubernetes pod log API to fetch container logs for debugging."),
+		mcp.WithString("pod_name", mcp.Required(),
+			mcp.Description("Name of the pod")),
+		mcp.WithString("namespace", mcp.Required(),
+			mcp.Description("Namespace of the pod")),
+		mcp.WithString("container",
+			mcp.Description("Container name. Omit for the default container.")),
+		mcp.WithBoolean("previous",
+			mcp.Description("If true, return logs from the previous container instance. Default: false")),
+		mcp.WithNumber("tail_lines",
+			mcp.Description("Number of lines from the end of the log to return. Default: 100")),
+	)
+
+	s.AddTool(tool, func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		return fetchPodLogs(ctx, clientset, req)
+	})
+}
+
+// fetchPodLogs retrieves pod logs using the client-go API.
+func fetchPodLogs(ctx context.Context, clientset kubernetes.Interface, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	podName := stringParam(req, "pod_name", "")
+	namespace := stringParam(req, "namespace", "")
+
+	if podName == "" {
+		return mcp.NewToolResultError("pod_name is required"), nil
+	}
+	if namespace == "" {
+		return mcp.NewToolResultError("namespace is required"), nil
+	}
+
+	tailLines := numberParam(req, "tail_lines", 100)
+	args, _ := req.Params.Arguments.(map[string]any)
+	prev, _ := args["previous"].(bool)
+	limitBytes := maxLogBytes + 1
+
+	opts := &corev1.PodLogOptions{
+		Container:  stringParam(req, "container", ""),
+		Previous:   prev,
+		TailLines:  &tailLines,
+		LimitBytes: &limitBytes,
+	}
+
+	stream, err := clientset.CoreV1().Pods(namespace).GetLogs(podName, opts).Stream(ctx)
+	if err != nil {
+		switch {
+		case k8serr.IsNotFound(err):
+			return mcp.NewToolResultError(fmt.Sprintf("pod %q not found in namespace %q", podName, namespace)), nil
+		case k8serr.IsBadRequest(err):
+			msg := err.Error()
+			switch {
+			case strings.Contains(msg, "previous terminated container"):
+				return mcp.NewToolResultError(fmt.Sprintf("no previous logs available for pod %q (namespace %q): %v", podName, namespace, err)), nil
+			case strings.Contains(msg, "not found") || strings.Contains(msg, "is not valid"):
+				return mcp.NewToolResultError(fmt.Sprintf("container not found in pod %q (namespace %q): %v", podName, namespace, err)), nil
+			}
+			fallthrough
+		default:
+			return mcp.NewToolResultError(fmt.Sprintf("pod logs error: %v", err)), nil
+		}
+	}
+	defer stream.Close()
+
+	data, err := io.ReadAll(io.LimitReader(stream, maxLogBytes+1))
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("pod logs error: %v", err)), nil
+	}
+
+	truncated := int64(len(data)) > maxLogBytes
+	if truncated {
+		data = data[:maxLogBytes]
+	}
+
+	output := string(data)
+	if truncated {
+		output = "[truncated: output exceeded 50KB limit]\n" + output
+	}
+
+	return mcp.NewToolResultText(output), nil
+}

--- a/cmd/mcp-server/tool_pod_logs_test.go
+++ b/cmd/mcp-server/tool_pod_logs_test.go
@@ -1,0 +1,140 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+)
+
+// newTestClientset creates a clientset backed by the given HTTP handler.
+func newTestClientset(t *testing.T, h http.Handler) kubernetes.Interface {
+	t.Helper()
+	ts := httptest.NewServer(h)
+	t.Cleanup(ts.Close)
+	cs, err := kubernetes.NewForConfig(&rest.Config{Host: ts.URL})
+	if err != nil {
+		t.Fatalf("clientset: %v", err)
+	}
+	return cs
+}
+
+func TestPodLogs(t *testing.T) {
+	echoHandler := func(msg string) http.HandlerFunc {
+		return func(w http.ResponseWriter, r *http.Request) { fmt.Fprint(w, msg) }
+	}
+
+	tests := []struct {
+		name    string
+		handler http.HandlerFunc
+		args    map[string]interface{}
+		want    string
+		wantErr bool
+	}{
+		{"default args", echoHandler("line1\nline2\n"),
+			map[string]interface{}{"pod_name": "my-pod", "namespace": "default"},
+			"line1\nline2\n", false},
+		{"with container", func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Query().Get("container") == "sidecar" {
+				fmt.Fprint(w, "sidecar logs")
+				return
+			}
+			http.NotFound(w, r)
+		}, map[string]interface{}{"pod_name": "my-pod", "namespace": "default", "container": "sidecar"},
+			"sidecar logs", false},
+		{"previous logs", func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Query().Get("previous") == "true" {
+				fmt.Fprint(w, "previous logs")
+				return
+			}
+			http.NotFound(w, r)
+		}, map[string]interface{}{"pod_name": "my-pod", "namespace": "default", "previous": true},
+			"previous logs", false},
+		{"custom tail_lines", func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Query().Get("tailLines") == "10" {
+				fmt.Fprint(w, "10 lines")
+				return
+			}
+			http.NotFound(w, r)
+		}, map[string]interface{}{"pod_name": "my-pod", "namespace": "default", "tail_lines": float64(10)},
+			"10 lines", false},
+		{"default tail_lines", func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Query().Get("tailLines") == "100" {
+				fmt.Fprint(w, "default 100 lines")
+				return
+			}
+			http.NotFound(w, r)
+		}, map[string]interface{}{"pod_name": "my-pod", "namespace": "default"},
+			"default 100 lines", false},
+		{"limit bytes set", func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Query().Get("limitBytes") == "51201" {
+				fmt.Fprint(w, "limited output")
+				return
+			}
+			http.NotFound(w, r)
+		}, map[string]interface{}{"pod_name": "my-pod", "namespace": "default"},
+			"limited output", false},
+		{"missing pod_name", echoHandler(""),
+			map[string]interface{}{"namespace": "default"},
+			"pod_name is required", true},
+		{"missing namespace", echoHandler(""),
+			map[string]interface{}{"pod_name": "my-pod"},
+			"namespace is required", true},
+		{"pod not found", func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusNotFound)
+			fmt.Fprint(w, `{"kind":"Status","apiVersion":"v1","status":"Failure","message":"pods \"missing\" not found","reason":"NotFound","code":404}`)
+		}, map[string]interface{}{"pod_name": "missing", "namespace": "default"},
+			"not found in namespace", true},
+		{"container not found", func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusBadRequest)
+			fmt.Fprint(w, `{"kind":"Status","apiVersion":"v1","status":"Failure","message":"container \"bad\" is not valid for pod \"my-pod\"","reason":"BadRequest","code":400}`)
+		}, map[string]interface{}{"pod_name": "my-pod", "namespace": "default", "container": "bad"},
+			"container not found in pod", true},
+		{"no previous logs", func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusBadRequest)
+			fmt.Fprint(w, `{"kind":"Status","apiVersion":"v1","status":"Failure","message":"previous terminated container \"main\" in pod \"my-pod\" not found","reason":"BadRequest","code":400}`)
+		}, map[string]interface{}{"pod_name": "my-pod", "namespace": "default", "previous": true},
+			"no previous logs available", true},
+		{"truncation", func(w http.ResponseWriter, r *http.Request) {
+			// Send more than maxLogBytes (50KB) to trigger truncation.
+			w.Write(make([]byte, maxLogBytes+100))
+		}, map[string]interface{}{"pod_name": "my-pod", "namespace": "default"},
+			"[truncated: output exceeded 50KB limit]", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cs := newTestClientset(t, tt.handler)
+			req := mcp.CallToolRequest{}
+			req.Params.Arguments = tt.args
+
+			result, err := fetchPodLogs(context.Background(), cs, req)
+			if err != nil {
+				t.Fatalf("fetchPodLogs error: %v", err)
+			}
+			if result.IsError != tt.wantErr {
+				t.Fatalf("IsError = %v, want %v", result.IsError, tt.wantErr)
+			}
+			if len(result.Content) == 0 {
+				t.Fatalf("result.Content is empty")
+			}
+			textContent, ok := result.Content[0].(mcp.TextContent)
+			if !ok {
+				t.Fatalf("result.Content[0] type = %T, want mcp.TextContent", result.Content[0])
+			}
+			got := textContent.Text
+			if !strings.Contains(got, tt.want) {
+				t.Errorf("got %q, want substring %q", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!---
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
Adds the `pod_logs` MCP tool to retrieve recent container logs for debugging failing pods. Accepts pod name, namespace, optional container, previous flag, and tail lines . Uses the client-go pod log API directly, handles pod/container not found errors, and truncates output at 50KB. Includes unit tests with mock HTTP server.

https://redhat.atlassian.net/browse/RHOAIENG-56931

## How Has This Been Tested?
Unit Test
cmd/mcp-server/tool_pod_logs_test.go — Tests for default args, custom container, previous logs, tail lines, limit bytes, and error handling using mock HTTP server


## Screenshot or short clip
<img width="1461" height="537" alt="image" src="https://github.com/user-attachments/assets/e275904a-e352-4b73-ad92-ba0185109a9e" />


## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [X] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [X] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work


### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [X] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
Add E2E tests if required.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a pod-logs tool to fetch container logs from Kubernetes pods with container selection, previous-instance logs, tail-length control, and output truncation for large logs.
  * Server now exposes the pod-logs capability at startup.

* **Bug Fixes / Reliability**
  * Improved Kubernetes client startup by setting a sensible default timeout.

* **Tests**
  * Added comprehensive tests for pod log retrieval, argument handling, error cases, and truncation.

* **Chores**
  * Promoted Kubernetes API libraries to direct dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->