### PR TITLE
offboard trainer operator

### DIFF
--- a/build/manifests-config.yaml
+++ b/build/manifests-config.yaml
@@ -48,9 +48,6 @@ map:
   odh-trainer:
     src: manifests
     dest: trainer
-  odh-trainer-operator:
-    src: config/manifests
-    dest: trainer-operator
   odh-mlflow-operator:
     src: config
     dest: mlflowoperator


### PR DESCRIPTION
offboarding this component as our build infra does not support the modular architecture yet for module operator. We won't be able to onboard them until we've finished implementing the changes on our side.
Onboarding ticket of component which is now to be offboarded: https://redhat.atlassian.net/browse/RHOAIENG-65430