### PR TITLE
Added unit tests with mock client , RBAC error handling, README docs,…

### DIFF
--- a/cmd/mcp-server/INTEGRATION_TEST.md
+++ b/cmd/mcp-server/INTEGRATION_TEST.md
@@ -1,0 +1,67 @@
+# MCP Server Integration Tests
+
+Manual test guide for the 7 MCP server tools against a live cluster.
+
+## Prerequisites
+
+| Requirement | Details |
+|---|---|
+| Cluster | OpenShift/Kubernetes with `KUBECONFIG` set |
+| ODH operator | Installed in `opendatahub-operator-system` |
+| CRs | DSCI + DSC created, at least one component `Managed` |
+| Tools | `jq` installed |
+| Binary | Built via `make mcp-server` |
+
+## Setup
+
+Run all commands from the repository root. Add these helpers to your shell:
+
+```bash
+# For tools returning JSON
+call_tool() {
+  echo "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/call\",\"params\":{\"name\":\"$1\",\"arguments\":${2:-\{\}}}}" \
+    | ./bin/mcp-server 2>/dev/null | jq -r '.result.content[0].text' | jq .
+}
+
+# For tools returning plaintext (pod_logs)
+call_tool_text() {
+  echo "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/call\",\"params\":{\"name\":\"$1\",\"arguments\":${2:-\{\}}}}" \
+    | ./bin/mcp-server 2>/dev/null | jq -r '.result.content[0].text'
+}
+
+# Get operator pod name for later tests
+POD=$(kubectl get pods -n opendatahub-operator-system -o jsonpath='{.items[0].metadata.name}')
+```
+
+## Test Cases
+
+| # | Tool | Command | Expected |
+|---|------|---------|----------|
+| 1a | `platform_health` | `call_tool platform_health '{}'` | JSON with all sections (nodes, deployments, pods, etc.) |
+| 1b | `platform_health` | `call_tool platform_health '{"sections":"nodes,operator"}'` | JSON with only `nodes` and `operator` |
+| 1c | `platform_health` | `call_tool platform_health '{"layer":"infrastructure"}'` | JSON with infrastructure-layer sections only |
+| 2a | `operator_dependencies` | `call_tool operator_dependencies '{}'` | JSON array with status per dependency |
+| 2b | `operator_dependencies` | `call_tool operator_dependencies '{"name":"cert-manager"}'` | Single-entry JSON array for cert-manager |
+| 3a | `describe_resource` | `call_tool describe_resource '{"apiVersion":"dscinitialization.opendatahub.io/v2","kind":"DSCInitialization","name":"default-dsci"}'` | Full DSCI resource JSON (sensitive data redacted) |
+| 3b | `describe_resource` | `call_tool describe_resource "{\"apiVersion\":\"v1\",\"kind\":\"Pod\",\"name\":\"${POD}\",\"namespace\":\"opendatahub-operator-system\"}"` | Full pod resource JSON |
+| 4a | `recent_events` | `call_tool recent_events '{}'` | JSON array of events (may be empty if healthy) |
+| 4b | `recent_events` | `call_tool recent_events '{"namespace":"opendatahub","since":"1h"}'` | Events from `opendatahub` namespace, last hour |
+| 5 | `classify_failure` | `call_tool classify_failure '{}'` | JSON with category, subcategory, error_code, evidence, confidence |
+| 6 | `component_status` | `call_tool component_status '{"component":"dashboard"}'` | JSON with CR conditions, pod statuses, deployment readiness |
+| 7 | `pod_logs` | `call_tool_text pod_logs "{\"pod_name\":\"${POD}\",\"namespace\":\"opendatahub-operator-system\",\"tail_lines\":10}"` | 10 lines of plaintext log output |
+
+> For test 6, replace `dashboard` with whichever component is `Managed` in your DSC.
+
+## Error Scenarios
+
+| Tool | Command | Expected |
+|------|---------|----------|
+| `describe_resource` | `call_tool describe_resource '{"apiVersion":"v1","kind":"Pod","name":"does-not-exist","namespace":"opendatahub-operator-system"}'` | Not-found error message |
+| `component_status` | `call_tool component_status '{"component":"nonexistent"}'` | Component-not-found error message |
+| `pod_logs` | `call_tool_text pod_logs '{"pod_name":"does-not-exist","namespace":"opendatahub-operator-system"}'` | Pod-not-found error message |
+
+## Pass Criteria
+
+1. Valid JSON (or plaintext for `pod_logs`) returned without server crash
+2. Expected fields present in responses
+3. Error cases return descriptive messages, not stack traces

--- a/cmd/mcp-server/Makefile
+++ b/cmd/mcp-server/Makefile
@@ -7,3 +7,8 @@ mcp-server:
 .PHONY: mcp-server-test
 mcp-server-test:
 	cd cmd/mcp-server && go test ./...
+
+.PHONY: mcp-server-integration
+mcp-server-integration: mcp-server
+	@echo "See cmd/mcp-server/INTEGRATION_TEST.md for manual integration test steps"
+	@echo "Requires: KUBECONFIG set, ODH operator deployed, DSCI/DSC created"

