### PR TITLE
add version aware gating

### DIFF
--- a/internal/controller/datasciencecluster/datasciencecluster_controller_actions.go
+++ b/internal/controller/datasciencecluster/datasciencecluster_controller_actions.go
@@ -219,11 +219,11 @@ func updateStatus(ctx context.Context, rr *odhtype.ReconciliationRequest) error 
 	if err != nil {
 		return err
 	}
-	versions, err := provision.ResolveUpgradeGateVersions(ctx, rr.Client, ns, instance.Status.Release, rr.Release)
+	targetVersion, err := provision.ResolveUpgradeGateVersion(ctx, rr.Client, ns, instance.Status.Release, rr.Release)
 	if err != nil {
-		return fmt.Errorf("failed to resolve upgrade gate versions: %w", err)
+		return fmt.Errorf("failed to resolve upgrade gate version: %w", err)
 	}
-	cleared, err := gates.AllGatesAcknowledged(ctx, rr.Client, ns, versions)
+	cleared, err := gates.AllGatesAcknowledged(ctx, rr.Client, ns, targetVersion)
 	if err != nil {
 		return fmt.Errorf("failed to check upgrade gates: %w", err)
 	}

--- a/internal/controller/datasciencecluster/datasciencecluster_controller_actions.go
+++ b/internal/controller/datasciencecluster/datasciencecluster_controller_actions.go
@@ -219,7 +219,11 @@ func updateStatus(ctx context.Context, rr *odhtype.ReconciliationRequest) error 
 	if err != nil {
 		return err
 	}
-	cleared, err := gates.AllGatesAcknowledged(ctx, rr.Client, ns)
+	versions, err := provision.ResolveUpgradeGateVersions(ctx, rr.Client, ns, instance.Status.Release, rr.Release)
+	if err != nil {
+		return fmt.Errorf("failed to resolve upgrade gate versions: %w", err)
+	}
+	cleared, err := gates.AllGatesAcknowledged(ctx, rr.Client, ns, versions)
 	if err != nil {
 		return fmt.Errorf("failed to check upgrade gates: %w", err)
 	}

