### PR TITLE
fix(e2e): add Dashboard deployment readiness check to the deletion recovery test case

### DIFF
--- a/tests/e2e/dashboard_test.go
+++ b/tests/e2e/dashboard_test.go
@@ -212,8 +212,38 @@ func (tc *DashboardTestCtx) ValidateVAPBlocksDashboardCRCreation(t *testing.T) {
 }
 
 // ValidateAllDeletionRecovery runs the standard set of deletion recovery tests.
+// Before running, it waits for all dashboard-labeled deployments to complete any
+// in-progress rollouts. Earlier tests (Validate_update_operand_resources,
+// Validate_dynamically_watches_operands) can trigger a rhods-dashboard rollout
+// that restarts the dashboard-operator pod; if deletion recovery runs while the
+// operator is mid-restart, it cannot recreate deleted ConfigMaps in time.
 func (tc *DashboardTestCtx) ValidateAllDeletionRecovery(t *testing.T) {
 	t.Helper()
+
+	// Wait for all dashboard deployments to finish rolling out
+	tc.EnsureResourcesExist(
+		WithMinimalObject(gvk.Deployment, types.NamespacedName{Namespace: tc.AppsNamespace}),
+		WithListOptions(
+			&client.ListOptions{
+				Namespace: tc.AppsNamespace,
+				LabelSelector: k8slabels.Set{
+					labels.PlatformPartOf: strings.ToLower(tc.GVK.Kind),
+				}.AsSelector(),
+			},
+		),
+		WithCondition(
+			HaveEach(
+				And(
+					jq.Match(`.metadata.generation == .status.observedGeneration`),
+					jq.Match(`.status.updatedReplicas == .spec.replicas`),
+					jq.Match(`.status.availableReplicas == .spec.replicas`),
+					jq.Match(`.status.readyReplicas == .spec.replicas`),
+				),
+			),
+		),
+		WithEventuallyTimeout(tc.TestTimeouts.defaultEventuallyTimeout),
+		WithCustomErrorMsg("All dashboard deployments should be fully rolled out before testing deletion recovery"),
+	)
 
 	// Run all the standard recovery tests first
 	tc.ComponentTestCtx.ValidateAllDeletionRecovery(t)


### PR DESCRIPTION
<!---
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
Adds Dashboard deployment readiness check before the deletion recovery test cases for the Dashboard resources, as unstable dashboard pod could cause test failure

## Release tracking
<!-- These fields are mandatory - CI will block merging unless they are set -->
<!-- Target release for this PR, e.g. rhoai-3.6 or rhoai-3.7ea1 -->
Release: rhoai-3.5
<!-- Full link to a jira ticket, e.g. https://redhat.atlassian.net/browse/RHOAIENG-XXXXX -->
Jira: [RHOAIENG-81077](https://redhat.atlassian.net/browse/RHOAIENG-81077) , [RHOAIENG-81074](https://redhat.atlassian.net/browse/RHOAIENG-81074), [RHOAIENG-80395](https://redhat.atlassian.net/browse/RHOAIENG-80395)

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [ ] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->


[RHOAIENG-81077]: https://redhat.atlassian.net/browse/RHOAIENG-81077?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RHOAIENG-81074]: https://redhat.atlassian.net/browse/RHOAIENG-81074?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RHOAIENG-80395]: https://redhat.atlassian.net/browse/RHOAIENG-80395?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dashboard deletion-recovery test reliability by waiting for deployments to become fully available before validation.
  * Added clearer timeout reporting when deployments do not reach the expected state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->