### PR TITLE
test: add regression tests for template ownerRef stripping (RHOAIENG-…

### DIFF
--- a/pkg/controller/actions/deploy/action_deploy_test.go
+++ b/pkg/controller/actions/deploy/action_deploy_test.go
@@ -1216,6 +1216,230 @@ func TestDeployStripsTemplateOwnerReferences(t *testing.T) {
 	g.Expect(*ownerRefs[0].BlockOwnerDeletion).Should(BeTrue())
 }
 
+func TestDeployStripsTemplateOwnerReferences_RepeatedReconciliation(t *testing.T) {
+	g := NewWithT(t)
+
+	ctx := t.Context()
+	ns := xid.New().String()
+
+	cl, err := fakeclient.New()
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	err = cl.Create(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}})
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	instance := &componentApi.Dashboard{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       componentApi.DashboardInstanceName,
+			UID:        "test-uid-12345",
+			Generation: 1,
+		},
+	}
+	instance.SetGroupVersionKind(gvk.Dashboard)
+
+	templateOwnerRef := metav1.OwnerReference{
+		APIVersion: gvk.Dashboard.GroupVersion().String(),
+		Kind:       gvk.Dashboard.Kind,
+		Name:       instance.Name,
+		UID:        instance.UID,
+	}
+
+	action := deploy.NewAction(deploy.WithMode(deploy.ModePatch))
+
+	// Run two reconciliation cycles with the same template ownerRef present each time.
+	// This proves repeated reconciliations don't accumulate ownerRefs or cause drift.
+	for i := range 2 {
+		configMap, err := resources.ToUnstructured(&corev1.ConfigMap{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: corev1.SchemeGroupVersion.String(),
+				Kind:       "ConfigMap",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            "test-cm",
+				Namespace:       ns,
+				OwnerReferences: []metav1.OwnerReference{templateOwnerRef},
+			},
+		})
+		g.Expect(err).ShouldNot(HaveOccurred())
+
+		rr := types.ReconciliationRequest{
+			Client:   cl,
+			Instance: instance,
+			Release: common.Release{
+				Name: cluster.OpenDataHub,
+				Version: version.OperatorVersion{Version: semver.Version{
+					Major: 1, Minor: 2, Patch: 3,
+				}},
+			},
+			Resources: []unstructured.Unstructured{*configMap},
+			Controller: mocks.NewMockController(func(m *mocks.MockController) {
+				m.On("Owns", gvk.ConfigMap).Return(true)
+			}),
+		}
+
+		err = action(ctx, &rr)
+		g.Expect(err).ShouldNot(HaveOccurred(), "reconciliation %d should not fail", i+1)
+
+		cm := resources.GvkToUnstructured(gvk.ConfigMap)
+		err = cl.Get(ctx, apimachinery.NamespacedName{Namespace: ns, Name: "test-cm"}, cm)
+		g.Expect(err).ShouldNot(HaveOccurred())
+
+		ownerRefs := cm.GetOwnerReferences()
+		g.Expect(ownerRefs).Should(HaveLen(1),
+			"reconciliation %d: should have exactly one ownerReference, got %d", i+1, len(ownerRefs))
+		g.Expect(ownerRefs[0].Kind).Should(Equal(gvk.Dashboard.Kind))
+		g.Expect(*ownerRefs[0].Controller).Should(BeTrue(),
+			"reconciliation %d: ownerReference should be a controller reference", i+1)
+	}
+}
+
+func TestDeployStripsTemplateOwnerReferences_ForeignOwner(t *testing.T) {
+	g := NewWithT(t)
+
+	ctx := t.Context()
+	ns := xid.New().String()
+
+	cl, err := fakeclient.New()
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	err = cl.Create(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}})
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	instance := &componentApi.Dashboard{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       componentApi.DashboardInstanceName,
+			UID:        "dashboard-uid-12345",
+			Generation: 1,
+		},
+	}
+	instance.SetGroupVersionKind(gvk.Dashboard)
+
+	// Template ownerRef pointing to a different resource (DataScienceCluster),
+	// simulating the actual bug where a template ownerRef points to a parent
+	// resource rather than the component controller.
+	foreignOwnerRef := metav1.OwnerReference{
+		APIVersion: gvk.DataScienceCluster.GroupVersion().String(),
+		Kind:       gvk.DataScienceCluster.Kind,
+		Name:       "default-dsc",
+		UID:        "dsc-uid-99999",
+	}
+
+	configMap, err := resources.ToUnstructured(&corev1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: corev1.SchemeGroupVersion.String(),
+			Kind:       "ConfigMap",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "test-cm",
+			Namespace:       ns,
+			OwnerReferences: []metav1.OwnerReference{foreignOwnerRef},
+		},
+	})
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	rr := types.ReconciliationRequest{
+		Client:   cl,
+		Instance: instance,
+		Release: common.Release{
+			Name: cluster.OpenDataHub,
+			Version: version.OperatorVersion{Version: semver.Version{
+				Major: 1, Minor: 2, Patch: 3,
+			}},
+		},
+		Resources: []unstructured.Unstructured{*configMap},
+		Controller: mocks.NewMockController(func(m *mocks.MockController) {
+			m.On("Owns", gvk.ConfigMap).Return(true)
+		}),
+	}
+
+	action := deploy.NewAction(deploy.WithMode(deploy.ModePatch))
+	err = action(ctx, &rr)
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	cm := resources.GvkToUnstructured(gvk.ConfigMap)
+	err = cl.Get(ctx, apimachinery.NamespacedName{Namespace: ns, Name: "test-cm"}, cm)
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	// The foreign DSC ownerRef must be replaced by the controller reference
+	// pointing to the Dashboard instance.
+	ownerRefs := cm.GetOwnerReferences()
+	g.Expect(ownerRefs).Should(HaveLen(1))
+	g.Expect(ownerRefs[0].Kind).Should(Equal(gvk.Dashboard.Kind),
+		"ownerReference should point to Dashboard, not DataScienceCluster")
+	g.Expect(ownerRefs[0].Name).Should(Equal(instance.Name))
+	g.Expect(ownerRefs[0].UID).Should(Equal(instance.UID))
+	g.Expect(*ownerRefs[0].Controller).Should(BeTrue())
+	g.Expect(*ownerRefs[0].BlockOwnerDeletion).Should(BeTrue())
+}
+
+func TestDeployStripsTemplateOwnerReferences_SSAMode(t *testing.T) {
+	g := NewWithT(t)
+
+	ctx := t.Context()
+
+	et, err := envt.New()
+	g.Expect(err).NotTo(HaveOccurred())
+	t.Cleanup(func() { _ = et.Stop() })
+
+	cl := et.Client()
+	ns := xid.New().String()
+	g.Expect(cl.Create(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}})).To(Succeed())
+
+	instance := &componentApi.Dashboard{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       componentApi.DashboardInstanceName,
+			Generation: 1,
+		},
+	}
+	instance.SetGroupVersionKind(gvk.Dashboard)
+
+	g.Expect(cl.Create(ctx, instance)).To(Succeed())
+
+	// Template ownerRef that should be cleared and replaced by SetControllerReference
+	templateOwnerRef := metav1.OwnerReference{
+		APIVersion: gvk.Dashboard.GroupVersion().String(),
+		Kind:       gvk.Dashboard.Kind,
+		Name:       instance.Name,
+		UID:        instance.UID,
+	}
+
+	rr := types.ReconciliationRequest{
+		Client:   cl,
+		Instance: instance,
+		Release: common.Release{
+			Name: cluster.OpenDataHub,
+			Version: version.OperatorVersion{Version: semver.Version{
+				Major: 1, Minor: 2, Patch: 3,
+			}},
+		},
+		Controller: mocks.NewMockController(func(m *mocks.MockController) {
+			m.On("Owns", gvk.ConfigMap).Return(true)
+		}),
+	}
+
+	g.Expect(rr.AddResources(&corev1.ConfigMap{
+		TypeMeta:   metav1.TypeMeta{APIVersion: corev1.SchemeGroupVersion.String(), Kind: "ConfigMap"},
+		ObjectMeta: metav1.ObjectMeta{Name: "test-cm", Namespace: ns, OwnerReferences: []metav1.OwnerReference{templateOwnerRef}},
+	})).To(Succeed())
+
+	// Default mode is SSA
+	action := deploy.NewAction()
+	err = action(ctx, &rr)
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	cm := &corev1.ConfigMap{}
+	g.Expect(cl.Get(ctx, apimachinery.NamespacedName{Namespace: ns, Name: "test-cm"}, cm)).To(Succeed())
+
+	ownerRefs := cm.GetOwnerReferences()
+	g.Expect(ownerRefs).Should(HaveLen(1))
+	g.Expect(ownerRefs[0].Kind).Should(Equal(gvk.Dashboard.Kind))
+	g.Expect(ownerRefs[0].Name).Should(Equal(instance.Name))
+	g.Expect(ownerRefs[0].UID).Should(Equal(instance.UID))
+	g.Expect(*ownerRefs[0].Controller).Should(BeTrue(),
+		"ownerReference should be a controller reference set by SetControllerReference, not a template-defined one")
+	g.Expect(*ownerRefs[0].BlockOwnerDeletion).Should(BeTrue())
+}
+
 func TestDeployDynamicOwnership_CRDsExcludedByDefault(t *testing.T) {
 	g := NewWithT(t)
 


### PR DESCRIPTION
RHOAIENG-37563

Add three unit tests to guard against regressions in the deploy action's template ownerReference clearing logic:

- RepeatedReconciliation: proves repeated deploys with template ownerRefs don't accumulate references or cause drift
- ForeignOwner: validates clearing works when the template ownerRef points to a different resource (e.g. DSC) than the controller (e.g. Dashboard)
- SSAMode: covers the SSA code path (default deploy mode) via envtest, closing the gap left by the existing ModePatch-only test

<!---
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [x] The developer has run the integration test pipeline and verified that it passed successfully
- [x] New RELATED_IMAGE mappings are already listed in ODH-Build-Config and RHOAI-Build-Config, and links are included in PR description

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for deployment configuration object ownership management, validating correct reference handling during repeated reconciliation cycles and various deployment modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->