### PR TITLE
[RHOAIENG-60484] update trainer image params from torch291 to torch210

### DIFF
--- a/internal/controller/components/trainer/trainer_support.go
+++ b/internal/controller/components/trainer/trainer_support.go
@@ -24,12 +24,12 @@ var (
 		"odh-kubeflow-trainer-controller-image":           "RELATED_IMAGE_ODH_TRAINER_IMAGE",
 		"odh-training-cuda128-torch29-py312-image":        "RELATED_IMAGE_ODH_TRAINING_CUDA128_TORCH29_PY312_IMAGE",
 		"odh-training-rocm64-torch29-py312-image":         "RELATED_IMAGE_ODH_TRAINING_ROCM64_TORCH29_PY312_IMAGE",
-		"odh-th06-cuda130-torch291-py312-image":           "RELATED_IMAGE_ODH_TH06_CUDA130_TORCH291_PY312_IMAGE",
+		"odh-th06-cuda130-torch210-py312-image":           "RELATED_IMAGE_ODH_TH06_CUDA130_TORCH210_PY312_IMAGE",
 		"odh-th06-rocm64-torch291-py312-image":            "RELATED_IMAGE_ODH_TH06_ROCM64_TORCH291_PY312_IMAGE",
-		"odh-th06-cpu-torch291-py312-image":               "RELATED_IMAGE_ODH_TH06_CPU_TORCH291_PY312_IMAGE",
-		"odh-training-universal-workbench-image-cuda-3-4": "RELATED_IMAGE_ODH_TH06_CUDA130_TORCH291_PY312_IMAGE",
+		"odh-th06-cpu-torch210-py312-image":               "RELATED_IMAGE_ODH_TH06_CPU_TORCH210_PY312_IMAGE",
+		"odh-training-universal-workbench-image-cuda-3-4": "RELATED_IMAGE_ODH_TH06_CUDA130_TORCH210_PY312_IMAGE",
 		"odh-training-universal-workbench-image-rocm-3-4": "RELATED_IMAGE_ODH_TH06_ROCM64_TORCH291_PY312_IMAGE",
-		"odh-training-universal-workbench-image-cpu-3-4":  "RELATED_IMAGE_ODH_TH06_CPU_TORCH291_PY312_IMAGE",
+		"odh-training-universal-workbench-image-cpu-3-4":  "RELATED_IMAGE_ODH_TH06_CPU_TORCH210_PY312_IMAGE",
 	}
 
 	conditionTypes = []string{


### PR DESCRIPTION
## Description

Update CUDA and CPU trainer image parameter keys and env var values from `torch291` to `torch210` in `trainer_support.go` to align with upstream manifest changes in opendatahub-io/trainer#161.

ROCm images are unchanged.

https://redhat.atlassian.net/browse/RHOAIENG-60484

**Changed mappings:**
| Old Key | New Key |
|---------|---------|
| `odh-th06-cuda130-torch291-py312-image` | `odh-th06-cuda130-torch210-py312-image` |
| `odh-th06-cpu-torch291-py312-image` | `odh-th06-cpu-torch210-py312-image` |

Universal workbench env var values for CUDA and CPU also updated from `TORCH291` to `TORCH210`.

## How Has This Been Tested?

- `go vet` — passes
- `go build` — compiles cleanly
- Unit tests (`go test ./internal/controller/components/trainer/...`) — all pass
- `make generate manifests api-docs` — no new diff produced

## Screenshot or short clip

N/A — no UI changes.

## Merge criteria

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully
- [ ] New RELATED_IMAGE mappings are already listed in ODH-Build-Config and RHOAI-Build-Config, and links are included in PR description

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification

This is a non-functional change that only renames image parameter keys and env var values to match upstream manifest renames (torch291 → torch210). No controller logic, API, or runtime behavior is affected. Existing E2E test coverage for the trainer component remains valid.