### PR TITLE
fix: remove openshift annotation in rhaii manifests

### DIFF
--- a/config/rhaii/rhoai/operator/kustomization.yaml
+++ b/config/rhaii/rhoai/operator/kustomization.yaml
@@ -14,3 +14,5 @@ patches:
 - path: manager_patch.yaml
 - path: manager_auth_proxy_patch.yaml
 - path: manager_webhook_patch.yaml
+- path: manager_remove_scc_annotation_patch.yaml
+- path: metrics_service_patch.yaml

--- a/config/rhaii/rhoai/operator/manager_remove_scc_annotation_patch.yaml
+++ b/config/rhaii/rhoai/operator/manager_remove_scc_annotation_patch.yaml
@@ -1,0 +1,10 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: rhods-operator
+  namespace: system
+spec:
+  template:
+    metadata:
+      annotations:
+        openshift.io/required-scc: null

--- a/config/rhaii/rhoai/operator/metrics_service_patch.yaml
+++ b/config/rhaii/rhoai/operator/metrics_service_patch.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: controller-manager-metrics-service
+  name: redhat-ods-operator-controller-manager-metrics-service
   namespace: system
   annotations:
     service.beta.openshift.io/serving-cert-secret-name: null


### PR DESCRIPTION
<!---
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
To unblock https://github.com/opendatahub-io/odh-gitops/pull/157, we need to remove openshift annotations from xks generated resources. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully
- [ ] New RELATED_IMAGE mappings are listed in ODH-Build-Config and RHOAI-Build-Config (CI validates names against build-config repos). Include links to build-config PRs in the description.

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->
Manifest cleanup, not need to update e2e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved metrics service compatibility when secure metrics are disabled or the service certificate is unavailable.
  * Metrics can now fall back to plain HTTP on port 8080.
  * Removed an unnecessary security context constraint annotation from the operator deployment to support broader deployment environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->