### PR TITLE
feat(security): remove system:authenticated from Auth CR API

### DIFF
--- a/api/services/v1alpha1/auth_types.go
+++ b/api/services/v1alpha1/auth_types.go
@@ -36,8 +36,8 @@ type AuthSpec struct {
 	// +kubebuilder:validation:XValidation:rule="size(self) > 0",message="AdminGroups cannot be empty"
 	// +kubebuilder:validation:XValidation:rule="self.all(group, group != 'system:authenticated' && group != '')",message="AdminGroups cannot contain 'system:authenticated' or empty strings"
 	AdminGroups []string `json:"adminGroups"`
-	// AllowedGroups cannot contain empty strings, but 'system:authenticated' is allowed for general access
-	// +kubebuilder:validation:XValidation:rule="self.all(group, group != '')",message="AllowedGroups cannot contain empty strings"
+	// AllowedGroups cannot contain 'system:authenticated' (security risk) or empty strings
+	// +kubebuilder:validation:XValidation:rule="self.all(group, group != 'system:authenticated' && group != '')",message="AllowedGroups cannot contain 'system:authenticated' or empty strings. Use explicit groups like 'odh-users', 'rhods-users', or namespace-specific groups"
 	AllowedGroups []string `json:"allowedGroups"`
 }
 

