### PR TITLE
fix(trustyai): self-heal after InferenceServices CRD becomes available

### DIFF
--- a/internal/controller/components/trustyai/trustyai_controller.go
+++ b/internal/controller/components/trustyai/trustyai_controller.go
@@ -42,7 +42,6 @@ import (
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/predicates/component"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/reconciler"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/metadata/labels"
-	pkgresources "github.com/opendatahub-io/opendatahub-operator/v2/pkg/resources"
 )
 
 const (
@@ -50,14 +49,10 @@ const (
 	InferenceServicesCRDName = "inferenceservices.serving.kserve.io"
 )
 
-// isInferenceServicesCRD checks if the given object is the InferenceServices CRD managed by KServe.
+// isInferenceServicesCRD checks if the given object is the InferenceServices CRD.
+// CRD names are globally unique, so name matching is sufficient.
 func isInferenceServicesCRD(obj client.Object) bool {
-	// Early return: check name first (cheaper comparison)
-	if obj.GetName() != InferenceServicesCRDName {
-		return false
-	}
-	// Check if it's managed by KServe using safe label check
-	return pkgresources.HasLabel(obj, labels.ODH.Component(componentApi.KserveComponentName), labels.True)
+	return obj.GetName() == InferenceServicesCRDName
 }
 
 func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.Manager) error {

--- a/internal/controller/components/trustyai/trustyai_controller.go
+++ b/internal/controller/components/trustyai/trustyai_controller.go
@@ -18,6 +18,7 @@ package trustyai
 
 import (
 	"context"
+	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -96,6 +97,7 @@ func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.
 		).
 		WithPreCondition(precondition.MonitorCRD(gvk.InferenceServices,
 			precondition.WithStopReconciliation(),
+			precondition.WithRequeueInterval(30*time.Second),
 			precondition.WithMessage(status.ISVCMissingCRDMessage),
 		)).
 		WithAction(precondition.RunlevelGateAction()).

--- a/internal/controller/components/trustyai/trustyai_test.go
+++ b/internal/controller/components/trustyai/trustyai_test.go
@@ -400,6 +400,59 @@ func TestInitializeWithMCPGuardrailsMode(t *testing.T) {
 	})
 }
 
