### PR TITLE
Added 11 Failure scenarios to MCP Server.

### DIFF
--- a/cmd/mcp-server/scenarios/dashboard-sidecar-imagepull-ground-truth.json
+++ b/cmd/mcp-server/scenarios/dashboard-sidecar-imagepull-ground-truth.json
@@ -1,0 +1,30 @@
+{
+  "scenario_id": "dashboard-sidecar-imagepull",
+  "scenario_name": "Dashboard Sidecar ImagePull",
+  "description": "Multiple sidecar containers in the dashboard pod patched to use nonexistent image tags, causing ImagePullBackOff on multiple containers simultaneously. Based on RHOAIENG-62189 where 4 sidecar images were missing the v3.4.3-odh tag on quay.io.",
+  "root_cause": "Multiple sidecar container images in the dashboard deployment reference nonexistent tags on a valid registry",
+  "expected_classification": {
+    "category": "infrastructure",
+    "subcategory": "image-pull",
+    "error_code": 1001,
+    "confidence": "medium"
+  },
+  "expected_tool_outputs": {
+    "platform_health": {
+      "healthy": false
+    }
+  },
+  "expected_symptoms": [
+    "Multiple sidecar containers in ImagePullBackOff state",
+    "Main odh-dashboard container may be Running while sidecars fail",
+    "Warning events with ErrImagePull for multiple images",
+    "Deployment shows reduced ready replicas"
+  ],
+  "tools_that_detect": [
+    "classify_failure",
+    "platform_health",
+    "recent_events",
+    "component_status"
+  ],
+  "expected_remediation": "Correct the sidecar image tags to valid versions that exist on the registry"
+}

--- a/cmd/mcp-server/scenarios/dashboard-sidecar-imagepull-setup.sh
+++ b/cmd/mcp-server/scenarios/dashboard-sidecar-imagepull-setup.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/common.sh"
+
+require_tools oc jq
+
+APPS_NS=$(discover_apps_namespace)
+OPERATOR_NS=$(discover_operator_namespace)
+OPERATOR_DEPLOY="opendatahub-operator-controller-manager"
+DEPLOYMENT="odh-dashboard"
+BAD_TAG="v999-does-not-exist"
+
+log_step "=== Scenario 20: Dashboard Sidecar ImagePull — Setup ==="
+
+# Scale down the ODH operator so it doesn't revert our image changes
+log_step "Scaling down ODH operator to prevent reconciliation..."
+oc scale deployment "$OPERATOR_DEPLOY" -n "$OPERATOR_NS" --replicas=0
+sleep 5
+
+# Backup original deployment
+backup_resource deployment "$DEPLOYMENT" "$APPS_NS" "$BACKUP_DIR/20-${DEPLOYMENT}.json"
+
+
+SIDECARS=("model-registry-ui" "gen-ai-ui" "maas-ui" "mlflow-ui")
+
+for sidecar in "${SIDECARS[@]}"; do
+  INDEX=$(oc get deployment "$DEPLOYMENT" -n "$APPS_NS" -o json | \
+    jq '.spec.template.spec.containers | to_entries[] | select(.value.name == "'"$sidecar"'") | .key')
+  if [[ -z "$INDEX" ]]; then
+    log_step "ERROR: Required sidecar $sidecar was not found in $DEPLOYMENT"
+    exit 1
+  fi
+  CURRENT_IMAGE=$(oc get deployment "$DEPLOYMENT" -n "$APPS_NS" -o jsonpath='{.spec.template.spec.containers['"$INDEX"'].image}')
+  IMAGE_NO_DIGEST="${CURRENT_IMAGE%@*}"
+  REPO="${IMAGE_NO_DIGEST%:*}"
+  BAD_IMAGE="${REPO}:${BAD_TAG}"
+  log_step "Patching $sidecar (index $INDEX) to use image: $BAD_IMAGE"
+  oc set image "deployment/$DEPLOYMENT" -n "$APPS_NS" "$sidecar=$BAD_IMAGE"
+done
+
+# Wait for ImagePullBackOff
+log_step "Waiting for sidecar containers to enter ImagePullBackOff..."
+elapsed=0
+while (( elapsed < 120 )); do
+  pull_errors=$(oc get pods -n "$APPS_NS" -l app=odh-dashboard \
+    -o jsonpath='{range .items[*]}{range .status.containerStatuses[*]}{.state.waiting.reason}{"\n"}{end}{end}' 2>/dev/null | grep -c "ImagePullBackOff\|ErrImagePull" || true)
+  if (( pull_errors >= 2 )); then
+    log_step "Multiple containers in ImagePullBackOff ($pull_errors found)."
+    break
+  fi
+  sleep 5
+  (( elapsed += 5 ))
+done
+
+if (( pull_errors < 2 )); then
+  log_step "WARN: Not enough containers in ImagePullBackOff within timeout (found: $pull_errors)"
+fi
+
+log_step "Dashboard sidecar image pull failure injected."
+log_step "Run MCP tools to validate, then run dashboard-sidecar-imagepull-teardown.sh to restore."

--- a/cmd/mcp-server/scenarios/dashboard-sidecar-imagepull-teardown.sh
+++ b/cmd/mcp-server/scenarios/dashboard-sidecar-imagepull-teardown.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/common.sh"
+
+require_tools oc
+
+APPS_NS=$(discover_apps_namespace)
+OPERATOR_NS=$(discover_operator_namespace)
+OPERATOR_DEPLOY="opendatahub-operator-controller-manager"
+DEPLOYMENT="odh-dashboard"
+
+log_step "=== Scenario 20: Dashboard Sidecar ImagePull — Teardown ==="
+
+# Ensure operator is always restored even if rollback fails
+trap 'oc scale deployment "$OPERATOR_DEPLOY" -n "$OPERATOR_NS" --replicas=3 2>/dev/null || true' EXIT
+
+# Rollback the deployment to restore original images
+log_step "Rolling back $DEPLOYMENT deployment..."
+oc rollout undo deployment/"$DEPLOYMENT" -n "$APPS_NS"
+
+# Scale operator back up
+log_step "Scaling $OPERATOR_DEPLOY back to 3 replicas..."
+oc scale deployment "$OPERATOR_DEPLOY" -n "$OPERATOR_NS" --replicas=3
+
+trap - EXIT
+
+wait_for_deployment_ready "$OPERATOR_NS" "$OPERATOR_DEPLOY" "180s"
+wait_for_deployment_ready "$APPS_NS" "$DEPLOYMENT" "180s"
+
+log_step "Operator and dashboard restored. Scenario 20 teardown complete."

--- a/cmd/mcp-server/scenarios/healthy-dependency-info-warnings-ground-truth.json
+++ b/cmd/mcp-server/scenarios/healthy-dependency-info-warnings-ground-truth.json
@@ -1,0 +1,30 @@
+{
+  "scenario_id": "healthy-dependency-info-warnings",
+  "scenario_name": "Healthy With Dependency Info Warnings",
+  "description": "DSC shows KserveLLMInferenceServiceDependencies=False and TrainerReady=False, but these are informational warnings about optional features (Kuadrant not installed, JobSet not installed). Core KServe is Ready=True, all pods Running. The agent must not escalate Info-severity conditions as failures.",
+  "root_cause": "No failure — optional dependency warnings are informational, not errors. Core platform is functional.",
+  "expected_classification": {
+    "category": "none",
+    "subcategory": "healthy",
+    "error_code": 0,
+    "confidence": "high"
+  },
+  "expected_tool_outputs": {
+    "platform_health": {
+      "healthy": true
+    }
+  },
+  "expected_symptoms": [
+    "KserveLLMInferenceServiceDependencies=False with severity=Info",
+    "KserveLLMInferenceServiceWideEPDependencies=False with severity=Info",
+    "TrainerReady=False with message about missing JobSet operator",
+    "Core KServe, Dashboard, and all other components Ready=True",
+    "All pods Running and Ready"
+  ],
+  "tools_that_detect": [
+    "platform_health",
+    "component_status",
+    "operator_dependencies"
+  ],
+  "expected_remediation": "No action needed for core platform functionality. Install Kuadrant or JobSet operators only if LLMInferenceService or Trainer features are required."
+}

