### PR TITLE
[superseded] feat(kserve): add EnableAuditLogging field to DSC CR kserve component

### DIFF
--- a/api/components/v1alpha1/kserve_types.go
+++ b/api/components/v1alpha1/kserve_types.go
@@ -93,6 +93,12 @@ type KserveCommonSpec struct {
 	// Enabled by default.
 	// +optional
 	EnableLLMInferenceServiceConsoleDashboards *bool `json:"enableLLMInferenceServiceConsoleDashboards,omitempty"`
+	// Enables audit logging for KServe inference requests.
+	// When enabled, the operator sets the audit logging default in the
+	// inferenceservice-config ConfigMap so all InferenceService deployments
+	// emit audit logs. Disabled by default.
+	// +optional
+	EnableAuditLogging *bool `json:"enableAuditLogging,omitempty"`
 	// Configures and enables Model Cache integration
 	ModelCache *ModelCacheSpec `json:"modelCache,omitempty"`
 }

--- a/api/components/v1alpha1/zz_generated.deepcopy.go
+++ b/api/components/v1alpha1/zz_generated.deepcopy.go
@@ -1084,6 +1084,11 @@ func (in *KserveCommonSpec) DeepCopyInto(out *KserveCommonSpec) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.EnableAuditLogging != nil {
+		in, out := &in.EnableAuditLogging, &out.EnableAuditLogging
+		*out = new(bool)
+		**out = **in
+	}
 	if in.ModelCache != nil {
 		in, out := &in.ModelCache, &out.ModelCache
 		*out = new(ModelCacheSpec)

--- a/api/datasciencecluster/v1/datasciencecluster_conversion_test.go
+++ b/api/datasciencecluster/v1/datasciencecluster_conversion_test.go
@@ -528,3 +528,32 @@ func TestConvertTo_CorruptStashAnnotationDoesNotLeak(t *testing.T) {
 	// Annotation must not leak onto the v2 object even though unmarshal failed
 	g.Expect(v2DSC.GetAnnotations()).NotTo(HaveKey("conversion.opendatahub.io/aigateway-state"))
 }
+
+func TestConvertRoundTrip_EnableAuditLogging(t *testing.T) {
+	g := NewWithT(t)
+
+	enabled := true
+	v2Original := &dscv2.DataScienceCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-dsc"},
+		Spec: dscv2.DataScienceClusterSpec{
+			Components: dscv2.Components{
+				Kserve: componentApi.DSCKserve{
+					ManagementSpec: common.ManagementSpec{ManagementState: operatorv1.Managed},
+					KserveCommonSpec: componentApi.KserveCommonSpec{
+						EnableAuditLogging: &enabled,
+					},
+				},
+			},
+		},
+	}
+
+	v1DSC := &DataScienceCluster{}
+	g.Expect(v1DSC.ConvertFrom(v2Original)).To(Succeed())
+	g.Expect(v1DSC.Spec.Components.Kserve.EnableAuditLogging).ToNot(BeNil())
+	g.Expect(*v1DSC.Spec.Components.Kserve.EnableAuditLogging).To(BeTrue())
+
+	v2RoundTripped := &dscv2.DataScienceCluster{}
+	g.Expect(v1DSC.ConvertTo(v2RoundTripped)).To(Succeed())
+	g.Expect(v2RoundTripped.Spec.Components.Kserve.EnableAuditLogging).ToNot(BeNil())
+	g.Expect(*v2RoundTripped.Spec.Components.Kserve.EnableAuditLogging).To(BeTrue())
+}

