### PR TITLE
[RHOAIENG-78080] feat(dashboard): enable Standalone deployment mode

### DIFF
--- a/internal/controller/modules/dashboard/handler.go
+++ b/internal/controller/modules/dashboard/handler.go
@@ -82,6 +82,10 @@ func (h *handler) BuildModuleCR(
 		return nil, fmt.Errorf("failed to convert DSCDashboard to unstructured: %w", err)
 	}
 
+	spec["deploymentMode"] = "Standalone"
+
+	spec["components"] = buildComponentsMap(platform)
+
 	if platform.GatewayDomain != "" {
 		spec["gateway"] = map[string]any{
 			"domain": platform.GatewayDomain,
@@ -97,4 +101,34 @@ func (h *handler) BuildModuleCR(
 	u.SetName(h.Config.CRName)
 
 	return u, nil
+}
+
+// buildComponentsMap projects the management state of DSC components
+// referenced by dashboard-operator modules onto the Dashboard CR.
+func buildComponentsMap(platform *modules.PlatformContext) map[string]any {
+	c := &platform.DSC.Spec.Components
+
+	refs := []struct {
+		name  string
+		state operatorv1.ManagementState
+	}{
+		{"modelregistry", c.ModelRegistry.ManagementState},
+		{"mlflowoperator", c.MLflowOperator.ManagementState},
+		{"trustyai", c.TrustyAI.ManagementState},
+		{"aipipelines", c.AIPipelines.ManagementState},
+	}
+
+	result := make(map[string]any, len(refs))
+	for _, ref := range refs {
+		state := string(ref.state)
+		if state == "" {
+			state = string(operatorv1.Removed)
+		}
+
+		result[ref.name] = map[string]any{
+			"managementState": state,
+		}
+	}
+
+	return result
 }

--- a/internal/controller/modules/dashboard/handler_test.go
+++ b/internal/controller/modules/dashboard/handler_test.go
@@ -29,6 +29,26 @@ func newPlatformCtx(mgmtState operatorv1.ManagementState) *modules.PlatformConte
 							ManagementState: mgmtState,
 						},
 					},
+					ModelRegistry: componentApi.DSCModelRegistry{
+						ManagementSpec: common.ManagementSpec{
+							ManagementState: operatorv1.Managed,
+						},
+					},
+					MLflowOperator: componentApi.DSCMLflowOperator{
+						ManagementSpec: common.ManagementSpec{
+							ManagementState: operatorv1.Removed,
+						},
+					},
+					TrustyAI: componentApi.DSCTrustyAI{
+						ManagementSpec: common.ManagementSpec{
+							ManagementState: operatorv1.Managed,
+						},
+					},
+					AIPipelines: componentApi.DSCDataSciencePipelines{
+						ManagementSpec: common.ManagementSpec{
+							ManagementState: operatorv1.Managed,
+						},
+					},
 				},
 			},
 		},
