### PR TITLE
fix: flaky unit test on dsci controller

### DIFF
--- a/.github/workflows/test-e2e-requirement-check.yaml
+++ b/.github/workflows/test-e2e-requirement-check.yaml
@@ -8,6 +8,7 @@ on:
       - 'Dockerfiles/**'
       - 'internal/**'
       - 'pkg/**'
+      - '!**/*_test.go'
       - 'cmd/main.go'
     branches: [ 'main' ]
 

--- a/internal/controller/dscinitialization/dscinitialization_test.go
+++ b/internal/controller/dscinitialization/dscinitialization_test.go
@@ -231,10 +231,10 @@ var _ = Describe("DataScienceCluster initialization", func() {
 			}).WithTimeout(timeout).WithPolling(interval).Should(Succeed())
 
 			// when - Monitoring is set to Removed in DSCI, which should delete the Monitoring CR
-			foundDsci := &dsciv2.DSCInitialization{}
-			Expect(k8sClient.Get(ctx, client.ObjectKey{Name: applicationName, Namespace: workingNamespace}, foundDsci)).To(Succeed())
+			foundDsci := &dsciv2.DSCInitialization{ObjectMeta: metav1.ObjectMeta{Name: applicationName}}
+			patch := client.MergeFrom(foundDsci.DeepCopy())
 			foundDsci.Spec.Monitoring.ManagementState = operatorv1.Removed
-			Expect(k8sClient.Update(ctx, foundDsci)).To(Succeed())
+			Expect(k8sClient.Patch(ctx, foundDsci, patch)).To(Succeed())
 
 			// then - Monitoring CR should be gone
 			Eventually(func() bool {
@@ -244,7 +244,7 @@ var _ = Describe("DataScienceCluster initialization", func() {
 
 			// then - DSCI status should reflect it's removed
 			Eventually(func(g Gomega) {
-				g.Expect(k8sClient.Get(ctx, client.ObjectKey{Name: applicationName, Namespace: workingNamespace}, foundDsci)).To(Succeed())
+				g.Expect(k8sClient.Get(ctx, client.ObjectKey{Name: applicationName}, foundDsci)).To(Succeed())
 				g.Expect(foundDsci.Status.Conditions).To(ContainElement(SatisfyAll(
 					HaveField("Type", "MonitoringReady"),
 					HaveField("Status", metav1.ConditionFalse),


### PR DESCRIPTION
<!---
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully
- [ ] New RELATED_IMAGE mappings are listed in ODH-Build-Config and RHOAI-Build-Config (CI validates names against build-config repos). Include links to build-config PRs in the description.

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [ ] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved coverage for DSCInitialization monitoring removal scenarios, including how Monitoring removal is applied and verified.
* **Chores**
  * Adjusted CI workflow trigger filters to prevent running the e2e requirement check when changes are limited to test files.

**Note:** No user-facing behavior or exported APIs were changed; this release focuses on test and CI reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->