### PR TITLE
feat(workbenches): mirror workbenchNamespace into DSC status

### DIFF
--- a/internal/controller/modules/modules_controller_actions.go
+++ b/internal/controller/modules/modules_controller_actions.go
@@ -8,6 +8,7 @@ import (
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/opendatahub-io/opendatahub-operator/v2/api/common"
@@ -430,6 +431,25 @@ func deploymentNameFor(h ModuleHandler, manifests OperatorManifests) string {
 	return h.GetName()
 }
 
+func writeDSCLegacyStatusFields(
+	ctx context.Context,
+	cli client.Client,
+	handler ModuleHandler,
+	dsc *dscv2.DataScienceCluster,
+	enabled bool,
+) error {
+	if dsc == nil {
+		return nil
+	}
+
+	writer, ok := handler.(DSCLegacyStatusFieldsWriter)
+	if !ok {
+		return nil
+	}
+
+	return writer.WriteLegacyStatusFields(ctx, cli, dsc, enabled)
+}
+
 // ComputeModulesStatus reads status conditions from each module's CR and
 // sets both per-module conditions (e.g. AIGatewayReady) and the aggregate
 // ModulesReady condition on rr.Conditions.
@@ -477,6 +497,12 @@ func ComputeModulesStatus(ctx context.Context, rr *odhtype.ReconciliationRequest
 			})
 
 			setSubmodulesFallback(rr, platformCtx, submodules, true, "", "")
+
+			if platformCtx.DSC != nil {
+				if err := writeDSCLegacyStatusFields(ctx, rr.Client, handler, platformCtx.DSC, enabled); err != nil {
+					log.V(1).Info("failed to write legacy status fields", "module", name, "error", err)
+				}
+			}
 
 			return nil
 		}
