### PR TITLE
Added remediation dry-run  and 9 single-failure scenarios.

### DIFF
--- a/cmd/mcp-server/prompts/diagnostic.md
+++ b/cmd/mcp-server/prompts/diagnostic.md
@@ -155,9 +155,21 @@ high — all health checks passed, no warning events detected
 - <component 2>: <status, if cascading failure>
 
 ### Remediation
-1. <specific actionable step 1>
-2. <specific actionable step 2>
-3. <specific actionable step 3>
+
+> **Dry-run plan — commands below have NOT been executed. Review each command before running.**
+
+```bash
+# Step 1: <what this command does>
+oc <exact command using real resource names/namespaces from evidence>
+
+# Step 2: <what this command does>
+oc <exact command>
+
+# Step 3: Verify the fix
+oc <command to confirm the issue is resolved>
+```
+
+**Why:** <1-sentence explanation of why these commands fix the root cause>
 
 ### Confidence
 <high | medium | low> — <brief justification for the confidence level>
@@ -233,7 +245,7 @@ high — all health checks passed, no warning events detected
 3. **Always start with Step 1 (Triage)**. Never jump to pod logs or component details without first understanding the overall state.
 4. **Check dependencies before blaming a component**. A KServe failure caused by missing cert-manager should be diagnosed as a cert-manager issue, not a KServe issue.
 5. **Never guess**. Every claim in your diagnosis must be backed by evidence from a tool call.
-6. **Be specific in remediation**. "Check the logs" is not helpful. "Run `kubectl logs -n opendatahub deployment/odh-dashboard` to check for startup errors" is helpful.
+6. **Generate exact remediation commands**. Every remediation step must be a copy-pasteable `oc` or `kubectl` command using real resource names, namespaces, and values extracted from tool evidence — never use placeholders like `<pod-name>` or `<namespace>`. Always present commands inside the fenced `bash` block shown in the Remediation output format, with the dry-run disclaimer. Always include a final verification command (e.g., `oc get pods -n ... -w`) so the user can confirm the fix worked.
 7. **Report healthy clusters as healthy**. Do not investigate further or speculate about potential issues when all checks pass.
 8. **Use the error code reference**. When classify_failure returns a code, use the reference table to guide your investigation and remediation.
 9. **Cross-reference events with current state**. Events persist after resources are deleted. Before reporting an event as an active issue, verify the referenced pod/deployment still exists and the component is not set to `Removed` in the DSC.

--- a/cmd/mcp-server/scenarios/container-oom-ground-truth.json
+++ b/cmd/mcp-server/scenarios/container-oom-ground-truth.json
@@ -1,0 +1,29 @@
+{
+  "scenario_id": "container-oom",
+  "scenario_name": "Container OOMKilled",
+  "description": "Dashboard container killed by kernel OOM killer after exceeding its memory limit, causing pod restarts",
+  "root_cause": "Container odh-dashboard exceeded its memory limit and was OOMKilled by the kernel",
+  "expected_classification": {
+    "category": "infrastructure",
+    "subcategory": "pod-startup",
+    "error_code": 1002,
+    "confidence": "medium"
+  },
+  "expected_tool_outputs": {
+    "platform_health": {
+      "healthy": false
+    }
+  },
+  "expected_symptoms": [
+    "Container terminated with OOMKilled reason",
+    "Pod restart count increasing",
+    "Deployment shows reduced ready replicas"
+  ],
+  "tools_that_detect": [
+    "classify_failure",
+    "platform_health",
+    "pod_logs",
+    "recent_events"
+  ],
+  "expected_remediation": "Increase memory limits on the odh-dashboard container or investigate the memory leak causing excessive consumption"
+}

--- a/cmd/mcp-server/scenarios/container-oom-setup.sh
+++ b/cmd/mcp-server/scenarios/container-oom-setup.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/common.sh"
+
+require_tools oc jq
+
+APPS_NS=$(discover_apps_namespace)
+OPERATOR_NS=$(discover_operator_namespace)
+OPERATOR_DEPLOY="opendatahub-operator-controller-manager"
+DEPLOYMENT="odh-dashboard"
+
+log_step "=== Scenario 11: Container OOMKilled — Setup ==="
+
+# Scale down the ODH operator so it doesn't revert our resource change
+log_step "Scaling down ODH operator to prevent reconciliation..."
+oc scale deployment "$OPERATOR_DEPLOY" -n "$OPERATOR_NS" --replicas=0
+sleep 5
+
+# Backup original deployment
+backup_resource deployment "$DEPLOYMENT" "$APPS_NS" "$BACKUP_DIR/11-${DEPLOYMENT}.json"
+
+# Patch dashboard container memory request and limit to 1Mi to trigger OOMKill
+log_step "Patching $DEPLOYMENT memory request+limit to 1Mi to trigger OOMKill..."
+oc patch deployment "$DEPLOYMENT" -n "$APPS_NS" --type=json \
+  -p '[{"op":"replace","path":"/spec/template/spec/containers/0/resources/requests/memory","value":"1Mi"},{"op":"replace","path":"/spec/template/spec/containers/0/resources/limits/memory","value":"1Mi"}]'
+
+# Wait for OOMKilled
+log_step "Waiting for container to be OOMKilled..."
+elapsed=0
+while (( elapsed < 120 )); do
+  terminated_reason=$(oc get pods -n "$APPS_NS" -l app=odh-dashboard \
+    -o jsonpath='{.items[0].status.containerStatuses[?(@.name=="odh-dashboard")].lastState.terminated.reason}' 2>/dev/null || echo "")
+  if [[ "$terminated_reason" == "OOMKilled" ]]; then
+    log_step "Container was OOMKilled."
+    break
+  fi
+  sleep 5
+  (( elapsed += 5 ))
+done
+
+if [[ "$terminated_reason" != "OOMKilled" ]]; then
+  log_step "WARN: Container was not OOMKilled within timeout (current: $terminated_reason)"
+fi
+
+log_step "Container OOM failure injected."
+log_step "Run MCP tools to validate, then run container-oom-teardown.sh to restore."

--- a/cmd/mcp-server/scenarios/container-oom-teardown.sh
+++ b/cmd/mcp-server/scenarios/container-oom-teardown.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/common.sh"
+
+require_tools oc
+
+APPS_NS=$(discover_apps_namespace)
+OPERATOR_NS=$(discover_operator_namespace)
+OPERATOR_DEPLOY="opendatahub-operator-controller-manager"
+
+log_step "=== Scenario 11: Container OOMKilled — Teardown ==="
+
+# Scale operator back up — it will reconcile and restore the deployment
+log_step "Scaling $OPERATOR_DEPLOY back to 3 replicas..."
+oc scale deployment "$OPERATOR_DEPLOY" -n "$OPERATOR_NS" --replicas=3
+
+wait_for_deployment_ready "$OPERATOR_NS" "$OPERATOR_DEPLOY" "180s"
+wait_for_deployment_ready "$APPS_NS" "odh-dashboard" "180s"
+
+log_step "Operator and dashboard restored. Scenario 11 teardown complete."

