### PR TITLE
feat: migrate the remaining checkPreConditions actions to the WithPreCondition framework

### DIFF
--- a/internal/controller/components/datasciencepipelines/datasciencepipelines_controller.go
+++ b/internal/controller/components/datasciencepipelines/datasciencepipelines_controller.go
@@ -62,8 +62,8 @@ func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.
 			reconciler.WithPredicates(
 				component.ForLabel(labels.ODH.Component(LegacyComponentName), labels.True)),
 		).
+		WithPreCondition(precondition.Custom(checkPreConditions, precondition.WithStopReconciliation())).
 		WithAction(precondition.RunlevelGateAction()).
-		WithAction(checkPreConditions).
 		WithAction(initialize).
 		WithAction(argoWorkflowsControllersOptions).
 		WithAction(releases.NewAction()).

--- a/internal/controller/components/datasciencepipelines/datasciencepipelines_controller_actions.go
+++ b/internal/controller/components/datasciencepipelines/datasciencepipelines_controller_actions.go
@@ -28,22 +28,23 @@ import (
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/api/components/v1alpha1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/status"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
-	odherr "github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/errors"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/conditions"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/precondition"
 	odhtypes "github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
 	odhdeploy "github.com/opendatahub-io/opendatahub-operator/v2/pkg/deploy"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/metadata/labels"
 )
 
-func checkPreConditions(ctx context.Context, rr *odhtypes.ReconciliationRequest) error {
+func checkPreConditions(ctx context.Context, rr *odhtypes.ReconciliationRequest) (precondition.CheckResult, error) {
 	dsp, ok := rr.Instance.(*componentApi.DataSciencePipelines)
 	if !ok {
-		return fmt.Errorf("resource instance %v is not a componentApi.DataSciencePipelines)", rr.Instance)
+		return precondition.CheckResult{}, fmt.Errorf("resource instance %v is not a componentApi.DataSciencePipelines)", rr.Instance)
 	}
 
 	awfSpec := dsp.Spec.ArgoWorkflowsControllers
 	awfRemoved := awfSpec != nil && awfSpec.ManagementState == operatorv1.Removed
 
+	// Initialize to True; path-specific logic below will override if needed.
 	rr.Conditions.MarkTrue(status.ConditionArgoWorkflowAvailable)
 
 	crd, err := cluster.GetCRD(ctx, rr.Client, ArgoWorkflowCRD)
@@ -57,20 +58,18 @@ func checkPreConditions(ctx context.Context, rr *odhtypes.ReconciliationRequest)
 				conditions.WithMessage(status.DataSciencePipelinesArgoWorkflowsCRDMissingMessage),
 			)
 
-			return ErrArgoWorkflowCRDMissing
+			return precondition.CheckResult{Pass: false, Message: ErrArgoWorkflowCRDMissing.Error()}, nil
 		}
 
-		return nil
+		return precondition.CheckResult{Pass: true}, nil
 	case err != nil:
-		err = odherr.NewStopError("failed to check for existing %s CRD: %w", ArgoWorkflowCRD, err)
-
 		rr.Conditions.MarkFalse(
 			status.ConditionArgoWorkflowAvailable,
 			conditions.WithObservedGeneration(rr.Instance.GetGeneration()),
 			conditions.WithError(err),
 		)
 
-		return err
+		return precondition.CheckResult{}, fmt.Errorf("failed to check for existing %s CRD: %w", ArgoWorkflowCRD, err)
 	}
 
 	if awfRemoved {
@@ -80,11 +79,9 @@ func checkPreConditions(ctx context.Context, rr *odhtypes.ReconciliationRequest)
 			conditions.WithMessage(status.DataSciencePipelinesArgoWorkflowsNotManagedMessage),
 		)
 
-		return nil
+		return precondition.CheckResult{Pass: true}, nil
 	}
 
-	// Verify if existing workflow is deployed by ODH with label
-	// if not then set Argo capability status condition to false
 	odhLabelValue, odhLabelExists := crd.Labels[labels.ODH.Component(LegacyComponentName)]
 	if !odhLabelExists || odhLabelValue != "true" {
 		rr.Conditions.MarkFalse(
@@ -94,10 +91,10 @@ func checkPreConditions(ctx context.Context, rr *odhtypes.ReconciliationRequest)
 			conditions.WithMessage(status.DataSciencePipelinesDoesntOwnArgoCRDMessage),
 		)
 
-		return ErrArgoWorkflowAPINotOwned
+		return precondition.CheckResult{Pass: false, Message: ErrArgoWorkflowAPINotOwned.Error()}, nil
 	}
 
