### PR TITLE
refactor(modelsasservice): move NetworkPolicy to upstream manifests

### DIFF
--- a/internal/controller/components/modelsasservice/modelsasservice_support.go
+++ b/internal/controller/components/modelsasservice/modelsasservice_support.go
@@ -194,8 +194,6 @@ func buildMaasOperatorInstallManifests(ctx context.Context, rr *odhtypes.Reconci
 	}
 	extra = append(extra, *paramsCM)
 
-	extra = append(extra, payloadProcessingNetworkPolicy(componentLabels))
-
 	out := make([]client.Object, len(extra))
 	for i := range extra {
 		out[i] = &extra[i]
@@ -244,92 +242,6 @@ func maasParametersConfigMapFromParamsEnv(manifestsBasePath string, appNs string
 		},
 	}
 	return cm, nil
-}
-
-// payloadProcessingNetworkPolicy returns a NetworkPolicy for the
-// payload-processing pod in the gateway namespace. OCP 4.22 introduced a
-// deny-all NetworkPolicy in openshift-ingress; without explicit rules the pod
-// cannot reach the Kubernetes API server (egress) or receive ext_proc calls
-// from the gateway (ingress).
-func payloadProcessingNetworkPolicy(componentLabels map[string]string) unstructured.Unstructured {
-	npLabels := make(map[string]any, len(componentLabels)+1)
-	for k, v := range componentLabels {
-		npLabels[k] = v
-	}
-	npLabels["app"] = "payload-processing"
-
-	return unstructured.Unstructured{
-		Object: map[string]any{
-			"apiVersion": "networking.k8s.io/v1",
-			"kind":       "NetworkPolicy",
-			"metadata": map[string]any{
-				"name":      "payload-processing",
-				"namespace": DefaultGatewayNamespace,
-				"labels":    npLabels,
-			},
-			"spec": map[string]any{
-				"podSelector": map[string]any{
-					"matchLabels": map[string]any{
-						"app": "payload-processing",
-					},
-				},
-				"policyTypes": []any{"Ingress", "Egress"},
-				"ingress": []any{
-					map[string]any{
-						"from": []any{
-							map[string]any{
-								"podSelector": map[string]any{
-									"matchLabels": map[string]any{
-										"gateway.networking.k8s.io/gateway-name": "data-science-gateway",
-									},
-								},
-								"namespaceSelector": map[string]any{
-									"matchLabels": map[string]any{
-										"kubernetes.io/metadata.name": DefaultGatewayNamespace,
-									},
-								},
-							},
-						},
-						"ports": []any{
-							map[string]any{
-								"protocol": "TCP",
-								"port":     int64(9004),
-							},
-						},
-					},
-					map[string]any{
-						"from": []any{
-							map[string]any{
-								"namespaceSelector": map[string]any{
-									"matchLabels": map[string]any{
-										"kubernetes.io/metadata.name": "openshift-monitoring",
-									},
-								},
-							},
-							map[string]any{
-								"namespaceSelector": map[string]any{
-									"matchLabels": map[string]any{
-										"kubernetes.io/metadata.name": "openshift-user-workload-monitoring",
-									},
-								},
-							},
-						},
-						"ports": []any{
-							map[string]any{
-								"protocol": "TCP",
-								"port":     int64(9005),
-							},
-							map[string]any{
-								"protocol": "TCP",
-								"port":     int64(9090),
-							},
-						},
-					},
-				},
-				"egress": []any{map[string]any{}},
-			},
-		},
-	}
 }
 
 // parseParamsEnv reads a key=value env file, skipping comments and blank lines.

--- a/internal/controller/components/modelsasservice/modelsasservice_support_test.go
+++ b/internal/controller/components/modelsasservice/modelsasservice_support_test.go
@@ -56,13 +56,6 @@ metadata:
   name: payload-processing-plugins
   namespace: redhat-ods-applications
 `,
-		`
-apiVersion: networking.k8s.io/v1
-kind: NetworkPolicy
-metadata:
-  name: payload-processing
-  namespace: redhat-ods-applications
-`,
 		// Unrelated resource that should NOT be moved
 		`
 apiVersion: apps/v1
@@ -187,50 +180,6 @@ roleRef:
 	}
 }
 
-func TestPayloadProcessingNetworkPolicy(t *testing.T) {
-	g := NewWithT(t)
-
-	labels := map[string]string{
-		"opendatahub.io/component":  "true",
-		"app.kubernetes.io/part-of": "modelsasservice",
-	}
-
-	np := payloadProcessingNetworkPolicy(labels)
-
-	g.Expect(np.GetKind()).To(Equal("NetworkPolicy"))
-	g.Expect(np.GetName()).To(Equal("payload-processing"))
-	g.Expect(np.GetNamespace()).To(Equal(DefaultGatewayNamespace))
-
-	npLabels := np.GetLabels()
-	g.Expect(npLabels).To(HaveKeyWithValue("app", "payload-processing"))
-	g.Expect(npLabels).To(HaveKeyWithValue("opendatahub.io/component", "true"))
-	g.Expect(npLabels).To(HaveKeyWithValue("app.kubernetes.io/part-of", "modelsasservice"))
-
-	spec, ok := np.Object["spec"].(map[string]any)
-	g.Expect(ok).To(BeTrue(), "spec should be a map")
-
-	podSelector, ok := spec["podSelector"].(map[string]any)
-	g.Expect(ok).To(BeTrue(), "podSelector should be a map")
-	matchLabels, ok := podSelector["matchLabels"].(map[string]any)
-	g.Expect(ok).To(BeTrue(), "matchLabels should be a map")
-	g.Expect(matchLabels).To(HaveKeyWithValue("app", "payload-processing"))
-
-	policyTypes, ok := spec["policyTypes"].([]any)
-	g.Expect(ok).To(BeTrue(), "policyTypes should be an array")
-	g.Expect(policyTypes).To(ConsistOf("Ingress", "Egress"))
-
-	// Verify egress allows all outbound traffic
-	egress, ok := spec["egress"].([]any)
-	g.Expect(ok).To(BeTrue(), "egress should be an array")
-	g.Expect(egress).To(HaveLen(1))
-	g.Expect(egress[0]).To(Equal(map[string]any{}))
-
-	// Verify ingress rules: gateway on 9004, monitoring on 9090
-	ingress, ok := spec["ingress"].([]any)
-	g.Expect(ok).To(BeTrue(), "ingress should be an array")
-	g.Expect(ingress).To(HaveLen(2))
-}
-
 func TestRestoreCRBSubjectsNamespace_NoSubjects(t *testing.T) {
 	g := NewWithT(t)
 
@@ -248,4 +197,12 @@ roleRef:
 
 	err = restoreCRBSubjectsNamespace(res, "openshift-ingress")
 	g.Expect(err).ShouldNot(HaveOccurred())
+}
+
+func TestGatewayNamespaceResources_IncludesNetworkPolicy(t *testing.T) {
+	g := NewWithT(t)
+
+	g.Expect(gatewayNamespaceResources).To(HaveKey(
+		resourceKey{kind: "NetworkPolicy", name: "payload-processing"}),
+		"NetworkPolicy must be registered for namespace restoration")
 }