--- a/cmd/mcp-server/README.md
+++ b/cmd/mcp-server/README.md
@@ -1,0 +1,238 @@
+# ODH MCP Server
+
+A [Model Context Protocol](https://modelcontextprotocol.io/) (MCP) server that exposes diagnostic tools for OpenDataHub clusters. It communicates over stdio using JSON-RPC, designed to be called by AI assistants (e.g. Claude Code, VS Code Copilot) or any MCP-compatible client.
+
+## Build & Run
+
+```bash
+# Build the binary
+make mcp-server
+
+# Run tests
+make mcp-server-test
+```
+
+The server requires a valid `KUBECONFIG` (or in-cluster config). Namespace defaults can be overridden via environment variables:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `E2E_TEST_OPERATOR_NAMESPACE` | `opendatahub-operator-system` | Namespace where the ODH operator is deployed |
+| `E2E_TEST_APPLICATIONS_NAMESPACE` | `opendatahub` | Namespace where ODH components are deployed |
+
+## Tool Reference
+
+### platform_health
+
+Run cluster health checks and return the full report as JSON. Checks nodes, deployments, pods, events, quotas, operator status, DSCI, and DSC.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `sections` | string | no | all | Comma-separated sections: `nodes`, `deployments`, `pods`, `events`, `quotas`, `operator`, `dsci`, `dsc` |
+| `layer` | string | no | all | Comma-separated layers: `infrastructure`, `workload`, `operator`. Ignored if `sections` is set |
+| `operator_namespace` | string | no | auto-discover (env → `opendatahub-operator-system`) | Operator namespace |
+| `applications_namespace` | string | no | auto-discover (DSCI → env → `opendatahub`) | Applications namespace |
+
+```jsonc
+// Example call
+{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"platform_health","arguments":{"sections":"nodes,operator"}}}
+
+// Example output (truncated)
+{
+  "nodes": {
+    "total": 3,
+    "ready": 3,
+    "items": [{"name": "node-1", "ready": true, "roles": "control-plane,worker", ...}]
+  },
+  "operator": {
+    "deployment": "opendatahub-operator-controller-manager",
+    "ready": true,
+    "replicas": 1,
+    "readyReplicas": 1
+  }
+}
+```
+
+### operator_dependencies
+
+Check status of dependent operators (cert-manager, Tempo, OpenTelemetry, Kueue, LWS, etc.).
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `operator_namespace` | string | no | auto-discover (env → `opendatahub-operator-system`) | Operator namespace |
+| `name` | string | no | all | Filter to a single dependency by name (e.g. `cert-manager`) |
+
+```jsonc
+// Example call
+{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"operator_dependencies","arguments":{}}}
+
+// Example output
+[
+  {"name": "cert-manager", "installed": true, "healthy": true, "version": "v1.14.0"},
+  {"name": "tempo-operator", "installed": false, "healthy": false}
+]
+```
+
+### describe_resource
+
+Get any Kubernetes resource by apiVersion/kind/name. Returns the full resource as JSON with sensitive data redacted (Secret `.data`, token fields).
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `apiVersion` | string | yes | | API version, e.g. `v1`, `apps/v1`, `datasciencecluster.opendatahub.io/v2` |
+| `kind` | string | yes | | Resource kind, e.g. `Pod`, `Deployment`, `DSCInitialization` |
+| `name` | string | yes | | Resource name |
+| `namespace` | string | no | | Namespace. Omit for cluster-scoped resources |
+
+```jsonc
+// Example call
+{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"describe_resource","arguments":{
+  "apiVersion":"dscinitialization.opendatahub.io/v2","kind":"DSCInitialization","name":"default-dsci"
+}}}
+
+// Example output (truncated)
+{
+  "apiVersion": "dscinitialization.opendatahub.io/v2",
+  "kind": "DSCInitialization",
+  "metadata": {"name": "default-dsci", "creationTimestamp": "2025-01-15T10:00:00Z", ...},
+  "spec": {"applicationsNamespace": "opendatahub", ...},
+  "status": {"phase": "Ready", "conditions": [...]}
+}
+```
+
+### recent_events
+
+Warning/error events in ODH namespaces, sorted by last timestamp (most recent first). Auto-discovers ODH namespaces from DSCI if not specified.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `namespace` | string | no | auto-discover | Comma-separated namespaces to query |
+| `since` | string | no | `5m` | Go duration for look-back window (e.g. `5m`, `1h`) |
+| `event_type` | string | no | all | Filter by type: `Warning`, `Normal` |
+
+```jsonc
+// Example call
+{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"recent_events","arguments":{"since":"1h"}}}
+
+// Example output
+[
+  {
+    "namespace": "opendatahub",
+    "name": "dashboard-pod.abc123",
+    "kind": "Pod",
+    "type": "Warning",
+    "reason": "BackOff",
+    "message": "Back-off restarting failed container",
+    "count": 5,
+    "lastTimestamp": "2025-01-15T12:30:00Z"
+  }
+]
+```
+
+### classify_failure
+
+Run cluster health checks and classify the failure deterministically. Returns a structured classification with category, subcategory, error code, evidence, and confidence.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `sections` | string | no | all | Same as `platform_health` |
+| `layer` | string | no | all | Same as `platform_health` |
+| `operator_namespace` | string | no | auto-discover (env → `opendatahub-operator-system`) | Operator namespace |
+| `applications_namespace` | string | no | auto-discover (DSCI → env → `opendatahub`) | Applications namespace |
+
+```jsonc
+// Example call
+{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"classify_failure","arguments":{}}}
+
+// Example output
+{
+  "category": "component",
+  "subcategory": "degraded",
+  "error_code": "COMP_DEGRADED",
+  "evidence": "Dashboard deployment has 0/1 ready replicas",
+  "confidence": 0.9
+}
+```
+
+### component_status
+
+Get detailed status of a specific ODH component: CR conditions, pod statuses, and deployment readiness.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `component` | string | yes | | Component name: `kserve`, `dashboard`, `workbenches`, `ray`, `trustyai`, `modelregistry`, `datasciencepipelines`, `trainingoperator`, `feastoperator`, `trainer`, `kueue`, `mlflowoperator`, `sparkoperator`, etc. |
+| `applications_namespace` | string | no | auto-discover (DSCI → env → `opendatahub`) | Applications namespace |
+
+```jsonc
+// Example call
+{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"component_status","arguments":{"component":"dashboard"}}}
+
+// Example output
+{
+  "component": "dashboard",
+  "crFound": true,
+  "conditions": [
+    {"type": "Ready", "status": "True", "reason": "Ready", "message": ""}
+  ],
+  "deployments": [
+    {"name": "odh-dashboard", "replicas": 2, "ready": 2}
+  ],
+  "pods": [
+    {"name": "odh-dashboard-abc12", "phase": "Running"},
+    {"name": "odh-dashboard-def34", "phase": "Running"}
+  ]
+}
+```
+
+### pod_logs
+
+Retrieve recent logs for a specific pod/container. Returns plaintext (not JSON).
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `pod_name` | string | yes | | Name of the pod |
+| `namespace` | string | yes | | Namespace of the pod |
+| `container` | string | no | default container | Container name |
+| `previous` | boolean | no | `false` | Return logs from the previous container instance |
+| `tail_lines` | number | no | `100` | Number of lines from the end of the log |
+
+```jsonc
+// Example call
+{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"pod_logs","arguments":{
+  "pod_name":"odh-dashboard-abc12","namespace":"opendatahub","tail_lines":10
+}}}
+```
+
+```text
+// Example output (plaintext, not JSON)
+2025-01-15T12:00:01Z INFO  Starting server on :8080
+2025-01-15T12:00:02Z INFO  Connected to database
+2025-01-15T12:00:03Z INFO  Health check passed
+...
+```
+
+Output is capped at 50KB. If exceeded, a `[truncated: output exceeded 50KB limit]` marker is appended.
+
+## Client Configuration
+
+**Claude Code:** This repo includes a `.mcp.json` at the project root — no setup needed.
+
+**Cursor / Claude Desktop:** Add to your MCP config (`.cursor/mcp.json` for Cursor, `claude_desktop_config.json` for Claude Desktop):
+
+```json
+{
+  "mcpServers": {
+    "odh-diagnostics": {
+      "command": "/absolute/path/to/opendatahub-operator/bin/mcp-server",
+      "env": {
+        "KUBECONFIG": "/absolute/path/to/.kube/config"
+      }
+    }
+  }
+}
+```
+
+Build the binary first with `make mcp-server`. The `env` block can be omitted if `KUBECONFIG` is already in your shell environment.
+
+## Integration Testing
+
+For manual testing against a live cluster, see [INTEGRATION_TEST.md](INTEGRATION_TEST.md).

--- a/cmd/mcp-server/error_helpers_test.go
+++ b/cmd/mcp-server/error_helpers_test.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"context"
+	"fmt"
+
+	k8serr "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+)
+
+func newErrorClient(err error) client.Client {
+	return fake.NewClientBuilder().
+		WithScheme(scheme.Scheme).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(_ context.Context, _ client.WithWatch, _ client.ObjectKey, _ client.Object, _ ...client.GetOption) error {
+				return err
+			},
+			List: func(_ context.Context, _ client.WithWatch, _ client.ObjectList, _ ...client.ListOption) error {
+				return err
+			},
+		}).
+		Build()
+}
+
+func newForbiddenClient() client.Client {
+	return newErrorClient(k8serr.NewForbidden(
+		schema.GroupResource{Resource: "resources"},
+		"", fmt.Errorf("forbidden")))
+}
+
+func newNoMatchClient() client.Client {
+	return newErrorClient(&meta.NoKindMatchError{
+		GroupKind:        schema.GroupKind{Group: "dscinitialization.opendatahub.io", Kind: "DSCInitialization"},
+		SearchedVersions: []string{"v1"},
+	})
+}

