### PR TITLE
fix(trainer): inject operator namespace into params.env before kustomize

### DIFF
--- a/internal/controller/components/trainer/trainer_controller.go
+++ b/internal/controller/components/trainer/trainer_controller.go
@@ -81,6 +81,7 @@ func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.
 		})).
 		WithAction(precondition.RunlevelGateAction()).
 		WithAction(initialize).
+		WithAction(setKustomizedParams).
 		WithAction(checkJobSetCRD).
 		WithAction(releases.NewAction()).
 		WithAction(kustomize.NewAction()).

--- a/internal/controller/components/trainer/trainer_controller_actions.go
+++ b/internal/controller/components/trainer/trainer_controller_actions.go
@@ -18,6 +18,7 @@ package trainer
 
 import (
 	"context"
+	"fmt"
 
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -29,6 +30,7 @@ import (
 	odherrors "github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/errors"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/precondition"
 	odhtypes "github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
+	odhdeploy "github.com/opendatahub-io/opendatahub-operator/v2/pkg/deploy"
 )
 
 func checkPreConditions(ctx context.Context, rr *odhtypes.ReconciliationRequest) (precondition.CheckResult, error) {
@@ -71,5 +73,25 @@ func checkJobSetCRD(ctx context.Context, rr *odhtypes.ReconciliationRequest) err
 
 func initialize(_ context.Context, rr *odhtypes.ReconciliationRequest) error { //nolint:unparam
 	rr.Manifests = append(rr.Manifests, manifestPath(rr.ManifestsBasePath))
+	return nil
+}
+
+// setKustomizedParams injects runtime values into params.env before kustomize renders the
+// manifests. operator-namespace drives the ServiceMonitor TLS serverName, which must match
+// the namespace the operator is actually deployed into (opendatahub on ODH,
+// redhat-ods-applications on RHOAI).
+func setKustomizedParams(_ context.Context, rr *odhtypes.ReconciliationRequest) error {
+	if len(rr.Manifests) == 0 {
+		return fmt.Errorf("no manifests initialized before setKustomizedParams")
+	}
+
+	extraParams := map[string]string{
+		"operator-namespace": cluster.GetApplicationNamespace(),
+	}
+
+	if err := odhdeploy.ApplyParams(rr.Manifests[0].String(), "params.env", nil, extraParams); err != nil {
+		return fmt.Errorf("failed to update params.env with operator namespace: %w", err)
+	}
+
 	return nil
 }

--- a/internal/controller/components/trainer/trainer_controller_actions.go
+++ b/internal/controller/components/trainer/trainer_controller_actions.go
@@ -18,6 +18,7 @@ package trainer
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
@@ -82,7 +83,7 @@ func initialize(_ context.Context, rr *odhtypes.ReconciliationRequest) error { /
 // redhat-ods-applications on RHOAI).
 func setKustomizedParams(_ context.Context, rr *odhtypes.ReconciliationRequest) error {
 	if len(rr.Manifests) == 0 {
-		return fmt.Errorf("no manifests initialized before setKustomizedParams")
+		return errors.New("no manifests initialized before setKustomizedParams")
 	}
 
 	extraParams := map[string]string{

--- a/internal/controller/components/trainer/trainer_controller_actions_test.go
+++ b/internal/controller/components/trainer/trainer_controller_actions_test.go
@@ -2,7 +2,11 @@
 package trainer
 
 import (
+	"bufio"
 	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	ofapiv2 "github.com/operator-framework/api/pkg/operators/v2"
@@ -12,6 +16,7 @@ import (
 
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/api/components/v1alpha1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/status"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/conditions"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
@@ -184,6 +189,77 @@ func TestCheckPreConditions_Success(t *testing.T) {
 	g.Expect(err).ShouldNot(HaveOccurred())
 	g.Expect(result.Pass).To(BeTrue())
 	g.Expect(result.Message).To(BeEmpty())
+}
+
+func readParamsEnv(t *testing.T, path string) map[string]string {
+	t.Helper()
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("open params.env: %v", err)
+	}
+	defer f.Close()
+
+	m := map[string]string{}
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		k, v, ok := strings.Cut(scanner.Text(), "=")
+		if ok {
+			m[k] = v
+		}
+	}
+	return m
+}
+
+func TestSetKustomizedParams(t *testing.T) {
+	ctx := t.Context()
+	g := NewWithT(t)
+
+	dir := t.TempDir()
+	paramsFile := filepath.Join(dir, "params.env")
+
+	initial := "operator-namespace=opendatahub\nodh-kubeflow-trainer-controller-image=quay.io/example:latest\n"
+	g.Expect(os.WriteFile(paramsFile, []byte(initial), 0600)).To(Succeed())
+
+	cli, err := fakeclient.New()
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	trainer := componentApi.Trainer{}
+	rr := types.ReconciliationRequest{
+		Client:          cli,
+		Instance:        &trainer,
+		Conditions:      conditions.NewManager(&trainer, status.ConditionTypeReady),
+		ManifestsBasePath: dir,
+		Manifests: []types.ManifestInfo{
+			{Path: dir, ContextDir: "", SourcePath: ""},
+		},
+	}
+
+	err = setKustomizedParams(ctx, &rr)
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	params := readParamsEnv(t, paramsFile)
+	g.Expect(params["operator-namespace"]).To(Equal(cluster.GetApplicationNamespace()))
+	// unrelated keys must be preserved
+	g.Expect(params["odh-kubeflow-trainer-controller-image"]).To(Equal("quay.io/example:latest"))
+}
+
+func TestSetKustomizedParams_NoManifests(t *testing.T) {
+	ctx := t.Context()
+	g := NewWithT(t)
+
+	cli, err := fakeclient.New()
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	trainer := componentApi.Trainer{}
+	rr := types.ReconciliationRequest{
+		Client:     cli,
+		Instance:   &trainer,
+		Conditions: conditions.NewManager(&trainer, status.ConditionTypeReady),
+	}
+
+	err = setKustomizedParams(ctx, &rr)
+	g.Expect(err).Should(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("no manifests initialized"))
 }
 
 func TestJobSetConditionFilter(t *testing.T) {

--- a/internal/controller/components/trainer/trainer_controller_actions_test.go
+++ b/internal/controller/components/trainer/trainer_controller_actions_test.go
@@ -225,13 +225,10 @@ func TestSetKustomizedParams(t *testing.T) {
 
 	trainer := componentApi.Trainer{}
 	rr := types.ReconciliationRequest{
-		Client:          cli,
-		Instance:        &trainer,
-		Conditions:      conditions.NewManager(&trainer, status.ConditionTypeReady),
-		ManifestsBasePath: dir,
-		Manifests: []types.ManifestInfo{
-			{Path: dir, ContextDir: "", SourcePath: ""},
-		},
+		Client:     cli,
+		Instance:   &trainer,
+		Conditions: conditions.NewManager(&trainer, status.ConditionTypeReady),
+		Manifests:  []types.ManifestInfo{{Path: dir}},
 	}
 
 	err = setKustomizedParams(ctx, &rr)


### PR DESCRIPTION
## Description

Part of RHOAIENG-72207 (trainer TLS / SecureServing).

The ServiceMonitor for trainer metrics uses a Kustomize replacement to build the TLS `serverName` from `operator-namespace` in `params.env`:

```
serverName: kubeflow-trainer-controller-manager.NAMESPACE.svc
```

The default value is `opendatahub`, which is wrong on RHOAI (`redhat-ods-applications`). The operator's namespace plugin only rewrites `.metadata.namespace` on resources, not arbitrary string values inside spec — so without this fix the ServiceMonitor `serverName` would be wrong on RHOAI and TLS verification would fail.

Fix: add a `setKustomizedParams` action that calls `ApplyParams` with `operator-namespace` set to `cluster.GetApplicationNamespace()` before kustomize renders the manifests. Same pattern used by modelcontroller and feastoperator.

Related PR in trainer repo: opendatahub-io/trainer#206

## How Has This Been Tested?

- Unit tests added for `setKustomizedParams`: verifies the key is updated to the runtime namespace and unrelated keys are preserved.
- Verified `cluster.GetApplicationNamespace()` returns `opendatahub` on ODH and `redhat-ods-applications` on RHOAI.
- All existing trainer controller tests pass.

## Merge criteria

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work