### PR TITLE
RHOAIENG-62691: fix(gateway): fix stale client ID on upgrade and cleanup legacy OAuthClient 

### DIFF
--- a/Dockerfiles/e2e-tests/e2e-tests.Dockerfile
+++ b/Dockerfiles/e2e-tests/e2e-tests.Dockerfile
@@ -1,5 +1,5 @@
 # E2E Test Image with precompiled tests
-ARG GOLANG_VERSION=1.25
+ARG GOLANG_VERSION=1.26
 
 ################################################################################
 FROM registry.access.redhat.com/ubi9/go-toolset:$GOLANG_VERSION as builder

--- a/internal/controller/services/gateway/gateway_controller_actions.go
+++ b/internal/controller/services/gateway/gateway_controller_actions.go
@@ -326,7 +326,7 @@ func getTemplateData(ctx context.Context, rr *odhtypes.ReconciliationRequest) (m
 		"TLSCertsVolumeName":       TLSCertsVolumeName,
 		"TLSCertsMountPath":        TLSCertsMountPath,
 		"EnvoyFilter":              AuthnFilterName,
-		"RedirectURL":              fmt.Sprintf("https://%s/oauth2/callback", hostname),
+		"RedirectURL":              fmt.Sprintf("https://%s%s", hostname, OAuthCallbackPath),
 		"DestinationRuleName":      DestinationRuleName,
 		"CookieExpire":             cookieExpire,
 		"CookieRefresh":            cookieRefresh,

--- a/internal/controller/services/gateway/gateway_integration_helpers_test.go
+++ b/internal/controller/services/gateway/gateway_integration_helpers_test.go
@@ -145,7 +145,7 @@ func HostForSubdomain(subdomain, domain string) string {
 
 // OAuthRedirectURI returns the OAuth redirect URI for the given hostname (used to assert OAuthClient.RedirectURIs).
 func OAuthRedirectURI(hostname string) string {
-	return "https://" + hostname + gateway.AuthProxyOAuth2Path + "/callback"
+	return "https://" + hostname + gateway.OAuthCallbackPath
 }
 
 // SpecMutationCookieConfig returns the cookie config used in spec-mutation tests (48h expire, 2h refresh).

--- a/internal/controller/services/gateway/gateway_support.go
+++ b/internal/controller/services/gateway/gateway_support.go
@@ -43,6 +43,7 @@ const (
 	LegacyGatewaySubdomain  = "data-science-gateway"               // Legacy subdomain to redirect from
 
 	// Authentication constants.
+	LegacyAuthClientID       = "odh"          // Legacy OauthClient name from RHOAI 3.3.
 	AuthClientID             = "data-science" // OauthClient name.
 	KubeAuthProxyName        = "kube-auth-proxy"
 	KubeAuthProxySecretsName = "kube-auth-proxy-creds" //nolint:gosec // This is a resource name, not actual credentials
@@ -58,6 +59,7 @@ const (
 	GatewayHTTPSPort     = 8443
 
 	AuthProxyOAuth2Path = "/oauth2"
+	OAuthCallbackPath   = AuthProxyOAuth2Path + "/callback"
 	// OAuth2 proxy cookie name - used in both proxy args and EnvoyFilter Lua filter.
 	AuthProxyCookieName = "_oauth2_proxy"
 
@@ -385,7 +387,7 @@ func createOAuthClient(ctx context.Context, rr *odhtypes.ReconciliationRequest, 
 	if err != nil {
 		return fmt.Errorf("failed to resolve domain: %w", err)
 	}
-	redirectURL := fmt.Sprintf("https://%s/oauth2/callback", domain)
+	redirectURL := fmt.Sprintf("https://%s%s", domain, OAuthCallbackPath)
 	oauthClient := &oauthv1.OAuthClient{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: AuthClientID,
@@ -584,10 +586,16 @@ func getAuthProxySecretValues(
 	if secretErr == nil {
 		clientSecretBytes, hasClientSecret := existingSecret.Data["OAUTH2_PROXY_CLIENT_SECRET"]
 		cookieSecretBytes, hasCookieSecret := existingSecret.Data["OAUTH2_PROXY_COOKIE_SECRET"]
-		clientIDBytes, hasClientID := existingSecret.Data["OAUTH2_PROXY_CLIENT_ID"]
 
-		if hasClientSecret && hasCookieSecret && hasClientID {
-			return string(clientIDBytes), string(clientSecretBytes), string(cookieSecretBytes), nil
+		if hasClientSecret && hasCookieSecret {
+			switch authMode {
+			case cluster.AuthModeOIDC:
+				return oidcConfig.ClientID, string(clientSecretBytes), string(cookieSecretBytes), nil
+			case cluster.AuthModeIntegratedOAuth:
+				return AuthClientID, string(clientSecretBytes), string(cookieSecretBytes), nil
+			default:
+				return "", "", "", fmt.Errorf("auth mode: %s is not supported", authMode)
+			}
 		}
 	}
 

--- a/pkg/upgrade/upgrade.go
+++ b/pkg/upgrade/upgrade.go
@@ -5,11 +5,13 @@ package upgrade
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"reflect"
 	"strings"
 
 	"github.com/go-logr/logr"
 	"github.com/hashicorp/go-multierror"
+	oauthv1 "github.com/openshift/api/oauth/v1"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -94,6 +96,8 @@ func CleanupExistingResource(ctx context.Context,
 	multiErr = multierror.Append(multiErr, cleanupModelControllerLegacyDeployment(ctx, cli, applicationNS))
 	// cleanup deprecated kueue ValidatingAdmissionPolicyBinding
 	multiErr = multierror.Append(multiErr, cleanupDeprecatedKueueVAPB(ctx, cli))
+	// cleanup legacy "odh" OAuthClient from RHOAI 3.3
+	multiErr = multierror.Append(multiErr, cleanupLegacyOAuthClient(ctx, cli))
 
 	// HardwareProfile migration as described in RHOAIENG-33158 and RHOAIENG-33159
 	// This includes creating HardwareProfile resources and updating annotations on Notebooks and InferenceServices
@@ -228,6 +232,48 @@ func cleanupDeprecatedKueueVAPB(ctx context.Context, cli client.Client) error {
 		log.Info("Successfully deleted deprecated ValidatingAdmissionPolicyBinding")
 	}
 
+	return nil
+}
+
+// cleanupLegacyOAuthClient removes the legacy "odh" OAuthClient left over from
+// RHOAI 3.3 upgrades. It only deletes the client if a redirect URI is an HTTPS
+// URL whose path exactly matches OAuthCallbackPath, confirming it was created by
+// the gateway controller and not by an unrelated user workload.
+func cleanupLegacyOAuthClient(ctx context.Context, cli client.Client) error {
+	log := logf.FromContext(ctx)
+
+	legacyClient := &oauthv1.OAuthClient{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: gateway.LegacyAuthClientID,
+		},
+	}
+
+	if err := cli.Get(ctx, client.ObjectKeyFromObject(legacyClient), legacyClient); err != nil {
+		// IsNoMatchError: OAuthClient CRD not registered (OIDC clusters)
+		if k8serr.IsNotFound(err) || meta.IsNoMatchError(err) {
+			return nil
+		}
+		return fmt.Errorf("failed to check for legacy OAuthClient %q: %w", gateway.LegacyAuthClientID, err)
+	}
+
+	isGatewayClient := false
+	for _, uri := range legacyClient.RedirectURIs {
+		u, err := url.Parse(uri)
+		if err == nil && u.Scheme == "https" && u.Path == gateway.OAuthCallbackPath {
+			isGatewayClient = true
+			break
+		}
+	}
+
+	if !isGatewayClient {
+		return nil
+	}
+
+	if err := cli.Delete(ctx, legacyClient); client.IgnoreNotFound(err) != nil {
+		return fmt.Errorf("failed to delete legacy OAuthClient %q: %w", gateway.LegacyAuthClientID, err)
+	}
+
+	log.Info("Deleted legacy OAuthClient from previous version", "name", gateway.LegacyAuthClientID)
 	return nil
 }
 

--- a/tests/e2e/gateway_test.go
+++ b/tests/e2e/gateway_test.go
@@ -118,7 +118,7 @@ func gatewayTestSuite(t *testing.T) {
 // makeRedirectURL constructs the OAuth redirect URL for the authentication proxy.
 // Format: https://<gateway-hostname>/oauth2/callback
 func makeRedirectURL(hostname string) string {
-	return fmt.Sprintf("--redirect-url=https://%s%s/callback", hostname, authProxyOAuth2Path)
+	return fmt.Sprintf("--redirect-url=https://%s%s", hostname, gateway.OAuthCallbackPath)
 }
 
 // makeCookieDomain constructs the cookie domain argument for the authentication proxy.
@@ -203,7 +203,7 @@ func (tc *GatewayTestCtx) ValidateOAuthClientAndSecret(t *testing.T) {
 	t.Log("Validating OAuth client and secret creation")
 
 	expectedGatewayHostname := tc.getExpectedGatewayHostname(t)
-	expectedRedirectURI := "https://" + expectedGatewayHostname + authProxyOAuth2Path + "/callback"
+	expectedRedirectURI := "https://" + expectedGatewayHostname + gateway.OAuthCallbackPath
 
 	// OAuthClient
 	t.Log("Validating OAuthClient resource")


### PR DESCRIPTION
After upgrading from RHOAI 3.3 to 3.4, the kube-auth-proxy-creds secret preserved the stale "odh" client ID instead of updating to "data-science". Fix getAuthProxySecretValues to always use the desired client ID from the current auth mode config while reusing existing clientSecret and cookieSecret to avoid session invalidation.

Also add one-time cleanup of the legacy "odh" OAuthClient in the startup upgrade path (pkg/upgrade), with a safety check that only deletes it if the redirect URI contains /oauth2/callback.

Extract OAuthCallbackPath constant and LegacyAuthClientID constant to avoid hardcoded strings.

<!---
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully
- [ ] New RELATED_IMAGE mappings are listed in ODH-Build-Config and RHOAI-Build-Config (CI validates names against build-config repos). Include links to build-config PRs in the description.

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [ ] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped Go default to 1.26 for the end-to-end test environment.

* **Bug Fixes**
  * Standardized OAuth callback URL usage across runtime and tests.
  * Improved reuse logic for OAuth client/secret so the correct client and secrets are selected.
  * Added automatic cleanup of a legacy OAuth client during upgrades when its redirect URI matches the current callback path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->