--- a/cmd/mcp-server/scenarios/healthy-dependency-info-warnings-setup.sh
+++ b/cmd/mcp-server/scenarios/healthy-dependency-info-warnings-setup.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/common.sh"
+
+require_tools oc jq
+
+log_step "=== Scenario 29: Healthy Dependency Info Warnings — Setup ==="
+
+# This scenario uses the cluster's natural state — optional dependencies (Kuadrant, JobSet)
+# are not installed, producing Info-severity warnings in DSC conditions.
+# No injection needed if these dependencies are already absent.
+
+# Verify the Info-severity warnings exist
+KSERVE_LLM_STATUS=$(oc get dsc -o jsonpath='{.items[0].status.conditions[?(@.type=="KserveLLMInferenceServiceDependencies")].status}' 2>/dev/null || echo "")
+KSERVE_LLM_SEVERITY=$(oc get dsc -o jsonpath='{.items[0].status.conditions[?(@.type=="KserveLLMInferenceServiceDependencies")].severity}' 2>/dev/null || echo "")
+KSERVE_WIDEEP_STATUS=$(oc get dsc -o jsonpath='{.items[0].status.conditions[?(@.type=="KserveLLMInferenceServiceWideEPDependencies")].status}' 2>/dev/null || echo "")
+KSERVE_WIDEEP_SEVERITY=$(oc get dsc -o jsonpath='{.items[0].status.conditions[?(@.type=="KserveLLMInferenceServiceWideEPDependencies")].severity}' 2>/dev/null || echo "")
+TRAINER_STATUS=$(oc get dsc -o jsonpath='{.items[0].status.conditions[?(@.type=="TrainerReady")].status}' 2>/dev/null || echo "")
+TRAINER_MESSAGE=$(oc get dsc -o jsonpath='{.items[0].status.conditions[?(@.type=="TrainerReady")].message}' 2>/dev/null || echo "")
+
+log_step "KserveLLMInferenceServiceDependencies: status=$KSERVE_LLM_STATUS severity=$KSERVE_LLM_SEVERITY"
+log_step "KserveLLMInferenceServiceWideEPDependencies: status=$KSERVE_WIDEEP_STATUS severity=$KSERVE_WIDEEP_SEVERITY"
+log_step "TrainerReady: status=$TRAINER_STATUS"
+
+if [[ "$KSERVE_LLM_STATUS" == "False" ]] \
+  && [[ "$KSERVE_LLM_SEVERITY" == "Info" ]] \
+  && [[ "$KSERVE_WIDEEP_STATUS" == "False" ]] \
+  && [[ "$KSERVE_WIDEEP_SEVERITY" == "Info" ]] \
+  && [[ "$TRAINER_STATUS" == "False" ]] \
+  && grep -qi "jobset" <<<"$TRAINER_MESSAGE"; then
+  log_step "Info-severity dependency warnings present — false-positive condition active."
+else
+  log_step "ERROR: Cluster does not match healthy-dependency-info-warnings prerequisites."
+  exit 1
+fi
+
+# Verify all component pods are healthy
+APPS_NS=$(discover_apps_namespace)
+UNHEALTHY_PODS=$(oc get pods -n "$APPS_NS" --field-selector='status.phase!=Running,status.phase!=Succeeded' --no-headers 2>/dev/null | wc -l)
+if (( UNHEALTHY_PODS == 0 )); then
+  log_step "All pods healthy — agent should report 'Platform Healthy' despite False conditions with Info severity."
+else
+  log_step "WARN: $UNHEALTHY_PODS unhealthy pods found — resolve before running this false-positive test."
+fi
+
+log_step "Run MCP tools to validate. Agent should not escalate Info-severity conditions as failures."
+log_step "Run healthy-dependency-info-warnings-teardown.sh to clean up."

--- a/cmd/mcp-server/scenarios/healthy-dependency-info-warnings-teardown.sh
+++ b/cmd/mcp-server/scenarios/healthy-dependency-info-warnings-teardown.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/common.sh"
+
+log_step "=== Scenario 29: Healthy Dependency Info Warnings — Teardown ==="
+
+# No changes were made — this scenario uses the cluster's natural state
+log_step "No cleanup needed — scenario used existing cluster state."
+log_step "Scenario 29 teardown complete."

--- a/cmd/mcp-server/scenarios/healthy-imagestream-warnings-ground-truth.json
+++ b/cmd/mcp-server/scenarios/healthy-imagestream-warnings-ground-truth.json
@@ -1,0 +1,29 @@
+{
+  "scenario_id": "healthy-imagestream-warnings",
+  "scenario_name": "Healthy With ImageStream Warnings",
+  "description": "DSC shows WorkbenchesReady=True but with a warning message about failed ImageStream tag imports. All pods are Running and Ready. The agent must recognize that ImageStream import warnings are non-blocking — WorkbenchesReady is True, the warning is informational. Inspired by RHOAIENG-13921.",
+  "root_cause": "No failure — ImageStream import warnings are expected when some notebook images are not available in the registry but the component is functional",
+  "expected_classification": {
+    "category": "none",
+    "subcategory": "healthy",
+    "error_code": 0,
+    "confidence": "high"
+  },
+  "expected_tool_outputs": {
+    "platform_health": {
+      "healthy": true
+    }
+  },
+  "expected_symptoms": [
+    "WorkbenchesReady=True with warning message about failed ImageStream tag imports",
+    "All workbench pods Running and Ready",
+    "ImageStream tags show ImportSuccess=False for some images",
+    "DSC phase may show Ready despite the warnings"
+  ],
+  "tools_that_detect": [
+    "platform_health",
+    "component_status",
+    "describe_resource"
+  ],
+  "expected_remediation": "No action needed — ImageStream import warnings are non-blocking. If specific notebook images are needed, verify registry access and image availability"
+}

--- a/cmd/mcp-server/scenarios/healthy-imagestream-warnings-setup.sh
+++ b/cmd/mcp-server/scenarios/healthy-imagestream-warnings-setup.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/common.sh"
+
+require_tools oc jq
+
+APPS_NS=$(discover_apps_namespace)
+
+log_step "=== Scenario 28: Healthy ImageStream Warnings (RHOAIENG-13921) — Setup ==="
+
+# Check if ImageStream warnings already exist on the cluster (they often do naturally)
+IMAGESTREAM_WARNINGS=$(oc get dsc -o jsonpath='{.items[0].status.conditions[?(@.type=="WorkbenchesReady")].message}' 2>/dev/null || echo "")
+
+if echo "$IMAGESTREAM_WARNINGS" | grep -qi "ImageStream\|failed to import"; then
+  log_step "ImageStream warnings already present in WorkbenchesReady condition:"
+  log_step "  $IMAGESTREAM_WARNINGS"
+  log_step "No additional setup needed — cluster already has the false-positive condition."
+else
+  # Create an ImageStream with a bad tag to generate import warnings
+  log_step "Creating ImageStream with invalid tag to generate import warnings..."
+  if oc get imagestream scenario-test-notebook -n "$APPS_NS" >/dev/null 2>&1; then
+    log_step "ERROR: imagestream/scenario-test-notebook already exists in $APPS_NS."
+    exit 1
+  fi
+  oc create -f - <<EOF
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  name: scenario-test-notebook
+  namespace: $APPS_NS
+  labels:
+    opendatahub.io/notebook-image: "true"
+spec:
+  tags:
+  - name: "latest"
+    from:
+      kind: DockerImage
+      name: "quay.io/opendatahub/nonexistent-notebook:v999-does-not-exist"
+    importPolicy:
+      importMode: Legacy
+EOF
+  log_step "Waiting for ImageStream import failure..."
+  for _ in {1..12}; do
+    IMAGESTREAM_WARNINGS=$(oc get dsc -o jsonpath='{.items[0].status.conditions[?(@.type=="WorkbenchesReady")].message}' 2>/dev/null || echo "")
+    if echo "$IMAGESTREAM_WARNINGS" | grep -qi "ImageStream\|failed to import"; then
+      log_step "ImageStream warning detected."
+      break
+    fi
+    sleep 5
+  done
+fi
+
+# Verify all pods are still healthy
+UNHEALTHY_PODS=$(oc get pods -n "$APPS_NS" --field-selector='status.phase!=Running,status.phase!=Succeeded' --no-headers 2>/dev/null | wc -l)
+if (( UNHEALTHY_PODS == 0 )); then
+  log_step "All pods healthy — false-positive condition active (warnings present but no failures)."
+else
+  log_step "WARN: $UNHEALTHY_PODS unhealthy pods found — this may not be a clean false-positive test."
+fi
+
+log_step "Run MCP tools to validate. Agent should report 'Platform Healthy' despite ImageStream warnings."
+log_step "Run healthy-imagestream-warnings-teardown.sh to clean up."

--- a/cmd/mcp-server/scenarios/healthy-imagestream-warnings-teardown.sh
+++ b/cmd/mcp-server/scenarios/healthy-imagestream-warnings-teardown.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/common.sh"
+
+require_tools oc
+
+APPS_NS=$(discover_apps_namespace)
+
+log_step "=== Scenario 28: Healthy ImageStream Warnings — Teardown ==="
+
+# Delete the test ImageStream if we created one
+if oc get imagestream scenario-test-notebook -n "$APPS_NS" &>/dev/null; then
+  log_step "Deleting test ImageStream scenario-test-notebook..."
+  oc delete imagestream scenario-test-notebook -n "$APPS_NS"
+fi
+
+log_step "Scenario 28 teardown complete."

