### PR TITLE
Fix gates (RBAC, Kueue, ServiceMesh v2)

### DIFF
--- a/internal/controller/datasciencecluster/kubebuilder_rbac.go
+++ b/internal/controller/datasciencecluster/kubebuilder_rbac.go
@@ -203,6 +203,12 @@ package datasciencecluster
 // +kubebuilder:rbac:groups="build.openshift.io",resources=builds,verbs=get;list;watch;delete
 // +kubebuilder:rbac:groups="build.openshift.io",resources=buildconfigs,verbs=list;watch;create;patch;delete;get;update
 
+// Upgrade gate checks need cluster-wide read access to detect blocking workloads and dependencies.
+// +kubebuilder:rbac:groups="serving.kserve.io",resources=inferenceservices;servingruntimes;llminferenceservices,verbs=get;list;watch
+// +kubebuilder:rbac:groups="trustyai.opendatahub.io",resources=trustyaiservices,verbs=get;list;watch
+// +kubebuilder:rbac:groups="operator.authorino.kuadrant.io",resources=authorinos,verbs=get;list;watch
+// +kubebuilder:rbac:groups="kubeflow.org",resources=pytorchjobs,verbs=get;list;watch
+
 // General operator permissions
 // +kubebuilder:rbac:groups=metrics.k8s.io,resources=pods;nodes,verbs=get;list;watch
 // +kubebuilder:rbac:groups="apps",resources=daemonsets,verbs=get;list;watch;create;update;patch;delete

--- a/pkg/upgrade/gates/AGENTS.md
+++ b/pkg/upgrade/gates/AGENTS.md
@@ -110,9 +110,9 @@ from the DSC component map.
 
 ### `kueue`
 
-- checks the runtime internal `kueue.openshift.io/v1` `Kueue` CR
-- blocks immediately when `managementState=Managed`
-- requires the `kueue-operator` OLM subscription when `managementState=Unmanaged`
+- reads Kueue management state from the user-facing `DataScienceCluster` CR
+- the separate `dependencies-kueue-operator` gate blocks when `managementState=Managed`
+- the dependency gate requires the `kueue-operator` OLM subscription when `managementState=Unmanaged`
 - validates that kueue-labeled workloads do not live in namespaces missing
   `kueue.openshift.io/managed=true` once the `Unmanaged` operator prerequisite is met
 

--- a/pkg/upgrade/gates/TASKS.md
+++ b/pkg/upgrade/gates/TASKS.md
@@ -90,7 +90,7 @@ Legend:
 - Checks implemented in repo:
   - block when queued workloads (`kueue.x-k8s.io/queue-name`) live in
     namespaces missing `kueue.openshift.io/managed=true`
-  - block when queued workloads exist while the internal Kueue CR is `Removed`
+  - block when queued workloads exist while Kueue is `Removed` in the DSC
 - Detailed behavior:
   - workload discovery is cross-component: `Notebook`, `InferenceService`,
     `LLMInferenceService`, `RayCluster`, `RayJob`, and `PyTorchJob` resources
@@ -100,10 +100,10 @@ Legend:
   - the namespace-label branch caches namespace lookups, so repeated queued
     workloads in the same namespace do not multiply API reads
 - Related dependency gate:
-  - `dependencies-kueue-operator` blocks when the internal
-    `kueue.openshift.io/v1` `Kueue` CR is still `Managed`
+  - `dependencies-kueue-operator` blocks when Kueue is still `Managed` in the
+    DSC
   - `dependencies-kueue-operator` requires the `kueue-operator` OLM
-    subscription when the internal Kueue CR is `Unmanaged`
+    subscription when Kueue is `Unmanaged` in the DSC
 - Left out from odh-cli:
   - odh-cli's `workloads.kueue.data-integrity` lint is broader: it also checks
     workloads inside Kueue-managed namespaces that are missing the queue label,
@@ -336,22 +336,22 @@ Legend:
   - this is a strict presence check on the expected OLM subscription and does
     not currently inspect CSV health or channel/version skew
 - `dependencies-kueue-operator`
-  - blocks when the internal Kueue CR is still `Managed`
-  - blocks when the internal Kueue CR is `Unmanaged` but the `kueue-operator`
+  - blocks when Kueue is still `Managed` in the `DataScienceCluster` spec
+  - blocks when Kueue is `Unmanaged` in the `DataScienceCluster` spec but the `kueue-operator`
     `Subscription` is missing
   - this is split out locally rather than tracked by a dedicated Jira child
 - `dependencies-kueue-operator` detail:
-  - the gate is intentionally state-aware: it does nothing when no internal
-    Kueue CR exists, treats `Managed` as unsupported for the upgrade path, and
-    only requires the subscription in the `Unmanaged` handoff case
+  - the gate is intentionally state-aware: it does nothing when no
+    `DataScienceCluster` exists, treats `Managed` as unsupported for the upgrade
+    path, and only requires the subscription in the `Unmanaged` handoff case
 - `dependencies-servicemeshoperatorv2`
-  - blocks when a `servicemeshoperatorv2` `Subscription` still exists on
-    blocking channels (`stable`, `v2.x`)
+  - blocks when a `Subscription` for the `servicemeshoperator` package still
+    exists
   - no matching Jira child issue exists in this list; this is a repo-local
     dependency cleanup gate
 - `dependencies-servicemeshoperatorv2` detail:
