### PR TITLE
test(kserve): assert RHCL-missing condition is Info severity with auth-disable guidance

### DIFF
--- a/internal/controller/components/kserve/kserve_controller_dependency_test.go
+++ b/internal/controller/components/kserve/kserve_controller_dependency_test.go
@@ -224,8 +224,20 @@ func TestSubscriptionDependencyMonitoring(t *testing.T) {
 				LLMInferenceServiceWideEPDependencies, metav1.ConditionFalse),
 		))
 
+		// Conditions must be Info severity — they are advisory, not blockers (RHOAIENG-68944).
+		wt.Get(gvk.Kserve, nn).Eventually().Should(And(
+			jq.Match(`.status.conditions[] | select(.type == "%s") | .severity == "%s"`,
+				LLMInferenceServiceDependencies, common.ConditionSeverityInfo),
+			jq.Match(`.status.conditions[] | select(.type == "%s") | .severity == "%s"`,
+				LLMInferenceServiceWideEPDependencies, common.ConditionSeverityInfo),
+		))
+
+		// The RHCL-missing message must include self-documenting guidance on how to deploy
+		// LLMInferenceService without authentication (RHOAIENG-68944).
 		wt.Get(gvk.Kserve, nn).Eventually().Should(And(
 			jq.Match(`.status.conditions[] | select(.type == "%s") | .message | contains("Red Hat Connectivity Link")`,
+				LLMInferenceServiceDependencies),
+			jq.Match(`.status.conditions[] | select(.type == "%s") | .message | contains("enable-auth")`,
 				LLMInferenceServiceDependencies),
 			jq.Match(`.status.conditions[] | select(.type == "%s") | .message | contains("cert-manager operator")`,
 				LLMInferenceServiceDependencies),


### PR DESCRIPTION
## Summary

Adds regression-guard assertions to the `TestSubscriptionDependencyMonitoring` test for the `KserveLLMInferenceServiceDependencies` and `KserveLLMInferenceServiceWideEPDependencies` DSC conditions.

Two things are now verified:

1. **Severity is Info** — both LLMISVC dependency conditions must carry `ConditionSeverityInfo`. This prevents a future regression where someone accidentally promotes them to a blocking severity, which would be wrong: RHCL absence should be advisory, not a reconciliation blocker.

2. **RHCL-missing message includes auth-disable guidance** — the `LLMInferenceServiceDependencies` message must contain both `"Red Hat Connectivity Link"` and `"enable-auth"`. This ensures the `rhclMissingMessage` constant (updated in the companion fix) stays self-documenting: users must be able to read the DSC condition and know how to deploy `LLMInferenceService` without authentication.

## Context

`LLMInferenceService` can be used without RHCL by annotating the resource with `security.opendatahub.io/enable-auth: 'false'`. The previous DSC warning message did not mention this, leaving users with the incorrect impression that RHCL was a hard requirement. The message was updated in a companion change; this test locks in that behavior going forward.

Both conditions use `common.ConditionSeverityInfo` and neither gates reconciliation via `RunlevelGateAction` — they are purely informational hints to the cluster admin.

## Test plan

- `go test ./internal/controller/components/kserve/... -run TestSubscriptionDependencyMonitoring` passes (all 5 subtests green)