### PR TITLE
feat(RHOAIENG-53373): add CI check to validate RELATED_IMAGE references against build configs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -27,7 +27,7 @@ Please complete the following sections for a smooth review.
 - [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
 - [ ] The developer has manually tested the changes and verified that the changes work
 - [ ] The developer has run the integration test pipeline and verified that it passed successfully
-- [ ] New RELATED_IMAGE mappings are already listed in ODH-Build-Config and RHOAI-Build-Config, and links are included in PR description (validated by CI)
+- [ ] New RELATED_IMAGE mappings are listed in ODH-Build-Config and RHOAI-Build-Config (CI validates names against build-config repos). Include links to build-config PRs in the description.
 
 ### E2E test suite update requirement
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -27,7 +27,7 @@ Please complete the following sections for a smooth review.
 - [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
 - [ ] The developer has manually tested the changes and verified that the changes work
 - [ ] The developer has run the integration test pipeline and verified that it passed successfully
-- [ ] New RELATED_IMAGE mappings are already listed in ODH-Build-Config and RHOAI-Build-Config, and links are included in PR description
+- [ ] New RELATED_IMAGE mappings are already listed in ODH-Build-Config and RHOAI-Build-Config, and links are included in PR description (validated by CI)
 
 ### E2E test suite update requirement
 

--- a/.github/scripts/validate-related-images.sh
+++ b/.github/scripts/validate-related-images.sh
@@ -1,0 +1,176 @@
+#!/bin/bash
+# Validates that all RELATED_IMAGE_* names used in the operator source code
+# are present in ODH-Build-Config and/or RHOAI-Build-Config bundle-patch.yaml
+# and additional-images-patch.yaml files.
+#
+# Environment variables:
+#   RHOAI_BUILD_CONFIG_BRANCH - Branch in RHOAI-Build-Config repo (e.g. rhoai-3.3)
+#   ODH_BUILD_CONFIG_BRANCH   - Branch in ODH-Build-Config repo (default: main)
+#   DEBUG                     - Set to "true" to keep intermediate files for inspection
+
+set -euo pipefail
+
+ODH_BUILD_CONFIG_BRANCH="${ODH_BUILD_CONFIG_BRANCH:-main}"
+RHOAI_BUILD_CONFIG_BRANCH="${RHOAI_BUILD_CONFIG_BRANCH:?RHOAI_BUILD_CONFIG_BRANCH is required}"
+
+# Validate branch names contain only safe characters
+validate_branch_name() {
+    local branch="$1"
+    local var_name="$2"
+    if ! echo "$branch" | grep -qE '^[a-zA-Z0-9._/-]+$'; then
+        echo "ERROR: ${var_name} contains invalid characters: ${branch}" >&2
+        exit 1
+    fi
+}
+validate_branch_name "$ODH_BUILD_CONFIG_BRANCH" "ODH_BUILD_CONFIG_BRANCH"
+validate_branch_name "$RHOAI_BUILD_CONFIG_BRANCH" "RHOAI_BUILD_CONFIG_BRANCH"
+
+ODH_REPO="opendatahub-io/ODH-Build-Config"
+RHOAI_REPO="red-hat-data-services/RHOAI-Build-Config"
+
+ODH_BASE_URL="https://raw.githubusercontent.com/${ODH_REPO}/${ODH_BUILD_CONFIG_BRANCH}"
+RHOAI_BASE_URL="https://raw.githubusercontent.com/${RHOAI_REPO}/${RHOAI_BUILD_CONFIG_BRANCH}"
+
+DEBUG="${DEBUG:-false}"
+
+TMPDIR="${TMPDIR:-/tmp}"
+WORKDIR=$(mktemp -d "${TMPDIR}/validate-related-images.XXXXXX")
+if [ "$DEBUG" = "true" ]; then
+    echo "DEBUG: Working directory: ${WORKDIR} (will NOT be deleted)"
+else
+    trap 'rm -rf "$WORKDIR"' EXIT
+fi
+
+echo "Validating RELATED_IMAGE_* references against build configs..."
+echo "  ODH-Build-Config branch:  ${ODH_BUILD_CONFIG_BRANCH}"
+echo "  RHOAI-Build-Config branch: ${RHOAI_BUILD_CONFIG_BRANCH}"
+echo ""
+
+# Step 1: Extract RELATED_IMAGE_* names from internal/ (excluding test files)
+# Collect all RELATED_IMAGE_* strings, then subtract Go map keys
+# (strings before ":") to keep only env var references.
+
+# All RELATED_IMAGE_* strings
+grep -roh 'RELATED_IMAGE_[A-Z0-9_]\+' internal/ \
+    --include='*.go' --exclude='*_test.go' \
+    | sort -u > "$WORKDIR/all-refs.txt"
+
+# Map keys only: "RELATED_IMAGE_KEY": (before colon in Go map literals)
+grep -roh '"RELATED_IMAGE_[A-Z0-9_]*"[[:space:]]*:' internal/ \
+    --include='*.go' --exclude='*_test.go' 2>/dev/null \
+    | grep -oh 'RELATED_IMAGE_[A-Z0-9_]\+' \
+    | sort -u > "$WORKDIR/map-keys.txt"
+
+# Subtract map keys that are NOT also used as values elsewhere
+comm -23 "$WORKDIR/all-refs.txt" "$WORKDIR/map-keys.txt" > "$WORKDIR/operator-images.txt"
+
+OPERATOR_COUNT=$(wc -l < "$WORKDIR/operator-images.txt" | tr -d ' ')
+echo "Found ${OPERATOR_COUNT} unique RELATED_IMAGE_* names in internal/"
+
+# Step 2: Fetch build config files and extract RELATED_IMAGE names
+fetch_and_extract() {
+    local url="$1"
+    local output="$2"
+    local label="$3"
+
+    if ! curl -sfL --max-filesize 10485760 --connect-timeout 10 --max-time 30 \
+            "$url" -o "$WORKDIR/fetched.yaml" 2>/dev/null; then
+        echo "WARNING: Failed to fetch ${label}: ${url}"
+        return 1
+    fi
+    grep -oh 'RELATED_IMAGE_[A-Z0-9_]\+' "$WORKDIR/fetched.yaml" >> "$output" 2>/dev/null || true
+    rm -f "$WORKDIR/fetched.yaml"
+}
+
+# Fetch RELATED_IMAGE names from a build config repo.
+# Args: label, base_url, output_file
+fetch_repo_images() {
+    local label="$1"
+    local base_url="$2"
+    local output="$3"
+    local fetch_failed=0
+
+    touch "$output"
+    echo ""
+    echo "Fetching ${label}..."
+    for file in bundle-patch.yaml additional-images-patch.yaml; do
+        if ! fetch_and_extract "${base_url}/bundle/${file}" "$output" "${label} ${file}"; then
+            fetch_failed=1
+        fi
+    done
+
+    if [ "$fetch_failed" -eq 1 ] && [ ! -s "$output" ]; then
+        echo "ERROR: Could not fetch any files from ${label}"
+        exit 1
+    fi
+    sort -u -o "$output" "$output"
+    local count
+    count=$(wc -l < "$output" | tr -d ' ')
+    echo "  Found ${count} RELATED_IMAGE_* names in ${label}"
+}
+
+ODH_IMAGES="$WORKDIR/odh-images.txt"
+RHOAI_IMAGES="$WORKDIR/rhoai-images.txt"
+
+fetch_repo_images "ODH-Build-Config (${ODH_BUILD_CONFIG_BRANCH})" "$ODH_BASE_URL" "$ODH_IMAGES"
+fetch_repo_images "RHOAI-Build-Config (${RHOAI_BUILD_CONFIG_BRANCH})" "$RHOAI_BASE_URL" "$RHOAI_IMAGES"
+
+# Step 3: Find operator images missing from any build config
+# An image must be present in ALL build configs, not just one.
+REPO_LABELS=("ODH-Build-Config (${ODH_BUILD_CONFIG_BRANCH})" "RHOAI-Build-Config (${RHOAI_BUILD_CONFIG_BRANCH})")
+REPO_FILES=("$ODH_IMAGES" "$RHOAI_IMAGES")
+
+HAS_ERRORS=false
+
+echo ""
+while IFS= read -r img; do
+    missing_from=""
+    present_in=""
+    for i in "${!REPO_LABELS[@]}"; do
+        if grep -qx "$img" "${REPO_FILES[$i]}"; then
+            present_in="${present_in:+${present_in}, }${REPO_LABELS[$i]}"
+        else
+            missing_from="${missing_from:+${missing_from}, }${REPO_LABELS[$i]}"
+        fi
+    done
+
+    [ -z "$missing_from" ] && continue
+
+    # Print header on first error
+    if [ "$HAS_ERRORS" = false ]; then
+        echo "ERROR: RELATED_IMAGE_* names missing from build configs:"
+        echo ""
+        HAS_ERRORS=true
+    fi
+
+    echo "  ${img}"
+    grep -rn "$img" internal/ --include='*.go' --exclude='*_test.go' | head -3 | while IFS= read -r line; do
+        echo "    Source: ${line%%:*}:$(echo "$line" | cut -d: -f2)"
+    done
+    echo "    Missing from: ${missing_from}"
+    [ -n "$present_in" ] && echo "    Present in:   ${present_in}"
+    echo ""
+done < "$WORKDIR/operator-images.txt"
+
+if [ "$HAS_ERRORS" = true ]; then
+    # Summary: list images grouped by which repo they're missing from
+    echo "---"
+    echo "Summary:"
+    for i in "${!REPO_LABELS[@]}"; do
+        missing_list=$(comm -23 "$WORKDIR/operator-images.txt" "${REPO_FILES[$i]}")
+        if [ -n "$missing_list" ]; then
+            echo ""
+            echo "  Missing from ${REPO_LABELS[$i]}:"
+            echo "$missing_list" | while IFS= read -r img; do
+                echo "    - ${img}"
+            done
+        fi
+    done
+
+    echo ""
+    echo "Please ensure these images are added to the build config repos before merging."
+    echo "See: https://github.com/${ODH_REPO} and https://github.com/${RHOAI_REPO}"
+    exit 1
+fi
+
+echo "All RELATED_IMAGE_* references are present in all build configs."

--- a/.github/scripts/validate-related-images.sh
+++ b/.github/scripts/validate-related-images.sh
@@ -462,6 +462,29 @@ if [ -s "$KNOWN_ISSUES_MATCHED" ]; then
     done
 fi
 
+# Detect stale known issues (configured but no longer triggered)
+if [ -s "$KNOWN_ISSUES_FILE" ]; then
+    matched_images="$WORKDIR/matched-images.txt"
+    sort -u "$KNOWN_ISSUES_MATCHED" | cut -d'|' -f2 | sort -u > "$matched_images" 2>/dev/null || true
+
+    stale_count=0
+    while IFS='|' read -r ki_image ki_jira ki_reason; do
+        if ! grep -qxF "$ki_image" "$matched_images" 2>/dev/null; then
+            if [ "$stale_count" -eq 0 ]; then
+                echo ""
+                printf "  ${YELLOW}${BOLD}Stale known issues (no longer triggered, please remove from ${CONFIG_FILE}):${RESET}\n"
+            fi
+            printf "    ${YELLOW}%s${RESET} - %s (%s)\n" "$ki_image" "$ki_reason" "$ki_jira"
+            stale_count=$((stale_count + 1))
+        fi
+    done < "$KNOWN_ISSUES_FILE"
+    rm -f "$matched_images"
+
+    if [ "$stale_count" -gt 0 ]; then
+        WARNINGS=$((WARNINGS + stale_count))
+    fi
+fi
+
 if [ "$ERRORS" -gt 0 ]; then
     echo ""
     printf "${RED}Please ensure images are added to the build config repos and params.env before merging.${RESET}\n"

--- a/.github/scripts/validate-related-images.sh
+++ b/.github/scripts/validate-related-images.sh
@@ -120,8 +120,8 @@ fetch_repo_images() {
         fi
     done
 
-    if [ "$fetch_failed" -eq 1 ] && [ ! -s "$output" ]; then
-        echo "ERROR: Could not fetch any files from ${label}"
+    if [ "$fetch_failed" -eq 1 ]; then
+        echo "ERROR: Failed to fetch one or more files from ${label}"
         exit 1
     fi
     sort -u -o "$output" "$output"
@@ -137,15 +137,15 @@ RHOAI_BUILD_CONFIG="$WORKDIR/rhoai-build-config.txt"
 
 # Components that require RHAI Helm chart check
 RHAI_HELM_COMPONENTS="$WORKDIR/rhai-helm-components.txt"
-yq -r '.rhai_helm_components[]' "$CONFIG_FILE" 2>/dev/null > "$RHAI_HELM_COMPONENTS" || true
+yq -r '(.rhai_helm_components // [])[]' "$CONFIG_FILE" > "$RHAI_HELM_COMPONENTS"
 
 # Known issues: each line is "RELATED_IMAGE_NAME|jira|reason"
 
 KNOWN_ISSUES_FILE="$WORKDIR/known-issues.txt"
 KNOWN_ISSUES_MATCHED="$WORKDIR/known-issues-matched.txt"
 touch "$KNOWN_ISSUES_FILE" "$KNOWN_ISSUES_MATCHED"
-yq -r '.known_issues[] | .image + "|" + .jira + "|" + .reason' "$CONFIG_FILE" 2>/dev/null \
-    > "$KNOWN_ISSUES_FILE" || true
+yq -r '(.known_issues // [])[] | .image + "|" + .jira + "|" + .reason' "$CONFIG_FILE" \
+    > "$KNOWN_ISSUES_FILE"
 
 is_known_issue() {
     grep -q "^$1|" "$KNOWN_ISSUES_FILE"
@@ -269,7 +269,11 @@ for comp_file in "$WORKDIR/components/"*.txt; do
 done
 
 # Collect unmapped refs (os.Getenv, function args, etc.)
-cat "$WORKDIR/components/"*.txt 2>/dev/null | cut -d'/' -f3 | sort -u > "$WORKDIR/mapped-images.txt"
+if compgen -G "$WORKDIR/components/"*.txt > /dev/null 2>&1; then
+    cat "$WORKDIR/components/"*.txt | cut -d'/' -f3 | sort -u > "$WORKDIR/mapped-images.txt"
+else
+    touch "$WORKDIR/mapped-images.txt"
+fi
 grep -roh 'RELATED_IMAGE_[A-Z0-9_]\+' internal/ \
     --include='*.go' --exclude='*_test.go' \
     | sort -u > "$WORKDIR/all-refs.txt"

--- a/.github/scripts/validate-related-images.sh
+++ b/.github/scripts/validate-related-images.sh
@@ -17,6 +17,8 @@ CONFIG_FILE="component-params-env.yaml"
 MANIFESTS_DIR="opt/manifests"
 COMPONENTS_DIR="internal/controller/components"
 
+YQ="${YQ:-yq}"
+
 ODH_BUILD_CONFIG_BRANCH="${ODH_BUILD_CONFIG_BRANCH:-main}"
 RHOAI_BUILD_CONFIG_BRANCH="${RHOAI_BUILD_CONFIG_BRANCH:?RHOAI_BUILD_CONFIG_BRANCH is required}"
 
@@ -137,14 +139,14 @@ RHOAI_BUILD_CONFIG="$WORKDIR/rhoai-build-config.txt"
 
 # Components that require RHAI Helm chart check
 RHAI_HELM_COMPONENTS="$WORKDIR/rhai-helm-components.txt"
-yq -r '(.rhai_helm_components // [])[]' "$CONFIG_FILE" > "$RHAI_HELM_COMPONENTS"
+$YQ -r '(.rhai_helm_components // [])[]' "$CONFIG_FILE" > "$RHAI_HELM_COMPONENTS"
 
 # Known issues: each line is "RELATED_IMAGE_NAME|jira|reason"
 
 KNOWN_ISSUES_FILE="$WORKDIR/known-issues.txt"
 KNOWN_ISSUES_MATCHED="$WORKDIR/known-issues-matched.txt"
 touch "$KNOWN_ISSUES_FILE" "$KNOWN_ISSUES_MATCHED"
-yq -r '(.known_issues // [])[] | .image + "|" + .jira + "|" + .reason' "$CONFIG_FILE" \
+$YQ -r '(.known_issues // [])[] | .image + "|" + .jira + "|" + .reason' "$CONFIG_FILE" \
     > "$KNOWN_ISSUES_FILE"
 
 is_known_issue() {
@@ -239,7 +241,7 @@ RHAI_HELM_URL="${RHOAI_BASE_URL}/helm/rhai-on-xks-chart/values.yaml"
 rhai_temp=$(mktemp "${WORKDIR}/fetched.XXXXXX.yaml")
 if curl -sfL --max-filesize 10485760 --connect-timeout 10 --max-time 30 \
         "$RHAI_HELM_URL" -o "$rhai_temp" 2>/dev/null; then
-    yq '.rhaiOperator.relatedImages[].name' "$rhai_temp" 2>/dev/null | sort -u > "$RHAI_HELM_CONFIG"
+    $YQ -r '.rhaiOperator.relatedImages[].name' "$rhai_temp" 2>/dev/null | sort -u > "$RHAI_HELM_CONFIG"
     rhai_count=$(wc -l < "$RHAI_HELM_CONFIG" | tr -d ' ')
     echo "  Found ${rhai_count} RELATED_IMAGE_* names in RHAI Helm chart"
 else

--- a/.github/scripts/validate-related-images.sh
+++ b/.github/scripts/validate-related-images.sh
@@ -133,8 +133,13 @@ fetch_repo_images() {
 ODH_BUILD_CONFIG="$WORKDIR/odh-build-config.txt"
 RHOAI_BUILD_CONFIG="$WORKDIR/rhoai-build-config.txt"
 
-# --- Step 2: Load known issues from config ---
-# Store as a file: each line is "RELATED_IMAGE_NAME|jira|reason"
+# --- Step 2: Load config ---
+
+# Components that require RHAI Helm chart check
+RHAI_HELM_COMPONENTS="$WORKDIR/rhai-helm-components.txt"
+yq -r '.rhai_helm_components[]' "$CONFIG_FILE" 2>/dev/null > "$RHAI_HELM_COMPONENTS" || true
+
+# Known issues: each line is "RELATED_IMAGE_NAME|jira|reason"
 
 KNOWN_ISSUES_FILE="$WORKDIR/known-issues.txt"
 KNOWN_ISSUES_MATCHED="$WORKDIR/known-issues-matched.txt"
@@ -225,8 +230,26 @@ fetch_repo_images "RHOAI-Build-Config (${RHOAI_BUILD_CONFIG_BRANCH})" "$RHOAI_BA
 echo ""
 fetch_repo_images "ODH-Build-Config (${ODH_BUILD_CONFIG_BRANCH})" "$ODH_BASE_URL" "$ODH_BUILD_CONFIG"
 
+# Fetch RHAI Helm chart relatedImages (kserve images for xKS deployments)
+RHAI_HELM_CONFIG="$WORKDIR/rhai-helm-config.txt"
+touch "$RHAI_HELM_CONFIG"
+echo ""
+echo "Fetching RHAI Helm chart values (${RHOAI_BUILD_CONFIG_BRANCH})..."
+RHAI_HELM_URL="${RHOAI_BASE_URL}/helm/rhai-on-xks-chart/values.yaml"
+rhai_temp=$(mktemp "${WORKDIR}/fetched.XXXXXX.yaml")
+if curl -sfL --max-filesize 10485760 --connect-timeout 10 --max-time 30 \
+        "$RHAI_HELM_URL" -o "$rhai_temp" 2>/dev/null; then
+    yq '.rhaiOperator.relatedImages[].name' "$rhai_temp" 2>/dev/null | sort -u > "$RHAI_HELM_CONFIG"
+    rhai_count=$(wc -l < "$RHAI_HELM_CONFIG" | tr -d ' ')
+    echo "  Found ${rhai_count} RELATED_IMAGE_* names in RHAI Helm chart"
+else
+    echo "  WARNING: Failed to fetch RHAI Helm chart values.yaml"
+fi
+rm -f "$rhai_temp"
+
 ODH_LABEL="ODH (${ODH_BUILD_CONFIG_BRANCH})"
 RHOAI_LABEL="RHOAI (${RHOAI_BUILD_CONFIG_BRANCH})"
+RHAI_LABEL="RHAI Helm"
 
 # --- Step 6: Unified validation ---
 # Build a single list of all RELATED_IMAGE entries to check, then validate each once.
@@ -274,8 +297,10 @@ sort -u -t'|' -k1,1 "$ALL_ENTRIES" | cut -d'|' -f1 | sort -u > "$WORKDIR/unique-
 while IFS= read -r related_image; do
     in_odh=false
     in_rhoai=false
+    in_rhai=false
     grep -qx "$related_image" "$ODH_BUILD_CONFIG" && in_odh=true || true
     grep -qx "$related_image" "$RHOAI_BUILD_CONFIG" && in_rhoai=true || true
+    grep -qx "$related_image" "$RHAI_HELM_CONFIG" && in_rhai=true || true
 
     # Collect all references to this RELATED_IMAGE
     entries=$(grep "^${related_image}|" "$ALL_ENTRIES")
@@ -295,20 +320,41 @@ while IFS= read -r related_image; do
         params_info="Not in any map (used via os.Getenv or function arg)"
     fi
 
+    # Check if this image is used by a component that requires RHAI Helm check
+    needs_rhai_helm=false
+    if [ -s "$RHAI_HELM_COMPONENTS" ]; then
+        while IFS= read -r rhai_comp; do
+            echo "$entries" | grep -q "|${rhai_comp}|" && needs_rhai_helm=true && break
+        done < "$RHAI_HELM_COMPONENTS"
+    fi
+
     # Skip if everything is OK
-    $in_params_env && $in_odh && $in_rhoai && continue
-    [ -z "$has_map_entry" ] && $in_odh && $in_rhoai && continue
+    if $in_params_env && $in_odh && $in_rhoai; then
+        if $needs_rhai_helm && [ -s "$RHAI_HELM_CONFIG" ]; then
+            $in_rhai && continue
+        else
+            continue
+        fi
+    fi
+    if [ -z "$has_map_entry" ] && $in_odh && $in_rhoai; then
+        if $needs_rhai_helm && [ -s "$RHAI_HELM_CONFIG" ]; then
+            $in_rhai && continue
+        else
+            continue
+        fi
+    fi
 
     # Build config status
-    bc_status=""
-    if $in_odh && $in_rhoai; then
-        bc_status="${GREEN}ODH ✓${RESET}, ${GREEN}RHOAI ✓${RESET}"
-    elif $in_odh; then
-        bc_status="${GREEN}ODH ✓${RESET}, ${RED}RHOAI ✗${RESET}"
-    elif $in_rhoai; then
-        bc_status="${RED}ODH ✗${RESET}, ${GREEN}RHOAI ✓${RESET}"
-    else
-        bc_status="${RED}ODH ✗${RESET}, ${RED}RHOAI ✗${RESET}"
+    bc_odh="${RED}ODH ✗${RESET}"
+    $in_odh && bc_odh="${GREEN}ODH ✓${RESET}"
+    bc_rhoai="${RED}RHOAI ✗${RESET}"
+    $in_rhoai && bc_rhoai="${GREEN}RHOAI ✓${RESET}"
+
+    bc_status="${bc_odh}, ${bc_rhoai}"
+    if $needs_rhai_helm && [ -s "$RHAI_HELM_CONFIG" ]; then
+        bc_rhai="${RED}RHAI Helm ✗${RESET}"
+        $in_rhai && bc_rhai="${GREEN}RHAI Helm ✓${RESET}"
+        bc_status="${bc_status}, ${bc_rhai}"
     fi
 
     # Known issue check
@@ -322,11 +368,18 @@ while IFS= read -r related_image; do
     if ! $in_odh || ! $in_rhoai; then
         is_error=true
     fi
+    if $needs_rhai_helm && [ -s "$RHAI_HELM_CONFIG" ] && ! $in_rhai; then
+        is_error=true
+    fi
     if [ -z "$has_map_entry" ] && ! $in_odh && ! $in_rhoai; then
         is_error=true
     fi
     if ! $in_params_env && $in_odh && $in_rhoai; then
-        is_error=false
+        if $needs_rhai_helm && [ -s "$RHAI_HELM_CONFIG" ] && ! $in_rhai; then
+            : # still error - missing from RHAI Helm
+        else
+            is_error=false
+        fi
     fi
 
     target_file="$ERRORS_FILE"

--- a/.github/scripts/validate-related-images.sh
+++ b/.github/scripts/validate-related-images.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
-# Validates that all RELATED_IMAGE_* names used in the operator source code
-# are present in ODH-Build-Config and/or RHOAI-Build-Config bundle-patch.yaml
-# and additional-images-patch.yaml files.
+# Validates RELATED_IMAGE_* references per-platform:
+#   params.env (overlay) → map key → RELATED_IMAGE_* → Build-Config
 #
 # Environment variables:
 #   RHOAI_BUILD_CONFIG_BRANCH - Branch in RHOAI-Build-Config repo (e.g. rhoai-3.3)
@@ -9,6 +8,14 @@
 #   DEBUG                     - Set to "true" to keep intermediate files for inspection
 
 set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+cd "$REPO_ROOT"
+
+CONFIG_FILE="component-params-env.yaml"
+MANIFESTS_DIR="opt/manifests"
+COMPONENTS_DIR="internal/controller/components"
 
 ODH_BUILD_CONFIG_BRANCH="${ODH_BUILD_CONFIG_BRANCH:-main}"
 RHOAI_BUILD_CONFIG_BRANCH="${RHOAI_BUILD_CONFIG_BRANCH:?RHOAI_BUILD_CONFIG_BRANCH is required}"
@@ -25,14 +32,34 @@ validate_branch_name() {
 validate_branch_name "$ODH_BUILD_CONFIG_BRANCH" "ODH_BUILD_CONFIG_BRANCH"
 validate_branch_name "$RHOAI_BUILD_CONFIG_BRANCH" "RHOAI_BUILD_CONFIG_BRANCH"
 
+# Validate paths from config don't contain traversal sequences
+validate_path() {
+    local path="$1"
+    local label="$2"
+    if [[ "$path" =~ \.\. ]] || [[ "$path" =~ ^/ ]]; then
+        echo "ERROR: ${label} contains invalid path: ${path}" >&2
+        exit 1
+    fi
+}
+
 ODH_REPO="opendatahub-io/ODH-Build-Config"
 RHOAI_REPO="red-hat-data-services/RHOAI-Build-Config"
-
 ODH_BASE_URL="https://raw.githubusercontent.com/${ODH_REPO}/${ODH_BUILD_CONFIG_BRANCH}"
 RHOAI_BASE_URL="https://raw.githubusercontent.com/${RHOAI_REPO}/${RHOAI_BUILD_CONFIG_BRANCH}"
 
-DEBUG="${DEBUG:-false}"
+# Colors (disabled if not a terminal or NO_COLOR is set)
+if [ -t 1 ] && [ -z "${NO_COLOR:-}" ]; then
+    RED='\033[0;31m'
+    YELLOW='\033[0;33m'
+    GREEN='\033[0;32m'
+    CYAN='\033[0;36m'
+    BOLD='\033[1m'
+    RESET='\033[0m'
+else
+    RED='' YELLOW='' GREEN='' CYAN='' BOLD='' RESET=''
+fi
 
+DEBUG="${DEBUG:-false}"
 TMPDIR="${TMPDIR:-/tmp}"
 WORKDIR=$(mktemp -d "${TMPDIR}/validate-related-images.XXXXXX")
 if [ "$DEBUG" = "true" ]; then
@@ -41,49 +68,44 @@ else
     trap 'rm -rf "$WORKDIR"' EXIT
 fi
 
-echo "Validating RELATED_IMAGE_* references against build configs..."
+# --- Pre-flight checks ---
+
+if [ ! -f "$CONFIG_FILE" ]; then
+    echo "ERROR: Config file not found: ${CONFIG_FILE}"
+    exit 1
+fi
+
+if [ ! -d "$MANIFESTS_DIR" ]; then
+    echo "ERROR: Manifests directory not found: ${MANIFESTS_DIR}"
+    echo "Run 'make get-manifests' first."
+    exit 1
+fi
+
+echo "Validating RELATED_IMAGE_* references per platform..."
 echo "  ODH-Build-Config branch:  ${ODH_BUILD_CONFIG_BRANCH}"
 echo "  RHOAI-Build-Config branch: ${RHOAI_BUILD_CONFIG_BRANCH}"
 echo ""
 
-# Step 1: Extract RELATED_IMAGE_* names from internal/ (excluding test files)
-# Collect all RELATED_IMAGE_* strings, then subtract Go map keys
-# (strings before ":") to keep only env var references.
+# --- Step 1: Fetch build config RELATED_IMAGE names ---
 
-# All RELATED_IMAGE_* strings
-grep -roh 'RELATED_IMAGE_[A-Z0-9_]\+' internal/ \
-    --include='*.go' --exclude='*_test.go' \
-    | sort -u > "$WORKDIR/all-refs.txt"
-
-# Map keys only: "RELATED_IMAGE_KEY": (before colon in Go map literals)
-grep -roh '"RELATED_IMAGE_[A-Z0-9_]*"[[:space:]]*:' internal/ \
-    --include='*.go' --exclude='*_test.go' 2>/dev/null \
-    | grep -oh 'RELATED_IMAGE_[A-Z0-9_]\+' \
-    | sort -u > "$WORKDIR/map-keys.txt"
-
-# Subtract map keys that are NOT also used as values elsewhere
-comm -23 "$WORKDIR/all-refs.txt" "$WORKDIR/map-keys.txt" > "$WORKDIR/operator-images.txt"
-
-OPERATOR_COUNT=$(wc -l < "$WORKDIR/operator-images.txt" | tr -d ' ')
-echo "Found ${OPERATOR_COUNT} unique RELATED_IMAGE_* names in internal/"
-
-# Step 2: Fetch build config files and extract RELATED_IMAGE names
 fetch_and_extract() {
     local url="$1"
     local output="$2"
     local label="$3"
 
+    local temp_file
+    temp_file=$(mktemp "${WORKDIR}/fetched.XXXXXX.yaml")
+
     if ! curl -sfL --max-filesize 10485760 --connect-timeout 10 --max-time 30 \
-            "$url" -o "$WORKDIR/fetched.yaml" 2>/dev/null; then
+            "$url" -o "$temp_file" 2>/dev/null; then
         echo "WARNING: Failed to fetch ${label}: ${url}"
+        rm -f "$temp_file"
         return 1
     fi
-    grep -oh 'RELATED_IMAGE_[A-Z0-9_]\+' "$WORKDIR/fetched.yaml" >> "$output" 2>/dev/null || true
-    rm -f "$WORKDIR/fetched.yaml"
+    grep -oh 'RELATED_IMAGE_[A-Z0-9_]\+' "$temp_file" >> "$output" 2>/dev/null || true
+    rm -f "$temp_file"
 }
 
-# Fetch RELATED_IMAGE names from a build config repo.
-# Args: label, base_url, output_file
 fetch_repo_images() {
     local label="$1"
     local base_url="$2"
@@ -91,7 +113,6 @@ fetch_repo_images() {
     local fetch_failed=0
 
     touch "$output"
-    echo ""
     echo "Fetching ${label}..."
     for file in bundle-patch.yaml additional-images-patch.yaml; do
         if ! fetch_and_extract "${base_url}/bundle/${file}" "$output" "${label} ${file}"; then
@@ -109,68 +130,291 @@ fetch_repo_images() {
     echo "  Found ${count} RELATED_IMAGE_* names in ${label}"
 }
 
-ODH_IMAGES="$WORKDIR/odh-images.txt"
-RHOAI_IMAGES="$WORKDIR/rhoai-images.txt"
+ODH_BUILD_CONFIG="$WORKDIR/odh-build-config.txt"
+RHOAI_BUILD_CONFIG="$WORKDIR/rhoai-build-config.txt"
 
-fetch_repo_images "ODH-Build-Config (${ODH_BUILD_CONFIG_BRANCH})" "$ODH_BASE_URL" "$ODH_IMAGES"
-fetch_repo_images "RHOAI-Build-Config (${RHOAI_BUILD_CONFIG_BRANCH})" "$RHOAI_BASE_URL" "$RHOAI_IMAGES"
+# --- Step 2: Load known issues from config ---
+# Store as a file: each line is "RELATED_IMAGE_NAME|jira|reason"
 
-# Step 3: Find operator images missing from any build config
-# An image must be present in ALL build configs, not just one.
-REPO_LABELS=("ODH-Build-Config (${ODH_BUILD_CONFIG_BRANCH})" "RHOAI-Build-Config (${RHOAI_BUILD_CONFIG_BRANCH})")
-REPO_FILES=("$ODH_IMAGES" "$RHOAI_IMAGES")
+KNOWN_ISSUES_FILE="$WORKDIR/known-issues.txt"
+KNOWN_ISSUES_MATCHED="$WORKDIR/known-issues-matched.txt"
+touch "$KNOWN_ISSUES_FILE" "$KNOWN_ISSUES_MATCHED"
+yq -r '.known_issues[] | .image + "|" + .jira + "|" + .reason' "$CONFIG_FILE" 2>/dev/null \
+    > "$KNOWN_ISSUES_FILE" || true
 
-HAS_ERRORS=false
+is_known_issue() {
+    grep -q "^$1|" "$KNOWN_ISSUES_FILE"
+}
+
+get_known_issue_info() {
+    grep "^$1|" "$KNOWN_ISSUES_FILE" | head -1 | cut -d'|' -f2,3 | tr '|' ' - '
+}
+
+record_known_issue_match() {
+    local image="$1"
+    local platform="$2"
+    grep "^${image}|" "$KNOWN_ISSUES_FILE" | head -1 | while IFS='|' read -r img jira reason; do
+        echo "${platform}|${img}|${jira}|${reason}" >> "$KNOWN_ISSUES_MATCHED"
+    done
+}
+
+# --- Step 3: Extract map entries per component ---
+# For each component dir, extract Go map entries: "key": "RELATED_IMAGE_*"
+# Output: component/key/RELATED_IMAGE_VALUE lines
+
+extract_image_param_map() {
+    local comp_dir="$1"
+    local comp_name
+    comp_name=$(basename "$comp_dir")
+
+    # Find all "key": "RELATED_IMAGE_*" patterns in Go source (excluding tests)
+    # Output format: component/key/RELATED_IMAGE_VALUE/source_file:line
+    grep -rn '"[^"]*"[[:space:]]*:[[:space:]]*"RELATED_IMAGE_[A-Z0-9_]*"' "$comp_dir" \
+        --include='*.go' --exclude='*_test.go' 2>/dev/null | while IFS= read -r match; do
+        local source key value content
+        source=$(echo "$match" | cut -d: -f1,2)  # file:line
+        content=$(echo "$match" | cut -d: -f3-)   # the matched content
+        key=$(echo "$content" | sed 's/.*"\([^"]*\)"[[:space:]]*:.*/\1/')
+        value=$(echo "$content" | sed 's/.*:[[:space:]]*//' | grep -o 'RELATED_IMAGE_[A-Z0-9_]\+')
+        [ -z "$key" ] || [ -z "$value" ] && continue
+        echo "${comp_name}/${key}/${value}/${source}"
+    done
+}
+
+mkdir -p "$WORKDIR/components"
+for comp_dir in "$COMPONENTS_DIR"/*/; do
+    comp_name=$(basename "$comp_dir")
+    [ "$comp_name" = "registry" ] && continue
+    [ ! -d "$comp_dir" ] && continue
+
+    extract_image_param_map "$comp_dir" | sort -u > "$WORKDIR/components/${comp_name}.txt" || true
+
+    # Remove empty files (components without RELATED_IMAGE_* references)
+    [ ! -s "$WORKDIR/components/${comp_name}.txt" ] && rm -f "$WORKDIR/components/${comp_name}.txt"
+done
+
+# --- Step 4: Discover all params.env files and collect keys ---
+# Use the union of ALL params.env keys (not per-platform) because some components
+# reuse the same overlay for both ODH and RHOAI (e.g. kserve uses overlays/odh/ for both).
+
+ERRORS=0
+WARNINGS=0
+
+ALL_PARAMS_ENV_KEYS="$WORKDIR/all-params-env-keys.txt"
+ALL_PARAMS_ENV_FILES="$WORKDIR/all-params-env-files.txt"
+touch "$ALL_PARAMS_ENV_KEYS" "$ALL_PARAMS_ENV_FILES"
+
+find "$MANIFESTS_DIR" -type f \( -name 'params.env' -o -name 'params-*.env' \) | sort > "$WORKDIR/params-env-list.txt"
+while IFS= read -r pfile; do
+    validate_path "$pfile" "params.env path"
+    grep -o '^[^#=]*' "$pfile" | sed 's/[[:space:]]*$//' >> "$ALL_PARAMS_ENV_KEYS"
+    echo "$pfile" >> "$ALL_PARAMS_ENV_FILES"
+done < "$WORKDIR/params-env-list.txt"
+
+sort -u -o "$ALL_PARAMS_ENV_KEYS" "$ALL_PARAMS_ENV_KEYS"
+
+PARAMS_ENV_COUNT=$(wc -l < "$ALL_PARAMS_ENV_FILES" | tr -d ' ')
+PARAMS_KEY_COUNT=$(wc -l < "$ALL_PARAMS_ENV_KEYS" | tr -d ' ')
+echo ""
+echo "Discovered ${PARAMS_ENV_COUNT} params.env files with ${PARAMS_KEY_COUNT} unique keys"
+
+# --- Step 5: Fetch both build configs ---
 
 echo ""
+fetch_repo_images "RHOAI-Build-Config (${RHOAI_BUILD_CONFIG_BRANCH})" "$RHOAI_BASE_URL" "$RHOAI_BUILD_CONFIG"
+echo ""
+fetch_repo_images "ODH-Build-Config (${ODH_BUILD_CONFIG_BRANCH})" "$ODH_BASE_URL" "$ODH_BUILD_CONFIG"
+
+ODH_LABEL="ODH (${ODH_BUILD_CONFIG_BRANCH})"
+RHOAI_LABEL="RHOAI (${RHOAI_BUILD_CONFIG_BRANCH})"
+
+# --- Step 6: Unified validation ---
+# Build a single list of all RELATED_IMAGE entries to check, then validate each once.
+# Format: RELATED_IMAGE|key|component|source|has_map_entry
+# For unmapped refs (os.Getenv etc.), key is empty.
+
+ALL_ENTRIES="$WORKDIR/all-entries.txt"
+touch "$ALL_ENTRIES"
+
+# Collect from map entries
+for comp_file in "$WORKDIR/components/"*.txt; do
+    [ ! -f "$comp_file" ] && continue
+    comp_name=$(basename "$comp_file" .txt)
+    while IFS='/' read -r _ key related_image source; do
+        echo "${related_image}|${key}|${comp_name}|${source}|true" >> "$ALL_ENTRIES"
+    done < "$comp_file"
+done
+
+# Collect unmapped refs (os.Getenv, function args, etc.)
+cat "$WORKDIR/components/"*.txt 2>/dev/null | cut -d'/' -f3 | sort -u > "$WORKDIR/mapped-images.txt"
+grep -roh 'RELATED_IMAGE_[A-Z0-9_]\+' internal/ \
+    --include='*.go' --exclude='*_test.go' \
+    | sort -u > "$WORKDIR/all-refs.txt"
+grep -roh '"RELATED_IMAGE_[A-Z0-9_]*"[[:space:]]*:' internal/ \
+    --include='*.go' --exclude='*_test.go' 2>/dev/null \
+    | grep -oh 'RELATED_IMAGE_[A-Z0-9_]\+' \
+    | sort -u > "$WORKDIR/map-keys.txt"
+comm -23 "$WORKDIR/all-refs.txt" "$WORKDIR/map-keys.txt" > "$WORKDIR/all-env-refs.txt"
+comm -23 "$WORKDIR/all-env-refs.txt" "$WORKDIR/mapped-images.txt" > "$WORKDIR/unmapped-refs.txt"
 while IFS= read -r img; do
-    missing_from=""
-    present_in=""
-    for i in "${!REPO_LABELS[@]}"; do
-        if grep -qx "$img" "${REPO_FILES[$i]}"; then
-            present_in="${present_in:+${present_in}, }${REPO_LABELS[$i]}"
-        else
-            missing_from="${missing_from:+${missing_from}, }${REPO_LABELS[$i]}"
+    src=$(grep -rn "$img" internal/ --include='*.go' --exclude='*_test.go' | head -1)
+    src_file=""
+    [ -n "$src" ] && src_file="${src%%:*}:$(echo "$src" | cut -d: -f2)"
+    echo "${img}||unmapped|${src_file}|false" >> "$ALL_ENTRIES"
+done < "$WORKDIR/unmapped-refs.txt"
+
+# Deduplicate by RELATED_IMAGE and validate each once
+ERRORS_FILE="$WORKDIR/errors.txt"
+WARNINGS_FILE="$WORKDIR/warnings.txt"
+touch "$ERRORS_FILE" "$WARNINGS_FILE"
+
+# Get unique RELATED_IMAGE names
+sort -u -t'|' -k1,1 "$ALL_ENTRIES" | cut -d'|' -f1 | sort -u > "$WORKDIR/unique-images.txt"
+
+while IFS= read -r related_image; do
+    in_odh=false
+    in_rhoai=false
+    grep -qx "$related_image" "$ODH_BUILD_CONFIG" && in_odh=true || true
+    grep -qx "$related_image" "$RHOAI_BUILD_CONFIG" && in_rhoai=true || true
+
+    # Collect all references to this RELATED_IMAGE
+    entries=$(grep "^${related_image}|" "$ALL_ENTRIES")
+    has_map_entry=$(echo "$entries" | grep '|true$' | head -1 || true)
+
+    # Check params.env (only relevant for map entries)
+    in_params_env=false
+    params_info="Not in any params.env"
+    if [ -n "$has_map_entry" ]; then
+        first_key=$(echo "$has_map_entry" | cut -d'|' -f2)
+        if grep -qx "$first_key" "$ALL_PARAMS_ENV_KEYS"; then
+            in_params_env=true
+            pfiles=$(grep -rl "^${first_key}=" "$MANIFESTS_DIR" --include='params.env' --include='params-*.env' 2>/dev/null | tr '\n' ',' | sed 's/,$//' | sed 's/,/, /g')
+            params_info="In params.env: ${pfiles}"
         fi
-    done
-
-    [ -z "$missing_from" ] && continue
-
-    # Print header on first error
-    if [ "$HAS_ERRORS" = false ]; then
-        echo "ERROR: RELATED_IMAGE_* names missing from build configs:"
-        echo ""
-        HAS_ERRORS=true
+    else
+        params_info="Not in any map (used via os.Getenv or function arg)"
     fi
 
-    echo "  ${img}"
-    grep -rn "$img" internal/ --include='*.go' --exclude='*_test.go' | head -3 | while IFS= read -r line; do
-        echo "    Source: ${line%%:*}:$(echo "$line" | cut -d: -f2)"
-    done
-    echo "    Missing from: ${missing_from}"
-    [ -n "$present_in" ] && echo "    Present in:   ${present_in}"
-    echo ""
-done < "$WORKDIR/operator-images.txt"
+    # Skip if everything is OK
+    $in_params_env && $in_odh && $in_rhoai && continue
+    [ -z "$has_map_entry" ] && $in_odh && $in_rhoai && continue
 
-if [ "$HAS_ERRORS" = true ]; then
-    # Summary: list images grouped by which repo they're missing from
-    echo "---"
-    echo "Summary:"
-    for i in "${!REPO_LABELS[@]}"; do
-        missing_list=$(comm -23 "$WORKDIR/operator-images.txt" "${REPO_FILES[$i]}")
-        if [ -n "$missing_list" ]; then
-            echo ""
-            echo "  Missing from ${REPO_LABELS[$i]}:"
-            echo "$missing_list" | while IFS= read -r img; do
-                echo "    - ${img}"
-            done
+    # Build config status
+    bc_status=""
+    if $in_odh && $in_rhoai; then
+        bc_status="${GREEN}ODH ✓${RESET}, ${GREEN}RHOAI ✓${RESET}"
+    elif $in_odh; then
+        bc_status="${GREEN}ODH ✓${RESET}, ${RED}RHOAI ✗${RESET}"
+    elif $in_rhoai; then
+        bc_status="${RED}ODH ✗${RESET}, ${GREEN}RHOAI ✓${RESET}"
+    else
+        bc_status="${RED}ODH ✗${RESET}, ${RED}RHOAI ✗${RESET}"
+    fi
+
+    # Known issue check
+    known_issue_info=""
+    if is_known_issue "$related_image"; then
+        known_issue_info=$(get_known_issue_info "$related_image")
+    fi
+
+    # Severity: ERROR if missing from any build config, WARNING if only missing from params.env
+    is_error=false
+    if ! $in_odh || ! $in_rhoai; then
+        is_error=true
+    fi
+    if [ -z "$has_map_entry" ] && ! $in_odh && ! $in_rhoai; then
+        is_error=true
+    fi
+    if ! $in_params_env && $in_odh && $in_rhoai; then
+        is_error=false
+    fi
+
+    target_file="$ERRORS_FILE"
+    if [ -n "$known_issue_info" ]; then
+        target_file="$WARNINGS_FILE"
+        record_known_issue_match "$related_image" "build-config"
+    elif ! $is_error; then
+        target_file="$WARNINGS_FILE"
+    fi
+
+    {
+        if [ "$target_file" = "$ERRORS_FILE" ]; then
+            printf "  ${RED}%s${RESET}\n" "$related_image"
+        else
+            printf "  ${YELLOW}%s${RESET}" "$related_image"
+            [ -n "$known_issue_info" ] && printf " [known issue: %s]" "$known_issue_info"
+            printf "\n"
         fi
-    done
 
+        # List all references (component/key/source)
+        echo "$entries" | while IFS='|' read -r _ ekey ecomp esource emap; do
+            if [ "$emap" = "true" ]; then
+                echo "    Component: ${ecomp}, key: ${ekey}, source: ${esource}"
+            elif [ -n "$esource" ]; then
+                echo "    Source: ${esource} (used via os.Getenv or function arg)"
+            fi
+        done
+
+        echo "    ${params_info}"
+        printf "    Build configs: ${bc_status}\n"
+        echo ""
+    } >> "$target_file"
+done < "$WORKDIR/unique-images.txt"
+
+# --- Print results: errors first, then warnings ---
+
+ERRORS=0
+WARNINGS=0
+
+if [ -s "$ERRORS_FILE" ]; then
+    ERRORS=$(grep -c '^  [^ ]' "$ERRORS_FILE" || true)
     echo ""
-    echo "Please ensure these images are added to the build config repos before merging."
+    printf "${RED}${BOLD}Errors:${RESET}\n"
+    cat "$ERRORS_FILE"
+fi
+
+if [ -s "$WARNINGS_FILE" ]; then
+    WARNINGS=$(grep -c '^  [^ ]' "$WARNINGS_FILE" || true)
+    echo ""
+    printf "${YELLOW}${BOLD}Warnings:${RESET}\n"
+    cat "$WARNINGS_FILE"
+fi
+
+# --- Summary ---
+
+echo ""
+printf "${BOLD}=== Summary ===${RESET}\n"
+echo ""
+
+printf "  ${BOLD}Total:${RESET} "
+if [ "$ERRORS" -gt 0 ]; then
+    printf "${RED}%d error(s)${RESET}, " "$ERRORS"
+else
+    printf "${GREEN}%d error(s)${RESET}, " "$ERRORS"
+fi
+printf "${YELLOW}%d warning(s)${RESET}" "$WARNINGS"
+
+if [ -s "$KNOWN_ISSUES_MATCHED" ]; then
+    local_ki_count=$(sort -u "$KNOWN_ISSUES_MATCHED" | wc -l | tr -d ' ')
+    printf ", ${CYAN}%d known issue(s)${RESET}" "$local_ki_count"
+fi
+echo ""
+
+# Known issues detail
+if [ -s "$KNOWN_ISSUES_MATCHED" ]; then
+    echo ""
+    printf "  ${CYAN}${BOLD}Known issues (downgraded to warnings):${RESET}\n"
+    sort -u "$KNOWN_ISSUES_MATCHED" | while IFS='|' read -r _ ki_image ki_jira ki_reason; do
+        printf "    ${CYAN}%s${RESET} - %s (%s)\n" "$ki_image" "$ki_reason" "$ki_jira"
+    done
+fi
+
+if [ "$ERRORS" -gt 0 ]; then
+    echo ""
+    printf "${RED}Please ensure images are added to the build config repos and params.env before merging.${RESET}\n"
     echo "See: https://github.com/${ODH_REPO} and https://github.com/${RHOAI_REPO}"
     exit 1
 fi
 
-echo "All RELATED_IMAGE_* references are present in all build configs."
+echo ""
+printf "${GREEN}All RELATED_IMAGE_* references validated successfully.${RESET}\n"

--- a/.github/workflows/pr-comment.yaml
+++ b/.github/workflows/pr-comment.yaml
@@ -1,47 +1,91 @@
 name: Comment on pr
 on:
   workflow_run:
-    workflows: ["Check config and readme updates"]
+    workflows: ["Check config and readme updates", "Validate RELATED_IMAGE references"]
     types:
       - completed
 jobs:
-  download-artifact-data:
+  resolve-workflow:
     runs-on: ubuntu-latest
     outputs:
       pr_number: ${{ steps.artifact-data.outputs.pr_number }}
+      comment_tag: ${{ steps.resolve.outputs.comment_tag }}
+      message: ${{ steps.resolve.outputs.message }}
     steps:
-      - name: Download artifact
-        id: artifact-download
+      - name: Resolve workflow config and download PR number
+        id: resolve
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           script: |
-            let allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({
-               owner: context.repo.owner,
-               repo: context.repo.repo,
-               run_id: context.payload.workflow_run.id,
+            // Add new workflow checks here: artifact name, comment tag, and failure message.
+            const workflows = {
+              "Check config and readme updates": {
+                artifactName: "pr_number",
+                commentTag: "required-files-check",
+                message: `## This PR can't be merged just yet 😢
+
+            Please run \`make generate manifests-all api-docs\` and commit the changes.`,
+              },
+              "Validate RELATED_IMAGE references": {
+                artifactName: "pr_number_related_images",
+                commentTag: "related-images-check",
+                message: `## RELATED_IMAGE validation failed
+
+            Some \`RELATED_IMAGE_*\` names used in the operator are not present in ODH-Build-Config or RHOAI-Build-Config.
+
+            Please ensure the images are added to the build config repos before merging.`,
+              },
+            };
+
+            const workflowName = context.payload.workflow_run.name;
+            const config = workflows[workflowName];
+            if (!config) {
+              core.setFailed(`Unknown workflow: ${workflowName}`);
+              return;
+            }
+
+            // Download PR number artifact
+            const allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: context.payload.workflow_run.id,
             });
 
-            let matchArtifact = allArtifacts.data.artifacts.filter((artifact) => {
-              return artifact.name == "pr_number"
-            })[0];
+            const matchArtifact = allArtifacts.data.artifacts.find(
+              (a) => a.name === config.artifactName
+            );
+            if (!matchArtifact) {
+              core.setFailed(`Artifact "${config.artifactName}" not found`);
+              return;
+            }
 
-            let download = await github.rest.actions.downloadArtifact({
-               owner: context.repo.owner,
-               repo: context.repo.repo,
-               artifact_id: matchArtifact.id,
-               archive_format: 'zip',
+            const download = await github.rest.actions.downloadArtifact({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              artifact_id: matchArtifact.id,
+              archive_format: "zip",
             });
-            let fs = require('fs');
-            fs.writeFileSync(`${process.env.GITHUB_WORKSPACE}/pr_number.zip`, Buffer.from(download.data));
+            const fs = require("fs");
+            fs.writeFileSync(
+              `${process.env.GITHUB_WORKSPACE}/pr_number.zip`,
+              Buffer.from(download.data)
+            );
+
+            // Set outputs
+            const runUrl = `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${context.payload.workflow_run.id}`;
+            const fullMessage = `${config.message}\n\nFor more info: ${runUrl}`;
+
+            core.setOutput("comment_tag", config.commentTag);
+            core.setOutput("message", fullMessage);
       - name: Unzip artifact
         run: unzip pr_number.zip
-      - name: Extract data
+      - name: Extract PR number
         id: artifact-data
         run: |
           echo "pr_number=$(head -n 1 pr_number.txt)" >> $GITHUB_OUTPUT
   comment-on-pr:
     needs:
-      - download-artifact-data
+      - resolve-workflow
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
@@ -50,19 +94,14 @@ jobs:
         if: ${{ github.event.workflow_run.conclusion == 'failure' }}
         uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3.0.1
         with:
-          message: |
-              ## This PR can't be merged just yet 😢
-
-                Please run `make generate manifests-all api-docs` and commit the changes.
-
-                For more info: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.event.workflow_run.id }}
-          pr-number: ${{ needs.download-artifact-data.outputs.pr_number }}
-          comment-tag: required-files-check
+          message: ${{ needs.resolve-workflow.outputs.message }}
+          pr-number: ${{ needs.resolve-workflow.outputs.pr_number }}
+          comment-tag: ${{ needs.resolve-workflow.outputs.comment_tag }}
           mode: upsert
       - name: Delete resolved comment
         if: ${{ github.event.workflow_run.conclusion == 'success' }}
         uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3.0.1
         with:
-          pr-number: ${{ needs.download-artifact-data.outputs.pr_number }}
-          comment-tag: required-files-check
+          pr-number: ${{ needs.resolve-workflow.outputs.pr_number }}
+          comment-tag: ${{ needs.resolve-workflow.outputs.comment_tag }}
           mode: delete

--- a/.github/workflows/pr-comment.yaml
+++ b/.github/workflows/pr-comment.yaml
@@ -6,7 +6,10 @@ on:
       - completed
 jobs:
   resolve-workflow:
+    if: github.event.workflow_run.event == 'pull_request'
     runs-on: ubuntu-latest
+    permissions:
+      actions: read
     outputs:
       pr_number: ${{ steps.artifact-data.outputs.pr_number }}
       comment_tag: ${{ steps.resolve.outputs.comment_tag }}
@@ -82,7 +85,7 @@ jobs:
       - name: Extract PR number
         id: artifact-data
         run: |
-          echo "pr_number=$(head -n 1 pr_number.txt)" >> $GITHUB_OUTPUT
+          echo "pr_number=$(head -n 1 pr_number.txt)" >> "$GITHUB_OUTPUT"
   comment-on-pr:
     needs:
       - resolve-workflow

--- a/.github/workflows/validate-related-images.yaml
+++ b/.github/workflows/validate-related-images.yaml
@@ -1,0 +1,38 @@
+name: Validate RELATED_IMAGE references
+on:
+  pull_request:
+    # TODO: Uncomment this when all existent issues are resolved
+    # paths:
+    #   - 'internal/**'
+  workflow_dispatch:
+
+jobs:
+  validate:
+    name: Check RELATED_IMAGE names against build configs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          fetch-depth: 0
+      - name: Save the PR number for artifact upload
+        run: |
+          echo ${{ github.event.number }} > pr_number.txt
+      - name: Upload the PR number as artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: pr_number_related_images
+          path: ./pr_number.txt
+          retention-days: 1
+      # TODO: Uncomment this when all existent issues are resolved
+      # - name: Check if RELATED_IMAGE references changed
+      #   id: check
+      #   run: |
+      #     if git diff origin/${{ github.event.pull_request.base.ref }}...HEAD -- internal/ | grep -qE '^\+.*RELATED_IMAGE_'; then
+      #       echo "changed=true" >> $GITHUB_OUTPUT
+      #     else
+      #       echo "No RELATED_IMAGE_* changes detected, skipping validation."
+      #       echo "changed=false" >> $GITHUB_OUTPUT
+      #     fi
+      - name: Validate RELATED_IMAGE references
+        # if: steps.check.outputs.changed == 'true' || github.event_name == 'workflow_dispatch'
+        run: make validate-related-images

--- a/.github/workflows/validate-related-images.yaml
+++ b/.github/workflows/validate-related-images.yaml
@@ -1,40 +1,53 @@
 name: Validate RELATED_IMAGE references
 on:
+  push:
+    branches:
+      - main
   pull_request:
-    # TODO: Uncomment this when all existent issues are resolved
-    # paths:
-    #   - 'internal/**'
+    paths:
+      - 'internal/**'
+      - '.github/scripts/validate-related-images.sh'
+      - '.github/workflows/validate-related-images.yaml'
+      - 'component-params-env.yaml'
   workflow_dispatch:
 
 jobs:
   validate:
     name: Check RELATED_IMAGE names against build configs
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           fetch-depth: 0
       - name: Save the PR number for artifact upload
+        if: github.event_name == 'pull_request'
+        env:
+          PR_NUMBER: ${{ github.event.number }}
         run: |
-          echo ${{ github.event.number }} > pr_number.txt
+          echo "$PR_NUMBER" > pr_number.txt
       - name: Upload the PR number as artifact
+        if: github.event_name == 'pull_request'
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: pr_number_related_images
           path: ./pr_number.txt
           retention-days: 1
-      # TODO: Uncomment this when all existent issues are resolved
-      # - name: Check if RELATED_IMAGE references changed
-      #   id: check
-      #   run: |
-      #     if git diff origin/${{ github.event.pull_request.base.ref }}...HEAD -- internal/ | grep -qE '^\+.*RELATED_IMAGE_'; then
-      #       echo "changed=true" >> $GITHUB_OUTPUT
-      #     else
-      #       echo "No RELATED_IMAGE_* changes detected, skipping validation."
-      #       echo "changed=false" >> $GITHUB_OUTPUT
-      #     fi
+      - name: Check if RELATED_IMAGE references changed
+        if: github.event_name == 'pull_request'
+        id: check
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+        run: |
+          if git diff "origin/${BASE_REF}...HEAD" -- internal/ | grep -qE '^\+.*RELATED_IMAGE_'; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "No RELATED_IMAGE_* changes detected, skipping validation."
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          fi
       - name: Fetch component manifests
         run: make get-manifests
       - name: Validate RELATED_IMAGE references
-        # if: steps.check.outputs.changed == 'true' || github.event_name == 'workflow_dispatch'
+        # if: steps.check.outputs.changed == 'true' || github.event_name == 'workflow_dispatch' || github.event_name == 'push'
         run: make validate-related-images

--- a/.github/workflows/validate-related-images.yaml
+++ b/.github/workflows/validate-related-images.yaml
@@ -33,6 +33,8 @@ jobs:
       #       echo "No RELATED_IMAGE_* changes detected, skipping validation."
       #       echo "changed=false" >> $GITHUB_OUTPUT
       #     fi
+      - name: Fetch component manifests
+        run: make get-manifests
       - name: Validate RELATED_IMAGE references
         # if: steps.check.outputs.changed == 'true' || github.event_name == 'workflow_dispatch'
         run: make validate-related-images

--- a/.github/workflows/validate-related-images.yaml
+++ b/.github/workflows/validate-related-images.yaml
@@ -49,5 +49,5 @@ jobs:
       - name: Fetch component manifests
         run: make get-manifests
       - name: Validate RELATED_IMAGE references
-        # if: steps.check.outputs.changed == 'true' || github.event_name == 'workflow_dispatch' || github.event_name == 'push'
+        if: steps.check.outputs.changed == 'true' || github.event_name == 'workflow_dispatch' || github.event_name == 'push'
         run: make validate-related-images

--- a/Makefile
+++ b/Makefile
@@ -334,6 +334,11 @@ get-manifests: ## Fetch components manifests from remote git repo
 	@./.github/scripts/validate-manifest-images.sh
 CLEANFILES += opt/manifests/*
 
+.PHONY: validate-related-images
+validate-related-images: ## Validate RELATED_IMAGE_* names against build configs
+	@RHOAI_BUILD_CONFIG_BRANCH=rhoai-$(shell echo $(VERSION) | sed 's/\([0-9]*\.[0-9]*\)\.[0-9]*/\1/') \
+		./.github/scripts/validate-related-images.sh
+
 # Default to standard sed command
 SED_COMMAND = sed
 

--- a/Makefile
+++ b/Makefile
@@ -141,7 +141,7 @@ KUSTOMIZE_VERSION ?= v5.8.1
 CONTROLLER_TOOLS_VERSION ?= v0.17.3
 OPERATOR_SDK_VERSION ?= v1.39.2
 GOLANGCI_LINT_VERSION ?= v2.5.0
-YQ_VERSION ?= v4.12.2
+YQ_VERSION ?= v4.53.2
 HELM_VERSION ?= v4.1.1
 KUBE_LINTER_VERSION ?= v0.7.6
 #ENVTEST_K8S_VERSION is the version of Kubernetes to use for setting up ENVTEST binaries (i.e. 1.31)
@@ -335,9 +335,9 @@ get-manifests: ## Fetch components manifests from remote git repo
 CLEANFILES += opt/manifests/*
 
 .PHONY: validate-related-images
-validate-related-images: ## Validate RELATED_IMAGE_* names against build configs
+validate-related-images: yq ## Validate RELATED_IMAGE_* names against build configs
 	@RHOAI_BUILD_CONFIG_BRANCH=rhoai-$(shell echo $(VERSION) | sed 's/\([0-9]*\.[0-9]*\)\.[0-9]*/\1/') \
-		./.github/scripts/validate-related-images.sh
+		YQ=$(YQ) ./.github/scripts/validate-related-images.sh
 
 # Default to standard sed command
 SED_COMMAND = sed

--- a/component-params-env.yaml
+++ b/component-params-env.yaml
@@ -8,20 +8,41 @@
 rhai_helm_components:
   - kserve
 
-known_issues:
-- image: RELATED_IMAGE_RHAII_VLLM_CPU_IMAGE
-  jira: https://redhat.atlassian.net/browse/RHOAIENG-59802
-  reason: RHAII image must be renamed from RHAIIS
-- image: RELATED_IMAGE_RHAII_VLLM_CUDA_IMAGE
-  jira: https://redhat.atlassian.net/browse/RHOAIENG-59802
-  reason: RHAII image must be renamed from RHAIIS
-- image: RELATED_IMAGE_RHAII_VLLM_ROCM_IMAGE
-  jira: https://redhat.atlassian.net/browse/RHOAIENG-59802
-  reason: RHAII image must be renamed from RHAIIS
-- image: RELATED_IMAGE_RHAII_VLLM_SPYRE_IMAGE
-  jira: https://redhat.atlassian.net/browse/RHOAIENG-59802
-  reason: RHAII image must be renamed from RHAIIS
 # Example:
 # - image: RELATED_IMAGE_ODH_CAIKIT_NLP_IMAGE
 #   jira: https://issues.redhat.com/browse/RHOAIENG-XXXXX
 #   reason: Deprecated image, removal tracked in Jira
+known_issues:
+- image: RELATED_IMAGE_ODH_ML_PIPELINES_RUNTIME_GENERIC_IMAGE
+  jira: https://redhat.atlassian.net/browse/RHOAIENG-60396
+  reason: Removed with InstrutLab pipeline removal since RHOAI 3.0
+- image: RELATED_IMAGE_DSP_INSTRUCTLAB_NVIDIA_IMAGE
+  jira: https://redhat.atlassian.net/browse/RHOAIENG-60396
+  reason: Removed with InstrutLab pipeline removal since RHOAI 3.0
+- image: RELATED_IMAGE_DSP_TOOLBOX_IMAGE
+  jira: https://redhat.atlassian.net/browse/RHOAIENG-60396
+  reason: Removed with InstrutLab pipeline removal since RHOAI 3.0
+- image: RELATED_IMAGE_CLI_IMAGE
+  jira: https://redhat.atlassian.net/browse/RHOAIENG-60519
+  reason: image is not used in monitoring templates and should be removed
+- image: RELATED_IMAGE_ODH_CAIKIT_NLP_IMAGE
+  jira: https://redhat.atlassian.net/browse/RHOAIENG-60523
+  reason: caikit-nlp support is removed since RHOAI 3.0
+- image: RELATED_IMAGE_ODH_EVAL_HUB_IMAGE
+  jira: https://redhat.enterprise.slack.com/lists/T027F3GAJ/F07SBP17R7Z?record_id=Rec0B00862M6J
+  reason: PR created, need to be merged
+- image: RELATED_IMAGE_ODH_TRUSTYAI_NEMO_GUARDRAILS_SERVER_IMAGE
+  jira: https://redhat.enterprise.slack.com/lists/T027F3GAJ/F07SBP17R7Z?record_id=Rec0B00862M6J
+  reason: PR created, need to be merged
+- image: RELATED_IMAGE_ODH_TRUSTYAI_GARAK_LLS_PROVIDER_DSP_IMAGE
+  jira: https://redhat.enterprise.slack.com/lists/T027F3GAJ/F07SBP17R7Z?record_id=Rec0B00862M6J
+  reason: need to be added the image
+- image: RELATED_IMAGE_ODH_LLM_D_KV_CACHE_IMAGE
+  jira: https://redhat.atlassian.net/browse/RHOAIENG-60572
+  reason: need to be added the image to ODH-Build-Config
+- image: RELATED_IMAGE_ODH_MODEL_PERFORMANCE_DATA_IMAGE
+  jira: https://redhat.atlassian.net/browse/RHOAIENG-60572
+  reason: need to be added the image to ODH-Build-Config, or set an exception for the image
+- image: RELATED_IMAGE_ODH_VLLM_CPU_IMAGE
+  jira: https://redhat.atlassian.net/browse/RHOAIENG-60572
+  reason: need to be added the image to ODH-Build-Config, or set an exception for the image

--- a/component-params-env.yaml
+++ b/component-params-env.yaml
@@ -1,7 +1,12 @@
 # Configuration for validate-related-images.sh.
 #
+# rhai_helm_components: components whose RELATED_IMAGE_* must also be present
+#   in RHOAI-Build-Config helm/rhai-on-xks-chart/values.yaml (rhaiOperator.relatedImages).
 # known_issues: RELATED_IMAGE errors to downgrade to warnings.
-# Each entry MUST include a Jira link and reason.
+#   Each entry MUST include a Jira link and reason.
+
+rhai_helm_components:
+  - kserve
 
 known_issues:
 - image: RELATED_IMAGE_RHAII_VLLM_CPU_IMAGE

--- a/component-params-env.yaml
+++ b/component-params-env.yaml
@@ -1,0 +1,10 @@
+# Configuration for validate-related-images.sh.
+#
+# known_issues: RELATED_IMAGE errors to downgrade to warnings.
+# Each entry MUST include a Jira link and reason.
+
+known_issues: []
+# Example:
+# - image: RELATED_IMAGE_ODH_CAIKIT_NLP_IMAGE
+#   jira: https://issues.redhat.com/browse/RHOAIENG-XXXXX
+#   reason: Deprecated image, removal tracked in Jira

--- a/component-params-env.yaml
+++ b/component-params-env.yaml
@@ -3,7 +3,19 @@
 # known_issues: RELATED_IMAGE errors to downgrade to warnings.
 # Each entry MUST include a Jira link and reason.
 
-known_issues: []
+known_issues:
+- image: RELATED_IMAGE_RHAII_VLLM_CPU_IMAGE
+  jira: https://redhat.atlassian.net/browse/RHOAIENG-59802
+  reason: RHAII image must be renamed from RHAIIS
+- image: RELATED_IMAGE_RHAII_VLLM_CUDA_IMAGE
+  jira: https://redhat.atlassian.net/browse/RHOAIENG-59802
+  reason: RHAII image must be renamed from RHAIIS
+- image: RELATED_IMAGE_RHAII_VLLM_ROCM_IMAGE
+  jira: https://redhat.atlassian.net/browse/RHOAIENG-59802
+  reason: RHAII image must be renamed from RHAIIS
+- image: RELATED_IMAGE_RHAII_VLLM_SPYRE_IMAGE
+  jira: https://redhat.atlassian.net/browse/RHOAIENG-59802
+  reason: RHAII image must be renamed from RHAIIS
 # Example:
 # - image: RELATED_IMAGE_ODH_CAIKIT_NLP_IMAGE
 #   jira: https://issues.redhat.com/browse/RHOAIENG-XXXXX


### PR DESCRIPTION
## Description

Add automated CI validation that ensures all `RELATED_IMAGE_*` env var names used in the operator source are present in ODH-Build-Config and RHOAI-Build-Config, and that their map keys exist in `params.env` files.

- New bash script (`.github/scripts/validate-related-images.sh`) performs unified per-platform validation: discovers all `params.env` files from `opt/manifests/`, extracts Go map entries mapping keys to `RELATED_IMAGE_*` values, checks both ODH and RHOAI build configs, and reports errors/warnings with `ODH ✓/✗, RHOAI ✓/✗` status per image
- New GitHub Actions workflow (`.github/workflows/validate-related-images.yaml`) runs the check on PRs modifying `internal/**`, with `make get-manifests` for params.env discovery
- Refactored `.github/workflows/pr-comment.yaml` into a config-driven, generic workflow that supports multiple check workflows via a single config map
- New `component-params-env.yaml` config for known issues (downgrade specific errors to warnings with Jira link + reason)
- New `make validate-related-images` Makefile target for local validation

Jira task: https://issues.redhat.com/browse/RHOAIENG-53373

## How Has This Been Tested?

- Ran `make get-manifests && make validate-related-images` locally, verified correct detection of errors (missing from build config) and warnings (missing from params.env)
- Verified deduplication: each `RELATED_IMAGE_*` appears exactly once with unified ODH/RHOAI status
- Verified `DEBUG=true make validate-related-images` outputs working directory for intermediate file inspection
- Verified `internal/controller/services/` refs (e.g. monitoring, gateway) are correctly caught
- Tested known issues config: errors matching `known_issues` entries are downgraded to warnings with Jira link shown

Jira task: https://issues.redhat.com/browse/RHOAIENG-53373

## How Has This Been Tested?

- Ran `make validate-related-images` locally to verify the script correctly identifies RELATED_IMAGE references and detects mismatches
- Verified the VERSION-to-branch derivation works for all formats (`3.3.0` → `rhoai-3.3`, `3.5.0-ea.1` → `rhoai-3.5-ea.1`)
- Verified map key exclusion logic correctly filters out Go map keys (e.g. `"RELATED_IMAGE_FEAST_OPERATOR": "RELATED_IMAGE_ODH_FEAST_OPERATOR_IMAGE"` only extracts the value side)
- `DEBUG=true make validate-related-images` can be used to inspect intermediate files

## Merge criteria

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [x] The developer has run the integration test pipeline and verified that it passed successfully
- [x] New RELATED_IMAGE mappings are already listed in ODH-Build-Config and RHOAI-Build-Config, and links are included in PR description (validated by CI)

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->
This PR only adds CI tooling (bash script, GitHub Actions workflow, Makefile target). No operator runtime code is changed, so no E2E test update is needed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated RELATED_IMAGE validation for PRs with configurable known-issues to manage exceptions.
  * New CI workflow to run validation on PRs and on demand.

* **Chores**
  * CI now coordinates multiple validation runs and posts dynamic PR feedback based on outcomes.
  * Added a Make target to invoke the RELATED_IMAGE validation.

* **Documentation**
  * PR checklist wording clarified to note CI validation of build-config mappings and PR links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->