### PR TITLE
feat(RHOAIENG-52466): add per-dependency monitoring status for CCM

### DIFF
--- a/.rules/testing.md
+++ b/.rules/testing.md
@@ -4,11 +4,17 @@ paths: ["**/*_test.go", "tests/**/*.go"]
 
 # Testing Patterns
 
-Unit tests: use `fake.NewClientBuilder()` with explicit scheme registration via `pkg/utils/test/scheme`.
+Unit tests: use `fakeclient.New()` from `pkg/utils/test/fakeclient` for tests that only need a fake k8s client. Use `envt.New()` from `pkg/utils/test/envt` when testing against unstructured CRDs or when the test needs a real API server (CRD registration, status subresource updates).
+
 E2E tests: use `TestContext` (`tc.Client()`, `tc.Context()`).
+
+Prefer table-driven tests when multiple cases share the same setup/assertion structure. Use separate test functions only when setup differs significantly (e.g. fakeclient vs envtest).
 
 E2E test oracles MUST be structurally independent from production code. Never call same production function or read same API resource as code-under-test — derive expectations from independent signals.
 
 Follow patterns in:
-- Unit: `internal/controller/components/dashboard/dashboard_controller_actions_test.go`
+
+- Unit (fakeclient): `pkg/controller/cloudmanager/action_monitor_dependencies_test.go`
+- Unit (envtest): `pkg/controller/actions/dependency/action_operator_test.go`
+- Unit (dashboard): `internal/controller/components/dashboard/dashboard_controller_actions_test.go`
 - E2E: `tests/e2e/`

--- a/api/cloudmanager/aws/v1alpha1/awskubernetesengine_types.go
+++ b/api/cloudmanager/aws/v1alpha1/awskubernetesengine_types.go
@@ -27,8 +27,8 @@ const (
 	AWSKubernetesEngineInstanceName = "default-awskubernetesengine"
 )
 
-// Check that the component implements common.PlatformObject.
-var _ apicommon.PlatformObject = (*AWSKubernetesEngine)(nil)
+// Check that the component implements common.KubernetesEngineInstance.
+var _ common.KubernetesEngineInstance = (*AWSKubernetesEngine)(nil)
 
 // AWSKubernetesEngineSpec defines the desired state of AWSKubernetesEngine.
 type AWSKubernetesEngineSpec struct {
@@ -58,6 +58,10 @@ type AWSKubernetesEngine struct {
 
 	Spec   AWSKubernetesEngineSpec   `json:"spec,omitempty"`
 	Status AWSKubernetesEngineStatus `json:"status,omitempty"`
+}
+
+func (e *AWSKubernetesEngine) GetDependencies() common.Dependencies {
+	return e.Spec.Dependencies
 }
 
 // +kubebuilder:object:root=true

--- a/api/cloudmanager/azure/v1alpha1/azurekubernetesengine_types.go
+++ b/api/cloudmanager/azure/v1alpha1/azurekubernetesengine_types.go
@@ -27,8 +27,8 @@ const (
 	AzureKubernetesEngineInstanceName = "default-azurekubernetesengine"
 )
 
-// Check that the component implements common.PlatformObject.
-var _ apicommon.PlatformObject = (*AzureKubernetesEngine)(nil)
+// Check that the component implements common.KubernetesEngineInstance.
+var _ common.KubernetesEngineInstance = (*AzureKubernetesEngine)(nil)
 
 // AzureKubernetesEngineSpec defines the desired state of AzureKubernetesEngine.
 type AzureKubernetesEngineSpec struct {
@@ -58,6 +58,10 @@ type AzureKubernetesEngine struct {
 
 	Spec   AzureKubernetesEngineSpec   `json:"spec,omitempty"`
 	Status AzureKubernetesEngineStatus `json:"status,omitempty"`
+}
+
+func (e *AzureKubernetesEngine) GetDependencies() common.Dependencies {
+	return e.Spec.Dependencies
 }
 
 // +kubebuilder:object:root=true

--- a/api/cloudmanager/common/doc.go
+++ b/api/cloudmanager/common/doc.go
@@ -1,3 +1,0 @@
-// Package common contains shared types for cloud manager API resources.
-// +kubebuilder:object:generate=true
-package common

--- a/api/cloudmanager/common/types.go
+++ b/api/cloudmanager/common/types.go
@@ -1,5 +1,9 @@
 package common
 
+import (
+	apicommon "github.com/opendatahub-io/opendatahub-operator/v2/api/common"
+)
+
 // ManagementPolicy defines the policy for managing a cloud manager dependency.
 // +kubebuilder:validation:Enum=Managed;Unmanaged
 type ManagementPolicy string
@@ -14,8 +18,10 @@ const (
 
 // Default namespaces for cloud manager dependencies.
 const (
-	DefaultNamespaceLWSOperator  = "openshift-lws-operator"
-	DefaultNamespaceSailOperator = "istio-system"
+	DefaultNamespaceCertManagerOperator = "cert-manager-operator"
+	DefaultNamespaceCertManagerOperand  = "cert-manager"
+	DefaultNamespaceLWSOperator         = "openshift-lws-operator"
+	DefaultNamespaceSailOperator        = "istio-system"
 )
 
 // Namespace represents a Kubernetes namespace name (RFC 1123 DNS label).
@@ -124,6 +130,12 @@ type GatewayAPIDependency struct {
 	// Configuration for the Gateway API.
 	// +optional
 	Configuration GatewayAPIConfiguration `json:"configuration,omitempty"`
+}
+
+// KubernetesEngineInstance is implemented by CCM CR types that expose their Dependencies.
+type KubernetesEngineInstance interface {
+	apicommon.PlatformObject
+	GetDependencies() Dependencies
 }
 
 // Dependencies defines the dependency configurations for cloud manager operators.

--- a/api/cloudmanager/coreweave/v1alpha1/coreweavekubernetesengine_types.go
+++ b/api/cloudmanager/coreweave/v1alpha1/coreweavekubernetesengine_types.go
@@ -27,8 +27,8 @@ const (
 	CoreWeaveKubernetesEngineInstanceName = "default-coreweavekubernetesengine"
 )
 
-// Check that the component implements common.PlatformObject.
-var _ apicommon.PlatformObject = (*CoreWeaveKubernetesEngine)(nil)
+// Check that the component implements common.KubernetesEngineInstance.
+var _ common.KubernetesEngineInstance = (*CoreWeaveKubernetesEngine)(nil)
 
 // CoreWeaveKubernetesEngineSpec defines the desired state of CoreWeaveKubernetesEngine.
 type CoreWeaveKubernetesEngineSpec struct {
@@ -58,6 +58,10 @@ type CoreWeaveKubernetesEngine struct {
 
 	Spec   CoreWeaveKubernetesEngineSpec   `json:"spec,omitempty"`
 	Status CoreWeaveKubernetesEngineStatus `json:"status,omitempty"`
+}
+
+func (e *CoreWeaveKubernetesEngine) GetDependencies() common.Dependencies {
+	return e.Spec.Dependencies
 }
 
 // +kubebuilder:object:root=true

--- a/internal/controller/cloudmanager/common/charts.go
+++ b/internal/controller/cloudmanager/common/charts.go
@@ -4,8 +4,11 @@ import (
 	"path/filepath"
 
 	helm "github.com/k8s-manifest-kit/renderer-helm/pkg"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	ccmcommon "github.com/opendatahub-io/opendatahub-operator/v2/api/cloudmanager/common"
+	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/status"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
 )
 
@@ -14,6 +17,17 @@ import (
 type chartDef struct {
 	policyFn func(ccmcommon.Dependencies) ccmcommon.ManagementPolicy
 	chart    types.HelmChartInfo
+	monitor  monitorConfig
+}
+
+// monitorConfig holds per-dependency monitoring metadata embedded in chartDef.
+type monitorConfig struct {
+	ConditionType  string
+	HasDeployments bool
+	Namespace      string
+	OperatorGVK    schema.GroupVersionKind
+	CRName         string
+	CRNamespace    string
 }
 
 // allChartDefs is the single source of truth for all charts and their target
@@ -31,6 +45,10 @@ func allChartDefs(deps ccmcommon.Dependencies, chartsPath string) []chartDef {
 					Values:      helm.Values(map[string]any{}),
 				},
 			},
+			monitor: monitorConfig{
+				ConditionType:  status.ConditionGatewayAPIReady,
+				HasDeployments: false,
+			},
 		},
 		{
 			policyFn: func(d ccmcommon.Dependencies) ccmcommon.ManagementPolicy {
@@ -41,11 +59,18 @@ func allChartDefs(deps ccmcommon.Dependencies, chartsPath string) []chartDef {
 					Chart:       filepath.Join(chartsPath, "cert-manager-operator"),
 					ReleaseName: "cert-manager-operator",
 					Values: helm.Values(map[string]any{
-						"operatorNamespace": "cert-manager-operator",
-						"operandNamespace":  "cert-manager",
+						"operatorNamespace": ccmcommon.DefaultNamespaceCertManagerOperator,
+						"operandNamespace":  ccmcommon.DefaultNamespaceCertManagerOperand,
 					}),
 				},
 				PreApply: []types.HookFn{},
+			},
+			monitor: monitorConfig{
+				ConditionType:  status.ConditionCertManagerReady,
+				HasDeployments: true,
+				Namespace:      ccmcommon.DefaultNamespaceCertManagerOperator,
+				OperatorGVK:    gvk.CertManagerV1Alpha1,
+				CRName:         "cluster",
 			},
 		},
 		{
@@ -61,6 +86,14 @@ func allChartDefs(deps ccmcommon.Dependencies, chartsPath string) []chartDef {
 					}),
 				},
 				PreApply: []types.HookFn{SkipCRDIfPresent(ServiceMonitorCRDName)},
+			},
+			monitor: monitorConfig{
+				ConditionType:  status.ConditionLWSReady,
+				HasDeployments: true,
+				Namespace:      deps.LWS.GetNamespace(),
+				OperatorGVK:    gvk.LeaderWorkerSetOperatorV1,
+				CRName:         "cluster",
+				CRNamespace:    deps.LWS.GetNamespace(),
 			},
 		},
 		{
@@ -79,8 +112,50 @@ func allChartDefs(deps ccmcommon.Dependencies, chartsPath string) []chartDef {
 				// TODO(OSSM-12397): Remove PostApply hook once the sail-operator ships a fix.
 				PostApply: []types.HookFn{AnnotateIstioWebhooksHook()},
 			},
+			monitor: monitorConfig{
+				ConditionType:  status.ConditionSailOperatorReady,
+				HasDeployments: true,
+				Namespace:      deps.SailOperator.GetNamespace(),
+				OperatorGVK:    gvk.Istio,
+				CRName:         "default",
+				CRNamespace:    deps.SailOperator.GetNamespace(),
+			},
 		},
 	}
+}
+
+// DependencyMonitorConfig holds per-dependency monitoring metadata.
+type DependencyMonitorConfig struct {
+	ReleaseName    string
+	ConditionType  string
+	HasDeployments bool
+	Policy         ccmcommon.ManagementPolicy
+	Namespace      string
+	OperatorGVK    schema.GroupVersionKind
+	CRName         string
+	CRNamespace    string
+}
+
+// AllDependencyMonitorConfigs returns monitoring configs for all 4 dependencies,
+// derived from the same chartDef source of truth used by BuildHelmCharts.
+func AllDependencyMonitorConfigs(deps ccmcommon.Dependencies, chartsPath string) []DependencyMonitorConfig {
+	defs := allChartDefs(deps, chartsPath)
+	configs := make([]DependencyMonitorConfig, 0, len(defs))
+
+	for _, def := range defs {
+		configs = append(configs, DependencyMonitorConfig{
+			ReleaseName:    def.chart.ReleaseName,
+			ConditionType:  def.monitor.ConditionType,
+			HasDeployments: def.monitor.HasDeployments,
+			Policy:         def.policyFn(deps),
+			Namespace:      def.monitor.Namespace,
+			OperatorGVK:    def.monitor.OperatorGVK,
+			CRName:         def.monitor.CRName,
+			CRNamespace:    def.monitor.CRNamespace,
+		})
+	}
+
+	return configs
 }
 
 // BuildHelmCharts returns the charts filtered by management policy,

