### PR TITLE
feat(monitoring): add cluster prometheus tenancy datasource for Perses

### DIFF
--- a/docs/NAMESPACE_RESTRICTED_METRICS.md
+++ b/docs/NAMESPACE_RESTRICTED_METRICS.md
@@ -33,7 +33,7 @@ Prometheus (prometheus-operated service on port 9090)
 
 1. Extracts the `namespace` query parameter from incoming requests
 2. Validates the bearer token via TokenReview API call to Kubernetes API server
-3. Performs SubjectAccessReview to verify the user has `get pods` permission in the `metrics.k8s.io` API group for the specified namespace
+3. Performs SubjectAccessReview for `metrics.k8s.io/pods` in the specified namespace, with the verb derived from the HTTP method (`GET`→`get`, `POST`→`create`)
 4. Allows (proxies to prom-label-proxy) or denies (403 Forbidden) based on the result
 
 **Configuration**: `data-science-prometheus-restricted-config` ConfigMap
@@ -111,17 +111,24 @@ curl "https://.../api/v1/query?query=up&namespace=my-namespace"
 
 **Error Message:**
 
-```
+```text
 Forbidden (user=<username>, verb=get, resource=pods, subresource=)
 ```
 
-**Cause**: User lacks permissions for `metrics.k8s.io/pods` resource in the requested namespace
+or (for POST requests, e.g. from Perses):
+
+```text
+Forbidden (user=<username>, verb=create, resource=pods, subresource=)
+```
+
+**Cause**: User lacks permissions for `metrics.k8s.io/pods` resource in the requested namespace. The verb in the error corresponds to the HTTP method used (GET→`get`, POST→`create`).
 
 **Diagnostic**:
 
 ```bash
-# Check who has metrics permissions
+# Check who has metrics permissions (use the verb from the error message)
 oc adm policy who-can get pods.metrics.k8s.io -n my-namespace
+oc adm policy who-can create pods.metrics.k8s.io -n my-namespace
 ```
 
 **Fix**: Grant appropriate role
@@ -137,7 +144,7 @@ oc adm policy add-role-to-user view alice -n my-namespace
 oc adm policy add-role-to-user edit alice -n my-namespace
 ```
 
-**Note**: OpenShift's built-in roles (view, edit, admin) already include `metrics.k8s.io` permissions.
+**Note**: OpenShift's built-in roles (view, edit, admin) include `get` permissions for `metrics.k8s.io`. The operator's `data-science-metrics-view` ClusterRole aggregates the `create` verb into these roles to support POST-based clients like Perses.
 
 ---
 
@@ -199,14 +206,19 @@ oc get namespaces | grep my-namespace
 
 ### SubjectAccessReview Details
 
-The kube-rbac-proxy performs authorization checks with these attributes:
+The kube-rbac-proxy config omits `verb` from `resourceAttributes`, so it derives the verb from the HTTP method of each incoming request:
+
+| HTTP Method | SAR Verb | Used By |
+|-------------|----------|---------|
+| GET         | `get`    | curl, browser, Grafana |
+| POST        | `create` | Perses, large PromQL queries |
 
 ```yaml
 resourceAttributes:
   apiGroup: metrics.k8s.io
   resource: pods
   namespace: "<value from query parameter>"
-  verb: get
+  # verb is omitted — derived from HTTP method (GET→get, POST→create)
 ```
 
 This is **different** from checking pod visibility (core API):
@@ -223,10 +235,12 @@ resourceAttributes:
 
 OpenShift built-in roles that include `metrics.k8s.io/pods` permission:
 
-- ✅ `view` - Read-only access to namespace resources including metrics
-- ✅ `edit` - Modify namespace resources including metrics access
-- ✅ `admin` - Full namespace control including metrics access
+- ✅ `view` - Read-only access including metrics (`get`, `list`, `watch`)
+- ✅ `edit` - Modify namespace resources including metrics access (`get`, `list`, `watch`)
+- ✅ `admin` - Full namespace control including metrics access (`get`, `list`, `watch`)
 - ✅ `cluster-monitoring-view` - Metrics-specific read access
+
+These built-in roles cover **GET** requests. For **POST** requests (used by Perses), the operator deploys an aggregated `data-science-metrics-view` ClusterRole that adds the `create` verb to `view`, `edit`, and `admin`. The `metrics.k8s.io` API is read-only, so granting `create` has no side-effects — it only satisfies the SAR authorization check.
 
 Custom roles need explicit grants:
 