--- a/cmd/mcp-server/scenarios/crashloop-exit-code-ground-truth.json
+++ b/cmd/mcp-server/scenarios/crashloop-exit-code-ground-truth.json
@@ -1,0 +1,31 @@
+{
+  "scenario_id": "crashloop-exit-code",
+  "scenario_name": "CrashLoop Exit Code",
+  "description": "Dashboard container command replaced with /bin/false, causing immediate exit with code 1 and CrashLoopBackOff. Based on RHOAIENG-62502 where kserve-container crashed with exit code 127 in RawDeployment mode.",
+  "root_cause": "Container odh-dashboard exits immediately with non-zero exit code due to invalid command, entering CrashLoopBackOff",
+  "expected_classification": {
+    "category": "infrastructure",
+    "subcategory": "pod-startup",
+    "error_code": 1002,
+    "confidence": "medium"
+  },
+  "expected_tool_outputs": {
+    "platform_health": {
+      "healthy": false
+    }
+  },
+  "expected_symptoms": [
+    "Container terminated with exit code 1",
+    "Pod in CrashLoopBackOff state",
+    "Pod restart count increasing rapidly",
+    "Deployment shows reduced ready replicas"
+  ],
+  "tools_that_detect": [
+    "classify_failure",
+    "platform_health",
+    "pod_logs",
+    "recent_events",
+    "describe_resource"
+  ],
+  "expected_remediation": "Restore the correct container command for odh-dashboard or fix the binary/entrypoint causing the non-zero exit"
+}

--- a/cmd/mcp-server/scenarios/crashloop-exit-code-setup.sh
+++ b/cmd/mcp-server/scenarios/crashloop-exit-code-setup.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/common.sh"
+
+require_tools oc jq
+
+APPS_NS=$(discover_apps_namespace)
+OPERATOR_NS=$(discover_operator_namespace)
+OPERATOR_DEPLOY="opendatahub-operator-controller-manager"
+DEPLOYMENT="odh-dashboard"
+CONTAINER="odh-dashboard"
+
+log_step "=== Scenario 15: CrashLoop Exit Code — Setup ==="
+
+# Scale down the ODH operator so it doesn't revert our change
+log_step "Scaling down ODH operator to prevent reconciliation..."
+oc scale deployment "$OPERATOR_DEPLOY" -n "$OPERATOR_NS" --replicas=0
+sleep 5
+
+# Backup original deployment
+backup_resource deployment "$DEPLOYMENT" "$APPS_NS" "$BACKUP_DIR/15-${DEPLOYMENT}.json"
+
+# Patch dashboard container command to /bin/false (exits immediately with code 1)
+log_step "Patching $DEPLOYMENT container command to /bin/false..."
+oc patch deployment "$DEPLOYMENT" -n "$APPS_NS" --type=json \
+  -p '[{"op":"add","path":"/spec/template/spec/containers/0/command","value":["/bin/false"]}]'
+
+# Wait for CrashLoopBackOff
+log_step "Waiting for container to enter CrashLoopBackOff..."
+elapsed=0
+while (( elapsed < 120 )); do
+  waiting_reason=$(oc get pods -n "$APPS_NS" -l app=odh-dashboard \
+    -o jsonpath='{.items[0].status.containerStatuses[?(@.name=="'"$CONTAINER"'")].state.waiting.reason}' 2>/dev/null || echo "")
+  if [[ "$waiting_reason" == "CrashLoopBackOff" ]]; then
+    log_step "Container is in CrashLoopBackOff."
+    break
+  fi
+  sleep 5
+  (( elapsed += 5 ))
+done
+
+if [[ "$waiting_reason" != "CrashLoopBackOff" ]]; then
+  log_step "WARN: Container did not enter CrashLoopBackOff within timeout (current: $waiting_reason)"
+fi
+
+log_step "CrashLoop exit code failure injected."
+log_step "Run MCP tools to validate, then run crashloop-exit-code-teardown.sh to restore."

--- a/cmd/mcp-server/scenarios/crashloop-exit-code-teardown.sh
+++ b/cmd/mcp-server/scenarios/crashloop-exit-code-teardown.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/common.sh"
+
+require_tools oc
+
+APPS_NS=$(discover_apps_namespace)
+OPERATOR_NS=$(discover_operator_namespace)
+OPERATOR_DEPLOY="opendatahub-operator-controller-manager"
+DEPLOYMENT="odh-dashboard"
+
+log_step "=== Scenario 15: CrashLoop Exit Code — Teardown ==="
+
+# Ensure operator is always restored even if rollback fails
+trap 'oc scale deployment "$OPERATOR_DEPLOY" -n "$OPERATOR_NS" --replicas=3 2>/dev/null || true' EXIT
+
+# Rollback the deployment to restore original command
+log_step "Rolling back $DEPLOYMENT deployment..."
+oc rollout undo deployment/"$DEPLOYMENT" -n "$APPS_NS"
+
+# Scale operator back up
+log_step "Scaling $OPERATOR_DEPLOY back to 3 replicas..."
+oc scale deployment "$OPERATOR_DEPLOY" -n "$OPERATOR_NS" --replicas=3
+
+trap - EXIT
+
+wait_for_deployment_ready "$OPERATOR_NS" "$OPERATOR_DEPLOY" "180s"
+wait_for_deployment_ready "$APPS_NS" "$DEPLOYMENT" "180s"
+
+log_step "Operator and dashboard restored. Scenario 15 teardown complete."

--- a/cmd/mcp-server/scenarios/invalid-cli-flag-ground-truth.json
+++ b/cmd/mcp-server/scenarios/invalid-cli-flag-ground-truth.json
@@ -1,0 +1,31 @@
+{
+  "scenario_id": "invalid-cli-flag",
+  "scenario_name": "Invalid CLI Flag",
+  "description": "Component container args patched with an undefined CLI flag, causing immediate exit on startup with CrashLoopBackOff.",
+  "root_cause": "Container starts but exits immediately because of an undefined CLI flag in the container args",
+  "expected_classification": {
+    "category": "infrastructure",
+    "subcategory": "pod-startup",
+    "error_code": 1002,
+    "confidence": "medium"
+  },
+  "expected_tool_outputs": {
+    "platform_health": {
+      "healthy": false
+    }
+  },
+  "expected_symptoms": [
+    "Container terminated with non-zero exit code",
+    "Pod in CrashLoopBackOff state",
+    "Pod logs show 'flag provided but not defined' error",
+    "Deployment shows reduced ready replicas"
+  ],
+  "tools_that_detect": [
+    "classify_failure",
+    "platform_health",
+    "pod_logs",
+    "recent_events",
+    "describe_resource"
+  ],
+  "expected_remediation": "Remove the invalid CLI flag from the container args in the deployment spec"
+}

