### PR TITLE
fix: add apply ordering to mlflow and kuberay component controllers

### DIFF
--- a/internal/controller/components/modelsasservice/modelsasservice_controller.go
+++ b/internal/controller/components/modelsasservice/modelsasservice_controller.go
@@ -76,7 +76,6 @@ func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.
 		WithAction(precondition.RunlevelGateAction()).
 		WithAction(renderMaasOperatorInstall).
 		WithAction(deploy.NewAction(
-			deploy.WithApplyOrder(),
 			deploy.WithCache(),
 		)).
 		WithAction(ensureMaasClusterConfigControllerRef).

--- a/pkg/controller/actions/deploy/action_deploy.go
+++ b/pkg/controller/actions/deploy/action_deploy.go
@@ -137,8 +137,9 @@ func WithSortFn(fn SortFn) ActionOpts {
 	}
 }
 
-// WithApplyOrder is a convenience option that sorts resources into
-// dependency order (CRDs first, webhooks last) before deploying.
+// WithApplyOrder explicitly sets SortByApplyOrder as the sort function.
+// This is now the default for NewAction, so callers only need this if
+// the default was previously overridden by WithSortFn(nil).
 func WithApplyOrder() ActionOpts {
 	return WithSortFn(resources.SortByApplyOrder)
 }
@@ -678,6 +679,7 @@ func NewAction(opts ...ActionOpts) actions.Fn {
 		deployMode:       ModeSSA,
 		partOfLabelKey:   labels.PlatformPartOf,
 		annotationPrefix: labels.ODHPlatformPrefix,
+		sortFn:           resources.SortByApplyOrder,
 	}
 
 	for _, opt := range opts {

--- a/pkg/controller/actions/deploy/action_deploy_test.go
+++ b/pkg/controller/actions/deploy/action_deploy_test.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/blang/semver/v4"
 	"github.com/onsi/gomega/gstruct"
@@ -850,6 +851,20 @@ func TestDeployOwnerRef(t *testing.T) {
 
 	err = cli.Create(ctx, crd.DeepCopy())
 	g.Expect(err).ToNot(HaveOccurred())
+
+	// Wait for the CRD to be established by the API server's CRD controller
+	// before running deploy, otherwise the controller's status update can
+	// conflict with our owner reference removal (resourceVersion mismatch).
+	g.Eventually(func(g Gomega) {
+		established := &apiextensionsv1.CustomResourceDefinition{}
+		g.Expect(cli.Get(ctx, client.ObjectKeyFromObject(crdRef), established)).To(Succeed())
+		for _, c := range established.Status.Conditions {
+			if c.Type == apiextensionsv1.Established && c.Status == apiextensionsv1.ConditionTrue {
+				return
+			}
+		}
+		g.Expect(false).To(BeTrue(), "CRD not yet established")
+	}).WithTimeout(10 * time.Second).WithPolling(100 * time.Millisecond).Should(Succeed())
 
 	//
 	// deploy


### PR DESCRIPTION
## Description

Make `deploy.WithApplyOrder()` the default for all component controllers by setting `SortByApplyOrder` as the default sort function in `deploy.NewAction()`.

Previously, only 4 of 16 component controllers opted into apply ordering (kserve, modelsasservice, mlflow, ray). The remaining 12 deployed resources in arbitrary kustomize output order. If a Deployment was applied before its Service, service-ca hadn't seen the annotation yet and the cert secret didn't exist, causing `FailedMount` errors in nightly smoke tests.

This change ensures all controllers get dependency-ordered resource application (CRDs first, Services before Deployments, webhooks last) without requiring each one to remember the `WithApplyOrder()` option.

Controllers with custom ordering (kserve chains `SortByApplyOrder` with `sortLLMInferenceServiceConfigLast`) continue to work because `WithSortFn` replaces the default sort function.

Companion PRs (optional: true on secret volumes as defense-in-depth):
- mlflow-operator: opendatahub-io/mlflow-operator#158
- kuberay: opendatahub-io/kuberay#208
- kserve/llmisvc: opendatahub-io/kserve#1689

[RHOAIENG-72306](https://issues.redhat.com/browse/RHOAIENG-72306)

## How Has This Been Tested?

- `go build` passes
- All deploy action unit tests pass (fakeclient-based tests, envtest-based tests need cluster)
- `SortByApplyOrder` unit tests pass (11 subtests covering standard ordering, cert-manager ordering, edge cases)
- Verified kserve's custom `WithSortFn` correctly overrides the default

## Screenshot or short clip

N/A (backend change, no UI impact)

## Merge criteria

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully
- [ ] New RELATED_IMAGE mappings are listed in ODH-Build-Config and RHOAI-Build-Config (CI validates names against build-config repos). Include links to build-config PRs in the description.

### E2E test suite update requirement

- [x] Skip requirement to update E2E test suite for this PR

#### E2E update requirement opt-out justification

This change only reorders the application sequence of already-deployed resources. No new resources or APIs are added. The sort function (`SortByApplyOrder`) already has comprehensive unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Deployment actions now default to ordering aligned with apply/dependency order, improving consistency across reconciliation runs.
  * Reconciliation deploy now uses a cached configuration path, making deployments more consistent.
* **Tests**
  * Updated deploy tests to wait until the CRD is fully established before executing deployment steps, reducing timing-related flakiness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->