### PR TITLE
Add odh-kserve-module-operator to manifests-config.yaml

### DIFF
--- a/build/manifests-config.yaml
+++ b/build/manifests-config.yaml
@@ -60,3 +60,6 @@ map:
   odh-ogx-k8s-operator:
     src: config
     dest: ogx
+  odh-kserve-module-operator:
+    src: kserve-module/config
+    dest: kserve-module


### PR DESCRIPTION
Adds 'odh-kserve-module-operator' to the operator manifests config map.

Component: odh-kserve-module-operator
Manifest source path: kserve-module/config
Manifest dest path:   kserve-module
Upstream repo: https://github.com/opendatahub-io/kserve @ master
Jira: https://redhat.atlassian.net/browse/RHOAIENG-62284

**File changed:**
- `build/manifests-config.yaml` — added `odh-kserve-module-operator` entry under `map:`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added KServe Module Operator to the build manifest configuration, making it available in the distribution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->