### PR TITLE
RHOAIENG-81871: dynamically discover RELATED_IMAGE_ODH_MOD_ARCH_* env vars

### DIFF
--- a/internal/controller/modules/dashboard/handler_test.go
+++ b/internal/controller/modules/dashboard/handler_test.go
@@ -229,6 +229,21 @@ func TestBuildModuleCR_NilDSCReturnsError(t *testing.T) {
 
 func TestGetOperatorManifests(t *testing.T) {
 	g := NewWithT(t)
+
+	modArchVars := []string{
+		"RELATED_IMAGE_ODH_MOD_ARCH_MODEL_REGISTRY_IMAGE",
+		"RELATED_IMAGE_ODH_MOD_ARCH_GEN_AI_IMAGE",
+		"RELATED_IMAGE_ODH_MOD_ARCH_MLFLOW_IMAGE",
+		"RELATED_IMAGE_ODH_MOD_ARCH_MAAS_IMAGE",
+		"RELATED_IMAGE_ODH_MOD_ARCH_EVAL_HUB_IMAGE",
+		"RELATED_IMAGE_ODH_MOD_ARCH_AUTOML_IMAGE",
+		"RELATED_IMAGE_ODH_MOD_ARCH_AUTORAG_IMAGE",
+		"RELATED_IMAGE_ODH_MOD_ARCH_AGENT_OPS_IMAGE",
+	}
+	for _, v := range modArchVars {
+		t.Setenv(v, "")
+	}
+
 	h := dashboard.NewHandler()
 	platform := &modules.PlatformContext{
 		ApplicationsNamespace: "opendatahub",
@@ -266,24 +281,42 @@ func TestGetControllerImage(t *testing.T) {
 
 func TestGetRelatedImages(t *testing.T) {
 	g := NewWithT(t)
-	h := dashboard.NewHandler()
-	images := h.GetRelatedImages()
 
-	g.Expect(images).Should(ConsistOf(
-		"RELATED_IMAGE_ODH_DASHBOARD_IMAGE",
+	modArchVars := []string{
 		"RELATED_IMAGE_ODH_MOD_ARCH_MODEL_REGISTRY_IMAGE",
 		"RELATED_IMAGE_ODH_MOD_ARCH_GEN_AI_IMAGE",
 		"RELATED_IMAGE_ODH_MOD_ARCH_MLFLOW_IMAGE",
 		"RELATED_IMAGE_ODH_MOD_ARCH_MAAS_IMAGE",
 		"RELATED_IMAGE_ODH_MOD_ARCH_EVAL_HUB_IMAGE",
-		"RELATED_IMAGE_ODH_KUBE_RBAC_PROXY_IMAGE",
-		"RELATED_IMAGE_ODH_MODEL_REGISTRY_JOB_ASYNC_UPLOAD_IMAGE",
 		"RELATED_IMAGE_ODH_MOD_ARCH_AUTOML_IMAGE",
-		"RELATED_IMAGE_ODH_AUTOML_IMAGE",
 		"RELATED_IMAGE_ODH_MOD_ARCH_AUTORAG_IMAGE",
 		"RELATED_IMAGE_ODH_MOD_ARCH_AGENT_OPS_IMAGE",
+	}
+	for _, v := range modArchVars {
+		t.Setenv(v, "test-image:latest")
+	}
+
+	h := dashboard.NewHandler()
+	images := h.GetRelatedImages()
+
+	g.Expect(images).Should(ContainElements(
+		"RELATED_IMAGE_ODH_DASHBOARD_IMAGE",
+		"RELATED_IMAGE_ODH_KUBE_RBAC_PROXY_IMAGE",
+		"RELATED_IMAGE_ODH_MODEL_REGISTRY_JOB_ASYNC_UPLOAD_IMAGE",
+		"RELATED_IMAGE_ODH_AUTOML_IMAGE",
 		"RELATED_IMAGE_ODH_AUTORAG_IMAGE",
 		"RELATED_IMAGE_ODH_CORE_BFF_IMAGE",
 		"RELATED_IMAGE_POSTGRESQL_16_IMAGE",
 	))
+	for _, v := range modArchVars {
+		g.Expect(images).Should(ContainElement(v))
+	}
+}
+
+func TestGetRelatedImages_DiscoversFutureModules(t *testing.T) {
+	g := NewWithT(t)
+	t.Setenv("RELATED_IMAGE_ODH_MOD_ARCH_FUTURE_MODULE_IMAGE", "future:v1")
+	h := dashboard.NewHandler()
+	images := h.GetRelatedImages()
+	g.Expect(images).Should(ContainElement("RELATED_IMAGE_ODH_MOD_ARCH_FUTURE_MODULE_IMAGE"))
 }

--- a/internal/controller/modules/dashboard/handler_test.go
+++ b/internal/controller/modules/dashboard/handler_test.go
@@ -243,6 +243,14 @@ func TestGetOperatorManifests(t *testing.T) {
 	for _, v := range modArchVars {
 		t.Setenv(v, "")
 	}
+	moduleAuxVars := []string{
+		"RELATED_IMAGE_ODH_AUTOML_IMAGE",
+		"RELATED_IMAGE_ODH_AUTORAG_IMAGE",
+		"RELATED_IMAGE_ODH_MODEL_REGISTRY_JOB_ASYNC_UPLOAD_IMAGE",
+	}
+	for _, v := range moduleAuxVars {
+		t.Setenv(v, "")
+	}
 
 	h := dashboard.NewHandler()
 	platform := &modules.PlatformContext{
@@ -295,6 +303,14 @@ func TestGetRelatedImages(t *testing.T) {
 	for _, v := range modArchVars {
 		t.Setenv(v, "test-image:latest")
 	}
+	moduleAuxVars := []string{
+		"RELATED_IMAGE_ODH_AUTOML_IMAGE",
+		"RELATED_IMAGE_ODH_AUTORAG_IMAGE",
+		"RELATED_IMAGE_ODH_MODEL_REGISTRY_JOB_ASYNC_UPLOAD_IMAGE",
+	}
+	for _, v := range moduleAuxVars {
+		t.Setenv(v, "test-image:latest")
+	}
 
 	h := dashboard.NewHandler()
 	images := h.GetRelatedImages()
@@ -302,13 +318,13 @@ func TestGetRelatedImages(t *testing.T) {
 	g.Expect(images).Should(ContainElements(
 		"RELATED_IMAGE_ODH_DASHBOARD_IMAGE",
 		"RELATED_IMAGE_ODH_KUBE_RBAC_PROXY_IMAGE",
-		"RELATED_IMAGE_ODH_MODEL_REGISTRY_JOB_ASYNC_UPLOAD_IMAGE",
-		"RELATED_IMAGE_ODH_AUTOML_IMAGE",
-		"RELATED_IMAGE_ODH_AUTORAG_IMAGE",
 		"RELATED_IMAGE_ODH_CORE_BFF_IMAGE",
 		"RELATED_IMAGE_POSTGRESQL_16_IMAGE",
 	))
 	for _, v := range modArchVars {
+		g.Expect(images).Should(ContainElement(v))
+	}
+	for _, v := range moduleAuxVars {
 		g.Expect(images).Should(ContainElement(v))
 	}
 }
@@ -319,4 +335,18 @@ func TestGetRelatedImages_DiscoversFutureModules(t *testing.T) {
 	h := dashboard.NewHandler()
 	images := h.GetRelatedImages()
 	g.Expect(images).Should(ContainElement("RELATED_IMAGE_ODH_MOD_ARCH_FUTURE_MODULE_IMAGE"))
+}
+
+func TestGetRelatedImages_DiscoversAuxiliaryModuleImages(t *testing.T) {
+	g := NewWithT(t)
+	t.Setenv("RELATED_IMAGE_ODH_AUTOML_SOME_NEW_IMAGE", "automl-aux:v1")
+	t.Setenv("RELATED_IMAGE_ODH_AUTORAG_SOME_NEW_IMAGE", "autorag-aux:v1")
+	t.Setenv("RELATED_IMAGE_ODH_MODEL_REGISTRY_JOB_NEW_IMAGE", "mr-job:v1")
+	h := dashboard.NewHandler()
+	images := h.GetRelatedImages()
+	g.Expect(images).Should(ContainElements(
+		"RELATED_IMAGE_ODH_AUTOML_SOME_NEW_IMAGE",
+		"RELATED_IMAGE_ODH_AUTORAG_SOME_NEW_IMAGE",
+		"RELATED_IMAGE_ODH_MODEL_REGISTRY_JOB_NEW_IMAGE",
+	))
 }

--- a/internal/controller/modules/dashboard/support.go
+++ b/internal/controller/modules/dashboard/support.go
@@ -6,32 +6,41 @@ import (
 	"strings"
 )
 
-const relatedImageModArchPrefix = "RELATED_IMAGE_ODH_MOD_ARCH_"
-
-// coreRelatedImages lists RELATED_IMAGE_* env vars that are NOT module-arch
-// images but are still needed by the dashboard-operator.
+// coreRelatedImages lists RELATED_IMAGE_* env vars for core dashboard
+// infrastructure that is always deployed regardless of which modules are enabled.
 var coreRelatedImages = []string{
 	"RELATED_IMAGE_ODH_DASHBOARD_IMAGE",
 	"RELATED_IMAGE_ODH_KUBE_RBAC_PROXY_IMAGE",
-	"RELATED_IMAGE_ODH_MODEL_REGISTRY_JOB_ASYNC_UPLOAD_IMAGE",
-	"RELATED_IMAGE_ODH_AUTOML_IMAGE",
-	"RELATED_IMAGE_ODH_AUTORAG_IMAGE",
 	"RELATED_IMAGE_ODH_CORE_BFF_IMAGE",
 	"RELATED_IMAGE_POSTGRESQL_16_IMAGE",
 }
 
+// moduleImagePrefixes lists env var prefixes for module-specific images.
+// RELATED_IMAGE_ODH_MOD_ARCH_* covers module UI sidecar images. The remaining
+// prefixes cover auxiliary module images (pipeline runtimes, job images) that
+// predate the MOD_ARCH naming convention.
+var moduleImagePrefixes = []string{
+	"RELATED_IMAGE_ODH_MOD_ARCH_",
+	"RELATED_IMAGE_ODH_AUTOML_",
+	"RELATED_IMAGE_ODH_AUTORAG_",
+	"RELATED_IMAGE_ODH_MODEL_REGISTRY_JOB_",
+}
+
 // relatedImages returns RELATED_IMAGE_* environment variables required by the
-// dashboard-operator Deployment. Module-arch images (RELATED_IMAGE_ODH_MOD_ARCH_*)
-// are discovered dynamically from the process environment so that new modules
-// are forwarded automatically without code changes here.
+// dashboard-operator Deployment. Core images are always included. Module images
+// are discovered dynamically from the process environment by prefix matching so
+// that new modules are forwarded automatically without code changes here.
 func relatedImages() []string {
 	result := make([]string, 0, len(coreRelatedImages)+8)
 	result = append(result, coreRelatedImages...)
 
 	for _, env := range os.Environ() {
 		name, _, _ := strings.Cut(env, "=")
-		if strings.HasPrefix(name, relatedImageModArchPrefix) {
-			result = append(result, name)
+		for _, prefix := range moduleImagePrefixes {
+			if strings.HasPrefix(name, prefix) {
+				result = append(result, name)
+				break
+			}
 		}
 	}
 

--- a/internal/controller/modules/dashboard/support.go
+++ b/internal/controller/modules/dashboard/support.go
@@ -1,26 +1,42 @@
 package dashboard
 
+import (
+	"os"
+	"sort"
+	"strings"
+)
+
+const relatedImageModArchPrefix = "RELATED_IMAGE_ODH_MOD_ARCH_"
+
+// coreRelatedImages lists RELATED_IMAGE_* env vars that are NOT module-arch
+// images but are still needed by the dashboard-operator.
+var coreRelatedImages = []string{
+	"RELATED_IMAGE_ODH_DASHBOARD_IMAGE",
+	"RELATED_IMAGE_ODH_KUBE_RBAC_PROXY_IMAGE",
+	"RELATED_IMAGE_ODH_MODEL_REGISTRY_JOB_ASYNC_UPLOAD_IMAGE",
+	"RELATED_IMAGE_ODH_AUTOML_IMAGE",
+	"RELATED_IMAGE_ODH_AUTORAG_IMAGE",
+	"RELATED_IMAGE_ODH_CORE_BFF_IMAGE",
+	"RELATED_IMAGE_POSTGRESQL_16_IMAGE",
+}
+
 // relatedImages returns RELATED_IMAGE_* environment variables required by the
-// dashboard-operator Deployment. Values are sourced from the former in-tree
-// component handler imagesMap.
+// dashboard-operator Deployment. Module-arch images (RELATED_IMAGE_ODH_MOD_ARCH_*)
+// are discovered dynamically from the process environment so that new modules
+// are forwarded automatically without code changes here.
 func relatedImages() []string {
-	return []string{
-		"RELATED_IMAGE_ODH_DASHBOARD_IMAGE",
-		"RELATED_IMAGE_ODH_MOD_ARCH_MODEL_REGISTRY_IMAGE",
-		"RELATED_IMAGE_ODH_MOD_ARCH_GEN_AI_IMAGE",
-		"RELATED_IMAGE_ODH_MOD_ARCH_MLFLOW_IMAGE",
-		"RELATED_IMAGE_ODH_MOD_ARCH_MAAS_IMAGE",
-		"RELATED_IMAGE_ODH_MOD_ARCH_EVAL_HUB_IMAGE",
-		"RELATED_IMAGE_ODH_KUBE_RBAC_PROXY_IMAGE",
-		"RELATED_IMAGE_ODH_MODEL_REGISTRY_JOB_ASYNC_UPLOAD_IMAGE",
-		"RELATED_IMAGE_ODH_MOD_ARCH_AUTOML_IMAGE",
-		"RELATED_IMAGE_ODH_AUTOML_IMAGE",
-		"RELATED_IMAGE_ODH_MOD_ARCH_AUTORAG_IMAGE",
-		"RELATED_IMAGE_ODH_MOD_ARCH_AGENT_OPS_IMAGE",
-		"RELATED_IMAGE_ODH_AUTORAG_IMAGE",
-		"RELATED_IMAGE_ODH_CORE_BFF_IMAGE",
-		"RELATED_IMAGE_POSTGRESQL_16_IMAGE",
+	result := make([]string, 0, len(coreRelatedImages)+8)
+	result = append(result, coreRelatedImages...)
+
+	for _, env := range os.Environ() {
+		name, _, _ := strings.Cut(env, "=")
+		if strings.HasPrefix(name, relatedImageModArchPrefix) {
+			result = append(result, name)
+		}
 	}
+
+	sort.Strings(result)
+	return result
 }
 
 // emptyRelatedImageValues returns a Helm values map that overrides the chart's


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-81871

## Summary

- Replace the hardcoded module-arch entries in `relatedImages()` with dynamic discovery via `os.Environ()` prefix matching for `RELATED_IMAGE_ODH_MOD_ARCH_*`
- New dashboard modules are automatically forwarded to the dashboard-operator without code changes here — only the Konflux nudge pipeline needs to inject the new image digest
- Core (non-module) `RELATED_IMAGE` entries remain explicit in `coreRelatedImages`

Companion to https://github.com/opendatahub-io/odh-dashboard/pull/9395 which simplifies module onboarding in the dashboard-operator.

## How Has This Been Tested?

- `go test ./internal/controller/modules/dashboard/... -count=1` — all 18 tests pass
- `TestGetRelatedImages` updated to set env vars via `t.Setenv` before testing
- `TestGetOperatorManifests` updated to set mod arch env vars so `relatedImages()` discovers them

## Test Impact

- Added `TestGetRelatedImages_DiscoversFutureModules` — sets a hypothetical future env var (`RELATED_IMAGE_ODH_MOD_ARCH_FUTURE_MODULE_IMAGE`) and verifies it is discovered
- Updated existing tests to use `t.Setenv` for env var setup (required now that discovery is dynamic)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Related image lists now automatically include configured images for existing and newly introduced modules, including auxiliary services.
  * Image discovery supports future architecture variants without requiring additional updates.
  * Image results are returned in a consistent sorted order.
  * Manifest and Helm value generation now handles module image configuration more reliably across supported module types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->