### PR TITLE
Change Dashboard SM manifest location (RHOAIENG-59386)

### DIFF
--- a/internal/controller/components/dashboard/dashboard_support.go
+++ b/internal/controller/components/dashboard/dashboard_support.go
@@ -32,8 +32,8 @@ var (
 	}
 
 	overlaysSourcePaths = map[common.Platform]string{
-		cluster.SelfManagedRhoai: "/rhoai/onprem",
-		cluster.ManagedRhoai:     "/rhoai/addon",
+		cluster.SelfManagedRhoai: "/rhoai",
+		cluster.ManagedRhoai:     "/rhoai", // not official anymore
 		cluster.OpenDataHub:      "/odh",
 	}
 


### PR DESCRIPTION
## Description

https://redhat.atlassian.net/browse/RHOAIENG-59386

Managed Addon support ended with RHOAI 2.25. The dashboard manifests in `odh-dashboard` are being consolidated in [odh-dashboard#7370](https://github.com/opendatahub-io/odh-dashboard/pull/7370): the `rhoai/addon/` directory is deleted and `rhoai/onprem/` is flattened to just `rhoai/`.

This is the companion operator change — both `SelfManagedRhoai` and `ManagedRhoai` platform types now point to the consolidated `/rhoai` overlay path instead of the previous `/rhoai/onprem` and `/rhoai/addon` respectively.

**Scope:** Only the `overlaysSourcePaths` map in `dashboard_support.go` is affected. Other components (trustyai, datasciencepipelines) already use a single path for both RHOAI variants. The `ManagedRhoai` platform type and all its other usages (auth groups, namespace selection, deployment names) remain unchanged.

## How Has This Been Tested?

- `go build ./...` — compiles successfully
- `go vet ./...` — no issues
- Verified that this is the only reference to `/rhoai/addon` and `/rhoai/onprem` in the codebase (`grep -rn`)
- No existing unit or e2e tests reference these specific overlay paths, so no test changes are needed

## Merge criteria

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully
- [ ] New RELATED_IMAGE mappings are already listed in ODH-Build-Config and RHOAI-Build-Config, and links are included in PR description

### E2E test suite update requirement

- [x] Skip requirement to update E2E test suite for this PR

#### E2E update requirement opt-out justification

This change only updates a path string constant in `dashboard_support.go`. No logic, control flow, or test-observable behavior is altered. The overlay path values are not referenced by any existing tests. This is a manifest path consolidation matching the upstream dashboard manifest restructure.