### PR TITLE
fix(modelsasservice): extend NetworkPolicy to cover payload-pre-processing

### DIFF
--- a/internal/controller/components/modelsasservice/modelsasservice_controller.go
+++ b/internal/controller/components/modelsasservice/modelsasservice_controller.go
@@ -85,6 +85,7 @@ func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.
 			deployments.WithSelectorLabel(labels.ODH.Component(componentApi.ModelsAsServiceComponentName), labels.True),
 		)).
 		WithAction(gc.NewAction()).
+		WithAction(cleanupGatewayNamespaceResources).
 		WithConditions(conditionTypes...).
 		Build(ctx)
 

--- a/internal/controller/components/modelsasservice/modelsasservice_controller_actions.go
+++ b/internal/controller/components/modelsasservice/modelsasservice_controller_actions.go
@@ -20,7 +20,13 @@ import (
 	"context"
 	"fmt"
 
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/api/components/v1alpha1"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/metadata/labels"
 	odhtypes "github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
 )
 
@@ -38,6 +44,63 @@ func renderMaasOperatorInstall(ctx context.Context, rr *odhtypes.ReconciliationR
 	rr.Resources = nil
 	if err := rr.AddResources(out...); err != nil {
 		return fmt.Errorf("add maas-controller install manifest: %w", err)
+	}
+
+	return nil
+}
+
+// cleanupGatewayNamespaceResources deletes resources in the gateway namespace
+// that have the MaaS component label but are no longer in the rendered manifests.
+// Standard gc.NewAction() only covers the operator namespace; resources deployed
+// cross-namespace (e.g. payload-processing in openshift-ingress) need explicit cleanup.
+func cleanupGatewayNamespaceResources(ctx context.Context, rr *odhtypes.ReconciliationRequest) error {
+	l := log.FromContext(ctx)
+	componentLabel := labels.ODH.Component(componentApi.ModelsAsServiceComponentName)
+
+	// Build set of expected resources from the current rendered manifests.
+	type objKey struct {
+		gvk       schema.GroupVersionKind
+		namespace string
+		name      string
+	}
+	expected := make(map[objKey]bool)
+	for i := range rr.Resources {
+		res := &rr.Resources[i]
+		if res.GetNamespace() == DefaultGatewayNamespace {
+			expected[objKey{gvk: res.GroupVersionKind(), namespace: res.GetNamespace(), name: res.GetName()}] = true
+		}
+	}
+
+	// GVKs to scan in the gateway namespace.
+	gvks := []schema.GroupVersionKind{
+		{Group: "apps", Version: "v1", Kind: "Deployment"},
+		{Version: "v1", Kind: "Service"},
+		{Version: "v1", Kind: "ServiceAccount"},
+		{Version: "v1", Kind: "ConfigMap"},
+		{Group: "networking.k8s.io", Version: "v1", Kind: "NetworkPolicy"},
+	}
+
+	for _, gvk := range gvks {
+		list := &unstructured.UnstructuredList{}
+		list.SetGroupVersionKind(gvk)
+		if err := rr.Client.List(ctx, list,
+			client.InNamespace(DefaultGatewayNamespace),
+			client.MatchingLabels{componentLabel: labels.True},
+		); err != nil {
+			continue
+		}
+		for i := range list.Items {
+			item := &list.Items[i]
+			k := objKey{gvk: item.GroupVersionKind(), namespace: item.GetNamespace(), name: item.GetName()}
+			if expected[k] {
+				continue
+			}
+			l.Info("deleting stale gateway namespace resource",
+				"kind", item.GetKind(), "name", item.GetName(), "ns", item.GetNamespace())
+			if err := rr.Client.Delete(ctx, item); client.IgnoreNotFound(err) != nil {
+				return fmt.Errorf("delete stale %s %s/%s: %w", item.GetKind(), item.GetNamespace(), item.GetName(), err)
+			}
+		}
 	}
 
 	return nil

--- a/internal/controller/components/modelsasservice/modelsasservice_controller_actions.go
+++ b/internal/controller/components/modelsasservice/modelsasservice_controller_actions.go
@@ -26,8 +26,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/api/components/v1alpha1"
-	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/metadata/labels"
 	odhtypes "github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/metadata/labels"
 )
 
 func renderMaasOperatorInstall(ctx context.Context, rr *odhtypes.ReconciliationRequest) error {
@@ -54,6 +54,10 @@ func renderMaasOperatorInstall(ctx context.Context, rr *odhtypes.ReconciliationR
 // Standard gc.NewAction() only covers the operator namespace; resources deployed
 // cross-namespace (e.g. payload-processing in openshift-ingress) need explicit cleanup.
 func cleanupGatewayNamespaceResources(ctx context.Context, rr *odhtypes.ReconciliationRequest) error {
+	if rr.SkipDeploy {
+		return nil
+	}
+
 	l := log.FromContext(ctx)
 	componentLabel := labels.ODH.Component(componentApi.ModelsAsServiceComponentName)
 
@@ -87,7 +91,7 @@ func cleanupGatewayNamespaceResources(ctx context.Context, rr *odhtypes.Reconcil
 			client.InNamespace(DefaultGatewayNamespace),
 			client.MatchingLabels{componentLabel: labels.True},
 		); err != nil {
-			continue
+			return fmt.Errorf("list gateway namespace %s resources: %w", gvk.String(), err)
 		}
 		for i := range list.Items {
 			item := &list.Items[i]

--- a/internal/controller/components/modelsasservice/modelsasservice_support.go
+++ b/internal/controller/components/modelsasservice/modelsasservice_support.go
@@ -191,6 +191,8 @@ func buildMaasOperatorInstallManifests(ctx context.Context, rr *odhtypes.Reconci
 	}
 	extra = append(extra, *paramsCM)
 
+	extra = append(extra, payloadProcessingNetworkPolicy(componentLabels))
+
 	out := make([]client.Object, len(extra))
 	for i := range extra {
 		out[i] = &extra[i]
@@ -239,6 +241,92 @@ func maasParametersConfigMapFromParamsEnv(manifestsBasePath string, appNs string
 		},
 	}
 	return cm, nil
+}
+
+// payloadProcessingNetworkPolicy returns a NetworkPolicy for the
+// payload-processing pod in the gateway namespace. OCP 4.22 introduced a
+// deny-all NetworkPolicy in openshift-ingress; without explicit rules the pod
+// cannot reach the Kubernetes API server (egress) or receive ext_proc calls
+// from the gateway (ingress).
+func payloadProcessingNetworkPolicy(componentLabels map[string]string) unstructured.Unstructured {
+	npLabels := make(map[string]any, len(componentLabels)+1)
+	for k, v := range componentLabels {
+		npLabels[k] = v
+	}
+	npLabels["app"] = "payload-processing"
+
+	return unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "networking.k8s.io/v1",
+			"kind":       "NetworkPolicy",
+			"metadata": map[string]any{
+				"name":      "payload-processing",
+				"namespace": DefaultGatewayNamespace,
+				"labels":    npLabels,
+			},
+			"spec": map[string]any{
+				"podSelector": map[string]any{
+					"matchLabels": map[string]any{
+						"app": "payload-processing",
+					},
+				},
+				"policyTypes": []any{"Ingress", "Egress"},
+				"ingress": []any{
+					map[string]any{
+						"from": []any{
+							map[string]any{
+								"podSelector": map[string]any{
+									"matchLabels": map[string]any{
+										"gateway.networking.k8s.io/gateway-name": "data-science-gateway",
+									},
+								},
+								"namespaceSelector": map[string]any{
+									"matchLabels": map[string]any{
+										"kubernetes.io/metadata.name": DefaultGatewayNamespace,
+									},
+								},
+							},
+						},
+						"ports": []any{
+							map[string]any{
+								"protocol": "TCP",
+								"port":     int64(9004),
+							},
+						},
+					},
+					map[string]any{
+						"from": []any{
+							map[string]any{
+								"namespaceSelector": map[string]any{
+									"matchLabels": map[string]any{
+										"kubernetes.io/metadata.name": "openshift-monitoring",
+									},
+								},
+							},
+							map[string]any{
+								"namespaceSelector": map[string]any{
+									"matchLabels": map[string]any{
+										"kubernetes.io/metadata.name": "openshift-user-workload-monitoring",
+									},
+								},
+							},
+						},
+						"ports": []any{
+							map[string]any{
+								"protocol": "TCP",
+								"port":     int64(9005),
+							},
+							map[string]any{
+								"protocol": "TCP",
+								"port":     int64(9090),
+							},
+						},
+					},
+				},
+				"egress": []any{map[string]any{}},
+			},
+		},
+	}
 }
 
 // parseParamsEnv reads a key=value env file, skipping comments and blank lines.
@@ -296,6 +384,7 @@ var gatewayNamespaceResources = map[resourceKey]bool{
 	{kind: "Service", name: "payload-processing"}:                   true,
 	{kind: "ServiceAccount", name: "payload-processing"}:            true,
 	{kind: "ConfigMap", name: "payload-processing-plugins"}:         true,
+	{kind: "NetworkPolicy", name: "payload-processing"}:             true,
 	{kind: "ClusterRoleBinding", name: "payload-processing-reader"}: true,
 }
 

--- a/internal/controller/components/modelsasservice/modelsasservice_support.go
+++ b/internal/controller/components/modelsasservice/modelsasservice_support.go
@@ -243,11 +243,11 @@ func maasParametersConfigMapFromParamsEnv(manifestsBasePath string, appNs string
 	return cm, nil
 }
 
-// payloadProcessingNetworkPolicy returns a NetworkPolicy for the
-// payload-processing pod in the gateway namespace. OCP 4.22 introduced a
-// deny-all NetworkPolicy in openshift-ingress; without explicit rules the pod
-// cannot reach the Kubernetes API server (egress) or receive ext_proc calls
-// from the gateway (ingress).
+// payloadProcessingNetworkPolicy returns a NetworkPolicy for both the
+// payload-processing and payload-pre-processing pods in the gateway namespace.
+// OCP 4.22 introduced a deny-all NetworkPolicy in openshift-ingress; without
+// explicit rules the pods cannot reach the Kubernetes API server (egress) or
+// receive ext_proc calls from the gateway (ingress).
 func payloadProcessingNetworkPolicy(componentLabels map[string]string) unstructured.Unstructured {
 	npLabels := make(map[string]any, len(componentLabels)+1)
 	for k, v := range componentLabels {
@@ -266,8 +266,12 @@ func payloadProcessingNetworkPolicy(componentLabels map[string]string) unstructu
 			},
 			"spec": map[string]any{
 				"podSelector": map[string]any{
-					"matchLabels": map[string]any{
-						"app": "payload-processing",
+					"matchExpressions": []any{
+						map[string]any{
+							"key":      "app",
+							"operator": "In",
+							"values":   []any{"payload-processing", "payload-pre-processing"},
+						},
 					},
 				},
 				"policyTypes": []any{"Ingress", "Egress"},
@@ -381,7 +385,9 @@ type resourceKey struct {
 // kind+name to avoid accidentally matching unrelated resources.
 var gatewayNamespaceResources = map[resourceKey]bool{
 	{kind: "Deployment", name: "payload-processing"}:                true,
+	{kind: "Deployment", name: "payload-pre-processing"}:            true,
 	{kind: "Service", name: "payload-processing"}:                   true,
+	{kind: "Service", name: "payload-pre-processing"}:               true,
 	{kind: "ServiceAccount", name: "payload-processing"}:            true,
 	{kind: "ConfigMap", name: "payload-processing-plugins"}:         true,
 	{kind: "NetworkPolicy", name: "payload-processing"}:             true,

--- a/internal/controller/components/modelsasservice/modelsasservice_support_test.go
+++ b/internal/controller/components/modelsasservice/modelsasservice_support_test.go
@@ -56,6 +56,13 @@ metadata:
   name: payload-processing-plugins
   namespace: redhat-ods-applications
 `,
+		`
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: payload-processing
+  namespace: redhat-ods-applications
+`,
 		// Unrelated resource that should NOT be moved
 		`
 apiVersion: apps/v1
@@ -178,6 +185,50 @@ roleRef:
 		g.Expect(subj["namespace"]).To(Equal("openshift-ingress"),
 			"subjects[%d].namespace should be restored", i)
 	}
+}
+
+func TestPayloadProcessingNetworkPolicy(t *testing.T) {
+	g := NewWithT(t)
+
+	labels := map[string]string{
+		"opendatahub.io/component":  "true",
+		"app.kubernetes.io/part-of": "modelsasservice",
+	}
+
+	np := payloadProcessingNetworkPolicy(labels)
+
+	g.Expect(np.GetKind()).To(Equal("NetworkPolicy"))
+	g.Expect(np.GetName()).To(Equal("payload-processing"))
+	g.Expect(np.GetNamespace()).To(Equal(DefaultGatewayNamespace))
+
+	npLabels := np.GetLabels()
+	g.Expect(npLabels).To(HaveKeyWithValue("app", "payload-processing"))
+	g.Expect(npLabels).To(HaveKeyWithValue("opendatahub.io/component", "true"))
+	g.Expect(npLabels).To(HaveKeyWithValue("app.kubernetes.io/part-of", "modelsasservice"))
+
+	spec, ok := np.Object["spec"].(map[string]any)
+	g.Expect(ok).To(BeTrue(), "spec should be a map")
+
+	podSelector, ok := spec["podSelector"].(map[string]any)
+	g.Expect(ok).To(BeTrue(), "podSelector should be a map")
+	matchLabels, ok := podSelector["matchLabels"].(map[string]any)
+	g.Expect(ok).To(BeTrue(), "matchLabels should be a map")
+	g.Expect(matchLabels).To(HaveKeyWithValue("app", "payload-processing"))
+
+	policyTypes, ok := spec["policyTypes"].([]any)
+	g.Expect(ok).To(BeTrue(), "policyTypes should be an array")
+	g.Expect(policyTypes).To(ConsistOf("Ingress", "Egress"))
+
+	// Verify egress allows all outbound traffic
+	egress, ok := spec["egress"].([]any)
+	g.Expect(ok).To(BeTrue(), "egress should be an array")
+	g.Expect(egress).To(HaveLen(1))
+	g.Expect(egress[0]).To(Equal(map[string]any{}))
+
+	// Verify ingress rules: gateway on 9004, monitoring on 9090
+	ingress, ok := spec["ingress"].([]any)
+	g.Expect(ok).To(BeTrue(), "ingress should be an array")
+	g.Expect(ingress).To(HaveLen(2))
 }
 
 func TestRestoreCRBSubjectsNamespace_NoSubjects(t *testing.T) {

--- a/internal/controller/components/modelsasservice/modelsasservice_support_test.go
+++ b/internal/controller/components/modelsasservice/modelsasservice_support_test.go
@@ -211,9 +211,14 @@ func TestPayloadProcessingNetworkPolicy(t *testing.T) {
 
 	podSelector, ok := spec["podSelector"].(map[string]any)
 	g.Expect(ok).To(BeTrue(), "podSelector should be a map")
-	matchLabels, ok := podSelector["matchLabels"].(map[string]any)
-	g.Expect(ok).To(BeTrue(), "matchLabels should be a map")
-	g.Expect(matchLabels).To(HaveKeyWithValue("app", "payload-processing"))
+	matchExpressions, ok := podSelector["matchExpressions"].([]any)
+	g.Expect(ok).To(BeTrue(), "matchExpressions should be an array")
+	g.Expect(matchExpressions).To(HaveLen(1))
+	expr, ok := matchExpressions[0].(map[string]any)
+	g.Expect(ok).To(BeTrue())
+	g.Expect(expr["key"]).To(Equal("app"))
+	g.Expect(expr["operator"]).To(Equal("In"))
+	g.Expect(expr["values"]).To(ConsistOf("payload-processing", "payload-pre-processing"))
 
 	policyTypes, ok := spec["policyTypes"].([]any)
 	g.Expect(ok).To(BeTrue(), "policyTypes should be an array")

--- a/tests/e2e/modelsasservice_test.go
+++ b/tests/e2e/modelsasservice_test.go
@@ -315,8 +315,8 @@ func (tc *ModelsAsServiceTestCtx) ValidateTenantSingletonEnforcement(t *testing.
 }
 
 // ValidatePayloadProcessingNetworkPolicy verifies that the NetworkPolicy for
-// payload-processing exists in the gateway namespace with correct ingress and
-// egress rules.
+// payload-processing and payload-pre-processing exists in the gateway namespace
+// with correct ingress and egress rules.
 func (tc *ModelsAsServiceTestCtx) ValidatePayloadProcessingNetworkPolicy(t *testing.T) {
 	t.Helper()
 	skipUnless(t, Tier1)
@@ -329,7 +329,10 @@ func (tc *ModelsAsServiceTestCtx) ValidatePayloadProcessingNetworkPolicy(t *test
 			Namespace: maasGatewayNamespace,
 		}),
 		WithCondition(And(
-			jq.Match(`.spec.podSelector.matchLabels.app == "payload-processing"`),
+			jq.Match(`.spec.podSelector.matchExpressions | length == 1`),
+			jq.Match(`.spec.podSelector.matchExpressions[0].key == "app"`),
+			jq.Match(`.spec.podSelector.matchExpressions[0].operator == "In"`),
+			jq.Match(`.spec.podSelector.matchExpressions[0].values | sort == ["payload-pre-processing", "payload-processing"]`),
 			jq.Match(`.spec.policyTypes | any(. == "Ingress")`),
 			jq.Match(`.spec.policyTypes | any(. == "Egress")`),
 			jq.Match(`.spec.ingress | length == 2`),

--- a/tests/e2e/modelsasservice_test.go
+++ b/tests/e2e/modelsasservice_test.go
@@ -79,6 +79,7 @@ func modelsAsServiceTestSuite(t *testing.T) {
 		{"Validate Tenant CR in subscription namespace", componentCtx.ValidateTenantInSubscriptionNamespace},
 		{"Validate Tenant CRD is namespace-scoped", componentCtx.ValidateTenantCRDNamespaceScoped},
 		{"Validate Tenant singleton enforcement", componentCtx.ValidateTenantSingletonEnforcement},
+		{"Validate payload-processing egress NetworkPolicy", componentCtx.ValidatePayloadProcessingNetworkPolicy},
 		{"Validate Tenant deleted on disable", componentCtx.ValidateTenantDeletedOnDisable},
 	}
 
@@ -311,6 +312,32 @@ func (tc *ModelsAsServiceTestCtx) ValidateTenantSingletonEnforcement(t *testing.
 	t.Cleanup(func() {
 		_ = tc.Client().Delete(tc.Context(), u)
 	})
+}
+
+// ValidatePayloadProcessingNetworkPolicy verifies that the NetworkPolicy for
+// payload-processing exists in the gateway namespace with correct ingress and
+// egress rules.
+func (tc *ModelsAsServiceTestCtx) ValidatePayloadProcessingNetworkPolicy(t *testing.T) {
+	t.Helper()
+	skipUnless(t, Tier1)
+
+	t.Logf("Validating NetworkPolicy for payload-processing in %s", maasGatewayNamespace)
+
+	tc.EnsureResourceExists(
+		WithMinimalObject(gvk.NetworkPolicy, types.NamespacedName{
+			Name:      "payload-processing",
+			Namespace: maasGatewayNamespace,
+		}),
+		WithCondition(And(
+			jq.Match(`.spec.podSelector.matchLabels.app == "payload-processing"`),
+			jq.Match(`.spec.policyTypes | any(. == "Ingress")`),
+			jq.Match(`.spec.policyTypes | any(. == "Egress")`),
+			jq.Match(`.spec.ingress | length == 2`),
+			jq.Match(`.spec.egress | length == 1`),
+			jq.Match(`.spec.egress[0] == {}`),
+		)),
+		WithCustomErrorMsg("NetworkPolicy should exist with correct ingress and egress rules for payload-processing in %s", maasGatewayNamespace),
+	)
 }
 
 // ValidateTenantDeletedOnDisable verifies that the Tenant CR is deleted when MaaS is set to


### PR DESCRIPTION
## Summary
- Extend the payload-processing NetworkPolicy to also cover `payload-pre-processing` pods, which were introduced in 3.5EA2
- Switch `podSelector` from `matchLabels` to `matchExpressions` with `In` operator to match both `payload-processing` and `payload-pre-processing` in a single NetworkPolicy
- Add `payload-pre-processing` Deployment and Service to the gateway namespace resource allowlist

Builds on top of #3699. Without this change, `payload-pre-processing` pods will CrashLoopBackOff on OCP 4.22 due to the deny-all NetworkPolicy in `openshift-ingress`.

## Test plan
- [x] Unit tests pass (`TestPayloadProcessingNetworkPolicy`, `TestRestoreGatewayNamespaceResources`)
- [ ] E2e: `ValidatePayloadProcessingNetworkPolicy` verifies matchExpressions covers both pods
- [ ] Deploy on OCP 4.22 cluster and verify both payload-processing and payload-pre-processing pods are Running

Jira: RHOAIENG-71268

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a gateway namespace `NetworkPolicy` named `payload-processing` with pod selectors and defined ingress/egress rules.
* **Bug Fixes**
  * Ensured the gateway `NetworkPolicy` is kept in the gateway namespace during reconciliation.
* **Improvements**
  * Added gateway-namespace cleanup to remove unexpected resources during reconcile runs.
* **Tests**
  * Added unit tests for policy generation and namespace restoration.
  * Extended end-to-end coverage to validate labels, selectors, and ingress/egress configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->