### PR TITLE
[RHOAIENG-77786] fix(trustyai): restore self-healing when InferenceServices CRD appears

### DIFF
--- a/internal/controller/components/trustyai/trustyai_controller.go
+++ b/internal/controller/components/trustyai/trustyai_controller.go
@@ -79,13 +79,20 @@ func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.
 				component.ForLabel(labels.ODH.Component(LegacyComponentName), labels.True), // if TrustyAI CR is changed
 				predicate.Funcs{ // OR if ISVC CRD from kserve is created or deleted
 					CreateFunc: func(e event.CreateEvent) bool {
-						// React when InferenceServices CRD is created (dependency becomes available)
-						return isInferenceServicesCRD(e.Object)
+						// React when InferenceServices CRD is created. Name-only check: the ODH label
+						// (app.opendatahub.io/kserve) is added later by ODH and is absent at creation time.
+						return e.Object.GetName() == InferenceServicesCRDName
 					},
 					UpdateFunc: func(e event.UpdateEvent) bool {
-						// Don't react to updates - MonitorCRD precondition only checks if CRD exists, not its version/spec
-						// This also prevents continuous reconciliation on CRD status updates
-						return false
+						// React when the ODH label is added to the InferenceServices CRD. This covers
+						// the case where the operator restarts after the CRD already exists: no Create
+						// event fires, but ODH later labels the CRD triggering this handler.
+						if e.ObjectNew.GetName() != InferenceServicesCRDName {
+							return false
+						}
+						wasLabeled := pkgresources.HasLabel(e.ObjectOld, labels.ODH.Component(componentApi.KserveComponentName), labels.True)
+						isLabeled := pkgresources.HasLabel(e.ObjectNew, labels.ODH.Component(componentApi.KserveComponentName), labels.True)
+						return !wasLabeled && isLabeled
 					},
 					DeleteFunc: func(e event.DeleteEvent) bool {
 						// React when InferenceServices CRD is deleted (dependency becomes unavailable)

--- a/internal/controller/components/trustyai/trustyai_controller.go
+++ b/internal/controller/components/trustyai/trustyai_controller.go
@@ -24,7 +24,6 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
@@ -42,23 +41,12 @@ import (
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/predicates/component"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/reconciler"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/metadata/labels"
-	pkgresources "github.com/opendatahub-io/opendatahub-operator/v2/pkg/resources"
 )
 
 const (
 	// InferenceServicesCRDName is the name of the InferenceServices CRD that TrustyAI depends on.
 	InferenceServicesCRDName = "inferenceservices.serving.kserve.io"
 )
-
-// isInferenceServicesCRD checks if the given object is the InferenceServices CRD managed by KServe.
-func isInferenceServicesCRD(obj client.Object) bool {
-	// Early return: check name first (cheaper comparison)
-	if obj.GetName() != InferenceServicesCRDName {
-		return false
-	}
-	// Check if it's managed by KServe using safe label check
-	return pkgresources.HasLabel(obj, labels.ODH.Component(componentApi.KserveComponentName), labels.True)
-}
 
 func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.Manager) error {
 	_, err := reconciler.ReconcilerFor(mgr, &componentApi.TrustyAI{}).
@@ -79,28 +67,15 @@ func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.
 				component.ForLabel(labels.ODH.Component(LegacyComponentName), labels.True), // if TrustyAI CR is changed
 				predicate.Funcs{ // OR if ISVC CRD from kserve is created or deleted
 					CreateFunc: func(e event.CreateEvent) bool {
-						// React when InferenceServices CRD is created. Name-only check: the ODH label
-						// (app.opendatahub.io/kserve) is added later by ODH and is absent at creation time.
 						return e.Object.GetName() == InferenceServicesCRDName
 					},
 					UpdateFunc: func(e event.UpdateEvent) bool {
-						// React when the ODH label is added to the InferenceServices CRD. This covers
-						// the case where the operator restarts after the CRD already exists: no Create
-						// event fires, but ODH later labels the CRD triggering this handler.
-						if e.ObjectNew.GetName() != InferenceServicesCRDName {
-							return false
-						}
-						wasLabeled := pkgresources.HasLabel(e.ObjectOld, labels.ODH.Component(componentApi.KserveComponentName), labels.True)
-						isLabeled := pkgresources.HasLabel(e.ObjectNew, labels.ODH.Component(componentApi.KserveComponentName), labels.True)
-						return !wasLabeled && isLabeled
+						return false
 					},
 					DeleteFunc: func(e event.DeleteEvent) bool {
-						// React when InferenceServices CRD is deleted (dependency becomes unavailable)
-						// MonitorCRD precondition will detect the missing CRD and set conditions to False
-						return isInferenceServicesCRD(e.Object)
+						return e.Object.GetName() == InferenceServicesCRDName
 					},
 					GenericFunc: func(e event.GenericEvent) bool {
-						// Don't match Generic events
 						return false
 					},
 				},

--- a/internal/controller/components/trustyai/trustyai_test.go
+++ b/internal/controller/components/trustyai/trustyai_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/conditions"
 	odhtypes "github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/metadata/annotations"
-	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/metadata/labels"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/fakeclient"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/matchers/jq"
 
@@ -500,42 +499,26 @@ func makeCRD(name string, lbls map[string]string) *extv1.CustomResourceDefinitio
 	return crd
 }
 
-func odhKserveLabel() map[string]string {
-	return map[string]string{
-		labels.ODH.Component(componentApi.KserveComponentName): labels.True,
+// TestInferenceServicesCRDDeletePredicate covers the DeleteFunc predicate (name-only check).
+// The ODH label is not required: the CRD may be deleted before ODH labels it.
+func TestInferenceServicesCRDDeletePredicate(t *testing.T) {
+	deleteFired := func(crd *extv1.CustomResourceDefinition) bool {
+		return crd.GetName() == InferenceServicesCRDName
 	}
-}
 
-// TestIsInferenceServicesCRD covers the DeleteFunc predicate (full name + label check).
-func TestIsInferenceServicesCRD(t *testing.T) {
 	tests := []struct {
 		name     string
 		crdName  string
-		lbls     map[string]string
 		expected bool
 	}{
 		{
-			name:     "correct name and ODH label → true",
+			name:     "correct CRD name → fires",
 			crdName:  InferenceServicesCRDName,
-			lbls:     odhKserveLabel(),
 			expected: true,
 		},
 		{
-			name:     "correct name but no ODH label → false",
-			crdName:  InferenceServicesCRDName,
-			lbls:     nil,
-			expected: false,
-		},
-		{
-			name:     "wrong name with ODH label → false",
+			name:     "wrong CRD name → does not fire",
 			crdName:  "other.crd.io",
-			lbls:     odhKserveLabel(),
-			expected: false,
-		},
-		{
-			name:     "wrong name no label → false",
-			crdName:  "other.crd.io",
-			lbls:     nil,
 			expected: false,
 		},
 	}
@@ -543,14 +526,13 @@ func TestIsInferenceServicesCRD(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			g := NewWithT(t)
-			crd := makeCRD(tt.crdName, tt.lbls)
-			g.Expect(isInferenceServicesCRD(crd)).Should(Equal(tt.expected))
+			crd := makeCRD(tt.crdName, nil)
+			g.Expect(deleteFired(crd)).Should(Equal(tt.expected))
 		})
 	}
 }
 
 // TestInferenceServicesCRDCreatePredicate covers the CreateFunc predicate (name-only check).
-// KServe creates the CRD without the ODH label; the predicate must fire on name match alone.
 func TestInferenceServicesCRDCreatePredicate(t *testing.T) {
 	createFired := func(crd *extv1.CustomResourceDefinition) bool {
 		return crd.GetName() == InferenceServicesCRDName
@@ -559,25 +541,16 @@ func TestInferenceServicesCRDCreatePredicate(t *testing.T) {
 	tests := []struct {
 		name     string
 		crdName  string
-		lbls     map[string]string
 		expected bool
 	}{
 		{
-			name:     "correct name, no ODH label (KServe-created CRD) → fires",
+			name:     "correct CRD name → fires",
 			crdName:  InferenceServicesCRDName,
-			lbls:     nil,
 			expected: true,
 		},
 		{
-			name:     "correct name, with ODH label → fires",
-			crdName:  InferenceServicesCRDName,
-			lbls:     odhKserveLabel(),
-			expected: true,
-		},
-		{
-			name:     "wrong name → does not fire",
+			name:     "wrong CRD name → does not fire",
 			crdName:  "other.crd.io",
-			lbls:     nil,
 			expected: false,
 		},
 	}
@@ -585,75 +558,8 @@ func TestInferenceServicesCRDCreatePredicate(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			g := NewWithT(t)
-			crd := makeCRD(tt.crdName, tt.lbls)
+			crd := makeCRD(tt.crdName, nil)
 			g.Expect(createFired(crd)).Should(Equal(tt.expected))
-		})
-	}
-}
-
-// TestInferenceServicesCRDUpdatePredicate covers the UpdateFunc predicate (label-added transition).
-func TestInferenceServicesCRDUpdatePredicate(t *testing.T) {
-	odhLabel := labels.ODH.Component(componentApi.KserveComponentName)
-
-	updateFired := func(oldObj, newObj *extv1.CustomResourceDefinition) bool {
-		if newObj.GetName() != InferenceServicesCRDName {
-			return false
-		}
-		wasLabeled := oldObj.GetLabels()[odhLabel] == labels.True
-		isLabeled := newObj.GetLabels()[odhLabel] == labels.True
-		return !wasLabeled && isLabeled
-	}
-
-	tests := []struct {
-		name     string
-		crdName  string
-		oldLbls  map[string]string
-		newLbls  map[string]string
-		expected bool
-	}{
-		{
-			name:     "ODH label added (absent → present) → fires",
-			crdName:  InferenceServicesCRDName,
-			oldLbls:  nil,
-			newLbls:  odhKserveLabel(),
-			expected: true,
-		},
-		{
-			name:     "ODH label already present → does not fire (no spurious reconciliation)",
-			crdName:  InferenceServicesCRDName,
-			oldLbls:  odhKserveLabel(),
-			newLbls:  odhKserveLabel(),
-			expected: false,
-		},
-		{
-			name:     "ODH label removed (present → absent) → does not fire",
-			crdName:  InferenceServicesCRDName,
-			oldLbls:  odhKserveLabel(),
-			newLbls:  nil,
-			expected: false,
-		},
-		{
-			name:     "neither old nor new has ODH label → does not fire",
-			crdName:  InferenceServicesCRDName,
-			oldLbls:  nil,
-			newLbls:  nil,
-			expected: false,
-		},
-		{
-			name:     "wrong CRD name with label added → does not fire",
-			crdName:  "other.crd.io",
-			oldLbls:  nil,
-			newLbls:  odhKserveLabel(),
-			expected: false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			g := NewWithT(t)
-			oldCRD := makeCRD(tt.crdName, tt.oldLbls)
-			newCRD := makeCRD(tt.crdName, tt.newLbls)
-			g.Expect(updateFired(oldCRD, newCRD)).Should(Equal(tt.expected))
 		})
 	}
 }

