### PR TITLE
fix: update e2e-failure-triage to use correct secret

### DIFF
--- a/.github/scripts/e2e-failure-triage/triage.py
+++ b/.github/scripts/e2e-failure-triage/triage.py
@@ -852,6 +852,23 @@ def print_summary(result: TriageResult) -> None:
 SECTION_START_MARKER = "<!-- e2e-triage-section:{suite} -->"
 SECTION_END_MARKER = "<!-- /e2e-triage-section:{suite} -->"
 
+# The thollander/actions-comment-pull-request action appends its own tracking
+# marker (e.g. `<!-- thollander/actions-comment-pull-request "e2e-failure-triage" -->`)
+# to the comment body on every run. Since we carry forward the previous
+# comment's raw text when merging suite sections, that marker would otherwise
+# accumulate one extra line per run. The action re-appends a fresh marker
+# itself whenever it (re)creates the comment, so it's safe to strip any
+# existing occurrences before merging.
+THOLLANDER_MARKER_PATTERN = re.compile(
+    r'[ \t]*<!-- thollander/actions-comment-pull-request "[^"]*" -->[ \t]*\n?'
+)
+
+
+def strip_thollander_markers(text: str) -> str:
+    """Remove stale thollander/actions-comment-pull-request tracking markers."""
+    stripped = THOLLANDER_MARKER_PATTERN.sub("", text)
+    return re.sub(r"\n{3,}", "\n\n", stripped).rstrip("\n")
+
 
 def _generate_section(
     result: TriageResult,
@@ -989,7 +1006,7 @@ def main() -> None:
     action_run_url = args.action_run_url or None
     existing_comment = None
     if args.existing_comment and Path(args.existing_comment).exists():
-        existing_comment = Path(args.existing_comment).read_text()
+        existing_comment = strip_thollander_markers(Path(args.existing_comment).read_text())
 
     if not result.component_failures:
         comment_body = generate_pr_comment(result, None, action_run_url, existing_comment)

--- a/.github/workflows/e2e-failure-triage.yaml
+++ b/.github/workflows/e2e-failure-triage.yaml
@@ -95,7 +95,7 @@ jobs:
         env:
           PROW_URL: ${{ steps.extract-pr.outputs.prow_url }}
           E2E_TRIAGE_JIRA_EMAIL: ${{ secrets.E2E_TRIAGE_JIRA_EMAIL }}
-          E2E_TRIAGE_JIRA_API_TOKEN: ${{ secrets.E2E_TRIAGE_JIRA_API_TOKEN }}
+          E2E_TRIAGE_JIRA_API_TOKEN: ${{ secrets.E2E_TRIAGE_API_TOKEN }}
           GITHUB_ACTION_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           python .github/scripts/e2e-failure-triage/triage.py \
@@ -110,4 +110,4 @@ jobs:
           file-path: ${{ runner.temp }}/pr-comment.md
           pr-number: ${{ steps.extract-pr.outputs.pr_number }}
           comment-tag: e2e-failure-triage
-          mode: upsert
+          mode: recreate


### PR DESCRIPTION
## Description
This PR updates the existing E2E Failure Triage GHA by making the following changes:

- Fix `E2E_TRIAGE_JIRA_API_TOKEN` secret reference (repo secret is actually named `E2E_TRIAGE_API_TOKEN`) — this mismatch was silently blocking every Jira blocker-bug filing since the automation was added.
- Switch the PR comment to `mode: recreate` so it sorts to the bottom of the conversation on each run instead of staying pinned at its original position from continuous in-place edits.
- Strip stale `thollander/actions-comment-pull-request` tracking markers before merging suite sections, preventing them from silently accumulating in the comment body on every run.


## Release tracking
<!-- Optional. Set a target release only if this PR must ship in a specific release; it will be prioritized accordingly. -->
<!-- Target release for this PR, e.g. rhoai-3.6 or rhoai-3.7ea1 -->
Release: 
<!-- Required only if a Release is set above. Full link to a jira ticket, e.g. https://redhat.atlassian.net/browse/RHOAIENG-XXXXX -->
Jira:


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully
- [ ] New RELATED_IMAGE mappings are listed in ODH-Build-Config and RHOAI-Build-Config (CI validates names against build-config repos). Include links to build-config PRs in the description.

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [X] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
Updating GHA which doesn't require e2e changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Cleaned up stale tracking markers in automated pull request comments.
  - Removed repeated markers and collapsed excessive blank lines while preserving comment content.
  - Improved comment recreation so refreshed comments remain clean and readable.
- **Chores**
  - Updated automated end-to-end failure triage configuration for more reliable comment processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->