### PR TITLE
RHOAIENG-75601: fail resolve-image-digests on illegal imageOverrides

### DIFF
--- a/.github/workflows/test-unit.yaml
+++ b/.github/workflows/test-unit.yaml
@@ -9,8 +9,10 @@ on:
       - 'internal/**'
       - 'pkg/**'
       - 'cmd/main.go'
+      - 'cmd/manifest-tools/**'
       - 'api/**'
       - 'config/**'
+      - 'manifests-config.yaml'
 
 jobs:
   unit-test:

--- a/cmd/manifest-tools/pkg/config/config.go
+++ b/cmd/manifest-tools/pkg/config/config.go
@@ -96,6 +96,51 @@ func ExtractBranch(ref string) string {
 	return ref
 }
 
+var tagPlaceholderPattern = regexp.MustCompile(`\{[^{}]+\}`)
+
+const (
+	// TagSHA and TagShortSHA are the only placeholders ValidateTagTemplate
+	// accepts. Substitution uses the same strings when building a registry tag.
+	TagSHA      = "{SHA}"
+	TagShortSHA = "{SHORT_SHA}"
+)
+
+// ValidateTagTemplate returns an error unless template can be used to build an
+// image tag from a component SHA. It must contain TagSHA and/or TagShortSHA.
+// Every {…} token must be one of those two (case-sensitive). Prefixes and
+// suffixes are allowed. Leftover { or } after those tokens, and whitespace-only
+// values, are rejected.
+func ValidateTagTemplate(template string) error {
+	if strings.TrimSpace(template) == "" {
+		return fmt.Errorf("must contain %s and/or %s", TagSHA, TagShortSHA)
+	}
+
+	placeholders := tagPlaceholderPattern.FindAllString(template, -1)
+	hasKnown := false
+	var unknown []string
+	for _, p := range placeholders {
+		switch p {
+		case TagSHA, TagShortSHA:
+			hasKnown = true
+		default:
+			unknown = append(unknown, p)
+		}
+	}
+	if len(unknown) > 0 {
+		return fmt.Errorf("unknown placeholder %s; only %s and %s are allowed",
+			strings.Join(unknown, ", "), TagSHA, TagShortSHA)
+	}
+	if !hasKnown {
+		return fmt.Errorf("must contain %s and/or %s", TagSHA, TagShortSHA)
+	}
+	remainder := strings.ReplaceAll(template, TagSHA, "")
+	remainder = strings.ReplaceAll(remainder, TagShortSHA, "")
+	if strings.ContainsAny(remainder, "{}") {
+		return fmt.Errorf("malformed placeholder; only %s and %s are allowed", TagSHA, TagShortSHA)
+	}
+	return nil
+}
+
 func Load(path string) (*ManifestsConfig, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
@@ -116,6 +161,33 @@ func Parse(data []byte) (*ManifestsConfig, error) {
 	}
 
 	return &cfg, nil
+}
+
+// CheckImageOverride returns an error if the row's name, source, component, or
+// tagTemplate is illegal, or if paramsEnvKey is set without a component. It
+// does not look up params.env on disk.
+func (c *ManifestsConfig) CheckImageOverride(envName string, override ImageOverride) error {
+	if !strings.HasPrefix(envName, "RELATED_IMAGE_") {
+		return fmt.Errorf("imageOverrides.%s: key must start with RELATED_IMAGE_", envName)
+	}
+	if override.Source != "" && override.Source != "csv" {
+		return fmt.Errorf("imageOverrides.%s.source: %q is not %q", envName, override.Source, "csv")
+	}
+	if override.Component != "" && c.FindComponent(override.Component) == nil {
+		return fmt.Errorf("imageOverrides.%s.component: %q is not a key in components, ccmCharts, or componentCharts", envName, override.Component)
+	}
+	if override.TagTemplate != "" {
+		if override.Component == "" {
+			return fmt.Errorf("imageOverrides.%s.tagTemplate: requires component", envName)
+		}
+		if err := ValidateTagTemplate(override.TagTemplate); err != nil {
+			return fmt.Errorf("imageOverrides.%s.tagTemplate: %q: %w", envName, override.TagTemplate, err)
+		}
+	}
+	if override.ParamsEnvKey != "" && override.Component == "" {
+		return fmt.Errorf("imageOverrides.%s.paramsEnvKey: requires component", envName)
+	}
+	return nil
 }
 
 func (c *ManifestsConfig) FindComponent(name string) *Component {

--- a/cmd/manifest-tools/pkg/config/config_test.go
+++ b/cmd/manifest-tools/pkg/config/config_test.go
@@ -3,6 +3,7 @@ package config_test
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/opendatahub-io/opendatahub-operator/v2/cmd/manifest-tools/pkg/config"
@@ -277,5 +278,107 @@ func TestNodeDocSetAndSave(t *testing.T) {
 	dsp := cfg.ImageOverrides["RELATED_IMAGE_ODH_DSP_IMAGE"]
 	if dsp.ODH.Digest != "sha256:newdigest1234567890abcdef1234567890abcdef1234567890abcdef12345678" {
 		t.Errorf("unexpected digest after save: %s", dsp.ODH.Digest)
+	}
+}
+
+func TestValidateTagTemplate(t *testing.T) {
+	tests := []struct {
+		name    string
+		tmpl    string
+		wantErr string
+	}{
+		{name: "SHA", tmpl: "{SHA}"},
+		{name: "SHORT_SHA", tmpl: "{SHORT_SHA}"},
+		{name: "prefix", tmpl: "v{SHA}"},
+		{name: "suffix", tmpl: "{SHORT_SHA}-rc"},
+		{name: "both", tmpl: "v{SHORT_SHA}-{SHA}"},
+		{name: "unknown", tmpl: "{FOO}", wantErr: "unknown placeholder"},
+		{name: "unknown beside known", tmpl: "{SHA}-{FOO}", wantErr: "unknown placeholder"},
+		{name: "lowercase", tmpl: "{sha}", wantErr: "unknown placeholder"},
+		{name: "no braces", tmpl: "SHA", wantErr: "must contain"},
+		{name: "empty", tmpl: "", wantErr: "must contain"},
+		{name: "whitespace", tmpl: "   ", wantErr: "must contain"},
+		{name: "extra close", tmpl: "{SHA}}", wantErr: "malformed placeholder"},
+		{name: "extra open", tmpl: "{{SHA}", wantErr: "malformed placeholder"},
+		{name: "empty braces", tmpl: "{SHA}{}", wantErr: "malformed placeholder"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := config.ValidateTagTemplate(tt.tmpl)
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("ValidateTagTemplate(%q) unexpected error: %v", tt.tmpl, err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("ValidateTagTemplate(%q) wanted error containing %q", tt.tmpl, tt.wantErr)
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Errorf("ValidateTagTemplate(%q) error %q, want substring %q", tt.tmpl, err.Error(), tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestCheckImageOverride(t *testing.T) {
+	const catalog = `components:
+  ray:
+    odh:
+      repo: opendatahub-io/kuberay
+      ref: dev@abc
+      sourcePath: config
+`
+	tests := []struct {
+		name       string
+		overrides  string
+		wantSubstr string
+	}{
+		{
+			name:       "prefix",
+			overrides:  "  NOT_A_RELATED_IMAGE:\n    component: ray\n",
+			wantSubstr: "RELATED_IMAGE_",
+		},
+		{
+			name:       "source",
+			overrides:  "  RELATED_IMAGE_ODH_RAY_IMAGE:\n    source: csvv\n    component: ray\n",
+			wantSubstr: "csvv",
+		},
+		{
+			name:       "unknown component",
+			overrides:  "  RELATED_IMAGE_ODH_RAY_IMAGE:\n    component: does-not-exist\n",
+			wantSubstr: "does-not-exist",
+		},
+		{
+			name:       "tagTemplate",
+			overrides:  "  RELATED_IMAGE_ODH_RAY_IMAGE:\n    component: ray\n    tagTemplate: \"{FOO}\"\n",
+			wantSubstr: "{FOO}",
+		},
+		{
+			name:       "paramsEnvKey requires component",
+			overrides:  "  RELATED_IMAGE_ODH_RAY_IMAGE:\n    paramsEnvKey: IMAGES_DSPO\n",
+			wantSubstr: "requires component",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg, err := config.Parse([]byte(catalog + "imageOverrides:\n" + tt.overrides))
+			if err != nil {
+				t.Fatalf("Parse: %v", err)
+			}
+			var checkErr error
+			for envName, override := range cfg.ImageOverrides {
+				checkErr = cfg.CheckImageOverride(envName, override)
+				if checkErr != nil {
+					break
+				}
+			}
+			if checkErr == nil {
+				t.Fatal("expected CheckImageOverride to fail")
+			}
+			if !strings.Contains(checkErr.Error(), tt.wantSubstr) {
+				t.Errorf("error %q, want substring %q", checkErr.Error(), tt.wantSubstr)
+			}
+		})
 	}
 }

--- a/cmd/manifest-tools/pkg/e2escope/manifest_test.go
+++ b/cmd/manifest-tools/pkg/e2escope/manifest_test.go
@@ -15,6 +15,18 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const illegalImageOverrideKeyYAML = `
+components:
+  kserve:
+    odh:
+      repo: opendatahub-io/example
+      ref: main@aaa
+      sourcePath: config
+imageOverrides:
+  NOT_A_RELATED_IMAGE:
+    component: kserve
+`
+
 func TestResolveManifestNames_PlatformManifestsChangeForcesFullSuiteEvenWithAResolvedComponent(t *testing.T) {
 	root, _ := initGitRepo(t)
 	configPath := filepath.Join(root, "manifests-config.yaml")
@@ -46,4 +58,19 @@ platformManifests:
 
 	_, err := ResolveManifestNames(context.Background(), root, configPath, configCommit, nil)
 	assert.Error(t, err, "a platformManifests change must force the full suite even though kserve also resolved")
+}
+
+func TestLoadManifestsConfigAtRef_IllegalImageOverrideKeyStillParses(t *testing.T) {
+	root, _ := initGitRepo(t)
+	configPath := filepath.Join(root, "manifests-config.yaml")
+
+	require.NoError(t, os.WriteFile(configPath, []byte(illegalImageOverrideKeyYAML), 0o600))
+	runGitForTest(t, root, "add", "manifests-config.yaml")
+	runGitForTest(t, root, "commit", "-q", "-m", "illegal key")
+	commit := strings.TrimSpace(runGitForTest(t, root, "rev-parse", "HEAD"))
+
+	cfg, err := loadManifestsConfigAtRef(context.Background(), commit, configPath)
+	require.NoError(t, err)
+	_, ok := cfg.ImageOverrides["NOT_A_RELATED_IMAGE"]
+	assert.True(t, ok, "git show of a snapshot with an illegal imageOverrides key must still unmarshal")
 }

--- a/cmd/manifest-tools/pkg/resolver/image_base_test.go
+++ b/cmd/manifest-tools/pkg/resolver/image_base_test.go
@@ -1,0 +1,24 @@
+package resolver
+
+import "testing"
+
+func TestImageBaseWithoutTag(t *testing.T) {
+	tests := []struct {
+		ref  string
+		want string
+	}{
+		{ref: "quay.io/opendatahub/foo:tag", want: "quay.io/opendatahub/foo"},
+		{ref: "registry.example:5000/ns/img:tag", want: "registry.example:5000/ns/img"},
+		{ref: "localhost:5000/img:tag", want: "localhost:5000/img"},
+		{ref: "nginx:latest", want: "nginx"},
+		{ref: "quay.io/opendatahub/foo", want: "quay.io/opendatahub/foo"},
+		{ref: "registry.example:5000/ns/img", want: "registry.example:5000/ns/img"},
+		{ref: "quay.io/opendatahub/foo@sha256:abc", want: "quay.io/opendatahub/foo"},
+	}
+	for _, tt := range tests {
+		got := imageBaseWithoutTag(tt.ref)
+		if got != tt.want {
+			t.Errorf("imageBaseWithoutTag(%q) = %q, want %q", tt.ref, got, tt.want)
+		}
+	}
+}

--- a/cmd/manifest-tools/pkg/resolver/overrides_config_test.go
+++ b/cmd/manifest-tools/pkg/resolver/overrides_config_test.go
@@ -1,0 +1,325 @@
+package resolver_test
+
+import (
+	"bytes"
+	"context"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/opendatahub-io/opendatahub-operator/v2/cmd/manifest-tools/pkg/resolver"
+)
+
+const catalogYAML = `
+components:
+  ray:
+    odh:
+      repo: opendatahub-io/kuberay
+      ref: dev@ad425f7febc4039f2378747f2a0ea5dcf5a2263f
+      sourcePath: config
+ccmCharts:
+  cert-manager-operator:
+    odh:
+      repo: opendatahub-io/odh-gitops
+      ref: main@abc1234
+      sourcePath: charts
+componentCharts:
+  dashboard-operator:
+    odh:
+      repo: opendatahub-io/odh-dashboard
+      ref: main@abc1234
+      sourcePath: charts
+`
+
+func cancelledContext() context.Context {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	return ctx
+}
+
+func writePlantedConfig(t *testing.T, overridesYAML string) (string, []byte) {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "manifests-config.yaml")
+	content := []byte(strings.TrimSpace(catalogYAML) + "\nimageOverrides:\n" + overridesYAML)
+	if err := os.WriteFile(path, content, 0644); err != nil {
+		t.Fatal(err)
+	}
+	return path, content
+}
+
+func writeParamsTree(t *testing.T, component, paramsEnv string) string {
+	t.Helper()
+	root := t.TempDir()
+	dir := filepath.Join(root, component, "base")
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "params.env"), []byte(paramsEnv), 0644); err != nil {
+		t.Fatal(err)
+	}
+	return root
+}
+
+func TestResolve_MalformedImageOverrides(t *testing.T) {
+	rayBase := `
+  RELATED_IMAGE_ODH_RAY_IMAGE:
+    component: ray
+    tagTemplate: %s
+    odh:
+      base: "quay.io/opendatahub/kuberay-operator"
+`
+
+	tests := []struct {
+		name       string
+		overrides  string
+		manifests  string
+		wantSubstr []string
+	}{
+		{
+			name: "unknown component",
+			overrides: `
+  RELATED_IMAGE_ODH_RAY_IMAGE:
+    component: does-not-exist
+`,
+			wantSubstr: []string{"imageOverrides.RELATED_IMAGE_ODH_RAY_IMAGE.component", "does-not-exist"},
+		},
+		{
+			name: "csv unknown component",
+			overrides: `
+  RELATED_IMAGE_ODH_RAY_IMAGE:
+    source: csv
+    component: does-not-exist
+`,
+			wantSubstr: []string{"imageOverrides.RELATED_IMAGE_ODH_RAY_IMAGE.component", "does-not-exist"},
+		},
+		{
+			name:       "unknown placeholder",
+			overrides:  sprintfOverride(rayBase, `"{FOO}"`),
+			wantSubstr: []string{"imageOverrides.RELATED_IMAGE_ODH_RAY_IMAGE.tagTemplate", "{FOO}"},
+		},
+		{
+			name:       "lowercase placeholder",
+			overrides:  sprintfOverride(rayBase, `"{sha}"`),
+			wantSubstr: []string{"imageOverrides.RELATED_IMAGE_ODH_RAY_IMAGE.tagTemplate", "{sha}"},
+		},
+		{
+			name:       "no braces",
+			overrides:  sprintfOverride(rayBase, `"SHA"`),
+			wantSubstr: []string{"imageOverrides.RELATED_IMAGE_ODH_RAY_IMAGE.tagTemplate", "SHA"},
+		},
+		{
+			name:       "whitespace tagTemplate",
+			overrides:  sprintfOverride(rayBase, `"   "`),
+			wantSubstr: []string{"imageOverrides.RELATED_IMAGE_ODH_RAY_IMAGE.tagTemplate"},
+		},
+		{
+			name: "tagTemplate without component",
+			overrides: `
+  RELATED_IMAGE_ODH_RAY_IMAGE:
+    tagTemplate: "{SHA}"
+`,
+			wantSubstr: []string{"imageOverrides.RELATED_IMAGE_ODH_RAY_IMAGE.tagTemplate", "requires component"},
+		},
+		{
+			name: "csv tagTemplate without component",
+			overrides: `
+  RELATED_IMAGE_ODH_RAY_IMAGE:
+    source: csv
+    tagTemplate: "{SHA}"
+`,
+			wantSubstr: []string{"imageOverrides.RELATED_IMAGE_ODH_RAY_IMAGE.tagTemplate", "requires component"},
+		},
+		{
+			name: "paramsEnvKey missing key",
+			overrides: `
+  RELATED_IMAGE_ODH_RAY_IMAGE:
+    component: ray
+    paramsEnvKey: missing-key
+`,
+			manifests:  "tree",
+			wantSubstr: []string{"imageOverrides.RELATED_IMAGE_ODH_RAY_IMAGE.paramsEnvKey", "missing-key"},
+		},
+		{
+			name: "paramsEnvKey empty ManifestsDir",
+			overrides: `
+  RELATED_IMAGE_ODH_RAY_IMAGE:
+    component: ray
+    paramsEnvKey: missing-key
+`,
+			wantSubstr: []string{"imageOverrides.RELATED_IMAGE_ODH_RAY_IMAGE.paramsEnvKey", "manifests directory is required", "missing-key"},
+		},
+		{
+			name: "paramsEnvKey missing directory",
+			overrides: `
+  RELATED_IMAGE_ODH_RAY_IMAGE:
+    component: ray
+    paramsEnvKey: missing-key
+`,
+			manifests:  "empty",
+			wantSubstr: []string{"imageOverrides.RELATED_IMAGE_ODH_RAY_IMAGE.paramsEnvKey", "looking up", "missing-key"},
+		},
+		{
+			name: "paramsEnvKey requires component",
+			overrides: `
+  RELATED_IMAGE_ODH_RAY_IMAGE:
+    paramsEnvKey: IMAGES_DSPO
+`,
+			wantSubstr: []string{"imageOverrides.RELATED_IMAGE_ODH_RAY_IMAGE.paramsEnvKey", "requires component"},
+		},
+		{
+			name: "csv paramsEnvKey requires component",
+			overrides: `
+  RELATED_IMAGE_ODH_RAY_IMAGE:
+    source: csv
+    paramsEnvKey: IMAGES_DSPO
+`,
+			wantSubstr: []string{"imageOverrides.RELATED_IMAGE_ODH_RAY_IMAGE.paramsEnvKey", "requires component"},
+		},
+		{
+			name: "prefix",
+			overrides: `
+  NOT_A_RELATED_IMAGE:
+    component: ray
+`,
+			wantSubstr: []string{"imageOverrides.NOT_A_RELATED_IMAGE", "RELATED_IMAGE_"},
+		},
+		{
+			name: "source csvv",
+			overrides: `
+  RELATED_IMAGE_ODH_RAY_IMAGE:
+    source: csvv
+    component: ray
+`,
+			wantSubstr: []string{"imageOverrides.RELATED_IMAGE_ODH_RAY_IMAGE.source", "csvv"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path, original := writePlantedConfig(t, tt.overrides)
+			opts := resolver.Options{ConfigFile: path}
+			switch tt.manifests {
+			case "tree":
+				opts.ManifestsDir = writeParamsTree(t, "ray", "OTHER_KEY=value\n")
+			case "empty":
+				opts.ManifestsDir = t.TempDir()
+			}
+
+			_, err := resolver.Resolve(cancelledContext(), opts)
+			if err == nil {
+				t.Fatal("expected Resolve to fail")
+			}
+			msg := err.Error()
+			for _, sub := range tt.wantSubstr {
+				if !strings.Contains(msg, sub) {
+					t.Errorf("error %q, want substring %q", msg, sub)
+				}
+			}
+
+			got, readErr := os.ReadFile(path)
+			if readErr != nil {
+				t.Fatal(readErr)
+			}
+			if !bytes.Equal(got, original) {
+				t.Error("Resolve wrote manifests-config.yaml on error")
+			}
+		})
+	}
+}
+
+func sprintfOverride(format, tag string) string {
+	return strings.Replace(format, "%s", tag, 1)
+}
+
+func TestEnvVarQuotedInOperatorGo(t *testing.T) {
+	root := t.TempDir()
+	files := map[string]string{
+		"internal/prod.go":             `env := "RELATED_IMAGE_ODH_PROD"`,
+		"internal/prod_test.go":        `env := "RELATED_IMAGE_ODH_TESTFILE"`,
+		"cmd/manifest-tools/ignore.go": `env := "RELATED_IMAGE_ODH_TOOLS"`,
+		"cmd/other/main.go":            `env := "RELATED_IMAGE_ODH_CMD"`,
+		"pkg/deploy/env.go":            `env := "RELATED_IMAGE_ODH_PKG"`,
+		"pkg/manifest-tools/keep.go":   `env := "RELATED_IMAGE_ODH_NESTED"`,
+	}
+	for rel, body := range files {
+		path := filepath.Join(root, rel)
+		if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte(body), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	tests := []struct {
+		name string
+		env  string
+		want bool
+	}{
+		{name: "internal production Go", env: "RELATED_IMAGE_ODH_PROD", want: true},
+		{name: "cmd production Go", env: "RELATED_IMAGE_ODH_CMD", want: true},
+		{name: "pkg production Go", env: "RELATED_IMAGE_ODH_PKG", want: true},
+		{name: "pkg directory named manifest-tools", env: "RELATED_IMAGE_ODH_NESTED", want: true},
+		{name: "test file", env: "RELATED_IMAGE_ODH_TESTFILE"},
+		{name: "cmd/manifest-tools", env: "RELATED_IMAGE_ODH_TOOLS"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			found, err := envVarQuotedInOperatorGo(root, tt.env)
+			if err != nil {
+				t.Fatalf("%s: %v", tt.env, err)
+			}
+			if found != tt.want {
+				t.Errorf("envVarQuotedInOperatorGo(%q) = %v, want %v", tt.env, found, tt.want)
+			}
+		})
+	}
+}
+
+func envVarQuotedInOperatorGo(repoRoot, envName string) (bool, error) {
+	needle := []byte(strconv.Quote(envName))
+	for _, rel := range []string{"internal", "pkg", "cmd"} {
+		root := filepath.Join(repoRoot, rel)
+		if _, err := os.Stat(root); err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return false, err
+		}
+		var found bool
+		err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+			if d.IsDir() {
+				rel, relErr := filepath.Rel(repoRoot, path)
+				if relErr == nil && rel == filepath.Join("cmd", "manifest-tools") {
+					return filepath.SkipDir
+				}
+				return nil
+			}
+			if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+				return nil
+			}
+			data, readErr := os.ReadFile(path)
+			if readErr != nil {
+				return readErr
+			}
+			if bytes.Contains(data, needle) {
+				found = true
+				return filepath.SkipAll
+			}
+			return nil
+		})
+		if found {
+			return true, nil
+		}
+		if err != nil {
+			return false, err
+		}
+	}
+	return false, nil
+}

