### PR TITLE
fix(e2e): add finalizer removal for ThanosQuerier deletion in monitoring test cleanup

### DIFF
--- a/tests/e2e/monitoring_test.go
+++ b/tests/e2e/monitoring_test.go
@@ -1315,6 +1315,7 @@ func (tc *MonitoringTestCtx) ValidateMonitoringServiceDisabled(t *testing.T) {
 	}{
 		{gvk: gvk.Monitoring, name: MonitoringCRName},
 		{gvk: gvk.MonitoringStack, name: MonitoringStackName, forceWithFinalizer: true},
+		{gvk: gvk.ThanosQuerier, name: ThanosQuerierName, forceWithFinalizer: true},
 		{gvk: gvk.TempoStack, name: TempoStackName, forceWithFinalizer: true},
 		{gvk: gvk.TempoMonolithic, name: TempoMonolithicName, forceWithFinalizer: true},
 		{gvk: gvk.OpenTelemetryCollector, name: OpenTelemetryCollectorName},
@@ -1645,6 +1646,17 @@ func (tc *MonitoringTestCtx) cleanupGroup(t *testing.T, secretName string) {
 			WithWaitForDeletion(true),
 		)
 	}
+
+	// Clean up ThanosQuerier if it exists
+	tc.DeleteResource(
+		WithMinimalObject(gvk.ThanosQuerier, types.NamespacedName{
+			Name:      ThanosQuerierName,
+			Namespace: tc.MonitoringNamespace,
+		}),
+		WithWaitForDeletion(true),
+		WithRemoveFinalizersOnDelete(true),
+		WithIgnoreNotFound(true),
+	)
 
 	// Clean up TempoMonolithic if it exists
 	tc.DeleteResource(


### PR DESCRIPTION
## Summary

- Add `WithRemoveFinalizersOnDelete(true)` for ThanosQuerier in `cleanupGroup` and `ValidateMonitoringServiceDisabled`
- Prevents 600s test timeout when ThanosQuerier gets stuck in terminating state between monitoring test groups

## Problem

The monitoring E2E test `Test_ThanosQuerier_not_deployed_without_metrics` (Group 5) times out after 600s waiting for the ThanosQuerier CR to be deleted. The CR is stuck with a `foregroundDeletion` finalizer:

```
ThanosQuerier "data-science-thanos-querier":
  deletionTimestamp: 2026-08-20T10:29:07Z
  finalizers: ["foregroundDeletion"]
  ownerReferences:
    - kind: Monitoring, name: default-monitoring, blockOwnerDeletion: true
```

### How the deadlock occurs

1. The ODH operator's deploy action creates ThanosQuerier CRs with `blockOwnerDeletion: true` on the ownerReference to the Monitoring CR (standard behavior for all `OwnsGVK` resources).
2. When the test reconfigures monitoring (disabling metrics), the operator's GC action deletes the ThanosQuerier. Kubernetes initiates **foreground cascading deletion** and adds a `foregroundDeletion` finalizer.
3. The Cluster Observability Operator's ThanosQuerier controller has **no `DeletionTimestamp` check** — it continues to reconcile, updating owned Deployments/Services while the garbage collector tries to delete them.
4. The controller's updates bump `resourceVersion`, causing GC conflicts. Neither side wins, and the finalizer is never cleared.

### CI evidence

Failing build: [2090374980800876544](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/opendatahub-io_opendatahub-operator/3984/pull-ci-opendatahub-io-opendatahub-operator-main-opendatahub-operator-rhoai-e2e/2090374980800876544) (PR #3984)

Deterministic — same behavior across all 3 test attempts. The ThanosQuerier reached 18 BackOff events with the finalizer never clearing.

## Fix

Add ThanosQuerier to the existing finalizer-removal pattern in two places:

1. **`cleanupGroup`** — called at the start of each monitoring test group to ensure clean state
2. **`ValidateMonitoringServiceDisabled`** — verifies all monitoring resources are cleaned up when monitoring is disabled

This matches the existing workaround for MonitoringStack, TempoStack, and TempoMonolithic, which all have the same external-operator finalizer issue. The `WithRemoveFinalizersOnDelete(true)` option is a no-op when there are no stuck finalizers, so this is safe to keep permanently.

### Upstream root cause fix

The root cause (missing `DeletionTimestamp` check in the COO ThanosQuerier controller) has been submitted upstream: [rhobs/observability-operator#1202](https://github.com/rhobs/observability-operator/pull/1202). This test workaround is needed until the upstream fix ships in a new COO release on CI clusters.

## Test plan

- [ ] Monitoring E2E tests pass, specifically `Test_ThanosQuerier_not_deployed_without_metrics` no longer times out
- [ ] No regressions in other monitoring test groups (the cleanup change is additive)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Monitoring cleanup now reliably removes the Thanos Querier resource when monitoring is disabled.
  * Group-level cleanup also removes lingering Thanos Querier resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->