### PR TITLE
feat(feast): Add feast.dev/featurestores CRUD permissions to RHOAI admin group ClusterRole

### DIFF
--- a/internal/controller/services/auth/resources/data-science-admingroup-clusterrole.tmpl.yaml
+++ b/internal/controller/services/auth/resources/data-science-admingroup-clusterrole.tmpl.yaml
@@ -41,6 +41,18 @@ rules:
       - patch
       - delete
   - apiGroups:
+      - feast.dev
+    resources:
+      - featurestores
+    verbs:
+      - watch
+      - update
+      - get
+      - list
+      - create
+      - patch
+      - delete
+  - apiGroups:
       - storage.k8s.io
     resources:
       - storageclasses


### PR DESCRIPTION

## Description

- Add `feast.dev/featurestores` CRUD permissions to the `data-science-admingroupcluster-role` ClusterRole template, following the same pattern as `modelregistry.opendatahub.io/modelregistries`
- This ensures RHOAI platform admin group members (`rhods-admins` / `dedicated-admins` / `odh-admins`) can create, update, and delete FeatureStore CRs cluster-wide without requiring separate namespace-level RoleBindings

## Problem
RHOAI platform admins do not have cluster-wide permissions on `feast.dev/featurestores` CRs. The Feature Store admin UI in odh-dashboard uses SelfSubjectAccessReview (SSAR) to gate create/delete actions. Without this change, SSAR denies those actions for platform admins who don't hold namespace-level `admin`/`edit` roles, leaving the create and delete buttons disabled in the dashboard.

The `data-science-admingroupcluster-role` already grants full CRUD on `modelregistry.opendatahub.io/modelregistries` but was missing the equivalent entry for `feast.dev/featurestores`.


https://redhat.atlassian.net/browse/RHOAIENG-79831 

## How Has This Been Tested?

- [x] Deploy the operator with this change
- [x] Verify `oc auth can-i create featurestores.feast.dev --as=<admin-group-member>` returns `yes`
- [x] Verify `oc auth can-i delete featurestores.feast.dev --as=<admin-group-member>` returns `yes`
- [x] Verify non-admin users (allowed groups) cannot create/delete FeatureStore CRs


## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [x] The developer has run the integration test pipeline and verified that it passed successfully
- [x] New RELATED_IMAGE mappings are listed in ODH-Build-Config and RHOAI-Build-Config (CI validates names against build-config repos). Include links to build-config PRs in the description.

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->

This change adds a single rules block to an existing RBAC template (data-science-admingroup-clusterrole.tmpl.yaml). It follows the identical pattern already established by modelregistry.opendatahub.io/modelregistries in the same template. The existing unit tests validate binding creation, subject filtering, and role name correctness — none of which are affected by adding rules to the template body. The E2E auth controller tests similarly validate binding structure, not rule content. No new controllers, reconciliation paths, or CRDs are introduced.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for managing Feast feature stores, including viewing, creating, updating, and deleting them.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->