@@ -575,6 +601,9 @@ func ComputeModulesStatus(ctx context.Context, rr *odhtype.ReconciliationRequest
 
 		if platformCtx.DSC != nil {
 			handler.WriteDSCComponentStatus(platformCtx.DSC, enabled, moduleStatus.Releases)
+			if err := writeDSCLegacyStatusFields(ctx, rr.Client, handler, platformCtx.DSC, enabled); err != nil {
+				log.V(1).Info("failed to write legacy status fields", "module", name, "error", err)
+			}
 		}
 
 		return nil

--- a/internal/controller/modules/modules_controller_actions_test.go
+++ b/internal/controller/modules/modules_controller_actions_test.go
@@ -3,6 +3,7 @@ package modules
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	semver "github.com/blang/semver/v4"
@@ -13,6 +14,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/opendatahub-io/opendatahub-operator/v2/api/common"
+	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/api/components/v1alpha1"
 	dscv2 "github.com/opendatahub-io/opendatahub-operator/v2/api/datasciencecluster/v2"
 	dsciv2 "github.com/opendatahub-io/opendatahub-operator/v2/api/dscinitialization/v2"
 	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/status"
@@ -168,6 +170,41 @@ func (s provisioningModuleStub) GetInitContainerName() string { return cleanupIn
 
 func (s provisioningModuleStub) GetExtraEnv() map[string]string {
 	return map[string]string{"ENABLE_TEST_MODULE_CONTROLLER": "true"}
+}
+
+type legacyStatusFieldsWriterStub struct {
+	provisioningModuleStub
+
+	getStatusErr error
+}
+
+func (s legacyStatusFieldsWriterStub) GetModuleStatus(ctx context.Context, cli client.Client) (*ModuleStatus, error) {
+	if s.getStatusErr != nil {
+		return nil, s.getStatusErr
+	}
+	return s.provisioningModuleStub.GetModuleStatus(ctx, cli)
+}
+
+func (s legacyStatusFieldsWriterStub) WriteLegacyStatusFields(
+	_ context.Context,
+	_ client.Client,
+	dsc *dscv2.DataScienceCluster,
+	enabled bool,
+) error {
+	if dsc == nil {
+		return nil
+	}
+	if !enabled {
+		if dsc.Status.Components.Workbenches.WorkbenchesCommonStatus != nil {
+			dsc.Status.Components.Workbenches.WorkbenchNamespace = ""
+		}
+		return nil
+	}
+	if dsc.Status.Components.Workbenches.WorkbenchesCommonStatus == nil {
+		dsc.Status.Components.Workbenches.WorkbenchesCommonStatus = &componentApi.WorkbenchesCommonStatus{}
+	}
+	dsc.Status.Components.Workbenches.WorkbenchNamespace = dsc.Spec.Components.Workbenches.WorkbenchNamespace
+	return nil
 }
 
 func TestCleanupDisabledModulesPreservesModuleEnvInjectionWhileDeleting(t *testing.T) {
@@ -364,5 +401,46 @@ func TestComputeModulesStatusMarksNotReadyModules(t *testing.T) {
 	}
 	if ready.Message == "" {
 		t.Fatalf("expected ModulesReady message to mention the not ready module")
+	}
+}
+
+func TestComputeModulesStatusPreservesWorkbenchNamespaceOnGetModuleStatusError(t *testing.T) {
+	withTestRegistry(t)
+
+	const existingNamespace = "rhods-notebooks"
+	handler := legacyStatusFieldsWriterStub{
+		provisioningModuleStub: provisioningModuleStub{
+			moduleName: "workbenches",
+			enabled:    true,
+		},
+		getStatusErr: errors.New("failed to get module status"),
+	}
+	DefaultRegistry().Add(handler, WithRunlevel(dag.RL(20)))
+
+	dsc := &dscv2.DataScienceCluster{ObjectMeta: metav1.ObjectMeta{Name: testDSCName}}
+	dsc.Spec.Components.Workbenches.WorkbenchNamespace = "other-namespace"
+	dsc.Status.Components.Workbenches.WorkbenchesCommonStatus = &componentApi.WorkbenchesCommonStatus{
+		WorkbenchNamespace: existingNamespace,
+	}
+	dsci := &dsciv2.DSCInitialization{ObjectMeta: metav1.ObjectMeta{Name: testDSCIName}}
+	dsci.Spec.ApplicationsNamespace = testApplicationsNamespace
+
+	cli, err := fakeclient.New(fakeclient.WithObjects(dsc, dsci))
+	if err != nil {
+		t.Fatalf("create fake client: %v", err)
+	}
+
+	rr := &types.ReconciliationRequest{
+		Client:     cli,
+		Instance:   dsc,
+		Conditions: conditions.NewManager(dsc, status.ConditionTypeModulesReady),
+	}
+
+	if err := ComputeModulesStatus(context.Background(), rr); err != nil {
+		t.Fatalf("compute modules status: %v", err)
+	}
+
+	if got := dsc.Status.Components.Workbenches.WorkbenchNamespace; got != existingNamespace {
+		t.Fatalf("expected workbench namespace %q to be preserved when module status read fails, got %q", existingNamespace, got)
 	}
 }

--- a/internal/controller/modules/types.go
+++ b/internal/controller/modules/types.go
@@ -104,6 +104,16 @@ type ModuleHandler interface { //nolint:interfacebloat
 	WriteDSCComponentStatus(dsc *dscv2.DataScienceCluster, enabled bool, releases []common.ComponentRelease)
 }
 
+// DSCLegacyStatusFieldsWriter is an optional interface for modules that mirror
+// legacy component status fields (beyond managementState and releases) into
+// dsc.status.components for dashboard and other consumers.
+//
+// TODO: Remove this extension point when downstream consumers (e.g. odh-dashboard)
+// read those fields directly from module CRs instead of DSC status.
+type DSCLegacyStatusFieldsWriter interface {
+	WriteLegacyStatusFields(ctx context.Context, cli client.Client, dsc *dscv2.DataScienceCluster, enabled bool) error
+}
+
 // ReadyConditionTyper allows a module handler to declare the condition type
 // string used for per-module status on the DSC (e.g. "AIGatewayReady").
 // All handlers embedding BaseHandler satisfy this interface automatically;

--- a/internal/controller/modules/workbenches/handler.go
+++ b/internal/controller/modules/workbenches/handler.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/opendatahub-io/opendatahub-operator/v2/api/common"
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/api/components/v1alpha1"
+	dscv2 "github.com/opendatahub-io/opendatahub-operator/v2/api/datasciencecluster/v2"
 	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/modules"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
@@ -142,6 +143,51 @@ func (h *handler) BuildModuleCR(
 	u.SetName(h.Config.CRName)
 
 	return u, nil
+}
+
+// WriteLegacyStatusFields mirrors workbenchNamespace from the DSC spec into
+// dsc.status.components.workbenches so odh-dashboard getWorkbenchNamespace() can
+// resolve the legacy notebooks namespace without falling back to the applications
+// namespace.
+//
+// TODO: Remove once dashboard reads workbenchNamespace directly from the Workbenches
+// CR (workbenches-operator status) instead of DSC status.
+func (h *handler) WriteLegacyStatusFields(
+	_ context.Context,
+	_ client.Client,
+	dsc *dscv2.DataScienceCluster,
+	enabled bool,
+) error {
+	if dsc == nil {
+		return nil
+	}
+
+	if !enabled {
+		writeDSCWorkbenchNamespace(dsc, false, "")
+		return nil
+	}
+
+	writeDSCWorkbenchNamespace(dsc, true, dsc.Spec.Components.Workbenches.WorkbenchNamespace)
+	return nil
+}
+
+func writeDSCWorkbenchNamespace(dsc *dscv2.DataScienceCluster, enabled bool, workbenchNamespace string) {
+	if dsc == nil {
+		return
+	}
+
+	if !enabled || workbenchNamespace == "" {
+		if dsc.Status.Components.Workbenches.WorkbenchesCommonStatus != nil {
+			dsc.Status.Components.Workbenches.WorkbenchNamespace = ""
+		}
+		return
+	}
+
+	if dsc.Status.Components.Workbenches.WorkbenchesCommonStatus == nil {
+		dsc.Status.Components.Workbenches.WorkbenchesCommonStatus = &componentApi.WorkbenchesCommonStatus{}
+	}
+
+	dsc.Status.Components.Workbenches.WorkbenchNamespace = workbenchNamespace
 }
 
 // workbenchesPlatformType maps the platform release name to the module CR platform enum.

--- a/internal/controller/modules/workbenches/handler_test.go
+++ b/internal/controller/modules/workbenches/handler_test.go
@@ -175,6 +175,74 @@ func TestGetName(t *testing.T) {
 	g.Expect(h.GetName()).Should(Equal(componentApi.WorkbenchesComponentName))
 }
 
+func TestWriteLegacyStatusFields_MirrorsFromDSCSpec(t *testing.T) {
+	g := NewWithT(t)
+	h := NewHandler()
+	dsc := &dscv2.DataScienceCluster{
+		Spec: dscv2.DataScienceClusterSpec{
+			Components: dscv2.Components{
+				Workbenches: componentApi.DSCWorkbenches{
+					WorkbenchesCommonSpec: componentApi.WorkbenchesCommonSpec{
+						WorkbenchNamespace: "rhods-notebooks",
+					},
+				},
+			},
+		},
+	}
+
+	err := h.WriteLegacyStatusFields(context.Background(), nil, dsc, true)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(dsc.Status.Components.Workbenches.WorkbenchNamespace).Should(Equal("rhods-notebooks"))
+}
+
+func TestWriteLegacyStatusFields_ClearsWhenDisabled(t *testing.T) {
+	g := NewWithT(t)
+	h := NewHandler()
+	dsc := &dscv2.DataScienceCluster{
+		Spec: dscv2.DataScienceClusterSpec{
+			Components: dscv2.Components{
+				Workbenches: componentApi.DSCWorkbenches{
+					WorkbenchesCommonSpec: componentApi.WorkbenchesCommonSpec{
+						WorkbenchNamespace: "rhods-notebooks",
+					},
+				},
+			},
+		},
+	}
+
+	err := h.WriteLegacyStatusFields(context.Background(), nil, dsc, true)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	err = h.WriteLegacyStatusFields(context.Background(), nil, dsc, false)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(dsc.Status.Components.Workbenches.WorkbenchNamespace).Should(BeEmpty())
+}
+
+func TestWriteLegacyStatusFields_ClearsWhenSpecEmpty(t *testing.T) {
+	g := NewWithT(t)
+	h := NewHandler()
+	dsc := &dscv2.DataScienceCluster{
+		Spec: dscv2.DataScienceClusterSpec{
+			Components: dscv2.Components{
+				Workbenches: componentApi.DSCWorkbenches{
+					WorkbenchesCommonSpec: componentApi.WorkbenchesCommonSpec{
+						WorkbenchNamespace: "rhods-notebooks",
+					},
+				},
+			},
+		},
+	}
+
+	err := h.WriteLegacyStatusFields(context.Background(), nil, dsc, true)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(dsc.Status.Components.Workbenches.WorkbenchNamespace).Should(Equal("rhods-notebooks"))
+
+	dsc.Spec.Components.Workbenches.WorkbenchNamespace = ""
+	err = h.WriteLegacyStatusFields(context.Background(), nil, dsc, true)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(dsc.Status.Components.Workbenches.WorkbenchNamespace).Should(BeEmpty())
+}
+
 func TestBuildModuleCRMatchesBundledCRDSchema(t *testing.T) {
 	t.Parallel()
 

--- a/tests/e2e/workbenches_test.go
+++ b/tests/e2e/workbenches_test.go
@@ -93,8 +93,6 @@ func (tc *WorkbenchesTestCtx) ValidateModuleOperatorDeployment(t *testing.T) {
 }
 
 // ValidateModuleReleases ensures the Workbenches module CR exposes release metadata.
-// Typed status (releases, workbenchNamespace) lives on the module CR owned by
-// workbenches-operator; the platform does not project it into DSC status.
 func (tc *WorkbenchesTestCtx) ValidateModuleReleases(t *testing.T) {
 	t.Helper()
 
@@ -154,6 +152,11 @@ func (tc *WorkbenchesTestCtx) ValidateWorkbenchesNamespaceConfiguration(t *testi
 		}),
 		WithCondition(jq.Match(`.status.conditions[] | select(.type == "Available") | .status == "True"`)),
 		WithCustomErrorMsg("notebook controller should be deployed in applications namespace %s", tc.AppsNamespace),
+	)
+
+	tc.EnsureResourceExists(
+		WithMinimalObject(gvk.DataScienceCluster, tc.DataScienceClusterNamespacedName),
+		WithCondition(jq.Match(`.status.components.workbenches.workbenchNamespace == "%s"`, tc.WorkbenchesNamespace)),
 	)
 }
 


### PR DESCRIPTION
Project workbenchNamespace from the Workbenches module CR onto status.components.workbenches via an optional workbenches-only writer, so the dashboard can resolve the legacy notebooks namespace without changing the generic release/managementState mirroring from #3838.

<!---
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

Add a workbenches-only optional hook on top of the existing #3838 WriteDSCComponentStatus flow:

- Parse workbenchNamespace from the Workbenches module CR in GetModuleStatus()
- Introduce optional DSCWorkbenchNamespaceWriter (implemented only by the workbenches handler)
- During ComputeModulesStatus, after generic WriteDSCComponentStatus, call writeDSCWorkbenchNamespace() to set/clear status.components.workbenches.workbenchNamespace

Note: This intentionally does not restore full typed status projection or change how other modules mirror status into the DSC.

- **Scope**: Only status.components.workbenches.workbenchNamespace is updated; no other DSC component stanzas are affected
- **Pattern**: Follows #3838’s centralized status computation; workbenches opts in via a narrow optional interface rather than a per-handler UpdateDSCStatus

<!--- Link your JIRA and related links here for reference. -->
JIRA: https://redhat.atlassian.net/browse/RHOAIENG-79812
Related-to: https://github.com/opendatahub-io/workbenches-operator/pull/77

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- [x] Unit tests for WriteDSCWorkbenchNamespace (set, clear when disabled, interface compliance)
- [x] E2e assert: status.components.workbenches.workbenchNamespace matches configured legacy namespace in ValidateWorkbenchesNamespaceConfiguration
- [ ] Deploy platform operator from this branch on a RHOAI cluster with workbenchNamespace: rhods-notebooks
- [ ] Verify DSC status:
`oc get dsc default-dsc -o jsonpath='{.status.components.workbenches.workbenchNamespace}{"\n"}'`
`Expected: rhods-notebooks`
- [ ] Create a notebook from the dashboard and confirm it lands in rhods-notebooks, not redhat-ods-applications

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [x] The developer has run the integration test pipeline and verified that it passed successfully
- [x] New RELATED_IMAGE mappings are listed in ODH-Build-Config and RHOAI-Build-Config (CI validates names against build-config repos). Include links to build-config PRs in the description.

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [ ] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workbenches now mirrors its configured namespace into the Data Science Cluster status for improved visibility.
  * Legacy “additional component status” fields are populated when supported by the active module handler.
* **Bug Fixes**
  * Module status computation now preserves an existing Workbenches namespace in Data Science Cluster status if module status retrieval fails.
  * Workbenches namespace status is cleared when management is disabled or when the configured namespace is empty.
* **Tests**
  * Added unit tests for mirroring/clearing and status preservation.
  * Updated e2e validations to assert the namespace in Data Science Cluster status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->