### PR TITLE
adding DSCI ability to watch the monitoring CR and get the conditions

### DIFF
--- a/internal/controller/dscinitialization/dscinitialization_controller.go
+++ b/internal/controller/dscinitialization/dscinitialization_controller.go
@@ -69,6 +69,13 @@ type DSCInitializationReconciler struct {
 	OperatorSettings operatorconfig.OperatorSettings
 }
 
+type DSCInitializationCondition struct {
+	Type         string
+	ReadyReason  string
+	ReadyMessage string
+	ReadyStatus  metav1.ConditionStatus
+}
+
 // Reconcile contains controller logic specific to DSCInitialization instance updates.
 func (r *DSCInitializationReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) { //nolint:funlen,maintidx,gocyclo
 	log := logf.FromContext(ctx).WithName("DSCInitialization")
@@ -252,8 +259,12 @@ func (r *DSCInitializationReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	}
 
 	// Finish reconciling
+	monitoringConditions := r.GetMonitoringReadyCondition(ctx)
 	_, err = status.UpdateWithRetry(ctx, r.Client, instance, func(saved *dsciv2.DSCInitialization) {
 		status.SetCompleteCondition(&saved.Status.Conditions, status.ReconcileCompleted, status.ReconcileCompletedMessage)
+		for _, c := range monitoringConditions {
+			status.SetCondition(&saved.Status.Conditions, c.Type, c.ReadyReason, c.ReadyMessage, c.ReadyStatus)
+		}
 		saved.Status.Phase = status.PhaseReady
 	})
 	if err != nil {
@@ -334,6 +345,10 @@ func (r *DSCInitializationReconciler) SetupWithManager(ctx context.Context, mgr 
 			getObject(gvk.GatewayConfig),
 			handler.EnqueueRequestsFromMapFunc(r.watchGatewayConfigResource),
 		).
+		Watches(
+			getObject(gvk.Monitoring),
+			handler.EnqueueRequestsFromMapFunc(r.watchMonitoringResource),
+		).
 		Watches( // TODO: this might not be needed after v3.3.
 			getObject(gvk.CustomResourceDefinition),
 			handler.EnqueueRequestsFromMapFunc(r.watchHWProfileCRDResource),
@@ -377,6 +392,83 @@ func (r *DSCInitializationReconciler) watchGatewayConfigResource(ctx context.Con
 	}
 
 	return nil
+}
+
+func (r *DSCInitializationReconciler) watchMonitoringResource(ctx context.Context, _ client.Object) []reconcile.Request {
+	log := logf.FromContext(ctx)
+	instanceList := &serviceApi.MonitoringList{}
+	if err := r.Client.List(ctx, instanceList); err != nil {
+		log.Error(err, "failed to get MonitoringList")
+		return nil
+	}
+	if len(instanceList.Items) == 0 {
+		log.Info("Found no Monitoring instance in cluster, reconciling to recreate one")
+		return []reconcile.Request{{NamespacedName: types.NamespacedName{Name: serviceApi.MonitoringInstanceName}}}
+	}
+
+	// Monitoring CR exists — trigger DSCI reconciliation so it can propagate
+	// the latest Monitoring status conditions into its own status.
+	dsciList := &dsciv2.DSCInitializationList{}
+	if err := r.Client.List(ctx, dsciList); err != nil {
+		log.Error(err, "Failed to get DSCInitializationList")
+		return nil
+	}
+	if len(dsciList.Items) == 0 {
+		log.Info("Found no DSCInitialization instance in cluster")
+		return []reconcile.Request{{NamespacedName: types.NamespacedName{Name: "default-dsci"}}}
+	}
+
+	return []reconcile.Request{{NamespacedName: types.NamespacedName{Name: dsciList.Items[0].Name}}}
+}
+
+func (r *DSCInitializationReconciler) GetMonitoringReadyCondition(ctx context.Context) []DSCInitializationCondition {
+	monitoring := &serviceApi.Monitoring{}
+	err := r.Client.Get(ctx, client.ObjectKey{Name: serviceApi.MonitoringInstanceName}, monitoring)
+	if err != nil {
+		if k8serr.IsNotFound(err) {
+			return []DSCInitializationCondition{{status.ConditionMonitoringReady, status.RemovedReason, "Monitoring is not enabled", metav1.ConditionFalse}}
+		}
+		return []DSCInitializationCondition{{status.ConditionMonitoringReady, status.NotReadyReason,
+			fmt.Sprintf("Failed to retrieve Monitoring CR status: %v", err), metav1.ConditionUnknown}}
+	}
+
+	monitoringConditions := monitoring.GetConditions()
+	conditions := make([]DSCInitializationCondition, 0, len(monitoringConditions)+1)
+
+	// we filter the conditions from the Monitoring CR to the list to be returned later
+	// we only care about the ones that are related to dependant operators (e.g. Thanos, OpenTelemetry, etc.)
+	for _, c := range monitoringConditions {
+		switch c.Type {
+		case status.ConditionTypeReady,
+			status.ConditionTypeProvisioningSucceeded,
+			status.ConditionMonitoringStackAvailable,
+			status.ConditionThanosQuerierAvailable,
+			status.ConditionOpenTelemetryCollectorAvailable,
+			status.ConditionTempoAvailable,
+			status.ConditionPersesAvailable,
+			status.ConditionAlertingAvailable:
+			conditions = append(conditions, DSCInitializationCondition{
+				Type:         c.Type,
+				ReadyReason:  c.Reason,
+				ReadyMessage: c.Message,
+				ReadyStatus:  c.Status,
+			})
+		}
+	}
+
+	if len(conditions) == 0 {
+		return []DSCInitializationCondition{{status.ConditionMonitoringReady, status.NotReadyReason, "Monitoring stack is initializing", metav1.ConditionUnknown}}
+	}
+
+	// If Monitoring stack is initialized, we add the MonitoringReady condition as True
+	conditions = append(conditions, DSCInitializationCondition{
+		Type:         status.ConditionMonitoringReady,
+		ReadyReason:  status.ReadyReason,
+		ReadyMessage: "Monitoring stack is initialized",
+		ReadyStatus:  metav1.ConditionTrue,
+	})
+
+	return conditions
 }
 
 func (r *DSCInitializationReconciler) deleteMonitoringCR(ctx context.Context) error {

--- a/internal/controller/dscinitialization/dscinitialization_controller.go
+++ b/internal/controller/dscinitialization/dscinitialization_controller.go
@@ -69,6 +69,13 @@ type DSCInitializationReconciler struct {
 	OperatorSettings operatorconfig.OperatorSettings
 }
 
+type DSCInitializationCondition struct {
+	Type         string
+	ReadyReason  string
+	ReadyMessage string
+	ReadyStatus  metav1.ConditionStatus
+}
+
 // Reconcile contains controller logic specific to DSCInitialization instance updates.
 func (r *DSCInitializationReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) { //nolint:funlen,maintidx,gocyclo
 	log := logf.FromContext(ctx).WithName("DSCInitialization")
@@ -252,8 +259,12 @@ func (r *DSCInitializationReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	}
 
 	// Finish reconciling
+	monitoringConditions := r.GetMonitoringReadyCondition(ctx)
 	_, err = status.UpdateWithRetry(ctx, r.Client, instance, func(saved *dsciv2.DSCInitialization) {
 		status.SetCompleteCondition(&saved.Status.Conditions, status.ReconcileCompleted, status.ReconcileCompletedMessage)
+		for _, c := range monitoringConditions {
+			status.SetCondition(&saved.Status.Conditions, c.Type, c.ReadyReason, c.ReadyMessage, c.ReadyStatus)
+		}
 		saved.Status.Phase = status.PhaseReady
 	})
 	if err != nil {
@@ -334,6 +345,10 @@ func (r *DSCInitializationReconciler) SetupWithManager(ctx context.Context, mgr 
 			getObject(gvk.GatewayConfig),
 			handler.EnqueueRequestsFromMapFunc(r.watchGatewayConfigResource),
 		).
+		Watches(
+			getObject(gvk.Monitoring),
+			handler.EnqueueRequestsFromMapFunc(r.watchMonitoringResource),
+		).
 		Watches( // TODO: this might not be needed after v3.3.
 			getObject(gvk.CustomResourceDefinition),
 			handler.EnqueueRequestsFromMapFunc(r.watchHWProfileCRDResource),
@@ -377,6 +392,84 @@ func (r *DSCInitializationReconciler) watchGatewayConfigResource(ctx context.Con
 	}
 
 	return nil
+}
+
+func (r *DSCInitializationReconciler) watchMonitoringResource(ctx context.Context, _ client.Object) []reconcile.Request {
+	log := logf.FromContext(ctx)
+	instanceList := &serviceApi.MonitoringList{}
+	if err := r.Client.List(ctx, instanceList); err != nil {
+		log.Error(err, "failed to get MonitoringList")
+		return nil
+	}
+	if len(instanceList.Items) == 0 {
+		log.Info("Found no Monitoring instance in cluster, reconciling to recreate one")
+		return []reconcile.Request{{NamespacedName: types.NamespacedName{Name: serviceApi.MonitoringInstanceName}}}
+	}
+
+	// Monitoring CR exists — trigger DSCI reconciliation so it can propagate
+	// the latest Monitoring status conditions into its own status.
+	dsciList := &dsciv2.DSCInitializationList{}
+	if err := r.Client.List(ctx, dsciList); err != nil {
+		log.Error(err, "Failed to get DSCInitializationList")
+		return nil
+	}
+	if len(dsciList.Items) == 0 {
+		log.Info("Found no DSCInitialization instance in cluster")
+		return []reconcile.Request{{NamespacedName: types.NamespacedName{Name: "default-dsci"}}}
+	}
+
+	return []reconcile.Request{{NamespacedName: types.NamespacedName{Name: dsciList.Items[0].Name}}}
+}
+
+func (r *DSCInitializationReconciler) GetMonitoringReadyCondition(ctx context.Context) []DSCInitializationCondition {
+	monitoring := &serviceApi.Monitoring{}
+	err := r.Client.Get(ctx, client.ObjectKey{Name: serviceApi.MonitoringInstanceName}, monitoring)
+	if err != nil {
+		if k8serr.IsNotFound(err) {
+			return []DSCInitializationCondition{{status.ConditionMonitoringReady, status.RemovedReason, "Monitoring is not enabled", metav1.ConditionFalse}}
+		}
+		return []DSCInitializationCondition{{status.ConditionMonitoringReady, status.NotReadyReason,
+			fmt.Sprintf("Failed to retrieve Monitoring CR status: %v", err), metav1.ConditionUnknown}}
+	}
+
+	monitoringConditions := monitoring.GetConditions()
+	conditions := make([]DSCInitializationCondition, 0, len(monitoringConditions)+1)
+
+	// we filter the conditions from the Monitoring CR to the list to be returned later
+	// we only care about the ones that are related to dependant operators (e.g. Thanos, OpenTelemetry, etc.)
+	for _, c := range monitoringConditions {
+		switch c.Type {
+		case status.ConditionTypeReady,
+			status.ConditionTypeProvisioningSucceeded,
+			status.ConditionMonitoringStackAvailable,
+			status.ConditionThanosQuerierAvailable,
+			status.ConditionOpenTelemetryCollectorAvailable,
+			status.ConditionTempoAvailable,
+			status.ConditionPersesAvailable,
+			status.ConditionAlertingAvailable,
+			status.ConditionNodeMetricsEndpointAvailable:
+			conditions = append(conditions, DSCInitializationCondition{
+				Type:         c.Type,
+				ReadyReason:  c.Reason,
+				ReadyMessage: c.Message,
+				ReadyStatus:  c.Status,
+			})
+		}
+	}
+
+	if len(conditions) == 0 {
+		return []DSCInitializationCondition{{status.ConditionMonitoringReady, status.NotReadyReason, "Monitoring stack is initializing", metav1.ConditionUnknown}}
+	}
+
+	// If Monitoring stack is initialized, we add the MonitoringReady condition as True
+	conditions = append(conditions, DSCInitializationCondition{
+		Type:         status.ConditionMonitoringReady,
+		ReadyReason:  status.ReadyReason,
+		ReadyMessage: "Monitoring stack is initialized",
+		ReadyStatus:  metav1.ConditionTrue,
+	})
+
+	return conditions
 }
 
 func (r *DSCInitializationReconciler) deleteMonitoringCR(ctx context.Context) error {
@@ -480,7 +573,7 @@ func (r *DSCInitializationReconciler) CreateGatewayConfig(ctx context.Context, i
 		return err
 	}
 
-	// GatewayConfig CR not found, create default GatewayConfig CR.
+	// GatewayConfig CR isn't found, create default GatewayConfig CR.
 	defaultGateway := &serviceApi.GatewayConfig{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       serviceApi.GatewayConfigKind,

--- a/internal/controller/dscinitialization/dscinitialization_test.go
+++ b/internal/controller/dscinitialization/dscinitialization_test.go
@@ -7,6 +7,7 @@ import (
 	userv1 "github.com/openshift/api/user/v1"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
+	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -90,6 +91,7 @@ var _ = Describe("DataScienceCluster initialization", func() {
 		AfterEach(cleanupResources)
 		const monitoringNamespace2 = "test-monitoring-ns2"
 		const applicationName = "default-dsci"
+
 		It("Should not create monitoring namespace if monitoring is disabled", func(ctx context.Context) {
 			// when
 			desiredDsci := createDSCI(operatorv1.Removed, operatorv1.Managed, monitoringNamespace2)
@@ -109,6 +111,146 @@ var _ = Describe("DataScienceCluster initialization", func() {
 				Should(BeFalse())
 		})
 
+		It("Should mirror dependent operator conditions from Monitoring CR to DSCI", func(ctx context.Context) {
+			// given
+			desiredDsci := createDSCI(operatorv1.Managed, operatorv1.Managed, monitoringNamespace)
+			Expect(k8sClient.Create(ctx, desiredDsci)).Should(Succeed())
+
+			// Wait for DSCI to be ready and Monitoring CR to be created
+			monitoringCR := &serviceApi.Monitoring{}
+			Eventually(func() error {
+				return k8sClient.Get(ctx, client.ObjectKey{Name: "default-monitoring"}, monitoringCR)
+			}).WithTimeout(timeout).WithPolling(interval).Should(Succeed())
+
+			// when - Simulate Monitoring CR getting some conditions
+			monitoringCR.Status.Conditions = []common.Condition{
+				{
+					Type:               "MonitoringStackAvailable",
+					Status:             metav1.ConditionTrue,
+					Reason:             "Ready",
+					Message:            "Monitoring stack is ready",
+					LastTransitionTime: metav1.Now(),
+				},
+				{
+					Type:               "ThanosQuerierAvailable",
+					Status:             metav1.ConditionFalse,
+					Reason:             "Degraded",
+					Message:            "Thanos querier is failing",
+					LastTransitionTime: metav1.Now(),
+				},
+				{
+					Type:               "UnrelatedCondition",
+					Status:             metav1.ConditionFalse,
+					Reason:             "Failing",
+					Message:            "This should not be mirrored",
+					LastTransitionTime: metav1.Now(),
+				},
+			}
+			Expect(k8sClient.Status().Update(ctx, monitoringCR)).Should(Succeed())
+
+			// then - DSCI should have only relevant conditions mirrored
+			foundDsci := &dsciv2.DSCInitialization{}
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, client.ObjectKey{Name: applicationName, Namespace: workingNamespace}, foundDsci)).To(Succeed())
+				// Should contain relevant ones
+				g.Expect(foundDsci.Status.Conditions).To(ContainElements(
+					SatisfyAll(
+						HaveField("Type", "MonitoringStackAvailable"),
+						HaveField("Status", metav1.ConditionTrue),
+					),
+					SatisfyAll(
+						HaveField("Type", "ThanosQuerierAvailable"),
+						HaveField("Status", metav1.ConditionFalse),
+						HaveField("Reason", "Degraded"),
+					),
+					SatisfyAll(
+						HaveField("Type", "MonitoringReady"),
+						HaveField("Status", metav1.ConditionTrue),
+						HaveField("Reason", "Ready"),
+					),
+				))
+				// Should NOT contain the unrelated one
+				g.Expect(foundDsci.Status.Conditions).ToNot(ContainElement(
+					HaveField("Type", "UnrelatedCondition"),
+				))
+			}).WithTimeout(timeout).WithPolling(interval).Should(Succeed())
+		})
+
+		It("Should set Ready condition to False when Monitoring CR Ready condition is False", func(ctx context.Context) {
+			// given
+			desiredDsci := createDSCI(operatorv1.Managed, operatorv1.Managed, monitoringNamespace)
+			Expect(k8sClient.Create(ctx, desiredDsci)).Should(Succeed())
+
+			// Wait for DSCI to be ready and Monitoring CR to be created
+			monitoringCR := &serviceApi.Monitoring{}
+			Eventually(func() error {
+				return k8sClient.Get(ctx, client.ObjectKey{Name: "default-monitoring"}, monitoringCR)
+			}).WithTimeout(timeout).WithPolling(interval).Should(Succeed())
+
+			// when - Simulate Monitoring CR Getting Ready=False
+			monitoringCR.Status.Conditions = []common.Condition{
+				{
+					Type:               "Ready",
+					Status:             metav1.ConditionFalse,
+					Reason:             "NotReady",
+					Message:            "Monitoring stack is not ready",
+					LastTransitionTime: metav1.Now(),
+				},
+			}
+			Expect(k8sClient.Status().Update(ctx, monitoringCR)).Should(Succeed())
+
+			// then - DSCI should have Ready=False mirrored from Monitoring AND MonitoringReady=True
+			foundDsci := &dsciv2.DSCInitialization{}
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, client.ObjectKey{Name: applicationName, Namespace: workingNamespace}, foundDsci)).To(Succeed())
+				g.Expect(foundDsci.Status.Conditions).To(ContainElements(
+					SatisfyAll(
+						HaveField("Type", "Ready"),
+						HaveField("Status", metav1.ConditionFalse),
+						HaveField("Reason", "NotReady"),
+						HaveField("Message", ContainSubstring("Monitoring stack is not ready")),
+					),
+					SatisfyAll(
+						HaveField("Type", "MonitoringReady"),
+						HaveField("Status", metav1.ConditionTrue),
+						HaveField("Reason", "Ready"),
+					),
+				))
+			}).WithTimeout(timeout).WithPolling(interval).Should(Succeed())
+		})
+
+		It("Should update DSCI status when Monitoring CR is deleted", func(ctx context.Context) {
+			// given
+			desiredDsci := createDSCI(operatorv1.Managed, operatorv1.Managed, monitoringNamespace)
+			Expect(k8sClient.Create(ctx, desiredDsci)).Should(Succeed())
+
+			monitoringCR := &serviceApi.Monitoring{}
+			Eventually(func() error {
+				return k8sClient.Get(ctx, client.ObjectKey{Name: "default-monitoring"}, monitoringCR)
+			}).WithTimeout(timeout).WithPolling(interval).Should(Succeed())
+
+			// when - Monitoring is set to Removed in DSCI, which should delete the Monitoring CR
+			foundDsci := &dsciv2.DSCInitialization{}
+			Expect(k8sClient.Get(ctx, client.ObjectKey{Name: applicationName, Namespace: workingNamespace}, foundDsci)).To(Succeed())
+			foundDsci.Spec.Monitoring.ManagementState = operatorv1.Removed
+			Expect(k8sClient.Update(ctx, foundDsci)).To(Succeed())
+
+			// then - Monitoring CR should be gone
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, client.ObjectKey{Name: "default-monitoring"}, monitoringCR)
+				return k8serr.IsNotFound(err) && err != nil
+			}).WithTimeout(timeout).WithPolling(interval).Should(BeTrue())
+
+			// then - DSCI status should reflect it's removed
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, client.ObjectKey{Name: applicationName, Namespace: workingNamespace}, foundDsci)).To(Succeed())
+				g.Expect(foundDsci.Status.Conditions).To(ContainElement(SatisfyAll(
+					HaveField("Type", "MonitoringReady"),
+					HaveField("Status", metav1.ConditionFalse),
+					HaveField("Reason", "Removed"),
+				)))
+			}).WithTimeout(timeout).WithPolling(interval).Should(Succeed())
+		})
 	})
 
 	Context("Handling existing resources", func() {

--- a/internal/controller/services/monitoring/monitoring_controller.go
+++ b/internal/controller/services/monitoring/monitoring_controller.go
@@ -35,6 +35,7 @@ import (
 	dscv2 "github.com/opendatahub-io/opendatahub-operator/v2/api/datasciencecluster/v2"
 	dsciv2 "github.com/opendatahub-io/opendatahub-operator/v2/api/dscinitialization/v2"
 	serviceApi "github.com/opendatahub-io/opendatahub-operator/v2/api/services/v1alpha1"
+	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/status"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/deploy"
@@ -165,6 +166,19 @@ func (h *serviceHandler) NewReconciler(ctx context.Context, mgr ctrl.Manager) er
 		)).
 		// Sync CA from ConfigMap to Secret (handles initial creation and rotation updates)
 		WithAction(syncPrometheusWebTLSCA).
+		WithConditions(
+			status.ConditionMonitoringAvailable,
+			status.ConditionMonitoringStackAvailable,
+			status.ConditionTempoAvailable,
+			status.ConditionOpenTelemetryCollectorAvailable,
+			status.ConditionInstrumentationAvailable,
+			status.ConditionAlertingAvailable,
+			status.ConditionThanosQuerierAvailable,
+			status.ConditionPersesAvailable,
+			status.ConditionPersesTempoDataSourceAvailable,
+			status.ConditionPersesPrometheusDataSourceAvailable,
+			status.ConditionNodeMetricsEndpointAvailable,
+		).
 		WithAction(gc.NewAction()).
 		Build(ctx)
 

--- a/internal/controller/services/monitoring/monitoring_controller_actions.go
+++ b/internal/controller/services/monitoring/monitoring_controller_actions.go
@@ -11,6 +11,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
+	"github.com/opendatahub-io/opendatahub-operator/v2/api/common"
 	serviceApi "github.com/opendatahub-io/opendatahub-operator/v2/api/services/v1alpha1"
 	cr "github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/components/registry"
 	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/status"
@@ -98,13 +99,25 @@ func validateRequiredCRDs(ctx context.Context, rr *odhtypes.ReconciliationReques
 }
 
 // setConditionFalse sets a condition to False with the specified reason and message.
-// This helper reduces code duplication and ensures uniform condition handling across
-// all monitoring components for various failure scenarios (missing CRDs, not managed, not configured, etc.).
+// Uses default Error severity, meaning it WILL block the overall Ready condition.
+// Use setConditionNotConfigured for optional features that are simply not enabled.
 func setConditionFalse(rr *odhtypes.ReconciliationRequest, conditionType, reason, message string) {
 	rr.Conditions.MarkFalse(
 		conditionType,
 		conditions.WithReason(reason),
 		conditions.WithMessage("%s", message),
+	)
+}
+
+// setConditionNotConfigured sets a condition to False with Info severity.
+// Info severity means the condition will NOT block the overall Ready condition.
+// Use this for optional features that are simply not configured/enabled.
+func setConditionNotConfigured(rr *odhtypes.ReconciliationRequest, conditionType, reason, message string) {
+	rr.Conditions.MarkFalse(
+		conditionType,
+		conditions.WithReason(reason),
+		conditions.WithMessage("%s", message),
+		conditions.WithSeverity(common.ConditionSeverityInfo),
 	)
 }
 
@@ -142,8 +155,8 @@ func deployMonitoringStackWithQuerierAndRestrictions(ctx context.Context, rr *od
 
 	// Early exit if no metrics configuration
 	if monitoring.Spec.Metrics == nil {
-		setConditionFalse(rr, status.ConditionMonitoringStackAvailable, status.MetricsNotConfiguredReason, status.MetricsNotConfiguredMessage)
-		setConditionFalse(rr, status.ConditionThanosQuerierAvailable, status.MetricsNotConfiguredReason, status.MetricsNotConfiguredMessage)
+		setConditionNotConfigured(rr, status.ConditionMonitoringStackAvailable, status.MetricsNotConfiguredReason, status.MetricsNotConfiguredMessage)
+		setConditionNotConfigured(rr, status.ConditionThanosQuerierAvailable, status.MetricsNotConfiguredReason, status.MetricsNotConfiguredMessage)
 		return nil
 	}
 
@@ -193,9 +206,9 @@ func deployTracingStack(ctx context.Context, rr *odhtypes.ReconciliationRequest)
 
 	// Early exit if no traces configuration - both components require traces to be configured
 	if monitoring.Spec.Traces == nil {
-		setConditionFalse(rr, status.ConditionTempoAvailable,
+		setConditionNotConfigured(rr, status.ConditionTempoAvailable,
 			status.TracesNotConfiguredReason, status.TracesNotConfiguredMessage)
-		setConditionFalse(rr, status.ConditionInstrumentationAvailable,
+		setConditionNotConfigured(rr, status.ConditionInstrumentationAvailable,
 			status.TracesNotConfiguredReason, status.TracesNotConfiguredMessage)
 		return nil
 	}
@@ -250,6 +263,7 @@ func deployOpenTelemetryCollector(ctx context.Context, rr *odhtypes.Reconciliati
 			status.ConditionOpenTelemetryCollectorAvailable,
 			conditions.WithReason(status.MetricsNotConfiguredReason+"And"+status.TracesNotConfiguredReason),
 			conditions.WithMessage(status.MetricsNotConfiguredMessage+"\n"+status.TracesNotConfiguredMessage),
+			conditions.WithSeverity(common.ConditionSeverityInfo),
 		)
 		return nil
 	}
@@ -314,6 +328,7 @@ func deployAlerting(ctx context.Context, rr *odhtypes.ReconciliationRequest) err
 			status.ConditionAlertingAvailable,
 			conditions.WithReason(status.AlertingNotConfiguredReason),
 			conditions.WithMessage(status.AlertingNotConfiguredMessage),
+			conditions.WithSeverity(common.ConditionSeverityInfo),
 		)
 		return nil
 	}
@@ -423,7 +438,7 @@ func deployPerses(ctx context.Context, rr *odhtypes.ReconciliationRequest) error
 	}
 
 	if monitoring.Spec.Metrics == nil && monitoring.Spec.Traces == nil {
-		setConditionFalse(rr, status.ConditionPersesAvailable,
+		setConditionNotConfigured(rr, status.ConditionPersesAvailable,
 			status.MetricsNotConfiguredReason+"And"+status.TracesNotConfiguredReason,
 			"Perses requires at least Metrics or Traces to be configured")
 		return nil
@@ -525,6 +540,7 @@ func deployPersesTempoIntegration(ctx context.Context, rr *odhtypes.Reconciliati
 			status.ConditionPersesTempoDataSourceAvailable,
 			conditions.WithReason(status.TracesNotConfiguredReason),
 			conditions.WithMessage(status.TracesNotConfiguredMessage),
+			conditions.WithSeverity(common.ConditionSeverityInfo),
 		)
 		return nil
 	}
@@ -574,7 +590,7 @@ func deployPersesPrometheusIntegration(ctx context.Context, rr *odhtypes.Reconci
 	}
 
 	if monitoring.Spec.Metrics == nil {
-		setConditionFalse(rr, status.ConditionPersesPrometheusDataSourceAvailable,
+		setConditionNotConfigured(rr, status.ConditionPersesPrometheusDataSourceAvailable,
 			status.MetricsNotConfiguredReason,
 			"Prometheus datasource requires metrics configuration")
 		return nil
@@ -632,6 +648,7 @@ func deployNodeMetricsEndpoint(_ context.Context, rr *odhtypes.ReconciliationReq
 			status.ConditionNodeMetricsEndpointAvailable,
 			conditions.WithReason(status.MetricsNotConfiguredReason),
 			conditions.WithMessage(status.MetricsNotConfiguredMessage),
+			conditions.WithSeverity(common.ConditionSeverityInfo),
 		)
 		return nil
 	}

--- a/internal/controller/services/monitoring/monitoring_status_test.go
+++ b/internal/controller/services/monitoring/monitoring_status_test.go
@@ -1,0 +1,216 @@
+package monitoring_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/opendatahub-io/opendatahub-operator/v2/api/common"
+	dsciv2 "github.com/opendatahub-io/opendatahub-operator/v2/api/dscinitialization/v2"
+	serviceApi "github.com/opendatahub-io/opendatahub-operator/v2/api/services/v1alpha1"
+	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/dscinitialization"
+	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/status"
+)
+
+func TestGetMonitoringReadyCondition(t *testing.T) {
+	// Setup
+	scheme := runtime.NewScheme()
+	_ = serviceApi.AddToScheme(scheme)
+	_ = dsciv2.AddToScheme(scheme)
+
+	tests := []struct {
+		name               string
+		monitoringCR       *serviceApi.Monitoring
+		expectedConditions []dscinitialization.DSCInitializationCondition
+	}{
+		{
+			name:         "Monitoring CR not found",
+			monitoringCR: nil,
+			expectedConditions: []dscinitialization.DSCInitializationCondition{
+				{
+					Type:         status.ConditionMonitoringReady,
+					ReadyReason:  status.RemovedReason,
+					ReadyMessage: "Monitoring is not enabled",
+					ReadyStatus:  metav1.ConditionFalse,
+				},
+			},
+		},
+		{
+			name: "Monitoring CR exists but has no relevant conditions",
+			monitoringCR: &serviceApi.Monitoring{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "default-monitoring",
+				},
+				Status: serviceApi.MonitoringStatus{
+					Status: common.Status{
+						Conditions: []common.Condition{
+							{
+								Type:    "UnrelatedCondition",
+								Status:  metav1.ConditionTrue,
+								Reason:  "Ready",
+								Message: "Some unrelated message",
+							},
+						},
+					},
+				},
+			},
+			expectedConditions: []dscinitialization.DSCInitializationCondition{
+				{
+					Type:         status.ConditionMonitoringReady,
+					ReadyReason:  status.NotReadyReason,
+					ReadyMessage: "Monitoring stack is initializing",
+					ReadyStatus:  metav1.ConditionUnknown,
+				},
+			},
+		},
+		{
+			name: "Monitoring CR has relevant conditions and all are True",
+			monitoringCR: &serviceApi.Monitoring{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "default-monitoring",
+				},
+				Status: serviceApi.MonitoringStatus{
+					Status: common.Status{
+						Conditions: []common.Condition{
+							{
+								Type:    status.ConditionTypeReady,
+								Status:  metav1.ConditionTrue,
+								Reason:  status.ReadyReason,
+								Message: "Ready message",
+							},
+							{
+								Type:    status.ConditionThanosQuerierAvailable,
+								Status:  metav1.ConditionTrue,
+								Reason:  status.ReadyReason,
+								Message: "Thanos message",
+							},
+						},
+					},
+				},
+			},
+			expectedConditions: []dscinitialization.DSCInitializationCondition{
+				{
+					Type:         status.ConditionTypeReady,
+					ReadyStatus:  metav1.ConditionTrue,
+					ReadyReason:  status.ReadyReason,
+					ReadyMessage: "Ready message",
+				},
+				{
+					Type:         status.ConditionThanosQuerierAvailable,
+					ReadyStatus:  metav1.ConditionTrue,
+					ReadyReason:  status.ReadyReason,
+					ReadyMessage: "Thanos message",
+				},
+				{
+					Type:         status.ConditionMonitoringReady,
+					ReadyStatus:  metav1.ConditionTrue,
+					ReadyReason:  status.ReadyReason,
+					ReadyMessage: "Monitoring stack is initialized",
+				},
+			},
+		},
+		{
+			name: "Monitoring CR has a relevant condition that is False",
+			monitoringCR: &serviceApi.Monitoring{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "default-monitoring",
+				},
+				Status: serviceApi.MonitoringStatus{
+					Status: common.Status{
+						Conditions: []common.Condition{
+							{
+								Type:    status.ConditionTypeReady,
+								Status:  metav1.ConditionTrue,
+								Reason:  status.ReadyReason,
+								Message: "Ready message",
+							},
+							{
+								Type:    status.ConditionThanosQuerierAvailable,
+								Status:  metav1.ConditionFalse,
+								Reason:  "Degraded",
+								Message: "Thanos is failing",
+							},
+						},
+					},
+				},
+			},
+			expectedConditions: []dscinitialization.DSCInitializationCondition{
+				{
+					Type:         status.ConditionTypeReady,
+					ReadyStatus:  metav1.ConditionTrue,
+					ReadyReason:  status.ReadyReason,
+					ReadyMessage: "Ready message",
+				},
+				{
+					Type:         status.ConditionThanosQuerierAvailable,
+					ReadyStatus:  metav1.ConditionFalse,
+					ReadyReason:  "Degraded",
+					ReadyMessage: "Thanos is failing",
+				},
+				{
+					Type:         status.ConditionMonitoringReady,
+					ReadyStatus:  metav1.ConditionTrue,
+					ReadyReason:  status.ReadyReason,
+					ReadyMessage: "Monitoring stack is initialized",
+				},
+			},
+		},
+		{
+			name: "Monitoring CR has a relevant condition that is Unknown",
+			monitoringCR: &serviceApi.Monitoring{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "default-monitoring",
+				},
+				Status: serviceApi.MonitoringStatus{
+					Status: common.Status{
+						Conditions: []common.Condition{
+							{
+								Type:    status.ConditionTypeReady,
+								Status:  metav1.ConditionUnknown,
+								Reason:  "Initializing",
+								Message: "Wait for it",
+							},
+						},
+					},
+				},
+			},
+			expectedConditions: []dscinitialization.DSCInitializationCondition{
+				{
+					Type:         status.ConditionTypeReady,
+					ReadyStatus:  metav1.ConditionUnknown,
+					ReadyReason:  "Initializing",
+					ReadyMessage: "Wait for it",
+				},
+				{
+					Type:         status.ConditionMonitoringReady,
+					ReadyStatus:  metav1.ConditionTrue,
+					ReadyReason:  status.ReadyReason,
+					ReadyMessage: "Monitoring stack is initialized",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Arrange
+			clientBuilder := fake.NewClientBuilder().WithScheme(scheme)
+			if tt.monitoringCR != nil {
+				clientBuilder.WithObjects(tt.monitoringCR)
+			}
+			r := &dscinitialization.DSCInitializationReconciler{
+				Client: clientBuilder.Build(),
+			}
+
+			// Act
+			conditions := r.GetMonitoringReadyCondition(context.Background())
+
+			// Assert
+			assert.Equal(t, tt.expectedConditions, conditions)
+		})
+	}
+}

