### PR TITLE
RHOAIENG 85499 syncPlatformCR

### DIFF
--- a/internal/controller/components/modelregistry/modelregistry.go
+++ b/internal/controller/components/modelregistry/modelregistry.go
@@ -10,6 +10,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/opendatahub-io/opendatahub-operator/v2/api/common"
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/api/components/v1alpha1"
@@ -48,14 +49,7 @@ func (s *componentHandler) Init(_ common.Platform, cfg operatorconfig.OperatorSe
 }
 
 func (s *componentHandler) NewCRObject(ctx context.Context, cli client.Client, dsc *dscv2.DataScienceCluster) (common.PlatformObject, error) {
-	commonSpec := dsc.Spec.Components.ModelRegistry.ModelRegistryCommonSpec
-	gatewayDomain, err := resources.GetGatewayDomain(ctx, cli)
-	if err != nil {
-		return nil, fmt.Errorf(
-			"gateway domain is missing for ModelRegistry; the Data Science Gateway may not be ready yet—check that "+
-				"GatewayConfig exists and its status reports a domain: %w", err)
-	}
-	return &componentApi.ModelRegistry{
+	cr := componentApi.ModelRegistry{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       componentApi.ModelRegistryKind,
 			APIVersion: componentApi.GroupVersion.String(),
@@ -67,10 +61,32 @@ func (s *componentHandler) NewCRObject(ctx context.Context, cli client.Client, d
 			},
 		},
 		Spec: componentApi.ModelRegistrySpec{
-			ModelRegistryCommonSpec: commonSpec,
-			Gateway:                 &common.GatewaySpec{Domain: gatewayDomain},
+			ModelRegistryCommonSpec: dsc.Spec.Components.ModelRegistry.ModelRegistryCommonSpec,
 		},
-	}, nil
+	}
+
+	gatewayDomain, err := resources.GetGatewayDomain(ctx, cli)
+	switch err {
+	case nil:
+		cr.Spec.Gateway = &common.GatewaySpec{Domain: gatewayDomain}
+	default:
+		// Intentionally do not fail CR creation when the gateway domain is unavailable.
+		// The DSC controller is allowed to create the ModelRegistry CR first, and the
+		// missing gateway projection is validated later by the API/server-side schema
+		// or by the component controller on a subsequent reconcile.
+		//
+		// In fact NewCRObject should never fail and the durable fix belongs to the
+		// framework's error handling, not in this component:
+		//
+		//   https://github.com/opendatahub-io/odh-platform-utilities/framework
+		//
+		logf.FromContext(ctx).Info(
+			"GatewayConfig domain not available yet",
+			"error", err,
+		)
+	}
+
+	return &cr, nil
 }
 
 func (s *componentHandler) IsEnabled(dsc *dscv2.DataScienceCluster) bool {

--- a/internal/controller/components/modelregistry/modelregistry_test.go
+++ b/internal/controller/components/modelregistry/modelregistry_test.go
@@ -54,37 +54,40 @@ func TestNewCRObject(t *testing.T) {
 		jq.Match(`.kind == "%s"`, componentApi.ModelRegistryKind),
 		jq.Match(`.apiVersion == "%s"`, componentApi.GroupVersion),
 		jq.Match(`.metadata.annotations["%s"] == "%s"`, annotations.ManagementStateAnnotation, operatorv1.Managed),
+		jq.Match(`.spec.gateway.domain == "%s"`, gatewayConfig.Status.Domain),
 	)))
 }
 
