### PR TITLE
Add odh-spark-operator-module to operator manifests

### DIFF
--- a/build/manifests-config.yaml
+++ b/build/manifests-config.yaml
@@ -82,3 +82,6 @@ map:
   odh-mcp-lifecycle-module-operator:
     src: config
     dest: mcplifecycleoperator
+  odh-spark-operator-module:
+    src: spark-operator-module/config
+    dest: spark-operator-module


### PR DESCRIPTION
Adds 'odh-spark-operator-module' entry to build/manifests-config.yaml.

Repo: https://github.com/opendatahub-io/spark-operator
Jira: https://redhat.atlassian.net/browse/RHOAIENG-76484

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added build manifest configuration for the Spark Operator module.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->