### PR TITLE
Iterate MCP tools based on agent feedback: add event count, summary mode, managed resources, and container discovery.

### DIFF
--- a/cmd/mcp-server/README.md
+++ b/cmd/mcp-server/README.md
@@ -1,0 +1,98 @@
+# OpenDataHub MCP Health Server
+
+MCP (Model Context Protocol) server that exposes cluster health diagnostic tools for OpenDataHub.
+
+## Tools
+
+### pod_logs
+
+Retrieve recent logs for a specific pod/container.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| pod_name | string | yes | Name of the pod |
+| namespace | string | yes | Namespace of the pod |
+| container | string | no | Container name. Omit for the default container |
+| previous | boolean | no | Return logs from previous container instance. Default: false |
+| tail_lines | number | no | Lines from end of log to return. Default: 100 |
+| list_containers | boolean | no | Return list of all containers (init, regular, ephemeral) instead of logs. Default: false |
+
+When a container name is invalid, the error response automatically includes the list of available containers.
+
+### platform_health
+
+Run cluster health checks and return report as JSON.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| sections | string | no | Comma-separated sections: nodes,deployments,pods,events,quotas,operator,dsci,dsc |
+| layer | string | no | Comma-separated layers: infrastructure,workload,operator. Ignored if sections is set |
+| operator_namespace | string | no | Operator namespace. Default: opendatahub-operator-system |
+| applications_namespace | string | no | Apps namespace. Default: opendatahub |
+| summary | boolean | no | Return compact summary instead of full report. Default: true |
+
+### component_status
+
+Get detailed status of a specific ODH component including managed resources.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| component | string | yes | Component name (e.g. kserve, dashboard, workbenches) |
+| applications_namespace | string | no | Apps namespace. Default: opendatahub |
+
+Response includes `managedResources` listing Services, ConfigMaps, ServiceAccounts, and Secrets owned by the component.
+
+### operator_dependencies
+
+Check status of dependent operators (cert-manager, tempo, OTel, etc.).
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| operator_namespace | string | no | Operator namespace. Default: opendatahub-operator-system |
+| name | string | no | Filter to specific dependent by name |
+
+### recent_events
+
+Warning/error events in ODH namespaces sorted by last timestamp.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| namespace | string | no | Comma-separated namespaces. Omit to auto-discover from DSCI |
+| since | string | no | Go duration for look-back window (e.g. 5m, 1h). Default: 5m |
+| event_type | string | no | Filter by type: Warning, Normal. Omit for all |
+
+Event output includes a `count` field showing how many times the event occurred.
+
+### describe_resource
+
+Get any Kubernetes resource by apiVersion/kind/name. Returns full resource as JSON with sensitive data redacted.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| apiVersion | string | yes | API version (e.g. v1, apps/v1) |
+| kind | string | yes | Resource kind (e.g. Pod, Deployment) |
+| name | string | yes | Resource name |
+| namespace | string | no | Namespace (omit for cluster-scoped resources) |
+
+### classify_failure
+
+Run health checks and classify the failure deterministically.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| sections | string | no | Comma-separated sections to check |
+| layer | string | no | Comma-separated layers to check |
+| operator_namespace | string | no | Operator namespace. Default: opendatahub-operator-system |
+| applications_namespace | string | no | Apps namespace. Default: opendatahub |
+
+## Running
+
+```bash
+cd cmd/mcp-server && go run .
+```
+
+## Testing
+
+```bash
+cd cmd/mcp-server && go test -v ./...
+```

--- a/cmd/mcp-server/helpers.go
+++ b/cmd/mcp-server/helpers.go
@@ -57,6 +57,18 @@ func numberParam(req mcp.CallToolRequest, name string, fallback int64) int64 {
 	return fallback
 }
 
