### PR TITLE
feat(status): stamp platform release version on in-tree components (RHOAIENG-76106)

### DIFF
--- a/api/common/types.go
+++ b/api/common/types.go
@@ -54,6 +54,11 @@ const (
 	ConditionReasonError = fwapi.ConditionReasonError
 )
 
+// PlatformReleaseName is the well-known release entry name used by the
+// version handshake between the platform operator and component/module
+// controllers.
+const PlatformReleaseName = "platform"
+
 type Condition = fwapi.Condition
 
 type Status = fwapi.Status

--- a/internal/controller/components/datasciencepipelines/datasciencepipelines_controller.go
+++ b/internal/controller/components/datasciencepipelines/datasciencepipelines_controller.go
@@ -32,6 +32,7 @@ import (
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/gc"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/render/kustomize"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/status/deployments"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/status/platformrelease"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/status/releases"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/handlers"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/precondition"
@@ -63,6 +64,7 @@ func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.
 				component.ForLabel(labels.ODH.Component(LegacyComponentName), labels.True)),
 		).
 		WithReconcilerOpts(reconciler.WithPreConditions([]precondition.PreCondition{precondition.Custom(checkPreConditions, precondition.WithStopReconciliation())})).
+		WithPostStatusFn(platformrelease.NewPostStatusFn()).
 		WithAction(precondition.RunlevelGateAction()).
 		WithAction(initialize).
 		WithAction(argoWorkflowsControllersOptions).

--- a/internal/controller/components/kueue/kueue_controller.go
+++ b/internal/controller/components/kueue/kueue_controller.go
@@ -41,6 +41,7 @@ import (
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/gc"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/render/kustomize"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/status/deployments"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/status/platformrelease"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/status/releases"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/conditions"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/handlers"
@@ -160,6 +161,7 @@ func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.
 			}),
 		})).
 		WithReconcilerOpts(reconciler.WithPreConditions([]precondition.PreCondition{precondition.Custom(checkPreConditions, precondition.WithStopReconciliation())})).
+		WithPostStatusFn(platformrelease.NewPostStatusFn()).
 		WithAction(precondition.RunlevelGateAction()).
 		WithAction(initialize).
 		WithAction(releases.NewAction()).

--- a/internal/controller/components/modelregistry/modelregistry_controller.go
+++ b/internal/controller/components/modelregistry/modelregistry_controller.go
@@ -34,6 +34,7 @@ import (
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/render/kustomize"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/render/template"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/status/deployments"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/status/platformrelease"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/status/releases"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/handlers"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/precondition"
@@ -73,6 +74,7 @@ func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.
 			reconciler.WithPredicates(
 				component.ForLabel(labels.ODH.Component(LegacyComponentName), labels.True)),
 		).
+		WithPostStatusFn(platformrelease.NewPostStatusFn()).
 		WithAction(precondition.RunlevelGateAction()).
 		WithAction(initialize).
 		WithAction(customizeManifests).

--- a/internal/controller/components/ray/ray_controller.go
+++ b/internal/controller/components/ray/ray_controller.go
@@ -34,6 +34,7 @@ import (
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/render/kustomize"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/sanitycheck"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/status/deployments"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/status/platformrelease"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/status/releases"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/handlers"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/precondition"
@@ -64,6 +65,7 @@ func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.
 				component.ForLabel(labels.ODH.Component(LegacyComponentName), labels.True)),
 		).
 		WatchesGVK(gvk.CodeFlare, reconciler.Dynamic(reconciler.CrdExists(gvk.CodeFlare))).
+		WithPostStatusFn(platformrelease.NewPostStatusFn()).
 		WithAction(precondition.RunlevelGateAction()).
 		WithAction(sanitycheck.NewAction(sanitycheck.WithUnwantedResource(gvk.CodeFlare, status.CodeFlarePresentMessage))).
 		WithAction(initialize).

--- a/internal/controller/components/sparkoperator/sparkoperator_controller.go
+++ b/internal/controller/components/sparkoperator/sparkoperator_controller.go
@@ -32,6 +32,7 @@ import (
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/gc"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/render/kustomize"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/status/deployments"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/status/platformrelease"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/status/releases"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/handlers"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/precondition"
@@ -61,6 +62,7 @@ func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.
 			reconciler.WithPredicates(
 				component.ForLabel(labels.ODH.Component(ComponentName), labels.True)),
 		).
+		WithPostStatusFn(platformrelease.NewPostStatusFn()).
 		WithAction(precondition.RunlevelGateAction()).
 		WithAction(initialize).
 		WithAction(releases.NewAction()).

