### PR TITLE
Fix manifests-config.yaml for MCPLO and AI Gateway

### DIFF
--- a/build/manifests-config.yaml
+++ b/build/manifests-config.yaml
@@ -67,8 +67,8 @@ map:
     src: kagenti-operator/config
     dest: kagenti-operator
   odh-ai-gateway-operator:
-    src: config/manifests
-    dest: ai-gateway-operator
+    src: config
+    dest: aigateway
   odh-batch-gateway-operator:
     src: config/
     dest: batch-gateway-operator
@@ -76,5 +76,5 @@ map:
     src: workspaces/controller/manifests/kustomize
     dest: workbenches/odh-workbenches-controller
   odh-mcp-lifecycle-module-operator:
-    src: config/manifests
-    dest: mcp-lifecycle-module-operator
+    src: config
+    dest: mcplifecycleoperator


### PR DESCRIPTION
## Description
This aligns AI Gateway with [RHOAI configuration](https://github.com/red-hat-data-services/rhods-operator/blob/main/build/manifests-config.yaml#L59-L61)
And changes MCPLO to `mcplifecycleoperator` (without hyphens) to have it uniform with other components.
## How Has This Been Tested?
ODH Nightly doesn't work for AI Gateway, this should fix it.


## Merge criteria

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully
- [ ] New RELATED_IMAGE mappings are listed in ODH-Build-Config and RHOAI-Build-Config (CI validates names against build-config repos). Include links to build-config PRs in the description.

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated component packaging mappings so two operators are published from the correct source location and to the expected output names.
  * No functional product behavior changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->