### PR TITLE
fix(maas): keep payload-processing in gateway namespace after namespace transform

### DIFF
--- a/internal/controller/components/modelsasservice/modelsasservice_support.go
+++ b/internal/controller/components/modelsasservice/modelsasservice_support.go
@@ -31,8 +31,10 @@ import (
 	"sigs.k8s.io/kustomize/api/builtins" //nolint:staticcheck // Remove after package update
 	"sigs.k8s.io/kustomize/api/krusty"
 	"sigs.k8s.io/kustomize/api/resmap"
+	"sigs.k8s.io/kustomize/api/resource"
 	"sigs.k8s.io/kustomize/api/types"
 	"sigs.k8s.io/kustomize/kyaml/filesys"
+	kyaml "sigs.k8s.io/kustomize/kyaml/yaml"
 
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/api/components/v1alpha1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/status"
@@ -264,28 +266,71 @@ func normalizeUnstructuredObject(obj map[string]any) (map[string]any, error) {
 	return out, nil
 }
 
-// gatewayNamespaceResourceNames lists namespaced resources that must remain in the
-// gateway namespace after the blanket NamespaceApplierPlugin transform.
-// Only namespaced resources are listed here; cluster-scoped resources like
-// ClusterRoleBinding are not affected by SetNamespace and are not included.
-var gatewayNamespaceResourceNames = map[string]bool{
-	"payload-processing":         true, // Deployment, Service, ServiceAccount
-	"payload-processing-plugins": true, // ConfigMap
+type resourceKey struct {
+	kind string
+	name string
+}
+
+// gatewayNamespaceResources lists the specific resources that must remain in the
+// gateway namespace after the blanket NamespaceApplierPlugin transform. Keyed by
+// kind+name to avoid accidentally matching unrelated resources.
+var gatewayNamespaceResources = map[resourceKey]bool{
+	{kind: "Deployment", name: "payload-processing"}:            true,
+	{kind: "Service", name: "payload-processing"}:               true,
+	{kind: "ServiceAccount", name: "payload-processing"}:        true,
+	{kind: "ConfigMap", name: "payload-processing-plugins"}:     true,
+	{kind: "ClusterRoleBinding", name: "payload-processing-reader"}: true,
 }
 
 // restoreGatewayNamespaceResources moves resources that belong in the gateway
 // namespace back from the application namespace. The blanket NamespaceApplierPlugin
 // moves everything to appNs, but payload-processing resources must stay in the
 // gateway namespace for the EnvoyFilter to attach to the Gateway.
+//
+// For ClusterRoleBindings, the NamespaceApplierPlugin also rewrites
+// subjects[].namespace; this function restores it to the gateway namespace
+// so the RBAC binding matches the actual ServiceAccount location.
 func restoreGatewayNamespaceResources(resMap resmap.ResMap) error {
 	for _, res := range resMap.Resources() {
-		if !gatewayNamespaceResourceNames[res.GetName()] {
+		k := resourceKey{kind: res.GetKind(), name: res.GetName()}
+		if !gatewayNamespaceResources[k] {
+			continue
+		}
+		if res.GetKind() == "ClusterRoleBinding" {
+			if err := restoreCRBSubjectsNamespace(res, DefaultGatewayNamespace); err != nil {
+				return fmt.Errorf("restore subjects namespace on ClusterRoleBinding %s: %w", res.GetName(), err)
+			}
 			continue
 		}
 		if err := res.SetNamespace(DefaultGatewayNamespace); err != nil {
 			return fmt.Errorf("set namespace on %s %s: %w", res.GetKind(), res.GetName(), err)
 		}
 	}
+	return nil
+}
+
+// restoreCRBSubjectsNamespace updates subjects[].namespace on a ClusterRoleBinding
+// resource. SetNamespace only changes metadata.namespace which is meaningless for
+// cluster-scoped resources; the NamespaceApplierPlugin rewrites subjects separately.
+func restoreCRBSubjectsNamespace(res *resource.Resource, namespace string) error {
+	m, err := res.Map()
+	if err != nil {
+		return err
+	}
+	subjects, ok := m["subjects"].([]any)
+	if !ok {
+		return nil
+	}
+	for _, s := range subjects {
+		if subject, ok := s.(map[string]any); ok {
+			subject["namespace"] = namespace
+		}
+	}
+	node, err := kyaml.FromMap(m)
+	if err != nil {
+		return err
+	}
+	res.RNode = *node
 	return nil
 }
 

--- a/internal/controller/components/modelsasservice/modelsasservice_support.go
+++ b/internal/controller/components/modelsasservice/modelsasservice_support.go
@@ -264,14 +264,13 @@ func normalizeUnstructuredObject(obj map[string]any) (map[string]any, error) {
 	return out, nil
 }
 
-// gatewayNamespaceResourceNames lists resources that must remain in the gateway
-// namespace after the blanket NamespaceApplierPlugin transform. These resources
-// are deployed to openshift-ingress in the base manifests because the EnvoyFilter
-// must run in the same namespace as the Gateway.
+// gatewayNamespaceResourceNames lists namespaced resources that must remain in the
+// gateway namespace after the blanket NamespaceApplierPlugin transform.
+// Only namespaced resources are listed here; cluster-scoped resources like
+// ClusterRoleBinding are not affected by SetNamespace and are not included.
 var gatewayNamespaceResourceNames = map[string]bool{
 	"payload-processing":         true, // Deployment, Service, ServiceAccount
 	"payload-processing-plugins": true, // ConfigMap
-	"payload-processing-reader":  true, // ClusterRoleBinding (subjects namespace)
 }
 
 // restoreGatewayNamespaceResources moves resources that belong in the gateway

--- a/internal/controller/components/modelsasservice/modelsasservice_support.go
+++ b/internal/controller/components/modelsasservice/modelsasservice_support.go
@@ -275,10 +275,10 @@ type resourceKey struct {
 // gateway namespace after the blanket NamespaceApplierPlugin transform. Keyed by
 // kind+name to avoid accidentally matching unrelated resources.
 var gatewayNamespaceResources = map[resourceKey]bool{
-	{kind: "Deployment", name: "payload-processing"}:            true,
-	{kind: "Service", name: "payload-processing"}:               true,
-	{kind: "ServiceAccount", name: "payload-processing"}:        true,
-	{kind: "ConfigMap", name: "payload-processing-plugins"}:     true,
+	{kind: "Deployment", name: "payload-processing"}:                true,
+	{kind: "Service", name: "payload-processing"}:                   true,
+	{kind: "ServiceAccount", name: "payload-processing"}:            true,
+	{kind: "ConfigMap", name: "payload-processing-plugins"}:         true,
 	{kind: "ClusterRoleBinding", name: "payload-processing-reader"}: true,
 }
 

--- a/internal/controller/components/modelsasservice/modelsasservice_support.go
+++ b/internal/controller/components/modelsasservice/modelsasservice_support.go
@@ -135,6 +135,15 @@ func buildMaasOperatorInstallManifests(ctx context.Context, rr *odhtypes.Reconci
 		return nil, fmt.Errorf("namespace transform for maas-controller bundle: %w", err)
 	}
 
+	// The blanket namespace transform above moves ALL resources to appNs, but
+	// payload-processing resources must remain in the gateway namespace because
+	// the EnvoyFilter must run in the same namespace as the Gateway for Envoy
+	// to attach ext_proc filters. Restore their namespace to the gateway ns.
+	// See RHOAIENG-59726.
+	if err := restoreGatewayNamespaceResources(resMap); err != nil {
+		return nil, fmt.Errorf("restore gateway namespace for payload-processing: %w", err)
+	}
+
 	componentLabels := map[string]string{
 		labels.ODH.Component(componentApi.ModelsAsServiceComponentName): labels.True,
 		labels.K8SCommon.PartOf: componentApi.ModelsAsServiceComponentName,
@@ -253,6 +262,32 @@ func normalizeUnstructuredObject(obj map[string]any) (map[string]any, error) {
 		return nil, err
 	}
 	return out, nil
+}
+
+// gatewayNamespaceResourceNames lists resources that must remain in the gateway
+// namespace after the blanket NamespaceApplierPlugin transform. These resources
+// are deployed to openshift-ingress in the base manifests because the EnvoyFilter
+// must run in the same namespace as the Gateway.
+var gatewayNamespaceResourceNames = map[string]bool{
+	"payload-processing":         true, // Deployment, Service, ServiceAccount
+	"payload-processing-plugins": true, // ConfigMap
+	"payload-processing-reader":  true, // ClusterRoleBinding (subjects namespace)
+}
+
+// restoreGatewayNamespaceResources moves resources that belong in the gateway
+// namespace back from the application namespace. The blanket NamespaceApplierPlugin
+// moves everything to appNs, but payload-processing resources must stay in the
+// gateway namespace for the EnvoyFilter to attach to the Gateway.
+func restoreGatewayNamespaceResources(resMap resmap.ResMap) error {
+	for _, res := range resMap.Resources() {
+		if !gatewayNamespaceResourceNames[res.GetName()] {
+			continue
+		}
+		if err := res.SetNamespace(DefaultGatewayNamespace); err != nil {
+			return fmt.Errorf("set namespace on %s %s: %w", res.GetKind(), res.GetName(), err)
+		}
+	}
+	return nil
 }
 
 // deployImageParams maps the kustomize image name (as rendered by the images

--- a/internal/controller/components/modelsasservice/modelsasservice_support_test.go
+++ b/internal/controller/components/modelsasservice/modelsasservice_support_test.go
@@ -1,0 +1,199 @@
+//nolint:testpackage
+package modelsasservice
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	"sigs.k8s.io/kustomize/api/provider"
+	"sigs.k8s.io/kustomize/api/resmap"
+)
+
+var rf = provider.NewDefaultDepProvider().GetResourceFactory()
+
+func buildTestResMap(t *testing.T, yamls ...string) resmap.ResMap {
+	t.Helper()
+	g := NewWithT(t)
+	rm := resmap.New()
+	for _, y := range yamls {
+		res, err := rf.FromBytes([]byte(y))
+		g.Expect(err).ShouldNot(HaveOccurred())
+		g.Expect(rm.Append(res)).ShouldNot(HaveOccurred())
+	}
+	return rm
+}
+
+func TestRestoreGatewayNamespaceResources(t *testing.T) {
+	g := NewWithT(t)
+
+	rm := buildTestResMap(t,
+		`
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: payload-processing
+  namespace: redhat-ods-applications
+`,
+		`
+apiVersion: v1
+kind: Service
+metadata:
+  name: payload-processing
+  namespace: redhat-ods-applications
+`,
+		`
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: payload-processing
+  namespace: redhat-ods-applications
+`,
+		`
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: payload-processing-plugins
+  namespace: redhat-ods-applications
+`,
+		// Unrelated resource that should NOT be moved
+		`
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: maas-controller
+  namespace: redhat-ods-applications
+`,
+		// CRB with subjects in the wrong namespace
+		`
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: payload-processing-reader
+subjects:
+- kind: ServiceAccount
+  name: payload-processing
+  namespace: redhat-ods-applications
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: payload-processing-reader
+`,
+	)
+
+	err := restoreGatewayNamespaceResources(rm)
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	for _, res := range rm.Resources() {
+		k := resourceKey{kind: res.GetKind(), name: res.GetName()}
+
+		switch {
+		case k == (resourceKey{kind: "Deployment", name: "maas-controller"}):
+			g.Expect(res.GetNamespace()).To(Equal("redhat-ods-applications"),
+				"unrelated resource should keep app namespace")
+
+		case k.kind == "ClusterRoleBinding":
+			m, err := res.Map()
+			g.Expect(err).ShouldNot(HaveOccurred())
+			subjects, ok := m["subjects"].([]any)
+			g.Expect(ok).To(BeTrue(), "CRB should have subjects")
+			for _, s := range subjects {
+				subj, ok := s.(map[string]any)
+				g.Expect(ok).To(BeTrue())
+				g.Expect(subj["namespace"]).To(Equal(DefaultGatewayNamespace),
+					"CRB subjects[].namespace should be restored to gateway namespace")
+			}
+
+		case gatewayNamespaceResources[k]:
+			g.Expect(res.GetNamespace()).To(Equal(DefaultGatewayNamespace),
+				"%s/%s should be moved to gateway namespace", k.kind, k.name)
+		}
+	}
+}
+
+func TestRestoreGatewayNamespaceResources_IgnoresNonAllowlisted(t *testing.T) {
+	g := NewWithT(t)
+
+	rm := buildTestResMap(t,
+		`
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: some-other-deployment
+  namespace: redhat-ods-applications
+`,
+		// Same name but different kind — should NOT match
+		`
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: payload-processing
+  namespace: redhat-ods-applications
+`,
+	)
+
+	err := restoreGatewayNamespaceResources(rm)
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	for _, res := range rm.Resources() {
+		g.Expect(res.GetNamespace()).To(Equal("redhat-ods-applications"),
+			"%s/%s should not be moved", res.GetKind(), res.GetName())
+	}
+}
+
+func TestRestoreCRBSubjectsNamespace(t *testing.T) {
+	g := NewWithT(t)
+
+	res, err := rf.FromBytes([]byte(`
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: payload-processing-reader
+subjects:
+- kind: ServiceAccount
+  name: payload-processing
+  namespace: wrong-namespace
+- kind: ServiceAccount
+  name: another-sa
+  namespace: wrong-namespace
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: payload-processing-reader
+`))
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	err = restoreCRBSubjectsNamespace(res, "openshift-ingress")
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	m, err := res.Map()
+	g.Expect(err).ShouldNot(HaveOccurred())
+	subjects, ok := m["subjects"].([]any)
+	g.Expect(ok).To(BeTrue())
+	g.Expect(subjects).To(HaveLen(2))
+
+	for i, s := range subjects {
+		subj, ok := s.(map[string]any)
+		g.Expect(ok).To(BeTrue())
+		g.Expect(subj["namespace"]).To(Equal("openshift-ingress"),
+			"subjects[%d].namespace should be restored", i)
+	}
+}
+
+func TestRestoreCRBSubjectsNamespace_NoSubjects(t *testing.T) {
+	g := NewWithT(t)
+
+	res, err := rf.FromBytes([]byte(`
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: no-subjects-crb
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: some-role
+`))
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	err = restoreCRBSubjectsNamespace(res, "openshift-ingress")
+	g.Expect(err).ShouldNot(HaveOccurred())
+}

--- a/internal/controller/components/modelsasservice/modelsasservice_support_test.go
+++ b/internal/controller/components/modelsasservice/modelsasservice_support_test.go
@@ -4,14 +4,15 @@ package modelsasservice
 import (
 	"testing"
 
-	. "github.com/onsi/gomega"
 	"sigs.k8s.io/kustomize/api/provider"
 	"sigs.k8s.io/kustomize/api/resmap"
+
+	. "github.com/onsi/gomega"
 )
 
 var rf = provider.NewDefaultDepProvider().GetResourceFactory()
 
-func buildTestResMap(t *testing.T, yamls ...string) resmap.ResMap {
+func buildTestResMap(t *testing.T, yamls ...string) resmap.ResMap { //nolint:ireturn
 	t.Helper()
 	g := NewWithT(t)
 	rm := resmap.New()


### PR DESCRIPTION
## Summary

- Add `restoreGatewayNamespaceResources()` to move payload-processing resources back to the gateway namespace (`openshift-ingress`) after the blanket `NamespaceApplierPlugin` transform
- Payload-processing Deployment, Service, ConfigMap, and ClusterRoleBinding must stay in the gateway namespace because the EnvoyFilter must run in the same namespace as the Gateway

## Problem

The operator's `NamespaceApplierPlugin` moves ALL resources in the maas-controller install bundle to the application namespace (e.g. `redhat-ods-applications`). This incorrectly moves payload-processing resources out of `openshift-ingress`, causing the EnvoyFilter `cluster_name` FQDN (`payload-processing.openshift-ingress.svc.cluster.local`) to not match the actual service location, breaking the ext_proc filter chain.

## Fix

After the blanket namespace transform, restore payload-processing resources (`payload-processing`, `payload-processing-plugins`, `payload-processing-reader`) back to `DefaultGatewayNamespace` (`openshift-ingress`).

Supersedes #3487 which was auto-generated and stale.

Ref: RHOAIENG-59726

## Test plan

- [x] Verify payload-processing Deployment, Service land in `openshift-ingress` after operator reconcile
- [x] Verify EnvoyFilter cluster_name FQDN resolves correctly
- [x] Operator E2E tests pass

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
Keep payload-processing in gateway namespace after namespace transform does not require the e2e tests update.

<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Restore select gateway/ingress payload resources back to the gateway namespace after namespace-wide transforms, preventing them from remaining in the application namespace.
  * Installer now surfaces a clear error if restoring these gateway resources fails.

* **Tests**
  * Added tests validating namespace restoration for allowed gateway resources and correct updating of ClusterRoleBinding subject namespaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->