--- a/cmd/test-retry/pkg/parser/parser_test.go
+++ b/cmd/test-retry/pkg/parser/parser_test.go
@@ -81,13 +81,13 @@ func TestParseGoTestJSON(t *testing.T) {
 
 func TestParseGoTestJSON_StderrDoesNotCauseError(t *testing.T) {
 	tests := []struct {
-		name          string
-		stdout        string
-		stderr        string
-		wantErr       bool
-		wantPassed    int
-		wantFailed    int
-		failedName    string
+		name       string
+		stdout     string
+		stderr     string
+		wantErr    bool
+		wantPassed int
+		wantFailed int
+		failedName string
 	}{
 		{
 			name: "stderr with failing test",
@@ -110,7 +110,7 @@ func TestParseGoTestJSON_StderrDoesNotCauseError(t *testing.T) {
 			wantPassed: 1,
 		},
 		{
-			name:   "large stderr payload",
+			name: "large stderr payload",
 			stdout: `{"Time":"2023-01-01T00:00:00Z","Action":"run","Package":"example.com/pkg","Test":"TestOk"}
 {"Time":"2023-01-01T00:00:01Z","Action":"output","Package":"example.com/pkg","Test":"TestOk","Output":"=== RUN   TestOk\n"}
 {"Time":"2023-01-01T00:00:02Z","Action":"output","Package":"example.com/pkg","Test":"TestOk","Output":"--- PASS: TestOk (1.00s)\n"}

--- a/docs/auth-security-migration.md
+++ b/docs/auth-security-migration.md
@@ -1,0 +1,277 @@
+# Auth Security Migration Guide
+
+## Overview
+
+This guide covers the migration from `system:authenticated` group usage to explicit, secure group configurations in the OpenDataHub/RHOAI Auth custom resource. This change follows Kubernetes security best practices and eliminates security vulnerabilities.
+
+## Background
+
+### Security Issue
+
+The `system:authenticated` group grants access to **any authenticated user** in the cluster, which violates Kubernetes security best practices:
+
+- **Kubernetes Documentation**: "Review bindings for the `system:authenticated` group and remove them where possible"
+- **Google Cloud Best Practices**: "In practice, this isn't meaningfully different from `system:unauthenticated` because anyone can create a Google Account"
+
+### What Changed
+
+1. **API Validation**: New Auth CRs can no longer contain `system:authenticated` in AdminGroups or AllowedGroups
+2. **Default Behavior**: Default Auth CRs now use platform-specific groups instead of `system:authenticated`
+3. **Controller Warnings**: Existing usage triggers warnings and status conditions
+
+## Migration Path
+
+### Phase 1: Detection (Current Release)
+
+**Check for existing usage:**
+```bash
+# Check Auth CRs for system:authenticated usage
+oc get auth -o yaml | grep -A 10 -B 10 "system:authenticated"
+
+# Get deprecation status from Auth CR
+oc describe auth auth
+```
+
+**Expected output if deprecated usage exists:**
+```
+Conditions:
+  Type:    DeprecatedGroupUsage
+  Status:  True
+  Reason:  SystemAuthenticatedDeprecated
+  Message: Deprecated usage detected: AllowedGroups contains deprecated 'system:authenticated' group
+```
+
+### Phase 2: Migration (Required)
+
+#### Automatic Migration Script
+
+Create and run the migration script:
+
+```bash
+#!/bin/bash
+# migrate-auth-security.sh
+
+echo "🔍 Checking for Auth CR with deprecated system:authenticated usage..."
+
+# Get current Auth CR
+CURRENT_AUTH=$(oc get auth auth -o json 2>/dev/null)
+if [ $? -ne 0 ]; then
+    echo "❌ No Auth CR found named 'auth'"
+    exit 1
+fi
+
+# Check if system:authenticated is used
+ADMIN_GROUPS_CHECK=$(echo "$CURRENT_AUTH" | jq -r '.spec.adminGroups[]? // empty' | grep "system:authenticated" || true)
+ALLOWED_GROUPS_CHECK=$(echo "$CURRENT_AUTH" | jq -r '.spec.allowedGroups[]? // empty' | grep "system:authenticated" || true)
+
+if [ -z "$ADMIN_GROUPS_CHECK" ] && [ -z "$ALLOWED_GROUPS_CHECK" ]; then
+    echo "✅ No deprecated system:authenticated usage found"
+    exit 0
+fi
+
+echo "⚠️ Found deprecated system:authenticated usage"
+
+# Determine platform-specific replacement groups
+PLATFORM=$(oc get infrastructure cluster -o jsonpath='{.status.platform}' 2>/dev/null || echo "unknown")
+case $PLATFORM in
+    "OpenShift")
+        NEW_ADMIN_GROUP="rhods-admins"
+        NEW_ALLOWED_GROUP="rhods-users"
+        ;;
+    *)
+        NEW_ADMIN_GROUP="odh-admins"
+        NEW_ALLOWED_GROUP="odh-users"
+        ;;
+esac
+
+echo "🔄 Migrating to platform-specific groups:"
+echo "   Admin group: $NEW_ADMIN_GROUP"
+echo "   Allowed group: $NEW_ALLOWED_GROUP"
+
+# Create backup
+echo "$CURRENT_AUTH" > auth-backup-$(date +%Y%m%d-%H%M%S).json
+echo "💾 Backup created: auth-backup-$(date +%Y%m%d-%H%M%S).json"
+
+# Update Auth CR
+echo "$CURRENT_AUTH" | jq --arg admin_group "$NEW_ADMIN_GROUP" --arg allowed_group "$NEW_ALLOWED_GROUP" '
+    .spec.adminGroups = [.spec.adminGroups[] | if . == "system:authenticated" then $admin_group else . end] |
+    .spec.allowedGroups = [.spec.allowedGroups[] | if . == "system:authenticated" then $allowed_group else . end] |
+    .metadata.annotations["auth.opendatahub.io/migration-timestamp"] = now | todate
+' | oc apply -f -
+
+if [ $? -eq 0 ]; then
+    echo "✅ Auth CR successfully migrated"
+    echo "🔍 Verifying migration..."
+    sleep 2
+    oc describe auth auth | grep -A 5 "Conditions:"
+else
+    echo "❌ Migration failed"
+    exit 1
+fi
+
+echo "📋 Next steps:"
+echo "1. Verify users can still access the platform"
+echo "2. Ensure the groups '$NEW_ADMIN_GROUP' and '$NEW_ALLOWED_GROUP' exist and contain appropriate users"
+echo "3. Remove any manual RoleBindings that reference system:authenticated"
+```
+
+#### Manual Migration Steps
+
+1. **Backup existing Auth CR:**
+   ```bash
+   oc get auth auth -o yaml > auth-backup.yaml
+   ```
+
+2. **Identify replacement groups:**
+   - **OpenDataHub**: `odh-admins`, `odh-users`
+   - **RHOAI Self-Managed**: `rhods-admins`, `rhods-users`
+   - **RHOAI Managed**: `dedicated-admins`, `rhods-users`
+
+3. **Update Auth CR:**
+   ```bash
+   # Edit the Auth CR
+   oc edit auth auth
+
+   # Replace system:authenticated with appropriate groups
+   spec:
+     adminGroups:
+     - odh-admins  # or rhods-admins for RHOAI
+     allowedGroups:
+     - odh-users   # or rhods-users for RHOAI
+   ```
+
+4. **Verify migration:**
+   ```bash
+   # Check that deprecated conditions are removed
+   oc describe auth auth
+
+   # Verify user access still works
+   oc auth can-i get auth --as=system:serviceaccount:default:test
+   ```
+
+### Phase 3: Validation
+
+After migration, verify:
+
+1. **No deprecation warnings in logs:**
+   ```bash
+   oc logs -n opendatahub-operator-system deployment/opendatahub-operator-controller-manager | grep -i "system:authenticated"
+   ```
+
+2. **Status conditions are clean:**
+   ```bash
+   oc get auth auth -o jsonpath='{.status.conditions[?(@.type=="DeprecatedGroupUsage")]}'
+   ```
+
+3. **Users retain appropriate access:**
+   ```bash
+   # Test admin user access
+   oc auth can-i create auth --as=user:admin-user
+
+   # Test regular user access
+   oc auth can-i get auth --as=user:regular-user
+   ```
+
+## Recommended Group Structure
+
+### Platform-Specific Groups
+
+| Platform | Admin Group | User Group | Purpose |
+|----------|-------------|------------|---------|
+| OpenDataHub | `odh-admins` | `odh-users` | Full platform admin / General user access |
+| RHOAI Self-Managed | `rhods-admins` | `rhods-users` | Full platform admin / General user access |
+| RHOAI Managed | `dedicated-admins` | `rhods-users` | Cluster admin / Data science users |
+
+### Custom Group Examples
+
+For organizations with specific needs:
+
+```yaml
+spec:
+  adminGroups:
+    - "data-science-platform-admins"
+    - "ml-ops-team"
+  allowedGroups:
+    - "data-scientists"
+    - "ml-engineers"
+    - "business-analysts"
+```
+
+## Troubleshooting
+
+### Common Issues
+
+#### Issue: "Users can't access the platform after migration"
+**Solution:**
+1. Check that the new groups exist:
+   ```bash
+   oc get groups
+   ```
+2. Verify users are in the correct groups:
+   ```bash
+   oc get group odh-users -o yaml
+   ```
+3. Check RoleBindings are created:
+   ```bash
+   oc get rolebinding -A | grep data-science
+   oc get clusterrolebinding | grep data-science
+   ```
+
+#### Issue: "API validation rejects Auth CR updates"
+**Solution:**
+This means the CR contains `system:authenticated`. Use the migration script or manually edit to remove it:
+```bash
+# Find the problematic field
+oc get auth auth -o yaml | grep -n "system:authenticated"
+
+# Edit to replace with appropriate groups
+oc edit auth auth
+```
+
+#### Issue: "Controller logs show security warnings"
+**Solution:**
+This indicates an existing Auth CR still contains `system:authenticated`. Follow the migration steps above.
+
+### Rollback Procedure
+
+If migration causes issues:
+
+1. **Restore from backup:**
+   ```bash
+   oc apply -f auth-backup.yaml
+   ```
+
+2. **Check operator status:**
+   ```bash
+   oc get pods -n opendatahub-operator-system
+   oc logs -n opendatahub-operator-system deployment/opendatahub-operator-controller-manager
+   ```
+
+3. **Verify user access restored:**
+   ```bash
+   oc auth can-i get auth --as=user:test-user
+   ```
+
+## Security Benefits
+
+After migration:
+
+- ✅ **Explicit Access Control**: Only users in designated groups have access
+- ✅ **Audit Trail**: Clear mapping of users to groups to permissions
+- ✅ **Principle of Least Privilege**: No overly broad access grants
+- ✅ **Kubernetes Compliance**: Follows official security recommendations
+- ✅ **Defense in Depth**: Multiple layers of validation prevent misconfigurations
+
+## References
+
+- [Kubernetes RBAC Good Practices](https://kubernetes.io/docs/concepts/security/rbac-good-practices/)
+- [Google Cloud RBAC Best Practices](https://cloud.google.com/kubernetes-engine/docs/best-practices/rbac)
+- [OpenShift Authentication and Authorization](https://docs.openshift.com/container-platform/latest/authentication/index.html)
+
+## Support
+
+For questions or issues:
+1. Check the [troubleshooting section](#troubleshooting) above
+2. Review Auth CR status: `oc describe auth auth`
+3. Check operator logs for detailed error messages
+4. File an issue with the complete migration script output and error details

--- a/internal/controller/dscinitialization/auth.go
+++ b/internal/controller/dscinitialization/auth.go
@@ -29,6 +29,22 @@ var (
 		cluster.ManagedRhoai:     "dedicated-admins",
 		cluster.OpenDataHub:      "odh-admins",
 	}
+
+	// allowedGroups maps each supported platform to its default allowed group(s).
+	// These groups are assigned general user access privileges in the Auth custom resource.
+	//
+	// SECURITY NOTE: Replaces the deprecated 'system:authenticated' group which violated
+	// Kubernetes security best practices by granting access to any authenticated user.
+	//
+	// Platform mappings:
+	//   - SelfManagedRhoai: "rhods-users" - for Red Hat OpenShift AI users
+	//   - ManagedRhoai: "rhods-users" - for Red Hat OpenShift AI users
+	//   - OpenDataHub: "odh-users" - for Open Data Hub users
+	allowedGroups = map[common.Platform][]string{
+		cluster.SelfManagedRhoai: {"rhods-users"},
+		cluster.ManagedRhoai:     {"rhods-users"},
+		cluster.OpenDataHub:      {"odh-users"},
+	}
 )
 
 // CreateAuth ensures an Auth custom resource exists in the cluster.
@@ -59,11 +75,14 @@ func (r *DSCInitializationReconciler) CreateAuth(ctx context.Context, platform c
 
 // BuildDefaultAuth creates a default Auth custom resource with platform-specific configuration.
 //
+// SECURITY UPDATE: Now uses explicit platform-specific groups instead of 'system:authenticated'
+// to follow Kubernetes security best practices.
+//
 // Parameters:
 //   - platform: The target platform type (OpenDataHub, SelfManagedRhoai, or ManagedRhoai)
 //
 // Returns:
-//   - client.Object: A serviceApi.Auth resource with platform-specific admin group and system:authenticated in allowed groups
+//   - client.Object: A serviceApi.Auth resource with platform-specific admin and allowed groups
 func BuildDefaultAuth(platform common.Platform) client.Object {
 	// Get admin group for the platform, with fallback to OpenDataHub admin group
 	adminGroup := adminGroups[platform]
@@ -71,12 +90,23 @@ func BuildDefaultAuth(platform common.Platform) client.Object {
 		adminGroup = adminGroups[cluster.OpenDataHub]
 	}
 
+	// Get allowed groups for the platform, with fallback to OpenDataHub allowed groups
+	allowedGroupsList := allowedGroups[platform]
+	if len(allowedGroupsList) == 0 {
+		allowedGroupsList = allowedGroups[cluster.OpenDataHub]
+	}
+
 	return &serviceApi.Auth{
-		TypeMeta:   metav1.TypeMeta{Kind: serviceApi.AuthKind, APIVersion: serviceApi.GroupVersion.String()},
-		ObjectMeta: metav1.ObjectMeta{Name: serviceApi.AuthInstanceName},
+		TypeMeta: metav1.TypeMeta{Kind: serviceApi.AuthKind, APIVersion: serviceApi.GroupVersion.String()},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: serviceApi.AuthInstanceName,
+			Annotations: map[string]string{
+				"auth.opendatahub.io/migration-note": "Default groups changed from 'system:authenticated' to platform-specific groups for security compliance",
+			},
+		},
 		Spec: serviceApi.AuthSpec{
 			AdminGroups:   []string{adminGroup},
-			AllowedGroups: []string{"system:authenticated"},
+			AllowedGroups: allowedGroupsList,
 		},
 	}
 }

--- a/internal/controller/dscinitialization/auth_test.go
+++ b/internal/controller/dscinitialization/auth_test.go
@@ -27,6 +27,18 @@ func expectedAdminGroupForPlatform(platform common.Platform) string {
 	}
 }
 
+// expectedAllowedGroupsForPlatform returns the expected allowed groups for a given platform.
+func expectedAllowedGroupsForPlatform(platform common.Platform) []string {
+	switch platform {
+	case cluster.SelfManagedRhoai:
+		return []string{"rhods-users"}
+	case cluster.ManagedRhoai:
+		return []string{"rhods-users"}
+	default:
+		return []string{"odh-users"} // fallback for OpenDataHub and unknown platforms
+	}
+}
+
 func TestBuildDefaultAuth(t *testing.T) {
 	tests := []struct {
 		name               string
@@ -80,9 +92,16 @@ func TestBuildDefaultAuth(t *testing.T) {
 			g.Expect(auth.Spec.AdminGroups[0]).Should(Equal(tt.expectedAdminGroup))
 			g.Expect(auth.Spec.AdminGroups[0]).ShouldNot(BeEmpty(), "AdminGroups should not contain empty strings")
 
-			// Verify AllowedGroups
-			g.Expect(auth.Spec.AllowedGroups).Should(HaveLen(1))
-			g.Expect(auth.Spec.AllowedGroups[0]).Should(Equal("system:authenticated"))
+			// Verify AllowedGroups (should now use platform-specific groups)
+			expectedAllowedGroups := expectedAllowedGroupsForPlatform(tt.platform)
+			g.Expect(auth.Spec.AllowedGroups).Should(Equal(expectedAllowedGroups))
+			g.Expect(auth.Spec.AllowedGroups).ShouldNot(ContainElement("system:authenticated"),
+				"AllowedGroups should not contain deprecated system:authenticated")
+
+			// Verify migration annotation is present
+			g.Expect(auth.Annotations).Should(HaveKey("auth.opendatahub.io/migration-note"))
+			g.Expect(auth.Annotations["auth.opendatahub.io/migration-note"]).Should(
+				ContainSubstring("system:authenticated"))
 		})
 	}
 }
@@ -171,12 +190,18 @@ func TestCreateAuth(t *testing.T) {
 				g.Expect(auth.Spec.AdminGroups).Should(Equal(tt.existingAuth.Spec.AdminGroups))
 				g.Expect(auth.Spec.AllowedGroups).Should(Equal(tt.existingAuth.Spec.AllowedGroups))
 			} else {
-				// Should create new Auth with correct admin group
+				// Should create new Auth with correct admin group and platform-specific allowed groups
 				expectedAdminGroup := expectedAdminGroupForPlatform(tt.platform)
+				expectedAllowedGroups := expectedAllowedGroupsForPlatform(tt.platform)
 
 				g.Expect(auth.Spec.AdminGroups).Should(HaveLen(1))
 				g.Expect(auth.Spec.AdminGroups[0]).Should(Equal(expectedAdminGroup))
-				g.Expect(auth.Spec.AllowedGroups).Should(Equal([]string{"system:authenticated"}))
+				g.Expect(auth.Spec.AllowedGroups).Should(Equal(expectedAllowedGroups))
+				g.Expect(auth.Spec.AllowedGroups).ShouldNot(ContainElement("system:authenticated"),
+					"New Auth should not contain deprecated system:authenticated")
+
+				// Verify migration annotation is present
+				g.Expect(auth.Annotations).Should(HaveKey("auth.opendatahub.io/migration-note"))
 			}
 		})
 	}

--- a/internal/controller/services/auth/auth_controller_actions.go
+++ b/internal/controller/services/auth/auth_controller_actions.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
+	"slices"
 
 	userv1 "github.com/openshift/api/user/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -27,11 +29,19 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
+	"github.com/opendatahub-io/opendatahub-operator/v2/api/common"
 	serviceApi "github.com/opendatahub-io/opendatahub-operator/v2/api/services/v1alpha1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
 	odhtypes "github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/metadata/annotations"
+)
+
+const (
+	// systemAuthenticated represents the deprecated system:authenticated group.
+	systemAuthenticated = "system:authenticated"
+	// deprecatedGroupUsageCondition represents the condition type for deprecated group usage.
+	deprecatedGroupUsageCondition = "DeprecatedGroupUsage"
 )
 
 func initialize(ctx context.Context, rr *odhtypes.ReconciliationRequest) error {
@@ -76,6 +86,12 @@ func initialize(ctx context.Context, rr *odhtypes.ReconciliationRequest) error {
 }
 
 func bindRole(ctx context.Context, rr *odhtypes.ReconciliationRequest, groups []string, roleBindingName string, roleName string, namespace string) error {
+	// Perform security validation on groups
+	strictMode := isStrictModeEnabled()
+	if err := validateGroupsSecurity(ctx, groups, roleName, strictMode); err != nil {
+		return fmt.Errorf("role binding security validation failed for %s: %w", roleBindingName, err)
+	}
+
 	if namespace == "" {
 		appNamespace, err := cluster.ApplicationNamespace(ctx, rr.Client)
 		if err != nil {
@@ -95,15 +111,14 @@ func bindRole(ctx context.Context, rr *odhtypes.ReconciliationRequest, groups []
 
 	groupsToBind := []rbacv1.Subject{}
 	for _, e := range groups {
-		isAdminRole := roleName == "data-science-admingroup-role" ||
-			roleName == "data-science-admingroup-maas-role" ||
-			roleName == "data-science-admingroup-kuadrant-role"
-		// we want to disallow adding system:authenticated to the adminGroups
-		if e == "" || (isAdminRole && e == "system:authenticated") {
+		// Enhanced security filtering: skip empty groups and system:authenticated for all roles
+		// Note: API validation should prevent system:authenticated, but this provides defense in depth
+		if e == "" || e == systemAuthenticated {
 			log := logf.FromContext(ctx)
-			log.Info("skipping adding invalid group to RoleBinding")
+			log.Info("skipping adding invalid group to RoleBinding", "group", e, "role", roleName, "reason", "empty or security-restricted group")
 			continue
 		}
+
 		rs := rbacv1.Subject{
 			Kind:     gvk.Group.Kind,
 			APIGroup: gvk.Group.Group,
@@ -133,15 +148,22 @@ func bindRole(ctx context.Context, rr *odhtypes.ReconciliationRequest, groups []
 }
 
 func bindClusterRole(ctx context.Context, rr *odhtypes.ReconciliationRequest, groups []string, roleBindingName string, roleName string) error {
+	// Perform security validation on groups
+	strictMode := isStrictModeEnabled()
+	if err := validateGroupsSecurity(ctx, groups, roleName, strictMode); err != nil {
+		return fmt.Errorf("cluster role binding security validation failed for %s: %w", roleBindingName, err)
+	}
+
 	groupsToBind := []rbacv1.Subject{}
 	for _, e := range groups {
-		// we want to disallow adding system:authenticated to the adminGroups
-		isAdminRole := roleName == "data-science-admingroupcluster-role"
-		if e == "" || (isAdminRole && e == "system:authenticated") {
+		// Enhanced security filtering: skip empty groups and system:authenticated for all roles
+		// Note: API validation should prevent system:authenticated, but this provides defense in depth
+		if e == "" || e == systemAuthenticated {
 			log := logf.FromContext(ctx)
-			log.Info("skipping adding invalid group to ClusterRoleBinding")
+			log.Info("skipping adding invalid group to ClusterRoleBinding", "group", e, "role", roleName, "reason", "empty or security-restricted group")
 			continue
 		}
+
 		rs := rbacv1.Subject{
 			Kind:     gvk.Group.Kind,
 			APIGroup: gvk.Group.Group,
@@ -170,11 +192,144 @@ func bindClusterRole(ctx context.Context, rr *odhtypes.ReconciliationRequest, gr
 	return nil
 }
 
+// validateGroupsSecurity performs security validation of groups and can reject system:authenticated
+// based on configuration. This provides a migration path for existing deployments.
+func validateGroupsSecurity(ctx context.Context, groups []string, roleName string, strictMode bool) error {
+	log := logf.FromContext(ctx)
+
+	for _, group := range groups {
+		if group == systemAuthenticated {
+			if strictMode {
+				return fmt.Errorf("security violation: group 'system:authenticated' is not allowed for role '%s'. "+
+					"This violates Kubernetes security best practices. "+
+					"Please use explicit groups like 'odh-users', 'rhods-users', or namespace-specific groups. "+
+					"See https://kubernetes.io/docs/concepts/security/rbac-good-practices/ for guidance",
+					roleName)
+			} else {
+				// Warn but allow for backward compatibility during migration period
+				log.Info("SECURITY WARNING: system:authenticated detected in role binding - this will be rejected in strict mode",
+					"role", roleName,
+					"group", group,
+					"recommendation", "Migrate to explicit groups before enabling strict security mode",
+					"enableStrictMode", "Set STRICT_SECURITY_MODE=true environment variable to test rejection")
+			}
+		}
+	}
+	return nil
+}
+
+// isStrictModeEnabled checks if strict security mode is enabled via environment variable.
+func isStrictModeEnabled() bool {
+	strictMode := os.Getenv("STRICT_SECURITY_MODE")
+	return strictMode == "true" || strictMode == "1"
+}
+
+// logDeprecationWarnings logs deprecation warnings for system:authenticated usage.
+func logDeprecationWarnings(ctx context.Context, auth *serviceApi.Auth) {
+	log := logf.FromContext(ctx)
+
+	// Check AdminGroups for system:authenticated (should already be blocked by API validation, but defensive logging)
+	for _, group := range auth.Spec.AdminGroups {
+		if group == systemAuthenticated {
+			log.Info("SECURITY WARNING: system:authenticated detected in AdminGroups - this should have been blocked by API validation",
+				"authCR", auth.Name,
+				"field", "adminGroups",
+				"recommendation", "Use platform-specific admin groups like 'odh-admins' or 'rhods-admins'",
+				"securityIssue", "system:authenticated grants admin access to any authenticated user",
+				"deprecationPhase", "immediate-rejection")
+		}
+	}
+
+	// Check AllowedGroups for system:authenticated
+	for _, group := range auth.Spec.AllowedGroups {
+		if group == systemAuthenticated {
+			log.Info("SECURITY WARNING: system:authenticated detected in AllowedGroups - this violates Kubernetes security best practices",
+				"authCR", auth.Name,
+				"field", "allowedGroups",
+				"recommendation", "Use explicit groups like 'odh-users', 'rhods-users', or namespace-specific groups",
+				"securityIssue", "system:authenticated grants access to any authenticated user",
+				"deprecationPhase", "migration-required",
+				"migrationGuide", "https://kubernetes.io/docs/concepts/security/rbac-good-practices/")
+		}
+	}
+}
+
+// updateDeprecationStatusConditions updates the Auth CR status with deprecation warnings.
+func updateDeprecationStatusConditions(ctx context.Context, rr *odhtypes.ReconciliationRequest, auth *serviceApi.Auth) {
+	hasDeprecatedUsage := false
+	var deprecationMessages []string
+
+	// Check for deprecated usage in AdminGroups
+	if slices.Contains(auth.Spec.AdminGroups, systemAuthenticated) {
+		hasDeprecatedUsage = true
+		deprecationMessages = append(deprecationMessages, "AdminGroups contains deprecated 'system:authenticated' group")
+	}
+
+	// Check for deprecated usage in AllowedGroups
+	if slices.Contains(auth.Spec.AllowedGroups, systemAuthenticated) {
+		hasDeprecatedUsage = true
+		deprecationMessages = append(deprecationMessages, "AllowedGroups contains deprecated 'system:authenticated' group")
+	}
+
+	if hasDeprecatedUsage {
+		// Add deprecation warning condition
+		deprecationCondition := common.Condition{
+			Type:   deprecatedGroupUsageCondition,
+			Status: metav1.ConditionTrue,
+			Reason: "SystemAuthenticatedDeprecated",
+			Message: fmt.Sprintf("Deprecated usage detected: %s. Please migrate to explicit groups for security compliance. "+
+				"See https://kubernetes.io/docs/concepts/security/rbac-good-practices/", deprecationMessages[0]),
+			LastTransitionTime: metav1.Now(),
+		}
+
+		// Update the status condition
+		conditions := auth.GetConditions()
+		conditionExists := false
+		for i, cond := range conditions {
+			if cond.Type == deprecatedGroupUsageCondition {
+				conditions[i] = deprecationCondition
+				conditionExists = true
+				break
+			}
+		}
+		if !conditionExists {
+			conditions = append(conditions, deprecationCondition)
+		}
+		auth.SetConditions(conditions)
+
+		// Schedule status update
+		if err := rr.Client.Status().Update(ctx, auth); err != nil {
+			log := logf.FromContext(ctx)
+			log.Info("Failed to update Auth status with deprecation warning", "error", err)
+		}
+	} else {
+		// Remove deprecation condition if it exists and no deprecated usage is found
+		conditions := auth.GetConditions()
+		for i, cond := range conditions {
+			if cond.Type == deprecatedGroupUsageCondition {
+				conditions = append(conditions[:i], conditions[i+1:]...)
+				auth.SetConditions(conditions)
+				if err := rr.Client.Status().Update(ctx, auth); err != nil {
+					log := logf.FromContext(ctx)
+					log.Info("Failed to remove deprecation warning from Auth status", "error", err)
+				}
+				break
+			}
+		}
+	}
+}
+
 func managePermissions(ctx context.Context, rr *odhtypes.ReconciliationRequest) error {
 	ai, ok := rr.Instance.(*serviceApi.Auth)
 	if !ok {
 		return errors.New("instance is not of type *services.Auth")
 	}
+
+	// Log deprecation warnings for system:authenticated usage
+	logDeprecationWarnings(ctx, ai)
+
+	// Update status conditions for deprecation warnings
+	updateDeprecationStatusConditions(ctx, rr, ai)
 
 	err := bindRole(ctx, rr, ai.Spec.AdminGroups, "data-science-admingroup-rolebinding", "data-science-admingroup-role", "")
 	if err != nil {

--- a/internal/controller/services/auth/auth_controller_actions_test.go
+++ b/internal/controller/services/auth/auth_controller_actions_test.go
@@ -151,11 +151,11 @@ func TestBindRoleValidation(t *testing.T) {
 			description:   "Should skip empty strings for admin roles",
 		},
 		{
-			name:          "non-admin role allows system:authenticated",
+			name:          "non-admin role skips system:authenticated",
 			groups:        []string{"user1", "system:authenticated", "user2"},
 			roleName:      "allowedgroup-role",
-			expectSkipped: []string{},
-			description:   "Should allow system:authenticated for non-admin roles",
+			expectSkipped: []string{"system:authenticated"},
+			description:   "Should skip system:authenticated for all roles",
 		},
 	}
 
@@ -454,8 +454,8 @@ func TestManagePermissionsMultipleGroups(t *testing.T) {
 	// Verify subjects for new role bindings also get the admin groups
 	g.Expect(kuadrantRoleSubjects).To(HaveLen(3), "Kuadrant role binding should have 3 subjects")
 
-	// Verify subjects for allowed groups (3 groups)
-	g.Expect(allowedGroupSubjects).To(HaveLen(3), "Allowed cluster role binding should have 3 subjects")
+	// Verify subjects for allowed groups (2 groups, system:authenticated is filtered out)
+	g.Expect(allowedGroupSubjects).To(HaveLen(2), "Allowed cluster role binding should have 2 subjects")
 
 	// Verify specific group names are present in subjects
 	adminGroupNames := extractGroupNamesFromSubjects(adminGroupSubjects)
@@ -465,7 +465,7 @@ func TestManagePermissionsMultipleGroups(t *testing.T) {
 	g.Expect(kuadrantGroupNames).To(ConsistOf("platform-admins", "data-science-admins", "ml-ops-admins"))
 
 	allowedGroupNames := extractGroupNamesFromSubjects(allowedGroupSubjects)
-	g.Expect(allowedGroupNames).To(ConsistOf("data-scientists", "analysts", "system:authenticated"))
+	g.Expect(allowedGroupNames).To(ConsistOf("data-scientists", "analysts"))
 }
 
 // TestManagePermissionsKuadrantNamespaceMissing validates that when the kuadrant-system
@@ -626,11 +626,11 @@ func TestBindClusterRoleValidation(t *testing.T) {
 			description:   "Should skip empty strings for admin cluster roles",
 		},
 		{
-			name:          "non-admin cluster role allows system:authenticated",
+			name:          "non-admin cluster role skips system:authenticated",
 			groups:        []string{"user1", "system:authenticated", "user2"},
 			roleName:      "data-science-allowedgroupcluster-role",
-			expectSkipped: []string{},
-			description:   "Should allow system:authenticated for non-admin cluster roles",
+			expectSkipped: []string{"system:authenticated"},
+			description:   "Should skip system:authenticated for all cluster roles",
 		},
 		{
 			name:          "non-admin cluster role skips empty strings",
@@ -742,4 +742,418 @@ func extractGroupNamesFromSubjects(subjects []any) []string {
 		}
 	}
 	return names
+}
+
+// TestValidateGroupsSecurity tests the security validation function that can reject
+// system:authenticated based on configuration.
+func TestValidateGroupsSecurity(t *testing.T) {
+	ctx := t.Context()
+
+	tests := []struct {
+		name          string
+		groups        []string
+		roleName      string
+		strictMode    bool
+		expectError   bool
+		errorContains string
+		description   string
+	}{
+		{
+			name:        "allows system:authenticated in non-strict mode",
+			groups:      []string{"user1", "system:authenticated", "user2"},
+			roleName:    "test-role",
+			strictMode:  false,
+			expectError: false,
+			description: "Should allow system:authenticated when strict mode is disabled",
+		},
+		{
+			name:          "rejects system:authenticated in strict mode",
+			groups:        []string{"user1", "system:authenticated", "user2"},
+			roleName:      "test-role",
+			strictMode:    true,
+			expectError:   true,
+			errorContains: "system:authenticated",
+			description:   "Should reject system:authenticated when strict mode is enabled",
+		},
+		{
+			name:        "allows valid groups in strict mode",
+			groups:      []string{"user1", "user2", "admin1"},
+			roleName:    "test-role",
+			strictMode:  true,
+			expectError: false,
+			description: "Should allow valid groups even in strict mode",
+		},
+		{
+			name:        "allows empty groups list",
+			groups:      []string{},
+			roleName:    "test-role",
+			strictMode:  true,
+			expectError: false,
+			description: "Should handle empty groups list without error",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			err := validateGroupsSecurity(ctx, tt.groups, tt.roleName, tt.strictMode)
+
+			if tt.expectError {
+				g.Expect(err).To(HaveOccurred(), tt.description)
+				if tt.errorContains != "" {
+					g.Expect(err.Error()).To(ContainSubstring(tt.errorContains), tt.description)
+				}
+			} else {
+				g.Expect(err).ToNot(HaveOccurred(), tt.description)
+			}
+		})
+	}
+}
+
+// TestLogDeprecationWarnings tests the deprecation warning logging functionality.
+func TestLogDeprecationWarnings(t *testing.T) {
+	ctx := t.Context()
+
+	tests := []struct {
+		name        string
+		auth        *serviceApi.Auth
+		description string
+	}{
+		{
+			name: "logs warning for system:authenticated in AdminGroups",
+			auth: &serviceApi.Auth{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-auth"},
+				Spec: serviceApi.AuthSpec{
+					AdminGroups:   []string{"admin1", "system:authenticated"},
+					AllowedGroups: []string{"user1"},
+				},
+			},
+			description: "Should log warning for system:authenticated in AdminGroups",
+		},
+		{
+			name: "logs warning for system:authenticated in AllowedGroups",
+			auth: &serviceApi.Auth{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-auth"},
+				Spec: serviceApi.AuthSpec{
+					AdminGroups:   []string{"admin1"},
+					AllowedGroups: []string{"user1", "system:authenticated"},
+				},
+			},
+			description: "Should log warning for system:authenticated in AllowedGroups",
+		},
+		{
+			name: "no warnings for valid groups",
+			auth: &serviceApi.Auth{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-auth"},
+				Spec: serviceApi.AuthSpec{
+					AdminGroups:   []string{"admin1", "admin2"},
+					AllowedGroups: []string{"user1", "user2"},
+				},
+			},
+			description: "Should not log warnings for valid groups",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			// The function should not error - it only logs
+			g.Expect(func() {
+				logDeprecationWarnings(ctx, tt.auth)
+			}).ToNot(Panic(), tt.description)
+		})
+	}
+}
+
+// TestUpdateDeprecationStatusConditions tests the status condition update functionality.
+func TestUpdateDeprecationStatusConditions(t *testing.T) {
+	ctx := t.Context()
+	g := NewWithT(t)
+
+	fakeClient := setupTestClient(g, false)
+
+	tests := []struct {
+		name                    string
+		auth                    *serviceApi.Auth
+		expectCondition         bool
+		expectedConditionType   string
+		expectedConditionStatus metav1.ConditionStatus
+		description             string
+	}{
+		{
+			name: "adds deprecation condition for system:authenticated in AdminGroups",
+			auth: &serviceApi.Auth{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-auth"},
+				Spec: serviceApi.AuthSpec{
+					AdminGroups:   []string{"admin1", "system:authenticated"},
+					AllowedGroups: []string{"user1"},
+				},
+			},
+			expectCondition:         true,
+			expectedConditionType:   deprecatedGroupUsageCondition,
+			expectedConditionStatus: metav1.ConditionTrue,
+			description:             "Should add deprecation condition for system:authenticated in AdminGroups",
+		},
+		{
+			name: "adds deprecation condition for system:authenticated in AllowedGroups",
+			auth: &serviceApi.Auth{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-auth"},
+				Spec: serviceApi.AuthSpec{
+					AdminGroups:   []string{"admin1"},
+					AllowedGroups: []string{"user1", "system:authenticated"},
+				},
+			},
+			expectCondition:         true,
+			expectedConditionType:   deprecatedGroupUsageCondition,
+			expectedConditionStatus: metav1.ConditionTrue,
+			description:             "Should add deprecation condition for system:authenticated in AllowedGroups",
+		},
+		{
+			name: "no deprecation condition for valid groups",
+			auth: &serviceApi.Auth{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-auth"},
+				Spec: serviceApi.AuthSpec{
+					AdminGroups:   []string{"admin1", "admin2"},
+					AllowedGroups: []string{"user1", "user2"},
+				},
+			},
+			expectCondition: false,
+			description:     "Should not add deprecation condition for valid groups",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			rr := &odhtypes.ReconciliationRequest{
+				Client:   fakeClient,
+				Instance: tt.auth,
+			}
+
+			// Note: This function updates status, but in test with fake client,
+			// we can check if conditions were set on the Auth object
+			updateDeprecationStatusConditions(ctx, rr, tt.auth)
+
+			conditions := tt.auth.GetConditions()
+
+			if tt.expectCondition {
+				g.Expect(conditions).ToNot(BeEmpty(), tt.description)
+
+				found := false
+				for _, condition := range conditions {
+					if condition.Type == tt.expectedConditionType {
+						found = true
+						g.Expect(condition.Status).To(Equal(tt.expectedConditionStatus), tt.description)
+						g.Expect(condition.Reason).To(Equal("SystemAuthenticatedDeprecated"), tt.description)
+						break
+					}
+				}
+				g.Expect(found).To(BeTrue(), "Should find deprecation condition")
+			} else {
+				// Check that no deprecation condition exists
+				for _, condition := range conditions {
+					g.Expect(condition.Type).ToNot(Equal(deprecatedGroupUsageCondition), tt.description)
+				}
+			}
+		})
+	}
+}
+
+// TestIsStrictModeEnabled tests the environment variable-based strict mode detection.
+func TestIsStrictModeEnabled(t *testing.T) {
+	// Test cases with environment variable manipulation
+	tests := []struct {
+		name           string
+		envValue       string
+		expectedResult bool
+		description    string
+	}{
+		{
+			name:           "strict mode enabled with 'true'",
+			envValue:       "true",
+			expectedResult: true,
+			description:    "Should return true when STRICT_SECURITY_MODE=true",
+		},
+		{
+			name:           "strict mode enabled with '1'",
+			envValue:       "1",
+			expectedResult: true,
+			description:    "Should return true when STRICT_SECURITY_MODE=1",
+		},
+		{
+			name:           "strict mode disabled with 'false'",
+			envValue:       "false",
+			expectedResult: false,
+			description:    "Should return false when STRICT_SECURITY_MODE=false",
+		},
+		{
+			name:           "strict mode disabled with empty value",
+			envValue:       "",
+			expectedResult: false,
+			description:    "Should return false when STRICT_SECURITY_MODE is empty",
+		},
+		{
+			name:           "strict mode disabled with invalid value",
+			envValue:       "invalid",
+			expectedResult: false,
+			description:    "Should return false when STRICT_SECURITY_MODE has invalid value",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			// Set environment variable for this test
+			t.Setenv("STRICT_SECURITY_MODE", tt.envValue)
+
+			result := isStrictModeEnabled()
+			g.Expect(result).To(Equal(tt.expectedResult), tt.description)
+		})
+	}
+}
+
+// TestManagePermissionsWithSecurityValidation tests that the enhanced managePermissions
+// function correctly calls security validation and deprecation tracking.
+func TestManagePermissionsWithSecurityValidation(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	fakeClient := setupTestClient(g, false)
+
+	tests := []struct {
+		name        string
+		auth        *serviceApi.Auth
+		expectError bool
+		description string
+	}{
+		{
+			name: "succeeds with valid groups in non-strict mode",
+			auth: &serviceApi.Auth{
+				ObjectMeta: metav1.ObjectMeta{Name: "auth"},
+				Spec: serviceApi.AuthSpec{
+					AdminGroups:   []string{"admin1", "admin2"},
+					AllowedGroups: []string{"user1", "user2"},
+				},
+			},
+			expectError: false,
+			description: "Should succeed with valid groups",
+		},
+		{
+			name: "succeeds with system:authenticated in non-strict mode",
+			auth: &serviceApi.Auth{
+				ObjectMeta: metav1.ObjectMeta{Name: "auth"},
+				Spec: serviceApi.AuthSpec{
+					AdminGroups:   []string{"admin1"},
+					AllowedGroups: []string{"user1", "system:authenticated"},
+				},
+			},
+			expectError: false,
+			description: "Should succeed with system:authenticated in non-strict mode",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			rr := &odhtypes.ReconciliationRequest{
+				Client:    fakeClient,
+				Instance:  tt.auth,
+				Resources: []unstructured.Unstructured{},
+			}
+
+			err := managePermissions(ctx, rr)
+
+			if tt.expectError {
+				g.Expect(err).To(HaveOccurred(), tt.description)
+			} else {
+				g.Expect(err).ToNot(HaveOccurred(), tt.description)
+
+				// Verify that security validation was called by checking that
+				// deprecation warnings would be set if system:authenticated is present
+				if slices.Contains(tt.auth.Spec.AllowedGroups, "system:authenticated") ||
+					slices.Contains(tt.auth.Spec.AdminGroups, "system:authenticated") {
+					conditions := tt.auth.GetConditions()
+					found := false
+					for _, condition := range conditions {
+						if condition.Type == deprecatedGroupUsageCondition {
+							found = true
+							break
+						}
+					}
+					g.Expect(found).To(BeTrue(), "Should have deprecation condition for system:authenticated usage")
+				}
+			}
+		})
+	}
+}
+
+// TestSystemAuthenticatedFilteredForAllRoles validates that system:authenticated
+// is filtered out for ALL role types (admin and non-admin) as a security measure.
+func TestSystemAuthenticatedFilteredForAllRoles(t *testing.T) {
+	ctx := t.Context()
+	g := NewWithT(t)
+
+	fakeClient := setupTestClient(g, false)
+
+	tests := []struct {
+		name     string
+		roleName string
+		isAdmin  bool
+	}{
+		{
+			name:     "admin role filters system:authenticated",
+			roleName: "data-science-admingroup-role",
+			isAdmin:  true,
+		},
+		{
+			name:     "allowed role filters system:authenticated",
+			roleName: "data-science-allowedgroupcluster-role",
+			isAdmin:  false,
+		},
+		{
+			name:     "custom role filters system:authenticated",
+			roleName: "custom-role",
+			isAdmin:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			rr := &odhtypes.ReconciliationRequest{
+				Client:    fakeClient,
+				Resources: []unstructured.Unstructured{},
+			}
+
+			groups := []string{"valid-group1", "system:authenticated", "valid-group2"}
+
+			if tt.isAdmin {
+				err := bindRole(ctx, rr, groups, "test-binding", tt.roleName, "test-namespace")
+				g.Expect(err).ToNot(HaveOccurred())
+			} else {
+				err := bindClusterRole(ctx, rr, groups, "test-cluster-binding", tt.roleName)
+				g.Expect(err).ToNot(HaveOccurred())
+			}
+
+			// Verify a resource was added
+			g.Expect(rr.Resources).ToNot(BeEmpty(), "Should add role binding resource")
+
+			// Extract subjects and verify system:authenticated is filtered out
+			resource := rr.Resources[0]
+			subjects, _, _ := unstructured.NestedSlice(resource.Object, "subjects")
+			names := extractGroupNamesFromSubjects(subjects)
+
+			// Should have only 2 valid groups, system:authenticated should be filtered
+			g.Expect(names).To(HaveLen(2), "Should filter out system:authenticated")
+			g.Expect(names).ToNot(ContainElement("system:authenticated"), "system:authenticated must be filtered")
+			g.Expect(names).To(ContainElement("valid-group1"), "Should retain valid groups")
+			g.Expect(names).To(ContainElement("valid-group2"), "Should retain valid groups")
+		})
+	}
 }

--- a/tests/e2e/authcontroller_test.go
+++ b/tests/e2e/authcontroller_test.go
@@ -23,7 +23,11 @@ const (
 	odhAdminsName       = "odh-admins"
 	dedicatedAdminsName = "dedicated-admins"
 
-	// Default allowed group name.
+	// Default allowed group names for different platforms.
+	rhodsUsersGroupName = "rhods-users"
+	odhUsersGroupName   = "odh-users"
+
+	// Deprecated group name (no longer used in defaults, filtered by controller).
 	systemAuthenticatedGroup = "system:authenticated"
 
 	// Role names used for RBAC configuration.
@@ -66,6 +70,7 @@ func authControllerTestSuite(t *testing.T) {
 		{"Validate removal of bindings when a group is removed", authCtx.ValidateRemovingGroups},
 		{"Validate CEL blocks Auth update with invalid groups", authCtx.ValidateCELBlocksInvalidGroupsViaUpdate},
 		{"Validate CEL allows Auth with valid groups", authCtx.ValidateCELAllowsValidGroups},
+		{"Validate controller security filtering", authCtx.ValidateControllerSecurityFiltering},
 	}
 
 	// Run the test suite.
@@ -79,6 +84,7 @@ func (tc *AuthControllerTestCtx) ValidateAuthSystemInitialization(t *testing.T) 
 	skipUnless(t, Smoke)
 
 	expectedAdminGroup := tc.getExpectedAdminGroupForPlatform()
+	expectedAllowedGroup := tc.getExpectedAllowedGroupForPlatform()
 
 	// 1. Validate that exactly one Auth CR exists with correct default content
 	tc.EnsureResourcesExist(
@@ -88,13 +94,13 @@ func (tc *AuthControllerTestCtx) ValidateAuthSystemInitialization(t *testing.T) 
 			// Validate the content of that single Auth CR
 			HaveEach(And(
 				jq.Match(`.spec.adminGroups | index("%s") != null`, expectedAdminGroup),
-				jq.Match(`.spec.allowedGroups | index("%s") != null`, systemAuthenticatedGroup),
+				jq.Match(`.spec.allowedGroups | index("%s") != null`, expectedAllowedGroup),
 			)),
 		)),
 		WithCustomErrorMsg(
 			"Expected exactly one Auth CR with adminGroups=['%s'] and allowedGroups=['%s'], but validation failed",
 			expectedAdminGroup,
-			systemAuthenticatedGroup,
+			expectedAllowedGroup,
 		),
 	)
 
@@ -177,6 +183,69 @@ func (tc *AuthControllerTestCtx) ValidateRemovingGroups(t *testing.T) {
 		WithCustomErrorMsg("Expected %s '%s' to have exactly one subject with name '%s'", gvk.ClusterRoleBinding.Kind, adminGroupClusterRoleBindingName, expectedGroup))
 }
 
+// ValidateControllerSecurityFiltering validates that the controller properly filters
+// system:authenticated from role bindings even if it were present in the Auth CR.
+// This tests the defense-in-depth security filtering implemented in the controller.
+func (tc *AuthControllerTestCtx) ValidateControllerSecurityFiltering(t *testing.T) {
+	t.Helper()
+
+	skipUnless(t, Tier1)
+
+	expectedAdminGroup := tc.getExpectedAdminGroupForPlatform()
+	expectedAllowedGroup := tc.getExpectedAllowedGroupForPlatform()
+
+	// Reset to defaults first to ensure clean state
+	tc.resetAuthToDefaults(t)
+
+	// Verify that the controller has properly filtered system:authenticated and that
+	// only platform-appropriate groups are bound to cluster roles.
+
+	// Validate AdminGroup ClusterRoleBinding subjects
+	tc.EnsureResourcesExist(
+		WithMinimalObject(gvk.ClusterRoleBinding, types.NamespacedName{Name: adminGroupClusterRoleBindingName}),
+		WithCondition(And(
+			// Ensure no system:authenticated is present in admin role binding subjects
+			jq.Match(`.subjects | map(select(.name == "%s")) | length == 0`, systemAuthenticatedGroup),
+			// Ensure the expected admin group is present
+			jq.Match(`.subjects | map(select(.name == "%s")) | length == 1`, expectedAdminGroup),
+		)),
+		WithCustomErrorMsg(
+			"Admin ClusterRoleBinding should not contain system:authenticated and should contain expected admin group '%s'",
+			expectedAdminGroup,
+		),
+	)
+
+	// Validate AllowedGroup ClusterRoleBinding subjects
+	tc.EnsureResourcesExist(
+		WithMinimalObject(gvk.ClusterRoleBinding, types.NamespacedName{Name: allowedGroupClusterRoleBindingName}),
+		WithCondition(And(
+			// Ensure no system:authenticated is present in allowed group role binding subjects
+			jq.Match(`.subjects | map(select(.name == "%s")) | length == 0`, systemAuthenticatedGroup),
+			// Ensure the expected allowed group is present
+			jq.Match(`.subjects | map(select(.name == "%s")) | length == 1`, expectedAllowedGroup),
+		)),
+		WithCustomErrorMsg(
+			"Allowed ClusterRoleBinding should not contain system:authenticated and should contain expected allowed group '%s'",
+			expectedAllowedGroup,
+		),
+	)
+
+	// Validate namespace-scoped RoleBinding subjects
+	tc.EnsureResourcesExist(
+		WithMinimalObject(gvk.RoleBinding, types.NamespacedName{Name: adminGroupRoleBindingName, Namespace: tc.AppsNamespace}),
+		WithCondition(And(
+			// Ensure no system:authenticated is present in role binding subjects
+			jq.Match(`.subjects | map(select(.name == "%s")) | length == 0`, systemAuthenticatedGroup),
+			// Ensure the expected admin group is present
+			jq.Match(`.subjects | map(select(.name == "%s")) | length == 1`, expectedAdminGroup),
+		)),
+		WithCustomErrorMsg(
+			"Admin RoleBinding should not contain system:authenticated and should contain expected admin group '%s'",
+			expectedAdminGroup,
+		),
+	)
+}
+
 // ValidateCELBlocksInvalidGroupsViaUpdate tests that CEL validation blocks Auth resources
 // with invalid groups. Since Auth is a singleton resource managed by the operator, we test
 // CEL validation by attempting to update the existing Auth resource with invalid values.
@@ -205,6 +274,11 @@ func (tc *AuthControllerTestCtx) ValidateCELBlocksInvalidGroupsViaUpdate(t *test
 			name:        "empty_string_in_admin_groups",
 			transforms:  testf.Transform(`.spec.adminGroups = ["valid-admin-group", ""] | .spec.allowedGroups = ["valid-allowed-group"]`),
 			description: "Empty string in AdminGroups should be blocked by CEL validation",
+		},
+		{
+			name:        "system_authenticated_in_allowed_groups",
+			transforms:  testf.Transform(`.spec.adminGroups = ["valid-admin-group"] | .spec.allowedGroups = ["valid-allowed-group", "%s"]`, systemAuthenticatedGroup),
+			description: "system:authenticated in AllowedGroups should be blocked by CEL validation",
 		},
 		{
 			name:        "empty_string_in_allowed_groups",
@@ -242,9 +316,9 @@ func (tc *AuthControllerTestCtx) ValidateCELAllowsValidGroups(t *testing.T) {
 			description: "Valid groups should be allowed by CEL validation",
 		},
 		{
-			name:        "system_authenticated_in_allowed_groups",
-			transforms:  testf.Transform(`.spec.adminGroups = ["valid-admin-group"] | .spec.allowedGroups = ["valid-allowed-group", "%s"]`, systemAuthenticatedGroup),
-			description: "system:authenticated in AllowedGroups should be allowed by CEL validation",
+			name:        "multiple_allowed_groups",
+			transforms:  testf.Transform(`.spec.adminGroups = ["valid-admin-group"] | .spec.allowedGroups = ["valid-allowed-group", "another-valid-group"]`),
+			description: "Multiple allowed groups should be allowed by CEL validation",
 		},
 		{
 			name:        "empty_allowed_groups_array",
@@ -252,9 +326,9 @@ func (tc *AuthControllerTestCtx) ValidateCELAllowsValidGroups(t *testing.T) {
 			description: "Empty AllowedGroups array should be allowed by CEL validation",
 		},
 		{
-			name:        "only_system_authenticated_in_allowed_groups",
-			transforms:  testf.Transform(`.spec.adminGroups = ["valid-admin-group"] | .spec.allowedGroups = ["%s"]`, systemAuthenticatedGroup),
-			description: "Only system:authenticated in AllowedGroups should be allowed by CEL validation",
+			name:        "single_allowed_group",
+			transforms:  testf.Transform(`.spec.adminGroups = ["valid-admin-group"] | .spec.allowedGroups = ["single-valid-group"]`),
+			description: "Single allowed group should be allowed by CEL validation",
 		},
 	}
 
@@ -278,11 +352,12 @@ func (tc *AuthControllerTestCtx) resetAuthToDefaults(t *testing.T) {
 	t.Helper()
 
 	expectedAdminGroup := tc.getExpectedAdminGroupForPlatform()
+	expectedAllowedGroup := tc.getExpectedAllowedGroupForPlatform()
 
 	// Reset Auth to default values (within-suite cleanup)
 	tc.EventuallyResourcePatched(
 		WithMinimalObject(gvk.Auth, tc.AuthNamespacedName),
-		WithMutateFunc(testf.Transform(`.spec.adminGroups = ["%s"] | .spec.allowedGroups = ["%s"]`, expectedAdminGroup, systemAuthenticatedGroup)),
+		WithMutateFunc(testf.Transform(`.spec.adminGroups = ["%s"] | .spec.allowedGroups = ["%s"]`, expectedAdminGroup, expectedAllowedGroup)),
 		WithCustomErrorMsg("Failed to reset Auth CR to default state after CEL tests"),
 	)
 }
@@ -299,6 +374,21 @@ func (tc *AuthControllerTestCtx) getExpectedAdminGroupForPlatform() string {
 		return odhAdminsName
 	default:
 		return odhAdminsName // Default fallback
+	}
+}
+
+// getExpectedAllowedGroupForPlatform returns the expected allowed group name based on the current platform.
+func (tc *AuthControllerTestCtx) getExpectedAllowedGroupForPlatform() string {
+	platform := tc.FetchPlatformRelease()
+	switch platform {
+	case cluster.SelfManagedRhoai:
+		return rhodsUsersGroupName
+	case cluster.ManagedRhoai:
+		return rhodsUsersGroupName
+	case cluster.OpenDataHub:
+		return odhUsersGroupName
+	default:
+		return odhUsersGroupName // Default fallback
 	}
 }
 


### PR DESCRIPTION
## Description
- Add XValidation rules to prevent system:authenticated in Auth CRs
  - Update default behavior to use platform-specific groups
  - Add controller-level security filtering for all role bindings
  - Implement deprecation warnings and status conditions
  - Create migration documentation and automated script

Fixes https://redhat.atlassian.net/browse/RHOAIENG-61180

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully
- [ ] New RELATED_IMAGE mappings are already listed in ODH-Build-Config and RHOAI-Build-Config, and links are included in PR description

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [ ] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced platform-specific default allowed groups based on your deployment type.
  * Added deprecation warnings for legacy group configurations.

* **Security**
  * Enhanced validation to prevent empty strings and `system:authenticated` in allowed groups.
  * Added security filtering for role bindings to enforce safer access controls.

* **Documentation**
  * Added comprehensive migration guide with automated and manual instructions for updating auth configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->