### PR TITLE
RHOAIENG-93536 - DataScienceCluster leaves orphaned out-of-tree module CRs when managementState flips Managed→Removed in quick succession

### DIFF
--- a/internal/controller/components/registry/registry.go
+++ b/internal/controller/components/registry/registry.go
@@ -300,10 +300,12 @@ func Add(ch ComponentHandler, opts ...RegistrationOption) {
 	r.Add(ch, opts...)
 }
 
+// Enable marks the component as enabled, i.e. not disabled via env var at operator startup.
 func Enable(name string) {
 	r.Enable(name)
 }
 
+// Disable marks the component as disabled via env var at operator startup.
 func Disable(name string) {
 	r.Disable(name)
 }

--- a/internal/controller/datasciencecluster/datasciencecluster_controller_actions.go
+++ b/internal/controller/datasciencecluster/datasciencecluster_controller_actions.go
@@ -106,7 +106,7 @@ func cleanupDisabledComponentsWith(
 
 	log := logf.FromContext(ctx)
 
-	reverseBatches, err := provisionReg.ReverseBatches()
+	reverseBatches, err := provisionReg.ReverseBatchesAll()
 	if err != nil {
 		return fmt.Errorf("DAG reverse resolution failed during component cleanup: %w", err)
 	}
@@ -201,7 +201,7 @@ func cleanupDisabledModuleCRsWith(
 	})
 
 	log := logf.FromContext(ctx)
