### PR TITLE
feat(RHOAIENG-80092): make release/JIRA PR fields optional, drop bot token

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,10 +10,10 @@ Please complete the following sections for a smooth review.
 <!-- For RHOAI PRs, request review on #ai-core-platform-requests Slack channel -->
 
 ## Release tracking
-<!-- These fields are mandatory - CI will block merging unless they are set -->
+<!-- Optional. Set a target release only if this PR must ship in a specific release; it will be prioritized accordingly. -->
 <!-- Target release for this PR, e.g. rhoai-3.6 or rhoai-3.7ea1 -->
 Release: 
-<!-- Full link to a jira ticket, e.g. https://redhat.atlassian.net/browse/RHOAIENG-XXXXX -->
+<!-- Required only if a Release is set above. Full link to a jira ticket, e.g. https://redhat.atlassian.net/browse/RHOAIENG-XXXXX -->
 Jira:
 
 

--- a/.github/workflows/pr-release-label.yaml
+++ b/.github/workflows/pr-release-label.yaml
@@ -22,50 +22,42 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - name: Generate GitHub App Token
-        id: app-token
-        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
-        with:
-          app-id: ${{ secrets.ODH_DEVOPS_APP_ID }}
-          private-key: ${{ secrets.ODH_DEVOPS_APP_PRIVATE_KEY }}
       - name: Apply release label
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
-          github-token: ${{ steps.app-token.outputs.token }}
           script: |
             const { owner, repo } = context.repo;
             const prNumber = context.payload.pull_request.number;
+            const prBody = context.payload.pull_request.body || '';
 
-            const { data: pr } = await github.rest.pulls.get({
-              owner,
-              repo,
-              pull_number: prNumber,
-            });
-            const prBody = pr.body || '';
+            const isReleaseLabel = name => /^rhoai-\d+\.\d+(?:ea\d+)?$/.test(name);
 
-            const match = prBody.match(/^Release:\s*(rhoai-\d+\.\d+(?:ea\d+)?)\s*$/m);
-            if (!match) {
-              console.log('No release target found in PR description');
-              return;
-            }
-
-            const targetLabel = match[1];
-            console.log(`Found release target: ${targetLabel}`);
-
+            // Fetch labels fresh (not from the payload): this job mutates them and
+            // concurrent runs may have changed them since the event fired.
             const { data: labels } = await github.rest.issues.listLabelsOnIssue({
               owner,
               repo,
               issue_number: prNumber,
             });
 
-            const isReleaseLabel = name =>
-              /^rhoai-\d+\.\d+(?:ea\d+)?$/.test(name);
+            // The `Release:` field in the PR description is the source of truth.
+            const match = prBody.match(/^Release:\s*(rhoai-\d+\.\d+(?:ea\d+)?)\s*$/m);
+            const targetLabel = match ? match[1] : null;
 
+            // No release target in the description: leave labels untouched so
+            // manually applied release labels are preserved.
+            if (!targetLabel) {
+              console.log('No release target found in PR description; leaving existing labels untouched');
+              return;
+            }
+
+            // A release target is set — treat it as authoritative and drop any
+            // other release labels that no longer match it.
             const staleLabels = labels.filter(
               l => isReleaseLabel(l.name) && l.name !== targetLabel
             );
             for (const label of staleLabels) {
-              console.log(`Removing stale label: ${label.name}`);
+              console.log(`Removing stale release label: ${label.name}`);
               await github.rest.issues.removeLabel({
                 owner,
                 repo,
@@ -74,8 +66,7 @@ jobs:
               });
             }
 
-            const alreadyApplied = labels.some(l => l.name === targetLabel);
-            if (alreadyApplied) {
+            if (labels.some(l => l.name === targetLabel)) {
               console.log(`Label ${targetLabel} already applied`);
               return;
             }
@@ -87,7 +78,7 @@ jobs:
                 issue_number: prNumber,
                 labels: [targetLabel],
               });
