### PR TITLE
fix community release token to use PAT

### DIFF
--- a/.github/scripts/create-community-pr.sh
+++ b/.github/scripts/create-community-pr.sh
@@ -50,7 +50,12 @@ echo " Creating pull request"
 PR_TITLE="operator opendatahub-operator (${VERSION})"
 PR_HEAD="${COMMUNITY_FORK%%/*}:${BRANCH_NAME}"
 
-PR_URL=$(gh pr create \
+# Use COMMUNITY_PR_TOKEN (classic PAT) for cross-org PR creation on upstream.
+# GitHub App tokens are installation-scoped and cannot create PRs on repos
+# outside their installation org. Falls back to GITHUB_TOKEN if not set.
+PR_TOKEN="${COMMUNITY_PR_TOKEN:-${GITHUB_TOKEN}}"
+
+PR_URL=$(GH_TOKEN="${PR_TOKEN}" gh pr create \
   --repo "${COMMUNITY_UPSTREAM}" \
   --title "${PR_TITLE}" \
   --head "${PR_HEAD}" \

--- a/.github/workflows/release-community.yaml
+++ b/.github/workflows/release-community.yaml
@@ -17,7 +17,7 @@ on:
         type: string
         description: OpenShift version compatibility (e.g., "v4.19" or "v4.19-v4.20").
         required: false
-        default: "v4.19-v4.20"
+        default: "v4.19-v4.21"
 
 env:
   VERSION: ${{ github.event.inputs.version }}
@@ -33,8 +33,7 @@ jobs:
   create-community-release:
     runs-on: ubuntu-latest
     permissions:
-      contents: write
-      pull-requests: write
+      contents: read
     steps:
     - name: Checkout opendatahub-operator release branch
       uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
@@ -162,6 +161,7 @@ jobs:
       id: create-pr
       env:
         GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
+        COMMUNITY_PR_TOKEN: ${{ secrets.COMMUNITY_PR_TOKEN }}
         VERSION: ${{ env.VERSION }}
         COMMUNITY_FORK: ${{ env.COMMUNITY_FORK }}
         COMMUNITY_UPSTREAM: ${{ env.COMMUNITY_UPSTREAM }}


### PR DESCRIPTION
<!---
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
 - Add my PAT to do the community releases(future solution would be a bot account)
 - Changed openshift label to support 4.21
 - tightned GH token perms

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully
- [ ] New RELATED_IMAGE mappings are already listed in ODH-Build-Config and RHOAI-Build-Config, and links are included in PR description

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [ ] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated community release automation to support OpenShift versions v4.19-v4.21
  * Enhanced security controls for internal release workflow configurations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->