### PR TITLE
fix(RHOAIENG-57045): add operator version for XKS platform

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -418,15 +418,15 @@ deploy: prepare ## Deploy controller to the K8s cluster specified in ~/.kube/con
 
 .PHONY: deploy-rhaii
 deploy-rhaii: prepare ## Deploy controller in rhaii mode (only KServe) to the K8s cluster specified in ~/.kube/config.
-	$(KUSTOMIZE) build $(RHAII_DEFAULT_CONFIG_DIR) | kubectl apply --namespace $(OPERATOR_NAMESPACE) -f -
+	$(KUSTOMIZE) build $(RHAII_DEFAULT_CONFIG_DIR) | $(SED_COMMAND) 's/REPLACE_RHAI_VERSION/$(VERSION)/g' | kubectl apply --namespace $(OPERATOR_NAMESPACE) -f -
 
 .PHONY: deploy-rhaii-local
 deploy-rhaii-local: prepare ## Deploy controller in rhaii mode (only KServe, local image pull policy) to the K8s cluster specified in ~/.kube/config.
-	$(KUSTOMIZE) build $(RHAII_LOCAL_CONFIG_DIR) | kubectl apply --namespace $(OPERATOR_NAMESPACE) -f -
+	$(KUSTOMIZE) build $(RHAII_LOCAL_CONFIG_DIR) | $(SED_COMMAND) 's/REPLACE_RHAI_VERSION/$(VERSION)/g' | kubectl apply --namespace $(OPERATOR_NAMESPACE) -f -
 
 .PHONY: undeploy-rhaii
 undeploy-rhaii: prepare ## Undeploy rhaii controller from the K8s cluster specified in ~/.kube/config.
-	$(KUSTOMIZE) build $(RHAII_DEFAULT_CONFIG_DIR) | kubectl delete --ignore-not-found=$(ignore-not-found) -f -
+	$(KUSTOMIZE) build $(RHAII_DEFAULT_CONFIG_DIR) | $(SED_COMMAND) 's/REPLACE_RHAI_VERSION/$(VERSION)/g' | kubectl delete --ignore-not-found=$(ignore-not-found) -f -
 
 .PHONY: undeploy
 undeploy: prepare ## Undeploy controller from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -272,9 +272,22 @@ func main() { //nolint:funlen,maintidx,gocyclo
 		os.Exit(1)
 	}
 
-	// Get operator platform
+	// Validate RHAI_VERSION: required on XKS (no OLM/CSV), must not be set on OpenShift.
+	rhaiVersion := flags.GetRHAIVersion()
 	release := cluster.GetRelease()
 	platform := release.Name
