### PR TITLE
fix: add missing ingresses RBAC marker and treat HTTP 500 as transient in TLS watcher

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -779,7 +779,8 @@ func fetchTLSProfile(ctx context.Context, scheme *runtime.Scheme, restCfg *rest.
 			case k8serr.IsServiceUnavailable(err),
 				k8serr.IsTimeout(err),
 				k8serr.IsServerTimeout(err),
-				k8serr.IsTooManyRequests(err):
+				k8serr.IsTooManyRequests(err),
+				k8serr.IsInternalError(err):
 				setupLog.Info("Transient error fetching TLS adherence policy, watcher will retry", "error", err)
 			default:
 				setupLog.Error(err, "unable to read TLS adherence policy, refusing to start with unknown adherence posture")

--- a/internal/controller/datasciencecluster/kubebuilder_rbac.go
+++ b/internal/controller/datasciencecluster/kubebuilder_rbac.go
@@ -117,6 +117,7 @@ package datasciencecluster
 // +kubebuilder:rbac:groups="core",resources=clusterversions,verbs=watch;list;get
 
 // +kubebuilder:rbac:groups="config.openshift.io",resources=clusterversions,verbs=watch;list;get
+// +kubebuilder:rbac:groups="config.openshift.io",resources=ingresses,verbs=get
 
 // +kubebuilder:rbac:groups="coordination.k8s.io",resources=leases,verbs=get;list;watch;create;update;patch;delete
 


### PR DESCRIPTION
## Description

Two small fixes:

- `cmd/main.go`: treat `IsInternalError` (HTTP 500) as a transient error in the TLS adherence policy fetch so the watcher retries instead of calling `os.Exit(1)`.
- `datasciencecluster/kubebuilder_rbac.go`: add missing `config.openshift.io/ingresses` RBAC marker. The controller calls `GetDomain` which reads this resource, but the marker was absent.

Jira: https://redhat.atlassian.net/browse/RHOAIENG-79003

## Release tracking

Release: rhoai-3.6
Jira: https://redhat.atlassian.net/browse/RHOAIENG-79003

## How Has This Been Tested?

- `make manifests` passes
- `make lint` passes
- CodeRabbit CLI: 0 findings

## Merge criteria

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully
- [ ] New RELATED_IMAGE mappings are listed in ODH-Build-Config and RHOAI-Build-Config

- [x] Skip requirement to update E2E test suite for this PR

#### E2E update requirement opt-out justification

No logic change in controllers. The `cmd/main.go` fix only affects error handling in the TLS watcher retry loop. The RBAC marker addition requires no behavioral testing beyond `make manifests`.