### PR TITLE
RHOAIENG-59722 | feat: Adding more E2E test reliability

### DIFF
--- a/cmd/test-retry/pkg/cli/e2e.go
+++ b/cmd/test-retry/pkg/cli/e2e.go
@@ -34,6 +34,11 @@ Example: test-retry e2e -- -run TestFoo -v`,
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			// viper.BindEnv populates viper, not cobra's StringVar; bridge manually.
+			if prOpts.Token == "" {
+				prOpts.Token = viper.GetString("github-token")
+			}
+
 			// Combine testFlags with additional args passed after --
 			finalTestFlags := testFlags
 			if len(args) > 0 {
@@ -72,10 +77,9 @@ Example: test-retry e2e -- -run TestFoo -v`,
 	cmd.Flags().IntVar(&maxRetries, "max-retries", 3, "Maximum number of retries for failed tests")
 	cmd.Flags().StringSliceVar(&neverSkip, "never-skip", []string{"TestOdhOperator/DSCInitialization_and_DataScienceCluster_management_E2E_Tests", "TestOdhOperator/DataScienceCluster"}, "Test prefixes that should never be skipped (always run, repeatable)")
 	cmd.Flags().StringSliceVar(&skipAtPrefix, "skip-at-prefix", []string{
-		"TestOdhOperator/services/*/monitoring", // Extract monitoring tests at group level for efficient retry
-		"TestOdhOperator/services/*/",           // Extract other services at service level
-		"TestOdhOperator/components/*/",         // Extract components at component level
-		"TestOdhOperator/",                      // Fallback: extract at root level
+		"TestOdhOperator/services/*/",   // Extract services at service level
+		"TestOdhOperator/components/*/", // Extract components at component level
+		"TestOdhOperator/",              // Fallback: extract at root level
 	}, "Test prefixes where tests should be extracted at prefix + 1 level (repeatable)")
 	cmd.Flags().StringVar(&junitOutput, "junit-output", "", "Path to JUnit XML output file (optional)")
 

--- a/cmd/test-retry/pkg/runner/e2e.go
+++ b/cmd/test-retry/pkg/runner/e2e.go
@@ -45,6 +45,8 @@ func (r *E2ETestRunner) Run() error {
 	// Run initial test execution
 	testResult, err := r.runE2ETests("")
 	if err != nil {
+		// Best-effort JUnit: write whatever we collected so far.
+		r.exportJUnitBestEffort(aggregateResult, "initial run failed: "+err.Error())
 		return fmt.Errorf("failed to run initial e2e tests: %w", err)
 	}
 
@@ -438,6 +440,36 @@ func (r *E2ETestRunner) exportJUnit(result *types.TestResult) error {
 		OutputPath: r.opts.JUnitOutputPath,
 		SuiteName:  "e2e-test",
 	})
+}
+
+// exportJUnitBestEffort writes a JUnit file with whatever results were
+// collected before a fatal error.
+// If there are no collected results, it writes a single synthetic failure entry.
+func (r *E2ETestRunner) exportJUnitBestEffort(result *types.TestResult, reason string) {
+	if r.opts.JUnitOutputPath == "" {
+		return
+	}
+
+	if result == nil {
+		result = &types.TestResult{
+			PassedTest: make([]types.TestCase, 0),
+			FailedTest: make([]types.TestCase, 0),
+		}
+	}
+
+	if len(result.PassedTest) == 0 && len(result.FailedTest) == 0 {
+		result.FailedTest = append(result.FailedTest, types.TestCase{
+			Name:          "TestOdhOperator",
+			Package:       "e2e",
+			FailureOutput: reason,
+		})
+	}
+
+	if err := r.exportJUnit(result); err != nil {
+		fmt.Printf("Warning: failed to export best-effort JUnit XML: %v\n", err)
+	} else {
+		fmt.Printf("Best-effort JUnit XML exported to %s (reason: %s)\n", r.opts.JUnitOutputPath, reason)
+	}
 }
 
 // notifyPROnFailure adds a label and/or comment to the GitHub PR if configured

