### PR TITLE
fix: track ai-gateway-operator from stable branch

### DIFF
--- a/get_all_manifests.sh
+++ b/get_all_manifests.sh
@@ -33,7 +33,7 @@ declare -A ODH_COMPONENT_MANIFESTS=(
     ["mlflowoperator"]="opendatahub-io:mlflow-operator:main@b432bf19dbad95968cc75dbf18962d349c544295:config"
     ["sparkoperator"]="opendatahub-io:spark-operator:main@ca3f3a7e9dcc7fa05d35f1f8b24063d589ea69a1:config"
     ["wva"]="opendatahub-io:workload-variant-autoscaler:main@ba229d66d60868553a8030092fb9808b24cad3b5:config"
-    ["aigateway"]="opendatahub-io:ai-gateway-operator:main@93c1750225d2fd78ede818337c419f54fae51d30:config"
+    ["aigateway"]="opendatahub-io:ai-gateway-operator:stable@93c1750225d2fd78ede818337c419f54fae51d30:config"
 )
 
 # RHOAI Component Manifests


### PR DESCRIPTION
## Summary
- Update the aigateway manifest entry to track the `stable` branch instead of `main`.

## Description
The ai-gateway-operator manifests were previously tracking the `main` branch. This change updates the tracking branch to `stable`, aligning with the release workflow for the ai-gateway-operator component.

- Change branch reference from `main` to `stable` in `get_all_manifests.sh`
- Commit SHA remains unchanged (`f0383d5d517c23249b6d7b73c6cb7c754036c1c3`)

## How it was tested
- Ran `get_all_manifests.sh` successfully and verified manifests were fetched from the `stable` branch at the pinned commit.
- Confirmed the fetched `opt/manifests/aigateway/` directory contains the expected structure (crd, default, manager, rbac, webhook, etc.).


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the component manifest lookup to use the **stable** release track instead of **main**, ensuring fetched content matches the intended release version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->