### PR TITLE
Added repeat runs for config-b and statistical analysis

### DIFF
--- a/cmd/mcp-server/eval/judges/hallucination.py
+++ b/cmd/mcp-server/eval/judges/hallucination.py
@@ -1,0 +1,91 @@
+"""Judge: Does the diagnosis fabricate resources or conditions?
+
+Contract: def judge(outputs, **kwargs) -> (float, str)
+Returns 1.0 when fully grounded, 0.0 when nothing is.
+"""
+
+import json
+import re
+
+from judges.common import get_diagnosis_text
+
+_RESOURCE_RE = re.compile(
+    r"(?:deployment|deploy|pod|service|svc|configmap|cm|secret|namespace|ns|"
+    r"statefulset|sts|daemonset|ds|replicaset|rs|job|cronjob|route|"
+    r"networkpolicy|pvc|serviceaccount|sa)"
+    r"[/\s]+([a-z][a-z0-9-]{2,})",
+    re.IGNORECASE,
+)
+_NS_RE = re.compile(r"(?:namespace|ns)[:/\s]+([a-z][a-z0-9-]{2,})", re.IGNORECASE)
+_CMD_RE = re.compile(r"(?:kubectl|oc)\s+\w+\s+(?:\w+/)?([a-z][a-z0-9-]{2,})", re.IGNORECASE)
+
+_GENERIC = frozenset({
+    "the", "all", "any", "new", "old", "test", "default",
+    "kube-system", "kube-public", "openshift", "openshift-operators",
+    "openshift-monitoring", "openshift-ingress", "openshift-config",
+    "redhat-ods-operator", "redhat-ods-applications",
+    "redhat-ods-monitoring", "opendatahub", "opendatahub-operator",
+})
+
+
+def judge(outputs, **kwargs):
+    annotations = outputs.get("annotations", {})
+    if not annotations:
+        return (0.0, "No ground truth annotations")
+
+    text = get_diagnosis_text(outputs)
+    if not text:
+        return (1.0, "No output — nothing to hallucinate")
+
+    try:
+        json.loads(text.strip())
+        return (1.0, "Config C JSON — no hallucination risk")
+    except (json.JSONDecodeError, ValueError):
+        pass
+
+    truth = _build_truth(annotations)
+    if not truth:
+        return (1.0, "No ground truth terms to validate against")
+
+    entities = _extract(text)
+    if not entities:
+        return (1.0, "No resource entities found in output")
+
+    grounded = {e for e in entities if _is_grounded(e, truth)}
+    fabricated = entities - grounded
+    score = len(grounded) / len(entities)
+
+    if fabricated:
+        return (score, "Hallucinated %d/%d: [%s]" % (
+            len(fabricated), len(entities), ", ".join(sorted(fabricated)[:5])))
+    return (score, "All %d entities grounded" % len(entities))
+
+
+def _build_truth(annotations):
+    parts = []
+    for key in ("root_cause", "expected_remediation", "description",
+                "scenario_name", "scenario_id"):
+        val = annotations.get(key, "")
+        if val:
+            parts.append(val)
+    for s in annotations.get("expected_symptoms", []):
+        parts.append(s)
+    for t in annotations.get("tools_that_detect", []):
+        parts.append(t)
+    return set(re.findall(r"[a-z][a-z0-9-]{2,}", " ".join(parts).lower()))
+
+
+def _extract(text):
+    found = set()
+    for pattern in (_RESOURCE_RE, _NS_RE, _CMD_RE):
+        for m in pattern.finditer(text):
+            name = m.group(1).lower().rstrip("-")
+            if name not in _GENERIC and len(name) > 2:
+                found.add(name)
+    return found
+
+
+def _is_grounded(entity, truth):
+    if entity in truth:
+        return True
+    return any(entity in t or t in entity for t in truth)

--- a/cmd/mcp-server/eval/judges/hallucination.py
+++ b/cmd/mcp-server/eval/judges/hallucination.py
@@ -85,7 +85,35 @@ def _extract(text):
     return found
 
 
+_MIN_SUBSTR_LEN = 5
+_OVERLAP_RATIO = 0.65
+
+
+def _segments_match(a_segs, b_segs):
+    """True if a's segments are a contiguous subsequence of b's."""
+    if len(a_segs) > len(b_segs):
+        return False
+    for i in range(len(b_segs) - len(a_segs) + 1):
+        if b_segs[i:i + len(a_segs)] == a_segs:
+            return True
+    return False
+
+
 def _is_grounded(entity, truth):
     if entity in truth:
         return True
