### PR TITLE
allow Perses deployment when OpenTelemetry operator is not installed

### DIFF
--- a/internal/controller/services/monitoring/monitoring_controller_support.go
+++ b/internal/controller/services/monitoring/monitoring_controller_support.go
@@ -428,7 +428,7 @@ func addMonitoringCapability(ctx context.Context, rr *odhtypes.ReconciliationReq
 	rr.Conditions.MarkUnknown(status.ConditionMonitoringAvailable)
 
 	if err := checkMonitoringPreconditions(ctx, rr); err != nil {
-		log.Error(err, "Monitoring preconditions failed")
+		log.Info("Some monitoring preconditions not met, individual actions will handle gracefully", "error", err.Error())
 
 		rr.Conditions.MarkFalse(
 			status.ConditionMonitoringAvailable,
@@ -436,7 +436,11 @@ func addMonitoringCapability(ctx context.Context, rr *odhtypes.ReconciliationReq
 			cond.WithMessage("Monitoring preconditions failed: %s", err.Error()),
 		)
 
-		return err
+		// Do not return the error — let subsequent actions check their own
+		// prerequisites and deploy what they can. Each action (deployPerses,
+		// deployOpenTelemetryCollector, etc.) already handles missing
+		// dependencies gracefully by setting conditions and returning nil.
+		return nil
 	}
 
 	rr.Conditions.MarkTrue(status.ConditionMonitoringAvailable)

--- a/internal/controller/services/monitoring/monitoring_controller_support.go
+++ b/internal/controller/services/monitoring/monitoring_controller_support.go
@@ -421,6 +421,7 @@ func getTemplateData(ctx context.Context, rr *odhtypes.ReconciliationRequest) (m
 	return templateData, nil
 }
 
+//nolint:unparam // signature required by WithAction; always returns nil to let the action chain continue.
 func addMonitoringCapability(ctx context.Context, rr *odhtypes.ReconciliationRequest) error {
 	log := logf.FromContext(ctx)
 


### PR DESCRIPTION
Allow Perses deployment when OpenTelemetry operator is not installed.

`addMonitoringCapability` blocks the entire monitoring reconciliation chain when any precondition fails. This prevents Perses from being deployed even though `deployPerses` and all other actions already handle missing dependencies gracefully by setting conditions and returning nil.

Changes:
- `addMonitoringCapability` logs the precondition failure and sets `MonitoringAvailable` to `false` without returning an error, allowing the action chain to continue
- Components that can deploy (e.g. Perses when only COO is installed) proceed, while components that can't (e.g. OTel collector without the operator) skip themselves and set their own conditions

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
Behavioral change is limited to error propagation in the monitoring action chain. Existing unit tests cover the change. No new CRDs, APIs, or user-facing features introduced.