### PR TITLE
fix(rhaii): revert metrics Service to plain HTTP for xKS deployments

### DIFF
--- a/config/rhaii/odh-operator/kustomization.yaml
+++ b/config/rhaii/odh-operator/kustomization.yaml
@@ -16,3 +16,4 @@ patches:
 - path: manager_auth_proxy_patch.yaml
 - path: manager_webhook_patch.yaml
 - path: manager_remove_scc_annotation_patch.yaml
+- path: metrics_service_patch.yaml

--- a/config/rhaii/odh-operator/manager_auth_proxy_patch.yaml
+++ b/config/rhaii/odh-operator/manager_auth_proxy_patch.yaml
@@ -1,5 +1,8 @@
-# This patch inject a sidecar container which is a HTTP proxy for the
-# controller manager, it performs RBAC authorization against the Kubernetes API using SubjectAccessReviews.
+# This patch configures the operator for xKS (non-OpenShift) deployments.
+# Metrics are served on plain HTTP port 8080 without authentication because
+# service-ca is not available. The deployment is single-tenant (one operator
+# per cluster). Network access controls (e.g., NetworkPolicy) must be applied
+# by the deployment environment if multi-tenant isolation is required.
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/config/rhaii/odh-operator/metrics_service_patch.yaml
+++ b/config/rhaii/odh-operator/metrics_service_patch.yaml
@@ -1,0 +1,14 @@
+# This patch reverts the metrics Service to plain HTTP for xKS deployments
+# where service-ca is not available and --metrics-secure=false is set.
+apiVersion: v1
+kind: Service
+metadata:
+  name: controller-manager-metrics-service
+  namespace: system
+spec:
+  ports:
+  - $patch: replace
+  - name: http
+    port: 8080
+    protocol: TCP
+    targetPort: 8080


### PR DESCRIPTION
## Description

The rhaii overlay for xKS deployments sets `--metrics-secure=false` and `--metrics-bind-address=0.0.0.0:8080` in the Deployment, but inherits the base Service from `config/rbac/auth_proxy_service.yaml` which has port 8443/https. This causes a port mismatch where the Service targets 8443 but the pod listens on 8080, breaking metrics scraping.

This PR adds a strategic merge patch in the rhaii overlay that replaces the Service port list with a single HTTP port on 8080, matching the Deployment configuration.

The service-ca annotation (added in `config/default/metrics_service_patch.yaml`) is not included in the rhaii overlay, so no annotation removal is needed.

## Release tracking

Release: rhoai-3.6
Jira: https://redhat.atlassian.net/browse/RHOAIENG-82304

## How Has This Been Tested?

Verified kustomize renders correctly:
- Base Service has port 8443/https (from `config/rbac/auth_proxy_service.yaml`)
- Default overlay adds service-ca annotation (from `config/default/metrics_service_patch.yaml`)
- rhaii overlay now renders with port 8080/http, no annotation (tested via `kustomize build` in isolation)

## Merge criteria

- [x] You have read the contributors guide.
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully
- [ ] New RELATED_IMAGE mappings are listed in ODH-Build-Config and RHOAI-Build-Config (CI validates names against build-config repos). Include links to build-config PRs in the description.

### E2E test suite update requirement

- [x] Skip requirement to update E2E test suite for this PR

#### E2E update requirement opt-out justification

Configuration-only change to rhaii overlay. No new operator logic, no behavior changes on OpenShift. The mismatch would be caught by integration testing in the rhaii deployment environment (xKS metrics scraping).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features

- Added controller-manager metrics service configuration.
- Metrics are available over plain HTTP on TCP port 8080 in the `system` namespace for supported non-OpenShift deployments.

## Documentation

- Updated metrics access guidance to reflect unauthenticated HTTP access where service-ca is unavailable.
- Clarified that appropriate environment-level network controls are required for multi-tenant isolation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->