### PR TITLE
feat(RHOAIENG-61467): add support for kueue 1.3 with v1beta2 resources

### DIFF
--- a/internal/controller/components/kueue/kueue_controller.go
+++ b/internal/controller/components/kueue/kueue_controller.go
@@ -83,16 +83,31 @@ func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.
 				handlers.ToNamed(componentApi.KueueInstanceName),
 			),
 			reconciler.Dynamic(reconciler.CrdExists(gvk.LocalQueue))).
+		WatchesGVK(gvk.LocalQueueV1Beta1,
+			reconciler.WithEventHandler(
+				handlers.ToNamed(componentApi.KueueInstanceName),
+			),
+			reconciler.Dynamic(reconciler.CrdExists(gvk.LocalQueueV1Beta1))).
 		WatchesGVK(gvk.ClusterQueue,
 			reconciler.WithEventHandler(
 				handlers.ToNamed(componentApi.KueueInstanceName),
 			),
 			reconciler.Dynamic(reconciler.CrdExists(gvk.ClusterQueue))).
+		WatchesGVK(gvk.ClusterQueueV1Beta1,
+			reconciler.WithEventHandler(
+				handlers.ToNamed(componentApi.KueueInstanceName),
+			),
+			reconciler.Dynamic(reconciler.CrdExists(gvk.ClusterQueueV1Beta1))).
 		WatchesGVK(gvk.ResourceFlavor,
 			reconciler.WithEventHandler(
 				handlers.ToNamed(componentApi.KueueInstanceName),
 			),
 			reconciler.Dynamic(reconciler.CrdExists(gvk.ResourceFlavor))).
