### PR TITLE
fix: missing RELATED_IMAGE entries in ODH build config for kserve, modelregistry, and modelcontroller

### DIFF
--- a/.github/scripts/validate-related-images.sh
+++ b/.github/scripts/validate-related-images.sh
@@ -165,6 +165,22 @@ record_known_issue_match() {
     done
 }
 
+# ODH exceptions: images intentionally absent from ODH-Build-Config (e.g. arch-specific)
+ODH_EXCEPTIONS_FILE="$WORKDIR/odh-exceptions.txt"
+ODH_EXCEPTIONS_MATCHED="$WORKDIR/odh-exceptions-matched.txt"
+touch "$ODH_EXCEPTIONS_FILE" "$ODH_EXCEPTIONS_MATCHED"
+$YQ -r '(.odh_exceptions // [])[] | .image + "|" + .reason' "$CONFIG_FILE" \
+    > "$ODH_EXCEPTIONS_FILE"
+
+is_odh_exception() {
+    grep -q "^$1|" "$ODH_EXCEPTIONS_FILE"
+}
+
+record_odh_exception_match() {
+    local image="$1"
+    grep "^${image}|" "$ODH_EXCEPTIONS_FILE" | head -1 >> "$ODH_EXCEPTIONS_MATCHED"
+}
+
 # --- Step 3: Extract map entries per component ---
 # For each component dir, extract Go map entries: "key": "RELATED_IMAGE_*"
 # Output: component/key/RELATED_IMAGE_VALUE lines
@@ -334,6 +350,12 @@ while IFS= read -r related_image; do
         done < "$RHAI_HELM_COMPONENTS"
     fi
 
+    # ODH exceptions: treat image as present in ODH if intentionally excluded
+    if is_odh_exception "$related_image"; then
+        record_odh_exception_match "$related_image"
+        in_odh=true
+    fi
+
     # Skip if everything is OK
     if $in_params_env && $in_odh && $in_rhoai; then
         if $needs_rhai_helm && [ -s "$RHAI_HELM_CONFIG" ]; then
@@ -457,6 +479,10 @@ if [ -s "$KNOWN_ISSUES_MATCHED" ]; then
     local_ki_count=$(sort -u "$KNOWN_ISSUES_MATCHED" | wc -l | tr -d ' ')
     printf ", ${CYAN}%d known issue(s)${RESET}" "$local_ki_count"
 fi
+if [ -s "$ODH_EXCEPTIONS_MATCHED" ]; then
+    local_oe_count=$(sort -u "$ODH_EXCEPTIONS_MATCHED" | wc -l | tr -d ' ')
+    printf ", ${CYAN}%d ODH exception(s)${RESET}" "$local_oe_count"
+fi
 echo ""
 
 # Known issues detail
@@ -465,6 +491,15 @@ if [ -s "$KNOWN_ISSUES_MATCHED" ]; then
     printf "  ${CYAN}${BOLD}Known issues (downgraded to warnings):${RESET}\n"
     sort -u "$KNOWN_ISSUES_MATCHED" | while IFS='|' read -r _ ki_image ki_jira ki_reason; do
         printf "    ${CYAN}%s${RESET} - %s (%s)\n" "$ki_image" "$ki_reason" "$ki_jira"
+    done
+fi
+
+# ODH exceptions detail
+if [ -s "$ODH_EXCEPTIONS_MATCHED" ]; then
+    echo ""
+    printf "  ${CYAN}${BOLD}ODH exceptions (not applicable to ODH, skipped):${RESET}\n"
+    sort -u "$ODH_EXCEPTIONS_MATCHED" | while IFS='|' read -r oe_image oe_reason; do
+        printf "    ${CYAN}%s${RESET} - %s\n" "$oe_image" "$oe_reason"
     done
 fi
 
@@ -488,6 +523,29 @@ if [ -s "$KNOWN_ISSUES_FILE" ]; then
 
     if [ "$stale_count" -gt 0 ]; then
         WARNINGS=$((WARNINGS + stale_count))
