### PR TITLE
Backport rhoaieng 80335

### DIFF
--- a/internal/controller/modules/modules_controller.go
+++ b/internal/controller/modules/modules_controller.go
@@ -119,7 +119,15 @@ func newDSCModuleReconciler(ctx context.Context, mgr ctrl.Manager) error {
 			reconciler.WithPredicates(predicate.Or(
 				resources.CreatedOrUpdatedOrDeletedNamed(gates.AcksConfigMap),
 				resources.CreatedOrUpdatedOrDeletedLabeled(gates.UpgradeGateLabel, "true"),
-			)))
+			))).
+		// Namespace events re-trigger reconciliation so that ensureDashboardNamespacedRBAC
+		// can create the notebooks/model-registry Role and RoleBinding when the target
+		// namespace appears after initial reconcile.
+		Watches(
+			&corev1.Namespace{},
+			reconciler.WithEventMapper(func(ctx context.Context, _ client.Object) []reconcile.Request {
+				return cluster.WatchDataScienceClusters(ctx, mgr.GetClient())
+			}))
 
 	b = addModuleCRWatches(b)
 	b = addModuleCRDWatches(b, func(ctx context.Context, _ client.Object) []reconcile.Request {

--- a/internal/controller/modules/modules_controller.go
+++ b/internal/controller/modules/modules_controller.go
@@ -48,6 +48,7 @@ func commonActions() []actions.Fn {
 		initializeModules,
 		cleanupDisabledModules,
 		provisionModules,
+		ensureDashboardNamespacedRBAC,
 		helmrender.NewAction(),
 		kustomizerender.NewAction(),
 		provision.ExtractUpgradeGates,

--- a/internal/controller/modules/modules_controller_actions_dashboard_rbac.go
+++ b/internal/controller/modules/modules_controller_actions_dashboard_rbac.go
@@ -36,11 +36,23 @@ const (
 	dashboardManagedRBACLabelValue = "true"
 )
 
+// dashboardRBACTarget pairs a namespace with the role suffix to apply there.
+type dashboardRBACTarget struct {
+	namespace string
+	suffix    string
+}
+
 func ensureDashboardNamespacedRBAC(ctx context.Context, rr *odhtype.ReconciliationRequest) error {
-	// Resolve active namespaces first (empty when dashboard is disabled).
-	activeNamespaces, saName, err := resolveDashboardActiveState(ctx, rr)
+	// Resolve active targets first (empty when dashboard is disabled).
+	targets, saName, err := resolveDashboardActiveState(ctx, rr)
 	if err != nil {
 		return err
+	}
+
+	// Build the set of active namespaces for stale cleanup.
+	activeNamespaces := make(map[string]struct{}, len(targets))
+	for _, t := range targets {
+		activeNamespaces[t.namespace] = struct{}{}
 	}
 
 	// Always clean up stale Roles/RoleBindings before creating new ones.
@@ -51,24 +63,24 @@ func ensureDashboardNamespacedRBAC(ctx context.Context, rr *odhtype.Reconciliati
 
 	logger := logf.FromContext(ctx)
 	appNamespace := cluster.GetApplicationNamespace()
-	for ns, suffix := range activeNamespaces {
-		logger.V(1).Info("ensuring Dashboard RBAC", "namespace", ns, "suffix", suffix)
-		rules := dashboardRBACRulesForSuffix(suffix)
-		if err := addDashboardNamespacedRBAC(ctx, rr, saName, appNamespace, ns, suffix, rules); err != nil {
-			return fmt.Errorf("failed to add RBAC for namespace %s: %w", ns, err)
+	for _, t := range targets {
+		logger.V(1).Info("ensuring Dashboard RBAC", "namespace", t.namespace, "suffix", t.suffix)
+		rules := dashboardRBACRulesForSuffix(t.suffix)
+		if err := addDashboardNamespacedRBAC(ctx, rr, saName, appNamespace, t.namespace, t.suffix, rules); err != nil {
+			return fmt.Errorf("failed to add RBAC for namespace %s: %w", t.namespace, err)
 		}
 	}
 
 	return nil
 }
 
-// resolveDashboardActiveState returns the set of namespace→roleSuffix pairs that
-// should have RBAC, and the SA name to use. Returns an empty map when dashboard is disabled.
-func resolveDashboardActiveState(ctx context.Context, rr *odhtype.ReconciliationRequest) (map[string]string, string, error) {
-	active := make(map[string]string)
-
+// resolveDashboardActiveState returns the list of namespace/suffix targets that
+// should have RBAC, and the SA name to use. Returns an empty slice when dashboard is disabled.
+// Using a slice (not a map) preserves both entries when notebooks and model-registry resolve
+// to the same namespace.
+func resolveDashboardActiveState(ctx context.Context, rr *odhtype.ReconciliationRequest) ([]dashboardRBACTarget, string, error) {
 	if !DefaultRegistry().IsEnabled(componentApi.DashboardComponentName) {
-		return active, "", nil
+		return nil, "", nil
 	}
 
 	saName := dashboardSANameODH
@@ -76,12 +88,14 @@ func resolveDashboardActiveState(ctx context.Context, rr *odhtype.Reconciliation
 		saName = dashboardSANameRHOAI
 	}
 
+	var targets []dashboardRBACTarget
+
 	notebooksNS, err := resolveDashboardNotebooksNamespace(ctx, rr)
 	if err != nil {
 		return nil, "", fmt.Errorf("failed to resolve notebooks namespace: %w", err)
 	}
 	if notebooksNS != "" {
-		active[notebooksNS] = "notebooks"
+		targets = append(targets, dashboardRBACTarget{namespace: notebooksNS, suffix: "notebooks"})
 	}
 
 	modelRegistryNS, err := resolveDashboardModelRegistryNamespace(ctx, rr)
@@ -89,16 +103,16 @@ func resolveDashboardActiveState(ctx context.Context, rr *odhtype.Reconciliation
 		return nil, "", fmt.Errorf("failed to resolve model-registry namespace: %w", err)
 	}
 	if modelRegistryNS != "" {
-		active[modelRegistryNS] = "model-registries"
+		targets = append(targets, dashboardRBACTarget{namespace: modelRegistryNS, suffix: "model-registries"})
 	}
 
-	return active, saName, nil
+	return targets, saName, nil
 }
 
 // cleanupStaleDashboardRBAC deletes labeled Roles/RoleBindings in namespaces that are
 // no longer in the active set. Runs unconditionally so that disabling the dashboard or
 // changing target namespaces always revokes access promptly.
-func cleanupStaleDashboardRBAC(ctx context.Context, rr *odhtype.ReconciliationRequest, activeNamespaces map[string]string) error {
+func cleanupStaleDashboardRBAC(ctx context.Context, rr *odhtype.ReconciliationRequest, activeNamespaces map[string]struct{}) error {
 	logger := logf.FromContext(ctx)
 	labelSelector := client.MatchingLabels{dashboardManagedRBACLabel: dashboardManagedRBACLabelValue}
 

--- a/internal/controller/modules/modules_controller_actions_dashboard_rbac.go
+++ b/internal/controller/modules/modules_controller_actions_dashboard_rbac.go
@@ -29,45 +29,117 @@ const (
 	rbacResourceSecrets  = "secrets"
 	rbacResourceCMs      = "configmaps"
 	rbacResourcePVCs     = "persistentvolumeclaims"
+
+	// dashboardManagedRBACLabel marks Roles and RoleBindings created by this
+	// reconciler so they can be found and deleted when a namespace is no longer active.
+	dashboardManagedRBACLabel      = "dashboard.opendatahub.io/managed-rbac"
+	dashboardManagedRBACLabelValue = "true"
 )
 
 func ensureDashboardNamespacedRBAC(ctx context.Context, rr *odhtype.ReconciliationRequest) error {
-	if !DefaultRegistry().IsEnabled(componentApi.DashboardComponentName) {
-		return nil
+	// Resolve active namespaces first (empty when dashboard is disabled).
+	activeNamespaces, saName, err := resolveDashboardActiveState(ctx, rr)
+	if err != nil {
+		return err
+	}
+
+	// Always clean up stale Roles/RoleBindings before creating new ones.
+	// This handles: dashboard disabled, namespace changes, ModelRegistry removal.
+	if err := cleanupStaleDashboardRBAC(ctx, rr, activeNamespaces); err != nil {
+		return err
 	}
 
 	logger := logf.FromContext(ctx)
+	appNamespace := cluster.GetApplicationNamespace()
+	for ns, suffix := range activeNamespaces {
+		logger.V(1).Info("ensuring Dashboard RBAC", "namespace", ns, "suffix", suffix)
+		rules := dashboardRBACRulesForSuffix(suffix)
+		if err := addDashboardNamespacedRBAC(ctx, rr, saName, appNamespace, ns, suffix, rules); err != nil {
+			return fmt.Errorf("failed to add RBAC for namespace %s: %w", ns, err)
+		}
+	}
+
+	return nil
+}
+
+// resolveDashboardActiveState returns the set of namespace→roleSuffix pairs that
+// should have RBAC, and the SA name to use. Returns an empty map when dashboard is disabled.
+func resolveDashboardActiveState(ctx context.Context, rr *odhtype.ReconciliationRequest) (map[string]string, string, error) {
+	active := make(map[string]string)
+
+	if !DefaultRegistry().IsEnabled(componentApi.DashboardComponentName) {
+		return active, "", nil
+	}
 
 	saName := dashboardSANameODH
 	if rr.Release.Name == cluster.SelfManagedRhoai || rr.Release.Name == cluster.ManagedRhoai {
 		saName = dashboardSANameRHOAI
 	}
 
-	appNamespace := cluster.GetApplicationNamespace()
-
 	notebooksNS, err := resolveDashboardNotebooksNamespace(ctx, rr)
 	if err != nil {
-		return fmt.Errorf("failed to resolve notebooks namespace: %w", err)
+		return nil, "", fmt.Errorf("failed to resolve notebooks namespace: %w", err)
 	}
 	if notebooksNS != "" {
-		logger.V(1).Info("ensuring Dashboard RBAC in notebooks namespace", "namespace", notebooksNS)
-		if err := addDashboardNamespacedRBAC(ctx, rr, saName, appNamespace, notebooksNS, "notebooks", dashboardNotebooksRBACRules()); err != nil {
-			return fmt.Errorf("failed to add notebooks RBAC resources: %w", err)
-		}
+		active[notebooksNS] = "notebooks"
 	}
 
 	modelRegistryNS, err := resolveDashboardModelRegistryNamespace(ctx, rr)
 	if err != nil {
-		return fmt.Errorf("failed to resolve model-registry namespace: %w", err)
+		return nil, "", fmt.Errorf("failed to resolve model-registry namespace: %w", err)
 	}
 	if modelRegistryNS != "" {
-		logger.V(1).Info("ensuring Dashboard RBAC in model-registry namespace", "namespace", modelRegistryNS)
-		if err := addDashboardNamespacedRBAC(ctx, rr, saName, appNamespace, modelRegistryNS, "model-registries", dashboardModelRegistryRBACRules()); err != nil {
-			return fmt.Errorf("failed to add model-registry RBAC resources: %w", err)
+		active[modelRegistryNS] = "model-registries"
+	}
+
+	return active, saName, nil
+}
+
+// cleanupStaleDashboardRBAC deletes labeled Roles/RoleBindings in namespaces that are
+// no longer in the active set. Runs unconditionally so that disabling the dashboard or
+// changing target namespaces always revokes access promptly.
+func cleanupStaleDashboardRBAC(ctx context.Context, rr *odhtype.ReconciliationRequest, activeNamespaces map[string]string) error {
+	logger := logf.FromContext(ctx)
+	labelSelector := client.MatchingLabels{dashboardManagedRBACLabel: dashboardManagedRBACLabelValue}
+
+	roleList := &rbacv1.RoleList{}
+	if err := rr.Client.List(ctx, roleList, labelSelector); err != nil {
+		return fmt.Errorf("listing managed dashboard Roles: %w", err)
+	}
+	for i := range roleList.Items {
+		role := &roleList.Items[i]
+		if _, active := activeNamespaces[role.Namespace]; active {
+			continue
+		}
+		logger.Info("deleting stale dashboard Role", "namespace", role.Namespace, "name", role.Name)
+		if err := rr.Client.Delete(ctx, role); err != nil && !k8serr.IsNotFound(err) {
+			return fmt.Errorf("deleting stale Role %s/%s: %w", role.Namespace, role.Name, err)
+		}
+	}
+
+	rbList := &rbacv1.RoleBindingList{}
+	if err := rr.Client.List(ctx, rbList, labelSelector); err != nil {
+		return fmt.Errorf("listing managed dashboard RoleBindings: %w", err)
+	}
+	for i := range rbList.Items {
+		rb := &rbList.Items[i]
+		if _, active := activeNamespaces[rb.Namespace]; active {
+			continue
+		}
+		logger.Info("deleting stale dashboard RoleBinding", "namespace", rb.Namespace, "name", rb.Name)
+		if err := rr.Client.Delete(ctx, rb); err != nil && !k8serr.IsNotFound(err) {
+			return fmt.Errorf("deleting stale RoleBinding %s/%s: %w", rb.Namespace, rb.Name, err)
 		}
 	}
 
 	return nil
+}
+
+func dashboardRBACRulesForSuffix(suffix string) []rbacv1.PolicyRule {
+	if suffix == "model-registries" {
+		return dashboardModelRegistryRBACRules()
+	}
+	return dashboardNotebooksRBACRules()
 }
 
 func resolveDashboardNotebooksNamespace(ctx context.Context, rr *odhtype.ReconciliationRequest) (string, error) {
@@ -136,11 +208,15 @@ func resolveDashboardModelRegistryNamespace(ctx context.Context, rr *odhtype.Rec
 
 func addDashboardNamespacedRBAC(ctx context.Context, rr *odhtype.ReconciliationRequest, saName, saNamespace, targetNamespace, roleSuffix string, rules []rbacv1.PolicyRule) error {
 	roleName := saName + "-" + roleSuffix
+	managedLabels := map[string]string{
+		dashboardManagedRBACLabel: dashboardManagedRBACLabelValue,
+	}
 
 	role := &rbacv1.Role{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      roleName,
 			Namespace: targetNamespace,
+			Labels:    managedLabels,
 		},
 		Rules: rules,
 	}
@@ -149,6 +225,7 @@ func addDashboardNamespacedRBAC(ctx context.Context, rr *odhtype.ReconciliationR
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      roleName,
 			Namespace: targetNamespace,
+			Labels:    managedLabels,
 		},
 		RoleRef: rbacv1.RoleRef{
 			APIGroup: rbacv1.GroupName,

--- a/internal/controller/modules/modules_controller_actions_dashboard_rbac.go
+++ b/internal/controller/modules/modules_controller_actions_dashboard_rbac.go
@@ -13,6 +13,7 @@ import (
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/api/components/v1alpha1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
 	odhtype "github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/resources"
 )
 
 const (
@@ -50,7 +51,7 @@ func ensureDashboardNamespacedRBAC(ctx context.Context, rr *odhtype.Reconciliati
 	}
 	if notebooksNS != "" {
 		logger.V(1).Info("ensuring Dashboard RBAC in notebooks namespace", "namespace", notebooksNS)
-		if err := addDashboardNamespacedRBAC(rr, saName, appNamespace, notebooksNS, "notebooks", dashboardNotebooksRBACRules()); err != nil {
+		if err := addDashboardNamespacedRBAC(ctx, rr, saName, appNamespace, notebooksNS, "notebooks", dashboardNotebooksRBACRules()); err != nil {
 			return fmt.Errorf("failed to add notebooks RBAC resources: %w", err)
 		}
 	}
@@ -61,7 +62,7 @@ func ensureDashboardNamespacedRBAC(ctx context.Context, rr *odhtype.Reconciliati
 	}
 	if modelRegistryNS != "" {
 		logger.V(1).Info("ensuring Dashboard RBAC in model-registry namespace", "namespace", modelRegistryNS)
-		if err := addDashboardNamespacedRBAC(rr, saName, appNamespace, modelRegistryNS, "model-registries", dashboardModelRegistryRBACRules()); err != nil {
+		if err := addDashboardNamespacedRBAC(ctx, rr, saName, appNamespace, modelRegistryNS, "model-registries", dashboardModelRegistryRBACRules()); err != nil {
 			return fmt.Errorf("failed to add model-registry RBAC resources: %w", err)
 		}
 	}
@@ -133,7 +134,7 @@ func resolveDashboardModelRegistryNamespace(ctx context.Context, rr *odhtype.Rec
 	return ns, nil
 }
 
-func addDashboardNamespacedRBAC(rr *odhtype.ReconciliationRequest, saName, saNamespace, targetNamespace, roleSuffix string, rules []rbacv1.PolicyRule) error {
+func addDashboardNamespacedRBAC(ctx context.Context, rr *odhtype.ReconciliationRequest, saName, saNamespace, targetNamespace, roleSuffix string, rules []rbacv1.PolicyRule) error {
 	roleName := saName + "-" + roleSuffix
 
 	role := &rbacv1.Role{
@@ -163,7 +164,18 @@ func addDashboardNamespacedRBAC(rr *odhtype.ReconciliationRequest, saName, saNam
 		},
 	}
 
-	return rr.AddResources(role, rb)
+	// Apply directly via SSA instead of rr.AddResources: the deploy action looks
+	// up resources via the informer cache, which does not cover cross-namespace
+	// targets like rhods-notebooks or the model-registry namespace. SSA writes
+	// go directly to the API server and bypass the cache restriction.
+	fieldOwner := client.FieldOwner("odh-operator-dashboard-rbac")
+	if err := resources.Apply(ctx, rr.Client, role, client.ForceOwnership, fieldOwner); err != nil {
+		return fmt.Errorf("failed to apply Role %s/%s: %w", targetNamespace, roleName, err)
+	}
+	if err := resources.Apply(ctx, rr.Client, rb, client.ForceOwnership, fieldOwner); err != nil {
+		return fmt.Errorf("failed to apply RoleBinding %s/%s: %w", targetNamespace, roleName, err)
+	}
+	return nil
 }
 
 func dashboardNotebooksRBACRules() []rbacv1.PolicyRule {

--- a/internal/controller/modules/modules_controller_actions_dashboard_rbac.go
+++ b/internal/controller/modules/modules_controller_actions_dashboard_rbac.go
@@ -1,0 +1,202 @@
+package modules
+
+import (
+	"context"
+	"fmt"
+
+	rbacv1 "k8s.io/api/rbac/v1"
+	k8serr "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
+	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/api/components/v1alpha1"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
+	odhtype "github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
+)
+
+const (
+	dashboardSANameODH   = "odh-dashboard"
+	dashboardSANameRHOAI = "rhods-dashboard"
+	dashboardRoleKind    = "Role"
+	rbacVerbCreate       = "create"
+	rbacVerbGet          = "get"
+	rbacVerbUpdate       = "update"
+	rbacVerbDelete       = "delete"
+	rbacVerbList         = "list"
+	rbacVerbPatch        = "patch"
+	rbacResourceSecrets  = "secrets"
+	rbacResourceCMs      = "configmaps"
+	rbacResourcePVCs     = "persistentvolumeclaims"
+)
+
+func ensureDashboardNamespacedRBAC(ctx context.Context, rr *odhtype.ReconciliationRequest) error {
+	if !DefaultRegistry().IsEnabled(componentApi.DashboardComponentName) {
+		return nil
+	}
+
+	logger := logf.FromContext(ctx)
+
+	saName := dashboardSANameODH
+	if rr.Release.Name == cluster.SelfManagedRhoai || rr.Release.Name == cluster.ManagedRhoai {
+		saName = dashboardSANameRHOAI
+	}
+
+	appNamespace := cluster.GetApplicationNamespace()
+
+	notebooksNS, err := resolveDashboardNotebooksNamespace(ctx, rr)
+	if err != nil {
+		return fmt.Errorf("failed to resolve notebooks namespace: %w", err)
+	}
+	if notebooksNS != "" {
+		logger.V(1).Info("ensuring Dashboard RBAC in notebooks namespace", "namespace", notebooksNS)
+		if err := addDashboardNamespacedRBAC(rr, saName, appNamespace, notebooksNS, "notebooks", dashboardNotebooksRBACRules()); err != nil {
+			return fmt.Errorf("failed to add notebooks RBAC resources: %w", err)
+		}
+	}
+
+	modelRegistryNS, err := resolveDashboardModelRegistryNamespace(ctx, rr)
+	if err != nil {
+		return fmt.Errorf("failed to resolve model-registry namespace: %w", err)
+	}
+	if modelRegistryNS != "" {
+		logger.V(1).Info("ensuring Dashboard RBAC in model-registry namespace", "namespace", modelRegistryNS)
+		if err := addDashboardNamespacedRBAC(rr, saName, appNamespace, modelRegistryNS, "model-registries", dashboardModelRegistryRBACRules()); err != nil {
+			return fmt.Errorf("failed to add model-registry RBAC resources: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func resolveDashboardNotebooksNamespace(ctx context.Context, rr *odhtype.ReconciliationRequest) (string, error) {
+	logger := logf.FromContext(ctx)
+
+	if !DefaultRegistry().IsEnabled(componentApi.WorkbenchesComponentName) {
+		logger.V(1).Info("Workbenches not enabled, skipping notebooks RBAC")
+		return "", nil
+	}
+
+	var ns string
+	if dsc := dscFromInstance(rr); dsc != nil {
+		ns = dsc.Spec.Components.Workbenches.WorkbenchNamespace
+	}
+	if ns == "" {
+		switch rr.Release.Name {
+		case cluster.SelfManagedRhoai, cluster.ManagedRhoai:
+			ns = cluster.DefaultNotebooksNamespaceRHOAI
+		case cluster.OpenDataHub:
+			ns = cluster.DefaultNotebooksNamespaceODH
+		}
+	}
+
+	exists, err := cluster.NamespaceExists(ctx, rr.Client, ns)
+	if err != nil {
+		return "", fmt.Errorf("failed to check notebooks namespace %q: %w", ns, err)
+	}
+	if !exists {
+		logger.V(1).Info("notebooks namespace not found, skipping RBAC", "namespace", ns)
+		return "", nil
+	}
+
+	return ns, nil
+}
+
+func resolveDashboardModelRegistryNamespace(ctx context.Context, rr *odhtype.ReconciliationRequest) (string, error) {
+	logger := logf.FromContext(ctx)
+
+	mr := &componentApi.ModelRegistry{}
+	err := rr.Client.Get(ctx, client.ObjectKey{Name: componentApi.ModelRegistryInstanceName}, mr)
+	if err != nil {
+		if k8serr.IsNotFound(err) {
+			logger.V(1).Info("ModelRegistry CR not found, skipping model-registry RBAC")
+			return "", nil
+		}
+		return "", fmt.Errorf("failed to get ModelRegistry CR: %w", err)
+	}
+
+	ns := mr.Spec.RegistriesNamespace
+	if ns == "" {
+		logger.V(1).Info("ModelRegistry registriesNamespace is empty, skipping RBAC")
+		return "", nil
+	}
+
+	exists, err := cluster.NamespaceExists(ctx, rr.Client, ns)
+	if err != nil {
+		return "", fmt.Errorf("failed to check model-registry namespace %q: %w", ns, err)
+	}
+	if !exists {
+		logger.V(1).Info("model-registry namespace not found, skipping RBAC", "namespace", ns)
+		return "", nil
+	}
+
+	return ns, nil
+}
+
+func addDashboardNamespacedRBAC(rr *odhtype.ReconciliationRequest, saName, saNamespace, targetNamespace, roleSuffix string, rules []rbacv1.PolicyRule) error {
+	roleName := saName + "-" + roleSuffix
+
+	role := &rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      roleName,
+			Namespace: targetNamespace,
+		},
+		Rules: rules,
+	}
+
+	rb := &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      roleName,
+			Namespace: targetNamespace,
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: rbacv1.GroupName,
+			Kind:     dashboardRoleKind,
+			Name:     roleName,
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:      rbacv1.ServiceAccountKind,
+				Name:      saName,
+				Namespace: saNamespace,
+			},
+		},
+	}
+
+	return rr.AddResources(role, rb)
+}
+
+func dashboardNotebooksRBACRules() []rbacv1.PolicyRule {
+	return []rbacv1.PolicyRule{
+		{
+			APIGroups: []string{""},
+			Resources: []string{rbacResourcePVCs},
+			Verbs:     []string{rbacVerbCreate, rbacVerbGet},
+		},
+		{
+			APIGroups: []string{""},
+			Resources: []string{rbacResourceCMs},
+			Verbs:     []string{rbacVerbCreate, rbacVerbGet, rbacVerbUpdate},
+		},
+		{
+			APIGroups: []string{""},
+			Resources: []string{rbacResourceSecrets},
+			Verbs:     []string{rbacVerbCreate, rbacVerbGet, rbacVerbUpdate},
+		},
+	}
+}
+
+func dashboardModelRegistryRBACRules() []rbacv1.PolicyRule {
+	return []rbacv1.PolicyRule{
+		{
+			APIGroups: []string{""},
+			Resources: []string{rbacResourceSecrets},
+			Verbs:     []string{rbacVerbCreate, rbacVerbDelete, rbacVerbGet, rbacVerbList, rbacVerbPatch},
+		},
+		{
+			APIGroups: []string{""},
+			Resources: []string{rbacResourceCMs},
+			Verbs:     []string{rbacVerbCreate, rbacVerbList},
+		},
+	}
+}

--- a/internal/controller/modules/modules_controller_actions_dashboard_rbac_test.go
+++ b/internal/controller/modules/modules_controller_actions_dashboard_rbac_test.go
@@ -1,0 +1,326 @@
+//nolint:testpackage // Needs package access for unexported functions and registry helpers.
+package modules
+
+import (
+	"context"
+	"slices"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/opendatahub-io/opendatahub-operator/v2/api/common"
+	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/api/components/v1alpha1"
+	dscv2 "github.com/opendatahub-io/opendatahub-operator/v2/api/datasciencecluster/v2"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/fakeclient"
+)
+
+const testModelRegistryNS = "rhoai-model-registries"
+
+func newDashboardRBACTestRR(t *testing.T, platform common.Platform, dsc *dscv2.DataScienceCluster, objects ...client.Object) *types.ReconciliationRequest {
+	t.Helper()
+
+	cli, err := fakeclient.New(fakeclient.WithObjects(objects...))
+	if err != nil {
+		t.Fatalf("create fake client: %v", err)
+	}
+
+	if dsc == nil {
+		dsc = &dscv2.DataScienceCluster{ObjectMeta: metav1.ObjectMeta{Name: "test-dsc"}}
+	}
+
+	return &types.ReconciliationRequest{
+		Client:   cli,
+		Instance: dsc,
+		Release:  common.Release{Name: platform},
+	}
+}
+
+func enableDashboardInRegistry(t *testing.T) {
+	t.Helper()
+	withTestRegistry(t)
+	DefaultRegistry().Add(&dashboardStub{enabled: true})
+}
+
+func enableWorkbenchesInRegistry(t *testing.T) {
+	t.Helper()
+	DefaultRegistry().Add(&workbenchesStub{enabled: true})
+}
+
+type dashboardStub struct {
+	BaseHandler
+
+	enabled bool
+}
+
+func (s *dashboardStub) GetName() string {
+	return componentApi.DashboardComponentName
+}
+func (s *dashboardStub) IsEnabled(_ *PlatformContext) bool {
+	return s.enabled
+}
+func (s *dashboardStub) BuildModuleCR(_ context.Context, _ client.Client, _ *PlatformContext) (*unstructured.Unstructured, error) {
+	return nil, nil
+}
+
+type workbenchesStub struct {
+	BaseHandler
+
+	enabled bool
+}
+
+func (s *workbenchesStub) GetName() string {
+	return componentApi.WorkbenchesComponentName
+}
+func (s *workbenchesStub) IsEnabled(_ *PlatformContext) bool {
+	return s.enabled
+}
+func (s *workbenchesStub) BuildModuleCR(_ context.Context, _ client.Client, _ *PlatformContext) (*unstructured.Unstructured, error) {
+	return nil, nil
+}
+
+func TestEnsureDashboardNamespacedRBAC_BothNamespacesExist(t *testing.T) {
+	enableDashboardInRegistry(t)
+	enableWorkbenchesInRegistry(t)
+
+	notebooksNS := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: cluster.DefaultNotebooksNamespaceRHOAI}}
+	modelRegNS := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: testModelRegistryNS}}
+	mr := &componentApi.ModelRegistry{
+		ObjectMeta: metav1.ObjectMeta{Name: componentApi.ModelRegistryInstanceName},
+		Spec: componentApi.ModelRegistrySpec{
+			ModelRegistryCommonSpec: componentApi.ModelRegistryCommonSpec{
+				RegistriesNamespace: testModelRegistryNS,
+			},
+		},
+	}
+
+	rr := newDashboardRBACTestRR(t, cluster.SelfManagedRhoai, nil, notebooksNS, modelRegNS, mr)
+
+	if err := ensureDashboardNamespacedRBAC(context.Background(), rr); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(rr.Resources) != 4 {
+		t.Fatalf("expected 4 resources (2 Roles + 2 RoleBindings), got %d", len(rr.Resources))
+	}
+
+	hasRole := func(name, namespace string) bool {
+		for _, res := range rr.Resources {
+			if res.GetKind() == dashboardRoleKind && res.GetName() == name && res.GetNamespace() == namespace {
+				return true
+			}
+		}
+		return false
+	}
+	hasRoleBinding := func(name, namespace string) bool {
+		for _, res := range rr.Resources {
+			if res.GetKind() == "RoleBinding" && res.GetName() == name && res.GetNamespace() == namespace {
+				return true
+			}
+		}
+		return false
+	}
+
+	if !hasRole("rhods-dashboard-notebooks", cluster.DefaultNotebooksNamespaceRHOAI) {
+		t.Error("missing notebooks Role")
+	}
+	if !hasRoleBinding("rhods-dashboard-notebooks", cluster.DefaultNotebooksNamespaceRHOAI) {
+		t.Error("missing notebooks RoleBinding")
+	}
+	if !hasRole("rhods-dashboard-model-registries", testModelRegistryNS) {
+		t.Error("missing model-registry Role")
+	}
+	if !hasRoleBinding("rhods-dashboard-model-registries", testModelRegistryNS) {
+		t.Error("missing model-registry RoleBinding")
+	}
+}
+
+func TestEnsureDashboardNamespacedRBAC_DashboardDisabled(t *testing.T) {
+	withTestRegistry(t)
+	DefaultRegistry().Add(&dashboardStub{enabled: false})
+
+	rr := newDashboardRBACTestRR(t, cluster.SelfManagedRhoai, nil)
+
+	if err := ensureDashboardNamespacedRBAC(context.Background(), rr); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(rr.Resources) != 0 {
+		t.Fatalf("expected 0 resources when dashboard disabled, got %d", len(rr.Resources))
+	}
+}
+
+func TestEnsureDashboardNamespacedRBAC_NotebooksMissing(t *testing.T) {
+	enableDashboardInRegistry(t)
+	enableWorkbenchesInRegistry(t)
+
+	modelRegNS := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: testModelRegistryNS}}
+	mr := &componentApi.ModelRegistry{
+		ObjectMeta: metav1.ObjectMeta{Name: componentApi.ModelRegistryInstanceName},
+		Spec: componentApi.ModelRegistrySpec{
+			ModelRegistryCommonSpec: componentApi.ModelRegistryCommonSpec{
+				RegistriesNamespace: testModelRegistryNS,
+			},
+		},
+	}
+
+	rr := newDashboardRBACTestRR(t, cluster.SelfManagedRhoai, nil, modelRegNS, mr)
+
+	if err := ensureDashboardNamespacedRBAC(context.Background(), rr); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(rr.Resources) != 2 {
+		t.Fatalf("expected 2 resources (model-registry only), got %d", len(rr.Resources))
+	}
+}
+
+func TestEnsureDashboardNamespacedRBAC_ModelRegistryMissing(t *testing.T) {
+	enableDashboardInRegistry(t)
+	enableWorkbenchesInRegistry(t)
+
+	notebooksNS := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: cluster.DefaultNotebooksNamespaceRHOAI}}
+
+	rr := newDashboardRBACTestRR(t, cluster.SelfManagedRhoai, nil, notebooksNS)
+
+	if err := ensureDashboardNamespacedRBAC(context.Background(), rr); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(rr.Resources) != 2 {
+		t.Fatalf("expected 2 resources (notebooks only), got %d", len(rr.Resources))
+	}
+}
+
+func TestEnsureDashboardNamespacedRBAC_WorkbenchesDisabled(t *testing.T) {
+	enableDashboardInRegistry(t)
+	DefaultRegistry().Add(&workbenchesStub{enabled: false})
+
+	rr := newDashboardRBACTestRR(t, cluster.SelfManagedRhoai, nil)
+
+	if err := ensureDashboardNamespacedRBAC(context.Background(), rr); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(rr.Resources) != 0 {
+		t.Fatalf("expected 0 resources when workbenches disabled, got %d", len(rr.Resources))
+	}
+}
+
+func TestEnsureDashboardNamespacedRBAC_ODHSAName(t *testing.T) {
+	enableDashboardInRegistry(t)
+	enableWorkbenchesInRegistry(t)
+
+	notebooksNS := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: cluster.DefaultNotebooksNamespaceODH}}
+
+	rr := newDashboardRBACTestRR(t, cluster.OpenDataHub, nil, notebooksNS)
+
+	if err := ensureDashboardNamespacedRBAC(context.Background(), rr); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(rr.Resources) != 2 {
+		t.Fatalf("expected 2 resources, got %d", len(rr.Resources))
+	}
+
+	for _, res := range rr.Resources {
+		if res.GetKind() == dashboardRoleKind && res.GetName() != "odh-dashboard-notebooks" {
+			t.Errorf("expected ODH SA name in role, got %q", res.GetName())
+		}
+	}
+}
+
+func TestDashboardModelRegistryRBACRules_ContainsCreateVerb(t *testing.T) {
+	rules := dashboardModelRegistryRBACRules()
+
+	for _, rule := range rules {
+		if len(rule.Resources) == 1 && rule.Resources[0] == rbacResourceSecrets {
+			if !slices.Contains(rule.Verbs, rbacVerbCreate) {
+				t.Error("model-registry secrets rule missing 'create' verb")
+			}
+			if !slices.Contains(rule.Verbs, rbacVerbGet) {
+				t.Error("model-registry secrets rule missing 'get' verb")
+			}
+			return
+		}
+	}
+	t.Error("no secrets rule found in model-registry RBAC rules")
+}
+
+func TestEnsureDashboardNamespacedRBAC_RoleBindingSubject(t *testing.T) {
+	enableDashboardInRegistry(t)
+	enableWorkbenchesInRegistry(t)
+
+	notebooksNS := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: cluster.DefaultNotebooksNamespaceRHOAI}}
+
+	rr := newDashboardRBACTestRR(t, cluster.SelfManagedRhoai, nil, notebooksNS)
+
+	if err := ensureDashboardNamespacedRBAC(context.Background(), rr); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	for _, res := range rr.Resources {
+		if res.GetKind() != "RoleBinding" {
+			continue
+		}
+
+		subjects, ok, _ := unstructured.NestedSlice(res.Object, "subjects")
+		if !ok || len(subjects) != 1 {
+			t.Fatalf("expected exactly 1 subject in RoleBinding, got %d", len(subjects))
+		}
+
+		subj, ok := subjects[0].(map[string]interface{})
+		if !ok {
+			t.Fatal("subject is not a map")
+		}
+
+		if subj["kind"] != string(rbacv1.ServiceAccountKind) {
+			t.Errorf("expected ServiceAccount kind, got %v", subj["kind"])
+		}
+		if subj["name"] != dashboardSANameRHOAI {
+			t.Errorf("expected SA name %q, got %v", dashboardSANameRHOAI, subj["name"])
+		}
+	}
+}
+
+func TestEnsureDashboardNamespacedRBAC_CustomWorkbenchNamespace(t *testing.T) {
+	enableDashboardInRegistry(t)
+	enableWorkbenchesInRegistry(t)
+
+	customNS := "custom-notebooks"
+	notebooksNS := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: customNS}}
+
+	dsc := &dscv2.DataScienceCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-dsc"},
+		Spec: dscv2.DataScienceClusterSpec{
+			Components: dscv2.Components{
+				Workbenches: componentApi.DSCWorkbenches{
+					WorkbenchesCommonSpec: componentApi.WorkbenchesCommonSpec{
+						WorkbenchNamespace: customNS,
+					},
+				},
+			},
+		},
+	}
+
+	rr := newDashboardRBACTestRR(t, cluster.SelfManagedRhoai, dsc, notebooksNS)
+
+	if err := ensureDashboardNamespacedRBAC(context.Background(), rr); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(rr.Resources) != 2 {
+		t.Fatalf("expected 2 resources (notebooks only), got %d", len(rr.Resources))
+	}
+
+	for _, res := range rr.Resources {
+		if res.GetNamespace() != customNS {
+			t.Errorf("expected namespace %q, got %q", customNS, res.GetNamespace())
+		}
+	}
+}

--- a/internal/controller/modules/modules_controller_actions_dashboard_rbac_test.go
+++ b/internal/controller/modules/modules_controller_actions_dashboard_rbac_test.go
@@ -10,19 +10,20 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	k8stypes "k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/opendatahub-io/opendatahub-operator/v2/api/common"
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/api/components/v1alpha1"
 	dscv2 "github.com/opendatahub-io/opendatahub-operator/v2/api/datasciencecluster/v2"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
-	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
+	odhtypes "github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/fakeclient"
 )
 
 const testModelRegistryNS = "rhoai-model-registries"
 
-func newDashboardRBACTestRR(t *testing.T, platform common.Platform, dsc *dscv2.DataScienceCluster, objects ...client.Object) *types.ReconciliationRequest {
+func newDashboardRBACTestRR(t *testing.T, platform common.Platform, dsc *dscv2.DataScienceCluster, objects ...client.Object) *odhtypes.ReconciliationRequest {
 	t.Helper()
 
 	cli, err := fakeclient.New(fakeclient.WithObjects(objects...))
@@ -34,10 +35,42 @@ func newDashboardRBACTestRR(t *testing.T, platform common.Platform, dsc *dscv2.D
 		dsc = &dscv2.DataScienceCluster{ObjectMeta: metav1.ObjectMeta{Name: "test-dsc"}}
 	}
 
-	return &types.ReconciliationRequest{
+	return &odhtypes.ReconciliationRequest{
 		Client:   cli,
 		Instance: dsc,
 		Release:  common.Release{Name: platform},
+	}
+}
+
+// getRoleAndBinding asserts that a Role and RoleBinding both exist in the fake
+// client for the given name and namespace, failing the test if either is missing.
+func getRoleAndBinding(t *testing.T, rr *odhtypes.ReconciliationRequest, name, namespace string) {
+	t.Helper()
+
+	role := &rbacv1.Role{}
+	if err := rr.Client.Get(context.Background(), k8stypes.NamespacedName{Name: name, Namespace: namespace}, role); err != nil {
+		t.Errorf("expected Role %s/%s to exist: %v", namespace, name, err)
+	}
+
+	rb := &rbacv1.RoleBinding{}
+	if err := rr.Client.Get(context.Background(), k8stypes.NamespacedName{Name: name, Namespace: namespace}, rb); err != nil {
+		t.Errorf("expected RoleBinding %s/%s to exist: %v", namespace, name, err)
+	}
+}
+
+// assertRoleAndBindingAbsent checks that neither a Role nor RoleBinding exists
+// for the given name and namespace.
+func assertRoleAndBindingAbsent(t *testing.T, rr *odhtypes.ReconciliationRequest, name, namespace string) {
+	t.Helper()
+
+	role := &rbacv1.Role{}
+	if err := rr.Client.Get(context.Background(), k8stypes.NamespacedName{Name: name, Namespace: namespace}, role); err == nil {
+		t.Errorf("expected Role %s/%s to be absent, but it exists", namespace, name)
+	}
+
+	rb := &rbacv1.RoleBinding{}
+	if err := rr.Client.Get(context.Background(), k8stypes.NamespacedName{Name: name, Namespace: namespace}, rb); err == nil {
+		t.Errorf("expected RoleBinding %s/%s to be absent, but it exists", namespace, name)
 	}
 }
 
@@ -105,39 +138,8 @@ func TestEnsureDashboardNamespacedRBAC_BothNamespacesExist(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	if len(rr.Resources) != 4 {
-		t.Fatalf("expected 4 resources (2 Roles + 2 RoleBindings), got %d", len(rr.Resources))
-	}
-
-	hasRole := func(name, namespace string) bool {
-		for _, res := range rr.Resources {
-			if res.GetKind() == dashboardRoleKind && res.GetName() == name && res.GetNamespace() == namespace {
-				return true
-			}
-		}
-		return false
-	}
-	hasRoleBinding := func(name, namespace string) bool {
-		for _, res := range rr.Resources {
-			if res.GetKind() == "RoleBinding" && res.GetName() == name && res.GetNamespace() == namespace {
-				return true
-			}
-		}
-		return false
-	}
-
-	if !hasRole("rhods-dashboard-notebooks", cluster.DefaultNotebooksNamespaceRHOAI) {
-		t.Error("missing notebooks Role")
-	}
-	if !hasRoleBinding("rhods-dashboard-notebooks", cluster.DefaultNotebooksNamespaceRHOAI) {
-		t.Error("missing notebooks RoleBinding")
-	}
-	if !hasRole("rhods-dashboard-model-registries", testModelRegistryNS) {
-		t.Error("missing model-registry Role")
-	}
-	if !hasRoleBinding("rhods-dashboard-model-registries", testModelRegistryNS) {
-		t.Error("missing model-registry RoleBinding")
-	}
+	getRoleAndBinding(t, rr, "rhods-dashboard-notebooks", cluster.DefaultNotebooksNamespaceRHOAI)
+	getRoleAndBinding(t, rr, "rhods-dashboard-model-registries", testModelRegistryNS)
 }
 
 func TestEnsureDashboardNamespacedRBAC_DashboardDisabled(t *testing.T) {
@@ -150,9 +152,8 @@ func TestEnsureDashboardNamespacedRBAC_DashboardDisabled(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	if len(rr.Resources) != 0 {
-		t.Fatalf("expected 0 resources when dashboard disabled, got %d", len(rr.Resources))
-	}
+	assertRoleAndBindingAbsent(t, rr, "rhods-dashboard-notebooks", cluster.DefaultNotebooksNamespaceRHOAI)
+	assertRoleAndBindingAbsent(t, rr, "rhods-dashboard-model-registries", testModelRegistryNS)
 }
 
 func TestEnsureDashboardNamespacedRBAC_NotebooksMissing(t *testing.T) {
@@ -175,9 +176,10 @@ func TestEnsureDashboardNamespacedRBAC_NotebooksMissing(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	if len(rr.Resources) != 2 {
-		t.Fatalf("expected 2 resources (model-registry only), got %d", len(rr.Resources))
-	}
+	// notebooks namespace doesn't exist — no RBAC there
+	assertRoleAndBindingAbsent(t, rr, "rhods-dashboard-notebooks", cluster.DefaultNotebooksNamespaceRHOAI)
+	// model-registry namespace exists — RBAC should be created
+	getRoleAndBinding(t, rr, "rhods-dashboard-model-registries", testModelRegistryNS)
 }
 
 func TestEnsureDashboardNamespacedRBAC_ModelRegistryMissing(t *testing.T) {
@@ -192,9 +194,10 @@ func TestEnsureDashboardNamespacedRBAC_ModelRegistryMissing(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	if len(rr.Resources) != 2 {
-		t.Fatalf("expected 2 resources (notebooks only), got %d", len(rr.Resources))
-	}
+	// notebooks namespace exists — RBAC should be created
+	getRoleAndBinding(t, rr, "rhods-dashboard-notebooks", cluster.DefaultNotebooksNamespaceRHOAI)
+	// no ModelRegistry CR — no model-registry RBAC
+	assertRoleAndBindingAbsent(t, rr, "rhods-dashboard-model-registries", testModelRegistryNS)
 }
 
 func TestEnsureDashboardNamespacedRBAC_WorkbenchesDisabled(t *testing.T) {
@@ -207,9 +210,7 @@ func TestEnsureDashboardNamespacedRBAC_WorkbenchesDisabled(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	if len(rr.Resources) != 0 {
-		t.Fatalf("expected 0 resources when workbenches disabled, got %d", len(rr.Resources))
-	}
+	assertRoleAndBindingAbsent(t, rr, "rhods-dashboard-notebooks", cluster.DefaultNotebooksNamespaceRHOAI)
 }
 
 func TestEnsureDashboardNamespacedRBAC_ODHSAName(t *testing.T) {
@@ -224,15 +225,8 @@ func TestEnsureDashboardNamespacedRBAC_ODHSAName(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	if len(rr.Resources) != 2 {
-		t.Fatalf("expected 2 resources, got %d", len(rr.Resources))
-	}
-
-	for _, res := range rr.Resources {
-		if res.GetKind() == dashboardRoleKind && res.GetName() != "odh-dashboard-notebooks" {
-			t.Errorf("expected ODH SA name in role, got %q", res.GetName())
-		}
-	}
+	// "odh-dashboard-notebooks" is the expected name: SA prefix is "odh-dashboard", suffix is "notebooks"
+	getRoleAndBinding(t, rr, "odh-dashboard-notebooks", cluster.DefaultNotebooksNamespaceODH)
 }
 
 func TestDashboardModelRegistryRBACRules_ContainsCreateVerb(t *testing.T) {
@@ -264,27 +258,24 @@ func TestEnsureDashboardNamespacedRBAC_RoleBindingSubject(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	for _, res := range rr.Resources {
-		if res.GetKind() != "RoleBinding" {
-			continue
-		}
+	rb := &rbacv1.RoleBinding{}
+	if err := rr.Client.Get(context.Background(), k8stypes.NamespacedName{
+		Name:      "rhods-dashboard-notebooks",
+		Namespace: cluster.DefaultNotebooksNamespaceRHOAI,
+	}, rb); err != nil {
+		t.Fatalf("expected RoleBinding to exist: %v", err)
+	}
 
-		subjects, ok, _ := unstructured.NestedSlice(res.Object, "subjects")
-		if !ok || len(subjects) != 1 {
-			t.Fatalf("expected exactly 1 subject in RoleBinding, got %d", len(subjects))
-		}
+	if len(rb.Subjects) != 1 {
+		t.Fatalf("expected exactly 1 subject in RoleBinding, got %d", len(rb.Subjects))
+	}
 
-		subj, ok := subjects[0].(map[string]interface{})
-		if !ok {
-			t.Fatal("subject is not a map")
-		}
-
-		if subj["kind"] != string(rbacv1.ServiceAccountKind) {
-			t.Errorf("expected ServiceAccount kind, got %v", subj["kind"])
-		}
-		if subj["name"] != dashboardSANameRHOAI {
-			t.Errorf("expected SA name %q, got %v", dashboardSANameRHOAI, subj["name"])
-		}
+	subj := rb.Subjects[0]
+	if subj.Kind != rbacv1.ServiceAccountKind {
+		t.Errorf("expected ServiceAccount kind, got %q", subj.Kind)
+	}
+	if subj.Name != dashboardSANameRHOAI {
+		t.Errorf("expected SA name %q, got %q", dashboardSANameRHOAI, subj.Name)
 	}
 }
 
@@ -314,13 +305,7 @@ func TestEnsureDashboardNamespacedRBAC_CustomWorkbenchNamespace(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	if len(rr.Resources) != 2 {
-		t.Fatalf("expected 2 resources (notebooks only), got %d", len(rr.Resources))
-	}
-
-	for _, res := range rr.Resources {
-		if res.GetNamespace() != customNS {
-			t.Errorf("expected namespace %q, got %q", customNS, res.GetNamespace())
-		}
-	}
+	// RBAC should land in the custom namespace, not the default one
+	getRoleAndBinding(t, rr, "rhods-dashboard-notebooks", customNS)
+	assertRoleAndBindingAbsent(t, rr, "rhods-dashboard-notebooks", cluster.DefaultNotebooksNamespaceRHOAI)
 }

--- a/internal/controller/modules/modules_controller_actions_dashboard_rbac_test.go
+++ b/internal/controller/modules/modules_controller_actions_dashboard_rbac_test.go
@@ -403,18 +403,19 @@ func TestEnsureDashboardNamespacedRBAC_Idempotent(t *testing.T) {
 }
 
 // TestEnsureDashboardNamespacedRBAC_NotebooksRBACRules verifies the notebooks rules
-// grant exactly the expected resources and verbs.
+// grant exactly the expected resources and verbs (no extras allowed — guards least-privilege).
 func TestEnsureDashboardNamespacedRBAC_NotebooksRBACRules(t *testing.T) {
 	rules := dashboardNotebooksRBACRules()
 
 	type expected struct {
 		resource string
 		verbs    []string
+		apiGroup string
 	}
 	wants := []expected{
-		{rbacResourcePVCs, []string{rbacVerbCreate, rbacVerbGet}},
-		{rbacResourceCMs, []string{rbacVerbCreate, rbacVerbGet, rbacVerbUpdate}},
-		{rbacResourceSecrets, []string{rbacVerbCreate, rbacVerbGet, rbacVerbUpdate}},
+		{rbacResourcePVCs, []string{rbacVerbCreate, rbacVerbGet}, ""},
+		{rbacResourceCMs, []string{rbacVerbCreate, rbacVerbGet, rbacVerbUpdate}, ""},
+		{rbacResourceSecrets, []string{rbacVerbCreate, rbacVerbGet, rbacVerbUpdate}, ""},
 	}
 
 	if len(rules) != len(wants) {
@@ -424,10 +425,16 @@ func TestEnsureDashboardNamespacedRBAC_NotebooksRBACRules(t *testing.T) {
 		if len(rules[i].Resources) != 1 || rules[i].Resources[0] != w.resource {
 			t.Errorf("rule %d: expected resource %q, got %v", i, w.resource, rules[i].Resources)
 		}
-		for _, v := range w.verbs {
-			if !slices.Contains(rules[i].Verbs, v) {
-				t.Errorf("rule %d (%s): missing verb %q", i, w.resource, v)
-			}
+		if len(rules[i].APIGroups) != 1 || rules[i].APIGroups[0] != w.apiGroup {
+			t.Errorf("rule %d (%s): expected APIGroups [%q], got %v", i, w.resource, w.apiGroup, rules[i].APIGroups)
+		}
+		// Exact verb match: missing verbs and extra verbs both fail.
+		gotVerbs := slices.Clone(rules[i].Verbs)
+		slices.Sort(gotVerbs)
+		wantVerbs := slices.Clone(w.verbs)
+		slices.Sort(wantVerbs)
+		if !slices.Equal(gotVerbs, wantVerbs) {
+			t.Errorf("rule %d (%s): expected verbs %v, got %v", i, w.resource, wantVerbs, gotVerbs)
 		}
 	}
 }
@@ -485,6 +492,48 @@ func TestEnsureDashboardNamespacedRBAC_NamespaceChangeCleansUpOld(t *testing.T) 
 	// Old namespace objects must be gone, new namespace should have RBAC
 	assertRoleAndBindingAbsent(t, rr, "rhods-dashboard-notebooks", oldNS)
 	getRoleAndBinding(t, rr, "rhods-dashboard-notebooks", newNS)
+}
+
+// TestEnsureDashboardNamespacedRBAC_SharedNamespace verifies that when notebooks and
+// model-registry resolve to the same namespace, both Role/RoleBinding pairs are created
+// (not one overwriting the other).
+func TestEnsureDashboardNamespacedRBAC_SharedNamespace(t *testing.T) {
+	enableDashboardInRegistry(t)
+	enableWorkbenchesInRegistry(t)
+
+	sharedNS := "shared-namespace"
+	sharedNSObj := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: sharedNS}}
+	mr := &componentApi.ModelRegistry{
+		ObjectMeta: metav1.ObjectMeta{Name: componentApi.ModelRegistryInstanceName},
+		Spec: componentApi.ModelRegistrySpec{
+			ModelRegistryCommonSpec: componentApi.ModelRegistryCommonSpec{
+				RegistriesNamespace: sharedNS,
+			},
+		},
+	}
+
+	dsc := &dscv2.DataScienceCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-dsc"},
+		Spec: dscv2.DataScienceClusterSpec{
+			Components: dscv2.Components{
+				Workbenches: componentApi.DSCWorkbenches{
+					WorkbenchesCommonSpec: componentApi.WorkbenchesCommonSpec{
+						WorkbenchNamespace: sharedNS,
+					},
+				},
+			},
+		},
+	}
+
+	rr := newDashboardRBACTestRR(t, cluster.SelfManagedRhoai, dsc, sharedNSObj, mr)
+
+	if err := ensureDashboardNamespacedRBAC(context.Background(), rr); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Both roles must exist in the shared namespace.
+	getRoleAndBinding(t, rr, "rhods-dashboard-notebooks", sharedNS)
+	getRoleAndBinding(t, rr, "rhods-dashboard-model-registries", sharedNS)
 }
 
 // TestEnsureDashboardNamespacedRBAC_ModelRegistryRemovedCleansUp verifies that

--- a/internal/controller/modules/modules_controller_actions_dashboard_rbac_test.go
+++ b/internal/controller/modules/modules_controller_actions_dashboard_rbac_test.go
@@ -309,3 +309,199 @@ func TestEnsureDashboardNamespacedRBAC_CustomWorkbenchNamespace(t *testing.T) {
 	getRoleAndBinding(t, rr, "rhods-dashboard-notebooks", customNS)
 	assertRoleAndBindingAbsent(t, rr, "rhods-dashboard-notebooks", cluster.DefaultNotebooksNamespaceRHOAI)
 }
+
+// TestEnsureDashboardNamespacedRBAC_ModelRegistryEmptyNamespace verifies that when the
+// ModelRegistry CR exists but RegistriesNamespace is empty, no model-registry RBAC is created.
+func TestEnsureDashboardNamespacedRBAC_ModelRegistryEmptyNamespace(t *testing.T) {
+	enableDashboardInRegistry(t)
+	enableWorkbenchesInRegistry(t)
+
+	notebooksNS := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: cluster.DefaultNotebooksNamespaceRHOAI}}
+	mr := &componentApi.ModelRegistry{
+		ObjectMeta: metav1.ObjectMeta{Name: componentApi.ModelRegistryInstanceName},
+		Spec: componentApi.ModelRegistrySpec{
+			ModelRegistryCommonSpec: componentApi.ModelRegistryCommonSpec{
+				RegistriesNamespace: "", // explicitly empty
+			},
+		},
+	}
+
+	rr := newDashboardRBACTestRR(t, cluster.SelfManagedRhoai, nil, notebooksNS, mr)
+
+	if err := ensureDashboardNamespacedRBAC(context.Background(), rr); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	getRoleAndBinding(t, rr, "rhods-dashboard-notebooks", cluster.DefaultNotebooksNamespaceRHOAI)
+	assertRoleAndBindingAbsent(t, rr, "rhods-dashboard-model-registries", testModelRegistryNS)
+}
+
+// TestEnsureDashboardNamespacedRBAC_ModelRegistryEmptyNamespaceCleansUpStale verifies that
+// when RegistriesNamespace is cleared on an existing ModelRegistry CR, stale RBAC is deleted.
+func TestEnsureDashboardNamespacedRBAC_ModelRegistryEmptyNamespaceCleansUpStale(t *testing.T) {
+	enableDashboardInRegistry(t)
+	enableWorkbenchesInRegistry(t)
+
+	mrNS := testModelRegistryNS
+	staleNSObj := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: mrNS}}
+	staleRole, staleRB := makeStaleRBACObjects(mrNS, "rhods-dashboard-model-registries")
+
+	// ModelRegistry CR exists but RegistriesNamespace is now empty
+	mr := &componentApi.ModelRegistry{
+		ObjectMeta: metav1.ObjectMeta{Name: componentApi.ModelRegistryInstanceName},
+		Spec: componentApi.ModelRegistrySpec{
+			ModelRegistryCommonSpec: componentApi.ModelRegistryCommonSpec{
+				RegistriesNamespace: "",
+			},
+		},
+	}
+
+	rr := newDashboardRBACTestRR(t, cluster.SelfManagedRhoai, nil, staleNSObj, staleRole, staleRB, mr)
+
+	if err := ensureDashboardNamespacedRBAC(context.Background(), rr); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	assertRoleAndBindingAbsent(t, rr, "rhods-dashboard-model-registries", mrNS)
+}
+
+// TestEnsureDashboardNamespacedRBAC_WorkbenchesDisabledCleansUpStale verifies that when
+// Workbenches is disabled, stale notebooks RBAC from a previous reconcile is deleted.
+func TestEnsureDashboardNamespacedRBAC_WorkbenchesDisabledCleansUpStale(t *testing.T) {
+	enableDashboardInRegistry(t)
+	DefaultRegistry().Add(&workbenchesStub{enabled: false})
+	DefaultRegistry().Disable(componentApi.WorkbenchesComponentName)
+
+	staleNS := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: cluster.DefaultNotebooksNamespaceRHOAI}}
+	staleRole, staleRB := makeStaleRBACObjects(cluster.DefaultNotebooksNamespaceRHOAI, "rhods-dashboard-notebooks")
+
+	rr := newDashboardRBACTestRR(t, cluster.SelfManagedRhoai, nil, staleNS, staleRole, staleRB)
+
+	if err := ensureDashboardNamespacedRBAC(context.Background(), rr); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	assertRoleAndBindingAbsent(t, rr, "rhods-dashboard-notebooks", cluster.DefaultNotebooksNamespaceRHOAI)
+}
+
+// TestEnsureDashboardNamespacedRBAC_Idempotent verifies that running reconcile twice
+// with the same state produces no error (SSA makes it safe to re-apply).
+func TestEnsureDashboardNamespacedRBAC_Idempotent(t *testing.T) {
+	enableDashboardInRegistry(t)
+	enableWorkbenchesInRegistry(t)
+
+	notebooksNS := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: cluster.DefaultNotebooksNamespaceRHOAI}}
+	rr := newDashboardRBACTestRR(t, cluster.SelfManagedRhoai, nil, notebooksNS)
+
+	for i := range 2 {
+		if err := ensureDashboardNamespacedRBAC(context.Background(), rr); err != nil {
+			t.Fatalf("reconcile %d: unexpected error: %v", i+1, err)
+		}
+	}
+
+	getRoleAndBinding(t, rr, "rhods-dashboard-notebooks", cluster.DefaultNotebooksNamespaceRHOAI)
+}
+
+// TestEnsureDashboardNamespacedRBAC_NotebooksRBACRules verifies the notebooks rules
+// grant exactly the expected resources and verbs.
+func TestEnsureDashboardNamespacedRBAC_NotebooksRBACRules(t *testing.T) {
+	rules := dashboardNotebooksRBACRules()
+
+	type expected struct {
+		resource string
+		verbs    []string
+	}
+	wants := []expected{
+		{rbacResourcePVCs, []string{rbacVerbCreate, rbacVerbGet}},
+		{rbacResourceCMs, []string{rbacVerbCreate, rbacVerbGet, rbacVerbUpdate}},
+		{rbacResourceSecrets, []string{rbacVerbCreate, rbacVerbGet, rbacVerbUpdate}},
+	}
+
+	if len(rules) != len(wants) {
+		t.Fatalf("expected %d notebook rules, got %d", len(wants), len(rules))
+	}
+	for i, w := range wants {
+		if len(rules[i].Resources) != 1 || rules[i].Resources[0] != w.resource {
+			t.Errorf("rule %d: expected resource %q, got %v", i, w.resource, rules[i].Resources)
+		}
+		for _, v := range w.verbs {
+			if !slices.Contains(rules[i].Verbs, v) {
+				t.Errorf("rule %d (%s): missing verb %q", i, w.resource, v)
+			}
+		}
+	}
+}
+
+// makeStaleRBACObjects returns a labeled Role and RoleBinding in the given namespace,
+// simulating objects left over from a previous reconcile.
+func makeStaleRBACObjects(namespace, name string) (*rbacv1.Role, *rbacv1.RoleBinding) {
+	managedLabels := map[string]string{dashboardManagedRBACLabel: dashboardManagedRBACLabelValue}
+	role := &rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace, Labels: managedLabels},
+	}
+	rb := &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace, Labels: managedLabels},
+	}
+	return role, rb
+}
+
+// TestEnsureDashboardNamespacedRBAC_DisabledCleansUpStale verifies that disabling
+// the dashboard causes pre-existing labeled Roles/RoleBindings to be deleted.
+func TestEnsureDashboardNamespacedRBAC_DisabledCleansUpStale(t *testing.T) {
+	withTestRegistry(t)
+	DefaultRegistry().Add(&dashboardStub{enabled: false})
+
+	staleNS := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: cluster.DefaultNotebooksNamespaceRHOAI}}
+	staleRole, staleRB := makeStaleRBACObjects(cluster.DefaultNotebooksNamespaceRHOAI, "rhods-dashboard-notebooks")
+
+	rr := newDashboardRBACTestRR(t, cluster.SelfManagedRhoai, nil, staleNS, staleRole, staleRB)
+
+	if err := ensureDashboardNamespacedRBAC(context.Background(), rr); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	assertRoleAndBindingAbsent(t, rr, "rhods-dashboard-notebooks", cluster.DefaultNotebooksNamespaceRHOAI)
+}
+
+// TestEnsureDashboardNamespacedRBAC_NamespaceChangeCleansUpOld verifies that when
+// the notebooks namespace changes, the old namespace's Role/RoleBinding is deleted.
+func TestEnsureDashboardNamespacedRBAC_NamespaceChangeCleansUpOld(t *testing.T) {
+	enableDashboardInRegistry(t)
+	enableWorkbenchesInRegistry(t)
+
+	oldNS := "rhods-notebooks-old"
+	newNS := cluster.DefaultNotebooksNamespaceRHOAI
+
+	oldNSObj := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: oldNS}}
+	newNSObj := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: newNS}}
+	staleRole, staleRB := makeStaleRBACObjects(oldNS, "rhods-dashboard-notebooks")
+
+	rr := newDashboardRBACTestRR(t, cluster.SelfManagedRhoai, nil, oldNSObj, newNSObj, staleRole, staleRB)
+
+	if err := ensureDashboardNamespacedRBAC(context.Background(), rr); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Old namespace objects must be gone, new namespace should have RBAC
+	assertRoleAndBindingAbsent(t, rr, "rhods-dashboard-notebooks", oldNS)
+	getRoleAndBinding(t, rr, "rhods-dashboard-notebooks", newNS)
+}
+
+// TestEnsureDashboardNamespacedRBAC_ModelRegistryRemovedCleansUp verifies that
+// removing the ModelRegistry CR causes its namespace's Role/RoleBinding to be deleted.
+func TestEnsureDashboardNamespacedRBAC_ModelRegistryRemovedCleansUp(t *testing.T) {
+	enableDashboardInRegistry(t)
+
+	mrNS := testModelRegistryNS
+	staleNSObj := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: mrNS}}
+	staleRole, staleRB := makeStaleRBACObjects(mrNS, "rhods-dashboard-model-registries")
+
+	// No ModelRegistry CR in the fake client
+	rr := newDashboardRBACTestRR(t, cluster.SelfManagedRhoai, nil, staleNSObj, staleRole, staleRB)
+
+	if err := ensureDashboardNamespacedRBAC(context.Background(), rr); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	assertRoleAndBindingAbsent(t, rr, "rhods-dashboard-model-registries", mrNS)
+}


