### PR TITLE
Add odh-workbenches-controller to manifests-config.yaml

### DIFF
--- a/build/manifests-config.yaml
+++ b/build/manifests-config.yaml
@@ -72,3 +72,6 @@ map:
   odh-batch-gateway-operator:
     src: config/
     dest: batch-gateway-operator
+  odh-workbenches-controller:
+    src: ./workspaces/controller/manifests/kustomize
+    dest: workbenches/odh-workbenches-controller


### PR DESCRIPTION
Adds 'odh-workbenches-controller' to the operator manifests config map.

Component: odh-workbenches-controller
Manifest source path: ./workspaces/controller/manifests/kustomize
Manifest dest path:   workbenches/odh-workbenches-controller
Upstream repo: https://github.com/opendatahub-io/workbenches @ main
Jira: https://redhat.atlassian.net/browse/RHOAIENG-66820

**File changed:**
- `build/manifests-config.yaml` — added `odh-workbenches-controller` entry under `map:`