### PR TITLE
fix(gateway): cover missing Dashboard CRD in redirect handling

### DIFF
--- a/internal/controller/services/gateway/dashboard_redirects.go
+++ b/internal/controller/services/gateway/dashboard_redirects.go
@@ -44,11 +44,13 @@ import (
 	"os"
 
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/api/components/v1alpha1"
+	serviceApi "github.com/opendatahub-io/opendatahub-operator/v2/api/services/v1alpha1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
 	odhtypes "github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
@@ -70,29 +72,48 @@ const (
 // the redirect resources rather than relying on GC. The GC action uses the owner CR's
 // metadata.generation to identify stale resources, but Dashboard removal does not change
 // GatewayConfig's generation, so GC would never clean them up.
-func createDashboardRedirects(ctx context.Context, rr *odhtypes.ReconciliationRequest) error {
+func createDashboardRedirectsAction(ctx context.Context, rr *odhtypes.ReconciliationRequest) error {
+	gatewayConfig, err := validateGatewayConfig(rr)
+	if err != nil {
+		return err
+	}
+
+	templates, err := createDashboardRedirects(ctx, rr.Client, gatewayConfig)
+	if err != nil {
+		return err
+	}
+
+	rr.Templates = append(rr.Templates, templates...)
+	return nil
+}
+
+func createDashboardRedirects(
+	ctx context.Context,
+	cli client.Client,
+	gatewayConfig *serviceApi.GatewayConfig,
+) ([]odhtypes.TemplateInfo, error) {
 	l := logf.FromContext(ctx).WithName("createDashboardRedirects")
 
 	// Check if feature is explicitly disabled via operator environment variable
 	if os.Getenv("DISABLE_DASHBOARD_REDIRECTS") == "true" {
 		l.Info("Dashboard redirects disabled via DISABLE_DASHBOARD_REDIRECTS environment variable")
-		return deleteDashboardRedirectResources(ctx, rr)
+		return nil, deleteDashboardRedirectResources(ctx, cli)
 	}
 
 	// When the Dashboard component is not deployed there is no dashboard route
 	// to redirect from, so the redirect pods serve no purpose.
 	dashboard := resources.GvkToUnstructured(gvk.Dashboard)
-	if err := rr.Client.Get(ctx, client.ObjectKey{Name: componentApi.DashboardInstanceName}, dashboard); err != nil {
-		if k8serr.IsNotFound(err) {
+	if err := cli.Get(ctx, client.ObjectKey{Name: componentApi.DashboardInstanceName}, dashboard); err != nil {
+		switch {
+		case k8serr.IsNotFound(err):
 			l.Info("Dashboard CR not found, cleaning up dashboard redirect resources")
-			return deleteDashboardRedirectResources(ctx, rr)
+			return nil, deleteDashboardRedirectResources(ctx, cli)
+		case meta.IsNoMatchError(err):
+			l.Info("Dashboard CRD not registered, cleaning up dashboard redirect resources")
+			return nil, deleteDashboardRedirectResources(ctx, cli)
+		default:
+			return nil, fmt.Errorf("failed to check Dashboard CR: %w", err)
 		}
-		return fmt.Errorf("failed to check Dashboard CR: %w", err)
-	}
-
-	gatewayConfig, err := validateGatewayConfig(rr)
-	if err != nil {
-		return err
 	}
 
 	l.Info("Creating dashboard redirect resources",
@@ -102,20 +123,20 @@ func createDashboardRedirects(ctx context.Context, rr *odhtypes.ReconciliationRe
 
 	// Add templates to reconciliation request
 	// Note: Legacy gateway redirect template uses {{- if .LegacyHostname }} to conditionally render
-	rr.Templates = append(rr.Templates,
-		odhtypes.TemplateInfo{FS: gatewayResources, Path: dashboardRedirectConfigMapTemplate},
-		odhtypes.TemplateInfo{FS: gatewayResources, Path: dashboardRedirectDeploymentTemplate},
-		odhtypes.TemplateInfo{FS: gatewayResources, Path: dashboardRedirectServiceTemplate},
-		odhtypes.TemplateInfo{FS: gatewayResources, Path: dashboardRedirectDashboardRouteTemplate},
-		odhtypes.TemplateInfo{FS: gatewayResources, Path: dashboardRedirectLegacyGatewayRouteTemplate},
-	)
+	templates := []odhtypes.TemplateInfo{
+		{FS: gatewayResources, Path: dashboardRedirectConfigMapTemplate},
+		{FS: gatewayResources, Path: dashboardRedirectDeploymentTemplate},
+		{FS: gatewayResources, Path: dashboardRedirectServiceTemplate},
+		{FS: gatewayResources, Path: dashboardRedirectDashboardRouteTemplate},
+		{FS: gatewayResources, Path: dashboardRedirectLegacyGatewayRouteTemplate},
+	}
 
-	return nil
+	return templates, nil
 }
 
 // deleteDashboardRedirectResources explicitly removes redirect resources that were
 // previously created by createDashboardRedirects.
-func deleteDashboardRedirectResources(ctx context.Context, rr *odhtypes.ReconciliationRequest) error {
+func deleteDashboardRedirectResources(ctx context.Context, cli client.Client) error {
 	l := logf.FromContext(ctx).WithName("deleteDashboardRedirectResources")
 	ns := cluster.GetApplicationNamespace()
 
@@ -136,13 +157,13 @@ func deleteDashboardRedirectResources(ctx context.Context, rr *odhtypes.Reconcil
 		obj.SetNamespace(ns)
 
 		// Check existence via cached Get to avoid unnecessary Delete API calls on every reconcile
-		if err := rr.Client.Get(ctx, client.ObjectKeyFromObject(obj), obj); err != nil {
-			if k8serr.IsNotFound(err) {
+		if err := cli.Get(ctx, client.ObjectKeyFromObject(obj), obj); err != nil {
+			if k8serr.IsNotFound(err) || meta.IsNoMatchError(err) {
 				continue
 			}
 			return fmt.Errorf("failed to get dashboard redirect resource %s/%s: %w", obj.GetKind(), r.name, err)
 		}
-		if err := rr.Client.Delete(ctx, obj); err != nil {
+		if err := cli.Delete(ctx, obj); err != nil {
 			if k8serr.IsNotFound(err) {
 				continue
 			}

--- a/internal/controller/services/gateway/dashboard_redirects_integration_test.go
+++ b/internal/controller/services/gateway/dashboard_redirects_integration_test.go
@@ -1,0 +1,284 @@
+//go:build integration
+
+//nolint:testpackage
+package gateway
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	k8serr "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+
+	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/api/components/v1alpha1"
+	serviceApi "github.com/opendatahub-io/opendatahub-operator/v2/api/services/v1alpha1"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/resources"
+	testscheme "github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/scheme"
+	"github.com/opendatahub-io/opendatahub-operator/v2/tests/envtestutil"
+
+	. "github.com/onsi/gomega"
+)
+
+type dashboardRedirectTestEnv struct {
+	env    *envtest.Environment
+	client client.Client
+}
+
+func TestCreateDashboardRedirectsWithRealAPIServer(t *testing.T) {
+	tc := startDashboardRedirectTestEnv(t, t.Context())
+
+	t.Run("when dashboard crd is not registered", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+		tc.resetDashboardRedirectTestState(t, ctx, false)
+
+		dashboard := resources.GvkToUnstructured(gvk.Dashboard)
+		err := tc.client.Get(ctx, client.ObjectKey{Name: componentApi.DashboardInstanceName}, dashboard)
+		g.Expect(err).To(Satisfy(meta.IsNoMatchError), "Dashboard CRD should not be registered in this case")
+
+		gatewayConfig := tc.createDashboardRedirectGatewayConfig(t, ctx)
+		redirectObjects := tc.createDashboardRedirectResources(t, ctx)
+
+		templates, err := createDashboardRedirects(ctx, tc.client, gatewayConfig)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(templates).To(BeEmpty())
+
+		for _, obj := range redirectObjects {
+			g.Expect(tc.client.Get(ctx, client.ObjectKeyFromObject(obj), obj)).
+				To(MatchError(ContainSubstring("not found")))
+		}
+	})
+
+	t.Run("when dashboard crd is registered but cr is absent", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+		tc.installDashboardCRD(t, ctx)
+		tc.resetDashboardRedirectTestState(t, ctx, true)
+
+		dashboard := resources.GvkToUnstructured(gvk.Dashboard)
+		err := tc.client.Get(ctx, client.ObjectKey{Name: componentApi.DashboardInstanceName}, dashboard)
+		g.Expect(err).To(Satisfy(k8serr.IsNotFound), "Dashboard CR should be absent in this case")
+
+		gatewayConfig := tc.createDashboardRedirectGatewayConfig(t, ctx)
+		redirectObjects := tc.createDashboardRedirectResources(t, ctx)
+
+		templates, err := createDashboardRedirects(ctx, tc.client, gatewayConfig)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(templates).To(BeEmpty())
+
+		for _, obj := range redirectObjects {
+			g.Expect(tc.client.Get(ctx, client.ObjectKeyFromObject(obj), obj)).
+				To(MatchError(ContainSubstring("not found")))
+		}
+	})
+
+	t.Run("when dashboard cr is present", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+		tc.installDashboardCRD(t, ctx)
+		tc.resetDashboardRedirectTestState(t, ctx, true)
+
+		gatewayConfig := tc.createDashboardRedirectGatewayConfig(t, ctx)
+		dashboard := resources.GvkToUnstructured(gvk.Dashboard)
+		dashboard.SetName(componentApi.DashboardInstanceName)
+		g.Expect(tc.client.Create(ctx, dashboard)).To(Succeed())
+		g.Expect(tc.client.Get(ctx, client.ObjectKey{Name: componentApi.DashboardInstanceName}, dashboard)).To(Succeed())
+
+		templates, err := createDashboardRedirects(ctx, tc.client, gatewayConfig)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(templates).To(HaveLen(5))
+	})
+}
+
+func startDashboardRedirectTestEnv(t *testing.T, ctx context.Context) *dashboardRedirectTestEnv {
+	t.Helper()
+	g := NewWithT(t)
+
+	rootPath, err := envtestutil.FindProjectRoot()
+	g.Expect(err).ToNot(HaveOccurred())
+
+	scheme, err := testscheme.New()
+	g.Expect(err).ToNot(HaveOccurred())
+
+	crdPaths := []string{
+		filepath.Join(rootPath, "config", "crd", "bases", "services.platform.opendatahub.io_gatewayconfigs.yaml"),
+		filepath.Join(rootPath, "config", "crd", "external", "route.openshift.io_routes.yaml"),
+	}
+
+	testEnv := &envtest.Environment{
+		CRDInstallOptions: envtest.CRDInstallOptions{
+			Scheme:             scheme,
+			Paths:              crdPaths,
+			ErrorIfPathMissing: true,
+			CleanUpAfterUse:    false,
+		},
+		ErrorIfCRDPathMissing: true,
+	}
+
+	cfg, err := testEnv.Start()
+	g.Expect(err).ToNot(HaveOccurred())
+
+	cli, err := client.New(cfg, client.Options{Scheme: scheme})
+	g.Expect(err).ToNot(HaveOccurred())
+
+	appNs := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: cluster.GetApplicationNamespace()}}
+	g.Expect(cli.Create(ctx, appNs)).To(Succeed())
+
+	t.Cleanup(func() {
+		g.Expect(testEnv.Stop()).To(Succeed())
+	})
+
+	return &dashboardRedirectTestEnv{
+		env:    testEnv,
+		client: cli,
+	}
+}
+
+func (tc *dashboardRedirectTestEnv) createDashboardRedirectGatewayConfig(
+	t *testing.T,
+	ctx context.Context,
+) *serviceApi.GatewayConfig {
+	t.Helper()
+	g := NewWithT(t)
+
+	gatewayConfig := &serviceApi.GatewayConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: serviceApi.GatewayConfigName,
+		},
+	}
+	g.Expect(tc.client.Create(ctx, gatewayConfig)).To(Succeed())
+
+	return gatewayConfig
+}
+
+func (tc *dashboardRedirectTestEnv) createDashboardRedirectResources(
+	t *testing.T,
+	ctx context.Context,
+) []client.Object {
+	t.Helper()
+	g := NewWithT(t)
+
+	appNs := cluster.GetApplicationNamespace()
+	objs := []client.Object{
+		&corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      DashboardRedirectConfigName,
+				Namespace: appNs,
+			},
+		},
+	}
+
+	for _, obj := range objs {
+		g.Expect(tc.client.Create(ctx, obj)).To(Succeed())
+	}
+
+	return objs
+}
+
+func (tc *dashboardRedirectTestEnv) installDashboardCRD(t *testing.T, ctx context.Context) {
+	t.Helper()
+	g := NewWithT(t)
+
+	crd := tc.getDashboardCRDForIntegration()
+	g.Expect(client.IgnoreAlreadyExists(tc.client.Create(ctx, crd))).To(Succeed())
+
+	g.Eventually(func() bool {
+		dashboard := resources.GvkToUnstructured(gvk.Dashboard)
+		dashboard.SetName(componentApi.DashboardInstanceName)
+
+		err := tc.client.Get(ctx, client.ObjectKey{Name: componentApi.DashboardInstanceName}, dashboard)
+		return err == nil || k8serr.IsNotFound(err)
+	}, 5*time.Second, 100*time.Millisecond).Should(
+		BeTrue(),
+		"Dashboard CRD should become queryable before the CR-present/absent cases run",
+	)
+}
+
+func (tc *dashboardRedirectTestEnv) resetDashboardRedirectTestState(
+	t *testing.T,
+	ctx context.Context,
+	includeDashboardCRD bool,
+) {
+	t.Helper()
+
+	appNs := cluster.GetApplicationNamespace()
+	configMap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      DashboardRedirectConfigName,
+			Namespace: appNs,
+		},
+	}
+	tc.deleteObjectEventually(t, ctx, configMap)
+
+	gatewayConfig := &serviceApi.GatewayConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: serviceApi.GatewayConfigName,
+		},
+	}
+	tc.deleteObjectEventually(t, ctx, gatewayConfig)
+
+	if includeDashboardCRD {
+		dashboard := resources.GvkToUnstructured(gvk.Dashboard)
+		dashboard.SetName(componentApi.DashboardInstanceName)
+		tc.deleteObjectEventually(t, ctx, dashboard)
+	}
+}
+
+func (tc *dashboardRedirectTestEnv) deleteObjectEventually(
+	t *testing.T,
+	ctx context.Context,
+	obj client.Object,
+) {
+	t.Helper()
+
+	g := NewWithT(t)
+	key := client.ObjectKeyFromObject(obj)
+
+	g.Eventually(func() error {
+		return client.IgnoreNotFound(tc.client.Delete(ctx, obj))
+	}).Should(Succeed())
+
+	g.Eventually(func() error {
+		return tc.client.Get(ctx, key, obj)
+	}).Should(Satisfy(k8serr.IsNotFound))
+}
+
+func (tc *dashboardRedirectTestEnv) getDashboardCRDForIntegration() *apiextensionsv1.CustomResourceDefinition {
+	preserveUnknown := true
+
+	return &apiextensionsv1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "dashboards." + gvk.Dashboard.Group,
+		},
+		Spec: apiextensionsv1.CustomResourceDefinitionSpec{
+			Group: gvk.Dashboard.Group,
+			Names: apiextensionsv1.CustomResourceDefinitionNames{
+				Kind:     gvk.Dashboard.Kind,
+				ListKind: gvk.Dashboard.Kind + "List",
+				Plural:   "dashboards",
+				Singular: "dashboard",
+			},
+			Scope: apiextensionsv1.ClusterScoped,
+			Versions: []apiextensionsv1.CustomResourceDefinitionVersion{{
+				Name:    gvk.Dashboard.Version,
+				Served:  true,
+				Storage: true,
+				Schema: &apiextensionsv1.CustomResourceValidation{
+					OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
+						Type:                   "object",
+						XPreserveUnknownFields: &preserveUnknown,
+					},
+				},
+			}},
+		},
+	}
+}

