### PR TITLE
fix: align MaaS unit test expectations with upstream image tag change

### DIFF
--- a/internal/controller/components/modelsasservice/modelsasservice_test.go
+++ b/internal/controller/components/modelsasservice/modelsasservice_test.go
@@ -695,10 +695,10 @@ func TestApplyImageOverridesFromParams(t *testing.T) {
 	resMap, err := k.Run(fs, kPath)
 	g.Expect(err).ShouldNot(HaveOccurred(), "kustomize build should succeed")
 
-	// Before override: the images transformer renders quay.io/opendatahub/maas-controller:latest
+	// Before override: the images transformer renders the default tag from the kustomization
 	depBefore := findDeploymentImage(g, resMap)
-	g.Expect(depBefore).To(Equal("quay.io/opendatahub/maas-controller:latest"),
-		"kustomize images transformer should produce the default :latest image")
+	g.Expect(depBefore).To(Equal("quay.io/opendatahub/maas-controller:odh-stable"),
+		"kustomize images transformer should produce the default :odh-stable image")
 
 	// Write a temporary params.env with a pinned digest to simulate what
 	// ApplyParams does when RELATED_IMAGE_* env vars are set in CI.
@@ -762,7 +762,7 @@ func TestApplyImageOverridesFromParams_NoOverride(t *testing.T) {
 	g.Expect(err).ShouldNot(HaveOccurred())
 
 	depAfter := findDeploymentImage(g, resMap)
-	g.Expect(depAfter).To(Equal("quay.io/opendatahub/maas-controller:latest"),
+	g.Expect(depAfter).To(Equal("quay.io/opendatahub/maas-controller:odh-stable"),
 		"image should remain unchanged when params.env has no controller image key")
 }
 


### PR DESCRIPTION
## Description

The upstream MaaS manifests ([models-as-a-service](https://github.com/opendatahub-io/models-as-a-service)) changed the default `maas-controller` image tag from `:latest` to `:odh-stable` in the kustomization (`opt/manifests/maas/base/maas-controller/manager/kustomization.yaml`). Two unit tests in `modelsasservice_test.go` still hardcoded the expectation of `:latest`, causing CI failures unrelated to any operator code change (e.g. [PR #3587](https://github.com/opendatahub-io/opendatahub-operator/pull/3587)).

### Changes
- Updated `TestApplyImageOverridesFromParams` expected image from `quay.io/opendatahub/maas-controller:latest` to `quay.io/opendatahub/maas-controller:odh-stable`
- Updated `TestApplyImageOverridesFromParams_NoOverride` expected image from `quay.io/opendatahub/maas-controller:latest` to `quay.io/opendatahub/maas-controller:odh-stable`

## How Has This Been Tested?
- All three `TestApplyImageOverridesFromParams*` tests pass locally (`go test -v -run TestApplyImageOverridesFromParams ./internal/controller/components/modelsasservice/ -tags odh`)

## Screenshot or short clip
N/A — test-only fix

## Merge criteria

- [X] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [X] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [X] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work
- [X] The developer has run the integration test pipeline and verified that it passed successfully
- [ ] New RELATED_IMAGE mappings are listed in ODH-Build-Config and RHOAI-Build-Config (CI validates names against build-config repos). Include links to build-config PRs in the description.

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [X] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
This is a test-only fix — no runtime behavior changed. The unit tests were failing because the upstream MaaS manifests changed their default image tag. No E2E coverage is needed.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated controller image override tests to dynamically derive the default controller image from upstream configuration, ensuring correct behavior when overrides are applied or absent. Added additional test coverage and parsing support to validate image resolution robustly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->