@@ -234,7 +248,7 @@ Custom roles need explicit grants:
 rules:
   - apiGroups: ["metrics.k8s.io"]
     resources: ["pods"]
-    verbs: ["get"]
+    verbs: ["get", "create"]
 ```
 
 ## Security Features
@@ -322,6 +336,7 @@ Look for:
 ### Test SubjectAccessReview Directly
 
 ```bash
+# Test GET access (verb: get)
 cat <<EOF | oc create -f -
 apiVersion: authorization.k8s.io/v1
 kind: SubjectAccessReview
@@ -329,6 +344,19 @@ spec:
   resourceAttributes:
     namespace: my-namespace
     verb: get
+    group: metrics.k8s.io
+    resource: pods
+  user: alice
+EOF
+
+# Test POST access (verb: create) — needed for Perses
+cat <<EOF | oc create -f -
+apiVersion: authorization.k8s.io/v1
+kind: SubjectAccessReview
+spec:
+  resourceAttributes:
+    namespace: my-namespace
+    verb: create
     group: metrics.k8s.io
     resource: pods
   user: alice

--- a/internal/controller/services/monitoring/monitoring_controller_actions.go
+++ b/internal/controller/services/monitoring/monitoring_controller_actions.go
@@ -23,34 +23,35 @@ import (
 
 const (
 	// Template files.
-	MonitoringStackTemplate                       = "resources/monitoring-stack.tmpl.yaml"
-	MonitoringAdmissionPoliciesTemplate           = "resources/monitoring-admission-policies.tmpl.yaml"
-	MonitoringStackAlertmanagerRBACTemplate       = "resources/monitoringstack-alertmanager-rbac.tmpl.yaml"
-	TempoMonolithicTemplate                       = "resources/tempo-monolithic.tmpl.yaml"
-	TempoStackTemplate                            = "resources/tempo-stack.tmpl.yaml"
-	OpenTelemetryCollectorTemplate                = "resources/opentelemetry-collector.tmpl.yaml"
-	CollectorServiceMonitorsTemplate              = "resources/collector-servicemonitors.tmpl.yaml"
-	CollectorPrometheusServiceTemplate            = "resources/collector-prometheus-service.tmpl.yaml"
-	CollectorRBACTemplate                         = "resources/collector-rbac.tmpl.yaml"
-	PrometheusRouteTemplate                       = "resources/data-science-prometheus-route.tmpl.yaml"
-	InstrumentationTemplate                       = "resources/instrumentation.tmpl.yaml"
-	PrometheusNamespaceProxyTemplate              = "resources/data-science-prometheus-namespace-proxy.tmpl.yaml"
-	PrometheusNamespaceProxyNetworkPolicyTemplate = "resources/data-science-prometheus-namespace-proxy-network-policy.tmpl.yaml"
-	PrometheusServiceOverrideTemplate             = "resources/data-science-prometheus-service-override.tmpl.yaml"
-	PrometheusNetworkPolicyTemplate               = "resources/data-science-prometheus-network-policy.tmpl.yaml"
-	PrometheusWebTLSServiceTemplate               = "resources/prometheus-web-tls-service.tmpl.yaml"
-	PrometheusSelfServiceMonitorTemplate          = "resources/prometheus-self-servicemonitor.tmpl.yaml"
-	ThanosQuerierTemplate                         = "resources/thanos-querier-cr.tmpl.yaml"
-	ThanosQuerierRouteTemplate                    = "resources/thanos-querier-route.tmpl.yaml"
-	PersesTemplate                                = "resources/perses.tmpl.yaml"
-	PersesTempoDatasourceTemplate                 = "resources/perses-tempo-datasource.tmpl.yaml"
-	PersesTempoDashboardV1Alpha1Template          = "resources/perses-tempo-dashboard-v1alpha1.tmpl.yaml"
-	PersesTempoDashboardV1Alpha2Template          = "resources/perses-tempo-dashboard-v1alpha2.tmpl.yaml"
-	PersesDatasourcePrometheusTemplate            = "resources/perses-datasource-prometheus.tmpl.yaml"
-	PersesDatasourceClusterPrometheusTemplate     = "resources/perses-datasource-cluster-prometheus.tmpl.yaml"
-	PrometheusClusterProxyTemplate                = "resources/data-science-prometheus-cluster-proxy.tmpl.yaml"
-	TempoServiceCAConfigMapTemplate               = "resources/tempo-service-ca-configmap.tmpl.yaml"
-	PersesOperatorAccessNetworkPolicyTemplate     = "resources/perses-operator-access-network-policy.tmpl.yaml"
+	MonitoringStackTemplate                          = "resources/monitoring-stack.tmpl.yaml"
+	MonitoringAdmissionPoliciesTemplate              = "resources/monitoring-admission-policies.tmpl.yaml"
+	MonitoringStackAlertmanagerRBACTemplate          = "resources/monitoringstack-alertmanager-rbac.tmpl.yaml"
+	TempoMonolithicTemplate                          = "resources/tempo-monolithic.tmpl.yaml"
+	TempoStackTemplate                               = "resources/tempo-stack.tmpl.yaml"
+	OpenTelemetryCollectorTemplate                   = "resources/opentelemetry-collector.tmpl.yaml"
+	CollectorServiceMonitorsTemplate                 = "resources/collector-servicemonitors.tmpl.yaml"
+	CollectorPrometheusServiceTemplate               = "resources/collector-prometheus-service.tmpl.yaml"
+	CollectorRBACTemplate                            = "resources/collector-rbac.tmpl.yaml"
+	PrometheusRouteTemplate                          = "resources/data-science-prometheus-route.tmpl.yaml"
+	InstrumentationTemplate                          = "resources/instrumentation.tmpl.yaml"
+	PrometheusNamespaceProxyTemplate                 = "resources/data-science-prometheus-namespace-proxy.tmpl.yaml"
+	PrometheusNamespaceProxyNetworkPolicyTemplate    = "resources/data-science-prometheus-namespace-proxy-network-policy.tmpl.yaml"
+	PrometheusServiceOverrideTemplate                = "resources/data-science-prometheus-service-override.tmpl.yaml"
+	PrometheusNetworkPolicyTemplate                  = "resources/data-science-prometheus-network-policy.tmpl.yaml"
+	PrometheusWebTLSServiceTemplate                  = "resources/prometheus-web-tls-service.tmpl.yaml"
+	PrometheusSelfServiceMonitorTemplate             = "resources/prometheus-self-servicemonitor.tmpl.yaml"
+	ThanosQuerierTemplate                            = "resources/thanos-querier-cr.tmpl.yaml"
+	ThanosQuerierRouteTemplate                       = "resources/thanos-querier-route.tmpl.yaml"
+	PersesTemplate                                   = "resources/perses.tmpl.yaml"
+	PersesTempoDatasourceTemplate                    = "resources/perses-tempo-datasource.tmpl.yaml"
+	PersesTempoDashboardV1Alpha1Template             = "resources/perses-tempo-dashboard-v1alpha1.tmpl.yaml"
+	PersesTempoDashboardV1Alpha2Template             = "resources/perses-tempo-dashboard-v1alpha2.tmpl.yaml"
+	PersesDatasourcePrometheusTemplate               = "resources/perses-datasource-prometheus.tmpl.yaml"
+	PersesDatasourceClusterPrometheusTemplate        = "resources/perses-datasource-cluster-prometheus.tmpl.yaml"
+	PersesDatasourceClusterPrometheusTenancyTemplate = "resources/perses-datasource-cluster-prometheus-tenancy.tmpl.yaml"
+	PrometheusClusterProxyTemplate                   = "resources/data-science-prometheus-cluster-proxy.tmpl.yaml"
+	TempoServiceCAConfigMapTemplate                  = "resources/tempo-service-ca-configmap.tmpl.yaml"
+	PersesOperatorAccessNetworkPolicyTemplate        = "resources/perses-operator-access-network-policy.tmpl.yaml"
 
 	// API versions.
 	persesV1Alpha2 = "v1alpha2"
@@ -630,6 +631,10 @@ func deployPersesPrometheusIntegration(ctx context.Context, rr *odhtypes.Reconci
 		{
 			FS:   resourcesFS,
 			Path: PersesDatasourceClusterPrometheusTemplate,
+		},
+		{
+			FS:   resourcesFS,
+			Path: PersesDatasourceClusterPrometheusTenancyTemplate,
 		},
 	}
 	rr.Templates = append(rr.Templates, templates...)

--- a/internal/controller/services/monitoring/resources/data-science-prometheus-namespace-proxy.tmpl.yaml
+++ b/internal/controller/services/monitoring/resources/data-science-prometheus-namespace-proxy.tmpl.yaml
@@ -1,3 +1,12 @@
+# Aggregated ClusterRole granting "create" on metrics.k8s.io/pods.
+#
+# Perses uses POST for Prometheus queries. The namespace proxy's kube-rbac-proxy
+# derives the SAR verb from the HTTP method (POST → "create"). OpenShift's
+# built-in view/edit/admin roles already grant "get" (covering GET requests),
+# but not "create". The metrics.k8s.io API is read-only so granting "create"
+# has no side-effects — it only satisfies the SAR authorization check.
+#
+# See: docs/NAMESPACE_RESTRICTED_METRICS.md
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/internal/controller/services/monitoring/resources/data-science-prometheus-namespace-proxy.tmpl.yaml
+++ b/internal/controller/services/monitoring/resources/data-science-prometheus-namespace-proxy.tmpl.yaml
@@ -1,4 +1,21 @@
 ---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: data-science-metrics-view
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+    platform.opendatahub.io/part-of: monitoring
+rules:
+  - apiGroups:
+      - metrics.k8s.io
+    resources:
+      - pods
+    verbs:
+      - create
+---
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/internal/controller/services/monitoring/resources/perses-datasource-cluster-prometheus-tenancy.tmpl.yaml
+++ b/internal/controller/services/monitoring/resources/perses-datasource-cluster-prometheus-tenancy.tmpl.yaml
@@ -1,0 +1,60 @@
+# Cluster Prometheus Tenancy Datasource for Perses
+#
+# This is a short-term workaround to provide namespace-scoped access to cluster
+# metrics via the OpenShift Monitoring stack's Thanos Querier tenancy endpoint.
+#
+# This datasource points to the cluster's Thanos Querier (in openshift-monitoring)
+# on the tenancy port (9092), which enforces namespace-level isolation by requiring
+# a namespace parameter in every query.
+#
+# This will be replaced/updated once decentralized metrics collection is implemented.
+#
+# The configuration uses:
+# - ConfigMap-based TLS CA (prometheus-web-tls-ca with OpenShift service CA)
+# - A secret for bearer token authentication to Thanos Querier
+#
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cluster-prometheus-tenancy-datasource-secret
+  namespace: {{.Namespace}}
+  labels:
+    platform.opendatahub.io/part-of: monitoring
+  annotations:
+    kubernetes.io/service-account.name: data-science-prometheus-cluster-proxy
+type: kubernetes.io/service-account-token
+---
+apiVersion: perses.dev/{{.PersesAPIVersion}}
+kind: PersesDatasource
+metadata:
+  name: cluster-prometheus-tenancy-datasource
+  namespace: {{.Namespace}}
+  labels:
+    platform.opendatahub.io/part-of: monitoring
+  annotations:
+    platform.opendatahub.io/description: "Namespace-scoped Prometheus metrics via OpenShift Monitoring Thanos Querier tenancy endpoint"
+spec:
+  client:
+    tls:
+      enable: true
+      caCert:
+        type: configmap
+        name: prometheus-web-tls-ca
+        certPath: service-ca.crt
+  config:
+    default: false
+    display:
+      name: "Cluster Prometheus Tenancy"
+      description: "OpenShift Monitoring Thanos Querier tenancy endpoint - provides namespace-scoped metrics"
+    plugin:
+      kind: "PrometheusDatasource"
+      spec:
+        proxy:
+          kind: HTTPProxy
+          spec:
+            # Secret contains bearer token for Thanos Querier authentication
+            secret: cluster-prometheus-tenancy-datasource-secret
+            url: https://thanos-querier.openshift-monitoring.svc:9092
+        queryParams:
+          namespace: "${namespace:raw}"

--- a/internal/controller/services/monitoring/resources/perses-datasource-cluster-prometheus-tenancy.tmpl.yaml
+++ b/internal/controller/services/monitoring/resources/perses-datasource-cluster-prometheus-tenancy.tmpl.yaml
@@ -40,6 +40,7 @@ spec:
       enable: true
       caCert:
         type: configmap
+        namespace: {{.Namespace}}
         name: prometheus-web-tls-ca
         certPath: service-ca.crt
   config:

--- a/internal/controller/services/monitoring/resources/perses-datasource-cluster-prometheus-tenancy.tmpl.yaml
+++ b/internal/controller/services/monitoring/resources/perses-datasource-cluster-prometheus-tenancy.tmpl.yaml
@@ -57,4 +57,4 @@ spec:
             secret: cluster-prometheus-tenancy-datasource-secret
             url: https://thanos-querier.openshift-monitoring.svc:9092
         queryParams:
-          namespace: "${namespace:raw}"
+          namespace: "${namespace:queryparam}"

--- a/internal/controller/services/monitoring/resources/perses-datasource-cluster-prometheus.tmpl.yaml
+++ b/internal/controller/services/monitoring/resources/perses-datasource-cluster-prometheus.tmpl.yaml
@@ -39,6 +39,7 @@ spec:
       enable: true
       caCert:
         type: configmap
+        namespace: {{.Namespace}}
         name: prometheus-web-tls-ca
         certPath: service-ca.crt
   config:

--- a/internal/controller/services/monitoring/resources/perses-tempo-datasource.tmpl.yaml
+++ b/internal/controller/services/monitoring/resources/perses-tempo-datasource.tmpl.yaml
@@ -11,6 +11,7 @@ spec:
       enable: true
       caCert:
         type: configmap
+        namespace: {{.Namespace}}
         name: tempo-service-ca
         certPath: service-ca.crt
   config:

--- a/tests/e2e/monitoring_test.go
+++ b/tests/e2e/monitoring_test.go
@@ -1212,7 +1212,7 @@ func (tc *MonitoringTestCtx) ValidatePersesDatasourceWithPrometheus(t *testing.T
 			jq.Match(`.spec.config.plugin.spec.proxy.spec.url | endswith(":9092")`),
 			jq.Match(`.spec.client.tls.enable == true`),
 			jq.Match(`.spec.config.plugin.spec.proxy.spec.secret == "%s"`, ClusterPrometheusTenancyDatasourceSecret),
-			jq.Match(`.spec.config.plugin.spec.queryParams.namespace == "${namespace:raw}"`),
+			jq.Match(`.spec.config.plugin.spec.queryParams.namespace == "${namespace:queryparam}"`),
 		)),
 		WithCustomErrorMsg("Cluster Prometheus Tenancy PersesDatasource CR should be created with namespace-scoped configuration on port 9092"),
 	)