+// boolParam extracts a boolean param from an MCP request, returning fallback if missing.
+func boolParam(req mcp.CallToolRequest, name string, fallback bool) bool {
+	args, ok := req.Params.Arguments.(map[string]any)
+	if !ok {
+		return fallback
+	}
+	if v, ok := args[name].(bool); ok {
+		return v
+	}
+	return fallback
+}
+
 // getEnvDefault returns the env var value if set, otherwise fallback.
 func getEnvDefault(key, fallback string) string {
 	if v := os.Getenv(key); v != "" {

--- a/cmd/mcp-server/helpers_test.go
+++ b/cmd/mcp-server/helpers_test.go
@@ -47,6 +47,32 @@ func TestGetEnvDefault(t *testing.T) {
 	}
 }
 
+func TestBoolParam(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     map[string]interface{}
+		param    string
+		fallback bool
+		want     bool
+	}{
+		{"missing param", map[string]interface{}{}, "summary", false, false},
+		{"true value", map[string]interface{}{"summary": true}, "summary", false, true},
+		{"false value", map[string]interface{}{"summary": false}, "summary", true, false},
+		{"non-bool type", map[string]interface{}{"summary": "yes"}, "summary", false, false},
+		{"nil args", nil, "summary", true, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := mcp.CallToolRequest{}
+			req.Params.Arguments = tt.args
+			got := boolParam(req, tt.param, tt.fallback)
+			if got != tt.want {
+				t.Errorf("boolParam() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestStringParam(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/cmd/mcp-server/tool_component_status.go
+++ b/cmd/mcp-server/tool_component_status.go
@@ -7,10 +7,56 @@ import (
 
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
+	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/clusterhealth"
 )
+
+type ManagedResource struct {
+	Kind      string `json:"kind"`
+	Name      string `json:"name"`
+	Namespace string `json:"namespace"`
+}
+
+func fetchManagedResources(ctx context.Context, c client.Client, component, appsNS string) ([]ManagedResource, error) {
+	opts := []client.ListOption{
+		client.InNamespace(appsNS),
+		client.MatchingLabels{"app.opendatahub.io/" + component: "true"},
+	}
+	var out []ManagedResource
+	add := func(kind, name, ns string) { out = append(out, ManagedResource{kind, name, ns}) }
+
+	var svcs corev1.ServiceList
+	if err := c.List(ctx, &svcs, opts...); err != nil {
+		return nil, fmt.Errorf("list services: %w", err)
+	}
+	for _, o := range svcs.Items {
+		add("Service", o.Name, o.Namespace)
+	}
+	var cms corev1.ConfigMapList
+	if err := c.List(ctx, &cms, opts...); err != nil {
+		return nil, fmt.Errorf("list configmaps: %w", err)
+	}
+	for _, o := range cms.Items {
+		add("ConfigMap", o.Name, o.Namespace)
+	}
+	var sas corev1.ServiceAccountList
+	if err := c.List(ctx, &sas, opts...); err != nil {
+		return nil, fmt.Errorf("list serviceaccounts: %w", err)
+	}
+	for _, o := range sas.Items {
+		add("ServiceAccount", o.Name, o.Namespace)
+	}
+	var secs corev1.SecretList
+	if err := c.List(ctx, &secs, opts...); err != nil {
+		return nil, fmt.Errorf("list secrets: %w", err)
+	}
+	for _, o := range secs.Items {
+		add("Secret", o.Name, o.Namespace)
+	}
+	return out, nil
+}
 
 // registerComponentStatus adds the component_status tool to the MCP server.
 func registerComponentStatus(s *server.MCPServer, kubeClient client.Client) {
@@ -24,15 +70,26 @@ func registerComponentStatus(s *server.MCPServer, kubeClient client.Client) {
 	)
 
 	s.AddTool(tool, func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		result, err := clusterhealth.GetComponentStatus(ctx, kubeClient,
-			stringParam(req, "component", ""),
-			stringParam(req, "applications_namespace",
-				getEnvDefault(envApplicationsNamespace, defaultAppsNS)),
-		)
+		component := stringParam(req, "component", "")
+		appsNS := stringParam(req, "applications_namespace",
+			getEnvDefault(envApplicationsNamespace, defaultAppsNS))
+
+		result, err := clusterhealth.GetComponentStatus(ctx, kubeClient, component, appsNS)
 		if err != nil {
 			return mcp.NewToolResultError(err.Error()), nil
 		}
-		data, err := json.MarshalIndent(result, "", "  ")
+
+		managed, err := fetchManagedResources(ctx, kubeClient, component, appsNS)
+		if err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("managed resources error: %v", err)), nil
+		}
+
+		response := struct {
+			*clusterhealth.ComponentStatusResult
+			ManagedResources []ManagedResource `json:"managedResources"`
+		}{result, managed}
+
+		data, err := json.MarshalIndent(response, "", "  ")
 		if err != nil {
 			return mcp.NewToolResultError(fmt.Sprintf("json marshal error: %v", err)), nil
 		}

--- a/cmd/mcp-server/tool_component_status_test.go
+++ b/cmd/mcp-server/tool_component_status_test.go
@@ -2,11 +2,14 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 
+	"github.com/mark3labs/mcp-go/server"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/clusterhealth"
 )
@@ -65,4 +68,71 @@ func TestComponentStatus_DeploymentsAndPods(t *testing.T) {
 	if len(r.Pods) != 1 || r.Pods[0].Phase != "Running" {
 		t.Errorf("Pods = %+v, want 1 Running", r.Pods)
 	}
+}
+
+func TestFetchManagedResources(t *testing.T) {
+	callTool := func(t *testing.T, cl client.Client, component string) string {
+		t.Helper()
+		s := server.NewMCPServer("test", "0.0.1")
+		registerComponentStatus(s, cl)
+		msg, _ := json.Marshal(map[string]any{
+			"jsonrpc": "2.0", "id": 1, "method": "tools/call",
+			"params": map[string]any{"name": "component_status", "arguments": map[string]any{"component": component}},
+		})
+		respBytes, _ := json.Marshal(s.HandleMessage(context.Background(), msg))
+		var rpcResp struct {
+			Result struct {
+				Content []struct{ Text string } `json:"content"`
+			} `json:"result"`
+		}
+		if err := json.Unmarshal(respBytes, &rpcResp); err != nil {
+			t.Fatalf("unmarshal rpc response: %v", err)
+		}
+		return rpcResp.Result.Content[0].Text
+	}
+
+	t.Run("no resources in empty cluster", func(t *testing.T) {
+		resources, err := fetchManagedResources(context.Background(), newFakeClient(), "dashboard", defaultAppsNS)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(resources) != 0 {
+			t.Fatalf("got %d resources, want 0", len(resources))
+		}
+	})
+
+	t.Run("tool response includes managedResources", func(t *testing.T) {
+		kserveLabel := map[string]string{"app.opendatahub.io/kserve": "true"}
+		replicas := int32(1)
+		cl := newFakeClient(
+			&appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{Name: "kserve-ctrl", Namespace: defaultAppsNS, Labels: kserveLabel},
+				Spec:       appsv1.DeploymentSpec{Replicas: &replicas, Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "kserve"}}},
+				Status:     appsv1.DeploymentStatus{ReadyReplicas: 1},
+			},
+			&corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "webhook-svc", Namespace: defaultAppsNS, Labels: kserveLabel}},
+			&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "isvc-config", Namespace: defaultAppsNS, Labels: kserveLabel}},
+			&corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "ray-svc", Namespace: defaultAppsNS, Labels: map[string]string{"app.opendatahub.io/ray": "true"}}},
+		)
+
+		var got struct {
+			Deployments      []json.RawMessage `json:"deployments"`
+			ManagedResources []ManagedResource `json:"managedResources"`
+		}
+		if err := json.Unmarshal([]byte(callTool(t, cl, "kserve")), &got); err != nil {
+			t.Fatalf("unmarshal tool output: %v", err)
+		}
+		if len(got.Deployments) != 1 {
+			t.Errorf("deployments = %d, want 1", len(got.Deployments))
+		}
+		wantKinds := []string{"Service", "ConfigMap"}
+		if len(got.ManagedResources) != len(wantKinds) {
+			t.Fatalf("managedResources = %d, want %d", len(got.ManagedResources), len(wantKinds))
+		}
+		for i, want := range wantKinds {
+			if got.ManagedResources[i].Kind != want {
+				t.Errorf("managedResources[%d].Kind = %q, want %q", i, got.ManagedResources[i].Kind, want)
+			}
+		}
+	})
 }

