### PR TITLE
feat: forward cert-manager shared configuration to modules

### DIFF
--- a/internal/controller/modules/modules_controller_actions_platform_config.go
+++ b/internal/controller/modules/modules_controller_actions_platform_config.go
@@ -3,6 +3,7 @@ package modules
 import (
 	"context"
 	"fmt"
+	"os"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -10,7 +11,10 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/dependency/certmanager"
 	odhtype "github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/env"
 )
 
 const (
@@ -24,7 +28,21 @@ const (
 	// PlatformVersionKey is the data key containing the platform version.
 	// This is platform-managed and reconciled back if modified externally.
 	PlatformVersionKey = "platformVersion"
+
+	CertManagerIssuerRefNameKey     = "CERT_MANAGER_ISSUER_REF_NAME"
+	CertManagerIssuerRefKindKey     = "CERT_MANAGER_ISSUER_REF_KIND"
+	CertManagerCASecretNameKey      = "CERT_MANAGER_CA_SECRET_NAME"      //nolint:gosec // ConfigMap key name, not a credential.
+	CertManagerCASecretNamespaceKey = "CERT_MANAGER_CA_SECRET_NAMESPACE" //nolint:gosec // ConfigMap key name, not a credential.
+	CertManagerIstioCACertPathKey   = "CERT_MANAGER_ISTIO_CA_CERT_PATH"
 )
+
+var platformManagedCertManagerKeys = []string{
+	CertManagerIssuerRefNameKey,
+	CertManagerIssuerRefKindKey,
+	CertManagerCASecretNameKey,
+	CertManagerCASecretNamespaceKey,
+	CertManagerIstioCACertPathKey,
+}
 
 // PlatformConfigName returns the well-known ConfigMap name for a module.
 func PlatformConfigName(moduleName string) string {
@@ -56,6 +74,11 @@ func injectPlatformConfig(ctx context.Context, rr *odhtype.ReconciliationRequest
 
 	platformVersion := rr.Release.Version.String()
 
+	var extraParams map[string]string
+	if rr.Release.Name == cluster.XKS {
+		extraParams = buildCertManagerConfigParams()
+	}
+
 	existingCMs := indexConfigMapsByName(rr.Resources)
 
 	return reg.ForEach(func(handler ModuleHandler) error {
@@ -71,11 +94,11 @@ func injectPlatformConfig(ctx context.Context, rr *odhtype.ReconciliationRequest
 		if idx, ok := existingCMs[cmName]; ok {
 			log.V(1).Info("merging platform config into existing ConfigMap",
 				"module", name, "configmap", cmName)
-			mergePlatformKeys(&rr.Resources[idx], platformVersion)
+			mergePlatformKeys(&rr.Resources[idx], platformVersion, extraParams)
 		} else {
 			log.V(1).Info("creating platform config ConfigMap",
 				"module", name, "configmap", cmName)
-			cm := buildPlatformConfigMap(cmName, ns, platformVersion)
+			cm := buildPlatformConfigMap(cmName, ns, platformVersion, extraParams)
 			u, err := toUnstructured(cm)
 			if err != nil {
 				return fmt.Errorf("converting platform config ConfigMap for %s: %w", name, err)
@@ -87,7 +110,14 @@ func injectPlatformConfig(ctx context.Context, rr *odhtype.ReconciliationRequest
 	})
 }
 
-func buildPlatformConfigMap(name, namespace, platformVersion string) *corev1.ConfigMap {
+func buildPlatformConfigMap(name, namespace, platformVersion string, extraParams map[string]string) *corev1.ConfigMap {
+	data := map[string]string{
+		PlatformVersionKey: platformVersion,
+	}
+	for k, v := range extraParams {
+		data[k] = v
+	}
+
 	return &corev1.ConfigMap{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "v1",
@@ -97,23 +127,45 @@ func buildPlatformConfigMap(name, namespace, platformVersion string) *corev1.Con
 			Name:      name,
 			Namespace: namespace,
 		},
-		Data: map[string]string{
-			PlatformVersionKey: platformVersion,
-		},
+		Data: data,
 	}
 }
 
 // mergePlatformKeys sets the platform-managed keys on an existing
 // unstructured ConfigMap. Existing module-owned keys are preserved.
-func mergePlatformKeys(u *unstructured.Unstructured, platformVersion string) {
+func mergePlatformKeys(u *unstructured.Unstructured, platformVersion string, extraParams map[string]string) {
 	data, _, _ := unstructured.NestedStringMap(u.Object, "data")
 	if data == nil {
 		data = make(map[string]string)
 	}
 
+	for _, k := range platformManagedCertManagerKeys {
+		delete(data, k)
+	}
+
 	data[PlatformVersionKey] = platformVersion
+	for k, v := range extraParams {
+		data[k] = v
+	}
 
 	_ = unstructured.SetNestedStringMap(u.Object, data, "data")
+}
+
+func buildCertManagerConfigParams() map[string]string {
+	bc := certmanager.DefaultBootstrapConfig()
+
+	params := map[string]string{
+		CertManagerIssuerRefNameKey:     bc.CAIssuerName,
+		CertManagerIssuerRefKindKey:     env.GetOrDefault(certmanager.EnvIssuerRefKind, certmanager.DefaultIssuerRefKind),
+		CertManagerCASecretNameKey:      bc.CertName,
+		CertManagerCASecretNamespaceKey: bc.CertManagerNamespace,
+	}
+
+	if v := os.Getenv(certmanager.EnvIstioCACertPath); v != "" {
+		params[CertManagerIstioCACertPathKey] = v
+	}
+
+	return params
 }
 
 func indexConfigMapsByName(resources []unstructured.Unstructured) map[string]int {

--- a/internal/controller/modules/modules_controller_actions_platform_config_test.go
+++ b/internal/controller/modules/modules_controller_actions_platform_config_test.go
@@ -6,6 +6,8 @@ import (
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/dependency/certmanager"
+
 	. "github.com/onsi/gomega"
 )
 
@@ -21,7 +23,7 @@ func TestBuildPlatformConfigMap(t *testing.T) {
 	t.Parallel()
 	g := NewWithT(t)
 
-	cm := buildPlatformConfigMap("odh-testmod-config", "test-ns", "2.20.0")
+	cm := buildPlatformConfigMap("odh-testmod-config", "test-ns", "2.20.0", nil)
 
 	g.Expect(cm.Name).Should(Equal("odh-testmod-config"))
 	g.Expect(cm.Namespace).Should(Equal("test-ns"))
@@ -49,7 +51,7 @@ func TestMergePlatformKeys(t *testing.T) {
 		},
 	}
 
-	mergePlatformKeys(u, "2.20.0")
+	mergePlatformKeys(u, "2.20.0", nil)
 
 	data, _, _ := unstructured.NestedStringMap(u.Object, "data")
 	g.Expect(data).Should(HaveKeyWithValue(PlatformVersionKey, "2.20.0"))
@@ -69,7 +71,7 @@ func TestMergePlatformKeys_NilData(t *testing.T) {
 		},
 	}
 
-	mergePlatformKeys(u, "2.20.0")
+	mergePlatformKeys(u, "2.20.0", nil)
 
 	data, _, _ := unstructured.NestedStringMap(u.Object, "data")
 	g.Expect(data).Should(HaveKeyWithValue(PlatformVersionKey, "2.20.0"))
@@ -90,7 +92,7 @@ func TestMergePlatformKeys_OverwritesOldVersion(t *testing.T) {
 		},
 	}
 
-	mergePlatformKeys(u, "2.20.0")
+	mergePlatformKeys(u, "2.20.0", nil)
 
 	data, _, _ := unstructured.NestedStringMap(u.Object, "data")
 	g.Expect(data).Should(HaveKeyWithValue(PlatformVersionKey, "2.20.0"))
@@ -112,7 +114,7 @@ func TestMergePlatformKeys_UserEditedPlatformVar_ReconciledBack(t *testing.T) {
 		},
 	}
 
-	mergePlatformKeys(u, "2.20.0")
+	mergePlatformKeys(u, "2.20.0", nil)
 
 	data, _, _ := unstructured.NestedStringMap(u.Object, "data")
 	g.Expect(data).Should(HaveKeyWithValue(PlatformVersionKey, "2.20.0"),
@@ -138,7 +140,7 @@ func TestMergePlatformKeys_ModuleAddsNewKeys_Preserved(t *testing.T) {
 		},
 	}
 
-	mergePlatformKeys(u, "2.20.0")
+	mergePlatformKeys(u, "2.20.0", nil)
 
 	data, _, _ := unstructured.NestedStringMap(u.Object, "data")
 	g.Expect(data).Should(HaveLen(3),
@@ -164,7 +166,7 @@ func TestMergePlatformKeys_ModuleChangesOwnKeys_NotReverted(t *testing.T) {
 		},
 	}
 
-	mergePlatformKeys(u, "2.20.0")
+	mergePlatformKeys(u, "2.20.0", nil)
 
 	data, _, _ := unstructured.NestedStringMap(u.Object, "data")
 	g.Expect(data).Should(HaveKeyWithValue("LOG_LEVEL", "debug"),
@@ -201,7 +203,7 @@ func TestToUnstructured(t *testing.T) {
 	t.Parallel()
 	g := NewWithT(t)
 
-	cm := buildPlatformConfigMap("odh-test-config", "test-ns", "1.0.0")
+	cm := buildPlatformConfigMap("odh-test-config", "test-ns", "1.0.0", nil)
 	u, err := toUnstructured(cm)
 
 	g.Expect(err).ShouldNot(HaveOccurred())
@@ -211,4 +213,130 @@ func TestToUnstructured(t *testing.T) {
 
 	data, _, _ := unstructured.NestedStringMap(u.Object, "data")
 	g.Expect(data).Should(HaveKeyWithValue(PlatformVersionKey, "1.0.0"))
+}
+
+func TestBuildCertManagerConfigParams_Defaults(t *testing.T) {
+	g := NewWithT(t)
+
+	for _, envVar := range []string{
+		certmanager.EnvCAIssuerName,
+		certmanager.EnvIssuerRefKind,
+		certmanager.EnvCertName,
+		certmanager.EnvCertManagerNS,
+		certmanager.EnvIstioCACertPath,
+	} {
+		t.Setenv(envVar, "")
+	}
+
+	params := buildCertManagerConfigParams()
+
+	bc := certmanager.DefaultBootstrapConfig()
+	g.Expect(params).Should(HaveKeyWithValue(CertManagerIssuerRefNameKey, bc.CAIssuerName))
+	g.Expect(params).Should(HaveKeyWithValue(CertManagerIssuerRefKindKey, certmanager.DefaultIssuerRefKind))
+	g.Expect(params).Should(HaveKeyWithValue(CertManagerCASecretNameKey, bc.CertName))
+	g.Expect(params).Should(HaveKeyWithValue(CertManagerCASecretNamespaceKey, bc.CertManagerNamespace))
+	g.Expect(params).ShouldNot(HaveKey(CertManagerIstioCACertPathKey))
+}
+
+func TestBuildCertManagerConfigParams_EnvOverrides(t *testing.T) {
+	g := NewWithT(t)
+
+	t.Setenv(certmanager.EnvCAIssuerName, "custom-issuer")
+	t.Setenv(certmanager.EnvIssuerRefKind, "Issuer")
+	t.Setenv(certmanager.EnvCertName, "custom-ca")
+	t.Setenv(certmanager.EnvCertManagerNS, "custom-ns")
+	t.Setenv(certmanager.EnvIstioCACertPath, "/custom/ca.crt")
+
+	params := buildCertManagerConfigParams()
+
+	g.Expect(params).Should(HaveKeyWithValue(CertManagerIssuerRefNameKey, "custom-issuer"))
+	g.Expect(params).Should(HaveKeyWithValue(CertManagerIssuerRefKindKey, "Issuer"))
+	g.Expect(params).Should(HaveKeyWithValue(CertManagerCASecretNameKey, "custom-ca"))
+	g.Expect(params).Should(HaveKeyWithValue(CertManagerCASecretNamespaceKey, "custom-ns"))
+	g.Expect(params).Should(HaveKeyWithValue(CertManagerIstioCACertPathKey, "/custom/ca.crt"))
+}
+
+func TestBuildPlatformConfigMap_WithExtraParams(t *testing.T) {
+	t.Parallel()
+	g := NewWithT(t)
+
+	extra := map[string]string{
+		CertManagerIssuerRefNameKey: "my-issuer",
+		CertManagerIssuerRefKindKey: "ClusterIssuer",
+	}
+
+	cm := buildPlatformConfigMap("odh-mod-config", "test-ns", "2.20.0", extra)
+
+	g.Expect(cm.Data).Should(HaveKeyWithValue(PlatformVersionKey, "2.20.0"))
+	g.Expect(cm.Data).Should(HaveKeyWithValue(CertManagerIssuerRefNameKey, "my-issuer"))
+	g.Expect(cm.Data).Should(HaveKeyWithValue(CertManagerIssuerRefKindKey, "ClusterIssuer"))
+}
+
+func TestBuildPlatformConfigMap_NilExtraParams(t *testing.T) {
+	t.Parallel()
+	g := NewWithT(t)
+
+	cm := buildPlatformConfigMap("odh-mod-config", "test-ns", "2.20.0", nil)
+
+	g.Expect(cm.Data).Should(HaveLen(1))
+	g.Expect(cm.Data).Should(HaveKeyWithValue(PlatformVersionKey, "2.20.0"))
+}
+
+func TestMergePlatformKeys_WithExtraParams(t *testing.T) {
+	t.Parallel()
+	g := NewWithT(t)
+
+	u := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "v1",
+			"kind":       "ConfigMap",
+			"metadata":   map[string]any{"name": "odh-mod-config"},
+			"data": map[string]any{
+				"LOG_LEVEL": "info",
+			},
+		},
+	}
+
+	extra := map[string]string{
+		CertManagerCASecretNameKey:      "my-ca",
+		CertManagerCASecretNamespaceKey: "cert-manager",
+	}
+
+	mergePlatformKeys(u, "2.20.0", extra)
+
+	data, _, _ := unstructured.NestedStringMap(u.Object, "data")
+	g.Expect(data).Should(HaveKeyWithValue(PlatformVersionKey, "2.20.0"))
+	g.Expect(data).Should(HaveKeyWithValue(CertManagerCASecretNameKey, "my-ca"))
+	g.Expect(data).Should(HaveKeyWithValue(CertManagerCASecretNamespaceKey, "cert-manager"))
+	g.Expect(data).Should(HaveKeyWithValue("LOG_LEVEL", "info"))
+}
+
+func TestMergePlatformKeys_RemovesStaleCertManagerKeys(t *testing.T) {
+	t.Parallel()
+	g := NewWithT(t)
+
+	u := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "v1",
+			"kind":       "ConfigMap",
+			"metadata":   map[string]any{"name": "odh-mod-config"},
+			"data": map[string]any{
+				PlatformVersionKey:          "2.19.0",
+				CertManagerIssuerRefNameKey: "old-issuer",
+				CertManagerIssuerRefKindKey: "ClusterIssuer",
+				CertManagerCASecretNameKey:  "old-ca",
+				"LOG_LEVEL":                 "info",
+			},
+		},
+	}
+
+	mergePlatformKeys(u, "2.20.0", nil)
+
+	data, _, _ := unstructured.NestedStringMap(u.Object, "data")
+	g.Expect(data).Should(HaveKeyWithValue(PlatformVersionKey, "2.20.0"))
+	g.Expect(data).Should(HaveKeyWithValue("LOG_LEVEL", "info"))
+	g.Expect(data).ShouldNot(HaveKey(CertManagerIssuerRefNameKey),
+		"stale cert-manager keys must be removed when extraParams is nil")
+	g.Expect(data).ShouldNot(HaveKey(CertManagerIssuerRefKindKey))
+	g.Expect(data).ShouldNot(HaveKey(CertManagerCASecretNameKey))
 }

--- a/tests/e2e/aigateway_test.go
+++ b/tests/e2e/aigateway_test.go
@@ -76,12 +76,6 @@ func aiGatewayTestSuite(t *testing.T) {
 			tc.EnsureResourceExists(
 				WithMinimalObject(gvk.DataScienceCluster, tc.DataScienceClusterNamespacedName),
 				WithEventuallyTimeout(tc.TestTimeouts.longEventuallyTimeout),
-				WithCondition(jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, status.ConditionTypeModulesReady, metav1.ConditionTrue)),
-			)
-
-			tc.EnsureResourceExists(
-				WithMinimalObject(gvk.DataScienceCluster, tc.DataScienceClusterNamespacedName),
-				WithEventuallyTimeout(tc.TestTimeouts.longEventuallyTimeout),
 				WithCondition(jq.Match(`.status.conditions[] | select(.type == "%sReady") | .status == "%s"`, componentApi.AIGatewayKind, metav1.ConditionTrue)),
 				WithCustomErrorMsg("DataScienceCluster should have %sReady condition set to True", componentApi.AIGatewayKind),
 			)

--- a/tests/e2e/kserve_test.go
+++ b/tests/e2e/kserve_test.go
@@ -16,6 +16,7 @@ import (
 	azurev1alpha1 "github.com/opendatahub-io/opendatahub-operator/v2/api/cloudmanager/azure/v1alpha1"
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/api/components/v1alpha1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/components/kserve"
+	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/modules"
 	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/status"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/metadata/labels"
@@ -82,6 +83,7 @@ func kserveTestSuite(t *testing.T) {
 	}
 
 	testCases = append(testCases,
+		TestCase{"Validate platform config ConfigMap", componentCtx.ValidatePlatformConfigMap},
 		TestCase{"Validate resource deletion recovery", componentCtx.ValidateAllDeletionRecovery},
 		TestCase{"Validate component disabled", componentCtx.ValidateComponentDisabled},
 	)
@@ -267,6 +269,54 @@ func (tc *KserveTestCtx) ValidateLLMInferenceServiceConfigVersioned(t *testing.T
 				WithCustomErrorMsg("All well-known LLMInferenceServiceConfig %s resources should have names starting with a semver version (vX-Y-Z-)", configGVK.Version),
 			)
 		})
+	}
+}
+
+// ValidatePlatformConfigMap verifies that the per-module platform ConfigMap
+// (odh-kserve-config) exists and, on XKS, contains cert-manager CA keys.
+func (tc *KserveTestCtx) ValidatePlatformConfigMap(t *testing.T) {
+	t.Helper()
+
+	skipUnless(t, Smoke)
+
+	cmName := modules.PlatformConfigName(componentApi.KserveComponentName)
+
+	t.Logf("Verifying platform config ConfigMap %s exists in namespace %s.", cmName, tc.AppsNamespace)
+	tc.EnsureResourceExists(
+		WithMinimalObject(gvk.ConfigMap, types.NamespacedName{
+			Name:      cmName,
+			Namespace: tc.AppsNamespace,
+		}),
+		WithCondition(
+			jq.Match(`.data | has("%s")`, modules.PlatformVersionKey),
+		),
+	)
+
+	if tc.IsXKS() {
+		t.Log("XKS platform: verifying cert-manager CA keys are present.")
+		tc.EnsureResourceExists(
+			WithMinimalObject(gvk.ConfigMap, types.NamespacedName{
+				Name:      cmName,
+				Namespace: tc.AppsNamespace,
+			}),
+			WithCondition(And(
+				jq.Match(`.data | has("%s")`, modules.CertManagerIssuerRefNameKey),
+				jq.Match(`.data | has("%s")`, modules.CertManagerIssuerRefKindKey),
+				jq.Match(`.data | has("%s")`, modules.CertManagerCASecretNameKey),
+				jq.Match(`.data | has("%s")`, modules.CertManagerCASecretNamespaceKey),
+			)),
+		)
+	} else {
+		t.Log("Non-XKS platform: verifying cert-manager CA keys are absent.")
+		tc.EnsureResourceExists(
+			WithMinimalObject(gvk.ConfigMap, types.NamespacedName{
+				Name:      cmName,
+				Namespace: tc.AppsNamespace,
+			}),
+			WithCondition(
+				jq.Match(`.data | has("%s") | not`, modules.CertManagerIssuerRefNameKey),
+			),
+		)
 	}
 }
 

