### PR TITLE
feat: forward platform-type to module operator deployments

### DIFF
--- a/internal/controller/modules/modules_controller_actions.go
+++ b/internal/controller/modules/modules_controller_actions.go
@@ -327,7 +327,7 @@ func provisionModules(ctx context.Context, rr *odhtype.ReconciliationRequest) er
 			PerModuleImages:       perModuleImages,
 			ApplicationsNamespace: platformCtx.ApplicationsNamespace,
 			MonitoringNamespace:   platformCtx.MonitoringNamespace,
-			PlatformType:          string(platformCtx.Release.Name),
+			PlatformType:          platformCtx.Release.Name,
 		}
 	}
 

--- a/internal/controller/modules/modules_controller_actions.go
+++ b/internal/controller/modules/modules_controller_actions.go
@@ -327,6 +327,7 @@ func provisionModules(ctx context.Context, rr *odhtype.ReconciliationRequest) er
 			PerModuleImages:       perModuleImages,
 			ApplicationsNamespace: platformCtx.ApplicationsNamespace,
 			MonitoringNamespace:   platformCtx.MonitoringNamespace,
+			PlatformType:          string(platformCtx.Release.Name),
 		}
 	}
 

--- a/internal/controller/modules/modules_controller_actions_inject_env.go
+++ b/internal/controller/modules/modules_controller_actions_inject_env.go
@@ -141,7 +141,7 @@ func injectEnvVarsIntoDeployment(log logr.Logger, obj *unstructured.Unstructured
 		}
 
 		if injection.PlatformType != "" {
-			if setOrOverrideEnv(&existingEnv, platformTypeEnv, injection.PlatformType) {
+			if setOrOverrideEnv(&existingEnv, platformTypeEnv, string(injection.PlatformType)) {
 				injected++
 			}
 		}

--- a/internal/controller/modules/modules_controller_actions_inject_env.go
+++ b/internal/controller/modules/modules_controller_actions_inject_env.go
@@ -16,6 +16,7 @@ import (
 const (
 	applicationsNamespaceEnv = "APPLICATIONS_NAMESPACE"
 	monitoringNamespaceEnv   = "MONITORING_NAMESPACE"
+	platformTypeEnv          = "ODH_MODULE_OPERATOR_PLATFORM_TYPE"
 )
 
 // injectModuleEnv is a pipeline action that runs after Helm/Kustomize rendering
@@ -135,6 +136,12 @@ func injectEnvVarsIntoDeployment(log logr.Logger, obj *unstructured.Unstructured
 
 		if injection.MonitoringNamespace != "" {
 			if setOrOverrideEnv(&existingEnv, monitoringNamespaceEnv, injection.MonitoringNamespace) {
+				injected++
+			}
+		}
+
+		if injection.PlatformType != "" {
+			if setOrOverrideEnv(&existingEnv, platformTypeEnv, injection.PlatformType) {
 				injected++
 			}
 		}

--- a/internal/controller/modules/modules_controller_actions_inject_env_test.go
+++ b/internal/controller/modules/modules_controller_actions_inject_env_test.go
@@ -417,6 +417,54 @@ func TestInjectModuleEnvEmptyMonitoringNamespace(t *testing.T) {
 	g.Expect(envNames(env)).ShouldNot(ContainElement(monitoringNamespaceEnv))
 }
 
+func TestInjectModuleEnvPlatformType(t *testing.T) {
+	g := NewWithT(t)
+
+	dep := makeDeployment("my-operator")
+
+	rr := &odhtype.ReconciliationRequest{
+		Resources: []unstructured.Unstructured{dep},
+		ModuleEnvInjection: &odhtype.ModuleEnvInjection{
+			PerModuleImages: []odhtype.ModuleImages{{
+				DeploymentName: "my-operator",
+			}},
+			ApplicationsNamespace: "opendatahub",
+			PlatformType:          "XKS",
+		},
+	}
+
+	err := injectModuleEnv(context.Background(), rr)
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	env := getContainerEnv(&rr.Resources[0])
+	g.Expect(envNames(env)).Should(ContainElement(platformTypeEnv))
+	g.Expect(envValue(env, platformTypeEnv)).Should(Equal("XKS"))
+}
+
+func TestInjectModuleEnvEmptyPlatformType(t *testing.T) {
+	g := NewWithT(t)
+
+	dep := makeDeployment("my-operator")
+
+	rr := &odhtype.ReconciliationRequest{
+		Resources: []unstructured.Unstructured{dep},
+		ModuleEnvInjection: &odhtype.ModuleEnvInjection{
+			PerModuleImages: []odhtype.ModuleImages{{
+				DeploymentName: "my-operator",
+			}},
+			ApplicationsNamespace: "opendatahub",
+			PlatformType:          "",
+		},
+	}
+
+	err := injectModuleEnv(context.Background(), rr)
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	env := getContainerEnv(&rr.Resources[0])
+	g.Expect(envNames(env)).Should(ConsistOf(applicationsNamespaceEnv))
+	g.Expect(envNames(env)).ShouldNot(ContainElement(platformTypeEnv))
+}
+
 func TestInjectControllerImage(t *testing.T) {
 	g := NewWithT(t)
 

--- a/internal/controller/modules/modules_controller_actions_inject_env_test.go
+++ b/internal/controller/modules/modules_controller_actions_inject_env_test.go
@@ -7,6 +7,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
+	"github.com/opendatahub-io/opendatahub-operator/v2/api/common"
 	odhtype "github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
 
 	. "github.com/onsi/gomega"
@@ -429,7 +430,7 @@ func TestInjectModuleEnvPlatformType(t *testing.T) {
 				DeploymentName: "my-operator",
 			}},
 			ApplicationsNamespace: "opendatahub",
-			PlatformType:          "XKS",
+			PlatformType:          common.Platform("XKS"),
 		},
 	}
 

--- a/pkg/controller/types/types.go
+++ b/pkg/controller/types/types.go
@@ -25,8 +25,9 @@ import (
 
 // ModuleEnvInjection holds aggregated environment variable injection data
 // for all enabled modules. Set by provisionModules and consumed by the
-// injectModuleEnv action to inject RELATED_IMAGE_*, APPLICATIONS_NAMESPACE and
-// MONITORING_NAMESPACE env vars into module operator Deployments.
+// injectModuleEnv action to inject RELATED_IMAGE_*, APPLICATIONS_NAMESPACE,
+// MONITORING_NAMESPACE and platform identity env vars into module operator
+// Deployments.
 type ModuleEnvInjection struct {
 	// PerModuleImages maps each module's related images to its chart/manifest
 	// resources. Each entry's images are only injected into Deployments
@@ -37,6 +38,10 @@ type ModuleEnvInjection struct {
 	// MonitoringNamespace is the platform's monitoring namespace. "" when
 	// monitoring is not configured or DSCI not exist (e.g xks).
 	MonitoringNamespace string
+	// PlatformType is the platform identifier (e.g. "OpenDataHub",
+	// "SelfManagedRHOAI", "XKS"). Forwarded to module operators so they
+	// can select platform-specific manifests without auto-detecting.
+	PlatformType string
 }
 
 // ModuleImages associates a module's related images with a deployment name

--- a/pkg/controller/types/types.go
+++ b/pkg/controller/types/types.go
@@ -38,10 +38,10 @@ type ModuleEnvInjection struct {
 	// MonitoringNamespace is the platform's monitoring namespace. "" when
 	// monitoring is not configured or DSCI not exist (e.g xks).
 	MonitoringNamespace string
-	// PlatformType is the platform identifier (e.g. "OpenDataHub",
-	// "SelfManagedRHOAI", "XKS"). Forwarded to module operators so they
+	// PlatformType is the platform identifier (e.g. OpenDataHub,
+	// SelfManagedRHOAI, XKS). Forwarded to module operators so they
 	// can select platform-specific manifests without auto-detecting.
-	PlatformType string
+	PlatformType common.Platform
 }
 
 // ModuleImages associates a module's related images with a deployment name


### PR DESCRIPTION
## Summary

Forward the platform type (e.g. `XKS`, `OpenDataHub`, `SelfManagedRHOAI`) from the main operator to module operator Deployments via the `ODH_MODULE_OPERATOR_PLATFORM_TYPE` environment variable.

Module operators like ai-gateway-operator need the platform type to select platform-specific manifests (e.g. xKS overlays that exclude OpenShift-specific monitoring and service-serving cert annotations). Currently, module operators have no way to know the platform type because `injectModuleEnv` only forwards `APPLICATIONS_NAMESPACE`, `MONITORING_NAMESPACE`, and `RELATED_IMAGE_*` variables.

## Changes

- Add `PlatformType` field to `ModuleEnvInjection` struct (`pkg/controller/types/types.go`)
- Populate `PlatformType` from `platformCtx.Release.Name` in `provisionModules` (`modules_controller_actions.go`)
- Inject `ODH_MODULE_OPERATOR_PLATFORM_TYPE` env var into module Deployments, following the same pattern as `APPLICATIONS_NAMESPACE` and `MONITORING_NAMESPACE` (`modules_controller_actions_inject_env.go`)
- Add tests for both set and empty platform-type cases

## Context

This is a companion to [ai-gateway-operator#58](https://github.com/opendatahub-io/ai-gateway-operator/pull/58) which adds xKS overlay selection for MaaS in ai-gateway-operator. Without this PR, `cfg.PlatformType` in ai-gateway-operator defaults to `"unknown"` and the xKS overlay is never selected.

Follows zdtsw's guidance that platform identity should be passed down from the operator rather than auto-detected by each module.

Related: RHAISTRAT-1377

## Test plan

- [x] `go test ./internal/controller/modules/ -run TestInjectModuleEnv` — all 10 tests pass
- [x] New `TestInjectModuleEnvPlatformType` verifies XKS value is injected
- [x] New `TestInjectModuleEnvEmptyPlatformType` verifies empty string is not injected


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Module-managed deployments now receive a platform type environment variable when configured.
  - The platform type is automatically populated from the release configuration and forwarded to module operators.

- **Bug Fixes**
  - Platform type injection is applied consistently; empty platform values are omitted without impacting other injected environment variables.

- **Tests**
  - Added/updated tests for both populated and empty platform type scenarios.

- **Documentation**
  - Updated `injectModuleEnv` documentation to reflect the additional platform identity variables.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->