### PR TITLE
RHOAIENG-66060: test(mcplifecycleoperator): add missing handler unit tests

### DIFF
--- a/internal/controller/modules/mcplifecycleoperator/handler_test.go
+++ b/internal/controller/modules/mcplifecycleoperator/handler_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/opendatahub-io/opendatahub-operator/v2/api/common"
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/api/components/v1alpha1"
+	configv1alpha1 "github.com/opendatahub-io/opendatahub-operator/v2/api/config/v1alpha1"
 	dscv2 "github.com/opendatahub-io/opendatahub-operator/v2/api/datasciencecluster/v2"
 	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/modules"
 	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/modules/mcplifecycleoperator"
@@ -25,6 +26,21 @@ func newPlatformCtx(mgmtState operatorv1.ManagementState) *modules.PlatformConte
 						ManagementSpec: common.ManagementSpec{
 							ManagementState: mgmtState,
 						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func newPlatformModePlatformCtx(mgmtState operatorv1.ManagementState) *modules.PlatformContext {
+	return &modules.PlatformContext{
+		ApplicationsNamespace: "opendatahub",
+		Platform: &configv1alpha1.Platform{
+			Spec: configv1alpha1.PlatformSpec{
+				Modules: configv1alpha1.PlatformModules{
+					MCPLifecycleOperator: common.ManagementSpec{
+						ManagementState: mgmtState,
 					},
 				},
 			},
@@ -63,6 +79,12 @@ func TestIsEnabled_NilPlatformContext(t *testing.T) {
 	g.Expect(h.IsEnabled(nil)).Should(BeFalse())
 }
 
+func TestIsEnabled_PlatformMode_Managed(t *testing.T) {
+	g := NewWithT(t)
+	h := mcplifecycleoperator.NewHandler()
+	g.Expect(h.IsEnabled(newPlatformModePlatformCtx(operatorv1.Managed))).Should(BeTrue())
+}
+
 func TestBuildModuleCR_BasicProjection(t *testing.T) {
 	g := NewWithT(t)
 	h := mcplifecycleoperator.NewHandler()
@@ -73,8 +95,25 @@ func TestBuildModuleCR_BasicProjection(t *testing.T) {
 	g.Expect(u.GetName()).Should(Equal(componentApi.MCPLifecycleOperatorInstanceName))
 	g.Expect(u.GetKind()).Should(Equal(componentApi.MCPLifecycleOperatorKind))
 
-	_, ok := u.Object["spec"].(map[string]any)
+	spec, ok := u.Object["spec"].(map[string]any)
 	g.Expect(ok).Should(BeTrue(), "spec is not a map")
+	g.Expect(spec).ShouldNot(HaveKey("managementState"),
+		"managementState is a DSC-level field and must not be projected into the component CR")
+}
+
+func TestBuildModuleCR_PlatformMode(t *testing.T) {
+	g := NewWithT(t)
+	h := mcplifecycleoperator.NewHandler()
+	platform := newPlatformModePlatformCtx(operatorv1.Managed)
+
+	u, err := h.BuildModuleCR(context.Background(), nil, platform)
+	g.Expect(err).ShouldNot(HaveOccurred())
+	g.Expect(u.GetName()).Should(Equal(componentApi.MCPLifecycleOperatorInstanceName))
+	g.Expect(u.GetKind()).Should(Equal(componentApi.MCPLifecycleOperatorKind))
+
+	spec, ok := u.Object["spec"].(map[string]any)
+	g.Expect(ok).Should(BeTrue(), "spec is not a map")
+	g.Expect(spec["managementState"]).Should(Equal("Managed"))
 }
 
 func TestBuildModuleCR_NilPlatformContextReturnsError(t *testing.T) {
@@ -84,7 +123,7 @@ func TestBuildModuleCR_NilPlatformContextReturnsError(t *testing.T) {
 	g.Expect(err).Should(HaveOccurred())
 }
 
-func TestBuildModuleCR_NilDSCReturnsError(t *testing.T) {
+func TestBuildModuleCR_NilDSCNilPlatformReturnsError(t *testing.T) {
 	g := NewWithT(t)
 	h := mcplifecycleoperator.NewHandler()
 	platform := &modules.PlatformContext{ApplicationsNamespace: "opendatahub"}
@@ -93,12 +132,25 @@ func TestBuildModuleCR_NilDSCReturnsError(t *testing.T) {
 	g.Expect(err).Should(HaveOccurred())
 }
 
-func TestGetRelatedImages(t *testing.T) {
+func TestGetDeploymentName(t *testing.T) {
 	g := NewWithT(t)
 	h := mcplifecycleoperator.NewHandler()
-	images := h.GetRelatedImages()
+	g.Expect(h.GetDeploymentName()).Should(Equal("mcp-lifecycle-module-operator-controller-manager"))
+	g.Expect(h.GetDeploymentName()).ShouldNot(Equal(h.GetName()),
+		"deployment name must differ from module name, which is the whole point of the override")
+}
 
-	g.Expect(images).Should(ConsistOf("RELATED_IMAGE_ODH_MCP_LIFECYCLE_OPERATOR_IMAGE"))
+func TestImageHandling(t *testing.T) {
+	g := NewWithT(t)
+	h := mcplifecycleoperator.NewHandler()
+
+	g.Expect(h.GetControllerImage()).Should(Equal("RELATED_IMAGE_ODH_MCP_LIFECYCLE_MODULE_OPERATOR_IMAGE"))
+
+	g.Expect(h.GetRelatedImages()).Should(ConsistOf(
+		"RELATED_IMAGE_ODH_MCP_LIFECYCLE_OPERATOR_IMAGE",
+	))
+
+	g.Expect(h.GetRelatedImages()).ShouldNot(ContainElement("RELATED_IMAGE_ODH_MCP_LIFECYCLE_MODULE_OPERATOR_IMAGE"))
 }
 
 func TestGetName(t *testing.T) {


### PR DESCRIPTION
Add Platform mode (xKS) tests for IsEnabled and BuildModuleCR, GetDeploymentName, GetControllerImage, image exclusion assertion, and strengthen BasicProjection to verify managementState is not projected into the component CR.

<!---
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully
- [ ] New RELATED_IMAGE mappings are listed in ODH-Build-Config and RHOAI-Build-Config (CI validates names against build-config repos). Include links to build-config PRs in the description.

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification

adds unit tests 

<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded coverage for platform-mode lifecycle configuration.
  * Verified managed-state handling and correct component configuration in platform mode.
  * Confirmed platform-specific fields are not incorrectly propagated into component specs.
  * Added validation for deployment naming and controller/related image reporting.
  * Improved error-case coverage for missing or nil platform configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->