### PR TITLE
[RHAISTRAT-1064] Return all nodes for cleanup & always inject env vars

### DIFF
--- a/cmd/mcp-server/main.go
+++ b/cmd/mcp-server/main.go
@@ -6,10 +6,11 @@ import (
 	"os"
 
 	"github.com/mark3labs/mcp-go/server"
-	"github.com/opendatahub-io/opendatahub-operator/pkg/mcptools"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	ctrl "sigs.k8s.io/controller-runtime/pkg/client/config"
+
+	"github.com/opendatahub-io/opendatahub-operator/pkg/mcptools"
 )
 
 func main() {

--- a/internal/controller/modules/modules_controller_actions.go
+++ b/internal/controller/modules/modules_controller_actions.go
@@ -160,8 +160,6 @@ func cleanupDisabledModules(ctx context.Context, rr *odhtype.ReconciliationReque
 		return err
 	}
 
-	var keptAliveImages []odhtype.ModuleImages
-
 	cleanupOne := func(handler ModuleHandler) error {
 		if handler.IsEnabled(platformCtx) && reg.IsEnabled(handler.GetName()) {
 			return nil
@@ -197,14 +195,6 @@ func cleanupDisabledModules(ctx context.Context, rr *odhtype.ReconciliationReque
 				rr.Manifests = append(rr.Manifests, operatorManifests.Manifests...)
 			}
 
-			keptAliveImages = append(keptAliveImages, odhtype.ModuleImages{
-				DeploymentName:    deploymentNameFor(handler, operatorManifests),
-				ContainerName:     containerNameFor(handler),
-				ControllerImage:   controllerImageFor(handler),
-				InitContainerName: initContainerNameFor(handler),
-				Images:            handler.GetRelatedImages(),
-			})
-
 			return nil
 		}
 
@@ -231,17 +221,6 @@ func cleanupDisabledModules(ctx context.Context, rr *odhtype.ReconciliationReque
 				}
 			}
 		}
-	}
-
-	if len(keptAliveImages) > 0 {
-		if rr.ModuleEnvInjection == nil {
-			rr.ModuleEnvInjection = &odhtype.ModuleEnvInjection{
-				ApplicationsNamespace: platformCtx.ApplicationsNamespace,
-				MonitoringNamespace:   platformCtx.MonitoringNamespace,
-				PlatformType:          platformCtx.Release.Name,
-			}
-		}
-		rr.ModuleEnvInjection.PerModuleImages = append(rr.ModuleEnvInjection.PerModuleImages, keptAliveImages...)
 	}
 
 	return nil

--- a/internal/controller/modules/modules_controller_actions.go
+++ b/internal/controller/modules/modules_controller_actions.go
@@ -160,6 +160,8 @@ func cleanupDisabledModules(ctx context.Context, rr *odhtype.ReconciliationReque
 		return err
 	}
 
