### PR TITLE
fix(ccm): continue deploying resources when individual apply fails

### DIFF
--- a/pkg/controller/actions/deploy/action_deploy.go
+++ b/pkg/controller/actions/deploy/action_deploy.go
@@ -55,6 +55,7 @@ type Action struct {
 	annotations      map[string]string
 	cache            *Cache
 	sortFn           SortFn
+	continueOnError  bool
 }
 
 type ActionOpts func(*Action)
@@ -142,6 +143,16 @@ func WithApplyOrder() ActionOpts {
 	return WithSortFn(resources.SortByApplyOrder)
 }
 
+// WithContinueOnError makes the deploy action continue applying remaining
+// resources when an individual resource fails instead of stopping at the
+// first error. All errors are collected and returned as a joined error.
+// Failed resources will be retried on the next reconcile cycle.
+func WithContinueOnError() ActionOpts {
+	return func(action *Action) {
+		action.continueOnError = true
+	}
+}
+
 // resolveFieldOwner returns the effective field owner for the reconciled
 // instance.  When a.fieldOwner is explicitly configured it is returned
 // as-is; otherwise the owner is derived from the instance's Kind.
@@ -179,6 +190,9 @@ func (a *Action) run(ctx context.Context, rr *odhTypes.ReconciliationRequest) er
 
 	igvk := rr.Instance.GetObjectKind().GroupVersionKind()
 
+	var firstErr error
+	var failedResources []string
+
 	for i := range rr.Resources {
 		res := rr.Resources[i]
 		current := resources.GvkToUnstructured(res.GroupVersionKind())
@@ -190,7 +204,21 @@ func (a *Action) run(ctx context.Context, rr *odhTypes.ReconciliationRequest) er
 			// that there's no previous known state of the resource
 			current = nil
 		case lookupErr != nil:
-			return fmt.Errorf("failed to lookup object %s/%s: %w", res.GetNamespace(), res.GetName(), lookupErr)
+			if !a.continueOnError {
+				return fmt.Errorf("failed to lookup object %s/%s: %w", res.GetNamespace(), res.GetName(), lookupErr)
+			}
+
+			resErr := fmt.Errorf("failed to lookup object %s/%s: %w", res.GetNamespace(), res.GetName(), lookupErr)
+			logf.FromContext(ctx).Error(lookupErr, "resource lookup failed, continuing",
+				"namespace", res.GetNamespace(), "name", res.GetName())
+
+			if firstErr == nil {
+				firstErr = resErr
+			}
+
+			failedResources = append(failedResources, res.GetNamespace()+"/"+res.GetName())
+
+			continue
 		default:
 			// Remove the previous owner reference if set, This is required during the
 			// transition from the old to the new operator.
@@ -221,12 +249,35 @@ func (a *Action) run(ctx context.Context, rr *odhTypes.ReconciliationRequest) er
 		}
 
 		if err != nil {
-			return fmt.Errorf("failure deploying resource %s/%s: %w", res.GetNamespace(), res.GetName(), err)
+			if !a.continueOnError {
+				return fmt.Errorf("failure deploying resource %s/%s: %w", res.GetNamespace(), res.GetName(), err)
+			}
+
+			resErr := fmt.Errorf("failure deploying resource %s/%s: %w", res.GetNamespace(), res.GetName(), err)
+			logf.FromContext(ctx).Error(err, "resource deploy failed, continuing",
+				"namespace", res.GetNamespace(), "name", res.GetName())
+
+			if firstErr == nil {
+				firstErr = resErr
+			}
+
+			failedResources = append(failedResources, res.GetNamespace()+"/"+res.GetName())
+
+			continue
 		}
 
 		if ok {
 			DeployedResourcesTotal.WithLabelValues(controllerName).Inc()
 		}
+	}
+
+	if len(failedResources) > 0 {
+		if len(failedResources) == 1 {
+			return firstErr
+		}
+
+		return fmt.Errorf("%w; %d more resources failed: %s (see logs for details)",
+			firstErr, len(failedResources)-1, strings.Join(failedResources[1:], ", "))
 	}
 
 	return nil