-              console.log(`Applied label: ${targetLabel}`);
+              console.log(`Applied release label: ${targetLabel}`);
             } catch (error) {
               if (error.status === 404) {
                 console.log(`Label "${targetLabel}" does not exist in the repository. A maintainer needs to create it first.`);

--- a/.github/workflows/pr-requirements-check.yaml
+++ b/.github/workflows/pr-requirements-check.yaml
@@ -1,7 +1,11 @@
 name: Check PR release label and JIRA link
 on:
   pull_request:
-    types: [opened, edited, labeled, unlabeled, synchronize]
+    types: [opened, edited, synchronize, reopened]
+
+concurrency:
+  group: ${{ github.workflow }}-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 jobs:
   check-pr-requirements:
@@ -22,71 +26,42 @@ jobs:
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           script: |
-            const { owner, repo } = context.repo;
-            const prNumber = context.payload.pull_request.number;
+            const prBody = context.payload.pull_request.body || '';
 
-            const { data: pr } = await github.rest.pulls.get({
-              owner,
-              repo,
-              pull_number: prNumber,
-            });
+            // The `Release:` field in the PR description is the source of truth.
+            // Setting it is optional; it means the PR should be prioritized for
+            // that release, and the auto-labeler applies the matching label.
+            const match = prBody.match(/^Release:\s*(rhoai-\d+\.\d+(?:ea\d+)?)\s*$/m);
+            const targetRelease = match ? match[1] : null;
 
-            const prBody = pr.body || '';
-            const errors = [];
-
-            // Check for release label
-            const { data: labels } = await github.rest.issues.listLabelsOnIssue({
-              owner,
-              repo,
-              issue_number: prNumber,
-            });
-
-            const hasReleaseLabel = labels.some(l => /^rhoai-\d+\.\d+(ea\d+)?$/.test(l.name));
-            if (!hasReleaseLabel) {
-              errors.push({
-                title: 'Missing release label',
-                detail: [
-                  'Every PR must have a release label (e.g., `rhoai-3.6`, `rhoai-3.7ea1`).',
-                  '',
-                  '**How to fix:**',
-                  '1. Edit the PR description and set the `Release:` field to your target release',
-                  '   (e.g., `Release: rhoai-3.6`). A CI workflow will apply the label automatically.',
-                  '2. Or ask a maintainer to add the label manually.',
-                ].join('\n'),
-              });
+            // No release target set — release and Jira are both optional. Pass.
+            if (!targetRelease) {
+              let summary = '## ✅ PR Requirements Check Passed\n\n';
+              summary += '- No release target set — release label and Jira link are optional\n';
+              await core.summary.addRaw(summary).write();
+              console.log('No release target set; nothing required');
+              return;
             }
 
-            // Check for JIRA URL
+            // A release target is set, so a Jira link is required.
             const hasJiraUrl = /https:\/\/redhat\.atlassian\.net\/browse\/[A-Z]+-\d+/.test(prBody);
             if (!hasJiraUrl) {
-              errors.push({
-                title: 'Missing JIRA link',
-                detail: [
-                  'Every PR must include a JIRA ticket URL in the description.',
-                  '',
-                  '**How to fix:**',
-                  'Edit the PR description and fill in the `Jira:` field with a valid JIRA URL, e.g.:',
-                  '`Jira: https://redhat.atlassian.net/browse/RHOAIENG-12345`',
-                ].join('\n'),
-              });
-            }
-
-            // Report results
-            if (errors.length > 0) {
               let summary = '## ❌ PR Requirements Check Failed\n\n';
-              for (const err of errors) {
-                summary += `### ${err.title}\n\n${err.detail}\n\n`;
-              }
+              summary += '### Missing Jira link\n\n';
+              summary += `You set a release target (\`${targetRelease}\`), so a Jira link is required.\n\n`;
+              summary += '**How to fix:**\n';
+              summary += 'Edit the PR description and fill in the `Jira:` field with a valid Jira URL, e.g.:\n';
+              summary += '`Jira: https://redhat.atlassian.net/browse/RHOAIENG-12345`\n\n';
+              summary += 'Or remove the `Release:` field if this PR does not need to ship in a specific release.\n\n';
               summary += '---\n';
-              summary += '*This check is required before merge. Bot PRs and automated branches are exempt.*\n';
-
+              summary += '*Bot PRs and automated branches are exempt.*\n';
               await core.summary.addRaw(summary).write();
-              core.setFailed(`Missing: ${errors.map(e => e.title).join(', ')}`);
-            } else {
-              let summary = '## ✅ PR Requirements Check Passed\n\n';
-              summary += `- Release label: \`${labels.find(l => /^rhoai-\d+\.\d+(ea\d+)?$/.test(l.name)).name}\`\n`;
-              summary += '- JIRA link: found\n';
-
-              await core.summary.addRaw(summary).write();
-              console.log('All PR requirements met');
+              core.setFailed('Release target set but no Jira link found');
+              return;
             }
+
+            let summary = '## ✅ PR Requirements Check Passed\n\n';
+            summary += `- Release target: \`${targetRelease}\`\n`;
+            summary += '- Jira link: found\n';
+            await core.summary.addRaw(summary).write();
+            console.log('All PR requirements met');


### PR DESCRIPTION

## Description


Update PR enforcement per revised requirements:
- Release and JIRA fields are now optional. A JIRA link is required only when a Release target is set in the PR description.
- pr-requirements-check runs on pull_request (read-only) and gates on the Release: body field, so the required status reports against the PR head SHA. pr-release-label runs on pull_request_target with the default GITHUB_TOKEN to apply/sync the label.
- Drop the GitHub App token: the check reads the body, not the label, so the label-event race no longer exists and no elevated bot credentials are needed.
- Auto-labeler leaves manually applied release labels untouched when no Release: field is present.
- Loosen PR template wording to reflect the optional fields.

<!---
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

<!--- Describe your changes in detail -->

<!-- For RHOAI PRs, request review on #ai-core-platform-requests Slack channel -->

## Release tracking
<!-- These fields are mandatory - CI will block merging unless they are set -->
<!-- Target release for this PR, e.g. rhoai-3.6 or rhoai-3.7ea1 -->
Release: 
<!-- Full link to a jira ticket, e.g. https://redhat.atlassian.net/browse/RHOAIENG-XXXXX -->
Jira:


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully
- [ ] New RELATED_IMAGE mappings are listed in ODH-Build-Config and RHOAI-Build-Config (CI validates names against build-config repos). Include links to build-config PRs in the description.

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [ ] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated pull request instructions to clarify when release and Jira details are required.
  * Added a complete Jira ticket URL example.

* **Chores**
  * Improved automated pull request validation and release-label handling.
  * Pull requests without a specified release now pass related checks without requiring Jira details.
  * Validation results and release-label updates now provide clearer status messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->