### PR TITLE
test(e2e): narrow resilience health checks to operator-owned conditions

### DIFF
--- a/tests/e2e/resilience_test.go
+++ b/tests/e2e/resilience_test.go
@@ -466,20 +466,28 @@ func (tc *OperatorResilienceTestCtx) validateDeploymentHealth(t *testing.T) {
 	)
 }
 
-// validateSystemHealth ensures DSCI and DSC remain ready after operations.
+// validateSystemHealth ensures the operator has successfully reconciled
+// DSCI and DSC after operations. It checks ProvisioningSucceeded and
+// ComponentsReady rather than the overall phase, which also aggregates
+// module readiness (external module operators reporting their status).
 func (tc *OperatorResilienceTestCtx) validateSystemHealth(t *testing.T) {
 	t.Helper()
 
 	tc.EnsureResourceExists(
 		WithMinimalObject(gvk.DSCInitialization, tc.DSCInitializationNamespacedName),
-		WithCondition(jq.Match(`.status.phase == "%s"`, status.ConditionTypeReady)),
-		WithCustomErrorMsg("DSCI should remain Ready after pod operations"),
+		WithCondition(
+			jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, status.ConditionTypeProvisioningSucceeded, metav1.ConditionTrue),
+		),
+		WithCustomErrorMsg("DSCI should have ProvisioningSucceeded=True after pod operations"),
 	)
 
 	tc.EnsureResourceExists(
 		WithMinimalObject(gvk.DataScienceCluster, tc.DataScienceClusterNamespacedName),
-		WithCondition(jq.Match(`.status.phase == "%s"`, status.ConditionTypeReady)),
-		WithCustomErrorMsg("DSC should remain Ready after pod operations"),
+		WithCondition(And(
+			jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, status.ConditionTypeProvisioningSucceeded, metav1.ConditionTrue),
+			jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, status.ConditionTypeComponentsReady, metav1.ConditionTrue),
+		)),
+		WithCustomErrorMsg("DSC should have ProvisioningSucceeded=True and ComponentsReady=True after pod operations"),
 	)
 }
 


### PR DESCRIPTION
The `validateSystemHealth` helper checked `.status.phase == "Ready"`, which aggregates module readiness (e.g. _AIGateway_). When a module operator has not reported its status, the overall phase stays `"Not Ready"` even though the operator itself has reconciled successfully, causing leader election and RBAC resilience tests to fail spuriously.

Switch to checking `ProvisioningSucceeded` and `ComponentsReady` conditions directly, which reflect the operator's own reconciliation state without depending on external module operator health.

<!---
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully
- [ ] New RELATED_IMAGE mappings are listed in ODH-Build-Config and RHOAI-Build-Config (CI validates names against build-config repos). Include links to build-config PRs in the description.

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [X] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
is tested with this

<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated resilience health validation to use readiness conditions instead of a single “Ready” phase indicator.
  * For DSCI, the checks now wait for successful provisioning.
  * For DSC, the checks now require both successful provisioning and components readiness.
  * Improved post-disruption verification to only treat the system as healthy after the expected reconciliation outcomes are observed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->