### PR TITLE
Fix false positives and expand coverage in failureclassifier

### DIFF
--- a/cmd/mcp-server/prompts/diagnostic.md
+++ b/cmd/mcp-server/prompts/diagnostic.md
@@ -49,7 +49,7 @@ Based on what Step 1 revealed, drill deeper. **Parallelize tool calls wherever p
    - If the pod has restarted, also call with `previous: true`.
    - Do not pull logs for Running/Ready pods with high restart counts — those restarts are historical.
 
-**After Step 2:** If investigation found no active failures (all pods Running/Ready, no errors, no warning events) → use the **"Platform Healthy"** structured output format and stop.
+**After Step 2:** If investigation found no active failures (all pods Running/Ready, no errors, no warning events) → use the **"Platform Healthy"** structured output format and stop. If `classify_failure` returns code **3001 (NoSignal)**, do not report healthy — use the "When Issues Are Found" format with confidence **low** and recommend manual investigation.
 
 ### Step 3: Correlate (Trace Root Cause Using Dependency Graph)
 
@@ -198,9 +198,16 @@ oc <command to confirm the issue is resolved>
 | 1008 | Operator | infrastructure |
 | 1009 | DSCI | infrastructure |
 | 1010 | DSC | infrastructure |
+| 1011 | RBAC | infrastructure |
+| 1012 | DNS | infrastructure |
+| 1013 | Timeout | infrastructure |
+| 1014 | ProbeFailure | infrastructure |
+| 1015 | InvalidFlags | infrastructure |
+| 1016 | ContainerExit | infrastructure |
 | 1099 | InfraUnknown | infrastructure |
 | 2001 | TestFailure | test failures |
-| 3000 | Unclassifiable | unknown |
+| 3000 | Unclassifiable | unknown — data collection failed or nil report |
+| 3001 | NoSignal | unknown — all sections collected; no pattern matched |
 
 ---
 
@@ -230,7 +237,31 @@ oc <command to confirm the issue is resolved>
 - **Common causes**: Dependency not installed, wrong version, dependency operator crashed
 - **Remediation**: Install the missing operator from OperatorHub, check version compatibility
 
-### 5. Image Pull Failures
+### 5. RBAC / Permission Errors
+- **Symptoms**: `classify_failure` returns code 1011, events contain "is forbidden" or "unauthorized"
+- **Investigation**: `recent_events`, `pod_logs` for the affected component
+- **Common causes**: Missing ClusterRole/RoleBinding, service account lacks permissions, namespace mismatch
+- **Remediation**: Inspect the RBAC resource, apply the missing role/binding, verify service account
+
+### 6. DNS Failures
+- **Symptoms**: `classify_failure` returns code 1012, events contain "no such host" or "name resolution failed"
+- **Investigation**: `recent_events`, check CoreDNS pods in `kube-system`
+- **Common causes**: CoreDNS not running, incorrect service name, network policy blocking DNS port 53
+- **Remediation**: Restart CoreDNS, verify service names and namespaces, check network policies
+
+### 7. Timeout / Deadline Exceeded
+- **Symptoms**: `classify_failure` returns code 1013, events contain "context deadline exceeded" or "timed out"
+- **Investigation**: `recent_events`, `pod_logs` for the component hitting the timeout
+- **Common causes**: Downstream service slow or unavailable, resource contention, misconfigured timeout values
+- **Remediation**: Check dependency health, increase resource limits if CPU-starved, inspect network latency
+
+### 8. Liveness / Readiness Probe Failures
+- **Symptoms**: `classify_failure` returns code 1014, `Unhealthy` events for a pod
+- **Investigation**: `recent_events`, `pod_logs` for the unhealthy pod
+- **Common causes**: Application not ready in time, health endpoint path wrong, resource limits too tight causing slow startup
+- **Remediation**: Check probe config, increase `initialDelaySeconds`, inspect app logs for startup errors
+
+### 9. Image Pull Failures
 - **Symptoms**: `classify_failure` returns code 1001, pods stuck in ImagePullBackOff
 - **Investigation**: `pod_logs`, `recent_events` for pull error details
 - **Common causes**: Wrong image tag, private registry without pull secret, registry unreachable, SHA-pinned image removed

