### PR TITLE
fix: align with labeled pod/service monitors

### DIFF
--- a/internal/controller/services/monitoring/resources/monitoring-admission-policies.tmpl.yaml
+++ b/internal/controller/services/monitoring/resources/monitoring-admission-policies.tmpl.yaml
@@ -19,9 +19,9 @@ spec:
   validations:
     - expression: >
         !has(object.metadata.labels) ||
-        !('opendatahub.io/monitoring' in object.metadata.labels) ||
-        object.metadata.labels['opendatahub.io/monitoring'] in ['true', 'false']
-      message: "The label 'opendatahub.io/monitoring' must be set to 'true' or 'false'."
+        !('monitoring.opendatahub.io/scrape' in object.metadata.labels) ||
+        object.metadata.labels['monitoring.opendatahub.io/scrape'] in ['true', 'false']
+      message: "The label 'monitoring.opendatahub.io/scrape' must be set to 'true' or 'false'."
 
 ---
 apiVersion: admissionregistration.k8s.io/v1

--- a/internal/controller/services/monitoring/resources/opentelemetry-collector.tmpl.yaml
+++ b/internal/controller/services/monitoring/resources/opentelemetry-collector.tmpl.yaml
@@ -14,10 +14,10 @@ spec:
       enabled: true
       podMonitorSelector:
         matchLabels:
-          opendatahub.io/monitoring: "true"
+          monitoring.opendatahub.io/scrape: "true"
       serviceMonitorSelector:
         matchLabels:
-          opendatahub.io/monitoring: "true"
+          monitoring.opendatahub.io/scrape: "true"
   {{- end }}
   resources:
     limits:

--- a/internal/webhook/monitoring/mutating.go
+++ b/internal/webhook/monitoring/mutating.go
@@ -203,7 +203,7 @@ func (i *Injector) performMonitoringInjection(ctx context.Context, req *admissio
 				"resource", obj.GetName(),
 				"namespace", resourceNamespace)
 
