### PR TITLE
chore: add workflow to automate RHOAI branch version bump

### DIFF
--- a/.github/scripts/manifest-utils.js
+++ b/.github/scripts/manifest-utils.js
@@ -135,8 +135,42 @@ function updateManifestFile(filePath, updates) {
     return hasChanges;
 }
 
+/**
+ * Filter components that use the branch@sha ref format and extract the parts
+ * @param {Array} components - Array of component info objects from parseManifestFile
+ * @returns {Array} Filtered array with added branchRef and commitSha properties
+ */
+function filterComponentsWithBranchSha(components) {
+    const result = [];
+    for (const componentInfo of components) {
+        if (!componentInfo.ref.includes('@')) {
+            continue;
+        }
+
+        const refParts = componentInfo.ref.split('@');
+        if (refParts.length !== 2) {
+            console.log(`⚠️  Skipping ${componentInfo.platform}:${componentInfo.componentName}: invalid ref format "${componentInfo.ref}" (expected "branch@sha")`);
+            continue;
+        }
+
+        const [branchRef, commitSha] = refParts;
+        if (!branchRef || !commitSha) {
+            console.log(`⚠️  Skipping ${componentInfo.platform}:${componentInfo.componentName}: empty branch or SHA in ref "${componentInfo.ref}"`);
+            continue;
+        }
+
+        result.push({
+            ...componentInfo,
+            branchRef,
+            commitSha
+        });
+    }
+    return result;
+}
+
 module.exports = {
     getLatestCommitSha,
     parseManifestFile,
-    updateManifestFile
+    updateManifestFile,
+    filterComponentsWithBranchSha
 };

