### PR TITLE
RHOAIENG 56111: Fix clusterVersion History[0] from panicking when empty 

### DIFF
--- a/pkg/cluster/cluster_config.go
+++ b/pkg/cluster/cluster_config.go
@@ -185,6 +185,9 @@ func getOCPVersion(ctx context.Context, c client.Client) (version.OperatorVersio
 	}, clusterVersion); err != nil {
 		return version.OperatorVersion{}, fmt.Errorf("unable to get OCP version: %w", err)
 	}
+	if len(clusterVersion.Status.History) == 0 {
+		return version.OperatorVersion{}, errors.New("cluster version history is empty")
+	}
 	v, err := semver.ParseTolerant(clusterVersion.Status.History[0].Version)
 	if err != nil {
 		return version.OperatorVersion{}, fmt.Errorf("unable to parse OCP version: %w", err)

--- a/pkg/cluster/cluster_config_internal_test.go
+++ b/pkg/cluster/cluster_config_internal_test.go
@@ -2,8 +2,10 @@ package cluster
 
 import (
 	"context"
+	"strings"
 	"testing"
 
+	configv1 "github.com/openshift/api/config/v1"
 	"github.com/spf13/viper"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -388,6 +390,86 @@ func TestApplicationNamespaceFallback(t *testing.T) {
 			}
 			if result != tc.expectedNamespace {
 				t.Errorf("ApplicationNamespace() = %q, want %q", result, tc.expectedNamespace)
+			}
+		})
+	}
+}
+
+func TestGetOCPVersion(t *testing.T) {
+	testCases := []struct {
+		name        string
+		history     []configv1.UpdateHistory
+		expectError string
+		expectVer   string
+	}{
+		{
+			name:        "returns error when history is empty",
+			history:     []configv1.UpdateHistory{},
+			expectError: "cluster version history is empty",
+		},
+		{
+			name:        "returns error when history is nil",
+			history:     nil,
+			expectError: "cluster version history is empty",
+		},
+		{
+			name: "parses version from first history entry",
+			history: []configv1.UpdateHistory{
+				{Version: "4.16.3"},
+			},
+			expectVer: "4.16.3",
+		},
+		{
+			name: "uses first entry when multiple exist",
+			history: []configv1.UpdateHistory{
+				{Version: "4.16.3"},
+				{Version: "4.15.0"},
+			},
+			expectVer: "4.16.3",
+		},
+		{
+			name: "returns error when version is unparseable",
+			history: []configv1.UpdateHistory{
+				{Version: "not-a-version"},
+			},
+			expectError: "unable to parse OCP version",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			scheme := runtime.NewScheme()
+			_ = configv1.Install(scheme)
+
+			cv := &configv1.ClusterVersion{
+				ObjectMeta: metav1.ObjectMeta{Name: OpenShiftVersionObj},
+				Status: configv1.ClusterVersionStatus{
+					History: tc.history,
+				},
+			}
+
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(cv).
+				Build()
+
+			result, err := getOCPVersion(context.Background(), fakeClient)
+
+			if tc.expectError != "" {
+				if err == nil {
+					t.Fatalf("Expected error containing %q, got nil", tc.expectError)
+				}
+				if !strings.Contains(err.Error(), tc.expectError) {
+					t.Errorf("Error = %q, want substring %q", err.Error(), tc.expectError)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+			if result.String() != tc.expectVer {
+				t.Errorf("Version = %q, want %q", result.String(), tc.expectVer)
 			}
 		})
 	}


### PR DESCRIPTION
<!---
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

JIRA: https://redhat.atlassian.net/browse/RHOAIENG-56111

getOCPVersion as of current accesses clusterVersion.Status.History[0] without firstly checking if the slice is not empty. This arises issue with freshly provisioned clusters or upgrades where the history has not been populated yet, which then goes to cause an index-out-of-range panic that would crash the controller.

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->



Unit tests added covering all return paths in getOCPVersion:
  - Empty history slice
  - Nil history slice
  - Valid single version entry
  - Multiple history entries (verifies first is used)
  - Unparseable version string
  - Make build and lint run fine without issue.


## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully
- [ ] New RELATED_IMAGE mappings are listed in ODH-Build-Config and RHOAI-Build-Config (CI validates names against build-config repos). Include links to build-config PRs in the description.

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->

No new e2e tests are needed to be added as there's no major behavioral change, just a guard on a internal function.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cluster version detection to handle empty version history safely, avoiding crashes when no history is available.
  * Added clearer error reporting when version information is missing or cannot be parsed.
* **Tests**
  * Expanded test coverage for version parsing across empty, nil, valid, and invalid history scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->