### PR TITLE
fix(dashboard): project observability config from DSCI into Dashboard CR

### DIFF
--- a/internal/controller/modules/dashboard/handler.go
+++ b/internal/controller/modules/dashboard/handler.go
@@ -19,6 +19,9 @@ const (
 	moduleName = componentApi.DashboardComponentName
 	// crName must match dashboard-operator CRD CEL (default-dashboard); see odh-dashboard#8093.
 	crName = componentApi.DashboardInstanceName
+
+	defaultPersesServiceName = "data-science-perses"
+	defaultPersesServicePort = 8080
 )
 
 type handler struct {
@@ -89,6 +92,19 @@ func (h *handler) BuildModuleCR(
 	if platform.GatewayDomain != "" {
 		spec["gateway"] = map[string]any{
 			"domain": platform.GatewayDomain,
+		}
+	}
+
+	if platform.DSCI != nil &&
+		platform.DSCI.Spec.Monitoring.ManagementState == operatorv1.Managed &&
+		platform.MonitoringNamespace != "" {
+		spec["observability"] = map[string]any{
+			"enabled": true,
+			"persesService": map[string]any{
+				"name":      defaultPersesServiceName,
+				"namespace": platform.MonitoringNamespace,
+				"port":      int64(defaultPersesServicePort),
+			},
 		}
 	}
 

--- a/internal/controller/modules/dashboard/handler_test.go
+++ b/internal/controller/modules/dashboard/handler_test.go
@@ -308,7 +308,7 @@ func TestBuildModuleCR_ProjectsObservabilityWhenMonitoringManaged(t *testing.T) 
 
 	obs, ok := spec["observability"].(map[string]any)
 	g.Expect(ok).Should(BeTrue(), "spec.observability should be present")
-	g.Expect(obs["enabled"]).Should(Equal(true))
+	g.Expect(obs["enabled"]).Should(BeTrue())
 
 	ps, ok := obs["persesService"].(map[string]any)
 	g.Expect(ok).Should(BeTrue(), "spec.observability.persesService should be present")

--- a/internal/controller/modules/dashboard/handler_test.go
+++ b/internal/controller/modules/dashboard/handler_test.go
@@ -10,6 +10,8 @@ import (
 	"github.com/opendatahub-io/opendatahub-operator/v2/api/common"
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/api/components/v1alpha1"
 	dscv2 "github.com/opendatahub-io/opendatahub-operator/v2/api/datasciencecluster/v2"
+	dsciv2 "github.com/opendatahub-io/opendatahub-operator/v2/api/dscinitialization/v2"
+	serviceApi "github.com/opendatahub-io/opendatahub-operator/v2/api/services/v1alpha1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/modules"
 	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/modules/dashboard"
 
@@ -273,4 +275,83 @@ func TestGetRelatedImages(t *testing.T) {
 		"RELATED_IMAGE_ODH_CORE_BFF_IMAGE",
 		"RELATED_IMAGE_POSTGRESQL_16_IMAGE",
 	))
+}
+
+func newPlatformCtxWithDSCI(mgmtState, monitoringState operatorv1.ManagementState, monitoringNS string) *modules.PlatformContext {
+	ctx := newPlatformCtx(mgmtState)
+	ctx.MonitoringNamespace = monitoringNS
+	ctx.DSCI = &dsciv2.DSCInitialization{
+		Spec: dsciv2.DSCInitializationSpec{
+			Monitoring: serviceApi.DSCIMonitoring{
+				ManagementSpec: common.ManagementSpec{
+					ManagementState: monitoringState,
+				},
+				MonitoringCommonSpec: serviceApi.MonitoringCommonSpec{
+					Namespace: monitoringNS,
+				},
+			},
+		},
+	}
+	return ctx
+}
+
+func TestBuildModuleCR_ProjectsObservabilityWhenMonitoringManaged(t *testing.T) {
+	g := NewWithT(t)
+	h := dashboard.NewHandler()
+	platform := newPlatformCtxWithDSCI(operatorv1.Managed, operatorv1.Managed, "redhat-ods-monitoring")
+
+	u, err := h.BuildModuleCR(context.Background(), nil, platform)
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	spec, ok := u.Object["spec"].(map[string]any)
+	g.Expect(ok).Should(BeTrue())
+
+	obs, ok := spec["observability"].(map[string]any)
+	g.Expect(ok).Should(BeTrue(), "spec.observability should be present")
+	g.Expect(obs["enabled"]).Should(Equal(true))
+
+	ps, ok := obs["persesService"].(map[string]any)
+	g.Expect(ok).Should(BeTrue(), "spec.observability.persesService should be present")
+	g.Expect(ps["name"]).Should(Equal("data-science-perses"))
+	g.Expect(ps["namespace"]).Should(Equal("redhat-ods-monitoring"))
+	g.Expect(ps["port"]).Should(Equal(int64(8080)))
+}
+
+func TestBuildModuleCR_OmitsObservabilityWhenDSCIIsNil(t *testing.T) {
+	g := NewWithT(t)
+	h := dashboard.NewHandler()
+	platform := newPlatformCtx(operatorv1.Managed)
+
+	u, err := h.BuildModuleCR(context.Background(), nil, platform)
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	spec, ok := u.Object["spec"].(map[string]any)
+	g.Expect(ok).Should(BeTrue())
+	g.Expect(spec).ShouldNot(HaveKey("observability"))
+}
+
+func TestBuildModuleCR_OmitsObservabilityWhenMonitoringRemoved(t *testing.T) {
+	g := NewWithT(t)
+	h := dashboard.NewHandler()
+	platform := newPlatformCtxWithDSCI(operatorv1.Managed, operatorv1.Removed, "redhat-ods-monitoring")
+
+	u, err := h.BuildModuleCR(context.Background(), nil, platform)
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	spec, ok := u.Object["spec"].(map[string]any)
+	g.Expect(ok).Should(BeTrue())
+	g.Expect(spec).ShouldNot(HaveKey("observability"))
+}
+
+func TestBuildModuleCR_OmitsObservabilityWhenMonitoringNamespaceEmpty(t *testing.T) {
+	g := NewWithT(t)
+	h := dashboard.NewHandler()
+	platform := newPlatformCtxWithDSCI(operatorv1.Managed, operatorv1.Managed, "")
+
+	u, err := h.BuildModuleCR(context.Background(), nil, platform)
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	spec, ok := u.Object["spec"].(map[string]any)
+	g.Expect(ok).Should(BeTrue())
+	g.Expect(spec).ShouldNot(HaveKey("observability"))
 }


### PR DESCRIPTION
## Description

https://redhat.atlassian.net/browse/RHOAIENG-87523
Follow-up to [RHOAIENG-80354](https://redhat.atlassian.net/browse/RHOAIENG-80354)

When DSCI monitoring is `Managed` and a monitoring namespace is configured, the Dashboard handler's `BuildModuleCR` now projects observability settings into the Dashboard module CR's `spec.observability`. This enables the dashboard-operator to configure the Perses proxy without having to read DSCI directly — following the modularization best practice that module operators should only read from their own CR spec.

### What changed

**`internal/controller/modules/dashboard/handler.go`**:
- Added constants `defaultPersesServiceName` ("data-science-perses") and `defaultPersesServicePort` (8080)
- In `BuildModuleCR`, after the gateway block: if `platform.DSCI.Spec.Monitoring.ManagementState == Managed` and `platform.MonitoringNamespace != ""`, sets `spec.observability` with `enabled: true` and the Perses service target

**`internal/controller/modules/dashboard/handler_test.go`**:
- Added `newPlatformCtxWithDSCI` helper
- 4 new tests: projects observability when monitoring is Managed, omits when DSCI is nil, omits when monitoring is Removed, omits when namespace is empty

### Context

Without this change, the Perses observability proxy is never configured on RHOAI deployments because nothing sets `spec.observability` on the Dashboard CR. The dashboard-operator relies on this field to set up the Perses proxy route in the federation ConfigMap.

Companion PR: opendatahub-io/odh-dashboard#9078

Ref: [RHOAIENG-87523](https://redhat.atlassian.net/browse/RHOAIENG-87523)
Original bug: [RHOAIENG-80354](https://redhat.atlassian.net/browse/RHOAIENG-80354)

[RHOAIENG-87523]: https://redhat.atlassian.net/browse/RHOAIENG-87523
[RHOAIENG-80354]: https://redhat.atlassian.net/browse/RHOAIENG-80354

## How Has This Been Tested?

- Unit tests added covering all branches: monitoring Managed with namespace, DSCI nil, monitoring Removed, empty namespace
- Verified the generated CR includes `spec.observability` with correct values when monitoring is Managed

## Merge criteria

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully
- [ ] New RELATED_IMAGE mappings are listed in ODH-Build-Config and RHOAI-Build-Config (CI validates names against build-config repos). Include links to build-config PRs in the description.

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification

This change only projects existing DSCI monitoring configuration into the Dashboard module CR spec — it is a data-mapping change with no new operator behavior, reconciliation logic, or resource lifecycle changes. The logic is fully covered by 4 new unit tests exercising all branches. No existing E2E scenarios are affected since the observability field was previously unset and the downstream dashboard-operator consuming it is tested separately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dashboard configurations now include observability settings when managed monitoring is enabled and a monitoring namespace is available.
  * Observability settings include the monitoring service name, namespace, and port.

* **Bug Fixes**
  * Prevented observability settings from being added when monitoring is unavailable, removed, or lacks a monitoring namespace.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->