### PR TITLE
feat(monitoring): convert service controller error logs to structured KV pairs (RHAI-526)

### DIFF
--- a/internal/controller/services/monitoring/monitoring_controller_support.go
+++ b/internal/controller/services/monitoring/monitoring_controller_support.go
@@ -428,7 +428,7 @@ func addMonitoringCapability(ctx context.Context, rr *odhtypes.ReconciliationReq
 	rr.Conditions.MarkUnknown(status.ConditionMonitoringAvailable)
 
 	if err := checkMonitoringPreconditions(ctx, rr); err != nil {
-		log.Error(err, "Monitoring preconditions failed")
+		log.Error(err, "Monitoring preconditions failed", "name", rr.Instance.GetName(), "namespace", rr.Instance.GetNamespace(), "resourceKind", "Monitoring")
 
 		rr.Conditions.MarkFalse(
 			status.ConditionMonitoringAvailable,

--- a/internal/controller/services/monitoring/monitoring_controller_support_test.go
+++ b/internal/controller/services/monitoring/monitoring_controller_support_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/go-logr/logr/funcr"
 	fwapi "github.com/opendatahub-io/odh-platform-utilities/framework/api"
 	operatorv1 "github.com/openshift/api/operator/v1"
 	"github.com/stretchr/testify/assert"
@@ -20,6 +21,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/opendatahub-io/opendatahub-operator/v2/api/common"
 	dsciv2 "github.com/opendatahub-io/opendatahub-operator/v2/api/dscinitialization/v2"
@@ -1815,6 +1817,43 @@ func TestDCGMRenameRulesInMetricRelabelConfigs(t *testing.T) {
 
 	assert.NotContains(t, relabelSection, "__name__",
 		"relabel_configs must not reference __name__ (unavailable at target-discovery stage)")
+}
+
+func TestLogErrorsFromAddMonitoringCapability(t *testing.T) {
+	g := NewWithT(t)
+
+	monitoring := &serviceApi.Monitoring{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-monitoring",
+			Namespace: "test-ns",
+		},
+		Spec: serviceApi.MonitoringSpec{
+			MonitoringCommonSpec: serviceApi.MonitoringCommonSpec{
+				Metrics: &serviceApi.Metrics{},
+			},
+		},
+	}
+
+	rr := &odhtypes.ReconciliationRequest{
+		Client:     fake.NewClientBuilder().Build(),
+		Instance:   monitoring,
+		Conditions: conditions.NewManager(monitoring, status.ConditionMonitoringAvailable),
+	}
+
+	var logged []string
+	logger := funcr.New(func(_, args string) {
+		logged = append(logged, args)
+	}, funcr.Options{})
+	ctx := logf.IntoContext(context.Background(), logger)
+
+	err := addMonitoringCapability(ctx, rr)
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(logged).To(ContainElement(And(
+		ContainSubstring(`"msg"="Monitoring preconditions failed"`),
+		ContainSubstring(`"name"="test-monitoring"`),
+		ContainSubstring(`"namespace"="test-ns"`),
+		ContainSubstring(`"resourceKind"="Monitoring"`),
+	)))
 }
 
 func extractSection(content, startMarker, endMarker string) string {


### PR DESCRIPTION
## Summary

- Convert the `log.Error()` call in `monitoring_controller_support.go` (`addMonitoringCapability`) to use structured KV pairs (`name`, `namespace`, `resourceKind`).
- Add `TestLogErrorsFromAddMonitoringCapability` unit test asserting all three structured fields are present.

**Note:** The other 4 service controllers (Auth, Gateway, CertConfigMapGenerator, Setup) and 3 action files have zero `log.Error()` calls — they propagate errors via `fmt.Errorf()` or use `log.Info()` only. No changes needed there.

Ref: [RHAI-526](https://redhat.atlassian.net/browse/RHAI-526)

## How Has This Been Tested?

- `make lint` passes (0 issues)
- `go test ./internal/controller/services/monitoring/...` passes
- `TestLogErrorsFromAddMonitoringCapability` asserts `name`, `namespace`, `resourceKind` present

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
Changes are limited to structured logging format (log.Error KV pairs) with no behavioral or API changes. Unit tests cover the new log format.

Made with [Cursor](https://cursor.com)

[RHAI-526]: https://redhat.atlassian.net/browse/RHAI-526?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved diagnostic logging when monitoring capability setup fails.
  * Error logs now include the monitoring resource’s name, namespace, and kind for easier troubleshooting.
  * Added validation coverage to verify errors and contextual logs are produced as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->