### PR TITLE
fix: use DefaultCount for HWP resource limits instead of MaxCount

### DIFF
--- a/internal/webhook/hardwareprofile/mutating.go
+++ b/internal/webhook/hardwareprofile/mutating.go
@@ -1158,9 +1158,8 @@ func (i *Injector) applyIdentifiersToContainer(container any, identifiers []infr
 		return err
 	}
 
-	// Apply limits for identifiers
-	// For extended resources (GPUs, etc.), limits must equal requests (Kubernetes requirement)
-	// For standard resources (cpu, memory, ephemeral-storage), only set limits if MaxCount is specified
+	// Apply limits for all identifiers (limits = requests = DefaultCount)
+	// This ensures Guaranteed QoS class consistent with dashboard behavior
 	if err := i.applyIdentifiersToLimits(requests, limits, identifiers); err != nil {
 		return err
 	}
@@ -1212,28 +1211,22 @@ func (i *Injector) applyIdentifiersToRequests(
 }
 
 // applyIdentifiersToLimits applies hardware identifiers to resource limits map.
-// For extended resources (anything except cpu, memory, ephemeral-storage), limits must equal requests.
-// For standard resources, only set limits if MaxCount is specified in the HardwareProfile.
+// For all resources (standard and extended), limits are set equal to requests (DefaultCount).
+// This ensures Guaranteed QoS class regardless of workload creation path,
+// consistent with how the dashboard sets resources.
 //
 // Parameters:
-//   - requests: The container's resource requests map (to read values from for extended resources)
+//   - requests: The container's resource requests map (to read values from)
 //   - limits: The container's resource limits map to modify
 //   - identifiers: Array of hardware identifiers from the hardware profile
 //
 // Returns:
