### PR TITLE
feat(status): stamp platform release version on in-tree components (RHOAIENG-76106)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -383,7 +383,7 @@ build: manifests generate fmt vet ## Build manager binary.
 	go build -o bin/manager cmd/main.go
 
 RUN_ARGS = --log-mode=devel --pprof-bind-address=127.0.0.1:6060
-GO_RUN_MAIN = OPERATOR_NAMESPACE=$(OPERATOR_NAMESPACE) DEFAULT_MANIFESTS_PATH=$(DEFAULT_MANIFESTS_PATH) go run $(GO_RUN_ARGS) ./cmd/main.go $(RUN_ARGS)
+GO_RUN_MAIN = OPERATOR_NAMESPACE=$(OPERATOR_NAMESPACE) DEFAULT_MANIFESTS_PATH=$(DEFAULT_MANIFESTS_PATH) DEFAULT_CHARTS_PATH=$(DEFAULT_CHARTS_PATH) go run $(GO_RUN_ARGS) ./cmd/main.go $(RUN_ARGS)
 .PHONY: run
 run: manifests generate fmt vet ## Run a controller from your host.
 	$(GO_RUN_MAIN)

--- a/api/common/types.go
+++ b/api/common/types.go
@@ -57,6 +57,11 @@ const (
 	ConditionReasonError = "Error"
 )
 
+// PlatformReleaseName is the well-known release entry name used by the
+// version handshake between the platform operator and component/module
+// controllers.
+const PlatformReleaseName = "platform"
+
 // +kubebuilder:object:generate=true
 type Condition struct {
 	// type of condition in CamelCase or in foo.example.com/CamelCase.
@@ -66,7 +71,6 @@ type Condition struct {
 	// +kubebuilder:validation:Pattern=`^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$`
 	// +kubebuilder:validation:MaxLength=316
 	Type string `json:"type"`
-
 	// status of the condition, one of True, False, Unknown.
 	// +required
 	// +kubebuilder:validation:Required

--- a/internal/controller/components/datasciencepipelines/datasciencepipelines_controller.go
+++ b/internal/controller/components/datasciencepipelines/datasciencepipelines_controller.go
@@ -37,6 +37,7 @@ import (
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/precondition"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/predicates"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/predicates/component"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/provision"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/reconciler"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/metadata/labels"
 )
@@ -64,6 +65,7 @@ func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.
 		).
 		WithPreCondition(precondition.Custom(checkPreConditions, precondition.WithStopReconciliation())).
 		WithAction(precondition.RunlevelGateAction()).
+		WithAction(provision.ComponentUpgradeGateAction).
 		WithAction(initialize).
 		WithAction(argoWorkflowsControllersOptions).
 		WithAction(releases.NewAction()).

--- a/internal/controller/components/datasciencepipelines/datasciencepipelines_controller.go
+++ b/internal/controller/components/datasciencepipelines/datasciencepipelines_controller.go
@@ -32,6 +32,7 @@ import (
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/gc"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/render/kustomize"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/status/deployments"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/status/platformrelease"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/status/releases"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/handlers"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/precondition"
@@ -64,6 +65,7 @@ func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.
 				component.ForLabel(labels.ODH.Component(LegacyComponentName), labels.True)),
 		).
 		WithPreCondition(precondition.Custom(checkPreConditions, precondition.WithStopReconciliation())).
+		WithPostStatusFn(platformrelease.NewPostStatusFn()).
 		WithAction(precondition.RunlevelGateAction()).
 		WithAction(provision.ComponentUpgradeGateAction).
 		WithAction(initialize).

--- a/internal/controller/components/kueue/kueue_controller.go
+++ b/internal/controller/components/kueue/kueue_controller.go
@@ -41,6 +41,7 @@ import (
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/gc"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/render/kustomize"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/status/deployments"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/status/platformrelease"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/status/releases"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/conditions"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/handlers"
@@ -159,6 +160,7 @@ func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.
 			Filter:      kueueDegradedConditionFilter,
 		})).
 		WithPreCondition(precondition.Custom(checkPreConditions, precondition.WithStopReconciliation())).
+		WithPostStatusFn(platformrelease.NewPostStatusFn()).
 		WithAction(precondition.RunlevelGateAction()).
 		WithAction(provision.ComponentUpgradeGateAction).
 		WithAction(initialize).

--- a/internal/controller/components/kueue/kueue_controller.go
+++ b/internal/controller/components/kueue/kueue_controller.go
@@ -49,6 +49,7 @@ import (
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/predicates/component"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/predicates/dependent"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/predicates/resources"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/provision"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/reconciler"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/metadata/labels"
@@ -159,6 +160,7 @@ func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.
 		})).
 		WithPreCondition(precondition.Custom(checkPreConditions, precondition.WithStopReconciliation())).
 		WithAction(precondition.RunlevelGateAction()).
+		WithAction(provision.ComponentUpgradeGateAction).
 		WithAction(initialize).
 		WithAction(releases.NewAction()).
 		WithAction(kustomize.NewAction(

--- a/internal/controller/components/modelregistry/modelregistry_controller.go
+++ b/internal/controller/components/modelregistry/modelregistry_controller.go
@@ -40,6 +40,7 @@ import (
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/predicates"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/predicates/component"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/predicates/generation"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/provision"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/reconciler"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/metadata/labels"
 )
@@ -74,6 +75,7 @@ func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.
 				component.ForLabel(labels.ODH.Component(LegacyComponentName), labels.True)),
 		).
 		WithAction(precondition.RunlevelGateAction()).
+		WithAction(provision.ComponentUpgradeGateAction).
 		WithAction(initialize).
 		WithAction(customizeManifests).
 		WithAction(releases.NewAction()).

--- a/internal/controller/components/modelregistry/modelregistry_controller.go
+++ b/internal/controller/components/modelregistry/modelregistry_controller.go
@@ -34,6 +34,7 @@ import (
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/render/kustomize"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/render/template"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/status/deployments"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/status/platformrelease"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/status/releases"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/handlers"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/precondition"
@@ -74,6 +75,7 @@ func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.
 			reconciler.WithPredicates(
 				component.ForLabel(labels.ODH.Component(LegacyComponentName), labels.True)),
 		).
+		WithPostStatusFn(platformrelease.NewPostStatusFn()).
 		WithAction(precondition.RunlevelGateAction()).
 		WithAction(provision.ComponentUpgradeGateAction).
 		WithAction(initialize).

--- a/internal/controller/components/ray/ray_controller.go
+++ b/internal/controller/components/ray/ray_controller.go
@@ -34,6 +34,7 @@ import (
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/render/kustomize"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/sanitycheck"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/status/deployments"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/status/platformrelease"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/status/releases"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/handlers"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/precondition"
@@ -65,6 +66,7 @@ func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.
 				component.ForLabel(labels.ODH.Component(LegacyComponentName), labels.True)),
 		).
 		WatchesGVK(gvk.CodeFlare, reconciler.Dynamic(reconciler.CrdExists(gvk.CodeFlare))).
+		WithPostStatusFn(platformrelease.NewPostStatusFn()).
 		WithAction(precondition.RunlevelGateAction()).
 		WithAction(provision.ComponentUpgradeGateAction).
 		WithAction(sanitycheck.NewAction(sanitycheck.WithUnwantedResource(gvk.CodeFlare, status.CodeFlarePresentMessage))).

--- a/internal/controller/components/ray/ray_controller.go
+++ b/internal/controller/components/ray/ray_controller.go
@@ -39,6 +39,7 @@ import (
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/precondition"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/predicates"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/predicates/component"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/provision"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/reconciler"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/metadata/labels"
 )
@@ -65,6 +66,7 @@ func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.
 		).
 		WatchesGVK(gvk.CodeFlare, reconciler.Dynamic(reconciler.CrdExists(gvk.CodeFlare))).
 		WithAction(precondition.RunlevelGateAction()).
+		WithAction(provision.ComponentUpgradeGateAction).
 		WithAction(sanitycheck.NewAction(sanitycheck.WithUnwantedResource(gvk.CodeFlare, status.CodeFlarePresentMessage))).
 		WithAction(initialize).
 		WithAction(releases.NewAction()).

--- a/internal/controller/components/sparkoperator/sparkoperator_controller.go
+++ b/internal/controller/components/sparkoperator/sparkoperator_controller.go
@@ -32,6 +32,7 @@ import (
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/gc"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/render/kustomize"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/status/deployments"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/status/platformrelease"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/status/releases"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/handlers"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/precondition"
@@ -62,6 +63,7 @@ func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.
 			reconciler.WithPredicates(
 				component.ForLabel(labels.ODH.Component(ComponentName), labels.True)),
 		).
+		WithPostStatusFn(platformrelease.NewPostStatusFn()).
 		WithAction(precondition.RunlevelGateAction()).
 		WithAction(provision.ComponentUpgradeGateAction).
 		WithAction(initialize).

--- a/internal/controller/components/sparkoperator/sparkoperator_controller.go
+++ b/internal/controller/components/sparkoperator/sparkoperator_controller.go
@@ -37,6 +37,7 @@ import (
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/precondition"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/predicates"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/predicates/component"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/provision"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/reconciler"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/metadata/labels"
 )
@@ -62,6 +63,7 @@ func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.
 				component.ForLabel(labels.ODH.Component(ComponentName), labels.True)),
 		).
 		WithAction(precondition.RunlevelGateAction()).
+		WithAction(provision.ComponentUpgradeGateAction).
 		WithAction(initialize).
 		WithAction(releases.NewAction()).
 		WithAction(kustomize.NewAction(

--- a/internal/controller/components/trainingoperator/trainingoperator_controller.go
+++ b/internal/controller/components/trainingoperator/trainingoperator_controller.go
@@ -36,6 +36,7 @@ import (
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/precondition"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/predicates"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/predicates/component"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/provision"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/reconciler"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/metadata/labels"
 )
@@ -58,6 +59,7 @@ func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.
 				component.ForLabel(labels.ODH.Component(LegacyComponentName), labels.True)),
 		).
 		WithAction(precondition.RunlevelGateAction()).
+		WithAction(provision.ComponentUpgradeGateAction).
 		WithAction(initialize).
 		WithAction(releases.NewAction()).
 		WithAction(kustomize.NewAction(

--- a/internal/controller/components/trainingoperator/trainingoperator_controller.go
+++ b/internal/controller/components/trainingoperator/trainingoperator_controller.go
@@ -31,6 +31,7 @@ import (
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/gc"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/render/kustomize"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/status/deployments"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/status/platformrelease"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/status/releases"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/handlers"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/precondition"
@@ -58,6 +59,7 @@ func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.
 			reconciler.WithPredicates(
 				component.ForLabel(labels.ODH.Component(LegacyComponentName), labels.True)),
 		).
+		WithPostStatusFn(platformrelease.NewPostStatusFn()).
 		WithAction(precondition.RunlevelGateAction()).
 		WithAction(provision.ComponentUpgradeGateAction).
 		WithAction(initialize).

--- a/internal/controller/components/trustyai/trustyai_controller.go
+++ b/internal/controller/components/trustyai/trustyai_controller.go
@@ -33,6 +33,7 @@ import (
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/gc"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/render/kustomize"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/status/deployments"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/status/platformrelease"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/status/releases"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/handlers"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/precondition"
@@ -68,6 +69,7 @@ func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.
 			precondition.WithStopReconciliation(),
 			precondition.WithMessage(status.ISVCMissingCRDMessage),
 		)).
+		WithPostStatusFn(platformrelease.NewPostStatusFn()).
 		WithAction(precondition.RunlevelGateAction()).
 		WithAction(provision.ComponentUpgradeGateAction).
 		WithAction(initialize).

--- a/internal/controller/components/trustyai/trustyai_controller.go
+++ b/internal/controller/components/trustyai/trustyai_controller.go
@@ -39,6 +39,7 @@ import (
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/predicates"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/predicates/component"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/predicates/resources"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/provision"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/reconciler"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/metadata/labels"
 )
@@ -68,6 +69,7 @@ func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.
 			precondition.WithMessage(status.ISVCMissingCRDMessage),
 		)).
 		WithAction(precondition.RunlevelGateAction()).
