### PR TITLE
fix(e2e): use Get-by-name instead of namespace-wide List in monitoring disable test

### DIFF
--- a/tests/e2e/monitoring_test.go
+++ b/tests/e2e/monitoring_test.go
@@ -1183,7 +1183,11 @@ func (tc *MonitoringTestCtx) ValidateMonitoringServiceDisabled(t *testing.T) {
 	// Disable monitoring service
 	tc.resetMonitoringConfigToRemoved()
 
-	// Verify all monitoring-related resources are cleaned up
+	// Verify all monitoring-related resources are cleaned up.
+	// Use EnsureResourceGone (singular/Get-by-name) instead of EnsureResourcesGone
+	// (plural/namespace-wide List) because other controllers (e.g. MaaS) may create
+	// their own PersesDatasource resources in the same namespace. A List would pick
+	// those up and fail even though monitoring cleanup succeeded.
 	for _, resource := range []struct {
 		gvk  schema.GroupVersionKind
 		name string
@@ -1198,7 +1202,7 @@ func (tc *MonitoringTestCtx) ValidateMonitoringServiceDisabled(t *testing.T) {
 		{gvk.PersesDatasource, PersesDatasourceName},
 		{gvk.PersesDatasource, ClusterPrometheusDatasourceName},
 	} {
-		tc.EnsureResourcesGone(
+		tc.EnsureResourceGone(
 			WithMinimalObject(resource.gvk, types.NamespacedName{
 				Name:      resource.name,
 				Namespace: tc.MonitoringNamespace,


### PR DESCRIPTION
ValidateMonitoringServiceDisabled used EnsureResourcesGone (List) to verify PersesDatasource cleanup. This lists ALL PersesDatasource resources in the namespace, but the MaaS controller creates its own (kuadrant-prometheus-datasource) which is not owned by monitoring. The List finds it and the test times out waiting for it to disappear.


Made-with: Cursor

<!---
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully
- [ ] New RELATED_IMAGE mappings are already listed in ODH-Build-Config and RHOAI-Build-Config, and links are included in PR description

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [ ] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved monitoring cleanup validation to be more precise and reliable, reducing false test failures caused by external factors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->