--- a/internal/controller/status/status.go
+++ b/internal/controller/status/status.go
@@ -83,6 +83,7 @@ const (
 	ConditionDependenciesAvailable               = "DependenciesAvailable"
 	ConditionArgoWorkflowAvailable               = "ArgoWorkflowAvailable"
 	ConditionTypeComponentsReady                 = "ComponentsReady"
+	ConditionMonitoringReady                     = "MonitoringReady"
 	ConditionMonitoringAvailable                 = "MonitoringAvailable"
 	ConditionMonitoringStackAvailable            = "MonitoringStackAvailable"
 	ConditionTempoAvailable                      = "TempoAvailable"

--- a/tests/e2e/monitoring_test.go
+++ b/tests/e2e/monitoring_test.go
@@ -113,118 +113,157 @@ func monitoringTestSuite(t *testing.T) {
 		t.Fatalf("Required monitoring operators are not installed. Cannot proceed with monitoring tests on this cluster.")
 	}
 
+	monitoringServiceCtx.runBaseConfigurationTests(t)
+	monitoringServiceCtx.runMetricsAndMonitoringStackTests(t)
+	monitoringServiceCtx.runOpenTelemetryCollectorTests(t)
+	monitoringServiceCtx.runTargetAllocatorTests(t)
+	monitoringServiceCtx.runThanosQuerierTests(t)
+	monitoringServiceCtx.runTracesWithPVBackendTests(t)
+	monitoringServiceCtx.runTracesWithCloudStorageTests(t)
+	monitoringServiceCtx.runPersesTests(t)
+	monitoringServiceCtx.runAdvancedNetworkingRBACTests(t)
+
+	monitoringServiceCtx.runWebhookTests(t)
+	monitoringServiceCtx.runNegativeConditionsTests(t)
+
+	// ========================================================================
+	// Final Test: Complete Cleanup
+	// Validates that monitoring can be fully disabled and resources removed
+	// ========================================================================
+	t.Run("Validate monitoring service disabled", monitoringServiceCtx.ValidateMonitoringServiceDisabled)
+	t.Run("Validate MonitoringReady condition reflects disabled state on DSCI", monitoringServiceCtx.ValidateMonitoringReadyConditionDisabledOnDSCI)
+}
+
+func (tc *MonitoringTestCtx) runBaseConfigurationTests(t *testing.T) {
+	t.Helper()
 	// ========================================================================
 	// Group 1: Base Configuration
 	// Tests that validate basic Monitoring CR creation and default values
 	// ========================================================================
 	t.Run("Group 1: Base Configuration", func(t *testing.T) {
 		// Ensure clean slate at the start of this group
-		monitoringServiceCtx.ensureMonitoringCleanSlate(t, "")
+		tc.ensureMonitoringCleanSlate(t, "")
 
 		// Setup: Create basic Monitoring CR with managementState=Managed
-		monitoringServiceCtx.setupBaseMonitoring(t)
+		tc.setupBaseMonitoring(t)
 
 		// Cleanup: Reset to Managed state (no metrics, no traces) at group end
 		t.Cleanup(func() {
-			monitoringServiceCtx.cleanupGroup(t, "")
+			tc.cleanupGroup(t, "")
 		})
 
-		t.Run("Auto creation of Monitoring CR", monitoringServiceCtx.ValidateMonitoringCRCreation)
-		t.Run("Test Monitoring CR content default value", monitoringServiceCtx.ValidateMonitoringCRDefaultContent)
-		t.Run("Test Traces default content", monitoringServiceCtx.ValidateMonitoringCRDefaultTracesContent)
+		t.Run("Auto creation of Monitoring CR", tc.ValidateMonitoringCRCreation)
+		t.Run("Test Monitoring CR content default value", tc.ValidateMonitoringCRDefaultContent)
+		t.Run("Test MonitoringReady condition propagated to DSCI", tc.ValidateMonitoringReadyConditionOnDSCI)
+		t.Run("Test Traces default content", tc.ValidateMonitoringCRDefaultTracesContent)
 	})
+}
 
