### PR TITLE
feat(trainer): select platform kustomize overlay for xKS, ODH, and RHOAI

### DIFF
--- a/internal/controller/modules/trainer/handler.go
+++ b/internal/controller/modules/trainer/handler.go
@@ -10,9 +10,11 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/opendatahub-io/opendatahub-operator/v2/api/common"
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/api/components/v1alpha1"
 	configv1alpha1 "github.com/opendatahub-io/opendatahub-operator/v2/api/config/v1alpha1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/modules"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
 )
 
@@ -20,6 +22,13 @@ const (
 	moduleName = componentApi.TrainerComponentName
 	crName     = componentApi.TrainerInstanceName
 )
+
+var overlayByPlatform = map[common.Platform]string{
+	cluster.XKS:              "default",
+	cluster.OpenDataHub:      "overlays/odh",
+	cluster.SelfManagedRhoai: "overlays/rhoai",
+	cluster.ManagedRhoai:     "overlays/rhoai",
+}
 
 type handler struct {
 	modules.BaseHandler
@@ -29,13 +38,14 @@ func NewHandler() *handler {
 	return &handler{
 		BaseHandler: modules.BaseHandler{
 			Config: modules.ModuleConfig{
-				Name:            moduleName,
-				CRName:          crName,
-				GVK:             gvk.Trainer,
-				ManifestDir:     "trainer",
-				ContextDir:      "default",
-				ControllerImage: "RELATED_IMAGE_ODH_TRAINER_OPERATOR_IMAGE",
-				DeploymentName:  "trainer-operator-controller-manager",
+				Name:                 moduleName,
+				CRName:               crName,
+				GVK:                  gvk.Trainer,
+				ManifestDir:          "trainer",
+				SourcePath:           overlayByPlatform[cluster.OpenDataHub],
+				SourcePathByPlatform: overlayByPlatform,
+				ControllerImage:      "RELATED_IMAGE_ODH_TRAINER_OPERATOR_IMAGE",
+				DeploymentName:       "trainer-operator-controller-manager",
 				RelatedImages: []string{
 					"RELATED_IMAGE_ODH_TRAINER_IMAGE",
 					"RELATED_IMAGE_ODH_TH_TORCH_CUDA_PY312_IMAGE",

--- a/internal/controller/modules/trainer/handler_test.go
+++ b/internal/controller/modules/trainer/handler_test.go
@@ -12,6 +12,9 @@ import (
 	configv1alpha1 "github.com/opendatahub-io/opendatahub-operator/v2/api/config/v1alpha1"
 	dscv2 "github.com/opendatahub-io/opendatahub-operator/v2/api/datasciencecluster/v2"
 	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/modules"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
+
+	. "github.com/onsi/gomega"
 )
 
 const testAppsNS = "opendatahub"
@@ -156,6 +159,39 @@ func TestGetRelatedImages(t *testing.T) {
 		if !found {
 			t.Errorf("missing related image: %q", name)
 		}
+	}
+}
+
+// TestGetOperatorManifests_PlatformOverlay verifies the handler selects the
+// platform-specific Kustomize overlay and resolves it under ManifestsBasePath.
+func TestGetOperatorManifests_PlatformOverlay(t *testing.T) {
+	h := NewHandler()
+
+	cases := []struct {
+		name     string
+		platform common.Platform
+		want     string
+	}{
+		{"xks-default", cluster.XKS, "/base/trainer/default"},
+		{"odh", cluster.OpenDataHub, "/base/trainer/overlays/odh"},
+		{"self-managed-rhoai", cluster.SelfManagedRhoai, "/base/trainer/overlays/rhoai"},
+		{"managed-rhoai", cluster.ManagedRhoai, "/base/trainer/overlays/rhoai"},
+	}
+
+	for _, tcase := range cases {
+		t.Run(tcase.name, func(t *testing.T) {
+			g := NewWithT(t)
+			ctx := &modules.PlatformContext{
+				ApplicationsNamespace: testAppsNS,
+				ManifestsBasePath:     "/base",
+				Release:               common.Release{Name: tcase.platform},
+			}
+
+			m := h.GetOperatorManifests(ctx)
+			g.Expect(m.HelmCharts).Should(BeEmpty())
+			g.Expect(m.Manifests).Should(HaveLen(1))
+			g.Expect(m.Manifests[0].String()).Should(Equal(tcase.want))
+		})
 	}
 }
 


### PR DESCRIPTION
## Description

Wire the Trainer module handler to deploy platform-specific trainer-operator kustomize overlays instead of always using `config/default`.

This is the platform-side half of the xKS overlay work tracked under [RHOAIENG-78997](https://redhat.atlassian.net/browse/RHOAIENG-78997). The component-repo overlay split lands in [trainer-operator #68](https://github.com/opendatahub-io/trainer-operator/pull/68).

**Jira:** [RHOAIENG-92022](https://redhat.atlassian.net/browse/RHOAIENG-92022)

### Changes

- Add `overlayByPlatform` map to `internal/controller/modules/trainer/handler.go`:
  - xKS → `default`
  - ODH → `overlays/odh`
  - RHOAI/RHOAI managed → `overlays/rhoai`
- Switch from `ContextDir: "default"` to `SourcePath` + `SourcePathByPlatform` (same pattern as mlflow-operator, ogx, spark)
- Add `TestGetOperatorManifests_PlatformOverlay` unit test

### Merge order

1. [trainer-operator #68](https://github.com/opendatahub-io/trainer-operator/pull/68) — overlay manifests in component repo
2. Manifest pin bump in this repo (`manifests-config.yaml` / `build/trainer/`) after #68 merges
3. **This PR** — handler overlay selection

> **Do not merge** until steps 1–2 are complete; vendored manifests must include `config/overlays/*` before this path mapping is active in production.

## Release tracking

Release: rhoai-3.6
Jira: https://redhat.atlassian.net/browse/RHOAIENG-92022

## How Has This Been Tested?

- [x] `go test ./internal/controller/modules/trainer/... -v`
- [x] `make lint`
- [ ] Trainer module e2e (`tests/e2e/trainer_test.go`) — run after manifest pin includes overlay paths from #68

## Screenshot or short clip

N/A

## Merge criteria

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully
- [ ] New RELATED_IMAGE mappings are listed in ODH-Build-Config and RHOAI-Build-Config (CI validates names against build-config repos). Include links to build-config PRs in the description.

### E2E test suite update requirement

- [x] Skip requirement to update E2E test suite for this PR

#### E2E update requirement opt-out justification

This PR only changes which kustomize subdirectory the Trainer module handler resolves at deploy time. Behaviour is covered by `TestGetOperatorManifests_PlatformOverlay`. Existing trainer e2e (`tests/e2e/trainer_test.go`) remains valid once the manifest pin includes the overlay directories from trainer-operator #68; no new e2e scenarios are introduced by the handler change itself.

Made with [Cursor](https://cursor.com)

[RHOAIENG-78997]: https://redhat.atlassian.net/browse/RHOAIENG-78997?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RHOAIENG-92022]: https://redhat.atlassian.net/browse/RHOAIENG-92022?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