--- a/cmd/mcp-server/scenarios/invalid-cli-flag-setup.sh
+++ b/cmd/mcp-server/scenarios/invalid-cli-flag-setup.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/common.sh"
+
+require_tools oc jq
+
+APPS_NS=$(discover_apps_namespace)
+OPERATOR_NS=$(discover_operator_namespace)
+OPERATOR_DEPLOY="opendatahub-operator-controller-manager"
+DEPLOYMENT="odh-dashboard"
+CONTAINER="odh-dashboard"
+
+log_step "=== Scenario 16: Invalid CLI Flag — Setup ==="
+
+# Scale down the ODH operator so it doesn't revert our change
+log_step "Scaling down ODH operator to prevent reconciliation..."
+oc scale deployment "$OPERATOR_DEPLOY" -n "$OPERATOR_NS" --replicas=0
+sleep 5
+
+# Backup original deployment
+backup_resource deployment "$DEPLOYMENT" "$APPS_NS" "$BACKUP_DIR/16-${DEPLOYMENT}.json"
+
+# Find the index of the target container
+CONTAINER_INDEX=$(oc get deployment "$DEPLOYMENT" -n "$APPS_NS" -o json | \
+  jq '.spec.template.spec.containers | to_entries[] | select(.value.name == "'"$CONTAINER"'") | .key')
+
+if [[ -z "$CONTAINER_INDEX" ]]; then
+  log_step "ERROR: Could not find container $CONTAINER in $DEPLOYMENT"
+  exit 1
+fi
+
+# Patch container args to include an undefined flag
+log_step "Patching $DEPLOYMENT/$CONTAINER (index $CONTAINER_INDEX) args with undefined flag --enable-cert-reload..."
+oc patch deployment "$DEPLOYMENT" -n "$APPS_NS" --type=json \
+  -p '[{"op":"add","path":"/spec/template/spec/containers/'"$CONTAINER_INDEX"'/args","value":["--enable-cert-reload"]}]'
+
+# Wait for CrashLoopBackOff
+log_step "Waiting for container to enter CrashLoopBackOff..."
+elapsed=0
+while (( elapsed < 120 )); do
+  waiting_reason=$(oc get pods -n "$APPS_NS" -l app=odh-dashboard \
+    -o jsonpath='{range .items[*]}{.status.containerStatuses[?(@.name=="'"$CONTAINER"'")].state.waiting.reason}{"\n"}{end}' 2>/dev/null || echo "")
+  if echo "$waiting_reason" | grep -q "CrashLoopBackOff"; then
+    log_step "Container is in CrashLoopBackOff."
+    break
+  fi
+  sleep 5
+  (( elapsed += 5 ))
+done
+
+if ! echo "$waiting_reason" | grep -q "CrashLoopBackOff"; then
+  log_step "WARN: Container did not enter CrashLoopBackOff within timeout (current: $waiting_reason)"
+fi
+
+log_step "Invalid CLI flag failure injected."
+log_step "Run MCP tools to validate, then run invalid-cli-flag-teardown.sh to restore."

--- a/cmd/mcp-server/scenarios/invalid-cli-flag-teardown.sh
+++ b/cmd/mcp-server/scenarios/invalid-cli-flag-teardown.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/common.sh"
+
+require_tools oc
+
+APPS_NS=$(discover_apps_namespace)
+OPERATOR_NS=$(discover_operator_namespace)
+OPERATOR_DEPLOY="opendatahub-operator-controller-manager"
+DEPLOYMENT="odh-dashboard"
+
+log_step "=== Scenario 16: Invalid CLI Flag — Teardown ==="
+
+# Ensure operator is always restored even if rollback fails
+trap 'oc scale deployment "$OPERATOR_DEPLOY" -n "$OPERATOR_NS" --replicas=3 2>/dev/null || true' EXIT
+
+# Rollback the deployment to restore original args
+log_step "Rolling back $DEPLOYMENT deployment..."
+oc rollout undo deployment/"$DEPLOYMENT" -n "$APPS_NS"
+
+# Scale operator back up
+log_step "Scaling $OPERATOR_DEPLOY back to 3 replicas..."
+oc scale deployment "$OPERATOR_DEPLOY" -n "$OPERATOR_NS" --replicas=3
+
+trap - EXIT
+
+wait_for_deployment_ready "$OPERATOR_NS" "$OPERATOR_DEPLOY" "180s"
+wait_for_deployment_ready "$APPS_NS" "$DEPLOYMENT" "180s"
+
+log_step "Operator and dashboard restored. Scenario 16 teardown complete."

--- a/cmd/mcp-server/scenarios/network-not-ready-ground-truth.json
+++ b/cmd/mcp-server/scenarios/network-not-ready-ground-truth.json
@@ -1,0 +1,28 @@
+{
+  "scenario_id": "network-not-ready",
+  "scenario_name": "Network Not Ready",
+  "description": "Worker node patched with NetworkUnavailable=True condition, simulating a node with broken network connectivity",
+  "root_cause": "Worker node reporting NetworkUnavailable condition as True, preventing pod networking",
+  "expected_classification": {
+    "category": "infrastructure",
+    "subcategory": "node-pressure",
+    "error_code": 1005,
+    "confidence": "high"
+  },
+  "expected_tool_outputs": {
+    "platform_health": {
+      "healthy": false
+    }
+  },
+  "expected_symptoms": [
+    "Node has NetworkUnavailable=True condition",
+    "Events show NetworkNotReady reason",
+    "Pods on affected node may become unready"
+  ],
+  "tools_that_detect": [
+    "classify_failure",
+    "platform_health",
+    "recent_events"
+  ],
+  "expected_remediation": "Investigate and restore network connectivity on the affected node; check CNI plugin pods and node network configuration"
+}

