### PR TITLE
Use a release branch for the workbenches-operator chart in rhoai

### DIFF
--- a/get_all_manifests.sh
+++ b/get_all_manifests.sh
@@ -85,7 +85,7 @@ declare -A RHOAI_CCM_CHARTS=(
 # RHOAI Component Charts
 declare -A RHOAI_COMPONENT_CHARTS=(
     ["dashboard-operator"]="red-hat-data-services:odh-dashboard:rhoai-3.5@483ec0c8f3f45cad3d4d185a191c36eda1cdbd47:dashboard-operator/charts/dashboard"
-    ["workbenches"]="red-hat-data-services:workbenches-operator:rhoai-3.5@0ee58985bf55b877987f3e3a9c442b276f121487:charts/operator"
+    ["workbenches"]="red-hat-data-services:workbenches-operator:rhoai-3.5@97d726ec6040b20d929585e558252769e637ddb9:charts/operator"
     ["feastoperator"]="red-hat-data-services:feast-module-operator:rhoai-3.5@bb135ff9df5e2fea2b58348c9ecd2ad3c5659759:config/chart"
 )
 

--- a/get_all_manifests.sh
+++ b/get_all_manifests.sh
@@ -85,7 +85,7 @@ declare -A RHOAI_CCM_CHARTS=(
 # RHOAI Component Charts
 declare -A RHOAI_COMPONENT_CHARTS=(
     ["dashboard-operator"]="red-hat-data-services:odh-dashboard:rhoai-3.5@483ec0c8f3f45cad3d4d185a191c36eda1cdbd47:dashboard-operator/charts/dashboard"
-    ["workbenches"]="red-hat-data-services:workbenches-operator:main@eb970ef4f20a402f87ecb4b6d3f5a3860485167c:charts/operator"
+    ["workbenches"]="red-hat-data-services:workbenches-operator:rhoai-3.5@0ee58985bf55b877987f3e3a9c442b276f121487:charts/operator"
     ["feastoperator"]="red-hat-data-services:feast-module-operator:rhoai-3.5@bb135ff9df5e2fea2b58348c9ecd2ad3c5659759:config/chart"
 )
 


### PR DESCRIPTION
<!---
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description

Workbenches-operator component for the rhoai release, should be released from the release branch. I presume that this change will be propagated by the branch synchronization all the way down to the rhds/rhoai-3.5 branch so we are on the same page for the actual release build.

Please, let me know whether I'm missing something here. Thank you!

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?

no tests performed

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully
- [ ] New RELATED_IMAGE mappings are listed in ODH-Build-Config and RHOAI-Build-Config (CI validates names against build-config repos). Include links to build-config PRs in the description.

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [ ] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Chores**
  * Updated the Workbenches component’s chart source to follow the RHOAI 3.5 release line while keeping the same chart location.
  * No changes were made to manifest fetching, merging, or download behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->