### PR TITLE
RHOAIENG-72180 | Early-gate: add early-gate CI pipelines

### DIFF
--- a/.tekton/early-gate-ci-build.yaml
+++ b/.tekton/early-gate-ci-build.yaml
@@ -1,0 +1,37 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-event: "[issue_comment]"
+    pipelinesascode.tekton.dev/on-comment: "^/early-gate(-build)?$"
+  labels:
+    appstudio.openshift.io/application: early-gate
+    appstudio.openshift.io/component: early-gate-ci
+    pipelines.appstudio.openshift.io/type: build
+  name: early-gate-ci-build
+  namespace: open-data-hub-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  pipelineRef:
+    resolver: git
+    params:
+    - name: url
+      value: https://github.com/opendatahub-io/odh-konflux-central.git
+    - name: revision
+      value: 'main'
+    - name: pathInRepo
+      value: early-gate/early-gate-operator-pipeline.yaml
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-early-gate-ci
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}

--- a/.tekton/early-gate-ci-test.yaml
+++ b/.tekton/early-gate-ci-test.yaml
@@ -1,0 +1,40 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-event: "[issue_comment]"
+    pipelinesascode.tekton.dev/on-comment: "^/early-gate-test$"
+  labels:
+    appstudio.openshift.io/application: early-gate
+    appstudio.openshift.io/component: early-gate-ci
+    pipelines.appstudio.openshift.io/type: test
+  name: early-gate-ci-test
+  namespace: open-data-hub-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  timeouts:
+    pipeline: 6h
+    tasks: 5h
+  pipelineRef:
+    resolver: git
+    params:
+    - name: url
+      value: https://github.com/opendatahub-io/odh-konflux-central.git
+    - name: revision
+      value: 'main'
+    - name: pathInRepo
+      value: early-gate/early-gate-test-pipeline.yaml
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-early-gate-ci
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}

--- a/.tekton/odh-operator-ci-pull-request.yaml
+++ b/.tekton/odh-operator-ci-pull-request.yaml
@@ -40,6 +40,8 @@ spec:
   - name: build-args
     value:
     - BUILD_TYPE=CI
+  - name: enable-early-gate-testing
+    value: "false"
   pipelineRef:
     resolver: git
     params:


### PR DESCRIPTION

<!---
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

This PR adds early-gate CI pipelines to the repository.
Changes

    Added .tekton/early-gate-ci-build.yaml for build validation
    Added .tekton/early-gate-ci-test.yaml for test validation (if available)
    Edited .tekton/odh-operator-ci-pull-request.yaml to disable auto-trigger for eg builds

Usage

Comment /early-gate or /early-gate-build on a PR to trigger the early-gate build pipeline.
Configuration

The repository has been added to the early-gate-config.yaml in odh-konflux-central.

<!--- Link your JIRA and related links here for reference. -->
* https://redhat.atlassian.net/browse/RHOAIENG-72180

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully
- [ ] New RELATED_IMAGE mappings are listed in ODH-Build-Config and RHOAI-Build-Config (CI validates names against build-config repos). Include links to build-config PRs in the description.

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->
no new e2e needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added two new Tekton PipelineRuns for early-gate CI: one for build and one for test.
  * Enabled issue-comment–based triggers for early-gate CI, with commit SHA and target-branch tracking metadata.
* **Configuration Updates**
  * Set up authenticated Git workspace access, pipeline parameters, and build/test timeouts; added retention to limit stored early-gate test runs.
  * Updated the operator CI pull-request PipelineRun with `enable-early-gate-testing` set to `"false"`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->