--- a/api/datasciencecluster/v1/datasciencecluster_conversion_test.go
+++ b/api/datasciencecluster/v1/datasciencecluster_conversion_test.go
@@ -530,30 +530,53 @@ func TestConvertTo_CorruptStashAnnotationDoesNotLeak(t *testing.T) {
 }
 
 func TestConvertRoundTrip_EnableAuditLogging(t *testing.T) {
-	g := NewWithT(t)
+	trueVal := true
+	falseVal := false
 
-	enabled := true
-	v2Original := &dscv2.DataScienceCluster{
-		ObjectMeta: metav1.ObjectMeta{Name: "test-dsc"},
-		Spec: dscv2.DataScienceClusterSpec{
-			Components: dscv2.Components{
-				Kserve: componentApi.DSCKserve{
-					ManagementSpec: common.ManagementSpec{ManagementState: operatorv1.Managed},
-					KserveCommonSpec: componentApi.KserveCommonSpec{
-						EnableAuditLogging: &enabled,
-					},
-				},
-			},
-		},
+	cases := []struct {
+		name     string
+		input    *bool
+		wantNil  bool
+		wantVal  bool
+	}{
+		{name: "enabled", input: &trueVal, wantNil: false, wantVal: true},
+		{name: "disabled", input: &falseVal, wantNil: false, wantVal: false},
+		{name: "nil", input: nil, wantNil: true},
 	}
 
-	v1DSC := &DataScienceCluster{}
-	g.Expect(v1DSC.ConvertFrom(v2Original)).To(Succeed())
-	g.Expect(v1DSC.Spec.Components.Kserve.EnableAuditLogging).ToNot(BeNil())
-	g.Expect(*v1DSC.Spec.Components.Kserve.EnableAuditLogging).To(BeTrue())
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
 
-	v2RoundTripped := &dscv2.DataScienceCluster{}
-	g.Expect(v1DSC.ConvertTo(v2RoundTripped)).To(Succeed())
-	g.Expect(v2RoundTripped.Spec.Components.Kserve.EnableAuditLogging).ToNot(BeNil())
-	g.Expect(*v2RoundTripped.Spec.Components.Kserve.EnableAuditLogging).To(BeTrue())
+			v2Original := &dscv2.DataScienceCluster{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-dsc"},
+				Spec: dscv2.DataScienceClusterSpec{
+					Components: dscv2.Components{
+						Kserve: componentApi.DSCKserve{
+							ManagementSpec: common.ManagementSpec{ManagementState: operatorv1.Managed},
+							KserveCommonSpec: componentApi.KserveCommonSpec{
+								EnableAuditLogging: tc.input,
+							},
+						},
+					},
+				},
+			}
+
+			v1DSC := &DataScienceCluster{}
+			g.Expect(v1DSC.ConvertFrom(v2Original)).To(Succeed())
+
+			v2RoundTripped := &dscv2.DataScienceCluster{}
+			g.Expect(v1DSC.ConvertTo(v2RoundTripped)).To(Succeed())
+
+			if tc.wantNil {
+				g.Expect(v1DSC.Spec.Components.Kserve.EnableAuditLogging).To(BeNil())
+				g.Expect(v2RoundTripped.Spec.Components.Kserve.EnableAuditLogging).To(BeNil())
+			} else {
+				g.Expect(v1DSC.Spec.Components.Kserve.EnableAuditLogging).ToNot(BeNil())
+				g.Expect(*v1DSC.Spec.Components.Kserve.EnableAuditLogging).To(Equal(tc.wantVal))
+				g.Expect(v2RoundTripped.Spec.Components.Kserve.EnableAuditLogging).ToNot(BeNil())
+				g.Expect(*v2RoundTripped.Spec.Components.Kserve.EnableAuditLogging).To(Equal(tc.wantVal))
+			}
+		})
+	}
 }

