### PR TITLE
RHOAIENG-68917: Add condition to skip e2e for automated manifest SHA PRs

### DIFF
--- a/.github/workflows/test-e2e-requirement-check.yaml
+++ b/.github/workflows/test-e2e-requirement-check.yaml
@@ -20,6 +20,7 @@ permissions:
 jobs:
   check-e2e-update-requirement:
     name: Check requirement to update E2E test suite
+    if: github.head_ref != 'sync/upgrade-manifest-shas' || github.event.pull_request.user.login != 'odh-release-bot[bot]'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
<!---
Many thanks for submitting your Pull Request :heart:!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

<!--- Link your JIRA and related links here for reference. -->

JIRA: https://redhat.atlassian.net/browse/RHOAIENG-68917

This PR is meant to address the issue of the automated manifest SHA update PR's failing due to the PR's themselves not changing anything within the e2e files and being unable to opt out of them within their descriptions.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

N/A

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

N/A

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully
- [ ] New RELATED_IMAGE mappings are listed in ODH-Build-Config and RHOAI-Build-Config (CI validates names against build-config repos). Include links to build-config PRs in the description.

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->

No new e2e tests required for this. There also weren't any major behavioral changes made.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated checks so a specific maintenance PR type skips the E2E requirement step, reducing unnecessary pipeline runs while leaving all other checks unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->