### PR TITLE
Add ubi-micro image mapping for OVMS auto-versioning

### DIFF
--- a/internal/controller/components/kserve/kserve_support.go
+++ b/internal/controller/components/kserve/kserve_support.go
@@ -48,6 +48,7 @@ var (
 		"kserve-llm-d-uds-tokenizer":       "RELATED_IMAGE_ODH_LLM_D_KV_CACHE_IMAGE",
 		"kserve-localmodel-controller":     "RELATED_IMAGE_ODH_KSERVE_LOCALMODEL_CONTROLLER_IMAGE",
 		"kserve-localmodelnode-agent":      "RELATED_IMAGE_ODH_KSERVE_LOCALMODELNODE_AGENT_IMAGE",
+		"ovms-versioning-ubi-micro":        "RELATED_IMAGE_ODH_UBI_MICRO_IMAGE",
 	}
 )
 


### PR DESCRIPTION
## Summary

Adds `ovms-versioning-ubi-micro` to the kserve image parameter mapping to support disconnected environments.

This maps the params.env key to the `RELATED_IMAGE_ODH_UBI_MICRO_IMAGE` environment variable, which will be injected by OLM in disconnected deployments.

## Changes

**File:** `internal/controller/components/kserve/kserve_support.go`
- Add `"ovms-versioning-ubi-micro": "RELATED_IMAGE_ODH_UBI_MICRO_IMAGE"` to `imageParamMap`

## Context

The OVMS auto-versioning init container uses a ubi-micro image to reorganize model files. In disconnected environments, this image needs to be:
1. Mirrored to the disconnected registry
2. Injected via RELATED_IMAGE_* env var by the operator

This PR completes the disconnected readiness fix for kserve by enabling the operator to wire the ubi-micro image reference.

## Dependencies

**Works with:** opendatahub-io/kserve#1708 (adds params.env entry and code to read the env var)

## Testing

- Disconnected readiness scanner will verify once both PRs are merged
- Expected: Removes last blocker for kserve disconnected readiness

## Related Issues

- RHOAIENG-69993

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated image resolution so the `ovms-versioning-ubi-micro` option now uses the correct container image, improving compatibility for related deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->