### PR TITLE
test(monitoring): add unit test for addTLSData

### DIFF
--- a/internal/controller/services/monitoring/monitoring_controller_support_test.go
+++ b/internal/controller/services/monitoring/monitoring_controller_support_test.go
@@ -1737,3 +1737,42 @@ func TestPersesGVKs(t *testing.T) {
 	g.Expect(ds).Should(Equal(gvk.PersesDatasourceV1Alpha1))
 	g.Expect(db).Should(Equal(gvk.PersesDashboardV1Alpha1))
 }
+
+// expectedIntermediateCiphers is the expected comma-joined IANA cipher string for the
+// Intermediate TLS profile. Derived directly from the openshift/api TLSProfileIntermediateType
+// cipher list passed through the openshift/library-go OpenSSL->IANA mapping.
+// It is intentionally NOT computed from production code so it serves as an independent oracle.
+const expectedIntermediateCiphers = "TLS_AES_128_GCM_SHA256," +
+	"TLS_AES_256_GCM_SHA384," +
+	"TLS_CHACHA20_POLY1305_SHA256," +
+	"TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256," +
+	"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256," +
+	"TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384," +
+	"TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384," +
+	"TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256," +
+	"TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256"
+
+func TestAddTLSData(t *testing.T) {
+	ctx := t.Context()
+
+	t.Run("no APIServer resource uses Intermediate defaults", func(t *testing.T) {
+		g := NewWithT(t)
+
+		fakeClient := setupTestClient(g)
+
+		rr := &odhtypes.ReconciliationRequest{
+			Client: fakeClient,
+		}
+
+		templateData := make(map[string]any)
+		addTLSData(ctx, rr, templateData)
+
+		minVersion, ok := templateData["TLSMinVersion"]
+		g.Expect(ok).Should(BeTrue(), "TLSMinVersion should be present")
+		g.Expect(minVersion).Should(Equal("TLS1.2"))
+
+		cipherSuites, ok := templateData["TLSCipherSuites"]
+		g.Expect(ok).Should(BeTrue(), "TLSCipherSuites should be present")
+		g.Expect(cipherSuites).Should(Equal(expectedIntermediateCiphers))
+	})
+}


### PR DESCRIPTION
## Description

Follow-up to #3717. Adds unit test for `addTLSData` as requested in [review](https://github.com/opendatahub-io/opendatahub-operator/pull/3717#issuecomment-5045552616).

### Changes

- `monitoring_controller_support_test.go`: add `TestAddTLSData` verifying Intermediate TLS fallback (TLS 1.2) when no APIServer CR exists.

One file, 25 lines.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a unit test to verify TLS configuration data is populated correctly.
  * Confirmed the default minimum TLS version is set to TLS 1.2.
  * Confirmed TLS cipher suite settings are set as expected and non-empty.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->