### PR TITLE
ci(e2e): add gateway service provisioning and failure collection to kind ODH e2e workflow

### DIFF
--- a/.github/workflows/test-kind-odh-e2e.yaml
+++ b/.github/workflows/test-kind-odh-e2e.yaml
@@ -21,6 +21,10 @@ on:
       - 'pkg/operatorconfig/cloudmanager.go'
       - 'pkg/utils/test/cloudmanager/**'
       - 'config/rhaii/**'
+      - 'internal/controller/services/gateway/**'
+      - 'tests/e2e/gateway_test.go'
+      - 'tests/e2e/gateway_tls_test.go'
+      - 'tests/e2e/gateway_redirect_test.go'
       - 'cmd/manifest-tools/**'
       - 'manifests-config.yaml'
       - '.github/workflows/test-kind-odh-e2e.yaml'
@@ -162,6 +166,80 @@ jobs:
           kubectl wait --for=condition=Available deployment/opendatahub-operator-controller-manager -n opendatahub-operator-system --timeout=600s
           echo "✅ ODH is Ready!"
 
+      - name: Enable Gateway Service in Operator
+        if: steps.prior-run.outputs.already_passed != 'true'
+        run: |
+          kubectl set env deployment/opendatahub-operator-controller-manager \
+            -n opendatahub-operator-system \
+            RHAI_DISABLE_GATEWAY_SERVICE=false
+          echo "Waiting for operator rollout after enabling gateway service..."
+          kubectl rollout status deployment/opendatahub-operator-controller-manager \
+            -n opendatahub-operator-system --timeout=120s
+          echo "✅ Gateway service enabled!"
+
+      - name: Create OIDC Client Secret and GatewayConfig CR
+        if: steps.prior-run.outputs.already_passed != 'true'
+        timeout-minutes: 5
+        run: |
+          GATEWAY_NS=rh-ai-gateway
+
+          echo "Creating gateway namespace..."
+          kubectl create namespace "${GATEWAY_NS}" --dry-run=client -o yaml | kubectl apply -f -
+
+          echo "Creating OIDC client secret in ${GATEWAY_NS}..."
+          kubectl apply -f - <<'EOF'
+          apiVersion: v1
+          kind: Secret
+          metadata:
+            name: oidc-client-secret
+            namespace: rh-ai-gateway
+          type: Opaque
+          stringData:
+            clientSecret: "e2e-test-dummy-oidc-client-secret"
+          EOF
+
+          echo "Creating GatewayConfig CR (BYOIDC mode, matching production XKS)..."
+          kubectl apply -f - <<'EOF'
+          apiVersion: services.platform.opendatahub.io/v1alpha1
+          kind: GatewayConfig
+          metadata:
+            name: default-gateway
+          spec:
+            ingressMode: LoadBalancer
+            domain: kind.local
+            certificate:
+              type: SelfSigned
+              secretName: data-science-gatewayconfig-tls
+            cookie:
+              expire: 24h
+              refresh: 1h
+            authProxyTimeout: 5s
+            oidc:
+              issuerURL: https://dex.kind.local
+              clientID: odh-gateway
+              clientSecretRef:
+                name: oidc-client-secret
+                key: clientSecret
+          EOF
+
+          echo "Waiting for GatewayConfig to become Ready..."
+          end=$((SECONDS + 300))
+          while true; do
+            ready=$(kubectl get gatewayconfig default-gateway -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2>/dev/null || echo "")
+            if [[ "$ready" == "True" ]]; then
+              echo "✅ GatewayConfig is Ready!"
+              break
+            fi
+            if [[ $SECONDS -ge $end ]]; then
+              echo "::error::GatewayConfig did not become Ready within 300s"
+              kubectl get gatewayconfig default-gateway -o yaml || true
+              kubectl logs deployment/opendatahub-operator-controller-manager \
+                -n opendatahub-operator-system --tail=40 || true
+              exit 1
+            fi
+            sleep 5
+          done
+
       - name: Run E2E Tests
         if: steps.prior-run.outputs.already_passed != 'true'
         run: make e2e-test-xks
@@ -174,6 +252,14 @@ jobs:
           kubectl logs -n opendatahub-cloudmanager-system \
             -l control-plane=controller-manager \
             --tail=500 || true
+
+      - name: Collect Gateway resources on failure
+        if: failure()
+        run: |
+          kubectl get gatewayconfig -o yaml || true
+          kubectl get gateway -A -o yaml || true
+          kubectl get gatewayclass -o yaml || true
+          kubectl get httproute -A -o yaml || true
 
       - name: Collect ODH Operator logs on failure
         if: failure()


### PR DESCRIPTION
## Description
Needed for https://github.com/opendatahub-io/opendatahub-operator/pull/3995 
## Release tracking
<!-- Optional. Set a target release only if this PR must ship in a specific release; it will be prioritized accordingly. -->
<!-- Target release for this PR, e.g. rhoai-3.6 or rhoai-3.7ea1 -->
Release: 
<!-- Required only if a Release is set above. Full link to a jira ticket, e.g.>
Jira: https://redhat.atlassian.net/browse/RHOAIENG-81156


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully
- [ ] New RELATED_IMAGE mappings are listed in ODH-Build-Config and RHOAI-Build-Config (CI validates names against build-config repos). Include links to build-config PRs in the description.

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [ ] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->