--- a/cmd/mcp-server/scenarios/healthy-node-not-ready-recovered-ground-truth.json
+++ b/cmd/mcp-server/scenarios/healthy-node-not-ready-recovered-ground-truth.json
@@ -1,0 +1,30 @@
+{
+  "scenario_id": "healthy-node-not-ready-recovered",
+  "scenario_name": "Healthy Node NotReady Recovered",
+  "description": "A worker node briefly went NotReady (condition patched), then recovered to Ready. The node now shows Ready=True but has a recent NodeNotReady event and lastTransitionTime is very recent. All ODH pods are Running. The agent must check current node status (Ready=True) over recent events (NodeNotReady) and conclude the platform is healthy.",
+  "root_cause": "No failure — node experienced a brief NotReady condition that has already recovered",
+  "expected_classification": {
+    "category": "none",
+    "subcategory": "healthy",
+    "error_code": 0,
+    "confidence": "high"
+  },
+  "expected_tool_outputs": {
+    "platform_health": {
+      "healthy": true
+    }
+  },
+  "expected_symptoms": [
+    "Node shows Ready=True (current state is healthy)",
+    "Recent Warning event shows NodeNotReady for the node (synthetic, simulating a resolved incident)",
+    "All ODH pods Running and Ready across all nodes",
+    "Node conditions show healthy (no MemoryPressure, DiskPressure, PIDPressure)",
+    "Contradicting signals: events say NotReady, current state says Ready"
+  ],
+  "tools_that_detect": [
+    "platform_health",
+    "recent_events",
+    "describe_resource"
+  ],
+  "expected_remediation": "No action needed — node has recovered to Ready state. Monitor for recurrence if it happens frequently."
+}

--- a/cmd/mcp-server/scenarios/healthy-node-not-ready-recovered-setup.sh
+++ b/cmd/mcp-server/scenarios/healthy-node-not-ready-recovered-setup.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/common.sh"
+
+require_tools oc jq
+
+log_step "=== Scenario 27: Healthy Node NotReady Recovered — Setup ==="
+
+# Pick a worker node (not master/control-plane)
+WORKER_NODE=$(oc get nodes -l node-role.kubernetes.io/worker -o jsonpath='{.items[0].metadata.name}' 2>/dev/null)
+if [[ -z "$WORKER_NODE" ]]; then
+  log_step "ERROR: No worker node found."
+  exit 1
+fi
+log_step "Target worker node: $WORKER_NODE"
+
+# Create a synthetic NodeNotReady event — simulates a brief NotReady that already recovered
+# We can't actually make the node NotReady safely (kubelet resets it instantly),
+# so we inject the event directly to test agent behavior
+NOW=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+log_step "Injecting synthetic NodeNotReady event for $WORKER_NODE..."
+oc apply -f - <<EOF
+apiVersion: v1
+kind: Event
+metadata:
+  name: scenario-27-node-not-ready
+  namespace: default
+involvedObject:
+  apiVersion: v1
+  kind: Node
+  name: $WORKER_NODE
+reason: NodeNotReady
+message: "Node $WORKER_NODE status is now: NodeNotReady"
+type: Warning
+firstTimestamp: "$NOW"
+lastTimestamp: "$NOW"
+count: 1
+source:
+  component: node-controller
+EOF
+
+# Also inject a NodeReady event right after — shows the recovery
+log_step "Injecting synthetic NodeReady event (recovery)..."
+oc apply -f - <<EOF
+apiVersion: v1
+kind: Event
+metadata:
+  name: scenario-27-node-ready
+  namespace: default
+involvedObject:
+  apiVersion: v1
+  kind: Node
+  name: $WORKER_NODE
+reason: NodeReady
+message: "Node $WORKER_NODE status is now: NodeReady"
+type: Normal
+firstTimestamp: "$NOW"
+lastTimestamp: "$NOW"
+count: 1
+source:
+  component: node-controller
+EOF
+
+sleep 2
+NODE_STATUS=$(oc get node "$WORKER_NODE" -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}')
+NOT_READY_EVENTS=$(oc get events -A --field-selector="reason=NodeNotReady" --no-headers 2>/dev/null | wc -l || echo "0")
+
+log_step "Node status: Ready=$NODE_STATUS"
+log_step "NodeNotReady events found: $NOT_READY_EVENTS"
+
+# Verify all ODH pods are healthy
+APPS_NS=$(discover_apps_namespace)
+UNHEALTHY_PODS=$(oc get pods -n "$APPS_NS" --field-selector='status.phase!=Running,status.phase!=Succeeded' --no-headers 2>/dev/null | wc -l)
+if (( UNHEALTHY_PODS == 0 )); then
+  log_step "All ODH pods healthy — false-positive condition active."
+else
+  log_step "WARN: $UNHEALTHY_PODS unhealthy pods found."
+fi
+
+log_step "Node recovered with stale NotReady events. Agent should report 'Platform Healthy'."
+log_step "Run healthy-node-not-ready-recovered-teardown.sh to clean up."

--- a/cmd/mcp-server/scenarios/healthy-node-not-ready-recovered-teardown.sh
+++ b/cmd/mcp-server/scenarios/healthy-node-not-ready-recovered-teardown.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/common.sh"
+
+require_tools oc
+
+log_step "=== Scenario 27: Healthy Node NotReady Recovered — Teardown ==="
+
+# Delete synthetic events
+log_step "Deleting synthetic events..."
+oc delete event scenario-27-node-not-ready -n default 2>/dev/null || true
+oc delete event scenario-27-node-ready -n default 2>/dev/null || true
+
+log_step "Scenario 27 teardown complete."

--- a/cmd/mcp-server/scenarios/healthy-stale-events-ground-truth.json
+++ b/cmd/mcp-server/scenarios/healthy-stale-events-ground-truth.json
@@ -1,0 +1,29 @@
+{
+  "scenario_id": "healthy-stale-events",
+  "scenario_name": "Healthy With Stale Events",
+  "description": "Cluster is fully healthy but recent_events shows Warning events (OOMKilled, FailedMount, Unhealthy) from a previous failure scenario that was already torn down. Events persist in Kubernetes for ~1 hour after resolution. The agent must cross-reference events with current pod state — all pods Running/Ready means the events are stale, not active failures.",
+  "root_cause": "No failure — stale events from a resolved incident remain in the Kubernetes event log",
+  "expected_classification": {
+    "category": "none",
+    "subcategory": "healthy",
+    "error_code": 0,
+    "confidence": "high"
+  },
+  "expected_tool_outputs": {
+    "platform_health": {
+      "healthy": true
+    }
+  },
+  "expected_symptoms": [
+    "Warning events showing OOMKilled, FailedMount, Unhealthy, BackOff from previous incidents",
+    "All pods currently Running and Ready with 0 restarts on current containers",
+    "No active CrashLoopBackOff, ImagePullBackOff, or Pending pods",
+    "Events reference pod names that no longer exist or have been replaced"
+  ],
+  "tools_that_detect": [
+    "platform_health",
+    "recent_events",
+    "describe_resource"
+  ],
+  "expected_remediation": "No action needed — events are historical and do not reflect current cluster state"
+}

--- a/cmd/mcp-server/scenarios/healthy-stale-events-setup.sh
+++ b/cmd/mcp-server/scenarios/healthy-stale-events-setup.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/common.sh"
+
+require_tools oc jq
+
+APPS_NS=$(discover_apps_namespace)
+OPERATOR_NS=$(discover_operator_namespace)
+OPERATOR_DEPLOY="opendatahub-operator-controller-manager"
+COMPONENT_DEPLOY="feast-operator-controller-manager"
+CONTAINER="manager"
+
+log_step "=== Scenario 30: Healthy With Stale Events — Setup ==="
+
+# Step 1: Inject a temporary failure to generate warning events
+log_step "Scaling down ODH operator..."
+oc scale deployment "$OPERATOR_DEPLOY" -n "$OPERATOR_NS" --replicas=0
+sleep 5
+
+# Patch feast-operator memory to 5Mi to generate OOMKilled events
+CONTAINER_INDEX=$(oc get deployment "$COMPONENT_DEPLOY" -n "$APPS_NS" -o json | \
+  jq --arg name "$CONTAINER" '.spec.template.spec.containers | to_entries[] | select(.value.name == $name) | .key')
+
+if [[ -z "$CONTAINER_INDEX" ]]; then
+  log_step "ERROR: Container '$CONTAINER' not found in deployment '$COMPONENT_DEPLOY'"
+  exit 1
+fi
+
+log_step "Temporarily injecting OOM failure to generate warning events..."
+oc patch deployment "$COMPONENT_DEPLOY" -n "$APPS_NS" --type=json \
+  -p '[{"op":"replace","path":"/spec/template/spec/containers/'"$CONTAINER_INDEX"'/resources/limits/memory","value":"5Mi"},{"op":"replace","path":"/spec/template/spec/containers/'"$CONTAINER_INDEX"'/resources/requests/memory","value":"5Mi"}]'
+
+# Wait for OOMKilled events to be generated
+log_step "Waiting for OOMKilled events to be generated..."
+elapsed=0
+while (( elapsed < 120 )); do
+  event_count=$(oc get events -n "$APPS_NS" --sort-by='.lastTimestamp' 2>/dev/null | grep -c "OOMKilled\|BackOff\|Unhealthy" || true)
+  if (( event_count > 0 )); then
+    log_step "OOM warning events detected ($event_count)."
+    break
+  fi
+  sleep 5
+  (( elapsed += 5 ))
+done
+
+if (( event_count == 0 )); then
+  log_step "WARN: No OOM events observed before timeout. Continuing with partial state."
+fi
+
+# Step 2: Restore the deployment — events will persist but failure is resolved
+log_step "Restoring feast-operator to healthy state..."
+oc rollout undo deployment/"$COMPONENT_DEPLOY" -n "$APPS_NS"
+
+# Scale operator back up
+log_step "Scaling ODH operator back to 3 replicas..."
+oc scale deployment "$OPERATOR_DEPLOY" -n "$OPERATOR_NS" --replicas=3
+
+wait_for_deployment_ready "$OPERATOR_NS" "$OPERATOR_DEPLOY" "180s"
+wait_for_deployment_ready "$APPS_NS" "$COMPONENT_DEPLOY" "180s"
+
+# Verify cluster is healthy but events remain
+STALE_EVENTS=$(oc get events -n "$APPS_NS" --sort-by='.lastTimestamp' | grep -c "OOMKilled\|BackOff\|Unhealthy\|FailedMount" || true)
+log_step "Cluster restored to healthy state. $STALE_EVENTS stale warning events remain."
+
+UNHEALTHY_PODS=$(oc get pods -n "$APPS_NS" --field-selector='status.phase!=Running,status.phase!=Succeeded' --no-headers 2>/dev/null | wc -l)
+if (( UNHEALTHY_PODS == 0 )); then
+  log_step "All pods healthy — false-positive condition active (stale events + healthy pods)."
+else
+  log_step "WARN: $UNHEALTHY_PODS unhealthy pods found — wait for full recovery before testing."
+fi
+
+log_step "Run MCP tools NOW. Agent should report 'Platform Healthy' despite warning events."
+log_step "Run healthy-stale-events-teardown.sh to clean up."

