### PR TITLE
fix: disable odh-agents-operator in manifests-config to unblock Konflux CI

### DIFF
--- a/build/manifests-config.yaml
+++ b/build/manifests-config.yaml
@@ -63,6 +63,9 @@ map:
   odh-kserve-module-operator:
     src: kserve-module/config
     dest: kserve-module
-  odh-agents-operator:
-    src: kagenti-operator/config
-    dest: kagenti-operator
+  # odh-agents-operator: disabled until odh-mod-arch-agent-ops image has
+  # a stable tag on quay.io (currently only has PR/build tags, which causes
+  # Konflux CI to fail with "no tags found" for all PRs targeting main).
+  # odh-agents-operator:
+  #   src: kagenti-operator/config
+  #   dest: kagenti-operator


### PR DESCRIPTION
## Description

Comment out the `odh-agents-operator` entry in `build/manifests-config.yaml` to unblock Konflux CI for all PRs targeting `main`.

### Problem

The `odh-agents-operator` was added to `manifests-config.yaml` in commits df2e3c41 / bdd39fea (May 20-21). During Konflux CI builds, the `prefetch-manifests` task fetches kagenti-operator manifests, which include a `RELATED_IMAGE_ODH_MOD_ARCH_AGENT_OPS_IMAGE` reference to `quay.io/opendatahub/odh-mod-arch-agent-ops`. The Konflux pipeline then validates that all referenced component images have proper tags.

The `odh-mod-arch-agent-ops` image on quay.io only has PR/build tags (`odh-pr`, `sha256-*`) -- no stable version tag (e.g. `odh-stable`). This causes the Konflux image validation to fail with:

```
Processing image entry - RELATED_IMAGE_ODH_MOD_ARCH_AGENT_OPS_IMAGE
no tags found for odh-mod-arch-agent-ops
Images missing for following components: ['odh-mod-arch-agent-ops']
```

This failure blocks **all open PRs** targeting `main`, not just PRs that touch agents-operator code.

### Fix

Temporarily comment out the `odh-agents-operator` entry with a clear explanation of why it is disabled and when it can be re-enabled (once the image has a stable tag on quay.io).

Related: [PR #3584](https://github.com/opendatahub-io/opendatahub-operator/pull/3584) (RHOAIENG-62623: Integrate agents-operator as modular component) should coordinate the re-enablement once the component is fully onboarded.

## How Has This Been Tested?

- Verified that the `odh-mod-arch-agent-ops` image on quay.io has no stable tags (only `odh-pr`, `sha256-*` build tags)
- Confirmed 10+ open PRs are all failing the same Konflux check, proving this is a systemic issue
- The change is a YAML comment-out only, no runtime behavior change

## Merge criteria

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully
- [ ] New RELATED_IMAGE mappings are listed in ODH-Build-Config and RHOAI-Build-Config (CI validates names against build-config repos). Include links to build-config PRs in the description.

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification

Build config change only (YAML comment). No runtime code modified, no E2E tests affected.
