### PR TITLE
fix(e2e): strip finalizers after delete to prevent controller re-addition

### DIFF
--- a/tests/e2e/resource_options_test.go
+++ b/tests/e2e/resource_options_test.go
@@ -91,9 +91,10 @@ type ResourceOptions struct {
 	// This helps handle controllers that immediately recreate resources after deletion.
 	WaitForRecreation bool
 
-	// RemoveFinalizersOnDelete determines whether to automatically remove finalizers before deletion.
-	// If true, DeleteResource will attempt to remove all finalizers if deletion is blocked.
-	// This helps with resources that get stuck in deletion due to finalizers.
+	// RemoveFinalizersOnDelete determines whether to automatically remove finalizers after deletion.
+	// If true, DeleteResource will attempt to remove all finalizers once the resource is Terminating.
+	// Stripping after the delete (not before) prevents a running controller from re-adding its
+	// finalizer between the strip and the delete.
 	RemoveFinalizersOnDelete bool
 
 	// CleanupT, when set, causes resource creation methods to register a t.Cleanup() that
@@ -225,9 +226,9 @@ func WithWaitForRecreation(wait bool) ResourceOpts {
 	}
 }
 
-// WithRemoveFinalizersOnDelete enables automatic finalizer removal before deletion.
-// When enabled, DeleteResource will attempt to remove all finalizers if deletion is blocked.
-// This helps with resources that get stuck in deletion due to finalizers.
+// WithRemoveFinalizersOnDelete enables automatic finalizer removal after deletion.
+// When enabled, DeleteResource strips all finalizers once the resource is Terminating,
+// preventing a running controller from re-adding its finalizer before the delete.
 func WithRemoveFinalizersOnDelete(remove bool) ResourceOpts {
 	return func(ro *ResourceOptions) {
 		ro.RemoveFinalizersOnDelete = remove

--- a/tests/e2e/test_context_test.go
+++ b/tests/e2e/test_context_test.go
@@ -1139,7 +1139,7 @@ func (tc *TestContext) waitForDeletionBestEffort(gvk schema.GroupVersionKind, nn
 //   - WithIgnoreNotFound: If true, skips existence check and ignores NotFound errors during deletion.
 //   - WithWaitForDeletion: If true, waits until the resource is fully deleted from the cluster.
 //   - WithWaitForRecreation: If true, waits for the resource to be recreated after deletion (useful for managed resources).
-//   - WithRemoveFinalizersOnDelete: If true, removes all finalizers before deletion to prevent stuck deletions.
+//   - WithRemoveFinalizersOnDelete: If true, removes all finalizers after deletion (while Terminating) to prevent stuck deletions.
 //   - WithClientDeleteOptions: Configures deletion behavior (e.g., propagation policy).
 //
 // Parameters:
@@ -1156,13 +1156,6 @@ func (tc *TestContext) DeleteResource(opts ...ResourceOpts) {
 		)
 	}
 
-	// Remove finalizers if requested, before attempting deletion
-	if ro.RemoveFinalizersOnDelete {
-		// Try to remove finalizers in a best-effort manner
-		// If this fails (e.g., due to validation errors), we continue with deletion anyway
-		tc.tryRemoveFinalizers(ro.GVK, ro.NN)
-	}
-
 	// Perform the delete and handle errors appropriately
 	err := tc.g.Delete(ro.GVK, ro.NN, ro.ClientDeleteOptions).Get()
 
@@ -1175,6 +1168,13 @@ func (tc *TestContext) DeleteResource(opts ...ResourceOpts) {
 
 	// For all remaining cases, expect success
 	tc.g.Expect(err).NotTo(HaveOccurred(), "Failed to delete %s instance %s", ro.GVK.Kind, ro.ResourceID)
+
+	// Remove finalizers AFTER the delete so the resource already has a
+	// deletionTimestamp. This prevents a running controller from re-adding
+	// its finalizer between the strip and the delete.
+	if ro.RemoveFinalizersOnDelete {
+		tc.tryRemoveFinalizers(ro.GVK, ro.NN)
+	}
 
 	if ro.WaitForDeletion {
 		opts = append(opts, WithCustomErrorMsg("Resource %s instance %s was not fully deleted", ro.GVK.Kind, ro.ResourceID))


### PR DESCRIPTION
<!---
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

**JIRA**: [RHOAIENG-71439](https://redhat.atlassian.net/browse/RHOAIENG-71439), [RHOAIENG-68513](https://redhat.atlassian.net/browse/RHOAIENG-68513)

`DeleteResource` was stripping finalizers **before** issuing the delete. A running controller (e.g. the OCP Kueue operator) could legally re-add its finalizer in the window between the strip and the delete, since the resource had no `deletionTimestamp` yet. Once the delete set the `deletionTimestamp` with the re-added finalizer, the CR was stuck in Terminating.

This PR moves the finalizer strip **after** the delete call so the resource already has a `deletionTimestamp` when we patch. Controllers check `deletionTimestamp` before re-adding finalizers, closing the race window.

[Slack thread](https://redhat-internal.slack.com/archives/C07ANR2U56C/p1782286215509089?thread_ts=1782156324.936529&cid=C07ANR2U56C)

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
E2E tests — Kueue component suite run against RHOAI 3.5.0 on OCP 4.21.11, all tests passed.

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully
- [ ] New RELATED_IMAGE mappings are listed in ODH-Build-Config and RHOAI-Build-Config (CI validates names against build-config repos). Include links to build-config PRs in the description.

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you are not opting out of the E2E requirement -->
This PR modifies the e2e test infrastructure itself (DeleteResource helper), not production code. The change fixes a race condition in the existing test cleanup path — no new e2e test scenarios are needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resource deletion behavior so finalizers are removed after deletion starts, reducing cases where controllers could re-add them and block cleanup.
  * Deletion now more reliably proceeds once a resource enters the terminating state.

* **Documentation**
  * Clarified the timing of finalizer removal in the public API comments and deletion guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->