--- a/pkg/controller/actions/deploy/action_deploy_test.go
+++ b/pkg/controller/actions/deploy/action_deploy_test.go
@@ -2,6 +2,7 @@ package deploy_test
 
 import (
 	"context"
+	"errors"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -16,6 +17,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -23,6 +25,7 @@ import (
 	apimachinery "k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 
@@ -1868,4 +1871,140 @@ func TestDeployCRDWithPartOfLabel(t *testing.T) {
 		jq.Match(`.metadata.labels."%s" == "%s"`, customLabelKey, "dashboard"),
 		Not(jq.Match(`.metadata.labels | has("%s")`, labels.PlatformPartOf)),
 	))
+}
+
+func TestDeployContinueOnError(t *testing.T) {
+	g := NewWithT(t)
+
+	ctx := t.Context()
+	ns := xid.New().String()
+	failName := xid.New().String()
+	okName := xid.New().String()
+
+	cl, err := fakeclient.New(
+		fakeclient.WithInterceptorFuncs(interceptor.Funcs{
+			Create: func(ctx context.Context, client client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
+				if obj.GetName() == failName {
+					return errors.New("simulated webhook error: connection refused")
+				}
+				return client.Create(ctx, obj, opts...)
+			},
+			Apply: func(ctx context.Context, cl client.WithWatch, apply runtime.ApplyConfiguration, opts ...client.ApplyOption) error {
+				// ApplyConfigurationFromUnstructured wraps *unstructured.Unstructured
+				type nameGetter interface {
+					GetName() string
+				}
+				if ng, ok := apply.(nameGetter); ok && ng.GetName() == failName {
+					return errors.New("simulated webhook error: connection refused")
+				}
+				return cl.Apply(ctx, apply, opts...)
+			},
+		}),
+	)
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	failObj, err := resources.ToUnstructured(&corev1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: corev1.SchemeGroupVersion.String(),
+			Kind:       "ConfigMap",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      failName,
+			Namespace: ns,
+		},
+	})
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	okObj, err := resources.ToUnstructured(&corev1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: corev1.SchemeGroupVersion.String(),
+			Kind:       "ConfigMap",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      okName,
+			Namespace: ns,
+		},
+	})
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	t.Run("WithContinueOnError deploys remaining resources after failure", func(t *testing.T) {
+		g := NewWithT(t)
+
+		action := deploy.NewAction(
+			deploy.WithContinueOnError(),
+		)
+
+		rr := types.ReconciliationRequest{
+			Client: cl,
+			Instance: &componentApi.Dashboard{
+				ObjectMeta: metav1.ObjectMeta{
+					Generation: 1,
+				},
+			},
+			Release: common.Release{
+				Name: cluster.OpenDataHub,
+				Version: version.OperatorVersion{Version: semver.Version{
+					Major: 1, Minor: 2, Patch: 3,
+				}},
+			},
+			Resources: []unstructured.Unstructured{*failObj, *okObj},
+			Controller: mocks.NewMockController(func(m *mocks.MockController) {
+				m.On("Owns", mock.Anything).Return(false)
+			}),
+		}
+
+		err := action(ctx, &rr)
+		g.Expect(err).Should(HaveOccurred())
+		g.Expect(err.Error()).Should(ContainSubstring(failName))
+		g.Expect(err.Error()).ShouldNot(ContainSubstring(okName))
+
+		out := &corev1.ConfigMap{}
+		g.Expect(cl.Get(ctx, client.ObjectKey{Namespace: ns, Name: okName}, out)).Should(Succeed())
+	})
+
+	t.Run("without ContinueOnError stops at first failure", func(t *testing.T) {
+		g := NewWithT(t)
+
+		okName2 := xid.New().String()
+		okObj2, err := resources.ToUnstructured(&corev1.ConfigMap{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: corev1.SchemeGroupVersion.String(),
+				Kind:       "ConfigMap",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      okName2,
+				Namespace: ns,
+			},
+		})
+		g.Expect(err).ShouldNot(HaveOccurred())
+
+		action := deploy.NewAction()
+
+		rr := types.ReconciliationRequest{
+			Client: cl,
+			Instance: &componentApi.Dashboard{
+				ObjectMeta: metav1.ObjectMeta{
+					Generation: 1,
+				},
+			},
+			Release: common.Release{
+				Name: cluster.OpenDataHub,
+				Version: version.OperatorVersion{Version: semver.Version{
+					Major: 1, Minor: 2, Patch: 3,
+				}},
+			},
+			Resources: []unstructured.Unstructured{*failObj, *okObj2},
+			Controller: mocks.NewMockController(func(m *mocks.MockController) {
+				m.On("Owns", mock.Anything).Return(false)
+			}),
+		}
+
+		err = action(ctx, &rr)
+		g.Expect(err).Should(HaveOccurred())
+		g.Expect(err.Error()).Should(ContainSubstring(failName))
+
+		out := &corev1.ConfigMap{}
+		err = cl.Get(ctx, client.ObjectKey{Namespace: ns, Name: okName2}, out)
+		g.Expect(k8serr.IsNotFound(err)).Should(BeTrue())
+	})
 }

