### PR TITLE
fix(e2e): filter nested JUnit parent failures

### DIFF
--- a/Dockerfiles/e2e-tests/e2e-tests.Dockerfile
+++ b/Dockerfiles/e2e-tests/e2e-tests.Dockerfile
@@ -43,8 +43,9 @@ RUN apt-get update -y && apt-get upgrade -y && \
     mv kubectl /usr/local/bin/ && \
     apt-get clean all
 
-# install gotestsum and build test2json
-RUN go install gotest.tools/gotestsum@latest \
+# install test reporting tools and build test2json
+RUN go install gotest.tools/gotestsum@v1.13.0 \
+ && go install github.com/jstemmer/go-junit-report/v2@v2.1.0 \
  && go build -o /usr/local/bin/test2json cmd/test2json
 
 WORKDIR /e2e

--- a/tests/e2e/scripts/run_e2e_tests.sh
+++ b/tests/e2e/scripts/run_e2e_tests.sh
@@ -145,11 +145,19 @@ if [ "$USE_TEST_RETRY" = "true" ] || [ "$USE_TEST_RETRY" = "1" ]; then
     --tag="$E2E_TEST_TAG" \
     "$@"
 else
-  echo "Using gotestsum (standard JUnit XML, no enrichment)"
+  echo "Using gotestsum with leaf-oriented JUnit XML"
 
-  # Run with gotestsum (existing behavior - DEFAULT)
-  exec gotestsum --junitfile-project-name odh-operator-e2e \
-    --junitfile results/xunit_report.xml --format standard-verbose --raw-command \
+  # Go reports a failed subtest and every failed parent as separate failures.
+  # Keep the raw artifacts for diagnostics, then exclude parent results from
+  # the JUnit report consumed by the CI failure importer.
+  # Keep raw JUnit content outside *.xml globs so CI ingests only final report.
+  raw_junit_report=results/xunit_report.unfiltered
+  test_events=results/test-events.json
+
+  set +e
+  gotestsum --junitfile-project-name odh-operator-e2e \
+    --junitfile "$raw_junit_report" --jsonfile "$test_events" \
+    --format standard-verbose --raw-command \
     -- test2json -t -p e2e ./e2e-tests --test.run='^TestOdhOperator' --test.v=test2json --test.parallel=8 \
     --deletion-policy="$E2E_TEST_DELETION_POLICY" \
     --clean-up-previous-resources="$E2E_TEST_CLEAN_UP_PREVIOUS_RESOURCES" \
@@ -168,4 +176,32 @@ else
     --dsc-monitoring-namespace="$E2E_TEST_DSC_MONITORING_NAMESPACE" \
     --tag="$E2E_TEST_TAG" \
     "$@"
+  test_status=$?
+  set -e
+
+  # Ignore only parent results. Their captured output is retained by the
+  # converter as suite-level output. If this leaves no failure/error despite
+  # a failed test process, retain the unfiltered report so parent-only
+  # failures (for example setup, cleanup, or watchdog failures) remain visible.
+  if go-junit-report -parser gojson \
+    -subtest-mode ignore-parent-results \
+    -in "$test_events" \
+    -out results/xunit_report.xml; then
+    if [ "$test_status" -ne 0 ] && \
+      ! grep -Eq '<(failure|error)([[:space:]>])' results/xunit_report.xml; then
+      echo "Warning: no leaf failure found; retaining unfiltered JUnit report" >&2
+      cp -- "$raw_junit_report" results/xunit_report.xml
+    fi
+  else
+    report_status=$?
+    echo "Error: failed to generate leaf-oriented JUnit report" >&2
+    if [ -s "$raw_junit_report" ]; then
+      echo "Retaining unfiltered JUnit report"
+      cp -- "$raw_junit_report" results/xunit_report.xml
+    else
+      exit "$report_status"
+    fi
+  fi
+
+  exit "$test_status"
 fi

--- a/tests/e2e/scripts/run_e2e_tests.sh
+++ b/tests/e2e/scripts/run_e2e_tests.sh
@@ -199,6 +199,9 @@ else
       echo "Retaining unfiltered JUnit report"
       cp -- "$raw_junit_report" results/xunit_report.xml
     else
+      if [ "$test_status" -ne 0 ]; then
+        exit "$test_status"
+      fi
       exit "$report_status"
     fi
   fi


### PR DESCRIPTION
## Description

Generate CI JUnit XML from raw Go test events with parent results ignored, so deeply nested subtest failures produce one actionable failure instead of one failure per ancestor. Preserve raw test events and the unfiltered JUnit report for diagnostics. Parent-only failures fall back to the unfiltered report.

## Release tracking

Release: rhoai-3.6ea1
Jira: https://redhat.atlassian.net/browse/RHOAIENG-89737

## How Has This Been Tested?

- `bash -n tests/e2e/scripts/run_e2e_tests.sh`
- `shellcheck tests/e2e/scripts/run_e2e_tests.sh`
- `go test ./...` from `cmd/test-retry`
- `make lint`
- `make fmt generate manifests api-docs`
- Built `Dockerfiles/e2e-tests/e2e-tests.Dockerfile` with Podman.
- Verified pinned reporting tools inside built image.
- Verified nested subtest conversion with `go-junit-report -subtest-mode ignore-parent-results` and XML validation.

Also injected failures into some of the component tests and ran the e2e locally:
```
❯ xmllint --xpath '//testcase[failure]/@name' $RESULTS_DIR/xunit_report.unfiltered
 name="TestOdhOperator/components/group_1/dashboard/Validate_component_enabled"
 name="TestOdhOperator/components/group_1/dashboard"
 name="TestOdhOperator/components/group_1/workbenches/Validate_component_enabled"
 name="TestOdhOperator/components/group_1/workbenches"
 name="TestOdhOperator/components/group_1"
 name="TestOdhOperator/components/group_2/modelregistry/Validate_component_enabled"
 name="TestOdhOperator/components/group_2/modelregistry"
 name="TestOdhOperator/components/group_2"
 name="TestOdhOperator/components"
 name="TestOdhOperator"


❯ xmllint --xpath '//testcase[failure]/@name' $RESULTS_DIR/xunit_report.xml
 name="TestOdhOperator/components/group_1/workbenches/Validate_component_enabled"
 name="TestOdhOperator/components/group_1/dashboard/Validate_component_enabled"
 name="TestOdhOperator/components/group_2/modelregistry/Validate_component_enabled"
```

## Screenshot or short clip

Not applicable.

## Merge criteria

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work.
- [ ] The developer has run the integration test pipeline and verified that it passed successfully.
- [ ] New RELATED_IMAGE mappings are listed in ODH-Build-Config and RHOAI-Build-Config (CI validates names against build-config repos). Include links to build-config PRs in the description.

### E2E test suite update requirement

- [x] Skip requirement to update E2E test suite for this PR

#### E2E update requirement opt-out justification

This change modifies only E2E report generation and container tooling. It does not change application behavior or test coverage; the reporting path was validated with nested subtest output and a built image.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved end-to-end test reports with clearer, leaf-level test results.
  * Preserved complete raw test output when report conversion cannot be completed.
  * Enhanced failure detection so test results accurately reflect unsuccessful test runs.
  * Improved reliability and consistency of generated JUnit reports for test result processing.
  * Standardized test-report generation for more predictable results across test runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->