--- a/pkg/clusterhealth/deployments.go
+++ b/pkg/clusterhealth/deployments.go
@@ -74,6 +74,7 @@ func deploymentToInfo(d *appsv1.Deployment) DeploymentInfo {
 		Name:      d.Name,
 		Ready:     d.Status.ReadyReplicas,
 		Replicas:  desiredReplicas(d),
+		CreatedAt: d.CreationTimestamp.Time,
 	}
 	for _, c := range d.Status.Conditions {
 		if c.Status != corev1.ConditionTrue {

--- a/pkg/clusterhealth/types.go
+++ b/pkg/clusterhealth/types.go
@@ -82,6 +82,7 @@ type DeploymentInfo struct {
 	Name       string             `json:"name"`
 	Ready      int32              `json:"ready"`
 	Replicas   int32              `json:"replicas"`
+	CreatedAt  time.Time          `json:"createdAt,omitzero"`
 	Conditions []ConditionSummary `json:"conditions"`
 }
 
@@ -95,7 +96,7 @@ type PodInfo struct {
 	Name       string          `json:"name"`
 	Phase      string          `json:"phase"`
 	NodeName   string          `json:"nodeName,omitempty"`
-	CreatedAt  time.Time       `json:"createdAt"`
+	CreatedAt  time.Time       `json:"createdAt,omitzero"`
 	Containers []ContainerInfo `json:"containers"`
 }
 

--- a/pkg/failureclassifier/classifier.go
+++ b/pkg/failureclassifier/classifier.go
@@ -8,9 +8,9 @@ import (
 	"github.com/opendatahub-io/opendatahub-operator/pkg/clusterhealth"
 )
 
-// PendingThreshold is the minimum duration a pod must be in Pending phase
-// before it is classified as "stuck pending". Pods pending for less than this
-// are assumed to be starting up normally.
+// PendingThreshold is the minimum duration a pod or deployment must be in an unready state
+// before it is classified as a real failure. Resources newer than this are assumed to be
+// starting up normally.
 const PendingThreshold = 60 * time.Second
 
 // Classify inspects a clusterhealth Report and categorizes the failure.
@@ -51,15 +51,15 @@ func Classify(report *clusterhealth.Report) FailureClassification {
 		return *fc
 	}
 
-	// The report is complete and no infrastructure issues were found.
-	// The failure is likely in the test itself.
+	// All sections collected successfully but no infrastructure pattern matched.
+	// The root cause is unknown — callers should not assume the test is at fault.
 	if report.Healthy() {
 		return FailureClassification{
-			Category:    CategoryTest,
-			Subcategory: "test-failure",
-			ErrorCode:   CodeTestFailure,
-			Evidence:    []string{"cluster state appears healthy, failure is likely test-related"},
-			Confidence:  ConfidenceMedium,
+			Category:    CategoryUnknown,
+			Subcategory: "no-signal",
+			ErrorCode:   CodeNoSignal,
+			Evidence:    []string{"all sections collected; no infrastructure pattern matched"},
+			Confidence:  ConfidenceLow,
 		}
 	}
 
@@ -85,14 +85,16 @@ func classifyFromPods(report *clusterhealth.Report) (*FailureClassification, *Fa
 						Confidence:  ConfidenceMedium,
 					}, nil
 				}
-				if match := matchesPattern(container.Terminated, terminatedPatterns); match != nil {
-					return &FailureClassification{
-						Category:    CategoryInfrastructure,
-						Subcategory: match.subcategory,
-						ErrorCode:   match.errorCode,
-						Evidence:    []string{fmt.Sprintf("container %s/%s terminated: %s", pod.Name, container.Name, container.Terminated)},
-						Confidence:  ConfidenceMedium,
-					}, nil
+				if !isGracefulTermination(container.Terminated) {
+					if match := matchesPattern(container.Terminated, terminatedPatterns); match != nil {
+						return &FailureClassification{
+							Category:    CategoryInfrastructure,
+							Subcategory: match.subcategory,
+							ErrorCode:   match.errorCode,
+							Evidence:    []string{fmt.Sprintf("container %s/%s terminated: %s", pod.Name, container.Name, container.Terminated)},
+							Confidence:  ConfidenceMedium,
+						}, nil
+					}
 				}
 				// Stash first unrecognized distress signal for deferred use.
 				if distress == nil {
@@ -104,7 +106,7 @@ func classifyFromPods(report *clusterhealth.Report) (*FailureClassification, *Fa
 							Evidence:    []string{fmt.Sprintf("container %s/%s in unrecognized waiting state: %s", pod.Name, container.Name, container.Waiting)},
 							Confidence:  ConfidenceLow,
 						}
-					} else if container.Terminated != "" && !isSuccessfulTermination(container.Terminated) {
+					} else if container.Terminated != "" && !isSuccessfulTermination(container.Terminated) && !isGracefulTermination(container.Terminated) {
 						distress = &FailureClassification{
 							Category:    CategoryInfrastructure,
 							Subcategory: "cluster-distress",
@@ -129,10 +131,18 @@ func classifyFromPods(report *clusterhealth.Report) (*FailureClassification, *Fa
 	return nil, distress
 }
 
-// classifyFromEvents checks event reasons/messages for network and storage patterns.
-// Covers: network, storage subcategories.
+// classifyFromEvents checks event reasons/messages for image-pull, network, storage, RBAC, DNS, timeout, and probe patterns.
 func classifyFromEvents(report *clusterhealth.Report) *FailureClassification {
 	for _, event := range report.Events.Data.Events {
+		if containsImagePullEventPattern(event.Message) {
+			return &FailureClassification{
+				Category:    CategoryInfrastructure,
+				Subcategory: "image-pull",
+				ErrorCode:   CodeImagePull,
+				Evidence:    []string{fmt.Sprintf("event %s/%s: %s - %s", event.Kind, event.Name, event.Reason, event.Message)},
+				Confidence:  ConfidenceMedium,
+			}
+		}
 		if networkEventReasons[event.Reason] || containsNetworkPattern(event.Message) {
 			return &FailureClassification{
 				Category:    CategoryInfrastructure,
@@ -147,6 +157,42 @@ func classifyFromEvents(report *clusterhealth.Report) *FailureClassification {
 				Category:    CategoryInfrastructure,
 				Subcategory: "storage",
 				ErrorCode:   CodeStorage,
+				Evidence:    []string{fmt.Sprintf("event %s/%s: %s - %s", event.Kind, event.Name, event.Reason, event.Message)},
+				Confidence:  ConfidenceMedium,
+			}
+		}
+		if probeEventReasons[event.Reason] || containsProbePattern(event.Message) {
+			return &FailureClassification{
+				Category:    CategoryInfrastructure,
+				Subcategory: "probe-failure",
+				ErrorCode:   CodeProbeFailure,
+				Evidence:    []string{fmt.Sprintf("event %s/%s: %s - %s", event.Kind, event.Name, event.Reason, event.Message)},
+				Confidence:  ConfidenceMedium,
+			}
+		}
+		if containsRBACPattern(event.Message) {
+			return &FailureClassification{
+				Category:    CategoryInfrastructure,
+				Subcategory: "rbac",
+				ErrorCode:   CodeRBAC,
+				Evidence:    []string{fmt.Sprintf("event %s/%s: %s - %s", event.Kind, event.Name, event.Reason, event.Message)},
+				Confidence:  ConfidenceMedium,
+			}
+		}
+		if containsDNSPattern(event.Message) {
+			return &FailureClassification{
+				Category:    CategoryInfrastructure,
+				Subcategory: "dns",
+				ErrorCode:   CodeDNS,
+				Evidence:    []string{fmt.Sprintf("event %s/%s: %s - %s", event.Kind, event.Name, event.Reason, event.Message)},
+				Confidence:  ConfidenceMedium,
+			}
+		}
+		if containsTimeoutPattern(event.Message) {
+			return &FailureClassification{
+				Category:    CategoryInfrastructure,
+				Subcategory: "timeout",
+				ErrorCode:   CodeTimeout,
 				Evidence:    []string{fmt.Sprintf("event %s/%s: %s - %s", event.Kind, event.Name, event.Reason, event.Message)},
 				Confidence:  ConfidenceMedium,
 			}
@@ -192,16 +238,20 @@ func classifyFromNodes(report *clusterhealth.Report) *FailureClassification {
 }
 
 // classifyClusterDistress uses the pre-computed pod distress signal (if any)
-// and checks for unready deployments. This avoids re-iterating over pods.
+// and checks for unready deployments. Deployments newer than PendingThreshold
+// are skipped — they are assumed to be mid-startup.
 func classifyClusterDistress(report *clusterhealth.Report, podDistress *FailureClassification) *FailureClassification {
 	if podDistress != nil {
 		return podDistress
 	}
 
-	// Check for unready deployments.
+	// Check for unready deployments, skipping recently-created ones.
 	for _, deploys := range report.Deployments.Data.ByNamespace {
 		for _, d := range deploys {
 			if d.Ready < d.Replicas {
+				if !d.CreatedAt.IsZero() && time.Since(d.CreatedAt) < PendingThreshold {
+					continue // still starting up, not a distress signal yet
+				}
 				return &FailureClassification{
 					Category:    CategoryInfrastructure,
 					Subcategory: "cluster-distress",
@@ -284,6 +334,14 @@ func classifyFromCRConditions(name string, section clusterhealth.SectionResult[c
 // string format from clusterhealth is "{Reason} (exit {Code})[: {Message}]".
 func isSuccessfulTermination(terminated string) bool {
 	return strings.Contains(terminated, "(exit 0)")
+}
+
+// isGracefulTermination returns true if the terminated string has Kubernetes
+// reason "Completed", meaning the container exited as part of a normal
+// shutdown (SIGTERM from drain/eviction/rolling-update). These must not be
+// classified as failures even when the exit code is non-zero (e.g. 143).
+func isGracefulTermination(terminated string) bool {
+	return strings.HasPrefix(terminated, "Completed ")
 }
 
 // unknown returns the default unclassifiable result.

--- a/pkg/failureclassifier/classifier_test.go
+++ b/pkg/failureclassifier/classifier_test.go
@@ -46,12 +46,12 @@ func TestClassify_NilAndCleanReport(t *testing.T) {
 			wantConfidence:  ConfidenceLow,
 		},
 		{
-			name:            "clean report classifies as test failure",
+			name:            "clean report returns no-signal",
 			report:          &clusterhealth.Report{},
-			wantCategory:    CategoryTest,
-			wantSubcategory: "test-failure",
-			wantErrorCode:   CodeTestFailure,
-			wantConfidence:  ConfidenceMedium,
+			wantCategory:    CategoryUnknown,
+			wantSubcategory: "no-signal",
+			wantErrorCode:   CodeNoSignal,
+			wantConfidence:  ConfidenceLow,
 		},
 		{
 			name: "all sections errored returns unknown",
@@ -214,7 +214,7 @@ func TestClassify_PendingBelowThreshold(t *testing.T) {
 				},
 			}
 			got := Classify(report)
-			assertClassification(t, got, CategoryTest, "test-failure", CodeTestFailure, ConfidenceMedium)
+			assertClassification(t, got, CategoryUnknown, "no-signal", CodeNoSignal, ConfidenceLow)
 		})
 	}
 }
@@ -421,6 +421,20 @@ func TestClassify_ClusterDistress(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "unready deployment past threshold",
+			report: &clusterhealth.Report{
+				Deployments: clusterhealth.SectionResult[clusterhealth.DeploymentsSection]{
+					Data: clusterhealth.DeploymentsSection{
+						ByNamespace: map[string][]clusterhealth.DeploymentInfo{
+							"test-ns": {
+								{Namespace: "test-ns", Name: "old-deploy", Ready: 0, Replicas: 1, CreatedAt: time.Now().Add(-2 * PendingThreshold)},
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -429,6 +443,23 @@ func TestClassify_ClusterDistress(t *testing.T) {
 			assertClassification(t, got, CategoryInfrastructure, "cluster-distress", CodeInfraUnknown, ConfidenceLow)
 		})
 	}
+}
+
+func TestClassify_DeploymentBelowThreshold(t *testing.T) {
+	// A recently-created unready deployment must be skipped — it is still starting up.
+	report := &clusterhealth.Report{
+		Deployments: clusterhealth.SectionResult[clusterhealth.DeploymentsSection]{
+			Data: clusterhealth.DeploymentsSection{
+				ByNamespace: map[string][]clusterhealth.DeploymentInfo{
+					"test-ns": {
+						{Namespace: "test-ns", Name: "new-deploy", Ready: 0, Replicas: 1, CreatedAt: time.Now().Add(-5 * time.Second)},
+					},
+				},
+			},
+		},
+	}
+	got := Classify(report)
+	assertClassification(t, got, CategoryUnknown, "no-signal", CodeNoSignal, ConfidenceLow)
 }
 
 func TestClassify_Priority(t *testing.T) {
@@ -656,7 +687,7 @@ func TestClassify_Operator(t *testing.T) {
 			wantConfidence:  ConfidenceLow,
 		},
 		{
-			name: "healthy operator classifies as test failure",
+			name: "healthy operator returns no-signal",
 			report: &clusterhealth.Report{
 				Operator: clusterhealth.SectionResult[clusterhealth.OperatorSection]{
 					Data: clusterhealth.OperatorSection{
@@ -671,10 +702,10 @@ func TestClassify_Operator(t *testing.T) {
 					},
 				},
 			},
-			wantCategory:    CategoryTest,
-			wantSubcategory: "test-failure",
-			wantErrorCode:   CodeTestFailure,
-			wantConfidence:  ConfidenceMedium,
+			wantCategory:    CategoryUnknown,
+			wantSubcategory: "no-signal",
+			wantErrorCode:   CodeNoSignal,
+			wantConfidence:  ConfidenceLow,
 		},
 	}
 
@@ -723,7 +754,7 @@ func TestClassify_DSCI(t *testing.T) {
 			wantConfidence:  ConfidenceLow,
 		},
 		{
-			name: "DSCI healthy classifies as test failure",
+			name: "DSCI healthy returns no-signal",
 			report: &clusterhealth.Report{
 				DSCI: clusterhealth.SectionResult[clusterhealth.CRConditionsSection]{
 					Data: clusterhealth.CRConditionsSection{
@@ -731,10 +762,10 @@ func TestClassify_DSCI(t *testing.T) {
 					},
 				},
 			},
-			wantCategory:    CategoryTest,
-			wantSubcategory: "test-failure",
-			wantErrorCode:   CodeTestFailure,
-			wantConfidence:  ConfidenceMedium,
+			wantCategory:    CategoryUnknown,
+			wantSubcategory: "no-signal",
+			wantErrorCode:   CodeNoSignal,
+			wantConfidence:  ConfidenceLow,
 		},
 	}
 
@@ -779,7 +810,7 @@ func TestClassify_SuccessfulTerminationNotFlagged(t *testing.T) {
 	}
 
 	got := Classify(report)
-	assertClassification(t, got, CategoryTest, "test-failure", CodeTestFailure, ConfidenceMedium)
+	assertClassification(t, got, CategoryUnknown, "no-signal", CodeNoSignal, ConfidenceLow)
 }
 
 func TestIsSuccessfulTermination(t *testing.T) {
@@ -837,6 +868,211 @@ func TestMatchesPattern(t *testing.T) {
 			if (got != nil) != tt.want {
 				t.Errorf("matchesPattern() returned %v, want match=%v", got, tt.want)
 			}
+		})
+	}
+}
+
+func TestClassify_RBAC(t *testing.T) {
+	tests := []struct {
+		name    string
+		message string
+	}{
+		{"is forbidden", "system:serviceaccount:ns:sa is forbidden: cannot get pods"},
+		{"access denied", "access denied for resource secrets in namespace foo"},
+		{"does not have permission", "user does not have permission to list configmaps"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			report := &clusterhealth.Report{
+				Events: clusterhealth.SectionResult[clusterhealth.EventsSection]{
+					Data: clusterhealth.EventsSection{
+						Events: []clusterhealth.EventInfo{
+							{Kind: "Pod", Name: "test-pod", Reason: "Failed", Message: tt.message},
+						},
+					},
+				},
+			}
+			got := Classify(report)
+			assertClassification(t, got, CategoryInfrastructure, "rbac", CodeRBAC, ConfidenceMedium)
+		})
+	}
+}
+
+func TestClassify_DNS(t *testing.T) {
+	tests := []struct {
+		name    string
+		message string
+	}{
+		{"no such host", "dial tcp: lookup api.example.com: no such host"},
+		{"failed to resolve", "failed to resolve hostname cluster.local"},
+		{"dns resolution failed", "dns resolution failed for service.namespace.svc.cluster.local"},
+		{"name or service not known", "dial tcp: lookup db: name or service not known"},
+		{"temporary failure in name resolution", "temporary failure in name resolution"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			report := &clusterhealth.Report{
+				Events: clusterhealth.SectionResult[clusterhealth.EventsSection]{
+					Data: clusterhealth.EventsSection{
+						Events: []clusterhealth.EventInfo{
+							{Kind: "Pod", Name: "test-pod", Reason: "Failed", Message: tt.message},
+						},
+					},
+				},
+			}
+			got := Classify(report)
+			assertClassification(t, got, CategoryInfrastructure, "dns", CodeDNS, ConfidenceMedium)
+		})
+	}
+}
+
+func TestClassify_Timeout(t *testing.T) {
+	tests := []struct {
+		name    string
+		message string
+	}{
+		{"context deadline exceeded", "error: context deadline exceeded while waiting for pod"},
+		{"deadline exceeded", "deadline exceeded calling API server"},
+		{"timed out waiting", "timed out waiting for condition"},
+		{"operation timed out", "operation timed out after 30s"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			report := &clusterhealth.Report{
+				Events: clusterhealth.SectionResult[clusterhealth.EventsSection]{
+					Data: clusterhealth.EventsSection{
+						Events: []clusterhealth.EventInfo{
+							{Kind: "Pod", Name: "test-pod", Reason: "Failed", Message: tt.message},
+						},
+					},
+				},
+			}
+			got := Classify(report)
+			assertClassification(t, got, CategoryInfrastructure, "timeout", CodeTimeout, ConfidenceMedium)
+		})
+	}
+}
+
+func TestClassify_ProbeFailure(t *testing.T) {
+	tests := []struct {
+		name   string
+		reason string
+		msg    string
+	}{
+		{"Unhealthy event reason", "Unhealthy", "Liveness probe failed: HTTP probe failed with statuscode: 503"},
+		{"liveness probe in message", "Warning", "liveness probe failed: Get http://10.0.0.1:8080/healthz: connection refused"},
+		{"readiness probe in message", "Warning", "readiness probe failed: command returned non-zero exit code: 1"},
+		{"startup probe in message", "Warning", "startup probe failed: dial tcp: connect: connection refused"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			report := &clusterhealth.Report{
+				Events: clusterhealth.SectionResult[clusterhealth.EventsSection]{
+					Data: clusterhealth.EventsSection{
+						Events: []clusterhealth.EventInfo{
+							{Kind: "Pod", Name: "test-pod", Reason: tt.reason, Message: tt.msg},
+						},
+					},
+				},
+			}
+			got := Classify(report)
+			assertClassification(t, got, CategoryInfrastructure, "probe-failure", CodeProbeFailure, ConfidenceMedium)
+		})
+	}
+}
+
+func TestClassify_TerminatedExitCodes(t *testing.T) {
+	tests := []struct {
+		name            string
+		terminated      string
+		wantSubcategory string
+		wantErrorCode   int
+	}{
+		{"exit 2 invalid flags", "Error (exit 2): flag provided but not defined: --invalid-flag", "invalid-cli-flags", CodeInvalidFlags},
+		{"exit 137 non-OOM forced kill", "Error (exit 137): container killed by signal", "container-exit", CodeContainerExit},
+		{"exit 143 error context", "Error (exit 143): container received SIGTERM", "container-exit", CodeContainerExit},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			report := &clusterhealth.Report{
+				Pods: clusterhealth.SectionResult[clusterhealth.PodsSection]{
+					Data: clusterhealth.PodsSection{
+						ByNamespace: map[string][]clusterhealth.PodInfo{
+							"test-ns": {
+								{
+									Name: "exit-pod",
+									Containers: []clusterhealth.ContainerInfo{
+										{Name: "main", Terminated: tt.terminated},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			got := Classify(report)
+			assertClassification(t, got, CategoryInfrastructure, tt.wantSubcategory, tt.wantErrorCode, ConfidenceMedium)
+		})
+	}
+}
+
+func TestClassify_GracefulTerminationNotFlagged(t *testing.T) {
+	// Containers terminated with reason "Completed" are graceful SIGTERM/drain shutdowns
+	// and must never be classified as failures regardless of exit code.
+	tests := []struct {
+		name       string
+		terminated string
+	}{
+		{"graceful SIGTERM exit 143", "Completed (exit 143)"},
+		{"graceful forced kill exit 137", "Completed (exit 137)"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			report := &clusterhealth.Report{
+				Pods: clusterhealth.SectionResult[clusterhealth.PodsSection]{
+					Data: clusterhealth.PodsSection{
+						ByNamespace: map[string][]clusterhealth.PodInfo{
+							"test-ns": {
+								{
+									Name: "draining-pod",
+									Containers: []clusterhealth.ContainerInfo{
+										{Name: "main", Terminated: tt.terminated},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			got := Classify(report)
+			assertClassification(t, got, CategoryUnknown, "no-signal", CodeNoSignal, ConfidenceLow)
+		})
+	}
+}
+
+func TestClassify_ImagePullEvent(t *testing.T) {
+	// Registry auth failures surfacing as events must be classified as CodeImagePull,
+	// not CodeRBAC, even though the message contains "unauthorized".
+	tests := []struct {
+		name    string
+		message string
+	}{
+		{"unauthorized authentication required", "failed to pull image: unauthorized: authentication required"},
+		{"unauthorized access to resource", "failed to pull and unpack image: unauthorized: access to the requested resource is not authorized"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			report := &clusterhealth.Report{
+				Events: clusterhealth.SectionResult[clusterhealth.EventsSection]{
+					Data: clusterhealth.EventsSection{
+						Events: []clusterhealth.EventInfo{
+							{Kind: "Pod", Name: "test-pod", Reason: "Failed", Message: tt.message},
+						},
+					},
+				},
+			}
+			got := Classify(report)
+			assertClassification(t, got, CategoryInfrastructure, "image-pull", CodeImagePull, ConfidenceMedium)
 		})
 	}
 }

--- a/pkg/failureclassifier/types.go
+++ b/pkg/failureclassifier/types.go
@@ -34,8 +34,15 @@ const (
 	CodeOperator       = 1008
 	CodeDSCI           = 1009
 	CodeDSC            = 1010
+	CodeRBAC           = 1011
+	CodeDNS            = 1012
+	CodeTimeout        = 1013
+	CodeProbeFailure   = 1014
+	CodeInvalidFlags   = 1015
+	CodeContainerExit  = 1016
 	CodeInfraUnknown   = 1099
 	CodeTestFailure    = 2001
+	CodeNoSignal       = 3001
 	CodeUnclassifiable = 3000
 )
 
@@ -57,19 +64,25 @@ type classificationPattern struct {
 
 // Patterns matched against container Waiting message text (substring match, case-insensitive).
 // Checked in order; first match wins.
+// NOTE: "pulling image" is intentionally absent — it fires during normal startup, not just on errors.
 var waitingPatterns = []classificationPattern{
 	{"ImagePullBackOff", "image-pull", CodeImagePull},
 	{"ErrImagePull", "image-pull", CodeImagePull},
 	{"InvalidImageName", "image-pull", CodeImagePull},
-	{"pulling image", "image-pull", CodeImagePull},
 	{"CrashLoopBackOff", "pod-startup", CodePodStartup},
 	{"CreateContainerConfigError", "pod-startup", CodePodStartup},
 	{"CreateContainerError", "pod-startup", CodePodStartup},
 }
 
-// Patterns matched against container Terminated message text (substring match).
+// Patterns matched against container Terminated message text (substring match, case-insensitive).
+// Checked in order; first match wins — OOMKilled must remain first so it takes priority over exit-code patterns.
+// Exit-code patterns are only evaluated when the termination is non-graceful (see isGracefulTermination);
+// graceful SIGTERM/drain cases have Kubernetes reason "Completed" and must not be classified as failures.
 var terminatedPatterns = []classificationPattern{
 	{"OOMKilled", "container-oom", CodeContainerOOM},
+	{"(exit 2)", "invalid-cli-flags", CodeInvalidFlags},
+	{"(exit 137)", "container-exit", CodeContainerExit},
+	{"(exit 143)", "container-exit", CodeContainerExit},
 }
 
 // Event reason patterns indicating network issues (exact match on event Reason field).
@@ -98,6 +111,57 @@ var storageMessagePatterns = []string{
 	"no persistent volumes available",
 }
 
+// RBAC message patterns matched against event Message text (substring match, case-insensitive).
+// RBAC errors have no single k8s event Reason; the signal is always in the message.
+// "unauthorized" is intentionally absent — it is HTTP 401 (authentication failure) not HTTP 403
+// (RBAC denial), and fires on registry auth errors like "unauthorized: authentication required".
+// Registry-auth "unauthorized" events are caught by imagePullEventPatterns instead.
+var rbacMessagePatterns = []string{
+	"is forbidden",
+	"access denied",
+	"does not have permission",
+}
+
+// Image pull event message patterns matched against event Message text (substring match, case-insensitive).
+// Covers registry auth failures that surface as events rather than pod waiting states.
+var imagePullEventPatterns = []string{
+	"unauthorized: authentication",
+	"failed to pull image",
+	"failed to pull and unpack image",
+}
+
+// DNS message patterns matched against event Message text (substring match, case-insensitive).
+// Patterns are intentionally specific to DNS resolution errors only — generic TCP patterns
+// like "dial tcp" or "connection refused" are excluded because they fire on any network error.
+var dnsMessagePatterns = []string{
+	"no such host",
+	"failed to resolve",
+	"dns resolution failed",
+	"name or service not known",
+	"temporary failure in name resolution",
+}
+
+// Timeout message patterns matched against event Message text (substring match, case-insensitive).
+// Use "timed out waiting" to match only k8s deadline timeout messages.
+var timeoutMessagePatterns = []string{
+	"context deadline exceeded",
+	"deadline exceeded",
+	"timed out waiting",
+	"operation timed out",
+}
+
+// Event reason patterns indicating liveness/readiness probe failures (exact match on event Reason field).
+var probeEventReasons = map[string]bool{
+	"Unhealthy": true,
+}
+
+// Probe message patterns matched against event Message text (substring match, case-insensitive).
+var probeMessagePatterns = []string{
+	"liveness probe failed",
+	"readiness probe failed",
+	"startup probe failed",
+}
+
 // matchesPattern checks if text contains any pattern (case-insensitive).
 // Returns the first matching pattern or nil.
 func matchesPattern(text string, patterns []classificationPattern) *classificationPattern {
@@ -121,6 +185,31 @@ func containsNetworkPattern(text string) bool {
 // containsStoragePattern checks if text contains any storage-related pattern (case-insensitive).
 func containsStoragePattern(text string) bool {
 	return containsAnyPattern(text, storageMessagePatterns)
+}
+
+// containsImagePullEventPattern checks if text contains any image-pull event pattern (case-insensitive).
+func containsImagePullEventPattern(text string) bool {
+	return containsAnyPattern(text, imagePullEventPatterns)
+}
+
+// containsRBACPattern checks if text contains any RBAC-related pattern (case-insensitive).
+func containsRBACPattern(text string) bool {
+	return containsAnyPattern(text, rbacMessagePatterns)
+}
+
+// containsDNSPattern checks if text contains any DNS-related pattern (case-insensitive).
+func containsDNSPattern(text string) bool {
+	return containsAnyPattern(text, dnsMessagePatterns)
+}
+
+// containsTimeoutPattern checks if text contains any timeout-related pattern (case-insensitive).
+func containsTimeoutPattern(text string) bool {
+	return containsAnyPattern(text, timeoutMessagePatterns)
+}
+
+// containsProbePattern checks if text contains any probe-failure pattern (case-insensitive).
+func containsProbePattern(text string) bool {
+	return containsAnyPattern(text, probeMessagePatterns)
 }
 
 // containsAnyPattern checks if text contains any of the given patterns (case-insensitive).

--- a/tests/e2e/circuit_breaker_test.go
+++ b/tests/e2e/circuit_breaker_test.go
@@ -93,7 +93,8 @@ func (cb *CircuitBreaker) RecordResult(passed bool, classification *atomic.Point
 	// Check the failure classification to decide if this failure counts
 	if classification != nil {
 		if fc := classification.Load(); fc != nil {
-			if fc.Category == failureclassifier.CategoryTest {
+			if fc.Category == failureclassifier.CategoryTest ||
+				fc.ErrorCode == failureclassifier.CodeNoSignal {
 				log.Printf("Circuit breaker: failure classified as test-logic (%s/%s, code=%d) — not counting toward threshold",
 					fc.Category, fc.Subcategory, fc.ErrorCode)
 				cb.consecutiveFailures = 0


### PR DESCRIPTION
<!---
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description

The failure classifier was hardened against false positives and extended with broader failure coverage. The "pulling image" pattern was removed from waiting-state detection since it fires during normal pod startup. New error codes and their corresponding patterns were added to types.go — covering RBAC errors, DNS failures, timeouts, probe failures, invalid CLI flags (exit 2), and non-OOM container exits (137, 143). 

https://redhat.atlassian.net/browse/RHOAIENG-70939

## How Has This Been Tested?

Done Unit Tests.



## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [X] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [X] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work


### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [X] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
Add E2E if required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * More granular infrastructure failure classifications (RBAC/permissions, DNS, timeouts, probe failures), plus container-exit and “no-signal” handling.
  * Deployment status now includes a creation timestamp.

* **Bug Fixes**
  * Healthy/clean scans now return “no-signal” (low confidence) instead of a failure classification.
  * Recently created unready deployments are treated as still starting; graceful terminations are no longer flagged.
  * “No-signal” no longer counts toward consecutive-failure thresholding.

* **Documentation**
  * Expanded diagnostic decision rules and error-code reference.

* **Tests**
  * Updated and expanded classification expectations and mappings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->