--- a/cmd/mcp-server/scenarios/healthy-stale-events-teardown.sh
+++ b/cmd/mcp-server/scenarios/healthy-stale-events-teardown.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/common.sh"
+
+log_step "=== Scenario 30: Healthy With Stale Events — Teardown ==="
+
+# No cleanup needed — cluster is already healthy, stale events will expire naturally (~1 hour)
+log_step "No cleanup needed — cluster is healthy, stale events will expire automatically."
+log_step "Scenario 30 teardown complete."

--- a/cmd/mcp-server/scenarios/missing-crd-crashloop-ground-truth.json
+++ b/cmd/mcp-server/scenarios/missing-crd-crashloop-ground-truth.json
@@ -1,0 +1,32 @@
+{
+  "scenario_id": "missing-crd-crashloop",
+  "scenario_name": "Missing CRD Cascade",
+  "description": "ODH operator scaled to 0, then InferenceService CRD deleted and odh-model-controller restarted. Controller logs show 'no matches for kind InferenceService' and 'failed to wait for inferenceservice caches to sync' errors. Pod appears Running but is functionally broken. Classifier detects operator-down (1008) as primary — the agent must use pod_logs to discover the missing CRD as the hidden second failure. Inspired by RHOAIENG-42017 and RHOAIENG-39206.",
+  "root_cause": "Two failures: (1) ODH operator scaled to 0, (2) InferenceService CRD deleted — odh-model-controller cannot sync its informer caches",
+  "expected_classification": {
+    "category": "infrastructure",
+    "subcategory": "operator",
+    "error_code": 1008,
+    "confidence": "high"
+  },
+  "expected_tool_outputs": {
+    "platform_health": {
+      "healthy": false
+    }
+  },
+  "expected_symptoms": [
+    "ODH operator deployment scaled to 0 replicas",
+    "odh-model-controller pod Running but functionally broken (restart count >= 1)",
+    "Pod logs show: no matches for kind InferenceService in version serving.kserve.io/v1beta1",
+    "Pod logs show: failed to wait for inferenceservice caches to sync",
+    "DSC phase NotReady"
+  ],
+  "tools_that_detect": [
+    "classify_failure",
+    "platform_health",
+    "pod_logs",
+    "component_status",
+    "describe_resource"
+  ],
+  "expected_remediation": "Restore the InferenceService CRD (inferenceservices.serving.kserve.io) and restart odh-model-controller. The CRD is part of the KServe installation — reinstall KServe component or apply the CRD manifest directly."
+}

--- a/cmd/mcp-server/scenarios/missing-crd-crashloop-setup.sh
+++ b/cmd/mcp-server/scenarios/missing-crd-crashloop-setup.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/common.sh"
+
+require_tools oc jq
+
+APPS_NS=$(discover_apps_namespace)
+OPERATOR_NS=$(discover_operator_namespace)
+OPERATOR_DEPLOY="opendatahub-operator-controller-manager"
+CRD_NAME="inferenceservices.serving.kserve.io"
+COMPONENT_DEPLOY="odh-model-controller"
+
+log_step "=== Scenario 23: Missing CRD Crashloop (RHOAIENG-42017) — Setup ==="
+
+# Scale down the ODH operator so it doesn't recreate the CRD
+log_step "Scaling down ODH operator to prevent reconciliation..."
+oc scale deployment "$OPERATOR_DEPLOY" -n "$OPERATOR_NS" --replicas=0
+while [[ "$(oc get deployment "$OPERATOR_DEPLOY" -n "$OPERATOR_NS" -o jsonpath='{.status.readyReplicas}' 2>/dev/null)" != "0" ]] \
+  && [[ -n "$(oc get deployment "$OPERATOR_DEPLOY" -n "$OPERATOR_NS" -o jsonpath='{.status.readyReplicas}' 2>/dev/null)" ]]; do
+  sleep 2
+done
+
+# Backup the CRD before deletion
+log_step "Backing up CRD $CRD_NAME..."
+oc get crd "$CRD_NAME" -o json > "$BACKUP_DIR/23-${CRD_NAME}.json"
+
+# Delete the CRD
+log_step "Deleting CRD $CRD_NAME..."
+oc delete crd "$CRD_NAME"
+
+# Restart odh-model-controller so it crashes on the missing CRD
+log_step "Restarting $COMPONENT_DEPLOY to trigger CRD watch failure..."
+oc rollout restart deployment "$COMPONENT_DEPLOY" -n "$APPS_NS"
+
+# Wait for CrashLoopBackOff
+log_step "Waiting for $COMPONENT_DEPLOY to enter CrashLoopBackOff..."
+elapsed=0
+while (( elapsed < 120 )); do
+  status=$(oc get pods -n "$APPS_NS" -o json | jq -r --arg deploy "$COMPONENT_DEPLOY" \
+    '.items[] | select(.metadata.name | startswith($deploy)) | .status.containerStatuses[]? | "\(.state.waiting.reason // "") \(.lastState.terminated.reason // "")"' 2>/dev/null)
+  if echo "$status" | grep -q "CrashLoopBackOff\|Error"; then
+    log_step "CrashLoopBackOff detected on $COMPONENT_DEPLOY."
+    break
+  fi
+  sleep 5
+  (( elapsed += 5 ))
+done
+
+if ! echo "$status" | grep -q "CrashLoopBackOff\|Error"; then
+  log_step "WARN: $COMPONENT_DEPLOY not in CrashLoopBackOff within timeout. Check manually."
+fi
+
+log_step "CRD deleted — odh-model-controller crashing on missing InferenceService kind."
+log_step "Run MCP tools to validate, then run missing-crd-crashloop-teardown.sh to restore."

--- a/cmd/mcp-server/scenarios/missing-crd-crashloop-teardown.sh
+++ b/cmd/mcp-server/scenarios/missing-crd-crashloop-teardown.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/common.sh"
+
+require_tools oc
+
+APPS_NS=$(discover_apps_namespace)
+OPERATOR_NS=$(discover_operator_namespace)
+OPERATOR_DEPLOY="opendatahub-operator-controller-manager"
+COMPONENT_DEPLOY="odh-model-controller"
+
+log_step "=== Scenario 23: Missing CRD Crashloop — Teardown ==="
+
+# Ensure operator is always restored even if restore fails
+trap 'oc scale deployment "$OPERATOR_DEPLOY" -n "$OPERATOR_NS" --replicas=3 2>/dev/null || true' EXIT
+
+# Scale operator back up — it will recreate the CRD via reconciliation
+log_step "Scaling $OPERATOR_DEPLOY back to 3 replicas..."
+oc scale deployment "$OPERATOR_DEPLOY" -n "$OPERATOR_NS" --replicas=3
+
+wait_for_deployment_ready "$OPERATOR_NS" "$OPERATOR_DEPLOY" "180s"
+
+# Wait for operator to recreate the CRD
+log_step "Waiting for operator to recreate the CRD..."
+sleep 30
+
+# Restart odh-model-controller so it picks up the restored CRD
+log_step "Restarting $COMPONENT_DEPLOY..."
+oc rollout restart deployment "$COMPONENT_DEPLOY" -n "$APPS_NS"
+
+trap - EXIT
+
+wait_for_deployment_ready "$APPS_NS" "$COMPONENT_DEPLOY" "180s"
+
+log_step "CRD restored, odh-model-controller and operator running. Scenario 23 teardown complete."