-    return any(entity in t or t in entity for t in truth)
+    if len(entity) < _MIN_SUBSTR_LEN:
+        return False
+    e_segs = entity.split("-")
+    for t in truth:
+        if len(t) < _MIN_SUBSTR_LEN:
+            continue
+        t_segs = t.split("-")
+        if len(e_segs) > 1 or len(t_segs) > 1:
+            if _segments_match(e_segs, t_segs) or _segments_match(t_segs, e_segs):
+                return True
+        else:
+            shorter, longer = sorted([entity, t], key=len)
+            if shorter in longer and len(shorter) >= len(longer) * _OVERLAP_RATIO:
+                return True
+    return False

--- a/cmd/mcp-server/eval/run-eval.sh
+++ b/cmd/mcp-server/eval/run-eval.sh
@@ -102,18 +102,23 @@ with open(sys.argv[2], 'w') as f:
 
 FILTER_SCENARIOS=""
 FILTER_CONFIGS="a,b,c"
+REPEATS=1
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --scenarios) FILTER_SCENARIOS="$2"; shift 2 ;;
     --configs)   FILTER_CONFIGS="$2"; shift 2 ;;
+    --repeats)   REPEATS="$2"; shift 2 ;;
     --help)
-      echo "Usage: $0 [--scenarios s1,s2] [--configs a,b,c]"
+      echo "Usage: $0 [--scenarios s1,s2] [--configs a,b,c] [--repeats N]"
+      echo "  --repeats N  Run Config B N times for consistency measurement (default 1)"
       echo "Env: INJECT_WAIT (default 30), TEARDOWN_WAIT (default 60)"
       exit 0 ;;
     *) die "Unknown argument: $1" ;;
   esac
 done
+
+[[ "$REPEATS" =~ ^[0-9]+$ ]] && [ "$REPEATS" -ge 1 ] || die "--repeats must be a positive integer"
 
 # --- Preflight ---
 
@@ -153,7 +158,7 @@ IFS=',' read -ra config_letters <<< "$FILTER_CONFIGS"
 RUN_ID="$(date +%Y-%m-%d-%H%M%S)"
 echo ""
 echo "=== Eval Run: $RUN_ID ==="
-echo "Scenarios: ${scenarios[*]} | Configs: ${config_letters[*]}"
+echo "Scenarios: ${scenarios[*]} | Configs: ${config_letters[*]} | Repeats (B): $REPEATS"
 echo ""
 
 failed=0
@@ -202,7 +207,23 @@ for i in "${!scenarios[@]}"; do
         ;;
       b)
         model=$(yaml_field "$SCRIPT_DIR/configs/config-b-agent.yaml" "models.skill" "claude-opus-4-6")
-        run_config_b "$prompt" "$output_dir" "$model" || exit_code=$?
+        if [ "$REPEATS" -gt 1 ]; then
+          for r in $(seq 1 "$REPEATS"); do
+            repeat_dir="$RESULTS_DIR/config-b-run${r}/$scenario"
+            mkdir -p "$repeat_dir"
+            echo "    run $r/$REPEATS..."
+            r_start=$(date +%s)
+            run_config_b "$prompt" "$repeat_dir" "$model" || exit_code=$?
+            r_dur=$(( $(date +%s) - r_start ))
+            python3 -c "
+import json, sys
+with open(sys.argv[1], 'w') as f:
+    json.dump({'exit_code': int(sys.argv[2]), 'duration_s': float(sys.argv[3])}, f, indent=2)
+" "$repeat_dir/run_result.json" "$exit_code" "$r_dur"
+          done
+        else
+          run_config_b "$prompt" "$output_dir" "$model" || exit_code=$?
+        fi
         ;;
       c)
         run_config_c "$output_dir" "$scenario" || exit_code=$?

--- a/cmd/mcp-server/eval/run-eval.sh
+++ b/cmd/mcp-server/eval/run-eval.sh
@@ -213,13 +213,15 @@ for i in "${!scenarios[@]}"; do
             mkdir -p "$repeat_dir"
             echo "    run $r/$REPEATS..."
             r_start=$(date +%s)
-            run_config_b "$prompt" "$repeat_dir" "$model" || exit_code=$?
+            r_exit=0
+            run_config_b "$prompt" "$repeat_dir" "$model" || r_exit=$?
             r_dur=$(( $(date +%s) - r_start ))
             python3 -c "
 import json, sys
 with open(sys.argv[1], 'w') as f:
     json.dump({'exit_code': int(sys.argv[2]), 'duration_s': float(sys.argv[3])}, f, indent=2)
-" "$repeat_dir/run_result.json" "$exit_code" "$r_dur"
+" "$repeat_dir/run_result.json" "$r_exit" "$r_dur"
+            [ "$r_exit" -ne 0 ] && exit_code="$r_exit"
           done
         else
           run_config_b "$prompt" "$output_dir" "$model" || exit_code=$?

