### PR TITLE
ensure env vars are always injected

### DIFF
--- a/internal/controller/modules/modules_controller_actions.go
+++ b/internal/controller/modules/modules_controller_actions.go
@@ -316,6 +316,14 @@ func provisionModules(ctx context.Context, rr *odhtype.ReconciliationRequest) er
 		return walkErr
 	}
 
+	if len(perModuleImages) > 0 || platformCtx.ApplicationsNamespace != "" || platformCtx.MonitoringNamespace != "" {
+		rr.ModuleEnvInjection = &odhtype.ModuleEnvInjection{
+			PerModuleImages:       perModuleImages,
+			ApplicationsNamespace: platformCtx.ApplicationsNamespace,
+			MonitoringNamespace:   platformCtx.MonitoringNamespace,
+		}
+	}
+
 	if requeueAfter > 0 {
 		return odherrors.NewRequeueAfterError(requeueAfter)
 	}
@@ -331,14 +339,6 @@ func provisionModules(ctx context.Context, rr *odhtype.ReconciliationRequest) er
 		}
 
 		return fmt.Errorf("BuildModuleCR failed for modules: %s", strings.Join(failedModules, ", "))
-	}
-
-	if len(perModuleImages) > 0 || platformCtx.ApplicationsNamespace != "" || platformCtx.MonitoringNamespace != "" {
-		rr.ModuleEnvInjection = &odhtype.ModuleEnvInjection{
-			PerModuleImages:       perModuleImages,
-			ApplicationsNamespace: platformCtx.ApplicationsNamespace,
-			MonitoringNamespace:   platformCtx.MonitoringNamespace,
-		}
 	}
 
 	return nil


### PR DESCRIPTION
<!---
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

- A RequeueAfterError would cause the env injection step to be skipped.
- This PR ensures env injection will always happen.

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Build operator image from this code.
- Add RELATED_IMAGE env var for ai gateway controller.
- Verify the var is injected in the deployment.
- Force another component to stay not ready by setting the deployment to 0 replicas.
- Force a reconcile by adding an annotation to the DSC.
- Verify the controller image stays correctly injected.
## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [x] The developer has run the integration test pipeline and verified that it passed successfully
- [x] New RELATED_IMAGE mappings are listed in ODH-Build-Config and RHOAI-Build-Config (CI validates names against build-config repos). Include links to build-config PRs in the description.

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->
This behaviour isn't covered by E2E.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of module environment settings by ensuring they’re applied as soon as module provisioning completes.
  * Fixed a scenario where environment configuration could be missed when provisioning ends early (including retry/requeue paths) or when provisioning fails for selected modules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->