### PR TITLE
feat(webhook): remove IS and LLMis from HWP mutating and Kueue validating webhooks

### DIFF
--- a/internal/webhook/hardwareprofile/mutating.go
+++ b/internal/webhook/hardwareprofile/mutating.go
@@ -40,14 +40,8 @@ const (
 	HardwareProfileNamespaceAnnotation = "opendatahub.io/hardware-profile-namespace"
 )
 
-// Container name constants.
-const (
-	LLMInferenceServiceMainContainerName = "main"
-)
-
 // NoMatchingContainerError is returned when no container matching the expected name is found.
-// For Notebooks, the container name must match the Notebook name.
-// For LLMInferenceServices, the container name must be "main".
+// For Notebooks with multiple containers, one must match the Notebook CR name.
 type NoMatchingContainerError struct {
 	WorkloadKind      string
 	WorkloadName      string
@@ -68,27 +62,17 @@ type WorkloadConfig struct {
 }
 
 // WorkloadConfigs maps Kubernetes resource kinds to their configuration paths.
+// InferenceService and LLMInferenceService are intentionally excluded: HardwareProfile
+// injection for those resource types was migrated to the kserve controller reconcile loop.
 var WorkloadConfigs = map[string]WorkloadConfig{
 	gvk.Notebook.Kind: {
 		ContainersPath:   []string{"spec", "template", "spec", "containers"}, // slice []interface{}
 		NodeSelectorPath: []string{"spec", "template", "spec", "nodeSelector"},
 		TolerationsPath:  []string{"spec", "template", "spec", "tolerations"},
 	},
-	gvk.InferenceServices.Kind: {
-		ContainersPath:   []string{"spec", "predictor", "model"}, // map map[string]interface{}
-		NodeSelectorPath: []string{"spec", "predictor", "nodeSelector"},
-		TolerationsPath:  []string{"spec", "predictor", "tolerations"},
-	},
-	gvk.LLMInferenceServiceV1Alpha1.Kind: {
-		ContainersPath:   []string{"spec", "template", "containers"}, // slice []interface{}
-		NodeSelectorPath: []string{"spec", "template", "nodeSelector"},
-		TolerationsPath:  []string{"spec", "template", "tolerations"},
-	},
 }
 
 //+kubebuilder:webhook:path=/mutate-hardware-profile,mutating=true,failurePolicy=fail,groups=kubeflow.org,resources=notebooks,verbs=create;update,versions=v1,name=hardwareprofile-notebook-injector.opendatahub.io,sideEffects=None,admissionReviewVersions=v1
-//+kubebuilder:webhook:path=/mutate-hardware-profile,mutating=true,failurePolicy=fail,groups=serving.kserve.io,resources=inferenceservices,verbs=create;update,versions=v1beta1,name=hardwareprofile-isvc-injector.opendatahub.io,sideEffects=None,admissionReviewVersions=v1
-//+kubebuilder:webhook:path=/mutate-hardware-profile,mutating=true,failurePolicy=fail,groups=serving.kserve.io,resources=llminferenceservices,verbs=create;update,versions=v1alpha1;v1alpha2,name=hardwareprofile-llmisvc-injector.opendatahub.io,sideEffects=None,admissionReviewVersions=v1
 //nolint:lll
 
 // Injector implements a mutating admission webhook for hardware profile injection.
@@ -111,7 +95,7 @@ var _ admission.Handler = &Injector{}
 func (i *Injector) SetupWithManager(mgr ctrl.Manager) error {
 	hookServer := mgr.GetWebhookServer()
 
-	// Register single webhook path for Notebooks, InferenceServices, and LLMInferenceServices
+	// Register single webhook path for Notebooks
 	hookServer.Register("/mutate-hardware-profile", &webhook.Admission{
 		Handler:        i,
 		LogConstructor: webhookutils.NewWebhookLogConstructor(i.Name),
@@ -185,11 +169,10 @@ func (i *Injector) Handle(ctx context.Context, req admission.Request) admission.
 //   - bool: true if the kind is supported by the webhook, false otherwise
 func isExpectedKind(kind metav1.GroupVersionKind) bool {
 	// expectedGVKs contains the list of resource types that the hardware profile webhook should handle.
+	// InferenceService and LLMInferenceService are excluded: their HWP injection was migrated to
+	// the kserve controller reconcile loop.
 	expectedGVKs := []schema.GroupVersionKind{
-		gvk.Notebook,                    // kubeflow.org/v1/Notebook
-		gvk.InferenceServices,           // serving.kserve.io/v1beta1/InferenceService
-		gvk.LLMInferenceServiceV1Alpha1, // serving.kserve.io/v1alpha1/LLMInferenceService
-		gvk.LLMInferenceServiceV1Alpha2, // serving.kserve.io/v1alpha2/LLMInferenceService
+		gvk.Notebook, // kubeflow.org/v1/Notebook
 	}
 
 	requestGVK := schema.GroupVersionKind{
@@ -430,8 +413,6 @@ func (i *Injector) detectProfileChange(req *admission.Request, newProfileName, n
 // Container name requirements:
 //   - Notebooks (single container): Always valid (no validation needed)
 //   - Notebooks (multiple containers): One must match the Notebook CR name
-//   - LLMInferenceServices: Must have a container named "main"
-//   - InferenceServices: Not validated (uses predictor model path, not containers)
 //
 // CRITICAL: This function should return NoMatchingContainerError for name mismatches,
 // but must be defensive about structural errors. The caller handles NoMatchingContainerError
@@ -446,11 +427,6 @@ func (i *Injector) validateContainerNames(obj *unstructured.Unstructured) error 
 		return err
 	}
 
-	// InferenceServices use predictor.model path, not containers - skip validation
-	if obj.GetKind() == gvk.InferenceServices.Kind {
-		return nil
-	}
-
 	// Get containers from the workload
 	// If this fails, return error but caller should log and continue (defensive)
 	containers, found, err := unstructured.NestedSlice(obj.Object, config.ContainersPath...)
@@ -461,57 +437,29 @@ func (i *Injector) validateContainerNames(obj *unstructured.Unstructured) error 
 		return nil // No containers to validate (will be created by controller)
 	}
 
-	// Determine expected container name based on workload type
-	var expectedName string
-	switch obj.GetKind() {
-	case gvk.Notebook.Kind:
-		// For Notebooks with a single container, always valid
-		if len(containers) == 1 {
-			return nil
+	// For Notebooks with a single container, always valid
+	if len(containers) == 1 {
+		return nil
+	}
+	// For multiple containers, one must match the Notebook name
+	expectedName := obj.GetName()
+	for _, c := range containers {
+		m, ok := c.(map[string]any)
+		if !ok {
+			continue
 		}
-		// For multiple containers, one must match the Notebook name
-		expectedName = obj.GetName()
-		for _, c := range containers {
-			m, ok := c.(map[string]any)
-			if !ok {
-				continue
-			}
-			name, _ := m["name"].(string)
-			if name == expectedName {
-				return nil // Found matching container
-			}
-		}
-		// No matching container found
-		return &NoMatchingContainerError{
-			WorkloadKind:      obj.GetKind(),
-			WorkloadName:      obj.GetName(),
-			WorkloadNamespace: obj.GetNamespace(),
-			ExpectedName:      expectedName,
-		}
-
-	case gvk.LLMInferenceServiceV1Alpha1.Kind:
-		// For LLMInferenceServices, must have a container named "main"
-		expectedName = LLMInferenceServiceMainContainerName
-		for _, c := range containers {
-			m, ok := c.(map[string]any)
-			if !ok {
-				continue
-			}
-			name, _ := m["name"].(string)
-			if name == expectedName {
-				return nil // Found "main" container
-			}
-		}
-		// No "main" container found
-		return &NoMatchingContainerError{
-			WorkloadKind:      obj.GetKind(),
-			WorkloadName:      obj.GetName(),
-			WorkloadNamespace: obj.GetNamespace(),
-			ExpectedName:      expectedName,
+		name, _ := m["name"].(string)
+		if name == expectedName {
+			return nil // Found matching container
 		}
 	}
-
-	return nil
+	// No matching container found
+	return &NoMatchingContainerError{
+		WorkloadKind:      obj.GetKind(),
+		WorkloadName:      obj.GetName(),
+		WorkloadNamespace: obj.GetNamespace(),
+		ExpectedName:      expectedName,
+	}
 }
 
 // emitContainerNameWarningEvent creates a Warning event on the workload to indicate
@@ -863,7 +811,7 @@ func (i *Injector) fetchHardwareProfile(ctx context.Context, namespace, name str
 //
 // Parameters:
 //   - ctx: Request context containing logger for operation tracking
-//   - obj: The unstructured workload object to modify (Notebook, InferenceService, etc.)
+//   - obj: The unstructured workload object to modify (Notebook)
 //   - hwp: The HardwareProfile resource containing specifications to apply
 //   - profileChanged: Whether the hardware profile annotation changed (triggers clearing)
 //
@@ -943,7 +891,7 @@ func (i *Injector) applyHardwareProfileToWorkload(ctx context.Context, obj *unst
 // within different Kubernetes resource types.
 //
 // Parameters:
-//   - kind: The Kubernetes resource kind (e.g., "Notebook", "InferenceService")
+//   - kind: The Kubernetes resource kind (e.g., "Notebook")
 //
 // Returns:
 //   - WorkloadConfig: Configuration containing JSON paths for the workload type
@@ -972,46 +920,13 @@ func (i *Injector) applyResourceRequirementsToWorkload(ctx context.Context, obj 
 	if err != nil {
 		return err
 	}
-	// Handle different workload types explicitly
-	switch obj.GetKind() {
-	case gvk.InferenceServices.Kind:
-		// For InferenceServices, apply resources to the model object
-		return i.applyResourceRequirementsToInferenceServiceModel(obj, hwp, config.ContainersPath)
-	case gvk.Notebook.Kind:
-		// For Notebooks, apply resources only to the main container (not sidecars like oauth-proxy)
-		return i.applyResourceRequirementsToContainers(ctx, obj, hwp, config.ContainersPath, notebookMainContainerIndices(obj, config.ContainersPath))
-	case gvk.LLMInferenceServiceV1Alpha1.Kind:
-		// For LLMInferenceServices, apply resources only to the main container
-		return i.applyResourceRequirementsToContainers(ctx, obj, hwp, config.ContainersPath, llmInferenceServiceMainContainerIndices(obj, config.ContainersPath))
-	default:
-		// This should never happen since isExpectedKind() should catch unsupported kinds earlier
-		return fmt.Errorf("unsupported workload kind: %s", obj.GetKind())
-	}
-}
-
-// for isvc.
-func (i *Injector) applyResourceRequirementsToInferenceServiceModel(obj *unstructured.Unstructured, hwp *infrav1.HardwareProfile, modelPath []string) error {
-	// Get the model object from the InferenceService
-	model, found, err := unstructured.NestedMap(obj.Object, modelPath...)
-	if err != nil {
-		return fmt.Errorf("failed to get model: %w", err)
-	}
-	if !found {
-		return nil // No model found
-	}
-
-	// Apply resource requirements to the model object
-	if err := i.applyIdentifiersToContainer(model, hwp.Spec.Identifiers); err != nil {
-		return fmt.Errorf("failed to apply resources to model: %w", err)
-	}
-
-	// Update the object with modified model
-	return unstructured.SetNestedMap(obj.Object, model, modelPath...)
+	// Apply resources only to the Notebook main container (not sidecars like oauth-proxy)
+	return i.applyResourceRequirementsToContainers(ctx, obj, hwp, config.ContainersPath, notebookMainContainerIndices(obj, config.ContainersPath))
 }
 
 // notebookMainContainerIndices returns the indices of the "main" container(s) for a Notebook
 // that should receive HWP resource injection. Sidecars (e.g. oauth-proxy, istio-proxy) must not
-// receive HWP resources. Returns nil to mean "all containers" (caller uses this for non-Notebook).
+// receive HWP resources.
 // Strategy: if 1 container -> [0]; if >1 containers -> container whose name == Notebook name, else none.
 func notebookMainContainerIndices(obj *unstructured.Unstructured, containersPath []string) []int {
 	containers, found, err := unstructured.NestedSlice(obj.Object, containersPath...)
@@ -1035,28 +950,8 @@ func notebookMainContainerIndices(obj *unstructured.Unstructured, containersPath
 	return []int{} // no main container found; apply to none
 }
 
-// llmInferenceServiceMainContainerIndices returns the indices of the main container for an LLMInferenceService.
-// For LLMInferenceService, we always use the container named LLMInferenceServiceMainContainerName.
-func llmInferenceServiceMainContainerIndices(obj *unstructured.Unstructured, containersPath []string) []int {
-	containers, found, err := unstructured.NestedSlice(obj.Object, containersPath...)
-	if err != nil || !found || len(containers) == 0 {
-		return nil
-	}
-	for idx, c := range containers {
-		m, ok := c.(map[string]any)
-		if !ok {
-			continue
-		}
-		name, _ := m["name"].(string)
-		if name == LLMInferenceServiceMainContainerName {
-			return []int{idx}
-		}
-	}
-	return []int{} // no main container found; apply to none
-}
-
 // applyResourceRequirementsToContainers applies resource requirements to workload containers.
-// When mainContainerIndices is non-nil (Notebook), only those indices are modified; otherwise all containers are.
+// When mainContainerIndices is non-nil, only those indices are modified; otherwise all containers are.
 func (i *Injector) applyResourceRequirementsToContainers(ctx context.Context, obj *unstructured.Unstructured,
 	hwp *infrav1.HardwareProfile, containersPath []string, mainContainerIndices []int) error {
 	log := logf.FromContext(ctx)
@@ -1067,16 +962,8 @@ func (i *Injector) applyResourceRequirementsToContainers(ctx context.Context, ob
 		return fmt.Errorf("failed to get containers: %w", err)
 	}
 
-	// If no containers found, create the minimal structure needed for resource injection
 	if !found || len(containers) == 0 {
-		if obj.GetKind() == gvk.LLMInferenceServiceV1Alpha1.Kind {
-			// Create minimal container with name "main"
-			containers = []any{map[string]any{
-				"name": "main",
-			}}
-		} else { // notebook kind
-			return nil
-		}
+		return nil
 	}
 
 	// When mainContainerIndices is empty (not nil), no matching main container was found

--- a/internal/webhook/kueue/validating.go
+++ b/internal/webhook/kueue/validating.go
@@ -30,8 +30,11 @@ import (
 // - kubeflow.org/v1: pytorchjobs, notebooks
 // - trainer.kubeflow.org/v1alpha1: trainjobs
 // - ray.io/v1 and v1alpha1: rayjobs, rayclusters
-// - serving.kserve.io/v1beta1: inferenceservices
-// - serving.kserve.io/v1alpha1,v1alpha2: llminferenceservices
+//
+// NOTE: InferenceService and LLMInferenceService are intentionally excluded. After HWP injection
+// was migrated to the kserve controller reconcile loop, the kueue.x-k8s.io/queue-name label is
+// applied to the Deployment/LeaderWorkerSet rather than the IS/LLMis object. Validating the label
+// on the IS/LLMis would reject valid workloads.
 //
 // NOTE: The kueue validating webhook is currently disabled. To re-enable it,
 // restore the +kubebuilder:webhook: prefix on the marker lines below and
@@ -40,8 +43,6 @@ import (
 // webhook:path=/validate-kueue,mutating=false,failurePolicy=fail,sideEffects=None,groups=kubeflow.org,resources=pytorchjobs;notebooks,verbs=create;update,versions=v1,name=kubeflow-kueuelabels-validator.opendatahub.io,admissionReviewVersions=v1
 // webhook:path=/validate-kueue,mutating=false,failurePolicy=fail,sideEffects=None,groups=trainer.kubeflow.org,resources=trainjobs,verbs=create;update,versions=v1alpha1,name=trainer-kueuelabels-validator.opendatahub.io,admissionReviewVersions=v1
 // webhook:path=/validate-kueue,mutating=false,failurePolicy=fail,sideEffects=None,groups=ray.io,resources=rayjobs;rayclusters,verbs=create;update,versions=v1;v1alpha1,name=ray-kueuelabels-validator.opendatahub.io,admissionReviewVersions=v1
-// webhook:path=/validate-kueue,mutating=false,failurePolicy=fail,sideEffects=None,groups=serving.kserve.io,resources=inferenceservices,verbs=create;update,versions=v1beta1,name=kserve-isvc-kueuelabels-validator.opendatahub.io,admissionReviewVersions=v1
-// webhook:path=/validate-kueue,mutating=false,failurePolicy=fail,sideEffects=None,groups=serving.kserve.io,resources=llminferenceservices,verbs=create;update,versions=v1alpha1;v1alpha2,name=kserve-llmisvc-kueuelabels-validator.opendatahub.io,admissionReviewVersions=v1
 //nolint:lll
 
 var (
@@ -136,18 +137,19 @@ func (v *Validator) Handle(ctx context.Context, req admission.Request) admission
 // Returns:
 //   - bool: true if the kind is expected, false otherwise
 func isExpectedKind(kind metav1.GroupVersionKind) bool {
-	// List of expected resource types that the Kueue webhook should handle
+	// List of expected resource types that the Kueue webhook should handle.
+	// InferenceService and LLMInferenceService are excluded: after HWP injection was migrated to
+	// the kserve controller reconcile loop, the kueue.x-k8s.io/queue-name label is set on the
+	// Deployment/LeaderWorkerSet rather than on the IS/LLMis object itself. Validating the label
+	// on the IS/LLMis would reject valid workloads.
 	expectedGVKs := []schema.GroupVersionKind{
-		gvk.Notebook,                    // kubeflow.org/v1/Notebook
-		gvk.PyTorchJob,                  // kubeflow.org/v1/PyTorchJob
-		gvk.TrainJob,                    // trainer.kubeflow.org/v1alpha1/TrainJob
-		gvk.RayJobV1Alpha1,              // ray.io/v1alpha1/RayJob
-		gvk.RayJobV1,                    // ray.io/v1/RayJob
-		gvk.RayClusterV1Alpha1,          // ray.io/v1alpha1/RayCluster
-		gvk.RayClusterV1,                // ray.io/v1/RayCluster
-		gvk.InferenceServices,           // serving.kserve.io/v1beta1/InferenceService
-		gvk.LLMInferenceServiceV1Alpha1, // serving.kserve.io/v1alpha1/LLMInferenceService
-		gvk.LLMInferenceServiceV1Alpha2, // serving.kserve.io/v1alpha2/LLMInferenceService
+		gvk.Notebook,       // kubeflow.org/v1/Notebook
+		gvk.PyTorchJob,     // kubeflow.org/v1/PyTorchJob
+		gvk.TrainJob,       // trainer.kubeflow.org/v1alpha1/TrainJob
+		gvk.RayJobV1Alpha1, // ray.io/v1alpha1/RayJob
+		gvk.RayJobV1,       // ray.io/v1/RayJob
+		gvk.RayClusterV1Alpha1, // ray.io/v1alpha1/RayCluster
+		gvk.RayClusterV1,       // ray.io/v1/RayCluster
 	}
 
 	requestGVK := schema.GroupVersionKind{


### PR DESCRIPTION
## Description

Now that kserve injects HardwareProfile scheduling stanzas directly during
reconciliation, the ODH operator webhooks no longer need to handle
InferenceService and LLMInferenceService objects.

From the HWP mutating webhook, remove the IS/LLMis workload configurations,
the IS-specific resource-requirements helper, the LLMis main-container index
helper, and the IS/LLMis webhook RBAC markers. From the Kueue validating
webhook, remove IS/LLMis from the expected-kind predicate and drop the two
disabled webhook marker comment lines, with an explanatory comment noting
that the Kueue label now lives on the Deployment/LWS rather than the IS/LLMis.

Related Jira https://redhat.atlassian.net/browse/RHOAIENG-62536
Related PR: https://github.com/opendatahub-io/kserve/pull/1538

## How Has This Been Tested?

TODO

## Merge criteria

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully
- [ ] New RELATED_IMAGE mappings are listed in ODH-Build-Config and RHOAI-Build-Config (CI validates names against build-config repos). Include links to build-config PRs in the description.

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [ ] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->
