### PR TITLE
RHOAIENG-58364: feat(kserve): apply LLMInferenceServiceConfig resources last during deploy

### DIFF
--- a/internal/controller/components/kserve/kserve_controller.go
+++ b/internal/controller/components/kserve/kserve_controller.go
@@ -18,6 +18,7 @@ package kserve
 
 import (
 	"context"
+	"slices"
 	"strings"
 
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
@@ -26,6 +27,7 @@ import (
 	networkingv1 "k8s.io/api/networking/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
@@ -46,6 +48,7 @@ import (
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/reconciler"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/metadata/labels"
+	pkgresources "github.com/opendatahub-io/opendatahub-operator/v2/pkg/resources"
 )
 
 // NewComponentReconciler creates a ComponentReconciler for the Kserve API.
@@ -158,7 +161,7 @@ func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.
 		}).
 		WithAction(deploy.NewAction(
 			deploy.WithCache(),
-			deploy.WithApplyOrder(),
+			WithApplyOrderLLMInferenceServiceConfigLast(),
 		)).
 		WithAction(deployments.NewAction()).
 		// must be the final action
@@ -169,4 +172,48 @@ func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.
 		Build(ctx)
 
 	return err
+}
+
+// WithApplyOrderLLMInferenceServiceConfigLast returns a deploy option that sorts
+// resources using the standard apply order (CRDs first, webhooks last), then
+// moves all LLMInferenceServiceConfig resources to the very end.
+//
+// This ordering is critical for upgrades (e.g. 3.3 → 3.4). In 3.3, a single
+// kserve controller handled LLMInferenceServiceConfig validation. In 3.4,
+// validation moves to the separate llmisvc controller with its own webhook.
+// During upgrades the kserve controller is updated to 3.4 first, but the old
+// ValidatingWebhookConfiguration still points to kserve-webhook-server-service
+// which no longer serves the LLMInferenceServiceConfig validation endpoint.
+// Since WithApplyOrder places webhooks last, if LLMInferenceServiceConfig
+// resources are applied before the new ValidatingWebhookConfiguration replaces
+// the old one, validation fails and the operator stops — preventing the new
+// webhook configuration from ever being applied.
+// Placing LLMInferenceServiceConfig resources after webhooks ensures the new
+// ValidatingWebhookConfiguration is applied first.
+func WithApplyOrderLLMInferenceServiceConfigLast() deploy.ActionOpts {
+	return deploy.WithSortFn(deploy.SortFn(pkgresources.SortByApplyOrder).Then(sortLLMInferenceServiceConfigLast))
+}
+
+func sortLLMInferenceServiceConfigLast(_ context.Context, objects []unstructured.Unstructured) ([]unstructured.Unstructured, error) {
+	result := objects
+	// Stable-sort LLMInferenceServiceConfig resources after everything else
+	// so they are applied only once the webhook(s) are updated.
+	slices.SortStableFunc(result, func(a, b unstructured.Unstructured) int {
+		if isLLMInferenceServiceConfig(a) && isLLMInferenceServiceConfig(b) {
+			// Keep the original order.
+			return 0
+		}
+		if isLLMInferenceServiceConfig(a) {
+			return 1
+		}
+		if isLLMInferenceServiceConfig(b) {
+			return -1
+		}
+		return 0
+	})
+	return result, nil
+}
+
+func isLLMInferenceServiceConfig(r unstructured.Unstructured) bool {
+	return r.GetKind() == gvk.LLMInferenceServiceConfigV1Alpha2.Kind
 }

--- a/internal/controller/components/kserve/kserve_controller.go
+++ b/internal/controller/components/kserve/kserve_controller.go
@@ -215,5 +215,6 @@ func sortLLMInferenceServiceConfigLast(_ context.Context, objects []unstructured
 }
 
 func isLLMInferenceServiceConfig(r unstructured.Unstructured) bool {
-	return r.GetKind() == gvk.LLMInferenceServiceConfigV1Alpha2.Kind
+	return r.GroupVersionKind().Group == gvk.LLMInferenceServiceConfigV1Alpha2.Group &&
+		r.GetKind() == gvk.LLMInferenceServiceConfigV1Alpha2.Kind
 }

--- a/internal/controller/components/kserve/kserve_controller_actions_test.go
+++ b/internal/controller/components/kserve/kserve_controller_actions_test.go
@@ -784,6 +784,9 @@ func TestSortLLMInferenceServiceConfigLast(t *testing.T) {
 		result, err := sortLLMInferenceServiceConfigLast(ctx, input)
 		g.Expect(err).NotTo(HaveOccurred())
 		g.Expect(result).To(HaveLen(3))
+		g.Expect(result[0].GetName()).To(Equal("deploy"))
+		g.Expect(result[1].GetName()).To(Equal("svc"))
+		g.Expect(result[2].GetName()).To(Equal("cm"))
 	})
 
 	t.Run("all LLMInferenceServiceConfig resources preserves input order", func(t *testing.T) {

--- a/internal/controller/components/kserve/kserve_controller_actions_test.go
+++ b/internal/controller/components/kserve/kserve_controller_actions_test.go
@@ -708,6 +708,112 @@ func TestCheckOperatorAndCRDDependencies(t *testing.T) {
 	})
 }
 
