### PR TITLE
fix(kserve): treat LWS CRD as informational on xKS

### DIFF
--- a/internal/controller/components/kserve/kserve_controller.go
+++ b/internal/controller/components/kserve/kserve_controller.go
@@ -28,6 +28,7 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
@@ -165,6 +166,12 @@ func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.
 		}, precondition.WithSeverity(common.ConditionSeverityInfo))).
 		WithPreCondition(precondition.MonitorCRDs(xksDependencyCRDs,
 			precondition.WithClusterTypes(cluster.ClusterTypeKubernetes))).
+		WithPreCondition(precondition.MonitorCRDs(
+			[]schema.GroupVersionKind{gvk.LeaderWorkerSetV1},
+			precondition.WithConditionType(LLMInferenceServiceWideEPDependencies),
+			precondition.WithClusterTypes(cluster.ClusterTypeKubernetes),
+			precondition.WithSeverity(common.ConditionSeverityInfo),
+		)).
 		WithPreCondition(precondition.MonitorSubscriptions(
 			[]precondition.SubscriptionDependency{
 				{Name: RHCLOperatorSubscription, DisplayName: "Red Hat Connectivity Link"},

--- a/internal/controller/components/kserve/kserve_controller_actions.go
+++ b/internal/controller/components/kserve/kserve_controller_actions.go
@@ -227,8 +227,6 @@ var xksDependencyCRDs = []schema.GroupVersionKind{
 	// cert-manager.io
 	gvk.CertManagerCertificate, gvk.CertManagerCertificateRequest,
 	gvk.CertManagerIssuer, gvk.CertManagerClusterIssuer,
-	// leaderworkerset.x-k8s.io
-	gvk.LeaderWorkerSetV1,
 }
 
 // deleteLLMInferenceServiceConfigs is a finalizer action that explicitly deletes

--- a/internal/controller/components/kserve/kserve_controller_dependency_test.go
+++ b/internal/controller/components/kserve/kserve_controller_dependency_test.go
@@ -17,6 +17,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	ctrlconfig "sigs.k8s.io/controller-runtime/pkg/config"
 
+	"github.com/opendatahub-io/opendatahub-operator/v2/api/common"
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/api/components/v1alpha1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/status"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
@@ -123,6 +124,50 @@ func TestCRDDependencyMonitoring(t *testing.T) {
 		wt.Get(gvk.Kserve, nn).Eventually().Should(
 			jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`,
 				status.ConditionDependenciesAvailable, metav1.ConditionTrue),
+		)
+	})
+
+	t.Run("Kubernetes cluster without LWS CRD sets WideEPDependencies to False with Info severity", func(t *testing.T) {
+		cluster.SetClusterInfo(cluster.ClusterInfo{Type: cluster.ClusterTypeKubernetes})
+		t.Cleanup(func() { cluster.SetClusterInfo(cluster.ClusterInfo{}) })
+
+		ctx, cancel := context.WithCancel(context.Background())
+		_, wt := startKserveController(t, ctx)
+		t.Cleanup(cancel)
+
+		createKserveDependencyCR(t, wt)
+
+		nn := types.NamespacedName{Name: componentApi.KserveInstanceName}
+		wt.Get(gvk.Kserve, nn).Eventually().Should(And(
+			jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`,
+				LLMInferenceServiceWideEPDependencies, metav1.ConditionFalse),
+			jq.Match(`.status.conditions[] | select(.type == "%s") | .severity == "%s"`,
+				LLMInferenceServiceWideEPDependencies, common.ConditionSeverityInfo),
+			jq.Match(`.status.conditions[] | select(.type == "%s") | .message | contains("LeaderWorkerSet")`,
+				LLMInferenceServiceWideEPDependencies),
+		))
+	})
+
+	t.Run("Kubernetes cluster with LWS CRD sets WideEPDependencies to True", func(t *testing.T) {
+		cluster.SetClusterInfo(cluster.ClusterInfo{Type: cluster.ClusterTypeKubernetes})
+		t.Cleanup(func() { cluster.SetClusterInfo(cluster.ClusterInfo{}) })
+
+		ctx, cancel := context.WithCancel(context.Background())
+		et, wt := startKserveController(t, ctx)
+		t.Cleanup(cancel)
+
+		crd, err := et.RegisterCRD(wt.Context(), gvk.LeaderWorkerSetV1,
+			"leaderworkersets", "leaderworkerset",
+			apiextensionsv1.NamespaceScoped)
+		wt.Expect(err).NotTo(HaveOccurred())
+		envt.CleanupDelete(t, NewWithT(t), wt.Context(), wt.Client(), crd)
+
+		createKserveDependencyCR(t, wt)
+
+		nn := types.NamespacedName{Name: componentApi.KserveInstanceName}
+		wt.Get(gvk.Kserve, nn).Eventually().Should(
+			jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`,
+				LLMInferenceServiceWideEPDependencies, metav1.ConditionTrue),
 		)
 	})
 
@@ -278,11 +323,15 @@ func TestSubscriptionDependencyMonitoring(t *testing.T) {
 		)
 
 		// Subscription conditions should not be written on Kubernetes
-		wt.Get(gvk.Kserve, nn).Consistently().WithTimeout(5 * time.Second).Should(And(
+		wt.Get(gvk.Kserve, nn).Consistently().WithTimeout(5 * time.Second).Should(
 			jq.Match(`all(.status.conditions[]?.type; . != "%s")`,
 				LLMInferenceServiceDependencies),
-			jq.Match(`all(.status.conditions[]?.type; . != "%s")`,
+		)
+
+		// LLMInferenceServiceWideEPDependencies IS expected on Kubernetes (from MonitorCRDs for LWS)
+		wt.Get(gvk.Kserve, nn).Eventually().Should(
+			jq.Match(`[.status.conditions[] | select(.type == "%s")] | length > 0`,
 				LLMInferenceServiceWideEPDependencies),
-		))
+		)
 	})
 }

--- a/tests/e2e/cleanup_test.go
+++ b/tests/e2e/cleanup_test.go
@@ -68,6 +68,7 @@ func cleanupCoreOperatorResources(t *testing.T, tc *TestContext) {
 			WithMinimalObject(gvk, types.NamespacedName{}),
 			WithWaitForDeletion(true),
 			WithIgnoreNotFound(true),
+			WithAcceptableErr(meta.IsNoMatchError, "IsNoMatchError"),
 		)
 	}
 

--- a/tests/e2e/kserve_test.go
+++ b/tests/e2e/kserve_test.go
@@ -67,7 +67,11 @@ func kserveTestSuite(t *testing.T) {
 	)
 
 	// Always run deletion recovery and component disable tests last
-	if !componentCtx.IsXKS() {
+	if componentCtx.IsXKS() {
+		testCases = append(testCases,
+			TestCase{"Validate CRD dependency conditions", componentCtx.ValidateCRDDependencyConditions},
+		)
+	} else {
 		testCases = append(testCases,
 			TestCase{"Validate subscription dependency conditions", componentCtx.ValidateSubscriptionDependencyConditions},
 		)
@@ -124,6 +128,26 @@ func (tc *KserveTestCtx) ValidateSpec(t *testing.T) {
 			// Validate management states of NIM and serving components.
 			jq.Match(`.spec.nim.managementState == "%s"`, dsc.Spec.Components.Kserve.NIM.ManagementState),
 		),
+		),
+	)
+}
+
+// ValidateCRDDependencyConditions verifies that the LWS WideEP CRD dependency
+// condition is present and True on the KServe component CR when the LWS CRD
+// is installed by the cloud manager. xKS only.
+func (tc *KserveTestCtx) ValidateCRDDependencyConditions(t *testing.T) {
+	t.Helper()
+
+	skipUnless(t, Tier1)
+
+	kserveNN := types.NamespacedName{Name: componentApi.KserveInstanceName}
+
+	t.Log("Verifying WideEP CRD dependency condition is True on KServe component CR.")
+	tc.EnsureResourceExists(
+		WithMinimalObject(tc.GVK, kserveNN),
+		WithCondition(
+			jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`,
+				kserve.LLMInferenceServiceWideEPDependencies, metav1.ConditionTrue),
 		),
 	)
 }
