### PR TITLE
fix(manifest-tools): fail fast when image overrides cannot be applied

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -472,10 +472,16 @@ deploy: prepare ## Deploy controller to the K8s cluster specified in ~/.kube/con
 	$(KUSTOMIZE) build $(CONFIG_DIR)/default | kubectl apply --namespace $(OPERATOR_NAMESPACE) -f -
 
 .PHONY: deploy-rhaii
+ifndef SKIP_IMAGE_OVERRIDES
+deploy-rhaii: apply-image-overrides
+endif
 deploy-rhaii: prepare ## Deploy controller in rhaii mode (only KServe) to the K8s cluster specified in ~/.kube/config.
 	$(KUSTOMIZE) build $(RHAII_DEFAULT_CONFIG_DIR) | $(SED_COMMAND) 's/REPLACE_RHAI_VERSION/$(VERSION)/g' | kubectl apply --namespace $(OPERATOR_NAMESPACE) -f -
 
 .PHONY: deploy-rhaii-local
+ifndef SKIP_IMAGE_OVERRIDES
+deploy-rhaii-local: apply-image-overrides
+endif
 deploy-rhaii-local: prepare ## Deploy controller in rhaii mode (only KServe, local image pull policy) to the K8s cluster specified in ~/.kube/config.
 	$(KUSTOMIZE) build $(RHAII_LOCAL_CONFIG_DIR) | $(SED_COMMAND) 's/REPLACE_RHAI_VERSION/$(VERSION)/g' | kubectl apply --namespace $(OPERATOR_NAMESPACE) -f -
 
@@ -857,7 +863,7 @@ e2e-setup-cluster:
 		-e E2E_TEST_CLEAN_UP_PREVIOUS_RESOURCES=true
 
 .PHONY: e2e-test-xks
-e2e-test-xks: ## Run e2e tests on external Kubernetes (KinD, AKS, CoreWeave, etc.)
+e2e-test-xks: ## Run e2e tests on external Kubernetes (KinD, AKS, CoreWeave, etc.). Image overrides are applied at deploy (see deploy-rhaii-local).
 	@$(MAKE) e2e-test \
 		-e E2E_TEST_CLEAN_UP_PREVIOUS_RESOURCES=false \
 		-e E2E_TEST_DEPENDANT_OPERATORS_MANAGEMENT=false \

--- a/cmd/manifest-tools/pkg/applier/deploy.go
+++ b/cmd/manifest-tools/pkg/applier/deploy.go
@@ -242,10 +242,9 @@ func loadOverridesFromConfig(configFile, platform string) ([]envVar, error) {
 		return nil, err
 	}
 