-	return nil
+	return precondition.CheckResult{Pass: true}, nil
 }
 
 func initialize(_ context.Context, rr *odhtypes.ReconciliationRequest) error { //nolint:unparam

--- a/internal/controller/components/datasciencepipelines/datasciencepipelines_controller_actions.go
+++ b/internal/controller/components/datasciencepipelines/datasciencepipelines_controller_actions.go
@@ -38,7 +38,7 @@ import (
 func checkPreConditions(ctx context.Context, rr *odhtypes.ReconciliationRequest) (precondition.CheckResult, error) {
 	dsp, ok := rr.Instance.(*componentApi.DataSciencePipelines)
 	if !ok {
-		return precondition.CheckResult{}, fmt.Errorf("resource instance %v is not a componentApi.DataSciencePipelines)", rr.Instance)
+		return precondition.CheckResult{}, fmt.Errorf("resource instance %T is not a componentApi.DataSciencePipelines", rr.Instance)
 	}
 
 	awfSpec := dsp.Spec.ArgoWorkflowsControllers

--- a/internal/controller/components/datasciencepipelines/datasciencepipelines_controller_actions_test.go
+++ b/internal/controller/components/datasciencepipelines/datasciencepipelines_controller_actions_test.go
@@ -33,7 +33,8 @@ func TestCheckPreConditions(t *testing.T) {
 		name                    string
 		setupClient             func() client.Client
 		instance                *componentApi.DataSciencePipelines
-		expectedError           error
+		expectedPass            bool
+		expectedResultMessage   string
 		expectedConditionStatus metav1.ConditionStatus
 		expectedReason          string
 		expectedMessage         string
@@ -57,7 +58,8 @@ func TestCheckPreConditions(t *testing.T) {
 					},
 				},
 			},
-			expectedError:           ErrArgoWorkflowCRDMissing,
+			expectedPass:            false,
+			expectedResultMessage:   status.DataSciencePipelinesArgoWorkflowsCRDMissingMessage,
 			expectedConditionStatus: metav1.ConditionFalse,
 			expectedReason:          status.DataSciencePipelinesArgoWorkflowsCRDMissingReason,
 			expectedMessage:         status.DataSciencePipelinesArgoWorkflowsCRDMissingMessage,
@@ -95,7 +97,7 @@ func TestCheckPreConditions(t *testing.T) {
 					},
 				},
 			},
-			expectedError:           nil,
+			expectedPass:            true,
 			expectedConditionStatus: metav1.ConditionTrue,
 			expectedReason:          status.DataSciencePipelinesArgoWorkflowsNotManagedReason,
 			expectedMessage:         status.DataSciencePipelinesArgoWorkflowsNotManagedMessage,
@@ -119,7 +121,7 @@ func TestCheckPreConditions(t *testing.T) {
 					},
 				},
 			},
-			expectedError:           nil,
+			expectedPass:            true,
 			expectedConditionStatus: metav1.ConditionTrue,
 			expectedReason:          "",
 			expectedMessage:         "",
@@ -161,7 +163,7 @@ func TestCheckPreConditions(t *testing.T) {
 					},
 				},
 			},
-			expectedError:           nil,
+			expectedPass:            true,
 			expectedConditionStatus: metav1.ConditionTrue,
 			expectedReason:          "",
 			expectedMessage:         "",
@@ -203,7 +205,8 @@ func TestCheckPreConditions(t *testing.T) {
 					},
 				},
 			},
-			expectedError:           ErrArgoWorkflowAPINotOwned,
+			expectedPass:            false,
+			expectedResultMessage:   status.DataSciencePipelinesDoesntOwnArgoCRDMessage,
 			expectedConditionStatus: metav1.ConditionFalse,
 			expectedReason:          status.DataSciencePipelinesDoesntOwnArgoCRDReason,
 			expectedMessage:         status.DataSciencePipelinesDoesntOwnArgoCRDMessage,
@@ -223,7 +226,7 @@ func TestCheckPreConditions(t *testing.T) {
 					DataSciencePipelinesCommonSpec: componentApi.DataSciencePipelinesCommonSpec{},
 				},
 			},
