### PR TITLE
Add odh-trustyai-module-operator to operator manifests

### DIFF
--- a/build/manifests-config.yaml
+++ b/build/manifests-config.yaml
@@ -62,3 +62,6 @@ map:
   odh-data-connect-hub-controller:
     src: dc-controller/config
     dest: data-connect-hub
+  odh-trustyai-module-operator:
+    src: config/default
+    dest: trustyai-module-operator


### PR DESCRIPTION
Adds 'odh-trustyai-module-operator' entry to build/manifests-config.yaml.

Repo: https://github.com/opendatahub-io/trustyai-service-operator
Jira: https://redhat.atlassian.net/browse/RHOAIENG-80231

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added manifest configuration for the TrustyAI Module Operator.
  * Enabled deployment configuration to be mapped to the TrustyAI Module Operator.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->