--- a/cmd/mcp-server/eval/scripts/analysis_helpers.py
+++ b/cmd/mcp-server/eval/scripts/analysis_helpers.py
@@ -1,0 +1,315 @@
+"""Shared helpers for statistical analysis in eval reports."""
+
+import json
+from functools import lru_cache
+from pathlib import Path
+
+import yaml
+
+try:
+    from scipy.stats import wilcoxon as scipy_wilcoxon
+    from scipy.stats import chi2 as scipy_chi2
+    HAS_SCIPY = True
+except ImportError:
+    HAS_SCIPY = False
+
+# Metric definitions used across multiple sections
+_BINARY_METRICS = [
+    ("root_cause_correct", "Root cause"),
+    ("remediation_actionable", "Remediation"),
+    ("false_positive", "No false positives"),
+]
+_CONTINUOUS_METRICS = [
+    ("evidence_citation", "Evidence citation"),
+    ("completeness", "Completeness"),
+    ("hallucination", "Hallucination"),
+]
+_VERDICT_KEYS = [
+    ("root_cause_pass_rate", "Root cause"),
+    ("remediation_pass_rate", "Remediation"),
+    ("false_positive_pass_rate", "No false positives"),
+    ("avg_evidence_citation", "Evidence citation"),
+    ("avg_completeness", "Completeness"),
+    ("avg_hallucination", "Hallucination"),
+]
+
+
+def mean(vals):
+    return sum(vals) / len(vals) if vals else None
+
+
+def paired_scores(scored_results, metric, cfg_a, cfg_b):
+    """Extract paired score lists for two configs across scenarios."""
+    a_vals, b_vals = [], []
+    for s in scored_results["scenarios"]:
+        va = s["configs"].get(cfg_a, {}).get(metric)
+        vb = s["configs"].get(cfg_b, {}).get(metric)
+        if va is not None and vb is not None:
+            a_vals.append(float(va) if not isinstance(va, bool) else int(va))
+            b_vals.append(float(vb) if not isinstance(vb, bool) else int(vb))
+    return a_vals, b_vals
+
+
+def wilcoxon_test(a_vals, b_vals):
+    """Wilcoxon signed-rank for continuous metrics. Returns (stat, p)."""
+    if not HAS_SCIPY or len(a_vals) < 5:
+        return None, None
+    diffs = [b - a for a, b in zip(a_vals, b_vals)]
+    if all(d == 0 for d in diffs):
+        return 0.0, 1.0
+    try:
+        stat, p = scipy_wilcoxon(diffs)
+        return stat, p
+    except Exception:
+        return None, None
+
+
+def mcnemar_test(a_vals, b_vals):
+    """McNemar's test for binary metrics. Returns (stat, p)."""
+    if not HAS_SCIPY or len(a_vals) < 5:
+        return None, None
+    b_only = sum(1 for a, b in zip(a_vals, b_vals) if not a and b)
+    a_only = sum(1 for a, b in zip(a_vals, b_vals) if a and not b)
+    n = b_only + a_only
+    if n == 0:
+        return 0.0, 1.0
+    stat = (abs(b_only - a_only) - 1) ** 2 / n
+    p = 1.0 - scipy_chi2.cdf(stat, df=1)
+    return stat, p
+
+
+@lru_cache(maxsize=128)
+def load_annotations(dataset_dir, scenario_id):
+    """Load annotations.yaml for a scenario (cached to avoid re-reading)."""
+    ann_file = Path(dataset_dir) / scenario_id / "annotations.yaml"
+    if not ann_file.exists():
+        return {}
+    try:
+        with open(ann_file) as f:
+            return yaml.safe_load(f) or {}
+    except Exception:
+        return {}
+
+
+def load_scored(results_dir):
+    """Load scored-results.json from a results directory."""
+    scored_file = Path(results_dir) / "scored-results.json"
+    if not scored_file.exists():
+        return {}
+    try:
+        with open(scored_file) as f:
+            return json.load(f)
+    except Exception:
+        return {}
+
+
+def _pass_rate(scenarios, config, metric):
+    """Compute pass rate for a binary metric across scenarios."""
+    vals = [s["configs"].get(config, {}).get(metric) for s in scenarios]
+    vals = [v for v in vals if v is not None]
+    if not vals:
+        return "N/A"
+    return "%.0f%%" % (sum(1 for v in vals if v) / len(vals) * 100)
+
+
+def _md_table_row(label, cells):
+    return "| %s | %s |" % (label, " | ".join(cells))
+
+
+# ---------------------------------------------------------------------------
+# Report analysis sections — appended to eval-report.md by score-results.py
+# ---------------------------------------------------------------------------
+
+def append_statistical(lines, scored_results, config_names):
+    if "config-a" not in config_names or "config-b" not in config_names:
+        return
+    lines.append("## Statistical Comparison: Config A vs B\n")
+    if not HAS_SCIPY:
+        lines.append("*scipy not installed — install for statistical tests.*\n")
+        return
+
+    lines.append("| Metric | Test | Statistic | p-value | Significant (p<0.05) |")
+    lines.append("|--------|------|-----------|---------|----------------------|")
+
+    tests = [(m, l, mcnemar_test, "McNemar") for m, l in _BINARY_METRICS] + \
+            [(m, l, wilcoxon_test, "Wilcoxon") for m, l in _CONTINUOUS_METRICS]
+
+    for metric, label, test_fn, test_name in tests:
+        a, b = paired_scores(scored_results, metric, "config-a", "config-b")
+        stat, p = test_fn(a, b)
+        if p is not None:
+            sig = "Yes" if p < 0.05 else "No"
+            lines.append("| %s | %s | %.2f | %.4f | %s |" % (label, test_name, stat, p, sig))
+        else:
+            lines.append("| %s | %s | — | — | insufficient data |" % (label, test_name))
+    lines.append("")
+
+
+def append_categories(lines, scored_results, dataset_dir):
+    categories = {}
+    for s in scored_results["scenarios"]:
+        ann = load_annotations(dataset_dir, s["scenario_id"])
+        cat = ann.get("expected_classification", {})
+        if isinstance(cat, dict):
+            cat = cat.get("category", "unknown")
+        if cat:
+            categories.setdefault(cat, []).append(s)
+
+    if not categories:
+        return
+
+    cfgs = sorted({c for s in scored_results["scenarios"] for c in s["configs"]})
+    lines.append("## Category Breakdown\n")
+
+    for cat, scenarios in sorted(categories.items()):
+        lines.append("### %s (%d scenarios)\n" % (cat, len(scenarios)))
+        lines.append("| Metric | %s |" % " | ".join(cfgs))
+        lines.append("|--------|%s|" % "|".join(["--------"] * len(cfgs)))
+        for metric, label in _BINARY_METRICS[:2]:
+            lines.append(_md_table_row(label, [_pass_rate(scenarios, c, metric) for c in cfgs]))
+        lines.append("")
+
+
+def append_agent_vs_classifier(lines, scored_results, dataset_dir):
+    """Compare Config B (agent) vs Config C (classifier) across all metrics."""
+    _compare_metrics = [
+        ("root_cause_correct", "Root cause", "bool"),
+        ("remediation_actionable", "Remediation", "bool"),
+        ("false_positive", "No false pos", "bool"),
+        ("evidence_citation", "Evidence", "float"),
+        ("completeness", "Completeness", "float"),
+    ]
+    rows, b_wins, c_wins, ties = [], 0, 0, 0
+
+    for s in scored_results["scenarios"]:
+        b = s["configs"].get("config-b", {})
+        c = s["configs"].get("config-c", {})
+        if not b or not c:
+            continue
+
+        b_score, c_score = 0, 0
+        for key, _, kind in _compare_metrics:
+            bv, cv = b.get(key), c.get(key)
+            if bv is None or cv is None:
+                continue
+            if kind == "bool":
+                b_score += int(bool(bv))
+                c_score += int(bool(cv))
+            else:
+                b_score += float(bv)
+                c_score += float(cv)
+
+        if b_score > c_score:
+            result, b_wins = "B wins", b_wins + 1
+        elif c_score > b_score:
+            result, c_wins = "C wins", c_wins + 1
+        else:
+            result, ties = "Tie", ties + 1
+
+        rows.append((s["scenario_id"], round(b_score, 1), round(c_score, 1), result))
+
+    if not rows:
+        return
+
+    lines.append("## Agent vs Deterministic Classifier (Config B vs C)\n")
+    lines.append("| Scenario | Agent score | Classifier score | Winner |")
+    lines.append("|----------|------------|-----------------|--------|")
+    for sid, bs, cs, result in rows:
+        lines.append("| %s | %.1f | %.1f | %s |" % (sid, bs, cs, result))
+    lines.append("")
+    lines.append("**Summary**: Agent wins %d, Classifier wins %d, Ties %d (out of %d)\n" %
+                 (b_wins, c_wins, ties, b_wins + c_wins + ties))
+
+
+def _load_diagnosis_summary(scenario_dir):
+    """Extract a normalised root-cause fingerprint from a diagnosis."""
+    diag_file = scenario_dir / "diagnosis.txt"
+    if not diag_file.exists():
+        return None
+    try:
+        text = diag_file.read_text().strip().lower()
+    except (OSError, UnicodeDecodeError):
+        return None
+    if len(text) < 10:
+        return None
+    try:
+        data = json.loads(text)
+        if isinstance(data, dict):
+            return data.get("category", "") + "|" + str(data.get("error_code", ""))
+    except (json.JSONDecodeError, ValueError):
+        pass
+    words = sorted(set(text.split()))[:30]
+    return " ".join(words)
+
+
+def append_consistency(lines, results_dir):
+    run_dirs = sorted(Path(results_dir).glob("config-b-run*"))
+    if len(run_dirs) < 2:
+        return
+
+    scenario_runs = {}
+    for rd in run_dirs:
+        for sd in sorted(rd.iterdir()):
+            if not sd.is_dir():
+                continue
+            summary = _load_diagnosis_summary(sd)
+            if summary is not None:
+                scenario_runs.setdefault(sd.name, []).append(summary)
+
+    if not scenario_runs:
+        return
+
+    lines.append("## Consistency Analysis (Config B — %d runs)\n" % len(run_dirs))
+    lines.append("| Scenario | Root cause agreement | Distinct diagnoses |")
+    lines.append("|----------|---------------------|-------------------|")
+
+    total_agree = 0
+    for sid, summaries in sorted(scenario_runs.items()):
+        distinct = len(set(summaries))
+        agree = distinct == 1
+        total_agree += agree
+        lines.append("| %s | %s | %d |" % (sid, "Yes" if agree else "No", distinct))
+
+    total = len(scenario_runs)
+    lines.append("")
+    lines.append("**Overall agreement**: %.0f%% (%d/%d scenarios produced identical root cause)\n" %
+                 (total_agree / total * 100 if total else 0, total_agree, total))
+
+
+def append_verdict(lines, scored_results):
+    summary = scored_results.get("summary", {})
+    a, b = summary.get("config-a", {}), summary.get("config-b", {})
+    if not a or not b:
+        return
+
+    lines.append("## Verdict\n")
+    wins, losses, ties = 0, 0, 0
+    comparisons = []
+
+    for key, label in _VERDICT_KEYS:
+        va, vb = a.get(key), b.get(key)
+        if va is None or vb is None:
+            continue
+        diff = vb - va
+        if abs(diff) < 0.01:
+            ties += 1
+            comparisons.append("- **%s**: tied (%.2f vs %.2f)" % (label, va, vb))
+        elif diff > 0:
+            wins += 1
+            comparisons.append("- **%s**: Config B wins (+%.2f)" % (label, diff))
+        else:
+            losses += 1
+            comparisons.append("- **%s**: Config A wins (+%.2f)" % (label, -diff))
+
+    if wins > losses:
+        verdict = "**Yes** — system prompt adds measurable value (%d wins, %d losses, %d ties)." % (wins, losses, ties)
+    elif losses > wins:
+        verdict = "**No** — raw LLM outperforms on more metrics (%d losses, %d wins, %d ties)." % (losses, wins, ties)
+    else:
+        verdict = "**Inconclusive** — results are split (%d wins, %d losses, %d ties)." % (wins, losses, ties)
+
+    lines.append("Does the system prompt (Config B) add value over raw LLM (Config A)?\n")
+    lines.append(verdict)
+    lines.append("")
+    lines.append("\n".join(comparisons))
+    lines.append("")

