### PR TITLE
RHOAIENG-57828: delete CertManager/cluster before cascade deletion

### DIFF
--- a/internal/controller/cloudmanager/azure/azurekubernetesengine_controller_test.go
+++ b/internal/controller/cloudmanager/azure/azurekubernetesengine_controller_test.go
@@ -8,8 +8,10 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -341,5 +343,83 @@ func TestAzureKubernetesEngineWithoutCertManager(t *testing.T) {
 			Eventually().ShouldNot(BeNil())
 		wtC.Get(gvk.CertManagerClusterIssuer, types.NamespacedName{Name: "opendatahub-ca-issuer"}).
 			Eventually().ShouldNot(BeNil())
+	})
+}
+
+// TestAzureKubernetesEngineCleanupAction verifies that the certmanager Bootstrap finalizer
+// action deletes CertManager/cluster before cascade deletion is released, allowing
+// cert-manager-operator to process its own finalizers while still running.
+func TestAzureKubernetesEngineCleanupAction(t *testing.T) {
+	ccmtest.RequireCharts(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	et, wt := ccmtest.StartIsolatedController(t, ctx, azureCfg)
+	t.Cleanup(cancel)
+
+	t.Run("cleanup action deletes CertManager/cluster before cascade", func(t *testing.T) {
+		// Register the CertManager operator CRD so CertManager/cluster can be created.
+		_, err := et.RegisterCRD(wt.Context(),
+			gvk.CertManagerV1Alpha1,
+			"certmanagers", "certmanager",
+			apiextensionsv1.ClusterScoped,
+		)
+		wt.Expect(err).NotTo(HaveOccurred())
+
+		// Create the AKE CR. The Bootstrap function registers NewCleanupAction as a
+		// finalizer, so the controller adds the platform finalizer after the first reconcile.
+		ccmtest.CreateCR(t, wt, azureCfg, ccmcommon.Dependencies{
+			CertManager: ccmcommon.CertManagerDependency{ManagementPolicy: ccmcommon.Managed},
+		})
+
+		nn := types.NamespacedName{Name: ccmv1alpha1.AzureKubernetesEngineInstanceName}
+
+		// Wait for the platform finalizer to be set, confirming the finalizer action is wired.
+		wt.Get(gvk.AzureKubernetesEngine, nn).Eventually().Should(
+			jq.Match(`.metadata.finalizers | index("platform.opendatahub.io/finalizer") != null`),
+		)
+
+		// Fetch the AKE CR to obtain its UID for the OwnerReference.
+		ake := &ccmv1alpha1.AzureKubernetesEngine{}
+		wt.Expect(wt.Client().Get(wt.Context(), nn, ake)).To(Succeed())
+
+		// Create CertManager/cluster with an OwnerReference to the AKE CR and a test
+		// finalizer simulating cert-manager-operator's runtime finalizers.
+		cm := &unstructured.Unstructured{}
+		cm.SetGroupVersionKind(gvk.CertManagerV1Alpha1)
+		cm.SetName("cluster")
+		cm.SetOwnerReferences([]metav1.OwnerReference{{
+			APIVersion: gvk.AzureKubernetesEngine.GroupVersion().String(),
+			Kind:       gvk.AzureKubernetesEngine.Kind,
+			Name:       ake.GetName(),
+			UID:        ake.GetUID(),
+		}})
+		cm.SetFinalizers([]string{"cert-manager-operator.operator.openshift.io/test-hold"})
+		cm.Object["spec"] = map[string]any{"managementState": "Managed"}
+		wt.Expect(wt.Client().Create(wt.Context(), cm)).To(Succeed())
+
+		// Delete the AKE CR. The cleanup action holds the platform finalizer until
+		// CertManager/cluster is fully gone.
+		wt.Expect(wt.Client().Delete(wt.Context(), ake)).To(Succeed())
+
+		// The cleanup action must trigger deletion of CertManager/cluster.
+		// Verify it receives a DeletionTimestamp, confirming the action fired.
+		wt.Get(gvk.CertManagerV1Alpha1, types.NamespacedName{Name: "cluster"}).
+			Eventually().Should(jq.Match(`.metadata.deletionTimestamp != null`))
+
+		// Simulate cert-manager-operator completing its finalizer processing by
+		// removing the test finalizer. This unblocks CertManager/cluster deletion.
+		cmGot := &unstructured.Unstructured{}
+		cmGot.SetGroupVersionKind(gvk.CertManagerV1Alpha1)
+		wt.Expect(wt.Client().Get(wt.Context(), types.NamespacedName{Name: "cluster"}, cmGot)).To(Succeed())
+		cmGot.SetFinalizers(nil)
+		wt.Expect(wt.Client().Update(wt.Context(), cmGot)).To(Succeed())
+
+		// CertManager/cluster must be fully deleted.
+		wt.Get(gvk.CertManagerV1Alpha1, types.NamespacedName{Name: "cluster"}).
+			Eventually().Should(BeNil())
+
+		// With CertManager/cluster gone, the cleanup action returns nil, the reconciler
+		// removes the platform finalizer, and the AKE CR is fully deleted.
+		wt.Get(gvk.AzureKubernetesEngine, nn).Eventually().Should(BeNil())
 	})
 }

--- a/pkg/cluster/gvk/gvk.go
+++ b/pkg/cluster/gvk/gvk.go
@@ -547,6 +547,12 @@ var (
 
 	// operator.openshift.io.
 
+	CertManagerV1Alpha1 = schema.GroupVersionKind{
+		Group:   "operator.openshift.io",
+		Version: "v1alpha1",
+		Kind:    "CertManager",
+	}
+
 	LeaderWorkerSetOperatorV1 = schema.GroupVersionKind{
 		Group:   "operator.openshift.io",
 		Version: "v1",

--- a/pkg/controller/actions/dependency/certmanager/bootstrap.go
+++ b/pkg/controller/actions/dependency/certmanager/bootstrap.go
@@ -18,10 +18,14 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	k8serr "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	"github.com/opendatahub-io/opendatahub-operator/v2/api/common"
@@ -288,6 +292,77 @@ func createCABackedIssuer(config BootstrapConfig) (*unstructured.Unstructured, e
 	return u, nil
 }
 
+// NewCleanupAction returns a finalizer action that explicitly deletes CertManager/cluster CR.
+//
+// When deleting the AKE/CWE CR, we need to explicitly delete CertManager/cluster first.
+// The cert-manager-operator has finalizers on CertManager/cluster that clean up its Deployments,
+// but these finalizers won't run if the operator is killed before the CR is deleted.
+// By deleting CertManager/cluster in this action, the operator stays alive long enough
+// to process its finalizers and clean up properly before the cascade deletion continues.
+//
+// The action does nothing if CertManager/cluster does not exist or if it is not owned
+// by the current CR instance.
+func NewCleanupAction() actions.Fn {
+	return func(ctx context.Context, rr *types.ReconciliationRequest) error {
+		l := logf.FromContext(ctx)
+
+		cm := &unstructured.Unstructured{}
+		cm.SetGroupVersionKind(gvk.CertManagerV1Alpha1)
+
+		if err := rr.Client.Get(ctx, client.ObjectKey{Name: "cluster"}, cm); err != nil {
+			if k8serr.IsNotFound(err) || meta.IsNoMatchError(err) {
+				return nil
+			}
+			return err
+		}
+
+		// Only delete CertManager/cluster if this CR instance owns it.
+		owned := false
+		for _, ref := range cm.GetOwnerReferences() {
+			if ref.UID == rr.Instance.GetUID() {
+				owned = true
+				break
+			}
+		}
+		if !owned {
+			l.V(1).Info("CertManager/cluster is not owned by this instance, skipping cleanup",
+				"instance", rr.Instance.GetName())
+			return nil
+		}
+
+		// Trigger deletion if not already in progress.
+		if cm.GetDeletionTimestamp().IsZero() {
+			l.Info("deleting CertManager/cluster to allow cert-manager-operator to clean up operands",
+				"instance", rr.Instance.GetName())
+			if err := rr.Client.Delete(ctx, cm); err != nil && !k8serr.IsNotFound(err) {
+				return err
+			}
+		}
+
+		// Only wait for cert-manager-operator's own finalizers (identified by its domain prefix).
+		var operatorFinalizers []string
+		for _, f := range cm.GetFinalizers() {
+			if strings.HasPrefix(f, "cert-manager-operator.") {
+				operatorFinalizers = append(operatorFinalizers, f)
+			}
+		}
+		if len(operatorFinalizers) == 0 {
+			l.V(1).Info("CertManager/cluster has no remaining cert-manager-operator finalizers, deletion complete",
+				"instance", rr.Instance.GetName())
+			return nil
+		}
+
+		// The CR is still Terminating and cert-manager-operator finalizers remain.
+		// Return an error to trigger reconciler re-queue. On the next call, Get should
+		// return NotFound once cert-manager-operator has removed all its finalizers.
+		l.Info("waiting for CertManager/cluster to be fully deleted",
+			"instance", rr.Instance.GetName(),
+			"remainingFinalizers", cm.GetFinalizers())
+		return fmt.Errorf("waiting for CertManager/cluster to be fully deleted (remaining finalizers: %v)",
+			cm.GetFinalizers())
+	}
+}
+
 // MonitorCRDs returns a dependency.ActionOpts that checks whether the three core cert-manager
 // CRDs (Certificate, Issuer, ClusterIssuer) are registered on the cluster. If any CRD
 // is absent, DependenciesAvailable is set to False.
@@ -359,8 +434,14 @@ func Bootstrap[T common.PlatformObject](instanceName string, config BootstrapCon
 				reconciler.WithPredicates(predicate.Or(certPredicates...)),
 				reconciler.Dynamic(reconciler.CrdExists(gvk.CertManagerCertificate)),
 			).
+			WatchesGVK(gvk.CertManagerV1Alpha1,
+				reconciler.WithEventHandler(handlers.ToNamed(instanceName)),
+				reconciler.WithPredicates(resourcespredicates.CreatedOrUpdatedOrDeletedNamed("cluster")),
+				reconciler.Dynamic(reconciler.CrdExists(gvk.CertManagerV1Alpha1)),
+			).
 			WithAction(dependency.NewAction(MonitorCRDs())).
 			WithActionE(NewBootstrapAction(config)).
-			WithConditions(status.ConditionDependenciesAvailable)
+			WithConditions(status.ConditionDependenciesAvailable).
+			WithFinalizer(NewCleanupAction())
 	}
 }

--- a/pkg/controller/actions/dependency/certmanager/cleanup_test.go
+++ b/pkg/controller/actions/dependency/certmanager/cleanup_test.go
@@ -1,0 +1,204 @@
+package certmanager_test
+
+import (
+	"context"
+	"testing"
+
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
+	certmanager "github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/dependency/certmanager"
+	ctypes "github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/envt"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/scheme"
+
+	. "github.com/onsi/gomega"
+)
+
+// TestNewCleanupActionNoCRD verifies that the finalizer action is a no-op when the
+// certmanagers.operator.openshift.io CRD is not registered on the cluster.
+func TestNewCleanupActionNoCRD(t *testing.T) {
+	g := NewWithT(t)
+
+	envTest, err := envt.New()
+	g.Expect(err).NotTo(HaveOccurred())
+	t.Cleanup(func() { _ = envTest.Stop() })
+
+	ctx := context.Background()
+
+	instance := &scheme.TestPlatformObject{}
+	instance.SetUID("owner-uid-1234")
+
+	rr := &ctypes.ReconciliationRequest{
+		Client:   envTest.Client(),
+		Instance: instance,
+	}
+
+	// CRD is NOT registered. Get returns a NoKindMatchError, which must be treated
+	// as NotFound (nothing to clean up) rather than propagated as a failure.
+	err = certmanager.NewCleanupAction()(ctx, rr)
+	g.Expect(err).NotTo(HaveOccurred())
+}
+
+// TestNewCleanupAction verifies the finalizer action that deletes
+// CertManager/cluster before cascade deletion is released.
+func TestNewCleanupAction(t *testing.T) {
+	g := NewWithT(t)
+
+	envTest, err := envt.New()
+	g.Expect(err).NotTo(HaveOccurred())
+	t.Cleanup(func() { _ = envTest.Stop() })
+
+	ctx := context.Background()
+
+	_, err = envTest.RegisterCRD(ctx,
+		gvk.CertManagerV1Alpha1,
+		"certmanagers", "certmanager",
+		apiextensionsv1.ClusterScoped,
+	)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	cli := envTest.Client()
+	action := certmanager.NewCleanupAction()
+
+	// instance represents the reconciled AKE/CWE CR. Only its UID is used by the action.
+	instance := &scheme.TestPlatformObject{}
+	instance.SetUID("owner-uid-1234")
+
+	rr := &ctypes.ReconciliationRequest{
+		Client:   cli,
+		Instance: instance,
+	}
+
+	t.Run("no-op when Terminating with only non-cert-manager-operator finalizers", func(t *testing.T) {
+		g := NewWithT(t)
+
+		// Simulate Kubernetes foreground deletion: DeletionTimestamp set and only the
+		// internal "foregroundDeletion" finalizer remains. cert-manager-operator's own
+		// finalizers are already gone, so the cleanup action should return nil.
+		cm := certManagerCR([]metav1.OwnerReference{
+			ownerRef(instance.GetUID()),
+		}, []string{"foregroundDeletion"})
+		g.Expect(cli.Create(ctx, cm)).To(Succeed())
+		t.Cleanup(func() {
+			got := &unstructured.Unstructured{}
+			got.SetGroupVersionKind(gvk.CertManagerV1Alpha1)
+			if err := cli.Get(ctx, types.NamespacedName{Name: "cluster"}, got); err == nil {
+				got.SetFinalizers(nil)
+				_ = cli.Update(ctx, got)
+				_ = cli.Delete(ctx, got)
+			}
+		})
+
+		// Trigger Delete so DeletionTimestamp is set.
+		g.Expect(cli.Delete(ctx, cm)).To(Succeed())
+
+		err := action(ctx, rr)
+		g.Expect(err).NotTo(HaveOccurred())
+	})
+
+	t.Run("no-op when CertManager/cluster does not exist", func(t *testing.T) {
+		g := NewWithT(t)
+
+		err := action(ctx, rr)
+		g.Expect(err).NotTo(HaveOccurred())
+	})
+
+	t.Run("no-op when CertManager/cluster exists but OwnerRef UID does not match", func(t *testing.T) {
+		g := NewWithT(t)
+
+		cm := certManagerCR([]metav1.OwnerReference{
+			ownerRef("some-other-uid-9999"),
+		}, nil)
+		g.Expect(cli.Create(ctx, cm)).To(Succeed())
+		t.Cleanup(func() { _ = cli.Delete(ctx, cm) })
+
+		err := action(ctx, rr)
+		g.Expect(err).NotTo(HaveOccurred())
+	})
+
+	// This subtest covers the full owned-CR lifecycle in sequence:
+	//   1. CR exists with matching UID → action deletes it, DeletionTimestamp set, error returned.
+	//   2. CR still Terminating (finalizer held) → action skips Delete, error returned.
+	//   3. Finalizer removed → CR gone → action returns nil.
+	// All three phases are in one subtest to share the CR state without t.Cleanup races.
+	t.Run("owned CertManager/cluster lifecycle: delete, wait, gone", func(t *testing.T) {
+		g := NewWithT(t)
+
+		// Create the CR owned by this instance with a finalizer matching the
+		// cert-manager-operator prefix, simulating the operator's runtime finalizers.
+		cm := certManagerCR([]metav1.OwnerReference{
+			ownerRef(instance.GetUID()),
+		}, []string{"cert-manager-operator.operator.openshift.io/test-hold"})
+		g.Expect(cli.Create(ctx, cm)).To(Succeed())
+		t.Cleanup(func() {
+			// Ensure the CR is cleaned up even if the test fails mid-way.
+			got := &unstructured.Unstructured{}
+			got.SetGroupVersionKind(gvk.CertManagerV1Alpha1)
+			if err := cli.Get(ctx, types.NamespacedName{Name: "cluster"}, got); err == nil {
+				got.SetFinalizers(nil)
+				_ = cli.Update(ctx, got)
+				_ = cli.Delete(ctx, got)
+			}
+		})
+
+		// Phase 1: CR present, DeletionTimestamp not yet set → action triggers Delete.
+		err := action(ctx, rr)
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("waiting for CertManager/cluster"))
+
+		// Verify Delete was triggered: CR must now have a DeletionTimestamp.
+		got := &unstructured.Unstructured{}
+		got.SetGroupVersionKind(gvk.CertManagerV1Alpha1)
+		g.Expect(cli.Get(ctx, types.NamespacedName{Name: "cluster"}, got)).To(Succeed())
+		g.Expect(got.GetDeletionTimestamp()).NotTo(BeNil())
+
+		// Phase 2: CR is Terminating (finalizer still held) → action re-queues without
+		// issuing a new Delete.
+		err = action(ctx, rr)
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("waiting for CertManager/cluster"))
+
+		// Phase 3: Simulate cert-manager-operator removing its finalizers.
+		got.SetFinalizers(nil)
+		g.Expect(cli.Update(ctx, got)).To(Succeed())
+
+		// Wait for the API server to remove the CR once all finalizers are gone.
+		g.Eventually(func() error {
+			return cli.Get(ctx, types.NamespacedName{Name: "cluster"}, got)
+		}).Should(MatchError(ContainSubstring("not found")))
+
+		// With the CR gone, the action must return nil.
+		err = action(ctx, rr)
+		g.Expect(err).NotTo(HaveOccurred())
+	})
+}
+
+// certManagerCR builds a minimal CertManager/cluster Unstructured object.
+func certManagerCR(ownerRefs []metav1.OwnerReference, finalizers []string) *unstructured.Unstructured {
+	cm := &unstructured.Unstructured{}
+	cm.SetGroupVersionKind(gvk.CertManagerV1Alpha1)
+	cm.SetName("cluster")
+	if len(ownerRefs) > 0 {
+		cm.SetOwnerReferences(ownerRefs)
+	}
+	if len(finalizers) > 0 {
+		cm.SetFinalizers(finalizers)
+	}
+	return cm
+}
+
+// ownerRef builds a minimal valid OwnerReference with the given UID.
+// APIVersion, Kind, and Name are required by the Kubernetes API server, but
+// the action only checks ref.UID, so these values are arbitrary placeholders.
+func ownerRef(uid types.UID) metav1.OwnerReference {
+	return metav1.OwnerReference{
+		APIVersion: "test.opendatahub.io/v1",
+		Kind:       "TestPlatformObject",
+		Name:       "test-owner",
+		UID:        uid,
+	}
+}

