### PR TITLE
chore: skip xKS e2e rerun on unchanged commits

### DIFF
--- a/.github/workflows/test-cloudmanager-e2e.yaml
+++ b/.github/workflows/test-cloudmanager-e2e.yaml
@@ -18,6 +18,7 @@ on:
 
 permissions:
   contents: read
+  actions: read
 
 env:
   IMAGE_BUILDER: podman
@@ -69,25 +70,43 @@ jobs:
           echo "::error::xKS e2e tests required. A maintainer must add the 'run-xks-e2e' label after reviewing the code."
           exit 1
 
+      - name: Check for a prior successful run
+        id: prior-run
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          PRIOR_SUCCESS_COUNT=$(gh api "repos/${{ github.repository }}/actions/workflows/test-cloudmanager-e2e.yaml/runs?head_sha=${HEAD_SHA}&status=success" \
+            --jq "[.workflow_runs[] | select(.id != ${{ github.run_id }})] | length")
+          if [[ "$PRIOR_SUCCESS_COUNT" -gt 0 ]]; then
+            echo "A run for commit $HEAD_SHA already succeeded. Skipping this rerun, there's no code change to test."
+            echo "already_passed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "already_passed=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Checkout PR code
-        if: ${{ !env.ACT }}
+        if: ${{ !env.ACT && steps.prior-run.outputs.already_passed != 'true' }}
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           ref: ${{ needs.get-merge-commit.outputs.mergedSha }}
+          persist-credentials: false
 
       - name: Set up Go
+        if: steps.prior-run.outputs.already_passed != 'true'
         uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
         with:
           go-version-file: go.mod
 
       - name: Create kind cluster
+        if: steps.prior-run.outputs.already_passed != 'true'
         uses: helm/kind-action@a1b0e391336a6ee6713a0583f8c6240d70863de3 # v1.12.0
         with:
           cluster_name: ${{ env.KIND_CLUSTER_NAME }}
           wait: 120s
 
       - name: Configure Pull Secrets for operator dependencies in the KinD Cluster
-        if: env.PULL_SECRET != ''
+        if: env.PULL_SECRET != '' && steps.prior-run.outputs.already_passed != 'true'
         run: |
           pull_secret_file="$RUNNER_TEMP/pull-secret.json"
           echo "$PULL_SECRET" > "$pull_secret_file"
@@ -97,21 +116,26 @@ jobs:
           PULL_SECRET: ${{ secrets.CCM_PULL_SECRET }}
 
       - name: Build operator image
+        if: steps.prior-run.outputs.already_passed != 'true'
         run: make image-build
 
       - name: Load image into kind
+        if: steps.prior-run.outputs.already_passed != 'true'
         run: make image-kind-load
 
       - name: Deploy cloud manager
+        if: steps.prior-run.outputs.already_passed != 'true'
         run: make deploy-ccm-local-${{ matrix.provider }}
 
       - name: Wait for cloud manager to be ready
+        if: steps.prior-run.outputs.already_passed != 'true'
         run: |
           kubectl rollout status deployment -n opendatahub-cloudmanager-system \
             -l control-plane=controller-manager \
             --timeout=120s
 
       - name: Run e2e tests
+        if: steps.prior-run.outputs.already_passed != 'true'
         env:
           CLOUD_MANAGER_PROVIDER: ${{ matrix.provider }}
         run: |
@@ -129,7 +153,7 @@ jobs:
             --tail=500 || true
 
       - name: Upload test log
-        if: always()
+        if: always() && steps.prior-run.outputs.already_passed != 'true'
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: test-log-${{ matrix.provider }}

--- a/.github/workflows/test-kind-odh-e2e.yaml
+++ b/.github/workflows/test-kind-odh-e2e.yaml
@@ -40,6 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      actions: read
     env:
       KIND_CLUSTER_NAME: kind-odh-e2e-tests-${{ github.run_id }}
     steps:
@@ -73,17 +74,36 @@ jobs:
           echo "::error::xKS e2e tests required. A maintainer must add the 'run-xks-e2e' label after reviewing the code."
           exit 1
 
+      - name: Check for a prior successful run
+        id: prior-run
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          PRIOR_SUCCESS_COUNT=$(gh api "repos/${{ github.repository }}/actions/workflows/test-kind-odh-e2e.yaml/runs?head_sha=${HEAD_SHA}&status=success" \
+            --jq "[.workflow_runs[] | select(.id != ${{ github.run_id }})] | length")
+          if [[ "$PRIOR_SUCCESS_COUNT" -gt 0 ]]; then
+            echo "A run for commit $HEAD_SHA already succeeded. Skipping this rerun, there's no code change to test."
+            echo "already_passed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "already_passed=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Checkout code
+        if: steps.prior-run.outputs.already_passed != 'true'
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           ref: ${{ needs.get-merge-commit.outputs.mergedSha }}
+          persist-credentials: false
 
       - name: Set up Go
