### PR TITLE
fix(trustyai): rename service image to RELATED_IMAGE_ODH_TRUSTYAI_SERVICE_PY_IMAGE

### DIFF
--- a/internal/controller/components/trustyai/trustyai_support.go
+++ b/internal/controller/components/trustyai/trustyai_support.go
@@ -21,7 +21,7 @@ const (
 
 var (
 	imageParamMap = map[string]string{
-		"trustyaiServiceImage":               "RELATED_IMAGE_ODH_TRUSTYAI_SERVICE_IMAGE",
+		"trustyaiServiceImage":               "RELATED_IMAGE_ODH_TRUSTYAI_SERVICE_PY_IMAGE",
 		"trustyaiOperatorImage":              "RELATED_IMAGE_ODH_TRUSTYAI_SERVICE_OPERATOR_IMAGE",
 		"lmes-driver-image":                  "RELATED_IMAGE_ODH_TA_LMES_DRIVER_IMAGE",
 		"lmes-pod-image":                     "RELATED_IMAGE_ODH_TA_LMES_JOB_IMAGE",


### PR DESCRIPTION
## Description

Rename `RELATED_IMAGE_ODH_TRUSTYAI_SERVICE_IMAGE` to `RELATED_IMAGE_ODH_TRUSTYAI_SERVICE_PY_IMAGE` in the TrustyAI image param map to align with the upstream trustyai-service-operator.

Related:
1. https://github.com/trustyai-explainability/trustyai-service-operator/pull/887
2. https://redhat.atlassian.net/browse/RHAISTRAT-130

## Release tracking

Release: rhoai-3.6-EA1

### E2E test suite update requirement

- [x] Skip requirement to update E2E test suite for this PR

#### E2E update requirement opt-out justification

This PR only renames an environment variable reference — no operator logic or behavior changes. No E2E test updates are required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

- Updated the TrustyAI service image configuration to use the correct Python service image reference.
- Added the image reference to the supported component configuration, improving deployment compatibility and ensuring the service uses the intended image.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->