### PR TITLE
fix(trainer): update ImageStream workbench keys from 3-4 to 3-5

### DIFF
--- a/internal/controller/components/trainer/trainer_support.go
+++ b/internal/controller/components/trainer/trainer_support.go
@@ -29,9 +29,9 @@ var (
 		"odh-th06-cuda130-torch210-py312-image":           "RELATED_IMAGE_ODH_TH06_CUDA130_TORCH210_PY312_IMAGE",
 		"odh-th06-rocm64-torch291-py312-image":            "RELATED_IMAGE_ODH_TH06_ROCM64_TORCH291_PY312_IMAGE",
 		"odh-th06-cpu-torch210-py312-image":               "RELATED_IMAGE_ODH_TH06_CPU_TORCH210_PY312_IMAGE",
-		"odh-training-universal-workbench-image-cuda-3-4": "RELATED_IMAGE_ODH_TH06_CUDA130_TORCH210_PY312_IMAGE",
-		"odh-training-universal-workbench-image-rocm-3-4": "RELATED_IMAGE_ODH_TH06_ROCM64_TORCH291_PY312_IMAGE",
-		"odh-training-universal-workbench-image-cpu-3-4":  "RELATED_IMAGE_ODH_TH06_CPU_TORCH210_PY312_IMAGE",
+		"odh-training-universal-workbench-image-cuda-3-5": "RELATED_IMAGE_ODH_TH06_CUDA130_TORCH210_PY312_IMAGE",
+		"odh-training-universal-workbench-image-rocm-3-5": "RELATED_IMAGE_ODH_TH06_ROCM64_TORCH291_PY312_IMAGE",
+		"odh-training-universal-workbench-image-cpu-3-5":  "RELATED_IMAGE_ODH_TH06_CPU_TORCH210_PY312_IMAGE",
 	}
 
 	conditionTypes = []string{


### PR DESCRIPTION
## Summary
- Update `imageParamMap` in `trainer_support.go` to use `*-3-5` keys instead of `*-3-4` for the universal workbench ImageStream entries
- The 3.4 ImageStream tags are now hardcoded with `registry.redhat.io` SHA-pinned references in the trainer manifests (see opendatahub-io/trainer#174)
- The operator's dynamic replacement should target the 3.5 ImageStream tags instead

## Test plan
- [ ] Verify 3.5 ImageStream tags get dynamically replaced with `registry.redhat.io` images
- [ ] Verify 3.4 ImageStream tags retain their hardcoded `registry.redhat.io` values

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated training infrastructure component versions from 3-4 to 3-5 for enhanced compatibility across CUDA, ROCm, and CPU environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->