--- a/cmd/mcp-server/helpers.go
+++ b/cmd/mcp-server/helpers.go
@@ -1,10 +1,19 @@
 package main
 
 import (
+	"context"
+	"fmt"
 	"os"
 	"strings"
 
 	"github.com/mark3labs/mcp-go/mcp"
+	k8serr "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/clusterhealth"
 )
 
 const (
@@ -63,6 +72,44 @@ func getEnvDefault(key, fallback string) string {
 		return strings.TrimSpace(v)
 	}
 	return fallback
+}
+
+// discoverAppsNamespace reads the DSCI singleton to find spec.applicationsNamespace.
+// Falls back to env var / hardcoded default if DSCI is absent or field is empty.
+// Returns an error for RBAC or CRD issues that should not be silently masked.
+func discoverAppsNamespace(ctx context.Context, kubeClient client.Client) (string, error) {
+	fallback := getEnvDefault(envApplicationsNamespace, defaultAppsNS)
+
+	list := &unstructured.UnstructuredList{}
+	list.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   clusterhealth.DSCInitializationGVK.Group,
+		Version: clusterhealth.DSCInitializationGVK.Version,
+		Kind:    clusterhealth.DSCInitializationGVK.Kind + "List",
+	})
+	if err := kubeClient.List(ctx, list); err != nil {
+		switch {
+		case k8serr.IsForbidden(err):
+			return "", fmt.Errorf("RBAC insufficient: cannot list DSCInitialization resources: %w", err)
+		case meta.IsNoMatchError(err):
+			return "", fmt.Errorf("CRD not installed: DSCInitialization CRD is not registered on this cluster: %w", err)
+		default:
+			return "", fmt.Errorf("failed to list DSCI: %w", err)
+		}
+	}
+
+	if len(list.Items) > 0 {
+		if ns, found, _ := unstructured.NestedString(list.Items[0].Object, "spec", "applicationsNamespace"); found && ns != "" {
+			return ns, nil
+		}
+	}
+
+	return fallback, nil
+}
+
+// discoverOperatorNamespace returns the operator namespace.
+// Operator namespace is not stored in DSCI, so this wraps env var / hardcoded default.
+func discoverOperatorNamespace() string {
+	return getEnvDefault(envOperatorNamespace, defaultOperatorNS)
 }
 
 // splitTrimmed splits a comma-separated string into trimmed, non-empty parts.

