### PR TITLE
update: add two new latency-predictor images into kserve + exclude validation on Helm image

### DIFF
--- a/.github/scripts/validate-related-images.sh
+++ b/.github/scripts/validate-related-images.sh
@@ -182,6 +182,23 @@ record_odh_exception_match() {
     grep "^${image}|" "$ODH_EXCEPTIONS_FILE" | head -1 >> "$ODH_EXCEPTIONS_MATCHED"
 }
 
+# RHAI Helm exceptions: images owned by a rhai_helm_components component but
+# intentionally absent from the RHAI Helm chart (still checked against ODH/RHOAI)
+RHAI_HELM_EXCEPTIONS_FILE="$WORKDIR/rhai-helm-exceptions.txt"
+RHAI_HELM_EXCEPTIONS_MATCHED="$WORKDIR/rhai-helm-exceptions-matched.txt"
+touch "$RHAI_HELM_EXCEPTIONS_FILE" "$RHAI_HELM_EXCEPTIONS_MATCHED"
+$YQ -r '(.rhai_helm_exceptions // [])[] | .image + "|" + .reason' "$CONFIG_FILE" \
+    > "$RHAI_HELM_EXCEPTIONS_FILE"
+
+is_rhai_helm_exception() {
+    grep -q "^$1|" "$RHAI_HELM_EXCEPTIONS_FILE"
+}
+
+record_rhai_helm_exception_match() {
+    local image="$1"
+    grep "^${image}|" "$RHAI_HELM_EXCEPTIONS_FILE" | head -1 >> "$RHAI_HELM_EXCEPTIONS_MATCHED"
+}
+
 # --- Step 3: Extract map entries per component ---
 # For each component dir, extract Go map entries: "key": "RELATED_IMAGE_*"
 # Output: component/key/RELATED_IMAGE_VALUE lines
@@ -381,6 +398,13 @@ while IFS= read -r related_image; do
         done < "$RHAI_HELM_COMPONENTS"
     fi
 
+    # RHAI Helm exceptions: skip the RHAI Helm chart requirement for images
+    # intentionally not deployed via the chart (still validated against ODH/RHOAI)
+    if $needs_rhai_helm && is_rhai_helm_exception "$related_image"; then
+        record_rhai_helm_exception_match "$related_image"
+        needs_rhai_helm=false
+    fi
+
     # ODH exceptions: treat image as present in ODH if intentionally excluded
     if is_odh_exception "$related_image"; then
         record_odh_exception_match "$related_image"
@@ -514,6 +538,10 @@ if [ -s "$ODH_EXCEPTIONS_MATCHED" ]; then
     local_oe_count=$(sort -u "$ODH_EXCEPTIONS_MATCHED" | wc -l | tr -d ' ')
     printf ", ${CYAN}%d ODH exception(s)${RESET}" "$local_oe_count"
 fi
+if [ -s "$RHAI_HELM_EXCEPTIONS_MATCHED" ]; then
+    local_re_count=$(sort -u "$RHAI_HELM_EXCEPTIONS_MATCHED" | wc -l | tr -d ' ')
+    printf ", ${CYAN}%d RHAI Helm exception(s)${RESET}" "$local_re_count"
+fi
 echo ""
 
 # Known issues detail
@@ -531,6 +559,15 @@ if [ -s "$ODH_EXCEPTIONS_MATCHED" ]; then
     printf "  ${CYAN}${BOLD}ODH exceptions (not applicable to ODH, skipped):${RESET}\n"
     sort -u "$ODH_EXCEPTIONS_MATCHED" | while IFS='|' read -r oe_image oe_reason; do
         printf "    ${CYAN}%s${RESET} - %s\n" "$oe_image" "$oe_reason"
+    done
+fi
+
+# RHAI Helm exceptions detail
+if [ -s "$RHAI_HELM_EXCEPTIONS_MATCHED" ]; then
+    echo ""
+    printf "  ${CYAN}${BOLD}RHAI Helm exceptions (not in RHAI Helm chart, skipped):${RESET}\n"
+    sort -u "$RHAI_HELM_EXCEPTIONS_MATCHED" | while IFS='|' read -r re_image re_reason; do
+        printf "    ${CYAN}%s${RESET} - %s\n" "$re_image" "$re_reason"
     done
 fi
 
@@ -577,6 +614,29 @@ if [ -s "$ODH_EXCEPTIONS_FILE" ]; then
 
     if [ "$stale_oe_count" -gt 0 ]; then
         WARNINGS=$((WARNINGS + stale_oe_count))