-			expectedError:           nil,
+			expectedPass:            true,
 			expectedConditionStatus: metav1.ConditionTrue,
 			expectedReason:          "",
 			expectedMessage:         "",
@@ -240,12 +243,12 @@ func TestCheckPreConditions(t *testing.T) {
 				Conditions: conditions.NewManager(tt.instance, status.ConditionTypeReady),
 			}
 
-			err := checkPreConditions(ctx, &rr)
+			result, err := checkPreConditions(ctx, &rr)
+			g.Expect(err).ShouldNot(HaveOccurred())
+			g.Expect(result.Pass).Should(Equal(tt.expectedPass))
 
-			if tt.expectedError != nil {
-				g.Expect(err).Should(Equal(tt.expectedError))
-			} else {
-				g.Expect(err).ShouldNot(HaveOccurred())
+			if tt.expectedResultMessage != "" {
+				g.Expect(result.Message).Should(ContainSubstring(tt.expectedResultMessage))
 			}
 
 			// Check condition status
@@ -294,7 +297,7 @@ func TestCheckPreConditions_WrongInstanceType(t *testing.T) {
 		Conditions: conditions.NewManager(wrongInstance, status.ConditionTypeReady),
 	}
 
-	err = checkPreConditions(ctx, &rr)
+	_, err = checkPreConditions(ctx, &rr)
 	g.Expect(err).Should(HaveOccurred())
 	g.Expect(err.Error()).Should(ContainSubstring("is not a componentApi.DataSciencePipelines"))
 }

--- a/internal/controller/components/datasciencepipelines/datasciencepipelines_support.go
+++ b/internal/controller/components/datasciencepipelines/datasciencepipelines_support.go
@@ -64,6 +64,7 @@ var (
 
 	conditionTypes = []string{
 		status.ConditionArgoWorkflowAvailable,
+		status.ConditionDependenciesAvailable,
 		status.ConditionDeploymentsAvailable,
 	}
 )

--- a/internal/controller/components/kueue/kueue_controller.go
+++ b/internal/controller/components/kueue/kueue_controller.go
@@ -157,8 +157,8 @@ func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.
 			CRName:      KueueCRName,
 			Filter:      kueueDegradedConditionFilter,
 		})).
+		WithPreCondition(precondition.Custom(checkPreConditions, precondition.WithStopReconciliation())).
 		WithAction(precondition.RunlevelGateAction()).
