### PR TITLE
fix: set trainer to Removed in DSC sample to prevent cascading test failures

### DIFF
--- a/config/rhoai/samples/datasciencecluster_v2_datasciencecluster.yaml
+++ b/config/rhoai/samples/datasciencecluster_v2_datasciencecluster.yaml
@@ -25,7 +25,7 @@ spec:
     kueue:
       managementState: "Removed"
     trainer:
-      managementState: "Managed"
+      managementState: "Removed"
     ray:
       managementState: "Managed"
     workbenches:


### PR DESCRIPTION
## Summary
- Change `trainer.managementState` from `Managed` to `Removed` in the DSC sample YAML
- Prevents cascading test failures when the prerequisite JobSet operator is not installed

## Root cause
The DSC sample sets `trainer: Managed` but the JobSet operator (prerequisite) is not installed on test clusters. This causes:
- `TrainerReady: False ("JobSet operator not installed, please install it first")`
- `DSC Ready: False ("Some components are not ready: trainer")`
- All MaaS Billing tests fail at the `maas_subscription_controller_enabled_latest` fixture (600s timeout waiting for `Ready=True`)

`ModelsAsServiceReady: True` — MaaS is fully operational, but the test fixture can't proceed because DSC `Ready` requires ALL components healthy.

Same class of issue as RHOAIENG-85607 (DSC sample missing `modelsAsService`, fixed by PR #40798).

## Verified on clusters
- `swattamw340-pool-hh5jt` (RHOAI 3.4.4): 11/11 MaaS Billing tests failed
- `mt-gcp-1508-pool-xtmbm` (RHOAI 3.4.4): Trainer stuck in deletion, same cascade

## Test plan
- [ ] MaaS Billing tests pass on clusters without JobSet operator installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Disabled automatic management of the trainer component in the Data Science Cluster configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->