### PR TITLE
chore: Add imageParamMap for mlserver-cuda-image with RELATED_IMAGE_ODH_MLSERVER_CUDA_IMAGE

### DIFF
--- a/internal/controller/components/modelcontroller/modelcontroller_support.go
+++ b/internal/controller/components/modelcontroller/modelcontroller_support.go
@@ -32,6 +32,7 @@ var (
 		"caikit-standalone-image": "RELATED_IMAGE_ODH_CAIKIT_NLP_IMAGE",
 		"ovms-image":              "RELATED_IMAGE_ODH_OPENVINO_MODEL_SERVER_IMAGE",
 		"mlserver-image":          "RELATED_IMAGE_ODH_MLSERVER_IMAGE",
+		"mlserver-cuda-image":     "RELATED_IMAGE_ODH_MLSERVER_CUDA_IMAGE",
 		"autogluon-image":         "RELATED_IMAGE_ODH_KSERVE_AUTOGLUON_SERVER_IMAGE",
 		"vllm-cuda-image":         "RELATED_IMAGE_RHAII_VLLM_CUDA_IMAGE",
 		"vllm-cpu-image":          "RELATED_IMAGE_ODH_VLLM_CPU_IMAGE",


### PR DESCRIPTION
Signed-off-by: Syed Nomaan Ali <syedali@redhat.com>

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED

<!---
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->
chore: Add imageParamMap for mlserver-cuda-image with RELATED_IMAGE_ODH_MLSERVER_CUDA_IMAGE

<!--- Link your JIRA and related links here for reference. -->
Jira-Link : https://redhat.atlassian.net/browse/RHOAIENG-71767

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully
- [ ] New RELATED_IMAGE mappings are listed in ODH-Build-Config and RHOAI-Build-Config (CI validates names against build-config repos). Include links to build-config PRs in the description.

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->
This is in addition to the image param map and no E2E needed for it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed MLServer CUDA image configuration by wiring the `mlserver-cuda-image` placeholder to the correct related-image setting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->