### PR TITLE
fix: remove ModulesReady check in sparkoperator e2e

### DIFF
--- a/tests/e2e/sparkoperator_test.go
+++ b/tests/e2e/sparkoperator_test.go
@@ -85,12 +85,6 @@ func sparkOperatorTestSuite(t *testing.T) {
 			tc.EnsureResourceExists(
 				WithMinimalObject(gvk.DataScienceCluster, tc.DataScienceClusterNamespacedName),
 				WithEventuallyTimeout(tc.TestTimeouts.longEventuallyTimeout),
-				WithCondition(jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, status.ConditionTypeModulesReady, metav1.ConditionTrue)),
-			)
-
-			tc.EnsureResourceExists(
-				WithMinimalObject(gvk.DataScienceCluster, tc.DataScienceClusterNamespacedName),
-				WithEventuallyTimeout(tc.TestTimeouts.longEventuallyTimeout),
 				WithCondition(jq.Match(`.status.conditions[] | select(.type == "%sReady") | .status == "%s"`, componentApi.SparkOperatorKind, metav1.ConditionTrue)),
 				WithCustomErrorMsg("DataScienceCluster should have %sReady condition set to True", componentApi.SparkOperatorKind),
 			)


### PR DESCRIPTION
<!---
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
Component e2e run in parallel, so another component could have issues. The ModulesReady status condition, which sum up all the modules conditions, should not be validated in the component tests.

<!-- For RHOAI PRs, request review on #ai-core-platform-requests Slack channel -->

## Release tracking
<!-- Optional. Set a target release only if this PR must ship in a specific release; it will be prioritized accordingly. -->
<!-- Target release for this PR, e.g. rhoai-3.6 or rhoai-3.7ea1 -->
Release: 
<!-- Required only if a Release is set above. Full link to a jira ticket, e.g. https://redhat.atlassian.net/browse/RHOAIENG-XXXXX -->
Jira:


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully
- [ ] New RELATED_IMAGE mappings are listed in ODH-Build-Config and RHOAI-Build-Config (CI validates names against build-config repos). Include links to build-config PRs in the description.

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [ ] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated Spark Operator enablement validation to check its component-specific ready status.
  * Improved the failure message shown when readiness is not confirmed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->