### PR TITLE
fix(modules): add Platform CRD to rhaii xKS deployment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -280,6 +280,7 @@ endif
 	@# Copy KServe CRD to shared rhaii overlay and generate kustomization
 	@mkdir -p config/rhaii/crd/bases
 	@cp $(CONFIG_DIR)/crd/bases/components.platform.opendatahub.io_kserves.yaml config/rhaii/crd/bases/
+	@cp $(CONFIG_DIR)/crd/bases/config.opendatahub.io_platforms.yaml config/rhaii/crd/bases/
 	@$(call add-crd-to-kustomization,config/rhaii/crd/bases)
 	@# Generate shared rhaii webhook manifests with only KServe connection webhooks
 	@$(YQ) eval 'select(.kind == "MutatingWebhookConfiguration") | .webhooks = [.webhooks[] | select(.name == "connection-isvc.opendatahub.io" or .name == "connection-llmisvc.opendatahub.io")]' $(CONFIG_DIR)/webhook/manifests.yaml > config/rhaii/webhook/manifests.yaml

--- a/tests/e2e/odh_manager_test.go
+++ b/tests/e2e/odh_manager_test.go
@@ -47,9 +47,9 @@ func (tc *OperatorTestCtx) filterCRDTestCases(crds []struct {
 	}
 
 	// In XKS platform (KinD cluster), only a subset of CRDs is expected.
-	// Only the KServe CRD is expected
 	allowedCRDs := []string{
 		"kserves.components.platform.opendatahub.io",
+		"platforms.config.opendatahub.io",
 	}
 
 	var filtered []struct {
@@ -93,6 +93,7 @@ func (tc *OperatorTestCtx) ValidateOwnedCRDs(t *testing.T) {
 		{"Auth CRD", "auths.services.platform.opendatahub.io"},
 		{"SparkOperator CRD", "sparkoperators.components.platform.opendatahub.io"},
 		{"MLflowOperator CRD", "mlflowoperators.components.platform.opendatahub.io"},
+		{"Platform CRD", "platforms.config.opendatahub.io"},
 	}
 
 	crdsTestCases = tc.filterCRDTestCases(crdsTestCases)


### PR DESCRIPTION
## Description

- Add Platform CRD (`config.opendatahub.io_platforms.yaml`) to `config/rhaii/crd/bases/` so the operator no longer crashes with `CrashLoopBackOff` on xKS clusters when entering Platform mode.
- Add `platforms.config.opendatahub.io` to the xKS e2e CRD allowlist in `filterCRDTestCases()` so `ValidateOwnedCRDs` catches missing Platform CRD regressions.

**Root cause:** PR #3459 introduced the Platform CRD and dual-mode module reconciler, but the Makefile only copied the KServe CRD to the rhaii overlay. Without Platform CRD, the informer cache sync times out after ~2 minutes → manager exits → CrashLoopBackOff. The e2e passed because the operator starts and serves KServe reconciliation during the retry window; the crash occurs after tests complete.

Jira task: https://issues.redhat.com/browse/RHOAIENG-67048

## How Has This Been Tested?

- Verified `config.opendatahub.io_platforms.yaml` exists in `config/crd/bases/` (generated by `make manifests`)
- After `make manifests`, `config/rhaii/crd/bases/kustomization.yaml` lists both `kserves` and `platforms`
- `kustomize build config/rhaii/odh` renders the Platform CRD in output
- E2E validation: `run-xks-e2e` label required — `ValidateOwnedCRDs` now verifies Platform CRD presence on xKS

## Merge criteria

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully
- [ ] New RELATED_IMAGE mappings are listed in ODH-Build-Config and RHOAI-Build-Config (CI validates names against build-config repos). Include links to build-config PRs in the description.

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [ ] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Platform CRD is now included in the RHAII overlay so platform configuration is propagated alongside existing CRDs.

* **Tests**
  * End-to-end platform validation tests updated to allow and validate the additional Platform CRD.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->