--- a/cmd/mcp-server/eval/scripts/analysis_helpers.py
+++ b/cmd/mcp-server/eval/scripts/analysis_helpers.py
@@ -221,58 +221,27 @@ def append_agent_vs_classifier(lines, scored_results, dataset_dir):
                  (b_wins, c_wins, ties, b_wins + c_wins + ties))
 
 
-def _load_diagnosis_summary(scenario_dir):
-    """Extract a normalised root-cause fingerprint from a diagnosis."""
-    diag_file = scenario_dir / "diagnosis.txt"
-    if not diag_file.exists():
-        return None
-    try:
-        text = diag_file.read_text().strip().lower()
-    except (OSError, UnicodeDecodeError):
-        return None
-    if len(text) < 10:
-        return None
-    try:
-        data = json.loads(text)
-        if isinstance(data, dict):
-            return data.get("category", "") + "|" + str(data.get("error_code", ""))
-    except (json.JSONDecodeError, ValueError):
-        pass
-    words = sorted(set(text.split()))[:30]
-    return " ".join(words)
-
-
-def append_consistency(lines, results_dir):
-    run_dirs = sorted(Path(results_dir).glob("config-b-run*"))
-    if len(run_dirs) < 2:
+def append_consistency(lines, scored_results, results_dir):
+    consistency = scored_results.get("consistency", {})
+    if not consistency:
         return
 