--- a/tests/e2e/workbenches_test.go
+++ b/tests/e2e/workbenches_test.go
@@ -72,11 +72,6 @@ func (tc *WorkbenchesTestCtx) ValidateComponentEnabled(t *testing.T) {
 
 	tc.EnsureResourceExists(
 		WithMinimalObject(gvk.DataScienceCluster, tc.DataScienceClusterNamespacedName),
-		WithCondition(jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, status.ConditionTypeModulesReady, metav1.ConditionTrue)),
-	)
-
-	tc.EnsureResourceExists(
-		WithMinimalObject(gvk.DataScienceCluster, tc.DataScienceClusterNamespacedName),
 		WithCondition(jq.Match(`.status.conditions[] | select(.type == "%sReady") | .status == "%s"`, componentApi.WorkbenchesKind, metav1.ConditionTrue)),
 		WithCustomErrorMsg("DataScienceCluster should have %sReady condition set to True", componentApi.WorkbenchesKind),
 	)


### PR DESCRIPTION
## Description

- On XKS clusters, cert-manager CA parameters (issuer name/kind, CA secret name/namespace, and optionally the Istio CA cert path) are now injected into every module's platform ConfigMap (`odh-<modulename>-config`) by the modules controller's `injectPlatformConfig` action.
- Params are sourced from `certmanager.DefaultBootstrapConfig()` and `RHAI_*` env vars, mirroring the existing KServe `buildCertManagerParams()` pattern. On non-XKS platforms (ODH/RHOAI) the extra keys are not injected.
- Keys use shell-safe `CERT_MANAGER_*` naming so modules can consume them via `envFrom: configMapRef` without issues.

