### PR TITLE
RHOAIENG-88161: remove obsolete paramsEnvKey entries from manifests-config

### DIFF
--- a/cmd/manifest-tools/pkg/config/e2e_scope_completeness_test.go
+++ b/cmd/manifest-tools/pkg/config/e2e_scope_completeness_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"sort"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -85,5 +86,30 @@ func TestManifestsConfigNamesAreKnownToE2EScopeRules(t *testing.T) {
 		if !known[override.Component] {
 			t.Errorf("manifests-config.yaml imageOverrides.%s references component %q, which has no matching entry, alias, or ignored-name in %s", envVar, override.Component, e2eScopeRulesRelPath)
 		}
+	}
+}
+
+// TestManifestsConfigImageOverridesAreValid validates that every entry in
+// manifests-config.yaml conforms to CheckImageOverride rules (valid RELATED_IMAGE_
+// prefix, known component, valid tagTemplate syntax, etc.).
+func TestManifestsConfigImageOverridesAreValid(t *testing.T) {
+	root := repoRoot(t)
+
+	manifestsCfg, err := config.Load(filepath.Join(root, manifestsConfigRelPath))
+	require.NoError(t, err, "loading %s", manifestsConfigRelPath)
+
+	envNames := make([]string, 0, len(manifestsCfg.ImageOverrides))
+	for envName := range manifestsCfg.ImageOverrides {
+		envNames = append(envNames, envName)
+	}
+	sort.Strings(envNames)
+
+	for _, envName := range envNames {
+		override := manifestsCfg.ImageOverrides[envName]
+		t.Run(envName, func(t *testing.T) {
+			if err := manifestsCfg.CheckImageOverride(envName, override); err != nil {
+				t.Errorf("manifests-config.yaml imageOverrides.%s invalid: %v", envName, err)
+			}
+		})
 	}
 }