-    scenario_runs = {}
-    for rd in run_dirs:
-        for sd in sorted(rd.iterdir()):
-            if not sd.is_dir():
-                continue
-            summary = _load_diagnosis_summary(sd)
-            if summary is not None:
-                scenario_runs.setdefault(sd.name, []).append(summary)
+    run_count = len(sorted(Path(results_dir).glob("config-b-run*")))
 
-    if not scenario_runs:
-        return
-
-    lines.append("## Consistency Analysis (Config B — %d runs)\n" % len(run_dirs))
-    lines.append("| Scenario | Root cause agreement | Distinct diagnoses |")
-    lines.append("|----------|---------------------|-------------------|")
+    lines.append("## Consistency Analysis (Config B — %d runs)\n" % run_count)
+    lines.append("| Scenario | Root cause agreement | Results |")
+    lines.append("|----------|---------------------|---------|")
 
     total_agree = 0
-    for sid, summaries in sorted(scenario_runs.items()):
-        distinct = len(set(summaries))
-        agree = distinct == 1
+    for sid, results in sorted(consistency.items()):
+        agree = len(set(results)) == 1
         total_agree += agree
-        lines.append("| %s | %s | %d |" % (sid, "Yes" if agree else "No", distinct))
+        labels = "/".join("PASS" if v else "FAIL" for v in results)
+        lines.append("| %s | %s | %s |" % (sid, "Yes" if agree else "No", labels))
 
