### PR TITLE
Add odh-trainer-operator to manifests-config.yaml

### DIFF
--- a/build/manifests-config.yaml
+++ b/build/manifests-config.yaml
@@ -48,6 +48,9 @@ map:
   odh-trainer:
     src: manifests
     dest: trainer
+  odh-trainer-operator:
+    src: config/manifests
+    dest: trainer-operator
   odh-mlflow-operator:
     src: config
     dest: mlflowoperator


### PR DESCRIPTION
Adds 'odh-trainer-operator' to the operator manifests config map.

Component: odh-trainer-operator
Manifest source path: config/manifests
Manifest dest path:   trainer-operator
Upstream repo: https://github.com/opendatahub-io/trainer-operator @ main
Jira: https://redhat.atlassian.net/browse/RHOAIENG-65430

**File changed:**
- `build/manifests-config.yaml` — added `odh-trainer-operator` entry under `map:`