### PR TITLE
fix(e2e): delete KServe webhook configs before namespace teardown

### DIFF
--- a/tests/e2e/cleanup_test.go
+++ b/tests/e2e/cleanup_test.go
@@ -42,6 +42,12 @@ func CleanupPreviousTestResources(t *testing.T) {
 	// can be processed, leaving the namespace stuck in Terminating. Strip the finalizer first.
 	cleanupMaaSControllerFinalizer(t, tc)
 
+	// KServe deploys cluster-scoped webhook configurations (with failurePolicy: Fail) that
+	// reference services inside the applications namespace. If the namespace is deleted first,
+	// the services are gone but the webhooks remain, blocking any resource validation and
+	// leaving the namespace stuck in Terminating.
+	cleanupKserveWebhookConfigurations(t, tc)
+
 	// Delete the entire applications namespace - this removes all component resources at once
 	// (AuthConfig, ResourceQuotas, Kueue resources, etc.) and the operator will recreate as needed
 	t.Logf("Cleaning up applications namespace: %s", tc.AppsNamespace)
@@ -188,6 +194,35 @@ func cleanupMaaSControllerFinalizer(t *testing.T, tc *TestContext) {
 		WithRemoveFinalizersOnDelete(true),
 		WithWaitForDeletion(false),
 	)
+}
+
+func cleanupKserveWebhookConfigurations(t *testing.T, tc *TestContext) {
+	t.Helper()
+
+	t.Log("Removing KServe webhook configurations that block namespace deletion")
+	webhooks := []struct {
+		gvk  schema.GroupVersionKind
+		name string
+	}{
+		{gvk.MutatingWebhookConfiguration, "llminferenceservice.serving.kserve.io"},
+		{gvk.ValidatingWebhookConfiguration, "llminferenceservice.serving.kserve.io"},
+		{gvk.ValidatingWebhookConfiguration, "llminferenceserviceconfig.serving.kserve.io"},
+		{gvk.MutatingWebhookConfiguration, "inferenceservice.serving.kserve.io"},
+		{gvk.ValidatingWebhookConfiguration, "inferenceservice.serving.kserve.io"},
+		{gvk.ValidatingWebhookConfiguration, "trainedmodel.serving.kserve.io"},
+		{gvk.ValidatingWebhookConfiguration, "inferencegraph.serving.kserve.io"},
+		{gvk.ValidatingWebhookConfiguration, "clusterservingruntime.serving.kserve.io"},
+		{gvk.ValidatingWebhookConfiguration, "servingruntime.serving.kserve.io"},
+		{gvk.ValidatingWebhookConfiguration, "localmodelcache.serving.kserve.io"},
+	}
+
+	for _, wh := range webhooks {
+		tc.DeleteResource(
+			WithMinimalObject(wh.gvk, types.NamespacedName{Name: wh.name}),
+			WithIgnoreNotFound(true),
+			WithWaitForDeletion(true),
+		)
+	}
 }
 
 func cleanupGateSourceConfigMaps(t *testing.T, tc *TestContext) {


### PR DESCRIPTION
KServe deploys cluster-scoped webhook configurations with failurePolicy: Fail that reference services inside the applications namespace. During e2e teardown, the namespace-scoped webhook services are deleted by GC before the cluster-scoped ValidatingWebhookConfiguration resources. With the services gone, any resource validation fails, blocking namespace finalization and leaving it stuck in Terminating.

Delete all KServe webhook configurations (llm-d, main KServe, and localmodel) before the applications namespace deletion, following the same pattern as cleanupMaaSControllerFinalizer.

Ref: #3808

<!---
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully
- [ ] New RELATED_IMAGE mappings are listed in ODH-Build-Config and RHOAI-Build-Config (CI validates names against build-config repos). Include links to build-config PRs in the description.

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
this improves tests 
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved end-to-end test environment cleanup by removing lingering KServe webhook configurations that could persist after namespace deletion.
  * Prevented namespaces from getting stuck in a terminating state during subsequent validation runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->