### PR TITLE
System Prompt Iteration — Cascading & Multi-Failure

### DIFF
--- a/cmd/mcp-server/prompts/diagnostic.md
+++ b/cmd/mcp-server/prompts/diagnostic.md
@@ -39,7 +39,7 @@ Based on what Step 1 revealed, drill deeper. **Parallelize tool calls wherever p
 
 1. Call these in parallel:
    - `classify_failure` — deterministic error classification (category, subcategory, error code, evidence, confidence).
-   - `operator_dependencies` — check external prerequisites (cert-manager, tempo, opentelemetry, cluster-observability, kueue, jobset, leader-worker-set, kuadrant). **Always inspect the deployment replica counts in the response** — a dependency with `installed: true` but `replicas: 0, ready: 0` has been scaled down and is NOT healthy.
+   - `operator_dependencies` — check external prerequisites (cert-manager, tempo, opentelemetry, cluster-observability, kueue, jobset, leader-worker-set, kuadrant). **Always inspect the deployment replica counts in the response** — a dependency with `installed: true` but `replicas: 0, ready: 0` has been scaled down and is NOT healthy. Conversely, `installed: false` does not always mean truly absent — cross-check with the component's CR conditions. If they report a specific failure like `Available=False (DeploymentUnavailable)`, the operator is **installed but unhealthy**, not missing.
    - `recent_events` with `since=15m` — warning/error events around the failure timeframe.
    - `component_status` only for components with pods not in Running/Succeeded phase — do not call for components whose only issue is historical restart counts.
    - Valid component names: `dashboard`, `kserve`, `workbenches`, `ray`, `trustyai`, `modelregistry`, `datasciencepipelines`, `trainingoperator`, `feastoperator`, `trainer`, `kueue`, `mlflowoperator`, `sparkoperator`, `modelcontroller`, `modelsasservice`, `ogx`, `modelmeshserving`.
@@ -60,9 +60,15 @@ Use the dependency graph below to trace failures upstream. A component failure m
 - Did the dependency failure appear first in the timeline? → Confirms causation direction.
 - Is the operator itself healthy? → If not, all components may be affected.
 - Is DSCI/DSC in a Ready state? → If not, no components can reconcile properly.
+- Are multiple components failing with NO shared dependency? → Report them as **independent** root causes. Do not fabricate a shared cause.
 
 **Example correlation:**
 - KServe pods are CrashLooping → check cert-manager dependency → cert-manager is not installed → root cause is missing cert-manager, not KServe itself.
+
+**Multi-Failure Correlation Rules:**
+
+1. **Transitive dependencies** — When an external operator's pod is unhealthy, investigate *why* using pod events/logs. If the evidence references another operator check that operator's health via `operator_dependencies`. The furthest-upstream unhealthy operator is the root cause.
+2. **Reporting** — For cascading failures: report the upstream root cause. For independent failures: report all root causes separately.
 
 ### Step 4: Diagnose (Produce Structured Output)
 
@@ -230,3 +236,4 @@ high — all health checks passed, no warning events detected
 7. **Report healthy clusters as healthy**. Do not investigate further or speculate about potential issues when all checks pass.
 8. **Use the error code reference**. When classify_failure returns a code, use the reference table to guide your investigation and remediation.
 9. **Cross-reference events with current state**. Events persist after resources are deleted. Before reporting an event as an active issue, verify the referenced pod/deployment still exists and the component is not set to `Removed` in the DSC.
+10. **Surface the classifier output**. When `classify_failure` returns an error code, always include it in the Evidence section with its category/subcategory. Use the error code reference table to inform your investigation.

