### PR TITLE
test: reduce unit test execution time by sharing envtest instances

### DIFF
--- a/internal/controller/cloudmanager/azure/azurekubernetesengine_controller_test.go
+++ b/internal/controller/cloudmanager/azure/azurekubernetesengine_controller_test.go
@@ -10,7 +10,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -33,27 +32,8 @@ import (
 
 const nsCertManagerOperator = "cert-manager-operator"
 
-// listCertManagerDeployments returns the Deployments with the InfrastructurePartOf
-// label in the cert-manager operator namespace.
-func listCertManagerDeployments(wt *testf.WithT) ([]unstructured.Unstructured, error) {
-	list := &unstructured.UnstructuredList{}
-	list.SetGroupVersionKind(gvk.Deployment.GroupVersion().WithKind(gvk.Deployment.Kind + "List"))
-
-	if err := wt.Client().List(wt.Context(), list,
-		client.InNamespace(nsCertManagerOperator),
-		client.MatchingLabels{
-			labels.InfrastructurePartOf: labels.NormalizePartOfValue(ccmv1alpha1.AzureKubernetesEngineKind),
-		},
-	); err != nil {
-		return nil, err
-	}
-
-	return list.Items, nil
-}
-
 func hasCertManagerDeployments(wt *testf.WithT) bool {
-	items, err := listCertManagerDeployments(wt)
-	return err == nil && len(items) > 0
+	return ccmtest.HasInfraDeployments(wt, nsCertManagerOperator, ccmv1alpha1.AzureKubernetesEngineKind)
 }
 
 var azureCfg = ccmtest.ControllerTestConfig{
@@ -185,10 +165,8 @@ func TestAzureKubernetesEngineGC(t *testing.T) {
 		wt.Expect(wt.Client().Update(wt.Context(), ake)).To(Succeed())
 
 		wt.Eventually(func() bool {
-			list, err := listCertManagerDeployments(wt)
-			if err != nil {
-				return false
-			}
+			list, err := ccmtest.ListInfraDeployments(wt, nsCertManagerOperator, ccmv1alpha1.AzureKubernetesEngineKind)
+			wt.Expect(err).NotTo(HaveOccurred())
 			if len(list) == 0 {
 				return true
 			}

--- a/internal/controller/cloudmanager/coreweave/coreweavekubernetesengine_controller_test.go
+++ b/internal/controller/cloudmanager/coreweave/coreweavekubernetesengine_controller_test.go
@@ -10,7 +10,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -33,27 +32,8 @@ import (
 
 const nsCertManagerOperator = "cert-manager-operator"
 
-// listCertManagerDeployments returns the Deployments with the InfrastructurePartOf
-// label in the cert-manager operator namespace.
-func listCertManagerDeployments(wt *testf.WithT) ([]unstructured.Unstructured, error) {
-	list := &unstructured.UnstructuredList{}
-	list.SetGroupVersionKind(gvk.Deployment.GroupVersion().WithKind(gvk.Deployment.Kind + "List"))
-
-	if err := wt.Client().List(wt.Context(), list,
-		client.InNamespace(nsCertManagerOperator),
-		client.MatchingLabels{
-			labels.InfrastructurePartOf: labels.NormalizePartOfValue(ccmv1alpha1.CoreWeaveKubernetesEngineKind),
-		},
-	); err != nil {
-		return nil, err
-	}
-
-	return list.Items, nil
-}
-
 func hasCertManagerDeployments(wt *testf.WithT) bool {
-	items, err := listCertManagerDeployments(wt)
-	return err == nil && len(items) > 0
+	return ccmtest.HasInfraDeployments(wt, nsCertManagerOperator, ccmv1alpha1.CoreWeaveKubernetesEngineKind)
 }
 
 var coreweaveCfg = ccmtest.ControllerTestConfig{
@@ -238,10 +218,8 @@ func TestCoreWeaveKubernetesEngineGC(t *testing.T) {
 		wt.Expect(wt.Client().Update(wt.Context(), cke)).To(Succeed())
 
 		wt.Eventually(func() bool {
-			list, err := listCertManagerDeployments(wt)
-			if err != nil {
-				return false
-			}
+			list, err := ccmtest.ListInfraDeployments(wt, nsCertManagerOperator, ccmv1alpha1.CoreWeaveKubernetesEngineKind)
+			wt.Expect(err).NotTo(HaveOccurred())
 			if len(list) == 0 {
 				return true
 			}

--- a/internal/controller/services/certconfigmapgenerator/certconfigmapgenerator_test.go
+++ b/internal/controller/services/certconfigmapgenerator/certconfigmapgenerator_test.go
@@ -35,7 +35,8 @@ func G(t *testing.T) *WithT {
 
 	g := NewWithT(t)
 	g.DurationBundle.EventuallyTimeout = 30 * time.Second
-	g.DurationBundle.ConsistentlyDuration = 15 * time.Second
+	g.DurationBundle.ConsistentlyDuration = 5 * time.Second
+	g.DurationBundle.ConsistentlyPollingInterval = 200 * time.Millisecond
 
 	return g
 }

--- a/internal/webhook/envtestutil/envtestutil.go
+++ b/internal/webhook/envtestutil/envtestutil.go
@@ -103,13 +103,18 @@ func SetupEnvAndClient(
 ) (context.Context, *envt.EnvT, func()) {
 	t.Helper()
 
-	testCtx, testCancel := context.WithTimeout(t.Context(), timeout)
+	// setupCtx is used only for the setup retry loop and WaitForWebhookServer;
+	// it does not leak into the returned context or the manager context so that
+	// tests are not bound by the setup timeout.
+	setupCtx, setupCancel := context.WithTimeout(t.Context(), timeout)
+	defer setupCancel()
+
 	backoff := 500 * time.Millisecond
 
-	// keep trying until the test context is cancelled or the environment is setup
+	// keep trying until the setup context is cancelled or the environment is setup
 	for attempt := 1; ; attempt++ {
-		if testCtx.Err() != nil {
-			t.Fatalf("test context cancelled or timed out while trying to setup test environment: %+v", testCtx.Err())
+		if setupCtx.Err() != nil {
+			t.Fatalf("test context cancelled or timed out while trying to setup test environment: %+v", setupCtx.Err())
 		}
 
 		env, err := envt.New(
@@ -117,12 +122,12 @@ func SetupEnvAndClient(
 			envt.WithRegisterControllers(registerControllers...),
 		)
 		if err != nil {
-			testCancel()
 			t.Fatalf("failed to start envtest: %+v", err)
 		}
 
-		// new shared context for the manager and the wait function
-		mgrCtx, mgrCancel := context.WithCancel(testCtx)
+		// mgrCtx is derived from t.Context() (no deadline) so the manager and
+		// tests are not constrained by the setup timeout.
+		mgrCtx, mgrCancel := context.WithCancel(t.Context())
 
 		// try to start the manager in the background
 		go func() {
@@ -134,9 +139,18 @@ func SetupEnvAndClient(
 			}
 		}()
 
+		// waitCtx combines the setup deadline with the manager lifetime:
+		// it expires if either the setup timeout elapses or the manager stops.
+		waitCtx, waitCancel := context.WithCancel(setupCtx)
+		go func() {
+			<-mgrCtx.Done()
+			waitCancel()
+		}()
+
 		// sync wait for the webhook server to be ready
-		if err := env.WaitForWebhookServer(mgrCtx); err != nil {
+		if err := env.WaitForWebhookServer(waitCtx); err != nil {
 			t.Logf("failed to wait for webhook server to be ready: %v", err)
+			waitCancel()
 			mgrCancel()
 
 			if err := env.Stop(); err != nil {
@@ -148,6 +162,7 @@ func SetupEnvAndClient(
 			time.Sleep(backoff)
 			continue
 		}
+		waitCancel()
 
 		// webhook server is ready
 		teardown := func() {
@@ -155,9 +170,8 @@ func SetupEnvAndClient(
 			if err := env.Stop(); err != nil {
 				t.Logf("failed to stop envtest: %v", err)
 			}
-			testCancel()
 		}
-		return testCtx, env, teardown
+		return t.Context(), env, teardown
 	}
 }
 
@@ -200,6 +214,28 @@ func SetupEnvAndClientWithCRDs(
 	}
 
 	return ctx, env, teardown
+}
+
+// SetupSharedEnvForSubtests creates a single envtest environment with webhook support and CRDs
+// that is shared across all subtests within a test function. This avoids the overhead of
+// creating separate envtest instances for each table-driven subtest.
+// Cleanup is handled automatically via t.Cleanup.
+//
+// Each subtest should create its own unique namespace (e.g., via xid.New()) for resource isolation.
+// Only use this when subtests operate exclusively on namespace-scoped resources.
+func SetupSharedEnvForSubtests(
+	t *testing.T,
+	registerWebhooks []envt.RegisterWebhooksFn,
+	registerControllers []envt.RegisterControllersFn,
+	timeout time.Duration,
+	opts ...CRDSetupOption,
+) (context.Context, *envt.EnvT) {
+	t.Helper()
+
+	ctx, env, teardown := SetupEnvAndClientWithCRDs(t, registerWebhooks, registerControllers, timeout, opts...)
+	t.Cleanup(teardown)
+
+	return ctx, env
 }
 
 // =============================================================================

--- a/internal/webhook/hardwareprofile/integration_test.go
+++ b/internal/webhook/hardwareprofile/integration_test.go
@@ -604,19 +604,18 @@ func TestHardwareProfileWebhook_Notebook(t *testing.T) {
 		},
 	}
 
+	ctx, env := envtestutil.SetupSharedEnvForSubtests(
+		t,
+		[]envt.RegisterWebhooksFn{envtestutil.RegisterWebhooks},
+		[]envt.RegisterControllersFn{},
+		envtestutil.DefaultWebhookTimeout,
+		envtestutil.WithNotebook(),
+	)
+
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			g := NewWithT(t)
-
-			ctx, env, teardown := envtestutil.SetupEnvAndClientWithCRDs(
-				t,
-				[]envt.RegisterWebhooksFn{envtestutil.RegisterWebhooks},
-				[]envt.RegisterControllersFn{},
-				envtestutil.DefaultWebhookTimeout,
-				envtestutil.WithNotebook(),
-			)
-			defer teardown()
 
 			// Create test namespace
 			ns := fmt.Sprintf("test-ns-%s", xid.New().String())
@@ -624,9 +623,6 @@ func TestHardwareProfileWebhook_Notebook(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: ns},
 			}
 			g.Expect(env.Client().Create(ctx, testNamespace)).To(Succeed())
-
-			// Add HardwareProfile types to scheme for client operations
-			g.Expect(infrav1.AddToScheme(env.Scheme())).To(Succeed())
 
 			// Run the specific test case
 			tc.test(g, ctx, env.Client(), ns)
@@ -697,19 +693,18 @@ func TestHardwareProfileWebhook_LlmInferenceService(t *testing.T) {
 			},
 		},
 	}
+	ctx, env := envtestutil.SetupSharedEnvForSubtests(
+		t,
+		[]envt.RegisterWebhooksFn{envtestutil.RegisterWebhooks},
+		[]envt.RegisterControllersFn{},
+		envtestutil.DefaultWebhookTimeout,
+		envtestutil.WithLlmInferenceService(),
+	)
+
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			g := NewWithT(t)
-
-			ctx, env, teardown := envtestutil.SetupEnvAndClientWithCRDs(
-				t,
-				[]envt.RegisterWebhooksFn{envtestutil.RegisterWebhooks},
-				[]envt.RegisterControllersFn{},
-				envtestutil.DefaultWebhookTimeout,
-				envtestutil.WithLlmInferenceService(),
-			)
-			defer teardown()
 
 			// Create test namespace
 			ns := fmt.Sprintf("test-ns-%s", xid.New().String())
@@ -717,9 +712,6 @@ func TestHardwareProfileWebhook_LlmInferenceService(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: ns},
 			}
 			g.Expect(env.Client().Create(ctx, testNamespace)).To(Succeed())
-
-			// Add HardwareProfile types to scheme for client operations
-			g.Expect(infrav1.AddToScheme(env.Scheme())).To(Succeed())
 
 			// Run the specific test case
 			tc.test(g, ctx, env.Client(), ns)
@@ -800,19 +792,18 @@ func TestHardwareProfileWebhook_InferenceService(t *testing.T) {
 			},
 		},
 	}
+	ctx, env := envtestutil.SetupSharedEnvForSubtests(
+		t,
+		[]envt.RegisterWebhooksFn{envtestutil.RegisterWebhooks},
+		[]envt.RegisterControllersFn{},
+		envtestutil.DefaultWebhookTimeout,
+		envtestutil.WithInferenceService(),
+	)
+
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			g := NewWithT(t)
-
-			ctx, env, teardown := envtestutil.SetupEnvAndClientWithCRDs(
-				t,
-				[]envt.RegisterWebhooksFn{envtestutil.RegisterWebhooks},
-				[]envt.RegisterControllersFn{},
-				envtestutil.DefaultWebhookTimeout,
-				envtestutil.WithInferenceService(),
-			)
-			defer teardown()
 
 			// Create test namespace
 			ns := fmt.Sprintf("test-ns-%s", xid.New().String())
@@ -820,9 +811,6 @@ func TestHardwareProfileWebhook_InferenceService(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: ns},
 			}
 			g.Expect(env.Client().Create(ctx, testNamespace)).To(Succeed())
-
-			// Add HardwareProfile types to scheme for client operations
-			g.Expect(infrav1.AddToScheme(env.Scheme())).To(Succeed())
 
 			// Run the specific test case
 			tc.test(g, ctx, env.Client(), ns)
@@ -896,19 +884,18 @@ func TestHardwareProfile_CRDValidation(t *testing.T) {
 		},
 	}
 
+	ctx, env := envtestutil.SetupSharedEnvForSubtests(
+		t,
+		[]envt.RegisterWebhooksFn{envtestutil.RegisterWebhooks},
+		[]envt.RegisterControllersFn{},
+		envtestutil.DefaultWebhookTimeout,
+		envtestutil.WithNotebook(),
+		envtestutil.WithInferenceService(),
+	)
+
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			g := NewWithT(t)
-
-			ctx, env, teardown := envtestutil.SetupEnvAndClientWithCRDs(
-				t,
-				[]envt.RegisterWebhooksFn{envtestutil.RegisterWebhooks},
-				[]envt.RegisterControllersFn{},
-				envtestutil.DefaultWebhookTimeout,
-				envtestutil.WithNotebook(),
-				envtestutil.WithInferenceService(),
-			)
-			t.Cleanup(teardown)
 
 			// Create test namespace
 			ns := fmt.Sprintf("test-ns-%s", xid.New().String())
@@ -916,9 +903,6 @@ func TestHardwareProfile_CRDValidation(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: ns},
 			}
 			g.Expect(env.Client().Create(ctx, testNamespace)).To(Succeed())
-
-			// Add HardwareProfile types to scheme for client operations
-			g.Expect(infrav1.AddToScheme(env.Scheme())).To(Succeed())
 
 			// Create hardware profile with test case specific options
 			hwp := envtestutil.NewHardwareProfile(fmt.Sprintf("test-hwp-%s", xid.New().String()), ns, tc.hwpOptions...)

--- a/internal/webhook/notebook/integration_test.go
+++ b/internal/webhook/notebook/integration_test.go
@@ -92,22 +92,20 @@ func TestNotebookWebhook_Integration(t *testing.T) {
 		},
 	}
 
+	ctx, env := envtestutil.SetupSharedEnvForSubtests(
+		t,
+		[]envt.RegisterWebhooksFn{
+			envtestutil.RegisterWebhooks,
+		},
+		[]envt.RegisterControllersFn{},
+		envtestutil.DefaultWebhookTimeout,
+		envtestutil.WithNotebook(),
+	)
+
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			g := NewWithT(t)
-
-			// Register both notebook webhook and hardware profile webhook to avoid missing webhook error
-			ctx, env, teardown := envtestutil.SetupEnvAndClientWithCRDs(
-				t,
-				[]envt.RegisterWebhooksFn{
-					envtestutil.RegisterWebhooks,
-				},
-				[]envt.RegisterControllersFn{},
-				envtestutil.DefaultWebhookTimeout,
-				envtestutil.WithNotebook(),
-			)
-			t.Cleanup(teardown)
 
 			k8sClient := env.Client()
 			ns := xid.New().String()

--- a/pkg/controller/actions/deploy/action_deploy_test.go
+++ b/pkg/controller/actions/deploy/action_deploy_test.go
@@ -396,15 +396,10 @@ func TestDeployDeOwn(t *testing.T) {
 	))
 }
 
-func setupManagedAnnotationTest(t *testing.T, managed string, replicas *int32, containers []corev1.Container) (client.Client, types.ReconciliationRequest, string) {
+func setupManagedAnnotationTest(t *testing.T, cl client.Client, managed string, replicas *int32, containers []corev1.Container) (types.ReconciliationRequest, string) {
 	t.Helper()
 	g := NewWithT(t)
 
-	et, err := envt.New()
-	g.Expect(err).NotTo(HaveOccurred())
-	t.Cleanup(func() { _ = et.Stop() })
-
-	cl := et.Client()
 	ns := xid.New().String()
 	g.Expect(cl.Create(t.Context(), &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}})).To(Succeed())
 
@@ -434,10 +429,18 @@ func setupManagedAnnotationTest(t *testing.T, managed string, replicas *int32, c
 		},
 	})).To(Succeed())
 
