### PR TITLE
(fix): Validate_missing_CRD_handling tests in e2e

### DIFF
--- a/tests/e2e/resilience_test.go
+++ b/tests/e2e/resilience_test.go
@@ -274,12 +274,35 @@ func (tc *OperatorResilienceTestCtx) ValidateMissingComponentsCRDHandling(t *tes
 	// Save a backup copy of the CRD
 	crdBackup := resources.StripServerMetadata(crd)
 
-	// Delete the CRD
+	// Snapshot Dashboard CRs before deleting the CRD — FetchResources will fail with
+	// NoMatchError once the CRD is gone so the list must be captured while it still exists.
+	dashboardCRs := tc.FetchResources(WithMinimalObject(gvk.Dashboard, types.NamespacedName{}))
+
+	// Delete the CRD — this triggers cascade deletion of component CR instances.
+	// Do not wait yet; module-based components need finalizer cleanup first.
 	tc.DeleteResource(
 		WithMinimalObject(gvk.CustomResourceDefinition, types.NamespacedName{
 			Name: crd.GetName(),
 		}),
-		WithWaitForDeletion(true),
+	)
+
+	// Module-based components carry platform.opendatahub.io/finalizer on their CR.
+	// When the CRD enters Terminating the module controller's informer is invalidated,
+	// so the finalizer can never be removed and the CRD gets stuck. Strip it here.
+	// For in-tree components this is a no-op — controller clears the finalizer promptly.
+	for _, cr := range dashboardCRs {
+		tc.DeleteResource(
+			WithMinimalObject(gvk.Dashboard, types.NamespacedName{Name: cr.GetName()}),
+			WithIgnoreNotFound(true),
+			WithRemoveFinalizersOnDelete(true),
+			WithWaitForDeletion(true),
+		)
+	}
+
+	// Now wait for the CRD to be fully gone
+	tc.EnsureResourceGone(
+		WithMinimalObject(gvk.CustomResourceDefinition, types.NamespacedName{Name: crd.GetName()}),
+		WithCustomErrorMsg("CRD %s was not fully deleted after finalizer cleanup", crd.GetName()),
 	)
 
 	// Validate pod health and system health


### PR DESCRIPTION
<!---
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
When the Dashboard CRD is deleted, Kubernetes cascades deletion to CR instances.
For now we just use kueue crd as we dont migrate it to modules

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully
- [ ] New RELATED_IMAGE mappings are listed in ODH-Build-Config and RHOAI-Build-Config (CI validates names against build-config repos). Include links to build-config PRs in the description.

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
Fixing a wrong test in e2e for dashboard


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end resilience coverage for scenarios where component definitions are missing.
  * Added additional cleanup logic to remove lingering finalizers on related dashboard resources.
  * Strengthened verification to confirm the component definition is fully deleted before the test completes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->