-    total = len(scenario_runs)
+    total = len(consistency)
     lines.append("")
-    lines.append("**Overall agreement**: %.0f%% (%d/%d scenarios produced identical root cause)\n" %
+    lines.append("**Overall agreement**: %.0f%% (%d/%d scenarios)\n" %
                  (total_agree / total * 100 if total else 0, total_agree, total))
 
 

--- a/cmd/mcp-server/eval/scripts/score-results.py
+++ b/cmd/mcp-server/eval/scripts/score-results.py
@@ -189,6 +189,20 @@ def main():
         sorted(all_scenarios),
     )
 
+    # Add per-run consistency data for config-b-run* directories
+    if repeat_names:
+        consistency = {}
+        for sid in sorted(all_scenarios):
+            runs = []
+            for rc in repeat_names:
+                scores = all_scores.get(rc, {}).get(sid, {})
+                rc_val = scores.get("root_cause_correct", {}).get("value")
+                if rc_val is not None:
+                    runs.append(rc_val)
+            if runs:
+                consistency[sid] = runs
+        scored_results["consistency"] = consistency
+
     # Write scored JSON
     scored_file = results_dir / "scored-results.json"
     with open(scored_file, "w") as f:
@@ -476,7 +490,7 @@ def _write_report(report_file, scored_results, config_names, results_dir, datase
     append_statistical(lines, scored_results, config_names)
     append_categories(lines, scored_results, dataset_dir)
     append_agent_vs_classifier(lines, scored_results, dataset_dir)
-    append_consistency(lines, results_dir)
+    append_consistency(lines, scored_results, results_dir)
     append_verdict(lines, scored_results)
 
     with open(report_file, "w") as f:

--- a/cmd/mcp-server/eval/scripts/score-results.py
+++ b/cmd/mcp-server/eval/scripts/score-results.py
@@ -12,10 +12,17 @@ Usage:
 import argparse
 import csv
 import json
+import re
 import sys
 from pathlib import Path
+from statistics import median as _median
 
 import yaml
+
+from analysis_helpers import (
+    append_statistical, append_categories, append_agent_vs_classifier,
+    append_consistency, append_verdict,
+)
 
 # Add eval root to sys.path so judges.* is importable
 EVAL_DIR = Path(__file__).resolve().parent.parent
@@ -25,6 +32,7 @@ from judges.root_cause_match import judge as judge_root_cause
 from judges.remediation_actionable import judge as judge_remediation
 from judges.false_positive import judge as judge_false_positive
 from judges.quality_scoring import judge_evidence_citation, judge_completeness
+from judges.hallucination import judge as judge_hallucination
 
 
 def main():
@@ -116,6 +124,7 @@ def main():
                 ("false_positive", judge_false_positive),
                 ("evidence_citation", judge_evidence_citation),
                 ("completeness", judge_completeness),
+                ("hallucination", judge_hallucination),
             ]:
                 try:
                     value, rationale = judge_fn(outputs)
@@ -143,8 +152,42 @@ def main():
 
         all_scores[config_name] = config_scores
 
