### PR TITLE
fix(manifest-tools): support RHOAI in apply-image-overrides

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,6 +89,8 @@ else
 	CCM_LOCAL_OVERLAY=rhoai
 endif
 
+MANAGER_FILE ?= $(CONFIG_DIR)/manager/manager.yaml
+
 IMAGE_BUILDER ?= podman
 DEFAULT_MANIFESTS_PATH ?= opt/manifests
 DEFAULT_CHARTS_PATH ?= opt/charts
@@ -370,7 +372,7 @@ update-refs-rhoai-branch: ## Update all RHOAI refs to a new branch (requires GIT
 
 .PHONY: apply-image-overrides
 apply-image-overrides: ## Apply image overrides to manager.yaml (for make deploy)
-	go run -C ./cmd/manifest-tools main.go apply-deploy --config $(CURDIR)/manifests-config.yaml --platform $(ODH_PLATFORM_TYPE) --manager-file $(CURDIR)/config/manager/manager.yaml
+	go run -C ./cmd/manifest-tools main.go apply-deploy --config $(CURDIR)/manifests-config.yaml --platform $(ODH_PLATFORM_TYPE) --manager-file $(CURDIR)/$(MANAGER_FILE)
 
 .PHONY: apply-image-overrides-olm
 apply-image-overrides-olm: ## Apply image overrides to OLM Subscription (for operator-sdk run bundle)

