### PR TITLE
fix: add modelsAsService to default DSC sample

### DIFF
--- a/config/rhoai/samples/datasciencecluster_v2_datasciencecluster.yaml
+++ b/config/rhoai/samples/datasciencecluster_v2_datasciencecluster.yaml
@@ -14,6 +14,8 @@ spec:
       managementState: "Managed"
       nim:
         managementState: "Managed"
+      modelsAsService:
+        managementState: "Removed"
       wva:
         managementState: "Removed"
     kueue:

--- a/config/samples/datasciencecluster_v2_datasciencecluster.yaml
+++ b/config/samples/datasciencecluster_v2_datasciencecluster.yaml
@@ -15,6 +15,8 @@ spec:
       nim:
         managementState: "Managed"
       rawDeploymentServiceConfig: "Headed"
+      modelsAsService:
+        managementState: "Removed"
       wva:
         managementState: "Removed"
     kueue:


### PR DESCRIPTION
## Summary
- Add `modelsAsService: {managementState: Removed}` to the DSC sample template used by CSV `alm-examples`
- Fixes cascading test failures on disconnected clusters where the DSC is created from the CSV template

## Problem
On disconnected clusters, the DSC is created from the CSV `alm-examples` annotation, which doesn't include `modelsAsService`. This causes:
1. **Platform test failure**: `oc patch --type json "op":"replace"` fails because the path doesn't exist
2. **DSC corruption**: `openshift-python-wrapper` `ResourceEditor` backs up `None` for the missing field, and on teardown restores `modelsAsService: null`, which invalidates the Kserve CR (`spec.modelsAsService: Invalid value: "null": spec.modelsAsService in body must be of type object`)
3. **Cascading failures**: The corrupted DSC breaks all subsequent test suites (Model Server, Model Runtime, AI Safety, AI Hub, MLflow)

## Fix
Add `modelsAsService: {managementState: Removed}` to the sample DSC, following the existing pattern of `nim` and `wva`. This ensures:
- The field exists on all clusters (connected and disconnected)
- `ResourceEditor` backs up `{managementState: Removed}` instead of `None`
- MaaS is **not enabled by default** (`Removed`), matching the kubebuilder default

## Test plan
- [ ] Verify YAML is valid
- [ ] Verify disconnected cluster DSC includes `modelsAsService` after operator install
- [ ] Verify `oc patch --type json -p '[{"op":"replace","path":"/spec/components/kserve/modelsAsService/managementState","value":"Managed"}]'` succeeds
- [ ] Verify MaaS test teardown restores `{managementState: Removed}` instead of `null`

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
Add modelsAsService to default DSC sample does not require the e2e tests update.



🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Documentation**
  * Updated the DataScienceCluster sample configuration to explicitly disable the `modelsAsService` component by setting its management state to **Removed**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->