-func TestNewCRObject_ReturnsError_WhenGatewayDomainMissing(t *testing.T) {
+func TestNewCRObject_ToleratesMissingGatewayDomain(t *testing.T) {
 	handler := &componentHandler{}
-	g := NewWithT(t)
 	dsc := createDSCWithModelRegistry(operatorv1.Managed)
 
-	t.Run("returns error when GatewayConfig does not exist", func(t *testing.T) {
+	t.Run("returns CR when GatewayConfig does not exist", func(t *testing.T) {
+		g := NewWithT(t)
 		cl, err := fakeclient.New()
 		g.Expect(err).To(Succeed())
 
 		cr, err := handler.NewCRObject(context.Background(), cl, dsc)
-		g.Expect(err).To(HaveOccurred())
-		g.Expect(cr).To(BeNil())
-		g.Expect(err.Error()).To(ContainSubstring("gateway domain is missing for ModelRegistry"))
-		g.Expect(err.Error()).To(ContainSubstring("GatewayConfig"))
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(cr).ToNot(BeNil())
+		mr, ok := cr.(*componentApi.ModelRegistry)
+		g.Expect(ok).To(BeTrue())
+		g.Expect(mr.Spec.Gateway).To(BeNil())
 	})
 
-	t.Run("returns error when GatewayConfig exists but Status.Domain is empty", func(t *testing.T) {
+	t.Run("returns CR when GatewayConfig exists but Status.Domain is empty", func(t *testing.T) {
+		g := NewWithT(t)
 		gatewayConfig := &serviceApi.GatewayConfig{}
 		gatewayConfig.SetName(serviceApi.GatewayConfigName)
-		// Status.Domain left empty
 		cl, err := fakeclient.New(fakeclient.WithObjects(gatewayConfig))
 		g.Expect(err).To(Succeed())
 
 		cr, err := handler.NewCRObject(context.Background(), cl, dsc)
-		g.Expect(err).To(HaveOccurred())
-		g.Expect(cr).To(BeNil())
-		g.Expect(err.Error()).To(ContainSubstring("gateway domain is missing for ModelRegistry"))
-		g.Expect(err.Error()).To(ContainSubstring("GatewayConfig"))
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(cr).ToNot(BeNil())
+		mr, ok := cr.(*componentApi.ModelRegistry)
+		g.Expect(ok).To(BeTrue())
+		g.Expect(mr.Spec.Gateway).To(BeNil())
 	})
 }
 

--- a/internal/controller/datasciencecluster/datasciencecluster_integration_test.go
+++ b/internal/controller/datasciencecluster/datasciencecluster_integration_test.go
@@ -1,0 +1,158 @@
+//go:build integration
+
+package datasciencecluster_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	operatorv1 "github.com/openshift/api/operator/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/config"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	"github.com/opendatahub-io/opendatahub-operator/v2/api/common"
+	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/api/components/v1alpha1"
+	dscv2 "github.com/opendatahub-io/opendatahub-operator/v2/api/datasciencecluster/v2"
+	dsciv2 "github.com/opendatahub-io/opendatahub-operator/v2/api/dscinitialization/v2"
+	serviceApi "github.com/opendatahub-io/opendatahub-operator/v2/api/services/v1alpha1"
+	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/components/modelregistry"
+	cr "github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/components/registry"
+	dscctrl "github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/datasciencecluster"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/dag"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/envt"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/matchers/jq"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/testf"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestModelRegistryBootstrapWithEmptyGatewayDomain(t *testing.T) {
+	g := NewWithT(t)
+	g.DurationBundle.EventuallyTimeout = 30 * time.Second
+	g.DurationBundle.EventuallyPollingInterval = 200 * time.Millisecond
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	if cr.DefaultRegistry().Lookup(componentApi.ModelRegistryComponentName) == nil {
+		cr.Add(modelregistry.NewHandler(), cr.WithRunlevel(dag.RL(20)))
+	}
+
+	et, err := envt.New(
+		envt.WithManager(ctrl.Options{
+			Controller: config.Controller{SkipNameValidation: new(true)},
+		}),
+		envt.WithRegisterControllers(func(mgr manager.Manager) error {
+			return dscctrl.NewDataScienceClusterReconciler(ctx, mgr)
+		}),
+	)
+	g.Expect(err).ToNot(HaveOccurred())
+	t.Cleanup(func() { _ = et.Stop() })
+
+	go func() {
+		_ = et.Manager().Start(ctx)
+	}()
+
+	g.Eventually(func() bool {
+		return et.Manager().GetCache().WaitForCacheSync(ctx)
+	}).Should(BeTrue())
+
+	dsci := newDSCIForBootstrapTest()
+	gwc := newGatewayConfigForBootstrapTest()
+	dsc := newDSCForBootstrapTest()
+
+	g.Expect(et.Client().Create(ctx, dsci)).To(Succeed())
+	g.Expect(et.Client().Create(ctx, gwc)).To(Succeed())
+	g.Expect(et.Client().Create(ctx, dsc)).To(Succeed())
+
+	tc, err := testf.NewTestContext(
+		testf.WithClient(et.Client()),
+		testf.WithContext(ctx),
+		testf.WithTOptions(
+			testf.WithEventuallyTimeout(30*time.Second),
+			testf.WithEventuallyPollingInterval(200*time.Millisecond),
+		),
+	)
+	g.Expect(err).ToNot(HaveOccurred())
+	tf := tc.NewWithT(t)
+
+	modelRegistryNN := types.NamespacedName{Name: componentApi.ModelRegistryInstanceName}
+	modelRegistryGVK := componentApi.GroupVersion.WithKind(componentApi.ModelRegistryKind)
+
+	tf.Get(modelRegistryGVK, modelRegistryNN).
+		Eventually().
+		ShouldNot(BeNil())
+
+	tf.Get(modelRegistryGVK, modelRegistryNN).
+		Eventually().
+		Should(jq.Match(`.spec.gateway == null`))
+
+	tf.UpdateStatus(
+		serviceApi.GroupVersion.WithKind(serviceApi.GatewayConfigKind),
+		types.NamespacedName{Name: serviceApi.GatewayConfigName},
+		testf.Transform(`.status.domain = "apps.example.com"`),
+	).Eventually().Should(Succeed())
+
+	tf.Get(modelRegistryGVK, modelRegistryNN).
+		Eventually().
+		Should(jq.Match(`.spec.gateway.domain == "apps.example.com"`))
+}
+
+func newDSCIForBootstrapTest() *dsciv2.DSCInitialization {
+	return &dsciv2.DSCInitialization{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "DSCInitialization",
+			APIVersion: dsciv2.GroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "bootstrap-dsci",
+		},
+		Spec: dsciv2.DSCInitializationSpec{
+			ApplicationsNamespace: "opendatahub",
+			Monitoring: serviceApi.DSCIMonitoring{
+				ManagementSpec: common.ManagementSpec{
+					ManagementState: operatorv1.Removed,
+				},
+				MonitoringCommonSpec: serviceApi.MonitoringCommonSpec{
+					Namespace: "opendatahub",
+				},
+			},
+		},
+	}
+}
+
+func newGatewayConfigForBootstrapTest() *serviceApi.GatewayConfig {
+	return &serviceApi.GatewayConfig{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       serviceApi.GatewayConfigKind,
+			APIVersion: serviceApi.GroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: serviceApi.GatewayConfigName,
+		},
+	}
+}
+
+func newDSCForBootstrapTest() *dscv2.DataScienceCluster {
+	return &dscv2.DataScienceCluster{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "DataScienceCluster",
+			APIVersion: dscv2.GroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "bootstrap-dsc",
+		},
+		Spec: dscv2.DataScienceClusterSpec{
+			Components: dscv2.Components{
+				ModelRegistry: componentApi.DSCModelRegistry{
+					ManagementSpec: common.ManagementSpec{
+						ManagementState: operatorv1.Managed,
+					},
+				},
+			},
+		},
+	}
+}

--- a/pkg/utils/test/testf/testf_witht.go
+++ b/pkg/utils/test/testf/testf_witht.go
@@ -365,6 +365,60 @@ func (t *WithT) Update(
 	}
 }
 
+// UpdateStatus performs a status subresource update on the specified Kubernetes resource,
+// applying a function to mutate the object before issuing Status().Update.
+//
+// Parameters:
+//   - gvk (schema.GroupVersionKind): The GroupVersionKind of the resource to update.
+//   - nn (types.NamespacedName): The namespace and name of the resource to update.
+//   - fn (func): A function that modifies the resource before the status update.
+//   - option (...client.SubResourceUpdateOption): Optional client options for the status update operation.
+//
+// Returns:
+//   - *EventuallyValue[*unstructured.Unstructured]: The eventually available resource wrapped in an EventuallyValue,
+//     which can be used with Gomega assertions to test the updated resource.
+func (t *WithT) UpdateStatus(
+	gvk schema.GroupVersionKind,
+	nn types.NamespacedName,
+	fn func(obj *unstructured.Unstructured) error,
+	option ...client.SubResourceUpdateOption,
+) *EventuallyValue[*unstructured.Unstructured] {
+	return &EventuallyValue[*unstructured.Unstructured]{
+		ctx: t.Context(),
+		g:   t.WithT,
+		f: func(ctx context.Context) (*unstructured.Unstructured, error) {
+			u := resources.GvkToUnstructured(gvk)
+
+			err := t.Client().Get(ctx, nn, u)
+			switch {
+			case k8serr.IsNotFound(err):
+				return nil, nil
+			case err != nil:
+				return nil, StopErr(err, "failed to get resource for status update: %s, nn: %s", gvk, nn.String())
+			}
+
+			in, err := resources.ToUnstructured(u)
+			if err != nil {
+				return nil, StopErr(err, "failed to convert to unstructured")
+			}
+
+			if err := fn(in); err != nil {
+				return nil, StopErr(err, "failed to apply function")
+			}
+
+			err = t.Client().Status().Update(ctx, in, option...)
+			switch {
+			case k8serr.IsForbidden(err):
+				return nil, StopErr(err, "failed to update status for resource: %s, nn: %s", gvk, nn.String())
+			case err != nil:
+				return nil, err
+			default:
+				return in, nil
+			}
+		},
+	}
+}
+
 // Patch performs a patch operation on an existing Kubernetes resource, applying a function to mutate the resource
 // before patching. Unlike CreateOrPatch, this will fail if the resource doesn't exist.
 // The result is wrapped in an EventuallyValue, which can be used in Gomega assertions.

--- a/pkg/utils/test/testf/testf_witht_test.go
+++ b/pkg/utils/test/testf/testf_witht_test.go
@@ -12,11 +12,14 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	clientfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
+	serviceApi "github.com/opendatahub-io/opendatahub-operator/v2/api/services/v1alpha1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/resources"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/fakeclient"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/matchers/jq"
+	testscheme "github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/scheme"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/testf"
 
 	. "github.com/onsi/gomega"
@@ -325,6 +328,86 @@ func TestUpdate(t *testing.T) {
 
 		v := wt.Update(gvk.ConfigMap, key, transformer).Consistently().WithTimeout(1 * time.Second).Should(Succeed())
 		g.Expect(v).Should(matchMetadataAndData)
+	})
+}
+
+func TestUpdateStatus(t *testing.T) {
+	g := NewWithT(t)
+
+	s, err := testscheme.New()
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	setup := func(t *testing.T) (*testf.WithT, client.Client, client.ObjectKey, types.GomegaMatcher, testf.TransformFn) {
+		t.Helper()
+
+		gatewayConfig := &serviceApi.GatewayConfig{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: serviceApi.GroupVersion.String(),
+				Kind:       serviceApi.GatewayConfigKind,
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: serviceApi.GatewayConfigName,
+			},
+		}
+
+		cl := clientfake.NewClientBuilder().
+			WithScheme(s).
+			WithStatusSubresource(&serviceApi.GatewayConfig{}).
+			WithObjects(gatewayConfig).
+			Build()
+
+		tc, err := testf.NewTestContext(testf.WithClient(cl))
+		g.Expect(err).ShouldNot(HaveOccurred())
+
+		return tc.NewWithT(t),
+			cl,
+			client.ObjectKeyFromObject(gatewayConfig),
+			jq.Match(`.status.domain == "apps.example.com"`),
+			testf.Transform(`.status.domain = "apps.example.com"`)
+	}
+
+	t.Run("Get", func(t *testing.T) {
+		wt, cl, key, matcher, transformer := setup(t)
+
+		v, err := wt.UpdateStatus(gvk.GatewayConfig, key, transformer).Get()
+
+		g.Expect(err).ShouldNot(HaveOccurred())
+		g.Expect(v).Should(matcher)
+
+		fetched := &serviceApi.GatewayConfig{}
+		g.Expect(cl.Get(t.Context(), key, fetched)).Should(Succeed())
+
+		value, err := resources.ToUnstructured(fetched)
+		g.Expect(err).ShouldNot(HaveOccurred())
+		g.Expect(value).Should(matcher)
+	})
+
+	t.Run("Eventually", func(t *testing.T) {
+		wt, cl, key, matcher, transformer := setup(t)
+
+		v := wt.UpdateStatus(gvk.GatewayConfig, key, transformer).Eventually().Should(matcher)
+		g.Expect(v).Should(matcher)
+
+		fetched := &serviceApi.GatewayConfig{}
+		g.Expect(cl.Get(t.Context(), key, fetched)).Should(Succeed())
+
+		value, err := resources.ToUnstructured(fetched)
+		g.Expect(err).ShouldNot(HaveOccurred())
+		g.Expect(value).Should(matcher)
+	})
+
+	t.Run("Eventually Succeed", func(t *testing.T) {
+		wt, cl, key, matcher, transformer := setup(t)
+
+		v := wt.UpdateStatus(gvk.GatewayConfig, key, transformer).Eventually().Should(Succeed())
+		g.Expect(v).Should(matcher)
+
+		fetched := &serviceApi.GatewayConfig{}
+		g.Expect(cl.Get(t.Context(), key, fetched)).Should(Succeed())
+
+		value, err := resources.ToUnstructured(fetched)
+		g.Expect(err).ShouldNot(HaveOccurred())
+		g.Expect(value).Should(matcher)
 	})
 }
 


