### PR TITLE
fix(dscinitialization): handle missing module CRDs

### DIFF
--- a/internal/controller/dscinitialization/dscinitialization_controller.go
+++ b/internal/controller/dscinitialization/dscinitialization_controller.go
@@ -609,13 +609,22 @@ func (r *DSCInitializationReconciler) reconcileDSCIModules(ctx context.Context, 
 			return nil
 		}
 
+		hasCRD, err := cluster.HasCRD(ctx, r.Client, handler.GetGVK())
+		if err != nil {
+			return fmt.Errorf("failed to check module CRD %s: %w", handler.GetName(), err)
+		}
+		if !hasCRD {
+			log.V(1).Info("module CRD not installed or terminating, will retry when CRD appears", "module", handler.GetName())
+			return nil
+		}
+
 		if err := controllerutil.SetControllerReference(instance, moduleCR, r.Scheme); err != nil {
 			return fmt.Errorf("failed to set owner reference for module %s: %w", handler.GetName(), err)
 		}
 
 		if err := resources.Apply(ctx, r.Client, moduleCR, client.FieldOwner(fieldManager), client.ForceOwnership); err != nil {
-			if meta.IsNoMatchError(err) {
-				log.V(1).Info("module CRD not installed yet, will retry when CRD appears", "module", handler.GetName())
+			if k8serr.IsNotFound(err) || meta.IsNoMatchError(err) {
+				log.V(1).Info("module CRD became unavailable, will retry when CRD appears", "module", handler.GetName())
 				return nil
 			}
 			return fmt.Errorf("failed to apply module CR %s: %w", handler.GetName(), err)


### PR DESCRIPTION
## Description

Fix DSCI reconciliation when a DSCI-configured module CRD is missing or terminating.

Previously, the controller attempted to apply the module CR and only ignored `NoMatchError`. When the CRD had been removed or was no longer available through the REST mapper, Kubernetes returned `NotFound`, causing reconciliation to fail and leaving `MonitoringReady` as `Unknown`.

The controller now checks for the module CRD before applying the CR and handles `NotFound`/`NoMatchError` if the CRD disappears during reconciliation. This allows the DSCI status to correctly report `MonitoringReady=False` with reason `Removed`.

## Release tracking

Release: 
Jira: https://redhat.atlassian.net/browse/RHOAIENG-90794

## How Has This Been Tested?

- Reproduced the failure with the existing DSCI envtest:
  `Should stay Ready when the Monitoring CRD is not installed`
- Verified the test passes after the fix:
  `make unit-test-operator TEST_SRC=./internal/controller/dscinitialization`
- Ran `make fmt`
- Ran `make generate manifests api-docs`
- Ran `make lint`

The focused DSCI suite passed all 11 specs.

## Screenshot or short clip

Not applicable.

## Merge criteria

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body.
- [x] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully
- [ ] New RELATED_IMAGE mappings are listed in ODH-Build-Config and RHOAI-Build-Config (not applicable)

### E2E test suite update requirement

- [x] Skip requirement to update E2E test suite for this PR

#### E2E update requirement opt-out justification
Small bug fix that is verified via envtest tests locally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

- Improved handling when required module resources are not yet available.
- Provisioning now waits and retries when a module’s resource definition is missing or becomes unavailable, preventing premature failures.
- Improved reconciliation reliability by ensuring shared platform resources are applied before dependent module resources are processed.
- Standardized reconciliation and resource-monitoring messages for clearer operational visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->