### PR TITLE
fix(RHOAIENG-77786): handle CRD update events in TrustyAI watch to fix Established race

### DIFF
--- a/internal/controller/components/trustyai/trustyai_controller.go
+++ b/internal/controller/components/trustyai/trustyai_controller.go
@@ -24,7 +24,6 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/api/components/v1alpha1"
@@ -39,6 +38,7 @@ import (
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/precondition"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/predicates"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/predicates/component"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/predicates/resources"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/reconciler"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/metadata/labels"
 )
@@ -64,21 +64,8 @@ func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.
 			reconciler.WithEventHandler(
 				handlers.ToNamed(componentApi.TrustyAIInstanceName)),
 			reconciler.WithPredicates(predicate.Or(
-				component.ForLabel(labels.ODH.Component(LegacyComponentName), labels.True), // if TrustyAI CR is changed
-				predicate.Funcs{ // OR if ISVC CRD from kserve is created or deleted
-					CreateFunc: func(e event.CreateEvent) bool {
-						return e.Object.GetName() == InferenceServicesCRDName
-					},
-					UpdateFunc: func(e event.UpdateEvent) bool {
-						return false
-					},
-					DeleteFunc: func(e event.DeleteEvent) bool {
-						return e.Object.GetName() == InferenceServicesCRDName
-					},
-					GenericFunc: func(e event.GenericEvent) bool {
-						return false
-					},
-				},
+				component.ForLabel(labels.ODH.Component(LegacyComponentName), labels.True),
+				resources.CreatedOrUpdatedOrDeletedNamed(InferenceServicesCRDName),
 			)),
 		).
 		WithPreCondition(precondition.MonitorCRD(gvk.InferenceServices,

--- a/internal/controller/components/trustyai/trustyai_test.go
+++ b/internal/controller/components/trustyai/trustyai_test.go
@@ -10,7 +10,6 @@ import (
 	operatorv1 "github.com/openshift/api/operator/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -489,78 +488,6 @@ func createTrustyAIDeployment(selectorLabels map[string]string) *appsv1.Deployme
 				Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "manager", Image: "test"}}},
 			},
 		},
-	}
-}
-
-func makeCRD(name string, lbls map[string]string) *extv1.CustomResourceDefinition {
-	crd := &extv1.CustomResourceDefinition{}
-	crd.SetName(name)
-	crd.SetLabels(lbls)
-	return crd
-}
-
-// TestInferenceServicesCRDDeletePredicate covers the DeleteFunc predicate (name-only check).
-// The ODH label is not required: the CRD may be deleted before ODH labels it.
-func TestInferenceServicesCRDDeletePredicate(t *testing.T) {
-	deleteFired := func(crd *extv1.CustomResourceDefinition) bool {
-		return crd.GetName() == InferenceServicesCRDName
-	}
-
-	tests := []struct {
-		name     string
-		crdName  string
-		expected bool
-	}{
-		{
-			name:     "correct CRD name → fires",
-			crdName:  InferenceServicesCRDName,
-			expected: true,
-		},
-		{
-			name:     "wrong CRD name → does not fire",
-			crdName:  "other.crd.io",
-			expected: false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			g := NewWithT(t)
-			crd := makeCRD(tt.crdName, nil)
-			g.Expect(deleteFired(crd)).Should(Equal(tt.expected))
-		})
-	}
-}
-
-// TestInferenceServicesCRDCreatePredicate covers the CreateFunc predicate (name-only check).
-func TestInferenceServicesCRDCreatePredicate(t *testing.T) {
-	createFired := func(crd *extv1.CustomResourceDefinition) bool {
-		return crd.GetName() == InferenceServicesCRDName
-	}
-
-	tests := []struct {
-		name     string
-		crdName  string
-		expected bool
-	}{
-		{
-			name:     "correct CRD name → fires",
-			crdName:  InferenceServicesCRDName,
-			expected: true,
-		},
-		{
-			name:     "wrong CRD name → does not fire",
-			crdName:  "other.crd.io",
-			expected: false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			g := NewWithT(t)
-			crd := makeCRD(tt.crdName, nil)
-			g.Expect(createFired(crd)).Should(Equal(tt.expected))
-		})
 	}
 }
 


### PR DESCRIPTION
## Description

- TrustyAI watches the InferenceServices CRD to detect when kserve is ready, but the watch predicate had `UpdateFunc: return false`, suppressing all CRD update events.
- A CRD transitions from Created → Established ~3 seconds after creation. The watch fires a Create event immediately, but the CRD is not yet served by the apiserver at that point. The Established transition is an Update event, which was dropped — leaving TrustyAI permanently stuck in `PreConditionFailed`.
- Replaced the hand-rolled `predicate.Funcs` with `resources.CreatedOrUpdatedOrDeletedNamed(InferenceServicesCRDName)`, which handles Create, Update, and Delete events by name. Removed obsolete predicate tests (the helper has its own test coverage).

Jira task: https://issues.redhat.com/browse/RHOAIENG-77786

## How Has This Been Tested?

- Reproduced the issue on a live OpenShift cluster: TrustyAI stuck in `PreConditionFailed` ("InferenceServices CRD does not exist") despite the CRD being present and Established.
- Confirmed root cause via operator logs: CRD created at `20:57:05`, Established at `20:57:08`, but TrustyAI reconcile at `20:57:07` (between the two) found the CRD not yet served. No subsequent reconcile was triggered because the Established status update was filtered out.
- Unit tests pass: `go test ./internal/controller/components/trustyai/`

## Screenshot or short clip

N/A

## Merge criteria

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully
- [ ] New RELATED_IMAGE mappings are listed in ODH-Build-Config and RHOAI-Build-Config (CI validates names against build-config repos). Include links to build-config PRs in the description.

### E2E test suite update requirement

- [x] Skip requirement to update E2E test suite for this PR

#### E2E update requirement opt-out justification

This is a one-line predicate fix replacing `UpdateFunc: return false` with an existing helper that includes Update events. The behavioral change is that CRD Update events now trigger reconciliation — this is a race condition fix, not new functionality. The existing `resources.CreatedOrUpdatedOrDeletedNamed` helper has its own unit test coverage. An E2E test for this specific race would require precise timing control over CRD creation vs. controller startup, which is not feasible in the current test harness.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Updated InferenceServices monitoring to use a standardized resource-name filter.
  - Monitoring now triggers on creation, updates, and deletion events for the configured resource.
- **Tests**
  - Removed predicate-specific InferenceServices create/delete test coverage that is no longer applicable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->