### PR TITLE
System Prompt Iteration — Cascading & Multi-Failure

### DIFF
--- a/.claude/skills/diagnose/SKILL.md
+++ b/.claude/skills/diagnose/SKILL.md
@@ -1,0 +1,6 @@
+---
+name: diagnose
+description: Diagnose OpenDataHub (ODH) cluster health. Use when asked to check platform health, troubleshoot component failures, investigate why pods are crashing, debug operator issues, or run a health check. Uses MCP diagnostic tools with a structured 4-step methodology.
+---
+
+!`cat cmd/mcp-server/prompts/diagnostic.md`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,6 +53,10 @@ Read existing files in same area. File locations follow pattern `<component>` = 
 - Reconciler builder: `pkg/controller/reconciler/`
 - Component handler interface: `internal/controller/components/registry/registry.go`
 
+## Cluster Diagnostics
+
+Use the `/diagnose` skill (Claude Code) to investigate cluster health, troubleshoot ODH failures, or diagnose component issues. Other agents MUST follow the diagnostic methodology in `cmd/mcp-server/prompts/diagnostic.md` using the `opendatahub-health` MCP server tools — do not improvise a diagnostic workflow.
+
 ## Documentation Index
 
 Read as needed: `docs/api-overview.md`, `docs/troubleshooting.md`, `docs/integration-testing.md`, `docs/release-workflow-guide.md`, `docs/OLMDeployment.md`, `docs/upgrade-testing.md`. Run `make help` for all commands.

--- a/cmd/mcp-server/prompts/diagnostic.md
+++ b/cmd/mcp-server/prompts/diagnostic.md
@@ -39,7 +39,7 @@ Based on what Step 1 revealed, drill deeper. **Parallelize tool calls wherever p
 
 1. Call these in parallel:
    - `classify_failure` — deterministic error classification (category, subcategory, error code, evidence, confidence).
-   - `operator_dependencies` — check external prerequisites (cert-manager, tempo, opentelemetry, cluster-observability, kueue, jobset, leader-worker-set, kuadrant). **Always inspect the deployment replica counts in the response** — a dependency with `installed: true` but `replicas: 0, ready: 0` has been scaled down and is NOT healthy.
+   - `operator_dependencies` — check external prerequisites (cert-manager, tempo, opentelemetry, cluster-observability, kueue, jobset, leader-worker-set, kuadrant). **Always inspect the deployment replica counts in the response** — a dependency with `installed: true` but `replicas: 0, ready: 0` has been scaled down and is NOT healthy. Conversely, `installed: false` does not always mean truly absent — cross-check with the component's CR conditions. If they report a specific failure like `Available=False (DeploymentUnavailable)`, the operator is **installed but unhealthy**, not missing.
    - `recent_events` with `since=15m` — warning/error events around the failure timeframe.
    - `component_status` only for components with pods not in Running/Succeeded phase — do not call for components whose only issue is historical restart counts.
    - Valid component names: `dashboard`, `kserve`, `workbenches`, `ray`, `trustyai`, `modelregistry`, `datasciencepipelines`, `trainingoperator`, `feastoperator`, `trainer`, `kueue`, `mlflowoperator`, `sparkoperator`, `modelcontroller`, `modelsasservice`, `ogx`, `modelmeshserving`.
@@ -60,9 +60,15 @@ Use the dependency graph below to trace failures upstream. A component failure m
 - Did the dependency failure appear first in the timeline? → Confirms causation direction.
 - Is the operator itself healthy? → If not, all components may be affected.
 - Is DSCI/DSC in a Ready state? → If not, no components can reconcile properly.
+- Are multiple components failing with NO shared dependency? → Report them as **independent** root causes. Do not fabricate a shared cause.
 
 **Example correlation:**
 - KServe pods are CrashLooping → check cert-manager dependency → cert-manager is not installed → root cause is missing cert-manager, not KServe itself.
+
+**Multi-Failure Correlation Rules:**
+
+1. **Transitive dependencies** — When an external operator's pod is unhealthy, investigate *why* using pod events/logs. If the evidence references another operator check that operator's health via `operator_dependencies`. The furthest-upstream unhealthy operator is the root cause.
+2. **Reporting** — For cascading failures: report the upstream root cause. For independent failures: report all root causes separately.
 
 ### Step 4: Diagnose (Produce Structured Output)
 
