### PR TITLE
refactor(dsc): remove obsolete finalizer migration code

### DIFF
--- a/internal/controller/datasciencecluster/datasciencecluster_controller.go
+++ b/internal/controller/datasciencecluster/datasciencecluster_controller.go
@@ -91,7 +91,6 @@ func NewDataScienceClusterReconciler(ctx context.Context, mgr ctrl.Manager) erro
 			))
 
 	_, err := b.
-		WithAction(initialize).
 		WithAction(checkPreConditions).
 		WithAction(updateStatus).
 		WithAction(checkUpgradeGates).

--- a/internal/controller/datasciencecluster/datasciencecluster_controller_actions.go
+++ b/internal/controller/datasciencecluster/datasciencecluster_controller_actions.go
@@ -8,7 +8,6 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -24,11 +23,6 @@ import (
 	odhtype "github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
 )
 
-const (
-	// TODO: remove after https://issues.redhat.com/browse/RHOAIENG-15920
-	finalizerName = "datasciencecluster.opendatahub.io/finalizer"
-)
-
 // persistAPI is implemented by component CRs that expose an alternative object
 // for the deploy action to persist (e.g. when the "public" CR wraps an inner
 // object that should actually be applied to the cluster).
@@ -38,22 +32,6 @@ type persistAPI interface {
 
 func isNilInterface(v any) bool {
 	return v == nil || (reflect.ValueOf(v).Kind() == reflect.Ptr && reflect.ValueOf(v).IsNil())
-}
-
-func initialize(ctx context.Context, rr *odhtype.ReconciliationRequest) error {
-	instance, ok := rr.Instance.(*dscv2.DataScienceCluster)
-	if !ok {
-		return fmt.Errorf("resource instance %v is not a dscv2.DataScienceCluster)", rr.Instance)
-	}
-
-	// TODO: remove after https://issues.redhat.com/browse/RHOAIENG-15920
-	if controllerutil.RemoveFinalizer(instance, finalizerName) {
-		if err := rr.Client.Update(ctx, instance); err != nil {
-			return err
-		}
-	}
-
-	return nil
 }
 
 func checkPreConditions(ctx context.Context, rr *odhtype.ReconciliationRequest) error {


### PR DESCRIPTION
## Description

Remove obsolete `initialize` action that stripped the old `datasciencecluster.opendatahub.io/finalizer` during DSC reconcile. This migration (RHOAIENG-15920, PR #1675) shipped Feb 2025; the new `platform.opendatahub.io/finalizer` is in use and nothing adds the old name anymore.

Ref: https://issues.redhat.com/browse/RHOAIENG-80037

## How Has This Been Tested?

- `make build` / `make lint` / `make unit-test` — all pass
- `grep -rn 'datasciencecluster.opendatahub.io/finalizer'` — no matches

## Merge criteria

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful.
- [x] Pull Request contains a description, JIRA link, and related PRs.
- [x] Testing instructions have been added.
- [x] The developer has manually tested the changes.
- [ ] The developer has run the integration test pipeline.
- [ ] New RELATED_IMAGE mappings are listed in build-config repos.

### E2E test suite update requirement

- [x] Skip requirement to update E2E test suite for this PR

#### E2E update requirement opt-out justification

Pure dead-code removal — no runtime behavior changes, no new code paths. Nothing to test.