### PR TITLE
fix(modelcontroller): remove deprecated caikit-nlp image reference

### DIFF
--- a/component-params-env.yaml
+++ b/component-params-env.yaml
@@ -11,7 +11,7 @@ rhai_helm_components:
   - kserve
 
 # Example:
-# - image: RELATED_IMAGE_ODH_CAIKIT_NLP_IMAGE
+# - image: RELATED_IMAGE_ODH_ML_PIPELINES_RUNTIME_GENERIC_IMAGE
 #   jira: https://issues.redhat.com/browse/RHOAIENG-XXXXX
 #   reason: Deprecated image, removal tracked in Jira
 known_issues:
@@ -27,9 +27,6 @@ known_issues:
 - image: RELATED_IMAGE_DSP_TOOLBOX_IMAGE
   jira: https://redhat.atlassian.net/browse/RHOAIENG-60396
   reason: Removed with InstrutLab pipeline removal since RHOAI 3.0
-- image: RELATED_IMAGE_ODH_CAIKIT_NLP_IMAGE
-  jira: https://redhat.atlassian.net/browse/RHOAIENG-60523
-  reason: caikit-nlp support is removed since RHOAI 3.0
 - image: RELATED_IMAGE_ODH_TRUSTYAI_SERVICE_IMAGE
   jira: https://redhat.atlassian.net/browse/RHAISTRAT-130
   reason: TrustyAI-Service descoped from RHOAI 3.5, delivering in 3.6-EA1

--- a/internal/controller/components/modelcontroller/modelcontroller_support.go
+++ b/internal/controller/components/modelcontroller/modelcontroller_support.go
@@ -27,19 +27,18 @@ var (
 	}
 
 	imageParamMap = map[string]string{
-		"odh-model-controller":    "RELATED_IMAGE_ODH_MODEL_CONTROLLER_IMAGE",
-		"odh-model-serving-api":   "RELATED_IMAGE_ODH_MODEL_SERVING_API_IMAGE",
-		"caikit-standalone-image": "RELATED_IMAGE_ODH_CAIKIT_NLP_IMAGE",
-		"ovms-image":              "RELATED_IMAGE_ODH_OPENVINO_MODEL_SERVER_IMAGE",
-		"mlserver-image":          "RELATED_IMAGE_ODH_MLSERVER_IMAGE",
-		"mlserver-cuda-image":     "RELATED_IMAGE_ODH_MLSERVER_CUDA_IMAGE",
-		"autogluon-image":         "RELATED_IMAGE_ODH_KSERVE_AUTOGLUON_SERVER_IMAGE",
-		"vllm-cuda-image":         "RELATED_IMAGE_RHAII_VLLM_CUDA_IMAGE",
-		"vllm-cpu-image":          "RELATED_IMAGE_ODH_VLLM_CPU_IMAGE",
-		"vllm-cpu-x86-image":      "RELATED_IMAGE_RHAII_VLLM_CPU_IMAGE",
-		"vllm-gaudi-image":        "RELATED_IMAGE_RHAII_VLLM_GAUDI_IMAGE",
-		"vllm-rocm-image":         "RELATED_IMAGE_RHAII_VLLM_ROCM_IMAGE",
-		"vllm-spyre-image":        "RELATED_IMAGE_RHAII_VLLM_SPYRE_IMAGE",
+		"odh-model-controller":  "RELATED_IMAGE_ODH_MODEL_CONTROLLER_IMAGE",
+		"odh-model-serving-api": "RELATED_IMAGE_ODH_MODEL_SERVING_API_IMAGE",
+		"ovms-image":            "RELATED_IMAGE_ODH_OPENVINO_MODEL_SERVER_IMAGE",
+		"mlserver-image":        "RELATED_IMAGE_ODH_MLSERVER_IMAGE",
+		"mlserver-cuda-image":   "RELATED_IMAGE_ODH_MLSERVER_CUDA_IMAGE",
+		"autogluon-image":       "RELATED_IMAGE_ODH_KSERVE_AUTOGLUON_SERVER_IMAGE",
+		"vllm-cuda-image":       "RELATED_IMAGE_RHAII_VLLM_CUDA_IMAGE",
+		"vllm-cpu-image":        "RELATED_IMAGE_ODH_VLLM_CPU_IMAGE",
+		"vllm-cpu-x86-image":    "RELATED_IMAGE_RHAII_VLLM_CPU_IMAGE",
+		"vllm-gaudi-image":      "RELATED_IMAGE_RHAII_VLLM_GAUDI_IMAGE",
+		"vllm-rocm-image":       "RELATED_IMAGE_RHAII_VLLM_ROCM_IMAGE",
+		"vllm-spyre-image":      "RELATED_IMAGE_RHAII_VLLM_SPYRE_IMAGE",
 		"guardrails-detector-huggingface-runtime-image": "RELATED_IMAGE_ODH_GUARDRAILS_DETECTOR_HUGGINGFACE_RUNTIME_IMAGE",
 	}
 


### PR DESCRIPTION

<!---
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

This PR cleans up references to `RELATED_IMAGE_ODH_CAIKIT_NLP_IMAGE` as it is now deprecated and no longer exists.

JIRA: https://redhat.atlassian.net/browse/RHOAIENG-60523

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

make manifests, generate and lint all pass without errors
e2e tests also pass without error
unit tests also pass without errors

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->
N/A

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully
- [ ] New RELATED_IMAGE mappings are listed in ODH-Build-Config and RHOAI-Build-Config (CI validates names against build-config repos). Include links to build-config PRs in the description.

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->

No changes to the e2e were made for this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Updated related-image validation to include KServe components.
  - Refreshed the validation example image and removed an outdated known-issue downgrade entry for the Caikit NLP-related image.
  - Refined related image substitution mappings for model-serving components (including OpenVINO, MLServer variants, KServe AutoGluon, and VLLM variants) and removed the Caikit standalone image substitution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->