### PR TITLE
feat: add agent-ops module image to dashboard imagesMap

### DIFF
--- a/internal/controller/components/dashboard/dashboard_support.go
+++ b/internal/controller/components/dashboard/dashboard_support.go
@@ -56,6 +56,7 @@ var (
 		"automl-pipeline-runtime-image":  "RELATED_IMAGE_ODH_AUTOML_IMAGE",
 		"autorag-ui-image":               "RELATED_IMAGE_ODH_MOD_ARCH_AUTORAG_IMAGE",
 		"autorag-pipeline-runtime-image": "RELATED_IMAGE_ODH_AUTORAG_IMAGE",
+		"agent-ops-ui-image":             "RELATED_IMAGE_ODH_MOD_ARCH_AGENT_OPS_IMAGE",
 	}
 
 	conditionTypes = []string{


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHOAIENG-62589

## Summary
Adds `agent-ops-ui-image` to the dashboard's `imagesMap` in the operator, mapping it to `RELATED_IMAGE_ODH_MOD_ARCH_AGENT_OPS_IMAGE`.

This is a single-line addition following the same pattern as all other modular architecture modules (gen-ai, maas, mlflow, eval-hub, automl, autorag, model-registry).

## Context
The dashboard manifest onboarding for agent-ops was completed in [odh-dashboard#7800](https://github.com/opendatahub-io/odh-dashboard/pull/7800), which added the deployment container, service port, federation-configmap entry, and `agent-ops-ui-image` param to `params.env`. This operator change completes the integration by enabling image parameter substitution.

## Changes
- `internal/controller/components/dashboard/dashboard_support.go` — add one entry to `imagesMap`

No logic changes — the existing `ApplyParams()` in `Init()` automatically handles the new entry.

## Test plan
- [ ] Operator builds successfully
- [ ] `make test` passes
- [ ] Operator deploys dashboard with agent-ops container using the injected image

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the agent operations UI component in the dashboard, enabling new operational capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->

Dashboard Modules aren't tested by our E2E