--- a/cmd/mcp-server/tool_platform_health.go
+++ b/cmd/mcp-server/tool_platform_health.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"time"
 
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
@@ -28,6 +29,8 @@ func registerPlatformHealth(s *server.MCPServer, kubeClient client.Client) {
 			mcp.Description("Operator namespace. Default: opendatahub-operator-system")),
 		mcp.WithString("applications_namespace",
 			mcp.Description("Apps namespace. Default: opendatahub")),
+		mcp.WithBoolean("summary",
+			mcp.Description("If true, return a compact summary instead of the full report. Default: true")),
 	)
 
 	s.AddTool(tool, func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
@@ -55,10 +58,92 @@ func registerPlatformHealth(s *server.MCPServer, kubeClient client.Client) {
 			return mcp.NewToolResultError(fmt.Sprintf("clusterhealth error: %v", err)), nil
 		}
 
-		data, err := json.MarshalIndent(report, "", "  ")
+		var output any
+		if boolParam(req, "summary", true) {
+			output = summarizeReport(report)
+		} else {
+			output = report
+		}
+
+		data, err := json.MarshalIndent(output, "", "  ")
 		if err != nil {
 			return mcp.NewToolResultError(fmt.Sprintf("json marshal error: %v", err)), nil
 		}
 		return mcp.NewToolResultText(string(data)), nil
 	})