+func (tc *MonitoringTestCtx) runMetricsAndMonitoringStackTests(t *testing.T) {
+	t.Helper()
 	// ========================================================================
 	// Group 2: Metrics & MonitoringStack
 	// Tests related to metrics configuration and MonitoringStack CR
 	// ========================================================================
 	t.Run("Group 2: Metrics & MonitoringStack", func(t *testing.T) {
 		// Setup: Enable metrics configuration once for all tests in this group
-		monitoringServiceCtx.setupMetrics(t)
+		tc.setupMetrics(t)
 
 		// Cleanup: Reset to Managed state at group end
 		t.Cleanup(func() {
-			monitoringServiceCtx.cleanupGroup(t, "")
+			tc.cleanupGroup(t, "")
 		})
 
-		t.Run("Test Metrics MonitoringStack CR Creation", monitoringServiceCtx.ValidateMonitoringStackCRMetricsWhenSet)
-		t.Run("Test Metrics MonitoringStack CR Configuration", monitoringServiceCtx.ValidateMonitoringStackCRMetricsConfiguration)
-		t.Run("Test Metrics Replicas Configuration", monitoringServiceCtx.ValidateMonitoringStackCRMetricsReplicasUpdate)
-		t.Run("Test Prometheus rules lifecycle", monitoringServiceCtx.ValidatePrometheusRulesLifecycle)
-		t.Run("Test Prometheus Self ServiceMonitor TLS Fix", monitoringServiceCtx.ValidatePrometheusSelfServiceMonitorTLSFix)
-		t.Run("Test ownerReference consistency over time", monitoringServiceCtx.ValidateOwnerReferenceConsistency)
-		t.Run("Test resourceVersion stability after reconciliation", monitoringServiceCtx.ValidateResourceVersionStability)
+		t.Run("Test Metrics MonitoringStack CR Creation", tc.ValidateMonitoringStackCRMetricsWhenSet)
+		t.Run("Test Metrics MonitoringStack CR Configuration", tc.ValidateMonitoringStackCRMetricsConfiguration)
+		t.Run("Test Metrics Replicas Configuration", tc.ValidateMonitoringStackCRMetricsReplicasUpdate)
+		t.Run("Test Prometheus rules lifecycle", tc.ValidatePrometheusRulesLifecycle)
+		t.Run("Test Prometheus Self ServiceMonitor TLS Fix", tc.ValidatePrometheusSelfServiceMonitorTLSFix)
+		t.Run("Test ownerReference consistency over time", tc.ValidateOwnerReferenceConsistency)
+		t.Run("Test resourceVersion stability after reconciliation", tc.ValidateResourceVersionStability)
 	})
+}
 
+func (tc *MonitoringTestCtx) runOpenTelemetryCollectorTests(t *testing.T) {
+	t.Helper()
 	// ========================================================================
 	// Group 3: OpenTelemetry Collector
 	// Tests related to OpenTelemetry Collector configuration and deployment
 	// ========================================================================
 	t.Run("Group 3: OpenTelemetry Collector", func(t *testing.T) {
 		// Setup: Enable metrics configuration for collector tests
-		monitoringServiceCtx.setupMetrics(t)
+		tc.setupMetrics(t)
 
 		// Cleanup: Reset to Managed state at group end
 		t.Cleanup(func() {
-			monitoringServiceCtx.cleanupGroup(t, "")
+			tc.cleanupGroup(t, "")
 		})
 
-		t.Run("Test OpenTelemetry Collector Configurations", monitoringServiceCtx.ValidateOpenTelemetryCollectorConfigurations)
-		t.Run("Test OpenTelemetry Collector replicas", monitoringServiceCtx.ValidateMonitoringCRCollectorReplicas)
-		t.Run("Test Metrics TLS is always enabled for Prometheus exporter", monitoringServiceCtx.ValidateMetricsTLSAlwaysEnabled)
+		t.Run("Test OpenTelemetry Collector Configurations", tc.ValidateOpenTelemetryCollectorConfigurations)
+		t.Run("Test OpenTelemetry Collector replicas", tc.ValidateMonitoringCRCollectorReplicas)
+		t.Run("Test Metrics TLS is always enabled for Prometheus exporter", tc.ValidateMetricsTLSAlwaysEnabled)
 	})
+}
 
+func (tc *MonitoringTestCtx) runTargetAllocatorTests(t *testing.T) {
+	t.Helper()
 	// ========================================================================
 	// Group 4: Target Allocator
 	// Tests related to Target Allocator deployment and configuration
 	// ========================================================================
 	t.Run("Group 4: Target Allocator", func(t *testing.T) {
 		// Ensure clean slate for this group
-		monitoringServiceCtx.ensureMonitoringCleanSlate(t, "")
+		tc.ensureMonitoringCleanSlate(t, "")
 
 		// Cleanup: Reset to Managed state at group end
 		t.Cleanup(func() {
-			monitoringServiceCtx.cleanupGroup(t, "")
+			tc.cleanupGroup(t, "")
 		})
 
 		// Subtest 1: Target Allocator without metrics
-		t.Run("Test Target Allocator not deployed without metrics", monitoringServiceCtx.ValidateTargetAllocatorNotDeployedWithoutMetrics)
+		t.Run("Test Target Allocator not deployed without metrics", tc.ValidateTargetAllocatorNotDeployedWithoutMetrics)
 
 		// Subtest 2-5: Target Allocator with metrics
 		t.Run("With Metrics", func(t *testing.T) {
 			// Setup metrics for these tests
-			monitoringServiceCtx.setupMetrics(t)
+			tc.setupMetrics(t)
 
-			t.Run("Test Target Allocator deployment with metrics", monitoringServiceCtx.ValidateTargetAllocatorDeploymentWithMetrics)
-			t.Run("Test Target Allocator Service and ConfigMap", monitoringServiceCtx.ValidateTargetAllocatorServiceAndConfigMap)
-			t.Run("Test Target Allocator lifecycle", monitoringServiceCtx.ValidateTargetAllocatorLifecycle)
-			t.Run("Test Target Allocator RBAC configuration", monitoringServiceCtx.ValidateTargetAllocatorRBACConfiguration)
+			t.Run("Test Target Allocator deployment with metrics", tc.ValidateTargetAllocatorDeploymentWithMetrics)
+			t.Run("Test Target Allocator Service and ConfigMap", tc.ValidateTargetAllocatorServiceAndConfigMap)
+			t.Run("Test Target Allocator lifecycle", tc.ValidateTargetAllocatorLifecycle)
+			t.Run("Test Target Allocator RBAC configuration", tc.ValidateTargetAllocatorRBACConfiguration)
 		})
 	})
+}
 
+func (tc *MonitoringTestCtx) runThanosQuerierTests(t *testing.T) {
+	t.Helper()
 	// ========================================================================
 	// Group 5: Thanos Querier
 	// Tests related to Thanos Querier deployment
 	// ========================================================================
 	t.Run("Group 5: Thanos Querier", func(t *testing.T) {
 		// Ensure clean slate for this group
-		monitoringServiceCtx.ensureMonitoringCleanSlate(t, "")
+		tc.ensureMonitoringCleanSlate(t, "")
 
 		// Cleanup: Reset to Managed state at group end
 		t.Cleanup(func() {
-			monitoringServiceCtx.cleanupGroup(t, "")
+			tc.cleanupGroup(t, "")
 		})
 
 		// Subtest 1: Without metrics
-		t.Run("Test ThanosQuerier not deployed without metrics", monitoringServiceCtx.ValidateThanosQuerierNotDeployedWithoutMetrics)
+		t.Run("Test ThanosQuerier not deployed without metrics", tc.ValidateThanosQuerierNotDeployedWithoutMetrics)
 
 		// Subtest 2: With metrics
-		t.Run("Test ThanosQuerier deployment with metrics", monitoringServiceCtx.ValidateThanosQuerierDeployment)
+		t.Run("Test ThanosQuerier deployment with metrics", tc.ValidateThanosQuerierDeployment)
 
 		// Subtest 3: NetworkPolicy allows Thanos Querier on gRPC port
-		t.Run("Test Prometheus NetworkPolicy allows Thanos Querier on gRPC port", monitoringServiceCtx.ValidatePrometheusNetworkPolicyAllowsThanosQuerier)
+		t.Run("Test Prometheus NetworkPolicy allows Thanos Querier on gRPC port", tc.ValidatePrometheusNetworkPolicyAllowsThanosQuerier)
 	})
+}
 