-		WithAction(checkPreConditions).
 		WithAction(initialize).
 		WithAction(releases.NewAction()).
 		WithAction(kustomize.NewAction(

--- a/internal/controller/components/kueue/kueue_controller_actions.go
+++ b/internal/controller/components/kueue/kueue_controller_actions.go
@@ -22,7 +22,7 @@ import (
 func checkPreConditions(ctx context.Context, rr *odhtypes.ReconciliationRequest) (precondition.CheckResult, error) {
 	kueueCRInstance, ok := rr.Instance.(*componentApi.Kueue)
 	if !ok {
-		return precondition.CheckResult{}, fmt.Errorf("resource instance %v is not a componentApi.Kueue)", rr.Instance)
+		return precondition.CheckResult{}, fmt.Errorf("resource instance %T is not a componentApi.Kueue", rr.Instance)
 	}
 
 	switch kueueCRInstance.Spec.ManagementState {

--- a/internal/controller/components/kueue/kueue_controller_actions.go
+++ b/internal/controller/components/kueue/kueue_controller_actions.go
@@ -15,32 +15,33 @@ import (
 	serviceApi "github.com/opendatahub-io/opendatahub-operator/v2/api/services/v1alpha1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
-	odherrors "github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/errors"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/precondition"
 	odhtypes "github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
 )
 
-func checkPreConditions(ctx context.Context, rr *odhtypes.ReconciliationRequest) error {
+func checkPreConditions(ctx context.Context, rr *odhtypes.ReconciliationRequest) (precondition.CheckResult, error) {
 	kueueCRInstance, ok := rr.Instance.(*componentApi.Kueue)
 	if !ok {
-		return fmt.Errorf("resource instance %v is not a componentApi.Kueue)", rr.Instance)
+		return precondition.CheckResult{}, fmt.Errorf("resource instance %v is not a componentApi.Kueue)", rr.Instance)
 	}
 
 	switch kueueCRInstance.Spec.ManagementState {
 	case operatorv1.Managed:
-		return ErrKueueStateManagedNotSupported
+		return precondition.CheckResult{Pass: false, Message: ErrKueueStateManagedNotSupported.Error()}, nil
 	case operatorv1.Unmanaged:
-		if kueueInfo, err := cluster.OperatorExists(ctx, rr.Client, kueueOperator); err != nil || kueueInfo == nil {
-			if err != nil {
-				return odherrors.NewStopErrorW(err)
-			}
+		kueueInfo, err := cluster.OperatorExists(ctx, rr.Client, kueueOperator)
+		if err != nil {
+			return precondition.CheckResult{}, err
+		}
 
-			return ErrKueueOperatorNotInstalled
+		if kueueInfo == nil {
+			return precondition.CheckResult{Pass: false, Message: ErrKueueOperatorNotInstalled.Error()}, nil
 		}
 	default:
-		return nil
+		return precondition.CheckResult{Pass: true}, nil
 	}
 
-	return nil
+	return precondition.CheckResult{Pass: true}, nil
 }
 
 func initialize(_ context.Context, rr *odhtypes.ReconciliationRequest) error {

--- a/internal/controller/components/kueue/kueue_controller_actions_test.go
+++ b/internal/controller/components/kueue/kueue_controller_actions_test.go
@@ -51,8 +51,12 @@ func TestCheckPreConditions_Unknown_State(t *testing.T) {
 		Conditions: conditions.NewManager(&kueue, status.ConditionTypeReady),
 	}
 
-	err = checkPreConditions(ctx, &rr)
+	result, err := checkPreConditions(ctx, &rr)
 	g.Expect(err).ShouldNot(HaveOccurred())
+	g.Expect(result.Pass).Should(BeTrue())
+
+	// Verify that checkPreConditions does not modify conditions directly;
+	// condition management is handled by the precondition framework.
 	g.Expect(&kueue).Should(
 		WithTransform(resources.ToUnstructured,
 			jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, status.ConditionTypeReady, metav1.ConditionUnknown),
@@ -90,9 +94,10 @@ func TestCheckPreConditions_Managed_KueueOperatorAlreadyInstalled(t *testing.T) 
 		Conditions: conditions.NewManager(&kueue, status.ConditionTypeReady),
 	}
 
-	err = checkPreConditions(ctx, &rr)
-	g.Expect(err).Should(HaveOccurred())
-	g.Expect(err).To(MatchError(ContainSubstring(status.KueueStateManagedNotSupportedMessage)))
+	result, err := checkPreConditions(ctx, &rr)
+	g.Expect(err).ShouldNot(HaveOccurred())
+	g.Expect(result.Pass).Should(BeFalse())
+	g.Expect(result.Message).Should(ContainSubstring(status.KueueStateManagedNotSupportedMessage))
 }
 
 func TestCheckPreConditions_Unmanaged_KueueOperatorNotInstalled(t *testing.T) {
@@ -116,9 +121,10 @@ func TestCheckPreConditions_Unmanaged_KueueOperatorNotInstalled(t *testing.T) {
 		Conditions: conditions.NewManager(&kueue, status.ConditionTypeReady),
 	}
 
-	err = checkPreConditions(ctx, &rr)
-	g.Expect(err).Should(HaveOccurred())
-	g.Expect(err).To(MatchError(ContainSubstring(status.KueueOperatorNotInstalledMessage)))
+	result, err := checkPreConditions(ctx, &rr)
+	g.Expect(err).ShouldNot(HaveOccurred())
+	g.Expect(result.Pass).Should(BeFalse())
+	g.Expect(result.Message).Should(ContainSubstring(status.KueueOperatorNotInstalledMessage))
 }
 
 func TestConfigureClusterQueueViewerRoleAction_RoleNotFound(t *testing.T) {

--- a/internal/controller/components/ogx/ogx_actions.go
+++ b/internal/controller/components/ogx/ogx_actions.go
@@ -7,6 +7,7 @@ import (
 	operatorv1 "github.com/openshift/api/operator/v1"
 
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/precondition"
 	odhtypes "github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
 )
 
@@ -15,15 +16,18 @@ func initialize(_ context.Context, rr *odhtypes.ReconciliationRequest) error { /
 	return nil
 }
 
-func checkPreConditions(ctx context.Context, rr *odhtypes.ReconciliationRequest) error {
+func checkPreConditions(ctx context.Context, rr *odhtypes.ReconciliationRequest) (precondition.CheckResult, error) {
 	dsc, err := cluster.GetDSC(ctx, rr.Client)
 	if err != nil {
-		return fmt.Errorf("failed to get DataScienceCluster: %w", err)
+		return precondition.CheckResult{}, fmt.Errorf("failed to get DataScienceCluster: %w", err)
 	}
 
 	if dsc.Spec.Components.LlamaStackOperator.ManagementState == operatorv1.Managed {
-		return fmt.Errorf("LlamaStackOperator is set to %s, it has been deprecated, please set it to %s before enabling OGX", operatorv1.Managed, operatorv1.Removed)
+		return precondition.CheckResult{
+			Pass:    false,
+			Message: fmt.Sprintf("LlamaStackOperator is set to %s, it has been deprecated, please set it to %s before enabling OGX", operatorv1.Managed, operatorv1.Removed),
+		}, nil
 	}
 
-	return nil
+	return precondition.CheckResult{Pass: true}, nil
 }

--- a/internal/controller/components/ogx/ogx_controller.go
+++ b/internal/controller/components/ogx/ogx_controller.go
@@ -44,9 +44,9 @@ func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.
 				component.ForLabel(labels.ODH.Component(ComponentName), labels.True)),
 		).
 		// Add LlamaStackOperator-specific actions
+		WithPreCondition(precondition.Custom(checkPreConditions, precondition.WithStopReconciliation())).
 		WithAction(precondition.RunlevelGateAction()).
 		WithAction(initialize).
-		WithAction(checkPreConditions).
 		WithAction(releases.NewAction()).
 		WithAction(kustomize.NewAction(
 			kustomize.WithLabel(labels.ODH.Component(ComponentName), labels.True),

--- a/internal/controller/components/ogx/ogx_support.go
+++ b/internal/controller/components/ogx/ogx_support.go
@@ -29,6 +29,7 @@ var (
 
 	conditionTypes = []string{
 		status.ConditionDeploymentsAvailable,
+		status.ConditionDependenciesAvailable,
 	}
 )
 

--- a/internal/controller/components/ogx/ogx_test.go
+++ b/internal/controller/components/ogx/ogx_test.go
@@ -167,7 +167,7 @@ func TestUpdateDSCStatus(t *testing.T) {
 }
 
 func TestCheckPreConditions(t *testing.T) {
-	t.Run("should return error when LlamaStackOperator is Managed", func(t *testing.T) {
+	t.Run("should fail when LlamaStackOperator is Managed", func(t *testing.T) {
 		g := NewWithT(t)
 		ctx := t.Context()
 
@@ -177,16 +177,17 @@ func TestCheckPreConditions(t *testing.T) {
 		cli, err := fakeclient.New(fakeclient.WithObjects(dsc))
 		g.Expect(err).ShouldNot(HaveOccurred())
 
-		err = checkPreConditions(ctx, &types.ReconciliationRequest{
+		result, err := checkPreConditions(ctx, &types.ReconciliationRequest{
 			Client: cli,
 		})
 
-		g.Expect(err).Should(HaveOccurred())
-		g.Expect(err.Error()).Should(ContainSubstring("LlamaStackOperator is set to Managed"))
-		g.Expect(err.Error()).Should(ContainSubstring("deprecated"))
+		g.Expect(err).ShouldNot(HaveOccurred())
+		g.Expect(result.Pass).Should(BeFalse())
+		g.Expect(result.Message).Should(ContainSubstring("LlamaStackOperator is set to Managed"))
+		g.Expect(result.Message).Should(ContainSubstring("deprecated"))
 	})
 
-	t.Run("should succeed when LlamaStackOperator is Removed", func(t *testing.T) {
+	t.Run("should pass when LlamaStackOperator is Removed", func(t *testing.T) {
 		g := NewWithT(t)
 		ctx := t.Context()
 
@@ -196,11 +197,12 @@ func TestCheckPreConditions(t *testing.T) {
 		cli, err := fakeclient.New(fakeclient.WithObjects(dsc))
 		g.Expect(err).ShouldNot(HaveOccurred())
 
-		err = checkPreConditions(ctx, &types.ReconciliationRequest{
+		result, err := checkPreConditions(ctx, &types.ReconciliationRequest{
 			Client: cli,
 		})
 
 		g.Expect(err).ShouldNot(HaveOccurred())
+		g.Expect(result.Pass).Should(BeTrue())
 	})
 }
 

--- a/internal/controller/components/trustyai/trustyai_controller.go
+++ b/internal/controller/components/trustyai/trustyai_controller.go
@@ -29,6 +29,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/api/components/v1alpha1"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/deploy"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/gc"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/render/kustomize"
@@ -81,13 +82,13 @@ func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.
 						return isInferenceServicesCRD(e.Object)
 					},
 					UpdateFunc: func(e event.UpdateEvent) bool {
-						// Don't react to updates - checkPreConditions only checks if CRD exists, not its version/spec
+						// Don't react to updates - MonitorCRD precondition only checks if CRD exists, not its version/spec
 						// This also prevents continuous reconciliation on CRD status updates
 						return false
 					},
 					DeleteFunc: func(e event.DeleteEvent) bool {
 						// React when InferenceServices CRD is deleted (dependency becomes unavailable)
-						// This triggers checkPreConditions which will detect the missing CRD and set conditions to False
+						// MonitorCRD precondition will detect the missing CRD and set conditions to False
 						return isInferenceServicesCRD(e.Object)
 					},
 					GenericFunc: func(e event.GenericEvent) bool {
@@ -97,8 +98,8 @@ func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.
 				},
 			)),
 		).
+		WithPreCondition(precondition.MonitorCRD(gvk.InferenceServices, precondition.WithStopReconciliation())).
 		WithAction(precondition.RunlevelGateAction()).
-		WithAction(checkPreConditions).
 		WithAction(initialize).
 		WithAction(createConfigMap).
 		WithAction(releases.NewAction()).

--- a/internal/controller/components/trustyai/trustyai_controller.go
+++ b/internal/controller/components/trustyai/trustyai_controller.go
@@ -29,6 +29,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/api/components/v1alpha1"
+	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/status"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/deploy"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/gc"
@@ -98,7 +99,10 @@ func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.
 				},
 			)),
 		).
-		WithPreCondition(precondition.MonitorCRD(gvk.InferenceServices, precondition.WithStopReconciliation())).
+		WithPreCondition(precondition.MonitorCRD(gvk.InferenceServices,
+			precondition.WithStopReconciliation(),
+			precondition.WithMessage(status.ISVCMissingCRDMessage),
+		)).
 		WithAction(precondition.RunlevelGateAction()).
 		WithAction(initialize).
 		WithAction(createConfigMap).

--- a/internal/controller/components/trustyai/trustyai_controller_actions.go
+++ b/internal/controller/components/trustyai/trustyai_controller_actions.go
@@ -29,10 +29,8 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/api/components/v1alpha1"
-	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/status"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
-	odherrors "github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/errors"
 	odhtypes "github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
 )
 
@@ -43,19 +41,6 @@ const (
 	partOfLabelKey         = "app.kubernetes.io/part-of"
 	partOfLabelValue       = "trustyai"
 )
-
-func checkPreConditions(ctx context.Context, rr *odhtypes.ReconciliationRequest) error {
-	isvc, err := cluster.HasCRD(ctx, rr.Client, gvk.InferenceServices)
-	if err != nil {
-		return odherrors.NewStopError("failed to check %s CRDs version: %w", gvk.InferenceServices, err)
-	}
-
-	if !isvc {
-		return odherrors.NewStopError(status.ISVCMissingCRDMessage)
-	}
-
-	return nil
-}
 
 func initialize(_ context.Context, rr *odhtypes.ReconciliationRequest) error {
 	trustyai, ok := rr.Instance.(*componentApi.TrustyAI)

--- a/internal/controller/components/trustyai/trustyai_support.go
+++ b/internal/controller/components/trustyai/trustyai_support.go
@@ -43,6 +43,7 @@ var (
 
 	conditionTypes = []string{
 		status.ConditionDeploymentsAvailable,
+		status.ConditionDependenciesAvailable,
 	}
 )
 

--- a/tests/e2e/ogx_test.go
+++ b/tests/e2e/ogx_test.go
@@ -3,9 +3,18 @@ package e2e_test
 import (
 	"testing"
 
+	operatorv1 "github.com/openshift/api/operator/v1"
 	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/api/components/v1alpha1"
+	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/status"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/matchers/jq"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/testf"
+
+	. "github.com/onsi/gomega"
 )
 
 type OGXTestCtx struct {
@@ -28,10 +37,57 @@ func ogxTestSuite(t *testing.T) {
 		{"Validate operands have OwnerReferences", componentCtx.ValidateOperandsOwnerReferences},
 		{"Validate update operand resources", componentCtx.ValidateUpdateDeploymentsResources},
 		{"Validate component releases", componentCtx.ValidateComponentReleases},
+		{"Validate LlamaStackOperator conflict", componentCtx.ValidateLlamaStackOperatorConflict},
 		{"Validate resource deletion recovery", componentCtx.ValidateAllDeletionRecovery},
 		{"Validate component disabled", componentCtx.ValidateComponentDisabled},
 	}
 
 	// Run the test suite.
 	RunTestCases(t, testCases)
+}
+
+// ValidateLlamaStackOperatorConflict verifies that OGX detects the deprecated
+// LlamaStackOperator conflict and recovers when it is resolved. Setting
+// LlamaStackOperator to Managed while OGX is enabled should cause the
+// precondition to fail; setting it back to Removed should allow recovery
+// via the DSC watch event (no requeue needed).
+func (tc *OGXTestCtx) ValidateLlamaStackOperatorConflict(t *testing.T) {
+	t.Helper()
+
+	skipUnless(t, Tier1)
+
+	// set LlamaStackOperator to Managed to trigger precondition failure
+	tc.EventuallyResourcePatched(
+		WithMinimalObject(gvk.DataScienceCluster, tc.DataScienceClusterNamespacedName),
+		WithMutateFunc(testf.Transform(`.spec.components.llamastackoperator.managementState = "%s"`, operatorv1.Managed)),
+	)
+
+	ogxNN := types.NamespacedName{Name: componentApi.OGXInstanceName}
+
+	// validate that OGX conditions reflect the failure
+	tc.EnsureResourceExists(
+		WithMinimalObject(tc.GVK, ogxNN),
+		WithCondition(
+			And(
+				jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, status.ConditionTypeReady, metav1.ConditionFalse),
+				jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, status.ConditionDependenciesAvailable, metav1.ConditionFalse),
+			),
+		),
+		WithCustomErrorMsg("OGX should have Ready and DependenciesAvailable conditions set to False when LlamaStackOperator is Managed"),
+	)
+
+	// set LlamaStackOperator back to Removed in DSC to resolve the conflict
+	tc.EventuallyResourcePatched(
+		WithMinimalObject(gvk.DataScienceCluster, tc.DataScienceClusterNamespacedName),
+		WithMutateFunc(testf.Transform(`.spec.components.llamastackoperator.managementState = "%s"`, operatorv1.Removed)),
+	)
+
+	// validate OGX recovers after the conflict is resolved
+	tc.EnsureResourceExists(
+		WithMinimalObject(tc.GVK, ogxNN),
+		WithCondition(
+			jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, status.ConditionTypeReady, metav1.ConditionTrue),
+		),
+		WithCustomErrorMsg("OGX should recover to Ready=True after LlamaStackOperator conflict is resolved"),
+	)
 }


### PR DESCRIPTION
<!---
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
Migrates the remaining components that utilized `checkPreCondition` actions (DSP, OGX, TrustyAI, Kueue) to instead utilize the pre-condition framework instead, particularly the `Custom` pre-condition type. Since TrustyAI's pre-condition check is only a CRD check, it was migrated to use `MonitorCR` pre-condition type. Original behavior of components is expected to be preserved

JIRA ref: [RHOAIENG-58949](https://redhat.atlassian.net/browse/RHOAIENG-58949)

## How Has This Been Tested?
Updated unit test coverage along with the changes
Manual testing on the cluster TBD

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->
These changes should not affect existing operator behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Controllers now use controller-runtime preconditions to stop reconciliation early when prerequisites (CRD availability, ownership, or management state) aren’t satisfied, with consistent pass/fail results and clearer messaging.
  * Improved handling for “managed but deprecated/conflicting” scenarios and missing dependency conditions.
  * Added `DependenciesAvailable` to readiness/condition reporting for DS Pipelines, OGX, and TrustyAI.
* **Tests**
  * Updated unit tests to validate precondition `Pass` and message with the new `(result, err)` contract.
  * Added an OGX e2e scenario covering management-state conflict and recovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[RHOAIENG-58949]: https://redhat.atlassian.net/browse/RHOAIENG-58949?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