### PR TITLE
chore: return fake recorders from MockManager instead of nil

### DIFF
--- a/pkg/controller/reconciler/reconciler_finalizer_test.go
+++ b/pkg/controller/reconciler/reconciler_finalizer_test.go
@@ -60,10 +60,14 @@ func (f *MockManager) GetConfig() *rest.Config        { return &rest.Config{} }
 func (f *MockManager) GetFieldIndexer() client.FieldIndexer { return nil }
 
 //nolint:ireturn // Returns stdlib interface required by manager.Manager
-func (f *MockManager) GetEventRecorderFor(name string) record.EventRecorder { return nil }
+func (f *MockManager) GetEventRecorderFor(name string) record.EventRecorder {
+	return record.NewFakeRecorder(100)
+}
 
 //nolint:ireturn // Returns stdlib interface required by manager.Manager
-func (f *MockManager) GetEventRecorder(name string) events.EventRecorder { return nil }
+func (f *MockManager) GetEventRecorder(name string) events.EventRecorder {
+	return events.NewFakeRecorder(100)
+}
 
 //nolint:ireturn // Returns stdlib interface required by manager.Manager
 func (f *MockManager) GetCache() cache.Cache                                    { return nil }


### PR DESCRIPTION
## Summary
- MockManager.GetEventRecorderFor() and GetEventRecorder() returned nil, causing a nil pointer dereference panic when any test hits a code path that calls r.Recorder.Eventf()
- This prevented testing error paths that emit events (e.g., provisioning error events in reconciler.apply())
- Return record.NewFakeRecorder(100) and events.NewFakeRecorder(100) to match production behavior

## Test plan
- [x] Existing finalizer tests pass
- [x] Reconciler tests that trigger provisioning errors no longer panic

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [X] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
This change modifies a unit test helper (MockManager) to return fake recorders instead of nil. It does not change any production code, API behavior, or operator functionality. The fix only affects the test infrastructure, enabling existing unit tests to exercise error code paths that previously caused nil pointer panics. No e2e test changes are needed because this is a test-only change with no impact on deployed behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Reconciler test helpers now provide functional fake event recorders (non-nil), ensuring events are captured during test runs and improving reliability of event-related assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->