### PR TITLE
 fix(monitoring): move DCGM metric rename rules to metric_relabel_configs

### DIFF
--- a/internal/controller/services/monitoring/monitoring_controller_support_test.go
+++ b/internal/controller/services/monitoring/monitoring_controller_support_test.go
@@ -1777,3 +1777,54 @@ func TestAddTLSData(t *testing.T) {
 		g.Expect(cipherSuites).Should(Equal(expectedIntermediateCiphers))
 	})
 }
+
+func TestDCGMRenameRulesInMetricRelabelConfigs(t *testing.T) {
+	g := NewWithT(t)
+
+	templateBytes, err := resourcesFS.ReadFile(OpenTelemetryCollectorTemplate)
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	templateContent := string(templateBytes)
+
+	// Isolate the dcgm-exporter-accelerator-metrics scrape job block
+	dcgmJob := extractSection(templateContent, "job_name: 'dcgm-exporter-accelerator-metrics'", "{{- end }}")
+	require.NotEmpty(t, dcgmJob, "dcgm-exporter-accelerator-metrics job must exist in template")
+
+	relabelSection := extractSection(dcgmJob, "relabel_configs:", "metric_relabel_configs:")
+	require.NotEmpty(t, relabelSection, "relabel_configs section must be extractable from dcgm job")
+	metricRelabelSection := extractSection(dcgmJob, "metric_relabel_configs:", "scrape_interval:")
+	require.NotEmpty(t, metricRelabelSection, "metric_relabel_configs section must be extractable from dcgm job")
+
+	dcgmRenameMetrics := []string{
+		"DCGM_FI_DEV_GPU_TEMP",
+		"DCGM_FI_DEV_GPU_UTIL",
+		"DCGM_FI_DEV_MEM_COPY_UTIL",
+		"DCGM_FI_DEV_FB_USED",
+		"DCGM_FI_DEV_FB_FREE",
+		"DCGM_FI_DEV_POWER_USAGE",
+		"DCGM_FI_DEV_SM_CLOCK",
+		"DCGM_FI_DEV_MEM_CLOCK",
+	}
+
+	for _, metric := range dcgmRenameMetrics {
+		assert.NotContains(t, relabelSection, metric,
+			"rename rule for %s must not be in relabel_configs (__name__ unavailable at target-discovery stage)", metric)
+		assert.Contains(t, metricRelabelSection, metric,
+			"rename rule for %s must be in metric_relabel_configs (post-scrape stage)", metric)
+	}
+
+	assert.NotContains(t, relabelSection, "__name__",
+		"relabel_configs must not reference __name__ (unavailable at target-discovery stage)")
+}
+
+func extractSection(content, startMarker, endMarker string) string {
+	startIdx := strings.Index(content, startMarker)
+	if startIdx == -1 {
+		return ""
+	}
+	endIdx := strings.Index(content[startIdx:], endMarker)
+	if endIdx == -1 {
+		return content[startIdx:]
+	}
+	return content[startIdx : startIdx+endIdx]
+}

--- a/internal/controller/services/monitoring/resources/opentelemetry-collector.tmpl.yaml
+++ b/internal/controller/services/monitoring/resources/opentelemetry-collector.tmpl.yaml
@@ -85,6 +85,13 @@ spec:
                   source_labels: [__meta_kubernetes_pod_node_name]
                   target_label: node
                 - action: replace
+                  source_labels: [__meta_kubernetes_pod_label_app]
+                  target_label: component
+                - action: replace
+                  replacement: 'rhoai-accelerator-metrics'
+                  target_label: job
+              metric_relabel_configs:
+                - action: replace
                   regex: 'DCGM_FI_DEV_GPU_TEMP'
                   replacement: 'nvidia_gpu_temperature_celsius'
                   source_labels: [__name__]
@@ -124,23 +131,13 @@ spec:
                   replacement: 'nvidia_gpu_memory_clock_mhz'
                   source_labels: [__name__]
                   target_label: __name__