+		WithAction(provision.ComponentUpgradeGateAction).
 		WithAction(initialize).
 		WithAction(createConfigMap).
 		WithAction(releases.NewAction()).

--- a/internal/controller/datasciencecluster/datasciencecluster_controller.go
+++ b/internal/controller/datasciencecluster/datasciencecluster_controller.go
@@ -37,6 +37,7 @@ import (
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/gates"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/predicates/dependent"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/predicates/resources"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/provision"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/reconciler"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
 )
@@ -98,6 +99,7 @@ func NewDataScienceClusterReconciler(ctx context.Context, mgr ctrl.Manager) erro
 		WithAction(initialize).
 		WithAction(checkPreConditions).
 		WithAction(updateStatus).
+		WithAction(provision.AutoAcknowledgeUpgradeGates).
 		WithAction(checkUpgradeGates).
 		WithAction(provisionComponents).
 		WithAction(deploy.NewAction(

--- a/internal/controller/modules/modules_controller.go
+++ b/internal/controller/modules/modules_controller.go
@@ -37,12 +37,15 @@ import (
 
 // commonActions returns the shared action chain for both DSC and Platform modes.
 //
-// Ordering: provisionModules and render run before the gate check so
-// that gate ConfigMaps embedded in module Helm charts are discovered
-// before the check runs. ExtractUpgradeGates pulls gate CMs out of
-// rr.Resources and stashes them on rr.GateEntries. checkUpgradeGates
-// then merges all gate sources and writes descriptions to
-// odh-upgrade-acks. If unacked gates exist, deploy never runs.
+// provisionModules and render run before the gate check so that gate
+// ConfigMaps embedded in module Helm charts are discovered first.
+// provisionModules only populates rr.Resources — nothing is applied
+// to the cluster until deploy runs. ExtractUpgradeGates pulls gate CMs
+// out of rr.Resources, AutoAcknowledgeUpgradeGates auto-acks healthy
+// or unmanaged components, and checkUpgradeGates blocks deploy when
+// any gate remains unacknowledged. Gate entries are loaded from the
+// embedded in-tree gates file so they are available on the very first
+// reconcile without waiting for the informer cache to sync.
 func commonActions() []actions.Fn {
 	return []actions.Fn{
 		initializeModules,
@@ -52,6 +55,7 @@ func commonActions() []actions.Fn {
 		helmrender.NewAction(),
 		kustomizerender.NewAction(),
 		provision.ExtractUpgradeGates,
+		provision.AutoAcknowledgeUpgradeGates,
 		checkUpgradeGates,
 		injectModuleEnv,
 		injectPlatformConfig,

--- a/pkg/controller/actions/status/platformrelease/platform_release.go
+++ b/pkg/controller/actions/status/platformrelease/platform_release.go
@@ -1,0 +1,55 @@
+package platformrelease
+
+import (
+	"context"
+
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/opendatahub-io/opendatahub-operator/v2/api/common"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/reconciler"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
+)
+
+// NewPostStatusFn returns a PostStatusFn that stamps
+// status.releases[name="platform"] with the current operator version
+// when the component is happy and deploy was not skipped.
+func NewPostStatusFn() reconciler.PostStatusFn {
+	return func(ctx context.Context, rr *types.ReconciliationRequest, isHappy bool) error {
+		if !isHappy || rr.SkipDeploy {
+			return nil
+		}
+
+		obj, ok := rr.Instance.(common.WithReleases)
+		if !ok {
+			logf.FromContext(ctx).V(3).Info("Resource does not implement WithReleases, skipping platform release stamp")
+
+			return nil
+		}
+
+		setPlatformRelease(obj, rr.Release.Version.String())
+
+		return nil
+	}
+}
+
+func setPlatformRelease(wr common.WithReleases, version string) {
+	releases := wr.GetReleaseStatus()
+
+	for i, r := range *releases {
+		if r.Name == common.PlatformReleaseName {
+			(*releases)[i].Version = version
+
+			if i != 0 {
+				entry := (*releases)[i]
+				*releases = append([]common.ComponentRelease{entry}, append((*releases)[:i], (*releases)[i+1:]...)...)
+			}
+
+			return
+		}
+	}
+
+	*releases = append([]common.ComponentRelease{{
+		Name:    common.PlatformReleaseName,
+		Version: version,
+	}}, *releases...)
+}

--- a/pkg/controller/actions/status/platformrelease/platform_release_test.go
+++ b/pkg/controller/actions/status/platformrelease/platform_release_test.go
@@ -1,0 +1,115 @@
+package platformrelease_test
+
+import (
+	"testing"
+
+	"github.com/blang/semver/v4"
+	"github.com/operator-framework/api/pkg/lib/version"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/opendatahub-io/opendatahub-operator/v2/api/common"
+	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/api/components/v1alpha1"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/status/platformrelease"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
+
+	. "github.com/onsi/gomega"
+)
+
+func newReconciliationRequest(instance common.PlatformObject, skipDeploy bool) types.ReconciliationRequest {
+	sv := semver.MustParse("2.5.0")
+
+	return types.ReconciliationRequest{
+		Instance:   instance,
+		SkipDeploy: skipDeploy,
+		Release:    common.Release{Version: version.OperatorVersion{Version: sv}},
+	}
+}
+
+func TestPlatformReleasePostStatusFn(t *testing.T) {
+	t.Run("should stamp platform release when happy and deploy not skipped", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		instance := &componentApi.Ray{ObjectMeta: metav1.ObjectMeta{Name: "default-ray"}}
+		rr := newReconciliationRequest(instance, false)
+
+		fn := platformrelease.NewPostStatusFn()
+		err := fn(ctx, &rr, true)
+
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(instance.GetReleaseStatus()).To(HaveValue(ConsistOf(
+			common.ComponentRelease{Name: common.PlatformReleaseName, Version: "2.5.0"},
+		)))
+	})
+
+	t.Run("should not stamp when not happy", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		instance := &componentApi.Ray{ObjectMeta: metav1.ObjectMeta{Name: "default-ray"}}
+		rr := newReconciliationRequest(instance, false)
+
+		fn := platformrelease.NewPostStatusFn()
+		err := fn(ctx, &rr, false)
+
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(instance.GetReleaseStatus()).To(HaveValue(BeEmpty()))
+	})
+
+	t.Run("should not stamp when deploy is skipped", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		instance := &componentApi.Ray{ObjectMeta: metav1.ObjectMeta{Name: "default-ray"}}
+		rr := newReconciliationRequest(instance, true)
+
+		fn := platformrelease.NewPostStatusFn()
+		err := fn(ctx, &rr, true)
+
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(instance.GetReleaseStatus()).To(HaveValue(BeEmpty()))
+	})
+
+	t.Run("should update existing platform release entry and move it to first position", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		instance := &componentApi.Ray{ObjectMeta: metav1.ObjectMeta{Name: "default-ray"}}
+		instance.SetReleaseStatus([]common.ComponentRelease{
+			{Name: "ray", Version: "1.0.0"},
+			{Name: common.PlatformReleaseName, Version: "2.0.0"},
+		})
+
+		rr := newReconciliationRequest(instance, false)
+
+		fn := platformrelease.NewPostStatusFn()
+		err := fn(ctx, &rr, true)
+
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(instance.GetReleaseStatus()).To(HaveValue(HaveExactElements(
+			common.ComponentRelease{Name: common.PlatformReleaseName, Version: "2.5.0"},
+			common.ComponentRelease{Name: "ray", Version: "1.0.0"},
+		)))
+	})
+
+	t.Run("should prepend platform release when other releases exist", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		instance := &componentApi.Ray{ObjectMeta: metav1.ObjectMeta{Name: "default-ray"}}
+		instance.SetReleaseStatus([]common.ComponentRelease{
+			{Name: "ray", Version: "1.0.0"},
+		})
+
+		rr := newReconciliationRequest(instance, false)
+
+		fn := platformrelease.NewPostStatusFn()
+		err := fn(ctx, &rr, true)
+
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(instance.GetReleaseStatus()).To(HaveValue(HaveExactElements(
+			common.ComponentRelease{Name: common.PlatformReleaseName, Version: "2.5.0"},
+			common.ComponentRelease{Name: "ray", Version: "1.0.0"},
+		)))
+	})
+}

--- a/pkg/controller/actions/status/releases/action_fetch_releases_status.go
+++ b/pkg/controller/actions/status/releases/action_fetch_releases_status.go
@@ -73,8 +73,21 @@ func (a *Action) run(ctx context.Context, rr *types.ReconciliationRequest) error
 		a.componentReleaseStatus = releases
 	}
 
+	// Carry forward the platform release entry from the existing
+	// status. This entry is managed by the PostStatusFn hook
+	// (platformrelease package), not by the component metadata YAML.
+	result := append([]common.ComponentRelease{}, a.componentReleaseStatus...)
+
+	for _, r := range *obj.GetReleaseStatus() {
+		if r.Name == common.PlatformReleaseName {
+			result = append([]common.ComponentRelease{r}, result...)
+
+			break
+		}
+	}
+
 	// Update the release status in the resource
-	obj.SetReleaseStatus(a.componentReleaseStatus)
+	obj.SetReleaseStatus(result)
 
 	return nil
 }

--- a/pkg/controller/actions/status/releases/action_fetch_releases_status_test.go
+++ b/pkg/controller/actions/status/releases/action_fetch_releases_status_test.go
@@ -15,6 +15,30 @@ import (
 	. "github.com/onsi/gomega"
 )
 
