### PR TITLE
feat(monitoring): add collector-to-MLflow ClusterRole and ClusterRoleBinding for trace ingestion

### DIFF
--- a/internal/controller/services/monitoring/monitoring_controller_actions.go
+++ b/internal/controller/services/monitoring/monitoring_controller_actions.go
@@ -32,6 +32,7 @@ const (
 	CollectorServiceMonitorsTemplate                 = "resources/collector-servicemonitors.tmpl.yaml"
 	CollectorPrometheusServiceTemplate               = "resources/collector-prometheus-service.tmpl.yaml"
 	CollectorRBACTemplate                            = "resources/collector-rbac.tmpl.yaml"
+	CollectorMLflowRBACTemplate                      = "resources/collector-mlflow-rbac.tmpl.yaml"
 	PrometheusRouteTemplate                          = "resources/data-science-prometheus-route.tmpl.yaml"
 	InstrumentationTemplate                          = "resources/instrumentation.tmpl.yaml"
 	PrometheusNamespaceProxyTemplate                 = "resources/data-science-prometheus-namespace-proxy.tmpl.yaml"
@@ -310,6 +311,14 @@ func deployOpenTelemetryCollector(ctx context.Context, rr *odhtypes.Reconciliati
 		template = append(template, odhtypes.TemplateInfo{
 			FS:   resourcesFS,
 			Path: CollectorPrometheusServiceTemplate,
+		})
+	}
+
+	// Collector RBAC for MLflow trace ingestion (only when tracing is enabled)
+	if monitoring.Spec.Traces != nil {
+		template = append(template, odhtypes.TemplateInfo{
+			FS:   resourcesFS,
+			Path: CollectorMLflowRBACTemplate,
 		})
 	}
 

--- a/internal/controller/services/monitoring/resources/collector-mlflow-rbac.tmpl.yaml
+++ b/internal/controller/services/monitoring/resources/collector-mlflow-rbac.tmpl.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: data-science-collector-mlflow-integration
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: mlflow-operator-mlflow-integration
+subjects:
+- kind: ServiceAccount
+  name: data-science-collector-collector
+  namespace: {{ .Namespace }}

--- a/internal/controller/services/monitoring/resources/collector-mlflow-rbac.tmpl.yaml
+++ b/internal/controller/services/monitoring/resources/collector-mlflow-rbac.tmpl.yaml
@@ -1,11 +1,23 @@
 apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: data-science-collector-mlflow-trace-export
+rules:
+- apiGroups:
+  - mlflow.kubeflow.org
+  resources:
+  - experiments
+  verbs:
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: data-science-collector-mlflow-integration
+  name: data-science-collector-mlflow-trace-export
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: mlflow-operator-mlflow-integration
+  name: data-science-collector-mlflow-trace-export
 subjects:
 - kind: ServiceAccount
   name: data-science-collector-collector

--- a/tests/e2e/monitoring_test.go
+++ b/tests/e2e/monitoring_test.go
@@ -277,6 +277,7 @@ func (tc *MonitoringTestCtx) runTracesWithPVBackendTests(t *testing.T) {
 		})
 
 		t.Run("Test TempoMonolithic CR Creation with PV backend", tc.ValidateTempoMonolithicCRCreation)
+		t.Run("Test Collector MLflow integration RBAC", tc.ValidateCollectorMLflowIntegrationRBAC)
 	})
 }
 
@@ -2896,6 +2897,30 @@ func (tc *MonitoringTestCtx) ValidateTargetAllocatorRBACConfiguration(t *testing
 			jq.Match(`.subjects[0].namespace == "%s"`, tc.MonitoringNamespace),
 		)),
 		WithCustomErrorMsg("ClusterRoleBinding should bind Target Allocator ClusterRole to ServiceAccount"),
+	)
+}
+
+// ValidateCollectorMLflowIntegrationRBAC tests that the collector SA has the mlflow-integration ClusterRoleBinding.
+func (tc *MonitoringTestCtx) ValidateCollectorMLflowIntegrationRBAC(t *testing.T) {
+	t.Helper()
+	t.Cleanup(tc.resetMonitoringConfigToManaged)
+
+	tc.updateMonitoringConfig(
+		withManagementState(operatorv1.Managed),
+		withMonitoringTraces(TracesStorageBackendPV, "", TracesStorageSize1Gi, DefaultRetention),
+	)
+
+	// Verify ClusterRoleBinding binds the collector SA to the mlflow-integration ClusterRole
+	tc.EnsureResourceExists(
+		WithMinimalObject(gvk.ClusterRoleBinding, types.NamespacedName{
+			Name: "data-science-collector-mlflow-integration",
+		}),
+		WithCondition(And(
+			jq.Match(`.roleRef.name == "mlflow-operator-mlflow-integration"`),
+			jq.Match(`.subjects[0].name == "%s"`, TargetAllocatorServiceAccount),
+			jq.Match(`.subjects[0].namespace == "%s"`, tc.MonitoringNamespace),
+		)),
+		WithCustomErrorMsg("ClusterRoleBinding should bind collector SA to mlflow-integration ClusterRole"),
 	)
 }
 

