### PR TITLE
fix(modules): align test stubs with ModuleHandler interface after DAG migration

### DIFF
--- a/internal/controller/modules/handler_compliance_test.go
+++ b/internal/controller/modules/handler_compliance_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/opendatahub-io/opendatahub-operator/v2/api/common"
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/api/components/v1alpha1"
+	configv1alpha1 "github.com/opendatahub-io/opendatahub-operator/v2/api/config/v1alpha1"
 	dscv2 "github.com/opendatahub-io/opendatahub-operator/v2/api/datasciencecluster/v2"
 	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/modules"
 	aigatewayModule "github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/modules/aigateway"
@@ -39,42 +40,50 @@ func allHandlers() []modules.ModuleHandler {
 	}
 }
 
+func managedDSCContext() (*modules.DSCContext, *modules.ModuleCRConfig) {
+	return &modules.DSCContext{
+			DSC: &dscv2.DataScienceCluster{
+				Spec: dscv2.DataScienceClusterSpec{
+					Components: dscv2.Components{
+						Dashboard: componentApi.DSCDashboard{
+							ManagementSpec: common.ManagementSpec{ManagementState: operatorv1.Managed},
+						},
+						AIGateway: componentApi.DSCAIGateway{
+							ManagementSpec: common.ManagementSpec{ManagementState: operatorv1.Managed},
+						},
+						Kserve: componentApi.DSCKserve{
+							ManagementSpec: common.ManagementSpec{ManagementState: operatorv1.Managed},
+						},
+						Workbenches: componentApi.DSCWorkbenches{
+							ManagementSpec: common.ManagementSpec{ManagementState: operatorv1.Managed},
+						},
+						FeastOperator: componentApi.DSCFeastOperator{
+							ManagementSpec: common.ManagementSpec{ManagementState: operatorv1.Managed},
+						},
+						MLflowOperator: componentApi.DSCMLflowOperator{
+							ManagementSpec: common.ManagementSpec{ManagementState: operatorv1.Managed},
+						},
+						MCPLifecycleOperator: componentApi.DSCMCPLifecycleOperator{
+							ManagementSpec: common.ManagementSpec{ManagementState: operatorv1.Managed},
+						},
+						OGX: componentApi.DSCOGX{
+							ManagementSpec: common.ManagementSpec{ManagementState: operatorv1.Managed},
+						},
+					},
+				},
+			},
+		}, &modules.ModuleCRConfig{
+			ApplicationsNamespace: "opendatahub",
+			Release:               common.Release{Name: "Open Data Hub"},
+		}
+}
+
 func managedDSCPlatformContext() *modules.PlatformContext {
 	return &modules.PlatformContext{
 		ApplicationsNamespace: "opendatahub",
 		Release:               common.Release{Name: "Open Data Hub"},
 		ManifestsBasePath:     "/opt/manifests",
 		ChartsBasePath:        "/opt/charts",
-		DSC: &dscv2.DataScienceCluster{
-			Spec: dscv2.DataScienceClusterSpec{
-				Components: dscv2.Components{
-					Dashboard: componentApi.DSCDashboard{
-						ManagementSpec: common.ManagementSpec{ManagementState: operatorv1.Managed},
-					},
-					AIGateway: componentApi.DSCAIGateway{
-						ManagementSpec: common.ManagementSpec{ManagementState: operatorv1.Managed},
-					},
-					Kserve: componentApi.DSCKserve{
-						ManagementSpec: common.ManagementSpec{ManagementState: operatorv1.Managed},
-					},
-					Workbenches: componentApi.DSCWorkbenches{
-						ManagementSpec: common.ManagementSpec{ManagementState: operatorv1.Managed},
-					},
-					FeastOperator: componentApi.DSCFeastOperator{
-						ManagementSpec: common.ManagementSpec{ManagementState: operatorv1.Managed},
-					},
-					MLflowOperator: componentApi.DSCMLflowOperator{
-						ManagementSpec: common.ManagementSpec{ManagementState: operatorv1.Managed},
-					},
-					MCPLifecycleOperator: componentApi.DSCMCPLifecycleOperator{
-						ManagementSpec: common.ManagementSpec{ManagementState: operatorv1.Managed},
-					},
-					OGX: componentApi.DSCOGX{
-						ManagementSpec: common.ManagementSpec{ManagementState: operatorv1.Managed},
-					},
-				},
-			},
-		},
 	}
 }
 