--- a/tests/e2e/monitoring_test.go
+++ b/tests/e2e/monitoring_test.go
@@ -25,20 +25,22 @@ import (
 
 // Constants for monitoring resource names.
 const (
-	MonitoringCRName                  = "default-monitoring"
-	MonitoringStackName               = "data-science-monitoringstack"
-	OpenTelemetryCollectorName        = "data-science-collector"
-	TargetAllocatorDeploymentName     = "data-science-collector-targetallocator"
-	TargetAllocatorServiceAccount     = "data-science-collector-collector"
-	TempoMonolithicName               = "data-science-tempomonolithic"
-	TempoStackName                    = "data-science-tempostack"
-	InstrumentationName               = "data-science-instrumentation"
-	ThanosQuerierName                 = "data-science-thanos-querier"
-	ThanosQuerierRouteName            = "data-science-thanos-querier-route"
-	PersesName                        = "data-science-perses"
-	PersesDatasourceName              = "data-science-prometheus-datasource"
-	ClusterPrometheusDatasourceName   = "cluster-prometheus-datasource"
-	ClusterPrometheusDatasourceSecret = "cluster-prometheus-datasource-secret"
+	MonitoringCRName                         = "default-monitoring"
+	MonitoringStackName                      = "data-science-monitoringstack"
+	OpenTelemetryCollectorName               = "data-science-collector"
+	TargetAllocatorDeploymentName            = "data-science-collector-targetallocator"
+	TargetAllocatorServiceAccount            = "data-science-collector-collector"
+	TempoMonolithicName                      = "data-science-tempomonolithic"
+	TempoStackName                           = "data-science-tempostack"
+	InstrumentationName                      = "data-science-instrumentation"
+	ThanosQuerierName                        = "data-science-thanos-querier"
+	ThanosQuerierRouteName                   = "data-science-thanos-querier-route"
+	PersesName                               = "data-science-perses"
+	PersesDatasourceName                     = "data-science-prometheus-datasource"
+	ClusterPrometheusDatasourceName          = "cluster-prometheus-datasource"
+	ClusterPrometheusDatasourceSecret        = "cluster-prometheus-datasource-secret"
+	ClusterPrometheusTenancyDatasourceName   = "cluster-prometheus-tenancy-datasource"
+	ClusterPrometheusTenancyDatasourceSecret = "cluster-prometheus-tenancy-datasource-secret"
 )
 
 // Constants for common test values.
@@ -1197,6 +1199,23 @@ func (tc *MonitoringTestCtx) ValidatePersesDatasourceWithPrometheus(t *testing.T
 		)),
 		WithCustomErrorMsg("Cluster Prometheus PersesDatasource CR should be created with correct openshift-monitoring Thanos Querier configuration"),
 	)