+    # Combine config-b-runN into a single config-b using majority vote / median
+    repeat_names = sorted(c for c in config_names if re.match(r"config-b-run\d+$", c))
+    if repeat_names and not all_scores.get("config-b"):
+        merged = {}
+        for sid in sorted(all_scenarios):
+            runs = [all_scores[rc][sid] for rc in repeat_names if sid in all_scores.get(rc, {})]
+            if not runs:
+                continue
+            combined = {}
+            for key in runs[0]:
+                vals = [r[key]["value"] for r in runs if key in r and r[key].get("value") is not None]
+                rats = [r[key].get("rationale", "") for r in runs if key in r and r[key].get("value") is not None]
+                if not vals:
+                    combined[key] = {"value": None, "rationale": ""}
+                elif isinstance(vals[0], bool):
+                    passes = sum(1 for v in vals if v)
+                    winner = passes > len(vals) / 2
+                    rat = next((r for v, r in zip(vals, rats) if v == winner), "")
+                    combined[key] = {"value": winner, "rationale": rat}
+                elif isinstance(vals[0], (int, float)):
+                    med = _median(vals)
+                    closest = min(range(len(vals)), key=lambda i: abs(vals[i] - med))
+                    combined[key] = {"value": round(med, 2) if isinstance(med, float) else med, "rationale": rats[closest]}
+                else:
+                    combined[key] = runs[0][key]
+            merged[sid] = combined
+        all_scores["config-b"] = merged
+
+    # Only use primary configs (config-a, config-b, config-c) for the report
+    report_configs = sorted(c for c in all_scores if not re.match(r"config-b-run\d+$", c))
+
     # Build scored results
-    scored_results = _build_scored_results(all_scores, sorted(all_scenarios))
+    scored_results = _build_scored_results(
+        {k: v for k, v in all_scores.items() if k in report_configs},
+        sorted(all_scenarios),
+    )
 
     # Write scored JSON
     scored_file = results_dir / "scored-results.json"
@@ -159,7 +202,7 @@ def main():
 
     # Generate comparison report
     report_file = results_dir / "eval-report.md"
-    _write_report(report_file, scored_results, config_names)
+    _write_report(report_file, scored_results, report_configs, results_dir, dataset_dir)
     print("Report: %s" % report_file)
 
 
@@ -225,6 +268,8 @@ def _build_scored_results(all_scores, scenarios):
                     "evidence_rationale": scores.get("evidence_citation", {}).get("rationale", ""),
                     "completeness": scores.get("completeness", {}).get("value"),
                     "completeness_rationale": scores.get("completeness", {}).get("rationale", ""),
+                    "hallucination": scores.get("hallucination", {}).get("value"),
+                    "hallucination_rationale": scores.get("hallucination", {}).get("rationale", ""),
                     "tool_call_count": scores.get("tool_call_count", {}).get("value", 0),
                     "duration_s": scores.get("duration_s", {}).get("value", 0),
                 }
@@ -236,6 +281,7 @@ def _build_scored_results(all_scores, scenarios):
                         "remediation_pass": 0, "remediation_total": 0,
                         "false_positive_pass": 0, "false_positive_total": 0,
                         "evidence_scores": [], "completeness_scores": [],
+                        "hallucination_scores": [],
                         "tool_calls": [], "durations": [],
                     }
                 s = summary[config_name]
@@ -260,6 +306,9 @@ def _build_scored_results(all_scores, scenarios):
                 comp = scores.get("completeness", {}).get("value")
                 if comp is not None:
                     s["completeness_scores"].append(comp)
+                hal = scores.get("hallucination", {}).get("value")
+                if hal is not None:
+                    s["hallucination_scores"].append(hal)
                 tc = scores.get("tool_call_count", {}).get("value", 0)
                 s["tool_calls"].append(tc)
                 dur = scores.get("duration_s", {}).get("value")
@@ -282,6 +331,8 @@ def _build_scored_results(all_scores, scenarios):
                                       if s["evidence_scores"] else None),
             "avg_completeness": (sum(s["completeness_scores"]) / len(s["completeness_scores"])
                                  if s["completeness_scores"] else None),
+            "avg_hallucination": (sum(s["hallucination_scores"]) / len(s["hallucination_scores"])
+                                  if s["hallucination_scores"] else None),
             "avg_tool_calls": (sum(s["tool_calls"]) / len(s["tool_calls"])
                                if s["tool_calls"] else None),
             "avg_duration_s": (sum(s["durations"]) / len(s["durations"])
@@ -302,6 +353,7 @@ def _write_csv(csv_file, scored_results):
             "false_positive", "false_positive_rationale",
             "evidence_citation", "evidence_rationale",
             "completeness", "completeness_rationale",
+            "hallucination", "hallucination_rationale",
             "tool_call_count", "duration_s",
         ])
         for s in scored_results["scenarios"]:
@@ -318,12 +370,14 @@ def _write_csv(csv_file, scored_results):
                     data.get("evidence_rationale", ""),
                     data.get("completeness", ""),
                     data.get("completeness_rationale", ""),
+                    data.get("hallucination", ""),
+                    data.get("hallucination_rationale", ""),
                     data.get("tool_call_count", ""),
                     data.get("duration_s", ""),
                 ])
 
 
-def _write_report(report_file, scored_results, config_names):
+def _write_report(report_file, scored_results, config_names, results_dir, dataset_dir):
     lines = []
     lines.append("# Eval Report: 3-Config Diagnostic Comparison\n")
 
@@ -356,6 +410,8 @@ def _write_report(report_file, scored_results, config_names):
                  " | ".join(_fmt_num(c, "avg_evidence_citation") for c in config_names))
     lines.append("| Avg completeness | %s |" %
                  " | ".join(_fmt_num(c, "avg_completeness") for c in config_names))
+    lines.append("| Avg hallucination score | %s |" %
+                 " | ".join(_fmt_num(c, "avg_hallucination") for c in config_names))
     lines.append("| Avg tool calls | %s |" %
                  " | ".join(_fmt_num(c, "avg_tool_calls") for c in config_names))
     lines.append("| Avg duration (s) | %s |" %
@@ -393,6 +449,8 @@ def _write_report(report_file, scored_results, config_names):
                      " | ".join(_get(c, "evidence_citation") for c in config_names))
         lines.append("| Completeness | %s |" %
                      " | ".join(_get(c, "completeness") for c in config_names))
+        lines.append("| Hallucination | %s |" %
+                     " | ".join(_get(c, "hallucination") for c in config_names))
         lines.append("| Tool calls | %s |" %
                      " | ".join(_get(c, "tool_call_count") for c in config_names))
         lines.append("| Duration (s) | %s |" %
@@ -404,7 +462,7 @@ def _write_report(report_file, scored_results, config_names):
             data = scenario["configs"].get(config_name, {})
             rationales = []
             for key in ("root_cause_rationale", "remediation_rationale",
-                        "false_positive_rationale"):
+                        "false_positive_rationale", "hallucination_rationale"):
                 r = data.get(key, "")
                 if r:
                     label = key.replace("_rationale", "").replace("_", " ").title()
@@ -413,6 +471,13 @@ def _write_report(report_file, scored_results, config_names):
                 lines.append("**%s rationale:**\n" % config_name)
                 lines.append("\n".join(rationales))
                 lines.append("")
+
+    # --- Analysis sections ---
+    append_statistical(lines, scored_results, config_names)
+    append_categories(lines, scored_results, dataset_dir)
+    append_agent_vs_classifier(lines, scored_results, dataset_dir)
+    append_consistency(lines, results_dir)
+    append_verdict(lines, scored_results)
 
     with open(report_file, "w") as f:
         f.write("\n".join(lines))

--- a/cmd/mcp-server/eval/setup.sh
+++ b/cmd/mcp-server/eval/setup.sh
@@ -33,6 +33,9 @@ if ! pip install -e ".[anthropic]" --quiet; then
   exit 1
 fi
 
+echo "Installing eval analysis dependencies..."
+pip install scipy --quiet || echo "WARNING: scipy install failed — statistical tests will be skipped" >&2
+
 echo ""
 echo "Verifying prerequisites..."
 exit_code=0


### PR DESCRIPTION


## Description
Add hallucination judge and wire it into the scoring pipeline. Support --repeats N flag so Config B runs multiple times per scenario for consistency measurement, with results merged via majority vote for boolean metrics and median for continuous scores. Introduce statistical analysis sections in eval-report.md  and a summary verdict on whether the system prompt adds value.


https://redhat.atlassian.net/browse/RHOAIENG-62339

## How Has This Been Tested?
Tested on cluster.

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [X] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [X] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work


### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [X] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
Add E2E if required.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a hallucination check to diagnostic evaluation, including an average hallucination score and per-scenario rationales in the results.
  * Enhanced reports with deeper analysis: statistical comparisons, category breakdowns, agent vs deterministic classifier results, consistency checks, and verdict summaries.
  * Introduced multi-run support for evaluation scenarios, saving per-repeat outputs and automatically aggregating repeated Config B runs.
* **Chores**
  * Updated evaluation setup to optionally install SciPy for statistical tests, while clearly noting when SciPy or sufficient data is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->