### PR TITLE
RHAIENG-5327: deprecate RStudio resources during operator upgrade

### DIFF
--- a/pkg/upgrade/upgrade.go
+++ b/pkg/upgrade/upgrade.go
@@ -98,6 +98,8 @@ func CleanupExistingResource(ctx context.Context,
 	multiErr = multierror.Append(multiErr, cleanupDeprecatedKueueVAPB(ctx, cli))
 	// cleanup legacy "odh" OAuthClient from RHOAI 3.3
 	multiErr = multierror.Append(multiErr, cleanupLegacyOAuthClient(ctx, cli))
+	// cleanup deprecated RStudio BuildConfigs and ImageStreams from RHOAI 3.4 (RHAIENG-5327)
+	multiErr = multierror.Append(multiErr, cleanupDeprecatedRStudioResources(ctx, cli, applicationNS))
 
 	// HardwareProfile migration as described in RHOAIENG-33158 and RHOAIENG-33159
 	// This includes creating HardwareProfile resources and updating annotations on Notebooks and InferenceServices

--- a/pkg/upgrade/upgrade_rstudio.go
+++ b/pkg/upgrade/upgrade_rstudio.go
@@ -1,0 +1,176 @@
+package upgrade
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	imagev1 "github.com/openshift/api/image/v1"
+	k8serr "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/util/retry"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+const (
+	imageTagOutdatedAnnotation          = "opendatahub.io/image-tag-outdated"
+	workbenchImageRecommendedAnnotation = "opendatahub.io/workbench-image-recommended"
+)
+
+var (
+	deprecatedRStudioBuildConfigs = []string{
+		"rstudio-server-rhel9",
+		"cuda-rstudio-server-rhel9",
+	}
+	deprecatedRStudioBuildImageStreams = []string{
+		"rstudio-rhel9",
+		"cuda-rstudio-rhel9",
+	}
+	deprecatedRStudioNotebookImageStreams = []string{
+		"rstudio-notebook",
+		"rstudio-gpu-notebook",
+	}
+	rstudioBuildConfigGVK = schema.GroupVersionKind{
+		Group:   "build.openshift.io",
+		Version: "v1",
+		Kind:    "BuildConfig",
+	}
+)
+
+// cleanupDeprecatedRStudioResources removes orphaned RStudio BuildConfigs and build
+// ImageStreams left over from RHOAI 3.4, and marks remaining RStudio workbench
+// ImageStreams as deprecated so they are hidden from the spawner UI.
+// RStudio was removed from the notebooks repository in RHAIENG-4776.
+//
+// TODO: Remove this cleanup once upgrade from RHOAI 3.4 is no longer supported.
+func cleanupDeprecatedRStudioResources(ctx context.Context, cli client.Client, applicationNS string) error {
+	log := logf.FromContext(ctx)
+	var multiErr *multierror.Error
+
+	for _, name := range deprecatedRStudioBuildConfigs {
+		if err := deleteRStudioBuildConfig(ctx, cli, applicationNS, name); err != nil {
+			multiErr = multierror.Append(multiErr, err)
+		}
+	}
+
+	for _, name := range deprecatedRStudioBuildImageStreams {
+		if err := deleteRStudioImageStream(ctx, cli, applicationNS, name); err != nil {
+			multiErr = multierror.Append(multiErr, err)
+		}
+	}
+
+	for _, name := range deprecatedRStudioNotebookImageStreams {
+		if err := deprecateRStudioImageStream(ctx, cli, applicationNS, name); err != nil {
+			multiErr = multierror.Append(multiErr, err)
+		}
+	}
+
+	if multiErr != nil {
+		return multiErr
+	}
+
+	log.Info("Completed RStudio deprecation cleanup", "namespace", applicationNS)
+	return nil
+}
+
+func deleteRStudioBuildConfig(ctx context.Context, cli client.Client, namespace, name string) error {
+	log := logf.FromContext(ctx)
+
+	bc := &unstructured.Unstructured{}
+	bc.SetGroupVersionKind(rstudioBuildConfigGVK)
+	bc.SetName(name)
+	bc.SetNamespace(namespace)
+
+	if err := cli.Delete(ctx, bc); err != nil {
+		if isIgnorableClusterResourceError(err) {
+			return nil
+		}
+		return fmt.Errorf("failed to delete BuildConfig %s: %w", name, err)
+	}
+
+	log.Info("Deleted deprecated RStudio BuildConfig", "name", name, "namespace", namespace)
+	return nil
+}
+
+func isIgnorableClusterResourceError(err error) bool {
+	return k8serr.IsNotFound(err) ||
+		meta.IsNoMatchError(err) ||
+		containsNoKindRegistered(err)
+}
+
+func containsNoKindRegistered(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "no kind is registered")
+}
+
+func deleteRStudioImageStream(ctx context.Context, cli client.Client, namespace, name string) error {
+	log := logf.FromContext(ctx)
+
+	is := &imagev1.ImageStream{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+	}
+
+	if err := cli.Delete(ctx, is); err != nil {
+		if isIgnorableClusterResourceError(err) {
+			return nil
+		}
+		return fmt.Errorf("failed to delete ImageStream %s: %w", name, err)
+	}
+
+	log.Info("Deleted deprecated RStudio build ImageStream", "name", name, "namespace", namespace)
+	return nil
+}
+
+func deprecateRStudioImageStream(ctx context.Context, cli client.Client, namespace, name string) error {
+	log := logf.FromContext(ctx)
+	key := client.ObjectKey{Name: name, Namespace: namespace}
+	updated := false
+
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		is := &imagev1.ImageStream{}
+		if err := cli.Get(ctx, key, is); err != nil {
+			if isIgnorableClusterResourceError(err) {
+				return nil
+			}
+			return err
+		}
+
+		changed := false
+		for i := range is.Spec.Tags {
+			tag := &is.Spec.Tags[i]
+			if tag.Annotations == nil {
+				tag.Annotations = map[string]string{}
+			}
+			if tag.Annotations[imageTagOutdatedAnnotation] != "true" {
+				tag.Annotations[imageTagOutdatedAnnotation] = "true"
+				changed = true
+			}
+			if tag.Annotations[workbenchImageRecommendedAnnotation] != "false" {
+				tag.Annotations[workbenchImageRecommendedAnnotation] = "false"
+				changed = true
+			}
+		}
+		if !changed {
+			return nil
+		}
+		updated = true
+		return cli.Update(ctx, is)
+	})
+	if err != nil {
+		return fmt.Errorf("failed to deprecate ImageStream %s: %w", name, err)
+	}
+	if !updated {
+		log.Info("RStudio workbench ImageStream already deprecated", "name", name, "namespace", namespace)
+		return nil
+	}
+
+	log.Info("Deprecated RStudio workbench ImageStream", "name", name, "namespace", namespace)
+	return nil
+}