+
+	switch {
+	case platform == cluster.XKS && rhaiVersion == "":
+		setupLog.Error(errors.New("RHAI_VERSION must be set when platform is XKS"), "invalid configuration")
+		os.Exit(1)
+	case platform != cluster.XKS && rhaiVersion != "":
+		setupLog.Error(fmt.Errorf(
+			"RHAI_VERSION (%q) must not be set when platform is not XKS; version is detected from CSV",
+			rhaiVersion,
+		), "invalid configuration")
+		os.Exit(1)
+	}
 
 	if err := initServices(ctx, platform); err != nil {
 		setupLog.Error(err, "unable to init services")

--- a/config/rhaii/odh-operator/manager_patch.yaml
+++ b/config/rhaii/odh-operator/manager_patch.yaml
@@ -59,5 +59,7 @@ spec:
           value: 'true'
         - name: RHAI_APPLICATIONS_NAMESPACE
           value: opendatahub
+        - name: RHAI_VERSION
+          value: REPLACE_RHAI_VERSION
         - name: ODH_PLATFORM_TYPE
           value: XKS

--- a/config/rhaii/rhoai/operator/manager_patch.yaml
+++ b/config/rhaii/rhoai/operator/manager_patch.yaml
@@ -59,5 +59,7 @@ spec:
           value: 'true'
         - name: RHAI_APPLICATIONS_NAMESPACE
           value: redhat-ods-applications
+        - name: RHAI_VERSION
+          value: REPLACE_RHAI_VERSION
         - name: ODH_PLATFORM_TYPE
           value: XKS

--- a/pkg/cluster/cluster_config.go
+++ b/pkg/cluster/cluster_config.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/opendatahub-io/opendatahub-operator/v2/api/common"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/flags"
 )
 
 type ClusterInfo struct {
@@ -349,6 +350,18 @@ func getRelease(ctx context.Context, cli client.Client) (common.Release, error) 
 
 	// For unit-tests
 	if os.Getenv("CI") == "true" {
+		return initRelease, nil
+	}
+
+	// If RHAI_VERSION is explicitly configured (via env var or CLI flag),
+	// use it instead of detecting from CSV. This is the primary path on
+	// non-OpenShift clusters where OLM is absent.
+	if rhaiVersion := flags.GetRHAIVersion(); rhaiVersion != "" {
+		v, err := semver.ParseTolerant(rhaiVersion)
+		if err != nil {
+			return initRelease, fmt.Errorf("invalid RHAI_VERSION %q: %w", rhaiVersion, err)
+		}
+		initRelease.Version = version.OperatorVersion{Version: v}
 		return initRelease, nil
 	}
 

--- a/pkg/utils/flags/flags.go
+++ b/pkg/utils/flags/flags.go
@@ -41,6 +41,13 @@ func AddOperatorFlagsAndEnvvars(envvarPrefix string) error {
 		return err
 	}
 
+	pflag.String("rhai-version", "",
+		"The operator version to report. When set, overrides CSV-based version detection. "+
+			"Must be a valid semver string (e.g. 3.4.0).")
+	if err := viper.BindEnv("rhai-version", "RHAI_VERSION"); err != nil {
+		return err
+	}
+
 	// zap logging flags
 	// these are taken from https://github.com/kubernetes-sigs/controller-runtime/blob/4161b012d114e6c1ea861fd8afcebf7ba2417b49/pkg/log/zap/zap.go#L255
 	// and need to be kept in sync.
@@ -106,4 +113,10 @@ func ParseZapFlags(zapFlagSet *flag.FlagSet, zapDevel bool, zapEncoder string, z
 // with surrounding whitespace trimmed.
 func GetRHAIApplicationsNamespace() string {
 	return strings.TrimSpace(viper.GetString("rhai-applications-namespace"))
+}
+
+// GetRHAIVersion returns the configured RHAI version,
+// with surrounding whitespace trimmed.
+func GetRHAIVersion() string {
+	return strings.TrimSpace(viper.GetString("rhai-version"))
 }


### PR DESCRIPTION
## Description
- Add `RHAI_VERSION` environment variable and CLI flag to provide the operator version on XKS (non-OpenShift) clusters where OLM/CSV is absent
- When `RHAI_VERSION` is set, use it directly for version detection instead of querying the CSV, which is the primary path on non-OpenShift clusters
- Add startup validation to enforce that `RHAI_VERSION` is required on XKS and must not be set on OpenShift (where version comes from CSV)

Jira task: https://issues.redhat.com/browse/RHOAIENG-57045

## How Has This Been Tested?
- Manual deployment on XKS cluster with `RHAI_VERSION` set via manager patch
- Verified startup fails when `RHAI_VERSION` is missing on XKS
- Verified startup fails when `RHAI_VERSION` is incorrectly set on OpenShift


## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [x] The developer has run the integration test pipeline and verified that it passed successfully
- [ ] New RELATED_IMAGE mappings are already listed in ODH-Build-Config and RHOAI-Build-Config, and links are included in PR description

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->
e2e for rhai are in progress in another PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for explicit RHAI version configuration through environment variables.

* **Bug Fixes**
  * Introduced platform-specific version validation to ensure correct configuration on startup.

* **Chores**
  * Updated deployment process to handle version substitution for both standard and extended deployment scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->