+func (tc *MonitoringTestCtx) runTracesWithPVBackendTests(t *testing.T) {
+	t.Helper()
 	// ========================================================================
 	// Group 6: Traces with PV Backend
 	// Tests for TempoMonolithic CR creation with PV backend
@@ -232,12 +271,15 @@ func monitoringTestSuite(t *testing.T) {
 	t.Run("Group 6: Traces with PV Backend", func(t *testing.T) {
 		// Cleanup: Reset and remove tempo resources at group end
 		t.Cleanup(func() {
-			monitoringServiceCtx.cleanupGroup(t, "")
+			tc.cleanupGroup(t, "")
 		})
 
-		t.Run("Test TempoMonolithic CR Creation with PV backend", monitoringServiceCtx.ValidateTempoMonolithicCRCreation)
+		t.Run("Test TempoMonolithic CR Creation with PV backend", tc.ValidateTempoMonolithicCRCreation)
 	})
+}
 
+func (tc *MonitoringTestCtx) runTracesWithCloudStorageTests(t *testing.T) {
+	t.Helper()
 	// ========================================================================
 	// Group 7: Traces with Cloud Storage (S3 & GCS)
 	// Tests for TempoStack CR creation with cloud storage backends
@@ -245,15 +287,18 @@ func monitoringTestSuite(t *testing.T) {
 	t.Run("Group 7: Traces with Cloud Storage", func(t *testing.T) {
 		// Cleanup: Reset and remove tempo resources at group end
 		t.Cleanup(func() {
-			monitoringServiceCtx.cleanupGroup(t, "s3-secret")
-			monitoringServiceCtx.cleanupGroup(t, "gcs-secret")
+			tc.cleanupGroup(t, "s3-secret")
+			tc.cleanupGroup(t, "gcs-secret")
 		})
 
-		t.Run("Test TempoStack CR Creation with Cloud Storage", monitoringServiceCtx.ValidateTempoStackCRCreationWithCloudStorage)
-		t.Run("Test Instrumentation CR Traces lifecycle", monitoringServiceCtx.ValidateInstrumentationCRTracesLifecycle)
-		t.Run("Test Traces Exporters Reserved Name Validation", monitoringServiceCtx.ValidateTracesExportersReservedNameValidation)
+		t.Run("Test TempoStack CR Creation with Cloud Storage", tc.ValidateTempoStackCRCreationWithCloudStorage)
+		t.Run("Test Instrumentation CR Traces lifecycle", tc.ValidateInstrumentationCRTracesLifecycle)
+		t.Run("Test Traces Exporters Reserved Name Validation", tc.ValidateTracesExportersReservedNameValidation)
 	})
+}
 
+func (tc *MonitoringTestCtx) runPersesTests(t *testing.T) {
+	t.Helper()
 	// ========================================================================
 	// Group 8: Perses
 	// Tests related to Perses deployment, configuration, and datasources
@@ -261,41 +306,44 @@ func monitoringTestSuite(t *testing.T) {
 	t.Run("Group 8: Perses", func(t *testing.T) {
 		// Cleanup: Reset at group end
 		t.Cleanup(func() {
-			monitoringServiceCtx.cleanupGroup(t, "")
+			tc.cleanupGroup(t, "")
 		})
 
 		// Subgroup 1: Perses Lifecycle
 		t.Run("Perses Lifecycle", func(t *testing.T) {
 			// Setup metrics for perses tests
-			monitoringServiceCtx.setupMetrics(t)
+			tc.setupMetrics(t)
 
-			t.Run("Test Perses deployment when monitoring is managed", monitoringServiceCtx.ValidatePersesCRCreation)
-			t.Run("Test Perses CR configuration", monitoringServiceCtx.ValidatePersesCRConfiguration)
-			t.Run("Test Perses lifecycle", monitoringServiceCtx.ValidatePersesLifecycle)
-			t.Run("Test Perses not deployed without metrics or traces", monitoringServiceCtx.ValidatePersesNotDeployedWithoutMetricsOrTraces)
-			t.Run("Test Perses NetworkPolicy creation", monitoringServiceCtx.ValidatePersesNetworkPolicy)
+			t.Run("Test Perses deployment when monitoring is managed", tc.ValidatePersesCRCreation)
+			t.Run("Test Perses CR configuration", tc.ValidatePersesCRConfiguration)
+			t.Run("Test Perses lifecycle", tc.ValidatePersesLifecycle)
+			t.Run("Test Perses not deployed without metrics or traces", tc.ValidatePersesNotDeployedWithoutMetricsOrTraces)
+			t.Run("Test Perses NetworkPolicy creation", tc.ValidatePersesNetworkPolicy)
 		})
 
 		// Subgroup 2: Perses Datasource with Traces
 		t.Run("Perses Datasource with Traces", func(t *testing.T) {
-			t.Run("Test Perses Datasource Creation with Traces", monitoringServiceCtx.ValidatePersesDatasourceCreationWithTraces)
-			t.Run("Test Perses Datasource Configuration", monitoringServiceCtx.ValidatePersesDatasourceConfiguration)
-			t.Run("Test PersesDatasource deployment with Prometheus", monitoringServiceCtx.ValidatePersesDatasourceWithPrometheus)
-			t.Run("Test PersesDatasource lifecycle", monitoringServiceCtx.ValidatePersesDatasourceLifecycle)
+			t.Run("Test Perses Datasource Creation with Traces", tc.ValidatePersesDatasourceCreationWithTraces)
+			t.Run("Test Perses Datasource Configuration", tc.ValidatePersesDatasourceConfiguration)
+			t.Run("Test PersesDatasource deployment with Prometheus", tc.ValidatePersesDatasourceWithPrometheus)
+			t.Run("Test PersesDatasource lifecycle", tc.ValidatePersesDatasourceLifecycle)
 		})
 
 		// Subgroup 3: Perses Datasource TLS with Cloud Backends
 		t.Run("Perses Datasource TLS with Cloud Backends", func(t *testing.T) {
 			t.Cleanup(func() {
-				monitoringServiceCtx.cleanupGroup(t, "s3-secret")
-				monitoringServiceCtx.cleanupGroup(t, "gcs-secret")
+				tc.cleanupGroup(t, "s3-secret")
+				tc.cleanupGroup(t, "gcs-secret")
 			})
 
-			t.Run("Test Perses Datasource TLS with S3 backend", monitoringServiceCtx.ValidatePersesDatasourceTLSWithS3Backend)
-			t.Run("Test Perses Datasource TLS with GCS backend", monitoringServiceCtx.ValidatePersesDatasourceTLSWithGCSBackend)
+			t.Run("Test Perses Datasource TLS with S3 backend", tc.ValidatePersesDatasourceTLSWithS3Backend)
+			t.Run("Test Perses Datasource TLS with GCS backend", tc.ValidatePersesDatasourceTLSWithGCSBackend)
 		})
 	})
+}
 
+func (tc *MonitoringTestCtx) runAdvancedNetworkingRBACTests(t *testing.T) {
+	t.Helper()
 	// ========================================================================
 	// Group 9: Advanced Networking/RBAC
 	// Tests related to namespace restrictions, proxy authentication, and node metrics
@@ -303,40 +351,58 @@ func monitoringTestSuite(t *testing.T) {
 	t.Run("Group 9: Advanced Networking/RBAC", func(t *testing.T) {
 		// Cleanup: Reset at group end
 		t.Cleanup(func() {
-			monitoringServiceCtx.cleanupGroup(t, "")
+			tc.cleanupGroup(t, "")
 		})
 
-		t.Run("Test Namespace Restricted Metrics Access", monitoringServiceCtx.ValidatePrometheusRestrictedResourceConfiguration)
-		t.Run("Test Prometheus Secure Proxy Authentication", monitoringServiceCtx.ValidatePrometheusSecureProxyAuthentication)
-		t.Run("Test Node Metrics Endpoint Deployment", monitoringServiceCtx.ValidateNodeMetricsEndpointDeployment)
-		t.Run("Test Node Metrics Endpoint RBAC Configuration", monitoringServiceCtx.ValidateNodeMetricsEndpointRBACConfiguration)
+		t.Run("Test Namespace Restricted Metrics Access", tc.ValidatePrometheusRestrictedResourceConfiguration)
+		t.Run("Test Prometheus Secure Proxy Authentication", tc.ValidatePrometheusSecureProxyAuthentication)
+		t.Run("Test Node Metrics Endpoint Deployment", tc.ValidateNodeMetricsEndpointDeployment)
+		t.Run("Test Node Metrics Endpoint RBAC Configuration", tc.ValidateNodeMetricsEndpointRBACConfiguration)
 	})
+}
 
-	// ========================================================================
-	// Final Test: Complete Cleanup
-	// Validates that monitoring can be fully disabled and resources removed
-	// ========================================================================
-	t.Run("Validate monitoring service disabled", monitoringServiceCtx.ValidateMonitoringServiceDisabled)
-
+func (tc *MonitoringTestCtx) runWebhookTests(t *testing.T) {
+	t.Helper()
 	// ========================================================================
 	// Webhook Tests (if enabled)
 	// ========================================================================
 	if testOpts.webhookTest {
 		t.Run("Webhook Tests", func(t *testing.T) {
-			t.Run("Setup monitoring admission components tests", monitoringServiceCtx.ValidateMonitoringWebhookTestsSetup)
-			t.Run("Validate monitoring label value enforcement on namespace", monitoringServiceCtx.ValidateMonitoringLabelValueEnforcementOnNamespace)
-			t.Run("Validate monitoring label value enforcement on monitors", monitoringServiceCtx.ValidateMonitoringLabelValueEnforcementOnMonitors)
-			t.Run("Validate monitors creation with custom labels", monitoringServiceCtx.ValidateMonitorsCreationWithCustomLabels)
-			t.Run("Validate monitors monitoring label injection", monitoringServiceCtx.ValidateMonitorLabelInjection)
-			t.Run("Validate monitor label injection on UPDATE", monitoringServiceCtx.ValidateMonitorLabelInjectionOnUpdate)
-			t.Run("Validate monitor label injection on UPDATE with custom labels", monitoringServiceCtx.ValidateMonitorLabelInjectionOnUpdateWithCustomLabels)
-			t.Run("Validate webhook skips non-monitored namespace", monitoringServiceCtx.ValidateWebhookSkipsNonMonitoredNamespace)
-			t.Run("Validate webhook skips explicitly opted-out namespace", monitoringServiceCtx.ValidateWebhookSkipsExplicitlyOptedOutNamespace)
-			t.Run("Validate webhook respects user opt-out", monitoringServiceCtx.ValidateWebhookRespectsUserOptOut)
-			t.Run("Validate webhook idempotency", monitoringServiceCtx.ValidateWebhookIdempotency)
-			t.Run("Validate webhook does not inject when monitoring disabled", monitoringServiceCtx.ValidateWebhookSkipsWhenMonitoringDisabled)
+			t.Run("Setup monitoring admission components tests", tc.ValidateMonitoringWebhookTestsSetup)
+			t.Run("Validate monitoring label value enforcement on namespace", tc.ValidateMonitoringLabelValueEnforcementOnNamespace)
+			t.Run("Validate monitoring label value enforcement on monitors", tc.ValidateMonitoringLabelValueEnforcementOnMonitors)
+			t.Run("Validate monitors creation with custom labels", tc.ValidateMonitorsCreationWithCustomLabels)
+			t.Run("Validate monitors monitoring label injection", tc.ValidateMonitorLabelInjection)
+			t.Run("Validate monitor label injection on UPDATE", tc.ValidateMonitorLabelInjectionOnUpdate)
+			t.Run("Validate monitor label injection on UPDATE with custom labels", tc.ValidateMonitorLabelInjectionOnUpdateWithCustomLabels)
+			t.Run("Validate webhook skips non-monitored namespace", tc.ValidateWebhookSkipsNonMonitoredNamespace)
+			t.Run("Validate webhook skips explicitly opted-out namespace", tc.ValidateWebhookSkipsExplicitlyOptedOutNamespace)
+			t.Run("Validate webhook respects user opt-out", tc.ValidateWebhookRespectsUserOptOut)
+			t.Run("Validate webhook idempotency", tc.ValidateWebhookIdempotency)
+			t.Run("Validate webhook does not inject when monitoring disabled", tc.ValidateWebhookSkipsWhenMonitoringDisabled)
 		})
 	}
+}
+
+func (tc *MonitoringTestCtx) runNegativeConditionsTests(t *testing.T) {
+	t.Helper()
+	// ========================================================================
+	// Group 12: Negative Conditions
+	// Tests the propagation of negative conditions when configurations are missing.
+	// ========================================================================
+	t.Run("Group 12: Negative Conditions", func(t *testing.T) {
+		// Cleanup: Reset at group end
+		t.Cleanup(func() {
+			tc.cleanupGroup(t, "")
+		})
+
+		t.Run("Test monitoring metrics negative conditions", tc.ValidateMonitoringMetricsNegativeConditions)
+		t.Run("Test monitoring traces negative conditions", tc.ValidateMonitoringTracesNegativeConditions)
+		t.Run("Test monitoring alerting negative conditions", tc.ValidateMonitoringAlertingNegativeConditions)
+		t.Run("Test monitoring perses negative conditions", tc.ValidateMonitoringPersesNegativeConditions)
+		t.Run("Test monitoring node metrics negative conditions", tc.ValidateMonitoringNodeMetricsNegativeConditions)
+		t.Run("Test monitoring opentelemetry negative conditions", tc.ValidateMonitoringOpenTelemetryNegativeConditions)
+	})
 }
 
 // ValidateMonitoringOperatorsInstallation ensures the required monitoring operators are installed.
@@ -353,10 +419,11 @@ func (tc *MonitoringTestCtx) ValidateMonitoringOperatorsInstallation(t *testing.
 	tc.ensureOperatorsAreInstalled(t, operators)
 }
 
-// ValidateMonitoringCRCreation ensures that exactly one Monitoring CR exists and status to Ready.
+// ValidateMonitoringCRCreation ensures that exactly one Monitoring CR exists and is eventually Ready.
 func (tc *MonitoringTestCtx) ValidateMonitoringCRCreation(t *testing.T) {
 	t.Helper()
 
+	// Initial check: Monitoring CR should exist but might be Not Ready if no features are enabled
 	tc.updateMonitoringConfig(withManagementState(operatorv1.Managed))
 
 	tc.EnsureResourcesExist(
@@ -366,11 +433,62 @@ func (tc *MonitoringTestCtx) ValidateMonitoringCRCreation(t *testing.T) {
 				HaveLen(1),
 				HaveEach(And(
 					jq.Match(`.metadata.ownerReferences[0].kind == "%s"`, gvk.DSCInitialization.Kind),
+					jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, status.ConditionTypeProvisioningSucceeded, metav1.ConditionTrue),
+				)),
+			),
+		),
+	)
+
+	// To reach Ready=True, we must enable at least one feature (e.g. metrics)
+	tc.setupMetrics(t)
+
+	tc.EnsureResourcesExist(
+		WithMinimalObject(gvk.Monitoring, types.NamespacedName{Name: MonitoringCRName}),
+		WithCondition(
+			And(
+				HaveLen(1),
+				HaveEach(And(
 					jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, status.ConditionTypeReady, metav1.ConditionTrue),
 					jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, status.ConditionTypeProvisioningSucceeded, metav1.ConditionTrue),
 				)),
 			),
 		),
+	)
+}
+
+// ValidateMonitoringReadyConditionOnDSCI verifies that mirrored conditions
+// are propagated to DSCI status when monitoring is Managed and the Monitoring CR is ready.
+func (tc *MonitoringTestCtx) ValidateMonitoringReadyConditionOnDSCI(t *testing.T) {
+	t.Helper()
+
+	tc.EnsureResourceExists(
+		WithMinimalObject(gvk.DSCInitialization, tc.DSCInitializationNamespacedName),
+		WithCondition(And(
+			jq.Match(`.status.phase == "%s"`, status.PhaseReady),
+			// Mirrored conditions from Monitoring CR
+			jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, status.ConditionTypeReady, metav1.ConditionTrue),
+			jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, status.ConditionTypeProvisioningSucceeded, metav1.ConditionTrue),
+			// Base condition
+			jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, status.ConditionMonitoringReady, metav1.ConditionTrue),
+			jq.Match(`.status.conditions[] | select(.type == "%s") | .reason == "%s"`, status.ConditionMonitoringReady, status.ReadyReason),
+		)),
+		WithCustomErrorMsg("DSCI should have mirrored Ready=True and ProvisioningSucceeded=True PLUS MonitoringReady=True when monitoring is Managed and Monitoring CR is ready"),
+	)
+}
+
+// ValidateMonitoringReadyConditionDisabledOnDSCI verifies that the MonitoringReady condition
+// is set to False on DSCI when monitoring is disabled (Removed).
+func (tc *MonitoringTestCtx) ValidateMonitoringReadyConditionDisabledOnDSCI(t *testing.T) {
+	t.Helper()
+
+	tc.EnsureResourceExists(
+		WithMinimalObject(gvk.DSCInitialization, tc.DSCInitializationNamespacedName),
+		WithCondition(And(
+			jq.Match(`.status.phase == "%s"`, status.PhaseReady),
+			jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, status.ConditionMonitoringReady, metav1.ConditionFalse),
+			jq.Match(`.status.conditions[] | select(.type == "%s") | .reason == "%s"`, status.ConditionMonitoringReady, status.RemovedReason),
+		)),
+		WithCustomErrorMsg("DSCI should have MonitoringReady=False with reason Removed when monitoring is disabled"),
 	)
 }
 
@@ -532,6 +650,7 @@ func (tc *MonitoringTestCtx) ValidateOpenTelemetryCollectorConfigurations(t *tes
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Helper()
+			t.Cleanup(tc.resetMonitoringConfigToManaged)
 
 			// Setup configuration first
 			tc.updateMonitoringConfig(testCase.transforms...)
@@ -564,7 +683,6 @@ func (tc *MonitoringTestCtx) ValidateOpenTelemetryCollectorConfigurations(t *tes
 			)
 
 			// Universal cleanup to prevent state contamination between tests
-			tc.resetMonitoringConfigToManaged()
 		})
 	}
 }