--- a/internal/controller/components/kserve/kserve_controller_actions_test.go
+++ b/internal/controller/components/kserve/kserve_controller_actions_test.go
@@ -2,6 +2,7 @@
 package kserve
 
 import (
+	"context"
 	"encoding/json"
 	"testing"
 
@@ -9,14 +10,15 @@ import (
 	"github.com/operator-framework/api/pkg/operators/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/meta"
+	k8serr "k8s.io/apimachinery/pkg/api/errors"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	clientFake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/api/components/v1alpha1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
@@ -26,7 +28,6 @@ import (
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/metadata/annotations"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/metadata/labels"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/fakeclient"
-	testscheme "github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/scheme"
 
 	. "github.com/onsi/gomega"
 )
@@ -983,7 +984,7 @@ func TestDeleteLLMInferenceServiceConfigs(t *testing.T) {
 		llmConfig1 := newLLMInferenceServiceConfig("config-1", "test-kserve-uid")
 		llmConfig2 := newLLMInferenceServiceConfig("config-2", "test-kserve-uid")
 
-		cli := buildClientWithLLMConfigs(t, llmConfig1, llmConfig2)
+		cli := buildClientWithLLMConfigs(g, llmConfig1, llmConfig2)
 
 		rr := &odhtypes.ReconciliationRequest{
 			Client:   cli,
@@ -1011,7 +1012,7 @@ func TestDeleteLLMInferenceServiceConfigs(t *testing.T) {
 
 		llmConfig := newLLMInferenceServiceConfig("config-1", "different-uid")
 
-		cli := buildClientWithLLMConfigs(t, llmConfig)
+		cli := buildClientWithLLMConfigs(g, llmConfig)
 
 		rr := &odhtypes.ReconciliationRequest{
 			Client:   cli,
@@ -1038,7 +1039,7 @@ func TestDeleteLLMInferenceServiceConfigs(t *testing.T) {
 			},
 		}
 
-		cli := buildClientWithLLMConfigs(t)
+		cli := buildClientWithLLMConfigs(g)
 
 		rr := &odhtypes.ReconciliationRequest{
 			Client:   cli,
@@ -1086,7 +1087,7 @@ func TestDeleteLLMInferenceServiceConfigs(t *testing.T) {
 		ownedConfig := newLLMInferenceServiceConfig("owned-config", "my-uid")
 		unownedConfig := newLLMInferenceServiceConfig("unowned-config", "other-uid")
 
-		cli := buildClientWithLLMConfigs(t, ownedConfig, unownedConfig)
+		cli := buildClientWithLLMConfigs(g, ownedConfig, unownedConfig)
 
 		rr := &odhtypes.ReconciliationRequest{
 			Client:   cli,
@@ -1102,6 +1103,45 @@ func TestDeleteLLMInferenceServiceConfigs(t *testing.T) {
 		g.Expect(cli.List(ctx, list)).Should(Succeed())
 		g.Expect(list.Items).Should(HaveLen(1))
 		g.Expect(list.Items[0].GetName()).Should(Equal("unowned-config"))
+	})
+
+	t.Run("should succeed when resource is deleted between List and Delete", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		instance := &componentApi.Kserve{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: componentApi.KserveInstanceName,
+				UID:  "test-kserve-uid",
+			},
+		}
+
+		llmConfig := newLLMInferenceServiceConfig("config-1", "test-kserve-uid")
+
+		cli, err := fakeclient.New(
+			fakeclient.WithObjects(llmConfig),
+			fakeclient.WithGVKs(
+				fakeclient.GVKMapping{GVK: gvk.LLMInferenceServiceConfigV1Alpha1, Scope: apimeta.RESTScopeNamespace},
+				fakeclient.GVKMapping{GVK: gvk.LLMInferenceServiceConfigV1Alpha2, Scope: apimeta.RESTScopeNamespace},
+			),
+			fakeclient.WithInterceptorFuncs(interceptor.Funcs{
+				Delete: func(_ context.Context, _ client.WithWatch, _ client.Object, _ ...client.DeleteOption) error {
+					return k8serr.NewNotFound(schema.GroupResource{
+						Group:    gvk.LLMInferenceServiceConfigV1Alpha2.Group,
+						Resource: "llminferenceserviceconfigs",
+					}, "config-1")
+				},
+			}),
+		)
+		g.Expect(err).ShouldNot(HaveOccurred())
+
+		rr := &odhtypes.ReconciliationRequest{
+			Client:   cli,
+			Instance: instance,
+		}
+
+		err = deleteLLMInferenceServiceConfigs(ctx, rr)
+		g.Expect(err).ShouldNot(HaveOccurred())
 	})
 }
 
@@ -1126,27 +1166,17 @@ func newLLMInferenceServiceConfig(name, ownerUID string) *unstructured.Unstructu
 	}
 }
 
-func buildClientWithLLMConfigs(t *testing.T, objs ...client.Object) client.Client {
-	t.Helper()
+func buildClientWithLLMConfigs(g Gomega, objs ...client.Object) client.Client {
+	cli, err := fakeclient.New(
+		fakeclient.WithObjects(objs...),
+		fakeclient.WithGVKs(
+			fakeclient.GVKMapping{GVK: gvk.LLMInferenceServiceConfigV1Alpha1, Scope: apimeta.RESTScopeNamespace},
+			fakeclient.GVKMapping{GVK: gvk.LLMInferenceServiceConfigV1Alpha2, Scope: apimeta.RESTScopeNamespace},
+		),
+	)
+	g.Expect(err).ShouldNot(HaveOccurred())
 
-	s, err := testscheme.New()
-	if err != nil {
-		t.Fatalf("failed to create scheme: %v", err)
-	}
-
-	fakeMapper := meta.NewDefaultRESTMapper(s.PreferredVersionAllGroups())
-	for kt := range s.AllKnownTypes() {
-		fakeMapper.Add(kt, meta.RESTScopeNamespace)
-	}
-
-	fakeMapper.Add(gvk.LLMInferenceServiceConfigV1Alpha1, meta.RESTScopeNamespace)
-	fakeMapper.Add(gvk.LLMInferenceServiceConfigV1Alpha2, meta.RESTScopeNamespace)
-
-	return clientFake.NewClientBuilder().
-		WithScheme(s).
-		WithRESTMapper(fakeMapper).
-		WithObjects(objs...).
-		Build()
+	return cli
 }
 
 func createTestConfigMap() *corev1.ConfigMap {

--- a/internal/controller/status/status.go
+++ b/internal/controller/status/status.go
@@ -97,6 +97,13 @@ const (
 	ConditionNodeMetricsEndpointAvailable        = "NodeMetricsEndpointAvailable"
 	ConditionImageStreamsAvailable               = "ImageStreamsAvailable"
 	ConditionImageStreamsNotAvailableReason      = "ImageStreamsNotReady"
+
+	// Cloud controller manager conditions.
+	ConditionDependenciesReady = "DependenciesReady"
+	ConditionGatewayAPIReady   = "GatewayAPIReady"
+	ConditionCertManagerReady  = "CertManagerReady"
+	ConditionLWSReady          = "LWSReady"
+	ConditionSailOperatorReady = "SailOperatorReady"
 )
 
 const (

--- a/pkg/controller/actions/status/deployments/action_deployments_available.go
+++ b/pkg/controller/actions/status/deployments/action_deployments_available.go
@@ -23,6 +23,7 @@ type Action struct {
 	labels                        map[string]string
 	namespaceFn                   actions.Getter[string]
 	disableAutomaticPartOfDefault bool
+	conditionType                 string
 }
 
 type ActionOpts func(*Action)
@@ -44,6 +45,14 @@ func WithSelectorLabels(values map[string]string) ActionOpts {
 func WithPartOfLabel(key string) ActionOpts {
 	return func(action *Action) {
 		action.partOfLabelKey = key
+	}
+}
+
+func WithConditionType(ct string) ActionOpts {
+	return func(action *Action) {
+		if ct = strings.TrimSpace(ct); ct != "" {
+			action.conditionType = ct
+		}
 	}
 }
 
@@ -120,11 +129,11 @@ func (a *Action) run(ctx context.Context, rr *types.ReconciliationRequest) error
 
 	s := obj.GetStatus()
 
-	rr.Conditions.MarkTrue(status.ConditionDeploymentsAvailable, conditions.WithObservedGeneration(s.ObservedGeneration))
+	rr.Conditions.MarkTrue(a.conditionType, conditions.WithObservedGeneration(s.ObservedGeneration))
 
 	if len(deployments.Items) == 0 || (len(deployments.Items) > 0 && ready != len(deployments.Items)) {
 		rr.Conditions.MarkFalse(
-			status.ConditionDeploymentsAvailable,
+			a.conditionType,
 			conditions.WithObservedGeneration(s.ObservedGeneration),
 			conditions.WithReason(status.ConditionDeploymentsNotAvailableReason),
 			conditions.WithMessage("%d/%d deployments ready", ready, len(deployments.Items)),
@@ -138,6 +147,7 @@ func NewAction(opts ...ActionOpts) actions.Fn {
 	action := Action{
 		partOfLabelKey: labels.PlatformPartOf,
 		labels:         map[string]string{},
+		conditionType:  status.ConditionDeploymentsAvailable,
 		namespaceFn: func(ctx context.Context, rr *types.ReconciliationRequest) (string, error) {
 			return cluster.ApplicationNamespace(ctx, rr.Client)
 		},

--- a/pkg/controller/actions/status/deployments/action_deployments_available_test.go
+++ b/pkg/controller/actions/status/deployments/action_deployments_available_test.go
@@ -326,6 +326,81 @@ func TestDeploymentsAvailableActionWithPartOfLabel(t *testing.T) {
 	)
 }
 
+func TestDeploymentsAvailableActionWithCustomConditionType(t *testing.T) {
+	tests := []struct {
+		name           string
+		readyReplicas  int32
+		expectedStatus metav1.ConditionStatus
+		expectedReason string
+	}{
+		{
+			name:           "ready",
+			readyReplicas:  1,
+			expectedStatus: metav1.ConditionTrue,
+		},
+		{
+			name:           "not ready",
+			readyReplicas:  0,
+			expectedStatus: metav1.ConditionFalse,
+			expectedReason: status.ConditionDeploymentsNotAvailableReason,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			ctx := t.Context()
+			ns := xid.New().String()
+			customCondition := "CustomAvailable"
+
+			cl, err := fakeclient.New(
+				fakeclient.WithObjects(
+					&appsv1.Deployment{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "test-operator",
+							Namespace: ns,
+							Labels:    map[string]string{labels.PlatformPartOf: ns},
+						},
+						Status: appsv1.DeploymentStatus{
+							Replicas:      1,
+							ReadyReplicas: tt.readyReplicas,
+						},
+					},
+				),
+			)
+			g.Expect(err).ShouldNot(HaveOccurred())
+
+			action := deployments.NewAction(
+				deployments.WithConditionType(customCondition),
+				deployments.WithSelectorLabel(labels.PlatformPartOf, ns),
+				deployments.InNamespace(ns),
+			)
+
+			rr := types.ReconciliationRequest{
+				Client:   cl,
+				Instance: &componentApi.Dashboard{},
+				Release:  common.Release{Name: cluster.OpenDataHub},
+			}
+			rr.Conditions = conditions.NewManager(rr.Instance, status.ConditionTypeReady, customCondition)
+
+			err = action(ctx, &rr)
+			g.Expect(err).ShouldNot(HaveOccurred())
+
+			fields := gstruct.Fields{"Status": Equal(tt.expectedStatus)}
+			if tt.expectedReason != "" {
+				fields["Reason"] = Equal(tt.expectedReason)
+			}
+
+			g.Expect(rr.Instance).Should(
+				WithTransform(
+					matchers.ExtractStatusCondition(customCondition),
+					gstruct.MatchFields(gstruct.IgnoreExtras, fields),
+				),
+			)
+		})
+	}
+}
+
 func TestDeploymentsAvailableActionNotReadyNotFound(t *testing.T) {
 	g := NewWithT(t)
 

--- a/pkg/controller/cloudmanager/action_monitor_dependencies.go
+++ b/pkg/controller/cloudmanager/action_monitor_dependencies.go
@@ -1,0 +1,112 @@
+package cloudmanager
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	ccmcommon "github.com/opendatahub-io/opendatahub-operator/v2/api/cloudmanager/common"
+	"github.com/opendatahub-io/opendatahub-operator/v2/api/common"
+	ccmcharts "github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/cloudmanager/common"
+	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/status"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/status/deployments"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/conditions"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/monitor"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/metadata/labels"
+)
+
+const dependencyDegradedReason = "DependencyDegraded"
+
+func defaultDegradedConditionFilter(condType, condStatus string) bool {
+	if condType == "Degraded" && condStatus == string(metav1.ConditionTrue) {
+		return true
+	}
+	if (condType == "Available" || condType == "Ready") && condStatus == string(metav1.ConditionFalse) {
+		return true
+	}
+
+	return false
+}
+
+func monitorDependencies(ctx context.Context, rr *types.ReconciliationRequest, resourceID string, configs []ccmcharts.DependencyMonitorConfig) error {
+	for _, cfg := range configs {
+		if cfg.Policy == ccmcommon.Unmanaged {
+			rr.Conditions.MarkTrue(
+				cfg.ConditionType,
+				conditions.WithReason(status.UnmanagedReason),
+			)
+
+			continue
+		}
+
+		// Tier 1: operator deployment health
+		if cfg.HasDeployments {
+			depAction := deployments.NewAction(
+				deployments.WithConditionType(cfg.ConditionType),
+				deployments.InNamespace(cfg.Namespace),
+				deployments.WithPartOfLabel(labels.InfrastructurePartOf),
+				deployments.WithSelectorLabel(labels.InfrastructurePartOf, resourceID),
+			)
+
+			if err := depAction(ctx, rr); err != nil {
+				return fmt.Errorf("deployment check for %s failed: %w", cfg.ReleaseName, err)
+			}
+		}
+
+		// Tier 2: operator CR health (skip if Tier 1 already marked unhealthy)
+		cond := rr.Conditions.GetCondition(cfg.ConditionType)
+		if cfg.OperatorGVK.Kind != "" && (cond == nil || cond.Status != metav1.ConditionFalse) {
+			result, err := monitor.CheckOperatorHealth(ctx, rr.Client, monitor.OperatorConfig{
+				OperatorGVK: cfg.OperatorGVK,
+				CRName:      cfg.CRName,
+				CRNamespace: cfg.CRNamespace,
+				Filter:      defaultDegradedConditionFilter,
+			})
+			if err != nil {
+				return fmt.Errorf("operator CR check for %s failed: %w", cfg.ReleaseName, err)
+			}
+
+			if !result.Pass {
+				rr.Conditions.MarkFalse(
+					cfg.ConditionType,
+					conditions.WithReason(dependencyDegradedReason),
+					conditions.WithMessage("%s", result.Message),
+				)
+			}
+		}
+
+		// No deployments and no CR (e.g. GatewayAPI): mark available after successful deploy
+		if !cfg.HasDeployments && cfg.OperatorGVK.Kind == "" {
+			rr.Conditions.MarkTrue(cfg.ConditionType)
+		}
+	}
+
+	return nil
+}
+
+func summarizeDependencyStatus(rr *types.ReconciliationRequest, configs []ccmcharts.DependencyMonitorConfig) {
+	var notReady []string
+
+	for _, cfg := range configs {
+		c := rr.Conditions.GetCondition(cfg.ConditionType)
+		if c == nil || c.Status != metav1.ConditionTrue {
+			notReady = append(notReady, cfg.ReleaseName)
+		}
+	}
+
+	if len(notReady) > 0 {
+		rr.Conditions.MarkFalse(
+			status.ConditionDependenciesReady,
+			conditions.WithReason(status.NotReadyReason),
+			conditions.WithMessage("Dependencies not ready: %s", strings.Join(notReady, ", ")),
+			conditions.WithSeverity(common.ConditionSeverityError),
+		)
+
+		return
+	}
+
+	rr.Conditions.MarkTrue(status.ConditionDependenciesReady)
+}

--- a/pkg/controller/cloudmanager/action_monitor_dependencies_test.go
+++ b/pkg/controller/cloudmanager/action_monitor_dependencies_test.go
@@ -1,0 +1,427 @@
+//nolint:testpackage // white-box tests for unexported monitorDependencies
+package cloudmanager
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/rs/xid"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	ccmv1alpha1 "github.com/opendatahub-io/opendatahub-operator/v2/api/cloudmanager/azure/v1alpha1"
+	ccmcommon "github.com/opendatahub-io/opendatahub-operator/v2/api/cloudmanager/common"
+	"github.com/opendatahub-io/opendatahub-operator/v2/api/common"
+	ccmcharts "github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/cloudmanager/common"
+	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/status"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/conditions"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/metadata/labels"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/envt"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/fakeclient"
+
+	. "github.com/onsi/gomega"
+)
+
+var testResourceID = labels.NormalizePartOfValue(ccmv1alpha1.AzureKubernetesEngineKind)
+
+var testOperatorGVK = schema.GroupVersionKind{
+	Group:   "test.cloudmanager.io",
+	Version: "v1",
+	Kind:    "TestDependencyOperator",
+}
+
+func TestMonitorDependencies(t *testing.T) {
+	tests := []struct {
+		name            string
+		dependencies    ccmcommon.Dependencies
+		objects         func(ns string) []client.Object
+		expectedStatus  map[string]metav1.ConditionStatus
+		expectedReasons map[string]string
+	}{
+		{
+			name: "unmanaged dependency is True with Unmanaged reason",
+			dependencies: ccmcommon.Dependencies{
+				CertManager:  ccmcommon.CertManagerDependency{ManagementPolicy: ccmcommon.Unmanaged},
+				GatewayAPI:   ccmcommon.GatewayAPIDependency{ManagementPolicy: ccmcommon.Unmanaged},
+				LWS:          ccmcommon.LWSDependency{ManagementPolicy: ccmcommon.Unmanaged},
+				SailOperator: ccmcommon.SailOperatorDependency{ManagementPolicy: ccmcommon.Unmanaged},
+			},
+			expectedStatus: map[string]metav1.ConditionStatus{
+				status.ConditionCertManagerReady:  metav1.ConditionTrue,
+				status.ConditionGatewayAPIReady:   metav1.ConditionTrue,
+				status.ConditionLWSReady:          metav1.ConditionTrue,
+				status.ConditionSailOperatorReady: metav1.ConditionTrue,
+			},
+			expectedReasons: map[string]string{
+				status.ConditionCertManagerReady:  status.UnmanagedReason,
+				status.ConditionGatewayAPIReady:   status.UnmanagedReason,
+				status.ConditionLWSReady:          status.UnmanagedReason,
+				status.ConditionSailOperatorReady: status.UnmanagedReason,
+			},
+		},
+		{
+			name: "managed GatewayAPI without deployments or CR is True",
+			dependencies: ccmcommon.Dependencies{
+				CertManager:  ccmcommon.CertManagerDependency{ManagementPolicy: ccmcommon.Unmanaged},
+				GatewayAPI:   ccmcommon.GatewayAPIDependency{ManagementPolicy: ccmcommon.Managed},
+				LWS:          ccmcommon.LWSDependency{ManagementPolicy: ccmcommon.Unmanaged},
+				SailOperator: ccmcommon.SailOperatorDependency{ManagementPolicy: ccmcommon.Unmanaged},
+			},
+			expectedStatus: map[string]metav1.ConditionStatus{
+				status.ConditionGatewayAPIReady: metav1.ConditionTrue,
+			},
+		},
+		{
+			name: "deployment not ready is False",
+			dependencies: ccmcommon.Dependencies{
+				CertManager:  ccmcommon.CertManagerDependency{ManagementPolicy: ccmcommon.Managed},
+				GatewayAPI:   ccmcommon.GatewayAPIDependency{ManagementPolicy: ccmcommon.Unmanaged},
+				LWS:          ccmcommon.LWSDependency{ManagementPolicy: ccmcommon.Unmanaged},
+				SailOperator: ccmcommon.SailOperatorDependency{ManagementPolicy: ccmcommon.Unmanaged},
+			},
+			objects: func(_ string) []client.Object {
+				return []client.Object{
+					newDeployment("cert-manager-operator", ccmcommon.DefaultNamespaceCertManagerOperator, 0),
+				}
+			},
+			expectedStatus: map[string]metav1.ConditionStatus{
+				status.ConditionCertManagerReady: metav1.ConditionFalse,
+			},
+			expectedReasons: map[string]string{
+				status.ConditionCertManagerReady: status.ConditionDeploymentsNotAvailableReason,
+			},
+		},
+		{
+			name: "deployment ready is True",
+			dependencies: ccmcommon.Dependencies{
+				CertManager:  ccmcommon.CertManagerDependency{ManagementPolicy: ccmcommon.Managed},
+				GatewayAPI:   ccmcommon.GatewayAPIDependency{ManagementPolicy: ccmcommon.Unmanaged},
+				LWS:          ccmcommon.LWSDependency{ManagementPolicy: ccmcommon.Unmanaged},
+				SailOperator: ccmcommon.SailOperatorDependency{ManagementPolicy: ccmcommon.Unmanaged},
+			},
+			objects: func(_ string) []client.Object {
+				return []client.Object{
+					newDeployment("cert-manager-operator", ccmcommon.DefaultNamespaceCertManagerOperator, 1),
+				}
+			},
+			expectedStatus: map[string]metav1.ConditionStatus{
+				status.ConditionCertManagerReady: metav1.ConditionTrue,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			ctx := t.Context()
+
+			var objects []client.Object
+			if tt.objects != nil {
+				objects = tt.objects(xid.New().String())
+			}
+
+			cl, err := fakeclient.New(fakeclient.WithObjects(objects...))
+			g.Expect(err).ShouldNot(HaveOccurred())
+
+			instance := &ccmv1alpha1.AzureKubernetesEngine{
+				Spec: ccmv1alpha1.AzureKubernetesEngineSpec{
+					Dependencies: tt.dependencies,
+				},
+			}
+			rr := &types.ReconciliationRequest{
+				Client:   cl,
+				Instance: instance,
+				Release:  common.Release{Name: cluster.OpenDataHub},
+			}
+			rr.Conditions = conditions.NewManager(instance, status.ConditionTypeReady, ConditionsTypes...)
+
+			action, err := NewReconcileAction(testResourceID)
+			g.Expect(err).ShouldNot(HaveOccurred())
+
+			err = action(ctx, rr)
+			g.Expect(err).ShouldNot(HaveOccurred())
+
+			for condType, expected := range tt.expectedStatus {
+				cond := rr.Conditions.GetCondition(condType)
+				g.Expect(cond).NotTo(BeNil(), "condition %s should exist", condType)
+				g.Expect(cond.Status).To(Equal(expected), "condition %s status", condType)
+			}
+
+			for condType, expectedReason := range tt.expectedReasons {
+				cond := rr.Conditions.GetCondition(condType)
+				g.Expect(cond.Reason).To(Equal(expectedReason), "condition %s reason", condType)
+			}
+		})
+	}
+}
+
+func TestMonitorDependencies_OperatorCR(t *testing.T) {
+	tests := []struct {
+		name             string
+		condType         string
+		condStatus       string
+		reason           string
+		message          string
+		expectedStatus   metav1.ConditionStatus
+		expectedReason   string
+		expectedMsgMatch string
+	}{
+		{
+			name:             "degraded CR sets condition False",
+			condType:         "Degraded",
+			condStatus:       "True",
+			reason:           "TestFailed",
+			message:          "test dependency degraded",
+			expectedStatus:   metav1.ConditionFalse,
+			expectedReason:   "DependencyDegraded",
+			expectedMsgMatch: "Degraded=True",
+		},
+		{
+			name:           "healthy CR sets condition True",
+			condType:       "Ready",
+			condStatus:     "True",
+			reason:         "Ready",
+			message:        "all good",
+			expectedStatus: metav1.ConditionTrue,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			envTest, err := envt.New()
+			g.Expect(err).NotTo(HaveOccurred())
+			t.Cleanup(func() { _ = envTest.Stop() })
+
+			ctx := context.Background()
+			cli := envTest.Client()
+
+			crd, err := envTest.RegisterCRD(ctx, testOperatorGVK, "testdependencyoperators", "testdependencyoperator", apiextensionsv1.NamespaceScoped, envt.WithPermissiveSchema())
+			g.Expect(err).NotTo(HaveOccurred())
+			envt.CleanupDelete(t, g, ctx, cli, crd)
+
+			nsn := xid.New().String()
+			ns := &unstructured.Unstructured{}
+			ns.SetGroupVersionKind(schema.GroupVersionKind{Version: "v1", Kind: "Namespace"})
+			ns.SetName(nsn)
+			g.Expect(cli.Create(ctx, ns)).NotTo(HaveOccurred())
+			t.Cleanup(func() { _ = cli.Delete(ctx, ns) })
+
+			dep := &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-operator",
+					Namespace: nsn,
+					Labels:    map[string]string{labels.InfrastructurePartOf: testResourceID},
+				},
+				Spec: appsv1.DeploymentSpec{
+					Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "test"}},
+					Template: corev1PodTemplate("test"),
+				},
+			}
+			g.Expect(cli.Create(ctx, dep)).NotTo(HaveOccurred())
+			t.Cleanup(func() { _ = cli.Delete(ctx, dep) })
+
+			dep.Status = appsv1.DeploymentStatus{Replicas: 1, ReadyReplicas: 1}
+			g.Expect(cli.Status().Update(ctx, dep)).NotTo(HaveOccurred())
+
+			operatorCR := &unstructured.Unstructured{}
+			operatorCR.SetGroupVersionKind(testOperatorGVK)
+			operatorCR.SetName("default")
+			operatorCR.SetNamespace(nsn)
+			g.Expect(cli.Create(ctx, operatorCR)).NotTo(HaveOccurred())
+			t.Cleanup(func() { _ = cli.Delete(ctx, operatorCR) })
+
+			setCRCondition(g, ctx, cli, operatorCR, tt.condType, tt.condStatus, tt.reason, tt.message)
+
+			conditionType := status.ConditionSailOperatorReady
+			instance := &ccmv1alpha1.AzureKubernetesEngine{}
+			rr := &types.ReconciliationRequest{
+				Client:   cli,
+				Instance: instance,
+				Release:  common.Release{Name: cluster.OpenDataHub},
+			}
+			rr.Conditions = conditions.NewManager(instance, status.ConditionTypeReady, ConditionsTypes...)
+
+			configs := []ccmcharts.DependencyMonitorConfig{
+				{
+					ConditionType:  conditionType,
+					Policy:         ccmcommon.Managed,
+					HasDeployments: true,
+					Namespace:      nsn,
+					OperatorGVK:    testOperatorGVK,
+					CRName:         "default",
+					CRNamespace:    nsn,
+				},
+			}
+
+			err = monitorDependencies(ctx, rr, testResourceID, configs)
+			g.Expect(err).ShouldNot(HaveOccurred())
+
+			cond := rr.Conditions.GetCondition(conditionType)
+			g.Expect(cond).NotTo(BeNil())
+			g.Expect(cond.Status).To(Equal(tt.expectedStatus))
+
+			if tt.expectedReason != "" {
+				g.Expect(cond.Reason).To(Equal(tt.expectedReason))
+			}
+
+			if tt.expectedMsgMatch != "" {
+				g.Expect(cond.Message).To(ContainSubstring(tt.expectedMsgMatch))
+			}
+		})
+	}
+}
+
+func TestSummarizeDependencyStatus(t *testing.T) {
+	tests := []struct {
+		name                 string
+		dependencies         ccmcommon.Dependencies
+		objects              func(ns string) []client.Object
+		expectedReadyStatus  metav1.ConditionStatus
+		expectedReadyReason  string
+		expectedReadyMessage string
+	}{
+		{
+			name: "all ready sets DependenciesReady and Ready True",
+			dependencies: ccmcommon.Dependencies{
+				CertManager:  ccmcommon.CertManagerDependency{ManagementPolicy: ccmcommon.Unmanaged},
+				GatewayAPI:   ccmcommon.GatewayAPIDependency{ManagementPolicy: ccmcommon.Unmanaged},
+				LWS:          ccmcommon.LWSDependency{ManagementPolicy: ccmcommon.Unmanaged},
+				SailOperator: ccmcommon.SailOperatorDependency{ManagementPolicy: ccmcommon.Unmanaged},
+			},
+			expectedReadyStatus: metav1.ConditionTrue,
+		},
+		{
+			name: "single dependency not ready lists it in DependenciesReady message",
+			dependencies: ccmcommon.Dependencies{
+				CertManager:  ccmcommon.CertManagerDependency{ManagementPolicy: ccmcommon.Managed},
+				GatewayAPI:   ccmcommon.GatewayAPIDependency{ManagementPolicy: ccmcommon.Unmanaged},
+				LWS:          ccmcommon.LWSDependency{ManagementPolicy: ccmcommon.Unmanaged},
+				SailOperator: ccmcommon.SailOperatorDependency{ManagementPolicy: ccmcommon.Unmanaged},
+			},
+			objects: func(_ string) []client.Object {
+				return []client.Object{
+					newDeployment("cert-manager-operator", ccmcommon.DefaultNamespaceCertManagerOperator, 0),
+				}
+			},
+			expectedReadyStatus:  metav1.ConditionFalse,
+			expectedReadyReason:  status.NotReadyReason,
+			expectedReadyMessage: "Dependencies not ready: cert-manager-operator",
+		},
+		{
+			name: "multiple dependencies not ready lists all in DependenciesReady message",
+			dependencies: ccmcommon.Dependencies{
+				CertManager:  ccmcommon.CertManagerDependency{ManagementPolicy: ccmcommon.Managed},
+				GatewayAPI:   ccmcommon.GatewayAPIDependency{ManagementPolicy: ccmcommon.Unmanaged},
+				LWS:          ccmcommon.LWSDependency{ManagementPolicy: ccmcommon.Managed},
+				SailOperator: ccmcommon.SailOperatorDependency{ManagementPolicy: ccmcommon.Unmanaged},
+			},
+			objects: func(ns string) []client.Object {
+				return []client.Object{
+					newDeployment("cert-manager-operator", ccmcommon.DefaultNamespaceCertManagerOperator, 0),
+					newDeployment("lws-operator", ns, 0),
+				}
+			},
+			expectedReadyStatus:  metav1.ConditionFalse,
+			expectedReadyReason:  status.NotReadyReason,
+			expectedReadyMessage: "Dependencies not ready: cert-manager-operator, lws-operator",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			ctx := t.Context()
+
+			var objects []client.Object
+			if tt.objects != nil {
+				objects = tt.objects(xid.New().String())
+			}
+
+			cl, err := fakeclient.New(fakeclient.WithObjects(objects...))
+			g.Expect(err).ShouldNot(HaveOccurred())
+
+			instance := &ccmv1alpha1.AzureKubernetesEngine{
+				Spec: ccmv1alpha1.AzureKubernetesEngineSpec{
+					Dependencies: tt.dependencies,
+				},
+			}
+			rr := &types.ReconciliationRequest{
+				Client:   cl,
+				Instance: instance,
+				Release:  common.Release{Name: cluster.OpenDataHub},
+			}
+			rr.Conditions = conditions.NewManager(instance, status.ConditionTypeReady, ConditionsTypes...)
+
+			action, err := NewReconcileAction(testResourceID)
+			g.Expect(err).ShouldNot(HaveOccurred())
+
+			err = action(ctx, rr)
+			g.Expect(err).ShouldNot(HaveOccurred())
+
+			depReadyCond := rr.Conditions.GetCondition(status.ConditionDependenciesReady)
+			g.Expect(depReadyCond).NotTo(BeNil())
+			g.Expect(depReadyCond.Status).To(Equal(tt.expectedReadyStatus))
+
+			if tt.expectedReadyReason != "" {
+				g.Expect(depReadyCond.Reason).To(Equal(tt.expectedReadyReason))
+			}
+
+			if tt.expectedReadyMessage != "" {
+				g.Expect(depReadyCond.Message).To(Equal(tt.expectedReadyMessage))
+			}
+
+			readyCond := rr.Conditions.GetCondition(status.ConditionTypeReady)
+			g.Expect(readyCond).NotTo(BeNil())
+			g.Expect(readyCond.Status).To(Equal(tt.expectedReadyStatus))
+		})
+	}
+}
+
+func newDeployment(name, namespace string, readyReplicas int32) *appsv1.Deployment {
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels:    map[string]string{labels.InfrastructurePartOf: testResourceID},
+		},
+		Status: appsv1.DeploymentStatus{
+			Replicas:      1,
+			ReadyReplicas: readyReplicas,
+		},
+	}
+}
+
+func setCRCondition(g *WithT, ctx context.Context, cli client.Client, cr *unstructured.Unstructured, condType, condStatus, reason, message string) {
+	crConditions := []any{
+		map[string]any{
+			"type":               condType,
+			"status":             condStatus,
+			"reason":             reason,
+			"message":            message,
+			"lastTransitionTime": metav1.Now().UTC().Format(time.RFC3339),
+		},
+	}
+
+	err := unstructured.SetNestedSlice(cr.Object, crConditions, "status", "conditions")
+	g.Expect(err).NotTo(HaveOccurred())
+
+	err = cli.Status().Update(ctx, cr)
+	g.Expect(err).NotTo(HaveOccurred())
+}
+
+func corev1PodTemplate(label string) corev1.PodTemplateSpec {
+	return corev1.PodTemplateSpec{
+		ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": label}},
+		Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "c", Image: "busybox"}}},
+	}
+}

