### PR TITLE
fix: correct imageParamMap keys for OGX related-image substitution

### DIFF
--- a/internal/controller/components/ogx/ogx_support.go
+++ b/internal/controller/components/ogx/ogx_support.go
@@ -21,10 +21,9 @@ var (
 		cluster.OpenDataHub:      "overlays/odh",
 	}
 
-	// TODO: double check if downsteam is using this as placeholder.
 	imageParamMap = map[string]string{
-		"RELATED_IMAGE_ODH_OGX_OPERATOR": "RELATED_IMAGE_ODH_OGX_K8S_OPERATOR_IMAGE",
-		"RELATED_IMAGE_RH_DISTRIBUTION":  "RELATED_IMAGE_ODH_OGX_CORE_IMAGE",
+		"RELATED_IMAGE_ODH_OGX_K8S_OPERATOR_IMAGE": "RELATED_IMAGE_ODH_OGX_K8S_OPERATOR_IMAGE",
+		"RELATED_IMAGE_ODH_OGX_CORE_IMAGE":         "RELATED_IMAGE_ODH_OGX_CORE_IMAGE",
 	}
 
 	conditionTypes = []string{


### PR DESCRIPTION
## Description

Fixes a silent RELATED_IMAGE substitution failure for the OGX component's disconnected-mirroring image resolution.

`ogx-k8s-operator` renamed its `RELATED_IMAGE_*` keys in `config/overlays/{odh,rhoai}/params.env` from `RELATED_IMAGE_ODH_OGX_OPERATOR` / `RELATED_IMAGE_RH_DISTRIBUTION` to `RELATED_IMAGE_ODH_OGX_K8S_OPERATOR_IMAGE` / `RELATED_IMAGE_ODH_OGX_CORE_IMAGE` (red-hat-data-services/ogx-k8s-operator@0c2dc3e, 2026-07-20), but `imageParamMap` in `internal/controller/components/ogx/ogx_support.go` was never updated to match.

`ApplyParams` (`pkg/deploy/envParams.go`) looks up each key found in the component's `params.env` inside `imageParamMap` to determine which `RELATED_IMAGE_*` env var to read the Konflux-pinned digest from:

```go
for i := range paramsEnvMap {
    relatedImageValue := os.Getenv(imageParamsMap[i])
    if relatedImageValue != "" {
        updated |= updateMap(&paramsEnvMap, i, relatedImageValue)
    }
}
```

Since the map still only had entries keyed by the old names, the lookup for the renamed keys missed, `os.Getenv("")` returned an empty string, and the substitution was silently skipped. The OGX operator deployment kept the literal placeholder tag (`quay.io/opendatahub/odh-ogx-k8s-operator:odh`) instead of the pinned digest, so the image was never captured for disconnected-environment mirroring — causing `ImagePullBackOff` on disconnected clusters.

Note: `#3813` (OGX module-operator migration) removes this file entirely and already uses the correct new names in its replacement handler, so this fix is scoped as a standalone hotfix to unblock disconnected installs independently of that larger migration landing in time.

## How Has This Been Tested?

- `go build ./internal/controller/components/ogx/...`
- `go test ./internal/controller/components/ogx/...` — passing
- `pre-commit run` (go fmt, go vet, golangci-lint) — passing

## Merge criteria

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution.
- [x] The developer has manually tested the changes and verified that the changes work

### E2E test suite update requirement

- [x] Skip requirement to update E2E test suite for this PR

#### E2E update requirement opt-out justification

Single-line correction of a hardcoded string-to-string key map (`imageParamMap`) in `ogx_support.go` — no control flow or reconciliation behavior changes. Covered by the existing `internal/controller/components/ogx` unit test suite, which passes with this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the related image parameter mapping to use the correct operator and core image parameter names.
  * Removed outdated placeholder/alternate related image entries to ensure consistent OGX image configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->