### PR TITLE
Added confidence scoring fallback, client setup guides, and scenario documentation.

### DIFF
--- a/cmd/mcp-server/README.md
+++ b/cmd/mcp-server/README.md
@@ -145,11 +145,11 @@ Run cluster health checks and classify the failure deterministically. Returns a 
 
 // Example output
 {
-  "category": "component",
-  "subcategory": "degraded",
-  "error_code": "COMP_DEGRADED",
-  "evidence": "Dashboard deployment has 0/1 ready replicas",
-  "confidence": 0.9
+  "category": "infrastructure",
+  "subcategory": "image-pull",
+  "error_code": 1001,
+  "evidence": ["container xyz waiting: ImagePullBackOff"],
+  "confidence": "medium"
 }
 ```
 
@@ -214,15 +214,20 @@ Output is capped at 50KB. If exceeded, a `[truncated: output exceeded 50KB limit
 
 ## Client Configuration
 
-**Claude Code:** This repo includes a `.mcp.json` at the project root — no setup needed.
+### Claude Code
 
-**Cursor / Claude Desktop:** Add to your MCP config (`.cursor/mcp.json` for Cursor, `claude_desktop_config.json` for Claude Desktop):
+This repo includes a `.mcp.json` at the project root — no setup needed. The `/diagnose` skill is also pre-configured.
+
+### Claude Desktop
+
+Add the following to your `claude_desktop_config.json`:
 
 ```json
 {
   "mcpServers": {
-    "odh-diagnostics": {
-      "command": "/absolute/path/to/opendatahub-operator/bin/mcp-server",
+    "opendatahub-health": {
+      "command": "bash",
+      "args": ["-c", "cd /absolute/path/to/opendatahub-operator/cmd/mcp-server && go run ."],
       "env": {
         "KUBECONFIG": "/absolute/path/to/.kube/config"
       }
@@ -231,8 +236,56 @@ Output is capped at 50KB. If exceeded, a `[truncated: output exceeded 50KB limit
 }
 ```
 
-Build the binary first with `make mcp-server`. The `env` block can be omitted if `KUBECONFIG` is already in your shell environment.
+Restart Claude Desktop after saving.
+
+### Cursor
+
+Create or edit `.cursor/mcp.json` in your project root:
+
+```json
+{
+  "mcpServers": {
+    "opendatahub-health": {
+      "command": "bash",
+      "args": ["-c", "cd /absolute/path/to/opendatahub-operator/cmd/mcp-server && go run ."],
+      "env": {
+        "KUBECONFIG": "/absolute/path/to/.kube/config"
+      }
+    }
+  }
+}
+```
+
+## Troubleshooting
+
+### Server won't start
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| `kubeconfig: unable to load` | `KUBECONFIG` not set or file missing | Export `KUBECONFIG=/path/to/.kube/config` or add it to the MCP config `env` block |
+| `binary not found` | Binary not built | Run `make mcp-server` from the repo root |
+| `go: command not found` | Using `.mcp.json` with `go run` but Go not installed | Build the binary with `make mcp-server` and use the binary path instead |
+
+### Tools return errors
+
+| Error message | Cause | Fix |
+|---------------|-------|-----|
+| `RBAC insufficient` | Kubeconfig user lacks permissions | Ensure the user has a ClusterRole with read access to pods, events, deployments, nodes, and ODH CRDs |
+| `CRD not installed` | ODH operator not deployed | Install the ODH operator and create DSCI/DSC CRs |
+| `namespace discovery failed` | No DSCI CR on the cluster | Create a `default-dsci` DSCInitialization CR, or set `E2E_TEST_APPLICATIONS_NAMESPACE` env var |
+
+### Agent gives wrong diagnosis
+
+1. **Verify with `oc` commands.** Cross-check the agent's claims manually:
+   - `oc get pods -n opendatahub` — are pods actually in the reported state?
+   - `oc get dsci default-dsci -o jsonpath='{.status.conditions}'` — is DSCI actually unhealthy?
+   - `oc get events -n opendatahub --sort-by=.lastTimestamp` — do events match the agent's evidence?
+2. **Check if the component is set to Removed.** If the agent reports a component as failing but it has `managementState: Removed` in the DSC spec, that's expected — not a failure.
+3. **Low classifier confidence.** If `classify_failure` returns confidence `low` or category `unknown`, the failure may not match any known pattern. Check the [failure scenarios](scenarios/README.md) for similar patterns, or investigate manually with `pod_logs` and `recent_events`.
+4. **Stale events.** Kubernetes events persist after resources are deleted. The agent may report an event-based issue for a pod that no longer exists. Verify the referenced resource still exists before acting on the diagnosis.
 
 ## Integration Testing
 
 For manual testing against a live cluster, see [INTEGRATION_TEST.md](INTEGRATION_TEST.md).
+
+For failure scenario validation, see the [scenarios documentation](scenarios/README.md).

--- a/cmd/mcp-server/prompts/diagnostic.md
+++ b/cmd/mcp-server/prompts/diagnostic.md
@@ -146,6 +146,7 @@ high — all health checks passed, no warning events detected
 <the specific root cause identified — be precise, not vague>
 
 ### Evidence
+- **Classifier**: <category>/<subcategory> (code <error_code>, confidence: <classifier_confidence>)
 - <evidence point 1> (source: <tool name>)
 - <evidence point 2> (source: <tool name>)
 
@@ -165,7 +166,7 @@ high — all health checks passed, no warning events detected
 **Confidence level guidelines:**
 - **high**: Direct evidence from logs/events pointing to a specific cause. Error code match with high classifier confidence.
 - **medium**: Correlated evidence across multiple signals, but no single definitive proof. Classifier returned medium confidence.
-- **low**: Symptoms observed but root cause is ambiguous. Multiple possible causes. Manual investigation recommended.
+- **low**: Root cause is ambiguous, multiple equally plausible causes exist, or evidence is indirect. Fall back to the deterministic `classify_failure` output as the starting point. Acknowledge the uncertainty in the Summary and recommend specific manual investigation steps in Remediation.
 
 ---
 

--- a/cmd/mcp-server/scenarios/README.md
+++ b/cmd/mcp-server/scenarios/README.md
@@ -1,0 +1,98 @@
+# Failure Scenarios
+
+Test scenarios for validating the deterministic classifier (`classify_failure`) and the diagnostic agent against known failure patterns. Each scenario injects a specific failure into a live ODH cluster, runs diagnostic tools, and compares results to ground truth.
+
+## Prerequisites
+
+| Requirement | Details |
+|---|---|
+| Environment safety | **Use a dedicated non-production cluster only**. These scenarios intentionally induce failures and can cause service disruption. |
+| Cluster | OpenShift/Kubernetes with `KUBECONFIG` set |
+| ODH operator | Installed and running |
+| CRs | DSCI (`default-dsci`) + DSC (`default-dsc`) created, at least one component `Managed` |
+| Tools | `oc`, `jq` installed |
+| Binary | Built via `make mcp-server` |
+
+## Scenario Index
+
+| Scenario | What it simulates | Expected Category | Expected Code | Confidence |
+|----------|-------------------|-------------------|---------------|------------|
+| cascading-failure | Deny-all NetworkPolicy blocking all traffic in apps namespace | infrastructure/pod-startup | 1002 | medium |
+| component-misconfiguration | Dashboard deployment references nonexistent secret | infrastructure/pod-startup | 1002 | medium |
+| dependency-chain | JobSetOperator CR set to Available=False, causing Trainer to degrade | infrastructure/dsci-unhealthy | 1009 | medium |
+| image-pull-failure | Dashboard deployment patched to use nonexistent image | infrastructure/image-pull | 1001 | medium |
+| independent-failures | Two unrelated component operators scaled to 0 | infrastructure/cluster-distress | 1099 | low |
+| missing-dependency | cert-manager operator scaled to 0 | unknown/unclassifiable | 3000 | low |
+| node-pressure | Worker node patched with MemoryPressure=True | infrastructure/node-pressure | 1005 | high |
+| operator-crash | ODH operator deployment scaled to 0 | infrastructure/operator | 1008 | high |
+| partial-failure | One component operator scaled to 0, others healthy | infrastructure/dsc-unhealthy | 1010 | medium |
+| resource-exhaustion | Impossibly low ResourceQuota applied to apps namespace | infrastructure/quota-oom | 1004 | high |
+
+## File Structure
+
+Each scenario consists of three files:
+
+```text
+<scenario-name>-setup.sh          # Injects the failure
+<scenario-name>-teardown.sh       # Restores the cluster
+<scenario-name>-ground-truth.json # Expected classifier output
+```
+
+Some scenarios include supplementary manifests:
+
+- `cascading-failure-networkpolicy.yaml` — deny-all NetworkPolicy
+- `resource-exhaustion-quota.yaml` — restrictive ResourceQuota
+
+Shared helpers are in `common.sh` (namespace discovery, backup/restore, MCP tool invocation, wait helpers).
+
+## Running a Scenario
+
+```bash
+# From the repo root:
+
+# 1. Build the binary
+make mcp-server
+
+# 2. Source shared helpers
+source cmd/mcp-server/scenarios/common.sh
+
+# 3. Run setup (injects the failure)
+bash cmd/mcp-server/scenarios/operator-crash-setup.sh
+
+# 4. Call classify_failure and compare to ground truth
+call_mcp_tool classify_failure '{}' | jq .
+cat cmd/mcp-server/scenarios/operator-crash-ground-truth.json | jq .expected_classification
+
+# 5. Teardown (restores the cluster)
+bash cmd/mcp-server/scenarios/operator-crash-teardown.sh
+```
+
+## Ground Truth Schema
+
+Each `*-ground-truth.json` file follows this structure:
+
+```json
+{
+  "scenario_id": "operator-crash",
+  "scenario_name": "Operator Crash",
+  "description": "What the scenario does",
+  "root_cause": "The actual root cause",
+  "expected_classification": {
+    "category": "infrastructure",
+    "subcategory": "operator",
+    "error_code": 1008,
+    "confidence": "high"
+  },
+  "expected_tool_outputs": { },
+  "expected_symptoms": ["symptom 1", "symptom 2"],
+  "tools_that_detect": ["classify_failure", "platform_health"],
+  "expected_remediation": "How to fix it"
+}
+```
+
+## Adding a New Scenario
+
+1. Create `<name>-setup.sh` — source `common.sh`, use `backup_resource()` to save state, inject the failure, use `wait_for_pod_status()` to confirm the failure is active
+2. Create `<name>-teardown.sh` — source `common.sh`, restore backups, wait for recovery
+3. Create `<name>-ground-truth.json` — fill in the expected classification using the [error code reference](../prompts/diagnostic.md#error-code-reference)
+4. Test: run setup, call `classify_failure`, compare output to ground truth, run teardown


### PR DESCRIPTION

## Description
Refines the diagnostic prompt with a classifier fallback rule for low-confidence diagnoses, ensuring the agent defers to deterministic output instead of speculating. Expands the README with copy-paste MCP configs for Claude Desktop and Cursor, and a troubleshooting guide for agent issues. Documents all 10 failure scenarios with a classification index and ground truth schema in a new scenarios README.

https://redhat.atlassian.net/browse/RHOAIENG-56945
https://redhat.atlassian.net/browse/RHOAIENG-56948

## How Has This Been Tested?
Done Manual Testing .

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [X] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [X] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [X] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
Add E2E if required.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Revised example output for the failure classifier and updated evidence/confidence fields shown to users
  * Required classifier-evidence bullet added to diagnostic report template and confidence-level guidance updated to prefer deterministic classifier output when uncertain
  * Expanded client setup instructions (code, desktop, cursor) with snippets and restart step
  * Added troubleshooting guidance and new failure-scenario testing docs with schema and validation steps
<!-- end of auto-generated comment: release notes by coderabbit.ai -->