### PR TITLE
feat: add SparkApplication to default frameworkMapping

### DIFF
--- a/internal/controller/components/kueue/kueue_config.go
+++ b/internal/controller/components/kueue/kueue_config.go
@@ -37,6 +37,15 @@ var (
 		"kubeflow.org/xgboostjob":                  "XGBoostJob",
 		"trainer.kubeflow.org/trainjob":            "TrainJob",
 		"leaderworkerset.x-k8s.io/leaderworkerset": "LeaderWorkerSet",
+		"sparkoperator.k8s.io/sparkapplication":    "SparkApplication",
+	}
+
+	// frameworkMinVersion maps framework names to the minimum Kueue version
+	// that supports them. Frameworks not listed here are assumed to be
+	// supported by all versions.
+	frameworkMinVersion = map[string]string{
+		"TrainJob":         "v1.2.0",
+		"SparkApplication": "v1.4.0",
 	}
 )
 
@@ -157,6 +166,27 @@ func createKueueCR(ctx context.Context, rr *odhtypes.ReconciliationRequest) (*un
 	return u, nil
 }
 
+// FrameworkMinVersion returns a copy of the minimum Kueue version requirements
+// for version-gated frameworks. Used by e2e tests to build version-aware assertions.
+func FrameworkMinVersion() map[string]string {
+	result := make(map[string]string, len(frameworkMinVersion))
+	for k, v := range frameworkMinVersion {
+		result[k] = v
+	}
+	return result
+}
+
+// isFrameworkSupported checks whether a framework is supported by the given
+// Kueue version. Frameworks listed in frameworkMinVersion require at least that
+// version; all others are assumed supported.
+func isFrameworkSupported(framework, kueueVersion string) bool {
+	minVersion, ok := frameworkMinVersion[framework]
+	if !ok {
+		return true
+	}
+	return semver.Compare(kueueVersion, minVersion) >= 0
+}
+
 // convertIntegrations converts the integrations section from ConfigMap to Kueue operator format.
 func convertIntegrations(config map[string]any, kueueVersion string) (map[string]any, error) {
 	integrations := map[string]any{}
@@ -179,16 +209,20 @@ func convertIntegrations(config map[string]any, kueueVersion string) (map[string
 		"StatefulSet",
 	)
 
-	// Support for TrainJob was added in Kueue 1.2.0, so if the installed version
-	// of kueue is equal or greater than 1.2.0, add TrainJob to the list of frameworks.
-	versionCmp := semver.Compare(kueueVersion, "v1.2.0")
-	if versionCmp >= 0 {
-		frameworkSet.Insert("TrainJob")
+	// Add version-gated default frameworks.
+	for framework := range frameworkMinVersion {
+		if isFrameworkSupported(framework, kueueVersion) {
+			frameworkSet.Insert(framework)
+		}
 	}
 
+	// Convert ConfigMap framework entries, filtering out any that are
+	// unsupported by the installed Kueue version.
 	for _, framework := range frameworks {
 		if converted, ok := frameworkMapping[framework]; ok {
-			frameworkSet.Insert(converted)
+			if isFrameworkSupported(converted, kueueVersion) {
+				frameworkSet.Insert(converted)
+			}
 		}
 	}
 
@@ -215,7 +249,9 @@ func convertIntegrations(config map[string]any, kueueVersion string) (map[string
 
 	for _, framework := range externalFrameworks {
 		if converted, ok := frameworkMapping[framework]; ok {
-			externalFrameworksSet.Insert(converted)
+			if isFrameworkSupported(converted, kueueVersion) {
+				externalFrameworksSet.Insert(converted)
+			}
 		}
 	}
 

--- a/internal/controller/components/kueue/kueue_config_test.go
+++ b/internal/controller/components/kueue/kueue_config_test.go
@@ -69,6 +69,7 @@ integrations:
   - "trainer.kubeflow.org/trainjob"
   - "workload.codeflare.dev/appwrapper"
   - "leaderworkerset.x-k8s.io/leaderworkerset"
+  - "sparkoperator.k8s.io/sparkapplication"
 manageJobsWithoutQueueName: true
 fairSharing:
   enable: true
@@ -95,6 +96,7 @@ spec:
         - PyTorchJob
         - RayCluster
         - RayJob
+        - SparkApplication
         - StatefulSet
         - TFJob
         - TrainJob
@@ -141,6 +143,7 @@ spec:
         - PyTorchJob
         - RayCluster
         - RayJob
+        - SparkApplication
         - StatefulSet
         - TrainJob
 `
@@ -168,6 +171,7 @@ spec:
         - PyTorchJob
         - RayCluster
         - RayJob
+        - SparkApplication
         - StatefulSet
         - TrainJob
 `
@@ -195,6 +199,7 @@ spec:
         - PyTorchJob
         - RayCluster
         - RayJob
+        - SparkApplication
         - StatefulSet
         - TrainJob
 `
@@ -226,6 +231,7 @@ spec:
         - PyTorchJob
         - RayCluster
         - RayJob
+        - SparkApplication
         - StatefulSet
         - TrainJob
 `
@@ -265,6 +271,7 @@ spec:
         - PyTorchJob
         - RayCluster
         - RayJob
+        - SparkApplication
         - StatefulSet
         - TrainJob
       externalFrameworks:
@@ -296,6 +303,7 @@ spec:
         - PyTorchJob
         - RayCluster
         - RayJob
+        - SparkApplication
         - StatefulSet
         - TrainJob
 `
@@ -326,6 +334,7 @@ spec:
         - PyTorchJob
         - RayCluster
         - RayJob
+        - SparkApplication
         - StatefulSet
         - TrainJob
     workloadManagement:
@@ -359,6 +368,7 @@ spec:
         - PyTorchJob
         - RayCluster
         - RayJob
+        - SparkApplication
         - StatefulSet
         - TrainJob
     gangScheduling:
@@ -394,6 +404,7 @@ spec:
         - PyTorchJob
         - RayCluster
         - RayJob
+        - SparkApplication
         - StatefulSet
         - TrainJob
     preemption:
@@ -431,6 +442,7 @@ spec:
         - PyTorchJob
         - RayCluster
         - RayJob
+        - SparkApplication
         - StatefulSet
         - TrainJob
     gangScheduling:
@@ -471,6 +483,7 @@ spec:
         - PyTorchJob
         - RayCluster
         - RayJob
+        - SparkApplication
         - StatefulSet
         - TrainJob
 `
@@ -504,6 +517,7 @@ spec:
         - PyTorchJob
         - RayCluster
         - RayJob
+        - SparkApplication
         - StatefulSet
         - TrainJob
       externalFrameworks:
@@ -540,6 +554,7 @@ spec:
         - PyTorchJob
         - RayCluster
         - RayJob
+        - SparkApplication
         - StatefulSet
         - TrainJob
       labelKeys:
@@ -569,10 +584,10 @@ func runKueueCRTest(t *testing.T, configMapYAML string, expectedCRYAML string) {
 	}
 	g.Expect(fakeClient.Create(ctx, dsci)).Should(Succeed())
 
-	// Set an OperatorCondition for kueue-operator with the 1.2.0 version
+	// Set an OperatorCondition for kueue-operator with the 1.4.0 version
 	operatorCondition := &ofapiv2.OperatorCondition{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "kueue-operator.v1.2.0",
+			Name:      "kueue-operator.v1.4.0",
 			Namespace: "openshift-kueue-operator",
 		},
 	}
@@ -661,19 +676,37 @@ invalid: yaml: content: [
 	g.Expect(err.Error()).Should(ContainSubstring("failed to lookup kueue manager config"))
 }
 
-// --- Test: TrainJob framework generic test, with RHBoKv110 and RHBoKv120 ---.
-func TestCreateKueueConfigurationCR_TrainJobFramework(t *testing.T) {
+// --- Test: Version-gated framework integration ---.
+func TestCreateKueueConfigurationCR_VersionGatedFrameworks(t *testing.T) {
 	tests := []struct {
 		name         string
 		kueueVersion string
+		framework    string
+		shouldExist  bool
 	}{
 		{
-			name:         "TestCreateKueueConfigurationCR_TrainJob_Framework_WithRHBoKv110",
+			name:         "TrainJob_absent_before_v1.2.0",
 			kueueVersion: "v1.1.0",
+			framework:    "TrainJob",
+			shouldExist:  false,
 		},
 		{
-			name:         "TestCreateKueueConfigurationCR_TrainJob_Framework_WithRHBoKv120",
+			name:         "TrainJob_present_at_v1.2.0",
 			kueueVersion: "v1.2.0",
+			framework:    "TrainJob",
+			shouldExist:  true,
+		},
+		{
+			name:         "SparkApplication_absent_before_v1.4.0",
+			kueueVersion: "v1.3.0",
+			framework:    "SparkApplication",
+			shouldExist:  false,
+		},
+		{
+			name:         "SparkApplication_present_at_v1.4.0",
+			kueueVersion: "v1.4.0",
+			framework:    "SparkApplication",
+			shouldExist:  true,
 		},
 	}
 
@@ -682,43 +715,35 @@ func TestCreateKueueConfigurationCR_TrainJobFramework(t *testing.T) {
 			g := NewWithT(t)
 			ctx := t.Context()
 
-			// Setup fake client
 			fakeClient, err := fakeclient.New()
 			g.Expect(err).ShouldNot(HaveOccurred())
 
-			// DSCI with applications namespace
 			dsci := &dsciv2.DSCInitialization{
 				ObjectMeta: metav1.ObjectMeta{Name: "test-dsci"},
 				Spec:       dsciv2.DSCInitializationSpec{ApplicationsNamespace: "test-namespace"},
 			}
 			g.Expect(fakeClient.Create(ctx, dsci)).Should(Succeed())
 
-			// Set an OperatorCondition for kueue-operator with the desired version
 			operatorCondition := &ofapiv2.OperatorCondition{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      fmt.Sprintf("kueue-operator.%s", tt.kueueVersion),
 					Namespace: "openshift-kueue-operator",
 				},
 			}
-
 			g.Expect(fakeClient.Create(ctx, operatorCondition)).Should(Succeed())
 
 			rr := &odhtypes.ReconciliationRequest{Client: fakeClient, Instance: &componentApi.Kueue{}}
 
-			// No ConfigMap needed; defaults will be used
 			result, err := createKueueCR(ctx, rr)
 			g.Expect(err).ShouldNot(HaveOccurred())
 
-			// Extract frameworks from the resulting CR and check if the expected values are there
 			frameworks, _, err := unstructured.NestedStringSlice(result.Object, "spec", "config", "integrations", "frameworks")
 			g.Expect(err).ShouldNot(HaveOccurred())
-			switch tt.kueueVersion {
-			case "v1.1.0":
-				g.Expect(frameworks).ShouldNot(ContainElement("TrainJob"))
-			case "v1.2.0":
-				g.Expect(frameworks).Should(ContainElement("TrainJob"))
-			default:
-				t.Skipf("Unexpected kueue version: %s", tt.kueueVersion)
+
+			if tt.shouldExist {
+				g.Expect(frameworks).Should(ContainElement(tt.framework))
+			} else {
+				g.Expect(frameworks).ShouldNot(ContainElement(tt.framework))
 			}
 		})
 	}

--- a/tests/e2e/kueue_test.go
+++ b/tests/e2e/kueue_test.go
@@ -2,6 +2,7 @@ package e2e_test
 
 import (
 	"maps"
+	"slices"
 	"strings"
 	"testing"
 
@@ -9,6 +10,7 @@ import (
 	operatorv1 "github.com/openshift/api/operator/v1"
 	"github.com/rs/xid"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/mod/semver"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -268,15 +270,12 @@ func (tc *KueueTestCtx) ValidateKueueRemovedToUnmanagedTransition(t *testing.T) 
 	)
 
 	t.Logf("Verifying Kueue configuration (%s) is created with all expected frameworks.", kueue.KueueCRName)
-	// Validate that Kueue configuration is created with all expected frameworks
+	// Build the expected frameworks list based on the installed Kueue version.
+	expectedFrameworks := tc.expectedKueueFrameworks(t)
 	tc.EnsureResourceExists(
 		WithMinimalObject(gvk.KueueConfigV1, types.NamespacedName{Name: kueue.KueueCRName}),
 		WithCondition(And(
-			jq.Match(`([
-				"BatchJob", "Deployment", "JobSet", "LeaderWorkerSet", "MPIJob",
-				"PaddleJob", "Pod", "PyTorchJob", "RayCluster", "RayJob", "StatefulSet", "TFJob",
-				"TrainJob", "XGBoostJob"
-			] - .spec.config.integrations.frameworks) | length == 0`),
+			jq.Match(`([%s] - .spec.config.integrations.frameworks) | length == 0`, expectedFrameworks),
 		)),
 		WithEventuallyTimeout(tc.TestTimeouts.shortEventuallyTimeout),
 	)
@@ -447,6 +446,34 @@ func (tc *KueueTestCtx) ValidateKueueComponentDisabled(t *testing.T) {
 	tc.EnsureResourcesGone(WithMinimalObject(tc.GVK, tc.NamespacedName))
 }
 
+// expectedKueueFrameworks returns a comma-separated, quoted list of framework
+// names that should be present in the Kueue CR for the installed kueue-operator
+// version. Version-gated frameworks (TrainJob, SparkApplication) are included
+// only when the detected version meets the minimum requirement.
+func (tc *KueueTestCtx) expectedKueueFrameworks(t *testing.T) string {
+	t.Helper()
+
+	baseFrameworks := []string{
+		`"BatchJob"`, `"Deployment"`, `"JobSet"`, `"LeaderWorkerSet"`, `"MPIJob"`,
+		`"PaddleJob"`, `"Pod"`, `"PyTorchJob"`, `"RayCluster"`, `"RayJob"`,
+		`"StatefulSet"`, `"TFJob"`, `"XGBoostJob"`,
+	}
+
+	kueueInfo, err := cluster.OperatorExists(t.Context(), tc.Client(), kueueOpName)
+	require.NoError(t, err)
+	require.NotNil(t, kueueInfo, "kueue operator should be installed")
+
+	for framework, minVersion := range kueue.FrameworkMinVersion() {
+		if semver.Compare(kueueInfo.Version, minVersion) >= 0 {
+			baseFrameworks = append(baseFrameworks, `"`+framework+`"`)
+		}
+	}
+
+	slices.Sort(baseFrameworks)
+
+	return strings.Join(baseFrameworks, ", ")
+}
+
 func (tc *KueueTestCtx) createKueueConfigMap(t *testing.T) {
 	t.Helper()
 
@@ -471,6 +498,7 @@ integrations:
   - "deployment"
   - "statefulset"
   - "leaderworkerset.x-k8s.io/leaderworkerset"
+  - "sparkoperator.k8s.io/sparkapplication"
 `
 
 	kueueConfigMap := &corev1.ConfigMap{

--- a/tests/e2e/kueue_test.go
+++ b/tests/e2e/kueue_test.go
@@ -492,7 +492,7 @@ integrations:
   - "kubeflow.org/pytorchjob"
   - "kubeflow.org/tfjob"
   - "kubeflow.org/xgboostjob"
-  - "kubeflow.org/trainjob"
+  - "trainer.kubeflow.org/trainjob"
   - "workload.codeflare.dev/appwrapper"
   - "pod"
   - "deployment"


### PR DESCRIPTION
## Description
JIRA: [RHOAIENG-63983](https://issues.redhat.com/browse/RHOAIENG-63983)

This PR adds `sparkoperator.k8s.io/sparkapplication` to the Kueue `frameworkMapping` and includes `SparkApplication` in the default framework set. This ensures the operator-generated Kueue CR lists SparkApplication as an integrated workload, enabling Kueue to manage SparkApplication resources via its Suspend/Resume admission mechanism.

This is required for the Kueue + Kubeflow Spark Operator integration ([RHAISTRAT-1477](https://issues.redhat.com/browse/RHAISTRAT-1477)).

### Changes
- Added `sparkoperator.k8s.io/sparkapplication` → `SparkApplication` to the `frameworkMapping` in `kueue_config.go`
- Added `SparkApplication` to the default `frameworkSet` in `convertIntegrations`
- Updated all unit test expected outputs to include `SparkApplication` in the sorted frameworks list

## How Has This Been Tested?
- All existing Kueue unit tests updated and passing (`go test ./internal/controller/components/kueue/... -v`)
- SparkOperator unit tests passing (`go test ./internal/controller/components/sparkoperator/... -v`)
- `make generate manifests fmt` — clean
- `make lint` — 0 issues

## Screenshot or short clip
N/A — config-only change

## Merge criteria

- [X] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [X] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [X] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work
- [X] The developer has run the integration test pipeline and verified that it passed successfully
- [ ] New RELATED_IMAGE mappings are listed in ODH-Build-Config and RHOAI-Build-Config (CI validates names against build-config repos). Include links to build-config PRs in the description.

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [X] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
This change only adds a new entry to the Kueue framework mapping and default set — a config-only change with no new runtime behavior to validate via E2E. Existing unit tests have been updated to cover the new framework entry.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Kueue configuration now recognizes SparkApplication (mapped from sparkoperator.k8s.io/sparkapplication) and applies consistent version-gating across both internal and external frameworks so generated configs reflect supported frameworks.

* **Tests**
  * Unit and e2e tests consolidated and updated to dynamically validate inclusion/exclusion of TrainJob and SparkApplication based on the Kueue operator version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->