--- a/cmd/manifest-tools/pkg/resolver/params_env_lookup_test.go
+++ b/cmd/manifest-tools/pkg/resolver/params_env_lookup_test.go
@@ -63,31 +63,86 @@ func TestLookupParamsEnvKey(t *testing.T) {
 
 func TestParamsEnvKeyLookup(t *testing.T) {
 	root := t.TempDir()
-	dir := filepath.Join(root, "ray", "base")
+	dir := filepath.Join(root, "component-with-params", "base")
 	if err := os.MkdirAll(dir, 0755); err != nil {
 		t.Fatal(err)
 	}
-	const present = "quay.io/opendatahub/kuberay-operator@sha256:abc"
-	if err := os.WriteFile(filepath.Join(dir, "params.env"), []byte("odh-kuberay-operator-controller-image="+present+"\nempty-key=\n"), 0644); err != nil {
+	const present = "quay.io/opendatahub/test-operator@sha256:abc"
+	if err := os.WriteFile(filepath.Join(dir, "params.env"), []byte("test-image-key="+present+"\nempty-key=\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	noParamsDir := filepath.Join(root, "component-without-params", "default")
+	if err := os.MkdirAll(noParamsDir, 0755); err != nil {
 		t.Fatal(err)
 	}
 
 	tests := []struct {
 		name         string
+		manifestsDir string
+		component    string
 		paramsEnvKey string
 		want         string
+		wantErr      bool
 	}{
-		{name: "present", paramsEnvKey: "odh-kuberay-operator-controller-image", want: present},
-		{name: "empty value", paramsEnvKey: "empty-key"},
+		{
+			name:         "present",
+			manifestsDir: root,
+			component:    "component-with-params",
+			paramsEnvKey: "test-image-key",
+			want:         present,
+		},
+		{
+			name:         "empty value",
+			manifestsDir: root,
+			component:    "component-with-params",
+			paramsEnvKey: "empty-key",
+		},
+		{
+			name:         "missing key in params.env",
+			manifestsDir: root,
+			component:    "component-with-params",
+			paramsEnvKey: "nonexistent-key",
+			wantErr:      true,
+		},
+		{
+			name:         "component directory has no params.env file",
+			manifestsDir: root,
+			component:    "component-without-params",
+			paramsEnvKey: "SOME_IMAGE_KEY",
+			wantErr:      true,
+		},
+		{
+			name:         "missing component directory",
+			manifestsDir: root,
+			component:    "nonexistent-component",
+			paramsEnvKey: "some-key",
+			wantErr:      true,
+		},
+		{
+			name:         "empty ManifestsDir",
+			manifestsDir: "",
+			component:    "component-with-params",
+			paramsEnvKey: "test-image-key",
+			wantErr:      true,
+		},
+		{
+			name:         "empty paramsEnvKey skips lookup",
+			manifestsDir: root,
+			component:    "component-with-params",
+			paramsEnvKey: "",
+			want:         "",
+			wantErr:      false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := paramsEnvKeyLookup(Options{ManifestsDir: root}, config.ImageOverride{
-				Component:    "ray",
+			got, err := paramsEnvKeyLookup(Options{ManifestsDir: tt.manifestsDir}, config.ImageOverride{
+				Component:    tt.component,
 				ParamsEnvKey: tt.paramsEnvKey,
-			}, "RELATED_IMAGE_ODH_RAY_IMAGE")
-			if err != nil {
-				t.Fatal(err)
+			}, "RELATED_IMAGE_TEST_IMAGE")
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("paramsEnvKeyLookup() error = %v, wantErr %v", err, tt.wantErr)
 			}
 			if got != tt.want {
 				t.Errorf("got %q, want %q", got, tt.want)

--- a/manifests-config.yaml
+++ b/manifests-config.yaml
@@ -278,7 +278,6 @@ imageOverrides:
       digest: "sha256:f7c6b2e020f200929ffe66646f1db66639f1db64f60381e2a9c1cc4509f1d528"
   RELATED_IMAGE_ODH_TRAINER_IMAGE:
     component: trainer
-    paramsEnvKey: odh-kubeflow-trainer-controller-image
     tagTemplate: "{SHA}"
     odh:
       base: "quay.io/opendatahub/trainer"
@@ -299,7 +298,6 @@ imageOverrides:
       digest: "sha256:0965acdfbd70daa7e6d4dd9d74a744eb282d9644fdd1ef74736e2d19ea9e13a3"
   RELATED_IMAGE_ODH_SPARK_OPERATOR_IMAGE:
     component: sparkoperator
-    paramsEnvKey: SPARK_OPERATOR_CONTROLLER_IMAGE
     tagTemplate: "{SHA}"
     odh:
       base: "quay.io/opendatahub/spark-operator"


### PR DESCRIPTION
## Description
Remove obsolete paramsEnvKey fields for RELATED_IMAGE_ODH_SPARK_OPERATOR_IMAGE
and RELATED_IMAGE_ODH_TRAINER_IMAGE in manifests-config.yaml. These keys no
longer exist in the respective component manifests after their module
migrations and caused resolve-image-digests pre-flight validation to fail.

Add TestManifestsConfigParamsEnvKeysExist and TestManifestsConfigImageOverridesAreValid
to validate imageOverrides and ensure paramsEnvKey entries exist in downloaded
manifests during unit test CI.

<!---
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->
<!--- Describe your changes in detail -->

<!-- For RHOAI PRs, request review on #ai-core-platform-requests Slack channel -->

## Release tracking
Release: rhoai-3.6ea1
Jira: https://redhat.atlassian.net/browse/RHOAIENG-88161


## How Has This Been Tested?
Ran `make resolve-image-digests` locally.
Also ran `make unit-test-manifest-tools` with the new test but without the changed manifest configs (fails on the new test as expected)

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully
- [x] New RELATED_IMAGE mappings are listed in ODH-Build-Config and RHOAI-Build-Config (CI validates names against build-config repos). Include links to build-config PRs in the description.

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [ ] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected manifest image configuration by removing invalid parameter environment key mappings for Trainer and Spark operator images.
  * Improved handling of missing or incomplete parameter configuration during manifest resolution.

* **Tests**
  * Added validation for configured image override entries.
  * Expanded coverage for missing keys, directories, configuration paths, and optional parameter lookups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->