### PR TITLE
test-only: CI smoke test for e2e cluster pool health 

### DIFF
--- a/scripts/ci-e2e-pool-smoke-test.sh
+++ b/scripts/ci-e2e-pool-smoke-test.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# Placeholder script to trigger CI e2e jobs for cluster-pool health validation.
+# This file has no runtime effect and can be deleted after the investigation.
+
+exit 0


### PR DESCRIPTION
## Purpose

Smoke-test PR to validate whether recent `opendatahub-operator-e2e` and `opendatahub-operator-rhoai-e2e` failures on #3678 are caused by a broken CI cluster pool or something specific to that PR.

This change is intentionally minimal and has **no functional impact**.

## Change

- Add `scripts/ci-e2e-pool-smoke-test.sh` — a no-op placeholder script (`exit 0`)

## What to compare

If these required jobs fail here with the same preflight/cluster issues (ServiceAccount controller, NotReady nodes, dashboard CrashLoopBackOff), that strongly indicates an **infra/pool problem**.

If they pass here but fail on #3678, that would warrant deeper investigation of that PR.

Related: #3678

## Cleanup

Close and delete this PR/branch once the investigation is complete.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added CI/CD infrastructure script for cluster validation testing purposes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->