### PR TITLE
Remove odh-training-operator from operator manifests (offboarding)

### DIFF
--- a/build/manifests-config.yaml
+++ b/build/manifests-config.yaml
@@ -15,9 +15,6 @@ map:
     src: dashboard-operator/charts/dashboard
     dest: dashboard-operator
     type: chart
-  odh-training-operator:
-    src: manifests
-    dest: trainingoperator
   odh-feast-module-operator:
     src: config/chart
     dest: feastoperator


### PR DESCRIPTION
Removes odh-training-operator from build/manifests-config.yaml (offboarding).

Jira: https://redhat.atlassian.net/browse/RHOAIENG-79608

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to remove an obsolete training operator manifest mapping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->