### PR TITLE
feat: add gateway and httproute env vars to model registry

### DIFF
--- a/internal/controller/components/modelregistry/modelregistry_controller_actions.go
+++ b/internal/controller/components/modelregistry/modelregistry_controller_actions.go
@@ -9,6 +9,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/api/components/v1alpha1"
+	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/services/gateway"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
 	odhtypes "github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
 	odhdeploy "github.com/opendatahub-io/opendatahub-operator/v2/pkg/deploy"
 )
@@ -62,7 +64,10 @@ func computeKustomizeVariable(rr *odhtypes.ReconciliationRequest) (map[string]st
 	}
 
 	return map[string]string{
-		"GATEWAY_DOMAIN": domain,
+		"GATEWAY_DOMAIN":      domain,
+		"GATEWAY_NAME":        gateway.DefaultGatewayName,
+		"GATEWAY_NAMESPACE":   gateway.GatewayNamespace,
+		"HTTPROUTE_NAMESPACE": cluster.GetApplicationNamespace(),
 	}, nil
 }
 


### PR DESCRIPTION
<!---
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

Companion PR on model registry operator: https://github.com/opendatahub-io/model-registry-operator/pull/513

## Description
<!--- Describe your changes in detail -->

- Adds `GATEWAY_NAME`, `GATEWAY_NAMESPACE`, and `HTTPROUTE_NAMESPACE` as kustomize template variables passed to the model-registry-operator manifests via `params.env`
- These variables supply the gateway resource name (`data-science-gateway`), gateway namespace (`openshift-ingress`), and the HTTPRoute namespace (the platform's application namespace) so the model-registry-operator can create Gateway API HTTPRoutes instead of relying solely on OpenShift Routes
- Companion PR in model-registry-operator (`feat/move-routes-to-gateway` branch) consumes these variables to template HTTPRoute and ReferenceGrant resources pointing at the data-science-gateway https://github.com/opendatahub-io/model-registry-operator/pull/513

### Context

The model-registry-operator is migrating from OpenShift Routes to Gateway API HTTPRoutes for ingress. It needs to know which Gateway to attach HTTPRoutes to and which namespace the routes should live in. Previously only `GATEWAY_DOMAIN` was passed; now the operator also needs the concrete gateway object reference and the namespace for HTTPRoute placement.


<!--- Link your JIRA and related links here for reference. -->

https://redhat.atlassian.net/browse/RHOAIENG-49128

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

`OPERATOR_NAMESPACE=redhat-ods-operator DEFAULT_MANIFESTS_PATH=opt/manifests go run -tags rhoai,nowebhook ./cmd/main.go --log-mode=devel --pprof-bind-address=127.0.0.1:6060`

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully
- [ ] New RELATED_IMAGE mappings are already listed in ODH-Build-Config and RHOAI-Build-Config, and links are included in PR description

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->

There are no changes to the business logic, only added new params

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Expanded kustomize deployment configuration: preserved the gateway domain and added gateway name, gateway namespace, and HTTPRoute namespace as deploy-time variables. These values are now injected into manifest customization parameters used during deployment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->