### PR TITLE
RHOAIENG-61022: stop setting deploymentMode on Dashboard CR

### DIFF
--- a/internal/controller/modules/dashboard/handler.go
+++ b/internal/controller/modules/dashboard/handler.go
@@ -23,10 +23,6 @@ const (
 	// crName must match dashboard-operator CRD CEL (default-dashboard); see odh-dashboard#8093.
 	crName = componentApi.DashboardInstanceName
 
-	// deploymentModeStandalone signals the dashboard-operator that the platform operator
-	// manages its lifecycle. Must match the dashboard-operator's expected deploymentMode values.
-	deploymentModeStandalone = "Standalone"
-
 	// dashboardAIPipelinesName is the key used in the Dashboard CR components map for
 	// AI Pipelines. Keep in sync with dashboard-operator's component name for DSP.
 	dashboardAIPipelinesName = "aipipelines"
@@ -106,8 +102,6 @@ func (h *handler) BuildModuleCR(
 	if ns := resolveModelRegistryNamespace(dscCtx); ns != "" {
 		spec["modelRegistryNamespace"] = ns
 	}
-
-	spec["deploymentMode"] = deploymentModeStandalone
 
 	if cfg != nil && cfg.GatewayDomain != "" {
 		spec["gateway"] = map[string]any{

--- a/internal/controller/modules/dashboard/handler_test.go
+++ b/internal/controller/modules/dashboard/handler_test.go
@@ -134,7 +134,6 @@ func TestBuildModuleCR_BasicProjection(t *testing.T) {
 	spec, ok := u.Object["spec"].(map[string]any)
 	g.Expect(ok).Should(BeTrue(), "spec is not a map")
 	g.Expect(spec["managementState"]).Should(Equal("Managed"))
-	g.Expect(spec["deploymentMode"]).Should(Equal("Standalone"))
 
 	gateway, ok := spec["gateway"].(map[string]any)
 	g.Expect(ok).Should(BeTrue(), "spec.gateway missing")


### PR DESCRIPTION
## Description

Fixes https://redhat.atlassian.net/browse/RHOAIENG-88550

Remove the hardcoded `spec["deploymentMode"] = "Standalone"` from `BuildModuleCR` in the dashboard handler and its corresponding test assertion.

The dashboard-operator has removed the `deploymentMode` CRD field entirely ([odh-dashboard#9392](https://github.com/opendatahub-io/odh-dashboard/pull/9392)). Sidecar deployment mode was deprecated and fully removed — standalone is now the only deployment mode, making the field unnecessary. Without this change, the operator would set an unrecognized field on the Dashboard CR once the CRD update lands.

| File | Change |
|------|--------|
| `internal/controller/modules/dashboard/handler.go` | Remove `spec["deploymentMode"] = "Standalone"` from `BuildModuleCR` |
| `internal/controller/modules/dashboard/handler_test.go` | Remove `g.Expect(spec["deploymentMode"]).Should(Equal("Standalone"))` assertion |

## Release tracking

Release: rhoai-3.6
Jira: https://redhat.atlassian.net/browse/RHOAIENG-61022
Fixes: https://redhat.atlassian.net/browse/RHOAIENG-88550

## How Has This Been Tested?

- Existing unit tests pass (the only test change is removing the `deploymentMode` assertion)
- Dashboard CR created by the operator no longer includes `spec.deploymentMode`
- Verified on an ODH cluster: deployed the updated dashboard-operator alongside the new dashboard CRD — operator reconciles successfully, all 9 modules deployed, Dashboard CR healthy

## Merge criteria

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully
- [ ] New RELATED_IMAGE mappings are listed in ODH-Build-Config and RHOAI-Build-Config (CI validates names against build-config repos). Include links to build-config PRs in the description.

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification

This PR is a non-functional refactoring with existing test coverage. It removes a single line that sets a now-removed CRD field (`deploymentMode`) and its corresponding unit test assertion. No new feature, API change, or behavioral change is introduced — the operator simply stops writing a field that the downstream CRD no longer defines. Existing E2E tests already validate Dashboard CR creation and reconciliation without depending on the `deploymentMode` field.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dashboard configuration validation when required context or configuration is unavailable.
  * Corrected namespace projection for notebooks and model registry across deployment types and custom configurations.
  * Normalized component management states for more consistent dashboard behavior.
  * Removed the standalone deployment mode setting from generated dashboard configuration.

* **Tests**
  * Expanded coverage for namespace projection, fallback behavior, and missing-context error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->