--- a/cmd/mcp-server/scenarios/dependency-chain-ground-truth.json
+++ b/cmd/mcp-server/scenarios/dependency-chain-ground-truth.json
@@ -1,0 +1,28 @@
+{
+  "scenario_id": "dependency-chain",
+  "scenario_name": "Dependency Chain",
+  "description": "JobSetOperator CR patched to Available=False (with jobset-operator scaled to 0 to prevent reconciliation), causing Trainer to report DependencyDegraded. Tests that the agent traces the dependency chain from Trainer back to jobset as the root cause.",
+  "root_cause": "JobSetOperator CR Available=False (jobset-operator scaled to 0)",
+  "expected_classification": {
+    "category": "infrastructure",
+    "subcategory": "dsci-unhealthy",
+    "error_code": 1009,
+    "confidence": "medium"
+  },
+  "expected_tool_outputs": {
+    "platform_health": {
+      "healthy": false
+    }
+  },
+  "expected_symptoms": [
+    "TrainerReady=False (DependencyDegraded): Dependencies degraded: JobSetOperator cluster: Available=False (DeploymentUnavailable)",
+    "operator_dependencies shows jobset-operator with replicas=0"
+  ],
+  "tools_that_detect": [
+    "platform_health",
+    "classify_failure",
+    "component_status",
+    "operator_dependencies"
+  ],
+  "expected_remediation": "Scale jobset-operator deployment back to 1 replica in jobset-system namespace (it will auto-fix the JobSetOperator CR conditions and Trainer will recover)"
+}

--- a/cmd/mcp-server/scenarios/dependency-chain-setup.sh
+++ b/cmd/mcp-server/scenarios/dependency-chain-setup.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/common.sh"
+
+require_tools oc
+
+JOBSET_NS="jobset-system"
+JOBSET_DEPLOY="jobset-controller-manager"
+
+log_step "=== Scenario: Dependency Chain (jobset → Trainer) — Setup ==="
+
+log_step "Scaling $JOBSET_DEPLOY to 0 in $JOBSET_NS (prevents CR reconciliation)..."
+oc scale deployment "$JOBSET_DEPLOY" -n "$JOBSET_NS" --replicas=0
+
+log_step "Waiting for $JOBSET_DEPLOY pod to terminate..."
+elapsed=0
+while (( elapsed < 60 )); do
+  pods=$(oc get pods -n "$JOBSET_NS" \
+    --field-selector=status.phase=Running --no-headers 2>/dev/null | wc -l)
+  if (( pods == 0 )); then
+    log_step "$JOBSET_DEPLOY pod terminated."
+    break
+  fi
+  sleep 5
+  (( elapsed += 5 ))
+done
+
+if (( pods > 0 )); then
+  log_step "ERROR: Timed out waiting for $JOBSET_DEPLOY pod to terminate (${pods} pods still running). CR patch would be reconciled back immediately."
+  exit 1
+fi
+
+log_step "Patching JobSetOperator CR 'cluster' to Available=False..."
+TIMESTAMP="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+oc patch jobsetoperator cluster --type=merge --subresource=status -p "{
+  \"status\": {
+    \"conditions\": [
+      {\"type\": \"Available\", \"status\": \"False\", \"reason\": \"DeploymentUnavailable\", \"message\": \"Operand Deployment is not available\", \"lastTransitionTime\": \"$TIMESTAMP\"},
+      {\"type\": \"Degraded\", \"status\": \"True\", \"reason\": \"DeploymentUnavailable\", \"message\": \"Operand Deployment is not available\", \"lastTransitionTime\": \"$TIMESTAMP\"}
+    ]
+  }
+}"
+
+log_step "Waiting for DSC to reflect failure (TrainerReady=False)..."
+elapsed=0
+TRAINER_STATUS="unknown"
+TRAINER_REASON="unknown"
+while (( elapsed < 150 )); do
+  TRAINER_STATUS=$(oc get dsc -A -o jsonpath='{.items[0].status.conditions[?(@.type=="TrainerReady")].status}' 2>/dev/null || echo "unknown")
+  TRAINER_REASON=$(oc get dsc -A -o jsonpath='{.items[0].status.conditions[?(@.type=="TrainerReady")].reason}' 2>/dev/null || echo "unknown")
+  if [[ "$TRAINER_STATUS" == "False" ]]; then
+    log_step "TrainerReady: $TRAINER_STATUS ($TRAINER_REASON)"
+    break
+  fi
+  sleep 10
+  (( elapsed += 10 ))
+done
+
+if [[ "$TRAINER_STATUS" != "False" ]]; then
+  log_step "ERROR: TrainerReady did not become False within timeout (current: $TRAINER_STATUS/$TRAINER_REASON). Scenario is invalid."
+  exit 1
+fi
+
+log_step "Dependency chain scenario setup complete."

