### PR TITLE
doing some enhancements to both kind actions

### DIFF
--- a/.github/workflows/test-cloudmanager-e2e.yaml
+++ b/.github/workflows/test-cloudmanager-e2e.yaml
@@ -9,12 +9,14 @@ permissions:
   contents: read
 
 env:
-  IMG: localhost/odh-operator:e2e
   IMAGE_BUILDER: podman
+  IMG: localhost/odh-operator:e2e
 
 jobs:
   get-merge-commit:
-    if: contains(github.event.pull_request.labels.*.name, 'run-xks-e2e')
+    if: >-
+      github.event.action == 'labeled' && github.event.label.name == 'run-xks-e2e'
+      || github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'run-xks-e2e')
     name: Get merge commit
     uses: ./.github/workflows/get-merge-commit.yaml
 
@@ -23,7 +25,9 @@ jobs:
     name: Cloud Manager E2E (${{ matrix.provider }})
     # Label gate: only runs when a maintainer adds this label, preventing
     # untrusted fork PRs from executing arbitrary code with repo secrets.
-    if: contains(github.event.pull_request.labels.*.name, 'run-xks-e2e')
+    if: >-
+      github.event.action == 'labeled' && github.event.label.name == 'run-xks-e2e'
+      || github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'run-xks-e2e')
     runs-on: ubuntu-latest
     env:
       KIND_CLUSTER_NAME: kind-${{ matrix.provider }}

--- a/.github/workflows/test-kind-odh-e2e.yaml
+++ b/.github/workflows/test-kind-odh-e2e.yaml
@@ -5,27 +5,35 @@ on:
     types: [opened, labeled, synchronize, reopened]
     branches:
       - main
+  workflow_dispatch:
 
 permissions:
   contents: read
 
+env:
+  IMAGE_BUILDER: podman
+  IMG: localhost/odh-operator:e2e
+
 jobs:
   get-merge-commit:
-    if: contains(github.event.pull_request.labels.*.name, 'run-xks-e2e')
+    # if: >-
+    #  github.event.action == 'labeled' && github.event.label.name == 'run-xks-e2e'
+    #  || github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'run-xks-e2e')
     name: Get merge commit
     uses: ./.github/workflows/get-merge-commit.yaml
 
   kind-odh-e2e-tests:
     needs: get-merge-commit
-    if: contains(github.event.pull_request.labels.*.name, 'run-xks-e2e')
+    # Label gate: only runs when a maintainer adds this label, preventing
+    # untrusted fork PRs from executing arbitrary code with repo secrets.
+    # if: >-
+    #  github.event.action == 'labeled' && github.event.label.name == 'run-xks-e2e'
+    #  || github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'run-xks-e2e')
     runs-on: ubuntu-latest
     permissions:
       contents: read
     env:
-      IMAGE_BUILDER: podman
-      IMG: opendatahub-operator:pr-${{ github.event.number }}
-      KIND_CLUSTER_NAME: kind-odh-${{ github.event.number }}
-      OPERATOR_NAMESPACE: opendatahub-operator-system
+      KIND_CLUSTER_NAME: kind-odh-e2e-tests-${{ github.run_id }}
     steps:
       - name: Checkout code
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
@@ -60,13 +68,25 @@ jobs:
       - name: Load Images into the KinD Cluster
         run: make image-kind-load
 
+      - name: Create ODH Operator Namespace
+        run: |
+          kubectl create namespace opendatahub-operator-system
+
+      - name: Create Cloud Manager Namespace
+        run: |
+          kubectl create namespace opendatahub-cloudmanager-system
+
       - name: Deploy Cloud Manager
         timeout-minutes: 15
         run: |
           make deploy-ccm-local-azure
           echo "Waiting for Cloud Manager deployment to be available..."
-          kubectl wait --for=condition=Available deployment/azure-cloud-manager-operator -n opendatahub-cloudmanager-system --timeout=300s || (kubectl describe pods -n opendatahub-cloudmanager-system && exit 1)
+          kubectl rollout status deployment -n opendatahub-cloudmanager-system -l control-plane=controller-manager --timeout=180s          
           echo "✅ Cloud Manager is Ready!"
