### PR TITLE
fix: preserve immutable namespace field when resetting monitoring to Removed in e2e tests

### DIFF
--- a/internal/controller/datasciencecluster/datasciencecluster_controller_actions.go
+++ b/internal/controller/datasciencecluster/datasciencecluster_controller_actions.go
@@ -34,7 +34,7 @@ type persistAPI interface {
 	APIPersistObject() client.Object
 }
 
-func isNilInterface(v interface{}) bool {
+func isNilInterface(v any) bool {
 	return v == nil || (reflect.ValueOf(v).Kind() == reflect.Ptr && reflect.ValueOf(v).IsNil())
 }
 

--- a/pkg/controller/actions/dependency/certmanager/bootstrap_test.go
+++ b/pkg/controller/actions/dependency/certmanager/bootstrap_test.go
@@ -467,7 +467,7 @@ func TestBootstrapOperatorCertConfig(t *testing.T) {
 		expectedCertSecretName string
 		expectedServiceName    string
 	}{
-		{ //nolint:gosec // G101 false positive: field name contains "Secret" but holds a resource name, not a credential
+		{
 			name:                   "uses the provided namespace",
 			namespace:              "my-namespace",
 			expectedNamespace:      "my-namespace",
@@ -475,7 +475,7 @@ func TestBootstrapOperatorCertConfig(t *testing.T) {
 			expectedCertSecretName: "opendatahub-operator-controller-webhook-cert",
 			expectedServiceName:    "opendatahub-operator-webhook-service",
 		},
-		{ //nolint:gosec // G101 false positive: field name contains "Secret" but holds a resource name, not a credential
+		{
 			name:                   "returns default webhook config when env is unset",
 			namespace:              "ns",
 			expectedNamespace:      "ns",
@@ -494,7 +494,7 @@ func TestBootstrapOperatorCertConfig(t *testing.T) {
 			expectedCertSecretName: "custom-secret",
 			expectedServiceName:    "opendatahub-operator-webhook-service",
 		},
-		{ //nolint:gosec // G101 false positive: field name contains "Secret" but holds a resource name, not a credential
+		{
 			name:      "overrides webhook service name from env",
 			namespace: "ns",
 			envVars: map[string]string{
@@ -505,7 +505,7 @@ func TestBootstrapOperatorCertConfig(t *testing.T) {
 			expectedCertSecretName: "opendatahub-operator-controller-webhook-cert",
 			expectedServiceName:    "custom-service",
 		},
-		{ //nolint:gosec // G101 false positive: field name contains "Secret" but holds a resource name, not a credential
+		{
 			name:      "overrides webhook cert name from env",
 			namespace: "ns",
 			envVars: map[string]string{

--- a/pkg/controller/actions/dependency/certmanager/bootstrap_test.go
+++ b/pkg/controller/actions/dependency/certmanager/bootstrap_test.go
@@ -467,7 +467,7 @@ func TestBootstrapOperatorCertConfig(t *testing.T) {
 		expectedCertSecretName string
 		expectedServiceName    string
 	}{
-		{
+		{ //nolint:gosec // G101 false positive: field name contains "Secret" but holds a resource name, not a credential
 			name:                   "uses the provided namespace",
 			namespace:              "my-namespace",
 			expectedNamespace:      "my-namespace",
@@ -475,7 +475,7 @@ func TestBootstrapOperatorCertConfig(t *testing.T) {
 			expectedCertSecretName: "opendatahub-operator-controller-webhook-cert",
 			expectedServiceName:    "opendatahub-operator-webhook-service",
 		},
-		{
+		{ //nolint:gosec // G101 false positive: field name contains "Secret" but holds a resource name, not a credential
 			name:                   "returns default webhook config when env is unset",
 			namespace:              "ns",
 			expectedNamespace:      "ns",
@@ -494,7 +494,7 @@ func TestBootstrapOperatorCertConfig(t *testing.T) {
 			expectedCertSecretName: "custom-secret",
 			expectedServiceName:    "opendatahub-operator-webhook-service",
 		},
-		{
+		{ //nolint:gosec // G101 false positive: field name contains "Secret" but holds a resource name, not a credential
 			name:      "overrides webhook service name from env",
 			namespace: "ns",
 			envVars: map[string]string{
@@ -505,7 +505,7 @@ func TestBootstrapOperatorCertConfig(t *testing.T) {
 			expectedCertSecretName: "opendatahub-operator-controller-webhook-cert",
 			expectedServiceName:    "custom-service",
 		},
-		{
+		{ //nolint:gosec // G101 false positive: field name contains "Secret" but holds a resource name, not a credential
 			name:      "overrides webhook cert name from env",
 			namespace: "ns",
 			envVars: map[string]string{

--- a/pkg/controller/actions/deploy/action_deploy_test.go
+++ b/pkg/controller/actions/deploy/action_deploy_test.go
@@ -1170,7 +1170,7 @@ func newOwnerRefReconciliationRequest(cl client.Client, instance *componentApi.D
 	}
 }
 
-func assertControllerOwnerRef(g Gomega, ownerRefs []metav1.OwnerReference, instance *componentApi.Dashboard, msgAndArgs ...interface{}) {
+func assertControllerOwnerRef(g Gomega, ownerRefs []metav1.OwnerReference, instance *componentApi.Dashboard, msgAndArgs ...any) {
 	g.Expect(ownerRefs).Should(HaveLen(1), msgAndArgs...)
 	g.Expect(ownerRefs[0].Kind).Should(Equal(gvk.Dashboard.Kind), msgAndArgs...)
 	g.Expect(ownerRefs[0].Name).Should(Equal(instance.Name), msgAndArgs...)

--- a/tests/e2e/monitoring_test.go
+++ b/tests/e2e/monitoring_test.go
@@ -1498,15 +1498,10 @@ func (tc *MonitoringTestCtx) resetMonitoringConfigToManaged() {
 // resetMonitoringConfigToRemoved resets monitoring configuration and sets management state to Removed.
 // It preserves the immutable namespace field while clearing all optional config fields.
 func (tc *MonitoringTestCtx) resetMonitoringConfigToRemoved() {
-func (tc *MonitoringTestCtx) resetMonitoringConfigToManaged() {
 	tc.updateMonitoringConfig(
-		withManagementState(operatorv1.Managed),
+		withManagementState(operatorv1.Removed),
 		testf.Transform(`del(.spec.monitoring.metrics, .spec.monitoring.traces, .spec.monitoring.alerting, .spec.monitoring.collectorReplicas)`),
 	)
-
-	// Wait for OpenTelemetryCollector to be deleted if it was running with metrics/traces
-	// The controller will delete it when monitoring is reset to empty config
-	tc.EnsureResourcesGone(
 }
 
 // updateMonitoringConfig provides a flexible way to update DSCI monitoring configuration.

--- a/tests/e2e/monitoring_test.go
+++ b/tests/e2e/monitoring_test.go
@@ -1483,10 +1483,11 @@ func (tc *MonitoringTestCtx) cleanupGroup(t *testing.T, secretName string) {
 // resetMonitoringConfigToManaged completely resets monitoring configuration and sets management state to Managed.
 // It waits for any in-flight deletions to complete to ensure clean state for the next test.
 func (tc *MonitoringTestCtx) resetMonitoringConfigToManaged() {
-	tc.updateMonitoringConfig(testf.Transform(`.spec.monitoring = {"managementState": "%s"}`, operatorv1.Managed))
+	tc.updateMonitoringConfig(
+		withManagementState(operatorv1.Managed),
+		testf.Transform(`del(.spec.monitoring.metrics, .spec.monitoring.traces, .spec.monitoring.alerting, .spec.monitoring.collectorReplicas)`),
+	)
 
-	// Wait for OpenTelemetryCollector to be deleted if it was running with metrics/traces
-	// The controller will delete it when monitoring is reset to empty config
 	tc.EnsureResourcesGone(
 		WithMinimalObject(gvk.OpenTelemetryCollector, types.NamespacedName{
 			Name:      OpenTelemetryCollectorName,
@@ -1501,6 +1502,13 @@ func (tc *MonitoringTestCtx) resetMonitoringConfigToRemoved() {
 	tc.updateMonitoringConfig(
 		withManagementState(operatorv1.Removed),
 		testf.Transform(`del(.spec.monitoring.metrics, .spec.monitoring.traces, .spec.monitoring.alerting, .spec.monitoring.collectorReplicas)`),
+	)
+
+	tc.EnsureResourcesGone(
+		WithMinimalObject(gvk.OpenTelemetryCollector, types.NamespacedName{
+			Name:      OpenTelemetryCollectorName,
+			Namespace: tc.MonitoringNamespace,
+		}),
 	)
 }
 

--- a/tests/e2e/monitoring_test.go
+++ b/tests/e2e/monitoring_test.go
@@ -1495,9 +1495,13 @@ func (tc *MonitoringTestCtx) resetMonitoringConfigToManaged() {
 	)
 }
 
-// resetMonitoringConfigToRemoved completely resets monitoring configuration and sets management state to Removed.
+// resetMonitoringConfigToRemoved resets monitoring configuration and sets management state to Removed.
+// It preserves the immutable namespace field while clearing all optional config fields.
 func (tc *MonitoringTestCtx) resetMonitoringConfigToRemoved() {
-	tc.updateMonitoringConfig(testf.Transform(`.spec.monitoring = {"managementState": "%s"}`, operatorv1.Removed))
+	tc.updateMonitoringConfig(
+		withManagementState(operatorv1.Removed),
+		testf.Transform(`del(.spec.monitoring.metrics, .spec.monitoring.traces, .spec.monitoring.alerting, .spec.monitoring.collectorReplicas)`),
+	)
 }
 
 // updateMonitoringConfig provides a flexible way to update DSCI monitoring configuration.

--- a/tests/e2e/monitoring_test.go
+++ b/tests/e2e/monitoring_test.go
@@ -1498,10 +1498,15 @@ func (tc *MonitoringTestCtx) resetMonitoringConfigToManaged() {
 // resetMonitoringConfigToRemoved resets monitoring configuration and sets management state to Removed.
 // It preserves the immutable namespace field while clearing all optional config fields.
 func (tc *MonitoringTestCtx) resetMonitoringConfigToRemoved() {
+func (tc *MonitoringTestCtx) resetMonitoringConfigToManaged() {
 	tc.updateMonitoringConfig(
-		withManagementState(operatorv1.Removed),
+		withManagementState(operatorv1.Managed),
 		testf.Transform(`del(.spec.monitoring.metrics, .spec.monitoring.traces, .spec.monitoring.alerting, .spec.monitoring.collectorReplicas)`),
 	)
+
+	// Wait for OpenTelemetryCollector to be deleted if it was running with metrics/traces
+	// The controller will delete it when monitoring is reset to empty config
+	tc.EnsureResourcesGone(
 }
 
 // updateMonitoringConfig provides a flexible way to update DSCI monitoring configuration.

--- a/tests/e2e/monitoring_test.go
+++ b/tests/e2e/monitoring_test.go
@@ -1480,8 +1480,8 @@ func (tc *MonitoringTestCtx) cleanupGroup(t *testing.T, secretName string) {
 	)
 }
 
-// resetMonitoringConfigToManaged completely resets monitoring configuration and sets management state to Managed.
-// It waits for any in-flight deletions to complete to ensure clean state for the next test.
+// resetMonitoringConfigToManaged selectively deletes optional monitoring config fields and sets management state to Managed.
+// It preserves the immutable namespace field and waits for any in-flight deletions to complete to ensure clean state for the next test.
 func (tc *MonitoringTestCtx) resetMonitoringConfigToManaged() {
 	tc.updateMonitoringConfig(
 		withManagementState(operatorv1.Managed),

--- a/tests/e2e/test_context_test.go
+++ b/tests/e2e/test_context_test.go
@@ -797,11 +797,11 @@ func (tc *TestContext) GetInstanceName(gvk schema.GroupVersionKind) string {
 func (tc *TestContext) CreateComponent(gvk schema.GroupVersionKind) *unstructured.Unstructured {
 	instanceName := tc.GetInstanceName(gvk)
 	return &unstructured.Unstructured{
-		Object: map[string]interface{}{
+		Object: map[string]any{
 			"apiVersion": gvk.GroupVersion().String(),
 			"kind":       gvk.Kind,
-			"metadata":   map[string]interface{}{"name": instanceName},
-			"spec":       map[string]interface{}{},
+			"metadata":   map[string]any{"name": instanceName},
+			"spec":       map[string]any{},
 		},
 	}
 }


### PR DESCRIPTION
The resetMonitoringConfigToRemoved helper was replacing the entire monitoring spec, which cleared the immutable namespace field and caused subsequent reconciliation failures in e2e tests.

<!---
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->
Summary                                                                                                                                            
                                                                                                                                                     
  - Fix E2E monitoring test failure caused by resetMonitoringConfigToRemoved() overwriting the entire .spec.monitoring object, which drops the       
  immutable namespace field and triggers a webhook validation error                                                                                  
  - Preserve the namespace field by switching from full object replacement to selective deletion of optional config fields (metrics, traces,         
  alerting, collectorReplicas)                               
                                                                                                                                                     
  Fixes: RHOAIENG-59921
<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
  Test plan                                                                                                                                          
                                                                                                                                                     
  - Run monitoring e2e tests: make e2e-test-single TEST="TestOdhOperator/Service_Tests/monitoring"                                                   
  - Verify tests that toggle monitoring between Managed and Removed no longer fail with namespace validation errors   
## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [x] The developer has run the integration test pipeline and verified that it passed successfully
- [x] New RELATED_IMAGE mappings are already listed in ODH-Build-Config and RHOAI-Build-Config, and links are included in PR description

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [ ] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated internal helper types and test utility signatures for cleaner, modernized code.

* **Tests**
  * Improved monitoring reset tests to selectively preserve immutable settings and more reliably verify collector removal and configuration state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->