### PR TITLE
docs: capitalize operator APIs acronym in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,7 +63,7 @@ For additional setup options (e.g., overriding Makefile variables, using a `loca
 To ensure the contributed code adheres to the project goals, we have set up some automated quality gates:
 
 1. [linters](https://github.com/opendatahub-io/opendatahub-operator/blob/main/.github/workflows/test-linter.yaml): Ensure the check for linters is successful. If it fails, run `make lint` to resolve errors
-2. [api-docs](https://github.com/opendatahub-io/opendatahub-operator/blob/main/.github/workflows/test-required-files-updated.yaml): Ensure the api-docs are updated when making changes to operator apis. If it fails, run `make generate manifests api-docs` to resolve errors
+2. [api-docs](https://github.com/opendatahub-io/opendatahub-operator/blob/main/.github/workflows/test-required-files-updated.yaml): Ensure the api-docs are updated when making changes to operator APIs. If it fails, run `make generate manifests api-docs` to resolve errors
 3. [unit-tests](https://github.com/opendatahub-io/opendatahub-operator/blob/main/.github/workflows/test-unit.yaml): Ensure unit tests pass. Run `make unit-tests`
 4. [e2e-tests](https://prow.ci.openshift.org/job-history/gs/test-platform-results/pr-logs/directory/pull-ci-opendatahub-io-opendatahub-operator-main-opendatahub-operator-e2e): Ensure CI job for [e2e tests](https://github.com/opendatahub-io/opendatahub-operator/tree/main/tests/e2e) pass. Refer run e2e locally to debug. CI test logs can also be found under `Artifacts` directory under Job details.
 


### PR DESCRIPTION
## Description
This PR fixes acronym capitalization in `CONTRIBUTING.md`.

## Details
Updated `operator apis` -> `operator APIs` under the Quality Gates section.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected capitalization in the contribution guidelines for references to operator APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->