### PR TITLE
Fix clusterhealth submodule import.

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -214,6 +214,22 @@ IsEnabled(dsc *dscv2.DataScienceCluster) bool
 - **Check Kubernetes errors**: Use `k8serr.IsNotFound(err)`, `k8serr.IsAlreadyExists(err)`, etc.
 - **Multierror support**: Use `github.com/hashicorp/go-multierror` for collecting multiple errors
 
+## Quality Gates (MANDATORY before completing any task)
+
+Before considering ANY code change complete, agents **MUST** run the following
+commands **every time** and fix all failures:
+
+```bash
+make generate manifests api-docs   # Regenerate all codegen (safe no-ops when unchanged)
+make fmt                           # Format code and imports
+make lint                          # Run golangci-lint
+```
+
+If any command fails, **you are not done** — fix the issues and re-run until
+all three pass cleanly. If a command produces new diff (e.g. generated code
+or formatting changes), ensure those changes are included before finishing
+and inform the user. Do NOT skip these steps or defer them to the reviewer.
+
 ## Critical Rules
 
 1. **Garbage collection action MUST be last** in the action chain

--- a/cmd/health-check/go.mod
+++ b/cmd/health-check/go.mod
@@ -3,7 +3,7 @@ module github.com/opendatahub-io/opendatahub-operator/v2/cmd/health-check
 go 1.25.7
 
 require (
-	github.com/opendatahub-io/opendatahub-operator/v2/pkg/clusterhealth v0.0.0
+	github.com/opendatahub-io/opendatahub-operator/pkg/clusterhealth v0.0.0
 	k8s.io/apimachinery v0.35.2
 	k8s.io/client-go v0.35.2
 	sigs.k8s.io/controller-runtime v0.22.4
@@ -50,4 +50,4 @@ require (
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )
 
-replace github.com/opendatahub-io/opendatahub-operator/v2/pkg/clusterhealth => ../../pkg/clusterhealth
+replace github.com/opendatahub-io/opendatahub-operator/pkg/clusterhealth => ../../pkg/clusterhealth

--- a/cmd/health-check/main.go
+++ b/cmd/health-check/main.go
@@ -16,7 +16,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	ctrl "sigs.k8s.io/controller-runtime/pkg/client/config"
 
-	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/clusterhealth"
+	"github.com/opendatahub-io/opendatahub-operator/pkg/clusterhealth"
 )
 
 const (

--- a/cmd/mcp-server/go.mod
+++ b/cmd/mcp-server/go.mod
@@ -4,7 +4,7 @@ go 1.25.7
 
 require (
 	github.com/mark3labs/mcp-go v0.32.0
-	github.com/opendatahub-io/opendatahub-operator/v2/pkg/clusterhealth v0.0.0
+	github.com/opendatahub-io/opendatahub-operator/pkg/clusterhealth v0.0.0
 	github.com/opendatahub-io/opendatahub-operator/v2/pkg/failureclassifier v0.0.0-00010101000000-000000000000
 	k8s.io/api v0.35.2
 	k8s.io/apimachinery v0.35.2
@@ -55,6 +55,6 @@ require (
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )
 
-replace github.com/opendatahub-io/opendatahub-operator/v2/pkg/clusterhealth => ../../pkg/clusterhealth
+replace github.com/opendatahub-io/opendatahub-operator/pkg/clusterhealth => ../../pkg/clusterhealth
 
 replace github.com/opendatahub-io/opendatahub-operator/v2/pkg/failureclassifier => ../../pkg/failureclassifier

--- a/cmd/mcp-server/tool_classify_failure.go
+++ b/cmd/mcp-server/tool_classify_failure.go
@@ -9,7 +9,7 @@ import (
 	"github.com/mark3labs/mcp-go/server"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/clusterhealth"
+	"github.com/opendatahub-io/opendatahub-operator/pkg/clusterhealth"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/failureclassifier"
 )
 

--- a/cmd/mcp-server/tool_classify_failure_test.go
+++ b/cmd/mcp-server/tool_classify_failure_test.go
@@ -3,7 +3,7 @@ package main
 import (
 	"testing"
 
-	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/clusterhealth"
+	"github.com/opendatahub-io/opendatahub-operator/pkg/clusterhealth"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/failureclassifier"
 )
 

--- a/cmd/mcp-server/tool_component_status.go
+++ b/cmd/mcp-server/tool_component_status.go
@@ -9,7 +9,7 @@ import (
 	"github.com/mark3labs/mcp-go/server"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/clusterhealth"
+	"github.com/opendatahub-io/opendatahub-operator/pkg/clusterhealth"
 )
 
 // registerComponentStatus adds the component_status tool to the MCP server.

--- a/cmd/mcp-server/tool_component_status_test.go
+++ b/cmd/mcp-server/tool_component_status_test.go
@@ -8,7 +8,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/clusterhealth"
+	"github.com/opendatahub-io/opendatahub-operator/pkg/clusterhealth"
 )
 
 func TestComponentStatus(t *testing.T) {

--- a/cmd/mcp-server/tool_describe_resource_test.go
+++ b/cmd/mcp-server/tool_describe_resource_test.go
@@ -69,7 +69,7 @@ func TestDescribeResource(t *testing.T) {
 		Data:       map[string][]byte{"password": []byte("s3cret")},
 	}
 	sa := &corev1.ServiceAccount{
-		ObjectMeta: metav1.ObjectMeta{Name: "my-sa", Namespace: "default"},
+		ObjectMeta:       metav1.ObjectMeta{Name: "my-sa", Namespace: "default"},
 		Secrets:          []corev1.ObjectReference{{Name: "my-sa-token"}},
 		ImagePullSecrets: []corev1.LocalObjectReference{{Name: "my-pull-secret"}},
 	}

--- a/cmd/mcp-server/tool_operator_dependencies.go
+++ b/cmd/mcp-server/tool_operator_dependencies.go
@@ -10,7 +10,7 @@ import (
 	"github.com/mark3labs/mcp-go/server"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/clusterhealth"
+	"github.com/opendatahub-io/opendatahub-operator/pkg/clusterhealth"
 )
 
 // registerOperatorDependencies adds the operator_dependencies tool to the MCP server.

--- a/cmd/mcp-server/tool_operator_dependencies_test.go
+++ b/cmd/mcp-server/tool_operator_dependencies_test.go
@@ -12,7 +12,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/clusterhealth"
+	"github.com/opendatahub-io/opendatahub-operator/pkg/clusterhealth"
 )
 
 func makeDeployment(ns, name string, ready, replicas int32) *appsv1.Deployment {

--- a/cmd/mcp-server/tool_platform_health.go
+++ b/cmd/mcp-server/tool_platform_health.go
@@ -9,7 +9,7 @@ import (
 	"github.com/mark3labs/mcp-go/server"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/clusterhealth"
+	"github.com/opendatahub-io/opendatahub-operator/pkg/clusterhealth"
 )
 
 // registerPlatformHealth adds the platform_health tool to the MCP server.

--- a/cmd/mcp-server/tool_platform_health_test.go
+++ b/cmd/mcp-server/tool_platform_health_test.go
@@ -10,7 +10,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/clusterhealth"
+	"github.com/opendatahub-io/opendatahub-operator/pkg/clusterhealth"
 )
 
 // newFakeClient creates a controller-runtime fake client with core + apps schemes.

--- a/cmd/mcp-server/tool_recent_events.go
+++ b/cmd/mcp-server/tool_recent_events.go
@@ -13,7 +13,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/clusterhealth"
+	"github.com/opendatahub-io/opendatahub-operator/pkg/clusterhealth"
 )
 
 // registerRecentEvents adds the recent_events tool to MCP server.

