### PR TITLE
fix(modelcontroller): remove unused DependenciesAvailable condition

### DIFF
--- a/internal/controller/components/modelcontroller/modelcontroller_support.go
+++ b/internal/controller/components/modelcontroller/modelcontroller_support.go
@@ -44,7 +44,6 @@ var (
 
 	conditionTypes = []string{
 		status.ConditionDeploymentsAvailable,
-		status.ConditionDependenciesAvailable,
 		LLMDWVADependencies,
 	}
 )


### PR DESCRIPTION
## Description

ModelController registers `DependenciesAvailable` as a dependent condition via `conditionTypes`, but has no preconditions or actions that ever set it. The condition is initialized as `Unknown` by `NewManager` every reconcile cycle and immediately cleaned up by `CleanupStaleConditions`, creating unnecessary churn.

This was harmless before #3495 changed the conditions framework to preserve conditions across cycles, but surfaced as a design issue during that work.

**JIRA:** [RHOAIENG-60488](https://redhat.atlassian.net/browse/RHOAIENG-60488)

## How Has This Been Tested?

- `go test ./internal/controller/components/modelcontroller/...` passes
- e2e (CI)

## Screenshot or short clip

N/A

## Merge criteria

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully
- [ ] New RELATED_IMAGE mappings are listed in ODH-Build-Config and RHOAI-Build-Config (CI validates names against build-config repos). Include links to build-config PRs in the description.

### E2E test suite update requirement

- [x] Skip requirement to update E2E test suite for this PR

#### E2E update requirement opt-out justification

Single-line removal of an unused condition type constant from a slice literal. No behavioral change, no new code paths. The condition was never set by any action or precondition, so no e2e test can observe the difference.