--- a/cmd/mcp-server/scenarios/multi-operator-oom-ground-truth.json
+++ b/cmd/mcp-server/scenarios/multi-operator-oom-ground-truth.json
@@ -1,0 +1,32 @@
+{
+  "scenario_id": "multi-operator-oom",
+  "scenario_name": "Multi-Operator OOM",
+  "description": "Three component operators (feast, spark, trustyai) OOMKilled simultaneously by setting memory limits to 5Mi. The agent must identify OOM as the common failure pattern but report each as an independent root cause since they are different operators with different memory requirements.",
+  "root_cause": "Memory limits set to 5Mi on feast-operator, spark-operator-controller, and trustyai-operator — all three OOMKilled on startup",
+  "expected_classification": {
+    "category": "infrastructure",
+    "subcategory": "pod-startup",
+    "error_code": 1002,
+    "confidence": "high"
+  },
+  "expected_tool_outputs": {
+    "platform_health": {
+      "healthy": false
+    }
+  },
+  "expected_symptoms": [
+    "feast-operator-controller-manager in CrashLoopBackOff with OOMKilled",
+    "spark-operator-controller in CrashLoopBackOff with OOMKilled",
+    "trustyai-service-operator-controller-manager in CrashLoopBackOff with OOMKilled",
+    "Multiple pods restarting simultaneously",
+    "DSC component conditions degraded for affected components"
+  ],
+  "tools_that_detect": [
+    "classify_failure",
+    "platform_health",
+    "pod_logs",
+    "recent_events",
+    "component_status"
+  ],
+  "expected_remediation": "Increase memory limits on feast-operator-controller-manager, spark-operator-controller, and trustyai-service-operator-controller-manager deployments to their original values (256Mi, 512Mi, 700Mi respectively)"
+}