@@ -102,10 +122,31 @@ func TestBuildModuleCR_BasicProjection(t *testing.T) {
 	spec, ok := u.Object["spec"].(map[string]any)
 	g.Expect(ok).Should(BeTrue(), "spec is not a map")
 	g.Expect(spec["managementState"]).Should(Equal("Managed"))
+	g.Expect(spec["deploymentMode"]).Should(Equal("Standalone"))
 
 	gateway, ok := spec["gateway"].(map[string]any)
 	g.Expect(ok).Should(BeTrue(), "spec.gateway missing")
 	g.Expect(gateway["domain"]).Should(Equal("dashboard.example.com"))
+
+	components, ok := spec["components"].(map[string]any)
+	g.Expect(ok).Should(BeTrue(), "spec.components missing")
+	g.Expect(components).Should(HaveLen(4))
+
+	mrComp, ok := components["modelregistry"].(map[string]any)
+	g.Expect(ok).Should(BeTrue())
+	g.Expect(mrComp["managementState"]).Should(Equal("Managed"))
+
+	mlflowComp, ok := components["mlflowoperator"].(map[string]any)
+	g.Expect(ok).Should(BeTrue())
+	g.Expect(mlflowComp["managementState"]).Should(Equal("Removed"))
+
+	trustyComp, ok := components["trustyai"].(map[string]any)
+	g.Expect(ok).Should(BeTrue())
+	g.Expect(trustyComp["managementState"]).Should(Equal("Managed"))
+
+	pipComp, ok := components["aipipelines"].(map[string]any)
+	g.Expect(ok).Should(BeTrue())
+	g.Expect(pipComp["managementState"]).Should(Equal("Managed"))
 }
 
 func TestBuildModuleCR_OmitsGatewayWhenDomainEmpty(t *testing.T) {
@@ -134,6 +175,31 @@ func TestBuildModuleCR_EmptyManagementStateOmitted(t *testing.T) {
 	g.Expect(ok).Should(BeTrue(), "spec is not a map")
 	g.Expect(spec).ShouldNot(HaveKey("managementState"),
 		"empty ManagementState should be omitted by unstructured conversion (omitempty)")
+}
+
+func TestBuildModuleCR_ComponentsDefaultToRemovedWhenEmpty(t *testing.T) {
+	g := NewWithT(t)
+	h := dashboard.NewHandler()
+	platform := newPlatformCtx(operatorv1.Managed)
+	platform.DSC.Spec.Components.ModelRegistry.ManagementState = ""
+	platform.DSC.Spec.Components.AIPipelines.ManagementState = ""
+
+	u, err := h.BuildModuleCR(context.Background(), nil, platform)
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	spec, ok := u.Object["spec"].(map[string]any)
+	g.Expect(ok).Should(BeTrue())
+
+	components, ok := spec["components"].(map[string]any)
+	g.Expect(ok).Should(BeTrue())
+
+	mrComp, ok := components["modelregistry"].(map[string]any)
+	g.Expect(ok).Should(BeTrue())
+	g.Expect(mrComp["managementState"]).Should(Equal("Removed"))
+
+	pipComp, ok := components["aipipelines"].(map[string]any)
+	g.Expect(ok).Should(BeTrue())
+	g.Expect(pipComp["managementState"]).Should(Equal("Removed"))
 }
 
 func TestBuildModuleCR_NilPlatformContextReturnsError(t *testing.T) {


### PR DESCRIPTION
## Description

Enable standalone deployment mode for the dashboard-operator by updating `BuildModuleCR` in the dashboard module handler to set two new fields on the Dashboard CR:

1. **`spec.deploymentMode: Standalone`** — switches BFF modules from sidecar containers to independent Deployments with their own Service and RBAC
2. **`spec.components`** — projects DSC component availability so the dashboard-operator can gate modules on their required DSC components

**Jira**: [RHOAIENG-78080](https://redhat.atlassian.net/browse/RHOAIENG-78080)

### What changed

In `internal/controller/modules/dashboard/handler.go`:
- `BuildModuleCR` now sets `spec.deploymentMode` to `"Standalone"` on the Dashboard CR
- New `buildComponentsMap()` projects the management state of the four DSC components referenced by dashboard-operator modules (`modelregistry`, `mlflowoperator`, `trustyai`, `aipipelines`). Empty management state defaults to `"Removed"`

### Prerequisites (already merged)

- [opendatahub-operator PR #3733](https://github.com/opendatahub-io/opendatahub-operator/pull/3733) — module handler migration
- [odh-dashboard PR #8454](https://github.com/opendatahub-io/odh-dashboard/pull/8454) — standalone deployment logic in dashboard-operator

### Testing

- All 17 dashboard handler unit tests pass (including 1 new test for components projection)
- Existing tests updated to verify `deploymentMode` and `components` fields

## How Has This Been Tested?

- `go build ./...` — compiles cleanly
- `go test ./internal/controller/modules/dashboard/ -v` — all tests pass

## Checklist
- [x] Unit tests added/updated
- [x] `go build ./...` compiles cleanly

[RHOAIENG-78080]: https://redhat.atlassian.net/browse/RHOAIENG-78080?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [X] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->
We don't need e2e in this change since pretty much everything was covered in the dashboard enablement PR, this will switch the mode to standalone deployments for the operator.

Reference PR: https://github.com/opendatahub-io/opendatahub-operator/pull/3733


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dashboard module deployments now explicitly use standalone mode.
  * Dashboard component management settings are now reflected for Model Registry, MLflow Operator, TrustyAI, and AI Pipelines.
  * Components without a specified management state default to **Removed**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->