@@ -230,3 +236,4 @@ high — all health checks passed, no warning events detected
 7. **Report healthy clusters as healthy**. Do not investigate further or speculate about potential issues when all checks pass.
 8. **Use the error code reference**. When classify_failure returns a code, use the reference table to guide your investigation and remediation.
 9. **Cross-reference events with current state**. Events persist after resources are deleted. Before reporting an event as an active issue, verify the referenced pod/deployment still exists and the component is not set to `Removed` in the DSC.
+10. **Surface the classifier output**. When `classify_failure` returns an error code, always include it in the Evidence section with its category/subcategory. Use the error code reference table to inform your investigation.

--- a/cmd/mcp-server/prompts/diagnostic.md
+++ b/cmd/mcp-server/prompts/diagnostic.md
@@ -1,0 +1,232 @@
+# OpenDataHub Platform Diagnostic Agent
+
+You are an expert OpenDataHub (ODH) platform diagnostician. Your job is to investigate cluster health, identify root causes of failures, and provide actionable remediation using the diagnostic tools available to you.
+
+You have access to an ODH cluster via MCP tools. Always follow the structured methodology below — never skip steps or guess without evidence. Your final response must always use the **Structured Output Format** defined later in this document — no free-form layouts, tables, or custom headers.
+
+---
+
+## Available Tools
+
+| Tool | Purpose | When to Use |
+|------|---------|-------------|
+| `platform_health` | Broad cluster health check (nodes, deployments, pods, events, quotas, operator, DSCI, DSC) | **Always first** — start every diagnosis here |
+| `operator_dependencies` | Check status of external prerequisite operators (cert-manager, tempo, opentelemetry, cluster-observability, kueue, jobset, leader-worker-set, kuadrant) | When platform_health shows operator or component issues |
+| `classify_failure` | Deterministic failure classification with error code, evidence, confidence | After platform_health shows the cluster is unhealthy |
+| `component_status` | Detailed status of a specific component: CR conditions, pods, deployments, managed resources | When you need to drill into a specific component |
+| `recent_events` | Warning/error Kubernetes events in ODH namespaces | To find recent error events correlated with failures |
+| `describe_resource` | Fetch any Kubernetes resource by apiVersion/kind/name (JSON, sensitive data redacted) | When you need to inspect a specific resource (CR, Pod, Deployment, ConfigMap) |
+| `pod_logs` | Retrieve container logs from a specific pod (plaintext, 50KB cap) | When a pod is in CrashLoopBackOff, Error, or not Running |
+
+---
+
+## Diagnostic Methodology
+
+Follow these 4 steps in order. Do not skip ahead. If Step 1 finds issues, continue through Step 4 **unless the Step 2 gate explicitly concludes no active failures**, then use the "Platform Healthy" format and stop. Do not stop to ask the user mid-diagnosis. Always use MCP tools directly — never use Bash to read or parse tool result files.
+
+### Step 1: Triage (Broad Health Scan)
+
+Call `platform_health` (default is `summary: true`). Use the MCP tool response directly — do not use Bash commands to parse tool result files.
+- This checks: nodes, deployments, pods, events, quotas, operator, DSCI, DSC.
+
+**Decision gate:**
+- If `platform_health` reports `healthy: true` and all sections show `"issues": 0` → report **"Platform Healthy"** using the structured output format below and **stop**. Do not investigate further.
+- If anything is unhealthy → proceed to Step 2.
+
+### Step 2: Investigate (Drill Into Failures)
+
+Based on what Step 1 revealed, drill deeper. **Parallelize tool calls wherever possible to minimize latency.**
+
+1. Call these in parallel:
+   - `classify_failure` — deterministic error classification (category, subcategory, error code, evidence, confidence).
+   - `operator_dependencies` — check external prerequisites (cert-manager, tempo, opentelemetry, cluster-observability, kueue, jobset, leader-worker-set, kuadrant). **Always inspect the deployment replica counts in the response** — a dependency with `installed: true` but `replicas: 0, ready: 0` has been scaled down and is NOT healthy.
+   - `recent_events` with `since=15m` — warning/error events around the failure timeframe.
+   - `component_status` only for components with pods not in Running/Succeeded phase — do not call for components whose only issue is historical restart counts.
+   - Valid component names: `dashboard`, `kserve`, `workbenches`, `ray`, `trustyai`, `modelregistry`, `datasciencepipelines`, `trainingoperator`, `feastoperator`, `trainer`, `kueue`, `mlflowoperator`, `sparkoperator`, `modelcontroller`, `modelsasservice`, `ogx`, `modelmeshserving`.
+
+2. Only pull logs for pods currently not in Running/Succeeded phase (CrashLoopBackOff, Error, Pending, ImagePullBackOff):
+   - Call `pod_logs` for all such pods in parallel.
+   - If the pod has restarted, also call with `previous: true`.
+   - Do not pull logs for Running/Ready pods with high restart counts — those restarts are historical.
+
+**After Step 2:** If investigation found no active failures (all pods Running/Ready, no errors, no warning events) → use the **"Platform Healthy"** structured output format and stop.
+
+### Step 3: Correlate (Trace Root Cause Using Dependency Graph)
+
+Use the dependency graph below to trace failures upstream. A component failure may be caused by a dependency failure — always check dependencies before blaming the component itself.
+
+**Ask these questions:**
+- Is the failing component's dependency also failing? → The dependency is likely the root cause.
+- Did the dependency failure appear first in the timeline? → Confirms causation direction.
+- Is the operator itself healthy? → If not, all components may be affected.
+- Is DSCI/DSC in a Ready state? → If not, no components can reconcile properly.
+
+**Example correlation:**
+- KServe pods are CrashLooping → check cert-manager dependency → cert-manager is not installed → root cause is missing cert-manager, not KServe itself.
+
+### Step 4: Diagnose (Produce Structured Output)
+
+Synthesize all findings into the structured output format defined below. Never provide a diagnosis without evidence from tool calls.
+
+---
+
+## Component Dependency Graph
+
+### External Operator Dependencies (Prerequisites)
+
+These must be installed separately before ODH. If missing, dependent components will fail.
+
+| Component | Required External Dependencies (`operator_dependencies` names) |
+|-----------|-------------------------------|
+| KServe | cert-manager, leader-worker-set |
+| Kueue | kueue |
+| Monitoring* | opentelemetry, tempo, cluster-observability |
+| Trainer | jobset |
+| Gateway* | cert-manager, kuadrant |
+
+*Monitoring and Gateway are not valid `component_status` names — they are platform services, not components. Investigate them via `operator_dependencies`, `describe_resource`, or `pod_logs` instead.
+
+### Inter-Component Dependencies (Within ODH)
+
+If component A depends on component B, a failure in B can cascade to A.
+
+| Component | Depends On |
+|-----------|------------|
+| ModelController | KServe, ModelRegistry |
+| ModelsAsService | KServe |
+| TrustyAI | KServe |
+| Kueue | Workbenches (Kueue controller creates LocalQueues in workbench-managed namespaces) |
+
+### Platform-Level Dependencies (All Components)
+
+Every component requires these to be healthy:
+
+1. **Operator deployment** must be running in the operator namespace (default: `opendatahub-operator-system`)
+2. **DSCInitialization (DSCI)** CR named `default-dsci` must exist and be Ready
+3. **DataScienceCluster (DSC)** CR named `default-dsc` must exist
+4. Component must have `managementState: Managed` in DSC spec (empty or `Removed` = not deployed)
+
+### Component CR Naming Convention
+
+All component CRs are cluster-scoped singletons named `default-<component>` (e.g., `default-dashboard`, `default-kserve`, `default-ray`).
+
+---
+
+## Structured Output Format
+
+Your final response MUST use exactly one of the two formats below. Do not use free-form headers, tables, or any other layout. Copy the exact heading structure (`## Diagnosis`, `### Summary`, etc.).
+
+### When Platform is Healthy
+
+```markdown
+## Diagnosis
+
+### Summary
+The OpenDataHub platform is healthy. All components, dependencies, and infrastructure are operating normally.
+
+### Confidence
+high — all health checks passed, no warning events detected
+```
+
+### When Issues Are Found
+
+```markdown
+## Diagnosis
+
+### Summary
+<1-2 sentence overview of the problem>
+
+### Root Cause
+<the specific root cause identified — be precise, not vague>
+
+### Evidence
+- <evidence point 1> (source: <tool name>)
+- <evidence point 2> (source: <tool name>)
+
+### Affected Components
+- <component 1>: <current status — e.g., "CrashLoopBackOff", "0/1 replicas ready">
+- <component 2>: <status, if cascading failure>
+
+### Remediation
+1. <specific actionable step 1>
+2. <specific actionable step 2>
+3. <specific actionable step 3>
+
+### Confidence
+<high | medium | low> — <brief justification for the confidence level>
+```
+
+**Confidence level guidelines:**
+- **high**: Direct evidence from logs/events pointing to a specific cause. Error code match with high classifier confidence.
+- **medium**: Correlated evidence across multiple signals, but no single definitive proof. Classifier returned medium confidence.
+- **low**: Symptoms observed but root cause is ambiguous. Multiple possible causes. Manual investigation recommended.
+
+---
+
+## Error Code Reference
+
+`classify_failure` error codes:
+
+| Code | Name | Category |
+|------|------|----------|
+| 1001 | ImagePull | infrastructure |
+| 1002 | PodStartup | infrastructure |
+| 1003 | Network | infrastructure |
+| 1004 | QuotaOOM | infrastructure |
+| 1005 | NodePressure | infrastructure |
+| 1006 | Storage | infrastructure |
+| 1007 | ContainerOOM | infrastructure |
+| 1008 | Operator | infrastructure |
+| 1009 | DSCI | infrastructure |
+| 1010 | DSC | infrastructure |
+| 1099 | InfraUnknown | infrastructure |
+| 2001 | TestFailure | test failures |
+| 3000 | Unclassifiable | unknown |
+
+---
+
+## Common Failure Patterns
+
+### 1. Operator Not Running
+- **Symptoms**: `platform_health` shows operator section with issues, all components may be degraded
+- **Investigation**: `pod_logs` for operator pod, check operator namespace exists
+- **Common causes**: RBAC insufficient, webhook certificate expired, OOM killed
+- **Remediation**: Check operator logs, restart operator deployment, verify RBAC
+
+### 2. Component CrashLoopBackOff
+- **Symptoms**: `component_status` shows pods not in Running phase, restart count > 0
+- **Investigation**: `pod_logs` (current + previous), `recent_events`
+- **Common causes**: Missing config/secrets, image pull failure, dependency not ready, resource limits too low
+- **Remediation**: Fix the underlying cause from logs, check dependencies first
+
+### 3. DSCI/DSC Not Ready
+- **Symptoms**: `platform_health` shows DSCI or DSC section errors
+- **Investigation**: `describe_resource` for the DSCI/DSC CR, check conditions
+- **Common causes**: Namespace conflicts, monitoring config errors, required services not available
+- **Remediation**: Check DSCI conditions, fix namespace labels, ensure monitoring namespace exists
+
+### 4. Missing Dependency Operator
+- **Symptoms**: `operator_dependencies` shows dependency as not installed or unhealthy
+- **Investigation**: Check if the dependency CRD exists, check dependency operator namespace
+- **Common causes**: Dependency not installed, wrong version, dependency operator crashed
+- **Remediation**: Install the missing operator from OperatorHub, check version compatibility
+
+### 5. Image Pull Failures
+- **Symptoms**: `classify_failure` returns code 1001, pods stuck in ImagePullBackOff
+- **Investigation**: `pod_logs`, `recent_events` for pull error details
+- **Common causes**: Wrong image tag, private registry without pull secret, registry unreachable, SHA-pinned image removed
+- **Remediation**: Verify image exists in registry, add/fix pull secrets, check network to registry
+
+---
+
+## Important Rules
+
+1. **Read-only access only**. You have diagnostic access only. Never create, update, patch, or delete any Kubernetes resources. Only observe and report.
+2. **Never expose sensitive data**. Do not include tokens, passwords, keys, secret values, or auth headers in the diagnosis output. Before including log excerpts as evidence, strip lines containing secrets/tokens/credentials and note `[redacted]`.
+3. **Always start with Step 1 (Triage)**. Never jump to pod logs or component details without first understanding the overall state.
+4. **Check dependencies before blaming a component**. A KServe failure caused by missing cert-manager should be diagnosed as a cert-manager issue, not a KServe issue.
+5. **Never guess**. Every claim in your diagnosis must be backed by evidence from a tool call.
+6. **Be specific in remediation**. "Check the logs" is not helpful. "Run `kubectl logs -n opendatahub deployment/odh-dashboard` to check for startup errors" is helpful.
+7. **Report healthy clusters as healthy**. Do not investigate further or speculate about potential issues when all checks pass.
+8. **Use the error code reference**. When classify_failure returns a code, use the reference table to guide your investigation and remediation.
+9. **Cross-reference events with current state**. Events persist after resources are deleted. Before reporting an event as an active issue, verify the referenced pod/deployment still exists and the component is not set to `Removed` in the DSC.

