### PR TITLE
fix(modelcontroller): revert WVA overlay to namespace-scoped/openshift

### DIFF
--- a/internal/controller/components/modelcontroller/modelcontroller_support.go
+++ b/internal/controller/components/modelcontroller/modelcontroller_support.go
@@ -59,6 +59,6 @@ func wvaManifestsPath(basePath string) types.ManifestInfo {
 	return types.ManifestInfo{
 		Path:       basePath,
 		ContextDir: "wva",
-		SourcePath: "overlays/cluster-scoped/openshift",
+		SourcePath: "overlays/namespace-scoped/openshift",
 	}
 }


### PR DESCRIPTION
PR #3765 (825fb122) switched the WVA manifest source path from "overlays/namespace-scoped/openshift" to "overlays/cluster-scoped/openshift".

The namespace-scoped overlay contains a params.env with the concrete controller image (quay.io/opendatahub/workload-variant-autoscaler:v0.8.0), a configMapGenerator that creates a ConfigMap from it, and a replacements block that injects the image into the Deployment's container spec.

The cluster-scoped overlay has none of these - no params.env, no configMapGenerator, no replacements. As a result, the Deployment is rendered with the kustomize placeholder "image: controller:latest", which does not exist and causes wva-controller-manager to CrashLoopBackOff on every cluster.

This cascades into LLM-D-WVADependencies=False, ModelControllerReady=False, and ultimately DSC Ready=False, blocking all Prow e2e tests across every open PR since PR #3765 was merged.

This reverts the source path back to namespace-scoped/openshift to restore the working image injection mechanism.

<!---
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully
- [ ] New RELATED_IMAGE mappings are listed in ODH-Build-Config and RHOAI-Build-Config (CI validates names against build-config repos). Include links to build-config PRs in the description.

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification

revert of commit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated OpenShift manifest loading to use the namespace-scoped overlay, helping ensure the correct configuration is applied in namespace-based deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->