### PR TITLE
feat: add DSC status condition and Subscription watch for NIM operator

### DIFF
--- a/internal/controller/components/kserve/kserve.go
+++ b/internal/controller/components/kserve/kserve.go
@@ -38,10 +38,12 @@ const (
 	ReadyConditionType                    = componentApi.KserveKind + status.ReadySuffix
 	LLMInferenceServiceDependencies       = componentApi.KserveKind + "LLMInferenceServiceDependencies"
 	LLMInferenceServiceWideEPDependencies = componentApi.KserveKind + "LLMInferenceServiceWideEPDependencies"
+	NIMOperatorDependencies               = componentApi.KserveKind + "NIMOperatorDependencies"
 	// OLM subscription names for KServe dependency operators.
 	RHCLOperatorSubscription        = "rhcl-operator"
 	LWSOperatorSubscription         = "leader-worker-set"
 	CertManagerOperatorSubscription = "openshift-cert-manager-operator"
+	NIMOperatorSubscription         = "nim-operator-certified"
 
 	// RHCL operator is not installed, message to users to deploy LLMInferenceService without auth.
 	rhclMissingMessage = "Red Hat Connectivity Link is not installed. To deploy LLMInferenceService " +
@@ -155,6 +157,9 @@ func (s *componentHandler) UpdateDSCStatus(ctx context.Context, rr *types.Reconc
 		}
 		if lwsCondition := conditions.FindStatusCondition(c.GetStatus(), LLMInferenceServiceWideEPDependencies); lwsCondition != nil {
 			rr.Conditions.MarkFrom(LLMInferenceServiceWideEPDependencies, *lwsCondition)
+		}
+		if nimCondition := conditions.FindStatusCondition(c.GetStatus(), NIMOperatorDependencies); nimCondition != nil {
+			rr.Conditions.MarkFrom(NIMOperatorDependencies, *nimCondition)
 		}
 	} else {
 		rr.Conditions.MarkFalse(

--- a/internal/controller/components/kserve/kserve_controller.go
+++ b/internal/controller/components/kserve/kserve_controller.go
@@ -145,6 +145,7 @@ func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.
 					resources.CreatedOrUpdatedOrDeletedNamed(RHCLOperatorSubscription),
 					resources.CreatedOrUpdatedOrDeletedNamed(LWSOperatorSubscription),
 					resources.CreatedOrUpdatedOrDeletedNamed(CertManagerOperatorSubscription),
+					resources.CreatedOrUpdatedOrDeletedNamed(NIMOperatorSubscription),
 				),
 			),
 			reconciler.Dynamic(reconciler.CrdExists(gvk.Subscription))).
@@ -207,6 +208,15 @@ func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.
 			precondition.WithConditionType(LLMInferenceServiceWideEPDependencies),
 			precondition.WithClusterTypes(cluster.ClusterTypeOpenShift),
 			precondition.WithSeverity(common.ConditionSeverityInfo),
+		)).
+		WithPreCondition(precondition.MonitorSubscriptions(
+			[]precondition.SubscriptionDependency{
+				{Name: NIMOperatorSubscription, DisplayName: "NVIDIA NIM"},
+			},
+			precondition.WithConditionType(NIMOperatorDependencies),
+			precondition.WithClusterTypes(cluster.ClusterTypeOpenShift),
+			precondition.WithSeverity(common.ConditionSeverityInfo),
+			precondition.WithSkipFunc(nimNotManaged),
 		)).
 
 		// actions

--- a/internal/controller/components/kserve/kserve_controller_dependency_test.go
+++ b/internal/controller/components/kserve/kserve_controller_dependency_test.go
@@ -340,10 +340,11 @@ func TestSubscriptionDependencyMonitoring(t *testing.T) {
 				status.ConditionDependenciesAvailable),
 		)
 
