### PR TITLE
feat: remove dry run flag from e2e failure triage action

### DIFF
--- a/.github/scripts/e2e-failure-triage/triage.py
+++ b/.github/scripts/e2e-failure-triage/triage.py
@@ -1005,11 +1005,11 @@ def main() -> None:
     print(f"\nMakefile VERSION: {version}")
     print(f"Affects Version:  {affects_version}")
 
-    jira_email = os.environ.get("JIRA_USER_EMAIL", "")
-    jira_token = os.environ.get("JIRA_API_TOKEN", "")
+    jira_email = os.environ.get("E2E_TRIAGE_JIRA_EMAIL", "")
+    jira_token = os.environ.get("E2E_TRIAGE_JIRA_API_TOKEN", "")
 
     if not args.dry_run and (not jira_email or not jira_token):
-        raise ValueError("Jira credentials required for non-dry-run mode. Set JIRA_USER_EMAIL and JIRA_API_TOKEN.")
+        raise ValueError("Jira credentials required for non-dry-run mode. Set E2E_TRIAGE_JIRA_EMAIL and E2E_TRIAGE_JIRA_API_TOKEN.")
 
     jira_config = JiraConfig(
         email=jira_email,

--- a/.github/workflows/e2e-failure-triage.yaml
+++ b/.github/workflows/e2e-failure-triage.yaml
@@ -94,15 +94,14 @@ jobs:
         if: steps.extract-pr.outputs.skip != 'true' && steps.check-label.outputs.skip != 'true'
         env:
           PROW_URL: ${{ steps.extract-pr.outputs.prow_url }}
-          JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}
-          JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
+          E2E_TRIAGE_JIRA_EMAIL: ${{ secrets.E2E_TRIAGE_JIRA_EMAIL }}
+          E2E_TRIAGE_JIRA_API_TOKEN: ${{ secrets.E2E_TRIAGE_JIRA_API_TOKEN }}
           GITHUB_ACTION_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           python .github/scripts/e2e-failure-triage/triage.py \
             --prow-url "$PROW_URL" \
             --existing-comment "${{ runner.temp }}/existing-comment.md" \
-            --comment-output "${{ runner.temp }}/pr-comment.md" \
-            --dry-run
+            --comment-output "${{ runner.temp }}/pr-comment.md"
 
       - name: Comment on PR
         if: steps.extract-pr.outputs.skip != 'true' && steps.check-label.outputs.skip != 'true'


### PR DESCRIPTION
## Description
JIRA: https://redhat.atlassian.net/browse/RHOAIENG-80088

Follow up PR from #3927 to remove the `--dry-run` flag and connect the action to the rhoaieng-automation bot's JIRA credentials. Once this PR is merged, the action will create JIRA tickets rather than just commenting that would have created a JIRA ticket (see [here](https://github.com/opendatahub-io/opendatahub-operator/pull/3921#issuecomment-5244091445) for example).

## Release tracking
<!-- Optional. Set a target release only if this PR must ship in a specific release; it will be prioritized accordingly. -->
<!-- Target release for this PR, e.g. rhoai-3.6 or rhoai-3.7ea1 -->
Release: 
<!-- Required only if a Release is set above. Full link to a jira ticket, e.g. https://redhat.atlassian.net/browse/RHOAIENG-XXXXX -->
Jira:


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [X] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [X] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work
- [X] The developer has run the integration test pipeline and verified that it passed successfully
- [X] New RELATED_IMAGE mappings are listed in ODH-Build-Config and RHOAI-Build-Config (CI validates names against build-config repos). Include links to build-config PRs in the description.

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [X] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
GitHub action change that doesn't require E2E tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated end-to-end failure triage to use dedicated Jira credentials.
  * Enabled the workflow to perform standard triage operations instead of running in preview mode.
  * Improved validation and error messaging for missing triage credentials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->