### PR TITLE
fix(e2e): reduce CI flakiness from monitoring state leak and control-plane saturation

### DIFF
--- a/tests/e2e/controller_test.go
+++ b/tests/e2e/controller_test.go
@@ -140,19 +140,23 @@ var (
 		parallel: true,
 		scenarios: []map[string]TestFn{
 			{
-				componentApi.DashboardComponentName:            dashboardTestSuite,
-				componentApi.RayComponentName:                  rayTestSuite,
-				componentApi.ModelRegistryComponentName:        modelRegistryTestSuite,
-				componentApi.TrainingOperatorComponentName:     trainingOperatorTestSuite,
-				componentApi.TrainerComponentName:              trainerTestSuite,
-				componentApi.DataSciencePipelinesComponentName: dataSciencePipelinesTestSuite,
-				componentApi.WorkbenchesComponentName:          workbenchesTestSuite,
+				componentApi.DashboardComponentName:        dashboardTestSuite,
+				componentApi.RayComponentName:              rayTestSuite,
+				componentApi.ModelRegistryComponentName:    modelRegistryTestSuite,
+				componentApi.TrainingOperatorComponentName: trainingOperatorTestSuite,
+				componentApi.TrainerComponentName:          trainerTestSuite,
+			},
+			{
 				componentApi.KserveComponentName:               kserveTestSuite,
-				componentApi.FeastOperatorComponentName:        feastOperatorTestSuite,
-				componentApi.OGXComponentName:                  ogxTestSuite,
 				componentApi.SparkOperatorComponentName:        sparkOperatorTestSuite,
-				componentApi.AIGatewayComponentName:            aiGatewayTestSuite,
+				componentApi.FeastOperatorComponentName:        feastOperatorTestSuite,
 				componentApi.MCPLifecycleOperatorComponentName: mcpLifecycleOperatorTestSuite,
+			},
+			{
+				componentApi.WorkbenchesComponentName:          workbenchesTestSuite,
+				componentApi.DataSciencePipelinesComponentName: dataSciencePipelinesTestSuite,
+				componentApi.OGXComponentName:                  ogxTestSuite,
+				componentApi.AIGatewayComponentName:            aiGatewayTestSuite,
 			},
 			{
 				// Kueue tests depends on Workbenches, so must not run with Workbenches tests in parallel

--- a/tests/e2e/monitoring_test.go
+++ b/tests/e2e/monitoring_test.go
@@ -134,6 +134,14 @@ func monitoringTestSuite(t *testing.T) {
 	// ========================================================================
 	t.Run("Validate monitoring service disabled", monitoringServiceCtx.ValidateMonitoringServiceDisabled)
 	t.Run("Validate MonitoringReady condition reflects disabled state on DSCI", monitoringServiceCtx.ValidateMonitoringReadyConditionDisabledOnDSCI)
+
+	// ========================================================================
+	// Post-Suite: Restore monitoring baseline
+	// Re-enables monitoring so the cluster is healthy for subsequent test suites
+	// (components, auth, gateway). Without this, the disabled monitoring state
+	// causes cascading timeouts and failures in component tests.
+	// ========================================================================
+	t.Run("Restore monitoring for subsequent test suites", monitoringServiceCtx.RestoreMonitoringAfterSuite)
 }
 
 func (tc *MonitoringTestCtx) runBaseConfigurationTests(t *testing.T) {
@@ -492,6 +500,23 @@ func (tc *MonitoringTestCtx) ValidateMonitoringReadyConditionDisabledOnDSCI(t *t
 			jq.Match(`.status.conditions[] | select(.type == "%s") | .reason == "%s"`, status.ConditionMonitoringReady, status.RemovedReason),
 		)),
 		WithCustomErrorMsg("DSCI should have MonitoringReady=False with reason Removed when monitoring is disabled"),
+	)
+}
+
+// RestoreMonitoringAfterSuite re-enables monitoring after the disable validation tests
+// so the cluster is in a healthy state for subsequent test suites (components, auth, gateway).
+func (tc *MonitoringTestCtx) RestoreMonitoringAfterSuite(t *testing.T) {
+	t.Helper()
+
+	tc.resetMonitoringConfigToManaged()
+
+	tc.EnsureResourceExists(
+		WithMinimalObject(gvk.DSCInitialization, tc.DSCInitializationNamespacedName),
+		WithCondition(And(
+			jq.Match(`.status.phase == "%s"`, status.PhaseReady),
+			jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, status.ConditionMonitoringReady, metav1.ConditionTrue),
+		)),
+		WithCustomErrorMsg("DSCI should have MonitoringReady=True after re-enabling monitoring for subsequent test suites"),
 	)
 }
 


### PR DESCRIPTION
## Description

Fixes two independent sources of e2e flakiness identified through CI failure analysis and cluster health metrics from CI test artifacts (`cluster-health-metrics.txt`).