--- a/.github/scripts/update-manifests-commit-sha.js
+++ b/.github/scripts/update-manifests-commit-sha.js
@@ -1,4 +1,4 @@
-const { getLatestCommitSha, parseManifestFile, updateManifestFile } = require('./manifest-utils');
+const { getLatestCommitSha, parseManifestFile, updateManifestFile, filterComponentsWithBranchSha } = require('./manifest-utils');
 
 module.exports = async function ({ github, core }) {
   const manifestFile = 'get_all_manifests.sh';
@@ -8,31 +8,7 @@ module.exports = async function ({ github, core }) {
 
   // Process both ODH and RHOAI platforms
   for (const components of [parsedManifests.odh, parsedManifests.rhoai, parsedManifests.odhCharts, parsedManifests.rhoaiCharts]) {
-    // Filter to only components with branch@sha format
-    const componentsWithSha = [];
-    for (const componentInfo of components) {
-      if (!componentInfo.ref.includes('@')) {
-        continue;
-      }
-
-      const refParts = componentInfo.ref.split('@');
-      if (refParts.length !== 2) {
-        console.log(`⚠️  Skipping ${componentInfo.platform}:${componentInfo.componentName}: invalid ref format "${componentInfo.ref}" (expected "branch@sha")`);
-        continue;
-      }
-
-      const [branchRef, commitSha] = refParts;
-      if (!branchRef || !commitSha) {
-        console.log(`⚠️  Skipping ${componentInfo.platform}:${componentInfo.componentName}: empty branch or SHA in ref "${componentInfo.ref}"`);
-        continue;
-      }
-
-      componentsWithSha.push({
-        ...componentInfo,
-        branchRef,
-        commitSha
-      });
-    }
+    const componentsWithSha = filterComponentsWithBranchSha(components);
 
     console.log(`Found ${componentsWithSha.length} ${componentsWithSha.length > 0 ? componentsWithSha[0].platform.toUpperCase() : ''} components with branch@sha format`);
 

--- a/.github/scripts/update-rhoai-branch.js
+++ b/.github/scripts/update-rhoai-branch.js
@@ -1,0 +1,62 @@
+const { getLatestCommitSha, parseManifestFile, updateManifestFile, filterComponentsWithBranchSha } = require('./manifest-utils');
+
+module.exports = async function ({ github, core }) {
+  const newBranch = process.env.NEW_RHOAI_BRANCH;
+  if (!newBranch) {
+    core.setFailed('NEW_RHOAI_BRANCH environment variable is required');
+    return;
+  }
+
+  console.log(`Updating RHOAI manifests to branch: ${newBranch}`);
+
+  const manifestFile = 'get_all_manifests.sh';
+  const parsedManifests = parseManifestFile(manifestFile);
+
+  const updates = [];
+  const missingBranches = [];
+
+  for (const components of [parsedManifests.rhoai, parsedManifests.rhoaiCharts]) {
+    const componentsWithSha = filterComponentsWithBranchSha(components);
+
+    console.log(`Found ${componentsWithSha.length} RHOAI components with branch@sha format`);
+
+    for (const manifest of componentsWithSha) {
+      console.log(`Updating ${manifest.componentName} (${manifest.org}/${manifest.repo}) to branch ${newBranch}...`);
+
+      const latestSha = await getLatestCommitSha(github, manifest.org, manifest.repo, newBranch);
+
+      if (!latestSha) {
+        missingBranches.push(`${manifest.org}/${manifest.repo}`);
+        continue;
+      }
+
+      updates.push({
+        componentName: manifest.componentName,
+        org: manifest.org,
+        repo: manifest.repo,
+        newRef: `${newBranch}@${latestSha}`,
+        sourcePath: manifest.sourcePath,
+        originalLine: manifest.originalLine,
+        logMessage: `✅ Updated ${manifest.componentName}: ${manifest.ref} → ${newBranch}@${latestSha.substring(0, 8)}`
+      });
+    }
+  }
+
+  if (missingBranches.length > 0) {
+    core.setFailed(`Branch "${newBranch}" was not found in: ${missingBranches.join(', ')}`);
+    return;
+  }
+
+  const hasUpdates = updates.length > 0;
+  core.setOutput('updates-needed', hasUpdates);
+
+  if (!hasUpdates) {
+    console.log('No RHOAI manifest updates needed');
+    return;
+  }
+
+  console.log('Updating manifest file...');
+  updateManifestFile(manifestFile, updates);
+
+  console.log(`Successfully updated ${updates.length} RHOAI manifest references to branch ${newBranch}`);
+}

--- a/.github/scripts/update-versions.sh
+++ b/.github/scripts/update-versions.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 
-set -euo
+set -euo pipefail
 
 NEW_VERSION=$1
 
 CSV_FILE=config/manifests/bases/opendatahub-operator.clusterserviceversion.yaml
-# Only update the main VERSION variable inside the ifeq block, not other VERSION variables
-sed -i -e "/^ifeq.*VERSION/,/^endif/{s/[[:space:]]*VERSION = .*/\tVERSION = $NEW_VERSION/;}" Makefile
+# Update the ODH VERSION variable (inside the ifeq ODH_PLATFORM_TYPE OpenDataHub block)
+sed -i -e "/^ifeq.*ODH_PLATFORM_TYPE.*OpenDataHub/,/^else$/{s/[[:space:]]*VERSION = .*/\t\tVERSION = $NEW_VERSION/;}" Makefile
 sed -i -e "s|containerImage.*|containerImage: quay.io/opendatahub/opendatahub-operator:v$NEW_VERSION|g" $CSV_FILE
 sed -i -e "s|createdAt.*|createdAt: \"$(date +"%Y-%-m-%dT00:00:00Z")\"|g" $CSV_FILE
 sed -i -e "s|name: opendatahub-operator.v.*|name: opendatahub-operator.v$NEW_VERSION|g" $CSV_FILE

--- a/.github/workflows/update-rhoai-branch.yml
+++ b/.github/workflows/update-rhoai-branch.yml
@@ -1,0 +1,105 @@
+name: Update RHOAI Branch Version
+
+on:
+  workflow_dispatch:
+    inputs:
+      new-rhoai-branch:
+        description: 'New RHOAI branch name (e.g., rhoai-3.5)'
+        required: true
+        type: string
+
+jobs:
+  update-rhoai-branch:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    if: github.ref == 'refs/heads/main'
+    steps:
+      - name: Validate input
+        env:
+          BRANCH: ${{ inputs.new-rhoai-branch }}
+        run: |
+          if [[ ! "$BRANCH" =~ ^rhoai-[0-9]+\.[0-9]+(-.+)?$ ]]; then
+            echo "Error: branch name must match pattern 'rhoai-X.Y' or 'rhoai-X.Y-suffix' (e.g., rhoai-3.5, rhoai-3.5-ea.1)"
+            exit 1
+          fi
+
+      - name: Checkout repository
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          fetch-depth: 0
+
+      - name: Derive version from branch name
+        id: derive-version
+        env:
+          BRANCH: ${{ inputs.new-rhoai-branch }}
+        run: |
+          # Strip rhoai- prefix, then insert .0 after X.Y (e.g., 3.5 → 3.5.0, 3.5-ea.1 → 3.5.0-ea.1)
+          WITHOUT_PREFIX="${BRANCH#rhoai-}"
+          VERSION=$(echo "$WITHOUT_PREFIX" | sed 's/^\([0-9]*\.[0-9]*\)/\1.0/')
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Derived version: $VERSION"
+
+      - name: Update RHOAI manifest branches and SHAs
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        id: update-branches
+        env:
+          NEW_RHOAI_BRANCH: ${{ inputs.new-rhoai-branch }}
+        with:
+          github-token: ${{ github.token }}
+          script: |
+            const script = require('./.github/scripts/update-rhoai-branch.js')
+            await script({github, core})
+
+      - name: Update ODH version
+        env:
+          VERSION: ${{ steps.derive-version.outputs.version }}
+        run: ./.github/scripts/update-versions.sh "$VERSION"
+
+      - name: Update RHOAI Makefile version
+        env:
+          VERSION: ${{ steps.derive-version.outputs.version }}
+        run: sed -i "/^else$/,/^endif$/{s/^[[:space:]]*VERSION = .*/\t\tVERSION = $VERSION/;}" Makefile
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7.0.8
+        id: create-pr
+        with:
+          token: ${{ github.token }}
+          commit-message: "chore: update RHOAI branch to ${{ inputs.new-rhoai-branch }}"
+          title: "chore: update RHOAI branch to ${{ inputs.new-rhoai-branch }}"
+          body: |
+            This PR updates RHOAI manifests to branch `${{ inputs.new-rhoai-branch }}` and bumps the version to `${{ steps.derive-version.outputs.version }}`.
+
+            Changes:
+            - RHOAI manifest branch references updated to `${{ inputs.new-rhoai-branch }}`
+            - Commit SHAs resolved to latest on the new branch
+            - ODH and RHOAI VERSION updated to `${{ steps.derive-version.outputs.version }}`
+
+            ### E2E test suite update requirement
+
+            When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.
+
+            To opt-out of this requirement:
+            1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
+            2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
+            3. Check the checkbox below:
+            - [x] Skip requirement to update E2E test suite for this PR
+            4. Submit/save these changes to the PR description. This will automatically trigger the check.
+
+            #### E2E update requirement opt-out justification
+            Automatic version bump, no functional changes.
+          branch: chore/upgrade-operator-version
+          delete-branch: true
+
+      - name: Output Summary
+        run: |
+          echo "✅ Updates processed successfully"
+          if [[ "${{ steps.create-pr.outputs.pull-request-operation }}" == "created" ]]; then
+            echo "📋 Pull request created: ${{ steps.create-pr.outputs.pull-request-url }}"
+          elif [[ "${{ steps.create-pr.outputs.pull-request-operation }}" == "updated" ]]; then
+            echo "📋 Pull request updated: ${{ steps.create-pr.outputs.pull-request-url }}"
+          else
+            echo "📋 No pull request changes needed"
+          fi


### PR DESCRIPTION
## Description

- Add a manually-triggered GitHub Actions workflow (`update-rhoai-branch.yml`) that automates the RHOAI release branch bump: updates all RHOAI manifest branch references in `get_all_manifests.sh`, resolves latest commit SHAs, and bumps both ODH and RHOAI VERSION in the Makefile/CSV.
- Extract shared `filterComponentsWithBranchSha()` into `manifest-utils.js` to deduplicate branch@sha parsing logic between `update-manifests-commit-sha.js` and the new `update-rhoai-branch.js`.
- The workflow accepts a single input (`rhoai-X.Y` or `rhoai-X.Y-suffix`) and derives the version automatically (e.g., `rhoai-3.5` → `3.5.0`).

## How Has This Been Tested?

- Verified the `filterComponentsWithBranchSha` function preserves existing `update-manifests-commit-sha.js` behavior (same logic, extracted to shared utility).
- Workflow YAML validated for correct input handling, version derivation, and step references.
- End-to-end testing will be done by triggering the workflow manually via GitHub Actions UI against a test branch.

## Merge criteria

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [x] The developer has run the integration test pipeline and verified that it passed successfully
- [x] New RELATED_IMAGE mappings are already listed in ODH-Build-Config and RHOAI-Build-Config, and links are included in PR description


### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [ ] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a manual GitHub workflow and accompanying action to update RHOAI component branch references, rewrite manifests, bump versions, and create/update a pull request.

* **Refactor**
  * Centralized and reused validation/filtering for component refs across manifest update scripts.

* **Chores**
  * Improved scripting robustness for version update tooling (pipeline failure handling and targeted Makefile edits).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->