--- a/cmd/mcp-server/scenarios/network-not-ready-setup.sh
+++ b/cmd/mcp-server/scenarios/network-not-ready-setup.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/common.sh"
+
+require_tools oc jq
+
+STATE_DIR="${XDG_RUNTIME_DIR:-/tmp}/odh-mcp-scenarios-${UID}"
+mkdir -p "$STATE_DIR"
+chmod 700 "$STATE_DIR"
+
+log_step "=== Scenario 13: Network Not Ready — Setup ==="
+
+# Select a worker node
+WORKER_NODE=$(oc get nodes -l node-role.kubernetes.io/worker -o jsonpath='{.items[0].metadata.name}' 2>/dev/null)
+if [[ -z "$WORKER_NODE" ]]; then
+  log_step "ERROR: No worker node found"
+  exit 1
+fi
+log_step "Selected worker node: $WORKER_NODE"
+printf '%s\n' "$WORKER_NODE" > "$STATE_DIR/odh-network-not-ready-node"
+
+# Backup node
+backup_resource node "$WORKER_NODE" "" "$BACKUP_DIR/13-${WORKER_NODE}.json"
+
+# Patch node status to add NetworkUnavailable=True condition.
+# Kubelet resets conditions periodically, so we run a background patcher.
+log_step "Patching $WORKER_NODE with NetworkUnavailable=True (background patcher)..."
+
+(
+  while true; do
+    oc patch node "$WORKER_NODE" --type=strategic --subresource=status -p '{
+      "status": {
+        "conditions": [
+          {
+            "type": "NetworkUnavailable",
+            "status": "True",
+            "reason": "NetworkNotReady",
+            "message": "Scenario 13: simulated network failure",
+            "lastHeartbeatTime": "'"$(date -u +%Y-%m-%dT%H:%M:%SZ)"'",
+            "lastTransitionTime": "'"$(date -u +%Y-%m-%dT%H:%M:%SZ)"'"
+          }
+        ]
+      }
+    }' 2>/dev/null || true
+    sleep 10
+  done
+) &
+
+PATCHER_PID=$!
+printf '%s\n' "$PATCHER_PID" > "$STATE_DIR/odh-network-not-ready-pid"
+log_step "Background patcher PID: $PATCHER_PID"
+
+# Wait for the condition to appear
+sleep 5
+condition=$(oc get node "$WORKER_NODE" -o jsonpath='{.status.conditions[?(@.type=="NetworkUnavailable")].status}' 2>/dev/null || echo "")
+if [[ "$condition" == "True" ]]; then
+  log_step "NetworkUnavailable=True condition set on $WORKER_NODE."
+else
+  log_step "WARN: NetworkUnavailable condition not detected (current: $condition)"
+fi
+
+log_step "Network not ready failure injected."
+log_step "Run MCP tools to validate, then run network-not-ready-teardown.sh to restore."

--- a/cmd/mcp-server/scenarios/network-not-ready-teardown.sh
+++ b/cmd/mcp-server/scenarios/network-not-ready-teardown.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/common.sh"
+
+require_tools oc
+
+STATE_DIR="${XDG_RUNTIME_DIR:-/tmp}/odh-mcp-scenarios-${UID}"
+
+log_step "=== Scenario 13: Network Not Ready — Teardown ==="
+
+# Kill the background patcher
+PID_FILE="$STATE_DIR/odh-network-not-ready-pid"
+if [[ -f "$PID_FILE" ]]; then
+  PATCHER_PID=$(cat "$PID_FILE")
+  if kill -0 "$PATCHER_PID" 2>/dev/null; then
+    log_step "Killing background patcher (PID $PATCHER_PID)..."
+    kill "$PATCHER_PID" 2>/dev/null || true
+  fi
+  rm -f "$PID_FILE"
+fi
+
+# Kubelet does NOT auto-clear NetworkUnavailable (unlike MemoryPressure),
+# so we must patch it back to False manually.
+NODE_FILE="$STATE_DIR/odh-network-not-ready-node"
+if [[ -f "$NODE_FILE" ]]; then
+  WORKER_NODE=$(cat "$NODE_FILE")
+  log_step "Patching NetworkUnavailable=False on $WORKER_NODE..."
+  oc patch node "$WORKER_NODE" --type=strategic --subresource=status -p '{
+    "status": {
+      "conditions": [
+        {
+          "type": "NetworkUnavailable",
+          "status": "False",
+          "reason": "NetworkReady",
+          "message": "Scenario 13 teardown: network restored",
+          "lastHeartbeatTime": "'"$(date -u +%Y-%m-%dT%H:%M:%SZ)"'",
+          "lastTransitionTime": "'"$(date -u +%Y-%m-%dT%H:%M:%SZ)"'"
+        }
+      ]
+    }
+  }'
+  log_step "NetworkUnavailable condition cleared on $WORKER_NODE."
+  rm -f "$NODE_FILE"
+fi
+
+log_step "Network restored. Scenario 13 teardown complete."

--- a/cmd/mcp-server/scenarios/panic-crash-ground-truth.json
+++ b/cmd/mcp-server/scenarios/panic-crash-ground-truth.json
@@ -1,0 +1,30 @@
+{
+  "scenario_id": "panic-crash",
+  "scenario_name": "Panic Crash",
+  "description": "Component container command replaced to trigger a panic-like crash on startup, producing a stack trace in logs and CrashLoopBackOff. Based on troubleshooting.md 'Panic or Fatal Errors' pattern (line 197).",
+  "root_cause": "Container crashes on startup with a fatal error or panic, producing a stack trace in logs before exiting",
+  "expected_classification": {
+    "category": "infrastructure",
+    "subcategory": "pod-startup",
+    "error_code": 1002,
+    "confidence": "medium"
+  },
+  "expected_tool_outputs": {
+    "platform_health": {
+      "healthy": false
+    }
+  },
+  "expected_symptoms": [
+    "Pod in CrashLoopBackOff state",
+    "Pod logs show panic/fatal error with stack trace",
+    "Container terminated with non-zero exit code",
+    "Deployment shows reduced ready replicas"
+  ],
+  "tools_that_detect": [
+    "classify_failure",
+    "platform_health",
+    "pod_logs",
+    "recent_events"
+  ],
+  "expected_remediation": "Check pod logs for the panic stack trace to identify the root cause; fix the code or configuration triggering the panic"
+}

