### PR TITLE
test(e2e): add monitoring ownerRef and resourceVersion stability tests

### DIFF
--- a/tests/e2e/monitoring_test.go
+++ b/tests/e2e/monitoring_test.go
@@ -147,6 +147,8 @@ func monitoringTestSuite(t *testing.T) {
 		t.Run("Test Metrics Replicas Configuration", monitoringServiceCtx.ValidateMonitoringStackCRMetricsReplicasUpdate)
 		t.Run("Test Prometheus rules lifecycle", monitoringServiceCtx.ValidatePrometheusRulesLifecycle)
 		t.Run("Test Prometheus Self ServiceMonitor TLS Fix", monitoringServiceCtx.ValidatePrometheusSelfServiceMonitorTLSFix)
+		t.Run("Test ownerReference consistency over time", monitoringServiceCtx.ValidateOwnerReferenceConsistency)
+		t.Run("Test resourceVersion stability after reconciliation", monitoringServiceCtx.ValidateResourceVersionStability)
 	})
 
 	// ========================================================================
@@ -1823,6 +1825,133 @@ func (tc *MonitoringTestCtx) ValidatePrometheusSelfServiceMonitorTLSFix(t *testi
 	)
 
 	tc.resetMonitoringConfigToManaged()
+}
+
+// ValidateOwnerReferenceConsistency verifies that ownerReferences on monitoring resources
+// remain stable over time — exactly 1 reference, pointing to the Monitoring CR, with controller=true.
+// This is a regression guard for RHOAIENG-37563 where conflicting ownerReferences between
+// templates and SetControllerReference() caused SSA diffs, triggering infinite reconciliation loops.
+func (tc *MonitoringTestCtx) ValidateOwnerReferenceConsistency(t *testing.T) {
+	t.Helper()
+
+	// Ensure metrics are configured so that monitoring resources are deployed.
+	tc.updateMonitoringConfig(
+		withManagementState(operatorv1.Managed),
+		tc.withMetricsConfig(),
+	)
+
+	// Wait for the Monitoring CR to be ready with MonitoringStack available.
+	tc.EnsureResourceExists(
+		WithMinimalObject(gvk.Monitoring, types.NamespacedName{Name: MonitoringCRName}),
+		WithCondition(And(
+			jq.Match(`.spec.metrics != null`),
+			jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, status.ConditionTypeReady, metav1.ConditionTrue),
+			jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, status.ConditionMonitoringStackAvailable, metav1.ConditionTrue),
+		)),
+		WithCustomErrorMsg("Monitoring resource should be ready before checking ownerReference consistency"),
+	)
+
+	// ownerRefStableCondition extends the existing monitoringOwnerReferencesCondition
+	// with a controller=true check — the field set by SetControllerReference().
+	ownerRefStableCondition := And(
+		monitoringOwnerReferencesCondition,
+		jq.Match(`.metadata.ownerReferences[0].controller == true`),
+	)
+
+	// Verify ownerReferences remain consistent over a sustained observation window
+	// across multiple resource types that were affected by the RHOAIENG-37563 bug.
+	type resource struct {
+		gvk  schema.GroupVersionKind
+		name string
+		ns   string
+		desc string
+	}
+
+	resources := []resource{
+		{gvk.MonitoringStack, MonitoringStackName, tc.MonitoringNamespace, "MonitoringStack"},
+		{gvk.ClusterRoleBinding, "data-science-monitoringstack-alertmanager-prometheus-metrics-reader", "", "alertmanager ClusterRoleBinding"},
+		{gvk.Service, "data-science-collector-prometheus", tc.MonitoringNamespace, "collector prometheus Service"},
+		{gvk.ConfigMap, "prometheus-web-tls-ca", tc.MonitoringNamespace, "prometheus TLS CA ConfigMap"},
+	}
+
+	for _, r := range resources {
+		tc.EnsureResourceExistsConsistently(
+			WithMinimalObject(r.gvk, types.NamespacedName{Name: r.name, Namespace: r.ns}),
+			WithCondition(ownerRefStableCondition),
+			WithConsistentlyDuration(1*time.Minute),
+			WithConsistentlyPollingInterval(5*time.Second),
+			WithCustomErrorMsg(
+				"%s ownerReferences should remain stable (exactly 1, controller=true, owned by Monitoring CR)", r.desc,
+			),
+		)
+	}
+}
+
+// ValidateResourceVersionStability verifies that resourceVersion on monitoring resources
+// does not increment after the initial deployment settles. A changing resourceVersion
+// indicates the controller is re-applying unchanged resources — the exact symptom of
+// the infinite reconciliation loop fixed in RHOAIENG-37563.
+func (tc *MonitoringTestCtx) ValidateResourceVersionStability(t *testing.T) {
+	t.Helper()
+
+	g := NewWithT(t)
+
+	// Ensure metrics are configured so that monitoring resources are deployed.
+	tc.updateMonitoringConfig(
+		withManagementState(operatorv1.Managed),
+		tc.withMetricsConfig(),
+	)
+
+	// Wait for the Monitoring CR to be ready with MonitoringStack available.
+	tc.EnsureResourceExists(
+		WithMinimalObject(gvk.Monitoring, types.NamespacedName{Name: MonitoringCRName}),
+		WithCondition(And(
+			jq.Match(`.spec.metrics != null`),
+			jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, status.ConditionTypeReady, metav1.ConditionTrue),
+			jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, status.ConditionMonitoringStackAvailable, metav1.ConditionTrue),
+		)),
+		WithCustomErrorMsg("Monitoring resource should be ready before checking resourceVersion stability"),
+	)
+
+	type resource struct {
+		gvk  schema.GroupVersionKind
+		name string
+		ns   string
+		desc string
+	}
+
+	resources := []resource{
+		{gvk.ClusterRoleBinding, "data-science-monitoringstack-alertmanager-prometheus-metrics-reader", "", "alertmanager ClusterRoleBinding"},
+		{gvk.ClusterRoleBinding, "generate-processors-collector-rolebinding", "", "collector ClusterRoleBinding"},
+		{gvk.Service, "data-science-collector-prometheus", tc.MonitoringNamespace, "collector prometheus Service"},
+		{gvk.ConfigMap, "prometheus-web-tls-ca", tc.MonitoringNamespace, "prometheus TLS CA ConfigMap"},
+	}
+
+	// Capture the resourceVersion for each resource after deployment has settled.
+	initialVersions := make(map[string]string, len(resources))
+	for _, r := range resources {
+		u := tc.FetchResource(
+			WithMinimalObject(r.gvk, types.NamespacedName{Name: r.name, Namespace: r.ns}),
+		)
+		require.NotNil(t, u, "%s should exist", r.desc)
+		initialVersions[r.name] = u.GetResourceVersion()
+	}
+
+	// Assert that resourceVersion does not change over the observation window.
+	// Any increment means the controller is re-applying unchanged resources.
+	g.Consistently(func(g Gomega) {
+		for _, r := range resources {
+			u := tc.FetchResource(
+				WithMinimalObject(r.gvk, types.NamespacedName{Name: r.name, Namespace: r.ns}),
+			)
+			g.Expect(u).NotTo(BeNil(), "%s should still exist", r.desc)
+			g.Expect(u.GetResourceVersion()).To(
+				Equal(initialVersions[r.name]),
+				"%s resourceVersion changed from %s — controller is re-applying unchanged resources (possible reconciliation loop)",
+				r.desc, initialVersions[r.name],
+			)
+		}
+	}).WithTimeout(1 * time.Minute).WithPolling(5 * time.Second).Should(Succeed())
 }
 
 // ValidatePersesDatasourceCreationWithTraces tests that Perses datasource is created when traces are configured.