+}
+
+type HealthSummary struct {
+	Healthy     bool                      `json:"healthy"`
+	CollectedAt time.Time                 `json:"collectedAt"`
+	Sections    map[string]SectionSummary `json:"sections"`
+}
+
+type SectionSummary struct {
+	Status string `json:"status"`
+	Error  string `json:"error,omitempty"`
+	Count  int    `json:"count"`
+	Issues int    `json:"issues"`
+}
+
+func section[T any](err string, items []T, isUnhealthy func(T) bool) SectionSummary {
+	issues := 0
+	for _, item := range items {
+		if isUnhealthy(item) {
+			issues++
+		}
+	}
+	status := "ok"
+	if err != "" {
+		status = "error"
+	}
+	return SectionSummary{Status: status, Error: err, Count: len(items), Issues: issues}
+}
+
+func flattenMap[T any](m map[string][]T) []T {
+	var out []T
+	for _, v := range m {
+		out = append(out, v...)
+	}
+	return out
+}
+
+func summarizeReport(report *clusterhealth.Report) *HealthSummary {
+	ran := make(map[string]bool, len(report.SectionsRun))
+	for _, name := range report.SectionsRun {
+		ran[name] = true
+	}
+
+	all := map[string]SectionSummary{
+		"nodes":       section(report.Nodes.Error, report.Nodes.Data.Nodes, func(n clusterhealth.NodeInfo) bool { return n.UnhealthyReason != "" }),
+		"deployments": section(report.Deployments.Error, flattenMap(report.Deployments.Data.ByNamespace), func(d clusterhealth.DeploymentInfo) bool { return d.Ready < d.Replicas }),
+		"pods":        section(report.Pods.Error, flattenMap(report.Pods.Data.ByNamespace), func(p clusterhealth.PodInfo) bool { return p.Phase != "Running" && p.Phase != "Succeeded" }),
+		"events":      section(report.Events.Error, report.Events.Data.Events, func(clusterhealth.EventInfo) bool { return false }),
+		"quotas":      section(report.Quotas.Error, flattenMap(report.Quotas.Data.ByNamespace), func(q clusterhealth.ResourceQuotaInfo) bool { return len(q.Exceeded) > 0 }),
+		"dsci":        section(report.DSCI.Error, report.DSCI.Data.Conditions, func(clusterhealth.ConditionSummary) bool { return false }),
+		"dsc":         section(report.DSC.Error, report.DSC.Data.Conditions, func(clusterhealth.ConditionSummary) bool { return false }),
+	}
+
+	opStatus := "ok"
+	if report.Operator.Error != "" {
+		opStatus = "error"
+	}
+	opIssues := 0
+	if d := report.Operator.Data.Deployment; d != nil && d.Ready < d.Replicas {
+		opIssues = 1
+	}
+	all["operator"] = SectionSummary{Status: opStatus, Error: report.Operator.Error, Count: 1, Issues: opIssues}
+
+	sections := make(map[string]SectionSummary, len(ran))
+	for name, summary := range all {
+		if ran[name] {
+			sections[name] = summary
+		}
+	}
+
+	return &HealthSummary{
+		Healthy:     report.Healthy(),
+		CollectedAt: report.CollectedAt,
+		Sections:    sections,
+	}
 }