--- a/cmd/mcp-server/scenarios/panic-crash-setup.sh
+++ b/cmd/mcp-server/scenarios/panic-crash-setup.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/common.sh"
+
+require_tools oc jq
+
+APPS_NS=$(discover_apps_namespace)
+OPERATOR_NS=$(discover_operator_namespace)
+OPERATOR_DEPLOY="opendatahub-operator-controller-manager"
+DEPLOYMENT="feast-operator-controller-manager"
+CONTAINER="manager"
+
+log_step "=== Scenario 18: Panic Crash — Setup ==="
+
+# Scale down the ODH operator so it doesn't revert our change
+log_step "Scaling down ODH operator to prevent reconciliation..."
+oc scale deployment "$OPERATOR_DEPLOY" -n "$OPERATOR_NS" --replicas=0
+sleep 5
+
+# Backup original deployment
+backup_resource deployment "$DEPLOYMENT" "$APPS_NS" "$BACKUP_DIR/18-${DEPLOYMENT}.json"
+
+# Find the index of the target container
+CONTAINER_INDEX=$(oc get deployment "$DEPLOYMENT" -n "$APPS_NS" -o json | \
+  jq '.spec.template.spec.containers | to_entries[] | select(.value.name == "'"$CONTAINER"'") | .key')
+
+if [[ -z "$CONTAINER_INDEX" ]]; then
+  log_step "ERROR: Could not find container $CONTAINER in $DEPLOYMENT"
+  exit 1
+fi
+
+# Patch container command to a script that prints a fake panic stack trace then exits
+log_step "Patching $DEPLOYMENT/$CONTAINER (index $CONTAINER_INDEX) to crash with panic-like output..."
+oc patch deployment "$DEPLOYMENT" -n "$APPS_NS" --type=json \
+  -p '[{"op":"add","path":"/spec/template/spec/containers/'"$CONTAINER_INDEX"'/command","value":["sh","-c","echo \"panic: runtime error: invalid memory address or nil pointer dereference\" >&2; echo \"[signal SIGSEGV: segmentation violation]\" >&2; echo \"\" >&2; echo \"goroutine 1 [running]:\" >&2; echo \"main.main()\" >&2; echo \"  /workspace/cmd/main.go:105 +0x1a4\" >&2; exit 2"]}]'
+
+# Wait for CrashLoopBackOff
+log_step "Waiting for container to enter CrashLoopBackOff..."
+elapsed=0
+while (( elapsed < 120 )); do
+  waiting_reason=$(oc get pods -n "$APPS_NS" -l control-plane=controller-manager,app.kubernetes.io/name=feast-operator \
+    -o jsonpath='{range .items[*]}{.status.containerStatuses[?(@.name=="'"$CONTAINER"'")].state.waiting.reason}{"\n"}{end}' 2>/dev/null || echo "")
+  if echo "$waiting_reason" | grep -q "CrashLoopBackOff"; then
+    log_step "Container is in CrashLoopBackOff."
+    break
+  fi
+  sleep 5
+  (( elapsed += 5 ))
+done
+
+if ! echo "$waiting_reason" | grep -q "CrashLoopBackOff"; then
+  log_step "WARN: Container did not enter CrashLoopBackOff within timeout (current: $waiting_reason)"
+fi
+
+log_step "Panic crash failure injected."
+log_step "Run MCP tools to validate, then run panic-crash-teardown.sh to restore."

--- a/cmd/mcp-server/scenarios/panic-crash-teardown.sh
+++ b/cmd/mcp-server/scenarios/panic-crash-teardown.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/common.sh"
+
+require_tools oc
+
+APPS_NS=$(discover_apps_namespace)
+OPERATOR_NS=$(discover_operator_namespace)
+OPERATOR_DEPLOY="opendatahub-operator-controller-manager"
+DEPLOYMENT="feast-operator-controller-manager"
+
+log_step "=== Scenario 18: Panic Crash — Teardown ==="
+
+# Delete the deployment so the operator recreates it with the correct spec
+log_step "Deleting $DEPLOYMENT so operator can recreate it..."
+oc delete deployment "$DEPLOYMENT" -n "$APPS_NS" --ignore-not-found
+
+# Scale operator back up
+log_step "Scaling $OPERATOR_DEPLOY back to 3 replicas..."
+oc scale deployment "$OPERATOR_DEPLOY" -n "$OPERATOR_NS" --replicas=3
+
+wait_for_deployment_ready "$OPERATOR_NS" "$OPERATOR_DEPLOY" "180s"
+
+# Wait for operator to recreate the deployment
+log_step "Waiting for operator to recreate $DEPLOYMENT..."
+elapsed=0
+while (( elapsed < 180 )); do
+  ready=$(oc get deployment "$DEPLOYMENT" -n "$APPS_NS" -o jsonpath='{.status.readyReplicas}' 2>/dev/null || echo "0")
+  if (( ready > 0 )); then
+    log_step "$DEPLOYMENT is ready ($ready replicas)."
+    break
+  fi
+  sleep 5
+  (( elapsed += 5 ))
+done
+
+if (( ready == 0 )); then
+  log_step "WARN: $DEPLOYMENT did not become ready within timeout."
+fi
+
+log_step "Operator and component restored. Scenario 18 teardown complete."

--- a/cmd/mcp-server/scenarios/quota-exceeded-realistic-ground-truth.json
+++ b/cmd/mcp-server/scenarios/quota-exceeded-realistic-ground-truth.json
@@ -1,0 +1,29 @@
+{
+  "scenario_id": "quota-exceeded-realistic",
+  "scenario_name": "Quota Exceeded Realistic",
+  "description": "A realistic ResourceQuota is applied that is just below the cumulative resource usage, so new pods cannot be created when a rollout is triggered. Based on RHOAIENG-51369 where ArgoCD controller could not start because cumulative memory requests exceeded the namespace quota.",
+  "root_cause": "ResourceQuota memory limit is set just below the total memory requested by existing pods, so new pods fail quota admission",
+  "expected_classification": {
+    "category": "infrastructure",
+    "subcategory": "quota-oom",
+    "error_code": 1004,
+    "confidence": "high"
+  },
+  "expected_tool_outputs": {
+    "platform_health": {
+      "healthy": false
+    }
+  },
+  "expected_symptoms": [
+    "Events show FailedCreate with 'exceeded quota' message",
+    "New pods cannot be created by ReplicaSet",
+    "Deployment shows fewer ready replicas than desired",
+    "ResourceQuota shows usage near or at hard limit"
+  ],
+  "tools_that_detect": [
+    "classify_failure",
+    "platform_health",
+    "recent_events"
+  ],
+  "expected_remediation": "Increase the ResourceQuota memory limit or reduce resource requests on existing pods to free headroom for new pods"
+}