-			// Inject opendatahub.io/monitoring=true label only if not already set
+			// Inject monitoring.opendatahub.io/scrape=true label only if not already set
 			lbls := obj.GetLabels()
 			if lbls == nil {
 				lbls = make(map[string]string)

--- a/internal/webhook/monitoring/mutating_test.go
+++ b/internal/webhook/monitoring/mutating_test.go
@@ -100,14 +100,14 @@ func createWebhookInjector(cli client.Client, sch *runtime.Scheme) *monitoring.I
 // hasLabelPatch checks if any patch adds the monitoring label.
 func hasLabelPatch(patches []jsonpatch.JsonPatchOperation) bool {
 	for _, patch := range patches {
-		if patch.Path == "/metadata/labels" || patch.Path == "/metadata/labels/opendatahub.io~1monitoring" {
+		if patch.Path == "/metadata/labels" || patch.Path == "/metadata/labels/monitoring.opendatahub.io~1scrape" {
 			if labelMap, ok := patch.Value.(map[string]any); ok {
 				if val, exists := labelMap[labels.ODHLabelMonitoring]; exists && val == monitoringLabelValue {
 					return true
 				}
 			}
 			// Check if it's a single label addition
-			if patch.Path == "/metadata/labels/opendatahub.io~1monitoring" && patch.Value == monitoringLabelValue {
+			if patch.Path == "/metadata/labels/monitoring.opendatahub.io~1scrape" && patch.Value == monitoringLabelValue {
 				return true
 			}
 		}

--- a/pkg/metadata/labels/types.go
+++ b/pkg/metadata/labels/types.go
@@ -15,7 +15,7 @@ const (
 	Platform                = "platform"
 	True                    = "true"
 	CustomizedAppNamespace  = "opendatahub.io/application-namespace"
-	ODHLabelMonitoring      = "opendatahub.io/monitoring"
+	ODHLabelMonitoring      = "monitoring.opendatahub.io/scrape"
 )
 
 // K8SCommon keeps common kubernetes labels [1]

--- a/tests/e2e/monitoring_admission_components_test.go
+++ b/tests/e2e/monitoring_admission_components_test.go
@@ -275,7 +275,7 @@ func (tc *MonitoringTestCtx) ValidateMonitoringLabelValueEnforcementOnMonitors(t
 	tc.g.Expect(err).To(MatchError(ContainSubstring("must be set to 'true' or 'false'")), "Error message should indicate valid values for ServiceMonitor")
 }
 
-// ValidateMonitorLabelInjection tests that the mutating webhook injects opendatahub.io/monitoring=true label into Monitors.
+// ValidateMonitorLabelInjection tests that the mutating webhook injects monitoring.opendatahub.io/scrape=true label into Monitors.
 func (tc *MonitoringTestCtx) ValidateMonitorLabelInjection(t *testing.T) {
 	t.Helper()
 
@@ -292,8 +292,8 @@ func (tc *MonitoringTestCtx) ValidateMonitorLabelInjection(t *testing.T) {
 			Name:      TestPodMonitorName,
 			Namespace: TestNamespaceName,
 		}),
-		WithCondition(jq.Match(`.metadata.labels."opendatahub.io/monitoring" == "true"`)),
-		WithCustomErrorMsg("Mutating webhook should inject opendatahub.io/monitoring=true label into PodMonitor"),
+		WithCondition(jq.Match(`.metadata.labels."monitoring.opendatahub.io/scrape" == "true"`)),
+		WithCustomErrorMsg("Mutating webhook should inject monitoring.opendatahub.io/scrape=true label into PodMonitor"),
 	)
 
 	// Verify webhook injected the monitoring label into ServiceMonitor
@@ -302,8 +302,8 @@ func (tc *MonitoringTestCtx) ValidateMonitorLabelInjection(t *testing.T) {
 			Name:      TestServiceMonitorName,
 			Namespace: TestNamespaceName,
 		}),
-		WithCondition(jq.Match(`.metadata.labels."opendatahub.io/monitoring" == "true"`)),
-		WithCustomErrorMsg("Mutating webhook should inject opendatahub.io/monitoring=true label into ServiceMonitor"),
+		WithCondition(jq.Match(`.metadata.labels."monitoring.opendatahub.io/scrape" == "true"`)),
+		WithCustomErrorMsg("Mutating webhook should inject monitoring.opendatahub.io/scrape=true label into ServiceMonitor"),
 	)
 }
 
@@ -332,7 +332,7 @@ func (tc *MonitoringTestCtx) ValidateMonitorsCreationWithCustomLabels(t *testing
 		}),
 		WithCondition(jq.Match(`.metadata.labels."app" == "my-app"`)),
 		WithCondition(jq.Match(`.metadata.labels."team" == "platform"`)),
-		WithCondition(jq.Match(`.metadata.labels."opendatahub.io/monitoring" == "true"`)),
+		WithCondition(jq.Match(`.metadata.labels."monitoring.opendatahub.io/scrape" == "true"`)),
 		WithCustomErrorMsg("Webhook should inject monitoring=true AND preserve custom labels (PodMonitor)"),
 	)
 
@@ -344,7 +344,7 @@ func (tc *MonitoringTestCtx) ValidateMonitorsCreationWithCustomLabels(t *testing
 		}),
 		WithCondition(jq.Match(`.metadata.labels."app" == "my-app"`)),
 		WithCondition(jq.Match(`.metadata.labels."team" == "platform"`)),
-		WithCondition(jq.Match(`.metadata.labels."opendatahub.io/monitoring" == "true"`)),
+		WithCondition(jq.Match(`.metadata.labels."monitoring.opendatahub.io/scrape" == "true"`)),
 		WithCustomErrorMsg("Webhook should inject monitoring=true AND preserve custom labels (ServiceMonitor)"),
 	)
 }
