### PR TITLE
Skip dashboard-redirect resources when Dashboard component is not deployed

### DIFF
--- a/internal/controller/components/kserve/kserve_controller_actions_test.go
+++ b/internal/controller/components/kserve/kserve_controller_actions_test.go
@@ -9,12 +9,14 @@ import (
 	"github.com/operator-framework/api/pkg/operators/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	clientFake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/api/components/v1alpha1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
@@ -24,6 +26,7 @@ import (
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/metadata/annotations"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/metadata/labels"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/fakeclient"
+	testscheme "github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/scheme"
 
 	. "github.com/onsi/gomega"
 )

--- a/internal/controller/services/gateway/dashboard_redirects.go
+++ b/internal/controller/services/gateway/dashboard_redirects.go
@@ -40,12 +40,19 @@ package gateway
 
 import (
 	"context"
+	"fmt"
 	"os"
 
+	k8serr "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
+	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/api/components/v1alpha1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
 	odhtypes "github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/resources"
 )
 
 const (
@@ -58,13 +65,29 @@ const (
 
 // createDashboardRedirects creates nginx-based redirect resources for legacy dashboard and gateway URLs.
 // This helps users transition from old route URLs to the new Gateway API URLs without breaking bookmarks.
+//
+// When Dashboard is removed (or redirects are disabled), this action explicitly deletes
+// the redirect resources rather than relying on GC. The GC action uses the owner CR's
+// metadata.generation to identify stale resources, but Dashboard removal does not change
+// GatewayConfig's generation, so GC would never clean them up.
 func createDashboardRedirects(ctx context.Context, rr *odhtypes.ReconciliationRequest) error {
 	l := logf.FromContext(ctx).WithName("createDashboardRedirects")
 
 	// Check if feature is explicitly disabled via operator environment variable
 	if os.Getenv("DISABLE_DASHBOARD_REDIRECTS") == "true" {
 		l.Info("Dashboard redirects disabled via DISABLE_DASHBOARD_REDIRECTS environment variable")
-		return nil
+		return deleteDashboardRedirectResources(ctx, rr)
+	}
+
+	// When the Dashboard component is not deployed there is no dashboard route
+	// to redirect from, so the redirect pods serve no purpose.
+	dashboard := &componentApi.Dashboard{}
+	if err := rr.Client.Get(ctx, client.ObjectKey{Name: componentApi.DashboardInstanceName}, dashboard); err != nil {
+		if k8serr.IsNotFound(err) {
+			l.Info("Dashboard CR not found, cleaning up dashboard redirect resources")
+			return deleteDashboardRedirectResources(ctx, rr)
+		}
+		return fmt.Errorf("failed to check Dashboard CR: %w", err)
 	}
 
 	gatewayConfig, err := validateGatewayConfig(rr)
@@ -72,7 +95,7 @@ func createDashboardRedirects(ctx context.Context, rr *odhtypes.ReconciliationRe
 		return err
 	}
 
-	l.V(1).Info("Creating dashboard redirect resources",
+	l.Info("Creating dashboard redirect resources",
 		"dashboardRouteName", GetDashboardRouteName(),
 		"namespace", cluster.GetApplicationNamespace(),
 		"currentSubdomain", getCurrentSubdomain(gatewayConfig))
@@ -86,6 +109,47 @@ func createDashboardRedirects(ctx context.Context, rr *odhtypes.ReconciliationRe
 		odhtypes.TemplateInfo{FS: gatewayResources, Path: dashboardRedirectDashboardRouteTemplate},
 		odhtypes.TemplateInfo{FS: gatewayResources, Path: dashboardRedirectLegacyGatewayRouteTemplate},
 	)
+
+	return nil
+}
+
+// deleteDashboardRedirectResources explicitly removes redirect resources that were
+// previously created by createDashboardRedirects.
+func deleteDashboardRedirectResources(ctx context.Context, rr *odhtypes.ReconciliationRequest) error {
+	l := logf.FromContext(ctx).WithName("deleteDashboardRedirectResources")
+	ns := cluster.GetApplicationNamespace()
+
+	names := []struct {
+		gvk  schema.GroupVersionKind
+		name string
+	}{
+		{gvk: gvk.Deployment, name: DashboardRedirectName},
+		{gvk: gvk.Service, name: DashboardRedirectName},
+		{gvk: gvk.ConfigMap, name: DashboardRedirectConfigName},
+		{gvk: gvk.Route, name: GetDashboardRouteName()},
+		{gvk: gvk.Route, name: LegacyGatewaySubdomain},
+	}
+
+	for _, r := range names {
+		obj := resources.GvkToUnstructured(r.gvk)
+		obj.SetName(r.name)
+		obj.SetNamespace(ns)
+
+		// Check existence via cached Get to avoid unnecessary Delete API calls on every reconcile
+		if err := rr.Client.Get(ctx, client.ObjectKeyFromObject(obj), obj); err != nil {
+			if k8serr.IsNotFound(err) {
+				continue
+			}
+			return fmt.Errorf("failed to get dashboard redirect resource %s/%s: %w", obj.GetKind(), r.name, err)
+		}
+		if err := rr.Client.Delete(ctx, obj); err != nil {
+			if k8serr.IsNotFound(err) {
+				continue
+			}
+			return fmt.Errorf("failed to delete dashboard redirect resource %s/%s: %w", obj.GetKind(), r.name, err)
+		}
+		l.Info("Deleted dashboard redirect resource", "kind", obj.GetKind(), "name", r.name, "namespace", ns)
+	}
 
 	return nil
 }

--- a/internal/controller/services/gateway/dashboard_redirects_test.go
+++ b/internal/controller/services/gateway/dashboard_redirects_test.go
@@ -1,0 +1,187 @@
+//go:build !integration
+
+//nolint:testpackage
+package gateway
+
+import (
+	"testing"
+
+	routev1 "github.com/openshift/api/route/v1"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/api/components/v1alpha1"
+	serviceApi "github.com/opendatahub-io/opendatahub-operator/v2/api/services/v1alpha1"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
+	odhtypes "github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/fakeclient"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestCreateDashboardRedirects_SkipsWhenDashboardNotDeployed(t *testing.T) {
+	t.Parallel()
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	gatewayConfig := &serviceApi.GatewayConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: serviceApi.GatewayConfigName,
+		},
+	}
+
+	cli, err := fakeclient.New(fakeclient.WithObjects(gatewayConfig))
+	g.Expect(err).To(Succeed())
+
+	rr := &odhtypes.ReconciliationRequest{
+		Client:   cli,
+		Instance: gatewayConfig,
+	}
+
+	err = createDashboardRedirects(ctx, rr)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(rr.Templates).To(BeEmpty(), "no redirect templates should be added when Dashboard CR does not exist")
+}
+
+func TestCreateDashboardRedirects_CreatesWhenDashboardExists(t *testing.T) {
+	t.Parallel()
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	gatewayConfig := &serviceApi.GatewayConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: serviceApi.GatewayConfigName,
+		},
+	}
+
+	dashboard := &componentApi.Dashboard{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: componentApi.DashboardInstanceName,
+		},
+	}
+
+	cli, err := fakeclient.New(fakeclient.WithObjects(gatewayConfig, dashboard))
+	g.Expect(err).To(Succeed())
+
+	rr := &odhtypes.ReconciliationRequest{
+		Client:   cli,
+		Instance: gatewayConfig,
+	}
+
+	err = createDashboardRedirects(ctx, rr)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(rr.Templates).ToNot(BeEmpty(), "redirect templates should be added when Dashboard CR exists")
+}
+
+func TestCreateDashboardRedirects_SkipsWhenEnvDisabled(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	t.Setenv("DISABLE_DASHBOARD_REDIRECTS", "true")
+
+	gatewayConfig := &serviceApi.GatewayConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: serviceApi.GatewayConfigName,
+		},
+	}
+
+	dashboard := &componentApi.Dashboard{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: componentApi.DashboardInstanceName,
+		},
+	}
+
+	cli, err := fakeclient.New(fakeclient.WithObjects(gatewayConfig, dashboard))
+	g.Expect(err).To(Succeed())
+
+	rr := &odhtypes.ReconciliationRequest{
+		Client:   cli,
+		Instance: gatewayConfig,
+	}
+
+	err = createDashboardRedirects(ctx, rr)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(rr.Templates).To(BeEmpty(), "no redirect templates should be added when DISABLE_DASHBOARD_REDIRECTS=true")
+}
+
+func TestCreateDashboardRedirects_DeletesResourcesWhenDashboardRemoved(t *testing.T) {
+	t.Parallel()
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	appNs := cluster.GetApplicationNamespace()
+
+	gatewayConfig := &serviceApi.GatewayConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: serviceApi.GatewayConfigName,
+		},
+	}
+
+	redirectDeployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      DashboardRedirectName,
+			Namespace: appNs,
+		},
+	}
+
+	redirectService := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      DashboardRedirectName,
+			Namespace: appNs,
+		},
+	}
+
+	redirectConfigMap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      DashboardRedirectConfigName,
+			Namespace: appNs,
+		},
+	}
+
+	redirectRoute := &routev1.Route{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      GetDashboardRouteName(),
+			Namespace: appNs,
+		},
+	}
+
+	legacyRoute := &routev1.Route{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      LegacyGatewaySubdomain,
+			Namespace: appNs,
+		},
+	}
+
+	cli, err := fakeclient.New(fakeclient.WithObjects(
+		gatewayConfig,
+		redirectDeployment,
+		redirectService,
+		redirectConfigMap,
+		redirectRoute,
+		legacyRoute,
+	))
+	g.Expect(err).To(Succeed())
+
+	rr := &odhtypes.ReconciliationRequest{
+		Client:   cli,
+		Instance: gatewayConfig,
+	}
+
+	err = createDashboardRedirects(ctx, rr)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(rr.Templates).To(BeEmpty(), "no redirect templates should be added when Dashboard CR does not exist")
+
+	// Verify all redirect resources were deleted
+	g.Expect(cli.Get(ctx, client.ObjectKeyFromObject(redirectDeployment), &appsv1.Deployment{})).
+		To(MatchError(ContainSubstring("not found")))
+	g.Expect(cli.Get(ctx, client.ObjectKeyFromObject(redirectService), &corev1.Service{})).
+		To(MatchError(ContainSubstring("not found")))
+	g.Expect(cli.Get(ctx, client.ObjectKeyFromObject(redirectConfigMap), &corev1.ConfigMap{})).
+		To(MatchError(ContainSubstring("not found")))
+	g.Expect(cli.Get(ctx, client.ObjectKeyFromObject(redirectRoute), &routev1.Route{})).
+		To(MatchError(ContainSubstring("not found")))
+	g.Expect(cli.Get(ctx, client.ObjectKeyFromObject(legacyRoute), &routev1.Route{})).
+		To(MatchError(ContainSubstring("not found")))
+}

