### PR TITLE
fix(kserve): default NIM configuration in DSC to prevent KServe CR divergence

### DIFF
--- a/api/components/v1alpha1/kserve_types.go
+++ b/api/components/v1alpha1/kserve_types.go
@@ -76,6 +76,7 @@ type KserveCommonSpec struct {
 	// +optional
 	OAuthProxy *OAuthProxyConfig `json:"oauthProxy,omitempty"`
 	// Configures and enables NVIDIA NIM integration
+	// +kubebuilder:default={}
 	NIM NimSpec `json:"nim,omitempty"`
 	// Configures and enables Models as a Service integration
 	ModelsAsService DSCModelsAsServiceSpec `json:"modelsAsService,omitempty"`

--- a/docs/api-overview.md
+++ b/docs/api-overview.md
@@ -190,7 +190,7 @@ _Appears in:_
 | `managementState` _[ManagementState](https://pkg.go.dev/github.com/openshift/api@v0.0.0-20250812222054-88b2b21555f3/operator/v1#ManagementState)_ | Set to one of the following values:<br />- "Managed" : the operator is actively managing the component and trying to keep it active.<br />              It will only upgrade the component if it is safe to do so<br />- "Removed" : the operator is actively managing the component and will not install it,<br />              or if it is installed, the operator will try to remove it |  | Enum: [Managed Removed] <br /> |
 | `rawDeploymentServiceConfig` _[RawServiceConfig](#rawserviceconfig)_ | Configures the type of service that is created for InferenceServices using RawDeployment.<br />The values for RawDeploymentServiceConfig can be "Headless" (default value) or "Headed".<br />Headless: to set "ServiceClusterIPNone = true" in the 'inferenceservice-config' configmap for Kserve.<br />Headed: to set "ServiceClusterIPNone = false" in the 'inferenceservice-config' configmap for Kserve. | Headless | Enum: [Headless Headed] <br /> |
 | `oauthProxy` _[OAuthProxyConfig](#oauthproxyconfig)_ | Configures the OAuth proxy sidecar container resources in the<br />'inferenceservice-config' ConfigMap for KServe. Only non-nil fields<br />override the defaults shipped with the operator manifests. |  |  |
-| `nim` _[NimSpec](#nimspec)_ | Configures and enables NVIDIA NIM integration |  |  |
+| `nim` _[NimSpec](#nimspec)_ | Configures and enables NVIDIA NIM integration | \{  \} |  |
 | `modelsAsService` _[DSCModelsAsServiceSpec](#dscmodelsasservicespec)_ | Configures and enables Models as a Service integration |  |  |
 | `wva` _[WVASpec](#wvaspec)_ | Configures and enables workload-variant-autoscaler (WVA) integration |  |  |
 | `modelCache` _[ModelCacheSpec](#modelcachespec)_ | Configures and enables Model Cache integration |  |  |
@@ -941,7 +941,7 @@ _Appears in:_
 | --- | --- | --- | --- |
 | `rawDeploymentServiceConfig` _[RawServiceConfig](#rawserviceconfig)_ | Configures the type of service that is created for InferenceServices using RawDeployment.<br />The values for RawDeploymentServiceConfig can be "Headless" (default value) or "Headed".<br />Headless: to set "ServiceClusterIPNone = true" in the 'inferenceservice-config' configmap for Kserve.<br />Headed: to set "ServiceClusterIPNone = false" in the 'inferenceservice-config' configmap for Kserve. | Headless | Enum: [Headless Headed] <br /> |
 | `oauthProxy` _[OAuthProxyConfig](#oauthproxyconfig)_ | Configures the OAuth proxy sidecar container resources in the<br />'inferenceservice-config' ConfigMap for KServe. Only non-nil fields<br />override the defaults shipped with the operator manifests. |  |  |
-| `nim` _[NimSpec](#nimspec)_ | Configures and enables NVIDIA NIM integration |  |  |
+| `nim` _[NimSpec](#nimspec)_ | Configures and enables NVIDIA NIM integration | \{  \} |  |
 | `modelsAsService` _[DSCModelsAsServiceSpec](#dscmodelsasservicespec)_ | Configures and enables Models as a Service integration |  |  |
 | `wva` _[WVASpec](#wvaspec)_ | Configures and enables workload-variant-autoscaler (WVA) integration |  |  |
 | `modelCache` _[ModelCacheSpec](#modelcachespec)_ | Configures and enables Model Cache integration |  |  |
@@ -979,7 +979,7 @@ _Appears in:_
 | --- | --- | --- | --- |
 | `rawDeploymentServiceConfig` _[RawServiceConfig](#rawserviceconfig)_ | Configures the type of service that is created for InferenceServices using RawDeployment.<br />The values for RawDeploymentServiceConfig can be "Headless" (default value) or "Headed".<br />Headless: to set "ServiceClusterIPNone = true" in the 'inferenceservice-config' configmap for Kserve.<br />Headed: to set "ServiceClusterIPNone = false" in the 'inferenceservice-config' configmap for Kserve. | Headless | Enum: [Headless Headed] <br /> |
 | `oauthProxy` _[OAuthProxyConfig](#oauthproxyconfig)_ | Configures the OAuth proxy sidecar container resources in the<br />'inferenceservice-config' ConfigMap for KServe. Only non-nil fields<br />override the defaults shipped with the operator manifests. |  |  |
-| `nim` _[NimSpec](#nimspec)_ | Configures and enables NVIDIA NIM integration |  |  |
+| `nim` _[NimSpec](#nimspec)_ | Configures and enables NVIDIA NIM integration | \{  \} |  |
 | `modelsAsService` _[DSCModelsAsServiceSpec](#dscmodelsasservicespec)_ | Configures and enables Models as a Service integration |  |  |
 | `wva` _[WVASpec](#wvaspec)_ | Configures and enables workload-variant-autoscaler (WVA) integration |  |  |
 | `modelCache` _[ModelCacheSpec](#modelcachespec)_ | Configures and enables Model Cache integration |  |  |

--- a/internal/webhook/datasciencecluster/v1/defaulting.go
+++ b/internal/webhook/datasciencecluster/v1/defaulting.go
@@ -85,4 +85,13 @@ func (d *Defaulter) applyDefaults(ctx context.Context, dsc *dscv1.DataScienceClu
 			modelRegistry.RegistriesNamespace = modelregistryctrl.DefaultModelRegistriesNamespace
 		}
 	}
+
+	// If Kserve is enabled and NIM ManagementState is empty, set it to the default value (Managed).
+	kserve := &dsc.Spec.Components.Kserve
+	if kserve.ManagementState == operatorv1.Managed {
+		if kserve.NIM.ManagementState == "" {
+			log.V(1).Info("Setting default ManagementState for Kserve NIM", "default", operatorv1.Managed)
+			kserve.NIM.ManagementState = operatorv1.Managed
+		}
+	}
 }

--- a/internal/webhook/datasciencecluster/v1/defaulting_test.go
+++ b/internal/webhook/datasciencecluster/v1/defaulting_test.go
@@ -81,3 +81,60 @@ func TestDefaulterV1_DefaultingLogic(t *testing.T) {
 		})
 	}
 }
+
+// TestDefaulterV1_NIMDefaultingLogic exercises the NIM defaulting webhook logic for DataScienceCluster v1 resources.
+func TestDefaulterV1_NIMDefaultingLogic(t *testing.T) {
+	t.Parallel()
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	testCases := []struct {
+		name                  string
+		kserveManagementState *operatorv1.ManagementState
+		nimManagementState    *operatorv1.ManagementState
+		expectedNIMState      operatorv1.ManagementState
+	}{
+		{
+			name:                  "Sets default NIM ManagementState if empty and Kserve is Managed",
+			kserveManagementState: ptrManagementState(operatorv1.Managed),
+			nimManagementState:    ptrManagementState(""),
+			expectedNIMState:      operatorv1.Managed,
+		},
+		{
+			name:                  "Does not overwrite NIM ManagementState if already set",
+			kserveManagementState: ptrManagementState(operatorv1.Managed),
+			nimManagementState:    ptrManagementState(operatorv1.Removed),
+			expectedNIMState:      operatorv1.Removed,
+		},
+		{
+			name:                  "Does nothing if Kserve is not Managed",
+			kserveManagementState: ptrManagementState(operatorv1.Removed),
+			nimManagementState:    ptrManagementState(""),
+			expectedNIMState:      "",
+		},
+		{
+			name:                  "Does nothing if Kserve is not set at all (upgrade case)",
+			kserveManagementState: nil,
+			nimManagementState:    nil,
+			expectedNIMState:      "",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			dsc := &dscv1.DataScienceCluster{}
+			if tc.kserveManagementState != nil {
+				dsc.Spec.Components.Kserve.ManagementState = *tc.kserveManagementState
+			}
+			if tc.nimManagementState != nil {
+				dsc.Spec.Components.Kserve.NIM.ManagementState = *tc.nimManagementState
+			}
+
+			defaulter := &v1webhook.Defaulter{Name: "test-v1"}
+			err := defaulter.Default(ctx, dsc)
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(dsc.Spec.Components.Kserve.NIM.ManagementState).To(Equal(tc.expectedNIMState))
+		})
+	}
+}

--- a/internal/webhook/datasciencecluster/v2/defaulting.go
+++ b/internal/webhook/datasciencecluster/v2/defaulting.go
@@ -85,4 +85,13 @@ func (d *Defaulter) applyDefaults(ctx context.Context, dsc *dscv2.DataScienceClu
 			modelRegistry.RegistriesNamespace = modelregistryctrl.DefaultModelRegistriesNamespace
 		}
 	}
+
+	// If Kserve is enabled and NIM ManagementState is empty, set it to the default value (Managed).
+	kserve := &dsc.Spec.Components.Kserve
+	if kserve.ManagementState == operatorv1.Managed {
+		if kserve.NIM.ManagementState == "" {
+			log.V(1).Info("Setting default ManagementState for Kserve NIM", "default", operatorv1.Managed)
+			kserve.NIM.ManagementState = operatorv1.Managed
+		}
+	}
 }

--- a/internal/webhook/datasciencecluster/v2/defaulting_test.go
+++ b/internal/webhook/datasciencecluster/v2/defaulting_test.go
@@ -81,3 +81,60 @@ func TestDefaulterV2_DefaultingLogic(t *testing.T) {
 		})
 	}
 }
+
+// TestDefaulterV2_NIMDefaultingLogic exercises the NIM defaulting webhook logic for DataScienceCluster v2 resources.
+func TestDefaulterV2_NIMDefaultingLogic(t *testing.T) {
+	t.Parallel()
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	testCases := []struct {
+		name                  string
+		kserveManagementState *operatorv1.ManagementState
+		nimManagementState    *operatorv1.ManagementState
+		expectedNIMState      operatorv1.ManagementState
+	}{
+		{
+			name:                  "Sets default NIM ManagementState if empty and Kserve is Managed",
+			kserveManagementState: ptrManagementState(operatorv1.Managed),
+			nimManagementState:    ptrManagementState(""),
+			expectedNIMState:      operatorv1.Managed,
+		},
+		{
+			name:                  "Does not overwrite NIM ManagementState if already set",
+			kserveManagementState: ptrManagementState(operatorv1.Managed),
+			nimManagementState:    ptrManagementState(operatorv1.Removed),
+			expectedNIMState:      operatorv1.Removed,
+		},
+		{
+			name:                  "Does nothing if Kserve is not Managed",
+			kserveManagementState: ptrManagementState(operatorv1.Removed),
+			nimManagementState:    ptrManagementState(""),
+			expectedNIMState:      "",
+		},
+		{
+			name:                  "Does nothing if Kserve is not set at all (upgrade case)",
+			kserveManagementState: nil,
+			nimManagementState:    nil,
+			expectedNIMState:      "",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			dsc := &dscv2.DataScienceCluster{}
+			if tc.kserveManagementState != nil {
+				dsc.Spec.Components.Kserve.ManagementState = *tc.kserveManagementState
+			}
+			if tc.nimManagementState != nil {
+				dsc.Spec.Components.Kserve.NIM.ManagementState = *tc.nimManagementState
+			}
+
+			defaulter := &v2webhook.Defaulter{Name: "test-v2"}
+			err := defaulter.Default(ctx, dsc)
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(dsc.Spec.Components.Kserve.NIM.ManagementState).To(Equal(tc.expectedNIMState))
+		})
+	}
+}

--- a/pkg/initialinstall/creation.go
+++ b/pkg/initialinstall/creation.go
@@ -42,6 +42,11 @@ func CreateDefaultDSC(ctx context.Context, cli client.Client) error {
 				},
 				Kserve: componentApi.DSCKserve{
 					ManagementSpec: common.ManagementSpec{ManagementState: operatorv1.Managed},
+					KserveCommonSpec: componentApi.KserveCommonSpec{
+						NIM: componentApi.NimSpec{
+							ManagementState: operatorv1.Managed,
+						},
+					},
 				},
 				Ray: componentApi.DSCRay{
 					ManagementSpec: common.ManagementSpec{ManagementState: operatorv1.Managed},

--- a/tests/e2e/helper_test.go
+++ b/tests/e2e/helper_test.go
@@ -252,7 +252,6 @@ func CreateDSC(name string, workbenchesNamespace string) *dscv2.DataScienceClust
 					ManagementSpec: common.ManagementSpec{
 						ManagementState: operatorv1.Removed,
 					},
-					KserveCommonSpec: componentApi.KserveCommonSpec{},
 				},
 				Ray: componentApi.DSCRay{
 					ManagementSpec: common.ManagementSpec{
@@ -358,7 +357,6 @@ func CreateDSCv1(name string, workbenchesNamespace string) *dscv1.DataScienceClu
 					ManagementSpec: common.ManagementSpec{
 						ManagementState: operatorv1.Removed,
 					},
-					KserveCommonSpec: componentApi.KserveCommonSpec{},
 				},
 				CodeFlare: componentApi.DSCCodeFlare{
 					ManagementSpec: common.ManagementSpec{


### PR DESCRIPTION
## Description

Fixes [RHOAIENG-64686](https://redhat.atlassian.net/browse/RHOAIENG-64686): Default DSC creation omits NIM configuration, causing DSC/KServe CR divergence.

### Problem

The DSC does not include the `nim` field when created via `oc apply` or the product install path (`pkg/initialinstall/creation.go`). The KServe component CR receives correct NIM defaults (`managementState: Managed`) via CRD schema defaults during SSA, but the DSC does not — causing the DSC and KServe CR to be out of sync from the moment of creation.

**Root cause:** `NimSpec` is tagged `json:"nim,omitempty"` in `KserveCommonSpec`, which strips the zero-value struct during JSON serialization. CRD schema defaults only apply to fields within objects that are present in the payload — since the entire `nim` object is absent, the API server never applies nested field-level defaults.

### Fix

1. **CRD schema fix** — Added `+kubebuilder:default={}` to the `NIM` field in `KserveCommonSpec`. This tells the API server to inject `nim: {}` when absent from the payload, which triggers the nested defaults (`managementState: Managed`, `airGapped: false`). Follows the pattern used in `api/cloudmanager/common/types.go` for LWS and Sail operator configs (suggested by @dbiazinim).

2. **Product default DSC** — Added explicit NIM config to the Kserve entry in `pkg/initialinstall/creation.go`, following the pattern used by Workbenches (`WorkbenchNamespace`) and ModelRegistry (`RegistriesNamespace`).

3. **Webhook defense-in-depth** — Added NIM defaulting to DSC v1/v2 webhooks: if Kserve is `Managed` and `NIM.ManagementState` is empty, set it to `Managed`. Catches edge cases like patching `nim` out of an existing DSC.

4. **E2E test gap fix** — Removed `KserveCommonSpec: componentApi.KserveCommonSpec{}` from `CreateDSC()` and `CreateDSCv1()` in `tests/e2e/helper_test.go`. This line caused the test to exercise a different code path than production: Go's `runtime.DefaultUnstructuredConverter.ToUnstructured()` uses reflection (not JSON serialization), which includes zero-value structs in the API payload — accidentally bypassing the `omitempty` bug. By removing it, the test DSC is created the same way a customer would, ensuring the `+kubebuilder:default={}` annotation is what provides the defaults. If someone reverts the CRD default, this test will now catch the regression.

## How Has This Been Tested?

- **Unit tests**: 8 new webhook defaulting tests (4 for v1, 4 for v2) covering: default when empty+Managed, don't overwrite if set, do nothing if Removed, do nothing if not set (upgrade case). All pass.
- **Lint**: `make lint` — 0 issues.
- **Manual verification**: Deployed fixed operator to OpenShift 4.21 cluster. Created DSC via `oc apply` without `nim` field — verified `nim: {managementState: Managed, airGapped: false}` appears on the DSC and matches the KServe CR.
- **Full e2e suite**: `make e2e-test E2E_TEST_TAG=All` — 489 passed, 0 failed (1 pre-existing flaky test passed on retry, unrelated to this change — RHOAIENG-46773).

## Merge criteria

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [x] The developer has run the integration test pipeline and verified that it passed successfully
- [ ] New RELATED_IMAGE mappings are listed in ODH-Build-Config and RHOAI-Build-Config (CI validates names against build-config repos). Include links to build-config PRs in the description.

### E2E test suite update requirement

- E2E test suite **is updated** in this PR (webhook unit tests added, e2e test gap fixed in `helper_test.go`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * NIM now defaults to "Managed" state when KServe is enabled.
  * Default empty configuration object provided for NIM specification.

* **Documentation**
  * Updated API reference to reflect NIM default configuration values.

* **Tests**
  * Added test coverage for NIM defaulting behavior across API versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->