### PR TITLE
feat(RHOAIENG-81894): add freeze-window hold automation for priority merge queue

### DIFF
--- a/.github/freeze.json
+++ b/.github/freeze.json
@@ -1,0 +1,4 @@
+{
+  "hold-window-days": 7,
+  "releases": []
+}

--- a/.github/workflows/pr-freeze-hold.yaml
+++ b/.github/workflows/pr-freeze-hold.yaml
@@ -1,0 +1,245 @@
+name: Freeze window hold automation
+
+on:
+  pull_request_target:
+    types: [opened, edited, labeled, unlabeled, synchronize]
+  push:
+    branches: [main]
+    paths: ['.github/freeze.json']
+  schedule:
+    - cron: '0 8 * * *'
+  workflow_dispatch: {}
+
+permissions:
+  pull-requests: write
+  contents: read
+
+concurrency:
+  group: >-
+    freeze-hold-${{
+      github.event_name == 'pull_request_target'
+        && format('pr-{0}', github.event.pull_request.number)
+        || 'bulk'
+    }}
+  cancel-in-progress: true
+
+jobs:
+  freeze-hold:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout freeze config
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          sparse-checkout: |
+            .github/freeze.json
+          sparse-checkout-cone-mode: false
+
+      - name: Evaluate PRs and manage hold labels
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        with:
+          script: |
+            const fs = require('fs');
+
+            const HOLD_LABEL = 'do-not-merge/release-freeze-hold';
+            const COMMENT_TAG = '<!-- freeze-hold-bot -->';
+            const CONFIG_PATH = '.github/freeze.json';
+
+            const EXEMPT_AUTHORS = [
+              'odh-release-bot[bot]',
+              'dependabot[bot]',
+              'openshift-merge-bot[bot]',
+              'red-hat-konflux[bot]',
+              'github-actions[bot]',
+              'odh-drs-automation-bot[bot]',
+            ];
+            const EXEMPT_BRANCHES = ['sync/upgrade-manifest-shas'];
+
+            // A PR's release target is set via its description `Release:` field,
+            // the same source of truth the pr-release-label workflow reads. We
+            // check both the description AND the applied label because they can
+            // legitimately diverge in time: on `opened` both workflows run
+            // concurrently so the label may not exist yet, and pr-release-label
+            // writes the label with GITHUB_TOKEN (which does not re-trigger this
+            // workflow). Reading the description makes the exemption immediate
+            // and independent of that race; the label check additionally honors
+            // release labels applied manually without editing the description.
+            const RELEASE_FIELD_RE = /^Release:\s*(rhoai-\d+\.\d+(?:ea\d+)?)\s*$/m;
+
+            // --- Parse freeze config ---
+
+            // holdActiveLabels: releases whose hold window is currently open.
+            //   Their presence means the hold is actively enforced right now.
+            // exemptLabels: releases whose hold window has started, INCLUDING
+            //   ones whose freeze date has already passed. A PR carrying any of
+            //   these labels is exempt from the hold. Keeping past releases here
+            //   lets ongoing work (e.g. blocker fixes for an already-frozen
+            //   release) merge during a later release's freeze, until the past
+            //   release is removed from the config.
+            let holdActiveLabels = [];
+            let exemptLabels = [];
+
+            try {
+              const config = JSON.parse(fs.readFileSync(CONFIG_PATH, 'utf8'));
+
+              if (config && typeof config === 'object') {
+                const windowDays = parseInt(config['hold-window-days'], 10) || 7;
+                const releases = config.releases || [];
+                const today = new Date();
+                today.setUTCHours(0, 0, 0, 0);
+
+                for (const release of releases) {
+                  try {
+                    const freezeDate = new Date(release.freeze + 'T00:00:00Z');
+                    const windowStart = new Date(freezeDate);
+                    windowStart.setUTCDate(windowStart.getUTCDate() - windowDays);
+
+                    // Window has started (current or past freeze) — label exempts.
+                    if (today >= windowStart) {
+                      exemptLabels.push(release.label);
+                    }
+
+                    // Currently within the hold window — enforce holds.
+                    if (today >= windowStart && today <= freezeDate) {
+                      holdActiveLabels.push(release.label);
+                      core.info(`Freeze window active for ${release.label} ` +
+                        `(${windowStart.toISOString().slice(0,10)} to ${freezeDate.toISOString().slice(0,10)})`);
+                    }
+                  } catch (e) {
+                    core.warning(`Skipping malformed release entry: ${JSON.stringify(release)} (${e.message})`);
+                  }
+                }
+              }
+            } catch (e) {
+              core.warning(`Failed to parse ${CONFIG_PATH}: ${e.message} — treating as no active freeze`);
+            }
+
+            const freezeActive = holdActiveLabels.length > 0;
+
+            if (!freezeActive) {
+              core.info('No active freeze window');
+            }
+
+            // --- Collect PRs to evaluate ---
+
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+
+            let prs;
+            if (context.eventName === 'pull_request_target') {
+              prs = [context.payload.pull_request];
+            } else {
+              prs = await github.paginate(github.rest.pulls.list, {
+                owner,
+                repo,
+                state: 'open',
+                per_page: 100,
+              });
+            }
+
+            core.info(`Evaluating ${prs.length} PR(s), freeze active: ${freezeActive}`);
+            if (freezeActive) {
+              core.info(`Hold window labels: ${holdActiveLabels.join(', ')}`);
+              core.info(`Exempt release labels: ${exemptLabels.join(', ')}`);
+            }
+
+            // --- Evaluate each PR ---
+
+            for (const pr of prs) {
+              const prNumber = pr.number;
+              const author = pr.user.login;
+              const branch = pr.head.ref;
+              const prLabels = pr.labels.map(l => l.name);
+
+              if (EXEMPT_AUTHORS.includes(author)) {
+                core.info(`PR #${prNumber}: skip (exempt author ${author})`);
+                continue;
+              }
+              if (EXEMPT_BRANCHES.includes(branch)) {
+                core.info(`PR #${prNumber}: skip (exempt branch ${branch})`);
+                continue;
+              }
+
+              const hasHold = prLabels.includes(HOLD_LABEL);
+              const bodyMatch = (pr.body || '').match(RELEASE_FIELD_RE);
+              const bodyRelease = bodyMatch ? bodyMatch[1] : null;
+              const hasReleaseLabel = freezeActive && (
+                exemptLabels.some(label => prLabels.includes(label)) ||
+                (bodyRelease !== null && exemptLabels.includes(bodyRelease))
+              );
+
+              if (freezeActive && !hasReleaseLabel && !hasHold) {
+                await github.rest.issues.addLabels({
+                  owner, repo,
+                  issue_number: prNumber,
+                  labels: [HOLD_LABEL],
+                });
+                core.info(`PR #${prNumber}: applied hold (missing release label)`);
+
+                const releaseLabelsStr = holdActiveLabels.map(l => `\`${l}\``).join(' or ');
+                const repoUrl = context.payload.repository?.html_url ?? `https://github.com/${owner}/${repo}`;
+                const defaultBranch = context.payload.repository?.default_branch ?? 'main';
+                const commentBody = [
+                  COMMENT_TAG,
+                  '',
+                  'This PR has been held from merging because a **release freeze window** is active.',
+                  '',
+                  `To exempt this PR, add the ${releaseLabelsStr} label.`,
+                  '',
+                  'The hold will be automatically removed when the freeze window ends.',
+                  `See [\`.github/freeze.json\`](${repoUrl}/blob/${defaultBranch}/.github/freeze.json) for the release schedule.`,
+                ].join('\n');
+
+                await github.rest.issues.createComment({
+                  owner, repo,
+                  issue_number: prNumber,
+                  body: commentBody,
+                });
+
+              } else if (freezeActive && hasReleaseLabel && hasHold) {
+                await removeLabel(prNumber);
+                await deleteComment(prNumber);
+                core.info(`PR #${prNumber}: removed hold (has release label)`);
+
+              } else if (!freezeActive && hasHold) {
+                await removeLabel(prNumber);
+                await deleteComment(prNumber);
+                core.info(`PR #${prNumber}: removed hold (no active freeze)`);
+
+              } else {
+                core.info(`PR #${prNumber}: no action needed`);
+              }
+            }
+
+            // --- Helpers ---
+
+            async function removeLabel(prNumber) {
+              try {
+                await github.rest.issues.removeLabel({
+                  owner, repo,
+                  issue_number: prNumber,
+                  name: HOLD_LABEL,
+                });
+              } catch (e) {
+                if (e.status !== 404) throw e;
+              }
+            }
+
+            async function deleteComment(prNumber) {
+              try {
+                const comments = await github.paginate(
+                  github.rest.issues.listComments,
+                  { owner, repo, issue_number: prNumber, per_page: 100 }
+                );
+                for (const comment of comments) {
+                  if (comment.body && comment.body.includes(COMMENT_TAG)) {
+                    await github.rest.issues.deleteComment({
+                      owner, repo,
+                      comment_id: comment.id,
+                    });
+                  }
+                }
+              } catch (e) {
+                core.warning(`Failed to delete comment on PR #${prNumber}: ${e.message}`);
+              }
+            }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,6 +92,31 @@ We follow the conventional commits format for writing commit messages. A good co
 3. Use developer [guide](./README.md#developer-guide) to deploy operator [using OLM](./README.md#deployment) on a cluster.
 4. Follow the steps given [here](./README.md#run-e2e-tests) to run e2e tests in your environment.
 
+## Release Freeze Windows
+
+Before each release, a freeze window automatically holds non-release PRs from Tide's merge pool to free E2E test capacity for release-critical PRs.
+
+### How it works
+
+- The release schedule is defined in [`.github/freeze.json`](.github/freeze.json) with freeze dates and a `hold-window-days` value (default: 7 days).
+- When the current date falls within `hold-window-days` before a release's freeze date, the `pr-freeze-hold` workflow applies the `do-not-merge/release-freeze-hold` label to PRs that lack the matching release label (e.g., `rhoai-3.6`).
+- When the freeze window passes, the hold label is automatically removed and normal merging resumes.
+- Manual `/hold` commands (which use the standard `do-not-merge/hold` label) are unaffected.
+
+### How to exempt a PR during freeze
+
+Add the current release label (e.g., `rhoai-3.6`) to your PR. The workflow will remove the hold on the next evaluation.
+
+Labels for a previous release that is still listed in `.github/freeze.json` also exempt a PR — even after that release's freeze date has passed. This keeps blocker fixes for an already-frozen release (which merge upstream before being cherry-picked downstream) moving during a later release's freeze. Once a release is fully shipped, remove it from `.github/freeze.json` so its label no longer grants an exemption.
+
+### Updating the freeze schedule
+
+Edit `.github/freeze.json` when release dates are known or change. The workflow re-evaluates all open PRs immediately when the config file is updated on `main`.
+
+### Important note
+
+Manual pushes to held PRs still trigger E2E tests even though the PR cannot merge. Avoid pushing to non-release PRs during freeze to conserve test capacity.
+
 ## Communication
 
 For general questions, feel free to open a discussion in our repository or communicate via:


### PR DESCRIPTION

## Description

Add workflow that auto-applies `do-not-merge/release-freeze-hold` label to PRs lacking the current release label during pre-freeze windows, removing them from Tide's merge pool to free E2E test capacity for release-critical PRs. Holds are automatically removed when the freeze window ends.

<!---
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

<!-- For RHOAI PRs, request review on #ai-core-platform-requests Slack channel -->

## Release tracking
<!-- Optional. Set a target release only if this PR must ship in a specific release; it will be prioritized accordingly. -->
<!-- Target release for this PR, e.g. rhoai-3.6 or rhoai-3.7ea1 -->
Release: 
<!-- Required only if a Release is set above. Full link to a jira ticket, e.g. https://redhat.atlassian.net/browse/RHOAIENG-XXXXX -->
Jira: https://redhat.atlassian.net/browse/RHOAIENG-81894


## How Has This Been Tested?
pushed to main on my fork, added a fake freeze file, created several PRs with various release labels

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully
- [ ] New RELATED_IMAGE mappings are listed in ODH-Build-Config and RHOAI-Build-Config (CI validates names against build-config repos). Include links to build-config PRs in the description.

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [ ] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated handling of pull requests during configured release freeze windows.
  * Pull requests are automatically marked or unmarked with a freeze hold, with explanatory status comments.
  * Added support for release exemptions and scheduled freeze periods.

* **Documentation**
  * Added guidance for configuring freeze windows, exemptions, schedule updates, and manual push effects on testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->