--- a/cmd/mcp-server/tool_platform_health_test.go
+++ b/cmd/mcp-server/tool_platform_health_test.go
@@ -96,3 +96,38 @@ func TestPlatformHealth_NilClient(t *testing.T) {
 		t.Error("Run(nil client) should return error")
 	}
 }
+
+func TestSummarizeReport(t *testing.T) {
+	for _, tt := range []struct {
+		name         string
+		sections     string
+		wantHealthy  bool
+		checkSection string
+		wantStatus   string
+	}{
+		{"healthy nodes only", "nodes", true, "nodes", "ok"},
+		{"healthy quotas only", "quotas", true, "quotas", "ok"},
+		{"unhealthy operator missing", "operator", false, "operator", "error"},
+		{"unhealthy dsc missing", "dsc", false, "dsc", "error"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			report := callTool(t, newFakeClient(), map[string]interface{}{"sections": tt.sections})
+			summary := summarizeReport(&report)
+
+			if summary.Healthy != tt.wantHealthy {
+				t.Errorf("Healthy = %v, want %v", summary.Healthy, tt.wantHealthy)
+			}
+			if summary.CollectedAt.IsZero() {
+				t.Error("CollectedAt should not be zero")
+			}
+			sec, ok := summary.Sections[tt.checkSection]
+			if !ok {
+				t.Fatalf("missing section %q", tt.checkSection)
+			}
+			if sec.Status != tt.wantStatus {
+				t.Errorf("section %q status = %q, want %q", tt.checkSection, sec.Status, tt.wantStatus)
+			}
+		})
+	}
+}
+

--- a/cmd/mcp-server/tool_pod_logs.go
+++ b/cmd/mcp-server/tool_pod_logs.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"strings"
@@ -10,10 +11,84 @@ import (
 	"github.com/mark3labs/mcp-go/server"
 	corev1 "k8s.io/api/core/v1"
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 )
 
 const maxLogBytes int64 = 50 * 1024 // 50KB