--- a/pkg/controller/cloudmanager/action_reconcile.go
+++ b/pkg/controller/cloudmanager/action_reconcile.go
@@ -5,17 +5,18 @@ import (
 	"errors"
 	"fmt"
 
+	ccmcommon "github.com/opendatahub-io/opendatahub-operator/v2/api/cloudmanager/common"
+	ccmcharts "github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/cloudmanager/common"
 	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/status"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/deploy"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/render/helm"
-	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/status/deployments"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/metadata/labels"
 )
 
 var ConditionsTypes = []string{
-	status.ConditionDeploymentsAvailable,
+	status.ConditionDependenciesReady,
 }
 
 // reconcileAction holds the configuration for the combined reconcile action.
@@ -47,7 +48,10 @@ func WithDeployOptions(opts ...deploy.ActionOpts) ReconcileActionOpts {
 // - Runs PreApply hooks from HelmCharts
 // - Deploys resources via SSA
 // - Runs PostApply hooks from HelmCharts
-// - Checks deployment status.
+// - Checks per-dependency health (deployment readiness + operator CR health).
+//
+// Per-dependency monitoring is enabled automatically when rr.Instance implements
+// ccmcommon.KubernetesEngineInstance.
 func NewReconcileAction(resourceID string, opts ...ReconcileActionOpts) (actions.Fn, error) {
 	resourceID = labels.NormalizePartOfValue(resourceID)
 	if resourceID == "" {
@@ -68,13 +72,6 @@ func NewReconcileAction(resourceID string, opts ...ReconcileActionOpts) (actions
 		deploy.WithPartOfLabel(labels.InfrastructurePartOf),
 		deploy.WithAnnotationPrefix(labels.ODHInfrastructurePrefix),
 	)...)
-	deploymentsAction := deployments.NewAction(
-		deployments.InNamespaceFn(func(_ context.Context, _ *types.ReconciliationRequest) (string, error) {
-			return "", nil
-		}),
-		deployments.WithPartOfLabel(labels.InfrastructurePartOf),
-		deployments.WithSelectorLabel(labels.InfrastructurePartOf, action.resourceID),
-	)
 
 	return func(ctx context.Context, rr *types.ReconciliationRequest) error {
 		// Render Helm charts (populates rr.Resources)
@@ -103,10 +100,14 @@ func NewReconcileAction(resourceID string, opts ...ReconcileActionOpts) (actions
 			return err
 		}
 
-		// Check deployments
-		// TODO: the monitoring should be set per dependency to improve user experience
-		if err := deploymentsAction(ctx, rr); err != nil {
-			return fmt.Errorf("deployments check failed: %w", err)
+		// Per-dependency health monitoring
+		if dp, ok := rr.Instance.(ccmcommon.KubernetesEngineInstance); ok {
+			configs := ccmcharts.AllDependencyMonitorConfigs(dp.GetDependencies(), rr.ChartsBasePath)
+			if err := monitorDependencies(ctx, rr, action.resourceID, configs); err != nil {
+				return err
+			}
+
+			summarizeDependencyStatus(rr, configs)
 		}
 
 		return nil

--- a/pkg/controller/monitor/operator.go
+++ b/pkg/controller/monitor/operator.go
@@ -1,0 +1,219 @@
+package monitor
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	k8serr "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlLog "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+// CheckResult holds the outcome of a health check.
+type CheckResult struct {
+	Pass    bool
+	Message string
+}
+
+// ConditionFilterFunc evaluates an operator CR's status condition and returns true
+// if the condition indicates an unhealthy state that should be reported.
+type ConditionFilterFunc func(conditionType string, status string) bool
+
+// OperatorConfig defines the domain parameters for monitoring an external operator CR.
+type OperatorConfig struct {
+	// OperatorGVK is the GVK of the operator CR to monitor. Required.
+	OperatorGVK schema.GroupVersionKind
+
+	// CRName is the name of the operator CR to fetch. Optional: when empty,
+	// the first CR found via list is used (selection may be arbitrary if multiple exist).
+	CRName string
+
+	// CRNamespace is the namespace of the operator CR. Optional: leave empty
+	// for cluster-scoped resources.
+	CRNamespace string
+
+	// Filter evaluates each status condition on the operator CR and returns true
+	// for conditions that should be reported as unhealthy. Required: must not be nil.
+	Filter ConditionFilterFunc
+
+	// RequireCR controls behavior when the CRD is registered but no CR exists.
+	// When false (default), a missing CR is treated as healthy (operator not active).
+	// When true, a missing CR is reported as unhealthy.
+	// A missing CRD always passes regardless of this setting (operator not installed).
+	RequireCR bool
+}
+
+var errOperatorCRNotFound = errors.New("operator CR not found")
+
+// CheckOperatorHealth checks an external operator's health by reading its CR's
+// status conditions and applying the configured Filter.
+// See [OperatorConfig] for configuration details including missing CRD/CR behavior.
+func CheckOperatorHealth(ctx context.Context, cli client.Client, config OperatorConfig) (CheckResult, error) {
+	if config.OperatorGVK == (schema.GroupVersionKind{}) {
+		return CheckResult{}, errors.New("CheckOperatorHealth: OperatorGVK must not be empty")
+	}
+	if config.Filter == nil {
+		return CheckResult{}, errors.New("CheckOperatorHealth: Filter must not be nil")
+	}
+
+	cr, err := fetchOperatorCR(ctx, cli, config)
+	if err != nil {
+		if meta.IsNoMatchError(err) {
+			return CheckResult{Pass: true}, nil
+		}
+		if k8serr.IsNotFound(err) || errors.Is(err, errOperatorCRNotFound) {
+			if config.RequireCR {
+				return CheckResult{
+					Pass:    false,
+					Message: fmt.Sprintf("%s: operator CR not found", operatorIdentifier(config)),
+				}, nil
+			}
+
+			return CheckResult{Pass: true}, nil
+		}
+
+		return CheckResult{}, fmt.Errorf("%s: failed to get operator CR: %w", operatorIdentifier(config), err)
+	}
+
+	degraded, err := collectDegradedConditions(ctx, cr, config)
+	if err != nil {
+		return CheckResult{}, fmt.Errorf("%s: failed to parse conditions: %w", operatorIdentifier(config), err)
+	}
+
+	if len(degraded) > 0 {
+		return CheckResult{Pass: false, Message: strings.Join(degraded, "; ")}, nil
+	}
+
+	l := ctrlLog.FromContext(ctx)
+	l.V(1).Info("Operator dependency check passed", "gvk", config.OperatorGVK.String(), "cr", cr.GetName())
+
+	return CheckResult{Pass: true}, nil
+}
+
+func fetchOperatorCR(ctx context.Context, cli client.Client, config OperatorConfig) (*unstructured.Unstructured, error) {
+	cr := &unstructured.Unstructured{}
+	cr.SetGroupVersionKind(config.OperatorGVK)
+
+	if config.CRName != "" {
+		err := cli.Get(ctx, types.NamespacedName{
+			Name:      config.CRName,
+			Namespace: config.CRNamespace,
+		}, cr)
+
+		return cr, err
+	}
+
+	return getFirstCR(ctx, cli, config)
+}
+
+func getFirstCR(ctx context.Context, cli client.Client, config OperatorConfig) (*unstructured.Unstructured, error) {
+	list := &unstructured.UnstructuredList{}
+	list.SetGroupVersionKind(config.OperatorGVK)
+
+	lo := []client.ListOption{client.Limit(2)}
+	if config.CRNamespace != "" {
+		lo = append(lo, client.InNamespace(config.CRNamespace))
+	}
+
+	if err := cli.List(ctx, list, lo...); err != nil {
+		return nil, err
+	}
+
+	if len(list.Items) == 0 {
+		return nil, errOperatorCRNotFound
+	}
+
+	if len(list.Items) > 1 {
+		l := ctrlLog.FromContext(ctx)
+		l.Info("Dependency monitoring found multiple CRs; relying on first returned item (selection may be arbitrary)",
+			"gvk", config.OperatorGVK.String(),
+			"namespace", config.CRNamespace)
+	}
+
+	return &list.Items[0], nil
+}
+
+func operatorIdentifier(config OperatorConfig) string {
+	id := config.OperatorGVK.Kind
+	if config.CRName != "" {
+		if config.CRNamespace != "" {
+			id = fmt.Sprintf("%s %s/%s", id, config.CRNamespace, config.CRName)
+		} else {
+			id = fmt.Sprintf("%s %s", id, config.CRName)
+		}
+	}
+
+	return id
+}
+
+func collectDegradedConditions(ctx context.Context, cr *unstructured.Unstructured, config OperatorConfig) ([]string, error) {
+	conditions, found, err := unstructured.NestedSlice(cr.Object, "status", "conditions")
+	if err != nil {
+		return nil, err
+	}
+	if !found {
+		return nil, nil
+	}
+
+	crIdentifier := cr.GetName()
+	if config.CRNamespace != "" {
+		crIdentifier = fmt.Sprintf("%s/%s", config.CRNamespace, crIdentifier)
+	}
+
+	degraded := make([]string, 0, len(conditions))
+
+	for _, c := range conditions {
+		condMap, ok := c.(map[string]any)
+		if !ok {
+			l := ctrlLog.FromContext(ctx)
+			l.V(1).Info("Skipping malformed condition entry in operator CR status",
+				"gvk", config.OperatorGVK.String(),
+				"value", fmt.Sprintf("%v", c))
+
+			continue
+		}
+
+		condType, _, _ := unstructured.NestedString(condMap, "type")
+		condStatus, _, _ := unstructured.NestedString(condMap, "status")
+
+		if condType == "" || condStatus == "" {
+			l := ctrlLog.FromContext(ctx)
+			l.V(1).Info("Skipping condition with missing type or status",
+				"gvk", config.OperatorGVK.String(),
+				"type", condType,
+				"status", condStatus)
+
+			continue
+		}
+
+		if !config.Filter(condType, condStatus) {
+			continue
+		}
+
+		reason, _, _ := unstructured.NestedString(condMap, "reason")
+		message, _, _ := unstructured.NestedString(condMap, "message")
+
+		condPrefix := config.OperatorGVK.Kind
+		if crIdentifier != "" {
+			condPrefix = fmt.Sprintf("%s %s", condPrefix, crIdentifier)
+		}
+
+		condDetail := fmt.Sprintf("%s: %s=%s", condPrefix, condType, condStatus)
+		if reason != "" {
+			condDetail += fmt.Sprintf(" (%s)", reason)
+		}
+		if message != "" {
+			condDetail += fmt.Sprintf(": %s", message)
+		}
+
+		degraded = append(degraded, condDetail)
+	}
+
+	return degraded, nil
+}

--- a/pkg/controller/monitor/operator_test.go
+++ b/pkg/controller/monitor/operator_test.go
@@ -1,0 +1,499 @@
+package monitor_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/rs/xid"
+	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/monitor"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/envt"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/fakeclient"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/testf"
+
+	. "github.com/onsi/gomega"
+)
+
+var testOperatorGVK = schema.GroupVersionKind{
+	Group:   "test.monitor.io",
+	Version: "v1",
+	Kind:    "TestOperator",
+}
+
+var testClusterOperatorGVK = schema.GroupVersionKind{
+	Group:   "test.monitor.io",
+	Version: "v1",
+	Kind:    "TestClusterOperator",
+}
+
+func defaultTestFilter(condType, condStatus string) bool {
+	if condType == "Degraded" && condStatus == string(metav1.ConditionTrue) {
+		return true
+	}
+	if (condType == "Available" || condType == "Ready") && condStatus == string(metav1.ConditionFalse) {
+		return true
+	}
+
+	return false
+}
+
+func TestCheckOperatorHealth(t *testing.T) {
+	g := NewWithT(t)
+
+	envTest, err := envt.New()
+	g.Expect(err).NotTo(HaveOccurred())
+	t.Cleanup(func() { _ = envTest.Stop() })
+
+	ctx := context.Background()
+	cli := envTest.Client()
+
+	crd, err := envTest.RegisterCRD(ctx, testOperatorGVK, "testoperators", "testoperator", apiextensionsv1.NamespaceScoped, envt.WithPermissiveSchema())
+	g.Expect(err).NotTo(HaveOccurred())
+	envt.CleanupDelete(t, g, ctx, cli, crd)
+
+	tests := []struct {
+		name                   string
+		setupOperatorCR        func(g *WithT, ns string) *unstructured.Unstructured
+		filter                 monitor.ConditionFilterFunc
+		requireCR              bool
+		expectedPass           bool
+		expectedMsgContains    []string
+		expectedMsgNotContains []string
+	}{
+		{
+			name: "Degraded=True fails",
+			setupOperatorCR: func(g *WithT, ns string) *unstructured.Unstructured {
+				cr := testf.NewUnstructuredCR(xid.New().String(), ns, testOperatorGVK)
+				setOperatorCondition(g, cr, "Degraded", "True", "TestFailed", "Test failure message")
+				g.Expect(testf.CreateAndUpdateStatus(ctx, cli, cr)).NotTo(HaveOccurred())
+
+				return cr
+			},
+			filter:              defaultTestFilter,
+			expectedPass:        false,
+			expectedMsgContains: []string{testOperatorGVK.Kind, "Degraded=True", "TestFailed", "Test failure message"},
+		},
+		{
+			name: "Ready=False fails",
+			setupOperatorCR: func(g *WithT, ns string) *unstructured.Unstructured {
+				cr := testf.NewUnstructuredCR(xid.New().String(), ns, testOperatorGVK)
+				setOperatorCondition(g, cr, "Ready", "False", "NotReady", "Waiting for something")
+				g.Expect(testf.CreateAndUpdateStatus(ctx, cli, cr)).NotTo(HaveOccurred())
+
+				return cr
+			},
+			filter:              defaultTestFilter,
+			expectedPass:        false,
+			expectedMsgContains: []string{testOperatorGVK.Kind, "Ready=False", "NotReady", "Waiting for something"},
+		},
+		{
+			name: "Available=False fails",
+			setupOperatorCR: func(g *WithT, ns string) *unstructured.Unstructured {
+				cr := testf.NewUnstructuredCR(xid.New().String(), ns, testOperatorGVK)
+				setOperatorCondition(g, cr, "Available", "False", "Unavailable", "Service unavailable")
+				g.Expect(testf.CreateAndUpdateStatus(ctx, cli, cr)).NotTo(HaveOccurred())
+
+				return cr
+			},
+			filter:              defaultTestFilter,
+			expectedPass:        false,
+			expectedMsgContains: []string{testOperatorGVK.Kind, "Available=False", "Unavailable", "Service unavailable"},
+		},
+		{
+			name: "healthy operator Ready=True passes",
+			setupOperatorCR: func(g *WithT, ns string) *unstructured.Unstructured {
+				cr := testf.NewUnstructuredCR(xid.New().String(), ns, testOperatorGVK)
+				setOperatorCondition(g, cr, "Ready", "True", "Ready", "All good")
+				g.Expect(testf.CreateAndUpdateStatus(ctx, cli, cr)).NotTo(HaveOccurred())
+
+				return cr
+			},
+			filter:       defaultTestFilter,
+			expectedPass: true,
+		},
+		{
+			name: "healthy operator Degraded=False passes",
+			setupOperatorCR: func(g *WithT, ns string) *unstructured.Unstructured {
+				cr := testf.NewUnstructuredCR(xid.New().String(), ns, testOperatorGVK)
+				setOperatorCondition(g, cr, "Degraded", "False", "AsExpected", "All is well")
+				g.Expect(testf.CreateAndUpdateStatus(ctx, cli, cr)).NotTo(HaveOccurred())
+
+				return cr
+			},
+			filter:       defaultTestFilter,
+			expectedPass: true,
+		},
+		{
+			name: "operator CR not found passes",
+			setupOperatorCR: func(_ *WithT, _ string) *unstructured.Unstructured {
+				return nil
+			},
+			filter:       defaultTestFilter,
+			expectedPass: true,
+		},
+		{
+			name: "operator CR not found with RequireCR fails",
+			setupOperatorCR: func(_ *WithT, _ string) *unstructured.Unstructured {
+				return nil
+			},
+			filter:              defaultTestFilter,
+			requireCR:           true,
+			expectedPass:        false,
+			expectedMsgContains: []string{"operator CR not found"},
+		},
+		{
+			name: "operator without conditions passes",
+			setupOperatorCR: func(g *WithT, ns string) *unstructured.Unstructured {
+				cr := testf.NewUnstructuredCR(xid.New().String(), ns, testOperatorGVK)
+				g.Expect(cli.Create(ctx, cr)).NotTo(HaveOccurred())
+
+				return cr
+			},
+			filter:       defaultTestFilter,
+			expectedPass: true,
+		},
+		{
+			name: "custom filter",
+			setupOperatorCR: func(g *WithT, ns string) *unstructured.Unstructured {
+				cr := testf.NewUnstructuredCR(xid.New().String(), ns, testOperatorGVK)
+				setOperatorCondition(g, cr, "CustomError", "True", "ErrorOccurred", "Custom error")
+				g.Expect(testf.CreateAndUpdateStatus(ctx, cli, cr)).NotTo(HaveOccurred())
+
+				return cr
+			},
+			filter: func(condType, condStatus string) bool {
+				return condType == "CustomError" && condStatus == "True"
+			},
+			expectedPass:        false,
+			expectedMsgContains: []string{testOperatorGVK.Kind, "CustomError=True", "ErrorOccurred", "Custom error"},
+		},
+		{
+			name: "multiple degraded conditions",
+			setupOperatorCR: func(g *WithT, ns string) *unstructured.Unstructured {
+				cr := testf.NewUnstructuredCR(xid.New().String(), ns, testOperatorGVK)
+				setMultipleOperatorConditions(g, cr, []metav1.Condition{
+					{Type: "Degraded", Status: metav1.ConditionTrue, Reason: "Error1", Message: "First error"},
+					{Type: "Available", Status: metav1.ConditionFalse, Reason: "Unavail", Message: "Second error"},
+					{Type: "Ready", Status: metav1.ConditionTrue, Reason: "Ready", Message: "Healthy"},
+				})
+				g.Expect(testf.CreateAndUpdateStatus(ctx, cli, cr)).NotTo(HaveOccurred())
+
+				return cr
+			},
+			filter:                 defaultTestFilter,
+			expectedPass:           false,
+			expectedMsgContains:    []string{"Degraded=True", "First error", "Available=False", "Second error"},
+			expectedMsgNotContains: []string{"Ready=True"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			nsn := xid.New().String()
+
+			ns := corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: nsn}}
+			g.Expect(cli.Create(ctx, &ns)).NotTo(HaveOccurred())
+			t.Cleanup(func() { _ = cli.Delete(ctx, &ns) })
+
+			var operatorCR *unstructured.Unstructured
+			if tt.setupOperatorCR != nil {
+				operatorCR = tt.setupOperatorCR(g, nsn)
+			}
+			t.Cleanup(func() {
+				if operatorCR != nil {
+					_ = cli.Delete(ctx, operatorCR)
+				}
+			})
+
+			config := monitor.OperatorConfig{
+				OperatorGVK: testOperatorGVK,
+				CRNamespace: nsn,
+				Filter:      tt.filter,
+				RequireCR:   tt.requireCR,
+			}
+			if operatorCR != nil {
+				config.CRName = operatorCR.GetName()
+			} else {
+				config.CRName = "missing-operator"
+			}
+
+			result, err := monitor.CheckOperatorHealth(ctx, cli, config)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(result.Pass).To(Equal(tt.expectedPass))
+
+			for _, s := range tt.expectedMsgContains {
+				g.Expect(result.Message).To(ContainSubstring(s))
+			}
+			for _, s := range tt.expectedMsgNotContains {
+				g.Expect(result.Message).NotTo(ContainSubstring(s))
+			}
+		})
+	}
+}
+
+func TestCheckOperatorHealth_MissingCRD(t *testing.T) {
+	g := NewWithT(t)
+
+	envTest, err := envt.New()
+	g.Expect(err).NotTo(HaveOccurred())
+	t.Cleanup(func() { _ = envTest.Stop() })
+
+	ctx := context.Background()
+
+	nonExistentGVK := schema.GroupVersionKind{
+		Group:   "nonexistent.monitor.io",
+		Version: "v1",
+		Kind:    "NonExistentOperator",
+	}
+
+	tests := []struct {
+		name      string
+		crName    string
+		requireCR bool
+	}{
+		{"with CRName specified", "any-name", false},
+		{"with CRName empty", "", false},
+		{"RequireCR=true still passes when CRD is missing", "any-name", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			result, err := monitor.CheckOperatorHealth(ctx, envTest.Client(), monitor.OperatorConfig{
+				OperatorGVK: nonExistentGVK,
+				CRName:      tt.crName,
+				CRNamespace: "any-namespace",
+				Filter:      defaultTestFilter,
+				RequireCR:   tt.requireCR,
+			})
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(result.Pass).To(BeTrue())
+		})
+	}
+}
+
+func TestCheckOperatorHealth_FirstCRDiscovery(t *testing.T) {
+	g := NewWithT(t)
+
+	envTest, err := envt.New()
+	g.Expect(err).NotTo(HaveOccurred())
+	t.Cleanup(func() { _ = envTest.Stop() })
+
+	ctx := context.Background()
+	cli := envTest.Client()
+
+	crd, err := envTest.RegisterCRD(ctx, testOperatorGVK, "testoperators", "testoperator", apiextensionsv1.NamespaceScoped, envt.WithPermissiveSchema())
+	g.Expect(err).NotTo(HaveOccurred())
+	envt.CleanupDelete(t, g, ctx, cli, crd)
+
+	crd, err = envTest.RegisterCRD(ctx, testClusterOperatorGVK, "testclusteroperators", "testclusteroperator", apiextensionsv1.ClusterScoped, envt.WithPermissiveSchema())
+	g.Expect(err).NotTo(HaveOccurred())
+	envt.CleanupDelete(t, g, ctx, cli, crd)
+
+	t.Run("namespace-scoped CR discovered without CRName", func(t *testing.T) {
+		g := NewWithT(t)
+
+		nsn := xid.New().String()
+		ns := corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: nsn}}
+		g.Expect(cli.Create(ctx, &ns)).NotTo(HaveOccurred())
+		t.Cleanup(func() { _ = cli.Delete(ctx, &ns) })
+
+		cr := testf.NewUnstructuredCR(xid.New().String(), nsn, testOperatorGVK)
+		setOperatorCondition(g, cr, "Degraded", "True", "TestReason", "Test message")
+		g.Expect(testf.CreateAndUpdateStatus(ctx, cli, cr)).NotTo(HaveOccurred())
+		t.Cleanup(func() { _ = cli.Delete(ctx, cr) })
+
+		result, err := monitor.CheckOperatorHealth(ctx, cli, monitor.OperatorConfig{
+			OperatorGVK: testOperatorGVK,
+			CRNamespace: nsn,
+			Filter:      defaultTestFilter,
+		})
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(result.Pass).To(BeFalse())
+		g.Expect(result.Message).To(ContainSubstring("Degraded=True"))
+		g.Expect(result.Message).To(ContainSubstring("TestReason"))
+	})
+
+	t.Run("cluster-scoped CR discovered without CRName", func(t *testing.T) {
+		g := NewWithT(t)
+
+		cr := testf.NewUnstructuredCR(xid.New().String(), "", testClusterOperatorGVK)
+		setOperatorCondition(g, cr, "Degraded", "True", "ClusterFailed", "Cluster-scoped failure")
+		g.Expect(testf.CreateAndUpdateStatus(ctx, cli, cr)).NotTo(HaveOccurred())
+		t.Cleanup(func() { _ = cli.Delete(ctx, cr) })
+
+		result, err := monitor.CheckOperatorHealth(ctx, cli, monitor.OperatorConfig{
+			OperatorGVK: testClusterOperatorGVK,
+			Filter:      defaultTestFilter,
+		})
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(result.Pass).To(BeFalse())
+		g.Expect(result.Message).To(ContainSubstring("Degraded=True"))
+		g.Expect(result.Message).To(ContainSubstring("ClusterFailed"))
+	})
+
+	t.Run("multiple CRs uses first found", func(t *testing.T) {
+		g := NewWithT(t)
+
+		nsn := xid.New().String()
+		ns := corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: nsn}}
+		g.Expect(cli.Create(ctx, &ns)).NotTo(HaveOccurred())
+		t.Cleanup(func() { _ = cli.Delete(ctx, &ns) })
+
+		cr1 := testf.NewUnstructuredCR(xid.New().String(), nsn, testOperatorGVK)
+		setOperatorCondition(g, cr1, "Degraded", "True", "FirstCR", "First CR is degraded")
+		g.Expect(testf.CreateAndUpdateStatus(ctx, cli, cr1)).NotTo(HaveOccurred())
+		t.Cleanup(func() { _ = cli.Delete(ctx, cr1) })
+
+		cr2 := testf.NewUnstructuredCR(xid.New().String(), nsn, testOperatorGVK)
+		g.Expect(cli.Create(ctx, cr2)).NotTo(HaveOccurred())
+		t.Cleanup(func() { _ = cli.Delete(ctx, cr2) })
+
+		result, err := monitor.CheckOperatorHealth(ctx, cli, monitor.OperatorConfig{
+			OperatorGVK: testOperatorGVK,
+			CRNamespace: nsn,
+			Filter:      defaultTestFilter,
+		})
+		g.Expect(err).NotTo(HaveOccurred())
+		// With multiple CRs, the check should still complete (not error).
+		g.Expect(result.Pass).NotTo(BeNil())
+	})
+}
+
+func TestCheckOperatorHealth_MalformedConditions(t *testing.T) {
+	g := NewWithT(t)
+
+	envTest, err := envt.New()
+	g.Expect(err).NotTo(HaveOccurred())
+	t.Cleanup(func() { _ = envTest.Stop() })
+
+	ctx := context.Background()
+	cli := envTest.Client()
+
+	crd, err := envTest.RegisterCRD(ctx, testOperatorGVK, "testoperators", "testoperator", apiextensionsv1.NamespaceScoped, envt.WithPermissiveSchema())
+	g.Expect(err).NotTo(HaveOccurred())
+	envt.CleanupDelete(t, g, ctx, cli, crd)
+
+	nsn := xid.New().String()
+	ns := corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: nsn}}
+	g.Expect(cli.Create(ctx, &ns)).NotTo(HaveOccurred())
+	t.Cleanup(func() { _ = cli.Delete(ctx, &ns) })
+
+	t.Run("conditions field is not a slice", func(t *testing.T) {
+		g := NewWithT(t)
+
+		cr := testf.NewUnstructuredCR(xid.New().String(), nsn, testOperatorGVK)
+		g.Expect(cli.Create(ctx, cr)).NotTo(HaveOccurred())
+		t.Cleanup(func() { _ = cli.Delete(ctx, cr) })
+
+		g.Expect(unstructured.SetNestedField(cr.Object, "not-a-slice", "status", "conditions")).NotTo(HaveOccurred())
+		g.Expect(cli.Status().Update(ctx, cr)).NotTo(HaveOccurred())
+
+		_, err := monitor.CheckOperatorHealth(ctx, cli, monitor.OperatorConfig{
+			OperatorGVK: testOperatorGVK,
+			CRName:      cr.GetName(),
+			CRNamespace: nsn,
+			Filter:      defaultTestFilter,
+		})
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("failed to parse conditions"))
+	})
+}
+
+func TestCheckOperatorHealth_NilFilter(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+
+	cli, err := fakeclient.New()
+	g.Expect(err).NotTo(HaveOccurred())
+
+	_, err = monitor.CheckOperatorHealth(ctx, cli, monitor.OperatorConfig{
+		OperatorGVK: testOperatorGVK,
+	})
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("Filter must not be nil"))
+}
+
+func TestCheckOperatorHealth_EmptyGVK(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+
+	cli, err := fakeclient.New()
+	g.Expect(err).NotTo(HaveOccurred())
+
+	_, err = monitor.CheckOperatorHealth(ctx, cli, monitor.OperatorConfig{
+		Filter: defaultTestFilter,
+	})
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("OperatorGVK must not be empty"))
+}
+
+func TestCheckOperatorHealth_TransientAPIError(t *testing.T) {
+	ctx := context.Background()
+
+	apiErr := errors.New("simulated transient API error")
+	cli, err := fakeclient.New(fakeclient.WithInterceptorFuncs(interceptor.Funcs{
+		Get: func(_ context.Context, _ client.WithWatch, _ client.ObjectKey, _ client.Object, _ ...client.GetOption) error {
+			return apiErr
+		},
+		List: func(_ context.Context, _ client.WithWatch, _ client.ObjectList, _ ...client.ListOption) error {
+			return apiErr
+		},
+	}))
+
+	NewWithT(t).Expect(err).NotTo(HaveOccurred())
+
+	tests := []struct {
+		name   string
+		crName string
+	}{
+		{"Get error with CRName", "some-cr"},
+		{"List error without CRName", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			_, err := monitor.CheckOperatorHealth(ctx, cli, monitor.OperatorConfig{
+				OperatorGVK: testOperatorGVK,
+				CRName:      tt.crName,
+				Filter:      defaultTestFilter,
+			})
+			g.Expect(err).To(HaveOccurred())
+			g.Expect(err.Error()).To(ContainSubstring("failed to get operator CR"))
+		})
+	}
+}
+
+// Test helpers
+
+func setOperatorCondition(g *WithT, cr *unstructured.Unstructured, cType, condStatus, reason, message string) {
+	g.THelper()
+
+	err := testf.SetTypedConditions(cr, []metav1.Condition{{
+		Type:               cType,
+		Status:             metav1.ConditionStatus(condStatus),
+		Reason:             reason,
+		Message:            message,
+		LastTransitionTime: metav1.Now(),
+	}})
+	g.Expect(err).NotTo(HaveOccurred())
+}
+
+func setMultipleOperatorConditions(g *WithT, cr *unstructured.Unstructured, conditions []metav1.Condition) {
+	g.THelper()
+
+	err := testf.SetTypedConditions(cr, conditions)
+	g.Expect(err).NotTo(HaveOccurred())
+}

