### PR TITLE
Refactor patch options to apply options across multiple files

### DIFF
--- a/internal/controller/services/monitoring/monitoring_controller_support.go
+++ b/internal/controller/services/monitoring/monitoring_controller_support.go
@@ -1096,7 +1096,7 @@ func syncPrometheusWebTLSCA(ctx context.Context, rr *odhtypes.ReconciliationRequ
 	}
 
 	// Apply the secret using server-side apply (create or update)
-	opts := []client.PatchOption{
+	opts := []client.ApplyOption{
 		client.ForceOwnership,
 		client.FieldOwner(resources.PlatformFieldOwner),
 	}

--- a/pkg/cluster/cert.go
+++ b/pkg/cluster/cert.go
@@ -47,7 +47,7 @@ func CreateSelfSignedCertificate(ctx context.Context, c client.Client, secretNam
 		return errApply
 	}
 
-	opts := []client.PatchOption{
+	opts := []client.ApplyOption{
 		client.ForceOwnership,
 		client.FieldOwner(CertFieldOwner),
 	}
@@ -259,7 +259,7 @@ func copySecretToNamespace(ctx context.Context, c client.Client, secret *corev1.
 		return errApply
 	}
 
-	opts := []client.PatchOption{
+	opts := []client.ApplyOption{
 		client.ForceOwnership,
 		client.FieldOwner(CertFieldOwner),
 	}

--- a/pkg/cluster/resources.go
+++ b/pkg/cluster/resources.go
@@ -269,7 +269,7 @@ func CreateOrUpdateConfigMap(ctx context.Context, c client.Client, desiredCfgMap
 		Kind:       gvk.ConfigMap.Kind,
 	}
 
-	opts := []client.PatchOption{
+	opts := []client.ApplyOption{
 		client.ForceOwnership,
 		client.FieldOwner(resources.PlatformFieldOwner),
 	}
@@ -297,7 +297,7 @@ func CreateNamespace(ctx context.Context, cli client.Client, namespace string, m
 		return nil, err
 	}
 
-	opts := []client.PatchOption{
+	opts := []client.ApplyOption{
 		client.ForceOwnership,
 		client.FieldOwner(resources.PlatformFieldOwner),
 	}

--- a/pkg/controller/actions/deploy/action_deploy.go
+++ b/pkg/controller/actions/deploy/action_deploy.go
@@ -248,7 +248,14 @@ func (a *Action) deployCRD(
 
 	var deployedObj *unstructured.Unstructured
 
-	ops := []client.PatchOption{
+	// Prepare options for both patch and apply modes
+	patchOps := []client.PatchOption{
+		client.ForceOwnership,
+		// Since CRDs are not bound to a component, set the field
+		// owner to the platform itself
+		client.FieldOwner(resources.PlatformFieldOwner),
+	}
+	applyOps := []client.ApplyOption{
 		client.ForceOwnership,
 		// Since CRDs are not bound to a component, set the field
 		// owner to the platform itself
@@ -257,9 +264,9 @@ func (a *Action) deployCRD(
 
 	switch a.deployMode {
 	case ModePatch:
-		deployedObj, err = a.patch(ctx, rr.Client, &obj, current, ops...)
+		deployedObj, err = a.patch(ctx, rr.Client, &obj, current, patchOps...)
 	case ModeSSA:
-		deployedObj, err = a.apply(ctx, rr.Client, &obj, current, ops...)
+		deployedObj, err = a.apply(ctx, rr.Client, &obj, current, applyOps...)
 	default:
 		err = fmt.Errorf("unsupported deploy mode %s", a.deployMode)
 	}
@@ -347,16 +354,21 @@ func (a *Action) deploy(
 			}
 		}
 
-		ops := []client.PatchOption{
+		// Prepare options for both patch and apply modes
+		patchOps := []client.PatchOption{
+			client.ForceOwnership,
+			client.FieldOwner(fo),
+		}
+		applyOps := []client.ApplyOption{
 			client.ForceOwnership,
 			client.FieldOwner(fo),
 		}
 
 		switch a.deployMode {
 		case ModePatch:
-			deployedObj, err = a.patch(ctx, rr.Client, &obj, current, ops...)
+			deployedObj, err = a.patch(ctx, rr.Client, &obj, current, patchOps...)
 		case ModeSSA:
-			deployedObj, err = a.apply(ctx, rr.Client, &obj, current, ops...)
+			deployedObj, err = a.apply(ctx, rr.Client, &obj, current, applyOps...)
 		default:
 			err = fmt.Errorf("unsupported deploy mode %s", a.deployMode)
 		}
@@ -458,7 +470,7 @@ func (a *Action) apply(
 	cli client.Client,
 	obj *unstructured.Unstructured,
 	old *unstructured.Unstructured,
-	opts ...client.PatchOption,
+	opts ...client.ApplyOption,
 ) (*unstructured.Unstructured, error) {
 	logf.FromContext(ctx).V(3).Info("apply",
 		"gvk", obj.GroupVersionKind(),

--- a/pkg/resources/resources.go
+++ b/pkg/resources/resources.go
@@ -520,11 +520,11 @@ func GvkToPartial(gvk schema.GroupVersionKind) *metav1.PartialObjectMetadata {
 //   - ctx: The context for the client operation
 //   - cli: The Kubernetes client interface used to perform the patch operation
 //   - in: The Kubernetes object to be applied
-//   - opts: Optional client patch options
+//   - opts: Optional client apply options
 //
 // Returns:
 //   - error: nil on success, or an error with context if the operation fails
-func Apply(ctx context.Context, cli client.Client, in client.Object, opts ...client.PatchOption) error {
+func Apply(ctx context.Context, cli client.Client, in client.Object, opts ...client.ApplyOption) error {
 	err := EnsureGroupVersionKind(cli.Scheme(), in)
 	if err != nil {
 		return fmt.Errorf("failed to ensure GVK: %w", err)
@@ -543,7 +543,7 @@ func Apply(ctx context.Context, cli client.Client, in client.Object, opts ...cli
 	unstructured.RemoveNestedField(u.Object, "metadata", "resourceVersion")
 	unstructured.RemoveNestedField(u.Object, "status")
 
-	err = cli.Patch(ctx, u, client.Apply, opts...) //nolint:staticcheck // TODO: migrate to cli.Apply() with client.ApplyOption once all callers are updated
+	err = cli.Apply(ctx, client.ApplyConfigurationFromUnstructured(u), opts...)
 	if err != nil {
 		// Include GVK and namespace/name for debugging context without logging sensitive object data
 		objRef := FormatObjectReference(u)
@@ -572,11 +572,11 @@ func Apply(ctx context.Context, cli client.Client, in client.Object, opts ...cli
 //   - ctx: The context for the client operation
 //   - cli: The Kubernetes client interface used to perform the patch operation
 //   - in: The Kubernetes object whose status should be applied
-//   - opts: Optional client subresource patch options
+//   - opts: Optional client subresource apply options
 //
 // Returns:
 //   - error: nil on success, or an error with context if the operation fails
-func ApplyStatus(ctx context.Context, cli client.Client, in client.Object, opts ...client.SubResourcePatchOption) error {
+func ApplyStatus(ctx context.Context, cli client.Client, in client.Object, opts ...client.SubResourceApplyOption) error {
 	err := EnsureGroupVersionKind(cli.Scheme(), in)
 	if err != nil {
 		return fmt.Errorf("failed to ensure GVK: %w", err)
@@ -594,7 +594,7 @@ func ApplyStatus(ctx context.Context, cli client.Client, in client.Object, opts 
 	unstructured.RemoveNestedField(u.Object, "metadata", "managedFields")
 	unstructured.RemoveNestedField(u.Object, "metadata", "resourceVersion")
 
-	err = cli.Status().Patch(ctx, u, client.Apply, opts...) //nolint:staticcheck // TODO: migrate to cli.Status().Apply() once all callers updated
+	err = cli.Status().Apply(ctx, client.ApplyConfigurationFromUnstructured(u), opts...)
 	switch {
 	case k8serr.IsNotFound(err): // Cannot be removed like in Apply func because reconciler_finalizer_test.go would then throw an error, needs extensive test rewrite
 		return nil

--- a/tests/e2e/test_context_test.go
+++ b/tests/e2e/test_context_test.go
@@ -1513,15 +1513,20 @@ func (tc *TestContext) ApproveInstallPlan(plan *ofapi.InstallPlan) {
 	// Prepare the InstallPlan object to be approved
 	obj := tc.createInstallPlan(plan.Name, plan.Namespace, plan.Spec.ClusterServiceVersionNames)
 
-	// Set up patch options
-	force := true
-	opt := &client.PatchOptions{
-		FieldManager: dscInstanceName,
-		Force:        &force,
+	// Convert InstallPlan to unstructured and use new Apply API
+	u, err := runtime.DefaultUnstructuredConverter.ToUnstructured(obj)
+	if err != nil {
+		tc.g.Expect(err).NotTo(HaveOccurred(), "Failed to convert InstallPlan to unstructured: %v", err)
+		return
 	}
+	unstrObj := &unstructured.Unstructured{Object: u}
 
-	// Apply the patch to approve the InstallPlan
-	err := tc.Client().Patch(tc.Context(), obj, client.Apply, opt) //nolint:staticcheck // TODO: migrate to cli.Apply() with client.ApplyOption
+	// Apply using new client.Apply API with typed options
+	err = tc.Client().Apply(tc.Context(),
+		client.ApplyConfigurationFromUnstructured(unstrObj),
+		client.FieldOwner(dscInstanceName),
+		client.ForceOwnership,
+	)
 	tc.g.Expect(err).
 		NotTo(
 			HaveOccurred(),


### PR DESCRIPTION
## Description
- Updated instances of client.PatchOption to client.ApplyOption in monitoring_controller_support.go, cert.go, resources.go, and action_deploy.go to align with the new apply API.
- Adjusted related function signatures and comments to reflect the change from patching to applying resources.
- Enhanced the Apply and ApplyStatus functions to utilize client.ApplyOption for better clarity and functionality.

This change improves consistency in resource management and prepares the codebase for future enhancements with the new client API.

https://redhat.atlassian.net/browse/RHOAIENG-56534

## How Has This Been Tested?
Made sure existing unit and e2e tests pass without any error

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully
- [ ] New RELATED_IMAGE mappings are already listed in ODH-Build-Config and RHOAI-Build-Config, and links are included in PR description

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [ ] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Switched internal resource operations from patch-based updates to server-side apply while preserving ownership and field-owner semantics.
  * Deployment, certificate, namespace, and config flows now use apply-style operations end-to-end.
  * No changes to public APIs or end-user behavior.

* **Tests**
  * End-to-end tests updated to use the new apply approach.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->