### PR TITLE
fix(monitoring): add Tempo trace-write RBAC for data-science-collector

### DIFF
--- a/internal/controller/services/monitoring/monitoring_controller_actions.go
+++ b/internal/controller/services/monitoring/monitoring_controller_actions.go
@@ -33,6 +33,7 @@ const (
 	CollectorPrometheusServiceTemplate               = "resources/collector-prometheus-service.tmpl.yaml"
 	CollectorRBACTemplate                            = "resources/collector-rbac.tmpl.yaml"
 	CollectorMLflowRBACTemplate                      = "resources/collector-mlflow-rbac.tmpl.yaml"
+	CollectorTempoRBACTemplate                       = "resources/collector-tempo-rbac.tmpl.yaml"
 	PrometheusRouteTemplate                          = "resources/data-science-prometheus-route.tmpl.yaml"
 	InstrumentationTemplate                          = "resources/instrumentation.tmpl.yaml"
 	PrometheusNamespaceProxyTemplate                 = "resources/data-science-prometheus-namespace-proxy.tmpl.yaml"
@@ -314,12 +315,18 @@ func deployOpenTelemetryCollector(ctx context.Context, rr *odhtypes.Reconciliati
 		})
 	}
 
-	// Collector RBAC for MLflow trace ingestion (only when tracing is enabled)
+	// Collector RBAC for trace ingestion (only when tracing is enabled)
 	if monitoring.Spec.Traces != nil {
-		template = append(template, odhtypes.TemplateInfo{
-			FS:   resourcesFS,
-			Path: CollectorMLflowRBACTemplate,
-		})
+		template = append(template,
+			odhtypes.TemplateInfo{
+				FS:   resourcesFS,
+				Path: CollectorMLflowRBACTemplate,
+			},
+			odhtypes.TemplateInfo{
+				FS:   resourcesFS,
+				Path: CollectorTempoRBACTemplate,
+			},
+		)
 	}
 
 	rr.Templates = append(rr.Templates, template...)

--- a/internal/controller/services/monitoring/resources/collector-tempo-rbac.tmpl.yaml
+++ b/internal/controller/services/monitoring/resources/collector-tempo-rbac.tmpl.yaml
@@ -1,0 +1,26 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: data-science-collector-tempo-trace-export
+rules:
+- apiGroups:
+  - tempo.grafana.com
+  resources:
+  - {{ .Namespace }}
+  resourceNames:
+  - traces
+  verbs:
+  - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: data-science-collector-tempo-trace-export
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: data-science-collector-tempo-trace-export
+subjects:
+- kind: ServiceAccount
+  name: data-science-collector-collector
+  namespace: {{ .Namespace }}

--- a/tests/e2e/monitoring_test.go
+++ b/tests/e2e/monitoring_test.go
@@ -278,6 +278,7 @@ func (tc *MonitoringTestCtx) runTracesWithPVBackendTests(t *testing.T) {
 
 		t.Run("Test TempoMonolithic CR Creation with PV backend", tc.ValidateTempoMonolithicCRCreation)
 		t.Run("Test Collector MLflow integration RBAC", tc.ValidateCollectorMLflowIntegrationRBAC)
+		t.Run("Test Collector Tempo trace export RBAC", tc.ValidateCollectorTempoTraceExportRBAC)
 	})
 }
 
@@ -2904,8 +2905,11 @@ func (tc *MonitoringTestCtx) ValidateCollectorMLflowIntegrationRBAC(t *testing.T
 		}),
 		WithCondition(And(
 			jq.Match(`.rules | length == 1`),
+			jq.Match(`(.rules[0].apiGroups | length) == 1`),
 			jq.Match(`.rules[0].apiGroups[0] == "mlflow.kubeflow.org"`),
+			jq.Match(`(.rules[0].resources | length) == 1`),
 			jq.Match(`.rules[0].resources[0] == "experiments"`),
+			jq.Match(`(.rules[0].verbs | length) == 1`),
 			jq.Match(`.rules[0].verbs[0] == "update"`),
 		)),
 		WithCustomErrorMsg("ClusterRole should grant only experiments update on mlflow.kubeflow.org"),
@@ -2917,7 +2921,11 @@ func (tc *MonitoringTestCtx) ValidateCollectorMLflowIntegrationRBAC(t *testing.T
 			Name: "data-science-collector-mlflow-trace-export",
 		}),
 		WithCondition(And(
+			jq.Match(`.roleRef.apiGroup == "rbac.authorization.k8s.io"`),
+			jq.Match(`.roleRef.kind == "ClusterRole"`),
 			jq.Match(`.roleRef.name == "data-science-collector-mlflow-trace-export"`),
+			jq.Match(`(.subjects | length) == 1`),
+			jq.Match(`.subjects[0].kind == "ServiceAccount"`),
 			jq.Match(`.subjects[0].name == "%s"`, TargetAllocatorServiceAccount),
 			jq.Match(`.subjects[0].namespace == "%s"`, tc.MonitoringNamespace),
 		)),