--- a/tests/e2e/monitoring_test.go
+++ b/tests/e2e/monitoring_test.go
@@ -2910,7 +2910,7 @@ func (tc *MonitoringTestCtx) ValidateCollectorMLflowIntegrationRBAC(t *testing.T
 		withMonitoringTraces(TracesStorageBackendPV, "", TracesStorageSize1Gi, DefaultRetention),
 	)
 
-	// Verify ClusterRoleBinding binds the collector SA to the mlflow-integration ClusterRole
+	// Step 1: Verify ClusterRoleBinding binds the collector SA to the mlflow-integration ClusterRole
 	tc.EnsureResourceExists(
 		WithMinimalObject(gvk.ClusterRoleBinding, types.NamespacedName{
 			Name: "data-science-collector-mlflow-integration",
@@ -2921,6 +2921,18 @@ func (tc *MonitoringTestCtx) ValidateCollectorMLflowIntegrationRBAC(t *testing.T
 			jq.Match(`.subjects[0].namespace == "%s"`, tc.MonitoringNamespace),
 		)),
 		WithCustomErrorMsg("ClusterRoleBinding should bind collector SA to mlflow-integration ClusterRole"),
+	)
+
+	// Step 2: Disable traces and verify ClusterRoleBinding is removed
+	tc.updateMonitoringConfig(
+		withManagementState(operatorv1.Managed),
+		withNoTraces(),
+	)
+
+	tc.EnsureResourceGone(
+		WithMinimalObject(gvk.ClusterRoleBinding, types.NamespacedName{
+			Name: "data-science-collector-mlflow-integration",
+		}),
 	)
 }
 

--- a/tests/e2e/monitoring_test.go
+++ b/tests/e2e/monitoring_test.go
@@ -2900,7 +2900,7 @@ func (tc *MonitoringTestCtx) ValidateTargetAllocatorRBACConfiguration(t *testing
 	)
 }
 
