### PR TITLE
feat: set monitoring namespace for MaaS

### DIFF
--- a/internal/controller/components/modelsasservice/modelsasservice_support.go
+++ b/internal/controller/components/modelsasservice/modelsasservice_support.go
@@ -27,6 +27,7 @@ import (
 	"strings"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/util/validation"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/kustomize/api/builtins" //nolint:staticcheck // Remove after package update
 	"sigs.k8s.io/kustomize/api/krusty"
@@ -126,6 +127,17 @@ func buildMaasOperatorInstallManifests(ctx context.Context, rr *odhtypes.Reconci
 		return nil, fmt.Errorf("application namespace for maas-controller install: %w", err)
 	}
 
+	monitoringNs, err := cluster.MonitoringNamespace(ctx, rr.Client)
+	if err != nil {
+		return nil, fmt.Errorf("monitoring namespace for maas-controller install: %w", err)
+	}
+	if monitoringNs == "" {
+		return nil, errors.New("monitoring namespace cannot be empty")
+	}
+	if errs := validation.IsDNS1123Label(monitoringNs); len(errs) > 0 {
+		return nil, fmt.Errorf("monitoring namespace %q is not a valid DNS-1123 label: %v", monitoringNs, errs)
+	}
+
 	k := krusty.MakeKustomizer(krusty.MakeDefaultOptions())
 	fs := filesys.MakeFsOnDisk()
 	resMap, err := k.Run(fs, kPath)
@@ -173,7 +185,7 @@ func buildMaasOperatorInstallManifests(ctx context.Context, rr *odhtypes.Reconci
 		extra = append(extra, unstructured.Unstructured{Object: m})
 	}
 
-	paramsCM, err := maasParametersConfigMapFromParamsEnv(root, appNs, componentLabels)
+	paramsCM, err := maasParametersConfigMapFromParamsEnv(root, appNs, monitoringNs, componentLabels)
 	if err != nil {
 		return nil, fmt.Errorf("build maas-parameters ConfigMap from params.env: %w", err)
 	}
@@ -192,7 +204,7 @@ func buildMaasOperatorInstallManifests(ctx context.Context, rr *odhtypes.Reconci
 // and builds the maas-parameters ConfigMap that is deployed alongside
 // maas-controller. This is the authoritative source of maas-parameters;
 // the Tenant reconciler consumes it rather than regenerating it.
-func maasParametersConfigMapFromParamsEnv(manifestsBasePath string, appNs string, componentLabels map[string]string) (*unstructured.Unstructured, error) {
+func maasParametersConfigMapFromParamsEnv(manifestsBasePath string, appNs string, monitoringNs string, componentLabels map[string]string) (*unstructured.Unstructured, error) {
 	paramsFile := filepath.Join(manifestsBasePath, MaasManifestContextDir, BaseManifestsSourcePath, "params.env")
 	paramsMap, err := parseParamsEnv(paramsFile)
 	if err != nil {
@@ -203,6 +215,11 @@ func maasParametersConfigMapFromParamsEnv(manifestsBasePath string, appNs string
 	// RHOAI deployments (redhat-ods-applications) don't use the ODH default
 	// hardcoded in params.env (opendatahub).
 	paramsMap["app-namespace"] = appNs
+
+	// Override monitoring-namespace with the resolved monitoring namespace so that
+	// RHOAI deployments (redhat-ods-monitoring) don't use the ODH default
+	// hardcoded in params.env (opendatahub).
+	paramsMap["monitoring-namespace"] = monitoringNs
 
 	data := make(map[string]any, len(paramsMap))
 	for k, v := range paramsMap {


### PR DESCRIPTION
<!---
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->
The MaaS component previously created observability and monitoring resources in the application namespace (either 'opendatahub' or 'redhat-ods-applications'). In order to change this so that these resources will be created in the monitoring namespace, we need to provide it this namespace that changes between ODH and RHOAI.

<!--- Link your JIRA and related links here for reference. -->
Related to https://github.com/opendatahub-io/models-as-a-service/pull/985

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully
- [ ] New RELATED_IMAGE mappings are listed in ODH-Build-Config and RHOAI-Build-Config (CI validates names against build-config repos). Include links to build-config PRs in the description.

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->
This PR just propagates the 'monitoring namespace' configuration to MaaS, an e2e test can be added when MaaS would respect this property and deploy its monitoring resources accordingly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **Bug Fixes**
  * Operator installation now resolves the cluster’s monitoring namespace and injects it into the generated configuration, rather than relying on environment defaults.
  * Installation now fails fast with clearer, more descriptive errors when the monitoring namespace is missing or fails DNS-1123 label validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->