### PR DESCRIPTION
- **fix(modelregistry): tolerate missing gateway domain during bootstrap**

Ref https://redhat.atlassian.net/browse/RHOAIENG-85499
Requires https://github.com/opendatahub-io/opendatahub-operator/pull/3993
Will be supersed by https://github.com/opendatahub-io/opendatahub-operator/pull/4000

<!---
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

<!-- For RHOAI PRs, request review on #ai-core-platform-requests Slack channel -->

## Release tracking
<!-- Optional. Set a target release only if this PR must ship in a specific release; it will be prioritized accordingly. -->
<!-- Target release for this PR, e.g. rhoai-3.6 or rhoai-3.7ea1 -->
Release: 
<!-- Required only if a Release is set above. Full link to a jira ticket, e.g. https://redhat.atlassian.net/browse/RHOAIENG-XXXXX -->
Jira:


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully
- [ ] New RELATED_IMAGE mappings are listed in ODH-Build-Config and RHOAI-Build-Config (CI validates names against build-config repos). Include links to build-config PRs in the description.

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [X] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->

Added an integration tests covering the changes, e2e tests are not yet possible due to the current e2e architecture as this would require to turn off the GatewayConfig controller which is not possible 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Model Registry resources can now be created when the gateway domain is unavailable or empty, without blocking initialization.
  - Gateway configuration is applied automatically once a domain becomes available.
  - Existing Model Registry deployments can now complete startup successfully while gateway configuration is still being established.

- **Tests**
  - Added coverage for Model Registry initialization with missing gateway domains.
  - Added integration coverage verifying gateway configuration updates propagate correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->