### PR TITLE
Add odh-ray-module-operator to manifests-config.yaml

### DIFF
--- a/build/manifests-config.yaml
+++ b/build/manifests-config.yaml
@@ -82,3 +82,6 @@ map:
   odh-mcp-lifecycle-module-operator:
     src: config
     dest: mcplifecycleoperator
+  odh-ray-module-operator:
+    src: config/manager
+    dest: ray-module-operator


### PR DESCRIPTION
Adds 'odh-ray-module-operator' to the operator manifests config map.

Component: odh-ray-module-operator
Manifest source path: config/manager
Manifest dest path:   ray-module-operator
Upstream repo: https://github.com/opendatahub-io/ray-module-operator @ main
Jira: https://redhat.atlassian.net/browse/RHOAIENG-78079

**File changed:**
- `build/manifests-config.yaml` — added `odh-ray-module-operator` entry under `map:`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added build configuration for the Ray Module Operator so its manager assets are included in generated manifests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->