### PR TITLE
fix: remove e2e skip for trustyai mcp guardrails

### DIFF
--- a/tests/e2e/modelsasservice_test.go
+++ b/tests/e2e/modelsasservice_test.go
@@ -59,15 +59,6 @@ func modelsAsServiceTestSuite(t *testing.T) {
 		ComponentTestCtx: ct,
 	}
 
-	// The maas-controller hardcodes "opendatahub" as the namespace for DB
-	// secret lookup (appNamespaceForTenant returns DefaultMaaSAPINamespace).
-	// On RHOAI the apps namespace is "redhat-ods-applications" so the secret is never found.
-	// Skip until the upstream maas-controller fix is available.
-	platform := componentCtx.FetchPlatformRelease()
-	if platform == cluster.ManagedRhoai || platform == cluster.SelfManagedRhoai {
-		t.Skip("RHOAIENG-69604: MaaS e2e skipped on RHOAI — maas-controller hardcodes opendatahub namespace (upstream fix pending)")
-	}
-
 	// Set per-operation timeout defaults for all operations in this suite.
 	// MaaS startup involves multiple dependencies (postgres, gateway, maas-controller leader election,
 	// ServiceAccount/TLS cert provisioning) that can take longer than the default 5m timeout.
@@ -330,7 +321,6 @@ func (tc *ModelsAsServiceTestCtx) ValidateTenantSingletonEnforcement(t *testing.
 // require MaaS to be re-enabled first.
 func (tc *ModelsAsServiceTestCtx) ValidateTenantDeletedOnDisable(t *testing.T) {
 	t.Helper()
-	t.Skip("RHOAIENG-69570: Skipping Tenant deletion check")
 	skipUnless(t, Smoke, Tier1)
 
 	t.Logf("Verifying Tenant %s/%s is present before disable", tenantSubscriptionNS, tenantName)

--- a/tests/e2e/trustyai_test.go
+++ b/tests/e2e/trustyai_test.go
@@ -81,7 +81,6 @@ func (tc *TrustyAITestCtx) ValidateComponentDisabled(t *testing.T) {
 // checks that the TrustyAI CR spec and Ready condition stay consistent with the DSC.
 func (tc *TrustyAITestCtx) ValidateMCPGuardrailsMode(t *testing.T) {
 	t.Helper()
-	t.Skip("RHOAIENG-69287: Skip MCP Guardrails mode test to avoid upstream manifest issue")
 
 	skipUnless(t, Tier1)
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enabled end-to-end tests for Models-as-a-Service on RHOAI platforms.
  * Enabled Tenant deletion validation test for Models-as-a-Service removal.
  * Enabled TrustyAI MCP guardrails mode test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->