### PR TITLE
fix(trustyai): update service image env var to match build config

### DIFF
--- a/internal/controller/components/trustyai/trustyai_support.go
+++ b/internal/controller/components/trustyai/trustyai_support.go
@@ -21,7 +21,7 @@ const (
 
 var (
 	imageParamMap = map[string]string{
-		"trustyaiServiceImage":               "RELATED_IMAGE_ODH_TRUSTYAI_SERVICE_IMAGE",
+		"trustyaiServiceImage":               "RELATED_IMAGE_ODH_TRUSTYAI_SERVICE_PY_IMAGE",
 		"trustyaiOperatorImage":              "RELATED_IMAGE_ODH_TRUSTYAI_SERVICE_OPERATOR_IMAGE",
 		"lmes-driver-image":                  "RELATED_IMAGE_ODH_TA_LMES_DRIVER_IMAGE",
 		"lmes-pod-image":                     "RELATED_IMAGE_ODH_TA_LMES_JOB_IMAGE",

--- a/manifests-config.yaml
+++ b/manifests-config.yaml
@@ -1161,7 +1161,7 @@ imageOverrides:
     rhoai:
       base: "quay.io/opendatahub/llama-stack-provider-ragas"
       digest: "sha256:fa46ce6a3dd16b0eb8e06c71f99b761d742599e569ed91f7b727149bc1085520"
-  RELATED_IMAGE_ODH_TRUSTYAI_SERVICE_IMAGE:
+  RELATED_IMAGE_ODH_TRUSTYAI_SERVICE_PY_IMAGE:
     source: "csv"
     odh:
       base: "quay.io/opendatahub/odh-trustyai-service"


### PR DESCRIPTION
## Description

Rename `RELATED_IMAGE_ODH_TRUSTYAI_SERVICE_IMAGE` to `RELATED_IMAGE_ODH_TRUSTYAI_SERVICE_PY_IMAGE` across all references to align with the image name used in [ODH-Build-Config](https://github.com/opendatahub-io/ODH-Build-Config/pull/3883).

Changes:
- `internal/controller/components/trustyai/trustyai_support.go`: update `imageParamMap` key to use the new env var name
- `manifests-config.yaml`: rename image override entry accordingly

## Release tracking

Release: rhoai-3.6-EA1

### E2E test suite update requirement

- [x] Skip requirement to update E2E test suite for this PR

#### E2E update requirement opt-out justification

This PR only renames an environment variable reference — no operator logic or behavior changes. No E2E test updates are required.