--- a/cmd/test-retry/pkg/runner/e2e_test.go
+++ b/cmd/test-retry/pkg/runner/e2e_test.go
@@ -3,6 +3,7 @@ package runner
 import (
 	"context"
 	"fmt"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -619,6 +620,63 @@ func TestExtractTestLevel(t *testing.T) {
 			require.Equal(t, tt.shouldSkip, shouldSkip, "shouldSkip mismatch")
 		})
 	}
+}
+
+func TestExportJUnitBestEffort(t *testing.T) {
+	t.Run("no-op when JUnitOutputPath is empty", func(t *testing.T) {
+		runner := &E2ETestRunner{opts: types.E2ETestOptions{JUnitOutputPath: ""}}
+		// Should not panic or write anything
+		runner.exportJUnitBestEffort(nil, "some reason")
+	})
+
+	t.Run("nil result produces synthetic failure", func(t *testing.T) {
+		out := filepath.Join(t.TempDir(), "junit.xml")
+		runner := &E2ETestRunner{opts: types.E2ETestOptions{JUnitOutputPath: out}}
+
+		runner.exportJUnitBestEffort(nil, "initial run crashed")
+
+		suite := readJUnitFile(t, out)
+		require.Equal(t, 1, suite.Tests)
+		require.Equal(t, 1, suite.Failures)
+		require.Equal(t, "TestOdhOperator", suite.TestCases[0].Name)
+		require.Contains(t, suite.TestCases[0].Failure.Content, "initial run crashed")
+	})
+
+	t.Run("empty result produces synthetic failure", func(t *testing.T) {
+		out := filepath.Join(t.TempDir(), "junit.xml")
+		runner := &E2ETestRunner{opts: types.E2ETestOptions{JUnitOutputPath: out}}
+
+		runner.exportJUnitBestEffort(&types.TestResult{
+			PassedTest: []types.TestCase{},
+			FailedTest: []types.TestCase{},
+		}, "timeout")
+
+		suite := readJUnitFile(t, out)
+		require.Equal(t, 1, suite.Tests)
+		require.Equal(t, 1, suite.Failures)
+		require.Equal(t, "TestOdhOperator", suite.TestCases[0].Name)
+	})
+
+	t.Run("preserves existing results without adding synthetic entry", func(t *testing.T) {
+		out := filepath.Join(t.TempDir(), "junit.xml")
+		runner := &E2ETestRunner{opts: types.E2ETestOptions{JUnitOutputPath: out}}
+
+		runner.exportJUnitBestEffort(&types.TestResult{
+			PassedTest: []types.TestCase{{Name: "TestOdhOperator/components/dashboard"}},
+			FailedTest: []types.TestCase{{Name: "TestOdhOperator/services/monitoring", FailureOutput: "timed out"}},
+		}, "partial failure")
+
+		suite := readJUnitFile(t, out)
+		require.Equal(t, 2, suite.Tests)
+		require.Equal(t, 1, suite.Failures)
+
+		names := make([]string, 0, len(suite.TestCases))
+		for _, tc := range suite.TestCases {
+			names = append(names, tc.Name)
+		}
+		require.Contains(t, names, "TestOdhOperator/components/dashboard")
+		require.Contains(t, names, "TestOdhOperator/services/monitoring")
+	})
 }
 
 func TestNotifyPROnFailure(t *testing.T) {

--- a/tests/e2e/controller_test.go
+++ b/tests/e2e/controller_test.go
@@ -225,16 +225,11 @@ func (tg *TestGroup) Validate() error {
 	return nil
 }
 
-func (tg *TestGroup) Run(t *testing.T) {
-	t.Helper()
-
-	if !tg.enabled {
-		t.Skipf("Test group %s is disabled", tg.name)
-		return
-	}
-
+// resolveEnabledTests parses tg.flags into a set of test names that should
+// run. Flags without "!" are inclusions, flags prefixed with "!" are exclusions.
+func (tg *TestGroup) resolveEnabledTests() map[string]bool {
+	enabledTests := make(map[string]bool)
 	disabledTests := make([]string, 0)
-	enabledTests := make(map[string]bool, 0)
 
 	for _, name := range tg.flags {
 		if strings.HasPrefix(name, "!") {
@@ -244,19 +239,29 @@ func (tg *TestGroup) Run(t *testing.T) {
 		}
 	}
 
-	// Run all tests if none are explicitly enabled
 	if len(enabledTests) == 0 {
 		for _, name := range tg.Names() {
 			enabledTests[name] = true
 		}
 	}
 
-	// Remove disabled tests
 	for _, name := range disabledTests {
 		delete(enabledTests, name)
 	}
 
-	// Run each test case by group
+	return enabledTests
+}
+
+func (tg *TestGroup) Run(t *testing.T) {
+	t.Helper()
+
+	if !tg.enabled {
+		t.Skipf("Test group %s is disabled", tg.name)
+		return
+	}
+
+	enabledTests := tg.resolveEnabledTests()
+
 	for i, group := range tg.scenarios {
 		mustRun(t, fmt.Sprintf("group %d", i+1), func(t *testing.T) {
 			t.Helper()
@@ -280,6 +285,81 @@ func (tg *TestGroup) Run(t *testing.T) {
 	}
 }
 
+// RunSingle returns a test function that runs only the named test from this group.
+func (tg *TestGroup) RunSingle(name string) func(t *testing.T) {
+	return func(t *testing.T) {
+		t.Helper()
+
+		if !tg.enabled {
+			t.Skipf("Test group %s is disabled", tg.name)
+			return
+		}
+
+		if !tg.isTestEnabled(name) {
+			t.Skipf("Test %s is disabled by flags in group %s", name, tg.name)
+			return
+		}
+
+		for _, group := range tg.scenarios {
+			if testFunc, ok := group[name]; ok {
+				testFunc(t)
+				return
+			}
+		}
+
+		t.Skipf("Test %s not found in group %s", name, tg.name)
+	}
+}
+
+// isTestEnabled returns true if the named test should run given the group's flags.
+func (tg *TestGroup) isTestEnabled(name string) bool {
+	_, ok := tg.resolveEnabledTests()[name]
+	return ok
+}
+
+// RunExcluding returns a test function that runs this group but skips the
+// named test. Used together with RunSingle to split a test out of its group.
+func (tg *TestGroup) RunExcluding(excludeName string) func(t *testing.T) {
+	return func(t *testing.T) {
+		t.Helper()
+
+		if !tg.enabled {
+			t.Skipf("Test group %s is disabled", tg.name)
+			return
+		}
+
+		enabledTests := tg.resolveEnabledTests()
+		delete(enabledTests, excludeName)
+
+		if len(enabledTests) == 0 {
+			t.Skipf("No tests remaining in group %s after excluding %s", tg.name, excludeName)
+			return
+		}
+
+		for i, group := range tg.scenarios {
+			mustRun(t, fmt.Sprintf("group %d", i+1), func(t *testing.T) {
+				t.Helper()
+
+				groupNames := slices.AppendSeq(make([]string, 0, len(group)), maps.Keys(group))
+				slices.Sort(groupNames)
+
+				for _, testName := range groupNames {
+					testFunc := group[testName]
+					if _, ok := enabledTests[testName]; !ok {
+						t.Logf("Skipping tests for %s/%s", tg.name, testName)
+						continue
+					}
+					if tg.parallel {
+						mustRun(t, testName, testFunc, WithParallel())
+					} else {
+						mustRun(t, testName, testFunc)
+					}
+				}
+			})
+		}
+	}
+}
+
 // Helper function to handle cleanup logic.
 func handleCleanup(t *testing.T) {
 	t.Helper()
@@ -293,6 +373,9 @@ func handleCleanup(t *testing.T) {
 	})
 }
 
+// testDeadlineMargin is the safety margin subtracted from the go test -timeout deadline.
+const testDeadlineMargin = 5 * time.Minute
+
 // TestOdhOperator sets up the testing suite for the Operator.
 func TestOdhOperator(t *testing.T) {
 	// Set up global panic handler for comprehensive debugging
@@ -301,6 +384,25 @@ func TestOdhOperator(t *testing.T) {
 	registerSchemes()
 
 	log.SetLogger(zap.New(zap.UseDevMode(true)))
+
+	if deadline, ok := t.Deadline(); ok {
+		remaining := time.Until(deadline)
+		if remaining > testDeadlineMargin {
+			done := make(chan struct{})
+			watchdog := time.AfterFunc(remaining-testDeadlineMargin, func() {
+				select {
+				case <-done:
+					return
+				default:
+					t.Errorf("Internal timeout watchdog fired (%s before go test deadline) — marking test failed to trigger cleanup and preserve JUnit output", testDeadlineMargin)
+				}
+			})
+			t.Cleanup(func() {
+				close(done)
+				watchdog.Stop()
+			})
+		}
+	}
 
 	if testOpts.circuitBreakerEnabled {
 		healthChecker := NewClusterHealthChecker()
@@ -352,9 +454,14 @@ func TestOdhOperator(t *testing.T) {
 		mustRun(t, "DSCInitialization and DataScienceCluster validation E2E Tests", dscValidationTestSuite)
 	}
 
-	// Run components and services test suites
+	// Run monitoring before components — monitoring setup is a prerequisite.
+	mustRun(t, serviceApi.MonitoringServiceName, Services.RunSingle(serviceApi.MonitoringServiceName))
+
+	// Run components test suites
 	mustRun(t, Components.String(), Components.Run)
-	mustRun(t, Services.String(), Services.Run)
+
+	// Run remaining services (auth, gateway)
+	mustRun(t, Services.String(), Services.RunExcluding(serviceApi.MonitoringServiceName))
 
 	// Run operator resilience test suites after functional tests
 	if testOpts.operatorResilienceTest {

--- a/tests/e2e/scripts/run_e2e_tests.sh
+++ b/tests/e2e/scripts/run_e2e_tests.sh
@@ -85,9 +85,21 @@ validate_namespace E2E_TEST_DSC_MONITORING_NAMESPACE
 : "${E2E_TEST_TAG:=All}"
 validate_tag E2E_TEST_TAG
 
-# Toggle for JUnit XML enrichment with failure classification
-: "${USE_TEST_RETRY:=false}"
+# Toggle for JUnit XML enrichment with failure classification (default: enabled)
+: "${USE_TEST_RETRY:=true}"
 validate_bool USE_TEST_RETRY
+
+# Label to apply to PRs when tests are flaky (pass on retry)
+: "${E2E_FLAKY_LABEL:=ci/flaky-test}"
+
+# Build GitHub PR notification flags when PULL_NUMBER and GITHUB_TOKEN are set
+# (both are injected by Prow into presubmit jobs)
+GITHUB_PR_FLAGS=""
+if [ -n "${PULL_NUMBER:-}" ] && [ -n "${GITHUB_TOKEN:-}" ]; then
+  : "${REPO_OWNER:=opendatahub-io}"
+  : "${REPO_NAME:=opendatahub-operator}"
+  GITHUB_PR_FLAGS="--github-owner=${REPO_OWNER} --github-repo=${REPO_NAME} --github-pr=${PULL_NUMBER} --failure-label=${E2E_FLAKY_LABEL}"
+fi
 
 # Choose test runner based on USE_TEST_RETRY flag
 if [ "$USE_TEST_RETRY" = "true" ] || [ "$USE_TEST_RETRY" = "1" ]; then
@@ -95,6 +107,7 @@ if [ "$USE_TEST_RETRY" = "true" ] || [ "$USE_TEST_RETRY" = "1" ]; then
 
   # Run with test-retry (enriched JUnit XML with <properties>)
   # Note: No --filter flag (uses custom e2e flags like --tag, --test-operator-controller instead)
+  # shellcheck disable=SC2086
   exec test-retry e2e \
     --command ./e2e-tests \
     --filter "" \
@@ -102,6 +115,7 @@ if [ "$USE_TEST_RETRY" = "true" ] || [ "$USE_TEST_RETRY" = "1" ]; then
     --max-retries 3 \
     --junit-output results/xunit_report.xml \
     --verbose \
+    ${GITHUB_PR_FLAGS} \
     -- --test.parallel=8 \
     --deletion-policy="$E2E_TEST_DELETION_POLICY" \
     --clean-up-previous-resources="$E2E_TEST_CLEAN_UP_PREVIOUS_RESOURCES" \
@@ -122,7 +136,7 @@ if [ "$USE_TEST_RETRY" = "true" ] || [ "$USE_TEST_RETRY" = "1" ]; then
 else
   echo "Using gotestsum (standard JUnit XML, no enrichment)"
 
-  # Run with gotestsum (existing behavior - DEFAULT)
+  # Run with gotestsum (existing behavior)
   exec gotestsum --junitfile-project-name odh-operator-e2e \
     --junitfile results/xunit_report.xml --format testname --raw-command \
     -- test2json -t -p e2e ./e2e-tests --test.v=test2json --test.parallel=8 \

--- a/tests/e2e/testgroup_test.go
+++ b/tests/e2e/testgroup_test.go
@@ -1,0 +1,199 @@
+package e2e_test
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveEnabledTests(t *testing.T) {
+	tg := TestGroup{
+		name:    "test",
+		enabled: true,
+		scenarios: []map[string]TestFn{
+			{"alpha": noop, "beta": noop, "gamma": noop},
+		},
+	}
+
+	t.Run("all enabled when no flags", func(t *testing.T) {
+		tg.flags = nil
+		got := tg.resolveEnabledTests()
+		require.Len(t, got, 3)
+		require.True(t, got["alpha"])
+		require.True(t, got["beta"])
+		require.True(t, got["gamma"])
+	})
+
+	t.Run("explicit inclusion limits to named tests", func(t *testing.T) {
+		tg.flags = arrayFlags{"alpha"}
+		got := tg.resolveEnabledTests()
+		require.Len(t, got, 1)
+		require.True(t, got["alpha"])
+	})
+
+	t.Run("exclusion removes from full set", func(t *testing.T) {
+		tg.flags = arrayFlags{"!beta"}
+		got := tg.resolveEnabledTests()
+		require.Len(t, got, 2)
+		require.False(t, got["beta"])
+		require.True(t, got["alpha"])
+		require.True(t, got["gamma"])
+	})
+
+	t.Run("inclusion and exclusion combined", func(t *testing.T) {
+		tg.flags = arrayFlags{"alpha", "beta", "!beta"}
+		got := tg.resolveEnabledTests()
+		require.Len(t, got, 1)
+		require.True(t, got["alpha"])
+	})
+}
+
+func TestRunSingle(t *testing.T) {
+	callLog := &callLog{}
+	tg := TestGroup{
+		name:    "services",
+		enabled: true,
+		scenarios: []map[string]TestFn{
+			{
+				"monitoring": callLog.recorder("monitoring"),
+				"auth":       callLog.recorder("auth"),
+				"gateway":    callLog.recorder("gateway"),
+			},
+		},
+	}
+
+	t.Run("runs only the named test", func(t *testing.T) {
+		callLog.reset()
+		fn := tg.RunSingle("monitoring")
+		t.Run("monitoring", fn)
+		require.Equal(t, []string{"monitoring"}, callLog.calls())
+	})
+
+	t.Run("skips when group is disabled", func(t *testing.T) {
+		callLog.reset()
+		disabled := tg
+		disabled.enabled = false
+		fn := disabled.RunSingle("monitoring")
+		t.Run("inner", fn)
+		require.Empty(t, callLog.calls())
+	})
+
+	t.Run("skips when test not found", func(t *testing.T) {
+		callLog.reset()
+		fn := tg.RunSingle("nonexistent")
+		t.Run("inner", fn)
+		require.Empty(t, callLog.calls())
+	})
+
+	t.Run("respects flags disabling the test", func(t *testing.T) {
+		callLog.reset()
+		flagged := tg
+		flagged.flags = arrayFlags{"!monitoring"}
+		fn := flagged.RunSingle("monitoring")
+		t.Run("inner", fn)
+		require.Empty(t, callLog.calls())
+	})
+}
+
+func TestRunExcluding(t *testing.T) {
+	callLog := &callLog{}
+	tg := TestGroup{
+		name:    "services",
+		enabled: true,
+		scenarios: []map[string]TestFn{
+			{
+				"monitoring": callLog.recorder("monitoring"),
+				"auth":       callLog.recorder("auth"),
+				"gateway":    callLog.recorder("gateway"),
+			},
+		},
+	}
+
+	t.Run("runs all except excluded", func(t *testing.T) {
+		callLog.reset()
+		fn := tg.RunExcluding("monitoring")
+		t.Run("services", fn)
+		got := callLog.calls()
+		require.NotContains(t, got, "monitoring")
+		require.Contains(t, got, "auth")
+		require.Contains(t, got, "gateway")
+	})
+
+	t.Run("skips when group is disabled", func(t *testing.T) {
+		callLog.reset()
+		disabled := tg
+		disabled.enabled = false
+		fn := disabled.RunExcluding("monitoring")
+		t.Run("inner", fn)
+		require.Empty(t, callLog.calls())
+	})
+
+	t.Run("skips entirely when excluding only remaining test", func(t *testing.T) {
+		callLog.reset()
+		single := TestGroup{
+			name:    "single",
+			enabled: true,
+			scenarios: []map[string]TestFn{
+				{"only": callLog.recorder("only")},
+			},
+		}
+		fn := single.RunExcluding("only")
+		t.Run("inner", fn)
+		require.Empty(t, callLog.calls())
+	})
+}
+
+func TestIsTestEnabled(t *testing.T) {
+	tg := TestGroup{
+		name:    "test",
+		enabled: true,
+		scenarios: []map[string]TestFn{
+			{"alpha": noop, "beta": noop},
+		},
+	}
+
+	t.Run("enabled by default", func(t *testing.T) {
+		tg.flags = nil
+		require.True(t, tg.isTestEnabled("alpha"))
+		require.True(t, tg.isTestEnabled("beta"))
+	})
+
+	t.Run("disabled by exclusion flag", func(t *testing.T) {
+		tg.flags = arrayFlags{"!alpha"}
+		require.False(t, tg.isTestEnabled("alpha"))
+		require.True(t, tg.isTestEnabled("beta"))
+	})
+}
+
+// --- helpers ---
+
+func noop(t *testing.T) { t.Helper() }
+
+type callLog struct {
+	mu      sync.Mutex
+	entries []string
+}
+
+func (c *callLog) recorder(name string) func(t *testing.T) {
+	return func(t *testing.T) {
+		t.Helper()
+		c.mu.Lock()
+		defer c.mu.Unlock()
+		c.entries = append(c.entries, name)
+	}
+}
+
+func (c *callLog) calls() []string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	out := make([]string, len(c.entries))
+	copy(out, c.entries)
+	return out
+}
+
+func (c *callLog) reset() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.entries = nil
+}


### PR DESCRIPTION
<!---
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->
E2E tests frequently timeout during the monitoring disable step (~20m), which runs last in the services group and gets squeezed by prior test duration. When go test -timeout fires, it kills the process before JUnit XML is written, losing all failure classification data. This creates a blind spot: the most informative failures (timeouts) produce zero data for analysis.
<!--- Link your JIRA and related links here for reference. -->
https://redhat.atlassian.net/browse/RHOAIENG-59722
## How Has This Been Tested?
Unit tests:
```
go test ./tests/e2e/ -run 'TestResolveEnabledTests|TestRunSingle|TestRunExcluding|TestIsTestEnabled' -v -count=1
```

E2E tests:
```
make e2e-setup-cluster
make e2e-test \
  E2E_TEST_DSC_MANAGEMENT=true \
  E2E_TEST_COMPONENTS=false \
  E2E_TEST_OPERATOR_CONTROLLER=false \
  E2E_TEST_DSC_VALIDATION=false \
  E2E_TEST_OPERATOR_RESILIENCE=false \
  E2E_TEST_OPERATOR_V2TOV3UPGRADE=false \
  E2E_TEST_WEBHOOK=false \
  E2E_TEST_DELETION_POLICY=never
  ```
 - TestOdhOperator/monitoring runs standalone before TestOdhOperator/components
- TestOdhOperator/services skips monitoring (Skipping tests for services/monitoring)
- Existing test-retry integration tests pass

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully
- [ ] New RELATED_IMAGE mappings are already listed in ODH-Build-Config and RHOAI-Build-Config, and links are included in PR description

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [ ] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Test-retry enabled by default in e2e scripts
  * Run individual tests or exclude specific ones; refined skip-prefix matching
  * Deadline watchdog to warn before test timeouts
  * Enhanced GitHub PR notification flags when invoking tests

* **Bug Fixes**
  * Best-effort JUnit export on initial e2e failures so results are preserved

* **Tests**
  * Added comprehensive tests covering execution control, JUnit export behavior, and selection logic
<!-- end of auto-generated comment: release notes by coderabbit.ai -->