### PR TITLE
[RHAISTRAT-1377] fix: skip AIGateway CR creation for xKS Platform CR path

### DIFF
--- a/internal/controller/modules/aigateway/handler.go
+++ b/internal/controller/modules/aigateway/handler.go
@@ -148,9 +148,9 @@ func (h *handler) BuildModuleCR(
 			return nil, fmt.Errorf("failed to convert AIGatewayCommonSpec to unstructured: %w", err)
 		}
 	case platform.Platform != nil:
-		spec = map[string]any{
-			"managementState": string(platform.Platform.Spec.Modules.AIGateway.ManagementState),
-		}
+		// On xKS the Helm chart creates the AIGateway CR; the operator
+		// only needs to deploy the ai-gateway-operator via manifests.
+		return nil, nil
 	default:
 		return nil, errors.New("neither DSC CR nor Platform CR exists, cannot build AIGateway CR")
 	}

--- a/internal/controller/modules/aigateway/handler_test.go
+++ b/internal/controller/modules/aigateway/handler_test.go
@@ -300,19 +300,16 @@ func TestBuildModuleCR_NilDSCNilPlatformReturnsError(t *testing.T) {
 	g.Expect(err).Should(HaveOccurred())
 }
 
-func TestBuildModuleCR_PlatformMode(t *testing.T) {
+// On xKS (Platform CR path), the Helm chart owns the AIGateway CR —
+// BuildModuleCR returns nil so the operator doesn't create or patch it.
+func TestBuildModuleCR_PlatformMode_ReturnsNil(t *testing.T) {
 	g := NewWithT(t)
 	h := aigateway.NewHandler()
 	platform := newPlatformModePlatformCtx(operatorv1.Managed)
 
 	u, err := h.BuildModuleCR(context.Background(), nil, platform)
 	g.Expect(err).ShouldNot(HaveOccurred())
-	g.Expect(u.GetName()).Should(Equal(componentApi.AIGatewayInstanceName))
-	g.Expect(u.GetKind()).Should(Equal(componentApi.AIGatewayKind))
-
-	spec, ok := u.Object["spec"].(map[string]any)
-	g.Expect(ok).Should(BeTrue(), "spec is not a map")
-	g.Expect(spec["managementState"]).Should(Equal("Managed"))
+	g.Expect(u).Should(BeNil(), "Platform CR path should return nil — Helm chart owns the AIGateway CR on xKS")
 }
 
 func TestGetName(t *testing.T) {


### PR DESCRIPTION
## Summary

On xKS the Helm chart (`odh-gitops` PR #120) creates the AIGateway CR — the operator only needs to deploy the ai-gateway-operator via manifests. This PR returns `nil` from `BuildModuleCR` for the Platform CR path so the operator does not attempt to create or patch the AIGateway CR.

**Problem:** The Platform CR (xKS) path in `BuildModuleCR` set `spec.managementState` directly on the AIGateway CR, but the CRD doesn't declare that field. Kubernetes rejects the patch: `.spec.managementState: field not declared in schema`. Confirmed on AKS during E2E testing.

**Fix:** Return `nil, nil` for the Platform CR path — the Helm chart owns the AIGateway CR on xKS, the operator just deploys the ai-gateway-operator via kustomize manifests.

Suggested by @davidebianchi and @somya-bhatnagar as part of the xKS MaaS enablement work.

## Context

For full xKS MaaS E2E, three items were identified:

| # | Item | Status |
|---|------|--------|
| 1 | `sourcePathByPlatform` XKS → `overlays/rhoai` mapping | ✅ Already merged in #3825 |
| 2 | `IsEnabled` Platform CR path | ✅ Already merged in #3723 |
| 3 | `BuildModuleCR` wrong field path for xKS | 🔧 **This PR** |

Companion PR: [ai-gateway-operator#65](https://github.com/opendatahub-io/ai-gateway-operator/pull/65) (gateway-namespace override for xKS overlay)

## Test plan

- [x] `go test ./internal/controller/modules/aigateway/...` — all 20 tests pass
- [x] Updated `TestBuildModuleCR_PlatformMode` to verify `nil` return (Helm chart owns the CR)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate AIGateway resources from being created or updated in platform-managed deployments.
  * Platform deployments now rely on the Helm-managed AIGateway resource as intended.

* **Tests**
  * Updated coverage to verify that no additional AIGateway resource is generated in platform mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->