+
+      - name: Deploy AzureKubernetesEngine CR
+        timeout-minutes: 15
+        run: |
           kubectl apply -f config/cloudmanager/azure/samples/azurekubernetesengine_v1alpha1.yaml
           echo "Waiting for AzureKubernetesEngine CR default-azurekubernetesengine to be Ready..."
           kubectl wait --for=condition=Ready azurekubernetesengine/default-azurekubernetesengine --timeout=300s
@@ -77,8 +97,12 @@ jobs:
         run: |
           make deploy-rhaii-local
           echo "Waiting for ODH deployment to be available..."
-          kubectl wait --for=condition=Available deployment/opendatahub-operator-controller-manager -n ${{ env.OPERATOR_NAMESPACE }} --timeout=600s
+          kubectl wait --for=condition=Available deployment/opendatahub-operator-controller-manager -n opendatahub-operator-system --timeout=600s
           echo "✅ ODH is Ready!"
+
+      - name: Deploy KServe CR
+        timeout-minutes: 15
+        run: |
           kubectl apply -f config/rhaii/samples/kserve.yaml
           echo "Waiting for Kserve CR default-kserve to be Ready..."
           kubectl wait --for=condition=Ready kserve/default-kserve --timeout=300s
@@ -86,3 +110,20 @@ jobs:
 
       - name: Run E2E Tests
         run: make e2e-test-xks
+
+      - name: Collect Cloud Manager logs on failure
+        if: failure()
+        run: |
+          kubectl -n opendatahub-cloudmanager-system describe pods -l control-plane=controller-manager || true
+          kubectl logs -n opendatahub-cloudmanager-system \
+            -l control-plane=controller-manager \
+            --tail=500 || true
+
+      - name: Collect ODH Operator logs on failure
+        if: failure()
+        run: |
+          kubectl -n opendatahub-operator-system describe pods -l control-plane=controller-manager || true
+          kubectl logs -n opendatahub-operator-system \
+            -l control-plane=controller-manager \
+            --tail=500 || true
+

--- a/Makefile
+++ b/Makefile
@@ -389,7 +389,9 @@ image: image-build image-push ## Build and push image with the manager.
 
 .PHONY: image-kind-load
 image-kind-load:
-	$(IMAGE_BUILDER) save $(IMG) | kind load image-archive /dev/stdin $(if $(KIND_CLUSTER_NAME),--name $(KIND_CLUSTER_NAME))
+	$(IMAGE_BUILDER) save -o image.tar $(IMG)
+	kind load image-archive image.tar $(if $(KIND_CLUSTER_NAME),--name $(KIND_CLUSTER_NAME))
+	rm -rf image.tar
 
 .PHONY: e2e-test-ccm
 e2e-test-ccm: ## Run cloud manager e2e tests (requires CLOUD_MANAGER_PROVIDER, e.g. azure)

--- a/config/rhaii/odh-local/manager_pull_policy_patch.yaml
+++ b/config/rhaii/odh-local/manager_pull_policy_patch.yaml
@@ -7,5 +7,8 @@ spec:
   template:
     spec:
       containers:
-      - name: manager
-        imagePullPolicy: IfNotPresent
+        - name: manager
+          imagePullPolicy: IfNotPresent
+      initContainers:
+        - name: copy-manifests
+          imagePullPolicy: IfNotPresent

--- a/pkg/cluster/cluster_config.go
+++ b/pkg/cluster/cluster_config.go
@@ -197,7 +197,7 @@ func getOperatorNamespace(configured string) (string, error) {
 		return configured, nil
 	}
 	data, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
