### PR TITLE
Add odh-ai-third-demo to manifests-config.yaml

### DIFF
--- a/build/manifests-config.yaml
+++ b/build/manifests-config.yaml
@@ -60,3 +60,6 @@ map:
   odh-spark-operator:
     src: config
     dest: sparkoperator
+  odh-ai-third-demo:
+    src: config/manifests
+    dest: opt/manifests/odh-ai-third-demo


### PR DESCRIPTION
Adds 'odh-ai-third-demo' to the operator manifests config map.

Component: odh-ai-third-demo
Manifest source path: config/manifests
Manifest dest path:   opt/manifests/odh-ai-third-demo
Upstream repo: https://github.com/rhoai-rhtap/odh-ai-third-demo @ main
Jira: https://redhat.atlassian.net/browse/RHODS-14226

**File changed:**
- `build/manifests-config.yaml` — added `odh-ai-third-demo` entry under `map:`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added manifest configuration for new component deployment.

* **Fixes**
  * Corrected formatting in build configuration file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->