--- a/cmd/mcp-server/helpers_test.go
+++ b/cmd/mcp-server/helpers_test.go
@@ -1,9 +1,15 @@
 package main
 
 import (
+	"context"
 	"testing"
 
 	"github.com/mark3labs/mcp-go/mcp"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 func TestSplitTrimmed(t *testing.T) {
@@ -69,6 +75,86 @@ func TestStringParam(t *testing.T) {
 			got := stringParam(req, tt.param, tt.fallback)
 			if got != tt.want {
 				t.Errorf("stringParam() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func newDSCI(appsNS string) *unstructured.Unstructured {
+	spec := map[string]interface{}{}
+	if appsNS != "" {
+		spec["applicationsNamespace"] = appsNS
+	}
+	return &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "dscinitialization.opendatahub.io/v2",
+			"kind":       "DSCInitialization",
+			"metadata":   map[string]interface{}{"name": "default-dsci"},
+			"spec":       spec,
+		},
+	}
+}
+
+func fakeClient(dsci *unstructured.Unstructured) client.Client {
+	s := runtime.NewScheme()
+	_ = scheme.AddToScheme(s)
+	b := fake.NewClientBuilder().WithScheme(s)
+	if dsci != nil {
+		b = b.WithRuntimeObjects(dsci)
+	}
+	return b.Build()
+}
+
+func TestDiscoverAppsNamespace(t *testing.T) {
+	tests := []struct {
+		name    string
+		dsci    *unstructured.Unstructured
+		client  client.Client
+		env     string
+		want    string
+		wantErr bool
+	}{
+		{"DSCI with custom namespace", newDSCI("custom-apps"), nil, "", "custom-apps", false},
+		{"DSCI with empty field", newDSCI(""), nil, "", defaultAppsNS, false},
+		{"no DSCI falls back to default", nil, nil, "", defaultAppsNS, false},
+		{"no DSCI uses env var", nil, nil, "env-apps", "env-apps", false},
+		{"DSCI takes precedence over env", newDSCI("dsci-apps"), nil, "env-apps", "dsci-apps", false},
+		{"RBAC forbidden ignores env var", nil, newForbiddenClient(), "env-apps", "", true},
+		{"CRD not installed ignores env var", nil, newNoMatchClient(), "custom-apps", "", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv(envApplicationsNamespace, tt.env)
+			c := tt.client
+			if c == nil {
+				c = fakeClient(tt.dsci)
+			}
+			got, err := discoverAppsNamespace(context.Background(), c)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("discoverAppsNamespace() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("discoverAppsNamespace() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDiscoverOperatorNamespace(t *testing.T) {
+	tests := []struct {
+		name string
+		env  string
+		want string
+	}{
+		{"default", "", defaultOperatorNS},
+		{"from env", "custom-operator-ns", "custom-operator-ns"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv(envOperatorNamespace, tt.env)
+			if got := discoverOperatorNamespace(); got != tt.want {
+				t.Errorf("discoverOperatorNamespace() = %q, want %q", got, tt.want)
 			}
 		})
 	}

--- a/cmd/mcp-server/tool_classify_failure.go
+++ b/cmd/mcp-server/tool_classify_failure.go
@@ -26,20 +26,33 @@ func registerClassifyFailure(s *server.MCPServer, kubeClient client.Client) {
 			mcp.Description("Comma-separated layers: infrastructure,workload,"+
 				"operator. Ignored if sections is set. Omit for all.")),
 		mcp.WithString("operator_namespace",
-			mcp.Description("Operator namespace. Default: opendatahub-operator-system")),
+			mcp.Description("Operator namespace. Auto-discovered from env or defaults to opendatahub-operator-system.")),
 		mcp.WithString("applications_namespace",
-			mcp.Description("Apps namespace. Default: opendatahub")),
+			mcp.Description("Apps namespace. Auto-discovered from DSCI if not provided. Falls back to env var or 'opendatahub'.")),
 	)
 
 	s.AddTool(tool, func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		operatorNS := stringParam(req, "operator_namespace", "")
+		if operatorNS == "" {
+			operatorNS = discoverOperatorNamespace()
+		}
+		appsNS := stringParam(req, "applications_namespace", "")
+		if appsNS == "" {
+			var err error
+			appsNS, err = discoverAppsNamespace(ctx, kubeClient)
+			if err != nil {
+				return mcp.NewToolResultError(fmt.Sprintf("namespace discovery failed: %v", err)), nil
+			}
+		}
+
 		cfg := clusterhealth.Config{
 			Client: kubeClient,
 			Operator: clusterhealth.OperatorConfig{
-				Namespace: stringParam(req, "operator_namespace", getEnvDefault(envOperatorNamespace, defaultOperatorNS)),
+				Namespace: operatorNS,
 				Name:      getEnvDefault(envOperatorDeployment, defaultOperatorDeploy),
 			},
 			Namespaces: clusterhealth.NamespaceConfig{
-				Apps:       stringParam(req, "applications_namespace", getEnvDefault(envApplicationsNamespace, defaultAppsNS)),
+				Apps:       appsNS,
 				Monitoring: getEnvDefault(envMonitoringNamespace, defaultMonitoringNS),
 				Extra:      []string{"kube-system"},
 			},

--- a/cmd/mcp-server/tool_classify_failure_test.go
+++ b/cmd/mcp-server/tool_classify_failure_test.go
@@ -3,9 +3,35 @@ package main
 import (
 	"testing"
 
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/clusterhealth"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/failureclassifier"
 )
+
+func TestClassifyFailure_ErrorClients(t *testing.T) {
+	tests := []struct {
+		name   string
+		client client.Client
+	}{
+		{"RBAC forbidden", newForbiddenClient()},
+		{"CRD not installed", newNoMatchClient()},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			report := callTool(t, tt.client, nil)
+			fc := failureclassifier.Classify(&report)
+
+			if fc.Category == "" {
+				t.Error("Category should not be empty")
+			}
+			if len(fc.Evidence) == 0 {
+				t.Error("Evidence should not be empty")
+			}
+		})
+	}
+}
 
 // TestClassifyFailure_FakeClient exercises the full Run + Classify pipeline with a fake client.
 func TestClassifyFailure_FakeClient(t *testing.T) {

--- a/cmd/mcp-server/tool_component_status.go
+++ b/cmd/mcp-server/tool_component_status.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
+	k8serr "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/clusterhealth"
@@ -20,17 +22,34 @@ func registerComponentStatus(s *server.MCPServer, kubeClient client.Client) {
 		mcp.WithString("component", mcp.Required(),
 			mcp.Description("Component name, e.g. kserve, dashboard, workbenches")),
 		mcp.WithString("applications_namespace",
-			mcp.Description("Apps namespace. Default: opendatahub")),
+			mcp.Description("Apps namespace. Auto-discovered from DSCI if not provided. Falls back to env var or 'opendatahub'.")),
 	)
 
 	s.AddTool(tool, func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		appsNS := stringParam(req, "applications_namespace", "")
+		if appsNS == "" {
+			var err error
+			appsNS, err = discoverAppsNamespace(ctx, kubeClient)
+			if err != nil {
+				return mcp.NewToolResultError(fmt.Sprintf("namespace discovery failed: %v", err)), nil
+			}
+		}
+
 		result, err := clusterhealth.GetComponentStatus(ctx, kubeClient,
 			stringParam(req, "component", ""),
-			stringParam(req, "applications_namespace",
-				getEnvDefault(envApplicationsNamespace, defaultAppsNS)),
+			appsNS,
 		)
 		if err != nil {
-			return mcp.NewToolResultError(err.Error()), nil
+			switch {
+			case k8serr.IsForbidden(err):
+				return mcp.NewToolResultError(fmt.Sprintf("RBAC insufficient: %v", err)), nil
+			case meta.IsNoMatchError(err):
+				return mcp.NewToolResultError(fmt.Sprintf(
+					"CRD not installed: component %q requires a CRD that is not registered on this cluster",
+					stringParam(req, "component", ""))), nil
+			default:
+				return mcp.NewToolResultError(err.Error()), nil
+			}
 		}
 		data, err := json.MarshalIndent(result, "", "  ")
 		if err != nil {

--- a/cmd/mcp-server/tool_component_status_test.go
+++ b/cmd/mcp-server/tool_component_status_test.go
@@ -6,7 +6,10 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	k8serr "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/clusterhealth"
 )
@@ -30,6 +33,33 @@ func TestComponentStatus(t *testing.T) {
 			t.Error("expected crFound=false")
 		}
 	})
+}
+
+func TestComponentStatus_ErrorClients(t *testing.T) {
+	components := []string{"kserve", "dashboard", "ray"}
+
+	tests := []struct {
+		name       string
+		client     client.Client
+		errorCheck func(error) bool
+	}{
+		{"RBAC forbidden", newForbiddenClient(), k8serr.IsForbidden},
+		{"CRD not installed", newNoMatchClient(), meta.IsNoMatchError},
+	}
+
+	for _, tt := range tests {
+		for _, comp := range components {
+			t.Run(tt.name+"/"+comp, func(t *testing.T) {
+				_, err := clusterhealth.GetComponentStatus(context.Background(), tt.client, comp, defaultAppsNS)
+				if err == nil {
+					t.Fatalf("expected error for component %q, got nil", comp)
+				}
+				if !tt.errorCheck(err) {
+					t.Fatalf("expected %s error, got: %v", tt.name, err)
+				}
+			})
+		}
+	}
 }
 
 func TestComponentStatus_DeploymentsAndPods(t *testing.T) {

--- a/cmd/mcp-server/tool_describe_resource_test.go
+++ b/cmd/mcp-server/tool_describe_resource_test.go
@@ -115,11 +115,27 @@ func TestDescribeResource(t *testing.T) {
 	}
 }
 
-func TestDescribeResource_NilClient(t *testing.T) {
-	_, isError := callDescribe(t, nil, map[string]any{
-		"apiVersion": "v1", "kind": "ConfigMap", "name": "x", "namespace": "default",
-	})
-	if !isError {
-		t.Error("describe with nil client should return error")
+func TestDescribeResource_ErrorClients(t *testing.T) {
+	args := map[string]any{"apiVersion": "v1", "kind": "ConfigMap", "name": "x", "namespace": "default"}
+
+	tests := []struct {
+		name   string
+		client client.Client
+	}{
+		{"nil client", nil},
+		{"RBAC forbidden", newForbiddenClient()},
+		{"CRD not installed", newNoMatchClient()},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			text, isError := callDescribe(t, tt.client, args)
+			if !isError {
+				t.Fatalf("expected isError=true, got text: %s", text)
+			}
+			if text == "" {
+				t.Error("expected non-empty error text")
+			}
+		})
 	}
 }

--- a/cmd/mcp-server/tool_operator_dependencies.go
+++ b/cmd/mcp-server/tool_operator_dependencies.go
@@ -20,16 +20,21 @@ func registerOperatorDependencies(s *server.MCPServer, kubeClient client.Client)
 			"(cert-manager, tempo, OTel, kueue, LWS, etc.). "+
 			"Returns installed/missing/unhealthy status for each."),
 		mcp.WithString("operator_namespace",
-			mcp.Description("Operator namespace. Default: opendatahub-operator-system")),
+			mcp.Description("Operator namespace. Auto-discovered from env or defaults to opendatahub-operator-system.")),
 		mcp.WithString("name",
 			mcp.Description("Filter to a specific dependent by name (e.g. cert-manager). Omit for all.")),
 	)
 
 	s.AddTool(tool, func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		operatorNS := stringParam(req, "operator_namespace", "")
+		if operatorNS == "" {
+			operatorNS = discoverOperatorNamespace()
+		}
+
 		report, err := clusterhealth.Run(ctx, clusterhealth.Config{
 			Client: kubeClient,
 			Operator: clusterhealth.OperatorConfig{
-				Namespace: stringParam(req, "operator_namespace", getEnvDefault(envOperatorNamespace, defaultOperatorNS)),
+				Namespace: operatorNS,
 				Name:      getEnvDefault(envOperatorDeployment, defaultOperatorDeploy),
 			},
 			OnlySections: []string{"operator"},

--- a/cmd/mcp-server/tool_operator_dependencies_test.go
+++ b/cmd/mcp-server/tool_operator_dependencies_test.go
@@ -202,3 +202,25 @@ func TestOperatorDependencies_NilClient(t *testing.T) {
 		t.Error("operator_dependencies with nil client should return error")
 	}
 }
+
+func TestOperatorDependencies_ErrorClients(t *testing.T) {
+	tests := []struct {
+		name   string
+		client client.Client
+	}{
+		{"RBAC forbidden", newForbiddenClient()},
+		{"CRD not installed", newNoMatchClient()},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			text, isError := callDeps(t, tt.client, map[string]any{})
+			if isError {
+				t.Fatalf("expected isError=false (errors captured per-section), got true; text: %s", text)
+			}
+			if !strings.Contains(strings.ToLower(text), "warning:") && !strings.Contains(text, `"error"`) {
+				t.Errorf("expected response to contain warning prefix or dependency error details; got: %s", text)
+			}
+		})
+	}
+}

