### PR TITLE
re-add segment.io resources

### DIFF
--- a/Dockerfiles/Dockerfile
+++ b/Dockerfiles/Dockerfile
@@ -31,6 +31,9 @@ COPY config/hardwareprofiles/ /opt/manifests/hardwareprofiles
 # Copy connectionAPI removing any possibly pre-existing symlinks
 RUN rm -f /opt/manifests/connectionAPI
 COPY config/connectionAPI/ /opt/manifests/connectionAPI
+# Copy segment.io config (dashboard telemetry dependency)
+RUN rm -f /opt/manifests/segment
+COPY config/segment/ /opt/manifests/segment
 
 ################################################################################
 FROM --platform=$BUILDPLATFORM registry.access.redhat.com/ubi9/go-toolset:$GOLANG_VERSION as builder

--- a/Dockerfiles/rhoai.Dockerfile
+++ b/Dockerfiles/rhoai.Dockerfile
@@ -38,6 +38,9 @@ COPY config/hardwareprofiles/ /opt/manifests/hardwareprofiles
 # Copy connectionAPI removing any possibly pre-existing symlinks
 RUN rm -f /opt/manifests/connectionAPI
 COPY config/connectionAPI/ /opt/manifests/connectionAPI
+# Copy segment.io config (dashboard telemetry dependency)
+RUN rm -f /opt/manifests/segment
+COPY config/segment/ /opt/manifests/segment
 
 ################################################################################
 FROM --platform=$BUILDPLATFORM registry.access.redhat.com/ubi9/go-toolset:$GOLANG_VERSION as builder

--- a/config/segment/kustomization.yaml
+++ b/config/segment/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - segment-key-config.yaml
+  - segment-key-secret.yaml

--- a/config/segment/segment-key-config.yaml
+++ b/config/segment/segment-key-config.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: odh-segment-key-config
+data:
+  segmentKeyEnabled: "true"

--- a/config/segment/segment-key-secret.yaml
+++ b/config/segment/segment-key-secret.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: odh-segment-key
+type: Opaque
+data:
+  segmentKey: S1JVaG9BSUVwV2xHdXo0c1dpeGFlMXZBWEtLR2xENUs=

--- a/internal/controller/dscinitialization/dscinitialization_controller.go
+++ b/internal/controller/dscinitialization/dscinitialization_controller.go
@@ -196,6 +196,12 @@ func (r *DSCInitializationReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		}
 	}
 
+	if platform == cluster.SelfManagedRhoai {
+		if err = r.configureSegmentIO(ctx, instance); err != nil {
+			return reconcile.Result{}, err
+		}
+	}
+
 	switch instance.Spec.Monitoring.ManagementState {
 	case operatorv1.Managed:
 		if err = r.newMonitoringCR(ctx, instance); err != nil {

--- a/internal/controller/dscinitialization/utils.go
+++ b/internal/controller/dscinitialization/utils.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"maps"
+	"path/filepath"
 
 	operatorv1 "github.com/openshift/api/operator/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -18,6 +19,7 @@ import (
 	"github.com/opendatahub-io/opendatahub-operator/v2/api/common"
 	dsciv2 "github.com/opendatahub-io/opendatahub-operator/v2/api/dscinitialization/v2"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/deploy"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/metadata/labels"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/resources"
 )
@@ -197,4 +199,40 @@ func createNetworkPolicyPeer(key, value string) []networkingv1.NetworkPolicyPeer
 			MatchLabels: map[string]string{key: value},
 		},
 	}}
+}
+
+// configureSegmentIO deploys the odh-segment-key-config ConfigMap and
+// odh-segment-key Secret into the applications namespace when they do not
+// already exist.  The dashboard reads these resources to decide whether to
+// send anonymous usage telemetry; they are only required on Self-Managed
+// RHOAI clusters.
+func (r *DSCInitializationReconciler) configureSegmentIO(ctx context.Context, dsciInit *dsciv2.DSCInitialization) error {
+	log := logf.FromContext(ctx)
+
+	segmentioConfigMap := &corev1.ConfigMap{}
+	if err := r.Client.Get(ctx, client.ObjectKey{
+		Namespace: dsciInit.Spec.ApplicationsNamespace,
+		Name:      "odh-segment-key-config",
+	}, segmentioConfigMap); err != nil {
+		if !k8serr.IsNotFound(err) {
+			log.Error(err, "error getting configmap 'odh-segment-key-config'")
+			return err
+		}
+
+		segmentPath := filepath.Join(r.OperatorSettings.ManifestsBasePath, "segment")
+		if err := deploy.DeployManifestsFromPath(
+			ctx,
+			r.Client,
+			dsciInit,
+			segmentPath,
+			dsciInit.Spec.ApplicationsNamespace,
+			"segment-io",
+			true,
+		); err != nil {
+			log.Error(err, "error deploying segment.io manifests", "path", segmentPath)
+			return err
+		}
+	}
+
+	return nil
 }


### PR DESCRIPTION
<!---
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

- The creation of the segment.io resources were previously tied to the creation of the managed monitoring stack.
- The managed monitoring stack was removed but the segment.io resources are still required.

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Build operator image from this branch.
- Deploy image and create dsci
- Confirm existance of segment resources

```
$ oc get secrets -n redhat-ods-applications | grep segment
odh-segment-key                   Opaque                    1      73s
```
## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully
- [ ] New RELATED_IMAGE mappings are listed in ODH-Build-Config and RHOAI-Build-Config (CI validates names against build-config repos). Include links to build-config PRs in the description.

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->
No E2E test for a simple configmap

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new configuration and secret management resources to support external service integration.
  * Expanded platform-specific initialization workflow to handle additional configuration requirements during deployment.

* **Chores**
  * Updated Docker build configurations to include additional manifest bundles in final deployment images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->