--- a/cmd/mcp-server/scenarios/quota-exceeded-realistic-setup.sh
+++ b/cmd/mcp-server/scenarios/quota-exceeded-realistic-setup.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/common.sh"
+
+require_tools oc jq
+
+APPS_NS=$(discover_apps_namespace)
+OPERATOR_NS=$(discover_operator_namespace)
+OPERATOR_DEPLOY="opendatahub-operator-controller-manager"
+DEPLOYMENT="odh-dashboard"
+QUOTA_NAME="scenario-tight-quota"
+
+log_step "=== Scenario 14: Quota Exceeded Realistic — Setup ==="
+
+# Calculate current total memory requests in the namespace
+TOTAL_MEM_BYTES=$(oc get pods -n "$APPS_NS" -o json 2>/dev/null | jq '
+  [.items[] | select(.status.phase == "Running") |
+   .spec.containers[].resources.requests.memory // "0" |
+   if endswith("Gi") then (rtrimstr("Gi") | tonumber * 1073741824)
+   elif endswith("Mi") then (rtrimstr("Mi") | tonumber * 1048576)
+   elif endswith("Ki") then (rtrimstr("Ki") | tonumber * 1024)
+   else tonumber end
+  ] | add // 0')
+
+# Set quota to 80% of current usage so new pods can't fit
+QUOTA_MEM_BYTES=$(( TOTAL_MEM_BYTES * 80 / 100 ))
+QUOTA_MEM_MI=$(( QUOTA_MEM_BYTES / 1048576 ))
+
+log_step "Current namespace memory requests: $(( TOTAL_MEM_BYTES / 1048576 ))Mi"
+log_step "Setting quota to ${QUOTA_MEM_MI}Mi (80% of current usage)"
+
+# Scale down the ODH operator so it doesn't interfere
+log_step "Scaling down ODH operator to prevent reconciliation..."
+oc scale deployment "$OPERATOR_DEPLOY" -n "$OPERATOR_NS" --replicas=0
+sleep 5
+
+# Apply tight quota
+log_step "Applying tight ResourceQuota to $APPS_NS..."
+cat <<EOF | oc apply -f -
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: $QUOTA_NAME
+  namespace: $APPS_NS
+spec:
+  hard:
+    requests.memory: "${QUOTA_MEM_MI}Mi"
+    limits.memory: "${QUOTA_MEM_MI}Mi"
+EOF
+
+# Trigger a pod restart so new pods hit the quota
+log_step "Deleting a $DEPLOYMENT pod to trigger reschedule against quota..."
+oc delete pod -l app=odh-dashboard -n "$APPS_NS" --wait=false
+
+# Wait for FailedCreate events
+log_step "Waiting for FailedCreate events..."
+elapsed=0
+events=0
+while (( elapsed < 90 )); do
+  events=$(oc get events -n "$APPS_NS" --field-selector reason=FailedCreate --no-headers 2>/dev/null | wc -l || echo "0")
+  events=$((events))
+  if (( events > 0 )); then
+    log_step "FailedCreate events detected ($events found)."
+    break
+  fi
+  sleep 5
+  (( elapsed += 5 ))
+done
+
+if (( events == 0 )); then
+  log_step "WARN: No FailedCreate events detected within timeout."
+fi
+
+log_step "Quota exceeded failure injected."
+log_step "Run MCP tools to validate, then run quota-exceeded-realistic-teardown.sh to restore."

--- a/cmd/mcp-server/scenarios/quota-exceeded-realistic-teardown.sh
+++ b/cmd/mcp-server/scenarios/quota-exceeded-realistic-teardown.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/common.sh"
+
+require_tools oc
+
+APPS_NS=$(discover_apps_namespace)
+OPERATOR_NS=$(discover_operator_namespace)
+OPERATOR_DEPLOY="opendatahub-operator-controller-manager"
+QUOTA_NAME="scenario-tight-quota"
+
+log_step "=== Scenario 14: Quota Exceeded Realistic — Teardown ==="
+
+# Delete the restrictive quota
+log_step "Deleting ResourceQuota $QUOTA_NAME from $APPS_NS..."
+oc delete resourcequota "$QUOTA_NAME" -n "$APPS_NS" --ignore-not-found
+
+# Scale operator back up
+log_step "Scaling $OPERATOR_DEPLOY back to 3 replicas..."
+oc scale deployment "$OPERATOR_DEPLOY" -n "$OPERATOR_NS" --replicas=3
+
+wait_for_deployment_ready "$OPERATOR_NS" "$OPERATOR_DEPLOY" "180s"
+
+log_step "Quota removed and operator restored. Scenario 14 teardown complete."

--- a/cmd/mcp-server/scenarios/sidecar-crash-ground-truth.json
+++ b/cmd/mcp-server/scenarios/sidecar-crash-ground-truth.json
@@ -1,0 +1,32 @@
+{
+  "scenario_id": "sidecar-crash",
+  "scenario_name": "Sidecar Container Crash",
+  "description": "Sidecar container (kube-rbac-proxy) in a multi-container pod crashes due to wrong binary/flags while the main container runs fine, causing partial readiness.",
+  "root_cause": "Sidecar container kube-rbac-proxy crashes with invalid flag error while main container continues running, pod shows partial readiness",
+  "expected_classification": {
+    "category": "infrastructure",
+    "subcategory": "pod-startup",
+    "error_code": 1002,
+    "confidence": "medium"
+  },
+  "expected_tool_outputs": {
+    "platform_health": {
+      "healthy": false
+    }
+  },
+  "expected_symptoms": [
+    "Pod shows partial readiness (8/9 Ready instead of 9/9)",
+    "Sidecar container kube-rbac-proxy in CrashLoopBackOff",
+    "Main container odh-dashboard is Running and healthy",
+    "Pod logs for kube-rbac-proxy show 'unknown flag' error",
+    "Events show BackOff for the sidecar container only"
+  ],
+  "tools_that_detect": [
+    "classify_failure",
+    "platform_health",
+    "pod_logs",
+    "recent_events",
+    "describe_resource"
+  ],
+  "expected_remediation": "Fix the kube-rbac-proxy container image or command flags to match the correct binary version"
+}

--- a/cmd/mcp-server/scenarios/sidecar-crash-setup.sh
+++ b/cmd/mcp-server/scenarios/sidecar-crash-setup.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/common.sh"
+
+require_tools oc jq
+
+APPS_NS=$(discover_apps_namespace)
+OPERATOR_NS=$(discover_operator_namespace)
+OPERATOR_DEPLOY="opendatahub-operator-controller-manager"
+DEPLOYMENT="odh-dashboard"
+SIDECAR="kube-rbac-proxy"
+
+log_step "=== Scenario 19: Sidecar Container Crash — Setup ==="
+
+# Scale down the ODH operator so it doesn't revert our change
+log_step "Scaling down ODH operator to prevent reconciliation..."
+oc scale deployment "$OPERATOR_DEPLOY" -n "$OPERATOR_NS" --replicas=0
+sleep 5
+
+# Backup original deployment
+backup_resource deployment "$DEPLOYMENT" "$APPS_NS" "$BACKUP_DIR/19-${DEPLOYMENT}.json"
+
+# Find the index of the kube-rbac-proxy container
+SIDECAR_INDEX=$(oc get deployment "$DEPLOYMENT" -n "$APPS_NS" -o json | \
+  jq '.spec.template.spec.containers | to_entries[] | select(.value.name == "'"$SIDECAR"'") | .key')
+
+if [[ -z "$SIDECAR_INDEX" ]]; then
+  log_step "ERROR: Could not find container $SIDECAR in $DEPLOYMENT"
+  exit 1
+fi
+log_step "Found $SIDECAR at container index $SIDECAR_INDEX"
+
+# Patch the sidecar container command to simulate wrong binary with invalid flag
+log_step "Patching $SIDECAR container with invalid flag --secure-listen-address..."
+oc patch deployment "$DEPLOYMENT" -n "$APPS_NS" --type=json \
+  -p '[{"op":"add","path":"/spec/template/spec/containers/'"$SIDECAR_INDEX"'/command","value":["sh","-c","echo \"flag provided but not defined: -secure-listen-address\" >&2; echo \"Usage of kube-rbac-proxy:\" >&2; exit 1"]}]'
+
+# Wait for CrashLoopBackOff on the sidecar
+log_step "Waiting for $SIDECAR container to enter CrashLoopBackOff..."
+elapsed=0
+while (( elapsed < 120 )); do
+  waiting_reason=$(oc get pods -n "$APPS_NS" -l app=odh-dashboard \
+    -o jsonpath='{range .items[*]}{.status.containerStatuses[?(@.name=="'"$SIDECAR"'")].state.waiting.reason}{"\n"}{end}' 2>/dev/null || echo "")
+  if echo "$waiting_reason" | grep -q "CrashLoopBackOff"; then
+    log_step "$SIDECAR container is in CrashLoopBackOff."
+    break
+  fi
+  sleep 5
+  (( elapsed += 5 ))
+done
+
+if ! echo "$waiting_reason" | grep -q "CrashLoopBackOff"; then
+  log_step "WARN: $SIDECAR did not enter CrashLoopBackOff within timeout (current: $waiting_reason)"
+fi
+
+log_step "Sidecar crash failure injected."
+log_step "Run MCP tools to validate, then run sidecar-crash-teardown.sh to restore."

--- a/cmd/mcp-server/scenarios/sidecar-crash-teardown.sh
+++ b/cmd/mcp-server/scenarios/sidecar-crash-teardown.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/common.sh"
+
+require_tools oc
+
+APPS_NS=$(discover_apps_namespace)
+OPERATOR_NS=$(discover_operator_namespace)
+OPERATOR_DEPLOY="opendatahub-operator-controller-manager"
+DEPLOYMENT="odh-dashboard"
+
+log_step "=== Scenario 19: Sidecar Container Crash — Teardown ==="
+
+# Rollback the deployment to restore original sidecar command
+log_step "Rolling back $DEPLOYMENT deployment..."
+oc rollout undo deployment/"$DEPLOYMENT" -n "$APPS_NS"
+
+# Scale operator back up
+log_step "Scaling $OPERATOR_DEPLOY back to 3 replicas..."
+oc scale deployment "$OPERATOR_DEPLOY" -n "$OPERATOR_NS" --replicas=3
+
+wait_for_deployment_ready "$OPERATOR_NS" "$OPERATOR_DEPLOY" "180s"
+wait_for_deployment_ready "$APPS_NS" "$DEPLOYMENT" "180s"
+
+log_step "Operator and dashboard restored. Scenario 19 teardown complete."

--- a/cmd/mcp-server/scenarios/storage-mount-failure-ground-truth.json
+++ b/cmd/mcp-server/scenarios/storage-mount-failure-ground-truth.json
@@ -1,0 +1,28 @@
+{
+  "scenario_id": "storage-mount-failure",
+  "scenario_name": "Storage Mount Failure",
+  "description": "Deployment patched to reference a nonexistent Secret volume, causing FailedMount events and pods stuck in ContainerCreating",
+  "root_cause": "Deployment references a nonexistent Secret 'scenario-nonexistent-secret' as a volume mount",
+  "expected_classification": {
+    "category": "infrastructure",
+    "subcategory": "storage",
+    "error_code": 1006,
+    "confidence": "medium"
+  },
+  "expected_tool_outputs": {
+    "platform_health": {
+      "healthy": false
+    }
+  },
+  "expected_symptoms": [
+    "Pod stuck in Pending or ContainerCreating state",
+    "Events show FailedMount with message referencing missing Secret",
+    "Deployment shows reduced ready replicas"
+  ],
+  "tools_that_detect": [
+    "classify_failure",
+    "platform_health",
+    "recent_events"
+  ],
+  "expected_remediation": "Remove the nonexistent Secret volume mount from the deployment or create the missing Secret 'scenario-nonexistent-secret'"
+}

--- a/cmd/mcp-server/scenarios/storage-mount-failure-setup.sh
+++ b/cmd/mcp-server/scenarios/storage-mount-failure-setup.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/common.sh"
+
+require_tools oc jq
+
+APPS_NS=$(discover_apps_namespace)
+OPERATOR_NS=$(discover_operator_namespace)
+OPERATOR_DEPLOY="opendatahub-operator-controller-manager"
+DEPLOYMENT="odh-dashboard"
+FAKE_SECRET="scenario-nonexistent-secret"
+
+log_step "=== Scenario 12: Storage Mount Failure — Setup ==="
+
+# Scale down the ODH operator so it doesn't revert our change
+log_step "Scaling down ODH operator to prevent reconciliation..."
+oc scale deployment "$OPERATOR_DEPLOY" -n "$OPERATOR_NS" --replicas=0
+sleep 5
+
+# Backup original deployment
+backup_resource deployment "$DEPLOYMENT" "$APPS_NS" "$BACKUP_DIR/12-${DEPLOYMENT}.json"
+
+# Patch deployment to add a volume referencing a nonexistent secret.
+# Secret volumes cause FailedMount events (unlike PVC volumes which cause FailedScheduling).
+log_step "Patching $DEPLOYMENT to mount nonexistent secret '$FAKE_SECRET'..."
+oc patch deployment "$DEPLOYMENT" -n "$APPS_NS" --type=json -p '[
+  {"op":"add","path":"/spec/template/spec/volumes/-","value":{"name":"fake-vol","secret":{"secretName":"'"$FAKE_SECRET"'"}}},
+  {"op":"add","path":"/spec/template/spec/containers/0/volumeMounts/-","value":{"name":"fake-vol","mountPath":"/mnt/fake"}}
+]'
+
+# Wait for FailedMount events
+log_step "Waiting for FailedMount events..."
+elapsed=0
+while (( elapsed < 120 )); do
+  event_count=$(oc get events -n "$APPS_NS" --field-selector reason=FailedMount --no-headers 2>/dev/null | wc -l || echo "0")
+  event_count=$((event_count))
+  if (( event_count > 0 )); then
+    log_step "FailedMount events detected ($event_count found)."
+    break
+  fi
+  sleep 5
+  (( elapsed += 5 ))
+done
+
+if (( event_count == 0 )); then
+  log_step "WARN: No FailedMount events detected within timeout."
+fi
+
+log_step "Storage mount failure injected."
+log_step "Run MCP tools to validate, then run storage-mount-failure-teardown.sh to restore."