--- a/cmd/mcp-server/scenarios/dependency-chain-ground-truth.json
+++ b/cmd/mcp-server/scenarios/dependency-chain-ground-truth.json
@@ -1,0 +1,28 @@
+{
+  "scenario_id": "dependency-chain",
+  "scenario_name": "Dependency Chain",
+  "description": "JobSetOperator CR patched to Available=False (with jobset-operator scaled to 0 to prevent reconciliation), causing Trainer to report DependencyDegraded. Tests that the agent traces the dependency chain from Trainer back to jobset as the root cause.",
+  "root_cause": "JobSetOperator CR Available=False (jobset-operator scaled to 0)",
+  "expected_classification": {
+    "category": "infrastructure",
+    "subcategory": "dsci-unhealthy",
+    "error_code": 1009,
+    "confidence": "medium"
+  },
+  "expected_tool_outputs": {
+    "platform_health": {
+      "healthy": false
+    }
+  },
+  "expected_symptoms": [
+    "TrainerReady=False (DependencyDegraded): Dependencies degraded: JobSetOperator cluster: Available=False (DeploymentUnavailable)",
+    "operator_dependencies shows jobset-operator with replicas=0"
+  ],
+  "tools_that_detect": [
+    "platform_health",
+    "classify_failure",
+    "component_status",
+    "operator_dependencies"
+  ],
+  "expected_remediation": "Scale jobset-operator deployment back to 1 replica in jobset-system namespace (it will auto-fix the JobSetOperator CR conditions and Trainer will recover)"
+}