@@ -986,6 +1104,7 @@ func (tc *MonitoringTestCtx) ValidatePersesLifecycle(t *testing.T) {
 
 func (tc *MonitoringTestCtx) ValidatePersesNotDeployedWithoutMetricsOrTraces(t *testing.T) {
 	t.Helper()
+	t.Cleanup(tc.resetMonitoringConfigToManaged)
 
 	tc.updateMonitoringConfig(
 		withManagementState(operatorv1.Managed),
@@ -1016,8 +1135,6 @@ func (tc *MonitoringTestCtx) ValidatePersesNotDeployedWithoutMetricsOrTraces(t *
 	tc.EnsureResourceGone(
 		WithMinimalObject(gvk.Perses, types.NamespacedName{Name: PersesName, Namespace: tc.MonitoringNamespace}),
 	)
-
-	tc.resetMonitoringConfigToManaged()
 }
 
 func (tc *MonitoringTestCtx) ValidatePersesNetworkPolicy(t *testing.T) {
@@ -1691,6 +1808,7 @@ func withMonitoringTraces(backend, secret, size, retention string) testf.Transfo
 // ValidateThanosQuerierDeployment tests that ThanosQuerier CR and Route are created when metrics are configured and ThanosQuerier CRD is available.
 func (tc *MonitoringTestCtx) ValidateThanosQuerierDeployment(t *testing.T) {
 	t.Helper()
+	t.Cleanup(tc.resetMonitoringConfigToManaged)
 
 	tc.updateMonitoringConfig(
 		withManagementState(operatorv1.Managed),
@@ -1737,11 +1855,11 @@ func (tc *MonitoringTestCtx) ValidateThanosQuerierDeployment(t *testing.T) {
 	)
 
 	// Cleanup: Reset monitoring configuration
-	tc.resetMonitoringConfigToManaged()
 }
 
 func (tc *MonitoringTestCtx) ValidateThanosQuerierNotDeployedWithoutMetrics(t *testing.T) {
 	t.Helper()
+	t.Cleanup(tc.resetMonitoringConfigToManaged)
 
 	tc.updateMonitoringConfig(
 		withManagementState(operatorv1.Managed),
@@ -1777,13 +1895,13 @@ func (tc *MonitoringTestCtx) ValidateThanosQuerierNotDeployedWithoutMetrics(t *t
 	)
 
 	// Cleanup: Reset monitoring configuration
-	tc.resetMonitoringConfigToManaged()
 }
 
 // ValidatePrometheusNetworkPolicyAllowsThanosQuerier tests that the Prometheus instance NetworkPolicy
 // includes an ingress rule allowing the Thanos Querier to reach the Thanos Sidecar on gRPC port 10901.
 func (tc *MonitoringTestCtx) ValidatePrometheusNetworkPolicyAllowsThanosQuerier(t *testing.T) {
 	t.Helper()
+	t.Cleanup(tc.resetMonitoringConfigToManaged)
 
 	tc.updateMonitoringConfig(
 		withManagementState(operatorv1.Managed),
@@ -1830,6 +1948,7 @@ func (tc *MonitoringTestCtx) ValidatePrometheusNetworkPolicyAllowsThanosQuerier(
 // and properly configured with the correct serverName to fix TLS SANs mismatch issues.
 func (tc *MonitoringTestCtx) ValidatePrometheusSelfServiceMonitorTLSFix(t *testing.T) {
 	t.Helper()
+	t.Cleanup(tc.resetMonitoringConfigToManaged)
 
 	tc.updateMonitoringConfig(
 		withManagementState(operatorv1.Managed),
@@ -1893,8 +2012,6 @@ func (tc *MonitoringTestCtx) ValidatePrometheusSelfServiceMonitorTLSFix(t *testi
 		)),
 		WithCustomErrorMsg("Prometheus StatefulSet should have at least one ready replica, indicating healthy operation"),
 	)
-
-	tc.resetMonitoringConfigToManaged()
 }
 
 // ValidateOwnerReferenceConsistency verifies that ownerReferences on monitoring resources
@@ -2630,6 +2747,7 @@ func (tc *MonitoringTestCtx) ValidatePersesDatasourceTLSWithGCSBackend(t *testin
 // ValidateTargetAllocatorNotDeployedWithoutMetrics tests that the Target Allocator is not deployed when metrics are not configured.
 func (tc *MonitoringTestCtx) ValidateTargetAllocatorNotDeployedWithoutMetrics(t *testing.T) {
 	t.Helper()
+	t.Cleanup(tc.resetMonitoringConfigToManaged)
 
 	tc.updateMonitoringConfig(
 		withManagementState(operatorv1.Managed),
@@ -2671,13 +2789,12 @@ func (tc *MonitoringTestCtx) ValidateTargetAllocatorNotDeployedWithoutMetrics(t 
 			Namespace: tc.MonitoringNamespace,
 		}),
 	)
-
-	tc.resetMonitoringConfigToManaged()
 }
 
 // ValidateTargetAllocatorDeploymentWithMetrics tests that the Target Allocator is deployed and ready when metrics are configured.
 func (tc *MonitoringTestCtx) ValidateTargetAllocatorDeploymentWithMetrics(t *testing.T) {
 	t.Helper()
+	t.Cleanup(tc.resetMonitoringConfigToManaged)
 
 	tc.updateMonitoringConfig(
 		withManagementState(operatorv1.Managed),
@@ -2721,13 +2838,12 @@ func (tc *MonitoringTestCtx) ValidateTargetAllocatorDeploymentWithMetrics(t *tes
 		)),
 		WithCustomErrorMsg("Target Allocator Deployment should be created and available"),
 	)
-
-	tc.resetMonitoringConfigToManaged()
 }
 
 // ValidateTargetAllocatorServiceAndConfigMap tests that the Target Allocator Service and ConfigMap are created correctly.
 func (tc *MonitoringTestCtx) ValidateTargetAllocatorServiceAndConfigMap(t *testing.T) {
 	t.Helper()
+	t.Cleanup(tc.resetMonitoringConfigToManaged)
 
 	tc.updateMonitoringConfig(
 		withManagementState(operatorv1.Managed),
@@ -2754,13 +2870,12 @@ func (tc *MonitoringTestCtx) ValidateTargetAllocatorServiceAndConfigMap(t *testi
 		}),
 		WithCustomErrorMsg("Target Allocator ConfigMap should be created by OpenTelemetry Operator"),
 	)
-
-	tc.resetMonitoringConfigToManaged()
 }
 
 // ValidateTargetAllocatorLifecycle tests the complete lifecycle of Target Allocator deployment and cleanup.
 func (tc *MonitoringTestCtx) ValidateTargetAllocatorLifecycle(t *testing.T) {
 	t.Helper()
+	t.Cleanup(tc.resetMonitoringConfigToManaged)
 
 	// Step 1: Enable metrics to deploy Target Allocator
 	tc.updateMonitoringConfig(
@@ -2805,13 +2920,12 @@ func (tc *MonitoringTestCtx) ValidateTargetAllocatorLifecycle(t *testing.T) {
 		WithCondition(jq.Match(`.status.readyReplicas >= 1`)),
 		WithCustomErrorMsg("Target Allocator should be recreated when metrics are re-enabled"),
 	)
-
-	tc.resetMonitoringConfigToManaged()
 }
 
 // ValidateTargetAllocatorRBACConfiguration tests that Target Allocator has correct RBAC permissions.
 func (tc *MonitoringTestCtx) ValidateTargetAllocatorRBACConfiguration(t *testing.T) {
 	t.Helper()
+	t.Cleanup(tc.resetMonitoringConfigToManaged)
 
 	tc.updateMonitoringConfig(
 		withManagementState(operatorv1.Managed),
@@ -2858,6 +2972,199 @@ func (tc *MonitoringTestCtx) ValidateTargetAllocatorRBACConfiguration(t *testing
 		)),
 		WithCustomErrorMsg("ClusterRoleBinding should bind Target Allocator ClusterRole to ServiceAccount"),
 	)
+}
 
-	tc.resetMonitoringConfigToManaged()
+// ValidateMonitoringMetricsNegativeConditions tests the propagation of negative conditions for Metrics.
+func (tc *MonitoringTestCtx) ValidateMonitoringMetricsNegativeConditions(t *testing.T) {
+	t.Helper()
+	t.Cleanup(tc.resetMonitoringConfigToManaged)
+
+	tc.updateMonitoringConfig(
+		withManagementState(operatorv1.Managed),
+		withNoMetrics(),
+	)
+
+	// Verify MetricsNotConfigured reason is present in Monitoring CR
+	tc.EnsureResourceExists(
+		WithMinimalObject(gvk.Monitoring, types.NamespacedName{Name: MonitoringCRName}),
+		WithCondition(And(
+			jq.Match(`[.status.conditions[] | select(.type=="%s" and .reason=="%s")] | length==1`,
+				status.ConditionMonitoringStackAvailable, status.MetricsNotConfiguredReason),
+			jq.Match(`[.status.conditions[] | select(.type=="%s" and .reason=="%s")] | length==1`,
+				status.ConditionThanosQuerierAvailable, status.MetricsNotConfiguredReason),
+		)),
+	)
+
+	// Verify these conditions are mirrored to DSCI
+	tc.EnsureResourceExists(
+		WithMinimalObject(gvk.DSCInitialization, tc.DSCInitializationNamespacedName),
+		WithCondition(And(
+			jq.Match(`[.status.conditions[] | select(.type=="%s" and .reason=="%s")] | length==1`,
+				status.ConditionMonitoringStackAvailable, status.MetricsNotConfiguredReason),
+		)),
+	)
+
+	// Cleanup: Reset monitoring configuration
+}
+
+// ValidateMonitoringTracesNegativeConditions tests the propagation of negative conditions for Traces.
+func (tc *MonitoringTestCtx) ValidateMonitoringTracesNegativeConditions(t *testing.T) {
+	t.Helper()
+	t.Cleanup(tc.resetMonitoringConfigToManaged)
+
+	tc.updateMonitoringConfig(
+		withManagementState(operatorv1.Managed),
+		withNoTraces(),
+	)
+
+	// Verify TracesNotConfigured reason is present in Monitoring CR
+	tc.EnsureResourceExists(
+		WithMinimalObject(gvk.Monitoring, types.NamespacedName{Name: MonitoringCRName}),
+		WithCondition(And(
+			jq.Match(`[.status.conditions[] | select(.type=="%s" and .reason=="%s")] | length==1`,
+				status.ConditionTempoAvailable, status.TracesNotConfiguredReason),
+			jq.Match(`[.status.conditions[] | select(.type=="%s" and .reason=="%s")] | length==1`,
+				status.ConditionInstrumentationAvailable, status.TracesNotConfiguredReason),
+		)),
+	)
+
+	// Verify these conditions are mirrored to DSCI
+	tc.EnsureResourceExists(
+		WithMinimalObject(gvk.DSCInitialization, tc.DSCInitializationNamespacedName),
+		WithCondition(And(
+			jq.Match(`[.status.conditions[] | select(.type=="%s" and .reason=="%s")] | length==1`,
+				status.ConditionTempoAvailable, status.TracesNotConfiguredReason),
+		)),
+	)
+
+	// Cleanup: Reset monitoring configuration
+}
+
+// ValidateMonitoringAlertingNegativeConditions tests the propagation of negative conditions for Alerting.
+func (tc *MonitoringTestCtx) ValidateMonitoringAlertingNegativeConditions(t *testing.T) {
+	t.Helper()
+	t.Cleanup(tc.resetMonitoringConfigToManaged)
+
+	tc.updateMonitoringConfig(
+		withManagementState(operatorv1.Managed),
+		withNoAlerting(),
+	)
+
+	// Verify AlertingNotConfigured reason is present in Monitoring CR
+	tc.EnsureResourceExists(
+		WithMinimalObject(gvk.Monitoring, types.NamespacedName{Name: MonitoringCRName}),
+		WithCondition(jq.Match(`[.status.conditions[] | select(.type=="%s" and .reason=="%s")] | length==1`,
+			status.ConditionAlertingAvailable, status.AlertingNotConfiguredReason)),
+	)
+
+	// Verify mirrored to DSCI
+	tc.EnsureResourceExists(
+		WithMinimalObject(gvk.DSCInitialization, tc.DSCInitializationNamespacedName),
+		WithCondition(And(
+			jq.Match(`[.status.conditions[] | select(.type=="%s" and .reason=="%s")] | length==1`,
+				status.ConditionAlertingAvailable, status.AlertingNotConfiguredReason),
+		)),
+	)
+}
+
+// ValidateMonitoringPersesNegativeConditions tests the propagation of negative conditions for Perses.
+func (tc *MonitoringTestCtx) ValidateMonitoringPersesNegativeConditions(t *testing.T) {
+	t.Helper()
+	t.Cleanup(tc.resetMonitoringConfigToManaged)
+
+	// Perses requires at least Metrics or Traces
+	tc.updateMonitoringConfig(
+		withManagementState(operatorv1.Managed),
+		withNoMetrics(),
+		withNoTraces(),
+	)
+
+	// Verify Perses conditions with negative reasons
+	tc.EnsureResourceExists(
+		WithMinimalObject(gvk.Monitoring, types.NamespacedName{Name: MonitoringCRName}),
+		WithCondition(And(
+			// Ready: True
+			jq.Match(`[.status.conditions[] | select(.type=="%s" and .status=="%s" and .reason=="%s")] | length==1`,
+				status.ConditionTypeReady, metav1.ConditionTrue, status.ReadyReason),
+			// PersesAvailable: MetricsNotConfiguredAndTracesNotConfigured
+			jq.Match(`[.status.conditions[] | select(.type=="%s" and .reason=="%s")] | length==1`,
+				status.ConditionPersesAvailable, status.MetricsNotConfiguredReason+"And"+status.TracesNotConfiguredReason),
+			// PersesTempoDataSourceAvailable: TracesNotConfigured
+			jq.Match(`[.status.conditions[] | select(.type=="%s" and .reason=="%s")] | length==1`,
+				status.ConditionPersesTempoDataSourceAvailable, status.TracesNotConfiguredReason),
+			// PersesPrometheusDataSourceAvailable: MetricsNotConfigured
+			jq.Match(`[.status.conditions[] | select(.type=="%s" and .reason=="%s")] | length==1`,
+				status.ConditionPersesPrometheusDataSourceAvailable, status.MetricsNotConfiguredReason),
+		)),
+	)
+
+	// Verify mirrored to DSCI
+	tc.EnsureResourceExists(
+		WithMinimalObject(gvk.DSCInitialization, tc.DSCInitializationNamespacedName),
+		WithCondition(And(
+			jq.Match(`[.status.conditions[] | select(.type=="%s" and .reason=="%s")] | length==1`,
+				status.ConditionPersesAvailable, status.MetricsNotConfiguredReason+"And"+status.TracesNotConfiguredReason),
+		)),
+	)
+}
+
+// ValidateMonitoringNodeMetricsNegativeConditions tests negative conditions for NodeMetricsEndpoint.
+func (tc *MonitoringTestCtx) ValidateMonitoringNodeMetricsNegativeConditions(t *testing.T) {
+	t.Helper()
+	t.Cleanup(tc.resetMonitoringConfigToManaged)
+
+	tc.updateMonitoringConfig(
+		withManagementState(operatorv1.Managed),
+		withNoMetrics(),
+	)
+
+	tc.EnsureResourceExists(
+		WithMinimalObject(gvk.Monitoring, types.NamespacedName{Name: MonitoringCRName}),
+		WithCondition(And(
+			jq.Match(`[.status.conditions[] | select(.type=="%s" and .status=="%s" and .reason=="%s")] | length==1`,
+				status.ConditionTypeReady, metav1.ConditionTrue, status.ReadyReason),
+			jq.Match(`[.status.conditions[] | select(.type=="%s" and .reason=="%s")] | length==1`,
+				status.ConditionNodeMetricsEndpointAvailable, status.MetricsNotConfiguredReason),
+		)),
+	)
+
+	// Verify mirrored to DSCI
+	tc.EnsureResourceExists(
+		WithMinimalObject(gvk.DSCInitialization, tc.DSCInitializationNamespacedName),
+		WithCondition(And(
+			jq.Match(`[.status.conditions[] | select(.type=="%s" and .reason=="%s")] | length==1`,
+				status.ConditionNodeMetricsEndpointAvailable, status.MetricsNotConfiguredReason),
+		)),
+	)
+}
+
+// ValidateMonitoringOpenTelemetryNegativeConditions tests negative conditions for OpenTelemetryCollector.
+func (tc *MonitoringTestCtx) ValidateMonitoringOpenTelemetryNegativeConditions(t *testing.T) {
+	t.Helper()
+	t.Cleanup(tc.resetMonitoringConfigToManaged)
+
+	tc.updateMonitoringConfig(
+		withManagementState(operatorv1.Managed),
+		withNoMetrics(),
+		withNoTraces(),
+	)
+
+	tc.EnsureResourceExists(
+		WithMinimalObject(gvk.Monitoring, types.NamespacedName{Name: MonitoringCRName}),
+		WithCondition(And(
+			jq.Match(`[.status.conditions[] | select(.type=="%s" and .status=="%s" and .reason=="%s")] | length==1`,
+				status.ConditionTypeReady, metav1.ConditionTrue, status.ReadyReason),
+			jq.Match(`[.status.conditions[] | select(.type=="%s" and .reason=="%s")] | length==1`,
+				status.ConditionOpenTelemetryCollectorAvailable, status.MetricsNotConfiguredReason+"And"+status.TracesNotConfiguredReason),
+		)),
+	)
+
+	// Verify mirrored to DSCI
+	tc.EnsureResourceExists(
+		WithMinimalObject(gvk.DSCInitialization, tc.DSCInitializationNamespacedName),
+		WithCondition(And(
+			jq.Match(`[.status.conditions[] | select(.type=="%s" and .reason=="%s")] | length==1`,
+				status.ConditionOpenTelemetryCollectorAvailable, status.MetricsNotConfiguredReason+"And"+status.TracesNotConfiguredReason),
+		)),
+	)
 }

--- a/tests/e2e/monitoring_test.go
+++ b/tests/e2e/monitoring_test.go
@@ -113,118 +113,157 @@ func monitoringTestSuite(t *testing.T) {
 		t.Fatalf("Required monitoring operators are not installed. Cannot proceed with monitoring tests on this cluster.")
 	}
 
+	monitoringServiceCtx.runBaseConfigurationTests(t)
+	monitoringServiceCtx.runMetricsAndMonitoringStackTests(t)
+	monitoringServiceCtx.runOpenTelemetryCollectorTests(t)
+	monitoringServiceCtx.runTargetAllocatorTests(t)
+	monitoringServiceCtx.runThanosQuerierTests(t)
+	monitoringServiceCtx.runTracesWithPVBackendTests(t)
+	monitoringServiceCtx.runTracesWithCloudStorageTests(t)
+	monitoringServiceCtx.runPersesTests(t)
+	monitoringServiceCtx.runAdvancedNetworkingRBACTests(t)
+
+	monitoringServiceCtx.runWebhookTests(t)
+	monitoringServiceCtx.runNegativeConditionsTests(t)
+
+	// ========================================================================
+	// Final Test: Complete Cleanup
+	// Validates that monitoring can be fully disabled and resources removed
+	// ========================================================================
+	t.Run("Validate monitoring service disabled", monitoringServiceCtx.ValidateMonitoringServiceDisabled)
+	t.Run("Validate MonitoringReady condition reflects disabled state on DSCI", monitoringServiceCtx.ValidateMonitoringReadyConditionDisabledOnDSCI)
+}
+
+func (tc *MonitoringTestCtx) runBaseConfigurationTests(t *testing.T) {
+	t.Helper()
 	// ========================================================================
 	// Group 1: Base Configuration
 	// Tests that validate basic Monitoring CR creation and default values
 	// ========================================================================
 	t.Run("Group 1: Base Configuration", func(t *testing.T) {
 		// Ensure clean slate at the start of this group
-		monitoringServiceCtx.ensureMonitoringCleanSlate(t, "")
+		tc.ensureMonitoringCleanSlate(t, "")
 
 		// Setup: Create basic Monitoring CR with managementState=Managed
-		monitoringServiceCtx.setupBaseMonitoring(t)
+		tc.setupBaseMonitoring(t)
 
 		// Cleanup: Reset to Managed state (no metrics, no traces) at group end
 		t.Cleanup(func() {
-			monitoringServiceCtx.cleanupGroup(t, "")
+			tc.cleanupGroup(t, "")
 		})
 
-		t.Run("Auto creation of Monitoring CR", monitoringServiceCtx.ValidateMonitoringCRCreation)
-		t.Run("Test Monitoring CR content default value", monitoringServiceCtx.ValidateMonitoringCRDefaultContent)
-		t.Run("Test Traces default content", monitoringServiceCtx.ValidateMonitoringCRDefaultTracesContent)
+		t.Run("Auto creation of Monitoring CR", tc.ValidateMonitoringCRCreation)
+		t.Run("Test Monitoring CR content default value", tc.ValidateMonitoringCRDefaultContent)
+		t.Run("Test MonitoringReady condition propagated to DSCI", tc.ValidateMonitoringReadyConditionOnDSCI)
+		t.Run("Test Traces default content", tc.ValidateMonitoringCRDefaultTracesContent)
 	})
+}
 
+func (tc *MonitoringTestCtx) runMetricsAndMonitoringStackTests(t *testing.T) {
+	t.Helper()
 	// ========================================================================
 	// Group 2: Metrics & MonitoringStack
 	// Tests related to metrics configuration and MonitoringStack CR
 	// ========================================================================
 	t.Run("Group 2: Metrics & MonitoringStack", func(t *testing.T) {
 		// Setup: Enable metrics configuration once for all tests in this group
-		monitoringServiceCtx.setupMetrics(t)
+		tc.setupMetrics(t)
 
 		// Cleanup: Reset to Managed state at group end
 		t.Cleanup(func() {
-			monitoringServiceCtx.cleanupGroup(t, "")
+			tc.cleanupGroup(t, "")
 		})
 
-		t.Run("Test Metrics MonitoringStack CR Creation", monitoringServiceCtx.ValidateMonitoringStackCRMetricsWhenSet)
-		t.Run("Test Metrics MonitoringStack CR Configuration", monitoringServiceCtx.ValidateMonitoringStackCRMetricsConfiguration)
-		t.Run("Test Metrics Replicas Configuration", monitoringServiceCtx.ValidateMonitoringStackCRMetricsReplicasUpdate)
-		t.Run("Test Prometheus rules lifecycle", monitoringServiceCtx.ValidatePrometheusRulesLifecycle)
-		t.Run("Test Prometheus Self ServiceMonitor TLS Fix", monitoringServiceCtx.ValidatePrometheusSelfServiceMonitorTLSFix)
-		t.Run("Test ownerReference consistency over time", monitoringServiceCtx.ValidateOwnerReferenceConsistency)
-		t.Run("Test resourceVersion stability after reconciliation", monitoringServiceCtx.ValidateResourceVersionStability)
+		t.Run("Test Metrics MonitoringStack CR Creation", tc.ValidateMonitoringStackCRMetricsWhenSet)
+		t.Run("Test Metrics MonitoringStack CR Configuration", tc.ValidateMonitoringStackCRMetricsConfiguration)
+		t.Run("Test Metrics Replicas Configuration", tc.ValidateMonitoringStackCRMetricsReplicasUpdate)
+		t.Run("Test Prometheus rules lifecycle", tc.ValidatePrometheusRulesLifecycle)
+		t.Run("Test Prometheus Self ServiceMonitor TLS Fix", tc.ValidatePrometheusSelfServiceMonitorTLSFix)
+		t.Run("Test ownerReference consistency over time", tc.ValidateOwnerReferenceConsistency)
+		t.Run("Test resourceVersion stability after reconciliation", tc.ValidateResourceVersionStability)
 	})
+}
 
+func (tc *MonitoringTestCtx) runOpenTelemetryCollectorTests(t *testing.T) {
+	t.Helper()
 	// ========================================================================
 	// Group 3: OpenTelemetry Collector
 	// Tests related to OpenTelemetry Collector configuration and deployment
 	// ========================================================================
 	t.Run("Group 3: OpenTelemetry Collector", func(t *testing.T) {
 		// Setup: Enable metrics configuration for collector tests
-		monitoringServiceCtx.setupMetrics(t)
+		tc.setupMetrics(t)
 
 		// Cleanup: Reset to Managed state at group end
 		t.Cleanup(func() {
-			monitoringServiceCtx.cleanupGroup(t, "")
+			tc.cleanupGroup(t, "")
 		})
 
-		t.Run("Test OpenTelemetry Collector Configurations", monitoringServiceCtx.ValidateOpenTelemetryCollectorConfigurations)
-		t.Run("Test OpenTelemetry Collector replicas", monitoringServiceCtx.ValidateMonitoringCRCollectorReplicas)
-		t.Run("Test Metrics TLS is always enabled for Prometheus exporter", monitoringServiceCtx.ValidateMetricsTLSAlwaysEnabled)
+		t.Run("Test OpenTelemetry Collector Configurations", tc.ValidateOpenTelemetryCollectorConfigurations)
+		t.Run("Test OpenTelemetry Collector replicas", tc.ValidateMonitoringCRCollectorReplicas)
+		t.Run("Test Metrics TLS is always enabled for Prometheus exporter", tc.ValidateMetricsTLSAlwaysEnabled)
 	})
+}
 
+func (tc *MonitoringTestCtx) runTargetAllocatorTests(t *testing.T) {
+	t.Helper()
 	// ========================================================================
 	// Group 4: Target Allocator
 	// Tests related to Target Allocator deployment and configuration
 	// ========================================================================
 	t.Run("Group 4: Target Allocator", func(t *testing.T) {
 		// Ensure clean slate for this group
-		monitoringServiceCtx.ensureMonitoringCleanSlate(t, "")
+		tc.ensureMonitoringCleanSlate(t, "")
 
 		// Cleanup: Reset to Managed state at group end
 		t.Cleanup(func() {
-			monitoringServiceCtx.cleanupGroup(t, "")
+			tc.cleanupGroup(t, "")
 		})
 
 		// Subtest 1: Target Allocator without metrics
-		t.Run("Test Target Allocator not deployed without metrics", monitoringServiceCtx.ValidateTargetAllocatorNotDeployedWithoutMetrics)
+		t.Run("Test Target Allocator not deployed without metrics", tc.ValidateTargetAllocatorNotDeployedWithoutMetrics)
 
 		// Subtest 2-5: Target Allocator with metrics
 		t.Run("With Metrics", func(t *testing.T) {
 			// Setup metrics for these tests
-			monitoringServiceCtx.setupMetrics(t)
+			tc.setupMetrics(t)
 
-			t.Run("Test Target Allocator deployment with metrics", monitoringServiceCtx.ValidateTargetAllocatorDeploymentWithMetrics)
-			t.Run("Test Target Allocator Service and ConfigMap", monitoringServiceCtx.ValidateTargetAllocatorServiceAndConfigMap)
-			t.Run("Test Target Allocator lifecycle", monitoringServiceCtx.ValidateTargetAllocatorLifecycle)
-			t.Run("Test Target Allocator RBAC configuration", monitoringServiceCtx.ValidateTargetAllocatorRBACConfiguration)
+			t.Run("Test Target Allocator deployment with metrics", tc.ValidateTargetAllocatorDeploymentWithMetrics)
+			t.Run("Test Target Allocator Service and ConfigMap", tc.ValidateTargetAllocatorServiceAndConfigMap)
+			t.Run("Test Target Allocator lifecycle", tc.ValidateTargetAllocatorLifecycle)
+			t.Run("Test Target Allocator RBAC configuration", tc.ValidateTargetAllocatorRBACConfiguration)
 		})
 	})
+}
 
+func (tc *MonitoringTestCtx) runThanosQuerierTests(t *testing.T) {
+	t.Helper()
 	// ========================================================================
 	// Group 5: Thanos Querier
 	// Tests related to Thanos Querier deployment
 	// ========================================================================
 	t.Run("Group 5: Thanos Querier", func(t *testing.T) {
 		// Ensure clean slate for this group
-		monitoringServiceCtx.ensureMonitoringCleanSlate(t, "")
+		tc.ensureMonitoringCleanSlate(t, "")
 
 		// Cleanup: Reset to Managed state at group end
 		t.Cleanup(func() {
-			monitoringServiceCtx.cleanupGroup(t, "")
+			tc.cleanupGroup(t, "")
 		})
 
 		// Subtest 1: Without metrics
-		t.Run("Test ThanosQuerier not deployed without metrics", monitoringServiceCtx.ValidateThanosQuerierNotDeployedWithoutMetrics)
+		t.Run("Test ThanosQuerier not deployed without metrics", tc.ValidateThanosQuerierNotDeployedWithoutMetrics)
 
 		// Subtest 2: With metrics
-		t.Run("Test ThanosQuerier deployment with metrics", monitoringServiceCtx.ValidateThanosQuerierDeployment)
+		t.Run("Test ThanosQuerier deployment with metrics", tc.ValidateThanosQuerierDeployment)
 
 		// Subtest 3: NetworkPolicy allows Thanos Querier on gRPC port
-		t.Run("Test Prometheus NetworkPolicy allows Thanos Querier on gRPC port", monitoringServiceCtx.ValidatePrometheusNetworkPolicyAllowsThanosQuerier)
+		t.Run("Test Prometheus NetworkPolicy allows Thanos Querier on gRPC port", tc.ValidatePrometheusNetworkPolicyAllowsThanosQuerier)
 	})
+}
 
+func (tc *MonitoringTestCtx) runTracesWithPVBackendTests(t *testing.T) {
+	t.Helper()
 	// ========================================================================
 	// Group 6: Traces with PV Backend
 	// Tests for TempoMonolithic CR creation with PV backend
@@ -232,12 +271,15 @@ func monitoringTestSuite(t *testing.T) {
 	t.Run("Group 6: Traces with PV Backend", func(t *testing.T) {
 		// Cleanup: Reset and remove tempo resources at group end
 		t.Cleanup(func() {
-			monitoringServiceCtx.cleanupGroup(t, "")
+			tc.cleanupGroup(t, "")
 		})
 
-		t.Run("Test TempoMonolithic CR Creation with PV backend", monitoringServiceCtx.ValidateTempoMonolithicCRCreation)
+		t.Run("Test TempoMonolithic CR Creation with PV backend", tc.ValidateTempoMonolithicCRCreation)
 	})
+}
 
+func (tc *MonitoringTestCtx) runTracesWithCloudStorageTests(t *testing.T) {
+	t.Helper()
 	// ========================================================================
 	// Group 7: Traces with Cloud Storage (S3 & GCS)
 	// Tests for TempoStack CR creation with cloud storage backends
@@ -245,15 +287,18 @@ func monitoringTestSuite(t *testing.T) {
 	t.Run("Group 7: Traces with Cloud Storage", func(t *testing.T) {
 		// Cleanup: Reset and remove tempo resources at group end
 		t.Cleanup(func() {
-			monitoringServiceCtx.cleanupGroup(t, "s3-secret")
-			monitoringServiceCtx.cleanupGroup(t, "gcs-secret")
+			tc.cleanupGroup(t, "s3-secret")
+			tc.cleanupGroup(t, "gcs-secret")
 		})
 
-		t.Run("Test TempoStack CR Creation with Cloud Storage", monitoringServiceCtx.ValidateTempoStackCRCreationWithCloudStorage)
-		t.Run("Test Instrumentation CR Traces lifecycle", monitoringServiceCtx.ValidateInstrumentationCRTracesLifecycle)
-		t.Run("Test Traces Exporters Reserved Name Validation", monitoringServiceCtx.ValidateTracesExportersReservedNameValidation)
+		t.Run("Test TempoStack CR Creation with Cloud Storage", tc.ValidateTempoStackCRCreationWithCloudStorage)
+		t.Run("Test Instrumentation CR Traces lifecycle", tc.ValidateInstrumentationCRTracesLifecycle)
+		t.Run("Test Traces Exporters Reserved Name Validation", tc.ValidateTracesExportersReservedNameValidation)
 	})
+}
 
+func (tc *MonitoringTestCtx) runPersesTests(t *testing.T) {
+	t.Helper()
 	// ========================================================================
 	// Group 8: Perses
 	// Tests related to Perses deployment, configuration, and datasources
@@ -261,41 +306,44 @@ func monitoringTestSuite(t *testing.T) {
 	t.Run("Group 8: Perses", func(t *testing.T) {
 		// Cleanup: Reset at group end
 		t.Cleanup(func() {
-			monitoringServiceCtx.cleanupGroup(t, "")
+			tc.cleanupGroup(t, "")
 		})
 
 		// Subgroup 1: Perses Lifecycle
 		t.Run("Perses Lifecycle", func(t *testing.T) {
 			// Setup metrics for perses tests
-			monitoringServiceCtx.setupMetrics(t)
+			tc.setupMetrics(t)
 
-			t.Run("Test Perses deployment when monitoring is managed", monitoringServiceCtx.ValidatePersesCRCreation)
-			t.Run("Test Perses CR configuration", monitoringServiceCtx.ValidatePersesCRConfiguration)
-			t.Run("Test Perses lifecycle", monitoringServiceCtx.ValidatePersesLifecycle)
-			t.Run("Test Perses not deployed without metrics or traces", monitoringServiceCtx.ValidatePersesNotDeployedWithoutMetricsOrTraces)
-			t.Run("Test Perses NetworkPolicy creation", monitoringServiceCtx.ValidatePersesNetworkPolicy)
+			t.Run("Test Perses deployment when monitoring is managed", tc.ValidatePersesCRCreation)
+			t.Run("Test Perses CR configuration", tc.ValidatePersesCRConfiguration)
+			t.Run("Test Perses lifecycle", tc.ValidatePersesLifecycle)
+			t.Run("Test Perses not deployed without metrics or traces", tc.ValidatePersesNotDeployedWithoutMetricsOrTraces)
+			t.Run("Test Perses NetworkPolicy creation", tc.ValidatePersesNetworkPolicy)
 		})
 
 		// Subgroup 2: Perses Datasource with Traces
 		t.Run("Perses Datasource with Traces", func(t *testing.T) {
-			t.Run("Test Perses Datasource Creation with Traces", monitoringServiceCtx.ValidatePersesDatasourceCreationWithTraces)
-			t.Run("Test Perses Datasource Configuration", monitoringServiceCtx.ValidatePersesDatasourceConfiguration)
-			t.Run("Test PersesDatasource deployment with Prometheus", monitoringServiceCtx.ValidatePersesDatasourceWithPrometheus)
-			t.Run("Test PersesDatasource lifecycle", monitoringServiceCtx.ValidatePersesDatasourceLifecycle)
+			t.Run("Test Perses Datasource Creation with Traces", tc.ValidatePersesDatasourceCreationWithTraces)
+			t.Run("Test Perses Datasource Configuration", tc.ValidatePersesDatasourceConfiguration)
+			t.Run("Test PersesDatasource deployment with Prometheus", tc.ValidatePersesDatasourceWithPrometheus)
+			t.Run("Test PersesDatasource lifecycle", tc.ValidatePersesDatasourceLifecycle)
 		})
 
 		// Subgroup 3: Perses Datasource TLS with Cloud Backends
 		t.Run("Perses Datasource TLS with Cloud Backends", func(t *testing.T) {
 			t.Cleanup(func() {
-				monitoringServiceCtx.cleanupGroup(t, "s3-secret")
-				monitoringServiceCtx.cleanupGroup(t, "gcs-secret")
+				tc.cleanupGroup(t, "s3-secret")
+				tc.cleanupGroup(t, "gcs-secret")
 			})
 
-			t.Run("Test Perses Datasource TLS with S3 backend", monitoringServiceCtx.ValidatePersesDatasourceTLSWithS3Backend)
-			t.Run("Test Perses Datasource TLS with GCS backend", monitoringServiceCtx.ValidatePersesDatasourceTLSWithGCSBackend)
+			t.Run("Test Perses Datasource TLS with S3 backend", tc.ValidatePersesDatasourceTLSWithS3Backend)
+			t.Run("Test Perses Datasource TLS with GCS backend", tc.ValidatePersesDatasourceTLSWithGCSBackend)
 		})
 	})
+}
 
+func (tc *MonitoringTestCtx) runAdvancedNetworkingRBACTests(t *testing.T) {
+	t.Helper()
 	// ========================================================================
 	// Group 9: Advanced Networking/RBAC
 	// Tests related to namespace restrictions, proxy authentication, and node metrics
@@ -303,40 +351,58 @@ func monitoringTestSuite(t *testing.T) {
 	t.Run("Group 9: Advanced Networking/RBAC", func(t *testing.T) {
 		// Cleanup: Reset at group end
 		t.Cleanup(func() {
-			monitoringServiceCtx.cleanupGroup(t, "")
+			tc.cleanupGroup(t, "")
 		})
 
-		t.Run("Test Namespace Restricted Metrics Access", monitoringServiceCtx.ValidatePrometheusRestrictedResourceConfiguration)
-		t.Run("Test Prometheus Secure Proxy Authentication", monitoringServiceCtx.ValidatePrometheusSecureProxyAuthentication)
-		t.Run("Test Node Metrics Endpoint Deployment", monitoringServiceCtx.ValidateNodeMetricsEndpointDeployment)
-		t.Run("Test Node Metrics Endpoint RBAC Configuration", monitoringServiceCtx.ValidateNodeMetricsEndpointRBACConfiguration)
+		t.Run("Test Namespace Restricted Metrics Access", tc.ValidatePrometheusRestrictedResourceConfiguration)
+		t.Run("Test Prometheus Secure Proxy Authentication", tc.ValidatePrometheusSecureProxyAuthentication)
+		t.Run("Test Node Metrics Endpoint Deployment", tc.ValidateNodeMetricsEndpointDeployment)
+		t.Run("Test Node Metrics Endpoint RBAC Configuration", tc.ValidateNodeMetricsEndpointRBACConfiguration)
 	})
+}
 
-	// ========================================================================
-	// Final Test: Complete Cleanup
-	// Validates that monitoring can be fully disabled and resources removed
-	// ========================================================================
-	t.Run("Validate monitoring service disabled", monitoringServiceCtx.ValidateMonitoringServiceDisabled)
-
+func (tc *MonitoringTestCtx) runWebhookTests(t *testing.T) {
+	t.Helper()
 	// ========================================================================
 	// Webhook Tests (if enabled)
 	// ========================================================================
 	if testOpts.webhookTest {
 		t.Run("Webhook Tests", func(t *testing.T) {
-			t.Run("Setup monitoring admission components tests", monitoringServiceCtx.ValidateMonitoringWebhookTestsSetup)
-			t.Run("Validate monitoring label value enforcement on namespace", monitoringServiceCtx.ValidateMonitoringLabelValueEnforcementOnNamespace)
-			t.Run("Validate monitoring label value enforcement on monitors", monitoringServiceCtx.ValidateMonitoringLabelValueEnforcementOnMonitors)
-			t.Run("Validate monitors creation with custom labels", monitoringServiceCtx.ValidateMonitorsCreationWithCustomLabels)
-			t.Run("Validate monitors monitoring label injection", monitoringServiceCtx.ValidateMonitorLabelInjection)
-			t.Run("Validate monitor label injection on UPDATE", monitoringServiceCtx.ValidateMonitorLabelInjectionOnUpdate)
-			t.Run("Validate monitor label injection on UPDATE with custom labels", monitoringServiceCtx.ValidateMonitorLabelInjectionOnUpdateWithCustomLabels)
-			t.Run("Validate webhook skips non-monitored namespace", monitoringServiceCtx.ValidateWebhookSkipsNonMonitoredNamespace)
-			t.Run("Validate webhook skips explicitly opted-out namespace", monitoringServiceCtx.ValidateWebhookSkipsExplicitlyOptedOutNamespace)
-			t.Run("Validate webhook respects user opt-out", monitoringServiceCtx.ValidateWebhookRespectsUserOptOut)
-			t.Run("Validate webhook idempotency", monitoringServiceCtx.ValidateWebhookIdempotency)
-			t.Run("Validate webhook does not inject when monitoring disabled", monitoringServiceCtx.ValidateWebhookSkipsWhenMonitoringDisabled)
+			t.Run("Setup monitoring admission components tests", tc.ValidateMonitoringWebhookTestsSetup)
+			t.Run("Validate monitoring label value enforcement on namespace", tc.ValidateMonitoringLabelValueEnforcementOnNamespace)
+			t.Run("Validate monitoring label value enforcement on monitors", tc.ValidateMonitoringLabelValueEnforcementOnMonitors)
+			t.Run("Validate monitors creation with custom labels", tc.ValidateMonitorsCreationWithCustomLabels)
+			t.Run("Validate monitors monitoring label injection", tc.ValidateMonitorLabelInjection)
+			t.Run("Validate monitor label injection on UPDATE", tc.ValidateMonitorLabelInjectionOnUpdate)
+			t.Run("Validate monitor label injection on UPDATE with custom labels", tc.ValidateMonitorLabelInjectionOnUpdateWithCustomLabels)
+			t.Run("Validate webhook skips non-monitored namespace", tc.ValidateWebhookSkipsNonMonitoredNamespace)
+			t.Run("Validate webhook skips explicitly opted-out namespace", tc.ValidateWebhookSkipsExplicitlyOptedOutNamespace)
+			t.Run("Validate webhook respects user opt-out", tc.ValidateWebhookRespectsUserOptOut)
+			t.Run("Validate webhook idempotency", tc.ValidateWebhookIdempotency)
+			t.Run("Validate webhook does not inject when monitoring disabled", tc.ValidateWebhookSkipsWhenMonitoringDisabled)
 		})
 	}
+}
+
+func (tc *MonitoringTestCtx) runNegativeConditionsTests(t *testing.T) {
+	t.Helper()
+	// ========================================================================
+	// Group 12: Negative Conditions
+	// Tests the propagation of negative conditions when configurations are missing.
+	// ========================================================================
+	t.Run("Group 12: Negative Conditions", func(t *testing.T) {
+		// Cleanup: Reset at group end
+		t.Cleanup(func() {
+			tc.cleanupGroup(t, "")
+		})
+
+		t.Run("Test monitoring metrics negative conditions", tc.ValidateMonitoringMetricsNegativeConditions)
+		t.Run("Test monitoring traces negative conditions", tc.ValidateMonitoringTracesNegativeConditions)
+		t.Run("Test monitoring alerting negative conditions", tc.ValidateMonitoringAlertingNegativeConditions)
+		t.Run("Test monitoring perses negative conditions", tc.ValidateMonitoringPersesNegativeConditions)
+		t.Run("Test monitoring node metrics negative conditions", tc.ValidateMonitoringNodeMetricsNegativeConditions)
+		t.Run("Test monitoring opentelemetry negative conditions", tc.ValidateMonitoringOpenTelemetryNegativeConditions)
+	})
 }
 
 // ValidateMonitoringOperatorsInstallation ensures the required monitoring operators are installed.
@@ -353,10 +419,11 @@ func (tc *MonitoringTestCtx) ValidateMonitoringOperatorsInstallation(t *testing.
 	tc.ensureOperatorsAreInstalled(t, operators)
 }
 
-// ValidateMonitoringCRCreation ensures that exactly one Monitoring CR exists and status to Ready.
+// ValidateMonitoringCRCreation ensures that exactly one Monitoring CR exists and is eventually Ready.
 func (tc *MonitoringTestCtx) ValidateMonitoringCRCreation(t *testing.T) {
 	t.Helper()
 
+	// Initial check: Monitoring CR should exist but might be Not Ready if no features are enabled
 	tc.updateMonitoringConfig(withManagementState(operatorv1.Managed))
 
 	tc.EnsureResourcesExist(
@@ -366,11 +433,62 @@ func (tc *MonitoringTestCtx) ValidateMonitoringCRCreation(t *testing.T) {
 				HaveLen(1),
 				HaveEach(And(
 					jq.Match(`.metadata.ownerReferences[0].kind == "%s"`, gvk.DSCInitialization.Kind),
+					jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, status.ConditionTypeProvisioningSucceeded, metav1.ConditionTrue),
+				)),
+			),
+		),
+	)
+
+	// To reach Ready=True, we must enable at least one feature (e.g. metrics)
+	tc.setupMetrics(t)
+
+	tc.EnsureResourcesExist(
+		WithMinimalObject(gvk.Monitoring, types.NamespacedName{Name: MonitoringCRName}),
+		WithCondition(
+			And(
+				HaveLen(1),
+				HaveEach(And(
 					jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, status.ConditionTypeReady, metav1.ConditionTrue),
 					jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, status.ConditionTypeProvisioningSucceeded, metav1.ConditionTrue),
 				)),
 			),
 		),
+	)
+}
+
+// ValidateMonitoringReadyConditionOnDSCI verifies that mirrored conditions
+// are propagated to DSCI status when monitoring is Managed and the Monitoring CR is ready.
+func (tc *MonitoringTestCtx) ValidateMonitoringReadyConditionOnDSCI(t *testing.T) {
+	t.Helper()
+
+	tc.EnsureResourceExists(
+		WithMinimalObject(gvk.DSCInitialization, tc.DSCInitializationNamespacedName),
+		WithCondition(And(
+			jq.Match(`.status.phase == "%s"`, status.PhaseReady),
+			// Mirrored conditions from Monitoring CR
+			jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, status.ConditionTypeReady, metav1.ConditionTrue),
+			jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, status.ConditionTypeProvisioningSucceeded, metav1.ConditionTrue),
+			// Base condition
+			jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, status.ConditionMonitoringReady, metav1.ConditionTrue),
+			jq.Match(`.status.conditions[] | select(.type == "%s") | .reason == "%s"`, status.ConditionMonitoringReady, status.ReadyReason),
+		)),
+		WithCustomErrorMsg("DSCI should have mirrored Ready=True and ProvisioningSucceeded=True PLUS MonitoringReady=True when monitoring is Managed and Monitoring CR is ready"),
+	)
+}
+
+// ValidateMonitoringReadyConditionDisabledOnDSCI verifies that the MonitoringReady condition
+// is set to False on DSCI when monitoring is disabled (Removed).
+func (tc *MonitoringTestCtx) ValidateMonitoringReadyConditionDisabledOnDSCI(t *testing.T) {
+	t.Helper()
+
+	tc.EnsureResourceExists(
+		WithMinimalObject(gvk.DSCInitialization, tc.DSCInitializationNamespacedName),
+		WithCondition(And(
+			jq.Match(`.status.phase == "%s"`, status.PhaseReady),
+			jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, status.ConditionMonitoringReady, metav1.ConditionFalse),
+			jq.Match(`.status.conditions[] | select(.type == "%s") | .reason == "%s"`, status.ConditionMonitoringReady, status.RemovedReason),
+		)),
+		WithCustomErrorMsg("DSCI should have MonitoringReady=False with reason Removed when monitoring is disabled"),
 	)
 }
 
@@ -532,6 +650,7 @@ func (tc *MonitoringTestCtx) ValidateOpenTelemetryCollectorConfigurations(t *tes
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Helper()
+			t.Cleanup(tc.resetMonitoringConfigToManaged)
 
 			// Setup configuration first
 			tc.updateMonitoringConfig(testCase.transforms...)
@@ -564,7 +683,6 @@ func (tc *MonitoringTestCtx) ValidateOpenTelemetryCollectorConfigurations(t *tes
 			)
 
 			// Universal cleanup to prevent state contamination between tests
-			tc.resetMonitoringConfigToManaged()
 		})
 	}
 }