--- a/cmd/mcp-server/scenarios/storage-mount-failure-teardown.sh
+++ b/cmd/mcp-server/scenarios/storage-mount-failure-teardown.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/common.sh"
+
+require_tools oc
+
+APPS_NS=$(discover_apps_namespace)
+OPERATOR_NS=$(discover_operator_namespace)
+OPERATOR_DEPLOY="opendatahub-operator-controller-manager"
+DEPLOYMENT="odh-dashboard"
+
+log_step "=== Scenario 12: Storage Mount Failure — Teardown ==="
+
+# Rollback the deployment to remove the bad volume mount
+log_step "Rolling back $DEPLOYMENT deployment..."
+oc rollout undo deployment/"$DEPLOYMENT" -n "$APPS_NS"
+
+# Scale operator back up — it will reconcile and restore the deployment
+log_step "Scaling $OPERATOR_DEPLOY back to 3 replicas..."
+oc scale deployment "$OPERATOR_DEPLOY" -n "$OPERATOR_NS" --replicas=3
+
+wait_for_deployment_ready "$OPERATOR_NS" "$OPERATOR_DEPLOY" "180s"
+wait_for_deployment_ready "$APPS_NS" "$DEPLOYMENT" "180s"
+
+log_step "Operator and dashboard restored. Scenario 12 teardown complete."

