### PR TITLE
fix gc action and buildmodule should allow nil return

### DIFF
--- a/internal/controller/components/kserve/kserve.go
+++ b/internal/controller/components/kserve/kserve.go
@@ -8,12 +8,14 @@ import (
 	operatorv1 "github.com/openshift/api/operator/v1"
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/opendatahub-io/opendatahub-operator/v2/api/common"
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/api/components/v1alpha1"
 	dscv2 "github.com/opendatahub-io/opendatahub-operator/v2/api/datasciencecluster/v2"
 	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/components"
+	cr "github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/components/registry"
 	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/status"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/conditions"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
@@ -83,8 +85,18 @@ func (s *componentHandler) Init(_ common.Platform, cfg operatorconfig.OperatorSe
 	return nil
 }
 
+var _ cr.InstanceNamer = (*componentHandler)(nil)
+
 func (s *componentHandler) GetName() string {
 	return componentName
+}
+
+func (s *componentHandler) GetInstanceName() string {
+	return componentApi.KserveInstanceName
+}
+
+func (s *componentHandler) GetInstanceGVK() schema.GroupVersionKind {
+	return componentApi.GroupVersion.WithKind(componentApi.KserveKind)
 }
 
 // for DSC to get component Kserve's CR.

--- a/internal/controller/components/registry/readiness.go
+++ b/internal/controller/components/registry/readiness.go
@@ -7,6 +7,8 @@ import (
 
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -15,6 +17,15 @@ import (
 	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/status"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/dag"
 )
+
+// InstanceNamer is an optional interface a ComponentHandler can implement
+// to expose the well-known singleton CR name and GVK. The readiness
+// checker uses this on xKS (where DSC is nil) to fetch the CR directly
+// without calling NewCRObject, which requires a non-nil DSC.
+type InstanceNamer interface {
+	GetInstanceName() string
+	GetInstanceGVK() schema.GroupVersionKind
+}
 
 // ComponentReadinessChecker implements dag.ReadinessChecker for
 // in-tree components. It looks up the handler by name, constructs
@@ -27,8 +38,11 @@ type ComponentReadinessChecker struct {
 }
 
 // NewReadinessChecker creates a ReadinessChecker backed by this
-// component registry. It needs a client and DSC instance to fetch
-// each component's CR and inspect its conditions.
+// component registry. It needs a client to fetch each component's
+// CR and inspect its conditions. The dsc parameter may be nil on
+// xKS where the DSC controller is suppressed; in that case the
+// checker falls back to registry-level enablement and the
+// InstanceNamer interface for CR lookups.
 func NewReadinessChecker(reg *Registry, cli client.Client, dsc *dscv2.DataScienceCluster) *ComponentReadinessChecker {
 	return &ComponentReadinessChecker{
 		registry: reg,
@@ -45,6 +59,10 @@ func (c *ComponentReadinessChecker) IsReady(ctx context.Context, name string) (b
 	handler := c.registry.Lookup(name)
 	if handler == nil {
 		return false, fmt.Errorf("component %q: %w", name, dag.ErrUnknownNode)
+	}
+
+	if c.dsc == nil {
+		return c.isReadyWithoutDSC(ctx, name, handler)
 	}
 
 	if !handler.IsEnabled(c.dsc) {
@@ -64,7 +82,6 @@ func (c *ComponentReadinessChecker) IsReady(ctx context.Context, name string) (b
 		return false, fmt.Errorf("component %q CR does not implement client.Object", name)
 	}
 
-	// Fetch the live CR from the cluster to read its actual status.
 	err = c.client.Get(ctx, types.NamespacedName{Name: obj.GetName()}, obj)
 	if err != nil {
 		if k8serr.IsNotFound(err) {
@@ -79,6 +96,48 @@ func (c *ComponentReadinessChecker) IsReady(ctx context.Context, name string) (b
 	}
 
 	return isComponentCRReady(live), nil
+}
+
+func (c *ComponentReadinessChecker) isReadyWithoutDSC(ctx context.Context, name string, handler ComponentHandler) (bool, error) {
+	if !c.registry.IsEnabled(name) {
+		return true, nil
+	}
+
+	namer, ok := handler.(InstanceNamer)
+	if !ok {
+		return true, nil
+	}
+
+	u := &unstructured.Unstructured{}
+	u.SetGroupVersionKind(namer.GetInstanceGVK())
+
+	if err := c.client.Get(ctx, types.NamespacedName{Name: namer.GetInstanceName()}, u); err != nil {
+		if k8serr.IsNotFound(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("component %q: failed to get CR: %w", name, err)
+	}
+
+	return isUnstructuredCRReady(u), nil
+}
+
+func isUnstructuredCRReady(u *unstructured.Unstructured) bool {
+	conditions, found, _ := unstructured.NestedSlice(u.Object, "status", "conditions")
+	if !found {
+		return false
+	}
+	for _, item := range conditions {
+		c, ok := item.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		condType, _, _ := unstructured.NestedString(c, "type")
+		condStatus, _, _ := unstructured.NestedString(c, "status")
+		if condType == status.ConditionTypeReady {
+			return condStatus == string(metav1.ConditionTrue)
+		}
+	}
+	return false
 }
 
 func isComponentCRReady(obj common.PlatformObject) bool {

--- a/internal/controller/components/registry/readiness_test.go
+++ b/internal/controller/components/registry/readiness_test.go
@@ -1,0 +1,173 @@
+package registry_test
+
+import (
+	"context"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/opendatahub-io/opendatahub-operator/v2/api/common"
+	dscv2 "github.com/opendatahub-io/opendatahub-operator/v2/api/datasciencecluster/v2"
+	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/components/registry"
+	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/status"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/dag"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/operatorconfig"
+
+	. "github.com/onsi/gomega"
+)
+
+var testGVK = schema.GroupVersionKind{
+	Group:   "test.example.com",
+	Version: "v1",
+	Kind:    "TestComponent",
+}
+
+type readinessHandler struct {
+	name    string
+	enabled bool
+}
+
+func (f *readinessHandler) Init(_ common.Platform, _ operatorconfig.OperatorSettings) error {
+	return nil
+}
+func (f *readinessHandler) GetName() string { return f.name }
+func (f *readinessHandler) NewCRObject(_ context.Context, _ client.Client, _ *dscv2.DataScienceCluster) (common.PlatformObject, error) {
+	return nil, nil
+}
+func (f *readinessHandler) NewComponentReconciler(_ context.Context, _ ctrl.Manager) error {
+	return nil
+}
+func (f *readinessHandler) UpdateDSCStatus(_ context.Context, _ *types.ReconciliationRequest) (metav1.ConditionStatus, error) {
+	return metav1.ConditionTrue, nil
+}
+func (f *readinessHandler) IsEnabled(_ *dscv2.DataScienceCluster) bool { return f.enabled }
+
+type readinessHandlerWithNamer struct {
+	readinessHandler
+
+	instanceName string
+	instanceGVK  schema.GroupVersionKind
+}
+
+func (f *readinessHandlerWithNamer) GetInstanceName() string                 { return f.instanceName }
+func (f *readinessHandlerWithNamer) GetInstanceGVK() schema.GroupVersionKind { return f.instanceGVK }
+
+var _ registry.InstanceNamer = (*readinessHandlerWithNamer)(nil)
+
+func newFakeClient(scheme *runtime.Scheme, objs ...client.Object) client.Client {
+	return fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
+}
+
+func readinessTestScheme() *runtime.Scheme {
+	s := runtime.NewScheme()
+	_ = dscv2.AddToScheme(s)
+	return s
+}
+
+func TestReadinessChecker_NilDSC_SuppressedComponent_IsReady(t *testing.T) {
+	t.Parallel()
+	g := NewWithT(t)
+
+	reg := &registry.Registry{}
+	reg.Add(&readinessHandler{name: "suppressed", enabled: true})
+	reg.Disable("suppressed")
+
+	checker := registry.NewReadinessChecker(reg, newFakeClient(readinessTestScheme()), nil)
+	ready, err := checker.IsReady(context.Background(), "suppressed")
+	g.Expect(err).ShouldNot(HaveOccurred())
+	g.Expect(ready).Should(BeTrue(), "suppressed component should be treated as ready")
+}
+
+func TestReadinessChecker_NilDSC_EnabledNoInstanceNamer_IsReady(t *testing.T) {
+	t.Parallel()
+	g := NewWithT(t)
+
+	reg := &registry.Registry{}
+	reg.Add(&readinessHandler{name: "no-namer", enabled: true})
+
+	checker := registry.NewReadinessChecker(reg, newFakeClient(readinessTestScheme()), nil)
+	ready, err := checker.IsReady(context.Background(), "no-namer")
+	g.Expect(err).ShouldNot(HaveOccurred())
+	g.Expect(ready).Should(BeTrue(), "handler without InstanceNamer should be treated as ready")
+}
+
+func TestReadinessChecker_NilDSC_CRNotFound_NotReady(t *testing.T) {
+	t.Parallel()
+	g := NewWithT(t)
+
+	reg := &registry.Registry{}
+	reg.Add(&readinessHandlerWithNamer{
+		readinessHandler: readinessHandler{name: "comp-a", enabled: true},
+		instanceName:     "default-comp-a",
+		instanceGVK:      testGVK,
+	})
+
+	cli := newFakeClient(readinessTestScheme())
+	checker := registry.NewReadinessChecker(reg, cli, nil)
+	ready, err := checker.IsReady(context.Background(), "comp-a")
+	g.Expect(err).ShouldNot(HaveOccurred())
+	g.Expect(ready).Should(BeFalse(), "CR not found should mean not ready")
+}
+
+func TestReadinessChecker_NilDSC_CRExistsReadinessStatus(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		condStatus  metav1.ConditionStatus
+		expectReady bool
+	}{
+		{"Ready=True means ready", metav1.ConditionTrue, true},
+		{"Ready=False means not ready", metav1.ConditionFalse, false},
+		{"Ready=Unknown means not ready", metav1.ConditionUnknown, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewWithT(t)
+
+			cr := &unstructured.Unstructured{}
+			cr.SetGroupVersionKind(testGVK)
+			cr.SetName("default-comp")
+			_ = unstructured.SetNestedSlice(cr.Object, []interface{}{
+				map[string]interface{}{
+					"type":   status.ConditionTypeReady,
+					"status": string(tt.condStatus),
+				},
+			}, "status", "conditions")
+
+			reg := &registry.Registry{}
+			reg.Add(&readinessHandlerWithNamer{
+				readinessHandler: readinessHandler{name: "comp", enabled: true},
+				instanceName:     "default-comp",
+				instanceGVK:      testGVK,
+			})
+
+			cli := newFakeClient(readinessTestScheme(), cr)
+			checker := registry.NewReadinessChecker(reg, cli, nil)
+			ready, err := checker.IsReady(context.Background(), "comp")
+			g.Expect(err).ShouldNot(HaveOccurred())
+			g.Expect(ready).Should(Equal(tt.expectReady))
+		})
+	}
+}
+
+func TestReadinessChecker_NilDSC_UnknownNode(t *testing.T) {
+	t.Parallel()
+	g := NewWithT(t)
+
+	reg := &registry.Registry{}
+
+	checker := registry.NewReadinessChecker(reg, newFakeClient(readinessTestScheme()), nil)
+	_, err := checker.IsReady(context.Background(), "nonexistent")
+	g.Expect(err).Should(HaveOccurred())
+	g.Expect(err).Should(MatchError(ContainSubstring(dag.ErrUnknownNode.Error())))
+}

--- a/internal/controller/datasciencecluster/datasciencecluster_controller_actions.go
+++ b/internal/controller/datasciencecluster/datasciencecluster_controller_actions.go
@@ -109,8 +109,6 @@ func provisionComponents(ctx context.Context, rr *odhtype.ReconciliationRequest)
 		return fmt.Errorf("resource instance %v is not a dscv2.DataScienceCluster)", rr.Instance)
 	}
 
-	rr.Generated = true
-
 	checker := provision.NewCompositeChecker(
 		cr.NewReadinessChecker(cr.DefaultRegistry(), rr.Client, instance),
 		modules.NewReadinessChecker(modules.DefaultRegistry(), rr.Client, rr.Release.Version.String(),
@@ -176,10 +174,10 @@ func provisionComponents(ctx context.Context, rr *odhtype.ReconciliationRequest)
 	}
 
 	if requeueAfter > 0 {
-		rr.Generated = false
-
 		return odherrors.NewRequeueAfterError(requeueAfter)
 	}
+
+	rr.Generated = true
 
 	if len(failedComponents) > 0 {
 		rr.Conditions.SetCondition(common.Condition{

--- a/internal/controller/datasciencecluster/datasciencecluster_controller_actions.go
+++ b/internal/controller/datasciencecluster/datasciencecluster_controller_actions.go
@@ -176,6 +176,8 @@ func provisionComponents(ctx context.Context, rr *odhtype.ReconciliationRequest)
 	}
 
 	if requeueAfter > 0 {
+		rr.Generated = false
+
 		return odherrors.NewRequeueAfterError(requeueAfter)
 	}
 

--- a/internal/controller/modules/modules_controller.go
+++ b/internal/controller/modules/modules_controller.go
@@ -141,6 +141,7 @@ func newPlatformModuleReconciler(ctx context.Context, mgr ctrl.Manager) error {
 	if reg.HasEntries() {
 		_ = reg.ForAll(func(h ModuleHandler, _ bool) error {
 			b = b.WatchesGVK(h.GetGVK(),
+				reconciler.Dynamic(reconciler.CrdExists(h.GetGVK())),
 				reconciler.WithEventMapper(
 					func(ctx context.Context, _ client.Object) []reconcile.Request {
 						return cluster.WatchPlatforms(ctx, mgr.GetClient())

--- a/internal/controller/modules/modules_controller.go
+++ b/internal/controller/modules/modules_controller.go
@@ -137,11 +137,27 @@ func newPlatformModuleReconciler(ctx context.Context, mgr ctrl.Manager) error {
 		WithoutStatusConditionsIf(cr.HasEntries).
 		WithAction(enableModulesFromPlatform)
 
+	reg := DefaultRegistry()
+	if reg.HasEntries() {
+		_ = reg.ForAll(func(h ModuleHandler, _ bool) error {
+			b = b.WatchesGVK(h.GetGVK(),
+				reconciler.WithEventMapper(
+					func(ctx context.Context, _ client.Object) []reconcile.Request {
+						return cluster.WatchPlatforms(ctx, mgr.GetClient())
+					}),
+				reconciler.WithPredicates(predicates.DefaultPredicate))
+			return nil
+		})
+	}
+
 	for _, a := range commonActions() {
 		b = b.WithAction(a)
 	}
 
-	rec, err := b.WithConditions(status.ConditionTypeModulesReady).Build(ctx)
+	rec, err := b.WithConditions(
+		status.ConditionTypeModulesReady,
+		status.ConditionTypeProvisioningProgress,
+	).Build(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to create module reconciler (platform mode): %w", err)
 	}

--- a/internal/controller/modules/modules_controller.go
+++ b/internal/controller/modules/modules_controller.go
@@ -139,7 +139,7 @@ func newPlatformModuleReconciler(ctx context.Context, mgr ctrl.Manager) error {
 
 	reg := DefaultRegistry()
 	if reg.HasEntries() {
-		_ = reg.ForAll(func(h ModuleHandler, _ bool) error {
+		if err := reg.ForAll(func(h ModuleHandler, _ bool) error {
 			b = b.WatchesGVK(h.GetGVK(),
 				reconciler.Dynamic(reconciler.CrdExists(h.GetGVK())),
 				reconciler.WithEventMapper(
@@ -148,7 +148,9 @@ func newPlatformModuleReconciler(ctx context.Context, mgr ctrl.Manager) error {
 					}),
 				reconciler.WithPredicates(predicates.DefaultPredicate))
 			return nil
-		})
+		}); err != nil {
+			return fmt.Errorf("failed to register module GVK watches: %w", err)
+		}
 	}
 
 	for _, a := range commonActions() {

--- a/internal/controller/modules/modules_controller_actions.go
+++ b/internal/controller/modules/modules_controller_actions.go
@@ -258,12 +258,20 @@ func provisionModules(ctx context.Context, rr *odhtype.ReconciliationRequest) er
 	var perModuleImages []odhtype.ModuleImages
 	var failedModules []string
 
-	// The DSC controller is the sole owner of the ProvisioningProgress
-	// condition. Pass a no-op writer so the modules controller still
-	// participates in DAG gating but doesn't clobber the DSC
-	// controller's condition via the +listType=atomic SSA race.
-	requeueAfter, walkErr := provision.WalkBatches(ctx, checker, moduleStuckTracker, string(rr.Instance.GetUID()), provision.NoOpConditionWriter{},
+	var condWriter provision.ConditionWriter = provision.NoOpConditionWriter{}
+	if !flags.IsDSCEnabled() {
+		condWriter = rr.Conditions
+	}
+
+	requeueAfter, walkErr := provision.WalkBatches(ctx, checker, moduleStuckTracker, string(rr.Instance.GetUID()), condWriter,
 		func(batch []provision.UnifiedNode) error {
+			if !flags.IsDSCEnabled() {
+				provision.GetRunlevelTracker().MarkCleared(
+					rr.Release.Version.String(),
+					batch[0].GetRunlevel().Order,
+				)
+			}
+
 			for _, entry := range provision.ModulesInBatch(batch) {
 				handler := reg.Lookup(entry.GetName())
 				if handler == nil {
@@ -280,18 +288,6 @@ func provisionModules(ctx context.Context, rr *odhtype.ReconciliationRequest) er
 
 				operatorManifests := handler.GetOperatorManifests(platformCtx)
 
-				moduleCR, err := handler.BuildModuleCR(ctx, rr.Client, platformCtx)
-				if err != nil {
-					log.Error(err, "BuildModuleCR failed (programming error)", "module", name)
-					failedModules = append(failedModules, name)
-					continue
-				}
-				if moduleCR == nil {
-					log.Error(nil, "BuildModuleCR returned nil without error (programming error)", "module", name)
-					failedModules = append(failedModules, name)
-					continue
-				}
-
 				perModuleImages = append(perModuleImages, odhtype.ModuleImages{
 					DeploymentName:    deploymentNameFor(handler, operatorManifests),
 					ContainerName:     containerNameFor(handler),
@@ -306,7 +302,17 @@ func provisionModules(ctx context.Context, rr *odhtype.ReconciliationRequest) er
 					rr.Manifests = append(rr.Manifests, operatorManifests.Manifests...)
 				}
 
-				rr.Resources = append(rr.Resources, *moduleCR)
+				moduleCR, err := handler.BuildModuleCR(ctx, rr.Client, platformCtx)
+				if err != nil {
+					log.Error(err, "BuildModuleCR failed", "module", name)
+					failedModules = append(failedModules, name)
+					continue
+				}
+				if moduleCR != nil {
+					rr.Resources = append(rr.Resources, *moduleCR)
+				} else {
+					log.V(1).Info("BuildModuleCR returned nil, CR is externally managed", "module", name)
+				}
 			}
 			return nil
 		},

--- a/internal/controller/modules/types.go
+++ b/internal/controller/modules/types.go
@@ -64,6 +64,11 @@ type ModuleHandler interface {
 	// added to rr.Resources and applied by deploy.NewAction alongside operator
 	// resources. This is the single isolation point for the platform-to-module-CR
 	// field mapping.
+	//
+	// Returning (nil, nil) is valid and signals that the CR is externally
+	// managed (e.g. created by the CCM Helm chart on xKS). Operator
+	// manifests and image overrides are still collected; only the CR
+	// itself is skipped.
 	BuildModuleCR(ctx context.Context, cli client.Client, platform *PlatformContext) (*unstructured.Unstructured, error)
 
 	// GetRelatedImages returns the RELATED_IMAGE_* environment variable names

--- a/pkg/cluster/resources.go
+++ b/pkg/cluster/resources.go
@@ -22,6 +22,7 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
+	configv1alpha1 "github.com/opendatahub-io/opendatahub-operator/v2/api/config/v1alpha1"
 	dscv2 "github.com/opendatahub-io/opendatahub-operator/v2/api/datasciencecluster/v2"
 	dsciv2 "github.com/opendatahub-io/opendatahub-operator/v2/api/dscinitialization/v2"
 	infrav1 "github.com/opendatahub-io/opendatahub-operator/v2/api/infrastructure/v1"
@@ -119,6 +120,26 @@ func WatchDataScienceClusters(ctx context.Context, cli client.Client) []reconcil
 	instanceList := &dscv2.DataScienceClusterList{}
 	if err := cli.List(ctx, instanceList); err != nil {
 		logf.FromContext(ctx).Error(err, "failed to list DataScienceCluster instances for watch mapping")
+		return []reconcile.Request{}
+	}
+
+	requests := make([]reconcile.Request, len(instanceList.Items))
+	for i := range instanceList.Items {
+		requests[i] = reconcile.Request{
+			NamespacedName: types.NamespacedName{Name: instanceList.Items[i].Name},
+		}
+	}
+
+	return requests
+}
+
+// WatchPlatforms lists all Platform CR instances and returns reconcile
+// requests for each. Use this as an event mapper to re-queue the Platform
+// controller when related resources (module CRs) change.
+func WatchPlatforms(ctx context.Context, cli client.Client) []reconcile.Request {
+	instanceList := &configv1alpha1.PlatformList{}
+	if err := cli.List(ctx, instanceList); err != nil {
+		logf.FromContext(ctx).Error(err, "failed to list Platform instances for watch mapping")
 		return []reconcile.Request{}
 	}
 

--- a/pkg/cluster/resources.go
+++ b/pkg/cluster/resources.go
@@ -133,24 +133,12 @@ func WatchDataScienceClusters(ctx context.Context, cli client.Client) []reconcil
 	return requests
 }
 
-// WatchPlatforms lists all Platform CR instances and returns reconcile
-// requests for each. Use this as an event mapper to re-queue the Platform
-// controller when related resources (module CRs) change.
-func WatchPlatforms(ctx context.Context, cli client.Client) []reconcile.Request {
-	instanceList := &configv1alpha1.PlatformList{}
-	if err := cli.List(ctx, instanceList); err != nil {
-		logf.FromContext(ctx).Error(err, "failed to list Platform instances for watch mapping")
-		return []reconcile.Request{}
+// WatchPlatforms returns a reconcile request for the Platform singleton.
+// Platform has a webhook-enforced name so no list call is needed.
+func WatchPlatforms(_ context.Context, _ client.Client) []reconcile.Request {
+	return []reconcile.Request{
+		{NamespacedName: types.NamespacedName{Name: configv1alpha1.PlatformInstanceName}},
 	}
-
-	requests := make([]reconcile.Request, len(instanceList.Items))
-	for i := range instanceList.Items {
-		requests[i] = reconcile.Request{
-			NamespacedName: types.NamespacedName{Name: instanceList.Items[i].Name},
-		}
-	}
-
-	return requests
 }
 
 // GetDSCI retrieves the DSCInitialization (DSCI) instance from the Kubernetes cluster.

--- a/pkg/cluster/resources_test.go
+++ b/pkg/cluster/resources_test.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	configv1alpha1 "github.com/opendatahub-io/opendatahub-operator/v2/api/config/v1alpha1"
 	dscv2 "github.com/opendatahub-io/opendatahub-operator/v2/api/datasciencecluster/v2"
 	dsciv2 "github.com/opendatahub-io/opendatahub-operator/v2/api/dscinitialization/v2"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
@@ -365,5 +366,37 @@ func TestListConfigMapUsingGVK(t *testing.T) {
 		g.Expect(res).Should(HaveLen(1))
 		g.Expect(res[0].GetName()).Should(Equal("configmap2"))
 		g.Expect(res[0].GetNamespace()).Should(Equal(ns))
+	})
+}
+
+func TestWatchPlatforms(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	t.Run("should return requests for existing Platform CRs", func(t *testing.T) {
+		t.Parallel()
+		g := NewWithT(t)
+
+		cli, err := fakeclient.New(
+			fakeclient.WithObjects(
+				&configv1alpha1.Platform{ObjectMeta: metav1.ObjectMeta{Name: "default"}},
+			),
+		)
+		g.Expect(err).ShouldNot(HaveOccurred())
+
+		requests := cluster.WatchPlatforms(ctx, cli)
+		g.Expect(requests).Should(HaveLen(1))
+		g.Expect(requests[0].Name).Should(Equal("default"))
+	})
+
+	t.Run("should return empty slice when no Platform CRs exist", func(t *testing.T) {
+		t.Parallel()
+		g := NewWithT(t)
+
+		cli, err := fakeclient.New()
+		g.Expect(err).ShouldNot(HaveOccurred())
+
+		requests := cluster.WatchPlatforms(ctx, cli)
+		g.Expect(requests).Should(BeEmpty())
 	})
 }

--- a/pkg/cluster/resources_test.go
+++ b/pkg/cluster/resources_test.go
@@ -371,32 +371,13 @@ func TestListConfigMapUsingGVK(t *testing.T) {
 
 func TestWatchPlatforms(t *testing.T) {
 	t.Parallel()
-	ctx := t.Context()
 
-	t.Run("should return requests for existing Platform CRs", func(t *testing.T) {
+	t.Run("should return request for the Platform singleton", func(t *testing.T) {
 		t.Parallel()
 		g := NewWithT(t)
 
-		cli, err := fakeclient.New(
-			fakeclient.WithObjects(
-				&configv1alpha1.Platform{ObjectMeta: metav1.ObjectMeta{Name: "default"}},
-			),
-		)
-		g.Expect(err).ShouldNot(HaveOccurred())
-
-		requests := cluster.WatchPlatforms(ctx, cli)
+		requests := cluster.WatchPlatforms(t.Context(), nil)
 		g.Expect(requests).Should(HaveLen(1))
-		g.Expect(requests[0].Name).Should(Equal("default"))
-	})
-
-	t.Run("should return empty slice when no Platform CRs exist", func(t *testing.T) {
-		t.Parallel()
-		g := NewWithT(t)
-
-		cli, err := fakeclient.New()
-		g.Expect(err).ShouldNot(HaveOccurred())
-
-		requests := cluster.WatchPlatforms(ctx, cli)
-		g.Expect(requests).Should(BeEmpty())
+		g.Expect(requests[0].Name).Should(Equal(configv1alpha1.PlatformInstanceName))
 	})
 }


### PR DESCRIPTION
<!---
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

- Prevent GC from deleting component CRs during DAG gating (RHOAIENG-73142): When a lower-runlevel component blocks provisioning, rr.Generated is now set to false so the GC action skips execution with an incomplete resource set.
- Unblock DAG progression on xKS (RHOAIENG-72878): On xKS (no DSC controller), runlevels were never cleared. The module controller's provisionModules now calls MarkCleared() and writes ProvisioningProgress conditions when !IsDSCEnabled(), taking over DAG orchestration from the absent DSC controller.
- Support externally-created module CRs (RHOAIENG-68289): BuildModuleCR can now return (nil, nil) to signal an externally-managed CR (e.g. created by CCM Helm chart on xKS). The Platform reconciler registers explicit watches for each module CR GVK so it reacts to external creates/updates. ComponentReadinessChecker.IsReady handles nil DSC by fetching the CR directly via an InstanceNamer optional interface.

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully
- [ ] New RELATED_IMAGE mappings are listed in ODH-Build-Config and RHOAI-Build-Config (CI validates names against build-config repos). Include links to build-config PRs in the description.

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->
XKS E2E covers this behaviour.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added platform watch mapping so the platform controller reacts to Platform CR changes.
  * Enhanced KServe component integration to expose instance identity for readiness checks.
* **Bug Fixes**
  * Improved component readiness when live DSC data is unavailable, including externally managed components via CR status conditions.
  * Fixed module provisioning progress handling to avoid clobbering and to support externally managed modules returning no CR.
* **Documentation**
  * Clarified that modules may be externally managed by returning `(nil, nil)`, and described nil-DSC readiness behavior.
* **Tests**
  * Added coverage for nil-DSC readiness scenarios and platform watch mapping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->