### PR TITLE
RHOAIENG-69996: add kube-rbac-proxy image to ray imageParamMap for disconnected support (3.3)

### DIFF
--- a/internal/controller/components/ray/ray_support.go
+++ b/internal/controller/components/ray/ray_support.go
@@ -21,6 +21,7 @@ const (
 var (
 	imageParamMap = map[string]string{
 		"odh-kuberay-operator-controller-image": "RELATED_IMAGE_ODH_KUBERAY_OPERATOR_CONTROLLER_IMAGE",
+		"odh-kube-rbac-proxy-image":             "RELATED_IMAGE_ODH_KUBE_RBAC_PROXY_IMAGE",
 	}
 
 	conditionTypes = []string{


### PR DESCRIPTION
## Description

Backport of PR #3742 from `main` to the `odh-3.3.0` release branch. Adds `odh-kube-rbac-proxy-image` → `RELATED_IMAGE_ODH_KUBE_RBAC_PROXY_IMAGE` mapping to the Ray component's `imageParamMap`, allowing the ODH/RHOAI operator to substitute the kube-rbac-proxy image at deploy time from CSV `relatedImages`. This enables disconnected environment support for the KubeRay authentication controller.

https://redhat.atlassian.net/browse/RHOAIENG-69996

Companion KubeRay PR: https://github.com/opendatahub-io/kuberay/pull/213

## How Has This Been Tested?

- `go build ./...` passes
- CI passes
- Verified image substitution works in disconnected cluster

## Merge criteria

- [x] You have read the contributors guide.
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work

## E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:

- Please inspect the opt-out guidelines, to determine if the nature of the PR changes allows for skipping this requirement
- If opt-out is applicable, provide justification in the dedicated E2E update requirement opt-out justification section below
- Check the checkbox below:

- [x] Skip requirement to update E2E test suite for this PR

Submit/save these changes to the PR description. This will automatically trigger the check.

## E2E update requirement opt-out justification

This is a backport of an already-merged and tested change (#3742). The change only adds an image parameter mapping entry—no new operator logic or behavior that would require E2E coverage beyond existing CI validation.