--- a/pkg/upgrade/upgrade_rstudio_test.go
+++ b/pkg/upgrade/upgrade_rstudio_test.go
@@ -1,0 +1,163 @@
+package upgrade_test
+
+import (
+	"testing"
+
+	buildv1 "github.com/openshift/api/build/v1"
+	imagev1 "github.com/openshift/api/image/v1"
+	k8serr "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/upgrade"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/fakeclient"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/scheme"
+
+	. "github.com/onsi/gomega"
+)
+
+const testAppNamespace = "test-app-ns"
+
+func newTestDSCI(appNamespace string) *unstructured.Unstructured {
+	dsci := &unstructured.Unstructured{}
+	dsci.SetGroupVersionKind(gvk.DSCInitialization)
+	dsci.SetName("test-dsci")
+	dsci.SetNamespace("test-namespace")
+	_ = unstructured.SetNestedField(dsci.Object, appNamespace, "spec", "applicationsNamespace")
+	return dsci
+}
+
+func newTestRStudioBuildConfig(name, namespace string) *buildv1.BuildConfig {
+	return &buildv1.BuildConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+	}
+}
+
+func newTestRStudioNotebookImageStream(name string, tags ...string) *imagev1.ImageStream {
+	is := &imagev1.ImageStream{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: testAppNamespace,
+		},
+		Spec: imagev1.ImageStreamSpec{
+			Tags: make([]imagev1.TagReference, 0, len(tags)),
+		},
+	}
+
+	for _, tagName := range tags {
+		is.Spec.Tags = append(is.Spec.Tags, imagev1.TagReference{
+			Name: tagName,
+			Annotations: map[string]string{
+				"opendatahub.io/workbench-image-recommended": "true",
+			},
+		})
+	}
+
+	return is
+}
+
+func newUpgradeTestScheme(g *WithT) *runtime.Scheme {
+	s, err := scheme.New()
+	g.Expect(err).ShouldNot(HaveOccurred())
+	g.Expect(buildv1.Install(s)).Should(Succeed())
+	return s
+}
+
+func TestCleanupDeprecatedRStudioResources(t *testing.T) {
+	ctx := t.Context()
+
+	t.Run("should delete BuildConfigs and build ImageStreams and deprecate notebook ImageStreams", func(t *testing.T) {
+		g := NewWithT(t)
+
+		objects := []client.Object{
+			newTestDSCI(testAppNamespace),
+			newTestRStudioBuildConfig("rstudio-server-rhel9", testAppNamespace),
+			newTestRStudioBuildConfig("cuda-rstudio-server-rhel9", testAppNamespace),
+			newTestRStudioNotebookImageStream("rstudio-rhel9", "latest"),
+			newTestRStudioNotebookImageStream("cuda-rstudio-rhel9", "latest"),
+			newTestRStudioNotebookImageStream("rstudio-notebook", "3.4", "2025.2"),
+			newTestRStudioNotebookImageStream("rstudio-gpu-notebook", "3.4", "2025.2"),
+		}
+
+		cli, err := fakeclient.New(
+			fakeclient.WithScheme(newUpgradeTestScheme(g)),
+			fakeclient.WithObjects(objects...),
+		)
+		g.Expect(err).ShouldNot(HaveOccurred())
+
+		err = upgrade.CleanupExistingResource(ctx, cli, "")
+		g.Expect(err).ShouldNot(HaveOccurred())
+
+		for _, name := range []string{"rstudio-server-rhel9", "cuda-rstudio-server-rhel9"} {
+			bc := &buildv1.BuildConfig{}
+			err = cli.Get(ctx, client.ObjectKey{Name: name, Namespace: testAppNamespace}, bc)
+			g.Expect(k8serr.IsNotFound(err)).To(BeTrue())
+		}
+
+		for _, name := range []string{"rstudio-rhel9", "cuda-rstudio-rhel9"} {
+			is := &imagev1.ImageStream{}
+			err = cli.Get(ctx, client.ObjectKey{Name: name, Namespace: testAppNamespace}, is)
+			g.Expect(k8serr.IsNotFound(err)).To(BeTrue())
+		}
+
+		for _, name := range []string{"rstudio-notebook", "rstudio-gpu-notebook"} {
+			is := &imagev1.ImageStream{}
+			err = cli.Get(ctx, client.ObjectKey{Name: name, Namespace: testAppNamespace}, is)
+			g.Expect(err).ShouldNot(HaveOccurred())
+			for _, tag := range is.Spec.Tags {
+				g.Expect(tag.Annotations).To(HaveKeyWithValue("opendatahub.io/image-tag-outdated", "true"))
+				g.Expect(tag.Annotations).To(HaveKeyWithValue("opendatahub.io/workbench-image-recommended", "false"))
+			}
+		}
+	})
+
+	t.Run("should be idempotent when RStudio resources are already cleaned up", func(t *testing.T) {
+		g := NewWithT(t)
+
+		cli, err := fakeclient.New(
+			fakeclient.WithScheme(newUpgradeTestScheme(g)),
+			fakeclient.WithObjects(newTestDSCI(testAppNamespace)),
+		)
+		g.Expect(err).ShouldNot(HaveOccurred())
+
+		for range 2 {
+			err = upgrade.CleanupExistingResource(ctx, cli, "")
+			g.Expect(err).ShouldNot(HaveOccurred())
+		}
+	})
+
+	t.Run("should be idempotent when notebook ImageStreams are already deprecated", func(t *testing.T) {
+		g := NewWithT(t)
+
+		is := newTestRStudioNotebookImageStream("rstudio-gpu-notebook", "3.4")
+		for i := range is.Spec.Tags {
+			is.Spec.Tags[i].Annotations["opendatahub.io/image-tag-outdated"] = "true"
+			is.Spec.Tags[i].Annotations["opendatahub.io/workbench-image-recommended"] = "false"
+		}
+
+		cli, err := fakeclient.New(
+			fakeclient.WithScheme(newUpgradeTestScheme(g)),
+			fakeclient.WithObjects(newTestDSCI(testAppNamespace), is),
+		)
+		g.Expect(err).ShouldNot(HaveOccurred())
+
+		for range 2 {
+			err = upgrade.CleanupExistingResource(ctx, cli, "")
+			g.Expect(err).ShouldNot(HaveOccurred())
+		}
+
+		updated := &imagev1.ImageStream{}
+		err = cli.Get(ctx, client.ObjectKey{Name: "rstudio-gpu-notebook", Namespace: testAppNamespace}, updated)
+		g.Expect(err).ShouldNot(HaveOccurred())
+		for _, tag := range updated.Spec.Tags {
+			g.Expect(tag.Annotations).To(HaveKeyWithValue("opendatahub.io/image-tag-outdated", "true"))
+			g.Expect(tag.Annotations).To(HaveKeyWithValue("opendatahub.io/workbench-image-recommended", "false"))
+		}
+	})
+}


