### PR TITLE
feat(maas): add ubi-minimal image param for api-key cleanup cronjob

### DIFF
--- a/internal/controller/components/modelsasservice/modelsasservice_support.go
+++ b/internal/controller/components/modelsasservice/modelsasservice_support.go
@@ -81,9 +81,10 @@ const (
 var (
 	// Image parameter mappings for manifest substitution.
 	imagesMap = map[string]string{
-		"maas-api-image":           "RELATED_IMAGE_ODH_MAAS_API_IMAGE",
-		"maas-controller-image":    "RELATED_IMAGE_ODH_MAAS_CONTROLLER_IMAGE",
-		"payload-processing-image": "RELATED_IMAGE_ODH_AI_GATEWAY_PAYLOAD_PROCESSING_IMAGE",
+		"maas-api-image":             "RELATED_IMAGE_ODH_MAAS_API_IMAGE",
+		"maas-controller-image":      "RELATED_IMAGE_ODH_MAAS_CONTROLLER_IMAGE",
+		"payload-processing-image":   "RELATED_IMAGE_ODH_AI_GATEWAY_PAYLOAD_PROCESSING_IMAGE",
+		"maas-api-key-cleanup-image": "RELATED_IMAGE_UBI_MINIMAL_IMAGE",
 	}
 
 	// Additional parameters for manifest customization.


### PR DESCRIPTION
## Summary
- Add `maas-api-key-cleanup-image` → `RELATED_IMAGE_UBI_MINIMAL_IMAGE` mapping to the MaaS `imagesMap` so the operator injects the pinned UBI-minimal digest into `params.env` at reconciliation time.

## Description
The MaaS component now includes an api-key-cleanup CronJob whose container image is parameterised through `params.env` as `maas-api-key-cleanup-image`. Without a corresponding entry in the operator's `imagesMap`, `ApplyParams()` never overwrites the placeholder with the SHA-pinned image from the bundle CSV, causing the CronJob to reference an unpinned or missing image.

This PR adds the mapping so that:
1. The operator reads `RELATED_IMAGE_UBI_MINIMAL_IMAGE` from its environment (set by the bundle CSV).
2. `ApplyParams()` writes that value into the `maas-api-key-cleanup-image` key in `params.env`.
3. Kustomize injects the resolved digest into the cleanup CronJob container spec.

### Companion PRs
- [RHOAI-Build-Config#19203](https://github.com/red-hat-data-services/RHOAI-Build-Config/pull/19203) — adds `RELATED_IMAGE_UBI_MINIMAL_IMAGE` to the bundle
- [models-as-a-service#751](https://github.com/opendatahub-io/models-as-a-service/pull/751) — adds `maas-api-key-cleanup-image` to `params.env` and kustomize replacement

## How it was tested
- Verified the new key appears in the resolved `imagesMap` at build time.
- Confirmed `ApplyParams()` substitutes the image value when `RELATED_IMAGE_UBI_MINIMAL_IMAGE` is set in the operator environment.
- All existing MaaS unit tests pass (`go test ./internal/controller/components/modelsasservice/... -v`).

- [x] Skip requirement to update E2E test suite for this PR

#### E2E update requirement opt-out justification
This is a data-only change adding one key-value entry to an existing map literal. No new code paths, no behavioral changes, and no existing e2e coverage for `ApplyParams` image substitution. The mapping is a no-op until the companion PRs (bundle CSV + manifest params.env) are merged. Existing unit tests confirm the change compiles and does not regress any component behavior.