### PR TITLE
RHOAIENG-72878: add xKS regression test for DAG runlevel gating

### DIFF
--- a/.github/workflows/test-kind-odh-e2e.yaml
+++ b/.github/workflows/test-kind-odh-e2e.yaml
@@ -11,6 +11,7 @@ on:
       - 'config/rbac/components_kserve_editor_role.yaml'
       - 'config/rbac/components_kserve_viewer_role.yaml'
       - 'tests/e2e/kserve_test.go'
+      - 'tests/e2e/dag_ordering_test.go'
       - 'cmd/cloudmanager/**'
       - 'internal/controller/cloudmanager/**'
       - 'config/cloudmanager/**'

--- a/tests/e2e/dag_ordering_test.go
+++ b/tests/e2e/dag_ordering_test.go
@@ -137,25 +137,53 @@ var extensionGVKs = []schema.GroupVersionKind{
 
 const dagQuotaName = "dag-test-restrictive-quota"
 
+// dagOrderingTestSuite runs the DAG runlevel gating test suite. OpenShift
+// and xKS clusters enable components through different resources (the
+// DataScienceCluster on OpenShift, the Platform CR directly on xKS, which
+// has no DataScienceCluster), so each cluster type runs its own set of
+// scenarios below.
 func dagOrderingTestSuite(t *testing.T) {
 	t.Helper()
 
 	tc, err := NewTestContext(t)
 	require.NoError(t, err, "Failed to initialize test context")
 
-	tc.SkipIfXKSCluster(t)
-
 	ctx := DAGOrderingTestCtx{TestContext: tc}
 
+	if tc.IsXKS() {
+		ctx.runXKSTestCases(t)
+		return
+	}
+
+	ctx.runOpenShiftTestCases(t)
+}
+
+// runXKSTestCases exercises DAG runlevel gating on xKS clusters, which
+// have no DataScienceCluster. Component enablement and runlevel gating
+// both go through the Platform CR on this platform.
+func (tc *DAGOrderingTestCtx) runXKSTestCases(t *testing.T) {
+	t.Helper()
+
+	RunTestCases(t, []TestCase{
+		{"Validate Kserve DAG gating unblocks via Platform CR", tc.ValidateXKSRunlevelGating},
+	})
+}
+
+// runOpenShiftTestCases exercises DAG runlevel gating on OpenShift
+// clusters, where component enablement goes through the
+// DataScienceCluster (DSC).
+func (tc *DAGOrderingTestCtx) runOpenShiftTestCases(t *testing.T) {
+	t.Helper()
+
 	t.Log("Ensuring clean slate: setting all components to Removed")
-	ctx.setAllRemoved(t)
-	ctx.removeOperatorEnvVars(t, "RHAI_VERSION", "CI")
+	tc.setAllRemoved(t)
+	tc.removeOperatorEnvVars(t, "RHAI_VERSION", "CI")
 
 	t.Cleanup(func() {
 		t.Log("Cleanup: setting all components to Removed, deleting quota, and restoring operator env vars")
-		ctx.setAllRemoved(t)
-		ctx.deleteDAGQuota()
-		ctx.removeOperatorEnvVars(t, "RHAI_VERSION", "CI")
+		tc.setAllRemoved(t)
+		tc.deleteDAGQuota()
+		tc.removeOperatorEnvVars(t, "RHAI_VERSION", "CI")
 	})
 
 	// Tests are ordered to minimise expensive enable/disable cycles.
@@ -177,25 +205,25 @@ func dagOrderingTestSuite(t *testing.T) {
 
 	// Phase 1: gate tests
 	RunTestCases(t, []TestCase{
-		{"Validate in-tree gates block and unblock provisioning", ctx.ValidateInTreeGates},
-		{"Validate admin ack gates block and unblock provisioning", ctx.ValidateAdminAckGates},
+		{"Validate in-tree gates block and unblock provisioning", tc.ValidateInTreeGates},
+		{"Validate admin ack gates block and unblock provisioning", tc.ValidateAdminAckGates},
 	})
 
 	// Phase 2: deploy + gating with version upgrade
 	RunTestCases(t, []TestCase{
-		{"Validate partial enablement", ctx.ValidatePartialEnablement},
-		{"Validate runlevel gating and convergence", ctx.ValidateRunlevelGatingAndConvergence},
+		{"Validate partial enablement", tc.ValidatePartialEnablement},
+		{"Validate runlevel gating and convergence", tc.ValidateRunlevelGatingAndConvergence},
 	})
 
 	// Restore operator to original version after Phase 2 upgrade.
 	// Components have platform release = 99.0.0. Restoring triggers
 	// another gating cycle (version mismatch) until components reconcile.
 	t.Log("Restoring operator to original version for Phase 3")
-	ctx.removeOperatorEnvVars(t, "RHAI_VERSION", "CI")
+	tc.removeOperatorEnvVars(t, "RHAI_VERSION", "CI")
 
 	t.Log("Waiting for DSC to fully reconcile at original version")
-	ctx.EnsureResourceExists(
-		WithMinimalObject(gvk.DataScienceCluster, ctx.DataScienceClusterNamespacedName),
+	tc.EnsureResourceExists(
+		WithMinimalObject(gvk.DataScienceCluster, tc.DataScienceClusterNamespacedName),
 		WithCondition(And(
 			jq.Match(`.status.observedGeneration == .metadata.generation`),
 			jq.Match(
@@ -213,10 +241,58 @@ func dagOrderingTestSuite(t *testing.T) {
 
 	// Phase 3: steady-state tests
 	RunTestCases(t, []TestCase{
-		{"Validate PlatformReady condition on component CRs", ctx.ValidatePlatformReady},
-		{"Validate component stability across enable/disable cycles (RHOAIENG-73142)", ctx.ValidateComponentStability},
-		{"Validate DAG cleanup", ctx.ValidateDAGCleanup},
+		{"Validate PlatformReady condition on component CRs", tc.ValidatePlatformReady},
+		{"Validate component stability across enable/disable cycles (RHOAIENG-73142)", tc.ValidateComponentStability},
+		{"Validate DAG cleanup", tc.ValidateDAGCleanup},
 	})
+}
+
+// ValidateXKSRunlevelGating exercises DAG runlevel gating on xKS
+// clusters, which have no DataScienceCluster. It enables the Kserve
+// module (runlevel 31) through the Platform CR and asserts Kserve
+// reaches Ready=True, proving the DAG walk that clears runlevels runs
+// against the Platform CR on this platform.
+func (tc *DAGOrderingTestCtx) ValidateXKSRunlevelGating(t *testing.T) {
+	t.Helper()
+
+	skipUnless(t, Tier2, Tier3)
+
+	t.Cleanup(func() {
+		tc.DeleteResource(
+			WithMinimalObject(gvk.Kserve, types.NamespacedName{Name: tc.GetInstanceName(gvk.Kserve)}),
+			WithForegroundDeletion(),
+			WithWaitForDeletion(true),
+		)
+		tc.SetModuleStateInPlatformCR(t, "kserve", operatorv1.Removed)
+	})
+
+	t.Log("Enabling Kserve module via Platform CR")
+	tc.SetModuleStateInPlatformCR(t, "kserve", operatorv1.Managed)
+
+	t.Log("Creating Kserve CR for the module operator to reconcile")
+	tc.EventuallyResourceCreatedOrUpdated(
+		WithObjectToCreate(tc.CreateComponent(gvk.Kserve)),
+	)
+
+	t.Log("Waiting for Kserve module CR to reach Ready=True")
+	tc.EnsureResourceExists(
+		WithMinimalObject(gvk.Kserve, types.NamespacedName{Name: tc.GetInstanceName(gvk.Kserve)}),
+		WithCondition(jq.Match(`any(.status.conditions[]; .type == "Ready" and .status == "True")`)),
+		WithEventuallyTimeout(tc.TestTimeouts.longEventuallyTimeout),
+		WithEventuallyPollingInterval(15*time.Second),
+		WithCustomErrorMsg("Kserve should reach Ready=True on xKS after the Platform controller processes runlevel 31"),
+	)
+
+	t.Log("Verifying Platform CR ProvisioningProgress=True")
+	tc.EnsureResourceExists(
+		WithMinimalObject(gvk.Platform, tc.PlatformNamespacedName),
+		WithCondition(jq.Match(
+			`any(.status.conditions[]; .type == "%s" and .status == "%s")`,
+			status.ConditionTypeProvisioningProgress, metav1.ConditionTrue,
+		)),
+		WithEventuallyTimeout(2*time.Minute),
+		WithEventuallyPollingInterval(tc.TestTimeouts.defaultEventuallyPollInterval),
+	)
 }
 
 // ValidateRunlevelGatingAndConvergence proves that the DAG readiness

--- a/tests/e2e/dag_ordering_test.go
+++ b/tests/e2e/dag_ordering_test.go
@@ -261,6 +261,7 @@ func (tc *DAGOrderingTestCtx) ValidateXKSRunlevelGating(t *testing.T) {
 		tc.DeleteResource(
 			WithMinimalObject(gvk.Kserve, types.NamespacedName{Name: tc.GetInstanceName(gvk.Kserve)}),
 			WithForegroundDeletion(),
+			WithIgnoreNotFound(true),
 			WithWaitForDeletion(true),
 		)
 		tc.SetModuleStateInPlatformCR(t, "kserve", operatorv1.Removed)


### PR DESCRIPTION
<!---
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
On xKS clusters (vanilla Kubernetes: EKS, GKE, AKS, kind) there's no `DataScienceCluster`, so `tests/e2e/dag_ordering_test.go` just skipped itself entirely via `SkipIfXKSCluster`. 

This adds `ValidateXKSRunlevelGating`, which enables Kserve through the `Platform` CR (how xKS enables components, since there's no DSC) and checks that it reaches `Ready=True`.

Original PR: https://github.com/opendatahub-io/opendatahub-operator/pull/3786

<!-- For RHOAI PRs, request review on #ai-core-platform-requests Slack channel -->

## Release tracking
<!-- Optional. Set a target release only if this PR must ship in a specific release; it will be prioritized accordingly. -->
<!-- Target release for this PR, e.g. rhoai-3.6 or rhoai-3.7ea1 -->
Release: 
<!-- Required only if a Release is set above. Full link to a jira ticket, e.g. https://redhat.atlassian.net/browse/RHOAIENG-XXXXX -->
Jira: https://redhat.atlassian.net/browse/RHOAIENG-72878

## How Has This Been Tested?
Ran it against a local kind cluster set up the same way CI does for xKS, with Cloud Manager, cert-manager, the LWS operator, and the Istio/service mesh operator all deployed for real. The test passed, and I cross-checked it against the `kserve-module-controller-manager` reconcile logs and the Kubernetes events too, not just the test's own pass/fail.

## Screenshot or short clip
Not applicable, this is a backend e2e test change with no UI.

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully
- [ ] New RELATED_IMAGE mappings are listed in ODH-Build-Config and RHOAI-Build-Config (CI validates names against build-config repos). Include links to build-config PRs in the description.

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [ ] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added end-to-end validation for enabling KServe on xKS clusters.
  * Verified KServe component readiness and platform provisioning progress.
  * Preserved and reorganized DAG ordering coverage for OpenShift clusters.
  * Updated automated test triggers to run when DAG ordering tests change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->