### PR TITLE
fix: add safety net on CRD precondition check when stop reconciliation

### DIFF
--- a/internal/controller/components/kserve/kserve_controller.go
+++ b/internal/controller/components/kserve/kserve_controller.go
@@ -28,7 +28,6 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
@@ -167,7 +166,7 @@ func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.
 		WithPreCondition(precondition.MonitorCRDs(xksDependencyCRDs,
 			precondition.WithClusterTypes(cluster.ClusterTypeKubernetes))).
 		WithPreCondition(precondition.MonitorCRDs(
-			[]schema.GroupVersionKind{gvk.LeaderWorkerSetV1},
+			[]string{gvk.LeaderWorkerSetCRDName},
 			precondition.WithConditionType(LLMInferenceServiceWideEPDependencies),
 			precondition.WithClusterTypes(cluster.ClusterTypeKubernetes),
 			precondition.WithSeverity(common.ConditionSeverityInfo),

--- a/internal/controller/components/kserve/kserve_controller_actions.go
+++ b/internal/controller/components/kserve/kserve_controller_actions.go
@@ -15,7 +15,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -221,19 +220,19 @@ func versionedWellKnownLLMInferenceServiceConfigs(_ context.Context, version str
 	return nil
 }
 
-var xksDependencyCRDs = []schema.GroupVersionKind{
+var xksDependencyCRDs = []string{
 	// networking.istio.io
-	gvk.DestinationRule, gvk.EnvoyFilter, gvk.IstioGateway, gvk.ProxyConfig,
-	gvk.ServiceEntry, gvk.Sidecar, gvk.WorkloadEntry, gvk.WorkloadGroup,
+	gvk.DestinationRuleCRDName, gvk.EnvoyFilterCRDName, gvk.IstioGatewayCRDName, gvk.ProxyConfigCRDName,
+	gvk.ServiceEntryCRDName, gvk.SidecarCRDName, gvk.WorkloadEntryCRDName, gvk.WorkloadGroupCRDName,
 	// security.istio.io
-	gvk.AuthorizationPolicy, gvk.PeerAuthentication, gvk.RequestAuthentication,
+	gvk.AuthorizationPolicyCRDName, gvk.PeerAuthenticationCRDName, gvk.RequestAuthenticationCRDName,
 	// telemetry.istio.io
-	gvk.Telemetry,
+	gvk.TelemetryCRDName,
 	// extensions.istio.io
-	gvk.WasmPlugin,
+	gvk.WasmPluginCRDName,
 	// cert-manager.io
-	gvk.CertManagerCertificate, gvk.CertManagerCertificateRequest,
-	gvk.CertManagerIssuer, gvk.CertManagerClusterIssuer,
+	gvk.CertManagerCertificateCRDName, gvk.CertManagerCertificateRequestCRDName,
+	gvk.CertManagerIssuerCRDName, gvk.CertManagerClusterIssuerCRDName,
 }
 
 // deleteLLMInferenceServiceConfigs is a finalizer action that explicitly deletes

--- a/internal/controller/components/kserve/kserve_controller_dependency_test.go
+++ b/internal/controller/components/kserve/kserve_controller_dependency_test.go
@@ -91,10 +91,10 @@ func TestCRDDependencyMonitoring(t *testing.T) {
 				status.ConditionDependenciesAvailable, precondition.PreConditionFailedReason),
 		))
 
-		for _, crdGVK := range xksDependencyCRDs {
+		for _, crdName := range xksDependencyCRDs {
 			wt.Get(gvk.Kserve, nn).Eventually().Should(
 				jq.Match(`.status.conditions[] | select(.type == "%s") | .message | contains("%s")`,
-					status.ConditionDependenciesAvailable, crdGVK.Kind),
+					status.ConditionDependenciesAvailable, crdName),
 			)
 		}
 	})
