### PR TITLE
add controller image injection

### DIFF
--- a/internal/controller/modules/base.go
+++ b/internal/controller/modules/base.go
@@ -79,6 +79,14 @@ type ModuleConfig struct {
 	// Override only if the module chart uses a different container name.
 	ContainerName string
 
+	// ControllerImage is the RELATED_IMAGE_* env var name whose value is the
+	// fully-qualified image reference for this module's operator container.
+	// When set and the env var is present on the platform operator process,
+	// the inject action overwrites the target container's image field in the
+	// rendered Deployment. Leave empty if the chart already bakes in the
+	// correct image and no override is needed.
+	ControllerImage string
+
 	// RelatedImages lists RELATED_IMAGE_* environment variable names that the
 	// module operator needs. The platform reads each name from its own process
 	// environment (where the release pipeline sets digest-pinned references)
@@ -107,6 +115,10 @@ func (b *BaseHandler) GetContainerName() string {
 		return b.Config.ContainerName
 	}
 	return "manager"
+}
+
+func (b *BaseHandler) GetControllerImage() string {
+	return b.Config.ControllerImage
 }
 
 func (b *BaseHandler) GetRelatedImages() []string {

--- a/internal/controller/modules/modules_controller_actions.go
+++ b/internal/controller/modules/modules_controller_actions.go
@@ -226,9 +226,10 @@ func provisionModules(ctx context.Context, rr *odhtype.ReconciliationRequest) er
 		}
 
 		perModuleImages = append(perModuleImages, odhtype.ModuleImages{
-			DeploymentName: deploymentNameFromManifests(operatorManifests, handler.GetName()),
-			ContainerName:  containerNameFor(handler),
-			Images:         handler.GetRelatedImages(),
+			DeploymentName:  deploymentNameFromManifests(operatorManifests, handler.GetName()),
+			ContainerName:   containerNameFor(handler),
+			ControllerImage: controllerImageFor(handler),
+			Images:          handler.GetRelatedImages(),
 		})
 		if len(operatorManifests.HelmCharts) > 0 {
 			rr.HelmCharts = append(rr.HelmCharts, operatorManifests.HelmCharts...)
@@ -268,6 +269,13 @@ func containerNameFor(h ModuleHandler) string {
 		return cn.GetContainerName()
 	}
 	return defaultContainerName
+}
+
+func controllerImageFor(h ModuleHandler) string {
+	if ci, ok := h.(ControllerImager); ok {
+		return ci.GetControllerImage()
+	}
+	return ""
 }
 
 // deploymentNameFromManifests returns the expected Deployment name for a module

--- a/internal/controller/modules/modules_controller_actions_inject_env.go
+++ b/internal/controller/modules/modules_controller_actions_inject_env.go
@@ -90,6 +90,19 @@ func injectEnvVarsIntoDeployment(log logr.Logger, obj *unstructured.Unstructured
 			continue
 		}
 
+		if mi.ControllerImage != "" {
+			if img := os.Getenv(mi.ControllerImage); img != "" {
+				container["image"] = img
+				injected++
+				log.V(3).Info("overriding controller image",
+					"deployment", deployName, "container", targetName,
+					"envVar", mi.ControllerImage)
+			} else {
+				log.V(1).Info("controller image env var not set, keeping chart default",
+					"envVar", mi.ControllerImage, "deployment", deployName)
+			}
+		}
+
 		existingEnv, _ := container["env"].([]any)
 
 		for _, relImg := range mi.Images {

--- a/internal/controller/modules/modules_controller_actions_inject_env_test.go
+++ b/internal/controller/modules/modules_controller_actions_inject_env_test.go
@@ -78,6 +78,20 @@ func getContainerEnvByName(obj *unstructured.Unstructured, containerName string)
 	return nil
 }
 
