### PR TITLE
fix(e2e): filter framework tests from Docker runner

### DIFF
--- a/tests/e2e/scripts/run_e2e_tests.sh
+++ b/tests/e2e/scripts/run_e2e_tests.sh
@@ -150,7 +150,7 @@ else
   # Run with gotestsum (existing behavior - DEFAULT)
   exec gotestsum --junitfile-project-name odh-operator-e2e \
     --junitfile results/xunit_report.xml --format standard-verbose --raw-command \
-    -- test2json -t -p e2e ./e2e-tests --test.v=test2json --test.parallel=8 \
+    -- test2json -t -p e2e ./e2e-tests --test.run='^TestOdhOperator' --test.v=test2json --test.parallel=8 \
     --deletion-policy="$E2E_TEST_DELETION_POLICY" \
     --clean-up-previous-resources="$E2E_TEST_CLEAN_UP_PREVIOUS_RESOURCES" \
     --backup-and-restore-dsci-and-dsc="$E2E_TEST_BACKUP_AND_RESTORE_DSCI_AND_DSC" \


### PR DESCRIPTION
## Description

The Docker E2E image's default `gotestsum` path executed every top-level test in the precompiled binary. This included framework consistency tests such as `TestScopeRulesComponentsMatchRealTestGroup`, which do not exercise product behavior.

`make e2e-test` already filters to `^TestOdhOperator` through `test-retry`. Apply the same `--test.run='^TestOdhOperator'` filter to Docker's default runner path.

## Release tracking

Release:
Jira: https://redhat.atlassian.net/browse/RHOAIENG-84750

## How Has This Been Tested?

- `bash -n tests/e2e/scripts/run_e2e_tests.sh`
- `go test ./tests/e2e/ -run '^TestScopeRulesComponentsMatchRealTestGroup$' -count=1`
- `make generate manifests api-docs`
- `make fmt`
- `make lint`

No live-cluster E2E run was available.

## Screenshot or short clip

Not applicable.

## Merge criteria

- [x] Read contributors guide.
- [x] Commit message is meaningful.
- [x] PR contains solution description, Jira link, and related issue.
- [x] Testing instructions are included.
- [ ] Developer manually tested the Docker image change.
- [ ] Integration test pipeline has passed.
- [ ] No new RELATED_IMAGE mappings are required.

### E2E test suite update requirement

- [x] Skip requirement to update E2E test suite for this PR.

#### E2E update requirement opt-out justification

This changes E2E runner selection only. It excludes framework-level consistency tests from product E2E execution and adds no product behavior or component coverage.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated the end-to-end test execution to target tests matching the `TestOdhOperator` prefix when using the gotestsum workflow.
  * Preserved the existing test-retry behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->