### PR TITLE
fix: handle transient API errors in TLS profile resolution

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -719,6 +719,13 @@ func fetchTLSProfile(ctx context.Context, scheme *runtime.Scheme, restCfg *rest.
 			setupLog.Info("TLS profile not available, using hardened defaults (non-OpenShift cluster)")
 		case k8serr.IsNotFound(err):
 			setupLog.Info("APIServer resource not found, using hardened defaults")
+		case k8serr.IsForbidden(err):
+			setupLog.Error(err, "APIServer access forbidden, using hardened defaults",
+			"action", "verify RBAC: service account needs get/list/watch on config.openshift.io/apiservers")
+		case k8serr.IsServiceUnavailable(err),
+			k8serr.IsTimeout(err),
+			k8serr.IsTooManyRequests(err):
+			setupLog.Info("Transient API error reading TLS profile, using hardened defaults", "error", err)
 		default:
 			setupLog.Error(err, "unable to read APIServer TLS profile, refusing to start with unknown TLS posture")
 			os.Exit(1)


### PR DESCRIPTION
## Description

Add IsForbidden, IsServiceUnavailable, IsTimeout, and IsTooManyRequests to the graceful fallback cases when reading the cluster TLS profile at startup. Previously these caused `os.Exit(1)`, turning minor network issues or restricted RBAC into CrashLoopBackOff.

Follow-up to #3653 (TLS profile integration). Addresses review feedback from [trustyai-service-operator#774](https://github.com/trustyai-explainability/trustyai-service-operator/pull/774#pullrequestreview-4627792796) where the same pattern was identified.

[RHOAIENG-61062](https://issues.redhat.com/browse/RHOAIENG-61062)

## How Has This Been Tested?

- `go build ./...` passes
- The change only adds new graceful fallback cases to an existing switch statement
- Transient errors now fall back to Intermediate TLS defaults instead of crashing

## Screenshot or short clip

N/A (backend change)

## Merge criteria

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body.
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

- [x] Skip requirement to update E2E test suite for this PR

#### E2E update requirement opt-out justification

Adds graceful error handling cases to existing startup code. No new resources or APIs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved startup resilience when TLS profile information can’t be retrieved.
  * The service now falls back to hardened TLS defaults for additional API error cases, including access denied and temporary service issues (such as rate limiting and timeouts).
  * This helps the service continue starting instead of stopping on recoverable TLS profile fetch failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->