### PR TITLE
Support controller image injection into init containers

### DIFF
--- a/internal/controller/modules/base.go
+++ b/internal/controller/modules/base.go
@@ -87,6 +87,13 @@ type ModuleConfig struct {
 	// correct image and no override is needed.
 	ControllerImage string
 
+	// InitContainerName is the name of an init container whose image field
+	// should be overridden with the same ControllerImage value. This is for
+	// modules whose Deployment includes an init container that shares the
+	// operator image (e.g. "copy-manifests"). Leave empty if no init
+	// container needs the override.
+	InitContainerName string
+
 	// RelatedImages lists RELATED_IMAGE_* environment variable names that the
 	// module operator needs. The platform reads each name from its own process
 	// environment (where the release pipeline sets digest-pinned references)
@@ -119,6 +126,10 @@ func (b *BaseHandler) GetContainerName() string {
 
 func (b *BaseHandler) GetControllerImage() string {
 	return b.Config.ControllerImage
+}
+
+func (b *BaseHandler) GetInitContainerName() string {
+	return b.Config.InitContainerName
 }
 
 func (b *BaseHandler) GetRelatedImages() []string {

--- a/internal/controller/modules/modules_controller_actions.go
+++ b/internal/controller/modules/modules_controller_actions.go
@@ -226,10 +226,11 @@ func provisionModules(ctx context.Context, rr *odhtype.ReconciliationRequest) er
 		}
 
 		perModuleImages = append(perModuleImages, odhtype.ModuleImages{
-			DeploymentName:  deploymentNameFromManifests(operatorManifests, handler.GetName()),
-			ContainerName:   containerNameFor(handler),
-			ControllerImage: controllerImageFor(handler),
-			Images:          handler.GetRelatedImages(),
+			DeploymentName:    deploymentNameFromManifests(operatorManifests, handler.GetName()),
+			ContainerName:     containerNameFor(handler),
+			ControllerImage:   controllerImageFor(handler),
+			InitContainerName: initContainerNameFor(handler),
+			Images:            handler.GetRelatedImages(),
 		})
 		if len(operatorManifests.HelmCharts) > 0 {
 			rr.HelmCharts = append(rr.HelmCharts, operatorManifests.HelmCharts...)
@@ -274,6 +275,13 @@ func containerNameFor(h ModuleHandler) string {
 func controllerImageFor(h ModuleHandler) string {
 	if ci, ok := h.(ControllerImager); ok {
 		return ci.GetControllerImage()
+	}
+	return ""
+}
+
+func initContainerNameFor(h ModuleHandler) string {
+	if icn, ok := h.(InitContainerNamer); ok {
+		return icn.GetInitContainerName()
 	}
 	return ""
 }

--- a/internal/controller/modules/modules_controller_actions_inject_env.go
+++ b/internal/controller/modules/modules_controller_actions_inject_env.go
@@ -78,7 +78,7 @@ func injectEnvVarsIntoDeployment(log logr.Logger, obj *unstructured.Unstructured
 			targetName = defaultContainerName
 		}
 
-		idx := findManagerContainer(containers, targetName)
+		idx := findNamedContainer(containers, targetName)
 		if idx < 0 {
 			log.Error(nil, "target container not found in Deployment, skipping env injection",
 				"deployment", deployName, "container", targetName)
@@ -173,9 +173,9 @@ func setOrOverrideEnv(envSlice *[]any, name, value string) bool {
 	return true
 }
 
-// findManagerContainer returns the index of the container with the given
+// findNamedContainer returns the index of the container with the given
 // name, or -1 if none is found.
-func findManagerContainer(containers []any, targetName string) int {
+func findNamedContainer(containers []any, targetName string) int {
 	for i, c := range containers {
 		if cm, ok := c.(map[string]any); ok {
 			if name, ok := cm["name"].(string); ok && name == targetName {
@@ -211,11 +211,9 @@ func injectInitContainerImage(
 		return 0, nil
 	}
 
-	idx := findManagerContainer(initContainers, initContainerName)
+	idx := findNamedContainer(initContainers, initContainerName)
 	if idx < 0 {
-		log.Error(nil, "target init container not found in Deployment, skipping",
-			"deployment", deployName, "initContainer", initContainerName)
-		return 0, nil
+		return 0, fmt.Errorf("init container %q not found in Deployment %s", initContainerName, deployName)
 	}
 
 	ic, ok := initContainers[idx].(map[string]any)

--- a/internal/controller/modules/modules_controller_actions_inject_env.go
+++ b/internal/controller/modules/modules_controller_actions_inject_env.go
@@ -97,6 +97,12 @@ func injectEnvVarsIntoDeployment(log logr.Logger, obj *unstructured.Unstructured
 				log.V(3).Info("overriding controller image",
 					"deployment", deployName, "container", targetName,
 					"envVar", mi.ControllerImage)
+
+				initInjected, err := injectInitContainerImage(log, obj, mi.InitContainerName, img, deployName, mi.ControllerImage)
+				if err != nil {
+					return err
+				}
+				injected += initInjected
 			} else {
 				log.V(1).Info("controller image env var not set, keeping chart default",
 					"envVar", mi.ControllerImage, "deployment", deployName)
@@ -179,4 +185,54 @@ func findManagerContainer(containers []any, targetName string) int {
 	}
 
 	return -1
+}
+
+// injectInitContainerImage overrides the image field on a named init container
+// with the resolved controller image. Returns 1 if patched, 0 otherwise.
+func injectInitContainerImage(
+	log logr.Logger,
+	obj *unstructured.Unstructured,
+	initContainerName string,
+	img string,
+	deployName string,
+	envVar string,
+) (int, error) {
+	if initContainerName == "" {
+		return 0, nil
+	}
+
+	initContainers, found, err := unstructured.NestedSlice(obj.Object, "spec", "template", "spec", "initContainers")
+	if err != nil {
+		return 0, err
+	}
+	if !found || len(initContainers) == 0 {
+		log.V(1).Info("no initContainers in Deployment, skipping init container image injection",
+			"deployment", deployName)
+		return 0, nil
+	}
+
+	idx := findManagerContainer(initContainers, initContainerName)
+	if idx < 0 {
+		log.Error(nil, "target init container not found in Deployment, skipping",
+			"deployment", deployName, "initContainer", initContainerName)
+		return 0, nil
+	}
+
+	ic, ok := initContainers[idx].(map[string]any)
+	if !ok {
+		return 0, nil
+	}
+
+	ic["image"] = img
+	initContainers[idx] = ic
+
+	if err := unstructured.SetNestedSlice(obj.Object, initContainers, "spec", "template", "spec", "initContainers"); err != nil {
+		return 0, err
+	}
+
+	log.V(3).Info("overriding init container image",
+		"deployment", deployName, "initContainer", initContainerName,
+		"envVar", envVar)
+
+	return 1, nil
 }

--- a/internal/controller/modules/modules_controller_actions_inject_env_test.go
+++ b/internal/controller/modules/modules_controller_actions_inject_env_test.go
@@ -92,6 +92,54 @@ func getContainerImage(obj *unstructured.Unstructured, containerName string) str
 	return ""
 }
 
+func getInitContainerImage(obj *unstructured.Unstructured, containerName string) string {
+	initContainers, _, _ := unstructured.NestedSlice(obj.Object, "spec", "template", "spec", "initContainers")
+	for _, c := range initContainers {
+		if cm, ok := c.(map[string]any); ok {
+			if name, _ := cm["name"].(string); name == containerName {
+				img, _ := cm["image"].(string)
+				return img
+			}
+		}
+	}
+
+	return ""
+}
+
+func makeDeploymentWithInitContainers(name string, initContainerNames ...string) unstructured.Unstructured {
+	initContainers := make([]any, 0, len(initContainerNames))
+	for _, n := range initContainerNames {
+		initContainers = append(initContainers, map[string]any{
+			"name":  n,
+			"image": "registry.example.com/module:latest",
+		})
+	}
+
+	return unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "apps/v1",
+			"kind":       "Deployment",
+			"metadata": map[string]any{
+				"name":      name,
+				"namespace": "opendatahub",
+			},
+			"spec": map[string]any{
+				"template": map[string]any{
+					"spec": map[string]any{
+						"initContainers": initContainers,
+						"containers": []any{
+							map[string]any{
+								"name":  "manager",
+								"image": "registry.example.com/module:latest",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
 func getContainerEnv(obj *unstructured.Unstructured) []any {
 	return getContainerEnvByName(obj, "manager")
 }
@@ -294,6 +342,9 @@ func TestInjectModuleEnvTargetsManagerContainer(t *testing.T) {
 
 	sidecarEnv := getContainerEnvByName(&rr.Resources[0], "sidecar")
 	g.Expect(sidecarEnv).Should(BeNil())
+
+	g.Expect(getContainerImage(&rr.Resources[0], "sidecar")).
+		Should(Equal("registry.example.com/sidecar:latest"))
 }
 
 func TestInjectModuleEnvEmptyNamespace(t *testing.T) {
@@ -388,4 +439,109 @@ func TestInjectControllerImageWithRelatedImages(t *testing.T) {
 
 	env := getContainerEnv(&rr.Resources[0])
 	g.Expect(envValue(env, "RELATED_IMAGE_SIDECAR")).Should(Equal("registry.example.com/sidecar@sha256:def456"))
+}
+
+func TestInjectInitContainerImage(t *testing.T) {
+	g := NewWithT(t)
+
+	t.Setenv("RELATED_IMAGE_MODULE_CONTROLLER", "registry.example.com/module-ctrl@sha256:abc123")
+
+	dep := makeDeploymentWithInitContainers("ai-gateway-operator", "setup")
+
+	rr := &odhtype.ReconciliationRequest{
+		Resources: []unstructured.Unstructured{dep},
+		ModuleEnvInjection: &odhtype.ModuleEnvInjection{
+			PerModuleImages: []odhtype.ModuleImages{{
+				DeploymentName:    "ai-gateway-operator",
+				ControllerImage:   "RELATED_IMAGE_MODULE_CONTROLLER",
+				InitContainerName: "setup",
+			}},
+		},
+	}
+
+	err := injectModuleEnv(context.Background(), rr)
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	g.Expect(getContainerImage(&rr.Resources[0], "manager")).
+		Should(Equal("registry.example.com/module-ctrl@sha256:abc123"))
+	g.Expect(getInitContainerImage(&rr.Resources[0], "setup")).
+		Should(Equal("registry.example.com/module-ctrl@sha256:abc123"))
+}
+
+func TestInjectInitContainerImageNotSet(t *testing.T) {
+	g := NewWithT(t)
+
+	dep := makeDeploymentWithInitContainers("module-operator", "copy-manifests")
+
+	rr := &odhtype.ReconciliationRequest{
+		Resources: []unstructured.Unstructured{dep},
+		ModuleEnvInjection: &odhtype.ModuleEnvInjection{
+			PerModuleImages: []odhtype.ModuleImages{{
+				DeploymentName:    "module-operator",
+				ControllerImage:   "RELATED_IMAGE_NOT_SET",
+				InitContainerName: "copy-manifests",
+			}},
+		},
+	}
+
+	err := injectModuleEnv(context.Background(), rr)
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	g.Expect(getContainerImage(&rr.Resources[0], "manager")).
+		Should(Equal("registry.example.com/module:latest"))
+	g.Expect(getInitContainerImage(&rr.Resources[0], "copy-manifests")).
+		Should(Equal("registry.example.com/module:latest"))
+}
+
+func TestInjectInitContainerNotFound(t *testing.T) {
+	g := NewWithT(t)
+
+	t.Setenv("RELATED_IMAGE_MODULE_CONTROLLER", "registry.example.com/module-ctrl@sha256:abc123")
+
+	dep := makeDeploymentWithInitContainers("module-operator", "copy-manifests")
+
+	rr := &odhtype.ReconciliationRequest{
+		Resources: []unstructured.Unstructured{dep},
+		ModuleEnvInjection: &odhtype.ModuleEnvInjection{
+			PerModuleImages: []odhtype.ModuleImages{{
+				DeploymentName:    "module-operator",
+				ControllerImage:   "RELATED_IMAGE_MODULE_CONTROLLER",
+				InitContainerName: "nonexistent",
+			}},
+		},
+	}
+
+	err := injectModuleEnv(context.Background(), rr)
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	g.Expect(getContainerImage(&rr.Resources[0], "manager")).
+		Should(Equal("registry.example.com/module-ctrl@sha256:abc123"))
+	g.Expect(getInitContainerImage(&rr.Resources[0], "copy-manifests")).
+		Should(Equal("registry.example.com/module:latest"))
+}
+
+func TestInjectEmptyInitContainerName(t *testing.T) {
+	g := NewWithT(t)
+
+	t.Setenv("RELATED_IMAGE_MODULE_CONTROLLER", "registry.example.com/module-ctrl@sha256:abc123")
+
+	dep := makeDeploymentWithInitContainers("module-operator", "copy-manifests")
+
+	rr := &odhtype.ReconciliationRequest{
+		Resources: []unstructured.Unstructured{dep},
+		ModuleEnvInjection: &odhtype.ModuleEnvInjection{
+			PerModuleImages: []odhtype.ModuleImages{{
+				DeploymentName:  "module-operator",
+				ControllerImage: "RELATED_IMAGE_MODULE_CONTROLLER",
+			}},
+		},
+	}
+
+	err := injectModuleEnv(context.Background(), rr)
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	g.Expect(getContainerImage(&rr.Resources[0], "manager")).
+		Should(Equal("registry.example.com/module-ctrl@sha256:abc123"))
+	g.Expect(getInitContainerImage(&rr.Resources[0], "copy-manifests")).
+		Should(Equal("registry.example.com/module:latest"))
 }

--- a/internal/controller/modules/modules_controller_actions_inject_env_test.go
+++ b/internal/controller/modules/modules_controller_actions_inject_env_test.go
@@ -512,12 +512,8 @@ func TestInjectInitContainerNotFound(t *testing.T) {
 	}
 
 	err := injectModuleEnv(context.Background(), rr)
-	g.Expect(err).ShouldNot(HaveOccurred())
-
-	g.Expect(getContainerImage(&rr.Resources[0], "manager")).
-		Should(Equal("registry.example.com/module-ctrl@sha256:abc123"))
-	g.Expect(getInitContainerImage(&rr.Resources[0], "copy-manifests")).
-		Should(Equal("registry.example.com/module:latest"))
+	g.Expect(err).Should(HaveOccurred())
+	g.Expect(err.Error()).Should(ContainSubstring(`init container "nonexistent" not found`))
 }
 
 func TestInjectEmptyInitContainerName(t *testing.T) {

--- a/internal/controller/modules/types.go
+++ b/internal/controller/modules/types.go
@@ -108,6 +108,14 @@ type ControllerImager interface {
 	GetControllerImage() string
 }
 
+// InitContainerNamer allows a module handler to declare an init container
+// whose image should be overridden with the same ControllerImage value.
+// All handlers embedding BaseHandler satisfy this interface automatically;
+// the override is only active when ModuleConfig.InitContainerName is set.
+type InitContainerNamer interface {
+	GetInitContainerName() string
+}
+
 // ModuleStatus holds the parsed status from a module CR. It includes the
 // standard conditions and generation metadata needed for staleness detection
 // per the onboarding guide's PlatformObject contract.

--- a/pkg/controller/types/types.go
+++ b/pkg/controller/types/types.go
@@ -48,6 +48,9 @@ type ModuleImages struct {
 	// ControllerImage is the RELATED_IMAGE_* env var name whose value
 	// replaces the target container's image field. Empty means no override.
 	ControllerImage string
+	// InitContainerName is the name of an init container whose image field
+	// should also be overridden with the ControllerImage value.
+	InitContainerName string
 	// Images is the list of RELATED_IMAGE_* env var names for this module.
 	Images []string
 }


### PR DESCRIPTION
Add InitContainerName to ModuleConfig so module handlers can declare an init container that shares the operator image. The inject action overrides its image field with the same ControllerImage env var value already used for the main container.

<!---
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->
**Summary**
Adds `InitContainerName` to `ModuleConfig` so module handlers can declare an init container whose image should be overridden with the same `ControllerImage` env var value used for the main container.
This supports modules like ai-gateway-operator whose Deployment includes an init container (e.g. `copy-manifests`) that shares the operator image and needs the same digest-pinned override injected by the platform.

**Usage**
```go
Config: modules.ModuleConfig{
    ControllerImage:   "RELATED_IMAGE_AI_GATEWAY_OPERATOR",
    InitContainerName: "copy-manifests",
}
```
**Changes**
- ModuleConfig.InitContainerName field + InitContainerNamer interface + BaseHandler accessor
- ModuleImages.InitContainerName field to carry the value through the pipeline
- injectInitContainerImage patches the named init container in spec.template.spec.initContainers after the main container image is resolved
- 4 new test cases: successful injection, env var not set (fallback), init container not found (graceful skip), empty name (no-op)
<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [x] The developer has run the integration test pipeline and verified that it passed successfully
- [x] New RELATED_IMAGE mappings are listed in ODH-Build-Config and RHOAI-Build-Config (CI validates names against build-config repos). Include links to build-config PRs in the description.

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->
Covered in unit tests.