### PR TITLE
fix(modelsasservice): read apiKeys.maxExpirationDays from CR spec

### DIFF
--- a/internal/controller/components/modelsasservice/modelsasservice_support.go
+++ b/internal/controller/components/modelsasservice/modelsasservice_support.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -189,6 +190,13 @@ func buildMaasOperatorInstallManifests(ctx context.Context, rr *odhtypes.Reconci
 	if err != nil {
 		return nil, fmt.Errorf("build maas-parameters ConfigMap from params.env: %w", err)
 	}
+
+	if maas, ok := rr.Instance.(*componentApi.ModelsAsService); ok && maas.Spec.APIKeys != nil && maas.Spec.APIKeys.MaxExpirationDays != nil {
+		if data, ok := paramsCM.Object["data"].(map[string]any); ok {
+			data["api-key-max-expiration-days"] = strconv.FormatInt(int64(*maas.Spec.APIKeys.MaxExpirationDays), 10)
+		}
+	}
+
 	extra = append(extra, *paramsCM)
 
 	out := make([]client.Object, len(extra))


### PR DESCRIPTION
## Summary
- Fix `api-key-max-expiration-days` being hardcoded to 90 in the `maas-parameters` ConfigMap
- Read `spec.apiKeys.maxExpirationDays` from the ModelsAsService CR and override the ConfigMap value when set
- Without this fix, patching the Tenant CR or ModelsAsService CR with a custom expiration has no effect — maas-api always sees 90

## Root Cause
`maasParametersConfigMapFromParamsEnv()` reads the static `params.env` file which has `api-key-max-expiration-days=90`. The reconciler never checked the CR spec for overrides.

## Changes
One 4-line override in `buildMaasOperatorInstallManifests()` — after the ConfigMap is built from `params.env`, check if `spec.apiKeys.maxExpirationDays` is set on the ModelsAsService CR and update the ConfigMap data accordingly.

## Test plan
- [ ] Set `spec.apiKeys.maxExpirationDays: 365` on ModelsAsService CR
- [ ] Verify `oc get cm maas-parameters -o jsonpath='{.data.api-key-max-expiration-days}'` shows `365`
- [ ] Verify `oc exec deploy/maas-api -- printenv API_KEY_MAX_EXPIRATION_DAYS` shows `365`
- [ ] Verify default (no CR override) still shows `90`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
 Reading apiKeys.maxExpirationDays from CR spec does not require e2e test update.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for configuring the maximum API key expiration period in generated installation settings when the option is set.
  * If no value is provided, existing behavior remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->