### PR TITLE
chore: update version script to support prerelease version

### DIFF
--- a/.github/scripts/update-versions.sh
+++ b/.github/scripts/update-versions.sh
@@ -10,4 +10,4 @@ sed -i -e "/^ifeq.*ODH_PLATFORM_TYPE.*OpenDataHub/,/^else$/{s/[[:space:]]*VERSIO
 sed -i -e "s|containerImage.*|containerImage: quay.io/opendatahub/opendatahub-operator:v$NEW_VERSION|g" $CSV_FILE
 sed -i -e "s|createdAt.*|createdAt: \"$(date +"%Y-%-m-%dT00:00:00Z")\"|g" $CSV_FILE
 sed -i -e "s|name: opendatahub-operator.v.*|name: opendatahub-operator.v$NEW_VERSION|g" $CSV_FILE
-sed -i -e "s|version: [0-9][0-9.]*|version: $NEW_VERSION|g" $CSV_FILE
+sed -i -e "s|version: [0-9][0-9a-zA-Z._-]*|version: $NEW_VERSION|g" $CSV_FILE


### PR DESCRIPTION
## Description

- Fix version regex in `update-versions.sh` to match full semver strings including pre-release suffixes (e.g. `3.5.0-ea.1`)
- The previous regex `[0-9][0-9.]*` only matched digits and dots, leaving pre-release suffixes like `-ea.1` behind after replacement, producing incorrect versions like `3.5.0-ea.2-ea.1`
- Seen in PR #3582 where `version` field in CSV was incorrectly updated

## How Has This Been Tested?

Verified the sed regex against version strings with pre-release suffixes:
- `3.5.0-ea.1` → correctly replaced to new version
- `3.5.0` → still works for plain semver versions

## Screenshot or short clip
N/A

## Merge criteria

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully
- [ ] New RELATED_IMAGE mappings are listed in ODH-Build-Config and RHOAI-Build-Config (CI validates names against build-config repos). Include links to build-config PRs in the description.

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [ ] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced version format handling in the release process to support a broader range of version number formats, improving flexibility in version management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->