### PR TITLE
test(e2e): scope kueue autoCreateQueues=false assertions to operator-owned queues (RHOAIENG-93444)

### DIFF
--- a/tests/e2e/kueue_test.go
+++ b/tests/e2e/kueue_test.go
@@ -14,6 +14,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/fields"
 	k8slabels "k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -480,12 +481,25 @@ func (tc *KueueTestCtx) ValidateKueueAutoCreateQueuesDisabled(t *testing.T) {
 		WithEventuallyTimeout(tc.TestTimeouts.shortEventuallyTimeout),
 	)
 
-	t.Logf("Verifying no ClusterQueue, ResourceFlavor or LocalQueue is created (autoCreateQueues=false).")
+	t.Logf("Verifying the operator did not create its default ClusterQueue, ResourceFlavor or LocalQueue (autoCreateQueues=false).")
+	// EnsureResourcesGone performs a LIST of the GVK — the NamespacedName's Name is only used
+	// for the error-message label, not as a filter. Without a field selector these checks would
+	// assert that NO ClusterQueue/ResourceFlavor exists anywhere on the cluster, and would fail
+	// on unrelated queues left behind by other suites sharing the cluster (e.g. cluster-queue-mnist
+	// from a distributed-workloads test). Scope the checks to the resources the operator itself
+	// would create (named "default"/"default-flavor") so the test verifies the operator's behaviour
+	// rather than the whole cluster's state.
 	tc.EnsureResourcesGone(
 		WithMinimalObject(gvk.ClusterQueue, types.NamespacedName{Name: kueueDefaultClusterQueueName}),
+		WithListOptions(&client.ListOptions{
+			FieldSelector: fields.OneTermEqualSelector("metadata.name", kueueDefaultClusterQueueName),
+		}),
 	)
 	tc.EnsureResourcesGone(
 		WithMinimalObject(gvk.ResourceFlavor, types.NamespacedName{Name: kueue.DefaultFlavorName}),
+		WithListOptions(&client.ListOptions{
+			FieldSelector: fields.OneTermEqualSelector("metadata.name", kueue.DefaultFlavorName),
+		}),
 	)
 	tc.EnsureResourcesDoNotExist(
 		WithMinimalObject(gvk.LocalQueue, types.NamespacedName{Name: kueueDefaultLocalQueueName, Namespace: managedNS}),


### PR DESCRIPTION
## Description

`ValidateKueueAutoCreateQueuesDisabled` (the `autoCreateQueues=false` e2e case) fails intermittently on shared clusters with a leftover queue such as `cluster-queue-mnist` showing up in a "list ... to be empty" assertion. This is a **test-isolation bug**, not a product bug.

### Root cause

The test used `EnsureResourcesGone` to verify the operator does **not** create its default `ClusterQueue` / `ResourceFlavor`:

```go
tc.EnsureResourcesGone(
    WithMinimalObject(gvk.ClusterQueue, types.NamespacedName{Name: kueueDefaultClusterQueueName}),
)
```

But `EnsureResourcesGone` performs a **`List` of the GVK and ignores the object's `Name`** — the `Name` is only used for the error-message label (`ensureResourcesDoNotExist` → `fetchResourcesSync` → `List(ro.GVK, ro.ListOptions)`). So the check actually asserted that **no `ClusterQueue`/`ResourceFlavor` exists anywhere on the cluster**.

On a shared cluster, an unrelated queue left behind by another suite (e.g. `cluster-queue-mnist` from a distributed-workloads test — the string `mnist` exists nowhere in this repo) makes the assertion fail even though the operator behaved correctly.

### Fix

Scope the two cluster-scoped "gone" checks to the operator's own resource names (`default` / `default-flavor`) via a `metadata.name` field selector. This matches the name-based convention already used by the positive test (`ensureClusterAndLocalQueueExist`) and the cleanup helper (`cleanupKueueClusterScopedResources`). The `LocalQueue` check already lists within the unique per-run namespace and is unchanged.

## How Has This Been Tested?

- `make fmt` — clean
- `make lint` — 0 issues
- `go vet ./tests/e2e/` — clean

## Jira

RHOAIENG-93444


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refined end-to-end validation to target operator-managed ClusterQueue and ResourceFlavor resources.
  * Preserved namespace-scoped checks for LocalQueue resources.
  * Reduced interference from unrelated resources during test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->