### PR TITLE
chore: reduce AGENTS.md context token usage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,31 +4,36 @@
 
 The Open Data Hub operator is a Kubernetes operator that deploys and manages a complete data science and AI/ML platform on OpenShift. It orchestrates 16 specialized components (Jupyter notebooks, KServe model serving, Ray distributed computing, ML pipelines, TrustyAI, ModelRegistry, etc.) through two primary Custom Resources: **DataScienceCluster (DSC)** for enabling/configuring components and **DSCInitialization (DSCI)** for platform-level setup. The operator uses a modern architecture with dedicated controllers per component, action-based reconciliation, and dynamic resource ownership.
 
-## CRITICAL: Required Reading for All Agents
+## Required Reading
 
-**Before starting ANY work on this project, agents MUST read the following documents in their entirety:**
+**Before starting ANY work on this project, agents MUST read these documents in their entirety:**
 
-### Core Documentation
-- @README.md - Project overview, installation, prerequisites, developer quick start
 - @CONTRIBUTING.md - PR workflow, code review, testing requirements, quality gates
 - @docs/DESIGN.md - Architecture, CRDs (DSC/DSCI), reconciliation refactor, component controllers
-- @docs/COMPONENT_INTEGRATION.md - Step-by-step guide for integrating new components
 
-### Build and Development
-- @Makefile - All build, test, deploy, and development commands (run `make help`)
+## Documentation Index
 
-### Specialized Documentation
-- @docs/troubleshooting.md - Debugging, common issues, environment setup
-- @docs/api-overview.md - Generated API reference for all CRDs
-- @docs/cloudmanager-api-overview.md - CloudManager infrastructure APIs
-- @docs/OLMDeployment.md - Operator Lifecycle Manager installation
-- @docs/integration-testing.md - Integration test architecture and execution
-- @docs/release-workflow-guide.md - Release process, branching strategy
-- @docs/ACCELERATOR_METRICS.md - GPU/accelerator metrics via OpenTelemetry
-- @docs/NAMESPACE_RESTRICTED_METRICS.md - Metrics access control and namespace isolation
-- @docs/AUTOMATED_MANIFEST_UPDATES.md - Manifest synchronization and automated updates
-- @docs/e2e-update-requirement-guidelines.md - E2E test requirements for new features
-- @docs/upgrade-testing.md - Upgrade path testing procedures
+Read these files as needed for specific tasks:
+
+### Core
+- `README.md` — Project overview, installation, prerequisites, developer guide, CR examples
+- `docs/COMPONENT_INTEGRATION.md` — Step-by-step guide for integrating new components
+
+### Build
+- `Makefile` — All build, test, deploy commands (run `make help`)
+
+### Reference
+- `docs/api-overview.md` — Generated API reference for all CRDs (large, read specific sections only)
+- `docs/cloudmanager-api-overview.md` — CloudManager infrastructure APIs
+- `docs/troubleshooting.md` — Debugging, common issues, environment setup
+- `docs/OLMDeployment.md` — Operator Lifecycle Manager installation
+- `docs/integration-testing.md` — Integration test architecture and execution
+- `docs/release-workflow-guide.md` — Release process, branching strategy
+- `docs/ACCELERATOR_METRICS.md` — GPU/accelerator metrics via OpenTelemetry
+- `docs/NAMESPACE_RESTRICTED_METRICS.md` — Metrics access control and namespace isolation
+- `docs/AUTOMATED_MANIFEST_UPDATES.md` — Manifest synchronization and automated updates
+- `docs/e2e-update-requirement-guidelines.md` — E2E test requirements for new features
+- `docs/upgrade-testing.md` — Upgrade path testing procedures
 
 ## Repository Structure
 ```


### PR DESCRIPTION
## Description

The `AGENTS.md` file had 17 `@` imports that loaded ~100k tokens of documentation into every Claude Code (and other AI agents) conversations before any work could begin. Most of those imports are reference docs that are rarely needed in full (the generated API reference alone is 42.9k tokens).

This PR removes 15 of the 17 `@` imports, keeping only `@CONTRIBUTING.md` (1.9k tokens) and `@docs/DESIGN.md` (2.8k tokens) as always-loaded context. The other 15 files are still listed in a new "Documentation Index" section as plain file paths with descriptions, so agents know where to find them and can read them on demand.

The inline content of AGENTS.md (repo structure, essential commands, architecture patterns, quality gates, critical rules, review guidance) is unchanged.

Token impact: ~104k down to ~9k per conversation start (~91% reduction).

## How Has This Been Tested?

Documentation-only change. Verified the edited file renders correctly and all file paths in the documentation index are accurate.

## Screenshot or short clip

N/A

## Merge criteria

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [x] The developer has run the integration test pipeline and verified that it passed successfully
- [x] New RELATED_IMAGE mappings are already listed in ODH-Build-Config and RHOAI-Build-Config, and links are included in PR description

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification

Documentation-only change to AGENTS.md (Claude Code context configuration). No functional code, tests, or runtime behavior affected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated developer guidelines documentation with improved organization and clarity.
  * Added new Documentation Index section with categorized reference materials for easier navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->