--- a/cmd/mcp-server/scenarios/wrong-image-tag-ground-truth.json
+++ b/cmd/mcp-server/scenarios/wrong-image-tag-ground-truth.json
@@ -1,0 +1,29 @@
+{
+  "scenario_id": "wrong-image-tag",
+  "scenario_name": "Wrong Image Tag",
+  "description": "Dashboard deployment patched to use a valid registry but nonexistent tag, causing ImagePullBackOff. Differs from image-pull-failure scenario which uses a completely nonexistent registry.",
+  "root_cause": "Deployment odh-dashboard using a valid registry (quay.io/opendatahub/odh-dashboard) but nonexistent tag (:v999-does-not-exist)",
+  "expected_classification": {
+    "category": "infrastructure",
+    "subcategory": "image-pull",
+    "error_code": 1001,
+    "confidence": "medium"
+  },
+  "expected_tool_outputs": {
+    "platform_health": {
+      "healthy": false
+    }
+  },
+  "expected_symptoms": [
+    "Pod in ImagePullBackOff or ErrImagePull state",
+    "Warning events with 'manifest unknown' or 'not found' error from registry",
+    "Deployment shows reduced ready replicas"
+  ],
+  "tools_that_detect": [
+    "classify_failure",
+    "platform_health",
+    "recent_events",
+    "component_status"
+  ],
+  "expected_remediation": "Correct the image tag on the odh-dashboard deployment to a valid tag that exists in the registry"
+}

--- a/cmd/mcp-server/scenarios/wrong-image-tag-setup.sh
+++ b/cmd/mcp-server/scenarios/wrong-image-tag-setup.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/common.sh"
+
+require_tools oc jq
+
+APPS_NS=$(discover_apps_namespace)
+OPERATOR_NS=$(discover_operator_namespace)
+OPERATOR_DEPLOY="opendatahub-operator-controller-manager"
+DEPLOYMENT="odh-dashboard"
+CONTAINER="odh-dashboard"
+BAD_IMAGE="quay.io/opendatahub/odh-dashboard:v999-does-not-exist"
+
+log_step "=== Scenario 17: Wrong Image Tag — Setup ==="
+
+# Scale down the ODH operator so it doesn't revert our image change
+log_step "Scaling down ODH operator to prevent reconciliation..."
+oc scale deployment "$OPERATOR_DEPLOY" -n "$OPERATOR_NS" --replicas=0
+sleep 5
+
+# Backup original deployment
+backup_resource deployment "$DEPLOYMENT" "$APPS_NS" "$BACKUP_DIR/17-${DEPLOYMENT}.json"
+
+# Patch to valid registry but nonexistent tag
+log_step "Patching $DEPLOYMENT to use image: $BAD_IMAGE"
+oc set image "deployment/$DEPLOYMENT" -n "$APPS_NS" "$CONTAINER=$BAD_IMAGE"
+
+# Wait for ImagePullBackOff
+log_step "Waiting for pod to enter ImagePullBackOff..."
+elapsed=0
+while (( elapsed < 120 )); do
+  waiting_reason=$(oc get pods -n "$APPS_NS" -l app=odh-dashboard \
+    -o jsonpath='{range .items[*]}{.status.containerStatuses[?(@.name=="'"$CONTAINER"'")].state.waiting.reason}{"\n"}{end}' 2>/dev/null || echo "")
+  if echo "$waiting_reason" | grep -q "ImagePullBackOff\|ErrImagePull"; then
+    log_step "Pod is in ImagePullBackOff/ErrImagePull state."
+    break
+  fi
+  sleep 5
+  (( elapsed += 5 ))
+done
+
+if ! echo "$waiting_reason" | grep -q "ImagePullBackOff\|ErrImagePull"; then
+  log_step "WARN: Pod did not enter ImagePullBackOff within timeout (current: $waiting_reason)"
+fi
+
+log_step "Wrong image tag failure injected."
+log_step "Run MCP tools to validate, then run wrong-image-tag-teardown.sh to restore."

--- a/cmd/mcp-server/scenarios/wrong-image-tag-teardown.sh
+++ b/cmd/mcp-server/scenarios/wrong-image-tag-teardown.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/common.sh"
+
+require_tools oc
+
+APPS_NS=$(discover_apps_namespace)
+OPERATOR_NS=$(discover_operator_namespace)
+OPERATOR_DEPLOY="opendatahub-operator-controller-manager"
+DEPLOYMENT="odh-dashboard"
+
+log_step "=== Scenario 17: Wrong Image Tag — Teardown ==="
+
+# Rollback the deployment to restore original image
+log_step "Rolling back $DEPLOYMENT deployment..."
+oc rollout undo deployment/"$DEPLOYMENT" -n "$APPS_NS"
+
+# Scale operator back up
+log_step "Scaling $OPERATOR_DEPLOY back to 3 replicas..."
+oc scale deployment "$OPERATOR_DEPLOY" -n "$OPERATOR_NS" --replicas=3
+
+wait_for_deployment_ready "$OPERATOR_NS" "$OPERATOR_DEPLOY" "180s"
+wait_for_deployment_ready "$APPS_NS" "$DEPLOYMENT" "180s"
+
+log_step "Operator and dashboard restored. Scenario 17 teardown complete."


### PR DESCRIPTION
<!---
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
Updated the diagnostic prompt to generate exact oc/kubectl remediation commands as a dry-run plan, never auto-executed, using real resource names from evidence. Added 9 single-failure scenarios sourced from resolved Jira tickets and troubleshooting.md, each with ground-truth JSON, setup, and teardown scripts. All scenarios verified on a live ODH cluster — covering OOMKilled, FailedMount, quota exceeded, CrashLoopBackOff variants, wrong image tags, panic crashes, and sidecar container failures.

https://redhat.atlassian.net/browse/RHOAIENG-56949
https://redhat.atlassian.net/browse/RHOAIENG-62337

## How Has This Been Tested?
Tested manually on cluster.

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [X] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [X] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work


### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [X] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
Add E2E if required.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added many failure scenarios (container OOM, crashloop exit code, invalid CLI flag, network-not-ready, panic crash, quota-exceeded, sidecar crash, storage-mount-failure, wrong-image-tag) with setup and teardown utilities to simulate and validate detection.

* **Documentation**
  * Remediation guidance updated to include a Dry-run plan with copy-pasteable CLI commands, mandatory real resource names/values from evidence, and a final verification step.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->