### PR DESCRIPTION
## Description
This PR backports https://github.com/red-hat-data-services/rhods-operator/pull/39703 and https://github.com/red-hat-data-services/rhods-operator/pull/39854 to midstream.

## Release tracking
<!-- Optional. Set a target release only if this PR must ship in a specific release; it will be prioritized accordingly. -->
<!-- Target release for this PR, e.g. rhoai-3.6 or rhoai-3.7ea1 -->
Release: rhoai-3.6ea1
<!-- Required only if a Release is set above. Full link to a jira ticket, e.g. https://redhat.atlassian.net/browse/RHOAIENG-XXXXX -->
Jira: https://redhat.atlassian.net/browse/RHOAIENG-80335


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully
- [ ] New RELATED_IMAGE mappings are listed in ODH-Build-Config and RHOAI-Build-Config (CI validates names against build-config repos). Include links to build-config PRs in the description.

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [X] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
Backporting CVE fix 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features

* Dashboard access permissions are now automatically configured for enabled Workbenches and Model Registry resources in their target namespaces.
* Permissions support different deployment types and custom or shared Workbench namespaces.
* Access configuration is refreshed when relevant namespaces are created, updated, removed, or changed.

## Bug Fixes

* Prevented unnecessary permissions from being created when Dashboard, Workbenches, Model Registry resources, or target namespaces are unavailable.
* Removed outdated permissions when components are disabled or their target namespaces change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->