--- a/pkg/utils/test/scheme/test_types.go
+++ b/pkg/utils/test/scheme/test_types.go
@@ -1,4 +1,3 @@
-//nolint:ireturn // DeepCopyObject methods must return runtime.Object interface as required by Kubernetes API
 package scheme
 
 import (

--- a/tests/e2e/cloudmanager/cloudmanager_test.go
+++ b/tests/e2e/cloudmanager/cloudmanager_test.go
@@ -468,6 +468,17 @@ func TestCloudManager(t *testing.T) { //nolint:maintidx // sequential subtests s
 			)
 		}
 
+		// CertManager/cluster must exist and be owned by this CR.
+		wt.Get(gvk.CertManagerV1Alpha1, types.NamespacedName{Name: "cluster"}).
+			Eventually().Should(jq.Match(`.metadata.ownerReferences | length > 0`))
+
+		// cert-manager operand Deployments must be running before we delete the CR.
+		for _, dep := range certManagerOperandDeployments {
+			wt.Get(gvk.Deployment, types.NamespacedName{
+				Name: dep.Name, Namespace: dep.Namespace,
+			}).Eventually().Should(Not(BeNil()))
+		}
+
 		// Namespaces are excluded from dynamic ownership to prevent cascade
 		// deletion of the entire namespace (and all third-party resources in it)
 		// when the CR is deleted. Verify they have no owner references.