-	return cl, rr, ns
+	return rr, ns
 }
 
 func TestDeployWithManagedAnnotation(t *testing.T) {
+	g := NewWithT(t)
+
+	et, err := envt.New()
+	g.Expect(err).NotTo(HaveOccurred())
+	t.Cleanup(func() { _ = et.Stop() })
+
+	cl := et.Client()
+
 	tests := []struct {
 		name        string
 		mode        deploy.Mode
@@ -458,7 +461,7 @@ func TestDeployWithManagedAnnotation(t *testing.T) {
 			ctx := t.Context()
 
 			replicas := int32(2)
-			cl, rr, ns := setupManagedAnnotationTest(t, tt.managed, &replicas,
+			rr, ns := setupManagedAnnotationTest(t, cl, tt.managed, &replicas,
 				[]corev1.Container{{Name: "test", Image: "test:v1"}})
 
 			action := deploy.NewAction(deploy.WithMode(tt.mode))
@@ -482,7 +485,7 @@ func TestDeployWithManagedAnnotation(t *testing.T) {
 		ctx := t.Context()
 
 		replicas := int32(1)
-		cl, rr, ns := setupManagedAnnotationTest(t, "true", &replicas,
+		rr, ns := setupManagedAnnotationTest(t, cl, "true", &replicas,
 			[]corev1.Container{{
 				Name:  "test",
 				Image: "test:v1",

--- a/pkg/controller/actions/gc/action_gc_test.go
+++ b/pkg/controller/actions/gc/action_gc_test.go
@@ -2,7 +2,9 @@ package gc_test
 
 import (
 	"context"
+	"fmt"
 	"maps"
+	"os"
 	"strconv"
 	"strings"
 	"testing"
@@ -39,24 +41,32 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-//nolint:gochecknoinits
-func init() {
+var sharedEnvTest *envt.EnvT
+
+func TestMain(m *testing.M) {
 	log.SetLogger(zap.New(zap.UseDevMode(true)))
+
+	var err error
+
+	sharedEnvTest, err = envt.New()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to start envtest: %v\n", err)
+		os.Exit(1)
+	}
+
+	code := m.Run()
+
+	if err := sharedEnvTest.Stop(); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to stop envtest: %v\n", err)
+	}
+
+	os.Exit(code)
 }
 
 //nolint:maintidx
 func TestGcAction(t *testing.T) {
-	g := NewWithT(t)
-
-	envTest, err := envt.New()
-	g.Expect(err).NotTo(HaveOccurred())
-
-	t.Cleanup(func() {
-		_ = envTest.Stop()
-	})
-
 	ctx := context.Background()
-	cli := envTest.Client()
+	cli := sharedEnvTest.Client()
 
 	tests := []struct {
 		name           string
@@ -189,9 +199,9 @@ func TestGcAction(t *testing.T) {
 				},
 				Generated: tt.generated,
 				Controller: mocks.NewMockController(func(m *mocks.MockController) {
-					m.On("GetClient").Return(envTest.Client())
-					m.On("GetDynamicClient").Return(envTest.DynamicClient())
-					m.On("GetDiscoveryClient").Return(envTest.DiscoveryClient())
+					m.On("GetClient").Return(sharedEnvTest.Client())
+					m.On("GetDynamicClient").Return(sharedEnvTest.DynamicClient())
+					m.On("GetDiscoveryClient").Return(sharedEnvTest.DiscoveryClient())
 					m.On("Owns", mock.Anything).Return(false)
 				}),
 			}
@@ -313,18 +323,17 @@ func TestGcAction(t *testing.T) {
 
 			a := gc.NewAction(opts...)
 
-			err = a(ctx, &rr)
-			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(a(ctx, &rr)).NotTo(HaveOccurred())
 
-			err = cli.Get(ctx, ctrlCli.ObjectKeyFromObject(&l), &coordinationv1.Lease{})
-			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(cli.Get(ctx, ctrlCli.ObjectKeyFromObject(&l), &coordinationv1.Lease{})).
+				ToNot(HaveOccurred())
 
-			err = cli.Get(ctx, ctrlCli.ObjectKeyFromObject(&crd), &apiextensionsv1.CustomResourceDefinition{})
-			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(cli.Get(ctx, ctrlCli.ObjectKeyFromObject(&crd), &apiextensionsv1.CustomResourceDefinition{})).
+				ToNot(HaveOccurred())
 
 			if tt.matcher != nil {
-				err = cli.Get(ctx, ctrlCli.ObjectKeyFromObject(&cm), &corev1.ConfigMap{})
-				g.Expect(err).To(tt.matcher)
+				g.Expect(cli.Get(ctx, ctrlCli.ObjectKeyFromObject(&cm), &corev1.ConfigMap{})).
+					To(tt.matcher)
 			}
 
 			if tt.metricsMatcher != nil {
@@ -336,17 +345,8 @@ func TestGcAction(t *testing.T) {
 }
 
 func TestGcActionOwn(t *testing.T) {
-	g := NewWithT(t)
-
-	envTest, err := envt.New()
-	g.Expect(err).NotTo(HaveOccurred())
-
-	t.Cleanup(func() {
-		_ = envTest.Stop()
-	})
-
 	ctx := context.Background()
-	cli := envTest.Client()
+	cli := sharedEnvTest.Client()
 
 	tests := []struct {
 		name    string
@@ -408,9 +408,9 @@ func TestGcActionOwn(t *testing.T) {
 				},
 				Generated: true,
 				Controller: mocks.NewMockController(func(m *mocks.MockController) {
-					m.On("GetClient").Return(envTest.Client())
-					m.On("GetDynamicClient").Return(envTest.DynamicClient())
-					m.On("GetDiscoveryClient").Return(envTest.DiscoveryClient())
+					m.On("GetClient").Return(sharedEnvTest.Client())
+					m.On("GetDynamicClient").Return(sharedEnvTest.DynamicClient())
+					m.On("GetDiscoveryClient").Return(sharedEnvTest.DiscoveryClient())
 					m.On("Owns", mock.Anything).Return(false)
 				}),
 			}
@@ -463,12 +463,11 @@ func TestGcActionOwn(t *testing.T) {
 
 			a := gc.NewAction(opts...)
 
-			err = a(ctx, &rr)
-			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(a(ctx, &rr)).NotTo(HaveOccurred())
 
 			if tt.matcher != nil {
-				err = cli.Get(ctx, ctrlCli.ObjectKeyFromObject(&cm), &corev1.ConfigMap{})
-				g.Expect(err).To(tt.matcher)
+				g.Expect(cli.Get(ctx, ctrlCli.ObjectKeyFromObject(&cm), &corev1.ConfigMap{})).
+					To(tt.matcher)
 			}
 		})
 	}
@@ -477,15 +476,8 @@ func TestGcActionOwn(t *testing.T) {
 func TestGcActionCluster(t *testing.T) {
 	g := NewWithT(t)
 
-	envTest, err := envt.New()
-	g.Expect(err).NotTo(HaveOccurred())
-
-	t.Cleanup(func() {
-		_ = envTest.Stop()
-	})
-
 	ctx := context.Background()
-	cli := envTest.Client()
+	cli := sharedEnvTest.Client()
 	nsn := xid.New().String()
 
 	ns := corev1.Namespace{
@@ -516,9 +508,9 @@ func TestGcActionCluster(t *testing.T) {
 		},
 		Generated: true,
 		Controller: mocks.NewMockController(func(m *mocks.MockController) {
-			m.On("GetClient").Return(envTest.Client())
-			m.On("GetDynamicClient").Return(envTest.DynamicClient())
-			m.On("GetDiscoveryClient").Return(envTest.DiscoveryClient())
+			m.On("GetClient").Return(sharedEnvTest.Client())
+			m.On("GetDynamicClient").Return(sharedEnvTest.DynamicClient())
+			m.On("GetDiscoveryClient").Return(sharedEnvTest.DiscoveryClient())
 			m.On("Owns", mock.Anything).Return(false)
 		}),
 	}
@@ -561,6 +553,14 @@ func TestGcActionCluster(t *testing.T) {
 	cr2.Name = xid.New().String()
 	cr2.Annotations[annotations.PlatformVersion] = rr.Release.Version.String()
 
+	t.Cleanup(func() {
+		for _, obj := range []ctrlCli.Object{&cm1, &cm2, &cr1, &cr2} {
+			if err := cli.Delete(ctx, obj); err != nil && !k8serr.IsNotFound(err) {
+				t.Fatalf("failed to delete %s/%s: %v", obj.GetNamespace(), obj.GetName(), err)
+			}
+		}
+	})
+
 	g.Expect(controllerutil.SetOwnerReference(rr.Instance, &cm1, cli.Scheme())).
 		NotTo(HaveOccurred())
 
@@ -590,20 +590,19 @@ func TestGcActionCluster(t *testing.T) {
 	gc.DeletedTotal.Reset()
 	gc.DeletedTotal.WithLabelValues("dashboard").Add(0)
 
-	err = a(ctx, &rr)
-	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(a(ctx, &rr)).NotTo(HaveOccurred())
 
-	err = cli.Get(ctx, ctrlCli.ObjectKeyFromObject(&cm1), &corev1.ConfigMap{})
-	g.Expect(err).To(MatchError(k8serr.IsNotFound, "IsNotFound"))
+	g.Expect(cli.Get(ctx, ctrlCli.ObjectKeyFromObject(&cm1), &corev1.ConfigMap{})).
+		To(MatchError(k8serr.IsNotFound, "IsNotFound"))
 
-	err = cli.Get(ctx, ctrlCli.ObjectKeyFromObject(&cm2), &corev1.ConfigMap{})
-	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(cli.Get(ctx, ctrlCli.ObjectKeyFromObject(&cm2), &corev1.ConfigMap{})).
+		ToNot(HaveOccurred())
 
-	err = cli.Get(ctx, ctrlCli.ObjectKeyFromObject(&cr1), &rbacv1.ClusterRole{})
-	g.Expect(err).To(MatchError(k8serr.IsNotFound, "IsNotFound"))
+	g.Expect(cli.Get(ctx, ctrlCli.ObjectKeyFromObject(&cr1), &rbacv1.ClusterRole{})).
+		To(MatchError(k8serr.IsNotFound, "IsNotFound"))
 
-	err = cli.Get(ctx, ctrlCli.ObjectKeyFromObject(&cr2), &rbacv1.ClusterRole{})
-	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(cli.Get(ctx, ctrlCli.ObjectKeyFromObject(&cr2), &rbacv1.ClusterRole{})).
+		ToNot(HaveOccurred())
 
 	ct := testutil.ToFloat64(gc.DeletedTotal)
 	g.Expect(ct).Should(BeNumerically("==", 2))
@@ -612,15 +611,8 @@ func TestGcActionCluster(t *testing.T) {
 func TestGcActionOnce(t *testing.T) {
 	g := NewWithT(t)
 
-	envTest, err := envt.New()
-	g.Expect(err).NotTo(HaveOccurred())
-
-	t.Cleanup(func() {
-		_ = envTest.Stop()
-	})
-
 	ctx := context.Background()
-	cli := envTest.Client()
+	cli := sharedEnvTest.Client()
 	nsn := xid.New().String()
 
 	ns := corev1.Namespace{
@@ -651,9 +643,9 @@ func TestGcActionOnce(t *testing.T) {
 		},
 		Generated: true,
 		Controller: mocks.NewMockController(func(m *mocks.MockController) {
-			m.On("GetClient").Return(envTest.Client())
-			m.On("GetDynamicClient").Return(envTest.DynamicClient())
-			m.On("GetDiscoveryClient").Return(envTest.DiscoveryClient())
+			m.On("GetClient").Return(sharedEnvTest.Client())
+			m.On("GetDynamicClient").Return(sharedEnvTest.DynamicClient())
+			m.On("GetDiscoveryClient").Return(sharedEnvTest.DiscoveryClient())
 			m.On("Owns", mock.Anything).Return(false)
 		}),
 	}
@@ -694,8 +686,9 @@ func TestGcActionOnce(t *testing.T) {
 	gc.DeletedTotal.WithLabelValues("dashboard").Add(0)
 
 	g.Expect(a(ctx, &rr)).NotTo(HaveOccurred())
-	g.Expect(testutil.ToFloat64(gc.DeletedTotal)).Should(BeNumerically("==", 1))
+	deletedAfterFirstRun := testutil.ToFloat64(gc.DeletedTotal)
+	g.Expect(deletedAfterFirstRun).Should(BeNumerically("==", 1))
 
 	g.Expect(a(ctx, &rr)).NotTo(HaveOccurred())
-	g.Expect(testutil.ToFloat64(gc.DeletedTotal)).Should(BeNumerically("==", 1))
+	g.Expect(testutil.ToFloat64(gc.DeletedTotal)).Should(BeNumerically("==", deletedAfterFirstRun))
 }

--- a/pkg/utils/test/cloudmanager/helpers.go
+++ b/pkg/utils/test/cloudmanager/helpers.go
@@ -11,6 +11,7 @@ import (
 	"github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -22,6 +23,8 @@ import (
 
 	ccmcommon "github.com/opendatahub-io/opendatahub-operator/v2/api/cloudmanager/common"
 	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/cloudmanager/common"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/metadata/labels"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/operatorconfig"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/envt"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/testf"
@@ -169,6 +172,32 @@ func CreateCR(t *testing.T, wt *testf.WithT, cfg ControllerTestConfig, deps ccmc
 	obj := cfg.NewCR(deps)
 	wt.Expect(wt.Client().Create(wt.Context(), obj)).Should(gomega.Succeed())
 	envt.CleanupDelete(t, gomega.NewWithT(t), wt.Context(), wt.Client(), obj)
+}
+
+// ListInfraDeployments returns the Deployments with the InfrastructurePartOf
+// label matching the given infraLabel in the specified namespace.
+func ListInfraDeployments(wt *testf.WithT, namespace, infraLabel string) ([]unstructured.Unstructured, error) {
+	list := &unstructured.UnstructuredList{}
+	list.SetGroupVersionKind(gvk.Deployment.GroupVersion().WithKind(gvk.Deployment.Kind + "List"))
+
+	if err := wt.Client().List(wt.Context(), list,
+		client.InNamespace(namespace),
+		client.MatchingLabels{
+			labels.InfrastructurePartOf: labels.NormalizePartOfValue(infraLabel),
+		},
+	); err != nil {
+		return nil, err
+	}
+
+	return list.Items, nil
+}
+
+// HasInfraDeployments returns true if there are Deployments with the InfrastructurePartOf
+// label matching the given infraLabel in the specified namespace.
+func HasInfraDeployments(wt *testf.WithT, namespace, infraLabel string) bool {
+	items, err := ListInfraDeployments(wt, namespace, infraLabel)
+	wt.Expect(err).NotTo(gomega.HaveOccurred())
+	return len(items) > 0
 }
 
 // RunTestMain executes the common TestMain boilerplate for cloud controller integration tests.


### PR DESCRIPTION
<!---
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
- Reduce unit test execution time by ~275s (~40%) by sharing envtest API server instances across subtests instead of creating one per table-driven case
- Reduce `Consistently` timeout from 15s to 5s in CertConfigmap tests (controller reconciles instantly in envtest)
- Add `SetupSharedEnvForSubtests` helper in envtestutil and extract `ListInfraDeployments`/`HasInfraDeployments` to deduplicate cloud manager test helpers

### Before vs After results

| Test | Before | After | Savings |
|------|--------|-------|---------|
| TestCertConfigmapGeneratorReconciler | 185s | 65s | **~120s** |
| TestHardwareProfileWebhook_Notebook (9 subtests) | ~40s | 4s | **~36s** |
| TestNotebookWebhook_Integration (7 subtests) | ~50s | 4s | **~46s** |
| TestHardwareProfileWebhook_InferenceService (5 subtests) | ~30s | 4s | **~26s** |
| TestHardwareProfile_CRDValidation (5 subtests) | 30s | 6s | **~24s** |
| TestHardwareProfileWebhook_LlmInferenceService (4 subtests) | ~24s | 4s | **~20s** |
| TestDeployWithManagedAnnotation (5 subtests) | 17s | 4s | **~13s** |
| TestGcActionOwn | 26s | 0.3s | **~26s** |
| TestGcActionCluster | 25s | 0.1s | **~25s** |
| TestGcActionOnce | 27s | 0.1s | **~27s** |

## How Has This Been Tested?
- Ran `make unit-test` locally and verified all modified tests pass
- Compared test timings before and after changes

## Merge criteria

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully
- [ ] New RELATED_IMAGE mappings are already listed in ODH-Build-Config and RHOAI-Build-Config, and links are included in PR description

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->
Unit tests improvements, no code changed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added shared test helpers for listing/detecting infrastructure deployments and a shared env setup to reuse a single test environment across subtests and packages
  * Tightened polling/timing defaults for consistently checks; GC and integration tests now assert list operations succeed and verify deletion timestamps
  * Improved cleanup in GC tests to remove created resources reliably

* **Refactor**
  * Consolidated per-test setup and duplicate helpers to simplify and centralize test startup/teardown
<!-- end of auto-generated comment: release notes by coderabbit.ai -->