+		WatchesGVK(gvk.ResourceFlavorV1Beta1,
+			reconciler.WithEventHandler(
+				handlers.ToNamed(componentApi.KueueInstanceName),
+			),
+			reconciler.Dynamic(reconciler.CrdExists(gvk.ResourceFlavorV1Beta1))).
 		WatchesGVK(gvk.KueueConfigV1,
 			reconciler.WithEventHandler(
 				handlers.ToNamed(componentApi.KueueInstanceName),

--- a/internal/controller/components/kueue/kueue_controller_actions.go
+++ b/internal/controller/components/kueue/kueue_controller_actions.go
@@ -148,17 +148,25 @@ func manageDefaultKueueResourcesAction(ctx context.Context, rr *odhtypes.Reconci
 		rr.Resources = append(rr.Resources, *defaultKueueConfig)
 	}
 
+	resolvedGVKs, err := resolveKueueResourceGVKs(ctx, rr.Client)
+	if err != nil {
+		return fmt.Errorf("failed to resolve kueue resource GVKs: %w", err)
+	}
+	if resolvedGVKs == nil {
+		return nil
+	}
+
 	clusterInfo, err := getClusterResourceInfo(ctx, rr.Client)
 	if err != nil {
 		return fmt.Errorf("failed to get cluster resource info: %w", err)
 	}
 
 	// Generate default ResourceFlavor.
-	resourcesFlavors := createDefaultResourceFlavors(clusterInfo)
+	resourcesFlavors := createDefaultResourceFlavors(clusterInfo, resolvedGVKs)
 	rr.Resources = append(rr.Resources, resourcesFlavors...)
 
 	// Generate default ClusterQueue.
-	clusterQueue := createDefaultClusterQueue(kueueCRInstance.Spec.DefaultClusterQueueName, clusterInfo)
+	clusterQueue := createDefaultClusterQueue(kueueCRInstance.Spec.DefaultClusterQueueName, clusterInfo, resolvedGVKs)
 	rr.Resources = append(rr.Resources, *clusterQueue)
 
 	// Get all managed namespaces (i.e. the one opted in with the addition of the proper labels).
@@ -179,7 +187,7 @@ func manageDefaultKueueResourcesAction(ctx context.Context, rr *odhtypes.Reconci
 		if !ns.GetDeletionTimestamp().IsZero() {
 			continue
 		}
-		localQueue := createDefaultLocalQueue(kueueCRInstance.Spec.DefaultLocalQueueName, kueueCRInstance.Spec.DefaultClusterQueueName, ns.Name)
+		localQueue := createDefaultLocalQueue(kueueCRInstance.Spec.DefaultLocalQueueName, kueueCRInstance.Spec.DefaultClusterQueueName, ns.Name, resolvedGVKs)
 		rr.Resources = append(rr.Resources, *localQueue)
 	}
 

--- a/internal/controller/components/kueue/kueue_controller_actions_test.go
+++ b/internal/controller/components/kueue/kueue_controller_actions_test.go
@@ -11,6 +11,8 @@ import (
 	"github.com/rs/xid"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -587,8 +589,20 @@ func TestDefaultKueueResourcesAction(t *testing.T) {
 			clusterNodes := getClusterNodes(t, test.withGPU)
 			runtimeObjects = append(runtimeObjects, clusterNodes...)
 
+			kueueCRD := &apiextensionsv1.CustomResourceDefinition{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "clusterqueues.kueue.x-k8s.io",
+				},
+			}
+			runtimeObjects = append(runtimeObjects, kueueCRD)
+
 			client, err := fakeclient.New(
 				fakeclient.WithObjects(runtimeObjects...),
+				fakeclient.WithGVKs(
+					fakeclient.GVKMapping{GVK: gvk.ClusterQueue, Scope: meta.RESTScopeRoot},
+					fakeclient.GVKMapping{GVK: gvk.LocalQueue, Scope: meta.RESTScopeNamespace},
+					fakeclient.GVKMapping{GVK: gvk.ResourceFlavor, Scope: meta.RESTScopeRoot},
+				),
 			)
 			g.Expect(err).ToNot(HaveOccurred())
 

--- a/internal/controller/components/kueue/kueue_support.go
+++ b/internal/controller/components/kueue/kueue_support.go
@@ -11,7 +11,9 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/api/components/v1alpha1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/status"
@@ -174,7 +176,7 @@ func createResourceGroup(flavors []Flavors) map[string]any {
 	}
 }
 
-func createDefaultClusterQueue(name string, clusterInfo ClusterResourceInfo) *unstructured.Unstructured {
+func createDefaultClusterQueue(name string, clusterInfo ClusterResourceInfo, gvks *kueueResourceGVKs) *unstructured.Unstructured {
 	clusterQueue := &unstructured.Unstructured{}
 
 	clusterGPU := slices.Sorted(maps.Keys(clusterInfo.GPUInfo))
@@ -201,8 +203,8 @@ func createDefaultClusterQueue(name string, clusterInfo ClusterResourceInfo) *un
 	}
 
 	clusterQueue.Object = map[string]any{
-		"apiVersion": gvk.ClusterQueue.GroupVersion().String(),
-		"kind":       gvk.ClusterQueue.Kind,
+		"apiVersion": gvks.ClusterQueue.GroupVersion().String(),
+		"kind":       gvks.ClusterQueue.Kind,
 		"metadata": map[string]any{
 			"name": name,
 			"annotations": map[string]any{
@@ -222,12 +224,12 @@ func createDefaultClusterQueue(name string, clusterInfo ClusterResourceInfo) *un
 	return clusterQueue
 }
 
-func createDefaultLocalQueue(name string, clusterQueueName string, namespace string) *unstructured.Unstructured {
+func createDefaultLocalQueue(name string, clusterQueueName string, namespace string, gvks *kueueResourceGVKs) *unstructured.Unstructured {
 	localQueue := &unstructured.Unstructured{}
 
 	localQueue.Object = map[string]any{
-		"apiVersion": gvk.LocalQueue.GroupVersion().String(),
-		"kind":       gvk.LocalQueue.Kind,
+		"apiVersion": gvks.LocalQueue.GroupVersion().String(),
+		"kind":       gvks.LocalQueue.Kind,
 		"metadata": map[string]any{
 			"name":      name,
 			"namespace": namespace,
@@ -243,13 +245,13 @@ func createDefaultLocalQueue(name string, clusterQueueName string, namespace str
 	return localQueue
 }
 
-func createDefaultResourceFlavors(clusterInfo ClusterResourceInfo) []unstructured.Unstructured {
+func createDefaultResourceFlavors(clusterInfo ClusterResourceInfo, gvks *kueueResourceGVKs) []unstructured.Unstructured {
 	resourceFlavors := make([]unstructured.Unstructured, 0, 1+len(clusterInfo.GPUInfo))
 
 	resourceFlavors = append(resourceFlavors, unstructured.Unstructured{
 		Object: map[string]any{
-			"apiVersion": gvk.ResourceFlavor.GroupVersion().String(),
-			"kind":       gvk.ResourceFlavor.Kind,
+			"apiVersion": gvks.ResourceFlavor.GroupVersion().String(),
+			"kind":       gvks.ResourceFlavor.Kind,
 			"metadata": map[string]any{
 				"name": DefaultFlavorName,
 				"annotations": map[string]any{
@@ -263,8 +265,8 @@ func createDefaultResourceFlavors(clusterInfo ClusterResourceInfo) []unstructure
 	for label := range clusterInfo.GPUInfo {
 		resourceFlavor := unstructured.Unstructured{}
 		resourceFlavor.Object = map[string]any{
-			"apiVersion": gvk.ResourceFlavor.GroupVersion().String(),
-			"kind":       gvk.ResourceFlavor.Kind,
+			"apiVersion": gvks.ResourceFlavor.GroupVersion().String(),
+			"kind":       gvks.ResourceFlavor.Kind,
 			"metadata": map[string]any{
 				"name": supportedGPUMap[label],
 				"annotations": map[string]any{
@@ -330,6 +332,51 @@ func getClusterResourceInfo(ctx context.Context, c client.Client) (ClusterResour
 	}
 
 	return info, nil
+}
+
+type kueueResourceGVKs struct {
+	ClusterQueue   schema.GroupVersionKind
+	LocalQueue     schema.GroupVersionKind
+	ResourceFlavor schema.GroupVersionKind
+}
+
+var (
+	kueueGVKsV1Beta2 = &kueueResourceGVKs{
+		ClusterQueue:   gvk.ClusterQueue,
+		LocalQueue:     gvk.LocalQueue,
+		ResourceFlavor: gvk.ResourceFlavor,
+	}
+	kueueGVKsV1Beta1 = &kueueResourceGVKs{
+		ClusterQueue:   gvk.ClusterQueueV1Beta1,
+		LocalQueue:     gvk.LocalQueueV1Beta1,
+		ResourceFlavor: gvk.ResourceFlavorV1Beta1,
+	}
+)
+
+// resolveKueueResourceGVKs probes the cluster to determine which kueue.x-k8s.io
+// API version is available, preferring v1beta2 over v1beta1.
+func resolveKueueResourceGVKs(ctx context.Context, cli client.Client) (*kueueResourceGVKs, error) {
+	log := logf.FromContext(ctx)
+	gk := gvk.ClusterQueue.GroupKind()
+
+	found, err := cluster.HasCRDWithVersion(ctx, cli, gk, gvk.ClusterQueue.Version)
+	if err != nil {
+		return nil, err
+	}
+	if found {
+		return kueueGVKsV1Beta2, nil
+	}
+
+	found, err = cluster.HasCRDWithVersion(ctx, cli, gk, gvk.ClusterQueueV1Beta1.Version)
+	if err != nil {
+		return nil, err
+	}
+	if found {
+		return kueueGVKsV1Beta1, nil
+	}
+
+	log.Info("no supported kueue CRD version found on the cluster")
+	return nil, nil
 }
 
 // kueueDegradedConditionFilter is used to filter condition that represent a degraded state in

--- a/pkg/cluster/gvk/gvk.go
+++ b/pkg/cluster/gvk/gvk.go
@@ -541,21 +541,39 @@ var (
 
 	// kueue.x-k8s.io.
 
-	LocalQueue = schema.GroupVersionKind{
+	LocalQueueV1Beta1 = schema.GroupVersionKind{
 		Group:   "kueue.x-k8s.io",
 		Version: "v1beta1",
 		Kind:    "LocalQueue",
 	}
 
-	ClusterQueue = schema.GroupVersionKind{
+	LocalQueue = schema.GroupVersionKind{
+		Group:   "kueue.x-k8s.io",
+		Version: "v1beta2",
+		Kind:    "LocalQueue",
+	}
+
+	ClusterQueueV1Beta1 = schema.GroupVersionKind{
 		Group:   "kueue.x-k8s.io",
 		Version: "v1beta1",
 		Kind:    "ClusterQueue",
 	}
 
-	ResourceFlavor = schema.GroupVersionKind{
+	ClusterQueue = schema.GroupVersionKind{
+		Group:   "kueue.x-k8s.io",
+		Version: "v1beta2",
+		Kind:    "ClusterQueue",
+	}
+
+	ResourceFlavorV1Beta1 = schema.GroupVersionKind{
 		Group:   "kueue.x-k8s.io",
 		Version: "v1beta1",
+		Kind:    "ResourceFlavor",
+	}
+
+	ResourceFlavor = schema.GroupVersionKind{
+		Group:   "kueue.x-k8s.io",
+		Version: "v1beta2",
 		Kind:    "ResourceFlavor",
 	}
 

--- a/pkg/utils/test/fakeclient/fakeclient.go
+++ b/pkg/utils/test/fakeclient/fakeclient.go
@@ -5,6 +5,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	clientFake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
@@ -14,10 +15,19 @@ import (
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/scheme"
 )
 
+// GVKMapping associates a GVK with a REST scope for registration in the fake
+// client's REST mapper. Use this for types that have no Go struct in the scheme
+// (e.g. kueue resources used as unstructured).
+type GVKMapping struct {
+	GVK   schema.GroupVersionKind
+	Scope meta.RESTScope
+}
+
 type clientOptions struct {
 	scheme      *runtime.Scheme
 	interceptor interceptor.Funcs
 	objects     []client.Object
+	gvkMappings []GVKMapping
 }
 type ClientOpts func(*clientOptions)
 
@@ -36,6 +46,12 @@ func WithObjects(values ...client.Object) ClientOpts {
 func WithScheme(value *runtime.Scheme) ClientOpts {
 	return func(o *clientOptions) {
 		o.scheme = value
+	}
+}
+
+func WithGVKs(mappings ...GVKMapping) ClientOpts {
+	return func(o *clientOptions) {
+		o.gvkMappings = append(o.gvkMappings, mappings...)
 	}
 }
 
@@ -88,6 +104,10 @@ func New(opts ...ClientOpts) (client.Client, error) {
 		default:
 			fakeMapper.Add(kt, meta.RESTScopeNamespace)
 		}
+	}
+
+	for _, m := range co.gvkMappings {
+		fakeMapper.Add(m.GVK, m.Scope)
 	}
 
 	b := clientFake.NewClientBuilder()

--- a/tests/e2e/helper_test.go
+++ b/tests/e2e/helper_test.go
@@ -72,7 +72,7 @@ const (
 	leaderWorkerSetNamespace    = "openshift-lws-operator"                   // Namespace for the Leader Worker Set Operator
 	leaderWorkerSetChannel      = "stable-v1.0"                              // Channel for the Leader Worker Set Operator
 	kueueOcpOperatorNamespace   = "openshift-kueue-operator"                 // Namespace for the OCP Kueue Operator
-	kueueOcpOperatorChannel     = "stable-v1.2"                              // Channel for the OCP Kueue Operator
+	kueueOcpOperatorChannel     = "stable-v1.3"                              // Channel for the OCP Kueue Operator
 	kuadrantOpName              = "rhcl-operator"                            // Name of the Red Hat Connectivity Link Operator subscription.
 	kuadrantNamespace           = "kuadrant-system"                          // Namespace for the Red Hat Connectivity Link Operator.
 

--- a/tests/e2e/kueue_test.go
+++ b/tests/e2e/kueue_test.go
@@ -67,6 +67,31 @@ var (
 	}
 )
 
+// ensureKueueOperatorsInstalled installs the LWS operator (with its CR) and the OCP Kueue operator.
+func (tc *KueueTestCtx) ensureKueueOperatorsInstalled(t *testing.T) {
+	t.Helper()
+
+	t.Logf("Ensuring LWS Operator is installed (namespace=%s, name=%s).", leaderWorkerSetNamespace, leaderWorkerSetOpName)
+	tc.EnsureOperatorInstalledWithGlobalOperatorGroupAndChannel(
+		types.NamespacedName{Name: leaderWorkerSetOpName, Namespace: leaderWorkerSetNamespace},
+		leaderWorkerSetChannel,
+	)
+
+	t.Logf("Ensuring LeaderWorkerSetOperator CR exists (namespace=%s, name=cluster).", leaderWorkerSetNamespace)
+	tc.EventuallyResourceCreatedOrUpdated(
+		WithMinimalObject(gvk.LeaderWorkerSetOperatorV1, types.NamespacedName{Name: "cluster", Namespace: leaderWorkerSetNamespace}),
+		WithMutateFunc(func(obj *unstructured.Unstructured) error {
+			return unstructured.SetNestedField(obj.Object, "Managed", "spec", "managementState")
+		}),
+	)
+
+	t.Logf("Ensuring OCP Kueue Operator is installed (namespace=%s, name=%s).", kueueOcpOperatorNamespace, kueueOpName)
+	tc.EnsureOperatorInstalledWithGlobalOperatorGroupAndChannel(
+		types.NamespacedName{Name: kueueOpName, Namespace: kueueOcpOperatorNamespace},
+		kueueOcpOperatorChannel,
+	)
+}
+
 func kueueTestSuite(t *testing.T) {
 	t.Helper()
 
@@ -121,11 +146,7 @@ func (tc *KueueTestCtx) EnsureKueueReady(t *testing.T) {
 
 	componentName := strings.ToLower(tc.GVK.Kind)
 
-	t.Logf("Ensuring OCP Kueue Operator is installed (namespace=%s, name=%s).", kueueOcpOperatorNamespace, kueueOpName)
-	tc.EnsureOperatorInstalledWithGlobalOperatorGroupAndChannel(
-		types.NamespacedName{Name: kueueOpName, Namespace: kueueOcpOperatorNamespace},
-		kueueOcpOperatorChannel,
-	)
+	tc.ensureKueueOperatorsInstalled(t)
 
 	t.Logf("Ensuring Kueue operator is running (namespace=%s).", kueueOcpOperatorNamespace)
 	tc.scaleKueueOperator(t, 1)
@@ -231,9 +252,7 @@ func (tc *KueueTestCtx) ValidateKueueRemovedToUnmanagedTransition(t *testing.T) 
 		WithCondition(And(conditionsUnmanagedNotReady...)),
 	)
 
-	t.Logf("Installing OCP Kueue Operator (%s/%s) to enable Kueue component readiness.", kueueOcpOperatorNamespace, kueueOpName)
-	// Install ocp kueue-operator
-	tc.EnsureOperatorInstalledWithGlobalOperatorGroupAndChannel(types.NamespacedName{Name: kueueOpName, Namespace: kueueOcpOperatorNamespace}, kueueOcpOperatorChannel)
+	tc.ensureKueueOperatorsInstalled(t)
 
 	conditionsUnmanagedReady := []gTypes.GomegaMatcher{
 		// Validate that the component's management state is updated correctly
@@ -291,10 +310,7 @@ func (tc *KueueTestCtx) ValidateKueueUnmanagedToRemovedTransition(t *testing.T) 
 	// ... and then cleanup tests resources
 	tc.cleanupKueueTestResources(t)
 
-	t.Logf("Installing OCP Kueue Operator (%s/%s) before testing Unmanaged state.", kueueOcpOperatorNamespace, kueueOpName)
-	// UNMANAGED
-	// Install ocp kueue-operator
-	tc.EnsureOperatorInstalledWithGlobalOperatorGroupAndChannel(types.NamespacedName{Name: kueueOpName, Namespace: kueueOcpOperatorNamespace}, kueueOcpOperatorChannel)
+	tc.ensureKueueOperatorsInstalled(t)
 
 	t.Logf("Defining expected conditions for Unmanaged state (Ready=True).")
 	stateUnmanaged := operatorv1.Unmanaged
@@ -514,11 +530,7 @@ func (tc *KueueTestCtx) ValidateExternalOperatorDegradedMonitoring(t *testing.T)
 	tc.UpdateComponentStateInDataScienceCluster(operatorv1.Removed)
 	tc.cleanupKueueTestResources(t)
 
-	t.Logf("Ensuring Kueue OCP operator is installed (namespace=%s, name=%s).", kueueOcpOperatorNamespace, kueueOpName)
-	tc.EnsureOperatorInstalledWithGlobalOperatorGroupAndChannel(
-		types.NamespacedName{Name: kueueOpName, Namespace: kueueOcpOperatorNamespace},
-		kueueOcpOperatorChannel,
-	)
+	tc.ensureKueueOperatorsInstalled(t)
 
 	t.Logf("Creating managed test namespace with Kueue management annotation (namespace=%s).", managedNS)
 	tc.setupNamespace(managedNS, KueueManagedLabels)


### PR DESCRIPTION
## Description

- Add support for Kueue 1.3 by introducing v1beta2 GVKs for ClusterQueue, LocalQueue, and ResourceFlavor resources
- Dynamically detect available Kueue API version at runtime (v1beta2 preferred, v1beta1 fallback), ensuring backward compatibility with existing Kueue 1.2 installations
- Update E2E tests to use `stable-v1.3` channel and extract shared operator installation into `ensureKueueOperatorsInstalled` helper (including LWS operator prerequisite)

Jira task: https://issues.redhat.com/browse/RHOAIENG-61467

## How Has This Been Tested?

- Unit tests via `make unit-test`
- E2E test suite updated to install Kueue 1.3 from `stable-v1.3` channel
- Runtime GVK resolution tested against clusters with v1beta2 and v1beta1 APIs
- verified in a real cluster with both kueue 1.2 and kueue 1.3

## Screenshot or short clip

N/A

## Merge criteria

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [x] The developer has run the integration test pipeline and verified that it passed successfully
- [ ] New RELATED_IMAGE mappings are listed in ODH-Build-Config and RHOAI-Build-Config (CI validates names against build-config repos). Include links to build-config PRs in the description.

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [ ] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Default Kueue resources are now created only when Kueue APIs are present and are generated using the detected Kueue API version.
  * Controller watches now cover multiple Kueue CRD versions to handle different API releases.

* **Tests**
  * E2E setup ensures installation/cooperation of relevant operators and updates the operator channel.
  * Test utilities can register API kinds in the fake client for more realistic testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->