-		// Subscription conditions should be True (not-applicable) on Kubernetes
+		// LLMInferenceServiceDependencies should not be written on Kubernetes
+		// (non-dependent, OpenShift-only subscription check)
 		wt.Get(gvk.Kserve, nn).Consistently().WithTimeout(5 * time.Second).Should(
-			jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`,
-				LLMInferenceServiceDependencies, metav1.ConditionTrue),
+			jq.Match(`all(.status.conditions[]?.type; . != "%s")`,
+				LLMInferenceServiceDependencies),
 		)
 
 		// LLMInferenceServiceWideEPDependencies IS expected on Kubernetes (from MonitorCRDs for LWS)
@@ -477,7 +478,7 @@ func TestNIMSubscriptionDependencyMonitoring(t *testing.T) {
 		)
 	})
 
-	t.Run("Kubernetes cluster sets NIM condition to True (not applicable)", func(t *testing.T) {
+	t.Run("Kubernetes cluster does not write NIM condition", func(t *testing.T) {
 		cluster.SetClusterInfo(cluster.ClusterInfo{Type: cluster.ClusterTypeKubernetes})
 		t.Cleanup(func() { cluster.SetClusterInfo(cluster.ClusterInfo{}) })
 
@@ -495,10 +496,10 @@ func TestNIMSubscriptionDependencyMonitoring(t *testing.T) {
 				status.ConditionDependenciesAvailable),
 		)
 
-		// NIM subscription condition should be True on Kubernetes (cluster-type skip = not applicable)
-		wt.Get(gvk.Kserve, nn).Eventually().Should(
-			jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`,
-				NIMOperatorDependencies, metav1.ConditionTrue),
+		// NIM condition should not be written on Kubernetes
+		wt.Get(gvk.Kserve, nn).Consistently().WithTimeout(5 * time.Second).Should(
+			jq.Match(`all(.status.conditions[]?.type; . != "%s")`,
+				NIMOperatorDependencies),
 		)
 	})
 }

--- a/internal/controller/components/kserve/kserve_controller_dependency_test.go
+++ b/internal/controller/components/kserve/kserve_controller_dependency_test.go
@@ -477,7 +477,7 @@ func TestNIMSubscriptionDependencyMonitoring(t *testing.T) {
 		)
 	})
 