+func TestIsInferenceServicesCRD(t *testing.T) {
+	tests := []struct {
+		name   string
+		obj    client.Object
+		expect bool
+	}{
+		{
+			name: "should match CRD by name alone without any labels",
+			obj: &metav1.PartialObjectMetadata{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: InferenceServicesCRDName,
+				},
+			},
+			expect: true,
+		},
+		{
+			name: "should match CRD by name with ODH component label present",
+			obj: &metav1.PartialObjectMetadata{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   InferenceServicesCRDName,
+					Labels: map[string]string{"opendatahub.io/component.kserve": "true"},
+				},
+			},
+			expect: true,
+		},
+		{
+			name: "should not match CRD with different name",
+			obj: &metav1.PartialObjectMetadata{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "servingruntime.serving.kserve.io",
+				},
+			},
+			expect: false,
+		},
+		{
+			name: "should not match CRD with empty name",
+			obj: &metav1.PartialObjectMetadata{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "",
+				},
+			},
+			expect: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			g.Expect(isInferenceServicesCRD(tt.obj)).To(Equal(tt.expect))
+		})
+	}
+}
+
 func createDSCWithTrustyAI(managementState operatorv1.ManagementState) *dscv2.DataScienceCluster {
 	dsc := dscv2.DataScienceCluster{}
 	dsc.SetGroupVersionKind(gvk.DataScienceCluster)

--- a/pkg/controller/precondition/custom_test.go
+++ b/pkg/controller/precondition/custom_test.go
@@ -31,7 +31,7 @@ func TestCustom_PassingCheck(t *testing.T) {
 	g := NewWithT(t)
 
 	rr := newRR(status.ConditionDependenciesAvailable)
-	shouldStop := RunAll(t.Context(), rr, []PreCondition{
+	shouldStop, _ := RunAll(t.Context(), rr, []PreCondition{
 		Custom(passingCheck),
 	})
 
@@ -46,7 +46,7 @@ func TestCustom_FailingCheck(t *testing.T) {
 	g := NewWithT(t)
 
 	rr := newRR(status.ConditionDependenciesAvailable)
-	shouldStop := RunAll(t.Context(), rr, []PreCondition{
+	shouldStop, _ := RunAll(t.Context(), rr, []PreCondition{
 		Custom(failingCheck("component not ready")),
 	})
 
@@ -62,7 +62,7 @@ func TestCustom_ErrorCheck(t *testing.T) {
 	g := NewWithT(t)
 
 	rr := newRR(status.ConditionDependenciesAvailable)
-	shouldStop := RunAll(t.Context(), rr, []PreCondition{
+	shouldStop, _ := RunAll(t.Context(), rr, []PreCondition{
 		Custom(errorCheck),
 	})
 
@@ -77,7 +77,7 @@ func TestCustom_WithStopReconciliation(t *testing.T) {
 	g := NewWithT(t)
 
 	rr := newRR(status.ConditionDependenciesAvailable)
-	shouldStop := RunAll(t.Context(), rr, []PreCondition{
+	shouldStop, _ := RunAll(t.Context(), rr, []PreCondition{
 		Custom(failingCheck("must stop"), WithStopReconciliation()),
 	})
 
@@ -93,7 +93,7 @@ func TestCustom_AllOptions(t *testing.T) {
 
 	customCondition := "CustomCheck"
 	rr := newRR(customCondition)
-	shouldStop := RunAll(t.Context(), rr, []PreCondition{
+	shouldStop, _ := RunAll(t.Context(), rr, []PreCondition{
 		Custom(
 			failingCheck("original"),
 			WithConditionType(customCondition),
@@ -117,7 +117,7 @@ func TestCustom_ErrorWithStopReconciliation(t *testing.T) {
 	g := NewWithT(t)
 
 	rr := newRR(status.ConditionDependenciesAvailable)
-	shouldStop := RunAll(t.Context(), rr, []PreCondition{
+	shouldStop, _ := RunAll(t.Context(), rr, []PreCondition{
 		Custom(errorCheck, WithStopReconciliation()),
 	})
 
@@ -142,7 +142,7 @@ func TestCustom_AccessesInstance(t *testing.T) {
 	}
 
 	rr := newRR(status.ConditionDependenciesAvailable)
-	shouldStop := RunAll(t.Context(), rr, []PreCondition{
+	shouldStop, _ := RunAll(t.Context(), rr, []PreCondition{
 		Custom(instanceCheck),
 	})
 
@@ -157,7 +157,7 @@ func TestCustom_NilCheck(t *testing.T) {
 	g := NewWithT(t)
 
 	rr := newRR(status.ConditionDependenciesAvailable)
-	shouldStop := RunAll(t.Context(), rr, []PreCondition{
+	shouldStop, _ := RunAll(t.Context(), rr, []PreCondition{
 		Custom(nil),
 	})
 
@@ -173,7 +173,7 @@ func TestCustom_NilCheckWithStopReconciliation(t *testing.T) {
 	g := NewWithT(t)
 
 	rr := newRR(status.ConditionDependenciesAvailable)
-	shouldStop := RunAll(t.Context(), rr, []PreCondition{
+	shouldStop, _ := RunAll(t.Context(), rr, []PreCondition{
 		Custom(nil, WithStopReconciliation()),
 	})
 
@@ -191,7 +191,7 @@ func TestCustom_SkippedOnClusterType(t *testing.T) {
 	t.Cleanup(func() { cluster.SetClusterInfo(cluster.ClusterInfo{}) })
 
 	rr := newRR(status.ConditionDependenciesAvailable)
-	shouldStop := RunAll(t.Context(), rr, []PreCondition{
+	shouldStop, _ := RunAll(t.Context(), rr, []PreCondition{
 		Custom(failingCheck("should not run"), WithClusterTypes(cluster.ClusterTypeKubernetes)),
 	})
 

--- a/pkg/controller/precondition/monitor_crd_test.go
+++ b/pkg/controller/precondition/monitor_crd_test.go
@@ -189,7 +189,7 @@ func TestMonitorCRD_IntegrationWithRunAll(t *testing.T) {
 		MonitorCRD(absentGVK),
 	}
 
-	shouldStop := RunAll(ctx, rr, pcs)
+	shouldStop, _ := RunAll(ctx, rr, pcs)
 	g.Expect(shouldStop).To(BeFalse())
 
 	got := condManager.GetCondition(status.ConditionDependenciesAvailable)

--- a/pkg/controller/precondition/monitor_subscription_test.go
+++ b/pkg/controller/precondition/monitor_subscription_test.go
@@ -211,7 +211,7 @@ func TestMonitorSubscriptions_ErrorWritesConditionUnknown(t *testing.T) {
 		),
 	}
 
-	shouldStop := RunAll(t.Context(), rr, pcs)
+	shouldStop, _ := RunAll(t.Context(), rr, pcs)
 	g.Expect(shouldStop).To(BeFalse())
 
 	got := condManager.GetCondition(condType)
@@ -287,7 +287,7 @@ func TestMonitorSubscriptions_IntegrationWithRunAll(t *testing.T) {
 		),
 	}
 
-	shouldStop := RunAll(t.Context(), rr, pcs)
+	shouldStop, _ := RunAll(t.Context(), rr, pcs)
 	g.Expect(shouldStop).To(BeFalse())
 
 	got := condManager.GetCondition(condType)

--- a/pkg/controller/precondition/precondition.go
+++ b/pkg/controller/precondition/precondition.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"slices"
 	"strings"
+	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrlLog "sigs.k8s.io/controller-runtime/pkg/log"
@@ -41,6 +42,7 @@ type PreCondition struct {
 	conditionType      string
 	severity           common.ConditionSeverity
 	stopReconciliation bool
+	requeueInterval    time.Duration
 	clusterTypes       []string
 	message            string
 	skipFunc           SkipFunc // runtime predicate to conditionally skip this precondition
@@ -81,6 +83,17 @@ func WithClusterTypes(types ...string) Option {
 func WithMessage(msg string) Option {
 	return func(pc *PreCondition) {
 		pc.message = msg
+	}
+}
+
+// WithRequeueInterval sets the interval at which the reconciler should
+// re-evaluate this precondition when it is not met. Use for transient
+// conditions (e.g. a CRD not yet installed) where the dependency may
+// appear independently of watch events. Preconditions for permanent
+// configuration errors should not set this option.
+func WithRequeueInterval(d time.Duration) Option {
+	return func(pc *PreCondition) {
+		pc.requeueInterval = d
 	}
 }
 
@@ -144,15 +157,19 @@ func (agg *conditionAggregate) record(s metav1.ConditionStatus, message string, 
 	}
 }
 
-// RunAll runs all the preconditions and returns true when the reconciliation should be stopped.
-func RunAll(ctx context.Context, rr *types.ReconciliationRequest, preConditions []PreCondition) bool {
+// RunAll runs all preconditions and returns whether reconciliation should
+// stop, plus the shortest requeue interval requested by any failing
+// precondition (zero if no requeue was requested).
+func RunAll(ctx context.Context, rr *types.ReconciliationRequest, preConditions []PreCondition) (bool, time.Duration) {
 	if len(preConditions) == 0 {
-		return false
+		return false, 0
 	}
 
 	l := ctrlLog.FromContext(ctx)
 	clusterType := cluster.GetClusterInfo().Type
 	results := make(map[string]*conditionAggregate)
+
+	var minRequeue time.Duration
 
 	for i := range preConditions {
 		pc := &preConditions[i]
@@ -210,6 +227,10 @@ func RunAll(ctx context.Context, rr *types.ReconciliationRequest, preConditions 
 			}
 
 			agg.record(metav1.ConditionFalse, msg, pc)
+
+			if pc.requeueInterval > 0 && (minRequeue == 0 || pc.requeueInterval < minRequeue) {
+				minRequeue = pc.requeueInterval
+			}
 		}
 	}
 
@@ -236,5 +257,5 @@ func RunAll(ctx context.Context, rr *types.ReconciliationRequest, preConditions 
 		}
 	}
 
-	return shouldStop
+	return shouldStop, minRequeue
 }

--- a/pkg/controller/precondition/precondition_test.go
+++ b/pkg/controller/precondition/precondition_test.go
@@ -252,7 +252,7 @@ func TestRunAll(t *testing.T) {
 				rr.Instance.SetGeneration(tt.generation)
 			}
 
-			shouldStop := RunAll(t.Context(), rr, tt.preConditions)
+			shouldStop, _ := RunAll(t.Context(), rr, tt.preConditions)
 			g.Expect(shouldStop).To(Equal(tt.expectedShouldStop))
 
 			got := rr.Conditions.GetCondition(status.ConditionDependenciesAvailable)
@@ -287,7 +287,7 @@ func TestRunAll_EmptyList(t *testing.T) {
 	g := NewWithT(t)
 
 	rr := newRR()
-	shouldStop := RunAll(t.Context(), rr, nil)
+	shouldStop, _ := RunAll(t.Context(), rr, nil)
 
 	g.Expect(shouldStop).To(BeFalse())
 }
@@ -307,7 +307,7 @@ func TestRunAll_ClusterTypeFiltering(t *testing.T) {
 		),
 	}
 
-	shouldStop := RunAll(t.Context(), rr, pcs)
+	shouldStop, _ := RunAll(t.Context(), rr, pcs)
 
 	g.Expect(shouldStop).To(BeFalse())
 	got := rr.Conditions.GetCondition(status.ConditionDependenciesAvailable)
@@ -382,7 +382,7 @@ func TestRunAll_SkipFuncError(t *testing.T) {
 		),
 	}
 
-	shouldStop := RunAll(t.Context(), rr, pcs)
+	shouldStop, _ := RunAll(t.Context(), rr, pcs)
 	g.Expect(shouldStop).To(BeFalse())
 
 	got := rr.Conditions.GetCondition(status.ConditionDependenciesAvailable)
@@ -448,7 +448,7 @@ func TestRunAll_ClusterTypeFilterRunsBeforeSkipFunc(t *testing.T) {
 		),
 	}
 
-	shouldStop := RunAll(t.Context(), rr, pcs)
+	shouldStop, _ := RunAll(t.Context(), rr, pcs)
 	g.Expect(shouldStop).To(BeFalse())
 	g.Expect(skipFuncCalled).To(BeFalse(), "SkipFunc should not be called when cluster type filter already skipped")
 }

--- a/pkg/controller/reconciler/reconciler.go
+++ b/pkg/controller/reconciler/reconciler.go
@@ -385,13 +385,15 @@ func (r *Reconciler) apply(ctx context.Context, res common.PlatformObject) (time
 	rr.Conditions.Reset()
 
 	// Check if all the preconditions are met. If not, flag to stop the reconciliation.
-	shouldStop := precondition.RunAll(ctx, &rr, r.preConditions)
+	shouldStop, preconditionRequeue := precondition.RunAll(ctx, &rr, r.preConditions)
 
 	var provisionErr error
 	var requeueAfter time.Duration
 
 	if shouldStop {
 		l.Info("Preconditions not met, stopping reconciliation")
+
+		requeueAfter = preconditionRequeue
 
 		rr.Conditions.MarkFalse(
 			status.ConditionTypeProvisioningSucceeded,


### PR DESCRIPTION
## Summary
TrustyAI gets permanently stuck in `PreConditionFailed` when it reconciles before KServe finishes installing the InferenceServices CRD. Three fixes, each addressing a different layer:

1. **Remove label gate from CRD watch** — watch predicate required `opendatahub.io/component: kserve = true`, but CRD may be installed without it. Name matching is sufficient (CRD names are globally unique). *Fast path: instant recovery.*

2. **Add opt-in `WithRequeueInterval` to precondition framework** — `RunAll` now returns `(bool, time.Duration)`. The reconciler uses the shortest interval from any failing precondition that opted in. Only TrustyAI opts in (30s). Other components unaffected. *Safety net: 30s recovery.*

3. **Tests** — `isInferenceServicesCRD` name-only matching (4 cases).

## Root cause
PR #3707 migrated `checkPreConditions` from `WithAction` (error → controller-runtime requeue) to `WithPreCondition` (`shouldStop=true` → no error → no requeue). This made the CRD watch the sole recovery path, but:
- Watch had a label gate that could silently block it
- REST mapper cache could serve stale "not found" results
- No fallback polling existed

## Commits

| # | Commit | Scope | Files |
|---|--------|-------|-------|
| 1 | `fix(trustyai): remove label gate` | TrustyAI only | `trustyai_controller.go` |
| 2 | `test(trustyai): CRD predicate tests` | TrustyAI only | `trustyai_test.go` |
| 3 | `fix: opt-in WithRequeueInterval` | Framework (opt-in) | `precondition.go`, `reconciler.go`, `trustyai_controller.go`, 4 test files |

### What's NOT affected
- Kueue, OGX, DSP, Trainer preconditions — no `WithRequeueInterval`, zero behavioral change
- Test file changes in `pkg/controller/precondition/` are mechanical: `shouldStop := RunAll(...)` → `shouldStop, _ := RunAll(...)`

## Test plan
- [x] `TestIsInferenceServicesCRD` — name-only match, with label, wrong name, empty name
- [x] `TestPreConditions_StopReconciliation` — without `WithRequeueInterval` → zero requeue (unchanged)
- [x] Full reconciler, precondition, TrustyAI test suites pass

Fixes: RHOAIENG-77786

🤖 Generated with [Claude Code](https://claude.com/claude-code)