### PR TITLE
chore: deactivate ISVC HardwareProfile annotation migration in upgrade path

### DIFF
--- a/pkg/upgrade/upgrade.go
+++ b/pkg/upgrade/upgrade.go
@@ -320,9 +320,9 @@ func MigrateToInfraHardwareProfiles(ctx context.Context, cli client.Client, appl
 	// 3. Attach HardwareProfile annotations to existing Notebooks
 	multiErr = multierror.Append(multiErr, AttachHardwareProfileToNotebooks(ctx, cli, applicationNS, odhConfig))
 
-	// 4. Attach HardwareProfile annotations to existing InferenceServices but create custom-serving HWP first.
+	// 4. Create custom-serving HardwareProfile used by kserve-module for ISVC annotation migration.
+	// Note: AttachHardwareProfileToInferenceServices has been moved to kserve-module (RHOAIENG-63833).
 	multiErr = multierror.Append(multiErr, createCustomServingHardwareProfile(ctx, cli, applicationNS))
-	multiErr = multierror.Append(multiErr, AttachHardwareProfileToInferenceServices(ctx, cli, applicationNS, odhConfig))
 
 	return multiErr.ErrorOrNil()
 }

--- a/pkg/upgrade/upgrade_idempotence_test.go
+++ b/pkg/upgrade/upgrade_idempotence_test.go
@@ -115,15 +115,15 @@ func TestMigrateToInfraHardwareProfilesIdempotence_FullMigration(t *testing.T) {
 	nb2Annotations := stateAfterFirstRun.NotebookAnnotations["notebook-size"]
 	g.Expect(nb2Annotations).To(HaveKeyWithValue("opendatahub.io/hardware-profile-name", "containersize-small-notebooks"))
 
-	// Verify InferenceService annotations were set
-	isvc1Annotations := stateAfterFirstRun.ISVCAnnotations["isvc-with-runtime"]
-	g.Expect(isvc1Annotations).To(HaveKeyWithValue("opendatahub.io/hardware-profile-name", "tpu-profile-serving"))
-
-	isvc2Annotations := stateAfterFirstRun.ISVCAnnotations["isvc-with-matching-size"]
-	g.Expect(isvc2Annotations).To(HaveKeyWithValue("opendatahub.io/hardware-profile-name", "containersize-small-serving"))
-
-	isvc3Annotations := stateAfterFirstRun.ISVCAnnotations["isvc-custom"]
-	g.Expect(isvc3Annotations).To(HaveKeyWithValue("opendatahub.io/hardware-profile-name", "custom-serving"))
+	// ISVC annotation migration moved to kserve-module (RHOAIENG-63833).
+	// isvc1Annotations := stateAfterFirstRun.ISVCAnnotations["isvc-with-runtime"]
+	// g.Expect(isvc1Annotations).To(HaveKeyWithValue("opendatahub.io/hardware-profile-name", "tpu-profile-serving"))
+	//
+	// isvc2Annotations := stateAfterFirstRun.ISVCAnnotations["isvc-with-matching-size"]
+	// g.Expect(isvc2Annotations).To(HaveKeyWithValue("opendatahub.io/hardware-profile-name", "containersize-small-serving"))
+	//
+	// isvc3Annotations := stateAfterFirstRun.ISVCAnnotations["isvc-custom"]
+	// g.Expect(isvc3Annotations).To(HaveKeyWithValue("opendatahub.io/hardware-profile-name", "custom-serving"))
 
 	// Verify idempotence with 2 additional runs
 	verifyClusterStateIdempotence(ctx, g, cli, namespace, 2, stateAfterFirstRun)

--- a/pkg/upgrade/upgrade_idempotence_test.go
+++ b/pkg/upgrade/upgrade_idempotence_test.go
@@ -115,16 +115,6 @@ func TestMigrateToInfraHardwareProfilesIdempotence_FullMigration(t *testing.T) {
 	nb2Annotations := stateAfterFirstRun.NotebookAnnotations["notebook-size"]
 	g.Expect(nb2Annotations).To(HaveKeyWithValue("opendatahub.io/hardware-profile-name", "containersize-small-notebooks"))
 
-	// ISVC annotation migration moved to kserve-module (RHOAIENG-63833).
-	// isvc1Annotations := stateAfterFirstRun.ISVCAnnotations["isvc-with-runtime"]
-	// g.Expect(isvc1Annotations).To(HaveKeyWithValue("opendatahub.io/hardware-profile-name", "tpu-profile-serving"))
-	//
-	// isvc2Annotations := stateAfterFirstRun.ISVCAnnotations["isvc-with-matching-size"]
-	// g.Expect(isvc2Annotations).To(HaveKeyWithValue("opendatahub.io/hardware-profile-name", "containersize-small-serving"))
-	//
-	// isvc3Annotations := stateAfterFirstRun.ISVCAnnotations["isvc-custom"]
-	// g.Expect(isvc3Annotations).To(HaveKeyWithValue("opendatahub.io/hardware-profile-name", "custom-serving"))
-
 	// Verify idempotence with 2 additional runs
 	verifyClusterStateIdempotence(ctx, g, cli, namespace, 2, stateAfterFirstRun)
 }


### PR DESCRIPTION
## Description

The HardwareProfile annotation migration for InferenceServices
(AttachHardwareProfileToInferenceServices) has been moved to kserve-module
(RHOAIENG-63833). This removes its invocation from
MigrateToInfraHardwareProfiles.

The custom-serving HardwareProfile creation step is kept in place so
that kserve-module can find the object when annotating ISVCs and set
both the name and namespace annotations correctly.

Fixes: https://redhat.atlassian.net/browse/RHOAIENG-75979

## How Has This Been Tested?

Running tests

## Merge criteria

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully
- [x] New RELATED_IMAGE mappings are listed in ODH-Build-Config and RHOAI-Build-Config (CI validates names against build-config repos). Include links to build-config PRs in the description.

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification

No new features being added.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the hardware profile migration flow so annotation handling for InferenceServices is managed by the serving module.
  * Continued migrating notebook and hardware profile configurations without changing other migration steps.
* **Tests**
  * Adjusted the idempotence test to no longer assert the specific InferenceService annotation outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->