### PR TITLE
ci: clean generated manifests before regeneration in PR check RHOAIENG-55037

### DIFF
--- a/.github/workflows/test-required-files-updated.yaml
+++ b/.github/workflows/test-required-files-updated.yaml
@@ -20,6 +20,8 @@ jobs:
           name: pr_number
           path: ./pr_number.txt
           retention-days: 1 # This will delete the generated artifacts every day.
+      - name: Clean generated manifests
+        run: make clean-manifests
       - name: Generate files
         run: make generate manifests-all api-docs
       - name: Ensure generated files are up-to-date

--- a/.github/workflows/test-required-files-updated.yaml
+++ b/.github/workflows/test-required-files-updated.yaml
@@ -20,8 +20,6 @@ jobs:
           name: pr_number
           path: ./pr_number.txt
           retention-days: 1 # This will delete the generated artifacts every day.
-      - name: Clean generated manifests
-        run: make clean-manifests
       - name: Generate files
         run: make generate manifests-all api-docs
       - name: Ensure generated files are up-to-date

--- a/Makefile
+++ b/Makefile
@@ -283,7 +283,6 @@ endif
 	@# Generate shared rhaii webhook manifests with only KServe connection webhooks
 	@$(YQ) eval 'select(.kind == "MutatingWebhookConfiguration") | .webhooks = [.webhooks[] | select(.name == "connection-isvc.opendatahub.io" or .name == "connection-llmisvc.opendatahub.io")]' $(CONFIG_DIR)/webhook/manifests.yaml > config/rhaii/webhook/manifests.yaml
 MANIFEST_GENERATED_FILES = config/crd/bases config/rhoai/crd/bases config/rhaii/crd/bases config/crd/external config/rhoai/crd/external config/rbac/role.yaml config/rhoai/rbac/role.yaml config/webhook/manifests.yaml config/rhoai/webhook/manifests.yaml config/rhaii/webhook/manifests.yaml
-CLEANFILES += $(MANIFEST_GENERATED_FILES)
 
 .PHONY: manifests-all
 manifests-all:
@@ -899,11 +898,8 @@ CCM_UNDEPLOY_TARGETS := $(addprefix undeploy-ccm-,$(CCM_PROVIDERS))
 $(CCM_UNDEPLOY_TARGETS): undeploy-ccm-%: kustomize ## Undeploy CCM from cluster (e.g., undeploy-ccm-azure)
 	$(KUSTOMIZE) build $(call ccm-config-dir,$*)/$(CCM_DEPLOY_OVERLAY) | kubectl delete --ignore-not-found=$(ignore-not-found) -f -
 
-# Cleanup
-$(foreach p,$(CCM_PROVIDERS),$(eval CLEANFILES += $(call ccm-config-dir,$(p))/crd/bases $(call ccm-config-dir,$(p))/rbac/role.yaml))
-
 .PHONY: clean
-clean: $(GOLANGCI_LINT)
+clean: clean-manifests $(GOLANGCI_LINT)
 	$(GOLANGCI_LINT) cache clean
 	chmod -R u+w $(LOCALBIN) # envtest makes its dir RO
 	rm -rf $(CLEANFILES)

--- a/Makefile
+++ b/Makefile
@@ -282,13 +282,19 @@ endif
 	@$(call add-crd-to-kustomization,config/rhaii/crd/bases)
 	@# Generate shared rhaii webhook manifests with only KServe connection webhooks
 	@$(YQ) eval 'select(.kind == "MutatingWebhookConfiguration") | .webhooks = [.webhooks[] | select(.name == "connection-isvc.opendatahub.io" or .name == "connection-llmisvc.opendatahub.io")]' $(CONFIG_DIR)/webhook/manifests.yaml > config/rhaii/webhook/manifests.yaml