--- a/cmd/mcp-server/tool_recent_events_test.go
+++ b/cmd/mcp-server/tool_recent_events_test.go
@@ -13,7 +13,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/clusterhealth"
+	"github.com/opendatahub-io/opendatahub-operator/pkg/clusterhealth"
 )
 
 func makeEvent(ns, name, kind, objName, etype, reason, msg string, lastTime time.Time) *corev1.Event {
@@ -23,7 +23,7 @@ func makeEvent(ns, name, kind, objName, etype, reason, msg string, lastTime time
 		Type:           etype,
 		Reason:         reason,
 		Message:        msg,
-		LastTimestamp:   metav1.NewTime(lastTime),
+		LastTimestamp:  metav1.NewTime(lastTime),
 	}
 }
 
@@ -114,9 +114,9 @@ func TestRecentEvents_SortOrder(t *testing.T) {
 
 func TestDiscoverODHNamespaces(t *testing.T) {
 	tests := []struct {
-		name    string
-		dsci    *unstructured.Unstructured
-		wantNS  string
+		name   string
+		dsci   *unstructured.Unstructured
+		wantNS string
 	}{
 		{"with DSCI", &unstructured.Unstructured{
 			Object: map[string]interface{}{

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/onsi/ginkgo/v2 v2.28.1
 	github.com/onsi/gomega v1.39.1
 	github.com/opendatahub-io/models-as-a-service/maas-controller v0.0.0-20260420142354-89fba298f42a
-	github.com/opendatahub-io/opendatahub-operator/v2/pkg/clusterhealth v0.0.0
+	github.com/opendatahub-io/opendatahub-operator/pkg/clusterhealth v0.0.0
 	github.com/opendatahub-io/opendatahub-operator/v2/pkg/failureclassifier v0.0.0-00010101000000-000000000000
 	github.com/openshift/api v0.0.0-20230823114715-5fdd7511b790
 	github.com/operator-framework/api v0.42.0
@@ -135,7 +135,7 @@ require (
 	sigs.k8s.io/structured-merge-diff/v6 v6.3.2 // indirect
 )
 
-replace github.com/opendatahub-io/opendatahub-operator/v2/pkg/clusterhealth => ./pkg/clusterhealth
+replace github.com/opendatahub-io/opendatahub-operator/pkg/clusterhealth => ./pkg/clusterhealth
 
 replace github.com/opendatahub-io/opendatahub-operator/v2/pkg/failureclassifier => ./pkg/failureclassifier
 

--- a/pkg/clusterhealth/README.md
+++ b/pkg/clusterhealth/README.md
@@ -2,7 +2,7 @@
 
 Library for running health and diagnostics checks against a Kubernetes cluster. It returns structured data only; callers decide logging and formatting.
 
-This is a **standalone Go module** (`github.com/opendatahub-io/opendatahub-operator/v2/pkg/clusterhealth`) that can be imported without pulling in the full operator dependency tree. Its only runtime dependencies are `controller-runtime`, `client-go`, and `k8s.io/apimachinery`.
+This is a **standalone Go module** (`github.com/opendatahub-io/opendatahub-operator/pkg/clusterhealth`) that can be imported without pulling in the full operator dependency tree. Its only runtime dependencies are `controller-runtime`, `client-go`, and `k8s.io/apimachinery`.
 
 ## Quick start
 
@@ -11,7 +11,7 @@ Build a `Config` with your controller-runtime client and namespace/CR names, the
 ```go
 import (
 	"context"
-	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/clusterhealth"
+	"github.com/opendatahub-io/opendatahub-operator/pkg/clusterhealth"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	ctrl "sigs.k8s.io/controller-runtime/pkg/client/config"

--- a/pkg/clusterhealth/go.mod
+++ b/pkg/clusterhealth/go.mod
@@ -1,4 +1,4 @@
-module github.com/opendatahub-io/opendatahub-operator/v2/pkg/clusterhealth
+module github.com/opendatahub-io/opendatahub-operator/pkg/clusterhealth
 
 go 1.25.7
 

--- a/pkg/failureclassifier/classifier.go
+++ b/pkg/failureclassifier/classifier.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/clusterhealth"
+	"github.com/opendatahub-io/opendatahub-operator/pkg/clusterhealth"
 )
 
 // PendingThreshold is the minimum duration a pod must be in Pending phase

--- a/pkg/failureclassifier/classifier_test.go
+++ b/pkg/failureclassifier/classifier_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/clusterhealth"
+	"github.com/opendatahub-io/opendatahub-operator/pkg/clusterhealth"
 )
 
 func assertClassification(t *testing.T, got FailureClassification, wantCategory, wantSubcategory string, wantErrorCode int, wantConfidence string) {

--- a/pkg/failureclassifier/go.mod
+++ b/pkg/failureclassifier/go.mod
@@ -2,7 +2,7 @@ module github.com/opendatahub-io/opendatahub-operator/v2/pkg/failureclassifier
 
 go 1.25.7
 
-require github.com/opendatahub-io/opendatahub-operator/v2/pkg/clusterhealth v0.0.0
+require github.com/opendatahub-io/opendatahub-operator/pkg/clusterhealth v0.0.0
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
@@ -47,4 +47,4 @@ require (
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )
 
-replace github.com/opendatahub-io/opendatahub-operator/v2/pkg/clusterhealth => ../clusterhealth
+replace github.com/opendatahub-io/opendatahub-operator/pkg/clusterhealth => ../clusterhealth

--- a/tests/e2e/cluster_health_test.go
+++ b/tests/e2e/cluster_health_test.go
@@ -10,7 +10,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	ctrlcfg "sigs.k8s.io/controller-runtime/pkg/client/config"
 
-	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/clusterhealth"
+	"github.com/opendatahub-io/opendatahub-operator/pkg/clusterhealth"
 )
 
 const healthCheckTimeout = 30 * time.Second

--- a/tests/e2e/debug_utils_test.go
+++ b/tests/e2e/debug_utils_test.go
@@ -20,9 +20,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	ctrlcfg "sigs.k8s.io/controller-runtime/pkg/client/config"
 
+	"github.com/opendatahub-io/opendatahub-operator/pkg/clusterhealth"
 	"github.com/opendatahub-io/opendatahub-operator/v2/api/common"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
-	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/clusterhealth"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/failureclassifier"
 )
 

--- a/tests/e2e/metrics_collector_test.go
+++ b/tests/e2e/metrics_collector_test.go
@@ -14,7 +14,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	ctrl "sigs.k8s.io/controller-runtime/pkg/client/config"
 
-	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/clusterhealth"
+	"github.com/opendatahub-io/opendatahub-operator/pkg/clusterhealth"
 )
 
 const (


### PR DESCRIPTION
<!---
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->
remove /v2 from clusterhealth submodule path to enable external iimport

The module path github.com/opendatahub-io/opendatahub-operator/v2/pkg/clusterhealth
is unfetchable by external consumers because Go interprets /v2 in the middle
of the path as part of the subdirectory (not as a major version suffix), causing
it to look for go.mod at v2/pkg/clusterhealth/ which doesn't exist.
Renaming to github.com/opendatahub-io/opendatahub-operator/pkg/clusterhealth
aligns the module path with the actual directory layout (pkg/clusterhealth/),
making it resolvable via the Go module proxy once tagged as
pkg/clusterhealth/v0.2.0.
<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [x] The developer has run the integration test pipeline and verified that it passed successfully
- [x] New RELATED_IMAGE mappings are already listed in ODH-Build-Config and RHOAI-Build-Config, and links are included in PR description

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->
No E2E required for the submodule change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated internal module dependency references across the codebase for consistency.
  * Formalized a mandatory pre-completion checklist in the project documentation requiring code generation, formatting, and linting steps to pass and any generated diffs to be committed before completion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->