-	reverseBatches, err := provisionReg.ReverseBatches()
+	reverseBatches, err := provisionReg.ReverseBatchesAll()
 	if err != nil {
 		log.Error(err, "DAG reverse resolution failed, falling back to alphabetical module CR cleanup")
 		return moduleReg.ForConfigSource(modules.ConfigFromDSC, func(handler modules.ModuleHandler, _ bool) error {
@@ -255,10 +255,8 @@ func provisionComponentsWith(ctx context.Context, rr *odhtype.ReconciliationRequ
 	if err := componentReg.ForEach(func(handler cr.ComponentHandler) error {
 		name := handler.GetName()
 		if !handler.IsEnabled(instance) {
-			provision.Disable(name)
 			return nil
 		}
-		provision.Enable(name)
 		ci, err := handler.NewCRObject(ctx, rr.Client, instance)
 		if err != nil {
 			log.Error(err, "NewCRObject failed", "component", name)

--- a/internal/controller/modules/modules_controller.go
+++ b/internal/controller/modules/modules_controller.go
@@ -73,8 +73,7 @@ func commonActions() []actions.Fn {
 func NewModuleReconciler(ctx context.Context, mgr ctrl.Manager) error {
 	b := reconciler.ReconcilerFor(mgr, &configv1alpha1.Platform{}).
 		WithInstanceName("modules").
-		WithDynamicOwnership().
-		WithAction(enableModulesFromPlatform)
+		WithDynamicOwnership()
 
 	platformRequest := []reconcile.Request{{NamespacedName: k8stypes.NamespacedName{Name: configv1alpha1.PlatformInstanceName}}}
 	statusPredicate := dependentpredicates.New(dependentpredicates.WithWatchStatus(true))

--- a/internal/controller/modules/modules_controller_actions.go
+++ b/internal/controller/modules/modules_controller_actions.go
@@ -147,23 +147,6 @@ func normalizePlatformModules(pm *configv1alpha1.PlatformModules) {
 	}
 }
 
-// enableModulesFromPlatform reads spec.modules from the Platform CR and
-// enables only those modules in the registry.
-//
-// Safety: this mutates the package-level registry. It is safe because the
-// controller uses the default MaxConcurrentReconciles=1, so only one
-// reconcile is in-flight at a time.
-func enableModulesFromPlatform(ctx context.Context, rr *odhtype.ReconciliationRequest) error {
-	modules, err := modulesFromInstance(ctx, rr)
-	if err != nil {
-		return err
-	}
-
-	EnableFromList(modules.EnabledModules())
-
-	return nil
-}
-
 // buildPlatformContext constructs a PlatformContext for the current reconcile
 // cycle. Always reads from Platform CR.
 func buildPlatformContext(ctx context.Context, rr *odhtype.ReconciliationRequest) (*PlatformContext, error) {

--- a/internal/controller/modules/registry.go
+++ b/internal/controller/modules/registry.go
@@ -93,29 +93,6 @@ func (r *Registry) IsEnabled(name string) bool {
 	return ok && e.enabled
 }
 
-// EnableFromList enables only the named modules, disabling all others.
-// Names that don't match any registered module are silently ignored.
-func (r *Registry) EnableFromList(names []string) {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-
-	want := make(map[string]bool, len(names))
-	for _, n := range names {
-		want[n] = true
-	}
-	for name, e := range r.entries {
-		e.enabled = want[name]
-		r.entries[name] = e
-
-		if want[name] {
-			provision.Enable(name)
-		} else {
-			provision.Disable(name)
-		}
-	}
-	r.resolvedCache = nil
-}
-
 // sortedNames returns module names in sorted order for deterministic iteration.
 // Caller must hold at least r.mu.RLock().
 func (r *Registry) sortedNames() []string {
@@ -299,20 +276,18 @@ func Add(handler ModuleHandler, opts ...RegistrationOption) {
 	r.Add(handler, opts...)
 }
 
+// Enable marks the module as enabled, i.e. not disabled via env var at operator startup.
 func Enable(name string) {
 	r.Enable(name)
 }
 
+// Disable marks the module as disabled via env var at operator startup.
 func Disable(name string) {
 	r.Disable(name)
 }
 
 func IsEnabled(name string) bool {
 	return r.IsEnabled(name)
-}
-
-func EnableFromList(names []string) {
-	r.EnableFromList(names)
 }
 
 func ForEach(f func(ModuleHandler) error) error {

--- a/internal/controller/services/registry/registry.go
+++ b/internal/controller/services/registry/registry.go
@@ -85,10 +85,12 @@ func Add(ch ServiceHandler) {
 	r.Add(ch)
 }
 
+// Enable marks the service as enabled, i.e. not disabled via env var at operator startup.
 func Enable(name string) {
 	r.setEnabled(name, true)
 }
 
+// Disable marks the service as disabled via env var at operator startup.
 func Disable(name string) {
 	r.setEnabled(name, false)
 }

--- a/pkg/controller/provision/unified.go
+++ b/pkg/controller/provision/unified.go
@@ -222,10 +222,12 @@ func Add(name string, kind NodeKind, runlevel dag.Runlevel) {
 	defaultRegistry.Add(name, kind, runlevel)
 }
 
+// Enable marks the component/module as enabled, i.e. not disabled via env var at operator startup.
 func Enable(name string) {
 	defaultRegistry.Enable(name)
 }
 
+// Disable marks the component/module as disabled via env var at operator startup.
 func Disable(name string) {
 	defaultRegistry.Disable(name)
 }

--- a/tests/e2e/dag_ordering_test.go
+++ b/tests/e2e/dag_ordering_test.go
@@ -155,6 +155,8 @@ const (
 func dagOrderingTestSuite(t *testing.T) {
 	t.Helper()
 
+	skipUnless(t, Tier2)
+
 	tc, err := NewTestContext(t)
 	require.NoError(t, err, "Failed to initialize test context")
 
@@ -265,8 +267,6 @@ func (tc *DAGOrderingTestCtx) runOpenShiftTestCases(t *testing.T) {
 func (tc *DAGOrderingTestCtx) ValidateXKSRunlevelGating(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, Tier2, Tier3)
-
 	t.Cleanup(func() {
 		tc.DeleteResource(
 			WithMinimalObject(gvk.Kserve, types.NamespacedName{Name: tc.GetInstanceName(gvk.Kserve)}),
@@ -322,8 +322,6 @@ func (tc *DAGOrderingTestCtx) ValidateXKSRunlevelGating(t *testing.T) {
 // version after Phase 2.
 func (tc *DAGOrderingTestCtx) ValidateRunlevelGatingAndConvergence(t *testing.T) {
 	t.Helper()
-
-	skipUnless(t, Tier2, Tier3)
 
 	// Guard against leftover quota from a prior crashed/interrupted run.
 	tc.deleteDAGQuota()
@@ -411,6 +409,7 @@ func (tc *DAGOrderingTestCtx) ValidateRunlevelGatingAndConvergence(t *testing.T)
 			if comp.internal {
 				continue
 			}
+			t.Logf("Waiting for %s to have PlatformReady=True", comp.name)
 			tc.EnsureResourceExists(
 				WithMinimalObject(comp.gvk, types.NamespacedName{Name: tc.GetInstanceName(comp.gvk)}),
 				WithCondition(jq.Match(
@@ -449,7 +448,7 @@ func (tc *DAGOrderingTestCtx) ValidateRunlevelGatingAndConvergence(t *testing.T)
 				t.Logf("No %s CRs found, skipping readiness check", comp.gvk.Kind)
 				continue
 			}
-
+			t.Logf("Waiting for %s to have Ready=True", comp.name)
 			tc.EnsureResourceExists(
 				WithMinimalObject(comp.gvk, types.NamespacedName{Name: instanceName}),
 				WithCondition(jq.Match(
@@ -470,8 +469,6 @@ func (tc *DAGOrderingTestCtx) ValidateRunlevelGatingAndConvergence(t *testing.T)
 // precondition to pass.
 func (tc *DAGOrderingTestCtx) ValidatePlatformReady(t *testing.T) {
 	t.Helper()
-
-	skipUnless(t, Tier2, Tier3)
 
 	for _, batch := range dagBatches {
 		for _, comp := range batch.components {
@@ -506,8 +503,6 @@ func (tc *DAGOrderingTestCtx) ValidatePlatformReady(t *testing.T) {
 // and asserts SparkOperator CR UID is unchanged.
 func (tc *DAGOrderingTestCtx) ValidateComponentStability(t *testing.T) {
 	t.Helper()
-
-	skipUnless(t, Tier2, Tier3)
 
 	t.Log("Ensuring KServe and SparkOperator are Managed")
 	tc.EventuallyResourcePatched(
@@ -601,8 +596,6 @@ func (tc *DAGOrderingTestCtx) ValidateComponentStability(t *testing.T) {
 func (tc *DAGOrderingTestCtx) ValidateDAGCleanup(t *testing.T) {
 	t.Helper()
 
-	skipUnless(t, Tier2, Tier3)
-
 	tc.setAllRemoved(t)
 
 	t.Log("Verifying all component CRs are cleaned up (no orphans)")
@@ -611,11 +604,10 @@ func (tc *DAGOrderingTestCtx) ValidateDAGCleanup(t *testing.T) {
 
 // ValidatePartialEnablement enables a subset of components spanning
 // multiple batches and verifies that disabled components don't block
-// the DAG.
+// the DAG. It also guards against RHOAIENG-93536, where quickly toggling a
+// module's managementState Removed -> Managed -> Removed left its CR orphaned.
 func (tc *DAGOrderingTestCtx) ValidatePartialEnablement(t *testing.T) {
 	t.Helper()
-
-	skipUnless(t, Tier2, Tier3)
 
 	// Prior test (AdminAckGates) leaves all components Removed.
 
@@ -627,8 +619,17 @@ func (tc *DAGOrderingTestCtx) ValidatePartialEnablement(t *testing.T) {
 		WithMutateFunc(selectComponentsTransform("Managed", partialFields)),
 	)
 
+	// Regression check (RHOAIENG-93536): flipping a module's managementState
+	// Managed -> Removed again before it settles used to leave its CR (and
+	// operator resources) orphaned forever.
+	t.Log("Immediately disabling modelregistry again (fast Removed->Managed->Removed toggle)")
+	tc.EventuallyResourcePatched(
+		WithMinimalObject(gvk.DataScienceCluster, tc.DataScienceClusterNamespacedName),
+		WithMutateFunc(selectComponentsTransform("Removed", []string{"modelregistry"})),
+	)
+
 	t.Log("Verifying enabled component CRs are created")
-	enabledGVKs := []schema.GroupVersionKind{gvk.Dashboard, gvk.Kserve, gvk.AIHub}
+	enabledGVKs := []schema.GroupVersionKind{gvk.Dashboard, gvk.Kserve}
 	for _, g := range enabledGVKs {
 		instanceName := tc.GetInstanceName(g)
 		tc.EnsureResourceExists(
@@ -639,8 +640,9 @@ func (tc *DAGOrderingTestCtx) ValidatePartialEnablement(t *testing.T) {
 		)
 	}
 
+	t.Log("Verifying disabled component CRs are not created")
 	disabledGVKs := []schema.GroupVersionKind{
-		gvk.Ray, gvk.FeastOperator, gvk.SparkOperator, gvk.TrustyAI,
+		gvk.Ray, gvk.FeastOperator, gvk.SparkOperator, gvk.TrustyAI, gvk.AIHub,
 	}
 	for _, g := range disabledGVKs {
 		instanceName := tc.GetInstanceName(g)
@@ -662,8 +664,6 @@ func (tc *DAGOrderingTestCtx) ValidatePartialEnablement(t *testing.T) {
 // in-tree entries for the current version and skips if none exist.
 func (tc *DAGOrderingTestCtx) ValidateInTreeGates(t *testing.T) {
 	t.Helper()
-
-	skipUnless(t, Tier2, Tier3)
 
 	operatorVersion := tc.getDeployedVersion(t)
 
@@ -745,8 +745,6 @@ func (tc *DAGOrderingTestCtx) ValidateInTreeGates(t *testing.T) {
 // (verifying provisioning resumes).
 func (tc *DAGOrderingTestCtx) ValidateAdminAckGates(t *testing.T) {
 	t.Helper()
-
-	skipUnless(t, Tier2, Tier3)
 
 	// Prior test (InTreeGates) leaves all components Removed.
 


### PR DESCRIPTION
## Description

Fixes an orphaned-resource bug: when a DSC-configured out-of-tree module (e.g. `dashboard`, `kserve`, `modelregistry`) has its `managementState` toggled `Removed` → `Managed` → `Removed` again in quick succession before settling, its CR and operator resources in `redhat-ods-applications` were left behind forever, even though the DSC reported it as `Removed`.

Root cause: `cleanupDisabledComponents`/`cleanupDisabledModuleCRs` decided what to delete by walking `provision.DefaultRegistry().ReverseBatches()`, which excludes any node currently marked `disabled` in a shared, package-level registry. That registry's `enabled` flag was also mutated dynamically, per reconcile, by the independent modules ("Platform") controller and by `provisionComponents` — so a module disabled again before that async, cross-controller sync caught up became permanently invisible to cleanup.

Fix:
- `cleanupDisabledComponents`/`cleanupDisabledModuleCRs` now use the existing unfiltered `ReverseBatchesAll()` instead, matching the pattern already used by the module controller's own cleanup path.
- Removed the dynamic, per-reconcile `Enable`/`Disable` mutation entirely (`provisionComponents`, `Registry.EnableFromList`, `enableModulesFromPlatform`). Every actual enable/disable decision was already re-derived fresh from the live DSC/Platform spec at each call site, so this dynamic registry state was redundant and was the source of the race. `Enable`/`Disable` now only ever run once, at operator startup, for build/feature-flag suppression — doc comments on the four registries (`components`, `modules`, `services`, `provision`) were updated to reflect this.

## Quick test in addition to what is present in a PR
After setting an arbitrary module component (modelregistry in this case) to Removed and having DSC ready, run this command:
```bash
oc patch dsc default-dsc --type merge --patch '{"spec":{"components":{"modelregistry":{"managementState":"Managed"}}}}';\
oc patch dsc default-dsc --type merge --patch '{"spec":{"components":{"modelregistry":{"managementState":"Removed"}}}}'
```
AIHub CR should be cleared and no modules should be pending delete in DSC.

Previously `sleep 1;` had to be added in order for it to work correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Behavior Changes**
  * Component and module activation is now controlled consistently through startup environment settings rather than platform resource reconciliation.
  * Disabled components are skipped without changing their registered enabled state.
  * Cleanup ordering now follows the complete dependency graph for improved removal handling.

* **Bug Fixes**
  * Improved handling of rapid component disable/re-enable transitions.
  * Updated readiness and convergence validation for more reliable startup behavior.

* **Documentation**
  * Clarified component, module, and service activation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->