### PR TITLE
fix: unit test failures

### DIFF
--- a/.github/workflows/test-kind-odh-e2e.yaml
+++ b/.github/workflows/test-kind-odh-e2e.yaml
@@ -16,8 +16,8 @@ env:
 jobs:
   get-merge-commit:
     if: >-
-      github.event.action == 'labeled' && github.event.label.name == 'run-xks-e2e'
-      || github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'run-xks-e2e')
+      github.event.action == 'labeled' && github.event.label.name == 'run-xks-e2e' ||
+      github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'run-xks-e2e')
     name: Get merge commit
     uses: ./.github/workflows/get-merge-commit.yaml
 
@@ -26,8 +26,8 @@ jobs:
     # Label gate: only runs when a maintainer adds this label, preventing
     # untrusted fork PRs from executing arbitrary code with repo secrets.
     if: >-
-      github.event.action == 'labeled' && github.event.label.name == 'run-xks-e2e'
-      || github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'run-xks-e2e')
+      github.event.action == 'labeled' && github.event.label.name == 'run-xks-e2e' ||
+      github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'run-xks-e2e')
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -71,16 +71,12 @@ jobs:
         run: |
           kubectl create namespace opendatahub-operator-system
 
-      - name: Create Cloud Manager Namespace
-        run: |
-          kubectl create namespace opendatahub-cloudmanager-system
-
       - name: Deploy Cloud Manager
         timeout-minutes: 15
         run: |
           make deploy-ccm-local-azure
           echo "Waiting for Cloud Manager deployment to be available..."
-          kubectl rollout status deployment -n opendatahub-cloudmanager-system -l control-plane=controller-manager --timeout=180s          
+          kubectl rollout status deployment -n opendatahub-cloudmanager-system -l control-plane=controller-manager --timeout=180s
           echo "✅ Cloud Manager is Ready!"
 
       - name: Deploy AzureKubernetesEngine CR
@@ -113,6 +109,7 @@ jobs:
       - name: Collect Cloud Manager logs on failure
         if: failure()
         run: |
+          kubectl get azurekubernetesengine -o yaml || true
           kubectl -n opendatahub-cloudmanager-system describe pods -l control-plane=controller-manager || true
           kubectl logs -n opendatahub-cloudmanager-system \
             -l control-plane=controller-manager \
@@ -121,6 +118,7 @@ jobs:
       - name: Collect ODH Operator logs on failure
         if: failure()
         run: |
+          kubectl get kserve -o yaml || true
           kubectl -n opendatahub-operator-system describe pods -l control-plane=controller-manager || true
           kubectl logs -n opendatahub-operator-system \
             -l control-plane=controller-manager \

--- a/.github/workflows/test-kind-odh-e2e.yaml
+++ b/.github/workflows/test-kind-odh-e2e.yaml
@@ -95,14 +95,6 @@ jobs:
           kubectl wait --for=condition=Available deployment/opendatahub-operator-controller-manager -n opendatahub-operator-system --timeout=600s
           echo "✅ ODH is Ready!"
 
-      - name: Deploy KServe CR
-        timeout-minutes: 15
-        run: |
-          kubectl apply -f config/rhaii/samples/kserve.yaml
-          echo "Waiting for Kserve CR default-kserve to be Ready..."
-          kubectl wait --for=condition=Ready kserve/default-kserve --timeout=300s
-          echo "✅ Kserve CR is Ready!"
-
       - name: Run E2E Tests
         run: make e2e-test-xks
 

--- a/Makefile
+++ b/Makefile
@@ -856,7 +856,7 @@ kind-setup-pull-secrets: ## Setup pull secrets for operator dependencies in the 
 		exit 1; \
 	fi
 	@if [ ! -f "$(PULL_SECRET)" ]; then \