--- a/cmd/mcp-server/tool_platform_health.go
+++ b/cmd/mcp-server/tool_platform_health.go
@@ -25,20 +25,33 @@ func registerPlatformHealth(s *server.MCPServer, kubeClient client.Client) {
 			mcp.Description("Comma-separated layers: infrastructure,workload,"+
 				"operator. Ignored if sections is set. Omit for all.")),
 		mcp.WithString("operator_namespace",
-			mcp.Description("Operator namespace. Default: opendatahub-operator-system")),
+			mcp.Description("Operator namespace. Auto-discovered from env or defaults to opendatahub-operator-system.")),
 		mcp.WithString("applications_namespace",
-			mcp.Description("Apps namespace. Default: opendatahub")),
+			mcp.Description("Apps namespace. Auto-discovered from DSCI if not provided. Falls back to env var or 'opendatahub'.")),
 	)
 
 	s.AddTool(tool, func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		operatorNS := stringParam(req, "operator_namespace", "")
+		if operatorNS == "" {
+			operatorNS = discoverOperatorNamespace()
+		}
+		appsNS := stringParam(req, "applications_namespace", "")
+		if appsNS == "" {
+			var err error
+			appsNS, err = discoverAppsNamespace(ctx, kubeClient)
+			if err != nil {
+				return mcp.NewToolResultError(fmt.Sprintf("namespace discovery failed: %v", err)), nil
+			}
+		}
+
 		cfg := clusterhealth.Config{
 			Client: kubeClient,
 			Operator: clusterhealth.OperatorConfig{
-				Namespace: stringParam(req, "operator_namespace", getEnvDefault(envOperatorNamespace, defaultOperatorNS)),
+				Namespace: operatorNS,
 				Name:      getEnvDefault(envOperatorDeployment, defaultOperatorDeploy),
 			},
 			Namespaces: clusterhealth.NamespaceConfig{
-				Apps:       stringParam(req, "applications_namespace", getEnvDefault(envApplicationsNamespace, defaultAppsNS)),
+				Apps:       appsNS,
 				Monitoring: getEnvDefault(envMonitoringNamespace, defaultMonitoringNS),
 				Extra:      []string{"kube-system"},
 			},

--- a/cmd/mcp-server/tool_platform_health_test.go
+++ b/cmd/mcp-server/tool_platform_health_test.go
@@ -3,9 +3,11 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
 	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -94,5 +96,138 @@ func TestPlatformHealth_NilClient(t *testing.T) {
 	_, err := clusterhealth.Run(context.Background(), clusterhealth.Config{})
 	if err == nil {
 		t.Error("Run(nil client) should return error")
+	}
+}
+
+func TestPlatformHealth_HandlerHappyPath(t *testing.T) {
+	cl := newFakeClient()
+	tests := []struct {
+		name string
+		args map[string]any
+		want []string
+	}{
+		{"empty arguments", map[string]any{}, nil},
+		{"explicit namespace overrides", map[string]any{
+			"operator_namespace":     "custom-op-ns",
+			"applications_namespace": "custom-apps-ns",
+			"sections":              "nodes,pods",
+		}, []string{"nodes", "pods"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := server.NewMCPServer("test", "0.0.1")
+			registerPlatformHealth(s, cl)
+			msg, _ := json.Marshal(map[string]any{
+				"jsonrpc": "2.0", "id": 1, "method": "tools/call",
+				"params": map[string]any{"name": "platform_health", "arguments": tt.args},
+			})
+			raw, _ := json.Marshal(s.HandleMessage(context.Background(), msg))
+			var rpc struct {
+				Result struct {
+					Content []struct{ Text string } `json:"content"`
+					IsError bool                    `json:"isError"`
+				} `json:"result"`
+			}
+			if err := json.Unmarshal(raw, &rpc); err != nil {
+				t.Fatalf("unmarshal rpc: %v", err)
+			}
+			if rpc.Result.IsError {
+				t.Fatalf("handler returned error: %s", rpc.Result.Content[0].Text)
+			}
+			if len(rpc.Result.Content) == 0 {
+				t.Fatal("empty content")
+			}
+			var report clusterhealth.Report
+			if err := json.Unmarshal([]byte(rpc.Result.Content[0].Text), &report); err != nil {
+				t.Fatalf("unmarshal report: %v", err)
+			}
+			if report.CollectedAt.IsZero() {
+				t.Error("CollectedAt should be non-zero")
+			}
+			if tt.want != nil {
+				if len(report.SectionsRun) != len(tt.want) {
+					t.Fatalf("SectionsRun = %v, want %v", report.SectionsRun, tt.want)
+				}
+				want := make(map[string]bool, len(tt.want))
+				for _, s := range tt.want {
+					want[s] = true
+				}
+				for _, s := range report.SectionsRun {
+					if !want[s] {
+						t.Errorf("unexpected section %q", s)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestPlatformHealth_ErrorClients(t *testing.T) {
+	tests := []struct {
+		name      string
+		client    client.Client
+		args      map[string]any
+		wantInErr string
+	}{
+		{"RBAC forbidden", newForbiddenClient(), map[string]any{
+			"applications_namespace": "opendatahub",
+			"operator_namespace":     "opendatahub-operator-system",
+		}, "forbidden"},
+		{"CRD not installed", newNoMatchClient(), map[string]any{
+			"applications_namespace": "opendatahub",
+			"operator_namespace":     "opendatahub-operator-system",
+		}, "no matches for kind"},
+		{"namespace discovery failed", newForbiddenClient(), map[string]any{}, "namespace discovery failed"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := server.NewMCPServer("test", "0.0.1")
+			registerPlatformHealth(s, tt.client)
+
+			msg, _ := json.Marshal(map[string]any{
+				"jsonrpc": "2.0", "id": 1, "method": "tools/call",
+				"params": map[string]any{"name": "platform_health", "arguments": tt.args},
+			})
+			raw, _ := json.Marshal(s.HandleMessage(context.Background(), msg))
+
+			var rpc struct {
+				Result struct {
+					Content []struct{ Text string } `json:"content"`
+					IsError bool                    `json:"isError"`
+				} `json:"result"`
+			}
+			if err := json.Unmarshal(raw, &rpc); err != nil {
+				t.Fatalf("unmarshal rpc: %v", err)
+			}
+			if len(rpc.Result.Content) == 0 {
+				t.Fatal("empty content")
+			}
+
+			text := rpc.Result.Content[0].Text
+
+			if rpc.Result.IsError {
+				if !strings.Contains(text, tt.wantInErr) {
+					t.Errorf("error text=%q, want substring %q", text, tt.wantInErr)
+				}
+				return
+			}
+
+			var report clusterhealth.Report
+			if err := json.Unmarshal([]byte(text), &report); err != nil {
+				t.Fatalf("unmarshal report: %v", err)
+			}
+
+			for _, sec := range []struct{ name, err string }{
+				{"nodes", report.Nodes.Error},
+				{"pods", report.Pods.Error},
+				{"events", report.Events.Error},
+				{"operator", report.Operator.Error},
+			} {
+				if !strings.Contains(sec.err, tt.wantInErr) {
+					t.Errorf("section %s: error=%q, want substring %q", sec.name, sec.err, tt.wantInErr)
+				}
+			}
+		})
 	}
 }

--- a/cmd/mcp-server/tool_pod_logs.go
+++ b/cmd/mcp-server/tool_pod_logs.go
@@ -74,7 +74,11 @@ func fetchPodLogs(ctx context.Context, clientset kubernetes.Interface, req mcp.C
 			case strings.Contains(msg, "not found") || strings.Contains(msg, "is not valid"):
 				return mcp.NewToolResultError(fmt.Sprintf("container not found in pod %q (namespace %q): %v", podName, namespace, err)), nil
 			}
-			fallthrough
+			return mcp.NewToolResultError(fmt.Sprintf("invalid pod log request for pod %q (namespace %q): %v", podName, namespace, err)), nil
+		case k8serr.IsForbidden(err):
+			return mcp.NewToolResultError(fmt.Sprintf(
+				"RBAC insufficient: the operator service-account lacks permission to read pod logs in namespace %q: %v",
+				namespace, err)), nil
 		default:
 			return mcp.NewToolResultError(fmt.Sprintf("pod logs error: %v", err)), nil
 		}

--- a/cmd/mcp-server/tool_pod_logs_test.go
+++ b/cmd/mcp-server/tool_pod_logs_test.go
@@ -109,6 +109,12 @@ func TestPodLogs(t *testing.T) {
 			w.Write(make([]byte, maxLogBytes+100))
 		}, map[string]interface{}{"pod_name": "my-pod", "namespace": "default"},
 			"[truncated: output exceeded 50KB limit]", false},
+		{"RBAC forbidden", func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusForbidden)
+			fmt.Fprint(w, `{"kind":"Status","apiVersion":"v1","status":"Failure","message":"pods \"my-pod\" is forbidden: User \"system:serviceaccount:test:default\" cannot get resource \"pods/log\" in API group \"\" in the namespace \"secure-ns\"","reason":"Forbidden","code":403}`)
+		}, map[string]interface{}{"pod_name": "my-pod", "namespace": "secure-ns"},
+			"RBAC insufficient", true},
 	}
 
 	for _, tt := range tests {

--- a/cmd/mcp-server/tool_recent_events.go
+++ b/cmd/mcp-server/tool_recent_events.go
@@ -9,8 +9,6 @@ import (
 
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/clusterhealth"
@@ -87,25 +85,11 @@ func registerRecentEvents(s *server.MCPServer, kubeClient client.Client) {
 // discoverODHNamespaces reads the DSCI singleton to find .spec.applicationsNamespace,
 // combined with the operator namespace for a deduplicated list.
 func discoverODHNamespaces(ctx context.Context, kubeClient client.Client) ([]string, error) {
-	appsNS := getEnvDefault(envApplicationsNamespace, defaultAppsNS)
-	operatorNS := getEnvDefault(envOperatorNamespace, defaultOperatorNS)
-
-	list := &unstructured.UnstructuredList{}
-	list.SetGroupVersionKind(schema.GroupVersionKind{
-		Group:   clusterhealth.DSCInitializationGVK.Group,
-		Version: clusterhealth.DSCInitializationGVK.Version,
-		Kind:    clusterhealth.DSCInitializationGVK.Kind + "List",
-	})
-	if err := kubeClient.List(ctx, list); err != nil {
-		return nil, fmt.Errorf("failed to list DSCI: %w", err)
+	appsNS, err := discoverAppsNamespace(ctx, kubeClient)
+	if err != nil {
+		return nil, err
 	}
-
-	if len(list.Items) > 0 {
-		if ns, found, _ := unstructured.NestedString(list.Items[0].Object, "spec", "applicationsNamespace"); found && ns != "" {
-			appsNS = ns
-		}
-	}
-
+	operatorNS := discoverOperatorNamespace()
 	if operatorNS == appsNS {
 		return []string{appsNS}, nil
 	}

--- a/cmd/mcp-server/tool_recent_events_test.go
+++ b/cmd/mcp-server/tool_recent_events_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -109,6 +110,32 @@ func TestRecentEvents_SortOrder(t *testing.T) {
 	}
 	if events[0].Name != "pod-b" {
 		t.Errorf("first event = %q, want pod-b (most recent)", events[0].Name)
+	}
+}
+
+func TestRecentEvents_ErrorClients(t *testing.T) {
+	tests := []struct {
+		name           string
+		client         client.Client
+		wantErrContains string
+	}{
+		{"RBAC forbidden", newForbiddenClient(), "forbidden"},
+		{"CRD not installed", newNoMatchClient(), "no matches for kind"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := clusterhealth.RunRecentEvents(context.Background(), clusterhealth.RecentEventsConfig{
+				Client:     tt.client,
+				Namespaces: []string{"opendatahub"},
+			})
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !strings.Contains(err.Error(), tt.wantErrContains) {
+				t.Errorf("error = %q, want substring %q", err.Error(), tt.wantErrContains)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
… and DSCI namespace auto-discovery in mcp server

<!---
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully
- [ ] New RELATED_IMAGE mappings are already listed in ODH-Build-Config and RHOAI-Build-Config, and links are included in PR description

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [ ] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **Documentation**
  * Added comprehensive MCP server README with setup instructions, tool reference, and client configuration examples.
  * Added integration test guide with setup requirements and test procedures.
  * Added Makefile target for integration testing.

* **Tests**
  * Expanded error scenario test coverage across tools to validate handling of permission issues and missing resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->