### PR TITLE
fix(e2e): make triggerDSCReconciliation idempotent-safe

### DIFF
--- a/tests/e2e/v2tov3upgrade_test.go
+++ b/tests/e2e/v2tov3upgrade_test.go
@@ -204,12 +204,23 @@ func (tc *V2Tov3UpgradeTestCtx) ValidateRayRaiseErrorIfCodeFlarePresent(t *testi
 func (tc *V2Tov3UpgradeTestCtx) triggerDSCReconciliation(t *testing.T) {
 	t.Helper()
 
+	// Use a two-step toggle to guarantee a spec change even on consecutive calls.
+	// Setting dashboard = {} is idempotent, so a second call with the same value
+	// won't bump generation and no reconciliation happens.
+	tc.EventuallyResourcePatched(
+		WithMinimalObject(gvk.DataScienceCluster, tc.DataScienceClusterNamespacedName),
+		WithMutateFunc(testf.Transform(`.spec.components.dashboard.managementState = "Removed"`)),
+		WithCondition(jq.Match(`.metadata.generation == .status.observedGeneration`)),
+		WithEventuallyTimeout(tc.TestTimeouts.defaultEventuallyTimeout),
+		WithCustomErrorMsg("Failed to trigger DSC reconciliation (set dashboard to Removed)"),
+	)
+
 	tc.EventuallyResourcePatched(
 		WithMinimalObject(gvk.DataScienceCluster, tc.DataScienceClusterNamespacedName),
 		WithMutateFunc(testf.Transform(`.spec.components.dashboard = {}`)),
 		WithCondition(jq.Match(`.metadata.generation == .status.observedGeneration`)),
 		WithEventuallyTimeout(tc.TestTimeouts.defaultEventuallyTimeout),
-		WithCustomErrorMsg("Failed to trigger DSC reconciliation"),
+		WithCustomErrorMsg("Failed to trigger DSC reconciliation (reset dashboard)"),
 	)
 }
 

--- a/tests/e2e/v2tov3upgrade_test.go
+++ b/tests/e2e/v2tov3upgrade_test.go
@@ -205,22 +205,22 @@ func (tc *V2Tov3UpgradeTestCtx) triggerDSCReconciliation(t *testing.T) {
 	t.Helper()
 
 	// Use a two-step toggle to guarantee a spec change even on consecutive calls.
-	// Setting dashboard = {} is idempotent, so a second call with the same value
-	// won't bump generation and no reconciliation happens.
-	tc.EventuallyResourcePatched(
-		WithMinimalObject(gvk.DataScienceCluster, tc.DataScienceClusterNamespacedName),
-		WithMutateFunc(testf.Transform(`.spec.components.dashboard.managementState = "Removed"`)),
-		WithCondition(jq.Match(`.metadata.generation == .status.observedGeneration`)),
-		WithEventuallyTimeout(tc.TestTimeouts.defaultEventuallyTimeout),
-		WithCustomErrorMsg("Failed to trigger DSC reconciliation (set dashboard to Removed)"),
-	)
-
+	// A single idempotent patch (e.g. dashboard = {}) won't bump generation on
+	// the second call, so no reconciliation happens.
 	tc.EventuallyResourcePatched(
 		WithMinimalObject(gvk.DataScienceCluster, tc.DataScienceClusterNamespacedName),
 		WithMutateFunc(testf.Transform(`.spec.components.dashboard = {}`)),
 		WithCondition(jq.Match(`.metadata.generation == .status.observedGeneration`)),
 		WithEventuallyTimeout(tc.TestTimeouts.defaultEventuallyTimeout),
-		WithCustomErrorMsg("Failed to trigger DSC reconciliation (reset dashboard)"),
+		WithCustomErrorMsg("Failed to trigger DSC reconciliation (set dashboard to default)"),
+	)
+
+	tc.EventuallyResourcePatched(
+		WithMinimalObject(gvk.DataScienceCluster, tc.DataScienceClusterNamespacedName),
+		WithMutateFunc(testf.Transform(`.spec.components.dashboard.managementState = "Removed"`)),
+		WithCondition(jq.Match(`.metadata.generation == .status.observedGeneration`)),
+		WithEventuallyTimeout(tc.TestTimeouts.defaultEventuallyTimeout),
+		WithCustomErrorMsg("Failed to trigger DSC reconciliation (restore dashboard to Removed)"),
 	)
 }
 


### PR DESCRIPTION
## Summary
- `triggerDSCReconciliation` sets `.spec.components.dashboard = {}`, which is idempotent. When called consecutively (CodeFlare preservation test followed by ModelMeshServing preservation test), the second call produces no spec change, generation doesn't bump, and the `.metadata.generation == .status.observedGeneration` condition passes immediately without reconciliation actually running.
- The ModelMeshServing preservation test passes vacuously because no reconciliation happens, not because the resource was actually preserved through a reconciliation cycle.
- Fix: use a two-step toggle (set dashboard to `Removed`, wait for reconcile, then reset to `{}`), guaranteeing a real spec change and reconciliation on every call.

## Test plan
- [ ] Run the v2tov3 upgrade e2e test suite and verify both CodeFlare and ModelMeshServing preservation tests trigger actual reconciliation
- [ ] Verify generation bumps on both calls to `triggerDSCReconciliation`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test reliability for dashboard upgrade scenarios by simulating sequential reconciliation steps, adding synchronization checks and clearer failure messages to make test outcomes easier to interpret.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->