### PR TITLE
feat: add prefetched Helm chart support to CI builds

### DIFF
--- a/Dockerfiles/rhoai.Dockerfile
+++ b/Dockerfiles/rhoai.Dockerfile
@@ -20,9 +20,10 @@ RUN if [[ "${BUILD_TYPE}" == "RELEASE" && "${USE_LOCAL}" != "true" ]]; then \
         rm -rf /opt/manifests/*; \
         ODH_PLATFORM_TYPE=rhoai ./get_all_manifests.sh ${OVERWRITE_MANIFESTS}; \
     elif [ "${BUILD_TYPE}" == "CI" ]; then \
-        rm -rf /opt/manifests/*; \
-        ls -la /cachi2/prefetched-manifests; \
+        rm -rf /opt/manifests/* /opt/charts/*; \
+        ls -la /cachi2/prefetched-manifests /cachi2/prefetched-charts; \
         cp -r /cachi2/prefetched-manifests/* /opt/manifests/; \
+        cp -r /cachi2/prefetched-charts/* /opt/charts/; \
     fi
 
 # Clean up unwanted directories and files from manifests

--- a/build/manifests-config.yaml
+++ b/build/manifests-config.yaml
@@ -39,6 +39,10 @@ map:
   odh-dashboard:
     src: manifests
     dest: dashboard
+  odh-dashboard-operator:
+    src: dashboard-operator/charts/dashboard
+    dest: dashboardoperator
+    type: chart
   odh-training-operator:
     src: manifests
     dest: trainingoperator


### PR DESCRIPTION
## Summary

Enable CI builds to use prefetched Helm charts from the Konflux pipeline, alongside the existing prefetched manifests.

## What changed

**`Dockerfiles/rhoai.Dockerfile`** — Updated the CI build path to clear and replace both `/opt/manifests/` and `/opt/charts/` from the prefetch task output. Previously only manifests were copied from `/cachi2/prefetched-manifests`; now charts are also copied from `/cachi2/prefetched-charts`.

**`build/manifests-config.yaml`** — Added `odh-dashboard-operator` as the first `type: chart` entry. The `type: chart` field tells the prefetch task to route this entry to `prefetched-charts/` instead of `prefetched-manifests/`.

## Related PRs

- **rhoai-konflux-tasks** — `prefetch-operand-manifests-oci-ta` task updated to support `type: chart` routing and `charts-config.yaml` prefetching (https://github.com/red-hat-data-services/rhoai-konflux-tasks/pull/273)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new chart mapping for the dashboard operator, so it is now included in generated manifests.
* **Bug Fixes**
  * Improved build output handling to include both manifests and charts, helping ensure packaged artifacts are complete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->