### PR TITLE
feat: auto-sync RELATED_IMAGE digests from ODH-Build-Config CSV

### DIFF
--- a/cmd/manifest-tools/pkg/cli/resolve.go
+++ b/cmd/manifest-tools/pkg/cli/resolve.go
@@ -8,20 +8,23 @@ import (
 
 func newResolveCommand(root *rootOptions) *cobra.Command {
 	var manifestsDir string
+	var csvImportRegistries []string
 
 	cmd := &cobra.Command{
 		Use:   "resolve-digests",
 		Short: "Resolve image digests and update manifests-config.yaml",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			_, err := resolver.Resolve(cmd.Context(), resolver.Options{
-				ConfigFile:   root.configFile,
-				ManifestsDir: manifestsDir,
+				ConfigFile:          root.configFile,
+				ManifestsDir:        manifestsDir,
+				CSVImportRegistries: csvImportRegistries,
 			})
 			return err
 		},
 	}
 
 	cmd.Flags().StringVar(&manifestsDir, "manifests-dir", "opt/manifests", "Downloaded manifests directory")
+	cmd.Flags().StringSliceVar(&csvImportRegistries, "csv-import-registries", []string{"quay.io/"}, "Only import CSV images from these registry prefixes (empty = all)")
 
 	return cmd
 }

--- a/cmd/manifest-tools/pkg/config/config.go
+++ b/cmd/manifest-tools/pkg/config/config.go
@@ -33,6 +33,7 @@ type ImageOverride struct {
 	ParamsEnvKey string         `yaml:"paramsEnvKey,omitempty"`
 	TagTemplate  string         `yaml:"tagTemplate,omitempty"`
 	Base         string         `yaml:"base,omitempty"`
+	Source       string         `yaml:"source,omitempty"`
 	ODH          *PlatformImage `yaml:"odh,omitempty"`
 	RHOAI        *PlatformImage `yaml:"rhoai,omitempty"`
 }
@@ -189,6 +190,57 @@ func (d *NodeDoc) SetImageOverrideField(envName, platform, field, value string) 
 
 	setMapField(platNode, field, value)
 	return nil
+}
+
+// AddImageOverride creates a new entry under imageOverrides with the given platform, base, and digest.
+func (d *NodeDoc) AddImageOverride(envName, platform, base, digest string) error {
+	root := d.Root.Content[0]
+
+	overridesNode := findMapValue(root, "imageOverrides")
+	if overridesNode == nil {
+		return fmt.Errorf("imageOverrides not found")
+	}
+
+	if existing := findMapValue(overridesNode, envName); existing != nil {
+		return fmt.Errorf("imageOverrides.%s already exists", envName)
+	}
+
+	platNode := &yaml.Node{Kind: yaml.MappingNode}
+	setMapField(platNode, "base", base)
+	setMapField(platNode, "digest", digest)
+
+	entryNode := &yaml.Node{Kind: yaml.MappingNode}
+	setMapField(entryNode, "source", "csv")
+	entryNode.Content = append(entryNode.Content,
+		&yaml.Node{Kind: yaml.ScalarNode, Value: platform},
+		platNode,
+	)
+
+	overridesNode.Content = append(overridesNode.Content,
+		&yaml.Node{Kind: yaml.ScalarNode, Value: envName},
+		entryNode,
+	)
+
+	return nil
+}
+
+// RemoveImageOverride removes an entry from imageOverrides by env name.
+func (d *NodeDoc) RemoveImageOverride(envName string) error {
+	root := d.Root.Content[0]
+
+	overridesNode := findMapValue(root, "imageOverrides")
+	if overridesNode == nil {
+		return fmt.Errorf("imageOverrides not found")
+	}
+
+	for i := 0; i < len(overridesNode.Content)-1; i += 2 {
+		if overridesNode.Content[i].Value == envName {
+			overridesNode.Content = append(overridesNode.Content[:i], overridesNode.Content[i+2:]...)
+			return nil
+		}
+	}
+
+	return fmt.Errorf("imageOverrides.%s not found", envName)
 }
 
 // SetComponentRef sets the ref field for a component in a specific section and platform.

--- a/cmd/manifest-tools/pkg/resolver/csv.go
+++ b/cmd/manifest-tools/pkg/resolver/csv.go
@@ -1,0 +1,100 @@
+package resolver
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"strings"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+const csvURL = "https://raw.githubusercontent.com/opendatahub-io/ODH-Build-Config/main/bundle/manifests/rhods-operator.clusterserviceversion.yaml"
+
+type CSVImage struct {
+	Base   string
+	Digest string
+}
+
+func FetchCSVRelatedImages(ctx context.Context) (map[string]CSVImage, error) {
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, csvURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("creating request: %w", err)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("fetching CSV: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("CSV fetch returned %d", resp.StatusCode)
+	}
+
+	const maxCSVBodySize = 50 << 20 // 50 MiB
+	limitedReader := io.LimitReader(resp.Body, maxCSVBodySize+1)
+	body, err := io.ReadAll(limitedReader)
+	if err != nil {
+		return nil, fmt.Errorf("reading CSV body: %w", err)
+	}
+	if int64(len(body)) > maxCSVBodySize {
+		return nil, fmt.Errorf("CSV body exceeds %d bytes", maxCSVBodySize)
+	}
+
+	return ParseCSVRelatedImages(body)
+}
+
+func ParseCSVRelatedImages(data []byte) (map[string]CSVImage, error) {
+	var csv struct {
+		Spec struct {
+			Install struct {
+				Spec struct {
+					Deployments []struct {
+						Spec struct {
+							Template struct {
+								Spec struct {
+									Containers []struct {
+										Env []struct {
+											Name  string `yaml:"name"`
+											Value string `yaml:"value"`
+										} `yaml:"env"`
+									} `yaml:"containers"`
+								} `yaml:"spec"`
+							} `yaml:"template"`
+						} `yaml:"spec"`
+					} `yaml:"deployments"`
+				} `yaml:"spec"`
+			} `yaml:"install"`
+		} `yaml:"spec"`
+	}
+
+	if err := yaml.Unmarshal(data, &csv); err != nil {
+		return nil, fmt.Errorf("parsing CSV YAML: %w", err)
+	}
+
+	images := map[string]CSVImage{}
+	for _, dep := range csv.Spec.Install.Spec.Deployments {
+		for _, container := range dep.Spec.Template.Spec.Containers {
+			for _, env := range container.Env {
+				if !strings.HasPrefix(env.Name, "RELATED_IMAGE_") {
+					continue
+				}
+				base, digest, ok := strings.Cut(env.Value, "@")
+				if !ok || !strings.HasPrefix(digest, "sha256:") {
+					slog.Debug("CSV entry skipped (no digest)", slog.String("env", env.Name))
+					continue
+				}
+				images[env.Name] = CSVImage{Base: base, Digest: digest}
+			}
+		}
+	}
+
+	return images, nil
+}

--- a/cmd/manifest-tools/pkg/resolver/csv_test.go
+++ b/cmd/manifest-tools/pkg/resolver/csv_test.go
@@ -1,0 +1,128 @@
+package resolver_test
+
+import (
+	"testing"
+
+	"github.com/opendatahub-io/opendatahub-operator/v2/cmd/manifest-tools/pkg/resolver"
+)
+
+func TestParseCSVRelatedImages(t *testing.T) {
+	csvYAML := `
+spec:
+  install:
+    spec:
+      deployments:
+      - spec:
+          template:
+            spec:
+              containers:
+              - env:
+                - name: RELATED_IMAGE_ODH_DASHBOARD_IMAGE
+                  value: "quay.io/opendatahub/odh-dashboard@sha256:abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"
+                - name: RELATED_IMAGE_ODH_MODEL_CONTROLLER_IMAGE
+                  value: "quay.io/opendatahub/odh-model-controller@sha256:1111111111111111111111111111111111111111111111111111111111111111"
+                - name: NOT_A_RELATED_IMAGE
+                  value: "should-be-skipped"
+                - name: RELATED_IMAGE_TAGGED_ONLY
+                  value: "quay.io/opendatahub/some-image:latest"
+                - name: OPERATOR_CONDITION_NAME
+                  value: "some-condition"
+`
+
+	images, err := resolver.ParseCSVRelatedImages([]byte(csvYAML))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(images) != 2 {
+		t.Fatalf("expected 2 images, got %d", len(images))
+	}
+
+	dashboard, ok := images["RELATED_IMAGE_ODH_DASHBOARD_IMAGE"]
+	if !ok {
+		t.Fatal("RELATED_IMAGE_ODH_DASHBOARD_IMAGE not found")
+	}
+	if dashboard.Base != "quay.io/opendatahub/odh-dashboard" {
+		t.Errorf("base = %q, want quay.io/opendatahub/odh-dashboard", dashboard.Base)
+	}
+	if dashboard.Digest != "sha256:abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890" {
+		t.Errorf("digest = %q", dashboard.Digest)
+	}
+
+	model, ok := images["RELATED_IMAGE_ODH_MODEL_CONTROLLER_IMAGE"]
+	if !ok {
+		t.Fatal("RELATED_IMAGE_ODH_MODEL_CONTROLLER_IMAGE not found")
+	}
+	if model.Base != "quay.io/opendatahub/odh-model-controller" {
+		t.Errorf("base = %q", model.Base)
+	}
+
+	if _, ok := images["NOT_A_RELATED_IMAGE"]; ok {
+		t.Error("non-RELATED_IMAGE entry should be skipped")
+	}
+	if _, ok := images["RELATED_IMAGE_TAGGED_ONLY"]; ok {
+		t.Error("tagged-only entry (no @sha256:) should be skipped")
+	}
+}
+
+func TestParseCSVRelatedImages_MultipleDeployments(t *testing.T) {
+	csvYAML := `
+spec:
+  install:
+    spec:
+      deployments:
+      - spec:
+          template:
+            spec:
+              containers:
+              - env:
+                - name: RELATED_IMAGE_ODH_FIRST
+                  value: "quay.io/first@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      - spec:
+          template:
+            spec:
+              containers:
+              - env:
+                - name: RELATED_IMAGE_ODH_SECOND
+                  value: "quay.io/second@sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+`
+
+	images, err := resolver.ParseCSVRelatedImages([]byte(csvYAML))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(images) != 2 {
+		t.Fatalf("expected 2 images from 2 deployments, got %d", len(images))
+	}
+	if _, ok := images["RELATED_IMAGE_ODH_FIRST"]; !ok {
+		t.Error("missing RELATED_IMAGE_ODH_FIRST")
+	}
+	if _, ok := images["RELATED_IMAGE_ODH_SECOND"]; !ok {
+		t.Error("missing RELATED_IMAGE_ODH_SECOND")
+	}
+}
+
+func TestParseCSVRelatedImages_EmptySpec(t *testing.T) {
+	csvYAML := `
+spec:
+  install:
+    spec:
+      deployments: []
+`
+
+	images, err := resolver.ParseCSVRelatedImages([]byte(csvYAML))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(images) != 0 {
+		t.Errorf("expected 0 images, got %d", len(images))
+	}
+}
+
+func TestParseCSVRelatedImages_InvalidYAML(t *testing.T) {
+	_, err := resolver.ParseCSVRelatedImages([]byte(`{invalid yaml`))
+	if err == nil {
+		t.Error("expected error for invalid YAML")
+	}
+}