@@ -107,12 +107,14 @@ func TestCRDDependencyMonitoring(t *testing.T) {
 		et, wt := startKserveController(t, ctx)
 		t.Cleanup(cancel)
 
-		for _, crdGVK := range xksDependencyCRDs {
-			plural := strings.ToLower(crdGVK.Kind) + "s"
-			singular := strings.ToLower(crdGVK.Kind)
+		for _, crdName := range xksDependencyCRDs {
+			parts := strings.SplitN(crdName, ".", 2)
+			plural := parts[0]
+			group := parts[1]
 
+			crdGVK := schema.GroupVersionKind{Group: group, Version: "v1", Kind: plural}
 			crd, err := et.RegisterCRD(wt.Context(), crdGVK,
-				plural, singular,
+				plural, plural,
 				apiextensionsv1.NamespaceScoped)
 			wt.Expect(err).NotTo(HaveOccurred())
 			envt.CleanupDelete(t, NewWithT(t), wt.Context(), wt.Client(), crd)
@@ -143,8 +145,8 @@ func TestCRDDependencyMonitoring(t *testing.T) {
 				LLMInferenceServiceWideEPDependencies, metav1.ConditionFalse),
 			jq.Match(`.status.conditions[] | select(.type == "%s") | .severity == "%s"`,
 				LLMInferenceServiceWideEPDependencies, common.ConditionSeverityInfo),
-			jq.Match(`.status.conditions[] | select(.type == "%s") | .message | contains("LeaderWorkerSet")`,
-				LLMInferenceServiceWideEPDependencies),
+			jq.Match(`.status.conditions[] | select(.type == "%s") | .message | contains("%s")`,
+				LLMInferenceServiceWideEPDependencies, gvk.LeaderWorkerSetCRDName),
 		))
 	})
 

--- a/internal/controller/components/trustyai/trustyai_controller.go
+++ b/internal/controller/components/trustyai/trustyai_controller.go
@@ -43,11 +43,6 @@ import (
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/metadata/labels"
 )
 
-const (
-	// InferenceServicesCRDName is the name of the InferenceServices CRD that TrustyAI depends on.
-	InferenceServicesCRDName = "inferenceservices.serving.kserve.io"
-)
-
 func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.Manager) error {
 	_, err := reconciler.ReconcilerFor(mgr, &componentApi.TrustyAI{}).
 		// customized Owns() for Component with new predicates
@@ -65,10 +60,10 @@ func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.
 				handlers.ToNamed(componentApi.TrustyAIInstanceName)),
 			reconciler.WithPredicates(predicate.Or(
 				component.ForLabel(labels.ODH.Component(LegacyComponentName), labels.True),
-				resources.CreatedOrUpdatedOrDeletedNamed(InferenceServicesCRDName),
+				resources.CreatedOrUpdatedOrDeletedNamed(gvk.InferenceServicesCRDName),
 			)),
 		).