-	if platform == "OpenDataHub" {
-		platform = "odh"
-	} else if platform != "odh" && platform != "rhoai" {
-		platform = "rhoai"
+	platform, err = config.NormalizePlatform(platform)
+	if err != nil {
+		return nil, err
 	}
 
 	var vars []envVar
@@ -255,13 +254,18 @@ func loadOverridesFromConfig(configFile, platform string) ([]envVar, error) {
 		}
 
 		pi := override.PlatformImage(platform)
-		if pi == nil || pi.Digest == "" || pi.Base == "" {
+		if pi == nil {
+			slog.Info("No platform image defined, skipping", slog.String("env", envName), slog.String("platform", platform))
 			continue
 		}
-
+		if pi.Base == "" {
+			return nil, fmt.Errorf("imageOverrides.%s.%s.base: required", envName, platform)
+		}
+		if pi.Digest == "" {
+			return nil, fmt.Errorf("imageOverrides.%s.%s.digest: required", envName, platform)
+		}
 		if !config.DigestPattern.MatchString(pi.Digest) {
-			slog.Warn("Invalid digest, skipping", slog.String("env", envName), slog.String("digest", pi.Digest))
-			continue
+			return nil, fmt.Errorf("imageOverrides.%s.%s.digest: invalid digest %q", envName, platform, pi.Digest)
 		}
 
 		vars = append(vars, envVar{

--- a/cmd/manifest-tools/pkg/applier/deploy_test.go
+++ b/cmd/manifest-tools/pkg/applier/deploy_test.go
@@ -42,7 +42,7 @@ func writeManagerFile(t *testing.T) string {
 
 func TestApplyDeploy_UpdateExisting(t *testing.T) {
 	managerPath := writeManagerFile(t)
-	cfgPath := writeTestConfig(t)
+	cfgPath := writeValidTestConfig(t)
 
 	err := ApplyDeploy(DeployOptions{
 		ConfigFile:  cfgPath,
@@ -94,7 +94,7 @@ spec:
 	if err := os.WriteFile(managerPath, []byte(managerYAML), 0644); err != nil {
 		t.Fatal(err)
 	}
-	cfgPath := writeTestConfig(t)
+	cfgPath := writeValidTestConfig(t)
 
 	err := ApplyDeploy(DeployOptions{
 		ConfigFile:  cfgPath,
@@ -125,7 +125,7 @@ func TestApplyDeploy_NoDeployment(t *testing.T) {
 	if err := os.WriteFile(managerPath, []byte("apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: test\n"), 0644); err != nil {
 		t.Fatal(err)
 	}
-	cfgPath := writeTestConfig(t)
+	cfgPath := writeValidTestConfig(t)
 
 	err := ApplyDeploy(DeployOptions{
 		ConfigFile:  cfgPath,

--- a/cmd/manifest-tools/pkg/applier/olm.go
+++ b/cmd/manifest-tools/pkg/applier/olm.go
@@ -8,6 +8,8 @@ import (
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
@@ -67,21 +69,27 @@ func ApplyOLM(opts Options) error {
 
 	subName, err := findSubscription(ctx, dynClient, opts.Namespace, opts.OperatorPackage)
 	if err != nil {
-		slog.Info("OLM not available, skipping OLM image overrides", slog.String("error", err.Error()))
-		return nil
+		if isOLMAPIUnavailable(err) {
+			slog.Info("OLM Subscriptions API not available, skipping OLM image overrides",
+				slog.String("namespace", opts.Namespace))
+			return nil
+		}
+		return fmt.Errorf("listing subscriptions in namespace %s: %w", opts.Namespace, err)
 	}
 
 	if subName == "" {
-		slog.Info("No Subscription found, skipping OLM image overrides",
-			slog.String("package", opts.OperatorPackage), slog.String("namespace", opts.Namespace))
-		return nil
+		return fmt.Errorf("no Subscription for package %q found in namespace %s", opts.OperatorPackage, opts.Namespace)
 	}
 
-	return applyToSubscription(ctx, dynClient, clientset, opts.Namespace, subName, envVars)
+	return applyToSubscription(ctx, dynClient, clientset, opts.Namespace, subName, opts.OperatorPackage, envVars, 120*time.Second)
+}
+
+func isOLMAPIUnavailable(err error) bool {
+	return meta.IsNoMatchError(err) || apierrors.IsNotFound(err)
 }
 
 func applyToSubscription(ctx context.Context, dynClient dynamic.Interface, clientset kubernetes.Interface,
-	namespace, subName string, envVars []envVar) error {
+	namespace, subName, operatorPackage string, envVars []envVar, rolloutTimeout time.Duration) error {
 
 	slog.Info("Found Subscription", slog.String("name", subName), slog.String("namespace", namespace))
 
@@ -136,16 +144,17 @@ func applyToSubscription(ctx context.Context, dynClient dynamic.Interface, clien
 		return fmt.Errorf("patching subscription: %w", err)
 	}
 
-	deployName, err := findDeployment(ctx, clientset, namespace)
-	if err != nil || deployName == "" {
-		slog.Warn("Could not find controller-manager deployment for rollout wait, Subscription patch was successful",
-			slog.String("namespace", namespace))
-		return nil
+	deployName, err := findDeployment(ctx, clientset, namespace, operatorPackage)
+	if err != nil {
+		return fmt.Errorf("finding operator deployment in namespace %s: %w", namespace, err)
+	}
+	if deployName == "" {
+		return fmt.Errorf("no operator deployment found in namespace %s after patching Subscription", namespace)
 	}
 
 	slog.Info("Waiting for Deployment rollout...")
-	if err := waitForRollout(ctx, clientset, namespace, deployName, 120*time.Second); err != nil {
-		slog.Warn("Rollout wait failed, Subscription patch was successful", slog.String("error", err.Error()))
+	if err := waitForRollout(ctx, clientset, namespace, deployName, rolloutTimeout); err != nil {
+		return fmt.Errorf("waiting for deployment %s rollout in namespace %s: %w", deployName, namespace, err)
 	}
 
 	slog.Info("Image overrides applied via Subscription")
@@ -176,19 +185,25 @@ func findSubscription(ctx context.Context, client dynamic.Interface, namespace, 
 	}
 }
 
-func findDeployment(ctx context.Context, client kubernetes.Interface, namespace string) (string, error) {
-	deployments, err := client.AppsV1().Deployments(namespace).List(ctx, metav1.ListOptions{
-		LabelSelector: "control-plane=controller-manager",
-	})
-	if err != nil {
-		return "", fmt.Errorf("listing deployments: %w", err)
+func findDeployment(ctx context.Context, client kubernetes.Interface, namespace, operatorPackage string) (string, error) {
+	selectors := []string{"control-plane=controller-manager"}
+	if operatorPackage != "" {
+		selectors = append(selectors, fmt.Sprintf("name=%s", operatorPackage))
 	}
 
-	if len(deployments.Items) == 0 {
-		return "", nil
+	for _, selector := range selectors {
+		deployments, err := client.AppsV1().Deployments(namespace).List(ctx, metav1.ListOptions{
+			LabelSelector: selector,
+		})
+		if err != nil {
+			return "", fmt.Errorf("listing deployments with selector %q: %w", selector, err)
+		}
+		if len(deployments.Items) > 0 {
+			return deployments.Items[0].Name, nil
+		}
 	}
 
-	return deployments.Items[0].Name, nil
+	return "", nil
 }
 
 func waitForRollout(ctx context.Context, client kubernetes.Interface, namespace, deployName string, timeout time.Duration) error {

--- a/cmd/manifest-tools/pkg/applier/olm_test.go
+++ b/cmd/manifest-tools/pkg/applier/olm_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -16,7 +17,7 @@ import (
 	fakeclientset "k8s.io/client-go/kubernetes/fake"
 )
 
-const testConfigYAML = `
+const validTestConfigYAML = `
 components:
   datasciencepipelines:
     odh:
@@ -32,34 +33,20 @@ imageOverrides:
     rhoai:
       base: quay.io/rhoai/dsp-operator
       digest: "sha256:aabbccdd11223344556677889900aabbccddeeff11223344556677889900aabb"
-  RELATED_IMAGE_NO_DIGEST:
-    component: datasciencepipelines
-    odh:
-      base: quay.io/opendatahub/no-digest
-  RELATED_IMAGE_BAD_DIGEST:
-    component: datasciencepipelines
-    odh:
-      base: quay.io/opendatahub/bad
-      digest: "sha256:short"
-  BAD_PREFIX:
-    component: datasciencepipelines
-    odh:
-      base: quay.io/opendatahub/bad-prefix
-      digest: "sha256:4db7f864ed11d3ea5585b56cb7d7473bf80d8a1dcfc47de343a7a182c805ecdc"
 `
 
-func writeTestConfig(t *testing.T) string {
+func writeValidTestConfig(t *testing.T) string {
 	t.Helper()
 	dir := t.TempDir()
 	cfgPath := filepath.Join(dir, "config.yaml")
-	if err := os.WriteFile(cfgPath, []byte(testConfigYAML), 0644); err != nil {
+	if err := os.WriteFile(cfgPath, []byte(validTestConfigYAML), 0644); err != nil {
 		t.Fatal(err)
 	}
 	return cfgPath
 }
 
 func TestLoadOverridesFromConfig(t *testing.T) {
-	cfgPath := writeTestConfig(t)
+	cfgPath := writeValidTestConfig(t)
 
 	vars, err := loadOverridesFromConfig(cfgPath, "odh")
 	if err != nil {
@@ -79,7 +66,7 @@ func TestLoadOverridesFromConfig(t *testing.T) {
 }
 
 func TestLoadOverridesFromConfig_RHOAI(t *testing.T) {
-	cfgPath := writeTestConfig(t)
+	cfgPath := writeValidTestConfig(t)
 
 	vars, err := loadOverridesFromConfig(cfgPath, "rhoai")
 	if err != nil {
@@ -103,7 +90,7 @@ func TestLoadOverridesFromConfig_MissingFile(t *testing.T) {
 }
 
 func TestLoadOverridesFromConfig_PlatformNormalization(t *testing.T) {
-	cfgPath := writeTestConfig(t)
+	cfgPath := writeValidTestConfig(t)
 
 	vars, err := loadOverridesFromConfig(cfgPath, "OpenDataHub")
 	if err != nil {
@@ -112,6 +99,107 @@ func TestLoadOverridesFromConfig_PlatformNormalization(t *testing.T) {
 
 	if len(vars) != 1 || vars[0].Name != "RELATED_IMAGE_DSP" {
 		t.Errorf("OpenDataHub should normalize to odh, got %d vars", len(vars))
+	}
+}
+
+func TestLoadOverridesFromConfig_MissingDigest(t *testing.T) {
+	cfgYAML := `
+components:
+  datasciencepipelines:
+    odh:
+      repo: opendatahub-io/dsp
+      ref: main@abc123
+      sourcePath: config
+imageOverrides:
+  RELATED_IMAGE_NO_DIGEST:
+    component: datasciencepipelines
+    odh:
+      base: quay.io/opendatahub/no-digest
+`
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(cfgPath, []byte(cfgYAML), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := loadOverridesFromConfig(cfgPath, "odh")
+	if err == nil {
+		t.Fatal("expected error for missing digest")
+	}
+	if !strings.Contains(err.Error(), "RELATED_IMAGE_NO_DIGEST") {
+		t.Errorf("expected RELATED_IMAGE_NO_DIGEST in error, got: %v", err)
+	}
+}
+
+func TestLoadOverridesFromConfig_BadDigest(t *testing.T) {
+	cfgYAML := `
+components:
+  datasciencepipelines:
+    odh:
+      repo: opendatahub-io/dsp
+      ref: main@abc123
+      sourcePath: config
+imageOverrides:
+  RELATED_IMAGE_BAD_DIGEST:
+    component: datasciencepipelines
+    odh:
+      base: quay.io/opendatahub/bad
+      digest: "sha256:short"
+`
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(cfgPath, []byte(cfgYAML), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := loadOverridesFromConfig(cfgPath, "odh")
+	if err == nil {
+		t.Fatal("expected error for invalid digest")
+	}
+	if !strings.Contains(err.Error(), "invalid digest") {
+		t.Errorf("expected invalid digest in error, got: %v", err)
+	}
+}
+
+func TestLoadOverridesFromConfig_UnknownPlatform(t *testing.T) {
+	cfgPath := writeValidTestConfig(t)
+
+	_, err := loadOverridesFromConfig(cfgPath, "unknown")
+	if err == nil {
+		t.Fatal("expected error for unknown platform")
+	}
+	if !strings.Contains(err.Error(), "unknown platform") {
+		t.Errorf("expected unknown platform in error, got: %v", err)
+	}
+}
+
+func TestLoadOverridesFromConfig_MissingPlatformSkips(t *testing.T) {
+	cfgYAML := `
+components:
+  datasciencepipelines:
+    rhoai:
+      repo: opendatahub-io/dsp
+      ref: main@abc123
+      sourcePath: config
+imageOverrides:
+  RELATED_IMAGE_DSP:
+    component: datasciencepipelines
+    rhoai:
+      base: quay.io/rhoai/dsp-operator
+      digest: "sha256:aabbccdd11223344556677889900aabbccddeeff11223344556677889900aabb"
+`
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(cfgPath, []byte(cfgYAML), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	vars, err := loadOverridesFromConfig(cfgPath, "odh")
+	if err != nil {
+		t.Fatalf("expected no error when platform image is not defined, got: %v", err)
+	}
+	if len(vars) != 0 {
+		t.Errorf("expected 0 vars when platform image is not defined, got %d", len(vars))
 	}
 }
 
@@ -205,7 +293,7 @@ func TestFindDeployment(t *testing.T) {
 	}
 	client := fakeclientset.NewClientset(deploy)
 
-	name, err := findDeployment(context.Background(), client, "test-ns")
+	name, err := findDeployment(context.Background(), client, "test-ns", "opendatahub-operator")
 	if err != nil {
 		t.Fatalf("findDeployment failed: %v", err)
 	}
@@ -224,12 +312,34 @@ func TestFindDeployment_NoMatch(t *testing.T) {
 	}
 	client := fakeclientset.NewClientset(deploy)
 
-	name, err := findDeployment(context.Background(), client, "test-ns")
+	name, err := findDeployment(context.Background(), client, "test-ns", "opendatahub-operator")
 	if err != nil {
 		t.Fatalf("findDeployment failed: %v", err)
 	}
 	if name != "" {
 		t.Errorf("expected empty, got %s", name)
+	}
+}
+
+func TestFindDeployment_RHOAI(t *testing.T) {
+	deploy := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "rhods-operator",
+			Namespace: "test-ns",
+			Labels:    map[string]string{"name": "rhods-operator"},
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: int32Ptr(1),
+		},
+	}
+	client := fakeclientset.NewClientset(deploy)
+
+	name, err := findDeployment(context.Background(), client, "test-ns", "rhods-operator")
+	if err != nil {
+		t.Fatalf("findDeployment failed: %v", err)
+	}
+	if name != "rhods-operator" {
+		t.Errorf("expected rhods-operator, got %s", name)
 	}
 }
 
@@ -304,5 +414,57 @@ func TestWaitForRollout_ContextCancelled(t *testing.T) {
 	err := waitForRollout(ctx, client, "test-ns", "manager", 60*time.Second)
 	if err == nil {
 		t.Error("expected error on cancelled context")
+	}
+}
+
+func TestApplyToSubscription_NoDeployment(t *testing.T) {
+	ctx := context.Background()
+	namespace := "test-ns"
+	sub := newFakeSubscription("my-sub", namespace, "opendatahub-operator")
+	dynClient := newFakeDynClient(sub)
+	clientset := fakeclientset.NewClientset()
+
+	envVars := []envVar{{Name: "RELATED_IMAGE_DSP", Value: "quay.io/test@sha256:4db7f864ed11d3ea5585b56cb7d7473bf80d8a1dcfc47de343a7a182c805ecdc"}}
+
+	err := applyToSubscription(ctx, dynClient, clientset, namespace, "my-sub", "opendatahub-operator", envVars, 5*time.Second)
+	if err == nil {
+		t.Fatal("expected error when controller-manager deployment is missing")
+	}
+	if !strings.Contains(err.Error(), "no operator deployment found") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestApplyToSubscription_RolloutTimeout(t *testing.T) {
+	ctx := context.Background()
+	namespace := "test-ns"
+	sub := newFakeSubscription("my-sub", namespace, "opendatahub-operator")
+	dynClient := newFakeDynClient(sub)
+
+	deploy := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "manager",
+			Namespace:  namespace,
+			Generation: 2,
+			Labels:     map[string]string{"control-plane": "controller-manager"},
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: int32Ptr(1),
+		},
+		Status: appsv1.DeploymentStatus{
+			ReadyReplicas:      0,
+			ObservedGeneration: 1,
+		},
+	}
+	clientset := fakeclientset.NewClientset(deploy)
+
+	envVars := []envVar{{Name: "RELATED_IMAGE_DSP", Value: "quay.io/test@sha256:4db7f864ed11d3ea5585b56cb7d7473bf80d8a1dcfc47de343a7a182c805ecdc"}}
+
+	err := applyToSubscription(ctx, dynClient, clientset, namespace, "my-sub", "opendatahub-operator", envVars, time.Second)
+	if err == nil {
+		t.Fatal("expected error when rollout does not complete")
+	}
+	if !strings.Contains(err.Error(), "waiting for deployment manager rollout") {
+		t.Errorf("unexpected error: %v", err)
 	}
 }

--- a/cmd/manifest-tools/pkg/config/config.go
+++ b/cmd/manifest-tools/pkg/config/config.go
@@ -141,6 +141,17 @@ func ValidateTagTemplate(template string) error {
 	return nil
 }
 
+func NormalizePlatform(platform string) (string, error) {
+	switch platform {
+	case "OpenDataHub":
+		return "odh", nil
+	case "odh", "rhoai":
+		return platform, nil
+	default:
+		return "", fmt.Errorf("unknown platform %q: must be OpenDataHub, odh, or rhoai", platform)
+	}
+}
+
 func Load(path string) (*ManifestsConfig, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {


### PR DESCRIPTION
<!---
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description

Fail fast when digest-pinned image overrides from `manifests-config.yaml` cannot be applied to the running operator before e2e tests.

Previously, `apply-olm` (used by `make e2e-test` via `apply-image-overrides-olm`) returned success in several failure cases, so e2e could run with whatever images were baked into the operator at build time:

- No OLM Subscription for the operator → skipped
- Operator Deployment did not roll out after patching the Subscription → warned and continued
- Empty/invalid `imageOverrides` entries → skipped per name
- Unknown platform string → silently treated as `rhoai`

**Changes:**

- `cmd/manifest-tools/pkg/applier/olm.go`: return errors when no Subscription is found, OLM list fails, controller-manager Deployment is missing after patch, or rollout does not complete within the timeout.
- `cmd/manifest-tools/pkg/applier/deploy.go`: `loadOverridesFromConfig` returns errors for missing/invalid platform images instead of skipping entries; unknown platforms error instead of defaulting to `rhoai`.

`SKIP_IMAGE_OVERRIDES=1` continues to skip this step for `make deploy` and `make e2e-test` (local runs without an OLM install).

Epic: [RHOAIENG-75500](https://redhat.atlassian.net/browse/RHOAIENG-75500)

<!-- For RHOAI PRs, request review on #ai-core-platform-requests Slack channel -->

## Release tracking
<!-- Optional. Set a target release only if this PR must ship in a specific release; it will be prioritized accordingly. -->
<!-- Target release for this PR, e.g. rhoai-3.6 or rhoai-3.7ea1 -->
Release:
<!-- Required only if a Release is set above. Full link to a jira ticket, e.g. https://redhat.atlassian.net/browse/RHOAIENG-XXXXX -->
Jira: https://redhat.atlassian.net/browse/RHOAIENG-85317

## How Has This Been Tested?

**Unit tests**

```bash
go -C cmd/manifest-tools test ./pkg/applier/... -v
make unit-test-manifest-tools
```

Added/updated tests for: missing digest, invalid digest, unknown platform, no controller-manager Deployment after Subscription patch, rollout timeout, and existing success paths with a valid-only test config.

**Manual (no OLM / no Subscription)**

```bash
make apply-image-overrides-olm
# Expected: error (no Subscription), non-zero exit
```

**Manual (explicit skip)**

```bash
SKIP_IMAGE_OVERRIDES=1 make e2e-test
# Expected: apply step skipped; e2e proceeds without patching Subscription
```

**On a cluster with OLM operator installed**

```bash
make apply-image-overrides-olm
# Expected: success after Subscription patch and Deployment rollout
```

**Quality gates**

```bash
make fmt lint
```

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

N/A — CLI / Makefile behavior change.

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully
- [ ] New RELATED_IMAGE mappings are listed in ODH-Build-Config and RHOAI-Build-Config (CI validates names against build-config repos). Include links to build-config PRs in the description.

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification

This PR only changes `cmd/manifest-tools` applier behavior (pre-e2e setup: `apply-image-overrides-olm`). It does not change operator reconciliation, component APIs, or runtime behavior under test in the ginkgo e2e suites. Failure modes are covered by unit tests in `cmd/manifest-tools/pkg/applier`. The intended e2e effect is that `make e2e-test` stops before tests when overrides cannot be applied—unless `SKIP_IMAGE_OVERRIDES=1`.


[RHOAIENG-75500]: https://redhat.atlassian.net/browse/RHOAIENG-75500?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
- Invalid or unsupported platform values are now rejected instead of silently defaulting.
- Incomplete or malformed image overrides now stop deployment with clear errors.
- OLM application failures, missing subscriptions, unavailable deployments, and rollout timeouts are now reported as errors.
- Deployment operations no longer continue after critical configuration or rollout failures.

## New Features
- OLM image overrides are now applied during deployment by default, with an option to skip them.

## Tests
- Added coverage for invalid configuration, unsupported platforms, missing deployments, and rollout timeouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->