+    fi
+fi
+
+# Detect stale RHAI Helm exceptions (configured but no longer triggered)
+if [ -s "$RHAI_HELM_EXCEPTIONS_FILE" ]; then
+    matched_re_images="$WORKDIR/matched-re-images.txt"
+    sort -u "$RHAI_HELM_EXCEPTIONS_MATCHED" | cut -d'|' -f1 | sort -u > "$matched_re_images" 2>/dev/null || true
+
+    stale_re_count=0
+    while IFS='|' read -r re_image re_reason; do
+        if ! grep -qxF "$re_image" "$matched_re_images" 2>/dev/null; then
+            if [ "$stale_re_count" -eq 0 ]; then
+                echo ""
+                printf "  ${YELLOW}${BOLD}Stale RHAI Helm exceptions (no longer triggered, please remove from ${CONFIG_FILE}):${RESET}\n"
+            fi
+            printf "    ${YELLOW}%s${RESET} - %s\n" "$re_image" "$re_reason"
+            stale_re_count=$((stale_re_count + 1))
+        fi
+    done < "$RHAI_HELM_EXCEPTIONS_FILE"
+    rm -f "$matched_re_images"
+
+    if [ "$stale_re_count" -gt 0 ]; then
+        WARNINGS=$((WARNINGS + stale_re_count))
     fi
 fi
 

--- a/component-params-env.yaml
+++ b/component-params-env.yaml
@@ -2,6 +2,9 @@
 #
 # rhai_helm_components: components whose RELATED_IMAGE_* must also be present
 #   in RHOAI-Build-Config helm/rhai-on-xks-chart/values.yaml (rhaiOperator.relatedImages).
+# rhai_helm_exceptions: RELATED_IMAGE entries owned by a rhai_helm_components
+#   component but intentionally absent from the RHAI Helm chart. These are excluded
+#   from the RHAI Helm validation only (still checked against ODH- and RHOAI-Build-Config).
 # odh_exceptions: RELATED_IMAGE entries intentionally absent from ODH-Build-Config.
 #   These are permanently excluded from ODH validation (e.g. architecture-specific images).
 # known_issues: RELATED_IMAGE errors to downgrade to warnings.
@@ -9,6 +12,12 @@
 
 rhai_helm_components:
   - kserve
+
+rhai_helm_exceptions:
+- image: RELATED_IMAGE_ODH_LATENCY_PREDICTOR_PREDICTION_IMAGE
+  reason: latency predictor images are not reqruied as feature on xKS
+- image: RELATED_IMAGE_ODH_LATENCY_PREDICTOR_TEST_IMAGE
+  reason: latency predictor images are not reqruied as feature on xKS
 
 # Example:
 # - image: RELATED_IMAGE_ODH_CAIKIT_NLP_IMAGE

