### PR TITLE
Security: Path traversal in component name can lead to arbitrary file write

### DIFF
--- a/cmd/component-codegen/cmd/generator/files.go
+++ b/cmd/component-codegen/cmd/generator/files.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"text/template"
 
@@ -15,11 +16,30 @@ type TemplateData struct {
 }
 
 func generateFilesFromTemplate(logger *logrus.Logger, componentName string, p PathConfig) error {
+	validComponentName, err := regexp.MatchString(`^[A-Za-z][A-Za-z0-9]*$`, componentName)
+	if err != nil {
+		return fmt.Errorf("error validating component name: %w", err)
+	}
+	if !validComponentName {
+		return fmt.Errorf("invalid component name: %s", componentName)
+	}
+
 	suffix := p.Suffix
 	outputPath := strings.ToLower(p.OutputPath)
 	templatePath := p.TemplatePath
 	componentFileName := strings.ToLower(componentName) + suffix
 	op := filepath.Join(outputPath, componentFileName)
+
+	cleanOutputPath := filepath.Clean(outputPath)
+	cleanOp := filepath.Clean(op)
+	relPath, err := filepath.Rel(cleanOutputPath, cleanOp)
+	if err != nil {
+		return fmt.Errorf("error resolving output path: %w", err)
+	}
+	if relPath == ".." || strings.HasPrefix(relPath, ".."+string(filepath.Separator)) {
+		return fmt.Errorf("invalid output path: %s", op)
+	}
+
 	if fileExists(op) {
 		logger.Warnf("File already exists: %s", op)
 		return nil


### PR DESCRIPTION
## Summary

Security: Path traversal in component name can lead to arbitrary file write

## Problem

**Severity**: `Medium` | **File**: `cmd/component-codegen/cmd/generator/files.go:L20`

The `componentName` argument is used to construct output paths and filenames without validation. In `generateFilesFromTemplate`, `componentName` is concatenated into `componentFileName` and joined with `outputPath`. If a user passes values like `../...` or absolute paths, generated files can escape intended directories and overwrite arbitrary files in the repository or host filesystem.

## Solution

Validate `componentName` against a strict allowlist (e.g., `^[A-Za-z][A-Za-z0-9]*$`), reject path separators (`/`, `\\`, `..`), and enforce that resolved paths stay within expected base directories after `filepath.Clean` + prefix checks.

## Changes

- `cmd/component-codegen/cmd/generator/files.go` (modified)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Strengthened component name validation to require alphanumeric characters starting with a letter.
  * Enhanced output path safety verification to prevent directory traversal attempts.
  * Improved error handling for invalid component names and paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->