### PR TITLE
RHOAIENG-58789: security improvements in e2e tests for xKS

### DIFF
--- a/.github/workflows/test-cloudmanager-e2e.yaml
+++ b/.github/workflows/test-cloudmanager-e2e.yaml
@@ -4,6 +4,17 @@ on:
     types: [opened, labeled, synchronize, reopened]
     branches:
       - main
+    paths:
+      - 'cmd/cloudmanager/**'
+      - 'internal/controller/cloudmanager/**'
+      - 'config/cloudmanager/**'
+      - 'api/cloudmanager/**'
+      - 'tests/e2e/cloudmanager/**'
+      - 'pkg/controller/cloudmanager/**'
+      - 'pkg/operatorconfig/cloudmanager.go'
+      - 'pkg/utils/test/cloudmanager/**'
+      - '.github/workflows/test-cloudmanager-e2e.yaml'
+      - 'get_all_manifests.sh'
 
 permissions:
   contents: read
@@ -14,20 +25,12 @@ env:
 
 jobs:
   get-merge-commit:
-    if: >-
-      github.event.action == 'labeled' && github.event.label.name == 'run-xks-e2e'
-      || github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'run-xks-e2e')
     name: Get merge commit
     uses: ./.github/workflows/get-merge-commit.yaml
 
   cloud-manager-e2e:
     needs: get-merge-commit
     name: Cloud Manager E2E (${{ matrix.provider }})
-    # Label gate: only runs when a maintainer adds this label, preventing
-    # untrusted fork PRs from executing arbitrary code with repo secrets.
-    if: >-
-      github.event.action == 'labeled' && github.event.label.name == 'run-xks-e2e'
-      || github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'run-xks-e2e')
     runs-on: ubuntu-latest
     env:
       KIND_CLUSTER_NAME: kind-${{ matrix.provider }}
@@ -36,6 +39,23 @@ jobs:
       matrix:
         provider: [azure, coreweave, aws]
     steps:
+      - name: Check authorization
+        env:
+          AUTHOR_ASSOCIATION: ${{ github.event.pull_request.author_association }}
+          EVENT_ACTION: ${{ github.event.action }}
+          LABEL_NAME: ${{ github.event.label.name }}
+        run: |
+          if [[ "$AUTHOR_ASSOCIATION" =~ ^(OWNER|MEMBER|COLLABORATOR)$ ]]; then
+            echo "Trusted contributor — running automatically"
+            exit 0
+          fi
+          if [[ "$EVENT_ACTION" == "labeled" && "$LABEL_NAME" == "run-xks-e2e" ]]; then
+            echo "External contributor — approved via label"
+            exit 0
+          fi
+          echo "::error::xKS e2e tests required. A maintainer must add the 'run-xks-e2e' label after reviewing the code."
+          exit 1
+
       - name: Checkout PR code
         if: ${{ !env.ACT }}
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1

--- a/.github/workflows/test-kind-odh-e2e.yaml
+++ b/.github/workflows/test-kind-odh-e2e.yaml
@@ -5,19 +5,6 @@ on:
     types: [opened, labeled, synchronize, reopened]
     branches:
       - main
-    paths-ignore:
-      - 'cmd/cloudmanager/**'
-      - 'internal/controller/cloudmanager/**'
-      - 'config/cloudmanager/**'
-      - 'api/cloudmanager/**'
-      - 'tests/e2e/cloudmanager/**'
-      - 'pkg/controller/cloudmanager/**'
-      - 'docs/cloudmanager-api-overview.md'
-      - 'hack/update-cloudmanager-rbac.sh'
-      - '.github/workflows/test-cloudmanager-e2e.yaml'
-      - 'crd-ref-docs.cloudmanager.config.yaml'
-      - 'pkg/operatorconfig/cloudmanager.go'
-      - 'pkg/utils/test/cloudmanager/**'
 
 permissions:
   contents: read
@@ -28,25 +15,34 @@ env:
 
 jobs:
   get-merge-commit:
-    if: >-
-      github.event.action == 'labeled' && github.event.label.name == 'run-xks-e2e' ||
-      github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'run-xks-e2e')
     name: Get merge commit
     uses: ./.github/workflows/get-merge-commit.yaml
 
   kind-odh-e2e-tests:
     needs: get-merge-commit