--- a/internal/controller/dscinitialization/dscinitialization_controller.go
+++ b/internal/controller/dscinitialization/dscinitialization_controller.go
@@ -51,6 +51,7 @@ import (
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/gates"
 	rp "github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/predicates/resources"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/provision"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/deploy"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/logger"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/operatorconfig"
@@ -166,7 +167,12 @@ func (r *DSCInitializationReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		if nsErr != nil {
 			return reconcile.Result{}, nsErr
 		}
-		cleared, gateErr := gates.AllGatesAcknowledged(ctx, r.Client, ns)
+		versions, gateErr := provision.ResolveUpgradeGateVersions(ctx, r.Client, ns, instance.Status.Release, currentOperatorRelease)
+		if gateErr != nil {
+			log.Error(gateErr, "Failed to resolve upgrade gate versions")
+			return reconcile.Result{}, gateErr
+		}
+		cleared, gateErr := gates.AllGatesAcknowledged(ctx, r.Client, ns, versions)
 		if gateErr != nil {
 			log.Error(gateErr, "Failed to check upgrade gates")
 			return reconcile.Result{}, gateErr

--- a/internal/controller/dscinitialization/dscinitialization_controller.go
+++ b/internal/controller/dscinitialization/dscinitialization_controller.go
@@ -167,12 +167,12 @@ func (r *DSCInitializationReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		if nsErr != nil {
 			return reconcile.Result{}, nsErr
 		}
-		versions, gateErr := provision.ResolveUpgradeGateVersions(ctx, r.Client, ns, instance.Status.Release, currentOperatorRelease)
+		targetVersion, gateErr := provision.ResolveUpgradeGateVersion(ctx, r.Client, ns, instance.Status.Release, currentOperatorRelease)
 		if gateErr != nil {
-			log.Error(gateErr, "Failed to resolve upgrade gate versions")
+			log.Error(gateErr, "Failed to resolve upgrade gate version")
 			return reconcile.Result{}, gateErr
 		}
-		cleared, gateErr := gates.AllGatesAcknowledged(ctx, r.Client, ns, versions)
+		cleared, gateErr := gates.AllGatesAcknowledged(ctx, r.Client, ns, targetVersion)
 		if gateErr != nil {
 			log.Error(gateErr, "Failed to check upgrade gates")
 			return reconcile.Result{}, gateErr

--- a/pkg/controller/gates/gates.go
+++ b/pkg/controller/gates/gates.go
@@ -243,12 +243,12 @@ func parseGateTarget(value string) (versionCore, bool) {
 }
 
 // AllGatesAcknowledged returns true when the odh-upgrade-acks
-// ConfigMap exists and every gate entry matching one of the target versions is
-// set to "true". Entries for other versions are ignored. Returns false when
-// the ConfigMap does not exist (the modules controller has not yet evaluated
-// gates) or when an applicable entry remains unacknowledged. An empty or
-// out-of-scope ConfigMap is considered fully acknowledged.
-func AllGatesAcknowledged(ctx context.Context, cli client.Client, namespace string, versions []string) (bool, error) {
+// ConfigMap exists and every gate entry matching the target version is set to
+// "true". Entries for other versions are ignored. Returns false when the
+// ConfigMap does not exist (the modules controller has not yet evaluated gates)
+// or when an applicable entry remains unacknowledged. An empty or out-of-scope
+// ConfigMap is considered fully acknowledged.
+func AllGatesAcknowledged(ctx context.Context, cli client.Client, namespace string, targetVersion string) (bool, error) {
 	cm := &corev1.ConfigMap{}
 	if err := cli.Get(ctx, client.ObjectKey{Name: AcksConfigMap, Namespace: namespace}, cm); err != nil {
 		if k8serr.IsNotFound(err) {
@@ -258,7 +258,7 @@ func AllGatesAcknowledged(ctx context.Context, cli client.Client, namespace stri
 	}
 
 	for key, val := range cm.Data {
-		if !matchesAnyVersion(key, versions) {
+		if _, matches := MatchGateKey(key, targetVersion); !matches {
 			continue
 		}
 		if val != "true" {
@@ -267,15 +267,6 @@ func AllGatesAcknowledged(ctx context.Context, cli client.Client, namespace stri
 	}
 
 	return true, nil
-}
-
-func matchesAnyVersion(key string, versions []string) bool {
-	for _, version := range versions {
-		if _, matches := MatchGateKey(key, version); matches {
-			return true
-		}
-	}
-	return false
 }
 
 // DiscoverGates lists ConfigMaps in the operator namespace that carry

--- a/pkg/controller/gates/gates.go
+++ b/pkg/controller/gates/gates.go
@@ -8,7 +8,9 @@ import (
 	"fmt"
 	"io"
 	"sort"
+	"strings"
 
+	"github.com/blang/semver/v4"
 	corev1 "k8s.io/api/core/v1"
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -171,12 +173,82 @@ func LoadInTreeGates() (map[string]string, error) {
 	return result, nil
 }
 
+// MatchGateKey reports whether key applies to version and returns the gate
+// name following the version scope. Supported key formats are:
+//
+//   - ack-<major>.<minor>-<gate-name>
+//   - ack-<major>.<minor>.<patch>-<gate-name>
+//
+// Minor-scoped gates apply to every patch in that minor release. Exact gates
+// apply only to the specified patch. Prerelease and build metadata in version
+// do not affect matching.
+func MatchGateKey(key string, version string) (string, bool) {
+	const prefix = "ack-"
+
+	if !strings.HasPrefix(key, prefix) {
+		return "", false
+	}
+
+	current, err := semver.Parse(version)
+	if err != nil {
+		return "", false
+	}
+
+	remainder := strings.TrimPrefix(key, prefix)
+	separator := strings.IndexByte(remainder, '-')
+	if separator <= 0 || separator == len(remainder)-1 {
+		return "", false
+	}
+
+	target, ok := parseGateTarget(remainder[:separator])
+	if !ok || target.major != current.Major || target.minor != current.Minor {
+		return "", false
+	}
+	if target.hasPatch && target.patch != current.Patch {
+		return "", false
+	}
+
+	return remainder[separator+1:], true
+}
+
+type versionCore struct {
+	major    uint64
+	minor    uint64
+	patch    uint64
+	hasPatch bool
+}
+
+func parseGateTarget(value string) (versionCore, bool) {
+	parts := strings.Split(value, ".")
+	if len(parts) != 2 && len(parts) != 3 {
+		return versionCore{}, false
+	}
+
+	result := versionCore{hasPatch: len(parts) == 3}
+	normalized := value
+	if len(parts) == 2 {
+		normalized += ".0"
+	}
+
+	parsed, err := semver.Parse(normalized)
+	if err != nil || len(parsed.Pre) > 0 || len(parsed.Build) > 0 {
+		return versionCore{}, false
+	}
+
+	result.major = parsed.Major
+	result.minor = parsed.Minor
+	result.patch = parsed.Patch
+
+	return result, true
+}
+
 // AllGatesAcknowledged returns true when the odh-upgrade-acks
-// ConfigMap exists and every entry in it is set to "true". Returns
-// false when the ConfigMap does not exist (the modules controller has
-// not yet evaluated gates) or when any entry remains unacknowledged.
-// An empty ConfigMap (no data entries) is considered fully acknowledged.
-func AllGatesAcknowledged(ctx context.Context, cli client.Client, namespace string) (bool, error) {
+// ConfigMap exists and every gate entry matching one of the target versions is
+// set to "true". Entries for other versions are ignored. Returns false when
+// the ConfigMap does not exist (the modules controller has not yet evaluated
+// gates) or when an applicable entry remains unacknowledged. An empty or
+// out-of-scope ConfigMap is considered fully acknowledged.
+func AllGatesAcknowledged(ctx context.Context, cli client.Client, namespace string, versions []string) (bool, error) {
 	cm := &corev1.ConfigMap{}
 	if err := cli.Get(ctx, client.ObjectKey{Name: AcksConfigMap, Namespace: namespace}, cm); err != nil {
 		if k8serr.IsNotFound(err) {
@@ -185,13 +257,25 @@ func AllGatesAcknowledged(ctx context.Context, cli client.Client, namespace stri
 		return false, fmt.Errorf("failed to get %s ConfigMap: %w", AcksConfigMap, err)
 	}
 
-	for _, val := range cm.Data {
+	for key, val := range cm.Data {
+		if !matchesAnyVersion(key, versions) {
+			continue
+		}
 		if val != "true" {
 			return false, nil
 		}
 	}
 
 	return true, nil
+}
+
+func matchesAnyVersion(key string, versions []string) bool {
+	for _, version := range versions {
+		if _, matches := MatchGateKey(key, version); matches {
+			return true
+		}
+	}
+	return false
 }
 
 // DiscoverGates lists ConfigMaps in the operator namespace that carry

--- a/pkg/controller/gates/gates_test.go
+++ b/pkg/controller/gates/gates_test.go
@@ -219,6 +219,43 @@ func TestEnsureGates_PreservesErrorMessageValues(t *testing.T) {
 		"acked entry must remain acknowledged")
 }
 
+func TestMatchGateKey(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		key      string
+		version  string
+		gateName string
+		match    bool
+	}{
+		{name: "minor first patch", key: "ack-3.5-kserve", version: "3.5.1", gateName: "kserve", match: true},
+		{name: "minor later patch", key: "ack-3.5-kserve", version: "3.5.2", gateName: "kserve", match: true},
+		{name: "different minor", key: "ack-3.5-kserve", version: "3.6.0", match: false},
+		{name: "exact match", key: "ack-3.5.1-kserve", version: "3.5.1", gateName: "kserve", match: true},
+		{name: "different patch", key: "ack-3.5.1-kserve", version: "3.5.2", match: false},
+		{name: "multi-digit patch", key: "ack-3.5.10-kserve", version: "3.5.10", gateName: "kserve", match: true},
+		{name: "multi-digit patch does not prefix-match", key: "ack-3.5.10-kserve", version: "3.5.1", match: false},
+		{name: "prerelease uses numeric core", key: "ack-3.5.2-kserve", version: "3.5.2-rc.1", gateName: "kserve", match: true},
+		{name: "build metadata uses numeric core", key: "ack-3.5-kserve", version: "3.5.2+build.7", gateName: "kserve", match: true},
+		{name: "missing prefix", key: "3.5-kserve", version: "3.5.1", match: false},
+		{name: "major only", key: "ack-3-kserve", version: "3.5.1", match: false},
+		{name: "empty patch", key: "ack-3.5.-kserve", version: "3.5.1", match: false},
+		{name: "version prefix", key: "ack-v3.5-kserve", version: "3.5.1", match: false},
+		{name: "missing gate name", key: "ack-3.5-", version: "3.5.1", match: false},
+		{name: "invalid current version", key: "ack-3.5-kserve", version: "3.5", match: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			gateName, match := gates.MatchGateKey(tc.key, tc.version)
+			assert.Equal(t, tc.match, match)
+			assert.Equal(t, tc.gateName, gateName)
+		})
+	}
+}
+
 func TestLoadInTreeGates_ReturnsAllEntries(t *testing.T) {
 	t.Parallel()
 
@@ -301,7 +338,7 @@ func TestEnsureGatesNil_ThenAllGatesAcknowledged_ReturnsTrue(t *testing.T) {
 	require.NoError(t, err)
 	assert.Empty(t, unacked)
 
-	cleared, err := gates.AllGatesAcknowledged(context.Background(), cli, testNamespace)
+	cleared, err := gates.AllGatesAcknowledged(context.Background(), cli, testNamespace, []string{"3.5.1"})
 	require.NoError(t, err)
 	assert.True(t, cleared, "AllGatesAcknowledged must return true after EnsureGates(nil) creates an empty ConfigMap")
 }
@@ -314,7 +351,7 @@ func TestAllGatesAcknowledged_NoCMReturnsFalse(t *testing.T) {
 
 	cli := fake.NewClientBuilder().WithScheme(scheme).Build()
 
-	cleared, err := gates.AllGatesAcknowledged(context.Background(), cli, testNamespace)
+	cleared, err := gates.AllGatesAcknowledged(context.Background(), cli, testNamespace, []string{"3.5.1"})
 	require.NoError(t, err)
 	assert.False(t, cleared, "missing acks CM means modules controller hasn't evaluated yet")
 }
@@ -331,7 +368,7 @@ func TestAllGatesAcknowledged_EmptyCMReturnsTrue(t *testing.T) {
 
 	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cm).Build()
 
-	cleared, err := gates.AllGatesAcknowledged(context.Background(), cli, testNamespace)
+	cleared, err := gates.AllGatesAcknowledged(context.Background(), cli, testNamespace, []string{"3.5.1"})
 	require.NoError(t, err)
 	assert.True(t, cleared, "empty CM means no gates needed (fresh install)")
 }
@@ -353,7 +390,7 @@ func TestAllGatesAcknowledged_AllAcked(t *testing.T) {
 
 	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cm).Build()
 
-	cleared, err := gates.AllGatesAcknowledged(context.Background(), cli, testNamespace)
+	cleared, err := gates.AllGatesAcknowledged(context.Background(), cli, testNamespace, []string{"3.5.1"})
 	require.NoError(t, err)
 	assert.True(t, cleared)
 }
@@ -374,9 +411,31 @@ func TestAllGatesAcknowledged_PartiallyAcked(t *testing.T) {
 
 	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cm).Build()
 
-	cleared, err := gates.AllGatesAcknowledged(context.Background(), cli, testNamespace)
+	cleared, err := gates.AllGatesAcknowledged(context.Background(), cli, testNamespace, []string{"3.5.1"})
 	require.NoError(t, err)
 	assert.False(t, cleared)
+}
+
+func TestAllGatesAcknowledged_IgnoresNonTargetVersions(t *testing.T) {
+	t.Parallel()
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: gates.AcksConfigMap, Namespace: testNamespace},
+		Data: map[string]string{
+			"ack-3.5.1-patch-only": "not acknowledged",
+			"ack-3.5-shared":       "true",
+			"ack-3.6-future":       "not acknowledged",
+		},
+	}
+
+	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cm).Build()
+
+	cleared, err := gates.AllGatesAcknowledged(context.Background(), cli, testNamespace, []string{"3.5.2"})
+	require.NoError(t, err)
+	assert.True(t, cleared)
 }
 
 const testNamespace = "test-ns"

--- a/pkg/controller/gates/gates_test.go
+++ b/pkg/controller/gates/gates_test.go
@@ -338,7 +338,7 @@ func TestEnsureGatesNil_ThenAllGatesAcknowledged_ReturnsTrue(t *testing.T) {
 	require.NoError(t, err)
 	assert.Empty(t, unacked)
 
-	cleared, err := gates.AllGatesAcknowledged(context.Background(), cli, testNamespace, []string{"3.5.1"})
+	cleared, err := gates.AllGatesAcknowledged(context.Background(), cli, testNamespace, "3.5.1")
 	require.NoError(t, err)
 	assert.True(t, cleared, "AllGatesAcknowledged must return true after EnsureGates(nil) creates an empty ConfigMap")
 }
@@ -351,7 +351,7 @@ func TestAllGatesAcknowledged_NoCMReturnsFalse(t *testing.T) {
 
 	cli := fake.NewClientBuilder().WithScheme(scheme).Build()
 
-	cleared, err := gates.AllGatesAcknowledged(context.Background(), cli, testNamespace, []string{"3.5.1"})
+	cleared, err := gates.AllGatesAcknowledged(context.Background(), cli, testNamespace, "3.5.1")
 	require.NoError(t, err)
 	assert.False(t, cleared, "missing acks CM means modules controller hasn't evaluated yet")
 }
@@ -368,7 +368,7 @@ func TestAllGatesAcknowledged_EmptyCMReturnsTrue(t *testing.T) {
 
 	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cm).Build()
 
-	cleared, err := gates.AllGatesAcknowledged(context.Background(), cli, testNamespace, []string{"3.5.1"})
+	cleared, err := gates.AllGatesAcknowledged(context.Background(), cli, testNamespace, "3.5.1")
 	require.NoError(t, err)
 	assert.True(t, cleared, "empty CM means no gates needed (fresh install)")
 }
@@ -390,7 +390,7 @@ func TestAllGatesAcknowledged_AllAcked(t *testing.T) {
 
 	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cm).Build()
 
-	cleared, err := gates.AllGatesAcknowledged(context.Background(), cli, testNamespace, []string{"3.5.1"})
+	cleared, err := gates.AllGatesAcknowledged(context.Background(), cli, testNamespace, "3.5.1")
 	require.NoError(t, err)
 	assert.True(t, cleared)
 }
@@ -411,7 +411,7 @@ func TestAllGatesAcknowledged_PartiallyAcked(t *testing.T) {
 
 	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cm).Build()
 
-	cleared, err := gates.AllGatesAcknowledged(context.Background(), cli, testNamespace, []string{"3.5.1"})
+	cleared, err := gates.AllGatesAcknowledged(context.Background(), cli, testNamespace, "3.5.1")
 	require.NoError(t, err)
 	assert.False(t, cleared)
 }
@@ -433,7 +433,7 @@ func TestAllGatesAcknowledged_IgnoresNonTargetVersions(t *testing.T) {
 
 	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cm).Build()
 
-	cleared, err := gates.AllGatesAcknowledged(context.Background(), cli, testNamespace, []string{"3.5.2"})
+	cleared, err := gates.AllGatesAcknowledged(context.Background(), cli, testNamespace, "3.5.2")
 	require.NoError(t, err)
 	assert.True(t, cleared)
 }

--- a/pkg/controller/gates/resources/gates.yaml
+++ b/pkg/controller/gates/resources/gates.yaml
@@ -1,7 +1,11 @@
 # In-tree upgrade gate definitions for components that have not yet
-# migrated to modules. Gate entries use version-scoped keys:
+# migrated to modules. Gate entries use minor- or patch-scoped keys:
 #
-#   ack-<version>-<description>: "Human-readable message"
+#   ack-<major>.<minor>-<description>: "Human-readable message"
+#   ack-<major>.<minor>.<patch>-<description>: "Human-readable message"
+#
+# Minor-scoped entries apply to every patch release in that minor line.
+# Patch-scoped entries apply only to that exact release.
 #
 # The operator merges these entries into the odh-upgrade-acks ConfigMap.
 # Unacknowledged entries appear as descriptive strings; admins acknowledge
@@ -20,24 +24,24 @@ metadata:
   labels:
     platform.opendatahub.io/upgrade-gate: "true"
 data:
-  ack-3.5.1-aigateway: "Acknowledge upgrade of aigateway from version 2.x to 3.5.1"
-  ack-3.5.1-dashboard: "Acknowledge upgrade of dashboard from version 2.x to 3.5.1"
-  ack-3.5.1-datasciencepipelines: "Acknowledge upgrade of datasciencepipelines from version 2.x to 3.5.1"
-  ack-3.5.1-feastoperator: "Acknowledge upgrade of feastoperator from version 2.x to 3.5.1"
-  ack-3.5.1-kserve: "Acknowledge upgrade of kserve from version 2.x to 3.5.1"
-  ack-3.5.1-kueue: "Acknowledge upgrade of kueue from version 2.x to 3.5.1"
-  ack-3.5.1-mcplifecycleoperator: "Acknowledge upgrade of mcplifecycleoperator from version 2.x to 3.5.1"
-  ack-3.5.1-mlflowoperator: "Acknowledge upgrade of mlflowoperator from version 2.x to 3.5.1"
-  ack-3.5.1-modelregistry: "Acknowledge upgrade of modelregistry from version 2.x to 3.5.1"
-  ack-3.5.1-ogx: "Acknowledge upgrade of ogx from version 2.x to 3.5.1"
-  ack-3.5.1-ray: "Acknowledge upgrade of ray from version 2.x to 3.5.1"
-  ack-3.5.1-sparkoperator: "Acknowledge upgrade of sparkoperator from version 2.x to 3.5.1"
-  ack-3.5.1-trainer: "Acknowledge upgrade of trainer from version 2.x to 3.5.1"
-  ack-3.5.1-trainingoperator: "Acknowledge upgrade of trainingoperator from version 2.x to 3.5.1"
-  ack-3.5.1-trustyai: "Acknowledge upgrade of trustyai from version 2.x to 3.5.1"
-  ack-3.5.1-workbenches: "Acknowledge upgrade of workbenches from version 2.x to 3.5.1"
-  ack-3.5.1-removed-codeflare: "Acknowledge upgrade of codeflare from version 2.x to 3.5.1"
-  ack-3.5.1-removed-modelmeshserving: "Acknowledge upgrade of modelmeshserving from version 2.x to 3.5.1"
-  ack-3.5.1-dependencies-cert-manager: "Acknowledge upgrade dependency on cert-manager from version 2.x to 3.5.1"
-  ack-3.5.1-dependencies-kueue-operator: "Acknowledge upgrade dependency on kueue-operator from version 2.x to 3.5.1"
-  ack-3.5.1-dependencies-servicemeshoperatorv2: "Acknowledge upgrade dependency on removing Service Mesh Operator v2 from version 2.x to 3.5.1"
+  ack-3.5-aigateway: "Acknowledge upgrade of aigateway from version 2.x to 3.5.x"
+  ack-3.5-dashboard: "Acknowledge upgrade of dashboard from version 2.x to 3.5.x"
+  ack-3.5-datasciencepipelines: "Acknowledge upgrade of datasciencepipelines from version 2.x to 3.5.x"
+  ack-3.5-feastoperator: "Acknowledge upgrade of feastoperator from version 2.x to 3.5.x"
+  ack-3.5-kserve: "Acknowledge upgrade of kserve from version 2.x to 3.5.x"
+  ack-3.5-kueue: "Acknowledge upgrade of kueue from version 2.x to 3.5.x"
+  ack-3.5-mcplifecycleoperator: "Acknowledge upgrade of mcplifecycleoperator from version 2.x to 3.5.x"
+  ack-3.5-mlflowoperator: "Acknowledge upgrade of mlflowoperator from version 2.x to 3.5.x"
+  ack-3.5-modelregistry: "Acknowledge upgrade of modelregistry from version 2.x to 3.5.x"
+  ack-3.5-ogx: "Acknowledge upgrade of ogx from version 2.x to 3.5.x"
+  ack-3.5-ray: "Acknowledge upgrade of ray from version 2.x to 3.5.x"
+  ack-3.5-sparkoperator: "Acknowledge upgrade of sparkoperator from version 2.x to 3.5.x"
+  ack-3.5-trainer: "Acknowledge upgrade of trainer from version 2.x to 3.5.x"
+  ack-3.5-trainingoperator: "Acknowledge upgrade of trainingoperator from version 2.x to 3.5.x"
+  ack-3.5-trustyai: "Acknowledge upgrade of trustyai from version 2.x to 3.5.x"
+  ack-3.5-workbenches: "Acknowledge upgrade of workbenches from version 2.x to 3.5.x"
+  ack-3.5-removed-codeflare: "Acknowledge upgrade of codeflare from version 2.x to 3.5.x"
+  ack-3.5-removed-modelmeshserving: "Acknowledge upgrade of modelmeshserving from version 2.x to 3.5.x"
+  ack-3.5-dependencies-cert-manager: "Acknowledge upgrade dependency on cert-manager from version 2.x to 3.5.x"
+  ack-3.5-dependencies-kueue-operator: "Acknowledge upgrade dependency on kueue-operator from version 2.x to 3.5.x"
+  ack-3.5-dependencies-servicemeshoperatorv2: "Acknowledge upgrade dependency on removing Service Mesh Operator v2 from version 2.x to 3.5.x"

--- a/pkg/controller/provision/auto_ack_action.go
+++ b/pkg/controller/provision/auto_ack_action.go
@@ -47,11 +47,11 @@ func AutoAcknowledgeUpgradeGates(ctx context.Context, rr *odhtype.Reconciliation
 		return fmt.Errorf("failed to determine deployed release for upgrade gates: %w", err)
 	}
 
-	versions, err := ResolveUpgradeGateVersions(ctx, reader, ns, deployed, rr.Release)
+	targetVersion, err := ResolveUpgradeGateVersion(ctx, reader, ns, deployed, rr.Release)
 	if err != nil {
-		return fmt.Errorf("failed to resolve upgrade gate versions: %w", err)
+		return fmt.Errorf("failed to resolve upgrade gate version: %w", err)
 	}
-	if len(versions) == 0 || !isVersionUpgrade(deployed.Version.Version, versions[0]) {
+	if !isVersionUpgrade(deployed.Version.Version, targetVersion) {
 		return nil
 	}
 
@@ -61,7 +61,7 @@ func AutoAcknowledgeUpgradeGates(ctx context.Context, rr *odhtype.Reconciliation
 		reader,
 		cm,
 		cluster.GetApplicationNamespace(),
-		versions,
+		targetVersion,
 		resolveManagedComponents(rr.Instance),
 	); err != nil {
 		return err
@@ -87,7 +87,7 @@ func AutoAcknowledgeUpgradeGatesInNamespace(
 	reader client.Reader,
 	cm *corev1.ConfigMap,
 	appsNS string,
-	versions []string,
+	targetVersion string,
 	componentStates map[string]operatorv1.ManagementState,
 ) error {
 	if cm == nil {
@@ -96,10 +96,10 @@ func AutoAcknowledgeUpgradeGatesInNamespace(
 
 	log := logf.FromContext(ctx)
 
-	log.Info("running auto-ack upgrade checks", "versions", versions)
+	log.Info("running auto-ack upgrade checks", "version", targetVersion)
 
 	for key, value := range cm.Data {
-		gateKey, matches := matchUpgradeGateKey(key, versions)
+		gateKey, matches := gates.MatchGateKey(key, targetVersion)
 		if !matches || value == "true" {
 			continue
 		}

--- a/pkg/controller/provision/auto_ack_action.go
+++ b/pkg/controller/provision/auto_ack_action.go
@@ -22,8 +22,8 @@ import (
 // upgrade gates for components whose health checks pass. Components
 // that are not Managed in the DSC are auto-acked immediately since
 // they are not expected to be present. It is a no-op when the acks
-// ConfigMap does not exist or has no unacknowledged entries for the
-// current version (fresh install or same-major upgrade).
+// ConfigMap does not exist or there is no newer target version to evaluate
+// (fresh install or a reconciliation at the current version).
 func AutoAcknowledgeUpgradeGates(ctx context.Context, rr *odhtype.ReconciliationRequest) error {
 	ns, nsErr := cluster.GetOperatorNamespace()
 	if nsErr != nil {
@@ -42,13 +42,26 @@ func AutoAcknowledgeUpgradeGates(ctx context.Context, rr *odhtype.Reconciliation
 		return fmt.Errorf("failed to get %s ConfigMap: %w", gates.AcksConfigMap, err)
 	}
 
+	deployed, err := cluster.GetDeployedRelease(ctx, rr.Client)
+	if err != nil {
+		return fmt.Errorf("failed to determine deployed release for upgrade gates: %w", err)
+	}
+
+	versions, err := ResolveUpgradeGateVersions(ctx, reader, ns, deployed, rr.Release)
+	if err != nil {
+		return fmt.Errorf("failed to resolve upgrade gate versions: %w", err)
+	}
+	if len(versions) == 0 || !isVersionUpgrade(deployed.Version.Version, versions[0]) {
+		return nil
+	}
+
 	original := cm.DeepCopy()
 	if err := AutoAcknowledgeUpgradeGatesInNamespace(
 		ctx,
 		reader,
 		cm,
 		cluster.GetApplicationNamespace(),
-		UpgradeGateVersion,
+		versions,
 		resolveManagedComponents(rr.Instance),
 	); err != nil {
 		return err
@@ -74,7 +87,7 @@ func AutoAcknowledgeUpgradeGatesInNamespace(
 	reader client.Reader,
 	cm *corev1.ConfigMap,
 	appsNS string,
-	version string,
+	versions []string,
 	componentStates map[string]operatorv1.ManagementState,
 ) error {
 	if cm == nil {
@@ -83,15 +96,14 @@ func AutoAcknowledgeUpgradeGatesInNamespace(
 
 	log := logf.FromContext(ctx)
 
-	versionPrefix := "ack-" + version + "-"
-	log.Info("running auto-ack upgrade checks", "version", version)
+	log.Info("running auto-ack upgrade checks", "versions", versions)
 
 	for key, value := range cm.Data {
-		if !strings.HasPrefix(key, versionPrefix) || value == "true" {
+		gateKey, matches := matchUpgradeGateKey(key, versions)
+		if !matches || value == "true" {
 			continue
 		}
 
-		gateKey := strings.TrimPrefix(key, versionPrefix)
 		if gateKey == "" {
 			continue
 		}

--- a/pkg/controller/provision/auto_ack_action_test.go
+++ b/pkg/controller/provision/auto_ack_action_test.go
@@ -92,7 +92,7 @@ func runAutoAck(
 	t.Helper()
 
 	return provision.AutoAcknowledgeUpgradeGatesInNamespace(
-		t.Context(), reader, cm, testApps, "3.0.0", componentStates,
+		t.Context(), reader, cm, testApps, []string{"3.0.0"}, componentStates,
 	)
 }
 
@@ -258,6 +258,21 @@ func TestAutoAck_PartialAck(t *testing.T) {
 	assert.Equal(t, "true", cm.Data["ack-3.0.0-dashboard"], "already acked stays acked")
 	assert.Equal(t, "true", cm.Data[passKey], "passing check auto-acked")
 	assert.NotEqual(t, "true", cm.Data[blockedKey], "blocked check remains unacked")
+}
+
+func TestAutoAck_MinorScopedGateMatchesPatchRelease(t *testing.T) {
+	t.Parallel()
+
+	cm := acksCM(map[string]string{
+		"ack-3.0-dashboard": "Acknowledge upgrade of dashboard",
+	})
+	cli := fake.NewClientBuilder().WithScheme(autoAckScheme()).
+		WithObjects(readyDeployment(testApps, "dashboard", "dashboard")).Build()
+
+	err := runAutoAck(t, cli, cm, allManaged("dashboard"))
+
+	require.NoError(t, err)
+	assert.Equal(t, "true", cm.Data["ack-3.0-dashboard"])
 }
 
 func TestAutoAck_IgnoresOtherVersionKeys(t *testing.T) {

--- a/pkg/controller/provision/auto_ack_action_test.go
+++ b/pkg/controller/provision/auto_ack_action_test.go
@@ -92,7 +92,7 @@ func runAutoAck(
 	t.Helper()
 
 	return provision.AutoAcknowledgeUpgradeGatesInNamespace(
-		t.Context(), reader, cm, testApps, []string{"3.0.0"}, componentStates,
+		t.Context(), reader, cm, testApps, "3.0.0", componentStates,
 	)
 }
 

--- a/pkg/controller/provision/gate_versions.go
+++ b/pkg/controller/provision/gate_versions.go
@@ -11,37 +11,39 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/opendatahub-io/opendatahub-operator/v2/api/common"
-	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/gates"
 )
 
-// ResolveUpgradeGateVersions returns the target release used to match
-// upgrade-gate keys. The release detected for the running operator is the
-// primary source. DSC-owning CSVs provide a fallback and protect against OLM's
-// transient two-CSV transition when the runtime release is stale.
-func ResolveUpgradeGateVersions(
+// ResolveUpgradeGateVersion returns the target release used to match
+// upgrade-gate keys. deployedRelease is the version persisted in the DSC or
+// DSCI status. operatorRelease is the version for the running operator, usually
+// obtained from RHAI_VERSION or the DSC-owning CSV during cluster.Init and
+// propagated through the reconciliation request. DSC-owning CSVs provide a
+// fallback and protect against OLM's transient two-CSV transition when the
+// operator release is stale.
+func ResolveUpgradeGateVersion(
 	ctx context.Context,
 	reader client.Reader,
 	namespace string,
-	deployed common.Release,
-	running common.Release,
-) ([]string, error) {
+	deployedRelease common.Release,
+	operatorRelease common.Release,
+) (string, error) {
 	var target *semver.Version
-	if isAtLeastVersion(running.Version.Version, deployed.Version.Version) {
-		version := running.Version.Version
+	if isAtLeastVersion(operatorRelease.Version.Version, deployedRelease.Version.Version) {
+		version := operatorRelease.Version.Version
 		target = &version
 	}
 
 	csvs := &operatorsv1alpha1.ClusterServiceVersionList{}
 	if err := reader.List(ctx, csvs, client.InNamespace(namespace)); err != nil {
 		if meta.IsNoMatchError(err) {
-			return targetVersion(target)
+			return resolvedTargetVersion(target)
 		}
-		return nil, fmt.Errorf("listing ClusterServiceVersions for upgrade gates: %w", err)
+		return "", fmt.Errorf("listing ClusterServiceVersions for upgrade gates: %w", err)
 	}
 
 	for i := range csvs.Items {
 		csv := &csvs.Items[i]
-		if !ownsDataScienceCluster(csv) || !isUpgradeTarget(csv.Spec.Version.Version, deployed.Version.Version) {
+		if !ownsDataScienceCluster(csv) || !isUpgradeTarget(csv.Spec.Version.Version, deployedRelease.Version.Version) {
 			continue
 		}
 
@@ -52,14 +54,14 @@ func ResolveUpgradeGateVersions(
 		}
 	}
 
-	return targetVersion(target)
+	return resolvedTargetVersion(target)
 }
 
-func targetVersion(target *semver.Version) ([]string, error) {
+func resolvedTargetVersion(target *semver.Version) (string, error) {
 	if target == nil {
-		return nil, errors.New("unable to determine target release for upgrade gates")
+		return "", errors.New("unable to determine target release for upgrade gates")
 	}
-	return []string{target.String()}, nil
+	return target.String(), nil
 }
 
 func isVersionUpgrade(deployed semver.Version, target string) bool {
@@ -102,13 +104,4 @@ func ownsDataScienceCluster(csv *operatorsv1alpha1.ClusterServiceVersion) bool {
 		}
 	}
 	return false
-}
-
-func matchUpgradeGateKey(key string, versions []string) (string, bool) {
-	for _, version := range versions {
-		if gateName, matches := gates.MatchGateKey(key, version); matches {
-			return gateName, true
-		}
-	}
-	return "", false
 }

--- a/pkg/controller/provision/gate_versions.go
+++ b/pkg/controller/provision/gate_versions.go
@@ -1,0 +1,114 @@
+package provision
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/blang/semver/v4"
+	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/opendatahub-io/opendatahub-operator/v2/api/common"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/gates"
+)
+
+// ResolveUpgradeGateVersions returns the target release used to match
+// upgrade-gate keys. The release detected for the running operator is the
+// primary source. DSC-owning CSVs provide a fallback and protect against OLM's
+// transient two-CSV transition when the runtime release is stale.
+func ResolveUpgradeGateVersions(
+	ctx context.Context,
+	reader client.Reader,
+	namespace string,
+	deployed common.Release,
+	running common.Release,
+) ([]string, error) {
+	var target *semver.Version
+	if isAtLeastVersion(running.Version.Version, deployed.Version.Version) {
+		version := running.Version.Version
+		target = &version
+	}
+
+	csvs := &operatorsv1alpha1.ClusterServiceVersionList{}
+	if err := reader.List(ctx, csvs, client.InNamespace(namespace)); err != nil {
+		if meta.IsNoMatchError(err) {
+			return targetVersion(target)
+		}
+		return nil, fmt.Errorf("listing ClusterServiceVersions for upgrade gates: %w", err)
+	}
+
+	for i := range csvs.Items {
+		csv := &csvs.Items[i]
+		if !ownsDataScienceCluster(csv) || !isUpgradeTarget(csv.Spec.Version.Version, deployed.Version.Version) {
+			continue
+		}
+
+		candidate := csv.Spec.Version.Version
+		if target == nil || candidate.GT(*target) {
+			candidateVersion := candidate
+			target = &candidateVersion
+		}
+	}
+
+	return targetVersion(target)
+}
+
+func targetVersion(target *semver.Version) ([]string, error) {
+	if target == nil {
+		return nil, errors.New("unable to determine target release for upgrade gates")
+	}
+	return []string{target.String()}, nil
+}
+
+func isVersionUpgrade(deployed semver.Version, target string) bool {
+	if isZeroVersion(deployed) {
+		return false
+	}
+
+	candidate, err := semver.Parse(target)
+	return err == nil && candidate.GT(deployed)
+}
+
+func isAtLeastVersion(candidate, deployed semver.Version) bool {
+	if isZeroVersion(candidate) {
+		return false
+	}
+	if isZeroVersion(deployed) {
+		return true
+	}
+	return !candidate.LT(deployed)
+}
+
+func isUpgradeTarget(candidate, deployed semver.Version) bool {
+	if isZeroVersion(candidate) {
+		return false
+	}
+	if isZeroVersion(deployed) {
+		return true
+	}
+	return candidate.GT(deployed)
+}
+
+func isZeroVersion(version semver.Version) bool {
+	return version.Major == 0 && version.Minor == 0 && version.Patch == 0
+}
+
+func ownsDataScienceCluster(csv *operatorsv1alpha1.ClusterServiceVersion) bool {
+	for _, owned := range csv.Spec.CustomResourceDefinitions.Owned {
+		if owned.Kind == "DataScienceCluster" {
+			return true
+		}
+	}
+	return false
+}
+
+func matchUpgradeGateKey(key string, versions []string) (string, bool) {
+	for _, version := range versions {
+		if gateName, matches := gates.MatchGateKey(key, version); matches {
+			return gateName, true
+		}
+	}
+	return "", false
+}

--- a/pkg/controller/provision/gate_versions_test.go
+++ b/pkg/controller/provision/gate_versions_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/provision"
 )
 
-func TestResolveUpgradeGateVersions(t *testing.T) {
+func TestResolveUpgradeGateVersion(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -24,7 +24,7 @@ func TestResolveUpgradeGateVersions(t *testing.T) {
 		deployed string
 		running  string
 		csvs     []*operatorsv1alpha1.ClusterServiceVersion
-		expected []string
+		expected string
 		err      bool
 	}{
 		{
@@ -32,7 +32,7 @@ func TestResolveUpgradeGateVersions(t *testing.T) {
 			deployed: "2.25.10",
 			running:  "3.5.1",
 			csvs:     []*operatorsv1alpha1.ClusterServiceVersion{dscOwningCSV("rhods-operator.2.25.10", "2.25.10")},
-			expected: []string{"3.5.1"},
+			expected: "3.5.1",
 		},
 		{
 			name:     "newer DSC-owning CSV protects against stale running release",
@@ -42,7 +42,7 @@ func TestResolveUpgradeGateVersions(t *testing.T) {
 				dscOwningCSV("rhods-operator.2.25.10", "2.25.10"),
 				dscOwningCSV("rhods-operator.v3.5.2", "3.5.2"),
 			},
-			expected: []string{"3.5.2"},
+			expected: "3.5.2",
 		},
 		{
 			name:     "highest DSC-owning CSV wins when running release is unavailable",
@@ -52,7 +52,7 @@ func TestResolveUpgradeGateVersions(t *testing.T) {
 				dscOwningCSV("rhods-operator.v3.5.3", "3.5.3"),
 				dscOwningCSV("rhods-operator.v3.5.2", "3.5.2"),
 			},
-			expected: []string{"3.5.3"},
+			expected: "3.5.3",
 		},
 		{
 			name:     "non-owning CSVs are ignored",
@@ -62,7 +62,7 @@ func TestResolveUpgradeGateVersions(t *testing.T) {
 				csv("dependency.v3.5.2", "3.5.2", false),
 				dscOwningCSV("rhods-operator.2.25.10", "2.25.10"),
 			},
-			expected: []string{"3.5.1"},
+			expected: "3.5.1",
 		},
 		{
 			name:     "missing target fails closed",
@@ -85,7 +85,7 @@ func TestResolveUpgradeGateVersions(t *testing.T) {
 			}
 			cli := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(objects...).Build()
 
-			versions, err := provision.ResolveUpgradeGateVersions(
+			targetVersion, err := provision.ResolveUpgradeGateVersion(
 				t.Context(), cli, testNS,
 				releaseForVersion(tc.deployed),
 				releaseForVersion(tc.running),
@@ -96,7 +96,7 @@ func TestResolveUpgradeGateVersions(t *testing.T) {
 				return
 			}
 			require.NoError(t, err)
-			assert.Equal(t, tc.expected, versions)
+			assert.Equal(t, tc.expected, targetVersion)
 		})
 	}
 }

--- a/pkg/controller/provision/gate_versions_test.go
+++ b/pkg/controller/provision/gate_versions_test.go
@@ -1,0 +1,131 @@
+package provision_test
+
+import (
+	"testing"
+
+	"github.com/blang/semver/v4"
+	ofversion "github.com/operator-framework/api/pkg/lib/version"
+	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/opendatahub-io/opendatahub-operator/v2/api/common"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/provision"
+)
+
+func TestResolveUpgradeGateVersions(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		deployed string
+		running  string
+		csvs     []*operatorsv1alpha1.ClusterServiceVersion
+		expected []string
+		err      bool
+	}{
+		{
+			name:     "running release is used when only old CSV is visible",
+			deployed: "2.25.10",
+			running:  "3.5.1",
+			csvs:     []*operatorsv1alpha1.ClusterServiceVersion{dscOwningCSV("rhods-operator.2.25.10", "2.25.10")},
+			expected: []string{"3.5.1"},
+		},
+		{
+			name:     "newer DSC-owning CSV protects against stale running release",
+			deployed: "2.25.10",
+			running:  "2.25.10",
+			csvs: []*operatorsv1alpha1.ClusterServiceVersion{
+				dscOwningCSV("rhods-operator.2.25.10", "2.25.10"),
+				dscOwningCSV("rhods-operator.v3.5.2", "3.5.2"),
+			},
+			expected: []string{"3.5.2"},
+		},
+		{
+			name:     "highest DSC-owning CSV wins when running release is unavailable",
+			deployed: "2.25.10",
+			csvs: []*operatorsv1alpha1.ClusterServiceVersion{
+				dscOwningCSV("rhods-operator.v3.5.1", "3.5.1"),
+				dscOwningCSV("rhods-operator.v3.5.3", "3.5.3"),
+				dscOwningCSV("rhods-operator.v3.5.2", "3.5.2"),
+			},
+			expected: []string{"3.5.3"},
+		},
+		{
+			name:     "non-owning CSVs are ignored",
+			deployed: "2.25.10",
+			running:  "3.5.1",
+			csvs: []*operatorsv1alpha1.ClusterServiceVersion{
+				csv("dependency.v3.5.2", "3.5.2", false),
+				dscOwningCSV("rhods-operator.2.25.10", "2.25.10"),
+			},
+			expected: []string{"3.5.1"},
+		},
+		{
+			name:     "missing target fails closed",
+			deployed: "2.25.10",
+			csvs:     []*operatorsv1alpha1.ClusterServiceVersion{dscOwningCSV("rhods-operator.2.25.10", "2.25.10")},
+			err:      true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			scheme := runtime.NewScheme()
+			require.NoError(t, operatorsv1alpha1.AddToScheme(scheme))
+
+			objects := make([]runtime.Object, len(tc.csvs))
+			for i := range tc.csvs {
+				objects[i] = tc.csvs[i]
+			}
+			cli := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(objects...).Build()
+
+			versions, err := provision.ResolveUpgradeGateVersions(
+				t.Context(), cli, testNS,
+				releaseForVersion(tc.deployed),
+				releaseForVersion(tc.running),
+			)
+
+			if tc.err {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.expected, versions)
+		})
+	}
+}
+
+func releaseForVersion(value string) common.Release {
+	if value == "" {
+		return common.Release{}
+	}
+	return common.Release{Version: ofversion.OperatorVersion{Version: semver.MustParse(value)}}
+}
+
+func dscOwningCSV(name string, version string) *operatorsv1alpha1.ClusterServiceVersion {
+	return csv(name, version, true)
+}
+
+func csv(name string, value string, ownsDSC bool) *operatorsv1alpha1.ClusterServiceVersion {
+	parsed := semver.MustParse(value)
+	result := &operatorsv1alpha1.ClusterServiceVersion{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: testNS},
+		Spec: operatorsv1alpha1.ClusterServiceVersionSpec{
+			Version: ofversion.OperatorVersion{Version: parsed},
+		},
+	}
+	if ownsDSC {
+		result.Spec.CustomResourceDefinitions.Owned = []operatorsv1alpha1.CRDDescription{{
+			Name:    "datascienceclusters.datasciencecluster.opendatahub.io",
+			Version: "v2",
+			Kind:    "DataScienceCluster",
+		}}
+	}
+	return result
+}

--- a/pkg/controller/provision/gates_action.go
+++ b/pkg/controller/provision/gates_action.go
@@ -91,12 +91,12 @@ func ComponentUpgradeGateAction(ctx context.Context, rr *odhtype.ReconciliationR
 	if err != nil {
 		return fmt.Errorf("failed to determine deployed release for upgrade gates: %w", err)
 	}
-	versions, err := ResolveUpgradeGateVersions(ctx, rr.Client, ns, deployed, rr.Release)
+	targetVersion, err := ResolveUpgradeGateVersion(ctx, rr.Client, ns, deployed, rr.Release)
 	if err != nil {
-		return fmt.Errorf("failed to resolve upgrade gate versions: %w", err)
+		return fmt.Errorf("failed to resolve upgrade gate version: %w", err)
 	}
 
-	return ComponentUpgradeGateCheck(ctx, rr.Client, ns, versions, rr.Conditions)
+	return ComponentUpgradeGateCheck(ctx, rr.Client, ns, targetVersion, rr.Conditions)
 }
 
 // ComponentUpgradeGateCheck is the namespace-explicit variant of
@@ -105,10 +105,10 @@ func ComponentUpgradeGateCheck(
 	ctx context.Context,
 	cli client.Client,
 	namespace string,
-	versions []string,
+	targetVersion string,
 	conditions ConditionWriter,
 ) error {
-	cleared, err := gates.AllGatesAcknowledged(ctx, cli, namespace, versions)
+	cleared, err := gates.AllGatesAcknowledged(ctx, cli, namespace, targetVersion)
 	if err != nil {
 		return fmt.Errorf("failed to check upgrade gates: %w", err)
 	}
@@ -165,12 +165,12 @@ func CheckUpgradeGatesInNamespace(
 		return fmt.Errorf("cannot determine deployed release for upgrade gate check: %w", err)
 	}
 
-	versions, err := ResolveUpgradeGateVersions(ctx, cli, namespace, deployed, release)
+	targetVersion, err := ResolveUpgradeGateVersion(ctx, cli, namespace, deployed, release)
 	if err != nil {
-		return fmt.Errorf("failed to resolve upgrade gate versions: %w", err)
+		return fmt.Errorf("failed to resolve upgrade gate version: %w", err)
 	}
 
-	if len(versions) == 0 || !isVersionUpgrade(deployed.Version.Version, versions[0]) {
+	if !isVersionUpgrade(deployed.Version.Version, targetVersion) {
 		// Not a version upgrade — create empty ConfigMap to signal
 		// "gate evaluation complete, no gates needed" so component
 		// controllers waiting on the ConfigMap can proceed.
@@ -201,13 +201,13 @@ func CheckUpgradeGatesInNamespace(
 		return fmt.Errorf("failed to discover cluster gates: %w", err)
 	}
 	for k, v := range clusterGates {
-		if _, matches := matchUpgradeGateKey(k, versions); matches {
+		if _, matches := gates.MatchGateKey(k, targetVersion); matches {
 			allGates[k] = v
 		}
 	}
 
 	for k, v := range chartGates {
-		if _, matches := matchUpgradeGateKey(k, versions); matches {
+		if _, matches := gates.MatchGateKey(k, targetVersion); matches {
 			allGates[k] = v
 		}
 	}
@@ -227,7 +227,7 @@ func CheckUpgradeGatesInNamespace(
 	}
 
 	log.Info("provisioning blocked by unacknowledged upgrade gates",
-		"versions", versions,
+		"version", targetVersion,
 		"unacked_gates", keys,
 	)
 
@@ -238,5 +238,5 @@ func CheckUpgradeGatesInNamespace(
 		Message: fmt.Sprintf("Upgrade gates not acknowledged: %s", strings.Join(keys, ", ")),
 	})
 
-	return odherrors.NewStopError("provisioning blocked: %d unacknowledged upgrade gate(s) for versions %s", len(unacked), strings.Join(versions, ", "))
+	return odherrors.NewStopError("provisioning blocked: %d unacknowledged upgrade gate(s) for version %s", len(unacked), targetVersion)
 }

--- a/pkg/controller/provision/gates_action.go
+++ b/pkg/controller/provision/gates_action.go
@@ -19,11 +19,6 @@ import (
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/flags"
 )
 
-// TODO(RHOAIENG-82327): during an OLM upgrade the new operator binary
-// inherits the old CSV's version. Hardcode the target gate version so
-// in-tree gates are evaluated correctly regardless of what OLM reports.
-const UpgradeGateVersion = "3.5.1"
-
 // ExtractUpgradeGates scans rr.Resources for ConfigMaps carrying the
 // upgrade-gate label, collects their data entries into rr.GateEntries,
 // and removes the gate CMs from rr.Resources so they are not deployed
@@ -92,13 +87,28 @@ func ComponentUpgradeGateAction(ctx context.Context, rr *odhtype.ReconciliationR
 		return nil //nolint:nilerr // operator NS not initialized (e.g. tests); skip gracefully
 	}
 
-	return ComponentUpgradeGateCheck(ctx, rr.Client, ns, rr.Conditions)
+	deployed, err := cluster.GetDeployedRelease(ctx, rr.Client)
+	if err != nil {
+		return fmt.Errorf("failed to determine deployed release for upgrade gates: %w", err)
+	}
+	versions, err := ResolveUpgradeGateVersions(ctx, rr.Client, ns, deployed, rr.Release)
+	if err != nil {
+		return fmt.Errorf("failed to resolve upgrade gate versions: %w", err)
+	}
+
+	return ComponentUpgradeGateCheck(ctx, rr.Client, ns, versions, rr.Conditions)
 }
 
 // ComponentUpgradeGateCheck is the namespace-explicit variant of
 // ComponentUpgradeGateAction, suitable for direct testing.
-func ComponentUpgradeGateCheck(ctx context.Context, cli client.Client, namespace string, conditions ConditionWriter) error {
-	cleared, err := gates.AllGatesAcknowledged(ctx, cli, namespace)
+func ComponentUpgradeGateCheck(
+	ctx context.Context,
+	cli client.Client,
+	namespace string,
+	versions []string,
+	conditions ConditionWriter,
+) error {
+	cleared, err := gates.AllGatesAcknowledged(ctx, cli, namespace, versions)
 	if err != nil {
 		return fmt.Errorf("failed to check upgrade gates: %w", err)
 	}
@@ -138,9 +148,9 @@ func CheckUpgradeGates(ctx context.Context, cli client.Client, release common.Re
 }
 
 // CheckUpgradeGatesInNamespace is the namespace-explicit variant of
-// CheckUpgradeGates. Gates only apply when upgrading from a 2.x
-// release; same-major upgrades (3.x → 3.y) and fresh installs are
-// allowed through without blocking.
+// CheckUpgradeGates. Gates apply when upgrading to any newer release; equal
+// versions, downgrades, and fresh installs are allowed through without
+// blocking.
 func CheckUpgradeGatesInNamespace(
 	ctx context.Context, cli client.Client, namespace string,
 	release common.Release, conditions ConditionWriter,
@@ -155,8 +165,13 @@ func CheckUpgradeGatesInNamespace(
 		return fmt.Errorf("cannot determine deployed release for upgrade gate check: %w", err)
 	}
 
-	if deployed.Version.Major != 2 {
-		// Not a 2.x upgrade — create empty ConfigMap to signal
+	versions, err := ResolveUpgradeGateVersions(ctx, cli, namespace, deployed, release)
+	if err != nil {
+		return fmt.Errorf("failed to resolve upgrade gate versions: %w", err)
+	}
+
+	if len(versions) == 0 || !isVersionUpgrade(deployed.Version.Version, versions[0]) {
+		// Not a version upgrade — create empty ConfigMap to signal
 		// "gate evaluation complete, no gates needed" so component
 		// controllers waiting on the ConfigMap can proceed.
 		if _, err := gc.EnsureGates(ctx, nil); err != nil {
@@ -165,19 +180,12 @@ func CheckUpgradeGatesInNamespace(
 		return nil
 	}
 
-	// TODO(RHOAIENG-82327): OLM sets the release version from the
-	// installed CSV, so during an upgrade the new binary still reports
-	// the OLD version. Use the hardcoded gate version for the in-tree
-	// lookup and EnsureGates so the 3.5.1 gates are always evaluated.
-	version := UpgradeGateVersion
-	versionPrefix := "ack-" + version + "-"
-
 	allGates := make(map[string]string)
 
-	// In-tree gates are embedded in the binary and always apply for 2.x
-	// upgrades — no version filtering. This ensures they are evaluated
-	// even when OLM's two-step CSV rollout causes getRelease() to
-	// temporarily report the old version.
+	// In-tree gates are embedded in the binary and are already scoped by the
+	// gate definitions. This ensures they are evaluated even when OLM's
+	// two-step CSV rollout causes the running release to temporarily report an
+	// old version.
 	intreeGates, err := gates.LoadInTreeGates()
 	if err != nil {
 		return fmt.Errorf("failed to load in-tree gates: %w", err)
@@ -193,13 +201,13 @@ func CheckUpgradeGatesInNamespace(
 		return fmt.Errorf("failed to discover cluster gates: %w", err)
 	}
 	for k, v := range clusterGates {
-		if strings.HasPrefix(k, versionPrefix) {
+		if _, matches := matchUpgradeGateKey(k, versions); matches {
 			allGates[k] = v
 		}
 	}
 
 	for k, v := range chartGates {
-		if strings.HasPrefix(k, versionPrefix) {
+		if _, matches := matchUpgradeGateKey(k, versions); matches {
 			allGates[k] = v
 		}
 	}
@@ -219,7 +227,7 @@ func CheckUpgradeGatesInNamespace(
 	}
 
 	log.Info("provisioning blocked by unacknowledged upgrade gates",
-		"version", version,
+		"versions", versions,
 		"unacked_gates", keys,
 	)
 
@@ -230,5 +238,5 @@ func CheckUpgradeGatesInNamespace(
 		Message: fmt.Sprintf("Upgrade gates not acknowledged: %s", strings.Join(keys, ", ")),
 	})
 
-	return odherrors.NewStopError("provisioning blocked: %d unacknowledged upgrade gate(s) for version %s", len(unacked), version)
+	return odherrors.NewStopError("provisioning blocked: %d unacknowledged upgrade gate(s) for versions %s", len(unacked), strings.Join(versions, ", "))
 }

--- a/pkg/controller/provision/gates_action_test.go
+++ b/pkg/controller/provision/gates_action_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/blang/semver/v4"
 	ofaversion "github.com/operator-framework/api/pkg/lib/version"
+	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
@@ -39,6 +40,7 @@ func newScheme() *runtime.Scheme {
 	_ = corev1.AddToScheme(s)
 	_ = dsciv2.AddToScheme(s)
 	_ = dscv2.AddToScheme(s)
+	_ = operatorsv1alpha1.AddToScheme(s)
 	return s
 }
 
@@ -53,6 +55,12 @@ func dsciWithMajor(major uint64) *dsciv2.DSCInitialization {
 			},
 		},
 	}
+}
+
+func dsciWithVersion(value string) *dsciv2.DSCInitialization {
+	result := dsciWithMajor(0)
+	result.Status.Release.Version.Version = semver.MustParse(value)
+	return result
 }
 
 func release() common.Release {
@@ -105,11 +113,11 @@ func TestCheckUpgradeGates_FreshInstallCreatesEmptyCM(t *testing.T) {
 	assert.Empty(t, cm.Data)
 }
 
-func TestCheckUpgradeGates_SameMajorCreatesEmptyCM(t *testing.T) {
+func TestCheckUpgradeGates_SameVersionCreatesEmptyCM(t *testing.T) {
 	t.Parallel()
 
 	cli := fake.NewClientBuilder().WithScheme(newScheme()).
-		WithObjects(dsciWithMajor(3)).Build()
+		WithObjects(dsciWithVersion(testGateVersion)).Build()
 	conds := &condRecorder{}
 
 	err := provision.CheckUpgradeGatesInNamespace(context.Background(), cli, "test-ns", release(), conds, nil)
@@ -120,8 +128,41 @@ func TestCheckUpgradeGates_SameMajorCreatesEmptyCM(t *testing.T) {
 	cm := &corev1.ConfigMap{}
 	require.NoError(t, cli.Get(context.Background(), client.ObjectKey{
 		Name: gates.AcksConfigMap, Namespace: "test-ns",
-	}, cm), "empty CM must be created on same-major upgrade")
+	}, cm), "empty CM must be created when there is no version upgrade")
 	assert.Empty(t, cm.Data)
+}
+
+func TestCheckUpgradeGates_SameMajorPatchUpgradeEvaluatesGates(t *testing.T) {
+	t.Parallel()
+
+	source := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "gate-source",
+			Namespace: "test-ns",
+			Labels:    map[string]string{gates.UpgradeGateLabel: "true"},
+		},
+		Data: map[string]string{
+			"ack-3.5.2-patch-change": "Patch release requires migration",
+		},
+	}
+	cli := fake.NewClientBuilder().WithScheme(newScheme()).WithObjects(
+		dsciWithVersion("3.5.1"),
+		acksCM(ackedInTreeGates(t)),
+		source,
+	).Build()
+	conds := &condRecorder{}
+
+	err := provision.CheckUpgradeGatesInNamespace(
+		context.Background(), cli, "test-ns", releaseForVersion("3.5.2"), conds, nil,
+	)
+
+	require.Error(t, err)
+
+	cm := &corev1.ConfigMap{}
+	require.NoError(t, cli.Get(context.Background(), client.ObjectKey{
+		Name: gates.AcksConfigMap, Namespace: "test-ns",
+	}, cm))
+	assert.Equal(t, "Patch release requires migration", cm.Data["ack-3.5.2-patch-change"])
 }
 
 func TestCheckUpgradeGates_BlocksOnUpgradeFrom2x(t *testing.T) {
@@ -135,7 +176,7 @@ func TestCheckUpgradeGates_BlocksOnUpgradeFrom2x(t *testing.T) {
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unacknowledged upgrade gate(s)")
-	assert.Contains(t, err.Error(), testGateVersion)
+	assert.Contains(t, err.Error(), "3.5.1")
 
 	require.Len(t, conds.conditions, 1)
 	assert.Equal(t, status.AdminAckRequiredReason, conds.conditions[0].Reason)
@@ -163,7 +204,7 @@ func TestCheckUpgradeGates_AllInTreeGatesAcked(t *testing.T) {
 	}
 
 	cli := fake.NewClientBuilder().WithScheme(newScheme()).
-		WithObjects(dsciWithMajor(2), acksCM, source).Build()
+		WithObjects(dsciWithMajor(2), dscOwningGateCSV("rhods-operator.v3.5.1", "3.5.1"), acksCM, source).Build()
 	conds := &condRecorder{}
 
 	err := provision.CheckUpgradeGatesInNamespace(context.Background(), cli, "test-ns", release(), conds, nil)
@@ -189,6 +230,7 @@ func TestCheckUpgradeGates_MergesClusterAndChartGates(t *testing.T) {
 
 	cli := fake.NewClientBuilder().WithScheme(newScheme()).WithObjects(
 		dsciWithMajor(2),
+		dscOwningGateCSV("rhods-operator.v3.5.1", "3.5.1"),
 		acksCM(ackedInTreeGates(t)),
 		source,
 	).Build()
@@ -214,6 +256,85 @@ func TestCheckUpgradeGates_MergesClusterAndChartGates(t *testing.T) {
 	}, acksCM))
 	assert.Equal(t, "KServe API changed; review migration guide", acksCM.Data["ack-3.5.1-kserve-api-change"])
 	assert.Equal(t, "Model Registry schema updated", acksCM.Data["ack-3.5.1-model-registry"])
+}
+
+func TestCheckUpgradeGates_MinorScopedGateMatchesPatchRelease(t *testing.T) {
+	t.Parallel()
+
+	source := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "gate-source",
+			Namespace: "test-ns",
+			Labels:    map[string]string{gates.UpgradeGateLabel: "true"},
+		},
+		Data: map[string]string{
+			"ack-3.5-minor-scope-test": "Migration applies to every 3.5 patch",
+		},
+	}
+
+	cli := fake.NewClientBuilder().WithScheme(newScheme()).WithObjects(
+		dsciWithMajor(2),
+		acksCM(ackedInTreeGates(t)),
+		source,
+	).Build()
+	conds := &condRecorder{}
+
+	err := provision.CheckUpgradeGatesInNamespace(context.Background(), cli, "test-ns", release(), conds, nil)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "1 unacknowledged upgrade gate(s)")
+	require.Len(t, conds.conditions, 1)
+	assert.Contains(t, conds.conditions[0].Message, "ack-3.5-minor-scope-test")
+
+	acksCM := &corev1.ConfigMap{}
+	require.NoError(t, cli.Get(context.Background(), client.ObjectKey{
+		Name: gates.AcksConfigMap, Namespace: "test-ns",
+	}, acksCM))
+	assert.Equal(t, "Migration applies to every 3.5 patch", acksCM.Data["ack-3.5-minor-scope-test"])
+}
+
+func TestCheckUpgradeGates_ExactGateMatchesDiscoveredTargetCSV(t *testing.T) {
+	t.Parallel()
+
+	source := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "gate-source",
+			Namespace: "test-ns",
+			Labels:    map[string]string{gates.UpgradeGateLabel: "true"},
+		},
+		Data: map[string]string{
+			"ack-3.5.2-exact-scope-test": "Migration applies only to 3.5.2",
+			"ack-3.5.1-other-patch":      "Must not apply",
+		},
+	}
+
+	cli := fake.NewClientBuilder().WithScheme(newScheme()).WithObjects(
+		dsciWithMajor(2),
+		acksCM(ackedInTreeGates(t)),
+		dscOwningGateCSV("rhods-operator.2.25.10", "2.25.10"),
+		dscOwningGateCSV("rhods-operator.v3.5.2", "3.5.2"),
+		source,
+	).Build()
+	conds := &condRecorder{}
+
+	err := provision.CheckUpgradeGatesInNamespace(context.Background(), cli, "test-ns", release(), conds, nil)
+
+	require.Error(t, err)
+	assert.Contains(t, conds.conditions[0].Message, "ack-3.5.2-exact-scope-test")
+	assert.NotContains(t, conds.conditions[0].Message, "ack-3.5.1-other-patch")
+}
+
+func dscOwningGateCSV(name string, value string) *operatorsv1alpha1.ClusterServiceVersion {
+	parsed := semver.MustParse(value)
+	return &operatorsv1alpha1.ClusterServiceVersion{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "test-ns"},
+		Spec: operatorsv1alpha1.ClusterServiceVersionSpec{
+			Version: ofaversion.OperatorVersion{Version: parsed},
+			CustomResourceDefinitions: operatorsv1alpha1.CustomResourceDefinitions{
+				Owned: []operatorsv1alpha1.CRDDescription{{Kind: "DataScienceCluster"}},
+			},
+		},
+	}
 }
 
 func TestCheckUpgradeGates_IgnoresOtherVersions(t *testing.T) {
@@ -259,6 +380,7 @@ func TestCheckUpgradeGates_WritesDescriptionsToAcks(t *testing.T) {
 
 	cli := fake.NewClientBuilder().WithScheme(newScheme()).WithObjects(
 		dsciWithMajor(2),
+		dscOwningGateCSV("rhods-operator.v3.5.1", "3.5.1"),
 		acksCM(ackedInTreeGates(t)),
 		source,
 	).Build()
@@ -296,6 +418,7 @@ func TestCheckUpgradeGates_MergesChartGates(t *testing.T) {
 
 	cli := fake.NewClientBuilder().WithScheme(newScheme()).WithObjects(
 		dsciWithMajor(2),
+		dscOwningGateCSV("rhods-operator.v3.5.1", "3.5.1"),
 		acksCM(ackedInTreeGates(t)),
 		clusterGateCM,
 	).Build()
@@ -405,7 +528,7 @@ func TestComponentUpgradeGateCheck_NoCMReturnsStopError(t *testing.T) {
 	cli := fake.NewClientBuilder().WithScheme(newScheme()).Build()
 	conds := &condRecorder{}
 
-	err := provision.ComponentUpgradeGateCheck(context.Background(), cli, "test-ns", conds)
+	err := provision.ComponentUpgradeGateCheck(context.Background(), cli, "test-ns", []string{"3.5.1"}, conds)
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "waiting for upgrade gates to be acknowledged")
@@ -430,7 +553,7 @@ func TestComponentUpgradeGateCheck_AllAckedReturnsNil(t *testing.T) {
 	cli := fake.NewClientBuilder().WithScheme(newScheme()).WithObjects(acksCM).Build()
 	conds := &condRecorder{}
 
-	err := provision.ComponentUpgradeGateCheck(context.Background(), cli, "test-ns", conds)
+	err := provision.ComponentUpgradeGateCheck(context.Background(), cli, "test-ns", []string{"3.5.1"}, conds)
 
 	require.NoError(t, err)
 	assert.Empty(t, conds.conditions)
@@ -450,7 +573,7 @@ func TestComponentUpgradeGateCheck_PartialAckReturnsStopError(t *testing.T) {
 	cli := fake.NewClientBuilder().WithScheme(newScheme()).WithObjects(acksCM).Build()
 	conds := &condRecorder{}
 
-	err := provision.ComponentUpgradeGateCheck(context.Background(), cli, "test-ns", conds)
+	err := provision.ComponentUpgradeGateCheck(context.Background(), cli, "test-ns", []string{"3.5.1"}, conds)
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "waiting for upgrade gates to be acknowledged")
@@ -471,7 +594,7 @@ func TestComponentUpgradeGateCheck_EmptyCMReturnsNil(t *testing.T) {
 	cli := fake.NewClientBuilder().WithScheme(newScheme()).WithObjects(acksCM).Build()
 	conds := &condRecorder{}
 
-	err := provision.ComponentUpgradeGateCheck(context.Background(), cli, "test-ns", conds)
+	err := provision.ComponentUpgradeGateCheck(context.Background(), cli, "test-ns", []string{"3.5.1"}, conds)
 
 	require.NoError(t, err)
 	assert.Empty(t, conds.conditions)

--- a/pkg/controller/provision/gates_action_test.go
+++ b/pkg/controller/provision/gates_action_test.go
@@ -528,7 +528,7 @@ func TestComponentUpgradeGateCheck_NoCMReturnsStopError(t *testing.T) {
 	cli := fake.NewClientBuilder().WithScheme(newScheme()).Build()
 	conds := &condRecorder{}
 
-	err := provision.ComponentUpgradeGateCheck(context.Background(), cli, "test-ns", []string{"3.5.1"}, conds)
+	err := provision.ComponentUpgradeGateCheck(context.Background(), cli, "test-ns", "3.5.1", conds)
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "waiting for upgrade gates to be acknowledged")
@@ -553,7 +553,7 @@ func TestComponentUpgradeGateCheck_AllAckedReturnsNil(t *testing.T) {
 	cli := fake.NewClientBuilder().WithScheme(newScheme()).WithObjects(acksCM).Build()
 	conds := &condRecorder{}
 
-	err := provision.ComponentUpgradeGateCheck(context.Background(), cli, "test-ns", []string{"3.5.1"}, conds)
+	err := provision.ComponentUpgradeGateCheck(context.Background(), cli, "test-ns", "3.5.1", conds)
 
 	require.NoError(t, err)
 	assert.Empty(t, conds.conditions)
@@ -573,7 +573,7 @@ func TestComponentUpgradeGateCheck_PartialAckReturnsStopError(t *testing.T) {
 	cli := fake.NewClientBuilder().WithScheme(newScheme()).WithObjects(acksCM).Build()
 	conds := &condRecorder{}
 
-	err := provision.ComponentUpgradeGateCheck(context.Background(), cli, "test-ns", []string{"3.5.1"}, conds)
+	err := provision.ComponentUpgradeGateCheck(context.Background(), cli, "test-ns", "3.5.1", conds)
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "waiting for upgrade gates to be acknowledged")
@@ -594,7 +594,7 @@ func TestComponentUpgradeGateCheck_EmptyCMReturnsNil(t *testing.T) {
 	cli := fake.NewClientBuilder().WithScheme(newScheme()).WithObjects(acksCM).Build()
 	conds := &condRecorder{}
 
-	err := provision.ComponentUpgradeGateCheck(context.Background(), cli, "test-ns", []string{"3.5.1"}, conds)
+	err := provision.ComponentUpgradeGateCheck(context.Background(), cli, "test-ns", "3.5.1", conds)
 
 	require.NoError(t, err)
 	assert.Empty(t, conds.conditions)

--- a/pkg/upgrade/gates/AGENTS.md
+++ b/pkg/upgrade/gates/AGENTS.md
@@ -166,13 +166,12 @@ cluster-wide check to the application namespace by accident.
 
 ## Versioning Gotchas
 
-- `pkg/controller/provision/gates_action.go` currently hardcodes the in-tree
-  gate lookup version via the exported `UpgradeGateVersion = "3.5.1"` constant.
-- `pkg/controller/provision/auto_ack_action.go` reuses that same
-  `UpgradeGateVersion` constant for the auto-ack version, so changing the target
-  gate version is a single-source edit.
-- Tests around `CheckUpgradeGatesInNamespace(...)` and
-  `AutoAcknowledgeUpgradeGatesInNamespace(...)` must respect that behavior.
+- Upgrade gate matching always includes the `3.5` minor scope while upgrading
+  from 2.x, even if OLM still exposes only the old CSV.
+- When a DSC-owning CSV in the range `>=3.5.0 <3.6.0` is present, the highest
+  matching version is also used so exact patch gates such as `ack-3.5.2-*` run.
+- `CheckUpgradeGatesInNamespace(...)` and auto-ack must use the same resolved
+  version scopes; otherwise a gate can block without its health check running.
 - `rr.Release` is the **current running operator release**, not the previous
   deployed release.
 - `cluster.GetDeployedRelease()` reads previous deployed state from:

--- a/pkg/upgrade/gates/gates_test.go
+++ b/pkg/upgrade/gates/gates_test.go
@@ -1,11 +1,9 @@
 package gates_test
 
 import (
-	"strings"
 	"testing"
 
 	controllergates "github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/gates"
-	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/provision"
 	upgradegates "github.com/opendatahub-io/opendatahub-operator/v2/pkg/upgrade/gates"
 
 	. "github.com/onsi/gomega"
@@ -20,11 +18,9 @@ func TestRegisteredChecksCoverInTreeGateKeys(t *testing.T) {
 	gateEntries, err := controllergates.LoadInTreeGates()
 	g.Expect(err).ToNot(HaveOccurred())
 
-	versionPrefix := "ack-" + provision.UpgradeGateVersion + "-"
-
 	for key := range gateEntries {
-		component := strings.TrimPrefix(key, versionPrefix)
-		g.Expect(component).ToNot(Equal(key), "expected gate key %q to start with %q", key, versionPrefix)
+		component, matches := controllergates.MatchGateKey(key, "3.5.0")
+		g.Expect(matches).To(BeTrue(), "expected gate key %q to match the 3.5 gate scope", key)
 		g.Expect(registeredChecks).To(HaveKey(component), "every in-tree gate key must have an explicit registered check")
 	}
 }


### PR DESCRIPTION
<!---
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

Implemented version-aware upgrade gates:

- Gate keys now support both minor scopes (`ack-3.5-*`) and exact patch scopes (`ack-3.5.2-*`).
- Target versions are derived dynamically from the running release and DSC-owning CSVs; no release-line constants are hardcoded.
- Gates run for any newer version, including same-major patch upgrades.
- Acknowledgement checks now ignore stale keys from other versions.
- Module, DSC, DSCI, and component reconciliation all use the same scoped gate logic.
- Added focused tests and updated upgrade-testing documentation.
- Rebased the branch onto the merged `upstream/RHOAIENG-82327` fixes.

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Testing instructions are [here](https://gist.github.com/StevenTobin/64819e7ff5825817dc6ae7333f68589c).

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [x] The developer has run the integration test pipeline and verified that it passed successfully
- [x] New RELATED_IMAGE mappings are listed in ODH-Build-Config and RHOAI-Build-Config (CI validates names against build-config repos). Include links to build-config PRs in the description.

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->
Upgrade testing would require building two bundles are upgrading between them.