### PR TITLE
RHOAIENG-56117: Add checks for UPDATE in validation webhooks

### DIFF
--- a/internal/webhook/dscinitialization/integration_test.go
+++ b/internal/webhook/dscinitialization/integration_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	operatorv1 "github.com/openshift/api/operator/v1"
 	"github.com/rs/xid"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -22,6 +23,8 @@ import (
 // It uses table-driven tests to verify singleton enforcement and deletion restrictions in a real envtest environment.
 func TestDSCIWebhook_Integration(t *testing.T) {
 	t.Parallel()
+
+	validPEM := envtestutil.GenerateTestCertPEM(t)
 
 	testCases := []struct {
 		name  string
@@ -81,6 +84,51 @@ func TestDSCIWebhook_Integration(t *testing.T) {
 				key := types.NamespacedName{Name: "v2-dsci-delete", Namespace: ns}
 				g.Expect(k8sClient.Get(ctx, key, dsci)).To(Succeed(), "should get DSCI v2 for deletion test")
 				g.Expect(k8sClient.Delete(ctx, dsci)).To(Succeed(), "should allow deletion if no DSC exists")
+			},
+		},
+		{
+			name: "V2 Update: allows update with valid PEM when TrustedCABundle is Managed",
+			setup: func(ns string) []client.Object {
+				return nil
+			},
+			test: func(g Gomega, ctx context.Context, k8sClient client.Client, ns string) {
+				dsci := envtestutil.NewDSCI("v2-dsci-update-valid")
+				g.Expect(k8sClient.Create(ctx, dsci)).To(Succeed())
+				dsci.Spec.TrustedCABundle = &dsciv2.TrustedCABundleSpec{
+					ManagementState: operatorv1.Managed,
+					CustomCABundle:  validPEM,
+				}
+				g.Expect(k8sClient.Update(ctx, dsci)).To(Succeed(), "should allow update with valid PEM")
+			},
+		},
+		{
+			name: "V2 Update: denies update with invalid PEM when TrustedCABundle is Managed",
+			setup: func(ns string) []client.Object {
+				return nil
+			},
+			test: func(g Gomega, ctx context.Context, k8sClient client.Client, ns string) {
+				dsci := envtestutil.NewDSCI("v2-dsci-update-invalid")
+				g.Expect(k8sClient.Create(ctx, dsci)).To(Succeed())
+				dsci.Spec.TrustedCABundle = &dsciv2.TrustedCABundleSpec{
+					ManagementState: operatorv1.Managed,
+					CustomCABundle:  "not-a-valid-pem",
+				}
+				g.Expect(k8sClient.Update(ctx, dsci)).NotTo(Succeed(), "should deny update with invalid PEM")
+			},
+		},
+		{
+			name: "V2 Update: allows update with invalid PEM when TrustedCABundle is Removed",
+			setup: func(ns string) []client.Object {
+				return nil
+			},
+			test: func(g Gomega, ctx context.Context, k8sClient client.Client, ns string) {
+				dsci := envtestutil.NewDSCI("v2-dsci-update-removed")
+				g.Expect(k8sClient.Create(ctx, dsci)).To(Succeed())
+				dsci.Spec.TrustedCABundle = &dsciv2.TrustedCABundleSpec{
+					ManagementState: operatorv1.Removed,
+					CustomCABundle:  "not-a-valid-pem",
+				}
+				g.Expect(k8sClient.Update(ctx, dsci)).To(Succeed(), "should allow update when TrustedCABundle is Removed")
 			},
 		},
 	}

--- a/internal/webhook/dscinitialization/v1/register.go
+++ b/internal/webhook/dscinitialization/v1/register.go
@@ -4,6 +4,7 @@ package v1
 
 import (
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	dsciv1 "github.com/opendatahub-io/opendatahub-operator/v2/api/dscinitialization/v1"
 )
@@ -16,8 +17,9 @@ func RegisterWebhooks(mgr ctrl.Manager) error {
 	}
 
 	if err := (&Validator{
-		Client: mgr.GetAPIReader(),
-		Name:   "dscinitialization-v1-validating",
+		Client:  mgr.GetAPIReader(),
+		Name:    "dscinitialization-v1-validating",
+		Decoder: admission.NewDecoder(mgr.GetScheme()),
 	}).SetupWithManager(mgr); err != nil {
 		return err
 	}

--- a/internal/webhook/dscinitialization/v1/validating.go
+++ b/internal/webhook/dscinitialization/v1/validating.go
@@ -5,7 +5,9 @@ package v1
 import (
 	"context"
 	"fmt"
+	"net/http"
 
+	operatorv1 "github.com/openshift/api/operator/v1"
 	admissionv1 "k8s.io/api/admission/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -13,18 +15,21 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
+	dsciv1 "github.com/opendatahub-io/opendatahub-operator/v2/api/dscinitialization/v1"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
 	webhookutils "github.com/opendatahub-io/opendatahub-operator/v2/pkg/webhook"
 )
 
-//+kubebuilder:webhook:path=/validate-dscinitialization-v1,matchPolicy=Exact,mutating=false,failurePolicy=fail,sideEffects=None,groups=dscinitialization.opendatahub.io,resources=dscinitializations,verbs=create;delete,versions=v1,name=dscinitialization-v1-validator.opendatahub.io,admissionReviewVersions=v1
+//+kubebuilder:webhook:path=/validate-dscinitialization-v1,matchPolicy=Exact,mutating=false,failurePolicy=fail,sideEffects=None,groups=dscinitialization.opendatahub.io,resources=dscinitializations,verbs=create;update;delete,versions=v1,name=dscinitialization-v1-validator.opendatahub.io,admissionReviewVersions=v1
 //nolint:lll
 
 // Validator implements webhook.AdmissionHandler for DSCInitialization v1 validation webhooks.
 // It enforces singleton creation and deletion rules for DSCInitialization resources.
 type Validator struct {
-	Client client.Reader
-	Name   string
+	Client  client.Reader
+	Name    string
+	Decoder admission.Decoder
 }
 
 // Assert that Validator implements admission.Handler interface.
@@ -46,8 +51,8 @@ func (v *Validator) SetupWithManager(mgr ctrl.Manager) error {
 	return nil
 }
 
-// Handle processes admission requests for create and delete operations on DSCInitialization v1 resources.
-// It enforces singleton and deletion rules, allowing other operations by default.
+// Handle processes admission requests for create, update, and delete operations on DSCInitialization v1 resources.
+// It enforces singleton creation, PEM validation for customCABundle, and deletion rules.
 //
 // Parameters:
 //   - ctx: Context for the admission request (logger is extracted from here).
@@ -59,21 +64,42 @@ func (v *Validator) Handle(ctx context.Context, req admission.Request) admission
 	log := logf.FromContext(ctx)
 	ctx = logf.IntoContext(ctx, log)
 
-	var resp admission.Response
+	allowMessage := fmt.Sprintf("Operation %s on %s v1 allowed", req.Operation, req.Kind.Kind)
 
 	switch req.Operation {
 	case admissionv1.Create:
-		resp = webhookutils.ValidateSingletonCreation(ctx, v.Client, &req, gvk.DSCInitialization)
+		if resp := webhookutils.ValidateSingletonCreation(ctx, v.Client, &req, gvk.DSCInitialization); !resp.Allowed {
+			return resp
+		}
+		return v.validateSpec(ctx, &req, allowMessage)
+	case admissionv1.Update:
+		return v.validateSpec(ctx, &req, allowMessage)
 	case admissionv1.Delete:
-		resp = webhookutils.DenyCountGtZero(ctx, v.Client, gvk.DataScienceCluster,
+		resp := webhookutils.DenyCountGtZero(ctx, v.Client, gvk.DataScienceCluster,
 			"Cannot delete DSCInitialization v1 object when DataScienceCluster object still exists")
+		if !resp.Allowed {
+			return resp
+		}
+		return admission.Allowed(allowMessage)
 	default:
-		resp.Allowed = true
+		return admission.Allowed(allowMessage)
+	}
+}
+
+func (v *Validator) validateSpec(ctx context.Context, req *admission.Request, allowMessage string) admission.Response {
+	dsci := &dsciv1.DSCInitialization{}
+	if err := v.Decoder.DecodeRaw(req.Object, dsci); err != nil {
+		logf.FromContext(ctx).Error(err, "failed to decode DSCInitialization v1")
+		return admission.Errored(http.StatusBadRequest, err)
 	}
 
-	if !resp.Allowed {
-		return resp
+	if dsci.Spec.TrustedCABundle != nil &&
+		dsci.Spec.TrustedCABundle.ManagementState == operatorv1.Managed &&
+		dsci.Spec.TrustedCABundle.CustomCABundle != "" {
+		if err := cluster.ValidateCustomCABundle(dsci.Spec.TrustedCABundle.CustomCABundle); err != nil {
+			return admission.Denied(fmt.Sprintf("invalid customCABundle: %v", err))
+		}
 	}
 
-	return admission.Allowed(fmt.Sprintf("Operation %s on %s v1 allowed", req.Operation, req.Kind.Kind))
+	return admission.Allowed(allowMessage)
 }

--- a/internal/webhook/dscinitialization/v1/validating_test.go
+++ b/internal/webhook/dscinitialization/v1/validating_test.go
@@ -3,28 +3,47 @@ package v1_test
 import (
 	"testing"
 
+	operatorv1 "github.com/openshift/api/operator/v1"
 	admissionv1 "k8s.io/api/admission/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	dscv2 "github.com/opendatahub-io/opendatahub-operator/v2/api/datasciencecluster/v2"
+	dsciv1 "github.com/opendatahub-io/opendatahub-operator/v2/api/dscinitialization/v1"
 	v1webhook "github.com/opendatahub-io/opendatahub-operator/v2/internal/webhook/dscinitialization/v1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/internal/webhook/envtestutil"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/fakeclient"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/scheme"
 
 	. "github.com/onsi/gomega"
 )
 
 // TestDSCInitializationV1_ValidatingWebhook exercises the validating webhook logic for DSCInitialization v1 resources.
-// It verifies singleton enforcement and deletion restrictions using table-driven tests and a fake client.
+// It verifies singleton enforcement, deletion restrictions, and customCABundle PEM validation
+// using table-driven tests and a fake client.
 func TestDSCInitializationV1_ValidatingWebhook(t *testing.T) {
 	t.Parallel()
-	g := NewWithT(t)
 	ctx := t.Context()
 
 	ns := "test-ns"
+	validPEM := envtestutil.GenerateTestCertPEM(t)
+
+	withTrustedCABundle := func(state operatorv1.ManagementState, bundle string) func(*dsciv1.DSCInitialization) {
+		return func(dsci *dsciv1.DSCInitialization) {
+			dsci.Spec.TrustedCABundle = &dsciv1.TrustedCABundleSpec{
+				ManagementState: state,
+				CustomCABundle:  bundle,
+			}
+		}
+	}
+
+	gvr := metav1.GroupVersionResource{
+		Group:    gvk.DSCInitializationV1.Group,
+		Version:  gvk.DSCInitializationV1.Version,
+		Resource: "dscinitializations",
+	}
 
 	cases := []struct {
 		name         string
@@ -35,77 +54,86 @@ func TestDSCInitializationV1_ValidatingWebhook(t *testing.T) {
 		{
 			name:         "Allows creation if none exist",
 			existingObjs: nil,
-			req: envtestutil.NewAdmissionRequest(
-				t,
-				admissionv1.Create,
-				envtestutil.NewDSCIV1("test-create"),
-				gvk.DSCInitialization,
-				metav1.GroupVersionResource{
-					Group:    gvk.DSCInitializationV1.Group,
-					Version:  gvk.DSCInitializationV1.Version,
-					Resource: "dscinitializations",
-				},
-			),
-			allowed: true,
+			req:          envtestutil.NewAdmissionRequest(t, admissionv1.Create, envtestutil.NewDSCIV1("test-create"), gvk.DSCInitialization, gvr),
+			allowed:      true,
 		},
 		{
-			name: "Denies creation if one already exists",
-			existingObjs: []client.Object{
-				envtestutil.NewDSCI("existing"),
-			},
-			req: envtestutil.NewAdmissionRequest(
-				t,
-				admissionv1.Create,
-				envtestutil.NewDSCIV1("test-create"),
-				gvk.DSCInitialization,
-				metav1.GroupVersionResource{
-					Group:    gvk.DSCInitializationV1.Group,
-					Version:  gvk.DSCInitializationV1.Version,
-					Resource: "dscinitializations",
-				},
-			),
-			allowed: false,
+			name:         "Denies creation if one already exists",
+			existingObjs: []client.Object{envtestutil.NewDSCI("existing")},
+			req:          envtestutil.NewAdmissionRequest(t, admissionv1.Create, envtestutil.NewDSCIV1("test-create"), gvk.DSCInitialization, gvr),
+			allowed:      false,
 		},
 		{
 			name: "Denies deletion if DSC exists",
 			existingObjs: []client.Object{
-				&dscv2.DataScienceCluster{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "dsc-1",
-						Namespace: ns,
-					},
-				},
+				&dscv2.DataScienceCluster{ObjectMeta: metav1.ObjectMeta{Name: "dsc-1", Namespace: ns}},
 				envtestutil.NewDSCI("dsci-1"),
 			},
-			req: envtestutil.NewAdmissionRequest(
-				t,
-				admissionv1.Delete,
-				envtestutil.NewDSCIV1("dsci-1"),
-				gvk.DSCInitialization,
-				metav1.GroupVersionResource{
-					Group:    gvk.DSCInitializationV1.Group,
-					Version:  gvk.DSCInitializationV1.Version,
-					Resource: "dscinitializations",
-				},
-			),
+			req:     envtestutil.NewAdmissionRequest(t, admissionv1.Delete, envtestutil.NewDSCIV1("dsci-1"), gvk.DSCInitialization, gvr),
 			allowed: false,
 		},
 		{
-			name: "Allows deletion if no DSC exists",
-			existingObjs: []client.Object{
-				envtestutil.NewDSCI("dsci-1"),
-			},
-			req: envtestutil.NewAdmissionRequest(
-				t,
-				admissionv1.Delete,
-				envtestutil.NewDSCIV1("dsci-1"),
-				gvk.DSCInitialization,
-				metav1.GroupVersionResource{
-					Group:    gvk.DSCInitializationV1.Group,
-					Version:  gvk.DSCInitializationV1.Version,
-					Resource: "dscinitializations",
-				},
-			),
+			name:         "Allows deletion if no DSC exists",
+			existingObjs: []client.Object{envtestutil.NewDSCI("dsci-1")},
+			req:          envtestutil.NewAdmissionRequest(t, admissionv1.Delete, envtestutil.NewDSCIV1("dsci-1"), gvk.DSCInitialization, gvr),
+			allowed:      true,
+		},
+		// PEM validation on Create
+		{
+			name: "Create with valid PEM and TrustedCABundle Managed",
+			req: envtestutil.NewAdmissionRequest(t, admissionv1.Create,
+				envtestutil.NewDSCIV1("test-valid-pem", withTrustedCABundle(operatorv1.Managed, validPEM)),
+				gvk.DSCInitialization, gvr),
+			allowed: true,
+		},
+		{
+			name: "Denies create with invalid PEM and TrustedCABundle Managed",
+			req: envtestutil.NewAdmissionRequest(t, admissionv1.Create,
+				envtestutil.NewDSCIV1("test-bad-pem", withTrustedCABundle(operatorv1.Managed, "not-a-pem")),
+				gvk.DSCInitialization, gvr),
+			allowed: false,
+		},
+		// PEM validation on Update
+		{
+			name: "Update with valid PEM and TrustedCABundle Managed",
+			req: envtestutil.NewAdmissionRequest(t, admissionv1.Update,
+				envtestutil.NewDSCIV1("test-update", withTrustedCABundle(operatorv1.Managed, validPEM)),
+				gvk.DSCInitialization, gvr),
+			allowed: true,
+		},
+		{
+			name: "Denies update with invalid PEM and TrustedCABundle Managed",
+			req: envtestutil.NewAdmissionRequest(t, admissionv1.Update,
+				envtestutil.NewDSCIV1("test-update-bad", withTrustedCABundle(operatorv1.Managed, "garbage")),
+				gvk.DSCInitialization, gvr),
+			allowed: false,
+		},
+		{
+			name: "Allows update with invalid PEM when TrustedCABundle is Removed",
+			req: envtestutil.NewAdmissionRequest(t, admissionv1.Update,
+				envtestutil.NewDSCIV1("test-removed", withTrustedCABundle(operatorv1.Removed, "garbage")),
+				gvk.DSCInitialization, gvr),
+			allowed: true,
+		},
+		{
+			name: "Allows update with empty customCABundle when TrustedCABundle is Managed",
+			req: envtestutil.NewAdmissionRequest(t, admissionv1.Update,
+				envtestutil.NewDSCIV1("test-empty", withTrustedCABundle(operatorv1.Managed, "")),
+				gvk.DSCInitialization, gvr),
+			allowed: true,
+		},
+		{
+			name: "Allows update with no TrustedCABundle set",
+			req: envtestutil.NewAdmissionRequest(t, admissionv1.Update,
+				envtestutil.NewDSCIV1("test-nil"),
+				gvk.DSCInitialization, gvr),
+			allowed: true,
+		},
+		{
+			name: "Update with valid multi-cert PEM chain",
+			req: envtestutil.NewAdmissionRequest(t, admissionv1.Update,
+				envtestutil.NewDSCIV1("test-chain", withTrustedCABundle(operatorv1.Managed, validPEM+validPEM)),
+				gvk.DSCInitialization, gvr),
 			allowed: true,
 		},
 	}
@@ -113,13 +141,18 @@ func TestDSCInitializationV1_ValidatingWebhook(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			cli, err := fakeclient.New(fakeclient.WithObjects(tc.existingObjs...))
+			g := NewWithT(t)
+			sch, err := scheme.New()
+			g.Expect(err).ShouldNot(HaveOccurred())
+			cli, err := fakeclient.New(fakeclient.WithObjects(tc.existingObjs...), fakeclient.WithScheme(sch))
 			g.Expect(err).ShouldNot(HaveOccurred())
 			validator := &v1webhook.Validator{
-				Client: cli,
-				Name:   "test-v1",
+				Client:  cli,
+				Name:    "test-v1",
+				Decoder: admission.NewDecoder(sch),
 			}
 			resp := validator.Handle(ctx, tc.req)
+			t.Logf("Admission response: Allowed=%v, Result=%+v", resp.Allowed, resp.Result)
 			g.Expect(resp.Allowed).To(Equal(tc.allowed))
 			if !tc.allowed {
 				g.Expect(resp.Result.Message).ToNot(BeEmpty(), "Expected error message when request is denied")

--- a/internal/webhook/dscinitialization/v2/register.go
+++ b/internal/webhook/dscinitialization/v2/register.go
@@ -4,13 +4,15 @@ package v2
 
 import (
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
 // RegisterWebhooks registers the webhooks for DSCInitialization v2.
 func RegisterWebhooks(mgr ctrl.Manager) error {
 	if err := (&Validator{
-		Client: mgr.GetAPIReader(),
-		Name:   "dscinitialization-v2-validating",
+		Client:  mgr.GetAPIReader(),
+		Name:    "dscinitialization-v2-validating",
+		Decoder: admission.NewDecoder(mgr.GetScheme()),
 	}).SetupWithManager(mgr); err != nil {
 		return err
 	}

--- a/internal/webhook/dscinitialization/v2/validating.go
+++ b/internal/webhook/dscinitialization/v2/validating.go
@@ -5,7 +5,9 @@ package v2
 import (
 	"context"
 	"fmt"
+	"net/http"
 
+	operatorv1 "github.com/openshift/api/operator/v1"
 	admissionv1 "k8s.io/api/admission/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -13,18 +15,21 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
+	dsciv2 "github.com/opendatahub-io/opendatahub-operator/v2/api/dscinitialization/v2"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
 	webhookutils "github.com/opendatahub-io/opendatahub-operator/v2/pkg/webhook"
 )
 
-//+kubebuilder:webhook:path=/validate-dscinitialization-v2,matchPolicy=Exact,mutating=false,failurePolicy=fail,sideEffects=None,groups=dscinitialization.opendatahub.io,resources=dscinitializations,verbs=create;delete,versions=v2,name=dscinitialization-v2-validator.opendatahub.io,admissionReviewVersions=v1
+//+kubebuilder:webhook:path=/validate-dscinitialization-v2,matchPolicy=Exact,mutating=false,failurePolicy=fail,sideEffects=None,groups=dscinitialization.opendatahub.io,resources=dscinitializations,verbs=create;update;delete,versions=v2,name=dscinitialization-v2-validator.opendatahub.io,admissionReviewVersions=v1
 //nolint:lll
 
 // Validator implements webhook.AdmissionHandler for DSCInitialization v2 validation webhooks.
 // It enforces singleton creation and deletion rules for DSCInitialization resources.
 type Validator struct {
-	Client client.Reader
-	Name   string
+	Client  client.Reader
+	Name    string
+	Decoder admission.Decoder
 }
 
 // Assert that Validator implements admission.Handler interface.
@@ -46,8 +51,8 @@ func (v *Validator) SetupWithManager(mgr ctrl.Manager) error {
 	return nil
 }
 
-// Handle processes admission requests for create and delete operations on DSCInitialization v2 resources.
-// It enforces singleton and deletion rules, allowing other operations by default.
+// Handle processes admission requests for create, update, and delete operations on DSCInitialization v2 resources.
+// It enforces singleton creation, PEM validation for customCABundle, and deletion rules.
 //
 // Parameters:
 //   - ctx: Context for the admission request (logger is extracted from here).
@@ -59,21 +64,42 @@ func (v *Validator) Handle(ctx context.Context, req admission.Request) admission
 	log := logf.FromContext(ctx)
 	ctx = logf.IntoContext(ctx, log)
 
-	var resp admission.Response
+	allowMessage := fmt.Sprintf("Operation %s on %s v2 allowed", req.Operation, req.Kind.Kind)
 
 	switch req.Operation {
 	case admissionv1.Create:
-		resp = webhookutils.ValidateSingletonCreation(ctx, v.Client, &req, gvk.DSCInitialization)
+		if resp := webhookutils.ValidateSingletonCreation(ctx, v.Client, &req, gvk.DSCInitialization); !resp.Allowed {
+			return resp
+		}
+		return v.validateSpec(ctx, &req, allowMessage)
+	case admissionv1.Update:
+		return v.validateSpec(ctx, &req, allowMessage)
 	case admissionv1.Delete:
-		resp = webhookutils.DenyCountGtZero(ctx, v.Client, gvk.DataScienceCluster,
+		resp := webhookutils.DenyCountGtZero(ctx, v.Client, gvk.DataScienceCluster,
 			"Cannot delete DSCInitialization v2 object when DataScienceCluster object still exists")
+		if !resp.Allowed {
+			return resp
+		}
+		return admission.Allowed(allowMessage)
 	default:
-		resp.Allowed = true
+		return admission.Allowed(allowMessage)
+	}
+}
+
+func (v *Validator) validateSpec(ctx context.Context, req *admission.Request, allowMessage string) admission.Response {
+	dsci := &dsciv2.DSCInitialization{}
+	if err := v.Decoder.DecodeRaw(req.Object, dsci); err != nil {
+		logf.FromContext(ctx).Error(err, "failed to decode DSCInitialization v2")
+		return admission.Errored(http.StatusBadRequest, err)
 	}
 
-	if !resp.Allowed {
-		return resp
+	if dsci.Spec.TrustedCABundle != nil &&
+		dsci.Spec.TrustedCABundle.ManagementState == operatorv1.Managed &&
+		dsci.Spec.TrustedCABundle.CustomCABundle != "" {
+		if err := cluster.ValidateCustomCABundle(dsci.Spec.TrustedCABundle.CustomCABundle); err != nil {
+			return admission.Denied(fmt.Sprintf("invalid customCABundle: %v", err))
+		}
 	}
 
-	return admission.Allowed(fmt.Sprintf("Operation %s on %s v2 allowed", req.Operation, req.Kind.Kind))
+	return admission.Allowed(allowMessage)
 }

--- a/internal/webhook/dscinitialization/v2/validating_test.go
+++ b/internal/webhook/dscinitialization/v2/validating_test.go
@@ -3,28 +3,46 @@ package v2_test
 import (
 	"testing"
 
+	operatorv1 "github.com/openshift/api/operator/v1"
 	admissionv1 "k8s.io/api/admission/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	dscv2 "github.com/opendatahub-io/opendatahub-operator/v2/api/datasciencecluster/v2"
+	dsciv2 "github.com/opendatahub-io/opendatahub-operator/v2/api/dscinitialization/v2"
 	v2webhook "github.com/opendatahub-io/opendatahub-operator/v2/internal/webhook/dscinitialization/v2"
 	"github.com/opendatahub-io/opendatahub-operator/v2/internal/webhook/envtestutil"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/fakeclient"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/scheme"
 
 	. "github.com/onsi/gomega"
 )
 
 // TestDSCInitializationV2_ValidatingWebhook exercises the validating webhook logic for DSCInitialization v2 resources.
-// It verifies singleton enforcement and deletion restrictions using table-driven tests and a fake client.
+// It verifies singleton enforcement, deletion restrictions, and customCABundle PEM validation
+// using table-driven tests and a fake client.
 func TestDSCInitializationV2_ValidatingWebhook(t *testing.T) {
 	t.Parallel()
-	g := NewWithT(t)
 	ctx := t.Context()
 
-	ns := "test-ns"
+	validPEM := envtestutil.GenerateTestCertPEM(t)
+
+	withTrustedCABundle := func(state operatorv1.ManagementState, bundle string) func(*dsciv2.DSCInitialization) {
+		return func(dsci *dsciv2.DSCInitialization) {
+			dsci.Spec.TrustedCABundle = &dsciv2.TrustedCABundleSpec{
+				ManagementState: state,
+				CustomCABundle:  bundle,
+			}
+		}
+	}
+
+	gvr := metav1.GroupVersionResource{
+		Group:    gvk.DSCInitialization.Group,
+		Version:  gvk.DSCInitialization.Version,
+		Resource: "dscinitializations",
+	}
 
 	cases := []struct {
 		name         string
@@ -35,77 +53,86 @@ func TestDSCInitializationV2_ValidatingWebhook(t *testing.T) {
 		{
 			name:         "Allows creation if none exist",
 			existingObjs: nil,
-			req: envtestutil.NewAdmissionRequest(
-				t,
-				admissionv1.Create,
-				envtestutil.NewDSCI("test-create"),
-				gvk.DSCInitialization,
-				metav1.GroupVersionResource{
-					Group:    gvk.DSCInitialization.Group,
-					Version:  gvk.DSCInitialization.Version,
-					Resource: "dscinitializations",
-				},
-			),
-			allowed: true,
+			req:          envtestutil.NewAdmissionRequest(t, admissionv1.Create, envtestutil.NewDSCI("test-create"), gvk.DSCInitialization, gvr),
+			allowed:      true,
 		},
 		{
-			name: "Denies creation if one already exists",
-			existingObjs: []client.Object{
-				envtestutil.NewDSCI("existing"),
-			},
-			req: envtestutil.NewAdmissionRequest(
-				t,
-				admissionv1.Create,
-				envtestutil.NewDSCI("test-create"),
-				gvk.DSCInitialization,
-				metav1.GroupVersionResource{
-					Group:    gvk.DSCInitialization.Group,
-					Version:  gvk.DSCInitialization.Version,
-					Resource: "dscinitializations",
-				},
-			),
-			allowed: false,
+			name:         "Denies creation if one already exists",
+			existingObjs: []client.Object{envtestutil.NewDSCI("existing")},
+			req:          envtestutil.NewAdmissionRequest(t, admissionv1.Create, envtestutil.NewDSCI("test-create"), gvk.DSCInitialization, gvr),
+			allowed:      false,
 		},
 		{
 			name: "Denies deletion if DSC exists",
 			existingObjs: []client.Object{
-				&dscv2.DataScienceCluster{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "dsc-1",
-						Namespace: ns,
-					},
-				},
+				&dscv2.DataScienceCluster{ObjectMeta: metav1.ObjectMeta{Name: "dsc-1", Namespace: "test-ns"}},
 				envtestutil.NewDSCI("dsci-1"),
 			},
-			req: envtestutil.NewAdmissionRequest(
-				t,
-				admissionv1.Delete,
-				envtestutil.NewDSCI("dsci-1"),
-				gvk.DSCInitialization,
-				metav1.GroupVersionResource{
-					Group:    gvk.DSCInitialization.Group,
-					Version:  gvk.DSCInitialization.Version,
-					Resource: "dscinitializations",
-				},
-			),
+			req:     envtestutil.NewAdmissionRequest(t, admissionv1.Delete, envtestutil.NewDSCI("dsci-1"), gvk.DSCInitialization, gvr),
 			allowed: false,
 		},
 		{
-			name: "Allows deletion if no DSC exists",
-			existingObjs: []client.Object{
-				envtestutil.NewDSCI("dsci-1"),
-			},
-			req: envtestutil.NewAdmissionRequest(
-				t,
-				admissionv1.Delete,
-				envtestutil.NewDSCI("dsci-1"),
-				gvk.DSCInitialization,
-				metav1.GroupVersionResource{
-					Group:    gvk.DSCInitialization.Group,
-					Version:  gvk.DSCInitialization.Version,
-					Resource: "dscinitializations",
-				},
-			),
+			name:         "Allows deletion if no DSC exists",
+			existingObjs: []client.Object{envtestutil.NewDSCI("dsci-1")},
+			req:          envtestutil.NewAdmissionRequest(t, admissionv1.Delete, envtestutil.NewDSCI("dsci-1"), gvk.DSCInitialization, gvr),
+			allowed:      true,
+		},
+		// PEM validation on Create
+		{
+			name: "Create with valid PEM and TrustedCABundle Managed",
+			req: envtestutil.NewAdmissionRequest(t, admissionv1.Create,
+				envtestutil.NewDSCI("test-valid-pem", withTrustedCABundle(operatorv1.Managed, validPEM)),
+				gvk.DSCInitialization, gvr),
+			allowed: true,
+		},
+		{
+			name: "Denies create with invalid PEM and TrustedCABundle Managed",
+			req: envtestutil.NewAdmissionRequest(t, admissionv1.Create,
+				envtestutil.NewDSCI("test-bad-pem", withTrustedCABundle(operatorv1.Managed, "not-a-pem")),
+				gvk.DSCInitialization, gvr),
+			allowed: false,
+		},
+		// PEM validation on Update
+		{
+			name: "Update with valid PEM and TrustedCABundle Managed",
+			req: envtestutil.NewAdmissionRequest(t, admissionv1.Update,
+				envtestutil.NewDSCI("test-update", withTrustedCABundle(operatorv1.Managed, validPEM)),
+				gvk.DSCInitialization, gvr),
+			allowed: true,
+		},
+		{
+			name: "Denies update with invalid PEM and TrustedCABundle Managed",
+			req: envtestutil.NewAdmissionRequest(t, admissionv1.Update,
+				envtestutil.NewDSCI("test-update-bad", withTrustedCABundle(operatorv1.Managed, "garbage")),
+				gvk.DSCInitialization, gvr),
+			allowed: false,
+		},
+		{
+			name: "Allows update with invalid PEM when TrustedCABundle is Removed",
+			req: envtestutil.NewAdmissionRequest(t, admissionv1.Update,
+				envtestutil.NewDSCI("test-removed", withTrustedCABundle(operatorv1.Removed, "garbage")),
+				gvk.DSCInitialization, gvr),
+			allowed: true,
+		},
+		{
+			name: "Allows update with empty customCABundle when TrustedCABundle is Managed",
+			req: envtestutil.NewAdmissionRequest(t, admissionv1.Update,
+				envtestutil.NewDSCI("test-empty", withTrustedCABundle(operatorv1.Managed, "")),
+				gvk.DSCInitialization, gvr),
+			allowed: true,
+		},
+		{
+			name: "Allows update with no TrustedCABundle set",
+			req: envtestutil.NewAdmissionRequest(t, admissionv1.Update,
+				envtestutil.NewDSCI("test-nil"),
+				gvk.DSCInitialization, gvr),
+			allowed: true,
+		},
+		{
+			name: "Update with valid multi-cert PEM chain",
+			req: envtestutil.NewAdmissionRequest(t, admissionv1.Update,
+				envtestutil.NewDSCI("test-chain", withTrustedCABundle(operatorv1.Managed, validPEM+validPEM)),
+				gvk.DSCInitialization, gvr),
 			allowed: true,
 		},
 	}
@@ -113,13 +140,18 @@ func TestDSCInitializationV2_ValidatingWebhook(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			cli, err := fakeclient.New(fakeclient.WithObjects(tc.existingObjs...))
+			g := NewWithT(t)
+			sch, err := scheme.New()
+			g.Expect(err).ShouldNot(HaveOccurred())
+			cli, err := fakeclient.New(fakeclient.WithObjects(tc.existingObjs...), fakeclient.WithScheme(sch))
 			g.Expect(err).ShouldNot(HaveOccurred())
 			validator := &v2webhook.Validator{
-				Client: cli,
-				Name:   "test-v2",
+				Client:  cli,
+				Name:    "test-v2",
+				Decoder: admission.NewDecoder(sch),
 			}
 			resp := validator.Handle(ctx, tc.req)
+			t.Logf("Admission response: Allowed=%v, Result=%+v", resp.Allowed, resp.Result)
 			g.Expect(resp.Allowed).To(Equal(tc.allowed))
 			if !tc.allowed {
 				g.Expect(resp.Result.Message).ToNot(BeEmpty(), "Expected error message when request is denied")

--- a/internal/webhook/envtestutil/envtestutil.go
+++ b/internal/webhook/envtestutil/envtestutil.go
@@ -2,9 +2,15 @@ package envtestutil
 
 import (
 	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
 	"encoding/json"
+	"encoding/pem"
 	"errors"
 	"fmt"
+	"math/big"
 	"reflect"
 	"testing"
 	"time"
@@ -60,6 +66,30 @@ type CRDSetupOption func(ctx context.Context, t *testing.T, env *envt.EnvT) erro
 // =============================================================================
 // Helper Functions
 // =============================================================================
+
+// GenerateTestCertPEM generates a self-signed PEM-encoded certificate for use in tests.
+func GenerateTestCertPEM(t *testing.T) string {
+	t.Helper()
+
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("failed to generate RSA key: %v", err)
+	}
+
+	tmpl := x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "test"},
+		NotBefore:    time.Now(),
+		NotAfter:     time.Now().Add(time.Hour),
+	}
+
+	der, err := x509.CreateCertificate(rand.Reader, &tmpl, &tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("failed to create certificate: %v", err)
+	}
+
+	return string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}))
+}
 
 // createAndWaitForCRD creates a CRD and waits for it to be established.
 // This helper eliminates code duplication between different CRD setup functions.

--- a/pkg/cluster/cert.go
+++ b/pkg/cluster/cert.go
@@ -8,6 +8,7 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"math/big"
 	"net"
@@ -35,6 +36,42 @@ const (
 var IngressControllerName = types.NamespacedName{
 	Namespace: "openshift-ingress-operator",
 	Name:      "default",
+}
+
+func ValidateCustomCABundle(pemData string) error {
+	if pemData == "" {
+		return nil
+	}
+
+	rest := []byte(pemData)
+	blockCount := 0
+
+	for {
+		var block *pem.Block
+		block, rest = pem.Decode(rest)
+		if block == nil {
+			break
+		}
+		blockCount++
+
+		if block.Type != "CERTIFICATE" {
+			return fmt.Errorf("PEM block %d has type %q, expected CERTIFICATE", blockCount, block.Type)
+		}
+
+		if _, err := x509.ParseCertificate(block.Bytes); err != nil {
+			return fmt.Errorf("PEM block %d is not a valid certificate: %w", blockCount, err)
+		}
+	}
+
+	if blockCount == 0 {
+		return errors.New("no valid PEM blocks found in customCABundle")
+	}
+
+	if len(strings.TrimSpace(string(rest))) > 0 {
+		return fmt.Errorf("trailing non-PEM data after %d valid certificate block(s)", blockCount)
+	}
+
+	return nil
 }
 
 func CreateSelfSignedCertificate(ctx context.Context, c client.Client, secretName, domain, namespace string, metaOptions ...MetaOptions) error {

--- a/pkg/cluster/cert_test.go
+++ b/pkg/cluster/cert_test.go
@@ -1,0 +1,101 @@
+package cluster_test
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
+
+	. "github.com/onsi/gomega"
+)
+
+func generateTestCertPEM(t *testing.T) string {
+	t.Helper()
+
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("failed to generate RSA key: %v", err)
+	}
+
+	tmpl := x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "test"},
+		NotBefore:    time.Now(),
+		NotAfter:     time.Now().Add(time.Hour),
+	}
+
+	der, err := x509.CreateCertificate(rand.Reader, &tmpl, &tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("failed to create certificate: %v", err)
+	}
+
+	return string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}))
+}
+
+func TestValidateCustomCABundle(t *testing.T) {
+	t.Parallel()
+
+	validCert := generateTestCertPEM(t)
+	validChain := validCert + validCert
+
+	cases := []struct {
+		name    string
+		input   string
+		wantErr bool
+	}{
+		{
+			name:    "Empty string is valid",
+			input:   "",
+			wantErr: false,
+		},
+		{
+			name:    "Valid single certificate",
+			input:   validCert,
+			wantErr: false,
+		},
+		{
+			name:    "Valid certificate chain",
+			input:   validChain,
+			wantErr: false,
+		},
+		{
+			name:    "Garbage data",
+			input:   "this is not a PEM",
+			wantErr: true,
+		},
+		{
+			name:    "Valid PEM block but not a certificate",
+			input:   string(pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: []byte("fake")})),
+			wantErr: true,
+		},
+		{
+			name:    "Certificate PEM header with invalid DER",
+			input:   string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: []byte("not-a-cert")})),
+			wantErr: true,
+		},
+		{
+			name:    "Valid cert followed by garbage",
+			input:   validCert + "some trailing garbage",
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewWithT(t)
+			err := cluster.ValidateCustomCABundle(tc.input)
+			if tc.wantErr {
+				g.Expect(err).To(HaveOccurred())
+			} else {
+				g.Expect(err).ToNot(HaveOccurred())
+			}
+		})
+	}
+}