--- a/pkg/controller/precondition/monitor_operator.go
+++ b/pkg/controller/precondition/monitor_operator.go
@@ -2,217 +2,24 @@ package precondition
 
 import (
 	"context"
-	"errors"
-	"fmt"
-	"strings"
 
-	k8serr "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/api/meta"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	ctrlLog "sigs.k8s.io/controller-runtime/pkg/log"
-
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/monitor"
 	odhtypes "github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
 )
 
-// ConditionFilterFunc evaluates an operator CR's status condition and returns true
-// if the condition indicates an unhealthy state that should be reported.
-type ConditionFilterFunc func(conditionType string, status string) bool
+// ConditionFilterFunc is an alias for [monitor.ConditionFilterFunc].
+type ConditionFilterFunc = monitor.ConditionFilterFunc
 
-// OperatorConfig defines the domain parameters for monitoring an external operator CR.
-type OperatorConfig struct {
-	// OperatorGVK is the GVK of the operator CR to monitor. Required.
-	OperatorGVK schema.GroupVersionKind
-
-	// CRName is the name of the operator CR to fetch. Optional: when empty,
-	// the first CR found via list is used (selection may be arbitrary if multiple exist).
-	CRName string
-
-	// CRNamespace is the namespace of the operator CR. Optional: leave empty
-	// for cluster-scoped resources.
-	CRNamespace string
-
-	// Filter evaluates each status condition on the operator CR and returns true
-	// for conditions that should be reported as unhealthy. Required: must not be nil.
-	Filter ConditionFilterFunc
-
-	// RequireCR controls behavior when the CRD is registered but no CR exists.
-	// When false (default), a missing CR is treated as healthy (operator not active).
-	// When true, a missing CR is reported as unhealthy.
-	// A missing CRD always passes regardless of this setting (operator not installed).
-	RequireCR bool
-}
-
-var errOperatorCRNotFound = errors.New("operator CR not found")
+// OperatorConfig is an alias for [monitor.OperatorConfig].
+type OperatorConfig = monitor.OperatorConfig
 
 // MonitorOperator creates a PreCondition that checks an external operator's health
 // by reading its CR's status conditions and applying the configured Filter.