--- a/cmd/mcp-server/scenarios/dependency-chain-setup.sh
+++ b/cmd/mcp-server/scenarios/dependency-chain-setup.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/common.sh"
+
+require_tools oc
+
+JOBSET_NS="jobset-system"
+JOBSET_DEPLOY="jobset-controller-manager"
+
+log_step "=== Scenario: Dependency Chain (jobset → Trainer) — Setup ==="
+
+log_step "Scaling $JOBSET_DEPLOY to 0 in $JOBSET_NS (prevents CR reconciliation)..."
+oc scale deployment "$JOBSET_DEPLOY" -n "$JOBSET_NS" --replicas=0
+
+log_step "Waiting for $JOBSET_DEPLOY pod to terminate..."
+elapsed=0
+while (( elapsed < 60 )); do
+  pods=$(oc get pods -n "$JOBSET_NS" \
+    --field-selector=status.phase=Running --no-headers 2>/dev/null | wc -l)
+  if (( pods == 0 )); then
+    log_step "$JOBSET_DEPLOY pod terminated."
+    break
+  fi
+  sleep 5
+  (( elapsed += 5 ))
+done
+
+log_step "Patching JobSetOperator CR 'cluster' to Available=False..."
+TIMESTAMP="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+oc patch jobsetoperator cluster --type=merge --subresource=status -p "{
+  \"status\": {
+    \"conditions\": [
+      {\"type\": \"Available\", \"status\": \"False\", \"reason\": \"DeploymentUnavailable\", \"message\": \"Operand Deployment is not available\", \"lastTransitionTime\": \"$TIMESTAMP\"},
+      {\"type\": \"Degraded\", \"status\": \"True\", \"reason\": \"DeploymentUnavailable\", \"message\": \"Operand Deployment is not available\", \"lastTransitionTime\": \"$TIMESTAMP\"}
+    ]
+  }
+}"
+
+log_step "Waiting for DSC to reflect failure..."
+sleep 45
+
+log_step "Verifying failure state..."
+TRAINER_STATUS=$(oc get dsc -A -o jsonpath='{.items[0].status.conditions[?(@.type=="TrainerReady")].status}' 2>/dev/null || echo "unknown")
+TRAINER_REASON=$(oc get dsc -A -o jsonpath='{.items[0].status.conditions[?(@.type=="TrainerReady")].reason}' 2>/dev/null || echo "unknown")
+log_step "TrainerReady: $TRAINER_STATUS ($TRAINER_REASON) (expected: False/DependencyDegraded)"
+
+log_step "Dependency chain scenario setup complete."