--- a/tests/e2e/monitoring_test.go
+++ b/tests/e2e/monitoring_test.go
@@ -1834,6 +1834,8 @@ func (tc *MonitoringTestCtx) ValidatePrometheusSelfServiceMonitorTLSFix(t *testi
 func (tc *MonitoringTestCtx) ValidateOwnerReferenceConsistency(t *testing.T) {
 	t.Helper()
 
+	g := NewWithT(t)
+
 	// Ensure metrics are configured so that monitoring resources are deployed.
 	tc.updateMonitoringConfig(
 		withManagementState(operatorv1.Managed),
@@ -1874,17 +1876,28 @@ func (tc *MonitoringTestCtx) ValidateOwnerReferenceConsistency(t *testing.T) {
 		{gvk.ConfigMap, "prometheus-web-tls-ca", tc.MonitoringNamespace, "prometheus TLS CA ConfigMap"},
 	}
 
+	// Ensure all target resources exist before starting the stability window.
 	for _, r := range resources {
-		tc.EnsureResourceExistsConsistently(
+		tc.EnsureResourceExists(
 			WithMinimalObject(r.gvk, types.NamespacedName{Name: r.name, Namespace: r.ns}),
 			WithCondition(ownerRefStableCondition),
-			WithConsistentlyDuration(1*time.Minute),
-			WithConsistentlyPollingInterval(5*time.Second),
-			WithCustomErrorMsg(
-				"%s ownerReferences should remain stable (exactly 1, controller=true, owned by Monitoring CR)", r.desc,
-			),
+			WithCustomErrorMsg("%s should exist with correct ownerReferences before stability check", r.desc),
 		)
 	}
+
+	// Observe all resources in the same stability window so a flap on any
+	// resource is detected regardless of when it occurs.
+	g.Consistently(func(g Gomega) {
+		for _, r := range resources {
+			u := tc.FetchResource(
+				WithMinimalObject(r.gvk, types.NamespacedName{Name: r.name, Namespace: r.ns}),
+			)
+			g.Expect(u).NotTo(BeNil(), "%s should still exist", r.desc)
+			g.Expect(u).To(ownerRefStableCondition,
+				"%s ownerReferences should remain stable (exactly 1, controller=true, owned by Monitoring CR)", r.desc,
+			)
+		}
+	}).WithTimeout(1 * time.Minute).WithPolling(5 * time.Second).Should(Succeed())
 }
 
 // ValidateResourceVersionStability verifies that resourceVersion on monitoring resources
@@ -1927,13 +1940,15 @@ func (tc *MonitoringTestCtx) ValidateResourceVersionStability(t *testing.T) {
 		{gvk.ConfigMap, "prometheus-web-tls-ca", tc.MonitoringNamespace, "prometheus TLS CA ConfigMap"},
 	}
 
-	// Capture the resourceVersion for each resource after deployment has settled.
+	// Wait for each resource to exist and settle before capturing its resourceVersion.
+	// This prevents a race where collector-backed resources (e.g. data-science-collector-prometheus,
+	// prometheus-web-tls-ca) are still receiving initial writes when the baseline is captured.
 	initialVersions := make(map[string]string, len(resources))
 	for _, r := range resources {
-		u := tc.FetchResource(
+		u := tc.EnsureResourceExists(
 			WithMinimalObject(r.gvk, types.NamespacedName{Name: r.name, Namespace: r.ns}),
+			WithCustomErrorMsg("%s should exist before capturing resourceVersion baseline", r.desc),
 		)
-		require.NotNil(t, u, "%s should exist", r.desc)
 		initialVersions[r.name] = u.GetResourceVersion()
 	}
 

--- a/tests/e2e/monitoring_test.go
+++ b/tests/e2e/monitoring_test.go
@@ -1959,7 +1959,9 @@ func (tc *MonitoringTestCtx) ValidateResourceVersionStability(t *testing.T) {
 			u := tc.FetchResource(
 				WithMinimalObject(r.gvk, types.NamespacedName{Name: r.name, Namespace: r.ns}),
 			)
-			g.Expect(u).NotTo(BeNil(), "%s should still exist", r.desc)
+			if !g.Expect(u).NotTo(BeNil(), "%s should still exist", r.desc) {
+				continue
+			}
 			g.Expect(u.GetResourceVersion()).To(
 				Equal(initialVersions[r.name]),
 				"%s resourceVersion changed from %s — controller is re-applying unchanged resources (possible reconciliation loop)",


### PR DESCRIPTION
Add two regression e2e tests for RHOAIENG-37563 to guard against infinite reconciliation loops caused by conflicting ownerReferences:

- ValidateOwnerReferenceConsistency: verifies ownerReferences on monitoring resources (ClusterRoleBinding, Service, ConfigMap, MonitoringStack) remain stable over a 1-minute observation window using EnsureResourceExistsConsistently.

- ValidateResourceVersionStability: captures resourceVersion after deployment settles and asserts it does not change over 1 minute, detecting any re-application of unchanged resources.

Ref: RHOAIENG-58406
Ref: RHOAIENG-37563

<!---
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully
- [ ] New RELATED_IMAGE mappings are already listed in ODH-Build-Config and RHOAI-Build-Config, and links are included in PR description

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [ ] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added end-to-end checks that continuously verify owner-reference consistency across monitoring resources to detect flapping.
  * Added end-to-end checks that confirm resourceVersion stability for key monitoring resources after reconciliation to catch unexpected updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->