--- a/README.md
+++ b/README.md
@@ -355,7 +355,7 @@ e.g `make image-build USE_LOCAL=true"`
   make undeploy
   ```
 
-- `make deploy` auto-applies digest-pinned image overrides from `manifests-config.yaml` to `config/manager/manager.yaml`. To skip: `SKIP_IMAGE_OVERRIDES=1 make deploy`.
+- `make deploy` auto-applies digest-pinned image overrides from `manifests-config.yaml` to `config/manager/manager.yaml` (or `config/rhoai/manager/manager.yaml` when `ODH_PLATFORM_TYPE=rhoai`). To skip: `SKIP_IMAGE_OVERRIDES=1 make deploy`.
 
 #### Image Overrides
 

--- a/cmd/manifest-tools/pkg/applier/deploy.go
+++ b/cmd/manifest-tools/pkg/applier/deploy.go
@@ -47,7 +47,11 @@ func ApplyDeploy(opts DeployOptions) error {
 
 	root := docs[deployIdx].Content[0]
 
-	envNode, err := findManagerEnvNode(root)
+	platform, err := config.NormalizePlatform(opts.Platform)
+	if err != nil {
+		return err
+	}
+	envNode, err := findManagerEnvNode(root, platform)
 	if err != nil {
 		return fmt.Errorf("finding env node: %w", err)
 	}
@@ -119,7 +123,7 @@ func findScalarValue(mapping *yaml.Node, key string) string {
 	return ""
 }
 
-func findManagerEnvNode(root *yaml.Node) (*yaml.Node, error) {
+func findManagerEnvNode(root *yaml.Node, platform string) (*yaml.Node, error) {
 	spec := findMapNode(root, "spec")
 	if spec == nil {
 		return nil, fmt.Errorf("spec not found")
@@ -137,9 +141,18 @@ func findManagerEnvNode(root *yaml.Node) (*yaml.Node, error) {
 		return nil, fmt.Errorf("spec.template.spec.containers not found")
 	}
 
+	var containerName string
+	switch platform {
+	case "odh":
+		containerName = "manager"
+	case "rhoai":
+		containerName = "rhods-operator"
+	default:
+		return nil, fmt.Errorf("unknown platform: %s", platform)
+	}
 	for _, container := range containers.Content {
 		name := findScalarValue(container, "name")
-		if name == "manager" {
+		if name == containerName {
 			env := findSequenceNode(container, "env")
 			if env == nil {
 				env = &yaml.Node{Kind: yaml.SequenceNode}
@@ -152,7 +165,7 @@ func findManagerEnvNode(root *yaml.Node) (*yaml.Node, error) {
 		}
 	}
 
-	return nil, fmt.Errorf("container 'manager' not found")
+	return nil, fmt.Errorf("container '%s' not found", containerName)
 }
 
 func findMapNode(mapping *yaml.Node, key string) *yaml.Node {

--- a/cmd/manifest-tools/pkg/applier/deploy_test.go
+++ b/cmd/manifest-tools/pkg/applier/deploy_test.go
@@ -189,8 +189,156 @@ spec:
 		t.Fatal(err)
 	}
 	root := docs[0].Content[0]
-	_, err = findManagerEnvNode(root)
+	_, err = findManagerEnvNode(root, "odh")
 	if err == nil {
 		t.Fatal("expected error when manager container not found")
+	}
+}
+
+func TestApplyDeploy_RHOAI(t *testing.T) {
+	rhoaiYAML := `apiVersion: v1
+kind: Namespace
+metadata:
+  name: redhat-ods-operator
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: rhods-operator
+spec:
+  template:
+    spec:
+      containers:
+      - name: rhods-operator
+        env:
+          - name: OPERATOR_NAME
+            value: "rhods-operator"
+          - name: RELATED_IMAGE_DSP
+            value: "old-value"
+`
+	dir := t.TempDir()
+	managerPath := filepath.Join(dir, "manager.yaml")
+	if err := os.WriteFile(managerPath, []byte(rhoaiYAML), 0644); err != nil {
+		t.Fatal(err)
+	}
+	cfgPath := writeValidTestConfig(t)
+
+	err := ApplyDeploy(DeployOptions{
+		ConfigFile:  cfgPath,
+		Platform:    "rhoai",
+		ManagerFile: managerPath,
+	})
+	if err != nil {
+		t.Fatalf("ApplyDeploy failed for rhoai: %v", err)
+	}
+
+	data, err := os.ReadFile(managerPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	content := string(data)
+	if !strings.Contains(content, "quay.io/rhoai/dsp-operator@sha256:aabbccdd11223344556677889900aabbccddeeff11223344556677889900aabb") {
+		t.Error("expected updated RHOAI DSP image in manager.yaml")
+	}
+	if strings.Contains(content, "old-value") {
+		t.Error("old value should have been replaced")
+	}
+	if !strings.Contains(content, "OPERATOR_NAME") {
+		t.Error("existing env var OPERATOR_NAME should be preserved")
+	}
+}
+
+func TestApplyDeploy_OpenDataHubNormalization(t *testing.T) {
+	managerPath := writeManagerFile(t)
+	cfgPath := writeValidTestConfig(t)
+
+	err := ApplyDeploy(DeployOptions{
+		ConfigFile:  cfgPath,
+		Platform:    "OpenDataHub",
+		ManagerFile: managerPath,
+	})
+	if err != nil {
+		t.Fatalf("ApplyDeploy failed with platform OpenDataHub: %v", err)
+	}
+
+	data, err := os.ReadFile(managerPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	content := string(data)
+	if !strings.Contains(content, "quay.io/opendatahub/dsp-operator@sha256:4db7f864ed11d3ea5585b56cb7d7473bf80d8a1dcfc47de343a7a182c805ecdc") {
+		t.Error("expected updated ODH DSP image in manager.yaml")
+	}
+}
+
+func TestApplyDeploy_UnknownPlatform(t *testing.T) {
+	managerPath := writeManagerFile(t)
+	cfgPath := writeValidTestConfig(t)
+
+	err := ApplyDeploy(DeployOptions{
+		ConfigFile:  cfgPath,
+		Platform:    "invalid-platform",
+		ManagerFile: managerPath,
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid platform")
+	}
+	if !strings.Contains(err.Error(), "unknown platform") {
+		t.Errorf("expected unknown platform in error, got: %v", err)
+	}
+}
+
+func TestFindManagerEnvNode_RHOAI(t *testing.T) {
+	yaml := `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: rhods-operator
+spec:
+  template:
+    spec:
+      containers:
+      - name: rhods-operator
+        env:
+          - name: OPERATOR_NAME
+            value: "rhods-operator"
+`
+	docs, err := parseMultiDoc([]byte(yaml))
+	if err != nil {
+		t.Fatal(err)
+	}
+	root := docs[0].Content[0]
+	envNode, err := findManagerEnvNode(root, "rhoai")
+	if err != nil {
+		t.Fatalf("expected to find env node for rhoai container: %v", err)
+	}
+	if envNode == nil {
+		t.Fatal("expected non-nil envNode")
+	}
+}
+
+func TestFindManagerEnvNode_UnknownPlatform(t *testing.T) {
+	yaml := `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test
+spec:
+  template:
+    spec:
+      containers:
+      - name: manager
+`
+	docs, err := parseMultiDoc([]byte(yaml))
+	if err != nil {
+		t.Fatal(err)
+	}
+	root := docs[0].Content[0]
+	_, err = findManagerEnvNode(root, "invalid")
+	if err == nil {
+		t.Fatal("expected error for unknown platform")
+	}
+	if !strings.Contains(err.Error(), "unknown platform") {
+		t.Errorf("expected unknown platform error, got: %v", err)
 	}
 }


### PR DESCRIPTION

## Description
<!--- Describe your changes in detail -->

Dynamically select manager file path based on CONFIG_DIR and support
both manager and rhods-operator container names when applying image
overrides for deployment.


## Release tracking
<!-- Optional. Set a target release only if this PR must ship in a specific release; it will be prioritized accordingly. -->
<!-- Target release for this PR, e.g. rhoai-3.6 or rhoai-3.7ea1 -->
Release: rhoai-3.6ea1
<!-- Required only if a Release is set above. Full link to a jira ticket, e.g. https://redhat.atlassian.net/browse/RHOAIENG-XXXXX -->
Jira: https://redhat.atlassian.net/browse/RHOAIENG-88545


## How Has This Been Tested?
Ran unit tests locally
Ran `make apply-image-overrides` both with and without `ODH_PLATFORM_TYPE=rhoai`

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully
- [ ] New RELATED_IMAGE mappings are listed in ODH-Build-Config and RHOAI-Build-Config (CI validates names against build-config repos). Include links to build-config PRs in the description.

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [ ] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Deployment image overrides now support configurable manager manifest locations.
  - RHOAI deployments now apply digest-pinned image overrides to the appropriate manager manifest.
  - Platform names are handled consistently regardless of capitalization.

- **Bug Fixes**
  - Improved validation and error messages for unsupported platforms and missing manager containers.

- **Documentation**
  - Updated deployment guidance to describe RHOAI image override behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->