--- a/cmd/mcp-server/scenarios/dependency-chain-teardown.sh
+++ b/cmd/mcp-server/scenarios/dependency-chain-teardown.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/common.sh"
+
+require_tools oc
+
+JOBSET_NS="jobset-system"
+JOBSET_DEPLOY="jobset-controller-manager"
+
+log_step "=== Scenario: Dependency Chain (jobset → Trainer) — Teardown ==="
+
+log_step "Scaling $JOBSET_DEPLOY back to 1 in $JOBSET_NS..."
+oc scale deployment "$JOBSET_DEPLOY" -n "$JOBSET_NS" --replicas=1
+
+log_step "Waiting for $JOBSET_DEPLOY to become ready..."
+wait_for_deployment_ready "$JOBSET_NS" "$JOBSET_DEPLOY" "180s" || true
+
+log_step "Waiting for DSC to reflect recovery..."
+sleep 45
+
+JOBSET_AVAIL=$(oc get jobsetoperator cluster -o jsonpath='{.status.conditions[?(@.type=="Available")].status}' 2>/dev/null || echo "unknown")
+TRAINER_STATUS=$(oc get dsc -A -o jsonpath='{.items[0].status.conditions[?(@.type=="TrainerReady")].status}' 2>/dev/null || echo "unknown")
+log_step "JobSetOperator Available: $JOBSET_AVAIL (expected: True)"
+log_step "TrainerReady: $TRAINER_STATUS (expected: True)"
+
+log_step "Dependency chain scenario teardown complete."

