### PR TITLE
Add odh-ogx-module-operator to operator manifests

### DIFF
--- a/build/manifests-config.yaml
+++ b/build/manifests-config.yaml
@@ -82,3 +82,6 @@ map:
   odh-mcp-lifecycle-module-operator:
     src: config
     dest: mcplifecycleoperator
+  odh-ogx-module-operator:
+    src: config/
+    dest: /opt/manifests/ogx/

--- a/build/manifests-config.yaml
+++ b/build/manifests-config.yaml
@@ -61,9 +61,6 @@ map:
   odh-spark-operator:
     src: config
     dest: sparkoperator
-  odh-ogx-k8s-operator:
-    src: config
-    dest: ogx
   odh-kserve-module-operator:
     src: kserve-module/config
     dest: kserve-module-operator
@@ -84,4 +81,4 @@ map:
     dest: mcplifecycleoperator
   odh-ogx-module-operator:
     src: config/
-    dest: /opt/manifests/ogx/
+    dest: ogx


### PR DESCRIPTION
Adds 'odh-ogx-module-operator' entry to build/manifests-config.yaml.

Repo: https://github.com/opendatahub-io/ogx-k8s-operator
Jira: https://redhat.atlassian.net/browse/RHOAIENG-78492

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated deployment manifest configuration to use the OGX module operator.
  * Adjusted the manifest mapping so releases pull the appropriate manifests from the configuration directory and deploy them to the corresponding OGX location (replacing the previous OGX k8s operator mapping).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->