### PR TITLE
fix: remove stale RELATED_IMAGE_ODH_TRAINING_OPERATOR_IMAGE exception

### DIFF
--- a/component-params-env.yaml
+++ b/component-params-env.yaml
@@ -49,9 +49,6 @@ known_issues:
 odh_exceptions:
 - image: RELATED_IMAGE_ODH_VLLM_CPU_IMAGE
   reason: ppc64le/s390x only, not applicable to ODH
-- image: RELATED_IMAGE_ODH_TRAINING_OPERATOR_IMAGE
-  jira: https://redhat.atlassian.net/browse/RHOAIENG-78350
-  reason: it must be offboarded in rhoai 3.6, already offboarded in ODH-Build-Config
 - image: RELATED_IMAGE_RHAII_MODEL_OPT_CUDA_IMAGE
   reason: RHOAI-only image, not applicable to ODH
 - image: RELATED_IMAGE_RHAII_VLLM_CUDA_IMAGE


### PR DESCRIPTION
## Description

Removes the stale `RELATED_IMAGE_ODH_TRAINING_OPERATOR_IMAGE` exception from `component-params-env.yaml`.

The TrainingOperator v1 handler was removed in #3868, so the image is no longer referenced in the codebase. The ODH exception entry became stale and `validate-related-images` flags it as an error.

Ref: [RHOAIENG-78348](https://redhat.atlassian.net/browse/RHOAIENG-78348)

## How Has This Been Tested?

- `make validate-related-images` passes locally
- `grep -r TRAINING_OPERATOR` returns zero matches

[RHOAIENG-78348]: https://redhat.atlassian.net/browse/RHOAIENG-78348?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Known Issues**
  * Documented validation and software inventory metadata issues affecting vLLM Omni CUDA images.

* **Chores**
  * Removed an outdated training operator image exception from the environment configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->