-// ValidateCollectorMLflowIntegrationRBAC tests that the collector SA has the mlflow-integration ClusterRoleBinding.
+// ValidateCollectorMLflowIntegrationRBAC tests that the collector SA has the MLflow trace export ClusterRole and ClusterRoleBinding.
 func (tc *MonitoringTestCtx) ValidateCollectorMLflowIntegrationRBAC(t *testing.T) {
 	t.Helper()
 	t.Cleanup(tc.resetMonitoringConfigToManaged)
@@ -2910,28 +2910,48 @@ func (tc *MonitoringTestCtx) ValidateCollectorMLflowIntegrationRBAC(t *testing.T
 		withMonitoringTraces(TracesStorageBackendPV, "", TracesStorageSize1Gi, DefaultRetention),
 	)
 
-	// Step 1: Verify ClusterRoleBinding binds the collector SA to the mlflow-integration ClusterRole
+	// Step 1: Verify ClusterRole grants only experiments update on mlflow.kubeflow.org
 	tc.EnsureResourceExists(
-		WithMinimalObject(gvk.ClusterRoleBinding, types.NamespacedName{
-			Name: "data-science-collector-mlflow-integration",
+		WithMinimalObject(gvk.ClusterRole, types.NamespacedName{
+			Name: "data-science-collector-mlflow-trace-export",
 		}),
 		WithCondition(And(
-			jq.Match(`.roleRef.name == "mlflow-operator-mlflow-integration"`),
+			jq.Match(`.rules | length == 1`),
+			jq.Match(`.rules[0].apiGroups[0] == "mlflow.kubeflow.org"`),
+			jq.Match(`.rules[0].resources[0] == "experiments"`),
+			jq.Match(`.rules[0].verbs[0] == "update"`),
+		)),
+		WithCustomErrorMsg("ClusterRole should grant only experiments update on mlflow.kubeflow.org"),
+	)
+
+	// Step 2: Verify ClusterRoleBinding binds the collector SA to the trace export ClusterRole
+	tc.EnsureResourceExists(
+		WithMinimalObject(gvk.ClusterRoleBinding, types.NamespacedName{
+			Name: "data-science-collector-mlflow-trace-export",
+		}),
+		WithCondition(And(
+			jq.Match(`.roleRef.name == "data-science-collector-mlflow-trace-export"`),
 			jq.Match(`.subjects[0].name == "%s"`, TargetAllocatorServiceAccount),
 			jq.Match(`.subjects[0].namespace == "%s"`, tc.MonitoringNamespace),
 		)),
-		WithCustomErrorMsg("ClusterRoleBinding should bind collector SA to mlflow-integration ClusterRole"),
+		WithCustomErrorMsg("ClusterRoleBinding should bind collector SA to mlflow trace export ClusterRole"),
 	)
 
-	// Step 2: Disable traces and verify ClusterRoleBinding is removed
+	// Step 3: Disable traces and verify both resources are removed
 	tc.updateMonitoringConfig(
 		withManagementState(operatorv1.Managed),
 		withNoTraces(),
 	)
 
 	tc.EnsureResourceGone(
+		WithMinimalObject(gvk.ClusterRole, types.NamespacedName{
+			Name: "data-science-collector-mlflow-trace-export",
+		}),
+	)
+
+	tc.EnsureResourceGone(
 		WithMinimalObject(gvk.ClusterRoleBinding, types.NamespacedName{
-			Name: "data-science-collector-mlflow-integration",
+			Name: "data-science-collector-mlflow-trace-export",
 		}),
 	)
 }


### PR DESCRIPTION
## Description

When tracing is enabled via DSCI spec.monitoring.traces, the monitoring controller provisions the OTel Collector and its ServiceAccount. To support trace export to MLflow via /v1/traces, the collector SA needs the experiments update permission required by MLflow's kubernetes-auth plugin. This PR adds a ClusterRole and ClusterRoleBinding template to the monitoring controller to provide that access.

Add `collector-mlflow-rbac.tmpl.yaml` gated on `monitoring.Spec.Traces != nil`, creating a ClusterRole and ClusterRoleBinding that binds the ClusterRole permissions to the collector SA (data-science-collector-collector). Follows the existing `collector-rbac.tmpl.yaml` pattern, owned by the Monitoring CR.

**JIRA:** [RHOAIENG-68229](https://redhat.atlassian.net/browse/RHOAIENG-68229)
**Parent feature:** [RHAISTRAT-133](https://redhat.atlassian.net/browse/RHAISTRAT-133)
**Spike:** [RHOAIENG-61346](https://redhat.atlassian.net/browse/RHOAIENG-61346)

## How Has This Been Tested?

Isolated verification on ODH cluster (and a RHOAI cluster with 3.5 ea.2):
1. Observe that without the CRB, OTel Collector exported traces to MLflow /v1/traces → 403 Forbidden
2. After deploying these changes and allowing CRB to get auto created by monitoring controller → traces accepted at 200 OK

Template verification:
- CR & CRB created by monitoring controller when spec.monitoring.traces is enabled in DSCI
- CR & CRB owned by the Monitoring CR (proper lifecycle management)
- Toggled DSCI traces off and back on — CR & CRB recreated correctly

**E2E test added:**
- `ValidateCollectorMLflowIntegrationRBAC` — verifies ClusterRole and ClusterRoleBinding is created/removed with correct roleRef and subjects

## Merge criteria

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully
- [ ] New RELATED_IMAGE mappings are listed in ODH-Build-Config and RHOAI-Build-Config (CI validates names against build-config repos). Include links to build-config PRs in the description.

### E2E test suite update requirement

E2E test added in `tests/e2e/monitoring_test.go`:
- `ValidateCollectorMLflowIntegrationRBAC` — verifies ClusterRole and ClusterRoleBinding for MLflow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **New Features**
  * Added MLflow integration RBAC for the monitoring collector, including a dedicated `ClusterRole` and `ClusterRoleBinding`.

* **Behavior Updates**
  * The MLflow RBAC resources are now applied only when tracing is enabled; existing OpenTelemetry collector and metrics-related RBAC behavior remains unchanged.

* **Tests**
  * Added end-to-end validation to confirm the MLflow RBAC role/binding are created with the correct permissions when tracing is enabled and removed when tracing is disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[RHOAIENG-68229]: https://redhat.atlassian.net/browse/RHOAIENG-68229?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RHAISTRAT-133]: https://redhat.atlassian.net/browse/RHAISTRAT-133?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[RHOAIENG-61346]: https://redhat.atlassian.net/browse/RHOAIENG-61346?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