### PR TITLE
fix: update to correct  branch to use

### DIFF
--- a/get_all_manifests.sh
+++ b/get_all_manifests.sh
@@ -71,10 +71,10 @@ declare -A ODH_COMPONENT_CHARTS=(
 
 # RHOAI Component Charts
 declare -A RHOAI_COMPONENT_CHARTS=(
-    ["cert-manager-operator"]="red-hat-data-services:odh-gitops:main@38fde97044b04fb7b0a37b58df3e7e6ce577ebeb:charts/dependencies/cert-manager-operator"
-    ["lws-operator"]="red-hat-data-services:odh-gitops:main@38fde97044b04fb7b0a37b58df3e7e6ce577ebeb:charts/dependencies/lws-operator"
-    ["sail-operator"]="red-hat-data-services:odh-gitops:main@38fde97044b04fb7b0a37b58df3e7e6ce577ebeb:charts/dependencies/sail-operator"
-    ["gateway-api"]="red-hat-data-services:odh-gitops:main@38fde97044b04fb7b0a37b58df3e7e6ce577ebeb:charts/dependencies/gateway-api"
+    ["cert-manager-operator"]="red-hat-data-services:odh-gitops:rhoai-3.4@eaeef9830e88ff9a6f588d4b1cb38efd3cb54cc2:charts/dependencies/cert-manager-operator"
+    ["lws-operator"]="red-hat-data-services:odh-gitops:rhoai-3.4@eaeef9830e88ff9a6f588d4b1cb38efd3cb54cc2:charts/dependencies/lws-operator"
+    ["sail-operator"]="red-hat-data-services:odh-gitops:rhoai-3.4@eaeef9830e88ff9a6f588d4b1cb38efd3cb54cc2:charts/dependencies/sail-operator"
+    ["gateway-api"]="red-hat-data-services:odh-gitops:rhoai-3.4@eaeef9830e88ff9a6f588d4b1cb38efd3cb54cc2:charts/dependencies/gateway-api"
 )
 
 # Select the appropriate manifest based on platform type

--- a/get_all_manifests.sh
+++ b/get_all_manifests.sh
@@ -54,7 +54,7 @@ declare -A RHOAI_COMPONENT_MANIFESTS=(
     ["maas"]="red-hat-data-services:maas-billing:rhoai-3.4@c04f0e2b68f545fbe2deca2ca9b19972e3baac0b:deployment"
     ["mlflowoperator"]="red-hat-data-services:mlflow-operator:rhoai-3.4@45ad3d560ce1e241733e55614d157f53c7cbeacc:config"
     ["sparkoperator"]="red-hat-data-services:spark-operator:rhoai-3.4@8ecee53b4752854eeff7456ddaf9a81251147ca4:config"
-    ["wva"]="red-hat-data-services:workload-variant-autoscaler:rhoai-3.4-ea.2@da1e961bf28f9db47b30f9ba52b4f08a3177c258:config"
+    ["wva"]="red-hat-data-services:workload-variant-autoscaler:rhoai-3.4@63b6911bb789e5fbc800e526cea2cc5168a2543c:config"
 )
 
 # {ODH,RHOAI}_COMPONENT_CHARTS are lists of chart repositories info to fetch helm charts
@@ -71,6 +71,10 @@ declare -A ODH_COMPONENT_CHARTS=(
 
 # RHOAI Component Charts
 declare -A RHOAI_COMPONENT_CHARTS=(
+    ["cert-manager-operator"]="red-hat-data-services:odh-gitops:main@38fde97044b04fb7b0a37b58df3e7e6ce577ebeb:charts/dependencies/cert-manager-operator"
+    ["lws-operator"]="red-hat-data-services:odh-gitops:main@38fde97044b04fb7b0a37b58df3e7e6ce577ebeb:charts/dependencies/lws-operator"
+    ["sail-operator"]="red-hat-data-services:odh-gitops:main@38fde97044b04fb7b0a37b58df3e7e6ce577ebeb:charts/dependencies/sail-operator"
+    ["gateway-api"]="red-hat-data-services:odh-gitops:main@38fde97044b04fb7b0a37b58df3e7e6ce577ebeb:charts/dependencies/gateway-api"
 )
 
 # Select the appropriate manifest based on platform type


### PR DESCRIPTION
<!---
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->
- originally when wva was intregraded to operator, there was no 3.4 branch in RHDS created
so it was set to u se 3.4-ea2 but this never got updated so the SHA1 keeps using the tip of the 3.4-ea2 branch
- another thing is since we start use the code from RHDS odh-gitops, empty map for RHDS pulls down the ODH one with new changes which might not be for 3.4

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully
- [ ] New RELATED_IMAGE mappings are already listed in ODH-Build-Config and RHOAI-Build-Config, and links are included in PR description

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [ ] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the workload-variant-autoscaler component manifest reference to a new pinned version.
  * Added four new chart dependencies: cert-manager-operator, lws-operator, sail-operator, and gateway-api to the component manifest collection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->