### PR TITLE
fix(maas): correct GatewayAuthPolicyName to match manifest resource name

### DIFF
--- a/internal/controller/components/modelsasservice/modelsasservice_support.go
+++ b/internal/controller/components/modelsasservice/modelsasservice_support.go
@@ -38,7 +38,7 @@ const (
 	// GatewayAuthPolicyName is the name of the AuthPolicy resource that configures
 	// authentication for the MaaS gateway. This resource needs to be deployed to
 	// the same namespace as the gateway it targets.
-	GatewayAuthPolicyName = "gateway-auth-policy"
+	GatewayAuthPolicyName = "gateway-default-auth"
 
 	// GatewayDestinationRuleName is the name of the DestinationRule resource that
 	// configures TLS for the MaaS gateway. This resource needs to be deployed to

--- a/tests/e2e/modelsasservice_test.go
+++ b/tests/e2e/modelsasservice_test.go
@@ -66,11 +66,35 @@ func modelsAsServiceTestSuite(t *testing.T) {
 		{"Validate operands have OwnerReferences", componentCtx.ValidateOperandsOwnerReferences},
 		{"Validate update operand resources", componentCtx.ValidateUpdateDeploymentsResources},
 		{"Validate subcomponent releases", componentCtx.ValidateSubComponentReleases},
+		{"Validate gateway AuthPolicy placement", componentCtx.ValidateGatewayAuthPolicy},
 		{"Validate resource deletion recovery", componentCtx.ValidateAllDeletionRecovery},
 		{"Validate subcomponent disabled", componentCtx.ValidateSubComponentDisabled},
 	}
 
 	RunTestCases(t, testCases)
+}
+
+// ValidateGatewayAuthPolicy verifies that the gateway-level AuthPolicy is deployed
+// to the gateway namespace (not the application namespace) and has been accepted.
+// This catches mismatches between the GatewayAuthPolicyName constant and the actual
+// manifest resource name, which would leave the AuthPolicy in the wrong namespace
+// and break deny-by-default protection for unconfigured models.
+func (tc *ModelsAsServiceTestCtx) ValidateGatewayAuthPolicy(t *testing.T) {
+	t.Helper()
+
+	tc.EnsureResourceExists(
+		WithMinimalObject(gvk.AuthPolicyv1, types.NamespacedName{
+			Name:      modelsasservice.GatewayAuthPolicyName,
+			Namespace: maasGatewayNamespace,
+		}),
+		WithCondition(
+			jq.Match(`.status.conditions[] | select(.type == "Accepted") | .status == "True"`),
+		),
+		WithCustomErrorMsg(
+			"AuthPolicy %s should exist in namespace %s with Accepted status",
+			modelsasservice.GatewayAuthPolicyName, maasGatewayNamespace,
+		),
+	)
 }
 
 // createMaaSPostgres creates a minimal PostgreSQL instance and the maas-db-config secret


### PR DESCRIPTION
## Summary

- `GatewayAuthPolicyName` was `"gateway-auth-policy"` but the manifest resource ([`deployment/base/maas-controller/policies/gateway-default-auth.yaml`](https://github.com/opendatahub-io/models-as-a-service/blob/main/deployment/base/maas-controller/policies/gateway-default-auth.yaml#L21)) is named `"gateway-default-auth"`
- This mismatch caused [`configureGatewayNamespaceResources()`](https://github.com/mynhardtburger/opendatahub-operator/blob/fix/gateway-auth-policy-name/internal/controller/components/modelsasservice/modelsasservice_controller_actions.go#L179) to never match the AuthPolicy, so it was never moved to the gateway namespace (`openshift-ingress`)
- The AuthPolicy reported `TargetNotFound`, leaving models without explicit `MaaSAuthPolicy` accessible instead of denied by default (401/403)



## Root cause

The post-render function `configureGatewayNamespaceResources()` loops through rendered resources and matches by name using the `GatewayAuthPolicyName` constant. Because the constant didn't match the actual resource name, `configureAuthPolicy()` never executed, and the namespace was never corrected.

## Fix

Change the constant in `modelsasservice_support.go:41` from `"gateway-auth-policy"` to `"gateway-default-auth"`.


Resolves: [RHOAIENG-57321](https://redhat.atlassian.net/browse/RHOAIENG-57321)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Renamed the gateway authentication policy identifier from "gateway-auth-policy" to "gateway-default-auth" (affects gateway auth resource naming).
* **Tests**
  * Added an end-to-end test that verifies the gateway-level authentication policy exists, is placed in the gateway namespace, and is marked as accepted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->