--- a/pkg/controller/cloudmanager/action_reconcile.go
+++ b/pkg/controller/cloudmanager/action_reconcile.go
@@ -65,6 +65,7 @@ func NewReconcileAction(resourceID string, opts ...ReconcileActionOpts) (actions
 	helmRender := helm.NewAction(action.helmOpts...)
 	deployAction := deploy.NewAction(append(action.deployOpts,
 		deploy.WithApplyOrder(),
+		deploy.WithContinueOnError(),
 		deploy.WithPartOfLabel(labels.InfrastructurePartOf),
 		deploy.WithAnnotationPrefix(labels.ODHInfrastructurePrefix),
 	)...)

--- a/tests/e2e/cloudmanager/cloudmanager_test.go
+++ b/tests/e2e/cloudmanager/cloudmanager_test.go
@@ -27,7 +27,7 @@ func TestCloudManager_InvalidNameRejected(t *testing.T) {
 	cr.SetGroupVersionKind(provider.GVK)
 	cr.SetName("wrong-name")
 	cr.Object["spec"] = map[string]any{
-		"dependencies": allManagedWithCustomNamespaces(),
+		"dependencies": depsWithCustomNamespaces(ccmapi.Managed),
 	}
 
 	err := wt.Client().Create(wt.Context(), cr)
@@ -43,23 +43,24 @@ func TestCloudManager_InvalidNameRejected(t *testing.T) {
 //  3. NamespaceImmutability — verify namespace fields cannot be changed after creation
 //  4. StatusAfterSpecChange — mutates spec but restores to all-Managed
 //  5. UnmanagedNotReconciled — switches cert-manager to Unmanaged
-//  6. GarbageCollection — GC action: stale deletion, protected PKI, unmanaged transition
-//  7. CascadeDeletionOnCRDelete — Kubernetes cascade via ownerReferences (must be last)
+//  6. ManagedRecovery — all Managed→Unmanaged→Managed (RHOAIENG-62288)
+//  7. GarbageCollection — GC action: stale deletion, protected PKI, unmanaged transition
+//  8. CascadeDeletionOnCRDelete — Kubernetes cascade via ownerReferences (must be last)
 func TestCloudManager(t *testing.T) { //nolint:maintidx // sequential subtests sharing one CR lifecycle are clearer inline
 	wt := tc.NewWithT(t)
 
-	cr := newCloudManagerCR(allManagedWithCustomNamespaces())
+	cr := newCloudManagerCR(depsWithCustomNamespaces(ccmapi.Managed))
 	wt.Create(cr, k8sEngineCrNn()).Eventually().Should(Not(BeNil()))
 
 	// Safety net: if any test fails before GarbageCollectionOnDelete runs,
 	// clean up the CR so the next local run starts fresh.
 	t.Cleanup(func() {
-		_ = wt.Client().Delete(wt.Context(), newCloudManagerCR(allManagedWithCustomNamespaces()))
+		_ = wt.Client().Delete(wt.Context(), newCloudManagerCR(depsWithCustomNamespaces(ccmapi.Managed)))
 	})
 
 	waitForReady(wt)
 
-	// Read namespace values from the CR spec (custom namespaces configured in allManagedWithCustomNamespaces).
+	// Read namespace values from the CR spec (custom namespaces configured in depsWithCustomNamespaces).
 	crObj := wt.Get(provider.GVK, k8sEngineCrNn()).Eventually().Should(Not(BeNil()))
 	deployments := getManagedDependencyDeployments(wt, crObj)
 	certManagerOperandNS := getCertManagerOperandNamespace()
@@ -432,16 +433,45 @@ func TestCloudManager(t *testing.T) { //nolint:maintidx // sequential subtests s
 		}
 	})
 
-	// --- 5. GarbageCollection ---
+	// --- 6. ManagedRecovery ---
+	// Switches all dependencies to Unmanaged (tearing down operators and operands),
+	// then back to Managed. Verifies the controller recovers without error loops
+	// (e.g. RHOAIENG-62288: cert-manager CRDs present but webhook not yet ready).
+	t.Run("ManagedRecovery", func(t *testing.T) {
+		wt := tc.NewWithT(t)
+
+		// Switch all dependencies to Unmanaged. GC will delete all managed resources,
+		// including the cert-manager operator and its operand pods (webhook, controller,
+		// cainjector). CRDs may still remain on the cluster.
+		wt.Patch(provider.GVK, k8sEngineCrNn(), func(obj *unstructured.Unstructured) error {
+			return unstructured.SetNestedField(obj.Object, depsWithCustomNamespaces(ccmapi.Unmanaged), "spec", "dependencies")
+		}).Eventually().Should(Not(BeNil()))
+
+		wt.Get(provider.GVK, k8sEngineCrNn()).Eventually().Should(And(
+			jq.Match(`.status.observedGeneration == .metadata.generation`),
+			jq.Match(`.status.phase == "Ready"`),
+		))
+
+		// Switch all dependencies back to Managed. The operator must redeploy
+		// cert-manager and wait for webhook readiness before creating PKI resources.
+		wt.Patch(provider.GVK, k8sEngineCrNn(), func(obj *unstructured.Unstructured) error {
+			return unstructured.SetNestedField(obj.Object, depsWithCustomNamespaces(ccmapi.Managed), "spec", "dependencies")
+		}).Eventually().Should(Not(BeNil()))
+
+		waitForReady(wt)
+	})
+
+	// --- 7. GarbageCollection ---
 	// Tests the GC action that runs as the last step in the reconciliation pipeline.
 	// GC identifies stale or orphaned resources by comparing InstanceGeneration
 	// annotations and deletes them, while preserving protected PKI resources.
 	t.Run("GarbageCollection", func(t *testing.T) {
 		wt := tc.NewWithT(t)
 
-		// Restore all dependencies to Managed (step 4 left cert-manager Unmanaged).
+		// Restore all dependencies to Managed (step 6 already restored all to Managed,
+		// but this ensures a clean state regardless of earlier test mutations).
 		wt.Patch(provider.GVK, k8sEngineCrNn(), func(obj *unstructured.Unstructured) error {
-			return unstructured.SetNestedField(obj.Object, allManagedWithCustomNamespaces(), "spec", "dependencies")
+			return unstructured.SetNestedField(obj.Object, depsWithCustomNamespaces(ccmapi.Managed), "spec", "dependencies")
 		}).Eventually().Should(Not(BeNil()))
 
 		waitForReady(wt)
@@ -549,7 +579,7 @@ func TestCloudManager(t *testing.T) { //nolint:maintidx // sequential subtests s
 		})
 	})
 
-	// --- 6. CascadeDeletionOnCRDelete ---
+	// --- 8. CascadeDeletionOnCRDelete ---
 	// Deletes the CR and verifies Kubernetes cascade-deletes all owned resources
 	// (those with ownerReferences). Namespaces are excluded from ownership and
 	// survive deletion. Must be the last test since it destroys the CR.
@@ -559,7 +589,7 @@ func TestCloudManager(t *testing.T) { //nolint:maintidx // sequential subtests s
 		// Restore all dependencies to Managed (previous tests may have changed
 		// some to Unmanaged) and wait for all deployments to come back.
 		wt.Patch(provider.GVK, k8sEngineCrNn(), func(obj *unstructured.Unstructured) error {
-			return unstructured.SetNestedField(obj.Object, allManagedWithCustomNamespaces(), "spec", "dependencies")
+			return unstructured.SetNestedField(obj.Object, depsWithCustomNamespaces(ccmapi.Managed), "spec", "dependencies")
 		}).Eventually().Should(Not(BeNil()))
 
 		waitForReady(wt)

--- a/tests/e2e/cloudmanager/cloudmanager_test.go
+++ b/tests/e2e/cloudmanager/cloudmanager_test.go
@@ -42,8 +42,8 @@ func TestCloudManager_InvalidNameRejected(t *testing.T) {
 //  2. ReadOnlyValidation  — status, labels, workload checks, self-healing
 //  3. NamespaceImmutability — verify namespace fields cannot be changed after creation
 //  4. StatusAfterSpecChange — mutates spec but restores to all-Managed
-//  5. UnmanagedNotReconciled — switches cert-manager to Unmanaged
-//  6. ManagedRecovery — all Managed→Unmanaged→Managed (RHOAIENG-62288)
+//  5. ManagedRecovery — all Managed→Unmanaged→Managed (RHOAIENG-62288)
+//  6. UnmanagedNotReconciled — switches cert-manager to Unmanaged
 //  7. GarbageCollection — GC action: stale deletion, protected PKI, unmanaged transition
 //  8. CascadeDeletionOnCRDelete — Kubernetes cascade via ownerReferences (must be last)
 func TestCloudManager(t *testing.T) { //nolint:maintidx // sequential subtests sharing one CR lifecycle are clearer inline
@@ -383,7 +383,45 @@ func TestCloudManager(t *testing.T) { //nolint:maintidx // sequential subtests s
 		))
 	})
 
-	// --- 5. UnmanagedNotReconciled ---
+	// --- 5. ManagedRecovery ---
+	// Switches all dependencies to Unmanaged (tearing down operators and operands),
+	// then back to Managed. Verifies the controller recovers without error loops
+	// (e.g. RHOAIENG-62288: cert-manager CRDs present but webhook not yet ready).
+	t.Run("ManagedRecovery", func(t *testing.T) {
+		wt := tc.NewWithT(t)
+
+		// Switch all dependencies to Unmanaged. GC will delete all managed resources,
+		// including the cert-manager operator and its operand pods (webhook, controller,
+		// cainjector). CRDs may still remain on the cluster.
+		wt.Patch(provider.GVK, k8sEngineCrNn(), func(obj *unstructured.Unstructured) error {
+			return unstructured.SetNestedField(obj.Object, depsWithCustomNamespaces(ccmapi.Unmanaged), "spec", "dependencies")
+		}).Eventually().Should(Not(BeNil()))
+
+		// Verify all managed deployments are removed before switching back.
+		// We cannot use the KubernetesEngine CR because if cert-manager is not installed in the cluster,
+		// but the CRD are, it will never be in the Ready state.
+		wt.List(gvk.Deployment,
+			client.MatchingLabels{labels.InfrastructurePartOf: getPartOfLabelValue()},
+		).Eventually().Should(BeEmpty())
+
+		// CM-1019: cert-manager-operator may die before processing CertManager/cluster
+		// finalizers, leaving operand deployments orphaned. Force-delete them so the
+		// Unmanaged→Managed cycle is not flaky.
+		wt.DeleteAll(gvk.Deployment, client.InNamespace(certManagerOperandNS)).Eventually().Should(Succeed())
+		wt.List(gvk.Deployment,
+			client.InNamespace(certManagerOperandNS),
+		).Eventually().Should(BeEmpty())
+
+		// Switch all dependencies back to Managed. The operator must redeploy
+		// cert-manager and wait for webhook readiness before creating PKI resources.
+		wt.Patch(provider.GVK, k8sEngineCrNn(), func(obj *unstructured.Unstructured) error {
+			return unstructured.SetNestedField(obj.Object, depsWithCustomNamespaces(ccmapi.Managed), "spec", "dependencies")
+		}).Eventually().Should(Not(BeNil()))
+
+		waitForReady(wt)
+	})
+
+	// --- 6. UnmanagedNotReconciled ---
 	// Switches cert-manager to Unmanaged, then deletes its deployment and
 	// verifies the controller does NOT recreate it. Leaves the CR modified.
 	t.Run("UnmanagedNotReconciled", func(t *testing.T) {
@@ -431,34 +469,6 @@ func TestCloudManager(t *testing.T) { //nolint:maintidx // sequential subtests s
 				Name: dep.GetName(), Namespace: dep.GetNamespace(),
 			}).Eventually().Should(Not(BeNil()))
 		}
-	})
-
-	// --- 6. ManagedRecovery ---
-	// Switches all dependencies to Unmanaged (tearing down operators and operands),
-	// then back to Managed. Verifies the controller recovers without error loops
-	// (e.g. RHOAIENG-62288: cert-manager CRDs present but webhook not yet ready).
-	t.Run("ManagedRecovery", func(t *testing.T) {
-		wt := tc.NewWithT(t)
-
-		// Switch all dependencies to Unmanaged. GC will delete all managed resources,
-		// including the cert-manager operator and its operand pods (webhook, controller,
-		// cainjector). CRDs may still remain on the cluster.
-		wt.Patch(provider.GVK, k8sEngineCrNn(), func(obj *unstructured.Unstructured) error {
-			return unstructured.SetNestedField(obj.Object, depsWithCustomNamespaces(ccmapi.Unmanaged), "spec", "dependencies")
-		}).Eventually().Should(Not(BeNil()))
-
-		wt.Get(provider.GVK, k8sEngineCrNn()).Eventually().Should(And(
-			jq.Match(`.status.observedGeneration == .metadata.generation`),
-			jq.Match(`.status.phase == "Ready"`),
-		))
-
-		// Switch all dependencies back to Managed. The operator must redeploy
-		// cert-manager and wait for webhook readiness before creating PKI resources.
-		wt.Patch(provider.GVK, k8sEngineCrNn(), func(obj *unstructured.Unstructured) error {
-			return unstructured.SetNestedField(obj.Object, depsWithCustomNamespaces(ccmapi.Managed), "spec", "dependencies")
-		}).Eventually().Should(Not(BeNil()))
-
-		waitForReady(wt)
 	})
 
 	// --- 7. GarbageCollection ---

