### PR TITLE
fix(dashboard-rbac): fix stale cleanup in shared-namespace case, scope namespace watch to CREATE only

### DIFF
--- a/internal/controller/modules/modules_controller.go
+++ b/internal/controller/modules/modules_controller.go
@@ -10,6 +10,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -120,13 +121,20 @@ func newDSCModuleReconciler(ctx context.Context, mgr ctrl.Manager) error {
 				resources.CreatedOrUpdatedOrDeletedNamed(gates.AcksConfigMap),
 				resources.CreatedOrUpdatedOrDeletedLabeled(gates.UpgradeGateLabel, "true"),
 			))).
-		// Namespace events re-trigger reconciliation so that ensureDashboardNamespacedRBAC
+		// Namespace CREATE events re-trigger reconciliation so that ensureDashboardNamespacedRBAC
 		// can create the notebooks/model-registry Role and RoleBinding when the target
-		// namespace appears after initial reconcile.
+		// namespace appears after initial reconcile. UPDATE and DELETE are not needed:
+		// deletions cascade automatically, and label/annotation changes don't affect RBAC provisioning.
 		Watches(
 			&corev1.Namespace{},
 			reconciler.WithEventMapper(func(ctx context.Context, _ client.Object) []reconcile.Request {
 				return cluster.WatchDataScienceClusters(ctx, mgr.GetClient())
+			}),
+			reconciler.WithPredicates(predicate.Funcs{
+				CreateFunc:  func(_ event.CreateEvent) bool { return true },
+				UpdateFunc:  func(_ event.UpdateEvent) bool { return false },
+				DeleteFunc:  func(_ event.DeleteEvent) bool { return false },
+				GenericFunc: func(_ event.GenericEvent) bool { return false },
 			}))
 
 	b = addModuleCRWatches(b)

--- a/internal/controller/modules/modules_controller_actions_dashboard_rbac.go
+++ b/internal/controller/modules/modules_controller_actions_dashboard_rbac.go
@@ -49,15 +49,18 @@ func ensureDashboardNamespacedRBAC(ctx context.Context, rr *odhtype.Reconciliati
 		return err
 	}
 
-	// Build the set of active namespaces for stale cleanup.
-	activeNamespaces := make(map[string]struct{}, len(targets))
+	// Build the set of active (namespace, name) pairs for stale cleanup.
+	// Keying by namespace alone would skip cleanup when two targets share a
+	// namespace and one of them is removed (e.g. ModelRegistry deleted while
+	// Workbenches still active in the same namespace).
+	activeKeys := make(map[string]struct{}, len(targets))
 	for _, t := range targets {
-		activeNamespaces[t.namespace] = struct{}{}
+		activeKeys[t.namespace+"/"+saName+"-"+t.suffix] = struct{}{}
 	}
 
 	// Always clean up stale Roles/RoleBindings before creating new ones.
 	// This handles: dashboard disabled, namespace changes, ModelRegistry removal.
