### PR TITLE
fix(resolver): warn and fall back to CSV when SHA image not found in registry.

### DIFF
--- a/cmd/manifest-tools/pkg/resolver/resolver.go
+++ b/cmd/manifest-tools/pkg/resolver/resolver.go
@@ -233,9 +233,13 @@ func Resolve(ctx context.Context, opts Options) ([]Result, error) {
 				}
 			}
 
-			// Priority 3: CSV fallback (only if no cloned commit SHA)
-			if sha == "" && csvImages != nil {
+			// Priority 3: CSV fallback
+			if csvImages != nil {
 				if img, ok := csvImages[envName]; ok && config.DigestPattern.MatchString(img.Digest) {
+					if sha != "" {
+						slog.Warn("Image for commit SHA not found in registry, falling back to CSV",
+							slog.String("env", envName), slog.String("platform", platform))
+					}
 					if err := nodeDoc.SetImageOverrideField(envName, platform, "base", img.Base); err != nil {
 						slog.Warn("Failed to set base field", slog.String("error", err.Error()))
 					}
@@ -325,7 +329,12 @@ func Resolve(ctx context.Context, opts Options) ([]Result, error) {
 
 	if len(unresolved) > 0 {
 		printSummary(results, unresolved)
-		return results, fmt.Errorf("%d image(s) could not be resolved for their cloned commits; check logs above", len(unresolved))
+		for _, u := range unresolved {
+			if u.Source == "unknown-component" {
+				return results, fmt.Errorf("unknown component(s) found in imageOverrides; check logs above")
+			}
+		}
+		slog.Warn("Some images could not be resolved, skipping", slog.Int("count", len(unresolved)))
 	}
 
 	if err := nodeDoc.Save(opts.ConfigFile); err != nil {
@@ -384,7 +393,7 @@ func printSummary(results []Result, unresolved []Result) {
 	}
 
 	if len(unresolved) > 0 {
-		fmt.Fprintf(os.Stderr, "\n%s%s▸ unresolved%s %s(%d)%s\n", bold, red, reset, dim, len(unresolved), reset)
+		fmt.Fprintf(os.Stderr, "\n%s%s▸ unresolved (warning: these images were skipped)%s %s(%d)%s\n", bold, red, reset, dim, len(unresolved), reset)
 		for _, r := range unresolved {
 			fmt.Fprintf(os.Stderr, "  %s%-5s%s %s\n", dim, r.Platform, reset, r.EnvName)
 		}

--- a/cmd/manifest-tools/pkg/resolver/resolver_test.go
+++ b/cmd/manifest-tools/pkg/resolver/resolver_test.go
@@ -103,7 +103,7 @@ imageOverrides:
 	}
 }
 
-func TestResolve_ClonedCommitImageNotFound_ReturnsError(t *testing.T) {
+func TestResolve_ClonedCommitImageNotFound_FallsBackToCSV(t *testing.T) {
 	dir := t.TempDir()
 	configFile := filepath.Join(dir, "manifests-config.yaml")
 	manifestsDir := filepath.Join(dir, "manifests")
@@ -137,7 +137,7 @@ imageOverrides:
 		ManifestsDir:   manifestsDir,
 		FetchCSVImages: fakeFetch,
 	})
-	if err == nil {
-		t.Error("expected error for unresolved cloned commit image, got nil — CSV fallback must not apply to non-csv images")
+	if err != nil {
+		t.Errorf("expected CSV fallback to succeed when SHA image not found, got error: %v", err)
 	}
 }


### PR DESCRIPTION


<!---
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
Previously, resolve-image-digests hard-failed when a component's SHA-tagged image was missing from the registry. This changes Priority 3 to allow CSV fallback for all unresolved images (not just those without a SHA), logging a warning when falling back, so daily digest updates are not blocked when component teams skip building for unrelated commits.


https://redhat.atlassian.net/browse/RHOAIENG-85318




## How Has This Been Tested?
Tested locally.

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [X] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [X] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work


### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [ ] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added CSV fallback when an image cannot be found in the registry, including images with a commit SHA.
  * Manifest resolution now continues for unresolved images when possible, allowing the configuration to be saved.
  * Unknown components still return an error when they cannot be resolved.
  * Added warnings when registry lookup fails, CSV fallback is used, or an image is skipped.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->