### PR TITLE
feat: add SparkConnect e2e test for server provisioning

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -81,6 +81,7 @@ require (
 	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/pprof v0.0.0-20260115054156-294ebfa9ad83 // indirect
 	github.com/google/uuid v1.6.0 // indirect
+	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/huandu/xstrings v1.5.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
@@ -90,10 +91,12 @@ require (
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
+	github.com/moby/spdystream v0.5.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
+	github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.1 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,8 @@ github.com/Masterminds/semver/v3 v3.4.0 h1:Zog+i5UMtVoCU8oKka5P7i9q9HgrJeGzI9SA1
 github.com/Masterminds/semver/v3 v3.4.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/Masterminds/sprig/v3 v3.3.0 h1:mQh0Yrg1XPo6vjYXgtf5OtijNAKJRNcTdOOGZe3tPhs=
 github.com/Masterminds/sprig/v3 v3.3.0/go.mod h1:Zy1iXRYNqNLUolqCpL4uhk6SHUMAOSCzdgBfDb35Lz0=
+github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
+github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=
@@ -108,6 +110,8 @@ github.com/google/pprof v0.0.0-20260115054156-294ebfa9ad83 h1:z2ogiKUYzX5Is6zr/v
 github.com/google/pprof v0.0.0-20260115054156-294ebfa9ad83/go.mod h1:MxpfABSjhmINe3F1It9d+8exIHFvUqtLIRCdOGNXqiI=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674 h1:JeSE6pjso5THxAzdVpqr6/geYxZytqFMBCOtn/ujyeo=
+github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674/go.mod h1:r4w70xmWCQKmi1ONH4KIaBptdivuRPyosB9RmPlGEwA=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY2I=
 github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
@@ -151,6 +155,8 @@ github.com/mitchellh/copystructure v1.2.0 h1:vpKXTN4ewci03Vljg/q9QvCGUDttBOGBIa1
 github.com/mitchellh/copystructure v1.2.0/go.mod h1:qLl+cE2AmVv+CoeAwDPye/v+N2HKCj9FbZEVFJRxO9s=
 github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zxSIeXaQ=
 github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
+github.com/moby/spdystream v0.5.0 h1:7r0J1Si3QO/kjRitvSLVVFUjxMEb/YLj6S9FF62JBCU=
+github.com/moby/spdystream v0.5.0/go.mod h1:xBAYlnt/ay+11ShkdFKNAG7LsyK/tmNBVvVOwrfMgdI=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
@@ -161,6 +167,8 @@ github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00 h1:n6/
 github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00/go.mod h1:Pm3mSP3c5uWn86xMLZ5Sa7JB9GsEZySvHYXCTK4E9q4=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
+github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f h1:y5//uYreIhSUg3J1GEMiLbxo1LJaP8RfCpH6pymGZus=
+github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
 github.com/onsi/ginkgo/v2 v2.28.1 h1:S4hj+HbZp40fNKuLUQOYLDgZLwNUVn19N3Atb98NCyI=
 github.com/onsi/ginkgo/v2 v2.28.1/go.mod h1:CLtbVInNckU3/+gC8LzkGUb9oF+e8W8TdUsxPwvdOgE=
 github.com/onsi/gomega v1.39.1 h1:1IJLAad4zjPn2PsnhH70V4DKRFlrCzGBNrNaru+Vf28=

--- a/pkg/cluster/gvk/gvk.go
+++ b/pkg/cluster/gvk/gvk.go
@@ -997,4 +997,10 @@ var (
 		Version: "v1beta2",
 		Kind:    "ScheduledSparkApplication",
 	}
+
+	SparkConnect = schema.GroupVersionKind{
+		Group:   "sparkoperator.k8s.io",
+		Version: "v1alpha1",
+		Kind:    "SparkConnect",
+	}
 )

--- a/tests/e2e/sparkoperator_test.go
+++ b/tests/e2e/sparkoperator_test.go
@@ -1,13 +1,21 @@
 package e2e_test
 
 import (
+	"bytes"
+	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/rs/xid"
 	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/remotecommand"
+	ctrlcfg "sigs.k8s.io/controller-runtime/pkg/client/config"
 
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/api/components/v1alpha1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
@@ -16,8 +24,9 @@ import (
 )
 
 const (
-	sparkVersion = "4.0.1"
-	sparkImage   = "quay.io/opendatahub/data-processing:Spark-v" + sparkVersion
+	sparkVersion       = "4.0.1"
+	sparkImage         = "quay.io/opendatahub/data-processing:Spark-v" + sparkVersion
+	pysparkClientImage = "quay.io/fedora/python-312:latest"
 )
 
 type SparkOperatorTestCtx struct {
@@ -42,6 +51,7 @@ func sparkOperatorTestSuite(t *testing.T) {
 		{"Validate component releases", componentCtx.ValidateComponentReleases},
 		{"Validate SparkPi workload execution", componentCtx.ValidateSparkPiWorkload},
 		{"Validate ScheduledSparkApplication workload execution", componentCtx.ValidateScheduledSparkPiWorkload},
+		{"Validate SparkConnect server provisioning", componentCtx.ValidateSparkConnectServer},
 		{"Validate resource deletion recovery", componentCtx.ValidateAllDeletionRecovery},
 		{"Validate component disabled", componentCtx.ValidateComponentDisabled},
 	}
@@ -256,6 +266,204 @@ func (tc *SparkOperatorTestCtx) createScheduledSparkPiApplication(name, namespac
 				"successfulRunHistoryLimit": int64(1),
 				"failedRunHistoryLimit":     int64(1),
 				"template":                  sparkPiSpec(),
+			},
+		},
+	}
+}
+
+// ValidateSparkConnectServer validates that a SparkConnect server can be provisioned
+// and a separate PySpark client pod can connect and execute a query via the Spark Connect protocol.
+func (tc *SparkOperatorTestCtx) ValidateSparkConnectServer(t *testing.T) {
+	t.Helper()
+
+	sparkConnectName := "spark-connect-" + xid.New().String()
+	clientPodName := "pyspark-client-" + xid.New().String()
+	namespace := tc.AppsNamespace
+	containerName := "pyspark-client"
+
+	t.Logf("Creating SparkConnect %s in namespace %s", sparkConnectName, namespace)
+	sparkConnect := tc.createSparkConnectInstance(sparkConnectName, namespace)
+
+	tc.EventuallyResourceCreatedOrUpdated(
+		WithObjectToCreate(sparkConnect),
+		WithCustomErrorMsg("Failed to create SparkConnect %s", sparkConnectName),
+	)
+
+	defer func() {
+		t.Logf("Cleaning up SparkConnect %s", sparkConnectName)
+		tc.DeleteResource(
+			WithMinimalObject(gvk.SparkConnect, types.NamespacedName{Name: sparkConnectName, Namespace: namespace}),
+			WithIgnoreNotFound(true),
+			WithWaitForDeletion(true),
+		)
+	}()
+
+	t.Logf("Waiting for SparkConnect %s to reach Ready state", sparkConnectName)
+	tc.EnsureResourceExists(
+		WithMinimalObject(gvk.SparkConnect, types.NamespacedName{Name: sparkConnectName, Namespace: namespace}),
+		WithCondition(
+			jq.Match(`.status.state == "Ready"`),
+		),
+		WithCustomErrorMsg("SparkConnect %s did not reach Ready state", sparkConnectName),
+		WithEventuallyTimeout(tc.TestTimeouts.defaultEventuallyTimeout),
+		WithEventuallyPollingInterval(tc.TestTimeouts.defaultEventuallyPollInterval),
+	)
+
+	t.Logf("Creating PySpark client pod %s", clientPodName)
+	clientPod := createPySparkClientPod(clientPodName, namespace)
+
+	tc.EventuallyResourceCreatedOrUpdated(
+		WithObjectToCreate(clientPod),
+		WithCustomErrorMsg("Failed to create PySpark client pod %s", clientPodName),
+	)
+
+	defer func() {
+		t.Logf("Cleaning up PySpark client pod %s", clientPodName)
+		tc.DeleteResource(
+			WithMinimalObject(gvk.Pod, types.NamespacedName{Name: clientPodName, Namespace: namespace}),
+			WithIgnoreNotFound(true),
+			WithWaitForDeletion(true),
+		)
+	}()
+
+	t.Logf("Waiting for PySpark client pod %s to be Running", clientPodName)
+	tc.EnsureResourceExists(
+		WithMinimalObject(gvk.Pod, types.NamespacedName{Name: clientPodName, Namespace: namespace}),
+		WithCondition(
+			jq.Match(`.status.phase == "Running"`),
+		),
+		WithCustomErrorMsg("PySpark client pod %s is not Running", clientPodName),
+		WithEventuallyTimeout(tc.TestTimeouts.defaultEventuallyTimeout),
+		WithEventuallyPollingInterval(tc.TestTimeouts.defaultEventuallyPollInterval),
+	)
+
+	t.Logf("Installing Python dependencies in client pod %s", clientPodName)
+	pipCmd := "pip install --quiet --disable-pip-version-check 'pyspark[connect]' pandas pyarrow grpcio grpcio-status zstandard"
+	_, pipStderr, err := execInPod(namespace, clientPodName, containerName, []string{"sh", "-c", pipCmd})
+	require.NoError(t, err, "pip install failed in pod %s: stderr=%s", clientPodName, pipStderr)
+
+	connectURL := fmt.Sprintf("sc://%s-server.%s.svc.cluster.local:15002", sparkConnectName, namespace)
+	pyScript := fmt.Sprintf(`
+from pyspark.sql import SparkSession
+spark = SparkSession.builder.remote("%s").getOrCreate()
+df = spark.range(100).selectExpr("id", "id * 2 as doubled")
+print("ROW_COUNT=" + str(df.count()))
+spark.stop()
+`, connectURL)
+
+	t.Logf("Executing PySpark query from client pod %s against %s", clientPodName, connectURL)
+	stdout, stderr, err := execInPod(namespace, clientPodName, containerName, []string{"python3", "-c", pyScript})
+	require.NoError(t, err, "PySpark query failed in pod %s: stderr=%s", clientPodName, stderr)
+	require.Contains(t, stdout, "ROW_COUNT=100", "Expected ROW_COUNT=100 in output, got: %s", stdout)
+
+	t.Logf("SparkConnect %s successfully executed PySpark query from client pod (ROW_COUNT=100)", sparkConnectName)
+}
+
+// execInPod executes a command in a container and returns stdout, stderr, and any error.
+func execInPod(namespace, podName, containerName string, command []string) (string, string, error) {
+	config, err := ctrlcfg.GetConfig()
+	if err != nil {
+		return "", "", fmt.Errorf("failed to get Kubernetes config: %w", err)
+	}
+
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return "", "", fmt.Errorf("failed to create clientset: %w", err)
+	}
+
+	req := clientset.CoreV1().RESTClient().Post().
+		Resource("pods").
+		Name(podName).
+		Namespace(namespace).
+		SubResource("exec").
+		VersionedParams(&corev1.PodExecOptions{
+			Container: containerName,
+			Command:   command,
+			Stdout:    true,
+			Stderr:    true,
+		}, scheme.ParameterCodec)
+
+	exec, err := remotecommand.NewSPDYExecutor(config, "POST", req.URL())
+	if err != nil {
+		return "", "", fmt.Errorf("failed to create SPDY executor: %w", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	var stdout, stderr bytes.Buffer
+	err = exec.StreamWithContext(ctx, remotecommand.StreamOptions{
+		Stdout: &stdout,
+		Stderr: &stderr,
+	})
+
+	return stdout.String(), stderr.String(), err
+}
+
+func (tc *SparkOperatorTestCtx) createSparkConnectInstance(name, namespace string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "sparkoperator.k8s.io/v1alpha1",
+			"kind":       "SparkConnect",
+			"metadata": map[string]any{
+				"name":      name,
+				"namespace": namespace,
+			},
+			"spec": map[string]any{
+				"sparkVersion": sparkVersion,
+				"sparkConf": map[string]any{
+					"spark.driver.blockManager.port": "7079",
+				},
+				"server": map[string]any{
+					"template": map[string]any{
+						"spec": map[string]any{
+							"serviceAccount": "spark-operator-spark",
+							"containers": []any{
+								map[string]any{
+									"name":  "spark-kubernetes-driver",
+									"image": sparkImage,
+									"resources": map[string]any{
+										"requests": map[string]any{
+											"cpu":    "1",
+											"memory": "512Mi",
+										},
+										"limits": map[string]any{
+											"cpu":    "1",
+											"memory": "512Mi",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				"executor": map[string]any{
+					"instances": int64(1),
+					"cores":     int64(1),
+					"memory":    "512m",
+				},
+			},
+		},
+	}
+}
+
+func createPySparkClientPod(name, namespace string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "v1",
+			"kind":       "Pod",
+			"metadata": map[string]any{
+				"name":      name,
+				"namespace": namespace,
+			},
+			"spec": map[string]any{
+				"containers": []any{
+					map[string]any{
+						"name":    "pyspark-client",
+						"image":   pysparkClientImage,
+						"command": []any{"sleep", "infinity"},
+					},
+				},
 			},
 		},
 	}


### PR DESCRIPTION
<!---
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
Add basic smoke test coverage for SparkConnect CRD (v1alpha1) to validate that the spark-operator can provision a Spark Connect server and reach Ready state. Follows the same patterns as SparkApplication and ScheduledSparkApplication tests.
<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully
- [ ] New RELATED_IMAGE mappings are already listed in ODH-Build-Config and RHOAI-Build-Config, and links are included in PR description

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [ ] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced SparkConnect support for Apache Spark integration.

* **Tests**
  * Added comprehensive end-to-end validation tests for SparkConnect functionality, including remote query execution scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->