### PR TITLE
fix: health check used deployment in rhoai e2e

### DIFF
--- a/pkg/clusterhealth/operator.go
+++ b/pkg/clusterhealth/operator.go
@@ -101,9 +101,9 @@ func runOperatorSection(ctx context.Context, c client.Client, op OperatorConfig)
 	return out
 }
 
-// findOperatorDeploymentInNamespace lists deployments in the namespace and returns the one to use for health.
+// FindOperatorDeploymentInNamespace lists deployments in the namespace and returns the one to use for health.
 // Prefers a deployment whose name contains "operator"; otherwise returns the first.
-func findOperatorDeploymentInNamespace(ctx context.Context, c client.Client, namespace string) (*appsv1.Deployment, error) {
+func FindOperatorDeploymentInNamespace(ctx context.Context, c client.Client, namespace string) (*appsv1.Deployment, error) {
 	list := &appsv1.DeploymentList{}
 	if err := c.List(ctx, list, client.InNamespace(namespace)); err != nil {
 		return nil, err
@@ -126,7 +126,7 @@ func findOperatorDeploymentInNamespace(ctx context.Context, c client.Client, nam
 
 func runDependentOperatorCheck(ctx context.Context, c client.Client, name, namespace string) DependentOperatorResult {
 	out := DependentOperatorResult{Name: name}
-	deploy, err := findOperatorDeploymentInNamespace(ctx, c, namespace)
+	deploy, err := FindOperatorDeploymentInNamespace(ctx, c, namespace)
 	if err != nil {
 		if k8serr.IsForbidden(err) {
 			out.Error = "list deployments: permission denied"

--- a/tests/e2e/debug_utils_test.go
+++ b/tests/e2e/debug_utils_test.go
@@ -529,19 +529,25 @@ func getDSCI(ctx context.Context) *unstructured.Unstructured {
 }
 
 func getControllerDeploymentName(ctx context.Context) string {
-	defaultControllerDeploymentName := controllerDeploymentODH
+	// First try to detect platform from the DSCI status.
 	dsci := getDSCI(ctx)
-	if dsci == nil {
-		return defaultControllerDeploymentName
+	if dsci != nil {
+		platform, ok, err := unstructured.NestedString(dsci.Object, "status", "release", "name")
+		if err == nil && ok {
+			return getControllerDeploymentNameByPlatform(common.Platform(platform))
+		}
+		log.Printf("Failed to get platform from DSCI (err=%v, ok=%v), falling back to deployment probe", err, ok)
 	}
-	platform, ok, err := unstructured.NestedString(dsci.Object, "status", "release", "name")
-	if err != nil {
-		log.Printf("Failed to get platform from DSCI: %v", err)
-		return defaultControllerDeploymentName
+
+	// Fall back to discovering the operator deployment in the namespace.
+	// This is needed during preflight health checks when the DSCI may not exist yet.
+	if globalDebugClient != nil {
+		deploy, err := clusterhealth.FindOperatorDeploymentInNamespace(ctx, globalDebugClient, testOpts.operatorNamespace)
+		if err == nil && deploy != nil {
+			return deploy.Name
+		}
+		log.Printf("Failed to discover operator deployment in namespace %s: %v", testOpts.operatorNamespace, err)
 	}
-	if !ok {
-		log.Printf("Failed to get platform from DSCI: platform not found")
-		return defaultControllerDeploymentName
-	}
-	return getControllerDeploymentNameByPlatform(common.Platform(platform))
+
+	return controllerDeploymentODH
 }


### PR DESCRIPTION
<!---
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
In rhoai e2e, after the first test failure, test fails with:

```
No DSCI instance found
CIRCUIT BREAKER TRIPPED: Pre-flight health check failed: [operator deployment not found: deployments.apps "opendatahub-operator-controller-manager" not found]
```

as in [this run](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/opendatahub-io_opendatahub-operator/3423/pull-ci-opendatahub-io-opendatahub-operator-main-opendatahub-operator-rhoai-e2e/2044103567635124224).

To resolve this, in case DSCI does not exists, the health check now find operator deployment dynamically searching in the operator namespace.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully
- [ ] New RELATED_IMAGE mappings are already listed in ODH-Build-Config and RHOAI-Build-Config, and links are included in PR description

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [ ] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal deployment discovery mechanism to enhance cluster health validation with multiple fallback approaches for retrieving operator deployment information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->