### PR TITLE
replace valueFrom when injecting env vars

### DIFF
--- a/internal/controller/modules/modules_controller_actions_inject_env.go
+++ b/internal/controller/modules/modules_controller_actions_inject_env.go
@@ -165,10 +165,12 @@ func setOrOverrideEnv(envSlice *[]any, name, value string) bool {
 	for i, e := range *envSlice {
 		if em, ok := e.(map[string]any); ok {
 			if n, ok := em["name"].(string); ok && n == name {
-				if em["value"] == value {
+				_, hasValueFrom := em["valueFrom"]
+				if em["value"] == value && !hasValueFrom {
 					return false
 				}
 				em["value"] = value
+				delete(em, "valueFrom")
 				(*envSlice)[i] = em
 				return true
 			}

--- a/internal/controller/modules/modules_controller_actions_inject_env_test.go
+++ b/internal/controller/modules/modules_controller_actions_inject_env_test.go
@@ -255,6 +255,64 @@ func TestInjectModuleEnvOverridesExistingVars(t *testing.T) {
 	g.Expect(envNames(env)).Should(ContainElement(applicationsNamespaceEnv))
 }
 
+func TestInjectModuleEnvReplacesValueFrom(t *testing.T) {
+	g := NewWithT(t)
+
+	dep := makeDeployment("ogx-operator",
+		map[string]any{
+			"name": "ODH_MODULE_OPERATOR_NAMESPACE",
+			"valueFrom": map[string]any{
+				"fieldRef": map[string]any{"fieldPath": "metadata.namespace"},
+			},
+		},
+		map[string]any{
+			"name": applicationsNamespaceEnv,
+			"valueFrom": map[string]any{
+				"fieldRef": map[string]any{"fieldPath": "metadata.namespace"},
+			},
+		},
+	)
+
+	rr := &odhtype.ReconciliationRequest{
+		Resources: []unstructured.Unstructured{dep},
+		ModuleEnvInjection: &odhtype.ModuleEnvInjection{
+			PerModuleImages: []odhtype.ModuleImages{{
+				DeploymentName: "ogx-operator",
+			}},
+			ApplicationsNamespace: "opendatahub",
+		},
+	}
+
+	err := injectModuleEnv(context.Background(), rr)
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	env := getContainerEnv(&rr.Resources[0])
+
+	// APPLICATIONS_NAMESPACE should have value set and valueFrom removed
+	for _, e := range env {
+		em, ok := e.(map[string]any)
+		if !ok {
+			continue
+		}
+		if em["name"] == applicationsNamespaceEnv {
+			g.Expect(em["value"]).Should(Equal("opendatahub"))
+			g.Expect(em).ShouldNot(HaveKey("valueFrom"))
+		}
+	}
+
+	// ODH_MODULE_OPERATOR_NAMESPACE should be untouched (not injected by the action)
+	for _, e := range env {
+		em, ok := e.(map[string]any)
+		if !ok {
+			continue
+		}
+		if em["name"] == "ODH_MODULE_OPERATOR_NAMESPACE" {
+			g.Expect(em).Should(HaveKey("valueFrom"))
+			g.Expect(em).ShouldNot(HaveKey("value"))
+		}
+	}
+}
+
 func TestInjectModuleEnvScopesPerModule(t *testing.T) {
 	g := NewWithT(t)
 


### PR DESCRIPTION
<!---
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->
Some modules may include APPLICATION_NAMESPACE in their manifests using the standard k8s way of reading env vars

```
            - name: APPLICATIONS_NAMESPACE
              valueFrom:
                fieldRef:
                  fieldPath: metadata.namespace
```

Our module handler injects env vars and the existance of the `valueFrom` field creates a conflict, so we should strip that from a var if it is already there and we are injecting a value.
<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [x] The developer has run the integration test pipeline and verified that it passed successfully
- [x] New RELATED_IMAGE mappings are listed in ODH-Build-Config and RHOAI-Build-Config (CI validates names against build-config repos). Include links to build-config PRs in the description.

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->
Covered in unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected environment variable injection when an existing variable references another source.
  * Direct values now properly replace referenced values, while unrelated environment variables remain unchanged.
  * Prevented stale source references from overriding updated configuration values.

* **Tests**
  * Added coverage to verify environment variables are correctly updated and existing references are preserved when appropriate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->