### PR TITLE
[RHAISTRAT-1064] RHOAIENG-78297: fix(modules): skip Namespace deletion in deleteRenderedResources

### DIFF
--- a/internal/controller/modules/base.go
+++ b/internal/controller/modules/base.go
@@ -373,6 +373,13 @@ func (b *BaseHandler) deleteRenderedResources(
 			continue
 		}
 
+		if res.GetKind() == "Namespace" {
+			log.V(1).Info("skipping Namespace deletion during module cleanup",
+				"module", b.Config.Name,
+				"name", res.GetName())
+			continue
+		}
+
 		log.V(1).Info("deleting module operator resource",
 			"module", b.Config.Name,
 			"kind", res.GetKind(),

--- a/internal/controller/modules/base_delete_test.go
+++ b/internal/controller/modules/base_delete_test.go
@@ -1,0 +1,95 @@
+//nolint:testpackage
+package modules
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestDeleteRenderedResources_SkipsNamespaces(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	var deletedKinds []string
+
+	cli := fake.NewClientBuilder().
+		WithInterceptorFuncs(interceptor.Funcs{
+			Delete: func(_ context.Context, _ client.WithWatch, obj client.Object, _ ...client.DeleteOption) error {
+				u, ok := obj.(*unstructured.Unstructured)
+				if ok {
+					deletedKinds = append(deletedKinds, u.GetKind())
+				}
+				return nil
+			},
+		}).
+		Build()
+
+	resources := []unstructured.Unstructured{
+		makeResource("Deployment", "apps", "controller-manager", "test-ns"),
+		makeResource("Namespace", "", "my-module-system", ""),
+		makeResource("ServiceAccount", "", "controller-manager", "test-ns"),
+	}
+
+	b := &BaseHandler{Config: ModuleConfig{Name: "test-module"}}
+	err := b.deleteRenderedResources(context.Background(), cli, logr.Discard(), resources)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(deletedKinds).To(ConsistOf("Deployment", "ServiceAccount"))
+}
+
+func TestDeleteRenderedResources_SkipsCRDs(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	var deletedKinds []string
+
+	cli := fake.NewClientBuilder().
+		WithInterceptorFuncs(interceptor.Funcs{
+			Delete: func(_ context.Context, _ client.WithWatch, obj client.Object, _ ...client.DeleteOption) error {
+				u, ok := obj.(*unstructured.Unstructured)
+				if ok {
+					deletedKinds = append(deletedKinds, u.GetKind())
+				}
+				return nil
+			},
+		}).
+		Build()
+
+	resources := []unstructured.Unstructured{
+		makeResource("Deployment", "apps", "controller-manager", "test-ns"),
+		makeCRD("myresources.example.com"),
+		makeResource("ClusterRole", "rbac.authorization.k8s.io", "manager-role", ""),
+	}
+
+	b := &BaseHandler{Config: ModuleConfig{Name: "test-module"}}
+	err := b.deleteRenderedResources(context.Background(), cli, logr.Discard(), resources)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(deletedKinds).To(ConsistOf("Deployment", "ClusterRole"))
+}
+
+func makeResource(kind, group, name, namespace string) unstructured.Unstructured {
+	u := unstructured.Unstructured{}
+	u.SetGroupVersionKind(schema.GroupVersionKind{Group: group, Version: "v1", Kind: kind})
+	u.SetName(name)
+	if namespace != "" {
+		u.SetNamespace(namespace)
+	}
+	return u
+}
+
+func makeCRD(name string) unstructured.Unstructured {
+	u := unstructured.Unstructured{}
+	u.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "apiextensions.k8s.io",
+		Version: "v1",
+		Kind:    "CustomResourceDefinition",
+	})
+	u.SetName(name)
+	return u
+}


### PR DESCRIPTION
Standard kubebuilder scaffolding includes a namespace.yaml in kustomize manifests. When a module transitions to Removed, deleteRenderedResources deletes all rendered resources including the Namespace, which cascades into deleting everything inside it. This is far more destructive than intended - the cleanup contract is to remove operator resources (Deployments, RBAC, ConfigMaps), not namespaces.

Add a Namespace skip alongside the existing CRD skip so the framework prevents this regardless of whether individual modules add kustomize patches to strip the Namespace from their rendered output.

Ref: RHOAIENG-78297

<!---
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully
- [ ] New RELATED_IMAGE mappings are listed in ODH-Build-Config and RHOAI-Build-Config (CI validates names against build-config repos). Include links to build-config PRs in the description.

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
tested via e2e
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Module cleanup now preserves Kubernetes Namespace resources while removing other rendered resources.
  * Custom Resource Definitions continue to be protected from deletion.

* **Tests**
  * Added coverage verifying that Namespaces and Custom Resource Definitions are excluded from cleanup while other resources are deleted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->