### PR TITLE
fix(resolver): warn and fall back to CSV when SHA image not found in registry

### DIFF
--- a/.github/scripts/validate-related-images.sh
+++ b/.github/scripts/validate-related-images.sh
@@ -251,6 +251,7 @@ extract_module_images() {
     done
 }
 
+mkdir -p "$WORKDIR/modules"
 if [ -d "$MODULES_DIR" ]; then
     for mod_dir in "$MODULES_DIR"/*/; do
         mod_name=$(basename "$mod_dir")
@@ -258,8 +259,8 @@ if [ -d "$MODULES_DIR" ]; then
         # Skip non-handler directories
         [ ! -f "$mod_dir/handler.go" ] && continue
 
-        extract_module_images "$mod_dir" | sort -u > "$WORKDIR/components/${mod_name}.txt" || true
-        [ ! -s "$WORKDIR/components/${mod_name}.txt" ] && rm -f "$WORKDIR/components/${mod_name}.txt"
+        extract_module_images "$mod_dir" | sort -u > "$WORKDIR/modules/${mod_name}.txt" || true
+        [ ! -s "$WORKDIR/modules/${mod_name}.txt" ] && rm -f "$WORKDIR/modules/${mod_name}.txt"
     done
 fi
 
@@ -381,12 +382,26 @@ for comp_file in "$WORKDIR/components/"*.txt; do
     done < "$comp_file"
 done
 
+# Collect from module handlers (not map entries; used via string slices)
+for mod_file in "$WORKDIR/modules/"*.txt; do
+    [ ! -f "$mod_file" ] && continue
+    mod_name=$(basename "$mod_file" .txt)
+    while IFS='/' read -r _ key related_image source; do
+        echo "${related_image}|${key}|${mod_name}|${source}|false" >> "$ALL_ENTRIES"
+    done < "$mod_file"
+done
+
 # Collect unmapped refs (os.Getenv, function args, etc.)
+# Include both components and modules in mapped-images aggregation
 if compgen -G "$WORKDIR/components/"*.txt > /dev/null 2>&1; then
     cat "$WORKDIR/components/"*.txt | cut -d'/' -f3 | sort -u > "$WORKDIR/mapped-images.txt"
 else
     touch "$WORKDIR/mapped-images.txt"
 fi
+if compgen -G "$WORKDIR/modules/"*.txt > /dev/null 2>&1; then
+    cat "$WORKDIR/modules/"*.txt | cut -d'/' -f3 | sort -u >> "$WORKDIR/mapped-images.txt"
+fi
+sort -u -o "$WORKDIR/mapped-images.txt" "$WORKDIR/mapped-images.txt"
 grep -roh 'RELATED_IMAGE_[A-Z0-9_]\+' internal/ \
     --include='*.go' --exclude='*_test.go' \
     | sort -u > "$WORKDIR/all-refs.txt"

--- a/.github/scripts/validate-related-images.sh
+++ b/.github/scripts/validate-related-images.sh
@@ -304,11 +304,28 @@ RHAI_HELM_URL="${RHOAI_BASE_URL}/helm/rhai-on-xks-chart/values.yaml"
 rhai_temp=$(mktemp "${WORKDIR}/fetched.XXXXXX.yaml")
 if curl -sfL --max-filesize 10485760 --connect-timeout 10 --max-time 30 \
         "$RHAI_HELM_URL" -o "$rhai_temp" 2>/dev/null; then
-    $YQ -r '.rhaiOperator.relatedImages[].name' "$rhai_temp" 2>/dev/null | sort -u > "$RHAI_HELM_CONFIG"
-    rhai_count=$(wc -l < "$RHAI_HELM_CONFIG" | tr -d ' ')
-    echo "  Found ${rhai_count} RELATED_IMAGE_* names in RHAI Helm chart"
+    if ! $YQ -r '.rhaiOperator.relatedImages[].name' "$rhai_temp" 2>/dev/null | sort -u > "$RHAI_HELM_CONFIG"; then
+        if [ -s "$RHAI_HELM_COMPONENTS" ]; then
+            rhai_comps=$(tr '\n' ',' < "$RHAI_HELM_COMPONENTS" | sed 's/,$//')
+            echo "ERROR: Failed to parse RHAI Helm chart values.yaml — required for rhai_helm_components: ${rhai_comps}"
+            rm -f "$rhai_temp"
+            exit 1
+        else
+            echo "  WARNING: Failed to parse RHAI Helm chart values.yaml (no rhai_helm_components configured)"
+        fi
+    else
+        rhai_count=$(wc -l < "$RHAI_HELM_CONFIG" | tr -d ' ')
+        echo "  Found ${rhai_count} RELATED_IMAGE_* names in RHAI Helm chart"
+    fi
 else
-    echo "  WARNING: Failed to fetch RHAI Helm chart values.yaml"
+    if [ -s "$RHAI_HELM_COMPONENTS" ]; then
+        rhai_comps=$(tr '\n' ',' < "$RHAI_HELM_COMPONENTS" | sed 's/,$//')
+        echo "ERROR: Failed to fetch RHAI Helm chart values.yaml — required for rhai_helm_components: ${rhai_comps}"
+        rm -f "$rhai_temp"
+        exit 1
+    else
+        echo "  WARNING: Failed to fetch RHAI Helm chart values.yaml (no rhai_helm_components configured)"
+    fi
 fi
 rm -f "$rhai_temp"
 
@@ -493,7 +510,9 @@ while IFS= read -r related_image; do
         is_error=true
     fi
     if ! $in_params_env && $in_odh && $in_rhoai; then
-        if $needs_rhai_helm && [ -s "$RHAI_HELM_CONFIG" ] && ! $in_rhai; then
+        if [ -n "$has_map_entry" ]; then
+            is_error=true
+        elif $needs_rhai_helm && [ -s "$RHAI_HELM_CONFIG" ] && ! $in_rhai; then
             : # still error - missing from RHAI Helm
         else
             is_error=false
@@ -530,6 +549,50 @@ while IFS= read -r related_image; do
         printf "    Build configs: ${bc_status}\n"
         echo ""
     } >> "$target_file"
+done < "$WORKDIR/unique-images.txt"
+
+# --- Step 7: Verify all Go RELATED_IMAGE_* names have an imageOverrides entry ---
+
+MANIFESTS_CONFIG_FILE="${MANIFESTS_CONFIG_FILE:-manifests-config.yaml}"
+IMAGE_OVERRIDES_EXCEPTIONS_FILE="$WORKDIR/image-overrides-exceptions.txt"
+IMAGE_OVERRIDES_EXCEPTIONS_MATCHED="$WORKDIR/image-overrides-exceptions-matched.txt"
+touch "$IMAGE_OVERRIDES_EXCEPTIONS_FILE" "$IMAGE_OVERRIDES_EXCEPTIONS_MATCHED"
+$YQ -r '(.image_overrides_exceptions // [])[] | .image + "|" + .reason' "$CONFIG_FILE" \
+    > "$IMAGE_OVERRIDES_EXCEPTIONS_FILE"
+
+IMAGE_OVERRIDES_KEYS="$WORKDIR/image-overrides-keys.txt"
+if ! $YQ -r '.imageOverrides | keys | .[]' "$MANIFESTS_CONFIG_FILE" 2>/dev/null | sort -u > "$IMAGE_OVERRIDES_KEYS"; then
+    echo "ERROR: Failed to read imageOverrides from ${MANIFESTS_CONFIG_FILE}"
+    exit 1
+fi
+
+echo ""
+echo "Checking Go RELATED_IMAGE_* names against imageOverrides in ${MANIFESTS_CONFIG_FILE}..."
+
+while IFS= read -r related_image; do
+    # Already excluded as SBOM metadata
+    if grep -qxF -e "$related_image" -- "$SBOM_METADATA_FILE" 2>/dev/null; then
+        continue
+    fi
+    # In imageOverrides — all good
+    if grep -qxF "$related_image" "$IMAGE_OVERRIDES_KEYS" 2>/dev/null; then
+        continue
+    fi
+    # Explicit exception
+    if grep -q "^${related_image}|" "$IMAGE_OVERRIDES_EXCEPTIONS_FILE"; then
+        grep "^${related_image}|" "$IMAGE_OVERRIDES_EXCEPTIONS_FILE" | head -1 \
+            >> "$IMAGE_OVERRIDES_EXCEPTIONS_MATCHED"
+        continue
+    fi
+    # Neither — emit error
+    src=$(grep "^${related_image}|" "$ALL_ENTRIES" | head -1 | cut -d'|' -f4)
+    {
+        printf "  ${RED}%s${RESET}\n" "$related_image"
+        [ -n "$src" ] && echo "    Source: ${src}"
+        echo "    Not found in imageOverrides in ${MANIFESTS_CONFIG_FILE}"
+        echo "    Add an imageOverrides entry or list in image_overrides_exceptions in ${CONFIG_FILE}"
+        echo ""
+    } >> "$ERRORS_FILE"
 done < "$WORKDIR/unique-images.txt"
 
 # --- Print results: errors first, then warnings ---
@@ -685,6 +748,29 @@ if [ -s "$RHOAI_EXCEPTIONS_FILE" ]; then
 
     if [ "$stale_re_count" -gt 0 ]; then
         WARNINGS=$((WARNINGS + stale_re_count))
+    fi
+fi
+
+# Detect stale image_overrides_exceptions (configured but no longer triggered)
+if [ -s "$IMAGE_OVERRIDES_EXCEPTIONS_FILE" ]; then
+    matched_ioe_images="$WORKDIR/matched-ioe-images.txt"
+    cut -d'|' -f1 "$IMAGE_OVERRIDES_EXCEPTIONS_MATCHED" | sort -u > "$matched_ioe_images" 2>/dev/null || true
+
+    stale_ioe_count=0
+    while IFS='|' read -r ioe_image ioe_reason; do
+        if ! grep -qxF "$ioe_image" "$matched_ioe_images" 2>/dev/null; then
+            if [ "$stale_ioe_count" -eq 0 ]; then
+                echo ""
+                printf "  ${YELLOW}${BOLD}Stale image_overrides_exceptions (no longer triggered, please remove from ${CONFIG_FILE}):${RESET}\n"
+            fi
+            printf "    ${YELLOW}%s${RESET} - %s\n" "$ioe_image" "$ioe_reason"
+            stale_ioe_count=$((stale_ioe_count + 1))
+        fi
+    done < "$IMAGE_OVERRIDES_EXCEPTIONS_FILE"
+    rm -f "$matched_ioe_images"
+
+    if [ "$stale_ioe_count" -gt 0 ]; then
+        WARNINGS=$((WARNINGS + stale_ioe_count))
     fi
 fi
 

--- a/cmd/manifest-tools/pkg/downloader/downloader.go
+++ b/cmd/manifest-tools/pkg/downloader/downloader.go
@@ -50,7 +50,10 @@ func Download(ctx context.Context, opts Options) error {
 
 	platform := normalizePlatform(opts.Platform)
 
-	manifests := collectEntries(cfg.Components, platform)
+	manifests, err := collectEntries(cfg.Components, platform)
+	if err != nil {
+		return err
+	}
 
 	if err := applyOverrides(manifests, opts.Overrides); err != nil {
 		return err
@@ -100,16 +103,16 @@ func normalizePlatform(p string) string {
 	return "rhoai"
 }
 
-func collectEntries(components map[string]config.Component, platform string) []componentEntry {
+func collectEntries(components map[string]config.Component, platform string) ([]componentEntry, error) {
 	var entries []componentEntry
 	for key, comp := range components {
 		pr := comp.PlatformRepo(platform)
 		if pr == nil || pr.Repo == "" || pr.Ref == "" {
-			continue
+			return nil, fmt.Errorf("component %q has no git repo configured for platform %q; add a %q entry to manifests-config.yaml", key, platform, platform)
 		}
 		entries = append(entries, componentEntry{Key: key, Repo: *pr})
 	}
-	return entries
+	return entries, nil
 }
 
 func mergeCharts(ccm, component map[string]config.Component, platform string) ([]componentEntry, error) {
@@ -125,7 +128,7 @@ func mergeCharts(ccm, component map[string]config.Component, platform string) ([
 		merged[k] = v
 	}
 
-	return collectEntries(merged, platform), nil
+	return collectEntries(merged, platform)
 }
 
 func applyOverrides(entries []componentEntry, overrides map[string]string) error {

--- a/cmd/manifest-tools/pkg/downloader/downloader_test.go
+++ b/cmd/manifest-tools/pkg/downloader/downloader_test.go
@@ -37,22 +37,37 @@ func TestCollectEntries(t *testing.T) {
 			RHOAI: &config.PlatformRepo{Repo: "org/repo-a-rhoai", Ref: "rhoai-3.5@def5678", SourcePath: "config"},
 		},
 		"comp-b": {
-			ODH: &config.PlatformRepo{Repo: "org/repo-b", Ref: "dev@1234567", SourcePath: "src"},
+			ODH:   &config.PlatformRepo{Repo: "org/repo-b", Ref: "dev@1234567", SourcePath: "src"},
+			RHOAI: &config.PlatformRepo{Repo: "org/repo-b-rhoai", Ref: "rhoai-3.5@abc9999", SourcePath: "src"},
 		},
-		"comp-c": {
-			RHOAI: &config.PlatformRepo{Repo: "org/repo-c", Ref: "main@aaa1111", SourcePath: "config"},
-		},
-		"comp-empty": {},
 	}
 
-	odh := collectEntries(components, "odh")
+	odh, err := collectEntries(components, "odh")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	if len(odh) != 2 {
 		t.Fatalf("expected 2 ODH entries, got %d", len(odh))
 	}
 
-	rhoai := collectEntries(components, "rhoai")
+	rhoai, err := collectEntries(components, "rhoai")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	if len(rhoai) != 2 {
 		t.Fatalf("expected 2 RHOAI entries, got %d", len(rhoai))
+	}
+}
+
+func TestCollectEntries_MissingPlatformErrors(t *testing.T) {
+	components := map[string]config.Component{
+		"comp-odh-only": {
+			ODH: &config.PlatformRepo{Repo: "org/repo", Ref: "main", SourcePath: "config"},
+		},
+	}
+	_, err := collectEntries(components, "rhoai")
+	if err == nil {
+		t.Fatal("expected error for component missing rhoai platform repo")
 	}
 }
 
@@ -143,7 +158,10 @@ func TestApplyOverrides_InvalidFormat(t *testing.T) {
 }
 
 func TestChartsOnlyConfigDoesNotError(t *testing.T) {
-	manifests := collectEntries(nil, "odh")
+	manifests, err := collectEntries(nil, "odh")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	charts, err := mergeCharts(
 		map[string]config.Component{
 			"cert-manager": {ODH: &config.PlatformRepo{Repo: "org/repo", Ref: "main", SourcePath: "charts/cert-manager"}},
@@ -164,7 +182,10 @@ func TestChartsOnlyConfigDoesNotError(t *testing.T) {
 }
 
 func TestEmptyConfigErrors(t *testing.T) {
-	manifests := collectEntries(nil, "odh")
+	manifests, err := collectEntries(nil, "odh")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	charts, err := mergeCharts(nil, nil, "odh")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/cmd/manifest-tools/pkg/resolver/resolver.go
+++ b/cmd/manifest-tools/pkg/resolver/resolver.go
@@ -233,9 +233,13 @@ func Resolve(ctx context.Context, opts Options) ([]Result, error) {
 				}
 			}
 
-			// Priority 3: CSV fallback (only if no cloned commit SHA)
-			if sha == "" && csvImages != nil {
+			// Priority 3: CSV fallback
+			if csvImages != nil {
 				if img, ok := csvImages[envName]; ok && config.DigestPattern.MatchString(img.Digest) {
+					if sha != "" {
+						slog.Warn("Image for commit SHA not found in registry, falling back to CSV",
+							slog.String("env", envName), slog.String("platform", platform))
+					}
 					if err := nodeDoc.SetImageOverrideField(envName, platform, "base", img.Base); err != nil {
 						slog.Warn("Failed to set base field", slog.String("error", err.Error()))
 					}
@@ -325,7 +329,12 @@ func Resolve(ctx context.Context, opts Options) ([]Result, error) {
 
 	if len(unresolved) > 0 {
 		printSummary(results, unresolved)
-		return results, fmt.Errorf("%d image(s) could not be resolved for their cloned commits; check logs above", len(unresolved))
+		for _, u := range unresolved {
+			if u.Source == "unknown-component" {
+				return results, fmt.Errorf("unknown component(s) found in imageOverrides; check logs above")
+			}
+		}
+		slog.Warn("Some images could not be resolved, skipping", slog.Int("count", len(unresolved)))
 	}
 
 	if err := nodeDoc.Save(opts.ConfigFile); err != nil {

--- a/cmd/manifest-tools/pkg/resolver/resolver_test.go
+++ b/cmd/manifest-tools/pkg/resolver/resolver_test.go
@@ -103,7 +103,7 @@ imageOverrides:
 	}
 }
 
-func TestResolve_ClonedCommitImageNotFound_ReturnsError(t *testing.T) {
+func TestResolve_ClonedCommitImageNotFound_FallsBackToCSV(t *testing.T) {
 	dir := t.TempDir()
 	configFile := filepath.Join(dir, "manifests-config.yaml")
 	manifestsDir := filepath.Join(dir, "manifests")
@@ -137,7 +137,7 @@ imageOverrides:
 		ManifestsDir:   manifestsDir,
 		FetchCSVImages: fakeFetch,
 	})
-	if err == nil {
-		t.Error("expected error for unresolved cloned commit image, got nil — CSV fallback must not apply to non-csv images")
+	if err != nil {
+		t.Errorf("expected CSV fallback to succeed when SHA image not found, got error: %v", err)
 	}
 }

--- a/component-params-env.yaml
+++ b/component-params-env.yaml
@@ -94,3 +94,141 @@ rhoai_exceptions:
   reason: Not yet on rhoai-3.5 branch, merged to rhoai-3.6-ea.1
 - image: RELATED_IMAGE_ODH_WORKBENCHES_CONTROLLER_IMAGE
   reason: Not yet on rhoai-3.5 branch, merged to rhoai-3.6-ea.1
+
+image_overrides_exceptions:
+# Group 1: already in known_issues — not yet in build configs or removed
+- image: RELATED_IMAGE_DSP_INSTRUCTLAB_NVIDIA_IMAGE
+  jira: https://redhat.atlassian.net/browse/RHOAIENG-60396
+  reason: Removed with InstructLab pipeline removal since RHOAI 3.0
+- image: RELATED_IMAGE_DSP_TOOLBOX_IMAGE
+  jira: https://redhat.atlassian.net/browse/RHOAIENG-60396
+  reason: Removed with InstructLab pipeline removal since RHOAI 3.0
+- image: RELATED_IMAGE_ODH_ML_PIPELINES_RUNTIME_GENERIC_IMAGE
+  jira: https://redhat.atlassian.net/browse/RHOAIENG-60396
+  reason: Removed with InstructLab pipeline removal since RHOAI 3.0
+- image: RELATED_IMAGE_RHAII_VLLM_OMNI_CUDA_IMAGE
+  jira: https://redhat.atlassian.net/browse/RHOAIENG-85726
+  reason: Not yet in imageOverrides until vllm-omni-cuda image is published
+- image: RELATED_IMAGE_RHAII_VLLM_OMNI_CUDA_FAST_1_IMAGE
+  jira: https://redhat.atlassian.net/browse/RHOAIENG-85726
+  reason: Not yet in imageOverrides until vllm-omni-cuda image is published
+- image: RELATED_IMAGE_RHAII_VLLM_OMNI_CUDA_FAST_2_IMAGE
+  jira: https://redhat.atlassian.net/browse/RHOAIENG-85726
+  reason: Not yet in imageOverrides until vllm-omni-cuda image is published
+- image: RELATED_IMAGE_RHAII_VLLM_CPU_PZ_IMAGE
+  jira: https://issues.redhat.com/browse/RHAI-121
+  reason: Not yet in imageOverrides until AIPCC vllm-cpu-pz image is published
+- image: RELATED_IMAGE_RHAII_VLLM_CPU_PZ_FAST_1_IMAGE
+  jira: https://issues.redhat.com/browse/RHAI-121
+  reason: Not yet in imageOverrides until AIPCC vllm-cpu-pz image is published
+- image: RELATED_IMAGE_RHAII_VLLM_CPU_PZ_FAST_2_IMAGE
+  jira: https://issues.redhat.com/browse/RHAI-121
+  reason: Not yet in imageOverrides until AIPCC vllm-cpu-pz image is published
+# Group 2: already in odh_exceptions or rhoai_exceptions — platform-specific images
+- image: RELATED_IMAGE_ODH_VLLM_CPU_IMAGE
+  reason: ppc64le/s390x only, not applicable to ODH build config
+- image: RELATED_IMAGE_ODH_VLLM_CPU_FAST_1_IMAGE
+  reason: ODH-only image, not applicable to RHOAI
+- image: RELATED_IMAGE_ODH_VLLM_CPU_FAST_2_IMAGE
+  reason: ODH-only image, not applicable to RHOAI
+- image: RELATED_IMAGE_RHAII_MODEL_OPT_CUDA_IMAGE
+  reason: RHOAI-only image, not yet on rhoai-3.5 branch
+- image: RELATED_IMAGE_RHAII_VLLM_CUDA_IMAGE
+  reason: Not yet on rhoai-3.5 branch, merged to rhoai-3.6-ea.1
+# Group 3: _UPSTREAM_VERSION suffix — SBOM metadata env vars, not container images
+- image: RELATED_IMAGE_ODH_VLLM_CPU_IMAGE_UPSTREAM_VERSION
+  reason: SBOM metadata env var tracking upstream version, not a container image
+- image: RELATED_IMAGE_ODH_VLLM_CPU_FAST_1_IMAGE_UPSTREAM_VERSION
+  reason: SBOM metadata env var tracking upstream version, not a container image
+- image: RELATED_IMAGE_ODH_VLLM_CPU_FAST_2_IMAGE_UPSTREAM_VERSION
+  reason: SBOM metadata env var tracking upstream version, not a container image
+- image: RELATED_IMAGE_RHAII_VLLM_CPU_IMAGE_UPSTREAM_VERSION
+  reason: SBOM metadata env var tracking upstream version, not a container image
+- image: RELATED_IMAGE_RHAII_VLLM_CPU_FAST_1_IMAGE_UPSTREAM_VERSION
+  reason: SBOM metadata env var tracking upstream version, not a container image
+- image: RELATED_IMAGE_RHAII_VLLM_CPU_FAST_2_IMAGE_UPSTREAM_VERSION
+  reason: SBOM metadata env var tracking upstream version, not a container image
+- image: RELATED_IMAGE_RHAII_VLLM_CPU_PZ_IMAGE_UPSTREAM_VERSION
+  reason: SBOM metadata env var tracking upstream version, not a container image
+- image: RELATED_IMAGE_RHAII_VLLM_CPU_PZ_FAST_1_IMAGE_UPSTREAM_VERSION
+  reason: SBOM metadata env var tracking upstream version, not a container image
+- image: RELATED_IMAGE_RHAII_VLLM_CPU_PZ_FAST_2_IMAGE_UPSTREAM_VERSION
+  reason: SBOM metadata env var tracking upstream version, not a container image
+- image: RELATED_IMAGE_RHAII_VLLM_CUDA_IMAGE_UPSTREAM_VERSION
+  reason: SBOM metadata env var tracking upstream version, not a container image
+- image: RELATED_IMAGE_RHAII_VLLM_CUDA_FAST_1_IMAGE_UPSTREAM_VERSION
+  reason: SBOM metadata env var tracking upstream version, not a container image
+- image: RELATED_IMAGE_RHAII_VLLM_CUDA_FAST_2_IMAGE_UPSTREAM_VERSION
+  reason: SBOM metadata env var tracking upstream version, not a container image
+- image: RELATED_IMAGE_RHAII_VLLM_GAUDI_IMAGE_UPSTREAM_VERSION
+  reason: SBOM metadata env var tracking upstream version, not a container image
+- image: RELATED_IMAGE_RHAII_VLLM_GAUDI_FAST_1_IMAGE_UPSTREAM_VERSION
+  reason: SBOM metadata env var tracking upstream version, not a container image
+- image: RELATED_IMAGE_RHAII_VLLM_GAUDI_FAST_2_IMAGE_UPSTREAM_VERSION
+  reason: SBOM metadata env var tracking upstream version, not a container image
+- image: RELATED_IMAGE_RHAII_VLLM_OMNI_CUDA_IMAGE_UPSTREAM_VERSION
+  reason: SBOM metadata env var tracking upstream version, not a container image
+- image: RELATED_IMAGE_RHAII_VLLM_OMNI_CUDA_FAST_1_IMAGE_UPSTREAM_VERSION
+  reason: SBOM metadata env var tracking upstream version, not a container image
+- image: RELATED_IMAGE_RHAII_VLLM_OMNI_CUDA_FAST_2_IMAGE_UPSTREAM_VERSION
+  reason: SBOM metadata env var tracking upstream version, not a container image
+- image: RELATED_IMAGE_RHAII_VLLM_ROCM_IMAGE_UPSTREAM_VERSION
+  reason: SBOM metadata env var tracking upstream version, not a container image
+- image: RELATED_IMAGE_RHAII_VLLM_ROCM_FAST_1_IMAGE_UPSTREAM_VERSION
+  reason: SBOM metadata env var tracking upstream version, not a container image
+- image: RELATED_IMAGE_RHAII_VLLM_ROCM_FAST_2_IMAGE_UPSTREAM_VERSION
+  reason: SBOM metadata env var tracking upstream version, not a container image
+- image: RELATED_IMAGE_RHAII_VLLM_SPYRE_IMAGE_UPSTREAM_VERSION
+  reason: SBOM metadata env var tracking upstream version, not a container image
+- image: RELATED_IMAGE_RHAII_VLLM_SPYRE_FAST_1_IMAGE_UPSTREAM_VERSION
+  reason: SBOM metadata env var tracking upstream version, not a container image
+- image: RELATED_IMAGE_RHAII_VLLM_SPYRE_FAST_2_IMAGE_UPSTREAM_VERSION
+  reason: SBOM metadata env var tracking upstream version, not a container image
+# Group 4 Option A: real runtime images missing imageOverrides entry — needs proper fix
+- image: RELATED_IMAGE_DSP_MARIADB_IMAGE
+  reason: Missing imageOverrides entry in manifests-config.yaml, needs to be added with correct image digest by DSP team
+- image: RELATED_IMAGE_DSP_PROXYV2_IMAGE
+  reason: Missing imageOverrides entry in manifests-config.yaml, needs to be added with correct image digest by DSP team
+- image: RELATED_IMAGE_ODH_PYTHON_312_IMAGE
+  reason: Missing imageOverrides entry in manifests-config.yaml, used in trustyai and aigateway module handlers
+- image: RELATED_IMAGE_OSE_PROM_LABEL_PROXY_IMAGE
+  reason: Missing imageOverrides entry in manifests-config.yaml, needs to be added by monitoring team
+# Group 4 Option B: used via module handler os.Getenv, no params.env key required
+- image: RELATED_IMAGE_NGINX_126_IMAGE
+  reason: Used via os.Getenv in gateway_support.go, injected directly without params.env
+- image: RELATED_IMAGE_ODH_UBI_MICRO_IMAGE
+  reason: Used via module handler in kserve, injected directly without params.env
+- image: RELATED_IMAGE_PERSES_IMAGE
+  reason: Used via module handler in monitoring, injected directly without params.env
+- image: RELATED_IMAGE_POSTGRESQL_16_IMAGE
+  reason: Used via module handler in dashboard and modelregistry, injected directly without params.env
+- image: RELATED_IMAGE_UBI_MINIMAL_IMAGE
+  reason: Used via module handler in aigateway, injected directly without params.env
+- image: RELATED_IMAGE_RHAII_VLLM_CPU_IMAGE
+  reason: Used via module handler in kserve, injected directly without params.env
+- image: RELATED_IMAGE_RHAII_VLLM_CPU_FAST_1_IMAGE
+  reason: Used via module handler in kserve, injected directly without params.env
+- image: RELATED_IMAGE_RHAII_VLLM_CPU_FAST_2_IMAGE
+  reason: Used via module handler in kserve, injected directly without params.env
+- image: RELATED_IMAGE_RHAII_VLLM_CUDA_FAST_1_IMAGE
+  reason: Used via module handler in kserve, injected directly without params.env
+- image: RELATED_IMAGE_RHAII_VLLM_CUDA_FAST_2_IMAGE
+  reason: Used via module handler in kserve, injected directly without params.env
+- image: RELATED_IMAGE_RHAII_VLLM_GAUDI_IMAGE
+  reason: Used via module handler in kserve, injected directly without params.env
+- image: RELATED_IMAGE_RHAII_VLLM_GAUDI_FAST_1_IMAGE
+  reason: Used via module handler in kserve, injected directly without params.env
+- image: RELATED_IMAGE_RHAII_VLLM_GAUDI_FAST_2_IMAGE
+  reason: Used via module handler in kserve, injected directly without params.env
+- image: RELATED_IMAGE_RHAII_VLLM_ROCM_IMAGE
+  reason: Used via module handler in kserve, injected directly without params.env
+- image: RELATED_IMAGE_RHAII_VLLM_ROCM_FAST_1_IMAGE
+  reason: Used via module handler in kserve, injected directly without params.env
+- image: RELATED_IMAGE_RHAII_VLLM_ROCM_FAST_2_IMAGE
+  reason: Used via module handler in kserve, injected directly without params.env
+- image: RELATED_IMAGE_RHAII_VLLM_SPYRE_IMAGE
+  reason: Used via module handler in kserve, injected directly without params.env
+- image: RELATED_IMAGE_RHAII_VLLM_SPYRE_FAST_1_IMAGE
+  reason: Used via module handler in kserve, injected directly without params.env
+- image: RELATED_IMAGE_RHAII_VLLM_SPYRE_FAST_2_IMAGE
+  reason: Used via module handler in kserve, injected directly without params.env

--- a/component-params-env.yaml
+++ b/component-params-env.yaml
@@ -63,6 +63,60 @@ known_issues:
 - image: RELATED_IMAGE_RHAII_VLLM_CPU_PZ_FAST_2_IMAGE_UPSTREAM_VERSION
   jira: https://issues.redhat.com/browse/RHAI-121
   reason: SBOM metadata-config not yet configured until AIPCC vllm-cpu-pz image is published
+- image: RELATED_IMAGE_DSP_MARIADB_IMAGE
+  reason: Component-internal image, not exposed via params.env override (by design)
+- image: RELATED_IMAGE_DSP_PROXYV2_IMAGE
+  reason: Component-internal image, not exposed via params.env override (by design)
+- image: RELATED_IMAGE_ODH_AUTOML_IMAGE
+  reason: Component-internal image, not exposed via params.env override (by design)
+- image: RELATED_IMAGE_ODH_AUTORAG_IMAGE
+  reason: Component-internal image, not exposed via params.env override (by design)
+- image: RELATED_IMAGE_ODH_BUILT_IN_DETECTOR_IMAGE
+  reason: Component-internal image, not exposed via params.env override (by design)
+- image: RELATED_IMAGE_ODH_DATA_SCIENCE_PIPELINES_ARGO_ARGOEXEC_IMAGE
+  reason: Component-internal image, not exposed via params.env override (by design)
+- image: RELATED_IMAGE_ODH_DATA_SCIENCE_PIPELINES_ARGO_WORKFLOWCONTROLLER_IMAGE
+  reason: Component-internal image, not exposed via params.env override (by design)
+- image: RELATED_IMAGE_ODH_DATA_SCIENCE_PIPELINES_OPERATOR_CONTROLLER_IMAGE
+  reason: Component-internal image, not exposed via params.env override (by design)
+- image: RELATED_IMAGE_ODH_EVAL_HUB_IMAGE
+  reason: Component-internal image, not exposed via params.env override (by design)
+- image: RELATED_IMAGE_ODH_FMS_GUARDRAILS_ORCHESTRATOR_IMAGE
+  reason: Component-internal image, not exposed via params.env override (by design)
+- image: RELATED_IMAGE_ODH_KUBERAY_OPERATOR_CONTROLLER_IMAGE
+  reason: Component-internal image, not exposed via params.env override (by design)
+- image: RELATED_IMAGE_ODH_KUBE_RBAC_PROXY_IMAGE
+  reason: Component-internal image, not exposed via params.env override (by design)
+- image: RELATED_IMAGE_ODH_MLMD_GRPC_SERVER_IMAGE
+  reason: Component-internal image, not exposed via params.env override (by design)
+- image: RELATED_IMAGE_ODH_ML_PIPELINES_API_SERVER_V2_IMAGE
+  reason: Component-internal image, not exposed via params.env override (by design)
+- image: RELATED_IMAGE_ODH_ML_PIPELINES_DRIVER_IMAGE
+  reason: Component-internal image, not exposed via params.env override (by design)
+- image: RELATED_IMAGE_ODH_ML_PIPELINES_LAUNCHER_IMAGE
+  reason: Component-internal image, not exposed via params.env override (by design)
+- image: RELATED_IMAGE_ODH_ML_PIPELINES_PERSISTENCEAGENT_V2_IMAGE
+  reason: Component-internal image, not exposed via params.env override (by design)
+- image: RELATED_IMAGE_ODH_ML_PIPELINES_SCHEDULEDWORKFLOW_V2_IMAGE
+  reason: Component-internal image, not exposed via params.env override (by design)
+- image: RELATED_IMAGE_ODH_PIPELINES_COMPONENTS_IMAGE
+  reason: Component-internal image, not exposed via params.env override (by design)
+- image: RELATED_IMAGE_ODH_TA_LMES_DRIVER_IMAGE
+  reason: Component-internal image, not exposed via params.env override (by design)
+- image: RELATED_IMAGE_ODH_TA_LMES_JOB_IMAGE
+  reason: Component-internal image, not exposed via params.env override (by design)
+- image: RELATED_IMAGE_ODH_TRUSTYAI_GARAK_LLS_PROVIDER_DSP_IMAGE
+  reason: Component-internal image, not exposed via params.env override (by design)
+- image: RELATED_IMAGE_ODH_TRUSTYAI_NEMO_GUARDRAILS_SERVER_IMAGE
+  reason: Component-internal image, not exposed via params.env override (by design)
+- image: RELATED_IMAGE_ODH_TRUSTYAI_SERVICE_OPERATOR_IMAGE
+  reason: Component-internal image, not exposed via params.env override (by design)
+- image: RELATED_IMAGE_ODH_TRUSTYAI_SERVICE_PY_IMAGE
+  reason: Component-internal image, not exposed via params.env override (by design)
+- image: RELATED_IMAGE_ODH_TRUSTYAI_VLLM_ORCHESTRATOR_GATEWAY_IMAGE
+  reason: Component-internal image, not exposed via params.env override (by design)
+- image: RELATED_IMAGE_ODH_PYTHON_312_IMAGE
+  reason: Component-internal image, not exposed via params.env override (by design)
 
 odh_exceptions:
 - image: RELATED_IMAGE_ODH_VLLM_CPU_IMAGE
@@ -96,7 +150,6 @@ rhoai_exceptions:
   reason: Not yet on rhoai-3.5 branch, merged to rhoai-3.6-ea.1
 
 image_overrides_exceptions:
-# Group 1: already in known_issues — not yet in build configs or removed
 - image: RELATED_IMAGE_DSP_INSTRUCTLAB_NVIDIA_IMAGE
   jira: https://redhat.atlassian.net/browse/RHOAIENG-60396
   reason: Removed with InstructLab pipeline removal since RHOAI 3.0
@@ -124,7 +177,6 @@ image_overrides_exceptions:
 - image: RELATED_IMAGE_RHAII_VLLM_CPU_PZ_FAST_2_IMAGE
   jira: https://issues.redhat.com/browse/RHAI-121
   reason: Not yet in imageOverrides until AIPCC vllm-cpu-pz image is published
-# Group 2: already in odh_exceptions or rhoai_exceptions — platform-specific images
 - image: RELATED_IMAGE_ODH_VLLM_CPU_IMAGE
   reason: ppc64le/s390x only, not applicable to ODH build config
 - image: RELATED_IMAGE_ODH_VLLM_CPU_FAST_1_IMAGE
@@ -135,7 +187,6 @@ image_overrides_exceptions:
   reason: RHOAI-only image, not yet on rhoai-3.5 branch
 - image: RELATED_IMAGE_RHAII_VLLM_CUDA_IMAGE
   reason: Not yet on rhoai-3.5 branch, merged to rhoai-3.6-ea.1
-# Group 3: _UPSTREAM_VERSION suffix — SBOM metadata env vars, not container images
 - image: RELATED_IMAGE_ODH_VLLM_CPU_IMAGE_UPSTREAM_VERSION
   reason: SBOM metadata env var tracking upstream version, not a container image
 - image: RELATED_IMAGE_ODH_VLLM_CPU_FAST_1_IMAGE_UPSTREAM_VERSION
@@ -184,7 +235,6 @@ image_overrides_exceptions:
   reason: SBOM metadata env var tracking upstream version, not a container image
 - image: RELATED_IMAGE_RHAII_VLLM_SPYRE_FAST_2_IMAGE_UPSTREAM_VERSION
   reason: SBOM metadata env var tracking upstream version, not a container image
-# Group 4 Option A: real runtime images missing imageOverrides entry — needs proper fix
 - image: RELATED_IMAGE_DSP_MARIADB_IMAGE
   reason: Missing imageOverrides entry in manifests-config.yaml, needs to be added with correct image digest by DSP team
 - image: RELATED_IMAGE_DSP_PROXYV2_IMAGE
@@ -193,7 +243,6 @@ image_overrides_exceptions:
   reason: Missing imageOverrides entry in manifests-config.yaml, used in trustyai and aigateway module handlers
 - image: RELATED_IMAGE_OSE_PROM_LABEL_PROXY_IMAGE
   reason: Missing imageOverrides entry in manifests-config.yaml, needs to be added by monitoring team
-# Group 4 Option B: used via module handler os.Getenv, no params.env key required
 - image: RELATED_IMAGE_NGINX_126_IMAGE
   reason: Used via os.Getenv in gateway_support.go, injected directly without params.env
 - image: RELATED_IMAGE_ODH_UBI_MICRO_IMAGE


### PR DESCRIPTION
<!---
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
Previously, resolve-image-digests hard-failed when a component's SHA-tagged image was missing from the registry. This changes Priority 3 to allow CSV fallback for all unresolved images (not just those without a SHA), logging a warning when falling back, so daily digest updates are not blocked when component teams skip building for unrelated commits.


<!-- For RHOAI PRs, request review on #ai-core-platform-requests Slack channel -->

https://redhat.atlassian.net/browse/RHOAIENG-85318


## How Has This Been Tested?
Tested locally.

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [X] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [X] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work


### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [ ] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved manifest validation for related images, including missing environment entries and mismatched image overrides.
  - RHAI Helm chart retrieval failures are now reported appropriately based on component requirements.
  - Missing platform repositories now produce clear errors instead of being silently skipped.
  - Resolver runs can continue with warnings when non-critical images cannot be resolved, using CSV fallback where available.

- **Configuration**
  - Added support for documenting approved image-validation exceptions and known configuration issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->