+	var keptAliveImages []odhtype.ModuleImages
+
 	cleanupOne := func(handler ModuleHandler) error {
 		if handler.IsEnabled(platformCtx) && reg.IsEnabled(handler.GetName()) {
 			return nil
@@ -195,6 +197,14 @@ func cleanupDisabledModules(ctx context.Context, rr *odhtype.ReconciliationReque
 				rr.Manifests = append(rr.Manifests, operatorManifests.Manifests...)
 			}
 
+			keptAliveImages = append(keptAliveImages, odhtype.ModuleImages{
+				DeploymentName:    deploymentNameFor(handler, operatorManifests),
+				ContainerName:     containerNameFor(handler),
+				ControllerImage:   controllerImageFor(handler),
+				InitContainerName: initContainerNameFor(handler),
+				Images:            handler.GetRelatedImages(),
+			})
+
 			return nil
 		}
 
@@ -204,21 +214,34 @@ func cleanupDisabledModules(ctx context.Context, rr *odhtype.ReconciliationReque
 	reverseBatches, err := provision.ReverseBatchesAll()
 	if err != nil {
 		logf.FromContext(ctx).Error(err, "DAG reverse resolution failed, falling back to alphabetical cleanup order")
-		return reg.ForAll(func(handler ModuleHandler, _ bool) error {
+		if forAllErr := reg.ForAll(func(handler ModuleHandler, _ bool) error {
 			return cleanupOne(handler)
-		})
-	}
-
-	for _, batch := range reverseBatches {
-		for _, entry := range provision.ModulesInBatch(batch) {
-			handler := reg.Lookup(entry.GetName())
-			if handler == nil {
-				continue
-			}
-			if err := cleanupOne(handler); err != nil {
-				return err
+		}); forAllErr != nil {
+			return forAllErr
+		}
+	} else {
+		for _, batch := range reverseBatches {
+			for _, entry := range provision.ModulesInBatch(batch) {
+				handler := reg.Lookup(entry.GetName())
+				if handler == nil {
+					continue
+				}
+				if err := cleanupOne(handler); err != nil {
+					return err
+				}
 			}
 		}
+	}
+
+	if len(keptAliveImages) > 0 {
+		if rr.ModuleEnvInjection == nil {
+			rr.ModuleEnvInjection = &odhtype.ModuleEnvInjection{
+				ApplicationsNamespace: platformCtx.ApplicationsNamespace,
+				MonitoringNamespace:   platformCtx.MonitoringNamespace,
+				PlatformType:          platformCtx.Release.Name,
+			}
+		}
+		rr.ModuleEnvInjection.PerModuleImages = append(rr.ModuleEnvInjection.PerModuleImages, keptAliveImages...)
 	}
 
 	return nil

--- a/internal/controller/modules/modules_controller_actions.go
+++ b/internal/controller/modules/modules_controller_actions.go
@@ -201,7 +201,7 @@ func cleanupDisabledModules(ctx context.Context, rr *odhtype.ReconciliationReque
 		return nil
 	}
 
-	reverseBatches, err := provision.DefaultRegistry().ReverseBatches()
+	reverseBatches, err := provision.ReverseBatchesAll()
 	if err != nil {
 		logf.FromContext(ctx).Error(err, "DAG reverse resolution failed, falling back to alphabetical cleanup order")
 		return reg.ForAll(func(handler ModuleHandler, _ bool) error {

--- a/pkg/controller/provision/unified.go
+++ b/pkg/controller/provision/unified.go
@@ -167,6 +167,7 @@ func (r *UnifiedRegistry) ResolvedBatches() ([][]UnifiedNode, error) {
 }
 
 // ReverseBatches returns batches in reverse order for cleanup.
+// Only enabled nodes are included.
 func (r *UnifiedRegistry) ReverseBatches() ([][]UnifiedNode, error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -178,6 +179,18 @@ func (r *UnifiedRegistry) ReverseBatches() ([][]UnifiedNode, error) {
 			continue
 		}
 		g.Add(n)
+	}
+
+	return g.ReverseBatches()
+}
+
+func (r *UnifiedRegistry) ReverseBatchesAll() ([][]UnifiedNode, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	g := dag.NewGraph[UnifiedNode]()
+	for _, name := range r.order {
+		g.Add(r.nodes[name])
 	}
 
 	return g.ReverseBatches()
@@ -215,6 +228,10 @@ func Enable(name string) {
 
 func Disable(name string) {
 	defaultRegistry.Disable(name)
+}
+
+func ReverseBatchesAll() ([][]UnifiedNode, error) {
+	return defaultRegistry.ReverseBatchesAll()
 }
 
 func InvalidateCache() {

--- a/pkg/controller/provision/unified_test.go
+++ b/pkg/controller/provision/unified_test.go
@@ -186,6 +186,59 @@ func TestReverseBatches(t *testing.T) {
 	assert.Equal(t, []string{"infra"}, batchNames(batches)[2])
 }
 
+func TestReverseBatches_ExcludesDisabled(t *testing.T) {
+	t.Parallel()
+
+	r := newRegistry()
+	r.Add("infra", provision.KindComponent, dag.RL(0))
+	r.Add("core", provision.KindModule, dag.RL(20))
+	r.Add("ext", provision.KindComponent, dag.RL(30))
+	r.Disable("core")
+
+	batches, err := r.ReverseBatches()
+	require.NoError(t, err)
+	require.Len(t, batches, 2)
+
+	assert.Equal(t, []string{"ext"}, batchNames(batches)[0])
+	assert.Equal(t, []string{"infra"}, batchNames(batches)[1])
+}
+
+func TestReverseBatchesAll_IncludesDisabled(t *testing.T) {
+	t.Parallel()
+
+	r := newRegistry()
+	r.Add("infra", provision.KindComponent, dag.RL(0))
+	r.Add("core", provision.KindModule, dag.RL(20))
+	r.Add("ext", provision.KindComponent, dag.RL(30))
+	r.Disable("core")
+
+	batches, err := r.ReverseBatchesAll()
+	require.NoError(t, err)
+	require.Len(t, batches, 3, "disabled nodes must be included for cleanup")
+
+	assert.Equal(t, []string{"ext"}, batchNames(batches)[0])
+	assert.Equal(t, []string{"core"}, batchNames(batches)[1])
+	assert.Equal(t, []string{"infra"}, batchNames(batches)[2])
+}
+
+func TestReverseBatchesAll_PreservesOrder(t *testing.T) {
+	t.Parallel()
+
+	r := newRegistry()
+	r.Add("alpha", provision.KindComponent, dag.RL(10))
+	r.Add("beta", provision.KindModule, dag.RL(10))
+	r.Add("gamma", provision.KindComponent, dag.RL(30))
+	r.Disable("alpha")
+	r.Disable("gamma")
+
+	batches, err := r.ReverseBatchesAll()
+	require.NoError(t, err)
+	require.Len(t, batches, 2)
+
+	assert.Equal(t, []string{"gamma"}, batchNames(batches)[0])
+	assert.ElementsMatch(t, []string{"alpha", "beta"}, batchNames(batches)[1])
+}
+
 func TestResolvedBatches_GranularRunlevelMixedTypes(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
<!---
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

- When cleaning up modules, the reverseBatches function returned only enabled modules. When cleaning up we need to iterate over all modules.
- When keeping a modular controller deployment alive during deletion always inject env vars so the deployment doesn't change.

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Before fix (reproduced on cluster):
```
Events:
  Scaled up kserve-module-controller-manager-75df4bb977 from 0 to 1
  Scaled up kserve-module-controller-manager-958f99d68 from 0 to 1   <-- new RS, different template
  Scaled down kserve-module-controller-manager-958f99d68 from 1 to 0  <-- killed within 1s
```
Result: two ReplicaSets, operator killed, module CR stuck with observedGeneration < generation.

After fix (same toggle test, same cluster):
```
Deployment: generation=3 observedGeneration=3 ready=1
ReplicaSets: kserve-module-controller-manager-75df4bb977  1/1/1  (single RS)
Env vars:    POD_NAMESPACE APPLICATIONS_NAMESPACE MONITORING_NAMESPACE ODH_MODULE_OPERATOR_PLATFORM_TYPE
Events:      (no scaling events during toggle window)
```
## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [x] The developer has run the integration test pipeline and verified that it passed successfully
- [x] New RELATED_IMAGE mappings are listed in ODH-Build-Config and RHOAI-Build-Config (CI validates names against build-config repos). Include links to build-config PRs in the description.

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->
Bugfix no E2E required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

- **Bug Fixes**
  - Improved cleanup sequencing for disabled modules by computing reverse execution order across all registered dependencies.
  - Updated module environment image handling to keep required “alive” image metadata so environment injection can continue during deletion/CR transitions.

- **New Features**
  - Added an “all-nodes” reverse batch computation option that includes disabled nodes (vs the existing enabled-only behavior).

- **Tests**
  - Added unit tests validating disabled-node inclusion and verifying batch/runlevel ordering is preserved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->