### PR TITLE
Add odh-feast-module-operator to operator manifests

### DIFF
--- a/build/manifests-config.yaml
+++ b/build/manifests-config.yaml
@@ -78,3 +78,6 @@ map:
   odh-mcp-lifecycle-module-operator:
     src: config
     dest: mcplifecycleoperator
+  odh-feast-module-operator:
+    src: config/chart
+    dest: config/manifests


### PR DESCRIPTION
Adds 'odh-feast-module-operator' entry to build/manifests-config.yaml.

Repo: https://github.com/opendatahub-io/feast-module-operator/
Jira: https://redhat.atlassian.net/browse/RHOAIENG-73115

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build manifest mapping to include an additional operator source-to-destination path, which supports manifest generation for that component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->