### PR TITLE
fix(maas): remove maas-controller cleanup finalizer before GC on disable

### DIFF
--- a/internal/controller/datasciencecluster/datasciencecluster_controller_actions.go
+++ b/internal/controller/datasciencecluster/datasciencecluster_controller_actions.go
@@ -6,6 +6,7 @@ import (
 	"reflect"
 
 	maasv1alpha1 "github.com/opendatahub-io/models-as-a-service/maas-controller/api/maas/v1alpha1"
+	appsv1 "k8s.io/api/apps/v1"
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -139,6 +140,10 @@ func provisionComponents(ctx context.Context, rr *odhtype.ReconciliationRequest)
 		return err
 	}
 
+	if err := removeMaaSControllerFinalizerIfDisabled(ctx, rr, instance, cr.DefaultRegistry()); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -171,6 +176,52 @@ func removeTenantIfModelsAsServiceDisabled(
 
 	if err := rr.Client.Delete(ctx, t, client.PropagationPolicy(metav1.DeletePropagationForeground)); err != nil && !k8serr.IsNotFound(err) {
 		return fmt.Errorf("delete Tenant %s when ModelsAsService disabled: %w", maasv1alpha1.TenantInstanceName, err)
+	}
+
+	return nil
+}
+
+const (
+	maasControllerDeploymentName   = "maas-controller"
+	maasControllerCleanupFinalizer = "maas.opendatahub.io/cleanup"
+)
+
+// removeMaaSControllerFinalizerIfDisabled strips the maas-controller's self-referencing
+// CleanupFinalizer from its Deployment when MaaS is disabled. Without this, namespace
+// deletion deadlocks: Kubernetes terminates the controller pod before processing
+// Deployment finalizers, leaving no controller alive to remove the finalizer.
+// See RHOAIENG-61660.
+func removeMaaSControllerFinalizerIfDisabled(
+	ctx context.Context,
+	rr *odhtype.ReconciliationRequest,
+	dsc *dscv2.DataScienceCluster,
+	reg *cr.Registry,
+) error {
+	if reg.IsComponentEnabled(componentApi.ModelsAsServiceComponentName, dsc) {
+		return nil
+	}
+
+	appNs := cluster.GetApplicationNamespace()
+
+	dep := &appsv1.Deployment{}
+	key := client.ObjectKey{Name: maasControllerDeploymentName, Namespace: appNs}
+	if err := rr.Client.Get(ctx, key, dep); err != nil {
+		if k8serr.IsNotFound(err) {
+			return nil
+		}
+		return fmt.Errorf("get maas-controller Deployment: %w", err)
+	}
+
+	if !controllerutil.ContainsFinalizer(dep, maasControllerCleanupFinalizer) {
+		return nil
+	}
+
+	controllerutil.RemoveFinalizer(dep, maasControllerCleanupFinalizer)
+	if err := rr.Client.Update(ctx, dep); err != nil {
+		if k8serr.IsNotFound(err) {
+			return nil
+		}
+		return fmt.Errorf("remove maas-controller cleanup finalizer: %w", err)
 	}
 
 	return nil


### PR DESCRIPTION
The maas-controller Deployment has a self-referencing CleanupFinalizer (maas.opendatahub.io/cleanup) that requires the controller pod to be alive to process cleanup and remove the finalizer. During namespace deletion, Kubernetes terminates the pod before processing Deployment finalizers, creating a deadlock: the finalizer can't be removed because the controller that would remove it is dead.

Strip the CleanupFinalizer from the maas-controller Deployment when MaaS is disabled, before the GC action deletes the Deployment. This allows namespace deletion to complete without waiting for a dead controller.

Closes RHOAIENG-61660

<!---
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully
- [ ] New RELATED_IMAGE mappings are listed in ODH-Build-Config and RHOAI-Build-Config (CI validates names against build-config repos). Include links to build-config PRs in the description.

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
The change doesn't need an E2E test update.

<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed cleanup behavior when the Models-as-a-Service component is disabled. The system now properly identifies and removes associated deployment resources during component deactivation, preventing orphaned resources from remaining in the system and ensuring complete cleanup across all deployments for better stability and resource management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->