### PR TITLE
test: add e2e tests for ScheduledSparkApplication in Spark Operator

### DIFF
--- a/pkg/cluster/gvk/gvk.go
+++ b/pkg/cluster/gvk/gvk.go
@@ -902,4 +902,10 @@ var (
 		Version: "v1beta2",
 		Kind:    "SparkApplication",
 	}
+
+	ScheduledSparkApplication = schema.GroupVersionKind{
+		Group:   "sparkoperator.k8s.io",
+		Version: "v1beta2",
+		Kind:    "ScheduledSparkApplication",
+	}
 )

--- a/tests/e2e/sparkoperator_test.go
+++ b/tests/e2e/sparkoperator_test.go
@@ -6,12 +6,14 @@ import (
 
 	"github.com/rs/xid"
 	"github.com/stretchr/testify/require"
+	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
 
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/api/components/v1alpha1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/matchers/jq"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/testf"
 )
 
 const (
@@ -94,9 +96,7 @@ func (tc *SparkOperatorTestCtx) ValidateSparkPiWorkload(t *testing.T) {
 func (tc *SparkOperatorTestCtx) ValidateScheduledSparkPiWorkload(t *testing.T) {
 	t.Helper()
 
-	// Use a unique name to avoid conflicts with previous test runs
 	scheduledSparkAppName := "scheduled-spark-pi-" + xid.New().String()
-	// Run in the applications namespace where spark-operator-spark SA exists
 	namespace := tc.AppsNamespace
 
 	t.Logf("Creating ScheduledSparkApplication %s in namespace %s", scheduledSparkAppName, namespace)
@@ -110,21 +110,34 @@ func (tc *SparkOperatorTestCtx) ValidateScheduledSparkPiWorkload(t *testing.T) {
 	var lastRunName string
 
 	defer func() {
-		if lastRunName != "" {
-			t.Logf("Cleaning up SparkApplication %s", lastRunName)
-			tc.DeleteResource(
-				WithMinimalObject(gvk.SparkApplication, types.NamespacedName{Name: lastRunName, Namespace: namespace}),
-				WithIgnoreNotFound(true),
-				WithWaitForDeletion(true),
-			)
-		}
-
 		t.Logf("Cleaning up ScheduledSparkApplication %s", scheduledSparkAppName)
 		tc.DeleteResource(
 			WithMinimalObject(gvk.ScheduledSparkApplication, types.NamespacedName{Name: scheduledSparkAppName, Namespace: namespace}),
 			WithIgnoreNotFound(true),
 			WithWaitForDeletion(true),
 		)
+
+		if lastRunName != "" {
+			t.Logf("Verifying cascade deletion of SparkApplication %s", lastRunName)
+
+			child := &unstructured.Unstructured{}
+			child.SetGroupVersionKind(gvk.SparkApplication)
+
+			err := tc.Client().Get(tc.Context(), types.NamespacedName{Name: lastRunName, Namespace: namespace}, child)
+			switch {
+			case err == nil:
+				t.Errorf("cascade deletion failed: SparkApplication %s still exists after deleting parent", lastRunName)
+				t.Logf("Manually cleaning up leaked SparkApplication %s", lastRunName)
+				tc.DeleteResource(
+					WithMinimalObject(gvk.SparkApplication, types.NamespacedName{Name: lastRunName, Namespace: namespace}),
+					WithIgnoreNotFound(true),
+				)
+			case k8serr.IsNotFound(err):
+				t.Logf("Cascade deletion verified: SparkApplication %s was deleted with parent", lastRunName)
+			default:
+				t.Errorf("failed to check SparkApplication %s after cascade deletion: %v", lastRunName, err)
+			}
+		}
 	}()
 
 	t.Logf("Waiting for ScheduledSparkApplication %s to schedule a run", scheduledSparkAppName)
@@ -138,16 +151,18 @@ func (tc *SparkOperatorTestCtx) ValidateScheduledSparkPiWorkload(t *testing.T) {
 		WithEventuallyPollingInterval(tc.TestTimeouts.defaultEventuallyPollInterval),
 	)
 
-	var found bool
-	var err error
-
-	lastRunName, found, err = unstructured.NestedString(scheduledApp.Object, "status", "lastRunName")
+	lastRunName, found, err := unstructured.NestedString(scheduledApp.Object, "status", "lastRunName")
 	require.NoError(t, err, "Failed to extract lastRunName from ScheduledSparkApplication status")
 	require.True(t, found, "lastRunName not found in ScheduledSparkApplication status")
 
 	t.Logf("ScheduledSparkApplication %s created SparkApplication: %s", scheduledSparkAppName, lastRunName)
 
-	// Wait for the spawned SparkApplication to reach a terminal state
+	t.Logf("Suspending ScheduledSparkApplication %s to prevent additional runs", scheduledSparkAppName)
+	tc.EventuallyResourcePatched(
+		WithMinimalObject(gvk.ScheduledSparkApplication, types.NamespacedName{Name: scheduledSparkAppName, Namespace: namespace}),
+		WithMutateFunc(testf.Transform(`.spec.suspend = true`)),
+	)
+
 	t.Logf("Waiting for SparkApplication %s to reach terminal state", lastRunName)
 	completedApp := tc.EnsureResourceExists(
 		WithMinimalObject(gvk.SparkApplication, types.NamespacedName{Name: lastRunName, Namespace: namespace}),
@@ -159,8 +174,7 @@ func (tc *SparkOperatorTestCtx) ValidateScheduledSparkPiWorkload(t *testing.T) {
 		WithEventuallyPollingInterval(tc.TestTimeouts.defaultEventuallyPollInterval),
 	)
 
-	var state string
-	state, found, err = unstructured.NestedString(completedApp.Object, "status", "applicationState", "state")
+	state, found, err := unstructured.NestedString(completedApp.Object, "status", "applicationState", "state")
 	require.NoError(t, err, "Failed to extract state from SparkApplication %s status", lastRunName)
 	require.True(t, found, "state not found in SparkApplication %s status", lastRunName)
 	require.Equal(t, "COMPLETED", state, "SparkApplication %s ended in %s state instead of COMPLETED", lastRunName, state)

--- a/tests/e2e/sparkoperator_test.go
+++ b/tests/e2e/sparkoperator_test.go
@@ -34,6 +34,7 @@ func sparkOperatorTestSuite(t *testing.T) {
 		{"Validate update operand resources", componentCtx.ValidateUpdateDeploymentsResources},
 		{"Validate component releases", componentCtx.ValidateComponentReleases},
 		{"Validate SparkPi workload execution", componentCtx.ValidateSparkPiWorkload},
+		{"Validate ScheduledSparkApplication workload execution", componentCtx.ValidateScheduledSparkPiWorkload},
 		{"Validate resource deletion recovery", componentCtx.ValidateAllDeletionRecovery},
 		{"Validate component disabled", componentCtx.ValidateComponentDisabled},
 	}
@@ -81,6 +82,79 @@ func (tc *SparkOperatorTestCtx) ValidateSparkPiWorkload(t *testing.T) {
 	)
 
 	t.Logf("SparkApplication %s completed successfully", sparkAppName)
+}
+
+// ValidateScheduledSparkPiWorkload validates that a ScheduledSparkApplication can run successfully.
+func (tc *SparkOperatorTestCtx) ValidateScheduledSparkPiWorkload(t *testing.T) {
+	t.Helper()
+
+	// Use a unique name to avoid conflicts with previous test runs
+	scheduledSparkAppName := "scheduled-spark-pi-" + xid.New().String()
+	// Run in the applications namespace where spark-operator-spark SA exists
+	namespace := tc.AppsNamespace
+
+	t.Logf("Creating ScheduledSparkApplication %s in namespace %s", scheduledSparkAppName, namespace)
+	scheduledSparkApp := tc.createScheduledSparkPiApplication(scheduledSparkAppName, namespace)
+
+	tc.EventuallyResourceCreatedOrUpdated(
+		WithObjectToCreate(scheduledSparkApp),
+		WithCustomErrorMsg("Failed to create ScheduledSparkApplication %s", scheduledSparkAppName),
+	)
+
+	// Cleanup ScheduledSparkApplication after test
+	defer func() {
+		t.Logf("Cleaning up ScheduledSparkApplication %s", scheduledSparkAppName)
+		tc.DeleteResource(
+			WithMinimalObject(gvk.ScheduledSparkApplication, types.NamespacedName{Name: scheduledSparkAppName, Namespace: namespace}),
+			WithIgnoreNotFound(true),
+			WithWaitForDeletion(true),
+		)
+	}()
+
+	t.Logf("Waiting for ScheduledSparkApplication %s to schedule a run", scheduledSparkAppName)
+	// Wait for the ScheduledSparkApplication to populate status with lastRunName
+	tc.EnsureResourceExists(
+		WithMinimalObject(gvk.ScheduledSparkApplication, types.NamespacedName{Name: scheduledSparkAppName, Namespace: namespace}),
+		WithCondition(
+			jq.Match(`.status.lastRunName != null and .status.lastRunName != ""`),
+		),
+		WithCustomErrorMsg("ScheduledSparkApplication %s did not schedule a run", scheduledSparkAppName),
+		WithEventuallyTimeout(tc.TestTimeouts.longEventuallyTimeout),
+		WithEventuallyPollingInterval(tc.TestTimeouts.defaultEventuallyPollInterval),
+	)
+
+	// Get the actual SparkApplication name that was created
+	var lastRunName string
+	tc.GetResource(
+		WithMinimalObject(gvk.ScheduledSparkApplication, types.NamespacedName{Name: scheduledSparkAppName, Namespace: namespace}),
+		WithResult(func(obj *unstructured.Unstructured) error {
+			name, found, err := unstructured.NestedString(obj.Object, "status", "lastRunName")
+			if err != nil {
+				return err
+			}
+			if !found {
+				return nil
+			}
+			lastRunName = name
+			return nil
+		}),
+	)
+
+	t.Logf("ScheduledSparkApplication %s created SparkApplication: %s", scheduledSparkAppName, lastRunName)
+
+	// Wait for the spawned SparkApplication to complete
+	t.Logf("Waiting for SparkApplication %s to complete", lastRunName)
+	tc.EnsureResourceExists(
+		WithMinimalObject(gvk.SparkApplication, types.NamespacedName{Name: lastRunName, Namespace: namespace}),
+		WithCondition(
+			jq.Match(`.status.applicationState.state == "COMPLETED"`),
+		),
+		WithCustomErrorMsg("SparkApplication %s (created by ScheduledSparkApplication) did not complete successfully", lastRunName),
+		WithEventuallyTimeout(tc.TestTimeouts.longEventuallyTimeout),
+		WithEventuallyPollingInterval(tc.TestTimeouts.defaultEventuallyPollInterval),
+	)
+
+	t.Logf("ScheduledSparkApplication %s successfully scheduled and executed SparkApplication %s", scheduledSparkAppName, lastRunName)
 }
 
 // createSparkPiApplication creates a SparkApplication CR for spark-pi test.
@@ -146,6 +220,87 @@ func (tc *SparkOperatorTestCtx) createSparkPiApplication(name, namespace string)
 						map[string]any{
 							"name":      "spark-work-dir",
 							"mountPath": "/opt/spark/work-dir",
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// createScheduledSparkPiApplication creates a ScheduledSparkApplication CR for spark-pi test.
+func (tc *SparkOperatorTestCtx) createScheduledSparkPiApplication(name, namespace string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "sparkoperator.k8s.io/v1beta2",
+			"kind":       "ScheduledSparkApplication",
+			"metadata": map[string]any{
+				"name":      name,
+				"namespace": namespace,
+			},
+			"spec": map[string]any{
+				// Run immediately and then every 5 minutes
+				"schedule": "@every 1m",
+				// Don't allow concurrent runs
+				"concurrencyPolicy": "Forbid",
+				// Keep only the last successful and failed run
+				"successfulRunHistoryLimit": int64(1),
+				"failedRunHistoryLimit":     int64(1),
+				// SparkApplication template - same as the regular SparkPi test
+				"template": map[string]any{
+					"type":                "Scala",
+					"mode":                "cluster",
+					"image":               "quay.io/opendatahub/data-processing:Spark-v4.0.1",
+					"imagePullPolicy":     "IfNotPresent",
+					"mainClass":           "org.apache.spark.examples.SparkPi",
+					"mainApplicationFile": "local:///opt/spark/examples/jars/spark-examples_2.13-4.0.1.jar",
+					"arguments":           []any{"1000"},
+					"sparkVersion":        "4.0.1",
+					"restartPolicy": map[string]any{
+						"type": "Never",
+					},
+					"sparkConf": map[string]any{
+						"spark.driver.port":              "8080",
+						"spark.driver.blockManager.port": "8082",
+						"spark.blockManager.port":        "8081",
+						"spark.port.maxRetries":          "0",
+					},
+					// Volume for OpenShift compatibility - provides writable work directory
+					"volumes": []any{
+						map[string]any{
+							"name":     "spark-work-dir",
+							"emptyDir": map[string]any{},
+						},
+					},
+					"driver": map[string]any{
+						"labels": map[string]any{
+							"version": "4.0.1",
+						},
+						"cores":           int64(1),
+						"coreLimit":       "1200m",
+						"memory":          "512m",
+						"serviceAccount":  "spark-operator-spark",
+						"securityContext": map[string]any{},
+						"volumeMounts": []any{
+							map[string]any{
+								"name":      "spark-work-dir",
+								"mountPath": "/opt/spark/work-dir",
+							},
+						},
+					},
+					"executor": map[string]any{
+						"labels": map[string]any{
+							"version": "4.0.1",
+						},
+						"instances":       int64(1),
+						"cores":           int64(1),
+						"memory":          "512m",
+						"securityContext": map[string]any{},
+						"volumeMounts": []any{
+							map[string]any{
+								"name":      "spark-work-dir",
+								"mountPath": "/opt/spark/work-dir",
+							},
 						},
 					},
 				},

--- a/tests/e2e/sparkoperator_test.go
+++ b/tests/e2e/sparkoperator_test.go
@@ -83,7 +83,7 @@ func (tc *SparkOperatorTestCtx) ValidateSparkPiWorkload(t *testing.T) {
 			jq.Match(`.status.applicationState.state == "COMPLETED"`),
 		),
 		WithCustomErrorMsg("SparkApplication %s did not complete successfully", sparkAppName),
-		WithEventuallyTimeout(tc.TestTimeouts.longEventuallyTimeout),
+		WithEventuallyTimeout(tc.TestTimeouts.defaultEventuallyTimeout),
 		WithEventuallyPollingInterval(tc.TestTimeouts.defaultEventuallyPollInterval),
 	)
 
@@ -107,8 +107,18 @@ func (tc *SparkOperatorTestCtx) ValidateScheduledSparkPiWorkload(t *testing.T) {
 		WithCustomErrorMsg("Failed to create ScheduledSparkApplication %s", scheduledSparkAppName),
 	)
 
-	// Cleanup ScheduledSparkApplication after test
+	var lastRunName string
+
 	defer func() {
+		if lastRunName != "" {
+			t.Logf("Cleaning up SparkApplication %s", lastRunName)
+			tc.DeleteResource(
+				WithMinimalObject(gvk.SparkApplication, types.NamespacedName{Name: lastRunName, Namespace: namespace}),
+				WithIgnoreNotFound(true),
+				WithWaitForDeletion(true),
+			)
+		}
+
 		t.Logf("Cleaning up ScheduledSparkApplication %s", scheduledSparkAppName)
 		tc.DeleteResource(
 			WithMinimalObject(gvk.ScheduledSparkApplication, types.NamespacedName{Name: scheduledSparkAppName, Namespace: namespace}),
@@ -118,7 +128,6 @@ func (tc *SparkOperatorTestCtx) ValidateScheduledSparkPiWorkload(t *testing.T) {
 	}()
 
 	t.Logf("Waiting for ScheduledSparkApplication %s to schedule a run", scheduledSparkAppName)
-	// Wait for the ScheduledSparkApplication to populate status with lastRunName
 	scheduledApp := tc.EnsureResourceExists(
 		WithMinimalObject(gvk.ScheduledSparkApplication, types.NamespacedName{Name: scheduledSparkAppName, Namespace: namespace}),
 		WithCondition(
@@ -129,8 +138,10 @@ func (tc *SparkOperatorTestCtx) ValidateScheduledSparkPiWorkload(t *testing.T) {
 		WithEventuallyPollingInterval(tc.TestTimeouts.defaultEventuallyPollInterval),
 	)
 
-	// Get the actual SparkApplication name that was created
-	lastRunName, found, err := unstructured.NestedString(scheduledApp.Object, "status", "lastRunName")
+	var found bool
+	var err error
+
+	lastRunName, found, err = unstructured.NestedString(scheduledApp.Object, "status", "lastRunName")
 	require.NoError(t, err, "Failed to extract lastRunName from ScheduledSparkApplication status")
 	require.True(t, found, "lastRunName not found in ScheduledSparkApplication status")
 
@@ -148,7 +159,10 @@ func (tc *SparkOperatorTestCtx) ValidateScheduledSparkPiWorkload(t *testing.T) {
 		WithEventuallyPollingInterval(tc.TestTimeouts.defaultEventuallyPollInterval),
 	)
 
-	state, _, _ := unstructured.NestedString(completedApp.Object, "status", "applicationState", "state")
+	var state string
+	state, found, err = unstructured.NestedString(completedApp.Object, "status", "applicationState", "state")
+	require.NoError(t, err, "Failed to extract state from SparkApplication %s status", lastRunName)
+	require.True(t, found, "state not found in SparkApplication %s status", lastRunName)
 	require.Equal(t, "COMPLETED", state, "SparkApplication %s ended in %s state instead of COMPLETED", lastRunName, state)
 
 	t.Logf("ScheduledSparkApplication %s successfully scheduled and executed SparkApplication %s", scheduledSparkAppName, lastRunName)

--- a/tests/e2e/sparkoperator_test.go
+++ b/tests/e2e/sparkoperator_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/rs/xid"
 	"github.com/stretchr/testify/require"
-	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -119,24 +118,10 @@ func (tc *SparkOperatorTestCtx) ValidateScheduledSparkPiWorkload(t *testing.T) {
 
 		if lastRunName != "" {
 			t.Logf("Verifying cascade deletion of SparkApplication %s", lastRunName)
-
-			child := &unstructured.Unstructured{}
-			child.SetGroupVersionKind(gvk.SparkApplication)
-
-			err := tc.Client().Get(tc.Context(), types.NamespacedName{Name: lastRunName, Namespace: namespace}, child)
-			switch {
-			case err == nil:
-				t.Errorf("cascade deletion failed: SparkApplication %s still exists after deleting parent", lastRunName)
-				t.Logf("Manually cleaning up leaked SparkApplication %s", lastRunName)
-				tc.DeleteResource(
-					WithMinimalObject(gvk.SparkApplication, types.NamespacedName{Name: lastRunName, Namespace: namespace}),
-					WithIgnoreNotFound(true),
-				)
-			case k8serr.IsNotFound(err):
-				t.Logf("Cascade deletion verified: SparkApplication %s was deleted with parent", lastRunName)
-			default:
-				t.Errorf("failed to check SparkApplication %s after cascade deletion: %v", lastRunName, err)
-			}
+			tc.EnsureResourceGone(
+				WithMinimalObject(gvk.SparkApplication, types.NamespacedName{Name: lastRunName, Namespace: namespace}),
+				WithCustomErrorMsg("cascade deletion failed: SparkApplication %s still exists after deleting parent", lastRunName),
+			)
 		}
 	}()
 

--- a/tests/e2e/sparkoperator_test.go
+++ b/tests/e2e/sparkoperator_test.go
@@ -1,6 +1,7 @@
 package e2e_test
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/rs/xid"
@@ -11,6 +12,11 @@ import (
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/api/components/v1alpha1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/matchers/jq"
+)
+
+const (
+	sparkVersion = "4.0.1"
+	sparkImage   = "quay.io/opendatahub/data-processing:Spark-v" + sparkVersion
 )
 
 type SparkOperatorTestCtx struct {
@@ -119,7 +125,7 @@ func (tc *SparkOperatorTestCtx) ValidateScheduledSparkPiWorkload(t *testing.T) {
 			jq.Match(`.status.lastRunName != null and .status.lastRunName != ""`),
 		),
 		WithCustomErrorMsg("ScheduledSparkApplication %s did not schedule a run", scheduledSparkAppName),
-		WithEventuallyTimeout(tc.TestTimeouts.longEventuallyTimeout),
+		WithEventuallyTimeout(tc.TestTimeouts.defaultEventuallyTimeout),
 		WithEventuallyPollingInterval(tc.TestTimeouts.defaultEventuallyPollInterval),
 	)
 
@@ -130,17 +136,20 @@ func (tc *SparkOperatorTestCtx) ValidateScheduledSparkPiWorkload(t *testing.T) {
 
 	t.Logf("ScheduledSparkApplication %s created SparkApplication: %s", scheduledSparkAppName, lastRunName)
 
-	// Wait for the spawned SparkApplication to complete
-	t.Logf("Waiting for SparkApplication %s to complete", lastRunName)
-	tc.EnsureResourceExists(
+	// Wait for the spawned SparkApplication to reach a terminal state
+	t.Logf("Waiting for SparkApplication %s to reach terminal state", lastRunName)
+	completedApp := tc.EnsureResourceExists(
 		WithMinimalObject(gvk.SparkApplication, types.NamespacedName{Name: lastRunName, Namespace: namespace}),
 		WithCondition(
-			jq.Match(`.status.applicationState.state == "COMPLETED"`),
+			jq.Match(`.status.applicationState.state == "COMPLETED" or .status.applicationState.state == "FAILED"`),
 		),
-		WithCustomErrorMsg("SparkApplication %s (created by ScheduledSparkApplication) did not complete successfully", lastRunName),
-		WithEventuallyTimeout(tc.TestTimeouts.longEventuallyTimeout),
+		WithCustomErrorMsg("SparkApplication %s (created by ScheduledSparkApplication) did not reach terminal state", lastRunName),
+		WithEventuallyTimeout(tc.TestTimeouts.defaultEventuallyTimeout),
 		WithEventuallyPollingInterval(tc.TestTimeouts.defaultEventuallyPollInterval),
 	)
+
+	state, _, _ := unstructured.NestedString(completedApp.Object, "status", "applicationState", "state")
+	require.Equal(t, "COMPLETED", state, "SparkApplication %s ended in %s state instead of COMPLETED", lastRunName, state)
 
 	t.Logf("ScheduledSparkApplication %s successfully scheduled and executed SparkApplication %s", scheduledSparkAppName, lastRunName)
 }
@@ -155,68 +164,70 @@ func (tc *SparkOperatorTestCtx) createSparkPiApplication(name, namespace string)
 				"name":      name,
 				"namespace": namespace,
 			},
-			"spec": map[string]any{
-				"type":                "Scala",
-				"mode":                "cluster",
-				"image":               "quay.io/opendatahub/data-processing:Spark-v4.0.1",
-				"imagePullPolicy":     "IfNotPresent",
-				"mainClass":           "org.apache.spark.examples.SparkPi",
-				"mainApplicationFile": "local:///opt/spark/examples/jars/spark-examples_2.13-4.0.1.jar",
-				"arguments":           []any{"1000"},
-				"sparkVersion":        "4.0.1",
-				"restartPolicy": map[string]any{
-					"type": "Never",
+			"spec": sparkPiSpec(),
+		},
+	}
+}
+
+func sparkPiSpec() map[string]any {
+	return map[string]any{
+		"type":                "Scala",
+		"mode":                "cluster",
+		"image":               sparkImage,
+		"imagePullPolicy":     "IfNotPresent",
+		"mainClass":           "org.apache.spark.examples.SparkPi",
+		"mainApplicationFile": fmt.Sprintf("local:///opt/spark/examples/jars/spark-examples_2.13-%s.jar", sparkVersion),
+		"arguments":           []any{"1000"},
+		"sparkVersion":        sparkVersion,
+		"restartPolicy": map[string]any{
+			"type": "Never",
+		},
+		"sparkConf": map[string]any{
+			"spark.driver.port":              "8080",
+			"spark.driver.blockManager.port": "8082",
+			"spark.blockManager.port":        "8081",
+			"spark.port.maxRetries":          "0",
+		},
+		"volumes": []any{
+			map[string]any{
+				"name":     "spark-work-dir",
+				"emptyDir": map[string]any{},
+			},
+		},
+		"driver": map[string]any{
+			"labels": map[string]any{
+				"version": sparkVersion,
+			},
+			"cores":           int64(1),
+			"coreLimit":       "1200m",
+			"memory":          "512m",
+			"serviceAccount":  "spark-operator-spark",
+			"securityContext": map[string]any{},
+			"volumeMounts": []any{
+				map[string]any{
+					"name":      "spark-work-dir",
+					"mountPath": "/opt/spark/work-dir",
 				},
-				"sparkConf": map[string]any{
-					"spark.driver.port":              "8080",
-					"spark.driver.blockManager.port": "8082",
-					"spark.blockManager.port":        "8081",
-					"spark.port.maxRetries":          "0",
-				},
-				// Volume for OpenShift compatibility - provides writable work directory
-				"volumes": []any{
-					map[string]any{
-						"name":     "spark-work-dir",
-						"emptyDir": map[string]any{},
-					},
-				},
-				"driver": map[string]any{
-					"labels": map[string]any{
-						"version": "4.0.1",
-					},
-					"cores":           int64(1),
-					"coreLimit":       "1200m",
-					"memory":          "512m",
-					"serviceAccount":  "spark-operator-spark",
-					"securityContext": map[string]any{},
-					"volumeMounts": []any{
-						map[string]any{
-							"name":      "spark-work-dir",
-							"mountPath": "/opt/spark/work-dir",
-						},
-					},
-				},
-				"executor": map[string]any{
-					"labels": map[string]any{
-						"version": "4.0.1",
-					},
-					"instances":       int64(1),
-					"cores":           int64(1),
-					"memory":          "512m",
-					"securityContext": map[string]any{},
-					"volumeMounts": []any{
-						map[string]any{
-							"name":      "spark-work-dir",
-							"mountPath": "/opt/spark/work-dir",
-						},
-					},
+			},
+		},
+		"executor": map[string]any{
+			"labels": map[string]any{
+				"version": sparkVersion,
+			},
+			"instances":       int64(1),
+			"cores":           int64(1),
+			"memory":          "512m",
+			"securityContext": map[string]any{},
+			"volumeMounts": []any{
+				map[string]any{
+					"name":      "spark-work-dir",
+					"mountPath": "/opt/spark/work-dir",
 				},
 			},
 		},
 	}
 }
 
-// createScheduledSparkPiApplication creates a ScheduledSparkApplication CR for spark-pi test.
 func (tc *SparkOperatorTestCtx) createScheduledSparkPiApplication(name, namespace string) *unstructured.Unstructured {
 	return &unstructured.Unstructured{
 		Object: map[string]any{
@@ -227,71 +238,11 @@ func (tc *SparkOperatorTestCtx) createScheduledSparkPiApplication(name, namespac
 				"namespace": namespace,
 			},
 			"spec": map[string]any{
-				// Run immediately and then every 5 minutes
-				"schedule": "@every 1m",
-				// Don't allow concurrent runs
-				"concurrencyPolicy": "Forbid",
-				// Keep only the last successful and failed run
+				"schedule":                  "@every 30s",
+				"concurrencyPolicy":         "Forbid",
 				"successfulRunHistoryLimit": int64(1),
 				"failedRunHistoryLimit":     int64(1),
-				// SparkApplication template - same as the regular SparkPi test
-				"template": map[string]any{
-					"type":                "Scala",
-					"mode":                "cluster",
-					"image":               "quay.io/opendatahub/data-processing:Spark-v4.0.1",
-					"imagePullPolicy":     "IfNotPresent",
-					"mainClass":           "org.apache.spark.examples.SparkPi",
-					"mainApplicationFile": "local:///opt/spark/examples/jars/spark-examples_2.13-4.0.1.jar",
-					"arguments":           []any{"1000"},
-					"sparkVersion":        "4.0.1",
-					"restartPolicy": map[string]any{
-						"type": "Never",
-					},
-					"sparkConf": map[string]any{
-						"spark.driver.port":              "8080",
-						"spark.driver.blockManager.port": "8082",
-						"spark.blockManager.port":        "8081",
-						"spark.port.maxRetries":          "0",
-					},
-					// Volume for OpenShift compatibility - provides writable work directory
-					"volumes": []any{
-						map[string]any{
-							"name":     "spark-work-dir",
-							"emptyDir": map[string]any{},
-						},
-					},
-					"driver": map[string]any{
-						"labels": map[string]any{
-							"version": "4.0.1",
-						},
-						"cores":           int64(1),
-						"coreLimit":       "1200m",
-						"memory":          "512m",
-						"serviceAccount":  "spark-operator-spark",
-						"securityContext": map[string]any{},
-						"volumeMounts": []any{
-							map[string]any{
-								"name":      "spark-work-dir",
-								"mountPath": "/opt/spark/work-dir",
-							},
-						},
-					},
-					"executor": map[string]any{
-						"labels": map[string]any{
-							"version": "4.0.1",
-						},
-						"instances":       int64(1),
-						"cores":           int64(1),
-						"memory":          "512m",
-						"securityContext": map[string]any{},
-						"volumeMounts": []any{
-							map[string]any{
-								"name":      "spark-work-dir",
-								"mountPath": "/opt/spark/work-dir",
-							},
-						},
-					},
-				},
+				"template":                  sparkPiSpec(),
 			},
 		},
 	}

--- a/tests/e2e/sparkoperator_test.go
+++ b/tests/e2e/sparkoperator_test.go
@@ -113,7 +113,7 @@ func (tc *SparkOperatorTestCtx) ValidateScheduledSparkPiWorkload(t *testing.T) {
 
 	t.Logf("Waiting for ScheduledSparkApplication %s to schedule a run", scheduledSparkAppName)
 	// Wait for the ScheduledSparkApplication to populate status with lastRunName
-	tc.EnsureResourceExists(
+	scheduledApp := tc.EnsureResourceExists(
 		WithMinimalObject(gvk.ScheduledSparkApplication, types.NamespacedName{Name: scheduledSparkAppName, Namespace: namespace}),
 		WithCondition(
 			jq.Match(`.status.lastRunName != null and .status.lastRunName != ""`),
@@ -124,21 +124,9 @@ func (tc *SparkOperatorTestCtx) ValidateScheduledSparkPiWorkload(t *testing.T) {
 	)
 
 	// Get the actual SparkApplication name that was created
-	var lastRunName string
-	tc.GetResource(
-		WithMinimalObject(gvk.ScheduledSparkApplication, types.NamespacedName{Name: scheduledSparkAppName, Namespace: namespace}),
-		WithResult(func(obj *unstructured.Unstructured) error {
-			name, found, err := unstructured.NestedString(obj.Object, "status", "lastRunName")
-			if err != nil {
-				return err
-			}
-			if !found {
-				return nil
-			}
-			lastRunName = name
-			return nil
-		}),
-	)
+	lastRunName, found, err := unstructured.NestedString(scheduledApp.Object, "status", "lastRunName")
+	require.NoError(t, err, "Failed to extract lastRunName from ScheduledSparkApplication status")
+	require.True(t, found, "lastRunName not found in ScheduledSparkApplication status")
 
 	t.Logf("ScheduledSparkApplication %s created SparkApplication: %s", scheduledSparkAppName, lastRunName)
 


### PR DESCRIPTION
Adds validation tests for ScheduledSparkApplication resource which enables running Spark applications on a cron schedule. The test validates that a scheduled job is created and successfully executes a SparkPi workload.

<!---
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully
- [ ] New RELATED_IMAGE mappings are already listed in ODH-Build-Config and RHOAI-Build-Config, and links are included in PR description

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [ ] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for scheduled Spark applications, enabling periodic Spark workloads with configurable schedule, concurrency policy, and run history limits.

* **Tests**
  * Added end-to-end tests that create scheduled Spark workloads, verify scheduled runs are created and reach successful completion, and ensure proper cleanup after execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->