### PR TITLE
Filter stale events and check operator container states

### DIFF
--- a/pkg/failureclassifier/classifier.go
+++ b/pkg/failureclassifier/classifier.go
@@ -13,6 +13,11 @@ import (
 // starting up normally.
 const PendingThreshold = 60 * time.Second
 
+// EventAgeThreshold is the maximum age of an event to be considered current.
+// Events older than this are skipped to avoid false positives from stale signals
+// on clusters that have already recovered.
+const EventAgeThreshold = 5 * time.Minute
+
 // Classify inspects a clusterhealth Report and categorizes the failure.
 // If report is nil, returns unknown/unclassifiable/3000/low.
 func Classify(report *clusterhealth.Report) FailureClassification {
@@ -30,24 +35,36 @@ func Classify(report *clusterhealth.Report) FailureClassification {
 	}
 
 	// Remaining section classifiers, ordered by priority (first match wins).
-	sectionClassifiers := []func(*clusterhealth.Report) *FailureClassification{
+	for _, fn := range []func(*clusterhealth.Report) *FailureClassification{
 		classifyFromEvents,
 		classifyFromQuotas,
 		classifyFromNodes,
-		classifyFromOperator,
-		classifyFromDSCI,
-		classifyFromDSC,
-	}
-
-	for _, fn := range sectionClassifiers {
+	} {
 		if fc := fn(report); fc != nil {
 			return *fc
 		}
 	}
 
-	// Catch-all: use the deferred pod distress signal if we found one during
-	// the pod scan, or check for unready deployments.
-	if fc := classifyClusterDistress(report, podDistress); fc != nil {
+	// classifyFromOperator returns a specific high-confidence result and a deferred
+	// low-confidence distress signal. The distress signal is held back so that
+	// classifyFromDSCI/classifyFromDSC can fire first — a transient PodInitializing
+	// state must not mask a medium-confidence DSCI/DSC classification.
+	specificOperator, operatorDistress := classifyFromOperator(report)
+	if specificOperator != nil {
+		return *specificOperator
+	}
+
+	for _, fn := range []func(*clusterhealth.Report) *FailureClassification{
+		classifyFromDSCI,
+		classifyFromDSC,
+	} {
+		if fc := fn(report); fc != nil {
+			return *fc
+		}
+	}
+
+	// Catch-all: use the deferred distress signals if no more specific classifier fired.
+	if fc := classifyClusterDistress(report, podDistress, operatorDistress); fc != nil {
 		return *fc
 	}
 
@@ -96,25 +113,23 @@ func classifyFromPods(report *clusterhealth.Report) (*FailureClassification, *Fa
 						}, nil
 					}
 				}
-				// Stash first unrecognized distress signal for deferred use.
-				if distress == nil {
-					if container.Waiting != "" {
+				// Collect all unrecognized distress signals for richer diagnostics.
+				var evidence string
+				if container.Waiting != "" {
+					evidence = fmt.Sprintf("container %s/%s in unrecognized waiting state: %s", pod.Name, container.Name, container.Waiting)
+				} else if container.Terminated != "" && !isSuccessfulTermination(container.Terminated) && !isGracefulTermination(container.Terminated) {
+					evidence = fmt.Sprintf("container %s/%s terminated: %s", pod.Name, container.Name, container.Terminated)
+				}
+				if evidence != "" {
+					if distress == nil {
 						distress = &FailureClassification{
 							Category:    CategoryInfrastructure,
 							Subcategory: "cluster-distress",
 							ErrorCode:   CodeInfraUnknown,
-							Evidence:    []string{fmt.Sprintf("container %s/%s in unrecognized waiting state: %s", pod.Name, container.Name, container.Waiting)},
-							Confidence:  ConfidenceLow,
-						}
-					} else if container.Terminated != "" && !isSuccessfulTermination(container.Terminated) && !isGracefulTermination(container.Terminated) {
-						distress = &FailureClassification{
-							Category:    CategoryInfrastructure,
-							Subcategory: "cluster-distress",
-							ErrorCode:   CodeInfraUnknown,
-							Evidence:    []string{fmt.Sprintf("container %s/%s terminated: %s", pod.Name, container.Name, container.Terminated)},
 							Confidence:  ConfidenceLow,
 						}
 					}
+					distress.Evidence = append(distress.Evidence, evidence)
 				}
 			}
 			if pod.Phase == "Pending" && !pod.CreatedAt.IsZero() && time.Since(pod.CreatedAt) > PendingThreshold {
@@ -134,6 +149,9 @@ func classifyFromPods(report *clusterhealth.Report) (*FailureClassification, *Fa
 // classifyFromEvents checks event reasons/messages for image-pull, network, storage, RBAC, DNS, timeout, and probe patterns.
 func classifyFromEvents(report *clusterhealth.Report) *FailureClassification {
 	for _, event := range report.Events.Data.Events {
+		if !event.LastTime.IsZero() && time.Since(event.LastTime) > EventAgeThreshold {
+			continue
+		}
 		if containsImagePullEventPattern(event.Message) {
 			return &FailureClassification{
 				Category:    CategoryInfrastructure,
@@ -237,12 +255,15 @@ func classifyFromNodes(report *clusterhealth.Report) *FailureClassification {
 	return nil
 }
 
-// classifyClusterDistress uses the pre-computed pod distress signal (if any)
-// and checks for unready deployments. Deployments newer than PendingThreshold
-// are skipped — they are assumed to be mid-startup.
-func classifyClusterDistress(report *clusterhealth.Report, podDistress *FailureClassification) *FailureClassification {
+// classifyClusterDistress uses the pre-computed distress signals (if any) from pods and
+// the operator, then checks for unready deployments. podDistress and operatorDistress are
+// both low-confidence and deferred — they only fire if no more specific classifier matched.
+func classifyClusterDistress(report *clusterhealth.Report, podDistress, operatorDistress *FailureClassification) *FailureClassification {
 	if podDistress != nil {
 		return podDistress
+	}
+	if operatorDistress != nil {
+		return operatorDistress
 	}
 
 	// Check for unready deployments, skipping recently-created ones.
@@ -267,7 +288,9 @@ func classifyClusterDistress(report *clusterhealth.Report, podDistress *FailureC
 }
 
 // classifyFromOperator checks the operator deployment and pod status.
-func classifyFromOperator(report *clusterhealth.Report) *FailureClassification {
+// Returns two values — specific (high-confidence, returned immediately) and distress
+// (low-confidence, deferred so classifyFromDSCI/classifyFromDSC can fire first).
+func classifyFromOperator(report *clusterhealth.Report) (*FailureClassification, *FailureClassification) {
 	if d := report.Operator.Data.Deployment; d != nil {
 		if d.Replicas == 0 {
 			return &FailureClassification{
@@ -276,7 +299,7 @@ func classifyFromOperator(report *clusterhealth.Report) *FailureClassification {
 				ErrorCode:   CodeOperator,
 				Evidence:    []string{fmt.Sprintf("operator deployment %s scaled to 0 replicas", d.Name)},
 				Confidence:  ConfidenceHigh,
-			}
+			}, nil
 		}
 		if d.Ready < d.Replicas {
 			return &FailureClassification{
@@ -285,9 +308,10 @@ func classifyFromOperator(report *clusterhealth.Report) *FailureClassification {
 				ErrorCode:   CodeOperator,
 				Evidence:    []string{fmt.Sprintf("operator deployment %s not ready: %d/%d replicas", d.Name, d.Ready, d.Replicas)},
 				Confidence:  ConfidenceHigh,
-			}
+			}, nil
 		}
 	}
+	var distress *FailureClassification
 	for _, pod := range report.Operator.Data.Pods {
 		if pod.Phase != "Running" && pod.Phase != "Succeeded" {
 			return &FailureClassification{
@@ -296,10 +320,52 @@ func classifyFromOperator(report *clusterhealth.Report) *FailureClassification {
 				ErrorCode:   CodeOperator,
 				Evidence:    []string{fmt.Sprintf("operator pod %s in phase %s", pod.Name, pod.Phase)},
 				Confidence:  ConfidenceHigh,
+			}, nil
+		}
+		for _, container := range pod.Containers {
+			if matchesPattern(container.Waiting, waitingPatterns) != nil {
+				return &FailureClassification{
+					Category:    CategoryInfrastructure,
+					Subcategory: "operator",
+					ErrorCode:   CodeOperator,
+					Evidence:    []string{fmt.Sprintf("operator container %s/%s waiting: %s", pod.Name, container.Name, container.Waiting)},
+					Confidence:  ConfidenceHigh,
+				}, nil
+			}
+			if matchesPattern(container.Terminated, terminatedPatterns) != nil {
+				return &FailureClassification{
+					Category:    CategoryInfrastructure,
+					Subcategory: "operator",
+					ErrorCode:   CodeOperator,
+					Evidence:    []string{fmt.Sprintf("operator container %s/%s terminated: %s", pod.Name, container.Name, container.Terminated)},
+					Confidence:  ConfidenceHigh,
+				}, nil
+			}
+			if container.Waiting != "" {
+				if distress == nil {
+					distress = &FailureClassification{
+						Category:    CategoryInfrastructure,
+						Subcategory: "operator",
+						ErrorCode:   CodeOperator,
+						Confidence:  ConfidenceLow,
+					}
+				}
+				distress.Evidence = append(distress.Evidence, fmt.Sprintf("operator container %s/%s in unrecognized waiting state: %s", pod.Name, container.Name, container.Waiting))
+			}
+			if container.Terminated != "" && !isSuccessfulTermination(container.Terminated) {
+				if distress == nil {
+					distress = &FailureClassification{
+						Category:    CategoryInfrastructure,
+						Subcategory: "operator",
+						ErrorCode:   CodeOperator,
+						Confidence:  ConfidenceLow,
+					}
+				}
+				distress.Evidence = append(distress.Evidence, fmt.Sprintf("operator container %s/%s terminated: %s", pod.Name, container.Name, container.Terminated))
 			}
 		}
 	}
-	return nil
+	return nil, distress
 }
 
 // classifyFromDSCI checks the DSCInitialization CR conditions.

--- a/pkg/failureclassifier/classifier_test.go
+++ b/pkg/failureclassifier/classifier_test.go
@@ -328,6 +328,58 @@ func TestClassify_Events(t *testing.T) {
 	}
 }
 
+func TestClassify_StaleEvents(t *testing.T) {
+	tests := []struct {
+		name            string
+		lastTime        time.Time
+		wantCategory    string
+		wantSubcategory string
+		wantErrorCode   int
+		wantConfidence  string
+	}{
+		{
+			name:            "stale event is skipped",
+			lastTime:        time.Now().Add(-2 * EventAgeThreshold),
+			wantCategory:    CategoryUnknown,
+			wantSubcategory: "no-signal",
+			wantErrorCode:   CodeNoSignal,
+			wantConfidence:  ConfidenceLow,
+		},
+		{
+			name:            "recent event triggers classification",
+			lastTime:        time.Now().Add(-1 * time.Minute),
+			wantCategory:    CategoryInfrastructure,
+			wantSubcategory: "network",
+			wantErrorCode:   CodeNetwork,
+			wantConfidence:  ConfidenceMedium,
+		},
+		{
+			name:            "zero LastTime is not skipped",
+			lastTime:        time.Time{},
+			wantCategory:    CategoryInfrastructure,
+			wantSubcategory: "network",
+			wantErrorCode:   CodeNetwork,
+			wantConfidence:  ConfidenceMedium,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			report := &clusterhealth.Report{
+				Events: clusterhealth.SectionResult[clusterhealth.EventsSection]{
+					Data: clusterhealth.EventsSection{
+						Events: []clusterhealth.EventInfo{
+							{Kind: "Node", Name: "worker-1", Reason: "NetworkNotReady", Message: "network plugin not ready", LastTime: tt.lastTime},
+						},
+					},
+				},
+			}
+			got := Classify(report)
+			assertClassification(t, got, tt.wantCategory, tt.wantSubcategory, tt.wantErrorCode, tt.wantConfidence)
+		})
+	}
+}
+
 func TestClassify_Quota(t *testing.T) {
 	report := &clusterhealth.Report{
 		Quotas: clusterhealth.SectionResult[clusterhealth.QuotasSection]{
@@ -460,6 +512,38 @@ func TestClassify_DeploymentBelowThreshold(t *testing.T) {
 	}
 	got := Classify(report)
 	assertClassification(t, got, CategoryUnknown, "no-signal", CodeNoSignal, ConfidenceLow)
+}
+
+func TestClassifyOperator_MultiContainerEvidence(t *testing.T) {
+	// Two containers both in unrecognized bad states — one waiting, one terminated.
+	// Verifies that evidence is collected from all containers, not just the first.
+	report := &clusterhealth.Report{
+		Operator: clusterhealth.SectionResult[clusterhealth.OperatorSection]{
+			Data: clusterhealth.OperatorSection{
+				Deployment: &clusterhealth.DeploymentInfo{
+					Name:     "odh-controller",
+					Ready:    1,
+					Replicas: 1,
+				},
+				Pods: []clusterhealth.PodInfo{
+					{
+						Name:  "odh-controller-abc",
+						Phase: "Running",
+						Containers: []clusterhealth.ContainerInfo{
+							{Name: "sidecar", Waiting: "ContainerCreating"},
+							{Name: "manager", Terminated: "Error (exit 255): unexpected failure"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	got := Classify(report)
+	assertClassification(t, got, CategoryInfrastructure, "operator", CodeOperator, ConfidenceLow)
+	if len(got.Evidence) != 2 {
+		t.Errorf("expected evidence from both containers, got %d: %v", len(got.Evidence), got.Evidence)
+	}
 }
 
 func TestClassify_Priority(t *testing.T) {
@@ -685,6 +769,219 @@ func TestClassify_Operator(t *testing.T) {
 			wantSubcategory: "unclassifiable",
 			wantErrorCode:   CodeUnclassifiable,
 			wantConfidence:  ConfidenceLow,
+		},
+		{
+			name: "operator pod Running but container in CrashLoopBackOff",
+			report: &clusterhealth.Report{
+				Operator: clusterhealth.SectionResult[clusterhealth.OperatorSection]{
+					Data: clusterhealth.OperatorSection{
+						Deployment: &clusterhealth.DeploymentInfo{
+							Name:     "odh-controller",
+							Ready:    1,
+							Replicas: 1,
+						},
+						Pods: []clusterhealth.PodInfo{
+							{
+								Name:  "odh-controller-abc",
+								Phase: "Running",
+								Containers: []clusterhealth.ContainerInfo{
+									{Name: "manager", Waiting: "CrashLoopBackOff: back-off restarting failed container"},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantCategory:    CategoryInfrastructure,
+			wantSubcategory: "operator",
+			wantErrorCode:   CodeOperator,
+			wantConfidence:  ConfidenceHigh,
+		},
+		{
+			name: "operator pod Running but container OOMKilled",
+			report: &clusterhealth.Report{
+				Operator: clusterhealth.SectionResult[clusterhealth.OperatorSection]{
+					Data: clusterhealth.OperatorSection{
+						Deployment: &clusterhealth.DeploymentInfo{
+							Name:     "odh-controller",
+							Ready:    1,
+							Replicas: 1,
+						},
+						Pods: []clusterhealth.PodInfo{
+							{
+								Name:  "odh-controller-abc",
+								Phase: "Running",
+								Containers: []clusterhealth.ContainerInfo{
+									{Name: "manager", Terminated: "OOMKilled"},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantCategory:    CategoryInfrastructure,
+			wantSubcategory: "operator",
+			wantErrorCode:   CodeOperator,
+			wantConfidence:  ConfidenceHigh,
+		},
+		{
+			// Two containers: sidecar is healthy, manager is in CrashLoopBackOff.
+			// Exercises the inner container loop — hit must come from the second container.
+			name: "operator pod with two containers one healthy one CrashLoopBackOff",
+			report: &clusterhealth.Report{
+				Operator: clusterhealth.SectionResult[clusterhealth.OperatorSection]{
+					Data: clusterhealth.OperatorSection{
+						Deployment: &clusterhealth.DeploymentInfo{
+							Name:     "odh-controller",
+							Ready:    1,
+							Replicas: 1,
+						},
+						Pods: []clusterhealth.PodInfo{
+							{
+								Name:  "odh-controller-abc",
+								Phase: "Running",
+								Containers: []clusterhealth.ContainerInfo{
+									{Name: "sidecar", Ready: true},
+									{Name: "manager", Waiting: "CrashLoopBackOff: back-off 5m0s restarting failed container"},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantCategory:    CategoryInfrastructure,
+			wantSubcategory: "operator",
+			wantErrorCode:   CodeOperator,
+			wantConfidence:  ConfidenceHigh,
+		},
+		{
+			// Low-confidence path: container in an unrecognized waiting state (not in waitingPatterns).
+			// Should produce ConfidenceLow — the operatorDistress fallback, not the early-return path.
+			name: "operator container in unrecognized waiting state gives low confidence",
+			report: &clusterhealth.Report{
+				Operator: clusterhealth.SectionResult[clusterhealth.OperatorSection]{
+					Data: clusterhealth.OperatorSection{
+						Deployment: &clusterhealth.DeploymentInfo{
+							Name:     "odh-controller",
+							Ready:    1,
+							Replicas: 1,
+						},
+						Pods: []clusterhealth.PodInfo{
+							{
+								Name:  "odh-controller-abc",
+								Phase: "Running",
+								Containers: []clusterhealth.ContainerInfo{
+									{Name: "sidecar", Ready: true},
+									{Name: "manager", Waiting: "ContainerCreating"},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantCategory:    CategoryInfrastructure,
+			wantSubcategory: "operator",
+			wantErrorCode:   CodeOperator,
+			wantConfidence:  ConfidenceLow,
+		},
+		{
+			// Low-confidence path: container terminated with an unrecognized exit (not in terminatedPatterns).
+			// Should produce ConfidenceLow — the operatorDistress fallback, not the early-return path.
+			name: "operator container terminated with unrecognized exit gives low confidence",
+			report: &clusterhealth.Report{
+				Operator: clusterhealth.SectionResult[clusterhealth.OperatorSection]{
+					Data: clusterhealth.OperatorSection{
+						Deployment: &clusterhealth.DeploymentInfo{
+							Name:     "odh-controller",
+							Ready:    1,
+							Replicas: 1,
+						},
+						Pods: []clusterhealth.PodInfo{
+							{
+								Name:  "odh-controller-abc",
+								Phase: "Running",
+								Containers: []clusterhealth.ContainerInfo{
+									{Name: "sidecar", Ready: true},
+									{Name: "manager", Terminated: "Error (exit 255): unexpected failure"},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantCategory:    CategoryInfrastructure,
+			wantSubcategory: "operator",
+			wantErrorCode:   CodeOperator,
+			wantConfidence:  ConfidenceLow,
+		},
+		{
+			// DSCI must win over a low-confidence operator distress signal.
+			// This proves the operatorDistress is deferred and does not block classifyFromDSCI.
+			name: "DSCI unhealthy wins over operator container in unrecognized waiting state",
+			report: &clusterhealth.Report{
+				Operator: clusterhealth.SectionResult[clusterhealth.OperatorSection]{
+					Data: clusterhealth.OperatorSection{
+						Deployment: &clusterhealth.DeploymentInfo{
+							Name:     "odh-controller",
+							Ready:    1,
+							Replicas: 1,
+						},
+						Pods: []clusterhealth.PodInfo{
+							{
+								Name:  "odh-controller-abc",
+								Phase: "Running",
+								Containers: []clusterhealth.ContainerInfo{
+									{Name: "manager", Waiting: "PodInitializing"},
+								},
+							},
+						},
+					},
+				},
+				DSCI: clusterhealth.SectionResult[clusterhealth.CRConditionsSection]{
+					Error: "Degraded: True - component X is degraded",
+					Data: clusterhealth.CRConditionsSection{
+						Name: "default-dsci",
+					},
+				},
+			},
+			wantCategory:    CategoryInfrastructure,
+			wantSubcategory: "dsci-unhealthy",
+			wantErrorCode:   CodeDSCI,
+			wantConfidence:  ConfidenceMedium,
+		},
+		{
+			// DSC must win over a low-confidence operator distress signal.
+			name: "DSC unhealthy wins over operator container in unrecognized waiting state",
+			report: &clusterhealth.Report{
+				Operator: clusterhealth.SectionResult[clusterhealth.OperatorSection]{
+					Data: clusterhealth.OperatorSection{
+						Deployment: &clusterhealth.DeploymentInfo{
+							Name:     "odh-controller",
+							Ready:    1,
+							Replicas: 1,
+						},
+						Pods: []clusterhealth.PodInfo{
+							{
+								Name:  "odh-controller-abc",
+								Phase: "Running",
+								Containers: []clusterhealth.ContainerInfo{
+									{Name: "manager", Waiting: "PodInitializing"},
+								},
+							},
+						},
+					},
+				},
+				DSC: clusterhealth.SectionResult[clusterhealth.CRConditionsSection]{
+					Error: "component dashboard: Ready=False",
+					Data: clusterhealth.CRConditionsSection{
+						Name: "default-dsc",
+					},
+				},
+			},
+			wantCategory:    CategoryInfrastructure,
+			wantSubcategory: "dsc-unhealthy",
+			wantErrorCode:   CodeDSC,
+			wantConfidence:  ConfidenceMedium,
 		},
 		{
 			name: "healthy operator returns no-signal",


### PR DESCRIPTION
<!---
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
Adds stale event filtering to classifyFromEvents — events older than 5 minutes are skipped to prevent false positives from recovered clusters, fixing healthy-stale-events and healthy-node-not-ready-recovered scenarios.Extends classifyFromOperator to inspect container-level waiting and terminated states inside operator pods, not just pod phase. 

https://redhat.atlassian.net/browse/RHOAIENG-70940

## How Has This Been Tested?
Done unit tests.



## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [X] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [X] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work


### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [X] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
Add E2E if required.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Failure detection now ignores stale events older than 5 minutes to reduce false alerts.
  * Refined operator classification by separating high-confidence operator causes from deferred low-confidence operator distress signals.
  * Unrecognized pod-container distress is now aggregated across containers; cluster distress prioritizes pod distress, then operator distress.
* **Tests**
  * Added coverage for stale-event handling.
  * Expanded operator test scenarios, including multi-container evidence aggregation and DSCI/DSC precedence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->