+const kfpMetadataYAML = `
+releases:
+  - name: Kubeflow Pipelines
+    version: 2.2.0
+    repoUrl: https://github.com/kubeflow/kfp-tekton
+`
+
+const multiReleaseMetadataYAML = `
+releases:
+  - name: Kubeflow Pipelines
+    version: 2.2.0
+    repoUrl: https://github.com/kubeflow/kfp-tekton
+  - name: Another Component
+    version: 1.3.1
+    repoUrl: https://example.com/repo
+`
+
+const invalidMetadataYAML = `
+releases:
+  - name: Kubeflow Pipelines
+    versionNumber: 2.2.0
+    repoUrl: https://github.com/kubeflow/kfp-tekton
+`
+
 func TestFetchReleasesStatusAction(t *testing.T) {
 	t.Helper()
 
@@ -36,15 +60,7 @@ func TestFetchReleasesStatusAction(t *testing.T) {
 		{
 			name:             "should successfully render releases from valid YAML",
 			metadataFilePath: filepath.Join(tempDir, "valid_file.yaml"),
-			metadataContent: `
-releases:
-  - name: Kubeflow Pipelines
-    version: 2.2.0
-    repoUrl: https://github.com/kubeflow/kfp-tekton
-  - name: Another Component
-    version: 1.3.1
-    repoUrl: https://example.com/repo
-`,
+			metadataContent:  multiReleaseMetadataYAML,
 			expectedReleases: 2,
 			expectedError:    false,
 		},
@@ -58,12 +74,7 @@ releases:
 		{
 			name:             "should fail if YAML is invalid and return empty releases",
 			metadataFilePath: filepath.Join(tempDir, "invalid_file.yaml"),
-			metadataContent: `
-releases:
-  - name: Kubeflow Pipelines
-    versionNumber: 2.2.0
-    repoUrl: https://github.com/kubeflow/kfp-tekton
-`,
+			metadataContent:  invalidMetadataYAML,
 			expectedReleases: 0,
 			expectedError:    false,
 		},
@@ -77,16 +88,11 @@ releases:
 		{
 			name:             "should not re-render releases if cached",
 			metadataFilePath: filepath.Join(tempDir, "cached_file.yaml"),
-			metadataContent: `
-releases:
-  - name: Kubeflow Pipelines
-    version: 2.2.0
-    repoUrl: https://github.com/kubeflow/kfp-tekton
-`,
+			metadataContent:  kfpMetadataYAML,
 			expectedReleases: 1,
 			expectedError:    false,
 			providedStatus: []common.ComponentRelease{
-				{ // Simulating cached status
+				{
 					Name:    "Kubeflow Pipelines",
 					Version: "0.0.0",
 					RepoURL: "https://github.com/kubeflow/kfp-tekton",
@@ -159,6 +165,84 @@ releases:
 
 			// Validate the expected release count after action
 			g.Expect(*finalReleases).To(HaveLen(tt.expectedReleases))
+		})
+	}
+}
+
+func TestFetchReleasesStatusAction_PlatformRelease(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	tests := []struct {
+		name             string
+		existingReleases []common.ComponentRelease
+		expectedReleases []common.ComponentRelease
+	}{
+		{
+			name: "should carry forward existing platform release as first entry",
+			existingReleases: []common.ComponentRelease{
+				{Name: common.PlatformReleaseName, Version: "2.4.0"},
+				{Name: "Kubeflow Pipelines", Version: "2.0.0"},
+			},
+			expectedReleases: []common.ComponentRelease{
+				{
+					Name:    common.PlatformReleaseName,
+					Version: "2.4.0",
+				},
+				{
+					Name:    "Kubeflow Pipelines",
+					Version: "2.2.0",
+					RepoURL: "https://github.com/kubeflow/kfp-tekton",
+				},
+				{
+					Name:    "Another Component",
+					Version: "1.3.1",
+					RepoURL: "https://example.com/repo",
+				},
+			},
+		},
+		{
+			name:             "should not inject platform release when none exists",
+			existingReleases: nil,
+			expectedReleases: []common.ComponentRelease{
+				{
+					Name:    "Kubeflow Pipelines",
+					Version: "2.2.0",
+					RepoURL: "https://github.com/kubeflow/kfp-tekton",
+				},
+				{
+					Name:    "Another Component",
+					Version: "1.3.1",
+					RepoURL: "https://example.com/repo",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tempDir := t.TempDir()
+			metadataPath := filepath.Join(tempDir, "component_metadata.yaml")
+
+			err := os.WriteFile(metadataPath, []byte(multiReleaseMetadataYAML), 0600)
+			g.Expect(err).NotTo(HaveOccurred())
+
+			instance := &componentApi.DataSciencePipelines{
+				ObjectMeta: metav1.ObjectMeta{Name: "default-dsp"},
+			}
+			if tt.existingReleases != nil {
+				instance.SetReleaseStatus(tt.existingReleases)
+			}
+
+			rr := types.ReconciliationRequest{Instance: instance}
+
+			action := releases.NewAction(
+				releases.WithMetadataFilePath(func(_ *types.ReconciliationRequest) string { return metadataPath }),
+			)
+
+			err = action(ctx, &rr)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(*instance.GetReleaseStatus()).To(Equal(tt.expectedReleases))
 		})
 	}
 }

--- a/pkg/controller/gates/gates.go
+++ b/pkg/controller/gates/gates.go
@@ -23,6 +23,7 @@ var gateResourcesFS embed.FS
 const (
 	UpgradeGateLabel    = "platform.opendatahub.io/upgrade-gate"
 	AcksConfigMap       = "odh-upgrade-acks"
+	GateConfigMap       = "odh-2.x-operator-upgrade-gates"
 	ManagedByAnnotation = "platform.opendatahub.io/managed-by"
 )
 

--- a/pkg/controller/gates/resources/gates.yaml
+++ b/pkg/controller/gates/resources/gates.yaml
@@ -19,4 +19,20 @@ metadata:
   name: odh-intree-gates
   labels:
     platform.opendatahub.io/upgrade-gate: "true"
-data: {}
+data:
+  ack-3.5.1-aigateway: "Acknowledge upgrade of aigateway from version 2.x to 3.5.1"
+  ack-3.5.1-dashboard: "Acknowledge upgrade of dashboard from version 2.x to 3.5.1"
+  ack-3.5.1-datasciencepipelines: "Acknowledge upgrade of datasciencepipelines from version 2.x to 3.5.1"
+  ack-3.5.1-feastoperator: "Acknowledge upgrade of feastoperator from version 2.x to 3.5.1"
+  ack-3.5.1-kserve: "Acknowledge upgrade of kserve from version 2.x to 3.5.1"
+  ack-3.5.1-kueue: "Acknowledge upgrade of kueue from version 2.x to 3.5.1"
+  ack-3.5.1-mcplifecycleoperator: "Acknowledge upgrade of mcplifecycleoperator from version 2.x to 3.5.1"
+  ack-3.5.1-mlflowoperator: "Acknowledge upgrade of mlflowoperator from version 2.x to 3.5.1"
+  ack-3.5.1-modelregistry: "Acknowledge upgrade of modelregistry from version 2.x to 3.5.1"
+  ack-3.5.1-ogx: "Acknowledge upgrade of ogx from version 2.x to 3.5.1"
+  ack-3.5.1-ray: "Acknowledge upgrade of ray from version 2.x to 3.5.1"
+  ack-3.5.1-sparkoperator: "Acknowledge upgrade of sparkoperator from version 2.x to 3.5.1"
+  ack-3.5.1-trainer: "Acknowledge upgrade of trainer from version 2.x to 3.5.1"
+  ack-3.5.1-trainingoperator: "Acknowledge upgrade of trainingoperator from version 2.x to 3.5.1"
+  ack-3.5.1-trustyai: "Acknowledge upgrade of trustyai from version 2.x to 3.5.1"
+  ack-3.5.1-workbenches: "Acknowledge upgrade of workbenches from version 2.x to 3.5.1"

--- a/pkg/controller/provision/auto_ack_action.go
+++ b/pkg/controller/provision/auto_ack_action.go
@@ -1,0 +1,158 @@
+package provision
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"strings"
+
+	operatorv1 "github.com/openshift/api/operator/v1"
+	corev1 "k8s.io/api/core/v1"
+	k8serr "k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
+	dscv2 "github.com/opendatahub-io/opendatahub-operator/v2/api/datasciencecluster/v2"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/gates"
+	odhtype "github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
+)
+
+// AutoAcknowledgeUpgradeGates is an actions.Fn that auto-acknowledges
+// upgrade gates for components whose health checks pass. Components
+// that are not Managed in the DSC are auto-acked immediately since
+// they are not expected to be present. It is a no-op when the acks
+// ConfigMap does not exist or has no unacknowledged entries for the
+// current version (fresh install or same-major upgrade).
+func AutoAcknowledgeUpgradeGates(ctx context.Context, rr *odhtype.ReconciliationRequest) error {
+	ns, err := cluster.GetOperatorNamespace()
+	if err != nil {
+		return nil //nolint:nilerr // operator NS not initialized (e.g. tests); skip gracefully
+	}
+
+	appsNS := cluster.GetApplicationNamespace()
+	managed := resolveManagedComponents(rr.Instance)
+
+	return AutoAcknowledgeUpgradeGatesInNamespace(ctx, rr.Client, ns, appsNS, "3.5.1", managed)
+}
+
+// managedComponents maps component names to true
+// when they are Managed in the DSC. A nil map means
+// all components require a health check.
+func AutoAcknowledgeUpgradeGatesInNamespace(
+	ctx context.Context, cli client.Client,
+	operatorNS, appsNS, version string,
+	managedComponents map[string]bool,
+) error {
+	log := logf.FromContext(ctx)
+
+	acksCM := &corev1.ConfigMap{}
+	if err := cli.Get(ctx, client.ObjectKey{
+		Name:      gates.AcksConfigMap,
+		Namespace: operatorNS,
+	}, acksCM); err != nil {
+		if k8serr.IsNotFound(err) {
+			return nil
+		}
+		return fmt.Errorf("failed to get %s ConfigMap: %w", gates.AcksConfigMap, err)
+	}
+
+	versionPrefix := "ack-" + version + "-"
+	unacked := collectUnackedComponents(acksCM.Data, versionPrefix)
+
+	if len(unacked) == 0 {
+		return nil
+	}
+
+	log.Info("running auto-ack upgrade checks", "version", version, "unacked", len(unacked))
+
+	dirty := false
+	for key, component := range unacked {
+		if managedComponents == nil || !managedComponents[component] {
+			acksCM.Data[key] = "true"
+			dirty = true
+
+			log.Info("auto-acknowledged upgrade gate for unmanaged component",
+				"key", key, "component", component)
+
+			continue
+		}
+
+		checkFn := GetUpgradeCheck(component)
+
+		if err := checkFn(ctx, cli, component, appsNS); err != nil {
+			log.V(1).Info("component not ready for auto-ack",
+				"component", component, "reason", err)
+			continue
+		}
+
+		acksCM.Data[key] = "true"
+		dirty = true
+
+		log.Info("auto-acknowledged upgrade gate", "key", key, "component", component)
+	}
+
+	if dirty {
+		if err := cli.Update(ctx, acksCM); err != nil {
+			return fmt.Errorf("failed to patch %s ConfigMap: %w", gates.AcksConfigMap, err)
+		}
+	}
+
+	return nil
+}
+
+// collectUnackedComponents returns a map of gate-key → component-name
+// for entries that match the version prefix and are not yet acknowledged.
+func collectUnackedComponents(data map[string]string, versionPrefix string) map[string]string {
+	result := make(map[string]string)
+	for key, val := range data {
+		if !strings.HasPrefix(key, versionPrefix) {
+			continue
+		}
+		if val == "true" {
+			continue
+		}
+		component := strings.TrimPrefix(key, versionPrefix)
+		if component != "" {
+			result[key] = component
+		}
+	}
+	return result
+}
+
+// resolveManagedComponents extracts a set of component names that have
+// ManagementState == Managed from the DSC spec. Returns nil when the
+// instance is not a DSC (e.g. Platform CR in xKS mode), which means
+// all components will require a health check.
+func resolveManagedComponents(instance client.Object) map[string]bool {
+	dsc, ok := instance.(*dscv2.DataScienceCluster)
+	if !ok || dsc == nil {
+		return nil
+	}
+
+	result := make(map[string]bool)
+
+	componentsValue := reflect.ValueOf(dsc.Spec.Components)
+	componentsType := componentsValue.Type()
+
+	for i := range componentsType.NumField() {
+		field := componentsType.Field(i)
+
+		jsonTag := field.Tag.Get("json")
+		name := strings.Split(jsonTag, ",")[0]
+		if name == "" || name == "-" {
+			continue
+		}
+
+		mgmtField := componentsValue.Field(i).FieldByName("ManagementState")
+		if !mgmtField.IsValid() {
+			continue
+		}
+
+		if mgmtField.Interface() == operatorv1.Managed {
+			result[name] = true
+		}
+	}
+
+	return result
+}

--- a/pkg/controller/provision/auto_ack_action_test.go
+++ b/pkg/controller/provision/auto_ack_action_test.go
@@ -1,0 +1,351 @@
+package provision_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/gates"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/provision"
+)
+
+const (
+	testNS   = "test-ns"
+	testApps = "apps-ns"
+)
+
+func autoAckScheme() *runtime.Scheme {
+	s := runtime.NewScheme()
+	_ = corev1.AddToScheme(s)
+	_ = appsv1.AddToScheme(s)
+	return s
+}
+
+func gateCM(data map[string]string) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      gates.GateConfigMap,
+			Namespace: testNS,
+			Labels:    map[string]string{gates.UpgradeGateLabel: "true"},
+		},
+		Data: data,
+	}
+}
+
+func acksCM(data map[string]string) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      gates.AcksConfigMap,
+			Namespace: testNS,
+		},
+		Data: data,
+	}
+}
+
+func readyDeployment(ns, name, component string) *appsv1.Deployment {
+	replicas := int32(1)
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: ns,
+			Labels: map[string]string{
+				"app.opendatahub.io/" + component: "true",
+			},
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &replicas,
+		},
+		Status: appsv1.DeploymentStatus{
+			ReadyReplicas: 1,
+		},
+	}
+}
+
+func unreadyDeployment(name, component string) *appsv1.Deployment {
+	replicas := int32(1)
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: testApps,
+			Labels: map[string]string{
+				"app.opendatahub.io/" + component: "true",
+			},
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &replicas,
+		},
+		Status: appsv1.DeploymentStatus{
+			ReadyReplicas: 0,
+		},
+	}
+}
+
+// allManaged is a helper that marks all given components as Managed.
+func allManaged(names ...string) map[string]bool {
+	m := make(map[string]bool, len(names))
+	for _, n := range names {
+		m[n] = true
+	}
+	return m
+}
+
+func TestAutoAck_NoGateConfigMap(t *testing.T) {
+	t.Parallel()
+
+	cli := fake.NewClientBuilder().WithScheme(autoAckScheme()).Build()
+
+	err := provision.AutoAcknowledgeUpgradeGatesInNamespace(
+		context.Background(), cli, testNS, testApps, "3.0.0", nil)
+
+	require.NoError(t, err)
+}
+
+func TestAutoAck_NoAcksConfigMap(t *testing.T) {
+	t.Parallel()
+
+	cli := fake.NewClientBuilder().WithScheme(autoAckScheme()).
+		WithObjects(gateCM(map[string]string{
+			"ack-3.0.0-dashboard": "Dashboard upgrade",
+		})).Build()
+
+	err := provision.AutoAcknowledgeUpgradeGatesInNamespace(
+		context.Background(), cli, testNS, testApps, "3.0.0", nil)
+
+	require.NoError(t, err)
+}
+
+func TestAutoAck_AllAlreadyAcked(t *testing.T) {
+	t.Parallel()
+
+	cli := fake.NewClientBuilder().WithScheme(autoAckScheme()).
+		WithObjects(
+			gateCM(map[string]string{
+				"ack-3.0.0-dashboard": "Dashboard upgrade",
+			}),
+			acksCM(map[string]string{
+				"ack-3.0.0-dashboard": "true",
+			}),
+		).Build()
+
+	err := provision.AutoAcknowledgeUpgradeGatesInNamespace(
+		context.Background(), cli, testNS, testApps, "3.0.0",
+		allManaged("dashboard"))
+
+	require.NoError(t, err)
+
+	cm := &corev1.ConfigMap{}
+	require.NoError(t, cli.Get(context.Background(),
+		client.ObjectKey{Name: gates.AcksConfigMap, Namespace: testNS}, cm))
+	assert.Equal(t, "true", cm.Data["ack-3.0.0-dashboard"])
+}
+
+func TestAutoAck_HealthyComponentAutoAcked(t *testing.T) {
+	t.Parallel()
+
+	cli := fake.NewClientBuilder().WithScheme(autoAckScheme()).
+		WithObjects(
+			gateCM(map[string]string{
+				"ack-3.0.0-dashboard": "Dashboard upgrade",
+			}),
+			acksCM(map[string]string{
+				"ack-3.0.0-dashboard": "Acknowledge upgrade of dashboard from version 2.x to 3.0.0",
+			}),
+			readyDeployment(testApps, "dashboard", "dashboard"),
+		).Build()
+
+	err := provision.AutoAcknowledgeUpgradeGatesInNamespace(
+		context.Background(), cli, testNS, testApps, "3.0.0",
+		allManaged("dashboard"))
+
+	require.NoError(t, err)
+
+	cm := &corev1.ConfigMap{}
+	require.NoError(t, cli.Get(context.Background(),
+		client.ObjectKey{Name: gates.AcksConfigMap, Namespace: testNS}, cm))
+	assert.Equal(t, "true", cm.Data["ack-3.0.0-dashboard"])
+}
+
+func TestAutoAck_UnhealthyComponentLeftUnacked(t *testing.T) {
+	t.Parallel()
+
+	cli := fake.NewClientBuilder().WithScheme(autoAckScheme()).
+		WithObjects(
+			gateCM(map[string]string{
+				"ack-3.0.0-kserve": "KServe upgrade",
+			}),
+			acksCM(map[string]string{
+				"ack-3.0.0-kserve": "Acknowledge upgrade of kserve from version 2.x to 3.0.0",
+			}),
+			unreadyDeployment("kserve-controller", "kserve"),
+		).Build()
+
+	err := provision.AutoAcknowledgeUpgradeGatesInNamespace(
+		context.Background(), cli, testNS, testApps, "3.0.0",
+		allManaged("kserve"))
+
+	require.NoError(t, err)
+
+	cm := &corev1.ConfigMap{}
+	require.NoError(t, cli.Get(context.Background(),
+		client.ObjectKey{Name: gates.AcksConfigMap, Namespace: testNS}, cm))
+	assert.NotEqual(t, "true", cm.Data["ack-3.0.0-kserve"],
+		"unhealthy component should remain unacked")
+}
+
+func TestAutoAck_PartialAck(t *testing.T) {
+	t.Parallel()
+
+	cli := fake.NewClientBuilder().WithScheme(autoAckScheme()).
+		WithObjects(
+			gateCM(map[string]string{
+				"ack-3.0.0-dashboard": "Dashboard upgrade",
+				"ack-3.0.0-kserve":    "KServe upgrade",
+				"ack-3.0.0-ray":       "Ray upgrade",
+			}),
+			acksCM(map[string]string{
+				"ack-3.0.0-dashboard": "true",
+				"ack-3.0.0-kserve":    "Acknowledge upgrade of kserve from version 2.x to 3.0.0",
+				"ack-3.0.0-ray":       "Acknowledge upgrade of ray from version 2.x to 3.0.0",
+			}),
+			readyDeployment(testApps, "ray-operator", "ray"),
+			unreadyDeployment("kserve-controller", "kserve"),
+		).Build()
+
+	err := provision.AutoAcknowledgeUpgradeGatesInNamespace(
+		context.Background(), cli, testNS, testApps, "3.0.0",
+		allManaged("dashboard", "kserve", "ray"))
+
+	require.NoError(t, err)
+
+	cm := &corev1.ConfigMap{}
+	require.NoError(t, cli.Get(context.Background(),
+		client.ObjectKey{Name: gates.AcksConfigMap, Namespace: testNS}, cm))
+
+	assert.Equal(t, "true", cm.Data["ack-3.0.0-dashboard"], "already acked stays acked")
+	assert.Equal(t, "true", cm.Data["ack-3.0.0-ray"], "healthy component auto-acked")
+	assert.NotEqual(t, "true", cm.Data["ack-3.0.0-kserve"], "unhealthy remains unacked")
+}
+
+func TestAutoAck_IgnoresOtherVersionKeys(t *testing.T) {
+	t.Parallel()
+
+	cli := fake.NewClientBuilder().WithScheme(autoAckScheme()).
+		WithObjects(
+			gateCM(map[string]string{
+				"ack-3.0.0-dashboard": "Dashboard upgrade",
+			}),
+			acksCM(map[string]string{
+				"ack-3.0.0-dashboard": "Acknowledge upgrade of dashboard",
+				"ack-2.0.0-dashboard": "Old version gate",
+			}),
+			readyDeployment(testApps, "dashboard", "dashboard"),
+		).Build()
+
+	err := provision.AutoAcknowledgeUpgradeGatesInNamespace(
+		context.Background(), cli, testNS, testApps, "3.0.0",
+		allManaged("dashboard"))
+
+	require.NoError(t, err)
+
+	cm := &corev1.ConfigMap{}
+	require.NoError(t, cli.Get(context.Background(),
+		client.ObjectKey{Name: gates.AcksConfigMap, Namespace: testNS}, cm))
+
+	assert.Equal(t, "true", cm.Data["ack-3.0.0-dashboard"])
+	assert.Equal(t, "Old version gate", cm.Data["ack-2.0.0-dashboard"],
+		"other version keys should not be touched")
+}
+
+func TestAutoAck_NoDeployments_ComponentConsideredHealthy(t *testing.T) {
+	t.Parallel()
+
+	cli := fake.NewClientBuilder().WithScheme(autoAckScheme()).
+		WithObjects(
+			gateCM(map[string]string{
+				"ack-3.0.0-trustyai": "TrustyAI upgrade",
+			}),
+			acksCM(map[string]string{
+				"ack-3.0.0-trustyai": "Acknowledge upgrade of trustyai",
+			}),
+		).Build()
+
+	err := provision.AutoAcknowledgeUpgradeGatesInNamespace(
+		context.Background(), cli, testNS, testApps, "3.0.0",
+		allManaged("trustyai"))
+
+	require.NoError(t, err)
+
+	cm := &corev1.ConfigMap{}
+	require.NoError(t, cli.Get(context.Background(),
+		client.ObjectKey{Name: gates.AcksConfigMap, Namespace: testNS}, cm))
+	assert.Equal(t, "true", cm.Data["ack-3.0.0-trustyai"],
+		"component with no deployments should be auto-acked")
+}
+
+func TestAutoAck_UnmanagedComponentAutoAckedWithoutHealthCheck(t *testing.T) {
+	t.Parallel()
+
+	cli := fake.NewClientBuilder().WithScheme(autoAckScheme()).
+		WithObjects(
+			gateCM(map[string]string{
+				"ack-3.0.0-dashboard": "Dashboard upgrade",
+				"ack-3.0.0-trustyai":  "TrustyAI upgrade",
+			}),
+			acksCM(map[string]string{
+				"ack-3.0.0-dashboard": "Acknowledge upgrade of dashboard",
+				"ack-3.0.0-trustyai":  "Acknowledge upgrade of trustyai",
+			}),
+			unreadyDeployment("dashboard", "dashboard"),
+			unreadyDeployment("trustyai-service", "trustyai"),
+		).Build()
+
+	managed := allManaged("dashboard")
+
+	err := provision.AutoAcknowledgeUpgradeGatesInNamespace(
+		context.Background(), cli, testNS, testApps, "3.0.0", managed)
+
+	require.NoError(t, err)
+
+	cm := &corev1.ConfigMap{}
+	require.NoError(t, cli.Get(context.Background(),
+		client.ObjectKey{Name: gates.AcksConfigMap, Namespace: testNS}, cm))
+
+	assert.NotEqual(t, "true", cm.Data["ack-3.0.0-dashboard"],
+		"managed component with unready deployments stays unacked")
+	assert.Equal(t, "true", cm.Data["ack-3.0.0-trustyai"],
+		"unmanaged component should be auto-acked regardless of deployment state")
+}
+
+func TestAutoAck_NilManagedMap_AllComponentsAutoAcked(t *testing.T) {
+	t.Parallel()
+
+	cli := fake.NewClientBuilder().WithScheme(autoAckScheme()).
+		WithObjects(
+			gateCM(map[string]string{
+				"ack-3.0.0-kserve": "KServe upgrade",
+			}),
+			acksCM(map[string]string{
+				"ack-3.0.0-kserve": "Acknowledge upgrade of kserve",
+			}),
+			unreadyDeployment("kserve-controller", "kserve"),
+		).Build()
+
+	err := provision.AutoAcknowledgeUpgradeGatesInNamespace(
+		context.Background(), cli, testNS, testApps, "3.0.0", nil)
+
+	require.NoError(t, err)
+
+	cm := &corev1.ConfigMap{}
+	require.NoError(t, cli.Get(context.Background(),
+		client.ObjectKey{Name: gates.AcksConfigMap, Namespace: testNS}, cm))
+	assert.Equal(t, "true", cm.Data["ack-3.0.0-kserve"],
+		"nil managed map (xKS) means all components are treated as unmanaged and auto-acked")
+}