--- a/tests/e2e/modelsasservice_test.go
+++ b/tests/e2e/modelsasservice_test.go
@@ -343,12 +343,14 @@ func (tc *ModelsAsServiceTestCtx) ValidatePayloadProcessingNetworkPolicy(t *test
 			Namespace: maasGatewayNamespace,
 		}),
 		WithCondition(And(
-			jq.Match(`.spec.podSelector.matchLabels.app == "payload-processing"`),
+			jq.Match(`.spec.podSelector.matchExpressions[]
+				| select(.key == "app") | .operator == "In" and (.values | sort == ["payload-pre-processing","payload-processing"])`),
 			jq.Match(`.spec.policyTypes | any(. == "Ingress")`),
 			jq.Match(`.spec.policyTypes | any(. == "Egress")`),
 			jq.Match(`.spec.ingress | length == 2`),
-			jq.Match(`.spec.egress | length == 1`),
-			jq.Match(`.spec.egress[0] == {}`),
+			jq.Match(`.spec.egress | length == 2`),
+			jq.Match(`.spec.egress[] | select(.ports[] | .port == 53) | .ports | length == 4`),
+			jq.Match(`.spec.egress[] | select(.ports[] | .port == 443) | .ports | length == 2`),
 		)),
 		WithCustomErrorMsg("NetworkPolicy should exist with correct ingress and egress rules for payload-processing in %s", maasGatewayNamespace),
 	)


### PR DESCRIPTION
## Description

Moves the payload-processing NetworkPolicy from Go-constructed code (#3699) to the upstream `models-as-a-service` kustomize bundle, where it belongs alongside the other payload-processing resources (Deployment, Service, ServiceAccount, ConfigMap).

**MaaS PR:** opendatahub-io/models-as-a-service#1084

Supersedes #3731.

**Operator-side changes:**
- Remove `payloadProcessingNetworkPolicy()` raw `map[string]any` builder
- Add `{kind: "NetworkPolicy", name: "payload-processing"}` to `gatewayNamespaceResources` so the existing kustomize pipeline handles namespace restoration from `appNs` back to `openshift-ingress`
- The NP flows through the same rendering pipeline as all other payload-processing resources: kustomize build, namespace transform, `restoreGatewayNamespaceResources`, label injection, GC cleanup

**Why move to upstream?**
- The payload-processing Deployment, Service, ServiceAccount, and ConfigMap already come from the upstream kustomize bundle. The NP is the only resource the operator was constructing in Go.
- maas-api already has 4 NetworkPolicy manifests in the upstream repo following the `networking/` subdirectory pattern.
- No template rendering code, no `embed.FS`, no `text/template` needed in the operator.

## How Has This Been Tested?

**Unit tests:**
- `TestGatewayNamespaceResources_IncludesNetworkPolicy`: verifies the NetworkPolicy is registered in the namespace restoration map
- Existing `TestRestoreGatewayNamespaceResources`: validates the restoration logic works for all registered resource types

**Lint:** `golangci-lint` passes with no new issues.

**E2e:** requires OCP 4.22+ cluster with updated MaaS manifest bundle (from models-as-a-service#1084). Same test surface as #3699.

## Screenshot or short clip

N/A (no UI changes)

## Merge criteria

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully
- [ ] New RELATED_IMAGE mappings are listed in ODH-Build-Config and RHOAI-Build-Config (CI validates names against build-config repos). Include links to build-config PRs in the description.

### E2E test suite update requirement

- [x] Skip requirement to update E2E test suite for this PR

#### E2E update requirement opt-out justification

This PR removes operator-constructed code and relies on the upstream kustomize manifest instead. The NP's behavior is unchanged. The only operator-side change is a map entry for namespace restoration, which is covered by existing unit tests. The NP itself is tested in the upstream models-as-a-service repo.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated installer bundle networking output to no longer include the payload-processing `NetworkPolicy`.

* **Tests**
  * Adjusted namespace restoration fixtures and assertions to reflect the updated allowlisted resource set.
  * Removed the payload-processing `NetworkPolicy` test and added coverage to ensure restoration succeeds when a `ClusterRoleBinding` omits `subjects`.
  * Added a test to confirm `gatewayNamespaceResources` includes the expected `NetworkPolicy`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->