+
+	// Verify Cluster Prometheus Tenancy PersesDatasource CR is created (default: false, namespace-scoped via port 9092)
+	tc.EnsureResourceExists(
+		WithMinimalObject(gvk.PersesDatasource, types.NamespacedName{Name: ClusterPrometheusTenancyDatasourceName, Namespace: tc.MonitoringNamespace}),
+		WithCondition(And(
+			monitoringOwnerReferencesCondition,
+			jq.Match(`.spec.config.default == false`),
+			jq.Match(`.spec.config.plugin.kind == "PrometheusDatasource"`),
+			jq.Match(`.spec.config.plugin.spec.proxy.kind == "HTTPProxy"`),
+			jq.Match(`.spec.config.plugin.spec.proxy.spec.url | contains("thanos-querier.openshift-monitoring")`),
+			jq.Match(`.spec.config.plugin.spec.proxy.spec.url | endswith(":9092")`),
+			jq.Match(`.spec.client.tls.enable == true`),
+			jq.Match(`.spec.config.plugin.spec.proxy.spec.secret == "%s"`, ClusterPrometheusTenancyDatasourceSecret),
+			jq.Match(`.spec.config.plugin.spec.queryParams.namespace == "${namespace:raw}"`),
+		)),
+		WithCustomErrorMsg("Cluster Prometheus Tenancy PersesDatasource CR should be created with namespace-scoped configuration on port 9092"),
+	)
 }
 
 // ValidatePersesDatasourceLifecycle tests the complete lifecycle of PersesDatasource deployment and cleanup.