@@ -482,17 +506,19 @@ func (tc *KserveTestCtx) runDegradedConditionTest(t *testing.T, testCase degrade
 }
 
 // runXKSDegradedMonitoringTest verifies that setting the AzureKubernetesEngine LWS dependency
-// to Unmanaged causes the Kserve DependenciesAvailable condition to become False,
+// to Unmanaged causes the Kserve WideEP condition to become False (informational),
 // and that setting it back to Managed restores it to True.
+// LWS is an optional dependency on xKS — its absence does not affect DependenciesAvailable.
 func (tc *KserveTestCtx) runXKSDegradedMonitoringTest(t *testing.T, kserveNN types.NamespacedName) {
 	t.Helper()
 
-	t.Logf("Verifying Kserve component DependenciesAvailable=True before test (name=%s).", kserveNN.Name)
+	t.Logf("Verifying Kserve component is healthy before test (name=%s).", kserveNN.Name)
 	tc.EnsureResourceExists(
 		WithMinimalObject(tc.GVK, kserveNN),
-		WithCondition(
+		WithCondition(And(
 			jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, status.ConditionDependenciesAvailable, metav1.ConditionTrue),
-		),
+			jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, kserve.LLMInferenceServiceWideEPDependencies, metav1.ConditionTrue),
+		)),
 	)
 
 	t.Logf("Setting AzureKubernetesEngine LWS managementPolicy to Unmanaged.")