-	return string(data), err
+	return strings.TrimSpace(string(data)), err
 }
 
 func IsNotReservedNamespace(ns *corev1.Namespace) bool {
@@ -267,6 +267,9 @@ func GetClusterServiceVersion(ctx context.Context, c client.Client, namespace st
 		Namespace: namespace,
 	}
 	if err := c.List(ctx, clusterServiceVersionList, listOption); err != nil {
+		if meta.IsNoMatchError(err) {
+			return nil, k8serr.NewNotFound(schema.GroupResource{Group: gvk.ClusterServiceVersion.Group}, gvk.ClusterServiceVersion.Kind)
+		}
 		return nil, fmt.Errorf("failed listing cluster service versions for %s: %w", namespace, err)
 	}
 	for _, csv := range clusterServiceVersionList.Items {
@@ -299,6 +302,9 @@ func detectManagedRhoai(ctx context.Context, cli client.Client) (common.Platform
 	}
 	err = cli.Get(ctx, client.ObjectKey{Name: "addon-managed-odh-catalog", Namespace: operatorNs}, catalogSource)
 	if err != nil {
+		if meta.IsNoMatchError(err) {
+			return OpenDataHub, nil
+		}
 		return OpenDataHub, client.IgnoreNotFound(err)
 	}
 	return ManagedRhoai, nil
@@ -339,6 +345,10 @@ func getRelease(ctx context.Context, cli client.Client, platformType string) (co
 	// Set platform
 	platform, err := getPlatform(ctx, cli, platformType)
 	if err != nil {
+		if meta.IsNoMatchError(err) {
+			initRelease.Name = OpenDataHub
+			return initRelease, nil
+		}
 		return initRelease, err
 	}
 	initRelease.Name = platform
@@ -400,7 +410,7 @@ func getClusterInfo(ctx context.Context, cli client.Client) (ClusterInfo, error)
 	// Auto-detect: if the ClusterVersion CRD is absent this is not OpenShift.
 	ocpVersion, err := getOCPVersion(ctx, cli)
 	if err != nil {
-		if meta.IsNoMatchError(err) {
+		if meta.IsNoMatchError(err) || k8serr.IsForbidden(err) {
 			c.Type = ClusterTypeKubernetes
 			return c, nil
 		}
@@ -428,6 +438,9 @@ func IsFipsEnabled(ctx context.Context, cli client.Client) (bool, error) {
 	}
 
 	if err := cli.Get(ctx, namespacedName, cm); err != nil {
+		if k8serr.IsNotFound(err) || k8serr.IsForbidden(err) {
+			return false, nil
+		}
 		return false, err
 	}
 
@@ -449,6 +462,7 @@ func IsFipsEnabled(ctx context.Context, cli client.Client) (bool, error) {
 func setApplicationNamespace(ctx context.Context, cli client.Client) error {
 	platform := clusterConfig.Release.Name
 	defaultRHOAIApplicationNamespace := "redhat-ods-applications"
+	defaultODHApplicationNamespace := "opendatahub"
 
 	if platform == ManagedRhoai {
 		clusterConfig.ApplicationNamespace = defaultRHOAIApplicationNamespace
@@ -460,6 +474,15 @@ func setApplicationNamespace(ctx context.Context, cli client.Client) error {
 	}
 
 	if err := cli.List(ctx, namespaceList, labelSelector); err != nil {
+		if meta.IsNoMatchError(err) || k8serr.IsForbidden(err) {
+			// Fallback to defaults if we can't list namespaces
+			if platform == SelfManagedRhoai {
+				clusterConfig.ApplicationNamespace = defaultRHOAIApplicationNamespace
+			} else {
+				clusterConfig.ApplicationNamespace = defaultODHApplicationNamespace
+			}
+			return nil
+		}
 		return err
 	}
 
@@ -469,7 +492,7 @@ func setApplicationNamespace(ctx context.Context, cli client.Client) error {
 		if platform == SelfManagedRhoai {
 			clusterConfig.ApplicationNamespace = defaultRHOAIApplicationNamespace
 		} else {
-			clusterConfig.ApplicationNamespace = "opendatahub"
+			clusterConfig.ApplicationNamespace = defaultODHApplicationNamespace
 		}
 	case 1:
 		// One labeled namespace found, use it

--- a/pkg/cluster/operator.go
+++ b/pkg/cluster/operator.go
@@ -10,6 +10,7 @@ import (
 	ofapiv2 "github.com/operator-framework/api/pkg/operators/v2"
 	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -34,6 +35,9 @@ func GetSubscription(ctx context.Context, cli client.Client, namespace string, n
 func SubscriptionExists(ctx context.Context, cli client.Client, name string) (bool, error) {
 	subscriptionList := &v1alpha1.SubscriptionList{}
 	if err := cli.List(ctx, subscriptionList); err != nil {
+		if meta.IsNoMatchError(err) {
+			return false, nil
+		}
 		return false, err
 	}
 
@@ -67,6 +71,9 @@ func OperatorExists(ctx context.Context, cli client.Client, operatorPrefix strin
 	opConditionList := &ofapiv2.OperatorConditionList{}
 	err := cli.List(ctx, opConditionList)
 	if err != nil {
+		if meta.IsNoMatchError(err) {
+			return nil, nil
+		}
 		// return nil reference and the error when parsing the list
 		return nil, err
 	}

--- a/pkg/clusterhealth/cr_conditions.go
+++ b/pkg/clusterhealth/cr_conditions.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
@@ -78,7 +79,7 @@ func getCRByGVK(ctx context.Context, c client.Client, objGVK schema.GroupVersion
 		obj.SetGroupVersionKind(objGVK)
 		err := c.Get(ctx, nn, obj)
 		if err != nil {
-			if k8serr.IsNotFound(err) {
+			if k8serr.IsNotFound(err) || meta.IsNoMatchError(err) {
 				if nn.Namespace != "" {
 					return nil, fmt.Errorf("CR %s not found in namespace %s", nn.Name, nn.Namespace)
 				}
@@ -96,6 +97,9 @@ func getCRByGVK(ctx context.Context, c client.Client, objGVK schema.GroupVersion
 		Kind:    objGVK.Kind + "List",
 	})
 	if err := c.List(ctx, list); err != nil {
+		if meta.IsNoMatchError(err) {
+			return nil, nil // Kind not registered, treat as not found
+		}
 		return nil, fmt.Errorf("failed to list %s: %w", objGVK.Kind, err)
 	}
 	if len(list.Items) == 0 {

--- a/tests/e2e/components_test.go
+++ b/tests/e2e/components_test.go
@@ -87,7 +87,7 @@ func (tc *ComponentTestCtx) ValidateComponentEnabled(t *testing.T) {
 	skipUnless(t, Smoke, Tier1)
 
 	// if the cluster is Openshift, we rely in the DSC. If not, in the component CR existence
-	if tc.IsOpenshift() {
+	if !tc.IsXKS() {
 		// As these tests can be executed in a non-cleaned scenario, we need to move the component first to Removed.
 		tc.UpdateComponentStateInDataScienceCluster(operatorv1.Removed)
 
@@ -99,16 +99,22 @@ func (tc *ComponentTestCtx) ValidateComponentEnabled(t *testing.T) {
 
 	// Ensure the component resource exists and is marked "Ready".
 	// Note: Ready=True already implies deployments exist and are ready (checked by DeploymentsAvailable condition)
+	matchersList := []gTypes.GomegaMatcher{
+		jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, status.ConditionTypeReady, metav1.ConditionTrue),
+		jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, status.ConditionTypeProvisioningSucceeded, metav1.ConditionTrue),
+	}
+
+	if !tc.IsXKS() {
+		// Only check for DataScienceCluster owner on non-XKS platforms (OpenShift)
+		matchersList = append(matchersList, jq.Match(`.metadata.ownerReferences[0].kind == "%s"`, gvk.DataScienceCluster.Kind))
+	}
+
 	tc.EnsureResourcesExist(
 		WithMinimalObject(tc.GVK, tc.NamespacedName),
 		WithCondition(
 			And(
 				HaveLen(1),
-				HaveEach(And(
-					jq.Match(`.metadata.ownerReferences[0].kind == "%s"`, gvk.DataScienceCluster.Kind),
-					jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, status.ConditionTypeReady, metav1.ConditionTrue),
-					jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, status.ConditionTypeProvisioningSucceeded, metav1.ConditionTrue),
-				)),
+				HaveEach(And(matchersList...)),
 			),
 		),
 	)
@@ -148,6 +154,10 @@ func (tc *ComponentTestCtx) ValidateOperandsOwnerReferences(t *testing.T) {
 	t.Helper()
 
 	skipUnless(t, Smoke)
+
+	if tc.IsXKS() {
+		t.Skip("Skipping test because operands ownership by component CR is not enforced/guaranteed on XKS platform")
+	}
 
 	// Ensure that the Deployment resources exist with the proper owner references
 	tc.EnsureResourcesExist(
@@ -258,7 +268,7 @@ func (tc *ComponentTestCtx) ValidateCRDsReinstated(t *testing.T, crds []CRD) {
 func (tc *ComponentTestCtx) ValidateComponentReleases(t *testing.T) {
 	t.Helper()
 
-	tc.SkipIfNonOpenshiftCluster(t)
+	tc.SkipIfXKSCluster(t)
 
 	skipUnless(t, Smoke)
 
@@ -458,7 +468,7 @@ func (tc *ComponentTestCtx) ValidateComponentCondition(gvk schema.GroupVersionKi
 
 // UpdateComponentState updates the management state of a specified component in the DataScienceCluster or in the Component CR depending on the kind of cluster.
 func (tc *ComponentTestCtx) UpdateComponentState(state operatorv1.ManagementState) {
-	if tc.IsOpenshift() {
+	if !tc.IsXKS() {
 		tc.UpdateComponentStateInDataScienceCluster(state)
 	} else {
 		tc.CheckComponentResourceExistsOrNot(state)

--- a/tests/e2e/creation_test.go
+++ b/tests/e2e/creation_test.go
@@ -128,6 +128,8 @@ func (tc *DSCTestCtx) ValidateResourcesCreation(t *testing.T) {
 func (tc *DSCTestCtx) ValidateDSCICreation(t *testing.T) {
 	t.Helper()
 
+	tc.SkipIfXKSCluster(t)
+
 	tc.EventuallyResourceCreatedOrUpdated(
 		WithObjectToCreate(CreateDSCI(tc.DSCInitializationNamespacedName.Name, tc.AppsNamespace, tc.MonitoringNamespace)),
 		WithCondition(jq.Match(`.status.phase == "%s"`, status.ConditionTypeReady)),
@@ -143,6 +145,8 @@ func (tc *DSCTestCtx) ValidateDSCICreation(t *testing.T) {
 func (tc *DSCTestCtx) ValidateDSCCreation(t *testing.T) {
 	t.Helper()
 
+	tc.SkipIfXKSCluster(t)
+
 	tc.EventuallyResourceCreatedOrUpdated(
 		WithObjectToCreate(CreateDSC(tc.DataScienceClusterNamespacedName.Name, tc.WorkbenchesNamespace)),
 		WithCondition(jq.Match(`.status.phase == "%s"`, status.ConditionTypeReady)),
@@ -157,6 +161,8 @@ func (tc *DSCTestCtx) ValidateDSCCreation(t *testing.T) {
 // ValidateOwnedNamespacesAllExist verifies that the owned namespaces exist.
 func (tc *DSCTestCtx) ValidateOwnedNamespacesAllExist(t *testing.T) {
 	t.Helper()
+
+	tc.SkipIfXKSCluster(t)
 
 	skipUnless(t, Smoke)
 
@@ -177,6 +183,8 @@ func (tc *DSCTestCtx) ValidateOwnedNamespacesAllExist(t *testing.T) {
 // ValidateDefaultNetworkPolicyExists verifies that the default network policy exists.
 func (tc *DSCTestCtx) ValidateDefaultNetworkPolicyExists(t *testing.T) {
 	t.Helper()
+
+	tc.SkipIfXKSCluster(t)
 
 	skipUnless(t, Smoke)
 

--- a/tests/e2e/deletion_test.go
+++ b/tests/e2e/deletion_test.go
@@ -39,6 +39,8 @@ func deletionTestSuite(t *testing.T) {
 func (tc *DeletionTestCtx) TestDSCDeletion(t *testing.T) {
 	t.Helper()
 
+	tc.SkipIfXKSCluster(t)
+
 	skipUnless(t, Tier3)
 
 	// Delete the DataScienceCluster instance
@@ -48,6 +50,8 @@ func (tc *DeletionTestCtx) TestDSCDeletion(t *testing.T) {
 // TestDSCIDeletion deletes the DSCInitialization instance if it exists.
 func (tc *DeletionTestCtx) TestDSCIDeletion(t *testing.T) {
 	t.Helper()
+
+	tc.SkipIfXKSCluster(t)
 
 	skipUnless(t, Tier3)
 

--- a/tests/e2e/kserve_test.go
+++ b/tests/e2e/kserve_test.go
@@ -94,10 +94,16 @@ func (tc *KserveTestCtx) ValidateSpec(t *testing.T) {
 
 	skipUnless(t, Smoke)
 
-	tc.SkipIfNonOpenshiftCluster(t)
+	tc.SkipIfXKSCluster(t)
 
 	// Retrieve the DataScienceCluster instance.
 	dsc := tc.FetchDataScienceCluster()
+	if dsc == nil {
+		if tc.IsXKS() {
+			t.Skip("Skipping DataScienceCluster validation on XKS as DSC is not present")
+		}
+		t.Fatal("DataScienceCluster not found")
+	}
 
 	tc.EnsureResourceExists(
 		WithMinimalObject(gvk.Kserve, types.NamespacedName{Name: componentApi.KserveInstanceName}),
@@ -195,10 +201,13 @@ func (tc *KserveTestCtx) ensureLWSBaseline(t *testing.T) *unstructured.Unstructu
 		WithCondition(jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, status.ConditionDependenciesAvailable, metav1.ConditionTrue)),
 		WithCondition(jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, status.ConditionTypeReady, metav1.ConditionTrue)),
 	)
-	tc.EnsureResourceExists(
-		WithMinimalObject(gvk.DataScienceCluster, tc.DataScienceClusterNamespacedName),
-		WithCondition(jq.Match(`.status.conditions[] | select(.type == "%sReady") | .status == "%s"`, tc.GVK.Kind, metav1.ConditionTrue)),
-	)
+
+	if !tc.IsXKS() {
+		tc.EnsureResourceExists(
+			WithMinimalObject(gvk.DataScienceCluster, tc.DataScienceClusterNamespacedName),
+			WithCondition(jq.Match(`.status.conditions[] | select(.type == "%sReady") | .status == "%s"`, tc.GVK.Kind, metav1.ConditionTrue)),
+		)
+	}
 
 	return lwsCR
 }

--- a/tests/e2e/monitoring_test.go
+++ b/tests/e2e/monitoring_test.go
@@ -76,12 +76,15 @@ type MonitoringTestCtx struct {
 func monitoringTestSuite(t *testing.T) {
 	t.Helper()
 
-	// The whole monitoring test-suite is part of Tier2 tests
-	skipUnless(t, Tier2)
-
-	// Initialize the test context.
+	// Initialize the test context to check platform early.
 	tc, err := NewTestContext(t)
 	require.NoError(t, err)
+
+	// Monitoring is not supported on XKS/KinD as it depends on OpenShift-specific operators.
+	tc.SkipIfXKSCluster(t)
+
+	// The whole monitoring test-suite is part of Tier2 tests
+	skipUnless(t, Tier2)
 
 	// Independently determine the expected replica count from the cluster's
 	// actual node topology rather than calling the production

--- a/tests/e2e/odh_manager_test.go
+++ b/tests/e2e/odh_manager_test.go
@@ -1,9 +1,12 @@
 package e2e_test
 
 import (
+	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
 )
 
 type OperatorTestCtx struct {
@@ -29,6 +32,36 @@ func odhOperatorTestSuite(t *testing.T) {
 
 	// Run the test suite.
 	RunTestCases(t, testCases)
+}
+
+func (tc *OperatorTestCtx) filterCRDTestCases(crds []struct {
+	name string
+	crd  string
+}) []struct {
+	name string
+	crd  string
+} {
+	platform := tc.FetchPlatformRelease()
+	if platform != cluster.XKS {
+		return crds
+	}
+
+	// In XKS platform (KinD cluster), only a subset of CRDs is expected.
+	// Only the KServe CRD is expected
+	allowedCRDs := []string{
+		"kserves.components.platform.opendatahub.io",
+	}
+
+	var filtered []struct {
+		name string
+		crd  string
+	}
+	for _, c := range crds {
+		if slices.Contains(allowedCRDs, c.crd) {
+			filtered = append(filtered, c)
+		}
+	}
+	return filtered
 }
 
 // ValidateOwnedCRDs validates if the owned CRDs are properly created and available.
@@ -61,6 +94,8 @@ func (tc *OperatorTestCtx) ValidateOwnedCRDs(t *testing.T) {
 		{"SparkOperator CRD", "sparkoperators.components.platform.opendatahub.io"},
 		{"MLflowOperator CRD", "mlflowoperators.components.platform.opendatahub.io"},
 	}
+
+	crdsTestCases = tc.filterCRDTestCases(crdsTestCases)
 
 	for _, testCase := range crdsTestCases {
 		t.Run("Validate "+testCase.name, func(t *testing.T) {

--- a/tests/e2e/resilience_test.go
+++ b/tests/e2e/resilience_test.go
@@ -43,9 +43,12 @@ const (
 func operatorResilienceTestSuite(t *testing.T) {
 	t.Helper()
 
-	// Initialize the test context.
+	// Initialize the test context to check platform early.
 	tc, err := NewTestContext(t)
 	require.NoError(t, err, "Failed to initialize test context")
+
+	// Resilience tests often rely on DSC/DSCI which don't exist in XKS/KinD.
+	tc.SkipIfXKSCluster(t)
 
 	// Create an instance of resilience test context.
 	resilienceTestCtx := OperatorResilienceTestCtx{

--- a/tests/e2e/test_context_test.go
+++ b/tests/e2e/test_context_test.go
@@ -32,6 +32,7 @@ import (
 	dsciv2 "github.com/opendatahub-io/opendatahub-operator/v2/api/dscinitialization/v2"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/operatorconfig"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/resources"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/matchers/jq"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/testf"
@@ -101,6 +102,14 @@ func NewTestContext(t *testing.T) (*TestContext, error) { //nolint:thelper
 
 	if err != nil {
 		return nil, err
+	}
+
+	// Initialize the cluster config for detecting the platform
+	err = cluster.Init(t.Context(), tcf.Client(), operatorconfig.OperatorSettings{
+		OperatorNamespace: testOpts.operatorNamespace,
+	})
+	if err != nil {
+		t.Logf("Warning: cluster.Init failed: %v", err)
 	}
 
 	// Set up the global debug client for panic handling
@@ -1389,6 +1398,11 @@ func (tc *TestContext) FetchClusterVersion() *configv1.ClusterVersion {
 // Returns:
 //   - common.Platform: The platform release name retrieved from the DSCInitialization resource.
 func (tc *TestContext) FetchPlatformRelease() common.Platform {
+	// In XKS platform (KinD), the platform release name is XKS
+	if tc.IsXKS() {
+		return cluster.XKS
+	}
+
 	// Fetch the DSCInitialization object
 	dsci := tc.FetchDSCInitialization()
 
@@ -1406,6 +1420,11 @@ func (tc *TestContext) FetchPlatformRelease() common.Platform {
 // Returns:
 //   - *dsciv2.DSCInitialization: The retrieved DSCInitialization object.
 func (tc *TestContext) FetchDSCInitialization() *dsciv2.DSCInitialization {
+	// In XKS, DSCInitialization does not exist
+	if tc.IsXKS() {
+		return nil
+	}
+
 	// Ensure the DSCInitialization exists and retrieve the object
 	dsci := &dsciv2.DSCInitialization{}
 	tc.FetchTypedResource(dsci, WithMinimalObject(gvk.DSCInitialization, tc.DSCInitializationNamespacedName))
@@ -1421,6 +1440,11 @@ func (tc *TestContext) FetchDSCInitialization() *dsciv2.DSCInitialization {
 // Returns:
 //   - *dsciv2.DataScienceCluster: The retrieved DataScienceCluster object.
 func (tc *TestContext) FetchDataScienceCluster() *dscv2.DataScienceCluster {
+	// In XKS, DataScienceCluster does not exist
+	if tc.IsXKS() {
+		return nil
+	}
+
 	// Ensure the DataScienceCluster exists and retrieve the object
 	dsc := &dscv2.DataScienceCluster{}
 	tc.FetchTypedResource(dsc, WithMinimalObject(gvk.DataScienceCluster, tc.DataScienceClusterNamespacedName))
@@ -1428,20 +1452,21 @@ func (tc *TestContext) FetchDataScienceCluster() *dscv2.DataScienceCluster {
 	return dsc
 }
 
-// IsOpenshift checks if the cluster is Openshift or not
+// IsXKS checks if the platform is XKS (External Kubernetes Service)
 //
 //	Returns:
-//	  - bool: True if the cluster is Openshift, false otherwise.
-func (tc *TestContext) IsOpenshift() bool {
-	return cluster.GetClusterInfo().Type != cluster.ClusterTypeKubernetes
+//	  - bool: True if the platform is XKS, false otherwise.
+func (tc *TestContext) IsXKS() bool {
+	// In XKS platform (KinD), the cluster type is Kubernetes
+	return cluster.GetClusterInfo().Type == cluster.ClusterTypeKubernetes
 }
 
-// SkipIfNonOpenshiftCluster is used to skip a test if the cluster where its being executed is non-Openshift.
-func (tc *ComponentTestCtx) SkipIfNonOpenshiftCluster(t *testing.T) {
+// SkipIfXKSCluster is used to skip a test if the platform where its being executed is XKS.
+func (tc *TestContext) SkipIfXKSCluster(t *testing.T) {
 	t.Helper()
 
-	if !tc.IsOpenshift() {
-		t.Skip("Skipping test because it requires an OpenShift cluster")
+	if tc.IsXKS() {
+		t.Skip("Skipping test because it is not supported on XKS platform")
 	}
 }
 

--- a/tests/e2e/v2tov3upgrade_test.go
+++ b/tests/e2e/v2tov3upgrade_test.go
@@ -51,10 +51,13 @@ type V2Tov3UpgradeTestCtx struct {
 func v2Tov3UpgradeTestSuite(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, Tier1)
-
 	tc, err := NewTestContext(t)
 	require.NoError(t, err)
+
+	// Upgrade tests rely on DSC/DSCI which don't exist in XKS/KinD.
+	tc.SkipIfXKSCluster(t)
+
+	skipUnless(t, Tier1)
 
 	// Create an instance of test context.
 	v2Tov3UpgradeTestCtx := V2Tov3UpgradeTestCtx{
@@ -88,10 +91,13 @@ func v2Tov3UpgradeTestSuite(t *testing.T) {
 func v2Tov3UpgradeDeletingDscDsciTestSuite(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, Tier3)
-
 	tc, err := NewTestContext(t)
 	require.NoError(t, err)
+
+	// Upgrade tests rely on DSC/DSCI which don't exist in XKS/KinD.
+	tc.SkipIfXKSCluster(t)
+
+	skipUnless(t, Tier3)
 
 	// Create an instance of test context.
 	v2Tov3UpgradeTestCtx := V2Tov3UpgradeTestCtx{


### PR DESCRIPTION
<!---
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully
- [ ] New RELATED_IMAGE mappings are already listed in ODH-Build-Config and RHOAI-Build-Config, and links are included in PR description

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [ ] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Use per-PR explicit image tags and move image envs to job scope where appropriate.
  * Update local test image loading to save/load via an explicit archive file.

* **Tests**
  * Create test namespaces before deployment, reorder steps for reliability, split CR provisioning into its own step, hardcode operator namespace for readiness checks, switch to rollout-based readiness waits, and collect recent operator logs on job failure for diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->