@@ -1221,6 +1240,13 @@ func (tc *MonitoringTestCtx) ValidatePersesDatasourceLifecycle(t *testing.T) {
 		WithMinimalObject(gvk.PersesDatasource, types.NamespacedName{Name: ClusterPrometheusDatasourceName, Namespace: tc.MonitoringNamespace}),
 		WithCondition(jq.Match(`.metadata.name == "%s"`, ClusterPrometheusDatasourceName)),
 		WithCustomErrorMsg("Cluster Prometheus PersesDatasource should exist when metrics are configured"),
+	)
+
+	// Verify Cluster Prometheus Tenancy datasource is created
+	tc.EnsureResourceExists(
+		WithMinimalObject(gvk.PersesDatasource, types.NamespacedName{Name: ClusterPrometheusTenancyDatasourceName, Namespace: tc.MonitoringNamespace}),
+		WithCondition(jq.Match(`.metadata.name == "%s"`, ClusterPrometheusTenancyDatasourceName)),
+		WithCustomErrorMsg("Cluster Prometheus Tenancy PersesDatasource should exist when metrics are configured"),
 	)
 
 	// Step 2: Remove metrics configuration and verify datasources are deleted
@@ -1248,6 +1274,11 @@ func (tc *MonitoringTestCtx) ValidatePersesDatasourceLifecycle(t *testing.T) {
 		WithMinimalObject(gvk.PersesDatasource, types.NamespacedName{Name: ClusterPrometheusDatasourceName, Namespace: tc.MonitoringNamespace}),
 	)
 