--- a/pkg/controller/provision/gates_action.go
+++ b/pkg/controller/provision/gates_action.go
@@ -18,6 +18,11 @@ import (
 	odhtype "github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
 )
 
+// TODO(RHOAIENG-82327): during an OLM upgrade the new operator binary
+// inherits the old CSV's version. Hardcode the target gate version so
+// in-tree gates are evaluated correctly regardless of what OLM reports.
+const gateVersion = "3.5.1"
+
 // ExtractUpgradeGates scans rr.Resources for ConfigMaps carrying the
 // upgrade-gate label, collects their data entries into rr.GateEntries,
 // and removes the gate CMs from rr.Resources so they are not deployed
@@ -70,6 +75,15 @@ func ExtractUpgradeGates(ctx context.Context, rr *odhtype.ReconciliationRequest)
 	return nil
 }
 
+// ComponentUpgradeGateAction is an actions.Fn suitable for component
+// controller action chains. It blocks reconciliation when any upgrade
+// gate remains unacknowledged. Gate entries are loaded from the
+// embedded in-tree gates file, so they are available immediately
+// without waiting for the informer cache to sync cluster ConfigMaps.
+func ComponentUpgradeGateAction(ctx context.Context, rr *odhtype.ReconciliationRequest) error {
+	return CheckUpgradeGates(ctx, rr.Client, rr.Release, rr.Conditions, nil)
+}
+
 // CheckUpgradeGates evaluates admin-acknowledgment gates for the current
 // operator version. It collects gates from all sources (in-tree, labeled
 // cluster ConfigMaps, chart-extracted entries), writes their descriptions
