### PR TITLE
Add odh-mcp-lifecycle-module-operator to operator manifests

### DIFF
--- a/build/manifests-config.yaml
+++ b/build/manifests-config.yaml
@@ -75,3 +75,6 @@ map:
   odh-workbenches-controller:
     src: workspaces/controller/manifests/kustomize
     dest: workbenches/odh-workbenches-controller
+  odh-mcp-lifecycle-module-operator:
+    src: config/manifests
+    dest: mcp-lifecycle-module-operator


### PR DESCRIPTION
Adds 'odh-mcp-lifecycle-module-operator' entry to build/manifests-config.yaml.

Repo: https://github.com/opendatahub-io/mcp-lifecycle-module-operator
Jira: https://redhat.atlassian.net/browse/RHOAIENG-70904

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a new packaging/configuration entry to include an additional module in the build output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->