### Fix 1: Restore monitoring after suite

The monitoring e2e suite ends with `ValidateMonitoringServiceDisabled` which sets `managementState=Removed` and verifies all monitoring CRs are deleted. Because there is no re-enable step before the component suite, components start with monitoring disabled — DSCI reports `MonitoringReady=False`, and namespace-level cleanup triggered by the disable can cause `"unable to create new content in namespace opendatahub because it is being terminated"` errors, cascading into widespread timeouts across all parallel component tests.

This was identified as the #1 source of monitoring test flakiness in RHOAIENG-51602 (79 failures in 90 days).

**Fix:** Add a `RestoreMonitoringAfterSuite` step at the end of `monitoringTestSuite` that calls `resetMonitoringConfigToManaged()` and waits for `MonitoringReady=True` on the DSCI before returning.

### Fix 2: Split component group_1 (13 → 5/4/4)

All 13 independent component tests (dashboard, ray, kserve, sparkoperator, etc.) ran in a single parallel batch. Cluster health metrics collected during failed CI runs (`cluster-health-metrics.txt` in CI artifacts) showed control-plane CPU saturation — one control-plane node (`m6i.xlarge`, 4 vCPU / 3.5 allocatable) hit **112% of allocatable CPU** during peak component lifecycle activity. All three control-plane nodes peaked simultaneously, confirming an API server reconciliation storm from 13 concurrent enable/test/disable cycles.

Worker nodes (m5.2xlarge, 8 vCPU) stayed under 50% — the bottleneck is API server load from concurrent resource mutations (CRD watches, webhook admissions, foreground GC traversals), not workload pod scheduling.

<details>
<summary>How to find the metrics data</summary>

The e2e test suite runs a background `MetricsCollector` (see `tests/e2e/metrics_collector_test.go`) that polls `clusterhealth.Run()` every 30s and writes Prometheus exposition format lines to `$ARTIFACT_DIR/cluster-health-metrics.txt`. This file is uploaded as a CI artifact on every Prow e2e run.

To find it for any Prow job:
1. Open the Prow job link (e.g. `prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/...`)
2. Navigate to **Artifacts** → `opendatahub-operator-e2e/` → `e2e/` → `artifacts/`
3. Open `cluster-health-metrics.txt`

Key metrics to look for:
- `node_cpu_usage_cores` — actual CPU usage per node
- `kube_node_status_allocatable{resource="cpu"}` — allocatable CPU per node
- `kube_node_role` — identifies control-plane vs worker nodes
- `kube_pod_container_resource_requests{resource="cpu"}` — CPU requests per pod

The data from these runs is available at:
- [ODH e2e artifacts](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/pr-logs/pull/opendatahub-io_opendatahub-operator/3828/pull-ci-opendatahub-io-opendatahub-operator-main-opendatahub-operator-e2e/2078478143009591296/artifacts/opendatahub-operator-e2e/e2e/artifacts/)
- [RHOAI e2e artifacts](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/pr-logs/pull/opendatahub-io_opendatahub-operator/3828/pull-ci-opendatahub-io-opendatahub-operator-main-opendatahub-operator-rhoai-e2e/2078478143043145728/artifacts/opendatahub-operator-rhoai-e2e/e2e/artifacts/)
</details>

**Fix:** Split `scenarios[0]` into three sequential batches of 5, 4, and 4 components. All inter-group dependency constraints (Kueue→Workbenches, ModelController→KServe+ModelRegistry, TrustyAI→KServe, etc.) remain satisfied. Adds ~5-10 minutes wall-clock time but reduces peak concurrent API server load by ~60%.

**JIRA:** [RHOAIENG-51602](https://issues.redhat.com/browse/RHOAIENG-51602)

**Related PRs:**
- #3298 — original fix proposal (reorder monitoring tests, closed in favor of #3351)
- #3351 — reorganized monitoring tests into 9 groups (merged, but did not add re-enable step)
- #3486 — narrower fix for PersesDatasource list flake (merged)

## How Has This Been Tested?

- `go vet` passes on all modified packages
- Full validation via Prow `opendatahub-operator-e2e` and `opendatahub-operator-rhoai-e2e` CI jobs

## Screenshot or short clip

N/A

## Merge criteria

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully
- [ ] New RELATED_IMAGE mappings are listed in ODH-Build-Config and RHOAI-Build-Config (CI validates names against build-config repos). Include links to build-config PRs in the description.

### E2E test suite update requirement

- [x] Skip requirement to update E2E test suite for this PR

#### E2E update requirement opt-out justification

This PR *is* an E2E test fix — it adds a monitoring restore step and splits component test parallelism. No production code is changed.


[RHOAIENG-51602]: https://redhat.atlassian.net/browse/RHOAIENG-51602?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