### PR TITLE
fix: discover PKI resource names from cloud manager deployment in e2e tests

### DIFF
--- a/tests/e2e/cloudmanager/cloudmanager_test.go
+++ b/tests/e2e/cloudmanager/cloudmanager_test.go
@@ -140,7 +140,7 @@ func TestCloudManager(t *testing.T) { //nolint:maintidx // sequential subtests s
 			t.Run("selfsigned ClusterIssuer is ready", func(t *testing.T) {
 				wt := tc.NewWithT(t)
 				wt.Get(gvk.CertManagerClusterIssuer, types.NamespacedName{
-					Name: "opendatahub-selfsigned-issuer",
+					Name: pki.IssuerName,
 				}).Eventually().Should(
 					jq.Match(`.status.conditions[] | select(.type == "Ready") | .status == "True"`),
 				)
@@ -149,7 +149,7 @@ func TestCloudManager(t *testing.T) { //nolint:maintidx // sequential subtests s
 			t.Run("root CA Certificate is issued", func(t *testing.T) {
 				wt := tc.NewWithT(t)
 				wt.Get(gvk.CertManagerCertificate, types.NamespacedName{
-					Name: "opendatahub-ca", Namespace: "cert-manager",
+					Name: pki.CertName, Namespace: pki.CertManagerNamespace,
 				}).Eventually().Should(
 					jq.Match(`.status.conditions[] | select(.type == "Ready") | .status == "True"`),
 				)
@@ -158,7 +158,7 @@ func TestCloudManager(t *testing.T) { //nolint:maintidx // sequential subtests s
 			t.Run("CA-backed ClusterIssuer is ready", func(t *testing.T) {
 				wt := tc.NewWithT(t)
 				wt.Get(gvk.CertManagerClusterIssuer, types.NamespacedName{
-					Name: "opendatahub-ca-issuer",
+					Name: pki.CAIssuerName,
 				}).Eventually().Should(
 					jq.Match(`.status.conditions[] | select(.type == "Ready") | .status == "True"`),
 				)
@@ -167,7 +167,7 @@ func TestCloudManager(t *testing.T) { //nolint:maintidx // sequential subtests s
 			t.Run("CA Secret is created", func(t *testing.T) {
 				wt := tc.NewWithT(t)
 				wt.Get(gvk.Secret, types.NamespacedName{
-					Name: "opendatahub-ca", Namespace: "cert-manager",
+					Name: pki.CertName, Namespace: pki.CertManagerNamespace,
 				}).Eventually().Should(Not(BeNil()))
 			})
 		})
@@ -355,13 +355,13 @@ func TestCloudManager(t *testing.T) { //nolint:maintidx // sequential subtests s
 
 			// PKI resources must survive the GC run.
 			wt.Get(gvk.CertManagerClusterIssuer, types.NamespacedName{
-				Name: "opendatahub-selfsigned-issuer",
+				Name: pki.IssuerName,
 			}).Eventually().Should(Not(BeNil()))
 			wt.Get(gvk.CertManagerCertificate, types.NamespacedName{
-				Name: "opendatahub-ca", Namespace: "cert-manager",
+				Name: pki.CertName, Namespace: pki.CertManagerNamespace,
 			}).Eventually().Should(Not(BeNil()))
 			wt.Get(gvk.CertManagerClusterIssuer, types.NamespacedName{
-				Name: "opendatahub-ca-issuer",
+				Name: pki.CAIssuerName,
 			}).Eventually().Should(Not(BeNil()))
 
 			// Restore sailOperator.

--- a/tests/e2e/cloudmanager/cloudmanager_test.go
+++ b/tests/e2e/cloudmanager/cloudmanager_test.go
@@ -208,7 +208,7 @@ func TestCloudManager(t *testing.T) { //nolint:maintidx // sequential subtests s
 			t.Run("selfsigned ClusterIssuer is ready", func(t *testing.T) {
 				wt := tc.NewWithT(t)
 				wt.Get(gvk.CertManagerClusterIssuer, types.NamespacedName{
-					Name: "opendatahub-selfsigned-issuer",
+					Name: pki.IssuerName,
 				}).Eventually().Should(
 					jq.Match(`.status.conditions[] | select(.type == "Ready") | .status == "True"`),
 				)
@@ -217,7 +217,7 @@ func TestCloudManager(t *testing.T) { //nolint:maintidx // sequential subtests s
 			t.Run("root CA Certificate is issued", func(t *testing.T) {
 				wt := tc.NewWithT(t)
 				wt.Get(gvk.CertManagerCertificate, types.NamespacedName{
-					Name: "opendatahub-ca", Namespace: certManagerOperandNS,
+					Name: pki.CertName, Namespace: pki.CertManagerNamespace,
 				}).Eventually().Should(
 					jq.Match(`.status.conditions[] | select(.type == "Ready") | .status == "True"`),
 				)
@@ -226,7 +226,7 @@ func TestCloudManager(t *testing.T) { //nolint:maintidx // sequential subtests s
 			t.Run("CA-backed ClusterIssuer is ready", func(t *testing.T) {
 				wt := tc.NewWithT(t)
 				wt.Get(gvk.CertManagerClusterIssuer, types.NamespacedName{
-					Name: "opendatahub-ca-issuer",
+					Name: pki.CAIssuerName,
 				}).Eventually().Should(
 					jq.Match(`.status.conditions[] | select(.type == "Ready") | .status == "True"`),
 				)
@@ -235,7 +235,7 @@ func TestCloudManager(t *testing.T) { //nolint:maintidx // sequential subtests s
 			t.Run("CA Secret is created", func(t *testing.T) {
 				wt := tc.NewWithT(t)
 				wt.Get(gvk.Secret, types.NamespacedName{
-					Name: "opendatahub-ca", Namespace: certManagerOperandNS,
+					Name: pki.CertName, Namespace: pki.CertManagerNamespace,
 				}).Eventually().Should(Not(BeNil()))
 			})
 		})
@@ -533,13 +533,13 @@ func TestCloudManager(t *testing.T) { //nolint:maintidx // sequential subtests s
 
 			// PKI resources must survive the GC run.
 			wt.Get(gvk.CertManagerClusterIssuer, types.NamespacedName{
-				Name: "opendatahub-selfsigned-issuer",
+				Name: pki.IssuerName,
 			}).Eventually().Should(Not(BeNil()))
 			wt.Get(gvk.CertManagerCertificate, types.NamespacedName{
-				Name: "opendatahub-ca", Namespace: "cert-manager",
+				Name: pki.CertName, Namespace: pki.CertManagerNamespace,
 			}).Eventually().Should(Not(BeNil()))
 			wt.Get(gvk.CertManagerClusterIssuer, types.NamespacedName{
-				Name: "opendatahub-ca-issuer",
+				Name: pki.CAIssuerName,
 			}).Eventually().Should(Not(BeNil()))
 
 			// Restore sailOperator.

--- a/tests/e2e/cloudmanager/helper_test.go
+++ b/tests/e2e/cloudmanager/helper_test.go
@@ -1,13 +1,17 @@
 package cloudmanager_test
 
 import (
+	"fmt"
 	"time"
 
+	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	ccmapi "github.com/opendatahub-io/opendatahub-operator/v2/api/cloudmanager/common"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/dependency/certmanager"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/matchers/jq"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/testf"
 
@@ -76,4 +80,54 @@ func consistentlyGone(wt *testf.WithT, nn types.NamespacedName) {
 		WithTimeout(30 * time.Second).
 		WithPolling(5 * time.Second).
 		Should(BeNil())
+}
+
+// pkiNames holds cert-manager PKI resource names discovered from the cloud manager deployment.
+type pkiNames struct {
+	IssuerName           string
+	CertName             string
+	CAIssuerName         string
+	CertManagerNamespace string
+}
+
+// discoverPKIConfig reads the RHAI_* env vars from the cloud manager deployment
+// on the cluster to determine the cert-manager PKI resource names. Falls back to
+// opendatahub-prefixed defaults if the deployment is not found or env vars are absent.
+func discoverPKIConfig(tc *testf.TestContext, providerName string) (pkiNames, error) {
+	defaults := certmanager.DefaultBootstrapConfig()
+	cfg := pkiNames{
+		IssuerName:           defaults.IssuerName,
+		CertName:             defaults.CertName,
+		CAIssuerName:         defaults.CAIssuerName,
+		CertManagerNamespace: defaults.CertManagerNamespace,
+	}
+
+	deployName := providerName + "-cloud-manager-operator"
+
+	deployList := &appsv1.DeploymentList{}
+	if err := tc.Client().List(tc.Context(), deployList, client.MatchingLabels{"name": deployName}); err != nil {
+		return cfg, fmt.Errorf("failed to list deployments: %w", err)
+	}
+
+	if len(deployList.Items) == 0 {
+		return cfg, nil
+	}
+
+	envVars := deployList.Items[0].Spec.Template.Spec.Containers[0].Env
+	envMap := make(map[string]string, len(envVars))
+	for _, e := range envVars {
+		envMap[e.Name] = e.Value
+	}
+
+	if v, ok := envMap[certmanager.EnvCertName]; ok && v != "" {
+		cfg.CertName = v
+	}
+	if v, ok := envMap[certmanager.EnvCAIssuerName]; ok && v != "" {
+		cfg.CAIssuerName = v
+	}
+	if v, ok := envMap[certmanager.EnvCertManagerNS]; ok && v != "" {
+		cfg.CertManagerNamespace = v
+	}
+
+	return cfg, nil
 }

--- a/tests/e2e/cloudmanager/helper_test.go
+++ b/tests/e2e/cloudmanager/helper_test.go
@@ -2,16 +2,19 @@ package cloudmanager_test
 
 import (
 	"encoding/json"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
 
+	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	ccmapi "github.com/opendatahub-io/opendatahub-operator/v2/api/cloudmanager/common"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/dependency/certmanager"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/metadata/labels"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/matchers/jq"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/testf"
@@ -243,4 +246,54 @@ func waitForCertManagerOperandAvailable(wt *testf.WithT) {
 	deployments := getCertManagerOperandDeployments(wt)
 	wt.Expect(deployments).To(HaveLen(3), "expected 3 cert-manager operand deployments (controller, webhook, cainjector)")
 	waitForDeploymentsAvailable(wt, deployments)
+}
+
+// pkiNames holds cert-manager PKI resource names discovered from the cloud manager deployment.
+type pkiNames struct {
+	IssuerName           string
+	CertName             string
+	CAIssuerName         string
+	CertManagerNamespace string
+}
+
+// discoverPKIConfig reads the RHAI_* env vars from the cloud manager deployment
+// on the cluster to determine the cert-manager PKI resource names. Falls back to
+// opendatahub-prefixed defaults if the deployment is not found or env vars are absent.
+func discoverPKIConfig(tc *testf.TestContext, providerName string) (pkiNames, error) {
+	defaults := certmanager.DefaultBootstrapConfig()
+	cfg := pkiNames{
+		IssuerName:           defaults.IssuerName,
+		CertName:             defaults.CertName,
+		CAIssuerName:         defaults.CAIssuerName,
+		CertManagerNamespace: defaults.CertManagerNamespace,
+	}
+
+	deployName := providerName + "-cloud-manager-operator"
+
+	deployList := &appsv1.DeploymentList{}
+	if err := tc.Client().List(tc.Context(), deployList, client.MatchingLabels{"name": deployName}); err != nil {
+		return cfg, fmt.Errorf("failed to list deployments: %w", err)
+	}
+
+	if len(deployList.Items) == 0 {
+		return cfg, nil
+	}
+
+	envVars := deployList.Items[0].Spec.Template.Spec.Containers[0].Env
+	envMap := make(map[string]string, len(envVars))
+	for _, e := range envVars {
+		envMap[e.Name] = e.Value
+	}
+
+	if v, ok := envMap[certmanager.EnvCertName]; ok && v != "" {
+		cfg.CertName = v
+	}
+	if v, ok := envMap[certmanager.EnvCAIssuerName]; ok && v != "" {
+		cfg.CAIssuerName = v
+	}
+	if v, ok := envMap[certmanager.EnvCertManagerNS]; ok && v != "" {
+		cfg.CertManagerNamespace = v
+	}
+
+	return cfg, nil
 }

--- a/tests/e2e/cloudmanager/suite_test.go
+++ b/tests/e2e/cloudmanager/suite_test.go
@@ -20,6 +20,7 @@ const rhaiOperatorNamespace = "opendatahub-operator-system"
 var (
 	tc       *testf.TestContext
 	provider ProviderConfig
+	pki      pkiNames
 )
 
 func TestMain(m *testing.M) {
@@ -51,6 +52,14 @@ func TestMain(m *testing.M) {
 		fmt.Fprintf(os.Stderr, "failed to create test context: %v\n", err)
 		os.Exit(1)
 	}
+
+	pki, err = discoverPKIConfig(tc, provider.Name)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to discover PKI config: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Printf("PKI config: issuer=%s, cert=%s, caIssuer=%s, ns=%s\n",
+		pki.IssuerName, pki.CertName, pki.CAIssuerName, pki.CertManagerNamespace)
 
 	if err := preflightCheck(); err != nil {
 		fmt.Fprintf(os.Stderr, "preflight check failed: %v\n", err)

--- a/tests/e2e/cloudmanager/suite_test.go
+++ b/tests/e2e/cloudmanager/suite_test.go
@@ -23,6 +23,7 @@ var (
 	tc         *testf.TestContext
 	provider   ProviderConfig
 	chartsPath string
+	pki        pkiNames
 )
 
 func TestMain(m *testing.M) {
@@ -60,6 +61,14 @@ func TestMain(m *testing.M) {
 		fmt.Fprintf(os.Stderr, "failed to create test context: %v\n", err)
 		os.Exit(1)
 	}
+
+	pki, err = discoverPKIConfig(tc, provider.Name)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to discover PKI config: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Printf("PKI config: issuer=%s, cert=%s, caIssuer=%s, ns=%s\n",
+		pki.IssuerName, pki.CertName, pki.CAIssuerName, pki.CertManagerNamespace)
 
 	if err := preflightCheck(); err != nil {
 		fmt.Fprintf(os.Stderr, "preflight check failed: %v\n", err)


### PR DESCRIPTION
 The cloudmanager e2e tests hardcoded cert-manager PKI resource names with the "opendatahub" prefix. On RHOAI clusters, the cloud manager overrides some of these via RHAI_* env vars (e.g. rhai-ca-issuer, rhai-ca). This caused test failures on productized deployments.

At test startup, discoverPKIConfig() now reads the RHAI_* env vars from the cloud manager deployment's container spec on the cluster, falling back to opendatahub-prefixed defaults when not found.

<!---
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
Ran manually on local kind cluster with a 3.4 nightly build

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [x] The developer has run the integration test pipeline and verified that it passed successfully
- [ ] New RELATED_IMAGE mappings are already listed in ODH-Build-Config and RHOAI-Build-Config, and links are included in PR description

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [ ] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved e2e test resilience by dynamically discovering PKI configuration at startup instead of relying on hardcoded values.
  * Added a package-local PKI discovery helper and store for discovered issuer, certificate, CA issuer, and namespace.
  * Tests now abort early on PKI discovery failure and log discovered PKI settings at test startup for clearer diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->