### PR TITLE
fix(rhoai): sync default DSC initialization-resource with sample and guard against drift (RHOAIENG-89419)

### DIFF
--- a/api/datasciencecluster/v2/init_resource_annotation_test.go
+++ b/api/datasciencecluster/v2/init_resource_annotation_test.go
@@ -1,0 +1,74 @@
+package v2_test
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/yaml"
+
+	dscv2 "github.com/opendatahub-io/opendatahub-operator/v2/api/datasciencecluster/v2"
+)
+
+const (
+	rhoaiCSVRelPath = "config/rhoai/manifests/bases/rhods-operator.clusterserviceversion.yaml"
+
+	initResourceAnnotation = "operatorframework.io/initialization-resource"
+)
+
+// repoRoot resolves the repository root regardless of the test binary's
+// working directory, using this file's own location via runtime.Caller. Walks
+// up looking for .git rather than hardcoding a directory depth.
+func repoRoot(t *testing.T) string {
+	t.Helper()
+
+	_, thisFile, _, ok := runtime.Caller(0)
+	require.True(t, ok, "runtime.Caller failed to resolve this test file's path")
+
+	dir := filepath.Dir(thisFile)
+	for {
+		if _, err := os.Stat(filepath.Join(dir, ".git")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		require.NotEqual(t, parent, dir, "no .git found above %s", thisFile)
+		dir = parent
+	}
+}
+
+// TestInitResourceAnnotationIsValidDSC guards the hand-maintained
+// operatorframework.io/initialization-resource annotation on the rhoai CSV
+// against the actual DataScienceCluster API schema. Unlike the drift check
+// against the sample (TestInitResourceAnnotationMatchesSample), this catches a
+// hand-edit -- or an API field rename -- that leaves the annotation (and a
+// matching sample) referencing a field the v2 type no longer has, or gives it
+// the wrong type: OLM would then fail to parse the initialization-resource.
+// Strict decoding rejects unknown fields, so a typo'd component key ("dashbaord")
+// fails here even when the drift check passes.
+func TestInitResourceAnnotationIsValidDSC(t *testing.T) {
+	root := repoRoot(t)
+
+	csvBytes, err := os.ReadFile(filepath.Join(root, rhoaiCSVRelPath))
+	require.NoError(t, err, "reading %s", rhoaiCSVRelPath)
+
+	var csv struct {
+		Metadata struct {
+			Annotations map[string]string `json:"annotations"`
+		} `json:"metadata"`
+	}
+	require.NoError(t, yaml.Unmarshal(csvBytes, &csv), "parsing %s", rhoaiCSVRelPath)
+
+	annotation := csv.Metadata.Annotations[initResourceAnnotation]
+	require.NotEmpty(t, annotation, "%s annotation missing from %s", initResourceAnnotation, rhoaiCSVRelPath)
+
+	var dsc dscv2.DataScienceCluster
+	require.NoError(t, yaml.UnmarshalStrict([]byte(annotation), &dsc),
+		"the %s annotation must deserialize into a v2 DataScienceCluster with no unknown fields; "+
+			"a field may be misspelled or renamed in the API (RHOAIENG-89419)", initResourceAnnotation)
+
+	require.Equal(t, "DataScienceCluster", dsc.Kind, "annotation kind")
+	require.Equal(t, "datasciencecluster.opendatahub.io/v2", dsc.APIVersion, "annotation apiVersion")
+	require.Equal(t, "default-dsc", dsc.Name, "annotation metadata.name")
+}

--- a/cmd/manifest-tools/go.mod
+++ b/cmd/manifest-tools/go.mod
@@ -12,6 +12,7 @@ require (
 	k8s.io/api v0.36.3
 	k8s.io/apimachinery v0.36.3
 	k8s.io/client-go v0.36.3
+	sigs.k8s.io/yaml v1.6.0
 )
 
 replace github.com/opendatahub-io/opendatahub-operator/pkg/scoperules => ../../pkg/scoperules
@@ -60,5 +61,4 @@ require (
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v6 v6.3.3 // indirect
-	sigs.k8s.io/yaml v1.6.0 // indirect
 )

--- a/cmd/manifest-tools/pkg/config/init_resource_sync_test.go
+++ b/cmd/manifest-tools/pkg/config/init_resource_sync_test.go
@@ -1,0 +1,62 @@
+package config_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/yaml"
+)
+
+const (
+	rhoaiCSVRelPath       = "config/rhoai/manifests/bases/rhods-operator.clusterserviceversion.yaml"
+	rhoaiDSCSampleRelPath = "config/rhoai/samples/datasciencecluster_v2_datasciencecluster.yaml"
+
+	initResourceAnnotation = "operatorframework.io/initialization-resource"
+)
+
+// TestInitResourceAnnotationMatchesSample guards against the RHOAIENG-89419
+// regression. The hand-maintained operatorframework.io/initialization-resource
+// annotation on the rhoai CSV drives the OLM "DataScienceCluster required"
+// prompt, while the "Provided APIs" tab is driven by alm-examples, which is
+// auto-generated from the DSC sample. The sample is the source of truth; the
+// annotation must present the same default DataScienceCluster. Nothing
+// regenerates the annotation, so when the two drift users see a different
+// default DSC depending on how they create it -- only this test catches it.
+func TestInitResourceAnnotationMatchesSample(t *testing.T) {
+	root := repoRoot(t)
+
+	csvBytes, err := os.ReadFile(filepath.Join(root, rhoaiCSVRelPath))
+	require.NoError(t, err, "reading %s", rhoaiCSVRelPath)
+
+	var csv struct {
+		Metadata struct {
+			Annotations map[string]string `json:"annotations"`
+		} `json:"metadata"`
+	}
+	require.NoError(t, yaml.Unmarshal(csvBytes, &csv), "parsing %s", rhoaiCSVRelPath)
+
+	annotation := csv.Metadata.Annotations[initResourceAnnotation]
+	require.NotEmpty(t, annotation, "%s annotation missing from %s", initResourceAnnotation, rhoaiCSVRelPath)
+
+	// The annotation value is a JSON DataScienceCluster. sigs.k8s.io/yaml
+	// parses JSON (a subset of YAML) and the sample YAML through the same
+	// JSON codec, so both decode to identically typed maps -- a deep compare
+	// then flags any drift, including future numeric or boolean fields.
+	var annotationDSC map[string]any
+	require.NoError(t, yaml.Unmarshal([]byte(annotation), &annotationDSC),
+		"parsing the %s annotation as a DataScienceCluster", initResourceAnnotation)
+
+	sampleBytes, err := os.ReadFile(filepath.Join(root, rhoaiDSCSampleRelPath))
+	require.NoError(t, err, "reading %s", rhoaiDSCSampleRelPath)
+
+	var sampleDSC map[string]any
+	require.NoError(t, yaml.Unmarshal(sampleBytes, &sampleDSC), "parsing %s", rhoaiDSCSampleRelPath)
+
+	require.Equal(t, sampleDSC, annotationDSC,
+		"the %s annotation in %s has drifted from %s; re-sync the annotation with the sample "+
+			"(the source of truth) so the OLM 'DataScienceCluster required' prompt and the "+
+			"'Provided APIs' tab present the same default DSC (RHOAIENG-89419)",
+		initResourceAnnotation, rhoaiCSVRelPath, rhoaiDSCSampleRelPath)
+}

