### PR TITLE
fix(gateway): add egress rules to kube-auth-proxy NetworkPolicy for OCP 4.22

### DIFF
--- a/internal/controller/services/gateway/gateway_integration_helpers_test.go
+++ b/internal/controller/services/gateway/gateway_integration_helpers_test.go
@@ -1697,7 +1697,10 @@ func RunNetworkPolicyCreationTest(t *testing.T, setup TestSetup) {
 
 	g.Expect(np.Spec.PodSelector.MatchLabels).To(HaveKeyWithValue("app", gateway.KubeAuthProxyName))
 	g.Expect(np.Spec.PolicyTypes).To(ContainElement(networkingv1.PolicyTypeIngress))
+	g.Expect(np.Spec.PolicyTypes).To(ContainElement(networkingv1.PolicyTypeEgress))
 	g.Expect(np.Spec.Ingress).To(HaveLen(3))
+	g.Expect(np.Spec.Egress).To(HaveLen(1))
+	g.Expect(np.Spec.Egress[0]).To(Equal(networkingv1.NetworkPolicyEgressRule{}))
 }
 
 // RunGatewayConfigStatusConditionsTest validates that GatewayConfig status gets conditions set (e.g. Ready).

--- a/internal/controller/services/gateway/resources/kube-auth-proxy-networkpolicy.yaml
+++ b/internal/controller/services/gateway/resources/kube-auth-proxy-networkpolicy.yaml
@@ -13,6 +13,7 @@ spec:
       app: {{.KubeAuthProxyServiceName}}
   policyTypes:
     - Ingress
+    - Egress
   ingress:
     # Allow traffic from gateway/envoy pods for authentication
     - from:
@@ -43,3 +44,7 @@ spec:
       ports:
         - protocol: TCP
           port: {{.AuthProxyMetricsPort}}
+  # Allow all egress: kube-auth-proxy needs to reach the Kubernetes API server
+  # for OAuth discovery, external OIDC providers at dynamic IPs, and DNS.
+  egress:
+    - {}

--- a/tests/e2e/gateway_test.go
+++ b/tests/e2e/gateway_test.go
@@ -1145,8 +1145,13 @@ func (tc *GatewayTestCtx) ValidateNetworkPolicy(t *testing.T) {
 			// Verify pod selector matches kube-auth-proxy with specific labels
 			jq.Match(`.spec.podSelector.matchLabels.app == "%s"`, kubeAuthProxyName),
 
-			// Verify ingress policy is enabled
+			// Verify ingress and egress policy types are enabled
 			jq.Match(`.spec.policyTypes | any(. == "Ingress")`),
+			jq.Match(`.spec.policyTypes | any(. == "Egress")`),
+
+			// Verify egress allows all outbound traffic (API server, OAuth, OIDC, DNS)
+			jq.Match(`.spec.egress | length == 1`),
+			jq.Match(`.spec.egress[0] == {}`),
 
 			// Verify ingress rules exist
 			jq.Match(`.spec.ingress | length >= 1`),
@@ -1165,7 +1170,7 @@ func (tc *GatewayTestCtx) ValidateNetworkPolicy(t *testing.T) {
 			jq.Match(`.spec.ingress[1].from[0].namespaceSelector.matchLabels."kubernetes.io/metadata.name" == "openshift-monitoring"`),
 			jq.Match(`.spec.ingress[2].from[0].namespaceSelector.matchLabels."kubernetes.io/metadata.name" == "openshift-user-workload-monitoring"`),
 		)),
-		WithCustomErrorMsg("NetworkPolicy should exist with correct ingress rules for kube-auth-proxy"),
+		WithCustomErrorMsg("NetworkPolicy should exist with correct ingress and egress rules for kube-auth-proxy"),
 	)
 
 	t.Log("NetworkPolicy validation completed")


### PR DESCRIPTION
## Description

Jira: [RHOAIENG-70137](https://redhat.atlassian.net/browse/RHOAIENG-70137)

OCP 4.22 introduced a default-deny NetworkPolicy (`openshift-ingress-deny-all`) in the `openshift-ingress` namespace via [NE-2501](https://redhat.atlassian.net/browse/NE-2501) ([cluster-ingress-operator PR #1392](https://github.com/openshift/cluster-ingress-operator/pull/1392)). This policy blocks **all** ingress and egress traffic by default, requiring each component to have explicit allow policies.

The `kube-auth-proxy` NetworkPolicy only defined ingress rules with `policyTypes: [Ingress]`, leaving egress unaddressed. With the deny-all in place, the oauth-proxy inside `kube-auth-proxy` cannot reach the Kubernetes API server (`172.30.0.1:443`) for OAuth discovery, causing authentication to fail with `context deadline exceeded` errors:

```
[openshift.go:479] Performing OAuth discovery against https://172.30.0.1:443/.well-known/oauth-authorization-server
[openshift.go:141] Please configure --login-url and --redeem-url manually
[openshift.go:139] Failed to discover OpenShift OAuth endpoints: Get "https://172.30.0.1:443/.well-known/oauth-authorization-server": context deadline exceeded
```

On managed ROSA clusters, users cannot manually patch NetworkPolicies in the `openshift-ingress` namespace, so this fix must come from the operator.

## Changes

- Add `Egress` to `policyTypes` and allow-all egress rule (`egress: [{}]`) to `kube-auth-proxy-networkpolicy.yaml`
- This matches the pattern used by OCP's own components in the same namespace: `router-default`, `data-science-gateway-allow`, and `istiod-allow` all use `egress: [{}]`
- Allow-all egress is required because kube-auth-proxy needs to reach the Kubernetes API server, DNS, and in OIDC mode, arbitrary external identity providers at dynamic IPs
- Update integration and e2e tests to validate egress rules

### Backport PRs
- 3.4: [red-hat-data-services/rhods-operator#32266](https://github.com/red-hat-data-services/rhods-operator/pull/32266)
- 3.5-ea.2: [red-hat-data-services/rhods-operator#32267](https://github.com/red-hat-data-services/rhods-operator/pull/32267)
- 3.3: [red-hat-data-services/rhods-operator#32268](https://github.com/red-hat-data-services/rhods-operator/pull/32268)

## How Has This Been Tested?

- Integration test updated: validates `PolicyTypeEgress`, egress rule count, and allow-all shape
- E2E test updated: validates both ingress and egress policy types are present
- Gateway Integration Tests CI: 3/3 passed

## Merge criteria

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

- [ ] Skip requirement to update E2E test suite for this PR

E2E test suite has been updated to validate the new egress rules.