### PR TITLE
chore: update known issues in component-params-env

### DIFF
--- a/component-params-env.yaml
+++ b/component-params-env.yaml
@@ -28,15 +28,6 @@ known_issues:
 - image: RELATED_IMAGE_ODH_CAIKIT_NLP_IMAGE
   jira: https://redhat.atlassian.net/browse/RHOAIENG-60523
   reason: caikit-nlp support is removed since RHOAI 3.0
-- image: RELATED_IMAGE_ODH_EVAL_HUB_IMAGE
-  jira: https://redhat.enterprise.slack.com/lists/T027F3GAJ/F07SBP17R7Z?record_id=Rec0B00862M6J
-  reason: PR created, need to be merged
-- image: RELATED_IMAGE_ODH_TRUSTYAI_NEMO_GUARDRAILS_SERVER_IMAGE
-  jira: https://redhat.enterprise.slack.com/lists/T027F3GAJ/F07SBP17R7Z?record_id=Rec0B00862M6J
-  reason: PR created, need to be merged
-- image: RELATED_IMAGE_ODH_TRUSTYAI_GARAK_LLS_PROVIDER_DSP_IMAGE
-  jira: https://redhat.enterprise.slack.com/lists/T027F3GAJ/F07SBP17R7Z?record_id=Rec0B00862M6J
-  reason: need to be added the image
 - image: RELATED_IMAGE_ODH_LLM_D_KV_CACHE_IMAGE
   jira: https://redhat.atlassian.net/browse/RHOAIENG-60572
   reason: need to be added the image to ODH-Build-Config
@@ -46,3 +37,9 @@ known_issues:
 - image: RELATED_IMAGE_ODH_VLLM_CPU_IMAGE
   jira: https://redhat.atlassian.net/browse/RHOAIENG-60572
   reason: need to be added the image to ODH-Build-Config, or set an exception for the image
+- image: RELATED_IMAGE_ODH_TH06_CPU_TORCH210_PY312_IMAGE
+  jira: https://redhat.atlassian.net/browse/RHOAIENG-60758
+  reason: need to be onboarded to RHOAI 3.5-ea.1
+- image: RELATED_IMAGE_ODH_TH06_CUDA130_TORCH210_PY312_IMAGE
+  jira: https://redhat.atlassian.net/browse/RHOAIENG-60756
+  reason: need to be onboarded to RHOAI 3.5-ea.1


### PR DESCRIPTION
## Description

- Remove 3 stale known issues (EVAL_HUB, TRUSTYAI_NEMO_GUARDRAILS, TRUSTYAI_GARAK) that have been resolved
- Add 2 new known issues for images that need onboarding to RHOAI 3.5-ea.1:
  - `RELATED_IMAGE_ODH_TH06_CPU_TORCH210_PY312_IMAGE` ([RHOAIENG-60758](https://redhat.atlassian.net/browse/RHOAIENG-60758))
  - `RELATED_IMAGE_ODH_TH06_CUDA130_TORCH210_PY312_IMAGE` ([RHOAIENG-60756](https://redhat.atlassian.net/browse/RHOAIENG-60756))

## How Has This Been Tested?

Config-only change — no code logic affected.

## Merge criteria

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully
- [x] New RELATED_IMAGE mappings are listed in ODH-Build-Config and RHOAI-Build-Config (CI validates names against build-config repos). Include links to build-config PRs in the description.

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [ ] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated supported container images: removed deprecated image references and added support for new caikit-nlp and TH06 CPU/CUDA image variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->