### PR TITLE
feat: add CI enforcement for release labels and JIRA links

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,7 +7,15 @@ Please complete the following sections for a smooth review.
 ## Description
 <!--- Describe your changes in detail -->
 
-<!--- Link your JIRA and related links here for reference. -->
+<!-- For RHOAI PRs, request review on #ai-core-platform-requests Slack channel -->
+
+## Release tracking
+<!-- These fields are mandatory - CI will block merging unless they are set -->
+<!-- Target release for this PR, e.g. rhoai-3.6 or rhoai-3.7ea1 -->
+Release: 
+<!-- Full link to a jira ticket, e.g. https://redhat.atlassian.net/browse/RHOAIENG-XXXXX -->
+Jira:
+
 
 ## How Has This Been Tested?
 <!--- Please describe in detail how you tested your changes. -->

--- a/.github/workflows/pr-release-label.yaml
+++ b/.github/workflows/pr-release-label.yaml
@@ -1,0 +1,96 @@
+name: Auto-label PR with release target
+on:
+  pull_request_target:
+    types: [opened, edited]
+
+concurrency:
+  group: ${{ github.workflow }}-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  apply-release-label:
+    name: Apply release label from PR description
+    if: >-
+      github.event.pull_request.user.login != 'odh-release-bot[bot]' &&
+      github.event.pull_request.user.login != 'dependabot[bot]' &&
+      github.event.pull_request.user.login != 'openshift-merge-bot[bot]' &&
+      github.event.pull_request.user.login != 'red-hat-konflux[bot]' &&
+      github.head_ref != 'sync/upgrade-manifest-shas'
+    permissions:
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
+        with:
+          app-id: ${{ secrets.ODH_DEVOPS_APP_ID }}
+          private-key: ${{ secrets.ODH_DEVOPS_APP_PRIVATE_KEY }}
+      - name: Apply release label
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          script: |
+            const { owner, repo } = context.repo;
+            const prNumber = context.payload.pull_request.number;
+
+            const { data: pr } = await github.rest.pulls.get({
+              owner,
+              repo,
+              pull_number: prNumber,
+            });
+            const prBody = pr.body || '';
+
+            const match = prBody.match(/^Release:\s*(rhoai-\d+\.\d+(?:ea\d+)?)\s*$/m);
+            if (!match) {
+              console.log('No release target found in PR description');
+              return;
+            }
+
+            const targetLabel = match[1];
+            console.log(`Found release target: ${targetLabel}`);
+
+            const { data: labels } = await github.rest.issues.listLabelsOnIssue({
+              owner,
+              repo,
+              issue_number: prNumber,
+            });
+
+            const isReleaseLabel = name =>
+              /^rhoai-\d+\.\d+(?:ea\d+)?$/.test(name);
+
+            const staleLabels = labels.filter(
+              l => isReleaseLabel(l.name) && l.name !== targetLabel
+            );
+            for (const label of staleLabels) {
+              console.log(`Removing stale label: ${label.name}`);
+              await github.rest.issues.removeLabel({
+                owner,
+                repo,
+                issue_number: prNumber,
+                name: label.name,
+              });
+            }
+
+            const alreadyApplied = labels.some(l => l.name === targetLabel);
+            if (alreadyApplied) {
+              console.log(`Label ${targetLabel} already applied`);
+              return;
+            }
+
+            try {
+              await github.rest.issues.addLabels({
+                owner,
+                repo,
+                issue_number: prNumber,
+                labels: [targetLabel],
+              });
+              console.log(`Applied label: ${targetLabel}`);
+            } catch (error) {
+              if (error.status === 404) {
+                console.log(`Label "${targetLabel}" does not exist in the repository. A maintainer needs to create it first.`);
+                core.warning(`Label "${targetLabel}" does not exist in the repository. A maintainer needs to create it first.`);
+              } else {
+                throw error;
+              }
+            }

