### PR TITLE
chore: Exclude more bots from PR requirements

### DIFF
--- a/.github/workflows/pr-release-label.yaml
+++ b/.github/workflows/pr-release-label.yaml
@@ -15,6 +15,8 @@ jobs:
       github.event.pull_request.user.login != 'dependabot[bot]' &&
       github.event.pull_request.user.login != 'openshift-merge-bot[bot]' &&
       github.event.pull_request.user.login != 'red-hat-konflux[bot]' &&
+      github.event.pull_request.user.login != 'github-actions[bot]' &&
+      github.event.pull_request.user.login != 'odh-drs-automation-bot[bot]' &&
       github.head_ref != 'sync/upgrade-manifest-shas'
     permissions:
       pull-requests: write

--- a/.github/workflows/pr-requirements-check.yaml
+++ b/.github/workflows/pr-requirements-check.yaml
@@ -13,6 +13,8 @@ jobs:
       github.event.pull_request.user.login != 'dependabot[bot]' &&
       github.event.pull_request.user.login != 'openshift-merge-bot[bot]' &&
       github.event.pull_request.user.login != 'red-hat-konflux[bot]' &&
+      github.event.pull_request.user.login != 'github-actions[bot]' &&
+      github.event.pull_request.user.login != 'odh-drs-automation-bot[bot]' &&
       github.head_ref != 'sync/upgrade-manifest-shas'
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Description
We already exclude other bot accounts, github-actions was missed originally.



## Release tracking
Release:  rhoai-3.6ea1
Jira: https://redhat.atlassian.net/browse/RHOAIENG-80092


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully
- [ ] New RELATED_IMAGE mappings are listed in ODH-Build-Config and RHOAI-Build-Config (CI validates names against build-config repos). Include links to build-config PRs in the description.

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [ ] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated pull request handling by exempting eligible system-generated pull requests from release-label application.
  * Updated requirements checks to avoid blocking eligible automated pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->