@@ -986,6 +1104,7 @@ func (tc *MonitoringTestCtx) ValidatePersesLifecycle(t *testing.T) {
 
 func (tc *MonitoringTestCtx) ValidatePersesNotDeployedWithoutMetricsOrTraces(t *testing.T) {
 	t.Helper()
+	t.Cleanup(tc.resetMonitoringConfigToManaged)
 
 	tc.updateMonitoringConfig(
 		withManagementState(operatorv1.Managed),
@@ -1016,8 +1135,6 @@ func (tc *MonitoringTestCtx) ValidatePersesNotDeployedWithoutMetricsOrTraces(t *
 	tc.EnsureResourceGone(
 		WithMinimalObject(gvk.Perses, types.NamespacedName{Name: PersesName, Namespace: tc.MonitoringNamespace}),
 	)
-
-	tc.resetMonitoringConfigToManaged()
 }
 
 func (tc *MonitoringTestCtx) ValidatePersesNetworkPolicy(t *testing.T) {
@@ -1184,30 +1301,42 @@ func (tc *MonitoringTestCtx) ValidateMonitoringServiceDisabled(t *testing.T) {
 	tc.resetMonitoringConfigToRemoved()
 
 	// Verify all monitoring-related resources are cleaned up.
-	// Use EnsureResourceGone (singular/Get-by-name) instead of EnsureResourcesGone
-	// (plural/namespace-wide List) because other controllers (e.g. MaaS) may create
-	// their own PersesDatasource resources in the same namespace. A List would pick
-	// those up and fail even though monitoring cleanup succeeded.
+	// Use DeleteResource with WithRemoveFinalizersOnDelete(true) for resources that
+	// are known to hang during deletion (e.g. MonitoringStack, TempoStack, TempoMonolithic).
+	// This ensures the test doesn't fail due to external operator finalization delays.
 	for _, resource := range []struct {
-		gvk  schema.GroupVersionKind
-		name string
+		gvk                schema.GroupVersionKind
+		name               string
+		forceWithFinalizer bool
 	}{
-		{gvk.Monitoring, MonitoringCRName},
-		{gvk.MonitoringStack, MonitoringStackName},
-		{gvk.TempoStack, TempoStackName},
-		{gvk.TempoMonolithic, TempoMonolithicName},
-		{gvk.OpenTelemetryCollector, OpenTelemetryCollectorName},
-		{gvk.Instrumentation, InstrumentationName},
-		{gvk.Perses, PersesName},
-		{gvk.PersesDatasource, PersesDatasourceName},
-		{gvk.PersesDatasource, ClusterPrometheusDatasourceName},
+		{gvk: gvk.Monitoring, name: MonitoringCRName},
+		{gvk: gvk.MonitoringStack, name: MonitoringStackName, forceWithFinalizer: true},
+		{gvk: gvk.TempoStack, name: TempoStackName, forceWithFinalizer: true},
+		{gvk: gvk.TempoMonolithic, name: TempoMonolithicName, forceWithFinalizer: true},
+		{gvk: gvk.OpenTelemetryCollector, name: OpenTelemetryCollectorName},
+		{gvk: gvk.Instrumentation, name: InstrumentationName},
+		{gvk: gvk.Perses, name: PersesName},
+		{gvk: gvk.PersesDatasource, name: PersesDatasourceName},
+		{gvk: gvk.PersesDatasource, name: ClusterPrometheusDatasourceName},
 	} {
-		tc.EnsureResourceGone(
-			WithMinimalObject(resource.gvk, types.NamespacedName{
-				Name:      resource.name,
-				Namespace: tc.MonitoringNamespace,
-			}),
-		)
+		if resource.forceWithFinalizer {
+			tc.DeleteResource(
+				WithMinimalObject(resource.gvk, types.NamespacedName{
+					Name:      resource.name,
+					Namespace: tc.MonitoringNamespace,
+				}),
+				WithWaitForDeletion(true),
+				WithRemoveFinalizersOnDelete(true),
+				WithIgnoreNotFound(true),
+			)
+		} else {
+			tc.EnsureResourceGone(
+				WithMinimalObject(resource.gvk, types.NamespacedName{
+					Name:      resource.name,
+					Namespace: tc.MonitoringNamespace,
+				}),
+			)
+		}
 	}
 }
 
@@ -1230,16 +1359,21 @@ func (tc *MonitoringTestCtx) ensureMonitoringCleanSlate(t *testing.T, secretName
 		WithWaitForDeletion(true),
 	)
 
-	// Forcefully delete TempoMonolithic (PV backend) by removing finalizers
-	tc.DeleteResource(
-		WithMinimalObject(gvk.TempoMonolithic, types.NamespacedName{
-			Name:      TempoMonolithicName,
-			Namespace: tc.MonitoringNamespace,
-		}),
-		WithWaitForDeletion(true),
-		WithRemoveFinalizersOnDelete(true),
-		WithIgnoreNotFound(true),
-	)
+	// Forcefully delete MonitoringStack and TempoMonolithic (PV backend) by removing finalizers
+	for _, gvk := range []schema.GroupVersionKind{
+		gvk.MonitoringStack,
+		gvk.TempoMonolithic,
+	} {
+		tc.DeleteResource(
+			WithMinimalObject(gvk, types.NamespacedName{
+				Name:      tc.GetInstanceName(gvk),
+				Namespace: tc.MonitoringNamespace,
+			}),
+			WithWaitForDeletion(true),
+			WithRemoveFinalizersOnDelete(true),
+			WithIgnoreNotFound(true),
+		)
+	}
 
 	// Clean up TempoStack and associated secret (if provided)
 	tc.cleanupTempoStackAndSecret(secretName)
@@ -1691,6 +1825,7 @@ func withMonitoringTraces(backend, secret, size, retention string) testf.Transfo
 // ValidateThanosQuerierDeployment tests that ThanosQuerier CR and Route are created when metrics are configured and ThanosQuerier CRD is available.
 func (tc *MonitoringTestCtx) ValidateThanosQuerierDeployment(t *testing.T) {
 	t.Helper()
+	t.Cleanup(tc.resetMonitoringConfigToManaged)
 
 	tc.updateMonitoringConfig(
 		withManagementState(operatorv1.Managed),
@@ -1737,11 +1872,11 @@ func (tc *MonitoringTestCtx) ValidateThanosQuerierDeployment(t *testing.T) {
 	)
 
 	// Cleanup: Reset monitoring configuration
-	tc.resetMonitoringConfigToManaged()
 }
 
 func (tc *MonitoringTestCtx) ValidateThanosQuerierNotDeployedWithoutMetrics(t *testing.T) {
 	t.Helper()
+	t.Cleanup(tc.resetMonitoringConfigToManaged)
 
 	tc.updateMonitoringConfig(
 		withManagementState(operatorv1.Managed),
@@ -1777,13 +1912,13 @@ func (tc *MonitoringTestCtx) ValidateThanosQuerierNotDeployedWithoutMetrics(t *t
 	)
 
 	// Cleanup: Reset monitoring configuration
-	tc.resetMonitoringConfigToManaged()
 }
 
 // ValidatePrometheusNetworkPolicyAllowsThanosQuerier tests that the Prometheus instance NetworkPolicy
 // includes an ingress rule allowing the Thanos Querier to reach the Thanos Sidecar on gRPC port 10901.
 func (tc *MonitoringTestCtx) ValidatePrometheusNetworkPolicyAllowsThanosQuerier(t *testing.T) {
 	t.Helper()
+	t.Cleanup(tc.resetMonitoringConfigToManaged)
 
 	tc.updateMonitoringConfig(
 		withManagementState(operatorv1.Managed),
@@ -1830,6 +1965,7 @@ func (tc *MonitoringTestCtx) ValidatePrometheusNetworkPolicyAllowsThanosQuerier(
 // and properly configured with the correct serverName to fix TLS SANs mismatch issues.
 func (tc *MonitoringTestCtx) ValidatePrometheusSelfServiceMonitorTLSFix(t *testing.T) {
 	t.Helper()
+	t.Cleanup(tc.resetMonitoringConfigToManaged)
 
 	tc.updateMonitoringConfig(
 		withManagementState(operatorv1.Managed),
@@ -1893,8 +2029,6 @@ func (tc *MonitoringTestCtx) ValidatePrometheusSelfServiceMonitorTLSFix(t *testi
 		)),
 		WithCustomErrorMsg("Prometheus StatefulSet should have at least one ready replica, indicating healthy operation"),
 	)
-
-	tc.resetMonitoringConfigToManaged()
 }
 
 // ValidateOwnerReferenceConsistency verifies that ownerReferences on monitoring resources
@@ -2630,6 +2764,7 @@ func (tc *MonitoringTestCtx) ValidatePersesDatasourceTLSWithGCSBackend(t *testin
 // ValidateTargetAllocatorNotDeployedWithoutMetrics tests that the Target Allocator is not deployed when metrics are not configured.
 func (tc *MonitoringTestCtx) ValidateTargetAllocatorNotDeployedWithoutMetrics(t *testing.T) {
 	t.Helper()
+	t.Cleanup(tc.resetMonitoringConfigToManaged)
 
 	tc.updateMonitoringConfig(
 		withManagementState(operatorv1.Managed),
@@ -2671,13 +2806,12 @@ func (tc *MonitoringTestCtx) ValidateTargetAllocatorNotDeployedWithoutMetrics(t 
 			Namespace: tc.MonitoringNamespace,
 		}),
 	)
-
-	tc.resetMonitoringConfigToManaged()
 }
 
 // ValidateTargetAllocatorDeploymentWithMetrics tests that the Target Allocator is deployed and ready when metrics are configured.
 func (tc *MonitoringTestCtx) ValidateTargetAllocatorDeploymentWithMetrics(t *testing.T) {
 	t.Helper()
+	t.Cleanup(tc.resetMonitoringConfigToManaged)
 
 	tc.updateMonitoringConfig(
 		withManagementState(operatorv1.Managed),
@@ -2721,13 +2855,12 @@ func (tc *MonitoringTestCtx) ValidateTargetAllocatorDeploymentWithMetrics(t *tes
 		)),
 		WithCustomErrorMsg("Target Allocator Deployment should be created and available"),
 	)
-
-	tc.resetMonitoringConfigToManaged()
 }
 
 // ValidateTargetAllocatorServiceAndConfigMap tests that the Target Allocator Service and ConfigMap are created correctly.
 func (tc *MonitoringTestCtx) ValidateTargetAllocatorServiceAndConfigMap(t *testing.T) {
 	t.Helper()
+	t.Cleanup(tc.resetMonitoringConfigToManaged)
 
 	tc.updateMonitoringConfig(
 		withManagementState(operatorv1.Managed),
@@ -2754,13 +2887,12 @@ func (tc *MonitoringTestCtx) ValidateTargetAllocatorServiceAndConfigMap(t *testi
 		}),
 		WithCustomErrorMsg("Target Allocator ConfigMap should be created by OpenTelemetry Operator"),
 	)
-
-	tc.resetMonitoringConfigToManaged()
 }
 
 // ValidateTargetAllocatorLifecycle tests the complete lifecycle of Target Allocator deployment and cleanup.
 func (tc *MonitoringTestCtx) ValidateTargetAllocatorLifecycle(t *testing.T) {
 	t.Helper()
+	t.Cleanup(tc.resetMonitoringConfigToManaged)
 
 	// Step 1: Enable metrics to deploy Target Allocator
 	tc.updateMonitoringConfig(
@@ -2805,13 +2937,12 @@ func (tc *MonitoringTestCtx) ValidateTargetAllocatorLifecycle(t *testing.T) {
 		WithCondition(jq.Match(`.status.readyReplicas >= 1`)),
 		WithCustomErrorMsg("Target Allocator should be recreated when metrics are re-enabled"),
 	)
-
-	tc.resetMonitoringConfigToManaged()
 }
 
 // ValidateTargetAllocatorRBACConfiguration tests that Target Allocator has correct RBAC permissions.
 func (tc *MonitoringTestCtx) ValidateTargetAllocatorRBACConfiguration(t *testing.T) {
 	t.Helper()
+	t.Cleanup(tc.resetMonitoringConfigToManaged)
 
 	tc.updateMonitoringConfig(
 		withManagementState(operatorv1.Managed),
@@ -2858,6 +2989,199 @@ func (tc *MonitoringTestCtx) ValidateTargetAllocatorRBACConfiguration(t *testing
 		)),
 		WithCustomErrorMsg("ClusterRoleBinding should bind Target Allocator ClusterRole to ServiceAccount"),
 	)
+}
 
-	tc.resetMonitoringConfigToManaged()
+// ValidateMonitoringMetricsNegativeConditions tests the propagation of negative conditions for Metrics.
+func (tc *MonitoringTestCtx) ValidateMonitoringMetricsNegativeConditions(t *testing.T) {
+	t.Helper()
+	t.Cleanup(tc.resetMonitoringConfigToManaged)
+
+	tc.updateMonitoringConfig(
+		withManagementState(operatorv1.Managed),
+		withNoMetrics(),
+	)
+
+	// Verify MetricsNotConfigured reason is present in Monitoring CR
+	tc.EnsureResourceExists(
+		WithMinimalObject(gvk.Monitoring, types.NamespacedName{Name: MonitoringCRName}),
+		WithCondition(And(
+			jq.Match(`[.status.conditions[] | select(.type=="%s" and .reason=="%s")] | length==1`,
+				status.ConditionMonitoringStackAvailable, status.MetricsNotConfiguredReason),
+			jq.Match(`[.status.conditions[] | select(.type=="%s" and .reason=="%s")] | length==1`,
+				status.ConditionThanosQuerierAvailable, status.MetricsNotConfiguredReason),
+		)),
+	)
+
+	// Verify these conditions are mirrored to DSCI
+	tc.EnsureResourceExists(
+		WithMinimalObject(gvk.DSCInitialization, tc.DSCInitializationNamespacedName),
+		WithCondition(And(
+			jq.Match(`[.status.conditions[] | select(.type=="%s" and .reason=="%s")] | length==1`,
+				status.ConditionMonitoringStackAvailable, status.MetricsNotConfiguredReason),
+		)),
+	)
+
+	// Cleanup: Reset monitoring configuration
+}
+
+// ValidateMonitoringTracesNegativeConditions tests the propagation of negative conditions for Traces.
+func (tc *MonitoringTestCtx) ValidateMonitoringTracesNegativeConditions(t *testing.T) {
+	t.Helper()
+	t.Cleanup(tc.resetMonitoringConfigToManaged)
+
+	tc.updateMonitoringConfig(
+		withManagementState(operatorv1.Managed),
+		withNoTraces(),
+	)
+
+	// Verify TracesNotConfigured reason is present in Monitoring CR
+	tc.EnsureResourceExists(
+		WithMinimalObject(gvk.Monitoring, types.NamespacedName{Name: MonitoringCRName}),
+		WithCondition(And(
+			jq.Match(`[.status.conditions[] | select(.type=="%s" and .reason=="%s")] | length==1`,
+				status.ConditionTempoAvailable, status.TracesNotConfiguredReason),
+			jq.Match(`[.status.conditions[] | select(.type=="%s" and .reason=="%s")] | length==1`,
+				status.ConditionInstrumentationAvailable, status.TracesNotConfiguredReason),
+		)),
+	)
+
+	// Verify these conditions are mirrored to DSCI
+	tc.EnsureResourceExists(
+		WithMinimalObject(gvk.DSCInitialization, tc.DSCInitializationNamespacedName),
+		WithCondition(And(
+			jq.Match(`[.status.conditions[] | select(.type=="%s" and .reason=="%s")] | length==1`,
+				status.ConditionTempoAvailable, status.TracesNotConfiguredReason),
+		)),
+	)
+
+	// Cleanup: Reset monitoring configuration
+}
+
+// ValidateMonitoringAlertingNegativeConditions tests the propagation of negative conditions for Alerting.
+func (tc *MonitoringTestCtx) ValidateMonitoringAlertingNegativeConditions(t *testing.T) {
+	t.Helper()
+	t.Cleanup(tc.resetMonitoringConfigToManaged)
+
+	tc.updateMonitoringConfig(
+		withManagementState(operatorv1.Managed),
+		withNoAlerting(),
+	)
+
+	// Verify AlertingNotConfigured reason is present in Monitoring CR
+	tc.EnsureResourceExists(
+		WithMinimalObject(gvk.Monitoring, types.NamespacedName{Name: MonitoringCRName}),
+		WithCondition(jq.Match(`[.status.conditions[] | select(.type=="%s" and .reason=="%s")] | length==1`,
+			status.ConditionAlertingAvailable, status.AlertingNotConfiguredReason)),
+	)
+
+	// Verify mirrored to DSCI
+	tc.EnsureResourceExists(
+		WithMinimalObject(gvk.DSCInitialization, tc.DSCInitializationNamespacedName),
+		WithCondition(And(
+			jq.Match(`[.status.conditions[] | select(.type=="%s" and .reason=="%s")] | length==1`,
+				status.ConditionAlertingAvailable, status.AlertingNotConfiguredReason),
+		)),
+	)
+}
+
+// ValidateMonitoringPersesNegativeConditions tests the propagation of negative conditions for Perses.
+func (tc *MonitoringTestCtx) ValidateMonitoringPersesNegativeConditions(t *testing.T) {
+	t.Helper()
+	t.Cleanup(tc.resetMonitoringConfigToManaged)
+
+	// Perses requires at least Metrics or Traces
+	tc.updateMonitoringConfig(
+		withManagementState(operatorv1.Managed),
+		withNoMetrics(),
+		withNoTraces(),
+	)
+
+	// Verify Perses conditions with negative reasons
+	tc.EnsureResourceExists(
+		WithMinimalObject(gvk.Monitoring, types.NamespacedName{Name: MonitoringCRName}),
+		WithCondition(And(
+			// Ready: True
+			jq.Match(`[.status.conditions[] | select(.type=="%s" and .status=="%s")] | length==1`,
+				status.ConditionTypeReady, metav1.ConditionTrue),
+			// PersesAvailable: MetricsNotConfiguredAndTracesNotConfigured
+			jq.Match(`[.status.conditions[] | select(.type=="%s" and .reason=="%s")] | length==1`,
+				status.ConditionPersesAvailable, status.MetricsNotConfiguredReason+"And"+status.TracesNotConfiguredReason),
+			// PersesTempoDataSourceAvailable: TracesNotConfigured
+			jq.Match(`[.status.conditions[] | select(.type=="%s" and .reason=="%s")] | length==1`,
+				status.ConditionPersesTempoDataSourceAvailable, status.TracesNotConfiguredReason),
+			// PersesPrometheusDataSourceAvailable: MetricsNotConfigured
+			jq.Match(`[.status.conditions[] | select(.type=="%s" and .reason=="%s")] | length==1`,
+				status.ConditionPersesPrometheusDataSourceAvailable, status.MetricsNotConfiguredReason),
+		)),
+	)
+
+	// Verify mirrored to DSCI
+	tc.EnsureResourceExists(
+		WithMinimalObject(gvk.DSCInitialization, tc.DSCInitializationNamespacedName),
+		WithCondition(And(
+			jq.Match(`[.status.conditions[] | select(.type=="%s" and .reason=="%s")] | length==1`,
+				status.ConditionPersesAvailable, status.MetricsNotConfiguredReason+"And"+status.TracesNotConfiguredReason),
+		)),
+	)
+}
+
+// ValidateMonitoringNodeMetricsNegativeConditions tests negative conditions for NodeMetricsEndpoint.
+func (tc *MonitoringTestCtx) ValidateMonitoringNodeMetricsNegativeConditions(t *testing.T) {
+	t.Helper()
+	t.Cleanup(tc.resetMonitoringConfigToManaged)
+
+	tc.updateMonitoringConfig(
+		withManagementState(operatorv1.Managed),
+		withNoMetrics(),
+	)
+
+	tc.EnsureResourceExists(
+		WithMinimalObject(gvk.Monitoring, types.NamespacedName{Name: MonitoringCRName}),
+		WithCondition(And(
+			jq.Match(`[.status.conditions[] | select(.type=="%s" and .status=="%s")] | length==1`,
+				status.ConditionTypeReady, metav1.ConditionTrue),
+			jq.Match(`[.status.conditions[] | select(.type=="%s" and .reason=="%s")] | length==1`,
+				status.ConditionNodeMetricsEndpointAvailable, status.MetricsNotConfiguredReason),
+		)),
+	)
+
+	// Verify mirrored to DSCI
+	tc.EnsureResourceExists(
+		WithMinimalObject(gvk.DSCInitialization, tc.DSCInitializationNamespacedName),
+		WithCondition(And(
+			jq.Match(`[.status.conditions[] | select(.type=="%s" and .reason=="%s")] | length==1`,
+				status.ConditionNodeMetricsEndpointAvailable, status.MetricsNotConfiguredReason),
+		)),
+	)
+}
+
+// ValidateMonitoringOpenTelemetryNegativeConditions tests negative conditions for OpenTelemetryCollector.
+func (tc *MonitoringTestCtx) ValidateMonitoringOpenTelemetryNegativeConditions(t *testing.T) {
+	t.Helper()
+	t.Cleanup(tc.resetMonitoringConfigToManaged)
+
+	tc.updateMonitoringConfig(
+		withManagementState(operatorv1.Managed),
+		withNoMetrics(),
+		withNoTraces(),
+	)
+
+	tc.EnsureResourceExists(
+		WithMinimalObject(gvk.Monitoring, types.NamespacedName{Name: MonitoringCRName}),
+		WithCondition(And(
+			jq.Match(`[.status.conditions[] | select(.type=="%s" and .status=="%s")] | length==1`,
+				status.ConditionTypeReady, metav1.ConditionTrue),
+			jq.Match(`[.status.conditions[] | select(.type=="%s" and .reason=="%s")] | length==1`,
+				status.ConditionOpenTelemetryCollectorAvailable, status.MetricsNotConfiguredReason+"And"+status.TracesNotConfiguredReason),
+		)),
+	)
+
+	// Verify mirrored to DSCI
+	tc.EnsureResourceExists(
+		WithMinimalObject(gvk.DSCInitialization, tc.DSCInitializationNamespacedName),
+		WithCondition(And(
+			jq.Match(`[.status.conditions[] | select(.type=="%s" and .reason=="%s")] | length==1`,
+				status.ConditionOpenTelemetryCollectorAvailable, status.MetricsNotConfiguredReason+"And"+status.TracesNotConfiguredReason),
+		)),
+	)
 }


### PR DESCRIPTION
<!---
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
This PR enhances the `DSCInitialization` (DSCI) controller to provide better visibility into the health and status of the Monitoring service by mirroring its conditions and integrating it into the DSCI reconciliation loop.

#### Key Changes

##### Controller Improvements
- **Monitoring CR Watcher**: Added a watcher for the `Monitoring` resource in the `DSCInitialization` controller. Changes to the `Monitoring` CR now automatically trigger a DSCI reconciliation.
- **Condition Mirroring**: The DSCI status now mirrors all sub-conditions from the `Monitoring` CR (e.g., `MonitoringStackAvailable`, `ThanosQuerierAvailable`, `TempoAvailable`, `PersesAvailable`, etc.). This ensures that component-specific statuses are visible directly on the DSCI resource.
- **Aggregate Readiness**: Implemented logic to compute an aggregate `MonitoringReady` condition in DSCI. This condition reflects the overall health of the monitoring service, forwarding degradation reasons if the underlying service is not healthy.
- **Optimization**: Pre-allocated condition slices in the status update logic to improve performance during reconciliation.

##### Testing & Maintainability
- **Comprehensive E2E Tests**: Added a suite of negative condition tests to verify how the operator handles missing dependencies (e.g., missing Prometheus or Tempo configurations).
- **Test Modularization**: Refactored the `monitoring_test.go` suite by extracting test groups into dedicated methods. This resolved `maintidx` (maintainability index) and cyclomatic complexity linting issues in CI.

<!--- Link your JIRA and related links here for reference. -->
https://redhat.atlassian.net/browse/RHOAIENG-59122

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [x] The developer has run the integration test pipeline and verified that it passed successfully
- [x] New RELATED_IMAGE mappings are already listed in ODH-Build-Config and RHOAI-Build-Config, and links are included in PR description

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [ ] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * DSCInitialization now records detailed Monitoring-related status conditions, including an aggregated "MonitoringReady" state that reflects ready, degraded, unknown, and removed scenarios, and reacts to Monitoring resource changes.

* **Tests**
  * Expanded end-to-end tests to validate Monitoring readiness propagation for enabled, disabled/removed, and multiple negative-condition scenarios across metrics, traces, alerting and related subsystems.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->