--- a/tests/e2e/cloudmanager/helper_test.go
+++ b/tests/e2e/cloudmanager/helper_test.go
@@ -58,29 +58,26 @@ func newCloudManagerCR(deps map[string]any) *unstructured.Unstructured {
 	return obj
 }
 
-// allManagedWithCustomNamespaces returns a dependencies map with custom namespace
-// configurations, ensuring the tests verify non-default namespace handling.
-// Note: cert-manager uses hardcoded namespaces and cannot be customized.
-func allManagedWithCustomNamespaces() map[string]any {
-	managed := string(ccmapi.Managed)
+func depsWithCustomNamespaces(policy ccmapi.ManagementPolicy) map[string]any {
+	p := string(policy)
 	return map[string]any{
 		"certManager": map[string]any{
-			"managementPolicy": managed,
+			"managementPolicy": p,
 		},
 		"lws": map[string]any{
-			"managementPolicy": managed,
+			"managementPolicy": p,
 			"configuration": map[string]any{
 				"namespace": customLWSOperatorNS,
 			},
 		},
 		"sailOperator": map[string]any{
-			"managementPolicy": managed,
+			"managementPolicy": p,
 			"configuration": map[string]any{
 				"namespace": customSailOperatorNS,
 			},
 		},
 		"gatewayAPI": map[string]any{
-			"managementPolicy": managed,
+			"managementPolicy": p,
 		},
 	}
 }


### PR DESCRIPTION
## Description

- **Continue-on-error deploy**: Add `WithContinueOnError()` option to the deploy action that collects individual resource failures instead of stopping at the first error. Remaining resources are still applied, and the aggregated error is returned with the first failure shown in full plus a summary of others. This prevents deadlocks where a transient failure (e.g., cert-manager webhook not ready) blocks deployment of later resources in the same cycle.
- **CCM opt-in**: Enable `WithContinueOnError` for all cloud manager reconcilers via `NewReconcileAction`. Component controllers keep the current stop-on-first-error behavior.
- **E2E ManagedRecovery test**: Add test for the Managed→Unmanaged→Managed transition cycle (RHOAIENG-62288), verifying all managed deployments are cleaned up before re-enabling, and the CR recovers to Ready state.

Jira: https://issues.redhat.com/browse/RHOAIENG-62288

## How Has This Been Tested?

- Unit tests: `TestDeployContinueOnError` — verifies remaining resources are deployed after a failure with `WithContinueOnError`, and verifies current stop-on-error behavior is preserved without the option.
- E2E tests: `TestCloudManager/ManagedRecovery` — full Unmanaged→Managed cycle on a KinD cluster.

## Screenshot or short clip

N/A

## Merge criteria

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully
- [ ] New RELATED_IMAGE mappings are listed in ODH-Build-Config and RHOAI-Build-Config (CI validates names against build-config repos). Include links to build-config PRs in the description.

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [ ] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Deployments can run in "continue on error" mode so processing continues past individual resource failures and returns a summarized failure report.
  * Reconcile flow now applies continue-on-error during server-side apply deployments.

* **Tests**
  * Added unit test validating continue-on-error vs fail-fast behavior.
  * Updated e2e tests: introduced a configurable dependency helper, added a ManagedRecovery subtest, renumbered steps, adjusted cleanup behavior, and skipped a flaky deletion subtest.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->