--- a/tests/e2e/creation_test.go
+++ b/tests/e2e/creation_test.go
@@ -96,6 +96,14 @@ func dscValidationTestSuite(t *testing.T) {
 
 	// Run the test suite.
 	RunTestCases(t, testCases, WithParallel())
+
+	webhookTestCases := []TestCase{
+		{"Validate DSCI webhook denies invalid PEM on update", dscTestCtx.ValidateDSCIWebhookDeniesInvalidPEMOnUpdate},
+		{"Validate DSCI webhook allows valid PEM on update", dscTestCtx.ValidateDSCIWebhookAllowsValidPEMOnUpdate},
+		{"Validate DSCI webhook allows invalid PEM when Removed", dscTestCtx.ValidateDSCIWebhookAllowsInvalidPEMWhenRemoved},
+	}
+
+	RunTestCases(t, webhookTestCases)
 }
 
 // ValidateOperatorsInstallation ensures the required operators are installed.
@@ -194,6 +202,63 @@ func (tc *DSCTestCtx) ValidateDefaultNetworkPolicyExists(t *testing.T) {
 	tc.EnsureResourcesExist(
 		WithMinimalObject(gvk.NetworkPolicy, types.NamespacedName{Namespace: dsci.Spec.ApplicationsNamespace, Name: dsci.Spec.ApplicationsNamespace}),
 		WithCustomErrorMsg("Expected the default NetworkPolicy to be created."),
+	)
+}
+
+// ValidateDSCIWebhookDeniesInvalidPEMOnUpdate verifies that the webhook rejects
+// an update with invalid PEM data in customCABundle when TrustedCABundle is Managed.
+func (tc *DSCTestCtx) ValidateDSCIWebhookDeniesInvalidPEMOnUpdate(t *testing.T) {
+	t.Helper()
+
+	tc.EnsureWebhookBlocksResourceUpdate(
+		WithMinimalObject(gvk.DSCInitialization, tc.DSCInitializationNamespacedName),
+		WithMutateFunc(setCustomCABundle("not-a-valid-pem")),
+		WithFieldName("customCABundle"),
+		WithCustomErrorMsg("Webhook should deny update with invalid PEM in customCABundle"),
+	)
+}
+
+// ValidateDSCIWebhookAllowsValidPEMOnUpdate verifies that the webhook allows
+// an update with valid PEM data in customCABundle when TrustedCABundle is Managed.
+func (tc *DSCTestCtx) ValidateDSCIWebhookAllowsValidPEMOnUpdate(t *testing.T) {
+	t.Helper()
+
+	validPEM := generateTestCertPEM(t)
+
+	tc.EventuallyResourceCreatedOrUpdated(
+		WithMinimalObject(gvk.DSCInitialization, tc.DSCInitializationNamespacedName),
+		WithMutateFunc(setCustomCABundle(validPEM)),
+		WithCondition(jq.Match(`.spec.trustedCABundle.customCABundle != ""`)),
+		WithCustomErrorMsg("Webhook should allow update with valid PEM in customCABundle"),
+	)
+
+	// restore customCABundle to empty
+	tc.EventuallyResourceCreatedOrUpdated(
+		WithMinimalObject(gvk.DSCInitialization, tc.DSCInitializationNamespacedName),
+		WithMutateFunc(setCustomCABundle("")),
+		WithCondition(jq.Match(`.spec.trustedCABundle.customCABundle == ""`)),
+		WithCustomErrorMsg("Failed to restore customCABundle to empty"),
+	)
+}
+
+// ValidateDSCIWebhookAllowsInvalidPEMWhenRemoved verifies that the webhook skips
+// PEM validation when TrustedCABundle ManagementState is Removed.
+func (tc *DSCTestCtx) ValidateDSCIWebhookAllowsInvalidPEMWhenRemoved(t *testing.T) {
+	t.Helper()
+
+	tc.EventuallyResourceCreatedOrUpdated(
+		WithMinimalObject(gvk.DSCInitialization, tc.DSCInitializationNamespacedName),
+		WithMutateFunc(testf.Transform(`.spec.trustedCABundle.managementState = "Removed" | .spec.trustedCABundle.customCABundle = "not-a-valid-pem"`)),
+		WithCondition(jq.Match(`.spec.trustedCABundle.managementState == "Removed" and .spec.trustedCABundle.customCABundle == "not-a-valid-pem"`)),
+		WithCustomErrorMsg("Webhook should allow invalid PEM when TrustedCABundle is Removed"),
+	)
+
+	// restore to original state
+	tc.EventuallyResourceCreatedOrUpdated(
+		WithMinimalObject(gvk.DSCInitialization, tc.DSCInitializationNamespacedName),
+		WithMutateFunc(testf.Transform(`.spec.trustedCABundle.managementState = "Managed" | .spec.trustedCABundle.customCABundle = ""`)),
+		WithCondition(jq.Match(`.spec.trustedCABundle.managementState == "Managed"`)),
+		WithCustomErrorMsg("Failed to restore TrustedCABundle state"),
 	)
 }
 