Jira task: https://issues.redhat.com/browse/RHOAIENG-77849

## How Has This Been Tested?

- Unit tests cover: default params from `DefaultBootstrapConfig()`, env var overrides (including optional `istioCACertPath`), extra params present/absent in ConfigMap build, correct merge behavior preserving module-owned keys, and nil extra params (non-XKS path).
- `go build`, `go vet`, and all existing tests pass.

## Screenshot or short clip

N/A

## Merge criteria

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully
- [ ] New RELATED_IMAGE mappings are listed in ODH-Build-Config and RHOAI-Build-Config (CI validates names against build-config repos). Include links to build-config PRs in the description.

### E2E test suite update requirement

- [x] Skip requirement to update E2E test suite for this PR

#### E2E update requirement opt-out justification

Internal platform config injection change with no new user-facing API surface. Behavior is gated to XKS platform and covered by unit tests. No new CRD fields, endpoints, or observable E2E behavior to validate.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced per-module platform ConfigMaps to include Cert-Manager issuer reference details, CA secret name/namespace, and optional Istio CA certificate path on supported releases.

* **Bug Fixes**
  * Improved E2E readiness checks by waiting for component-specific readiness conditions for AI Gateway and Workbenches.

* **Tests**
  * Added/updated E2E validation for per-module platform ConfigMaps (including XKS vs non-XKS Cert-Manager key presence).
  * Extended unit tests to cover Cert-Manager parameter generation, ConfigMap embedding, and safe merging/removal of platform-managed keys.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->