### PR TITLE
RHOAIENG-62629: Add agents-operator to RHOAI product description

### DIFF
--- a/config/rhoai/manifests/description-patch.yml
+++ b/config/rhoai/manifests/description-patch.yml
@@ -30,3 +30,4 @@ spec:
     * OGX - Unified open-source APIs for inference, RAG, agents, safety, evals & telemetry
     * MLflow - MLflow is an open-source platform, purpose-built to assist machine learning practitioners and teams in handling the complexities of the machine learning process. MLflow focuses on the full lifecycle for machine learning projects, ensuring that each phase is manageable, traceable, and reproducible.
     * Spark Operator - Spark Operator is a Kubernetes operator for managing Apache Spark applications. It provides a way to deploy and manage Spark applications on Kubernetes.
+    * Agent Operator (Tech Preview) - Register, discover, and manage AI agent workloads on the platform through AgentRuntime custom resources. Provides agent lifecycle management, capability discovery, and observability integration.


### PR DESCRIPTION
## Summary

Add Agent Operator (Tech Preview) to the RHOAI CSV product description for OperatorHub visibility.

## Changes

- `config/rhoai/manifests/description-patch.yml`: Added agents-operator entry to the `### Components` section

## Context

Part of [RHOAIENG-62629](https://redhat.atlassian.net/browse/RHOAIENG-62629) (RHOAI operator integration). The agents-operator is being onboarded as a modular component via [RHOAIENG-62623](https://redhat.atlassian.net/browse/RHOAIENG-62623).

### E2E test suite update requirement

- [x] Skip requirement to update E2E test suite for this PR

#### E2E update requirement opt-out justification

Documentation-only change — adds a product description line to the RHOAI CSV. No operator code, API, or behavior changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated product description to include Agent Operator (Tech Preview) capability information

<!-- end of auto-generated comment: release notes by coderabbit.ai -->