-// See [OperatorConfig] for configuration details including missing CRD/CR behavior.
+// See [monitor.OperatorConfig] for configuration details including missing CRD/CR behavior.
 func MonitorOperator(config OperatorConfig, opts ...Option) PreCondition {
 	return newPreCondition(func(ctx context.Context, rr *odhtypes.ReconciliationRequest) (CheckResult, error) {
-		if config.OperatorGVK == (schema.GroupVersionKind{}) {
-			return CheckResult{}, errors.New("MonitorOperator: OperatorGVK must not be empty")
-		}
-		if config.Filter == nil {
-			return CheckResult{}, errors.New("MonitorOperator: Filter must not be nil")
-		}
+		result, err := monitor.CheckOperatorHealth(ctx, rr.Client, config)
 
-		cr, err := fetchOperatorCR(ctx, rr.Client, config)
-		if err != nil {
-			if meta.IsNoMatchError(err) {
-				return CheckResult{Pass: true}, nil
-			}
-			if k8serr.IsNotFound(err) || errors.Is(err, errOperatorCRNotFound) {
-				if config.RequireCR {
-					return CheckResult{
-						Pass:    false,
-						Message: fmt.Sprintf("%s: operator CR not found", operatorIdentifier(config)),
-					}, nil
-				}
-
-				return CheckResult{Pass: true}, nil
-			}
-
-			return CheckResult{}, fmt.Errorf("%s: failed to get operator CR: %w", operatorIdentifier(config), err)
-		}
-
-		degraded, err := collectDegradedConditions(ctx, cr, config)
-		if err != nil {
-			return CheckResult{}, fmt.Errorf("%s: failed to parse conditions: %w", operatorIdentifier(config), err)
-		}
-
-		if len(degraded) > 0 {
-			return CheckResult{Pass: false, Message: strings.Join(degraded, "; ")}, nil
-		}
-
-		l := ctrlLog.FromContext(ctx)
-		l.V(1).Info("Operator dependency check passed", "gvk", config.OperatorGVK.String(), "cr", cr.GetName())
-
-		return CheckResult{Pass: true}, nil
+		return CheckResult(result), err
 	}, opts...)
-}
-
-func fetchOperatorCR(ctx context.Context, cli client.Client, config OperatorConfig) (*unstructured.Unstructured, error) {
-	cr := &unstructured.Unstructured{}
-	cr.SetGroupVersionKind(config.OperatorGVK)
-
-	if config.CRName != "" {
-		err := cli.Get(ctx, types.NamespacedName{
-			Name:      config.CRName,
-			Namespace: config.CRNamespace,
-		}, cr)
-
-		return cr, err
-	}
-
-	return getFirstCR(ctx, cli, config)
-}
-
-func getFirstCR(ctx context.Context, cli client.Client, config OperatorConfig) (*unstructured.Unstructured, error) {
-	list := &unstructured.UnstructuredList{}
-	list.SetGroupVersionKind(config.OperatorGVK)
-
-	// Limit to 2: enough to detect multiple CRs (logged as warning) without fetching the full list.
-	lo := []client.ListOption{client.Limit(2)}
-	if config.CRNamespace != "" {
-		lo = append(lo, client.InNamespace(config.CRNamespace))
-	}
-
-	if err := cli.List(ctx, list, lo...); err != nil {
-		return nil, err
-	}
-
-	if len(list.Items) == 0 {
-		return nil, errOperatorCRNotFound
-	}
-
-	if len(list.Items) > 1 {
-		l := ctrlLog.FromContext(ctx)
-		l.Info("Dependency monitoring found multiple CRs; relying on first returned item (selection may be arbitrary)",
-			"gvk", config.OperatorGVK.String(),
-			"namespace", config.CRNamespace)
-	}
-
-	return &list.Items[0], nil
-}
-
-func operatorIdentifier(config OperatorConfig) string {
-	id := config.OperatorGVK.Kind
-	if config.CRName != "" {
-		if config.CRNamespace != "" {
-			id = fmt.Sprintf("%s %s/%s", id, config.CRNamespace, config.CRName)
-		} else {
-			id = fmt.Sprintf("%s %s", id, config.CRName)
-		}
-	}
-
-	return id
-}
-
-func collectDegradedConditions(ctx context.Context, cr *unstructured.Unstructured, config OperatorConfig) ([]string, error) {
-	conditions, found, err := unstructured.NestedSlice(cr.Object, "status", "conditions")
-	if err != nil {
-		return nil, err
-	}
-	if !found {
-		return nil, nil
-	}
-
-	crIdentifier := cr.GetName()
-	if config.CRNamespace != "" {
-		crIdentifier = fmt.Sprintf("%s/%s", config.CRNamespace, crIdentifier)
-	}
-
-	degraded := make([]string, 0, len(conditions))
-
-	for _, c := range conditions {
-		condMap, ok := c.(map[string]any)
-		if !ok {
-			l := ctrlLog.FromContext(ctx)
-			l.V(1).Info("Skipping malformed condition entry in operator CR status",
-				"gvk", config.OperatorGVK.String(),
-				"value", fmt.Sprintf("%v", c))
-
-			continue
-		}
-
-		condType, _, _ := unstructured.NestedString(condMap, "type")
-		condStatus, _, _ := unstructured.NestedString(condMap, "status")
-
-		if condType == "" || condStatus == "" {
-			l := ctrlLog.FromContext(ctx)
-			l.V(1).Info("Skipping condition with missing type or status",
-				"gvk", config.OperatorGVK.String(),
-				"type", condType,
-				"status", condStatus)
-
-			continue
-		}
-
-		if !config.Filter(condType, condStatus) {
-			continue
-		}
-
-		reason, _, _ := unstructured.NestedString(condMap, "reason")
-		message, _, _ := unstructured.NestedString(condMap, "message")
-
-		condPrefix := config.OperatorGVK.Kind
-		if crIdentifier != "" {
-			condPrefix = fmt.Sprintf("%s %s", condPrefix, crIdentifier)
-		}
-
-		condDetail := fmt.Sprintf("%s: %s=%s", condPrefix, condType, condStatus)
-		if reason != "" {
-			condDetail += fmt.Sprintf(" (%s)", reason)
-		}
-		if message != "" {
-			condDetail += fmt.Sprintf(": %s", message)
-		}
-
-		degraded = append(degraded, condDetail)
-	}
-
-	return degraded, nil
 }

