### PR TITLE
Drop configs for wva, kserve and model-controller

### DIFF
--- a/build/manifests-config.yaml
+++ b/build/manifests-config.yaml
@@ -1,8 +1,4 @@
 map:
-  odh-kserve-controller:
-    src: config
-    dest: kserve
-    git.url: https://github.com/opendatahub-io/kserve
   odh-data-science-pipelines-operator-controller:
     src: config
     dest: datasciencepipelines
@@ -12,15 +8,6 @@ map:
   odh-trustyai-service-operator:
     src: config
     dest: trustyai
-  odh-model-controller:
-    src: config
-    dest: modelcontroller
-  workload-variant-autoscaler:
-    src: config
-    dest: wva
-    git.url: https://github.com/opendatahub-io/workload-variant-autoscaler
-    ref_type: branch
-    branch: main
   odh-model-registry-operator:
     src: config
     dest: modelregistry


### PR DESCRIPTION
No need to fetch manifests for wva, kserve and model-controller, since platform will deploy the kserve module operator.

Slack: https://redhat-internal.slack.com/archives/C07SBP17R7Z/p1785243940442949?thread_ts=1784829014.090029&cid=C07SBP17R7Z

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed obsolete component entries from the build manifest configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->