### PR TITLE
Add odh-trainer-operator to operator manifests

### DIFF
--- a/build/manifests-config.yaml
+++ b/build/manifests-config.yaml
@@ -78,3 +78,6 @@ map:
   odh-mcp-lifecycle-module-operator:
     src: config
     dest: mcplifecycleoperator
+  odh-trainer-operator:
+    src: config/manifests
+    dest: trainer-operator


### PR DESCRIPTION
Adds 'odh-trainer-operator' entry to build/manifests-config.yaml.

Repo: https://github.com/opendatahub-io/trainer-operator
Jira: https://redhat.atlassian.net/browse/RHOAIENG-72207

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the build/deployment manifest mapping for the trainer-operator component to route it to the correct destination.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->