-                - action: replace
-                  source_labels: [__meta_kubernetes_pod_label_app]
-                  target_label: component
-                - action: replace
-                  replacement: 'rhoai-accelerator-metrics'
-                  target_label: job
-              metric_relabel_configs:
-                - source_labels: [__name__]
-                  regex: 'DCGM_FI_DEV_GPU_UTIL|DCGM_FI_DEV_MEM_COPY_UTIL'
-                  action: drop
                 # Convert DCGM percentage metrics to ratios (0-1 scale) for OCP compatibility
                 - source_labels: [__name__]
                   regex: 'nvidia_gpu_(utilization|memory_utilization)_ratio'
                   target_label: __tmp_scale_needed
                   replacement: 'true'
                 - source_labels: [__name__]
-                  regex: '(nvidia_gpu_temperature_celsius|nvidia_gpu_utilization_ratio|nvidia_gpu_memory_utilization_ratio|nvidia_gpu_memory_used_bytes|nvidia_gpu_memory_free_bytes|nvidia_gpu_power_usage_watts|nvidia_gpu_sm_clock_mhz|nvidia_gpu_memory_clock_mhz|DCGM_FI_DEV_GPU_TEMP|DCGM_FI_DEV_FB_USED|DCGM_FI_DEV_FB_FREE|DCGM_FI_DEV_POWER_USAGE|DCGM_FI_DEV_SM_CLOCK|DCGM_FI_DEV_MEM_CLOCK)'
+                  regex: '(nvidia_gpu_temperature_celsius|nvidia_gpu_utilization_ratio|nvidia_gpu_memory_utilization_ratio|nvidia_gpu_memory_used_bytes|nvidia_gpu_memory_free_bytes|nvidia_gpu_power_usage_watts|nvidia_gpu_sm_clock_mhz|nvidia_gpu_memory_clock_mhz)'
                   action: keep
               scrape_interval: 30s
               scrape_timeout: 10s


### PR DESCRIPTION
<!---
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->
DCGM GPU metric rename rules using __name__ were placed in relabel_configs (pre-scrape target-discovery stage) where __name__ is not available. The renames never fired, and metric_relabel_configs then unconditionally dropped DCGM_FI_DEV_GPU_UTIL and DCGM_FI_DEV_MEM_COPY_UTIL, leaving GPU utilization permanently empty on the AI Observability Dashboard.

Moves all 8 rename rules into metric_relabel_configs before the drop rule so renames execute at the correct post-scrape stage.

Jira: https://redhat.atlassian.net/browse/RHOAIENG-79543
<!-- For RHOAI PRs, request review on #ai-core-platform-requests Slack channel -->

## Release tracking
<!-- Optional. Set a target release only if this PR must ship in a specific release; it will be prioritized accordingly. -->
<!-- Target release for this PR, e.g. rhoai-3.6 or rhoai-3.7ea1 -->
Release: 
<!-- Required only if a Release is set above. Full link to a jira ticket, e.g. https://redhat.atlassian.net/browse/RHOAIENG-XXXXX -->
Jira:


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit test TestDCGMRenameRulesInMetricRelabelConfigs validates that all DCGM rename rules are in metric_relabel_configs and no __name__ references remain in relabel_configs
Verified on a live RHOAI 3.4.3 cluster (OCP 4.20):
Confirmed the bug: rename rules in relabel_configs (wrong stage) in the deployed OTel collector CR
Ran fixed operator locally (make run-nowebhook), confirmed rename rules moved to metric_relabel_configs before the drop rule in the deployed CR
## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully
- [ ] New RELATED_IMAGE mappings are listed in ODH-Build-Config and RHOAI-Build-Config (CI validates names against build-config repos). Include links to build-config PRs in the description.

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->
Bug is a static YAML template structure issue (metric rename rules in the wrong Prometheus relabeling stage). Unit test validates rule placement at the template level. E2E test would only verify the same YAML structure on a deployed CR, not runtime metric flow, which requires GPU hardware unavailable in CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected accelerator metrics labeling for more consistent monitoring and dashboarding.
  * Ensured metric renaming rules are applied during metric processing.
  * Improved target discovery relabeling to avoid invalid metric-name references.
  * Standardized accelerator metrics with consistent component and job labels.
  * Refined accelerator metric filtering to retain the intended renamed NVIDIA metrics.

* **Tests**
  * Added coverage to verify monitoring relabeling behavior, configuration placement, and generated output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->