### PR TITLE
auto configure observability field on dashboard module CR

### DIFF
--- a/internal/controller/modules/dashboard/handler.go
+++ b/internal/controller/modules/dashboard/handler.go
@@ -92,6 +92,17 @@ func (h *handler) BuildModuleCR(
 		}
 	}
 
+	if platform.MonitoringNamespace != "" {
+		spec["observability"] = map[string]any{
+			"enabled": true,
+			"persesService": map[string]any{
+				"name":      "data-science-perses",
+				"namespace": platform.MonitoringNamespace,
+				"port":      int64(8080),
+			},
+		}
+	}
+
 	u := &unstructured.Unstructured{
 		Object: map[string]any{
 			"spec": spec,

--- a/internal/controller/modules/dashboard/handler_test.go
+++ b/internal/controller/modules/dashboard/handler_test.go
@@ -216,7 +216,7 @@ func TestBuildModuleCR_ObservabilitySetWhenMonitoringNamespaceConfigured(t *test
 
 	obs, ok := spec["observability"].(map[string]any)
 	g.Expect(ok).Should(BeTrue(), "spec.observability missing")
-	g.Expect(obs["enabled"]).Should(Equal(true))
+	g.Expect(obs["enabled"]).Should(BeTrue())
 
 	svc, ok := obs["persesService"].(map[string]any)
 	g.Expect(ok).Should(BeTrue(), "spec.observability.persesService missing")

--- a/internal/controller/modules/dashboard/handler_test.go
+++ b/internal/controller/modules/dashboard/handler_test.go
@@ -202,6 +202,42 @@ func TestBuildModuleCR_ComponentsDefaultToRemovedWhenEmpty(t *testing.T) {
 	g.Expect(pipComp["managementState"]).Should(Equal("Removed"))
 }
 
+func TestBuildModuleCR_ObservabilitySetWhenMonitoringNamespaceConfigured(t *testing.T) {
+	g := NewWithT(t)
+	h := dashboard.NewHandler()
+	platform := newPlatformCtx(operatorv1.Managed)
+	platform.MonitoringNamespace = "redhat-ods-monitoring"
+
+	u, err := h.BuildModuleCR(context.Background(), nil, platform)
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	spec, ok := u.Object["spec"].(map[string]any)
+	g.Expect(ok).Should(BeTrue())
+
+	obs, ok := spec["observability"].(map[string]any)
+	g.Expect(ok).Should(BeTrue(), "spec.observability missing")
+	g.Expect(obs["enabled"]).Should(Equal(true))
+
+	svc, ok := obs["persesService"].(map[string]any)
+	g.Expect(ok).Should(BeTrue(), "spec.observability.persesService missing")
+	g.Expect(svc["name"]).Should(Equal("data-science-perses"))
+	g.Expect(svc["namespace"]).Should(Equal("redhat-ods-monitoring"))
+	g.Expect(svc["port"]).Should(Equal(int64(8080)))
+}
+
+func TestBuildModuleCR_ObservabilityOmittedWhenMonitoringNamespaceEmpty(t *testing.T) {
+	g := NewWithT(t)
+	h := dashboard.NewHandler()
+	platform := newPlatformCtx(operatorv1.Managed)
+
+	u, err := h.BuildModuleCR(context.Background(), nil, platform)
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	spec, ok := u.Object["spec"].(map[string]any)
+	g.Expect(ok).Should(BeTrue())
+	g.Expect(spec).ShouldNot(HaveKey("observability"))
+}
+
 func TestBuildModuleCR_NilPlatformContextReturnsError(t *testing.T) {
 	g := NewWithT(t)
 	h := dashboard.NewHandler()


### PR DESCRIPTION
Fixes #3910.

Auto-configure Dashboard CR observability when monitoring namespace is set. On RHOAI deployments, the Perses proxy is not configured because nothing sets `observability.enabled: true` on the Dashboard CR. On ODH this works via the federation configmap's static `proxyService` entry.

Changes:
- `BuildModuleCR` in the dashboard module handler sets the `observability` field with `persesService` target when `MonitoringNamespace` is configured in `PlatformContext`
- Added two unit tests: observability set when monitoring namespace configured, omitted when empty

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
Configuration projection change in module handler. Unit tests cover both code paths. E2E validation requires a full RHOAI deployment with COO which is not available in the current E2E framework.