### PR TITLE
fix(webhook): persist injected connection type to survive secret deletion

### DIFF
--- a/internal/webhook/serving/mutating_isvc.go
+++ b/internal/webhook/serving/mutating_isvc.go
@@ -16,6 +16,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/metadata/annotations"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/resources"
 	webhookutils "github.com/opendatahub-io/opendatahub-operator/v2/pkg/webhook"
 )
 
@@ -206,14 +207,12 @@ func (w *ISVCConnectionWebhook) performConnectionInjection(
 		}
 		log.V(1).Info("Successfully injected OCI .spec.predictor.imagePullSecrets", "secretName", connInfo.SecretName)
 		// TODO: inject .spec.model.uri
-		return true, nil
 
 	case webhookutils.ConnectionTypeProtocolURI.String(), webhookutils.ConnectionTypeRefURI.String():
 		if err := w.injectURIStorageUri(ctx, decodedObj, connInfo.SecretName, req.Namespace); err != nil {
 			return false, fmt.Errorf("failed to inject host to .spec.predictor.model.storageUri: %w", err)
 		}
 		log.V(1).Info("Successfully injected URI .spec.predictor.model.storageUri", "secretName", connInfo.SecretName)
-		return true, nil
 
 	case webhookutils.ConnectionTypeProtocolS3.String(), webhookutils.ConnectionTypeRefS3.String():
 		// inject ServiceAccount only for S3 connections
@@ -236,12 +235,14 @@ func (w *ISVCConnectionWebhook) performConnectionInjection(
 			return false, fmt.Errorf("failed to inject S3 .spec.predictor.model.storage: %w", err)
 		}
 		log.V(1).Info("Successfully injected S3 .spec.predictor.model.storage", "secretName", connInfo.SecretName)
-		return true, nil
 
 	default: // this should not enter since ValidateConnectionAnnotation ensures valid types, but keep it for safety
 		log.V(1).Info("Unknown connection type, skipping injection", "connectionType", connInfo.Type)
 		return false, nil
 	}
+
+	resources.SetAnnotation(decodedObj, annotations.InjectedConnectionType, connInfo.Type)
+	return true, nil
 }
 
 // performConnectionCleanup removes previously injected connection fields when the annotation is removed on UPDATE operation.
@@ -316,6 +317,10 @@ func (w *ISVCConnectionWebhook) performConnectionCleanup(
 		// No specific cleanup needed for unknown connection types
 		log.V(1).Info("No specific cleanup needed for connection type", "connectionType", connInfo.Type)
 		cleanupPerformed = false
+	}
+
+	if cleanupPerformed {
+		resources.RemoveAnnotation(decodedObj, annotations.InjectedConnectionType)
 	}
 
 	return cleanupPerformed, nil

--- a/internal/webhook/serving/mutating_llmisvc.go
+++ b/internal/webhook/serving/mutating_llmisvc.go
@@ -15,6 +15,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/metadata/annotations"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/resources"
 	webhookutils "github.com/opendatahub-io/opendatahub-operator/v2/pkg/webhook"
 )
 
@@ -217,6 +218,7 @@ func (w *LLMISVCConnectionWebhook) performConnectionInjection(
 
 		// TODO: inject .spec.model.uri
 		// uriValue = webhookutils.GetOCIValue(decodedObj)
+		resources.SetAnnotation(decodedObj, annotations.InjectedConnectionType, connInfo.Type)
 		return true, nil
 
 	case webhookutils.ConnectionTypeProtocolS3.String(), webhookutils.ConnectionTypeRefS3.String():
@@ -241,6 +243,8 @@ func (w *LLMISVCConnectionWebhook) performConnectionInjection(
 		return false, fmt.Errorf("failed to inject .spec.model.uri: %w", err)
 	}
 	log.V(1).Info("Successfully injected .spec.model.uri", "secretName", connInfo.SecretName)
+
+	resources.SetAnnotation(decodedObj, annotations.InjectedConnectionType, connInfo.Type)
 	return true, nil
 }
 