@@ -366,14 +366,14 @@ func (tc *MonitoringTestCtx) ValidateMonitorLabelInjectionOnUpdate(t *testing.T)
 			Name:      TestPodMonitorName,
 			Namespace: TestNamespaceName,
 		}),
-		WithCondition(jq.Match(`.metadata.labels."opendatahub.io/monitoring" == null`)),
+		WithCondition(jq.Match(`.metadata.labels."monitoring.opendatahub.io/scrape" == null`)),
 		WithCustomErrorMsg("PodMonitor should not have monitoring label when created in non-monitored namespace"),
 	)
 
 	// Step 2: Update namespace to opt-in for monitoring
 	tc.EventuallyResourcePatched(
 		WithMinimalObject(gvk.Namespace, types.NamespacedName{Name: TestNamespaceName}),
-		WithMutateFunc(testf.Transform(`.metadata.labels."opendatahub.io/monitoring" = "true"`)),
+		WithMutateFunc(testf.Transform(`.metadata.labels."monitoring.opendatahub.io/scrape" = "true"`)),
 	)
 
 	// Step 3: UPDATE the PodMonitor (trigger webhook on UPDATE operation)
@@ -391,7 +391,7 @@ func (tc *MonitoringTestCtx) ValidateMonitorLabelInjectionOnUpdate(t *testing.T)
 			Name:      TestPodMonitorName,
 			Namespace: TestNamespaceName,
 		}),
-		WithCondition(jq.Match(`.metadata.labels."opendatahub.io/monitoring" == "true"`)),
+		WithCondition(jq.Match(`.metadata.labels."monitoring.opendatahub.io/scrape" == "true"`)),
 		WithCustomErrorMsg("Webhook should inject monitoring label on UPDATE operation (PodMonitor)"),
 	)
 
@@ -410,7 +410,7 @@ func (tc *MonitoringTestCtx) ValidateMonitorLabelInjectionOnUpdate(t *testing.T)
 			Name:      TestServiceMonitorName,
 			Namespace: TestNamespaceName,
 		}),
-		WithCondition(jq.Match(`.metadata.labels."opendatahub.io/monitoring" == "true"`)),
+		WithCondition(jq.Match(`.metadata.labels."monitoring.opendatahub.io/scrape" == "true"`)),
 		WithCustomErrorMsg("Webhook should inject monitoring label on UPDATE operation (ServiceMonitor)"),
 	)
 }
@@ -440,14 +440,14 @@ func (tc *MonitoringTestCtx) ValidateMonitorLabelInjectionOnUpdateWithCustomLabe
 		}),
 		WithCondition(jq.Match(`.metadata.labels."app" == "my-app"`)),
 		WithCondition(jq.Match(`.metadata.labels."team" == "platform"`)),
-		WithCondition(jq.Match(`.metadata.labels."opendatahub.io/monitoring" == null`)),
+		WithCondition(jq.Match(`.metadata.labels."monitoring.opendatahub.io/scrape" == null`)),
 		WithCustomErrorMsg("PodMonitor should have custom labels but no monitoring label initially"),
 	)
 
 	// Step 2: Update namespace to opt-in for monitoring
 	tc.EventuallyResourcePatched(
 		WithMinimalObject(gvk.Namespace, types.NamespacedName{Name: TestNamespaceName}),
-		WithMutateFunc(testf.Transform(`.metadata.labels."opendatahub.io/monitoring" = "true"`)),
+		WithMutateFunc(testf.Transform(`.metadata.labels."monitoring.opendatahub.io/scrape" = "true"`)),
 	)
 
 	// Step 3: UPDATE the PodMonitor
@@ -467,7 +467,7 @@ func (tc *MonitoringTestCtx) ValidateMonitorLabelInjectionOnUpdateWithCustomLabe
 		}),
 		WithCondition(jq.Match(`.metadata.labels."app" == "my-app"`)),
 		WithCondition(jq.Match(`.metadata.labels."team" == "platform"`)),
