### PR TITLE
add module status reporting

### DIFF
--- a/internal/controller/modules/base.go
+++ b/internal/controller/modules/base.go
@@ -17,6 +17,7 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/opendatahub-io/opendatahub-operator/v2/api/common"
+	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/status"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/manifests/kustomize"
@@ -130,6 +131,10 @@ func (b *BaseHandler) GetName() string {
 
 func (b *BaseHandler) GetGVK() schema.GroupVersionKind {
 	return b.Config.GVK
+}
+
+func (b *BaseHandler) GetReadyConditionType() string {
+	return b.Config.GVK.Kind + status.ReadySuffix
 }
 
 func (b *BaseHandler) GetContainerName() string {

--- a/internal/controller/modules/modules_controller_actions.go
+++ b/internal/controller/modules/modules_controller_actions.go
@@ -369,6 +369,13 @@ func deploymentNameFor(h ModuleHandler, manifests OperatorManifests) string {
 	return deploymentNameFromManifests(manifests, h.GetName())
 }
 
+func readyConditionTypeFor(h ModuleHandler) string {
+	if rct, ok := h.(ReadyConditionTyper); ok {
+		return rct.GetReadyConditionType()
+	}
+	return h.GetGVK().Kind + status.ReadySuffix
+}
+
 func controllerImageFor(h ModuleHandler) string {
 	if ci, ok := h.(ControllerImager); ok {
 		return ci.GetControllerImage()
@@ -395,8 +402,9 @@ func deploymentNameFromManifests(manifests OperatorManifests, fallbackName strin
 	return fallbackName
 }
 
-// ComputeModulesStatus reads status conditions from each enabled module's CR
-// and sets the aggregate ModulesReady condition on rr.Conditions.
+// ComputeModulesStatus reads status conditions from each module's CR and
+// sets both per-module conditions (e.g. AIGatewayReady) and the aggregate
+// ModulesReady condition on rr.Conditions.
 //
 // During the transition period (in-tree components exist), the DSC
 // controller calls this and is the sole status writer — the modules
@@ -423,8 +431,16 @@ func ComputeModulesStatus(ctx context.Context, rr *odhtype.ReconciliationRequest
 
 	err = reg.ForEach(func(handler ModuleHandler) error {
 		name := handler.GetName()
+		condType := readyConditionTypeFor(handler)
 
 		if !handler.IsEnabled(platformCtx) {
+			rr.Conditions.SetCondition(common.Condition{
+				Type:     condType,
+				Status:   metav1.ConditionFalse,
+				Reason:   status.RemovedReason,
+				Severity: common.ConditionSeverityInfo,
+				Message:  fmt.Sprintf("Module ManagementState is set to %s", status.RemovedReason),
+			})
 			return nil
 		}
 
@@ -434,6 +450,13 @@ func ComputeModulesStatus(ctx context.Context, rr *odhtype.ReconciliationRequest
 		if err != nil {
 			log.V(1).Info("failed to get module status", "module", name, "error", err)
 			notReadyModules = append(notReadyModules, name)
+
+			rr.Conditions.SetCondition(common.Condition{
+				Type:    condType,
+				Status:  metav1.ConditionFalse,
+				Reason:  status.NotReadyReason,
+				Message: fmt.Sprintf("Failed to get module status: %v", err),
+			})
 			return nil
 		}
 
@@ -444,19 +467,44 @@ func ComputeModulesStatus(ctx context.Context, rr *odhtype.ReconciliationRequest
 				"generation", moduleStatus.Generation,
 			)
 			notReadyModules = append(notReadyModules, name+" (stale)")
+
+			rr.Conditions.SetCondition(common.Condition{
+				Type:    condType,
+				Status:  metav1.ConditionFalse,
+				Reason:  status.NotReadyReason,
+				Message: "Module status is stale (observedGeneration < generation)",
+			})
 			return nil
 		}
 
 		ready := false
 		degraded := false
+		var readyCond *metav1.Condition
 
-		for _, c := range moduleStatus.Conditions {
-			switch c.Type {
+		for i := range moduleStatus.Conditions {
+			switch moduleStatus.Conditions[i].Type {
 			case status.ConditionTypeReady:
-				ready = c.Status == metav1.ConditionTrue
+				ready = moduleStatus.Conditions[i].Status == metav1.ConditionTrue
+				readyCond = &moduleStatus.Conditions[i]
 			case status.ConditionTypeDegraded:
-				degraded = c.Status == metav1.ConditionTrue
+				degraded = moduleStatus.Conditions[i].Status == metav1.ConditionTrue
 			}
+		}
+
+		if readyCond != nil {
+			rr.Conditions.SetCondition(common.Condition{
+				Type:    condType,
+				Status:  readyCond.Status,
+				Reason:  readyCond.Reason,
+				Message: readyCond.Message,
+			})
+		} else {
+			rr.Conditions.SetCondition(common.Condition{
+				Type:    condType,
+				Status:  metav1.ConditionFalse,
+				Reason:  status.NotReadyReason,
+				Message: "Module has not reported a Ready condition yet",
+			})
 		}
 
 		if !ready {

--- a/internal/controller/modules/modules_controller_actions_status_test.go
+++ b/internal/controller/modules/modules_controller_actions_status_test.go
@@ -1,0 +1,89 @@
+package modules_test
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/modules"
+	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/status"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestGetReadyConditionType(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		gvkKind  string
+		expected string
+	}{
+		{
+			name:     "AIGateway module",
+			gvkKind:  "AIGateway",
+			expected: "AIGatewayReady",
+		},
+		{
+			name:     "Monitoring module",
+			gvkKind:  "Monitoring",
+			expected: "MonitoringReady",
+		},
+		{
+			name:     "single word kind",
+			gvkKind:  "Feast",
+			expected: "FeastReady",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewWithT(t)
+
+			handler := modules.BaseHandler{
+				Config: modules.ModuleConfig{
+					Name: "test",
+					GVK: schema.GroupVersionKind{
+						Group:   "components.platform.opendatahub.io",
+						Version: "v1alpha1",
+						Kind:    tt.gvkKind,
+					},
+				},
+			}
+
+			g.Expect(handler.GetReadyConditionType()).Should(Equal(tt.expected))
+		})
+	}
+}
+
+func TestGetReadyConditionType_MatchesComponentPattern(t *testing.T) {
+	t.Parallel()
+	g := NewWithT(t)
+
+	handler := modules.BaseHandler{
+		Config: modules.ModuleConfig{
+			Name: "aigateway",
+			GVK: schema.GroupVersionKind{
+				Kind: "AIGateway",
+			},
+		},
+	}
+
+	g.Expect(handler.GetReadyConditionType()).Should(Equal("AIGateway" + status.ReadySuffix))
+}
+
+func TestStatusMockHandler_ReadyConditionType(t *testing.T) {
+	t.Parallel()
+	g := NewWithT(t)
+
+	mock := newStatusMock("testmod", &modules.ModuleStatus{
+		Conditions: []metav1.Condition{
+			{Type: "Ready", Status: metav1.ConditionTrue},
+		},
+	})
+	mock.Config.GVK = schema.GroupVersionKind{Kind: "TestModule"}
+
+	g.Expect(mock.GetReadyConditionType()).Should(Equal("TestModuleReady"))
+}

--- a/internal/controller/modules/types.go
+++ b/internal/controller/modules/types.go
@@ -92,6 +92,14 @@ type ModuleHandler interface {
 	DeleteOperatorResources(ctx context.Context, cli client.Client, platform *PlatformContext) error
 }
 
+// ReadyConditionTyper allows a module handler to declare the condition type
+// string used for per-module status on the DSC (e.g. "AIGatewayReady").
+// All handlers embedding BaseHandler satisfy this interface automatically;
+// the default derives the type from GVK.Kind + "Ready".
+type ReadyConditionTyper interface {
+	GetReadyConditionType() string
+}
+
 // ContainerNamer allows a module handler to override the default container
 // name ("manager") used for RELATED_IMAGE_* and controller image injection.
 // All handlers embedding BaseHandler satisfy this interface automatically;

--- a/tests/e2e/aigateway_test.go
+++ b/tests/e2e/aigateway_test.go
@@ -41,7 +41,6 @@ func aiGatewayTestSuite(t *testing.T) {
 			t.Helper()
 			skipUnless(t, Smoke, Tier1)
 
-			// DSC has no "AIGatewayReady" condition, the test is only to check if the AIGateway CR and its deployment exist
 			if !tc.IsXKS() {
 				tc.EventuallyResourcePatched(
 					WithMinimalObject(gvk.DataScienceCluster, tc.DataScienceClusterNamespacedName),
@@ -70,10 +69,15 @@ func aiGatewayTestSuite(t *testing.T) {
 				WithCondition(jq.Match(`.status.readyReplicas >= 1`)),
 			)
 
-			// do check on DSC ModulesReady is true
 			tc.EnsureResourceExists(
 				WithMinimalObject(gvk.DataScienceCluster, tc.DataScienceClusterNamespacedName),
 				WithCondition(jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, status.ConditionTypeModulesReady, metav1.ConditionTrue)),
+			)
+
+			tc.EnsureResourceExists(
+				WithMinimalObject(gvk.DataScienceCluster, tc.DataScienceClusterNamespacedName),
+				WithCondition(jq.Match(`.status.conditions[] | select(.type == "%sReady") | .status == "%s"`, componentApi.AIGatewayKind, metav1.ConditionTrue)),
+				WithCustomErrorMsg("DataScienceCluster should have %sReady condition set to True", componentApi.AIGatewayKind),
 			)
 		}},
 		{"Validate component disabled", func(t *testing.T) {
@@ -88,6 +92,15 @@ func aiGatewayTestSuite(t *testing.T) {
 
 			tc.EnsureResourceGone(WithMinimalObject(moduleGVK, moduleCRNN))
 			tc.EnsureResourceGone(WithMinimalObject(gvk.Deployment, controllerNN))
+
+			tc.EnsureResourceExists(
+				WithMinimalObject(gvk.DataScienceCluster, tc.DataScienceClusterNamespacedName),
+				WithCondition(And(
+					jq.Match(`.status.conditions[] | select(.type == "%sReady") | .status == "%s"`, componentApi.AIGatewayKind, metav1.ConditionFalse),
+					jq.Match(`.status.conditions[] | select(.type == "%sReady") | .reason == "%s"`, componentApi.AIGatewayKind, status.RemovedReason),
+				)),
+				WithCustomErrorMsg("DataScienceCluster should have %sReady condition set to False/Removed", componentApi.AIGatewayKind),
+			)
 		}},
 	}
 

--- a/tests/e2e/resilience_test.go
+++ b/tests/e2e/resilience_test.go
@@ -170,7 +170,7 @@ func (tc *OperatorResilienceTestCtx) ValidateComponentsDeploymentFailure(t *test
 	// TrustyAI is excluded from quota failure testing due to InferenceServices CRD dependency
 	// Kueue is excluded because it does not have any deployment to manage anymore
 	// LlamaStack Operator is excluded because it has been replaced by OGX and the field is deprecated (no deployments to manage anymore)
-	// AIGateway is excluded because it is a module so it does not report DSC ComponentsReady condition
+	// AIGateway is excluded because it is a module (reports AIGatewayReady via ModulesReady, not ComponentsReady)
 	// MCPLifecycleOperator is excluded because it is a module so it does not report DSC ComponentsReady condition
 	excludedComponents := 5 // TrustyAI, Kueue, LlamaStack Operator, AIGateway, MCPLifecycleOperator
 	expectedTestableComponents := expectedComponentCount - excludedComponents


### PR DESCRIPTION
<!---
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->
Add status reporting for modules that mirrors components.

DSC controller is the sole writer if any components are enabled. This is to avoid controllers overwriting status on each other.
<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Build operator image from this branch.
- Deploy and verify AIGatewayReady status exists.
- Set AIGateway to managed.
- Verify status is Ready=true.
## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [x] The developer has run the integration test pipeline and verified that it passed successfully
- [x] New RELATED_IMAGE mappings are listed in ODH-Build-Config and RHOAI-Build-Config (CI validates names against build-config repos). Include links to build-config PRs in the description.

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->
Covered in unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added dynamic per-module “Ready” condition types derived from each component kind, improving consistency across modules.

* **Bug Fixes**
  * Improved per-module readiness status reporting for disabled, error, and stale modules, with clearer reasons/messages.
  * Enhanced propagation of module status “Ready” details into the per-module conditions.

* **Tests**
  * Added unit coverage for readiness condition type derivation.
  * Updated end-to-end checks for AI Gateway readiness when enabled/disabled.
  * Refined resilience test messaging to align with the module readiness model.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->