--- a/internal/controller/components/kserve/kserve_support.go
+++ b/internal/controller/components/kserve/kserve_support.go
@@ -32,22 +32,24 @@ var (
 	ErrResourceNotFound = errors.New("resource not found")
 
 	imageParamMap = map[string]string{
-		"kserve-agent":                     "RELATED_IMAGE_ODH_KSERVE_AGENT_IMAGE",
-		"kserve-controller":                "RELATED_IMAGE_ODH_KSERVE_CONTROLLER_IMAGE",
-		"llmisvc-controller":               "RELATED_IMAGE_ODH_KSERVE_LLMISVC_CONTROLLER_IMAGE",
-		"kserve-router":                    "RELATED_IMAGE_ODH_KSERVE_ROUTER_IMAGE",
-		"kserve-storage-initializer":       "RELATED_IMAGE_ODH_KSERVE_STORAGE_INITIALIZER_IMAGE",
-		"kserve-llm-d":                     "RELATED_IMAGE_RHAII_VLLM_CUDA_IMAGE", // Default image (Nvidia CUDA)
-		"kserve-llm-d-nvidia-cuda":         "RELATED_IMAGE_RHAII_VLLM_CUDA_IMAGE",
-		"kserve-llm-d-amd-rocm":            "RELATED_IMAGE_RHAII_VLLM_ROCM_IMAGE",
-		"kserve-llm-d-ibm-spyre":           "RELATED_IMAGE_RHAII_VLLM_SPYRE_IMAGE",
-		"kserve-llm-d-intel-gaudi":         "RELATED_IMAGE_RHAII_VLLM_GAUDI_IMAGE",
-		"kserve-llm-d-inference-scheduler": "RELATED_IMAGE_ODH_LLM_D_ROUTER_ENDPOINT_PICKER_IMAGE",
-		"kserve-llm-d-routing-sidecar":     "RELATED_IMAGE_ODH_LLM_D_ROUTER_DISAGG_SIDECAR_IMAGE",
-		"kube-rbac-proxy":                  "RELATED_IMAGE_ODH_KUBE_RBAC_PROXY_IMAGE",
-		"kserve-llm-d-uds-tokenizer":       "RELATED_IMAGE_ODH_LLM_D_KV_CACHE_IMAGE",
-		"kserve-localmodel-controller":     "RELATED_IMAGE_ODH_KSERVE_LOCALMODEL_CONTROLLER_IMAGE",
-		"kserve-localmodelnode-agent":      "RELATED_IMAGE_ODH_KSERVE_LOCALMODELNODE_AGENT_IMAGE",
+		"kserve-agent":                              "RELATED_IMAGE_ODH_KSERVE_AGENT_IMAGE",
+		"kserve-controller":                         "RELATED_IMAGE_ODH_KSERVE_CONTROLLER_IMAGE",
+		"llmisvc-controller":                        "RELATED_IMAGE_ODH_KSERVE_LLMISVC_CONTROLLER_IMAGE",
+		"kserve-router":                             "RELATED_IMAGE_ODH_KSERVE_ROUTER_IMAGE",
+		"kserve-storage-initializer":                "RELATED_IMAGE_ODH_KSERVE_STORAGE_INITIALIZER_IMAGE",
+		"kserve-llm-d":                              "RELATED_IMAGE_RHAII_VLLM_CUDA_IMAGE", // Default image (Nvidia CUDA)
+		"kserve-llm-d-nvidia-cuda":                  "RELATED_IMAGE_RHAII_VLLM_CUDA_IMAGE",
+		"kserve-llm-d-amd-rocm":                     "RELATED_IMAGE_RHAII_VLLM_ROCM_IMAGE",
+		"kserve-llm-d-ibm-spyre":                    "RELATED_IMAGE_RHAII_VLLM_SPYRE_IMAGE",
+		"kserve-llm-d-intel-gaudi":                  "RELATED_IMAGE_RHAII_VLLM_GAUDI_IMAGE",
+		"kserve-llm-d-inference-scheduler":          "RELATED_IMAGE_ODH_LLM_D_ROUTER_ENDPOINT_PICKER_IMAGE",
+		"kserve-llm-d-routing-sidecar":              "RELATED_IMAGE_ODH_LLM_D_ROUTER_DISAGG_SIDECAR_IMAGE",
+		"kube-rbac-proxy":                           "RELATED_IMAGE_ODH_KUBE_RBAC_PROXY_IMAGE",
+		"kserve-llm-d-uds-tokenizer":                "RELATED_IMAGE_ODH_LLM_D_KV_CACHE_IMAGE",
+		"kserve-localmodel-controller":              "RELATED_IMAGE_ODH_KSERVE_LOCALMODEL_CONTROLLER_IMAGE",
+		"kserve-localmodelnode-agent":               "RELATED_IMAGE_ODH_KSERVE_LOCALMODELNODE_AGENT_IMAGE",
+		"kserve-llm-d-latency-predictor-prediction": "RELATED_IMAGE_ODH_LATENCY_PREDICTOR_PREDICTION_IMAGE",
+		"kserve-llm-d-latency-predictor-training":   "RELATED_IMAGE_ODH_LATENCY_PREDICTOR_TEST_IMAGE",
 	}
 )
 


### PR DESCRIPTION
<!---
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->
image already onboard in ODH and RHDS

<!--- Link your JIRA and related links here for reference. -->
ref https://redhat.atlassian.net/browse/INFERENG-7809

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully
- [x] New RELATED_IMAGE mappings are listed in ODH-Build-Config and RHOAI-Build-Config (CI validates names against build-config repos). Include links to build-config PRs in the description.

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->
no functional change


cc @RishabhSaini / @pierDipi / @Jooho 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added additional related image mappings for latency predictor prediction and training.
  * Enhanced related image validation to support configurable “RHAI Helm exceptions,” allowing specific images to bypass Helm chart checks when appropriate.
* **Documentation**
  * Updated `component-params-env.yaml` to clarify how RHAI Helm exceptions are owned and validated.
* **Style**
  * Improved formatting consistency in the related configuration mapping.
* **Chores / CI**
  * Improved validation output with exception counts, detailed listings, and warnings for unused configured exceptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->