--- a/cmd/mcp-server/scenarios/multi-operator-oom-setup.sh
+++ b/cmd/mcp-server/scenarios/multi-operator-oom-setup.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/common.sh"
+
+require_tools oc jq
+
+APPS_NS=$(discover_apps_namespace)
+OPERATOR_NS=$(discover_operator_namespace)
+OPERATOR_DEPLOY="opendatahub-operator-controller-manager"
+
+DEPLOYMENTS=("feast-operator-controller-manager" "spark-operator-controller" "trustyai-service-operator-controller-manager")
+CONTAINERS=("manager" "controller" "manager")
+
+log_step "=== Scenario 21: Multi-Operator OOM (RHOAIENG-52932 + 53745) — Setup ==="
+
+# Scale down the ODH operator so it doesn't revert our memory changes
+log_step "Scaling down ODH operator to prevent reconciliation..."
+oc scale deployment "$OPERATOR_DEPLOY" -n "$OPERATOR_NS" --replicas=0
+sleep 5
+
+# Backup and patch each operator
+for i in "${!DEPLOYMENTS[@]}"; do
+  deploy="${DEPLOYMENTS[$i]}"
+  container="${CONTAINERS[$i]}"
+
+  log_step "Backing up $deploy..."
+  backup_resource deployment "$deploy" "$APPS_NS" "$BACKUP_DIR/21-${deploy}.json"
+
+  CONTAINER_INDEX=$(oc get deployment "$deploy" -n "$APPS_NS" -o json | \
+    jq --arg name "$container" '.spec.template.spec.containers | to_entries[] | select(.value.name == $name) | .key')
+
+  if [[ -z "$CONTAINER_INDEX" ]]; then
+    log_step "ERROR: Container '$container' not found in deployment '$deploy'"
+    exit 1
+  fi
+
+  log_step "Patching $deploy container $container (index $CONTAINER_INDEX) memory to 5Mi..."
+  oc patch deployment "$deploy" -n "$APPS_NS" --type=json \
+    -p '[{"op":"replace","path":"/spec/template/spec/containers/'"$CONTAINER_INDEX"'/resources/limits/memory","value":"5Mi"},{"op":"replace","path":"/spec/template/spec/containers/'"$CONTAINER_INDEX"'/resources/requests/memory","value":"5Mi"}]'
+done
+
+# Wait for OOMKilled across all three
+log_step "Waiting for operators to be OOMKilled..."
+elapsed=0
+while (( elapsed < 120 )); do
+  oom_count=0
+  for deploy in "${DEPLOYMENTS[@]}"; do
+    status=$(oc get pods -n "$APPS_NS" -o json | jq -r --arg deploy "$deploy" \
+      '.items[] | select(.metadata.name | startswith($deploy)) | .status.containerStatuses[]? | "\(.state.waiting.reason // "") \(.lastState.terminated.reason // "")"' 2>/dev/null)
+    if echo "$status" | grep -q "OOMKilled\|CrashLoopBackOff"; then
+      (( ++oom_count ))
+    fi
+  done
+  if (( oom_count >= ${#DEPLOYMENTS[@]} )); then
+    log_step "OOMKilled/CrashLoopBackOff detected on $oom_count operators."
+    break
+  fi
+  sleep 5
+  (( elapsed += 5 ))
+done
+
+if (( oom_count < ${#DEPLOYMENTS[@]} )); then
+  log_step "WARN: Not enough operators OOMKilled within timeout (found: $oom_count). Check manually."
+fi
+
+log_step "Multi-operator OOM injected."
+log_step "Run MCP tools to validate, then run multi-operator-oom-teardown.sh to restore."

--- a/cmd/mcp-server/scenarios/multi-operator-oom-teardown.sh
+++ b/cmd/mcp-server/scenarios/multi-operator-oom-teardown.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/common.sh"
+
+require_tools oc
+
+APPS_NS=$(discover_apps_namespace)
+OPERATOR_NS=$(discover_operator_namespace)
+OPERATOR_DEPLOY="opendatahub-operator-controller-manager"
+
+DEPLOYMENTS=("feast-operator-controller-manager" "spark-operator-controller" "trustyai-service-operator-controller-manager")
+
+log_step "=== Scenario 21: Multi-Operator OOM — Teardown ==="
+
+# Ensure operator is always restored even if rollback fails
+trap 'oc scale deployment "$OPERATOR_DEPLOY" -n "$OPERATOR_NS" --replicas=3 2>/dev/null || true' EXIT
+
+# Scale operator back up — it will reconcile the correct deployment specs
+log_step "Scaling $OPERATOR_DEPLOY back to 3 replicas..."
+oc scale deployment "$OPERATOR_DEPLOY" -n "$OPERATOR_NS" --replicas=3
+
+trap - EXIT
+
+wait_for_deployment_ready "$OPERATOR_NS" "$OPERATOR_DEPLOY" "180s"
+
+for deploy in "${DEPLOYMENTS[@]}"; do
+  log_step "Deleting $deploy so the operator can recreate it..."
+  oc delete deployment "$deploy" -n "$APPS_NS" --ignore-not-found
+  wait_for_deployment_ready "$APPS_NS" "$deploy" "180s"
+done
+
+log_step "All operators restored. Scenario 21 teardown complete."

--- a/cmd/mcp-server/scenarios/oom-plus-wrong-tag-ground-truth.json
+++ b/cmd/mcp-server/scenarios/oom-plus-wrong-tag-ground-truth.json
@@ -1,0 +1,31 @@
+{
+  "scenario_id": "oom-plus-wrong-tag",
+  "scenario_name": "OOM Plus Wrong Image Tag",
+  "description": "Two independent failures simultaneously: TrustyAI operator OOMKilled by setting memory limit to 5Mi, and dashboard patched with a nonexistent image tag. The agent must identify both as independent root causes — OOM (1002) on trustyai and ImagePullBackOff (1001) on dashboard — without conflating them. Inspired by RHOAIENG-53745 (trustyai OOM) and troubleshooting.md wrong image tag pattern.",
+  "root_cause": "Two independent failures: (1) TrustyAI operator memory limit set to 5Mi causing OOMKilled, (2) Dashboard image tag changed to nonexistent v999-does-not-exist",
+  "expected_classification": {
+    "category": "infrastructure",
+    "subcategory": "image-pull",
+    "error_code": 1001,
+    "confidence": "medium"
+  },
+  "expected_tool_outputs": {
+    "platform_health": {
+      "healthy": false
+    }
+  },
+  "expected_symptoms": [
+    "trustyai-service-operator-controller-manager in CrashLoopBackOff with OOMKilled",
+    "odh-dashboard pod in ImagePullBackOff with ErrImagePull events",
+    "Two different failure types active simultaneously",
+    "DSC phase NotReady with multiple components affected"
+  ],
+  "tools_that_detect": [
+    "classify_failure",
+    "platform_health",
+    "pod_logs",
+    "recent_events",
+    "component_status"
+  ],
+  "expected_remediation": "Increase memory limits on trustyai-service-operator-controller-manager to 700Mi, and correct the odh-dashboard image tag to a valid version"
+}

--- a/cmd/mcp-server/scenarios/oom-plus-wrong-tag-setup.sh
+++ b/cmd/mcp-server/scenarios/oom-plus-wrong-tag-setup.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/common.sh"
+
+require_tools oc jq
+
+APPS_NS=$(discover_apps_namespace)
+OPERATOR_NS=$(discover_operator_namespace)
+OPERATOR_DEPLOY="opendatahub-operator-controller-manager"
+TRUSTYAI_DEPLOY="trustyai-service-operator-controller-manager"
+DASHBOARD_DEPLOY="odh-dashboard"
+BAD_TAG="v999-does-not-exist"
+
+log_step "=== Scenario 26: OOM Plus Wrong Tag (RHOAIENG-53745 + troubleshooting.md) — Setup ==="
+
+# Scale down the ODH operator so it doesn't revert our changes
+log_step "Scaling down ODH operator to prevent reconciliation..."
+oc scale deployment "$OPERATOR_DEPLOY" -n "$OPERATOR_NS" --replicas=0
+sleep 5
+
+# Backup both deployments
+log_step "Backing up $TRUSTYAI_DEPLOY..."
+backup_resource deployment "$TRUSTYAI_DEPLOY" "$APPS_NS" "$BACKUP_DIR/26-${TRUSTYAI_DEPLOY}.json"
+log_step "Backing up $DASHBOARD_DEPLOY..."
+backup_resource deployment "$DASHBOARD_DEPLOY" "$APPS_NS" "$BACKUP_DIR/26-${DASHBOARD_DEPLOY}.json"
+
+# Failure 1: Patch TrustyAI memory to 5Mi → OOMKilled
+TRUSTYAI_INDEX=$(oc get deployment "$TRUSTYAI_DEPLOY" -n "$APPS_NS" -o json | \
+  jq '.spec.template.spec.containers | to_entries[] | select(.value.name == "manager") | .key')
+
+if [[ -z "$TRUSTYAI_INDEX" ]]; then
+  log_step "ERROR: Container 'manager' not found in deployment '$TRUSTYAI_DEPLOY'"
+  exit 1
+fi
+
+log_step "Patching $TRUSTYAI_DEPLOY memory to 5Mi (will OOMKill)..."
+oc patch deployment "$TRUSTYAI_DEPLOY" -n "$APPS_NS" --type=json \
+  -p '[{"op":"replace","path":"/spec/template/spec/containers/'"$TRUSTYAI_INDEX"'/resources/limits/memory","value":"5Mi"},{"op":"replace","path":"/spec/template/spec/containers/'"$TRUSTYAI_INDEX"'/resources/requests/memory","value":"5Mi"}]'
+
+# Failure 2: Patch dashboard image to nonexistent tag → ImagePullBackOff
+CURRENT_IMAGE=$(oc get deployment "$DASHBOARD_DEPLOY" -n "$APPS_NS" -o json | \
+  jq -r '.spec.template.spec.containers[] | select(.name == "odh-dashboard") | .image')
+IMAGE_NO_DIGEST="${CURRENT_IMAGE%@*}"
+REPO="${IMAGE_NO_DIGEST%:*}"
+BAD_IMAGE="${REPO}:${BAD_TAG}"
+log_step "Patching $DASHBOARD_DEPLOY image to $BAD_IMAGE (will ImagePullBackOff)..."
+oc set image "deployment/$DASHBOARD_DEPLOY" -n "$APPS_NS" "odh-dashboard=$BAD_IMAGE"
+
+# Wait for both failures to manifest
+log_step "Waiting for both failures to manifest..."
+elapsed=0
+oom_detected=false
+pull_detected=false
+while (( elapsed < 120 )); do
+  # Check TrustyAI for OOMKilled/CrashLoopBackOff
+  trustyai_status=$(oc get pods -n "$APPS_NS" -o json | jq -r --arg deploy "$TRUSTYAI_DEPLOY" \
+    '.items[] | select(.metadata.name | startswith($deploy)) | .status.containerStatuses[]? | "\(.state.waiting.reason // "") \(.lastState.terminated.reason // "")"' 2>/dev/null)
+  if echo "$trustyai_status" | grep -q "OOMKilled\|CrashLoopBackOff"; then
+    oom_detected=true
+  fi
+
+  # Check dashboard for ImagePullBackOff
+  dashboard_status=$(oc get pods -n "$APPS_NS" -l app=odh-dashboard -o jsonpath='{range .items[*]}{range .status.containerStatuses[*]}{.state.waiting.reason}{"\n"}{end}{end}' 2>/dev/null)
+  if echo "$dashboard_status" | grep -q "ImagePullBackOff\|ErrImagePull"; then
+    pull_detected=true
+  fi
+
+  if [[ "$oom_detected" == "true" ]] && [[ "$pull_detected" == "true" ]]; then
+    log_step "Both failures detected: TrustyAI OOMKilled + Dashboard ImagePullBackOff."
+    break
+  fi
+  sleep 5
+  (( elapsed += 5 ))
+done
+
+if [[ "$oom_detected" != "true" ]]; then
+  log_step "WARN: TrustyAI OOMKilled not detected within timeout."
+fi
+if [[ "$pull_detected" != "true" ]]; then
+  log_step "WARN: Dashboard ImagePullBackOff not detected within timeout."
+fi
+
+log_step "Multi-failure injected: OOM + wrong image tag."
+log_step "Run MCP tools to validate, then run oom-plus-wrong-tag-teardown.sh to restore."

--- a/cmd/mcp-server/scenarios/oom-plus-wrong-tag-teardown.sh
+++ b/cmd/mcp-server/scenarios/oom-plus-wrong-tag-teardown.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/common.sh"
+
+require_tools oc
+
+APPS_NS=$(discover_apps_namespace)
+OPERATOR_NS=$(discover_operator_namespace)
+OPERATOR_DEPLOY="opendatahub-operator-controller-manager"
+TRUSTYAI_DEPLOY="trustyai-service-operator-controller-manager"
+DASHBOARD_DEPLOY="odh-dashboard"
+
+log_step "=== Scenario 26: OOM Plus Wrong Tag — Teardown ==="
+
+# Ensure operator is always restored even if rollback fails
+trap 'oc scale deployment "$OPERATOR_DEPLOY" -n "$OPERATOR_NS" --replicas=3 2>/dev/null || true' EXIT
+
+# Rollback both deployments
+log_step "Rolling back $TRUSTYAI_DEPLOY..."
+oc rollout undo deployment/"$TRUSTYAI_DEPLOY" -n "$APPS_NS"
+log_step "Rolling back $DASHBOARD_DEPLOY..."
+oc rollout undo deployment/"$DASHBOARD_DEPLOY" -n "$APPS_NS"
+
+# Scale operator back up
+log_step "Scaling $OPERATOR_DEPLOY back to 3 replicas..."
+oc scale deployment "$OPERATOR_DEPLOY" -n "$OPERATOR_NS" --replicas=3
+
+trap - EXIT
+
+wait_for_deployment_ready "$OPERATOR_NS" "$OPERATOR_DEPLOY" "180s"
+wait_for_deployment_ready "$APPS_NS" "$TRUSTYAI_DEPLOY" "180s"
+wait_for_deployment_ready "$APPS_NS" "$DASHBOARD_DEPLOY" "180s"
+
+log_step "Both components and operator restored. Scenario 26 teardown complete."

--- a/cmd/mcp-server/scenarios/rbac-blocks-reconciliation-ground-truth.json
+++ b/cmd/mcp-server/scenarios/rbac-blocks-reconciliation-ground-truth.json
@@ -1,0 +1,31 @@
+{
+  "scenario_id": "rbac-blocks-reconciliation",
+  "scenario_name": "RBAC Blocks Reconciliation Cascade",
+  "description": "ODH operator scaled to 0, then model-registry operator's ClusterRoleBinding deleted and controller restarted. Classifier detects operator-down (1008) as primary. The agent must use pod_logs on model-registry-operator to discover repeated 403 Forbidden errors on informer watches — a hidden cascading failure where the operator appears Running but cannot reconcile.",
+  "root_cause": "Two failures: (1) ODH operator scaled to 0, (2) ClusterRoleBinding model-registry-operator-manager-rolebinding deleted — model-registry controller cannot list/watch roles and configmaps",
+  "expected_classification": {
+    "category": "infrastructure",
+    "subcategory": "operator",
+    "error_code": 1008,
+    "confidence": "high"
+  },
+  "expected_tool_outputs": {
+    "platform_health": {
+      "healthy": false
+    }
+  },
+  "expected_symptoms": [
+    "ODH operator deployment scaled to 0 replicas",
+    "Model-registry operator pod Running (1/1) but functionally broken",
+    "Repeated 403 Forbidden errors in model-registry-operator logs: cannot list roles or configmaps",
+    "DSC phase NotReady"
+  ],
+  "tools_that_detect": [
+    "classify_failure",
+    "platform_health",
+    "pod_logs",
+    "component_status",
+    "describe_resource"
+  ],
+  "expected_remediation": "Scale ODH operator back to 3 replicas and recreate ClusterRoleBinding model-registry-operator-manager-rolebinding binding model-registry-operator-manager-role ClusterRole to model-registry-operator-controller-manager ServiceAccount in opendatahub namespace"
+}

--- a/cmd/mcp-server/scenarios/rbac-blocks-reconciliation-setup.sh
+++ b/cmd/mcp-server/scenarios/rbac-blocks-reconciliation-setup.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/common.sh"
+
+require_tools oc jq
+
+APPS_NS=$(discover_apps_namespace)
+OPERATOR_NS=$(discover_operator_namespace)
+OPERATOR_DEPLOY="opendatahub-operator-controller-manager"
+CRB_NAME="model-registry-operator-manager-rolebinding"
+COMPONENT_DEPLOY="model-registry-operator-controller-manager"
+
+log_step "=== Scenario 22: RBAC Blocks Reconciliation (RHOAIENG-54987) — Setup ==="
+
+# Scale down the ODH operator so it doesn't recreate the ClusterRoleBinding
+log_step "Scaling down ODH operator to prevent reconciliation..."
+oc scale deployment "$OPERATOR_DEPLOY" -n "$OPERATOR_NS" --replicas=0
+while [[ "$(oc get deployment "$OPERATOR_DEPLOY" -n "$OPERATOR_NS" -o jsonpath='{.status.readyReplicas}' 2>/dev/null)" != "0" ]] \
+  && [[ -n "$(oc get deployment "$OPERATOR_DEPLOY" -n "$OPERATOR_NS" -o jsonpath='{.status.readyReplicas}' 2>/dev/null)" ]]; do
+  sleep 2
+done
+
+# Backup the ClusterRoleBinding before deletion
+log_step "Backing up ClusterRoleBinding $CRB_NAME..."
+backup_resource clusterrolebinding "$CRB_NAME" "" "$BACKUP_DIR/22-${CRB_NAME}.json"
+
+# Delete the ClusterRoleBinding to remove all cluster-scoped permissions
+log_step "Deleting ClusterRoleBinding $CRB_NAME..."
+oc delete clusterrolebinding "$CRB_NAME"
+
+# Restart the model-registry controller so it picks up the missing permissions
+log_step "Restarting $COMPONENT_DEPLOY to trigger informer reconnect..."
+oc rollout restart deployment "$COMPONENT_DEPLOY" -n "$APPS_NS"
+oc rollout status deployment "$COMPONENT_DEPLOY" -n "$APPS_NS" --timeout=60s || true
+
+# Wait for 403 errors to appear in logs
+log_step "Waiting for 403 Forbidden errors in model-registry operator logs..."
+elapsed=0
+while (( elapsed < 120 )); do
+  forbidden_count=$(oc logs deployment/"$COMPONENT_DEPLOY" -n "$APPS_NS" --tail=100 2>/dev/null | grep -ci "forbidden\|403" || true)
+  if (( forbidden_count >= 1 )); then
+    log_step "403 Forbidden errors detected in model-registry logs ($forbidden_count occurrences)."
+    break
+  fi
+  sleep 5
+  (( elapsed += 5 ))
+done
+
+if (( forbidden_count < 1 )); then
+  log_step "WARN: No 403 errors detected within timeout. Check manually: oc logs deployment/$COMPONENT_DEPLOY -n $APPS_NS"
+fi
+
+log_step "RBAC removed — model-registry operator running without cluster-scoped permissions."
+log_step "Run MCP tools to validate, then run rbac-blocks-reconciliation-teardown.sh to restore."

--- a/cmd/mcp-server/scenarios/rbac-blocks-reconciliation-teardown.sh
+++ b/cmd/mcp-server/scenarios/rbac-blocks-reconciliation-teardown.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/common.sh"
+
+require_tools oc
+
+APPS_NS=$(discover_apps_namespace)
+OPERATOR_NS=$(discover_operator_namespace)
+OPERATOR_DEPLOY="opendatahub-operator-controller-manager"
+CRB_NAME="model-registry-operator-manager-rolebinding"
+COMPONENT_DEPLOY="model-registry-operator-controller-manager"
+
+log_step "=== Scenario 22: RBAC Blocks Reconciliation — Teardown ==="
+
+# Ensure operator is always restored even if rollback fails
+trap 'oc scale deployment "$OPERATOR_DEPLOY" -n "$OPERATOR_NS" --replicas=3 2>/dev/null || true' EXIT
+
+# Recreate the ClusterRoleBinding
+log_step "Recreating ClusterRoleBinding $CRB_NAME..."
+oc apply -f - <<EOF
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: ${CRB_NAME}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: model-registry-operator-manager-role
+subjects:
+  - kind: ServiceAccount
+    name: model-registry-operator-controller-manager
+    namespace: ${APPS_NS}
+EOF
+
+# Restart model-registry controller to pick up restored permissions
+log_step "Restarting $COMPONENT_DEPLOY..."
+oc rollout restart deployment "$COMPONENT_DEPLOY" -n "$APPS_NS"
+
+# Scale operator back up
+log_step "Scaling $OPERATOR_DEPLOY back to 3 replicas..."
+oc scale deployment "$OPERATOR_DEPLOY" -n "$OPERATOR_NS" --replicas=3
+
+trap - EXIT
+
+wait_for_deployment_ready "$OPERATOR_NS" "$OPERATOR_DEPLOY" "180s"
+wait_for_deployment_ready "$APPS_NS" "$COMPONENT_DEPLOY" "180s"
+
+log_step "RBAC restored, model-registry and operator running. Scenario 22 teardown complete."

--- a/cmd/mcp-server/scenarios/readiness-probe-misconfigured-ground-truth.json
+++ b/cmd/mcp-server/scenarios/readiness-probe-misconfigured-ground-truth.json
@@ -1,0 +1,32 @@
+{
+  "scenario_id": "readiness-probe-misconfigured",
+  "scenario_name": "Readiness Probe Misconfigured",
+  "description": "Component operator's readiness probe patched to wrong port. Pod stays Running but never becomes Ready (0/1). No crashes, no restarts — the container is alive but kubelet marks it not Ready and removes it from Service endpoints. Deployment shows 0 available replicas. From troubleshooting.md probe failure patterns and CI infrastructure failure logs.",
+  "root_cause": "Readiness probe on feast-operator-controller-manager patched to port 9999 which is not listening — pod permanently not Ready",
+  "expected_classification": {
+    "category": "infrastructure",
+    "subcategory": "operator",
+    "error_code": 1008,
+    "confidence": "high"
+  },
+  "expected_tool_outputs": {
+    "platform_health": {
+      "healthy": false
+    }
+  },
+  "expected_symptoms": [
+    "feast-operator-controller-manager pod Running but 0/1 Ready",
+    "Deployment shows 0 available replicas",
+    "Warning events: Unhealthy — Readiness probe failed: connection refused",
+    "No container restarts — pod is alive but not serving",
+    "FeastOperatorReady condition may degrade"
+  ],
+  "tools_that_detect": [
+    "classify_failure",
+    "platform_health",
+    "recent_events",
+    "component_status",
+    "describe_resource"
+  ],
+  "expected_remediation": "Fix the readiness probe port on feast-operator-controller-manager deployment to point to the correct health endpoint (port 8081, path /readyz)"
+}

--- a/cmd/mcp-server/scenarios/readiness-probe-misconfigured-setup.sh
+++ b/cmd/mcp-server/scenarios/readiness-probe-misconfigured-setup.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/common.sh"
+
+require_tools oc jq
+
+APPS_NS=$(discover_apps_namespace)
+OPERATOR_NS=$(discover_operator_namespace)
+OPERATOR_DEPLOY="opendatahub-operator-controller-manager"
+COMPONENT_DEPLOY="feast-operator-controller-manager"
+CONTAINER="manager"
+
+log_step "=== Scenario 25: Readiness Probe Misconfigured (troubleshooting.md) — Setup ==="
+
+# Scale down the ODH operator so it doesn't revert our probe changes
+log_step "Scaling down ODH operator to prevent reconciliation..."
+oc scale deployment "$OPERATOR_DEPLOY" -n "$OPERATOR_NS" --replicas=0
+sleep 5
+
+# Backup original deployment
+log_step "Backing up $COMPONENT_DEPLOY..."
+backup_resource deployment "$COMPONENT_DEPLOY" "$APPS_NS" "$BACKUP_DIR/25-${COMPONENT_DEPLOY}.json"
+
+# Find container index
+CONTAINER_INDEX=$(oc get deployment "$COMPONENT_DEPLOY" -n "$APPS_NS" -o json | \
+  jq --arg name "$CONTAINER" '.spec.template.spec.containers | to_entries[] | select(.value.name == $name) | .key')
+
+if [[ -z "$CONTAINER_INDEX" ]]; then
+  log_step "ERROR: Container '$CONTAINER' not found in deployment '$COMPONENT_DEPLOY'"
+  exit 1
+fi
+
+# Patch readiness probe to wrong port
+log_step "Patching readiness probe on $COMPONENT_DEPLOY to port 9999..."
+oc patch deployment "$COMPONENT_DEPLOY" -n "$APPS_NS" --type=json \
+  -p '[{"op":"replace","path":"/spec/template/spec/containers/'"$CONTAINER_INDEX"'/readinessProbe/httpGet/port","value":9999}]'
+
+# Wait for pod to be Running but not Ready (0/1)
+log_step "Waiting for pod to be Running but not Ready..."
+elapsed=0
+while (( elapsed < 120 )); do
+  ready=$(oc get pods -n "$APPS_NS" -o json | jq -r --arg deploy "$COMPONENT_DEPLOY" \
+    '[.items[] | select(.metadata.name | startswith($deploy)) | select(.status.phase == "Running") | .status.containerStatuses[]? | select(.ready == false)] | length' 2>/dev/null)
+  if (( ready > 0 )); then
+    log_step "Pod Running but not Ready detected (0/1)."
+    break
+  fi
+  sleep 5
+  (( elapsed += 5 ))
+done
+
+if (( ready == 0 )); then
+  log_step "WARN: Pod not in expected state within timeout. Check manually."
+fi
+
+log_step "Readiness probe misconfigured — pod Running but not Ready."
+log_step "Run MCP tools to validate, then run readiness-probe-misconfigured-teardown.sh to restore."

--- a/cmd/mcp-server/scenarios/readiness-probe-misconfigured-teardown.sh
+++ b/cmd/mcp-server/scenarios/readiness-probe-misconfigured-teardown.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/common.sh"
+
+require_tools oc
+
+APPS_NS=$(discover_apps_namespace)
+OPERATOR_NS=$(discover_operator_namespace)
+OPERATOR_DEPLOY="opendatahub-operator-controller-manager"
+COMPONENT_DEPLOY="feast-operator-controller-manager"
+
+log_step "=== Scenario 25: Readiness Probe Misconfigured — Teardown ==="
+
+# Ensure operator is always restored even if rollback fails
+trap 'oc scale deployment "$OPERATOR_DEPLOY" -n "$OPERATOR_NS" --replicas=3 2>/dev/null || true' EXIT
+
+# Rollback the deployment to restore original probe
+log_step "Rolling back $COMPONENT_DEPLOY..."
+oc rollout undo deployment/"$COMPONENT_DEPLOY" -n "$APPS_NS"
+
+# Scale operator back up
+log_step "Scaling $OPERATOR_DEPLOY back to 3 replicas..."
+oc scale deployment "$OPERATOR_DEPLOY" -n "$OPERATOR_NS" --replicas=3
+
+trap - EXIT
+
+wait_for_deployment_ready "$OPERATOR_NS" "$OPERATOR_DEPLOY" "180s"
+wait_for_deployment_ready "$APPS_NS" "$COMPONENT_DEPLOY" "180s"
+
+log_step "Probe restored, feast operator and ODH operator running. Scenario 25 teardown complete."

--- a/cmd/mcp-server/scenarios/serviceaccount-deleted-ground-truth.json
+++ b/cmd/mcp-server/scenarios/serviceaccount-deleted-ground-truth.json
@@ -1,0 +1,31 @@
+{
+  "scenario_id": "serviceaccount-deleted",
+  "scenario_name": "ServiceAccount Deleted",
+  "description": "Component operator's ServiceAccount deleted, then pod restarted. New pod cannot mount the API token volume, causing CreateContainerError. The operator cannot run, component condition degrades, and DSC goes NotReady. Inspired by CI infrastructure failure patterns from RHOAIENG-47806.",
+  "root_cause": "ServiceAccount mlflow-operator-controller-manager deleted — pod cannot mount projected service account token volume",
+  "expected_classification": {
+    "category": "infrastructure",
+    "subcategory": "pod-startup",
+    "error_code": 1002,
+    "confidence": "high"
+  },
+  "expected_tool_outputs": {
+    "platform_health": {
+      "healthy": false
+    }
+  },
+  "expected_symptoms": [
+    "mlflow-operator-controller-manager pod in CreateContainerError",
+    "Events show MountVolume.SetUp failed for kube-api-access projected volume",
+    "MLflowOperatorReady condition may degrade to False",
+    "DSC phase NotReady"
+  ],
+  "tools_that_detect": [
+    "classify_failure",
+    "platform_health",
+    "recent_events",
+    "component_status",
+    "describe_resource"
+  ],
+  "expected_remediation": "Recreate the ServiceAccount mlflow-operator-controller-manager in the opendatahub namespace and restart the mlflow-operator-controller-manager deployment"
+}

--- a/cmd/mcp-server/scenarios/serviceaccount-deleted-setup.sh
+++ b/cmd/mcp-server/scenarios/serviceaccount-deleted-setup.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/common.sh"
+
+require_tools oc jq
+
+APPS_NS=$(discover_apps_namespace)
+OPERATOR_NS=$(discover_operator_namespace)
+OPERATOR_DEPLOY="opendatahub-operator-controller-manager"
+COMPONENT_DEPLOY="mlflow-operator-controller-manager"
+SA_NAME="mlflow-operator-controller-manager"
+
+log_step "=== Scenario 24: ServiceAccount Deleted (RHOAIENG-47806) — Setup ==="
+
+# Scale down the ODH operator so it doesn't recreate the ServiceAccount
+log_step "Scaling down ODH operator to prevent reconciliation..."
+oc scale deployment "$OPERATOR_DEPLOY" -n "$OPERATOR_NS" --replicas=0
+while [[ "$(oc get deployment "$OPERATOR_DEPLOY" -n "$OPERATOR_NS" -o jsonpath='{.status.readyReplicas}' 2>/dev/null)" != "0" ]] \
+  && [[ -n "$(oc get deployment "$OPERATOR_DEPLOY" -n "$OPERATOR_NS" -o jsonpath='{.status.readyReplicas}' 2>/dev/null)" ]]; do
+  sleep 2
+done
+
+# Backup the ServiceAccount before deletion
+log_step "Backing up ServiceAccount $SA_NAME..."
+oc get serviceaccount "$SA_NAME" -n "$APPS_NS" -o json > "$BACKUP_DIR/24-${SA_NAME}.json"
+
+# Delete the ServiceAccount
+log_step "Deleting ServiceAccount $SA_NAME..."
+oc delete serviceaccount "$SA_NAME" -n "$APPS_NS"
+
+# Restart the component so the new pod tries to mount the missing SA token
+log_step "Restarting $COMPONENT_DEPLOY..."
+oc rollout restart deployment "$COMPONENT_DEPLOY" -n "$APPS_NS"
+
+# Wait for CreateContainerError
+log_step "Waiting for CreateContainerError on $COMPONENT_DEPLOY..."
+elapsed=0
+while (( elapsed < 120 )); do
+  status=$(oc get pods -n "$APPS_NS" -o json | jq -r --arg deploy "$COMPONENT_DEPLOY" \
+    '.items[] | select(.metadata.name | startswith($deploy)) | .status.containerStatuses[]? | .state.waiting.reason // ""' 2>/dev/null)
+  if echo "$status" | grep -q "CreateContainerError\|CreateContainerConfigError"; then
+    log_step "CreateContainerError detected on $COMPONENT_DEPLOY."
+    break
+  fi
+  sleep 5
+  (( elapsed += 5 ))
+done
+
+if ! echo "$status" | grep -q "CreateContainerError\|CreateContainerConfigError"; then
+  log_step "WARN: CreateContainerError not detected within timeout. Check manually."
+fi
+
+log_step "ServiceAccount deleted — mlflow operator cannot start."
+log_step "Run MCP tools to validate, then run serviceaccount-deleted-teardown.sh to restore."

--- a/cmd/mcp-server/scenarios/serviceaccount-deleted-teardown.sh
+++ b/cmd/mcp-server/scenarios/serviceaccount-deleted-teardown.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/common.sh"
+
+require_tools oc
+
+APPS_NS=$(discover_apps_namespace)
+OPERATOR_NS=$(discover_operator_namespace)
+OPERATOR_DEPLOY="opendatahub-operator-controller-manager"
+COMPONENT_DEPLOY="mlflow-operator-controller-manager"
+SA_NAME="mlflow-operator-controller-manager"
+
+log_step "=== Scenario 24: ServiceAccount Deleted — Teardown ==="
+
+# Ensure operator is always restored even if SA restore fails
+trap 'oc scale deployment "$OPERATOR_DEPLOY" -n "$OPERATOR_NS" --replicas=3 2>/dev/null || true' EXIT
+
+# Recreate the ServiceAccount if missing
+log_step "Restoring ServiceAccount $SA_NAME..."
+if ! oc get serviceaccount "$SA_NAME" -n "$APPS_NS" >/dev/null 2>&1; then
+  oc create serviceaccount "$SA_NAME" -n "$APPS_NS"
+fi
+
+# Restart the component to pick up the restored SA
+log_step "Restarting $COMPONENT_DEPLOY..."
+oc rollout restart deployment "$COMPONENT_DEPLOY" -n "$APPS_NS"
+
+# Scale operator back up
+log_step "Scaling $OPERATOR_DEPLOY back to 3 replicas..."
+oc scale deployment "$OPERATOR_DEPLOY" -n "$OPERATOR_NS" --replicas=3
+
+trap - EXIT
+
+wait_for_deployment_ready "$OPERATOR_NS" "$OPERATOR_DEPLOY" "180s"
+wait_for_deployment_ready "$APPS_NS" "$COMPONENT_DEPLOY" "180s"
+
+log_step "ServiceAccount restored, mlflow operator and ODH operator running. Scenario 24 teardown complete."


### PR DESCRIPTION
<!---
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
Add 7 cascading/multi-failure and 4 false-positive scenarios to the diagnostic corpus. Cascading scenarios sourced from resolved Jira tickets and troubleshoot.md file. False-positive scenarios test agent judgment on healthy clusters with noisy signals (stale events, ImageStream warnings, node recovery). 

https://redhat.atlassian.net/browse/RHOAIENG-62337

## How Has This Been Tested?
Tested on a live cluster.

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [X] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [X] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work


### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [X] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
Add E2E if required.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added 11 new MCP scenarios covering sidecar image-pull failures, missing CRD crashloop, RBAC reconciliation break, multi-operator OOM, combined OOM+wrong-image, readiness-probe misconfiguration, ServiceAccount deletion, and several “healthy but warning/recovered” cases.
  * Each scenario includes ground-truth definitions plus setup and teardown workflows to validate detection, platform-health outputs, symptoms, and remediation guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->