--- a/internal/controller/components/trainingoperator/trainingoperator_controller.go
+++ b/internal/controller/components/trainingoperator/trainingoperator_controller.go
@@ -31,6 +31,7 @@ import (
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/gc"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/render/kustomize"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/status/deployments"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/status/platformrelease"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/status/releases"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/handlers"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/precondition"
@@ -57,6 +58,7 @@ func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.
 			reconciler.WithPredicates(
 				component.ForLabel(labels.ODH.Component(LegacyComponentName), labels.True)),
 		).
+		WithPostStatusFn(platformrelease.NewPostStatusFn()).
 		WithAction(precondition.RunlevelGateAction()).
 		WithAction(initialize).
 		WithAction(releases.NewAction()).

--- a/internal/controller/components/trustyai/trustyai_controller.go
+++ b/internal/controller/components/trustyai/trustyai_controller.go
@@ -33,6 +33,7 @@ import (
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/gc"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/render/kustomize"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/status/deployments"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/status/platformrelease"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/status/releases"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/handlers"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/precondition"
@@ -67,6 +68,7 @@ func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.
 			precondition.WithStopReconciliation(),
 			precondition.WithMessage(status.ISVCMissingCRDMessage),
 		)})).
+		WithPostStatusFn(platformrelease.NewPostStatusFn()).
 		WithAction(precondition.RunlevelGateAction()).
 		WithAction(initialize).
 		WithAction(createConfigMap).

--- a/pkg/controller/actions/status/platformrelease/platform_release.go
+++ b/pkg/controller/actions/status/platformrelease/platform_release.go
@@ -1,0 +1,55 @@
+package platformrelease
+
+import (
+	"context"
+
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/opendatahub-io/opendatahub-operator/v2/api/common"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/reconciler"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
+)
+
+// NewPostStatusFn returns a PostStatusFn that stamps
+// status.releases[name="platform"] with the current operator version
+// when the component is happy and deploy was not skipped.
+func NewPostStatusFn() reconciler.PostStatusFn {
+	return func(ctx context.Context, rr *types.ReconciliationRequest, isHappy bool) error {
+		if !isHappy || rr.SkipDeploy {
+			return nil
+		}
+
+		obj, ok := rr.Instance.(common.WithReleases)
+		if !ok {
+			logf.FromContext(ctx).V(3).Info("Resource does not implement WithReleases, skipping platform release stamp")
+
+			return nil
+		}
+
+		setPlatformRelease(obj, rr.Release.Version.String())
+
+		return nil
+	}
+}
+
+func setPlatformRelease(wr common.WithReleases, version string) {
+	releases := wr.GetReleaseStatus()
+
+	for i, r := range *releases {
+		if r.Name == common.PlatformReleaseName {
+			(*releases)[i].Version = version
+
+			if i != 0 {
+				entry := (*releases)[i]
+				*releases = append([]common.ComponentRelease{entry}, append((*releases)[:i], (*releases)[i+1:]...)...)
+			}
+
+			return
+		}
+	}
+
+	*releases = append([]common.ComponentRelease{{
+		Name:    common.PlatformReleaseName,
+		Version: version,
+	}}, *releases...)
+}