+        if: steps.prior-run.outputs.already_passed != 'true'
         uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
         with:
           go-version-file: go.mod
 
       - name: Create KinD Cluster
+        if: steps.prior-run.outputs.already_passed != 'true'
         uses: helm/kind-action@a1b0e391336a6ee6713a0583f8c6240d70863de3 # v1.12.0
         with:
           cluster_name: ${{ env.KIND_CLUSTER_NAME }}
@@ -91,7 +111,7 @@ jobs:
           config: config/kind/kind-config.yaml
 
       - name: Configure Pull Secrets for operator dependencies in the KinD Cluster
-        if: env.PULL_SECRET != ''
+        if: env.PULL_SECRET != '' && steps.prior-run.outputs.already_passed != 'true'
         run: |
           pull_secret_file="$RUNNER_TEMP/pull-secret.json"
           echo "$PULL_SECRET" > "$pull_secret_file"
@@ -101,16 +121,20 @@ jobs:
           PULL_SECRET: ${{ secrets.CCM_PULL_SECRET }}
 
       - name: Build ODH Operator and Cloud Manager Images
+        if: steps.prior-run.outputs.already_passed != 'true'
         run: make image-build
 
       - name: Load Images into the KinD Cluster
+        if: steps.prior-run.outputs.already_passed != 'true'
         run: make image-kind-load
 
       - name: Create ODH Operator Namespace
+        if: steps.prior-run.outputs.already_passed != 'true'
         run: |
           kubectl create namespace opendatahub-operator-system
 
       - name: Deploy Cloud Manager
+        if: steps.prior-run.outputs.already_passed != 'true'
         timeout-minutes: 15
         run: |
           make deploy-ccm-local-azure
@@ -119,6 +143,7 @@ jobs:
           echo "✅ Cloud Manager is Ready!"
 
       - name: Deploy AzureKubernetesEngine CR
+        if: steps.prior-run.outputs.already_passed != 'true'
         timeout-minutes: 15
         run: |
           kubectl apply -f config/cloudmanager/azure/samples/azurekubernetesengine_v1alpha1.yaml
@@ -127,6 +152,7 @@ jobs:
           echo "✅ AzureKubernetesEngine CR is Ready!"
 
       - name: Deploy ODH Operator
+        if: steps.prior-run.outputs.already_passed != 'true'
         timeout-minutes: 15
         run: |
           make deploy-rhaii-local
@@ -135,6 +161,7 @@ jobs:
           echo "✅ ODH is Ready!"
 
       - name: Run E2E Tests
+        if: steps.prior-run.outputs.already_passed != 'true'
         run: make e2e-test-xks
 
       - name: Collect Cloud Manager logs on failure


### PR DESCRIPTION
## Description

Adding `lgtm` or `approved` to a PR reruns the whole xKS e2e suite, including real cloud provisioning, even when it already passed for that exact commit.

This PR adds a check for a prior successful run of the same workflow at the PR's current head SHA:
- If a prior success exists, every downstream step (build, deploy, e2e run, log/artifact upload) is skipped. The job still reports success.
- If the last run for that SHA failed, or never ran, the suite runs in full. Approving a red PR can't flip the check to green without retesting.

Jira: [RHOAIENG-58789](https://issues.redhat.com/browse/RHOAIENG-58789)
Follow-up to [#3767](https://github.com/opendatahub-io/opendatahub-operator/pull/3767). The `run-xks-e2e` label itself still trusts its own presence on every event, not just its own labeling event, unlike `lgtm`/`approved`. That gap is tracked for the Konflux migration, not fixed here.

## How Has This Been Tested?

Validated end to end against a throwaway workflow in a personal sandbox repo ([rinaldodev/test-env-gate](https://github.com/rinaldodev/test-env-gate/pull/3)), mirroring this exact authorization and skip logic:
- A fresh commit runs the e2e stand-in step.
- Adding `lgtm` with no new commit skips the step. The check stays green.
- Pushing a new commit afterward forces a real rerun.

This change only affects which steps execute, not the steps themselves, so no local cluster run was needed beyond that.

## Screenshot or short clip

Not applicable, this is a CI workflow change with no user-facing UI.

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully
- [ ] New RELATED_IMAGE mappings are listed in ODH-Build-Config and RHOAI-Build-Config (CI validates names against build-config repos). Include links to build-config PRs in the description.

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification

This is a CI workflow change only. It does not touch operator code, CRDs, or runtime behavior, it only changes which steps of an existing GitHub Actions job run.


[RHOAIENG-58789]: https://redhat.atlassian.net/browse/RHOAIENG-58789?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **CI Improvements**
  * Avoids repeating end-to-end test workflows when the same commit has already passed successfully.
  * Adds a prior-success check to conditionally skip redundant steps, including setup, deployments, and E2E execution.
  * Updates CI permissions to allow the prior-success lookup.
  * Preserves test log upload for runs that actually execute the tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->