-	if err := cleanupStaleDashboardRBAC(ctx, rr, activeNamespaces); err != nil {
+	if err := cleanupStaleDashboardRBAC(ctx, rr, activeKeys); err != nil {
 		return err
 	}
 
@@ -109,10 +112,12 @@ func resolveDashboardActiveState(ctx context.Context, rr *odhtype.Reconciliation
 	return targets, saName, nil
 }
 
-// cleanupStaleDashboardRBAC deletes labeled Roles/RoleBindings in namespaces that are
-// no longer in the active set. Runs unconditionally so that disabling the dashboard or
-// changing target namespaces always revokes access promptly.
-func cleanupStaleDashboardRBAC(ctx context.Context, rr *odhtype.ReconciliationRequest, activeNamespaces map[string]struct{}) error {
+// cleanupStaleDashboardRBAC deletes labeled Roles/RoleBindings whose namespace/name
+// key is no longer in the active set. Runs unconditionally so that disabling the
+// dashboard, changing namespaces, or removing a component always revokes access promptly.
+// activeKeys is keyed as "namespace/roleName" so that removing one target from a shared
+// namespace doesn't skip cleanup of the other target's objects.
+func cleanupStaleDashboardRBAC(ctx context.Context, rr *odhtype.ReconciliationRequest, activeKeys map[string]struct{}) error {
 	logger := logf.FromContext(ctx)
 	labelSelector := client.MatchingLabels{dashboardManagedRBACLabel: dashboardManagedRBACLabelValue}
 
@@ -122,7 +127,7 @@ func cleanupStaleDashboardRBAC(ctx context.Context, rr *odhtype.ReconciliationRe
 	}
 	for i := range roleList.Items {
 		role := &roleList.Items[i]
-		if _, active := activeNamespaces[role.Namespace]; active {
+		if _, active := activeKeys[role.Namespace+"/"+role.Name]; active {
 			continue
 		}
 		logger.Info("deleting stale dashboard Role", "namespace", role.Namespace, "name", role.Name)
@@ -137,7 +142,7 @@ func cleanupStaleDashboardRBAC(ctx context.Context, rr *odhtype.ReconciliationRe
 	}
 	for i := range rbList.Items {
 		rb := &rbList.Items[i]
-		if _, active := activeNamespaces[rb.Namespace]; active {
+		if _, active := activeKeys[rb.Namespace+"/"+rb.Name]; active {
 			continue
 		}
 		logger.Info("deleting stale dashboard RoleBinding", "namespace", rb.Namespace, "name", rb.Name)

--- a/internal/controller/modules/modules_controller_actions_dashboard_rbac_test.go
+++ b/internal/controller/modules/modules_controller_actions_dashboard_rbac_test.go
@@ -554,3 +554,43 @@ func TestEnsureDashboardNamespacedRBAC_ModelRegistryRemovedCleansUp(t *testing.T
 
 	assertRoleAndBindingAbsent(t, rr, "rhods-dashboard-model-registries", mrNS)
 }
+
+// TestEnsureDashboardNamespacedRBAC_SharedNamespaceModelRegistryRemoved verifies that
+// when notebooks and model-registry share a namespace and ModelRegistry is then removed,
+// only the model-registry Role/RoleBinding is deleted (notebooks RBAC survives).
+// This is the exact scenario from the CodeRabbit finding: namespace-based cleanup would
+// skip deletion because the namespace is still active for the notebooks target.
+func TestEnsureDashboardNamespacedRBAC_SharedNamespaceModelRegistryRemoved(t *testing.T) {
+	enableDashboardInRegistry(t)
+	enableWorkbenchesInRegistry(t)
+
+	sharedNS := "shared-namespace"
+	sharedNSObj := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: sharedNS}}
+
+	// Pre-seed stale model-registry objects in the shared namespace.
+	staleRole, staleRB := makeStaleRBACObjects(sharedNS, "rhods-dashboard-model-registries")
+
+	dsc := &dscv2.DataScienceCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-dsc"},
+		Spec: dscv2.DataScienceClusterSpec{
+			Components: dscv2.Components{
+				Workbenches: componentApi.DSCWorkbenches{
+					WorkbenchesCommonSpec: componentApi.WorkbenchesCommonSpec{
+						WorkbenchNamespace: sharedNS,
+					},
+				},
+			},
+		},
+	}
+
+	// No ModelRegistry CR — it was removed.
+	rr := newDashboardRBACTestRR(t, cluster.SelfManagedRhoai, dsc, sharedNSObj, staleRole, staleRB)
+
+	if err := ensureDashboardNamespacedRBAC(context.Background(), rr); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Notebooks RBAC must be created; model-registry stale objects must be gone.
+	getRoleAndBinding(t, rr, "rhods-dashboard-notebooks", sharedNS)
+	assertRoleAndBindingAbsent(t, rr, "rhods-dashboard-model-registries", sharedNS)
+}


### PR DESCRIPTION
## Description

Follow-up to #3972, addressing two correctness issues found in post-merge review.

**Fix 1: stale cleanup misses objects in shared-namespace scenario (CWE-284)**

`cleanupStaleDashboardRBAC` was keyed by namespace string. If notebooks and model-registry share a namespace and ModelRegistry is then removed, the namespace remains active for the notebooks target — so the stale `*-model-registries` Role/RoleBinding was never deleted, leaving the dashboard SA with persistent model-registry permissions it should no longer have.

Fix: switch the active key from `namespace` to `namespace/roleName`. Each target is now matched independently regardless of what other targets share the namespace.

**Fix 2: namespace watch fired on UPDATE and DELETE (unnecessary noise)**

The `corev1.Namespace` watch added in #3972 triggered reconciliation on all namespace events. Only CREATE is needed: namespace deletion cascades automatically (Kubernetes deletes all namespaced objects), and UPDATE events (label/annotation changes) don't affect RBAC provisioning. Added `predicate.Funcs` to filter to CREATE only.

## Release tracking

Release:
Jira:

## How Has This Been Tested?

- `TestEnsureDashboardNamespacedRBAC_SharedNamespaceModelRegistryRemoved`: new regression test that reproduces the exact shared-namespace cleanup failure — notebooks and model-registry share one namespace, ModelRegistry CR is removed, stale `*-model-registries` objects must be deleted while `*-notebooks` objects survive
- All 18 dashboard RBAC unit tests pass: `go test github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/modules -run TestEnsureDashboard`

## Screenshot or short clip

N/A

## Merge criteria

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully
- [ ] New RELATED_IMAGE mappings are listed in ODH-Build-Config and RHOAI-Build-Config (CI validates names against build-config repos). Include links to build-config PRs in the description.

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification

This PR fixes two correctness bugs in controller reconciliation logic: cleanup key granularity (shared-namespace stale RBAC) and watch predicate scoping (CREATE-only namespace watch). Neither change introduces new user-facing behavior or new API surface. The exact regression scenario for fix 1 is covered by `TestEnsureDashboardNamespacedRBAC_SharedNamespaceModelRegistryRemoved`, and all 18 dashboard RBAC unit tests exercise the full range of namespace/component combinations. E2E coverage for this edge case would require orchestrating two components into the same namespace, removing one, and asserting on RBAC object existence — not justified relative to the unit test coverage already in place.