+func getContainerImage(obj *unstructured.Unstructured, containerName string) string {
+	containers, _, _ := unstructured.NestedSlice(obj.Object, "spec", "template", "spec", "containers")
+	for _, c := range containers {
+		if cm, ok := c.(map[string]any); ok {
+			if name, _ := cm["name"].(string); name == containerName {
+				img, _ := cm["image"].(string)
+				return img
+			}
+		}
+	}
+
+	return ""
+}
+
 func getContainerEnv(obj *unstructured.Unstructured) []any {
 	return getContainerEnvByName(obj, "manager")
 }
@@ -299,4 +313,79 @@ func TestInjectModuleEnvEmptyNamespace(t *testing.T) {
 
 	env := getContainerEnv(&rr.Resources[0])
 	g.Expect(env).Should(BeNil())
+}
+
+func TestInjectControllerImage(t *testing.T) {
+	g := NewWithT(t)
+
+	t.Setenv("RELATED_IMAGE_MODULE_CONTROLLER", "registry.example.com/module-ctrl@sha256:abc123")
+
+	dep := makeDeployment("module-operator")
+
+	rr := &odhtype.ReconciliationRequest{
+		Resources: []unstructured.Unstructured{dep},
+		ModuleEnvInjection: &odhtype.ModuleEnvInjection{
+			PerModuleImages: []odhtype.ModuleImages{{
+				DeploymentName:  "module-operator",
+				ControllerImage: "RELATED_IMAGE_MODULE_CONTROLLER",
+			}},
+		},
+	}
+
+	err := injectModuleEnv(context.Background(), rr)
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	img := getContainerImage(&rr.Resources[0], "manager")
+	g.Expect(img).Should(Equal("registry.example.com/module-ctrl@sha256:abc123"))
+}
+
+func TestInjectControllerImageNotSet(t *testing.T) {
+	g := NewWithT(t)
+
+	dep := makeDeployment("module-operator")
+
+	rr := &odhtype.ReconciliationRequest{
+		Resources: []unstructured.Unstructured{dep},
+		ModuleEnvInjection: &odhtype.ModuleEnvInjection{
+			PerModuleImages: []odhtype.ModuleImages{{
+				DeploymentName:  "module-operator",
+				ControllerImage: "RELATED_IMAGE_NOT_SET",
+			}},
+		},
+	}
+
+	err := injectModuleEnv(context.Background(), rr)
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	img := getContainerImage(&rr.Resources[0], "manager")
+	g.Expect(img).Should(Equal("registry.example.com/module:latest"))
+}
+
+func TestInjectControllerImageWithRelatedImages(t *testing.T) {
+	g := NewWithT(t)
+
+	t.Setenv("RELATED_IMAGE_MODULE_CONTROLLER", "registry.example.com/module-ctrl@sha256:abc123")
+	t.Setenv("RELATED_IMAGE_SIDECAR", "registry.example.com/sidecar@sha256:def456")
+
+	dep := makeDeployment("module-operator")
+
+	rr := &odhtype.ReconciliationRequest{
+		Resources: []unstructured.Unstructured{dep},
+		ModuleEnvInjection: &odhtype.ModuleEnvInjection{
+			PerModuleImages: []odhtype.ModuleImages{{
+				DeploymentName:  "module-operator",
+				ControllerImage: "RELATED_IMAGE_MODULE_CONTROLLER",
+				Images:          []string{"RELATED_IMAGE_SIDECAR"},
+			}},
+		},
+	}
+
+	err := injectModuleEnv(context.Background(), rr)
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	img := getContainerImage(&rr.Resources[0], "manager")
+	g.Expect(img).Should(Equal("registry.example.com/module-ctrl@sha256:abc123"))
+
+	env := getContainerEnv(&rr.Resources[0])
+	g.Expect(envValue(env, "RELATED_IMAGE_SIDECAR")).Should(Equal("registry.example.com/sidecar@sha256:def456"))
 }

--- a/internal/controller/modules/types.go
+++ b/internal/controller/modules/types.go
@@ -98,6 +98,13 @@ type ContainerNamer interface {
 	GetContainerName() string
 }
 
