### PR TITLE
RHOAIENG-56723: fix dashboard-redirect OOMKill by pinning nginx worker_processes to 2

### DIFF
--- a/cmd/test-retry/pkg/parser/parser.go
+++ b/cmd/test-retry/pkg/parser/parser.go
@@ -27,7 +27,7 @@ type ParseConfig struct {
 // from FAILURE_CLASSIFICATION: JSON lines in test output.
 type classificationTracker struct {
 	mu              sync.Mutex
-	currentTest     string                                    // currently running test name
+	currentTest     string                                  // currently running test name
 	classifications map[string]*types.FailureClassification // test name → classification
 }
 

--- a/cmd/test-retry/pkg/parser/parser_test.go
+++ b/cmd/test-retry/pkg/parser/parser_test.go
@@ -193,8 +193,8 @@ func TestParseClassificationLine(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name:    "empty evidence array",
-			line:    `FAILURE_CLASSIFICATION: {"category":"infrastructure","subcategory":"network","error_code":1003,"evidence":[],"confidence":"low"}`,
+			name: "empty evidence array",
+			line: `FAILURE_CLASSIFICATION: {"category":"infrastructure","subcategory":"network","error_code":1003,"evidence":[],"confidence":"low"}`,
 			want: &types.FailureClassification{
 				Category:    "infrastructure",
 				Subcategory: "network",

--- a/cmd/test-retry/pkg/types/types.go
+++ b/cmd/test-retry/pkg/types/types.go
@@ -71,7 +71,7 @@ type TestCase struct {
 	Name           string
 	Package        string
 	Duration       time.Duration
-	FailureOutput  string                  `json:",omitempty"`
-	Time           time.Time               `json:",omitempty"`
-	Classification *FailureClassification  `json:",omitempty"` // Parsed from FAILURE_CLASSIFICATION: JSON output
+	FailureOutput  string                 `json:",omitempty"`
+	Time           time.Time              `json:",omitempty"`
+	Classification *FailureClassification `json:",omitempty"` // Parsed from FAILURE_CLASSIFICATION: JSON output
 }

--- a/internal/controller/services/gateway/gateway_integration_helpers_test.go
+++ b/internal/controller/services/gateway/gateway_integration_helpers_test.go
@@ -1498,6 +1498,12 @@ func RunNginxDashboardRedirectCreationTest(t *testing.T, setup TestSetup) {
 	}, TestTimeout, TestInterval).Should(Succeed())
 	assertOwnedByGatewayConfig(g, &cm)
 	g.Expect(cm.Labels).To(HaveKeyWithValue("app", gateway.DashboardRedirectName))
+
+	// RHOAIENG-56723: ConfigMap must include nginx.conf with a fixed worker_processes count (not auto).
+	g.Expect(cm.Data).To(HaveKey("nginx.conf"))
+	g.Expect(cm.Data["nginx.conf"]).To(MatchRegexp(`(?m)^\s*worker_processes\s+2;`))
+	g.Expect(cm.Data["nginx.conf"]).NotTo(ContainSubstring("worker_processes auto"))
+
 	g.Expect(cm.Data).To(HaveKey("redirect.conf"))
 	redirectConf := cm.Data["redirect.conf"]
 	g.Expect(redirectConf).To(ContainSubstring("location /"))
@@ -1519,7 +1525,34 @@ func RunNginxDashboardRedirectCreationTest(t *testing.T, setup TestSetup) {
 	g.Expect(*dep.Spec.Replicas).To(BeNumerically(">=", 1))
 	g.Expect(dep.Spec.Selector.MatchLabels).To(HaveKeyWithValue("app", gateway.DashboardRedirectName))
 	g.Expect(dep.Spec.Template.Spec.Containers).NotTo(BeEmpty())
-	g.Expect(dep.Spec.Template.Spec.Containers[0].Image).NotTo(BeEmpty())
+	container := dep.Spec.Template.Spec.Containers[0]
+	g.Expect(container.Image).NotTo(BeEmpty())
+
+	// RHOAIENG-56723: nginx.conf must be mounted to override worker_processes auto (causes OOMKill on high-CPU nodes).
+	var hasNginxConfMount bool
+	for _, vm := range container.VolumeMounts {
+		if vm.Name == "redirect-config" &&
+			vm.MountPath == "/etc/nginx/nginx.conf" &&
+			vm.SubPath == "nginx.conf" {
+			hasNginxConfMount = true
+			break
+		}
+	}
+	g.Expect(hasNginxConfMount).To(BeTrue(),
+		"dashboard-redirect must mount nginx.conf at /etc/nginx/nginx.conf to control worker_processes")
+
+	var hasRedirectConfigVolume bool
+	for _, vol := range dep.Spec.Template.Spec.Volumes {
+		if vol.Name == "redirect-config" &&
+			vol.ConfigMap != nil &&
+			vol.ConfigMap.Name == gateway.DashboardRedirectConfigName {
+			hasRedirectConfigVolume = true
+			break
+		}
+	}
+	g.Expect(hasRedirectConfigVolume).To(BeTrue(),
+		"dashboard-redirect must source nginx.conf from the redirect ConfigMap volume")
+
 	g.Expect(dep.Spec.Template.Annotations).To(HaveKey(redirectConfigHashAnnotation))
 	actualHash := dep.Spec.Template.Annotations[redirectConfigHashAnnotation]
 	g.Expect(actualHash).To(MatchRegexp("^[0-9a-f]{64}$"))

--- a/internal/controller/services/gateway/resources/dashboard-redirect-configmap.tmpl.yaml
+++ b/internal/controller/services/gateway/resources/dashboard-redirect-configmap.tmpl.yaml
@@ -7,6 +7,75 @@ metadata:
     app: {{.DashboardRedirectName}}
     {{.PartOfLabelKey}}: {{.PartOfGatewayConfig}}
 data:
+  nginx.conf: |
+    # For more information on configuration, see:
+    #   * Official English Documentation: http://nginx.org/en/docs/
+    #   * Official Russian Documentation: http://nginx.org/ru/docs/
+
+    # RHOAIENG-56723: Use a fixed worker count instead of auto (one per CPU core)
+    # to prevent OOMKill on nodes with many cores.
+    worker_processes 2;
+    error_log /var/log/nginx/error.log notice;
+    pid /run/nginx.pid;
+
+    # Load dynamic modules. See /usr/share/doc/nginx/README.dynamic.
+    include /usr/share/nginx/modules/*.conf;
+
+    events {
+        worker_connections 1024;
+    }
+
+    http {
+        log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                          '$status $body_bytes_sent "$http_referer" '
+                          '"$http_user_agent" "$http_x_forwarded_for"';
+
+        access_log  /var/log/nginx/access.log  main;
+
+        sendfile            on;
+        tcp_nopush          on;
+        keepalive_timeout   65;
+        types_hash_max_size 4096;
+
+        include             /etc/nginx/mime.types;
+        default_type        application/octet-stream;
+
+        # Load modular configuration files from the /etc/nginx/conf.d directory.
+        # See http://nginx.org/en/docs/ngx_core_module.html#include
+        # for more information.
+        include /opt/app-root/etc/nginx.d/*.conf;
+
+        server {
+            listen       8080 default_server;
+            listen       [::]:8080 default_server;
+            server_name  _;
+            root         /opt/app-root/src;
+
+            # Load configuration files for the default server block.
+            include /opt/app-root/etc/nginx.default.d/*.conf;
+        }
+
+    # Settings for a TLS enabled server.
+    #
+    #    server {
+    #        listen       443 ssl;
+    #        listen       [::]:443 ssl;
+    #        http2        on;
+    #        server_name  _;
+    #        root         /opt/app-root/src;
+    #
+    #        ssl_certificate "/etc/pki/nginx/server.crt";
+    #        ssl_certificate_key "/etc/pki/nginx/private/server.key";
+    #        ssl_session_cache shared:SSL:1m;
+    #        ssl_session_timeout  10m;
+    #        ssl_ciphers PROFILE=SYSTEM;
+    #        ssl_prefer_server_ciphers on;
+    #
+    #        # Load configuration files for the default server block.
+    #        include /opt/app-root/etc/nginx.default.d/*.conf;
+    #    }
+
+    }
   redirect.conf: |
     location / {
         add_header Cache-Control "no-store, no-cache, must-revalidate";

--- a/internal/controller/services/gateway/resources/dashboard-redirect-deployment.tmpl.yaml
+++ b/internal/controller/services/gateway/resources/dashboard-redirect-deployment.tmpl.yaml
@@ -30,6 +30,9 @@ spec:
           protocol: TCP
         volumeMounts:
         - name: redirect-config
+          mountPath: /etc/nginx/nginx.conf
+          subPath: nginx.conf
+        - name: redirect-config
           mountPath: /opt/app-root/etc/nginx.default.d/redirect.conf
           subPath: redirect.conf
         resources:


### PR DESCRIPTION
The dashboard-redirect pod uses the ubi9/nginx-126 S2I image which defaults to worker_processes auto (one worker per CPU core). On high-CPU nodes (43–257 cores), this causes memory usage to exceed the 128Mi limit, resulting in OOMKill and CrashLoopBackOff.

Fix: supply a custom nginx.conf via the existing ConfigMap with worker_processes set to 2, and mount it at /etc/nginx/nginx.conf. Two workers are more than sufficient for a static 301 redirect workload, while providing a safety margin if one worker is momentarily busy.

Made-with: Cursor

<!---
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully
- [ ] New RELATED_IMAGE mappings are already listed in ODH-Build-Config and RHOAI-Build-Config, and links are included in PR description

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
no e2e included.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a full NGINX base configuration for the dashboard redirect, including explicit worker/process and HTTP settings.

* **Tests**
  * Enhanced tests to verify the NGINX config content, ensure it’s present in the ConfigMap, and confirm it’s mounted into the deployment with the correct subPath and mount path.

* **Style**
  * Minor formatting and alignment cleanups in code and tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->