@@ -303,6 +307,10 @@ func (w *LLMISVCConnectionWebhook) performConnectionCleanup(
 		}
 		log.V(1).Info("Successfully cleaned up from .spec.model.uri", "name", req.Name, "namespace", req.Namespace)
 		cleanupPerformed = true
+	}
+
+	if cleanupPerformed {
+		resources.RemoveAnnotation(decodedObj, annotations.InjectedConnectionType)
 	}
 
 	return cleanupPerformed, nil

--- a/internal/webhook/serving/mutating_test.go
+++ b/internal/webhook/serving/mutating_test.go
@@ -65,6 +65,7 @@ type TestCase struct {
 	oldAnnotations     map[string]string
 	oldPredictorSpec   map[string]any
 	oldSecretType      string // For UPDATE operations to determine old connection type
+	skipOldSecret      bool   // Skip creating old secret in fake client (simulates deleted secret)
 	operation          admissionv1.Operation
 	expectedAllowed    bool
 	expectedMessage    string
@@ -167,7 +168,7 @@ func runISVCTestCase(t *testing.T, tc TestCase) { //nolint:dupl
 	}
 
 	// Create old secret if needed for UPDATE operations
-	if tc.operation == admissionv1.Update && tc.oldAnnotations != nil {
+	if tc.operation == admissionv1.Update && tc.oldAnnotations != nil && !tc.skipOldSecret {
 		if oldSecretName, exists := tc.oldAnnotations[annotations.Connection]; exists {
 			// Use the specified old secret type, or default to S3 if not specified
 			oldSecretType := tc.oldSecretType
@@ -264,7 +265,7 @@ func runLLMISVCTestCase(t *testing.T, tc TestCase) { //nolint:dupl
 	}
 
 	// Create old secret if needed for UPDATE operations
-	if tc.operation == admissionv1.Update && tc.oldAnnotations != nil {
+	if tc.operation == admissionv1.Update && tc.oldAnnotations != nil && !tc.skipOldSecret {
 		if oldSecretName, exists := tc.oldAnnotations[annotations.Connection]; exists {
 			// Use the specified old secret type, or default to URI if not specified
 			oldSecretType := tc.oldSecretType
@@ -718,6 +719,104 @@ func TestISVCConnectionWebhook(t *testing.T) {
 			expectedPatchCheck: hasStorageUriPatch("s3://new-bucket/new-model"),
 		},
 
+		// Replace tests when old secret has been deleted before IS update.
+		// The old ISVC has the injected-connection-type annotation (set during original injection),
+		// so GetOldConnectionInfo recovers the type even though the secret is gone.
+		{
+			name:            "OCI replace with deleted old secret should not strip storageUri",
+			secretType:      webhookutils.ConnectionTypeProtocolOCI.String(),
+			secretNamespace: testNamespace,
+			annotations:     map[string]string{annotations.Connection: testSecret},
+			predictorSpec: map[string]any{
+				"model": map[string]any{
+					"storageUri": "oci://quay.io/example/model:latest",
+				},
+				"imagePullSecrets": []any{
+					map[string]any{"name": testSecretOld},
+				},
+			},
+			oldAnnotations: map[string]string{
+				annotations.Connection:             testSecretOld,
+				annotations.InjectedConnectionType: webhookutils.ConnectionTypeProtocolOCI.String(),
+			},
+			oldPredictorSpec: map[string]any{"model": map[string]any{"storageUri": "oci://quay.io/example/model:latest"}},
+			skipOldSecret:    true,
+			operation:        admissionv1.Update,
+			expectedAllowed:  true,
+			expectedPatchCheck: func(patches []jsonpatch.JsonPatchOperation) bool {
+				hasSecretReplacement := false
+				for _, p := range patches {
+					if strings.HasPrefix(p.Path, isvcImagePullSecretsPath) && p.Value == testSecret {
+						hasSecretReplacement = true
+					}
+				}
+				return hasSecretReplacement && noStorageUriRemovePatch()(patches)
+			},
+		},
+		{
+			name:            "S3 replace with deleted old secret should re-inject storage fields",
+			secretType:      webhookutils.ConnectionTypeProtocolS3.String(),
+			secretNamespace: testNamespace,
+			annotations:     map[string]string{annotations.Connection: testSecret},
+			predictorSpec: map[string]any{
+				"model": map[string]any{
+					"storage": map[string]any{
+						"key": testSecretOld,
+					},
+				},
+			},
+			oldAnnotations: map[string]string{
+				annotations.Connection:             testSecretOld,
+				annotations.InjectedConnectionType: webhookutils.ConnectionTypeProtocolS3.String(),
+			},
+			oldPredictorSpec: map[string]any{
+				"model": map[string]any{
+					"storage": map[string]any{
+						"key": testSecretOld,
+					},
+				},
+			},
+			skipOldSecret:      true,
+			operation:          admissionv1.Update,
+			expectedAllowed:    true,
+			expectedPatchCheck: hasStorageKeyPatch(testSecret),
+		},
+		{
+			name:            "URI replace with deleted old secret should re-inject storageUri",
+			secretType:      webhookutils.ConnectionTypeProtocolURI.String(),
+			secretNamespace: testNamespace,
+			secretData:      map[string][]byte{"URI": []byte("https://example.com/new-model")},
+			annotations:     map[string]string{annotations.Connection: testSecret},
+			predictorSpec: map[string]any{
+				"model": map[string]any{},
+			},
+			oldAnnotations: map[string]string{
+				annotations.Connection:             testSecretOld,
+				annotations.InjectedConnectionType: webhookutils.ConnectionTypeProtocolURI.String(),
+			},
+			oldPredictorSpec: map[string]any{
+				"model": map[string]any{
+					"storageUri": "https://example.com/old-model",
+				},
+			},
+			skipOldSecret:      true,
+			operation:          admissionv1.Update,
+			expectedAllowed:    true,
+			expectedPatchCheck: hasStorageUriPatch("https://example.com/new-model"),
+		},
+
+		// Verify annotation is set during injection
+		{
+			name:               "OCI injection sets injected-connection-type annotation",
+			secretType:         webhookutils.ConnectionTypeProtocolOCI.String(),
+			secretNamespace:    testNamespace,
+			annotations:        map[string]string{annotations.Connection: testSecret},
+			predictorSpec:      map[string]any{"model": map[string]any{}},
+			operation:          admissionv1.Create,
+			expectedAllowed:    true,
+			expectedPatchCheck: hasInjectedConnectionTypeAnnotationPatch(webhookutils.ConnectionTypeProtocolOCI.String()),
+		},
+
 		// Cleanup tests when annotation is removed
 		{
 			name:            "annotation removed, imagePullSecrets is cleanup",
@@ -904,6 +1003,63 @@ func TestLLMISVCConnectionWebhook(t *testing.T) {
 			expectedAllowed:    true,
 			expectedPatchCheck: hasUriPath("s3://my-bucket/models/new-path"),
 		},
+		// Replace tests when old secret has been deleted before LLMISVC update
+		{
+			name:            "OCI replace with deleted old secret should inject imagePullSecrets for LLMISVC",
+			secretType:      webhookutils.ConnectionTypeProtocolOCI.String(),
+			secretNamespace: testNamespace,
+			annotations:     map[string]string{annotations.Connection: testSecret},
+			predictorSpec: map[string]any{
+				"template": map[string]any{
+					"imagePullSecrets": []any{
+						map[string]any{"name": testSecretOld},
+					},
+				},
+			},
+			oldAnnotations: map[string]string{
+				annotations.Connection:             testSecretOld,
+				annotations.InjectedConnectionType: webhookutils.ConnectionTypeProtocolOCI.String(),
+			},
+			oldPredictorSpec: map[string]any{},
+			skipOldSecret:    true,
+			operation:        admissionv1.Update,
+			expectedAllowed:  true,
+			expectedPatchCheck: func(patches []jsonpatch.JsonPatchOperation) bool {
+				for _, p := range patches {
+					if strings.HasPrefix(p.Path, llmisvcImagePullSecretsPath) && p.Value == testSecret {
+						return true
+					}
+				}
+				return false
+			},
+		},
+		{
+			name:            "S3 replace with deleted old secret should re-inject URI for LLMISVC",
+			secretType:      webhookutils.ConnectionTypeProtocolS3.String(),
+			secretNamespace: testNamespace,
+			secretData:      map[string][]byte{"AWS_S3_BUCKET": []byte("my-bucket")},
+			annotations:     map[string]string{annotations.Connection: testSecret, annotations.ConnectionPath: "models/path"},
+			predictorSpec: map[string]any{
+				"model": map[string]any{
+					"uri": "s3://old-bucket/models/old-path",
+				},
+			},
+			oldAnnotations: map[string]string{
+				annotations.Connection:             testSecretOld,
+				annotations.InjectedConnectionType: webhookutils.ConnectionTypeProtocolS3.String(),
+				annotations.ConnectionPath:         "models/old-path",
+			},
+			oldPredictorSpec: map[string]any{
+				"model": map[string]any{
+					"uri": "s3://old-bucket/models/old-path",
+				},
+			},
+			skipOldSecret:      true,
+			operation:          admissionv1.Update,
+			expectedAllowed:    true,
+			expectedPatchCheck: hasUriPath("s3://my-bucket/models/path"),
+		},
+
 		// cleanup tests
 		{
 			name:            "annotation removed, uri is cleanup for any type of connection previously injected",
@@ -1190,7 +1346,7 @@ func runTestCaseWithCustomSecret(t *testing.T, tc TestCase, secretCreator func(n
 	}
 
 	// Create old secret if needed for UPDATE operations
-	if tc.operation == admissionv1.Update && tc.oldAnnotations != nil {
+	if tc.operation == admissionv1.Update && tc.oldAnnotations != nil && !tc.skipOldSecret {
 		if oldSecretName, exists := tc.oldAnnotations[annotations.Connection]; exists {
 			// Use the specified old secret type, or default to S3 if not specified
 			oldSecretType := tc.oldSecretType

--- a/internal/webhook/serving/mutating_util_test.go
+++ b/internal/webhook/serving/mutating_util_test.go
@@ -74,7 +74,7 @@ func hasStorageUriPatch(expectedUri string) func([]jsonpatch.JsonPatchOperation)
 }
 
 // s3 for isvc.
-func hasStorageKeyPatch(expectedStorageKey string) func([]jsonpatch.JsonPatchOperation) bool {
+func hasStorageKeyPatch(expectedStorageKey string) func([]jsonpatch.JsonPatchOperation) bool { //nolint:unparam
 	return func(patches []jsonpatch.JsonPatchOperation) bool {
 		for _, patch := range patches {
 			if patch.Path == isvcStorageKeyPath {
@@ -129,6 +129,35 @@ func hasStorageUriCleanupPatch() func([]jsonpatch.JsonPatchOperation) bool {
 		for _, patch := range patches {
 			if patch.Path == isvcStorageUriPath && patch.Operation == OperationRemove {
 				return true
+			}
+		}
+		return false
+	}
+}
+
+func noStorageUriRemovePatch() func([]jsonpatch.JsonPatchOperation) bool {
+	return func(patches []jsonpatch.JsonPatchOperation) bool {
+		for _, patch := range patches {
+			if patch.Path == isvcStorageUriPath && patch.Operation == OperationRemove {
+				return false
+			}
+		}
+		return true
+	}
+}
+
+func hasInjectedConnectionTypeAnnotationPatch(expectedType string) func([]jsonpatch.JsonPatchOperation) bool {
+	return func(patches []jsonpatch.JsonPatchOperation) bool {
+		for _, patch := range patches {
+			if patch.Path == "/metadata/annotations/opendatahub.io~1injected-connection-type" {
+				return patch.Value == expectedType
+			}
+			if patch.Path == "/metadata/annotations" {
+				if anns, ok := patch.Value.(map[string]any); ok {
+					if v, exists := anns["opendatahub.io/injected-connection-type"]; exists {
+						return v == expectedType
+					}
+				}
 			}
 		}
 		return false

--- a/pkg/metadata/annotations/annotations.go
+++ b/pkg/metadata/annotations/annotations.go
@@ -62,3 +62,8 @@ const ConnectionTypeProtocol = "opendatahub.io/connection-type-protocol"
 // ConnectionPath annotation for specifying the path under bucket(s3) to use for the connection.
 // TODO: extend to oci.
 const ConnectionPath = "opendatahub.io/connection-path"
+
+// InjectedConnectionType is set on an InferenceService/LLMInferenceService by the connection
+// webhook after injection. It records the connection type so that cleanup can determine the
+// correct type-specific path even when the original connection secret has been deleted.
+const InjectedConnectionType = "opendatahub.io/injected-connection-type"

--- a/pkg/webhook/utils.go
+++ b/pkg/webhook/utils.go
@@ -501,11 +501,12 @@ func (w *BaseServingConnectionWebhook) GetOldConnectionInfo(ctx context.Context,
 	secretMeta := resources.GvkToPartial(gvk.Secret)
 	if err := w.APIReader.Get(ctx, types.NamespacedName{Name: oldAnnotationValue, Namespace: req.Namespace}, secretMeta); err != nil {
 		if k8serr.IsNotFound(err) { // secret itself might be deleted already.
-			log.V(1).Info("Old secret not found, but still need to cleanup references", "secretName", oldAnnotationValue)
+			log.V(1).Info("Old secret not found, recovering type from object annotation", "secretName", oldAnnotationValue)
+			oldConnectionType := resources.GetAnnotation(oldObj, annotations.InjectedConnectionType)
 			oldConnectionPath := resources.GetAnnotation(oldObj, annotations.ConnectionPath)
 			return ConnectionInfo{
 				SecretName: oldAnnotationValue,
-				Type:       "", // we won't know which connection-type-ref was set on a already deleted secret
+				Type:       oldConnectionType,
 				Path:       oldConnectionPath,
 			}, nil
 		}


### PR DESCRIPTION
## Description
  - Fix connection webhook stripping `storageUri` when the old connection secret is deleted before the InferenceService update
  - Persist the injected connection type as an annotation (`opendatahub.io/injected-connection-type`) on the InferenceService during injection, so cleanup can determine the correct type-specific path even when the
  original secret is gone

**The same fix seems to be needed in `odh-model-controller` repo since it has an independent webhook with the same logic.**:  https://github.com/opendatahub-io/odh-model-controller/pull/861

### Root cause
  `GetOldConnectionInfo` relied on fetching the old secret to determine the previous connection type. When the secret was already deleted, it returned `Type: ""`, which triggered a full cleanup in
  `performConnectionCleanup` that wiped all webhook-managed fields, including `storageUri`

  ### Solution
  - During injection, write the connection type to `opendatahub.io/injected-connection-type` on the ISVC/LLMISVC
  - In `GetOldConnectionInfo`, when the old secret is NotFound, recover the type from this annotation instead of returning `""`
  - During cleanup, remove the annotation so it doesn't persist after the connection is fully removed

JIRA ref: [RHOAIENG-61105](https://redhat.atlassian.net/browse/RHOAIENG-61105)

## How Has This Been Tested?
Manually tested on the cluster according to the bug scenario described in the ticket

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
7. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
8. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
9. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
Added test coverage for the changes via unit tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an annotation to preserve AI Gateway conversion state across conversions.
  * Added an injected-connection-type annotation on managed InferenceService and LLMInferenceService to improve connection-type tracking during updates.
* **Bug Fixes**
  * Improved UPDATE handling when the original connection secret is missing by recovering the connection type from the injected annotation.
  * More reliably preserves/re-injects OCI/S3/URI connection settings and prevents unintended storage field removals; cleanup now removes the marker only after successful cleanup.
* **Tests**
  * Expanded webhook UPDATE scenarios and strengthened patch-matching assertions for ISVC and LLMISVC.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[RHOAIENG-61105]: https://redhat.atlassian.net/browse/RHOAIENG-61105?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