--- a/config/rhoai/manifests/bases/rhods-operator.clusterserviceversion.yaml
+++ b/config/rhoai/manifests/bases/rhods-operator.clusterserviceversion.yaml
@@ -49,9 +49,6 @@ metadata:
               "nim": {
                 "managementState": "Managed"
               },
-              "modelsAsService": {
-                "managementState": "Removed"
-              },
               "wva": {
                 "managementState": "Removed"
               }
@@ -80,9 +77,6 @@ metadata:
             },
             "feastoperator": {
               "managementState": "Managed"
-            },
-            "llamastackoperator": {
-              "managementState": "Removed"
             },
             "ogx": {
               "managementState": "Managed"

--- a/config/rhoai/manifests/bases/rhods-operator.clusterserviceversion.yaml
+++ b/config/rhoai/manifests/bases/rhods-operator.clusterserviceversion.yaml
@@ -32,16 +32,53 @@ metadata:
         },
         "spec": {
           "components": {
+            "aigateway": {
+              "managementState": "Removed",
+              "batchGateway": {
+                "managementState": "Removed"
+              }
+            },
             "dashboard": {
               "managementState": "Managed"
             },
             "aipipelines": {
               "managementState": "Managed"
             },
-            "feastoperator": {
+            "kserve": {
+              "managementState": "Managed",
+              "nim": {
+                "managementState": "Managed"
+              },
+              "modelsAsService": {
+                "managementState": "Removed"
+              },
+              "wva": {
+                "managementState": "Removed"
+              }
+            },
+            "kueue": {
+              "managementState": "Removed"
+            },
+            "trainer": {
               "managementState": "Managed"
             },
-            "kserve": {
+            "ray": {
+              "managementState": "Managed"
+            },
+            "workbenches": {
+              "managementState": "Managed",
+              "workbenchesV2": {
+                "managementState": "Removed"
+              }
+            },
+            "trustyai": {
+              "managementState": "Managed"
+            },
+            "modelregistry": {
+              "managementState": "Managed",
+              "registriesNamespace": "rhoai-model-registries"
+            },
+            "feastoperator": {
               "managementState": "Managed"
             },
             "llamastackoperator": {
@@ -50,30 +87,14 @@ metadata:
             "ogx": {
               "managementState": "Managed"
             },
-            "kueue": {
-              "managementState": "Removed"
-            },
             "mlflowoperator": {
               "managementState": "Managed"
             },
             "sparkoperator": {
               "managementState": "Removed"
             },
-            "modelregistry": {
-              "managementState": "Managed",
-              "registriesNamespace": "rhoai-model-registries"
-            },
-            "ray": {
-              "managementState": "Managed"
-            },
-            "workbenches": {
-              "managementState": "Managed"
-            },
-            "trainer": {
-              "managementState": "Managed"
-            },
-            "trustyai": {
-              "managementState": "Managed"
+            "mcplifecycleoperator": {
+              "managementState": "Removed"
             }
           }
         }

--- a/config/rhoai/samples/datasciencecluster_v2_datasciencecluster.yaml
+++ b/config/rhoai/samples/datasciencecluster_v2_datasciencecluster.yaml
@@ -18,8 +18,6 @@ spec:
       managementState: "Managed"
       nim:
         managementState: "Managed"
-      modelsAsService:
-        managementState: "Removed"
       wva:
         managementState: "Removed"
     kueue:
@@ -39,8 +37,6 @@ spec:
       registriesNamespace: "rhoai-model-registries"
     feastoperator:
       managementState: "Managed"
-    llamastackoperator:
-      managementState: "Removed"
     ogx:
       managementState: "Managed"
     mlflowoperator:

--- a/internal/webhook/datasciencecluster/v2/init_resource_integration_test.go
+++ b/internal/webhook/datasciencecluster/v2/init_resource_integration_test.go
@@ -20,12 +20,17 @@ import (
 
 const dscSampleRelPath = "config/rhoai/samples/datasciencecluster_v2_datasciencecluster.yaml"
 
-// componentStates extracts the top-level managementState of every component in a
-// DataScienceCluster v2 Components tree. These fields come from common.ManagementSpec,
+// componentStates extracts the top-level managementState of every supported component
+// in a DataScienceCluster v2 Components tree. These fields come from common.ManagementSpec,
 // which -- unlike nested fields such as kserve.nim -- carries NO +kubebuilder:default,
 // so an unset one round-trips as "" (not Managed/Removed). Comparing this map before
 // and after an API-server round-trip proves the shipped default DSC specifies every
-// component explicitly.
+// supported component explicitly.
+//
+// Deprecated components are intentionally excluded: the shipped default must not present
+// them to users (RHOAIENG-89419). llamastackoperator (renamed to ogx) is dropped from the
+// default entirely; kserve.modelsAsService (migrated to aigateway.modelsAsAService) is a
+// nested field and is asserted absent from the sample separately. See TestDefaultDSCFromSampleAdmittedByAPIServer.
 func componentStates(c dscv2.Components) map[string]operatorv1.ManagementState {
 	return map[string]operatorv1.ManagementState{
 		"aigateway":            c.AIGateway.ManagementState,
@@ -39,7 +44,6 @@ func componentStates(c dscv2.Components) map[string]operatorv1.ManagementState {
 		"trustyai":             c.TrustyAI.ManagementState,
 		"modelregistry":        c.ModelRegistry.ManagementState,
 		"feastoperator":        c.FeastOperator.ManagementState,
-		"llamastackoperator":   c.LlamaStackOperator.ManagementState,
 		"ogx":                  c.OGX.ManagementState,
 		"mlflowoperator":       c.MLflowOperator.ManagementState,
 		"sparkoperator":        c.SparkOperator.ManagementState,
@@ -63,7 +67,10 @@ func componentStates(c dscv2.Components) map[string]operatorv1.ManagementState {
 //  2. every top-level component managementState round-trips unchanged and non-empty
 //     (a complete default, since these fields have no schema default);
 //  3. the defaulting webhook is a no-op on the already-complete sample (it neither
-//     overwrites the explicit ModelRegistry.RegistriesNamespace nor changes Kserve.NIM).
+//     overwrites the explicit ModelRegistry.RegistriesNamespace nor changes Kserve.NIM);
+//  4. deprecated components are absent from the shipped default, so users are never
+//     presented with a config they must remediate (RHOAIENG-89419): llamastackoperator
+//     (renamed to ogx) and kserve.modelsAsService (migrated to aigateway.modelsAsAService).
 //
 // A two-path (annotation vs sample) comparison would be redundant: U1 proves the two
 // inputs are identical and API-server defaulting is deterministic, so testing one path
@@ -94,6 +101,17 @@ func TestDefaultDSCFromSampleAdmittedByAPIServer(t *testing.T) {
 
 	dsc := &dscv2.DataScienceCluster{}
 	g.Expect(yaml.Unmarshal(sampleBytes, dsc)).To(Succeed(), "decoding %s into a v2 DataScienceCluster", dscSampleRelPath)
+
+	// (4) Deprecated components must not appear in the shipped default. Checked on the raw
+	// decoded sample (before API-server defaulting), since kserve.modelsAsService carries a
+	// +kubebuilder:default that the server would otherwise re-populate. The sample feeds
+	// alm-examples and -- per U1 -- is textually identical to the initialization-resource
+	// annotation, so this guards both OLM install paths against re-introducing deprecated
+	// items into the default users are presented with (RHOAIENG-89419).
+	g.Expect(dsc.Spec.Components.LlamaStackOperator.ManagementState).To(BeEmpty(),
+		"llamastackoperator is deprecated (renamed to ogx) and must not be set in the shipped default DSC")
+	g.Expect(dsc.Spec.Components.Kserve.ModelsAsService.ManagementState).To(BeEmpty(), //nolint:staticcheck // asserting the deprecated field is intentionally unset
+		"kserve.modelsAsService is deprecated (migrated to aigateway.modelsAsAService) and must not be set in the shipped default DSC")
 
 	// Capture the intended states before create -- controller-runtime's Create writes the
 	// server response (including defaults) back into dsc, so read expectations first.

--- a/internal/webhook/datasciencecluster/v2/init_resource_integration_test.go
+++ b/internal/webhook/datasciencecluster/v2/init_resource_integration_test.go
@@ -1,0 +1,130 @@
+package v2_test
+
+import (
+	"testing"
+
+	operatorv1 "github.com/openshift/api/operator/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/yaml"
+
+	dscv2 "github.com/opendatahub-io/opendatahub-operator/v2/api/datasciencecluster/v2"
+	v1webhook "github.com/opendatahub-io/opendatahub-operator/v2/internal/webhook/datasciencecluster/v1"
+	v2webhook "github.com/opendatahub-io/opendatahub-operator/v2/internal/webhook/datasciencecluster/v2"
+	dsciv1webhook "github.com/opendatahub-io/opendatahub-operator/v2/internal/webhook/dscinitialization/v1"
+	dsciv2webhook "github.com/opendatahub-io/opendatahub-operator/v2/internal/webhook/dscinitialization/v2"
+	"github.com/opendatahub-io/opendatahub-operator/v2/internal/webhook/envtestutil"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/envt"
+
+	. "github.com/onsi/gomega"
+)
+
+const dscSampleRelPath = "config/rhoai/samples/datasciencecluster_v2_datasciencecluster.yaml"
+
+// componentStates extracts the top-level managementState of every component in a
+// DataScienceCluster v2 Components tree. These fields come from common.ManagementSpec,
+// which -- unlike nested fields such as kserve.nim -- carries NO +kubebuilder:default,
+// so an unset one round-trips as "" (not Managed/Removed). Comparing this map before
+// and after an API-server round-trip proves the shipped default DSC specifies every
+// component explicitly.
+func componentStates(c dscv2.Components) map[string]operatorv1.ManagementState {
+	return map[string]operatorv1.ManagementState{
+		"aigateway":            c.AIGateway.ManagementState,
+		"dashboard":            c.Dashboard.ManagementState,
+		"aipipelines":          c.AIPipelines.ManagementState,
+		"kserve":               c.Kserve.ManagementState,
+		"kueue":                c.Kueue.ManagementState,
+		"trainer":              c.Trainer.ManagementState,
+		"ray":                  c.Ray.ManagementState,
+		"workbenches":          c.Workbenches.ManagementState,
+		"trustyai":             c.TrustyAI.ManagementState,
+		"modelregistry":        c.ModelRegistry.ManagementState,
+		"feastoperator":        c.FeastOperator.ManagementState,
+		"llamastackoperator":   c.LlamaStackOperator.ManagementState,
+		"ogx":                  c.OGX.ManagementState,
+		"mlflowoperator":       c.MLflowOperator.ManagementState,
+		"sparkoperator":        c.SparkOperator.ManagementState,
+		"mcplifecycleoperator": c.MCPLifecycleOperator.ManagementState,
+	}
+}
+
+// TestDefaultDSCFromSampleAdmittedByAPIServer is the RHOAIENG-89419 integration guard (I1).
+//
+// U1 (cmd/manifest-tools .../init_resource_sync_test.go) proves the CSV
+// initialization-resource annotation is textually identical to this sample, and U2
+// proves the annotation decodes into the v2 API type. Neither runs the object through a
+// real API server, so neither proves the shipped default DSC is actually *admissible*:
+// that it survives CRD structural + CEL validation and the validating/defaulting webhooks
+// a user's create request hits -- via either OLM path ("DataScienceCluster required"
+// prompt from the annotation, or the "Provided APIs" tab from alm-examples/the sample).
+//
+// This test decodes the shipped sample and creates it on an envtest API server with the
+// DSC v2 webhooks registered, asserting:
+//  1. Create succeeds (admissibility);
+//  2. every top-level component managementState round-trips unchanged and non-empty
+//     (a complete default, since these fields have no schema default);
+//  3. the defaulting webhook is a no-op on the already-complete sample (it neither
+//     overwrites the explicit ModelRegistry.RegistriesNamespace nor changes Kserve.NIM).
+//
+// A two-path (annotation vs sample) comparison would be redundant: U1 proves the two
+// inputs are identical and API-server defaulting is deterministic, so testing one path
+// covers both.
+func TestDefaultDSCFromSampleAdmittedByAPIServer(t *testing.T) {
+	t.Parallel()
+
+	g := NewWithT(t)
+
+	ctx, env, teardown := envtestutil.SetupEnvAndClient(
+		t,
+		[]envt.RegisterWebhooksFn{
+			v1webhook.RegisterWebhooks,
+			dsciv1webhook.RegisterWebhooks,
+			v2webhook.RegisterWebhooks,
+			dsciv2webhook.RegisterWebhooks,
+		},
+		[]envt.RegisterControllersFn{},
+		envtestutil.DefaultWebhookTimeout,
+	)
+	t.Cleanup(teardown)
+
+	// A DSCI is the established precondition for DSC tests in this package.
+	createDSCI(g, ctx, env.Client())
+
+	sampleBytes, err := env.ReadFile(dscSampleRelPath)
+	g.Expect(err).NotTo(HaveOccurred(), "reading %s", dscSampleRelPath)
+
+	dsc := &dscv2.DataScienceCluster{}
+	g.Expect(yaml.Unmarshal(sampleBytes, dsc)).To(Succeed(), "decoding %s into a v2 DataScienceCluster", dscSampleRelPath)
+
+	// Capture the intended states before create -- controller-runtime's Create writes the
+	// server response (including defaults) back into dsc, so read expectations first.
+	expectedStates := componentStates(dsc.Spec.Components)
+	expectedRegistriesNamespace := dsc.Spec.Components.ModelRegistry.RegistriesNamespace
+
+	// (1) Admissibility: the shipped default DSC must be accepted by the live API server.
+	g.Expect(env.Client().Create(ctx, dsc)).To(Succeed(),
+		"the shipped default DSC (%s) must be admissible: it must pass CRD structural + CEL "+
+			"validation and the validating webhook, since OLM creates exactly this object "+
+			"from the initialization-resource annotation (RHOAIENG-89419)", dscSampleRelPath)
+
+	fetched := &dscv2.DataScienceCluster{}
+	g.Eventually(func() error {
+		return env.Client().Get(ctx, client.ObjectKey{Name: dsc.Name}, fetched)
+	}, "10s", "1s").Should(Succeed(), "the created default DSC should be retrievable")
+
+	// (2) Every top-level component managementState round-trips unchanged and non-empty.
+	fetchedStates := componentStates(fetched.Spec.Components)
+	for component, want := range expectedStates {
+		g.Expect(want).NotTo(BeEmpty(),
+			"the shipped default DSC leaves component %q with an empty managementState; top-level "+
+				"managementState has no schema default, so users would get an incomplete default DSC "+
+				"(RHOAIENG-89419)", component)
+		g.Expect(fetchedStates[component]).To(Equal(want),
+			"component %q managementState changed across the API-server round-trip", component)
+	}
+
+	// (3) The defaulting webhook must not disturb the already-complete sample.
+	g.Expect(fetched.Spec.Components.ModelRegistry.RegistriesNamespace).To(Equal(expectedRegistriesNamespace),
+		"defaulting must preserve the explicit ModelRegistry.RegistriesNamespace from the sample")
+	g.Expect(fetched.Spec.Components.Kserve.NIM.ManagementState).To(Equal(operatorv1.Managed),
+		"Kserve.NIM should remain Managed (the sample sets it, and the webhook only defaults it when empty)")
+}


### PR DESCRIPTION
## Description

RHOAIENG-89419 is a customer-reported "Inconsistent Default DSC" bug. The default DataScienceCluster created at install time differed depending on the OLM install path, because the hand-maintained `operatorframework.io/initialization-resource` CSV annotation — which drives OLM's "DataScienceCluster required" install prompt — had drifted from the auto-generated `alm-examples` / DSC sample, which drives the "Provided APIs" tab and is regenerated from the sample.

This PR re-syncs the annotation to the shipped sample, removes deprecated components from the default per reporter guidance, and adds regression + integration guards so the two representations cannot silently diverge again.

## Changes

- **Fix — re-sync** (`config/rhoai/manifests/bases/rhods-operator.clusterserviceversion.yaml`): align the `operatorframework.io/initialization-resource` annotation with the rhoai DSC sample so both OLM install paths produce the same default DSC.
- **Fix — drop deprecated components** (sample YAML + annotation): per the reporter's guidance, the default DSC should not present deprecated options that users would have to remediate. Remove `llamastackoperator` (renamed to OGX) and `kserve.modelsAsService` (migrated to `aigateway.modelsAsAService`) from both sources of truth, matching how the deprecated Training Operator v1 is already omitted. Supported-but-disabled components (e.g. spark, kueue) intentionally remain as `Removed` so users can see they exist and can be enabled.
- **U1 — drift guard** (`cmd/manifest-tools/pkg/config/init_resource_sync_test.go`): deep-compares the annotation (JSON) against the DSC sample (YAML), failing on any divergence. Promotes `sigs.k8s.io/yaml` to a direct dependency in `cmd/manifest-tools/go.mod`.
- **U2 — schema-validity guard** (`api/datasciencecluster/v2/init_resource_annotation_test.go`): strict-decodes the annotation into the v2 `DataScienceCluster` type, catching a renamed/misspelled/unknown field a plain drift check would miss.
- **I1 — envtest admissibility guard** (`internal/webhook/datasciencecluster/v2/init_resource_integration_test.go`): creates the shipped sample through a live API server + DSC v2 webhooks, asserting it is admissible, that every supported top-level component managementState round-trips non-empty (no schema default exists), that defaulting is a no-op on the complete sample, and that the deprecated components stay absent from the shipped default.

## How Has This Been Tested?

- `make lint` — clean (0 issues).
- U1, U2, and I1 all pass (I1 verified on envtest with `KUBEBUILDER_ASSETS` set).
- Note: two unrelated, pre-existing failures were observed while running the full `make unit-test` suite and are NOT introduced by this PR — a chart-compliance test that requires `make get-manifests` first, and a `dscinitialization`/observability-module failure filed separately as RHOAIENG-90794.

## Jira

https://redhat.atlassian.net/browse/RHOAIENG-89419

### E2E test suite update requirement

To opt-out of this requirement:
1. Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md), to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification

The only non-test changes are a re-sync of the `operatorframework.io/initialization-resource` CSV annotation with the shipped DSC sample and removal of two deprecated entries from both, plus promoting `sigs.k8s.io/yaml` to a direct dependency in `cmd/manifest-tools/go.mod`. This annotation is OLM install-time metadata that drives OLM's "DataScienceCluster required" install prompt; it is not consumed by the operator's reconciliation logic. The E2E suite runs against an already-deployed operator and does not exercise the OLM install-prompt path, so it cannot meaningfully cover this change.

The fix is instead guarded at the levels that can test it, all added in this PR:
- U1 (manifest-tools unit test): fails if the annotation drifts from the DSC sample.
- U2 (api unit test): strict-decodes the annotation into the v2 DataScienceCluster type.
- I1 (webhook envtest): admits the exact shipped sample through a live API server + DSC v2 webhooks, asserting admissibility, that all supported component managementStates round-trip, and that deprecated components stay out of the default.

Remaining changes are unit/integration test additions and a no-functional-impact dependency promotion, both of which fall under the opt-out guidelines.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration Changes**
  * Updated DataScienceCluster initialization settings to manage KServe NIM, Trainer, Ray, Feast Operator, and MLflow Operator components.
  * Removed initialization settings for AI Gateway, Batch Gateway, KServe WVA, Workbenches V2, Spark Operator, MCP Lifecycle Operator, Models as a Service, and Llama Stack Operator.
* **Bug Fixes**
  * Added validation to ensure shipped initialization configuration remains consistent with the DataScienceCluster sample and API schema.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->