-CLEANFILES += config/crd/bases config/rhoai/crd/bases config/rhaii/crd/bases config/crd/external config/rhoai/crd/external config/rbac/role.yaml config/rhoai/rbac/role.yaml config/webhook/manifests.yaml config/rhoai/webhook/manifests.yaml config/rhaii/webhook/manifests.yaml
+MANIFEST_GENERATED_FILES = config/crd/bases config/rhoai/crd/bases config/rhaii/crd/bases config/crd/external config/rhoai/crd/external config/rbac/role.yaml config/rhoai/rbac/role.yaml config/webhook/manifests.yaml config/rhoai/webhook/manifests.yaml config/rhaii/webhook/manifests.yaml
+CLEANFILES += $(MANIFEST_GENERATED_FILES)
 
 .PHONY: manifests-all
 manifests-all:
 	$(MAKE) manifests
 	$(MAKE) manifests ODH_PLATFORM_TYPE=rhoai
 	$(MAKE) manifests-ccm
+
+.PHONY: clean-manifests
+clean-manifests: ## Remove generated manifest files (CRDs, RBAC, webhooks) for all variants.
+	rm -rf $(MANIFEST_GENERATED_FILES)
+	$(foreach p,$(CCM_PROVIDERS),rm -rf $(call ccm-config-dir,$(p))/crd/bases $(call ccm-config-dir,$(p))/rbac/role.yaml;)
 
 .PHONY: generate
 generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.

--- a/Makefile
+++ b/Makefile
@@ -292,8 +292,8 @@ manifests-all:
 
 .PHONY: clean-manifests
 clean-manifests: ## Remove generated manifest files (CRDs, RBAC, webhooks) for all variants.
-	rm -rf $(MANIFEST_GENERATED_FILES)
-	$(foreach p,$(CCM_PROVIDERS),rm -rf $(call ccm-config-dir,$(p))/crd/bases $(call ccm-config-dir,$(p))/rbac/role.yaml;)
+	rm -rf -- $(MANIFEST_GENERATED_FILES)
+	$(foreach p,$(CCM_PROVIDERS),rm -rf -- "$(call ccm-config-dir,$(p))/crd/bases" "$(call ccm-config-dir,$(p))/rbac/role.yaml" "$(call ccm-config-dir,$(p))/webhook/manifests.yaml";)
 
 .PHONY: generate
 generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.


### PR DESCRIPTION
RHOAIENG-55037

- Add clean-manifests Makefile target that removes generated manifest files (CRDs, RBAC role, webhook manifests) to enable regeneration from a clean state                                  
- Run make clean-manifests before make generate manifests api-docs in the check-file-updates CI workflow
                                                                                                                                                                                              
  This ensures the PR check catches manifest generation failures that would otherwise be masked by stale committed files — the exact class of bug seen in RHOAIENG-54987.                     
                                                                                                                                                                                              
  Details                                                                                                                                                                                     
                                                                       
  The existing CI workflow (check-file-updates.yaml) runs make generate manifests api-docs and checks for uncommitted diffs. However, it runs on top of already-committed generated files, so 
  if make manifests only succeeds because those files are already present, the check passes silently. Downstream, this causes Bundle Sync CI failures in ODH-Build-Config.
                                                                                                                                                                                              
  The fix adds a single step that deletes generated outputs (config/crd/bases/, config/crd/external/, config/rbac/role.yaml, config/webhook/manifests.yaml) before regeneration, proving that 
  manifests can be built from scratch.
                                                                                                                                                                                              
  Test plan                                                                                                                                                                                   
   
  - Verify make clean-manifests --dry-run expands to the correct rm -rf commands                                                                                                              
  - Verify make clean-manifests && make manifests regenerates all files with no diff

<!---
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully
- [ ] New RELATED_IMAGE mappings are already listed in ODH-Build-Config and RHOAI-Build-Config, and links are included in PR description

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->
These changes are not on E2E tests nor codebase

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Reorganized Makefile cleanup logic by separating manifest artifact removal into a dedicated `clean-manifests` target.
  * Introduced `MANIFEST_GENERATED_FILES` variable to track generated manifest paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->