--- a/tests/e2e/cloudmanager/cloudmanager_test.go
+++ b/tests/e2e/cloudmanager/cloudmanager_test.go
@@ -111,6 +111,32 @@ func TestCloudManager(t *testing.T) { //nolint:maintidx // sequential subtests s
 				))
 			})
 
+			t.Run("Dependency deployments running", func(t *testing.T) {
+				wt := tc.NewWithT(t)
+
+				for _, ns := range []string{certManagerOperatorNS, customLWSOperatorNS, customSailOperatorNS} {
+					wt.List(gvk.Deployment,
+						client.InNamespace(ns),
+						client.MatchingLabels{labels.InfrastructurePartOf: getPartOfLabelValue()},
+					).Eventually().Should(
+						jq.Match(`(. | length) > 0 and all(.status.readyReplicas == .status.replicas)`),
+						"all deployments in %s should have ready replicas", ns,
+					)
+				}
+			})
+
+			t.Run("Per-dependency conditions", func(t *testing.T) {
+				wt := tc.NewWithT(t)
+
+				wt.Get(provider.GVK, k8sEngineCrNn()).Eventually().Should(And(
+					jq.Match(`.status.conditions[] | select(.type == "DependenciesReady") | .status == "True"`),
+					jq.Match(`.status.conditions[] | select(.type == "GatewayAPIReady") | .status == "True"`),
+					jq.Match(`.status.conditions[] | select(.type == "CertManagerReady") | .status == "True"`),
+					jq.Match(`.status.conditions[] | select(.type == "LWSReady") | .status == "True"`),
+					jq.Match(`.status.conditions[] | select(.type == "SailOperatorReady") | .status == "True"`),
+				))
+			})
+
 			t.Run("ProvisioningSucceeded condition", func(t *testing.T) {
 				wt := tc.NewWithT(t)
 				wt.Get(provider.GVK, k8sEngineCrNn()).Eventually().Should(And(
@@ -362,6 +388,7 @@ func TestCloudManager(t *testing.T) { //nolint:maintidx // sequential subtests s
 			jq.Match(`.metadata.generation > %d`, gen1),
 			jq.Match(`.status.observedGeneration == .metadata.generation`),
 			jq.Match(`.status.phase == "Ready"`),
+			jq.Match(`.status.conditions[] | select(.type == "SailOperatorReady") | .reason == "Unmanaged"`),
 		))
 
 		// Second mutation: switch it back to Managed.
@@ -379,6 +406,8 @@ func TestCloudManager(t *testing.T) { //nolint:maintidx // sequential subtests s
 			jq.Match(`.metadata.generation > %d`, gen2),
 			jq.Match(`.status.observedGeneration == .metadata.generation`),
 			jq.Match(`.status.phase == "Ready"`),
+			jq.Match(`.status.conditions[] | select(.type == "SailOperatorReady") | .status == "True"`),
+			jq.Match(`.status.conditions[] | select(.type == "SailOperatorReady") | .reason != "Unmanaged"`),
 		))
 	})
 
