### PR TITLE
feat: add Custom precondition type, migrate Trainer checkPreConditions to utilize Custom precondition

### DIFF
--- a/internal/controller/components/trainer/trainer_controller.go
+++ b/internal/controller/components/trainer/trainer_controller.go
@@ -73,12 +73,12 @@ func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.
 				),
 			),
 			reconciler.Dynamic(reconciler.CrdExists(gvk.JobSetOperatorV1))).
+		WithPreCondition(precondition.Custom(checkPreConditions, precondition.WithStopReconciliation())).
 		WithPreCondition(precondition.MonitorOperator(precondition.OperatorConfig{
 			OperatorGVK: gvk.JobSetOperatorV1,
 			CRName:      jobSetOperatorCRName,
 			Filter:      jobSetConditionFilter,
 		})).
-		WithAction(checkPreConditions).
 		WithAction(initialize).
 		WithAction(checkJobSetCRD).
 		WithAction(releases.NewAction()).

--- a/internal/controller/components/trainer/trainer_controller_actions.go
+++ b/internal/controller/components/trainer/trainer_controller_actions.go
@@ -27,34 +27,30 @@ import (
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
 	odherrors "github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/errors"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/precondition"
 	odhtypes "github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
 )
 
-var (
-	ErrJobSetOperatorNotInstalled = odherrors.NewStopError(status.JobSetOperatorNotInstalledMessage)
-	ErrJobSetOperatorCRNotFound   = odherrors.NewStopError(status.JobSetOperatorCRNotFoundMessage)
-)
-
-func checkPreConditions(ctx context.Context, rr *odhtypes.ReconciliationRequest) error {
-	if jobSetInfo, err := cluster.OperatorExists(ctx, rr.Client, jobSetOperator); err != nil || jobSetInfo == nil {
-		if err != nil {
-			return odherrors.NewStopErrorW(err)
-		}
-
-		return ErrJobSetOperatorNotInstalled
+func checkPreConditions(ctx context.Context, rr *odhtypes.ReconciliationRequest) (precondition.CheckResult, error) {
+	jobSetInfo, err := cluster.OperatorExists(ctx, rr.Client, jobSetOperator)
+	if err != nil {
+		return precondition.CheckResult{}, err
 	}
 
-	// Check that JobSetOperator CR exists with name "cluster"
+	if jobSetInfo == nil {
+		return precondition.CheckResult{Pass: false, Message: status.JobSetOperatorNotInstalledMessage}, nil
+	}
+
 	jobSetOperatorCR := &unstructured.Unstructured{}
 	jobSetOperatorCR.SetGroupVersionKind(gvk.JobSetOperatorV1)
 	if err := rr.Client.Get(ctx, types.NamespacedName{Name: jobSetOperatorCRName}, jobSetOperatorCR); err != nil {
 		if k8serr.IsNotFound(err) {
-			return ErrJobSetOperatorCRNotFound
+			return precondition.CheckResult{Pass: false, Message: status.JobSetOperatorCRNotFoundMessage}, nil
 		}
-		return odherrors.NewStopErrorW(err)
+		return precondition.CheckResult{}, err
 	}
 
-	return nil
+	return precondition.CheckResult{Pass: true}, nil
 }
 
 // checkJobSetCRD verifies that the JobSet CRD exists.

--- a/internal/controller/components/trainer/trainer_controller_actions_test.go
+++ b/internal/controller/components/trainer/trainer_controller_actions_test.go
@@ -41,9 +41,10 @@ func TestCheckPreConditions_Managed_JobSetOperatorNotInstalled(t *testing.T) {
 		Conditions: conditions.NewManager(&trainer, status.ConditionTypeReady),
 	}
 
-	err = checkPreConditions(ctx, &rr)
-	g.Expect(err).Should(HaveOccurred())
-	g.Expect(err).To(MatchError(ContainSubstring(status.JobSetOperatorNotInstalledMessage)))
+	result, err := checkPreConditions(ctx, &rr)
+	g.Expect(err).ShouldNot(HaveOccurred())
+	g.Expect(result.Pass).To(BeFalse())
+	g.Expect(result.Message).To(ContainSubstring(status.JobSetOperatorNotInstalledMessage))
 }
 
 func TestCheckJobSetCRD_NotInstalled(t *testing.T) {
@@ -132,9 +133,10 @@ func TestCheckPreConditions_JobSetOperatorCRNotFound(t *testing.T) {
 		Conditions: conditions.NewManager(&trainer, status.ConditionTypeReady),
 	}
 
-	err = checkPreConditions(ctx, &rr)
-	g.Expect(err).Should(HaveOccurred())
-	g.Expect(err).To(MatchError(ContainSubstring(status.JobSetOperatorCRNotFoundMessage)))
+	result, err := checkPreConditions(ctx, &rr)
+	g.Expect(err).ShouldNot(HaveOccurred())
+	g.Expect(result.Pass).To(BeFalse())
+	g.Expect(result.Message).To(ContainSubstring(status.JobSetOperatorCRNotFoundMessage))
 }
 
 func TestCheckPreConditions_Success(t *testing.T) {
@@ -178,8 +180,10 @@ func TestCheckPreConditions_Success(t *testing.T) {
 		Conditions: conditions.NewManager(&trainer, status.ConditionTypeReady),
 	}
 
-	err = checkPreConditions(ctx, &rr)
+	result, err := checkPreConditions(ctx, &rr)
 	g.Expect(err).ShouldNot(HaveOccurred())
+	g.Expect(result.Pass).To(BeTrue())
+	g.Expect(result.Message).To(BeEmpty())
 }
 
 func TestJobSetConditionFilter(t *testing.T) {

--- a/pkg/controller/precondition/custom.go
+++ b/pkg/controller/precondition/custom.go
@@ -1,0 +1,8 @@
+package precondition
+
+// Custom creates a PreCondition from a caller-provided CheckFunc.
+// Use this for component-specific precondition logic that does not fit
+// the built-in types (MonitorCRD, MonitorOperator, etc.).
+func Custom(check CheckFunc, opts ...Option) PreCondition {
+	return newPreCondition(check, opts...)
+}

--- a/pkg/controller/precondition/custom_test.go
+++ b/pkg/controller/precondition/custom_test.go
@@ -1,0 +1,203 @@
+//nolint:testpackage
+package precondition
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/opendatahub-io/opendatahub-operator/v2/api/common"
+	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/status"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestCustom_Defaults(t *testing.T) {
+	g := NewWithT(t)
+
+	pc := Custom(passingCheck)
+
+	g.Expect(pc.check).NotTo(BeNil())
+	g.Expect(pc.conditionType).To(Equal(status.ConditionDependenciesAvailable))
+	g.Expect(pc.severity).To(Equal(common.ConditionSeverityError))
+	g.Expect(pc.stopReconciliation).To(BeFalse())
+}
+
+func TestCustom_PassingCheck(t *testing.T) {
+	g := NewWithT(t)
+
+	rr := newRR(status.ConditionDependenciesAvailable)
+	shouldStop := RunAll(t.Context(), rr, []PreCondition{
+		Custom(passingCheck),
+	})
+
+	g.Expect(shouldStop).To(BeFalse())
+
+	got := rr.Conditions.GetCondition(status.ConditionDependenciesAvailable)
+	g.Expect(got).NotTo(BeNil())
+	g.Expect(got.Status).To(Equal(metav1.ConditionTrue))
+}
+
+func TestCustom_FailingCheck(t *testing.T) {
+	g := NewWithT(t)
+
+	rr := newRR(status.ConditionDependenciesAvailable)
+	shouldStop := RunAll(t.Context(), rr, []PreCondition{
+		Custom(failingCheck("component not ready")),
+	})
+
+	g.Expect(shouldStop).To(BeFalse())
+
+	got := rr.Conditions.GetCondition(status.ConditionDependenciesAvailable)
+	g.Expect(got).NotTo(BeNil())
+	g.Expect(got.Status).To(Equal(metav1.ConditionFalse))
+	g.Expect(got.Message).To(ContainSubstring("component not ready"))
+}
+
+func TestCustom_ErrorCheck(t *testing.T) {
+	g := NewWithT(t)
+
+	rr := newRR(status.ConditionDependenciesAvailable)
+	shouldStop := RunAll(t.Context(), rr, []PreCondition{
+		Custom(errorCheck),
+	})
+
+	g.Expect(shouldStop).To(BeFalse())
+
+	got := rr.Conditions.GetCondition(status.ConditionDependenciesAvailable)
+	g.Expect(got).NotTo(BeNil())
+	g.Expect(got.Status).To(Equal(metav1.ConditionUnknown))
+}
+
+func TestCustom_WithStopReconciliation(t *testing.T) {
+	g := NewWithT(t)
+
+	rr := newRR(status.ConditionDependenciesAvailable)
+	shouldStop := RunAll(t.Context(), rr, []PreCondition{
+		Custom(failingCheck("must stop"), WithStopReconciliation()),
+	})
+
+	g.Expect(shouldStop).To(BeTrue())
+
+	got := rr.Conditions.GetCondition(status.ConditionDependenciesAvailable)
+	g.Expect(got).NotTo(BeNil())
+	g.Expect(got.Status).To(Equal(metav1.ConditionFalse))
+}
+
+func TestCustom_AllOptions(t *testing.T) {
+	g := NewWithT(t)
+
+	customCondition := "CustomCheck"
+	rr := newRR(customCondition)
+	shouldStop := RunAll(t.Context(), rr, []PreCondition{
+		Custom(
+			failingCheck("original"),
+			WithConditionType(customCondition),
+			WithSeverity(common.ConditionSeverityInfo),
+			WithStopReconciliation(),
+			WithMessage("overridden message"),
+		),
+	})
+
+	g.Expect(shouldStop).To(BeTrue())
+
+	got := rr.Conditions.GetCondition(customCondition)
+	g.Expect(got).NotTo(BeNil())
+	g.Expect(got.Status).To(Equal(metav1.ConditionFalse))
+	g.Expect(got.Severity).To(Equal(common.ConditionSeverityInfo))
+	g.Expect(got.Message).To(ContainSubstring("overridden message"))
+	g.Expect(got.Message).NotTo(ContainSubstring("original"))
+}
+
+func TestCustom_ErrorWithStopReconciliation(t *testing.T) {
+	g := NewWithT(t)
+
+	rr := newRR(status.ConditionDependenciesAvailable)
+	shouldStop := RunAll(t.Context(), rr, []PreCondition{
+		Custom(errorCheck, WithStopReconciliation()),
+	})
+
+	g.Expect(shouldStop).To(BeTrue())
+
+	got := rr.Conditions.GetCondition(status.ConditionDependenciesAvailable)
+	g.Expect(got).NotTo(BeNil())
+	g.Expect(got.Status).To(Equal(metav1.ConditionUnknown))
+}
+
+func TestCustom_AccessesInstance(t *testing.T) {
+	g := NewWithT(t)
+
+	instanceCheck := func(_ context.Context, rr *types.ReconciliationRequest) (CheckResult, error) {
+		if rr.Instance == nil {
+			return CheckResult{}, errors.New("instance is nil")
+		}
+		if rr.Instance.GetName() == "" {
+			return CheckResult{Pass: false, Message: "instance has no name"}, nil
+		}
+		return CheckResult{Pass: true}, nil
+	}
+
+	rr := newRR(status.ConditionDependenciesAvailable)
+	shouldStop := RunAll(t.Context(), rr, []PreCondition{
+		Custom(instanceCheck),
+	})
+
+	g.Expect(shouldStop).To(BeFalse())
+
+	got := rr.Conditions.GetCondition(status.ConditionDependenciesAvailable)
+	g.Expect(got).NotTo(BeNil())
+	g.Expect(got.Status).To(Equal(metav1.ConditionTrue))
+}
+
+func TestCustom_NilCheck(t *testing.T) {
+	g := NewWithT(t)
+
+	rr := newRR(status.ConditionDependenciesAvailable)
+	shouldStop := RunAll(t.Context(), rr, []PreCondition{
+		Custom(nil),
+	})
+
+	g.Expect(shouldStop).To(BeFalse())
+
+	got := rr.Conditions.GetCondition(status.ConditionDependenciesAvailable)
+	g.Expect(got).NotTo(BeNil())
+	g.Expect(got.Status).To(Equal(metav1.ConditionUnknown))
+	g.Expect(got.Message).To(ContainSubstring("precondition check function is nil"))
+}
+
+func TestCustom_NilCheckWithStopReconciliation(t *testing.T) {
+	g := NewWithT(t)
+
+	rr := newRR(status.ConditionDependenciesAvailable)
+	shouldStop := RunAll(t.Context(), rr, []PreCondition{
+		Custom(nil, WithStopReconciliation()),
+	})
+
+	g.Expect(shouldStop).To(BeTrue())
+
+	got := rr.Conditions.GetCondition(status.ConditionDependenciesAvailable)
+	g.Expect(got).NotTo(BeNil())
+	g.Expect(got.Status).To(Equal(metav1.ConditionUnknown))
+}
+
+func TestCustom_SkippedOnClusterType(t *testing.T) {
+	g := NewWithT(t)
+
+	cluster.SetClusterInfo(cluster.ClusterInfo{Type: cluster.ClusterTypeOpenShift})
+	t.Cleanup(func() { cluster.SetClusterInfo(cluster.ClusterInfo{}) })
+
+	rr := newRR(status.ConditionDependenciesAvailable)
+	shouldStop := RunAll(t.Context(), rr, []PreCondition{
+		Custom(failingCheck("should not run"), WithClusterTypes(cluster.ClusterTypeKubernetes)),
+	})
+
+	g.Expect(shouldStop).To(BeFalse())
+
+	got := rr.Conditions.GetCondition(status.ConditionDependenciesAvailable)
+	g.Expect(got).NotTo(BeNil())
+	g.Expect(got.Status).NotTo(Equal(metav1.ConditionFalse))
+}


### PR DESCRIPTION
## Description

Adds Custom pre-condition type to provide ground to migrate existing `checkPreCondition` controller actions to use the pre-condition framework instead. As per ticket description a single, less-complex component controller - Trainer - was chosen as candidate for the first migration

JIRA ref: [RHOAIENG-58948](https://redhat.atlassian.net/browse/RHOAIENG-58948)

## How Has This Been Tested?
Unit test coverage added for Custom type, updated Trainer unit test suite accordingly

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully
- [ ] New RELATED_IMAGE mappings are listed in ODH-Build-Config and RHOAI-Build-Config (CI validates names against build-config repos). Include links to build-config PRs in the description.

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->
These changes should not be affecting existing behavior


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved precondition validation handling in the trainer operator reconciliation process. Precondition checks now execute earlier with enhanced error reporting through structured results instead of sentinel errors.

* **Tests**
  * Added comprehensive test coverage for the new precondition framework, including validation of check execution, error handling, and cluster-type filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->