+	// Verify Cluster Prometheus Tenancy datasource is deleted
+	tc.EnsureResourceGone(
+		WithMinimalObject(gvk.PersesDatasource, types.NamespacedName{Name: ClusterPrometheusTenancyDatasourceName, Namespace: tc.MonitoringNamespace}),
+	)
+
 	// Step 3: Re-enable metrics and verify datasources are recreated
 	tc.updateMonitoringConfig(
 		withManagementState(operatorv1.Managed),
@@ -1264,6 +1295,12 @@ func (tc *MonitoringTestCtx) ValidatePersesDatasourceLifecycle(t *testing.T) {
 		WithMinimalObject(gvk.PersesDatasource, types.NamespacedName{Name: ClusterPrometheusDatasourceName, Namespace: tc.MonitoringNamespace}),
 		WithCondition(jq.Match(`.metadata.name == "%s"`, ClusterPrometheusDatasourceName)),
 		WithCustomErrorMsg("Cluster Prometheus PersesDatasource should be recreated when metrics are re-enabled"),
+	)
+
+	tc.EnsureResourceExists(
+		WithMinimalObject(gvk.PersesDatasource, types.NamespacedName{Name: ClusterPrometheusTenancyDatasourceName, Namespace: tc.MonitoringNamespace}),
+		WithCondition(jq.Match(`.metadata.name == "%s"`, ClusterPrometheusTenancyDatasourceName)),
+		WithCustomErrorMsg("Cluster Prometheus Tenancy PersesDatasource should be recreated when metrics are re-enabled"),
 	)
 }
 
