### PR TITLE
feat(mcplifecycleoperator): use ODH kustomize overlay for Prometheus ServiceMonitor

### DIFF
--- a/internal/controller/modules/mcplifecycleoperator/handler.go
+++ b/internal/controller/modules/mcplifecycleoperator/handler.go
@@ -10,8 +10,10 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/opendatahub-io/opendatahub-operator/v2/api/common"
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/api/components/v1alpha1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/modules"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
 )
 
@@ -24,6 +26,11 @@ const (
 	deploymentName = "mcp-lifecycle-module-operator-controller-manager"
 )
 
+var sourcePathByPlatform = map[common.Platform]string{
+	cluster.OpenDataHub:      "overlays/odh",
+	cluster.SelfManagedRhoai: "overlays/odh",
+}
+
 type handler struct {
 	modules.BaseHandler
 }
@@ -32,13 +39,13 @@ func NewHandler() *handler {
 	return &handler{
 		BaseHandler: modules.BaseHandler{
 			Config: modules.ModuleConfig{
-				Name:            moduleName,
-				CRName:          crName,
-				ManifestDir:     "mcplifecycleoperator",
-				ContextDir:      "default",
-				DeploymentName:  deploymentName,
-				GVK:             gvk.MCPLifecycleOperator,
-				ControllerImage: "RELATED_IMAGE_ODH_MCP_LIFECYCLE_MODULE_OPERATOR_IMAGE",
+				Name:                 moduleName,
+				CRName:               crName,
+				ManifestDir:          "mcplifecycleoperator",
+				SourcePathByPlatform: sourcePathByPlatform,
+				DeploymentName:       deploymentName,
+				GVK:                  gvk.MCPLifecycleOperator,
+				ControllerImage:      "RELATED_IMAGE_ODH_MCP_LIFECYCLE_MODULE_OPERATOR_IMAGE",
 				RelatedImages: []string{
 					"RELATED_IMAGE_ODH_MCP_LIFECYCLE_OPERATOR_IMAGE",
 				},


### PR DESCRIPTION
Switch the MCPLO module handler from ContextDir ("default") to SourcePathByPlatform so the operator deploys from config/overlays/odh on OpenDataHub and RHOAI platforms. The overlay layers the Prometheus ServiceMonitor on top of config/default, enabling metrics scraping on OpenShift without modifying the upstream kustomization.

Depends on opendatahub-io/mcp-lifecycle-operator#46.

<!---
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully
- [ ] New RELATED_IMAGE mappings are listed in ODH-Build-Config and RHOAI-Build-Config (CI validates names against build-config repos). Include links to build-config PRs in the description.

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->
This PR fixes an issue to unblock the E2E

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved platform-specific configuration handling for the MCP lifecycle operator.
  * Automatically selects the correct manifest overlay source for each supported platform instead of using a single default source.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->