--- a/internal/controller/components/trustyai/trustyai_test.go
+++ b/internal/controller/components/trustyai/trustyai_test.go
@@ -14,7 +14,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/event"
 
 	"github.com/opendatahub-io/opendatahub-operator/v2/api/common"
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/api/components/v1alpha1"
@@ -587,8 +586,6 @@ func TestInferenceServicesCRDCreatePredicate(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			g := NewWithT(t)
 			crd := makeCRD(tt.crdName, tt.lbls)
-			e := event.CreateEvent{Object: crd}
-			g.Expect(e.Object.GetName() == InferenceServicesCRDName).Should(Equal(tt.expected))
 			g.Expect(createFired(crd)).Should(Equal(tt.expected))
 		})
 	}

--- a/internal/controller/components/trustyai/trustyai_test.go
+++ b/internal/controller/components/trustyai/trustyai_test.go
@@ -10,9 +10,11 @@ import (
 	operatorv1 "github.com/openshift/api/operator/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 
 	"github.com/opendatahub-io/opendatahub-operator/v2/api/common"
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/api/components/v1alpha1"
@@ -24,6 +26,7 @@ import (
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/conditions"
 	odhtypes "github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/metadata/annotations"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/metadata/labels"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/fakeclient"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/matchers/jq"
 
@@ -488,6 +491,173 @@ func createTrustyAIDeployment(selectorLabels map[string]string) *appsv1.Deployme
 				Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "manager", Image: "test"}}},
 			},
 		},