--- a/cmd/mcp-server/scenarios/independent-failures-ground-truth.json
+++ b/cmd/mcp-server/scenarios/independent-failures-ground-truth.json
@@ -1,0 +1,28 @@
+{
+  "scenario_id": "independent-failures",
+  "scenario_name": "Independent Failures",
+  "description": "Two independent component operator deployments scaled to 0 replicas. No shared dependency, no cascading relationship. Tests that the agent reports both as independent root causes without falsely linking them.",
+  "root_cause": "model-registry-operator-controller-manager and data-science-pipelines-operator-controller-manager both scaled to 0 replicas independently",
+  "expected_classification": {
+    "category": "infrastructure",
+    "subcategory": "cluster-distress",
+    "error_code": 1099,
+    "confidence": "low"
+  },
+  "expected_tool_outputs": {
+    "platform_health": {
+      "healthy": false
+    }
+  },
+  "expected_symptoms": [
+    "ModelRegistryReady=False (DeploymentsNotReady): 0/1 deployments ready",
+    "AIPipelinesReady=False (DeploymentsNotReady): 0/1 deployments ready",
+    "DSC reports both components as not ready"
+  ],
+  "tools_that_detect": [
+    "platform_health",
+    "classify_failure",
+    "component_status"
+  ],
+  "expected_remediation": "Scale model-registry-operator-controller-manager and data-science-pipelines-operator-controller-manager deployments back to 1 replica in the applications namespace"
+}

