### PR TITLE
Add odh-dashboard-operator to operator manifests

### DIFF
--- a/build/manifests-config.yaml
+++ b/build/manifests-config.yaml
@@ -76,5 +76,5 @@ map:
     src: workspaces/controller/manifests/kustomize
     dest: workbenches/odh-workbenches-controller
   odh-dashboard-operator:
-    src: ./manifests
+    src: manifests
     dest: odh-dashboard-operator

--- a/build/manifests-config.yaml
+++ b/build/manifests-config.yaml
@@ -75,3 +75,6 @@ map:
   odh-workbenches-controller:
     src: workspaces/controller/manifests/kustomize
     dest: workbenches/odh-workbenches-controller
+  odh-dashboard-operator:
+    src: ./manifests
+    dest: odh-dashboard-operator


### PR DESCRIPTION
Adds 'odh-dashboard-operator' entry to build/manifests-config.yaml.

Repo: https://github.com/opendatahub-io/odh-dashboard
Jira: https://redhat.atlassian.net/browse/RHOAIENG-69576

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the build manifest configuration to add a new mapping for the dashboard operator, placing its generated output in the correct location.
  * No user-facing functionality was changed directly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->