--- a/internal/controller/services/gateway/gateway_controller.go
+++ b/internal/controller/services/gateway/gateway_controller.go
@@ -25,6 +25,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
 
+	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/api/components/v1alpha1"
 	serviceApi "github.com/opendatahub-io/opendatahub-operator/v2/api/services/v1alpha1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
@@ -69,6 +70,13 @@ func (h *ServiceHandler) NewReconciler(ctx context.Context, mgr ctrl.Manager) er
 			&gwapiv1.HTTPRoute{},
 			reconciler.WithEventHandler(handlers.ToNamed(serviceApi.GatewayConfigName)),
 			reconciler.WithPredicates(resources.HTTPRouteReferencesGateway(DefaultGatewayName, GatewayNamespace)),
+		).
+		// Reconcile when Dashboard CR is created or deleted so dashboard redirect
+		// resources are deployed or cleaned up accordingly.
+		Watches(
+			&componentApi.Dashboard{},
+			reconciler.WithEventHandler(handlers.ToNamed(serviceApi.GatewayConfigName)),
+			reconciler.WithPredicates(resources.CreatedOrUpdatedOrDeletedNamed(componentApi.DashboardInstanceName)),
 		).
 		WithAction(createGatewayInfrastructure).
 		WithAction(createKubeAuthProxyInfrastructure). //  include destinationrule