--- a/cmd/manifest-tools/pkg/resolver/resolver.go
+++ b/cmd/manifest-tools/pkg/resolver/resolver.go
@@ -4,8 +4,10 @@ import (
 	"bufio"
 	"context"
 	"fmt"
+	"io/fs"
 	"log/slog"
 	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 
@@ -13,8 +15,9 @@ import (
 )
 
 type Options struct {
-	ConfigFile   string
-	ManifestsDir string
+	ConfigFile          string
+	ManifestsDir        string
+	CSVImportRegistries []string
 }
 
 type Result struct {
@@ -37,6 +40,15 @@ func Resolve(ctx context.Context, opts Options) ([]Result, error) {
 	}
 
 	var results []Result
+	var unresolved []Result
+	var csvStale []string
+
+	csvImages, err := FetchCSVRelatedImages(ctx)
+	if err != nil {
+		slog.Warn("Failed to fetch CSV related images, csv fallback disabled", slog.String("error", err.Error()))
+	} else {
+		slog.Info("Fetched CSV related images", slog.Int("count", len(csvImages)))
+	}
 
 	// Track resolved digests so shaFrom can reference freshly-resolved values
 	type resolvedImage struct {
@@ -62,6 +74,29 @@ func Resolve(ctx context.Context, opts Options) ([]Result, error) {
 	for _, envName := range envNames {
 		override := cfg.ImageOverrides[envName]
 		for _, platform := range []string{"odh", "rhoai"} {
+			// Entries with source: csv are always updated from CSV
+			if override.Source == "csv" {
+				if csvImages != nil {
+					if img, ok := csvImages[envName]; ok && config.DigestPattern.MatchString(img.Digest) {
+						if len(opts.CSVImportRegistries) > 0 && !matchesRegistry(img.Base, opts.CSVImportRegistries) {
+							slog.Info("CSV entry skipped (registry not allowed)", slog.String("env", envName), slog.String("platform", platform))
+							continue
+						}
+						if err := nodeDoc.SetImageOverrideField(envName, platform, "base", img.Base); err != nil {
+							slog.Warn("Failed to set base field", slog.String("error", err.Error()))
+						}
+						if err := nodeDoc.SetImageOverrideField(envName, platform, "digest", img.Digest); err != nil {
+							slog.Warn("Failed to set digest field", slog.String("error", err.Error()))
+						}
+						results = append(results, Result{envName, platform, img.Base, img.Digest, "csv"})
+						slog.Info("Updated from CSV (auto-managed)", slog.String("env", envName), slog.String("platform", platform))
+					} else if platform == "odh" {
+						csvStale = append(csvStale, envName)
+					}
+				}
+				continue
+			}
+
 			comp := cfg.FindComponent(override.Component)
 			if comp == nil {
 				continue
@@ -124,8 +159,8 @@ func Resolve(ctx context.Context, opts Options) ([]Result, error) {
 
 			// Priority 2: params.env
 			if override.ParamsEnvKey != "" && override.Component != "" {
-				paramsFile := fmt.Sprintf("%s/%s/params.env", opts.ManifestsDir, override.Component)
-				if imageRef, err := ReadParamsEnvKey(paramsFile, override.ParamsEnvKey); err == nil && imageRef != "" {
+				componentDir := fmt.Sprintf("%s/%s", opts.ManifestsDir, override.Component)
+				if imageRef, err := FindParamsEnvKey(componentDir, override.ParamsEnvKey); err == nil && imageRef != "" {
 					if strings.Contains(imageRef, "@sha256:") {
 						pBase, pDigest := SplitImageRef(imageRef)
 						if config.DigestPattern.MatchString(pDigest) {
@@ -165,7 +200,28 @@ func Resolve(ctx context.Context, opts Options) ([]Result, error) {
 				}
 			}
 
-			slog.Warn("No source found", slog.String("env", envName), slog.String("platform", platform))
+			slog.Warn("No source found via commit-sha or params.env", slog.String("env", envName), slog.String("platform", platform))
+
+			// Priority 3: ODH-Build-Config CSV
+			if csvImages != nil {
+				if img, ok := csvImages[envName]; ok && config.DigestPattern.MatchString(img.Digest) {
+					if err := nodeDoc.SetImageOverrideField(envName, platform, "base", img.Base); err != nil {
+						slog.Warn("Failed to set base field", slog.String("error", err.Error()))
+					}
+					if err := nodeDoc.SetImageOverrideField(envName, platform, "digest", img.Digest); err != nil {
+						slog.Warn("Failed to set digest field", slog.String("error", err.Error()))
+					}
+					results = append(results, Result{envName, platform, img.Base, img.Digest, "csv"})
+					if resolved[envName] == nil {
+						resolved[envName] = map[string]resolvedImage{}
+					}
+					resolved[envName][platform] = resolvedImage{img.Base, img.Digest}
+					slog.Info("Resolved via CSV", slog.String("env", envName), slog.String("platform", platform), slog.String("base", img.Base), slog.String("digest", img.Digest))
+					continue
+				}
+			}
+
+			unresolved = append(unresolved, Result{envName, platform, "", "", "unresolved"})
 		}
 	}
 
@@ -186,6 +242,7 @@ func Resolve(ctx context.Context, opts Options) ([]Result, error) {
 		}
 		if src.Digest == "" {
 			slog.Warn("shaFrom has no digest available", slog.String("env", entry.envName), slog.String("platform", entry.platform), slog.String("shaFrom", entry.source))
+			unresolved = append(unresolved, Result{entry.envName, entry.platform, "", "", "unresolved"})
 			continue
 		}
 		if err := nodeDoc.SetImageOverrideField(entry.envName, entry.platform, "base", src.Base); err != nil {
@@ -198,32 +255,73 @@ func Resolve(ctx context.Context, opts Options) ([]Result, error) {
 		slog.Info("Copied from shaFrom source", slog.String("env", entry.envName), slog.String("platform", entry.platform), slog.String("source", entry.source))
 	}
 
+	// Third pass: import CSV entries not already in manifests-config
+	if csvImages != nil {
+		csvEnvNames := make([]string, 0, len(csvImages))
+		for envName := range csvImages {
+			csvEnvNames = append(csvEnvNames, envName)
+		}
+		sort.Strings(csvEnvNames)
+
+		for _, envName := range csvEnvNames {
+			if _, exists := cfg.ImageOverrides[envName]; exists {
+				continue
+			}
+			img := csvImages[envName]
+			if !config.DigestPattern.MatchString(img.Digest) {
+				continue
+			}
+			if len(opts.CSVImportRegistries) > 0 && !matchesRegistry(img.Base, opts.CSVImportRegistries) {
+				continue
+			}
+			if err := nodeDoc.AddImageOverride(envName, "odh", img.Base, img.Digest); err != nil {
+				slog.Warn("Failed to add CSV image override", slog.String("env", envName), slog.String("error", err.Error()))
+				continue
+			}
+			results = append(results, Result{envName, "odh", img.Base, img.Digest, "csv-imported"})
+			slog.Info("Imported from CSV", slog.String("env", envName), slog.String("base", img.Base))
+		}
+	}
+
+	// Remove source: csv entries no longer present in CSV
+	for _, envName := range csvStale {
+		if err := nodeDoc.RemoveImageOverride(envName); err != nil {
+			slog.Warn("Failed to remove stale CSV entry", slog.String("env", envName), slog.String("error", err.Error()))
+			continue
+		}
+		slog.Info("Removed stale CSV entry", slog.String("env", envName))
+	}
+
 	if err := nodeDoc.Save(opts.ConfigFile); err != nil {
 		return nil, fmt.Errorf("saving config: %w", err)
 	}
 
 	slog.Info("Digests updated", slog.String("file", opts.ConfigFile))
-	printSummary(results)
+	printSummary(results, unresolved)
 	return results, nil
 }
 
-func printSummary(results []Result) {
+func printSummary(results []Result, unresolved []Result) {
 	const (
 		reset   = "\033[0m"
 		bold    = "\033[1m"
 		green   = "\033[32m"
+		red     = "\033[31m"
 		cyan    = "\033[36m"
 		yellow  = "\033[33m"
 		magenta = "\033[35m"
 		dim     = "\033[2m"
 	)
 
-	sourceOrder := []string{"commit-sha", "params.env", "params.env+registry", "shaFrom"}
+	blue := "\033[34m"
+	sourceOrder := []string{"commit-sha", "params.env", "params.env+registry", "csv", "shaFrom", "csv-imported"}
 	sourceColor := map[string]string{
 		"commit-sha":          green,
 		"params.env":          yellow,
 		"params.env+registry": yellow,
+		"csv":                 cyan,
 		"shaFrom":             magenta,
+		"csv-imported":        blue,
 	}
 
 	grouped := map[string][]Result{}
@@ -249,6 +347,13 @@ func printSummary(results []Result) {
 		}
 	}
 
+	if len(unresolved) > 0 {
+		fmt.Fprintf(os.Stderr, "\n%s%s▸ unresolved%s %s(%d)%s\n", bold, red, reset, dim, len(unresolved), reset)
+		for _, r := range unresolved {
+			fmt.Fprintf(os.Stderr, "  %s%-5s%s %s\n", dim, r.Platform, reset, r.EnvName)
+		}
+	}
+
 	fmt.Fprintf(os.Stderr, "\n%sTotal: %d images resolved%s\n\n", bold, len(results), reset)
 }
 
@@ -258,6 +363,39 @@ func SplitImageRef(ref string) (base, digest string) {
 		return ref, ""
 	}
 	return ref[:idx], ref[idx+1:]
+}
+
+// FindParamsEnvKey searches for params.env files recursively under dir
+// and returns the value for the given key from the first file that contains it.
+func FindParamsEnvKey(dir, key string) (string, error) {
+	var result string
+	err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil || d.IsDir() || d.Name() != "params.env" {
+			return err
+		}
+		val, err := ReadParamsEnvKey(path, key)
+		if err == nil {
+			result = val
+			return filepath.SkipAll
+		}
+		return nil
+	})
+	if result != "" {
+		return result, nil
+	}
+	if err != nil {
+		return "", err
+	}
+	return "", fmt.Errorf("key %q not found in any params.env under %s", key, dir)
+}
+
+func matchesRegistry(imageBase string, registries []string) bool {
+	for _, reg := range registries {
+		if strings.HasPrefix(imageBase, reg) {
+			return true
+		}
+	}
+	return false
 }
 
 func ReadParamsEnvKey(path, key string) (string, error) {

--- a/cmd/manifest-tools/pkg/resolver/resolver_test.go
+++ b/cmd/manifest-tools/pkg/resolver/resolver_test.go
@@ -51,6 +51,62 @@ func TestReadParamsEnvKey_FileNotFound(t *testing.T) {
 	}
 }
 
+func TestFindParamsEnvKey(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create nested structure: component/base/params.env
+	baseDir := filepath.Join(dir, "base")
+	if err := os.MkdirAll(baseDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(baseDir, "params.env"), []byte("MY_KEY=my-value\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create another nested: component/overlays/odh/params.env
+	overlayDir := filepath.Join(dir, "overlays", "odh")
+	if err := os.MkdirAll(overlayDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(overlayDir, "params.env"), []byte("OVERLAY_KEY=overlay-value\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("finds key in subdirectory", func(t *testing.T) {
+		got, err := resolver.FindParamsEnvKey(dir, "MY_KEY")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != "my-value" {
+			t.Errorf("got %q, want %q", got, "my-value")
+		}
+	})
+
+	t.Run("finds key in deeper subdirectory", func(t *testing.T) {
+		got, err := resolver.FindParamsEnvKey(dir, "OVERLAY_KEY")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != "overlay-value" {
+			t.Errorf("got %q, want %q", got, "overlay-value")
+		}
+	})
+
+	t.Run("returns error for missing key", func(t *testing.T) {
+		_, err := resolver.FindParamsEnvKey(dir, "NONEXISTENT")
+		if err == nil {
+			t.Error("expected error for missing key")
+		}
+	})
+
+	t.Run("returns error for missing directory", func(t *testing.T) {
+		_, err := resolver.FindParamsEnvKey("/nonexistent/dir", "KEY")
+		if err == nil {
+			t.Error("expected error for missing directory")
+		}
+	})
+}
+
 func TestSplitImageRef_EdgeCases(t *testing.T) {
 	tests := []struct {
 		ref        string

--- a/manifests-config.yaml
+++ b/manifests-config.yaml
@@ -234,24 +234,6 @@ imageOverrides:
       shaFrom: odh
       base: "quay.io/opendatahub/odh-kserve-localmodel-controller"
       digest: "sha256:a0a257ce64651c84b031fe34d55488692d2448b28134a5c64faaf261b1908660"
-  RELATED_IMAGE_ODH_MODEL_CONTROLLER_IMAGE:
-    component: kserve-module-operator
-    paramsEnvKey: odh-model-controller
-    odh:
-      base: "quay.io/opendatahub/odh-model-controller"
-      digest: "sha256:29bfb975e3d72c06228bc2501e0b1e386611bd94d1b70362226c5642535373fa"
-    rhoai:
-      base: "quay.io/opendatahub/odh-model-controller"
-      digest: "sha256:29bfb975e3d72c06228bc2501e0b1e386611bd94d1b70362226c5642535373fa"
-  RELATED_IMAGE_ODH_WORKLOAD_VARIANT_AUTOSCALER_CONTROLLER_IMAGE:
-    component: kserve-module-operator
-    paramsEnvKey: workload-variant-autoscaler-controller
-    odh:
-      base: "quay.io/opendatahub/workload-variant-autoscaler"
-      digest: "sha256:2211eb4c4da31c2c5718903bfb4555bbab5fab92b3ccf2f9b32dbf959e014629"
-    rhoai:
-      base: "quay.io/opendatahub/workload-variant-autoscaler"
-      digest: "sha256:2211eb4c4da31c2c5718903bfb4555bbab5fab92b3ccf2f9b32dbf959e014629"
   RELATED_IMAGE_ODH_KSERVE_MODULE_OPERATOR_IMAGE:
     component: kserve-module-operator
     tagTemplate: "{SHA}"
@@ -279,23 +261,23 @@ imageOverrides:
     paramsEnvKey: trustyaiOperatorImage
     tagTemplate: "{SHA}"
     odh:
-      base: "quay.io/opendatahub/trustyai-service-operator"
-      digest: "sha256:10c387a4177ffb88581f15bd130cf37a8ac40209b11b5fa672c1c2f4bd5481f8"
+      base: "quay.io/trustyai/trustyai-service-operator"
+      digest: "sha256:2b4adaa22f2e85356f7044fc1546d04a12160ca843ac5e19b0cf99dee5c37b9c"
     rhoai:
       shaFrom: odh
-      base: "quay.io/opendatahub/trustyai-service-operator"
-      digest: "sha256:10c387a4177ffb88581f15bd130cf37a8ac40209b11b5fa672c1c2f4bd5481f8"
+      base: "quay.io/trustyai/trustyai-service-operator"
+      digest: "sha256:2b4adaa22f2e85356f7044fc1546d04a12160ca843ac5e19b0cf99dee5c37b9c"
   RELATED_IMAGE_ODH_MODEL_REGISTRY_OPERATOR_IMAGE:
     component: modelregistry
     paramsEnvKey: IMAGES_MODELREGISTRY_OPERATOR
     tagTemplate: "{SHA}"
     odh:
       base: "quay.io/opendatahub/model-registry-operator"
-      digest: "sha256:041dbeb4374083d26dba4cfb62eda0828e47f060460dc1128f8f647c19391658"
+      digest: "sha256:54d3497ef69c2a2af02150dcc4b7541b420587ca7805fd07a6dcb29cb78d4ea3"
     rhoai:
       shaFrom: odh
       base: "quay.io/opendatahub/model-registry-operator"
-      digest: "sha256:041dbeb4374083d26dba4cfb62eda0828e47f060460dc1128f8f647c19391658"
+      digest: "sha256:54d3497ef69c2a2af02150dcc4b7541b420587ca7805fd07a6dcb29cb78d4ea3"
   RELATED_IMAGE_ODH_TRAINING_OPERATOR_IMAGE:
     component: trainingoperator
     paramsEnvKey: odh-training-operator-controller-image
@@ -313,11 +295,11 @@ imageOverrides:
     tagTemplate: "{SHA}"
     odh:
       base: "quay.io/opendatahub/data-science-pipelines-operator"
-      digest: "sha256:4db7f864ed11d3ea5585b56cb7d7473bf80d8a1dcfc47de343a7a182c805ecdc"
+      digest: "sha256:7d528b11629f692b4ef3928be625f46e9a44fb16999c209f2d98a709db2bb8f1"
     rhoai:
       shaFrom: odh
       base: "quay.io/opendatahub/data-science-pipelines-operator"
-      digest: "sha256:4db7f864ed11d3ea5585b56cb7d7473bf80d8a1dcfc47de343a7a182c805ecdc"
+      digest: "sha256:7d528b11629f692b4ef3928be625f46e9a44fb16999c209f2d98a709db2bb8f1"
   RELATED_IMAGE_ODH_OGX_K8S_OPERATOR_IMAGE:
     component: ogx
     paramsEnvKey: RELATED_IMAGE_ODH_OGX_OPERATOR
@@ -381,14 +363,6 @@ imageOverrides:
       shaFrom: odh
       base: "quay.io/opendatahub/odh-mcp-lifecycle-module-operator"
       digest: "sha256:aeb7ef047105e537ff4b179e86f20ad368e5091fac0e62bb9e8c75ca4bff10ec"
-  RELATED_IMAGE_ODH_MCP_LIFECYCLE_OPERATOR_IMAGE:
-    component: mcplifecycleoperator
-    odh:
-      base: "quay.io/opendatahub/odh-mcp-lifecycle-operator"
-      digest: "sha256:972246b68be40253746a9ae98f56059e9d13a1377343ace454d655139d4b0795"
-    rhoai:
-      base: "quay.io/opendatahub/odh-mcp-lifecycle-operator"
-      digest: "sha256:972246b68be40253746a9ae98f56059e9d13a1377343ace454d655139d4b0795"
   RELATED_IMAGE_ODH_DASHBOARD_OPERATOR_IMAGE:
     component: dashboard-operator
     tagTemplate: "{SHA}"
@@ -429,12 +403,919 @@ imageOverrides:
       shaFrom: odh
       base: "quay.io/opendatahub/odh-feast-module-operator"
       digest: "sha256:2009fdaae670b64e3ec3f7744d7b9d6d738814fe3f33af16c5de98817a24db6e"
+  RELATED_IMAGE_ODH_MCP_LIFECYCLE_OPERATOR_IMAGE:
+    component: mcplifecycleoperator
+    source: "csv"
+    odh:
+      base: "quay.io/opendatahub/odh-mcp-lifecycle-operator"
+      digest: "sha256:a51dd1ae92ff3b1f77ae24522d7e8465f4acec2b709c747b2d1e49d2fc9afd9a"
+    rhoai:
+      base: "quay.io/opendatahub/odh-mcp-lifecycle-operator"
+      digest: "sha256:a51dd1ae92ff3b1f77ae24522d7e8465f4acec2b709c747b2d1e49d2fc9afd9a"
+  RELATED_IMAGE_ODH_MODEL_CONTROLLER_IMAGE:
+    component: kserve-module-operator
+    source: "csv"
+    odh:
+      base: "quay.io/opendatahub/odh-model-controller"
+      digest: "sha256:29bfb975e3d72c06228bc2501e0b1e386611bd94d1b70362226c5642535373fa"
+    rhoai:
+      base: "quay.io/opendatahub/odh-model-controller"
+      digest: "sha256:29bfb975e3d72c06228bc2501e0b1e386611bd94d1b70362226c5642535373fa"
+  RELATED_IMAGE_ODH_WORKLOAD_VARIANT_AUTOSCALER_CONTROLLER_IMAGE:
+    component: kserve-module-operator
+    source: "csv"
+    odh:
+      base: "quay.io/opendatahub/workload-variant-autoscaler"
+      digest: "sha256:642abfca38d8114f391b987dc571cb8d5d4c78d287f5b91d88cd075a770a4459"
+    rhoai:
+      base: "quay.io/opendatahub/workload-variant-autoscaler"
+      digest: "sha256:642abfca38d8114f391b987dc571cb8d5d4c78d287f5b91d88cd075a770a4459"
   RELATED_IMAGE_ODH_FEAST_OPERATOR_IMAGE:
+    source: "csv"
     component: feastoperator
-    paramsEnvKey: RELATED_IMAGE_FEAST_OPERATOR
     odh:
       base: "quay.io/opendatahub/feast-operator"
       digest: "sha256:f59bf3783fb1af417a48a45c001f7e9a09ef45f514eaba4513e7fcd5b7f08d7e"
     rhoai:
       base: "quay.io/opendatahub/feast-operator"
       digest: "sha256:f59bf3783fb1af417a48a45c001f7e9a09ef45f514eaba4513e7fcd5b7f08d7e"
+  RELATED_IMAGE_ODH_AGENTS_OPERATOR_IMAGE:
+    source: "csv"
+    odh:
+      base: "quay.io/opendatahub/odh-agents-operator"
+      digest: "sha256:167c0f19d9a39ab7b9b3f80fac60fa77957d7ce00cb5867354d4f7ae51310002"
+    rhoai:
+      base: "quay.io/opendatahub/odh-agents-operator"
+      digest: "sha256:167c0f19d9a39ab7b9b3f80fac60fa77957d7ce00cb5867354d4f7ae51310002"
+  RELATED_IMAGE_ODH_AI_GATEWAY_PAYLOAD_PROCESSING_E2E_IMAGE:
+    source: "csv"
+    odh:
+      base: "quay.io/opendatahub/ai-gateway-payload-processing-e2e"
+      digest: "sha256:b7b183016e1b44a4b313b2c01c577d16191e2a181cd4da50536c841baaddddb3"
+    rhoai:
+      base: "quay.io/opendatahub/ai-gateway-payload-processing-e2e"
+      digest: "sha256:b7b183016e1b44a4b313b2c01c577d16191e2a181cd4da50536c841baaddddb3"
+  RELATED_IMAGE_ODH_AI_GATEWAY_PAYLOAD_PROCESSING_IMAGE:
+    source: "csv"
+    odh:
+      base: "quay.io/opendatahub/odh-ai-gateway-payload-processing"
+      digest: "sha256:8344f2649eabc3c4cbb95eecd1a2004b27deddc1586c8fd26122fde3cf2149b4"
+    rhoai:
+      base: "quay.io/opendatahub/odh-ai-gateway-payload-processing"
+      digest: "sha256:8344f2649eabc3c4cbb95eecd1a2004b27deddc1586c8fd26122fde3cf2149b4"
+  RELATED_IMAGE_ODH_AUTHBRIDGE_PROXY_IMAGE:
+    source: "csv"
+    odh:
+      base: "quay.io/opendatahub/odh-authbridge-proxy"
+      digest: "sha256:315486763a88668daab872fe5ec3d0f228ab21cc310190622d6ece0043927d28"
+    rhoai:
+      base: "quay.io/opendatahub/odh-authbridge-proxy"
+      digest: "sha256:315486763a88668daab872fe5ec3d0f228ab21cc310190622d6ece0043927d28"
+  RELATED_IMAGE_ODH_AUTOML_IMAGE:
+    source: "csv"
+    odh:
+      base: "quay.io/opendatahub/odh-automl"
+      digest: "sha256:8f9a2f8f99fdf2d8ad310d1118f63930bd4d17b659f337579eb0ac6f281af1d6"
+    rhoai:
+      base: "quay.io/opendatahub/odh-automl"
+      digest: "sha256:8f9a2f8f99fdf2d8ad310d1118f63930bd4d17b659f337579eb0ac6f281af1d6"
+  RELATED_IMAGE_ODH_AUTORAG_IMAGE:
+    source: "csv"
+    odh:
+      base: "quay.io/opendatahub/odh-autorag"
+      digest: "sha256:4f1fedfccf0b2099794450b0530426cf9fc392ca47c254e8e78907277f182827"
+    rhoai:
+      base: "quay.io/opendatahub/odh-autorag"
+      digest: "sha256:4f1fedfccf0b2099794450b0530426cf9fc392ca47c254e8e78907277f182827"
+  RELATED_IMAGE_ODH_BUILT_IN_DETECTOR_IMAGE:
+    source: "csv"
+    odh:
+      base: "quay.io/opendatahub/odh-built-in-detector"
+      digest: "sha256:8541cf4c8c2568c25810913e5c8613845dbd3473b3c253c1b117797575a5db81"
+    rhoai:
+      base: "quay.io/opendatahub/odh-built-in-detector"
+      digest: "sha256:8541cf4c8c2568c25810913e5c8613845dbd3473b3c253c1b117797575a5db81"
+  RELATED_IMAGE_ODH_CORE_BFF_IMAGE:
+    source: "csv"
+    odh:
+      base: "quay.io/opendatahub/odh-core-bff"
+      digest: "sha256:7f00cc1c12465bdddaf49343922941b5d48cf4c871a07c83ee372d188f697907"
+    rhoai:
+      base: "quay.io/opendatahub/odh-core-bff"
+      digest: "sha256:7f00cc1c12465bdddaf49343922941b5d48cf4c871a07c83ee372d188f697907"
+  RELATED_IMAGE_ODH_DATA_CONNECT_HUB_FLIGHT_IMAGE:
+    source: "csv"
+    odh:
+      base: "quay.io/opendatahub/odh-data-connect-hub-flight"
+      digest: "sha256:5fb91d1d681c743cb8b3b0a96c7add634e0d4b6f5e4c7a3e3983eeb0a0e4181d"
+    rhoai:
+      base: "quay.io/opendatahub/odh-data-connect-hub-flight"
+      digest: "sha256:5fb91d1d681c743cb8b3b0a96c7add634e0d4b6f5e4c7a3e3983eeb0a0e4181d"
+  RELATED_IMAGE_ODH_DATA_CONNECT_HUB_REST_IMAGE:
+    source: "csv"
+    odh:
+      base: "quay.io/opendatahub/odh-data-connect-hub-rest"
+      digest: "sha256:f377347debb48c9c2301607b3996d75f0f1b8bfb73e6040b32d2dd581b64305e"
+    rhoai:
+      base: "quay.io/opendatahub/odh-data-connect-hub-rest"
+      digest: "sha256:f377347debb48c9c2301607b3996d75f0f1b8bfb73e6040b32d2dd581b64305e"
+  RELATED_IMAGE_ODH_DATA_SCIENCE_PIPELINES_ARGO_ARGOEXEC_IMAGE:
+    source: "csv"
+    odh:
+      base: "quay.io/opendatahub/ds-pipelines-argo-argoexec"
+      digest: "sha256:5a7e9beb40fdebd696ad480fc6bf44a6207e0154599d6d258f43b8545658a922"
+    rhoai:
+      base: "quay.io/opendatahub/ds-pipelines-argo-argoexec"
+      digest: "sha256:5a7e9beb40fdebd696ad480fc6bf44a6207e0154599d6d258f43b8545658a922"
+  RELATED_IMAGE_ODH_DATA_SCIENCE_PIPELINES_ARGO_WORKFLOWCONTROLLER_IMAGE:
+    source: "csv"
+    odh:
+      base: "quay.io/opendatahub/ds-pipelines-argo-workflowcontroller"
+      digest: "sha256:e1435acb979bee0b127f8bf7b0b22b9308043b56389995524a8ecf60ec9b6be1"
+    rhoai:
+      base: "quay.io/opendatahub/ds-pipelines-argo-workflowcontroller"
+      digest: "sha256:e1435acb979bee0b127f8bf7b0b22b9308043b56389995524a8ecf60ec9b6be1"
+  RELATED_IMAGE_ODH_EVAL_HUB_IMAGE:
+    source: "csv"
+    odh:
+      base: "quay.io/opendatahub/odh-eval-hub"
+      digest: "sha256:0ca74ba7939e2c5968d4288616e39907bab4a5b1e34183eb3502a44da9c89069"
+    rhoai:
+      base: "quay.io/opendatahub/odh-eval-hub"
+      digest: "sha256:0ca74ba7939e2c5968d4288616e39907bab4a5b1e34183eb3502a44da9c89069"
+  RELATED_IMAGE_ODH_FEATURE_SERVER_IMAGE:
+    source: "csv"
+    odh:
+      base: "quay.io/opendatahub/feature-server"
+      digest: "sha256:685227c222958d9a67211a962290488a9bb06d76450fc84fa70052e514ccc56d"
+    rhoai:
+      base: "quay.io/opendatahub/feature-server"
+      digest: "sha256:685227c222958d9a67211a962290488a9bb06d76450fc84fa70052e514ccc56d"
+  RELATED_IMAGE_ODH_FMS_GUARDRAILS_ORCHESTRATOR_IMAGE:
+    source: "csv"
+    odh:
+      base: "quay.io/opendatahub/ta-guardrails-orchestrator"
+      digest: "sha256:757f3c3e05fe0c40bcfa8d29d0511ddcaff640a38c4ee507696cf126009381b6"
+    rhoai:
+      base: "quay.io/opendatahub/ta-guardrails-orchestrator"
+      digest: "sha256:757f3c3e05fe0c40bcfa8d29d0511ddcaff640a38c4ee507696cf126009381b6"
+  RELATED_IMAGE_ODH_GUARDRAILS_DETECTOR_HUGGINGFACE_RUNTIME_IMAGE:
+    source: "csv"
+    odh:
+      base: "quay.io/opendatahub/guardrails-detector-huggingface-runtime"
+      digest: "sha256:5771760caed7344e76a55ecc5d91a847583df24cede511638e081ee12e670f31"
+    rhoai:
+      base: "quay.io/opendatahub/guardrails-detector-huggingface-runtime"
+      digest: "sha256:5771760caed7344e76a55ecc5d91a847583df24cede511638e081ee12e670f31"
+  RELATED_IMAGE_ODH_KF_NOTEBOOK_CONTROLLER_IMAGE:
+    source: "csv"
+    odh:
+      base: "quay.io/opendatahub/kubeflow-notebook-controller"
+      digest: "sha256:eae1eebff25b7f3db62f6ec10f257dfd6c94f2c906091e52025c0d8dca02f354"
+    rhoai:
+      base: "quay.io/opendatahub/kubeflow-notebook-controller"
+      digest: "sha256:eae1eebff25b7f3db62f6ec10f257dfd6c94f2c906091e52025c0d8dca02f354"
+  RELATED_IMAGE_ODH_KSERVE_AGENT_IMAGE:
+    source: "csv"
+    odh:
+      base: "quay.io/opendatahub/kserve-agent"
+      digest: "sha256:d43eb33f89d0b9cc2cc54978bac377606b95972957e33af300fe87a72fe30713"
+    rhoai:
+      base: "quay.io/opendatahub/kserve-agent"
+      digest: "sha256:d43eb33f89d0b9cc2cc54978bac377606b95972957e33af300fe87a72fe30713"
+  RELATED_IMAGE_ODH_KSERVE_AUTOGLUON_SERVER_IMAGE:
+    source: "csv"
+    odh:
+      base: "quay.io/opendatahub/odh-kserve-autogluon-server"
+      digest: "sha256:ba22d4ae6daec22d8ee340476b9b2c74c3ff82a6fb1ab02a74f287704cc27ff7"
+    rhoai:
+      base: "quay.io/opendatahub/odh-kserve-autogluon-server"
+      digest: "sha256:ba22d4ae6daec22d8ee340476b9b2c74c3ff82a6fb1ab02a74f287704cc27ff7"
+  RELATED_IMAGE_ODH_KSERVE_LOCALMODELNODE_AGENT_IMAGE:
+    source: "csv"
+    odh:
+      base: "quay.io/opendatahub/odh-kserve-localmodelnode-agent"
+      digest: "sha256:76c5af8b9cf9217f5f991dc55a4c289caa5a363a229b9a2ae3098b49d74b8224"
+    rhoai:
+      base: "quay.io/opendatahub/odh-kserve-localmodelnode-agent"
+      digest: "sha256:76c5af8b9cf9217f5f991dc55a4c289caa5a363a229b9a2ae3098b49d74b8224"
+  RELATED_IMAGE_ODH_KSERVE_ROUTER_IMAGE:
+    source: "csv"
+    odh:
+      base: "quay.io/opendatahub/kserve-router"
+      digest: "sha256:b90d4381a1e7f769c84454898f7dec80dace621c82215f2e343b71edfeac4c99"
+    rhoai:
+      base: "quay.io/opendatahub/kserve-router"
+      digest: "sha256:b90d4381a1e7f769c84454898f7dec80dace621c82215f2e343b71edfeac4c99"
+  RELATED_IMAGE_ODH_KSERVE_STORAGE_INITIALIZER_IMAGE:
+    source: "csv"
+    odh:
+      base: "quay.io/opendatahub/kserve-storage-initializer"
+      digest: "sha256:cbeff424330ff61e575e581b614ce5e0896756608c9e1ab92cdfde975bba9f5a"
+    rhoai:
+      base: "quay.io/opendatahub/kserve-storage-initializer"
+      digest: "sha256:cbeff424330ff61e575e581b614ce5e0896756608c9e1ab92cdfde975bba9f5a"
+  RELATED_IMAGE_ODH_KUBE_AUTH_PROXY_IMAGE:
+    source: "csv"
+    odh:
+      base: "quay.io/opendatahub/odh-kube-auth-proxy"
+      digest: "sha256:7972ebb9203a2c07447ec4f683c27e9ff6385fc04a4518ddd71c6ef710c81e11"
+    rhoai:
+      base: "quay.io/opendatahub/odh-kube-auth-proxy"
+      digest: "sha256:7972ebb9203a2c07447ec4f683c27e9ff6385fc04a4518ddd71c6ef710c81e11"
+  RELATED_IMAGE_ODH_KUBE_RBAC_PROXY_IMAGE:
+    source: "csv"
+    odh:
+      base: "quay.io/opendatahub/odh-kube-rbac-proxy"
+      digest: "sha256:db643f5de15c0aab3eac9c60dc4cb311007f6977f96a790031b108f5c44a17d3"
+    rhoai:
+      base: "quay.io/opendatahub/odh-kube-rbac-proxy"
+      digest: "sha256:db643f5de15c0aab3eac9c60dc4cb311007f6977f96a790031b108f5c44a17d3"
+  RELATED_IMAGE_ODH_LATENCY_PREDICTOR_PREDICTION_IMAGE:
+    source: "csv"
+    odh:
+      base: "quay.io/opendatahub/odh-latency-predictor-prediction"
+      digest: "sha256:2ba5a0dd8ed9bbcc3a17df1384e8e0c7d4884db1148646f09a2e02f56445c655"
+    rhoai:
+      base: "quay.io/opendatahub/odh-latency-predictor-prediction"
+      digest: "sha256:2ba5a0dd8ed9bbcc3a17df1384e8e0c7d4884db1148646f09a2e02f56445c655"
+  RELATED_IMAGE_ODH_LATENCY_PREDICTOR_TEST_IMAGE:
+    source: "csv"
+    odh:
+      base: "quay.io/opendatahub/odh-latency-predictor-test"
+      digest: "sha256:f6f83524fb21dc9b60af4369e5fd0d9342f999a811bce074067c6f8b678fb027"
+    rhoai:
+      base: "quay.io/opendatahub/odh-latency-predictor-test"
+      digest: "sha256:f6f83524fb21dc9b60af4369e5fd0d9342f999a811bce074067c6f8b678fb027"
+  RELATED_IMAGE_ODH_LATENCY_PREDICTOR_TRAINING_IMAGE:
+    source: "csv"
+    odh:
+      base: "quay.io/opendatahub/odh-latency-predictor-training"
+      digest: "sha256:f81144ea845d7b33367986f006f9767b91a0057b2512a8e4dfeefd812d1cbd9d"
+    rhoai:
+      base: "quay.io/opendatahub/odh-latency-predictor-training"
+      digest: "sha256:f81144ea845d7b33367986f006f9767b91a0057b2512a8e4dfeefd812d1cbd9d"
+  RELATED_IMAGE_ODH_LLM_D_ASYNC_IMAGE:
+    source: "csv"
+    odh:
+      base: "quay.io/opendatahub/odh-llm-d-async"
+      digest: "sha256:d46aacbbdc0baeb458c3bd3179aadcbc8eb868b8e395f5ec55411149850e5f5e"
+    rhoai:
+      base: "quay.io/opendatahub/odh-llm-d-async"
+      digest: "sha256:d46aacbbdc0baeb458c3bd3179aadcbc8eb868b8e395f5ec55411149850e5f5e"
+  RELATED_IMAGE_ODH_LLM_D_BATCH_GATEWAY_APISERVER_IMAGE:
+    source: "csv"
+    odh:
+      base: "quay.io/opendatahub/odh-llm-d-batch-gateway-apiserver"
+      digest: "sha256:9096d0a9ab884f03e2fea9c5dde01e8499caafd40a1ece74a748a80280c69e1c"
+    rhoai:
+      base: "quay.io/opendatahub/odh-llm-d-batch-gateway-apiserver"
+      digest: "sha256:9096d0a9ab884f03e2fea9c5dde01e8499caafd40a1ece74a748a80280c69e1c"
+  RELATED_IMAGE_ODH_LLM_D_BATCH_GATEWAY_GC_IMAGE:
+    source: "csv"
+    odh:
+      base: "quay.io/opendatahub/odh-llm-d-batch-gateway-gc"
+      digest: "sha256:063a748583d531eda6d1afba977bfe58ad3a1e341b385bec267288c7bb484d5c"
+    rhoai:
+      base: "quay.io/opendatahub/odh-llm-d-batch-gateway-gc"
+      digest: "sha256:063a748583d531eda6d1afba977bfe58ad3a1e341b385bec267288c7bb484d5c"
+  RELATED_IMAGE_ODH_LLM_D_BATCH_GATEWAY_OPERATOR_IMAGE:
+    source: "csv"
+    odh:
+      base: "quay.io/opendatahub/odh-batch-gateway-operator"
+      digest: "sha256:ed815f115897a942487cc70a8a8742469b355516344ddd47221249570b2f6865"
+    rhoai:
+      base: "quay.io/opendatahub/odh-batch-gateway-operator"
+      digest: "sha256:ed815f115897a942487cc70a8a8742469b355516344ddd47221249570b2f6865"
+  RELATED_IMAGE_ODH_LLM_D_BATCH_GATEWAY_PROCESSOR_IMAGE:
+    source: "csv"
+    odh:
+      base: "quay.io/opendatahub/odh-llm-d-batch-gateway-processor"
+      digest: "sha256:3e791d91015b356ff903b8fed1d7cf7c0309d5c92269f6d7e136cb3596ccd913"
+    rhoai:
+      base: "quay.io/opendatahub/odh-llm-d-batch-gateway-processor"
+      digest: "sha256:3e791d91015b356ff903b8fed1d7cf7c0309d5c92269f6d7e136cb3596ccd913"
+  RELATED_IMAGE_ODH_LLM_D_ROUTER_DISAGG_SIDECAR_IMAGE:
+    source: "csv"
+    odh:
+      base: "quay.io/opendatahub/odh-llm-d-router-disagg-sidecar"
+      digest: "sha256:8802b6b39757350495f92b0eaef44df1111be483b10519e156681c7d4a99b9ba"
+    rhoai:
+      base: "quay.io/opendatahub/odh-llm-d-router-disagg-sidecar"
+      digest: "sha256:8802b6b39757350495f92b0eaef44df1111be483b10519e156681c7d4a99b9ba"
+  RELATED_IMAGE_ODH_LLM_D_ROUTER_ENDPOINT_PICKER_IMAGE:
+    source: "csv"
+    odh:
+      base: "quay.io/opendatahub/odh-llm-d-router-endpoint-picker"
+      digest: "sha256:fde57f346731494cc1201df53586a35b83f040dcd37219d0a43b3d2a88cef57a"
+    rhoai:
+      base: "quay.io/opendatahub/odh-llm-d-router-endpoint-picker"
+      digest: "sha256:fde57f346731494cc1201df53586a35b83f040dcd37219d0a43b3d2a88cef57a"
+  RELATED_IMAGE_ODH_MAAS_API_IMAGE:
+    source: "csv"
+    odh:
+      base: "quay.io/opendatahub/maas-api"
+      digest: "sha256:fa3f398814727cae74468c4d622a843b920d763f908107e2cce5abcff1e2fb2c"
+    rhoai:
+      base: "quay.io/opendatahub/maas-api"
+      digest: "sha256:fa3f398814727cae74468c4d622a843b920d763f908107e2cce5abcff1e2fb2c"
+  RELATED_IMAGE_ODH_MAAS_CONTROLLER_IMAGE:
+    source: "csv"
+    odh:
+      base: "quay.io/opendatahub/maas-controller"
+      digest: "sha256:db30b938aed1b657a3203634182e23fe70b08042c789114ea9d8bfc8c2be7ac7"
+    rhoai:
+      base: "quay.io/opendatahub/maas-controller"
+      digest: "sha256:db30b938aed1b657a3203634182e23fe70b08042c789114ea9d8bfc8c2be7ac7"
+  RELATED_IMAGE_ODH_MCP_LIFECYCLE_OPERATOR_E2E_IMAGE:
+    source: "csv"
+    odh:
+      base: "quay.io/opendatahub/odh-mcp-lifecycle-operator-e2e"
+      digest: "sha256:2dcb8cab647a29eb7e7aff02aa239bba638a5764d5686f00929adf33b227e16b"
+    rhoai:
+      base: "quay.io/opendatahub/odh-mcp-lifecycle-operator-e2e"
+      digest: "sha256:2dcb8cab647a29eb7e7aff02aa239bba638a5764d5686f00929adf33b227e16b"
+  RELATED_IMAGE_ODH_MLFLOW_IMAGE:
+    source: "csv"
+    odh:
+      base: "quay.io/opendatahub/mlflow"
+      digest: "sha256:08746c9bbdc581da8976ccc693ac3b07b7481fb943da8e85cd1e792f8c38bc77"
+    rhoai:
+      base: "quay.io/opendatahub/mlflow"
+      digest: "sha256:08746c9bbdc581da8976ccc693ac3b07b7481fb943da8e85cd1e792f8c38bc77"
+  RELATED_IMAGE_ODH_MLMD_GRPC_SERVER_IMAGE:
+    source: "csv"
+    odh:
+      base: "quay.io/opendatahub/mlmd-grpc-server"
+      digest: "sha256:9aea59acdd7b914b8e8e902f4b388ddf2871b1047e644dbd3c69cb2d4ef8de95"
+    rhoai:
+      base: "quay.io/opendatahub/mlmd-grpc-server"
+      digest: "sha256:9aea59acdd7b914b8e8e902f4b388ddf2871b1047e644dbd3c69cb2d4ef8de95"
+  RELATED_IMAGE_ODH_MLSERVER_CUDA_IMAGE:
+    source: "csv"
+    odh:
+      base: "quay.io/opendatahub/odh-mlserver-cuda"
+      digest: "sha256:0ff38d0cca8f44644819db68d9b96d55ba3bb5ec4a4e57ac7d0e5a1bf52e25f9"
+    rhoai:
+      base: "quay.io/opendatahub/odh-mlserver-cuda"
+      digest: "sha256:0ff38d0cca8f44644819db68d9b96d55ba3bb5ec4a4e57ac7d0e5a1bf52e25f9"
+  RELATED_IMAGE_ODH_MLSERVER_IMAGE:
+    source: "csv"
+    odh:
+      base: "quay.io/opendatahub/mlserver"
+      digest: "sha256:c1ca8bfcf2bd0578319e4d51394bc193abdc243fc107e6c0f891832141613c6c"
+    rhoai:
+      base: "quay.io/opendatahub/mlserver"
+      digest: "sha256:c1ca8bfcf2bd0578319e4d51394bc193abdc243fc107e6c0f891832141613c6c"
+  RELATED_IMAGE_ODH_ML_PIPELINES_API_SERVER_V2_IMAGE:
+    source: "csv"
+    odh:
+      base: "quay.io/opendatahub/ds-pipelines-api-server"
+      digest: "sha256:03d8bc359764a62bdb0471eb98477d484a1076dbef9a7be763be35a88a9ca8d3"
+    rhoai:
+      base: "quay.io/opendatahub/ds-pipelines-api-server"
+      digest: "sha256:03d8bc359764a62bdb0471eb98477d484a1076dbef9a7be763be35a88a9ca8d3"
+  RELATED_IMAGE_ODH_ML_PIPELINES_DRIVER_IMAGE:
+    source: "csv"
+    odh:
+      base: "quay.io/opendatahub/ds-pipelines-driver"
+      digest: "sha256:41d67a3bd1e25a69569ffff58e9cf490370627e0e0666b27519fe6ec926d63b3"
+    rhoai:
+      base: "quay.io/opendatahub/ds-pipelines-driver"
+      digest: "sha256:41d67a3bd1e25a69569ffff58e9cf490370627e0e0666b27519fe6ec926d63b3"
+  RELATED_IMAGE_ODH_ML_PIPELINES_LAUNCHER_IMAGE:
+    source: "csv"
+    odh:
+      base: "quay.io/opendatahub/ds-pipelines-launcher"
+      digest: "sha256:06126748fbb9edb66dc2dfd06ce027042723db0ba70bbb0d287f2fca58afdebe"
+    rhoai:
+      base: "quay.io/opendatahub/ds-pipelines-launcher"
+      digest: "sha256:06126748fbb9edb66dc2dfd06ce027042723db0ba70bbb0d287f2fca58afdebe"
+  RELATED_IMAGE_ODH_ML_PIPELINES_PERSISTENCEAGENT_V2_IMAGE:
+    source: "csv"
+    odh:
+      base: "quay.io/opendatahub/ds-pipelines-persistenceagent"
+      digest: "sha256:85643e0482dd74b5732c2fc559e3ef718aeaa86bf1c87eb0974b273271273b3d"
+    rhoai:
+      base: "quay.io/opendatahub/ds-pipelines-persistenceagent"
+      digest: "sha256:85643e0482dd74b5732c2fc559e3ef718aeaa86bf1c87eb0974b273271273b3d"
+  RELATED_IMAGE_ODH_ML_PIPELINES_SCHEDULEDWORKFLOW_V2_IMAGE:
+    source: "csv"
+    odh:
+      base: "quay.io/opendatahub/ds-pipelines-scheduledworkflow"
+      digest: "sha256:fb335b7be62745db181cd3a7206fc74f76b76f8a9bac7677f358928ab43d1c2a"
+    rhoai:
+      base: "quay.io/opendatahub/ds-pipelines-scheduledworkflow"
+      digest: "sha256:fb335b7be62745db181cd3a7206fc74f76b76f8a9bac7677f358928ab43d1c2a"
+  RELATED_IMAGE_ODH_MODEL_METADATA_COLLECTION_IMAGE:
+    source: "csv"
+    odh:
+      base: "quay.io/opendatahub/odh-model-metadata-collection"
+      digest: "sha256:b5c23757da85fe4bf6b923320d5ad17987792ccce90734cfd045ca484d057698"
+    rhoai:
+      base: "quay.io/opendatahub/odh-model-metadata-collection"
+      digest: "sha256:b5c23757da85fe4bf6b923320d5ad17987792ccce90734cfd045ca484d057698"
+  RELATED_IMAGE_ODH_MODEL_PERFORMANCE_DATA_IMAGE:
+    source: "csv"
+    odh:
+      base: "quay.io/opendatahub/odh-model-metadata-collection"
+      digest: "sha256:b5c23757da85fe4bf6b923320d5ad17987792ccce90734cfd045ca484d057698"
+    rhoai:
+      base: "quay.io/opendatahub/odh-model-metadata-collection"
+      digest: "sha256:b5c23757da85fe4bf6b923320d5ad17987792ccce90734cfd045ca484d057698"
+  RELATED_IMAGE_ODH_MODEL_REGISTRY_IMAGE:
+    source: "csv"
+    odh:
+      base: "quay.io/opendatahub/model-registry"
+      digest: "sha256:5a3c91a272e792db836ef3729c466b8cca8cb4cec7d4d3e7842973c7faafd4b1"
+    rhoai:
+      base: "quay.io/opendatahub/model-registry"
+      digest: "sha256:5a3c91a272e792db836ef3729c466b8cca8cb4cec7d4d3e7842973c7faafd4b1"
+  RELATED_IMAGE_ODH_MODEL_REGISTRY_JOB_ASYNC_UPLOAD_IMAGE:
+    source: "csv"
+    odh:
+      base: "quay.io/opendatahub/model-registry-job-async-upload"
+      digest: "sha256:e468402ddc24d6ed4ce83073714d5c38b99a9856010cbca4e0c147a45817dfc7"
+    rhoai:
+      base: "quay.io/opendatahub/model-registry-job-async-upload"
+      digest: "sha256:e468402ddc24d6ed4ce83073714d5c38b99a9856010cbca4e0c147a45817dfc7"
+  RELATED_IMAGE_ODH_MODEL_SERVING_API_IMAGE:
+    source: "csv"
+    odh:
+      base: "quay.io/opendatahub/odh-model-serving-api"
+      digest: "sha256:4737761af05984b32bf44905678dc5563b45580bbac87f70919552a6c5846c19"
+    rhoai:
+      base: "quay.io/opendatahub/odh-model-serving-api"
+      digest: "sha256:4737761af05984b32bf44905678dc5563b45580bbac87f70919552a6c5846c19"
+  RELATED_IMAGE_ODH_MOD_ARCH_AGENT_OPS_IMAGE:
+    source: "csv"
+    odh:
+      base: "quay.io/opendatahub/odh-mod-arch-agent-ops"
+      digest: "sha256:0d6c5cefef0d82536e75b1127c3d453a05949da5528823b9f1ddc8c8102990ab"
+    rhoai:
+      base: "quay.io/opendatahub/odh-mod-arch-agent-ops"
+      digest: "sha256:0d6c5cefef0d82536e75b1127c3d453a05949da5528823b9f1ddc8c8102990ab"
+  RELATED_IMAGE_ODH_MOD_ARCH_AUTOML_IMAGE:
+    source: "csv"
+    odh:
+      base: "quay.io/opendatahub/odh-mod-arch-automl"
+      digest: "sha256:6e7162f92e23aafa1cae8c047601ce70d91138777d4a9f79bdcade76cd1a0f1c"
+    rhoai:
+      base: "quay.io/opendatahub/odh-mod-arch-automl"
+      digest: "sha256:6e7162f92e23aafa1cae8c047601ce70d91138777d4a9f79bdcade76cd1a0f1c"
+  RELATED_IMAGE_ODH_MOD_ARCH_AUTORAG_IMAGE:
+    source: "csv"
+    odh:
+      base: "quay.io/opendatahub/odh-mod-arch-autorag"
+      digest: "sha256:117f9928b914bd6d541743eb070e1691cd9e2f5a8b2e179f8f74187d392a4aa8"
+    rhoai:
+      base: "quay.io/opendatahub/odh-mod-arch-autorag"
+      digest: "sha256:117f9928b914bd6d541743eb070e1691cd9e2f5a8b2e179f8f74187d392a4aa8"
+  RELATED_IMAGE_ODH_MOD_ARCH_EVAL_HUB_IMAGE:
+    source: "csv"
+    odh:
+      base: "quay.io/opendatahub/odh-mod-arch-eval-hub"
+      digest: "sha256:c203b70975f6c44cfd765169b29a6d8f0450a7ce95139b1bf5e6c44585e8515e"
+    rhoai:
+      base: "quay.io/opendatahub/odh-mod-arch-eval-hub"
+      digest: "sha256:c203b70975f6c44cfd765169b29a6d8f0450a7ce95139b1bf5e6c44585e8515e"
+  RELATED_IMAGE_ODH_MOD_ARCH_GEN_AI_IMAGE:
+    source: "csv"
+    odh:
+      base: "quay.io/opendatahub/odh-mod-arch-gen-ai"
+      digest: "sha256:caa0f685849436a49beeb933feca816dc11a3ad3079d0627471d693189556163"
+    rhoai:
+      base: "quay.io/opendatahub/odh-mod-arch-gen-ai"
+      digest: "sha256:caa0f685849436a49beeb933feca816dc11a3ad3079d0627471d693189556163"
+  RELATED_IMAGE_ODH_MOD_ARCH_MAAS_IMAGE:
+    source: "csv"
+    odh:
+      base: "quay.io/opendatahub/mod-arch-maas"
+      digest: "sha256:fe31a9cdac65d7a040b9f5c19cc81fa77443860029ec4a2a88730255abe0734b"
+    rhoai:
+      base: "quay.io/opendatahub/mod-arch-maas"
+      digest: "sha256:fe31a9cdac65d7a040b9f5c19cc81fa77443860029ec4a2a88730255abe0734b"
+  RELATED_IMAGE_ODH_MOD_ARCH_MLFLOW_IMAGE:
+    source: "csv"
+    odh:
+      base: "quay.io/opendatahub/odh-mod-arch-mlflow"
+      digest: "sha256:48c975f272a651bf66974534bbc6a2b3333af1dd4c13bf7bbdb8e3aa8098a577"
+    rhoai:
+      base: "quay.io/opendatahub/odh-mod-arch-mlflow"
+      digest: "sha256:48c975f272a651bf66974534bbc6a2b3333af1dd4c13bf7bbdb8e3aa8098a577"
+  RELATED_IMAGE_ODH_MOD_ARCH_MODEL_REGISTRY_IMAGE:
+    source: "csv"
+    odh:
+      base: "quay.io/opendatahub/odh-mod-arch-modular-architecture"
+      digest: "sha256:0348f474cb919a22a1bed9c09e10b5d09d40f81b1770c3f046f39e3afa7fa707"
+    rhoai:
+      base: "quay.io/opendatahub/odh-mod-arch-modular-architecture"
+      digest: "sha256:0348f474cb919a22a1bed9c09e10b5d09d40f81b1770c3f046f39e3afa7fa707"
+  RELATED_IMAGE_ODH_NOTEBOOK_CONTROLLER_IMAGE:
+    source: "csv"
+    odh:
+      base: "quay.io/opendatahub/odh-notebook-controller"
+      digest: "sha256:5f7437445980f90fc7e0ca05fafb188cded1149f5121c1dc7c80853818d55a46"
+    rhoai:
+      base: "quay.io/opendatahub/odh-notebook-controller"
+      digest: "sha256:5f7437445980f90fc7e0ca05fafb188cded1149f5121c1dc7c80853818d55a46"
+  RELATED_IMAGE_ODH_OBSERVABILITY_IMAGE:
+    source: "csv"
+    odh:
+      base: "quay.io/opendatahub/odh-observability"
+      digest: "sha256:77a0aa1a0ff6e0d6a041d30397dc8c9cff6c793c8465811b0e20e878ce7bb521"
+    rhoai:
+      base: "quay.io/opendatahub/odh-observability"
+      digest: "sha256:77a0aa1a0ff6e0d6a041d30397dc8c9cff6c793c8465811b0e20e878ce7bb521"
+  RELATED_IMAGE_ODH_OGX_CORE_IMAGE:
+    source: "csv"
+    odh:
+      base: "quay.io/opendatahub/odh-ogx-core"
+      digest: "sha256:97b194d0d145cfb41428660620c0c623a924feede22594bb17c7c5ad3cc1fe82"
+    rhoai:
+      base: "quay.io/opendatahub/odh-ogx-core"
+      digest: "sha256:97b194d0d145cfb41428660620c0c623a924feede22594bb17c7c5ad3cc1fe82"
+  RELATED_IMAGE_ODH_OGX_MODULE_OPERATOR_IMAGE:
+    source: "csv"
+    odh:
+      base: "quay.io/opendatahub/odh-ogx-module-operator"
+      digest: "sha256:3263f93dc1176b6d01c2ee275933e6a8199ce1cde4397fa302f16467031a3bdf"
+    rhoai:
+      base: "quay.io/opendatahub/odh-ogx-module-operator"
+      digest: "sha256:3263f93dc1176b6d01c2ee275933e6a8199ce1cde4397fa302f16467031a3bdf"
+  RELATED_IMAGE_ODH_OPENVINO_MODEL_SERVER_IMAGE:
+    source: "csv"
+    odh:
+      base: "quay.io/opendatahub/openvino_model_server"
+      digest: "sha256:aea6779e5fa366a33e02cf5f8c1937cb4ad5feeb18dae12b0619b2e775168da2"
+    rhoai:
+      base: "quay.io/opendatahub/openvino_model_server"
+      digest: "sha256:aea6779e5fa366a33e02cf5f8c1937cb4ad5feeb18dae12b0619b2e775168da2"
+  RELATED_IMAGE_ODH_PIPELINES_COMPONENTS_IMAGE:
+    source: "csv"
+    odh:
+      base: "quay.io/opendatahub/odh-pipelines-components"
+      digest: "sha256:7df197d9fabca3c64ce6e46b6074884071f4d0c6889dba746663bc0a7606893a"
+    rhoai:
+      base: "quay.io/opendatahub/odh-pipelines-components"
+      digest: "sha256:7df197d9fabca3c64ce6e46b6074884071f4d0c6889dba746663bc0a7606893a"
+  RELATED_IMAGE_ODH_PIPELINE_RUNTIME_DATASCIENCE_CPU_PY312_IMAGE:
+    source: "csv"
+    odh:
+      base: "quay.io/opendatahub/odh-pipeline-runtime-datascience-cpu-py312-ubi9"
+      digest: "sha256:1721451cf0eac822d87cdddc2e0e37a347896d0497a5a3b2fee90f7b1cfe5052"
+    rhoai:
+      base: "quay.io/opendatahub/odh-pipeline-runtime-datascience-cpu-py312-ubi9"
+      digest: "sha256:1721451cf0eac822d87cdddc2e0e37a347896d0497a5a3b2fee90f7b1cfe5052"
+  RELATED_IMAGE_ODH_PIPELINE_RUNTIME_MINIMAL_CPU_PY312_IMAGE:
+    source: "csv"
+    odh:
+      base: "quay.io/opendatahub/odh-pipeline-runtime-minimal-cpu-py312-ubi9"
+      digest: "sha256:08f1ecb31d65b4a04c16c820d2fedf37a12c63cdde4247dca37bd70a1fc7473d"
+    rhoai:
+      base: "quay.io/opendatahub/odh-pipeline-runtime-minimal-cpu-py312-ubi9"
+      digest: "sha256:08f1ecb31d65b4a04c16c820d2fedf37a12c63cdde4247dca37bd70a1fc7473d"
+  RELATED_IMAGE_ODH_PIPELINE_RUNTIME_PYTORCH_CUDA_PY312_IMAGE:
+    source: "csv"
+    odh:
+      base: "quay.io/opendatahub/odh-pipeline-runtime-pytorch-cuda-py312-ubi9"
+      digest: "sha256:56f6a7f237c65031c60657f7a7359458eba86dc76aae06d108e6e6100be43157"
+    rhoai:
+      base: "quay.io/opendatahub/odh-pipeline-runtime-pytorch-cuda-py312-ubi9"
+      digest: "sha256:56f6a7f237c65031c60657f7a7359458eba86dc76aae06d108e6e6100be43157"
+  RELATED_IMAGE_ODH_PIPELINE_RUNTIME_PYTORCH_LLMCOMPRESSOR_CUDA_PY312_IMAGE:
+    source: "csv"
+    odh:
+      base: "quay.io/opendatahub/odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-ubi9"
+      digest: "sha256:98e5e8a45be1acd54191c8ccadb04e5b314b5befc239774de18e66b65aac8e6d"
+    rhoai:
+      base: "quay.io/opendatahub/odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-ubi9"
+      digest: "sha256:98e5e8a45be1acd54191c8ccadb04e5b314b5befc239774de18e66b65aac8e6d"
+  RELATED_IMAGE_ODH_PIPELINE_RUNTIME_PYTORCH_ROCM_PY312_IMAGE:
+    source: "csv"
+    odh:
+      base: "quay.io/opendatahub/odh-pipeline-runtime-pytorch-rocm-py312-ubi9"
+      digest: "sha256:2ff721e9a000c9bf0a83a8f605e9cb6788122b365de23ae39aceb51a81970962"
+    rhoai:
+      base: "quay.io/opendatahub/odh-pipeline-runtime-pytorch-rocm-py312-ubi9"
+      digest: "sha256:2ff721e9a000c9bf0a83a8f605e9cb6788122b365de23ae39aceb51a81970962"
+  RELATED_IMAGE_ODH_PIPELINE_RUNTIME_TENSORFLOW_CUDA_PY312_IMAGE:
+    source: "csv"
+    odh:
+      base: "quay.io/opendatahub/odh-pipeline-runtime-tensorflow-cuda-py312-ubi9"
+      digest: "sha256:8ce5fe5ac318c76a14bd90c534c3de2fd8143c7a52b0d1089d89cd3b324e68b2"
+    rhoai:
+      base: "quay.io/opendatahub/odh-pipeline-runtime-tensorflow-cuda-py312-ubi9"
+      digest: "sha256:8ce5fe5ac318c76a14bd90c534c3de2fd8143c7a52b0d1089d89cd3b324e68b2"
+  RELATED_IMAGE_ODH_PIPELINE_RUNTIME_TENSORFLOW_ROCM_PY312_IMAGE:
+    source: "csv"
+    odh:
+      base: "quay.io/opendatahub/odh-pipeline-runtime-tensorflow-rocm-py312-ubi9"
+      digest: "sha256:32e674789b5c7ee87d68e772396e7ddcc3751f7624c5a86dc641fce1546a31a8"
+    rhoai:
+      base: "quay.io/opendatahub/odh-pipeline-runtime-tensorflow-rocm-py312-ubi9"
+      digest: "sha256:32e674789b5c7ee87d68e772396e7ddcc3751f7624c5a86dc641fce1546a31a8"
+  RELATED_IMAGE_ODH_RAY_MODULE_OPERATOR_IMAGE:
+    source: "csv"
+    odh:
+      base: "quay.io/opendatahub/odh-ray-module-operator"
+      digest: "sha256:d6c3db8bafbf9e0312a82824b26f92a06958225e573933418abda9f2a5542a2b"
+    rhoai:
+      base: "quay.io/opendatahub/odh-ray-module-operator"
+      digest: "sha256:d6c3db8bafbf9e0312a82824b26f92a06958225e573933418abda9f2a5542a2b"
+  RELATED_IMAGE_ODH_RHAII_CLUSTER_VALIDATOR_IMAGE:
+    source: "csv"
+    odh:
+      base: "quay.io/opendatahub/odh-rhaii-cluster-validator"
+      digest: "sha256:683b44ac6828fc67d86bda17de62cafa557a9bfc96cd0a16d56148451516aba1"
+    rhoai:
+      base: "quay.io/opendatahub/odh-rhaii-cluster-validator"
+      digest: "sha256:683b44ac6828fc67d86bda17de62cafa557a9bfc96cd0a16d56148451516aba1"
+  RELATED_IMAGE_ODH_RHAII_VALIDATOR_TOOLS_IMAGE:
+    source: "csv"
+    odh:
+      base: "quay.io/opendatahub/odh-rhaii-validator-tools"
+      digest: "sha256:f33f94ffdffcdbc4e7cdaec4888c571501038815318a532408ca6d64127b8ac8"
+    rhoai:
+      base: "quay.io/opendatahub/odh-rhaii-validator-tools"
+      digest: "sha256:f33f94ffdffcdbc4e7cdaec4888c571501038815318a532408ca6d64127b8ac8"
+  RELATED_IMAGE_ODH_RHOAI_MCP_IMAGE:
+    source: "csv"
+    odh:
+      base: "quay.io/opendatahub/odh-rhoai-mcp"
+      digest: "sha256:bc8f26e215bb1e52da936220c4c097ea9e47a85bd3db329590ab5c1fea2bec6e"
+    rhoai:
+      base: "quay.io/opendatahub/odh-rhoai-mcp"
+      digest: "sha256:bc8f26e215bb1e52da936220c4c097ea9e47a85bd3db329590ab5c1fea2bec6e"
+  RELATED_IMAGE_ODH_SPARK_OPERATOR_MODULE_IMAGE:
+    source: "csv"
+    odh:
+      base: "quay.io/opendatahub/odh-spark-operator-module"
+      digest: "sha256:0fe9348af8cfa10a2039a16cfc9d215ed58635cd5f98bec1e3ee8c0f0cad6cb2"
+    rhoai:
+      base: "quay.io/opendatahub/odh-spark-operator-module"
+      digest: "sha256:0fe9348af8cfa10a2039a16cfc9d215ed58635cd5f98bec1e3ee8c0f0cad6cb2"
+  RELATED_IMAGE_ODH_TA_LMES_DRIVER_IMAGE:
+    source: "csv"
+    odh:
+      base: "quay.io/opendatahub/ta-lmes-driver"
+      digest: "sha256:0cef5660c6646897201b30e2f5b6d3090d368475c4cf116e5c2af5ec2c32e693"
+    rhoai:
+      base: "quay.io/opendatahub/ta-lmes-driver"
+      digest: "sha256:0cef5660c6646897201b30e2f5b6d3090d368475c4cf116e5c2af5ec2c32e693"
+  RELATED_IMAGE_ODH_TA_LMES_JOB_IMAGE:
+    source: "csv"
+    odh:
+      base: "quay.io/opendatahub/ta-lmes-job"
+      digest: "sha256:5c8a38df80f0541ce8d032be6665394505d9346cedee68f4dd99552d33cb0056"
+    rhoai:
+      base: "quay.io/opendatahub/ta-lmes-job"
+      digest: "sha256:5c8a38df80f0541ce8d032be6665394505d9346cedee68f4dd99552d33cb0056"
+  RELATED_IMAGE_ODH_TH_TORCH_CPU_PY312_IMAGE:
+    source: "csv"
+    odh:
+      base: "quay.io/opendatahub/odh-th-torch-cpu-py312"
+      digest: "sha256:5567a1dbe5b2583ae7bcb3689b59fa6506fdc1f8c9088d0406a264b76c089297"
+    rhoai:
+      base: "quay.io/opendatahub/odh-th-torch-cpu-py312"
+      digest: "sha256:5567a1dbe5b2583ae7bcb3689b59fa6506fdc1f8c9088d0406a264b76c089297"
+  RELATED_IMAGE_ODH_TH_TORCH_CUDA_PY312_IMAGE:
+    source: "csv"
+    odh:
+      base: "quay.io/opendatahub/odh-th-torch-cuda-py312"
+      digest: "sha256:a7d355b3d897c2c776ce4a606f2840cf216e0dccd349eb941971dc5d48a078c0"
+    rhoai:
+      base: "quay.io/opendatahub/odh-th-torch-cuda-py312"
+      digest: "sha256:a7d355b3d897c2c776ce4a606f2840cf216e0dccd349eb941971dc5d48a078c0"
+  RELATED_IMAGE_ODH_TH_TORCH_ROCM_PY312_IMAGE:
+    source: "csv"
+    odh:
+      base: "quay.io/opendatahub/odh-th-torch-rocm-py312"
+      digest: "sha256:642f7820db15e2c9d656c10190626db4091bfce8923234073f1600e5d125f98b"
+    rhoai:
+      base: "quay.io/opendatahub/odh-th-torch-rocm-py312"
+      digest: "sha256:642f7820db15e2c9d656c10190626db4091bfce8923234073f1600e5d125f98b"
+  RELATED_IMAGE_ODH_TRAINER_OPERATOR_IMAGE:
+    source: "csv"
+    odh:
+      base: "quay.io/opendatahub/odh-trainer-operator"
+      digest: "sha256:897b44b96939e8315e043cbf6d7a0a3079ed9d283b5e9abec21080c23971cf13"
+    rhoai:
+      base: "quay.io/opendatahub/odh-trainer-operator"
+      digest: "sha256:897b44b96939e8315e043cbf6d7a0a3079ed9d283b5e9abec21080c23971cf13"
+  RELATED_IMAGE_ODH_TRAINING_CUDA121_TORCH24_PY311_IMAGE:
+    source: "csv"
+    odh:
+      base: "quay.io/opendatahub/odh-training-cuda121-torch24-py311"
+      digest: "sha256:977d67581ccaa35ce49263951e5c5af4f925b490bb4861aca7c5170a1b3b21d6"
+    rhoai:
+      base: "quay.io/opendatahub/odh-training-cuda121-torch24-py311"
+      digest: "sha256:977d67581ccaa35ce49263951e5c5af4f925b490bb4861aca7c5170a1b3b21d6"
+  RELATED_IMAGE_ODH_TRAINING_CUDA124_TORCH25_PY311_IMAGE:
+    source: "csv"
+    odh:
+      base: "quay.io/opendatahub/odh-training-cuda124-torch25-py311"
+      digest: "sha256:2664e8ac0af9ad44cc0906b108603b02fce72fdd82440668eda1a6719aa913de"
+    rhoai:
+      base: "quay.io/opendatahub/odh-training-cuda124-torch25-py311"
+      digest: "sha256:2664e8ac0af9ad44cc0906b108603b02fce72fdd82440668eda1a6719aa913de"
+  RELATED_IMAGE_ODH_TRAINING_CUDA128_TORCH28_PY312_IMAGE:
+    source: "csv"
+    odh:
+      base: "quay.io/opendatahub/odh-training-cuda128-torch28-py312-rhel9"
+      digest: "sha256:e01435fb012a742b161ed9918ca70ac855db858a512c1f8ded7bc94b29c4e7b8"
+    rhoai:
+      base: "quay.io/opendatahub/odh-training-cuda128-torch28-py312-rhel9"
+      digest: "sha256:e01435fb012a742b161ed9918ca70ac855db858a512c1f8ded7bc94b29c4e7b8"
+  RELATED_IMAGE_ODH_TRAINING_CUDA128_TORCH29_PY312_IMAGE:
+    source: "csv"
+    odh:
+      base: "quay.io/opendatahub/odh-training-cuda128-torch29-py312"
+      digest: "sha256:6601b6fea1a9d4fcd78700407232d02f24a9e647c510973e58b0b38eff29e07a"
+    rhoai:
+      base: "quay.io/opendatahub/odh-training-cuda128-torch29-py312"
+      digest: "sha256:6601b6fea1a9d4fcd78700407232d02f24a9e647c510973e58b0b38eff29e07a"
+  RELATED_IMAGE_ODH_TRAINING_ROCM62_TORCH24_PY311_IMAGE:
+    source: "csv"
+    odh:
+      base: "quay.io/opendatahub/odh-training-rocm62-torch24-py311"
+      digest: "sha256:742fbcdc20e6e7c5f0ec07e3fede4fb3d700abe716c11ff808355c9ec316c220"
+    rhoai:
+      base: "quay.io/opendatahub/odh-training-rocm62-torch24-py311"
+      digest: "sha256:742fbcdc20e6e7c5f0ec07e3fede4fb3d700abe716c11ff808355c9ec316c220"
+  RELATED_IMAGE_ODH_TRAINING_ROCM62_TORCH25_PY311_IMAGE:
+    source: "csv"
+    odh:
+      base: "quay.io/opendatahub/odh-training-rocm62-torch25-py311"
+      digest: "sha256:e6534273238e207dd583a8f7f21802588af9d2faba27ee4878725cd8158d59e6"
+    rhoai:
+      base: "quay.io/opendatahub/odh-training-rocm62-torch25-py311"
+      digest: "sha256:e6534273238e207dd583a8f7f21802588af9d2faba27ee4878725cd8158d59e6"
+  RELATED_IMAGE_ODH_TRAINING_ROCM64_TORCH28_PY312_IMAGE:
+    source: "csv"
+    odh:
+      base: "quay.io/opendatahub/odh-training-rocm64-torch28-py312"
+      digest: "sha256:2061cb20c7309f2f3ce91c6644d1e2c5ba6d3adde0f73bb222b42dde999c6d78"
+    rhoai:
+      base: "quay.io/opendatahub/odh-training-rocm64-torch28-py312"
+      digest: "sha256:2061cb20c7309f2f3ce91c6644d1e2c5ba6d3adde0f73bb222b42dde999c6d78"
+  RELATED_IMAGE_ODH_TRAINING_ROCM64_TORCH29_PY312_IMAGE:
+    source: "csv"
+    odh:
+      base: "quay.io/opendatahub/odh-training-rocm64-torch29-py312"
+      digest: "sha256:873a7ae8f44e975d6c98c08af6448b5688d0e57df0eb71e5911d249145b075cc"
+    rhoai:
+      base: "quay.io/opendatahub/odh-training-rocm64-torch29-py312"
+      digest: "sha256:873a7ae8f44e975d6c98c08af6448b5688d0e57df0eb71e5911d249145b075cc"
+  RELATED_IMAGE_ODH_TRUSTYAI_GARAK_LLS_PROVIDER_DSP_IMAGE:
+    source: "csv"
+    odh:
+      base: "quay.io/opendatahub/odh-trustyai-garak-lls-provider-dsp"
+      digest: "sha256:89f298c570cf34c27503dbbda16fc0aae27931d533f9fd1ab3d5cebce486a984"
+    rhoai:
+      base: "quay.io/opendatahub/odh-trustyai-garak-lls-provider-dsp"
+      digest: "sha256:89f298c570cf34c27503dbbda16fc0aae27931d533f9fd1ab3d5cebce486a984"
+  RELATED_IMAGE_ODH_TRUSTYAI_NEMO_GUARDRAILS_SERVER_IMAGE:
+    source: "csv"
+    odh:
+      base: "quay.io/opendatahub/odh-trustyai-nemo-guardrails-server"
+      digest: "sha256:2e6b7204bc62ccedf501cacd3ec8dacdfa6f593dd5af1d94b07972389dd3943e"
+    rhoai:
+      base: "quay.io/opendatahub/odh-trustyai-nemo-guardrails-server"
+      digest: "sha256:2e6b7204bc62ccedf501cacd3ec8dacdfa6f593dd5af1d94b07972389dd3943e"
+  RELATED_IMAGE_ODH_TRUSTYAI_RAGAS_LLS_PROVIDER_DSP_IMAGE:
+    source: "csv"
+    odh:
+      base: "quay.io/opendatahub/llama-stack-provider-ragas"
+      digest: "sha256:fa46ce6a3dd16b0eb8e06c71f99b761d742599e569ed91f7b727149bc1085520"
+    rhoai:
+      base: "quay.io/opendatahub/llama-stack-provider-ragas"
+      digest: "sha256:fa46ce6a3dd16b0eb8e06c71f99b761d742599e569ed91f7b727149bc1085520"
+  RELATED_IMAGE_ODH_TRUSTYAI_SERVICE_IMAGE:
+    source: "csv"
+    odh:
+      base: "quay.io/opendatahub/odh-trustyai-service"
+      digest: "sha256:300889737a1c33e2a4b2883b707b9ebd141d1669dc904b06a0564428341b1abf"
+    rhoai:
+      base: "quay.io/opendatahub/odh-trustyai-service"
+      digest: "sha256:300889737a1c33e2a4b2883b707b9ebd141d1669dc904b06a0564428341b1abf"
+  RELATED_IMAGE_ODH_TRUSTYAI_SERVICE_PY_IMAGE:
+    source: "csv"
+    odh:
+      base: "quay.io/opendatahub/odh-trustyai-service-py"
+      digest: "sha256:e8ac6de8e3d908e4e3fda1b4b871a891e535e1a5f66aea3849ec29e04a8023b0"
+    rhoai:
+      base: "quay.io/opendatahub/odh-trustyai-service-py"
+      digest: "sha256:e8ac6de8e3d908e4e3fda1b4b871a891e535e1a5f66aea3849ec29e04a8023b0"
+  RELATED_IMAGE_ODH_TRUSTYAI_VLLM_ORCHESTRATOR_GATEWAY_IMAGE:
+    source: "csv"
+    odh:
+      base: "quay.io/opendatahub/vllm-orchestrator-gateway"
+      digest: "sha256:10789a3f024d520078e4d813d06fa1d0297d4cd4af87a2d271c44c132d8e39f2"
+    rhoai:
+      base: "quay.io/opendatahub/vllm-orchestrator-gateway"
+      digest: "sha256:10789a3f024d520078e4d813d06fa1d0297d4cd4af87a2d271c44c132d8e39f2"
+  RELATED_IMAGE_ODH_WORKBENCHES_CONTROLLER_IMAGE:
+    source: "csv"
+    odh:
+      base: "quay.io/opendatahub/odh-workbenches-controller"
+      digest: "sha256:40805eb65eaacb47b3725a2f7cb46ec90a00ceb580f33461b570ae62d5764d77"
+    rhoai:
+      base: "quay.io/opendatahub/odh-workbenches-controller"
+      digest: "sha256:40805eb65eaacb47b3725a2f7cb46ec90a00ceb580f33461b570ae62d5764d77"
+  RELATED_IMAGE_ODH_WORKBENCH_CODESERVER_DATASCIENCE_CPU_PY312_IMAGE:
+    source: "csv"
+    odh:
+      base: "quay.io/opendatahub/odh-workbench-codeserver-datascience-cpu-py312-ubi9"
+      digest: "sha256:bde3628d7109eb7c941487ecfe0f616c7034e8ba414cbf4fe44b73eb2e8ae7cc"
+    rhoai:
+      base: "quay.io/opendatahub/odh-workbench-codeserver-datascience-cpu-py312-ubi9"
+      digest: "sha256:bde3628d7109eb7c941487ecfe0f616c7034e8ba414cbf4fe44b73eb2e8ae7cc"
+  RELATED_IMAGE_ODH_WORKBENCH_JUPYTER_DATASCIENCE_CPU_PY312_IMAGE:
+    source: "csv"
+    odh:
+      base: "quay.io/opendatahub/odh-workbench-jupyter-datascience-cpu-py312-ubi9"
+      digest: "sha256:086c7fd74ecfd726e60dcdc69b2846771520dad1d045f1b30ec85853121a7702"
+    rhoai:
+      base: "quay.io/opendatahub/odh-workbench-jupyter-datascience-cpu-py312-ubi9"
+      digest: "sha256:086c7fd74ecfd726e60dcdc69b2846771520dad1d045f1b30ec85853121a7702"
+  RELATED_IMAGE_ODH_WORKBENCH_JUPYTER_MINIMAL_CPU_PY312_IMAGE:
+    source: "csv"
+    odh:
+      base: "quay.io/opendatahub/odh-workbench-jupyter-minimal-cpu-py312-ubi9"
+      digest: "sha256:a53a90ede0a3322ccae883b5ba075bd27680068c9612e7a83c7a4b31a3db0f16"
+    rhoai:
+      base: "quay.io/opendatahub/odh-workbench-jupyter-minimal-cpu-py312-ubi9"
+      digest: "sha256:a53a90ede0a3322ccae883b5ba075bd27680068c9612e7a83c7a4b31a3db0f16"
+  RELATED_IMAGE_ODH_WORKBENCH_JUPYTER_MINIMAL_CUDA_PY312_IMAGE:
+    source: "csv"
+    odh:
+      base: "quay.io/opendatahub/odh-workbench-jupyter-minimal-cuda-py312-ubi9"
+      digest: "sha256:bfe731720d7287cbd1195b81e5a4bfb700bc75599e4b7f26b695ec250de4aebc"
+    rhoai:
+      base: "quay.io/opendatahub/odh-workbench-jupyter-minimal-cuda-py312-ubi9"
+      digest: "sha256:bfe731720d7287cbd1195b81e5a4bfb700bc75599e4b7f26b695ec250de4aebc"
+  RELATED_IMAGE_ODH_WORKBENCH_JUPYTER_MINIMAL_ROCM_PY312_IMAGE:
+    source: "csv"
+    odh:
+      base: "quay.io/opendatahub/odh-workbench-jupyter-minimal-rocm-py312-ubi9"
+      digest: "sha256:a09fae755bfb8f854b9cefc6bd333572d5d59b93a0a322a7c7fb9b1b684b4f1f"
+    rhoai:
+      base: "quay.io/opendatahub/odh-workbench-jupyter-minimal-rocm-py312-ubi9"
+      digest: "sha256:a09fae755bfb8f854b9cefc6bd333572d5d59b93a0a322a7c7fb9b1b684b4f1f"
+  RELATED_IMAGE_ODH_WORKBENCH_JUPYTER_PYTORCH_CUDA_PY312_IMAGE:
+    source: "csv"
+    odh:
+      base: "quay.io/opendatahub/odh-workbench-jupyter-pytorch-cuda-py312-ubi9"
+      digest: "sha256:4d6653e8a52251b360095465801dd91c4ae2673ed2cf94d661da22e065e496bd"
+    rhoai:
+      base: "quay.io/opendatahub/odh-workbench-jupyter-pytorch-cuda-py312-ubi9"
+      digest: "sha256:4d6653e8a52251b360095465801dd91c4ae2673ed2cf94d661da22e065e496bd"
+  RELATED_IMAGE_ODH_WORKBENCH_JUPYTER_PYTORCH_LLMCOMPRESSOR_CUDA_PY312_IMAGE:
+    source: "csv"
+    odh:
+      base: "quay.io/opendatahub/odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-ubi9"
+      digest: "sha256:cd3e582d7408750adb72615008ace6a69d5e0052544c5fddb5408da7606c62d0"
+    rhoai:
+      base: "quay.io/opendatahub/odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-ubi9"
+      digest: "sha256:cd3e582d7408750adb72615008ace6a69d5e0052544c5fddb5408da7606c62d0"
+  RELATED_IMAGE_ODH_WORKBENCH_JUPYTER_PYTORCH_ROCM_PY312_IMAGE:
+    source: "csv"
+    odh:
+      base: "quay.io/opendatahub/odh-workbench-jupyter-pytorch-rocm-py312-ubi9"
+      digest: "sha256:fbf426747590ecbcc7bcd6d34b5a9b9883d2ad03ce918a7129cee91523b300e0"
+    rhoai:
+      base: "quay.io/opendatahub/odh-workbench-jupyter-pytorch-rocm-py312-ubi9"
+      digest: "sha256:fbf426747590ecbcc7bcd6d34b5a9b9883d2ad03ce918a7129cee91523b300e0"
+  RELATED_IMAGE_ODH_WORKBENCH_JUPYTER_TENSORFLOW_CUDA_PY312_IMAGE:
+    source: "csv"
+    odh:
+      base: "quay.io/opendatahub/odh-workbench-jupyter-tensorflow-cuda-py312-ubi9"
+      digest: "sha256:7e0f86106e35cf9da23312418758067e1bfa0c040dc8684fc0771f4665edf9cb"
+    rhoai:
+      base: "quay.io/opendatahub/odh-workbench-jupyter-tensorflow-cuda-py312-ubi9"
+      digest: "sha256:7e0f86106e35cf9da23312418758067e1bfa0c040dc8684fc0771f4665edf9cb"
+  RELATED_IMAGE_ODH_WORKBENCH_JUPYTER_TENSORFLOW_ROCM_PY312_IMAGE:
+    source: "csv"
+    odh:
+      base: "quay.io/opendatahub/odh-workbench-jupyter-tensorflow-rocm-py312-ubi9"
+      digest: "sha256:4b1389874ffcd0893c8e3c48315b928dcdf488f9d743f4fcc07ab4b5affa2e63"
+    rhoai:
+      base: "quay.io/opendatahub/odh-workbench-jupyter-tensorflow-rocm-py312-ubi9"
+      digest: "sha256:4b1389874ffcd0893c8e3c48315b928dcdf488f9d743f4fcc07ab4b5affa2e63"
+  RELATED_IMAGE_ODH_WORKBENCH_JUPYTER_TRUSTYAI_CPU_PY312_IMAGE:
+    source: "csv"
+    odh:
+      base: "quay.io/opendatahub/odh-workbench-jupyter-trustyai-cpu-py312-ubi9"
+      digest: "sha256:8cfbb8ee55b78489284538cb35d9216b82cf629e41268c6f769dfcfe689c579b"
+    rhoai:
+      base: "quay.io/opendatahub/odh-workbench-jupyter-trustyai-cpu-py312-ubi9"
+      digest: "sha256:8cfbb8ee55b78489284538cb35d9216b82cf629e41268c6f769dfcfe689c579b"
+  RELATED_IMAGE_OSE_KUBE_RBAC_PROXY_IMAGE:
+    source: "csv"
+    odh:
+      base: "quay.io/opendatahub/odh-kube-auth-proxy"
+      digest: "sha256:7972ebb9203a2c07447ec4f683c27e9ff6385fc04a4518ddd71c6ef710c81e11"
+    rhoai:
+      base: "quay.io/opendatahub/odh-kube-auth-proxy"
+      digest: "sha256:7972ebb9203a2c07447ec4f683c27e9ff6385fc04a4518ddd71c6ef710c81e11"


### PR DESCRIPTION
## Description

- Enhance `resolve-digests` to use ODH-Build-Config CSV as a fallback (Priority 3) when commit-sha and params.env resolution both fail for existing image overrides
- Import ALL `RELATED_IMAGE_*` entries from the CSV that don't exist in `manifests-config.yaml` yet, filtered by registry prefix (default: `quay.io/`). Imported entries are marked with `source: csv` and are auto-managed on every run — updated when the CSV changes, removed when the CSV drops them
- Fix params.env fallback: search recursively under the component directory instead of hardcoding `{component}/params.env` (the file is always in a subdirectory like `base/` or `overlays/`)
- Add unresolved images section to the digest resolution summary output

Release: rhoai-3.6-ea.1
Jira: https://redhat.atlassian.net/browse/RHOAIENG-80087

## How Has This Been Tested?

- Unit tests added for CSV parsing (`TestParseCSVRelatedImages`, `TestParseCSVRelatedImages_MultipleDeployments`, `TestParseCSVRelatedImages_EmptySpec`, `TestParseCSVRelatedImages_InvalidYAML`)
- Unit tests added for recursive params.env lookup (`TestFindParamsEnvKey`)
- All existing tests pass (`go test ./...` in `cmd/manifest-tools`)
- `go build ./...` succeeds


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatically discovers and imports operator images from CSV metadata.
  * Supports configurable registry filtering for CSV-based image imports.
  * Allows creating and removing image overrides, including CSV-sourced entries.
  * Recursively discovers component parameter files.
* **Updates**
  * Refreshed image digests and expanded pinned image overrides across platform components.
  * Removed obsolete image override entries.
* **Bug Fixes**
  * Improved handling of stale, unresolved, invalid, and tag-only image references.
  * Added clearer reporting for unresolved image references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->