### PR TITLE
Rename vllm images from RHAIIS to RHAII

### DIFF
--- a/internal/controller/components/kserve/kserve_support.go
+++ b/internal/controller/components/kserve/kserve_support.go
@@ -36,10 +36,10 @@ var (
 		"llmisvc-controller":               "RELATED_IMAGE_ODH_KSERVE_LLMISVC_CONTROLLER_IMAGE",
 		"kserve-router":                    "RELATED_IMAGE_ODH_KSERVE_ROUTER_IMAGE",
 		"kserve-storage-initializer":       "RELATED_IMAGE_ODH_KSERVE_STORAGE_INITIALIZER_IMAGE",
-		"kserve-llm-d":                     "RELATED_IMAGE_RHAIIS_VLLM_CUDA_IMAGE", // Default image (Nvidia CUDA)
-		"kserve-llm-d-nvidia-cuda":         "RELATED_IMAGE_RHAIIS_VLLM_CUDA_IMAGE",
-		"kserve-llm-d-amd-rocm":            "RELATED_IMAGE_RHAIIS_VLLM_ROCM_IMAGE",
-		"kserve-llm-d-ibm-spyre":           "RELATED_IMAGE_RHAIIS_VLLM_SPYRE_IMAGE",
+		"kserve-llm-d":                     "RELATED_IMAGE_RHAII_VLLM_CUDA_IMAGE", // Default image (Nvidia CUDA)
+		"kserve-llm-d-nvidia-cuda":         "RELATED_IMAGE_RHAII_VLLM_CUDA_IMAGE",
+		"kserve-llm-d-amd-rocm":            "RELATED_IMAGE_RHAII_VLLM_ROCM_IMAGE",
+		"kserve-llm-d-ibm-spyre":           "RELATED_IMAGE_RHAII_VLLM_SPYRE_IMAGE",
 		"kserve-llm-d-intel-gaudi":         "RELATED_IMAGE_RHAII_VLLM_GAUDI_IMAGE",
 		"kserve-llm-d-inference-scheduler": "RELATED_IMAGE_ODH_LLM_D_INFERENCE_SCHEDULER_IMAGE",
 		"kserve-llm-d-routing-sidecar":     "RELATED_IMAGE_ODH_LLM_D_ROUTING_SIDECAR_IMAGE",

--- a/internal/controller/components/modelcontroller/modelcontroller_support.go
+++ b/internal/controller/components/modelcontroller/modelcontroller_support.go
@@ -33,12 +33,12 @@ var (
 		"caikit-standalone-image": "RELATED_IMAGE_ODH_CAIKIT_NLP_IMAGE",
 		"ovms-image":              "RELATED_IMAGE_ODH_OPENVINO_MODEL_SERVER_IMAGE",
 		"mlserver-image":          "RELATED_IMAGE_ODH_MLSERVER_IMAGE",
-		"vllm-cuda-image":         "RELATED_IMAGE_RHAIIS_VLLM_CUDA_IMAGE",
+		"vllm-cuda-image":         "RELATED_IMAGE_RHAII_VLLM_CUDA_IMAGE",
 		"vllm-cpu-image":          "RELATED_IMAGE_ODH_VLLM_CPU_IMAGE",
-		"vllm-cpu-x86-image":      "RELATED_IMAGE_RHAIIS_VLLM_CPU_IMAGE",
+		"vllm-cpu-x86-image":      "RELATED_IMAGE_RHAII_VLLM_CPU_IMAGE",
 		"vllm-gaudi-image":        "RELATED_IMAGE_RHAII_VLLM_GAUDI_IMAGE",
-		"vllm-rocm-image":         "RELATED_IMAGE_RHAIIS_VLLM_ROCM_IMAGE",
-		"vllm-spyre-image":        "RELATED_IMAGE_RHAIIS_VLLM_SPYRE_IMAGE",
+		"vllm-rocm-image":         "RELATED_IMAGE_RHAII_VLLM_ROCM_IMAGE",
+		"vllm-spyre-image":        "RELATED_IMAGE_RHAII_VLLM_SPYRE_IMAGE",
 		"guardrails-detector-huggingface-runtime-image": "RELATED_IMAGE_ODH_GUARDRAILS_DETECTOR_HUGGINGFACE_RUNTIME_IMAGE",
 	}
 


### PR DESCRIPTION

<!---
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->
For now they're duplicated in the additional-images-patch.yaml in ODH-Build-Config and RHOAI-Build-Config, but eventually the old RHAIIS ones will be removed.

https://github.com/opendatahub-io/ODH-Build-Config/blob/main/bundle/additional-images-patch.yaml
https://github.com/red-hat-data-services/RHOAI-Build-Config/blob/rhoai-3.4/bundle/additional-images-patch.yaml

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully
- [x] New RELATED_IMAGE mappings are already listed in ODH-Build-Config and RHOAI-Build-Config, and links are included in PR description

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->
This doesn't have any impact on the e2e tests, it's just updating some variables that aren't used directly in the e2e tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated vLLM image references for KServe and model controller components, including support for CUDA, ROCm, CPU, and IBM SPYRE hardware variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->