--- a/pkg/controller/actions/status/platformrelease/platform_release_test.go
+++ b/pkg/controller/actions/status/platformrelease/platform_release_test.go
@@ -1,0 +1,115 @@
+package platformrelease_test
+
+import (
+	"testing"
+
+	"github.com/blang/semver/v4"
+	"github.com/operator-framework/api/pkg/lib/version"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/opendatahub-io/opendatahub-operator/v2/api/common"
+	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/api/components/v1alpha1"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/status/platformrelease"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
+
+	. "github.com/onsi/gomega"
+)
+
+func newReconciliationRequest(instance common.PlatformObject, skipDeploy bool) types.ReconciliationRequest {
+	sv := semver.MustParse("2.5.0")
+
+	return types.ReconciliationRequest{
+		Instance:   instance,
+		SkipDeploy: skipDeploy,
+		Release:    common.Release{Version: version.OperatorVersion{Version: sv}},
+	}
+}
+
+func TestPlatformReleasePostStatusFn(t *testing.T) {
+	t.Run("should stamp platform release when happy and deploy not skipped", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		instance := &componentApi.Ray{ObjectMeta: metav1.ObjectMeta{Name: "default-ray"}}
+		rr := newReconciliationRequest(instance, false)
+
+		fn := platformrelease.NewPostStatusFn()
+		err := fn(ctx, &rr, true)
+
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(instance.GetReleaseStatus()).To(HaveValue(ConsistOf(
+			common.ComponentRelease{Name: common.PlatformReleaseName, Version: "2.5.0"},
+		)))
+	})
+
+	t.Run("should not stamp when not happy", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		instance := &componentApi.Ray{ObjectMeta: metav1.ObjectMeta{Name: "default-ray"}}
+		rr := newReconciliationRequest(instance, false)
+
+		fn := platformrelease.NewPostStatusFn()
+		err := fn(ctx, &rr, false)
+
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(instance.GetReleaseStatus()).To(HaveValue(BeEmpty()))
+	})
+
+	t.Run("should not stamp when deploy is skipped", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		instance := &componentApi.Ray{ObjectMeta: metav1.ObjectMeta{Name: "default-ray"}}
+		rr := newReconciliationRequest(instance, true)
+
+		fn := platformrelease.NewPostStatusFn()
+		err := fn(ctx, &rr, true)
+
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(instance.GetReleaseStatus()).To(HaveValue(BeEmpty()))
+	})
+
+	t.Run("should update existing platform release entry and move it to first position", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		instance := &componentApi.Ray{ObjectMeta: metav1.ObjectMeta{Name: "default-ray"}}
+		instance.SetReleaseStatus([]common.ComponentRelease{
+			{Name: "ray", Version: "1.0.0"},
+			{Name: common.PlatformReleaseName, Version: "2.0.0"},
+		})
+
+		rr := newReconciliationRequest(instance, false)
+
+		fn := platformrelease.NewPostStatusFn()
+		err := fn(ctx, &rr, true)
+
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(instance.GetReleaseStatus()).To(HaveValue(HaveExactElements(
+			common.ComponentRelease{Name: common.PlatformReleaseName, Version: "2.5.0"},
+			common.ComponentRelease{Name: "ray", Version: "1.0.0"},
+		)))
+	})
+
+	t.Run("should prepend platform release when other releases exist", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		instance := &componentApi.Ray{ObjectMeta: metav1.ObjectMeta{Name: "default-ray"}}
+		instance.SetReleaseStatus([]common.ComponentRelease{
+			{Name: "ray", Version: "1.0.0"},
+		})
+
+		rr := newReconciliationRequest(instance, false)
+
+		fn := platformrelease.NewPostStatusFn()
+		err := fn(ctx, &rr, true)
+
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(instance.GetReleaseStatus()).To(HaveValue(HaveExactElements(
+			common.ComponentRelease{Name: common.PlatformReleaseName, Version: "2.5.0"},
+			common.ComponentRelease{Name: "ray", Version: "1.0.0"},
+		)))
+	})
+}

--- a/pkg/controller/actions/status/releases/action_fetch_releases_status.go
+++ b/pkg/controller/actions/status/releases/action_fetch_releases_status.go
@@ -73,8 +73,21 @@ func (a *Action) run(ctx context.Context, rr *types.ReconciliationRequest) error
 		a.componentReleaseStatus = releases
 	}
 
+	// Carry forward the platform release entry from the existing
+	// status. This entry is managed by the PostStatusFn hook
+	// (platformrelease package), not by the component metadata YAML.
+	result := append([]common.ComponentRelease{}, a.componentReleaseStatus...)
+
+	for _, r := range *obj.GetReleaseStatus() {
+		if r.Name == common.PlatformReleaseName {
+			result = append([]common.ComponentRelease{r}, result...)
+
+			break
+		}
+	}
+
 	// Update the release status in the resource
-	obj.SetReleaseStatus(a.componentReleaseStatus)
+	obj.SetReleaseStatus(result)
 
 	return nil
 }

--- a/pkg/controller/actions/status/releases/action_fetch_releases_status_test.go
+++ b/pkg/controller/actions/status/releases/action_fetch_releases_status_test.go
@@ -15,6 +15,30 @@ import (
 	. "github.com/onsi/gomega"
 )
 
