### PR TITLE
adding macgregor (myself) to platform owners alias

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -18,6 +18,7 @@ aliases:
     - kahowell
     - lburgazzoli
     - lphiri
+    - macgregor
     - MarianMacik
     - mlassak
     - resoluteCoder


### PR DESCRIPTION
## Description
Adds macgregor (myself) to the platform alias in OWNERS_ALIASES.

## How Has This Been Tested?

N/A

## Screenshot or short clip

N/A

## Merge criteria

N/A

## E2E update requirement opt-out justification

N/A

## Summary by CodeRabbit

* Chores
    * Updated internal aliases configuration.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated platform team member list in ownership configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->