### PR TITLE
RHOAIENG-84751: bundle e2e-scope-rules.yaml into the e2e test image

### DIFF
--- a/Dockerfiles/e2e-tests/e2e-tests.Dockerfile
+++ b/Dockerfiles/e2e-tests/e2e-tests.Dockerfile
@@ -52,6 +52,7 @@ WORKDIR /e2e
 COPY --from=builder /workspace/e2e-tests .
 COPY --from=builder /workspace/test-retry /go/bin/test-retry
 COPY tests/e2e/scripts/run_e2e_tests.sh /e2e/run_e2e_tests.sh
+COPY tests/e2e/scripts/e2e-scope-rules.yaml /e2e/scripts/e2e-scope-rules.yaml
 
 RUN chmod +x ./e2e-tests /e2e/run_e2e_tests.sh /go/bin/test-retry
 


### PR DESCRIPTION
<!---
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description

The e2e test image doesn't ship `tests/e2e/scripts/e2e-scope-rules.yaml`, so two tests fail with a missing-file error in every job that pulls and runs that image, not just in a live-cluster e2e run.

`Dockerfiles/e2e-tests/e2e-tests.Dockerfile`'s runtime stage copies the compiled `e2e-tests` binary and `run_e2e_tests.sh`, but never the yaml file:

```dockerfile
COPY tests/e2e/scripts/run_e2e_tests.sh /e2e/run_e2e_tests.sh
COPY tests/e2e/scripts/e2e-scope-rules.yaml /e2e/scripts/e2e-scope-rules.yaml  # <- added
```

`TestScopeRulesComponentsMatchRealTestGroup` and `TestScopeRulesServicesMatchRealTestGroup` (added in #3969) read that file by a path relative to the working directory at runtime. Any job that pulls `quay.io/opendatahub/opendatahub-operator-e2e` and runs the compiled binary hits `open scripts/e2e-scope-rules.yaml: no such file or directory`, regardless of which component or service the job targets.

Fixes RHOAIENG-84751, RHOAIENG-83799, and RHOAIENG-83798, three duplicate reports of the same failure.

## Release tracking
<!-- Optional. Set a target release only if this PR must ship in a specific release; it will be prioritized accordingly. -->
<!-- Target release for this PR, e.g. rhoai-3.6 or rhoai-3.7ea1 -->
Release:
<!-- Required only if a Release is set above. Full link to a jira ticket, e.g. https://redhat.atlassian.net/browse/RHOAIENG-XXXXX -->
Jira: https://redhat.atlassian.net/browse/RHOAIENG-84751


## How Has This Been Tested?

Built the e2e test image locally with `podman build -f Dockerfiles/e2e-tests/e2e-tests.Dockerfile .` and ran the two affected tests directly inside the built container, bypassing the entrypoint (`podman run --entrypoint /e2e/e2e-tests <image> -test.run='^TestScopeRulesComponentsMatchRealTestGroup$|^TestScopeRulesServicesMatchRealTestGroup$'`).

- Without the fix: both tests fail with the exact error from the linked tickets.
- With the fix: both tests pass.

## Screenshot or short clip

Not applicable, no UI change.

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully
- [ ] New RELATED_IMAGE mappings are listed in ODH-Build-Config and RHOAI-Build-Config (CI validates names against build-config repos). Include links to build-config PRs in the description.

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification

Build system change with no operator or controller behavior change: it only makes an existing test image contain a file its already-existing tests need. Verified locally instead, see Testing section above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured end-to-end test environments include the required scope-rules configuration at runtime.
  * Improved reliability of tests that depend on scope validation settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->