@@ -1296,6 +1333,7 @@ func (tc *MonitoringTestCtx) ValidateMonitoringServiceDisabled(t *testing.T) {
 		{gvk: gvk.Perses, name: PersesName},
 		{gvk: gvk.PersesDatasource, name: PersesDatasourceName},
 		{gvk: gvk.PersesDatasource, name: ClusterPrometheusDatasourceName},
+		{gvk: gvk.PersesDatasource, name: ClusterPrometheusTenancyDatasourceName},
 	} {
 		if resource.forceWithFinalizer {
 			tc.DeleteResource(


### PR DESCRIPTION
<!---
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

Adds a new operator-managed `PersesDatasource` CR (`cluster-prometheus-tenancy-datasource`) that targets the OpenShift Monitoring Thanos Querier **tenancy endpoint** on port 9092.

This complements the existing `cluster-prometheus-datasource` (port 9091, cluster-wide) by providing a namespace-scoped datasource that enforces per-namespace metric isolation via the `${namespace:queryparam}` query parameter.

Also adds an aggregated `data-science-metrics-view` ClusterRole that grants the `create` verb on `metrics.k8s.io/pods` to `view`/`edit`/`admin` roles — required because Perses uses POST for Prometheus queries, and kube-rbac-proxy maps POST to the `create` SAR verb. The `metrics.k8s.io` API is read-only, so this has no side-effects.

**Changes:**
- New template `perses-datasource-cluster-prometheus-tenancy.tmpl.yaml` — mirrors the existing cluster-prometheus template with: port 9092, `default: false`, and `queryParams.namespace`
- New aggregated ClusterRole `data-science-metrics-view` in the namespace proxy template — grants `create` on `metrics.k8s.io/pods` for POST-based clients
- Wired into `deployPersesPrometheusIntegration` alongside the existing prometheus datasources
- Updated `docs/NAMESPACE_RESTRICTED_METRICS.md` to document POST/create verb behavior
- E2E tests updated: configuration validation, lifecycle (create/delete/recreate), and cleanup

**Related:**
- Upstream Perses fix for multi-value queryparam URL construction: https://github.com/perses/shared/pull/152

<!--- Link your JIRA and related links here for reference. -->
https://redhat.atlassian.net/browse/RHOAIENG-51665

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- Manually applied the `PersesDatasource` CR on a live cluster and verified it reconciles successfully (status shows `Available: True`)
- Verified the operator manages the new resource through the same reconciliation path as the existing cluster-prometheus datasource
- E2E test assertions added covering: resource creation with correct spec fields (port 9092, `default: false`, `queryParams`, TLS, secret reference), lifecycle management (create → delete on metrics removal → recreate on re-enable), and cleanup on service disable

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully
- [ ] New RELATED_IMAGE mappings are listed in ODH-Build-Config and RHOAI-Build-Config (CI validates names against build-config repos). Include links to build-config PRs in the description.

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [ ] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a cluster Prometheus tenancy Perses datasource with TLS, proxy routing to Thanos Querier, service-account-token secret for auth, and namespace-scoped tenancy via query parameter.
  * Added a cluster-level RBAC role granting metrics view (including POST/create) for the namespace proxy.

* **Tests**
  * Added e2e tests validating tenancy datasource provisioning, deletion, recreation, and cleanup.

* **Documentation**
  * Clarified namespace-restricted metrics behavior and SAR debugging guidance, including GET/POST permission examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->