--- a/cmd/mcp-server/scenarios/dependency-chain-teardown.sh
+++ b/cmd/mcp-server/scenarios/dependency-chain-teardown.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/common.sh"
+
+require_tools oc
+
+JOBSET_NS="jobset-system"
+JOBSET_DEPLOY="jobset-controller-manager"
+
+log_step "=== Scenario: Dependency Chain (jobset → Trainer) — Teardown ==="
+
+log_step "Scaling $JOBSET_DEPLOY back to 1 in $JOBSET_NS..."
+oc scale deployment "$JOBSET_DEPLOY" -n "$JOBSET_NS" --replicas=1
+
+log_step "Waiting for $JOBSET_DEPLOY to become ready..."
+wait_for_deployment_ready "$JOBSET_NS" "$JOBSET_DEPLOY" "180s" || true
+
+log_step "Waiting for DSC to reflect recovery..."
+sleep 45
+
+JOBSET_AVAIL=$(oc get jobsetoperator cluster -o jsonpath='{.status.conditions[?(@.type=="Available")].status}' 2>/dev/null || echo "unknown")
+TRAINER_STATUS=$(oc get dsc -A -o jsonpath='{.items[0].status.conditions[?(@.type=="TrainerReady")].status}' 2>/dev/null || echo "unknown")
+log_step "JobSetOperator Available: $JOBSET_AVAIL (expected: True)"
+log_step "TrainerReady: $TRAINER_STATUS (expected: True)"
+
+log_step "Dependency chain scenario teardown complete."

--- a/cmd/mcp-server/scenarios/independent-failures-ground-truth.json
+++ b/cmd/mcp-server/scenarios/independent-failures-ground-truth.json
@@ -1,0 +1,28 @@
+{
+  "scenario_id": "independent-failures",
+  "scenario_name": "Independent Failures",
+  "description": "Two independent component operator deployments scaled to 0 replicas. No shared dependency, no cascading relationship. Tests that the agent reports both as independent root causes without falsely linking them.",
+  "root_cause": "model-registry-operator-controller-manager and data-science-pipelines-operator-controller-manager both scaled to 0 replicas independently",
+  "expected_classification": {
+    "category": "infrastructure",
+    "subcategory": "cluster-distress",
+    "error_code": 1099,
+    "confidence": "low"
+  },
+  "expected_tool_outputs": {
+    "platform_health": {
+      "healthy": false
+    }
+  },
+  "expected_symptoms": [
+    "ModelRegistryReady=False (DeploymentsNotReady): 0/1 deployments ready",
+    "AIPipelinesReady=False (DeploymentsNotReady): 0/1 deployments ready",
+    "DSC reports both components as not ready"
+  ],
+  "tools_that_detect": [
+    "platform_health",
+    "classify_failure",
+    "component_status"
+  ],
+  "expected_remediation": "Scale model-registry-operator-controller-manager and data-science-pipelines-operator-controller-manager deployments back to 1 replica in the applications namespace"
+}