@@ -504,11 +530,19 @@ func (tc *KserveTestCtx) runXKSDegradedMonitoringTest(t *testing.T, kserveNN typ
 		WithCustomErrorMsg("Failed to set AzureKubernetesEngine LWS managementPolicy to Unmanaged"),
 	)
 
-	t.Logf("Verifying Kserve component DependenciesAvailable=False after setting LWS to Unmanaged (name=%s).", kserveNN.Name)
+	t.Logf("Verifying Kserve component WideEPDependencies=False after setting LWS to Unmanaged (name=%s).", kserveNN.Name)
 	tc.EnsureResourceExists(
 		WithMinimalObject(tc.GVK, kserveNN),
 		WithCondition(
-			jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, status.ConditionDependenciesAvailable, metav1.ConditionFalse),
+			jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, kserve.LLMInferenceServiceWideEPDependencies, metav1.ConditionFalse),
+		),
+	)
+
+	t.Logf("Verifying Kserve DependenciesAvailable remains True (LWS is informational).")
+	tc.EnsureResourceExists(
+		WithMinimalObject(tc.GVK, kserveNN),
+		WithCondition(
+			jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, status.ConditionDependenciesAvailable, metav1.ConditionTrue),
 		),
 	)
 
@@ -521,11 +555,11 @@ func (tc *KserveTestCtx) runXKSDegradedMonitoringTest(t *testing.T, kserveNN typ
 		WithCustomErrorMsg("Failed to set AzureKubernetesEngine LWS managementPolicy to Managed"),
 	)
 
-	t.Logf("Verifying Kserve component DependenciesAvailable=True after restoring LWS to Managed (name=%s).", kserveNN.Name)
+	t.Logf("Verifying Kserve component WideEPDependencies=True after restoring LWS to Managed (name=%s).", kserveNN.Name)
 	tc.EnsureResourceExists(
 		WithMinimalObject(tc.GVK, kserveNN),
 		WithCondition(
-			jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, status.ConditionDependenciesAvailable, metav1.ConditionTrue),
+			jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, kserve.LLMInferenceServiceWideEPDependencies, metav1.ConditionTrue),
 		),
 	)
 


### PR DESCRIPTION
## Description

On xKS (vanilla Kubernetes), the KServe component becomes degraded when the LeaderWorkerSet CRD is not installed because `MonitorCRDs` defaults to `ConditionSeverityError`. On OCP, the equivalent check already uses `ConditionSeverityInfo` (non-blocking).

This PR:
- Removes `gvk.LeaderWorkerSetV1` from the `xksDependencyCRDs` list (which uses Error severity)
- Adds a separate `MonitorCRDs` precondition for LWS on xKS with `LLMInferenceServiceWideEPDependencies` condition type and `ConditionSeverityInfo`, matching the OCP approach
- Adds unit tests for both LWS-absent and LWS-present scenarios on Kubernetes clusters
- Adds e2e test in the cloudmanager suite verifying KServe WideEP condition transitions from False (before LWS CRD) to True (after cloudmanager installs LWS)

Jira: https://issues.redhat.com/browse/RHOAIENG-65114

## How Has This Been Tested?

- `go build -tags odh ./...` — compiles clean
- `go vet -tags odh ./internal/controller/components/kserve/... ./tests/e2e/cloudmanager/...` — passes
- Unit tests: two new envtest-based tests in `kserve_controller_dependency_test.go` verify the `LLMInferenceServiceWideEPDependencies` condition behavior with and without the LWS CRD
- E2E tests: cloudmanager suite verifies KServe WideEP=False before LWS is installed, and WideEP=True after cloudmanager installs LWS

## Screenshot or short clip

N/A

## Merge criteria

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully
- [ ] New RELATED_IMAGE mappings are listed in ODH-Build-Config and RHOAI-Build-Config (CI validates names against build-config repos). Include links to build-config PRs in the description.

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [ ] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * KServe now monitors the Kubernetes LeaderWorkerSet CRD and reports its availability via an informational "wide endpoint dependencies" condition.

* **Tests**
  * Expanded end-to-end tests to cover LeaderWorkerSet dependency monitoring, platform-specific dependency condition reporting, and a new helper to validate CRD dependency conditions.

* **Bug Fixes**
  * Cleanup now tolerates benign "no match" errors during bulk resource deletion to improve teardown robustness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->