-    # Label gate: only runs when a maintainer adds this label, preventing
-    # untrusted fork PRs from executing arbitrary code with repo secrets.
-    if: >-
-      github.event.action == 'labeled' && github.event.label.name == 'run-xks-e2e' ||
-      github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'run-xks-e2e')
     runs-on: ubuntu-latest
     permissions:
       contents: read
     env:
       KIND_CLUSTER_NAME: kind-odh-e2e-tests-${{ github.run_id }}
     steps:
+      - name: Check authorization
+        env:
+          AUTHOR_ASSOCIATION: ${{ github.event.pull_request.author_association }}
+          EVENT_ACTION: ${{ github.event.action }}
+          LABEL_NAME: ${{ github.event.label.name }}
+        run: |
+          if [[ "$AUTHOR_ASSOCIATION" =~ ^(OWNER|MEMBER|COLLABORATOR)$ ]]; then
+            echo "Trusted contributor — running automatically"
+            exit 0
+          fi
+          if [[ "$EVENT_ACTION" == "labeled" && "$LABEL_NAME" == "run-xks-e2e" ]]; then
+            echo "External contributor — approved via label"
+            exit 0
+          fi
+          echo "::error::xKS e2e tests required. A maintainer must add the 'run-xks-e2e' label after reviewing the code."
+          exit 1
+
       - name: Checkout code
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:


### PR DESCRIPTION
## Description

[RHOAIENG-58789](https://redhat.atlassian.net/browse/RHOAIENG-58789)
Related: [RHOAIENG-56108](https://redhat.atlassian.net/browse/RHOAIENG-56108) (auto-run for org members, covered by this change)

The xKS e2e workflows use `pull_request_target` with a label gate to protect `CCM_PULL_SECRET` from untrusted fork PRs. The label gate has two problems:

1. TOCTOU vulnerability (CWE-94): after a maintainer adds the label, an attacker can push malicious code. The `synchronize` event fires with the label still present and executes the new code with secrets.
2. Skipped jobs pass required checks: when the label is absent, the job-level `if:` produces a "skipped" status that GitHub treats as passing.

### Authorization check

The job-level `if:` conditions are replaced with an in-job authorization step that checks `author_association` from the event payload. Trusted contributors (OWNER, MEMBER, COLLABORATOR) auto-run on every event without needing the label. External contributors see a failed check, and a maintainer must add `run-xks-e2e` after reviewing the code. New commits require re-labeling since only the `labeled` event passes the check for externals, which closes the TOCTOU window.

The check is a step, not a job-level `if:`, so unauthorized PRs produce a failed check (which blocks merge) instead of a skipped one (which passes).

### Path filter changes

The ODH workflow's `paths-ignore` for cloudmanager files is removed because Cloud Manager deploys cert-manager, which KServe needs for its webhooks. A cloudmanager change that breaks cert-manager would break the KServe deployment, but the `paths-ignore` prevented the ODH tests from catching it.

The cloudmanager workflow had no path filter at all, so it now gets a `paths:` filter scoped to cloudmanager source files.

### Script injection prevention

GitHub context values (`author_association`, `action`, `label.name`) are passed via `env:` instead of direct `${{ }}` interpolation in the shell to prevent script injection (CWE-78 defense-in-depth).

## How Has This Been Tested?

These are workflow changes, so verification requires observing CI behavior on real PRs.

| Scenario | Expected |
|---|---|
| Trusted contributor opens PR | Tests auto-run, no label needed |
| External contributor opens fork PR | Authorization fails, merge blocked |
| Maintainer adds `run-xks-e2e` label | Tests run |
| External pushes new commit after label | Authorization fails, must re-label |
| PR touches only cloudmanager files | Only cloudmanager workflow triggers |

Scenario 1 is verified by this PR itself. The TOCTOU fix was validated in a test repo (`rinaldodev/test-env-gate`) with environment gates and branch protection during investigation.

## Screenshot or short clip

N/A

## Merge criteria

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully
- [ ] New RELATED_IMAGE mappings are listed in ODH-Build-Config and RHOAI-Build-Config (CI validates names against build-config repos). Include links to build-config PRs in the description.

### E2E test suite update requirement

- [x] Skip requirement to update E2E test suite for this PR

#### E2E update requirement opt-out justification

CI workflow configuration only. No operator source code or tests changed.

---

*This change was developed with AI assistance.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automation safeguards for end-to-end test runs on pull requests by moving authorization checks into early workflow steps.
  * Restricted the Cloud Manager E2E workflow to relevant changes only to reduce unnecessary runs.
  * Updated E2E authorization behavior so trusted contributors run automatically, while others require the explicit `run-xks-e2e` label.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->