### PR TITLE
chore: unpin kuberay image digest for RHOAI

### DIFF
--- a/manifests-config.yaml
+++ b/manifests-config.yaml
@@ -31,7 +31,7 @@ components:
       sourcePath: ray-operator/config
     rhoai:
       repo: red-hat-data-services/kuberay
-      ref: rhoai-3.5@b6e2cb5afb65f14562a3d2821dfaa7b14366c1e4
+      ref: rhoai-3.5@a93af8009d0bc6a8a070b4f864e67c9b663557ba
       sourcePath: ray-operator/config
   trustyai:
     odh:
@@ -252,10 +252,9 @@ imageOverrides:
       base: "quay.io/opendatahub/kuberay-operator"
       digest: "sha256:d5c32e7b6c4dd520fb16e6de07aec200b487f222aa503e464a92b2b97ba7bfc3"
     rhoai:
-      pinned: true # pinned because the rhoai-3.5 manifests are not updated with permissions needed from latest digest
       shaFrom: odh
       base: quay.io/opendatahub/kuberay-operator
-      digest: "sha256:257a3c2ada279123774368ed4ac430e9d337196de1ff512d7faf0fea5ecc7acf"
+      digest: "sha256:d5c32e7b6c4dd520fb16e6de07aec200b487f222aa503e464a92b2b97ba7bfc3"
   RELATED_IMAGE_ODH_TRUSTYAI_SERVICE_OPERATOR_IMAGE:
     component: trustyai
     paramsEnvKey: trustyaiOperatorImage


### PR DESCRIPTION
## Description
This PR unpins the kuberay image digest for RHOAI updates the manifest SHA now that the manifests and digests work together. I previously tried to make this change as part of #3921 but that change gets overridden any time the update-manifest-shas action is run.

## Release tracking
<!-- Optional. Set a target release only if this PR must ship in a specific release; it will be prioritized accordingly. -->
<!-- Target release for this PR, e.g. rhoai-3.6 or rhoai-3.7ea1 -->
Release: 
<!-- Required only if a Release is set above. Full link to a jira ticket, e.g. https://redhat.atlassian.net/browse/RHOAIENG-XXXXX -->
Jira:


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully
- [ ] New RELATED_IMAGE mappings are listed in ODH-Build-Config and RHOAI-Build-Config (CI validates names against build-config repos). Include links to build-config PRs in the description.

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [X] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Maintenance**
  * Updated the RHOAI Ray component to a newer revision.
  * Refreshed the RHOAI KubeRay image reference.
  * Removed a fixed-version setting from the RHOAI KubeRay image configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->