-//   - error: Any error encountered during identifier application or quantity conversion
+//   - error: Any error encountered during identifier application
 func (i *Injector) applyIdentifiersToLimits(
 	requests map[string]any,
 	limits map[string]any,
 	identifiers []infrav1.HardwareIdentifier,
 ) error {
-	// Standard Kubernetes resources that don't require limits to equal requests
-	standardResources := map[string]bool{
-		"cpu":               true,
-		"memory":            true,
-		"ephemeral-storage": true,
-	}
-
 	for _, identifier := range identifiers {
 		// Skip if the limit already exists (preserve existing limits)
 		if _, exists := limits[identifier.Identifier]; exists {
@@ -1246,18 +1239,10 @@ func (i *Injector) applyIdentifiersToLimits(
 			continue
 		}
 
-		// For extended resources (GPUs, etc.), limits must equal requests
-		// Since requests were set to DefaultCount, limits will also be DefaultCount
-		if !standardResources[identifier.Identifier] {
-			limits[identifier.Identifier] = requestValue
-		} else if identifier.MaxCount != nil {
-			// For standard resources, only set limit if MaxCount is specified in the HWP
-			quantity, err := convertIntOrStringToQuantity(*identifier.MaxCount)
-			if err != nil {
-				return fmt.Errorf("failed to convert max resource quantity for %s: %w", identifier.Identifier, err)
-			}
-			limits[identifier.Identifier] = quantity.String()
-		}
+		// Set limits equal to requests (DefaultCount) for all resource types.
+		// MaxCount is only used as a UI-side validation ceiling and does not
+		// flow into pod resource specs.
+		limits[identifier.Identifier] = requestValue
 	}
 	return nil
 }

--- a/internal/webhook/hardwareprofile/mutating_test.go
+++ b/internal/webhook/hardwareprofile/mutating_test.go
@@ -973,18 +973,17 @@ func TestHardwareProfile_SupportsCrossNamespaceAccess_Notebook(t *testing.T) {
 }
 
 // TestHardwareProfile_ResourceLimits_Notebook tests that hardware profiles properly apply limits:
-// - Standard resources (CPU, memory) get limits from MaxCount.
-// - Extended resources (GPU) get limits equal to requests.
+// - All resources (standard and extended) get limits equal to DefaultCount (same as requests).
+// - This ensures Guaranteed QoS class regardless of workload creation path.
 func TestHardwareProfile_ResourceLimits_Notebook(t *testing.T) {
 	t.Parallel()
 	g := NewWithT(t)
 	sch, ctx := setupTestEnvironment(t)
 
-	// Create hardware profile with CPU and memory identifiers that include MaxCount
 	hwp := envtestutil.NewHardwareProfile(testHardwareProfile, testNamespace,
 		envtestutil.WithCPUIdentifier("1", "2", "4"),                   // min: 1, default: 2, max: 4
 		envtestutil.WithMemoryIdentifier("1Gi", "2Gi", "4Gi"),          // min: 1Gi, default: 2Gi, max: 4Gi
-		envtestutil.WithGPUIdentifier("nvidia.com/gpu", "1", "1", "1"), // min: 1, default: 1, max: 1 (GPU must have equal values)
+		envtestutil.WithGPUIdentifier("nvidia.com/gpu", "1", "1", "1"), // min: 1, default: 1, max: 1
 	)
 
 	cli := fake.NewClientBuilder().WithScheme(sch).WithObjects(hwp).Build()
@@ -1010,7 +1009,6 @@ func TestHardwareProfile_ResourceLimits_Notebook(t *testing.T) {
 	g.Expect(resp.Allowed).Should(BeTrue())
 	g.Expect(resp.Patches).Should(Not(BeEmpty()))
 
-	// Verify that resources were applied with correct values
 	hasResourcesPatch := false
 	for _, patch := range resp.Patches {
 		if strings.Contains(patch.Path, "/resources") {
@@ -1031,15 +1029,13 @@ func TestHardwareProfile_ResourceLimits_Notebook(t *testing.T) {
 				g.Expect(requests["memory"]).Should(Equal("2Gi"), "Memory request should be DefaultCount")
 				g.Expect(requests["nvidia.com/gpu"]).Should(Equal("1"), "GPU request should be DefaultCount")
 
-				// Verify limits:
-				// - CPU/Memory limits should come from MaxCount
-				// - GPU limits should equal GPU requests (extended resource requirement)
+				// Verify limits are also set to DefaultCount (not MaxCount) for Guaranteed QoS
 				g.Expect(limits).Should(HaveKey("cpu"))
 				g.Expect(limits).Should(HaveKey("memory"))
 				g.Expect(limits).Should(HaveKey("nvidia.com/gpu"))
-				g.Expect(limits["cpu"]).Should(Equal("4"), "CPU limit should be MaxCount")
-				g.Expect(limits["memory"]).Should(Equal("4Gi"), "Memory limit should be MaxCount")
-				g.Expect(limits["nvidia.com/gpu"]).Should(Equal("1"), "GPU limit should equal GPU request (extended resource)")
+				g.Expect(limits["cpu"]).Should(Equal("2"), "CPU limit should be DefaultCount for Guaranteed QoS")
+				g.Expect(limits["memory"]).Should(Equal("2Gi"), "Memory limit should be DefaultCount for Guaranteed QoS")
+				g.Expect(limits["nvidia.com/gpu"]).Should(Equal("1"), "GPU limit should equal request")
 			}
 			break
 		}
@@ -1298,18 +1294,17 @@ func TestHardwareProfile_SupportsCrossNamespaceAccess_InferenceService(t *testin
 	g.Expect(resp.Patches).Should(Not(BeEmpty()))
 }
 
-// TestHardwareProfile_ResourceLimits_InferenceService tests that extended resources (GPUs) get limits equal to requests,
-// while standard resources (CPU, memory) without MaxCount don't get limits.
+// TestHardwareProfile_ResourceLimits_InferenceService tests that all resources get limits equal to
+// DefaultCount (same as requests), ensuring Guaranteed QoS regardless of MaxCount presence.
 func TestHardwareProfile_ResourceLimits_InferenceService(t *testing.T) {
 	t.Parallel()
 	g := NewWithT(t)
 	sch, ctx := setupTestEnvironment(t)
 
-	// Create hardware profile with CPU and memory identifiers without MaxCount, and GPU (extended resource)
 	hwp := envtestutil.NewHardwareProfile(testHardwareProfile, testNamespace,
 		envtestutil.WithCPUIdentifier("1", "2"),                // min: 1, default: 2 (no max)
 		envtestutil.WithMemoryIdentifier("1Gi", "2Gi"),         // min: 1Gi, default: 2Gi (no max)
-		envtestutil.WithGPUIdentifier("amd.com/gpu", "1", "1"), // min: 1, default: 1 (GPU must have equal values)
+		envtestutil.WithGPUIdentifier("amd.com/gpu", "1", "1"), // min: 1, default: 1
 	)
 
 	cli := fake.NewClientBuilder().WithScheme(sch).WithObjects(hwp).Build()
@@ -1335,21 +1330,19 @@ func TestHardwareProfile_ResourceLimits_InferenceService(t *testing.T) {
 	g.Expect(resp.Allowed).Should(BeTrue())
 	g.Expect(resp.Patches).Should(Not(BeEmpty()))
 
-	// Verify that resources were applied
 	hasResourcesPatch := false
 	for _, patch := range resp.Patches {
 		if strings.Contains(patch.Path, "/resources") {
 			hasResourcesPatch = true
 
-			// Check if the patch value contains requests and limits
 			if resourcesMap, ok := patch.Value.(map[string]any); ok {
 				requests, hasRequests := resourcesMap["requests"].(map[string]any)
 				limits, hasLimits := resourcesMap["limits"].(map[string]any)
 
 				g.Expect(hasRequests).Should(BeTrue(), "Resources patch should contain requests")
-				g.Expect(hasLimits).Should(BeTrue(), "Resources patch should contain limits for extended resources")
+				g.Expect(hasLimits).Should(BeTrue(), "Resources patch should contain limits")
 
-				// Verify requests contain all resources
+				// Verify requests contain all resources at DefaultCount
 				g.Expect(requests).Should(HaveKey("cpu"))
 				g.Expect(requests).Should(HaveKey("memory"))
 				g.Expect(requests).Should(HaveKey("amd.com/gpu"))
@@ -1357,11 +1350,13 @@ func TestHardwareProfile_ResourceLimits_InferenceService(t *testing.T) {
 				g.Expect(requests["memory"]).Should(Equal("2Gi"))
 				g.Expect(requests["amd.com/gpu"]).Should(Equal("1"))
 
-				// Verify limits: only GPU should have limits (extended resource), not CPU/memory (no MaxCount)
-				g.Expect(limits).Should(HaveKey("amd.com/gpu"), "Extended resource (GPU) should have limits")
+				// Verify limits equal requests (DefaultCount) for Guaranteed QoS
+				g.Expect(limits).Should(HaveKey("cpu"), "CPU should have limits for Guaranteed QoS")
+				g.Expect(limits["cpu"]).Should(Equal("2"), "CPU limit should equal DefaultCount")
+				g.Expect(limits).Should(HaveKey("memory"), "Memory should have limits for Guaranteed QoS")
+				g.Expect(limits["memory"]).Should(Equal("2Gi"), "Memory limit should equal DefaultCount")
+				g.Expect(limits).Should(HaveKey("amd.com/gpu"), "GPU should have limits")
 				g.Expect(limits["amd.com/gpu"]).Should(Equal("1"), "GPU limits should equal requests")
-				g.Expect(limits).ShouldNot(HaveKey("cpu"), "CPU without MaxCount should not have limits")
-				g.Expect(limits).ShouldNot(HaveKey("memory"), "Memory without MaxCount should not have limits")
 			}
 			break
 		}
@@ -1717,18 +1712,17 @@ func TestHardwareProfile_SupportsCrossNamespaceAccess_LLMInferenceService(t *tes
 	g.Expect(resp.Patches).Should(Not(BeEmpty()))
 }
 
-// TestHardwareProfile_ResourceLimits_LLMInferenceService tests that extended resources (GPUs) get limits equal to requests,
-// while standard resources (CPU, memory) without MaxCount don't get limits.
+// TestHardwareProfile_ResourceLimits_LLMInferenceService tests that all resources get limits equal to
+// DefaultCount (same as requests), ensuring Guaranteed QoS regardless of MaxCount presence.
 func TestHardwareProfile_ResourceLimits_LLMInferenceService(t *testing.T) {
 	t.Parallel()
 	g := NewWithT(t)
 	sch, ctx := setupTestEnvironment(t)
 
-	// Create hardware profile with CPU and memory identifiers without MaxCount, and GPU (extended resource)
 	hwp := envtestutil.NewHardwareProfile(testHardwareProfile, testNamespace,
 		envtestutil.WithCPUIdentifier("1", "2"),                // min: 1, default: 2 (no max)
 		envtestutil.WithMemoryIdentifier("1Gi", "2Gi"),         // min: 1Gi, default: 2Gi (no max)
-		envtestutil.WithGPUIdentifier("amd.com/gpu", "1", "1"), // min: 1, default: 1 (GPU must have equal values)
+		envtestutil.WithGPUIdentifier("amd.com/gpu", "1", "1"), // min: 1, default: 1
 	)
 
 	cli := fake.NewClientBuilder().WithScheme(sch).WithObjects(hwp).Build()
@@ -1754,7 +1748,6 @@ func TestHardwareProfile_ResourceLimits_LLMInferenceService(t *testing.T) {
 	g.Expect(resp.Allowed).Should(BeTrue())
 	g.Expect(resp.Patches).Should(Not(BeEmpty()))
 
-	// Verify that resources were applied with correct values
 	hasResourcesPatch := false
 	for _, patch := range resp.Patches {
 		if strings.Contains(patch.Path, "/resources") {
@@ -1765,9 +1758,9 @@ func TestHardwareProfile_ResourceLimits_LLMInferenceService(t *testing.T) {
 				limits, hasLimits := resourcesMap["limits"].(map[string]any)
 
 				g.Expect(hasRequests).Should(BeTrue(), "Resources patch should contain requests")
-				g.Expect(hasLimits).Should(BeTrue(), "Resources patch should contain limits for extended resources")
+				g.Expect(hasLimits).Should(BeTrue(), "Resources patch should contain limits")
 
-				// Verify requests contain all resources
+				// Verify requests contain all resources at DefaultCount
 				g.Expect(requests).Should(HaveKey("cpu"))
 				g.Expect(requests).Should(HaveKey("memory"))
 				g.Expect(requests).Should(HaveKey("amd.com/gpu"))
@@ -1775,11 +1768,13 @@ func TestHardwareProfile_ResourceLimits_LLMInferenceService(t *testing.T) {
 				g.Expect(requests["memory"]).Should(Equal("2Gi"))
 				g.Expect(requests["amd.com/gpu"]).Should(Equal("1"))
 
-				// Verify limits: only GPU should have limits (extended resource), not CPU/memory (no MaxCount)
-				g.Expect(limits).Should(HaveKey("amd.com/gpu"), "Extended resource (GPU) should have limits")
+				// Verify limits equal requests (DefaultCount) for Guaranteed QoS
+				g.Expect(limits).Should(HaveKey("cpu"), "CPU should have limits for Guaranteed QoS")
+				g.Expect(limits["cpu"]).Should(Equal("2"), "CPU limit should equal DefaultCount")
+				g.Expect(limits).Should(HaveKey("memory"), "Memory should have limits for Guaranteed QoS")
+				g.Expect(limits["memory"]).Should(Equal("2Gi"), "Memory limit should equal DefaultCount")
+				g.Expect(limits).Should(HaveKey("amd.com/gpu"), "GPU should have limits")
 				g.Expect(limits["amd.com/gpu"]).Should(Equal("1"), "GPU limits should equal requests")
-				g.Expect(limits).ShouldNot(HaveKey("cpu"), "CPU without MaxCount should not have limits")
-				g.Expect(limits).ShouldNot(HaveKey("memory"), "Memory without MaxCount should not have limits")
 			}
 			break
 		}
@@ -1789,33 +1784,29 @@ func TestHardwareProfile_ResourceLimits_LLMInferenceService(t *testing.T) {
 }
 
 // TestHardwareProfile_MixedResourceLimits_Notebook tests comprehensive limits behavior:
-// - Standard resources with MaxCount get limits from MaxCount.
-// - Standard resources without MaxCount don't get limits.
-// - Extended resources always get limits equal to requests (regardless of MaxCount).
+// - All resources (standard and extended) get limits equal to DefaultCount (same as requests).
+// - MaxCount is only a UI-side validation ceiling and does not flow into pod resource specs.
 func TestHardwareProfile_MixedResourceLimits_Notebook(t *testing.T) {
 	t.Parallel()
 	g := NewWithT(t)
 	sch, ctx := setupTestEnvironment(t)
 
-	// Create hardware profile with mixed resource types
 	hwp := envtestutil.NewHardwareProfile(testHardwareProfile, testNamespace,
 		envtestutil.WithCPUIdentifier("1", "4", "8"),                   // standard resource WITH MaxCount
 		envtestutil.WithMemoryIdentifier("2Gi", "8Gi", "16Gi"),         // standard resource WITH MaxCount
-		envtestutil.WithGPUIdentifier("nvidia.com/gpu", "2", "2", "4"), // extended resource (GPU must have equal values)
-		envtestutil.WithResourceIdentifiers(infrav1.HardwareIdentifier{ // another extended resource without MaxCount
+		envtestutil.WithGPUIdentifier("nvidia.com/gpu", "2", "2", "4"), // extended resource
+		envtestutil.WithResourceIdentifiers(infrav1.HardwareIdentifier{
 			DisplayName:  "Intel QAT",
 			Identifier:   "intel.com/qat",
 			MinCount:     intstr.FromString("1"),
 			DefaultCount: intstr.FromString("1"),
-			// No MaxCount
 			ResourceType: "Accelerator",
 		}),
-		envtestutil.WithResourceIdentifiers(infrav1.HardwareIdentifier{ // standard resource WITHOUT MaxCount (ResourceType omitted per API: CPU|Memory|Accelerator only)
+		envtestutil.WithResourceIdentifiers(infrav1.HardwareIdentifier{
 			DisplayName:  "Ephemeral Storage",
 			Identifier:   "ephemeral-storage",
 			MinCount:     intstr.FromString("1Gi"),
 			DefaultCount: intstr.FromString("10Gi"),
-			// No MaxCount; ResourceType left empty - valid enum values are CPU|Memory|Accelerator only
 		}),
 	)
 
@@ -1842,7 +1833,6 @@ func TestHardwareProfile_MixedResourceLimits_Notebook(t *testing.T) {
 	g.Expect(resp.Allowed).Should(BeTrue())
 	g.Expect(resp.Patches).Should(Not(BeEmpty()))
 
-	// Verify comprehensive limits behavior
 	hasResourcesPatch := false
 	for _, patch := range resp.Patches {
 		if strings.Contains(patch.Path, "/resources") {
@@ -1862,26 +1852,27 @@ func TestHardwareProfile_MixedResourceLimits_Notebook(t *testing.T) {
 				g.Expect(requests["intel.com/qat"]).Should(Equal("1"), "QAT request = DefaultCount")
 				g.Expect(requests["ephemeral-storage"]).Should(Equal("10Gi"), "Ephemeral storage request = DefaultCount")
 
-				// ========== Verify Limits ==========
+				// ========== Verify Limits (all should equal DefaultCount for Guaranteed QoS) ==========
 
-				// Standard resources WITH MaxCount → limits = MaxCount
-				g.Expect(limits).Should(HaveKey("cpu"), "CPU with MaxCount should have limits")
-				g.Expect(limits["cpu"]).Should(Equal("8"), "CPU limit should equal MaxCount (8)")
-				g.Expect(limits).Should(HaveKey("memory"), "Memory with MaxCount should have limits")
-				g.Expect(limits["memory"]).Should(Equal("16Gi"), "Memory limit should equal MaxCount (16Gi)")
+				// Standard resources get limits = DefaultCount (MaxCount is UI-only)
+				g.Expect(limits).Should(HaveKey("cpu"), "CPU should have limits")
+				g.Expect(limits["cpu"]).Should(Equal("4"), "CPU limit should equal DefaultCount (4), not MaxCount")
+				g.Expect(limits).Should(HaveKey("memory"), "Memory should have limits")
+				g.Expect(limits["memory"]).Should(Equal("8Gi"), "Memory limit should equal DefaultCount (8Gi), not MaxCount")
 
-				// Standard resources WITHOUT MaxCount → no limits
-				g.Expect(limits).ShouldNot(HaveKey("ephemeral-storage"),
-					"Ephemeral-storage without MaxCount should NOT have limits")
+				g.Expect(limits).Should(HaveKey("ephemeral-storage"),
+					"Ephemeral-storage should have limits for Guaranteed QoS")
+				g.Expect(limits["ephemeral-storage"]).Should(Equal("10Gi"),
+					"Ephemeral-storage limit should equal DefaultCount (10Gi)")
 
-				// Extended resources → limits = requests (regardless of MaxCount)
+				// Extended resources get limits = requests
 				g.Expect(limits).Should(HaveKey("nvidia.com/gpu"),
 					"GPU (extended resource) should have limits")
 				g.Expect(limits["nvidia.com/gpu"]).Should(Equal("2"),
-					"GPU limit should equal request (2), NOT MaxCount (4)")
+					"GPU limit should equal request (2)")
 
 				g.Expect(limits).Should(HaveKey("intel.com/qat"),
-					"QAT (extended resource) should have limits even without MaxCount")
+					"QAT (extended resource) should have limits")
 				g.Expect(limits["intel.com/qat"]).Should(Equal("1"),
 					"QAT limit should equal request (1)")
 			}


### PR DESCRIPTION
## Description
The HardwareProfile mutating webhook was setting resource limits to MaxCount for standard resources (cpu, memory, ephemeral-storage), while the dashboard sets them to DefaultCount. This caused workloads created via API/CLI to get Burstable QoS (Request < Limit) instead of Guaranteed QoS (Request = Limit), producing inconsistent behavior depending on the workload creation path.

Now limits are set equal to requests (DefaultCount) for all resource types. MaxCount continues to serve as a UI-side validation ceiling but no longer flows into pod resource specs.

Fixes: [RHOAIENG-59801](https://redhat.atlassian.net/browse/RHOAIENG-59801)

Generated-by: Claude

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [X] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [X] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [X] The developer has run the integration test pipeline and verified that it passed successfully
- [X] New RELATED_IMAGE mappings are already listed in ODH-Build-Config and RHOAI-Build-Config, and links are included in PR description

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [X] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
Minor bug fix - updated unit tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resource limits are now always set equal to requests for all resource types (CPU, memory, ephemeral storage and extended resources), ensuring Guaranteed QoS across notebooks and inference workloads.

* **Tests**
  * Updated tests to expect limits to match requests for all resources and workload types, removing prior special-case behaviors and reliance on separate max-count derivation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->