### PR TITLE
feat(rbac): add OpenShift-specific RBAC overlay for xKS compatibility

### DIFF
--- a/config/rhoai/rbac/kustomization.yaml
+++ b/config/rhoai/rbac/kustomization.yaml
@@ -6,3 +6,5 @@ resources:
 - role_binding.yaml
 - role.yaml
 - service_account.yaml
+- tls_clusterrole.yaml
+- tls_clusterrolebinding.yaml

--- a/config/rhoai/rbac/tls_clusterrole.yaml
+++ b/config/rhoai/rbac/tls_clusterrole.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: rhods-operator-openshift-tls-profile-reader
+rules:
+- apiGroups:
+  - config.openshift.io
+  resources:
+  - apiservers
+  - authentications
+  - clusterversions
+  - infrastructures
+  - ingresses
+  verbs:
+  - get
+  - list
+  - watch

--- a/config/rhoai/rbac/tls_clusterrolebinding.yaml
+++ b/config/rhoai/rbac/tls_clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: rhods-operator-openshift-tls-profile-reader-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: rhods-operator-openshift-tls-profile-reader
+subjects:
+- kind: ServiceAccount
+  name: redhat-ods-operator-controller-manager
+  namespace: system


### PR DESCRIPTION
## Description

Add a separate ClusterRole and ClusterRoleBinding for OpenShift-specific API groups to the RHOAI kustomize overlay (`config/rhoai/rbac/`). This makes the OpenShift-only RBAC explicit and separable, improving compatibility with non-OpenShift (xKS) deployments that use the base manifests without the RHOAI overlay.

The new `rhods-operator-openshift-tls-profile-reader` ClusterRole covers:
- `config.openshift.io`: apiservers, authentications, clusterversions, infrastructures, ingresses (TLS profile + cluster config access)

Follows the pattern established in kserve (`config/overlays/odh/rbac/tls/`) and model-registry-operator (`config/overlays/openshift/`).

Jira: https://redhat.atlassian.net/browse/RHOAIENG-79003

## Release tracking

Release: rhoai-3.6
Jira: https://redhat.atlassian.net/browse/RHOAIENG-79003

## How Has This Been Tested?

- `kustomize build config/rhoai/rbac` and `kustomize build config/rhoai/default` both produce valid output with the new resources included
- `make lint` passes

## Merge criteria

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully
- [ ] New RELATED_IMAGE mappings are listed in ODH-Build-Config and RHOAI-Build-Config

- [x] Skip requirement to update E2E test suite for this PR

#### E2E update requirement opt-out justification

RBAC manifest-only change — no Go code changed, no new controllers, no new API types. Kustomize build verified locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced platform integration with OpenShift TLS configuration resources.
  * Updated access permissions to support reliable reading of cluster-wide TLS settings.
  * No user-facing configuration changes are required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->