--- a/docs/api-overview.md
+++ b/docs/api-overview.md
@@ -270,6 +270,7 @@ _Appears in:_
 | `wva` _[WVASpec](#wvaspec)_ | Configures and enables workload-variant-autoscaler (WVA) integration | \{  \} |  |
 | `enableLLMInferenceServiceTLS` _boolean_ | Enables TLS for LLMInferenceService deployments.<br />When unset, the KServe default (TLS enabled) is preserved. |  |  |
 | `enableLLMInferenceServiceConsoleDashboards` _boolean_ | Enables OpenShift Developer Console dashboards for LLMInferenceService.<br />Enabled by default. |  |  |
+| `enableAuditLogging` _boolean_ | Enables audit logging for KServe inference requests.<br />When enabled, the operator sets the audit logging default in the<br />inferenceservice-config ConfigMap so all InferenceService deployments<br />emit audit logs. Disabled by default. |  |  |
 | `modelCache` _[ModelCacheSpec](#modelcachespec)_ | Configures and enables Model Cache integration |  |  |
 
 
@@ -888,6 +889,7 @@ _Appears in:_
 | `wva` _[WVASpec](#wvaspec)_ | Configures and enables workload-variant-autoscaler (WVA) integration | \{  \} |  |
 | `enableLLMInferenceServiceTLS` _boolean_ | Enables TLS for LLMInferenceService deployments.<br />When unset, the KServe default (TLS enabled) is preserved. |  |  |
 | `enableLLMInferenceServiceConsoleDashboards` _boolean_ | Enables OpenShift Developer Console dashboards for LLMInferenceService.<br />Enabled by default. |  |  |
+| `enableAuditLogging` _boolean_ | Enables audit logging for KServe inference requests.<br />When enabled, the operator sets the audit logging default in the<br />inferenceservice-config ConfigMap so all InferenceService deployments<br />emit audit logs. Disabled by default. |  |  |
 | `modelCache` _[ModelCacheSpec](#modelcachespec)_ | Configures and enables Model Cache integration |  |  |
 
 

--- a/internal/controller/modules/kserve/handler_test.go
+++ b/internal/controller/modules/kserve/handler_test.go
@@ -172,6 +172,49 @@ func TestBuildModuleCR_HeadedRawServiceConfig(t *testing.T) {
 	g.Expect(spec["rawDeploymentServiceConfig"]).Should(Equal("Headed"))
 }
 
+func TestBuildModuleCR_EnableAuditLogging(t *testing.T) {
+	g := NewWithT(t)
+	h := kserve.NewHandler()
+	platform := newPlatformCtx(operatorv1.Managed)
+	enabled := true
+	platform.DSC.Spec.Components.Kserve.EnableAuditLogging = &enabled
+
+	u, err := h.BuildModuleCR(context.Background(), nil, platform)
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	spec, ok := u.Object["spec"].(map[string]any)
+	g.Expect(ok).Should(BeTrue())
+	g.Expect(spec["enableAuditLogging"]).Should(BeTrue())
+}
+
+func TestBuildModuleCR_EnableAuditLogging_Disabled(t *testing.T) {
+	g := NewWithT(t)
+	h := kserve.NewHandler()
+	platform := newPlatformCtx(operatorv1.Managed)
+	disabled := false
+	platform.DSC.Spec.Components.Kserve.EnableAuditLogging = &disabled
+
+	u, err := h.BuildModuleCR(context.Background(), nil, platform)
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	spec, ok := u.Object["spec"].(map[string]any)
+	g.Expect(ok).Should(BeTrue())
+	g.Expect(spec["enableAuditLogging"]).Should(BeFalse())
+}
+
+func TestBuildModuleCR_EnableAuditLogging_Nil(t *testing.T) {
+	g := NewWithT(t)
+	h := kserve.NewHandler()
+	platform := newPlatformCtx(operatorv1.Managed)
+
+	u, err := h.BuildModuleCR(context.Background(), nil, platform)
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	spec, ok := u.Object["spec"].(map[string]any)
+	g.Expect(ok).Should(BeTrue())
+	g.Expect(spec).ShouldNot(HaveKey("enableAuditLogging"))
+}
+
 func TestGetRelatedImages(t *testing.T) {
 	g := NewWithT(t)
 	h := kserve.NewHandler()


### PR DESCRIPTION
## Superseded

This PR is **superseded** by [opendatahub-io/kserve#1858](https://github.com/opendatahub-io/kserve/pull/1858).

### Why

On the modular operator path, `BuildModuleCR` only projects DSC `KserveCommonSpec` into the Kserve module CR. It does **not** write `inferenceservice-config`.

The ConfigMap reconciliation for `enableAuditLogging` belongs in **kserve-module** (`KserveSpec` + `updateInferenceCM`), which is implemented in kserve#1858.

Platform control point for this change: `Kserve` module CR (`default-kserve`) `spec.enableAuditLogging`, not a DSC-only field in this PR.

Closing as superseded. Tracking: [RHOAIENG-78541](https://redhat.atlassian.net/browse/RHOAIENG-78541).

---

## Original summary (historical)

- Adds `enableAuditLogging` optional boolean field to `KserveCommonSpec` in the DSC CR kserve component section
- Allows cluster administrators to toggle audit logging as a platform-level default for all InferenceService deployments
- Field flows automatically through `BuildModuleCR` into the kserve module CR for downstream reconciliation into the `inferenceservice-config` ConfigMap
- Disabled by default (nil = no override)

## Jira

[RHOAIENG-78541](https://redhat.atlassian.net/browse/RHOAIENG-78541)

[RHOAIENG-78541]: https://redhat.atlassian.net/browse/RHOAIENG-78541?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RHOAIENG-78541]: https://redhat.atlassian.net/browse/RHOAIENG-78541?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