### PR DESCRIPTION
## Summary

- Add upgrade cleanup for RStudio resources left on clusters upgrading from RHOAI 3.4 to 3.5
- Delete orphaned `rstudio-server-rhel9` and `cuda-rstudio-server-rhel9` BuildConfigs plus their build output ImageStreams
- Deprecate remaining `rstudio-gpu-notebook` and `rstudio-notebook` ImageStream tags so RStudio is hidden from the workbench spawner while existing workbenches keep running

This runs automatically via `CleanupExistingResource` on operator leader election, matching existing upgrade cleanup patterns (OAuthClient, Kueue VAPB, model controller deployment).

Related:
- [RHAIENG-5327](https://redhat.atlassian.net/browse/RHAIENG-5327)
- [RHAIENG-4776](https://redhat.atlassian.net/browse/RHAIENG-4776) (RStudio removal from notebooks repo)

## Test plan

- [x] `go test ./pkg/upgrade/... -run TestCleanupDeprecatedRStudioResources -count=1`
- [ ] Upgrade test cluster from RHOAI 3.4 → 3.5 and verify:
  - RStudio BuildConfigs are removed
  - Build ImageStreams (`rstudio-rhel9`, `cuda-rstudio-rhel9`) are removed
  - `rstudio-gpu-notebook` tags have `opendatahub.io/image-tag-outdated: "true"`
  - Existing RStudio workbench still runs
  - Spawner no longer offers RStudio for new workbenches
- [ ] Restart operator pod and confirm cleanup is idempotent

### E2E test suite update requirement

- [x] Skip requirement to update E2E test suite for this PR

#### E2E update requirement opt-out justification

This follows the existing one-time upgrade cleanup pattern in `pkg/upgrade` (e.g. legacy OAuthClient removal, deprecated Kueue VAPB cleanup), which is covered by unit tests rather than dedicated E2E scenarios. Added `upgrade_rstudio_test.go` verifies deletion, deprecation, and idempotence via the fake client. A full E2E test would require pre-seeding RHOAI 3.4 RStudio BuildConfigs/ImageStreams on a cluster, which is out of scope for this targeted brownfield cleanup hook.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Upgrade cleanup now additionally removes deprecated RStudio resources from earlier RHOAI versions, including specific BuildConfigs and build ImageStreams.
  * Updates remaining RStudio notebook ImageStream tag annotations to mark images as outdated and not recommended.
  * Missing or already-updated resources are treated as non-blocking, so cleanup is safe to re-run.

* **Tests**
  * Added coverage for the RStudio deprecation cleanup, validating targeted deletions, annotation updates, and idempotency on repeated runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[RHAIENG-5327]: https://redhat.atlassian.net/browse/RHAIENG-5327?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RHAIENG-4776]: https://redhat.atlassian.net/browse/RHAIENG-4776?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