### PR TITLE
RHOAIENG-58789: trust bots, lgtm, and scope xKS e2e triggers

### DIFF
--- a/.github/workflows/test-cloudmanager-e2e.yaml
+++ b/.github/workflows/test-cloudmanager-e2e.yaml
@@ -42,14 +42,27 @@ jobs:
       - name: Check authorization
         env:
           AUTHOR_ASSOCIATION: ${{ github.event.pull_request.author_association }}
+          AUTHOR_LOGIN: ${{ github.event.pull_request.user.login }}
           EVENT_ACTION: ${{ github.event.action }}
           LABEL_NAME: ${{ github.event.label.name }}
+          HAS_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'run-xks-e2e') }}
         run: |
+          TRUSTED_BOTS=("odh-release-bot[bot]" "jira-autofix[bot]" "dependabot[bot]")
           if [[ "$AUTHOR_ASSOCIATION" =~ ^(OWNER|MEMBER|COLLABORATOR)$ ]]; then
             echo "Trusted contributor — running automatically"
             exit 0
           fi
-          if [[ "$EVENT_ACTION" == "labeled" && "$LABEL_NAME" == "run-xks-e2e" ]]; then
+          for bot in "${TRUSTED_BOTS[@]}"; do
+            if [[ "$AUTHOR_LOGIN" == "$bot" ]]; then
+              echo "Trusted bot — running automatically"
+              exit 0
+            fi
+          done
+          if [[ "$EVENT_ACTION" == "labeled" && ( "$LABEL_NAME" == "lgtm" || "$LABEL_NAME" == "approved" ) ]]; then
+            echo "Reviewer approval ($LABEL_NAME) — running automatically"
+            exit 0
+          fi
+          if [[ "$HAS_LABEL" == "true" ]]; then
             echo "External contributor — approved via label"
             exit 0
           fi

--- a/.github/workflows/test-kind-odh-e2e.yaml
+++ b/.github/workflows/test-kind-odh-e2e.yaml
@@ -5,6 +5,23 @@ on:
     types: [opened, labeled, synchronize, reopened]
     branches:
       - main
+    paths:
+      - 'api/components/v1alpha1/kserve_types.go'
+      - 'internal/controller/components/kserve/**'
+      - 'config/rbac/components_kserve_editor_role.yaml'
+      - 'config/rbac/components_kserve_viewer_role.yaml'
+      - 'tests/e2e/kserve_test.go'
+      - 'cmd/cloudmanager/**'
+      - 'internal/controller/cloudmanager/**'
+      - 'config/cloudmanager/**'
+      - 'api/cloudmanager/**'
+      - 'tests/e2e/cloudmanager/**'
+      - 'pkg/controller/cloudmanager/**'
+      - 'pkg/operatorconfig/cloudmanager.go'
+      - 'pkg/utils/test/cloudmanager/**'
+      - 'config/rhaii/**'
+      - 'get_all_manifests.sh'
+      - '.github/workflows/test-kind-odh-e2e.yaml'
 
 permissions:
   contents: read
@@ -29,14 +46,27 @@ jobs:
       - name: Check authorization
         env:
           AUTHOR_ASSOCIATION: ${{ github.event.pull_request.author_association }}
+          AUTHOR_LOGIN: ${{ github.event.pull_request.user.login }}
           EVENT_ACTION: ${{ github.event.action }}
           LABEL_NAME: ${{ github.event.label.name }}
+          HAS_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'run-xks-e2e') }}
         run: |
+          TRUSTED_BOTS=("odh-release-bot[bot]" "jira-autofix[bot]" "dependabot[bot]")
           if [[ "$AUTHOR_ASSOCIATION" =~ ^(OWNER|MEMBER|COLLABORATOR)$ ]]; then
             echo "Trusted contributor — running automatically"
             exit 0
           fi
-          if [[ "$EVENT_ACTION" == "labeled" && "$LABEL_NAME" == "run-xks-e2e" ]]; then
+          for bot in "${TRUSTED_BOTS[@]}"; do
+            if [[ "$AUTHOR_LOGIN" == "$bot" ]]; then
+              echo "Trusted bot — running automatically"
+              exit 0
+            fi
+          done
+          if [[ "$EVENT_ACTION" == "labeled" && ( "$LABEL_NAME" == "lgtm" || "$LABEL_NAME" == "approved" ) ]]; then
+            echo "Reviewer approval ($LABEL_NAME) — running automatically"
+            exit 0
+          fi
+          if [[ "$HAS_LABEL" == "true" ]]; then
             echo "External contributor — approved via label"
             exit 0
           fi


### PR DESCRIPTION
## Description

[RHOAIENG-58789](https://redhat.atlassian.net/browse/RHOAIENG-58789)

`author_association` was supposed to auto-trust the right people, but it under-reports `CONTRIBUTOR` for cases that are actually trusted:

- opendatahub-io members with private org visibility, including this PR's own author ([#3676](https://github.com/opendatahub-io/opendatahub-operator/pull/3676)). Only 70 of 611 members are public, so this is most of the org.
- Bots: `odh-release-bot`, `jira-autofix`, and `dependabot` ([#3768](https://github.com/opendatahub-io/opendatahub-operator/pull/3768), [#3760](https://github.com/opendatahub-io/opendatahub-operator/pull/3760), [#3756](https://github.com/opendatahub-io/opendatahub-operator/pull/3756)).

The membership fix still needs its own investigation into org-level read access. As a stopgap, `run-xks-e2e` is now accepted whenever present instead of only on `labeled`, and those three bot logins are trusted directly since a login can't be spoofed.

`lgtm` is trusted too, but only at the exact `labeled` event: Prow strips it on every new commit here by default, so a malicious `synchronize` commit never carries the action `lgtm` needs, even before Prow removes the stale label.

Since that first gap covers most of the org, running the ODH xKS workflow on every PR relied too much on a signal that fails most of the time:

- It only tests kserve on a Cloud Manager cluster (`make e2e-test-xks` sets `E2E_TEST_COMPONENT=kserve`), so its trigger is now scoped to kserve and cloudmanager paths.
- Shared reconciler changes that could affect kserve indirectly won't trigger it anymore, a smaller gap than running on every PR.

## How Has This Been Tested?

Workflow-only change. Confirmed by reading the updated trigger and authorization logic: a labeled PR keeps running after new commits, a trusted bot login or a fresh `lgtm` labeling runs automatically, an unlabeled PR from a non-trusted author still fails, and a PR touching unrelated paths doesn't trigger the ODH workflow at all.

## Screenshot or short clip

N/A

## Merge criteria

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully
- [ ] New RELATED_IMAGE mappings are listed in ODH-Build-Config and RHOAI-Build-Config (CI validates names against build-config repos). Include links to build-config PRs in the description.

### E2E test suite update requirement

- [x] Skip requirement to update E2E test suite for this PR

#### E2E update requirement opt-out justification

CI workflow configuration only. No operator source code or tests changed.


[RHOAIENG-58789]: https://redhat.atlassian.net/browse/RHOAIENG-58789?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved end-to-end test auto-approval so PR labels are checked directly on the pull request, making runs more reliable.
  * Updated trusted contributor handling to recognize the correct author account for automated approval.
  * Limited one test workflow to relevant file changes, reducing unnecessary runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->