### PR TITLE
fix(webhook): eliminate OLM upgrade race for conversion webhooks (RHOAIENG-76183)

### DIFF
--- a/cmd/manifest-tools/pkg/downloader/downloader.go
+++ b/cmd/manifest-tools/pkg/downloader/downloader.go
@@ -28,7 +28,6 @@ const (
 	colorReset  = "\033[0m"
 )
 
-
 type Options struct {
 	ConfigFile   string
 	Platform     string

--- a/cmd/manifest-tools/pkg/downloader/downloader_test.go
+++ b/cmd/manifest-tools/pkg/downloader/downloader_test.go
@@ -187,7 +187,7 @@ func TestSymlinkPlatformManifests(t *testing.T) {
 	}
 
 	testManifests := map[string]string{
-		"osd-configs":     "config/osd-configs",
+		"osd-configs":      "config/osd-configs",
 		"hardwareprofiles": "config/hardwareprofiles",
 	}
 

--- a/cmd/manifest-tools/pkg/resolver/resolver_test.go
+++ b/cmd/manifest-tools/pkg/resolver/resolver_test.go
@@ -126,4 +126,3 @@ func TestSplitImageRef_EdgeCases(t *testing.T) {
 		}
 	}
 }
-

--- a/cmd/manifest-tools/pkg/updater/tags_test.go
+++ b/cmd/manifest-tools/pkg/updater/tags_test.go
@@ -4,11 +4,11 @@ import "testing"
 
 func TestParseTrackerURL(t *testing.T) {
 	tests := []struct {
-		url         string
-		wantOwner   string
-		wantRepo    string
-		wantIssue   int
-		wantErr     bool
+		url       string
+		wantOwner string
+		wantRepo  string
+		wantIssue int
+		wantErr   bool
 	}{
 		{
 			url:       "https://github.com/opendatahub-io/odh-release-tracker/issues/42",

--- a/config/manifests/kustomization.yaml
+++ b/config/manifests/kustomization.yaml
@@ -33,6 +33,26 @@ patches:
     version: v1
     kind: CustomResourceDefinition
     name: datascienceclusters.datasciencecluster.opendatahub.io
+# Remove spec.conversion from bundle CRDs so OLM does not own conversion webhook
+# lifecycle. The operator patches spec.conversion at runtime after its webhook server
+# is ready, eliminating the upgrade-time race where OLM activates conversion before
+# new pods are serving /convert (RHOAIENG-76183).
+- patch: |-
+    - op: remove
+      path: /spec/conversion
+  target:
+    group: apiextensions.k8s.io
+    version: v1
+    kind: CustomResourceDefinition
+    name: dscinitializations.dscinitialization.opendatahub.io
+- patch: |-
+    - op: remove
+      path: /spec/conversion
+  target:
+    group: apiextensions.k8s.io
+    version: v1
+    kind: CustomResourceDefinition
+    name: datascienceclusters.datasciencecluster.opendatahub.io
 
 # [WEBHOOK] To enable webhooks, uncomment all the sections with [WEBHOOK] prefix.
 # Do NOT uncomment sections with prefix [CERTMANAGER], as OLM does not support cert-manager.

--- a/config/rhoai/manifests/kustomization.yaml
+++ b/config/rhoai/manifests/kustomization.yaml
@@ -32,6 +32,26 @@ patches:
     version: v1
     kind: CustomResourceDefinition
     name: datascienceclusters.datasciencecluster.opendatahub.io
+# Remove spec.conversion from bundle CRDs so OLM does not own conversion webhook
+# lifecycle. The operator patches spec.conversion at runtime after its webhook server
+# is ready, eliminating the upgrade-time race where OLM activates conversion before
+# new pods are serving /convert (RHOAIENG-76183).
+- patch: |-
+    - op: remove
+      path: /spec/conversion
+  target:
+    group: apiextensions.k8s.io
+    version: v1
+    kind: CustomResourceDefinition
+    name: dscinitializations.dscinitialization.opendatahub.io
+- patch: |-
+    - op: remove
+      path: /spec/conversion
+  target:
+    group: apiextensions.k8s.io
+    version: v1
+    kind: CustomResourceDefinition
+    name: datascienceclusters.datasciencecluster.opendatahub.io
 
 # [WEBHOOK] To enable webhooks, uncomment all the sections with [WEBHOOK] prefix.
 # Do NOT uncomment sections with prefix [CERTMANAGER], as OLM does not support cert-manager.


### PR DESCRIPTION
## Description

Fixes the OLM upgrade race condition for conversion webhooks (RHOAIENG-76183, RHOAI 3.5 GA blocker).

**Root cause:** OLM writes `spec.conversion` on CRDs during `Install()` — before any new pod is scheduled or ready — opening a window where the apiserver routes conversion calls to old pods that return HTTP 404. This causes CRD conversion failures mid-upgrade.

Evidence from Andrej's test: `manager=catalog` writes `spec.conversion` at T+0 (no caBundle), `manager=olm` overwrites at T+8s (adds caBundle, points to new service), all before any new pod serves `/convert`.

**Fix (two parts):**

1. Remove `ConversionWebhook` from bundle CRD manifests (`config/manifests` and `config/rhoai/manifests`) so OLM never writes `spec.conversion`. Non-bundle paths (`config/crd`, `config/rhoai/crd`) are unaffected — `spec.conversion` is still set there for non-OLM installs.

2. Add `ConversionCRDInstaller`: a `manager.Runnable` (`NeedLeaderElection=false`) that polls `https://localhost:9443/readyz` until the local webhook server is confirmed serving, then patches `spec.conversion` on the DSC and DSCI CRDs via SSA with `ForceOwnership`. The OCP CA-injection annotation (`service.beta.openshift.io/inject-cabundle: "true"`) is included so OCP injects the caBundle automatically. Runs on every pod.

Related: companion OLM fix in `openshift/operator-framework-olm` that moves the `createOrUpdateConversionWebhook()` call from `Install()` to `areWebhooksAvailable()` (post-readiness check).

Jira: https://redhat.atlassian.net/browse/RHOAIENG-76183

## Release tracking

Release: rhoai-3.5
Jira: https://redhat.atlassian.net/browse/RHOAIENG-76183

## How Has This Been Tested?

- Build compiles cleanly (`go build ./...`)
- `make generate manifests api-docs` produces no diff
- `make fmt` clean
- `make lint` clean (0 issues)
- Manual review of kustomize output: `spec.conversion` absent from bundle manifests, present in CRD-only paths
- Unit tests passing

Integration/upgrade testing with an actual OLM upgrade is pending — this is submitted as draft for early review.

## Merge criteria

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully

- [x] Skip requirement to update E2E test suite for this PR

#### E2E update requirement opt-out justification

This is a bug fix for an upgrade race condition. The fix removes operator-owned fields from the bundle and adds a runtime Runnable. The race condition requires a live OLM upgrade to reproduce — it cannot be covered by unit or existing E2E tests without a dedicated upgrade test scenario. A follow-up E2E upgrade test can be tracked separately.