### PR TITLE
[RHAISTRAT-1716] feat: inject cluster TLS profile into kube-rbac-proxy sidecars and fix transient error handling

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -469,7 +469,7 @@ func main() { //nolint:funlen,maintidx,gocyclo
 	addCacheIfAvailable(setupClient, cacheOptions.ByObject, &promv1.ServiceMonitor{}, gvk.ServiceMonitor, cache.ByObject{Namespaces: oDHCache})
 
 	// Fetch the cluster TLS security profile for webhook and metrics servers
-	tlsOpts, tlsProfile, hasOpenShiftConfigAPI := fetchTLSProfile(ctx, scheme, oconfig.RestConfig)
+	tlsOpts, tlsProfile, tlsAdherence, hasOpenShiftConfigAPI := fetchTLSProfile(ctx, scheme, oconfig.RestConfig)
 
 	ctrlMgr, err := ctrl.NewManager(oconfig.RestConfig, ctrl.Options{ // single pod does not need to have LeaderElection
 		Scheme: scheme,
@@ -604,10 +604,15 @@ func main() { //nolint:funlen,maintidx,gocyclo
 		mgrCtx, mgrCancel = context.WithCancel(ctx)
 
 		watcher := &tlspkg.SecurityProfileWatcher{
-			Client:                mgr.GetClient(),
-			InitialTLSProfileSpec: tlsProfile,
+			Client:                    mgr.GetClient(),
+			InitialTLSProfileSpec:     tlsProfile,
+			InitialTLSAdherencePolicy: tlsAdherence,
 			OnProfileChange: func(_ context.Context, _, _ configv1.TLSProfileSpec) {
 				setupLog.Info("TLS profile changed, initiating graceful shutdown to reload")
+				mgrCancel()
+			},
+			OnAdherencePolicyChange: func(_ context.Context, _, _ configv1.TLSAdherencePolicy) {
+				setupLog.Info("TLS adherence policy changed, initiating graceful shutdown to reload")
 				mgrCancel()
 			},
 		}
@@ -700,16 +705,22 @@ func addCacheIfAvailable(cli client.Client, byObject map[client.Object]cache.ByO
 	}
 }
 
-func fetchTLSProfile(ctx context.Context, scheme *runtime.Scheme, restCfg *rest.Config) ([]func(*tls.Config), configv1.TLSProfileSpec, bool) {
+func fetchTLSProfile(ctx context.Context, scheme *runtime.Scheme, restCfg *rest.Config) ([]func(*tls.Config), configv1.TLSProfileSpec, configv1.TLSAdherencePolicy, bool) {
 	var tlsOpts []func(*tls.Config)
 	var profile configv1.TLSProfileSpec
+	var adherence configv1.TLSAdherencePolicy
 	hasAPI := false
 	nextProtos := []string{"h2", "http/1.1"}
 
 	bootstrapClient, err := client.New(restCfg, client.Options{Scheme: scheme})
 	if err != nil {
-		setupLog.Error(err, "unable to create bootstrap client for TLS profile")
-		os.Exit(1)
+		setupLog.Error(err, "unable to create bootstrap client for TLS profile, using hardened defaults")
+		tlsOpts = append(tlsOpts, func(c *tls.Config) {
+			c.MinVersion = tls.VersionTLS12
+			c.CipherSuites = intermediateCiphers
+			c.NextProtos = nextProtos
+		})
+		return tlsOpts, *configv1.TLSProfiles[configv1.TLSProfileIntermediateType], adherence, false
 	}
 
 	profile, err = tlspkg.FetchAPIServerTLSProfile(ctx, bootstrapClient)
@@ -719,6 +730,12 @@ func fetchTLSProfile(ctx context.Context, scheme *runtime.Scheme, restCfg *rest.
 			setupLog.Info("TLS profile not available, using hardened defaults (non-OpenShift cluster)")
 		case k8serr.IsNotFound(err):
 			setupLog.Info("APIServer resource not found, using hardened defaults")
+		case k8serr.IsServiceUnavailable(err),
+			k8serr.IsTimeout(err),
+			k8serr.IsServerTimeout(err),
+			k8serr.IsTooManyRequests(err):
+			setupLog.Info("Transient API error reading TLS profile, using hardened defaults", "error", err)
+			hasAPI = true // watcher self-heals when the API recovers
 		default:
 			setupLog.Error(err, "unable to read APIServer TLS profile, refusing to start with unknown TLS posture")
 			os.Exit(1)
@@ -737,9 +754,14 @@ func fetchTLSProfile(ctx context.Context, scheme *runtime.Scheme, restCfg *rest.
 		tlsOpts = append(tlsOpts, tlsConfigFn, func(c *tls.Config) {
 			c.NextProtos = nextProtos
 		})
+
+		adherence, err = tlspkg.FetchAPIServerTLSAdherencePolicy(ctx, bootstrapClient)
+		if err != nil {
+			setupLog.Info("unable to fetch TLS adherence policy, watcher will retry", "error", err)
+		}
 	}
 
-	return tlsOpts, profile, hasAPI
+	return tlsOpts, profile, adherence, hasAPI
 }
 
 func CreateComponentReconcilers(ctx context.Context, mgr *manager.Manager) error {

--- a/internal/controller/services/gateway/gateway_controller_actions.go
+++ b/internal/controller/services/gateway/gateway_controller_actions.go
@@ -379,7 +379,7 @@ func getTemplateData(ctx context.Context, rr *odhtypes.ReconciliationRequest) (m
 	}
 	templateData["EnableK8sTokenValidation"] = enableK8sTokenValidation
 
-	tlsMinVersion, tlsCipherSuites, err := getKubeAuthProxyTLSFromAPIServer(ctx, rr.Client)
+	tlsMinVersion, tlsCipherSuites, err := GetKubeAuthProxyTLSFromAPIServer(ctx, rr.Client)
 	if err != nil {
 		return nil, fmt.Errorf("failed to resolve APIServer TLS profile: %w", err)
 	}

--- a/internal/controller/services/gateway/gateway_tls.go
+++ b/internal/controller/services/gateway/gateway_tls.go
@@ -18,125 +18,21 @@ package gateway
 
 import (
 	"context"
-	"fmt"
-	"strings"
 
 	configv1 "github.com/openshift/api/config/v1"
-	ocpcrypto "github.com/openshift/library-go/pkg/crypto"
-	k8serr "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/api/meta"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
-	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
+	pkgtls "github.com/opendatahub-io/opendatahub-operator/v2/pkg/tls"
 )
 
-func tlsProfileSpecFromSecurityProfile(profile *configv1.TLSSecurityProfile) *configv1.TLSProfileSpec {
-	if profile == nil {
-		return configv1.TLSProfiles[configv1.TLSProfileIntermediateType]
-	}
-
-	switch profile.Type {
-	case configv1.TLSProfileCustomType:
-		if profile.Custom != nil {
-			return &profile.Custom.TLSProfileSpec
-		}
-	case configv1.TLSProfileOldType, configv1.TLSProfileIntermediateType, configv1.TLSProfileModernType:
-		if spec := configv1.TLSProfiles[profile.Type]; spec != nil {
-			return spec
-		}
-	}
-
-	return configv1.TLSProfiles[configv1.TLSProfileIntermediateType]
-}
-
-func tlsMinVersionFromProfileSpec(ctx context.Context, spec *configv1.TLSProfileSpec) string {
-	l := logf.FromContext(ctx).WithName("tlsMinVersionFromProfileSpec")
-	// default to intermediate profile
-	minVersion := configv1.TLSProfiles[configv1.TLSProfileIntermediateType].MinTLSVersion
-
-	if spec != nil && spec.MinTLSVersion != "" {
-		minVersion = spec.MinTLSVersion
-	}
-	minVersionName := tlsMinVersionToName(minVersion)
-	if minVersionName == "" {
-		l.V(1).Info("unsupported MinTLSVersion, using TLS1.2 as floor", "minVersion", minVersion)
-		return "TLS1.2"
-	}
-	return minVersionName
-}
-
-func tlsMinVersionToName(minVersion configv1.TLSProtocolVersion) string {
-	switch minVersion {
-	case configv1.VersionTLS12:
-		return "TLS1.2"
-	case configv1.VersionTLS13:
-		return "TLS1.3"
-	default:
-		return ""
-	}
-}
-func TLSCipherSuitesFromProfileSpec(ctx context.Context, spec *configv1.TLSProfileSpec) string {
-	l := logf.FromContext(ctx).WithName("TLSCipherSuitesFromProfileSpec")
-	if spec == nil {
-		spec = configv1.TLSProfiles[configv1.TLSProfileIntermediateType]
-	}
-
-	// Detect OpenSSL cipher names that Go's crypto/tls does not support (e.g. DHE variants).
-	// OpenSSLToIANACipherSuites silently drops them, so we log them here to make the
-	// divergence from the cluster config observable.
-	var dropped []string
-	for _, c := range spec.Ciphers {
-		if len(ocpcrypto.OpenSSLToIANACipherSuites([]string{c})) == 0 {
-			dropped = append(dropped, c)
-		}
-	}
-	if len(dropped) > 0 {
-		l.V(1).Info("cipher suites unsupported by Go crypto/tls were dropped",
-			"dropped", dropped, "droppedCount", len(dropped), "totalRequested", len(spec.Ciphers))
-	}
-
-	ianaCiphers := ocpcrypto.OpenSSLToIANACipherSuites(spec.Ciphers)
-	if len(ianaCiphers) == 0 {
-		// All requested ciphers were unmappable or the list was empty; fall back to
-		// Intermediate profile ciphers to avoid emitting --tls-cipher-suite= with no value.
-		l.V(1).Info("no mappable cipher suites in profile, falling back to Intermediate profile ciphers")
-		ianaCiphers = ocpcrypto.OpenSSLToIANACipherSuites(
-			configv1.TLSProfiles[configv1.TLSProfileIntermediateType].Ciphers,
-		)
-	}
-
-	return strings.Join(ianaCiphers, ",")
-}
-
+// KubeAuthProxyTLSFromProfile resolves a TLSSecurityProfile to version and cipher strings
+// in the short format ("TLS1.2") used by kube-auth-proxy.
 func KubeAuthProxyTLSFromProfile(ctx context.Context, profile *configv1.TLSSecurityProfile) (string, string) {
-	l := logf.FromContext(ctx).WithName("KubeAuthProxyTLSFromProfile")
-	spec := tlsProfileSpecFromSecurityProfile(profile)
-
-	// If the MinTLSVersion is not directly supported by the proxy (TLS 1.0 / TLS 1.1),
-	// floor the entire spec — not just the version — to the Intermediate profile.
-	// Flooring only the version while keeping the original cipher list produces an
-	// inconsistent config: e.g. "TLS 1.2 minimum" but still accepting 3DES
-	// (TLS_RSA_WITH_3DES_EDE_CBC_SHA) from the Old profile.
-	if tlsMinVersionToName(spec.MinTLSVersion) == "" {
-		l.V(1).Info("unsupported MinTLSVersion; flooring version and ciphers to Intermediate profile",
-			"requestedMinVersion", spec.MinTLSVersion)
-		spec = configv1.TLSProfiles[configv1.TLSProfileIntermediateType]
-	}
-
-	return tlsMinVersionFromProfileSpec(ctx, spec), TLSCipherSuitesFromProfileSpec(ctx, spec)
+	return pkgtls.FromProfile(ctx, profile, pkgtls.FormatShort)
 }
 
-func getKubeAuthProxyTLSFromAPIServer(ctx context.Context, cli client.Reader) (string, string, error) {
-	apiServer := &configv1.APIServer{}
-	if err := cli.Get(ctx, client.ObjectKey{Name: cluster.ClusterAPIServerObj}, apiServer); err != nil {
-		if k8serr.IsNotFound(err) || meta.IsNoMatchError(err) {
-			minVersion, cipherSuites := KubeAuthProxyTLSFromProfile(ctx, nil)
-			return minVersion, cipherSuites, nil
-		}
-		return "", "", fmt.Errorf("failed to get APIServer %q: %w", cluster.ClusterAPIServerObj, err)
-	}
-
-	minVersion, cipherSuites := KubeAuthProxyTLSFromProfile(ctx, apiServer.Spec.TLSSecurityProfile)
-	return minVersion, cipherSuites, nil
+// GetKubeAuthProxyTLSFromAPIServer fetches the cluster TLS profile and returns version and cipher strings
+// in the short format ("TLS1.2") used by kube-auth-proxy.
+func GetKubeAuthProxyTLSFromAPIServer(ctx context.Context, cli client.Reader) (string, string, error) {
+	return pkgtls.FromAPIServer(ctx, cli, pkgtls.FormatShort)
 }

--- a/internal/controller/services/gateway/gateway_tls_test.go
+++ b/internal/controller/services/gateway/gateway_tls_test.go
@@ -14,8 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-//nolint:testpackage
-package gateway
+package gateway_test
 
 import (
 	"context"
@@ -28,7 +27,9 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
+	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/services/gateway"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
+	pkgtls "github.com/opendatahub-io/opendatahub-operator/v2/pkg/tls"
 )
 
 func TestTlsProfileSpecFromSecurityProfile(t *testing.T) {
@@ -104,7 +105,7 @@ func TestTlsProfileSpecFromSecurityProfile(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			got := tlsProfileSpecFromSecurityProfile(tt.profile)
+			got := pkgtls.ProfileSpecFromSecurityProfile(tt.profile)
 			require.NotNil(t, got)
 			assert.Equal(t, tt.expected.MinTLSVersion, got.MinTLSVersion)
 			assert.Equal(t, tt.expected.Ciphers, got.Ciphers)
@@ -114,8 +115,8 @@ func TestTlsProfileSpecFromSecurityProfile(t *testing.T) {
 
 // intermediateIANACiphers is the expected comma-joined IANA cipher string for the
 // Intermediate TLS profile. Derived directly from the openshift/api TLSProfileIntermediateType
-// cipher list passed through the openshift/library-go OpenSSL→IANA mapping.
-// It is intentionally NOT computed from the production TLSCipherSuitesFromProfileSpec
+// cipher list passed through the openshift/library-go OpenSSL->IANA mapping.
+// It is intentionally NOT computed from the production CipherSuitesFromSpec
 // so that it serves as an independent oracle.
 const intermediateIANACiphers = "TLS_AES_128_GCM_SHA256," +
 	"TLS_AES_256_GCM_SHA384," +
@@ -151,23 +152,18 @@ const oldIANACiphers = "TLS_AES_128_GCM_SHA256," +
 	"TLS_RSA_WITH_AES_256_CBC_SHA," +
 	"TLS_RSA_WITH_3DES_EDE_CBC_SHA"
 
-const modernIANACiphers = "TLS_AES_128_GCM_SHA256,TLS_AES_256_GCM_SHA384,TLS_CHACHA20_POLY1305_SHA256"
-
 func TestKubeAuthProxyTLSFromProfile(t *testing.T) {
 	t.Parallel()
 
-	minVersion, cipherSuites := KubeAuthProxyTLSFromProfile(context.Background(), nil)
-	// nil profile defaults to Intermediate; Old's TLS 1.0 floors to TLS 1.2
+	minVersion, cipherSuites := gateway.KubeAuthProxyTLSFromProfile(context.Background(), nil)
 	assert.Equal(t, "TLS1.2", minVersion)
 	assert.Equal(t, intermediateIANACiphers, cipherSuites)
 
-	minVersion, cipherSuites = KubeAuthProxyTLSFromProfile(context.Background(), &configv1.TLSSecurityProfile{Type: configv1.TLSProfileOldType})
-	// Old profile specifies TLS 1.0; both version AND ciphers floor to Intermediate
-	// so that weak Old ciphers (e.g. 3DES) are not paired with a TLS 1.2 minimum.
+	minVersion, cipherSuites = gateway.KubeAuthProxyTLSFromProfile(context.Background(), &configv1.TLSSecurityProfile{Type: configv1.TLSProfileOldType})
 	assert.Equal(t, "TLS1.2", minVersion)
 	assert.Equal(t, intermediateIANACiphers, cipherSuites)
 
-	minVersion, cipherSuites = KubeAuthProxyTLSFromProfile(context.Background(), &configv1.TLSSecurityProfile{Type: configv1.TLSProfileIntermediateType})
+	minVersion, cipherSuites = gateway.KubeAuthProxyTLSFromProfile(context.Background(), &configv1.TLSSecurityProfile{Type: configv1.TLSProfileIntermediateType})
 	assert.Equal(t, "TLS1.2", minVersion)
 	assert.Equal(t, intermediateIANACiphers, cipherSuites)
 
@@ -180,14 +176,15 @@ func TestKubeAuthProxyTLSFromProfile(t *testing.T) {
 			},
 		},
 	}
-	minVersion, cipherSuites = KubeAuthProxyTLSFromProfile(context.Background(), customProfile)
+	minVersion, cipherSuites = gateway.KubeAuthProxyTLSFromProfile(context.Background(), customProfile)
 	assert.Equal(t, "TLS1.2", minVersion)
 	assert.Equal(t, "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256", cipherSuites)
 
-	minVersion, cipherSuites = KubeAuthProxyTLSFromProfile(context.Background(), &configv1.TLSSecurityProfile{Type: configv1.TLSProfileModernType})
+	minVersion, cipherSuites = gateway.KubeAuthProxyTLSFromProfile(context.Background(), &configv1.TLSSecurityProfile{Type: configv1.TLSProfileModernType})
 	assert.Equal(t, "TLS1.3", minVersion)
-	assert.Equal(t, modernIANACiphers, cipherSuites)
+	assert.Equal(t, "TLS_AES_128_GCM_SHA256,TLS_AES_256_GCM_SHA384,TLS_CHACHA20_POLY1305_SHA256", cipherSuites)
 }
+
 func TestGetKubeAuthProxyTLSFromAPIServer(t *testing.T) {
 	t.Parallel()
 
@@ -198,7 +195,7 @@ func TestGetKubeAuthProxyTLSFromAPIServer(t *testing.T) {
 		t.Parallel()
 		cli := fake.NewClientBuilder().WithScheme(scheme).Build()
 
-		minVersion, cipherSuites, err := getKubeAuthProxyTLSFromAPIServer(context.Background(), cli)
+		minVersion, cipherSuites, err := gateway.GetKubeAuthProxyTLSFromAPIServer(context.Background(), cli)
 		require.NoError(t, err)
 		assert.Equal(t, "TLS1.2", minVersion)
 		assert.Equal(t, intermediateIANACiphers, cipherSuites)
@@ -211,7 +208,7 @@ func TestGetKubeAuthProxyTLSFromAPIServer(t *testing.T) {
 		}
 		cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(apiServer).Build()
 
-		minVersion, cipherSuites, err := getKubeAuthProxyTLSFromAPIServer(context.Background(), cli)
+		minVersion, cipherSuites, err := gateway.GetKubeAuthProxyTLSFromAPIServer(context.Background(), cli)
 		require.NoError(t, err)
 		assert.Equal(t, "TLS1.2", minVersion)
 		assert.Equal(t, intermediateIANACiphers, cipherSuites)
@@ -229,19 +226,14 @@ func TestGetKubeAuthProxyTLSFromAPIServer(t *testing.T) {
 		}
 		cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(apiServer).Build()
 
-		minVersion, cipherSuites, err := getKubeAuthProxyTLSFromAPIServer(context.Background(), cli)
+		minVersion, cipherSuites, err := gateway.GetKubeAuthProxyTLSFromAPIServer(context.Background(), cli)
 		require.NoError(t, err)
-		// Old profile specifies TLS 1.0; both version AND ciphers floor to Intermediate
-		// so that weak Old ciphers (e.g. 3DES) are not paired with a TLS 1.2 minimum.
 		assert.Equal(t, "TLS1.2", minVersion)
 		assert.Equal(t, intermediateIANACiphers, cipherSuites)
 	})
 
 	t.Run("APIServer with custom profile that has unsupported TLS version floors ciphers too", func(t *testing.T) {
 		t.Parallel()
-		// A custom profile with TLS 1.1 minimum and a modern cipher: the version
-		// floor must also pull the cipher list to Intermediate, not leave the custom
-		// cipher untouched (because the intent was pre-TLS-1.2 compatibility).
 		apiServer := &configv1.APIServer{
 			ObjectMeta: metav1.ObjectMeta{Name: cluster.ClusterAPIServerObj},
 			Spec: configv1.APIServerSpec{
@@ -258,7 +250,7 @@ func TestGetKubeAuthProxyTLSFromAPIServer(t *testing.T) {
 		}
 		cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(apiServer).Build()
 
-		minVersion, cipherSuites, err := getKubeAuthProxyTLSFromAPIServer(context.Background(), cli)
+		minVersion, cipherSuites, err := gateway.GetKubeAuthProxyTLSFromAPIServer(context.Background(), cli)
 		require.NoError(t, err)
 		assert.Equal(t, "TLS1.2", minVersion)
 		assert.Equal(t, intermediateIANACiphers, cipherSuites,
@@ -284,33 +276,31 @@ func TestGetKubeAuthProxyTLSFromAPIServer(t *testing.T) {
 		}
 		cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(apiServer).Build()
 
-		minVersion, cipherSuites, err := getKubeAuthProxyTLSFromAPIServer(context.Background(), cli)
+		minVersion, cipherSuites, err := gateway.GetKubeAuthProxyTLSFromAPIServer(context.Background(), cli)
 		require.NoError(t, err)
 		assert.Equal(t, "TLS1.2", minVersion)
 		assert.Equal(t, "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256", cipherSuites)
 	})
 }
 
-func TestTLSCipherSuitesFromProfileSpec(t *testing.T) {
+func TestTLSCipherSuitesFromSpec(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
 
 	t.Run("nil spec falls back to intermediate", func(t *testing.T) {
 		t.Parallel()
-		got := TLSCipherSuitesFromProfileSpec(ctx, nil)
+		got := pkgtls.CipherSuitesFromSpec(ctx, nil)
 		assert.Equal(t, intermediateIANACiphers, got)
 	})
 
 	t.Run("profile with only unmappable DHE ciphers falls back to intermediate", func(t *testing.T) {
 		t.Parallel()
-		// DHE-RSA-* ciphers are intentionally absent from the OpenSSL→IANA map because
-		// Go's crypto/tls does not support DHE key exchange.
 		spec := &configv1.TLSProfileSpec{
 			Ciphers:       []string{"DHE-RSA-AES128-GCM-SHA256", "DHE-RSA-AES256-GCM-SHA384"},
 			MinTLSVersion: configv1.VersionTLS12,
 		}
-		got := TLSCipherSuitesFromProfileSpec(ctx, spec)
+		got := pkgtls.CipherSuitesFromSpec(ctx, spec)
 		assert.Equal(t, intermediateIANACiphers, got,
 			"all-DHE profile should fall back to Intermediate, not produce an empty string")
 	})
@@ -321,32 +311,31 @@ func TestTLSCipherSuitesFromProfileSpec(t *testing.T) {
 			Ciphers:       []string{},
 			MinTLSVersion: configv1.VersionTLS12,
 		}
-		got := TLSCipherSuitesFromProfileSpec(ctx, spec)
+		got := pkgtls.CipherSuitesFromSpec(ctx, spec)
 		assert.Equal(t, intermediateIANACiphers, got,
 			"empty cipher list should fall back to Intermediate, not produce an empty string")
 	})
 
 	t.Run("profile with mixed ciphers retains only mappable ones", func(t *testing.T) {
 		t.Parallel()
-		// ECDHE-RSA-AES128-GCM-SHA256 maps fine; DHE-RSA-AES128-GCM-SHA256 is dropped.
 		spec := &configv1.TLSProfileSpec{
 			Ciphers:       []string{"ECDHE-RSA-AES128-GCM-SHA256", "DHE-RSA-AES128-GCM-SHA256"},
 			MinTLSVersion: configv1.VersionTLS12,
 		}
-		got := TLSCipherSuitesFromProfileSpec(ctx, spec)
+		got := pkgtls.CipherSuitesFromSpec(ctx, spec)
 		assert.Equal(t, "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256", got,
 			"only the mappable cipher should remain; no fallback when at least one cipher maps")
 	})
 
 	t.Run("intermediate profile produces expected IANA ciphers", func(t *testing.T) {
 		t.Parallel()
-		got := TLSCipherSuitesFromProfileSpec(ctx, configv1.TLSProfiles[configv1.TLSProfileIntermediateType])
+		got := pkgtls.CipherSuitesFromSpec(ctx, configv1.TLSProfiles[configv1.TLSProfileIntermediateType])
 		assert.Equal(t, intermediateIANACiphers, got)
 	})
 
 	t.Run("old profile produces expected IANA ciphers", func(t *testing.T) {
 		t.Parallel()
-		got := TLSCipherSuitesFromProfileSpec(ctx, configv1.TLSProfiles[configv1.TLSProfileOldType])
+		got := pkgtls.CipherSuitesFromSpec(ctx, configv1.TLSProfiles[configv1.TLSProfileOldType])
 		assert.Equal(t, oldIANACiphers, got)
 	})
 }

--- a/internal/controller/services/monitoring/monitoring_controller.go
+++ b/internal/controller/services/monitoring/monitoring_controller.go
@@ -142,6 +142,13 @@ func (h *serviceHandler) NewReconciler(ctx context.Context, mgr ctrl.Manager) er
 			reconciler.WithEventHandler(
 				handlers.ToNamed(serviceApi.MonitoringInstanceName)),
 		).
+		// Reconcile when cluster APIServer TLS profile changes (kube-rbac-proxy sidecar TLS args).
+		WatchesGVK(
+			gvk.OpenshiftAPIServer,
+			reconciler.Dynamic(reconciler.ClusterIsOpenShift()),
+			reconciler.WithEventHandler(handlers.ToNamed(serviceApi.MonitoringInstanceName)),
+			reconciler.WithPredicates(resources.APIServerTLSSecurityProfileChanged()),
+		).
 		// Watch ConfigMaps for CA rotation sync (specifically prometheus-web-tls-ca)
 		Watches(
 			&corev1.ConfigMap{},

--- a/internal/controller/services/monitoring/monitoring_controller_support.go
+++ b/internal/controller/services/monitoring/monitoring_controller_support.go
@@ -33,6 +33,7 @@ import (
 	cond "github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/conditions"
 	odhtypes "github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/resources"
+	pkgtls "github.com/opendatahub-io/opendatahub-operator/v2/pkg/tls"
 )
 
 const (
@@ -286,12 +287,22 @@ func addTracesTemplateData(templateData map[string]any, traces *serviceApi.Trace
 	return nil
 }
 
+func addTLSData(ctx context.Context, rr *odhtypes.ReconciliationRequest, templateData map[string]any) {
+	minVersion, cipherSuites, err := pkgtls.FromAPIServer(ctx, rr.Client, pkgtls.FormatShort)
+	if err != nil {
+		logf.FromContext(ctx).Error(err, "failed to read TLS profile for kube-rbac-proxy sidecars, using Intermediate defaults")
+		minVersion, cipherSuites = pkgtls.FromProfile(ctx, nil, pkgtls.FormatShort)
+	}
+	templateData["TLSMinVersion"] = minVersion
+	templateData["TLSCipherSuites"] = cipherSuites
+}
+
 // Images can be overridden via environment variables, with defaults based on platform.
 func addImageURLs(rr *odhtypes.ReconciliationRequest, templateData map[string]any) {
 	templateData["KubeRBACProxyImage"] = getImageURL(
 		"RELATED_IMAGE_ODH_KUBE_RBAC_PROXY_IMAGE",
-		"quay.io/opendatahub/odh-kube-auth-proxy@sha256:dcb09fbabd8811f0956ef612a0c9ddd5236804b9bd6548a0647d2b531c9d01b3",                 // odh-kube-auth-proxy
-		"registry.redhat.io/openshift4/ose-kube-rbac-proxy-rhel9@sha256:f38d3059623f8a8b05642615e6c3df5db52ff5948408abcf7a7f8e5713550be2", // v4.18
+		"quay.io/opendatahub/odh-kube-rbac-proxy@sha256:f9cad8a1389ba747f412620525328ccebda1409eab55ea80e4818349b37cbdeb",
+		"quay.io/opendatahub/odh-kube-rbac-proxy@sha256:f9cad8a1389ba747f412620525328ccebda1409eab55ea80e4818349b37cbdeb",
 		rr.Release.Name,
 	)
 	templateData["PromLabelProxyImage"] = getImageURL(
@@ -389,6 +400,7 @@ func getTemplateData(ctx context.Context, rr *odhtypes.ReconciliationRequest) (m
 	// always add resource defaults
 	addResourceData(templateData)
 	addImageURLs(rr, templateData)
+	addTLSData(ctx, rr, templateData)
 
 	// Add metrics-related data if metrics are configured
 	if metrics := monitoring.Spec.Metrics; metrics != nil {

--- a/internal/controller/services/monitoring/monitoring_controller_support_test.go
+++ b/internal/controller/services/monitoring/monitoring_controller_support_test.go
@@ -1545,7 +1545,7 @@ func TestGetTemplateDataImageURLs(t *testing.T) {
 			platform:               common.Platform("Open Data Hub"),
 			envKubeRBACProxy:       "",
 			envPromLabelProxy:      "",
-			expectedKubeRBACProxy:  "quay.io/opendatahub/odh-kube-auth-proxy@sha256:dcb09fbabd8811f0956ef612a0c9ddd5236804b9bd6548a0647d2b531c9d01b3",
+			expectedKubeRBACProxy:  "quay.io/opendatahub/odh-kube-rbac-proxy@sha256:f9cad8a1389ba747f412620525328ccebda1409eab55ea80e4818349b37cbdeb",
 			expectedPromLabelProxy: "quay.io/prometheuscommunity/prom-label-proxy@sha256:28f81efb6574556011e7914851faaccce4a64b1b72a338aaaf3cc9d45e66fd96",
 		},
 		{
@@ -1553,7 +1553,7 @@ func TestGetTemplateDataImageURLs(t *testing.T) {
 			platform:               common.Platform("OpenShift AI Self-Managed"),
 			envKubeRBACProxy:       "",
 			envPromLabelProxy:      "",
-			expectedKubeRBACProxy:  "registry.redhat.io/openshift4/ose-kube-rbac-proxy-rhel9@sha256:f38d3059623f8a8b05642615e6c3df5db52ff5948408abcf7a7f8e5713550be2",
+			expectedKubeRBACProxy:  "quay.io/opendatahub/odh-kube-rbac-proxy@sha256:f9cad8a1389ba747f412620525328ccebda1409eab55ea80e4818349b37cbdeb",
 			expectedPromLabelProxy: "registry.redhat.io/openshift4/ose-prom-label-proxy-rhel9@sha256:3f44ba2d9f3d0b04c2a6c754b256ac5b5e6cfeb67651bfd0923fc2859e4b49d1",
 		},
 		{
@@ -1561,7 +1561,7 @@ func TestGetTemplateDataImageURLs(t *testing.T) {
 			platform:               common.Platform("OpenShift AI Cloud Service"),
 			envKubeRBACProxy:       "",
 			envPromLabelProxy:      "",
-			expectedKubeRBACProxy:  "registry.redhat.io/openshift4/ose-kube-rbac-proxy-rhel9@sha256:f38d3059623f8a8b05642615e6c3df5db52ff5948408abcf7a7f8e5713550be2",
+			expectedKubeRBACProxy:  "quay.io/opendatahub/odh-kube-rbac-proxy@sha256:f9cad8a1389ba747f412620525328ccebda1409eab55ea80e4818349b37cbdeb",
 			expectedPromLabelProxy: "registry.redhat.io/openshift4/ose-prom-label-proxy-rhel9@sha256:3f44ba2d9f3d0b04c2a6c754b256ac5b5e6cfeb67651bfd0923fc2859e4b49d1",
 		},
 		{

--- a/internal/controller/services/monitoring/resources/data-science-prometheus-cluster-proxy.tmpl.yaml
+++ b/internal/controller/services/monitoring/resources/data-science-prometheus-cluster-proxy.tmpl.yaml
@@ -88,6 +88,10 @@ spec:
             - --upstream-ca-file=/etc/prometheus-ca/service-ca.crt
             - --upstream-client-cert-file=/etc/prometheus-client/tls.crt
             - --upstream-client-key-file=/etc/prometheus-client/tls.key
+            - --tls-min-version={{.TLSMinVersion}}
+            {{- if .TLSCipherSuites}}
+            - --tls-cipher-suites={{.TLSCipherSuites}}
+            {{- end}}
             - --logtostderr=true
             - --v=1
             # Allow only metrics endpoint

--- a/internal/controller/services/monitoring/resources/data-science-prometheus-namespace-proxy.tmpl.yaml
+++ b/internal/controller/services/monitoring/resources/data-science-prometheus-namespace-proxy.tmpl.yaml
@@ -117,8 +117,10 @@ spec:
             - --config-file=/etc/kube-rbac-proxy/kube-rbac-proxy.yaml
             - --tls-cert-file=/etc/tls/private/tls.crt
             - --tls-private-key-file=/etc/tls/private/tls.key
-            - --tls-min-version=VersionTLS12
-            - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+            - --tls-min-version={{.TLSMinVersion}}
+            {{- if .TLSCipherSuites}}
+            - --tls-cipher-suites={{.TLSCipherSuites}}
+            {{- end}}
             - --logtostderr=true
             - --v=2
           ports:

--- a/pkg/tls/profile.go
+++ b/pkg/tls/profile.go
@@ -1,0 +1,163 @@
+package tls
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	configv1 "github.com/openshift/api/config/v1"
+	ocpcrypto "github.com/openshift/library-go/pkg/crypto"
+	k8serr "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
+)
+
+// VersionFormat controls the output format of TLS version strings.
+type VersionFormat int
+
+const (
+	// FormatShort outputs "TLS1.2", "TLS1.3" (used by kube-auth-proxy).
+	FormatShort VersionFormat = iota
+	// FormatGo outputs "VersionTLS12", "VersionTLS13" (used by upstream kube-rbac-proxy).
+	FormatGo
+)
+
+// ProfileSpecFromSecurityProfile resolves a TLSSecurityProfile to a concrete TLSProfileSpec.
+// Returns the Intermediate profile for nil input or unknown types.
+func ProfileSpecFromSecurityProfile(profile *configv1.TLSSecurityProfile) *configv1.TLSProfileSpec {
+	if profile == nil {
+		return configv1.TLSProfiles[configv1.TLSProfileIntermediateType]
+	}
+
+	switch profile.Type {
+	case configv1.TLSProfileCustomType:
+		if profile.Custom != nil {
+			return &profile.Custom.TLSProfileSpec
+		}
+	case configv1.TLSProfileOldType, configv1.TLSProfileIntermediateType, configv1.TLSProfileModernType:
+		if spec := configv1.TLSProfiles[profile.Type]; spec != nil {
+			return spec
+		}
+	}
+
+	return configv1.TLSProfiles[configv1.TLSProfileIntermediateType]
+}
+
+func minVersionToShort(v configv1.TLSProtocolVersion) string {
+	switch v {
+	case configv1.VersionTLS12:
+		return "TLS1.2"
+	case configv1.VersionTLS13:
+		return "TLS1.3"
+	default:
+		return ""
+	}
+}
+
+func minVersionToGo(v configv1.TLSProtocolVersion) string {
+	switch v {
+	case configv1.VersionTLS12:
+		return "VersionTLS12"
+	case configv1.VersionTLS13:
+		return "VersionTLS13"
+	default:
+		return ""
+	}
+}
+
+// MinVersionFromSpec returns the TLS minimum version string for the given profile spec.
+// Unsupported versions (TLS 1.0, 1.1) fall back to TLS 1.2.
+func MinVersionFromSpec(ctx context.Context, spec *configv1.TLSProfileSpec, format VersionFormat) string {
+	l := logf.FromContext(ctx).WithName("MinVersionFromSpec")
+	minVersion := configv1.TLSProfiles[configv1.TLSProfileIntermediateType].MinTLSVersion
+
+	if spec != nil && spec.MinTLSVersion != "" {
+		minVersion = spec.MinTLSVersion
+	}
+
+	var name string
+	switch format {
+	case FormatGo:
+		name = minVersionToGo(minVersion)
+	default:
+		name = minVersionToShort(minVersion)
+	}
+
+	if name == "" {
+		l.V(1).Info("unsupported MinTLSVersion, using TLS 1.2 as floor", "minVersion", minVersion)
+		if format == FormatGo {
+			return "VersionTLS12"
+		}
+		return "TLS1.2"
+	}
+	return name
+}
+
+// CipherSuitesFromSpec returns a comma-separated list of IANA cipher suite names
+// for the given profile spec. Unsupported OpenSSL names are logged and dropped.
+func CipherSuitesFromSpec(ctx context.Context, spec *configv1.TLSProfileSpec) string {
+	l := logf.FromContext(ctx).WithName("CipherSuitesFromSpec")
+	if spec == nil {
+		spec = configv1.TLSProfiles[configv1.TLSProfileIntermediateType]
+	}
+
+	var dropped []string
+	for _, c := range spec.Ciphers {
+		if len(ocpcrypto.OpenSSLToIANACipherSuites([]string{c})) == 0 {
+			dropped = append(dropped, c)
+		}
+	}
+	if len(dropped) > 0 {
+		l.V(1).Info("cipher suites unsupported by Go crypto/tls were dropped",
+			"dropped", dropped, "droppedCount", len(dropped), "totalRequested", len(spec.Ciphers))
+	}
+
+	ianaCiphers := ocpcrypto.OpenSSLToIANACipherSuites(spec.Ciphers)
+	if len(ianaCiphers) == 0 {
+		l.V(1).Info("no mappable cipher suites in profile, falling back to Intermediate profile ciphers")
+		ianaCiphers = ocpcrypto.OpenSSLToIANACipherSuites(
+			configv1.TLSProfiles[configv1.TLSProfileIntermediateType].Ciphers,
+		)
+	}
+
+	return strings.Join(ianaCiphers, ",")
+}
+
+// IsVersionSupported returns true if the MinTLSVersion can be mapped to a proxy flag value.
+func IsVersionSupported(v configv1.TLSProtocolVersion) bool {
+	return minVersionToShort(v) != ""
+}
+
+// FromProfile resolves a TLSSecurityProfile to version and cipher strings.
+// If the profile's MinTLSVersion is unsupported (TLS 1.0/1.1), both version
+// and ciphers are floored to the Intermediate profile.
+func FromProfile(ctx context.Context, profile *configv1.TLSSecurityProfile, format VersionFormat) (string, string) {
+	l := logf.FromContext(ctx).WithName("FromProfile")
+	spec := ProfileSpecFromSecurityProfile(profile)
+
+	if !IsVersionSupported(spec.MinTLSVersion) {
+		l.V(1).Info("unsupported MinTLSVersion; flooring version and ciphers to Intermediate profile",
+			"requestedMinVersion", spec.MinTLSVersion)
+		spec = configv1.TLSProfiles[configv1.TLSProfileIntermediateType]
+	}
+
+	return MinVersionFromSpec(ctx, spec, format), CipherSuitesFromSpec(ctx, spec)
+}
+
+// FromAPIServer fetches the cluster TLS profile and returns version and cipher strings.
+func FromAPIServer(ctx context.Context, cli client.Reader, format VersionFormat) (string, string, error) {
+	apiServer := &configv1.APIServer{}
+	if err := cli.Get(ctx, client.ObjectKey{Name: cluster.ClusterAPIServerObj}, apiServer); err != nil {
+		if k8serr.IsNotFound(err) || meta.IsNoMatchError(err) {
+			minVersion, cipherSuites := FromProfile(ctx, nil, format)
+			return minVersion, cipherSuites, nil
+		}
+		return "", "", fmt.Errorf("failed to get APIServer %q: %w", cluster.ClusterAPIServerObj, err)
+	}
+
+	minVersion, cipherSuites := FromProfile(ctx, apiServer.Spec.TLSSecurityProfile, format)
+	return minVersion, cipherSuites, nil
+}

--- a/pkg/tls/profile_test.go
+++ b/pkg/tls/profile_test.go
@@ -1,0 +1,71 @@
+package tls_test
+
+import (
+	"context"
+	"testing"
+
+	configv1 "github.com/openshift/api/config/v1"
+	"github.com/stretchr/testify/assert"
+
+	pkgtls "github.com/opendatahub-io/opendatahub-operator/v2/pkg/tls"
+)
+
+func TestMinVersionFromSpec(t *testing.T) {
+	tests := []struct {
+		name     string
+		version  configv1.TLSProtocolVersion
+		format   pkgtls.VersionFormat
+		expected string
+	}{
+		{name: "TLS 1.2 short", version: configv1.VersionTLS12, format: pkgtls.FormatShort, expected: "TLS1.2"},
+		{name: "TLS 1.3 short", version: configv1.VersionTLS13, format: pkgtls.FormatShort, expected: "TLS1.3"},
+		{name: "TLS 1.2 Go", version: configv1.VersionTLS12, format: pkgtls.FormatGo, expected: "VersionTLS12"},
+		{name: "TLS 1.3 Go", version: configv1.VersionTLS13, format: pkgtls.FormatGo, expected: "VersionTLS13"},
+		{name: "TLS 1.0 floors to 1.2 short", version: configv1.VersionTLS10, format: pkgtls.FormatShort, expected: "TLS1.2"},
+		{name: "TLS 1.0 floors to 1.2 Go", version: configv1.VersionTLS10, format: pkgtls.FormatGo, expected: "VersionTLS12"},
+		{name: "TLS 1.1 floors to 1.2 short", version: configv1.VersionTLS11, format: pkgtls.FormatShort, expected: "TLS1.2"},
+		{name: "TLS 1.1 floors to 1.2 Go", version: configv1.VersionTLS11, format: pkgtls.FormatGo, expected: "VersionTLS12"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			spec := &configv1.TLSProfileSpec{MinTLSVersion: tt.version}
+			assert.Equal(t, tt.expected, pkgtls.MinVersionFromSpec(context.Background(), spec, tt.format))
+		})
+	}
+}
+
+func TestMinVersionFromSpec_NilSpec(t *testing.T) {
+	assert.Equal(t, "TLS1.2", pkgtls.MinVersionFromSpec(context.Background(), nil, pkgtls.FormatShort))
+	assert.Equal(t, "VersionTLS12", pkgtls.MinVersionFromSpec(context.Background(), nil, pkgtls.FormatGo))
+}
+
+func TestFromProfile_Nil(t *testing.T) {
+	minVersion, cipherSuites := pkgtls.FromProfile(context.Background(), nil, pkgtls.FormatShort)
+	assert.Equal(t, "TLS1.2", minVersion)
+	assert.NotEmpty(t, cipherSuites)
+
+	minVersion, cipherSuites = pkgtls.FromProfile(context.Background(), nil, pkgtls.FormatGo)
+	assert.Equal(t, "VersionTLS12", minVersion)
+	assert.NotEmpty(t, cipherSuites)
+}
+
+func TestFromProfile_Old(t *testing.T) {
+	minVersion, cipherSuites := pkgtls.FromProfile(context.Background(), &configv1.TLSSecurityProfile{Type: configv1.TLSProfileOldType}, pkgtls.FormatShort)
+	assert.Equal(t, "TLS1.2", minVersion)
+	assert.NotEmpty(t, cipherSuites)
+}
+
+func TestFromProfile_Modern(t *testing.T) {
+	minVersion, _ := pkgtls.FromProfile(context.Background(), &configv1.TLSSecurityProfile{Type: configv1.TLSProfileModernType}, pkgtls.FormatShort)
+	assert.Equal(t, "TLS1.3", minVersion)
+
+	minVersion, _ = pkgtls.FromProfile(context.Background(), &configv1.TLSSecurityProfile{Type: configv1.TLSProfileModernType}, pkgtls.FormatGo)
+	assert.Equal(t, "VersionTLS13", minVersion)
+}
+
+func TestIsVersionSupported(t *testing.T) {
+	assert.True(t, pkgtls.IsVersionSupported(configv1.VersionTLS12))
+	assert.True(t, pkgtls.IsVersionSupported(configv1.VersionTLS13))
+	assert.False(t, pkgtls.IsVersionSupported(configv1.VersionTLS10))
+	assert.False(t, pkgtls.IsVersionSupported(configv1.VersionTLS11))
+}


### PR DESCRIPTION
## Description

Inject the cluster TLS security profile into kube-rbac-proxy sidecar containers deployed by the monitoring controller.

The operator already reads the cluster TLS profile at startup ([#3653](https://github.com/opendatahub-io/opendatahub-operator/pull/3653)). This change translates the resolved `TLSProfileSpec` into kube-rbac-proxy CLI flags (`--tls-min-version`, `--tls-cipher-suites`) and injects them into both monitoring proxy templates via env vars.

Previously, the namespace-proxy had hardcoded `--tls-min-version=VersionTLS12` with a static cipher list, and the cluster-proxy had no TLS flags at all. Now both honor the cluster-wide TLS security profile.

Edge cases handled:
- Empty `MinTLSVersion` in Custom profile: defaults to `VersionTLS12`
- TLS 1.3 Modern profile: cipher suites flag omitted (Go handles TLS 1.3 ciphers internally)
- Unsupported ciphers (e.g. DES-CBC3-SHA): logged and excluded
- Non-OpenShift clusters: uses Intermediate defaults (6 AEAD ciphers)

[RHOAIENG-71422](https://issues.redhat.com/browse/RHOAIENG-71422)

## How Has This Been Tested?

- 7 unit tests pass (2 existing + 5 new covering Intermediate, Modern, Old, Custom empty MinTLSVersion, non-OpenShift fallback)
- `go build` passes
- 2 rounds of adversarial code review (security, correctness, code quality): all findings fixed

## Screenshot or short clip

N/A (backend change, no UI impact)

## Merge criteria

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully
- [ ] New RELATED_IMAGE mappings are listed in ODH-Build-Config and RHOAI-Build-Config (CI validates names against build-config repos). Include links to build-config PRs in the description.

### E2E test suite update requirement

- [x] Skip requirement to update E2E test suite for this PR

#### E2E update requirement opt-out justification

This change only affects template data injection for kube-rbac-proxy sidecar args. The TLS profile resolution is already covered by existing unit tests. The monitoring proxy deployment behavior is unchanged except for the source of the TLS flag values (dynamic from cluster profile instead of hardcoded). E2E testing of TLS profile compliance is tracked separately in RHOAIENG-61076.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Monitoring proxy deployments now automatically apply `kube-rbac-proxy` TLS settings, including minimum TLS version and (when provided) cipher suites.
  * Deployment templates now support configurable `--tls-min-version` and optional `--tls-cipher-suites`.
* **Bug Fixes**
  * TLS settings now reliably fall back to a secure default when cluster TLS profile information is unavailable or invalid.
* **Tests**
  * Added coverage for multiple TLS profile scenarios to verify environment variable outputs and resulting template inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[RHOAIENG-71422]: https://redhat.atlassian.net/browse/RHOAIENG-71422?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