@@ -117,7 +126,7 @@ func TestHandlerCompliance_GetOperatorManifestsReturnsAtLeastOneSource(t *testin
 }
 
 func TestHandlerCompliance_BuildModuleCR_ValidGVK(t *testing.T) {
-	platform := managedDSCPlatformContext()
+	dscCtx, cfg := managedDSCContext()
 
 	cli, err := fakeclient.New()
 	if err != nil {
@@ -127,7 +136,7 @@ func TestHandlerCompliance_BuildModuleCR_ValidGVK(t *testing.T) {
 	for _, h := range allHandlers() {
 		t.Run(h.GetName(), func(t *testing.T) {
 			g := NewWithT(t)
-			cr, err := h.BuildModuleCR(context.Background(), cli, platform)
+			cr, err := h.BuildModuleCR(context.Background(), cli, dscCtx, cfg)
 			g.Expect(err).ShouldNot(HaveOccurred())
 			if cr == nil {
 				return
@@ -142,16 +151,16 @@ func TestHandlerCompliance_BuildModuleCR_ValidGVK(t *testing.T) {
 	}
 }
 
-func TestHandlerCompliance_BuildModuleCR_NilPlatformReturnsError(t *testing.T) {
+func TestHandlerCompliance_BuildModuleCR_NilContextReturnsError(t *testing.T) {
 	for _, h := range allHandlers() {
 		t.Run(h.GetName(), func(t *testing.T) {
 			g := NewWithT(t)
-			cr, err := h.BuildModuleCR(context.Background(), nil, nil)
+			cr, err := h.BuildModuleCR(context.Background(), nil, nil, nil)
 			if err == nil && cr == nil {
-				t.Skipf("handler %s returns (nil, nil) for nil platform — acceptable if externally managed", h.GetName())
+				t.Skipf("handler %s returns (nil, nil) for nil context — acceptable if externally managed", h.GetName())
 			}
 			g.Expect(err).Should(HaveOccurred(),
-				"BuildModuleCR should return an error when PlatformContext is nil")
+				"BuildModuleCR should return an error when DSCContext is nil")
 		})
 	}
 }
@@ -166,13 +175,13 @@ func TestHandlerCompliance_IsEnabledFalseForNilPlatform(t *testing.T) {
 	}
 }
 
-func TestHandlerCompliance_IsEnabledFalseForEmptyPlatform(t *testing.T) {
+func TestHandlerCompliance_IsEnabledFalseForEmptyPlatformModules(t *testing.T) {
 	for _, h := range allHandlers() {
 		t.Run(h.GetName(), func(t *testing.T) {
 			g := NewWithT(t)
-			empty := &modules.PlatformContext{ApplicationsNamespace: "ns"}
+			empty := &configv1alpha1.PlatformModules{}
 			g.Expect(h.IsEnabled(empty)).Should(BeFalse(),
-				"IsEnabled should return false when neither DSC nor Platform CR is set")
+				"IsEnabled should return false when PlatformModules has no modules enabled")
 		})
 	}
 }

--- a/internal/controller/modules/lifecycle_integration_test.go
+++ b/internal/controller/modules/lifecycle_integration_test.go
@@ -13,6 +13,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/opendatahub-io/opendatahub-operator/v2/api/common"
+	configv1alpha1 "github.com/opendatahub-io/opendatahub-operator/v2/api/config/v1alpha1"
 	dscv2 "github.com/opendatahub-io/opendatahub-operator/v2/api/datasciencecluster/v2"
 	dsciv2 "github.com/opendatahub-io/opendatahub-operator/v2/api/dscinitialization/v2"
 	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/status"
@@ -42,9 +43,12 @@ type lifecycleModuleStub struct {
 	deleteOperatorCalls int
 }
 
-func (s *lifecycleModuleStub) GetName() string                 { return s.name }
-func (s *lifecycleModuleStub) IsEnabled(*PlatformContext) bool { return s.enabled }
-func (s *lifecycleModuleStub) GetGVK() schema.GroupVersionKind { return s.gvk }
+func (s *lifecycleModuleStub) GetName() string                                { return s.name }
+func (s *lifecycleModuleStub) IsEnabled(*configv1alpha1.PlatformModules) bool { return s.enabled }
+func (s *lifecycleModuleStub) GetGVK() schema.GroupVersionKind                { return s.gvk }
+
+func (s *lifecycleModuleStub) PopulatePlatformModule(_ *configv1alpha1.PlatformModules, _ *DSCContext) {
+}
 
 func (s *lifecycleModuleStub) GetOperatorManifests(*PlatformContext) OperatorManifests {
 	return OperatorManifests{
@@ -52,7 +56,7 @@ func (s *lifecycleModuleStub) GetOperatorManifests(*PlatformContext) OperatorMan
 	}
 }
 
-func (s *lifecycleModuleStub) BuildModuleCR(_ context.Context, _ client.Client, _ *PlatformContext) (*unstructured.Unstructured, error) {
+func (s *lifecycleModuleStub) BuildModuleCR(_ context.Context, _ client.Client, _ *DSCContext, _ *ModuleCRConfig) (*unstructured.Unstructured, error) {
 	u := &unstructured.Unstructured{}
 	u.SetGroupVersionKind(s.gvk)
 	u.SetName("default-" + s.name)
@@ -116,9 +120,9 @@ func lifecycleRR(t *testing.T) (*types.ReconciliationRequest, *dscv2.DataScience
 
 // TestLifecycle_ProvisionThenDisableThenCleanup verifies the full module
 // lifecycle state machine:
-//  1. Enabled module → provisionModules adds its resources and manifests
-//  2. Module disabled, CR still alive → cleanupDisabledModules deletes CR,
-//     keeps operator manifests alive for finalizer processing
+//  1. Enabled module → provisionModules adds operator manifests
+//  2. Module disabled, CR still alive → cleanupDisabledModules keeps operator
+//     manifests alive (CR deletion is owned by DSC/DSCI controllers)
 //  3. Module disabled, CR absent → cleanupDisabledModules removes operator resources
 func TestLifecycle_ProvisionThenDisableThenCleanup(t *testing.T) {
 	withTestRegistry(t)
@@ -153,19 +157,18 @@ func TestLifecycle_ProvisionThenDisableThenCleanup(t *testing.T) {
 	provision.Add(moduleA.name, provision.KindModule, dag.RL(20))
 	provision.Add(moduleB.name, provision.KindModule, dag.RL(30))
 
-	// Phase 1: Both enabled — provision should add resources for both.
+	// Phase 1: Both enabled — provision should add manifests for both.
 	rr, dsc := lifecycleRR(t)
 	if err := provisionModules(context.Background(), rr); err != nil {
 		t.Fatalf("phase 1 provision: %v", err)
-	}
-	if len(rr.Resources) != 2 {
-		t.Fatalf("phase 1: expected 2 module CRs, got %d", len(rr.Resources))
 	}
 	if len(rr.Manifests) != 2 {
 		t.Fatalf("phase 1: expected 2 manifest entries, got %d", len(rr.Manifests))
 	}
 
-	// Phase 2: Disable module-b, CR is still alive → cleanup deletes CR, keeps operator.
+	// Phase 2: Disable module-b, CR is still alive → cleanup keeps operator
+	// manifests alive (CR deletion is handled by DSC/DSCI controllers, not
+	// the platform controller's cleanup action).
 	moduleB.enabled = false
 	moduleB.crState = CRStateAlive
 
@@ -173,11 +176,11 @@ func TestLifecycle_ProvisionThenDisableThenCleanup(t *testing.T) {
 	if err := cleanupDisabledModules(context.Background(), rr2); err != nil {
 		t.Fatalf("phase 2 cleanup: %v", err)
 	}
-	if moduleB.deleteCRCalls != 1 {
-		t.Fatalf("phase 2: expected 1 DeleteModuleCR call for module-b, got %d", moduleB.deleteCRCalls)
+	if moduleB.deleteCRCalls != 0 {
+		t.Fatalf("phase 2: cleanup should NOT delete module CR (owned by DSC controller), got %d calls", moduleB.deleteCRCalls)
 	}
 	if moduleB.deleteOperatorCalls != 0 {
-		t.Fatalf("phase 2: should NOT delete operator resources while CR is still being finalized")
+		t.Fatalf("phase 2: should NOT delete operator resources while CR is still alive")
 	}
 	if len(rr2.Manifests) != 1 {
 		t.Fatalf("phase 2: expected 1 manifest entry (operator kept alive), got %d", len(rr2.Manifests))
@@ -202,15 +205,15 @@ func TestLifecycle_ProvisionThenDisableThenCleanup(t *testing.T) {
 	if err := provisionModules(context.Background(), rr4); err != nil {
 		t.Fatalf("phase 4 re-provision: %v", err)
 	}
-	if len(rr4.Resources) != 1 {
-		t.Fatalf("phase 4: expected 1 module CR (only module-a), got %d", len(rr4.Resources))
+	if len(rr4.Manifests) != 1 {
+		t.Fatalf("phase 4: expected 1 manifest entry (only module-a), got %d", len(rr4.Manifests))
 	}
 
 	// Verify status computation reflects the final state.
 	rr5, _ := lifecycleRR(t)
 	rr5.Instance = dsc
 	rr5.Conditions = conditions.NewManager(dsc, status.ConditionTypeModulesReady)
-	if err := ComputeModulesStatus(context.Background(), rr5); err != nil {
+	if err := ComputeModulesStatusDetailed(context.Background(), rr5); err != nil {
 		t.Fatalf("status computation: %v", err)
 	}
 	modulesReady := conditions.FindStatusCondition(dsc.GetStatus(), status.ConditionTypeModulesReady)
@@ -298,7 +301,7 @@ func TestLifecycle_MultiModuleStatusAggregation(t *testing.T) {
 	rr, dsc := lifecycleRR(t)
 	rr.Conditions = conditions.NewManager(dsc, status.ConditionTypeModulesReady)
 
-	if err := ComputeModulesStatus(context.Background(), rr); err != nil {
+	if err := ComputeModulesStatusDetailed(context.Background(), rr); err != nil {
 		t.Fatalf("compute status: %v", err)
 	}
 
@@ -344,7 +347,7 @@ func TestLifecycle_AllDisabledReportsNoManagedModules(t *testing.T) {
 	rr, dsc := lifecycleRR(t)
 	rr.Conditions = conditions.NewManager(dsc, status.ConditionTypeModulesReady)
 
-	if err := ComputeModulesStatus(context.Background(), rr); err != nil {
+	if err := ComputeModulesStatusDetailed(context.Background(), rr); err != nil {
 		t.Fatalf("compute status: %v", err)
 	}
 
@@ -383,7 +386,7 @@ func TestLifecycle_StaleModuleStatusMarksNotReady(t *testing.T) {
 	rr, dsc := lifecycleRR(t)
 	rr.Conditions = conditions.NewManager(dsc, status.ConditionTypeModulesReady)
 
-	if err := ComputeModulesStatus(context.Background(), rr); err != nil {
+	if err := ComputeModulesStatusDetailed(context.Background(), rr); err != nil {
 		t.Fatalf("compute status: %v", err)
 	}
 


### PR DESCRIPTION
## Description

Tests from #3916 were merged against the pre-#3786 `ModuleHandler` interface. This PR updates `lifecycle_integration_test.go` and `handler_compliance_test.go` to match the current interface signatures and cleanup semantics:

- `BuildModuleCR` now takes `(*DSCContext, *ModuleCRConfig)` instead of `*PlatformContext`
- `IsEnabled` now takes `*configv1alpha1.PlatformModules` instead of `*PlatformContext`
- Added missing `PopulatePlatformModule` stub method
- `ComputeModulesStatus` renamed to `ComputeModulesStatusDetailed`
- Provisioning assertions use `rr.Manifests` (CRs no longer added to `rr.Resources` by `provisionModules`)
- Cleanup assertions reflect that CR deletion is now owned by DSC/DSCI controllers

Fixes the `golangci-lint` CI failure on main.

## Release tracking

Release: 
Jira: 

## How Has This Been Tested?

Ran unit tests and lint locally to verify they now pass.

## Screenshot or short clip

N/A

## Merge criteria

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully
- [ ] New RELATED_IMAGE mappings are listed in ODH-Build-Config and RHOAI-Build-Config (CI validates names against build-config repos). Include links to build-config PRs in the description.

- [x] Skip requirement to update E2E test suite for this PR

#### E2E update requirement opt-out justification

This PR only fixes compilation errors in existing unit/integration tests to align with interface changes already merged to main. No production code or E2E-testable behavior is changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved module lifecycle handling so operator resources are cleaned up only after the associated custom resource is removed.
  * Updated module status and provisioning checks for more accurate lifecycle behavior.
* **Tests**
  * Expanded validation of module configuration, enablement, custom resource creation, manifest handling, and nil-context scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->