+func TestSortLLMInferenceServiceConfigLast(t *testing.T) {
+	newRes := func(group, version, kind, name string) unstructured.Unstructured {
+		u := unstructured.Unstructured{}
+		u.SetGroupVersionKind(schema.GroupVersionKind{Group: group, Version: version, Kind: kind})
+		u.SetName(name)
+		return u
+	}
+
+	llmISvcConfig := func(name string) unstructured.Unstructured {
+		return newRes(
+			gvk.LLMInferenceServiceConfigV1Alpha2.Group,
+			gvk.LLMInferenceServiceConfigV1Alpha2.Version,
+			gvk.LLMInferenceServiceConfigV1Alpha2.Kind,
+			name,
+		)
+	}
+
+	t.Run("LLMInferenceServiceConfig resources are placed after all other resources", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		input := []unstructured.Unstructured{
+			llmISvcConfig("config-a"),
+			newRes("apps", "v1", "Deployment", "my-deploy"),
+			llmISvcConfig("config-b"),
+			newRes("", "v1", "Service", "my-svc"),
+		}
+
+		result, err := sortLLMInferenceServiceConfigLast(ctx, input)
+		g.Expect(err).NotTo(HaveOccurred())
+
+		// Non-LLMInferenceServiceConfig resources should come first
+		g.Expect(result[len(result)-2].GetName()).To(Equal("config-a"))
+		g.Expect(result[len(result)-1].GetName()).To(Equal("config-b"))
+
+		// All non-LLMInferenceServiceConfig resources should precede them
+		for _, r := range result[:len(result)-2] {
+			g.Expect(r.GetKind()).NotTo(Equal(gvk.LLMInferenceServiceConfigV1Alpha2.Kind))
+		}
+	})
+
+	t.Run("preserves relative order among LLMInferenceServiceConfig resources", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		input := []unstructured.Unstructured{
+			llmISvcConfig("config-z"),
+			newRes("apps", "v1", "Deployment", "deploy"),
+			llmISvcConfig("config-a"),
+			llmISvcConfig("config-m"),
+		}
+
+		result, err := sortLLMInferenceServiceConfigLast(ctx, input)
+		g.Expect(err).NotTo(HaveOccurred())
+
+		// The three LLMInferenceServiceConfig resources should be at the end,
+		// in their original relative order (stable sort).
+		configs := result[len(result)-3:]
+		g.Expect(configs[0].GetName()).To(Equal("config-z"))
+		g.Expect(configs[1].GetName()).To(Equal("config-a"))
+		g.Expect(configs[2].GetName()).To(Equal("config-m"))
+	})
+
+	t.Run("no LLMInferenceServiceConfig resources leaves order unchanged", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		input := []unstructured.Unstructured{
+			newRes("apps", "v1", "Deployment", "deploy"),
+			newRes("", "v1", "Service", "svc"),
+			newRes("", "v1", "ConfigMap", "cm"),
+		}
+
+		result, err := sortLLMInferenceServiceConfigLast(ctx, input)
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(result).To(HaveLen(3))
+	})
+
+	t.Run("all LLMInferenceServiceConfig resources preserves input order", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		input := []unstructured.Unstructured{
+			llmISvcConfig("config-b"),
+			llmISvcConfig("config-a"),
+			llmISvcConfig("config-c"),
+		}
+
+		result, err := sortLLMInferenceServiceConfigLast(ctx, input)
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(result).To(HaveLen(3))
+		g.Expect(result[0].GetName()).To(Equal("config-b"))
+		g.Expect(result[1].GetName()).To(Equal("config-a"))
+		g.Expect(result[2].GetName()).To(Equal("config-c"))
+	})
+
+	t.Run("empty input returns empty", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		result, err := sortLLMInferenceServiceConfigLast(ctx, nil)
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(result).To(BeEmpty())
+	})
+}
+
 func createTestConfigMap() *corev1.ConfigMap {
 	return &corev1.ConfigMap{
 		TypeMeta: metav1.TypeMeta{

--- a/pkg/controller/actions/deploy/action_deploy.go
+++ b/pkg/controller/actions/deploy/action_deploy.go
@@ -34,6 +34,16 @@ const (
 // SortFn defines a function that reorders resources before deployment.
 type SortFn func(ctx context.Context, resources []unstructured.Unstructured) ([]unstructured.Unstructured, error)
 
+func (s SortFn) Then(then SortFn) SortFn {
+	return func(ctx context.Context, resources []unstructured.Unstructured) ([]unstructured.Unstructured, error) {
+		output, err := s(ctx, resources)
+		if err != nil {
+			return nil, err
+		}
+		return then(ctx, output)
+	}
+}
+
 // Action deploys the resources that are included in the ReconciliationRequest using
 // the same create or patch machinery implemented as part of deploy.DeployManifestsFromPath.
 type Action struct {


### PR DESCRIPTION
## Description

During 3.3 → 3.4 upgrades, the kserve controller is updated first but the
old ValidatingWebhookConfiguration still points to kserve-webhook-server-service
which no longer serves the LLMInferenceServiceConfig validation endpoint.
Since WithApplyOrder places webhooks last, if LLMInferenceServiceConfig
resources are applied before the new ValidatingWebhookConfiguration replaces
the old one, validation fails and the operator stops — preventing the new
webhook configuration from ever being applied.

Add WithApplyOrderLLMInferenceServiceConfigLast which composes
SortByApplyOrder with a stable sort that pushes LLMInferenceServiceConfig
resources after webhooks. Add SortFn.Then to enable sort function composition.

https://redhat.atlassian.net/browse/RHOAIENG-58364

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully
- [ ] New RELATED_IMAGE mappings are already listed in ODH-Build-Config and RHOAI-Build-Config, and links are included in PR description

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->

Existing E2E tests cover the change, unit tests added to verify ordering behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved KServe deployment ordering to ensure inference service configurations are applied last in the deployment sequence, preventing potential configuration ordering issues.

* **Tests**
  * Added comprehensive test coverage for resource ordering functionality, including edge cases for empty and null inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->