-		WithPreCondition(precondition.MonitorCRD(gvk.InferenceServices,
+		WithPreCondition(precondition.MonitorCRD(gvk.InferenceServicesCRDName,
 			precondition.WithStopReconciliation(),
 			precondition.WithMessage(status.ISVCMissingCRDMessage),
 		)).

--- a/pkg/cluster/gvk/gvk.go
+++ b/pkg/cluster/gvk/gvk.go
@@ -34,6 +34,39 @@ const (
 	LeaderWorkerSetOperatorCRDname = "leaderworkersetoperators.operator.openshift.io"
 	SubscriptionCRDname            = "subscriptions.operators.coreos.com"
 	VariantAutoscalingCRDname      = "variantautoscalings.llmd.ai"
+
+	// Istio CRDs — networking.istio.io.
+	DestinationRuleCRDName = "destinationrules.networking.istio.io"
+	EnvoyFilterCRDName     = "envoyfilters.networking.istio.io"
+	IstioGatewayCRDName    = "gateways.networking.istio.io"
+	ProxyConfigCRDName     = "proxyconfigs.networking.istio.io"
+	ServiceEntryCRDName    = "serviceentries.networking.istio.io"
+	SidecarCRDName         = "sidecars.networking.istio.io"
+	WorkloadEntryCRDName   = "workloadentries.networking.istio.io"
+	WorkloadGroupCRDName   = "workloadgroups.networking.istio.io"
+
+	// Istio CRDs — security.istio.io.
+	AuthorizationPolicyCRDName   = "authorizationpolicies.security.istio.io"
+	PeerAuthenticationCRDName    = "peerauthentications.security.istio.io"
+	RequestAuthenticationCRDName = "requestauthentications.security.istio.io"
+
+	// Istio CRDs — telemetry.istio.io.
+	TelemetryCRDName = "telemetries.telemetry.istio.io"
+
+	// Istio CRDs — extensions.istio.io.
+	WasmPluginCRDName = "wasmplugins.extensions.istio.io"
+
+	// cert-manager CRDs.
+	CertManagerCertificateCRDName        = "certificates.cert-manager.io"
+	CertManagerCertificateRequestCRDName = "certificaterequests.cert-manager.io"
+	CertManagerIssuerCRDName             = "issuers.cert-manager.io"
+	CertManagerClusterIssuerCRDName      = "clusterissuers.cert-manager.io"
+
+	// LeaderWorkerSet CRD.
+	LeaderWorkerSetCRDName = "leaderworkersets.leaderworkerset.x-k8s.io"
+
+	// KServe CRDs.
+	InferenceServicesCRDName = "inferenceservices.serving.kserve.io"
 )
 
 var (

--- a/pkg/controller/actions/dependency/certmanager/bootstrap.go
+++ b/pkg/controller/actions/dependency/certmanager/bootstrap.go
@@ -49,9 +49,9 @@ type monitoredCRD struct {
 }
 
 var monitoredCRDList = []monitoredCRD{
-	{gvk: gvk.CertManagerCertificate, resourceName: "certificates.cert-manager.io"},
-	{gvk: gvk.CertManagerIssuer, resourceName: "issuers.cert-manager.io"},
-	{gvk: gvk.CertManagerClusterIssuer, resourceName: "clusterissuers.cert-manager.io"},
+	{gvk: gvk.CertManagerCertificate, resourceName: gvk.CertManagerCertificateCRDName},
+	{gvk: gvk.CertManagerIssuer, resourceName: gvk.CertManagerIssuerCRDName},
+	{gvk: gvk.CertManagerClusterIssuer, resourceName: gvk.CertManagerClusterIssuerCRDName},
 }
 
 // DefaultIssuerRefKind is the default issuer reference kind used by downstream components.
@@ -293,13 +293,13 @@ func createCABackedIssuer(config BootstrapConfig) (*unstructured.Unstructured, e
 	return u, nil
 }
 
-func monitoredCRDs() []schema.GroupVersionKind {
-	gvks := make([]schema.GroupVersionKind, len(monitoredCRDList))
+func monitoredCRDs() []string {
+	names := make([]string, len(monitoredCRDList))
 	for i := range monitoredCRDList {
-		gvks[i] = monitoredCRDList[i].gvk
+		names[i] = monitoredCRDList[i].resourceName
 	}
 
-	return gvks
+	return names
 }
 
 func crdPredicate() predicate.Predicate {

--- a/pkg/controller/actions/dependency/certmanager/monitor_test.go
+++ b/pkg/controller/actions/dependency/certmanager/monitor_test.go
@@ -78,9 +78,9 @@ func TestMonitoredCRDs(t *testing.T) {
 			setupCRDs:      nil,
 			expectedStatus: metav1.ConditionFalse,
 			expectedMsgContains: []string{
-				gvk.CertManagerCertificate.Kind,
-				gvk.CertManagerIssuer.Kind,
-				gvk.CertManagerClusterIssuer.Kind,
+				gvk.CertManagerCertificateCRDName,
+				gvk.CertManagerIssuerCRDName,
+				gvk.CertManagerClusterIssuerCRDName,
 			},
 		},
 		{
@@ -101,8 +101,8 @@ func TestMonitoredCRDs(t *testing.T) {
 				g.Expect(err).NotTo(HaveOccurred())
 			},
 			expectedStatus:         metav1.ConditionFalse,
-			expectedMsgContains:    []string{gvk.CertManagerIssuer.Kind, gvk.CertManagerClusterIssuer.Kind},
-			expectedMsgNotContains: []string{gvk.CertManagerCertificate.Kind},
+			expectedMsgContains:    []string{gvk.CertManagerIssuerCRDName, gvk.CertManagerClusterIssuerCRDName},
+			expectedMsgNotContains: []string{gvk.CertManagerCertificateCRDName},
 		},
 	}
 
@@ -120,19 +120,19 @@ func TestMonitoredCRDs(t *testing.T) {
 				tt.setupCRDs(t, g, ctx, envTest)
 			}
 
-			gvks := monitoredCRDs()
-			g.Expect(gvks).To(HaveLen(3))
-			g.Expect(gvks).To(ContainElements(
-				gvk.CertManagerCertificate,
-				gvk.CertManagerIssuer,
-				gvk.CertManagerClusterIssuer,
+			crdNames := monitoredCRDs()
+			g.Expect(crdNames).To(HaveLen(3))
+			g.Expect(crdNames).To(ContainElements(
+				"certificates.cert-manager.io",
+				"issuers.cert-manager.io",
+				"clusterissuers.cert-manager.io",
 			))
 
 			instance := &scheme.TestPlatformObject{ObjectMeta: metav1.ObjectMeta{Name: xid.New().String()}}
 			condManager := cond.NewManager(instance, status.ConditionTypeReady, status.ConditionDependenciesAvailable)
 			rr := &types.ReconciliationRequest{Client: envTest.Client(), Instance: instance, Conditions: condManager}
 
-			pcs := []precondition.PreCondition{precondition.MonitorCRDs(gvks)}
+			pcs := []precondition.PreCondition{precondition.MonitorCRDs(crdNames)}
 			precondition.RunAll(ctx, rr, pcs)
 
 			got := condManager.GetCondition(status.ConditionDependenciesAvailable)

--- a/pkg/controller/precondition/monitor_crd.go
+++ b/pkg/controller/precondition/monitor_crd.go
@@ -7,37 +7,41 @@ import (
 	"slices"
 	"strings"
 
-	"k8s.io/apimachinery/pkg/runtime/schema"
+	apihelpers "k8s.io/apiextensions-apiserver/pkg/apihelpers"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
 )
 
-func MonitorCRD(gvk schema.GroupVersionKind, opts ...Option) PreCondition {
-	return MonitorCRDs([]schema.GroupVersionKind{gvk}, opts...)
+func MonitorCRD(crdName string, opts ...Option) PreCondition {
+	return MonitorCRDs([]string{crdName}, opts...)
 }
 
-// MonitorCRDs creates a PreCondition that checks for the presence of multiple CRDs.
-// All CRDs are checked and absent ones are reported together in a single failure message.
-// The first API error encountered is returned immediately.
-func MonitorCRDs(gvks []schema.GroupVersionKind, opts ...Option) PreCondition {
-	monitoredGVKs := slices.Clone(gvks)
+// MonitorCRDs creates a PreCondition that checks for the presence of multiple CRDs
+// by fetching the CRD objects directly, bypassing the RESTMapper discovery endpoint.
+// This avoids a race where the K8s DiscoveryController lags behind the
+// EstablishingController, causing the RESTMapper to report a CRD as absent
+// even though it is Established.
+func MonitorCRDs(crdNames []string, opts ...Option) PreCondition {
+	names := slices.Clone(crdNames)
 
 	return newPreCondition(func(ctx context.Context, rr *types.ReconciliationRequest) (CheckResult, error) {
-		if len(monitoredGVKs) == 0 {
-			return CheckResult{}, errors.New("MonitorCRDs called with empty GVK list")
+		if len(names) == 0 {
+			return CheckResult{}, errors.New("MonitorCRDs called with empty CRD name list")
 		}
 
 		var missing []string
 
-		for _, gvk := range monitoredGVKs {
-			has, err := cluster.HasCRD(ctx, rr.Client, gvk)
+		for _, name := range names {
+			has, err := hasCRDByName(ctx, rr.Client, name)
 			if err != nil {
-				return CheckResult{}, fmt.Errorf("%s: failed to check CRD presence: %w", gvk.Kind, err)
+				return CheckResult{}, fmt.Errorf("%s: failed to check CRD presence: %w", name, err)
 			}
 
 			if !has {
-				missing = append(missing, gvk.Kind+": CRD not found")
+				missing = append(missing, name+": CRD not found")
 			}
 		}
 
@@ -47,4 +51,17 @@ func MonitorCRDs(gvks []schema.GroupVersionKind, opts ...Option) PreCondition {
 
 		return CheckResult{Pass: true}, nil
 	}, opts...)
+}
+
+func hasCRDByName(ctx context.Context, cli client.Client, crdName string) (bool, error) {
+	crd, err := cluster.GetCRD(ctx, cli, crdName)
+	if err != nil {
+		return false, client.IgnoreNotFound(err)
+	}
+
+	if apihelpers.IsCRDConditionTrue(&crd, apiextensionsv1.Terminating) {
+		return false, nil
+	}
+
+	return true, nil
 }

--- a/pkg/controller/precondition/monitor_crd_test.go
+++ b/pkg/controller/precondition/monitor_crd_test.go
@@ -25,11 +25,17 @@ var testCRDGVK = schema.GroupVersionKind{
 	Kind:    "TestPreConditionResource",
 }
 
+const testCRDName = "testpreconditionresources.testprecondition.opendatahub.io"
+
 var testCRDGVK2 = schema.GroupVersionKind{
 	Group:   "testprecondition.opendatahub.io",
 	Version: "v1",
 	Kind:    "TestPreConditionResource2",
 }
+
+const testCRDName2 = "testpreconditionresource2s.testprecondition.opendatahub.io"
+
+const absentCRDName = "absentresources.absent.opendatahub.io"
 
 func TestMonitorCRD_Present(t *testing.T) {
 	g := NewWithT(t)
@@ -49,7 +55,7 @@ func TestMonitorCRD_Present(t *testing.T) {
 
 	t.Run("MonitorCRD", func(t *testing.T) {
 		g := NewWithT(t)
-		pc := MonitorCRD(testCRDGVK)
+		pc := MonitorCRD(testCRDName)
 		result, err := pc.check(ctx, rr)
 		g.Expect(err).NotTo(HaveOccurred())
 		g.Expect(result.Pass).To(BeTrue())
@@ -57,7 +63,7 @@ func TestMonitorCRD_Present(t *testing.T) {
 
 	t.Run("MonitorCRDs", func(t *testing.T) {
 		g := NewWithT(t)
-		pc := MonitorCRDs([]schema.GroupVersionKind{testCRDGVK})
+		pc := MonitorCRDs([]string{testCRDName})
 		result, err := pc.check(ctx, rr)
 		g.Expect(err).NotTo(HaveOccurred())
 		g.Expect(result.Pass).To(BeTrue())
@@ -84,7 +90,7 @@ func TestMonitorCRDs_AllPresent(t *testing.T) {
 
 	rr := &types.ReconciliationRequest{Client: cli}
 
-	pc := MonitorCRDs([]schema.GroupVersionKind{testCRDGVK, testCRDGVK2})
+	pc := MonitorCRDs([]string{testCRDName, testCRDName2})
 	result, err := pc.check(ctx, rr)
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(result.Pass).To(BeTrue())
@@ -98,18 +104,12 @@ func TestMonitorCRD_Absent(t *testing.T) {
 	g.Expect(err).NotTo(HaveOccurred())
 	t.Cleanup(func() { _ = envTest.Stop() })
 
-	absentGVK := schema.GroupVersionKind{
-		Group:   "absent.opendatahub.io",
-		Version: "v1",
-		Kind:    "AbsentResource",
-	}
-
-	pc := MonitorCRD(absentGVK)
+	pc := MonitorCRD(absentCRDName)
 	result, err := pc.check(ctx, &types.ReconciliationRequest{Client: envTest.Client()})
 
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(result.Pass).To(BeFalse())
-	g.Expect(result.Message).To(ContainSubstring("AbsentResource"))
+	g.Expect(result.Message).To(ContainSubstring(absentCRDName))
 	g.Expect(result.Message).To(ContainSubstring("CRD not found"))
 }
 
@@ -127,19 +127,13 @@ func TestMonitorCRDs_SomeAbsent(t *testing.T) {
 	g.Expect(err).NotTo(HaveOccurred())
 	envt.CleanupDelete(t, g, ctx, cli, crd)
 
-	absentGVK := schema.GroupVersionKind{
-		Group:   "absent.opendatahub.io",
-		Version: "v1",
-		Kind:    "AbsentResource",
-	}
-
-	pc := MonitorCRDs([]schema.GroupVersionKind{testCRDGVK, absentGVK})
+	pc := MonitorCRDs([]string{testCRDName, absentCRDName})
 	result, err := pc.check(ctx, &types.ReconciliationRequest{Client: cli})
 
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(result.Pass).To(BeFalse())
-	g.Expect(result.Message).To(ContainSubstring("AbsentResource"))
-	g.Expect(result.Message).NotTo(ContainSubstring("TestPreConditionResource"))
+	g.Expect(result.Message).To(ContainSubstring(absentCRDName))
+	g.Expect(result.Message).NotTo(ContainSubstring(testCRDName))
 }
 
 func TestMonitorCRDs_EmptySlice(t *testing.T) {
@@ -156,7 +150,7 @@ func TestMonitorCRDs_EmptySlice(t *testing.T) {
 	result, checkErr := pc.check(ctx, rr)
 
 	g.Expect(checkErr).To(HaveOccurred())
-	g.Expect(checkErr.Error()).To(ContainSubstring("empty GVK list"))
+	g.Expect(checkErr.Error()).To(ContainSubstring("empty CRD name list"))
 	g.Expect(result.Pass).To(BeFalse())
 }
 
@@ -174,19 +168,13 @@ func TestMonitorCRD_IntegrationWithRunAll(t *testing.T) {
 	g.Expect(err).NotTo(HaveOccurred())
 	envt.CleanupDelete(t, g, ctx, cli, crd)
 
-	absentGVK := schema.GroupVersionKind{
-		Group:   "absent.opendatahub.io",
-		Version: "v1",
-		Kind:    "AbsentResource",
-	}
-
 	instance := &scheme.TestPlatformObject{ObjectMeta: metav1.ObjectMeta{Name: xid.New().String()}}
 	condManager := cond.NewManager(instance, status.ConditionTypeReady, status.ConditionDependenciesAvailable)
 	rr := &types.ReconciliationRequest{Client: cli, Instance: instance, Conditions: condManager}
 
 	pcs := []PreCondition{
-		MonitorCRD(testCRDGVK),
-		MonitorCRD(absentGVK),
+		MonitorCRD(testCRDName),
+		MonitorCRD(absentCRDName),
 	}
 
 	shouldStop := RunAll(ctx, rr, pcs)
@@ -195,6 +183,6 @@ func TestMonitorCRD_IntegrationWithRunAll(t *testing.T) {
 	got := condManager.GetCondition(status.ConditionDependenciesAvailable)
 	g.Expect(got).NotTo(BeNil())
 	g.Expect(got.Status).To(Equal(metav1.ConditionFalse))
-	g.Expect(got.Message).To(ContainSubstring("AbsentResource"))
-	g.Expect(got.Message).NotTo(ContainSubstring("TestPreConditionResource"))
+	g.Expect(got.Message).To(ContainSubstring(absentCRDName))
+	g.Expect(got.Message).NotTo(ContainSubstring(testCRDName))
 }

--- a/pkg/controller/reconciler/reconciler.go
+++ b/pkg/controller/reconciler/reconciler.go
@@ -393,6 +393,10 @@ func (r *Reconciler) apply(ctx context.Context, res common.PlatformObject) (time
 	if shouldStop {
 		l.Info("Preconditions not met, stopping reconciliation")
 
+		// Safety net: requeue so the controller retries even if all watch
+		// events for the resource type were consumed.
+		requeueAfter = 30 * time.Second
+
 		rr.Conditions.MarkFalse(
 			status.ConditionTypeProvisioningSucceeded,
 			conditions.WithReason(precondition.PreConditionFailedReason),

--- a/pkg/controller/reconciler/reconciler_test.go
+++ b/pkg/controller/reconciler/reconciler_test.go
@@ -324,7 +324,7 @@ func TestPreConditions_StopReconciliation(t *testing.T) {
 	})
 
 	g.Expect(err).ShouldNot(HaveOccurred())
-	g.Expect(result.RequeueAfter).Should(BeZero())
+	g.Expect(result.RequeueAfter).Should(BeNumerically(">", 0), "precondition failure must schedule a requeue")
 	g.Expect(actionExecuted).To(BeFalse())
 
 	di := resources.GvkToUnstructured(gvk.Dashboard)
@@ -338,6 +338,74 @@ func TestPreConditions_StopReconciliation(t *testing.T) {
 		jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, status.ConditionTypeProvisioningSucceeded, metav1.ConditionFalse),
 		jq.Match(`.status.conditions[] | select(.type == "%s") | .reason == "%s"`, status.ConditionTypeProvisioningSucceeded, "PreConditionFailed"),
 	))
+}
+
+func TestPreConditions_StopReconciliation_RecoverAfterCRDAppears(t *testing.T) {
+	ctx := t.Context()
+	g := NewWithT(t)
+
+	fakeGVK := schema.GroupVersionKind{Group: "fake.opendatahub.io", Version: "v1", Kind: "FakeResource"}
+
+	et, err := envt.New(envt.WithManager(ctrl.Options{
+		Controller: config.Controller{SkipNameValidation: ptr.To(true)},
+	}))
+	g.Expect(err).NotTo(HaveOccurred())
+	t.Cleanup(func() { _ = et.Stop() })
+
+	mgr := et.Manager()
+	cli := et.Client()
+
+	dashboard := &componentApi.Dashboard{
+		ObjectMeta: metav1.ObjectMeta{Name: componentApi.DashboardInstanceName, Generation: 1},
+	}
+	dashboard.SetGroupVersionKind(gvk.Dashboard)
+	g.Expect(cli.Create(ctx, dashboard)).To(Succeed())
+
+	var actionExecuted atomic.Bool
+
+	_, err = ReconcilerFor(mgr, &componentApi.Dashboard{}).
+		WithInstanceName(xid.New().String()).
+		WithPreCondition(precondition.MonitorCRD(fakeGVK, precondition.WithStopReconciliation())).
+		WithAction(func(_ context.Context, _ *odhtype.ReconciliationRequest) error {
+			actionExecuted.Store(true)
+			return nil
+		}).
+		Build(ctx)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	startManager(t, g, mgr)
+
+	// Step 1: verify controller enters PreConditionFailed (CRD absent)
+	di := resources.GvkToUnstructured(gvk.Dashboard)
+	di.SetName(componentApi.DashboardInstanceName)
+
+	g.Eventually(func(gg Gomega) {
+		gg.Expect(cli.Get(ctx, client.ObjectKeyFromObject(di), di)).To(Succeed())
+		gg.Expect(di).Should(
+			jq.Match(`.status.conditions[] | select(.type == "%s") | .reason == "%s"`,
+				status.ConditionTypeProvisioningSucceeded, "PreConditionFailed"),
+		)
+	}).WithTimeout(10 * time.Second).Should(Succeed())
+	g.Expect(actionExecuted.Load()).To(BeFalse())
+
+	// Step 2: register the CRD (becomes Established)
+	crd, err := et.RegisterCRD(ctx, fakeGVK, "fakeresources", "fakeresource", apiextensionsv1.ClusterScoped)
+	g.Expect(err).NotTo(HaveOccurred())
+	t.Cleanup(func() {
+		_ = cli.Delete(ctx, crd, client.PropagationPolicy(metav1.DeletePropagationBackground))
+	})
+
+	// Step 3: verify controller recovers via requeue
+	g.Eventually(func() bool {
+		return actionExecuted.Load()
+	}).WithTimeout(60 * time.Second).WithPolling(1 * time.Second).Should(BeTrue(),
+		"controller should recover after CRD appears via requeue")
+
+	g.Expect(cli.Get(ctx, client.ObjectKeyFromObject(di), di)).To(Succeed())
+	g.Expect(di).Should(
+		jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`,
+			status.ConditionTypeProvisioningSucceeded, metav1.ConditionTrue),
+	)
 }
 
 // TestReconcilerBuilder_WatchMethods_UseUnstructured verifies that all watch

--- a/pkg/controller/reconciler/reconciler_test.go
+++ b/pkg/controller/reconciler/reconciler_test.go
@@ -310,7 +310,7 @@ func TestPreConditions_StopReconciliation(t *testing.T) {
 	cc := createReconciler(cli)
 	cc.preConditions = []precondition.PreCondition{
 		precondition.MonitorCRD(
-			schema.GroupVersionKind{Group: "fake.opendatahub.io", Version: "v1", Kind: "FakeResource"},
+			"fakeresources.fake.opendatahub.io",
 			precondition.WithStopReconciliation(),
 		),
 	}
@@ -345,6 +345,7 @@ func TestPreConditions_StopReconciliation_RecoverAfterCRDAppears(t *testing.T) {
 	g := NewWithT(t)
 
 	fakeGVK := schema.GroupVersionKind{Group: "fake.opendatahub.io", Version: "v1", Kind: "FakeResource"}
+	fakeCRDName := "fakeresources.fake.opendatahub.io"
 
 	et, err := envt.New(envt.WithManager(ctrl.Options{
 		Controller: config.Controller{SkipNameValidation: ptr.To(true)},
@@ -365,7 +366,7 @@ func TestPreConditions_StopReconciliation_RecoverAfterCRDAppears(t *testing.T) {
 
 	_, err = ReconcilerFor(mgr, &componentApi.Dashboard{}).
 		WithInstanceName(xid.New().String()).
-		WithPreCondition(precondition.MonitorCRD(fakeGVK, precondition.WithStopReconciliation())).
+		WithPreCondition(precondition.MonitorCRD(fakeCRDName, precondition.WithStopReconciliation())).
 		WithAction(func(_ context.Context, _ *odhtype.ReconciliationRequest) error {
 			actionExecuted.Store(true)
 			return nil
@@ -396,9 +397,7 @@ func TestPreConditions_StopReconciliation_RecoverAfterCRDAppears(t *testing.T) {
 	})
 
 	// Step 3: verify controller recovers via requeue
-	g.Eventually(func() bool {
-		return actionExecuted.Load()
-	}).WithTimeout(60 * time.Second).WithPolling(1 * time.Second).Should(BeTrue(),
+	g.Eventually(actionExecuted.Load).WithTimeout(60*time.Second).WithPolling(1*time.Second).Should(BeTrue(),
 		"controller should recover after CRD appears via requeue")
 
 	g.Expect(cli.Get(ctx, client.ObjectKeyFromObject(di), di)).To(Succeed())


### PR DESCRIPTION
## Description

- When `WithStopReconciliation()` preconditions fail (e.g. `MonitorCRD` checking for a dependency CRD), the reconciler returned `Result{}, nil` — no requeue, no error. Self-healing relied entirely on CRD watch events.
- A race exists inside the K8s API server: the discovery endpoint (used by `RESTMapper`) is updated by a separate internal controller (`DiscoveryController`) that lags behind the CRD `Established` condition (set by `EstablishingController`). If all watch events are consumed during this window, the controller is stuck permanently — confirmed on a live RHOAI 3.5.0 cluster where TrustyAI was stuck for 6.5 hours until manually poked.
- Fix: set `requeueAfter = 30s` when `shouldStop=true`, so the controller retries even if all watch events were consumed during the race window.

Jira: https://issues.redhat.com/browse/RHOAIENG-77786

## How Has This Been Tested?

- **Unit test updated**: `TestPreConditions_StopReconciliation` now asserts `RequeueAfter > 0` instead of `BeZero()`
- **Integration test added**: `TestPreConditions_StopReconciliation_RecoverAfterCRDAppears` — full manager test: CRD absent → precondition fails → CRD registered (Established) → requeue fires → actions execute → recovery confirmed
- **Live cluster validation**: manually triggered reconcile on a stuck TrustyAI controller → instant recovery, confirming the CRD check works once a reconcile runs

## Merge criteria

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully
- [ ] New RELATED_IMAGE mappings are listed in ODH-Build-Config and RHOAI-Build-Config (CI validates names against build-config repos). Include links to build-config PRs in the description.

### E2E test suite update requirement

- [x] Skip requirement to update E2E test suite for this PR

#### E2E update requirement opt-out justification

The fix is in the generic reconciler framework (`pkg/controller/reconciler`), not component-specific code. The existing E2E test `ValidateTrustyAIPreCheck` already covers the CRD dependency cycle (disable KServe → delete CRD → verify failure → re-enable → verify recovery). The new unit/integration tests directly validate the requeue behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reconciliation now retries automatically after precondition failures using a safety-net requeue delay (30s).
  * Controllers can recover when previously missing required CRDs appear, and status/conditions reflect the stop-and-recover lifecycle.
* **Refactor**
  * CRD presence monitoring and dependency reporting were standardized to use CRD name strings (including treating terminating CRDs as absent).
  * Shared CRD name constants were expanded and applied across controllers and cert-manager bootstrapping.
* **Tests**
  * Updated and added coverage for name-based CRD monitoring, recovery behavior, and dependency condition messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->