### PR TITLE
RHOAIENG-61102: forward user-agent headers to kube-auth-proxy

### DIFF
--- a/internal/controller/services/gateway/resources/envoyfilter-authn.tmpl.yaml
+++ b/internal/controller/services/gateway/resources/envoyfilter-authn.tmpl.yaml
@@ -40,6 +40,7 @@ spec:
                 patterns:
                 - exact: cookie
                 - exact: authorization
+                - exact: user-agent
             authorization_response:
               allowed_upstream_headers:
                 patterns:

--- a/tests/e2e/gateway_test.go
+++ b/tests/e2e/gateway_test.go
@@ -521,7 +521,8 @@ func (tc *GatewayTestCtx) ValidateEnvoyFilter(t *testing.T) {
 			jq.Match(`.spec.configPatches[0].patch.value.typed_config.http_service.server_uri.uri == "%s"`, authProxyURI),
 
 			// ext_authz allowed headers
-			jq.Match(`.spec.configPatches[0].patch.value.typed_config.http_service.authorization_request.allowed_headers.patterns[0].exact == "cookie"`),
+			jq.Match(`.spec.configPatches[0].patch.value.typed_config.http_service.authorization_request.allowed_headers.patterns | any(.exact == "cookie")`),
+			jq.Match(`.spec.configPatches[0].patch.value.typed_config.http_service.authorization_request.allowed_headers.patterns | any(.exact == "user-agent")`),
 			jq.Match(`.spec.configPatches[0].patch.value.typed_config.http_service.authorization_response.allowed_client_headers.patterns[0].exact == "set-cookie"`),
 			jq.Match(`.spec.configPatches[0].patch.value.typed_config.http_service.authorization_response.allowed_upstream_headers.patterns | any(.exact == "x-auth-request-user")`),
 			jq.Match(`.spec.configPatches[0].patch.value.typed_config.http_service.authorization_response.allowed_upstream_headers.patterns | any(.exact == "x-auth-request-email")`),


### PR DESCRIPTION


<!---
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description

This will allow kube-auth-proxy to provide a helpful error message to MLflow clients and the main way detect this is throught he user-agent header.

https://redhat.atlassian.net/browse/RHOAIENG-61102

## How Has This Been Tested?

I manually deployed the ODH operator and verified the `EnvoyFilter` includes this snippet:

```yaml
            http_service:
              authorization_request:
                allowed_headers:
                  patterns:
                    - exact: cookie
                    - exact: authorization
                    - exact: user-agent
```

It forwards the user-agent to kube-auth-proxy as expected.

```bash
❯ kubectl -n openshift-ingress get envoyfilters.networking.istio.io data-science-authn-filter  -o yaml | grep user-agent
                - exact: user-agent
```

## Screenshot or short clip

N/A

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully
- [ ] New RELATED_IMAGE mappings are listed in ODH-Build-Config and RHOAI-Build-Config (CI validates names against build-config repos). Include links to build-config PRs in the description.

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [ ] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Authorization requests now forward the User-Agent header to the external authorization proxy, in addition to existing cookie and authorization headers.

* **Tests**
  * End-to-end authorization validation updated to verify the allowed header set includes both cookie and User-Agent; assertions are now order-independent to avoid fragile ordering assumptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->