+	}
+}
+
+func makeCRD(name string, lbls map[string]string) *extv1.CustomResourceDefinition {
+	crd := &extv1.CustomResourceDefinition{}
+	crd.SetName(name)
+	crd.SetLabels(lbls)
+	return crd
+}
+
+func odhKserveLabel() map[string]string {
+	return map[string]string{
+		labels.ODH.Component(componentApi.KserveComponentName): labels.True,
+	}
+}
+
+// TestIsInferenceServicesCRD covers the DeleteFunc predicate (full name + label check).
+func TestIsInferenceServicesCRD(t *testing.T) {
+	tests := []struct {
+		name     string
+		crdName  string
+		lbls     map[string]string
+		expected bool
+	}{
+		{
+			name:     "correct name and ODH label → true",
+			crdName:  InferenceServicesCRDName,
+			lbls:     odhKserveLabel(),
+			expected: true,
+		},
+		{
+			name:     "correct name but no ODH label → false",
+			crdName:  InferenceServicesCRDName,
+			lbls:     nil,
+			expected: false,
+		},
+		{
+			name:     "wrong name with ODH label → false",
+			crdName:  "other.crd.io",
+			lbls:     odhKserveLabel(),
+			expected: false,
+		},
+		{
+			name:     "wrong name no label → false",
+			crdName:  "other.crd.io",
+			lbls:     nil,
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			crd := makeCRD(tt.crdName, tt.lbls)
+			g.Expect(isInferenceServicesCRD(crd)).Should(Equal(tt.expected))
+		})
+	}
+}
+
+// TestInferenceServicesCRDCreatePredicate covers the CreateFunc predicate (name-only check).
+// KServe creates the CRD without the ODH label; the predicate must fire on name match alone.
+func TestInferenceServicesCRDCreatePredicate(t *testing.T) {
+	createFired := func(crd *extv1.CustomResourceDefinition) bool {
+		return crd.GetName() == InferenceServicesCRDName
+	}
+
+	tests := []struct {
+		name     string
+		crdName  string
+		lbls     map[string]string
+		expected bool
+	}{
+		{
+			name:     "correct name, no ODH label (KServe-created CRD) → fires",
+			crdName:  InferenceServicesCRDName,
+			lbls:     nil,
+			expected: true,
+		},
+		{
+			name:     "correct name, with ODH label → fires",
+			crdName:  InferenceServicesCRDName,
+			lbls:     odhKserveLabel(),
+			expected: true,
+		},
+		{
+			name:     "wrong name → does not fire",
+			crdName:  "other.crd.io",
+			lbls:     nil,
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			crd := makeCRD(tt.crdName, tt.lbls)
+			e := event.CreateEvent{Object: crd}
+			g.Expect(e.Object.GetName() == InferenceServicesCRDName).Should(Equal(tt.expected))
+			g.Expect(createFired(crd)).Should(Equal(tt.expected))
+		})
+	}
+}
+
+// TestInferenceServicesCRDUpdatePredicate covers the UpdateFunc predicate (label-added transition).
+func TestInferenceServicesCRDUpdatePredicate(t *testing.T) {
+	odhLabel := labels.ODH.Component(componentApi.KserveComponentName)
+
+	updateFired := func(oldObj, newObj *extv1.CustomResourceDefinition) bool {
+		if newObj.GetName() != InferenceServicesCRDName {
+			return false
+		}
+		wasLabeled := oldObj.GetLabels()[odhLabel] == labels.True
+		isLabeled := newObj.GetLabels()[odhLabel] == labels.True
+		return !wasLabeled && isLabeled
+	}
+
+	tests := []struct {
+		name     string
+		crdName  string
+		oldLbls  map[string]string
+		newLbls  map[string]string
+		expected bool
+	}{
+		{
+			name:     "ODH label added (absent → present) → fires",
+			crdName:  InferenceServicesCRDName,
+			oldLbls:  nil,
+			newLbls:  odhKserveLabel(),
+			expected: true,
+		},
+		{
+			name:     "ODH label already present → does not fire (no spurious reconciliation)",
+			crdName:  InferenceServicesCRDName,
+			oldLbls:  odhKserveLabel(),
+			newLbls:  odhKserveLabel(),
+			expected: false,
+		},
+		{
+			name:     "ODH label removed (present → absent) → does not fire",
+			crdName:  InferenceServicesCRDName,
+			oldLbls:  odhKserveLabel(),
+			newLbls:  nil,
+			expected: false,
+		},
+		{
+			name:     "neither old nor new has ODH label → does not fire",
+			crdName:  InferenceServicesCRDName,
+			oldLbls:  nil,
+			newLbls:  nil,
+			expected: false,
+		},
+		{
+			name:     "wrong CRD name with label added → does not fire",
+			crdName:  "other.crd.io",
+			oldLbls:  nil,
+			newLbls:  odhKserveLabel(),
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			oldCRD := makeCRD(tt.crdName, tt.oldLbls)
+			newCRD := makeCRD(tt.crdName, tt.newLbls)
+			g.Expect(updateFired(oldCRD, newCRD)).Should(Equal(tt.expected))
+		})
 	}
 }
 