-		WithCondition(jq.Match(`.metadata.labels."opendatahub.io/monitoring" == "true"`)),
+		WithCondition(jq.Match(`.metadata.labels."monitoring.opendatahub.io/scrape" == "true"`)),
 		WithCustomErrorMsg("Webhook should inject monitoring label AND preserve custom labels on UPDATE (PodMonitor)"),
 	)
 
@@ -488,7 +488,7 @@ func (tc *MonitoringTestCtx) ValidateMonitorLabelInjectionOnUpdateWithCustomLabe
 		}),
 		WithCondition(jq.Match(`.metadata.labels."app" == "my-app"`)),
 		WithCondition(jq.Match(`.metadata.labels."team" == "platform"`)),
-		WithCondition(jq.Match(`.metadata.labels."opendatahub.io/monitoring" == "true"`)),
+		WithCondition(jq.Match(`.metadata.labels."monitoring.opendatahub.io/scrape" == "true"`)),
 		WithCustomErrorMsg("Webhook should inject monitoring label AND preserve custom labels on UPDATE (ServiceMonitor)"),
 	)
 }
@@ -510,7 +510,7 @@ func (tc *MonitoringTestCtx) ValidateWebhookSkipsNonMonitoredNamespace(t *testin
 			Name:      TestPodMonitorName,
 			Namespace: TestNamespaceName,
 		}),
-		WithCondition(jq.Match(`.metadata.labels."opendatahub.io/monitoring" == null`)),
+		WithCondition(jq.Match(`.metadata.labels."monitoring.opendatahub.io/scrape" == null`)),
 		WithCustomErrorMsg("Webhook should NOT inject monitoring label when namespace is not opted-in (PodMonitor)"),
 	)
 
@@ -520,7 +520,7 @@ func (tc *MonitoringTestCtx) ValidateWebhookSkipsNonMonitoredNamespace(t *testin
 			Name:      TestServiceMonitorName,
 			Namespace: TestNamespaceName,
 		}),
-		WithCondition(jq.Match(`.metadata.labels."opendatahub.io/monitoring" == null`)),
+		WithCondition(jq.Match(`.metadata.labels."monitoring.opendatahub.io/scrape" == null`)),
 		WithCustomErrorMsg("Webhook should NOT inject monitoring label when namespace is not opted-in (ServiceMonitor)"),
 	)
 }
@@ -542,7 +542,7 @@ func (tc *MonitoringTestCtx) ValidateWebhookSkipsExplicitlyOptedOutNamespace(t *
 			Name:      TestPodMonitorName,
 			Namespace: TestNamespaceName,
 		}),
-		WithCondition(jq.Match(`.metadata.labels."opendatahub.io/monitoring" == null`)),
+		WithCondition(jq.Match(`.metadata.labels."monitoring.opendatahub.io/scrape" == null`)),
 		WithCustomErrorMsg("Webhook should NOT inject monitoring label when namespace explicitly has monitoring=false (PodMonitor)"),
 	)
 
@@ -552,7 +552,7 @@ func (tc *MonitoringTestCtx) ValidateWebhookSkipsExplicitlyOptedOutNamespace(t *
 			Name:      TestServiceMonitorName,
 			Namespace: TestNamespaceName,
 		}),
-		WithCondition(jq.Match(`.metadata.labels."opendatahub.io/monitoring" == null`)),
+		WithCondition(jq.Match(`.metadata.labels."monitoring.opendatahub.io/scrape" == null`)),
 		WithCustomErrorMsg("Webhook should NOT inject monitoring label when namespace explicitly has monitoring=false (ServiceMonitor)"),
 	)
 }
@@ -579,7 +579,7 @@ func (tc *MonitoringTestCtx) ValidateWebhookRespectsUserOptOut(t *testing.T) {
 			Name:      TestPodMonitorName,
 			Namespace: TestNamespaceName,
 		}),