--- a/cmd/manifest-tools/pkg/resolver/params_env_lookup_test.go
+++ b/cmd/manifest-tools/pkg/resolver/params_env_lookup_test.go
@@ -1,0 +1,97 @@
+package resolver
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/opendatahub-io/opendatahub-operator/v2/cmd/manifest-tools/pkg/config"
+)
+
+func TestLookupParamsEnvKey(t *testing.T) {
+	dir := t.TempDir()
+
+	baseDir := filepath.Join(dir, "base")
+	if err := os.MkdirAll(baseDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(baseDir, "params.env"), []byte("MY_KEY=my-value\nEMPTY_KEY=\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	overlayDir := filepath.Join(dir, "overlays", "odh")
+	if err := os.MkdirAll(overlayDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(overlayDir, "params.env"), []byte("OVERLAY_KEY=overlay-value\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name      string
+		dir       string
+		key       string
+		want      string
+		wantFound bool
+		wantErr   bool
+	}{
+		{name: "subdirectory", key: "MY_KEY", want: "my-value", wantFound: true},
+		{name: "deeper subdirectory", key: "OVERLAY_KEY", want: "overlay-value", wantFound: true},
+		{name: "empty value", key: "EMPTY_KEY", wantFound: true},
+		{name: "missing key", key: "NONEXISTENT"},
+		{name: "missing directory", dir: "/nonexistent/dir", key: "KEY", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lookupDir := tt.dir
+			if lookupDir == "" {
+				lookupDir = dir
+			}
+			got, found, err := lookupParamsEnvKey(lookupDir, tt.key)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("lookupParamsEnvKey() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if found != tt.wantFound {
+				t.Errorf("found = %v, want %v", found, tt.wantFound)
+			}
+			if got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParamsEnvKeyLookup(t *testing.T) {
+	root := t.TempDir()
+	dir := filepath.Join(root, "ray", "base")
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	const present = "quay.io/opendatahub/kuberay-operator@sha256:abc"
+	if err := os.WriteFile(filepath.Join(dir, "params.env"), []byte("odh-kuberay-operator-controller-image="+present+"\nempty-key=\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name         string
+		paramsEnvKey string
+		want         string
+	}{
+		{name: "present", paramsEnvKey: "odh-kuberay-operator-controller-image", want: present},
+		{name: "empty value", paramsEnvKey: "empty-key"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := paramsEnvKeyLookup(Options{ManifestsDir: root}, config.ImageOverride{
+				Component:    "ray",
+				ParamsEnvKey: tt.paramsEnvKey,
+			}, "RELATED_IMAGE_ODH_RAY_IMAGE")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/manifest-tools/pkg/resolver/resolver.go
+++ b/cmd/manifest-tools/pkg/resolver/resolver.go
@@ -34,6 +34,32 @@ func Resolve(ctx context.Context, opts Options) ([]Result, error) {
 		return nil, err
 	}
 
+	envNames := make([]string, 0, len(cfg.ImageOverrides))
+	for envName := range cfg.ImageOverrides {
+		envNames = append(envNames, envName)
+	}
+	sort.Strings(envNames)
+
+	// Look up params.env before any digest work or CSV download so a missing
+	// key fails without rewriting the file or hitting the network.
+	slog.Info("Checking imageOverrides",
+		slog.String("file", opts.ConfigFile),
+		slog.String("manifestsDir", opts.ManifestsDir),
+		slog.Int("count", len(envNames)))
+	paramsEnvValue := make(map[string]string, len(envNames))
+	for _, envName := range envNames {
+		override := cfg.ImageOverrides[envName]
+		if err := cfg.CheckImageOverride(envName, override); err != nil {
+			return nil, err
+		}
+		val, err := paramsEnvKeyLookup(opts, override, envName)
+		if err != nil {
+			return nil, err
+		}
+		paramsEnvValue[envName] = val
+	}
+	slog.Info("imageOverrides check passed", slog.Int("count", len(envNames)))
+
 	nodeDoc, err := config.LoadNode(opts.ConfigFile)
 	if err != nil {
 		return nil, err
@@ -65,12 +91,6 @@ func Resolve(ctx context.Context, opts Options) ([]Result, error) {
 	}
 	var shaFromDeferred []shaFromEntry
 
-	envNames := make([]string, 0, len(cfg.ImageOverrides))
-	for envName := range cfg.ImageOverrides {
-		envNames = append(envNames, envName)
-	}
-	sort.Strings(envNames)
-
 	for _, envName := range envNames {
 		override := cfg.ImageOverrides[envName]
 		for _, platform := range []string{"odh", "rhoai"} {
@@ -99,10 +119,12 @@ func Resolve(ctx context.Context, opts Options) ([]Result, error) {
 
 			comp := cfg.FindComponent(override.Component)
 			if comp == nil {
+				slog.Info("No component, skipping digest lookup", slog.String("env", envName), slog.String("platform", platform))
 				continue
 			}
 			pr := comp.PlatformRepo(platform)
 			if pr == nil {
+				slog.Info("No platform repo, skipping", slog.String("env", envName), slog.String("platform", platform), slog.String("component", override.Component))
 				continue
 			}
 
@@ -114,6 +136,8 @@ func Resolve(ctx context.Context, opts Options) ([]Result, error) {
 
 			// Defer shaFrom entries to second pass so source digests are resolved first
 			if pi != nil && pi.SHAFrom != "" {
+				slog.Info("Deferring shaFrom until source digest is resolved",
+					slog.String("env", envName), slog.String("platform", platform), slog.String("shaFrom", pi.SHAFrom))
 				shaFromDeferred = append(shaFromDeferred, shaFromEntry{envName, platform, pi.SHAFrom})
 				continue
 			}
@@ -130,8 +154,8 @@ func Resolve(ctx context.Context, opts Options) ([]Result, error) {
 				if len(shortSHA) > 7 {
 					shortSHA = shortSHA[:7]
 				}
-				resolvedTag := strings.ReplaceAll(override.TagTemplate, "{SHA}", sha)
-				resolvedTag = strings.ReplaceAll(resolvedTag, "{SHORT_SHA}", shortSHA)
+				resolvedTag := strings.ReplaceAll(override.TagTemplate, config.TagSHA, sha)
+				resolvedTag = strings.ReplaceAll(resolvedTag, config.TagShortSHA, shortSHA)
 				imageRef := effectiveBase + ":" + resolvedTag
 
 				digest, err := ResolveDigestViaRegistry(ctx, imageRef)
@@ -157,46 +181,43 @@ func Resolve(ctx context.Context, opts Options) ([]Result, error) {
 				slog.Info("Registry lookup failed, falling through", slog.String("env", envName), slog.String("platform", platform), slog.String("imageRef", imageRef))
 			}
 
-			// Priority 2: params.env
-			if override.ParamsEnvKey != "" && override.Component != "" {
-				componentDir := fmt.Sprintf("%s/%s", opts.ManifestsDir, override.Component)
-				if imageRef, err := FindParamsEnvKey(componentDir, override.ParamsEnvKey); err == nil && imageRef != "" {
-					if strings.Contains(imageRef, "@sha256:") {
-						pBase, pDigest := SplitImageRef(imageRef)
-						if config.DigestPattern.MatchString(pDigest) {
-							if err := nodeDoc.SetImageOverrideField(envName, platform, "base", pBase); err != nil {
-								slog.Warn("Failed to set base field", slog.String("error", err.Error()))
-							}
-							if err := nodeDoc.SetImageOverrideField(envName, platform, "digest", pDigest); err != nil {
-								slog.Warn("Failed to set digest field", slog.String("error", err.Error()))
-							}
-							results = append(results, Result{envName, platform, pBase, pDigest, "params.env"})
-							if resolved[envName] == nil {
-								resolved[envName] = map[string]resolvedImage{}
-							}
-							resolved[envName][platform] = resolvedImage{pBase, pDigest}
-							slog.Info("Resolved via params.env", slog.String("env", envName), slog.String("platform", platform), slog.String("base", pBase), slog.String("digest", pDigest))
-							continue
-						}
-					}
-					// Tagged image → registry lookup
-					digest, err := ResolveDigestViaRegistry(ctx, imageRef)
-					if err == nil && config.DigestPattern.MatchString(digest) {
-						pBase, _, _ := strings.Cut(imageRef, ":")
+			// Priority 2: params.env (value cached during the check above)
+			if imageRef := paramsEnvValue[envName]; imageRef != "" {
+				if strings.Contains(imageRef, "@sha256:") {
+					pBase, pDigest := SplitImageRef(imageRef)
+					if config.DigestPattern.MatchString(pDigest) {
 						if err := nodeDoc.SetImageOverrideField(envName, platform, "base", pBase); err != nil {
 							slog.Warn("Failed to set base field", slog.String("error", err.Error()))
 						}
-						if err := nodeDoc.SetImageOverrideField(envName, platform, "digest", digest); err != nil {
+						if err := nodeDoc.SetImageOverrideField(envName, platform, "digest", pDigest); err != nil {
 							slog.Warn("Failed to set digest field", slog.String("error", err.Error()))
 						}
-						results = append(results, Result{envName, platform, pBase, digest, "params.env+registry"})
+						results = append(results, Result{envName, platform, pBase, pDigest, "params.env"})
 						if resolved[envName] == nil {
 							resolved[envName] = map[string]resolvedImage{}
 						}
-						resolved[envName][platform] = resolvedImage{pBase, digest}
-						slog.Info("Resolved via params.env+registry", slog.String("env", envName), slog.String("platform", platform), slog.String("base", pBase), slog.String("digest", digest))
+						resolved[envName][platform] = resolvedImage{pBase, pDigest}
+						slog.Info("Resolved via params.env", slog.String("env", envName), slog.String("platform", platform), slog.String("base", pBase), slog.String("digest", pDigest))
 						continue
 					}
+				}
+				// Tagged image → registry lookup
+				digest, err := ResolveDigestViaRegistry(ctx, imageRef)
+				if err == nil && config.DigestPattern.MatchString(digest) {
+					pBase := imageBaseWithoutTag(imageRef)
+					if err := nodeDoc.SetImageOverrideField(envName, platform, "base", pBase); err != nil {
+						slog.Warn("Failed to set base field", slog.String("error", err.Error()))
+					}
+					if err := nodeDoc.SetImageOverrideField(envName, platform, "digest", digest); err != nil {
+						slog.Warn("Failed to set digest field", slog.String("error", err.Error()))
+					}
+					results = append(results, Result{envName, platform, pBase, digest, "params.env+registry"})
+					if resolved[envName] == nil {
+						resolved[envName] = map[string]resolvedImage{}
+					}
+					resolved[envName][platform] = resolvedImage{pBase, digest}
+					slog.Info("Resolved via params.env+registry", slog.String("env", envName), slog.String("platform", platform), slog.String("base", pBase), slog.String("digest", digest))
+					continue
 				}
 			}
 
@@ -365,28 +386,63 @@ func SplitImageRef(ref string) (base, digest string) {
 	return ref[:idx], ref[idx+1:]
 }
 
-// FindParamsEnvKey searches for params.env files recursively under dir
-// and returns the value for the given key from the first file that contains it.
-func FindParamsEnvKey(dir, key string) (string, error) {
-	var result string
-	err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+// imageBaseWithoutTag returns the image name without a tag. The tag is the
+// colon suffix after the last slash, so a registry host:port is kept.
+func imageBaseWithoutTag(ref string) string {
+	if i := strings.LastIndex(ref, "@"); i >= 0 {
+		ref = ref[:i]
+	}
+	slash := strings.LastIndex(ref, "/")
+	colon := strings.LastIndex(ref, ":")
+	if colon > slash {
+		return ref[:colon]
+	}
+	return ref
+}
+
+func lookupParamsEnvKey(dir, key string) (value string, found bool, err error) {
+	err = filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
 		if err != nil || d.IsDir() || d.Name() != "params.env" {
 			return err
 		}
-		val, err := ReadParamsEnvKey(path, key)
-		if err == nil {
-			result = val
+		val, lookupErr := ReadParamsEnvKey(path, key)
+		if lookupErr == nil {
+			value = val
+			found = true
 			return filepath.SkipAll
 		}
 		return nil
 	})
-	if result != "" {
-		return result, nil
+	if found {
+		return value, true, nil
 	}
 	if err != nil {
-		return "", err
+		return "", false, err
 	}
-	return "", fmt.Errorf("key %q not found in any params.env under %s", key, dir)
+	return "", false, nil
+}
+
+func paramsEnvKeyLookup(opts Options, override config.ImageOverride, envName string) (string, error) {
+	if override.ParamsEnvKey == "" {
+		return "", nil
+	}
+	if opts.ManifestsDir == "" {
+		return "", fmt.Errorf("imageOverrides.%s.paramsEnvKey: manifests directory is required to look up %q", envName, override.ParamsEnvKey)
+	}
+	componentDir := filepath.Join(opts.ManifestsDir, override.Component)
+	val, found, err := lookupParamsEnvKey(componentDir, override.ParamsEnvKey)
+	if err != nil {
+		return "", fmt.Errorf("imageOverrides.%s.paramsEnvKey: looking up %q under %s: %w", envName, override.ParamsEnvKey, componentDir, err)
+	}
+	if !found {
+		return "", fmt.Errorf("imageOverrides.%s.paramsEnvKey: %q not found in any params.env under %s", envName, override.ParamsEnvKey, componentDir)
+	}
+	slog.Info("Found paramsEnvKey",
+		slog.String("env", envName),
+		slog.String("component", override.Component),
+		slog.String("paramsEnvKey", override.ParamsEnvKey),
+		slog.String("dir", componentDir))
+	return val, nil
 }
 
 func matchesRegistry(imageBase string, registries []string) bool {

--- a/cmd/manifest-tools/pkg/resolver/resolver_test.go
+++ b/cmd/manifest-tools/pkg/resolver/resolver_test.go
@@ -51,62 +51,6 @@ func TestReadParamsEnvKey_FileNotFound(t *testing.T) {
 	}
 }
 
-func TestFindParamsEnvKey(t *testing.T) {
-	dir := t.TempDir()
-
-	// Create nested structure: component/base/params.env
-	baseDir := filepath.Join(dir, "base")
-	if err := os.MkdirAll(baseDir, 0755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(baseDir, "params.env"), []byte("MY_KEY=my-value\n"), 0644); err != nil {
-		t.Fatal(err)
-	}
-
-	// Create another nested: component/overlays/odh/params.env
-	overlayDir := filepath.Join(dir, "overlays", "odh")
-	if err := os.MkdirAll(overlayDir, 0755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(overlayDir, "params.env"), []byte("OVERLAY_KEY=overlay-value\n"), 0644); err != nil {
-		t.Fatal(err)
-	}
-
-	t.Run("finds key in subdirectory", func(t *testing.T) {
-		got, err := resolver.FindParamsEnvKey(dir, "MY_KEY")
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if got != "my-value" {
-			t.Errorf("got %q, want %q", got, "my-value")
-		}
-	})
-
-	t.Run("finds key in deeper subdirectory", func(t *testing.T) {
-		got, err := resolver.FindParamsEnvKey(dir, "OVERLAY_KEY")
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if got != "overlay-value" {
-			t.Errorf("got %q, want %q", got, "overlay-value")
-		}
-	})
-
-	t.Run("returns error for missing key", func(t *testing.T) {
-		_, err := resolver.FindParamsEnvKey(dir, "NONEXISTENT")
-		if err == nil {
-			t.Error("expected error for missing key")
-		}
-	})
-
-	t.Run("returns error for missing directory", func(t *testing.T) {
-		_, err := resolver.FindParamsEnvKey("/nonexistent/dir", "KEY")
-		if err == nil {
-			t.Error("expected error for missing directory")
-		}
-	})
-}
-
 func TestSplitImageRef_EdgeCases(t *testing.T) {
 	tests := []struct {
 		ref        string

--- a/docs/AUTOMATED_MANIFEST_UPDATES.md
+++ b/docs/AUTOMATED_MANIFEST_UPDATES.md
@@ -46,3 +46,7 @@ Examples from `manifests-config.yaml`:
 
 - **Scheduled runs**: Daily at 6:00 AM UTC
 - **Manual triggers**: Available via GitHub Actions UI
+
+## Checking imageOverrides
+
+`make resolve-image-digests` fails if an `imageOverrides` row has an illegal key (must start with `RELATED_IMAGE_`), or if `component`, `tagTemplate`, `paramsEnvKey`, or `source` is set to a value that does not match its rules, and it does not rewrite `manifests-config.yaml`. PRs that change that YAML or `cmd/manifest-tools` run the unit tests that cover these errors.

--- a/manifests-config.yaml
+++ b/manifests-config.yaml
@@ -3,11 +3,10 @@
 # Top: repo definitions (components, ccmCharts, componentCharts).
 #   Per-platform sub-keys (odh / rhoai) with repo, ref, sourcePath.
 #
-# Bottom: imageOverrides — pinned operator image digests, keyed by component name.
-#   env:          RELATED_IMAGE_* env var name
+# Bottom: imageOverrides — pinned operator image digests, keyed by RELATED_IMAGE_* env var name.
 #   paramsEnvKey: key in params.env
 #   base:         full image URI without tag
-#   tagTemplate: "{SHA}"
+#   tagTemplate:  must contain {SHA} and/or {SHORT_SHA}; prefixes and suffixes are allowed (quote the value)
 #   odh.digest / rhoai.digest: pinned image digest (sha256:...)
 #   odh.pinned / rhoai.pinned: true to prevent resolve-image-digests from updating (add comment with reason)
 #   rhoai.shaFrom: resolve SHA from a different platform's manifest (e.g. "odh")
@@ -180,12 +179,11 @@ platformManifests:
   segment: config/segment
 #   component:    which component's SHA to use for tagTemplate (matches key in components/ccmCharts/componentCharts)
 #   paramsEnvKey: (optional) params.env key for Go runtime
-#   tagTemplate:  (optional) tag template for skopeo fallback (must be quoted when containing {SHORT_SHA})
+#   tagTemplate:  (optional) must contain {SHA} and/or {SHORT_SHA}; prefixes and suffixes are allowed (quote the value)
 #   odh/rhoai:    per-platform base image, digest, and optional shaFrom
 imageOverrides:
   RELATED_IMAGE_ODH_KSERVE_CONTROLLER_IMAGE:
     component: kserve-module-operator
-    paramsEnvKey: kserve-controller
     tagTemplate: "{SHA}"
     odh:
       base: "quay.io/opendatahub/kserve-controller"
@@ -196,7 +194,6 @@ imageOverrides:
       digest: "sha256:15ae54a475759e654380905f2f877df52503af77cacdc487aa777031d4d02582"
   RELATED_IMAGE_ODH_KSERVE_LLMISVC_CONTROLLER_IMAGE:
     component: kserve-module-operator
-    paramsEnvKey: kserve-llmisvc-controller
     tagTemplate: "{SHA}"
     odh:
       base: "quay.io/opendatahub/odh-kserve-llmisvc-controller"
@@ -207,7 +204,6 @@ imageOverrides:
       digest: "sha256:5204f3ec7cbf842ae82b24cdef9015e73afcd460fe04ef8a54cbe4bc17ec7854"
   RELATED_IMAGE_ODH_KSERVE_LOCALMODEL_CONTROLLER_IMAGE:
     component: kserve-module-operator
-    paramsEnvKey: kserve-localmodel-controller
     tagTemplate: "{SHA}"
     odh:
       base: "quay.io/opendatahub/odh-kserve-localmodel-controller"
@@ -272,7 +268,6 @@ imageOverrides:
       digest: "sha256:4db7f864ed11d3ea5585b56cb7d7473bf80d8a1dcfc47de343a7a182c805ecdc"
   RELATED_IMAGE_ODH_OGX_K8S_OPERATOR_IMAGE:
     component: ogx
-    paramsEnvKey: RELATED_IMAGE_ODH_OGX_OPERATOR
     tagTemplate: "{SHA}"
     odh:
       base: "quay.io/opendatahub/odh-ogx-k8s-operator"


### PR DESCRIPTION
## Description

`make resolve-image-digests` used to succeed and rewrite `manifests-config.yaml` when an `imageOverrides` row was illegal. `imageOverrides` is the catalog of operator images keyed by `RELATED_IMAGE_*` env names.

The command now fails and leaves the file unchanged when any of these is true:

- the key does not start with `RELATED_IMAGE_`
- `source` is set to something other than `csv`
- `component` is set but is not in `components`, `ccmCharts`, or `componentCharts`
- `tagTemplate` is set without a component, or it is not built from `{SHA}` and/or `{SHORT_SHA}` (prefixes and suffixes are allowed)
- `paramsEnvKey` is set without a component, or that key is not in the component's `params.env` (the kustomize `KEY=value` file in the cloned manifests)

The checks run after the YAML is read and before any ClusterServiceVersion download. `resolve-e2e-scope` (the command that picks e2e tests from a config diff) can still `git show` an old `manifests-config.yaml`, including one with a key that would fail these checks.

A `paramsEnvKey` whose `params.env` line is `KEY=` (empty value) does not fail the check. `resolve-image-digests` still ignores that empty value and tries another source. A row with no `component` still skips digest lookup.

The kserve and ogx rows no longer set `paramsEnvKey`, because those keys are not in those components' `params.env`. When `params.env` has a tagged image, the tag is the colon after the last slash, so a registry `host:port` stays in the base.

## Release tracking

Release:
Jira: https://redhat.atlassian.net/browse/RHOAIENG-75601

## How Has This Been Tested?

- Temporary `manifests-config.yaml` files with each of the mistakes above: `make resolve-image-digests` returns non-zero and the file bytes are unchanged.
- `git show` of a commit whose YAML has a key that does not start with `RELATED_IMAGE_` still unmarshals.
- Empty `KEY=` in `params.env` does not fail the check.
- `make unit-test-manifest-tools`
- `make lint`

PRs that change `cmd/manifest-tools` or `manifests-config.yaml` now run those unit tests.

## Screenshot or short clip

N/A. This is `resolve-image-digests`, not a UI.

## Merge criteria

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully
- [ ] New RELATED_IMAGE mappings are listed in ODH-Build-Config and RHOAI-Build-Config (CI validates names against build-config repos). Include links to build-config PRs in the description.

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification

This change is in `cmd/manifest-tools`, the CLI that pins image digests in CI. Cluster e2e does not run `resolve-image-digests`. Unit tests cover the new errors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for `{SHA}` and `{SHORT_SHA}` image tag templates.
  - Improved image override validation for sources, components, required fields, and parameter references.
  - Enhanced manifest resolution for `params.env` values, image tags, digests, and registry ports.
  - Missing components and platform repositories are now skipped during resolution.

- **Bug Fixes**
  - Invalid image overrides fail early without modifying configuration files.
  - Manifest loading tolerates unrelated `imageOverrides` entries.

- **Documentation**
  - Updated manifest configuration guidance and automated image update troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->