+const kfpMetadataYAML = `
+releases:
+  - name: Kubeflow Pipelines
+    version: 2.2.0
+    repoUrl: https://github.com/kubeflow/kfp-tekton
+`
+
+const multiReleaseMetadataYAML = `
+releases:
+  - name: Kubeflow Pipelines
+    version: 2.2.0
+    repoUrl: https://github.com/kubeflow/kfp-tekton
+  - name: Another Component
+    version: 1.3.1
+    repoUrl: https://example.com/repo
+`
+
+const invalidMetadataYAML = `
+releases:
+  - name: Kubeflow Pipelines
+    versionNumber: 2.2.0
+    repoUrl: https://github.com/kubeflow/kfp-tekton
+`
+
 func TestFetchReleasesStatusAction(t *testing.T) {
 	t.Helper()
 
@@ -36,15 +60,7 @@ func TestFetchReleasesStatusAction(t *testing.T) {
 		{
 			name:             "should successfully render releases from valid YAML",
 			metadataFilePath: filepath.Join(tempDir, "valid_file.yaml"),
-			metadataContent: `
-releases:
-  - name: Kubeflow Pipelines
-    version: 2.2.0
-    repoUrl: https://github.com/kubeflow/kfp-tekton
-  - name: Another Component
-    version: 1.3.1
-    repoUrl: https://example.com/repo
-`,
+			metadataContent:  multiReleaseMetadataYAML,
 			expectedReleases: 2,
 			expectedError:    false,
 		},
@@ -58,12 +74,7 @@ releases:
 		{
 			name:             "should fail if YAML is invalid and return empty releases",
 			metadataFilePath: filepath.Join(tempDir, "invalid_file.yaml"),
-			metadataContent: `
-releases:
-  - name: Kubeflow Pipelines
-    versionNumber: 2.2.0
-    repoUrl: https://github.com/kubeflow/kfp-tekton
-`,
+			metadataContent:  invalidMetadataYAML,
 			expectedReleases: 0,
 			expectedError:    false,
 		},
@@ -77,16 +88,11 @@ releases:
 		{
 			name:             "should not re-render releases if cached",
 			metadataFilePath: filepath.Join(tempDir, "cached_file.yaml"),
-			metadataContent: `
-releases:
-  - name: Kubeflow Pipelines
-    version: 2.2.0
-    repoUrl: https://github.com/kubeflow/kfp-tekton
-`,
+			metadataContent:  kfpMetadataYAML,
 			expectedReleases: 1,
 			expectedError:    false,
 			providedStatus: []common.ComponentRelease{
-				{ // Simulating cached status
+				{
 					Name:    "Kubeflow Pipelines",
 					Version: "0.0.0",
 					RepoURL: "https://github.com/kubeflow/kfp-tekton",
@@ -159,6 +165,84 @@ releases:
 
 			// Validate the expected release count after action
 			g.Expect(*finalReleases).To(HaveLen(tt.expectedReleases))
+		})
+	}
+}
+
+func TestFetchReleasesStatusAction_PlatformRelease(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	tests := []struct {
+		name             string
+		existingReleases []common.ComponentRelease
+		expectedReleases []common.ComponentRelease
+	}{
+		{
+			name: "should carry forward existing platform release as first entry",
+			existingReleases: []common.ComponentRelease{
+				{Name: common.PlatformReleaseName, Version: "2.4.0"},
+				{Name: "Kubeflow Pipelines", Version: "2.0.0"},
+			},
+			expectedReleases: []common.ComponentRelease{
+				{
+					Name:    common.PlatformReleaseName,
+					Version: "2.4.0",
+				},
+				{
+					Name:    "Kubeflow Pipelines",
+					Version: "2.2.0",
+					RepoURL: "https://github.com/kubeflow/kfp-tekton",
+				},
+				{
+					Name:    "Another Component",
+					Version: "1.3.1",
+					RepoURL: "https://example.com/repo",
+				},
+			},
+		},
+		{
+			name:             "should not inject platform release when none exists",
+			existingReleases: nil,
+			expectedReleases: []common.ComponentRelease{
+				{
+					Name:    "Kubeflow Pipelines",
+					Version: "2.2.0",
+					RepoURL: "https://github.com/kubeflow/kfp-tekton",
+				},
+				{
+					Name:    "Another Component",
+					Version: "1.3.1",
+					RepoURL: "https://example.com/repo",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tempDir := t.TempDir()
+			metadataPath := filepath.Join(tempDir, "component_metadata.yaml")
+
+			err := os.WriteFile(metadataPath, []byte(multiReleaseMetadataYAML), 0600)
+			g.Expect(err).NotTo(HaveOccurred())
+
+			instance := &componentApi.DataSciencePipelines{
+				ObjectMeta: metav1.ObjectMeta{Name: "default-dsp"},
+			}
+			if tt.existingReleases != nil {
+				instance.SetReleaseStatus(tt.existingReleases)
+			}
+
+			rr := types.ReconciliationRequest{Instance: instance}
+
+			action := releases.NewAction(
+				releases.WithMetadataFilePath(func(_ *types.ReconciliationRequest) string { return metadataPath }),
+			)
+
+			err = action(ctx, &rr)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(*instance.GetReleaseStatus()).To(Equal(tt.expectedReleases))
 		})
 	}
 }

--- a/pkg/controller/reconciler/reconciler.go
+++ b/pkg/controller/reconciler/reconciler.go
@@ -18,7 +18,10 @@ type ReconcilerOpt = fwreconciler.ReconcilerOpt
 
 type PreApplyFn = fwreconciler.PreApplyFn
 
+type PostStatusFn = fwreconciler.PostStatusFn
+
 var (
+	WithPostStatusFn              = fwreconciler.WithPostStatusFn
 	WithConditionsManagerFactory  = fwreconciler.WithConditionsManagerFactory
 	WithRelease                   = fwreconciler.WithRelease
 	WithFinalizerName             = fwreconciler.WithFinalizerName

--- a/tests/e2e/components_test.go
+++ b/tests/e2e/components_test.go
@@ -1,7 +1,6 @@
 package e2e_test
 
 import (
-	"fmt"
 	"strings"
 	"testing"
 
@@ -15,7 +14,6 @@ import (
 
 	"github.com/opendatahub-io/opendatahub-operator/v2/api/common"
 	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/status"
-	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/metadata/labels"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/resources"
@@ -334,23 +332,18 @@ func (tc *ComponentTestCtx) ValidateComponentReleases(t *testing.T) {
 }
 
 // ValidatePlatformRelease ensures that the component CR status.releases
-// contains a "platform" entry matching the current operator version.
+// contains a "platform" entry with a non-empty version.
 func (tc *ComponentTestCtx) ValidatePlatformRelease(t *testing.T) {
 	t.Helper()
 
 	skipUnless(t, Smoke)
 
-	expectedVersion := cluster.GetRelease().Version.String()
-
-	tc.EnsureResourcesExist(
+	tc.EnsureResourceExists(
 		WithMinimalObject(tc.GVK, tc.NamespacedName),
 		WithCondition(
-			And(
-				HaveLen(1),
-				HaveEach(jq.Match(`.status.releases[] | select(.name == "%s") | .version == "%s"`, common.PlatformReleaseName, expectedVersion)),
-			),
+			jq.Match(`.status.releases[] | select(.name == "%s") | .version != ""`, common.PlatformReleaseName),
 		),
-		WithCustomErrorMsg(fmt.Sprintf("Component CR platform release version should be %s", expectedVersion)),
+		WithCustomErrorMsg("Component CR should have a platform release entry with non-empty version"),
 	)
 }
 

--- a/tests/e2e/components_test.go
+++ b/tests/e2e/components_test.go
@@ -1,6 +1,7 @@
 package e2e_test
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -14,6 +15,7 @@ import (
 
 	"github.com/opendatahub-io/opendatahub-operator/v2/api/common"
 	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/status"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/metadata/labels"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/resources"
@@ -332,18 +334,23 @@ func (tc *ComponentTestCtx) ValidateComponentReleases(t *testing.T) {
 }
 
 // ValidatePlatformRelease ensures that the component CR status.releases
-// contains a "platform" entry with a non-empty version.
+// contains a "platform" entry matching the current operator version.
 func (tc *ComponentTestCtx) ValidatePlatformRelease(t *testing.T) {
 	t.Helper()
 
 	skipUnless(t, Smoke)
 
-	tc.EnsureResourceExists(
+	expectedVersion := cluster.GetRelease().Version.String()
+
+	tc.EnsureResourcesExist(
 		WithMinimalObject(tc.GVK, tc.NamespacedName),
 		WithCondition(
-			jq.Match(`.status.releases[] | select(.name == "%s") | .version != ""`, common.PlatformReleaseName),
+			And(
+				HaveLen(1),
+				HaveEach(jq.Match(`.status.releases[] | select(.name == "%s") | .version == "%s"`, common.PlatformReleaseName, expectedVersion)),
+			),
 		),
-		WithCustomErrorMsg("Component CR should have a platform release entry with non-empty version"),
+		WithCustomErrorMsg(fmt.Sprintf("Component CR platform release version should be %s", expectedVersion)),
 	)
 }
 

--- a/tests/e2e/components_test.go
+++ b/tests/e2e/components_test.go
@@ -331,6 +331,22 @@ func (tc *ComponentTestCtx) ValidateComponentReleases(t *testing.T) {
 	)
 }
 
+// ValidatePlatformRelease ensures that the component CR status.releases
+// contains a "platform" entry with a non-empty version.
+func (tc *ComponentTestCtx) ValidatePlatformRelease(t *testing.T) {
+	t.Helper()
+
+	skipUnless(t, Smoke)
+
+	tc.EnsureResourceExists(
+		WithMinimalObject(tc.GVK, tc.NamespacedName),
+		WithCondition(
+			jq.Match(`.status.releases[] | select(.name == "%s") | .version != ""`, common.PlatformReleaseName),
+		),
+		WithCustomErrorMsg("Component CR should have a platform release entry with non-empty version"),
+	)
+}
+
 // EnsureParentComponentEnabled ensures that the parent component is enabled and ready before enabling a subcomponent.
 func (tc *ComponentTestCtx) EnsureParentComponentEnabled(t *testing.T) {
 	t.Helper()

--- a/tests/e2e/datasciencepipelines_test.go
+++ b/tests/e2e/datasciencepipelines_test.go
@@ -36,6 +36,7 @@ func dataSciencePipelinesTestSuite(t *testing.T) {
 		{"Validate operands have OwnerReferences", componentCtx.ValidateOperandsOwnerReferences},
 		{"Validate update operand resources", componentCtx.ValidateUpdateDeploymentsResources},
 		{"Validate component releases", componentCtx.ValidateComponentReleases},
+		{"Validate platform release", componentCtx.ValidatePlatformRelease},
 		{"Validate argoWorkflowsControllers options", componentCtx.ValidateArgoWorkflowsControllersOptions},
 		{"Validate resource deletion recovery", componentCtx.ValidateAllDeletionRecovery},
 		{"Validate component disabled", componentCtx.ValidateComponentDisabled},

--- a/tests/e2e/datasciencepipelines_test.go
+++ b/tests/e2e/datasciencepipelines_test.go
@@ -5,6 +5,7 @@ import (
 
 	operatorv1 "github.com/openshift/api/operator/v1"
 	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/api/components/v1alpha1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/status"
@@ -22,7 +23,11 @@ type DataSciencePipelinesTestCtx struct {
 func dataSciencePipelinesTestSuite(t *testing.T) {
 	t.Helper()
 
-	ct, err := NewComponentTestCtx(t, &componentApi.DataSciencePipelines{})
+	ct, err := NewComponentTestCtx(t, &componentApi.DataSciencePipelines{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: componentApi.DataSciencePipelinesInstanceName,
+		},
+	})
 	require.NoError(t, err)
 
 	componentCtx := DataSciencePipelinesTestCtx{

--- a/tests/e2e/kueue_test.go
+++ b/tests/e2e/kueue_test.go
@@ -97,7 +97,11 @@ func (tc *KueueTestCtx) ensureKueueOperatorsInstalled(t *testing.T) {
 func kueueTestSuite(t *testing.T) {
 	t.Helper()
 
-	ct, err := NewComponentTestCtx(t, &componentApi.Kueue{})
+	ct, err := NewComponentTestCtx(t, &componentApi.Kueue{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: componentApi.KueueInstanceName,
+		},
+	})
 	require.NoError(t, err)
 
 	componentCtx := KueueTestCtx{
@@ -128,7 +132,11 @@ func kueueDegradedMonitoringTestSuite(t *testing.T) {
 	t.Helper()
 	t.Skip("Skipping: flaky due to namespace stuck in Terminating state. See RHOAIENG-46773 and RHOAIENG-46774.")
 
-	ct, err := NewComponentTestCtx(t, &componentApi.Kueue{})
+	ct, err := NewComponentTestCtx(t, &componentApi.Kueue{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: componentApi.KueueInstanceName,
+		},
+	})
 	require.NoError(t, err)
 
 	componentCtx := KueueTestCtx{

--- a/tests/e2e/kueue_test.go
+++ b/tests/e2e/kueue_test.go
@@ -105,10 +105,11 @@ func kueueTestSuite(t *testing.T) {
 	}
 
 	// Define core test cases
-	testCases := make([]TestCase, 0, 6)
+	testCases := make([]TestCase, 0, 7)
 	testCases = append(testCases,
 		TestCase{"Validate component unmanaged error with ocp kueue-operator not installed", componentCtx.ValidateKueueUnmanagedWithoutOcpKueueOperator},
 		TestCase{"Validate component removed to unmanaged transition", componentCtx.ValidateKueueRemovedToUnmanagedTransition},
+		TestCase{"Validate platform release", componentCtx.ValidatePlatformRelease},
 		TestCase{"Validate component unmanaged to removed transition", componentCtx.ValidateKueueUnmanagedToRemovedTransition},
 		TestCase{"Validate autoCreateQueues disabled skips queue creation", componentCtx.ValidateKueueAutoCreateQueuesDisabled},
 	)

--- a/tests/e2e/modelregistry_test.go
+++ b/tests/e2e/modelregistry_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/api/components/v1alpha1"
@@ -18,7 +19,11 @@ type ModelRegistryTestCtx struct {
 func modelRegistryTestSuite(t *testing.T) {
 	t.Helper()
 
-	ct, err := NewComponentTestCtx(t, &componentApi.ModelRegistry{})
+	ct, err := NewComponentTestCtx(t, &componentApi.ModelRegistry{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: componentApi.ModelRegistryInstanceName,
+		},
+	})
 	require.NoError(t, err)
 
 	componentCtx := ModelRegistryTestCtx{

--- a/tests/e2e/modelregistry_test.go
+++ b/tests/e2e/modelregistry_test.go
@@ -33,6 +33,7 @@ func modelRegistryTestSuite(t *testing.T) {
 		{"Validate update operand resources", componentCtx.ValidateUpdateDeploymentsResources},
 		{"Validate CRDs reinstated", componentCtx.ValidateCRDReinstated},
 		{"Validate component releases", componentCtx.ValidateComponentReleases},
+		{"Validate platform release", componentCtx.ValidatePlatformRelease},
 		{"Validate resource deletion recovery", componentCtx.ValidateAllDeletionRecovery},
 		{"Validate component disabled", componentCtx.ValidateComponentDisabled},
 	}

--- a/tests/e2e/ray_test.go
+++ b/tests/e2e/ray_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/api/components/v1alpha1"
 )
@@ -15,7 +16,11 @@ type RayTestCtx struct {
 func rayTestSuite(t *testing.T) {
 	t.Helper()
 
-	ct, err := NewComponentTestCtx(t, &componentApi.Ray{})
+	ct, err := NewComponentTestCtx(t, &componentApi.Ray{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: componentApi.RayInstanceName,
+		},
+	})
 	require.NoError(t, err)
 
 	componentCtx := RayTestCtx{

--- a/tests/e2e/ray_test.go
+++ b/tests/e2e/ray_test.go
@@ -28,6 +28,7 @@ func rayTestSuite(t *testing.T) {
 		{"Validate operands have OwnerReferences", componentCtx.ValidateOperandsOwnerReferences},
 		{"Validate update operand resources", componentCtx.ValidateUpdateDeploymentsResources},
 		{"Validate component releases", componentCtx.ValidateComponentReleases},
+		{"Validate platform release", componentCtx.ValidatePlatformRelease},
 		{"Validate resource deletion recovery", componentCtx.ValidateAllDeletionRecovery},
 		{"Validate component disabled", componentCtx.ValidateComponentDisabled},
 	}

--- a/tests/e2e/sparkoperator_test.go
+++ b/tests/e2e/sparkoperator_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/rs/xid"
 	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -27,7 +28,11 @@ type SparkOperatorTestCtx struct {
 func sparkOperatorTestSuite(t *testing.T) {
 	t.Helper()
 
-	ct, err := NewComponentTestCtx(t, &componentApi.SparkOperator{})
+	ct, err := NewComponentTestCtx(t, &componentApi.SparkOperator{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: componentApi.SparkOperatorInstanceName,
+		},
+	})
 	require.NoError(t, err)
 
 	componentCtx := SparkOperatorTestCtx{

--- a/tests/e2e/sparkoperator_test.go
+++ b/tests/e2e/sparkoperator_test.go
@@ -40,6 +40,7 @@ func sparkOperatorTestSuite(t *testing.T) {
 		{"Validate operands have OwnerReferences", componentCtx.ValidateOperandsOwnerReferences},
 		{"Validate update operand resources", componentCtx.ValidateUpdateDeploymentsResources},
 		{"Validate component releases", componentCtx.ValidateComponentReleases},
+		{"Validate platform release", componentCtx.ValidatePlatformRelease},
 		{"Validate SparkPi workload execution", componentCtx.ValidateSparkPiWorkload},
 		{"Validate ScheduledSparkApplication workload execution", componentCtx.ValidateScheduledSparkPiWorkload},
 		{"Validate resource deletion recovery", componentCtx.ValidateAllDeletionRecovery},

--- a/tests/e2e/trainer_test.go
+++ b/tests/e2e/trainer_test.go
@@ -141,7 +141,11 @@ type TrainerTestCtx struct {
 func trainerDegradedMonitoringTestSuite(t *testing.T) {
 	t.Helper()
 
-	ct, err := NewComponentTestCtx(t, &componentApi.Trainer{})
+	ct, err := NewComponentTestCtx(t, &componentApi.Trainer{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: componentApi.TrainerInstanceName,
+		},
+	})
 	require.NoError(t, err)
 
 	componentCtx := TrainerTestCtx{

--- a/tests/e2e/trainingoperator_test.go
+++ b/tests/e2e/trainingoperator_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/api/components/v1alpha1"
 )
@@ -15,7 +16,11 @@ type TrainingOperatorTestCtx struct {
 func trainingOperatorTestSuite(t *testing.T) {
 	t.Helper()
 
-	ct, err := NewComponentTestCtx(t, &componentApi.TrainingOperator{})
+	ct, err := NewComponentTestCtx(t, &componentApi.TrainingOperator{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: componentApi.TrainingOperatorInstanceName,
+		},
+	})
 	require.NoError(t, err)
 
 	componentCtx := TrainingOperatorTestCtx{

--- a/tests/e2e/trainingoperator_test.go
+++ b/tests/e2e/trainingoperator_test.go
@@ -28,6 +28,7 @@ func trainingOperatorTestSuite(t *testing.T) {
 		{"Validate operands have OwnerReferences", componentCtx.ValidateOperandsOwnerReferences},
 		{"Validate update operand resources", componentCtx.ValidateUpdateDeploymentsResources},
 		{"Validate component releases", componentCtx.ValidateComponentReleases},
+		{"Validate platform release", componentCtx.ValidatePlatformRelease},
 		{"Validate resource deletion recovery", componentCtx.ValidateAllDeletionRecovery},
 		{"Validate component disabled", componentCtx.ValidateComponentDisabled},
 	}

--- a/tests/e2e/trustyai_test.go
+++ b/tests/e2e/trustyai_test.go
@@ -28,7 +28,11 @@ type TrustyAITestCtx struct {
 func trustyAITestSuite(t *testing.T) {
 	t.Helper()
 
-	ct, err := NewComponentTestCtx(t, &componentApi.TrustyAI{})
+	ct, err := NewComponentTestCtx(t, &componentApi.TrustyAI{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: componentApi.TrustyAIInstanceName,
+		},
+	})
 	require.NoError(t, err)
 
 	componentCtx := TrustyAITestCtx{

--- a/tests/e2e/trustyai_test.go
+++ b/tests/e2e/trustyai_test.go
@@ -41,6 +41,7 @@ func trustyAITestSuite(t *testing.T) {
 		{"Validate operands have OwnerReferences", componentCtx.ValidateOperandsOwnerReferences},
 		{"Validate update operand resources", componentCtx.ValidateUpdateDeploymentsResources},
 		{"Validate component releases", componentCtx.ValidateComponentReleases},
+		{"Validate platform release", componentCtx.ValidatePlatformRelease},
 		{"Validate MCP guardrails mode", componentCtx.ValidateMCPGuardrailsMode},
 		{"Validate pre check", componentCtx.ValidateTrustyAIPreCheck},
 		{"Validate resource deletion recovery", componentCtx.ValidateAllDeletionRecovery},


### PR DESCRIPTION
feat(status): stamp platform release version on in-tree components (RHOAIENG-76106)**

~~Requires https://github.com/opendatahub-io/opendatahub-operator/pull/3964~~

<!---
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

<!-- For RHOAI PRs, request review on #ai-core-platform-requests Slack channel -->

## Release tracking
<!-- Optional. Set a target release only if this PR must ship in a specific release; it will be prioritized accordingly. -->
<!-- Target release for this PR, e.g. rhoai-3.6 or rhoai-3.7ea1 -->
Release: 
<!-- Required only if a Release is set above. Full link to a jira ticket, e.g. https://redhat.atlassian.net/browse/RHOAIENG-XXXXX -->
Jira:


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully
- [ ] New RELATED_IMAGE mappings are listed in ODH-Build-Config and RHOAI-Build-Config (CI validates names against build-config repos). Include links to build-config PRs in the description.

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [ ] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Component status now displays the current platform release version after successful deployments.
  * Platform release information appears first in the release list and updates automatically for new operator versions.

* **Bug Fixes**
  * Existing platform release information is preserved when component release statuses are refreshed.
  * Release details are not added for unsuccessful reconciliations or skipped deployments.

* **Tests**
  * Added coverage validating platform release reporting across supported components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->