### PR TITLE
fix(e2e): update MaaS tenant GVK and CRD name for Tenant→MaasTenantCo…

### DIFF
--- a/pkg/cluster/gvk/gvk.go
+++ b/pkg/cluster/gvk/gvk.go
@@ -412,7 +412,7 @@ var (
 	Tenant = schema.GroupVersionKind{
 		Group:   "maas.opendatahub.io",
 		Version: "v1alpha1",
-		Kind:    "Tenant",
+		Kind:    "MaasTenantConfig",
 	}
 
 	// MaasConfig is the cluster-scoped MaaS anchor CR (maas.opendatahub.io/v1alpha1, Kind=Config).

--- a/tests/e2e/modelsasservice_test.go
+++ b/tests/e2e/modelsasservice_test.go
@@ -263,7 +263,7 @@ func (tc *ModelsAsServiceTestCtx) createMaaSGateway(t *testing.T) {
 const (
 	tenantName           = "default-tenant"
 	tenantSubscriptionNS = modelsasservice.MaaSSubscriptionNamespace
-	tenantCRDName        = "tenants.maas.opendatahub.io"
+	tenantCRDName        = "maastenantconfigs.maas.opendatahub.io"
 )
 
 // ValidateTenantInSubscriptionNamespace verifies that the maas-controller self-bootstrapped


### PR DESCRIPTION
…nfig rename

## Description
<!--- Describe your changes in detail -->

The models-as-a-service repo renamed the tenant CRD from Tenant to MaasTenantConfig. Update the GVK Kind and CRD name so e2e tests look for the correct resource.


<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
TBD
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully
- [ ] New RELATED_IMAGE mappings are listed in ODH-Build-Config and RHOAI-Build-Config (CI validates names against build-config repos). Include links to build-config PRs in the description.

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [ ] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Tenant resource identification to use the correct `MaaS Tenant Configuration` resource kind.
  * Corrected end-to-end validation to check the current MaaS Tenant CRD and its namespace scope.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->