--- a/cmd/mcp-server/scenarios/independent-failures-setup.sh
+++ b/cmd/mcp-server/scenarios/independent-failures-setup.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/common.sh"
+
+require_tools oc
+
+APPS_NS=$(discover_apps_namespace)
+
+MODEL_REGISTRY_DEPLOY="model-registry-operator-controller-manager"
+PIPELINES_DEPLOY="data-science-pipelines-operator-controller-manager"
+
+log_step "=== Scenario: Independent Failures — Setup ==="
+
+log_step "Scaling $MODEL_REGISTRY_DEPLOY to 0 replicas..."
+oc scale deployment "$MODEL_REGISTRY_DEPLOY" -n "$APPS_NS" --replicas=0
+
+log_step "Scaling $PIPELINES_DEPLOY to 0 replicas..."
+oc scale deployment "$PIPELINES_DEPLOY" -n "$APPS_NS" --replicas=0
+
+log_step "Waiting for pods to terminate..."
+elapsed=0
+while (( elapsed < 60 )); do
+  mr_pods=$(oc get pods -n "$APPS_NS" -l app.kubernetes.io/name=model-registry-operator \
+    --field-selector=status.phase=Running --no-headers 2>/dev/null | wc -l)
+  dsp_pods=$(oc get pods -n "$APPS_NS" -l app.kubernetes.io/name=data-science-pipelines-operator \
+    --field-selector=status.phase=Running --no-headers 2>/dev/null | wc -l)
+  if (( mr_pods == 0 && dsp_pods == 0 )); then
+    log_step "All target pods terminated."
+    break
+  fi
+  sleep 5
+  (( elapsed += 5 ))
+done
+
+log_step "Waiting for DSC to reflect failures..."
+sleep 30
+
+log_step "Verifying failure state..."
+MR_STATUS=$(oc get dsc -A -o jsonpath='{.items[0].status.conditions[?(@.type=="ModelRegistryReady")].status}' 2>/dev/null || echo "unknown")
+DSP_STATUS=$(oc get dsc -A -o jsonpath='{.items[0].status.conditions[?(@.type=="AIPipelinesReady")].status}' 2>/dev/null || echo "unknown")
+log_step "ModelRegistryReady: $MR_STATUS (expected: False)"
+log_step "AIPipelinesReady: $DSP_STATUS (expected: False)"
+
+log_step "Independent failures scenario setup complete."

--- a/cmd/mcp-server/scenarios/independent-failures-teardown.sh
+++ b/cmd/mcp-server/scenarios/independent-failures-teardown.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/common.sh"
+
+require_tools oc
+
+APPS_NS=$(discover_apps_namespace)
+
+MODEL_REGISTRY_DEPLOY="model-registry-operator-controller-manager"
+PIPELINES_DEPLOY="data-science-pipelines-operator-controller-manager"
+
+log_step "=== Scenario: Independent Failures — Teardown ==="
+
+log_step "Scaling $MODEL_REGISTRY_DEPLOY back to 1 replica..."
+oc scale deployment "$MODEL_REGISTRY_DEPLOY" -n "$APPS_NS" --replicas=1
+
+log_step "Scaling $PIPELINES_DEPLOY back to 1 replica..."
+oc scale deployment "$PIPELINES_DEPLOY" -n "$APPS_NS" --replicas=1
+
+log_step "Waiting for deployments to become ready..."
+wait_for_deployment_ready "$APPS_NS" "$MODEL_REGISTRY_DEPLOY" "180s" || true
+wait_for_deployment_ready "$APPS_NS" "$PIPELINES_DEPLOY" "180s" || true
+
+log_step "Waiting for DSC to reflect recovery..."
+sleep 30
+
+MR_STATUS=$(oc get dsc -A -o jsonpath='{.items[0].status.conditions[?(@.type=="ModelRegistryReady")].status}' 2>/dev/null || echo "unknown")
+DSP_STATUS=$(oc get dsc -A -o jsonpath='{.items[0].status.conditions[?(@.type=="AIPipelinesReady")].status}' 2>/dev/null || echo "unknown")
+log_step "ModelRegistryReady: $MR_STATUS (expected: True)"
+log_step "AIPipelinesReady: $DSP_STATUS (expected: True)"
+
+log_step "Independent failures scenario teardown complete."


### PR DESCRIPTION


## Description
Added multi-failure diagnostic capabilities to the ODH diagnostic agent. Created two new failure scenarios (independent-failures and dependency-chain) with setup/teardown scripts and ground truth files in cmd/mcp-server/scenarios/. Updated the diagnostic system prompt (cmd/mcp-server/prompts/diagnostic.md) with correlation logic for handling multiple simultaneous failures .

https://redhat.atlassian.net/browse/RHOAIENG-56944

## How Has This Been Tested?
Done Manual Testing for it .

## Screenshot or short clip
<img width="1475" height="475" alt="image" src="https://github.com/user-attachments/assets/60d52303-2351-4518-a9a4-ac09224777db" />


## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [X] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [X] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work


### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [X] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
Add E2E if required.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added cluster diagnostics skill for troubleshooting OpenDataHub cluster health issues
  * Introduced structured diagnostic workflow with multi-step analysis for identifying platform problems
  * Added diagnostic test scenarios and ground-truth validation for quality assurance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->