### PR TITLE
fix(tls): treat context deadline as retryable on TLS bootstrap

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -754,7 +754,8 @@ func fetchTLSProfile(ctx context.Context, scheme *runtime.Scheme, restCfg *rest.
 		case k8serr.IsServiceUnavailable(err),
 			k8serr.IsTimeout(err),
 			k8serr.IsServerTimeout(err),
-			k8serr.IsTooManyRequests(err):
+			k8serr.IsTooManyRequests(err),
+			errors.Is(err, context.DeadlineExceeded):
 			setupLog.Info("Transient API error reading TLS profile, using hardened defaults", "error", err)
 			hasAPI = true // watcher self-heals when the API recovers
 		default:
@@ -787,7 +788,8 @@ func fetchTLSProfile(ctx context.Context, scheme *runtime.Scheme, restCfg *rest.
 				k8serr.IsTimeout(err),
 				k8serr.IsServerTimeout(err),
 				k8serr.IsTooManyRequests(err),
-				k8serr.IsInternalError(err):
+				k8serr.IsInternalError(err),
+				errors.Is(err, context.DeadlineExceeded):
 				setupLog.Info("Transient error fetching TLS adherence policy, watcher will retry", "error", err)
 			default:
 				setupLog.Error(err, "unable to read TLS adherence policy, refusing to start with unknown adherence posture")


### PR DESCRIPTION
<!---
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description

Treat `context.DeadlineExceeded` as a transient error when fetching the cluster TLS profile and adherence policy at startup.

`FetchAPIServerTLSProfile` wraps `client.Get` with `%w`. A client-side deadline is not a Kubernetes `StatusError`, so `k8serr.IsTimeout` / `IsServerTimeout` miss it and `fetchTLSProfile` fail-closed with `os.Exit(1)`. That matches the TLS Error Handling Contract (ServiceUnavailable / Timeout / ServerTimeout / TooManyRequests / DeadlineExceeded).

`IsInternalError` stays fail-closed on the **profile** GET: HTTP 500 means cluster TLS posture is unknown. Adherence still treats InternalError as retryable (same exception as #3952).

Related: https://github.com/opendatahub-io/opendatahub-operator/pull/3952, https://github.com/opendatahub-io/data-science-pipelines-operator/pull/1083

## Release tracking
Release:
Jira:

## How Has This Been Tested?

- `make generate manifests api-docs` (no generated diff)
- `make fmt`
- `make lint` (0 issues)
- Reviewed the profile vs adherence switch split against the TLS Error Handling Contract

## Screenshot or short clip

N/A

## Merge criteria

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully
- [ ] New RELATED_IMAGE mappings are listed in ODH-Build-Config and RHOAI-Build-Config (CI validates names against build-config repos). Include links to build-config PRs in the description.

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification

Startup-only error classification for a client-side `context.DeadlineExceeded` on the APIServer GET. The cluster e2e suite cannot inject that condition without a mock apiserver; after fallback the operator uses the existing Intermediate profile and `SecurityProfileWatcher` self-heal path.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved startup behavior when retrieving the API server TLS profile or adherence policy times out.
  * Timeouts now follow the existing retry or hardened-default behavior instead of preventing startup.
  * Updated gateway resource and secret handling to use the platform-specific namespace.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->