### PR TITLE
add config for odh-observability module

### DIFF
--- a/build/manifests-config.yaml
+++ b/build/manifests-config.yaml
@@ -19,6 +19,10 @@ map:
     src: config/chart
     dest: feastoperator
     type: chart
+  odh-observability:
+    src: charts/odh-observability
+    dest: odh-observability
+    type: chart
   odh-trainer-operator:
     src: config
     dest: trainer


### PR DESCRIPTION
<!---
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->
Add odh-observability chart to build config. It was missing in the latest 3.6 ea 1 nightly.

```
{"level":"error","ts":"2026-09-01T09:33:11Z","msg":"Reconciler error","controller":"modules","controllerGroup":"config.opendatahub.io","controllerKind":"Platform","Platform":{"name":"default"},"namespace":"","name":"default","reconcileID":"c7fac571-7a7d-4660-bf7a-afca33215703","error":"provisioning failed: error rendering helm chart /opt/charts/odh-observability (release: odh-observability): unable to locate chart (repo: , name: /opt/charts/odh-observability, version: ): failed to locate chart \"/opt/charts/odh-observability\": path not found: /opt/charts/odh-observability"...
```

<!-- For RHOAI PRs, request review on #ai-core-platform-requests Slack channel -->

## Release tracking
<!-- Optional. Set a target release only if this PR must ship in a specific release; it will be prioritized accordingly. -->
<!-- Target release for this PR, e.g. rhoai-3.6 or rhoai-3.7ea1 -->
Release: 
<!-- Required only if a Release is set above. Full link to a jira ticket, e.g. https://redhat.atlassian.net/browse/RHOAIENG-XXXXX -->
Jira: https://redhat.atlassian.net/browse/RHOAIENG-90091


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [] The developer has manually tested the changes and verified that the changes work
- [] The developer has run the integration test pipeline and verified that it passed successfully
- [] New RELATED_IMAGE mappings are listed in ODH-Build-Config and RHOAI-Build-Config (CI validates names against build-config repos). Include links to build-config PRs in the description.

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [ ] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `odh-observability` component to the deployment manifests, enabling it to be provisioned through the platform’s standard installation process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->