### PR DESCRIPTION
## What and why

TrustyAI fails to recover from `PreConditionFailed` (`DependenciesAvailable=False`) after KServe is installed. The only workaround is a manual annotation change to force re-reconciliation.

The root cause is in the CRD watch predicate introduced by #3707. `CreateFunc` called `isInferenceServicesCRD`, which checks for both the CRD name *and* the ODH label `app.opendatahub.io/kserve: "true"`. KServe's OLM operator creates the CRD without that label, ODH adds it later via an update. So the Create event never triggered re-reconciliation.
`UpdateFunc` was hardcoded to `return false`, so the label-added update also went unhandled. TrustyAI was permanently stuck with no automatic recovery.

Closes [RHOAIENG-77786](https://redhat.atlassian.net/browse/RHOAIENG-77786)

## Type

- [ ] feat
- [x] fix
- [ ] docs
- [ ] refactor / chore
- [ ] test / ci

## Testing

- [x] Tests added or updated
- [ ] Tested manually

Three new test functions cover all predicate cases:

- `TestIsInferenceServicesCRD`, DeleteFunc (full name + label check, unchanged behaviour)
- `TestInferenceServicesCRDCreatePredicate`, fires on name match with no ODH label (the previously
  broken case)
- `TestInferenceServicesCRDUpdatePredicate`, fires on absent -> present label transition; no spurious reconciliation on other update types

Manual verification: 

- install TrustyAI with KServe absent -> `DependenciesAvailable=False`
- Enable KServe -> TrustyAI recovers automatically without manual intervention (`oc get trustyai -o yaml` shows
  `DependenciesAvailable: True`)

[RHOAIENG-77786]: https://redhat.atlassian.net/browse/RHOAIENG-77786?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->
This resolves a flakiness in e2e testing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of KServe InferenceServices CustomResourceDefinition events by matching only on the CRD name for **create** and **delete**.
  * Ensured the controller does not react to **update** events for the InferenceServices CRD.
* **Tests**
  * Added table-driven unit tests covering InferenceServices CRD **create** and **delete** predicate behavior, using CRD objects constructed from extension API types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->