### PR TITLE
[RHAISTRAT-1314] feat(auth): extend admin RBAC role for app logs access

### DIFF
--- a/internal/controller/services/auth/resources/data-science-admingroup-clusterrole.tmpl.yaml
+++ b/internal/controller/services/auth/resources/data-science-admingroup-clusterrole.tmpl.yaml
@@ -67,4 +67,12 @@ rules:
       - get
       - watch
       - list
+  - apiGroups:
+      - loki.grafana.com
+    resources:
+      - application
+    resourceNames:
+      - logs
+    verbs:
+      - get
 


### PR DESCRIPTION
## Description
In 3.5 we add a usage dashboard for administrators that is similar to the one that was added in 3.4 but based on logs that are stored in Loki rather than metrics. Here we extend the cluster-role for admin users with a 'get' permission on Loki's application logs so they would have access to the data that is presented in this new dashboard. We may be able to narrow this down to a namespace-scoped role but that requires a non trivial change in how we deploy the dashboard, so this would be a future task we'll look into.

https://redhat.atlassian.net/browse/RHAISTRAT-1314

## How Has This Been Tested?
Tested manually: without this change, admin users without cluster-admin role haven't had access to the data in Loki (got 403 errors on the new logs-based usage dashboard) and when deploying the operator with this change, the admin's ClusterRole has changed and the new usage dashboard presented data for these admin users)

## Screenshot or short clip
<img width="1507" height="593" alt="Screenshot 2026-07-24 at 9 47 36" src="https://github.com/user-attachments/assets/904d8354-de88-49dd-a8b3-ea92cee7d89e" />


## Merge criteria

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [x] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
This PR just extends the existing `data-science-admingroupcluster-role` role

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated access controls to allow the data science admin role to read the specified application logging resource.
  * Enables viewing application logs for troubleshooting and monitoring while keeping permissions scoped to the designated log resource.
  * All other permissions remain unchanged, and no existing actions were modified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->