### PR TITLE
feat: register new related images in ai-gateway-operator module

### DIFF
--- a/internal/controller/modules/aigateway/handler.go
+++ b/internal/controller/modules/aigateway/handler.go
@@ -51,8 +51,9 @@ var (
 	}
 
 	// relatedImages are the operand images the ai-gateway-operator passes to
-	// the sub-module (batch-gateway-operator, maas-controller) deployments it creates;
-	// injected as RELATED_IMAGE_* env vars on the ai-gateway-operator container.
+	// the sub-module (batch-gateway-operator, maas-controller,
+	// ai-gateway-controller) deployments it creates; injected as
+	// RELATED_IMAGE_* env vars on the ai-gateway-operator container.
 	relatedImages = []string{
 		// Batch Gateway images
 		"RELATED_IMAGE_ODH_LLM_D_BATCH_GATEWAY_OPERATOR_IMAGE",
@@ -66,6 +67,9 @@ var (
 		"RELATED_IMAGE_ODH_AI_GATEWAY_PAYLOAD_PROCESSING_IMAGE",
 		"RELATED_IMAGE_UBI_MINIMAL_IMAGE",
 		"RELATED_IMAGE_ODH_PYTHON_312_IMAGE",
+		// AI Gateway Controller images
+		"RELATED_IMAGE_ODH_AI_GATEWAY_CONTROLLER_IMAGE",
+		"RELATED_IMAGE_ODH_PRAXIS_EXTPROC_IMAGE",
 	}
 )
 

--- a/internal/controller/modules/aigateway/handler_test.go
+++ b/internal/controller/modules/aigateway/handler_test.go
@@ -271,6 +271,8 @@ func TestImageHandling(t *testing.T) {
 		"RELATED_IMAGE_ODH_AI_GATEWAY_PAYLOAD_PROCESSING_IMAGE",
 		"RELATED_IMAGE_UBI_MINIMAL_IMAGE",
 		"RELATED_IMAGE_ODH_PYTHON_312_IMAGE",
+		"RELATED_IMAGE_ODH_AI_GATEWAY_CONTROLLER_IMAGE",
+		"RELATED_IMAGE_ODH_PRAXIS_EXTPROC_IMAGE",
 	))
 
 	// The operator image is handled by ControllerImage (image override), not


### PR DESCRIPTION
<!---
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->
AI Gateway team wants to add two sub-components (`ai-gateway-controller` and `praxis-extproc`) under AI Gateway operator module. They have been onboarded to ODH builds. Could you please review and see this PR is enough to pass the corresponding `RELATED_IMAGE_*` env vars down to AI Gateway operator module?

Build config PRs:
- [Praxis extproc ODH](https://github.com/opendatahub-io/ODH-Build-Config/pull/3759)
- [AI Gateway controller ODH](https://github.com/opendatahub-io/ODH-Build-Config/pull/4102)
- [Praxis extproc RHOAI](https://github.com/red-hat-data-services/RHOAI-Build-Config/pull/32033)
- [AI Gateway controller RHOAI](https://github.com/red-hat-data-services/RHOAI-Build-Config/pull/31900)

<!-- For RHOAI PRs, request review on #ai-core-platform-requests Slack channel -->

## Release tracking
<!-- Optional. Set a target release only if this PR must ship in a specific release; it will be prioritized accordingly. -->
<!-- Target release for this PR, e.g. rhoai-3.6 or rhoai-3.7ea1 -->
Release: rhoai-3.6ea2
<!-- Required only if a Release is set above. Full link to a jira ticket, e.g. https://redhat.atlassian.net/browse/RHOAIENG-XXXXX -->
Jira: https://redhat.atlassian.net/browse/RHOAIENG-91113


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [x] The developer has run the integration test pipeline and verified that it passed successfully
- [x] New RELATED_IMAGE mappings are listed in ODH-Build-Config and RHOAI-Build-Config (CI validates names against build-config repos). Include links to build-config PRs in the description.

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->
Same plumbing as the existing `RELATED_IMAGE_ODH_AI_GATEWAY_PAYLOAD_PROCESSING_IMAGE`. Coverage is already provided by `handler_test.go` and `modules_controller_actions_inject_env` unit tests; the AI Gateway E2E suite does not assert any `RELATED_IMAGE` values today, and this PR tends not to expand E2E scope.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring the AI Gateway Controller and Praxis external processing images.
  * Included these images in AI Gateway deployments managed by the operator.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->