### PR TITLE
fix: prevent reset of kserve-local-gateway

### DIFF
--- a/internal/controller/components/kserve/resources/servicemesh/routing/istio-kserve-local-gateway.tmpl.yaml
+++ b/internal/controller/components/kserve/resources/servicemesh/routing/istio-kserve-local-gateway.tmpl.yaml
@@ -8,6 +8,8 @@ kind: Gateway
 metadata:
   labels:
     platform.opendatahub.io/dependency: serverless
+  annotations:
+    opendatahub.io/managed: "false"
   name: kserve-local-gateway
   namespace: {{ .ControlPlane.Namespace }}
 spec:


### PR DESCRIPTION

## Description

The kserve-local-gateway should be created by the operator and, then,
edits should be tolerated. The odh-model-controller makes edits
to configure cluster-internal networking to models deployed in
Serverless mode.

Without the annotationi, odh-operator is resetting kserve-local-gateway
to its template state. This adds `opendatahub.io/managed=false`
annotation to prevent the reset.

Fixes: https://redhat.atlassian.net/browse/RHOAIENG-62568

## How Has This Been Tested?

Manual testing / replication:
* Deploy RHOAI v2.25 with KServe enabled and Serverless mode enabled (other components can be turned off).
* Deploy a sample InferenceService in Serverless mode.
* Observe kserve-local-gateway being automatically edited by odh-model-controller with a new entry in `servers` field.
* Restart odh-operator pod.
    * Observe kserve-local-gateway being reset to its template state

Fix:
* Build odh-operator with the changes in this PR, deploy and replicate manual testing steps.
* Observe kserve-local-gateway is no longer reset.

Workaround:
* Manually annotate kserve-local-gateway with `opendatahub.io/managed=false`.

## Merge criteria

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully
- [x] New RELATED_IMAGE mappings are listed in ODH-Build-Config and RHOAI-Build-Config (CI validates names against build-config repos). Include links to build-config PRs in the description.

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification

Relying on manual testing, since this branch is in maintenance only.