@@ -2939,6 +2947,71 @@ func (tc *MonitoringTestCtx) ValidateCollectorMLflowIntegrationRBAC(t *testing.T
 	tc.EnsureResourceGone(
 		WithMinimalObject(gvk.ClusterRoleBinding, types.NamespacedName{
 			Name: "data-science-collector-mlflow-trace-export",
+		}),
+	)
+}
+
+// ValidateCollectorTempoTraceExportRBAC tests that the collector SA has the Tempo trace export ClusterRole and ClusterRoleBinding.
+func (tc *MonitoringTestCtx) ValidateCollectorTempoTraceExportRBAC(t *testing.T) {
+	t.Helper()
+	t.Cleanup(tc.resetMonitoringConfigToManaged)
+
+	tc.updateMonitoringConfig(
+		withManagementState(operatorv1.Managed),
+		withMonitoringTraces(TracesStorageBackendPV, "", TracesStorageSize1Gi, DefaultRetention),
+	)
+
+	// Step 1: Verify ClusterRole grants traces create on tempo.grafana.com for the monitoring namespace
+	tc.EnsureResourceExists(
+		WithMinimalObject(gvk.ClusterRole, types.NamespacedName{
+			Name: "data-science-collector-tempo-trace-export",
+		}),
+		WithCondition(And(
+			jq.Match(`.rules | length == 1`),
+			jq.Match(`(.rules[0].apiGroups | length) == 1`),
+			jq.Match(`.rules[0].apiGroups[0] == "tempo.grafana.com"`),
+			jq.Match(`(.rules[0].resources | length) == 1`),
+			jq.Match(`.rules[0].resources[0] == "%s"`, tc.MonitoringNamespace),
+			jq.Match(`(.rules[0].resourceNames | length) == 1`),
+			jq.Match(`.rules[0].resourceNames[0] == "traces"`),
+			jq.Match(`(.rules[0].verbs | length) == 1`),
+			jq.Match(`.rules[0].verbs[0] == "create"`),
+		)),
+		WithCustomErrorMsg("ClusterRole should grant traces create on tempo.grafana.com for the monitoring namespace"),
+	)
+
+	// Step 2: Verify ClusterRoleBinding binds the collector SA to the trace export ClusterRole
+	tc.EnsureResourceExists(
+		WithMinimalObject(gvk.ClusterRoleBinding, types.NamespacedName{
+			Name: "data-science-collector-tempo-trace-export",
+		}),
+		WithCondition(And(
+			jq.Match(`.roleRef.apiGroup == "rbac.authorization.k8s.io"`),
+			jq.Match(`.roleRef.kind == "ClusterRole"`),
+			jq.Match(`.roleRef.name == "data-science-collector-tempo-trace-export"`),
+			jq.Match(`(.subjects | length) == 1`),
+			jq.Match(`.subjects[0].kind == "ServiceAccount"`),
+			jq.Match(`.subjects[0].name == "%s"`, TargetAllocatorServiceAccount),
+			jq.Match(`.subjects[0].namespace == "%s"`, tc.MonitoringNamespace),
+		)),
+		WithCustomErrorMsg("ClusterRoleBinding should bind collector SA to Tempo trace export ClusterRole"),
+	)
+
+	// Step 3: Disable traces and verify both resources are removed
+	tc.updateMonitoringConfig(
+		withManagementState(operatorv1.Managed),
+		withNoTraces(),
+	)
+
+	tc.EnsureResourceGone(
+		WithMinimalObject(gvk.ClusterRole, types.NamespacedName{
+			Name: "data-science-collector-tempo-trace-export",
+		}),
+	)
+
+	tc.EnsureResourceGone(
+		WithMinimalObject(gvk.ClusterRoleBinding, types.NamespacedName{
+			Name: "data-science-collector-tempo-trace-export",
 		}),
 	)
 }


### PR DESCRIPTION
## Description
Monitoring reconciler deploys an OpenTelemetryCollector configured to export traces to Tempo gateway, but does not create the Kubernetes RBAC required for Tempo OpenShift multitenancy write access. The collector receives OTLP spans but drops them on export with PermissionDenied.

Add ClusterRole and ClusterRoleBinding granting the collector SA create permission on the tempo.grafana.com virtual resource for trace export, mirroring the existing MLflow RBAC pattern. Resources are conditionally deployed when Spec.Traces is set and garbage-collected when removed.

## Release tracking
<!-- Optional. Set a target release only if this PR must ship in a specific release; it will be prioritized accordingly. -->
<!-- Target release for this PR, e.g. rhoai-3.6 or rhoai-3.7ea1 -->
Release:  rhoai-3.6ea1
<!-- Required only if a Release is set above. Full link to a jira ticket, e.g. https://redhat.atlassian.net/browse/RHOAIENG-XXXXX -->
Jira: https://redhat.atlassian.net/browse/RHOAIENG-83713


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Applied RBAC change on 3.6ea1 built cluster and performed a Hello World job to get Tempo traces to appear
- Unit tests added

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully
- [ ] New RELATED_IMAGE mappings are listed in ODH-Build-Config and RHOAI-Build-Config (CI validates names against build-config repos). Include links to build-config PRs in the description.

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [ ] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * OpenTelemetry tracing now automatically receives the permissions required to export traces to Tempo when tracing is enabled.
  * These permissions are automatically removed when Tempo trace exporting is disabled.

* **Bug Fixes**
  * Improved collector access to Tempo for trace exporting.

* **Tests**
  * Added end-to-end validation for Tempo permissions, bindings, and cleanup.
  * Strengthened validation of related collector permissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->