### PR TITLE
feat: add monitoring prefix skip

### DIFF
--- a/cmd/test-retry/pkg/cli/e2e.go
+++ b/cmd/test-retry/pkg/cli/e2e.go
@@ -77,6 +77,7 @@ Example: test-retry e2e -- -run TestFoo -v`,
 	cmd.Flags().IntVar(&maxRetries, "max-retries", 3, "Maximum number of retries for failed tests")
 	cmd.Flags().StringSliceVar(&neverSkip, "never-skip", []string{"TestOdhOperator/DSCInitialization_and_DataScienceCluster_management_E2E_Tests", "TestOdhOperator/DataScienceCluster"}, "Test prefixes that should never be skipped (always run, repeatable)")
 	cmd.Flags().StringSliceVar(&skipAtPrefix, "skip-at-prefix", []string{
+		"TestOdhOperator/monitoring/",   // Extract monitoring tests at group level for efficient retry
 		"TestOdhOperator/services/*/",   // Extract services at service level
 		"TestOdhOperator/components/*/", // Extract components at component level
 		"TestOdhOperator/",              // Fallback: extract at root level

--- a/cmd/test-retry/pkg/runner/e2e_test.go
+++ b/cmd/test-retry/pkg/runner/e2e_test.go
@@ -299,55 +299,53 @@ func TestBuildSkipFilter(t *testing.T) {
 			name: "monitoring-specific pattern for group level extraction",
 			opts: types.E2ETestOptions{
 				SkipAtPrefixes: []string{
-					"TestOdhOperator/services/*/monitoring",
-					"TestOdhOperator/services/*/",
+					"TestOdhOperator/monitoring/",
 					"TestOdhOperator/",
 				},
 			},
 			aggregatedTestResult: &types.TestResult{PassedTest: []types.TestCase{
-				{Name: "TestOdhOperator/services/group 1/monitoring/Group 1: Base Configuration"},
-				{Name: "TestOdhOperator/services/group 1/monitoring/Group 1: Base Configuration/Auto creation of Monitoring CR"},
-				{Name: "TestOdhOperator/services/group 1/monitoring/Group 1: Base Configuration/Test Monitoring CR content default value"},
-				{Name: "TestOdhOperator/services/group 1/monitoring/Group 2: Metrics & MonitoringStack"},
-				{Name: "TestOdhOperator/services/group 1/monitoring/Group 2: Metrics & MonitoringStack/Test Metrics MonitoringStack CR Creation"},
-				{Name: "TestOdhOperator/services/group 1/monitoring/Group 2: Metrics & MonitoringStack/Test Metrics MonitoringStack CR Configuration"},
+				{Name: "TestOdhOperator/monitoring/Group 1: Base Configuration"},
+				{Name: "TestOdhOperator/monitoring/Group 1: Base Configuration/Auto creation of Monitoring CR"},
+				{Name: "TestOdhOperator/monitoring/Group 1: Base Configuration/Test Monitoring CR content default value"},
+				{Name: "TestOdhOperator/monitoring/Group 2: Metrics & MonitoringStack"},
+				{Name: "TestOdhOperator/monitoring/Group 2: Metrics & MonitoringStack/Test Metrics MonitoringStack CR Creation"},
+				{Name: "TestOdhOperator/monitoring/Group 2: Metrics & MonitoringStack/Test Metrics MonitoringStack CR Configuration"},
 			}},
-			expected: "^TestOdhOperator$/^services$/^group 1$/^monitoring$/^Group 1: Base Configuration$|^TestOdhOperator$/^services$/^group 1$/^monitoring$/^Group 2: Metrics & MonitoringStack$",
+			expected: "^TestOdhOperator$/^monitoring$/^Group 1: Base Configuration$|^TestOdhOperator$/^monitoring$/^Group 2: Metrics & MonitoringStack$",
 		},
 		{
 			name: "monitoring-specific pattern with mixed monitoring and other service tests",
 			opts: types.E2ETestOptions{
 				SkipAtPrefixes: []string{
-					"TestOdhOperator/services/*/monitoring",
+					"TestOdhOperator/monitoring/",
 					"TestOdhOperator/services/*/",
 					"TestOdhOperator/",
 				},
 			},
 			aggregatedTestResult: &types.TestResult{PassedTest: []types.TestCase{
-				{Name: "TestOdhOperator/services/group 1/monitoring/Group 1: Base Configuration"},
-				{Name: "TestOdhOperator/services/group 1/monitoring/Group 1: Base Configuration/Test A"},
+				{Name: "TestOdhOperator/monitoring/Group 1: Base Configuration"},
+				{Name: "TestOdhOperator/monitoring/Group 1: Base Configuration/Test A"},
 				{Name: "TestOdhOperator/services/group 1/auth"},
 				{Name: "TestOdhOperator/services/group 1/auth/Test B"},
 				{Name: "TestOdhOperator/services/group 1/gateway"},
 				{Name: "TestOdhOperator/services/group 1/gateway/Test C"},
 			}},
-			expected: "^TestOdhOperator$/^services$/^group 1$/^auth$|^TestOdhOperator$/^services$/^group 1$/^gateway$|^TestOdhOperator$/^services$/^group 1$/^monitoring$/^Group 1: Base Configuration$",
+			expected: "^TestOdhOperator$/^monitoring$/^Group 1: Base Configuration$|^TestOdhOperator$/^services$/^group 1$/^auth$|^TestOdhOperator$/^services$/^group 1$/^gateway$",
 		},
 		{
 			name: "monitoring-specific pattern takes precedence over general pattern",
 			opts: types.E2ETestOptions{
 				SkipAtPrefixes: []string{
-					"TestOdhOperator/services/*/monitoring", // More specific (4 parts), should match first
-					"TestOdhOperator/services/*/",           // Less specific (3 parts)
+					"TestOdhOperator/monitoring/", // More specific
 					"TestOdhOperator/",
 				},
 			},
 			aggregatedTestResult: &types.TestResult{PassedTest: []types.TestCase{
-				{Name: "TestOdhOperator/services/group 1/monitoring/Group 5: Thanos Querier"},
-				{Name: "TestOdhOperator/services/group 1/monitoring/Group 5: Thanos Querier/Test ThanosQuerier deployment with metrics"},
+				{Name: "TestOdhOperator/monitoring/Group 5: Thanos Querier"},
+				{Name: "TestOdhOperator/monitoring/Group 5: Thanos Querier/Test ThanosQuerier deployment with metrics"},
 			}},
-			// Should extract at Group level (monitoring pattern), not at monitoring level (general pattern)
-			expected: "^TestOdhOperator$/^services$/^group 1$/^monitoring$/^Group 5: Thanos Querier$",
+			// Should extract at Group level (monitoring pattern), not at root level (general pattern)
+			expected: "^TestOdhOperator$/^monitoring$/^Group 5: Thanos Querier$",
 		},
 	}
 
@@ -545,13 +543,12 @@ func TestExtractTestLevel(t *testing.T) {
 			opts: types.E2ETestOptions{
 				NeverSkipPrefixes: []string{},
 				SkipAtPrefixes: []string{
-					"TestOdhOperator/services/*/monitoring",
-					"TestOdhOperator/services/*/",
+					"TestOdhOperator/monitoring/",
 					"TestOdhOperator/",
 				},
 			},
-			testName:   "TestOdhOperator/services/group 1/monitoring/Group 1: Base Configuration/Auto creation of Monitoring CR",
-			wantLevel:  "TestOdhOperator/services/group 1/monitoring/Group 1: Base Configuration",
+			testName:   "TestOdhOperator/monitoring/Group 1: Base Configuration/Auto creation of Monitoring CR",
+			wantLevel:  "TestOdhOperator/monitoring/Group 1: Base Configuration",
 			shouldSkip: true,
 		},
 		{
@@ -559,13 +556,12 @@ func TestExtractTestLevel(t *testing.T) {
 			opts: types.E2ETestOptions{
 				NeverSkipPrefixes: []string{},
 				SkipAtPrefixes: []string{
-					"TestOdhOperator/services/*/monitoring",
-					"TestOdhOperator/services/*/",
+					"TestOdhOperator/monitoring/",
 					"TestOdhOperator/",
 				},
 			},
-			testName:   "TestOdhOperator/services/group 1/monitoring/Group 5: Thanos Querier/Test ThanosQuerier deployment",
-			wantLevel:  "TestOdhOperator/services/group 1/monitoring/Group 5: Thanos Querier",
+			testName:   "TestOdhOperator/monitoring/Group 5: Thanos Querier/Test ThanosQuerier deployment",
+			wantLevel:  "TestOdhOperator/monitoring/Group 5: Thanos Querier",
 			shouldSkip: true,
 		},
 		{
@@ -573,27 +569,12 @@ func TestExtractTestLevel(t *testing.T) {
 			opts: types.E2ETestOptions{
 				NeverSkipPrefixes: []string{},
 				SkipAtPrefixes: []string{
-					"TestOdhOperator/services/*/monitoring",
-					"TestOdhOperator/services/*/",
+					"TestOdhOperator/monitoring/",
 					"TestOdhOperator/",
 				},
 			},
-			testName:   "TestOdhOperator/services/group 1/monitoring/Group 2: Metrics & MonitoringStack/Test CR Creation",
-			wantLevel:  "TestOdhOperator/services/group 1/monitoring/Group 2: Metrics & MonitoringStack",
-			shouldSkip: true,
-		},
-		{
-			name: "other service tests use general pattern not monitoring-specific",
-			opts: types.E2ETestOptions{
-				NeverSkipPrefixes: []string{},
-				SkipAtPrefixes: []string{
-					"TestOdhOperator/services/*/monitoring",
-					"TestOdhOperator/services/*/",
-					"TestOdhOperator/",
-				},
-			},
-			testName:   "TestOdhOperator/services/group 1/auth/Test Auth",
-			wantLevel:  "TestOdhOperator/services/group 1/auth",
+			testName:   "TestOdhOperator/monitoring/Group 2: Metrics & MonitoringStack/Test CR Creation",
+			wantLevel:  "TestOdhOperator/monitoring/Group 2: Metrics & MonitoringStack",
 			shouldSkip: true,
 		},
 		{
@@ -601,13 +582,12 @@ func TestExtractTestLevel(t *testing.T) {
 			opts: types.E2ETestOptions{
 				NeverSkipPrefixes: []string{},
 				SkipAtPrefixes: []string{
-					"TestOdhOperator/services/*/monitoring", // 4 parts with wildcard
-					"TestOdhOperator/services/*/",           // 3 parts with wildcard
-					"TestOdhOperator/",                      // 1 part
+					"TestOdhOperator/monitoring/", // 3 parts with wildcard
+					"TestOdhOperator/",            // 1 part
 				},
 			},
-			testName:   "TestOdhOperator/services/group 1/monitoring/Group 8: Perses/Test Perses",
-			wantLevel:  "TestOdhOperator/services/group 1/monitoring/Group 8: Perses",
+			testName:   "TestOdhOperator/monitoring/Group 8: Perses/Test Perses",
+			wantLevel:  "TestOdhOperator/monitoring/Group 8: Perses",
 			shouldSkip: true,
 		},
 	}


### PR DESCRIPTION
With this change, we avoid to rerun all monitoring tests but skip from rerun failed monitoring groups


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved end-to-end test retry/skip behavior by expanding the default monitoring-specific test prefix handling to include `TestOdhOperator/monitoring/`.
  * Monitoring tests now skip/retry at the correct, more granular group level, with the more specific monitoring pattern taking precedence over broader service/component/root fallback matching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->