### PR TITLE
RHOAIENG-56723: fix E2E volume mount assertions for dashboard-redirect

### DIFF
--- a/tests/e2e/gateway_redirect_test.go
+++ b/tests/e2e/gateway_redirect_test.go
@@ -120,9 +120,10 @@ func (tc *GatewayTestCtx) ValidateDashboardRedirectDeployment(t *testing.T) {
 			// Ports
 			jq.Match(`.spec.template.spec.containers[0].ports[] | select(.name == "http") | .containerPort == 8080`),
 
-			// Volume mounts - ConfigMap must be mounted at specific path
-			jq.Match(`.spec.template.spec.containers[0].volumeMounts[] | select(.name == "redirect-config") | .mountPath == "/opt/app-root/etc/nginx.default.d/redirect.conf"`),
-			jq.Match(`.spec.template.spec.containers[0].volumeMounts[] | select(.name == "redirect-config") | .subPath == "redirect.conf"`),
+			// Volume mounts - ConfigMap must be mounted at specific paths
+			jq.Match(`.spec.template.spec.containers[0].volumeMounts[] | select(.name == "redirect-config" and .subPath == "nginx.conf") | .mountPath == "/etc/nginx/nginx.conf"`),
+			jq.Match(`.spec.template.spec.containers[0].volumeMounts[] | select(.name == "redirect-config" and .subPath == "redirect.conf")`+
+				` | .mountPath == "/opt/app-root/etc/nginx.default.d/redirect.conf"`),
 
 			// Volumes
 			jq.Match(`.spec.template.spec.volumes[] | select(.name == "redirect-config") | .configMap.name == "%s"`, gateway.DashboardRedirectConfigName),


### PR DESCRIPTION
## Summary

- Fix `Validate_dashboard_redirect_Deployment` E2E test failure caused by ambiguous `jq.Match` selectors on volume mounts.
- The `redirect-config` ConfigMap now has two subPath mounts (`nginx.conf` and `redirect.conf`). The old `select(.name == "redirect-config")` matched both, causing the `mountPath` check to fail on the wrong mount.
- Updated `jq.Match` expressions to filter by both `name` and `subPath` so each assertion targets the correct volume mount.

## Test plan

- [x] Gateway integration tests pass (53/53)
- [x] `Validate_dashboard_redirect_Deployment` passes with updated assertions

<!---
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully
- [ ] New RELATED_IMAGE mappings are already listed in ODH-Build-Config and RHOAI-Build-Config, and links are included in PR description

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [ ] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Tightened end-to-end validation for gateway redirect deployments to more precisely verify nginx configuration file mounts — ensuring the main nginx.conf and redirect config are mounted at the expected locations and selected correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->