--- a/internal/controller/services/gateway/gateway_integration_helpers_test.go
+++ b/internal/controller/services/gateway/gateway_integration_helpers_test.go
@@ -71,6 +71,7 @@ import (
 	ctrlmetrics "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
 
+	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/api/components/v1alpha1"
 	dsciv2 "github.com/opendatahub-io/opendatahub-operator/v2/api/dscinitialization/v2"
 	serviceApi "github.com/opendatahub-io/opendatahub-operator/v2/api/services/v1alpha1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/services/gateway"
@@ -1360,6 +1361,19 @@ func RunLegacyRedirectRouteCreationTest(t *testing.T, setup TestSetup, expectedL
 	g := NewWithT(t)
 	defer setup.Setup(t)()
 
+	// Dashboard CR must exist for redirect resources (including the legacy route) to be created
+	dashboard := &componentApi.Dashboard{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: componentApi.DashboardInstanceName,
+		},
+	}
+	if err := setup.TC.K8sClient.Create(setup.TC.Ctx, dashboard); err != nil && !k8serr.IsAlreadyExists(err) {
+		t.Fatalf("Failed to create Dashboard CR: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = setup.TC.K8sClient.Delete(setup.TC.Ctx, dashboard)
+	})
+
 	legacyRouteName := gateway.LegacyGatewaySubdomain
 	legacyRouteNamespace := cluster.GetApplicationNamespace()
 	g.Eventually(func() error {
@@ -1483,11 +1497,48 @@ func RunLoadBalancerIngressModeTest(t *testing.T, tc *TestEnvContext, spec servi
 	}, TestTimeout, TestInterval).Should(BeTrue(), "OCP Route should not exist in LoadBalancer mode (GC removes stale Routes)")
 }
 
+// RunNginxDashboardRedirectSkippedWithoutDashboardTest validates that no redirect resources are created
+// when the Dashboard component CR does not exist.
+func RunNginxDashboardRedirectSkippedWithoutDashboardTest(t *testing.T, setup TestSetup) {
+	g := NewWithT(t)
+	defer setup.Setup(t)()
+
+	appNs := cluster.GetApplicationNamespace()
+
+	// Ensure Dashboard CR does not exist
+	dashboard := &componentApi.Dashboard{}
+	err := setup.TC.K8sClient.Get(setup.TC.Ctx, client.ObjectKey{Name: componentApi.DashboardInstanceName}, dashboard)
+	g.Expect(k8serr.IsNotFound(err)).To(BeTrue(), "Dashboard CR should not exist for this test")
+
+	// Verify redirect resources are not created
+	g.Consistently(func() bool {
+		cm := &corev1.ConfigMap{}
+		err := setup.TC.K8sClient.Get(setup.TC.Ctx, types.NamespacedName{
+			Name: gateway.DashboardRedirectConfigName, Namespace: appNs,
+		}, cm)
+		return k8serr.IsNotFound(err)
+	}, 5*time.Second, TestInterval).Should(BeTrue(),
+		"dashboard-redirect ConfigMap should not be created when Dashboard CR is absent")
+}
+
 // RunNginxDashboardRedirectCreationTest validates that nginx-based dashboard redirect resources exist in the application namespace:
 // ConfigMap (redirect.conf with 301 to gateway host), Deployment, Service, and dashboard Route (odh-dashboard or rhods-dashboard).
 func RunNginxDashboardRedirectCreationTest(t *testing.T, setup TestSetup) {
 	g := NewWithT(t)
 	defer setup.Setup(t)()
+
+	// Dashboard CR must exist for redirects to be created
+	dashboard := &componentApi.Dashboard{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: componentApi.DashboardInstanceName,
+		},
+	}
+	if err := setup.TC.K8sClient.Create(setup.TC.Ctx, dashboard); err != nil && !k8serr.IsAlreadyExists(err) {
+		t.Fatalf("Failed to create Dashboard CR: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = setup.TC.K8sClient.Delete(setup.TC.Ctx, dashboard)
+	})
 
 	appNs := cluster.GetApplicationNamespace()
 	nnCM := types.NamespacedName{Name: gateway.DashboardRedirectConfigName, Namespace: appNs}

--- a/internal/controller/services/gateway/gateway_oauth_integration_test.go
+++ b/internal/controller/services/gateway/gateway_oauth_integration_test.go
@@ -185,6 +185,11 @@ func TestOAuthNetworkPolicyCreation(t *testing.T) {
 	RunNetworkPolicyCreationTest(t, GetOAuthTestSetup())
 }
 
+// TestOAuthNginxDashboardRedirectSkippedWithoutDashboard validates redirects are skipped when Dashboard is not deployed in OAuth mode.
+func TestOAuthNginxDashboardRedirectSkippedWithoutDashboard(t *testing.T) {
+	RunNginxDashboardRedirectSkippedWithoutDashboardTest(t, GetOAuthTestSetup())
+}
+
 // TestOAuthNginxDashboardRedirectCreation validates nginx-based dashboard redirect resources (ConfigMap, Deployment, Service, Routes) in OAuth mode.
 func TestOAuthNginxDashboardRedirectCreation(t *testing.T) {
 	RunNginxDashboardRedirectCreationTest(t, GetOAuthTestSetup())

--- a/internal/controller/services/gateway/gateway_oidc_integration_test.go
+++ b/internal/controller/services/gateway/gateway_oidc_integration_test.go
@@ -250,6 +250,11 @@ func TestOIDCNetworkPolicyCreation(t *testing.T) {
 	RunNetworkPolicyCreationTest(t, GetOIDCTestSetup())
 }
 
+// TestOIDCNginxDashboardRedirectSkippedWithoutDashboard validates redirects are skipped when Dashboard is not deployed in OIDC mode.
+func TestOIDCNginxDashboardRedirectSkippedWithoutDashboard(t *testing.T) {
+	RunNginxDashboardRedirectSkippedWithoutDashboardTest(t, GetOIDCTestSetup())
+}
+
 // TestOIDCNginxDashboardRedirectCreation validates nginx-based dashboard redirect resources (ConfigMap, Deployment, Service, Routes) in OIDC mode.
 func TestOIDCNginxDashboardRedirectCreation(t *testing.T) {
 	RunNginxDashboardRedirectCreationTest(t, GetOIDCTestSetup())

--- a/internal/controller/services/gateway/kubebuilder_rbac.go
+++ b/internal/controller/services/gateway/kubebuilder_rbac.go
@@ -6,6 +6,9 @@ package gateway
 // +kubebuilder:rbac:groups=services.platform.opendatahub.io,resources=gatewayconfigs/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=services.platform.opendatahub.io,resources=gatewayconfigs/finalizers,verbs=update
 
+// Dashboard CR (read-only, to check if Dashboard is deployed before creating redirects)
+// +kubebuilder:rbac:groups=components.platform.opendatahub.io,resources=dashboards,verbs=get;list;watch
+
 // Gateway API resources (what the controller actually creates)
 // +kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=gateways;gatewayclasses;httproutes,verbs=get;list;watch;create;update;patch;delete
 // Gateway controller creates and manages the following Istio resources

--- a/tests/e2e/gateway_redirect_test.go
+++ b/tests/e2e/gateway_redirect_test.go
@@ -6,8 +6,10 @@ import (
 	"testing"
 	"time"
 
+	operatorv1 "github.com/openshift/api/operator/v1"
 	"k8s.io/apimachinery/pkg/types"
 
+	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/api/components/v1alpha1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/services/gateway"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/metadata/labels"
@@ -26,6 +28,11 @@ func (tc *GatewayTestCtx) DashboardRedirectTestSuite(t *testing.T) {
 		t.Skip("Dashboard redirects are only created in OcpRoute ingress mode")
 	}
 
+	// Dashboard CR must exist for redirect resources to be created.
+	// The gateway reconciler checks for the Dashboard CR and cleans up redirect
+	// resources when it is absent.
+	tc.ensureDashboardCRExists(t)
+
 	testCases := []TestCase{
 		{"Validate dashboard redirect ConfigMap", tc.ValidateDashboardRedirectConfigMap},
 		{"Validate dashboard redirect Deployment", tc.ValidateDashboardRedirectDeployment},
@@ -35,6 +42,22 @@ func (tc *GatewayTestCtx) DashboardRedirectTestSuite(t *testing.T) {
 	}
 
 	RunTestCases(t, testCases)
+}
+
+// ensureDashboardCRExists sets Dashboard to Managed in the DSC so the operator creates
+// the Dashboard CR through normal reconciliation. The gateway reconciler only creates
+// dashboard redirect resources when the Dashboard CR is present.
+// On cleanup, Dashboard is set back to Removed.
+func (tc *GatewayTestCtx) ensureDashboardCRExists(t *testing.T) {
+	t.Helper()
+
+	tc.UpdateComponentStateInDataScienceClusterWithKind(operatorv1.Managed, componentApi.DashboardKind)
+	t.Logf("Set Dashboard to Managed in DSC for redirect tests")
+
+	t.Cleanup(func() {
+		tc.UpdateComponentStateInDataScienceClusterWithKind(operatorv1.Removed, componentApi.DashboardKind)
+		t.Log("Restored Dashboard to Removed in DSC after redirect tests")
+	})
 }
 
 // ValidateDashboardRedirectConfigMap validates the nginx configuration for redirects.

--- a/tests/e2e/gateway_redirect_test.go
+++ b/tests/e2e/gateway_redirect_test.go
@@ -6,14 +6,13 @@ import (
 	"testing"
 	"time"
 
-	operatorv1 "github.com/openshift/api/operator/v1"
 	"k8s.io/apimachinery/pkg/types"
 
-	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/api/components/v1alpha1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/services/gateway"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/metadata/labels"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/matchers/jq"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/testf"
 
 	. "github.com/onsi/gomega"
 )
@@ -44,20 +43,22 @@ func (tc *GatewayTestCtx) DashboardRedirectTestSuite(t *testing.T) {
 	RunTestCases(t, testCases)
 }
 
-// ensureDashboardCRExists sets Dashboard to Managed in the DSC so the operator creates
-// the Dashboard CR through normal reconciliation. The gateway reconciler only creates
-// dashboard redirect resources when the Dashboard CR is present.
-// On cleanup, Dashboard is set back to Removed.
+// ensureDashboardCRExists sets Dashboard to Managed in the DSC and waits for the
+// Dashboard CR to be created. Unlike UpdateComponentStateInDataScienceClusterWithKind,
+// this does NOT wait for DashboardReady=True (full deployment), only for the CR to exist.
 func (tc *GatewayTestCtx) ensureDashboardCRExists(t *testing.T) {
 	t.Helper()
 
-	tc.UpdateComponentStateInDataScienceClusterWithKind(operatorv1.Managed, componentApi.DashboardKind)
-	t.Logf("Set Dashboard to Managed in DSC for redirect tests")
+	tc.EventuallyResourcePatched(
+		WithMinimalObject(gvk.DataScienceCluster, tc.DataScienceClusterNamespacedName),
+		WithMutateFunc(testf.Transform(`.spec.components.dashboard.managementState = "Managed"`)),
+		WithCondition(jq.Match(`.spec.components.dashboard.managementState == "Managed"`)),
+	)
 
-	t.Cleanup(func() {
-		tc.UpdateComponentStateInDataScienceClusterWithKind(operatorv1.Removed, componentApi.DashboardKind)
-		t.Log("Restored Dashboard to Removed in DSC after redirect tests")
-	})
+	tc.EnsureResourceExists(
+		WithMinimalObject(gvk.Dashboard, types.NamespacedName{Name: "default-dashboard"}),
+	)
+	t.Logf("Dashboard CR exists; redirect resources can now be created by gateway reconciler")
 }
 
 // ValidateDashboardRedirectConfigMap validates the nginx configuration for redirects.

--- a/tests/e2e/monitoring_test.go
+++ b/tests/e2e/monitoring_test.go
@@ -329,16 +329,8 @@ func (tc *MonitoringTestCtx) runPersesTests(t *testing.T) {
 			t.Run("Test PersesDatasource lifecycle", tc.ValidatePersesDatasourceLifecycle)
 		})
 
-		// Subgroup 3: Perses Datasource TLS with Cloud Backends
-		t.Run("Perses Datasource TLS with Cloud Backends", func(t *testing.T) {
-			t.Cleanup(func() {
-				tc.cleanupGroup(t, "s3-secret")
-				tc.cleanupGroup(t, "gcs-secret")
-			})
-
-			t.Run("Test Perses Datasource TLS with S3 backend", tc.ValidatePersesDatasourceTLSWithS3Backend)
-			t.Run("Test Perses Datasource TLS with GCS backend", tc.ValidatePersesDatasourceTLSWithGCSBackend)
-		})
+		// NOTE: Perses Datasource TLS with Cloud Backends is now validated within
+		// Group 7's ValidateTempoStackCRCreationWithCloudStorage to share the TempoStack lifecycle.
 	})
 }
 
