### PR TITLE
feat(dsc): convert reconciliation error logs to structured KV pairs (RHAI-524)

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -31,115 +31,397 @@ spec:
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 100
-            podAffinityTerm:
-              labelSelector:
-                matchExpressions:
-                - key: name
-                  operator: In
-                  values:
-                  - opendatahub-operator
-              topologyKey: kubernetes.io/hostname
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                    - key: name
+                      operator: In
+                      values:
+                        - opendatahub-operator
+                topologyKey: kubernetes.io/hostname
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
-            - matchExpressions:
-              - key: kubernetes.io/os
-                operator: In
-                values:
-                - linux
+              - matchExpressions:
+                  - key: kubernetes.io/os
+                    operator: In
+                    values:
+                      - linux
       securityContext:
         runAsNonRoot: true
         seccompProfile:
           type: RuntimeDefault
       initContainers:
-      - name: copy-manifests
-        # NOTE: image is provided in CI by pullspec substitution, and by make/kustomize for local builds
-        image: REPLACE_IMAGE:v0.0.0-placeholder
-        imagePullPolicy: Always
-        command: ["cp", "-r", "/opt/manifests-template/.", "/opt/manifests/"]
-        securityContext:
-          allowPrivilegeEscalation: false
-          readOnlyRootFilesystem: true
-          capabilities:
-            drop:
-              - "ALL"
-        resources:
-          requests:
-            cpu: 10m
-            memory: 64Mi
-          limits:
-            cpu: 100m
-            memory: 256Mi
-        volumeMounts:
-        - name: manifests
-          mountPath: /opt/manifests
+        - name: copy-manifests
+          # NOTE: image is provided in CI by pullspec substitution, and by make/kustomize for local builds
+          image: REPLACE_IMAGE:v0.0.0-placeholder
+          imagePullPolicy: Always
+          command: ["cp", "-r", "/opt/manifests-template/.", "/opt/manifests/"]
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - "ALL"
+          resources:
+            requests:
+              cpu: 10m
+              memory: 64Mi
+            limits:
+              cpu: 100m
+              memory: 256Mi
+          volumeMounts:
+            - name: manifests
+              mountPath: /opt/manifests
       containers:
-      - command:
-        - /manager
-        env:
-          - name: DISABLE_DSC_CONFIG
-            value: 'true'
-          - name: OPERATOR_NAMESPACE
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.namespace
-          - name: DEFAULT_MANIFESTS_PATH
-            value: /opt/manifests
-          - name: DEFAULT_CHARTS_PATH
-            value: /opt/charts
-          - name: ODH_PLATFORM_TYPE
-            value: OpenDataHub
-        args:
-        - --leader-elect
-        - --operator-name=opendatahub
-        # NOTE: image is provided in CI by pullspec substitution, and by make/kustomize for local builds
-        image: REPLACE_IMAGE:v0.0.0-placeholder
-        imagePullPolicy: Always
-        name: manager
-        ports:
-          - containerPort: 8443
-            protocol: TCP
-            name: https
-        securityContext:
-          allowPrivilegeEscalation: false
-          readOnlyRootFilesystem: true
-          capabilities:
-            drop:
-              - "ALL"
-        livenessProbe:
-          httpGet:
-            path: /healthz
-            port: 8081
-          initialDelaySeconds: 15
-          periodSeconds: 20
-        readinessProbe:
-          httpGet:
-            path: /readyz
-            port: 8081
-          initialDelaySeconds: 5
-          periodSeconds: 10
-        # TODO(user): Configure the resources accordingly based on the project requirements.
-        # More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-        resources:
-          limits:
-            cpu: 1000m
-            memory: 4Gi
-          requests:
-            cpu: 100m
-            memory: 780Mi
-        volumeMounts:
-        - name: manifests
-          mountPath: /opt/manifests
-        - name: tmp
-          mountPath: /tmp
+        - command:
+            - /manager
+          env:
+            - name: DISABLE_DSC_CONFIG
+              value: 'true'
+            - name: OPERATOR_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: DEFAULT_MANIFESTS_PATH
+              value: /opt/manifests
+            - name: DEFAULT_CHARTS_PATH
+              value: /opt/charts
+            - name: ODH_PLATFORM_TYPE
+              value: OpenDataHub
+            - name: RELATED_IMAGE_ODH_MCP_LIFECYCLE_MODULE_OPERATOR_IMAGE
+              value: quay.io/opendatahub/odh-mcp-lifecycle-module-operator@sha256:c776af1a7eceec0ced119aef26176f6f4ffe718e392e599e6f39c7edb6b6d99b
+            - name: RELATED_IMAGE_ODH_KSERVE_LLMISVC_CONTROLLER_IMAGE
+              value: quay.io/opendatahub/odh-kserve-llmisvc-controller@sha256:79a1f6dbc8b30c152b02dd78cef539b640ee187dd78a85470dc37c784186794c
+            - name: RELATED_IMAGE_ODH_KSERVE_LOCALMODEL_CONTROLLER_IMAGE
+              value: quay.io/opendatahub/odh-kserve-localmodel-controller@sha256:6b6ec4e927bba71e12ac07b3c34f63be18cfcce74984edc30afd3847577b4d33
+            - name: RELATED_IMAGE_ODH_MCP_LIFECYCLE_OPERATOR_IMAGE
+              value: quay.io/opendatahub/odh-mcp-lifecycle-operator@sha256:c6175040319cf88604b528efd817df04b63c55301fc2d659163a9d35e04ce32c
+            - name: RELATED_IMAGE_ODH_FEAST_OPERATOR_IMAGE
+              value: quay.io/opendatahub/feast-operator@sha256:0d821aeaadcd326c1320fa4f81ab8a4b05706dac9bac9c6f03dd4098fe22f4a6
+            - name: RELATED_IMAGE_ODH_MOD_ARCH_MLFLOW_IMAGE
+              value: quay.io/opendatahub/odh-mod-arch-mlflow@sha256:95c95bba8a51f6664d939fdaaacd238714b6e2dbbb99e1f0e037e6beca93c86b
+            - name: RELATED_IMAGE_ODH_MOD_ARCH_MODEL_REGISTRY_IMAGE
+              value: quay.io/opendatahub/odh-mod-arch-modular-architecture@sha256:e287d811eb4a9c52ff06782d02a32e669724a625e3cf49c6f6c1a7f8745ac62b
+            - name: RELATED_IMAGE_ODH_WORKBENCH_JUPYTER_PYTORCH_ROCM_PY312_IMAGE
+              value: quay.io/opendatahub/odh-workbench-jupyter-pytorch-rocm-py312-ubi9@sha256:eeeb6679d49bfa8c828c8255048749aaa04cf4aec566fd8fa7a6b485cd8fd699
+            - name: RELATED_IMAGE_ODH_KSERVE_AGENT_IMAGE
+              value: quay.io/opendatahub/kserve-agent@sha256:648f80fbcec3f6879f8ca58942e3b38831cfb14bd7feeb029a41935cc92566e6
+            - name: RELATED_IMAGE_ODH_MOD_ARCH_AGENT_OPS_IMAGE
+              value: quay.io/opendatahub/odh-mod-arch-agent-ops@sha256:6c6699be8a958630f0a45fb33f99fa128525f4f0f9afa4d08899280bc087ec6f
+            - name: RELATED_IMAGE_ODH_TRAINING_ROCM62_TORCH25_PY311_IMAGE
+              value: quay.io/opendatahub/odh-training-rocm62-torch25-py311@sha256:e6534273238e207dd583a8f7f21802588af9d2faba27ee4878725cd8158d59e6
+            - name: RELATED_IMAGE_ODH_TRUSTYAI_VLLM_ORCHESTRATOR_GATEWAY_IMAGE
+              value: quay.io/opendatahub/vllm-orchestrator-gateway@sha256:10789a3f024d520078e4d813d06fa1d0297d4cd4af87a2d271c44c132d8e39f2
+            - name: RELATED_IMAGE_ODH_TRUSTYAI_MODULE_OPERATOR_IMAGE
+              value: quay.io/opendatahub/odh-trustyai-module-operator@sha256:6063b3814f0b9fd61e5c9ea81835bdcd82ed37212cb7ad80afd858f2b7b6adaa
+            - name: RELATED_IMAGE_ODH_AUTHBRIDGE_PROXY_IMAGE
+              value: quay.io/opendatahub/odh-authbridge-proxy@sha256:315486763a88668daab872fe5ec3d0f228ab21cc310190622d6ece0043927d28
+            - name: RELATED_IMAGE_ODH_TRUSTYAI_RAGAS_LLS_PROVIDER_DSP_IMAGE
+              value: quay.io/opendatahub/llama-stack-provider-ragas@sha256:fa46ce6a3dd16b0eb8e06c71f99b761d742599e569ed91f7b727149bc1085520
+            - name: RELATED_IMAGE_ODH_AI_GATEWAY_PAYLOAD_PROCESSING_E2E_IMAGE
+              value: quay.io/opendatahub/ai-gateway-payload-processing-e2e@sha256:5decb883e3855cdd2470774f932c694aa799147952be37f1b524a1b557aeccc9
+            - name: RELATED_IMAGE_ODH_GUARDRAILS_DETECTOR_HUGGINGFACE_RUNTIME_IMAGE
+              value: quay.io/opendatahub/guardrails-detector-huggingface-runtime@sha256:5771760caed7344e76a55ecc5d91a847583df24cede511638e081ee12e670f31
+            - name: RELATED_IMAGE_ODH_LLM_D_ROUTER_DISAGG_SIDECAR_IMAGE
+              value: quay.io/opendatahub/odh-llm-d-router-disagg-sidecar@sha256:0713abaf87c2671e2e1da101ae2c76c3b692eb5f45da57816f83b07923f2fdc5
+            - name: RELATED_IMAGE_ODH_MLSERVER_IMAGE
+              value: quay.io/opendatahub/mlserver@sha256:46d73618db58195ef886dfab00dbf94dcddd035c1e6100fcb1629b17eb9eb9cf
+            - name: RELATED_IMAGE_ODH_ML_PIPELINES_LAUNCHER_IMAGE
+              value: quay.io/opendatahub/ds-pipelines-launcher@sha256:06126748fbb9edb66dc2dfd06ce027042723db0ba70bbb0d287f2fca58afdebe
+            - name: RELATED_IMAGE_ODH_TH_TORCH_CPU_PY312_IMAGE
+              value: quay.io/opendatahub/odh-th-torch-cpu-py312@sha256:e4b3b231435d247980a4ee406c524d1813552e4af50936c5fad22c86da6b5617
+            - name: RELATED_IMAGE_ODH_TRUSTYAI_GARAK_LLS_PROVIDER_DSP_IMAGE
+              value: quay.io/opendatahub/odh-trustyai-garak-lls-provider-dsp@sha256:89f298c570cf34c27503dbbda16fc0aae27931d533f9fd1ab3d5cebce486a984
+            - name: RELATED_IMAGE_ODH_WORKBENCH_JUPYTER_TENSORFLOW_ROCM_PY312_IMAGE
+              value: quay.io/opendatahub/odh-workbench-jupyter-tensorflow-rocm-py312-ubi9@sha256:711384a40da98b17236bede9467d348ac759dad371f803ac9e8f7ca4fac88c20
+            - name: RELATED_IMAGE_ODH_KSERVE_LOCALMODELNODE_AGENT_IMAGE
+              value: quay.io/opendatahub/odh-kserve-localmodelnode-agent@sha256:9c840accd39328f4f9b59e331c3f037bd4d84e55068e929d0a2e49775b8a0ff7
+            - name: RELATED_IMAGE_ODH_LLM_D_BATCH_GATEWAY_OPERATOR_IMAGE
+              value: quay.io/opendatahub/odh-batch-gateway-operator@sha256:6f8a26ca43445c424caa87f5c24fa79effbe248a8ee73ce903109bca1e07b49c
+            - name: RELATED_IMAGE_ODH_WORKBENCH_JUPYTER_PYTORCH_CUDA_PY312_IMAGE
+              value: quay.io/opendatahub/odh-workbench-jupyter-pytorch-cuda-py312-ubi9@sha256:b53876c1b37b35c90b1a6a5b7de5a46b1901089f38e3b544b14a7160941b3f29
+            - name: RELATED_IMAGE_ODH_DATA_SCIENCE_PIPELINES_OPERATOR_CONTROLLER_IMAGE
+              value: quay.io/opendatahub/data-science-pipelines-operator@sha256:c23ab7a171ef22e50f51adf24db352e8b59d22500c465af43f568c6487056fb7
+            - name: RELATED_IMAGE_ODH_EVAL_HUB_IMAGE
+              value: quay.io/opendatahub/odh-eval-hub@sha256:0ca74ba7939e2c5968d4288616e39907bab4a5b1e34183eb3502a44da9c89069
+            - name: RELATED_IMAGE_ODH_PIPELINE_RUNTIME_DATASCIENCE_CPU_PY312_IMAGE
+              value: quay.io/opendatahub/odh-pipeline-runtime-datascience-cpu-py312-ubi9@sha256:4b37a384792270677790ef164fdc17231b7ca4c253bdffd5e6f6c4003709aac2
+            - name: RELATED_IMAGE_ODH_TRUSTYAI_SERVICE_PY_IMAGE
+              value: quay.io/opendatahub/odh-trustyai-service-py@sha256:7de3a0b9f324ed628a3230bbcca8e50596023dc9fe44ed5387e0b7517aad9f05
+            - name: RELATED_IMAGE_ODH_MODELEXPRESS_OPERATOR_IMAGE
+              value: quay.io/opendatahub/odh-modelexpress-operator@sha256:f3e88b0b36b87e1e813be55cb9130409095c07c95c9023ecc81d3c78bddda7b3
+            - name: RELATED_IMAGE_ODH_FEAST_MODULE_OPERATOR_IMAGE
+              value: quay.io/opendatahub/odh-feast-module-operator@sha256:1773978c69784f4ef4680af8b9d52329dfca0614cca0a4cc85ab019f6149dffd
+            - name: RELATED_IMAGE_ODH_DATA_CONNECT_HUB_REST_IMAGE
+              value: quay.io/opendatahub/odh-data-connect-hub-rest@sha256:f88851df1568e90a99b77317e176578170b25f9b94f801b038cb47390d9fe42c
+            - name: RELATED_IMAGE_ODH_NOTEBOOK_CONTROLLER_IMAGE
+              value: quay.io/opendatahub/odh-notebook-controller@sha256:385105f352b98db88609e8293e32ea2537af0071c8c2472a8c86a1dd553b04b0
+            - name: RELATED_IMAGE_ODH_WORKBENCH_JUPYTER_MINIMAL_CUDA_PY312_IMAGE
+              value: quay.io/opendatahub/odh-workbench-jupyter-minimal-cuda-py312-ubi9@sha256:14252923cb6ac3f01a1d9dac002661e46a16970e1be08f7631ab4f71be7c3c49
+            - name: RELATED_IMAGE_ODH_SPARK_OPERATOR_IMAGE
+              value: quay.io/opendatahub/spark-operator@sha256:892a59cb55fe852ef7f2456d0779857be095724109a8cba4bca3990da9f91e30
+            - name: RELATED_IMAGE_ODH_KSERVE_CONTROLLER_IMAGE
+              value: quay.io/opendatahub/kserve-controller@sha256:31f2bbdd207dd2397fa4a3589b324903f02a9e6adea260e5ca60b44c917d992f
+            - name: RELATED_IMAGE_ODH_RHAII_CLUSTER_VALIDATOR_IMAGE
+              value: quay.io/opendatahub/odh-rhaii-cluster-validator@sha256:683b44ac6828fc67d86bda17de62cafa557a9bfc96cd0a16d56148451516aba1
+            - name: RELATED_IMAGE_ODH_RHOAI_MCP_IMAGE
+              value: quay.io/opendatahub/odh-rhoai-mcp@sha256:764f6c5dfae3021800454af9dae29b1207f87672612a89f94c4efb11e68a060e
+            - name: RELATED_IMAGE_ODH_WORKBENCH_JUPYTER_MINIMAL_CPU_PY312_IMAGE
+              value: quay.io/opendatahub/odh-workbench-jupyter-minimal-cpu-py312-ubi9@sha256:7fb1a2a3a060cd714ef5f4a09f449203e8b8d496fa7a3088472e624533579b86
+            - name: RELATED_IMAGE_ODH_MODELEXPRESS_IMAGE
+              value: quay.io/opendatahub/odh-modelexpress@sha256:8ff23004591259c0b444b5be5a31002a82f3f66dbf69ac8b73306c9335f87154
+            - name: RELATED_IMAGE_ODH_WORKLOAD_VARIANT_AUTOSCALER_CONTROLLER_IMAGE
+              value: quay.io/opendatahub/workload-variant-autoscaler@sha256:613fda9061f41621e17ba68be413f81f00a93a294883bdcbd3f60b59a4a40c10
+            - name: RELATED_IMAGE_ODH_TH_TORCH_ROCM_PY312_IMAGE
+              value: quay.io/opendatahub/odh-th-torch-rocm-py312@sha256:81b85d17da03b2842951a6fb65f5c4b3ac83cf882c90c1c686efba3d6eee53bc
+            - name: RELATED_IMAGE_ODH_MODEL_CONTROLLER_IMAGE
+              value: quay.io/opendatahub/odh-model-controller@sha256:b934f80aa65a5abf23417b8451c95e9997bcd6b5f8fefcc16172ade3b59ae94b
+            - name: RELATED_IMAGE_ODH_KSERVE_MODULE_OPERATOR_IMAGE
+              value: quay.io/opendatahub/odh-kserve-module-operator@sha256:882642f0528997822a08b993dbf6dce16b1a236c31b6e6470a73dab9a90e1142
+            - name: RELATED_IMAGE_ODH_PIPELINE_RUNTIME_TENSORFLOW_ROCM_PY312_IMAGE
+              value: quay.io/opendatahub/odh-pipeline-runtime-tensorflow-rocm-py312-ubi9@sha256:9c4a07d96e29808f2ce0f81364278ec8925f9affa3e0c334cb90025abe541a14
+            - name: RELATED_IMAGE_ODH_WORKBENCH_CODESERVER_DATASCIENCE_CPU_PY312_IMAGE
+              value: quay.io/opendatahub/odh-workbench-codeserver-datascience-cpu-py312-ubi9@sha256:b477db79794d8048a7057df4a5ee4b1df59bf638e81b28d993e704c696ac846d
+            - name: RELATED_IMAGE_ODH_MLFLOW_OPERATOR_IMAGE
+              value: quay.io/opendatahub/mlflow-operator@sha256:3c0794857be5f12b09be0482caeeadd01c0f560176524351d08675030c5d8769
+            - name: RELATED_IMAGE_ODH_ML_PIPELINES_DRIVER_IMAGE
+              value: quay.io/opendatahub/ds-pipelines-driver@sha256:41d67a3bd1e25a69569ffff58e9cf490370627e0e0666b27519fe6ec926d63b3
+            - name: RELATED_IMAGE_ODH_MODEL_REGISTRY_JOB_ASYNC_UPLOAD_IMAGE
+              value: quay.io/opendatahub/model-registry-job-async-upload@sha256:0ac8998a0a6b7fb459d0d4efa7b9f78e65bf648f9afbe54a7f78d78085f80ed8
+            - name: RELATED_IMAGE_ODH_TRAINING_OPERATOR_IMAGE
+              value: quay.io/opendatahub/training-operator@sha256:b76dc7605a25188610fa6208a4fdde65825c9069fc48c03beee204ce1481ce68
+            - name: RELATED_IMAGE_ODH_KUBE_AUTH_PROXY_IMAGE
+              value: quay.io/opendatahub/odh-kube-auth-proxy@sha256:7972ebb9203a2c07447ec4f683c27e9ff6385fc04a4518ddd71c6ef710c81e11
+            - name: RELATED_IMAGE_ODH_PIPELINE_RUNTIME_TENSORFLOW_CUDA_PY312_IMAGE
+              value: quay.io/opendatahub/odh-pipeline-runtime-tensorflow-cuda-py312-ubi9@sha256:9e7807e97e58e9ab865465fb1c2a1640f7e6ca4c5d63ec76f6991ea513d82281
+            - name: RELATED_IMAGE_ODH_WORKBENCH_JUPYTER_PYTORCH_LLMCOMPRESSOR_CUDA_PY312_IMAGE
+              value: quay.io/opendatahub/odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-ubi9@sha256:0f2bcd9ee5e5c5ab84569a6faff2f2321e507399b1a5e54318298b0a3fb85fc2
+            - name: RELATED_IMAGE_ODH_LLM_D_BATCH_GATEWAY_GC_IMAGE
+              value: quay.io/opendatahub/odh-llm-d-batch-gateway-gc@sha256:377b78656ef593e11d38f9c9d40c215854d09d09050d1bdd6a1f035ed4b2da4e
+            - name: RELATED_IMAGE_ODH_ML_PIPELINES_API_SERVER_V2_IMAGE
+              value: quay.io/opendatahub/ds-pipelines-api-server@sha256:03d8bc359764a62bdb0471eb98477d484a1076dbef9a7be763be35a88a9ca8d3
+            - name: RELATED_IMAGE_ODH_MODEL_METADATA_COLLECTION_IMAGE
+              value: quay.io/opendatahub/odh-model-metadata-collection@sha256:6b9b77e5be4e750c22b90ebe59cd8b916f9d99744823f461263e0dd981a4a429
+            - name: RELATED_IMAGE_ODH_RAY_MODULE_OPERATOR_IMAGE
+              value: quay.io/opendatahub/odh-ray-module-operator@sha256:edaa5e7119373c62b01c5bb145ac27b14575b46b1a8bd8a02975fdbae7a0cea4
+            - name: RELATED_IMAGE_ODH_PRAXIS_EXTPROC_IMAGE
+              value: quay.io/opendatahub/odh-praxis-extproc@sha256:9d03207463efe99dcc2b4286cc30a47169c05ea338b1b678d77d90c80e136046
+            - name: RELATED_IMAGE_ODH_KSERVE_ROUTER_IMAGE
+              value: quay.io/opendatahub/kserve-router@sha256:7c2f618b8d88a25974c5d284af7bee62ecef0c0a700b695a396ec2740c634ec6
+            - name: RELATED_IMAGE_ODH_MLSERVER_CUDA_IMAGE
+              value: quay.io/opendatahub/odh-mlserver-cuda@sha256:b1f9e0db08f4060919408ec4295231b70f8291b60cb8bafd8c69b4ce380bf3c9
+            - name: RELATED_IMAGE_ODH_MOD_ARCH_GEN_AI_IMAGE
+              value: quay.io/opendatahub/odh-mod-arch-gen-ai@sha256:93655d1e624402dc2abee8840c6c3b5ae82944de49642e5616935363b871e75a
+            - name: RELATED_IMAGE_ODH_MOD_ARCH_MAAS_IMAGE
+              value: quay.io/opendatahub/mod-arch-maas@sha256:b60a9134b0290c7c3b35dd2a33fb71a6535aaf8200b493cc71ad3dcccf668801
+            - name: RELATED_IMAGE_ODH_OBSERVABILITY_IMAGE
+              value: quay.io/opendatahub/odh-observability@sha256:9d6ff20e6323e634d8c0ed5d1da4c8b2a8b82d2dd248f2bdba0d59c86abb2cd6
+            - name: RELATED_IMAGE_ODH_MOD_ARCH_NOTEBOOKS_IMAGE
+              value: quay.io/opendatahub/odh-mod-arch-notebooks@sha256:d16650de3a49009a5940fafe3b0aff05222d206c09ca5c919212f9c6ac2db7cc
+            - name: RELATED_IMAGE_ODH_PIPELINE_RUNTIME_BASELINE_CPU_PY312_C9S_IMAGE
+              value: quay.io/opendatahub/odh-pipeline-runtime-baseline-cpu-py312-c9s@sha256:63ab42297591d3872b58be7236bcf4b94e55673b06eac2350873e813c44a9b4d
+            - name: RELATED_IMAGE_ODH_BUILT_IN_DETECTOR_IMAGE
+              value: quay.io/opendatahub/odh-built-in-detector@sha256:8541cf4c8c2568c25810913e5c8613845dbd3473b3c253c1b117797575a5db81
+            - name: RELATED_IMAGE_ODH_LATENCY_PREDICTOR_TRAINING_IMAGE
+              value: quay.io/opendatahub/odh-latency-predictor-training@sha256:c38bba00eb5154771f10577e8de697583889871aef78fd865d0fc47ff14115ce
+            - name: RELATED_IMAGE_ODH_LLM_D_ASYNC_IMAGE
+              value: quay.io/opendatahub/odh-llm-d-async@sha256:890fbdf0b1778df03602a8ddd075627f60629cb90b016746320936506c03c391
+            - name: RELATED_IMAGE_ODH_MOD_ARCH_AUTORAG_IMAGE
+              value: quay.io/opendatahub/odh-mod-arch-autorag@sha256:47f9f144437c7bb951a8836fecf15ef9b523c35ebc97bf84ce446f8eba48da03
+            - name: RELATED_IMAGE_ODH_SPARK_OPERATOR_MODULE_IMAGE
+              value: quay.io/opendatahub/odh-spark-operator-module@sha256:ad11b0004889fc71e897fd67a5170209f58131d644d71b7649e66b21e3f9b2c6
+            - name: RELATED_IMAGE_ODH_TRAINING_CUDA121_TORCH24_PY311_IMAGE
+              value: quay.io/opendatahub/odh-training-cuda121-torch24-py311@sha256:977d67581ccaa35ce49263951e5c5af4f925b490bb4861aca7c5170a1b3b21d6
+            - name: RELATED_IMAGE_ODH_WORKBENCH_JUPYTER_TENSORFLOW_CUDA_PY312_IMAGE
+              value: quay.io/opendatahub/odh-workbench-jupyter-tensorflow-cuda-py312-ubi9@sha256:cb0a2f27d5cdb5402a449c712b7b10f24d45afc980c756bb29de0c314f477603
+            - name: RELATED_IMAGE_OSE_KUBE_RBAC_PROXY_IMAGE
+              value: quay.io/opendatahub/odh-kube-auth-proxy@sha256:7972ebb9203a2c07447ec4f683c27e9ff6385fc04a4518ddd71c6ef710c81e11
+            - name: RELATED_IMAGE_ODH_TRAINING_CUDA124_TORCH25_PY311_IMAGE
+              value: quay.io/opendatahub/odh-training-cuda124-torch25-py311@sha256:2664e8ac0af9ad44cc0906b108603b02fce72fdd82440668eda1a6719aa913de
+            - name: RELATED_IMAGE_ODH_AGENTS_OPERATOR_IMAGE
+              value: quay.io/opendatahub/odh-agents-operator@sha256:167c0f19d9a39ab7b9b3f80fac60fa77957d7ce00cb5867354d4f7ae51310002
+            - name: RELATED_IMAGE_ODH_LATENCY_PREDICTOR_TEST_IMAGE
+              value: quay.io/opendatahub/odh-latency-predictor-test@sha256:d7c0dbbbfa156e9b3608244d6ab5eead4570c7dac205a67631af292499c06d9f
+            - name: RELATED_IMAGE_ODH_AUTOML_IMAGE
+              value: quay.io/opendatahub/odh-automl@sha256:576ebd8cc4b5a3a83c56aed919e0208dd860ccee6334b5a97e7f02b2d1f7a472
+            - name: RELATED_IMAGE_ODH_FEATURE_SERVER_IMAGE
+              value: quay.io/opendatahub/feature-server@sha256:98672911c37cad76859d38c5ec3c8c26f62147bccaea33f2b4dfb7c50b2f0d40
+            - name: RELATED_IMAGE_ODH_MODEL_REGISTRY_IMAGE
+              value: quay.io/opendatahub/model-registry@sha256:8f7f825c31a65cdb66868530d9724d56298af86bbd728ed1979b7ae50bd8654e
+            - name: RELATED_IMAGE_ODH_PIPELINE_RUNTIME_PYTORCH_ROCM_PY312_IMAGE
+              value: quay.io/opendatahub/odh-pipeline-runtime-pytorch-rocm-py312-ubi9@sha256:f5d319f9a87126e13722edf66bcb800e7e47dca9d1cb14a07aa9635d68a24f2d
+            - name: RELATED_IMAGE_ODH_TH_TORCH_CUDA_PY312_IMAGE
+              value: quay.io/opendatahub/odh-th-torch-cuda-py312@sha256:7559044c3e8f5ee0aad03c034056f7086429f10b24496ae1b0170d0ab2a61675
+            - name: RELATED_IMAGE_ODH_WORKBENCH_JUPYTER_DATASCIENCE_CPU_PY312_IMAGE
+              value: quay.io/opendatahub/odh-workbench-jupyter-datascience-cpu-py312-ubi9@sha256:d07d06a04b0de04c3c9b23c6126c7494961225de0265f78a2fc3f3ea1b233265
+            - name: RELATED_IMAGE_ODH_AI_GATEWAY_OPERATOR_IMAGE
+              value: quay.io/opendatahub/odh-ai-gateway-operator@sha256:3cc096f14524c5860c4d3309c2cf2f486262b55a95a81e33e62958fc427f5823
+            - name: RELATED_IMAGE_ODH_FMS_GUARDRAILS_ORCHESTRATOR_IMAGE
+              value: quay.io/opendatahub/ta-guardrails-orchestrator@sha256:757f3c3e05fe0c40bcfa8d29d0511ddcaff640a38c4ee507696cf126009381b6
+            - name: RELATED_IMAGE_ODH_KSERVE_STORAGE_INITIALIZER_IMAGE
+              value: quay.io/opendatahub/kserve-storage-initializer@sha256:982b7a1260f750bc3e1b91ae233f43a64d5442ad2196b35a2cf291d40834c845
+            - name: RELATED_IMAGE_ODH_MLMD_GRPC_SERVER_IMAGE
+              value: quay.io/opendatahub/mlmd-grpc-server@sha256:9aea59acdd7b914b8e8e902f4b388ddf2871b1047e644dbd3c69cb2d4ef8de95
+            - name: RELATED_IMAGE_ODH_OGX_CORE_IMAGE
+              value: quay.io/opendatahub/odh-ogx-core@sha256:0d810da6ddad9d500036cab549e9fc885d00270a0caaab72cb9570f57ae81290
+            - name: RELATED_IMAGE_ODH_DATA_CONNECT_HUB_CONTROLLER_IMAGE
+              value: quay.io/opendatahub/odh-data-connect-hub-controller@sha256:d81a576d8178ae55a622cdc7176985e4f0fa3398bc8fb97de33fb7ad10cee74d
+            - name: RELATED_IMAGE_ODH_LATENCY_PREDICTOR_PREDICTION_IMAGE
+              value: quay.io/opendatahub/odh-latency-predictor-prediction@sha256:6a3cf044cab634bfe0b178686d654b9671e3f59cd904028ddd6d49cfd9815518
+            - name: RELATED_IMAGE_ODH_AI_GATEWAY_PAYLOAD_PROCESSING_IMAGE
+              value: quay.io/opendatahub/odh-ai-gateway-payload-processing@sha256:77af81889fb225a6ee15defd6b87620ae1d0b45b3bb7b15149aed12b5f6785da
+            - name: RELATED_IMAGE_ODH_KSERVE_AUTOGLUON_SERVER_IMAGE
+              value: quay.io/opendatahub/odh-kserve-autogluon-server@sha256:9eda8c09567b80522ee1022a020af2c3dba4bcbd69d758dad13c85ffb288a500
+            - name: RELATED_IMAGE_ODH_KUBE_RBAC_PROXY_IMAGE
+              value: quay.io/opendatahub/odh-kube-rbac-proxy@sha256:c19ed97828e4e5e736334b3ea340ba92a5d0c95f7b21080c6fd7ccf6d36836af
+            - name: RELATED_IMAGE_ODH_ML_PIPELINES_PERSISTENCEAGENT_V2_IMAGE
+              value: quay.io/opendatahub/ds-pipelines-persistenceagent@sha256:85643e0482dd74b5732c2fc559e3ef718aeaa86bf1c87eb0974b273271273b3d
+            - name: RELATED_IMAGE_ODH_OGX_MODULE_OPERATOR_IMAGE
+              value: quay.io/opendatahub/odh-ogx-module-operator@sha256:8de1113ab3550b4f57388a6d05dc66a2404fe3b4f674e1c81f323e1cacf00c49
+            - name: RELATED_IMAGE_ODH_OPENVINO_MODEL_SERVER_IMAGE
+              value: quay.io/opendatahub/openvino_model_server@sha256:aea6779e5fa366a33e02cf5f8c1937cb4ad5feeb18dae12b0619b2e775168da2
+            - name: RELATED_IMAGE_ODH_TRAINING_CUDA128_TORCH28_PY312_IMAGE
+              value: quay.io/opendatahub/odh-training-cuda128-torch28-py312-rhel9@sha256:e01435fb012a742b161ed9918ca70ac855db858a512c1f8ded7bc94b29c4e7b8
+            - name: RELATED_IMAGE_ODH_WORKBENCH_JUPYTER_TRUSTYAI_CPU_PY312_IMAGE
+              value: quay.io/opendatahub/odh-workbench-jupyter-trustyai-cpu-py312-ubi9@sha256:a64150a4f2d3ed2572662673d2c953ca9c5b50eb0967055d922086fa6a78131f
+            - name: RELATED_IMAGE_ODH_WORKBENCHES_OPERATOR_IMAGE
+              value: quay.io/opendatahub/odh-workbenches-operator@sha256:7a1526f8b72ee28bbb6c6a402c66cf48a568e8a656937821e0cc0b540fb2e05a
+            - name: RELATED_IMAGE_ODH_MCP_LIFECYCLE_OPERATOR_E2E_IMAGE
+              value: quay.io/opendatahub/odh-mcp-lifecycle-operator-e2e@sha256:5fc23c7ef085f7e69da15e08e2287664dd1d73b7d88afb9fa18604c2cd200711
+            - name: RELATED_IMAGE_ODH_TA_LMES_DRIVER_IMAGE
+              value: quay.io/opendatahub/ta-lmes-driver@sha256:cbc67ff9c904972b55c5bb7940370ca6c1c18cf96fdd21194f8c348fe30c3dfc
+            - name: RELATED_IMAGE_ODH_TRAINING_CUDA128_TORCH29_PY312_IMAGE
+              value: quay.io/opendatahub/odh-training-cuda128-torch29-py312@sha256:6601b6fea1a9d4fcd78700407232d02f24a9e647c510973e58b0b38eff29e07a
+            - name: RELATED_IMAGE_ODH_MOD_ARCH_EVAL_HUB_IMAGE
+              value: quay.io/opendatahub/odh-mod-arch-eval-hub@sha256:19c7071566d46b08797e27ea9933b86bd9035b21bd75e31f72854899c65add49
+            - name: RELATED_IMAGE_ODH_PIPELINE_RUNTIME_MINIMAL_CPU_PY312_IMAGE
+              value: quay.io/opendatahub/odh-pipeline-runtime-minimal-cpu-py312-ubi9@sha256:90af807da7677d65c5df0fb1af9283cdfc3902d2449d0b802c3423f7864fe9aa
+            - name: RELATED_IMAGE_ODH_TA_LMES_JOB_IMAGE
+              value: quay.io/opendatahub/ta-lmes-job@sha256:77261f82663adcef1a01e1d3bbef8c5765ca173614aa27aa8f475e7ded16d8e2
+            - name: RELATED_IMAGE_ODH_LLM_D_BATCH_GATEWAY_APISERVER_IMAGE
+              value: quay.io/opendatahub/odh-llm-d-batch-gateway-apiserver@sha256:434a79f3e654964aaa4dfa297f212c95e31dba9c70c04f98f9729beba70e5909
+            - name: RELATED_IMAGE_ODH_MODEL_SERVING_API_IMAGE
+              value: quay.io/opendatahub/odh-model-serving-api@sha256:68056fb178fff75c011bd621ce660b434cd0656d7a4d4a7952f56c5c3f68ac46
+            - name: RELATED_IMAGE_ODH_PIPELINE_RUNTIME_PYTORCH_CUDA_PY312_IMAGE
+              value: quay.io/opendatahub/odh-pipeline-runtime-pytorch-cuda-py312-ubi9@sha256:31a5506873568393c6c84f1e6733dc1795342c275261f26e36fa7a4c28fbf9ed
+            - name: RELATED_IMAGE_ODH_AUTORAG_IMAGE
+              value: quay.io/opendatahub/odh-autorag@sha256:8143dfed0c83b37afe21f2c1dac268f10d2225e90b9d6d3eef6f5d394efbba70
+            - name: RELATED_IMAGE_ODH_MAAS_API_IMAGE
+              value: quay.io/opendatahub/maas-api@sha256:dfdb18088434c4a1259d920ca80196aefb3487b7a582215f2fa0c8d4d33dfd24
+            - name: RELATED_IMAGE_ODH_MAAS_CONTROLLER_IMAGE
+              value: quay.io/opendatahub/maas-controller@sha256:84ebf72265c76ad7709fb5f5f4d9b0ba5667e905e7eb2164a7f4a73aab36a571
+            - name: RELATED_IMAGE_ODH_MOD_ARCH_AUTOML_IMAGE
+              value: quay.io/opendatahub/odh-mod-arch-automl@sha256:0cc35b62968b84271fc464d71e7efbb460c890b422364a897d40abf0e0a6f3ff
+            - name: RELATED_IMAGE_ODH_PIPELINES_COMPONENTS_IMAGE
+              value: quay.io/opendatahub/odh-pipelines-components@sha256:1848a28202f4dc4b1593a692c6f15ef68c74bed47b8b85a8447a466d6463bd21
+            - name: RELATED_IMAGE_ODH_OPENSHELL_CLI_IMAGE
+              value: quay.io/opendatahub/odh-openshell-cli@sha256:d1f15998050d6e2384aad140f4985ceb39b3b3c360c0136760b75e738d4a7747
+            - name: RELATED_IMAGE_ODH_OGX_K8S_OPERATOR_IMAGE
+              value: quay.io/opendatahub/odh-ogx-k8s-operator@sha256:f7c6b2e020f200929ffe66646f1db66639f1db64f60381e2a9c1cc4509f1d528
+            - name: RELATED_IMAGE_ODH_TRAINER_IMAGE
+              value: quay.io/opendatahub/trainer@sha256:78b974c11f2ba7631622db9b90d75f9f1e5764fb5bedfa2c3c6d6f084aa17a70
+            - name: RELATED_IMAGE_ODH_DASHBOARD_IMAGE
+              value: quay.io/opendatahub/odh-dashboard@sha256:3569a6cc53365beba89f371a4e4bace739b10de1b9909a80afca60adb37f78d1
+            - name: RELATED_IMAGE_ODH_RHAII_VALIDATOR_TOOLS_IMAGE
+              value: quay.io/opendatahub/odh-rhaii-validator-tools@sha256:2e98087c9d9972333801d41501cfc3bd16bd5401fae197039703249f3435cc64
+            - name: RELATED_IMAGE_ODH_TRUSTYAI_NEMO_GUARDRAILS_SERVER_IMAGE
+              value: quay.io/opendatahub/odh-trustyai-nemo-guardrails-server@sha256:2e6b7204bc62ccedf501cacd3ec8dacdfa6f593dd5af1d94b07972389dd3943e
+            - name: RELATED_IMAGE_ODH_DATA_CONNECT_HUB_FLIGHT_IMAGE
+              value: quay.io/opendatahub/odh-data-connect-hub-flight@sha256:09095caeb39f17c98228416883e73e115ba161053b58d2303d075f63478cfa3d
+            - name: RELATED_IMAGE_ODH_LLM_D_BATCH_GATEWAY_PROCESSOR_IMAGE
+              value: quay.io/opendatahub/odh-llm-d-batch-gateway-processor@sha256:8b72f67908981dcbfdc9f904ddaafcf4186e2e7fbe60dc1c1c6e97ad0ff0f7fb
+            - name: RELATED_IMAGE_ODH_TRAINING_ROCM62_TORCH24_PY311_IMAGE
+              value: quay.io/opendatahub/odh-training-rocm62-torch24-py311@sha256:742fbcdc20e6e7c5f0ec07e3fede4fb3d700abe716c11ff808355c9ec316c220
+            - name: RELATED_IMAGE_ODH_WORKBENCH_JUPYTER_MINIMAL_ROCM_PY312_IMAGE
+              value: quay.io/opendatahub/odh-workbench-jupyter-minimal-rocm-py312-ubi9@sha256:35cc54c98bef5a6c004fe5d2c6a9e6eb5a4dcd2cfece1c184d098a74bfd81924
+            - name: RELATED_IMAGE_ODH_DATA_SCIENCE_PIPELINES_ARGO_WORKFLOWCONTROLLER_IMAGE
+              value: quay.io/opendatahub/ds-pipelines-argo-workflowcontroller@sha256:e1435acb979bee0b127f8bf7b0b22b9308043b56389995524a8ecf60ec9b6be1
+            - name: RELATED_IMAGE_ODH_KF_NOTEBOOK_CONTROLLER_IMAGE
+              value: quay.io/opendatahub/kubeflow-notebook-controller@sha256:706ab2506e98a2e9f91b32ec214e788913644be9e80d94303d56fa4396fc2f45
+            - name: RELATED_IMAGE_ODH_PIPELINE_RUNTIME_PYTORCH_LLMCOMPRESSOR_CUDA_PY312_IMAGE
+              value: quay.io/opendatahub/odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-ubi9@sha256:f0e697ce47d1bd0ddfee43410688ca82ff574bc6ab3f38259442e40e451cb61d
+            - name: RELATED_IMAGE_ODH_TRUSTYAI_SERVICE_IMAGE
+              value: quay.io/opendatahub/odh-trustyai-service@sha256:a94d0399afc50639dc12ed56792ad1cc462c3987a319f0bf315504a80e8a914a
+            - name: RELATED_IMAGE_ODH_TRUSTYAI_SERVICE_OPERATOR_IMAGE
+              value: quay.io/trustyai/trustyai-service-operator@sha256:2b4adaa22f2e85356f7044fc1546d04a12160ca843ac5e19b0cf99dee5c37b9c
+            - name: RELATED_IMAGE_ODH_CORE_BFF_IMAGE
+              value: quay.io/opendatahub/odh-core-bff@sha256:f3b89bf0976843afc843ee4e92a2eea67072a35ddcc2c80783c107000f926ab9
+            - name: RELATED_IMAGE_ODH_LLM_D_ROUTER_ENDPOINT_PICKER_IMAGE
+              value: quay.io/opendatahub/odh-llm-d-router-endpoint-picker@sha256:88eee839a6415be2e055c2aed2a11e4ceee01218a40f0a794b27c7eb07577e32
+            - name: RELATED_IMAGE_ODH_ML_PIPELINES_SCHEDULEDWORKFLOW_V2_IMAGE
+              value: quay.io/opendatahub/ds-pipelines-scheduledworkflow@sha256:fb335b7be62745db181cd3a7206fc74f76b76f8a9bac7677f358928ab43d1c2a
+            - name: RELATED_IMAGE_ODH_KUBERAY_OPERATOR_CONTROLLER_IMAGE
+              value: quay.io/opendatahub/kuberay-operator@sha256:9fc49f834bb9f6098e146f1b3c1468094f1628e12699cd531c5641b5530f70f2
+            - name: RELATED_IMAGE_ODH_MODEL_REGISTRY_OPERATOR_IMAGE
+              value: quay.io/opendatahub/model-registry-operator@sha256:95bb7d8843fe3c5ecc8d45264cff80a6978fe80d9f1f5d208778ec59982fc3ae
+            - name: RELATED_IMAGE_ODH_MLFLOW_IMAGE
+              value: quay.io/opendatahub/mlflow@sha256:5d184555dd4ce2b5b511490d1f57a178db81ef8f97b6ff614e5e8b4b0601fba8
+            - name: RELATED_IMAGE_ODH_MODEL_PERFORMANCE_DATA_IMAGE
+              value: quay.io/opendatahub/odh-model-metadata-collection@sha256:6b9b77e5be4e750c22b90ebe59cd8b916f9d99744823f461263e0dd981a4a429
+            - name: RELATED_IMAGE_ODH_TRAINING_ROCM64_TORCH29_PY312_IMAGE
+              value: quay.io/opendatahub/odh-training-rocm64-torch29-py312@sha256:873a7ae8f44e975d6c98c08af6448b5688d0e57df0eb71e5911d249145b075cc
+            - name: RELATED_IMAGE_ODH_WORKBENCHES_CONTROLLER_IMAGE
+              value: quay.io/opendatahub/odh-workbenches-controller@sha256:a258627c5fb0a6157d69afc63caa23d8f8c19ede527facefea85667da18db4b3
+            - name: RELATED_IMAGE_ODH_TRAINING_ROCM64_TORCH28_PY312_IMAGE
+              value: quay.io/opendatahub/odh-training-rocm64-torch28-py312@sha256:2061cb20c7309f2f3ce91c6644d1e2c5ba6d3adde0f73bb222b42dde999c6d78
+            - name: RELATED_IMAGE_ODH_DASHBOARD_OPERATOR_IMAGE
+              value: quay.io/opendatahub/odh-dashboard-operator@sha256:a3e1c263c717801fd076dda9e060cb0812ebb6685c8b983601505de7e6f8ad19
+            - name: RELATED_IMAGE_ODH_DATA_SCIENCE_PIPELINES_ARGO_ARGOEXEC_IMAGE
+              value: quay.io/opendatahub/ds-pipelines-argo-argoexec@sha256:5a7e9beb40fdebd696ad480fc6bf44a6207e0154599d6d258f43b8545658a922
+            - name: RELATED_IMAGE_ODH_TRAINER_OPERATOR_IMAGE
+              value: quay.io/opendatahub/odh-trainer-operator@sha256:692a38f4858ee92f687d85625d6c9f57e5aa123da58835b66d9d94d674db1e8b
+          args:
+            - --leader-elect
+            - --operator-name=opendatahub
+          # NOTE: image is provided in CI by pullspec substitution, and by make/kustomize for local builds
+          image: REPLACE_IMAGE:v0.0.0-placeholder
+          imagePullPolicy: Always
+          name: manager
+          ports:
+            - containerPort: 8443
+              protocol: TCP
+              name: https
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - "ALL"
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8081
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 8081
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          # TODO(user): Configure the resources accordingly based on the project requirements.
+          # More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+          resources:
+            limits:
+              cpu: 1000m
+              memory: 4Gi
+            requests:
+              cpu: 100m
+              memory: 780Mi
+          volumeMounts:
+            - name: manifests
+              mountPath: /opt/manifests
+            - name: tmp
+              mountPath: /tmp
       volumes:
-      - name: manifests
-        emptyDir:
-          sizeLimit: 256Mi
-      - name: tmp
-        emptyDir:
-          medium: Memory
-          sizeLimit: 10Mi
+        - name: manifests
+          emptyDir:
+            sizeLimit: 256Mi
+        - name: tmp
+          emptyDir:
+            medium: Memory
+            sizeLimit: 10Mi
       serviceAccountName: controller-manager
       terminationGracePeriodSeconds: 10

--- a/internal/controller/components/kueue/kueue_controller_actions.go
+++ b/internal/controller/components/kueue/kueue_controller_actions.go
@@ -182,7 +182,14 @@ func manageDefaultKueueResourcesAction(ctx context.Context, rr *odhtypes.Reconci
 	// Update managed namespaces with missing labels
 	err = ensureKueueLabelsOnManagedNamespaces(ctx, rr.Client, managedNamespaces)
 	if err != nil {
-		return fmt.Errorf("failed to add missing labels to managed namespaces: %v with error: %w", managedNamespaces, err)
+		nsNames := make([]string, 0, len(managedNamespaces))
+		for i := range managedNamespaces {
+			nsNames = append(nsNames, managedNamespaces[i].Name)
+		}
+		logf.FromContext(ctx).Error(err, "failed to add missing labels to managed namespaces",
+			"namespaces", nsNames,
+		)
+		return fmt.Errorf("failed to add missing labels to managed namespaces: %w", err)
 	}
 
 	// Generate LocalQueues in each managed namespaces.

--- a/internal/controller/components/registry/registry.go
+++ b/internal/controller/components/registry/registry.go
@@ -74,6 +74,12 @@ type Registry struct {
 
 var r = &Registry{}
 
+// resolveBatches is the DAG resolver used by ForEach. Tests override it to
+// exercise the alphabetical fallback path.
+var resolveBatches = func(r *Registry) ([][]HandlerEntry, error) {
+	return r.resolvedBatchesLocked()
+}
+
 // Add registers a new ComponentHandler to the registry.
 func (r *Registry) Add(ch ComponentHandler, opts ...RegistrationOption) {
 	r.mu.Lock()
@@ -154,9 +160,9 @@ func (r *Registry) ForEach(f func(ch ComponentHandler) error) error {
 
 	var errs *multierror.Error
 
-	batches, resolveErr := r.resolvedBatchesLocked()
+	batches, resolveErr := resolveBatches(r)
 	if resolveErr != nil {
-		ctrl.Log.WithName("component-registry").Error(resolveErr, "DAG resolution failed, falling back to alphabetical order")
+		ctrl.Log.WithName("component-registry").Error(resolveErr, "DAG resolution failed, falling back to alphabetical order", "controllerKind", "DataScienceCluster")
 		for _, name := range r.sortedNames() {
 			e := r.entries[name]
 			if !e.enabled {

--- a/internal/controller/components/registry/registry_foreach_fallback_test.go
+++ b/internal/controller/components/registry/registry_foreach_fallback_test.go
@@ -1,0 +1,79 @@
+//nolint:testpackage
+package registry
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/go-logr/logr/funcr"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/opendatahub-io/opendatahub-operator/v2/api/common"
+	dscv2 "github.com/opendatahub-io/opendatahub-operator/v2/api/datasciencecluster/v2"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/dag"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/operatorconfig"
+
+	. "github.com/onsi/gomega"
+)
+
+type fallbackHandler struct{ name string }
+
+func (f *fallbackHandler) Init(_ common.Platform, _ operatorconfig.OperatorSettings) error {
+	return nil
+}
+func (f *fallbackHandler) GetName() string { return f.name }
+func (f *fallbackHandler) NewCRObject(_ context.Context, _ client.Client, _ *dscv2.DataScienceCluster) (common.PlatformObject, error) {
+	return nil, nil
+}
+func (f *fallbackHandler) NewComponentReconciler(_ context.Context, _ ctrl.Manager) error {
+	return nil
+}
+func (f *fallbackHandler) UpdateDSCStatus(_ context.Context, _ *types.ReconciliationRequest) (metav1.ConditionStatus, error) {
+	return metav1.ConditionTrue, nil
+}
+func (f *fallbackHandler) GroupVersionKind() schema.GroupVersionKind {
+	return schema.GroupVersionKind{}
+}
+func (f *fallbackHandler) IsEnabled(_ *dscv2.DataScienceCluster) bool { return true }
+
+func TestForEachFallsBackAlphabeticallyWhenDAGFails(t *testing.T) {
+	g := NewWithT(t)
+
+	orig := resolveBatches
+	t.Cleanup(func() {
+		resolveBatches = orig
+		ctrl.SetLogger(logr.Discard())
+	})
+	resolveBatches = func(*Registry) ([][]HandlerEntry, error) {
+		return nil, errors.New("dag failed")
+	}
+
+	var logged []string
+	ctrl.SetLogger(funcr.New(func(_, args string) {
+		logged = append(logged, args)
+	}, funcr.Options{}))
+
+	reg := &Registry{}
+	reg.Add(&fallbackHandler{name: "zebra"}, WithRunlevel(dag.RL(0)))
+	reg.Add(&fallbackHandler{name: "alpha"}, WithRunlevel(dag.RL(30)))
+	reg.Add(&fallbackHandler{name: "middle"}, WithRunlevel(dag.RL(20)))
+	reg.Disable("middle")
+
+	var visited []string
+	err := reg.ForEach(func(ch ComponentHandler) error {
+		visited = append(visited, ch.GetName())
+		return nil
+	})
+	g.Expect(err).ShouldNot(HaveOccurred())
+	g.Expect(visited).Should(Equal([]string{"alpha", "zebra"}))
+	g.Expect(logged).To(ContainElement(And(
+		ContainSubstring(`"msg"="DAG resolution failed, falling back to alphabetical order"`),
+		ContainSubstring(`"controllerKind"="DataScienceCluster"`),
+	)))
+}

--- a/internal/controller/components/trustyai/trustyai_controller_actions.go
+++ b/internal/controller/components/trustyai/trustyai_controller_actions.go
@@ -115,7 +115,8 @@ func migrateDeploymentSelector(ctx context.Context, rr *odhtypes.ReconciliationR
 		if k8serr.IsNotFound(err) {
 			return nil
 		}
-		return fmt.Errorf("failed to get Deployment %s/%s: %w", ns, trustyaiDeploymentName, err)
+		log.Error(err, "failed to get Deployment", "deployment", trustyaiDeploymentName, "deploymentNamespace", ns)
+		return fmt.Errorf("failed to get Deployment: %w", err)
 	}
 
 	if deploy.Spec.Selector != nil &&
@@ -138,7 +139,8 @@ func migrateDeploymentSelector(ctx context.Context, rr *odhtypes.ReconciliationR
 		if k8serr.IsNotFound(err) {
 			return nil
 		}
-		return fmt.Errorf("failed to delete Deployment %s/%s with stale selector: %w", ns, trustyaiDeploymentName, err)
+		log.Error(err, "failed to delete Deployment with stale selector", "deployment", trustyaiDeploymentName, "deploymentNamespace", ns)
+		return fmt.Errorf("failed to delete Deployment with stale selector: %w", err)
 	}
 
 	log.Info("Deleted TrustyAI operator Deployment, it will be recreated with the correct selector",

--- a/internal/controller/datasciencecluster/datasciencecluster_controller_actions.go
+++ b/internal/controller/datasciencecluster/datasciencecluster_controller_actions.go
@@ -90,15 +90,23 @@ func disableDSCModulesOnDelete(ctx context.Context, rr *odhtype.ReconciliationRe
 }
 
 func cleanupDisabledComponents(ctx context.Context, rr *odhtype.ReconciliationRequest) error {
+	return cleanupDisabledComponentsWith(ctx, rr, cr.DefaultRegistry(), provision.DefaultRegistry())
+}
+
+func cleanupDisabledComponentsWith(
+	ctx context.Context,
+	rr *odhtype.ReconciliationRequest,
+	componentReg *cr.Registry,
+	provisionReg *provision.UnifiedRegistry,
+) error {
 	instance, ok := rr.Instance.(*dscv2.DataScienceCluster)
 	if !ok {
 		return fmt.Errorf("resource instance %v is not a dscv2.DataScienceCluster)", rr.Instance)
 	}
 
 	log := logf.FromContext(ctx)
-	componentReg := cr.DefaultRegistry()
 
-	reverseBatches, err := provision.DefaultRegistry().ReverseBatches()
+	reverseBatches, err := provisionReg.ReverseBatches()
 	if err != nil {
 		return fmt.Errorf("DAG reverse resolution failed during component cleanup: %w", err)
 	}
@@ -160,12 +168,20 @@ func isOwnedBy(obj, owner metav1.Object) bool {
 }
 
 func cleanupDisabledModuleCRs(ctx context.Context, rr *odhtype.ReconciliationRequest) error {
+	return cleanupDisabledModuleCRsWith(ctx, rr, modules.DefaultRegistry(), provision.DefaultRegistry())
+}
+
+func cleanupDisabledModuleCRsWith(
+	ctx context.Context,
+	rr *odhtype.ReconciliationRequest,
+	moduleReg *modules.Registry,
+	provisionReg *provision.UnifiedRegistry,
+) error {
 	instance, ok := rr.Instance.(*dscv2.DataScienceCluster)
 	if !ok {
 		return fmt.Errorf("resource instance %v is not a dscv2.DataScienceCluster)", rr.Instance)
 	}
 
-	moduleReg := modules.DefaultRegistry()
 	if !moduleReg.HasEntries() {
 		return nil
 	}
@@ -185,7 +201,7 @@ func cleanupDisabledModuleCRs(ctx context.Context, rr *odhtype.ReconciliationReq
 	})
 
 	log := logf.FromContext(ctx)
-	reverseBatches, err := provision.DefaultRegistry().ReverseBatches()
+	reverseBatches, err := provisionReg.ReverseBatches()
 	if err != nil {
 		log.Error(err, "DAG reverse resolution failed, falling back to alphabetical module CR cleanup")
 		return moduleReg.ForConfigSource(modules.ConfigFromDSC, func(handler modules.ModuleHandler, _ bool) error {
@@ -223,6 +239,10 @@ func cleanupDisabledModuleCRs(ctx context.Context, rr *odhtype.ReconciliationReq
 }
 
 func provisionComponents(ctx context.Context, rr *odhtype.ReconciliationRequest) error {
+	return provisionComponentsWith(ctx, rr, cr.DefaultRegistry())
+}
+
+func provisionComponentsWith(ctx context.Context, rr *odhtype.ReconciliationRequest, componentReg *cr.Registry) error {
 	instance, ok := rr.Instance.(*dscv2.DataScienceCluster)
 	if !ok {
 		return fmt.Errorf("resource instance %v is not a dscv2.DataScienceCluster)", rr.Instance)
@@ -230,7 +250,6 @@ func provisionComponents(ctx context.Context, rr *odhtype.ReconciliationRequest)
 
 	rr.Generated = true
 	log := logf.FromContext(ctx)
-	componentReg := cr.DefaultRegistry()
 	var failedComponents []string
 
 	if err := componentReg.ForEach(func(handler cr.ComponentHandler) error {

--- a/internal/controller/datasciencecluster/datasciencecluster_controller_actions_test.go
+++ b/internal/controller/datasciencecluster/datasciencecluster_controller_actions_test.go
@@ -1,0 +1,195 @@
+//nolint:testpackage
+package datasciencecluster
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/go-logr/logr/funcr"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
+	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/api/components/v1alpha1"
+	configv1alpha1 "github.com/opendatahub-io/opendatahub-operator/v2/api/config/v1alpha1"
+	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/modules"
+	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/status"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/conditions"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/dag"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/provision"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/fakeclient"
+
+	. "github.com/onsi/gomega"
+)
+
+func logCapturingContext(t *testing.T) (context.Context, *[]string) {
+	t.Helper()
+	var logged []string
+	logger := funcr.New(func(_, args string) {
+		logged = append(logged, args)
+	}, funcr.Options{})
+	return logf.IntoContext(t.Context(), logger), &logged
+}
+
+type mockModuleHandler struct {
+	modules.BaseHandler
+
+	deleteErr error
+}
+
+func (m *mockModuleHandler) IsEnabled(_ *configv1alpha1.PlatformModules) bool { return false }
+
+func (m *mockModuleHandler) BuildModuleCR(_ context.Context, _ client.Client, _ *modules.DSCContext, _ *modules.ModuleCRConfig) (*unstructured.Unstructured, error) {
+	return nil, nil
+}
+func (m *mockModuleHandler) DeleteModuleCR(_ context.Context, _ client.Client) error {
+	return m.deleteErr
+}
+
+var _ modules.ModuleHandler = (*mockModuleHandler)(nil)
+
+func TestProvisionComponentsErrorLogs(t *testing.T) {
+	tests := []struct {
+		name          string
+		handler       *mockHandler
+		newClient     func() client.Client
+		wantMsg       string
+		wantComponent string
+	}{
+		{
+			name:          "NewCRObject failure is logged with structured fields",
+			handler:       &mockHandler{name: "newcr-fail", enabled: true, newCRErr: errors.New("boom")},
+			newClient:     func() client.Client { return nil },
+			wantMsg:       "NewCRObject failed",
+			wantComponent: "newcr-fail",
+		},
+		{
+			name:    "AddResources failure is logged with structured fields",
+			handler: &mockHandler{name: "addresources-fail", enabled: true, newCRObj: &componentApi.Kueue{}},
+			// An empty scheme cannot resolve the returned object's GVK, so
+			// rr.AddResources fails and provisionComponents logs the error.
+			newClient:     func() client.Client { return fake.NewClientBuilder().WithScheme(runtime.NewScheme()).Build() },
+			wantMsg:       "AddResources failed",
+			wantComponent: "addresources-fail",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			dsc := newDSC()
+
+			ctx, logged := logCapturingContext(t)
+			rr := &types.ReconciliationRequest{
+				Instance:   dsc,
+				Client:     tt.newClient(),
+				Conditions: conditions.NewManager(dsc, status.ConditionTypeComponentsReady),
+			}
+
+			err := provisionComponentsWith(ctx, rr, newRegistry(tt.handler))
+
+			g.Expect(err).To(HaveOccurred())
+			g.Expect(*logged).To(ContainElement(And(
+				ContainSubstring(`"msg"="`+tt.wantMsg+`"`),
+				ContainSubstring(`"component"="`+tt.wantComponent+`"`),
+			)))
+		})
+	}
+}
+
+func TestProvisionComponentsAggregatesFailedComponents(t *testing.T) {
+	g := NewWithT(t)
+	dsc := newDSC()
+
+	handlers := []*mockHandler{
+		{name: "agg-newcr-fail", enabled: true, newCRErr: errors.New("boom")},
+		{name: "agg-addresources-fail", enabled: true, newCRObj: &componentApi.Kueue{}},
+	}
+
+	ctx, logged := logCapturingContext(t)
+
+	rr := &types.ReconciliationRequest{
+		Instance:   dsc,
+		Client:     fake.NewClientBuilder().WithScheme(runtime.NewScheme()).Build(),
+		Conditions: conditions.NewManager(dsc, status.ConditionTypeComponentsReady),
+	}
+
+	err := provisionComponentsWith(ctx, rr, newRegistry(handlers[0], handlers[1]))
+
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(And(
+		ContainSubstring("agg-newcr-fail"),
+		ContainSubstring("agg-addresources-fail"),
+	))
+	g.Expect(*logged).To(ContainElement(ContainSubstring(`"component"="agg-newcr-fail"`)))
+	g.Expect(*logged).To(ContainElement(ContainSubstring(`"component"="agg-addresources-fail"`)))
+}
+
+func TestCleanupDisabledComponentsLogsDeleteFailure(t *testing.T) {
+	g := NewWithT(t)
+	dsc := newDSC()
+
+	const name = "delete-fail"
+
+	compReg := newRegistry(&mockHandler{name: name, enabled: false})
+	provReg := provision.NewRegistry()
+	provReg.Add(name, provision.KindComponent, dag.RL(10))
+
+	cli := fake.NewClientBuilder().
+		WithInterceptorFuncs(interceptor.Funcs{
+			List: func(_ context.Context, _ client.WithWatch, _ client.ObjectList, _ ...client.ListOption) error {
+				return errors.New("list failed")
+			},
+		}).
+		Build()
+
+	ctx, logged := logCapturingContext(t)
+	rr := &types.ReconciliationRequest{Instance: dsc, Client: cli}
+
+	err := cleanupDisabledComponentsWith(ctx, rr, compReg, provReg)
+
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(*logged).To(ContainElement(And(
+		ContainSubstring(`"msg"="failed to delete component CR"`),
+		ContainSubstring(`"component"="`+name+`"`),
+	)))
+}
+
+func TestCleanupDisabledModuleCRsLogsDeleteFailure(t *testing.T) {
+	g := NewWithT(t)
+	dsc := newDSC()
+
+	const name = "module-delete-fail"
+	mod := &mockModuleHandler{deleteErr: errors.New("delete module cr failed")}
+	mod.Config = modules.ModuleConfig{
+		Name:   name,
+		CRName: "default",
+		GVK:    schema.GroupVersionKind{Group: "test.io", Version: "v1", Kind: "MockModule"},
+	}
+
+	modReg := &modules.Registry{}
+	modReg.Add(mod)
+	provReg := provision.NewRegistry()
+	provReg.Add(name, provision.KindModule, dag.RL(20))
+
+	cli, err := fakeclient.New()
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	ctx, logged := logCapturingContext(t)
+
+	rr := &types.ReconciliationRequest{Instance: dsc, Client: cli}
+
+	err = cleanupDisabledModuleCRsWith(ctx, rr, modReg, provReg)
+
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(*logged).To(ContainElement(And(
+		ContainSubstring(`"msg"="DeleteModuleCR failed"`),
+		ContainSubstring(`"module"="`+name+`"`),
+	)))
+}

--- a/internal/controller/datasciencecluster/datasciencecluster_controller_support_test.go
+++ b/internal/controller/datasciencecluster/datasciencecluster_controller_support_test.go
@@ -28,16 +28,21 @@ import (
 
 // mockHandler is a minimal ComponentHandler for testing computeComponentsStatus.
 type mockHandler struct {
-	name    string
-	enabled bool
-	status  metav1.ConditionStatus
-	err     error
+	name     string
+	enabled  bool
+	status   metav1.ConditionStatus
+	err      error
+	newCRErr error
+	newCRObj common.PlatformObject
 }
 
 func (m *mockHandler) Init(_ common.Platform, _ operatorconfig.OperatorSettings) error { return nil }
 func (m *mockHandler) GetName() string                                                 { return m.name }
 func (m *mockHandler) NewCRObject(_ context.Context, _ client.Client, _ *dscv2.DataScienceCluster) (common.PlatformObject, error) {
-	return nil, nil
+	if m.newCRErr != nil {
+		return nil, m.newCRErr
+	}
+	return m.newCRObj, nil
 }
 func (m *mockHandler) NewComponentReconciler(_ context.Context, _ ctrl.Manager) error {
 	return nil

--- a/internal/controller/dscinitialization/dscinitialization_controller.go
+++ b/internal/controller/dscinitialization/dscinitialization_controller.go
@@ -614,7 +614,7 @@ func (r *DSCInitializationReconciler) reconcileDSCIModules(ctx context.Context, 
 		}
 
 		if err := resources.Apply(ctx, r.Client, moduleCR, client.FieldOwner(fieldManager), client.ForceOwnership); err != nil {
-			if meta.IsNoMatchError(err) {
+			if meta.IsNoMatchError(err) || k8serr.IsNotFound(err) {
 				log.V(1).Info("module CRD not installed yet, will retry when CRD appears", "module", handler.GetName())
 				return nil
 			}

--- a/internal/controller/dscinitialization/dscinitialization_test.go
+++ b/internal/controller/dscinitialization/dscinitialization_test.go
@@ -92,20 +92,16 @@ var _ = Describe("DataScienceCluster initialization", func() {
 				g.Expect(k8sClient.Update(ctx, patched)).To(Succeed())
 			}).WithContext(ctx).WithTimeout(timeout).WithPolling(interval).Should(Succeed())
 
-			Eventually(dscInitializationIsReady(foundDsci)).
-				WithContext(ctx).
-				WithTimeout(timeout).
-				WithPolling(interval).
-				Should(BeTrue())
-
-			Expect(k8sClient.Get(ctx, client.ObjectKey{Name: applicationName, Namespace: workingNamespace}, foundDsci)).To(Succeed())
-			Expect(foundDsci.Status.Conditions).To(ContainElement(
-				SatisfyAll(
-					HaveField("Type", "MonitoringReady"),
-					HaveField("Status", metav1.ConditionFalse),
-					HaveField("Reason", "Removed"),
-				),
-			))
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, client.ObjectKey{Name: applicationName, Namespace: workingNamespace}, foundDsci)).To(Succeed())
+				g.Expect(foundDsci.Status.Conditions).To(ContainElement(
+					SatisfyAll(
+						HaveField("Type", "MonitoringReady"),
+						HaveField("Status", metav1.ConditionFalse),
+						HaveField("Reason", "Removed"),
+					),
+				))
+			}).WithContext(ctx).WithTimeout(timeout).WithPolling(interval).Should(Succeed())
 		})
 
 		// Currently commented out in the DSCI reconcile - setting test to Pending
@@ -205,7 +201,7 @@ var _ = Describe("DataScienceCluster initialization", func() {
 				g.Expect(foundDsci.Status.Conditions).ToNot(ContainElement(
 					HaveField("Type", "UnrelatedCondition"),
 				))
-			}).WithTimeout(timeout).WithPolling(interval).Should(Succeed())
+			}).WithContext(ctx).WithTimeout(timeout).WithPolling(interval).Should(Succeed())
 		})
 
 		It("Should set Ready condition to False when Monitoring CR Ready condition is False", func(ctx context.Context) {

--- a/internal/controller/dscinitialization/dscinitialization_test.go
+++ b/internal/controller/dscinitialization/dscinitialization_test.go
@@ -94,6 +94,7 @@ var _ = Describe("DataScienceCluster initialization", func() {
 
 			Eventually(func(g Gomega) {
 				g.Expect(k8sClient.Get(ctx, client.ObjectKey{Name: applicationName, Namespace: workingNamespace}, foundDsci)).To(Succeed())
+				g.Expect(foundDsci.Status.Phase).To(Equal(readyPhase))
 				g.Expect(foundDsci.Status.Conditions).To(ContainElement(
 					SatisfyAll(
 						HaveField("Type", "MonitoringReady"),

--- a/pkg/cluster/resources.go
+++ b/pkg/cluster/resources.go
@@ -116,7 +116,7 @@ func GetDSC(ctx context.Context, cli client.Reader) (*dscv2.DataScienceCluster, 
 func WatchDataScienceClusters(ctx context.Context, cli client.Client) []reconcile.Request {
 	instanceList := &dscv2.DataScienceClusterList{}
 	if err := cli.List(ctx, instanceList); err != nil {
-		logf.FromContext(ctx).Error(err, "failed to list DataScienceCluster instances for watch mapping")
+		logf.FromContext(ctx).Error(err, "failed to list DataScienceCluster instances for watch mapping", "resourceKind", "DataScienceCluster")
 		return []reconcile.Request{}
 	}
 

--- a/tests/e2e/deletion_test.go
+++ b/tests/e2e/deletion_test.go
@@ -44,7 +44,10 @@ func (tc *DeletionTestCtx) TestDSCDeletion(t *testing.T) {
 	skipUnless(t, Tier3)
 
 	// Delete the DataScienceCluster instance
-	tc.DeleteResource(WithMinimalObject(gvk.DataScienceCluster, tc.DataScienceClusterNamespacedName))
+	tc.DeleteResource(
+		WithMinimalObject(gvk.DataScienceCluster, tc.DataScienceClusterNamespacedName),
+		WithWaitForDeletion(true),
+	)
 }
 
 // TestDSCIDeletion deletes the DSCInitialization instance if it exists.
@@ -56,5 +59,8 @@ func (tc *DeletionTestCtx) TestDSCIDeletion(t *testing.T) {
 	skipUnless(t, Tier3)
 
 	// Delete the DSCInitialization instance
-	tc.DeleteResource(WithMinimalObject(gvk.DSCInitialization, tc.DSCInitializationNamespacedName))
+	tc.DeleteResource(
+		WithMinimalObject(gvk.DSCInitialization, tc.DSCInitializationNamespacedName),
+		WithWaitForDeletion(true),
+	)
 }


### PR DESCRIPTION
## Summary

- Convert all 7 `log.Error()` calls in `datasciencecluster_controller_actions.go` from message-embedded resource identity to structured KV pairs (`name`, `resourceKind`, `component`/`module`).
- Omit `namespace` for cluster-scoped `DataScienceCluster` resource.
- Add `TestLogErrorsFormatting` unit test asserting structured fields are present and `namespace` is absent.

**Note:** The 4 existing component controllers (DataSciencePipelines, Kueue, Ray, TrustyAI) have zero `log.Error()` calls — they propagate errors via `fmt.Errorf()`. SparkOperator, Trainer, and TrainingOperator no longer exist as in-tree component controllers (migrated to module / deprecated), so no changes were needed there.

Ref: [RHAI-524](https://redhat.atlassian.net/browse/RHAI-524)

## Test plan

- [x] `make lint` passes (0 issues)
- [x] `go test ./internal/controller/datasciencecluster/...` passes
- [x] `TestLogErrorsFormatting` asserts `name`, `resourceKind`, `component` present; `namespace` absent

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
Changes are limited to structured logging format (log.Error KV pairs) with no behavioral or API changes. Unit tests cover the new log format.



[RHAI-524]: https://redhat.atlassian.net/browse/RHAI-524?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

- Improved DataScienceCluster error messages with instance names, resource kinds, and component details during provisioning, cleanup, validation, and registration.
- Made failure information more specific and actionable for troubleshooting.
- Improved handling and reporting of multiple component failures.
- Improved error reporting when disabled components or modules cannot be removed.

## Tests

- Added coverage for provisioning and cleanup failures across components and modules.
- Verified structured error details and aggregated failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->