+    fi
+fi
+
+# Detect stale ODH exceptions (configured but no longer triggered)
+if [ -s "$ODH_EXCEPTIONS_FILE" ]; then
+    matched_oe_images="$WORKDIR/matched-oe-images.txt"
+    sort -u "$ODH_EXCEPTIONS_MATCHED" | cut -d'|' -f1 | sort -u > "$matched_oe_images" 2>/dev/null || true
+
+    stale_oe_count=0
+    while IFS='|' read -r oe_image oe_reason; do
+        if ! grep -qxF "$oe_image" "$matched_oe_images" 2>/dev/null; then
+            if [ "$stale_oe_count" -eq 0 ]; then
+                echo ""
+                printf "  ${YELLOW}${BOLD}Stale ODH exceptions (no longer triggered, please remove from ${CONFIG_FILE}):${RESET}\n"
+            fi
+            printf "    ${YELLOW}%s${RESET} - %s\n" "$oe_image" "$oe_reason"
+            stale_oe_count=$((stale_oe_count + 1))
+        fi
+    done < "$ODH_EXCEPTIONS_FILE"
+    rm -f "$matched_oe_images"
+
+    if [ "$stale_oe_count" -gt 0 ]; then
+        WARNINGS=$((WARNINGS + stale_oe_count))
     fi
 fi
 

--- a/.github/workflows/validate-related-images.yaml
+++ b/.github/workflows/validate-related-images.yaml
@@ -42,6 +42,8 @@ jobs:
         run: |
           if git diff "origin/${BASE_REF}...HEAD" -- internal/ | grep -qE '^\+.*RELATED_IMAGE_'; then
             echo "changed=true" >> "$GITHUB_OUTPUT"
+          elif git diff --name-only "origin/${BASE_REF}...HEAD" | grep -q 'component-params-env.yaml'; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
           else
             echo "No RELATED_IMAGE_* changes detected, skipping validation."
             echo "changed=false" >> "$GITHUB_OUTPUT"

--- a/component-params-env.yaml
+++ b/component-params-env.yaml
@@ -2,6 +2,8 @@
 #
 # rhai_helm_components: components whose RELATED_IMAGE_* must also be present
 #   in RHOAI-Build-Config helm/rhai-on-xks-chart/values.yaml (rhaiOperator.relatedImages).
+# odh_exceptions: RELATED_IMAGE entries intentionally absent from ODH-Build-Config.
+#   These are permanently excluded from ODH validation (e.g. architecture-specific images).
 # known_issues: RELATED_IMAGE errors to downgrade to warnings.
 #   Each entry MUST include a Jira link and reason.
 
@@ -28,18 +30,13 @@ known_issues:
 - image: RELATED_IMAGE_ODH_CAIKIT_NLP_IMAGE
   jira: https://redhat.atlassian.net/browse/RHOAIENG-60523
   reason: caikit-nlp support is removed since RHOAI 3.0
-- image: RELATED_IMAGE_ODH_LLM_D_KV_CACHE_IMAGE
-  jira: https://redhat.atlassian.net/browse/RHOAIENG-60572
-  reason: need to be added the image to ODH-Build-Config
-- image: RELATED_IMAGE_ODH_MODEL_PERFORMANCE_DATA_IMAGE
-  jira: https://redhat.atlassian.net/browse/RHOAIENG-60572
-  reason: need to be added the image to ODH-Build-Config, or set an exception for the image
-- image: RELATED_IMAGE_ODH_VLLM_CPU_IMAGE
-  jira: https://redhat.atlassian.net/browse/RHOAIENG-60572
-  reason: need to be added the image to ODH-Build-Config, or set an exception for the image
 - image: RELATED_IMAGE_ODH_TH06_CPU_TORCH210_PY312_IMAGE
   jira: https://redhat.atlassian.net/browse/RHOAIENG-60758
   reason: need to be onboarded to RHOAI 3.5-ea.1
 - image: RELATED_IMAGE_ODH_TH06_CUDA130_TORCH210_PY312_IMAGE
   jira: https://redhat.atlassian.net/browse/RHOAIENG-60756
   reason: need to be onboarded to RHOAI 3.5-ea.1
+
+odh_exceptions:
+- image: RELATED_IMAGE_ODH_VLLM_CPU_IMAGE
+  reason: ppc64le/s390x only, not applicable to ODH


### PR DESCRIPTION


<!---
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description

Complementary PR in ODH-Build-Config: https://github.com/opendatahub-io/ODH-Build-Config/pull/1918

JIRA ref: [RHOAIENG-60572](https://redhat.atlassian.net/browse/RHOAIENG-60572)

## How Has This Been Tested?
Run validation script against the complementary PR branch in ODH-Build-Config

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully
- [x] New RELATED_IMAGE mappings are listed in ODH-Build-Config and RHOAI-Build-Config (CI validates names against build-config repos). Include links to build-config PRs in the description.

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [ ] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced image validation to support configured ODH exceptions and treat matched exceptions as present.
  * Improved validation reporting: added exception counts, a skipped-exceptions detail list with reasons, and detection of stale exceptions that increment warnings.
  * Updated configuration docs to document excluded images and clarify known-issues entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->