@@ -94,7 +108,12 @@ func CheckUpgradeGatesInNamespace(
 	log := logf.FromContext(ctx)
 
 	gc := gates.NewGateChecker(cli, namespace)
-	version := release.Version.String()
+
+	// TODO(RHOAIENG-82327): OLM sets the release version from the
+	// installed CSV, so during an upgrade the new binary still reports
+	// the OLD version. Use the hardcoded gate version for the in-tree
+	// lookup and EnsureGates so the 3.5.1 gates are always evaluated.
+	version := gateVersion
 
 	allGates := make(map[string]string)
 

--- a/pkg/controller/provision/gates_action_test.go
+++ b/pkg/controller/provision/gates_action_test.go
@@ -1,7 +1,6 @@
 package provision_test
 
 import (
-	"context"
 	"testing"
 
 	"github.com/blang/semver/v4"
@@ -26,6 +25,8 @@ type condRecorder struct {
 	conditions []common.Condition
 }
 
+const testGateVersion = "3.5.1"
+
 func (c *condRecorder) SetCondition(cond common.Condition) {
 	c.conditions = append(c.conditions, cond)
 }
@@ -36,20 +37,47 @@ func newScheme() *runtime.Scheme {
 	return s
 }
 
-func release(ver string) common.Release {
-	sv, _ := semver.Parse(ver)
+func release() common.Release {
+	sv, _ := semver.Parse(testGateVersion)
 	return common.Release{
 		Version: ofaversion.OperatorVersion{Version: sv},
 	}
 }
 
+func ackedInTreeGates(t *testing.T) map[string]string {
+	t.Helper()
+
+	entries, err := gates.LoadInTreeGates(testGateVersion)
+	require.NoError(t, err)
+
+	result := make(map[string]string, len(entries))
+	for key := range entries {
+		result[key] = "true"
+	}
+
+	return result
+}
+
+func mergeGateData(base map[string]string, extra map[string]string) map[string]string {
+	result := make(map[string]string, len(base)+len(extra))
+	for key, value := range base {
+		result[key] = value
+	}
+	for key, value := range extra {
+		result[key] = value
+	}
+	return result
+}
+
 func TestCheckUpgradeGates_NoGates(t *testing.T) {
 	t.Parallel()
 
-	cli := fake.NewClientBuilder().WithScheme(newScheme()).Build()
+	cli := fake.NewClientBuilder().WithScheme(newScheme()).WithObjects(
+		acksCM(ackedInTreeGates(t)),
+	).Build()
 	conds := &condRecorder{}
 
-	err := provision.CheckUpgradeGatesInNamespace(context.Background(), cli, "test-ns", release("2.0.0"), conds, nil)
+	err := provision.CheckUpgradeGatesInNamespace(t.Context(), cli, "test-ns", release(), conds, nil)
 
 	require.NoError(t, err)
 	assert.Empty(t, conds.conditions)
@@ -60,9 +88,9 @@ func TestCheckUpgradeGates_AllGatesAcked(t *testing.T) {
 
 	acksCM := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{Name: gates.AcksConfigMap, Namespace: "test-ns"},
-		Data: map[string]string{
-			"ack-2.0.0-breaking-change": "true",
-		},
+		Data: mergeGateData(ackedInTreeGates(t), map[string]string{
+			"ack-3.5.1-breaking-change": "true",
+		}),
 	}
 
 	source := &corev1.ConfigMap{
@@ -72,14 +100,14 @@ func TestCheckUpgradeGates_AllGatesAcked(t *testing.T) {
 			Labels:    map[string]string{gates.UpgradeGateLabel: "true"},
 		},
 		Data: map[string]string{
-			"ack-2.0.0-breaking-change": "Review the migration guide before proceeding",
+			"ack-3.5.1-breaking-change": "Review the migration guide before proceeding",
 		},
 	}
 
 	cli := fake.NewClientBuilder().WithScheme(newScheme()).WithObjects(acksCM, source).Build()
 	conds := &condRecorder{}
 
-	err := provision.CheckUpgradeGatesInNamespace(context.Background(), cli, "test-ns", release("2.0.0"), conds, nil)
+	err := provision.CheckUpgradeGatesInNamespace(t.Context(), cli, "test-ns", release(), conds, nil)
 
 	require.NoError(t, err)
 	assert.Empty(t, conds.conditions)
@@ -95,34 +123,37 @@ func TestCheckUpgradeGates_UnackedGatesBlockProvisioning(t *testing.T) {
 			Labels:    map[string]string{gates.UpgradeGateLabel: "true"},
 		},
 		Data: map[string]string{
-			"ack-2.0.0-kserve-api-change": "KServe API changed; review migration guide",
-			"ack-2.0.0-model-registry":    "Model Registry schema updated",
+			"ack-3.5.1-kserve-api-change": "KServe API changed; review migration guide",
+			"ack-3.5.1-model-registry":    "Model Registry schema updated",
 		},
 	}
 
-	cli := fake.NewClientBuilder().WithScheme(newScheme()).WithObjects(source).Build()
+	cli := fake.NewClientBuilder().WithScheme(newScheme()).WithObjects(
+		acksCM(ackedInTreeGates(t)),
+		source,
+	).Build()
 	conds := &condRecorder{}
 
-	err := provision.CheckUpgradeGatesInNamespace(context.Background(), cli, "test-ns", release("2.0.0"), conds, nil)
+	err := provision.CheckUpgradeGatesInNamespace(t.Context(), cli, "test-ns", release(), conds, nil)
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "2 unacknowledged upgrade gate(s)")
-	assert.Contains(t, err.Error(), "2.0.0")
+	assert.Contains(t, err.Error(), testGateVersion)
 
 	require.Len(t, conds.conditions, 1)
 	cond := conds.conditions[0]
 	assert.Equal(t, status.ConditionTypeProvisioningProgress, cond.Type)
 	assert.Equal(t, metav1.ConditionFalse, cond.Status)
 	assert.Equal(t, status.AdminAckRequiredReason, cond.Reason)
-	assert.Contains(t, cond.Message, "ack-2.0.0-kserve-api-change")
-	assert.Contains(t, cond.Message, "ack-2.0.0-model-registry")
+	assert.Contains(t, cond.Message, "ack-3.5.1-kserve-api-change")
+	assert.Contains(t, cond.Message, "ack-3.5.1-model-registry")
 
 	acksCM := &corev1.ConfigMap{}
-	require.NoError(t, cli.Get(context.Background(), client.ObjectKey{
+	require.NoError(t, cli.Get(t.Context(), client.ObjectKey{
 		Name: gates.AcksConfigMap, Namespace: "test-ns",
 	}, acksCM))
-	assert.Equal(t, "KServe API changed; review migration guide", acksCM.Data["ack-2.0.0-kserve-api-change"])
-	assert.Equal(t, "Model Registry schema updated", acksCM.Data["ack-2.0.0-model-registry"])
+	assert.Equal(t, "KServe API changed; review migration guide", acksCM.Data["ack-3.5.1-kserve-api-change"])
+	assert.Equal(t, "Model Registry schema updated", acksCM.Data["ack-3.5.1-model-registry"])
 }
 
 func TestCheckUpgradeGates_IgnoresOtherVersions(t *testing.T) {
@@ -139,10 +170,13 @@ func TestCheckUpgradeGates_IgnoresOtherVersions(t *testing.T) {
 		},
 	}
 
-	cli := fake.NewClientBuilder().WithScheme(newScheme()).WithObjects(source).Build()
+	cli := fake.NewClientBuilder().WithScheme(newScheme()).WithObjects(
+		acksCM(ackedInTreeGates(t)),
+		source,
+	).Build()
 	conds := &condRecorder{}
 
-	err := provision.CheckUpgradeGatesInNamespace(context.Background(), cli, "test-ns", release("3.0.0"), conds, nil)
+	err := provision.CheckUpgradeGatesInNamespace(t.Context(), cli, "test-ns", release(), conds, nil)
 
 	require.NoError(t, err)
 	assert.Empty(t, conds.conditions)
@@ -158,23 +192,26 @@ func TestCheckUpgradeGates_WritesDescriptionsToAcks(t *testing.T) {
 			Labels:    map[string]string{gates.UpgradeGateLabel: "true"},
 		},
 		Data: map[string]string{
-			"ack-2.0.0-discovered-gate": "Discovered gate message",
+			"ack-3.5.1-discovered-gate": "Discovered gate message",
 		},
 	}
 
-	cli := fake.NewClientBuilder().WithScheme(newScheme()).WithObjects(source).Build()
+	cli := fake.NewClientBuilder().WithScheme(newScheme()).WithObjects(
+		acksCM(ackedInTreeGates(t)),
+		source,
+	).Build()
 	conds := &condRecorder{}
 
-	err := provision.CheckUpgradeGatesInNamespace(context.Background(), cli, "test-ns", release("2.0.0"), conds, nil)
+	err := provision.CheckUpgradeGatesInNamespace(t.Context(), cli, "test-ns", release(), conds, nil)
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "1 unacknowledged upgrade gate(s)")
 
 	acksCM := &corev1.ConfigMap{}
-	require.NoError(t, cli.Get(context.Background(), client.ObjectKey{
+	require.NoError(t, cli.Get(t.Context(), client.ObjectKey{
 		Name: gates.AcksConfigMap, Namespace: "test-ns",
 	}, acksCM))
-	assert.Equal(t, "Discovered gate message", acksCM.Data["ack-2.0.0-discovered-gate"])
+	assert.Equal(t, "Discovered gate message", acksCM.Data["ack-3.5.1-discovered-gate"])
 }
 
 func TestCheckUpgradeGates_MergesChartGates(t *testing.T) {
@@ -187,28 +224,31 @@ func TestCheckUpgradeGates_MergesChartGates(t *testing.T) {
 			Labels:    map[string]string{gates.UpgradeGateLabel: "true"},
 		},
 		Data: map[string]string{
-			"ack-2.0.0-cluster-gate": "From cluster",
+			"ack-3.5.1-cluster-gate": "From cluster",
 		},
 	}
 
 	chartGates := map[string]string{
-		"ack-2.0.0-chart-gate": "From chart",
+		"ack-3.5.1-chart-gate": "From chart",
 	}
 
-	cli := fake.NewClientBuilder().WithScheme(newScheme()).WithObjects(clusterGateCM).Build()
+	cli := fake.NewClientBuilder().WithScheme(newScheme()).WithObjects(
+		acksCM(ackedInTreeGates(t)),
+		clusterGateCM,
+	).Build()
 	conds := &condRecorder{}
 
-	err := provision.CheckUpgradeGatesInNamespace(context.Background(), cli, "test-ns", release("2.0.0"), conds, chartGates)
+	err := provision.CheckUpgradeGatesInNamespace(t.Context(), cli, "test-ns", release(), conds, chartGates)
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "2 unacknowledged upgrade gate(s)")
 
 	acksCM := &corev1.ConfigMap{}
-	require.NoError(t, cli.Get(context.Background(), client.ObjectKey{
+	require.NoError(t, cli.Get(t.Context(), client.ObjectKey{
 		Name: gates.AcksConfigMap, Namespace: "test-ns",
 	}, acksCM))
-	assert.Equal(t, "From cluster", acksCM.Data["ack-2.0.0-cluster-gate"])
-	assert.Equal(t, "From chart", acksCM.Data["ack-2.0.0-chart-gate"])
+	assert.Equal(t, "From cluster", acksCM.Data["ack-3.5.1-cluster-gate"])
+	assert.Equal(t, "From chart", acksCM.Data["ack-3.5.1-chart-gate"])
 }
 
 func TestExtractUpgradeGates_StashesOnGateEntries(t *testing.T) {
@@ -260,7 +300,7 @@ func TestExtractUpgradeGates_StashesOnGateEntries(t *testing.T) {
 		Resources: []unstructured.Unstructured{gateCM, regularCM, deployment},
 	}
 
-	err := provision.ExtractUpgradeGates(context.Background(), rr)
+	err := provision.ExtractUpgradeGates(t.Context(), rr)
 	require.NoError(t, err)
 
 	assert.Len(t, rr.Resources, 2, "gate CM should be removed, 2 resources remain")
@@ -289,7 +329,7 @@ func TestExtractUpgradeGates_NoGateCMs(t *testing.T) {
 		Resources: []unstructured.Unstructured{regular},
 	}
 
-	err := provision.ExtractUpgradeGates(context.Background(), rr)
+	err := provision.ExtractUpgradeGates(t.Context(), rr)
 	require.NoError(t, err)
 
 	assert.Len(t, rr.Resources, 1, "no resources should be removed")

--- a/pkg/controller/provision/upgrade_checks.go
+++ b/pkg/controller/provision/upgrade_checks.go
@@ -1,0 +1,76 @@
+package provision
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+
+	appsv1 "k8s.io/api/apps/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// UpgradeCheckFunc validates whether a component is ready to be auto-acknowledged
+// during an upgrade. Returns nil when the component is healthy.
+type UpgradeCheckFunc func(ctx context.Context, cli client.Client, component, namespace string) error
+
+var (
+	upgradeChecksMu sync.RWMutex
+
+	// TODO(RHOAIENG-82327): replace with real migration checks.
+	upgradeChecks = map[string]UpgradeCheckFunc{
+		"kserve": func(_ context.Context, _ client.Client, _, _ string) error {
+			return errors.New("kserve upgrade check not yet implemented")
+		},
+	}
+)
+
+// RegisterUpgradeCheck registers a component-specific upgrade check.
+// If a component has no custom check registered, DefaultUpgradeCheck is used.
+func RegisterUpgradeCheck(component string, fn UpgradeCheckFunc) {
+	upgradeChecksMu.Lock()
+	defer upgradeChecksMu.Unlock()
+	upgradeChecks[component] = fn
+}
+
+// GetUpgradeCheck returns the upgrade check for a component, falling
+// back to DefaultUpgradeCheck when no component-specific check exists.
+func GetUpgradeCheck(component string) UpgradeCheckFunc {
+	upgradeChecksMu.RLock()
+	defer upgradeChecksMu.RUnlock()
+	if fn, ok := upgradeChecks[component]; ok {
+		return fn
+	}
+	return DefaultUpgradeCheck
+}
+
+// DefaultUpgradeCheck verifies that all Deployments carrying the standard
+// component label (app.opendatahub.io/<component>: "true") have their
+// desired replicas ready. Components with no matching Deployments are
+// considered healthy (not yet deployed).
+func DefaultUpgradeCheck(ctx context.Context, cli client.Client, component, namespace string) error {
+	label := client.MatchingLabels{"app.opendatahub.io/" + component: "true"}
+
+	var deps appsv1.DeploymentList
+	if err := cli.List(ctx, &deps, client.InNamespace(namespace), label); err != nil {
+		return fmt.Errorf("listing deployments for %s: %w", component, err)
+	}
+
+	if len(deps.Items) == 0 {
+		return nil
+	}
+
+	for i := range deps.Items {
+		d := &deps.Items[i]
+		desired := int32(1)
+		if d.Spec.Replicas != nil {
+			desired = *d.Spec.Replicas
+		}
+		if d.Status.ReadyReplicas < desired {
+			return fmt.Errorf("deployment %s/%s not ready: %d/%d replicas",
+				d.Namespace, d.Name, d.Status.ReadyReplicas, desired)
+		}
+	}
+
+	return nil
+}

--- a/pkg/controller/provision/upgrade_checks_test.go
+++ b/pkg/controller/provision/upgrade_checks_test.go
@@ -1,0 +1,134 @@
+package provision_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/provision"
+)
+
+func checkScheme() *runtime.Scheme {
+	s := runtime.NewScheme()
+	_ = corev1.AddToScheme(s)
+	_ = appsv1.AddToScheme(s)
+	return s
+}
+
+func TestDefaultUpgradeCheck_AllReady(t *testing.T) {
+	t.Parallel()
+
+	replicas := int32(2)
+	dep := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "dashboard",
+			Namespace: "apps-ns",
+			Labels:    map[string]string{"app.opendatahub.io/dashboard": "true"},
+		},
+		Spec:   appsv1.DeploymentSpec{Replicas: &replicas},
+		Status: appsv1.DeploymentStatus{ReadyReplicas: 2},
+	}
+
+	cli := fake.NewClientBuilder().WithScheme(checkScheme()).WithObjects(dep).Build()
+
+	err := provision.DefaultUpgradeCheck(context.Background(), cli, "dashboard", "apps-ns")
+	require.NoError(t, err)
+}
+
+func TestDefaultUpgradeCheck_NotReady(t *testing.T) {
+	t.Parallel()
+
+	replicas := int32(3)
+	dep := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kserve-controller",
+			Namespace: "apps-ns",
+			Labels:    map[string]string{"app.opendatahub.io/kserve": "true"},
+		},
+		Spec:   appsv1.DeploymentSpec{Replicas: &replicas},
+		Status: appsv1.DeploymentStatus{ReadyReplicas: 1},
+	}
+
+	cli := fake.NewClientBuilder().WithScheme(checkScheme()).WithObjects(dep).Build()
+
+	err := provision.DefaultUpgradeCheck(context.Background(), cli, "kserve", "apps-ns")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not ready")
+	assert.Contains(t, err.Error(), "1/3")
+}
+
+func TestDefaultUpgradeCheck_NoDeployments(t *testing.T) {
+	t.Parallel()
+
+	cli := fake.NewClientBuilder().WithScheme(checkScheme()).Build()
+
+	err := provision.DefaultUpgradeCheck(context.Background(), cli, "trustyai", "apps-ns")
+	require.NoError(t, err)
+}
+
+func TestDefaultUpgradeCheck_MultipleDeployments(t *testing.T) {
+	t.Parallel()
+
+	replicas := int32(1)
+	dep1 := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kserve-controller",
+			Namespace: "apps-ns",
+			Labels:    map[string]string{"app.opendatahub.io/kserve": "true"},
+		},
+		Spec:   appsv1.DeploymentSpec{Replicas: &replicas},
+		Status: appsv1.DeploymentStatus{ReadyReplicas: 1},
+	}
+	dep2 := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kserve-webhook",
+			Namespace: "apps-ns",
+			Labels:    map[string]string{"app.opendatahub.io/kserve": "true"},
+		},
+		Spec:   appsv1.DeploymentSpec{Replicas: &replicas},
+		Status: appsv1.DeploymentStatus{ReadyReplicas: 0},
+	}
+
+	cli := fake.NewClientBuilder().WithScheme(checkScheme()).
+		WithObjects(dep1, dep2).Build()
+
+	err := provision.DefaultUpgradeCheck(context.Background(), cli, "kserve", "apps-ns")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "kserve-webhook")
+}
+
+func TestGetUpgradeCheck_DefaultFallback(t *testing.T) {
+	t.Parallel()
+
+	fn := provision.GetUpgradeCheck("nonexistent-component")
+	assert.NotNil(t, fn)
+
+	cli := fake.NewClientBuilder().WithScheme(checkScheme()).Build()
+	err := fn(context.Background(), cli, "nonexistent-component", "apps-ns")
+	require.NoError(t, err)
+}
+
+func TestRegisterUpgradeCheck_CustomOverridesDefault(t *testing.T) {
+	t.Parallel()
+
+	called := false
+	provision.RegisterUpgradeCheck("test-custom-component", func(ctx context.Context, cli client.Client, component, namespace string) error {
+		called = true
+		return nil
+	})
+
+	fn := provision.GetUpgradeCheck("test-custom-component")
+	cli := fake.NewClientBuilder().WithScheme(checkScheme()).Build()
+	err := fn(context.Background(), cli, "test-custom-component", "apps-ns")
+
+	require.NoError(t, err)
+	assert.True(t, called, "custom check should have been called")
+}