--- a/.github/workflows/pr-requirements-check.yaml
+++ b/.github/workflows/pr-requirements-check.yaml
@@ -1,0 +1,90 @@
+name: Check PR release label and JIRA link
+on:
+  pull_request:
+    types: [opened, edited, labeled, unlabeled, synchronize]
+
+jobs:
+  check-pr-requirements:
+    name: Validate release label and JIRA link
+    permissions:
+      pull-requests: read
+    if: >-
+      github.event.pull_request.user.login != 'odh-release-bot[bot]' &&
+      github.event.pull_request.user.login != 'dependabot[bot]' &&
+      github.event.pull_request.user.login != 'openshift-merge-bot[bot]' &&
+      github.event.pull_request.user.login != 'red-hat-konflux[bot]' &&
+      github.head_ref != 'sync/upgrade-manifest-shas'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate PR requirements
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const prNumber = context.payload.pull_request.number;
+
+            const { data: pr } = await github.rest.pulls.get({
+              owner,
+              repo,
+              pull_number: prNumber,
+            });
+
+            const prBody = pr.body || '';
+            const errors = [];
+
+            // Check for release label
+            const { data: labels } = await github.rest.issues.listLabelsOnIssue({
+              owner,
+              repo,
+              issue_number: prNumber,
+            });
+
+            const hasReleaseLabel = labels.some(l => /^rhoai-\d+\.\d+(ea\d+)?$/.test(l.name));
+            if (!hasReleaseLabel) {
+              errors.push({
+                title: 'Missing release label',
+                detail: [
+                  'Every PR must have a release label (e.g., `rhoai-3.6`, `rhoai-3.7ea1`).',
+                  '',
+                  '**How to fix:**',
+                  '1. Edit the PR description and set the `Release:` field to your target release',
+                  '   (e.g., `Release: rhoai-3.6`). A CI workflow will apply the label automatically.',
+                  '2. Or ask a maintainer to add the label manually.',
+                ].join('\n'),
+              });
+            }
+
+            // Check for JIRA URL
+            const hasJiraUrl = /https:\/\/redhat\.atlassian\.net\/browse\/[A-Z]+-\d+/.test(prBody);
+            if (!hasJiraUrl) {
+              errors.push({
+                title: 'Missing JIRA link',
+                detail: [
+                  'Every PR must include a JIRA ticket URL in the description.',
+                  '',
+                  '**How to fix:**',
+                  'Edit the PR description and fill in the `Jira:` field with a valid JIRA URL, e.g.:',
+                  '`Jira: https://redhat.atlassian.net/browse/RHOAIENG-12345`',
+                ].join('\n'),
+              });
+            }
+
+            // Report results
+            if (errors.length > 0) {
+              let summary = '## ❌ PR Requirements Check Failed\n\n';
+              for (const err of errors) {
+                summary += `### ${err.title}\n\n${err.detail}\n\n`;
+              }
+              summary += '---\n';
+              summary += '*This check is required before merge. Bot PRs and automated branches are exempt.*\n';
+
+              await core.summary.addRaw(summary).write();
+              core.setFailed(`Missing: ${errors.map(e => e.title).join(', ')}`);
+            } else {
+              let summary = '## ✅ PR Requirements Check Passed\n\n';
+              summary += `- Release label: \`${labels.find(l => /^rhoai-\d+\.\d+(ea\d+)?$/.test(l.name)).name}\`\n`;
+              summary += '- JIRA link: found\n';
+
+              await core.summary.addRaw(summary).write();
+              console.log('All PR requirements met');
+            }


### PR DESCRIPTION
## Description
Add two GitHub Actions workflows and update the PR template to enforce release tracking on every PR:

- pr-release-label.yaml: auto-applies release label from the Release field in the PR description (e.g., rhoai-3.6, rhoai-3.7ea1)
- pr-requirements-check.yaml: blocks merge if release label or JIRA URL is missing from the PR

Bot PRs and the sync/upgrade-manifest-shas branch are exempt.

Release: rhoai-3.6ea1
Jira: https://redhat.atlassian.net/browse/RHOAIENG-80092

<!---
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->
<!--- Describe your changes in detail -->

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully
- [ ] New RELATED_IMAGE mappings are listed in ODH-Build-Config and RHOAI-Build-Config (CI validates names against build-config repos). Include links to build-config PRs in the description.

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [ ] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Pull requests now automatically receive release labels based on the declared target release.
  - Added validation to ensure pull requests include a matching release label and valid Red Hat JIRA link.
  - Added clear status reporting when required release information is missing or incomplete.

- **Documentation**
  - Updated the pull request template with mandatory release-tracking fields and review guidance.
  - Added instructions for providing release targets, JIRA links, and appropriate review requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->