### PR TITLE
fix(RHOAIENG-85407): accept DataScienceCluster owner on dashboard_test.go failing test

### DIFF
--- a/tests/e2e/dashboard_test.go
+++ b/tests/e2e/dashboard_test.go
@@ -81,6 +81,7 @@ func (tc *DashboardTestCtx) ValidateOperandsOwnerReferences(t *testing.T) {
 				SatisfyAny(
 					jq.Match(`.metadata.ownerReferences[0].kind == "%s"`, tc.GVK.Kind),
 					jq.Match(`.metadata.ownerReferences[0].kind == "Platform"`),
+					jq.Match(`.metadata.ownerReferences[0].kind == "DataScienceCluster"`),
 				),
 			),
 		),


### PR DESCRIPTION
<!---
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description

Fix smoke failure `Validate operands have OwnerReferences` (dashboard component).

The test checks owner refs on all `part-of=dashboard` Deployments, including `dashboard-operator`. Operands are owned by `Dashboard`; on RHOAI smoke clusters the module controller is still owned by `DataScienceCluster` (DSC meta-operator path per modules README). After #3786 the test only accepted `Platform`, causing a ~5m timeout — not a product bug.

Add `DataScienceCluster` to the allowed owner kinds alongside `Dashboard` and `Platform` during DSC→Platform migration.

<!-- For RHOAI PRs, request review on #ai-core-platform-requests Slack channel -->

## Release tracking
Release:
Jira: https://redhat.atlassian.net/browse/RHOAIENG-85407

## How Has This Been Tested?

RHOAI 3.5.0 on OCP 4.21 — `Validate_operands_have_OwnerReferences` passes locally (~0.2s; was ~300s timeout before fix). `dashboard-operator` owner on cluster: `DataScienceCluster/default-dsc`.

```bash
make e2e-test-single ODH_PLATFORM_TYPE=rhoai \
  -e E2E_TEST_OPERATOR_NAMESPACE=redhat-ods-operator \
  -e E2E_TEST_APPLICATIONS_NAMESPACE=redhat-ods-applications \
  -e E2E_TEST_WORKBENCHES_NAMESPACE=rhods-notebooks \
  -e E2E_TEST_DSC_MONITORING_NAMESPACE=redhat-ods-monitoring \
  -e E2E_TEST_DSC_MANAGEMENT=false -e E2E_TEST_DSC_VALIDATION=false \
  -e E2E_TEST_OPERATOR_CONTROLLER=false -e E2E_TEST_WEBHOOK=false \
  -e E2E_TEST_OPERATOR_RESILIENCE=false -e E2E_TEST_DAG_ORDERING=false \
  -e E2E_TEST_DEPENDANT_OPERATORS_MANAGEMENT=false \
  -e E2E_TEST_COMPONENTS=true -e E2E_TEST_COMPONENT=dashboard \
  -e E2E_TEST_SERVICES=false \
  TEST='TestOdhOperator/components/group_1/dashboard/Validate operands have OwnerReferences$'
```

## Screenshot or short clip
N/A

## Merge criteria

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully
- [ ] New RELATED_IMAGE mappings are listed in ODH-Build-Config and RHOAI-Build-Config (CI validates names against build-config repos). Include links to build-config PRs in the description.

### E2E test suite update requirement

- [ ] Skip requirement to update E2E test suite for this PR

#### E2E update requirement opt-out justification

Not applicable — this PR updates the E2E test suite.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated dashboard end-to-end validation to recognize `DataScienceCluster` as a valid deployment owner reference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->