@@ -402,6 +431,8 @@ func TestCloudManager(t *testing.T) { //nolint:maintidx // sequential subtests s
 			jq.Match(`.metadata.generation > %d`, gen),
 			jq.Match(`.status.observedGeneration == .metadata.generation`),
 			jq.Match(`.status.phase == "Ready"`),
+			jq.Match(`.status.conditions[] | select(.type == "CertManagerReady") | .status == "True"`),
+			jq.Match(`.status.conditions[] | select(.type == "CertManagerReady") | .reason == "Unmanaged"`),
 		))
 
 		// Delete the cert-manager deployment.


### PR DESCRIPTION
<!---
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description

Add per-dependency health monitoring to the Cloud Manager (CCM) reconcile loop, replacing the single aggregated `DeploymentsAvailable` condition with granular per-dependency conditions and a `DependenciesReady` aggregate.

Each managed dependency gets its own condition (`GatewayAPIReady`, `CertManagerReady`, `LWSReady`, `SailOperatorReady`) monitored in two tiers:
- **Tier 1**: operator deployment readiness (replicas vs ready replicas)
- **Tier 2**: operator CR health (degraded conditions propagation)

A new `DependenciesReady` condition aggregates all per-dependency results and lists not-ready dependencies by name (e.g. `"Dependencies not ready: cert-manager-operator, lws-operator"`), following the same pattern as DSC's `ComponentsReady`. This is the sole dependent of the `Ready` condition, ensuring failures propagate correctly via `RecomputeHappiness`.