--- a/pkg/controller/reconciler/reconciler.go
+++ b/pkg/controller/reconciler/reconciler.go
@@ -62,11 +62,19 @@ func getChartsBasePath(mgr manager.Manager) string {
 
 type ReconcilerOpt func(*Reconciler)
 
+type PostStatusFn func(context.Context, *types.ReconciliationRequest, bool) error
+
 func WithConditionsManagerFactory(happy string, dependents ...string) ReconcilerOpt {
 	return func(reconciler *Reconciler) {
 		reconciler.conditionsManagerFactory = func(accessor common.ConditionsAccessor) *conditions.Manager {
 			return conditions.NewManager(accessor, happy, dependents...)
 		}
+	}
+}
+
+func withPostStatusFn(fn PostStatusFn) ReconcilerOpt {
+	return func(reconciler *Reconciler) {
+		reconciler.postStatusFns = append(reconciler.postStatusFns, fn)
 	}
 }
 
@@ -127,6 +135,7 @@ type Reconciler struct {
 	excludeFromDynamicOwnership map[schema.GroupVersionKind]struct{}
 	skipConditionCleanup        bool
 	skipStatusConditionsFn      func() bool
+	postStatusFns               []PostStatusFn
 }
 
 // NewReconciler creates a new reconciler for the given type.
@@ -461,6 +470,12 @@ func (r *Reconciler) apply(ctx context.Context, res common.PlatformObject) (time
 	if rr.Conditions.IsHappy() {
 		is.Phase = status.PhaseReady
 		is.ObservedGeneration = rr.Instance.GetGeneration()
+	}
+
+	for i := range r.postStatusFns {
+		if err := r.postStatusFns[i](ctx, &rr, rr.Conditions.IsHappy()); err != nil {
+			return 0, fmt.Errorf("failed to run post-status hook: %w", err)
+		}
 	}
 
 	if r.skipStatusConditionsFn != nil && r.skipStatusConditionsFn() {

--- a/pkg/controller/reconciler/reconciler_support.go
+++ b/pkg/controller/reconciler/reconciler_support.go
@@ -125,6 +125,7 @@ type ReconcilerBuilder[T common.PlatformObject] struct {
 	dynamicOwnershipGVKPreds map[schema.GroupVersionKind][]predicate.Predicate
 	skipConditionCleanup     bool
 	skipStatusConditionsFn   func() bool
+	postStatusFns            []PostStatusFn
 }
 
 func ReconcilerFor[T common.PlatformObject](mgr ctrl.Manager, object T, opts ...builder.ForOption) *ReconcilerBuilder[T] {
@@ -194,6 +195,11 @@ func (b *ReconcilerBuilder[T]) WithoutStatusConditionsIf(pred func() bool) *Reco
 
 func (b *ReconcilerBuilder[T]) WithAction(value actions.Fn) *ReconcilerBuilder[T] {
 	b.actions = append(b.actions, value)
+	return b
+}
+
+func (b *ReconcilerBuilder[T]) WithPostStatusFn(fn PostStatusFn) *ReconcilerBuilder[T] {
+	b.postStatusFns = append(b.postStatusFns, fn)
 	return b
 }
 
@@ -437,6 +443,9 @@ func (b *ReconcilerBuilder[T]) Build(_ context.Context) (*Reconciler, error) {
 	}
 	if b.skipStatusConditionsFn != nil {
 		opts = append(opts, withSkipStatusConditions(b.skipStatusConditionsFn))
+	}
+	for i := range b.postStatusFns {
+		opts = append(opts, withPostStatusFn(b.postStatusFns[i]))
 	}
 
 	r, err := NewReconciler(b.mgr, name, obj, opts...)

--- a/pkg/upgrade/upgrade.go
+++ b/pkg/upgrade/upgrade.go
@@ -29,6 +29,7 @@ import (
 	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/services/gateway"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/gates"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/metadata/labels"
 )
 
@@ -64,6 +65,28 @@ const (
 	kserveDeploymentModeAnnotationKey = "serving.kserve.io/deploymentMode"
 	kserveDeploymentModeServerless    = "Serverless"
 )
+
+// ManagedComponents lists all component and module names that receive an
+// upgrade gate key when migrating from major version 2.x. Keep in sync
+// with the registrations in cmd/main.go.
+var ManagedComponents = []string{
+	"aigateway",
+	"dashboard",
+	"datasciencepipelines",
+	"feastoperator",
+	"kserve",
+	"kueue",
+	"mcplifecycleoperator",
+	"mlflowoperator",
+	"modelregistry",
+	"ogx",
+	"ray",
+	"sparkoperator",
+	"trainer",
+	"trainingoperator",
+	"trustyai",
+	"workbenches",
+}
 
 var defaultResourceLimits = map[string]string{
 	"maxMemory": "120Gi",
@@ -124,6 +147,13 @@ func CleanupExistingResource(ctx context.Context,
 		multiErr = multierror.Append(multiErr, fmt.Errorf("failed to check GatewayConfig CRD: %w", err))
 	} else if hasGatewayConfig {
 		multiErr = multierror.Append(multiErr, MigrateGatewayConfigIngressMode(ctx, cli))
+	}
+
+	// Create upgrade gate ConfigMap for 2.x → 3.x major-version upgrades (RHOAIENG-82328).
+	// Requires operator namespace to be initialized; skip gracefully when it is not
+	// (e.g. unit tests that do not call cluster.Init).
+	if operatorNS, nsErr := cluster.GetOperatorNamespace(); nsErr == nil {
+		multiErr = multierror.Append(multiErr, CreateUpgradeGateConfigMap(ctx, cli, operatorNS, "3.5.1", ManagedComponents))
 	}
 
 	return multiErr.ErrorOrNil()
@@ -783,6 +813,47 @@ func MigrateGatewayConfigIngressMode(ctx context.Context, cli client.Client) err
 	}
 
 	l.Info("GatewayConfig migrated to ingressMode=LoadBalancer")
+
+	return nil
+}
+
+func CreateUpgradeGateConfigMap(ctx context.Context, cli client.Client, namespace, operatorVersion string, components []string) error {
+	log := logf.FromContext(ctx)
+
+	deployedVersion, err := cluster.GetDeployedRelease(ctx, cli)
+	if err != nil {
+		return fmt.Errorf("failed to get deployed release version: %w", err)
+	}
+
+	if deployedVersion.Version.Major != 2 {
+		return nil
+	}
+
+	data := make(map[string]string, len(components))
+	for _, comp := range components {
+		key := fmt.Sprintf("ack-%s-%s", operatorVersion, comp)
+		data[key] = fmt.Sprintf("Acknowledge upgrade of %s from version 2.x to %s", comp, operatorVersion)
+	}
+
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      gates.GateConfigMap,
+			Namespace: namespace,
+			Labels: map[string]string{
+				gates.UpgradeGateLabel: "true",
+			},
+		},
+		Data: data,
+	}
+
+	if err := cli.Create(ctx, cm); err != nil {
+		if k8serr.IsAlreadyExists(err) {
+			return nil
+		}
+		return fmt.Errorf("failed to create upgrade gate ConfigMap: %w", err)
+	}
+
+	log.Info("Created upgrade gate ConfigMap", "name", cm.Name, "namespace", namespace, "gates", len(data))
 
 	return nil
 }

--- a/pkg/upgrade/upgrade_gates_test.go
+++ b/pkg/upgrade/upgrade_gates_test.go
@@ -1,0 +1,163 @@
+package upgrade_test
+
+import (
+	"testing"
+
+	"github.com/blang/semver/v4"
+	"github.com/operator-framework/api/pkg/lib/version"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/opendatahub-io/opendatahub-operator/v2/api/common"
+	dsciv2 "github.com/opendatahub-io/opendatahub-operator/v2/api/dscinitialization/v2"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/gates"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/upgrade"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/fakeclient"
+
+	. "github.com/onsi/gomega"
+)
+
+const (
+	testOperatorNS      = "test-operator-ns"
+	testOperatorVersion = "3.0.0"
+)
+
+var testComponents = []string{"dashboard", "kserve", "ray"}
+
+func dsciWithVersion(major, minor uint64) *dsciv2.DSCInitialization {
+	return &dsciv2.DSCInitialization{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "default-dsci",
+		},
+		Status: dsciv2.DSCInitializationStatus{
+			Release: common.Release{
+				Version: version.OperatorVersion{
+					Version: semver.Version{Major: major, Minor: minor},
+				},
+			},
+		},
+	}
+}
+
+func TestCreateUpgradeGateConfigMap_UpgradeFrom2x(t *testing.T) {
+	ctx := t.Context()
+	g := NewWithT(t)
+
+	dsci := dsciWithVersion(2, 16)
+	cli, err := fakeclient.New(fakeclient.WithObjects(dsci))
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	err = upgrade.CreateUpgradeGateConfigMap(ctx, cli, testOperatorNS, testOperatorVersion, testComponents)
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	cm := &corev1.ConfigMap{}
+	err = cli.Get(ctx, client.ObjectKey{Name: gates.GateConfigMap, Namespace: testOperatorNS}, cm)
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	g.Expect(cm.Labels).To(HaveKeyWithValue(gates.UpgradeGateLabel, "true"))
+	g.Expect(cm.Data).To(HaveLen(len(testComponents)))
+
+	for _, comp := range testComponents {
+		key := "ack-" + testOperatorVersion + "-" + comp
+		g.Expect(cm.Data).To(HaveKey(key))
+		g.Expect(cm.Data[key]).To(ContainSubstring(comp))
+	}
+}
+
+func TestCreateUpgradeGateConfigMap_FreshInstall(t *testing.T) {
+	ctx := t.Context()
+	g := NewWithT(t)
+
+	// No DSCI → GetDeployedRelease returns empty Release (Major == 0)
+	cli, err := fakeclient.New()
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	err = upgrade.CreateUpgradeGateConfigMap(ctx, cli, testOperatorNS, testOperatorVersion, testComponents)
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	cm := &corev1.ConfigMap{}
+	err = cli.Get(ctx, client.ObjectKey{Name: gates.GateConfigMap, Namespace: testOperatorNS}, cm)
+	g.Expect(err).Should(HaveOccurred(), "no ConfigMap should be created on fresh install")
+}
+
+func TestCreateUpgradeGateConfigMap_SameMajor(t *testing.T) {
+	ctx := t.Context()
+	g := NewWithT(t)
+
+	dsci := dsciWithVersion(3, 0)
+	cli, err := fakeclient.New(fakeclient.WithObjects(dsci))
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	err = upgrade.CreateUpgradeGateConfigMap(ctx, cli, testOperatorNS, "3.1.0", testComponents)
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	cm := &corev1.ConfigMap{}
+	err = cli.Get(ctx, client.ObjectKey{Name: gates.GateConfigMap, Namespace: testOperatorNS}, cm)
+	g.Expect(err).Should(HaveOccurred(), "no ConfigMap should be created for same-major upgrade")
+}
+
+func TestCreateUpgradeGateConfigMap_Idempotent(t *testing.T) {
+	ctx := t.Context()
+	g := NewWithT(t)
+
+	dsci := dsciWithVersion(2, 16)
+	cli, err := fakeclient.New(fakeclient.WithObjects(dsci))
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	err = upgrade.CreateUpgradeGateConfigMap(ctx, cli, testOperatorNS, testOperatorVersion, testComponents)
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	// Second call must not error (AlreadyExists is silenced)
+	err = upgrade.CreateUpgradeGateConfigMap(ctx, cli, testOperatorNS, testOperatorVersion, testComponents)
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	cmList := &corev1.ConfigMapList{}
+	err = cli.List(ctx, cmList, client.InNamespace(testOperatorNS), client.MatchingLabels{gates.UpgradeGateLabel: "true"})
+	g.Expect(err).ShouldNot(HaveOccurred())
+	g.Expect(cmList.Items).To(HaveLen(1), "only one gate ConfigMap should exist")
+}
+
+func TestCreateUpgradeGateConfigMap_DiscoverableByGateChecker(t *testing.T) {
+	ctx := t.Context()
+	g := NewWithT(t)
+
+	dsci := dsciWithVersion(2, 20)
+	cli, err := fakeclient.New(fakeclient.WithObjects(dsci))
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	err = upgrade.CreateUpgradeGateConfigMap(ctx, cli, testOperatorNS, testOperatorVersion, testComponents)
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	gc := gates.NewGateChecker(cli, testOperatorNS)
+	discovered, err := gc.DiscoverGates(ctx)
+	g.Expect(err).ShouldNot(HaveOccurred())
+	g.Expect(discovered).To(HaveLen(len(testComponents)))
+
+	for _, comp := range testComponents {
+		key := "ack-" + testOperatorVersion + "-" + comp
+		g.Expect(discovered).To(HaveKey(key))
+	}
+}
+
+func TestCreateUpgradeGateConfigMap_AllManagedComponents(t *testing.T) {
+	ctx := t.Context()
+	g := NewWithT(t)
+
+	dsci := dsciWithVersion(2, 16)
+	cli, err := fakeclient.New(fakeclient.WithObjects(dsci))
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	err = upgrade.CreateUpgradeGateConfigMap(ctx, cli, testOperatorNS, testOperatorVersion, upgrade.ManagedComponents)
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	cm := &corev1.ConfigMap{}
+	err = cli.Get(ctx, client.ObjectKey{Name: gates.GateConfigMap, Namespace: testOperatorNS}, cm)
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	g.Expect(cm.Data).To(HaveLen(len(upgrade.ManagedComponents)))
+	for _, comp := range upgrade.ManagedComponents {
+		key := "ack-" + testOperatorVersion + "-" + comp
+		g.Expect(cm.Data).To(HaveKey(key))
+	}
+}