-		echo "Error: PULL_SECRET file '$(PULL_SECRET)' does not exist."; \
+		echo "Error: PULL_SECRET file '$(PULL_SECRET)' does not exist. Use '\$$HOME' instead of '~'."; \
 		exit 1; \
 	fi
 	@for ns in $(PULL_SECRET_NAMESPACES); do \

--- a/config/rhaii/odh-operator/manager_patch.yaml
+++ b/config/rhaii/odh-operator/manager_patch.yaml
@@ -63,11 +63,3 @@ spec:
           value: REPLACE_RHAI_VERSION
         - name: ODH_PLATFORM_TYPE
           value: XKS
-        - name: RHAI_CA_SECRET_NAME
-          value: rhai-ca
-        - name: RHAI_CA_SECRET_NAMESPACE
-          value: cert-manager
-        - name: RHAI_ISSUER_REF_NAME
-          value: rhai-ca-issuer
-        - name: RHAI_ISTIO_CA_CERTIFICATE_PATH
-          value: /var/run/secrets/rhai/ca.crt

--- a/pkg/cluster/cluster_config.go
+++ b/pkg/cluster/cluster_config.go
@@ -410,7 +410,7 @@ func getClusterInfo(ctx context.Context, cli client.Client) (ClusterInfo, error)
 	// Auto-detect: if the ClusterVersion CRD is absent this is not OpenShift.
 	ocpVersion, err := getOCPVersion(ctx, cli)
 	if err != nil {
-		if meta.IsNoMatchError(err) || k8serr.IsForbidden(err) {
+		if meta.IsNoMatchError(err) {
 			c.Type = ClusterTypeKubernetes
 			return c, nil
 		}
@@ -438,9 +438,6 @@ func IsFipsEnabled(ctx context.Context, cli client.Client) (bool, error) {
 	}
 
 	if err := cli.Get(ctx, namespacedName, cm); err != nil {
-		if k8serr.IsNotFound(err) || k8serr.IsForbidden(err) {
-			return false, nil
-		}
 		return false, err
 	}
 

--- a/pkg/cluster/cluster_config_test.go
+++ b/pkg/cluster/cluster_config_test.go
@@ -19,6 +19,8 @@ import (
 
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
+
+	. "github.com/onsi/gomega"
 )
 
 // erroringClient is a wrapper around a client.Client that allows us to inject errors.
@@ -153,6 +155,8 @@ invalid: yaml`,
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+
 			// Create a fake client
 			var fakeClient client.Client
 			if tc.configMap != nil || tc.clientErr != nil {
@@ -177,38 +181,30 @@ invalid: yaml`,
 			result, err := cluster.IsFipsEnabled(ctx, fakeClient)
 
 			// Check the result
-			if result != tc.expectedResult {
-				t.Errorf("IsFIPSEnabled() = %v, want %v", result, tc.expectedResult)
-			}
+			g.Expect(result).Should(Equal(tc.expectedResult))
 
-			// Check the error.  We need to handle nil vs. non-nil errors carefully.
+			// Check the error
 			if tc.expectedError != nil {
-				switch {
-				case err == nil:
-					t.Errorf("IsFIPSEnabled() error = nil, want %v", tc.expectedError)
-				case k8serr.IsNotFound(tc.expectedError):
-					if !k8serr.IsNotFound(err) {
-						t.Errorf("IsFipsEnabled() error = %v, want NotFound error", err)
-					}
-				default:
-					if err.Error() != tc.expectedError.Error() {
-						t.Errorf("IsFIPSEnabled() error = %v, want %v", err, tc.expectedError)
-					}
+				g.Expect(err).Should(HaveOccurred())
+				if k8serr.IsNotFound(tc.expectedError) {
+					g.Expect(k8serr.IsNotFound(err)).Should(BeTrue())
+				} else {
+					g.Expect(err).Should(MatchError(tc.expectedError.Error()))
 				}
-			} else if err != nil {
-				t.Errorf("IsFIPSEnabled() error = %v, want nil", err)
+			} else {
+				g.Expect(err).ShouldNot(HaveOccurred())
 			}
 		})
 	}
 }
 
 func TestGetClusterAuthenticationMode(t *testing.T) {
+	g := NewWithT(t)
+
 	// Register the configv1 scheme
 	scheme := runtime.NewScheme()
 	err := configv1.AddToScheme(scheme)
-	if err != nil {
-		t.Fatalf("failed to add configv1 scheme: %v", err)
-	}
+	g.Expect(err).ShouldNot(HaveOccurred())
 
 	testCases := []struct {
 		name          string
@@ -293,6 +289,7 @@ func TestGetClusterAuthenticationMode(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
 			ctx := context.Background()
 
 			var fakeClient client.Client
@@ -306,30 +303,25 @@ func TestGetClusterAuthenticationMode(t *testing.T) {
 			result, err := cluster.GetClusterAuthenticationMode(ctx, fakeClient)
 
 			if tc.expectedError {
-				if err == nil {
-					t.Errorf("GetClusterAuthenticationMode() expected error but got nil")
-				} else if tc.errorType == "notfound" && !k8serr.IsNotFound(err) {
-					t.Errorf("GetClusterAuthenticationMode() expected NotFound error but got %v", err)
+				g.Expect(err).Should(HaveOccurred())
+				if tc.errorType == "notfound" {
+					g.Expect(k8serr.IsNotFound(err)).Should(BeTrue())
 				}
 			} else {
-				if err != nil {
-					t.Errorf("GetClusterAuthenticationMode() unexpected error: %v", err)
-				}
-				if result != tc.expectedMode {
-					t.Errorf("GetClusterAuthenticationMode() = %v, want %v", result, tc.expectedMode)
-				}
+				g.Expect(err).ShouldNot(HaveOccurred())
+				g.Expect(result).Should(Equal(tc.expectedMode))
 			}
 		})
 	}
 }
 
 func TestIsIntegratedOAuth(t *testing.T) {
+	g := NewWithT(t)
+
 	// Register the configv1 scheme
 	scheme := runtime.NewScheme()
 	err := configv1.AddToScheme(scheme)
-	if err != nil {
-		t.Fatalf("failed to add configv1 scheme: %v", err)
-	}
+	g.Expect(err).ShouldNot(HaveOccurred())
 
 	testCases := []struct {
 		name           string
@@ -411,6 +403,7 @@ func TestIsIntegratedOAuth(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
 			ctx := context.Background()
 
 			var fakeClient client.Client
@@ -424,16 +417,10 @@ func TestIsIntegratedOAuth(t *testing.T) {
 			result, err := cluster.IsIntegratedOAuth(ctx, fakeClient)
 
 			if tc.expectedError {
-				if err == nil {
-					t.Errorf("IsIntegratedOAuth() expected error but got nil")
-				}
+				g.Expect(err).Should(HaveOccurred())
 			} else {
-				if err != nil {
-					t.Errorf("IsIntegratedOAuth() unexpected error: %v", err)
-				}
-				if result != tc.expectedResult {
-					t.Errorf("IsIntegratedOAuth() = %v, want %v", result, tc.expectedResult)
-				}
+				g.Expect(err).ShouldNot(HaveOccurred())
+				g.Expect(result).Should(Equal(tc.expectedResult))
 			}
 		})
 	}

--- a/tests/e2e/components_test.go
+++ b/tests/e2e/components_test.go
@@ -86,16 +86,12 @@ func (tc *ComponentTestCtx) ValidateComponentEnabled(t *testing.T) {
 
 	skipUnless(t, Smoke, Tier1)
 
-	// if the cluster is Openshift, we rely in the DSC. If not, in the component CR existence
 	if !tc.IsXKS() {
 		// As these tests can be executed in a non-cleaned scenario, we need to move the component first to Removed.
 		tc.UpdateComponentStateInDataScienceCluster(operatorv1.Removed)
-
-		// Ensure that DataScienceCluster exists and its component state is "Managed", with the "Ready" condition true.
-		tc.UpdateComponentStateInDataScienceCluster(operatorv1.Managed)
-	} else {
-		tc.CheckComponentResourceExistsOrNot(operatorv1.Managed)
 	}
+
+	tc.UpdateComponentState(operatorv1.Managed)
 
 	// Ensure the component resource exists and is marked "Ready".
 	// Note: Ready=True already implies deployments exist and are ready (checked by DeploymentsAvailable condition)
@@ -129,8 +125,7 @@ func (tc *ComponentTestCtx) ValidateComponentDisabled(t *testing.T) {
 	// Ensure that the resources associated with the component exist
 	tc.EnsureResourcesExist(WithMinimalObject(tc.GVK, tc.NamespacedName))
 
-	// Ensure that DataScienceCluster exists and its component state is "Removed", with the "Ready" condition false.
-	tc.UpdateComponentStateInDataScienceCluster(operatorv1.Removed)
+	tc.UpdateComponentState(operatorv1.Removed)
 
 	// Ensure that any Deployment resources for the component are not present
 	tc.EnsureResourcesGone(
@@ -469,9 +464,28 @@ func (tc *ComponentTestCtx) ValidateComponentCondition(gvk schema.GroupVersionKi
 // UpdateComponentState updates the management state of a specified component in the DataScienceCluster or in the Component CR depending on the kind of cluster.
 func (tc *ComponentTestCtx) UpdateComponentState(state operatorv1.ManagementState) {
 	if !tc.IsXKS() {
+		// Ensure that DataScienceCluster exists and its component state is "Managed", with the "Ready" condition true.
 		tc.UpdateComponentStateInDataScienceCluster(state)
-	} else {
-		tc.CheckComponentResourceExistsOrNot(state)
+
+		return
+	}
+
+	if state == operatorv1.Managed {
+		tc.EventuallyResourceCreatedOrUpdated(
+			WithObjectToCreate(tc.CreateComponent(tc.GVK)),
+			WithCondition(jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, status.ConditionTypeReady, metav1.ConditionTrue)),
+			WithEventuallyTimeout(tc.TestTimeouts.mediumEventuallyTimeout),
+		)
+
+		return
+	}
+	if state == operatorv1.Removed {
+		tc.DeleteResource(
+			WithMinimalObject(tc.GVK, types.NamespacedName{Name: tc.GetInstanceName(tc.GVK)}),
+			WithForegroundDeletion(),
+			WithWaitForDeletion(true),
+			WithEventuallyTimeout(tc.TestTimeouts.mediumEventuallyTimeout),
+		)
 	}
 }
 
@@ -483,6 +497,10 @@ func (tc *ComponentTestCtx) CheckComponentResourceExistsOrNot(state operatorv1.M
 
 // UpdateComponentStateInDataScienceCluster updates the management state of a specified component in the DataScienceCluster.
 func (tc *ComponentTestCtx) UpdateComponentStateInDataScienceCluster(state operatorv1.ManagementState) {
+	if tc.IsXKS() {
+		tc.Logf("Updating component state in DataScienceCluster is not supported on XKS platform, skipping")
+		return
+	}
 	tc.UpdateComponentStateInDataScienceClusterWithKind(state, tc.GVK.Kind)
 }
 
@@ -533,6 +551,7 @@ func (tc *ComponentTestCtx) ValidateModelControllerInstance(t *testing.T) {
 	t.Helper()
 
 	skipUnless(t, Smoke)
+	tc.SkipIfXKSCluster(t)
 
 	// Ensure ModelController resource exists with the expected owner references and status phase.
 	tc.EnsureResourceExists(

--- a/tests/e2e/kserve_test.go
+++ b/tests/e2e/kserve_test.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	azurev1alpha1 "github.com/opendatahub-io/opendatahub-operator/v2/api/cloudmanager/azure/v1alpha1"
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/api/components/v1alpha1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/components/kserve"
 	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/status"
@@ -98,12 +99,6 @@ func (tc *KserveTestCtx) ValidateSpec(t *testing.T) {
 
 	// Retrieve the DataScienceCluster instance.
 	dsc := tc.FetchDataScienceCluster()
-	if dsc == nil {
-		if tc.IsXKS() {
-			t.Skip("Skipping DataScienceCluster validation on XKS as DSC is not present")
-		}
-		t.Fatal("DataScienceCluster not found")
-	}
 
 	tc.EnsureResourceExists(
 		WithMinimalObject(gvk.Kserve, types.NamespacedName{Name: componentApi.KserveInstanceName}),
@@ -120,6 +115,9 @@ func (tc *KserveTestCtx) ValidateNoKserveFeatureTrackers(t *testing.T) {
 	t.Helper()
 
 	skipUnless(t, Smoke)
+
+	// FeatureTrackers are not supported on XKS platform (also CRD are not installed), skip the test
+	tc.SkipIfXKSCluster(t)
 
 	tc.EnsureResourcesDoNotExist(
 		WithMinimalObject(gvk.FeatureTracker, tc.NamespacedName),
@@ -223,6 +221,13 @@ func (tc *KserveTestCtx) ValidateExternalOperatorDegradedMonitoring(t *testing.T
 
 	skipUnless(t, Tier1)
 
+	kserveNN := types.NamespacedName{Name: componentApi.KserveInstanceName}
+
+	if tc.IsXKS() {
+		tc.runXKSDegradedMonitoringTest(t, kserveNN)
+		return
+	}
+
 	// condition types monitored by the Kserve Component
 	testCases := []degradedConditionTestCase{
 		{
@@ -241,8 +246,6 @@ func (tc *KserveTestCtx) ValidateExternalOperatorDegradedMonitoring(t *testing.T
 			conditionStatus: metav1.ConditionFalse,
 		},
 	}
-
-	kserveNN := types.NamespacedName{Name: componentApi.KserveInstanceName}
 
 	// Scale external operator only; per-case helpers handle condition clears
 	t.Logf("Ensuring LWS operator deployment is scaled down to prevent condition reset (namespace=%s, name=%s).", leaderWorkerSetNamespace, lwsOperatorDeploymentName)
@@ -379,4 +382,55 @@ func (tc *KserveTestCtx) runDegradedConditionTest(t *testing.T, testCase degrade
 	)
 
 	t.Logf("Test case passed: %s", testCase.name)
+}
+
+// runXKSDegradedMonitoringTest verifies that setting the AzureKubernetesEngine LWS dependency
+// to Unmanaged causes the Kserve DependenciesAvailable condition to become False,
+// and that setting it back to Managed restores it to True.
+func (tc *KserveTestCtx) runXKSDegradedMonitoringTest(t *testing.T, kserveNN types.NamespacedName) {
+	t.Helper()
+
+	t.Logf("Verifying Kserve component DependenciesAvailable=True before test (name=%s).", kserveNN.Name)
+	tc.EnsureResourceExists(
+		WithMinimalObject(tc.GVK, kserveNN),
+		WithCondition(
+			jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, status.ConditionDependenciesAvailable, metav1.ConditionTrue),
+		),
+	)
+
+	t.Logf("Setting AzureKubernetesEngine LWS managementPolicy to Unmanaged.")
+	tc.EventuallyResourceCreatedOrUpdated(
+		WithMinimalObject(gvk.AzureKubernetesEngine, types.NamespacedName{Name: azurev1alpha1.AzureKubernetesEngineInstanceName}),
+		WithMutateFunc(func(obj *unstructured.Unstructured) error {
+			return unstructured.SetNestedField(obj.Object, "Unmanaged", "spec", "dependencies", "lws", "managementPolicy")
+		}),
+		WithCustomErrorMsg("Failed to set AzureKubernetesEngine LWS managementPolicy to Unmanaged"),
+	)
+
+	t.Logf("Verifying Kserve component DependenciesAvailable=False after setting LWS to Unmanaged (name=%s).", kserveNN.Name)
+	tc.EnsureResourceExists(
+		WithMinimalObject(tc.GVK, kserveNN),
+		WithCondition(
+			jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, status.ConditionDependenciesAvailable, metav1.ConditionFalse),
+		),
+	)
+
+	t.Logf("Setting AzureKubernetesEngine LWS managementPolicy back to Managed.")
+	tc.EventuallyResourceCreatedOrUpdated(
+		WithMinimalObject(gvk.AzureKubernetesEngine, types.NamespacedName{Name: azurev1alpha1.AzureKubernetesEngineInstanceName}),
+		WithMutateFunc(func(obj *unstructured.Unstructured) error {
+			return unstructured.SetNestedField(obj.Object, "Managed", "spec", "dependencies", "lws", "managementPolicy")
+		}),
+		WithCustomErrorMsg("Failed to set AzureKubernetesEngine LWS managementPolicy to Managed"),
+	)
+
+	t.Logf("Verifying Kserve component DependenciesAvailable=True after restoring LWS to Managed (name=%s).", kserveNN.Name)
+	tc.EnsureResourceExists(
+		WithMinimalObject(tc.GVK, kserveNN),
+		WithCondition(
+			jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, status.ConditionDependenciesAvailable, metav1.ConditionTrue),
+		),
+	)
+
+	t.Log("XKS external operator degraded monitoring test passed")
 }

--- a/tests/e2e/test_context_test.go
+++ b/tests/e2e/test_context_test.go
@@ -790,9 +790,25 @@ func (tc *TestContext) EnsureCRDEstablished(name string) {
 		), "Expected CRD condition 'Established' to be True for CRD %s", name)
 }
 
+func (tc *TestContext) GetInstanceName(gvk schema.GroupVersionKind) string {
+	return fmt.Sprintf("default-%s", strings.ToLower(gvk.Kind))
+}
+
+func (tc *TestContext) CreateComponent(gvk schema.GroupVersionKind) *unstructured.Unstructured {
+	instanceName := tc.GetInstanceName(gvk)
+	return &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": gvk.GroupVersion().String(),
+			"kind":       gvk.Kind,
+			"metadata":   map[string]interface{}{"name": instanceName},
+			"spec":       map[string]interface{}{},
+		},
+	}
+}
+
 // CheckComponentResourceExistsOrNotWithKind validates if a component resource's state and readiness match the expected values.
 func (tc *TestContext) CheckComponentResourceExistsOrNotWithKind(shouldExist bool, gvk schema.GroupVersionKind) {
-	instanceName := "default-" + strings.ToLower(gvk.Kind)
+	instanceName := tc.GetInstanceName(gvk)
 
 	// Check if the component CR exists or not depending on the shouldExist flag
 	if shouldExist {


### PR DESCRIPTION
<!---
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
Unit test in main are failing, the changes done in cluster_config in #3421 change the actual behaviour of the operator. 
I reverted the behavior as the PR which change it was not related to change this. 
Also, updated those tests to use gomega (unit test failure was not easy to understand without using gomega checks).

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully
- [ ] New RELATED_IMAGE mappings are already listed in ODH-Build-Config and RHOAI-Build-Config, and links are included in PR description

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->
Fix unit test failures

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More accurate cluster-type detection and FIPS checks; API errors are no longer silently ignored and are surfaced to callers.

* **Tests**
  * Replaced fragile checks with clearer matchers; centralized component state handling, added XKS-aware test flows, and introduced shared helpers for component naming/creation.

* **Chores**
  * Updated CI workflow and failure diagnostics, clarified Makefile error guidance, and removed several RHAI certificate/issuer environment variables from the operator patch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->