-	t.Run("Kubernetes cluster skips NIM subscription check", func(t *testing.T) {
+	t.Run("Kubernetes cluster sets NIM condition to True (not applicable)", func(t *testing.T) {
 		cluster.SetClusterInfo(cluster.ClusterInfo{Type: cluster.ClusterTypeKubernetes})
 		t.Cleanup(func() { cluster.SetClusterInfo(cluster.ClusterInfo{}) })
 
@@ -495,10 +495,10 @@ func TestNIMSubscriptionDependencyMonitoring(t *testing.T) {
 				status.ConditionDependenciesAvailable),
 		)
 
-		// NIM subscription condition should not be written on Kubernetes
-		wt.Get(gvk.Kserve, nn).Consistently().WithTimeout(5 * time.Second).Should(
-			jq.Match(`all(.status.conditions[]?.type; . != "%s")`,
-				NIMOperatorDependencies),
+		// NIM subscription condition should be True on Kubernetes (cluster-type skip = not applicable)
+		wt.Get(gvk.Kserve, nn).Eventually().Should(
+			jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`,
+				NIMOperatorDependencies, metav1.ConditionTrue),
 		)
 	})
 }

--- a/internal/controller/components/kserve/kserve_controller_dependency_test.go
+++ b/internal/controller/components/kserve/kserve_controller_dependency_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	operatorv1 "github.com/openshift/api/operator/v1"
 	v1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -67,6 +68,23 @@ func createKserveDependencyCR(t *testing.T, wt *testf.WithT) {
 
 	cr := &componentApi.Kserve{
 		ObjectMeta: metav1.ObjectMeta{Name: componentApi.KserveInstanceName},
+	}
+	wt.Expect(wt.Client().Create(wt.Context(), cr)).Should(Succeed())
+	envt.CleanupDelete(t, NewWithT(t), wt.Context(), wt.Client(), cr)
+}
+
+func createKserveCRWithNIM(t *testing.T, wt *testf.WithT, nimState operatorv1.ManagementState) {
+	t.Helper()
+
+	cr := &componentApi.Kserve{
+		ObjectMeta: metav1.ObjectMeta{Name: componentApi.KserveInstanceName},
+		Spec: componentApi.KserveSpec{
+			KserveCommonSpec: componentApi.KserveCommonSpec{
+				NIM: componentApi.NimSpec{
+					ManagementState: nimState,
+				},
+			},
+		},
 	}
 	wt.Expect(wt.Client().Create(wt.Context(), cr)).Should(Succeed())
 	envt.CleanupDelete(t, NewWithT(t), wt.Context(), wt.Client(), cr)
@@ -332,6 +350,155 @@ func TestSubscriptionDependencyMonitoring(t *testing.T) {
 		wt.Get(gvk.Kserve, nn).Eventually().Should(
 			jq.Match(`[.status.conditions[] | select(.type == "%s")] | length > 0`,
 				LLMInferenceServiceWideEPDependencies),
+		)
+	})
+}
+
+func TestNIMSubscriptionDependencyMonitoring(t *testing.T) {
+	t.Run("OpenShift cluster with NIM Managed and missing subscription sets condition to False", func(t *testing.T) {
+		cluster.SetClusterInfo(cluster.ClusterInfo{Type: cluster.ClusterTypeOpenShift})
+		t.Cleanup(func() { cluster.SetClusterInfo(cluster.ClusterInfo{}) })
+
+		ctx, cancel := context.WithCancel(context.Background())
+		et, wt := startKserveController(t, ctx)
+		t.Cleanup(cancel)
+
+		crd, err := et.RegisterCRD(wt.Context(), gvk.Subscription,
+			"subscriptions", "subscription", apiextensionsv1.NamespaceScoped)
+		wt.Expect(err).NotTo(HaveOccurred())
+		envt.CleanupDelete(t, NewWithT(t), wt.Context(), wt.Client(), crd)
+
+		createKserveCRWithNIM(t, wt, operatorv1.Managed)
+
+		nn := types.NamespacedName{Name: componentApi.KserveInstanceName}
+
+		wt.Get(gvk.Kserve, nn).Eventually().Should(And(
+			jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`,
+				NIMOperatorDependencies, metav1.ConditionFalse),
+			jq.Match(`.status.conditions[] | select(.type == "%s") | .severity == "%s"`,
+				NIMOperatorDependencies, common.ConditionSeverityInfo),
+			jq.Match(`.status.conditions[] | select(.type == "%s") | .message | contains("NVIDIA NIM")`,
+				NIMOperatorDependencies),
+		))
+	})
+
+	t.Run("OpenShift cluster with NIM Managed and subscription present sets condition to True", func(t *testing.T) {
+		cluster.SetClusterInfo(cluster.ClusterInfo{Type: cluster.ClusterTypeOpenShift})
+		t.Cleanup(func() { cluster.SetClusterInfo(cluster.ClusterInfo{}) })
+
+		ctx, cancel := context.WithCancel(context.Background())
+		et, wt := startKserveController(t, ctx)
+		t.Cleanup(cancel)
+
+		crd, err := et.RegisterCRD(wt.Context(), gvk.Subscription,
+			"subscriptions", "subscription", apiextensionsv1.NamespaceScoped)
+		wt.Expect(err).NotTo(HaveOccurred())
+		envt.CleanupDelete(t, NewWithT(t), wt.Context(), wt.Client(), crd)
+
+		sub := &v1alpha1.Subscription{
+			ObjectMeta: metav1.ObjectMeta{Name: NIMOperatorSubscription, Namespace: "default"},
+		}
+		wt.Expect(wt.Client().Create(wt.Context(), sub)).To(Succeed())
+		envt.CleanupDelete(t, NewWithT(t), wt.Context(), wt.Client(), sub)
+
+		createKserveCRWithNIM(t, wt, operatorv1.Managed)
+
+		nn := types.NamespacedName{Name: componentApi.KserveInstanceName}
+
+		wt.Get(gvk.Kserve, nn).Eventually().Should(
+			jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`,
+				NIMOperatorDependencies, metav1.ConditionTrue),
+		)
+	})
+
+	t.Run("OpenShift cluster with NIM Removed skips condition", func(t *testing.T) {
+		cluster.SetClusterInfo(cluster.ClusterInfo{Type: cluster.ClusterTypeOpenShift})
+		t.Cleanup(func() { cluster.SetClusterInfo(cluster.ClusterInfo{}) })
+
+		ctx, cancel := context.WithCancel(context.Background())
+		et, wt := startKserveController(t, ctx)
+		t.Cleanup(cancel)
+
+		crd, err := et.RegisterCRD(wt.Context(), gvk.Subscription,
+			"subscriptions", "subscription", apiextensionsv1.NamespaceScoped)
+		wt.Expect(err).NotTo(HaveOccurred())
+		envt.CleanupDelete(t, NewWithT(t), wt.Context(), wt.Client(), crd)
+
+		createKserveCRWithNIM(t, wt, operatorv1.Removed)
+
+		nn := types.NamespacedName{Name: componentApi.KserveInstanceName}
+
+		// Wait for reconciliation by checking that other subscription conditions exist.
+		wt.Get(gvk.Kserve, nn).Eventually().Should(
+			jq.Match(`[.status.conditions[] | select(.type == "%s")] | length > 0`,
+				LLMInferenceServiceDependencies),
+		)
+
+		// NIM condition should not be written when NIM is Removed
+		wt.Get(gvk.Kserve, nn).Consistently().WithTimeout(5 * time.Second).Should(
+			jq.Match(`all(.status.conditions[]?.type; . != "%s")`,
+				NIMOperatorDependencies),
+		)
+	})
+
+	t.Run("OpenShift cluster cleans up condition when NIM transitions from Managed to Removed", func(t *testing.T) {
+		cluster.SetClusterInfo(cluster.ClusterInfo{Type: cluster.ClusterTypeOpenShift})
+		t.Cleanup(func() { cluster.SetClusterInfo(cluster.ClusterInfo{}) })
+
+		ctx, cancel := context.WithCancel(context.Background())
+		et, wt := startKserveController(t, ctx)
+		t.Cleanup(cancel)
+
+		crd, err := et.RegisterCRD(wt.Context(), gvk.Subscription,
+			"subscriptions", "subscription", apiextensionsv1.NamespaceScoped)
+		wt.Expect(err).NotTo(HaveOccurred())
+		envt.CleanupDelete(t, NewWithT(t), wt.Context(), wt.Client(), crd)
+
+		createKserveCRWithNIM(t, wt, operatorv1.Managed)
+
+		nn := types.NamespacedName{Name: componentApi.KserveInstanceName}
+
+		// Wait for the NIM condition to appear, expected to be False due to missing NIM Subscription
+		wt.Get(gvk.Kserve, nn).Eventually().Should(
+			jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`,
+				NIMOperatorDependencies, metav1.ConditionFalse),
+		)
+
+		// Patch NIM to Removed
+		cr := &componentApi.Kserve{}
+		wt.Expect(wt.Client().Get(wt.Context(), nn, cr)).To(Succeed())
+		cr.Spec.NIM.ManagementState = operatorv1.Removed
+		wt.Expect(wt.Client().Update(wt.Context(), cr)).To(Succeed())
+
+		// Wait for NIM condition to be cleaned up
+		wt.Get(gvk.Kserve, nn).Eventually().Should(
+			jq.Match(`all(.status.conditions[]?.type; . != "%s")`,
+				NIMOperatorDependencies),
+		)
+	})
+
+	t.Run("Kubernetes cluster skips NIM subscription check", func(t *testing.T) {
+		cluster.SetClusterInfo(cluster.ClusterInfo{Type: cluster.ClusterTypeKubernetes})
+		t.Cleanup(func() { cluster.SetClusterInfo(cluster.ClusterInfo{}) })
+
+		ctx, cancel := context.WithCancel(context.Background())
+		_, wt := startKserveController(t, ctx)
+		t.Cleanup(cancel)
+
+		createKserveCRWithNIM(t, wt, operatorv1.Managed)
+
+		nn := types.NamespacedName{Name: componentApi.KserveInstanceName}
+
+		// Wait for reconciliation by checking DependenciesAvailable exists
+		wt.Get(gvk.Kserve, nn).Eventually().Should(
+			jq.Match(`[.status.conditions[] | select(.type == "%s")] | length > 0`,
+				status.ConditionDependenciesAvailable),
+		)
+
+		// NIM subscription condition should not be written on Kubernetes
+		wt.Get(gvk.Kserve, nn).Consistently().WithTimeout(5 * time.Second).Should(
+			jq.Match(`all(.status.conditions[]?.type; . != "%s")`,
+				NIMOperatorDependencies),
 		)
 	})
 }