+
+type ContainerListEntry struct {
+	Name         string `json:"name"`
+	Type         string `json:"type"`
+	Ready        bool   `json:"ready"`
+	RestartCount int32  `json:"restartCount"`
+	State        string `json:"state"`
+}
+
+func containerState(s corev1.ContainerStatus) string {
+	switch {
+	case s.State.Running != nil:
+		return "running"
+	case s.State.Waiting != nil:
+		if s.State.Waiting.Reason != "" {
+			return "waiting: " + s.State.Waiting.Reason
+		}
+		return "waiting"
+	case s.State.Terminated != nil:
+		if s.State.Terminated.Reason != "" {
+			return "terminated: " + s.State.Terminated.Reason
+		}
+		return "terminated"
+	default:
+		return "unknown"
+	}
+}
+
+func listContainers(ctx context.Context, clientset kubernetes.Interface, podName, namespace string) (*mcp.CallToolResult, error) {
+	pod, err := clientset.CoreV1().Pods(namespace).Get(ctx, podName, metav1.GetOptions{})
+	if err != nil {
+		if k8serr.IsNotFound(err) {
+			return mcp.NewToolResultError(fmt.Sprintf("pod %q not found in namespace %q", podName, namespace)), nil
+		}
+		return mcp.NewToolResultError(fmt.Sprintf("error getting pod: %v", err)), nil
+	}
+
+	toMap := func(statuses []corev1.ContainerStatus) map[string]corev1.ContainerStatus {
+		m := make(map[string]corev1.ContainerStatus, len(statuses))
+		for _, s := range statuses {
+			m[s.Name] = s
+		}
+		return m
+	}
+
+	var entries []ContainerListEntry
+	add := func(name, ctype string, statuses map[string]corev1.ContainerStatus) {
+		e := ContainerListEntry{Name: name, Type: ctype}
+		if s, ok := statuses[name]; ok {
+			e.Ready, e.RestartCount, e.State = s.Ready, s.RestartCount, containerState(s)
+		}
+		entries = append(entries, e)
+	}
+
+	initS := toMap(pod.Status.InitContainerStatuses)
+	for _, c := range pod.Spec.InitContainers {
+		add(c.Name, "init", initS)
+	}
+	regS := toMap(pod.Status.ContainerStatuses)
+	for _, c := range pod.Spec.Containers {
+		add(c.Name, "regular", regS)
+	}
+	ephS := toMap(pod.Status.EphemeralContainerStatuses)
+	for _, c := range pod.Spec.EphemeralContainers {
+		add(c.Name, "ephemeral", ephS)
+	}
+
+	data, err := json.MarshalIndent(entries, "", "  ")
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("json marshal error: %v", err)), nil
+	}
+	return mcp.NewToolResultText(string(data)), nil
+}
 
 // registerPodLogs adds the pod_logs tool to the MCP server.
 func registerPodLogs(s *server.MCPServer, clientset kubernetes.Interface) {
@@ -30,6 +105,8 @@ func registerPodLogs(s *server.MCPServer, clientset kubernetes.Interface) {
 			mcp.Description("If true, return logs from the previous container instance. Default: false")),
 		mcp.WithNumber("tail_lines",
 			mcp.Description("Number of lines from the end of the log to return. Default: 100")),
+		mcp.WithBoolean("list_containers",
+			mcp.Description("If true, return a list of all containers instead of logs. Default: false")),
 	)
 
 	s.AddTool(tool, func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
@@ -47,6 +124,10 @@ func fetchPodLogs(ctx context.Context, clientset kubernetes.Interface, req mcp.C
 	}
 	if namespace == "" {
 		return mcp.NewToolResultError("namespace is required"), nil
+	}
+
+	if boolParam(req, "list_containers", false) {
+		return listContainers(ctx, clientset, podName, namespace)
 	}
 
 	tailLines := numberParam(req, "tail_lines", 100)
@@ -72,7 +153,15 @@ func fetchPodLogs(ctx context.Context, clientset kubernetes.Interface, req mcp.C
 			case strings.Contains(msg, "previous terminated container"):
 				return mcp.NewToolResultError(fmt.Sprintf("no previous logs available for pod %q (namespace %q): %v", podName, namespace, err)), nil
 			case strings.Contains(msg, "not found") || strings.Contains(msg, "is not valid"):
-				return mcp.NewToolResultError(fmt.Sprintf("container not found in pod %q (namespace %q): %v", podName, namespace, err)), nil
+				errMsg := fmt.Sprintf("container not found in pod %q (namespace %q): %v", podName, namespace, err)
+				if result, listErr := listContainers(ctx, clientset, podName, namespace); listErr == nil && !result.IsError {
+					if len(result.Content) > 0 {
+						if tc, ok := result.Content[0].(mcp.TextContent); ok {
+							errMsg += "\n\nAvailable containers:\n" + tc.Text
+						}
+					}
+				}
+				return mcp.NewToolResultError(errMsg), nil
 			}
 			fallthrough
 		default:

--- a/cmd/mcp-server/tool_pod_logs_test.go
+++ b/cmd/mcp-server/tool_pod_logs_test.go
@@ -109,6 +109,32 @@ func TestPodLogs(t *testing.T) {
 			w.Write(make([]byte, maxLogBytes+100))
 		}, map[string]interface{}{"pod_name": "my-pod", "namespace": "default"},
 			"[truncated: output exceeded 50KB limit]", false},
