### PR TITLE
RHOAIENG-61378 - Test retry mode doesn't work for e2e tests container…

### DIFF
--- a/cmd/test-retry/pkg/parser/parser.go
+++ b/cmd/test-retry/pkg/parser/parser.go
@@ -127,12 +127,8 @@ func ParseGoTestJSON(cfg ParseConfig) (*types.TestResult, error) {
 		return nil, fmt.Errorf("error scanning test output: %w", err)
 	}
 
-	// Stderr from the test binary (captured as execution.Errors()) is non-fatal.
-	// When tests run via --command (e.g. container image e2e), the binary
-	// routinely writes diagnostics to stderr.  Treating these as fatal would
-	// block the retry logic, which is the whole purpose of test-retry.
-	if errs := execution.Errors(); len(errs) > 0 {
-		fmt.Fprintf(os.Stderr, "Warning: stderr output from test execution (non-fatal): %d entries (details redacted)\n", len(errs))
+	if len(execution.Errors()) > 0 {
+		return nil, fmt.Errorf("errors found in execution: %v", execution.Errors())
 	}
 
 	testResult := &types.TestResult{

--- a/cmd/test-retry/pkg/parser/parser_test.go
+++ b/cmd/test-retry/pkg/parser/parser_test.go
@@ -79,15 +79,11 @@ func TestParseGoTestJSON(t *testing.T) {
 	}
 }
 
-func TestParseGoTestJSON_StderrDoesNotCauseError(t *testing.T) {
+func TestParseGoTestJSON_StderrCausesError(t *testing.T) {
 	tests := []struct {
-		name       string
-		stdout     string
-		stderr     string
-		wantErr    bool
-		wantPassed int
-		wantFailed int
-		failedName string
+		name   string
+		stdout string
+		stderr string
 	}{
 		{
 			name: "stderr with failing test",
@@ -96,9 +92,7 @@ func TestParseGoTestJSON_StderrDoesNotCauseError(t *testing.T) {
 {"Time":"2023-01-01T00:00:02Z","Action":"output","Package":"example.com/pkg","Test":"TestFailing","Output":"    failing_test.go:10: assertion failed\n"}
 {"Time":"2023-01-01T00:00:02Z","Action":"output","Package":"example.com/pkg","Test":"TestFailing","Output":"--- FAIL: TestFailing (0.50s)\n"}
 {"Time":"2023-01-01T00:00:02Z","Action":"fail","Package":"example.com/pkg","Test":"TestFailing","Elapsed":0.5}`,
-			stderr:     "panic: some diagnostic output\ngoroutine 1 [running]:\n",
-			wantFailed: 1,
-			failedName: "TestFailing",
+			stderr: "panic: some diagnostic output\ngoroutine 1 [running]:\n",
 		},
 		{
 			name: "stderr with passing test",
@@ -106,8 +100,7 @@ func TestParseGoTestJSON_StderrDoesNotCauseError(t *testing.T) {
 {"Time":"2023-01-01T00:00:01Z","Action":"output","Package":"example.com/pkg","Test":"TestPassing","Output":"=== RUN   TestPassing\n"}
 {"Time":"2023-01-01T00:00:02Z","Action":"output","Package":"example.com/pkg","Test":"TestPassing","Output":"--- PASS: TestPassing (1.00s)\n"}
 {"Time":"2023-01-01T00:00:02Z","Action":"pass","Package":"example.com/pkg","Test":"TestPassing","Elapsed":1.0}`,
-			stderr:     "level=warning msg=\"some library warning\"\n",
-			wantPassed: 1,
+			stderr: "level=warning msg=\"some library warning\"\n",
 		},
 		{
 			name: "large stderr payload",
@@ -115,8 +108,7 @@ func TestParseGoTestJSON_StderrDoesNotCauseError(t *testing.T) {
 {"Time":"2023-01-01T00:00:01Z","Action":"output","Package":"example.com/pkg","Test":"TestOk","Output":"=== RUN   TestOk\n"}
 {"Time":"2023-01-01T00:00:02Z","Action":"output","Package":"example.com/pkg","Test":"TestOk","Output":"--- PASS: TestOk (1.00s)\n"}
 {"Time":"2023-01-01T00:00:02Z","Action":"pass","Package":"example.com/pkg","Test":"TestOk","Elapsed":1.0}`,
-			stderr:     strings.Repeat("stderr line\n", 500),
-			wantPassed: 1,
+			stderr: strings.Repeat("stderr line\n", 500),
 		},
 	}
 
@@ -127,19 +119,8 @@ func TestParseGoTestJSON_StderrDoesNotCauseError(t *testing.T) {
 				Stderr: bytes.NewBuffer([]byte(tt.stderr)),
 			})
 
-			if tt.wantErr {
-				require.Error(t, err)
-				return
-			}
-
-			require.NoError(t, err, "stderr output from test binary should not cause a parse error")
-			require.NotNil(t, result)
-			require.Len(t, result.PassedTest, tt.wantPassed)
-			require.Len(t, result.FailedTest, tt.wantFailed)
-
-			if tt.failedName != "" {
-				require.Equal(t, tt.failedName, result.FailedTest[0].Name)
-			}
+			require.Error(t, err, "stderr output from test binary should cause a parse error")
+			require.Nil(t, result)
 		})
 	}
 }

--- a/tests/e2e/controller_test.go
+++ b/tests/e2e/controller_test.go
@@ -3,6 +3,7 @@ package e2e_test
 import (
 	"flag"
 	"fmt"
+	"log"
 	"maps"
 	"os"
 	"slices"
@@ -24,7 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
-	"sigs.k8s.io/controller-runtime/pkg/log"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/api/components/v1alpha1"
@@ -395,7 +396,8 @@ func TestOdhOperator(t *testing.T) {
 
 	registerSchemes()
 
-	log.SetLogger(zap.New(zap.UseDevMode(true)))
+	logf.SetLogger(zap.New(zap.UseDevMode(true), zap.WriteTo(os.Stdout)))
+	log.SetOutput(os.Stdout) // Used for cluster diagnostics output
 
 	if deadline, ok := t.Deadline(); ok {
 		remaining := time.Until(deadline)

--- a/tests/e2e/controller_test.go
+++ b/tests/e2e/controller_test.go
@@ -3,6 +3,7 @@ package e2e_test
 import (
 	"flag"
 	"fmt"
+	"log"
 	"maps"
 	"os"
 	"slices"
@@ -24,7 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
-	"sigs.k8s.io/controller-runtime/pkg/log"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/api/components/v1alpha1"
@@ -399,7 +400,8 @@ func TestOdhOperator(t *testing.T) {
 
 	registerSchemes()
 
-	log.SetLogger(zap.New(zap.UseDevMode(true)))
+	logf.SetLogger(zap.New(zap.UseDevMode(true)))
+	log.SetOutput(os.Stdout) // Used for cluster diagnostics output
 
 	if deadline, ok := t.Deadline(); ok {
 		remaining := time.Until(deadline)


### PR DESCRIPTION
… image

<!---
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
test-retry's container-image e2e mode (--command) intermittently reported spurious "errors found in execution" / silently masked real failures, because of how stderr is wired differently between the two ways test-retry can invoke tests:

  - **go test -json mode:** the go tool execs the test binary with `cmd.Stdout = cmd.Stderr = <test2json converter>` (cmd/go/internal/test/test.go), so anything the binary writes to stderr is folded into the same ordered JSON stream test-retry reads from stdout. test-retry's own cmd.StderrPipe() in this mode only ever sees go-tool-level errors (e.g. build failures), which is essentially always empty.
  - **--command mode (precompiled e2e binary, e.g. container image tests):** there is no go test wrapper, so test-retry pipes the binary's stdout through go tool test2json for JSON conversion, and pipes its real, distinct stderr directly into the parser (cmd/test-retry/pkg/parser/parser.go). Any content written to that stderr is picked up by gotest.tools/gotestsum/testjson.ScanTestOutput, which appends every non-blank, non-go:/warning:-prefixed stderr line to execution.Errors() — it has no notion of "expected diagnostic noise" vs. "real failure."

  The e2e suite's cluster-diagnostics helpers (tests/e2e/debug_utils_test.go, e.g. HandleGlobalPanic, runDiagnosticsAndClassify, logReport) log via Go's standard library log package (log.Printf), which defaults to os.Stderr (src/log/log.go: var std = New(os.Stderr, "", LstdFlags)). Under --command mode, this routine diagnostic output (cluster health reports, panic-handler traces, etc.) lands directly on the real stderr stream test-retry scans, was misclassified as an "execution error," and previously required a blanket Warning: ... (non-fatal) downgrade in parser.go — which had the side effect of also swallowing genuine stderr failures (real panics, data races) as non-fatal.

  Fix:
  1. `tests/e2e/controller_test.go:` redirect the standard-library log package's output to os.Stdout (`log.SetOutput(os.Stdout)`), since it's used exclusively for routine cluster-diagnostics output, not error signaling. Renamed the controller-runtime log import to logf to disambiguate it from the standard log package now used directly in this file.
  2. `cmd/test-retry/pkg/parser/parser.go:` now that diagnostics no longer pollute stderr, remove the blanket non-fatal downgrade — any content on `execution.Errors()` now correctly fails parsing (`return nil, fmt.Errorf("errors found in execution: %v", ...)`), so real stderr-only failures (panics,  races) are no longer masked.


## How Has This Been Tested?
  - Unit tests in cmd/test-retry/pkg/parser/parser_test.go updated and passing (TestParseGoTestJSON_StderrCausesError).
  - Verified locally that container-image e2e runs no longer emit spurious stderr-based failures from routine cluster-diagnostics logging, while genuine stderr-only failures are now correctly surfaced.

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [x] The developer has run the integration test pipeline and verified that it passed successfully
- [x] New RELATED_IMAGE mappings are listed in ODH-Build-Config and RHOAI-Build-Config (CI validates names against build-config repos). Include links to build-config PRs in the description.

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
Not needed because it doesn't touch the operator code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Test result parsing now stops and reports an error when test execution produces stderr output, preventing potentially incomplete or misleading results.
  * End-to-end test logging is now routed consistently to improve visibility during test runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->