-		WithCondition(jq.Match(`.metadata.labels."opendatahub.io/monitoring" == "false"`)),
+		WithCondition(jq.Match(`.metadata.labels."monitoring.opendatahub.io/scrape" == "false"`)),
 		WithCustomErrorMsg("Webhook should respect user's explicit monitoring=false on PodMonitor"),
 	)
 
@@ -589,7 +589,7 @@ func (tc *MonitoringTestCtx) ValidateWebhookRespectsUserOptOut(t *testing.T) {
 			Name:      TestServiceMonitorName,
 			Namespace: TestNamespaceName,
 		}),
-		WithCondition(jq.Match(`.metadata.labels."opendatahub.io/monitoring" == "false"`)),
+		WithCondition(jq.Match(`.metadata.labels."monitoring.opendatahub.io/scrape" == "false"`)),
 		WithCustomErrorMsg("Webhook should respect user's explicit monitoring=false on ServiceMonitor"),
 	)
 }
@@ -616,7 +616,7 @@ func (tc *MonitoringTestCtx) ValidateWebhookIdempotency(t *testing.T) {
 			Name:      TestPodMonitorName,
 			Namespace: TestNamespaceName,
 		}),
-		WithCondition(jq.Match(`.metadata.labels."opendatahub.io/monitoring" == "true"`)),
+		WithCondition(jq.Match(`.metadata.labels."monitoring.opendatahub.io/scrape" == "true"`)),
 		WithCustomErrorMsg("Webhook should be idempotent - PodMonitor already has monitoring=true"),
 	)
 
@@ -626,7 +626,7 @@ func (tc *MonitoringTestCtx) ValidateWebhookIdempotency(t *testing.T) {
 			Name:      TestServiceMonitorName,
 			Namespace: TestNamespaceName,
 		}),
-		WithCondition(jq.Match(`.metadata.labels."opendatahub.io/monitoring" == "true"`)),
+		WithCondition(jq.Match(`.metadata.labels."monitoring.opendatahub.io/scrape" == "true"`)),
 		WithCustomErrorMsg("Webhook should be idempotent - ServiceMonitor already has monitoring=true"),
 	)
 }
@@ -634,7 +634,7 @@ func (tc *MonitoringTestCtx) ValidateWebhookIdempotency(t *testing.T) {
 // ValidateWebhookSkipsWhenMonitoringDisabled tests that webhook does not inject labels when monitoring is disabled.
 // This test verifies that the webhook checks whether the Monitoring CR exists and monitoring is enabled
 // before performing label injection. When monitoring is disabled (managementState: Removed),
-// the webhook should not inject labels even if the namespace has opendatahub.io/monitoring=true.
+// the webhook should not inject labels even if the namespace has monitoring.opendatahub.io/scrape=true.
 func (tc *MonitoringTestCtx) ValidateWebhookSkipsWhenMonitoringDisabled(t *testing.T) {
 	t.Helper()
 
@@ -669,7 +669,7 @@ func (tc *MonitoringTestCtx) ValidateWebhookSkipsWhenMonitoringDisabled(t *testi
 		labels.ODHLabelMonitoring: "true",
 	}
 
-	// Step 4: Create monitors WITHOUT the opendatahub.io/monitoring label
+	// Step 4: Create monitors WITHOUT the monitoring.opendatahub.io/scrape label
 	// The webhook should NOT inject the label because monitoring is disabled
 	noLabels := map[string]string{} // No monitoring label on the monitor itself
 
@@ -683,7 +683,7 @@ func (tc *MonitoringTestCtx) ValidateWebhookSkipsWhenMonitoringDisabled(t *testi
 			Namespace: TestNamespaceName,
 		}),
 	)
