### PR TITLE
RHOAIENG-72279 - Fix TestOdhOperator/DAG_Ordering_E2E_Tests

### DIFF
--- a/tests/e2e/dag_ordering_test.go
+++ b/tests/e2e/dag_ordering_test.go
@@ -606,16 +606,7 @@ func (tc *DAGOrderingTestCtx) ValidateDAGCleanup(t *testing.T) {
 	tc.setAllRemoved(t)
 
 	t.Log("Verifying all component CRs are cleaned up (no orphans)")
-	for _, batch := range dagBatches {
-		for _, comp := range batch.components {
-			instanceName := tc.GetInstanceName(comp.gvk)
-			tc.EnsureResourceGone(
-				WithMinimalObject(comp.gvk, types.NamespacedName{Name: instanceName}),
-				WithEventuallyTimeout(5*time.Minute),
-				WithEventuallyPollingInterval(10*time.Second),
-			)
-		}
-	}
+	tc.ensureAllRemovedComponentsGone(t)
 }
 
 // ValidatePartialEnablement enables a subset of components spanning
@@ -984,8 +975,33 @@ func (tc *DAGOrderingTestCtx) setAllRemoved(t *testing.T) {
 		WithEventuallyPollingInterval(15*time.Second),
 	)
 
+	tc.ensureAllRemovedComponentsGone(t)
+}
+
+// ensureAllRemovedComponentsGone verifies that every componentEntry actually
+// driven to Removed has its CR deleted. Monitoring is removed via the DSCI
+// (setDSCIMonitoringState), not the DSC spec.components fields below, so it
+// is checked explicitly by name. Components absent from both DSC field lists
+// (e.g. Kueue, whose webhook blocks managementState=Managed) are never set
+// to Removed and are skipped rather than asserted gone.
+func (tc *DAGOrderingTestCtx) ensureAllRemovedComponentsGone(t *testing.T) {
+	t.Helper()
+
 	for _, batch := range dagBatches {
 		for _, comp := range batch.components {
+			name := comp.name
+			if name == dataSciencePipelinesComponentName {
+				name = aiPipelinesFieldName
+			}
+
+			removed := name == serviceApi.MonitoringServiceName ||
+				slices.Contains(dscComponentFieldsWithBrokenVersionHandshake, name) ||
+				slices.Contains(dscComponentFields, name)
+			if !removed {
+				t.Logf("Skipping gone-check for %s: not meant to be Removed", comp.name)
+				continue
+			}
+
 			instanceName := tc.GetInstanceName(comp.gvk)
 			tc.EnsureResourceGone(
 				WithMinimalObject(comp.gvk, types.NamespacedName{Name: instanceName}),


### PR DESCRIPTION
Fixes a false-positive timeout in `TestOdhOperator/DAG_Ordering_E2E_Tests` (RHOAIENG-72279) where `setAllRemoved()`/`ValidateDAGCleanup` would wait up to 5 minutes for the `default-kueue` CR to disappear and then fail — even though the test never actually asks the operator to remove Kueue.

Kueue is intentionally excluded from `dscComponentFields`/`dscComponentFieldsWithBrokenVersionHandshake` (a validating webhook rejects `managementState=Managed` for it), so the "set everything to Removed" DSC patch never touches its field. The gone-check loop, however, still asserted every component in `dagBatches` — including Kueue — must have its CR deleted, which can never succeed.

## Change

- Extracted the duplicated "assert component CRs are gone" loop (present in both `setAllRemoved` and `ValidateDAGCleanup`) into a single helper, `ensureAllRemovedComponentsGone`.
- The helper only asserts a component's CR is gone if that component was actually driven to `Removed`: Monitoring (removed via DSCI, not `spec.components`) is matched explicitly, DataSciencePipelines is normalized to its `aipipelines` DSC field key, and the rest are checked against `dscComponentFields`/`dscComponentFieldsWithBrokenVersionHandshake`.
- Components absent from those lists (Kueue today) are skipped with a `t.Logf`, instead of being asserted gone.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end cleanup validation for components removed through different configuration paths.
  * Added coverage for components that are intentionally not marked as removed, Monitoring cleanup, and Data Science Pipelines naming differences.
  * Reduced false failures when verifying that removed component resources are no longer present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->