### PR TITLE
Add odh-agents-operator to manifests-config.yaml

### DIFF
--- a/build/manifests-config.yaml
+++ b/build/manifests-config.yaml
@@ -64,5 +64,5 @@ map:
     src: kserve-module/config
     dest: kserve-module
   odh-agents-operator:
-    src: config
+    src: kagenti-operator/config
     dest: kagenti-operator

--- a/build/manifests-config.yaml
+++ b/build/manifests-config.yaml
@@ -64,5 +64,5 @@ map:
     src: kserve-module/config
     dest: kserve-module
   odh-agents-operator:
-    src: config/manifests
+    src: config
     dest: kagenti-operator

--- a/build/manifests-config.yaml
+++ b/build/manifests-config.yaml
@@ -63,3 +63,6 @@ map:
   odh-kserve-module-operator:
     src: kserve-module/config
     dest: kserve-module
+  odh-agents-operator:
+    src: config/manifests
+    dest: kagenti-operator


### PR DESCRIPTION
Adds 'odh-agents-operator' to the operator manifests config map.

Component: odh-agents-operator
Manifest source path: config/manifests
Manifest dest path:   kagenti-operator
Upstream repo: https://github.com/opendatahub-io/agents-operator @ main
Jira: https://redhat.atlassian.net/browse/RHOAIENG-63283

**File changed:**
- `build/manifests-config.yaml` — added `odh-agents-operator` entry under `map:`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled the agents operator, making agent-related functionality available across the platform.
  * Deployed operator configuration so agent features are provisioned and ready for use.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->