### PR TITLE
Image pin command succeeds when it cannot find the image for the cloned commit

### DIFF
--- a/.github/workflows/update-manifest-shas.yml
+++ b/.github/workflows/update-manifest-shas.yml
@@ -55,12 +55,27 @@ jobs:
         with:
           token: ${{ steps.generate-token.outputs.token }}
           commit-message: "chore: update manifest commit SHAs"
-          labels: "auto-bump-manifests-and-images"
+          labels: "auto-bump-manifests-and-images${{ steps.update-shas.outputs.fetch-failed == 'true' && ',do-not-merge' || '' }}"
           title: "chore: update manifest commit SHAs"
           body: |
             This PR updates the manifest commit SHAs to the latest available commits.
+            ${{ steps.update-shas.outputs.fetch-failed == 'true' && format('
+
+            > [!WARNING]
+            > These components failed to fetch from GitHub and were **not** updated:
+            > `{0}`
+
+            The scheduled workflow run is marked as failed. Please investigate.', steps.update-shas.outputs.failed-components) || '' }}
           branch: sync/upgrade-manifest-shas
           delete-branch: true
+
+      - name: Fail if any SHA fetches failed
+        if: steps.update-shas.outputs.fetch-failed == 'true'
+        env:
+          FAILED_COMPONENTS: ${{ steps.update-shas.outputs.failed-components }}
+        run: |
+          printf '::error::Some component SHA fetches failed: %s\n' "$FAILED_COMPONENTS"
+          exit 1
 
       - name: Output Summary
         if: steps.update-shas.outputs.updates-needed == 'true'

--- a/cmd/manifest-tools/pkg/cli/update_refs.go
+++ b/cmd/manifest-tools/pkg/cli/update_refs.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -36,15 +37,20 @@ func newUpdateRefsSHAsCommand(root *rootOptions) *cobra.Command {
 				return err
 			}
 
-			updated, err := updater.UpdateSHAs(cmd.Context(), updater.SHAsOptions{
+			result, err := updater.UpdateSHAs(cmd.Context(), updater.SHAsOptions{
 				ConfigFile: root.configFile,
 				GH:         gh,
 			})
+
+			writeGitHubOutput("updates-needed", fmt.Sprintf("%t", result.Updated))
+			if len(result.FailedComponents) > 0 {
+				writeGitHubOutput("fetch-failed", "true")
+				writeGitHubOutput("failed-components", strings.Join(result.FailedComponents, ", "))
+			}
+
 			if err != nil {
 				return err
 			}
-
-			writeGitHubOutput("updates-needed", fmt.Sprintf("%t", updated))
 			return nil
 		},
 	}

--- a/cmd/manifest-tools/pkg/resolver/resolver.go
+++ b/cmd/manifest-tools/pkg/resolver/resolver.go
@@ -18,6 +18,8 @@ type Options struct {
 	ConfigFile          string
 	ManifestsDir        string
 	CSVImportRegistries []string
+	// FetchCSVImages overrides the real HTTP fetch; used in tests only.
+	FetchCSVImages func(ctx context.Context) (map[string]CSVImage, error)
 }
 
 type Result struct {
@@ -69,7 +71,11 @@ func Resolve(ctx context.Context, opts Options) ([]Result, error) {
 	var unresolved []Result
 	var csvStale []string
 
-	csvImages, err := FetchCSVRelatedImages(ctx)
+	fetchCSV := opts.FetchCSVImages
+	if fetchCSV == nil {
+		fetchCSV = FetchCSVRelatedImages
+	}
+	csvImages, err := fetchCSV(ctx)
 	if err != nil {
 		slog.Warn("Failed to fetch CSV related images, csv fallback disabled", slog.String("error", err.Error()))
 	} else {
@@ -119,7 +125,13 @@ func Resolve(ctx context.Context, opts Options) ([]Result, error) {
 
 			comp := cfg.FindComponent(override.Component)
 			if comp == nil {
-				slog.Info("No component, skipping digest lookup", slog.String("env", envName), slog.String("platform", platform))
+				if override.Component == "" {
+					slog.Warn("No component specified for image override", slog.String("env", envName))
+				} else {
+					slog.Warn("Unknown component, cannot resolve image",
+						slog.String("env", envName), slog.String("component", override.Component))
+				}
+				unresolved = append(unresolved, Result{envName, platform, "", "", "unknown-component"})
 				continue
 			}
 			pr := comp.PlatformRepo(platform)
@@ -221,10 +233,8 @@ func Resolve(ctx context.Context, opts Options) ([]Result, error) {
 				}
 			}
 
-			slog.Warn("No source found via commit-sha or params.env", slog.String("env", envName), slog.String("platform", platform))
-
-			// Priority 3: ODH-Build-Config CSV
-			if csvImages != nil {
+			// Priority 3: CSV fallback (only if no cloned commit SHA)
+			if sha == "" && csvImages != nil {
 				if img, ok := csvImages[envName]; ok && config.DigestPattern.MatchString(img.Digest) {
 					if err := nodeDoc.SetImageOverrideField(envName, platform, "base", img.Base); err != nil {
 						slog.Warn("Failed to set base field", slog.String("error", err.Error()))
@@ -311,6 +321,11 @@ func Resolve(ctx context.Context, opts Options) ([]Result, error) {
 			continue
 		}
 		slog.Info("Removed stale CSV entry", slog.String("env", envName))
+	}
+
+	if len(unresolved) > 0 {
+		printSummary(results, unresolved)
+		return results, fmt.Errorf("%d image(s) could not be resolved for their cloned commits; check logs above", len(unresolved))
 	}
 
 	if err := nodeDoc.Save(opts.ConfigFile); err != nil {

--- a/cmd/manifest-tools/pkg/resolver/resolver_test.go
+++ b/cmd/manifest-tools/pkg/resolver/resolver_test.go
@@ -1,6 +1,7 @@
 package resolver_test
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -68,5 +69,75 @@ func TestSplitImageRef_EdgeCases(t *testing.T) {
 		if base != tt.wantBase || digest != tt.wantDigest {
 			t.Errorf("SplitImageRef(%q) = (%q, %q), want (%q, %q)", tt.ref, base, digest, tt.wantBase, tt.wantDigest)
 		}
+	}
+}
+
+func TestResolve_UnknownComponent_ReturnsError(t *testing.T) {
+	dir := t.TempDir()
+	configFile := filepath.Join(dir, "manifests-config.yaml")
+	manifestsDir := filepath.Join(dir, "manifests")
+	os.MkdirAll(manifestsDir, 0755)
+
+	// Config with imageOverrides entry pointing to non-existent component
+	content := `components: {}
+imageOverrides:
+  RELATED_IMAGE_TEST:
+    component: "nonexistent-component"
+    odh:
+      base: "quay.io/test/image"
+      tagTemplate: "v{SHA}"
+`
+	if err := os.WriteFile(configFile, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := resolver.Resolve(t.Context(), resolver.Options{
+		ConfigFile:   configFile,
+		ManifestsDir: manifestsDir,
+		FetchCSVImages: func(context.Context) (map[string]resolver.CSVImage, error) {
+			return map[string]resolver.CSVImage{}, nil
+		},
+	})
+	if err == nil {
+		t.Error("expected error for unknown component, got nil")
+	}
+}
+
+func TestResolve_ClonedCommitImageNotFound_ReturnsError(t *testing.T) {
+	dir := t.TempDir()
+	configFile := filepath.Join(dir, "manifests-config.yaml")
+	manifestsDir := filepath.Join(dir, "manifests")
+	os.MkdirAll(manifestsDir, 0755)
+
+	content := `components:
+  test-component:
+    odh:
+      repo: "test-org/test-repo"
+      ref: "main@abc123def456"
+      sourcePath: "config"
+imageOverrides:
+  RELATED_IMAGE_TEST:
+    component: "test-component"
+    odh:
+      base: "quay.io/test/image"
+      tagTemplate: "v{SHA}"
+`
+	if err := os.WriteFile(configFile, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	fakeFetch := func(_ context.Context) (map[string]resolver.CSVImage, error) {
+		return map[string]resolver.CSVImage{
+			"RELATED_IMAGE_TEST": {Base: "quay.io/bundle/image", Digest: "sha256:0000000000000000000000000000000000000000000000000000000000000000"},
+		}, nil
+	}
+
+	_, err := resolver.Resolve(t.Context(), resolver.Options{
+		ConfigFile:     configFile,
+		ManifestsDir:   manifestsDir,
+		FetchCSVImages: fakeFetch,
+	})
+	if err == nil {
+		t.Error("expected error for unresolved cloned commit image, got nil — CSV fallback must not apply to non-csv images")
 	}
 }

--- a/cmd/manifest-tools/pkg/updater/shas.go
+++ b/cmd/manifest-tools/pkg/updater/shas.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"sort"
 	"strings"
 
 	"github.com/opendatahub-io/opendatahub-operator/v2/cmd/manifest-tools/pkg/config"
@@ -14,15 +15,20 @@ type SHAsOptions struct {
 	GH         GitHubClient
 }
 
-func UpdateSHAs(ctx context.Context, opts SHAsOptions) (bool, error) {
+type SHAsResult struct {
+	Updated          bool
+	FailedComponents []string
+}
+
+func UpdateSHAs(ctx context.Context, opts SHAsOptions) (SHAsResult, error) {
 	cfg, err := config.Load(opts.ConfigFile)
 	if err != nil {
-		return false, err
+		return SHAsResult{}, err
 	}
 
 	nodeDoc, err := config.LoadNode(opts.ConfigFile)
 	if err != nil {
-		return false, err
+		return SHAsResult{}, err
 	}
 
 	gh := opts.GH
@@ -30,6 +36,8 @@ func UpdateSHAs(ctx context.Context, opts SHAsOptions) (bool, error) {
 	sections := allSections(cfg)
 
 	var updated int
+	var successfulFetches int
+	failedSet := map[string]struct{}{}
 
 	for _, sec := range sections {
 		for compName, comp := range sec.components {
@@ -55,8 +63,10 @@ func UpdateSHAs(ctx context.Context, opts SHAsOptions) (bool, error) {
 				latestSHA, err := gh.GetLatestCommitSHA(ctx, orgRepo[0], orgRepo[1], branch)
 				if err != nil {
 					slog.Warn("Failed to fetch SHA", slog.String("component", compName), slog.String("error", err.Error()))
+					failedSet[compName] = struct{}{}
 					continue
 				}
+				successfulFetches++
 
 				if latestSHA == currentSHA {
 					continue
@@ -78,15 +88,26 @@ func UpdateSHAs(ctx context.Context, opts SHAsOptions) (bool, error) {
 		}
 	}
 
+	failedComponents := make([]string, 0, len(failedSet))
+	for c := range failedSet {
+		failedComponents = append(failedComponents, c)
+	}
+	sort.Strings(failedComponents)
+	result := SHAsResult{Updated: updated > 0, FailedComponents: failedComponents}
+
+	if successfulFetches == 0 && len(failedComponents) > 0 {
+		return result, fmt.Errorf("%d component SHA fetch(es) failed and no SHAs were updated", len(failedComponents))
+	}
+
 	if updated == 0 {
 		slog.Info("All manifest references are up to date")
-		return false, nil
+		return result, nil
 	}
 
 	if err := nodeDoc.Save(opts.ConfigFile); err != nil {
-		return false, fmt.Errorf("saving config: %w", err)
+		return result, fmt.Errorf("saving config: %w", err)
 	}
 
 	slog.Info("Manifest SHAs updated", slog.Int("count", updated))
-	return true, nil
+	return result, nil
 }

--- a/cmd/manifest-tools/pkg/updater/shas_test.go
+++ b/cmd/manifest-tools/pkg/updater/shas_test.go
@@ -69,15 +69,18 @@ func TestUpdateSHAs_UpdatesChanged(t *testing.T) {
 		},
 	}
 
-	updated, err := UpdateSHAs(context.Background(), SHAsOptions{
+	result, err := UpdateSHAs(context.Background(), SHAsOptions{
 		ConfigFile: configPath,
 		GH:         gh,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if !updated {
+	if !result.Updated {
 		t.Fatal("expected updates-needed=true")
+	}
+	if len(result.FailedComponents) > 0 {
+		t.Fatalf("expected no failed components, got %v", result.FailedComponents)
 	}
 }
 
@@ -91,15 +94,18 @@ func TestUpdateSHAs_NoChanges(t *testing.T) {
 		},
 	}
 
-	updated, err := UpdateSHAs(context.Background(), SHAsOptions{
+	result, err := UpdateSHAs(context.Background(), SHAsOptions{
 		ConfigFile: configPath,
 		GH:         gh,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if updated {
+	if result.Updated {
 		t.Fatal("expected updates-needed=false when SHAs match")
+	}
+	if len(result.FailedComponents) > 0 {
+		t.Fatalf("expected no failed components, got %v", result.FailedComponents)
 	}
 }
 
@@ -117,15 +123,18 @@ componentCharts: {}
 
 	gh := &mockGitHub{shas: map[string]string{}}
 
-	updated, err := UpdateSHAs(context.Background(), SHAsOptions{
+	result, err := UpdateSHAs(context.Background(), SHAsOptions{
 		ConfigFile: configPath,
 		GH:         gh,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if updated {
+	if result.Updated {
 		t.Fatal("expected no updates for refs without SHA")
+	}
+	if len(result.FailedComponents) > 0 {
+		t.Fatalf("expected no failed components, got %v", result.FailedComponents)
 	}
 }
 
@@ -137,5 +146,54 @@ func TestUpdateSHAs_InvalidConfigPath(t *testing.T) {
 	})
 	if err == nil {
 		t.Fatal("expected error for missing config file")
+	}
+}
+
+func TestUpdateSHAs_PartialFailure_StillUpdatesOthers(t *testing.T) {
+	configPath := writeTestConfig(t, testConfigWithSHA)
+
+	// dashboard fetch fails, ray fetch succeeds with new SHA
+	gh := &mockGitHub{
+		shas: map[string]string{
+			"opendatahub-io/kuberay/dev": "newsha222233334444555566667777aaaabbbbcccc",
+		},
+		err: nil, // Will fail for dashboard (not in map), succeed for ray
+	}
+
+	result, err := UpdateSHAs(context.Background(), SHAsOptions{
+		ConfigFile: configPath,
+		GH:         gh,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.Updated {
+		t.Fatal("expected updates-needed=true (ray was updated)")
+	}
+	if len(result.FailedComponents) != 1 || result.FailedComponents[0] != "dashboard" {
+		t.Fatalf("expected failed-components=[dashboard], got %v", result.FailedComponents)
+	}
+}
+
+func TestUpdateSHAs_AllFetchesFail_ReturnsError(t *testing.T) {
+	configPath := writeTestConfig(t, testConfigWithSHA)
+
+	// All fetches fail (network error)
+	gh := &mockGitHub{
+		err: fmt.Errorf("network error"),
+	}
+
+	result, err := UpdateSHAs(context.Background(), SHAsOptions{
+		ConfigFile: configPath,
+		GH:         gh,
+	})
+	if err == nil {
+		t.Fatal("expected error when all fetches fail")
+	}
+	if result.Updated {
+		t.Fatal("expected updated=false when all fail")
+	}
+	if len(result.FailedComponents) != 2 {
+		t.Fatalf("expected 2 failed components, got %d", len(result.FailedComponents))
 	}
 }


### PR DESCRIPTION
<!---
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
Resolve-image-digests now fails when images cannot be found for cloned commits (no CSV fallback for non-csv images). update-refs-shas handles partial GitHub failures gracefully: updates components that succeed, warns in PR body, and fails the job only if all fetches fail. Added tests covering new failure paths.

https://redhat.atlassian.net/browse/RHOAIENG-85318




## How Has This Been Tested?
The test cases passed locally .

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [X] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [X] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work


### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [ ] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Manifest updates now identify components whose references could not be refreshed.
  - Partial failures preserve successful updates while reporting affected components.
  - Configurations are no longer saved when images remain unresolved or reference unknown components.
- **Reliability**
  - Update workflows now clearly distinguish partial and complete failures.
  - Generated pull requests include warnings and are marked do-not-merge when SHA retrieval fails.
  - Added stricter validation for unsupported image references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->