### PR TITLE
ci: disable early-gate-auto-trigger on push to main

### DIFF
--- a/.tekton/odh-operator-ci-push.yaml
+++ b/.tekton/odh-operator-ci-push.yaml
@@ -40,6 +40,8 @@ spec:
   - name: build-args
     value:
     - BUILD_TYPE=CI
+  - name: enable-early-gate-testing
+    value: "false"
   pipelineRef:
     resolver: git
     params:


### PR DESCRIPTION
<!---
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

- Adds `enable-early-gate-testing: "false"` to `.tekton/odh-operator-ci-push.yaml` to disable the automatic early-gate build trigger after merge

## Context

The [multi-arch-operator-build.yaml](https://github.com/opendatahub-io/odh-konflux-central/blob/main/pipeline/multi-arch-operator-build.yaml) shared pipeline (in `odh-konflux-central`) has a `trigger-early-gate-build` finally task that defaults to `enable-early-gate-testing: "true"`. This task posts `/early-gate-build` as a bot comment after every successful push to `main`, which in turn triggers the full early-gate pipeline chain (build → test). Both pipelines can still be triggered manually via `/early-gate-build` and `/early-gate-test` PR comments.

<!--- Link your JIRA and related links here for reference. -->
* https://redhat.atlassian.net/browse/RHOAIENG-72180

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully
- [ ] New RELATED_IMAGE mappings are listed in ODH-Build-Config and RHOAI-Build-Config (CI validates names against build-config repos). Include links to build-config PRs in the description.

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->
no new tests needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added an `enable-early-gate-testing` pipeline option, disabled by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->