+		{"list containers", func(w http.ResponseWriter, r *http.Request) {
+			if !strings.Contains(r.URL.Path, "/log") {
+				w.Header().Set("Content-Type", "application/json")
+				fmt.Fprint(w, `{"apiVersion":"v1","kind":"Pod","metadata":{"name":"my-pod","namespace":"default"},`+
+					`"spec":{"initContainers":[{"name":"init-setup"}],"containers":[{"name":"main"},{"name":"sidecar"}]},`+
+					`"status":{"initContainerStatuses":[{"name":"init-setup","ready":false,"restartCount":0,"state":{"terminated":{"reason":"Completed"}}}],`+
+					`"containerStatuses":[{"name":"main","ready":true,"restartCount":0,"state":{"running":{}}},`+
+					`{"name":"sidecar","ready":true,"restartCount":3,"state":{"running":{}}}]}}`)
+				return
+			}
+			http.NotFound(w, r)
+		}, map[string]interface{}{"pod_name": "my-pod", "namespace": "default", "list_containers": true},
+			`"name": "init-setup"`, false},
+		{"container not found includes available containers", func(w http.ResponseWriter, r *http.Request) {
+			if !strings.Contains(r.URL.Path, "/log") {
+				w.Header().Set("Content-Type", "application/json")
+				fmt.Fprint(w, `{"apiVersion":"v1","kind":"Pod","metadata":{"name":"my-pod","namespace":"default"},`+
+					`"spec":{"containers":[{"name":"main"}]},`+
+					`"status":{"containerStatuses":[{"name":"main","ready":true,"restartCount":0,"state":{"running":{}}}]}}`)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusBadRequest)
+			fmt.Fprint(w, `{"kind":"Status","apiVersion":"v1","status":"Failure","message":"container \"bad\" is not valid for pod \"my-pod\"","reason":"BadRequest","code":400}`)
+		}, map[string]interface{}{"pod_name": "my-pod", "namespace": "default", "container": "bad"},
+			"Available containers", true},
 	}
 
 	for _, tt := range tests {

--- a/cmd/mcp-server/tool_recent_events_test.go
+++ b/cmd/mcp-server/tool_recent_events_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -109,6 +110,31 @@ func TestRecentEvents_SortOrder(t *testing.T) {
 	}
 	if events[0].Name != "pod-b" {
 		t.Errorf("first event = %q, want pod-b (most recent)", events[0].Name)
+	}
+}
+
+func TestRecentEvents_Count(t *testing.T) {
+	now := time.Now()
+
+	for _, count := range []int32{0, 1, 150} {
+		t.Run(fmt.Sprintf("count_%d", count), func(t *testing.T) {
+			evt := makeEvent("opendatahub", "evt1", "Pod", "pod-a", "Warning", "BackOff", "back-off", now.Add(-1*time.Minute))
+			evt.Count = count
+			cl := newFakeClient(evt)
+
+			events, err := clusterhealth.RunRecentEvents(context.Background(), clusterhealth.RecentEventsConfig{
+				Client: cl, Namespaces: []string{"opendatahub"},
+			})
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(events) != 1 {
+				t.Fatalf("got %d events, want 1", len(events))
+			}
+			if events[0].Count != count {
+				t.Errorf("Count = %d, want %d", events[0].Count, count)
+			}
+		})
 	}
 }
 

--- a/pkg/clusterhealth/events.go
+++ b/pkg/clusterhealth/events.go
@@ -104,6 +104,7 @@ func eventToInfo(e *corev1.Event) EventInfo {
 		Reason:    e.Reason,
 		Message:   e.Message,
 		LastTime:  eventLastTime(e),
+		Count:     e.Count,
 	}
 }
 

--- a/pkg/clusterhealth/types.go
+++ b/pkg/clusterhealth/types.go
@@ -125,6 +125,7 @@ type EventInfo struct {
 	Reason    string    `json:"reason"`
 	Message   string    `json:"message"`
 	LastTime  time.Time `json:"lastTime"`
+	Count     int32     `json:"count"`
 }
 
 type QuotasSection struct {


### PR DESCRIPTION


<!---
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
Addresses four agent-reported limitations in the MCP server: recent_events tool now includes a count field to distinguish one-off warnings from persistent failures, platform_health tool defaults to a compact summary , component_status tool includes a managedResources list for complete resource inventory in a single call, and pod_logs tool supports container discovery via list_containers while automatically including available container names in container-not-found errors to eliminate blind retries. A README documenting all seven tool schemas is also added.


https://redhat.atlassian.net/browse/RHOAIENG-56938

## How Has This Been Tested?
Unit Tests

Unit tests were added for all four feedback items.


## Screenshot or short clip
<img width="1465" height="627" alt="image" src="https://github.com/user-attachments/assets/03702e26-d09b-47cc-9c2f-abde8f63fc5f" />


## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [X] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [X] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work


### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [X] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
Add E2E tests if required.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Container listing mode for pod-logs to show container inventory
  * Compact summary mode for platform-health (enabled by default)
  * Managed resources displayed in component-status responses

* **Documentation**
  * New comprehensive MCP Health Server README covering tools, inputs, defaults, responses, and local run/test steps
  * describe_resource behavior documented to redact sensitive data

* **Improvements**
  * Error messages for invalid containers now surface available containers
  * Event records include per-event counts
<!-- end of auto-generated comment: release notes by coderabbit.ai -->