### PR TITLE
(chore): Improve previous version calculation logic

### DIFF
--- a/.github/scripts/calculate-previous-version.sh
+++ b/.github/scripts/calculate-previous-version.sh
@@ -45,7 +45,9 @@ fi
 # NOTE: We exclude the current version because release-staging.yaml has already
 # created this tag before this script runs. Without exclusion, we'd incorrectly
 # return the current version as the "previous" version.
-prev_tag=$(git tag --list 'v*' --sort=-creatordate 2>/dev/null | \
+# Filter to only ODH release version tags (vX.Y.Z or vX.Y.Z-ea.N) to exclude Go module tags
+prev_tag=$(git tag --list --sort=-creatordate 2>/dev/null | \
+           grep -E '^v[0-9]+\.[0-9]+\.[0-9]+(-ea\.[0-9]+)?$' | \
            grep -Fxv "v${VERSION}" | head -n1)
 
 if [[ -z "$prev_tag" ]]; then


### PR DESCRIPTION
<!---
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
Improve calculate previous version logic, for creating catalog images during odh release(upgrade testing) so that the correct set of tags are taken into account(ordered) and the previous version is calculated

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
Run the script locally, with an input like `odh-3.5.0-ea.1`. It should return 3.4.0(for this case)

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully
- [ ] New RELATED_IMAGE mappings are listed in ODH-Build-Config and RHOAI-Build-Config (CI validates names against build-config repos). Include links to build-config PRs in the description.

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
Not related to E2E. Only for ODH release workflows


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved OLM upgrade path version detection by refining tag filtering logic to prioritize official release tags and exclude unrelated versioning tags, ensuring more reliable version identification during upgrade processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->