### PR TITLE
fix(dashboard): propagate pipeline runtime RELATED_IMAGE env vars to automl/autorag sidecars

### DIFF
--- a/cmd/test-retry/pkg/parser/parser_test.go
+++ b/cmd/test-retry/pkg/parser/parser_test.go
@@ -81,13 +81,13 @@ func TestParseGoTestJSON(t *testing.T) {
 
 func TestParseGoTestJSON_StderrDoesNotCauseError(t *testing.T) {
 	tests := []struct {
-		name          string
-		stdout        string
-		stderr        string
-		wantErr       bool
-		wantPassed    int
-		wantFailed    int
-		failedName    string
+		name       string
+		stdout     string
+		stderr     string
+		wantErr    bool
+		wantPassed int
+		wantFailed int
+		failedName string
 	}{
 		{
 			name: "stderr with failing test",
@@ -110,7 +110,7 @@ func TestParseGoTestJSON_StderrDoesNotCauseError(t *testing.T) {
 			wantPassed: 1,
 		},
 		{
-			name:   "large stderr payload",
+			name: "large stderr payload",
 			stdout: `{"Time":"2023-01-01T00:00:00Z","Action":"run","Package":"example.com/pkg","Test":"TestOk"}
 {"Time":"2023-01-01T00:00:01Z","Action":"output","Package":"example.com/pkg","Test":"TestOk","Output":"=== RUN   TestOk\n"}
 {"Time":"2023-01-01T00:00:02Z","Action":"output","Package":"example.com/pkg","Test":"TestOk","Output":"--- PASS: TestOk (1.00s)\n"}

--- a/internal/controller/components/dashboard/dashboard_support.go
+++ b/internal/controller/components/dashboard/dashboard_support.go
@@ -52,8 +52,10 @@ var (
 		"eval-hub-ui-image":        "RELATED_IMAGE_ODH_MOD_ARCH_EVAL_HUB_IMAGE",
 		"kube-rbac-proxy":          "RELATED_IMAGE_ODH_KUBE_RBAC_PROXY_IMAGE",
 		"images-jobs-async-upload": "RELATED_IMAGE_ODH_MODEL_REGISTRY_JOB_ASYNC_UPLOAD_IMAGE",
-		"automl-ui-image":          "RELATED_IMAGE_ODH_MOD_ARCH_AUTOML_IMAGE",
-		"autorag-ui-image":         "RELATED_IMAGE_ODH_MOD_ARCH_AUTORAG_IMAGE",
+		"automl-ui-image":                "RELATED_IMAGE_ODH_MOD_ARCH_AUTOML_IMAGE",
+		"automl-pipeline-runtime-image":  "RELATED_IMAGE_ODH_AUTOML_IMAGE",
+		"autorag-ui-image":               "RELATED_IMAGE_ODH_MOD_ARCH_AUTORAG_IMAGE",
+		"autorag-pipeline-runtime-image": "RELATED_IMAGE_ODH_AUTORAG_IMAGE",
 	}
 
 	conditionTypes = []string{

--- a/internal/controller/components/dashboard/dashboard_support.go
+++ b/internal/controller/components/dashboard/dashboard_support.go
@@ -44,14 +44,14 @@ var (
 	}
 
 	imagesMap = map[string]string{
-		"odh-dashboard-image":      "RELATED_IMAGE_ODH_DASHBOARD_IMAGE",
-		"model-registry-ui-image":  "RELATED_IMAGE_ODH_MOD_ARCH_MODEL_REGISTRY_IMAGE",
-		"gen-ai-ui-image":          "RELATED_IMAGE_ODH_MOD_ARCH_GEN_AI_IMAGE",
-		"mlflow-ui-image":          "RELATED_IMAGE_ODH_MOD_ARCH_MLFLOW_IMAGE",
-		"maas-ui-image":            "RELATED_IMAGE_ODH_MOD_ARCH_MAAS_IMAGE",
-		"eval-hub-ui-image":        "RELATED_IMAGE_ODH_MOD_ARCH_EVAL_HUB_IMAGE",
-		"kube-rbac-proxy":          "RELATED_IMAGE_ODH_KUBE_RBAC_PROXY_IMAGE",
-		"images-jobs-async-upload": "RELATED_IMAGE_ODH_MODEL_REGISTRY_JOB_ASYNC_UPLOAD_IMAGE",
+		"odh-dashboard-image":            "RELATED_IMAGE_ODH_DASHBOARD_IMAGE",
+		"model-registry-ui-image":        "RELATED_IMAGE_ODH_MOD_ARCH_MODEL_REGISTRY_IMAGE",
+		"gen-ai-ui-image":                "RELATED_IMAGE_ODH_MOD_ARCH_GEN_AI_IMAGE",
+		"mlflow-ui-image":                "RELATED_IMAGE_ODH_MOD_ARCH_MLFLOW_IMAGE",
+		"maas-ui-image":                  "RELATED_IMAGE_ODH_MOD_ARCH_MAAS_IMAGE",
+		"eval-hub-ui-image":              "RELATED_IMAGE_ODH_MOD_ARCH_EVAL_HUB_IMAGE",
+		"kube-rbac-proxy":                "RELATED_IMAGE_ODH_KUBE_RBAC_PROXY_IMAGE",
+		"images-jobs-async-upload":       "RELATED_IMAGE_ODH_MODEL_REGISTRY_JOB_ASYNC_UPLOAD_IMAGE",
 		"automl-ui-image":                "RELATED_IMAGE_ODH_MOD_ARCH_AUTOML_IMAGE",
 		"automl-pipeline-runtime-image":  "RELATED_IMAGE_ODH_AUTOML_IMAGE",
 		"autorag-ui-image":               "RELATED_IMAGE_ODH_MOD_ARCH_AUTORAG_IMAGE",


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-64768

## Description

Pipeline YAML files were embedded in the automl and autorag BFFs late in the 3.4 release to work around the delayed managed pipelines capability. These embedded YAMLs contain hardcoded container image SHA256 digests that go stale as the operator ships newer image builds.

This PR adds two entries to the dashboard `imagesMap` in `dashboard_support.go` so that `ApplyParams()` writes the operator's `RELATED_IMAGE_ODH_AUTOML_IMAGE` and `RELATED_IMAGE_ODH_AUTORAG_IMAGE` values into the modular-architecture `params.env`. The dashboard kustomize manifests then inject these as environment variables on the `automl-ui` and `autorag-ui` sidecar containers, where the BFFs use them at runtime to replace the hardcoded image digests before uploading pipeline YAMLs to Kubeflow.

### Changes

- Added `automl-pipeline-runtime-image` → `RELATED_IMAGE_ODH_AUTOML_IMAGE` to `imagesMap`
- Added `autorag-pipeline-runtime-image` → `RELATED_IMAGE_ODH_AUTORAG_IMAGE` to `imagesMap`

### Consumer

Dashboard PR with the BFF code and manifest changes: https://github.com/opendatahub-io/odh-dashboard/pull/7743

## How Has This Been Tested?

- Verified the operator builds successfully with the new map entries
- The existing `ApplyParams()` mechanism and `imagesMap` pattern is already covered by existing E2E tests for other dashboard sidecar images (model-registry-ui, gen-ai-ui, maas-ui, etc.)
- End-to-end validation of the full flow (operator → params.env → kustomize → container env → BFF image replacement) will be tested on-cluster with the companion dashboard PR

## Merge criteria

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully
- [ ] New RELATED_IMAGE mappings are listed in ODH-Build-Config and RHOAI-Build-Config (CI validates names against build-config repos). Include links to build-config PRs in the description.

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification

This change adds two key-value entries to an existing `imagesMap` in `dashboard_support.go`. It introduces no new controllers, APIs, or core logic — it extends an existing data map that follows the same pattern already used by 8 other entries (model-registry-ui, gen-ai-ui, maas-ui, etc.). The `ApplyParams()` code path that consumes this map is unchanged and already covered by existing tests. This is a data-only configuration change with no new runtime behavior in the operator itself.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded image variable support in the dashboard for AutoML and AutoRAG pipeline runtime configurations, enabling additional manifest/Kustomize image resolution mappings.

* **Tests**
  * Updated test formatting for improved consistency and readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->