--- a/tests/e2e/components_test.go
+++ b/tests/e2e/components_test.go
@@ -331,6 +331,22 @@ func (tc *ComponentTestCtx) ValidateComponentReleases(t *testing.T) {
 	)
 }
 
+// ValidatePlatformRelease ensures that the component CR status.releases
+// contains a "platform" entry with a non-empty version.
+func (tc *ComponentTestCtx) ValidatePlatformRelease(t *testing.T) {
+	t.Helper()
+
+	skipUnless(t, Smoke)
+
+	tc.EnsureResourceExists(
+		WithMinimalObject(tc.GVK, tc.NamespacedName),
+		WithCondition(
+			jq.Match(`.status.releases[] | select(.name == "%s") | .version != ""`, common.PlatformReleaseName),
+		),
+		WithCustomErrorMsg("Component CR should have a platform release entry with non-empty version"),
+	)
+}
+
 // EnsureParentComponentEnabled ensures that the parent component is enabled and ready before enabling a subcomponent.
 func (tc *ComponentTestCtx) EnsureParentComponentEnabled(t *testing.T) {
 	t.Helper()

--- a/tests/e2e/datasciencepipelines_test.go
+++ b/tests/e2e/datasciencepipelines_test.go
@@ -5,6 +5,7 @@ import (
 
 	operatorv1 "github.com/openshift/api/operator/v1"
 	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/api/components/v1alpha1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/status"
@@ -22,7 +23,11 @@ type DataSciencePipelinesTestCtx struct {
 func dataSciencePipelinesTestSuite(t *testing.T) {
 	t.Helper()
 
-	ct, err := NewComponentTestCtx(t, &componentApi.DataSciencePipelines{})
+	ct, err := NewComponentTestCtx(t, &componentApi.DataSciencePipelines{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: componentApi.DataSciencePipelinesInstanceName,
+		},
+	})
 	require.NoError(t, err)
 
 	componentCtx := DataSciencePipelinesTestCtx{
@@ -36,6 +41,7 @@ func dataSciencePipelinesTestSuite(t *testing.T) {
 		{"Validate operands have OwnerReferences", componentCtx.ValidateOperandsOwnerReferences},
 		{"Validate update operand resources", componentCtx.ValidateUpdateDeploymentsResources},
 		{"Validate component releases", componentCtx.ValidateComponentReleases},
+		{"Validate platform release", componentCtx.ValidatePlatformRelease},
 		{"Validate argoWorkflowsControllers options", componentCtx.ValidateArgoWorkflowsControllersOptions},
 		{"Validate resource deletion recovery", componentCtx.ValidateAllDeletionRecovery},
 		{"Validate component disabled", componentCtx.ValidateComponentDisabled},

--- a/tests/e2e/kueue_test.go
+++ b/tests/e2e/kueue_test.go
@@ -97,7 +97,11 @@ func (tc *KueueTestCtx) ensureKueueOperatorsInstalled(t *testing.T) {
 func kueueTestSuite(t *testing.T) {
 	t.Helper()
 
-	ct, err := NewComponentTestCtx(t, &componentApi.Kueue{})
+	ct, err := NewComponentTestCtx(t, &componentApi.Kueue{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: componentApi.KueueInstanceName,
+		},
+	})
 	require.NoError(t, err)
 
 	componentCtx := KueueTestCtx{
@@ -105,10 +109,11 @@ func kueueTestSuite(t *testing.T) {
 	}
 
 	// Define core test cases
-	testCases := make([]TestCase, 0, 6)
+	testCases := make([]TestCase, 0, 7)
 	testCases = append(testCases,
 		TestCase{"Validate component unmanaged error with ocp kueue-operator not installed", componentCtx.ValidateKueueUnmanagedWithoutOcpKueueOperator},
 		TestCase{"Validate component removed to unmanaged transition", componentCtx.ValidateKueueRemovedToUnmanagedTransition},
+		TestCase{"Validate platform release", componentCtx.ValidatePlatformRelease},
 		TestCase{"Validate component unmanaged to removed transition", componentCtx.ValidateKueueUnmanagedToRemovedTransition},
 		TestCase{"Validate autoCreateQueues disabled skips queue creation", componentCtx.ValidateKueueAutoCreateQueuesDisabled},
 	)
@@ -127,7 +132,11 @@ func kueueDegradedMonitoringTestSuite(t *testing.T) {
 	t.Helper()
 	t.Skip("Skipping: flaky due to namespace stuck in Terminating state. See RHOAIENG-46773 and RHOAIENG-46774.")
 
-	ct, err := NewComponentTestCtx(t, &componentApi.Kueue{})
+	ct, err := NewComponentTestCtx(t, &componentApi.Kueue{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: componentApi.KueueInstanceName,
+		},
+	})
 	require.NoError(t, err)
 
 	componentCtx := KueueTestCtx{

--- a/tests/e2e/modelregistry_test.go
+++ b/tests/e2e/modelregistry_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/api/components/v1alpha1"
@@ -18,7 +19,11 @@ type ModelRegistryTestCtx struct {
 func modelRegistryTestSuite(t *testing.T) {
 	t.Helper()
 
-	ct, err := NewComponentTestCtx(t, &componentApi.ModelRegistry{})
+	ct, err := NewComponentTestCtx(t, &componentApi.ModelRegistry{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: componentApi.ModelRegistryInstanceName,
+		},
+	})
 	require.NoError(t, err)
 
 	componentCtx := ModelRegistryTestCtx{
@@ -33,6 +38,7 @@ func modelRegistryTestSuite(t *testing.T) {
 		{"Validate update operand resources", componentCtx.ValidateUpdateDeploymentsResources},
 		{"Validate CRDs reinstated", componentCtx.ValidateCRDReinstated},
 		{"Validate component releases", componentCtx.ValidateComponentReleases},
+		{"Validate platform release", componentCtx.ValidatePlatformRelease},
 		{"Validate resource deletion recovery", componentCtx.ValidateAllDeletionRecovery},
 		{"Validate component disabled", componentCtx.ValidateComponentDisabled},
 	}

--- a/tests/e2e/ray_test.go
+++ b/tests/e2e/ray_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/api/components/v1alpha1"
 )
@@ -15,7 +16,11 @@ type RayTestCtx struct {
 func rayTestSuite(t *testing.T) {
 	t.Helper()
 
-	ct, err := NewComponentTestCtx(t, &componentApi.Ray{})
+	ct, err := NewComponentTestCtx(t, &componentApi.Ray{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: componentApi.RayInstanceName,
+		},
+	})
 	require.NoError(t, err)
 
 	componentCtx := RayTestCtx{
@@ -28,6 +33,7 @@ func rayTestSuite(t *testing.T) {
 		{"Validate operands have OwnerReferences", componentCtx.ValidateOperandsOwnerReferences},
 		{"Validate update operand resources", componentCtx.ValidateUpdateDeploymentsResources},
 		{"Validate component releases", componentCtx.ValidateComponentReleases},
+		{"Validate platform release", componentCtx.ValidatePlatformRelease},
 		{"Validate resource deletion recovery", componentCtx.ValidateAllDeletionRecovery},
 		{"Validate component disabled", componentCtx.ValidateComponentDisabled},
 	}

--- a/tests/e2e/sparkoperator_test.go
+++ b/tests/e2e/sparkoperator_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/rs/xid"
 	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -27,7 +28,11 @@ type SparkOperatorTestCtx struct {
 func sparkOperatorTestSuite(t *testing.T) {
 	t.Helper()
 
-	ct, err := NewComponentTestCtx(t, &componentApi.SparkOperator{})
+	ct, err := NewComponentTestCtx(t, &componentApi.SparkOperator{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: componentApi.SparkOperatorInstanceName,
+		},
+	})
 	require.NoError(t, err)
 
 	componentCtx := SparkOperatorTestCtx{
@@ -40,6 +45,7 @@ func sparkOperatorTestSuite(t *testing.T) {
 		{"Validate operands have OwnerReferences", componentCtx.ValidateOperandsOwnerReferences},
 		{"Validate update operand resources", componentCtx.ValidateUpdateDeploymentsResources},
 		{"Validate component releases", componentCtx.ValidateComponentReleases},
+		{"Validate platform release", componentCtx.ValidatePlatformRelease},
 		{"Validate SparkPi workload execution", componentCtx.ValidateSparkPiWorkload},
 		{"Validate ScheduledSparkApplication workload execution", componentCtx.ValidateScheduledSparkPiWorkload},
 		{"Validate resource deletion recovery", componentCtx.ValidateAllDeletionRecovery},

--- a/tests/e2e/trainer_test.go
+++ b/tests/e2e/trainer_test.go
@@ -48,7 +48,11 @@ func trainerTestSuite(t *testing.T) {
 func trainerDegradedMonitoringTestSuite(t *testing.T) {
 	t.Helper()
 
-	ct, err := NewComponentTestCtx(t, &componentApi.Trainer{})
+	ct, err := NewComponentTestCtx(t, &componentApi.Trainer{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: componentApi.TrainerInstanceName,
+		},
+	})
 	require.NoError(t, err)
 
 	componentCtx := TrainerTestCtx{

--- a/tests/e2e/trainingoperator_test.go
+++ b/tests/e2e/trainingoperator_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/api/components/v1alpha1"
 )
@@ -15,7 +16,11 @@ type TrainingOperatorTestCtx struct {
 func trainingOperatorTestSuite(t *testing.T) {
 	t.Helper()
 
-	ct, err := NewComponentTestCtx(t, &componentApi.TrainingOperator{})
+	ct, err := NewComponentTestCtx(t, &componentApi.TrainingOperator{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: componentApi.TrainingOperatorInstanceName,
+		},
+	})
 	require.NoError(t, err)
 
 	componentCtx := TrainingOperatorTestCtx{
@@ -28,6 +33,7 @@ func trainingOperatorTestSuite(t *testing.T) {
 		{"Validate operands have OwnerReferences", componentCtx.ValidateOperandsOwnerReferences},
 		{"Validate update operand resources", componentCtx.ValidateUpdateDeploymentsResources},
 		{"Validate component releases", componentCtx.ValidateComponentReleases},
+		{"Validate platform release", componentCtx.ValidatePlatformRelease},
 		{"Validate resource deletion recovery", componentCtx.ValidateAllDeletionRecovery},
 		{"Validate component disabled", componentCtx.ValidateComponentDisabled},
 	}

--- a/tests/e2e/trustyai_test.go
+++ b/tests/e2e/trustyai_test.go
@@ -28,7 +28,11 @@ type TrustyAITestCtx struct {
 func trustyAITestSuite(t *testing.T) {
 	t.Helper()
 
-	ct, err := NewComponentTestCtx(t, &componentApi.TrustyAI{})
+	ct, err := NewComponentTestCtx(t, &componentApi.TrustyAI{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: componentApi.TrustyAIInstanceName,
+		},
+	})
 	require.NoError(t, err)
 
 	componentCtx := TrustyAITestCtx{
@@ -41,6 +45,7 @@ func trustyAITestSuite(t *testing.T) {
 		{"Validate operands have OwnerReferences", componentCtx.ValidateOperandsOwnerReferences},
 		{"Validate update operand resources", componentCtx.ValidateUpdateDeploymentsResources},
 		{"Validate component releases", componentCtx.ValidateComponentReleases},
+		{"Validate platform release", componentCtx.ValidatePlatformRelease},
 		{"Validate MCP guardrails mode", componentCtx.ValidateMCPGuardrailsMode},
 		{"Validate pre check", componentCtx.ValidateTrustyAIPreCheck},
 		{"Validate resource deletion recovery", componentCtx.ValidateAllDeletionRecovery},


### PR DESCRIPTION
- **fix(make): pass DEFAULT_CHARTS_PATH to local run target (#3971)**
- **refactor(reconciler): add local post-status hook shim**
- **feat(status): stamp platform release version on in-tree components (RHOAIENG-76106) (#3966)**

<!---
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

<!-- For RHOAI PRs, request review on #ai-core-platform-requests Slack channel -->

## Release tracking
<!-- Optional. Set a target release only if this PR must ship in a specific release; it will be prioritized accordingly. -->
<!-- Target release for this PR, e.g. rhoai-3.6 or rhoai-3.7ea1 -->
Release: 
<!-- Required only if a Release is set above. Full link to a jira ticket, e.g. https://redhat.atlassian.net/browse/RHOAIENG-XXXXX -->
Jira:


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully
- [ ] New RELATED_IMAGE mappings are listed in ODH-Build-Config and RHOAI-Build-Config (CI validates names against build-config repos). Include links to build-config PRs in the description.

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [ ] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->
