### PR TITLE
DSC should watch module status

### DIFF
--- a/internal/controller/datasciencecluster/datasciencecluster_controller.go
+++ b/internal/controller/datasciencecluster/datasciencecluster_controller.go
@@ -30,6 +30,7 @@ import (
 	dscv2 "github.com/opendatahub-io/opendatahub-operator/v2/api/datasciencecluster/v2"
 	dsciv2 "github.com/opendatahub-io/opendatahub-operator/v2/api/dscinitialization/v2"
 	serviceApi "github.com/opendatahub-io/opendatahub-operator/v2/api/services/v1alpha1"
+	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/modules"
 	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/status"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/deploy"
@@ -44,7 +45,7 @@ import (
 func NewDataScienceClusterReconciler(ctx context.Context, mgr ctrl.Manager) error {
 	componentsPredicate := dependent.New(dependent.WithWatchStatus(true))
 
-	_, err := reconciler.ReconcilerFor(mgr, &dscv2.DataScienceCluster{}).
+	b := reconciler.ReconcilerFor(mgr, &dscv2.DataScienceCluster{}).
 		Owns(&componentApi.Dashboard{}, reconciler.WithPredicates(componentsPredicate)).
 		Owns(&componentApi.Workbenches{}, reconciler.WithPredicates(componentsPredicate)).
 		Owns(&componentApi.Ray{}, reconciler.WithPredicates(componentsPredicate)).
@@ -60,14 +61,32 @@ func NewDataScienceClusterReconciler(ctx context.Context, mgr ctrl.Manager) erro
 		Owns(&componentApi.FeastOperator{}, reconciler.WithPredicates(componentsPredicate)).
 		Owns(&componentApi.OGX{}, reconciler.WithPredicates(componentsPredicate)).
 		Owns(&componentApi.MLflowOperator{}, reconciler.WithPredicates(componentsPredicate)).
-		Owns(&componentApi.SparkOperator{}, reconciler.WithPredicates(componentsPredicate)).
-		WatchesGVK(gvk.Tenant,
-			reconciler.Dynamic(reconciler.CrdExists(gvk.Tenant)),
+		Owns(&componentApi.SparkOperator{}, reconciler.WithPredicates(componentsPredicate))
+
+	// Module CRs are not owned by the DSC controller, but their status
+	// changes must trigger a DSC reconcile so ComputeModulesStatus can
+	// update conditions while in-tree components still exist.
+	// (HasEntries prevents the modules controller from writing DSC status
+	// during the transition).
+	_ = modules.ForAll(func(h modules.ModuleHandler, _ bool) error {
+		moduleGVK := h.GetGVK()
+		b = b.WatchesGVK(moduleGVK,
+			reconciler.Dynamic(reconciler.CrdExists(moduleGVK)),
 			reconciler.WithEventMapper(func(ctx context.Context, _ client.Object) []reconcile.Request {
 				return watchDataScienceClusters(ctx, mgr.GetClient())
 			}),
 			reconciler.WithPredicates(componentsPredicate),
-		).
+		)
+		return nil
+	})
+
+	_, err := b.WatchesGVK(gvk.Tenant,
+		reconciler.Dynamic(reconciler.CrdExists(gvk.Tenant)),
+		reconciler.WithEventMapper(func(ctx context.Context, _ client.Object) []reconcile.Request {
+			return watchDataScienceClusters(ctx, mgr.GetClient())
+		}),
+		reconciler.WithPredicates(componentsPredicate),
+	).
 		Watches(
 			&dsciv2.DSCInitialization{},
 			reconciler.WithEventMapper(func(ctx context.Context, _ client.Object) []reconcile.Request {


### PR DESCRIPTION
<!---
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->
Now that the DSC writes [moduleStatus](https://github.com/opendatahub-io/opendatahub-operator/pull/3762) if any components are present to avoid controllers stomping on each other there is an issue. If only modules are enabled the DSC will not reconcile on status changes. This is hidden when there are other components enabled too because the DSC reconciles often enough to mask the gaps. 

The fix is to add a dynamic watch to the DSC so it reconciles on module status changes to correctly report the status.
<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [x] The developer has run the integration test pipeline and verified that it passed successfully
- [ x] New RELATED_IMAGE mappings are listed in ODH-Build-Config and RHOAI-Build-Config (CI validates names against build-config repos). Include links to build-config PRs in the description.

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->
This fixes an issue hidden in the e2e tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reconciliation updates when module custom resources change.
  * Added support for dynamically watching available module resources.
  * Preserved tenant resource event handling while improving reconciliation consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->