--- a/internal/controller/components/kserve/kserve_support.go
+++ b/internal/controller/components/kserve/kserve_support.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"strings"
 
+	operatorv1 "github.com/openshift/api/operator/v1"
 	corev1 "k8s.io/api/core/v1"
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -262,6 +263,15 @@ func isForDependency(s string) func(u *unstructured.Unstructured) bool {
 func isKserveOwnerRef(or metav1.OwnerReference) bool {
 	return or.APIVersion == componentApi.GroupVersion.String() &&
 		or.Kind == componentApi.KserveKind
+}
+
+func nimNotManaged(_ context.Context, rr *odhtypes.ReconciliationRequest) (bool, error) {
+	k, ok := rr.Instance.(*componentApi.Kserve)
+	if !ok {
+		return false, errors.New("instance is not a Kserve CR")
+	}
+
+	return k.Spec.NIM.ManagementState != operatorv1.Managed, nil
 }
 
 // lwsConditionFilter monitors LeaderWorkerSet operator conditions for degraded state.

--- a/pkg/controller/conditions/conditions.go
+++ b/pkg/controller/conditions/conditions.go
@@ -119,6 +119,10 @@ func (r *Manager) initializeConditions() {
 	}
 }
 
+func (r *Manager) IsDependent(conditionType string) bool {
+	return slices.Contains(r.dependents, conditionType)
+}
+
 func (r *Manager) IsHappy() bool {
 	if r.accessor == nil {
 		return false

--- a/pkg/controller/precondition/precondition.go
+++ b/pkg/controller/precondition/precondition.go
@@ -158,10 +158,15 @@ func RunAll(ctx context.Context, rr *types.ReconciliationRequest, preConditions 
 		pc := &preConditions[i]
 
 		// Skip preconditions that don't apply to this cluster type.
-		// Initialize the aggregate so the condition is written as True
-		// (not-applicable = satisfied) rather than left unset.
+		// Only write a True condition for dependents (which would
+		// otherwise be marked as ConditionNotSet errors by
+		// CleanupStaleConditions). Non-dependent conditions are
+		// left unwritten so cleanup removes them as orphans.
 		if len(pc.clusterTypes) > 0 && !slices.Contains(pc.clusterTypes, clusterType) {
-			initAggregate(results, pc.conditionType)
+			if rr.Conditions.IsDependent(pc.conditionType) {
+				initAggregate(results, pc.conditionType)
+			}
+
 			continue
 		}
 

--- a/pkg/controller/precondition/precondition.go
+++ b/pkg/controller/precondition/precondition.go
@@ -177,7 +177,14 @@ func RunAll(ctx context.Context, rr *types.ReconciliationRequest, preConditions 
 
 			if skip {
 				l.Info("Pre-condition skipped by runtime predicate", "conditionType", pc.conditionType)
-				initAggregate(results, pc.conditionType)
+
+				// Only write a True condition for dependents (which would
+				// otherwise be marked as ConditionNotSet errors by
+				// CleanupStaleConditions). Non-dependent conditions are
+				// left unwritten so cleanup removes them as orphans.
+				if rr.Conditions.IsDependent(pc.conditionType) {
+					initAggregate(results, pc.conditionType)
+				}
 
 				continue
 			}

--- a/pkg/controller/precondition/precondition_test.go
+++ b/pkg/controller/precondition/precondition_test.go
@@ -316,57 +316,78 @@ func TestRunAll_ClusterTypeFiltering(t *testing.T) {
 }
 
 func TestRunAll_SkipFunc(t *testing.T) {
-	tests := []struct {
-		name           string
-		skipFunc       SkipFunc
-		expectedStatus metav1.ConditionStatus
-		expectedMsg    string
-	}{
-		{
-			name:           "returns true skips precondition",
-			skipFunc:       func(_ context.Context, _ *types.ReconciliationRequest) (bool, error) { return true, nil },
-			expectedStatus: metav1.ConditionTrue,
-		},
-		{
-			name:           "returns false runs precondition",
-			skipFunc:       func(_ context.Context, _ *types.ReconciliationRequest) (bool, error) { return false, nil },
-			expectedStatus: metav1.ConditionFalse,
-			expectedMsg:    "skip func test",
-		},
-		{
-			name:           "nil runs precondition",
-			skipFunc:       nil,
-			expectedStatus: metav1.ConditionFalse,
-			expectedMsg:    "skip func test",
-		},
-	}
+	t.Run("returns true skips non-dependent precondition without writing condition", func(t *testing.T) {
+		g := NewWithT(t)
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			g := NewWithT(t)
+		const optionalDep = "OptionalDependency"
 
-			rr := newRR(status.ConditionDependenciesAvailable)
+		rr := newRR()
+		pcs := []PreCondition{
+			newPreCondition(
+				failingCheck("skip func test"),
+				WithConditionType(optionalDep),
+				WithSkipFunc(func(_ context.Context, _ *types.ReconciliationRequest) (bool, error) { return true, nil }),
+			),
+		}
 
-			opts := []Option{}
-			if tt.skipFunc != nil {
-				opts = append(opts, WithSkipFunc(tt.skipFunc))
-			}
+		RunAll(t.Context(), rr, pcs)
 
-			pcs := []PreCondition{
-				newPreCondition(failingCheck("skip func test"), opts...),
-			}
+		got := rr.Conditions.GetCondition(optionalDep)
+		g.Expect(got).To(BeNil(), "skipped non-dependent precondition should not write any condition")
+	})
 
-			RunAll(t.Context(), rr, pcs)
+	t.Run("returns true skips dependent precondition with True condition", func(t *testing.T) {
+		g := NewWithT(t)
 
-			got := rr.Conditions.GetCondition(status.ConditionDependenciesAvailable)
-			g.Expect(got).NotTo(BeNil())
-			g.Expect(got.Status).To(Equal(tt.expectedStatus))
+		rr := newRR(status.ConditionDependenciesAvailable)
+		pcs := []PreCondition{
+			newPreCondition(
+				failingCheck("skip func test"),
+				WithSkipFunc(func(_ context.Context, _ *types.ReconciliationRequest) (bool, error) { return true, nil }),
+			),
+		}
 
-			if tt.expectedMsg != "" {
-				g.Expect(got.Message).To(ContainSubstring(tt.expectedMsg))
-			}
-		})
-	}
+		RunAll(t.Context(), rr, pcs)
+
+		got := rr.Conditions.GetCondition(status.ConditionDependenciesAvailable)
+		g.Expect(got).NotTo(BeNil(), "skipped dependent precondition should still write the condition")
+		g.Expect(got.Status).To(Equal(metav1.ConditionTrue))
+	})
+
+	t.Run("returns false runs precondition", func(t *testing.T) {
+		g := NewWithT(t)
+
+		rr := newRR(status.ConditionDependenciesAvailable)
+		pcs := []PreCondition{
+			newPreCondition(
+				failingCheck("skip func test"),
+				WithSkipFunc(func(_ context.Context, _ *types.ReconciliationRequest) (bool, error) { return false, nil }),
+			),
+		}
+
+		RunAll(t.Context(), rr, pcs)
+
+		got := rr.Conditions.GetCondition(status.ConditionDependenciesAvailable)
+		g.Expect(got).NotTo(BeNil())
+		g.Expect(got.Status).To(Equal(metav1.ConditionFalse))
+		g.Expect(got.Message).To(ContainSubstring("skip func test"))
+	})
+
+	t.Run("nil runs precondition", func(t *testing.T) {
+		g := NewWithT(t)
+
+		rr := newRR(status.ConditionDependenciesAvailable)
+		pcs := []PreCondition{
+			newPreCondition(failingCheck("skip func test")),
+		}
+
+		RunAll(t.Context(), rr, pcs)
+
+		got := rr.Conditions.GetCondition(status.ConditionDependenciesAvailable)
+		g.Expect(got).NotTo(BeNil())
+		g.Expect(got.Status).To(Equal(metav1.ConditionFalse))
+		g.Expect(got.Message).To(ContainSubstring("skip func test"))
+	})
 }
 
 func TestRunAll_SkipFuncError(t *testing.T) {
@@ -394,25 +415,31 @@ func TestRunAll_SkipFuncError(t *testing.T) {
 func TestRunAll_SkipFuncCleansStaleCondition(t *testing.T) {
 	g := NewWithT(t)
 
-	rr := newRR(status.ConditionDependenciesAvailable)
+	const optionalDep = "OptionalDependency"
+
+	// Conditions guarded by WithSkipFunc (e.g. NIMOperatorDependencies) are
+	// not registered as dependents, so CleanupStaleConditions removes them
+	// as orphans when they are no longer written.
+	rr := newRR()
 
 	// Reconcile #1: skipFunc=false, check fails → condition written as False.
 	pcs := []PreCondition{
-		newPreCondition(failingCheck("dependency degraded")),
+		newPreCondition(failingCheck("dependency degraded"), WithConditionType(optionalDep)),
 	}
 
 	RunAll(t.Context(), rr, pcs)
 
-	got := rr.Conditions.GetCondition(status.ConditionDependenciesAvailable)
+	got := rr.Conditions.GetCondition(optionalDep)
 	g.Expect(got).NotTo(BeNil())
 	g.Expect(got.Status).To(Equal(metav1.ConditionFalse))
 
-	// Reconcile #2: skipFunc=true → precondition writes True (not-applicable = satisfied).
+	// Reconcile #2: skipFunc=true → no condition written, cleanup removes the stale one.
 	rr.Conditions.Reset()
 
 	pcs = []PreCondition{
 		newPreCondition(
 			failingCheck("should not run"),
+			WithConditionType(optionalDep),
 			WithSkipFunc(func(_ context.Context, _ *types.ReconciliationRequest) (bool, error) {
 				return true, nil
 			}),
@@ -422,9 +449,8 @@ func TestRunAll_SkipFuncCleansStaleCondition(t *testing.T) {
 	RunAll(t.Context(), rr, pcs)
 	rr.Conditions.CleanupStaleConditions()
 
-	got = rr.Conditions.GetCondition(status.ConditionDependenciesAvailable)
-	g.Expect(got).NotTo(BeNil(), "skipped precondition should still write the condition")
-	g.Expect(got.Status).To(Equal(metav1.ConditionTrue))
+	got = rr.Conditions.GetCondition(optionalDep)
+	g.Expect(got).To(BeNil(), "skipped precondition condition should be removed by cleanup")
 }
 
 func TestRunAll_ClusterTypeFilterRunsBeforeSkipFunc(t *testing.T) {

--- a/pkg/controller/precondition/precondition_test.go
+++ b/pkg/controller/precondition/precondition_test.go
@@ -293,26 +293,51 @@ func TestRunAll_EmptyList(t *testing.T) {
 }
 
 func TestRunAll_ClusterTypeFiltering(t *testing.T) {
-	g := NewWithT(t)
+	t.Run("skipped dependent precondition writes True condition", func(t *testing.T) {
+		g := NewWithT(t)
 
-	cluster.SetClusterInfo(cluster.ClusterInfo{Type: cluster.ClusterTypeOpenShift})
-	t.Cleanup(func() { cluster.SetClusterInfo(cluster.ClusterInfo{}) })
+		cluster.SetClusterInfo(cluster.ClusterInfo{Type: cluster.ClusterTypeOpenShift})
+		t.Cleanup(func() { cluster.SetClusterInfo(cluster.ClusterInfo{}) })
 
-	rr := newRR(status.ConditionDependenciesAvailable)
-	pcs := []PreCondition{
-		newPreCondition(
-			failingCheck("k8s only check"),
-			WithClusterTypes(cluster.ClusterTypeKubernetes),
-			WithStopReconciliation(),
-		),
-	}
+		rr := newRR(status.ConditionDependenciesAvailable)
+		pcs := []PreCondition{
+			newPreCondition(
+				failingCheck("k8s only check"),
+				WithClusterTypes(cluster.ClusterTypeKubernetes),
+				WithStopReconciliation(),
+			),
+		}
 
-	shouldStop := RunAll(t.Context(), rr, pcs)
+		shouldStop := RunAll(t.Context(), rr, pcs)
 
-	g.Expect(shouldStop).To(BeFalse())
-	got := rr.Conditions.GetCondition(status.ConditionDependenciesAvailable)
-	g.Expect(got).NotTo(BeNil())
-	g.Expect(got.Status).NotTo(Equal(metav1.ConditionFalse))
+		g.Expect(shouldStop).To(BeFalse())
+		got := rr.Conditions.GetCondition(status.ConditionDependenciesAvailable)
+		g.Expect(got).NotTo(BeNil())
+		g.Expect(got.Status).To(Equal(metav1.ConditionTrue))
+	})
+
+	t.Run("skipped non-dependent precondition does not write condition", func(t *testing.T) {
+		g := NewWithT(t)
+
+		const optionalDep = "OptionalDependency"
+
+		cluster.SetClusterInfo(cluster.ClusterInfo{Type: cluster.ClusterTypeOpenShift})
+		t.Cleanup(func() { cluster.SetClusterInfo(cluster.ClusterInfo{}) })
+
+		rr := newRR()
+		pcs := []PreCondition{
+			newPreCondition(
+				failingCheck("k8s only check"),
+				WithConditionType(optionalDep),
+				WithClusterTypes(cluster.ClusterTypeKubernetes),
+			),
+		}
+
+		RunAll(t.Context(), rr, pcs)
+
+		got := rr.Conditions.GetCondition(optionalDep)
+		g.Expect(got).To(BeNil(), "skipped non-dependent precondition should not write any condition")
+	})
 }
 
 func TestRunAll_SkipFunc(t *testing.T) {


### PR DESCRIPTION
<!---
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
Introduces a new `KserveNIMOperatorDependencies` status condition in DSC:
- if NIM is set to Managed in KServe config, this condition reflects the presence of NIM operator Subscription
- if NIM is set to Removed, the condition is skipped and not visible in DSC

JIRA ref: [RHOAIENG-62464](https://redhat.atlassian.net/browse/RHOAIENG-62464)

## How Has This Been Tested?
Added unit test coverage and manually verified the following scenarios on OpenShift cluster with KServe:
1. NIM set to Managed + NIM operator not installed
    - condition is False with `NVIDIA NIM: subscription not found` message 
2. NIM set to Managed + NIM operator installed
    - condition is True
3. NIM set to Removed
    - condition not visible/present in DSC

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully
- [ ] New RELATED_IMAGE mappings are listed in ODH-Build-Config and RHOAI-Build-Config (CI validates names against build-config repos). Include links to build-config PRs in the description.

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
5. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
6. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
7. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
Change does not affect existing e2e coverage, unit test coverage was added similarly to how LWS/RHCL dependencies are handled

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * KServe now watches the NVIDIA NIM operator subscription on OpenShift and propagates NIM dependency status into component conditions.
  * Reconciliation is gated by the NIM management setting, and NIM-related conditions are skipped/cleaned appropriately when not managed.

* **Bug Fixes**
  * Precondition handling no longer writes `True` for skipped non-dependent conditions, ensuring stale-condition cleanup can remove orphans.

* **Tests**
  * Added KServe dependency-monitoring tests for NIM scenarios (subscription present/missing, Managed/Removed transitions, and Kubernetes behavior).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->