### PR TITLE
RHOAIENG-92805 - Guard DAG test against undeleted MLflow instances

### DIFF
--- a/tests/e2e/cleanup_test.go
+++ b/tests/e2e/cleanup_test.go
@@ -2,6 +2,7 @@ package e2e_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
@@ -272,5 +273,32 @@ func cleanupCodeFlareTestResources(t *testing.T, tc *TestContext) {
 		WithIgnoreNotFound(true),
 		WithWaitForDeletion(false),
 		WithAcceptableErr(meta.IsNoMatchError, "IsNoMatchError"),
+	)
+}
+
+// cleanupStaleMLflowInstances deletes any leftover MLflow tracking-server
+// instances (mlflow.opendatahub.io/v1, Kind=MLflow). The mlflow-operator refuses to delete itself while any
+// MLflow instance exists (finalizer mlflow.opendatahub.io/mlflow-operator-protection,
+// condition reason MLflowInstancesPresent), so a stray instance left behind by
+// another test suite sharing the cluster would otherwise permanently block
+// setting MLflow operator component to Removed later in the test suite (see RHOAIENG-92805).
+// The MLflow CRD may not be registered at all if MLflowOperator was never enabled, so a NoMatchError is
+// expected and acceptable.
+func cleanupStaleMLflowInstances(t *testing.T) {
+	t.Helper()
+
+	// Initialize the test context.
+	tc, err := NewTestContext(t)
+	require.NoError(t, err, "Failed to initialize test context")
+
+	t.Log("Removing any stale MLflow instances that could block MLflowOperator deletion")
+
+	tc.DeleteResources(
+		WithMinimalObject(gvk.MLflow, types.NamespacedName{}),
+		WithWaitForDeletion(true),
+		WithIgnoreNotFound(true),
+		WithAcceptableErr(meta.IsNoMatchError, "IsNoMatchError"),
+		WithEventuallyTimeout(2*time.Minute),
+		WithEventuallyPollingInterval(5*time.Second),
 	)
 }

--- a/tests/e2e/controller_test.go
+++ b/tests/e2e/controller_test.go
@@ -451,6 +451,10 @@ func TestOdhOperator(t *testing.T) {
 	if testOpts.cleanUpPreviousResources {
 		CleanupPreviousTestResources(t)
 	}
+	// Remove any leftover MLflow instances from previous test runs which might have been created by previous components
+	// when running within DevTestOps pipeline. CleanupPreviousTestResources is disabled in that pipeline, so this has
+	// to run separately.
+	cleanupStaleMLflowInstances(t)
 
 	if collector := startMetricsCollectorIfEnabled(); collector != nil {
 		defer collector.Stop()


### PR DESCRIPTION
Makes MLflow operator disabling (setting to Removed) more robust in case a forgotten MLflow CR instance is present on the cluster.

This fixes issues like [RHOAIENG-92805](https://redhat.atlassian.net/browse/RHOAIENG-92805).

[RHOAIENG-92805]: https://redhat.atlassian.net/browse/RHOAIENG-92805?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Improved end-to-end test reliability by automatically removing leftover MLflow instances before test execution.
  - Cleanup waits for resources to be fully removed and safely continues when MLflow support is unavailable.
  - This helps prevent artifacts from previous runs from interfering with subsequent test results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->