### PR TITLE
fixing e2e tests in xks

### DIFF
--- a/tests/e2e/cfmap_deletion_test.go
+++ b/tests/e2e/cfmap_deletion_test.go
@@ -58,6 +58,8 @@ func cfgMapDeletionTestSuite(t *testing.T) {
 func (tc *CfgMapDeletionTestCtx) ValidateDSCDeletionUsingConfigMap(t *testing.T) {
 	t.Helper()
 
+	tc.SkipIfXKSCluster(t)
+
 	skipUnless(t, Tier3)
 
 	// Create or update the deletion config map
@@ -88,6 +90,8 @@ func (tc *CfgMapDeletionTestCtx) ValidateDSCDeletionUsingConfigMap(t *testing.T)
 // ValidateOwnedNamespacesAllExist verifies that the owned namespaces exist.
 func (tc *CfgMapDeletionTestCtx) ValidateOwnedNamespacesAllExist(t *testing.T) {
 	t.Helper()
+
+	tc.SkipIfXKSCluster(t)
 
 	skipUnless(t, Tier3)
 

--- a/tests/e2e/test_context_test.go
+++ b/tests/e2e/test_context_test.go
@@ -1436,7 +1436,7 @@ func (tc *TestContext) FetchPlatformRelease() common.Platform {
 // Returns:
 //   - *dsciv2.DSCInitialization: The retrieved DSCInitialization object.
 func (tc *TestContext) FetchDSCInitialization() *dsciv2.DSCInitialization {
-	// In XKS, DSCInitialization does not exist
+	// In XKS, DSCInitialization does not exist, so returning nil
 	if tc.IsXKS() {
 		return nil
 	}
@@ -1456,7 +1456,7 @@ func (tc *TestContext) FetchDSCInitialization() *dsciv2.DSCInitialization {
 // Returns:
 //   - *dsciv2.DataScienceCluster: The retrieved DataScienceCluster object.
 func (tc *TestContext) FetchDataScienceCluster() *dscv2.DataScienceCluster {
-	// In XKS, DataScienceCluster does not exist
+	// In XKS, DataScienceCluster does not exist, so returning nil
 	if tc.IsXKS() {
 		return nil
 	}


### PR DESCRIPTION
<!---
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully
- [ ] New RELATED_IMAGE mappings are already listed in ODH-Build-Config and RHOAI-Build-Config, and links are included in PR description

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [ ] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated inline documentation for internal test utilities to clarify behavior on XKS platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->