### PR TITLE
fix(monitoring): remove unused RELATED_IMAGE_CLI_IMAGE

### DIFF
--- a/component-params-env.yaml
+++ b/component-params-env.yaml
@@ -28,8 +28,8 @@ known_issues:
   jira: https://redhat.atlassian.net/browse/RHOAIENG-60523
   reason: caikit-nlp support is removed since RHOAI 3.0
 - image: RELATED_IMAGE_ODH_TRUSTYAI_SERVICE_IMAGE
-  jira: https://redhat.atlassian.net/browse/RHOAIENG-60396
-  reason: Removed with InstrutLab pipeline removal since RHOAI 3.0
+  jira: https://redhat.atlassian.net/browse/RHAISTRAT-130
+  reason: TrustyAI-Service descoped from RHOAI 3.5, delivering in 3.6-EA1
 
 odh_exceptions:
 - image: RELATED_IMAGE_ODH_VLLM_CPU_IMAGE

--- a/component-params-env.yaml
+++ b/component-params-env.yaml
@@ -27,7 +27,7 @@ known_issues:
 - image: RELATED_IMAGE_ODH_CAIKIT_NLP_IMAGE
   jira: https://redhat.atlassian.net/browse/RHOAIENG-60523
   reason: caikit-nlp support is removed since RHOAI 3.0
-  image: RELATED_IMAGE_DSP_TOOLBOX_IMAGE
+- image: RELATED_IMAGE_ODH_TRUSTYAI_SERVICE_IMAGE
   jira: https://redhat.atlassian.net/browse/RHOAIENG-60396
   reason: Removed with InstrutLab pipeline removal since RHOAI 3.0
 

--- a/component-params-env.yaml
+++ b/component-params-env.yaml
@@ -27,6 +27,9 @@ known_issues:
 - image: RELATED_IMAGE_ODH_CAIKIT_NLP_IMAGE
   jira: https://redhat.atlassian.net/browse/RHOAIENG-60523
   reason: caikit-nlp support is removed since RHOAI 3.0
+  image: RELATED_IMAGE_DSP_TOOLBOX_IMAGE
+  jira: https://redhat.atlassian.net/browse/RHOAIENG-60396
+  reason: Removed with InstrutLab pipeline removal since RHOAI 3.0
 
 odh_exceptions:
 - image: RELATED_IMAGE_ODH_VLLM_CPU_IMAGE

--- a/component-params-env.yaml
+++ b/component-params-env.yaml
@@ -24,9 +24,6 @@ known_issues:
 - image: RELATED_IMAGE_DSP_TOOLBOX_IMAGE
   jira: https://redhat.atlassian.net/browse/RHOAIENG-60396
   reason: Removed with InstrutLab pipeline removal since RHOAI 3.0
-- image: RELATED_IMAGE_CLI_IMAGE
-  jira: https://redhat.atlassian.net/browse/RHOAIENG-60519
-  reason: image is not used in monitoring templates and should be removed
 - image: RELATED_IMAGE_ODH_CAIKIT_NLP_IMAGE
   jira: https://redhat.atlassian.net/browse/RHOAIENG-60523
   reason: caikit-nlp support is removed since RHOAI 3.0

--- a/internal/controller/modules/monitoring/handler.go
+++ b/internal/controller/modules/monitoring/handler.go
@@ -37,7 +37,6 @@ func NewHandler() *handler {
 				RelatedImages: []string{
 					"RELATED_IMAGE_ODH_KUBE_RBAC_PROXY_IMAGE",
 					"RELATED_IMAGE_OSE_PROM_LABEL_PROXY_IMAGE",
-					"RELATED_IMAGE_CLI_IMAGE",
 					"RELATED_IMAGE_PERSES_IMAGE",
 				},
 			},

--- a/internal/controller/modules/monitoring/handler_test.go
+++ b/internal/controller/modules/monitoring/handler_test.go
@@ -246,7 +246,6 @@ func TestGetRelatedImages(t *testing.T) {
 	g.Expect(images).Should(ConsistOf(
 		"RELATED_IMAGE_ODH_KUBE_RBAC_PROXY_IMAGE",
 		"RELATED_IMAGE_OSE_PROM_LABEL_PROXY_IMAGE",
-		"RELATED_IMAGE_CLI_IMAGE",
 		"RELATED_IMAGE_PERSES_IMAGE",
 	))
 }

--- a/internal/controller/services/monitoring/monitoring_controller_support.go
+++ b/internal/controller/services/monitoring/monitoring_controller_support.go
@@ -300,12 +300,6 @@ func addImageURLs(rr *odhtypes.ReconciliationRequest, templateData map[string]an
 		"registry.redhat.io/openshift4/ose-prom-label-proxy-rhel9@sha256:3f44ba2d9f3d0b04c2a6c754b256ac5b5e6cfeb67651bfd0923fc2859e4b49d1", // v4.18
 		rr.Release.Name,
 	)
-	templateData["CLIImage"] = getImageURL(
-		"RELATED_IMAGE_CLI_IMAGE",
-		"quay.io/openshift/origin-cli@sha256:4c1b64a79727e392c11cf337936f9edb792e436075d4bdad5f554b79652d16dd",                // 4.18
-		"registry.redhat.io/openshift4/ose-cli-rhel9@sha256:16c25aadbd5f564a7c5f1508470f734d676a411b89bd98b307001619d1a5338f", // v4.18
-		rr.Release.Name,
-	)
 }
 
 func getImageURL(envVar, upstreamDefault, rhoaiDefault string, platform apicommon.Platform) string {


### PR DESCRIPTION
## Description

JIRA: https://redhat.atlassian.net/browse/RHOAIENG-60519

Removes the orphaned `RELATED_IMAGE_CLI_IMAGE` from the monitoring module. The template that consumed it (`prometheus-web-tls-ca-secret-job.tmpl.yaml`) was removed, and the image is not referenced in ODH-Build-Config or RHOAI-Build-Config.

- Removed `RELATED_IMAGE_CLI_IMAGE` from `RelatedImages` in `handler.go`
- Removed corresponding test expectation in `handler_test.go`
- Removed known issue entry from `component-params-env.yaml`

## How Has This Been Tested?

- `make lint` — 0 issues
- `go test ./internal/controller/modules/monitoring/...` — 17/17 PASS
- Grep confirmed no remaining references to `CLIImage` or `RELATED_IMAGE_CLI_IMAGE`

## Merge criteria

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful.
- [x] Pull Request contains a description, JIRA link, and related PRs.
- [x] Testing instructions have been added.
- [x] The developer has manually tested the changes.
- [ ] The developer has run the integration test pipeline and verified that it passed successfully.
- [x] New RELATED_IMAGE mappings are listed in build-config repos (N/A — only removing).

### E2E test suite update requirement

- [x] Skip requirement to update E2E test suite for this PR

#### E2E update requirement opt-out justification
Deletion-only cleanup of dead code. No behavioral or runtime changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Removed the CLI image from monitoring’s selectable/related images.
  - Updated monitoring image handling so the removed CLI image is no longer referenced in generated image URLs.
  - Adjusted monitoring-related validation and test expectations to match the updated related images set.
  - Cleaned up the known-issues entry for this CLI image and updated the surrounding ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->