### PR TITLE
chore(ci): update manifest SHA workflow to regenerate CCM RBAC

### DIFF
--- a/.github/workflows/update-manifest-shas.yml
+++ b/.github/workflows/update-manifest-shas.yml
@@ -38,6 +38,16 @@ jobs:
             const script = require('./.github/scripts/update-manifests-commit-sha.js')
             await script({github, core})
 
+      - name: Set up Go
+        if: steps.update-shas.outputs.updates-needed == 'true'
+        uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
+        with:
+          go-version-file: go.mod
+
+      - name: Update cloud manager RBAC
+        if: steps.update-shas.outputs.updates-needed == 'true'
+        run: make update-cloudmanager-rbac
+
       - name: Create Pull Request
         if: steps.update-shas.outputs.updates-needed == 'true'
         uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7.0.8


### PR DESCRIPTION
## Description

- Extends the `update-manifest-shas` workflow to automatically regenerate cloud manager RBAC after manifest SHA updates
- When dependency component ClusterRole names change during SHA updates, the CCM RBAC must be regenerated to stay in sync
- Adds Go setup and `make update-cloudmanager-rbac` steps, both gated behind `updates-needed == 'true'`

Jira task: https://issues.redhat.com/browse/RHOAIENG-57045

## How Has This Been Tested?

- Verified workflow YAML syntax
- The workflow runs conditionally only when `updates-needed` is true, so existing behavior is unchanged when no SHA updates occur

## Screenshot or short clip

N/A — CI workflow change only.

## Merge criteria

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully
- [ ] New RELATED_IMAGE mappings are listed in ODH-Build-Config and RHOAI-Build-Config (CI validates names against build-config repos). Include links to build-config PRs in the description.

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [ ] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automation workflow to conditionally execute additional setup and configuration update steps only when necessary, improving efficiency of the manifest update process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->