### PR TITLE
[RHAISTRAT-1477] chore(RHOAIENG-66142): update kueueOcpOperatorChannel to stable-v1.4

### DIFF
--- a/tests/e2e/helper_test.go
+++ b/tests/e2e/helper_test.go
@@ -78,7 +78,7 @@ const (
 	leaderWorkerSetNamespace    = "openshift-lws-operator"                   // Namespace for the Leader Worker Set Operator
 	leaderWorkerSetChannel      = "stable-v1.0"                              // Channel for the Leader Worker Set Operator
 	kueueOcpOperatorNamespace   = "openshift-kueue-operator"                 // Namespace for the OCP Kueue Operator
-	kueueOcpOperatorChannel     = "stable-v1.3"                              // Channel for the OCP Kueue Operator
+	kueueOcpOperatorChannel     = "stable-v1.4"                              // Channel for the OCP Kueue Operator
 	kuadrantOpName              = "rhcl-operator"                            // Name of the Red Hat Connectivity Link Operator subscription.
 	kuadrantNamespace           = "kuadrant-system"                          // Namespace for the Red Hat Connectivity Link Operator.
 


### PR DESCRIPTION
## Description

Update the Kueue OCP operator subscription channel used by e2e tests from `stable-v1.3` to `stable-v1.4` (RHBoK 1.4 / upstream Kueue v0.18).

This activates the SparkApplication version gate (>= v1.4.0) already wired in `kueue_config.go`, so SparkApplication will now appear in the default Kueue CR frameworks list on e2e test clusters.

Follow-up to [RHOAIENG-63983](https://issues.redhat.com/browse/RHOAIENG-63983), which added SparkApplication to the Kueue frameworkMapping gated behind Kueue >= v1.4.0.

Jira: https://issues.redhat.com/browse/RHOAIENG-66142

### Companion PR

- **odh-gitops**: https://github.com/opendatahub-io/odh-gitops/pull/140 (updates kustomize subscription + helm chart channel — merge after this PR)

## How Has This Been Tested?

- `make generate manifests` — passes
- `make fmt` — passes
- `make lint` — 0 issues
- Kueue unit tests (`go test ./internal/controller/components/kueue/...`) — all 42 tests pass, including SparkApplication version gate tests
- E2e test package compiles cleanly

## Merge criteria

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully
- [ ] New RELATED_IMAGE mappings are listed in ODH-Build-Config and RHOAI-Build-Config (CI validates names against build-config repos). Include links to build-config PRs in the description.

### E2E test suite update requirement

- [ ] Skip requirement to update E2E test suite for this PR

#### E2E update requirement opt-out justification

This PR updates the e2e test channel constant itself — the e2e test suite is the change.

[RHOAIENG-63983]: https://redhat.atlassian.net/browse/RHOAIENG-63983?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated end-to-end test infrastructure to use the stable v1.4 channel for the Kueue Operator.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->