+// ControllerImager is an optional interface a ModuleHandler can implement to
+// declare a RELATED_IMAGE_* env var whose value replaces the operator
+// container's image in the rendered Deployment. See BaseHandler.GetControllerImage.
+type ControllerImager interface {
+	GetControllerImage() string
+}
+
 // ModuleStatus holds the parsed status from a module CR. It includes the
 // standard conditions and generation metadata needed for staleness detection
 // per the onboarding guide's PlatformObject contract.

--- a/internal/controller/modules/types.go
+++ b/internal/controller/modules/types.go
@@ -91,16 +91,19 @@ type ModuleHandler interface {
 	DeleteOperatorResources(ctx context.Context, cli client.Client, platform *PlatformContext) error
 }
 
-// ContainerNamer is an optional interface a ModuleHandler can implement to
-// override the default container name ("manager") used for RELATED_IMAGE_*
-// environment variable injection. See BaseHandler.GetContainerName.
+// ContainerNamer allows a module handler to override the default container
+// name ("manager") used for RELATED_IMAGE_* and controller image injection.
+// All handlers embedding BaseHandler satisfy this interface automatically;
+// the override is only active when ModuleConfig.ContainerName is set.
 type ContainerNamer interface {
 	GetContainerName() string
 }
 
-// ControllerImager is an optional interface a ModuleHandler can implement to
-// declare a RELATED_IMAGE_* env var whose value replaces the operator
-// container's image in the rendered Deployment. See BaseHandler.GetControllerImage.
+// ControllerImager allows a module handler to declare a RELATED_IMAGE_* env
+// var whose value replaces the operator container's image in the rendered
+// Deployment. All handlers embedding BaseHandler satisfy this interface
+// automatically; the override is only active when ModuleConfig.ControllerImage
+// is set.
 type ControllerImager interface {
 	GetControllerImage() string
 }

--- a/pkg/controller/types/types.go
+++ b/pkg/controller/types/types.go
@@ -45,6 +45,9 @@ type ModuleImages struct {
 	// ContainerName is the target container within the Deployment.
 	// Defaults to "manager" (the kubebuilder convention).
 	ContainerName string
+	// ControllerImage is the RELATED_IMAGE_* env var name whose value
+	// replaces the target container's image field. Empty means no override.
+	ControllerImage string
 	// Images is the list of RELATED_IMAGE_* env var names for this module.
 	Images []string
 }


### PR DESCRIPTION
<!---
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->
Controller Image Injection lets the ODH operator override a module operator's container image at deploy time using a RELATED_IMAGE_* environment variable. This enables disconnected/air-gapped deployments where OLM sets digest-pinned image references on the ODH operator, which then forwards them to each module's Deployment.

Configuration — add ControllerImage to your module's ModuleConfig:

```
func NewHandler() *handler {
    return &handler{
        BaseHandler: modules.BaseHandler{
            Config: modules.ModuleConfig{
                Name:            "my-module",
                GVK:             gvk.MyModule,
                CRName:          "default",
                ReleaseName:     "my-module-operator",
                ChartDir:        "my-module-operator",
                ControllerImage: "RELATED_IMAGE_MY_MODULE_CONTROLLER",
                RelatedImages: []string{
                    "RELATED_IMAGE_MY_MODULE_PROXY",
                    "RELATED_IMAGE_MY_MODULE_SIDECAR",
                },
            },
        },
    }
}
```

ControllerImage — the env var name whose value replaces the image field on the target container (defaults to "manager") in the rendered Deployment. If the env var is unset, the chart's baked-in image is kept.
RelatedImages — env var names injected as environment variables into the same container (existing behavior, unchanged).
<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [x] The developer has run the integration test pipeline and verified that it passed successfully
- [x] New RELATED_IMAGE mappings are listed in ODH-Build-Config and RHOAI-Build-Config (CI validates names against build-config repos). Include links to build-config PRs in the description.

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->
No e2e tests for modules yet.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-module support for overriding the operator container image via an environment-variable name, with automatic fallback to chart defaults when unset.
  * Handlers may now optionally supply a controller-image override to influence rendered deployments.

* **Tests**
  * Added tests covering controller-image injection, fallback behavior, and interaction with related-image injections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->