@@ -484,6 +495,20 @@ func TestCloudManager(t *testing.T) { //nolint:maintidx // sequential subtests s
 
 		// All owned deployments should be cascade-deleted via owner references.
 		for _, dep := range managedDependencyDeployments {
+			wt.Get(gvk.Deployment, types.NamespacedName{
+				Name: dep.Name, Namespace: dep.Namespace,
+			}).Eventually().Should(BeNil())
+		}
+
+		// CertManager/cluster CR must be deleted. The finalizer action deletes it
+		// to allow cert-manager-operator to clean up its own resources.
+		wt.Get(gvk.CertManagerV1Alpha1, types.NamespacedName{Name: "cluster"}).
+			Eventually().Should(BeNil())
+
+		// cert-manager operand Deployments must be removed by the cert-manager-operator
+		// finalizer. They are not directly owned by our CR, so cascade deletion
+		// does not cover them.
+		for _, dep := range certManagerOperandDeployments {
 			wt.Get(gvk.Deployment, types.NamespacedName{
 				Name: dep.Name, Namespace: dep.Namespace,
 			}).Eventually().Should(BeNil())

--- a/tests/e2e/cloudmanager/helper_test.go
+++ b/tests/e2e/cloudmanager/helper_test.go
@@ -25,6 +25,18 @@ var managedDependencyDeployments = []deploymentRef{
 	{Name: "servicemesh-operator3", Namespace: "istio-system"},
 }
 
+// certManagerOperandDeployments lists the cert-manager operand Deployments created
+// by cert-manager-operator when it processes the CertManager/cluster CR. These are
+// not directly owned by the *Engine CRs (no OwnerRef), so they do not appear in
+// managedDependencyDeployments. They are cleaned up transitively: the CCM finalizer
+// action deletes CertManager/cluster, cert-manager-operator processes its own
+// finalizers, and removes these Deployments before the operator pod is killed.
+var certManagerOperandDeployments = []deploymentRef{
+	{Name: "cert-manager", Namespace: "cert-manager"},
+	{Name: "cert-manager-cainjector", Namespace: "cert-manager"},
+	{Name: "cert-manager-webhook", Namespace: "cert-manager"},
+}
+
 func newCloudManagerCR(deps map[string]any) *unstructured.Unstructured {
 	obj := &unstructured.Unstructured{}
 	obj.SetGroupVersionKind(provider.GVK)


### PR DESCRIPTION
## Description

[RHOAIENG-57828](https://issues.redhat.com/browse/RHOAIENG-57828)

Depends on https://github.com/opendatahub-io/odh-gitops/pull/78

When an AKE/CWE CR is deleted, cascade deletion kills cert-manager-operator at the same time as its CertManager/cluster CR. Since the cert-manager-operator sets finalizers on `CertManager/cluster` to clean up its deployments (`cert-manager`, `cert-manager-cainjector`, `cert-manager-webhook`), because the operator is killed before these finalizers are processed, the cert-manager deployments are left running in a broken state.

This PR adds a `NewCleanupAction()` finalizer action inside `certmanager.Bootstrap`, which both AKE and CWE inherit. On CR deletion, the action:

- Gets `CertManager/cluster`; returns nil (no-op) if NotFound, CRD absent, or not owned by this CR instance (UID check on OwnerReferences)
- Deletes the CR if not already terminating
- Returns an error to trigger re-queue while cert-manager-operator finalizers remain (identified by `cert-manager-operator.` prefix)
- Returns nil once all operator finalizers are gone, releasing cascade deletion

Kubernetes-internal finalizers (e.g. `foregroundDeletion`) are intentionally ignored since they do not indicate pending cert-manager-operator cleanup.

### Changes

- **`pkg/controller/actions/dependency/certmanager/bootstrap.go`**: Added `NewCleanupAction()` and wired it as `.WithFinalizer()` in the `Bootstrap` function
- **`pkg/cluster/gvk/gvk.go`**: Added `CertManagerV1Alpha1` GVK constant (`operator.openshift.io/v1alpha1 CertManager`)
- **`pkg/controller/actions/dependency/certmanager/cleanup_test.go`** (new): Unit tests covering all action branches: no CRD registered, CR not found, UID mismatch, foregroundDeletion-only finalizer, and the full owned-CR lifecycle (delete, wait, gone)
- **`internal/controller/cloudmanager/azure/azurekubernetesengine_controller_test.go`**: Integration test verifying the cleanup action fires during AKE CR deletion
- **`tests/e2e/cloudmanager/cloudmanager_test.go`** and **`helper_test.go`**: E2E assertions that `CertManager/cluster` and cert-manager operand Deployments are fully removed after CR deletion

## How Has This Been Tested?

- **Unit tests** (`cleanup_test.go`): envtest-based tests covering all branches of `NewCleanupAction()`:
  - No CRD registered on the cluster (NoKindMatchError treated as no-op)
  - CertManager/cluster does not exist (NotFound treated as no-op)
  - CertManager/cluster exists but OwnerRef UID does not match (no-op, does not delete unrelated CRs)
  - CertManager/cluster is Terminating with only non-cert-manager-operator finalizers like `foregroundDeletion` (no-op)
  - Full owned-CR lifecycle: action triggers Delete, re-queues while operator finalizers remain, returns nil once CR is gone
- **Integration test** (`azurekubernetesengine_controller_test.go`): Creates an AKE CR with the CertManager CRD registered, verifies the platform finalizer is set, creates CertManager/cluster with an OwnerRef and a test finalizer, deletes the AKE CR, and confirms the cleanup action triggers deletion and waits for finalizer removal
- **E2E assertions** (`cloudmanager_test.go`): Verifies CertManager/cluster and operand Deployments exist before CR deletion and are fully removed after deletion

## Screenshot or short clip

N/A, backend-only change.

## Merge criteria

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [x] The developer has run the integration test pipeline and verified that it passed successfully
- [x] New RELATED_IMAGE mappings are already listed in ODH-Build-Config and RHOAI-Build-Config, and links are included in PR description

### E2E test suite update requirement

E2E test assertions have been added in `cloudmanager_test.go` and `helper_test.go`.

- [ ] Skip requirement to update E2E test suite for this PR

#### E2E update requirement opt-out justification

N/A. E2E are included.

Assisted-By: Claude Sonnet 4.6 <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cert-manager cascade deletion: platform CR removal now waits for cert-manager finalizers and ensures cert-manager operands are removed before finalization.

* **New Features**
  * Added reconciliation cleanup to watch and coordinate cert-manager cluster deletion so platform finalization is unblocked reliably.

* **Tests**
  * Added unit tests for CRD absent, owner-mismatch, and lifecycle; expanded e2e checks and test helpers for cert-manager operands.

* **Style**
  * Narrowed linter suppression scope in deepcopy test helpers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->