-	tc.g.Expect(podMonitor.GetLabels()).NotTo(HaveKey("opendatahub.io/monitoring"),
+	tc.g.Expect(podMonitor.GetLabels()).NotTo(HaveKey("monitoring.opendatahub.io/scrape"),
 		"Webhook should NOT inject monitoring=true when monitoring is disabled (PodMonitor)")
 
 	// Step 6: Verify ServiceMonitor does NOT have monitoring=true label injected
@@ -694,7 +694,7 @@ func (tc *MonitoringTestCtx) ValidateWebhookSkipsWhenMonitoringDisabled(t *testi
 			Namespace: TestNamespaceName,
 		}),
 	)
-	tc.g.Expect(serviceMonitor.GetLabels()).NotTo(HaveKey("opendatahub.io/monitoring"),
+	tc.g.Expect(serviceMonitor.GetLabels()).NotTo(HaveKey("monitoring.opendatahub.io/scrape"),
 		"Webhook should NOT inject monitoring=true when monitoring is disabled (ServiceMonitor)")
 
 	t.Logf("Webhook correctly skipped injection when monitoring was disabled")

--- a/tests/e2e/monitoring_test.go
+++ b/tests/e2e/monitoring_test.go
@@ -2770,8 +2770,8 @@ func (tc *MonitoringTestCtx) ValidateTargetAllocatorDeploymentWithMetrics(t *tes
 			jq.Match(`.spec.targetAllocator.enabled == true`),
 			jq.Match(`.spec.targetAllocator.serviceAccount == "%s"`, TargetAllocatorServiceAccount),
 			jq.Match(`.spec.targetAllocator.prometheusCR.enabled == true`),
-			jq.Match(`.spec.targetAllocator.prometheusCR.podMonitorSelector.matchLabels."opendatahub.io/monitoring" == "true"`),
-			jq.Match(`.spec.targetAllocator.prometheusCR.serviceMonitorSelector.matchLabels."opendatahub.io/monitoring" == "true"`),
+			jq.Match(`.spec.targetAllocator.prometheusCR.podMonitorSelector.matchLabels."monitoring.opendatahub.io/scrape" == "true"`),
+			jq.Match(`.spec.targetAllocator.prometheusCR.serviceMonitorSelector.matchLabels."monitoring.opendatahub.io/scrape" == "true"`),
 		)),
 		WithCustomErrorMsg("OpenTelemetryCollector should have targetAllocator enabled with correct configuration"),
 	)


### PR DESCRIPTION
<!---
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->
In order to export metrics to the ODH/RHOAI monitoring stack, pod and service monitors are expected to be labeled with the "monitoring.opendatahub.io/scrape" key set to "true".

However, the OTEL collector's target allocator was looking for a label with "opendatahub.io/monitoring" key set to "true", and thus never matched those monitor objects, resulting in metrics not being scraped by the above mentioned collector, and consequently not reaching the Prometheus instance that is part of the ODH/RHOAI monitoring stack.

Hence, we replace the "opendatahub.io/monitoring" key with "monitoring.opendatahub.io/scrape".

<!--- Link your JIRA and related links here for reference. -->
RHOAIENG-56593

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested manually - deployed on a cluster in which the service monitor for usage data from MaaS is labeled properly and seeing the data gets to the Prometheus instance within the `opendatahub` namespace.

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully
- [ ] New RELATED_IMAGE mappings are listed in ODH-Build-Config and RHOAI-Build-Config (CI validates names against build-config repos). Include links to build-config PRs in the description.

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
This PR fixes functionality that exists already.
<!--- This section can be left empty if you're not opting out of the E2E requirement -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Configuration Updates**
  * Renamed monitoring label from `opendatahub.io/monitoring` to `monitoring.opendatahub.io/scrape` across the system.

* **Policy Validation**
  * Admission policy now allows missing labels and accepts explicit `"true"`/`"false"` for the new scrape label.

* **Bug Fixes**
  * Fixed Prometheus selector rendering so collectors and target allocators reference the new scrape label.

* **Webhook**
  * Mutating webhook injects `monitoring.opendatahub.io/scrape=true` when appropriate and respects explicit `true`/`false`.

* **Tests**
  * Updated e2e and unit tests to validate the new label key and behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->