--- a/internal/controller/services/gateway/dashboard_redirects_test.go
+++ b/internal/controller/services/gateway/dashboard_redirects_test.go
@@ -16,7 +16,6 @@ import (
 	serviceApi "github.com/opendatahub-io/opendatahub-operator/v2/api/services/v1alpha1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
-	odhtypes "github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/resources"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/fakeclient"
 
@@ -37,14 +36,9 @@ func TestCreateDashboardRedirects_SkipsWhenDashboardNotDeployed(t *testing.T) {
 	cli, err := fakeclient.New(fakeclient.WithObjects(gatewayConfig))
 	g.Expect(err).To(Succeed())
 
-	rr := &odhtypes.ReconciliationRequest{
-		Client:   cli,
-		Instance: gatewayConfig,
-	}
-
-	err = createDashboardRedirects(ctx, rr)
+	templates, err := createDashboardRedirects(ctx, cli, gatewayConfig)
 	g.Expect(err).ToNot(HaveOccurred())
-	g.Expect(rr.Templates).To(BeEmpty(), "no redirect templates should be added when Dashboard CR does not exist")
+	g.Expect(templates).To(BeEmpty(), "no redirect templates should be added when Dashboard CR does not exist")
 }
 
 func TestCreateDashboardRedirects_CreatesWhenDashboardExists(t *testing.T) {
@@ -64,14 +58,9 @@ func TestCreateDashboardRedirects_CreatesWhenDashboardExists(t *testing.T) {
 	cli, err := fakeclient.New(fakeclient.WithObjects(gatewayConfig, dashboard))
 	g.Expect(err).To(Succeed())
 
-	rr := &odhtypes.ReconciliationRequest{
-		Client:   cli,
-		Instance: gatewayConfig,
-	}
-
-	err = createDashboardRedirects(ctx, rr)
+	templates, err := createDashboardRedirects(ctx, cli, gatewayConfig)
 	g.Expect(err).ToNot(HaveOccurred())
-	g.Expect(rr.Templates).ToNot(BeEmpty(), "redirect templates should be added when Dashboard CR exists")
+	g.Expect(templates).ToNot(BeEmpty(), "redirect templates should be added when Dashboard CR exists")
 }
 
 func TestCreateDashboardRedirects_SkipsWhenEnvDisabled(t *testing.T) {
@@ -92,14 +81,9 @@ func TestCreateDashboardRedirects_SkipsWhenEnvDisabled(t *testing.T) {
 	cli, err := fakeclient.New(fakeclient.WithObjects(gatewayConfig, dashboard))
 	g.Expect(err).To(Succeed())
 
-	rr := &odhtypes.ReconciliationRequest{
-		Client:   cli,
-		Instance: gatewayConfig,
-	}
-
-	err = createDashboardRedirects(ctx, rr)
+	templates, err := createDashboardRedirects(ctx, cli, gatewayConfig)
 	g.Expect(err).ToNot(HaveOccurred())
-	g.Expect(rr.Templates).To(BeEmpty(), "no redirect templates should be added when DISABLE_DASHBOARD_REDIRECTS=true")
+	g.Expect(templates).To(BeEmpty(), "no redirect templates should be added when DISABLE_DASHBOARD_REDIRECTS=true")
 }
 
 func TestCreateDashboardRedirects_DeletesResourcesWhenDashboardRemoved(t *testing.T) {
@@ -160,14 +144,9 @@ func TestCreateDashboardRedirects_DeletesResourcesWhenDashboardRemoved(t *testin
 	))
 	g.Expect(err).To(Succeed())
 
-	rr := &odhtypes.ReconciliationRequest{
-		Client:   cli,
-		Instance: gatewayConfig,
-	}
-
-	err = createDashboardRedirects(ctx, rr)
+	templates, err := createDashboardRedirects(ctx, cli, gatewayConfig)
 	g.Expect(err).ToNot(HaveOccurred())
-	g.Expect(rr.Templates).To(BeEmpty(), "no redirect templates should be added when Dashboard CR does not exist")
+	g.Expect(templates).To(BeEmpty(), "no redirect templates should be added when Dashboard CR does not exist")
 
 	// Verify all redirect resources were deleted
 	g.Expect(cli.Get(ctx, client.ObjectKeyFromObject(redirectDeployment), &appsv1.Deployment{})).

--- a/internal/controller/services/gateway/gateway_controller.go
+++ b/internal/controller/services/gateway/gateway_controller.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
+	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
@@ -56,6 +57,13 @@ func (h *ServiceHandler) NewReconciler(ctx context.Context, mgr ctrl.Manager) er
 		OwnsGVK(gvk.ClusterRoleBinding).
 		OwnsGVK(gvk.EnvoyFilter, reconciler.Dynamic(reconciler.CrdExists(gvk.EnvoyFilter))).
 		OwnsGVK(gvk.DestinationRule, reconciler.Dynamic(reconciler.CrdExists(gvk.DestinationRule))).
+		Watches(
+			&extv1.CustomResourceDefinition{},
+			reconciler.WithEventHandler(
+				handlers.ToNamed(serviceApi.GatewayConfigName)),
+			reconciler.WithPredicates(
+				resources.CreatedOrUpdatedOrDeletedNamed(gvk.DashboardComponentCRDName)),
+		).
 		// Watch for certificate secrets (both OpenShift default ingress and provided).
 		Watches(
 			&corev1.Secret{},
@@ -91,7 +99,7 @@ func (h *ServiceHandler) NewReconciler(ctx context.Context, mgr ctrl.Manager) er
 		WithAction(createEnvoyFilter).
 		WithAction(createNetworkPolicy).
 		WithAction(createOCPRoutes).
-		WithAction(createDashboardRedirects).
+		WithAction(createDashboardRedirectsAction).
 		WithAction(template.NewAction(
 			template.WithDataFn(getTemplateData),
 		)).

--- a/internal/controller/services/gateway/kubebuilder_rbac.go
+++ b/internal/controller/services/gateway/kubebuilder_rbac.go
@@ -8,6 +8,7 @@ package gateway
 
 // Dashboard CR (read-only, to check if Dashboard is deployed before creating redirects)
 // +kubebuilder:rbac:groups=components.platform.opendatahub.io,resources=dashboards,verbs=get;list;watch
+// +kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=list;watch
 
 // OpenShift APIServer config (TLS security profile for kube-auth-proxy)
 // +kubebuilder:rbac:groups="config.openshift.io",resources=apiservers,verbs=get;list;watch

--- a/pkg/cluster/gvk/gvk.go
+++ b/pkg/cluster/gvk/gvk.go
@@ -67,6 +67,9 @@ const (
 
 	// KServe CRDs.
 	InferenceServicesCRDName = "inferenceservices.serving.kserve.io"
+
+	// Components CRDs.
+	DashboardComponentCRDName = "dashboards.components.platform.opendatahub.io"
 )
 
 var (


### PR DESCRIPTION
Handle the Dashboard CRD not being registered as a cleanup case and add real-api coverage for Dashboard CRD and CR presence states under RHOAIENG-85498.

Ref: https://redhat.atlassian.net/browse/RHOAIENG-85498

<!---
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

<!-- For RHOAI PRs, request review on #ai-core-platform-requests Slack channel -->

## Release tracking
<!-- Optional. Set a target release only if this PR must ship in a specific release; it will be prioritized accordingly. -->
<!-- Target release for this PR, e.g. rhoai-3.6 or rhoai-3.7ea1 -->
Release: 
<!-- Required only if a Release is set above. Full link to a jira ticket, e.g. https://redhat.atlassian.net/browse/RHOAIENG-XXXXX -->
Jira:


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully
- [ ] New RELATED_IMAGE mappings are listed in ODH-Build-Config and RHOAI-Build-Config (CI validates names against build-config repos). Include links to build-config PRs in the description.

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->

Changes here do not require additional e2e, integration tests are covering the change enogh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dashboard redirect handling when Dashboard resources or their CRD are unavailable.
  * Ensured redirect cleanup works reliably during resource deletion.
  * Gateway updates now respond to Dashboard component lifecycle changes.
  * Redirects are reconciled automatically when Dashboard components are created, updated, or removed.

* **Tests**
  * Added integration coverage using a real Kubernetes API server.
  * Expanded validation for missing CRDs, missing Dashboard resources, existing Dashboards, disabled redirects, and cleanup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->