--- a/cmd/mcp-server/scenarios/independent-failures-setup.sh
+++ b/cmd/mcp-server/scenarios/independent-failures-setup.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/common.sh"
+
+require_tools oc
+
+APPS_NS=$(discover_apps_namespace)
+
+MODEL_REGISTRY_DEPLOY="model-registry-operator-controller-manager"
+PIPELINES_DEPLOY="data-science-pipelines-operator-controller-manager"
+
+log_step "=== Scenario: Independent Failures — Setup ==="
+
+log_step "Scaling $MODEL_REGISTRY_DEPLOY to 0 replicas..."
+oc scale deployment "$MODEL_REGISTRY_DEPLOY" -n "$APPS_NS" --replicas=0
+
+log_step "Scaling $PIPELINES_DEPLOY to 0 replicas..."
+oc scale deployment "$PIPELINES_DEPLOY" -n "$APPS_NS" --replicas=0
+
+log_step "Waiting for pods to terminate..."
+elapsed=0
+while (( elapsed < 60 )); do
+  mr_pods=$(oc get pods -n "$APPS_NS" -l app.kubernetes.io/name=model-registry-operator \
+    --field-selector=status.phase=Running --no-headers 2>/dev/null | wc -l)
+  dsp_pods=$(oc get pods -n "$APPS_NS" -l app.kubernetes.io/name=data-science-pipelines-operator \
+    --field-selector=status.phase=Running --no-headers 2>/dev/null | wc -l)
+  if (( mr_pods == 0 && dsp_pods == 0 )); then
+    log_step "All target pods terminated."
+    break
+  fi
+  sleep 5
+  (( elapsed += 5 ))
+done
+
+if (( mr_pods > 0 || dsp_pods > 0 )); then
+  log_step "ERROR: Timed out waiting for pods to terminate (model-registry: ${mr_pods}, pipelines: ${dsp_pods} still running)"
+  exit 1
+fi
+
+log_step "Waiting for DSC to reflect failures (ModelRegistryReady=False, AIPipelinesReady=False)..."
+elapsed=0
+MR_STATUS="unknown"
+DSP_STATUS="unknown"
+while (( elapsed < 150 )); do
+  MR_STATUS=$(oc get dsc -A -o jsonpath='{.items[0].status.conditions[?(@.type=="ModelRegistryReady")].status}' 2>/dev/null || echo "unknown")
+  DSP_STATUS=$(oc get dsc -A -o jsonpath='{.items[0].status.conditions[?(@.type=="AIPipelinesReady")].status}' 2>/dev/null || echo "unknown")
+  if [[ "$MR_STATUS" == "False" && "$DSP_STATUS" == "False" ]]; then
+    log_step "ModelRegistryReady: $MR_STATUS, AIPipelinesReady: $DSP_STATUS"
+    break
+  fi
+  sleep 10
+  (( elapsed += 10 ))
+done
+
+if [[ "$MR_STATUS" != "False" || "$DSP_STATUS" != "False" ]]; then
+  log_step "ERROR: DSC conditions did not reflect failures within timeout (ModelRegistryReady=$MR_STATUS, AIPipelinesReady=$DSP_STATUS). Scenario is invalid."
+  exit 1
+fi
+
+log_step "Independent failures scenario setup complete."

--- a/cmd/mcp-server/scenarios/independent-failures-teardown.sh
+++ b/cmd/mcp-server/scenarios/independent-failures-teardown.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/common.sh"
+
+require_tools oc
+
+APPS_NS=$(discover_apps_namespace)
+
+MODEL_REGISTRY_DEPLOY="model-registry-operator-controller-manager"
+PIPELINES_DEPLOY="data-science-pipelines-operator-controller-manager"
+
+log_step "=== Scenario: Independent Failures — Teardown ==="
+
+log_step "Scaling $MODEL_REGISTRY_DEPLOY back to 1 replica..."
+oc scale deployment "$MODEL_REGISTRY_DEPLOY" -n "$APPS_NS" --replicas=1
+
+log_step "Scaling $PIPELINES_DEPLOY back to 1 replica..."
+oc scale deployment "$PIPELINES_DEPLOY" -n "$APPS_NS" --replicas=1
+
+log_step "Waiting for deployments to become ready..."
+wait_for_deployment_ready "$APPS_NS" "$MODEL_REGISTRY_DEPLOY" "180s" || true
+wait_for_deployment_ready "$APPS_NS" "$PIPELINES_DEPLOY" "180s" || true
+
+log_step "Waiting for DSC to reflect recovery..."
+sleep 30
+
+MR_STATUS=$(oc get dsc -A -o jsonpath='{.items[0].status.conditions[?(@.type=="ModelRegistryReady")].status}' 2>/dev/null || echo "unknown")
+DSP_STATUS=$(oc get dsc -A -o jsonpath='{.items[0].status.conditions[?(@.type=="AIPipelinesReady")].status}' 2>/dev/null || echo "unknown")
+log_step "ModelRegistryReady: $MR_STATUS (expected: True)"
+log_step "AIPipelinesReady: $DSP_STATUS (expected: True)"
+
+log_step "Independent failures scenario teardown complete."


### PR DESCRIPTION


## Description
Added multi-failure diagnostic capabilities to the ODH diagnostic agent. Created two new failure scenarios (independent-failures and dependency-chain) with setup/teardown scripts and ground truth files in cmd/mcp-server/scenarios/. Updated the diagnostic system prompt (cmd/mcp-server/prompts/diagnostic.md) with correlation logic for handling multiple simultaneous failures .

https://redhat.atlassian.net/browse/RHOAIENG-56944

## How Has This Been Tested?
Done Manual Testing for it .

## Screenshot or short clip
<img width="1475" height="475" alt="image" src="https://github.com/user-attachments/assets/a1e75e92-4f18-4083-9b6d-e1d79b70ef1a" />


## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [X] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [X] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work


### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [X] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
Add E2E if required.