--- a/tests/e2e/helper_test.go
+++ b/tests/e2e/helper_test.go
@@ -1,9 +1,15 @@
 package e2e_test
 
 import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
 	"encoding/json"
+	"encoding/pem"
 	"flag"
 	"fmt"
+	"math/big"
 	"os"
 	"strings"
 	"testing"
@@ -695,6 +701,35 @@ func RestoreResourceFromBackup(t *testing.T, tc *TestContext, backupPath string)
 	} else {
 		t.Logf("%s backup file %s removed successfully", backedUpObject.GetKind(), backupPath)
 	}
+}
+
+func setCustomCABundle(value string) func(*unstructured.Unstructured) error {
+	return func(obj *unstructured.Unstructured) error {
+		return unstructured.SetNestedField(obj.Object, value, "spec", "trustedCABundle", "customCABundle")
+	}
+}
+
+func generateTestCertPEM(t *testing.T) string {
+	t.Helper()
+
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("failed to generate RSA key: %v", err)
+	}
+
+	tmpl := x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "test"},
+		NotBefore:    time.Now(),
+		NotAfter:     time.Now().Add(time.Hour),
+	}
+
+	der, err := x509.CreateCertificate(rand.Reader, &tmpl, &tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("failed to create certificate: %v", err)
+	}
+
+	return string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}))
 }
 
 func loadResourceFromTempFile(path string) (*unstructured.Unstructured, error) {

--- a/tests/e2e/v2tov3upgrade_test.go
+++ b/tests/e2e/v2tov3upgrade_test.go
@@ -348,10 +348,12 @@ func (tc *V2Tov3UpgradeTestCtx) ValidateDefaultDSCIRemainsReadyAfterDeprecatedCR
 func (tc *V2Tov3UpgradeTestCtx) triggerDSCIReconciliation(t *testing.T) {
 	t.Helper()
 
-	// trigger DSCI reconciliation by setting a customCABundle
+	validPEM := generateTestCertPEM(t)
+
+	// trigger DSCI reconciliation by setting a customCABundle with a valid PEM
 	tc.EventuallyResourceCreatedOrUpdated(
 		WithMinimalObject(gvk.DSCInitialization, tc.DSCInitializationNamespacedName),
-		WithMutateFunc(testf.Transform(`.spec.trustedCABundle.customCABundle = "# reconcile trigger"`)),
+		WithMutateFunc(setCustomCABundle(validPEM)),
 		WithCondition(jq.Match(`.status.phase == "%s"`, status.ConditionTypeReady)),
 		WithCustomErrorMsg("Failed to trigger DSCI reconciliation"),
 	)
@@ -359,7 +361,7 @@ func (tc *V2Tov3UpgradeTestCtx) triggerDSCIReconciliation(t *testing.T) {
 	// restore original customCABundle in DSCInitialization instance
 	tc.EventuallyResourceCreatedOrUpdated(
 		WithMinimalObject(gvk.DSCInitialization, tc.DSCInitializationNamespacedName),
-		WithMutateFunc(testf.Transform(`.spec.trustedCABundle.customCABundle = ""`)),
+		WithMutateFunc(setCustomCABundle("")),
 		WithCondition(jq.Match(`.status.phase == "%s"`, status.ConditionTypeReady)),
 		WithCustomErrorMsg("Failed to trigger DSCI reconciliation"),
 	)


### PR DESCRIPTION
<!---
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

<!--- Link your JIRA and related links here for reference. -->

JIRA: https://redhat.atlassian.net/browse/RHOAIENG-56117

As of current, the DSCInitialization validation webhooks only were registered with `verbs=create;delete`, which meant that any update operation could pass through without any kind of validation at all. A valid DSCI could be made and then edited to have an invalid configuration, which then would cause a failure.

This PR does the following:
 - Add update to webhook verb registration for both DSCI v1 and v2
 - Add Decoder field to Validator structs to decode admission request payloads
 - Add ValidateCustomCABundle utility in pkg/cluster/cert.go that validates PEM encoding and X.509 certificate parsing
 - Add validateSpec method to both v1 and v2 webhooks that validates customCABundle when TrustedCABundle.ManagementState is Managed (applies to both create and update)
 - Add unit tests (fakeclient), envtest integration tests, and E2E tests for the new validation
 - Fix existing triggerDSCIReconciliation in v2tov3upgrade_test.go to use a valid PEM cert instead of a dummy string, which the new webhook would reject


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- Unit tests: 12 table-driven test cases each for v1 and v2 webhooks covering singleton enforcement, deletion restrictions, and PEM validation on create/update
 - PEM validation unit tests: 7 test cases for ValidateCustomCABundle (empty string, valid cert, cert chain, garbage data, wrong PEM type, invalid DER, trailing garbage)
 - Integration tests (envtest): 7 test cases exercising the real admission path against a test API server
 - E2E tests: 3 new test cases in dscValidationTestSuite:
   - Webhook denies update with invalid PEM when TrustedCABundle is Managed
   - Webhook allows update with valid PEM when TrustedCABundle is Managed
   - Webhook allows invalid PEM when TrustedCABundle ManagementState is Removed
 - Manual cluster testing via make deploy: verified create with invalid PEM is denied, update with invalid PEM when Managed is denied, update with invalid PEM when Removed is allowed, update with valid PEM
  succeeds, create with valid config succeeds
  - make build, make lint, make generate manifests api-docs all pass clean

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

N/A

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully
- [ ] New RELATED_IMAGE mappings are listed in ODH-Build-Config and RHOAI-Build-Config (CI validates names against build-config repos). Include links to build-config PRs in the description.

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [ ] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Webhook validation for DSCInitialization now supports create, update, and delete operations (v1 and v2).
  * Trusted CA bundle custom PEM content is validated, including multi-certificate PEM chains.
* **Bug Fixes**
  * Invalid custom CABundle is rejected only when Trusted CABundle is in **Managed** mode, and allowed when **Removed**.
  * Deletions are blocked only while dependent DataScienceCluster resources still exist.
* **Tests**
  * Expanded unit and end-to-end coverage for Trusted CABundle management-state transitions and PEM edge cases (empty/nil/multi-cert).
  * Added shared certificate/PEM generation helpers and webhook admission decoding in tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->