-  - the gate keys off subscription name plus channel, so unrelated subscriptions
-    or non-blocking channels do not trip it
+  - the gate keys off `Subscription.spec.name`, so custom Subscription resource
+    names are supported and unrelated OLM packages do not trip it
 - `removed-codeflare`
   - blocks when the internal `CodeFlare` CR still exists
   - this does not map cleanly to `RHOAIENG-82353`, but it no longer conflicts

--- a/pkg/upgrade/gates/kueue/kueue_integration_test.go
+++ b/pkg/upgrade/gates/kueue/kueue_integration_test.go
@@ -5,12 +5,15 @@ import (
 	"errors"
 	"testing"
 
+	operatorv1 "github.com/openshift/api/operator/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/api/components/v1alpha1"
+	dscv2 "github.com/opendatahub-io/opendatahub-operator/v2/api/datasciencecluster/v2"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
 	kueuegate "github.com/opendatahub-io/opendatahub-operator/v2/pkg/upgrade/gates/kueue"
@@ -56,7 +59,7 @@ func (tc *kueueGateTestCtx) testCleanClusterPasses(t *testing.T) {
 func (tc *kueueGateTestCtx) testManagedKueuePasses(t *testing.T) {
 	g := NewWithT(t)
 
-	obj := renderKueue(t, "Managed")
+	obj := renderIntegrationDSC(operatorv1.Managed)
 	g.Expect(tc.cli.Create(t.Context(), obj)).ToNot(HaveOccurred())
 	defer deleteObject(g, tc.cli, obj)
 
@@ -67,7 +70,7 @@ func (tc *kueueGateTestCtx) testManagedKueuePasses(t *testing.T) {
 func (tc *kueueGateTestCtx) testUnmanagedKueueWithoutOperatorPasses(t *testing.T) {
 	g := NewWithT(t)
 
-	obj := renderKueue(t, "Unmanaged")
+	obj := renderIntegrationDSC(operatorv1.Unmanaged)
 	g.Expect(tc.cli.Create(t.Context(), obj)).ToNot(HaveOccurred())
 	defer deleteObject(g, tc.cli, obj)
 
@@ -88,17 +91,9 @@ func (tc *kueueGateTestCtx) assertMissingNamespaceLabelBlocks(
 
 	g := NewWithT(t)
 
-	obj := renderKueue(t, managementState)
+	obj := renderIntegrationDSC(operatorv1.ManagementState(managementState))
 	g.Expect(tc.cli.Create(t.Context(), obj)).ToNot(HaveOccurred())
 	defer deleteObject(g, tc.cli, obj)
-
-	subscriptionNamespace := namespace + "-operator"
-	operatorNamespace := renderNamespace(subscriptionNamespace, nil)
-	g.Expect(tc.cli.Create(t.Context(), operatorNamespace)).ToNot(HaveOccurred())
-
-	subscription := renderSubscription(subscriptionNamespace)
-	g.Expect(tc.cli.Create(t.Context(), subscription)).ToNot(HaveOccurred())
-	defer deleteObject(g, tc.cli, subscription)
 
 	ns := renderNamespace(namespace, nil)
 	g.Expect(tc.cli.Create(t.Context(), ns)).ToNot(HaveOccurred())
@@ -118,16 +113,9 @@ func (tc *kueueGateTestCtx) assertMissingNamespaceLabelBlocks(
 func (tc *kueueGateTestCtx) testUnmanagedKueueWithManagedNamespacePasses(t *testing.T) {
 	g := NewWithT(t)
 
-	obj := renderKueue(t, "Unmanaged")
+	obj := renderIntegrationDSC(operatorv1.Unmanaged)
 	g.Expect(tc.cli.Create(t.Context(), obj)).ToNot(HaveOccurred())
 	defer deleteObject(g, tc.cli, obj)
-
-	operatorNamespace := renderNamespace("openshift-kueue-operator", nil)
-	g.Expect(tc.cli.Create(t.Context(), operatorNamespace)).ToNot(HaveOccurred())
-
-	subscription := renderSubscription(operatorNamespace.Name)
-	g.Expect(tc.cli.Create(t.Context(), subscription)).ToNot(HaveOccurred())
-	defer deleteObject(g, tc.cli, subscription)
 
 	ns := renderNamespace("workloads-with-label", map[string]string{cluster.KueueManagedLabelKey: "true"})
 	g.Expect(tc.cli.Create(t.Context(), ns)).ToNot(HaveOccurred())
@@ -143,7 +131,7 @@ func (tc *kueueGateTestCtx) testUnmanagedKueueWithManagedNamespacePasses(t *test
 func (tc *kueueGateTestCtx) testRemovedKueueWithQueuedWorkloadsBlocks(t *testing.T) {
 	g := NewWithT(t)
 
-	obj := renderKueue(t, "Removed")
+	obj := renderIntegrationDSC(operatorv1.Removed)
 	g.Expect(tc.cli.Create(t.Context(), obj)).ToNot(HaveOccurred())
 	defer deleteObject(g, tc.cli, obj)
 
@@ -166,7 +154,7 @@ func (tc *kueueGateTestCtx) testRemovedKueueWithQueuedWorkloadsBlocks(t *testing
 func (tc *kueueGateTestCtx) testRemovedKueueWithoutQueuedWorkloadsPasses(t *testing.T) {
 	g := NewWithT(t)
 
-	obj := renderKueue(t, "Removed")
+	obj := renderIntegrationDSC(operatorv1.Removed)
 	g.Expect(tc.cli.Create(t.Context(), obj)).ToNot(HaveOccurred())
 	defer deleteObject(g, tc.cli, obj)
 
@@ -177,21 +165,10 @@ func (tc *kueueGateTestCtx) testRemovedKueueWithoutQueuedWorkloadsPasses(t *test
 func installKueueGateCRDs(ctx context.Context, te *envt.EnvT) error {
 	if _, err := te.RegisterCRD(
 		ctx,
-		gvk.Kueue,
-		"kueues",
-		"kueue",
+		gvk.DataScienceCluster,
+		"datascienceclusters",
+		"datasciencecluster",
 		apiextensionsv1.ClusterScoped,
-		envt.WithPermissiveSchema(),
-	); err != nil {
-		return err
-	}
-
-	if _, err := te.RegisterCRD(
-		ctx,
-		gvk.Subscription,
-		"subscriptions",
-		"subscription",
-		apiextensionsv1.NamespaceScoped,
 		envt.WithPermissiveSchema(),
 	); err != nil {
 		return err
@@ -222,6 +199,15 @@ func installKueueGateCRDs(ctx context.Context, te *envt.EnvT) error {
 	}
 
 	return nil
+}
+
+func renderIntegrationDSC(managementState operatorv1.ManagementState) *dscv2.DataScienceCluster {
+	dsc := &dscv2.DataScienceCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "default-dsc"},
+	}
+	dsc.Spec.Components.Kueue.ManagementState = managementState
+
+	return dsc
 }
 
 func deleteObject(g *WithT, cli client.Client, obj client.Object) {

--- a/pkg/upgrade/gates/kueue/kueue_support.go
+++ b/pkg/upgrade/gates/kueue/kueue_support.go
@@ -4,34 +4,26 @@ import (
 	"context"
 	"fmt"
 
+	operatorv1 "github.com/openshift/api/operator/v1"
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/api/meta"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/api/components/v1alpha1"
-	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
 )
 
 func ManagementState(ctx context.Context, reader client.Reader) (string, error) {
-	obj := &unstructured.Unstructured{}
-	obj.SetGroupVersionKind(gvk.Kueue)
-
-	err := reader.Get(ctx, client.ObjectKey{Name: componentApi.KueueInstanceName}, obj)
+	dsc, err := cluster.GetDSC(ctx, reader)
 	switch {
-	case k8serr.IsNotFound(err), meta.IsNoMatchError(err):
+	case k8serr.IsNotFound(err):
 		return "", nil
 	case err != nil:
-		return "", fmt.Errorf("getting Kueue CR: %w", err)
+		return "", fmt.Errorf("getting DataScienceCluster for Kueue managementState: %w", err)
 	}
 
-	state, found, err := unstructured.NestedString(obj.Object, "spec", "managementState")
-	switch {
-	case err != nil:
-		return "", fmt.Errorf("reading Kueue managementState: %w", err)
-	case !found:
-		return "", nil
-	default:
-		return state, nil
+	state := dsc.Spec.Components.Kueue.ManagementState
+	if state == "" {
+		state = operatorv1.Removed
 	}
+
+	return string(state), nil
 }

--- a/pkg/upgrade/gates/kueue/kueue_test.go
+++ b/pkg/upgrade/gates/kueue/kueue_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"testing"
 
+	operatorv1 "github.com/openshift/api/operator/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -12,6 +13,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/api/components/v1alpha1"
+	dscv2 "github.com/opendatahub-io/opendatahub-operator/v2/api/datasciencecluster/v2"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/provision"
@@ -38,12 +40,12 @@ func TestRegister_CleanClusterPasses(t *testing.T) {
 	g.Expect(err).ToNot(HaveOccurred())
 }
 
-func TestRegister_ManagedKueueBlocks(t *testing.T) {
+func TestRegister_ManagedKueuePasses(t *testing.T) {
 	g := NewWithT(t)
 	ctx := t.Context()
 
 	cli, err := newKueueClient(
-		renderKueue(t, "Managed"),
+		renderDSC(operatorv1.Managed),
 	)
 	g.Expect(err).ToNot(HaveOccurred())
 
@@ -58,7 +60,7 @@ func TestRegister_UnmanagedKueueWithoutOperatorPasses(t *testing.T) {
 	ctx := t.Context()
 
 	cli, err := newKueueClient(
-		renderKueue(t, "Unmanaged"),
+		renderDSC(operatorv1.Unmanaged),
 	)
 	g.Expect(err).ToNot(HaveOccurred())
 
@@ -73,8 +75,7 @@ func TestRegister_UnmanagedKueueWithMissingNamespaceLabelBlocks(t *testing.T) {
 	ctx := t.Context()
 
 	cli, err := newKueueClient(
-		renderKueue(t, "Unmanaged"),
-		renderSubscription("openshift-kueue-operator"),
+		renderDSC(operatorv1.Unmanaged),
 		renderNamespace("workloads", nil),
 		renderNotebook(t, "workloads"),
 	)
@@ -95,8 +96,7 @@ func TestRegister_UnmanagedKueueWithManagedNamespacePasses(t *testing.T) {
 	ctx := t.Context()
 
 	cli, err := newKueueClient(
-		renderKueue(t, "Unmanaged"),
-		renderSubscription("openshift-kueue-operator"),
+		renderDSC(operatorv1.Unmanaged),
 		renderNamespace("workloads", map[string]string{cluster.KueueManagedLabelKey: "true"}),
 		renderNotebook(t, "workloads"),
 	)
@@ -113,7 +113,7 @@ func TestRegister_RemovedKueueWithQueuedWorkloadsBlocks(t *testing.T) {
 	ctx := t.Context()
 
 	cli, err := newKueueClient(
-		renderKueue(t, "Removed"),
+		renderDSC(operatorv1.Removed),
 		renderNamespace("workloads", nil),
 		renderNotebook(t, "workloads"),
 	)
@@ -135,7 +135,7 @@ func TestRegister_RemovedKueueWithoutQueuedWorkloadsPasses(t *testing.T) {
 	ctx := t.Context()
 
 	cli, err := newKueueClient(
-		renderKueue(t, "Removed"),
+		renderDSC(operatorv1.Removed),
 	)
 	g.Expect(err).ToNot(HaveOccurred())
 
@@ -149,23 +149,18 @@ func newKueueClient(objects ...client.Object) (client.Client, error) {
 	return fakeclient.New(
 		fakeclient.WithObjects(objects...),
 		fakeclient.WithGVKs(
-			fakeclient.GVKMapping{GVK: gvk.Kueue, Scope: meta.RESTScopeRoot},
 			fakeclient.GVKMapping{GVK: gvk.Notebook, Scope: meta.RESTScopeNamespace},
-			fakeclient.GVKMapping{GVK: gvk.Subscription, Scope: meta.RESTScopeNamespace},
 		),
 	)
 }
 
-func renderKueue(t *testing.T, managementState string) *unstructured.Unstructured {
-	t.Helper()
+func renderDSC(managementState operatorv1.ManagementState) *dscv2.DataScienceCluster {
+	dsc := &dscv2.DataScienceCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "default-dsc"},
+	}
+	dsc.Spec.Components.Kueue.ManagementState = managementState
 
-	g := NewWithT(t)
-	obj, err := tp.RenderObject(resourcesFS, "resources/kueue.tmpl.yaml", map[string]any{
-		"ManagementState": managementState,
-	})
-	g.Expect(err).ToNot(HaveOccurred())
-
-	return obj
+	return dsc
 }
 
 func renderNotebook(t *testing.T, namespace string) *unstructured.Unstructured {
@@ -189,13 +184,4 @@ func renderNamespace(name string, labels map[string]string) *corev1.Namespace {
 			Labels: labels,
 		},
 	}
-}
-
-func renderSubscription(namespace string) *unstructured.Unstructured {
-	obj := &unstructured.Unstructured{}
-	obj.SetGroupVersionKind(gvk.Subscription)
-	obj.SetName("kueue-operator")
-	obj.SetNamespace(namespace)
-
-	return obj
 }

--- a/pkg/upgrade/gates/kueueoperator/kueueoperator_test.go
+++ b/pkg/upgrade/gates/kueueoperator/kueueoperator_test.go
@@ -5,9 +5,12 @@ import (
 	"errors"
 	"testing"
 
+	operatorv1 "github.com/openshift/api/operator/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	dscv2 "github.com/opendatahub-io/opendatahub-operator/v2/api/datasciencecluster/v2"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
 	kueueoperatorgate "github.com/opendatahub-io/opendatahub-operator/v2/pkg/upgrade/gates/kueueoperator"
 	tp "github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/template"
@@ -36,7 +39,7 @@ func TestCheck_BlocksWhenKueueManaged(t *testing.T) {
 
 	g := NewWithT(t)
 
-	cli, err := newKueueOperatorClient(renderKueue(t, "Managed"))
+	cli, err := newKueueOperatorClient(renderDSC(operatorv1.Managed))
 	g.Expect(err).ToNot(HaveOccurred())
 
 	err = kueueoperatorgate.Check(t.Context(), cli, "", "")
@@ -52,7 +55,7 @@ func TestCheck_BlocksWhenKueueUnmanagedWithoutOperator(t *testing.T) {
 
 	g := NewWithT(t)
 
-	cli, err := newKueueOperatorClient(renderKueue(t, "Unmanaged"))
+	cli, err := newKueueOperatorClient(renderDSC(operatorv1.Unmanaged))
 	g.Expect(err).ToNot(HaveOccurred())
 
 	err = kueueoperatorgate.Check(t.Context(), cli, "", "")
@@ -69,7 +72,7 @@ func TestCheck_PassesWhenKueueUnmanagedWithOperator(t *testing.T) {
 	g := NewWithT(t)
 
 	cli, err := newKueueOperatorClient(
-		renderKueue(t, "Unmanaged"),
+		renderDSC(operatorv1.Unmanaged),
 		renderSubscription(t, "openshift-kueue-operator"),
 	)
 	g.Expect(err).ToNot(HaveOccurred())
@@ -83,7 +86,23 @@ func TestCheck_PassesWhenKueueRemoved(t *testing.T) {
 
 	g := NewWithT(t)
 
-	cli, err := newKueueOperatorClient(renderKueue(t, "Removed"))
+	cli, err := newKueueOperatorClient(renderDSC(operatorv1.Removed))
+	g.Expect(err).ToNot(HaveOccurred())
+
+	err = kueueoperatorgate.Check(t.Context(), cli, "", "")
+	g.Expect(err).ToNot(HaveOccurred())
+}
+
+func TestCheck_UsesDSCStateWhenInternalKueueCRIsStale(t *testing.T) {
+	t.Parallel()
+
+	g := NewWithT(t)
+
+	cli, err := newKueueOperatorClient(
+		renderDSC(operatorv1.Unmanaged),
+		renderKueue(t, "Managed"),
+		renderSubscription(t, "openshift-kueue-operator"),
+	)
 	g.Expect(err).ToNot(HaveOccurred())
 
 	err = kueueoperatorgate.Check(t.Context(), cli, "", "")
@@ -110,6 +129,15 @@ func renderKueue(t *testing.T, managementState string) client.Object {
 	g.Expect(err).ToNot(HaveOccurred())
 
 	return obj
+}
+
+func renderDSC(managementState operatorv1.ManagementState) *dscv2.DataScienceCluster {
+	dsc := &dscv2.DataScienceCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "default-dsc"},
+	}
+	dsc.Spec.Components.Kueue.ManagementState = managementState
+
+	return dsc
 }
 
 func renderSubscription(t *testing.T, namespace string) client.Object {

--- a/pkg/upgrade/gates/servicemeshoperatorv2/servicemeshoperatorv2.go
+++ b/pkg/upgrade/gates/servicemeshoperatorv2/servicemeshoperatorv2.go
@@ -3,19 +3,13 @@ package servicemeshoperatorv2
 import (
 	"context"
 	"fmt"
-	"slices"
 
 	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-const subscriptionName = "servicemeshoperatorv2"
-
-var blockingChannels = []string{
-	"stable",
-	"v2.x",
-}
+const subscriptionPackage = "servicemeshoperator"
 
 func Check(ctx context.Context, cli client.Reader, _ string, _ string) error {
 	subscriptions := &operatorsv1alpha1.SubscriptionList{}
@@ -28,7 +22,7 @@ func Check(ctx context.Context, cli client.Reader, _ string, _ string) error {
 
 	for i := range subscriptions.Items {
 		sub := &subscriptions.Items[i]
-		if sub.Name != subscriptionName || !slices.Contains(blockingChannels, sub.Spec.Channel) {
+		if sub.Spec == nil || sub.Spec.Package != subscriptionPackage {
 			continue
 		}
 

--- a/pkg/upgrade/gates/servicemeshoperatorv2/servicemeshoperatorv2_test.go
+++ b/pkg/upgrade/gates/servicemeshoperatorv2/servicemeshoperatorv2_test.go
@@ -46,14 +46,15 @@ func TestCheck_BlocksWhenLegacySubscriptionExists(t *testing.T) {
 		WithScheme(serviceMeshOperatorV2Scheme(t)).
 		WithObjects(&operatorsv1alpha1.Subscription{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "servicemeshoperatorv2",
+				Name:      "custom-service-mesh-subscription",
 				Namespace: "openshift-operators",
 			},
 			Spec: &operatorsv1alpha1.SubscriptionSpec{
+				Package: "servicemeshoperator",
 				Channel: "stable",
 			},
 			Status: operatorsv1alpha1.SubscriptionStatus{
-				InstalledCSV: "servicemeshoperatorv2.v2.5.0",
+				InstalledCSV: "servicemeshoperator.v2.6.17",
 			},
 		}).
 		Build()
@@ -64,12 +65,12 @@ func TestCheck_BlocksWhenLegacySubscriptionExists(t *testing.T) {
 	var blockingErr *servicemeshoperatorv2gate.UpgradeBlockedError
 	g.Expect(errors.As(err, &blockingErr)).To(BeTrue())
 	g.Expect(blockingErr.SubscriptionNamespace).To(Equal("openshift-operators"))
-	g.Expect(blockingErr.SubscriptionName).To(Equal("servicemeshoperatorv2"))
+	g.Expect(blockingErr.SubscriptionName).To(Equal("custom-service-mesh-subscription"))
 	g.Expect(blockingErr.Channel).To(Equal("stable"))
-	g.Expect(blockingErr.InstalledCSV).To(Equal("servicemeshoperatorv2.v2.5.0"))
+	g.Expect(blockingErr.InstalledCSV).To(Equal("servicemeshoperator.v2.6.17"))
 }
 
-func TestCheck_IgnoresNonBlockingChannels(t *testing.T) {
+func TestCheck_BlocksWhenMatchingPackageHasNoChannel(t *testing.T) {
 	t.Parallel()
 
 	g := NewWithT(t)
@@ -78,11 +79,33 @@ func TestCheck_IgnoresNonBlockingChannels(t *testing.T) {
 		WithScheme(serviceMeshOperatorV2Scheme(t)).
 		WithObjects(&operatorsv1alpha1.Subscription{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "servicemeshoperatorv2",
+				Name:      "servicemeshoperator",
 				Namespace: "openshift-operators",
 			},
 			Spec: &operatorsv1alpha1.SubscriptionSpec{
-				Channel: "stable-v3",
+				Package: "servicemeshoperator",
+			},
+		}).
+		Build()
+
+	err := servicemeshoperatorv2gate.Check(t.Context(), cli, "", "")
+	g.Expect(err).To(HaveOccurred())
+}
+
+func TestCheck_IgnoresMetadataNameWhenPackageDoesNotMatch(t *testing.T) {
+	t.Parallel()
+
+	g := NewWithT(t)
+
+	cli := fake.NewClientBuilder().
+		WithScheme(serviceMeshOperatorV2Scheme(t)).
+		WithObjects(&operatorsv1alpha1.Subscription{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "servicemeshoperator",
+				Namespace: "openshift-operators",
+			},
+			Spec: &operatorsv1alpha1.SubscriptionSpec{
+				Package: "servicemeshoperator3",
 			},
 		}).
 		Build()

--- a/tests/integration/upgrades/resources/datasciencecluster.tmpl.yaml
+++ b/tests/integration/upgrades/resources/datasciencecluster.tmpl.yaml
@@ -2,12 +2,12 @@ apiVersion: datasciencecluster.opendatahub.io/v2
 kind: DataScienceCluster
 metadata:
   name: {{ .Name }}
-{{- if .ManagedComponents }}
+{{- if .ComponentStates }}
 spec:
   components:
-{{- range .ManagedComponents }}
-    {{ . }}:
-      managementState: Managed
+{{- range $component, $state := .ComponentStates }}
+    {{ $component }}:
+      managementState: {{ $state }}
 {{- end }}
 {{- end }}
 {{- if .Version }}

--- a/tests/integration/upgrades/resources/subscription.tmpl.yaml
+++ b/tests/integration/upgrades/resources/subscription.tmpl.yaml
@@ -3,9 +3,16 @@ kind: Subscription
 metadata:
   name: {{ .Name }}
   namespace: {{ .Namespace }}
-{{- if .Channel }}
+{{- $package := index . "Package" }}
+{{- $channel := index . "Channel" }}
+{{- if or $package $channel }}
 spec:
-  channel: {{ .Channel }}
+{{- if $package }}
+  name: {{ $package }}
+{{- end }}
+{{- if $channel }}
+  channel: {{ $channel }}
+{{- end }}
 {{- end }}
 {{- if .InstalledCSV }}
 status:

--- a/tests/integration/upgrades/scenarios/AGENTS.md
+++ b/tests/integration/upgrades/scenarios/AGENTS.md
@@ -70,9 +70,10 @@ kubectl get dsc default-dsc -o yaml | sed -n '/conditions:/,$p'
 
 Expected unacknowledged categories include CodeFlare, ModelMeshServing,
 KServe, Ray, TrustyAI, Workbenches, DSP stored versions, and Kueue. The
-Service Mesh dependency can also block because the baseline Subscription uses
-the `stable` channel. Cert-manager is installed in the documented baseline,
-so its dependency gate should not block.
+Service Mesh dependency also blocks while the baseline Subscription has
+`spec.name: servicemeshoperator`; its `stable` channel is not used to identify
+the v2 package. Cert-manager is installed in the documented baseline, so its
+dependency gate should not block.
 
 ## Operational lessons
 
@@ -88,10 +89,10 @@ so its dependency gate should not block.
   `datasciencepipelinesapplications.datasciencepipelinesapplications.opendatahub.io`.
   Its `status.storedVersions` is a status-subresource field; the supplied JSON
   patch intentionally leaves only `v1`.
-- Kueue's dependency gate reads the generated `default-kueue` CR, but the DSC
-  is its source of truth. Change `spec.components.kueue.managementState` on
-  `default-dsc` first. For the missing-operator case use `Unmanaged` and make
-  sure there is no `kueue-operator` Subscription.
+- Kueue gates read `spec.components.kueue.managementState` directly from
+  `default-dsc`; the generated `default-kueue` CR is not consulted. For the
+  missing-operator case use `Unmanaged` and make sure there is no
+  `kueue-operator` Subscription.
 - Admission webhooks reject deliberately broken objects at creation time.
   KServe InferenceServices need a predictor, ServingRuntimes need a container,
   TrustyAIService needs metrics, RayCluster needs a structural head/worker

--- a/tests/integration/upgrades/scenarios/SETUP.md
+++ b/tests/integration/upgrades/scenarios/SETUP.md
@@ -23,6 +23,10 @@ All listed CSVs were `Succeeded` when the fixtures were prepared:
 | Service Mesh operator | `openshift-operators` | `2.6.17`, `stable` |
 | Serverless operator | `openshift-serverless` | `1.37.1`, `stable` |
 
+The Service Mesh v2 Subscription is named `servicemeshoperator` and has
+`spec.name: servicemeshoperator`. The upgrade gate identifies the v2 package
+by that spec field; the shared `stable` channel is not a version discriminator.
+
 The RHOAI 2.25 operator supplied the component operands and CRDs, including
 KServe `v0.14.0`, ModelMesh Serving `v0.12.0`, Kueue `v0.11.6`, KubeRay
 `1.4.0`, CodeFlare `1.15.0`, TrustyAI `v1.37.0`, Kubeflow Pipelines `2.5.0`,
@@ -86,6 +90,7 @@ metadata reconcile if the ConfigMap still contains the old blocker message.
 
 The final run cleared the gates in sequence: KServe and Kueue workload gates
 after removing their fixtures, Kueue dependency after installing its operator,
-CodeFlare and ModelMeshServing after deleting their legacy CRs, Ray and
-TrustyAI after repairing their state, Workbenches after deleting its broken
-Notebook, and DSP after setting the CRD stored version to `v1`.
+Service Mesh after removing its v2 Subscription, CodeFlare and ModelMeshServing
+after deleting their legacy CRs, Ray and TrustyAI after repairing their state,
+Workbenches after deleting its broken Notebook, and DSP after setting the CRD
+stored version to `v1`.

--- a/tests/integration/upgrades/upgrade_gates_dependenceis_test.go
+++ b/tests/integration/upgrades/upgrade_gates_dependenceis_test.go
@@ -76,20 +76,21 @@ func TestUpgradeGatesForCertManagerDependency(t *testing.T) {
 }
 
 func TestUpgradeGatesForServiceMeshOperatorV2Dependency(t *testing.T) {
-	t.Run("blocks_when_subscription_exists_on_blocking_channel", func(t *testing.T) {
+	t.Run("blocks_when_legacy_subscription_package_exists", func(t *testing.T) {
 		h := setupUpgradeGateTest(
 			t,
 			append(
 				certManagerPresentFixtures(),
 				fixture("resources/namespace.tmpl.yaml", map[string]any{
-					"Name":   "istio-system",
+					"Name":   "openshift-operators",
 					"Labels": map[string]string{},
 				}),
 				fixture("resources/subscription.tmpl.yaml", map[string]any{
-					"Name":         "servicemeshoperatorv2",
-					"Namespace":    "istio-system",
+					"Name":         "servicemeshoperator",
+					"Namespace":    "openshift-operators",
+					"Package":      "servicemeshoperator",
 					"Channel":      "stable",
-					"InstalledCSV": "servicemeshoperatorv2.v2.6.0",
+					"InstalledCSV": "servicemeshoperator.v2.6.17",
 				}),
 			)...,
 		)

--- a/tests/integration/upgrades/upgrade_gates_kueue_test.go
+++ b/tests/integration/upgrades/upgrade_gates_kueue_test.go
@@ -16,14 +16,10 @@ import (
 
 func TestUpgradeGatesForKueueOperatorDependency(t *testing.T) {
 	t.Run("blocks_when_managed", func(t *testing.T) {
-		h := setupUpgradeGateTest(
+		h := setupUpgradeGateTestWithComponentStates(
 			t,
-			append(
-				certManagerPresentFixtures(),
-				fixture("resources/kueue/kueue.tmpl.yaml", map[string]any{
-					"ManagementState": "Managed",
-				}),
-			)...,
+			map[string]string{"kueue": "Managed"},
+			certManagerPresentFixtures()...,
 		)
 
 		h.tf.Get(gvk.ConfigMap, upgradeAcksKey).Eventually().Should(
@@ -35,14 +31,10 @@ func TestUpgradeGatesForKueueOperatorDependency(t *testing.T) {
 	})
 
 	t.Run("blocks_when_subscription_missing", func(t *testing.T) {
-		h := setupUpgradeGateTest(
+		h := setupUpgradeGateTestWithComponentStates(
 			t,
-			append(
-				certManagerPresentFixtures(),
-				fixture("resources/kueue/kueue.tmpl.yaml", map[string]any{
-					"ManagementState": "Unmanaged",
-				}),
-			)...,
+			map[string]string{"kueue": "Unmanaged"},
+			certManagerPresentFixtures()...,
 		)
 
 		h.tf.Get(gvk.ConfigMap, upgradeAcksKey).Eventually().Should(
@@ -150,14 +142,11 @@ func setupKueueComponentUpgradeTest(
 ) *upgradeGateHarness {
 	t.Helper()
 
-	return setupUpgradeGateTestWithManagedComponents(
+	return setupUpgradeGateTestWithComponentStates(
 		t,
-		[]string{"kueue"},
+		map[string]string{"kueue": "Unmanaged"},
 		append(
 			certManagerPresentFixtures(),
-			fixture("resources/kueue/kueue.tmpl.yaml", map[string]any{
-				"ManagementState": "Unmanaged",
-			}),
 			fixture("resources/namespace.tmpl.yaml", map[string]any{
 				"Name":   "openshift-kueue-operator",
 				"Labels": map[string]string{},

--- a/tests/integration/upgrades/upgrade_machinery_test.go
+++ b/tests/integration/upgrades/upgrade_machinery_test.go
@@ -100,7 +100,7 @@ func TestUpgradeGatesAutoAckRemovedComponent(t *testing.T) {
 // once every gate is acknowledged.
 //
 // Two non-component dependency gates are forced to block: cert-manager is absent
-// and a servicemeshoperatorv2 subscription sits on a blocking channel. This is
+// and a servicemeshoperator subscription is installed. This is
 // gate-agnostic machinery — the specific gates are just convenient blockers.
 func TestUpgradeGatesMultipleUnacked(t *testing.T) {
 	const (
@@ -109,18 +109,19 @@ func TestUpgradeGatesMultipleUnacked(t *testing.T) {
 	)
 
 	// cert-manager fixtures are intentionally omitted so its gate blocks; a
-	// servicemeshoperatorv2 subscription on a blocking channel blocks the second.
+	// servicemeshoperator package subscription blocks the second.
 	h := setupUpgradeGateTest(
 		t,
 		fixture("resources/namespace.tmpl.yaml", map[string]any{
-			"Name":   "istio-system",
+			"Name":   "openshift-operators",
 			"Labels": map[string]string{},
 		}),
 		fixture("resources/subscription.tmpl.yaml", map[string]any{
-			"Name":         "servicemeshoperatorv2",
-			"Namespace":    "istio-system",
+			"Name":         "servicemeshoperator",
+			"Namespace":    "openshift-operators",
+			"Package":      "servicemeshoperator",
 			"Channel":      "stable",
-			"InstalledCSV": "servicemeshoperatorv2.v2.6.0",
+			"InstalledCSV": "servicemeshoperator.v2.6.17",
 		}),
 	)
 

--- a/tests/integration/upgrades/upgrade_support_test.go
+++ b/tests/integration/upgrades/upgrade_support_test.go
@@ -75,6 +75,21 @@ func setupUpgradeGateTestWithManagedComponents(
 	return setupUpgradeGateTestWithReleases(t, deployedVersion, managedComponents, extraFixtures...)
 }
 
+func setupUpgradeGateTestWithComponentStates(
+	t *testing.T,
+	componentStates map[string]string,
+	extraFixtures ...fixtureSpec,
+) *upgradeGateHarness {
+	t.Helper()
+
+	return setupUpgradeGateTestWithComponentStatesAndReleases(
+		t,
+		deployedVersion,
+		componentStates,
+		extraFixtures...,
+	)
+}
+
 // setupUpgradeGateTestWithReleases is the deployed-release-explicit variant.
 // deployedVer stamps the DSC/DSCI status.release used by
 // cluster.GetDeployedRelease to decide whether gating applies (only 2.x
@@ -84,6 +99,27 @@ func setupUpgradeGateTestWithReleases(
 	t *testing.T,
 	deployedVer string,
 	managedComponents []string,
+	extraFixtures ...fixtureSpec,
+) *upgradeGateHarness {
+	t.Helper()
+
+	componentStates := make(map[string]string, len(managedComponents))
+	for _, component := range managedComponents {
+		componentStates[component] = "Managed"
+	}
+
+	return setupUpgradeGateTestWithComponentStatesAndReleases(
+		t,
+		deployedVer,
+		componentStates,
+		extraFixtures...,
+	)
+}
+
+func setupUpgradeGateTestWithComponentStatesAndReleases(
+	t *testing.T,
+	deployedVer string,
+	componentStates map[string]string,
 	extraFixtures ...fixtureSpec,
 ) *upgradeGateHarness {
 	t.Helper()
@@ -110,7 +146,7 @@ func setupUpgradeGateTestWithReleases(
 	})
 
 	tc := &upgradeGateTestCtx{cli: te.Client()}
-	for _, fixture := range append(baseUpgradeFixtures(deployedVer, managedComponents), extraFixtures...) {
+	for _, fixture := range append(baseUpgradeFixtures(deployedVer, componentStates), extraFixtures...) {
 		tc.applyFixture(t, fixture.path, fixture.data)
 	}
 
@@ -144,7 +180,7 @@ func setupUpgradeGateTestWithReleases(
 	}
 }
 
-func baseUpgradeFixtures(deployedVer string, managedComponents []string) []fixtureSpec {
+func baseUpgradeFixtures(deployedVer string, componentStates map[string]string) []fixtureSpec {
 	return []fixtureSpec{
 		fixture("resources/namespace.tmpl.yaml", map[string]any{
 			"Name":   operatorNamespace,
@@ -156,10 +192,10 @@ func baseUpgradeFixtures(deployedVer string, managedComponents []string) []fixtu
 			"Version":  deployedVer,
 		}),
 		fixture("resources/datasciencecluster.tmpl.yaml", map[string]any{
-			"Name":              "default-dsc",
-			"Platform":          "OpenDataHub",
-			"Version":           deployedVer,
-			"ManagedComponents": managedComponents,
+			"Name":            "default-dsc",
+			"Platform":        "OpenDataHub",
+			"Version":         deployedVer,
+			"ComponentStates": componentStates,
 		}),
 		fixture("resources/clusterserviceversion.tmpl.yaml", map[string]any{
 			"Name":      "opendatahub-operator.v" + targetVersion,


### PR DESCRIPTION
<!---
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

<!-- For RHOAI PRs, request review on #ai-core-platform-requests Slack channel -->

## Release tracking
<!-- Optional. Set a target release only if this PR must ship in a specific release; it will be prioritized accordingly. -->
<!-- Target release for this PR, e.g. rhoai-3.6 or rhoai-3.7ea1 -->
Release: 
<!-- Required only if a Release is set above. Full link to a jira ticket, e.g. https://redhat.atlassian.net/browse/RHOAIENG-XXXXX -->
Jira:


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully
- [ ] New RELATED_IMAGE mappings are listed in ODH-Build-Config and RHOAI-Build-Config (CI validates names against build-config repos). Include links to build-config PRs in the description.

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [ ] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->