Unmanaged dependencies are marked `True` with reason `Unmanaged`.

Monitoring configuration is derived from the same `chartDef` source of truth used by `BuildHelmCharts`, ensuring consistency between what is deployed and what is monitored.

Jira task: https://issues.redhat.com/browse/RHOAIENG-52466

### Changes

- Add `monitorConfig` to `chartDef` and expose `AllDependencyMonitorConfigs()` from charts source of truth
- Add `KubernetesEngineInstance` interface with `GetDependencies()` to both Azure and CoreWeave CR types
- Add `WithConditionType` option to `dependency.NewAction` and `deployments.NewAction` for custom condition types
- Replace single `deploymentsAction` in `NewReconcileAction` with `monitorDependencies()` that iterates all dependencies
- Add `DependenciesReady` aggregate condition as sole dependent of `Ready`, with `summarizeDependencyStatus()` listing all not-ready dependencies by release name
- Rename per-dependency conditions from `XAvailable` to `XReady` for consistency with component convention
- Add per-dependency condition constants in `internal/controller/status`
- Add unit tests for `monitorDependencies`, `summarizeDependencyStatus`, `WithConditionType` in both dependency and deployments actions
- Add e2e assertions for `DependenciesReady` and per-dependency conditions in managed, unmanaged, and transition flows
- Update `.rules/testing.md` with new test pattern references

## How Has This Been Tested?

- New unit tests:
  - `TestMonitorDependencies` (fakeclient): unmanaged, deployment ready/not-ready scenarios
  - `TestMonitorDependencies_OperatorCR` (envtest): degraded/healthy operator CR propagation
  - `TestDependencyAction_WithConditionType` (envtest): custom condition type routing
  - `TestDeploymentsAvailableActionWithCustomConditionType` (fakeclient): custom condition in deployment checks
- Extended e2e tests:
  - Per-dependency conditions all `True` after successful deploy
  - `SailOperatorAvailable` reason `Unmanaged` after transition, then back to `True`
  - `CertManagerAvailable` reason `Unmanaged` after transition

## Screenshot or short clip

N/A

## Merge criteria

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [x] The developer has run the integration test pipeline and verified that it passed successfully
- [ ] New RELATED_IMAGE mappings are listed in ODH-Build-Config and RHOAI-Build-Config (CI validates names against build-config repos). Include links to build-config PRs in the description.

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [ ] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-dependency health monitoring with distinct availability conditions (GatewayAPI, CertManager, LWS, SailOperator), a utility to check operator CR health, and an option to configure which condition key deployment checks update.

* **Tests**
  * Added extensive unit and e2e tests covering dependency monitoring, operator-CR health checks, deployment readiness, and new failure/race scenarios.

* **Documentation**
  * Revised testing guidance clarifying when to use fake vs envtest setups and enforcing test-oracle separation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->