### PR TITLE
fix(bundle): strip spec.conversion from bundle CRDs so OLM owns conversion (RHOAIENG-76183)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -555,6 +555,17 @@ bundle: prepare operator-sdk ## Generate bundle manifests and metadata, then val
 	rm bundle.Dockerfile
 	rm -f $(BUNDLE_DIR)/manifests/opendatahub-operator-webhook-service_v1_service.yaml
 	rm -f $(BUNDLE_DIR)/manifests/rhods-operator-webhook-service_v1_service.yaml
+	# RHOAIENG-76183: strip spec.conversion from the bundle CRDs so OLM fully owns the
+	# conversion webhook config. operator-sdk has already synthesised the ConversionWebhook
+	# entry into the CSV webhookdefinitions above (from the CRD's spec.conversion), so OLM
+	# will apply the correct conversion (service + caBundle) after install. Shipping
+	# spec.conversion in the bundle CRD instead makes OLM apply it verbatim during the
+	# InstallPlan preflight (wrong service, no caBundle) and the CR-validation LIST hits an
+	# unreachable webhook -> 404 -> failed upgrade. Non-OLM installs (config/crd) keep their
+	# static conversion, so xKS/self-managed deployments are unaffected.
+	for f in $(BUNDLE_DIR)/manifests/datasciencecluster.opendatahub.io_datascienceclusters.yaml $(BUNDLE_DIR)/manifests/dscinitialization.opendatahub.io_dscinitializations.yaml; do \
+		[ -f "$$f" ] && $(YQ) -i 'del(.spec.conversion)' "$$f"; \
+	done
 CLEANFILES += rhoai-bundle odh-bundle
 
 .PHONY: bundle-all


### PR DESCRIPTION
## Description

The 2.25 -> 3.x OLM upgrade fails with "conversion webhook for datasciencecluster.opendatahub.io/v1, Kind=DataScienceCluster failed: the server could not find the requested resource" (404), blocking the upgrade.

Root cause: OLM applies the bundle CRD verbatim during the InstallPlan preflight. The bundle CRD carries a hardcoded spec.conversion (needed for non-OLM installs) whose service name is wrong for OLM and whose caBundle is absent, so it arms a conversion webhook that cannot be reached until the new operator pod is serving /convert. When OLM re-runs the CR-validation preflight (e.g. after an InstallPlan write conflict), its LIST of existing CRs is routed to that unreachable webhook and 404s, failing the InstallPlan.

Fix: let OLM fully own the conversion webhook configuration, per OLM guidance. operator-sdk still synthesises the CSV ConversionWebhook entry from the CRD's spec.conversion during `make bundle`, so after the manifests are generated we strip spec.conversion from the bundle CRDs only. OLM then applies the CRD with no conversion (the preflight LIST succeeds) and writes the correct conversion config (service + caBundle) from the CSV ConversionWebhook once the install completes and the serving pod is up.

Non-OLM installs consume config/crd, which is untouched and keeps its static spec.conversion, so xKS/self-managed deployments are unaffected.


<!-- For RHOAI PRs, request review on #ai-core-platform-requests Slack channel -->

## Release tracking
<!-- Optional. Set a target release only if this PR must ship in a specific release; it will be prioritized accordingly. -->
<!-- Target release for this PR, e.g. rhoai-3.6 or rhoai-3.7ea1 -->
Release: rhoai-3.5
<!-- Required only if a Release is set above. Full link to a jira ticket, e.g. https://redhat.atlassian.net/browse/RHOAIENG-XXXXX -->
Jira: https://redhat.atlassian.net/browse/RHOAIENG-76183


## How Has This Been Tested?
- installed 2.25.10
- built custom bundle with the changes
- built and deployed custom catalog referencing the bundle
- approved the created installplan
- watched the datasciencecluster CRD in a loop, checking the values and owner of the `.spec.conversion` field


## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully
- [ ] New RELATED_IMAGE mappings are listed in ODH-Build-Config and RHOAI-Build-Config (CI validates names against build-config repos). Include links to build-config PRs in the description.

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [ ] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated generated DataScienceCluster and DSCInitialization manifests to omit unsupported `.spec.conversion` fields when present.
  * Improved compatibility of bundled deployment manifests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->