@@ -853,7 +845,7 @@ func (tc *MonitoringTestCtx) ValidateTempoStackCRCreationWithCloudStorage(t *tes
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			tc.validateTempoStackCreationWithBackend(
+			tc.validateTempoStackCreationAndPersesTLS(
 				t,
 				testCase.backend,
 				testCase.monitoringCondition,
@@ -1413,26 +1405,43 @@ func (tc *MonitoringTestCtx) cleanupTempoStackAndSecret(secretName string) {
 //   - backend: The storage backend type (e.g., "s3", "gcs")
 //   - monitoringCondition: Gomega matcher to validate the Monitoring resource state
 //   - monitoringErrorMsg: Error message to display if Monitoring resource validation fails
-func (tc *MonitoringTestCtx) validateTempoStackCreationWithBackend(t *testing.T, backend string, monitoringCondition gTypes.GomegaMatcher, monitoringErrorMsg string) {
+//
+// validateTempoStackCreationAndPersesTLS validates both TempoStack creation with a cloud backend
+// AND PersesDatasource TLS configuration in a single TempoStack lifecycle.
+// This eliminates the need to create/delete TempoStack twice for the same backend.
+func (tc *MonitoringTestCtx) validateTempoStackCreationAndPersesTLS(t *testing.T, backend string, monitoringCondition gTypes.GomegaMatcher, monitoringErrorMsg string) {
 	t.Helper()
 
-	// Derive secret name from backend (e.g., "s3" -> "s3-secret")
 	secretName := fmt.Sprintf("%s-secret", backend)
 
-	t.Logf("Starting validateTempoStackCreationWithBackend for backend=%s, secretName=%s", backend, secretName)
+	t.Logf("Starting combined TempoStack+TLS validation for backend=%s, secretName=%s", backend, secretName)
 
-	// Create the secret before enabling monitoring
+	tc.validateTempoStackCreation(t, backend, secretName, monitoringCondition, monitoringErrorMsg)
+	tc.validatePersesDatasourceTLS(t, backend, secretName)
+
+	t.Logf("Cleanup traces configuration and TempoStack")
+	tc.cleanupTracesConfiguration()
+	tc.cleanupTempoStackAndSecret(secretName)
+
+	t.Logf("Combined TempoStack+TLS validation completed for backend=%s", backend)
+}
+
+// validateTempoStackCreation creates a secret, enables traces for the given backend,
+// and waits until the TempoStack is ready with the correct configuration.
+func (tc *MonitoringTestCtx) validateTempoStackCreation(t *testing.T, backend, secretName string, monitoringCondition gTypes.GomegaMatcher, monitoringErrorMsg string) {
+	t.Helper()
+
+	tc.ensureMonitoringCleanSlate(t, secretName)
+
 	t.Logf("Creating secret %s in namespace %s", secretName, tc.MonitoringNamespace)
 	tc.createDummySecret(backend, secretName, tc.MonitoringNamespace)
 
-	// Now update DSCI to set traces with specified backend
 	t.Logf("Updating DSCI with backend=%s, secretName=%s", backend, secretName)
 	tc.updateMonitoringConfig(
 		withManagementState(operatorv1.Managed),
 		withMonitoringTraces(backend, secretName, "", DefaultRetention),
 	)
 
-	// Wait for the Monitoring resource to be updated by DSCInitialization controller
 	t.Logf("Waiting for Monitoring resource to be updated")
 	tc.EnsureResourceExists(
 		WithMinimalObject(gvk.Monitoring, types.NamespacedName{Name: MonitoringCRName}),
@@ -1440,8 +1449,6 @@ func (tc *MonitoringTestCtx) validateTempoStackCreationWithBackend(t *testing.T,
 		WithCustomErrorMsg(monitoringErrorMsg),
 	)
 
-	// Ensure the TempoStack CR is created by the controller with specified backend
-	// (status conditions are set by external tempo operator)
 	t.Logf("Validating TempoStack creation with backend=%s, secretName=%s", backend, secretName)
 	tc.EnsureResourceExists(
 		WithMinimalObject(gvk.TempoStack, types.NamespacedName{
@@ -1450,28 +1457,59 @@ func (tc *MonitoringTestCtx) validateTempoStackCreationWithBackend(t *testing.T,
 		}),
 		WithCondition(
 			And(
-				// Validate the backend is set correctly
 				jq.Match(`.spec.storage.secret.type == "%s"`, backend),
 				jq.Match(`.spec.storage.secret.name == "%s"`, secretName),
-				// Validate retention is set correctly
-				jq.Match(`.spec.retention.global.traces == "%s"`, FormattedRetention), // to match 100m
-				// Validate that the Tempo operator has accepted and reconciled the resource
+				jq.Match(`.spec.retention.global.traces == "%s"`, FormattedRetention),
 				jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, status.ConditionTypeReady, metav1.ConditionTrue),
 			),
 		),
 		WithEventuallyTimeout(tc.TestTimeouts.monitoringStackTimeout),
 		WithCustomErrorMsg("TempoStack should be created by controller with %s backend, but was not found or has incorrect backend type", backend),
 	)
+}
 
-	// Cleanup: Reset DSCInitialization traces configuration, delete TempoStack and secret
-	// This ensures proper test isolation and prevents state contamination between tests
-	t.Logf("Cleanup traces configuration and TempoStack")
-	tc.cleanupTracesConfiguration()
+// validatePersesDatasourceTLS enables TLS on the existing traces configuration and validates
+// that the PersesDatasource is updated with the correct TLS settings.
+// Assumes TempoStack is already running for the given backend.
+func (tc *MonitoringTestCtx) validatePersesDatasourceTLS(t *testing.T, backend, secretName string) {
+	t.Helper()
 
-	t.Logf("Cleaning up TempoStack and secret for backend=%s", backend)
-	tc.cleanupTempoStackAndSecret(secretName)
+	ctx := context.Background()
+	hasCRD, err := cluster.HasCRD(ctx, tc.Client(), gvk.PersesDatasource)
+	require.NoError(t, err)
 
-	t.Logf("Cleanup completed for backend=%s", backend)
+	if !hasCRD {
+		t.Log("Skipping PersesDatasource TLS validation: PersesDatasource CRD not installed")
+		return
+	}
+
+	t.Logf("Enabling TLS on existing %s traces configuration", backend)
+	tc.updateMonitoringConfig(
+		withManagementState(operatorv1.Managed),
+		withMonitoringTraces(backend, secretName, "", DefaultRetention),
+		testf.Transform(`.spec.monitoring.traces.tls.enabled = true`),
+	)
+
+	t.Logf("Validating PersesDatasource has TLS configuration for %s backend", backend)
+	expectedTempoEndpoint := fmt.Sprintf("https://tempo-data-science-tempostack-gateway.%s.svc.cluster.local:8080/api/traces/v1/%s/tempo",
+		tc.MonitoringNamespace, tc.MonitoringNamespace)
+
+	tc.EnsureResourceExists(
+		WithMinimalObject(gvk.PersesDatasource, types.NamespacedName{Name: "tempo-datasource", Namespace: tc.MonitoringNamespace}),
+		WithCondition(
+			And(
+				jq.Match(`.spec.config.plugin.spec.proxy.spec.url == "%s"`, expectedTempoEndpoint),
+				jq.Match(`.spec.client.tls.enable == true`),
+				jq.Match(`.spec.client.tls.caCert.type == "configmap"`),
+				jq.Match(`.spec.client.tls.caCert.name == "tempo-service-ca"`),
+				jq.Match(`.spec.client.tls.caCert.certPath == "service-ca.crt"`),
+				jq.Match(`.spec.config.plugin.spec.proxy.spec.secret == "tempo-datasource-secret"`),
+			),
+		),
+		WithEventuallyTimeout(tc.TestTimeouts.mediumEventuallyTimeout),
+		WithCustomErrorMsg("PersesDatasource should have TLS enabled for %s backend", backend),
+	)
+	t.Logf("PersesDatasource TLS validation passed for %s backend", backend)
 }
 
 // createDummySecret creates a dummy secret for TempoStack testing (S3 or GCS).
@@ -1516,7 +1554,7 @@ func (tc *MonitoringTestCtx) createDummySecret(backendType, secretName, namespac
 		return
 	}
 
-	tc.EventuallyResourceCreated(WithObjectToCreate(secret))
+	tc.EventuallyResourceCreatedOrUpdated(WithObjectToCreate(secret))
 }
 
 // cleanupTracesConfiguration resets DSCInitialization traces configuration to prevent state contamination.
@@ -2591,107 +2629,6 @@ func (tc *MonitoringTestCtx) ValidateNodeMetricsEndpointRBACConfiguration(t *tes
 		)),
 		WithCustomErrorMsg("deployment should have volumes and mounts for mTLS to Prometheus"),
 	)
-}
-
-// validatePersesDatasourceTLSWithCloudBackend is a helper function that validates TLS configuration
-// for PersesDatasource with cloud storage backends (S3 or GCS).
-func (tc *MonitoringTestCtx) validatePersesDatasourceTLSWithCloudBackend(t *testing.T, backend string) {
-	t.Helper()
-
-	// Skip if PersesDatasource CRD is not installed
-	ctx := context.Background()
-	exists, err := cluster.HasCRD(ctx, tc.Client(), gvk.PersesDatasource)
-	require.NoError(t, err)
-	if !exists {
-		t.Skip("Skipping Perses datasource tests: PersesDatasource CRD not installed in cluster")
-	}
-
-	secretName := fmt.Sprintf("%s-tls-test-secret", backend)
-	t.Logf("Starting %s backend TLS validation test with secret=%s", backend, secretName)
-
-	// Create backend secret
-	t.Logf("Creating %s secret %s in namespace %s", backend, secretName, tc.MonitoringNamespace)
-	tc.createDummySecret(backend, secretName, tc.MonitoringNamespace)
-
-	// Set traces configuration with backend and enable TLS
-	t.Logf("Updating DSCI with %s traces configuration and TLS enabled", backend)
-	tc.updateMonitoringConfig(
-		withManagementState(operatorv1.Managed),
-		withMonitoringTraces(backend, secretName, "", DefaultRetention),
-		testf.Transform(`.spec.monitoring.traces.tls.enabled = true`),
-	)
-
-	// Wait for Monitoring CR to be updated with traces configuration
-	t.Logf("Waiting for Monitoring resource to be updated with %s traces", backend)
-	tc.EnsureResourceExists(
-		WithMinimalObject(gvk.Monitoring, types.NamespacedName{Name: MonitoringCRName}),
-		WithCondition(
-			And(
-				jq.Match(`.spec.traces != null`),
-				jq.Match(`.spec.traces.storage.backend == "%s"`, backend),
-			),
-		),
-		WithCustomErrorMsg("Monitoring resource should be updated with %s traces configuration", backend),
-	)
-
-	// Wait for TempoStack to be created and ready (cloud backends use TempoStack)
-	t.Logf("Waiting for TempoStack to be ready with %s backend", backend)
-	tc.EnsureResourceExists(
-		WithMinimalObject(gvk.TempoStack, types.NamespacedName{Name: TempoStackName, Namespace: tc.MonitoringNamespace}),
-		WithCondition(
-			And(
-				jq.Match(`.spec.storage.secret.type == "%s"`, backend),
-				jq.Match(`.spec.storage.secret.name == "%s"`, secretName),
-				jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, status.ConditionTypeReady, metav1.ConditionTrue),
-			),
-		),
-		WithEventuallyTimeout(tc.TestTimeouts.monitoringStackTimeout),
-		WithCustomErrorMsg("TempoStack should be ready with %s backend before checking PersesDatasource", backend),
-	)
-
-	// This is the critical assertion - proves cloud backend now has TLS
-	t.Logf("Validating PersesDatasource has TLS configuration for %s backend", backend)
-	expectedTempoEndpoint := fmt.Sprintf("https://tempo-data-science-tempostack-gateway.%s.svc.cluster.local:8080/api/traces/v1/%s/tempo",
-		tc.MonitoringNamespace, tc.MonitoringNamespace)
-
-	tc.EnsureResourceExists(
-		WithMinimalObject(gvk.PersesDatasource, types.NamespacedName{Name: "tempo-datasource", Namespace: tc.MonitoringNamespace}),
-		WithCondition(
-			And(
-				// Validate HTTPS endpoint
-				jq.Match(`.spec.config.plugin.spec.proxy.spec.url == "%s"`, expectedTempoEndpoint),
-				// Validate TLS client configuration exists at top-level spec.client.tls
-				jq.Match(`.spec.client.tls.enable == true`),
-				jq.Match(`.spec.client.tls.caCert.type == "configmap"`),
-				jq.Match(`.spec.client.tls.caCert.name == "tempo-service-ca"`),
-				jq.Match(`.spec.client.tls.caCert.certPath == "service-ca.crt"`),
-				// Validate secret reference links the CA cert to the proxy
-				jq.Match(`.spec.config.plugin.spec.proxy.spec.secret == "tempo-datasource-secret"`),
-			),
-		),
-		WithEventuallyTimeout(tc.TestTimeouts.monitoringStackTimeout),
-		WithCustomErrorMsg("PersesDatasource should have TLS enabled for %s backend", backend),
-	)
-
-	// Cleanup
-	t.Logf("Cleaning up %s traces configuration and resources", backend)
-	tc.cleanupTracesConfiguration()
-	tc.cleanupTempoStackAndSecret(secretName)
-	t.Logf("%s backend TLS validation test completed", backend)
-}
-
-// ValidatePersesDatasourceTLSWithS3Backend tests that TLS is enabled for S3 backend.
-func (tc *MonitoringTestCtx) ValidatePersesDatasourceTLSWithS3Backend(t *testing.T) {
-	t.Helper()
-
-	tc.validatePersesDatasourceTLSWithCloudBackend(t, "s3")
-}
-
-// ValidatePersesDatasourceTLSWithGCSBackend tests that TLS is enabled for GCS backend.
-func (tc *MonitoringTestCtx) ValidatePersesDatasourceTLSWithGCSBackend(t *testing.T) {
-	t.Helper()
-
-	tc.validatePersesDatasourceTLSWithCloudBackend(t, "gcs")
 }
 
 // ValidateTargetAllocatorNotDeployedWithoutMetrics tests that the Target Allocator is not deployed when metrics are not configured.


### PR DESCRIPTION
When Dashboard is removed from DSC, the gateway controller was not
cleaning up the dashboard-redirect resources (Deployment, Service,
ConfigMap, OCP Routes)

Issue: https://redhat.atlassian.net/browse/RHOAIENG-59344

<!---
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully
- [ ] New RELATED_IMAGE mappings are listed in ODH-Build-Config and RHOAI-Build-Config (CI validates names against build-config repos). Include links to build-config PRs in the description.

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
Added integration test for Oauth and OIDC


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dashboard redirect resources are created when the dashboard component is deployed and are removed when the component is removed; setting the DISABLE flag now triggers cleanup of previously created redirects.
* **Tests**
  * Added unit and integration tests covering creation, skipping when dashboard absent or env-disabled, and cleanup on removal.
* **Chores**
  * Added controller RBAC annotations, updated e2e helpers to ensure dashboard CR presence, and consolidated TLS test logic for improved idempotency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->