### PR TITLE
fix(gateway): [3.5-ea.2] add egress rules to kube-auth-proxy NetworkPolicy for OCP 4.22

### DIFF
--- a/internal/controller/services/gateway/gateway_integration_helpers_test.go
+++ b/internal/controller/services/gateway/gateway_integration_helpers_test.go
@@ -1659,6 +1659,7 @@ func RunNetworkPolicyCreationTest(t *testing.T, setup TestSetup) {
 	g.Expect(np.Spec.PolicyTypes).To(ContainElement(networkingv1.PolicyTypeEgress))
 	g.Expect(np.Spec.Ingress).To(HaveLen(3))
 	g.Expect(np.Spec.Egress).To(HaveLen(1))
+	g.Expect(np.Spec.Egress[0]).To(Equal(networkingv1.NetworkPolicyEgressRule{}))
 }
 
 // RunGatewayConfigStatusConditionsTest validates that GatewayConfig status gets conditions set (e.g. Ready).

--- a/internal/controller/services/gateway/gateway_integration_helpers_test.go
+++ b/internal/controller/services/gateway/gateway_integration_helpers_test.go
@@ -1656,7 +1656,9 @@ func RunNetworkPolicyCreationTest(t *testing.T, setup TestSetup) {
 
 	g.Expect(np.Spec.PodSelector.MatchLabels).To(HaveKeyWithValue("app", gateway.KubeAuthProxyName))
 	g.Expect(np.Spec.PolicyTypes).To(ContainElement(networkingv1.PolicyTypeIngress))
+	g.Expect(np.Spec.PolicyTypes).To(ContainElement(networkingv1.PolicyTypeEgress))
 	g.Expect(np.Spec.Ingress).To(HaveLen(3))
+	g.Expect(np.Spec.Egress).To(HaveLen(1))
 }
 
 // RunGatewayConfigStatusConditionsTest validates that GatewayConfig status gets conditions set (e.g. Ready).

--- a/internal/controller/services/gateway/resources/kube-auth-proxy-networkpolicy.yaml
+++ b/internal/controller/services/gateway/resources/kube-auth-proxy-networkpolicy.yaml
@@ -44,5 +44,7 @@ spec:
       ports:
         - protocol: TCP
           port: {{.AuthProxyMetricsPort}}
+  # Allow all egress: kube-auth-proxy needs to reach the Kubernetes API server
+  # for OAuth discovery, external OIDC providers at dynamic IPs, and DNS.
   egress:
     - {}

--- a/internal/controller/services/gateway/resources/kube-auth-proxy-networkpolicy.yaml
+++ b/internal/controller/services/gateway/resources/kube-auth-proxy-networkpolicy.yaml
@@ -13,6 +13,7 @@ spec:
       app: {{.KubeAuthProxyServiceName}}
   policyTypes:
     - Ingress
+    - Egress
   ingress:
     # Allow traffic from gateway/envoy pods for authentication
     - from:
@@ -43,3 +44,5 @@ spec:
       ports:
         - protocol: TCP
           port: {{.AuthProxyMetricsPort}}
+  egress:
+    - {}

--- a/tests/e2e/gateway_test.go
+++ b/tests/e2e/gateway_test.go
@@ -1143,7 +1143,8 @@ func (tc *GatewayTestCtx) ValidateNetworkPolicy(t *testing.T) {
 			jq.Match(`.spec.policyTypes | any(. == "Egress")`),
 
 			// Verify egress allows all outbound traffic (API server, OAuth, OIDC, DNS)
-			jq.Match(`.spec.egress | length >= 1`),
+			jq.Match(`.spec.egress | length == 1`),
+			jq.Match(`.spec.egress[0] == {}`),
 
 			// Verify ingress rules exist
 			jq.Match(`.spec.ingress | length >= 1`),

--- a/tests/e2e/gateway_test.go
+++ b/tests/e2e/gateway_test.go
@@ -1162,7 +1162,7 @@ func (tc *GatewayTestCtx) ValidateNetworkPolicy(t *testing.T) {
 			jq.Match(`.spec.ingress[1].from[0].namespaceSelector.matchLabels."kubernetes.io/metadata.name" == "openshift-monitoring"`),
 			jq.Match(`.spec.ingress[2].from[0].namespaceSelector.matchLabels."kubernetes.io/metadata.name" == "openshift-user-workload-monitoring"`),
 		)),
-		WithCustomErrorMsg("NetworkPolicy should exist with correct ingress rules for kube-auth-proxy"),
+		WithCustomErrorMsg("NetworkPolicy should exist with correct ingress and egress rules for kube-auth-proxy"),
 	)
 
 	t.Log("NetworkPolicy validation completed")

--- a/tests/e2e/gateway_test.go
+++ b/tests/e2e/gateway_test.go
@@ -1138,8 +1138,12 @@ func (tc *GatewayTestCtx) ValidateNetworkPolicy(t *testing.T) {
 			// Verify pod selector matches kube-auth-proxy with specific labels
 			jq.Match(`.spec.podSelector.matchLabels.app == "%s"`, kubeAuthProxyName),
 
-			// Verify ingress policy is enabled
+			// Verify ingress and egress policy types are enabled
 			jq.Match(`.spec.policyTypes | any(. == "Ingress")`),
+			jq.Match(`.spec.policyTypes | any(. == "Egress")`),
+
+			// Verify egress allows all outbound traffic (API server, OAuth, OIDC, DNS)
+			jq.Match(`.spec.egress | length >= 1`),
 
 			// Verify ingress rules exist
 			jq.Match(`.spec.ingress | length >= 1`),


### PR DESCRIPTION
## Description

Jira: [RHOAIENG-70947](https://redhat.atlassian.net/browse/RHOAIENG-70947)

Cherry-pick of [#3682](https://github.com/opendatahub-io/opendatahub-operator/pull/3682) to odh-3.5.0-ea.2.

OCP 4.22 introduced a default-deny NetworkPolicy in the openshift-ingress namespace (NE-2501). The kube-auth-proxy NetworkPolicy only defined ingress rules, so egress is blocked, preventing oauth-proxy from reaching the Kubernetes API server for OAuth discovery.

Fix: add Egress to policyTypes and allow-all egress rule to the kube-auth-proxy NetworkPolicy template.

## Merge criteria

- [x] Commit messages are meaningful
- [x] Cherry-pick of reviewed and approved PR #3682